### PR TITLE
LMTP segmentation fault on mailshare with sieve redirections

### DIFF
--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -414,7 +414,7 @@ static int sieve_redirect(void *ac,
     /* if we have a msgid, we can track our redirects */
     if (m->id) {
         snprintf(buf, sizeof(buf), "%s-%s", m->id, rc->addr);
-        sievedb = make_sieve_db(mbname_userid(sd->mbname));
+        sievedb = make_sieve_db(mbname_recipient(sd->mbname, ((deliver_data_t *) mc)->ns));
 
         dkey.id = buf;
         dkey.to = sievedb;
@@ -735,7 +735,7 @@ static int send_response(void *ac,
     while (waitpid(sm_pid, &sm_stat, 0) < 0);
 
     if (sm_stat == 0) { /* sendmail exit value */
-        sievedb = make_sieve_db(mbname_userid(sdata->mbname));
+        sievedb = make_sieve_db(mbname_recipient(sdata->mbname, ((deliver_data_t *) mc)->ns));
 
         dkey.id = outmsgid;
         dkey.to = sievedb;


### PR DESCRIPTION
Create a mailshare with _email mailshare@domain.tld_ and set sieve script with redirection like:
`if allof ( address :contains ["to", "cc"] "sender") {
        redirect :copy "target@domain.tld";
        stop;
}`

Got a LMTP segmentation fault when receiving mail matching sieve rule:
`Nov 28 12:53:46 cyrus-vm postfix/qmgr[10701]: CDDAD800E1: from=<sender@domain.tld>, size=74989, nrcpt=1 (queue active)
Nov 28 12:53:46 cyrus-vm cyrus/master[11265]: process type:SERVICE name:lmtp path:/usr/lib/cyrus/lmtpd age:9.817s pid:11291 signaled to death by signal 11 (Segmentation fault)
Nov 28 12:53:46 cyrus-vm postfix/lmtp[11344]: CDDAD800E1: to=<+mailshare@domain.tld>, relay=172.16.20.51[172.16.20.51]:24, delay=165587, delays=165587/0.02/0/0.06, dsn=4.4.2, status=deferred (lost connection with 172.16.20.51[172.16.20.51] while sending end of data -- message may be sent more than once)`