### PR TITLE
Return correct group names when groups are resolved by filter

### DIFF
--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -1336,11 +1336,15 @@ static int ptsmodule_make_authstate_filter(
             syslog(LOG_ERR, "No values for attribute '%s' on entry '%s'",
                             ptsm->member_attribute,
                             errdn);
+            *reply = "no values";
+            rc = PTSM_FAIL;
+            ldap_value_free(vals);
+            vals = NULL;
+            goto done;
         } else if (ldap_count_values(vals) > 1) {
             syslog(LOG_ERR, "Too many values for attribute '%s' on entry '%s'",
                             ptsm->member_attribute,
                             errdn);
-        } else {
             *reply = "too many values";
             rc = PTSM_FAIL;
             ldap_value_free(vals);


### PR DESCRIPTION
This fixes an regression, that was introduced with 61f5296c0d727faee4726525a6812b200d946d83.
Back then the logic was changed from `ldap_count_values(vals) != 1` to two `if` clauses
`ldap_count_values(vals) < 1` and `ldap_count_values(vals) > 1`
which logged errors and an else clause (which matched the correct number
of `ldap_count_values(val) == 1`) that got the old error handling code.