### PR TITLE
Disassemble basicserver.rst into bits

### DIFF
--- a/docsrc/assets/README.md
+++ b/docsrc/assets/README.md
@@ -1,0 +1,11 @@
+Cyrus Assets Directory
+======================
+
+This directory contains bits and pieces of instructions and examples.
+The intent is that these bits and pieces are included into other
+documents within the doctree.
+
+*   All files within this directory should be marked as :orphan:
+*   The highest level of hierarchy used in headings should be ###
+  *   Do not use === or ---, these should be reserved for the containing
+      documents.

--- a/docsrc/assets/cyrus-build-devpkg.rst
+++ b/docsrc/assets/cyrus-build-devpkg.rst
@@ -1,0 +1,15 @@
+As well as all of the things needed for building Cyrus itself, we'll
+also install some packages needed to support Cassandane -- the
+automated test facility.
+
+.. code-block:: bash
+
+    sudo apt-get install -y autoconf automake autotools-dev bash-completion bison build-essential comerr-dev \
+        debhelper flex g++ git gperf groff heimdal-dev libbsd-resource-perl libclone-perl libconfig-inifiles-perl \
+        libcunit1-dev libdatetime-perl libdb-dev libdigest-sha-perl libencode-imaputf7-perl libfile-chdir-perl \
+        libglib2.0-dev libical-dev libio-socket-inet6-perl libio-stringy-perl libjansson-dev libldap2-dev \
+        libmysqlclient-dev libnet-server-perl libnews-nntpclient-perl libpam0g-dev libpcre3-dev libsasl2-dev \
+        libsnmp-dev libsqlite3-dev libssl-dev libtest-unit-perl libtool libunix-syslog-perl liburi-perl \
+        libxapian-dev libxml-generator-perl libxml-xpath-perl libxml2-dev libwrap0-dev libzephyr-dev lsb-base \
+        net-tools perl php5-cli php5-curl pkg-config po-debconf tcl-dev \
+        transfig uuid-dev vim wamerican wget xutils-dev zlib1g-dev sasl2-bin rsyslog sudo acl telnet

--- a/docsrc/assets/cyrus-build-reqpkg.rst
+++ b/docsrc/assets/cyrus-build-reqpkg.rst
@@ -1,0 +1,7 @@
+.. code-block:: bash
+
+    sudo apt-get install git build-essential autoconf automake libtool \
+        pkg-config bison flex libssl-dev libjansson-dev libxml2-dev \
+        libsqlite3-dev libical-dev libsasl2-dev libpcre3-dev uuid-dev \
+        libicu-dev
+    sudo apt-get -t jessie-backports install libxapian-dev

--- a/docsrc/assets/cyrus-user-group.rst
+++ b/docsrc/assets/cyrus-user-group.rst
@@ -1,0 +1,29 @@
+Now let's create a **special user account just for the Cyrus server**
+to sandbox Cyrus: called ``cyrus``. We'll also create a ``mail`` group
+as well. This allows Cyrus to give other programs some permissions if
+they are run under the ``mail`` group, again, without causing a Cyrus
+bug to delete all of your cat pictures. Disaster!
+
+If you have installed from packages, your package vendor may have
+already done this for you.  To check, use these commands::
+
+    getent group mail
+    mail:x:8:
+
+::
+
+    getent passwd cyrus
+    cyrus:x:999:8:Cyrus IMAP Server:/var/lib/imap:/bin/bash
+
+Example group and user creation commands for GNU/Linux::
+
+    groupadd -fr mail
+    useradd -c "Cyrus IMAP Server" -d /var/lib/imap -g mail -s /bin/bash -r cyrus
+
+If your installation will use system locations for things like SSL
+certificates (i.e. ``/etc/ssl/certs /etc/ssl/private``), then you should
+also add the ``cyrus`` user to the appropriate group to gain access to
+the PKI files.  On Debian/Ubuntu systems, for example, this group is
+``ssl-cert``::
+
+    usermod -aG ssl-cert cyrus

--- a/docsrc/assets/services.rst
+++ b/docsrc/assets/services.rst
@@ -1,0 +1,22 @@
+The Cyrus IMAP server provides service interfaces via either TCP/IP
+ports or Unix domain sockets.  For the former, Cyrus requires that there
+are proper entries in the host's ``/etc/services`` file.  The following
+are required for any host using the listed services:
+
+::
+
+    pop3      110/tcp  # Post Office Protocol v3
+    nntp      119/tcp  # Network News Transport Protocol
+    imap      143/tcp  # Internet Mail Access Protocol rev4
+    imsp      406/tcp  # Internet Message Support Protocol (deprecated)
+    nntps     563/tcp  # NNTP over TLS
+    imaps     993/tcp  # IMAP over TLS
+    pop3s     995/tcp  # POP3 over TLS
+    kpop      1109/tcp # Kerberized Post Office Protocol
+    lmtp      2003/tcp # Lightweight Mail Transport Protocol service
+    smmap     2004/tcp # Cyrus smmapd (quota check) service
+    csync     2005/tcp # Cyrus replication service
+    mupdate   3905/tcp # Cyrus mupdate service
+    sieve     4190/tcp # timsieved Sieve Mail Filtering Language service
+
+Make sure that these lines are present and add them if they are missing.

--- a/docsrc/assets/setup-dir-struct.rst
+++ b/docsrc/assets/setup-dir-struct.rst
@@ -1,0 +1,8 @@
+Set up a simple directory structure for Cyrus to store emails, owned by
+the ``cyrus`` user and group ``mail``:
+
+::
+
+    sudo mkdir -p /var/lib/cyrus /var/spool/cyrus
+    sudo chown -R cyrus:mail /var/lib/cyrus /var/spool/imap
+    sudo chmod 750 /var/lib/cyrus /var/spool/cyrus

