### PR TITLE
Revert getmetadata list changes

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8156,7 +8156,7 @@ static int parse_metadata_string_or_list(const char *tag,
 
     // Assume by default the arguments are a list of entries,
     // until proven otherwise.
-    *is_list = 0;
+    *is_list = 1;
 
     c = prot_getc(imapd_in);
     if (c == EOF) {
@@ -8204,9 +8204,9 @@ static int parse_metadata_string_or_list(const char *tag,
 	strarray_append(entries, arg.s);
 
 	// It is a list if there are wildcards
-	if (!strchr(arg.s, '*') && !strchr(arg.s, '%')) {
+	if (!strchr(arg.s, '*') || !strchr(arg.s, '%')) {
 	    // No wildcards; Not a list
-	    *is_list = 1;
+	    *is_list = 0;
 	}
     }
 
@@ -8871,7 +8871,7 @@ static void cmd_getmetadata(const char *tag)
     if (nlists == 2) {
 	/* no options */
 	mboxes = &lists[0];
-	mbox_is_pattern = is_list[0];
+	mbox_is_pattern = !is_list[0];
     }
     if (nlists == 3) {
 	/* options, either before or after */
@@ -8885,12 +8885,12 @@ static void cmd_getmetadata(const char *tag)
 	    /* (options) (mailboxes) */
 	    options = &lists[0];
 	    mboxes = &lists[1];
-	    mbox_is_pattern = is_list[1];
+	    mbox_is_pattern = !is_list[1];
 	    break;
 	case 2:
 	    /* (mailboxes) (options) */
 	    mboxes = &lists[0];
-	    mbox_is_pattern = is_list[0];
+	    mbox_is_pattern = !is_list[0];
 	    options = &lists[1];
 	    break;
 	case 3:

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8203,9 +8203,9 @@ static int parse_metadata_string_or_list(const char *tag,
 
 	strarray_append(entries, arg.s);
 
-	// It is a list if there are wildcards
-	if (!strchr(arg.s, '*') && !strchr(arg.s, '%')) {
-	    // No wildcards; Not a list
+	// It is only not a list if there are wildcards,
+	// otherwise it's just a list of 1 item
+	if (strchr(arg.s, '*') || strchr(arg.s, '%')) {
 	    *is_list = 0;
 	}
     }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8204,7 +8204,7 @@ static int parse_metadata_string_or_list(const char *tag,
 	strarray_append(entries, arg.s);
 
 	// It is a list if there are wildcards
-	if (!strchr(arg.s, '*') || !strchr(arg.s, '%')) {
+	if (!strchr(arg.s, '*') && !strchr(arg.s, '%')) {
 	    // No wildcards; Not a list
 	    *is_list = 0;
 	}


### PR DESCRIPTION
I have a Kolab installation and I have recently update my cyrus installation (from 2.57 to 2.5.10). After the upgrade, I started having problems listing mailboxes in roundcube. The listing is done using the following IMAP command: `GETMETADATA * /shared/vendor/kolab/folder-type`. The problem is that cyrus-imapd 2.5.10 returns `NO Mailbox does not exist`, but in 2.5.7 it works.

After looking at the changelog, I tracked the problem to a set of changes by @kanarip, that change the way GETMETADATA interprets lists vs patterns. This PR reverts those changes and fixes the problem I'm seeing.

Here's a gist comparing the outputs pre and post patch: https://gist.github.com/javitonino/cb3d83dd40b5ab351c0297c527252034. The output is the same for mailbox lists, but the current version fail for mailbox patterns, and the patched version works.

Based on my observations, I think reverting this patch is correct, but I may be missing some key point on why this was initially applied. Maybe @kanarip can shed some light into the original patch rationale.