### PR TITLE
Check if mechlist buffer is not empty

### DIFF
--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -3084,7 +3084,7 @@ int main(int argc, char **argv)
             /* try to get the capabilities from the banner */
             mechlist = ask_capability(protocol, servername,
                                       &capabilities, AUTO_BANNER);
-            if (!mechlist && !(capabilities & CAPA_STARTTLS)) {
+            if ((!mechlist || !buf_len(mechlist)) && !(capabilities & CAPA_STARTTLS)) {
                 /* found no capabilities in banner -> get them explicitly */
                 protocol->banner.is_capa = 0;
             }


### PR DESCRIPTION
Check if mechlist is null is redundant because it's initialized in
ask_capabilities flow. As the result some capabilities may be lost and
reported as not advertised
Keeping (now reduntant) null check to avoid regressions in the future
This is regression in 9fd201ba2b4ab58eda3372fb6765e1d5d8f027b4

Bug-Url: https://bugzilla.redhat.com/1543481