--- a/docsrc/assets/setup-sasl-sasldb.rst
+++ b/docsrc/assets/setup-sasl-sasldb.rst
@@ -1,0 +1,41 @@
+Now, let's set up **SASL**. This will allow you to connect to your
+local IMAP server and login, just like any IMAP user would before
+checking for new emails.
+
+Create a ``saslauth`` group and add the ``cyrus`` user to the group, so
+Cyrus can access SASL. (on Debian, this group is called 'sasl': adjust
+the following commands to suit.)
+
+::
+
+    groupadd -fr saslauth
+    usermod -aG saslauth cyrus
+
+Change the default SASL configuration in ``/etc/default/saslauthd``.
+    1. Make sure that the ``START`` option is set to *yes*
+       ``(START=yes)`` and
+    2. Set the``MECHANISMS`` option to **sasldb**
+       ``(MECHANISMS="sasldb")``.
+
+Start the SASL auth daemon:
+
+::
+
+    /etc/init.d/saslauthd start
+
+Now, we'll create the IMAP user inside SASL. This is the user you'll
+use to login to the IMAP server later on.
+
+::
+
+    echo 'secret' | saslpasswd2 -p -c imapuser
+
+You can replace ``secret`` with a more suitable password you want and
+``imapuser`` with the username you want. Once this is done, check that
+the user exists and is set up correctly:
+
+::
+
+    testsaslauthd -u imapuser -p secret
+
+You should get an ``0: OK "Success."`` message.

