### PR TITLE
Close file descriptior in case of error

### DIFF
--- a/backup/lcb.c
+++ b/backup/lcb.c
@@ -182,6 +182,7 @@ HIDDEN int backup_real_open(struct backup **backupp,
         if (r) {
             syslog(LOG_ERR, "IOERROR: (f)stat %s: %m", backup->data_fname);
             r = IMAP_IOERROR;
+            close(fd);
             goto error;
         }
 


### PR DESCRIPTION
Make static code analizers happy.
If stat() failed for some reason it may lead backup fd unclosed.