### PR TITLE
Move the REID operation from cyr_info to mbtool

### DIFF
--- a/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
@@ -18,7 +18,6 @@ Synopsis
     **cyr_info** [OPTIONS] conf-all
     **cyr_info** [OPTIONS] conf-lint
     **cyr_info** [OPTIONS] proc
-    **cyr_info** [OPTIONS] reid *mailbox*
 
 Description
 ===========
@@ -55,16 +54,6 @@ configuring Cyrus easier.
 .. option:: proc
 
     Print all currently connected processes in the proc directory
-
-.. option:: reid
-
-    .. parsed-literal::
-
-        **cyr_info** [OPTIONS] reid *mailbox*
-
-    Create a new unique ID for mailbox *mailbox*.  The *mailbox*
-    argument is required.
-
 
 Options
 =======

--- a/docsrc/imap/reference/manpages/systemcommands/mbtool.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/mbtool.rst
@@ -13,15 +13,19 @@ Synopsis
 
 .. parsed-literal::
 
-    **mbtool** [ **-C** *config-file* ] **-t** *mailboxes*...
+    **mbtool** [ **-C** *config-file* ] **-r** *mailbox*...
+    **mbtool** [ **-C** *config-file* ] **-t** *mailbox*...
 
 Description
 ===========
 
 **mbtool** is a tool for performing various actions on the indexes of a
-list of mailboxes. The only action currently supported is **-t**, which
-will normalize the ``internaldate`` time stamp of each record in the
-index to GMT.
+list of mailboxes. The only actions currently supported are **-t**,
+which will normalize the ``internaldate`` time stamp of each record in
+the index to GMT, and **-r** which will create a new unique ID for each
+mailbox.
+
+Only one action may be given and at least mailbox must be listed.
 
 It is intended that **mbtool** will be extended over time to perform
 more such actions.
@@ -44,8 +48,20 @@ Options
     than a day, which can be used to fix up a mailbox which has been
     restored from backup and lost its internaldate information.
 
+.. option:: -r
+
+    Create a new unique ID for all listed *mailbox*\ es.
+
 Examples
 ========
+
+.. parsed-literal::
+
+    **mbtool -r** user.jsmith
+
+..
+
+        Create new UUID for mailbox *user.jsmith*.
 
 .. parsed-literal::
 
@@ -64,6 +80,9 @@ Examples
         00000001: Tue, 08 Jul 2014 16:45:18 -0500 => Mon, 07 Jul 2014 20:44:18 +0000
         00000002: Tue Jul 08 16:45:13 CDT 2013 => Fri, 30 Aug 2013 19:46:03 +0000
         <...>
+
+..
+
 
 Files
 =====

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -69,7 +69,7 @@ struct service_item {
 
 static void usage(void)
 {
-    fprintf(stderr, "cyr_info [-C <altconfig>] [-M <cyrus.conf>] [-n servicename] command [mailbox]\n");
+    fprintf(stderr, "cyr_info [-C <altconfig>] [-M <cyrus.conf>] [-n servicename] command\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "If you give a service name, it will show config as if you were\n");
     fprintf(stderr, "running that service, i.e. imap\n");
@@ -81,7 +81,6 @@ static void usage(void)
     fprintf(stderr, "  * conf-default  - listing of all default config values\n");
     fprintf(stderr, "  * conf-lint     - unknown config keys\n");
     fprintf(stderr, "  * proc          - listing of all open processes\n");
-    fprintf(stderr, "  * reid [mbox]   - create new unique ID for mailbox [mbox]\n");
     cyrus_done();
     exit(-1);
 }
@@ -347,42 +346,6 @@ static void do_lint(void)
     }
 }
 
-static void do_reid(const char *mboxname)
-{
-    struct mailbox *mailbox = NULL;
-    mbentry_t *mbentry = NULL;
-    int r;
-
-    annotate_init(NULL, NULL);
-    annotatemore_open();
-
-    mboxlist_init(0);
-    mboxlist_open(NULL);
-
-    r = mailbox_open_iwl(mboxname, &mailbox);
-    if (r) return;
-
-    mailbox_make_uniqueid(mailbox);
-
-    r = mboxlist_lookup(mboxname, &mbentry, NULL);
-    if (r) return;
-
-    free(mbentry->uniqueid);
-    mbentry->uniqueid = xstrdup(mailbox->uniqueid);
-
-    mboxlist_update(mbentry, 0);
-
-    mailbox_close(&mailbox);
-
-    mboxlist_close();
-    mboxlist_done();
-
-    annotatemore_close();
-    annotate_done();
-
-    printf("did reid %s\n", mboxname);
-}
-
 int main(int argc, char *argv[])
 {
     extern char *optarg;
@@ -429,11 +392,6 @@ int main(int argc, char *argv[])
         do_defconf();
     else if (!strcmp(argv[optind], "conf-lint"))
         do_lint();
-    else if (!strcmp(argv[optind], "reid")) {
-        if (optind + 1 >= argc)
-            usage();
-        do_reid(argv[optind+1]);
-    }
     else
         usage();
 


### PR DESCRIPTION
It's always struck me as odd that re-IDing a mailbox is a job for
cyr_info, rather than for mbtool.  From their respective man pages:

- **cyr_info** is a tool for getting information from Cyrus.
- **mbtool** is a tool for performing various actions on the indexes of a list of mailboxes.

Wouldn't the "reid" action then fall under the purview of mbtool?  Granted it's not an "index" operation, however, but that's just semantics.

It looked to me as though it should be pretty easy to move it, so I've tried just that.  Man pages are updated, too.

**Note:** I am by no means a C programmer, so please treat as a proof of concept, not final goods.  However, I have tested it and it does work as expected.