### PR TITLE
GCC 7 compilation fixes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,13 @@ AH_BOTTOM([#if HAVE_VISIBILITY
 #define HIDDEN
 #endif])
 
+AH_BOTTOM([#if defined __GNUC__ &&  __GNUC__ > 6
+    #define GCC_FALLTHROUGH __attribute__((fallthrough));
+#else
+    #define GCC_FALLTHROUGH /* fall through */
+#endif
+])
+
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])
 AC_SUBST([LIBTOOL_DEPS])

--- a/imap/append.c
+++ b/imap/append.c
@@ -1257,7 +1257,7 @@ HIDDEN int append_run_annotator(struct appendstate *as,
 
     /* Reset user flags */
     uint32_t user_flags[MAX_USER_FLAGS/32];
-    memset(user_flags, 0, sizeof(user_flags)/sizeof(user_flags[0]));
+    memset(user_flags, 0, sizeof(user_flags));
     r = msgrecord_set_userflags(msgrec, user_flags);
     if (r) goto out;
 

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -1007,6 +1007,7 @@ int main(int argc, char *argv[])
 
     case M_POPULATE:
         syslog(LOG_NOTICE, "%spopulating mupdate", warn_only ? "test " : "");
+        GCC_FALLTHROUGH
 
     case DUMP:
         mboxlist_init(0);

--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -275,6 +275,8 @@ static int action_murder(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         return precond;
@@ -355,6 +357,8 @@ static int action_menu(struct transaction_t *txn)
         txn->flags.cc |= CC_MAXAGE;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */
@@ -855,6 +859,8 @@ static int action_df(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         return precond;
@@ -1184,6 +1190,8 @@ static int action_conf(struct transaction_t *txn)
         txn->flags.cc |= CC_MAXAGE;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1463,6 +1463,8 @@ static int export_calendar(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         ret = precond;
@@ -1777,6 +1779,8 @@ static int list_calendars(struct transaction_t *txn)
         txn->flags.cc |= CC_REVALIDATE;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */
@@ -2409,6 +2413,8 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
     case HTTP_LOCKED:
         txn->error.precond = DAV_NEED_LOCK_TOKEN;
         txn->error.resource = txn->req_tgt.path;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -666,6 +666,8 @@ static int export_addressbook(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         ret = precond;
@@ -897,6 +899,8 @@ static int list_addressbooks(struct transaction_t *txn)
         txn->flags.cc |= CC_REVALIDATE;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3006,6 +3006,7 @@ static int preload_proplist(xmlNodePtr proplist, struct propfind_ctx *fctx)
             }
         }
         /* Fall through and build hash table of namespaces */
+        GCC_FALLTHROUGH
 
     case PROPFIND_EXPAND:
         /* Add all namespaces attached to the response to our hash table */
@@ -4178,6 +4179,8 @@ int meth_copy_move(struct transaction_t *txn, void *params)
         txn->error.precond = DAV_NEED_LOCK_TOKEN;
         txn->error.resource = txn->req_tgt.path;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         ret = precond;
@@ -4558,6 +4561,8 @@ int meth_delete(struct transaction_t *txn, void *params)
         txn->error.precond = DAV_NEED_LOCK_TOKEN;
         txn->error.resource = txn->req_tgt.path;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         ret = precond;
@@ -4726,6 +4731,8 @@ int meth_get_head(struct transaction_t *txn, void *params)
         txn->flags.cc |= CC_MAXAGE | CC_REVALIDATE;  /* don't use stale data */
 
         if (precond != HTTP_NOT_MODIFIED && record.uid) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */
@@ -4923,6 +4930,8 @@ int meth_lock(struct transaction_t *txn, void *params)
         else
             txn->error.precond = DAV_NEED_LOCK_TOKEN;
         txn->error.resource = txn->req_tgt.path;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */
@@ -6466,6 +6475,8 @@ static int dav_post_import(struct transaction_t *txn,
         txn->error.precond = DAV_NEED_LOCK_TOKEN;
         txn->error.resource = txn->req_tgt.path;
 
+        GCC_FALLTHROUGH
+
     case HTTP_PRECOND_FAILED:
     default:
         /* We failed a precondition */
@@ -6720,6 +6731,7 @@ int meth_patch(struct transaction_t *txn, void *params)
         txn->resp_body.lastmod = lastmod;
 
         /* Fall through and load message */
+        GCC_FALLTHROUGH
 
     case HTTP_OK: {
         unsigned offset;
@@ -6772,6 +6784,8 @@ int meth_patch(struct transaction_t *txn, void *params)
         switch (ret) {
         case HTTP_NO_CONTENT:
             ret = HTTP_OK;
+
+            GCC_FALLTHROUGH
 
         case HTTP_CREATED:
         case HTTP_PRECOND_FAILED:
@@ -7034,6 +7048,8 @@ int meth_put(struct transaction_t *txn, void *params)
         switch (ret) {
         case HTTP_NO_CONTENT:
             ret = HTTP_OK;
+
+            GCC_FALLTHROUGH
 
         case HTTP_CREATED:
         case HTTP_PRECOND_FAILED:
@@ -8727,6 +8743,8 @@ static int get_server_info(struct transaction_t *txn)
         txn->flags.cc |= CC_MAXAGE;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -242,6 +242,8 @@ static int meth_get_isched(struct transaction_t *txn,
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         return precond;
@@ -522,6 +524,8 @@ static int meth_post_isched(struct transaction_t *txn,
         switch (meth) {
         case ICAL_METHOD_POLLSTATUS:
             if (kind != ICAL_VPOLL_COMPONENT) goto invalid_meth;
+
+            GCC_FALLTHROUGH
 
         case ICAL_METHOD_REQUEST:
         case ICAL_METHOD_REPLY:
@@ -1022,6 +1026,8 @@ static int meth_get_domainkey(struct transaction_t *txn,
         if (!httpd_userisanonymous) txn->flags.cc |= CC_PUBLIC;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -255,6 +255,8 @@ static int meth_get(struct transaction_t *txn,
 
                 if (precond != HTTP_NOT_MODIFIED) break;
 
+                GCC_FALLTHROUGH
+
             default:
                 /* We failed a precondition - don't perform the request */
                 ret = precond;
@@ -630,6 +632,8 @@ static int list_feeds(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         ret = precond;
@@ -817,6 +821,8 @@ static int list_messages(struct transaction_t *txn, struct mailbox *mailbox)
         txn->flags.cc |= CC_MAXAGE;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -790,6 +790,8 @@ static int action_capa(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         return precond;
@@ -939,6 +941,8 @@ static int action_leap(struct transaction_t *txn)
         if (!httpd_userisanonymous) txn->flags.cc |= CC_PUBLIC;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */
@@ -1156,6 +1160,8 @@ static int action_list(struct transaction_t *txn)
         if (!httpd_userisanonymous) txn->flags.cc |= CC_PUBLIC;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */
@@ -1813,6 +1819,8 @@ static int action_get(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         resp_body->type = NULL;
@@ -2008,6 +2016,8 @@ static int action_expand(struct transaction_t *txn)
         if (!httpd_userisanonymous) txn->flags.cc |= CC_PUBLIC;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -409,6 +409,8 @@ static int http2_frame_recv_cb(nghttp2_session *session,
             }
         }
 
+        GCC_FALLTHROUGH
+
     case NGHTTP2_DATA:
         /* Check that the client request has finished */
         if (!(frame->hd.flags & NGHTTP2_FLAG_END_STREAM)) break;
@@ -2687,6 +2689,7 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
         if (txn->flags.ver == VER_2) break;
 
         /* Fall through and specify connection options - HTTP/1.x only */
+        GCC_FALLTHROUGH
 
     case HTTP_SWITCH_PROT:
         if (txn->flags.conn) {
@@ -2715,6 +2718,7 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
         if (code != HTTP_SWITCH_PROT) break;
 
         /* Fall through as provisional response */
+        GCC_FALLTHROUGH
 
     case HTTP_CONTINUE:
     case HTTP_PROCESSING:
@@ -2984,6 +2988,7 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
         }
 
         /* Fall through and specify framing */
+        GCC_FALLTHROUGH
 
     default:
         if (txn->flags.te) {
@@ -4388,6 +4393,8 @@ static int list_well_known(struct transaction_t *txn)
 
         if (precond != HTTP_NOT_MODIFIED) break;
 
+        GCC_FALLTHROUGH
+
     default:
         /* We failed a precondition - don't perform the request */
         return precond;
@@ -4543,6 +4550,8 @@ static int meth_get(struct transaction_t *txn,
         if (!httpd_userisanonymous) txn->flags.cc |= CC_PUBLIC;
 
         if (precond != HTTP_NOT_MODIFIED) break;
+
+        GCC_FALLTHROUGH
 
     default:
         /* We failed a precondition - don't perform the request */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3201,6 +3201,8 @@ static void cmd_idle(char *tag)
             for (p = buf; *p == '['; p++); /* can't have [ be first char */
             prot_printf(imapd_out, "* BYE [ALERT] %s\r\n", p);
             /* fallthrough */
+            GCC_FALLTHROUGH
+
         case shutdown_silent:
             shut_down(0);
             break;
@@ -11273,6 +11275,7 @@ static void xfer_recover(struct xfer_header *xfer)
                        "Could not back out MOVING flag during move of %s (%s)",
                        item->mbentry->name, error_message(r));
             }
+            GCC_FALLTHROUGH
 
         case XFER_REMOTE_CREATED:
             if (!xfer->use_replication) {
@@ -11287,6 +11290,7 @@ static void xfer_recover(struct xfer_header *xfer)
                         item->mbentry->name, error_message(r));
                 }
             }
+            GCC_FALLTHROUGH
 
         case XFER_DEACTIVATED:
             /* Tell murder it's back here and active */

--- a/imap/jcal.c
+++ b/imap/jcal.c
@@ -254,9 +254,11 @@ static void icalparameter_as_json_object_member(icalparameter *param,
         break;
 #endif
 
-    default:
+    default:                    /* XXX: Is the default case here deliberate?? */
         kind_string = icalparameter_kind_to_string(kind);
         if (kind_string) break;
+
+        GCC_FALLTHROUGH
 
     case ICAL_NO_PARAMETER:
     case ICAL_ANY_PARAMETER:
@@ -351,6 +353,7 @@ static json_t *icalproperty_as_json_array(icalproperty *prop)
                 tok_fini(&tok);
                 break;
             }
+            GCC_FALLTHROUGH
 
         default:
             json_array_append_new(jprop, icalvalue_as_json_object(value));
@@ -726,6 +729,7 @@ static icalproperty *json_array_to_icalproperty(json_t *jprop)
             buf_free(&buf);
             break;
         }
+        GCC_FALLTHROUGH
 
     default:
         value = json_object_to_icalvalue(jvalue, valkind);

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -947,8 +947,6 @@ int main(int argc, char **argv)
             break;
 
         case 'h':
-            usage("squatter");
-
         default:
             usage("squatter");
         }

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -265,6 +265,8 @@ static xmlNodePtr icalparameter_as_xml_element(icalparameter *param)
         kind_string = icalparameter_kind_to_string(kind);
         if (kind_string) break;
 
+        GCC_FALLTHROUGH
+
     case ICAL_NO_PARAMETER:
     case ICAL_ANY_PARAMETER:
             icalerror_set_errno(ICAL_BADARG_ERROR);
@@ -946,6 +948,7 @@ static icalproperty *xml_element_to_icalproperty(xmlNodePtr xprop)
             buf_free(&buf);
             break;
         }
+        GCC_FALLTHROUGH
 
     default:
         value = xml_element_to_icalvalue(node, valkind);

--- a/lib/murmurhash.c
+++ b/lib/murmurhash.c
@@ -11,6 +11,7 @@
 // 1. It will not work incrementally.
 // 2. It will not produce the same results on little-endian and big-endian
 //    machines.
+#include <config.h>
 
 unsigned int murmurhash2(const void * key, int len, const unsigned int seed)
 {
@@ -48,7 +49,9 @@ unsigned int murmurhash2(const void * key, int len, const unsigned int seed)
 	switch(len)
 	{
 	case 3: h ^= data[2] << 16;
+            GCC_FALLTHROUGH
 	case 2: h ^= data[1] << 8;
+            GCC_FALLTHROUGH
 	case 1: h ^= data[0];
 	        h *= m;
 	};

--- a/lib/util.h
+++ b/lib/util.h
@@ -379,4 +379,14 @@ const char *makeuuid();
 void tcp_enable_keepalive(int fd);
 void tcp_disable_nagle(int fd);
 
+/*
+ * GCC_VERSION macro usage:
+ * #if GCC_VERSION > 60909    //GCC version 7 and above
+ *   do_something();
+ * #endif
+ */
+#define GCC_VERSION (__GNUC__ * 10000           \
+                     + __GNUC_MINOR__ * 100     \
+                     + __GNUC_PATCHLEVEL__)
+
 #endif /* INCLUDED_UTIL_H */

--- a/lib/vparse.c
+++ b/lib/vparse.c
@@ -123,6 +123,7 @@ static int _parse_param_quoted(struct vparse_state *state, int multiparam)
             if (multiparam)
                 return PE_QSTRING_COMMA;
             /* or fall through, comma isn't special */
+            GCC_FALLTHROUGH
 
         default:
             PUTC(*state->p);
@@ -311,6 +312,7 @@ repeat:
                 break;
             }
             /* or fall through, comma isn't special */
+            GCC_FALLTHROUGH
 
         default:
             PUTC(*state->p);

--- a/master/service.c
+++ b/master/service.c
@@ -541,6 +541,7 @@ int main(int argc, char **argv, char **envp)
 
                     case EINVAL:
                         if (signals_poll() == SIGHUP) break;
+                        GCC_FALLTHROUGH
 
                     default:
                         syslog(LOG_ERR, "accept failed: %m");

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -921,6 +921,8 @@ envelope_err:
     case BC_STRING:/*21*/
         is_string = 1;
 
+        GCC_FALLTHROUGH
+
     case BC_HASFLAG:/*15*/
     {
         int haystacksi=i+4;/*the i value for the beginning of the variables*/
@@ -1250,6 +1252,8 @@ envelope_err:
     }
     case BC_DATE:/*11*/
         has_index=1;
+        GCC_FALLTHROUGH
+
     case BC_CURRENTDATE:/*12*/
         if (0x07 == version) {
             /* There was a version of the bytecode that had the index extension

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -413,6 +413,7 @@ static int dump2_test(bytecode_input_t * d, int i, int version)
         break;
     case BC_DATE:/*11*/
         has_index=1;
+        GCC_FALLTHROUGH
     case BC_CURRENTDATE:/*12*/
         if (0x07 == version) {
             /* There was a version of the bytecode that had the index extension

--- a/sieve/tree.c
+++ b/sieve/tree.c
@@ -101,6 +101,7 @@ test_t *new_test(int type, sieve_script_t *parse_script)
     case ENVELOPE:
         capability = "envelope";
         supported = parse_script->support & SIEVE_CAPA_ENVELOPE;
+        GCC_FALLTHROUGH
 
     case ADDRESS:
         init_comptags(&p->u.ae.comp);
@@ -143,6 +144,7 @@ test_t *new_test(int type, sieve_script_t *parse_script)
 
     case METADATA:
         init_comptags(&p->u.mm.comp);
+        GCC_FALLTHROUGH
 
     case METADATAEXISTS:
         capability = "mboxmetadata";
@@ -151,6 +153,7 @@ test_t *new_test(int type, sieve_script_t *parse_script)
 
     case SERVERMETADATA:
         init_comptags(&p->u.mm.comp);
+        GCC_FALLTHROUGH
 
     case SERVERMETADATAEXISTS:
         capability = "servermetadata";
@@ -257,6 +260,7 @@ commandlist_t *new_command(int type, sieve_script_t *parse_script)
 
     case INCLUDE:
         p->u.inc.once = p->u.inc.location = p->u.inc.optional = -1;
+        GCC_FALLTHROUGH
 
     case RETURN:
         capability = "include";
@@ -270,6 +274,7 @@ commandlist_t *new_command(int type, sieve_script_t *parse_script)
 
     case DELETEHEADER:
         init_comptags(&p->u.dh.comp);
+        GCC_FALLTHROUGH
 
     case ADDHEADER:
         capability = "editheader";

--- a/sieve/variables.c
+++ b/sieve/variables.c
@@ -94,7 +94,7 @@ EXPORTED char *variables_modify_string(const char *string, int modifiers)
             case '{':
             case '|':
                 if (!(BFV_QUOTEREGEX & modifiers)) break;
-
+                GCC_FALLTHROUGH
                 /* :matches AND :regex special characters */
             case '*':
             case '?':


### PR DESCRIPTION
This patch fixes the warnings when compiling `cyrus-imapd` with gcc 7.
Primarily address thing fallthrough cases in `switch` statements[1].

[1] https://gcc.gnu.org/onlinedocs/gcc-7.1.0/gcc/Statement-Attributes.html