### PR TITLE
Show titles against badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-[![Build Status:master](https://api.travis-ci.org/cyrusimap/cyrus-imapd.svg?branch=master)](https://travis-ci.org/cyrusimap/cyrus-imapd)
-[![Build Status:3.x](https://api.travis-ci.org/cyrusimap/cyrus-imapd.svg?branch=cyrus-imapd-3.0)](https://travis-ci.org/cyrusimap/cyrus-imapd)
+<sup>master: </sup>[![Build Status:master](https://api.travis-ci.org/cyrusimap/cyrus-imapd.svg?branch=master)](https://travis-ci.org/cyrusimap/cyrus-imapd)
+<sup> stable(3.0): </sup>[![Build Status:3.x](https://api.travis-ci.org/cyrusimap/cyrus-imapd.svg?branch=cyrus-imapd-3.0)](https://travis-ci.org/cyrusimap/cyrus-imapd)
 [![IRC](https://img.shields.io/badge/IRC-%23cyrus-1e72ff.svg?style=flat)](http://webchat.freenode.net/?channels=cyrus)
 
+-----
 
 Welcome
 =======


### PR DESCRIPTION
Since we have build status for 2 branches, master and stable, add a
title against the badge to clarify the branch the badge is displaying
status of.