### PR TITLE
Labels via IMAP

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4897,6 +4897,10 @@ badannotation:
 
         case 'M':
             if (config_getswitch(IMAPOPT_CONVERSATIONS)
+                && !strcmp(fetchatt.s, "MAILBOXES")) {
+                fa->fetchitems |= FETCH_MAILBOXES;
+            }
+            else if (config_getswitch(IMAPOPT_CONVERSATIONS)
                 && !strcmp(fetchatt.s, "MAILBOXIDS")) {
                 fa->fetchitems |= FETCH_MAILBOXIDS;
             }
@@ -5109,7 +5113,7 @@ badannotation:
         }
     }
 
-    if (fa->fetchitems & (FETCH_ANNOTATION|FETCH_FOLDER)) {
+    if (fa->fetchitems & (FETCH_ANNOTATION|FETCH_FOLDER|FETCH_MAILBOXES)) {
         fa->namespace = &imapd_namespace;
         fa->userid = imapd_userid;
     }
@@ -5118,7 +5122,7 @@ badannotation:
         fa->authstate = imapd_authstate;
     }
     if (config_getswitch(IMAPOPT_CONVERSATIONS)
-        && (fa->fetchitems & FETCH_MAILBOXIDS)) {
+        && (fa->fetchitems & (FETCH_MAILBOXIDS|FETCH_MAILBOXES))) {
         int r = conversations_open_user(imapd_userid, &fa->convstate);
         if (r) {
             syslog(LOG_WARNING, "error opening conversations for %s: %s",

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5004,6 +5004,13 @@ badannotation:
             else goto badatt;
             break;
 
+        case 'X':
+            if (!strcmp(fetchatt.s, "X-MAILBOXID")) {
+                fa->fetchitems |= FETCH_XMAILBOXID;
+            }
+            else goto badatt;
+            break;
+
         default:
         badatt:
             prot_printf(imapd_out, "%s BAD Invalid %s attribute %s\r\n", tag, cmd, fetchatt.s);
@@ -5105,7 +5112,7 @@ badannotation:
         }
     }
 
-    if (fa->fetchitems & (FETCH_ANNOTATION|FETCH_FOLDER)) {
+    if (fa->fetchitems & (FETCH_ANNOTATION|FETCH_FOLDER|FETCH_XMAILBOXID)) {
         fa->namespace = &imapd_namespace;
         fa->userid = imapd_userid;
     }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5120,6 +5120,15 @@ badannotation:
         fa->isadmin = imapd_userisadmin || imapd_userisproxyadmin;
         fa->authstate = imapd_authstate;
     }
+    if (config_getswitch(IMAPOPT_CONVERSATIONS)
+        && (fa->fetchitems & FETCH_XMAILBOXID)) {
+        int r = conversations_open_user(imapd_userid, &fa->convstate);
+        if (r) {
+            syslog(LOG_WARNING, "error opening conversations for %s: %s",
+                                imapd_userid,
+                                error_message(r));
+        }
+    }
 
     strarray_free(newfields);
     return 0;
@@ -5139,6 +5148,7 @@ static void fetchargs_fini (struct fetchargs *fa)
     strarray_fini(&fa->headers_not);
     strarray_fini(&fa->entries);
     strarray_fini(&fa->attribs);
+    conversations_commit(&fa->convstate);
 
     memset(fa, 0, sizeof(struct fetchargs));
 }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4896,7 +4896,11 @@ badannotation:
             break;
 
         case 'M':
-            if (!strcmp(fetchatt.s, "MODSEQ")) {
+            if (config_getswitch(IMAPOPT_CONVERSATIONS)
+                && !strcmp(fetchatt.s, "MAILBOXIDS")) {
+                fa->fetchitems |= FETCH_MAILBOXIDS;
+            }
+            else if (!strcmp(fetchatt.s, "MODSEQ")) {
                 fa->fetchitems |= FETCH_MODSEQ;
             }
             else goto badatt;
@@ -5004,14 +5008,6 @@ badannotation:
             else goto badatt;
             break;
 
-        case 'X':
-            if (config_getswitch(IMAPOPT_CONVERSATIONS)
-                && !strcmp(fetchatt.s, "X-MAILBOXID")) {
-                fa->fetchitems |= FETCH_XMAILBOXID;
-            }
-            else goto badatt;
-            break;
-
         default:
         badatt:
             prot_printf(imapd_out, "%s BAD Invalid %s attribute %s\r\n", tag, cmd, fetchatt.s);
@@ -5113,7 +5109,7 @@ badannotation:
         }
     }
 