--- a/docsrc/assets/setup-sendmail.rst
+++ b/docsrc/assets/setup-sendmail.rst
@@ -1,0 +1,39 @@
+Install Sendmail
+################
+
+We'll set up LMTP with the Sendmail SMTP server.
+
+::
+
+    sudo apt-get install -y sendmail
+
+We need to make Sendmail aware of the fact we are using the Cyrus IMAP server: modify the ``/etc/mail/sendmail.mc`` file. Add this line before the ``MAILER_DEFINITIONS`` section:
+
+::
+
+    define(`confLOCAL_MAILER', `cyrusv2')dnl
+
+And right below ``MAILER_DEFINITIONS``, add this:
+
+::
+
+    MAILER(`cyrusv2')dnl
+
+This enables the **cyrusv2** mailer for local mail delivery. This is a sendmail property that tells sendmail it's talking to Cyrus. (Cyrus 3.x works with this property, despite the naming confusion.)
+
+Next, we run a script that takes the ``/etc/mail/sendmail.mc`` file and and prepares it for use by Sendmail. This may take some time.
+
+::
+
+    sudo sendmailconfig
+
+Sendmail communication
+######################
+
+One last thing we need to do for LMTP to work with Sendmail is to create a folder that will contain the UNIX socket used by Sendmail and Cyrus to deliver/receive emails:
+
+::
+
+    sudo mkdir -p /var/run/cyrus/socket
+    sudo chown cyrus:mail /var/run/cyrus/socket
+    sudo chmod 750 /var/run/cyrus/socket

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -98,7 +98,7 @@ release = '3.1.0 (dev)'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = [ '/assets' ]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docsrc/imap/developer/basicserver.rst
+++ b/docsrc/imap/developer/basicserver.rst
@@ -4,22 +4,33 @@
 Running a basic server
 ======================
 
-Once you have :ref:`compiled and installed Cyrus <imapinstallguide>`, you can configure your environment and start Cyrus.
+Once you have :ref:`compiled and installed Cyrus <imapinstallguide>`,
+you can configure your environment and start Cyrus.
 
-At the end of this guide, you will be up and running with a local instance of Cyrus. It will have with basic incoming and outgoing mail flow, with CalDAV and CardDAV support.
+At the end of this guide, you will be up and running with a local
+instance of Cyrus. It will have with basic incoming and outgoing mail
+flow, with CalDAV and CardDAV support.
 
 .. note::
-    These instructions are for Ubuntu 15.04. For other operating systems, dependency names in package managers may differ, but the main concepts remain the same.
+    These instructions are for Debian "Jessie" or newer. For other
+    operating systems or distros, dependency names in package managers
+    may differ, but the main concepts remain the same.
 
-    Please note that **this guide is meant to get you a working environment quickly, not to allow you to customize everything**.
+    Please note that **this guide is meant to get you a working
+    environment quickly, not to allow you to customize everything**.
 
-    This guide will set up Cyrus to work with the Sendmail SMTP server - and there will be no instructions for using Postfix. Once you have a working environment, you are welcome to experiment further and set up a different MTA or use different kinds of authentication schemes, etc.
+    This guide will set up Cyrus to work with the Sendmail SMTP server
+    - and there will be no instructions for using Postfix. Once you
+    have a working environment, you are welcome to experiment further
+    and set up a different MTA or use different kinds of authentication
+    schemes, etc.
 
 
 1. Update your system
 ----------------------
 
-First update the system to ensure everything is current. This may take some time; you can check `Hacker News`_ in the meantime.
+First update the system to ensure everything is current. This may take
+some time; you can check `Hacker News`_ in the meantime.
 
 ::
 
@@ -30,200 +41,69 @@ First update the system to ensure everything is current. This may take some time
 
 2. Install Cyrus 3rd party dependencies
 ---------------------------------------
+Install libraries and tools used by Cyrus IMAP. This includes a C
+compiler, build tools, and some support libraries.  Just like the
+previous command, this one may take a few minutes to complete.
 
-Install libraries and tools used by Cyrus IMAP. This includes a C compiler, some Perl libraries (used for Cyrus's command line utilities such as cyradm) or C clients for various databases (ie Mysql, Postgresql, etc). Just like the previous command, this one may take a few minutes to complete.
+.. include:: /assets/cyrus-build-devpkg.rst
 
-.. code-block:: bash
+3. Setup the cyrus:mail user and group
+--------------------------------------
 
-    sudo apt-get install -y autoconf automake autotools-dev bash-completion bison build-essential comerr-dev \
-    debhelper flex g++ git gperf groff heimdal-dev libbsd-resource-perl libclone-perl libconfig-inifiles-perl \
-    libcunit1-dev libdatetime-perl libdb-dev libdigest-sha-perl libencode-imaputf7-perl libfile-chdir-perl \
-    libglib2.0-dev libical-dev libio-socket-inet6-perl libio-stringy-perl libjansson-dev libldap2-dev \
-    libmysqlclient-dev libnet-server-perl libnews-nntpclient-perl libpam0g-dev libpcre3-dev libsasl2-dev \
-    libsnmp-dev libsqlite3-dev libssl-dev libtest-unit-perl libtool libunix-syslog-perl liburi-perl \
-    libxapian-dev libxml-generator-perl libxml-xpath-perl libxml2-dev libwrap0-dev libzephyr-dev lsb-base \
-    net-tools perl php5-cli php5-curl pkg-config po-debconf tcl-dev \
-    transfig uuid-dev vim wamerican wget xutils-dev zlib1g-dev sasl2-bin rsyslog sudo acl telnet
-
-
-3. The cyrus:mail user
-----------------------
-
-.. _basicserver_cyrus_user:
-
-Now let's create a **special user account just for the Cyrus server** to sandbox Cyrus: called ``cyrus``. We'll also create a ``mail`` group as well. This allows Cyrus to give other programs some permissions if they are run under the ``mail`` group, again, without causing a Cyrus bug to delete all of your cat pictures. Disaster!
-
-::
-
-    groupadd -r mail
-    useradd -c "Cyrus IMAP Server" -d /var/lib/imap -g mail -s /bin/bash -r cyrus
+.. include:: /assets/cyrus-user-group.rst
 
 4. Setting up authentication with SASL
 --------------------------------------
 
-Now, let's set up **SASL**. This will allow you to connect to your local IMAP server and login, just like any IMAP user would before checking for new emails.
-
-Create a ``saslauth`` group and add the ``cyrus`` user to the group, so Cyrus can access SASL. (on Debian, this group is called 'sasl': adjust the following commands to suit.)
-
-::
-
-    groupadd -r saslauth
-    usermod -aG saslauth cyrus
-
-Change the default SASL configuration in ``/etc/default/saslauthd``.
-    1. Make sure that the ``START`` option is set to *yes* ``(START=yes)`` and
-    2. Set the``MECHANISMS`` option to **sasldb** ``(MECHANISMS="sasldb")``.
-
-Start the SASL auth daemon:
-
-::
-
-    /etc/init.d/saslauthd start
-
-Now, we'll create the IMAP user inside SASL. This is the user you'll use to login to the IMAP server later on.
-
-::
-
-    echo 'secret' | saslpasswd2 -p -c imapuser
-
-You can replace ``secret`` with a more suitable password you want and ``imapuser`` with the username you want. Once this is done, check that the user exists and is set up correctly:
-
-::
-
-    testsaslauthd -u imapuser -p secret
-
-You should get an ``0: OK "Success."`` message.
+.. include:: /assets/setup-sasl-sasldb.rst
 
 
-5. Enabling mail delivery with LMTP
------------------------------------
+5. Setup mail delivery from your MTA
+------------------------------------
 
-Your Cyrus IMAP server will want to receive the emails accepted by your SMTP server (ie Sendmail, Postfix, etc). In Cyrus, this happens via a protocol called LMTP, which is usually supported by your SMTP server.
+Your Cyrus IMAP server will want to receive the emails accepted by your
+SMTP server (ie Sendmail, Postfix, etc). In Cyrus, this happens via a
+protocol called LMTP, which is usually supported by your SMTP server.
 
-Install Sendmail
-################
-
-We'll set up LMTP with the Sendmail SMTP server.
-
-::
-
-    sudo apt-get install -y sendmail
-
-We need to make Sendmail aware of the fact we are using the Cyrus IMAP server: modify the ``/etc/mail/sendmail.mc`` file. Add this line before the ``MAILER_DEFINITIONS`` section:
-
-::
-
-    define(`confLOCAL_MAILER', `cyrusv2')dnl
-
-And right below ``MAILER_DEFINITIONS``, add this:
-
-::
-
-    MAILER(`cyrusv2')dnl
-
-This enables the **cyrusv2** mailer for local mail delivery. This is a sendmail property that tells sendmail it's talking to Cyrus. (Cyrus 3.x works with this property, despite the naming confusion.)
-
-Next, we run a script that takes the ``/etc/mail/sendmail.mc`` file and and prepares it for use by Sendmail. This may take some time.
-
-::
-
-    sudo sendmailconfig
-
-Sendmail communication
-######################
-
-One last thing we need to do for LMTP to work with Sendmail is to create a folder that will contain the UNIX socket used by Sendmail and Cyrus to deliver/receive emails:
-
-::
-
-    sudo mkdir -p /var/run/cyrus/socket
-    sudo chown cyrus:mail /var/run/cyrus/socket
-    sudo chmod 750 /var/run/cyrus/socket
+.. include:: /assets/setup-sendmail.rst
 
 6. Protocol ports
 -----------------
-Cyrus uses assorted protocols, which need to have their ports defined in ``/etc/services``. Make sure that these lines are present and add them if they are missing:
 
-::
-
-    pop3      110/tcp
-    nntp      119/tcp
-    imap      143/tcp
-    imsp      406/tcp
-    nntps     563/tcp
-    imaps     993/tcp
-    pop3s     995/tcp
-    kpop      1109/tcp
-    lmtp      2003/tcp
-    sieve     4190/tcp
+.. include:: /assets/services.rst
 
 7. Configuring Cyrus
 --------------------
 
 (Nearly there)
 
-Set up a simple directory structure for Cyrus to store emails, owned by the ``cyrus:mail`` account:
+.. include:: /assets/setup-dir-struct.rst
 
-::
+Let's add some basic configuration for the Cyrus IMAP server. Two files
+have to be added: ``/etc/imapd.conf`` and ``/etc/cyrus.conf``.  There
+are several examples included with the software, in ``doc/examples/``.
+Pick one each from the ``imapd_conf`` and ``cyrus_conf`` directories,
+or create your own.
 
-    sudo mkdir -p /var/imap /var/spool/imap
-    sudo chown cyrus:mail /var/imap /var/spool/imap
-    sudo chmod 750 /var/imap /var/spool/imap
+For :cyrusman:`imapd.conf(5)`, let's start with the ``normal.conf``
+example:
 
+.. literalinclude:: /../doc/examples/imapd_conf/normal.conf
 
-Let's add some basic configuration for the Cyrus IMAP server. Two files have to be added: ``/etc/imapd.conf`` and ``/etc/cyrus.conf``.
+Note that **configdirectory** and **partition-default** are set to the
+folders we just created.
 
-For :cyrusman:`imapd.conf(5)`, start with this:
+The admin user is the ``imapuser`` created in step 4, for
+authentication against sasl. Change this value if you named your user
+something different.
 
-::
+For :cyrusman:`cyrus.conf(5)`, again we'll start with the
+``normal.conf`` example:
 
-    configdirectory: /var/imap
-    partition-default: /var/spool/imap
-    admins: imapuser
-    sasl_pwcheck_method: saslauthd
-    allowplaintext: yes
-    virtdomains: yes
-    defaultdomain: localhost
+.. literalinclude:: /../doc/examples/cyrus_conf/normal.conf
 
-Note that **configdirectory** and **partition-default** are set to the folders we just created.
-
-The admin user is the ``imapuser`` created in step 4, for authentication against sasl. Change this value if you named your user something different.
-
-For :cyrusman:`cyrus.conf(5)`, start with this:
-
-::
-
-    START {
-      # do not delete this entry!
-      recover    cmd="ctl_cyrusdb -r"
-    }
-
-    # UNIX sockets start with a slash and are put into /var/imap/sockets
-    SERVICES {
-      # add or remove based on preferences
-      imap        cmd="imapd" listen="imap" prefork=0
-      pop3        cmd="pop3d" listen="pop3" prefork=0
-
-      # LMTP is required for delivery (socket is set for Sendmail MTA)
-      lmtpunix    cmd="lmtpd" listen="/var/run/cyrus/socket/lmtp" prefork=0
-    }
-
-    EVENTS {
-      # this is required
-      checkpoint    cmd="ctl_cyrusdb -c" period=30
-
-      # this is only necessary if using duplicate delivery suppression
-      delprune    cmd="ctl_deliver -E 3" at=0400
-
-      # expire data older than 28 days
-      deleteprune cmd="cyr_expire -E 4 -D 28" at=0430
-      expungeprune cmd="cyr_expire -E 4 -X 28" at=0445
-
-      # this is only necessary if caching TLS sessions
-      tlsprune    cmd="tls_prune" at=0400
-    }
-
-Before you launch Cyrus for the first time, create the Cyrus directory structure: use :cyrusman:`mkimap(8)`.
+Before you launch Cyrus for the first time, create the Cyrus directory
+structure: use :cyrusman:`mkimap(8)`.
 
 ::
 
@@ -236,74 +116,111 @@ Before you launch Cyrus for the first time, create the Cyrus directory structure
 
     sudo ./master/master -d
 
-Check ``/var/log/syslog`` for errors so you can quickly understand any problems.
+Check ``/var/log/syslog`` for errors so you can quickly understand any
+problems.
 
-When you're ready, you can create init scripts to start and stop your daemons. This
-https://www.linux.com/learn/managing-linux-daemons-init-scripts is old, but has a good
-explanation of the concepts required.
+When you're ready, you can create init scripts to start and stop your
+daemons. This
+https://www.linux.com/learn/managing-linux-daemons-init-scripts is old,
+but has a good explanation of the concepts required.
 
 Optional: Setting up SSL certificates
 -------------------------------------
 
-Let's set up encryption with TLS. Create a TLS certificate using OpenSSL. Generate the certificate and store it in the /var/imap/server.pem file:
+Create a TLS certificate using OpenSSL. Generate the certificate and
+store it in the /var/lib/cyrus/server.pem file:
 
 ::
 
-    sudo openssl req -new -x509 -nodes -out /var/imap/server.pem \
-    -keyout /var/imap/server.pem -days 365 \
+    sudo openssl req -new -x509 -nodes -out /var/lib/cyrus/server.pem \
+    -keyout /var/lib/cyrus/server.pem -days 365 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost"
 
-This creates a TLS certificate (`-out`) and private key (`-keyout`) in the `X.509 <https://en.wikipedia.org/wiki/X.509>`_ format (`-x509`). The certificate is set to expire in 365 days (`-days`) and has default information set up (`-subj ...`). The contents of the -subj is non-trivial and defined in `RFC 5280 <http://www.ietf.org/rfc/rfc5280.txt>`_, a brief summary is available on `stackoverflow <http://stackoverflow.com/questions/6464129/certificate-subject-x-509>`_ which is enough to decode our sample above.
+This creates a TLS certificate (`-out`) and private key (`-keyout`) in
+the `X.509 <https://en.wikipedia.org/wiki/X.509>`_ format (`-x509`).
+The certificate is set to expire in 365 days (`-days`) and has default
+information set up (`-subj ...`). The contents of the -subj is
+non-trivial and defined in `RFC 5280
+<http://www.ietf.org/rfc/rfc5280.txt>`_, a brief summary is available
+on `stackoverflow
+<http://stackoverflow.com/questions/6464129/certificate-subject-x-509>`_
+which is enough to decode our sample above.
 
-Great! You should now have a file at /var/imap/server.pem. Give Cyrus access to this file:
+Great! You should now have a file at /var/lib/cyrus/server.pem. Give
+Cyrus access to this file:
 
 ::
 
-    sudo chown cyrus:mail /var/imap/server.pem
+    sudo chown cyrus:mail /var/lib/cyrus/server.pem
 
-Awesome! Almost done. We will now configure the Cyrus IMAP server to actually use this TLS certificate. Open your Cyrus configuration file /etc/imapd.conf and add the following to lines at the end of it:
+Awesome! Almost done. We will now configure the Cyrus IMAP server to
+actually use this TLS certificate. Open your Cyrus configuration file
+``/etc/imapd.conf`` and add the following to lines at the end of it:
 
 ::
 
-    tls_server_cert: /var/imap/server.pem
-    tls_server_key: /var/imap/server.pem
+    tls_server_cert: /var/lib/cyrus/server.pem
+    tls_server_key: /var/lib/cyrus/server.pem
 
-This tells the server where to find the TLS certificate and the key. It may seem weird to specify the same file twice, but since the file has the x509 format, the server will know what to do. Cyrus is there for you, always (unless your hard drive burns down) ! :-)
+This tells the server where to find the TLS certificate and the key. It
+may seem weird to specify the same file twice, but since the file has
+the x509 format, the server will know what to do. Cyrus is there for
+you, always (unless your hard drive burns down) ! :-)
 
