### PR TITLE
squatter: get rid of undocumented '-c' argument

### DIFF
--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -81,8 +81,6 @@ static const struct search_engine default_search_engine = {
     NULL,
     NULL,
     NULL,
-    NULL,
-    NULL,
 };
 
 static const struct search_engine *engine(void)
@@ -277,18 +275,6 @@ EXPORTED void search_free_internalised(void *internalised)
 {
     const struct search_engine *se = engine();
     if (se->free_internalised) se->free_internalised(internalised);
-}
-
-EXPORTED int search_start_daemon(int verbose)
-{
-    const struct search_engine *se = engine();
-    return (se->start_daemon ? se->start_daemon(verbose) : 0);
-}
-
-EXPORTED int search_stop_daemon(int verbose)
-{
-    const struct search_engine *se = engine();
-    return (se->stop_daemon ? se->stop_daemon(verbose) : 0);
 }
 
 EXPORTED int search_list_files(const char *userid,

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -139,8 +139,6 @@ struct search_engine {
     int (*end_snippets)(search_text_receiver_t *);
     char *(*describe_internalised)(void *);
     void (*free_internalised)(void *);
-    int (*start_daemon)(int verbose);
-    int (*stop_daemon)(int verbose);
     int (*list_files)(const char *userid, strarray_t *);
     int (*compact)(const char *userid, const char *tempdir,
                    const strarray_t *srctiers, const char *desttier,
@@ -178,8 +176,6 @@ int search_end_snippets(search_text_receiver_t *rx);
  * be free()d by the caller.  Only useful for whitebox testing.  */
 char *search_describe_internalised(void *internalised);
 void search_free_internalised(void *internalised);
-int search_start_daemon(int verbose);
-int search_stop_daemon(int verbose);
 int search_list_files(const char *userid, strarray_t *);
 int search_compact(const char *userid, const char *tempdir,
                    const strarray_t *srctiers, const char *desttier, int verbose);

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -1012,8 +1012,6 @@ const struct search_engine squat_search_engine = {
     /* end_snippets */NULL,
     /* describe_internalised */NULL,
     /* free_internalised */NULL,
-    /* start_daemon */NULL,
-    /* stop_daemon */NULL,
     /* list_files */NULL,
     /* compact */NULL,
     /* deluser */NULL,

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -3111,8 +3111,6 @@ const struct search_engine xapian_search_engine = {
     end_snippets,
     describe_internalised,
     free_internalised,
-    /*start_daemon*/NULL,
-    /*stop_daemon*/NULL,
     list_files,
     compact_dbs,
     delete_user,  /* XXX: fixme */


### PR DESCRIPTION
This was needed when the Sphinx engine had its own separate
daemon that needed hand-holding.  The Sphinx engine is no more.

Closes #2242