### PR TITLE
remove chdir for do_examine and do_quota

### DIFF
--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -216,11 +216,6 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
     r = mailbox_open_irl(name, &mailbox);
     if (r) return r;
 
-    if (chdir(mailbox_datapath(mailbox, 0)) == -1) {
-        r = IMAP_IOERROR;
-        goto done;
-    }
-
     printf(" Mailbox Header Info:\n");
     printf("  Path to mailbox: %s\n", mailbox_datapath(mailbox, 0));
     printf("  Mailbox ACL: %s\n", mailbox->acl); /* xxx parse */
@@ -352,7 +347,6 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
         printf("Desired message not found\n");
     }
 
- done:
     mailbox_close(&mailbox);
 
     return r;
@@ -383,11 +377,6 @@ static int do_quota(struct findall_data *data, void *rock __attribute__((unused)
     /* Open/lock header */
     r = mailbox_open_irl(name, &mailbox);
     if (r) return r;
-
-    if (chdir(mailbox_datapath(mailbox, 0)) == -1) {
-        r = IMAP_IOERROR;
-        goto done;
-    }
 
     struct mailbox_iter *iter = mailbox_iter_init(mailbox, 0, ITER_SKIP_EXPUNGED);
     const message_t *msg;


### PR DESCRIPTION
Partial Fixes #2606 by removing the chdir from do_examine and do_quota.
The the function do_compare still needs a fix.