### PR TITLE
prometheus: service labels based on config_ident

### DIFF
--- a/imap/promdatagen
+++ b/imap/promdatagen
@@ -182,11 +182,10 @@ struct prom_metric {
 };
 
 struct prom_stats {
-    pid_t pid;
     char  ident[512];   /* XXX places upper limit on service names */
     struct prom_metric metrics[PROM_NUM_METRICS];
 };
-#define PROM_STATS_INITIALIZER {0}
+#define PROM_STATS_INITIALIZER { {0}, {{0, 0}} }
 
 OKAY
 

--- a/imap/promdatagen
+++ b/imap/promdatagen
@@ -183,6 +183,7 @@ struct prom_metric {
 
 struct prom_stats {
     pid_t pid;
+    char  ident[512];   /* XXX places upper limit on service names */
     struct prom_metric metrics[PROM_NUM_METRICS];
 };
 #define PROM_STATS_INITIALIZER {0}

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -106,7 +106,6 @@ static void prometheus_init(void)
     char fname[PATH_MAX];
     struct prometheus_handle *handle = NULL;
     struct prom_stats stats = PROM_STATS_INITIALIZER;
-    int i;
     int r;
 
     if (promhandle != NULL) return;
@@ -115,10 +114,6 @@ static void prometheus_init(void)
     if (!prometheus_enabled) return;
 
     stats.pid = getpid();
-    for (i = 0; i < PROM_NUM_METRICS; i++) {
-        stats.metrics[i].last_updated = now_ms();
-    }
-
     r = snprintf(stats.ident, sizeof(stats.ident), "%s", config_ident);
     if (r < 0 || (size_t) r >= sizeof(stats.ident))
         syslog(LOG_WARNING, "service name '%s' is longer than " SIZE_T_FMT

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -113,7 +113,6 @@ static void prometheus_init(void)
     prometheus_enabled = config_getswitch(IMAPOPT_PROMETHEUS_ENABLED);
     if (!prometheus_enabled) return;
 
-    stats.pid = getpid();
     r = snprintf(stats.ident, sizeof(stats.ident), "%s", config_ident);
     if (r < 0 || (size_t) r >= sizeof(stats.ident))
         syslog(LOG_WARNING, "service name '%s' is longer than " SIZE_T_FMT
@@ -122,7 +121,7 @@ static void prometheus_init(void)
                             sizeof(stats.ident) - 1);
 
     r = snprintf(fname, sizeof(fname), "%s%jd",
-                 prometheus_stats_dir(), (intmax_t) stats.pid);
+                 prometheus_stats_dir(), (intmax_t) getpid());
     if (r < 0 || (size_t) r >= sizeof(fname))
         fatal("unable to register stats for prometheus", EC_CONFIG);
 
@@ -209,7 +208,6 @@ static void prometheus_done(void *rock __attribute__((unused)))
     if (r) goto done;
 
     memcpy(&accum, mappedfile_base(doneprocs), mappedfile_size(doneprocs));
-    if (accum.pid == 0) accum.pid = (pid_t) -1;
     if (accum.ident[0] == '\0') {
         snprintf(accum.ident, sizeof(accum.ident), "%s", config_ident);
     }

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -119,6 +119,13 @@ static void prometheus_init(void)
         stats.metrics[i].last_updated = now_ms();
     }
 
+    r = snprintf(stats.ident, sizeof(stats.ident), "%s", config_ident);
+    if (r < 0 || (size_t) r >= sizeof(stats.ident))
+        syslog(LOG_WARNING, "service name '%s' is longer than " SIZE_T_FMT
+                            " characters - prometheus label will be truncated",
+                            config_ident,
+                            sizeof(stats.ident) - 1);
+
     r = snprintf(fname, sizeof(fname), "%s%jd",
                  prometheus_stats_dir(), (intmax_t) stats.pid);
     if (r < 0 || (size_t) r >= sizeof(fname))
@@ -169,14 +176,33 @@ static void prometheus_done(void *rock __attribute__((unused)))
     struct prom_stats thisproc = PROM_STATS_INITIALIZER;
     struct mappedfile *doneprocs = NULL;
     char *doneprocs_fname;
