### PR TITLE
Include squatter.8 if SQUATTER, not if USE_SQUAT

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1523,10 +1523,10 @@ dist_man8_MANS = \
 	man/tls_prune.8 \
 	man/unexpunge.8
 
-if USE_SQUAT
+if SQUATTER
 dist_man8_MANS += \
 	man/squatter.8
-endif # USE_SQUAT
+endif # SQUATTER
 
 if NNTPD
 dist_man8_MANS += \


### PR DESCRIPTION
The man page was (incorrectly) only included when squat was compiled in, not if squatter was being used e.g. with another search engine.