### PR TITLE
Fix error message about failing to install SIGUSR2 handler

### DIFF
--- a/lib/signals.c
+++ b/lib/signals.c
@@ -102,7 +102,7 @@ EXPORTED void signals_add_handlers(int alarm)
     if (sigaction(SIGTERM, &action, NULL) < 0)
         fatal("unable to install signal handler for SIGTERM", EC_TEMPFAIL);
     if (sigaction(SIGUSR2, &action, NULL) < 0)
-        fatal("unable to install signal handler for SIGTERM", EC_TEMPFAIL);
+        fatal("unable to install signal handler for SIGUSR2", EC_TEMPFAIL);
 
     signals_reset_sighup_handler(1);
 }


### PR DESCRIPTION
The error message when the SIGUSR2 handler fails to be installed said
SIGTERM when it should have said SIGUSR2.