### PR TITLE
[Bug 2086] Should be able to set special value twice.

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3103,18 +3103,30 @@ static int annotation_set_pop3showafter(annotate_state_t *state,
     return 0;
 }
 
-EXPORTED int specialuse_validate(const char *userid, const char *src, struct buf *dest)
+EXPORTED int specialuse_validate(const char *mboxname, const char *userid,
+                                 const char *src, struct buf *dest)
 {
     const char *specialuse_extra_opt = config_getstring(IMAPOPT_SPECIALUSE_EXTRA);
     char *strval = NULL;
     strarray_t *valid = NULL;
-    strarray_t *values = NULL;
+    strarray_t *new_attribs = NULL;
+    strarray_t *cur_attribs = NULL;
+    struct buf mbattribs = BUF_INITIALIZER;
     int i, j;
     int r = 0;
 
     if (!src) {
         buf_reset(dest);
         return 0;
+    }
+
+    /* If there is a valid mboxname, we get the current specialuse annotations.
+     */
+    if (mboxname) {
+        annotatemore_lookup(mboxname, "/specialuse", userid, &mbattribs);
+        if (mbattribs.len) {
+            cur_attribs = strarray_split(buf_cstring(&mbattribs), NULL, 0);
+        }
     }
 
     /* check specialuse_extra option if set */
@@ -3131,10 +3143,11 @@ EXPORTED int specialuse_validate(const char *userid, const char *src, struct buf
     strarray_add(valid, "\\Sent");
     strarray_add(valid, "\\Trash");
 
-    values = strarray_split(src, NULL, 0);
+    new_attribs = strarray_split(src, NULL, 0);
 
-    for (i = 0; i < values->count; i++) {
-        const char *item = strarray_nth(values, i);
+    for (i = 0; i < new_attribs->count; i++) {
+        int skip_mbcheck = 0;
+        const char *item = strarray_nth(new_attribs, i);
 
         for (j = 0; j < valid->count; j++) { /* can't use find here */
             if (!strcasecmp(strarray_nth(valid, j), item))
@@ -3143,30 +3156,42 @@ EXPORTED int specialuse_validate(const char *userid, const char *src, struct buf
             if (!strcasecmp(strarray_nth(valid, j) + 1, item))
                 break;
         }
+
         if (j >= valid->count) {
             r = IMAP_ANNOTATION_BADENTRY;
             goto done;
         }
 
+        if (cur_attribs &&
+            (strarray_find_case(cur_attribs, strarray_nth(valid, j), 0) >= 0)) {
+            /* The mailbox has this specialuse attribute set already */
+            skip_mbcheck = 1;
+        }
+
         /* don't allow names that are already in use */
-        char *mboxname = mboxlist_find_specialuse(strarray_nth(valid, j), userid);
-        if (mboxname) {
-            free(mboxname);
-            r = IMAP_MAILBOX_SPECIALUSE;
-            goto done;
+        if (!skip_mbcheck) {
+            char *mbname = mboxlist_find_specialuse(strarray_nth(valid, j),
+                                                    userid);
+            if (mbname) {
+                free(mbname);
+                r = IMAP_MAILBOX_SPECIALUSE;
+                goto done;
+            }
         }
 
         /* normalise the value */
-        strarray_set(values, i, strarray_nth(valid, j));
+        strarray_set(new_attribs, i, strarray_nth(valid, j));
     }
 
-    strval = strarray_join(values, " ");
+    strval = strarray_join(new_attribs, " ");
     buf_setcstr(dest, strval);
 
 done:
     free(strval);
     strarray_free(valid);
-    strarray_free(values);
+    strarray_free(new_attribs);
+    strarray_free(cur_attribs);
+    buf_free(&mbattribs);
     return r;
 }
 
@@ -3185,7 +3210,8 @@ static int annotation_set_specialuse(annotate_state_t *state,
         goto done;
     }
 
-    r = specialuse_validate(state->userid, buf_cstring(&entry->priv), &res);
+    r = specialuse_validate(state->mailbox->name, state->userid,
+                            buf_cstring(&entry->priv), &res);
     if (r) goto done;
 
     r = write_entry(state->mailbox, state->uid, entry->name, state->userid,

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -274,6 +274,7 @@ int annotate_getdb(const char *mboxname, annotate_db_t **dbp);
 void annotate_putdb(annotate_db_t **dbp);
 
 /* Maybe this isn't the right place - move later */
-int specialuse_validate(const char *userid, const char *src, struct buf *dest);
+int specialuse_validate(const char *mboxname, const char *userid,
+                        const char *src, struct buf *dest);
 
 #endif /* ANNOTATE_H */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6655,7 +6655,7 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
         }
         raw = strarray_join(su, " ");
         strarray_free(su);
-        r = specialuse_validate(imapd_userid, raw, &specialuse);
+        r = specialuse_validate(NULL, imapd_userid, raw, &specialuse);
         free(raw);
         if (r) {
             prot_printf(imapd_out, "%s NO [USEATTR] %s\r\n", tag, error_message(r));

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -979,7 +979,7 @@ static int sieve_fileinto(void *ac,
             if (fc->specialuse) {
                 /* Attempt to add special-use flag to newly created mailbox */
                 struct buf specialuse = BUF_INITIALIZER;
-                int r = specialuse_validate(userid, fc->specialuse, &specialuse);
+                int r = specialuse_validate(NULL, userid, fc->specialuse, &specialuse);
 
                 if (!r) {
                     annotatemore_write(intname, "/specialuse",
@@ -1145,7 +1145,7 @@ static void do_fcc(script_data_t *sdata, sieve_fileinto_context_t *fcc,
         if (!r && fcc->specialuse) {
             /* Attempt to add special-use flag to newly created mailbox */
             struct buf specialuse = BUF_INITIALIZER;
-            int r2 = specialuse_validate(userid, fcc->specialuse, &specialuse);
+            int r2 = specialuse_validate(NULL, userid, fcc->specialuse, &specialuse);
 
             if (!r2) {
                 annotatemore_write(intname, "/specialuse", userid, &specialuse);


### PR DESCRIPTION
Currently when setting the special value of a folder twice to same
value, the `setmetadata` command is rejected. This patch checks if the
mailbox we are trying to set the special use flag on is the same
folder(with the same flag), we don't error, and return a success instead.