### PR TITLE
getMessageListUpdates: Fix uptoMessageId parsing

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4374,10 +4374,7 @@ static int getMessageListUpdates(jmap_req_t *req)
     window.sincemodesq = atomodseq_t(since);
 
     /* uptoMessageId */
-    pe = readprop(req->args, "uptoMessageId", 0, invalid, "s", &upto);
-    if (pe > 0) {
-        json_array_append_new(invalid, json_string("uptoMessageId"));
-    }
+    readprop(req->args, "uptoMessageId", 0, invalid, "s", &upto);
     window.uptomsgid = upto;
 
     /* maxChanges */


### PR DESCRIPTION
readprop returns < 0 if there is an error, not greater than