### PR TITLE
[lib] Fix warnings in times.c

### DIFF
--- a/lib/times.c
+++ b/lib/times.c
@@ -932,7 +932,8 @@ static inline int get_previous_char(struct rfc5322dtbuf *buf)
 /*
   TODO: Support comments as per RFC.
 */
-static int skip_ws(struct rfc5322dtbuf *buf, int skipcomment)
+static int skip_ws(struct rfc5322dtbuf *buf,
+                   int skipcomment __attribute__((unused)))
 {
     int c = buf->str[buf->offset];
 


### PR DESCRIPTION
A previous commit[1] had a unused varilable in the function `skip_ws`. I'm
now tying it to `__attribute__((unused))`.

[1] - 55cdf51025aa94875c729fb380a06c3e44643408