### PR TITLE
httpd: enable support for no HTTP/2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1446,7 +1446,6 @@ AM_CONDITIONAL([HTTPD], [test "$enable_http" != "no"])
 
 HTTP_CPPFLAGS=
 HTTP_LIBS=
-with_nghttp2=no
 with_xml2=no
 with_ical=no
 with_icu4c=no
@@ -1556,14 +1555,20 @@ dnl                        AC_DEFINE(WITH_DKIM,[],
 dnl                                [Build DKIM support into iSchedule?]),
 dnl                        AC_MSG_WARN([Your version of OpenDKIM can not support iSchedule.  Consider patching OpenDKIM with contrib/dkim_canon_ischedule.patch])),
 dnl                AC_MSG_WARN([Your version of OpenDKIM can not support iSchedule.  Consider upgrading to OpenDKIM >= 2.7.0]))
-
-        PKG_CHECK_MODULES([NGHTTP2], [libnghttp2 >= 1.5], [
-                AC_DEFINE(HAVE_NGHTTP2,[],
-                        [Build HTTP/2 support into httpd?])
-                with_nghttp2=yes
-                ],
-                AC_MSG_NOTICE([httpd will not have support for HTTP/2.  Consider installing libnghttp2 >= 1.5]))
-
+        AC_ARG_WITH(nghttp2, [AS_HELP_STRING([--without-nghttp2], [disable HTTP/2 support (check)])],,[with_nghttp2="check"])
+        if test "x$with_nghttp2" = "xyes" -o "x$with_nghttp2" = "xcheck"; then
+                PKG_CHECK_MODULES([NGHTTP2], [libnghttp2 >= 1.5], [
+                    with_nghttp2=yes
+                    AC_DEFINE(HAVE_NGHTTP2,[],
+                            [Build HTTP/2 support into httpd?])
+                ], [
+                    if test "x$with_nghttp2" = "xyes"; then
+                        AC_MSG_ERROR([HTTP/2 explicitly requested, but libnghttp2 was not found])
+                    fi
+                    with_nghttp2=no
+                    AC_MSG_NOTICE([httpd will not have support for HTTP/2.  Consider installing libnghttp2 >= 1.5])
+                ])
+        fi
 
         PKG_CHECK_MODULES([BROTLI], [libbrotlienc], [
                 AC_DEFINE(HAVE_BROTLI,[],

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1621,10 +1621,14 @@ static int examine_request(struct transaction_t *txn)
     }
     else if (!httpd_tls_done && txn->flags.ver == VER_1_1) {
         /* Advertise available upgrade protocols */
+#ifdef HAVE_NGHTTP2
         txn->flags.conn |= CONN_UPGRADE;
         txn->flags.upgrade = UPGRADE_HTTP2;
-        if (config_mupdate_server && config_getstring(IMAPOPT_PROXYSERVERS))
+#endif
+        if (config_mupdate_server && config_getstring(IMAPOPT_PROXYSERVERS)) {
             txn->flags.upgrade |= UPGRADE_TLS;
+            txn->flags.conn |= CONN_UPGRADE;
+        }
     }
 
     query = URI_QUERY(txn->req_uri);


### PR DESCRIPTION
-- ./configure --disable-http2 disables HTTP/2 even when libnghttp2 is installed
-- when nghttp/2 is not enabled/installed, don't send
      Connection: Upgrade
      Upgrade:
   headers