### PR TITLE
bring back SETANNOTATION/GETANNOTATION, behind config

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -325,6 +325,7 @@ static struct capa_struct base_capabilities[] = {
     { "THREAD=ORDEREDSUBJECT", 2 },
     { "THREAD=REFERENCES",     2 },
     { "THREAD=REFS",           2 }, /* draft-ietf-morg-inthread */
+    { "ANNOTATEMORE",          2 },
     { "ANNOTATE-EXPERIMENT-1", 2 },
     { "METADATA",              2 },
     { "LIST-EXTENDED",         2 },
@@ -433,7 +434,9 @@ static void cmd_resetkey(char *tag, char *mailbox, char *mechanism);
 static void cmd_compress(char *tag, char *alg);
 #endif
 
+static void cmd_getannotation(const char* tag, char *mboxpat);
 static void cmd_getmetadata(const char* tag);
+static void cmd_setannotation(const char* tag, char *mboxpat);
 static void cmd_setmetadata(const char* tag, char *mboxpat);
 static void cmd_xrunannotator(const char *tag, const char *sequence,
                               int usinguid);
@@ -1539,6 +1542,15 @@ static void cmdloop(void)
                 prometheus_increment(CYRUS_IMAP_GETACL_TOTAL);
                 snmp_increment(GETACL_COUNT, 1);
             }
