### PR TITLE
Fix segfault due to unitialized local variable in timsieved.

### DIFF
--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -773,6 +773,7 @@ static int cmd_authenticate(struct protstream *sieved_out,
       (*sieved_namespace.mboxname_tointernal)(&sieved_namespace, "INBOX",
 					     username, inboxname);
 
+      memset(&mbentry, 0, sizeof mbentry);
       r = mboxlist_lookup(inboxname, &mbentry, NULL);
       
       if(r && !sieved_userisadmin) {


### PR DESCRIPTION
This happens when a connection is made as an admin-user without a
mailbox (`sieveshell --authname cyrus localhost`)

See issue #855.