### PR TITLE
Try to clarify documentation in re: Partitions

### DIFF
--- a/docsrc/imap/concepts/features/mail-spool-partitions.rst
+++ b/docsrc/imap/concepts/features/mail-spool-partitions.rst
@@ -4,13 +4,10 @@
 Mail Spool Partitions
 =====================
 
-A mail spool is divided in partitions. The partition Cyrus IMAP ships
-with by default is called ``default``.
-
-Partitions can give you the opportunity to tier your storage, and/or use
-multiple filesystems to apply restrictions to information (contained
-within mailboxes), such as the absolute maximum quantity of storage
-used.
+A mail spool is divided in partitions. Partitions can give you the
+opportunity to tier your storage, and/or use multiple filesystems to
+apply restrictions to information (contained within mailboxes), such as
+the absolute maximum quantity of storage used.
 
 .. seealso::
 

--- a/docsrc/imap/reference/admin/locations.rst
+++ b/docsrc/imap/reference/admin/locations.rst
@@ -35,6 +35,55 @@ In general, Cyrus allows one to maintain several separate partitions for
 each of these data types, and to establish rules governing distribution
 of data within each pool.
 
+Types of Partitions
+-------------------
+
+Cyrus supports several different types of partitions:
+
+*   Mail Spool Partitions
+*   Metadata Partitions
+*   Backup Partitions
+*   Archive Partitions
+*   Search Partitions
+
+Each of these are discussed in their own sections of the documentation.
+All share in common a few aspects in how they are configured.  For each
+partition defined, you must tell Cyrus where the partition is rooted in
+the filesystem.  This is accomplished via a "*partition*-*name*:" directive
+for each partition, where "*partition*" specifies the partition type and
+"*name*" is the actual name of the partition.
+
+Here are some sample declarations of each different type of partition
+supported within Cyrus.  For the purposes of this example, we'll
+stipulate the following:
+
+*   There are two main storage pools, "fast" and "slow," which are on
+    SSDs and traditional disks, respectively.
+*   The mailboxes are divided alphabetically, with A to M in one group
+    and N to Z in the other.
+
+.. parsed-literal::
+
+    # The Mail Spool Partitions
+    partition-atom: /var/spool/cyrus/fast/mail/atom/
+    partition-ntoz: /var/spool/cyrus/fast/mail/ntoz/
+
+    # The Metadata Partitions
+    metapartition-atom: /var/spool/cyrus/fast/meta/atom/
+    metapartition-ntoz: /var/spool/cyrus/fast/meta/ntoz/
+
+    # Backup Partition
+    backuppartition-main: /var/spool/cyrus/slow/backup/
+
+    # Archive Partitions
+    archivepartition-atom: /var/spool/cyrus/slow/mail/atom/
+    archivepartition-ntoz: /var/spool/cyrus/slow/mail/ntoz/
+
+    # Search Partitions
+    defaultsearchtier: tier1
+    tier1searchpartition-atom: /var/spool/cyrus/slow/search/atom/
+    tier1searchpartition-ntoz: /var/spool/cyrus/slow/search/ntoz/
+
 Working With Partitions
 =======================
 
@@ -96,5 +145,21 @@ media.
 .. include:: /imap/reference/manpages/configs/imapd.conf.rst
         :start-after: startblob archivepartition-name
         :end-before: endblob archivepartition-name
+
+Search Partitions
+-----------------
+
+Modern Cyrus uses the Xapian search engine to index messages for
+server-side search support.  Index data are stored in search "tiers"
+which are themselves related to search partitions.  There are two key
+settings for search tiers:
+
+.. include:: /imap/reference/manpages/configs/imapd.conf.rst
+        :start-after: startblob defaultsearchtier
+        :end-before: endblob defaultsearchtier
+
+.. include:: /imap/reference/manpages/configs/imapd.conf.rst
+        :start-after: startblob searchtierpartition-name
+        :end-before: endblob searchtierpartition-name
 
 Back to :ref:`imap-admin`

--- a/docsrc/imap/reference/admin/locations.rst
+++ b/docsrc/imap/reference/admin/locations.rst
@@ -159,7 +159,7 @@ settings for search tiers:
         :end-before: endblob defaultsearchtier
 
 .. include:: /imap/reference/manpages/configs/imapd.conf.rst
-        :start-after: startblob searchtierpartition-name
-        :end-before: endblob searchtierpartition-name
+        :start-after: startblob searchpartition-name
+        :end-before: endblob searchpartition-name
 
 Back to :ref:`imap-admin`

--- a/docsrc/imap/reference/admin/locations.rst
+++ b/docsrc/imap/reference/admin/locations.rst
@@ -42,7 +42,6 @@ Cyrus supports several different types of partitions:
 
 *   Mail Spool Partitions
 *   Metadata Partitions
-*   Backup Partitions
 *   Archive Partitions
 *   Search Partitions
 
@@ -71,9 +70,6 @@ stipulate the following:
     # The Metadata Partitions
     metapartition-atom: /var/spool/cyrus/fast/meta/atom/
     metapartition-ntoz: /var/spool/cyrus/fast/meta/ntoz/
-
-    # Backup Partition
-    backuppartition-main: /var/spool/cyrus/slow/backup/
 
     # Archive Partitions
     archivepartition-atom: /var/spool/cyrus/slow/mail/atom/
@@ -122,15 +118,6 @@ headers, caches, indexes, etc.
 .. include:: /imap/reference/manpages/configs/imapd.conf.rst
         :start-after: startblob metapartition_files
         :end-before: endblob metapartition_files
