### PR TITLE
sync_support: emit a SYNCERROR on unexpected mailbox uniqueid change

### DIFF
--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2681,7 +2681,7 @@ int sync_apply_mailbox(struct dlist *kin,
             mailbox->header_dirty = 1;
         }
         else {
-            syslog(LOG_ERR, "Mailbox uniqueid changed %s (%s => %s) - retry",
+            syslog(LOG_ERR, "SYNCERROR: Mailbox uniqueid changed %s (%s => %s) - retry",
                    mboxname, mailbox->uniqueid, uniqueid);
             r = IMAP_MAILBOX_MOVED;
             goto done;


### PR DESCRIPTION
I saw this today while recovering after a disk crash. It did not recover
by itself. I don't know if it should be recoverable by a full sync (and
this code should return IMAP_SYNC_CHECKSUM), but as long as requires
operator interventions, is should log a SYNCERROR.