### PR TITLE
Preserve the existing unique ID of a mailbox renamed / transferred

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1402,6 +1402,7 @@ EXPORTED int mboxlist_renamemailbox(const char *oldname, const char *newname,
 	newmbentry->mbtype = oldmailbox->mbtype;
 	newmbentry->partition = xstrdupnull(newpartition);
 	newmbentry->acl = xstrdupnull(oldmailbox->acl);
+	newmbentry->uniqueid = xstrdupnull(oldmailbox->uniqueid);
 	newmbentry->uidvalidity = oldmailbox->i.uidvalidity;
 	mboxent = mboxlist_entry_cstring(newmbentry);
 	r = cyrusdb_store(mbdb, newname, strlen(newname), 


### PR DESCRIPTION
A renamed mailbox doesn't really create a new mailbox, but more importantly, a transferred mailbox doesn't really create a new mailbox -- it's just moved.
    
The use-case in which this would otherwise be problematic is in transferring a mailbox between replicated backends. The replica master on the receiving end would (prematurely) create a mailbox, with a new uniqueid, provided the command issued is a `LC1 LOCALCREATE user.john (PARTITION default)`. The dumping and undumping of the mailbox's `cyrus.header` file would continue to refer to the original uniqueid, however, and thus so would `GETMETADATA`.
    
This patch ensures that the command is, instead;
    
 `LC1 LOCALCREATE user.john (PARTITION default UNIQUEID <uniqueid>)`.
    
It is not allowed for non-admins and non-proxyservers.

Also note that the 'active' database entry for a mailbox moved between partitions was "lost" temporarily, as `mboxlist_renamemailbox()` did not care to preserve the original in the new record.

**IMPORTANT:** This pull request includes #70, upon which 2eca709432e87fbbc85c7a3ff8693933497627b8 depends.