### PR TITLE
[squatter] Fix usage.

### DIFF
--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -141,7 +141,6 @@ static int usage(const char *name)
             "  -F          filter during compaction\n"
             "  -T dir      use temporary directory dir during compaction\n"
             "  -X          reindex during compaction\n"
-            "  -U          reindex tiers having deprecated stems or prefixes\n"
             "  -o          copy db rather compacting\n"
             "  -U          only compact if re-indexing\n"
             "\n"


### PR DESCRIPTION
Squatter when run with `-h` displayed the usage of `-U` twice. Only show
the correct one.