### PR TITLE
Bug 1968 - Inhert GCOV flags for imap perl module.

### DIFF
--- a/perl/imap/Makefile.PL.in
+++ b/perl/imap/Makefile.PL.in
@@ -80,7 +80,7 @@ installcheck:
 EOT
 }
 
-WriteMakefile( 
+WriteMakefile(
     'NAME'	=> 'Cyrus::IMAP',
     'ABSTRACT'  => 'Cyrus administrative interface',
     'VERSION_FROM' => "@top_srcdir@/perl/imap/IMAP.pm", # finds $VERSION
@@ -88,11 +88,12 @@ WriteMakefile(
 		    'IMCLIENT_LIBS' => '',	# hack
 		},
     'clean'	=> {'FILES' => 'libcyrperl.a cyradm'},
+    'LD'       => $Config{ld} . ' @GCOV_LDFLAGS@',
     'OBJECT'    => 'IMAP.o',
     'MYEXTLIB'  => '@top_builddir@/perl/.libs/libcyrus.a @top_builddir@/perl/.libs/libcyrus_min.a',
-    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ @ZLIB@"],
-    'DEFINE'	=> '-DPERL_POLLUTE',    # e.g., '-DHAVE_SOMETHING' 
-    'INC'	=> "-I@top_srcdir@ -I@top_srcdir@/com_err/et @SASLFLAGS@ @SSL_CPPFLAGS@ -I@top_srcdir@/perl/imap", 
+    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ @ZLIB@, @GCOV_LIBS@"],
+    'DEFINE'	=> '-DPERL_POLLUTE',    # e.g., '-DHAVE_SOMETHING'
+    'INC'	=> "-I@top_srcdir@ -I@top_srcdir@/com_err/et @SASLFLAGS@ @SSL_CPPFLAGS@ @GCOV_CFLAGS@ -I@top_srcdir@/perl/imap",
     'EXE_FILES' => [cyradm],
     # This is a disgusting hack to effectively disable the stupid
     # behaviour of the generated Makefile which moves itself aside


### PR DESCRIPTION
Not inheriting the GCOV_LIBS and linker flags, results in undefined
`gcov_*` references in `IMAP.so`

Fixes #1968.