### PR TITLE
[Docs] Ensure --configure options are escaped.

### DIFF
--- a/docsrc/imap/download/installation/diy.rst
+++ b/docsrc/imap/download/installation/diy.rst
@@ -251,12 +251,12 @@ CalDAV and CardDAV
 Murder
 ######
 
-    ```./configure --enable-murder``
+    ``./configure --enable-murder``
 
 Replication
 ###########
 
-    ```./configure --enable-replication``
+    ``./configure --enable-replication``
 
 4. Compile and install
 ======================

--- a/docsrc/imap/download/release-notes/2.5/x/2.5.1.rst
+++ b/docsrc/imap/download/release-notes/2.5/x/2.5.1.rst
@@ -54,11 +54,11 @@ Changes to cyradm
 
 With thanks to Leena Heino and Norbert Warmuth for their contributions
 
-* createmailbox command now accepts --specialuse flag if server supports CREATE-SPECIAL-USE
+* createmailbox command now accepts ``--specialuse flag`` if server supports CREATE-SPECIAL-USE
 * listmailbox command now returns special-use attribute if server supports SPECIAL-USE
-* listmailbox command now accepts --specialuse flag to list only mailboxes with special-use attribute
+* listmailbox command now accepts ``--specialuse`` flag to list only mailboxes with special-use attribute
 * cyradm now uses LIST and REMOTE rather than RLIST if server supports LIST-EXTENDED
-* mboxconfig now accepts --private flag to switch from default shared to private version of an annotation
+* mboxconfig now accepts ``--private flag`` to switch from default shared to private version of an annotation
 * getmetadata: new command
 * setmetadata: new command
 

--- a/docsrc/imap/download/release-notes/2.5/x/2.5.5.rst
+++ b/docsrc/imap/download/release-notes/2.5/x/2.5.5.rst
@@ -29,7 +29,7 @@ Changes Since 2.5.4
 Bug fixes
 ---------
 
-* Security fix: compiling with --enable-autocreate no longer allows arbitrary
+* Security fix: compiling with ``--enable-autocreate`` no longer allows arbitrary
   mailbox creation
 * Fixed :task:`207`: don't segfault on mboxutil -d of MBTYPE_DELETED mailboxes (thanks Chris Stromsoe)
 * Fixed lock management over rename (thanks Thomas Jarosch)

--- a/docsrc/imap/download/release-notes/2.5/x/2.5.6.rst
+++ b/docsrc/imap/download/release-notes/2.5/x/2.5.6.rst
@@ -35,10 +35,10 @@ New imapd.conf options
 New cyradm options
 ------------------
 
-* --tlskey keyfile: use certificate with keyfile to authenticate with server
-* --notls: disable StartTLS negotiation
-* --cafile cacertfile: Use CA certificate file to validate server certificate
-* --cadir cacertdirectory: Use CA certificate directory to validate server certificate
+* ``--tlskey keyfile``: use certificate with keyfile to authenticate with server
+* ``--notls``: disable StartTLS negotiation
+* ``--cafile cacertfile``: Use CA certificate file to validate server certificate
+* ``--cadir cacertdirectory``: Use CA certificate directory to validate server certificate
 
 Thanks Leena Heino and Carlos Velasco
 

--- a/docsrc/imap/reference/admin/backups.rst
+++ b/docsrc/imap/reference/admin/backups.rst
@@ -96,7 +96,7 @@ Requirements
 Cyrus Backups server
 --------------------
 
-#. Compile cyrus with the --enable-backup configure option and install it.
+#. Compile cyrus with the ``--enable-backup`` configure option and install it.
 #. Set up an :cyrusman:`imapd.conf(5)` file for it with the following options
    (default values shown):
 
@@ -112,7 +112,7 @@ Cyrus Backups server
         of running backupd's, plus some wiggle room.
     backup\_retention\_days: 7
         Number of days for which backup data (messages etc) should be kept
-        within the backup storage after the corresponding item has been 
+        within the backup storage after the corresponding item has been
         deleted/expunged from the Cyrus IMAP server.
     backuppartition-\ *name*: /path/to/this/partition
         You need at least one backuppartition-\ *name* to store backup data.

--- a/docsrc/imap/reference/admin/eventsource.rst
+++ b/docsrc/imap/reference/admin/eventsource.rst
@@ -7,7 +7,7 @@ Cyrus Event Source
 Overview
 ========
 
