### PR TITLE
[Docs] 3.0 upgrade guide.

### DIFF
--- a/docsrc/imap/concepts/deployment/databases.rst
+++ b/docsrc/imap/concepts/deployment/databases.rst
@@ -1,3 +1,5 @@
+.. _databases:
+
 =========
 Databases
 =========
@@ -33,17 +35,17 @@ One per system:
 * `STATUS cache (statuscache.db)`_
 * `User Access (user_deny.db)`_
 * `Backups (backup.db)`_
-* `Conversations (conversations.db)`_
 * `News database (fetchnews.db)`_
-* `Search Index db (?.db)`_
 * `Sort Cache db (?.db)`_
 * `Zoneinfo db (zoneinfo.db)`_
 
 One per user:
 
+* `Conversations (conversations.db)`_
 * `Seen State (<userid>.seen)`_
 * `Subscriptions (<userid>.sub)`_
 * `Mailbox Keys (<userid>.mboxkey)`_
+* `Search Index db (?.db)`_
 
 Mailbox List (mailboxes.db)
 ---------------------------
@@ -165,6 +167,9 @@ File format not selectable.
 
 Search Index db (?.db)
 ----------------------
+
+This is either cyrus.squatter if you're using squatter, or xapian.active
+if you're using xapian.
 
 File type can be: `twoskip`_ (default), `flat`_, `skiplist`_, or `lmdb`_.
 

--- a/docsrc/imap/concepts/features/namespaces.rst
+++ b/docsrc/imap/concepts/features/namespaces.rst
@@ -1,5 +1,7 @@
 :tocdepth: 2
 
+.. _mailbox-namespaces:
+
 ==================
 Mailbox Namespaces
 ==================

--- a/docsrc/imap/developer/basicserver.rst
+++ b/docsrc/imap/developer/basicserver.rst
@@ -14,10 +14,10 @@ At the end of this guide, you will be up and running with a local instance of Cy
 .. note::
     These instructions are for Ubuntu, specifically Ubuntu 15.04. For other operating systems, dependency names in package managers may differ, but the main concepts remain the same.
 
-    Please note that **this guide is meant to get you a working environment quickly, not to allow you to customize everything from the get go**. 
+    Please note that **this guide is meant to get you a working environment quickly, not to allow you to customize everything from the get go**.
 
     This guide will set up Cyrus to work with the Sendmail SMTP server - and there will be no instructions for using Postfix. Once you have a working environment, you are encouraged to experiment further and set up Postfix instead of Sendmail, use different kinds of authentication schemes, etc.
-  
+
 
 1. Update your system
 ----------------------
@@ -26,7 +26,7 @@ First things first, let's update our existing system to ensure everything is cur
 
 ::
 
-    sudo apt-get update  
+    sudo apt-get update
     sudo apt-get upgrade -y
 
 .. _Hacker News: https://news.ycombinator.com/
@@ -46,7 +46,7 @@ Now, let's install libraries and tools used by Cyrus IMAP. This includes a C com
     libsnmp-dev libsqlite3-dev libssl-dev libtest-unit-perl libtool libunix-syslog-perl liburi-perl \
     libxapian-dev libxml-generator-perl libxml-xpath-perl libxml2-dev libwrap0-dev libzephyr-dev lsb-base \
     net-tools perl php5-cli php5-curl pkg-config po-debconf tcl-dev \
-    transfig uuid-dev vim wamerican wget xutils-dev zlib1g-dev sasl2-bin rsyslog sudo acl telnet  
+    transfig uuid-dev vim wamerican wget xutils-dev zlib1g-dev sasl2-bin rsyslog sudo acl telnet
 
 
 3. The cyrus:mail user
@@ -56,8 +56,8 @@ Now let's create a **special user account just for the Cyrus server** to sandbox
 
 ::
 
-    groupadd -r mail  
-    useradd -c "Cyrus IMAP Server" -d /var/lib/imap -g mail -s /bin/bash -r cyrus  
+    groupadd -r mail
+    useradd -c "Cyrus IMAP Server" -d /var/lib/imap -g mail -s /bin/bash -r cyrus
 
 4. Setting up authentication with SASL
 --------------------------------------
@@ -68,31 +68,31 @@ Create a ``saslauth`` group and add the ``cyrus`` user to the group, so Cyrus ca
 
 ::
 
-    groupadd -r saslauth  
+    groupadd -r saslauth
     usermod -aG saslauth cyrus
-    
+
 Change the default SASL configuration in ``/etc/default/saslauthd``.
     1. Make sure that the ``START`` option is set to *yes* ``(START=yes)`` and
     2. Set the``MECHANISMS`` option to **sasldb** ``(MECHANISMS="sasldb")``.
-    
+
 Start the SASL auth daemon:
 
 ::
 
     /etc/init.d/saslauthd start
