### PR TITLE
Docedit cyr virusscan

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1500,6 +1500,7 @@ dist_man8_MANS = \
 	man/cyr_expire.8 \
 	man/cyr_info.8 \
 	man/cyr_synclog.8 \
+	man/cyr_virusscan.8 \
 	man/deliver.8 \
 	man/fud.8 \
 	man/idled.8 \

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -439,6 +439,17 @@ man_pages = [
     ),
 
         (
+            'imap/reference/manpages/systemcommands/cyr_virusscan',
+            'cyr_virusscan',
+            u'Cyrus IMAP Documentation',
+            [
+                    u'The Cyrus Team',
+                    u'Nic Bernstein (Onlight)'
+                ],
+            8
+    ),
+
+        (
             'imap/reference/manpages/systemcommands/cyradm',
             'cyradm',
             u'Cyrus IMAP Documentation',

--- a/docsrc/imap/reference/administration-tools.rst
+++ b/docsrc/imap/reference/administration-tools.rst
@@ -40,6 +40,12 @@ cyrdump
 cyr_expire
 ++++++++++
 
+cyr_virusscan
++++++++++++++
+
+Tool to disinfect mailboxes by operation of external virus scanning
+library or provided IMAP SEARCH string.
+
 fetchnews
 +++++++++
 
@@ -89,4 +95,3 @@ upgradesieve
 ++++++++++++
 
 absolutely ancient (upgrade from 1.6.13), probably should be obsoleted entirely 
-

--- a/docsrc/imap/reference/manpages/commands.rst
+++ b/docsrc/imap/reference/manpages/commands.rst
@@ -38,6 +38,7 @@ Man pages
     systemcommands/cyr_info
     systemcommands/cyr_sequence    
     systemcommands/cyr_synclog
+    systemcommands/cyr_virusscan
     systemcommands/cyradm
     systemcommands/cyrdump
     systemcommands/deliver

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
@@ -70,7 +70,94 @@ Options
 Examples
 ========
 
-Examples needed.
+.. parsed-literal::
+
+    **cyr_virusscan**
+
+..
+
+        Scan all mailboxes, printing report on the screen.  Do not
+        remove infected messages.
+
+.. only:: html
+
+    ::
+
+        Using ClamAV virus scanner
+        Loaded 5789330 virus signatures.
+
+        Mailbox Name                            	   Msg UID	Status	Virus Name
+        ----------------------------------------	----------	------	--------------------------------------------------
+        user.betty                              	    185395	  READ	Heuristics.Phishing.Email.SpoofedDomain
+
+        Mailbox Name                            	   Msg UID	Status	Virus Name
+        ----------------------------------------	----------	------	--------------------------------------------------
+        user.betty.Bank stuff                   	         9	  READ	Html.Phishing.Bank-1172
+        user.betty.Bank stuff                   	        10	  READ	Html.Phishing.Bank-1172
+        user.betty.Bank stuff                   	        11	  READ	Html.Phishing.Bank-1172
+
+        Mailbox Name                            	   Msg UID	Status	Virus Name
+        ----------------------------------------	----------	------	--------------------------------------------------
+        user.bovik                                	     17426	  READ	Email.Trojan.Trojan-1051
+
+.. parsed-literal::
+
+    **cyr_virusscan** -r -n user/bovik
+
+..
+
+        Scan mailbox *user/bovik*, removing infected messages and append
+        notifications to bovik's inbox.
+
+.. only:: html
+
+    ::
+
+        Mailbox Name                            	   Msg UID	Status	Virus Name
+        ----------------------------------------	----------	------	--------------------------------------------------
+        user.bovik                                	   17426	  READ	Email.Trojan.Trojan-1051
+
+.. only:: html
+
+        A message like this would end up in bovik's inbox:
+
+    ::
+
+        The following message was deleted from mailbox 'Inbox.bovik'
+        because it was infected with virus 'Email.Trojan.Trojan-1051'
+
+            Message-ID: <201308131519.r7DFJM9K083763@tselina.kiev.ua>
+            Date: Tue, 13 Aug 2013 18:19:22 +0300 (EEST)
+            From: ("FEDEX Thomas Cooper" NIL "thomas_cooper94" "themovieposterpage.com")
+            Subject: Problem with the delivery of parcel
+            IMAP UID: 17426
+
+..
+
+.. parsed-literal::
+
+        **cyr_virusscan** -r -n -s 'SUBJECT "Fedex"' user/bovik
+
+..
+
+        Search mailbox user/bovik for messages which have Fedex in the
+        subject line, removing them all, and appending notifications to
+        Bovik's inbox.
+        
+.. only:: html
+
+    ::
+
+        Mailbox Name                            	   Msg UID	Status	Virus Name
+        ----------------------------------------	----------	------	--------------------------------------------------
+        user.bovik                                	   17185	  READ	Cyrus Administrator Targeted Removal (Phish, etc.)
+        user.bovik                                	   17203	  READ	Cyrus Administrator Targeted Removal (Phish, etc.)
+        user.bovik                                	   17338	  READ	Cyrus Administrator Targeted Removal (Phish, etc.)
+        user.bovik                                	   17373	  READ	Cyrus Administrator Targeted Removal (Phish, etc.)
+        user.bovik                                	   19238	  READ	Cyrus Administrator Targeted Removal (Phish, etc.)
+        user.bovik                                	   19268	  READ	Cyrus Administrator Targeted Removal (Phish, etc.)
+
+..
 
 History
 =======

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
@@ -1,0 +1,88 @@
+.. cyrusman:: cyr_virusscan(8)
+
+.. _imap-reference-manpages-systemcommands-cyr_virusscan:
+
+=================
+**cyr_virusscan**
+=================
+
+Scan mailbox(es) or messages for viruses using configured virus scanner
+or provided search criteria.
+
+Synopsis
+========
+
+.. parsed-literal::
+
+    **cyr_virusscan** [ **-C** *config-file* ] [ **-s** *imap-search-string* ] [ **-r** [ **-n**] ] [ *mboxpattern1* ... ]
+
+Description
+===========
+
+**cyr_virusscan** is used to scan the specified IMAP mailbox(es) with
+the configured virus scanner (currently only ClamAV is supported).  If
+no mboxpattern is given, **cyr_virusscan** works on all mailboxes.
+
+Alternately, with the **-s** option, rather than **scanning** mailboxes
+for virus, the IMAP SEARCH string will be used as a specification of
+messages which are *assumed* to be infected, and will be treated as such.
+Useful for removing messages without a distinct signature, such as
+Phish.
+
+A table of infected messages will be output.  However, with the remove
+flag, **-r**, infected messages will be removed.
+
+With the notify flag, **-n**, notifications with message digest
+information will be appended to the inbox of the mailbox owner.  This
+flag is only operable in combination with **-r**.
+
+**cyr_virusscan** is may be configured to run periodically by cron(8)
+via crontab(5) or your preferred method (i.e. /etc/cron.hourly), or by
+:cyrusman:`master(8)` via the EVENTS{} stanza in
+:cyrusman:`cyrus.conf(5)`.
+    
+**cyr_virusscan** |default-conf-text|
+
+Options
+=======
+
+.. program:: cyr_virusscan
+
+.. option:: -C config-file
+
+    |cli-dash-c-text|
+
+   
+.. option:: -n
+
+    Notify mailbox owner of deleted messages via email.  This flag is
+    only operable in combination with **-r**.
+
+.. option:: -r
+
+    Remove infected messages.
+    
+.. option:: -s imap-search-string
+
+    Rather than scanning for viruses, messages matching the search
+    criteria will be treated as infected.
+
+Examples
+========
+
+Examples needed.
+
+History
+=======
+
+Virus scan support was first introduced in Cyrus version 3.0.
+
+Files
+=====
+
+/etc/imapd.conf
+
+See Also
+========
+
+:cyrusman:`imapd.conf(5)`, :cyrusman:`master(8)`


### PR DESCRIPTION
Address lack of man page for cyr_virusscan, as identified by @hagedose in #1837 