### PR TITLE
imap/annotate.c:annotate_state_writemask: put shared attributes on shared mailboxes

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -2643,7 +2643,7 @@ EXPORTED int annotate_state_writemask(annotate_state_t *state,
                                       const struct buf *value)
 {
     /* if the user is the owner, then write to the shared namespace */
-    if (mboxname_userownsmailbox(userid, state->mailbox->name))
+    if (mboxname_userownsmailbox(userid, state->mailbox->name) || !mboxname_isusermailbox(state->mailbox->name, 1))
         return annotate_state_write(state, entry, "", value);
     else
         return annotate_state_write(state, entry, userid, value);


### PR DESCRIPTION
The mailbox #addressbook/shared does not belong to anybody, but a user with write-privileges to it shall be able to set global properties over WebDAV like CARD:addressbook-description or DAV:displayname.