### PR TITLE
libconfig: warn about lookups of nonexistent partitions

### DIFF
--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -196,7 +196,12 @@ EXPORTED const char *config_partitiondir(const char *partition)
     if (strlcat(buf, partition, sizeof(buf)) >= sizeof(buf))
         return 0;
 
-    return config_getoverflowstring(buf, NULL);
+    const char *dir = config_getoverflowstring(buf, NULL);
+    if (!dir)
+        syslog(LOG_WARNING, "requested partition directory for unknown partition '%s'",
+                            partition);
+
+    return dir;
 }
 
 EXPORTED const char *config_metapartitiondir(const char *partition)
@@ -208,7 +213,12 @@ EXPORTED const char *config_metapartitiondir(const char *partition)
     if (strlcat(buf, partition, sizeof(buf)) >= sizeof(buf))
         return 0;
 
-    return config_getoverflowstring(buf, NULL);
+    const char *dir = config_getoverflowstring(buf, NULL);
+    if (!dir)
+        syslog(LOG_WARNING, "requested meta partition directory for unknown partition '%s'",
+                            partition);
+
+    return dir;
 }
 
 EXPORTED const char *config_archivepartitiondir(const char *partition)
@@ -220,7 +230,12 @@ EXPORTED const char *config_archivepartitiondir(const char *partition)
     if(strlcat(buf, partition, sizeof(buf)) >= sizeof(buf))
         return 0;
 
-    return config_getoverflowstring(buf, NULL);
+    const char *dir = config_getoverflowstring(buf, NULL);
+    if (!dir)
+        syslog(LOG_WARNING, "requested archive partition directory for unknown partition '%s'",
+                            partition);
+
+    return dir;
 }
 
 EXPORTED const char *config_backupstagingpath(void)

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -215,8 +215,8 @@ EXPORTED const char *config_metapartitiondir(const char *partition)
 
     const char *dir = config_getoverflowstring(buf, NULL);
     if (!dir)
-        syslog(LOG_WARNING, "requested meta partition directory for unknown partition '%s'",
-                            partition);
+        syslog(LOG_DEBUG, "requested meta partition directory for unknown partition '%s'",
+                          partition);
 
     return dir;
 }
@@ -232,8 +232,8 @@ EXPORTED const char *config_archivepartitiondir(const char *partition)
 
     const char *dir = config_getoverflowstring(buf, NULL);
     if (!dir)
-        syslog(LOG_WARNING, "requested archive partition directory for unknown partition '%s'",
-                            partition);
+        syslog(LOG_DEBUG, "requested archive partition directory for unknown partition '%s'",
+                          partition);
 
     return dir;
 }


### PR DESCRIPTION
This should help make self-diagnosis of cases like #2120 a little easier