### PR TITLE
WS: Upgrade header value 'websocket' should ignore case

### DIFF
--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1958,7 +1958,7 @@ static int parse_connection(struct transaction_t *txn)
                             txn->flags.upgrade |= UPGRADE_HTTP2;
                         }
                         else if (ws_enabled() &&
-                                 !strncmp(upgrade[0], WS_TOKEN,
+                                 !strncasecmp(upgrade[0], WS_TOKEN,
                                           strcspn(upgrade[0], " ,"))) {
                             /* Upgrade to WebSockets */
                             txn->flags.conn |= CONN_UPGRADE;


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc6455#section-4.2.1 point 3:

   3.   An |Upgrade| header field containing the value "websocket",
        treated as an ASCII case-insensitive value.