### PR TITLE
Close backup on failure.

### DIFF
--- a/backup/ctl_backups.c
+++ b/backup/ctl_backups.c
@@ -955,6 +955,7 @@ static int lock_run_pipe(const char *userid, const char *fname,
 
     if (r) {
         printf("NO failed (%s)\n", error_message(r));
+        r = backup_close(&backup);
         return EC_SOFTWARE; // FIXME would something else be more appropriate?
     }
 
@@ -993,6 +994,7 @@ static int lock_run_sqlite(const char *userid, const char *fname,
         fprintf(stderr, "unable to lock %s: %s\n",
                 userid ? userid : fname,
                 error_message(r));
+        r = backup_close(backup);
         return EC_SOFTWARE;
     }
 
@@ -1053,6 +1055,7 @@ static int lock_run_exec(const char *userid, const char *fname,
         fprintf(stderr, "unable to lock %s: %s\n",
                 userid ? userid : fname,
                 error_message(r));
+        r = backup_close(backup);
         return EC_SOFTWARE;
     }
 


### PR DESCRIPTION
Static analizers report this as memory leak issue.