### PR TITLE
cyrus.cache: don't cache Topicbox-specific headers

### DIFF
--- a/imap/mailbox_header_cache.gperf
+++ b/imap/mailbox_header_cache.gperf
@@ -95,3 +95,6 @@ struct mailbox_header_cache {
 "authentication-results", BIT32_MAX
 "received-spf", BIT32_MAX
 "archived-at", BIT32_MAX
+"listbox-message-date", BIT32_MAX
+"topicbox-message-uuid", BIT32_MAX
+"topicbox-policy-reasoning", BIT32_MAX


### PR DESCRIPTION
It's likely something needs to be done to generate the gperf magic, but I'm not really set up to do that.