### PR TITLE
rely on CL_SCAN_STDOPT instead of LIBCLAMAV_MAJORVER

### DIFF
--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -192,7 +192,7 @@ int clamav_scanfile(void *state, const char *fname,
     int r;
 
     /* scan file */
-#if LIBCLAMAV_MAJORVER < 9
+#ifdef CL_SCAN_STDOPT
     r = cl_scanfile(fname, virname, NULL, st->av_engine,
                     CL_SCAN_STDOPT);
 #else


### PR DESCRIPTION
This PR uses a different approach for 09b5bf11e12185727d53a6ae06d71a767952a537.

As `LIBCLAMAV_MAJORVER` is only set in `clamav-config.h` which is not being installed by `make install` the devel-packages of clamav don't contain that macro. So the majorver switch point doesn't work – at least with RHEL/CentOS/SL using EPEL's clamav or Fedora. Not sure regarding other distributions, though.
IMHO it is quite easier checking for the existence of `CL_SCAN_STDOPT`.