### PR TITLE
Makefile.am: make sure the output directory for fig2dev exists

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1992,6 +1992,7 @@ install-binsymlinks:
 SUFFIXES = .fig.png
 
 .fig.png:
+	mkdir -p $(@D)
 	fig2dev -L png $< $@
 
 valgrind:


### PR DESCRIPTION
This is essential for VPATH builds.