### PR TITLE
[lib] RFC5322 date time parser.

### DIFF
--- a/cunit/times.testc
+++ b/cunit/times.testc
@@ -442,4 +442,248 @@ test_leapyear_rfc822(void)
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, FEB2004_TIMET);
 }
+
+static void
+test_rfc5322(void)
+{
+    time_t t;
+    int r;
+
+    /* 1 Jan 1970 */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Thu, 01 Jan 1970 00:00:00  ", &t);
+    CU_ASSERT_EQUAL(r, 27);
+    CU_ASSERT_EQUAL(t, 0);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Thu, 01 Jan 1970 01:00:00 +0100", &t);
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 0);
+
+    /* Zero Hour */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29 -0500", &t); /* NYC */
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 2189);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322(" 1-JAN-1970 11:36:29 +1100", &t); /* MEL */
+    CU_ASSERT_EQUAL(r, 26);
+    CU_ASSERT_EQUAL(t, 2189);
+
+    /* Pre Jan 1 1970 */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29", &t);
+    CU_ASSERT_EQUAL(r, 25);
+    CU_ASSERT_EQUAL(t, -15811);
+
+    /* Well-formed full RFC5322 format with 2-digit day
+     * "dd-mmm-yyyy HH:MM:SS zzzzz" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-2010 03:19:52 +1100", &t);
+    CU_ASSERT_EQUAL(r, 26);
+    CU_ASSERT_EQUAL(t, 1287073192);
+
+    /* Well-formed full RFC5322 format with 1-digit day
+     * " d-mmm-yyyy HH:MM:SS zzzzz" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322(" 5-Oct-2010 03:19:52 +1100", &t);
+    CU_ASSERT_EQUAL(r, 26);
+    CU_ASSERT_EQUAL(t, 1286209192);
+
+    /* dd mmm yyyy HH:MM:SS zzzzz */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("20 Jun 2017 00:49:38 +0000", &t);
+    CU_ASSERT_EQUAL(r, 26);
+    CU_ASSERT_EQUAL(t, 1497919778);
+
+    /* dow, dd mmm yyyy HH:MM:SS zzzzz */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Tue, 20 Jun 2017 00:49:38 +0000", &t);
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 1497919778);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Tue, 20 Jun 2017 00:49:38 +0200", &t);
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 1497912578);
+
+    /* Timezone tests - same time different timezones*/
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("FRI, 26 NOV 2010 14:22:02 +1100", &t); /* MEL */
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 1290741722);
+
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("FRI, 26 NOV 2010 03:22:02 +0000", &t); /* UTC */
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 1290741722);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("THU, 25 NOV 2010 22:22:02 -0500", &t); /* NYC */
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 1290741722);
+
+
+    /* Time with period as separator */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322(" 3-jan-2009 04.05    -0400", &t);
+    CU_ASSERT_EQUAL(r, 26);
+    CU_ASSERT_EQUAL(t, 1230969900);
+
+    /* Year 9999 */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Fri, 31-Dec-9999 23:59:59 +0000", &t);
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 253402300799);
+
+    /* Year 1 - This will fail*/
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("1 Jan 1 00:00:00 +0000", &t);
+    CU_ASSERT_EQUAL(r, -1);
+
+    /* 5 digit year */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Sat, 1 Jan 10000 00:00:00", &t);
+    CU_ASSERT_EQUAL(r, 25);
+    CU_ASSERT_EQUAL(t, 253402300800);
+
+    /* Invalid date */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("foobar, 2 +5000", &t);
+    CU_ASSERT_EQUAL(r, -1);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Sun, Hello, World!", &t);
+    CU_ASSERT_EQUAL(r, -1);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("-1000", &t);
+    CU_ASSERT_EQUAL(r, -1);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("Thu, 06 Jul 2017", &t);
+    CU_ASSERT_EQUAL(r, -1);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("This is some random text", &t);
+    CU_ASSERT_EQUAL(r, -1);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("0100200200300400502989587984579845", &t);
+    CU_ASSERT_EQUAL(r, -1);
+
+}
+
+static void
+test_military_timezones_using_rfc5322(void)
+{
+    time_t t;
+    int r;
+    time_t zulu = 813727192;
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * uppercase 1-char timezone = UTC, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-Z", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * lowercase 1-char timezone = UTC, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-z", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * uppercase 1-char timezone = +0100, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-A", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu-1*3600);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * uppercase 1-char timezone = +0200, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-B", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu-2*3600);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * uppercase 1-char timezone = +0900, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-I", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu-9*3600);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * erroneous uppercase 1-char timezone, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-J", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, 813727192);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * uppercase 1-char timezone = +1000, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-K", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu-10*3600);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * 1-char timezone = +1200, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-M", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu-12*3600);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * uppercase 1-char timezone = -0100, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-N", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu+1*3600);
+
+    /* Well-formed legacy format with 2-digit day, 2-digit year,
+     * 1-char timezone = -1200, "dd-mmm-yy HH:MM:SS-z" */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322("15-Oct-95 03:19:52-Y", &t);
+    CU_ASSERT_EQUAL(r, 20);
+    CU_ASSERT_EQUAL(t, zulu+12*3600);
+}
+
+static void
+test_leapyear_rfc5322(void)
+{
+    /* 2000 is a leapyear */
+    static const char FEB2000_STR[] = "Tue, 29 Feb 2000 11:22:33 +1100";
+    static const time_t FEB2000_TIMET = 951783753;
+    /* 2001 is not a leapyear */
+    static const char FEB2001_STR[] = "Thu, 29 Feb 2001 11:22:33 +1100";
+    /* 2004 is a leapyear */
+    static const char FEB2004_STR[] = "Sun, 29 Feb 2004 11:22:33 +1100";
+    static const time_t FEB2004_TIMET = 1078014153;
+    time_t t;
+    int r;
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322(FEB2000_STR, &t);
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, FEB2000_TIMET);
+
+    /* This will be converted to: Thu Mar  1 11:22:33 2001 */
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322(FEB2001_STR, &t);
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, 983406153);
+
+    t = UNINIT_TIMET;
+    r = time_from_rfc5322(FEB2004_STR, &t);
+    CU_ASSERT_EQUAL(r, 31);
+    CU_ASSERT_EQUAL(t, FEB2004_TIMET);
+}
+
+
 /* vim: set ft=c: */

