### PR TITLE
Adding -w option to man pages

### DIFF
--- a/docsrc/imap/reference/manpages/usercommands/imtest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/imtest.rst
@@ -138,7 +138,7 @@ Options
 
 .. option:: -w passwd
 
-    Password to use (if not supplied, we will prompt)
+    Password to use (if not supplied, we will prompt).
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/imtest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/imtest.rst
@@ -17,7 +17,7 @@ Synopsis
         [ **-a** *userid* ] [ **-u** *userid* ] [ **-k** *num* ] [ **-l** *num* ]
         [ **-r** *realm* ] [ **-f** *file* ] [ **-n** *num* ] [ **-s** ] [ **-q** ]
         [ **-c** ] [ **-i** ] [ **-z** ] [ **-v** ] [ **-I** *file* ] [ **-x** *file* ]
-        [ **-X** *file* ] [ **-o** *option*\ =\ *value* ] *hostname*
+        [ **-X** *file* ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ] *hostname*
 
 Description
 ===========
@@ -135,6 +135,10 @@ Options
 .. option:: -X  file
 
     Like -x, only close all file descriptors & daemonize the process.
+
+.. option:: -w passwd
+
+    Password to use (if not supplied, we will prompt)
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/lmtptest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/lmtptest.rst
@@ -16,7 +16,7 @@ Synopsis
     **lmtptest** [ **-t** *keyfile* ] [ **-p** *port* ] [ **-m** *mechanism* ]
         [ **-a** *userid* ] [ **-u** *userid* ] [ **-k** *num* ] [ **-l** *num* ]
         [ **-r** *realm* ] [ **-f** *file* ] [ **-n** *num* ] [ **-c** ] [ **-i** ] 
-        [ **-v** ] [ **-o** *option*\ =\ *value* ] *hostname*
+        [ **-v** ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ] *hostname*
 
 Description
 ===========
@@ -111,6 +111,10 @@ Options
 .. option:: -v
 
     Verbose. Print out more information than usual.
+
+.. option:: -w passwd
+
+    Password to use (if not supplied, we will prompt)
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/lmtptest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/lmtptest.rst
@@ -114,7 +114,7 @@ Options
 
 .. option:: -w passwd
 
-    Password to use (if not supplied, we will prompt)
+    Password to use (if not supplied, we will prompt).
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/mupdatetest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/mupdatetest.rst
@@ -15,7 +15,7 @@ Synopsis
 
     **mupdatetest** [ **-p** *port* ] [ **-m** *mechanism* ] [ **-a** *userid* ] [ **-u** *userid* ]
         [ **-k** *num* ] [ **-l** *num* ] [ **-r** *realm* ] [ **-f** *file* ] [ **-n** *num* ]
-        [ **-q** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-o** *option*\ =\ *value* ] *hostname*
+        [ **-q** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ] *hostname*
 
 Description
 ===========
@@ -106,6 +106,10 @@ Options
 .. option:: -v
 
     Verbose. Print out more information than usual.
+
+.. option:: -w passwd
+
+    Password to use (if not supplied, we will prompt).
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/nntptest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/nntptest.rst
@@ -15,7 +15,7 @@ Synopsis
 
     **nntptest** [ **-t** *keyfile* ] [ **-p** *port* ] [ **-m** *mechanism* ] [ **-a** *userid* ]
         [ **-u** *userid* ] [ **-k** *num* ] [ **-l** *num* ] [ **-r** *realm* ] [ **-f** *file* ]
-        [ **-n** *num* ] [ **-s** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-q** ] 
+        [ **-n** *num* ] [ **-s** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-w** *passwd* ] [ **-q** ] 
         [ **-o** *option*\ =\ *value* ] *hostname*
 
 Description
@@ -117,6 +117,10 @@ Options
 .. option:: -v
 
     Verbose. Print out more information than usual.
+
+.. option:: -w
+
+    Password to use (if not supplied, we will prompt).
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/nntptest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/nntptest.rst
@@ -118,7 +118,7 @@ Options
 
     Verbose. Print out more information than usual.
 
-.. option:: -w
+.. option:: -w passwd
 
     Password to use (if not supplied, we will prompt).
 

--- a/docsrc/imap/reference/manpages/usercommands/pop3test.rst
+++ b/docsrc/imap/reference/manpages/usercommands/pop3test.rst
@@ -15,7 +15,7 @@ Synopsis
 
     **pop3test** [ **-t** *keyfile* ] [ **-p** *port* ] [ **-m** *mechanism* ] [ **-a** *userid* ]
         [ **-u** *userid* ] [ **-k** *num* ] [ **-l** *num* ] [ **-r** *realm* ] [ **-f** *file* ]
-        [ **-n** *num* ] [ **-s** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-o** *option*\ =\ *value* ] *hostname*
+        [ **-n** *num* ] [ **-s** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ] *hostname*
 
 Description
 ===========
@@ -114,6 +114,10 @@ Options
 .. option:: -v
 
     Verbose. Print out more information than usual.
+
+.. option:: -w passwd
+
+    Password to use (if not supplied, we will prompt).
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/sivtest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/sivtest.rst
@@ -15,7 +15,7 @@ Synopsis
 
     **sivtest** [ **-t** *keyfile* ] [ **-p** *port* ] [ **-m** *mechanism* ] [ **-a** *userid* ]
         [ **-u** *userid* ] [ **-k** *num* ] [ **-l** *num* ] [ **-r** *realm* ] [ **-f** *file* ]
-        [ **-n** *num* ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-o** *option*\ =\ *value* ] *hostname*
+        [ **-n** *num* ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ] *hostname*
 
 Description
 ===========
@@ -108,6 +108,10 @@ Options
 .. option:: -v
 
     Verbose. Print out more information than usual.
+
+.. option:: -w passwd
+
+    Password to use (if not supplied, we will prompt).
 
 .. option:: -o  option=value
 

--- a/docsrc/imap/reference/manpages/usercommands/smtptest.rst
+++ b/docsrc/imap/reference/manpages/usercommands/smtptest.rst
@@ -15,7 +15,7 @@ Synopsis
 
     **smtptest** [ **-t** *keyfile* ] [ **-p** *port* ] [ **-m** *mechanism* ] [ **-a** *userid* ]
         [ **-u** *userid* ] [ **-k** *num* ] [ **-l** *num* ] [ **-r** *realm* ] [ **-f** *file* ]
-        [ **-n** *num* ] [ **-s** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-o** *option*\ =\ *value* ] *hostname*
+        [ **-n** *num* ] [ **-s** ] [ **-c** ] [ **-i** ] [ **-v** ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ] *hostname*
 
 Description
 ===========
@@ -112,6 +112,10 @@ Options
 .. option:: -v
 
     Verbose. Print out more information than usual.
+
+.. option:: -w passwd
+
+    Password to use (if not supplied, we will prompt).
 
 .. option:: -o  option=value
 


### PR DESCRIPTION
Hi,
I found out option '-w passwd' is missing from manual pages, but it is in help. This commit will fix it.