-Cyrus can be configured to send events to another program any time something changes in a mailbox. The event contains details about the type of action that occurred, identifying information about the message and other useful information. Cyrus generates events for pretty much everything – every user action, data change, and other interesting things like calendar alarms. 
+Cyrus can be configured to send events to another program any time something changes in a mailbox. The event contains details about the type of action that occurred, identifying information about the message and other useful information. Cyrus generates events for pretty much everything – every user action, data change, and other interesting things like calendar alarms.
 
 The notifications are compliant with :rfc:`5423`, though Cyrus includes some additional events outside of the RFC.
 
@@ -18,9 +18,9 @@ Compile options
 
 You can control what kind of events Cyrus generates during the ``configure`` step of compilation.
 
-**--enable_event_notification**: Set this to "yes" to have Cyrus generate mailbox related events. This is enabled by default.
+``--enable_event_notification``: Set this to "yes" to have Cyrus generate mailbox related events. This is enabled by default.
 
-**--enable-apple-push-service**: Set this to "yes" to enable support for the Apple Push service. This is *disabled* by default.
+``--enable-apple-push-service``: Set this to "yes" to enable support for the Apple Push service. This is *disabled* by default.
 
 Configuration options
 =====================
@@ -30,30 +30,30 @@ These need to be set in :cyrusman:`imapd.conf(5)`.
 .. include:: ../manpages/configs/imapd.conf.rst
         :start-after: startblob event_content_inclusion_mode
         :end-before: endblob event_content_inclusion_mode
-        
+
 .. include:: ../manpages/configs/imapd.conf.rst
         :start-after: startblob event_content_size
         :end-before: endblob event_content_size
- 
+
 .. include:: ../manpages/configs/imapd.conf.rst
         :start-after: startblob event_exclude_flags
-        :end-before: endblob event_exclude_flags 
+        :end-before: endblob event_exclude_flags
 
 .. include:: ../manpages/configs/imapd.conf.rst
         :start-after: startblob event_exclude_specialuse
-        :end-before: endblob event_exclude_specialuse 
+        :end-before: endblob event_exclude_specialuse
 
 .. include:: ../manpages/configs/imapd.conf.rst
         :start-after: startblob event_extra_params
-        :end-before: endblob event_extra_params 
+        :end-before: endblob event_extra_params
 
 .. include:: ../manpages/configs/imapd.conf.rst
         :start-after: startblob event_groups
-        :end-before: endblob event_groups 
+        :end-before: endblob event_groups
 
 .. include:: ../manpages/configs/imapd.conf.rst
         :start-after: startblob event_notifier
-        :end-before: endblob event_notifier 
+        :end-before: endblob event_notifier
 
 Event Types
 ===========
@@ -68,9 +68,8 @@ While Cyrus only communicates with a single notification process, it doesn't hav
 Apple Push Service
 ==================
 
-While Cyrus supports the `Apple Push Service`_, each provider needs its own account with Apple to use the Push Service. 
+While Cyrus supports the `Apple Push Service`_, each provider needs its own account with Apple to use the Push Service.
 
 Should you wish to support the Apple Push Service, you will need to write your own notifier daemon with APS support.
 
 .. _Apple Push Service: https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#/apple_ref/doc/uid/TP40008194-CH100-SW9
-

--- a/docsrc/overview/what_is_cyrus.rst
+++ b/docsrc/overview/what_is_cyrus.rst
@@ -22,7 +22,7 @@ The core technology used by Project Cyrus is the Internet Message Access Protoco
 
 IMAP4 is an improvement over other popular Internet mail protocols when it comes to scale and availability. The Post Office Protocol (POP) family, and similar protocols, are less useful to a student-heavy user base, as they are designed to act primarily as store and forward engines. Clients contact a remote message store and download all their mail to a local message store. When the messages have been downloaded from the remote message store to the client, mobility becomes a real problem: The downloaded messages are no longer easily accessible from other clients. Even more importantly, many of the clients that students use have no permanent storage for their use, necessitating use of a remote filesystem for storage, which leads to problems with access and scale.
 
-IMAP4 is a super-set of the functionality provided by POP3--that is, all the functionality of a POP3 client can be mimicked using the IMAP4 protocol. The IMAP4 revision of the IMAP protocol adds support for disconnected operation. This will allow for a client on a notebook computer to download portions of a mail store and keep them synchronized with the mail store over time.
+IMAP4 is a super-set of the functionality provided by POP3 -- that is, all the functionality of a POP3 client can be mimicked using the IMAP4 protocol. The IMAP4 revision of the IMAP protocol adds support for disconnected operation. This will allow for a client on a notebook computer to download portions of a mail store and keep them synchronized with the mail store over time.
 
 Mime
 -----


### PR DESCRIPTION
Leave emdash alone, but genuine configure options are now
escaped.

GH #1879