### PR TITLE
Fixed cyr_info.rst to match actual command names

### DIFF
--- a/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
@@ -44,16 +44,21 @@ Options
 Commands
 ========
 
-*allconf*
-
-    Print ALL configuration options - including default options
-
 *conf*
 
     Print only the configuration options which are not the same as
-    default (regardless of whether you have specified them or not)
+    default (regardless of whether you have specified them or not).
 
-*lint*
+*conf-default*
+
+    Print all default configuration options, ignoring those set locally.
+
+*conf-all*
+
+    Print ALL configuration options - including default options.  This
+    command shows which options will be in effect at runtime.
+
+*conf-lint*
 
     Print only configuration options which are NOT recognised.  This
     command should not print anything.  It uses cyrus.conf to find

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -78,7 +78,7 @@ static void usage(void)
     fprintf(stderr, "\n");
     fprintf(stderr, "  * conf-all      - listing of all config values\n");
     fprintf(stderr, "  * conf          - listing of non-default config values\n");
-    fprintf(stderr, "  * conf-defaults - listing of all default config values\n");
+    fprintf(stderr, "  * conf-default  - listing of all default config values\n");
     fprintf(stderr, "  * conf-lint     - unknown config keys\n");
     fprintf(stderr, "  * proc          - listing of all open processes\n");
     cyrus_done();
@@ -252,11 +252,23 @@ static int known_overflowkey(const char *key)
             return 1;
     }
 
+    /* only valid if there's a partition with the same name */
+    if (!strncmp(key, "archivepartition-", 17)) {
+        if (config_getoverflowstring(key+8, NULL))
+            return 1;
+    }
+
+    /* no relation to partition- */
+    if (!strncmp(key, "backuppartition-", 16)) return 1;
+
     match = strstr(key, "searchpartition-");
     if (match) {
         if (config_getoverflowstring(match+6, NULL))
             return 1;
     }
+
+    /* legacy xlist-flag settings are OK */
+    if (!strncmp(key, "xlist-", 6)) return 1;
 
     return 0;
 }


### PR DESCRIPTION
The man page for cyr_info(8) listed commnd names which didn't match
the actual program.

Also, cyr_info.c had a typo for the "conf-default" command.