-The other configuration file we have to edit is /etc/cyrus.conf. Open it up with your favorite text editor and in the **SERVICES** section, add this line:
+The other configuration file we have to edit is ``/etc/cyrus.conf``.
+Open it up with your favorite text editor and in the **SERVICES**
+section, add (or uncomment) this line:
 
 ::
 
     imaps        cmd="imapd" listen="imaps" prefork=0
 
 Notice the `s` at the end of `imaps`. This says we are using TLS.
+Similar such lines may be used for `pop3s`, `lmtps` and other protocols.
+See Protocol Ports, above, for more information on these. 
 
-If you now restart (or start) your Cyrus server, you should have Cyrus listening on port **993** (the IMAPS port) with the **STARTTLS IMAP extension** enabled. You can check that TLS works as expected with the following command:
+If you now restart (or start) your Cyrus server, you should have Cyrus
+listening on port **993** (the IMAPS port) with the **STARTTLS IMAP
+extension** enabled. You can check that TLS works as expected with the
+following command:
 
 ::
 
     imtest -t "" -u imapuser -a imapuser -w secret localhost
 
-Make sure to replace `imapuser` with whatever user you set up with saslpasswd2 before, and to replace `secret` with the actual password you set for that user.
+Make sure to replace `imapuser` with whatever user you set up with
+saslpasswd2 before, and to replace `secret` with the actual password
+you set for that user.
 
 Sending a test email
 --------------------
 
