### PR TITLE
Update help for multiple cyr tools.

### DIFF
--- a/docsrc/imap/reference/manpages/systemcommands/reconstruct.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/reconstruct.rst
@@ -17,11 +17,11 @@ Synopsis
 
     **reconstruct** [ **-C** *config-file* ] [ **-p** *partition* ] [ **-x** ] [ **-r** ]
         [ **-f** ] [ **-U** ] [ **-s** ] [ **-q** ] [ **-G** ] [ **-R** ] [ **-o** ]
-        [ **-O** ] [ **-M** ] *mailbox*...
+        [ **-O** ] [ **-M** ] [ **-V** ] *mailbox*...
 
     **reconstruct** [ **-C** *config-file* ] [ **-p** *partition* ] [ **-x** ] [ **-r** ]
         [ **-f** ] [ **-U** ] [ **-s** ] [ **-q** ] [ **-G** ] [ **-R** ] [ **-o** ]
-        [ **-O** ] [ **-M** ] [ -u ] *users*...
+        [ **-O** ] [ **-M** ] [ -u ] [ **-V** ] *users*...
 
     **reconstruct** [ **-C** *config-file* ] **-m**
 

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -1,6 +1,6 @@
 /* cyr_expire.c -- Program to expire deliver.db entries and messages
  *
- * Copyright (c) 1994-2008 Carnegie Mellon University.  All rights reserved.
+ * Copyright (c) 1994-2017 Carnegie Mellon University.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,6 +62,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <libgen.h>
 
 #include <sasl/sasl.h>
 
@@ -217,18 +218,9 @@ static void cyr_expire_cleanup(struct cyr_expire_ctx *ctx)
     cyrus_done();
 }
 
-static void set_progname(const char *str)
-{
-    const char *slash = strrchr(str, '/');
-    if (slash)
-        progname = slash + 1;
-    else
-        progname = str;
-}
-
 static void usage(void)
 {
-    fprintf(stderr, "Usage: %s [OPTIONS]\n", progname);
+    fprintf(stderr, "Usage: %s [OPTIONS] {mailbox|users}\n", progname);
     fprintf(stderr, "Expire messages and duplicate delivery database entries.\n");
     fprintf(stderr, "\n");
 
@@ -248,7 +240,7 @@ static void usage(void)
 
     fprintf(stderr, "\n");
 
-    exit(-1);
+    exit(EC_USAGE);
 }
 
 /*
@@ -873,7 +865,7 @@ int main(int argc, char *argv[])
     int r = 0;
     struct cyr_expire_ctx ctx = zero_ctx;
 
-    set_progname(argv[0]);
+    progname = basename(argv[0]);
 
     if ((geteuid()) == 0 && (become_cyrus(/*is_master*/0) != 0)) {
         fatal("must run as the Cyrus user", EC_USAGE);

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -1,4 +1,4 @@
-/* ctl_info.c - tool to get information about cyrus
+/* cyr_info.c - tool to get information about cyrus
  *
  * Copyright (c) 1994-2008 Carnegie Mellon University.  All rights reserved.
  *

--- a/imap/cyrdump.c
+++ b/imap/cyrdump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994-2008 Carnegie Mellon University.  All rights reserved.
+ * Copyright (c) 1994-2017 Carnegie Mellon University.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <libgen.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -65,6 +66,7 @@
 #include "imap/imap_err.h"
 
 static int verbose = 0;
+static const char *progname = NULL;
 
 static int dump_me(struct findall_data *data, void *rock);
 static void print_seq(const char *tag, const char *attrib,
@@ -85,6 +87,8 @@ int main(int argc, char *argv[])
     if ((geteuid()) == 0 && (become_cyrus(/*is_master*/0) != 0)) {
         fatal("must run as the Cyrus user", EC_USAGE);
     }
