### PR TITLE
[zeroskip] Support for Zeroskip DB.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1413,6 +1413,13 @@ endif
 lib_libcyrus_la_LIBADD = libcrc32.la ${LIB_SASL} $(SSL_LIBS) $(GCOV_LIBS)
 lib_libcyrus_la_CFLAGS = $(AM_CFLAGS) $(CFLAG_VISIBILITY)
 
+if USE_ZEROSKIP
+lib_libcyrus_la_SOURCES += lib/cyrusdb_zeroskip.c
+lib_libcyrus_la_LIBADD += $(ZEROSKIP_LIBS)
+lib_libcyrus_la_CFLAGS += $(ZEROSKIP_CFLAGS)
+AM_CPPFLAGS += $(ZEROSKIP_CFLAGS)
+endif
+
 noinst_LTLIBRARIES += libcrc32.la
 libcrc32_la_SOURCES = lib/crc32.c lib/crc32c.c
 libcrc32_la_CFLAGS = -O3 $(AM_CFLAGS) $(CFLAG_VISIBILITY)

--- a/configure.ac
+++ b/configure.ac
@@ -1404,6 +1404,20 @@ AC_SUBST([JANSSON_LIBS])
 AC_SUBST([JANSSON_CFLAGS])
 
 dnl
+dnl Check for zeroskip library, needed for zeroskip support
+dnl
+AC_ARG_WITH([zeroskip],
+	AS_HELP_STRING([--without-zeroskip], [ignore presence of Zeroskip and disable it]))
+AS_IF([test "x$with_zeroskip" != "xno"],
+	[ PKG_CHECK_MODULES([ZEROSKIP], [libzeroskip],
+		[ AC_DEFINE(HAVE_ZEROSKIP, [], [Do we have Zeroskip?])
+		  with_zeroskip=yes ],
+		with_zeroskip=no)])
+AC_SUBST([ZEROSKIP_LIBS])
+AC_SUBST([ZEROSKIP_CFLAGS])
+AM_CONDITIONAL([USE_ZEROSKIP], [test "x$with_zeroskip" = xyes])
+
+dnl
 dnl Set pidfile location
 dnl
 AC_ARG_WITH(pidfile,
@@ -2349,6 +2363,7 @@ Database support:
    mysql:              $with_mysql
    postgresql:         $use_pgsql
    sqlite:             $use_sqlite
+   zeroskip:           $with_zeroskip
 
 Search engine:
    squat:              $enable_squat

--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -19,7 +19,7 @@ struct binary_result
     size_t datalen;
 };
 
-static char *backend = CUNIT_PARAM("skiplist,flat,twoskip");
+static char *backend = CUNIT_PARAM("skiplist,flat,twoskip,zeroskip");
 static char *filename;
 static char *filename2;
 
@@ -203,6 +203,14 @@ static char *make_basedir(const char * const *reldirs)
 static int skiptest()
 {
     /* cunit.pl doesn't play nice with #ifdef'ed CUNIT_PARAMS */
+
+    if (!strcmp(backend, "zeroskip")) {
+#ifdef HAVE_ZEROSKIP
+        return 0;
+#else
+        return 1;
+#endif
+    }
     return 0;
 }
 

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -1358,7 +1358,11 @@ static int set_up(void)
 
     libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     cyrusdb_init();
+#ifdef HAVE_ZEROSKIP
+    config_conversations_db = "zeroskip";
+#else
     config_conversations_db = "twoskip";