-We will send a test email to our local development environment to check if:
+We will send a test email to our local development environment to check
+if:
 
-* Sendmail accepts the incoming email,
+* The SMTP server\* accepts the incoming email,
 * LMTP transmits the email to Cyrus IMAP,
 * You can see the email stored on your filesystem.
 
-But first, create a mailbox to send the test email to. We'll call this test mailbox `example@localhost`.
+..  Note:: \*SMTP servers also often called an "MTA," for Mail Transport
+    Agent
+
+But first, create a mailbox to send the test email to. We'll call this
+test mailbox `example@localhost`.
 
 ::
 
     echo 'createmailbox user/example@localhost' | cyradm -u imapuser -w secret localhost
 
-We seem to be creating a mailbox named `user/example@localhost`. In fact, Cyrus understands this to be a user called `example@localhost`. As usual, adjust the password via the `-w` option to the password you set above.
+We seem to be creating a mailbox named ``user/example@localhost``. In
+fact, Cyrus understands this to be a user called ``example@localhost``.
+As usual, adjust the password via the ``-w`` option to the password you
+set above.
 
-If you have explicitly disabled `unixhierarchysep` in `/etc/imapd.conf` (it is enabled by default in 3.0+), you should replace `user/example@localhost` with `user.example@localhost`. You can read more about unixhierarchysep in :cyrusman:`imapd.conf(5)`.
+If you have explicitly disabled ``unixhierarchysep`` in
+``/etc/imapd.conf`` (it is enabled by default in 3.0+), you should
+replace ``user/example@localhost`` with ``user.example@localhost``. You
+can read more about ``unixhierarchysep`` in :cyrusman:`imapd.conf(5)`.
 
 The command will produce the following output:
 
