### PR TITLE
imap/http_caldav.c:caldav_put() compare the ORGANIZERs case-insensitive

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -3992,7 +3992,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
         if (prop) nextorg = icalproperty_get_organizer(prop);
         /* if no toplevel organizer, use the one from here */
         if (!organizer && nextorg) organizer = nextorg;
-        if (nextorg && strcmp(organizer, nextorg)) {
+        if (nextorg && strcasecmp(organizer, nextorg)) {
             txn->error.precond = CALDAV_SAME_ORGANIZER;
             ret = HTTP_FORBIDDEN;
             goto done;


### PR DESCRIPTION
PUTting a
```
BEGIN:VCALENDAR
BEGIN:VEVENT
ORGANIZER;CN=A B:mailto:a.b@example.org
END:VEVENT
BEGIN:VEVENT
ORGANIZER:MAILTO:a.b@example.org
END:VEVENT
END:VCALENDAR
```
shall not trigger the CalDAV:same-organizer-in-all-components precondition.

So “mailto:a.b@example.org” and “MAILTO:a.b@example.org” must be compared
with strcasecmp().