+    char *doneprocs_lock_fname;
+    int doneprocs_lock_fd;
     int i, r = 0;
     int unlinked = 0;
 
     if (!promhandle) return; /* make double-call safe */
 
-    /* load existing doneprocs stats.  we hold this write lock until we're
-     * finished, so that promstatsd won't double-count in the interim */
-    doneprocs_fname = strconcat(prometheus_stats_dir(), FNAME_PROM_DONEPROCS, NULL);
+    /* hold a lock on .doneprocs.lock - this keeps promstatsd from double
+     * counting while we're juggling files */
+    doneprocs_lock_fname = strconcat(prometheus_stats_dir(), ".",
+                                     FNAME_PROM_DONEPROCS, ".lock", NULL);
+
+    doneprocs_lock_fd = open(doneprocs_lock_fname, O_CREAT|O_TRUNC|O_RDWR, 0644);
+    if (doneprocs_lock_fd == -1) {
+        syslog(LOG_ERR, "can't open doneprocs lock: %s (%m)", doneprocs_lock_fname);
+        goto done;
+    }
+    if (lock_setlock(doneprocs_lock_fd, /*ex*/1, /*nb*/0, doneprocs_lock_fname)) {
+        syslog(LOG_ERR, "can't get exclusive lock on %s", doneprocs_lock_fname);
+        close(doneprocs_lock_fd);
+        doneprocs_lock_fd = -1;
+        goto done;
+    }
+
+    /* load existing doneprocs stats */
+    doneprocs_fname = strconcat(prometheus_stats_dir(), FNAME_PROM_DONEPROCS,
+                                ".", config_ident, NULL);
     r = mappedfile_open(&doneprocs, doneprocs_fname, MAPPEDFILE_CREATE | MAPPEDFILE_RW);
     if (r) {
         syslog(LOG_ERR, "IOERROR: mappedfile_open(%s): %s",
@@ -189,6 +215,9 @@ static void prometheus_done(void *rock __attribute__((unused)))
 
     memcpy(&accum, mappedfile_base(doneprocs), mappedfile_size(doneprocs));
     if (accum.pid == 0) accum.pid = (pid_t) -1;
+    if (accum.ident[0] == '\0') {
+        snprintf(accum.ident, sizeof(accum.ident), "%s", config_ident);
+    }
 
     /* read stats from this process */
     r = mappedfile_readlock(promhandle->mf);
@@ -236,6 +265,14 @@ done:
 
     mappedfile_unlock(doneprocs);
     mappedfile_close(&doneprocs);
+
+    /* release .doneprocs.lock */
+    if (doneprocs_lock_fd != -1) {
+        unlink(doneprocs_lock_fname);
+        lock_unlock(doneprocs_lock_fd, doneprocs_lock_fname);
+        close(doneprocs_lock_fd);
+    }
+    free(doneprocs_lock_fname);
 }
 
 /* use the prometheus_increment() and prometheus_decrement() wrapper macros

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -218,6 +218,10 @@ static void format_metric(const char *key __attribute__((unused)),
     struct prom_stats *stats = (struct prom_stats *) data;
     struct format_metric_rock *fmrock = (struct format_metric_rock *) rock;
 
+    /* don't report service/metric combinations that have never been seen */
+    if (!stats->metrics[fmrock->metric].last_updated)
+        return;
+
     buf_appendcstr(fmrock->buf, prom_metric_descs[fmrock->metric].name);
     buf_printf(fmrock->buf, "{service=\"%s\"", stats->ident);
     if (prom_metric_descs[fmrock->metric].label)


### PR DESCRIPTION
This PR labels metrics with the ident of the service counting them. For example if your cyrus.conf has both "imap" and "imaps" services, the `cyrus_imap_foo` metric will be split up into `cyrus_imap_foo{service="imap"}` and `cyrus_imap_foo{service="imaps"}`, even though the same binary is used for both services.

To avoid reporting metric/service combinations that will never be seen (e.g. `cyrus_lmtp_foo{service="imap"}`), this PR: 
   * no longer automatically initialises the last_updated field of metrics during `prometheus_init()`, instead leaving it as zero; and
   * only reports metrics that have a non-zero last updated

A consequence of this is that a newly started Cyrus instance will report very few statistics at all, but the report will gradually thicken out as interesting events occur and are counted.