+#endif
 
     return 0;
 }

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -925,8 +925,9 @@ static int split_attribs(const char *data, int datalen,
     /* initialize metadata */
     memset(mdata, 0, sizeof(struct annotate_metadata));
 
-    /* xxx use datalen? */
     /* xxx sanity check the data? */
+    if (datalen <= 0)
+            return 1;
     /*
      * Sigh...this is dumb.  We take care to be machine independent by
      * storing the length in network byte order...but the size of the

--- a/lib/bsearch.c
+++ b/lib/bsearch.c
@@ -214,6 +214,40 @@ HIDDEN int bsearch_ncompare_mbox(const char *s1, int l1, const char *s2, int l2)
     }
 }
 
+HIDDEN int bsearch_uncompare_mbox(const unsigned char *s1, size_t l1,
+                                  const unsigned char *s2, size_t l2)
+{
+    ssize_t min = l1 < l2 ? l1 : l2;
+    int cmp = 0;
+
+    while (min-- > 0 && (cmp = TOCOMPARE(*s1) - TOCOMPARE(*s2)) == 0) {
+        s1++;
+        s2++;
+    }
+    if (min >= 0) {
+        return cmp;
+    } else {
+        if (l2 > l1) return -1;
+        else if (l1 > l2) return 1;
+        else return 0;
+    }
+}
+
+HIDDEN int bsearch_memtree_mbox(const unsigned char *s1, size_t l1,
+                                const unsigned char *s2, size_t l2)
+{
+    size_t min = l1 < l2 ? l1 : l2;
+    int cmp = 0;
+
+    while ((min-- >0) &&
+           (cmp = (TOCOMPARE(*s1) - TOCOMPARE(*s2))) == 0) {
+        s1++;
+        s2++;
+    }
+
+    return cmp;
+}
+
 /* direct from the qsort manpage */
 EXPORTED int cmpstringp_raw(const void *p1, const void *p2)
 {

--- a/lib/bsearch.c
+++ b/lib/bsearch.c
@@ -245,7 +245,17 @@ HIDDEN int bsearch_memtree_mbox(const unsigned char *s1, size_t l1,
         s2++;
     }
 
-    return cmp;
+    /* found a mismatch */
+    if (cmp) return cmp;
+
+    /* Walked off the end of one (or both strings), in which case one
+     * (or both) of these will be zero, and the string with bytes remaining
+     * is the greater.
+     * XXX Arguably we don't need to TOCOMPARE() them here cause it's
+     * always a comparison against zero, but if this turns into a perf
+     * problem we can always optimise it then!
+     */
+    return TOCOMPARE(*s1) - TOCOMPARE(*s2);
 }
 
 /* direct from the qsort manpage */

--- a/lib/bsearch.h
+++ b/lib/bsearch.h
@@ -51,6 +51,10 @@ extern int bsearch_mem_mbox(const char *word,
 extern int bsearch_compare_mbox(const char *s1, const char *s2);
 
 extern int bsearch_ncompare_mbox(const char *s1, int l1, const char *s2, int l2);
+extern int bsearch_uncompare_mbox(const unsigned char *s1, size_t l1,
+                                  const unsigned char *s2, size_t l2);
+extern int bsearch_memtree_mbox(const unsigned char *s1, size_t l1,
+                                const unsigned char *s2, size_t l2);
 
 extern int bsearch_ncompare_raw(const char *s1, int l1, const char *s2, int l2);
 

--- a/lib/cyrusdb.c
+++ b/lib/cyrusdb.c
@@ -68,6 +68,7 @@ extern struct cyrusdb_backend cyrusdb_skiplist;
 extern struct cyrusdb_backend cyrusdb_quotalegacy;
 extern struct cyrusdb_backend cyrusdb_sql;
 extern struct cyrusdb_backend cyrusdb_twoskip;
+extern struct cyrusdb_backend cyrusdb_zeroskip;
 
 static struct cyrusdb_backend *_backends[] = {
     &cyrusdb_flat,
@@ -77,6 +78,9 @@ static struct cyrusdb_backend *_backends[] = {
     &cyrusdb_sql,
 #endif
     &cyrusdb_twoskip,
+#if defined HAVE_ZEROSKIP
+    &cyrusdb_zeroskip,
+#endif
     NULL };
 
 #define DEFAULT_BACKEND "twoskip"

--- a/lib/cyrusdb_zeroskip.c
+++ b/lib/cyrusdb_zeroskip.c
@@ -1,0 +1,592 @@
+/* cyrusdb_zeroskip.c - Support for Zeroskip
+ *
+ * Copyright (c) 1994-2018 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <sys/types.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "assert.h"
+#include "bsearch.h"
+#include "cyrusdb.h"
+#include "util.h"
+#include "xmalloc.h"
+
+#include <libzeroskip/zeroskip.h>
+#include <libzeroskip/btree.h>
+
+struct txn {
+    struct zsdb_txn *t;
+};
+
+
+struct dbengine {
+    struct zsdb *db;
+    struct zsdb_txn **curent_txn;
+};
+
+
+struct dblist {
+    struct dbengine *db;
+    struct dblist *next;
+};
+
+/****** INTERNAL FUNCTIONS ******/
+static int create_or_reuse_txn(struct dbengine *db,
+                               struct txn **curtidptr,
+                               struct txn **newtidptr)
+{
+    struct txn *tid = NULL;
+
+    assert(newtidptr);
+    tid = *newtidptr;
+
+    if (!curtidptr || !*curtidptr) {
+        /* New transaction */
+        int r;
+
+        tid = xcalloc(1, sizeof(struct txn));
+        r = zsdb_transaction_begin(db->db, &tid->t);
+        if (r != ZS_OK) {
+            free(tid);
+            tid = NULL;
+            *newtidptr = NULL;
+            return CYRUSDB_INTERNAL;
+        }
+    } else {
+        /* Existing transaction */
+        tid = *curtidptr;
+    }
+
+    if (curtidptr)
+        *curtidptr = tid;
+
+    *newtidptr = tid;
+
+    return CYRUSDB_OK;
+}
+
+btree_memcmp_fn(
+  mbox,
+  ,
+  bsearch_memtree_mbox(k, keylen, b, blen)
+)
+/****** CYRUS DB API ******/
+
+HIDDEN int cyrusdb_zeroskip_init(const char *dbdir __attribute__((unused)),
+                                 int myflags __attribute__((unused)))
+{
+    return CYRUSDB_OK;
+}
+
+HIDDEN int cyrusdb_zeroskip_done(void)
+{
+    return CYRUSDB_OK;
+}
+
+HIDDEN int cyrusdb_zeroskip_sync(void)
+{
+    return CYRUSDB_OK;
+}
+
+HIDDEN int cyrusdb_zeroskip_archive(const strarray_t *fnames __attribute__((unused)),
+                                    const char *dirname __attribute__((unused)))
+{
+    return CYRUSDB_OK;
+}
+
+
+HIDDEN int cyrusdb_zeroskip_unlink(const char *fname __attribute__((unused)),
+                                   int flags __attribute__((unused)))
+{
+    return CYRUSDB_OK;
+}
+
+static int cyrusdb_zeroskip_open(const char *fname,
+                                 int flags,
+                                 struct dbengine **ret,
+                                 struct txn **mytid)
+{
+    struct dbengine *dbe;
+    int r = CYRUSDB_OK;
+    int zsdbflags = MODE_RDWR;
+    zsdb_cmp_fn dbcmpfn = NULL;
+    btree_search_cb_t btcmpfn = NULL;
+
+    dbe = (struct dbengine *) xzmalloc(sizeof(struct dbengine));
+
+    if (flags & CYRUSDB_CREATE)
+        zsdbflags = MODE_CREATE;
+
+    if (flags & CYRUSDB_MBOXSORT) {
+        zsdbflags |= MODE_CUSTOMSEARCH;
+        dbcmpfn = bsearch_uncompare_mbox;
+        btcmpfn = btree_memcmp_mbox;
+    }
+
+    if (zsdb_init(&dbe->db, dbcmpfn, btcmpfn) != ZS_OK) {
+        r = CYRUSDB_IOERROR;
+        goto done;
+    }
+
+    r = zsdb_open(dbe->db, fname, zsdbflags);
+    if (r) {
+        if (r == ZS_NOTFOUND) r = CYRUSDB_NOTFOUND;
+        else r = CYRUSDB_IOERROR;
+        goto finalise_db;
+    }
+
+    *ret = dbe;
+
+    if (mytid) {
+        *mytid = xmalloc(sizeof(struct txn));
+        r = zsdb_transaction_begin(dbe->db, &(*mytid)->t);
+        if (r != ZS_OK) {
+            r = CYRUSDB_INTERNAL;
+            goto close_db;
+        }
+    }
+
+    r = CYRUSDB_OK;
+    goto done;
+
+ close_db:
+    zsdb_close(dbe->db);
+ finalise_db:
+    zsdb_final(&dbe->db);
+    free(dbe);
+
+ done:
+    return r;
+}
+
+static int cyrusdb_zeroskip_close(struct dbengine *dbe)
+{
+    int r = CYRUSDB_OK;
+
+    assert(dbe);
+    assert(dbe->db);
+
+    r = zsdb_close(dbe->db);
+    if (r) {
+        r = CYRUSDB_INTERNAL;
+        goto done;
+    }
+
+    zsdb_final(&dbe->db);
+
+    free(dbe);
+    dbe = NULL;
+
+ done:
+    return r;
+}
+
+static int cyrusdb_zeroskip_fetch(struct dbengine *db,
+                                  const char *key, size_t keylen,
+                                  const char **data, size_t *datalen,
+                                  struct txn **tidptr)
+{
+    int r = CYRUSDB_OK;
+    struct txn *tid = NULL;
+
+    assert(db);
+    assert(key);
+    assert(keylen);
+
+    if (datalen) assert(data);
+
+    if (data) *data = NULL;
+    if (datalen) *datalen = 0;
+
+    r = create_or_reuse_txn(db, tidptr, &tid);
+    if (r)
+        goto done;
+
+    r = zsdb_fetch(db->db, (const unsigned char *)key, keylen,
+                   (const unsigned char **)data, datalen,
+                   tidptr ? &tid->t : NULL);
+    if (r == ZS_NOTFOUND){
+        r = CYRUSDB_NOTFOUND;
+        if (data) *data = NULL;
+        if (datalen) *datalen = 0;
+
+        goto done;
+
+    } else if (r) {
+        r = CYRUSDB_IOERROR;
+        goto done;
+    }
+
+    if (tidptr) {
+        *tidptr = tid;
+    }
+
+    r = CYRUSDB_OK;
+
+ done:
+    if (tid && (!tidptr || !*tidptr)) {
+        zsdb_transaction_end(&tid->t);
+        free(tid);
+        tid = NULL;
+    }
+
+    return r;
+}
+
+static int cyrusdb_zeroskip_fetchlock(struct dbengine *db,
+                                      const char *key, size_t keylen,
+                                      const char **data, size_t *datalen,
+                                      struct txn **tidptr)
+{
+    assert(key);
+    assert(keylen);
+
+    /* TODO: LOCK??? */
+    return cyrusdb_zeroskip_fetch(db, key, keylen,
+                                  data, datalen,
+                                  tidptr);
+}
+
+static int cyrusdb_zeroskip_fetchnext(struct dbengine *db,
+                                      const char *key, size_t keylen,
+                                      const char **foundkey, size_t *fklen,
+                                      const char **data, size_t *datalen,
+                                      struct txn **tidptr)
+{
+    int r = CYRUSDB_OK;
+    struct txn *tid = NULL;
+
+    assert(db);
+
+    r = zsdb_fetchnext(db->db, (const unsigned char *)key, keylen,
+                       (const unsigned char **)foundkey, fklen,
+                       (const unsigned char **)data, datalen,
+                       &tid->t);
+    if (r != ZS_OK) {
+        if (r == ZS_NOTFOUND) r = CYRUSDB_NOTFOUND;
+        else                  r = CYRUSDB_IOERROR;
+        goto done;
+    }
+
+ done:
+    return r;
+}
+
+static int cyrusdb_zeroskip_foreach(struct dbengine *db,
+                                    const char *prefix, size_t prefixlen,
+                                    foreach_p *goodp,
+                                    foreach_cb *cb, void *rock,
+                                    struct txn **tidptr)
+{
+    int r = CYRUSDB_OK;
+    struct txn *tid = NULL;
+
+    assert(db);
+    assert(cb);
+
+    if (prefixlen) assert(prefix);
+
+    r = create_or_reuse_txn(db, tidptr, &tid);
+    if (r)
+        goto done;
+
+    r = zsdb_foreach(db->db, prefix, prefixlen, goodp, cb,
+                     rock, tidptr ? &tid->t : NULL);
+    if (r != ZS_OK) {
+        r = CYRUSDB_IOERROR;
+        goto done;
+    }
+
+    if (tidptr) {
+        *tidptr = tid;
+    }
+
+    r = CYRUSDB_OK;
+
+ done:
+    if (tid && (!tidptr || !*tidptr)) {
+        zsdb_transaction_end(&tid->t);
+        free(tid);
+        tid = NULL;
+    }
+
+    return r;
+}
+
+static int cyrusdb_zeroskip_create(struct dbengine *db,
+                                   const char *key, size_t keylen,
+                                   const char *data, size_t datalen,
+                                   struct txn **tidptr)
+{
+    if (datalen) assert(data);
+
+    return 0;
+}
+
+static int cyrusdb_zeroskip_store(struct dbengine *db,
+                                  const char *key, size_t keylen,
+                                  const char *data, size_t datalen,
+                                  struct txn **tidptr)
+{
+    struct txn *tid = NULL;
+    int r = 0;
+
+    if (datalen) assert(data);
+
+    assert(db);
+    assert(key && keylen);
+
+    r = create_or_reuse_txn(db, tidptr, &tid);
+    if (r)
+        goto done;
+
+    /* Acquire write lock */
+    zsdb_write_lock_acquire(db->db, 0);
+
+    r = zsdb_add(db->db, (const unsigned char *)key, keylen,
+                 (const unsigned char *)data, datalen,
+                 tidptr ? &tid->t : NULL);
+    if (r == ZS_NOTFOUND) {
+        r = CYRUSDB_NOTFOUND;
+        goto done;
+    } else if (r) {
+        zsdb_abort(db->db, &tid->t);
+        r = CYRUSDB_IOERROR;
+        goto done;
+    }
+
+    if (tidptr) {
+        *tidptr = tid;
+    }
+
+    if (r) r = CYRUSDB_IOERROR;
+    else   r = CYRUSDB_OK;
+
+ done:
+    /* Release write lock */
+    zsdb_write_lock_release(db->db);
+
+    if (tid && (!tidptr || !*tidptr)) {
+        zsdb_transaction_end(&tid->t);
+        free(tid);
+        tid = NULL;
+    }
+
+    return r;
+}
+
+static int cyrusdb_zeroskip_delete(struct dbengine *db,
+                                   const char *key, size_t keylen,
+                                   struct txn **tidptr, int force)
+{
+    struct txn *tid = NULL;
+    int r = 0;
+
+    if (keylen) assert(key);
+
+    assert(db);
+
+    r = create_or_reuse_txn(db, tidptr, &tid);
+    if (r)
+        goto done;
+
+    /* Acquire write lock */
+    zsdb_write_lock_acquire(db->db, 0);
+
+    r = zsdb_remove(db->db, (const unsigned char *)key, keylen, &tid->t);
+    if (r == ZS_NOTFOUND) {
+        r = CYRUSDB_NOTFOUND;
+        goto done;
+    } else if (r) {
+        r = CYRUSDB_INTERNAL;
+        goto done;
+    }
+
+    if (tidptr) {
+        *tidptr = tid;
+    }
+
+    if (r) r = CYRUSDB_IOERROR;
+    else   r = CYRUSDB_OK;
+
+ done:
+    /* Release write lock */
+    zsdb_write_lock_release(db->db);
+
+    if (tid && (!tidptr || !*tidptr)) {
+        zsdb_transaction_end(&tid->t);
+        free(tid);
+        tid = NULL;
+    }
+
+    return r;
+}
+
+
+static int cyrusdb_zeroskip_commit(struct dbengine *db, struct txn *tid)
+{
+    int r = 0;
+
+    assert(db);
+
+    r = zsdb_commit(db->db, tid ? tid->t : NULL);
+    if (r)
+        r = CYRUSDB_IOERROR;
+    else
+        r = CYRUSDB_OK;
+
+    if (tid)
+        free(tid);
+
+    return r;
+}
+
+static int cyrusdb_zeroskip_abort(struct dbengine *db, struct txn *tid)
+{
+    assert(db);
+    assert(tid);
+
+    zsdb_abort(db->db, &tid->t);
+    free(tid);
+    tid = NULL;
+
+    return CYRUSDB_OK;
+}
+
+/* cyrusdb_zeroskip_dump:
+   if detail == 1, dump all records.
+   if detail == 2, dump active records only
+*/
+static int cyrusdb_zeroskip_dump(struct dbengine *db,
+                                 int detail)
+{
+    int r = 0;
+
+    assert(db);
+
+    r = zsdb_dump(db->db, (detail == 1) ? DB_DUMP_ALL : DB_DUMP_ACTIVE);
+    if (r)
+        r = CYRUSDB_IOERROR;
+    else
+        r = CYRUSDB_OK;
+
+    return r;
+}
+
+static int cyrusdb_zeroskip_consistent(struct dbengine *db)
+{
+    return 0;
+}
+
+static int cyrusdb_zeroskip_checkpoint(struct dbengine *db)
+{
+    int r = 0;
+
+    assert(db);
+
+    if (zsdb_pack_lock_acquire(db->db, 0) != ZS_OK) {
+        r = CYRUSDB_IOERROR;
+        goto done;
+    }
+
+    r = zsdb_repack(db->db);
+    if (r)
+        r = CYRUSDB_IOERROR;
+    else
+        r = CYRUSDB_OK;
+fail:
+    if (zsdb_pack_lock_release(db->db) != ZS_OK) {
+        r = CYRUSDB_IOERROR;
+    }
+
+done:
+    return r;
+}
+
+static int cyrusdb_zeroskip_compar(struct dbengine *db,
+                                   const char *a, int alen,
+                                   const char *b, int blen)
+{
+    /* return db->compar(a, alen, b, blen); */
+    return 0;
+}
+
+
+HIDDEN struct cyrusdb_backend cyrusdb_zeroskip =
+{
+    "zeroskip",                  /* name */
+
+    &cyrusdb_zeroskip_init,
+    &cyrusdb_zeroskip_done,
+    &cyrusdb_zeroskip_sync,
+    &cyrusdb_zeroskip_archive,
+    &cyrusdb_zeroskip_unlink,
+
+    &cyrusdb_zeroskip_open,
+    &cyrusdb_zeroskip_close,
+
+    &cyrusdb_zeroskip_fetch,
+    &cyrusdb_zeroskip_fetchlock,
+    &cyrusdb_zeroskip_fetchnext,
+
+    &cyrusdb_zeroskip_foreach,
+    &cyrusdb_zeroskip_create,
+    &cyrusdb_zeroskip_store,
+    &cyrusdb_zeroskip_delete,
+
+    &cyrusdb_zeroskip_commit,
+    &cyrusdb_zeroskip_abort,
+
+    &cyrusdb_zeroskip_dump,
+    &cyrusdb_zeroskip_consistent,
+    &cyrusdb_zeroskip_checkpoint,
+    &cyrusdb_zeroskip_compar
+};
+

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -180,7 +180,7 @@ are listed with ``<none>''.
 /* Alternative INBOX spellings that can't be accessed in altnamespace
    otherwise go under here */
 
-{ "annotation_db", "twoskip", STRINGLIST("skiplist", "twoskip")}
+{ "annotation_db", "twoskip", STRINGLIST("skiplist", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for mailbox annotations. */
 
 { "annotation_db_path", NULL, STRING }
@@ -483,7 +483,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    from the source.  If set to a negative value or zero, deleted content
    will be kept indefinitely. */
 
-{ "backup_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip")}
+{ "backup_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the backup locations database. */
 
 { "backup_db_path", NULL, STRING }
@@ -620,7 +620,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    database with ctl_conversationsdb if you change this option on a
    running server, or the counts will be wrong.  */
 
-{ "conversations_db", "skiplist", STRINGLIST("skiplist", "sql", "twoskip")}
+{ "conversations_db", "skiplist", STRINGLIST("skiplist", "sql", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the per-user conversations database. */
 
 { "conversations_expire_days", 90, INT }
@@ -764,7 +764,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    specifies the actual key used for iSchedule DKIM signing within the
    domain. */
 
-{ "duplicate_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip")}
+{ "duplicate_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the duplicate delivery suppression
    and sieve. */
 
@@ -1380,10 +1380,10 @@ Blank lines and lines beginning with ``#'' are ignored.
 { "maxword", 131072, INT }
 /* Maximum size of a single word for the parser.  Default 128k */
 
-{ "mboxkey_db", "twoskip", STRINGLIST("skiplist", "twoskip") }
+{ "mboxkey_db", "twoskip", STRINGLIST("skiplist", "twoskip", "zeroskip") }
 /* The cyrusdb backend to use for mailbox keys. */
 
-{ "mboxlist_db", "twoskip", STRINGLIST("flat", "skiplist", "sql", "twoskip")}
+{ "mboxlist_db", "twoskip", STRINGLIST("flat", "skiplist", "sql", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the mailbox list. */
 
 { "mboxlist_db_path", NULL, STRING }
@@ -1773,7 +1773,7 @@ If all partitions are over that limit, this feature is not used anymore.
 /* Unix domain socket that ptloader listens on.
    (defaults to configdirectory/ptclient/ptsock) */
 
-{ "ptscache_db", "twoskip", STRINGLIST("skiplist", "twoskip")}
+{ "ptscache_db", "twoskip", STRINGLIST("skiplist", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the pts cache. */
 
 { "ptscache_db_path", NULL, STRING }
@@ -1798,7 +1798,7 @@ If all partitions are over that limit, this feature is not used anymore.
 /* This specifies the Class Selector or Differentiated Services Code Point
    designation on IP headers (in the ToS field). */
 
-{ "quota_db", "quotalegacy", STRINGLIST("flat", "skiplist", "sql", "quotalegacy", "twoskip")}
+{ "quota_db", "quotalegacy", STRINGLIST("flat", "skiplist", "sql", "quotalegacy", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for quotas. */
 
 { "quota_db_path", NULL, STRING }
@@ -1959,7 +1959,7 @@ If all partitions are over that limit, this feature is not used anymore.
    headers can still be searched, the searches will just be slower.
  */
 
-{ "search_indexed_db", "twoskip", STRINGLIST("flat", "skiplist", "twoskip")}
+{ "search_indexed_db", "twoskip", STRINGLIST("flat", "skiplist", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the search latest indexed uid state. */
 
 { "search_maxtime", NULL, STRING }
@@ -2011,7 +2011,7 @@ If all partitions are over that limit, this feature is not used anymore.
 .PP
    This option MUST be specified for xapian search. */
 
-{ "seenstate_db", "twoskip", STRINGLIST("flat", "skiplist", "twoskip")}
+{ "seenstate_db", "twoskip", STRINGLIST("flat", "skiplist", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the seen state. */
 
 { "sendmail", "/usr/lib/sendmail", STRING }
@@ -2224,7 +2224,7 @@ product version in the capabilities
    successfully authenticate.  Otherwise lmtpd returns permanent failures
    (causing the mail to bounce immediately). */
 
-{ "sortcache_db", "twoskip", STRINGLIST("skiplist", "twoskip")}
+{ "sortcache_db", "twoskip", STRINGLIST("skiplist", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for caching sort results (currently only
    used for xconvmultisort) */
 
@@ -2285,7 +2285,7 @@ product version in the capabilities
    allowed to fetch the contents of any valid "urlauth=submit+" IMAP URL:
    use with caution. */
 
-{ "subscription_db", "flat", STRINGLIST("flat", "skiplist", "twoskip")}
+{ "subscription_db", "flat", STRINGLIST("flat", "skiplist", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the subscriptions list. */
 
 { "suppress_capabilities", NULL, STRING }
@@ -2298,7 +2298,7 @@ product version in the capabilities
 { "statuscache", 0, SWITCH }
 /* Enable/disable the imap status cache. */
 
-{ "statuscache_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip") }
+{ "statuscache_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip", "zeroskip") }
 /* The cyrusdb backend to use for the imap status cache. */
 
 { "statuscache_db_path", NULL, STRING }
@@ -2431,7 +2431,7 @@ product version in the capabilities
 { "tls_ca_path", NULL, STRING, "2.5.0", "tls_client_ca_dir" }
 /* Deprecated in favor of \fItls_client_ca_dir\fR. */
 
-{ "tlscache_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip"), "2.5.0", "tls_sessions_db" }
+{ "tlscache_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip", "zeroskip"), "2.5.0", "tls_sessions_db" }
 /* Deprecated in favor of \fItls_sessions_db\fR. */
 
 { "tlscache_db_path", NULL, STRING, "2.5.0", "tls_sessions_db_path" }
@@ -2511,7 +2511,7 @@ product version in the capabilities
 /* File containing the private key belonging to the certificate in
    tls_server_cert. */
 
-{ "tls_sessions_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip")}
+{ "tls_sessions_db", "twoskip", STRINGLIST("skiplist", "sql", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the TLS cache. */
 
 { "tls_sessions_db_path", NULL, STRING }
@@ -2538,7 +2538,7 @@ product version in the capabilities
 { "umask", "077", STRING }
 /* The umask value used by various Cyrus IMAP programs. */
 
-{ "userdeny_db", "flat", STRINGLIST("flat", "skiplist", "sql", "twoskip")}
+{ "userdeny_db", "flat", STRINGLIST("flat", "skiplist", "sql", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for the user access list. */
 
 { "userdeny_db_path", NULL, STRING }
@@ -2598,7 +2598,7 @@ product version in the capabilities
    this user.  NOTE: This must be an existing local user name with an
    INBOX, NOT an email address! */
 
-{ "zoneinfo_db", "twoskip", STRINGLIST("flat", "skiplist", "twoskip")}
+{ "zoneinfo_db", "twoskip", STRINGLIST("flat", "skiplist", "twoskip", "zeroskip")}
 /* The cyrusdb backend to use for zoneinfo. */
 
 { "zoneinfo_db_path", NULL, STRING }


### PR DESCRIPTION
This commit adds support for Zeroskip to Cyrus DB. When Cyrus is build with Zeroskip, all the unit tests pass. There are issues with Cassandane, which I'm going to fix soon.