### PR TITLE
Doc restructure: a simpler hierarchy

### DIFF
--- a/docsrc/concepts.rst
+++ b/docsrc/concepts.rst
@@ -1,0 +1,12 @@
+========
+Concepts
+========
+
+
+.. toctree::
+    :maxdepth: 2
+    :glob:
+
+    imap/features
+    imap/deployment
+    imap/admin

--- a/docsrc/concepts.rst
+++ b/docsrc/concepts.rst
@@ -5,7 +5,7 @@ Concepts
 
 .. toctree::
     :maxdepth: 2
-    :glob:
 
     imap/features
+    imap/deployment/overview_and_concepts    
     imap/deployment

--- a/docsrc/concepts.rst
+++ b/docsrc/concepts.rst
@@ -9,4 +9,3 @@ Concepts
 
     imap/features
     imap/deployment
-    imap/admin

--- a/docsrc/developers.rst
+++ b/docsrc/developers.rst
@@ -1,0 +1,11 @@
+==========
+Developers
+==========
+
+
+.. toctree::
+    :maxdepth: 2
+    :glob:
+
+    Contribute <contribute>
+    imap/developer

--- a/docsrc/download.rst
+++ b/docsrc/download.rst
@@ -4,8 +4,6 @@ Download
 
 
 .. toctree::
-    :maxdepth: 2
-    :glob:
 
     imap/installation
     imap/release-notes/index

--- a/docsrc/download.rst
+++ b/docsrc/download.rst
@@ -1,0 +1,13 @@
+========
+Download
+========
+
+
+.. toctree::
+    :maxdepth: 2
+    :glob:
+
+    imap/installation
+    imap/release-notes/index
+    
+    imap/admin/packagers

--- a/docsrc/imap/admin.rst
+++ b/docsrc/imap/admin.rst
@@ -1,8 +1,8 @@
 .. _imap-admin:
 
-========================
-IMAP Administrator Guide
-========================
+===================
+Administrator Guide
+===================
 
 
 

--- a/docsrc/imap/admin.rst
+++ b/docsrc/imap/admin.rst
@@ -38,27 +38,6 @@ Management
     Conversations
     DAV / HTTP
 
-References
-==========
 
-.. toctree::
-    :maxdepth: 1
-
-    admin/commands
-    admin/pycommands
-    admin/administration-tools
-    admin/access-control/rights-reference
-
-.. :todo:
-
-    This was listed here, but there's no file. Hmm!
-    howtos/shared-folder-mail-delivery
-
-Other
-=====
-.. toctree::
-    :maxdepth: 2
-
-    admin/packagers
 
 

--- a/docsrc/imap/deployment.rst
+++ b/docsrc/imap/deployment.rst
@@ -8,9 +8,7 @@ guide addresses these considerations, to aid in planning the
 successful deployment of Cyrus IMAP.
 
 .. toctree::
-   :maxdepth: 2
 
-   deployment/overview_and_concepts
    deployment/deployment_scenarios
    deployment/mailbox_creation_distribution
    deployment/known_protocol_limitations

--- a/docsrc/imap/deployment.rst
+++ b/docsrc/imap/deployment.rst
@@ -1,16 +1,11 @@
-IMAP Configuration Guide
-========================
+Configuration Guide
+===================
 
-A Guide to Planning a Cyrus IMAP Deployment
--------------------------------------------
 
 A number of considerations need to be made prior to deploying Cyrus
 IMAP in an existing infrastructure, especially larger ones. This
 guide addresses these considerations, to aid in planning the
 successful deployment of Cyrus IMAP.
-
-Contents
---------
 
 .. toctree::
    :maxdepth: 2

--- a/docsrc/imap/deployment/deployment_scenarios.rst
+++ b/docsrc/imap/deployment/deployment_scenarios.rst
@@ -47,8 +47,8 @@ Note that in this type of setup, it is the user authentication that directs the 
 
 .. _cyrus_imap_murder:
 
-Cyrus IMAP Murder
-=================
+Cyrus Murder: Server aggregation
+================================
 
 The Discrete Murder
 -------------------
@@ -80,8 +80,12 @@ The Shared Murder
 -----------------
 .. todo:: What is a Shared Murder?
 
+*To be written*
+
 Cyrus Replication
 =================
+
+*To be written*
 
 .. todo::
    Describe advantages and disadvantages of using replication (rather than how to configure it as this is described in the Administration Guide).
@@ -89,23 +93,8 @@ Cyrus Replication
 Hosted Environments
 ===================
 
+*To be written*
+
 .. todo::
    Describe some of the common ways that hosted Cyrus installations are setup, for example security for admin users, global sieve scripts, etc.
-
-Mailbox Creation Distribution
-=============================
-
-By default, when creating a mailbox in Cyrus IMAP:
-
-* the backend with the most free disk space is selected on the Murder frontend
-* the partition with the most free disk space is selected on the backend
-
-This may not be the most appropriate backend or partition to create the new mailbox on, and Cyrus IMAP therefor allows for a variety of additional modes of calculating and selecting the most appropriate backend and partition. The exact mode for the selection is controlled with the ``imapd.conf`` setting ``serverlist_select_mode`` on the frontend and ``partition_select_mode`` on the backend.
-
-Alternatively, a default backend can be configured with the ``defaultserver`` setting on a frontend, and a default partition can be configured with the ``defaultpartition`` on a backend.
-
-As usual, details and guidelines are available in the Administrator Guide and the Configuration Reference.
-
-.. todo::
-    Make the remark above a general one, and provide a link to the administrator guide and configuration reference ? (how ?)
 

--- a/docsrc/imap/deployment/mailbox_creation_distribution.rst
+++ b/docsrc/imap/deployment/mailbox_creation_distribution.rst
@@ -1,6 +1,16 @@
 Mailbox Creation Distribution
 =============================
 
+By default, when creating a mailbox in Cyrus IMAP:
+
+* the backend with the most free disk space is selected on the Murder frontend
+* the partition with the most free disk space is selected on the backend
+
+This may not be the most appropriate backend or partition to create the new mailbox on, and Cyrus IMAP therefor allows for a variety of additional modes of calculating and selecting the most appropriate backend and partition. The exact mode for the selection is controlled with the ``imapd.conf`` setting ``serverlist_select_mode`` on the frontend and ``partition_select_mode`` on the backend.
+
+Alternatively, a default backend can be configured with the ``defaultserver`` setting on a frontend, and a default partition can be configured with the ``defaultpartition`` on a backend.
+
+
 Prior to Cyrus IMAP version 2.5, when creating a mailbox, should no
 target partition have been specified, the mailbox is either created on:
 
@@ -82,7 +92,7 @@ Available Selection Modes
         * 35% for ``part4``
 
 Usage convergence
-=================
+"""""""""""""""""
 
 In ``freespace-percent-weighted`` mode, partitions percentage usages converge towards 100%. So if they have different usages, those differences will stay and only really diminish upon reaching 100% of usage.
 
@@ -97,7 +107,7 @@ Then a weighted choice is performed to select one of those partitions.
 As such, considering the percentages of usage, the more the partition is lagging behind the most used partition (which is the one with the lowest percentage of free space), the more chances it has to be selected.
 
 Computed weight
-===============
+"""""""""""""""
 
 The added 0.5 in partitions weight is so that selection gets smoother when all partitions get close to each other.
 
@@ -123,10 +133,10 @@ The added 0.5 in partitions weight is so that selection gets smoother when all p
     In ``freespace-percent-weighted-delta`` mode, partitions percentage usages converge towards the most used one. And then partitions usages grow equally.
 
 Special cases
-=============
+-------------
 
 What happens when two partitions are equal as most fitting?
------------------------------------------------------------
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Suppose you are using the ``freespace-most`` selection mode, that two (or more) partitions have the same free size, and that this freespace happens to be the biggest one of all configured partitions.
 
@@ -135,7 +145,7 @@ In that case, only one of those partitions will be selected. You may not know in
 Also note that since the selected partition will now have less free space, it shall not be seen as most fitting next time.
 
 What happens when two partitions point to the same device?
-----------------------------------------------------------
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Suppose you are using the ``freespace-most`` or ``freespace-percent-most`` selection mode, and that two (or more) partitions actually point to the same device (that is the device id is the same).
 
@@ -199,7 +209,7 @@ If you tend to use the same service instance for a long lapse of time and perfor
 
 
 Mailbox Creation Distribution Through ``murder frontend``
-=========================================================
+---------------------------------------------------------
 
 Upon creating a user mailbox, if the target server is not given as extra parameter, the mailbox is either created on
 
@@ -208,7 +218,7 @@ Upon creating a user mailbox, if the target server is not given as extra paramet
 
 
 Selection Mode
---------------
+""""""""""""""
 
 Among the backends, how the most fitting one is selected depends on the configured selection mode: ``serverlist_mode`` setting in ``/etc/imapd.conf``.
 
