### PR TITLE
promstatsd: report usage information

### DIFF
--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -312,6 +312,15 @@ struct partition_data {
     int64_t timestamp;
 };
 
+static void free_partition_data(void *ptr)
+{
+    struct partition_data *pdata = (struct partition_data *) ptr;
+
+    free_hash_table(&pdata->shared, free);
+    memset(pdata, 0, sizeof *pdata);
+    free(pdata);
+}
+
 static int count_users_mailboxes(struct findall_data *data, void *rock)
 {
     hash_table *h = (hash_table *) rock;
@@ -586,7 +595,7 @@ static void do_collate_usage(struct buf *buf)
     format_usage_quota_commitment(buf, partition_names, &h);
 
     strarray_free(partition_names);
-    free_hash_table(&h, free);
+    free_hash_table(&h, free_partition_data);
 }
 
 static void do_write_report(struct mappedfile *mf, const struct buf *report)

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -336,6 +336,7 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
         !strarray_size(mbname_boxes(data->mbname))) {
         syslog(LOG_DEBUG, "counting user: %s", mbname_intname(data->mbname));
         pdata->n_users ++;
+        pdata->n_mailboxes ++; /* an inbox is also a mailbox */
         pdata->timestamp = now_ms();
     }
     /* XXX shared ? */


### PR DESCRIPTION
This PR builds upon #2102 and must be merged after it.

This adds usage information (per partition) to the prometheus report:

* number of user accounts
* number of deleted mailboxes
* number of shared mailboxes
* quota commitments

The quota commitments are tricky, because there is no hard relationship between quota roots and disk partitions.  If a quota root crosses partition boundaries, its quota commitments will be counted towards each partition it affects, making it hard to infer anything useful from the data.  (Quota roots that cross partition boundaries are hard to work with in plenty of other ways, so my advice here is "just don't do that then".)

This does not count actual on-disk usage or free space; get those from your operating system metrics if you want to calculate percentages or alarm at risky thresholds etc.

Also, note that quota commitments can be infinite.  This is represented correctly per the Prometheus spec, but is worth a heads up. :)

This is an ad-hoc implementation within promstatsd.c, similar to the one in master.c (#2102).  These stats aren't suitable for counting from a service process, as they're global to the Cyrus instance, so promstatsd just calculates them itself at report time, bypassing the service API from prometheus.h.  I expect to generalise a bunch of this once the gremlins are shook out.

I have Cassandane tests for the tricky bits at  https://github.com/elliefm/cassandane/tree/v31/prometheus, but I won't merge them until the functionality is in Cyrus master.

Sample report contents:

```
# HELP cyrus_usage_deleted_mailboxes The number of deleted Cyrus mailboxes
# TYPE cyrus_usage_deleted_mailboxes gauge
cyrus_usage_deleted_mailboxes{partition="default"} 0 1513575267167
cyrus_usage_deleted_mailboxes{partition="p2"} 0 1513575267166
# HELP cyrus_usage_users The number of Cyrus user Inboxes
# TYPE cyrus_usage_users gauge
cyrus_usage_users{partition="default"} 1 1513575267167
cyrus_usage_users{partition="p2"} 0 1513575267166
# HELP cyrus_usage_mailboxes The number of Cyrus mailboxes
# TYPE cyrus_usage_mailboxes gauge
cyrus_usage_mailboxes{partition="default"} 4 1513575267167
cyrus_usage_mailboxes{partition="p2"} 2 1513575267166
# HELP cyrus_usage_shared_mailboxes The number of shared Cyrus mailboxes
# TYPE cyrus_usage_shared_mailboxes gauge
cyrus_usage_shared_mailboxes{partition="default",namespace="bar"} 3 1513575491793
cyrus_usage_shared_mailboxes{partition="default",namespace="foo"} 3 1513575491793
# HELP cyrus_usage_quota_commitment The amount of quota committed
# TYPE cyrus_usage_quota_commitment gauge
cyrus_usage_quota_commitment{partition="default",resource="STORAGE"} 12000 1513575267167
cyrus_usage_quota_commitment{partition="default",resource="MESSAGE"} inf 1513575267167
cyrus_usage_quota_commitment{partition="default",resource="X-ANNOTATION-STORAGE"} inf 1513575267167
cyrus_usage_quota_commitment{partition="default",resource="X-NUM-FOLDERS"} inf 1513575267167
cyrus_usage_quota_commitment{partition="p2",resource="STORAGE"} 10000 1513575267166
cyrus_usage_quota_commitment{partition="p2",resource="MESSAGE"} inf 1513575267166
cyrus_usage_quota_commitment{partition="p2",resource="X-ANNOTATION-STORAGE"} inf 1513575267166
cyrus_usage_quota_commitment{partition="p2",resource="X-NUM-FOLDERS"} inf 1513575267166
```