### PR TITLE
[Annotator] Control use of annotator during append

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -1223,6 +1223,11 @@ HIDDEN int append_run_annotator(struct appendstate *as,
     if (!config_getstring(IMAPOPT_ANNOTATION_CALLOUT))
         return 0;
 
+    if (config_getswitch(IMAPOPT_ANNOTATION_CALLOUT_DISABLE_APPEND)) {
+        syslog(LOG_DEBUG, "append_run_annotator: Append disabled.");
+        return 0;
+    }
+
     r = msgrecord_extract_flags(msgrec, as->userid, &flags);
     if (r) goto out;
     r = msgrecord_extract_annots(msgrec, &user_annots);

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -272,6 +272,8 @@ Blank lines and lines beginning with ``#'' are ignored.
    or flags to a message when it is appended to a mailbox.  The path can
    be either an executable (including a script), or a UNIX domain
    socket.  */
+{ "annotation_callout_disable_append", 0, SWITCH }
+/* Disables annotations on append with xrunannotator */
 
 { "aps_topic", NULL, STRING }
 /* Topic for Apple Push Service registration. */


### PR DESCRIPTION
Add separate config variable to control use of annotator during append.

Fixes #2109