### PR TITLE
Remove references to `librt`.

### DIFF
--- a/libcyrus.pc.in
+++ b/libcyrus.pc.in
@@ -5,4 +5,4 @@ Cflags: @SSL_CPPFLAGS@ @SASLFLAGS@
 Version: @PACKAGE_VERSION@
 Requires.private: libcyrus_min = @PACKAGE_VERSION@
 Libs: -lcyrus
-Libs.private: @LIB_RT@ @LIB_SASL@ @SSL_LIBS@
+Libs.private: @LIB_SASL@ @SSL_LIBS@

--- a/perl/imap/Makefile.PL.in
+++ b/perl/imap/Makefile.PL.in
@@ -91,7 +91,7 @@ WriteMakefile(
     'LD'       => $Config{ld} . ' @GCOV_LDFLAGS@',
     'OBJECT'    => 'IMAP.o',
     'MYEXTLIB'  => '@top_builddir@/perl/.libs/libcyrus.a @top_builddir@/perl/.libs/libcyrus_min.a',
-    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ @ZLIB@, @GCOV_LIBS@"],
+    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @ZLIB@ @GCOV_LIBS@"],
     'DEFINE'	=> '-DPERL_POLLUTE',    # e.g., '-DHAVE_SOMETHING'
     'INC'	=> "-I@top_srcdir@ -I@top_srcdir@/com_err/et @SASLFLAGS@ @SSL_CPPFLAGS@ @GCOV_CFLAGS@ -I@top_srcdir@/perl/imap",
     'EXE_FILES' => [cyradm],

--- a/perl/sieve/managesieve/Makefile.PL.in
+++ b/perl/sieve/managesieve/Makefile.PL.in
@@ -69,7 +69,7 @@ WriteMakefile(
     'ABSTRACT'  => 'Cyrus Sieve management interface',
     'VERSION_FROM' => "@top_srcdir@/perl/sieve/managesieve/managesieve.pm", # finds $VERSION
     'MYEXTLIB'  => '../lib/.libs/libisieve.a @top_builddir@/perl/.libs/libcyrus.a @top_builddir@/perl/.libs/libcyrus_min.a',
-    'LIBS'	=> ["$LIB_SASL @SSL_LIBS@ @LIB_RT@ @LIB_UUID@ @ZLIB@"],
+    'LIBS'	=> ["$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @ZLIB@"],
     'CCFLAGS'	=> '@GCOV_CFLAGS@',
     'DEFINE'	=> '-DPERL_POLLUTE',     # e.g., '-DHAVE_SOMETHING' 
     'INC'	=> "-I@top_srcdir@/lib -I@top_srcdir@/perl/sieve -I@top_srcdir@/perl/sieve/lib @SASLFLAGS@ @SSL_CPPFLAGS@",


### PR DESCRIPTION
We don't seem to use `librt` anymore, so removing references to it from
the repo.