### PR TITLE
[build] Workarounds to work with makemaker.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1915,6 +1915,8 @@ if PERL
 	( packlists=`find $(DESTDIR)$(libdir) -type f -name .packlist` && \
 	  echo "uninstalling files from packlists: $$packlists" && \
 	  rm -f `cat $$packlists` )
+	( podfiles=`find $(DESTDIR)$(libdir) -type f -name perllocal.pod` && \
+	  rm -f `echo $$podfiles` )
 endif
 
 install-binsymlinks:

--- a/configure.ac
+++ b/configure.ac
@@ -1837,6 +1837,7 @@ dnl compile perl stuff and perl/cyradm
 dnl Make sure perl modules are in the build directory (which isn't necessarily
 dnl the source directory)
     AC_CONFIG_LINKS([perl/sieve/managesieve/managesieve.pm:perl/sieve/managesieve/managesieve.pm])
+    AC_CONFIG_FILES([perl/sieve/managesieve/MANIFEST:perl/sieve/managesieve/MANIFEST])
     AC_CONFIG_LINKS([perl/imap/Cyrus/HeaderFile.pm:perl/imap/Cyrus/HeaderFile.pm])
     AC_CONFIG_LINKS([perl/imap/Cyrus/CacheFile.pm:perl/imap/Cyrus/CacheFile.pm])
     AC_CONFIG_LINKS([perl/imap/Cyrus/IndexFile.pm:perl/imap/Cyrus/IndexFile.pm])
@@ -1847,9 +1848,11 @@ dnl the source directory)
     AC_CONFIG_LINKS([perl/imap/IMAP/IMSP.pm:perl/imap/IMAP/IMSP.pm])
     AC_CONFIG_LINKS([perl/imap/IMAP/Admin.pm:perl/imap/IMAP/Admin.pm])
     AC_CONFIG_LINKS([perl/imap/IMAP.pm:perl/imap/IMAP.pm])
+    AC_CONFIG_FILES([perl/imap/MANIFEST:perl/imap/MANIFEST])
     AC_CONFIG_LINKS([perl/annotator/Message.pm:perl/annotator/Message.pm])
     AC_CONFIG_LINKS([perl/annotator/AnnotateInlinedCIDs.pm:perl/annotator/AnnotateInlinedCIDs.pm])
     AC_CONFIG_LINKS([perl/annotator/Daemon.pm:perl/annotator/Daemon.pm])
+    AC_CONFIG_FILES([perl/annotator/MANIFEST:perl/annotator/MANIFEST])
 
 dnl add perl cccdlflags when building libraries -- this ensures that the
 dnl libraries will be compiled as PIC if perl requires PIC objects


### PR DESCRIPTION
`make distcheck fails in the Debian testing because of this[1] change in
`ExtUtils::MakeMaker`.

To workaround that problem, this commit adds the `MANIFEST` files to the
build src directories using `AC_CONFIG_FILES`. I tried with
`AC_CONFIG_LINKS` but since the resulting symbolic links point to read
only files, that didn't work. So using `AC_CONFIG_FILES` instead.

Using `AC_CONFIG_FILES` results in a couple of warnings from automake
saying there is a circular dependency issues and that rule isn't being
ignored.

At this point there are too many workarounds in place for autotools to
work with the perl modules in Cyrus. Perhaps it is time to rethink how
we work with the perl modules.

[1] -
https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/5742aeb93564a24634adc6055aa2a745d228d287