### PR TITLE
add prometheus metrics for httpd

### DIFF
--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -91,7 +91,7 @@ static int action_conf(struct transaction_t *txn);
 
 /* Namespace for admin service */
 struct namespace_t namespace_admin = {
-    URL_NS_ADMIN, 1, "/admin", NULL,
+    URL_NS_ADMIN, 1, "admin", "/admin", NULL,
     http_allow_noauth_get, /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -57,7 +57,7 @@ static int meth_get_applepush(struct transaction_t *txn, void *params);
 static int meth_post_applepush(struct transaction_t *txn, void *params);
 
 struct namespace_t namespace_applepush = {
-    URL_NS_APPLEPUSH, /*enabled*/0, "/applepush/subscribe", NULL,
+    URL_NS_APPLEPUSH, /*enabled*/0, "applepush", "/applepush/subscribe", NULL,
     http_allow_noauth_get, /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ|ALLOW_POST,

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -581,7 +581,7 @@ static struct meth_params caldav_params = {
 
 /* Namespace for CalDAV collections */
 struct namespace_t namespace_calendar = {
-    URL_NS_CALENDAR, 0, "/dav/calendars", "/.well-known/caldav",
+    URL_NS_CALENDAR, 0, "calendar", "/dav/calendars", "/.well-known/caldav",
     http_allow_noauth_get, /*authschemes*/0,
     MBTYPE_CALENDAR,
     (ALLOW_READ | ALLOW_POST | ALLOW_WRITE | ALLOW_DELETE |
@@ -621,7 +621,7 @@ struct namespace_t namespace_calendar = {
 
 /* Namespace for Freebusy Read URL */
 struct namespace_t namespace_freebusy = {
-    URL_NS_FREEBUSY, 0, "/freebusy", NULL,
+    URL_NS_FREEBUSY, 0, "freebusy", "/freebusy", NULL,
     http_allow_noauth_get, /*authschemes*/0,
     MBTYPE_CALENDAR,
     ALLOW_READ,

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -339,7 +339,7 @@ static struct meth_params carddav_params = {
 
 /* Namespace for Carddav collections */
 struct namespace_t namespace_addressbook = {
-    URL_NS_ADDRESSBOOK, 0, "/dav/addressbooks", "/.well-known/carddav",
+    URL_NS_ADDRESSBOOK, 0, "addressbook", "/dav/addressbooks", "/.well-known/carddav",
     http_allow_noauth_get, /*authschemes*/0,
     MBTYPE_ADDRESSBOOK,
     (ALLOW_READ | ALLOW_POST | ALLOW_WRITE | ALLOW_DELETE |

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -297,7 +297,7 @@ static struct meth_params princ_params = {
 
 /* Namespace for WebDAV principals */
 struct namespace_t namespace_principal = {
-    URL_NS_PRINCIPAL, 0, "/dav/principals", NULL,
+    URL_NS_PRINCIPAL, 0, "principal", "/dav/principals", NULL,
     http_allow_noauth_get, /*authschemes*/0,
     /*mbtype */ 0,
     ALLOW_READ | ALLOW_DAV,
@@ -9206,7 +9206,7 @@ struct meth_params notify_params = {
 
 /* Namespace for WebDAV notification collections */
 struct namespace_t namespace_notify = {
-    URL_NS_NOTIFY, 0, "/dav/notifications", NULL,
+    URL_NS_NOTIFY, 0, "notify", "/dav/notifications", NULL,
     http_allow_noauth_get, /*authschemes*/0,
     MBTYPE_COLLECTION,
     (ALLOW_READ | ALLOW_POST | ALLOW_DELETE |

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -56,7 +56,7 @@ static int meth_get_db(struct transaction_t *txn, void *params);
 
 /* Namespace for DB lookups */
 struct namespace_t namespace_dblookup = {
-    URL_NS_DBLOOKUP, /*enabled*/1, "/dblookup", NULL,
+    URL_NS_DBLOOKUP, /*enabled*/1, "dblookup", "/dblookup", NULL,
     http_allow_noauth, /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,

--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -46,6 +46,7 @@
 #include "exitcodes.h"
 #include "httpd.h"
 #include "md5.h"
+#include "prometheus.h"
 #include "util.h"
 
 int (*alpn_select_cb)(SSL *ssl,
@@ -347,6 +348,9 @@ static int frame_recv_cb(nghttp2_session *session,
                 &txn->req_tgt.namespace->methods[txn->meth];
 
             ret = (*meth_t->proc)(txn, meth_t->params);
+
+            prometheus_increment(prometheus_lookup_label(http_methods[txn->meth].metric,
+                                                         txn->req_tgt.namespace->name));
         }
 
         if (ret == HTTP_UNAUTHORIZED) {

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -117,7 +117,7 @@ static struct mime_type_t isched_mime_types[] = {
 };
 
 struct namespace_t namespace_ischedule = {
-    URL_NS_ISCHEDULE, 0, "/ischedule", ISCHED_WELLKNOWN_URI,
+    URL_NS_ISCHEDULE, 0, "ischedule", "/ischedule", ISCHED_WELLKNOWN_URI,
     http_allow_noauth, /*authschemes*/0,
     /*mbtype*/0,
     (ALLOW_READ | ALLOW_POST | ALLOW_ISCHEDULE),
@@ -147,7 +147,7 @@ struct namespace_t namespace_ischedule = {
 };
 
 struct namespace_t namespace_domainkey = {
-    URL_NS_DOMAINKEY, 0, "/domainkeys", "/.well-known/domainkey",
+    URL_NS_DOMAINKEY, 0, "domainkey", "/domainkeys", "/.well-known/domainkey",
     http_allow_noauth, /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -110,7 +110,7 @@ static int myrights_byname(struct auth_state *authstate,
 
 /* Namespace for JMAP */
 struct namespace_t namespace_jmap = {
-    URL_NS_JMAP, 0, JMAP_ROOT, "/.well-known/jmap",
+    URL_NS_JMAP, 0, "jmap", JMAP_ROOT, "/.well-known/jmap",
     jmap_need_auth, /*authschemes*/0,
     /*mbtype*/0, 
     (ALLOW_READ | ALLOW_POST),

--- a/imap/http_prometheus.c
+++ b/imap/http_prometheus.c
@@ -57,6 +57,7 @@ static int prom_get(struct transaction_t *txn, void *params);
 struct namespace_t namespace_prometheus = {
     URL_NS_PROMETHEUS,
     /*enabled*/ 0,
+    "prometheus",
     "/metrics",
     /* XXX .well-known url*/ NULL,
     prom_need_auth,

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -108,7 +108,7 @@ static struct body *body_fetch_section(struct body *body, const char *section);
 
 /* Namespace for RSS feeds of mailboxes */
 struct namespace_t namespace_rss = {
-    URL_NS_RSS, 0, "/rss", NULL,
+    URL_NS_RSS, 0, "rss", "/rss", NULL,
     http_allow_noauth_get, /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -138,7 +138,7 @@ static struct mime_type_t tz_mime_types[] = {
 
 /* Namespace for tzdist service */
 struct namespace_t namespace_tzdist = {
-    URL_NS_TZDIST, 0, "/tzdist", TZDIST_WELLKNOWN_URI,
+    URL_NS_TZDIST, 0, "tzdist", "/tzdist", TZDIST_WELLKNOWN_URI,
     http_allow_noauth, /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -254,7 +254,7 @@ struct meth_params webdav_params = {
 
 /* Namespace for Webdav collections */
 struct namespace_t namespace_drive = {
-    URL_NS_DRIVE, 0, "/dav/drive", NULL,
+    URL_NS_DRIVE, 0, "drive", "/dav/drive", NULL,
     http_allow_noauth_get, /*authschemes*/0,
     MBTYPE_COLLECTION,
     (ALLOW_READ | ALLOW_POST | ALLOW_WRITE | ALLOW_DELETE |

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -907,6 +907,9 @@ void shut_down(int code)
         prometheus_decrement(CYRUS_HTTP_READY_LISTENERS);
     }
 
+    prometheus_increment(code ? CYRUS_HTTP_SHUTDOWN_TOTAL_STATUS_ERROR
+                              : CYRUS_HTTP_SHUTDOWN_TOTAL_STATUS_OK);
+
     if (protin) protgroup_free(protin);
 
     if (config_auditlog)

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -393,32 +393,32 @@ static struct sasl_callback mysasl_cb[] = {
 
 /* Array of HTTP methods known by our server. */
 const struct known_meth_t http_methods[] = {
-    { "ACL",            0 },
-    { "BIND",           0 },
-    { "COPY",           METH_NOBODY },
-    { "DELETE",         METH_NOBODY },
-    { "GET",            METH_NOBODY },
-    { "HEAD",           METH_NOBODY },
-    { "LOCK",           0 },
-    { "MKCALENDAR",     0 },
-    { "MKCOL",          0 },
-    { "MOVE",           METH_NOBODY },
-    { "OPTIONS",        METH_NOBODY },
-    { "PATCH",          0 },
-    { "POST",           0 },
-    { "PROPFIND",       0 },
-    { "PROPPATCH",      0 },
-    { "PUT",            0 },
-    { "REPORT",         0 },
-    { "TRACE",          METH_NOBODY },
-    { "UNBIND",         0 },
-    { "UNLOCK",         METH_NOBODY },
-    { NULL,             0 }
+    { "ACL",            0,              CYRUS_HTTP_ACL_TOTAL },
+    { "BIND",           0,              CYRUS_HTTP_BIND_TOTAL },
+    { "COPY",           METH_NOBODY,    CYRUS_HTTP_COPY_TOTAL },
+    { "DELETE",         METH_NOBODY,    CYRUS_HTTP_DELETE_TOTAL },
+    { "GET",            METH_NOBODY,    CYRUS_HTTP_GET_TOTAL },
+    { "HEAD",           METH_NOBODY,    CYRUS_HTTP_HEAD_TOTAL },
+    { "LOCK",           0,              CYRUS_HTTP_LOCK_TOTAL },
+    { "MKCALENDAR",     0,              CYRUS_HTTP_MKCALENDAR_TOTAL },
+    { "MKCOL",          0,              CYRUS_HTTP_MKCOL_TOTAL },
+    { "MOVE",           METH_NOBODY,    CYRUS_HTTP_MOVE_TOTAL },
+    { "OPTIONS",        METH_NOBODY,    CYRUS_HTTP_OPTIONS_TOTAL },
+    { "PATCH",          0,              CYRUS_HTTP_PATCH_TOTAL },
+    { "POST",           0,              CYRUS_HTTP_POST_TOTAL },
+    { "PROPFIND",       0,              CYRUS_HTTP_PROPFIND_TOTAL },
+    { "PROPPATCH",      0,              CYRUS_HTTP_PROPPATCH_TOTAL },
+    { "PUT",            0,              CYRUS_HTTP_PUT_TOTAL },
+    { "REPORT",         0,              CYRUS_HTTP_REPORT_TOTAL },
+    { "TRACE",          METH_NOBODY,    CYRUS_HTTP_TRACE_TOTAL },
+    { "UNBIND",         0,              CYRUS_HTTP_UNBIND_TOTAL },
+    { "UNLOCK",         METH_NOBODY,    CYRUS_HTTP_UNLOCK_TOTAL },
+    { NULL,             0,              0 }
 };
 
 /* Namespace to fetch static content from filesystem */
 struct namespace_t namespace_default = {
-    URL_NS_DEFAULT, 1, "", NULL,
+    URL_NS_DEFAULT, 1, "default", "", NULL,
     http_allow_noauth, /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,
@@ -1605,6 +1605,9 @@ static int http1_input(struct transaction_t *txn)
             &txn->req_tgt.namespace->methods[txn->meth];
         
         ret = (*meth_t->proc)(txn, meth_t->params);
+
+        prometheus_increment(prometheus_lookup_label(http_methods[txn->meth].metric,
+                                                     txn->req_tgt.namespace->name));
     }
 
     if (ret == HTTP_UNAUTHORIZED) {

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -53,6 +53,7 @@
 #include "hash.h"
 #include "http_client.h"
 #include "mailbox.h"
+#include "prometheus.h"
 #include "spool.h"
 
 #define MAX_REQ_LINE    8000  /* minimum size per RFC 7230 */
@@ -101,6 +102,7 @@
 struct known_meth_t {
     const char *name;
     unsigned flags;
+    enum prom_labelled_metric metric;
 };
 extern const struct known_meth_t http_methods[];
 
@@ -430,6 +432,7 @@ struct method_t {
 struct namespace_t {
     unsigned id;                /* Namespace identifier */
     unsigned enabled;           /* Is this namespace enabled? */
+    const char *name;           /* Text name of this namespace ([A-Z][a-z][0-9]+) */
     const char *prefix;         /* Prefix of URL path denoting namespace */
     const char *well_known;     /* Any /.well-known/ URI */
     int (*need_auth)(txn_t *);  /* Function run prior to unauthorized requests */

--- a/imap/promdata.p
+++ b/imap/promdata.p
@@ -86,3 +86,7 @@ metric counter cyrus_lmtp_sieve_keep_total              The number of sieve KEEP
 metric counter cyrus_lmtp_sieve_notify_total            The number of sieve NOTIFYs
 metric counter cyrus_lmtp_sieve_autorespond_total       The number of sieve AUTORESPONDs considered
 metric counter cyrus_lmtp_sieve_autorespond_sent_total  The number of sieve AUTORESPONDs sent
+
+metric counter cyrus_http_connections_total       The total number of HTTP connections
+metric gauge   cyrus_http_active_connections      The number of active HTTP connections
+metric gauge   cyrus_http_ready_listeners         The number of currently ready HTTP listeners

--- a/imap/promdata.p
+++ b/imap/promdata.p
@@ -90,3 +90,43 @@ metric counter cyrus_lmtp_sieve_autorespond_sent_total  The number of sieve AUTO
 metric counter cyrus_http_connections_total       The total number of HTTP connections
 metric gauge   cyrus_http_active_connections      The number of active HTTP connections
 metric gauge   cyrus_http_ready_listeners         The number of currently ready HTTP listeners
+metric counter cyrus_http_acl_total               The total number of HTTP ACLs
+    label cyrus_http_acl_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_bind_total              The total number of HTTP BINDs
+    label cyrus_http_bind_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_copy_total              The total number of HTTP COPYs
+    label cyrus_http_copy_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_delete_total            The total number of HTTP DELETEs
+    label cyrus_http_delete_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_get_total               The total number of HTTP GETs
+    label cyrus_http_get_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_head_total              The total number of HTTP HEADs
+    label cyrus_http_head_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_lock_total              The total number of HTTP LOCKs
+    label cyrus_http_lock_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_mkcalendar_total        The total number of HTTP MKCALENDARs
+    label cyrus_http_mkcalendar_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_mkcol_total             The total number of HTTP MKCOLs
+    label cyrus_http_mkcol_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_move_total              The total number of HTTP MOVEs
+    label cyrus_http_move_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_options_total           The total number of HTTP OPTIONSs
+    label cyrus_http_options_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_patch_total             The total number of HTTP PATCHs
+    label cyrus_http_patch_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_post_total              The total number of HTTP POSTs
+    label cyrus_http_post_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_propfind_total          The total number of HTTP PROPFINDs
+    label cyrus_http_propfind_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_proppatch_total         The total number of HTTP PROPPATCHs
+    label cyrus_http_proppatch_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_put_total               The total number of HTTP PUTs
+    label cyrus_http_put_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_report_total            The total number of HTTP REPORTs
+    label cyrus_http_report_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_trace_total             The total number of HTTP TRACEs
+    label cyrus_http_trace_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_unbind_total            The total number of HTTP UNBINDs
+    label cyrus_http_unbind_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
+metric counter cyrus_http_unlock_total            The total number of HTTP UNLOCKs
+    label cyrus_http_unlock_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive

--- a/imap/promdata.p
+++ b/imap/promdata.p
@@ -90,6 +90,8 @@ metric counter cyrus_lmtp_sieve_autorespond_sent_total  The number of sieve AUTO
 metric counter cyrus_http_connections_total       The total number of HTTP connections
 metric gauge   cyrus_http_active_connections      The number of active HTTP connections
 metric gauge   cyrus_http_ready_listeners         The number of currently ready HTTP listeners
+metric counter cyrus_http_shutdown_total          The number of HTTP process shutdowns
+    label cyrus_http_shutdown_total status ok error
 metric counter cyrus_http_acl_total               The total number of HTTP ACLs
     label cyrus_http_acl_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive
 metric counter cyrus_http_bind_total              The total number of HTTP BINDs

--- a/imap/promdatagen
+++ b/imap/promdatagen
@@ -50,6 +50,7 @@ my %types = ( counter => 'PROM_METRIC_COUNTER', gauge => 'PROM_METRIC_GAUGE' );
 
 my %options;
 my @metrics;
+my @labels;
 
 sub output_header;
 sub output_source;
@@ -104,7 +105,8 @@ while (my $line = <>) {
 
         foreach my $metric (@metrics) {
             if ($metric->{name} eq $name) {
-                $metric->{label} = { label => $label, values => [ @values ] };
+                $metric->{label} = { name => $name, label => $label, values => [ @values ] };
+                push @labels, $metric->{label};
                 last;
             }
         }
@@ -115,14 +117,14 @@ while (my $line = <>) {
     }
 }
 
-output_header($options{h}, \@metrics) if $options{h};
-output_source($options{c}, \@metrics) if $options{c};
+output_header($options{h}, \@metrics, \@labels) if $options{h};
+output_source($options{c}, \@metrics, \@labels) if $options{c};
 
 exit 0;
 
 sub output_header
 {
-    my ($fname, $metrics) = @_;
+    my ($fname, $metrics, $labels) = @_;
 
     open my $header, '>', $fname or die "$fname: $!\n";
     print $header "#ifndef INCLUDE_PROMDATA_H\n#define INCLUDE_PROMDATA_H\n";
@@ -164,7 +166,29 @@ OKAY
         }
     }
     print $header "\n    PROM_NUM_METRICS /* n.b. leave last! */\n";
+    print $header "};\n\n";
+
+    print $header "enum prom_labelled_metric {\n";
+    $first = 1;
+    foreach my $label (@{$labels}) {
+        print $header "    \U$label->{name}\E";
+        print $header q{ = 0} if $first;
+        $first = 0;
+        print $header qq{,\n};
+    }
+    print $header "\n    PROM_NUM_LABELLED_METRICS /* n.b. leave last! */\n";
     print $header "};\n";
+
+print $header <<OKAY;
+
+struct prom_label_lookup_value {
+    const char *value;
+    enum prom_metric_id id;
+};
+
+extern const struct prom_label_lookup_value *prom_label_lookup_table[];
+
+OKAY
 
     print $header <<OKAY;
 
@@ -195,7 +219,7 @@ OKAY
 
 sub output_source
 {
-    my ($fname, $metrics) = @_;
+    my ($fname, $metrics, $labels) = @_;
 
     open my $source, '>', $fname or die "$fname: $!\n";
 
@@ -225,10 +249,10 @@ OKAY
                             $metric->{name},
                             ($first ? $types{$metric->{type}} : "PROM_METRIC_CONTINUED");
                 if ($first && defined $metric->{help}) {
-                    printf $source '"%s",', $metric->{help};
+                    printf $source '"%s", ', $metric->{help};
                 }
                 else {
-                    print $source "NULL,";
+                    print $source "NULL, ";
                 }
                 printf $source '"%s=\\"%s\\""', $metric->{label}->{label}, $v;
                 print $source " },\n";
@@ -249,6 +273,22 @@ OKAY
         }
     }
     print $source "    { NULL, 0, NULL, NULL },\n";
+    print $source "};\n\n";
+
+    foreach my $label(@{$labels}) {
+        print $source "static const struct prom_label_lookup_value ";
+        print $source "\U$label->{name}_$label->{label}\E_values[] = {\n";
+        foreach my $value(sort @{$label->{values}}) {
+            print $source "    { \"$value\", \U$label->{name}_$label->{label}_$value\E },\n";
+        }
+        print $source "    { NULL, 0 },\n";
+        print $source "};\n\n";
+    }
+
+    print $source "EXPORTED const struct prom_label_lookup_value *prom_label_lookup_table[] = {\n";
+    foreach my $label (@{$labels}) {
+        print $source "    \U$label->{name}_$label->{label}\E_values,\n";
+    }
     print $source "};\n";
 
     close $source;

--- a/imap/promdatagen
+++ b/imap/promdatagen
@@ -105,6 +105,9 @@ while (my $line = <>) {
 
         foreach my $metric (@metrics) {
             if ($metric->{name} eq $name) {
+                if (exists $metric->{label} ) {
+                    die "cannot define more than one label for metric \"$name\" at line $lineno\n";
+                }
                 $metric->{label} = { name => $name, label => $label, values => [ @values ] };
                 push @labels, $metric->{label};
                 last;

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -313,3 +313,23 @@ EXPORTED int prometheus_text_report(struct buf *buf, const char **mimetype)
     free(report_fname);
     return r;
 }
+
+EXPORTED enum prom_metric_id prometheus_lookup_label(enum prom_labelled_metric metric,
+                                                     const char *value)
+{
+    size_t i;
+
+    assert(metric >= 0 && metric < PROM_NUM_LABELLED_METRICS);
+
+    for (i = 0; prom_label_lookup_table[metric][i].value != NULL; i++) {
+        const struct prom_label_lookup_value *v = &prom_label_lookup_table[metric][i];
+
+        int cmp = strcmp(v->value, value);
+        if (cmp == 0) /* found it */
+            return v->id;
+        if (cmp > 0) /* gone too far, not found */
+            break;
+    }
+
+    fatal("invalid metric value -- compile time bug", EC_SOFTWARE);
+}

--- a/imap/prometheus.h
+++ b/imap/prometheus.h
@@ -69,4 +69,7 @@ extern void prometheus_apply_delta(enum prom_metric_id metric_id,
 
 extern int prometheus_text_report(struct buf *buf, const char **mimetype);
 
+extern enum prom_metric_id prometheus_lookup_label(enum prom_labelled_metric metric,
+                                                   const char *value);
+
 #endif


### PR DESCRIPTION
This adds two kinds of metrics to httpd:

* basic connection level stuff (total connections, active connections, ready listeners, shutdown statuses)
* general method/namespace stuff (introspectively)

I expect at some point we will want to enrich the statistics we gather for some protocols that sit on top of httpd -- I'm thinking particularly of JMAP here.  There's no reason that each `imap/http_[namespace].c` file cannot track its own metrics in addition to the generic ones `imap/httpd.c` tracks: just set them up and count them appropriately.  I'd suggest naming such metrics `cyrus_jmap_...` or whatever, so they're clearly distinct from `cyrus_http_...`

In the meantime though, here's the bones.  I think this is also a pretty good demo of how to add new metrics to services we're not currently tracking metrics from (such as popd).