### PR TITLE
[Docs] Odd-even release cycle versioning.

### DIFF
--- a/docsrc/imap/download/release-notes/3.1/index.rst
+++ b/docsrc/imap/download/release-notes/3.1/index.rst
@@ -1,8 +1,15 @@
 .. _imap-release-notes-3.1:
 
-=============================
-Cyrus IMAP 3.1 Releases
-=============================
+===================
+Cyrus IMAP 3.1 Tags
+===================
+
+.. warning::
+
+    The 3.1 series are tagged snapshots of the master branch, and should be considered for
+    **testing purposes** and **bleeding-edge features** only. We will try to tag these
+    snapshots at coherent development points, but there will generally be **large
+    breaking changes** occurring between releases in this series.
 
 .. toctree::
     :maxdepth: 1

--- a/docsrc/imap/download/release-notes/3.1/x/3.1.1.rst
+++ b/docsrc/imap/download/release-notes/3.1/x/3.1.1.rst
@@ -1,12 +1,19 @@
 :tocdepth: 3
 
-==================================
-Cyrus IMAP 3.1.1 Release Notes
-==================================
+==========================
+Cyrus IMAP 3.1.1 Tag Notes
+==========================
 
 Unavailable for download as this is a development branch only.
 
 Access is via git.
+
+.. warning::
+
+    This should be considered for
+    **testing purposes** and **bleeding-edge features** only. We will try to tag these
+    snapshots at coherent development points, but there will generally be **large
+    breaking changes** occurring between releases in this series.
 
 .. _relnotes-3.1.1-changes:
 

--- a/docsrc/imap/download/release-notes/index.rst
+++ b/docsrc/imap/download/release-notes/index.rst
@@ -2,6 +2,13 @@
 Release Notes
 =============
 
+Cyrus has switched to an `odd-even release cycle <http://producingoss.com/en/development-cycle.html#release-number-even-odd-strategy>`_.
+
+With our versioning system using ``major.minor.micro`` numbering, the minor number
+reveals whether a version is stable (even), or development-only (odd).
+
+A 3.0.1 release is stable, but a 3.1.4 release is developmental only.
+
 Stable Version
 ==============
 
@@ -11,14 +18,19 @@ Latest stable version is |imap_stable_release_notes|. Documentation at :cyrus-st
 Development Version
 ===================
 
-..
-    Latest development version is |imap_development_release_notes|. Documentation at :cyrus-dev:`/`.
+Latest development snapshot is |imap_development_release_notes|. Documentation at :cyrus-dev:`/`.
 
-There have not yet been any releases from the current development series.
-Documentation is at :cyrus-dev:`/`.
+.. warning::
+
+    These are tagged snapshots of the master branch, and should be considered for
+    **testing purposes** and **bleeding-edge features** only. We will try to tag these
+    snapshots at coherent development points, but there will generally be **large
+    breaking changes** occurring between releases in this series.
 
 Supported Product Series
 ========================
+
+.. Hide the release notes for unstable series
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
Some documentation outlining the odd and even approach
in our release versioning. Odd = development only, even= stable.

Flagging the odd releases with big warning messages so
nobody can be surprised at what they're seeing.