### PR TITLE
Ensure the directory hierarchy is created for an empty mailbox

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -3988,6 +3988,17 @@ EXPORTED int mailbox_copy_files(struct mailbox *mailbox, const char *newpart,
 	}
     }
 
+    // Ensure the directory hierarchy is created, especially for empty mailbox
+    // spool directories (split metadata). Fake the UID as 1 to ensure it is
+    // the mailbox created, not the parent mailbox (trailing slash parsing in
+    // cyrus_mkdir).
+    xstrncpy(newbuf, mboxname_datapath(newpart, newname, 1), MAX_MAILBOX_PATH);
+
+    if (cyrus_mkdir(newbuf, 0755) == -1) {
+       syslog(LOG_ERR, "Could not create directory for '%s'", newbuf);
+       return IMAP_IOERROR;
+    }
+
     for (recno = 1; recno <= mailbox->i.num_records; recno++) {
 	r = mailbox_read_index_record(mailbox, recno, &record);
 	if (r) return r;


### PR DESCRIPTION
Ensure the directory hierarchy is created for an empty mailbox that is renamed.

When using metadata partitions, seperating the mailbox metadata files from the mail spool, and empty mailbox (no messages) would result in an empty directory in the filesystem hierarchy.

When such mailbox is renamed, the original filesystem directory hierarchy would be deleted, but no new hierarchy would.

However, transferring a mailbox does rely on the mailbox's folder being present on the filesystem.

This pull request ensures the directory for the mailbox is created, despite there being no records within the mailbox to attempt to copy over.

Please advise on the desire or necessity to include this fix in master as well, as this chunk of logic seems to have changed quite a bit