+
+    progname = basename(argv[0]);
 
     while ((option = getopt(argc, argv, "vC:")) != EOF) {
         switch (option) {
@@ -125,7 +129,14 @@ int main(int argc, char *argv[])
 
 static int usage(const char *name)
 {
-    fprintf(stderr, "usage: %s [-v] [mboxpattern ...]\n", name);
+    fprintf(stderr, "Usage: %s [OPTIONS] {mailboxes}\n", progname);
+    fprintf(stderr, "Dumps out a basic copy of mailbox data to stdout.\n");
+    fprintf(stderr, "\n");
+
+    fprintf(stderr, "-C <config-file>         use <config-file> instead of config from imapd.conf\n");
+    fprintf(stderr, "-v                       enable verbose output\n");
+
+    fprintf(stderr, "\n");
 
     exit(EC_USAGE);
 }

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -1,6 +1,6 @@
 /* reconstruct.c -- program to reconstruct a mailbox
  *
- * Copyright (c) 1994-2008 Carnegie Mellon University.  All rights reserved.
+ * Copyright (c) 1994-2017 Carnegie Mellon University.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,6 +54,7 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <sys/stat.h>
+#include <libgen.h>
 #ifdef HAVE_ZLIB
 #include <zlib.h>
 #endif
@@ -113,6 +114,9 @@ struct reconstruct_rock {
     hash_table visited;
 };
 
+/* Program name */
+static const char *progname = NULL;
+
 /* forward declarations */
 static void do_mboxlist(void);
 static int do_reconstruct_p(const mbentry_t *mbentry, void *rock);
@@ -140,6 +144,8 @@ int main(int argc, char **argv)
     if ((geteuid()) == 0 && (become_cyrus(/*is_master*/0) != 0)) {
         fatal("must run as the Cyrus user", EC_USAGE);
     }
+
+    progname = basename(argv[0]);
 
     construct_hash_table(&unqid_table, 2047, 1);
 
@@ -382,9 +388,30 @@ int main(int argc, char **argv)
 
 static void usage(void)
 {
-    fprintf(stderr,
-            "usage: reconstruct [-C <alt_config>] [-p partition] [-ksrfxu] mailbox...\n");
-    fprintf(stderr, "       reconstruct [-C <alt_config>] -m\n");
+    fprintf(stderr, "Usage: %s [OPTIONS]\n", progname);
+    fprintf(stderr, "A tool to reconstruct mailboxes.\n");
+    fprintf(stderr, "\n");
+
+    fprintf(stderr, "-C <config-file>   use <config-file> instead of config from imapd.conf");
+    fprintf(stderr, "-p <partition>     use this indicated partition for search\n");
+    fprintf(stderr, "-x                 do not import metadata, create new\n");
+    fprintf(stderr, "-r                 recursively reconstruct\n");
+    fprintf(stderr, "-f                 examine filesystem underneath the mailbox\n");
+    fprintf(stderr, "-s                 don't stat underlying files\n");
+    fprintf(stderr, "-q                 run quietly\n");
+    fprintf(stderr, "-n                 do not make changes\n");
+    fprintf(stderr, "-G                 force re-parsing(checks GUID correctness)\n");
+    fprintf(stderr, "-R                 perform UID upgrade operation on GUID mismatched files\n");
+    fprintf(stderr, "-U                 use this if there are corrupt message files in spool\n");
+    fprintf(stderr, "                   WARNING: this option deletes corrupted message files permanently\n");
+    fprintf(stderr, "-o                 ignore odd files in mailbox disk directories\n");
+    fprintf(stderr, "-O                 delete odd files(unlike -o)\n");
+    fprintf(stderr, "-M                 prefer mailboxes.db over cyrus.header\n");
+    fprintf(stderr, "-V <version>       Change the cyrus.index minor version to the version specified\n");
+    fprintf(stderr, "-u                 give usernames instead of mailbox prefixes\n");
+
+    fprintf(stderr, "\n");
+
     exit(EC_USAGE);
 }
 


### PR DESCRIPTION
Show better help when run on the command line with the `-h`. This patch
updates the following tools:
 * cyr_expire
 * cyr_info
 * cyrdump
 * reconstruct

This patch uses `basename()` function from `libgen.h`.