### PR TITLE
Bump MODSEQ for changes made by xrunannotator.

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -1462,6 +1462,10 @@ EXPORTED int index_run_annotator(struct index_state *state,
         msgrecord_unref(&msgrec);
     }
 
+    /* Update highestmodseq if something has changed */
+    if (state->highestmodseq != state->mailbox->i.highestmodseq)
+        index_refresh_locked(state);
+
 out:
     seqset_free(seq);
 


### PR DESCRIPTION
Changes made by annotator via `xrunannotator` aren't immediately
visible. This was because the MODSEQ wasn't being bumped. This patch
updates the MODSEQ appropriately when `xrunannotor` command is run.