@@ -311,11 +228,13 @@ The command will produce the following output:
 
     localhost> localhost>
 
-This happens because cyradm is normally used interactively, with a prompt. We aren't using a prompt, so this output is expected.
+This happens because cyradm is normally used interactively, with a
+prompt. We aren't using a prompt, so this output is expected.
 
-Now that the mailbox exists, we can send an email using telnet with raw SMTP commands.
+Now that the mailbox exists, we can send an email using telnet with raw
+SMTP commands.
 
-First, connect to the Sendmail SMTP server:
+First, connect to the MTA:
 
 ::
 
@@ -331,7 +250,7 @@ You should see a prompt appear:
     Escape character is '^]'.
     220 ... ESMTP Sendmail ...
 
-Now, we'll send the `SMTP commands <https://www.ietf.org/rfc/rfc2821.txt>`_ to the server. These are responsible for ordering Sendmail to store an email:
+Now, we'll send the `SMTP commands <https://www.ietf.org/rfc/rfc2821.txt>`_ to the server. These are responsible for ordering the MTA to store an email:
 
 ::
 
@@ -343,13 +262,21 @@ Now, we'll send the `SMTP commands <https://www.ietf.org/rfc/rfc2821.txt>`_ to t
     .
     QUIT
 
-If you are using Sendmail as your SMTP server, you should be able to safely copy and paste this bit into the terminal before hitting your ENTER key. If not, you may want to paste these commands one by one (or make sure you enable `PIPELINING` in the SMTP config).
+If you are using Sendmail as your SMTP server, you should be able to
+safely copy and paste this bit into the terminal before hitting your
+ENTER key. If not, you may want to paste these commands one by one (or
+make sure you enable `PIPELINING` in the SMTP config).
 
-If you see a message like **250 2.0.0 ... Message accepted for delivery**, you did it! You should now have a file called `1.` in the `/var/spool/imap/user/example` directory, with the content of the email you sent just before.
+If you see a message like **250 2.0.0 ... Message accepted for
+delivery**, you did it! You should now have a file called `1.` in the
+`/var/spool/cyrus/user/example` directory, with the content of the email
+you sent just before.
 
-If not, you may want to check `syslog` to see if any error messages show up and go through the previous steps again.
+If not, you may want to check `syslog` to see if any error messages
+show up and go through the previous steps again.
 
-To let the example user log in via IMAP on a normal mail client, you need to add them to SASL (as before)::
+To let the example user log in via IMAP on a normal mail client, you
+need to add them to SASL (as before)::
 
     echo 'mypassword' | saslpasswd2 -p -c example
 
@@ -357,26 +284,28 @@ Check your two users are there::
 
     sasldblistusers2
 
-You can now configure a mail client to access your new mailserver and connect to the mailbox for example@localhost via IMAP and see the message.
+You can now configure a mail client to access your new mailserver and
+connect to the mailbox for example@localhost via IMAP and see the
+message.
 
 Checking CardDAV and CardDAV
 ----------------------------
 
-Modify ``/etc/cyrus.conf`` and add this line to the services::
+Modify ``/etc/cyrus.conf`` and add (or uncomment) this line in the
+SERVICES section::
 
     http        cmd="httpd" listen="http" prefork=0
 
-Modify ``/etc/imapd.conf`` and add this line::
+Modify ``/etc/imapd.conf`` and add (or uncomment) this line::
 
     httpmodules: caldav carddav
 
-
-Running the following commands should return you sample entry addressbook and calendar entry for the sample example user::
+Running the following commands should return you sample entry
+addressbook and calendar entry for the sample example user::
 
     curl -u example@[hostname]:mypassword -i -X PROPFIND -H 'Depth: 1' http://localhost:8080/dav/addressbooks/user/example@[hostname]/Default
 
     curl -u example@[hostname]:mypassword -i -X PROPFIND -H 'Depth: 1' http://localhost:8080/dav/principals/user/example@[hostname]/
-
 
 ----
 

--- a/docsrc/imap/download/installation/diy.rst
+++ b/docsrc/imap/download/installation/diy.rst
@@ -87,6 +87,10 @@ Building a basic Cyrus that can send and receive email: the minimum libraries re
 .. _pkgconfig: http://pkgconfig.freedesktop.org
 .. _sqlite: https://www.sqlite.org/
 
+To install all dependencies from packages on Debian Jessie, use this:
+
+.. include:: /assets/cyrus-build-reqpkg.rst
+
 Optional Build Dependencies
 ---------------------------
 

--- a/docsrc/imap/download/packagers.rst
+++ b/docsrc/imap/download/packagers.rst
@@ -5,10 +5,11 @@ Notes for Packagers
 Sample configuration files
 ==========================
 
-There are several samples of :cyrusman:`cyrus.conf(5)` located in the
-``doc/examples`` directory of the distribution tarball.  Please install
-these to your preferred documentation directory (i.e.
-``/usr/share/doc/cyrus-imapd``) as a reference for your users.
+There are several samples of :cyrusman:`cyrus.conf(5)` and
+:cyrusman:`imapd.conf(5)` located in the ``doc/examples`` directory of
+the distribution tarball.  Please install these to your preferred
+documentation directory (i.e. ``/usr/share/doc/cyrus-imapd``) as a
+reference for your users.
 
 Predefined configurations
 =========================
@@ -65,11 +66,11 @@ sections are:
 The configuration file for the various programs: imapd.conf
 -----------------------------------------------------------
 