-    
+
 Great! Now, we'll create the IMAP user inside SASL. This is the user you'll use to login to the IMAP server later on.
 
 ::
 
     echo 'secret' | saslpasswd2 -p -c imapuser
-    
+
 You can replace ``secret`` with a more suitable password you want and ``imapuser`` with the username you want. Once this is done, check that the user exists and is set up correctly:
 
 ::
 
-    testsaslauthd -u imapuser -p secret  
-    
+    testsaslauthd -u imapuser -p secret
+
 You should get an ``0: OK "Success."`` message.
 
 .. note::
@@ -111,41 +111,41 @@ We'll set up LMTP with the Sendmail SMTP server.
 
 ::
 
-    sudo apt-get install -y sendmail  
-    
+    sudo apt-get install -y sendmail
+
 We need to make Sendmail aware of the fact we are using the Cyrus IMAP server: modify the ``/etc/mail/sendmail.mc`` file. Add this line before the ``MAILER_DEFINITIONS`` section:
 
 ::
 
-    define(`confLOCAL_MAILER', `cyrusv2')dnl  
-    
+    define(`confLOCAL_MAILER', `cyrusv2')dnl
+
 And right below ``MAILER_DEFINITIONS``, add this:
 
 ::
 
-    MAILER(`cyrusv2')dnl  
-    
+    MAILER(`cyrusv2')dnl
+
 This enables the **cyrusv2** mailer for local mail delivery. In case you're wondering, cyrusv2 stands for Cyrus v2.x, which means this is meant to work with versions 2.x of Cyrus IMAP. It may or may not work with Cyrus 3.x too.
 
 Next, we run a script that takes the ``/etc/mail/sendmail.mc`` file and and prepares it for use by Sendmail. This may take some time. In the meantime, you are encouraged to read the `IMAP spec`_ one more time, because, you know, it's a fun read :-)
 
 ::
 
-    sudo sendmailconfig  
+    sudo sendmailconfig
 
 Sendmail communication
 ######################
-    
+
 One last thing we need to do for LMTP to work with Sendmail is to create a folder that will contain the UNIX socket used by Sendmail and Cyrus to deliver/receive emails:
 
 ::
 
-    sudo mkdir -p /var/run/cyrus/socket  
-    sudo chown cyrus:mail /var/run/cyrus/socket  
-    sudo chmod 750 /var/run/cyrus/socket  
+    sudo mkdir -p /var/run/cyrus/socket
+    sudo chown cyrus:mail /var/run/cyrus/socket
+    sudo chmod 750 /var/run/cyrus/socket
 
-.. note::   
-    For some reason, the /var/run/cyrus/socket folder disappears when I reboot my PC. I need to recreate it when I reboot. You may or may not have to do that too.   
+.. note::
+    For some reason, the /var/run/cyrus/socket folder disappears when I reboot my PC. I need to recreate it when I reboot. You may or may not have to do that too.
 
 .. _IMAP spec: http://tools.ietf.org/html/rfc3501
 
@@ -155,19 +155,19 @@ Cyrus uses assorted protocols, which need to have their ports defined in ``/etc/
 
 ::
 
-    pop3      110/tcp  
-    nntp      119/tcp  
-    imap      143/tcp  
-    imsp      406/tcp  
-    nntps     563/tcp  
-    acap      674/tcp  
-    imaps     993/tcp  
-    pop3s     995/tcp  
-    kpop      1109/tcp  
-    lmtp      2003/tcp  
-    sieve     4190/tcp  
-    fud       4201/udp      
-    
+    pop3      110/tcp
+    nntp      119/tcp
+    imap      143/tcp
+    imsp      406/tcp
+    nntps     563/tcp
+    acap      674/tcp
+    imaps     993/tcp
+    pop3s     995/tcp
+    kpop      1109/tcp
+    lmtp      2003/tcp
+    sieve     4190/tcp
+    fud       4201/udp
+
 7. Configuring Cyrus
 --------------------
 
@@ -177,25 +177,25 @@ Set up a simple directory structure for Cyrus to store emails, owned by the ``cy
 
 ::
 
-    sudo mkdir -p /var/imap /var/spool/imap  
-    sudo chown cyrus:mail /var/imap /var/spool/imap  
-    sudo chmod 750 /var/imap /var/spool/imap  
+    sudo mkdir -p /var/imap /var/spool/imap
+    sudo chown cyrus:mail /var/imap /var/spool/imap
+    sudo chmod 750 /var/imap /var/spool/imap
 
-    
+
 Let's add some basic configuration for the Cyrus IMAP server. Two files have to be added: ``/etc/imapd.conf`` and ``/etc/cyrus.conf``.
 
 For :cyrusman:`imapd.conf(5)`, start with this:
 
 ::
 
-    configdirectory: /var/imap  
-    partition-default: /var/spool/imap  
-    admins: imapuser 
-    sasl_pwcheck_method: saslauthd  
-    allowplaintext: yes  
-    virtdomains: yes  
-    defaultdomain: localhost  
-    
+    configdirectory: /var/imap
+    partition-default: /var/spool/imap
+    admins: imapuser
+    sasl_pwcheck_method: saslauthd
+    allowplaintext: yes
+    virtdomains: yes
+    defaultdomain: localhost
+
 Note that **configdirectory** and **partition-default** are set to the folders we just created.
 
 The admin user is the ``imapuser`` created in step 4, for authentication against sasl. Change this value if you named your user something different.
@@ -204,13 +204,13 @@ For :cyrusman:`cyrus.conf(5)`, start with this:
 
 ::
 
-    START {  
+    START {
       # do not delete this entry!
       recover    cmd="ctl_cyrusdb -r"
     }
 
     # UNIX sockets start with a slash and are put into /var/imap/sockets
-    SERVICES {  
+    SERVICES {
       # add or remove based on preferences
       imap        cmd="imapd" listen="imap" prefork=0
       pop3        cmd="pop3d" listen="pop3" prefork=0
@@ -219,7 +219,7 @@ For :cyrusman:`cyrus.conf(5)`, start with this:
       lmtpunix    cmd="lmtpd" listen="/var/run/cyrus/socket/lmtp" prefork=0
     }
 
-    EVENTS {  
+    EVENTS {
       # this is required
       checkpoint    cmd="ctl_cyrusdb -c" period=30
 
@@ -238,19 +238,23 @@ Before you launch Cyrus for the first time, create the Cyrus directory structure
 
 ::
 
-    sudo -u cyrus ./tools/mkimap  
-        
+    sudo -u cyrus ./tools/mkimap
+
 8. Launch Cyrus
 ---------------
 
 ::
 
-    sudo ./master/master -d  
+    sudo ./master/master -d
 
 Check ``/var/log/syslog`` for errors so you can quickly understand potential problems.
 
+When you're ready, you can create init scripts to start and stop your daemons. This
+https://www.linux.com/learn/managing-linux-daemons-init-scripts is old, but has a good
+explanation of the concepts required.
+
 Time to cheer!
- 
+
 Optional: Setting up SSL certificates
 -------------------------------------
 
@@ -260,22 +264,22 @@ Let's set up encryption with TLS. Create a TLS certificate using OpenSSL. Genera
 
     sudo openssl req -new -x509 -nodes -out /var/imap/server.pem \
     -keyout /var/imap/server.pem -days 365 \
-    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost"  
-    
+    -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost"
+
 This creates a TLS certificate (`-out`) and private key (`-keyout`) in the `X.509 <https://en.wikipedia.org/wiki/X.509>`_ format (`-x509`). The certificate is set to expire in 365 days (`-days`) and has default information set up (`-subj ...`). The contents of the -subj is non-trivial and defined in `RFC 5280 <http://www.ietf.org/rfc/rfc5280.txt>`_, a brief summary is available on `stackoverflow <http://stackoverflow.com/questions/6464129/certificate-subject-x-509>`_ which is enough to decode our sample above.
 
 Great! You should now have a file at /var/imap/server.pem. Give Cyrus access to this file:
 
 ::
 
-    sudo chown cyrus:mail /var/imap/server.pem 
- 
+    sudo chown cyrus:mail /var/imap/server.pem
+
 Awesome! Almost done. We will now configure the Cyrus IMAP server to actually use this TLS certificate. Open your Cyrus configuration file /etc/imapd.conf and add the following to lines at the end of it:
 
 ::
 
-    tls_server_cert: /var/imap/server.pem  
-    tls_server_key: /var/imap/server.pem  
+    tls_server_cert: /var/imap/server.pem
+    tls_server_key: /var/imap/server.pem
 
 This tells the server where to find the TLS certificate and the key. It may seem weird to specify the same file twice, but since the file has the x509 format, the server will know what to do. Cyrus is there for you, always (unless your hard drive burns down) ! :-)
 
@@ -283,17 +287,17 @@ The other configuration file we have to edit is /etc/cyrus.conf. Open it up with
 
 ::
 
-    imaps        cmd="imapd" listen="imaps" prefork=0  
-    
-Notice the `s` at the end of `imaps`. This says we are using TLS.   
+    imaps        cmd="imapd" listen="imaps" prefork=0
+
+Notice the `s` at the end of `imaps`. This says we are using TLS.
 
 If you now restart (or start) your Cyrus server, you should have Cyrus listening on port **993** (the IMAPS port) with the **STARTTLS IMAP extension** enabled. You can check that TLS works as expected with the following command:
 
 ::
 
-    imtest -t "" -u imapuser -a imapuser -w secret localhost  
-    
-Make sure to replace `imapuser` with whatever user you set up with saslpasswd2 before, and to replace `secret` with the actual password you set for that user. 
+    imtest -t "" -u imapuser -a imapuser -w secret localhost
+
+Make sure to replace `imapuser` with whatever user you set up with saslpasswd2 before, and to replace `secret` with the actual password you set for that user.
 
 Sending a test email
 --------------------
@@ -304,12 +308,12 @@ We will now send a test email to our local development environment to see if eve
 * LMTP should transmit the email to Cyrus IMAP,
 * You should be able to see the email stored on your filesystem.
 
-But first, let's create a mailbox that we will send the test email to. We'll call this test mailbox `example@localhost`. 
+But first, let's create a mailbox that we will send the test email to. We'll call this test mailbox `example@localhost`.
 
 ::
 
-    echo 'createmailbox user.example@localhost' | cyradm -u imapuser -w secret localhost  
-    
+    echo 'createmailbox user.example@localhost' | cyradm -u imapuser -w secret localhost
+
 Notice how we seem to be creating a mailbox named `user.example@localhost`. In fact, Cyrus understands this to be `example@localhost`, so we're fine. As usual, adjust the password via the `-w` option to the password you set above.
 
 If you have explicitly enabled `unixhierarchysep` in `/etc/imapd.conf`, you should replace `user.example@localhost` with `user/example@localhost`. You can read more about unixhierarchysep in :cyrusman:`imapd.conf(5)`.
@@ -318,9 +322,9 @@ Also, note that the command above might produce some weird looking output, such 
 
 ::
 
-    localhost> localhost>  
-    
-This happens because cyradm is normally used interactively, with a prompt. We aren't using a prompt, so this output is fine and expected. 
+    localhost> localhost>
+
+This happens because cyradm is normally used interactively, with a prompt. We aren't using a prompt, so this output is fine and expected.
 
 Now that the mailbox exists, we'll send it an email. We won't be using Fastmail or Yahoo Mail or Google Mail. No, no. We will use the good old telnet with raw SMTP commands. Let's do this!
 
@@ -328,30 +332,30 @@ First, connect to the Sendmail SMTP server:
 
 ::
 
-    telnet localhost smtp 
-    
+    telnet localhost smtp
+
 You should see a prompt appear:
 
 ::
 
-    Trying ::1...  
-    Trying 127.0.0.1...  
-    Connected to localhost.  
-    Escape character is '^]'.  
-    220 ... ESMTP Sendmail ...  
-    
+    Trying ::1...
+    Trying 127.0.0.1...
+    Connected to localhost.
+    Escape character is '^]'.
+    220 ... ESMTP Sendmail ...
+
 Now, we'll send the `SMTP commands <https://www.ietf.org/rfc/rfc2821.txt>`_ to the server. These are responsible for ordering Sendmail to store an email:
 
 ::
 
-    EHLO localhost  
-    MAIL FROM:<hello@localhost>  
-    RCPT TO:<example@localhost>  
-    DATA  
-    Hello world!  
+    EHLO localhost
+    MAIL FROM:<hello@localhost>
+    RCPT TO:<example@localhost>
+    DATA
+    Hello world!
     .
-    QUIT  
-    
+    QUIT
+
 If you are using Sendmail as your SMTP server, you should be able to safely copy and paste this bit into the terminal before hitting your ENTER key. If not, you may want to paste these commands one by one (or make sure you enable `PIPELINING` in the SMTP config).
 
 If you see a message like **250 2.0.0 ... Message accepted for delivery**, you did it! You should now have a file called `1.` in the `/var/spool/imap/user/example` directory, with the content of the email you sent just before.
@@ -375,7 +379,7 @@ To be written.
 Troubleshooting
 ---------------
 
-Some common issues are explained below. 
+Some common issues are explained below.
 
 I have all kinds of weird Perl errors when running cyradm
 #########################################################
@@ -384,8 +388,8 @@ The solution is to set the Perl library path right. To be honest, I was too lazy
 
 ::
 
-    export PERL5LIB="$PERL5LIB:$(find path/to/cyrus/perl -type d | tr "\\n" ":")"  
-    
+    export PERL5LIB="$PERL5LIB:$(find path/to/cyrus/perl -type d | tr "\\n" ":")"
+
 Just make sure to change **path/to/cyrus** to the actual path to the Cyrus source code directory. This should be something like ``/home/jack/cyrus-src/perl``.
 
 I can't connect to the IMAP server
@@ -396,7 +400,7 @@ Make sure that the SASL auth daemon is running. You can start it with this comma
 ::
 
     /etc/init.d/saslauthd start
-    
+
 You can safely run this command even if you don't know whether the SASL auth daemon is already running or not.
 
 Emails are not being delivered to Cyrus
@@ -407,7 +411,7 @@ Make sure that you have started Sendmail, which you can do like this:
 ::
 
     /etc/init.d/sendmail start
-    
+
 Something is not working but I can't figure out why
 ###################################################
 
@@ -415,9 +419,9 @@ More information is almost always logged to **syslog**. Make sure you start sysl
 
 ::
 
-    /etc/init.d/rsyslog start 
+    /etc/init.d/rsyslog start
 
 My question isn't answered here
 ###############################
 
-Join us in the :ref:`#cyrus IRC channel on Freenode <feedback>` or on the mailing lists if you need help or just want to chat about Cyrus, IMAP, donuts, etc.   
+Join us in the :ref:`#cyrus IRC channel on Freenode <feedback>` or on the mailing lists if you need help or just want to chat about Cyrus, IMAP, donuts, etc.

--- a/docsrc/imap/download/installation.rst
+++ b/docsrc/imap/download/installation.rst
@@ -6,7 +6,14 @@ IMAP Installation Guide
 
 Cyrus IMAP packages are shipped with every major distribution, including
 but not limited to Fedora, Red Hat Enterprise Linux, CentOS, Scientific
-Linux, Debian, Ubuntu, openSUSE, Gentoo, Mageia and ClearOS.
+Linux, Debian, Ubuntu, openSUSE, Gentoo, Mageia and ClearOS. They are not
+guaranteed to be up to date!
+
+Upgrading
+==========
+
+.. toctree::
+    upgrade
 
 Installation Using Packages
 ===========================
@@ -25,20 +32,20 @@ Build and Install Yourself
     :maxdepth: 2
 
     installation/diy
-	
+
 .. toctree::
     :hidden:
 
     installation/mta/index
-    
+
 External Tools
 ==============
 
-These are projects that are not directly developed or managed 
-under the umbrella of the Cyrus Project, but may provide enhancements 
+These are projects that are not directly developed or managed
+under the umbrella of the Cyrus Project, but may provide enhancements
 or additional functionality.
 
-Both of these projects are not under active development, but are 
+Both of these projects are not under active development, but are
 definitely worthwhile and would be Good Things to have available.
 If you think you'd be interested in taking them on and bringing them
 up to speed, we encourage you to contact the original authors.
@@ -46,13 +53,13 @@ up to speed, we encourage you to contact the original authors.
 There is an effort to develop `Cyrus utilities <http://sourceforge.net/projects/cyrus-utils/>`_.
 
 Additionally, a Cyrus administrative GUI is available from http://korreio.sf.net
-    
+
 Licensing
 =========
 
-All versions of the Cyrus IMAP server and Cyrus SASL library are now 
-covered by the following copyright message. However, please note that 
-in older distributions, there may still be files that have the old 
+All versions of the Cyrus IMAP server and Cyrus SASL library are now
+covered by the following copyright message. However, please note that
+in older distributions, there may still be files that have the old
 copyright text.
 
 ::
@@ -64,7 +71,7 @@ copyright text.
     * are met:
     *
     * 1. Redistributions of source code must retain the above copyright
-    *    notice, this list of conditions and the following disclaimer. 
+    *    notice, this list of conditions and the following disclaimer.
     *
     * 2. Redistributions in binary form must reproduce the above copyright
     *    notice, this list of conditions and the following disclaimer in
@@ -74,7 +81,7 @@ copyright text.
     * 3. The name "Carnegie Mellon University" must not be used to
     *    endorse or promote products derived from this software without
     *    prior written permission. For permission or any legal
-    *    details, please contact  
+    *    details, please contact
     *      Office of Technology Transfer
     *      Carnegie Mellon University
     *      5000 Forbes Avenue

--- a/docsrc/imap/download/installation/distributions/debian.rst
+++ b/docsrc/imap/download/installation/distributions/debian.rst
@@ -1,14 +1,90 @@
+.. _imap-installation-distributions-debian:
+
 Debian
 ======
 
-The good news is Debian distributions are supported by the Cyrus IMAP
-team, the bad news is nobody has written up this part of the
-documentation yet.
+Currently supported versions of Debian include Cyrus IMAP packages in
+the repositories configured on a stock system.
+
 
 .. NOTE::
 
-    Cyrus IMAP documentation is a work in progress. The completion of
-    this particular part of the documentation is pending a Debian-savvy
-    volunteer. If you're interested, please see the instructions for
-    :ref:`imap-installation-distributions-centos` for a general idea of
-    a write-up next-next finish installation of Cyrus IMAP.
+    The Cyrus project does not support running any versions of the Cyrus
+    IMAP software older than the version of the software shipped
+    with the operating system itself.
+
+To install the version of Cyrus IMAP that comes with the operating
+system, issue the following command:
+
+.. parsed-literal::
+
+    # :command:`apt-get install cyrus-imapd cyrus-sasl cyrus-sasl-plain`
+
+If you want xapian, you'll need to build all of Cyrus yourself. See developer guide here. TODO.
+
+Next, set a password for the default administrative user ``cyrus``:
+
+.. parsed-literal::
+
+    # :command:`passwd cyrus`
+    Changing password for user cyrus.
+    New password:
+    Retype new password:
+    passwd: all authentication tokens updated successfully.
+
+Start and configure to start when the system boots, the
+:manpage:`saslauthd` service:
+
+.. parsed-literal::
+
+    # :command:`service saslauthd start`
+    Starting saslauthd:                                        [  OK  ]
+    # :command:`chkconfig saslauthd on`
+
+You should at this moment be able to authenticate against
+:manpage:`saslauthd`:
+
+.. parsed-literal::
+
+    # :command:`testsaslauthd -u cyrus -p YOUR-PASSWORD`
+
+You should get an ``0: OK "Success."`` message.
+
+.. todo::
+    If this does not succeed, see ref:`sasl-troubleshooting-saslauthd`.
+
+Start the service, and ensure the service starts up when the system
+boots:
+
+.. parsed-literal::
+
+    # :command:`service cyrus-imapd start`
+    # :command:`chkconfig cyrus-imapd on`
+
+You should now be able to login as the ``cyrus`` user, which is
+configured by default as an administrator for Cyrus IMAP:
+
+.. parsed-literal::
+
+    # :command:`imtest -t "" -u cyrus -a cyrus localhost`
+    S: * OK [CAPABILITY IMAP4 IMAP4rev1 LITERAL+ ID STARTTLS LOGINDISABLED COMPRESS=DEFLATE] d5ec35c1414a Cyrus IMAP v2.3.16-Fedora-RPM-2.3.16-13.el6_6 server ready
+    C: S01 STARTTLS
+    S: S01 OK Begin TLS negotiation now
+    verify error:num=18:self signed certificate
+    TLS connection established: TLSv1.2 with cipher DHE-RSA-AES256-GCM-SHA384 (256/256 bits)
+    C: C01 CAPABILITY
+    S: * CAPABILITY IMAP4 IMAP4rev1 LITERAL+ ID AUTH=PLAIN SASL-IR COMPRESS=DEFLATE ACL RIGHTS=kxte QUOTA MAILBOX-REFERRALS NAMESPACE UIDPLUS NO_ATOMIC_RENAME UNSELECT CHILDREN MULTIAPPEND BINARY SORT SORT=MODSEQ THREAD=ORDEREDSUBJECT THREAD=REFERENCES ANNOTATEMORE CATENATE CONDSTORE SCAN IDLE LISTEXT LIST-SUBSCRIBED X-NETSCAPE URLAUTH
+    S: C01 OK Completed
+    Please enter your password:
+    C: A01 AUTHENTICATE PLAIN \*\*\*\*\*\*\*\*\*\*\*\*
+    S: A01 OK [CAPABILITY IMAP4 IMAP4rev1 LITERAL+ ID LOGINDISABLED COMPRESS=DEFLATE ACL RIGHTS=kxte QUOTA MAILBOX-REFERRALS NAMESPACE UIDPLUS NO_ATOMIC_RENAME UNSELECT CHILDREN MULTIAPPEND BINARY SORT SORT=MODSEQ THREAD=ORDEREDSUBJECT THREAD=REFERENCES ANNOTATEMORE CATENATE CONDSTORE SCAN IDLE LISTEXT LIST-SUBSCRIBED X-NETSCAPE URLAUTH] Success (tls protection)
+    Authenticated.
+    Security strength factor: 256
+    . LIST "" "*"
+    . OK Completed (0.000 secs 1 calls)
+    C: Q01 LOGOUT
+    * BYE LOGOUT received
+    Q01 OK Completed
+    Connection closed.
+
+Next, continue with :ref:`imap-configuring-the-mta`.

--- a/docsrc/imap/download/installation/diy.rst
+++ b/docsrc/imap/download/installation/diy.rst
@@ -1,3 +1,5 @@
+.. _install-diy:
+
 ==============
 Do It Yourself
 ==============

--- a/docsrc/imap/download/upgrade.rst
+++ b/docsrc/imap/download/upgrade.rst
@@ -1,0 +1,228 @@
+.. _upgrade:
+
+================
+Upgrading to 3.0
+================
+
+.. note::
+
+    This guide assumes that you are familiar and comfortable with administration of a
+    Cyrus installation, and system administration in general.
+
+..  contents:: Upgrading: an overview
+    :local:
+
+1. Preparation
+--------------
+
+Things to consider **before** you begin:
+
+Installation from tarball
+#########################
+
+It takes some time before platform packages are up to date. It is likely you will need to install from our packaged tarball, at least initially. We provide a full list of libraries that Debian requires, but we aren't able to test all platforms: you may find you need to install additional or different libraries to support v3.0.
+
+How are you planning on upgrading?
+##################################
+
+Ideally, you will do a sandboxed test installation of 3.0 using a snapshot of your existing data before you switch off your existing installation. The rest of the instructions are assuming a sandboxed 3.0 installation.
+
+If you're familiar with replication, and your current installation is 2.4 or newer, you can set up your existing
+installation to replicate data to a new 3.0 installation and failover to the new installation when you're
+ready. The replication protocol has been kept backwards compatible.
+
+Most risky is upgrading in-place. Please don't do this, for your sanity and ours.
+
+2. Install new 3.0 Cyrus
+------------------------
+
+Download the release :ref:`3.0 package tarball<install-diy>`.
+
+Fetch the libraries for your platform. The list for Debian is::
+
+    sudo apt-get install -y autoconf automake autotools-dev bash-completion bison build-essential comerr-dev \
+    debhelper flex g++ git gperf groff heimdal-dev libbsd-resource-perl libclone-perl libconfig-inifiles-perl \
+    libcunit1-dev libdatetime-perl libdb-dev libdigest-sha-perl libencode-imaputf7-perl libfile-chdir-perl \
+    libglib2.0-dev libical-dev libio-socket-inet6-perl libio-stringy-perl libjansson-dev libldap2-dev \
+    libmysqlclient-dev libnet-server-perl libnews-nntpclient-perl libpam0g-dev libpcre3-dev libsasl2-dev \
+    libsnmp-dev libsqlite3-dev libssl-dev libtest-unit-perl libtool libunix-syslog-perl liburi-perl \
+    libxapian-dev libxml-generator-perl libxml-xpath-perl libxml2-dev libwrap0-dev libzephyr-dev lsb-base \
+    net-tools perl php5-cli php5-curl pkg-config po-debconf tcl-dev \
+    transfig uuid-dev vim wamerican wget xutils-dev zlib1g-dev sasl2-bin rsyslog sudo acl telnet
+
+If you're on another platform and can provide the list of dependencies, please
+let us know via a `GitHub issue <https://github.com/cyrusimap/cyrus-imapd/issues>`_ or documentation pull request or send mail to the :ref:`developer list<feedback>`.
+
+Follow the :ref:`general install instructions <basicserver>`.
+
+.. note::
+
+    Note you won't want to set up your new Cyrus initially to be able to listen for new inbound/outbound imap connections.
+
+3. Shut down existing Cyrus
+---------------------------
+
+Shut down your existing Cyrus as user cyrus.
+
+This is necessary to guarantee a clean data snapshot.
+
+4. Backup existing data
+-----------------------
+
+We recommend backing up all your data before continuing.
+
+* Sieve scripts
+* Config files
+* Mail spool
+* :ref:`Cyrus Databases <databases>`
+
+(You do already have a backup strategy in place, right? Once you're on 3.0, you can
+use the new inbuilt :ref:`backup tools <cyrus-backups>`.)
+
+5. Copy config files and update
+-------------------------------
+
+Copy your existing :cyrusman:`imapd.conf(5)` and :cyrusman:`cyrus.conf(5)` into the new 3.0 locations.
+
+Update imapd.conf (edit as root) so that the new data directories are in the right spot (you don't want to mix
+your existing data with your new install).
+
+Check to see if your config file contains any deprecated options::
+
+    cyr_info conf-lint -C <path to cyrus.conf> -M <path to imapd.conf>
+
+Check to see that the sum of your system's config values is correct. This command
+takes all the system defaults, along with anything you have provided overrides for
+in your config files::
+
+    cyr_info conf-all -C <path to cyrus.conf> -M <path to imapd.conf>
+
+**Important config** options: unixhierarchysep and altnamespace defaults have changed
+in :cyrusman:`imapd.conf(5)`. Implications are outlined in :ref:`Mailbox namespaces <mailbox-namespaces>`.
+
+* unixhierarchysep: on
+* altnamespace: on
+
+Note: if you're using groups, don't turn reverseacls: on. Reverseacl support
+only works well for users without groups.
+
+
+6. Copy all data to new location
+--------------------------------
+
+Before you launch Cyrus for the first time, create the Cyrus directory structure: use :cyrusman:`mkimap(8)`.
+
+::
+
+    sudo -u cyrus ./tools/mkimap
+
+Copy your data files to the new Cyrus 3.0 locations you just specified.
+
+* Sieve scripts
+* Config files
+* Mail spool
+* :ref:`Cyrus Databases <databases>`
+
+You don't need to copy the following databases as Cyrus 3.0 will recreate these for you automatically:
+
+* duplicate delivery (deliver.db),
+* TLS cache (tls_sessions.db),
+* PTS cache (ptscache.db),
+* STATUS cache (statuscache.db).
+
+.. warning::
+
+    **Berkeley db format no longer supported**
+
+    If you have any databases using Berkeley db, they'll need to be converted to skiplist or flat in your
+    existing installation. And then optionally converted to whatever final format
+    you'd like in your 3.0 installation.
+
+    Databases potentially affected: mailboxes, annotations, conversations, quotas.
+
+    Using old version tool::
+
+       cvt_cyrusdb mailboxes.db berkeley new-mailboxes.db skiplist
+
+    If you don't want to use flat or skiplist for 3.0, you can use the new 3.0 cvt_cyrusdb to swap to new format::
+
+       cvt_cyrusdb new-mailboxes.db skiplist really-new-mailboxes.db <new file format>
+
+
+7. Start new 3.0 Cyrus and verify
+---------------------------------
+
+::
+
+    sudo ./master/master -d
+
+Check ``/var/log/syslog`` for errors so you can quickly understand potential problems.
+
+When you're satisfied version 3.0 is running and can see all its data correctly,
+connect the new Cyrus back up to send and receive mail and you're
+back in business.
+
+If something has gone wrong, contact us on the :ref:`mailing list <feedback>`.
+You can switch your old installation back on
+and keep processing mail until you're able to finish your 3.0 installation.
+
+8. Reconstruct databases and cache
+----------------------------------
+
+The following steps can each take a long time, so we recommend
+running them one at a time (to reduce locking contention and high I/O load).
+
+To upgrade all the mailboxes to the latest version. This will take hours, possibly days.
+
+::
+
+    reconstruct -V max
+
+New configuration: if turning on conversations, you need to create conversations.db for each user.
+This is required for jmap.::
+
+     ctl_conversationsdb -b -r
+
+To check (and correct) quota usage::
+
+    quota -f
+
+If you're using CalDAV/CardDAV/all of the DAV, then all the user.dav databases need
+to be reconstructed due to format changes.::
+
+    dav_reconstruct -a
+
+9. Do you want any new features?
+--------------------------------
+
+3.0 comes with many lovely new features. Consider which ones you want to enable.
+Here are some which may interest you. Check the :ref:`3.0 release notes <imap-release-notes-3.0>`
+for the full list.
+
+* :ref:`JMAP <developer-jmap>`
+* :ref:`Backups <cyrus-backups>`
+* :ref:`Xapian for searching <imapinstall-xapian>`
+* Cross-domain support. See ``crossdomains`` in :cyrusman:`imapd.conf(5)`
+
+10. Upgrade complete
+--------------------
+
+Your upgrade is complete! We have a super-quick survey (3 questions only,
+anonymous responses) we would love for you to fill out, so we can get a feel for
+how many Cyrus installations are out there, and how the upgrade process went.
+
+|3.0 survey link|
+
+.. |3.0 survey link| raw:: html
+
+    <a href="https://cyrusimap.typeform.com/to/YI9P0f" target="_blank">
+    I'll fill in the survey right now</a> (opens in a new window)
+
+
+Special note for Murder configurations
+--------------------------------------
+
+Generally accepted wisdom when upgrading a Murder configuration is to
+upgrade your back end servers first. This can be done one at a time.
+
+Then upgrade your front ends and the mupdate master.

--- a/docsrc/imap/reference/admin/access-control/rights-reference.rst
+++ b/docsrc/imap/reference/admin/access-control/rights-reference.rst
@@ -123,7 +123,7 @@ Individual Rights Reference
         NOT fail, as the tagged NO response is not handled very well by
         deployed clients.
 
-        In order to comply, we have `Bug #3488 <https://bugzilla.cyrusimap.org/show_bug.cgi?id=3488>`__, as
+        In order to comply, we have `Bug #1375 <https://github.com/cyrusimap/cyrus-imapd/issues/1375>`__, as
         Cyrus IMAP currently does seem to issue a tagged ``NO``
         response.
 


### PR DESCRIPTION
@elliefm @brong ( @rsto ) Can you please eyeball this guide?

This is a first cut of the 3.0 upgrade guide. It assumes (correctly? incorrectly?) that people will maintain two physical installations (one of existing, one of new 3.0) until they're ready to actually cut over. Is that assumption correct? (It does mention you can replicate to a 3.0 install, but for more info I might need ellie to write that bit)

It assumes that someone doing this will know where certain files (config/sieve/databases/spool/etc) live and being told explicitly is overkill. Is that reasonable or should I spell out the default locations?