-    if (fa->fetchitems & (FETCH_ANNOTATION|FETCH_FOLDER|FETCH_XMAILBOXID)) {
+    if (fa->fetchitems & (FETCH_ANNOTATION|FETCH_FOLDER)) {
         fa->namespace = &imapd_namespace;
         fa->userid = imapd_userid;
     }
@@ -5122,7 +5118,7 @@ badannotation:
         fa->authstate = imapd_authstate;
     }
     if (config_getswitch(IMAPOPT_CONVERSATIONS)
-        && (fa->fetchitems & FETCH_XMAILBOXID)) {
+        && (fa->fetchitems & FETCH_MAILBOXIDS)) {
         int r = conversations_open_user(imapd_userid, &fa->convstate);
         if (r) {
             syslog(LOG_WARNING, "error opening conversations for %s: %s",

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5005,7 +5005,8 @@ badannotation:
             break;
 
         case 'X':
-            if (!strcmp(fetchatt.s, "X-MAILBOXID")) {
+            if (config_getswitch(IMAPOPT_CONVERSATIONS)
+                && !strcmp(fetchatt.s, "X-MAILBOXID")) {
                 fa->fetchitems |= FETCH_XMAILBOXID;
             }
             else goto badatt;

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -134,7 +134,8 @@ enum {
     FETCH_EMAILID =             (1<<22),
     FETCH_THREADID =            (1<<23),
     FETCH_SAVEDATE =            (1<<24),
-    FETCH_CREATEDMODSEQ =       (1<<25)
+    FETCH_CREATEDMODSEQ =       (1<<25),
+    FETCH_XMAILBOXID =          (1<<26),
 };
 
 enum {

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -105,6 +105,7 @@ struct fetchargs {
     int isadmin;
     struct auth_state *authstate;
     hash_table *cidhash;          /* for XCONVFETCH */
+    struct conversations_state *convstate; /* for FETCH_XMAILBOXID */
 };
 
 /* Bitmasks for fetchitems */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -137,6 +137,9 @@ enum {
     FETCH_SAVEDATE =            (1<<24),
     FETCH_CREATEDMODSEQ =       (1<<25),
     FETCH_MAILBOXIDS =          (1<<26),
+    FETCH_MAILBOXES =           (1<<27),
+
+    /* XXX fetchitems is an int, we're running low on bits */
 };
 
 enum {

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -105,7 +105,7 @@ struct fetchargs {
     int isadmin;
     struct auth_state *authstate;
     hash_table *cidhash;          /* for XCONVFETCH */
-    struct conversations_state *convstate; /* for FETCH_XMAILBOXID */
+    struct conversations_state *convstate; /* for FETCH_MAILBOXIDS */
 };
 
 /* Bitmasks for fetchitems */
@@ -136,7 +136,7 @@ enum {
     FETCH_THREADID =            (1<<23),
     FETCH_SAVEDATE =            (1<<24),
     FETCH_CREATEDMODSEQ =       (1<<25),
-    FETCH_XMAILBOXID =          (1<<26),
+    FETCH_MAILBOXIDS =          (1<<26),
 };
 
 enum {

--- a/imap/index.c
+++ b/imap/index.c
@@ -4192,7 +4192,8 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
                     state->mailbox->i.uidvalidity);
         sepchar = ' ';
     }
-    if ((fetchitems & FETCH_XMAILBOXID)) {
+    if (config_getswitch(IMAPOPT_CONVERSATIONS)
+        && (fetchitems & FETCH_XMAILBOXID)) {
         prot_printf(state->out, "%cX-MAILBOXID (", sepchar);
         r = index_fetchmailboxids(state, msgno, fetchargs);
         r = 0;

--- a/imap/index.c
+++ b/imap/index.c
@@ -3828,7 +3828,6 @@ static int _mailboxid_cb(const conv_guidrec_t *rec, void *rock)
     struct mailbox *mailbox = NULL;
     msgrecord_t *msgrecord = NULL;
     uint32_t system_flags, internal_flags;
-    char *extname = NULL;
     int r = 0;
 
     assert(mbid_rock->state != NULL);
@@ -3864,17 +3863,12 @@ static int _mailboxid_cb(const conv_guidrec_t *rec, void *rock)
         || (internal_flags & FLAG_INTERNAL_EXPUNGED))
         goto done;
 
-    extname = mboxname_to_external(rec->mboxname,
-                                   mbid_rock->fetchargs->namespace,
-                                   mbid_rock->fetchargs->userid);
-
     if (mbid_rock->sep)
         prot_putc(mbid_rock->sep, mbid_rock->state->out);
-    prot_printf(mbid_rock->state->out, "%s", extname);
+    prot_printf(mbid_rock->state->out, "%s", mbentry->uniqueid);
     mbid_rock->sep = ' ';
 
 done:
-    if (extname) free(extname);
     if (msgrecord) msgrecord_unref(&msgrecord);
     if (mailbox) mailbox_close(&mailbox);
     if (mbentry) mboxlist_entry_free(&mbentry);
@@ -3882,7 +3876,7 @@ done:
 }
 
 /*
- * Helper function to send FETCH data for the X-MAILBOXID
+ * Helper function to send FETCH data for the MAILBOXIDS
  * fetch item.
  */
 static int index_fetchmailboxids(struct index_state *state,
@@ -4200,8 +4194,8 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
         sepchar = ' ';
     }
     if (config_getswitch(IMAPOPT_CONVERSATIONS)
-        && (fetchitems & FETCH_XMAILBOXID)) {
-        prot_printf(state->out, "%cX-MAILBOXID (", sepchar);
+        && (fetchitems & FETCH_MAILBOXIDS)) {
+        prot_printf(state->out, "%cMAILBOXIDS (", sepchar);
         r = index_fetchmailboxids(state, msgno, fetchargs);
         r = 0;
         prot_printf(state->out, ")");

--- a/imap/index.c
+++ b/imap/index.c
@@ -3882,25 +3882,19 @@ static int index_fetchmailboxids(struct index_state *state,
                                  uint32_t msgno,
                                  const struct fetchargs *fetchargs)
 {
-    struct conversations_state *cstate = NULL;
     struct mailboxid_rock rock = { state, 0, fetchargs};
     struct index_record record;
     int r;
 
-    /* FIXME nasty, one open/close per message :/ */
-    r = conversations_open_user(state->userid, &cstate);
-    if (r) goto done;
+    if (!fetchargs->convstate) return 0;
 
     r = index_reload_record(state, msgno, &record);
-    if (r) goto done;
+    if (r) return r;
 
-    r = conversations_guid_foreach(cstate,
-                                   message_guid_encode(&record.guid),
-                                   &_mailboxid_cb,
-                                   &rock);
-done:
-    if (cstate) conversations_commit(&cstate);
-    return r;
+    return conversations_guid_foreach(fetchargs->convstate,
+                                      message_guid_encode(&record.guid),
+                                      &_mailboxid_cb,
+                                      &rock);
 }
 
 /*


### PR DESCRIPTION
Implements the first stage (FETCH) of #2547 

```
    C: 5 fetch 1 (X-MAILBOXID)
    S: * 1 FETCH (X-MAILBOXID (INBOX))
    S: 5 OK Completed (0.000 sec)
    C: 6 create INBOX.target
    S: 6 OK [MAILBOXID (b265a82e-9a73-4aa5-873a-8e7a42dcea3b)] Completed
    C: 7 copy 1 INBOX.target
    S: 7 OK [COPYUID 1542073619 1 1] Completed
    C: 8 fetch 1 (X-MAILBOXID)
    S: * 1 FETCH (X-MAILBOXID (INBOX INBOX.target))
    S: 8 OK Completed (0.000 sec)
```

Cassandane tests here: https://github.com/cyrusimap/cassandane/compare/master...elliefm:v31/2547-imap-labels

I'm not wedded to the spelling `X-MAILBOXID` -- in fact, the more I see it, the more I dislike it.  I initially used the `X-` prefix because gmail's similar `X-GM-LABELS` does, but none of our other non-standard FETCH extensions use an `X-` prefix, so it's a bit out of place in a Cyrus context (the IMAP spec only specifies the `X-` prefix for commands, not other words).  Also, in hindsight I think it should be plural, and there's now a certain overlap with the nonstandard `FOLDER` fetch item.

So, I'm thinking to rename it to just `MAILBOXIDS` (which conveniently mirrors jmap lingo too).  Thoughts?

I'd appreciate a close review of the conversations db interactions. It's not clear to me when `conversations_state`s are suitably precached (e.g. in `mailbox->local_cstate`) or not, so I'm not certain whether just going ahead and opening a new state like I'm doing is safe or not.