### PR TITLE
Fix "Use of uninitialized..." warnings in installsieve

### DIFF
--- a/tools/fixsearchpath.pl
+++ b/tools/fixsearchpath.pl
@@ -75,8 +75,9 @@ my @dirvars = (
 
 my $boilerplate = << 'EOT'
 ## Boilerplate added by Cyrus fixsearchpath.pl
-my $__cyrus_destdir = '';
+my $__cyrus_destdir;
 BEGIN {
+    $__cyrus_destdir = '';
     if ($0 =~ m/\//) {
         my $d = $0;
 EOT


### PR DESCRIPTION
In this code:

  my $x = '';
  use lib $x . "...";

The assignment of the empty string to $x happens *after* the
`use $x . " ..."`, so you get a warning.

To get around that you have to:

  my $x;
  BEGIN {
    $x = '...';
  }
  use lib $x . "...";