### PR TITLE
[Bug 1988] Add per folder annotation for cyr_expire

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1967,6 +1967,24 @@ static const annotate_entrydesc_t mailbox_builtin_entries[] =
         /*set*/NULL,
         NULL
     },{
+        IMAP_ANNOT_NS "archive",
+        ATTRIB_TYPE_UINT,
+        BACKEND_ONLY,
+        ATTRIB_VALUE_SHARED,
+        ACL_ADMIN,
+        annotation_get_fromdb,
+        annotation_set_todb,
+        NULL
+    },{
+        IMAP_ANNOT_NS "delete",
+        ATTRIB_TYPE_UINT,
+        BACKEND_ONLY,
+        ATTRIB_VALUE_SHARED,
+        ACL_ADMIN,
+        annotation_get_fromdb,
+        annotation_set_todb,
+        NULL
+    },{
         IMAP_ANNOT_NS "duplicatedeliver",
         ATTRIB_TYPE_BOOLEAN,
         BACKEND_ONLY,


### PR DESCRIPTION
`cyr_expire` already has annotation for `expire`, this patch adds support for
`archive` and `delete` operations.