### PR TITLE
[Bug 2044] Date header parsing compliance with RFC5322

### DIFF
--- a/cunit/times.testc
+++ b/cunit/times.testc
@@ -451,127 +451,127 @@ test_rfc5322(void)
 
     /* 1 Jan 1970 */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Thu, 01 Jan 1970 00:00:00  ", &t);
+    r = time_from_rfc5322("Thu, 01 Jan 1970 00:00:00  ", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 27);
     CU_ASSERT_EQUAL(t, 0);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Thu, 01 Jan 1970 01:00:00 +0100", &t);
+    r = time_from_rfc5322("Thu, 01 Jan 1970 01:00:00 +0100", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 0);
 
     /* Zero Hour */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29 -0500", &t); /* NYC */
+    r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29 -0500", &t, DATETIME_FULL); /* NYC */
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 2189);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322(" 1-JAN-1970 11:36:29 +1100", &t); /* MEL */
+    r = time_from_rfc5322(" 1-JAN-1970 11:36:29 +1100", &t, DATETIME_FULL); /* MEL */
     CU_ASSERT_EQUAL(r, 26);
     CU_ASSERT_EQUAL(t, 2189);
 
     /* Pre Jan 1 1970 */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29", &t);
+    r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 25);
     CU_ASSERT_EQUAL(t, -15811);
 
     /* Well-formed full RFC5322 format with 2-digit day
      * "dd-mmm-yyyy HH:MM:SS zzzzz" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-2010 03:19:52 +1100", &t);
+    r = time_from_rfc5322("15-Oct-2010 03:19:52 +1100", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 26);
     CU_ASSERT_EQUAL(t, 1287073192);
 
     /* Well-formed full RFC5322 format with 1-digit day
      * " d-mmm-yyyy HH:MM:SS zzzzz" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322(" 5-Oct-2010 03:19:52 +1100", &t);
+    r = time_from_rfc5322(" 5-Oct-2010 03:19:52 +1100", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 26);
     CU_ASSERT_EQUAL(t, 1286209192);
 
     /* dd mmm yyyy HH:MM:SS zzzzz */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("20 Jun 2017 00:49:38 +0000", &t);
+    r = time_from_rfc5322("20 Jun 2017 00:49:38 +0000", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 26);
     CU_ASSERT_EQUAL(t, 1497919778);
 
     /* dow, dd mmm yyyy HH:MM:SS zzzzz */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Tue, 20 Jun 2017 00:49:38 +0000", &t);
+    r = time_from_rfc5322("Tue, 20 Jun 2017 00:49:38 +0000", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 1497919778);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Tue, 20 Jun 2017 00:49:38 +0200", &t);
+    r = time_from_rfc5322("Tue, 20 Jun 2017 00:49:38 +0200", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 1497912578);
 
     /* Timezone tests - same time different timezones*/
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("FRI, 26 NOV 2010 14:22:02 +1100", &t); /* MEL */
+    r = time_from_rfc5322("FRI, 26 NOV 2010 14:22:02 +1100", &t, DATETIME_FULL); /* MEL */
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 1290741722);
 
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("FRI, 26 NOV 2010 03:22:02 +0000", &t); /* UTC */
+    r = time_from_rfc5322("FRI, 26 NOV 2010 03:22:02 +0000", &t, DATETIME_FULL); /* UTC */
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 1290741722);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("THU, 25 NOV 2010 22:22:02 -0500", &t); /* NYC */
+    r = time_from_rfc5322("THU, 25 NOV 2010 22:22:02 -0500", &t, DATETIME_FULL); /* NYC */
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 1290741722);
 
 
     /* Time with period as separator */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322(" 3-jan-2009 04.05    -0400", &t);
+    r = time_from_rfc5322(" 3-jan-2009 04.05    -0400", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 26);
     CU_ASSERT_EQUAL(t, 1230969900);
 
     /* Year 9999 */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Fri, 31-Dec-9999 23:59:59 +0000", &t);
+    r = time_from_rfc5322("Fri, 31-Dec-9999 23:59:59 +0000", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 253402300799);
 
     /* Year 1 - This will fail*/
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("1 Jan 1 00:00:00 +0000", &t);
+    r = time_from_rfc5322("1 Jan 1 00:00:00 +0000", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, -1);
 
     /* 5 digit year */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Sat, 1 Jan 10000 00:00:00", &t);