@@ -216,7 +226,7 @@ The principle is similar to the mailbox creation distribution on backend (see <x
 
 
 Available Selection Modes on Frontend
--------------------------------------
+"""""""""""""""""""""""""""""""""""""
 
 * random
 
@@ -297,7 +307,7 @@ Then a weighted choice is performed to select one of the backends.
 
 
 Backends Exclusion
-==================
+------------------
 
 When using a selection mode other than ``random``, backends are automatically excluded if their considered usage percentage is beyond the ``serverlist_mode_soft_usage_limit`` integer setting.
 
@@ -322,7 +332,7 @@ If all backends are beyond the configured value, this feature is automatically d
 
 
 Backends Usage Data Reset
-=========================
+-------------------------
 
 By default backends usage data are retrieved only once upon service initialization. This only concerns selection modes other than ``random``.
 

--- a/docsrc/imap/deployment/overview_and_concepts.rst
+++ b/docsrc/imap/deployment/overview_and_concepts.rst
@@ -3,18 +3,6 @@ Overview and Concepts
 
 This chapter gives an overview of several aspects of the Cyrus IMAP server, as they relate to deployment.
 
-Cyrus IMAP
-----------
-
-The Cyrus IMAP (Internet Message Access Protocol) server provides access to personal mail and system-wide bulletin boards through the IMAP protocol. The Cyrus IMAP server is a scalable enterprise mail system designed for use from small to large enterprise environments using technologies based on well-established Open Standards.
-
-A full Cyrus IMAP implementation allows a seamless mail and bulletin board environment to be set up across one or more nodes. It differs from other IMAP server implementations in that it is run on *sealed nodes*, where users are not normally permitted to log in. The mailbox database is stored in parts of the filesystem that are private to the Cyrus IMAP system. All user access to mail is through software using the IMAP, IMAPS, POP3, POP3S, or KPOP protocols.
-
-The private mailbox database design gives the Cyrus IMAP server large advantages in efficiency, scalability, and administratability. Multiple concurrent read/write connections to the same mailbox are permitted. The server supports access control lists on mailboxes and storage quotas on mailbox hierarchies.
-
-include::
-supported-platforms.rst
-
 Cyrus IMAP Features
 -------------------
 
@@ -136,7 +124,7 @@ Alternate Namespace
 The Cyrus IMAP server can also use analternate namespace which allows a user's personal mailboxes to appear as if they reside at the same level as that user's <code>INBOX</code> as opposed to children of it. With this feature, it may appear that there are non-unique names for mailboxes between users (2 different users may each have a top level "work" mailbox), but the internal representation is still <code>user.name.work</code>.
 
 Access Control Lists
-""""""""""""""""""""
+--------------------
 
 Access to each mailbox is controlled by each mailbox's access control list. Access Control Lists (ACLs) provide a powerful mechanism for specifying the users or groups of users who have permission to access the mailboxes.
 
@@ -292,7 +280,7 @@ Regardless of the ACL on a mailbox, users who are listed in the "admins" configu
 
 
 Initial ACLs for Newly Created Mailboxes
-----------------------------------------
+""""""""""""""""""""""""""""""""""""""""
 
 When a mailbox is created, its ACL starts off with a copy of the ACL of its closest parent mailbox. When a user is created, the ACL on the user's <code>INBOX</code> starts off with a single entry granting all rights to the user. When a non-user mailbox is created and does not have a parent, its ACL is initialized to the value of the "<code>defaultacl</code>" option in "<code>/etc/imapd.conf</code>".
 
@@ -410,27 +398,22 @@ Quotas and Partitions
 Quota roots are independent of partitions. A single quota root can apply to mailboxes in different partitions.
 
 
-HTML Block that was commented out in XML
-========================================
-
-.. todo:: Looks like this block of HTML never got converted to XML for Publican.
-
-<!--
-<h2><a name="notification">New Mail Notification</a></h2>
+New Mail Notification
+---------------------
 
 The Cyrus IMAP server comes with a notification daemon which
 supports multiple mechanisms for notifying users of new mail.
 Notifications can be configured to be sent upon normal delivery
-(<code>"MAIL"</code> class) and/or sent as requested by a <a
-href=specs.php#sieve>Sieve</a> script (<code>"SIEVE"</code> class).
+(``"MAIL"`` class) and/or sent as requested by a <a
+href=specs.php#sieve>Sieve</a> script (``"SIEVE"`` class).
 
 By default, both types of notifications are disabled.
 Notifications are enabled by using one or both of the following
 configuration options:
 
-* the "``mailnotifier``" option selects the <a href=man/notifyd.8.php>notifyd</a> method to use for "<code>MAIL</code>" class notifications
+* the "``mailnotifier``" option selects the :cyrusman:`notifyd(8)` method to use for "``MAIL``" class notifications
 
-* the "``sievenotifier``" option selects the <a href=man/notifyd.8.php>notifyd</a> method to use for "``SIEVE``" class notifications (when no method is specified by the Sieve action)
+* the "``sievenotifier``" option selects the :cyrusman:`notifyd(8)` method to use for "``SIEVE``" class notifications (when no method is specified by the Sieve action)
 
 
 Partitions
@@ -445,7 +428,8 @@ When an administrator creates a new mailbox, the name of the partition for the m
 
 The optional second argument to the "create" command can usually be given only when using a specialized Cyrus-aware administrative client such as ``cyradm``.
 
-<h3><a name="partitionsrename">Changing Partitions with "<code>rename</code>"</a></h3>
+Changing Partitions with "rename"
+"""""""""""""""""""""""""""""""""
 
 An administrator may change the partition of a mailbox by using the
 rename command with an optional third argument.  When a third argument
@@ -457,14 +441,16 @@ If a third argument to rename is not given and the first argument is
 "<code>INBOX</code>", the newly created mailbox gets the same partition it would
 get from the "<code>create</code>" command.
 
-<h2><A NAME="news">News</a></h2>
+News
+----
 
 Cyrus has the ability to export Usenet via IMAP and/or export shared
 IMAP mailboxes via an NNTP server which is included with Cyrus.  For
 more information on exporting news groups through the IMAP server, see
 <a href="install-netnews.php">install-netnews.php</a>.
 
-<h2><a name="pop3">POP3 Server</a></h2>
+POP3 Server
+-----------
 
 The Cyrus IMAP server software comes with a compatibility POP3 server.
 Due to limitations in the POP3 protocol, the server can only access a
@@ -481,7 +467,8 @@ name and "<code><VAR>realm</VAR></code>" is the server's Kerberos realm.
 When the POP3 server is invoked with the "<code>-k</code>" switch, the
 server exports MIT's KPOP protocol instead of generic POP3.
 
-<h3><a name="syslog">The <code>syslog</code> facility</a></h3>
+The syslog facility
+-------------------
 
 The Cyrus IMAP server software sends log messages to the "<code>local6</code>"
 syslog facility.  The severity levels used are:
@@ -496,13 +483,15 @@ timeouts
 <LI><code>INFO</code> - Mailbox openings, duplicate delivery suppression
 </UL>
 
-<h2><a name="recovery">Mail Directory Recovery</a></h2>
+Mail Directory Recovery
+-----------------------
 
 This section describes the various databases used by the Cyrus IMAP
 server software and what can be done to recover from various
 inconsistencies in these databases.
 
-<h3><a name="recoverymboxdir">Reconstructing Mailbox Directories</a></h3>
+Reconstructing Mailbox Directories
+""""""""""""""""""""""""""""""""""
 
 The largest database is the mailbox directories.  Each
 mailbox directory contains the following files:
@@ -541,17 +530,18 @@ recorded in any quota root files.  After running reconstruct, it is
 advisable to run "<code>quota -f</code>" (described below) in order to fix
 the quota root files.
 
-<h3><a name="recoverymbox">Reconstructing the Mailboxes File</a></h3>
+Reconstructing the Mailboxes File
+"""""""""""""""""""""""""""""""""
 
-<B><I> NOTE: CURRENTLY UNAVAILABLE </I></B>
+**NOTE: CURRENTLY UNAVAILABLE**
 
 The mailboxes file in the configuration directory is the most critical
 file in the entire Cyrus IMAP system.  It contains a sorted list of
 each mailbox on the server, along with the mailboxes quota root and
 ACL.
 
-To reconstruct a corrupted mailboxes file, run the "<code>reconstruct
--m</code>" command.  The "<code>reconstruct</code>" program, when invoked
+To reconstruct a corrupted mailboxes file, run the ``reconstruct
+-m`` command.  The ``reconstruct`` program, when invoked
 with the "<code>-m</code>" switch, scavenges and corrects whatever data it
 can find in the existing mailboxes file.  It then scans all partitions
 listed in the imapd.conf file for additional mailbox directories to
@@ -561,7 +551,8 @@ put in the mailboxes file.
 redundant copy of the mailbox ACL, to be used as a backup when
 rebuilding the mailboxes file.
 
-<h3><a name="recoveryquotas">Reconstructing Quota Roots</a></h3>
+Reconstructing Quota Roots
+""""""""""""""""""""""""""
 
 The subdirectory "<code>quota</code>" of the configuration directory (specified in
 the "<code>configdirectory</code>" configuration option) contains one file per
@@ -572,39 +563,44 @@ files store the quota usage and limits of each of the quota roots.
 switch, recalculates the quota root of each mailbox and the quota
 usage of each <a href="#quotaroots">quota root</a>.
 
-<h4><a name="recoveryquotasrm">Removing Quota Roots</a></h4>
+Removing Quota Roots
+""""""""""""""""""""
 
 To remove a quota root, remove the quota root's file.  Then run
 "<code>quota -f</code>" to make the quota files consistent again.
 
-<h3><a name="recoverysubs">Subscriptions</a></h3>
+Subscriptions
+"""""""""""""
 
 The subdirectory "<code>user</code>" of the configuration directory contains user
 subscriptions.  There is one file per user, with a filename of the
 userid followed by "<code>.sub</code>".  Each file contains a sorted list of
 subscribed mailboxes.
 
-<p>There is no program to recover from damaged subscription files.  A
+There is no program to recover from damaged subscription files.  A
 site may recover from lost subscription files by restoring from backups.
 
-<h2><a name="configdir">Configuration Directory</a></h2>
+Configuration Directory
+-----------------------
 
 Many objects in the configuration directory are discussed in
 the Database Recovery section. This section documents two
 other directories that reside in the configuration directory.
 
-<h3><a name="configdirlog">"<code>log</code>" Directory</a></h3>
+Log Directory
+"""""""""""""
 
 The subdirectory "<code>log</code>" under the configuration directory permits
 administrators to keep protocol telemetry logs on a per-user basis.
 
-<p>If a subdirectory of "<code>log</code>" exists with the same name as a user, the
+If a subdirectory of "<code>log</code>" exists with the same name as a user, the
 IMAP and POP3 servers will keep a telemetry log of protocol sessions
 authenticating as that user.  The telemetry log is stored in the
 subdirectory with a filename of the server process-id and starts with
 the first command following authentication.
 
-<h3><a name="configdirproc">"<code>proc</code>" Directory</a></h3>
+Proc Directory
+""""""""""""""
 
 The subdirectory "<code>proc</code>" under the configuration directory
 contains one file per active server process.  The file name is the ASCII
@@ -620,78 +616,82 @@ tab-separated fields:
 The file may contain arbitrary characters after the first newline
 character.
 
-<p>The "<code>proc</code>" subdirectory is normally be cleaned out on
+The "<code>proc</code>" subdirectory is normally be cleaned out on
 server reboot.
 
-<h2>Message Delivery</h2><a name="messagedelivery"></a>
+Message Delivery
+----------------
 
-<p>Mail transport agents such as Sendmail, Postfix, or Exim communicate
+Mail transport agents such as Sendmail, Postfix, or Exim communicate
 with the Cyrus server via LMTP (the Local Mail Transport Protocol)
 implemented by the LMTP daemon.  This can be done either directly by the
 MTA (prefered, for performance reasons) or via the <code>deliver</code> LMTP
 client.
 
-<h3>Local Mail Transfer Protocol</h3><a name="lmtp"></a>
+Local Mail Transfer Protocol (lmtp)
+"""""""""""""""""""""""""""""""""""
 
-<p>LMTP, the Local Mail Transfer Protocol, is a variant of SMTP design for
+LMTP, the Local Mail Transfer Protocol, is a variant of SMTP design for
 transferring mail to the final message store.  LMTP allows MTAs to deliver
 "local" mail over a network.  This is an easy optimization so that the
 IMAP server doesn't need to maintain a queue of messages or run an
-MTA.</p>
+MTA.
 
-<p>The Cyrus server implements LMTP via the <code>lmtpd</code> daemon.  LMTP
+The Cyrus server implements LMTP via the <code>lmtpd</code> daemon.  LMTP
 can either be used over a network via TCP or local via a UNIX domain
 socket. There are security differnces between these two alternatives; read
-more below</p>
+more below.
 
-<p>For final delivery via LMTP over a TCP socket, it is necessary to use
+For final delivery via LMTP over a TCP socket, it is necessary to use
 LMTP AUTH.  This is accomplished using SASL to authenticate the delivering
 user.  If your mail server is performing delivery via LMTP AUTH (that is,
 using a SASL mechanism), you will want their authentication id to be an
 LMTP admins (either via the <code>admins</code> imapd.conf option or via the
-<code>&lt;service&gt;_admins</code> option, typically <code>lmtp_admins</code>).</p>
+<code>&lt;service&gt;_admins</code> option, typically <code>lmtp_admins</code>).
 
-<p>Alternatively you may deliver via LMTP to a unix domain socket, and the
+Alternatively you may deliver via LMTP to a unix domain socket, and the
 connection will be preauthenticated as an administrative user (and access
-control is accomplished by controlling access to the socket).</p>
+control is accomplished by controlling access to the socket).
 
-<p>Note that if a user has a sieve script, the sieve script runs authorized
+Note that if a user has a sieve script, the sieve script runs authorized
 as *that* user, and the rights of the posting user are ignored for the purposes
-of determining the outcome of the sieve script.</p>
+of determining the outcome of the sieve script.
 
-<h3>Single Instance Store</h3><a name="singleinstance"></a>
+Single Instance Store
+"""""""""""""""""""""
 
-<p>If a delivery attempt mentions several recipients (only possible if
+If a delivery attempt mentions several recipients (only possible if
 the MTA is speaking LMTP to <code>lmtpd</code>), the server attempts to
 store as few copies of a message as possible.  It will store one copy
 of the message per partition, and create hard links for all other
-recipients of the message.</p>
+recipients of the message.
 
-<p>Single instance store can be turned off by using the
-"singleinstancestore" flag in the configuration file.</p>
+Single instance store can be turned off by using the
+"singleinstancestore" flag in the configuration file.
 
-<h3>Duplicate Delivery Suppression</h3><a name="duplicate"></a>
+Duplicate Delivery Suppression
+""""""""""""""""""""""""""""""
 
 A message is considered a duplicate if two copies of a message with
 the same message-id and the same envelope receipient are received.
 Cyrus uses the duplicate delivery database to hold this information,
 and it looks approximately 3 days back in the default install.
 
-<p>Duplicate delivery suppression can be turned off by using the
-"duplicatesuppression" flag in the configuration file.</p>
+Duplicate delivery suppression can be turned off by using the
+"duplicatesuppression" flag in the configuration file.
 
-<h3>Sieve, a Mail Filtering Language</h3><a name="sieve"></a>
+Sieve, a Mail Filtering Language
+--------------------------------
 
 Sieve is a mail filtering language that can filter mail into an appropriate
 IMAP mailbox as it is delivered via lmtp.  For more information, look
 <A HREF="sieve.php">here</a>.
 
-<h3>Cyrus Murder, the IMAP Aggregator</h3><a name="aggregator"></a>
+Cyrus Murder, the IMAP Aggregator
+---------------------------------
 
 Cyrus now supports the distribution of mailboxes across a number of IMAP
 servers to allow for horizontal scalability.  For information on setting
 up this configuration, see <A href="install-murder.php">here</A>.
 
-//    -->
-</chapter>
 

--- a/docsrc/imap/deployment/overview_and_concepts.rst
+++ b/docsrc/imap/deployment/overview_and_concepts.rst
@@ -1,5 +1,5 @@
-Overview and Concepts
-=====================
+Overview
+========
 
 This chapter gives an overview of several aspects of the Cyrus IMAP server, as they relate to deployment.
 
@@ -332,7 +332,7 @@ Quotas allow server administrators to limit resources used by hierarchies of mai
 Supports Quotas on Storage
 """"""""""""""""""""""""""
 
-The Cyrus IMAP server supports quotas on storage, which is defined as the number of bytes of the relevant :ref:`822` messages, in kilobytes. Each copy of a message is counted independently, even when the server can conserve disk space use by making hard links to message files. The additional disk space overhead used by mailbox index and cache files is not charged against a quota.
+The Cyrus IMAP server supports quotas on storage, which is defined as the number of bytes of the relevant :rfc:`822` messages, in kilobytes. Each copy of a message is counted independently, even when the server can conserve disk space use by making hard links to message files. The additional disk space overhead used by mailbox index and cache files is not charged against a quota.
 
 Quota Roots
 """""""""""
@@ -421,7 +421,7 @@ Changing Partitions with "rename"
 An administrator may change the partition of a mailbox by using the
 rename command with an optional third argument.  When a third argument
 to rename is given, the first and second arguments can be the
-same &mdash;this changes the partition of a mailbox without changing its
+same; this changes the partition of a mailbox without changing its
 name.  If a third argument to rename is not given and the first
 argument is not ``INBOX``, the partition of a mailbox does not change.
 If a third argument to rename is not given and the first argument is
@@ -429,7 +429,7 @@ If a third argument to rename is not given and the first argument is
 get from the ``create`` command.
 
 News
-----
+-----
 
 Cyrus has the ability to export Usenet via IMAP and/or export shared
 IMAP mailboxes via an NNTP server which is included with Cyrus.  
@@ -478,7 +478,7 @@ The largest database is the mailbox directories.  Each
 mailbox directory contains the following files:
 
 message files
-    There is one file per message, containing the message in RFC 822 format.  Lines in the message are separated by CRLF, not just LF.  The file name of each message is the message's UID followed by a dot (.).
+    There is one file per message, containing the message in :rfc:`822` format.  Lines in the message are separated by CRLF, not just LF.  The file name of each message is the message's UID followed by a dot (.).
 
     In netnews newsgroups, the message files instead follow the format and naming conventions imposed by the netnews software.
 

--- a/docsrc/imap/deployment/overview_and_concepts.rst
+++ b/docsrc/imap/deployment/overview_and_concepts.rst
@@ -3,21 +3,18 @@ Overview and Concepts
 
 This chapter gives an overview of several aspects of the Cyrus IMAP server, as they relate to deployment.
 
-Cyrus IMAP Features
--------------------
-
 Mailbox Namespaces
-""""""""""""""""""
+------------------
 
 By default, the Cyrus IMAP server presents mailboxes using the **netnews** namespace convention. This means that;
 
 * mailbox names are case-sensitive,
-* a mailbox name may not start or end with a <code>.</code> (dot) character,
-* a mailbox name may not contain two subsequent <code>.</code> (dot) characters.
+* a mailbox name may not start or end with a ``.`` (dot) character,
+* a mailbox name may not contain two subsequent ``.`` (dot) characters.
 
-While the aforementioned implications of the **netnews** namespace convention apply under all circumstances, some of the implications imposed by the **netnews** namespace convention can be influenced by specifying additional configuration options to Cyrus IMAP, such as is the case with the hierarchy seperator.
+While the aforementioned implications of the netnews namespace convention apply under all circumstances, some of the implications imposed by the netnews namespace convention can be influenced by specifying additional configuration options to Cyrus IMAP, such as is the case with the hierarchy seperator.
 
-When using the **netnews** namespace convention, the default, a user's shorthand qualifier (e.g. `user' for ``user@example.org``) MAY NOT contain a '.' (dot) character, as the character is being used as a hierarchy separator in mailbox names, and would thus create a personal mailbox rather then a user's INBOX.
+When using the netnews namespace convention, the default, a user's shorthand qualifier (e.g. `user' for ``user@example.org``) MAY NOT contain a '.' (dot) character, as the character is being used as a hierarchy separator in mailbox names, and would thus create a personal mailbox rather then a user's INBOX.
 
 The same limitation goes for the use of virtual domains. Since a mailbox in a virtual domain typically uses a fully qualified user identifier (e.g. ``user@example.org``, thus including a valid (sub-)domain name), the '.' (dot) character is inherited from the Domain Name System naming convention. This poses a problem without the use of the '.' (dot) character as a mailbox hierarchy separator.
 
@@ -26,7 +23,7 @@ To illustrate the effects on an environment, please examine the following proced
 Example Effects of the Netnews Namespace Convention
 """""""""""""""""""""""""""""""""""""""""""""""""""
 
-#. In ``imapd.conf``, set ``unixhierarchysep`` to ``0``.
+#. In :cyrusman:`imapd.conf(5)`, set ``unixhierarchysep`` to ``0``.
 
 #. Attempt to create a mailbox for user *bovik@example.org* using the shorthand qualifier (e.g. `bovik`), and the fully qualified user identifier (e.g. ``bovik@example.org``).
 
@@ -58,7 +55,7 @@ As you can see, the mailbox has been created succesfully using the shorthand qua
     createmailbox: Permission denied
 
 
-In ``imapd.conf``, set ``unixhierarchysep`` to ``1``.
+In :cyrusman:`imapd.conf(5)`, set ``unixhierarchysep`` to ``1``.
 
 Attempt to create a mailbox for user *bovik@example.org* using the shorthand qualifier (e.g. ``bovik``), and the fully qualified user identifier (e.g. ``bovik@example.org``).
 
@@ -121,7 +118,7 @@ In contexts which permit relative mailbox names, the mailbox namespace works as 
 Alternate Namespace
 """""""""""""""""""
 
-The Cyrus IMAP server can also use analternate namespace which allows a user's personal mailboxes to appear as if they reside at the same level as that user's <code>INBOX</code> as opposed to children of it. With this feature, it may appear that there are non-unique names for mailboxes between users (2 different users may each have a top level "work" mailbox), but the internal representation is still <code>user.name.work</code>.
+The Cyrus IMAP server can also use analternate namespace which allows a user's personal mailboxes to appear as if they reside at the same level as that user's ``INBOX`` as opposed to children of it. With this feature, it may appear that there are non-unique names for mailboxes between users (2 different users may each have a top level "work" mailbox), but the internal representation is still ``user.name.work``.
 
 Access Control Lists
 --------------------
@@ -157,7 +154,7 @@ i
 p
     The user may send email to the submission address for the mailbox (**post**).
 
-    This right differs from the "<code>i</code>" (**insert**) right in that the delivery system inserts trace information into messages posted, whereas no delivery trace information is added to messages inserted (by move or copy).
+    This right differs from the ``i`` (**insert**) right in that the delivery system inserts trace information into messages posted, whereas no delivery trace information is added to messages inserted (by move or copy).
 
 c
     The user may create new mailboxes in this mailbox, delete the current mailbox, or rename the mailbox (**create**).
@@ -169,16 +166,16 @@ a
     The user may change the *Access Control Information* (ACI) on the mailbox (**administer**).
 
 .. todo::
-    FIXME: Clarification Needed! Does the <code>a</code> right imply any other rights?
+    FIXME: Clarification Needed! Does the ``a`` right imply any other rights?
 
 
 You can combine these access rights in different ways. A few examples;
 
 lrs
-    Give the user read-only access to the mailbox (<emphasis>lookup</emphasis>, <emphasis>read</emphasis> and <emphasis>seen</emphasis>).
+    Give the user read-only access to the mailbox (*lookup*, *read* and *seen*).
 
 lrsp
-    Give the user read access to the mailbox, and allow the user to post to the mailbox using the delivery system (<emphasis>lookup</emphasis>, <emphasis>read</emphasis>, <emphasis>seen</emphasis> and <emphasis>post</emphasis>). Most delivery systems do not provide authentication, so the "<code>p</code>" right usually has meaning only for the "anonymous" user.
+    Give the user read access to the mailbox, and allow the user to post to the mailbox using the delivery system (*lookup*, *read*, *seen* and *post*). Most delivery systems do not provide authentication, so the ``p`` right usually has meaning only for the "anonymous" user.
 
 lr
     The user can lookup and read the contents of the mailbox, but no "Seen" or "Recent" flags may be set on the mailbox nor its contents. This set of rights is primarily useful for anonymous IMAP, which is often used to make the archives of mailing lists available.
@@ -199,16 +196,16 @@ The identifier part of an ACL entry specifies the user or group for which the en
 
 There are two special identifiers, "anonymous", and "anyone", which are explained below. The meaning of other identifiers usually depends on the authorization mechanism being used (selected by ``--with-auth`` at compile time, defaulting to Unix).
 
-"<code>anonymous</code>" and "<code>anyone</code>"
+``anonymous`` and ``anyone``
 """"""""""""""""""""""""""""""""""""""""""""""""""
 
-With any authorization mechanism, two special identifiers are defined. The identifier "<code>anonymous</code>" refers to the anonymous, or unauthenticated user. The identifier "<code>anyone</code>" refers to all users, including the anonymous user.
+With any authorization mechanism, two special identifiers are defined. The identifier ``anonymous`` refers to the anonymous, or unauthenticated user. The identifier ``anyone`` refers to all users, including the anonymous user.
 
 
 Kerberos vs. Unix Authorization
 """""""""""""""""""""""""""""""
 
-The Cyrus IMAP server comes with four authorization mechanisms, one is compatible with Unix-style ("<code>/etc/passwd</code>") authorization, one for use with Kerberos 4, one for use with Kerberos 5, and one for use with an external authorization process (ptloader) which can interface with other group databases (e.g. AFS PTS groups, LDAP Groups, etc).
+The Cyrus IMAP server comes with four authorization mechanisms, one is compatible with Unix-style (``/etc/passwd``) authorization, one for use with Kerberos 4, one for use with Kerberos 5, and one for use with an external authorization process (ptloader) which can interface with other group databases (e.g. AFS PTS groups, LDAP Groups, etc).
 
 .. note::
     **Authentication !== Authorization**
@@ -218,7 +215,7 @@ The Cyrus IMAP server comes with four authorization mechanisms, one is compatibl
 .. todo::
    In the paragraph above, make sure 'Login Authentication' links to the appropriate section.
 
-In the Unix authorization mechanism, identifiers are either a valid userid or the string "``group``": followed by a group listed in ``/etc/group``. Thus:
+In the Unix authorization mechanism, identifiers are either a valid userid or the string ``group``: followed by a group listed in ``/etc/group``. Thus:
 
 ::
 
@@ -226,7 +223,7 @@ In the Unix authorization mechanism, identifiers are either a valid userid or th
     group:staff         Refers to the group staff
 
 
-It is also possible to use unix groups with users authenticated through a non-/etc/passwd backend. Note that using unix groups in this way (without associated <filename>/etc/passwd</filename> entries) is not recommended.
+It is also possible to use unix groups with users authenticated through a non-/etc/passwd backend. Note that using unix groups in this way (without associated ``/etc/passwd`` entries) is not recommended.
 
 .. todo::
     Actually, what Cyrus requires is the getgrent(3) POSIX sysctl. As such, NSS needs to be configured to have the groups available, one of which includes "files", but could also include "ldap".
@@ -234,7 +231,7 @@ It is also possible to use unix groups with users authenticated through a non-/e
 
 Using the Kerberos authorization mechanism, identifiers are of the form:
 
-    <emphasis>$principal</emphasis>.<emphasis>$instance</emphasis>@<emphasis>$realm</emphasis></screen>
+    *$principal*.*$instance*@*$realm*
 
 If ``$instance`` is omitted, it defaults to the null string. If ``$realm`` is omitted, it defaults to the local realm.
 
@@ -247,21 +244,18 @@ The file ``/etc/krb.equiv`` contains mappings between Kerberos principals. The f
 
 will cause the identity ``bovik@REMOTE.COM`` to be treated as if it were the local identity ``bovik``.
 
-A site may wish to write their own authorization mechanism, perhaps to implement a local group mechanism. If it does so (by implementing an <code>auth_[whatever]</code> PTS module), it will dictate its own form and meaning of identifiers.
+A site may wish to write their own authorization mechanism, perhaps to implement a local group mechanism. If it does so (by implementing an ``auth_[whatever]`` PTS module), it will dictate its own form and meaning of identifiers.
 
 
 Negative Rights
 """""""""""""""
 
-Any of the above defined identifiers may be prefixed with a "<code>-</code>" character. The associated rights are then removed from that identifier. These are referred to as *negative rights*.
+Any of the above defined identifiers may be prefixed with a ``-`` character. The associated rights are then removed from that identifier. These are referred to as *negative rights*.
 
 Calculating the Users' Rights
 """""""""""""""""""""""""""""
 
 To calculate the set of rights granted to a user, the server first calculates the union of all of the rights granted to the user and to all groups the user is a member of. The server then calculates and removes the union of all the negative rights granted to the user and to all groups the user is a member of.
-
-    <example id="exam-Deployment_Guide-Calculating_the_Users_Rights-Example_ACL_with_Negative_User_Rights">
-    <title>Example ACL with Negative User Rights</title>
 
 ::
 
@@ -269,20 +263,18 @@ To calculate the set of rights granted to a user, the server first calculates th
    fred         lwi
    -anonymous   s
 
-</example>
-
-The user "<code>fred</code>" will be granted the rights "<code>lrswip</code>" and the anonymous user will be granted the rights "<code>lrp</code>".
+The user ``fred`` will be granted the rights ``lrswip`` and the anonymous user will be granted the rights ``lrp``.
 
 Implicit Rights for Administrators on Personal Mailboxes
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Regardless of the ACL on a mailbox, users who are listed in the "admins" configuration option in "<code>/etc/imapd.conf</code>" implicitly have the "<code>l</code>" and "<code>a</code>" rights on all mailboxes. Users also implicitly have the "<code>l</code>" and "<code>a</code>" rights on their INBOX and all of their personal mailboxes.
+Regardless of the ACL on a mailbox, users who are listed in the "admins" configuration option in :cyrusman:`imapd.conf(5)` implicitly have the ``l`` and ``a`` rights on all mailboxes. Users also implicitly have the ``l`` and ``a`` rights on their INBOX and all of their personal mailboxes.
 
 
 Initial ACLs for Newly Created Mailboxes
 """"""""""""""""""""""""""""""""""""""""
 
-When a mailbox is created, its ACL starts off with a copy of the ACL of its closest parent mailbox. When a user is created, the ACL on the user's <code>INBOX</code> starts off with a single entry granting all rights to the user. When a non-user mailbox is created and does not have a parent, its ACL is initialized to the value of the "<code>defaultacl</code>" option in "<code>/etc/imapd.conf</code>".
+When a mailbox is created, its ACL starts off with a copy of the ACL of its closest parent mailbox. When a user is created, the ACL on the user's ``INBOX`` starts off with a single entry granting all rights to the user. When a non-user mailbox is created and does not have a parent, its ACL is initialized to the value of the ``defaultacl`` option in :cyrusman:`imapd.conf(5)`.
 
 Note that some rights are available implicitly, for example 'anonymous' always has 'p' on user INBOXes, and users always have rights on mailboxes within their INBOX hierarchy.
 
@@ -292,49 +284,45 @@ Login Authentication
 
 This section discusses different types of authentication (ways of logging in) that can be used with Cyrus IMAP.
 
-The Cyrus IMAP server uses the Cyrus SASL library for authentication. This section describes how to configure SASL with use with Cyrus imapd. Please consult the Cyrus SASL System Administrator's Guide for more detailed, up-to-date information.
+The Cyrus IMAP server uses the Cyrus SASL library for authentication. This section describes how to configure SASL with use with Cyrus imapd. Please consult the :ref:`Cyrus SASL System Administrator's Guide <sasl>` for more detailed, up-to-date information.
 
 Anonymous Login
 """""""""""""""
 
-Regardless of the SASL mechanism used by an individual connection, the server can support anonymous login. If the "<code>allowanonymouslogin</code>" option in "<code>/etc/imapd.conf</code>" is turned on, then the server will permit plaintext password logins using the user "<code>anonymous</code>" and any password.
+Regardless of the SASL mechanism used by an individual connection, the server can support anonymous login. If the ``allowanonymouslogin`` option in :cyrusman:`imapd.conf(5)` is turned on, then the server will permit plaintext password logins using the user ``anonymous`` and any password.
 
 Additionally, the server will enable any SASL mechanisms that allow anonymous logins.
 
 Plaintext Authentication
 """"""""""""""""""""""""
 
-The SASL library has several ways of verifying plaintext passwords. Plaintext passwords are passed either by the IMAP <code>LOGIN</code> command or by the SASL <code>PLAIN</code> mechanism (under a TLS layer).
+The SASL library has several ways of verifying plaintext passwords. Plaintext passwords are passed either by the IMAP ``LOGIN`` command or by the SASL ``PLAIN`` mechanism (under a TLS layer).
 
 * PAM
-* Kerberos v4
-    Plaintext passwords are verified by obtaining a ticket for the server's Kerberos identity, to protect against Kerberos server spoofing attacks.
+* Kerberos v4: Plaintext passwords are verified by obtaining a ticket for the server's Kerberos identity, to protect against Kerberos server spoofing attacks.
 
 * ``/etc/passwd``
-* ``/etc/shadow``
+* ``/etc/shadow``: ``sasl_auto_transition`` automatically creates secrets for shared secret authentication when given a password.
 
-            <para>
-                <code>sasl_auto_transition</code> automatically creates secrets for shared secret authentication when given a password.
+The method of plaintext password verification is always through the SASL library, even in the case of the internal LOGIN command. This is to allow the SASL library to be the only source of authentication information. You'll want to look at the ``sasl_pwcheck_method`` option in the SASL documentation to understand how to configure a plaintext password verifier for your system.
 
-The method of plaintext password verification is always through the SASL library, even in the case of the internal LOGIN command. This is to allow the SASL library to be the only source of authentication information. You'll want to look at the <code>sasl_pwcheck_method</code> option in the SASL documentation to understand how to configure a plaintext password verifier for your system.
-
-To disallow the use of plaintext passwords for authentication, you can set <code>allowplaintext: no</code> in imapd.conf. This will still allow PLAIN under TLS, but IMAP LOGIN commands will now fail.
+To disallow the use of plaintext passwords for authentication, you can set ``allowplaintext: no`` in imapd.conf. This will still allow PLAIN under TLS, but IMAP LOGIN commands will now fail.
 
 Kerberos Logins
 """""""""""""""
 
-The Kerberos SASL mechanism supports the <code>KERBEROS_V4</code> authentication mechanism. The mechanism requires that a <code>srvtab</code> file exist in the location given in the "<code>srvtab</code>" configuration option. The <code>srvtab</code> file must be readable by the Cyrus server and must contain a "<code>imap.$host@$realm</code>" service key, where <code>$host</code> is the first component of the server's host name and <code>$realm</code> is the server's Kerberos realm.
+The Kerberos SASL mechanism supports the ``KERBEROS_V4`` authentication mechanism. The mechanism requires that a ``srvtab`` file exist in the location given in the ``srvtab`` configuration option. The ``srvtab`` file must be readable by the Cyrus server and must contain a ``imap.$host@$realm`` service key, where ``$host`` is the first component of the server's host name and ``$realm`` is the server's Kerberos realm.
 
-The server will permit logins by identities in the local realm and identities in the realms listed in the <code>loginrealms</code> option in <filename>/etc/imapd.conf</filename>.
+The server will permit logins by identities in the local realm and identities in the realms listed in the ``loginrealms`` option in :cyrusman:`imapd.conf(5)`.
 
-The file <filename>/etc/krb.equiv</filename> contains mappings between Kerberos principals. The file contains zero or more lines, each containing two fields. Any identity matching the first field of a line is permitted to log in as the identity in the second field.
+The file ``/etc/krb.equiv`` contains mappings between Kerberos principals. The file contains zero or more lines, each containing two fields. Any identity matching the first field of a line is permitted to log in as the identity in the second field.
 
-If the <code>loginuseacl</code> configuration option is turned on, than any Kerberos identity that is granted the "<code>a</code>" right on the user's <code>INBOX</code> is permitted to log in as that user.
+If the ``loginuseacl`` configuration option is turned on, than any Kerberos identity that is granted the ``a`` right on the user's ``INBOX`` is permitted to log in as that user.
 
 Shared Secrets Logins
 """""""""""""""""""""
 
-Some mechanisms require the user and the server to share a secret (generally a password) that can be used for comparison without actually passing the password in the clear across the network. For these mechanism (such as CRAM-MD5 and DIGEST-MD5), you will need to supply a source of passwords, such as the sasldb (which is described more fully in the Cyrus SASL distribution)
+Some mechanisms require the user and the server to share a secret (generally a password) that can be used for comparison without actually passing the password in the clear across the network. For these mechanism (such as CRAM-MD5 and DIGEST-MD5), you will need to supply a source of passwords, such as the sasldb (which is described more fully in the :ref:`Cyrus SASL distribution <sasl>`)
 
 Quota
 -----
@@ -344,7 +332,7 @@ Quotas allow server administrators to limit resources used by hierarchies of mai
 Supports Quotas on Storage
 """"""""""""""""""""""""""
 
-The Cyrus IMAP server supports quotas on storage, which is defined as the number of bytes of the relevant RFC-822 messages, in kilobytes. Each copy of a message is counted independently, even when the server can conserve disk space use by making hard links to message files. The additional disk space overhead used by mailbox index and cache files is not charged against a quota.
+The Cyrus IMAP server supports quotas on storage, which is defined as the number of bytes of the relevant :ref:`822` messages, in kilobytes. Each copy of a message is counted independently, even when the server can conserve disk space use by making hard links to message files. The additional disk space overhead used by mailbox index and cache files is not charged against a quota.
 
 Quota Roots
 """""""""""
@@ -371,9 +359,9 @@ exist and the quota roots
    user.bovik.list
    user.bovik.saved
 
-exist, then the quota root "<code>user.bovik</code>" applies to the mailboxes "<code>user.bovik</code>" and "<code>user.bovik.todo</code>"; the quota root "<code>user.bovik.list</code>" applies to the mailboxes "<code>user.bovik.list.imap</code>" and "<code>user.bovik.list.info-cyrus</code>"; and the quota root "<code>user.bovik.saved</code>" applies to the mailbox "<code>user.bovik.saved</code>".
+exist, then the quota root ``user.bovik`` applies to the mailboxes ``user.bovik`` and ``user.bovik.todo``; the quota root ``user.bovik.list`` applies to the mailboxes ``user.bovik.list.imap`` and ``user.bovik.list.info-cyrus``; and the quota root ``user.bovik.saved`` applies to the mailbox ``user.bovik.saved``.
 
-Quota roots are created automatically when they are mentioned in the <code>setquota</code> command. Quota roots may not be deleted through the protocol, see Removing Quota Roots for instructions on how to delete them.
+Quota roots are created automatically when they are mentioned in the ``setquota`` command. Quota roots may not be deleted through the protocol, see Removing Quota Roots for instructions on how to delete them.
 
 
 Mail Delivery Behavior
@@ -385,12 +373,12 @@ Mail delivery is a special case. In order for a message to be delivered to a mai
 
 If the usage is over the limit, then the mail delivery will fail with a temporary error. This will cause the delivery system to re-attempt delivery for a couple of days (permitting the user time to notice and correct the problem) and then return the mail to the sender.
 
-Quota Warnings Upon Select When User Has "<code>d</code>" Rights
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Quota Warnings Upon Select When User Has ``d`` Rights
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-When a user selects a mailbox whose quota root has usage that is close to or over the limit and the user has "<code>d</code>" rights on the mailbox, the server will issue an alert notifying the user that usage is close to or over the limit. The threshold of usage at which the server will issue quota warnings is set by the <code>quotawarn</code> configuration option.
+When a user selects a mailbox whose quota root has usage that is close to or over the limit and the user has ``d`` rights on the mailbox, the server will issue an alert notifying the user that usage is close to or over the limit. The threshold of usage at which the server will issue quota warnings is set by the ``quotawarn`` configuration option.
 
-The server only issues warnings when the user has "<code>d</code>" rights because only users with "<code>d</code>" rights are capable of correcting the problem.
+The server only issues warnings when the user has ``d`` rights because only users with ``d`` rights are capable of correcting the problem.
 
 Quotas and Partitions
 """""""""""""""""""""
@@ -404,16 +392,15 @@ New Mail Notification
 The Cyrus IMAP server comes with a notification daemon which
 supports multiple mechanisms for notifying users of new mail.
 Notifications can be configured to be sent upon normal delivery
-(``"MAIL"`` class) and/or sent as requested by a <a
-href=specs.php#sieve>Sieve</a> script (``"SIEVE"`` class).
+(``MAIL`` class) and/or sent as requested by a Sieve script (``SIEVE`` class).
 
 By default, both types of notifications are disabled.
 Notifications are enabled by using one or both of the following
 configuration options:
 
-* the "``mailnotifier``" option selects the :cyrusman:`notifyd(8)` method to use for "``MAIL``" class notifications
+* the ``mailnotifier`` option selects the :cyrusman:`notifyd(8)` method to use for ``MAIL`` class notifications
 
-* the "``sievenotifier``" option selects the :cyrusman:`notifyd(8)` method to use for "``SIEVE``" class notifications (when no method is specified by the Sieve action)
+* the ``sievenotifier`` option selects the :cyrusman:`notifyd(8)` method to use for ``SIEVE`` class notifications (when no method is specified by the Sieve action)
 
 
 Partitions
@@ -436,52 +423,46 @@ rename command with an optional third argument.  When a third argument
 to rename is given, the first and second arguments can be the
 same &mdash;this changes the partition of a mailbox without changing its
 name.  If a third argument to rename is not given and the first
-argument is not "<code>INBOX</code>", the partition of a mailbox does not change.
+argument is not ``INBOX``, the partition of a mailbox does not change.
 If a third argument to rename is not given and the first argument is
-"<code>INBOX</code>", the newly created mailbox gets the same partition it would
-get from the "<code>create</code>" command.
+``INBOX``, the newly created mailbox gets the same partition it would
+get from the ``create`` command.
 
 News
 ----
 
 Cyrus has the ability to export Usenet via IMAP and/or export shared
-IMAP mailboxes via an NNTP server which is included with Cyrus.  For
-more information on exporting news groups through the IMAP server, see
-<a href="install-netnews.php">install-netnews.php</a>.
+IMAP mailboxes via an NNTP server which is included with Cyrus.  
 
 POP3 Server
 -----------
 
 The Cyrus IMAP server software comes with a compatibility POP3 server.
 Due to limitations in the POP3 protocol, the server can only access a
-user's <code>INBOX</code> and only one instance of a POP3 server may exist for any
-one user at any time.  While a POP3 server has a user's <code>INBOX</code> open,
+user's ``INBOX`` and only one instance of a POP3 server may exist for any
+one user at any time.  While a POP3 server has a user's ``INBOX`` open,
 expunge operations from any concurrent IMAP session will fail.
 
 When Kerberos login authentication is being used, the POP3 server
 uses the server identity
-"<code>pop.<VAR>host</VAR>@<VAR>realm</VAR></code>" instead of
-"<code>imap.<VAR>host</VAR>@<VAR>realm</VAR></code>", where
-"<code><VAR>host</VAR></code>" is the first component of the server's host
-name and "<code><VAR>realm</VAR></code>" is the server's Kerberos realm.
-When the POP3 server is invoked with the "<code>-k</code>" switch, the
+``pop.host@realm`` instead of
+``imap.host@realm``, where
+``host`` is the first component of the server's host
+name and ``realm`` is the server's Kerberos realm.
+When the POP3 server is invoked with the ``-k`` switch, the
 server exports MIT's KPOP protocol instead of generic POP3.
 
 The syslog facility
 -------------------
 
-The Cyrus IMAP server software sends log messages to the "<code>local6</code>"
+The Cyrus IMAP server software sends log messages to the ``local6``
 syslog facility.  The severity levels used are:
 
-<UL>
-<LI><code>CRIT</code> - Critical errors which probably require prompt administrator action
-<LI><code>ERR</code> - I/O errors, including failure to update quota usage.
-The syslog message includes the specific file and Unix error.
-<LI><code>WARNING</code> - Protection mechanism failures, client inactivity
-timeouts
-<LI><code>NOTICE</code> - Authentications, both successful and unsuccessful
-<LI><code>INFO</code> - Mailbox openings, duplicate delivery suppression
-</UL>
+* **CRIT** - Critical errors which probably require prompt administrator action
+* **ERR** - I/O errors, including failure to update quota usage. The syslog message includes the specific file and Unix error.
+* **WARNING** - Protection mechanism failures, client inactivity timeouts
+* **NOTICE** - Authentications, both successful and unsuccessful
+* **INFO** - Mailbox openings, duplicate delivery suppression
 
 Mail Directory Recovery
 -----------------------
@@ -501,39 +482,41 @@ message files
 
     In netnews newsgroups, the message files instead follow the format and naming conventions imposed by the netnews software.
 
-<code>cyrus.header</code>
+``cyrus.header``
     This file contains a magic number and variable-length information about the mailbox itself.
 
-<code>cyrus.index</code>
+``cyrus.index``
     This file contains fixed-length information about the mailbox itself and each message in the mailbox.
 
-<code>cyrus.cache</code>
+``cyrus.cache``
     This file contans variable-length information about each message in the mailbox.
 
-<code>cyrus.seen</code>
-    This file contains variable-length state information about each reader of the mailbox who has "<code>s</code>" permissions.
+``cyrus.seen``
+    This file contains variable-length state information about each reader of the mailbox who has ``s`` permissions.
 
-The "<code>reconstruct</code>" program can be used to recover from
-corruption in mailbox directories.  If "<code>reconstruct</code>" can find
+The ``reconstruct`` program can be used to recover from
+corruption in mailbox directories.  If ``reconstruct`` can find
 existing header and index files, it attempts to preserve any data in
 them that is not derivable from the message files themselves.  The
-state "<code>reconstruct</code>" attempts to preserve includes the flag
-names, flag state, and internal date.  "<code>Reconstruct</code>"
+state ``reconstruct`` attempts to preserve includes the flag
+names, flag state, and internal date.  ``Reconstruct``
 derives all other information from the message files.
 
 An administrator may recover from a damaged disk by restoring message
 files from a backup and then running reconstruct to regenerate what it
 can of the other files.
 
-The "<code>reconstruct</code>" program does not adjust the quota usage
+The ``reconstruct`` program does not adjust the quota usage
 recorded in any quota root files.  After running reconstruct, it is
-advisable to run "<code>quota -f</code>" (described below) in order to fix
+advisable to run ``quota -f`` (described below) in order to fix
 the quota root files.
 
 Reconstructing the Mailboxes File
 """""""""""""""""""""""""""""""""
 
-**NOTE: CURRENTLY UNAVAILABLE**
+.. note::
+
+    CURRENTLY UNAVAILABLE
 
 The mailboxes file in the configuration directory is the most critical
 file in the entire Cyrus IMAP system.  It contains a sorted list of
@@ -542,39 +525,39 @@ ACL.
 
 To reconstruct a corrupted mailboxes file, run the ``reconstruct
 -m`` command.  The ``reconstruct`` program, when invoked
-with the "<code>-m</code>" switch, scavenges and corrects whatever data it
+with the ``-m`` switch, scavenges and corrects whatever data it
 can find in the existing mailboxes file.  It then scans all partitions
 listed in the imapd.conf file for additional mailbox directories to
 put in the mailboxes file.
 
-<p>The <code>cyrus.header</code> file in each mailbox directory stores a
+The ``cyrus.header`` file in each mailbox directory stores a
 redundant copy of the mailbox ACL, to be used as a backup when
 rebuilding the mailboxes file.
 
 Reconstructing Quota Roots
 """"""""""""""""""""""""""
 
-The subdirectory "<code>quota</code>" of the configuration directory (specified in
-the "<code>configdirectory</code>" configuration option) contains one file per
+The subdirectory ``quota`` of the configuration directory (specified in
+the ``configdirectory`` configuration option) contains one file per
 quota root, with the file name being the name of the quota root.  These
 files store the quota usage and limits of each of the quota roots.
 
-<p>The "<code>quota</code>" program, when invoked with the "<code>-f</code>"
+The ``quota`` program, when invoked with the ``-f``
 switch, recalculates the quota root of each mailbox and the quota
-usage of each <a href="#quotaroots">quota root</a>.
+usage of each quota root.
 
 Removing Quota Roots
 """"""""""""""""""""
 
 To remove a quota root, remove the quota root's file.  Then run
-"<code>quota -f</code>" to make the quota files consistent again.
+``quota -f`` to make the quota files consistent again.
 
 Subscriptions
 """""""""""""
 
-The subdirectory "<code>user</code>" of the configuration directory contains user
+The subdirectory ``user`` of the configuration directory contains user
 subscriptions.  There is one file per user, with a filename of the
-userid followed by "<code>.sub</code>".  Each file contains a sorted list of
+userid followed by ``.sub``.  Each file contains a sorted list of
 subscribed mailboxes.
 
 There is no program to recover from damaged subscription files.  A
@@ -590,10 +573,10 @@ other directories that reside in the configuration directory.
 Log Directory
 """""""""""""
 
-The subdirectory "<code>log</code>" under the configuration directory permits
+The subdirectory ``log`` under the configuration directory permits
 administrators to keep protocol telemetry logs on a per-user basis.
 
-If a subdirectory of "<code>log</code>" exists with the same name as a user, the
+If a subdirectory of ``log`` exists with the same name as a user, the
 IMAP and POP3 servers will keep a telemetry log of protocol sessions
 authenticating as that user.  The telemetry log is stored in the
 subdirectory with a filename of the server process-id and starts with
@@ -602,21 +585,19 @@ the first command following authentication.
 Proc Directory
 """"""""""""""
 
-The subdirectory "<code>proc</code>" under the configuration directory
+The subdirectory ``proc`` under the configuration directory
 contains one file per active server process.  The file name is the ASCII
 representation of the process id and the file contains the following
 tab-separated fields:
 
-<UL>
-<LI>hostname of the client
-<LI>login name of the user, if logged in
-<LI>selected mailbox, if a mailbox is selected
-</UL>
+* hostname of the client
+* login name of the user, if logged in
+* selected mailbox, if a mailbox is selected
 
 The file may contain arbitrary characters after the first newline
 character.
 
-The "<code>proc</code>" subdirectory is normally be cleaned out on
+The ``proc`` subdirectory is normally be cleaned out on
 server reboot.
 
 Message Delivery
@@ -625,7 +606,7 @@ Message Delivery
 Mail transport agents such as Sendmail, Postfix, or Exim communicate
 with the Cyrus server via LMTP (the Local Mail Transport Protocol)
 implemented by the LMTP daemon.  This can be done either directly by the
-MTA (prefered, for performance reasons) or via the <code>deliver</code> LMTP
+MTA (prefered, for performance reasons) or via the ``deliver`` LMTP
 client.
 
 Local Mail Transfer Protocol (lmtp)
@@ -637,7 +618,7 @@ transferring mail to the final message store.  LMTP allows MTAs to deliver
 IMAP server doesn't need to maintain a queue of messages or run an
 MTA.
 
-The Cyrus server implements LMTP via the <code>lmtpd</code> daemon.  LMTP
+The Cyrus server implements LMTP via the ``lmtpd`` daemon.  LMTP
 can either be used over a network via TCP or local via a UNIX domain
 socket. There are security differnces between these two alternatives; read
 more below.
@@ -646,8 +627,8 @@ For final delivery via LMTP over a TCP socket, it is necessary to use
 LMTP AUTH.  This is accomplished using SASL to authenticate the delivering
 user.  If your mail server is performing delivery via LMTP AUTH (that is,
 using a SASL mechanism), you will want their authentication id to be an
-LMTP admins (either via the <code>admins</code> imapd.conf option or via the
-<code>&lt;service&gt;_admins</code> option, typically <code>lmtp_admins</code>).
+LMTP admins (either via the ``admins`` imapd.conf option or via the
+``<service>_admins`` option, typically ``lmtp_admins``).
 
 Alternatively you may deliver via LMTP to a unix domain socket, and the
 connection will be preauthenticated as an administrative user (and access
@@ -661,7 +642,7 @@ Single Instance Store
 """""""""""""""""""""
 
 If a delivery attempt mentions several recipients (only possible if
-the MTA is speaking LMTP to <code>lmtpd</code>), the server attempts to
+the MTA is speaking LMTP to ``lmtpd``), the server attempts to
 store as few copies of a message as possible.  It will store one copy
 of the message per partition, and create hard links for all other
 recipients of the message.
@@ -684,14 +665,11 @@ Sieve, a Mail Filtering Language
 --------------------------------
 
 Sieve is a mail filtering language that can filter mail into an appropriate
-IMAP mailbox as it is delivered via lmtp.  For more information, look
-<A HREF="sieve.php">here</a>.
+IMAP mailbox as it is delivered via lmtp.  
 
 Cyrus Murder, the IMAP Aggregator
 ---------------------------------
 
 Cyrus now supports the distribution of mailboxes across a number of IMAP
-servers to allow for horizontal scalability.  For information on setting
-up this configuration, see <A href="install-murder.php">here</A>.
-
+servers to allow for horizontal scalability.  
 

--- a/docsrc/imap/faq.rst
+++ b/docsrc/imap/faq.rst
@@ -1,8 +1,8 @@
 .. _imap-faq:
 
-===============================
-IMAP Frequently Asked Questions
-===============================
+==========================
+Frequently Asked Questions
+==========================
 
 Features
 ========

--- a/docsrc/imap/features.rst
+++ b/docsrc/imap/features.rst
@@ -1,8 +1,8 @@
 .. _imap-features:
 
-=============
-IMAP Features
-=============
+========
+Features
+========
 
 The following documents show the full power of each feature that is included with Cyrus IMAP.
 

--- a/docsrc/imap/features.rst
+++ b/docsrc/imap/features.rst
@@ -4,6 +4,13 @@
 Features
 ========
 
+The Cyrus IMAP (Internet Message Access Protocol) server provides access to personal mail and system-wide bulletin boards through the IMAP protocol. The Cyrus IMAP server is a scalable enterprise mail system designed for use from small to large enterprise environments using technologies based on well-established Open Standards.
+
+A full Cyrus IMAP implementation allows a seamless mail and bulletin board environment to be set up across one or more nodes. It differs from other IMAP server implementations in that it is run on *sealed nodes*, where users are not normally permitted to log in. The mailbox database is stored in parts of the filesystem that are private to the Cyrus IMAP system. All user access to mail is through software using the IMAP, IMAPS, POP3, POP3S, or KPOP protocols.
+
+The private mailbox database design gives the Cyrus IMAP server large advantages in efficiency, scalability, and administratability. Multiple concurrent read/write connections to the same mailbox are permitted. The server supports access control lists on mailboxes and storage quotas on mailbox hierarchies.
+
+
 The following documents show the full power of each feature that is included with Cyrus IMAP.
 
 Exceptions notwithstanding, most of this documentation does not involve

--- a/docsrc/imap/installation/diy.rst
+++ b/docsrc/imap/installation/diy.rst
@@ -5,22 +5,9 @@ Do It Yourself
 The following guides outline building Cyrus IMAP from a fresh clone of
 the GIT repository's branches, or a tarball of a released version.
 
-.. WARNING::
-
-    The level of technical difficulty involved with home-brew or DIY
-    Cyrus IMAP versions is **high**.
-
-    You are specifically requested **not** to build your own unless you
-    have an appropriate comprehension of dependencies and building those
-    yourself if you have to.
-
-From GIT
-========
-
-Read our :ref:`Guide to GitHub <github-guide>` for details on how to
-access our GitHub repository, and fork/clone the source.
-
-Continue with :ref:`imap-installation-diy-build-dependencies`.
+Unless you specifically need unreleased patches, the tarball package is
+recommended as it comes with a number of resources pre-built for you,
+such as the documentation.
 
 From Tarball
 ============
@@ -34,6 +21,14 @@ Extract the tarball:
     $ :command:`tar xzvf cyrus-imapd-x.y.z.tar.gz`
 	
 .. _latest stable tarball: ftp://ftp.cyrusimap.org/cyrus-imapd/
+
+Continue with :ref:`imap-installation-diy-build-dependencies`.
+
+From GIT
+========
+
+Read our :ref:`Guide to GitHub <github-guide>` for details on how to
+access our GitHub repository, and fork/clone the source.
 
 Continue with :ref:`imap-installation-diy-build-dependencies`.
 

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -33,32 +33,15 @@ This is the highlight reel of Cyrus's full list of features_.
 .. _features: imap/features.html
 
 .. toctree::
-    :maxdepth: 1
-    :caption: Welcome to Cyrus
-    :glob:
+    :maxdepth: 3
+    :caption: Cyrus IMAP
 
-    imap/introduction
-    imap/features
-    Support <feedback>
-    About <overview/about_cyrus>
-    
-.. toctree::
-    :maxdepth: 1
-    :caption: Administrators
-    
-    imap/installation
-    imap/deployment
-    imap/admin
-    imap/faq    
-    imap/release-notes/index
-    
-.. toctree::
-    :maxdepth: 1    
-    :caption: Developers
-    
-    Contribute <contribute>
-    imap/developer
-
+    quickstart
+    download
+    concepts
+    reference
+    developers
+    support
     
 .. toctree::
     :hidden:
@@ -68,15 +51,6 @@ This is the highlight reel of Cyrus's full list of features_.
     preface
     styles
     glossary
-
-..  note to documentation contributors:
-
-    The files included in the release notes glob are symbolic links to actual files deeper
-    in the hierarchy of directories, so that the next version
-    of the release notes can be worked on without getting in the way
-    of the current release notes
-
-
 
 --------
 
@@ -101,7 +75,7 @@ Cyrus IMAP uses Cyrus SASL to provide authentication support to the mail server,
     :maxdepth: 1
     :caption: Cyrus SASL
 
-    SASL Getting Started <sasl/getting_started>
+    Getting Started <sasl/getting_started>
     sasl/auxiliary_properties
     sasl/authentication_mechanisms
     sasl/pwcheck

--- a/docsrc/quickstart.rst
+++ b/docsrc/quickstart.rst
@@ -1,0 +1,24 @@
+================
+Quickstart Guide
+================
+
+
+.. toctree::
+    :maxdepth: 2
+    :glob:
+
+    imap/introduction
+    
+Coming Soon
+-----------
+
+Quick install
+#############
+
+A quick guide to getting a basic installation of Cyrus up and running in 5 minutes.    
+
+Feature overview
+################
+
+A short overview of Cyrus features.
+    

--- a/docsrc/quickstart.rst
+++ b/docsrc/quickstart.rst
@@ -4,8 +4,6 @@ Quickstart Guide
 
 
 .. toctree::
-    :maxdepth: 2
-    :glob:
 
     imap/introduction
     

--- a/docsrc/reference.rst
+++ b/docsrc/reference.rst
@@ -4,7 +4,7 @@ Reference
 
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
     :glob:
 
     imap/admin    

--- a/docsrc/reference.rst
+++ b/docsrc/reference.rst
@@ -7,6 +7,7 @@ Reference
     :maxdepth: 2
     :glob:
 
+    imap/admin    
     imap/faq  
     imap/admin/commands
     imap/admin/pycommands

--- a/docsrc/reference.rst
+++ b/docsrc/reference.rst
@@ -1,0 +1,15 @@
+=========
+Reference
+=========
+
+
+.. toctree::
+    :maxdepth: 2
+    :glob:
+
+    imap/faq  
+    imap/admin/commands
+    imap/admin/pycommands
+    imap/admin/administration-tools
+    imap/admin/access-control/rights-reference
+    

--- a/docsrc/sasl/authentication_mechanisms.rst
+++ b/docsrc/sasl/authentication_mechanisms.rst
@@ -1,5 +1,5 @@
-SASL Authentication Mechanisms
-==============================
+Authentication Mechanisms
+=========================
 
 EXTERNAL
 --------

--- a/docsrc/sasl/auxiliary_properties.rst
+++ b/docsrc/sasl/auxiliary_properties.rst
@@ -1,5 +1,5 @@
-SASL Auxiliary Properties
-=========================
+Auxiliary Properties
+====================
 
 Auxiliary Properties and the Glue Layer
 ---------------------------------------

--- a/docsrc/sasl/faq.rst
+++ b/docsrc/sasl/faq.rst
@@ -1,7 +1,7 @@
 .. _sasl-faq:
 
-SASL Frequently Asked Questions
-===============================
+Frequently Asked Questions
+==========================
 
 .. toctree::
     :maxdepth: 2  

--- a/docsrc/sasl/pwcheck.rst
+++ b/docsrc/sasl/pwcheck.rst
@@ -1,5 +1,5 @@
-SASL Pwcheck
-============
+Pwcheck
+=======
 
 Auxprop
 -------

--- a/docsrc/sitemap.rst
+++ b/docsrc/sitemap.rst
@@ -5,6 +5,6 @@ Sitemap
 =======
 
 .. toctree::
-    :maxdepth: 6
+    :maxdepth: 7
 
     index

--- a/docsrc/support.rst
+++ b/docsrc/support.rst
@@ -1,0 +1,11 @@
+=================
+Support/Community
+=================
+
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    Support <feedback>
+    About <overview/about_cyrus>  


### PR DESCRIPTION
Making the initial left hand navigation simpler, easier to follow and faster to locate information as it's less cluttered.

Splitting up the old concepts guide into Concepts and Admin, and removing leftover html cruft that was from a time long ago.

Restructuring some of the content to get the hierarchy easier to read and navigate.
