### PR TITLE
cyr_expire, quota : Fix for issue #1699. Accept parameters based on current namespace settings

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -593,6 +593,17 @@ int main(int argc, char *argv[])
 
     mboxevent_setnamespace(&expire_namespace);
 
+    mbname_t *prefix_mbname = mbname_from_extname(find_prefix, &expire_namespace, NULL);
+
+    /* convert find_prefix to internal namespace */
+    if (find_prefix) {
+	const char *intname = mbname_intname(prefix_mbname);
+
+	find_prefix = intname;
+
+    }
+
+
     if (duplicate_init(NULL) != 0) {
         fprintf(stderr,
                 "cyr_expire: unable to init duplicate delivery database\n");
@@ -737,6 +748,8 @@ int main(int argc, char *argv[])
         r = duplicate_prune(expire_seconds, &erock.table);
 
 finish:
+    mbname_free(&prefix_mbname);
+
     free_hash_table(&erock.table, free);
     free_hash_table(&crock.seen, NULL);
     strarray_fini(&drock.to_delete);

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -393,14 +393,21 @@ int buildquotalist(char *domain, char **roots, int nroots)
      * with the matching prefixes.
      */
     for (i = 0; i < nroots; i++) {
-        strlcpy(tail, roots[i], sizeof(buf) - domainlen);
-        /* XXX - namespace fixes here */
+
+        /* namespace fix */
+        mbname_t *mbname = mbname_from_extname(roots[i], &quota_namespace, NULL);
+        const char *intname = mbname_intname(mbname);
+
+        strlcpy(tail, intname, sizeof(buf) - domainlen);
+
+        mbname_free(&mbname);
 
         r = quota_foreach(buf, fixquota_addroot, buf, NULL);
         if (r) {
             errmsg("failed building quota list for '%s'", buf, IMAP_IOERROR);
             break;
         }
+        
     }
 
     return r;
@@ -638,8 +645,15 @@ int fixquota_dopass(char *domain, char **roots, int nroots,
      * with the matching prefixes.
      */
     for (i = 0; i < nroots; i++) {
-        strlcpy(tail, roots[i], sizeof(buf) - domainlen);
 
+        /* namespace fix */
+        mbname_t *mbname = mbname_from_extname(roots[i], &quota_namespace, NULL);
+        const char *intname = mbname_intname(mbname);
+
+        strlcpy(tail, intname, sizeof(buf) - domainlen);
+
+	    mbname_free(&mbname);
+	
         r = mboxlist_allmbox(buf, cb, buf, /*incdel*/0);
         if (r) {
             errmsg("processing mbox list for '%s'", buf, IMAP_IOERROR);


### PR DESCRIPTION
Fix for issue #1699. Convert command line mailbox parameters to internal namespace based on current settings. This applies to cyr_expire and quota commands