### PR TITLE
GH#2665 imap/http_caldav_sched.c:propcmp() compare in the DATE-TIME properties the absolute value

### DIFF
--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -2119,6 +2119,12 @@ static unsigned propcmp(icalcomponent *oldical, icalcomponent *newical,
 
     if (!oldprop) return (newprop != NULL);
     else if (!newprop) return 1;
+    else if (kind == ICAL_DTSTART_PROPERTY || kind == ICAL_DTEND_PROPERTY || kind == ICAL_DUE_PROPERTY) {
+        //this could handle all DATE-TIME properties, like COMPLETED
+        //convert to UTC and compare, otherwise TZID is ignored
+        return icaltime_compare(icalproperty_get_datetime_with_component(oldprop, oldical),
+                                icalproperty_get_datetime_with_component(newprop, newical)) ? 1 : 0;
+    }
     else if ((kind == ICAL_RDATE_PROPERTY) || (kind == ICAL_EXDATE_PROPERTY)) {
         const char *str;
         uint32_t old_crc = 0, new_crc = 0;


### PR DESCRIPTION
Comparing only the value with icalproperty_get_value_as_string() ignores the TZ information and does not trigger a change, when the timezone changes, the event is uploaded, the relative value remains the same, but the value converted to UTC does change.