### PR TITLE
sync improvements

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -3034,7 +3034,7 @@ index_copy(struct index_state *state,
 
     /* we log the first name to get GUID-copy magic */
     if (!r)
-        sync_log_mailbox_double(index_mboxname(state), name);
+        sync_log_rename(index_mboxname(state), name);
 
 done:
     free(copyargs.records);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7425,7 +7425,7 @@ static int _copy_msgrecords(struct auth_state *authstate,
     r = append_commit(&as);
     if (r) goto done;
 
-    sync_log_mailbox_double(src->name, dst->name);
+    sync_log_rename(src->name, dst->name);
 done:
     return r;
 }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2456,7 +2456,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
              * we never nuke the mailbox from the replica before realising
              * that it has been renamed.  This can be moved later again when
              * we sync mailboxes by uniqueid rather than name... */
-            sync_log_mailbox_double(oldname, newname);
+            sync_log_rename(oldname, newname);
 
             mailbox_rename_cleanup(&oldmailbox, isusermbox);
 

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -379,9 +379,8 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
             report_verbose("  Deferred: QUOTA %s\n", action->name);
         }
         else if (r) {
-            /* XXX - bogus handling, should be user */
-            sync_action_list_add(mailbox_list, action->name, NULL);
-            report_verbose("  Promoting: QUOTA %s -> MAILBOX %s\n",
+            sync_action_list_add(user_list, action->name, NULL);
+            report_verbose("  Promoting: QUOTA %s -> USER %s\n",
                            action->name, action->name);
         }
     }
@@ -401,9 +400,8 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
             report_verbose("  Deferred: ANNOTATION %s\n", action->name);
         }
         else if (r) {
-            /* XXX - bogus handling, should be ... er, something */
-            sync_action_list_add(mailbox_list, action->name, NULL);
-            report_verbose("  Promoting: ANNOTATION %s -> MAILBOX %s\n",
+            sync_action_list_add(user_list, action->name, NULL);
+            report_verbose("  Promoting: ANNOTATION %s -> USER %s\n",
                            action->name, action->name);
         }
     }

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -83,6 +83,7 @@
 #include "xstrlcat.h"
 #include "signals.h"
 #include "cyrusdb.h"
+#include "hash.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -287,6 +288,50 @@ static int do_restart()
     return sync_parse_response("RESTART", sync_in, NULL);
 }
 
+struct split_user_mailboxes_rock {
+    struct sync_name_list *mboxname_list;
+    struct sync_action_list *user_list;
+    char **channelp;
+    unsigned flags;
+    int r;
+};
+
+static void split_user_mailboxes(const char *key __attribute__((unused)),
+                                 void *data,
+                                 void *rock)
+{
+    struct split_user_mailboxes_rock *smrock =
+        (struct split_user_mailboxes_rock *) rock;
+    struct sync_action_list *mailbox_list = (struct sync_action_list *) data;
+    struct sync_action *action;
+
+    for (action = mailbox_list->head; action; action = action->next) {
+        if (!action->active)
+            continue;
+
+        sync_name_list_add(smrock->mboxname_list, action->name);
+    }
+
+    if (smrock->mboxname_list->count >= 1000) {
+        syslog(LOG_NOTICE, "sync_mailboxes: doing %lu",
+                           smrock->mboxname_list->count);
+        smrock->r = do_sync_mailboxes(smrock->mboxname_list, smrock->user_list,
+                              (const char **) smrock->channelp, smrock->flags);
+        if (smrock->r) return;
+        smrock->r = do_restart();
+        if (smrock->r) return;
+        sync_name_list_free(&smrock->mboxname_list);
+        smrock->mboxname_list = sync_name_list_create();
+    }
+}
+
+/* need this lil wrapper for free_hash_table callback */
+static void sync_action_list_free_wrapper(void *p)
+{
+    struct sync_action_list *l = (struct sync_action_list *) p;
+    sync_action_list_free(&l);
+}
+
 /*
  *   channelp = NULL    => we're not processing a channel
  *   *channelp = NULL   => we're processing the default channel
@@ -297,16 +342,17 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
     struct sync_action_list *user_list = sync_action_list_create();
     struct sync_action_list *unuser_list = sync_action_list_create();
     struct sync_action_list *meta_list = sync_action_list_create();
-    struct sync_action_list *mailbox_list = sync_action_list_create();
     struct sync_action_list *unmailbox_list = sync_action_list_create();
     struct sync_action_list *quota_list = sync_action_list_create();
     struct sync_action_list *annot_list = sync_action_list_create();
     struct sync_action_list *seen_list = sync_action_list_create();
     struct sync_action_list *sub_list = sync_action_list_create();
-    struct sync_name_list *mboxname_list = sync_name_list_create();
+    hash_table user_mailboxes = HASH_TABLE_INITIALIZER;
     const char *args[3];
     struct sync_action *action;
     int r = 0;
+
+    construct_hash_table(&user_mailboxes, 1024 /* XXX */, 0);
 
     while (1) {
         r = sync_log_reader_getitem(slr, args);
@@ -320,10 +366,18 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
             sync_action_list_add(meta_list, NULL, args[1]);
         else if (!strcmp(args[0], "SIEVE"))
             sync_action_list_add(meta_list, NULL, args[1]);
-        else if (!strcmp(args[0], "APPEND")) /* just a mailbox event */
+        else if ((!strcmp(args[0], "APPEND")) /* just a mailbox event */
+                 || (!strcmp(args[0], "MAILBOX"))) {
+            char *userid = mboxname_to_userid(args[1]);
+            if (!userid) userid = ""; /* treat non-user mboxes as a single cohort */
+            struct sync_action_list *mailbox_list;
+            mailbox_list = hash_lookup(userid, &user_mailboxes);
+            if (!mailbox_list) {
+                mailbox_list = sync_action_list_create();
+                hash_insert(userid, mailbox_list, &user_mailboxes);
+            }
             sync_action_list_add(mailbox_list, args[1], NULL);
-        else if (!strcmp(args[0], "MAILBOX"))
-            sync_action_list_add(mailbox_list, args[1], NULL);
+        }
         else if (!strcmp(args[0], "UNMAILBOX"))
             sync_action_list_add(unmailbox_list, args[1], NULL);
         else if (!strcmp(args[0], "QUOTA"))
@@ -448,30 +502,28 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
         }
     }
 
