### PR TITLE
Fix condition for missing __compare_fn_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,9 @@ AC_STRUCT_TM
 AC_STRUCT_TIMEZONE
 AC_CHECK_FUNCS(timegm)
 
+dnl glibc internal qsort(3) compar function prototype
+AC_CHECK_TYPE(__compar_fn_t, AC_DEFINE(HAVE_GLIBC_COMPAR_FN_T,[],[Do we have glibc __compar_fn_t?]))
+
 AC_SUBST(CPPFLAGS)
 AC_SUBST(LOCALDEFS)
 AC_FUNC_VPRINTF

--- a/lib/util.h
+++ b/lib/util.h
@@ -68,7 +68,7 @@
 # endif /* HAVE_PCREPOSIX_H */
 #endif /* ENABLE_REGEX */
 
-#ifndef __GNUC__
+#ifndef HAVE_GLIBC_COMPAR_FN_T
 typedef int (*__compar_fn_t)(const void *, const void *);
 #endif
 


### PR DESCRIPTION
"__compare_fn_t" for qsort(3) compare function prototype is not a
GCC feature, but a internal private type for glibc and some other
libc implementations.

Change to detect the type with configure script.

fixes #64 #1721 