### PR TITLE
Cyr info2

### DIFF
--- a/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
@@ -13,7 +13,7 @@ Synopsis
 
 .. parsed-literal::
 
-    **cyr_info** [ **-C** *config-file* ] [ **-M** *config-file* ] [ **-n** *servicename* ] *command*
+    **cyr_info** [ **-C** *config-file* ] [ **-M** *config-file* ] [ **-n** *servicename* ] *command* [*mailbox*]
 
 Description
 ===========
@@ -21,6 +21,8 @@ Description
 **cyr_info** is a tool for getting information from Cyrus.  The intent
 is to extend this tool with useful commands to make managing and
 configuring Cyrus easier.
+
+If *command* is **reid**, the *mailbox* argument is required.
 
 **cyr_info** |default-conf-text|
 
@@ -68,6 +70,11 @@ Commands
 *proc*
 
     Print all currently connected processes in the proc directory
+
+*reid* *mailbox*
+
+    Create a new unique ID for mailbox *mailbox*.  The *mailbox*
+    argument is required.
 
 Examples
 ========

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -69,7 +69,7 @@ struct service_item {
 
 static void usage(void)
 {
-    fprintf(stderr, "cyr_info [-C <altconfig>] [-M <cyrus.conf>] [-n servicename] command\n");
+    fprintf(stderr, "cyr_info [-C <altconfig>] [-M <cyrus.conf>] [-n servicename] command [mailbox]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "If you give a service name, it will show config as if you were\n");
     fprintf(stderr, "running that service, i.e. imap\n");
@@ -81,6 +81,7 @@ static void usage(void)
     fprintf(stderr, "  * conf-default  - listing of all default config values\n");
     fprintf(stderr, "  * conf-lint     - unknown config keys\n");
     fprintf(stderr, "  * proc          - listing of all open processes\n");
+    frpintf(stderr, "  * reid [mbox]   - create new unique ID for mailbox [mbox]\n");
     cyrus_done();
     exit(-1);
 }


### PR DESCRIPTION
Add "reid" command information to cyr_info

The "reid" command for cyr_info program was not documented.  This
has been added both to cyr_info(8) man page and to the usage.