### PR TITLE
Build new pages for port & socket info.

### DIFF
--- a/docsrc/imap/reference/admin.rst
+++ b/docsrc/imap/reference/admin.rst
@@ -19,16 +19,17 @@ Management
     :maxdepth: 2
 
     admin/locations
-    admin/murder/murder
+    admin/ports-sockets
     admin/access-control
-    admin/nntp
-    admin/protlayer
     admin/quotas
     admin/sieve
     admin/backups
+    admin/nntp
+    admin/protlayer
     admin/sop
     admin/eventsource    
     admin/config-mailboxdistribution
+    admin/murder/murder
     admin/nginx-proxy
     admin/tweaking
 

--- a/docsrc/imap/reference/admin/ports-sockets.rst
+++ b/docsrc/imap/reference/admin/ports-sockets.rst
@@ -1,0 +1,19 @@
+.. _imap-admin-ports-sockets:
+
+=================
+Ports and Sockets
+=================
+
+Cyrus IMAP uses TCP/IP and Unix domain sockets to achieve much of the
+requisite communications both with other applications, such as your MTA,
+and with other components.
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    ports/*
+
+.. _imap-admin-ports-sockets-end:
+
+Back to :ref:`imap-admin`

--- a/docsrc/imap/reference/admin/ports/services.rst
+++ b/docsrc/imap/reference/admin/ports/services.rst
@@ -1,0 +1,39 @@
+.. _imap-admin-ports-services:
+
+Cyrus Service Definitions
+=========================
+
+.. _imap-admin-ports-servent:
+
+The Cyrus IMAP server provides service interfaces via either TCP/IP
+ports or Unix domain sockets.  For the former, Cyrus requires that there
+are proper entries in the host's ``/etc/services`` file.  The following
+are required for any host using the listed services:
+
+::
+
+    pop3      110/tcp  # Post Office Protocol v3
+    nntp      119/tcp  # Network News Transport Protocol
+    imap      143/tcp  # Internet Mail Access Protocol rev4
+    imsp      406/tcp  # Internet Message Support Protocol (deprecated)
+    nntps     563/tcp  # NNTP over TLS
+    imaps     993/tcp  # IMAP over TLS
+    pop3s     995/tcp  # POP3 over TLS
+    kpop      1109/tcp # Kerberized Post Office Protocol
+    lmtp      2003/tcp # Lightweight Mail Transport Protocol service
+    smmap     2004/tcp # Cyrus smmapd (quota check) service
+    csync     2005/tcp # Cyrus replication service
+    mupdate   3905/tcp # Cyrus mupdate service
+    sieve     4190/tcp # timsieved Sieve Mail Filtering Language service
+
+Make sure that these lines are present and add them if they are missing.
+
+.. _imap-admin-ports-servent-end:
+
+Controlling Service Ports and Sockets
+-------------------------------------
+
+The actual port or socket used by any given service may be controlled
+in the service definition line for that service in the
+:cyrusman:`cyrus.conf(5)` file, using the ``listen=`` directive.  Please
+consult the :cyrusman:`cyrus.conf(5)` man page for details.

--- a/docsrc/imap/reference/admin/ports/sockets.rst
+++ b/docsrc/imap/reference/admin/ports/sockets.rst
@@ -1,0 +1,53 @@
+.. _imap-admin-sockets:
+
+Cyrus Socket Locations
+======================
+
+.. _imap-admin-sock:
+
+The Cyrus IMAP server provides service interfaces via either TCP/IP
+ports or Unix domain sockets.  For the later, Cyrus requires the parent
+directory exist prior to initialization.
+
+The following sockets may be required for any host providing local Unix
+domain access for the listed services, where ``<rundir>`` is the base
+directory for Cyrus sockets. This defaults to
+``{configdirectory}/socket/`` where {configdirectory} is as defined in
+:cyrusman:`imapd.conf(5)`, but is often redefined as
+``/var/run/cyrus/socket/`` or more recently ``/run/cyrus/socket/``:
+
+::
+
+    lmtp      <rundir>/lmtp   # Lightweight Mail Transport Protocol service
+    idle      <rundir>/idle   # idled daemon socket
+    notify    <rundir>/notify # Notification daemon socket
+    ptloader  <rundir>/ptsock # PT Loader socket (alternative authorization)
+    sphinx    <rundir>/sphinx # Sphinx full-text search daemon socket
+
+.. _imap-admin-sock-end:
+
+Controlling Socket Locations
+----------------------------
+
+Locations of sockets may be tailored to the needs of different
+sites, via the use of several settings in :cyrusman:`imapd.conf(5)`:
+
+.. include:: /imap/reference/manpages/configs/imapd.conf.rst
+	:start-after: startblob idlesocket
+	:end-before: endblob idlesocket
+
+.. include:: /imap/reference/manpages/configs/imapd.conf.rst
+	:start-after: startblob lmtpsocket
+	:end-before: endblob lmtpsocket
+
+.. include:: /imap/reference/manpages/configs/imapd.conf.rst
+	:start-after: startblob notifysocket
+	:end-before: endblob notifysocket
+
+.. include:: /imap/reference/manpages/configs/imapd.conf.rst
+	:start-after: startblob ptloader_sock
+	:end-before: endblob ptloader_sock
+
+.. include:: /imap/reference/manpages/configs/imapd.conf.rst
+	:start-after: startblob sphinx_socket
+	:end-before: endblob sphinx_socket

--- a/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
+++ b/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
@@ -12,7 +12,7 @@ Description
 ===========
 
 **cyrus.conf** is the configuration file for the Cyrus
-:cyrusman:`master` process.  It defines the startup procedures,
+:cyrusman:`master(8)` process.  It defines the startup procedures,
 services, events and daemons to be spawned, managed and tended to by
 **master**.
 

--- a/docsrc/quickstart.rst
+++ b/docsrc/quickstart.rst
@@ -6,17 +6,83 @@ Quickstart Guide
 .. toctree::
 
     imap/quickstart/introduction
-    
+
 Coming Soon
 -----------
 
 Quick install
 #############
 
-A quick guide to getting a basic installation of Cyrus up and running in 5 minutes.    
+A quick guide to getting a basic installation of Cyrus up and running in 5 minutes.
+
+The first place to start with a new installation of Cyrus IMAP is with
+your OS distribution of choice and their packaging, where available.  If
+there is no Cyrus IMAP 3.0 package available yet from your distro, 
+download the `latest stable package`_ : version |imap_current_stable_version|.
+
+.. _latest stable package: ftp://ftp.cyrusimap.org/cyrus-imapd/
+
+We only provide limited options for reference packages, so use a
+supported distribution.
+
+Install the package as provided for in your distro.  Please see guides
+here:
+
+The packaging should pull along all necessary support libraries, etc..
 
 Feature overview
 ################
 
-A short overview of Cyrus features.
-    
+The features (configuration options) supported in our reference
+packages are:
+
+Cyrus Server configured components
+
+    * event notification: yes
+    * gssapi:             no
+    * autocreate:         yes
+    * idled:              yes
+    * httpd:              yes
+    * kerberos V4:        no
+    * murder:             yes
+    * nntpd:              yes
+    * replication:        yes
+    * sieve:              yes
+    * calalarmd:          no
+    * jmap:               no
+    * objectstore:        no
+    * backup:             yes
+
+External dependencies:
+
+    * ldap:               yes
+    * openssl:            yes
+    * zlib:               yes
+    * pcre:               no
+    * clamav:             yes
+    * caringo:            no
+    * openio:             no
+    * nghttp2:            no
+    * brotli:             no
+    * xml2:               yes
+    * ical:               yes
+    * icu4c:              yes
+    * shapelib:           no
+
+Database support:
+
+    * mysql:              no
+    * postgresql:         no
+    * sqlite:             yes
+    * lmdb:               no
+
+Search engine:
+
+    * squat:              yes
+    * sphinx:             no
+    * xapian:             yes
+    * xapian_flavor:      vanilla
+
+Installation directories:
+    * prefix:             /usr
+    * sysconfdir:         /etc


### PR DESCRIPTION
New pages describe ports and sockets needed by Cyrus in such a way
that the information may easily be included into other pages.

Fix typo in cyrus.conf.rst

Augment "quickstart" guide.