### PR TITLE
Fix: sieve runtime error on fileinto for a mailshare

### DIFF
--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -529,7 +529,10 @@ static int sieve_fileinto(void *ac,
     char namebuf[MAX_MAILBOX_BUFFER];
     int ret;
 
-    char *intname = mboxname_from_external(fc->mailbox, sd->ns, mbname_userid(sd->mbname));
+    char *intname = mboxname_from_external(fc->mailbox, sd->ns,
+                                           mbname_recipient(sd->mbname,
+                                                            sd->ns));
+
     strncpy(namebuf, intname, sizeof(namebuf));
     free(intname);
 


### PR DESCRIPTION
Create shared folder: _mailshare@domain.tld_ with subfolder _Sent_.
Put a sieve script on _mailshare@domain.tld_  shared folder with a _fileinto_ instruction like:
`
if allof ( header :is "Subject" "fileinto") {
        fileinto "Shared Folders/mailshare/Sent";
        stop;
}
`

Sending email with subject _fileinto_ to this shared folder using LMTP and get:
`
Dec  5 11:55:18 bluemind-40 cyrus/lmtp[14072]: sieve runtime error for (null) id <e6a78d5b724c21fd4fc8071c1803fa1b@blue-mind.net>: Fileinto (Shared Folders/mailshare/Sent): Mailbox does not exist
`
Mail is delivered into _mailshare@domain.tld_ shared folder instead of its _Sent_ subfolder.