### PR TITLE
Update http_dav.c

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -10039,7 +10039,7 @@ static void xml_add_sharee(const char *userid, void *data, void *rock)
     int isadmin;
 
     if ((rights & DACL_SHARE) != DACL_SHARE) return;  /* not shared */
-    if (!strcmp(userid, irock->owner)) return;  /* user is owner */
+    if (!strcmpnull(userid, irock->owner)) return;  /* user is owner */
 
     authstate = auth_newstate(userid);
     isadmin = global_authisa(authstate, IMAPOPT_ADMINS);


### PR DESCRIPTION
irock->owner can be null in the case of public collections. This causes httpd to segfault.
problem can be reproduced when using a shared calendar url as the account url from apple devices