### PR TITLE
prototype mappedfile_discard() api

### DIFF
--- a/lib/mappedfile.c
+++ b/lib/mappedfile.c
@@ -555,6 +555,11 @@ EXPORTED int mappedfile_iswritable(const struct mappedfile *mf)
     return !!mf->is_rw;
 }
 
+EXPORTED int mappedfile_isdirty(const struct mappedfile *mf)
+{
+    return !!mf->dirty;
+}
+
 EXPORTED const char *mappedfile_base(const struct mappedfile *mf)
 {
     /* XXX - require locked? */

--- a/lib/mappedfile.c
+++ b/lib/mappedfile.c
@@ -201,6 +201,55 @@ EXPORTED int mappedfile_close(struct mappedfile **mfp)
     return r;
 }
 
+/* function of last resort: a write has failed (maybe due to
+ * full disk), the data in the file is in unknown state
+ * (probably junk), and we have no reasonable expectation of
+ * a subsequent write succeeding.  just throw it all away.
+ */
+EXPORTED void mappedfile_discard(struct mappedfile **mfp)
+{
+    struct mappedfile *mf = *mfp;
+
+    /* make this safe to call multiple times */
+    if (!mf) return;
+
+    /* makes no sense to be here unless the map is writeable */
+    assert(mf->is_rw);
+
+    /* destroy the abomination */
+    if (mf->fname)
+        unlink(mf->fname);
+
+    /* still complain about long locks, it might be useful */
+    if (mf->lock_status != MF_UNLOCKED) {
+        struct timeval endtime;
+        double timediff;
+        int r;
+
+        r = lock_unlock(mf->fd, mf->fname);
+        if (r < 0) {
+            syslog(LOG_ERR, "IOERROR: lock_unlock %s: %m", mf->fname);
+        }
+
+        mf->lock_status = MF_UNLOCKED;
+        gettimeofday(&endtime, 0);
+        timediff = timesub(&mf->starttime, &endtime);
+        if (timediff > 1.0) {
+            syslog(LOG_NOTICE, "mappedfile: longlock %s for %0.1f seconds",
+                mf->fname, timediff);
+        }
+    }
+
+    if (mf->fd >= 0)
+        close(mf->fd);
+
+    buf_free(&mf->map_buf);
+    free(mf->fname);
+    free(mf);
+
+    *mfp = NULL;
+}
+
 EXPORTED int mappedfile_readlock(struct mappedfile *mf)
 {
     struct stat sbuf, sbuffile;

--- a/lib/mappedfile.h
+++ b/lib/mappedfile.h
@@ -80,6 +80,7 @@ extern int mappedfile_islocked(const struct mappedfile *mf);
 extern int mappedfile_isreadlocked(const struct mappedfile *mf);
 extern int mappedfile_iswritelocked(const struct mappedfile *mf);
 extern int mappedfile_iswritable(const struct mappedfile *mf);
+extern int mappedfile_isdirty(const struct mappedfile *mf);
 
 extern const char *mappedfile_base(const struct mappedfile *mf);
 extern size_t mappedfile_size(const struct mappedfile *mf);

--- a/lib/mappedfile.h
+++ b/lib/mappedfile.h
@@ -56,6 +56,7 @@ struct mappedfile;
 extern int mappedfile_open(struct mappedfile **mfp,
                            const char *fname, int flags);
 extern int mappedfile_close(struct mappedfile **mfp);
+extern void mappedfile_discard(struct mappedfile **mfp);
 
 extern int mappedfile_readlock(struct mappedfile *mf);
 extern int mappedfile_writelock(struct mappedfile *mf);


### PR DESCRIPTION
A possibility for dealing with IOERROR during mappedfile operations.  If it's not an abortable file format, and fails mid-write, it's probably corrupt.  This function is for the "just throw it away then" solution.