### PR TITLE
[sieve] Don't truncate .script extentions when uploading.

### DIFF
--- a/docsrc/imap/reference/manpages/usercommands/installsieve.rst
+++ b/docsrc/imap/reference/manpages/usercommands/installsieve.rst
@@ -52,9 +52,7 @@ Options
 
     Install a file onto the server. If a script with the same name
     already exists on the server it is overwritten. Upon successfully
-    putting the script on the server the script is set active. If
-    *file* has the extension .script it is chopped when put on the
-    server since sieve names may not contain a '.'.
+    putting the script on the server the script is set active.
 
 .. option:: -a  name
 

--- a/perl/sieve/lib/request.c
+++ b/perl/sieve/lib/request.c
@@ -279,11 +279,6 @@ static char *getsievename(char *filename)
 
   strcpy(ret, ptr);
 
-  if ( strcmp( ret + strlen(ret) - 7,".script")==0)
-  {
-    ret[ strlen(ret) - 7] = '\0';
-  }
-
   return ret;
 }
 


### PR DESCRIPTION
We shouldn't be truncating filenames of files with extensions `.script`
when uploading.

This patch was originally submitted by Дилян Палаузов.

Fixes #1907.