### PR TITLE
sieve: account for comparison result of a multipart message.

### DIFF
--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -987,7 +987,7 @@ envelope_err:
 
         /* bodypart(s) exist, now to test them */
 
-        for (y = 0; val && val[y]; y++) {
+        for (y = 0; val && val[y] && !res; y++) {
 
             if (match == B_COUNT) {
                 count++;


### PR DESCRIPTION
When applying a sieve rule on a multipart message, we should account for
the result of all the comparison matches. Before this match, even if we
found a patch, the result would be ignored, unless it is the last part
in a multipart message.
This patch fixes this issue.