### PR TITLE
[Bug 1155] Check CRL's in TLS.

### DIFF
--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2284,6 +2284,9 @@ product version in the capabilities */
 .PP
    https://wiki.mozilla.org/Security/Server_Side_TLS */
 
+{ "tls_crl_file", NULL, STRING }
+/* Path to a file containing the Certificate Revocation List */
+
 { "tls_client_ca_dir", NULL, STRING }
 /* Path to a directory containing the CA certificates used to verify
    client SSL certificates used for authentication. */


### PR DESCRIPTION
We don't check CRL's in TLS and this patch adds support for that. An
imap option called `IMAPOPT_TLS_CRL_FILE` is available to specify the
path of the CRL PEM file.

This patch is based of the work done by `stacy@millions.ca`.