+    r = time_from_rfc5322("Sat, 1 Jan 10000 00:00:00", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 25);
     CU_ASSERT_EQUAL(t, 253402300800);
 
     /* Invalid date */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("foobar, 2 +5000", &t);
+    r = time_from_rfc5322("foobar, 2 +5000", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, -1);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Sun, Hello, World!", &t);
+    r = time_from_rfc5322("Sun, Hello, World!", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, -1);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("-1000", &t);
+    r = time_from_rfc5322("-1000", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, -1);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("Thu, 06 Jul 2017", &t);
+    r = time_from_rfc5322("Thu, 06 Jul 2017", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, -1);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("This is some random text", &t);
+    r = time_from_rfc5322("This is some random text", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, -1);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("0100200200300400502989587984579845", &t);
+    r = time_from_rfc5322("0100200200300400502989587984579845", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, -1);
 
 }
@@ -586,70 +586,70 @@ test_military_timezones_using_rfc5322(void)
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * uppercase 1-char timezone = UTC, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-Z", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-Z", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * lowercase 1-char timezone = UTC, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-z", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-z", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * uppercase 1-char timezone = +0100, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-A", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-A", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu-1*3600);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * uppercase 1-char timezone = +0200, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-B", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-B", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu-2*3600);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * uppercase 1-char timezone = +0900, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-I", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-I", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu-9*3600);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * erroneous uppercase 1-char timezone, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-J", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-J", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, 813727192);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * uppercase 1-char timezone = +1000, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-K", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-K", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu-10*3600);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * 1-char timezone = +1200, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-M", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-M", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu-12*3600);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * uppercase 1-char timezone = -0100, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-N", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-N", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu+1*3600);
 
     /* Well-formed legacy format with 2-digit day, 2-digit year,
      * 1-char timezone = -1200, "dd-mmm-yy HH:MM:SS-z" */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322("15-Oct-95 03:19:52-Y", &t);
+    r = time_from_rfc5322("15-Oct-95 03:19:52-Y", &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 20);
     CU_ASSERT_EQUAL(t, zulu+12*3600);
 }
@@ -669,18 +669,18 @@ test_leapyear_rfc5322(void)
     int r;
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322(FEB2000_STR, &t);
+    r = time_from_rfc5322(FEB2000_STR, &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, FEB2000_TIMET);
 
     /* This will be converted to: Thu Mar  1 11:22:33 2001 */
     t = UNINIT_TIMET;
-    r = time_from_rfc5322(FEB2001_STR, &t);
+    r = time_from_rfc5322(FEB2001_STR, &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 983406153);
 
     t = UNINIT_TIMET;
