### PR TITLE
Fix build failure with LibreSSL 2.7

### DIFF
--- a/imap/tls.c
+++ b/imap/tls.c
@@ -227,7 +227,7 @@ static RSA *tmp_rsa_cb(SSL * s __attribute__((unused)),
 }
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 /* replacements for new 1.1 API accessors */
 /* XXX probably put these somewhere central */
 static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)


### PR DESCRIPTION
LibreSSL 2.7 adds OpenSSL 1.1 API leading to conflicts in method names

Patch also applies to 2.4 and 2.5

See also: https://bugs.freebsd.org/227166
Signed-off-by: Bernard Spil <brnrd@FreeBSD.org>