--- a/lib/times.c
+++ b/lib/times.c
@@ -61,6 +61,45 @@ static const char * const wday[7] = {
 };
 
 
+#define EOB (-1)            /* End Of Buffer */
+
+static const char rfc5322_special[256] = {
+    [' ']  = 1,
+    ['\t'] = 1,
+    ['\r'] = 1,
+    ['\n'] = 1,
+};
+
+static const char rfc5322_separators[256] = {
+    [' ']  = 1,
+    [',']  = 1,
+    ['-']  = 1,
+    ['+']  = 1,
+    [':']  = 1,
+};
+
+enum {
+    Alpha = 1,              /* Alphabet */
+    UAlpha = 2,             /* Uppercase Alphabet */
+    LAlpha = 4,             /* Lowercase Alphabet */
+    Digit = 8,              /* Digits/Numbers */
+    TZSign = 16,            /* Timzone sign +/- */
+};
+
+static const long rfc5322_usascii_charset[257] = {
+    ['0' + 1 ... '9' + 1] = Digit,
+    ['A' + 1 ... 'Z' + 1] = Alpha | UAlpha,
+    ['a' + 1 ... 'z' + 1] = Alpha | LAlpha,
+    ['+' + 1] = TZSign,
+    ['-' + 1] = TZSign
+};
+
+struct rfc5322dtbuf {
+    const char *str;
+    int len;
+    int offset;
+};
+
 static int monthdays(int year/*since 1900*/, int month/*0-based*/)
 {
     int leapday;
@@ -74,7 +113,6 @@ static int monthdays(int year/*since 1900*/, int month/*0-based*/)
     return mdays[month] + leapday;
 #undef isleap
 }
-
 
 /* 'buf' must be at least 80 characters */
 EXPORTED int time_to_rfc822(time_t t, char *buf, size_t len)
@@ -854,3 +892,446 @@ baddate:
     return -1;
 }
 
