### PR TITLE
idled, promstatsd, squatter: exit on SIGHUP when started as DAEMON

### DIFF
--- a/imap/idled.c
+++ b/imap/idled.c
@@ -334,8 +334,14 @@ int main(int argc, char **argv)
 
     for (;;) {
         int n;
+        int sig;
 
-        signals_poll();
+        sig = signals_poll();
+        if (sig == SIGHUP && getenv("CYRUS_ISDAEMON")) {
+            /* XXX maybe don't restart if we have clients? */
+            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully\n");
+            shut_down(0);
+        }
 
         /* check for shutdown file */
         if (shutdown_file(NULL, 0)) {

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -361,7 +361,13 @@ int main(int argc, char **argv)
     if (r) fatal("couldn't open report file", EC_IOERR);
 
     for (;;) {
-        signals_poll();
+        int sig;
+
+        sig = signals_poll();
+        if (sig == SIGHUP && getenv("CYRUS_ISDAEMON")) {
+            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully\n");
+            shut_down(0);
+        }
 
         /* check for shutdown file */
         if (shutdown_file(NULL, 0)) {

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -720,7 +720,14 @@ static void do_rolling(const char *channel)
     slr = sync_log_reader_create_with_channel(channel);
 
     for (;;) {
-        signals_poll();
+        int sig = signals_poll();
+
+        if (sig == SIGHUP && getenv("CYRUS_ISDAEMON")) {
+            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully\n");
+            sync_log_reader_end(slr);
+            shut_down(0);
+        }
+
         if (shutdown_file(NULL, 0))
             shut_down(EC_TEMPFAIL);
 


### PR DESCRIPTION
This allows master to restart it, so that configuration is reloaded.

Fixes #2096

We don't have Cassandane tests for DAEMON processes (https://github.com/cyrusimap/cassandane/issues/48) yet, so this will need manual testing before it's merged.