-There is no sample for the :cyrusman:`imapd.conf(5)` file, as it must
-vary so much from site to site.  Here, therefore, we'll attempt to
-point you towards some reasonable settings which take advantage of
-recent improvements and features, and may help guide you and your users
-to a better performing Cyrus installation.
+The sample :cyrusman:`imapd.conf(5)` files must be adapted for use from
+site to site.  Here, therefore, we'll attempt to point you towards some
+reasonable settings which take advantage of recent improvements and
+features, and may help guide you and your users to a better performing
+Cyrus installation.
 
 Ephemeral files and temporary filesystems
 #########################################
@@ -102,6 +103,56 @@ New default settings
 With the introduction of version 3.0, the defaults for some settings
 have changed.  Please consult :ref:`upgrade` for details.
 
+New features
+############
+
+There are several features either new to version 3.0, or newly improved.
+Some of these may be features which previously were not considered ripe
+for packaging, but merit new consideration.
+
+Please see the release notes :ref:`relnotes-3.0.0-changes` for more
+details and other recent changes.
+
+*   Conversations
+
+    *   Server-side threading with reduced protocol chatter for mobile
+        or other high-latency clients.
+    *   Required for JMAP support.
+    *   See the ``conversations`` options in :cyrusman:`imapd.conf(5)`
+
+*   JMAP
+
+    *   JSON Mail Access Protocol
+    *   Follow-on successor to IMAP ("J comes after I") with a special
+        focus on mobile and other clients with high-latency or
+        unreliable connectivity.
+    *   Includes Calendaring, Contacts, Conversations, message delivery.
+    *   See ``httpmodules`` in :cyrusman:`imapd.conf(5)`
+
+*   Xapian
+
+    *   Higher quality full-text search support.
+    *   Required for JMAP support.
+    *   See the ``search_engine`` option in :cyrusman:`imapd.conf(5)`
+        and ``doc/README.xapian`` in the source distribution.
+
+*   Archive partitions
+
+    *   Automatically migrate messages from posh, fast storage (think
+        SSD) to cheap, slow storage (spinning rust).
+    *   Requires addition of an archive partition for each data
+        partition.
+    *   See ``archive_*`` options in :cyrusman:`imapd.conf(5)`
+
+*   Backup
+
+    *   Replication-based backup to dedicated instance with efficient,
+        compact scheme.
+    *   See :ref:`Cyrus Backups <cyrus-backups>`
+
+Please consider enabling these features in the :cyrusman:`imapd.conf(5)`
+you ship  in your packages.
+
 Services in ``/etc/services``
 =============================
 
@@ -109,50 +160,4 @@ Listing named services through ``/etc/services`` aids in cross-system consistenc
 
 Some of the services Cyrus IMAP would like to see available through ``/etc/services`` have not been assigned an IANA port number, and few have configuration options.
 
-The following lists services Cyrus IMAP should have available in ``/etc/services``:
-
-* **csync**
-
-    The Cyrus IMAP synchronisation server port, for replication clients to connect to.
-
-    * Description: *Cyrus IMAP Replication Daemon*
-    * Suggested Port(s): **2005/tcp**
-
-.. note::
-    **Default in /etc/imapd.conf**
-
-    While **2005/tcp** is the suggested default port for **csync**, the value of the port number is specified through the **sync_port** option in ``/etc/imapd.conf`` (generated from ``lib/imapoptions``). Note that when changing the suggested port for **csync** we recommend you also patch ``lib/imapoptions`` prior to building Cyrus IMAP.
-
-* **lmtp**
-
-    Some platforms do not specify the service port for LMTP –like Solaris and Debian. Fedora-based Linux distributions allocate port **24/tcp** for LMTP Mail Delivery, however. Whatever port packagers choose to use, please note they should be the same across all platforms deployed in a single environment.
-
-    * Description: *LMTP Mail Delivery*
-    * Suggested Port(s): **24/tcp** (Fedora-based platforms), **2003/tcp** (other platforms)
-
-* **mupdate**
-
-    The Cyrus IMAP Murder Mailbox Update protocol (MUPDATE) ensures mailboxes
-
-    * Description: *Mailbox Update (MUPDATE) protocol*
-    * Recommended Port(s): **3905/tcp**
-
-.. note::
-    Default in ``/etc/imapd.conf``
-
-    **3905/tcp** is the suggested default port for mupdate, as it is the default value specified for the **mupdate_port** option available in ``/etc/imapd.conf`` (generated from ``lib/imapoptions``). Note that when changing the suggested port for mupdate we recommend you also patch ``lib/imapoptions`` prior to building Cyrus IMAP.
-
-* **sieve**
-
-    * Description: *ManageSieve protocol*
-    * IANA Port: **4190/tcp**
-
-.. note::
-    **Port 2000/tcp**
-
-    **2000/tcp** is actually sieve-filter with description *Sieve Mail Filter Daemon*.
-
-* **smmap**
-
-    * Description: *Cyrus smmapd (quota check) service*
-    * Suggested Port(s): **/tcp**
+..  include:: /assets/services.rst

--- a/docsrc/imap/reference/admin/ports/services.rst
+++ b/docsrc/imap/reference/admin/ports/services.rst
@@ -3,32 +3,7 @@
 Cyrus Service Definitions
 =========================
 