+            else if (!strcmp(cmd.s, "Getannotation")) {
+                if (c != ' ') goto missingargs;
+                c = getastring(imapd_in, imapd_out, &arg1);
+                if (c != ' ') goto missingargs;
+
+                cmd_getannotation(tag.s, arg1.s);
+
+                snmp_increment(GETANNOTATION_COUNT, 1);
+            }
             else if (!strcmp(cmd.s, "Getmetadata")) {
                 if (c != ' ') goto missingargs;
 
@@ -2008,6 +2020,15 @@ static void cmdloop(void)
 
                 prometheus_increment(CYRUS_IMAP_SETACL_TOTAL);
                 snmp_increment(SETACL_COUNT, 1);
+            }
+            else if (!strcmp(cmd.s, "Setannotation")) {
+                if (c != ' ') goto missingargs;
+                c = getastring(imapd_in, imapd_out, &arg1);
+                if (c != ' ') goto missingargs;
+
+                cmd_setannotation(tag.s, arg1.s);
+
+                snmp_increment(SETANNOTATION_COUNT, 1);
             }
             else if (!strcmp(cmd.s, "Setmetadata")) {
                 if (c != ' ') goto missingargs;
@@ -9490,7 +9511,7 @@ static int parse_metadata_string_or_list(const char *tag,
  *
  * This is a generic routine which parses just the annotation data.
  * Any surrounding command text must be parsed elsewhere, ie,
- * STORE, APPEND.
+ * SETANNOTATION, STORE, APPEND.
  *
  * Also parse RFC5257 per-message annotation store data, which
  * is almost identical but differs in that entry names and attrib
@@ -9617,7 +9638,7 @@ static int parse_annotate_store_data(const char *tag,
  *
  * This is a generic routine which parses just the annotation data.
  * Any surrounding command text must be parsed elsewhere, ie,
- * STORE, APPEND.
+ * SETANNOTATION, STORE, APPEND.
  */
 static int parse_metadata_store_data(const char *tag,
                                      struct entryattlist **entryatts)
@@ -9704,6 +9725,35 @@ static int parse_metadata_store_data(const char *tag,
     if (attvalues) freeattvalues(attvalues);
     if (c != EOF) prot_ungetc(c, imapd_in);
     return EOF;
+}
+
+static void getannotation_response(const char *mboxname,
+                                   uint32_t uid
+                                        __attribute__((unused)),
+                                   const char *entry,
+                                   struct attvaluelist *attvalues,
+                                   void *rock __attribute__((unused)))
+{
+    int sep = '(';
+    struct attvaluelist *l;
+    char *extname = *mboxname ?
+        mboxname_to_external(mboxname, &imapd_namespace, imapd_userid) :
+        xstrdup("");  /* server annotation */
+
+    prot_printf(imapd_out, "* ANNOTATION ");
+    prot_printastring(imapd_out, extname);
+    prot_putc(' ', imapd_out);
+    prot_printstring(imapd_out, entry);
+    prot_putc(' ', imapd_out);
+    for (l = attvalues ; l ; l = l->next) {
+        prot_putc(sep, imapd_out);
+        sep = ' ';
+        prot_printstring(imapd_out, l->attrib);
+        prot_putc(' ',  imapd_out);
+        prot_printmap(imapd_out, l->value.s, l->value.len);
+    }
+    prot_printf(imapd_out, ")\r\n");
+    free(extname);
 }
 
 struct annot_fetch_rock
@@ -9838,6 +9888,69 @@ static int apply_mailbox_array(annotate_state_t *state,
     return r;
 }
 
+
+/*
+ * Perform a GETANNOTATION command
+ *
+ * The command has been parsed up to the entries
+ */
+static void cmd_getannotation(const char *tag, char *mboxpat)
+{
+    int c, r = 0;
+    strarray_t entries = STRARRAY_INITIALIZER;
+    strarray_t attribs = STRARRAY_INITIALIZER;
+    annotate_state_t *astate = NULL;
+
+    c = parse_annotate_fetch_data(tag, /*permessage_flag*/0, &entries, &attribs);
+    if (c == EOF) {
+        eatline(imapd_in, c);
+        goto freeargs;
+    }
+
+    /* check for CRLF */
+    if (c == '\r') c = prot_getc(imapd_in);
+    if (c != '\n') {
+        prot_printf(imapd_out,
+                    "%s BAD Unexpected extra arguments to Getannotation\r\n",
+                    tag);
+        eatline(imapd_in, c);
+        goto freeargs;
+    }
+
+    astate = annotate_state_new();
+    annotate_state_set_auth(astate,
+                            imapd_userisadmin || imapd_userisproxyadmin,
+                            imapd_userid, imapd_authstate);
+    if (!*mboxpat) {
+        r = annotate_state_set_server(astate);
+        if (!r)
+            r = annotate_state_fetch(astate, &entries, &attribs,
+                                     getannotation_response, NULL);
+    }
+    else {
+        struct annot_fetch_rock arock;
+        arock.entries = &entries;
+        arock.attribs = &attribs;
+        arock.callback = getannotation_response;
+        arock.cbrock = NULL;
+        r = apply_mailbox_pattern(astate, mboxpat, annot_fetch_cb, &arock);
+    }
+    /* we didn't write anything */
+    annotate_state_abort(&astate);
+
+    imapd_check(NULL, 0);
+
+    if (r) {
+        prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
+    } else {
+        prot_printf(imapd_out, "%s OK %s\r\n",
+                    tag, error_message(IMAP_OK_COMPLETED));
+    }
+
+ freeargs:
+    strarray_fini(&entries);
+    strarray_fini(&attribs);
+}
 
 static void getmetadata_response(const char *mboxname,
                                  uint32_t uid __attribute__((unused)),
@@ -10163,6 +10276,66 @@ missingargs:
     prot_printf(imapd_out, "%s BAD Missing arguments to Getmetadata\r\n", tag);
     eatline(imapd_in, c);
     goto freeargs;
+}
+
+/*
+ * Perform a SETANNOTATION command
+ *
+ * The command has been parsed up to the entry-att list
+ */
+static void cmd_setannotation(const char *tag, char *mboxpat)
+{
+    int c, r = 0;
+    struct entryattlist *entryatts = NULL;
+    annotate_state_t *astate = NULL;
+
+    c = parse_annotate_store_data(tag, 0, &entryatts);
+    if (c == EOF) {
+        eatline(imapd_in, c);
+        goto freeargs;
+    }
+
+    /* check for CRLF */
+    if (c == '\r') c = prot_getc(imapd_in);
+    if (c != '\n') {
+        prot_printf(imapd_out,
+                    "%s BAD Unexpected extra arguments to Setannotation\r\n",
+                    tag);
+        eatline(imapd_in, c);
+        goto freeargs;
+    }
+
+    astate = annotate_state_new();
+    annotate_state_set_auth(astate, imapd_userisadmin,
+                            imapd_userid, imapd_authstate);
+    if (!r) {
+        if (!*mboxpat) {
+            r = annotate_state_set_server(astate);
+            if (!r)
+                r = annotate_state_store(astate, entryatts);
+        }
+        else {
+            struct annot_store_rock arock;
+            arock.entryatts = entryatts;
+            r = apply_mailbox_pattern(astate, mboxpat, annot_store_cb, &arock);
+        }
+    }
+    if (!r)
+        annotate_state_commit(&astate);
+    else
+        annotate_state_abort(&astate);
+
+    imapd_check(NULL, 0);
+
+    if (r) {
+        prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
+    } else {
+        prot_printf(imapd_out, "%s OK %s\r\n", tag,
+                    error_message(IMAP_OK_COMPLETED));
+    }
+
+  freeargs:
+    if (entryatts) freeentryatts(entryatts);
 }
 
 /*

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1549,6 +1549,7 @@ static void cmdloop(void)
 
                 cmd_getannotation(tag.s, arg1.s);
 
+                prometheus_increment(CYRUS_IMAP_GETANNOTATION_TOTAL);
                 snmp_increment(GETANNOTATION_COUNT, 1);
             }
             else if (!strcmp(cmd.s, "Getmetadata")) {
@@ -2028,6 +2029,7 @@ static void cmdloop(void)
 
                 cmd_setannotation(tag.s, arg1.s);
 
+                prometheus_increment(CYRUS_IMAP_SETANNOTATION_TOTAL);
                 snmp_increment(SETANNOTATION_COUNT, 1);
             }
             else if (!strcmp(cmd.s, "Setmetadata")) {

--- a/imap/promdata.p
+++ b/imap/promdata.p
@@ -38,6 +38,7 @@ metric counter cyrus_imap_expunge_total                 The total number of IMAP
 metric counter cyrus_imap_examine_total                 The total number of IMAP EXAMINEs
 metric counter cyrus_imap_fetch_total                   The total number of IMAP FETCHs
 metric counter cyrus_imap_getacl_total                  The total number of IMAP GETACLs
+metric counter cyrus_imap_getannotation_total           The total number of IMAP SETANNOTATIONs
 metric counter cyrus_imap_getmetadata_total             The total number of IMAP GETMETADATAs
 metric counter cyrus_imap_getquota_total                The total number of IMAP GETQUOTAs
 metric counter cyrus_imap_getquotaroot_total            The total number of IMAP GETQUOTAROOTs
@@ -56,6 +57,7 @@ metric counter cyrus_imap_select_total                  The total number of IMAP
 metric counter cyrus_imap_search_total                  The total number of IMAP SEARCHs
 metric counter cyrus_imap_subscribe_total               The total number of IMAP SUBSCRIBEs
 metric counter cyrus_imap_setacl_total                  The total number of IMAP SETACLs
+metric counter cyrus_imap_setannotation_total           The total number of IMAP SETANNOTATIONs
 metric counter cyrus_imap_setmetadata_total             The total number of IMAP SETMETADATAs
 metric counter cyrus_imap_setquota_total                The total number of IMAP SETQUOTAs
 metric counter cyrus_imap_sort_total                    The total number of IMAP SORTs

--- a/imap/pushstats.snmp
+++ b/imap/pushstats.snmp
@@ -126,6 +126,7 @@ C,SELECT_COUNT,"Number of select", auto
 C,SEARCH_COUNT,"Number of search", auto
 C,SUBSCRIBE_COUNT,"Number of subscribe", auto
 C,SETACL_COUNT,"Number of setacl", auto
+C,SETANNOTATION_COUNT,"Number of setannotation", auto
 C,SETMETADATA_COUNT,"Number of setmetadata", auto
 C,SETQUOTA_COUNT,"Number of setquota", auto
 C,STATUS_COUNT,"Number of status", auto

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -274,6 +274,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    socket.  */
 { "annotation_callout_disable_append", 0, SWITCH }
 /* Disables annotations on append with xrunannotator */
+{ "annotation_enable_legacy_commands", 0, SWITCH }
+/* Whether to enable the legacy GETANNOTATION/SETANNOTATION commands.
+   These commands are deprecated and will be removed in the future,
+   but might be useful in the meantime for supporting old clients that
+   do not implement the RFC5464 IMAP METADATA extension. */
 
 { "aps_topic", NULL, STRING }
 /* Topic for Apple Push Service registration. */


### PR DESCRIPTION
Brings back the ANNOTATEMORE capability and SETANNOTATION and GETANNOTATION commands, hidden behind a new config item `annotate_enable_legacy_commands` (default: off).  This is for #2525.

Requesting code review as Cassandane doesn't exercise these commands directly, so we have no real tests for it, and I dunno how useful it is writing a bunch of brand new tests for a feature we keep trying to get rid of...  

(It looks like maybe Cassandane used to exercise these commands implicitly through calls to cyradm, but cyradm has since been updated to use the METADATA extension.)