### PR TITLE
Docs. Upgrade and install docs update

### DIFF
--- a/docsrc/_static/cyrus.css
+++ b/docsrc/_static/cyrus.css
@@ -133,16 +133,16 @@ ol.arabic li {
 	line-height: 110%
 }
 
-p.caption {
+nav.wy-nav-side p.caption {
     font-style: italic;
 }
 
-.caption-text {
+nav.wy-nav-side p.caption-text {
     font-size: 60%
 }
 
 nav.wy-nav-side p.caption {
-    font-size: 150%
+    font-size: 100%
 }
 
 /* For bold-italic and italic inside other formatting styles */
@@ -175,7 +175,7 @@ nav.wy-nav-side p.caption {
 
 .pageheader li {
     float: left;
-    margin: 0 0 0 10px; 
+    margin: 0 0 0 10px;
 }
 
 .pageheader li a {
@@ -221,4 +221,12 @@ nav.wy-nav-side p.caption {
     width: 100%;
     height: 100%;
     background-color: #2d9dcb;
+}
+
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}
+
+h4 {
+    font-style: italic;
 }

--- a/docsrc/imap/developer/installguide.rst
+++ b/docsrc/imap/developer/installguide.rst
@@ -23,11 +23,12 @@ Setting up dependencies
 
 1. Install tools for building
     * ``sudo apt-get install build-essential autoconf automake libtool pkg-config bison flex valgrind``
-    
-2. Install dependencies for master branch
-    * ``sudo apt-get install libjansson-dev libxml2-dev libsqlite3-dev libical-dev libsasl2-dev libssl-dev libopendkim-dev libcunit1-dev libpcre3-dev uuid-dev``
 
-3. Additional dependencies for cyrus-imapd-2.5: you'll need the ``-dev`` package to match whichever version of libdb you already have installed (assuming it's probably already installed). On Debian 8.0, ``libdb5.3-dev`` is needed, but ``libdb5.1-dev`` on 7.8.
+2. Install dependencies for master branch
+    * ``sudo apt-get install libjansson-dev libxml2-dev libsqlite3-dev libical-dev libsasl2-dev \
+      libssl-dev libopendkim-dev libcunit1-dev libpcre3-dev uuid-dev``
+
+3. Additional dependencies for cyrus-imapd-3: you'll need the ``-dev`` package to match whichever version of libdb you already have installed (assuming it's probably already installed). On Debian 8.0, ``libdb5.3-dev`` is needed, but ``libdb5.1-dev`` on 7.8.
 
 4. Install dependencies for :ref:`building the docs <contribute-docs>`.
     * ``sudo pip install python-sphinx``
@@ -37,14 +38,14 @@ Setting up dependencies
 Compile Cyrus
 ---------------
 
-There are additional :ref:`compile and installation steps<imapinstall-xapian>` if you are using Xapian for searching.  
+There are additional :ref:`compile and installation steps<imapinstall-xapian>` if you are using Xapian for searching.
 
 .. code-block:: bash
 
     cd /path/to/cyrus-imapd
-    
+
     autoreconf -i -s   # generates a configure script, and its various dependencies
-    
+
     ./configure CFLAGS="-W -Wno-unused-parameter -g -O0 -Wall -Wextra -Werror -fPIC" \
     --enable-coverage --enable-calalarmd --enable-apple-push-service --enable-autocreate \
     --enable-nntp --enable-http --enable-unit-tests \
@@ -56,16 +57,22 @@ There are additional :ref:`compile and installation steps<imapinstall-xapian>` i
     make
 
     make check
-    
+
     make install  # optional if you're just developing on this machine
-    
+
     make install-binsymlinks    # Useful if you're testing older Cyrus versions
 
 The ``--prefix`` option sets where Cyrus is installed to. Adjust to suit.
 
 It may be of use to also add ``--std=gnu99`` to the ``CFLAGS``.  That generates TONS of warnings.
-    
-You may see warnings regarding libical v2.0 being recommended to support certain functionality. Currently libical v1.0.1 is sufficient, unless you need/want RSCALE (non-gregorian recurrences), VPOLL (consensus scheduling), or VAVAILABILITY (specifying availability over time) functionality. If v2 is required, it will need to be installed from `github <https://github.com/libical/libical>`_.  
+
+You may see warnings regarding libical v2.0 being recommended to support certain functionality. Currently libical v1.0.1 is sufficient, unless you need/want RSCALE (non-gregorian recurrences), VPOLL (consensus scheduling), or VAVAILABILITY (specifying availability over time) functionality. If v2 is required, it will need to be installed from `github <https://github.com/libical/libical>`_.
+
+If you're running on Debian, and you install to ``/usr/local``, you may need to update your library loader. Edit ``/etc/ld.so.conf.d/x86_64-linux-gnu.conf`` so it includes the following additional line::
+
+    /usr/local/lib/x86_64-linux-gnu
+
+Without this, when you attempt to start Cyrus, it reports ``error while loading shared libraries: libcyrus_imap.so.0: cannot open shared object file: No such file or directory`` because it can't find the Cyrus library in /usr/local/lib.
 
 Setting up syslog
 =================
@@ -76,13 +83,13 @@ A lot of Cyrus's debugging information gets logged with ``syslog``, so you'll wa
 2. Add lines like
 
     ``local6.*        /var/log/imapd.log``
-    
+
     ``auth.debug      /var/log/auth.log``
-    
+
 3. Restart the rsyslog service
 
     ``sudo /etc/init.d/rsyslog restart``
-    
+
 4. Arrange to rotate ``/var/log/imapd.log`` so it doesn't get stupendously large. Create ``/etc/logrotate.d/cyrus.conf`` with content like::
 
     /etc/logrotate.d/cyrus.conf
@@ -103,5 +110,5 @@ A lot of Cyrus's debugging information gets logged with ``syslog``, so you'll wa
 ----
 
 Ready to get a :ref:`basic server <basicserver>` up and running now you're all installed?
-    
+
 .. _FastMail : https://www.fastmail.com

--- a/docsrc/imap/download/installation.rst
+++ b/docsrc/imap/download/installation.rst
@@ -7,10 +7,14 @@ IMAP Installation Guide
 Cyrus IMAP packages are shipped with every major distribution, including
 but not limited to Fedora, Red Hat Enterprise Linux, CentOS, Scientific
 Linux, Debian, Ubuntu, openSUSE, Gentoo, Mageia and ClearOS. They are not
-guaranteed to be up to date!
+guaranteed to be up to date.
 
 Upgrading
 ==========
+
+Instructions are provided for upgrading using Cyrus tarball packages or from git.
+If you'd like to upgrade using platform packages, check with your package provider
+for upgrade instructions.
 
 .. toctree::
     upgrade

--- a/docsrc/imap/download/installation/distributions/debian.rst
+++ b/docsrc/imap/download/installation/distributions/debian.rst
@@ -20,7 +20,7 @@ system, issue the following command:
 
     # :command:`apt-get install cyrus-imapd cyrus-sasl cyrus-sasl-plain`
 
-If you want xapian, you'll need to build all of Cyrus yourself. See developer guide here. TODO.
+If you want xapian, you'll need to :ref:`build all of Cyrus yourself <imapinstallguide>`.
 
 Next, set a password for the default administrative user ``cyrus``:
 

--- a/docsrc/imap/download/installation/diy.rst
+++ b/docsrc/imap/download/installation/diy.rst
@@ -11,8 +11,18 @@ Unless you specifically need unreleased patches, the tarball package is
 recommended as it comes with a number of resources pre-built for you,
 such as the documentation.
 
+----
+
+.. contents::
+    :local:
+
+----
+
+1. Fetch the source
+===================
+
 From Tarball
-============
+------------
 
 Download the `latest stable tarball`_ : version |imap_current_stable_version|.
 
@@ -27,7 +37,7 @@ Extract the tarball:
 Continue with :ref:`imap-installation-diy-build-dependencies`.
 
 From GIT
-========
+--------
 
 Read our :ref:`Guide to GitHub <github-guide>` for details on how to
 access our GitHub repository, and fork/clone the source.
@@ -36,293 +46,219 @@ Continue with :ref:`imap-installation-diy-build-dependencies`.
 
 .. _imap-installation-diy-build-dependencies:
 
-Build Dependencies
-==================
-
-If you run an operating system or Linux distribution that already
-includes packages for Cyrus IMAP, then the build dependencies for
-Cyrus IMAP are specified in the packaging specification for that
-package.
-
-To install build dependencies on a Fedora, Red Hat Enterprise Linux or
-CentOS system for example, you can run the following commands:
-
-.. parsed-literal::
-
-    # :command:`yum install yum-utils`
-    # :command:`yum-builddep cyrus-imapd`
-
-Consult the upstream documentation of your platform for further
-information on the availability of such commands and their usage.
+2. Build Dependencies
+=====================
 
 Required Build Dependencies
 ---------------------------
 
-The following list includes the names of packages used in RPM-based
-distributions:
+Building a basic Cyrus that can send and receive email: the minimum libraries required to build a functional Cyrus.
 
-**autoconf** 2.63 or higher
+.. csv-table:: Build Dependencies
+    :header: "Package", "Debian", "RedHat"
 
-    from http://www.gnu.org/software/autoconf/
+    `autoconf`_, "autoconf", "autoconf"
+    `automake`_, "automake", "automake"
+    `bison`_, "bison", "bison"
+    `Cyrus SASL`_, "libsasl2-dev", "cyrus-sasl-devel"
+    `flex`_, flex, flex
+    `gcc`_, gcc, gcc
+    `gperf`_, gperf, gperf
+    `jansson`_, libjansson-dev, jansson-devel
+    `libtool`_, libtool, libtool
+    `ICU`_, libicu-dev, libicu
+    `uuid`_, uuid-dev, libuuid-devel
+    `openssl`_, libssl-dev, openssl-devel
+    `pkgconfig`_, pkg-config, pkgconfig
+    `sqlite`_, libsqlite3-dev, sqlite-devel
 
-**automake**
-
-    from http://www.gnu.org/software/automake/
-
-**bison**
-
-    from http://www.gnu.org/software/bison/
-
-**cyrus-sasl-devel**
-
-    from http://asg.web.cmu.edu/sasl/sasl-library.html
-
-**flex**
-
-    from http://flex.sourceforge.net/
-
-**gcc** version 4.9 or higher
-
-    from http://gcc.gnu.org
-
-**gperf**
-
-    from http://www.gnu.org/software/gperf/
-
-**jansson-devel** version 2.3 or higher
-
-    from http://www.digip.org/jansson/.
-
-**libtool** version 2.2.6 or higher
-
-    from http://www.gnu.org/software/libtool/
-
-**libuuid-devel**
-
-    from https://www.kernel.org/pub/linux/utils/util-linux/
-
-**openssl-devel** (see :task:`29`) version 0.9.4 or higher
-
-    from http://www.openssl.org/
-
-**pkgconfig**
-
-    from http://pkgconfig.freedesktop.org
+.. _autoconf: http://www.gnu.org/software/autoconf/
+.. _automake: http://www.gnu.org/software/automake/
+.. _bison: http://www.gnu.org/software/bison/
+.. _Cyrus SASL: :ref:`Cyrus SASL <cyrussasl:sasl-index>`
+.. _flex: http://flex.sourceforge.net/
+.. _gcc: http://gcc.gnu.org
+.. _gperf: http://www.gnu.org/software/gperf/
+.. _jansson: http://www.digip.org/jansson/
+.. _libtool: http://www.gnu.org/software/libtool/
+.. _ICU: http://www.icu-project.org/
+.. _uuid: https://www.kernel.org/pub/linux/utils/util-linux/
+.. _openssl: http://www.openssl.org/
+.. _pkgconfig: http://pkgconfig.freedesktop.org
+.. _sqlite: https://www.sqlite.org/
 
 Optional Build Dependencies
 ---------------------------
 
 The following build dependencies are optional, and enable functionality,
-Cyrus IMAP code maintenance tasks or documentation rendering.
+code maintenance tasks or building the documentation.
 
-**CUnit-devel**
+Developers only
+###############
 
-    Development headers for compiling Cyrus IMAP's unit tests, from
-    http://cunit.sourceforge.net/.
+.. csv-table::
+    :header: "Package", "Debian", "RedHat",  "Required for ``make check``?", "Notes"
+    :widths: 20,15,15,5,45
 
-    Used for ``make check``.
+    `CUnit`_, libcunit1-dev, cunit-devel, "yes", "Development headers for compiling Cyrus IMAP's unit tests."
+    `perl(ExtUtils::MakeMaker)`_, ??, ??, "no", "Perl library to assist in building extensions to Perl.
 
-**cyrus-sasl-plain** version 2.1.7 or higher
+    Configure option: ``--with-perl``"
+    `perl-devel`_, perl-dev, perl-devel, "no", "Perl development headers to allow building binary perl libraries. Needs version 5+.
 
-    Cyrus SASL package that ships the library required to pass Cyrus
-    IMAP's PLAIN authentication unit tests, from
-    http://asg.web.cmu.edu/sasl/sasl-library.html
+    Configure option: ``--with-perl``"
+    `valgrind`_, valgrind, valgrind, "no", "Performance and memory testing."
 
-    Used with ``make check``.
+SASL Authentication
+###################
 
-**cyrus-sasl-md5** version 2.1.7 or higher
+.. csv-table::
+    :header: "Package", "Debian", "RedHat",  "Required for ``make check``?", "Notes"
+    :widths: 20,15,15,5,45
 
-    Cyrus SASL library required to pass Cyrus IMAP's DIGEST-MD5
-    authentication unit tests, from
-    http://asg.web.cmu.edu/sasl/sasl-library.html
+    `Cyrus SASL Plain`_, libsasl2-modules, cyrus-sasl-plain,  "yes", "Cyrus SASL package that ships the \
+    library required to pass Cyrus IMAP's PLAIN authentication unit tests."
+    `Cyrus SASL MD5`_, libsasl2-modules, cyrus-sasl-md5, "yes", "Cyrus SASL library required to pass Cyrus IMAP's DIGEST-MD5
+    authentication unit tests"
+    `sasl binaries`_, sasl2-bin, sasl2-bin, "no", "Administration tools for managing SASL"
+    `Kerberos`_, libsasl2-modules-gssapi-mit, krb5-devel, "no", "Development headers required to enable Kerberos v5 authentication
+    capabilities. Otherwise also known as the authentication mechanism *GSSAPI*.
 
-    Used with ``make check``.
+    Configure option: ``--with-krbimpl=mit`` "
 
-**db4-devel** or **libdb-devel** version 3.0.55 or higher
+Alternate database formats
+##########################
 
-    .. NOTE::
+.. csv-table::
+    :header: "Package", "Debian", "RedHat",  "Required for ``make check``?", "Notes"
+    :widths: 20,15,15,5,45
 
-        Berkeley DB support has been dropped in versions of Cyrus IMAP
-        equal to or higher than Cyrus IMAP 3.0.
-
-    Berkely DB backend for Cyrus IMAP databases, from
-    https://www.oracle.com/database/berkeley-db/index.html.
-
-    .. NOTE::
-
-        The use of Berkely DB for Cyrus IMAP databases is discouraged,
-        and is likely to be obsoleted.
-
-**lmdb** version 0.9.14 or higher
-
-    Lightning Memory-Mapped Database Manager (LMDB) backend for Cyrus IMAP
-    databases, from http://lmdb.tech/.
-
-    LMDB requires database environments to be set to a (user-configurable)
+    `lmdb`_, lmdb-dev, lmdb, "no", "Lightning Memory-Mapped Database Manager (LMDB) backend for Cyrus IMAP
+    databases.     LMDB requires database environments to be set to a (user-configurable)
     maximum size. The Cyrus backend uses 512MB as default size. Cyrus
     installations may override this by setting the environment variable
     CYRUSDB_LMDB_MAXSIZE. The value of this variable must be an integer,
-    optionally followed (without space) by "mb" or "gb" to define the
+    optionally followed (without space) by 'mb' or 'gb' to define the
     maximum size in bytes, megabytes or gigabytes. The size should be a
-    multiple of the OS page size.
+    multiple of the OS page size. "
+    `mysql`_ or `mariadb`_, libmysqlclient-dev or libmariadb-dev, mysql-devel or mariadb-devel, "no", "MariaDB or MySQL development headers, to allow Cyrus IMAP to use
+    it as the backend for its databases.
 
-    .. NOTE::
+    Configure option: ``--with-mysql``, ``--with-mysql-incdir``, ``--with-mysql-libdir``"
+    `postgresql`_, postgresql-dev, postgresql-devel, "no"
 
-        The use of LMDB for Cyrus IMAP databases is experimental.
+CalDAV and/or CardDAV
+#####################
 
-**db4-utils** or **libdb-utils** version 3.0.55 or higher
+.. csv-table::
+    :header: "Package", "Debian", "RedHat",  "Required for ``make check``?", "Notes"
+    :widths: 20,15,15,5,45
 
-    .. NOTE::
+    `libical`_, libical-dev, libical-devel, "no", "libical >= 0.48 required for scheduling support.
+    **Note:** Linux distributions Enterprise Linux 6 and Debian Squeeze are
+    known to ship outdated **libical** packages versions 0.43 and
+    0.44 respectively. The platforms will not support scheduling."
+    `libxml`_, libxml2-dev, libxml2-devel, "", "no"
 
-        Berkeley DB support has been dropped in versions of Cyrus IMAP
-        equal to or higher than Cyrus IMAP 3.0.
+Other
+#####
 
-    Utilities for Berkeley DB databases, from
-    https://www.oracle.com/database/berkeley-db/index.html, needed to pass unit
-    tests.
+.. csv-table::
+    :header: "Package", "Debian", "RedHat",  "Required for ``make check``?", "Notes"
+    :widths: 20,15,15,5,45
 
-    Used with ``make check``.
-
-**groff**
-
-    from http://www.gnu.org/software/groff/
-
-**krb5-devel**
-
-    Development headers required to enable Kerberos v5 authentication
-    capabilities for Cyrus IMAP, from http://web.mit.edu/kerberos/www/.
-
-    Otherwise also known as the authentication mechanism *GSSAPI*.
-
-    Configure option: ``--with-krbimpl=mit``
-
-**libical-devel**
-
-    .. IMPORTANT::
-
-        **libical >= 0.48** is required for scheduling support.
-
-    from http://freeassociation.sourceforge.net/
-
-    .. NOTE::
-
-        Linux distributions Enterprise Linux 6 and Debian Squeeze are
-        known to ship outdated **libical** packages versions 0.43 and
-        0.44 respectively. The platforms will not support scheduling.
-
-**libxml2-devel**
-
-    from http://xmlsoft.org/
-
-**mariadb-devel** or **mysql-devel**
-
-    MariaDB or MySQL development headers, to allow Cyrus IMAP to use
-    either as the backend for its databases.
-
-    **mariadb-devel** from http://mariadb.org
-
-    **mysql-devel** from http://www.mysql.com
-
-    Configure option: ``--with-mysql``
-
-    .. versionadded:: 2.5.0
-
-    Configure options: ``--with-mysql-incdir``, ``--with-mysql-libdir``
-
-    *Prior to version 2.5*.
-
-**net-snmp-devel** version 4.2 or higher
-
-    from http://net-snmp.sourceforge.net/
-
-**openldap-devel**
-
-    Development headers to enable **ptloader** to interface with LDAP
+    `net-snmp`_, libsnmp-dev, net-snmp-devel, "no", "version 4.2 or higher"
+    `openldap`_, libldap2-dev, openldap-devel, "no", "Development headers to enable **ptloader** to interface with LDAP
     directly, for canonification of login usernames to mailbox names,
     and verification of login usernames, ACL subjects and group
-    membership, from http://www.openldap.org/.
+    membership.
 
-    Configure option: ``--with-ldap``
+    Configure option: ``--with-ldap``"
+    `tcp_wrappers`_, tcp_wrappers, xx, "no"
+    `transfig`_, transfig, xx, "no"
 
-**perl(ExtUtils::MakeMaker)**
-
-    Perl library to assist in building extensions to Perl, from http://search.cpan.org/dist/ExtUtils-MakeMaker/.
-
-    Configure option: ``--with-perl``
-
-**perl-devel** version 5 or higher
-
-    Perl development headers to allow building binary perl libraries,
-    from http://www.perl.org/.
-
-    Configure option: ``--with-perl``
-
-**postgresql-devel**
-
-    from http://www.postgresql.org/
-
-**sqlite-devel**
-
-    from http://www.sqlite.org/
-
-**tcp_wrappers**
-
-    from ftp://ftp.porcupine.org/pub/security/index.html
-
-**transfig**
-
-    from http://www.xfig.org/
-
-**valgrind**
-
-    from http://www.valgrind.org/
+.. _CUnit: http://cunit.sourceforge.net/
+.. _Cyrus SASL Plain: :ref:`Cyrus SASL <cyrussasl:sasl-index>`
+.. _Cyrus SASL MD5: :ref:`Cyrus SASL <cyrussasl:sasl-index`
+.. _sasl binaries: :ref:`Cyrus SASL <cyrussasl:sasl-index`
+.. _lmdb: http://lmdb.tech/
+.. _Kerberos: http://web.mit.edu/kerberos/www/
+.. _libical: http://freeassociation.sourceforge.net/
+.. _libxml: http://xmlsoft.org/
+.. _mysql: http://www.mysql.com
+.. _mariadb: http://mariadb.org
+.. _net-snmp:  http://net-snmp.sourceforge.net/
+.. _openldap: http://www.openldap.org/
+.. _perl(ExtUtils::MakeMaker): http://search.cpan.org/dist/ExtUtils-MakeMaker/
+.. _perl-devel: http://www.perl.org/
+.. _postgresql: http://www.postgresql.org/
+.. _tcp_wrappers: ftp://ftp.porcupine.org/pub/security/index.html
+.. _transfig: http://www.xfig.org/
+.. _valgrind: http://www.valgrind.org/
 
 Continue with :ref:`imap-installation-diy-configure`
 
 .. _imap-installation-diy-configure:
 
-Configure the Build
-===================
+3. Configure the Build
+======================
+
+Default build: mail only
+------------------------
 
 .. parsed-literal::
 
     $ :command:`autoreconf -i`
     $ :command:`./configure` [options]
 
-Check the summary after ``./configure`` completes successfully. The
-following segment shows the defaults in version 2.5.0, ran on a system
-with all mandatory and optional build dependencies installed, so yours
-may (read: will) differ:
+Check the summary after ``./configure`` completes to ensure it
+matches your expectations.
 
-.. parsed-literal::
-
-    Cyrus Imapd configured components
-
-        event notification: yes
-        gssapi:             yes
-        autocreate:         no
-        idled:              no
-        http:               no
-        kerberos V4:        no
-        murder:             no
-        nntpd:              no
-        replication:        no
-        sieve:              yes
-
-    External dependencies:
-        ldap:               no
-        openssl:            yes
-        pcre:               yes
-
-    Database support:
-        bdb:                yes
-        mysql:              no
-        postgresql:         no
-        sqlite:             no
-
-To view additional options, and disable or enable specific features,
+To view all options, and disable or enable specific features,
 please see:
 
 .. parsed-literal::
 
     # :command:`./configure --help`
+
+Optional dependencies
+---------------------
+
+Some features are disabled by default and must be explicitly enable-idled
+via configure.
+
+Sieve is enabled by default.
+
+CalDAV and CardDAV
+##################
+
+    ``./configure --with-httpd --with-calalarmd``
+
+Murder
+######
+
+    ```./configure --enable-murder``
+
+Replication
+###########
+
+    ```./configure --enable-replication``
+
+4. Compile and install
+======================
+
+.. code-block:: bash
+
+    cd /path/to/cyrus-imapd
+
+    autoreconf -i
+    ./configure [options]
+
+    make
+
+    make check
+
+    make install  # optional if you're just developing on this machine
+
+If this is the first time you've installed Cyrus, read our :ref:`Basic Server Configuration guide <basicserver>`.
+It walks through the steps of configuring the server and sending a sample piece of test mail.

--- a/docsrc/imap/download/upgrade.rst
+++ b/docsrc/imap/download/upgrade.rst
@@ -9,6 +9,9 @@ Upgrading to 3.0
     This guide assumes that you are familiar and comfortable with administration of a
     Cyrus installation, and system administration in general.
 
+    It assumes you are intalling from source or tarball. If you want to install from package,
+    use the upgrade instructions from the package provider.
+
 ..  contents:: Upgrading: an overview
     :local:
 
@@ -20,7 +23,7 @@ Things to consider **before** you begin:
 Installation from tarball
 #########################
 
-It takes some time before platform packages are up to date. It is likely you will need to install from our packaged tarball, at least initially. We provide a full list of libraries that Debian requires, but we aren't able to test all platforms: you may find you need to install additional or different libraries to support v3.0.
+You will need to install from our packaged tarball. We provide a full list of libraries that Debian requires, but we aren't able to test all platforms: you may find you need to install additional or different libraries to support v3.0.
 
 How are you planning on upgrading?
 ##################################
@@ -32,8 +35,8 @@ installation to replicate data to a new 3.0 installation and failover to the new
 ready. The replication protocol has been kept backwards compatible.
 
 If you are upgrading in place, you will need to shut down Cyrus entirely while you install the new package.  If your
-old installation was using berkeley DB format databases, you will need to convert or upgrade the databases **before**
-you upgrade.  Cyrus v3.0 does not support berkeley at all.
+old installation was using Berkeley DB format databases, you will need to convert or upgrade the databases **before**
+you upgrade.  Cyrus v3.0 does not support Berkeley DB at all.
 
 We strongly recommend that you read this entire document before upgrading.
 
@@ -42,7 +45,7 @@ We strongly recommend that you read this entire document before upgrading.
 
 Download the release :ref:`3.0 package tarball<install-diy>`.
 
-Fetch the libraries for your platform. The list for Debian is::
+Fetch the libraries for your platform. The full list (including all optional packages) for Debian is::
 
     sudo apt-get install -y autoconf automake autotools-dev bash-completion bison build-essential comerr-dev \
     debhelper flex g++ git gperf groff heimdal-dev libbsd-resource-perl libclone-perl libconfig-inifiles-perl \


### PR DESCRIPTION
Aim: 1) get the basic install guide(s) to the point where even a newbie admin could install Cyrus and get to the point where someone can send a test email.

2) Update the upgrade guide now that typical upgrade paths are better understood.

NOT DONE: finish off CalDAV/CardDAV config/install/test instructions. (In my testing, my curl based queries were still failing with a 404 mailbox not found, and my imap client also couldn't see the mailbox)... ACLs?