-    r = time_from_rfc5322(FEB2004_STR, &t);
+    r = time_from_rfc5322(FEB2004_STR, &t, DATETIME_FULL);
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, FEB2004_TIMET);
 }

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1651,7 +1651,7 @@ static void annotation_get_lastupdate(annotate_state_t *state,
     if (stat(fname, &sbuf) == -1)
         goto out;
 
-    time_to_rfc3501(sbuf.st_mtime, valuebuf, sizeof(valuebuf));
+    time_to_rfc5322(sbuf.st_mtime, valuebuf, sizeof(valuebuf));
     buf_appendcstr(&value, valuebuf);
 
     output_entryatt(state, entry->name, "", &value);
@@ -1669,7 +1669,7 @@ static void annotation_get_lastpop(annotate_state_t *state,
     assert(mailbox);
 
     if (mailbox->i.pop3_last_login) {
-        time_to_rfc3501(mailbox->i.pop3_last_login, valuebuf,
+        time_to_rfc5322(mailbox->i.pop3_last_login, valuebuf,
                         sizeof(valuebuf));
         buf_appendcstr(&value, valuebuf);
     }
@@ -1704,7 +1704,7 @@ static void annotation_get_pop3showafter(annotate_state_t *state,
 
     if (mailbox->i.pop3_show_after)
     {
-        time_to_rfc3501(mailbox->i.pop3_show_after, valuebuf, sizeof(valuebuf));
+        time_to_rfc5322(mailbox->i.pop3_show_after, valuebuf, sizeof(valuebuf));
         buf_appendcstr(&value, valuebuf);
     }
 
@@ -3090,7 +3090,7 @@ static int annotation_set_pop3showafter(annotate_state_t *state,
         date = 0;
     }
     else {
-        r = time_from_rfc3501(buf_cstring(&entry->shared), &date);
+        r = time_from_rfc5322(buf_cstring(&entry->shared), &date, DATETIME_FULL);
         if (r < 0)
             return IMAP_PROTOCOL_BAD_PARAMETERS;
     }

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -869,7 +869,7 @@ EXPORTED int carddav_store(struct mailbox *mailbox, struct vparse_card *vcard,
     vparse_tobuf(vcard, &buf);
     char *mbuserid = mboxname_to_userid(mailbox->name);
 
-    time_to_rfc822(now, datestr, sizeof(datestr));
+    time_to_rfc5322(now, datestr, sizeof(datestr));
 
     /* XXX  This needs to be done via an LDAP/DB lookup */
     header = charset_encode_mimeheader(mbuserid, 0);

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -535,7 +535,7 @@ void append_notifications()
                      (int) p, (int) t,
                      outgoing_count++, config_servername);
             fprintf(f, "Message-ID: %s\r\n", buf);
-            time_to_rfc822(t, datestr, sizeof(datestr));
+            time_to_rfc5322(t, datestr, sizeof(datestr));
             fprintf(f, "Date: %s\r\n", datestr);
             fprintf(f, "From: Mail System Administrator <%s>\r\n",
                     config_getstring(IMAPOPT_POSTMASTER));

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -7510,7 +7510,7 @@ int caldav_store_resource(struct transaction_t *txn, icalcomponent *ical,
                              mimehdr, txn->req_hdrs);
     }
 
-    time_to_rfc822(icaltime_as_timet_with_zone(icalcomponent_get_dtstamp(comp),
+    time_to_rfc5322(icaltime_as_timet_with_zone(icalcomponent_get_dtstamp(comp),
                                                utc_zone),
                    datestr, sizeof(datestr));
     spool_replace_header(xstrdup("Date"), xstrdup(datestr), txn->req_hdrs);

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -400,7 +400,7 @@ static int imip_send_sendmail(icalcomponent *ical,
     }
     fputs("\r\n", sm);
 
-    time_to_rfc822(t, datestr, sizeof(datestr));
+    time_to_rfc5322(t, datestr, sizeof(datestr));
     fprintf(sm, "Date: %s\r\n", datestr);
 
     fprintf(sm, "Message-ID: <cyrus-caldav-%u-%ld-%u@%s>\r\n",

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -8301,8 +8301,8 @@ int dav_store_resource(struct transaction_t *txn,
         fprintf(f, "Date: %s\r\n", hdr[0]);
     }
     else {
-        char datestr[80];
-        time_to_rfc822(now, datestr, sizeof(datestr));
+        char datestr[80];       /* XXX: Why do we need 80 character buffer? */
+        time_to_rfc5322(now, datestr, sizeof(datestr));
         fprintf(f, "Date: %s\r\n", datestr);
     }
 

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -893,7 +893,7 @@ EXPORTED int jmap_upload(struct transaction_t *txn)
     }
     else {
         char datestr[80];
-        time_to_rfc822(now, datestr, sizeof(datestr));
+        time_to_rfc5322(now, datestr, sizeof(datestr));
         fprintf(f, "Date: %s\r\n", datestr);
     }
 

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -910,7 +910,7 @@ static int list_messages(struct transaction_t *txn, struct mailbox *mailbox)
     /* <subtitle> - optional */
     annotatemore_lookup(mailbox->name, "/comment", NULL, &attrib);
     if (age_mark) {
-        time_to_rfc822(age_mark, datestr, sizeof(datestr));
+        time_to_rfc5322(age_mark, datestr, sizeof(datestr));
         buf_printf_markup(buf, level,
                         "<subtitle>%s [posts since %s]</subtitle>",
                           buf_cstring(&attrib), datestr);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -4242,7 +4242,8 @@ EXPORTED int check_precond(struct transaction_t *txn,
 
     /* Step 2 */
     else if ((hdr = spool_getheader(hdrcache, "If-Unmodified-Since"))) {
-        if (time_from_rfc822(hdr[0], &since) < 0) return HTTP_BAD_REQUEST;
+        if (time_from_rfc5322(hdr[0], &since, DATETIME_FULL) < 0)
+            return HTTP_BAD_REQUEST;
 
         if (lastmod > since) return HTTP_PRECOND_FAILED;
 
@@ -4264,7 +4265,8 @@ EXPORTED int check_precond(struct transaction_t *txn,
     /* Step 4 */
     else if ((txn->meth == METH_GET || txn->meth == METH_HEAD) &&
              (hdr = spool_getheader(hdrcache, "If-Modified-Since"))) {
-        if (time_from_rfc822(hdr[0], &since) < 0) return HTTP_BAD_REQUEST;
+        if (time_from_rfc5322(hdr[0], &since, DATETIME_FULL) < 0)
+            return HTTP_BAD_REQUEST;
 
         if (lastmod <= since) return HTTP_NOT_MODIFIED;
 
@@ -4276,7 +4278,7 @@ EXPORTED int check_precond(struct transaction_t *txn,
         txn->meth == METH_GET && (hdr = spool_getheader(hdrcache, "Range"))) {
 
         if ((hdr = spool_getheader(hdrcache, "If-Range"))) {
-            time_from_rfc822(hdr[0], &since); /* error OK here, could be an etag */
+            time_from_rfc5322(hdr[0], &since, DATETIME_FULL); /* error OK here, could be an etag */
         }
 
         /* Only process Range if If-Range isn't present or validator matches */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -12104,7 +12104,7 @@ static int getdatetime(time_t *date)
     }
     buf[i] = '\0';
 
-    r = time_from_rfc3501(buf, date);
+    r = time_from_rfc5322(buf, date, DATETIME_FULL);
     if (r < 0)
         goto baddate;
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -3030,7 +3030,7 @@ static int index_appendremote(struct index_state *state, uint32_t msgno,
     }
 
     /* add internal date */
-    time_to_rfc3501(record.internaldate, datebuf, sizeof(datebuf));
+    time_to_rfc5322(record.internaldate, datebuf, sizeof(datebuf));
     prot_printf(pout, ") \"%s\" ", datebuf);
 
     /* message literal */
@@ -3966,7 +3966,7 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
         time_t msgdate = record.internaldate;
         char datebuf[RFC3501_DATETIME_MAX+1];
 
-        time_to_rfc3501(msgdate, datebuf, sizeof(datebuf));
+        time_to_rfc5322(msgdate, datebuf, sizeof(datebuf));
 
         prot_printf(state->out, "%cINTERNALDATE \"%s\"",
                     sepchar, datebuf);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -357,38 +357,38 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *rock)
     }
 
     if (_wantprop(crock->props, "mayReadFreeBusy")) {
-        int bool = rights & DACL_READFB;
-        json_object_set_new(obj, "mayReadFreeBusy", bool ? json_true() : json_false());
+        json_object_set_new(obj, "mayReadFreeBusy",
+                            rights & DACL_READFB ? json_true() : json_false());
     }
 
     if (_wantprop(crock->props, "mayReadItems")) {
-        int bool = rights & DACL_READ;
-        json_object_set_new(obj, "mayReadItems", bool ? json_true() : json_false());
+        json_object_set_new(obj, "mayReadItems",
+                            rights & DACL_READ ? json_true() : json_false());
     }
 
     if (_wantprop(crock->props, "mayAddItems")) {
-        int bool = rights & DACL_WRITECONT;
-        json_object_set_new(obj, "mayAddItems", bool ? json_true() : json_false());
+        json_object_set_new(obj, "mayAddItems",
+                            rights & DACL_WRITECONT ? json_true() : json_false());
     }
 
     if (_wantprop(crock->props, "mayModifyItems")) {
-        int bool = rights & DACL_WRITECONT;
-        json_object_set_new(obj, "mayModifyItems", bool ? json_true() : json_false());
+        json_object_set_new(obj, "mayModifyItems",
+                            rights & DACL_WRITECONT ? json_true() : json_false());
     }
 
     if (_wantprop(crock->props, "mayRemoveItems")) {
-        int bool = rights & DACL_RMRES;
-        json_object_set_new(obj, "mayRemoveItems", bool ? json_true() : json_false());
+        json_object_set_new(obj, "mayRemoveItems",
+                            rights & DACL_RMRES ? json_true() : json_false());
     }
 
     if (_wantprop(crock->props, "mayRename")) {
-        int bool = rights & DACL_RMCOL;
-        json_object_set_new(obj, "mayRename", bool ? json_true() : json_false());
+        json_object_set_new(obj, "mayRename",
+                            rights & DACL_RMCOL ? json_true() : json_false());
     }
 
     if (_wantprop(crock->props, "mayDelete")) {
-        int bool = rights & DACL_RMCOL;
-        json_object_set_new(obj, "mayDelete", bool ? json_true() : json_false());
+        json_object_set_new(obj, "mayDelete",
+                            rights & DACL_RMCOL ? json_true() : json_false());
     }
 
     json_array_append_new(crock->array, obj);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2360,7 +2360,7 @@ static int jmapmsg_from_body(jmap_req_t *req, hash_table *props,
         if (r) return r;
 
         if (is_embedded)
-            time_from_rfc822(body->date, &t);
+            time_from_rfc5322(body->date, &t, DATETIME_FULL);
 
         time_to_rfc3339(t, datestr, RFC3339_DATETIME_MAX);
         json_object_set_new(msg, "date", json_string(datestr));
@@ -5220,9 +5220,9 @@ static int jmapmsg_to_mime(jmap_req_t *req, FILE *out, json_t *msg)
         date = mktime(&tm);
     }
     if (json_object_get(msg, "date") || !d.date) {
-        char fmt[RFC822_DATETIME_MAX+1];
-        memset(fmt, 0, RFC822_DATETIME_MAX+1);
-        time_to_rfc822(date, fmt, RFC822_DATETIME_MAX+1);
+        char fmt[RFC5322_DATETIME_MAX+1];
+        memset(fmt, 0, RFC5322_DATETIME_MAX+1);
+        time_to_rfc5322(date, fmt, RFC5322_DATETIME_MAX+1);
         if (d.date) free(d.date);
         d.date = xstrdup(fmt);
     }

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -371,7 +371,7 @@ static int send_rejection(const char *origid,
 
     namebuf = make_sieve_db(mailreceip);
 
-    time_to_rfc822(t, datestr, sizeof(datestr));
+    time_to_rfc5322(t, datestr, sizeof(datestr));
 
     dkey.id = buf;
     dkey.to = namebuf;
@@ -1166,7 +1166,7 @@ static int send_response(void *ac,
 
     buf_printf(&header, "Message-ID: %s\r\n", outmsgid);
 
-    time_to_rfc822(t, datestr, sizeof(datestr));
+    time_to_rfc5322(t, datestr, sizeof(datestr));
     buf_printf(&header, "Date: %s\r\n", datestr);
 
     buf_printf(&header, "X-Sieve: %s\r\n", SIEVE_VERSION);

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -517,7 +517,8 @@ int deliver_mailbox(FILE *f,
         r = message_parse_file(f, &content->base, &content->len, &content->body);
         /* If the body contains received_date, we should always use that. */
         if (content->body->received_date)
-            time_from_rfc822(content->body->received_date, &internaldate);
+            time_from_rfc5322(content->body->received_date, &internaldate,
+                              DATETIME_FULL);
     }
 
     if (!r) {

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -636,7 +636,7 @@ static int savemsg(struct clientdata *cd,
     }
 
     /* add a received header */
-    time_to_rfc822(now, datestr, sizeof(datestr));
+    time_to_rfc5322(now, datestr, sizeof(datestr));
     addlen = 8 + strlen(cd->lhlo_param) + strlen(cd->clienthost);
     if (m->authuser) addlen += 28 + strlen(m->authuser) + 5; /* +5 for ssf */
     addlen += 25 + strlen(config_servername) + strlen(CYRUS_VERSION);

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -542,11 +542,11 @@ static int do_compare(struct findall_data *data, void *rock __attribute__((unuse
                 printf("\t%-50u", fs_record.size);
             printf("\n");
 
-            if (record) time_to_rfc822(record->sentdate, sent, sizeof(sent));
+            if (record) time_to_rfc5322(record->sentdate, sent, sizeof(sent));
             printf("   Date: %-50s", sent);
 
             if (fs_record.uid && !message_guid_isnull(&fs_record.guid)) {
-                time_to_rfc822(fs_record.sentdate, sent, sizeof(sent));
+                time_to_rfc5322(fs_record.sentdate, sent, sizeof(sent));
                 printf("\t%-50s", sent);
             }
             printf("\n");

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -203,8 +203,8 @@ static int do_timestamp(const mbname_t *mbname)
 
         struct index_record copyrecord = *record;
 
-        time_to_rfc822(copyrecord.internaldate, olddate, sizeof(olddate));
-        time_to_rfc822(copyrecord.gmtime, newdate, sizeof(newdate));
+        time_to_rfc5322(copyrecord.internaldate, olddate, sizeof(olddate));
+        time_to_rfc5322(copyrecord.gmtime, newdate, sizeof(newdate));
         printf("  %u: %s => %s\n", copyrecord.uid, olddate, newdate);
 
         /* switch internaldate */

--- a/imap/message.c
+++ b/imap/message.c
@@ -586,11 +586,11 @@ HIDDEN int message_create_record(struct index_record *record,
                           const struct body *body)
 {
     /* used for sent time searching, truncated to day with no TZ */
-    if (day_from_rfc822(body->date, &record->sentdate) < 0)
+    if (time_from_rfc5322(body->date, &record->sentdate, DATETIME_DATE_ONLY) < 0)
         record->sentdate = 0;
 
     /* used for sent time sorting, full gmtime of Date: header */
-    if (time_from_rfc822(body->date, &record->gmtime) < 0)
+    if (time_from_rfc5322(body->date, &record->gmtime, DATETIME_FULL) < 0)
         record->gmtime = 0;
 
     record->size = body->filesize;

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3082,7 +3082,7 @@ static int savemsg(message_data_t *m, FILE *f)
         /* no date, create one */
         char datestr[RFC822_DATETIME_MAX+1];
 
-        time_to_rfc822(now, datestr, sizeof(datestr));
+        time_to_rfc5322(now, datestr, sizeof(datestr));
         m->date = xstrdup(datestr);
         fprintf(f, "Date: %s\r\n", datestr);
         spool_cache_header(xstrdup("Date"), xstrdup(datestr), m->hdrcache);

--- a/imap/notify.c
+++ b/imap/notify.c
@@ -185,7 +185,7 @@ EXPORTED int notify_at(time_t when, const char *method,
     }
 
     syslog(LOG_NOTICE, "APPENDING TO STAGE: %s (%u)", mailbox->name, (unsigned)when);
-    time_to_rfc822(when, datestr, sizeof(datestr));
+    time_to_rfc5322(when, datestr, sizeof(datestr));
     fprintf(f, "Date: %s\r\n", datestr);
     fprintf(f, "Method: %s\r\n", charset_encode_mimeheader(method, 0));
     fprintf(f, "Class: %s\r\n", charset_encode_mimeheader(class, 0));

--- a/lib/times.h
+++ b/lib/times.h
@@ -88,8 +88,12 @@ int time_to_rfc3339(time_t t, char *buf, size_t len);
 /*
  * RFC5322 datetime format
  */
+enum datetime_parse_mode {
+    DATETIME_DATE_ONLY = 0,
+    DATETIME_FULL,
+};
 #define RFC5322_DATETIME_MAX 32 /* 32 because we support 5 digit year format */
 int time_to_rfc5322(time_t date, char *buf, size_t len);
-int time_from_rfc5322(const char *s, time_t *date);
+int time_from_rfc5322(const char *s, time_t *date, enum datetime_parse_mode mode);
 
 #endif /* __CYRUS__TIME_H__ */

--- a/notifyd/notify_mailto.c
+++ b/notifyd/notify_mailto.c
@@ -73,7 +73,7 @@ char* notify_mailto(const char *class,
     char outmsgid[256];
     int sm_stat;
     time_t t;
-    char datestr[RFC822_DATETIME_MAX+1];
+    char datestr[RFC5322_DATETIME_MAX+1];
     pid_t sm_pid;
     int fds[2];
 
@@ -115,7 +115,7 @@ char* notify_mailto(const char *class,
 
     fprintf(sm, "Message-ID: %s\r\n", outmsgid);
 
-    time_to_rfc822(t, datestr, sizeof(datestr));
+    time_to_rfc5322(t, datestr, sizeof(datestr));
     fprintf(sm, "Date: %s\r\n", datestr);
 
     fprintf(sm, "X-Sieve: %s\r\n", SIEVE_VERSION);

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -1430,7 +1430,7 @@ envelope_err:
                         header_data = header;
                 }
 
-                if (-1 == time_from_rfc822(header_data, &t)) {
+                if (-1 == time_from_rfc5322(header_data, &t, DATETIME_FULL)) {
                         res = 0;
                         free(bc_makeArray(bc, &i));
                         break;
@@ -1528,7 +1528,7 @@ envelope_err:
                         time_to_iso8601(t, buffer, sizeof(buffer), 1);
                         break;
                 case B_STD11:
-                        time_to_rfc822(t, buffer, sizeof(buffer));
+                        time_to_rfc5322(t, buffer, sizeof(buffer));
                         break;
                 case B_ZONE:
                         snprintf(buffer, sizeof(buffer), "%c%02d%02d",


### PR DESCRIPTION
Use `time_from_rfc5322()` which complies with the RFC5322.

Fixes #2044