### PR TITLE
Clamav 0.101 for cyrus imapd 3.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -879,6 +879,7 @@ imap_cyr_sphinxmgr_SOURCES = imap/cli_fatal.c imap/cyr_sphinxmgr.c imap/mutex_fa
 imap_cyr_sphinxmgr_LDADD = $(LD_UTILITY_ADD)
 
 imap_cyr_virusscan_SOURCES = imap/cli_fatal.c imap/cyr_virusscan.c imap/mutex_fake.c
+imap_cyr_virusscan_CFLAGS = $(AM_CFLAGS) $(CLAMAV_CFLAGS) $(CFLAG_VISIBILITY)
 imap_cyr_virusscan_LDADD = $(LD_UTILITY_ADD) $(CLAMAV_LIBS)
 
 imap_ctl_zoneinfo_SOURCES = imap/cli_fatal.c imap/ctl_zoneinfo.c imap/mutex_fake.c imap/zoneinfo_db.c

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -193,8 +193,17 @@ int clamav_scanfile(void *state, const char *fname,
     int r;
 
     /* scan file */
+#if LIBCLAMAV_MAJORVER < 9
     r = cl_scanfile(fname, virname, NULL, st->av_engine,
                     CL_SCAN_STDOPT);
+#else
+    static struct cl_scan_options options;
+
+    memset(&options, 0, sizeof(struct cl_scan_options));
+    options.parse |= ~0; /* enable all parsers */
+
+    r = cl_scanfile(fname, virname, NULL, st->av_engine, &options);
+#endif
 
     switch (r) {
     case CL_CLEAN:


### PR DESCRIPTION
Add support clamav-0.101.0 to cyrus-imapd-3.0 branch, pass CLAMAV_CFLAGS when building