### PR TITLE
[Docs] Generate google sitemap.xml

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -46,6 +46,13 @@ extensions.append('sphinxlocal.builders.gitstamp')
 
 gitstamp_fmt = "%b %d %Y"
 
+extensions.append('sphinxlocal.sitemap')
+
+# We publish master branch at /dev
+# Other branches are available at multiple locations (3.0 is at 3.0 and stable and /).
+# Supply all webroots that this set of docs is available at.
+sitemap_website = ["https://www.cyrusimap.org/dev/"]
+
 intersphinx_mapping = {'cyrussasl': ('https://www.cyrusimap.org/sasl', None)}
 
 mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js'

--- a/docsrc/exts/sphinxlocal/sitemap.py
+++ b/docsrc/exts/sphinxlocal/sitemap.py
@@ -1,0 +1,71 @@
+"""
+sphinxlocal.sitemap
+~~~~~~~~~~~~~~~~~~~
+Generate google sitemap if doing an html output build.
+Placed in build/html/sitemap.xml
+
+Use sitemap_website to specify the webroot where the files will be
+served.
+
+:version: 0.1
+:author: Nicola Nye <nicola@fastmailteam.com>
+
+:copyright: Copyright 2007-2016 by the Cyrus team.
+:license: BSD, see LICENSE for details.
+"""
+
+import os
+import xml.etree.ElementTree
+from sphinx import errors
+
+namespace = "http://www.sitemaps.org/schemas/sitemap/0.9"
+
+def generate_sitemap(app, exception):
+    if exception:
+        return
+
+    urls = []
+    website = app.config.sitemap_website
+    if website is None:
+        raise errors.ExtensionError("Cannot generate sitemap. Set 'sitemap_website' in conf.py with website hostname")
+
+    env = app.builder.env
+    for page in env.found_docs:
+        for site in website:
+            url = {}
+            url["loc"] = "{}{}.html".format(site, page)
+
+            # If we can deduce last modified time from gitstamp,
+            # then we can publish this here.
+            # url["lastmod"] = ...
+
+            urls.append(url)
+
+    urlset = xml.etree.ElementTree.Element("urlset", {"xmlns": namespace})
+    for url in urls:
+        url_element = xml.etree.ElementTree.SubElement(urlset, "url")
+
+        loc = xml.etree.ElementTree.SubElement(url_element, "loc")
+        loc.text = url["loc"]
+
+        if "lastmod" in url:
+            lastmod = xml.etree.ElementTree.SubElement(url_element, "lastmod")
+            lastmod.text = url["lastmod"]
+
+
+    tree = xml.etree.ElementTree.ElementTree(urlset)
+    tree.write(os.path.join(app.outdir, "sitemap.xml"), "UTF-8", True)
+
+# Only add the sitemap generator if we're generating html
+def what_build_am_i(app):
+    if (app.builder.format != 'html'):
+        return;
+
+    app.connect("build-finished", generate_sitemap)
+
+# We can't immediately add the generator: we need to wait until we
+# know what the build output format is. Don't want to output for anything
+# other than html output
+def setup(app):
+    app.add_config_value("sitemap_website", None, '')
+    app.connect('builder-inited', what_build_am_i)


### PR DESCRIPTION
Add new extension sphinxlocal.sitemap to conf.py
Add new config value sitemap_website to conf.py

Produces sitemap.xml in build/<target>/
where <target> is either man or html, depending on output format
being generated

[Docs] Sitemap generator

Only generate if output is html.
Support multiple webroots.