-.. _imap-admin-ports-servent:
-
-The Cyrus IMAP server provides service interfaces via either TCP/IP
-ports or Unix domain sockets.  For the former, Cyrus requires that there
-are proper entries in the host's ``/etc/services`` file.  The following
-are required for any host using the listed services:
-
-::
-
-    pop3      110/tcp  # Post Office Protocol v3
-    nntp      119/tcp  # Network News Transport Protocol
-    imap      143/tcp  # Internet Mail Access Protocol rev4
-    imsp      406/tcp  # Internet Message Support Protocol (deprecated)
-    nntps     563/tcp  # NNTP over TLS
-    imaps     993/tcp  # IMAP over TLS
-    pop3s     995/tcp  # POP3 over TLS
-    kpop      1109/tcp # Kerberized Post Office Protocol
-    lmtp      2003/tcp # Lightweight Mail Transport Protocol service
-    smmap     2004/tcp # Cyrus smmapd (quota check) service
-    csync     2005/tcp # Cyrus replication service
-    mupdate   3905/tcp # Cyrus mupdate service
-    sieve     4190/tcp # timsieved Sieve Mail Filtering Language service
-
-Make sure that these lines are present and add them if they are missing.
-
-.. _imap-admin-ports-servent-end:
+.. include:: /assets/services.rst
 
 Controlling Service Ports and Sockets
 -------------------------------------

--- a/docsrc/quickstart.rst
+++ b/docsrc/quickstart.rst
@@ -11,7 +11,7 @@ Quickstart Guide
 .. -----------
 
 Quick install
--------------
+=============
 
 A quick guide to getting a basic installation of Cyrus up and running in 5 minutes.
 
@@ -29,7 +29,10 @@ official Cyrus packages are for Debian Jessie (with backports enabled).
 Please download both the packages (\*.deb) and the signature files.
 Installation is a two step process:
 
-1. First, invoke the ``dpkg -i`` command with the list of all packages::
+1. Install Cyrus reference packages
+-----------------------------------
+
+First, invoke the ``dpkg -i`` command with the list of all packages::
 
     $ sudo dpkg -i \
         cyrus-common_3.0.1-jessie_amd64.deb  \
@@ -48,15 +51,46 @@ Installation is a two step process:
 That step will produce an error, as there will doubtless be unmet
 dependencies.  Not to worry, there's a fix for that...
 
-2.  Now invoke ``apt-get install -f`` to pull in the dependencies and
-    complete the installation::
+2. Use "apt-get install -f" to complete installation
+----------------------------------------------------
+
+Now invoke ``apt-get install -f`` to pull in the dependencies and
+complete the installation::
 
     $ sudo apt-get install -f
 
 The packaging should pull along all necessary support libraries, etc..
 
-CONFIGURATION
--------------
+3. Setup the cyrus:mail user and group
+--------------------------------------
+
+.. include:: /assets/cyrus-user-group.rst
+
+4. Setting up authentication with SASL
+--------------------------------------
+
+.. include:: /assets/setup-sasl-sasldb.rst
+
+5. Setup mail delivery from your MTA
+------------------------------------
+
+Your Cyrus IMAP server will want to receive the emails accepted by your
+SMTP server (ie Sendmail, Postfix, etc). In Cyrus, this happens via a
+protocol called LMTP, which is usually supported by your SMTP server.
+
+.. include:: /assets/setup-sendmail.rst
+
+6. Protocol ports
+-----------------
+
+.. include:: /assets/services.rst
+
+7. Configuring Cyrus
+--------------------
+
+(Nearly there)
+
+.. include:: /assets/setup-dir-struct.rst
 
 Following installation, a fairly comprehensive set of sample
 configuration files may be found in
@@ -76,6 +110,10 @@ A basic description of these files:
             As above, but with several server processes pre-forked for
             faster connection initialization.
 
+    ..  note::  The ``normal.conf`` file in the ``imapd_conf`` directory
+        is intended to work with any of the above files from the
+        ``cyrus_conf`` directory.
+        
 *   Cyrus Aggregation - Murder -- configurations (these constitute a
     set, with at least one of each required):
 
@@ -101,19 +139,41 @@ A basic description of these files:
             A typical replica server, which accepts updates from the
             master.
 
+    .. note::
+        When working with replication or aggregation (Murder), the
+        example files in ``cyrus_conf`` and ``imapd_conf`` of the same
+        name are intended to be used together.
+
 You should review each of these and then install as desired to
 ``/etc/``, making changes as needed.  In particular, you'll need to set
 passwords for the various users used to authenticate between instances
 in a Murder or Replication environment.
 
-.. Note::
-    Continue with instructions in :ref:`The cyrus:mail user <basicserver_cyrus_user>`
+For example::
+
+    install -m 600 doc/examples/cyrus_conf/normal.conf /etc/cyrus.conf
+    install -m 600 doc/examples/imapd_conf/normal.conf /etc/imapd.conf
+    vi /etc/imapd.conf
+    ...
+    vi /etc/cyrus.conf
+    ...
+
+8. Launch Cyrus
+---------------
+
+If using our packages on Debian Jessie, you will have a SystemV
+compatible init script installed, with systemd support.  Start Cyrus
+with the following command::
+
+    systemctl start cyrus-imapd
+
+Tada!  You should now have a working Cyrus IMAP server.
 
 Feature overview
 ----------------
 
-The features (configuration options) supported in our reference
-packages are:
+The features (compile-time configuration options) supported in our
+reference packages are:
 
 Cyrus Server configured components
     * event notification : yes


### PR DESCRIPTION
Split basicserver.rst into bits and place these in new 'assets'
top level directory.  Then include those bits back into main file.
Modify conf.py to ignore the '/assets' directory.

Create more assets and update other docs to use them.

Add more steps to quickstart.rst, using assets.

Fix typos.