+/**
+ ** Support functions for time_from_rfc5322()
+ **/
+static inline int get_next_char(struct rfc5322dtbuf *buf)
+{
+    int c;
+
+    if (buf->offset < buf->len) {
+        buf->offset++;
+        c = buf->str[buf->offset];
+        return c;
+    }
+
+    return EOB;
+}
+
+static inline int get_current_char(struct rfc5322dtbuf *buf)
+{
+    int offset = buf->offset;
+
+    if (offset < buf->len)
+        return buf->str[offset];
+    else
+        return EOB;
+}
+
+static inline int get_previous_char(struct rfc5322dtbuf *buf)
+{
+    int offset = buf->offset;
+
+    offset--;
+    if (offset >= 0)
+        return buf->str[offset];
+    else
+        return EOB;
+}
+
+/*
+  TODO: Support comments as per RFC.
+*/
+static int skip_ws(struct rfc5322dtbuf *buf, int skipcomment)
+{
+    int c = buf->str[buf->offset];
+
+    while (c != EOB) {
+        if (rfc5322_special[c]) {
+            c = get_next_char(buf);
+            continue;
+        }
+
+        break;
+    }
+
+    return 1;
+}
+
+static int get_next_token(struct rfc5322dtbuf *buf, char **str, int *len)
+{
+    int c, ret = 1;
+    long ch;
+    static char cache[RFC5322_DATETIME_MAX];
+
+    memset(cache, 1, RFC5322_DATETIME_MAX);
+
+    c = get_current_char(buf);
+    if (c == EOB) {
+        ret = 0;
+        goto failed;
+    }
+
+    *len = 0;
+    for (;;) {
+        if (rfc5322_special[c] || rfc5322_separators[c])
+            break;
+
+        ch = rfc5322_usascii_charset[c + 1];
+        if (!(ch & (Alpha | Digit)))
+            break;
+
+        if (*len >= RFC5322_DATETIME_MAX)
+            break;
+
+        cache[*len] = c;
+        *len += 1;
+
+        c = get_next_char(buf);
+        if (c == EOB) {
+            ret = 0;
+            break;
+        }
+    }
+
+ failed:
+    *str = cache;
+
+    return ret;
+}
+
+static inline int to_int(char *str, int len)
+{
+    int i, num = 0;
+
+    for (i = 0; i < len; i++) {
+        if (rfc5322_usascii_charset[str[i] + 1] & Digit)
+            num = num * 10 + (str[i] - '0');
+        else {
+            num = -9999;
+            break;
+        }
+    }
+
+    return num;
+}
+
+static inline int to_upper_str_in_place(char **str, int len)
+{
+    int i;
+
+    for (i = 0; i < len; i++) {
+        int c = str[0][i];
+        if (rfc5322_usascii_charset[c + 1] & LAlpha)
+            str[0][i] = str[0][i] - 32;
+    }
+
+    return 1;
+}
+
+static inline int to_upper(char ch)
+{
+    if (rfc5322_usascii_charset[ch + 1] & LAlpha)
+        ch =  ch - 32;
+
+    return ch;
+}
+
+static inline int to_lower(char ch)
+{
+    if (rfc5322_usascii_charset[ch + 1] & UAlpha)
+        ch = ch + 32;
+
+    return ch;
+}
+
+static int compute_tzoffset(char *str, int len, int sign)
+{
+    int offset = 0;
+
+    if (len == 1) {         /* Military timezone */
+        int ch;
+        ch = to_upper(str[0]);
+        if (ch < 'J')
+            return (str[0] - 'A' + 1) * 60;
+        if (ch == 'J')
+            return 0;
+        if (ch <= 'M')
+            return (str[0] - 'A') * 60;;
+        if (ch < 'Z')
+            return ('M' - str[0]) * 60;
+
+        return 0;
+    }
+
+    if (len == 2 &&
+        to_upper(str[0]) == 'U' &&
+        to_upper(str[1]) == 'T') {         /* Universal Time zone (UT) */
+        return 0;
+    }
+
+    if (len == 3) {
+        char *p;
+
+        if (to_upper(str[2]) != 'T')
+            return 0;
+
+        p = strchr("AECMPYHB", to_upper(str[0]));
+        if (!p)
+            return 0;
+        offset = (strlen(p) - 12) *  60;
+
+        if (to_upper(str[1]) == 'D')
+            return offset + 60;
+        if (to_upper(str[1]) == 'S')
+            return offset;
+    }
+
+    if (len == 4) {         /* The number timezone offset */
+        int i;
+
+        for (i = 0; i < len; i++) {
+            if (!(rfc5322_usascii_charset[str[i] + 1] & Digit))
+                return 0;
+        }
+
+        offset = ((str[0] - '0') * 10 + (str[1] - '0')) * 60 +
+            (str[2] - '0') * 10 +
+            (str[3] - '0');
+
+        return (sign == '+') ? offset : -offset;
+    }
+
+    return 0;
+}
+
+/*
+ *  Date Format as per https://tools.ietf.org/html/rfc5322#section-3.3:
+ *
+ * date-time = [ ([FWS] day-name) "," ]
+ *             ([FWS] 1*2DIGIT FWS)
+ *             month
+ *             (FWS 4*DIGIT FWS)
+ *             2DIGIT ":" 2DIGIT [ ":" 2DIGIT ]
+ *             (FWS ( "+" / "-" ) 4DIGIT)
+ *             [CFWS]
+ *
+ * day-name = "Mon" / "Tue" / "Wed" / "Thu" / "Fri" / "Sat" / "Sun"
+ * month = "Jan" / "Feb" / "Mar" / "Apr" / "May" / "Jun" / "Jul" / "Aug" /
+ *         "Sep" / "Oct" / "Nov" / "Dec"
+ *
+ */
+
+static int tokenise_str_and_create_tm(struct rfc5322dtbuf *buf,
+                                      struct tm *tm,
+                                      int *tz_offset)
+{
+    long ch;
+    int c, i, len;
+    char *str_token = NULL;
+
+    /* Skip leading WS, if any */
+    skip_ws(buf, 0);
+
+    c = get_current_char(buf);
+    if (c == EOB)
+        goto failed;
+
+    ch = rfc5322_usascii_charset[c + 1];
+    if (ch & Alpha) {       /* Most likely a weekday at the start. */
+        if (!get_next_token(buf, &str_token, &len))
+            goto failed;
+
+        /* We might have a weekday token here, which we should skip*/
+        if (len != 3)
+            goto failed;
+
+        /* The weekday is foll wed by a ',', consume that. */
+        if (get_current_char(buf) == ',')
+            get_next_char(buf);
+        else
+            goto failed;
+
+        skip_ws(buf, 0);
+    }
+
+    /** DATE **/
+    /* date (1 or 2 digits) */
+    if (!get_next_token(buf, &str_token, &len))
+        goto failed;
+
+    if (len < 1 || len > 2 ||
+        !(rfc5322_usascii_charset[str_token[0] + 1] & Digit))
+        goto failed;
+
+    tm->tm_mday = to_int(str_token, len);
+    if (tm->tm_mday == -9999)
+        goto failed;
+
+    /* month name */
+    get_next_char(buf);     /* Consume a character, either a '-' or ' ' */
+
+    if (!get_next_token(buf, &str_token, &len) ||
+        len != 3 ||
+        !(rfc5322_usascii_charset[str_token[0] + 1] & Alpha))
+        goto failed;
+
+    str_token[0] = to_upper(str_token[0]);
+    str_token[1] = to_lower(str_token[1]);
+    str_token[2] = to_lower(str_token[2]);
+    for (i = 0; i < 12; i++) {
+        if (memcmp(monthname[i], str_token, 3) == 0) {
+            tm->tm_mon = i;
+            break;
+        }
+    }
+    if (i == 12)
+        goto failed;
+
+    /* year 2, 4 or >4 digits */
+    get_next_char(buf);     /* Consume a character, either a '-' or ' ' */
+
+    if (!get_next_token(buf, &str_token, &len))
+        goto failed;
+
+    tm->tm_year = to_int(str_token, len);
+    if (tm->tm_year == -9999)
+        goto failed;
+
+    if (len == 2) {
+        /* A 2 digit year */
+        if (tm->tm_year < 70)
+            tm->tm_year += 100;
+    } else {
+        if (tm->tm_year < 1900)
+            goto failed;
+        tm->tm_year -= 1900;
+    }
+
+    /** TIME **/
+    skip_ws(buf, 0);
+    /* hour */
+    if (!get_next_token(buf, &str_token, &len))
+        goto failed;
+
+    if (len < 1 || len > 2 ||
+        !(rfc5322_usascii_charset[str_token[0] + 1] & Digit))
+        goto failed;
+
+    tm->tm_hour = to_int(str_token, len);
+    if (tm->tm_hour == -9999)
+        goto failed;
+
+    /* minutes */
+    if (get_current_char(buf) == ':' ||
+        get_current_char(buf) == '.')
+        get_next_char(buf); /* Consume ':'/'.' */
+    else
+        goto failed;    /* Something is broken */
+
+    if (!get_next_token(buf, &str_token, &len))
+        goto failed;
+
+    if (len < 1 || len > 2 ||
+        !(rfc5322_usascii_charset[str_token[0] + 1] & Digit))
+        goto failed;
+
+    tm->tm_min = to_int(str_token, len);
+    if (tm->tm_min == -9999)
+        goto failed;
+
+
+    /* seconds[optional] */
+    if (get_current_char(buf) == ':' ||
+        get_current_char(buf) == '.') {
+        get_next_char(buf); /* Consume ':'/'.' */
+
+        if (!get_next_token(buf, &str_token, &len))
+            goto failed;
+
+        if (len < 1 || len > 2 ||
+            !(rfc5322_usascii_charset[str_token[0] + 1] & Digit))
+            goto failed;
+
+        tm->tm_sec = to_int(str_token, len);
+        if (tm->tm_sec == -9999)
+            goto failed;
+
+    }
+
+    /* timezone */
+    skip_ws(buf, 0);
+    c = get_current_char(buf); /* the '+' or '-' in the timezone */
+    get_next_char(buf);        /* consume '+' or '-' */
+
+    if (!get_next_token(buf, &str_token, &len)) {
+        *tz_offset = 0;
+    } else {
+        *tz_offset = compute_tzoffset(str_token, len, c);
+    }
+
+    /* dst */
+    tm->tm_isdst = -1;
+    return buf->offset;
+
+ failed:
+    return -1;
+}
+
+
+/*
+ * time_from_rfc5322()
+ * This is meant to be the replacement function for time_from_rfc822() and
+ * time_from_rfc3501() functions.
+ * Returns: Number of characters consumed from @s on success,
+ *          or -1 on error.
+ */
+EXPORTED int time_from_rfc5322(const char *s, time_t *date)
+{
+    struct rfc5322dtbuf buf;
+    struct tm tm;
+    time_t tmp_gmtime;
+    int tzone_offset = 0;
+
+    if (!s)
+        goto baddate;
+
+    memset(&tm, 0, sizeof(struct tm));
+    *date = 0;
+
+    buf.str = s;
+    buf.len = strlen(s);
+    buf.offset = 0;
+
+    if (tokenise_str_and_create_tm(&buf, &tm, &tzone_offset) == -1)
+        goto baddate;
+
+    tmp_gmtime = mkgmtime(&tm);
+    if (tmp_gmtime == -1)
+        goto baddate;
+
+    *date = tmp_gmtime - tzone_offset * 60;
+
+    return buf.offset;
+
+ baddate:
+    return -1;
+}
+
+/*
+ * time_to_rfc5322()
+ * Convert a time_t date to an IMAP-style date.
+ * `buf` which is the buffer this function is going to write into, needs to
+ * be atleast RFC5322_DATETIME_MAX (32), if not more.
+ *
+ */
+EXPORTED int time_to_rfc5322(time_t date, char *buf, size_t len)
+{
+    struct tm *tm = localtime(&date);
+    long gmtoff = gmtoff_of(tm, date);
+    int gmtnegative = 0;
+
+    if (gmtoff < 0) {
+        gmtoff = -gmtoff;
+        gmtnegative = 1;
+    }
+
+    gmtoff /= 60;
+
+    return snprintf(buf, len,
+             "%s, %02d %s %04d %02d:%02d:%02d %c%02lu%02lu",
+             wday[tm->tm_wday],
+             tm->tm_mday, monthname[tm->tm_mon], tm->tm_year + 1900,
+             tm->tm_hour, tm->tm_min, tm->tm_sec,
+             gmtnegative ? '-' : '+', gmtoff/60, gmtoff%60);
+}

--- a/lib/times.h
+++ b/lib/times.h
@@ -85,4 +85,11 @@ int time_from_rfc3501(const char *s, time_t *tp);
 #define RFC3339_DATETIME_MAX 21
 int time_to_rfc3339(time_t t, char *buf, size_t len);
 
+/*
+ * RFC5322 datetime format
+ */
+#define RFC5322_DATETIME_MAX 32 /* 32 because we support 5 digit year format */
+int time_to_rfc5322(time_t date, char *buf, size_t len);
+int time_from_rfc5322(const char *s, time_t *date);
+
 #endif /* __CYRUS__TIME_H__ */


### PR DESCRIPTION
This commit adds support for RFC5322 date time parsing as per this[1].

We should eventually nuke the `time_from_rfc822()` and `time_from_rfc3501()`
functions.

[1] - https://tools.ietf.org/html/rfc5322#section-3.3