### PR TITLE
Align docs to code

### DIFF
--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1131,7 +1131,9 @@ Blank lines and lines beginning with ``#'' are ignored.
    %u   = user
    %U   = user portion of %u (%U = test when %u = test@domain.tld)
    %d   = domain portion of %u if available (%d = domain.tld when %u =
-          %test@domain.tld), otherwise same as %r
+          test@domain.tld), otherwise same as %R
+   %R   = domain portion of %u starting with @ (%R = @domain.tld
+          when %u = test@domain.tld)
    %D   = user dn.  (use when ldap_member_method: filter)
    %1-9 = domain tokens (%1 = tld, %2 = domain when %d = domain.tld)
 

--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -723,7 +723,7 @@ static int ptsmodule_tokenize_domains(
  *   %%   = %
  *   %u   = user
  *   %U   = user part of %u
- *   %d   = domain part of %u if available, otherwise same as %r
+ *   %d   = domain part of %u if available, otherwise same as %R
  *   %R   = prepend '@' to domain
  *   %1-9 = domain tokens (%1 = tld, %2 = domain when %d = domain.tld)
  *   %D   = user DN


### PR DESCRIPTION
The switch statement uses `%R` for the domain part starting with `@`.
Add the missing `%R` line to *imapoptions*.