### PR TITLE
sync_support: downgrade recoverable SYNCERRORs to SYNCNOTICE

### DIFF
--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2442,7 +2442,7 @@ static int sync_mailbox_compare_update(struct mailbox *mailbox,
             /* GUID mismatch is an error straight away, it only ever happens if we
              * had a split brain - and it will take a full sync to sort out the mess */
             if (!message_guid_equal(&mrecord.guid, &rrecord->guid)) {
-                syslog(LOG_ERR, "SYNCERROR: guid mismatch %s %u",
+                syslog(LOG_ERR, "SYNCNOTICE: guid mismatch %s %u",
                        mailbox->name, mrecord.uid);
                 r = IMAP_SYNC_CHECKSUM;
                 goto out;
@@ -2455,7 +2455,7 @@ static int sync_mailbox_compare_update(struct mailbox *mailbox,
                            mailbox->name, mrecord.uid, rrecord->modseq, mrecord.modseq);
                 }
                 else {
-                    syslog(LOG_ERR, "SYNCERROR: higher modseq on replica %s %u (" MODSEQ_FMT " > " MODSEQ_FMT ")",
+                    syslog(LOG_ERR, "SYNCNOTICE: higher modseq on replica %s %u (" MODSEQ_FMT " > " MODSEQ_FMT ")",
                            mailbox->name, mrecord.uid, rrecord->modseq, mrecord.modseq);
                     r = IMAP_SYNC_CHECKSUM;
                     goto out;
@@ -2466,7 +2466,7 @@ static int sync_mailbox_compare_update(struct mailbox *mailbox,
              * that's bad */
             if (!(mrecord.system_flags & FLAG_EXPUNGED) &&
                  (rrecord->system_flags & FLAG_EXPUNGED)) {
-                syslog(LOG_ERR, "SYNCERROR: expunged on replica %s %u",
+                syslog(LOG_ERR, "SYNCNOTICE: expunged on replica %s %u",
                        mailbox->name, mrecord.uid);
                 r = IMAP_SYNC_CHECKSUM;
                 goto out;
@@ -4936,7 +4936,7 @@ static int mailbox_update_loop(struct mailbox *mailbox,
             else if (rrecord.uid > mrecord->uid) {
                 /* record only exists on the master */
                 if (!(mrecord->system_flags & FLAG_EXPUNGED)) {
-                    syslog(LOG_ERR, "SYNCERROR: only exists on master %s %u (%s)",
+                    syslog(LOG_ERR, "SYNCNOTICE: only exists on master %s %u (%s)",
                            mailbox->name, mrecord->uid,
                            message_guid_encode(&mrecord->guid));
                     r = renumber_one_record(mrecord, kaction);
@@ -4950,7 +4950,7 @@ static int mailbox_update_loop(struct mailbox *mailbox,
                 /* record only exists on the replica */
                 if (!(rrecord.system_flags & FLAG_EXPUNGED)) {
                     if (kaction)
-                        syslog(LOG_ERR, "SYNCERROR: only exists on replica %s %u (%s)",
+                        syslog(LOG_ERR, "SYNCNOTICE: only exists on replica %s %u (%s)",
                                mailbox->name, rrecord.uid,
                                message_guid_encode(&rrecord.guid));
                     r = copyback_one_record(mailbox, &rrecord, rannots, kaction, part_list, sync_be);


### PR DESCRIPTION
Assuming that SYNCERROR means what I think it (should mean), namely "I
can't possible continue and will need an operator to intervene", all the
cases that are recoverable by doing a full resync should only warn.

The only thing I'm not sure about is if a full resync can ever fail for
one of these reasons. If it can, then there's now nothing to alert the
operator, and this patch probably should be applied as-is (at the cost
of someone getting woken up :/ )