### PR TITLE
[imap] Use RFC5322_DATETIME_MAX instead of RFC822_DATETIME_MAX.

### DIFF
--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -520,7 +520,7 @@ void append_notifications()
         if (i_mbox->msgs) {
             FILE *f = fdopen(fd, "w+");
             struct infected_msg *msg;
-            char buf[8192], datestr[RFC822_DATETIME_MAX+1];
+            char buf[8192], datestr[RFC5322_DATETIME_MAX+1];
             time_t t;
             struct protstream *pout;
             struct appendstate as;

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -263,7 +263,7 @@ static int imip_send_sendmail(icalcomponent *ical,
     const char *argv[7], *msg_type, *filename;
     struct address_t *recipients = NULL, *originator = NULL, *recip;
     struct icaltimetype start, end;
-    char *cp, when[2*RFC822_DATETIME_MAX+4], datestr[RFC822_DATETIME_MAX+1];
+    char *cp, when[2*RFC5322_DATETIME_MAX+4], datestr[RFC5322_DATETIME_MAX+1];
     char boundary[100], *mimebody, *ical_str;
     size_t outlen;
     struct buf plainbuf = BUF_INITIALIZER, tmpbuf = BUF_INITIALIZER;

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -401,7 +401,7 @@ static int send_rejection(const char *origid,
     char buf[8192], *namebuf;
     int i, sm_stat;
     time_t t;
-    char datestr[RFC822_DATETIME_MAX+1];
+    char datestr[RFC5322_DATETIME_MAX+1];
     pid_t sm_pid, p;
     duplicate_key_t dkey = DUPLICATE_INITIALIZER;
 
@@ -1191,7 +1191,7 @@ static int send_response(void *ac,
     char outmsgid[8192], *sievedb, *subj;
     int i, sl, sm_stat, ret;
     time_t t;
-    char datestr[RFC822_DATETIME_MAX+1];
+    char datestr[RFC5322_DATETIME_MAX+1];
     pid_t sm_pid, p;
     sieve_send_response_context_t *src = (sieve_send_response_context_t *) ac;
     message_data_t *md = ((deliver_data_t *) mc)->m;

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -592,7 +592,7 @@ static int savemsg(struct clientdata *cd,
     int nrcpts = m->rcpt_num;
     time_t now = time(NULL);
     static unsigned msgid_count = 0;
-    char datestr[RFC822_DATETIME_MAX+1], tls_info[250] = "";
+    char datestr[RFC5322_DATETIME_MAX+1], tls_info[250] = "";
     const char *skipheaders[] = {
         "Return-Path",  /* need to remove (we add our own) */
         NULL

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -501,7 +501,7 @@ static int do_compare(struct findall_data *data, void *rock __attribute__((unuse
         do {
             struct index_record fs_record = { .uid = 0 };
             const struct buf *citem, empty_buf = BUF_INITIALIZER;
-            char sent[RFC822_DATETIME_MAX+1] = "";
+            char sent[RFC5322_DATETIME_MAX+1] = "";
 
             if (msgno < count) {
                 char fname[100];

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -178,8 +178,8 @@ static int do_timestamp(const mbname_t *mbname)
 {
     int r = 0;
     struct mailbox *mailbox = NULL;
-    char olddate[RFC822_DATETIME_MAX+1];
-    char newdate[RFC822_DATETIME_MAX+1];
+    char olddate[RFC5322_DATETIME_MAX+1];
+    char newdate[RFC5322_DATETIME_MAX+1];
 
     signals_poll();
 

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3080,7 +3080,7 @@ static int savemsg(message_data_t *m, FILE *f)
     /* get date */
     if ((body = spool_getheader(m->hdrcache, "date")) == NULL) {
         /* no date, create one */
-        char datestr[RFC822_DATETIME_MAX+1];
+        char datestr[RFC5322_DATETIME_MAX+1];
 
         time_to_rfc5322(now, datestr, sizeof(datestr));
         m->date = xstrdup(datestr);

--- a/imap/notify.c
+++ b/imap/notify.c
@@ -160,7 +160,7 @@ EXPORTED int notify_at(time_t when, const char *method,
             const char *message)
 {
     struct mailbox *mailbox = NULL;
-    char datestr[RFC822_DATETIME_MAX+1];
+    char datestr[RFC5322_DATETIME_MAX+1];
     int i;
     int r = mailbox_open_iwl("#events", &mailbox);
     struct buf buf = BUF_INITIALIZER;


### PR DESCRIPTION
Although, both `RFC5322_DATETIME_MAX` and `RFC822_DATETIME_MAX` have the same
buffer sizes, we should use `RFC5322_DATETIME_MAX` since we eventually
deprecate the rfc822* functions in favour of rfc5322* functions.