### PR TITLE
master: report service metrics for prometheus

### DIFF
--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -311,5 +311,25 @@ EXPORTED int prometheus_text_report(struct buf *buf, const char **mimetype)
     mappedfile_unlock(mf);
     mappedfile_close(&mf);
     free(report_fname);
-    return r;
+
+    if (r) return r;
+
+    report_fname = strconcat(prometheus_stats_dir(), FNAME_PROM_MASTER_REPORT, NULL);
+
+    r = mappedfile_open(&mf, report_fname, 0);
+    if (r) {
+        free(report_fname);
+        return 0; /* no master.txt yet? no worries */
+    }
+
+    r = mappedfile_readlock(mf);
+    if (!r) {
+        buf_appendmap(buf, mappedfile_base(mf), mappedfile_size(mf));
+    }
+
+    mappedfile_unlock(mf);
+    mappedfile_close(&mf);
+    free(report_fname);
+
+    return 0;
 }

--- a/imap/prometheus.h
+++ b/imap/prometheus.h
@@ -53,6 +53,7 @@
 #include "imap/promdata.h"
 
 #define FNAME_PROM_REPORT "report.txt"
+#define FNAME_PROM_MASTER_REPORT "master.txt"
 #define FNAME_PROM_DONEPROCS "doneprocs"
 #define FNAME_PROM_STATS_DIR "/stats"
 

--- a/master/master.c
+++ b/master/master.c
@@ -1997,6 +1997,7 @@ static void init_prom_report(struct timeval now)
         if (prom_report_fname) free(prom_report_fname);
         prom_report_fname = buf_release(&buf);
         cyrus_mkdir(prom_report_fname, 0755);
+        syslog(LOG_DEBUG, "updating %s every %d seconds", prom_report_fname, prom_frequency);
     }
 }
 
@@ -2028,6 +2029,7 @@ static void do_prom_report(struct timeval now)
     }
 
     /* okay, now prepare the report */
+    syslog(LOG_DEBUG, "updating prometheus report for master process");
     last_updated = now_ms();
 
     buf_printf(&report, "# HELP %s %s\n",

--- a/master/master.c
+++ b/master/master.c
@@ -2136,6 +2136,8 @@ static void do_prom_report(struct timeval now)
     close(fd);
 
     prom_prev_report = now;
+
+    buf_free(&report);
 }
 
 static void reread_conf(struct timeval now)

--- a/master/master.c
+++ b/master/master.c
@@ -2028,26 +2028,23 @@ static void do_prom_report(struct timeval now)
     }
 
     /* okay, now prepare the report */
-//    int ready_workers;          /* num child processes ready for service */
-//    int nforks;                 /* num child processes spawned */
-//    int nactive;                /* num children servicing clients */
-//    int nconnections;           /* num connections made to children */
-//    double forkrate;            /* rate at which we're spawning children */
-//    int nreadyfails;            /* number of failures in READY state */
-
     last_updated = now_ms();
 
-    buf_appendcstr(&report, "# HELP cyrus_master_ready_total The number of ready workers\n");
-    buf_appendcstr(&report, "# TYPE cyrus_master_ready_total gauge\n");
+    buf_printf(&report, "# HELP %s %s\n",
+                        "cyrus_master_ready_workers",
+                        "The number of ready workers");
+    buf_appendcstr(&report, "# TYPE cyrus_master_ready_workers gauge\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];
-        buf_printf(&report, "cyrus_master_ready_total{service=\"%s\",family=\"%s\"}",
+        buf_printf(&report, "cyrus_master_ready_workers{service=\"%s\",family=\"%s\"}",
                             s->name, s->familyname);
         buf_printf(&report, " %d %" PRId64 "\n",
                             s->ready_workers, last_updated);
     }
 
-    buf_appendcstr(&report, "# HELP cyrus_master_forks_total The number of children spawned\n");
+    buf_printf(&report, "# HELP %s %s\n",
+                        "cyrus_master_forks_total",
+                        "The number of children spawned");
     buf_appendcstr(&report, "# TYPE cyrus_master_forks_total counter\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];
@@ -2057,11 +2054,13 @@ static void do_prom_report(struct timeval now)
                             s->nforks, last_updated);
     }
 
