### PR TITLE
jmap_mail: optimise header retrieval for getMessages

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3289,7 +3289,7 @@ static int jmapmsg_from_body(jmap_req_t *req, hash_table *props,
     r = find_msgbodies(body, msg_buf, &bodies);
     if (r) goto done;
 
-    /* Always read the message headers */
+    /* Read message headers, but just the ones we care about */
     struct extract_headers_rock ehrock = { headers, props };
     r = message_foreach_header(msg_buf->s + body->header_offset,
                                body->header_size, extract_headers, &ehrock);


### PR DESCRIPTION
charset_decode_mimeheader turns out to be pretty expensive, so don't just blindly decode all headers