### PR TITLE
Update the 'upgrade' document & cyrus.conf manpage

### DIFF
--- a/docsrc/imap/concepts/features/namespaces.rst
+++ b/docsrc/imap/concepts/features/namespaces.rst
@@ -216,7 +216,8 @@ User Namespace Mode
 altnamespace: on or off
 -----------------------
 
-NOTE: If you are upgrading an existing server which uses :cyrusman:`timsieved(8)` to manage Sieve scripts and choose to swap namespace modes, you should run the script :cyrusman:`translatesieve(8)` after configuring the namespace option(s). This script will translate the folder names in fileinto actions.
+.. note::
+    If you are upgrading an existing server which uses :cyrusman:`timsieved(8)` to manage Sieve scripts and choose to swap namespace modes, you should run the script :cyrusman:`translatesieve(8)` after configuring the namespace option(s). This script will translate the folder names in fileinto actions.
 
 By default  Cyrus IMAP uses *altnamespace: on* , and unixhierarchysep: on "/" (slash) character for the
 hierarchy separator.

--- a/docsrc/imap/reference/admin/sop/altnamespace.rst
+++ b/docsrc/imap/reference/admin/sop/altnamespace.rst
@@ -1,8 +1,14 @@
 Alternative Namespace
 =====================
 
+.. _imap-switching-alt-namespace-mode:
+
 Switching the Alternative Namespace
 -----------------------------------
 
-When switching the alternative namespace configuration variable in /etc/imapd.conf, bear in mind that client applications might conclude folders to have been removed and to have been added, as opposed to having been moved, resulting in a complete download of all folders and messages.
+When switching the alternative namespace configuration variable in
+:cyrusman:`imapd.conf(5)`, bear in mind that client applications might
+conclude folders to have been removed and to have been added, as opposed
+to having been moved, resulting in a complete download of all folders
+and messages.
 

--- a/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
+++ b/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
@@ -107,10 +107,14 @@ on certain Internet/UNIX sockets.
 
     ..
 
-        where *path* is the explicit path to a UNIX socket, *host* is
-        either the hostname or bracket-enclosed IP address of a network
-        interface, and *port* is either a port number or service name
-        (as listed in ``/etc/services``).
+    where *path* is the explicit path to a UNIX socket, *host* is
+    either the hostname or bracket-enclosed IP address of a network
+    interface, and *port* is either a port number or service name
+    (as listed in ``/etc/services``).
+
+    If *host* is missing, 0.0.0.0 (all interfaces) is assumed.  Use
+    localhost or 127.0.0.1 to restict access, i.e. when a proxy
+    on the same host is front-ending Cyrus.
 
 .. parsed-literal::
 


### PR DESCRIPTION
Added new content to upgrade.rst based upon actual experience
performing an upgrade (2.4.18 => 3.0.0rc1).

Add clarifying information to cyrus.conf manpage in regards
to missing 'host' declaration in listen portion of SERVICE commands.