-
-Backup Partitions
------------------
-
-Cyrus Backups are a replication-based backup service for Cyrus IMAP servers.
-
-.. include:: /imap/reference/manpages/configs/imapd.conf.rst
-        :start-after: startblob backuppartition-name
-        :end-before: endblob backuppartition-name
 
 Archive Partitions
 ------------------

--- a/docsrc/imap/reference/admin/locations/searchtiers.rst
+++ b/docsrc/imap/reference/admin/locations/searchtiers.rst
@@ -6,7 +6,7 @@ Search Tiers
 The Xapian search engine supports searching from multiple databases at
 once, creating a tiered database structure.  To use Xapian, these tiers
 must be defined in :cyrusman:`imapd.conf(5)` with the
-`defaultsearchtier` and `searchtierpartition-name` settings.
+`defaultsearchtier` and `searchpartition-name` settings.
 
 Default Search Tier name
 ------------------------
@@ -22,7 +22,7 @@ Search Tier Partition location
 ------------------------------
 
 Each search tier to be used requires a partition location be specified
-via a `searchtierpartition-name` setting, wherein "name" is replaced
+via a `searchpartition-name` setting, wherein "name" is replaced
 with the name of the mail spool for which this search partition is to
 be used, and prepended by the name of the tier with which it is
 associated::
@@ -58,5 +58,5 @@ will be adding three search partitions.
 These settings are in :cyrusman:`imapd.conf(5)`:
 
 .. include:: /imap/reference/manpages/configs/imapd.conf.rst
-        :start-after: startblob searchtierpartition-name
-        :end-before: endblob searchtierpartition-name
+        :start-after: startblob searchpartition-name
+        :end-before: endblob searchpartition-name

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1584,8 +1584,8 @@ And the notification message will be available on \fIstdin\fR.
 /* The pathname of the partition \fIname\fR.  At least one partition
    pathname MUST be specified.  If the \fBdefaultpartition\fR option is
    used, then its pathname MUST be specified.  For example, if the
-   value of the \fBdefaultpartion\fR option is \fBdefault\fR, then the
-   \fBpartition-default\fR field is required. */
+   value of the \fBdefaultpartion\fR option is \fBpart1\fR, then the
+   \fBpartition-part1\fR field is required. */
 
 { "outbox_sendlater", 0, SWITCH }
 /* If enabled, any message with a \Draft flag will be sent at the time of its INTERNALDATE */
@@ -1992,7 +1992,7 @@ If all partitions are over that limit, this feature is not used anymore.
 .PP
    For example: if \fIdefaultpartition\fR is defined as part1 and
    \fIdefaultsearchtier\fR as tier1 then the configuration must contain
-   an entry \fItier1partitionname-part1\fR that defines the path where to
+   an entry \fItier1searchpartition-part1\fR that defines the path where to
    store this tier1's search index for the part1 partition.
 .PP
    This option MUST be specified for xapian search. */
@@ -2061,7 +2061,7 @@ If all backends are over that limit, this feature is not used anymore.
 { "serverinfo", "on", ENUM("off", "min", "on") }
 /* The server information to display in the greeting and capability
    responses. Information is displayed as follows:
-   
+
 .IP
    "off" = no server information in the greeting or capabilities
 .br
@@ -2545,7 +2545,7 @@ product version in the capabilities
 
 { "object_storage_dummy_spool", NULL, STRING }
 /* Dummy object storage spool; this is for test only.
-   Spool where user directory (container) will be created to store all emails 
+   Spool where user directory (container) will be created to store all emails
    in a flat structure  */
 
 { "openio_namespace", NULL, STRING }
@@ -2582,7 +2582,7 @@ product version in the capabilities
 { "caringo_hostname", NULL, STRING }
 /* The Caringo hostname used to store archived email messages. A hostname
    identifies the physical platform cyrus must contact. This directive is used
-   by the Caringo's SDK (CastorSDK: Caringo Simple Content Storage Protocol (SCSP) 
+   by the Caringo's SDK (CastorSDK: Caringo Simple Content Storage Protocol (SCSP)
    on HTTP 1.1 using a RESTful architecture  */
 
 { "caringo_port", 80, INT }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1982,9 +1982,9 @@ If all partitions are over that limit, this feature is not used anymore.
    no stopwords will be taken into account during search indexing. Currently,
    the only supported and default stop word file is english.list. */
 
-# Commented out - there's no such thing as "searchtierpartition-name",
+# Commented out - there's no such thing as "searchpartition-name",
 # but we need this for the man page
-# { "searchtierpartition-name", NULL, STRING }
+# { "searchpartition-name", NULL, STRING }
 /* The pathname where to store the xapian search indexes of \fIsearchtier\fR
    for mailboxes of partition \fIname\fR. This must be configured for the
    \fIdefaultsearchtier\fR and any additional search tier (see squatter for


### PR DESCRIPTION
This is a first attempt to clear up some confusion in regards to the
nameing of partitions and the use of the various "partition-name"
configuration directives in imapd.conf(5).

It's my goal to eliminate all use of common words like "default" or
"archive" in the names of partitions in samples and descriptive
language, lest people perceive such use to mean that those names
*must* be used.

For example, rather than using the following:
    defaultpartition: default
    partition-default: /var/spool/cyrus

we can use:
    defaultpartition: part1
    partition-part1: /var/spool/cyrus

The file /lib/imapoptions has been lightly modified in service to this
cause, and to correct typos in the definition of searchpartition-name
settings.

Note: There had been some trailing white space in /lib/imapoptions which my editor removed, which accounts for the last couple of diffs in that file.