-    /* XXX - need to process this in sets of users at a time, such that we never split
-     * on a user boundary.  This will require a data structure change to carry the list
-     * of mailboxes in per-user sets */
-    for (action = mailbox_list->head; action; action = action->next) {
-        if (!action->active)
-            continue;
+    if (hash_numrecords(&user_mailboxes)) {
+        struct split_user_mailboxes_rock smrock;
+        smrock.mboxname_list = sync_name_list_create();
+        smrock.user_list = user_list;
+        smrock.channelp = (char **) channelp; /* n.b. casting away constness bc struct */
+        smrock.flags = flags;
+        smrock.r = 0;
 
-        sync_name_list_add(mboxname_list, action->name);
-        /* only do up to 1000 mailboxes at a time */
-        if (mboxname_list->count > 1000) {
-            syslog(LOG_NOTICE, "sync_mailboxes: doing 1000");
-            r = do_sync_mailboxes(mboxname_list, user_list, channelp, flags);
-            if (r) goto cleanup;
+        /* process user_mailboxes in sets of ~1000, splitting only on
+         * user boundaries */
+        hash_enumerate(&user_mailboxes, split_user_mailboxes, &smrock);
+        r = smrock.r;
+
+        /* process any stragglers (<1000 remaining) */
+        if (!r)
+            r = do_sync_mailboxes(smrock.mboxname_list, user_list, channelp, flags);
+        if (!r)
             r = do_restart();
-            if (r) goto cleanup;
-            sync_name_list_free(&mboxname_list);
-            mboxname_list = sync_name_list_create();
-        }
-    }
 
-    r = do_sync_mailboxes(mboxname_list, user_list, channelp, flags);
-    if (r) goto cleanup;
-    r = do_restart();
-    if (r) goto cleanup;
+        sync_name_list_free(&smrock.mboxname_list);
+        if (r) goto cleanup;
+    }
 
     /* XXX - is unmailbox used much anyway - we need to see if it's logged for a rename,
      * e.g.
@@ -547,13 +599,12 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
     sync_action_list_free(&user_list);
     sync_action_list_free(&unuser_list);
     sync_action_list_free(&meta_list);
-    sync_action_list_free(&mailbox_list);
     sync_action_list_free(&unmailbox_list);
     sync_action_list_free(&quota_list);
     sync_action_list_free(&annot_list);
     sync_action_list_free(&seen_list);
     sync_action_list_free(&sub_list);
-    sync_name_list_free(&mboxname_list);
+    free_hash_table(&user_mailboxes, sync_action_list_free_wrapper);
 
     return r;
 }

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -382,22 +382,30 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
             sync_action_list_add(meta_list, NULL, args[1]);
         else if ((!strcmp(args[0], "APPEND")) /* just a mailbox event */
                  || (!strcmp(args[0], "MAILBOX"))) {
-            char *userid = mboxname_to_userid(args[1]);
-            if (!userid) userid = ""; /* treat non-user mboxes as a single cohort */
+            char *freeme = NULL;
+            const char *userid;
             struct sync_action_list *mailbox_list;
+
+            userid = freeme = mboxname_to_userid(args[1]);
+            if (!userid) userid = ""; /* treat non-user mboxes as a single cohort */
+
             mailbox_list = hash_lookup(userid, &user_mailboxes);
             if (!mailbox_list) {
                 mailbox_list = sync_action_list_create();
                 hash_insert(userid, mailbox_list, &user_mailboxes);
             }
             sync_action_list_add(mailbox_list, args[1], NULL);
+            free(freeme);
         }
         else if (!strcmp(args[0], "RENAME")) {
-            char *userid1 = mboxname_to_userid(args[1]);
-            if (!userid1) userid1 = "";
-            char *userid2 = mboxname_to_userid(args[2]);
-            if (!userid2) userid2 = "";
+            char *freeme1 = NULL, *freeme2 = NULL;
+            const char *userid1, *userid2;
             struct sync_action_list *mailbox_list;
+
+            userid1 = freeme1 = mboxname_to_userid(args[1]);
+            if (!userid1) userid1 = "";
+            userid2 = freeme2 = mboxname_to_userid(args[2]);
+            if (!userid2) userid2 = "";
 
             /* add both mboxnames to the list for the first one's user */
             mailbox_list = hash_lookup(userid1, &user_mailboxes);
@@ -418,6 +426,9 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
                 sync_action_list_add(mailbox_list, args[1], NULL);
                 sync_action_list_add(mailbox_list, args[2], NULL);
             }
