### PR TITLE
version: make cyrus_version accessible to the debugger

### DIFF
--- a/imap/version.c
+++ b/imap/version.c
@@ -76,9 +76,11 @@ static char id_resp_arguments[MAXIDVALUELEN] = "";
 #define CYRUS_VERSION PACKAGE_VERSION
 #endif
 
+static const char *cyrus_version_str = CYRUS_VERSION;
+
 EXPORTED const char *cyrus_version(void)
 {
-    return CYRUS_VERSION;
+    return cyrus_version_str;
 }
 
 /*


### PR DESCRIPTION
This will help with my crash reporting work.

```
$ gdb -batch -ex 'p cyrus_version_str' /usr/cyrus-future/lib/libcyrus_imap.so
$1 = 0xd9500 "future-fmjessie43922-14953-git-future-14953"
```