### PR TITLE
[Docs] Add Travis build status marker to sidebar

### DIFF
--- a/docsrc/_static/cyrus.css
+++ b/docsrc/_static/cyrus.css
@@ -256,3 +256,14 @@ h4 {
 .rst-content .sidebar p {
     line-height: 18px;
 }
+
+div.buildstatus {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    font-size: 80%;
+}
+
+div.buildstatus a:visited {
+    color: white;
+}

--- a/docsrc/_templates/layout.html
+++ b/docsrc/_templates/layout.html
@@ -1,8 +1,8 @@
 {% extends "!layout.html" %}
 {% set css_files = css_files + [ '_static/cyrus.css' ] %}
 
-
 {% block header %}
+
 <div class="pageheader">
   <ul>
     <li><a href="{{ pathto('index') }}">Home</a></li>

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -144,7 +144,7 @@ html_context = {
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = { 'travis_version': 'master'}
 
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -185,7 +185,7 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {'**' : ['localtoc.html', 'searchbox.html']}
+html_sidebars = {'**' : ['localtoc.html', 'searchbox.html', 'buildstatus.html']}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docsrc/exts/themes/cyrus/buildstatus.html
+++ b/docsrc/exts/themes/cyrus/buildstatus.html
@@ -1,0 +1,5 @@
+{%- if builder != 'singlehtml' %}
+<div class="buildstatus">
+    <a href="https://travis-ci.org/cyrusimap/cyrus-imapd" target="_blank">{{ theme_travis_version }}: <img src="https://travis-ci.org/cyrusimap/cyrus-imapd.svg?branch={{ theme_travis_version }}"></a>
+</div>
+{%- endif %}

--- a/docsrc/exts/themes/cyrus/layout.html
+++ b/docsrc/exts/themes/cyrus/layout.html
@@ -82,7 +82,7 @@
 
 <body class="wy-body-for-nav" role="document">
 
-  
+
   {% block header %}
   {% endblock %}
 
@@ -97,7 +97,7 @@
  {#       {% if logo and theme_logo_only %} #}
           <a href="{{ pathto(master_doc) }}">
  {#       {% else %}
-          <a href="{{ pathto(master_doc) }}" class="icon icon-home"> {{ project }} 
+          <a href="{{ pathto(master_doc) }}" class="icon icon-home"> {{ project }}
         {% endif %} #}
 
   {#      {% if logo %} #}
@@ -122,6 +122,7 @@
           {% endif %}
         {% endblock %}
       </div>
+        {% include "buildstatus.html" %}
       &nbsp;
     </nav>
 
@@ -137,7 +138,7 @@
       {# PAGE CONTENT #}
       <div class="wy-nav-content">
         <div class="rst-content">
-          
+
           {% include "breadcrumbs.html" %}
           <div role="main" class="document">
             {% block body %}{% endblock %}

--- a/docsrc/exts/themes/cyrus/theme.conf
+++ b/docsrc/exts/themes/cyrus/theme.conf
@@ -4,6 +4,7 @@ stylesheet = css/theme.css
 
 [options]
 typekit_id = hiw1hhg
-analytics_id = 
+analytics_id =
 sticky_navigation = false
 logo_only = true
+travis_version = master

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -13,7 +13,8 @@ What is Cyrus IMAP?
 
 Cyrus IMAP is an email, contacts and calendar server.
 
-This is the documentation for the **development** version |imap_latest_development_version| of Cyrus IMAP.
+This is the documentation for the **development** version
+|imap_latest_development_version| of Cyrus IMAP.
 
 Documentation for the latest stable version |imap_current_stable_version| is at :cyrus-stable:`/`.
 
@@ -47,7 +48,6 @@ This is the highlight reel of Cyrus's full list of :ref:`features <imap-features
     operations
     developers
     support
-
 ..
 
     OLD INDEX


### PR DESCRIPTION
Put travis-version in conf.py for travis builds.

Requires conf.py be kept updated for each branch, but the templates can stay templated.