+
+            free(freeme1);
+            free(freeme2);
         }
         else if (!strcmp(args[0], "UNMAILBOX"))
             sync_action_list_add(unmailbox_list, args[1], NULL);

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -377,6 +377,13 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
                 hash_insert(userid, mailbox_list, &user_mailboxes);
             }
             sync_action_list_add(mailbox_list, args[1], NULL);
+            if (args[2]) {
+                /* if there's a second MAILBOX recorded (i.e. a rename), add
+                 * it to the same user's mailbox_list (even if it's a diff
+                 * user), so that the rename order doesn't get lost.
+                 */
+                sync_action_list_add(mailbox_list, args[2], NULL);
+            }
         }
         else if (!strcmp(args[0], "UNMAILBOX"))
             sync_action_list_add(unmailbox_list, args[1], NULL);

--- a/imap/sync_log.h
+++ b/imap/sync_log.h
@@ -73,8 +73,8 @@ void sync_log_channel(const char *channel, const char *fmt, ...);
 #define sync_log_unmailbox(name) \
     sync_log("UNMAILBOX %s\n", name)
 
-#define sync_log_mailbox_double(name1, name2) \
-    sync_log("MAILBOX %s %s\n", name1, name2)
+#define sync_log_rename(name1, name2) \
+    sync_log("RENAME %s %s\nMAILBOX %s\nMAILBOX %s\n", name1, name2, name1, name2)
 
 #define sync_log_quota(name) \
     sync_log("QUOTA %s\n", name)
@@ -106,8 +106,9 @@ void sync_log_channel(const char *channel, const char *fmt, ...);
 #define sync_log_channel_unmailbox(channel, name) \
     sync_log_channel(channel, "UNMAILBOX %s\n", name)
 
-#define sync_log_channel_mailbox_double(channel, name1, name2) \
-    sync_log_channel(channel, "MAILBOX %s %s\n", name1, name2)
+#define sync_log_channel_rename(channel, name1, name2) \
+    sync_log_channel(channel, "RENAME %s %s\nMAILBOX %s\nMAILBOX %s\n", \
+                              name1, name2, name1, name2)
 
 #define sync_log_channel_quota(channel, name) \
     sync_log_channel(channel, "QUOTA %s\n", name)

--- a/imap/sync_log.h
+++ b/imap/sync_log.h
@@ -74,7 +74,7 @@ void sync_log_channel(const char *channel, const char *fmt, ...);
     sync_log("UNMAILBOX %s\n", name)
 
 #define sync_log_mailbox_double(name1, name2) \
-    sync_log("MAILBOX %s\nMAILBOX %s\n", name1, name2)
+    sync_log("MAILBOX %s %s\n", name1, name2)
 
 #define sync_log_quota(name) \
     sync_log("QUOTA %s\n", name)
@@ -107,7 +107,7 @@ void sync_log_channel(const char *channel, const char *fmt, ...);
     sync_log_channel(channel, "UNMAILBOX %s\n", name)
 
 #define sync_log_channel_mailbox_double(channel, name1, name2) \
-    sync_log_channel(channel, "MAILBOX %s\nMAILBOX %s\n", name1, name2)
+    sync_log_channel(channel, "MAILBOX %s %s\n", name1, name2)
 
 #define sync_log_channel_quota(channel, name) \
     sync_log_channel(channel, "QUOTA %s\n", name)


### PR DESCRIPTION
There's more to do here still, but I'll open this PR now so it can be reviewed iteratively.

This first stage bundles MAILBOX updates by user, instead of processing them purely in the order they were seen.  Within each user, their MAILBOX order is preserved (though this doesn't make much difference in practice, I don't think: the whole list ends up as a single GET MAILBOXES call further down the stack).  However, the user list is processed in no particular order (i.e. hash table enumeration order -- I don't think this is a problem: we're already making user-ordering fairly meaningless by clustering mailboxes by user).

Instead of splitting operations into batches of exactly 1000 mailboxes, we collect user/mailbox operations one-whole-user at a time until we've accumulated 1000+ mailboxes, and then send that batch (rinse/repeat until the user/mailbox list is exhausted).  This means that when a user's mailbox is renamed, the updates to both the oldname and newname are always performed in the same batch.

Non-user mailboxes are batched as if they all belong to a single user called "".

So far, this PR only affects the batching process, the actual replication is unchanged.

There's still work to be done to better cope with mailbox renames between users, to clarify the handling of UNMAILBOX, and to automatically promote failed MAILBOX updates into USER updates.