### PR TITLE
Use rfc3501 for internaldate.

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1651,7 +1651,7 @@ static void annotation_get_lastupdate(annotate_state_t *state,
     if (stat(fname, &sbuf) == -1)
         goto out;
 
-    time_to_rfc5322(sbuf.st_mtime, valuebuf, sizeof(valuebuf));
+    time_to_rfc3501(sbuf.st_mtime, valuebuf, sizeof(valuebuf));
     buf_appendcstr(&value, valuebuf);
 
     output_entryatt(state, entry->name, "", &value);
@@ -1669,7 +1669,7 @@ static void annotation_get_lastpop(annotate_state_t *state,
     assert(mailbox);
 
     if (mailbox->i.pop3_last_login) {
-        time_to_rfc5322(mailbox->i.pop3_last_login, valuebuf,
+        time_to_rfc3501(mailbox->i.pop3_last_login, valuebuf,
                         sizeof(valuebuf));
         buf_appendcstr(&value, valuebuf);
     }
@@ -1704,7 +1704,7 @@ static void annotation_get_pop3showafter(annotate_state_t *state,
 
     if (mailbox->i.pop3_show_after)
     {
-        time_to_rfc5322(mailbox->i.pop3_show_after, valuebuf, sizeof(valuebuf));
+        time_to_rfc3501(mailbox->i.pop3_show_after, valuebuf, sizeof(valuebuf));
         buf_appendcstr(&value, valuebuf);
     }
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -3030,7 +3030,7 @@ static int index_appendremote(struct index_state *state, uint32_t msgno,
     }
 
     /* add internal date */
-    time_to_rfc5322(record.internaldate, datebuf, sizeof(datebuf));
+    time_to_rfc3501(record.internaldate, datebuf, sizeof(datebuf));
     prot_printf(pout, ") \"%s\" ", datebuf);
 
     /* message literal */
@@ -3966,7 +3966,7 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
         time_t msgdate = record.internaldate;
         char datebuf[RFC3501_DATETIME_MAX+1];
 
-        time_to_rfc5322(msgdate, datebuf, sizeof(datebuf));
+        time_to_rfc3501(msgdate, datebuf, sizeof(datebuf));
 
         prot_printf(state->out, "%cINTERNALDATE \"%s\"",
                     sepchar, datebuf);


### PR DESCRIPTION
`INTERNALDATE` expects date to be seprated by '-' where as RFC5322 date uses
' '(space) as separator. Using RFC3501 implementation for INTERNALDATE for
now.