### PR TITLE
support clamav-0.101.0 and apply CLAMAV_CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -896,6 +896,7 @@ imap_cyr_userseen_SOURCES = imap/cli_fatal.c imap/cyr_userseen.c imap/mutex_fake
 imap_cyr_userseen_LDADD = $(LD_UTILITY_ADD)
 
 imap_cyr_virusscan_SOURCES = imap/cli_fatal.c imap/cyr_virusscan.c imap/mutex_fake.c
+imap_cyr_virusscan_CFLAGS = $(AM_CFLAGS) $(CLAMAV_CFLAGS) $(CFLAG_VISIBILITY)
 imap_cyr_virusscan_LDADD = $(LD_UTILITY_ADD) $(CLAMAV_LIBS)
 
 imap_deliver_SOURCES = \

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -192,8 +192,17 @@ int clamav_scanfile(void *state, const char *fname,
     int r;
 
     /* scan file */
+#if LIBCLAMAV_MAJORVER < 9
     r = cl_scanfile(fname, virname, NULL, st->av_engine,
                     CL_SCAN_STDOPT);
+#else
+    static struct cl_scan_options options;
+
+    memset(&options, 0, sizeof(struct cl_scan_options));
+    options.parse |= ~0; /* enable all parsers */
+
+    r = cl_scanfile(fname, virname, NULL, st->av_engine, &options);
+#endif
 
     switch (r) {
     case CL_CLEAN:


### PR DESCRIPTION
minor change is required to imap/cyr_virusscan.c to support clamav-0.101.0.

Also pass CLAMAV_CFLAGS when building imap/cyr_viursscan.c

