### PR TITLE
Turn off noise about annotation lookups in cyr_expire.

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -336,7 +336,7 @@ static int get_annotation_value(const char *mboxname,
     buf_free(&attrib);
     free(buf);
 
-    syslog(LOG_NOTICE, "get_annotation_value: ret(%d):secondsp(%d)\n", ret, *secondsp);
+    syslog(LOG_DEBUG, "get_annotation_value: ret(%d):secondsp(%d)\n", ret, *secondsp);
     return ret;
 }
 


### PR DESCRIPTION
The commit[1] had a stray LOG_NOTICE instead of LOG_DEBUG resulting in a
lot of noise in the syslogs. This patch fixes that.

Thanks to Ellie and Bron for noticing this.

[1] 757e6cb3a20.