### PR TITLE
Fix #2129 timsieved sieve_path

### DIFF
--- a/imap/user.h
+++ b/imap/user.h
@@ -46,7 +46,7 @@
 #include "auth.h"
 
 /* path to user's sieve directory */
-const char *user_sieve_path(const char *user);
+char *user_sieve_path(const char *user);
 
 /* Delete meta-data (seen state, subscriptions, ACLs, quotaroots,
  * sieve scripts) for 'user'.

--- a/timsieved/actions.h
+++ b/timsieved/actions.h
@@ -112,13 +112,6 @@ int listscripts(struct protstream *conn);
 int setactive(struct protstream *conn, const struct buf *name);
 
 /*
- * Initialize
- *
- */
-
-int actions_init(void);
-
-/*
  * Set user after sucessful authentication
  *
  */

--- a/timsieved/timsieved.c
+++ b/timsieved/timsieved.c
@@ -280,8 +280,11 @@ EXPORTED int service_main(int argc __attribute__((unused)),
     secprops = mysasl_secprops(0);
     sasl_setprop(sieved_saslconn, SASL_SEC_PROPS, secprops);
 
-    if (actions_init() != TIMSIEVE_OK)
-      fatal("Error initializing actions",-1);
+    if (config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR)) {
+        /* can't use home directories with timsieved */
+        syslog(LOG_ERR, "can't use home directories");
+        fatal("Error initializing actions",-1);
+    }
 
     sieved_tls_required = config_getswitch(IMAPOPT_TLS_REQUIRED);
 


### PR DESCRIPTION
-- imap/autocreate.c: IMAPOPT_SIEVEDIR has default value, so that it cannot be undefined.

Use a single implementation of sieve_find_script() instead of five.