### PR TITLE
Split the system_flags field in struct index_record.

### DIFF
--- a/doc/internal/mailbox-api.html
+++ b/doc/internal/mailbox-api.html
@@ -211,7 +211,7 @@ int make_changes;
 for (recno = 1; recno &lt;= mailbox-&gt;i.num_records; recno++) {
     if (mailbox_read_index_record(mailbox, recno, &amp;record))
         fatal("invalid record", EC_SOFTWARE); // or return an error
-    if (record.system_flags &amp; FLAG_EXPUNGED)
+    if (record.internal_flags &amp; FLAG_INTERNAL_EXPUNGED)
         continue; // skip expunged records
     make_changes = do_stuff(mailbox, &amp;record);
     if (make_changes)
@@ -296,7 +296,7 @@ format documentation.</p>
 for (recno = 1; recno &lt;= mailbox-&gt;i.num_records; recno++) {
     if (mailbox_read_index_record(mailbox, recno, &amp;record))
         fatal("invalid record", EC_SOFTWARE); // or return an error
-    if (record.system_flags &amp; FLAG_EXPUNGED)
+    if (record.internal_flags &amp; FLAG_INTERNAL_EXPUNGED)
         continue; // skip expunged records
     if (mailbox_cacherecord(mailbox, &amp;record))
         fatal("failed to read cache", EC_SOFTWARE);

--- a/docsrc/imap/developer/API/mailbox-api.rst
+++ b/docsrc/imap/developer/API/mailbox-api.rst
@@ -200,7 +200,7 @@ An example of iterating through a mailbox
     for (recno = 1; recno <= mailbox->i.num_records; recno++) {
         if (mailbox_read_index_record(mailbox, recno, &record))
             fatal("invalid record", EC_SOFTWARE); // or return an error
-        if (record.system_flags & FLAG_EXPUNGED)
+        if (record.internal_flags & FLAG_INTERNAL_EXPUNGED)
             continue; // skip expunged records
         make_changes = do_stuff(mailbox, &record);
         if (make_changes)
@@ -285,7 +285,7 @@ those fields in the mailbox internal format documentation.
     for (recno = 1; recno <= mailbox->i.num_records; recno++) {
         if (mailbox_read_index_record(mailbox, recno, &record))
             fatal("invalid record", EC_SOFTWARE); // or return an error
-        if (record.system_flags & FLAG_EXPUNGED)
+        if (record.internal_flags & FLAG_INTERNAL_EXPUNGED)
             continue; // skip expunged records
         if (mailbox_cacherecord(mailbox, &record))
             fatal("failed to read cache", EC_SOFTWARE);

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -825,7 +825,7 @@ static void process_one_record(struct mailbox *mailbox, uint32_t imap_uid,
         caldav_alarm_delete_record(mailbox->name, imap_uid);
         goto done_item;
     }
-    if (record.system_flags & FLAG_EXPUNGED) {
+    if (record.internal_flags & FLAG_INTERNAL_EXPUNGED) {
         syslog(LOG_ERR, "already expunged mailbox %s uid %u",
                mailbox->name, imap_uid);
         /* no longer exists?  nothing to do */

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -995,9 +995,9 @@ EXPORTED int carddav_remove(struct mailbox *mailbox,
     init_internal();
 
     if (!r) r = mailbox_find_index_record(mailbox, olduid, &oldrecord);
-    if (!r && !(oldrecord.system_flags & FLAG_EXPUNGED)) {
+    if (!r && !(oldrecord.internal_flags & FLAG_INTERNAL_EXPUNGED)) {
         if (isreplace) oldrecord.user_flags[userflag/32] |= 1<<(userflag&31);
-        oldrecord.system_flags |= FLAG_EXPUNGED;
+        oldrecord.internal_flags |= FLAG_INTERNAL_EXPUNGED;
 
         r = mailbox_rewrite_index_record(mailbox, &oldrecord);
 

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -1865,8 +1865,8 @@ EXPORTED int conversations_update_record(struct conversations_state *cstate,
         assert(old->modseq <= new->modseq);
 
         /* this flag cannot go away */
-        if ((old->system_flags & FLAG_EXPUNGED))
-            assert((new->system_flags & FLAG_EXPUNGED));
+        if (old->internal_flags & FLAG_INTERNAL_EXPUNGED)
+                assert(new->internal_flags & FLAG_INTERNAL_EXPUNGED);
 
         /* we're changing the CID for any reason at all, treat as
          * a removal and re-add, so cache gets parsed and msgids
@@ -1925,7 +1925,7 @@ EXPORTED int conversations_update_record(struct conversations_state *cstate,
     /* calculate the changes */
     if (old) {
         /* decrease any relevent counts */
-        if (!(old->system_flags & FLAG_EXPUNGED)) {
+        if (!(old->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
             delta_exists--;
             delta_size -= old->size;
             /* drafts don't update the 'unseen' counter so that
@@ -1950,7 +1950,7 @@ EXPORTED int conversations_update_record(struct conversations_state *cstate,
 
     if (new) {
         /* add any counts */
-        if (!(new->system_flags & FLAG_EXPUNGED)) {
+        if (!(new->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
             delta_exists++;
             delta_size += new->size;
             /* drafts don't update the 'unseen' counter so that

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1861,7 +1861,7 @@ static int export_calendar(struct transaction_t *txn)
                 /* Don't duplicate any VTIMEZONEs in our iCalendar */
                 if (kind == ICAL_VTIMEZONE_COMPONENT) {
                     if (syncmodseq) continue;
-                    if (record->system_flags & FLAG_EXPUNGED) continue;
+                    if (record->internal_flags & FLAG_INTERNAL_EXPUNGED) continue;
 
                     icalproperty *prop =
                         icalcomponent_get_first_property(comp,
@@ -1873,7 +1873,7 @@ static int export_calendar(struct transaction_t *txn)
                     if (hash_lookup(tzid, &tzid_table)) continue;
                     else hash_insert(tzid, (void *)0xDEADBEEF, &tzid_table);
                 }
-                else if (record->system_flags & FLAG_EXPUNGED) {
+                else if (record->internal_flags & FLAG_INTERNAL_EXPUNGED) {
                     /* Resource was deleted - remove non-mandatory properties */
                     icalproperty *prop, *next;
 
@@ -2625,7 +2625,7 @@ static void decrement_refcount(const char *managed_id,
         struct index_record record;
 
         mailbox_find_index_record(attachments, wdata->dav.imap_uid, &record);
-        record.system_flags |= FLAG_EXPUNGED;
+        record.internal_flags |= FLAG_INTERNAL_EXPUNGED;
 
         r = mailbox_rewrite_index_record(attachments, &record);
 

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4515,7 +4515,7 @@ int meth_copy_move(struct transaction_t *txn, void *params)
             /* Expunge the source message */
             if (src_rec.uid) {
                 /* Mapped URL */
-                src_rec.system_flags |= FLAG_EXPUNGED;
+                src_rec.internal_flags |= FLAG_INTERNAL_EXPUNGED;
                 if ((r = mailbox_rewrite_index_record(src_mbox, &src_rec))) {
                     syslog(LOG_ERR, "expunging src record (%s) failed: %s",
                            txn->req_tgt.mbentry->name, error_message(r));
@@ -4827,7 +4827,7 @@ int meth_delete(struct transaction_t *txn, void *params)
         if (dparams->delete) dparams->delete(txn, mailbox, &record, ddata);
 
         /* Expunge the resource */
-        record.system_flags |= FLAG_EXPUNGED;
+        record.internal_flags |= FLAG_INTERNAL_EXPUNGED;
 
         mboxevent = mboxevent_new(EVENT_MESSAGE_EXPUNGE);
 
@@ -8707,7 +8707,7 @@ int dav_store_resource(struct transaction_t *txn,
                     r = mailbox_user_flag(mailbox, DFLAG_UNBIND, &userflag, 1);
                     if (!r) {
                         oldrecord->user_flags[userflag/32] |= 1 << (userflag & 31);
-                        oldrecord->system_flags |= FLAG_EXPUNGED;
+                        oldrecord->internal_flags |= FLAG_INTERNAL_EXPUNGED;
                         r = mailbox_rewrite_index_record(mailbox, oldrecord);
                     }
                     if (r) {

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -696,7 +696,8 @@ static int fetch_message(struct transaction_t *txn, struct mailbox *mailbox,
     record->uid = uid;
     r = mailbox_reload_index_record(mailbox, record);
     if ((r == CYRUSDB_NOTFOUND) ||
-        (record->system_flags & (FLAG_DELETED|FLAG_EXPUNGED))) {
+        ((record->system_flags & FLAG_DELETED) ||
+         record->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
         txn->error.desc = "Message has been removed\r\n";
 
         /* Fill in Expires */

--- a/imap/index.h
+++ b/imap/index.h
@@ -96,11 +96,12 @@ struct index_init {
 struct index_map {
     modseq_t modseq;
     modseq_t told_modseq;
+    uint64_t cache_offset;
+    uint32_t user_flags[MAX_USER_FLAGS/32];
     uint32_t uid;
     uint32_t recno;
     uint32_t system_flags;
-    uint64_t cache_offset;
-    uint32_t user_flags[MAX_USER_FLAGS/32];
+    uint32_t internal_flags;
     unsigned int isseen:1;
     unsigned int isrecent:1;
 };
@@ -159,6 +160,7 @@ typedef struct msgdata {
     bit32 hasflag;              /* hasflag values (up to 32 of them) */
     struct message_guid guid;   /* message guid */
     uint32_t system_flags;      /* system flags */
+    uint32_t internal_flags;    /* internal flags */
 
     /* items from the conversations database */
     modseq_t convmodseq;        /* modseq of conversation */

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1842,7 +1842,7 @@ static int setcalendarevents_update(jmap_req_t *req,
 
     if (dstmbox) {
         /* Expunge the resource from mailbox. */
-        record.system_flags |= FLAG_EXPUNGED;
+        record.internal_flags |= FLAG_INTERNAL_EXPUNGED;
         mboxevent = mboxevent_new(EVENT_MESSAGE_EXPUNGE);
         r = mailbox_rewrite_index_record(mbox, &record);
         if (r) {
@@ -1975,7 +1975,7 @@ static int setcalendarevents_destroy(jmap_req_t *req,
 
 
     /* Expunge the resource from mailbox. */
-    record.system_flags |= FLAG_EXPUNGED;
+    record.internal_flags |= FLAG_INTERNAL_EXPUNGED;
     mboxevent = mboxevent_new(EVENT_MESSAGE_EXPUNGE);
     r = mailbox_rewrite_index_record(mbox, &record);
     if (r) {

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -149,6 +149,7 @@ struct index_record {
     size_t cache_offset;
     time_t last_updated;
     uint32_t system_flags;
+    uint32_t internal_flags;
     uint32_t user_flags[MAX_USER_FLAGS/32];
     time_t savedate;
     uint16_t cache_version;
@@ -383,18 +384,22 @@ typedef enum _MsgFlags {
     FLAG_DELETED            = (1<<2),
     FLAG_DRAFT              = (1<<3),
     FLAG_SEEN               = (1<<4),
-    FLAG_SPLITCONVERSATION  = (1<<27),
-    FLAG_NEEDS_CLEANUP      = (1<<28),
-    FLAG_ARCHIVED           = (1<<29),
-    FLAG_UNLINKED           = (1<<30),
-    FLAG_EXPUNGED           = (1U<<31),
 } MsgFlags;
 
+typedef enum _MsgInternalFlags {
+    FLAG_INTERNAL_SPLITCONVERSATION  = (1<<27),
+    FLAG_INTERNAL_NEEDS_CLEANUP      = (1<<28),
+    FLAG_INTERNAL_ARCHIVED           = (1<<29),
+    FLAG_INTERNAL_UNLINKED           = (1<<30),
+    FLAG_INTERNAL_EXPUNGED           = (1U<<31),
+} MsgInternalFlags;
+
 #define FLAGS_SYSTEM   (FLAG_ANSWERED|FLAG_FLAGGED|FLAG_DELETED|FLAG_DRAFT|FLAG_SEEN)
-#define FLAGS_INTERNAL (FLAG_SPLITCONVERSATION|FLAG_NEEDS_CLEANUP|FLAG_ARCHIVED|FLAG_UNLINKED|FLAG_EXPUNGED)
-/* for replication */
-#define FLAGS_LOCAL    (FLAG_SPLITCONVERSATION|FLAG_NEEDS_CLEANUP|FLAG_ARCHIVED|FLAG_UNLINKED)
-#define FLAGS_GLOBAL   (FLAGS_SYSTEM|FLAG_EXPUNGED)
+#define FLAGS_INTERNAL (FLAG_INTERNAL_SPLITCONVERSATION |       \
+                        FLAG_INTERNAL_NEEDS_CLEANUP |           \
+                        FLAG_INTERNAL_ARCHIVED |                \
+                        FLAG_INTERNAL_UNLINKED |                \
+                        FLAG_INTERNAL_EXPUNGED)
 
 #define OPT_POP3_NEW_UIDL (1<<0)        /* added for Outlook stupidity */
 /* NOTE: not used anymore - but don't reuse it */

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -238,7 +238,7 @@ static int dump_index(struct mailbox *mailbox, int oldversion,
         /* we have to make sure expunged records don't get the
          * file copied, or a reconstruct could bring them back
          * to life!  It we're not creating an expunged file... */
-        if (record->system_flags & FLAG_EXPUNGED) {
+        if (record->internal_flags & FLAG_INTERNAL_EXPUNGED) {
             if (oldversion < 9) seqset_add(expunged_seq, record->uid, 1);
             continue;
         }
@@ -274,7 +274,7 @@ static int dump_index(struct mailbox *mailbox, int oldversion,
         while ((msg = mailbox_iter_step(iter))) {
             const struct index_record *record = msg_record(msg);
             /* ignore non-expunged records */
-            if (!(record->system_flags & FLAG_EXPUNGED))
+            if (!(record->internal_flags & FLAG_INTERNAL_EXPUNGED))
                 continue;
             downgrade_record(record, rbuf, oldversion);
             n = retry_write(oldindex_fd, rbuf, record_size);

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -299,19 +299,24 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
 
         printf("\n");
 
-    	printf("      > SYSTEMFLAGS:");
-    	if (record->system_flags & FLAG_EXPUNGED) printf(" FLAG_EXPUNGED");
-    	if (record->system_flags & FLAG_UNLINKED) printf(" FLAG_UNLINKED");
-    	if (record->system_flags & FLAG_ARCHIVED) printf(" FLAG_ARCHIVED");
-    	if (record->system_flags & FLAG_NEEDS_CLEANUP) printf(" FLAG_NEEDS_CLEANUP");
+        printf("      > INTERNALFLAGS:");
+        if (record->internal_flags & FLAG_INTERNAL_EXPUNGED)
+            printf(" FLAG_INTERNAL_EXPUNGED");
+        if (record->internal_flags & FLAG_INTERNAL_UNLINKED)
+            printf(" FLAG_INTERNAL_UNLINKED");
+        if (record->internal_flags & FLAG_INTERNAL_ARCHIVED)
+            printf(" FLAG_INTERNAL_ARCHIVED");
+        if (record->internal_flags & FLAG_INTERNAL_NEEDS_CLEANUP)
+            printf(" FLAG_INTERNAL_NEEDS_CLEANUP");
 
-    	if (record->system_flags & FLAG_SEEN) printf(" FLAG_SEEN");
-    	if (record->system_flags & FLAG_DRAFT) printf(" FLAG_DRAFT");
-    	if (record->system_flags & FLAG_DELETED) printf(" FLAG_DELETED");
-    	if (record->system_flags & FLAG_FLAGGED) printf(" FLAG_FLAGGED");
-    	if (record->system_flags & FLAG_ANSWERED) printf(" FLAG_ANSWERED");
+        printf("      > SYSTEMFLAGS:");
+        if (record->system_flags & FLAG_SEEN) printf(" FLAG_SEEN");
+        if (record->system_flags & FLAG_DRAFT) printf(" FLAG_DRAFT");
+        if (record->system_flags & FLAG_DELETED) printf(" FLAG_DELETED");
+        if (record->system_flags & FLAG_FLAGGED) printf(" FLAG_FLAGGED");
+        if (record->system_flags & FLAG_ANSWERED) printf(" FLAG_ANSWERED");
 
-    	printf("\n");
+        printf("\n");
 
         printf("      > USERFLAGS:");
         for (j=(MAX_USER_FLAGS/32)-1; j>=0; j--) {

--- a/imap/message.c
+++ b/imap/message.c
@@ -3504,7 +3504,7 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
 
     /* mark that it's split so basecid gets saved */
     if (record->basecid != record->cid)
-        record->system_flags |= FLAG_SPLITCONVERSATION;
+        record->internal_flags |= FLAG_INTERNAL_SPLITCONVERSATION;
 
 out:
     free(msgid);

--- a/imap/msgrecord.c
+++ b/imap/msgrecord.c
@@ -242,6 +242,16 @@ EXPORTED int msgrecord_get_systemflags(msgrecord_t *mr, uint32_t *flags)
     return 0;
 }
 
+EXPORTED int msgrecord_get_internalflags(msgrecord_t *mr, uint32_t *flags)
+{
+    if (!mr->isappend) {
+        int r = msgrecord_need(mr, M_RECORD);
+        if (r) return r;
+    }
+    *flags = mr->record.internal_flags;
+    return 0;
+}
+
 EXPORTED int msgrecord_get_userflags(msgrecord_t *mr,
                                      uint32_t flags[MAX_USER_FLAGS/32])
 {
@@ -517,6 +527,12 @@ EXPORTED int msgrecord_add_systemflags(msgrecord_t *mr, uint32_t system_flags)
     return 0;
 }
 
+EXPORTED int msgrecord_add_internalflags(msgrecord_t *mr, uint32_t internal_flags)
+{
+    mr->record.internal_flags |= internal_flags;
+    return 0;
+}
+
 EXPORTED int msgrecord_set_uid(msgrecord_t *mr, uint32_t uid)
 {
     assert(mr->isappend);
@@ -545,9 +561,18 @@ EXPORTED int msgrecord_set_systemflags(msgrecord_t *mr, uint32_t system_flags)
     return 0;
 }
 
+EXPORTED int msgrecord_set_internalflags(msgrecord_t *mr, uint32_t internal_flags)
+{
+    if (!mr->isappend) {
+        int r = msgrecord_need(mr, M_RECORD);
+        if (r) return r;
+    }
+    mr->record.internal_flags = internal_flags;
+    return 0;
+}
+
 EXPORTED int msgrecord_set_userflags(msgrecord_t *mr,
                                      uint32_t user_flags[MAX_USER_FLAGS/32])
- 
 {
     if (!mr->isappend) {
         int r = msgrecord_need(mr, M_RECORD);

--- a/imap/msgrecord.h
+++ b/imap/msgrecord.h
@@ -74,6 +74,7 @@ extern int msgrecord_get_message(msgrecord_t *mr, message_t **msg);
 extern int msgrecord_get_size(msgrecord_t *mr, uint32_t *size);
 extern int msgrecord_get_header_size(msgrecord_t *mr, uint32_t *header_size);
 extern int msgrecord_get_systemflags(msgrecord_t *mr, uint32_t *flags);
+extern int msgrecord_get_internalflags(msgrecord_t *mr, uint32_t *flags);
 extern int msgrecord_hasflag(msgrecord_t *mr, const char *flag, int *has);
 extern int msgrecord_get_index_record(msgrecord_t *mr, struct index_record *record);
 extern int msgrecord_get_index_record_rw(msgrecord_t *mr, struct index_record **record);
@@ -91,6 +92,8 @@ extern int msgrecord_load_cache(msgrecord_t *mr);
 // TODO(rsto): also strarray variant */
 extern int msgrecord_set_systemflags(msgrecord_t *mr, uint32_t system_flags);
 extern int msgrecord_add_systemflags(msgrecord_t *mr, uint32_t system_flags);
+extern int msgrecord_set_internalflags(msgrecord_t *mr, uint32_t internal_flags);
+extern int msgrecord_add_internalflags(msgrecord_t *mr, uint32_t internal_flags);
 extern int msgrecord_set_userflags(msgrecord_t *mr, uint32_t user_flags[MAX_USER_FLAGS/32]);
 extern int msgrecord_set_userflag(msgrecord_t *mr, uint32_t user_flag, int bit);
 extern int msgrecord_set_uid(msgrecord_t *mr, uint32_t uid);

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -802,11 +802,12 @@ static int expunge_deleted(void)
         if (r) break;
 
         /* already expunged? skip */
-        if (record.system_flags & FLAG_EXPUNGED)
+        if (record.internal_flags & FLAG_INTERNAL_EXPUNGED)
             continue;
 
         /* mark expunged */
-        record.system_flags |= FLAG_DELETED | FLAG_EXPUNGED;
+        record.system_flags |= FLAG_DELETED;
+        record.internal_flags |= FLAG_INTERNAL_EXPUNGED;
         numexpunged++;
 
         /* store back to the mailbox */
@@ -2111,7 +2112,7 @@ static int update_seen(void)
         record.recno = popd_map[msgno-1].recno;
         if (mailbox_reload_index_record(popd_mailbox, &record))
             continue;
-        if (record.system_flags & FLAG_EXPUNGED)
+        if (record.internal_flags & FLAG_INTERNAL_EXPUNGED)
             continue; /* already expunged */
         if (record.system_flags & FLAG_SEEN)
             continue; /* already seen */

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -513,7 +513,7 @@ static void subquery_post_indexed(const char *key, void *data, void *rock)
             continue;
 
         /* can happen if we didn't "tellchanges" yet */
-        if ((im->system_flags & FLAG_EXPUNGED) && !query->want_expunged)
+        if ((im->internal_flags & FLAG_INTERNAL_EXPUNGED) && !query->want_expunged)
             continue;
 
         /* run the search program */
@@ -682,7 +682,7 @@ static int subquery_run_one_folder(search_query_t *query,
         if (r) goto out;
 
         /* can happen if we didn't "tellchanges" yet */
-        if ((im->system_flags & FLAG_EXPUNGED) && !query->want_expunged)
+        if ((im->internal_flags & FLAG_INTERNAL_EXPUNGED) && !query->want_expunged)
             continue;
 
         /* run the search program */

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -385,7 +385,8 @@ static int index_single_message(const char *mboxname, uint32_t uid)
     r = mailbox_find_index_record(mailbox, uid, &record);
     if (r) goto out;
 
-    if (record.system_flags & (FLAG_EXPUNGED|FLAG_UNLINKED)) goto out;
+    if (record.internal_flags & (FLAG_INTERNAL_EXPUNGED | FLAG_INTERNAL_UNLINKED))
+        goto out;
 
     msg = message_new_from_record(mailbox, &record);
     if (!msg) goto out;

--- a/imap/unexpunge.c
+++ b/imap/unexpunge.c
@@ -121,7 +121,7 @@ static void list_expunged(const char *mboxname)
     while ((msg = mailbox_iter_step(iter))) {
         const struct index_record *record = msg_record(msg);
         /* still active */
-        if (!(record->system_flags & FLAG_EXPUNGED))
+        if (!(record->internal_flags & FLAG_INTERNAL_EXPUNGED))
             continue;
 
         /* pre-allocate more space */
@@ -186,7 +186,7 @@ static int restore_expunged(struct mailbox *mailbox, int mode, unsigned long *ui
     while ((msg = mailbox_iter_step(iter))) {
         const struct index_record *record = msg_record(msg);
         /* still active */
-        if (!(record->system_flags & FLAG_EXPUNGED))
+        if (!(record->internal_flags & FLAG_INTERNAL_EXPUNGED))
             continue;
 
         if (mode == MODE_UID) {
@@ -213,7 +213,7 @@ static int restore_expunged(struct mailbox *mailbox, int mode, unsigned long *ui
 
         /* bump the UID, strip the flags */
         newrecord.uid = mailbox->i.last_uid + 1;
-        newrecord.system_flags &= ~FLAG_EXPUNGED;
+        newrecord.internal_flags &= ~FLAG_INTERNAL_EXPUNGED;
         if (unsetdeleted)
             newrecord.system_flags &= ~FLAG_DELETED;
 
@@ -252,7 +252,8 @@ static int restore_expunged(struct mailbox *mailbox, int mode, unsigned long *ui
 
         /* mark the old one unlinked so we don't see it again */
         struct index_record oldrecord = *record;
-        oldrecord.system_flags |= FLAG_UNLINKED | FLAG_NEEDS_CLEANUP;
+        oldrecord.internal_flags |= FLAG_INTERNAL_UNLINKED |
+            FLAG_INTERNAL_NEEDS_CLEANUP;
         r = mailbox_rewrite_index_record(mailbox, &oldrecord);
         if (r) break;
 


### PR DESCRIPTION
The `system_flags` field in `struct index_record` is used to store the
following flags on disk:

-- System flags:
FLAG_ANSWERED
FLAG_FLAGGED
FLAG_DELETED
FLAG_DRAFT
FLAG_SEEN

-- Internal flags for bookeeping:
FLAG_SPLITCONVERSATION
FLAG_NEEDS_CLEANUP
FLAG_ARCHIVED
FLAG_UNLINKED
FLAG_EXPUNGED

This patch, removes the use of `system_flags` to store the internal
flags in memory. Instead, we now have several bit fields in `struct
index_record` representing the internal flags.

The on-disk representation continues to be the same.

The methods `mailbox_buf_to_index_record()` and
`mailbox_index_record_to_buf()` serialise and deserialise these fields.

Fixes #2331