### PR TITLE
Updated git clone command

### DIFF
--- a/docsrc/imap/installation/diy.rst
+++ b/docsrc/imap/installation/diy.rst
@@ -21,19 +21,19 @@ Clone the GIT repository:
 
 .. parsed-literal::
 
-    $ `git clone git@github.com:cyrusimap/cyrus-imapd.git`
+    $ :command: `git clone git@github.com:cyrusimap/cyrus-imapd.git`
 
 Check out the desired branch or revision:
 
 .. parsed-literal::
 
-    $ `git branch -la`
+    $ :command: `git branch -la`
     * master
       (...snip...)
       remotes/origin/cyrus-imapd-2.3
       remotes/origin/cyrus-imapd-2.4
       remotes/origin/cyrus-imapd-2.5
-    $ `git checkout $BRANCH`
+    $ :command: `git checkout $BRANCH`
 
 Continue with :ref:`imap-installation-diy-build-dependencies`.
 
@@ -46,7 +46,7 @@ Extract the tarball:
 
 .. parsed-literal::
 
-    $ `tar xzvf cyrus-imapd-x.y.z.tar.gz`
+    $ :command: `tar xzvf cyrus-imapd-x.y.z.tar.gz`
 
 .. _latest stable tarball: ftp://ftp.cyrusimap.org/cyrus-imapd/
 
@@ -67,8 +67,8 @@ CentOS system for example, you can run the following commands:
 
 .. parsed-literal::
 
-    # `yum install yum-utils`
-    # `yum-builddep cyrus-imapd`
+    # :command: `yum install yum-utils`
+    # :command: `yum-builddep cyrus-imapd`
 
 Consult the upstream documentation of your platform for further
 information on the availability of such commands and their usage.
@@ -302,8 +302,8 @@ Configure the Build
 
 .. parsed-literal::
 
-    $ `autoreconf -vi`
-    $ `./configure [options]`
+    $ :command: `autoreconf -vi`
+    $ :command: `./configure [options]`
 
 Check the summary after ``./configure`` completes successfully. The
 following segment shows the defaults in version 2.5.0, ran on a system
@@ -341,4 +341,4 @@ please see:
 
 .. parsed-literal::
 
-    # `./configure --help`
+    # :command: `./configure --help`

--- a/docsrc/imap/installation/diy.rst
+++ b/docsrc/imap/installation/diy.rst
@@ -21,19 +21,19 @@ Clone the GIT repository:
 
 .. parsed-literal::
 
-    $ :command: `git clone git@github.com:cyrusimap/cyrus-imapd.git`
+    $ :command:`git clone git@github.com:cyrusimap/cyrus-imapd.git`
 
 Check out the desired branch or revision:
 
 .. parsed-literal::
 
-    $ :command: `git branch -la`
+    $ :command:`git branch -la`
     * master
       (...snip...)
       remotes/origin/cyrus-imapd-2.3
       remotes/origin/cyrus-imapd-2.4
       remotes/origin/cyrus-imapd-2.5
-    $ :command: `git checkout $BRANCH`
+    $ :command:`git checkout $BRANCH`
 
 Continue with :ref:`imap-installation-diy-build-dependencies`.
 
@@ -46,7 +46,7 @@ Extract the tarball:
 
 .. parsed-literal::
 
-    $ :command: `tar xzvf cyrus-imapd-x.y.z.tar.gz`
+    $ :command:`tar xzvf cyrus-imapd-x.y.z.tar.gz`
 
 .. _latest stable tarball: ftp://ftp.cyrusimap.org/cyrus-imapd/
 
@@ -67,8 +67,8 @@ CentOS system for example, you can run the following commands:
 
 .. parsed-literal::
 
-    # :command: `yum install yum-utils`
-    # :command: `yum-builddep cyrus-imapd`
+    # :command:`yum install yum-utils`
+    # :command:`yum-builddep cyrus-imapd`
 
 Consult the upstream documentation of your platform for further
 information on the availability of such commands and their usage.
@@ -302,8 +302,8 @@ Configure the Build
 
 .. parsed-literal::
 
-    $ :command: `autoreconf -vi`
-    $ :command: `./configure [options]`
+    $ :command:`autoreconf -vi`
+    $ :command:`./configure [options]`
 
 Check the summary after ``./configure`` completes successfully. The
 following segment shows the defaults in version 2.5.0, ran on a system
@@ -341,4 +341,4 @@ please see:
 
 .. parsed-literal::
 
-    # :command: `./configure --help`
+    # :command:`./configure --help`

--- a/docsrc/imap/installation/diy.rst
+++ b/docsrc/imap/installation/diy.rst
@@ -21,19 +21,19 @@ Clone the GIT repository:
 
 .. parsed-literal::
 
-    $ :command:`git clone github.com/cyrusimap/cyrus-imapd.git`
+    $ `git clone git@github.com:cyrusimap/cyrus-imapd.git`
 
 Check out the desired branch or revision:
 
 .. parsed-literal::
 
-    $ :command:`git branch -la`
+    $ `git branch -la`
     * master
       (...snip...)
       remotes/origin/cyrus-imapd-2.3
       remotes/origin/cyrus-imapd-2.4
       remotes/origin/cyrus-imapd-2.5
-    $ :command:`git checkout` *$branch*
+    $ `git checkout $BRANCH`
 
 Continue with :ref:`imap-installation-diy-build-dependencies`.
 
@@ -46,7 +46,7 @@ Extract the tarball:
 
 .. parsed-literal::
 
-    $ :command:`tar xzvf cyrus-imapd-x.y.z.tar.gz`
+    $ `tar xzvf cyrus-imapd-x.y.z.tar.gz`
 
 .. _latest stable tarball: ftp://ftp.cyrusimap.org/cyrus-imapd/
 
@@ -67,8 +67,8 @@ CentOS system for example, you can run the following commands:
 
 .. parsed-literal::
 
-    # :command:`yum install yum-utils`
-    # :command:`yum-builddep cyrus-imapd`
+    # `yum install yum-utils`
+    # `yum-builddep cyrus-imapd`
 
 Consult the upstream documentation of your platform for further
 information on the availability of such commands and their usage.
@@ -302,8 +302,8 @@ Configure the Build
 
 .. parsed-literal::
 
-    $ :command:`autoreconf -vi`
-    $ :command:`./configure` [options]
+    $ `autoreconf -vi`
+    $ `./configure [options]`
 
 Check the summary after ``./configure`` completes successfully. The
 following segment shows the defaults in version 2.5.0, ran on a system
@@ -341,4 +341,4 @@ please see:
 
 .. parsed-literal::
 
-    # :command:`./configure --help`
+    # `./configure --help`


### PR DESCRIPTION
Updated git clone command.  The git clone command doesn't work (at least not for me) in its current form.
Updated markup on all other commands meant to be issued in *nix shell so they are formatted correctly.