### PR TITLE
[caldav] Check for return of icalproperty_get_tzid().

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1856,6 +1856,8 @@ static int export_calendar(struct transaction_t *txn)
                                                          ICAL_TZID_PROPERTY);
                     const char *tzid = icalproperty_get_tzid(prop);
 
+                    if (!tzid) continue;
+
                     if (hash_lookup(tzid, &tzid_table)) continue;
                     else hash_insert(tzid, (void *)0xDEADBEEF, &tzid_table);
                 }
@@ -7454,7 +7456,7 @@ static void strip_vtimezones(icalcomponent *ical)
         const char *tzid = icalproperty_get_tzid(prop);
         struct zoneinfo zi;
 
-        if (!zoneinfo_lookup(tzid, &zi)) {
+        if (tzid && !zoneinfo_lookup(tzid, &zi)) {
             if (zi.type == ZI_LINK) {
                 /* Add this alias to our table */
                 hash_insert(tzid, xstrdup(zi.data->s), &tzid_table);

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1567,6 +1567,7 @@ static int deliver_merge_request(const char *attendee,
              icalcomponent_get_next_component(ical, ICAL_VTIMEZONE_COMPONENT)) {
         prop = icalcomponent_get_first_property(comp, ICAL_TZID_PROPERTY);
         tzid = icalproperty_get_tzid(prop);
+        if (!tzid) continue;
 
         hash_insert(tzid, comp, &comp_table);
     }
@@ -1580,6 +1581,7 @@ static int deliver_merge_request(const char *attendee,
         /* Lookup this TZID in the hash table */
         prop = icalcomponent_get_first_property(itip, ICAL_TZID_PROPERTY);
         tzid = icalproperty_get_tzid(prop);
+        if (!tzid) continue;
 
         comp = hash_lookup(tzid, &comp_table);
         if (comp) {

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -2779,7 +2779,7 @@ EXPORTED void icalcomponent_add_required_timezones(icalcomponent *ical)
         prop = icalcomponent_get_first_property(tzcomp, ICAL_TZID_PROPERTY);
         if (prop) {
             const char *tzid = icalproperty_get_tzid(prop);
-            if (tz_from_tzid(tzid)) {
+            if (tzid && tz_from_tzid(tzid)) {
                 icalcomponent_remove_component(ical, tzcomp);
                 icalcomponent_free(tzcomp);
             }


### PR DESCRIPTION
`icalproperty_get_tzid()` can return NULL if TZID has no entry. Ensure
that we check that we have a non-NULL `tzid` before using it.