### PR TITLE
Clarify documentation regarding default sync_log

### DIFF
--- a/docsrc/imap/reference/admin/sop/replication.rst
+++ b/docsrc/imap/reference/admin/sop/replication.rst
@@ -226,6 +226,12 @@ it in :cyrusman:`imapd.conf(5)` using these options:
     See :ref:`replication-channels`, below, for details on how to use
     these settings to control syncing to multiple replicas.
 
+.. Important::
+    If using sync_log_channels for any other purpose, such as
+    specifying the sync_log used by :cyrusman:`squatter(8)` command,
+    you must *also* either specify a sync_log channel for replication,
+    or specify the default "" (the two-character string U+22 U+22).
+
 Add invocation specifications to :cyrusman:`cyrus.conf(5)` to spawn
 :cyrusman:`sync_client(8)` as desired (for each channel used) as
 described below in Rolling Replication or Periodic Replication.

--- a/docsrc/imap/reference/manpages/systemcommands/squatter.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/squatter.rst
@@ -287,10 +287,14 @@ rolling **squatter** operation:
 
 ..  Note::
 
-    When using the *-R* rolling mode, you MUST enable sync_log operation
-    in :cyrusman:`imapd.conf(5)` via the `sync_log: on` setting, and
-    MUST define a sync_log channel via the `sync_log_channels:`
-    setting.
+    When using the *-R* rolling mode, you MUST enable sync_log
+    operation in :cyrusman:`imapd.conf(5)` via the `sync_log: on`
+    setting, and MUST define a sync_log channel via the
+    `sync_log_channels:` setting.  If also using replication, you must
+    either explicitly specify your replication sync_log channel via the
+    `sync_log_channels` directive with a name, or specify the default
+    empty name with "" (the two-character string U+22 U+22).  [Please
+    see :cyrusman:`imapd.conf(5)` for details].
 
 ..  Note::
 


### PR DESCRIPTION
The Cyrus IMAP replication subsystem assumes a default sync_log
channel named "" (the two-character string U+22 U+22).  If one modifies
the sync_log_channels: directive with a name for another sync_log
channel, such as "squatter" then the default "" channel vanishes, unless
it is also specified explicitly. [issue #2248]

This commit is a first draft at making this clear.  Changes are made to
both the manpage for squatter(8) and to the Admin Guide, Replication
pages.

I feel that we actually need to produce more generalized documentation
of the sync_log mechanism, and then link to that from all points
which deal with sync_log usage, as these will no doubt grow due to the
usefullness of the sync_log functionality.

Addresses #2248.