### PR TITLE
fix performance issue in charset header parser

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -100,6 +100,8 @@
 
 #define CONVERSATIONS_VERSION 0
 
+struct conversations_open *open_conversations;
+
 static conv_status_t NULLSTATUS = { 0, 0, 0};
 
 static char *convdir = NULL;

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -78,7 +78,7 @@ struct conversations_open {
     struct conversations_open *next;
 };
 
-struct conversations_open *open_conversations;
+extern struct conversations_open *open_conversations;
 
 typedef struct conversation conversation_t;
 typedef struct conv_folder  conv_folder_t;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3618,7 +3618,7 @@ int sync_apply_message(struct dlist *kin,
         const char *fname;
 
         /* XXX - complain more? */
-        if (!dlist_tofile(ki, &part, &guid, (ulong *) &size, &fname))
+        if (!dlist_tofile(ki, &part, &guid, (unsigned long *) &size, &fname))
             continue;
 
         part_list = sync_reserve_partlist(reserve_list, part);
@@ -4675,7 +4675,7 @@ static int fetch_file(struct mailbox *mailbox, unsigned uid,
         return r;
     }
 
-    if (!dlist_tofile(kin->head, NULL, &guid, (ulong *) &size, &fname)) {
+    if (!dlist_tofile(kin->head, NULL, &guid, (unsigned long *) &size, &fname)) {
         r = IMAP_MAILBOX_NONEXISTENT;
         syslog(LOG_ERR, "IOERROR: fetch_file failed tofile %s", error_message(r));
         goto done;


### PR DESCRIPTION
fix performance issue in charset header parser when header is long and contains many encoded words, also fix non-portable use of ulong and declaration of variable in conversions.h that should be in conversions.c