### PR TITLE
Remove old cyrus.conf samples from master/ in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -388,11 +388,6 @@ EXTRA_DIST += \
 	lib/test/pool.c \
 	lib/test/rnddb.c \
 	master/CYRUS-MASTER.mib \
-	master/conf/cmu-backend.conf \
-	master/conf/cmu-frontend.conf \
-	master/conf/normal.conf \
-	master/conf/prefork.conf \
-	master/conf/small.conf \
 	master/README \
 	netnews/inn.diffs \
 	perl/annotator/Daemon.pm \


### PR DESCRIPTION
We've moved these into docs/examples, so no longer need them in the Makefile explicitly.