### PR TITLE
Add note explaining increased memory footprint.

### DIFF
--- a/docsrc/assets/cyrus-more-memory-post23.rst
+++ b/docsrc/assets/cyrus-more-memory-post23.rst
@@ -1,0 +1,5 @@
+For those upgrading from 2.3.X; newer releases of Cyrus IMAP will use
+significantly more memory per selected mailbox.  This is not an error
+or bug; it's a feature.  The newer code is holding more data and
+metadata in memory for purposes of faster access to more of the
+mailbox.  This is not a memory leak.

--- a/docsrc/imap/download/release-notes/2.5/x/2.5.0.rst
+++ b/docsrc/imap/download/release-notes/2.5/x/2.5.0.rst
@@ -113,6 +113,11 @@ Environments that run a Cyrus IMAP Murder topology will want to upgrade
 their backends before they upgrade their frontends. See :task:`16` for
 details.
 
+Greater Memory Footprint
+------------------------
+
+.. include:: /assets/cyrus-more-memory-post23.rst
+
 .. _relnotes-2.5.0-new-features:
 
 New Features

--- a/docsrc/imap/download/upgrade.rst
+++ b/docsrc/imap/download/upgrade.rst
@@ -15,6 +15,10 @@ Upgrading to 3.0
 ..  contents:: Upgrading: an overview
     :local:
 
+.. note::
+
+    .. include:: /assets/cyrus-more-memory-post23.rst
+
 1. Preparation
 --------------
 


### PR DESCRIPTION
This is added to 2.5.0 release notes and 3.0 upgrade docs.  A new
"asset" is added.  This will require that 2.5.0 have new asset
directory, too.

Addresses issue #1937