-    buf_appendcstr(&report, "# HELP cyrus_master_active_total The number of children servicing clients\n");
-    buf_appendcstr(&report, "# TYPE cyrus_master_active_total gauge\n");
+    buf_printf(&report, "# HELP %s %s\n",
+                        "cyrus_master_active_children",
+                        "The number of children servicing clients");
+    buf_appendcstr(&report, "# TYPE cyrus_master_active_children gauge\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];
-        buf_printf(&report, "cyrus_master_active_total{service=\"%s\",family=\"%s\"}",
+        buf_printf(&report, "cyrus_master_active_children{service=\"%s\",family=\"%s\"}",
                             s->name, s->familyname);
         buf_printf(&report, " %d %" PRId64 "\n",
                             s->nactive, last_updated);
@@ -2069,17 +2068,21 @@ static void do_prom_report(struct timeval now)
 
     /* XXX what is nconnections? */
 
-    buf_appendcstr(&report, "# HELP cyrus_master_fork_rate The rate at which we're spawning children\n");
-    buf_appendcstr(&report, "# TYPE cyrus_master_fork_rate gauge\n");
+    buf_printf(&report, "# HELP %s %s\n",
+                        "cyrus_master_forks_per_second",
+                        "The rate at which we're spawning children");
+    buf_appendcstr(&report, "# TYPE cyrus_master_forks_per_second gauge\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];
-        buf_printf(&report, "cyrus_master_fork_rate{service=\"%s\",family=\"%s\"}",
+        buf_printf(&report, "cyrus_master_forks_per_second{service=\"%s\",family=\"%s\"}",
                             s->name, s->familyname);
         buf_printf(&report, " %g %" PRId64 "\n",
                             s->forkrate, last_updated);
     }
 
-    buf_appendcstr(&report, "# HELP cyrus_master_ready_fails_total The number of failures in READY state\n");
+    buf_printf(&report, "# HELP %s %s\n",
+                        "cyrus_master_ready_fails_total",
+                        "The number of failures in READY state");
     buf_appendcstr(&report, "# TYPE cyrus_master_ready_fails_total counter\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];

--- a/master/master.c
+++ b/master/master.c
@@ -2080,6 +2080,18 @@ static void do_prom_report(struct timeval now)
                             s->nactive, last_updated);
     }
 
+    buf_printf(&report, "# HELP %s %s\n",
+                        "cyrus_master_max_children",
+                        "The maximum number of child processes");
+    buf_appendcstr(&report, "# TYPE cyrus_master_max_children gauge\n");
+    for (i = 0; i < nservices; i++) {
+        const struct service *s = &Services[i];
+        buf_printf(&report, "cyrus_master_max_children{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %d %" PRId64 "\n",
+                            s->max_workers, last_updated);
+    }
+
     /* XXX what is nconnections? */
 
     buf_printf(&report, "# HELP %s %s\n",
@@ -2092,6 +2104,18 @@ static void do_prom_report(struct timeval now)
                             s->name, s->familyname);
         buf_printf(&report, " %g %" PRId64 "\n",
                             s->forkrate, last_updated);
+    }
+
+    buf_printf(&report, "# HELP %s %s\n",
+                        "cyrus_master_max_forks_per_second",
+                        "The maximum rate at which we will spawn children");
+    buf_appendcstr(&report, "# TYPE cyrus_master_max_forks_per_second gauge\n");
+    for (i = 0; i < nservices; i++) {
+        const struct service *s = &Services[i];
+        buf_printf(&report, "cyrus_master_max_forks_per_second{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %u %" PRId64 "\n",
+                            s->maxforkrate, last_updated);
     }
 
     buf_printf(&report, "# HELP %s %s\n",


### PR DESCRIPTION
This adds a mechanism by which master can include its service metrics into the prometheus metrics, while only depending on code already in libcyrus_min.

I'm particularly interested in suggestions for what these metrics should be named, their help strings, and most importantly, whether they're actually useful.  I've also left out the "nconnections" stat for now cause I'm not really clear what it's actually counting.

I consider this pull request to be a work in progress at the moment.