### PR TITLE
jmap_mail.c: Add missing format specifier.

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4728,8 +4728,10 @@ static int writeattach(jmap_req_t *req, json_t *att, const char *boundary, FILE 
     else {
         content_type = xstrdup("message/rfc822");
     }
-    fprintf(out, "Content-Type: ");
-    fprintf(out, content_type);
+
+    fwrite("Content-Type: ", 1, strlen("Content-Type: "), out);
+    fwrite(content_type, 1, strlen(content_type), out);
+
     if (name) {
         /* RFC 2045 dropped the "name" parameter value for Content-Type,
          * but the quasi-standard is to QP-encode any attachment name in
@@ -4757,7 +4759,7 @@ static int writeattach(jmap_req_t *req, json_t *att, const char *boundary, FILE 
             free(param_name);
         }
     }
-    fprintf(out, "\r\n");
+    fputs("\r\n", out);
     free(content_type);
 
     /* Content-ID */
@@ -4766,7 +4768,8 @@ static int writeattach(jmap_req_t *req, json_t *att, const char *boundary, FILE 
     }
 
     /* Content-Disposition */
-    fprintf(out, "Content-Disposition: attachment");
+    fwrite("Content-Disposition: attachment", 1,
+           strlen("Content-Disposition: attachment"), out);
     if (name) {
         /* XXX break excessively long parameter values */
         if (!name_is_ascii) {
@@ -4777,7 +4780,7 @@ static int writeattach(jmap_req_t *req, json_t *att, const char *boundary, FILE 
             writeparam(out, "filename", name, 1, 0);
         }
     }
-    fprintf(out, "\r\n");
+    fputs("\r\n", out);
 
     /* Raw file */
     if (!part) {


### PR DESCRIPTION
The `fprintf()` is missing a format specifier. This patch makes sure we
add one with CRLF.