### PR TITLE
Fix imapd.conf example files for murder

### DIFF
--- a/doc/examples/imapd_conf/murder-backend.conf
+++ b/doc/examples/imapd_conf/murder-backend.conf
@@ -22,7 +22,8 @@ mupdate_password: <secret>
 # The proxyservers parameter is a list of users or groups who are
 # allowed to proxy for any other users, and are necessary for backend
 # servers to support user and mailbox moves between backends.
-# NOTE: for lmtp to work in a murder, the proxyservers entries must
+# NOTE: This should match the proxy_authname: setting in the frontend(s).
+# NOTE: For lmtp to work in a murder, the proxyservers entries must
 # also appear in the lmtp_admins entry!!
 proxyservers: mailproxy
 lmtp_admins: mailproxy

--- a/doc/examples/imapd_conf/murder-frontend.conf
+++ b/doc/examples/imapd_conf/murder-frontend.conf
@@ -26,14 +26,8 @@ mupdate_username: postman
 mupdate_authname: postman
 mupdate_password: <secret>
 
-# The proxyservers parameter is a list of users or groups who are
-# allowed to proxy for any other users, and are necessary for backend
-# servers to support user and mailbox moves between backends.
-# NOTE: for lmtp to work in a murder, the proxyservers entries must
-# also appear in the lmtp_admins entry!!
-proxyservers: mailproxy
-lmtp_admins: mailproxy
-
+# The credentials below must match the account listed in lmtp_admins
+# on the backend servers.
 proxy_authname: mailproxy
 proxy_password: <secret>
 


### PR DESCRIPTION
There was an error regarding the use of "proxyservers:" in the example
configuration files for murder frontends.  This commit fixes it.

Closes #2099