### PR TITLE
sieve: add x-cyrus-log capability and log action

### DIFF
--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1518,6 +1518,15 @@ static int sieve_execute_error_handler(const char *msg,
     return SIEVE_OK;
 }
 
+void sieve_log(void *sc, void *mc, const char *text)
+{
+    script_data_t *sd = (script_data_t *) sc;
+    message_data_t *md = ((deliver_data_t *) mc)->m;
+
+    syslog(LOG_INFO, "sieve log: userid=%s messageid=%s text=%s",
+           mbname_userid(sd->mbname), md->id ? md->id : "(null)", text);
+}
+
 sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
 {
     sieve_interp_t *interp = NULL;
@@ -1564,6 +1573,8 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     sieve_register_environment(interp, &getenvironment);
     sieve_register_body(interp, &getbody);
     sieve_register_include(interp, &getinclude);
+
+    sieve_register_logger(interp, &sieve_log); 
 
     res = sieve_register_vacation(interp, &vacation);
     if (res != SIEVE_OK) {

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2140,7 +2140,7 @@ product version in the capabilities
 /* Maximum expiration time (in seconds) for duplicate message tracking
    records. */
 
-{ "sieve_extensions", "fileinto reject vacation vacation-seconds imapflags notify include envelope environment body relational regex subaddress copy date index imap4flags mailbox mboxmetadata servermetadata variables editheader extlists duplicate ihave fcc special-use redirect-dsn redirect-deliverby mailboxid", BITFIELD("fileinto", "reject", "vacation", "vacation-seconds", "imapflags", "notify", "include", "envelope", "environment", "body", "relational", "regex", "subaddress", "copy", "date", "index", "imap4flags", "mailbox", "mboxmetadata", "servermetadata", "variables", "editheader", "extlists", "duplicate", "ihave", "fcc", "special-use", "redirect-dsn", "redirect-deliverby", "mailboxid") }
+{ "sieve_extensions", "fileinto reject vacation vacation-seconds imapflags notify include envelope environment body relational regex subaddress copy date index imap4flags mailbox mboxmetadata servermetadata variables editheader extlists duplicate ihave fcc special-use redirect-dsn redirect-deliverby mailboxid x-cyrus-log", BITFIELD("fileinto", "reject", "vacation", "vacation-seconds", "imapflags", "notify", "include", "envelope", "environment", "body", "relational", "regex", "subaddress", "copy", "date", "index", "imap4flags", "mailbox", "mboxmetadata", "servermetadata", "variables", "editheader", "extlists", "duplicate", "ihave", "fcc", "special-use", "redirect-dsn", "redirect-deliverby", "mailboxid", "x-cyrus-log") }
 /* Space-separated list of Sieve extensions allowed to be used in
    sieve scripts, enforced at submission by timsieved(8).  Any
    previously installed script will be unaffected by this option and

--- a/sieve/bc_emit.c
+++ b/sieve/bc_emit.c
@@ -472,6 +472,7 @@ static int bc_action_emit(int fd, int codep, int stopcodep,
         case B_SET:
         case B_ADDHEADER:
         case B_DELETEHEADER:
+        case B_LOG:
         case B_NULL:
         case B_STOP:
         case B_DISCARD:

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -2329,6 +2329,12 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
             break;
         }
 
+        case B_LOG:
+        {
+            if (i->log) i->log(sc, m, cmd.u.l.text);
+            break;
+        }
+
         case B_ERROR:
             res = SIEVE_RUN_ERROR;
             *errmsg = cmd.u.str;

--- a/sieve/bc_generate.c
+++ b/sieve/bc_generate.c
@@ -1126,6 +1126,16 @@ static int bc_action_generate(int codep, bytecode_info_t *retval,
                 if (codep == -1) return -1;
                 break;
 
+            case LOG:
+                /* LOG
+                   STRING text
+                */
+                retval->data[codep++].u.op = B_LOG;
+                if (!atleast(retval, codep+1)) return -1;
+                retval->data[codep].type = BT_STR;
+                retval->data[codep++].u.str = c->u.l.text;
+                break;
+
             case IF:
             {
                 int jumpVal;

--- a/sieve/bc_parse.c
+++ b/sieve/bc_parse.c
@@ -348,6 +348,11 @@ EXPORTED int bc_action_parse(bytecode_input_t *bc, int pos, int version,
         break;
 
 
+    case B_LOG:
+        pos = bc_string_parse(bc, pos, &cmd->u.l.text);
+        break;
+
+
     case B_ERROR:           /* 34 */
         pos = bc_string_parse(bc, pos, &cmd->u.str);
         break;

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -132,8 +132,9 @@ typedef union
  * version 0x14 scripts implemented Environment (RFC5183)
  * version 0x15 scripts implemented Redirect-DeliverBy, Redirect-DSN (RFC6009)
  * version 0x16 scripts implemented draft-gondwana-sieve-mailboxid-01
+ * version 0x17 scripts implemented x-cyrus-log
  */
-#define BYTECODE_VERSION 0x16
+#define BYTECODE_VERSION 0x17
 #define BYTECODE_MIN_VERSION 0x03 /* minimum supported version */
 #define BYTECODE_MAGIC "CyrSBytecode"
 #define BYTECODE_MAGIC_LEN 12 /* Should be multiple of 4 */
@@ -206,6 +207,8 @@ enum bytecode {
     B_REDIRECT,         /* require copy, list, redirect-dsn */
 
     B_FILEINTO,         /* require mailbox, imap4flags, copy, specialuse, mailboxid */
+
+    B_LOG,              /* require x-cyrus-log */
 };
 
 enum bytecode_comps {

--- a/sieve/interp.c
+++ b/sieve/interp.c
@@ -181,6 +181,9 @@ EXPORTED const strarray_t *sieve_listextensions(sieve_interp_t *i)
 
         if (config_sieve_extensions & IMAP_ENUM_SIEVE_EXTENSIONS_MAILBOXID)
             buf_appendcstr(&buf, " mailboxid");
+
+        if (config_sieve_extensions & IMAP_ENUM_SIEVE_EXTENSIONS_X_CYRUS_LOG)
+            buf_appendcstr(&buf, " x-cyrus-log");
     }
 
     return i->extensions;
@@ -304,6 +307,11 @@ EXPORTED void sieve_register_envelope(sieve_interp_t *interp, sieve_get_envelope
 EXPORTED void sieve_register_include(sieve_interp_t *interp, sieve_get_include *f)
 {
     interp->getinclude = f;
+}
+
+EXPORTED void sieve_register_logger(sieve_interp_t *interp, sieve_logger *f)
+{
+    interp->log = f;
 }
 
 EXPORTED void sieve_register_environment(sieve_interp_t *interp,
@@ -491,6 +499,9 @@ static const struct sieve_capa_t {
     /* Mailboxid - draft-gondwana-sieve-mailboxid */
     { "mailboxid", SIEVE_CAPA_MAILBOXID },
 
+    /* log - x-cyrus-log */
+    { "x-cyrus-log", SIEVE_CAPA_LOG },
+
     { NULL, 0 }
 };
     
@@ -666,6 +677,10 @@ unsigned long long extension_isactive(sieve_interp_t *interp, const char *str)
     case SIEVE_CAPA_MAILBOXID:
         if (!(interp->getmailboxidexists &&
               (config_ext & IMAP_ENUM_SIEVE_EXTENSIONS_MAILBOXID))) capa = 0;
+        break;
+
+    case SIEVE_CAPA_LOG:
+        if (!(config_ext & IMAP_ENUM_SIEVE_EXTENSIONS_X_CYRUS_LOG)) capa = 0;
         break;
 
     default:

--- a/sieve/interp.h
+++ b/sieve/interp.h
@@ -66,6 +66,8 @@ struct sieve_interp {
     sieve_get_specialuseexists *getspecialuseexists;
     sieve_get_metadata *getmetadata;
 
+    sieve_logger *log;
+
     sieve_list_validator *isvalidlist;
     sieve_list_comparator *listcompare;
 
@@ -199,6 +201,9 @@ enum sieve_capa_flag {
 
     /* Mailboxid - draft-gondwana-sieve-mailboxid */
     SIEVE_CAPA_MAILBOXID    = 1LL<<46,
+
+    /* Log - x-cyrus-log */
+    SIEVE_CAPA_LOG          = 1LL<<47
 };
 
 #define SIEVE_CAPA_ALL (SIEVE_CAPA_BASE           \
@@ -248,6 +253,7 @@ enum sieve_capa_flag {
                         | SIEVE_CAPA_SPECIAL_USE  \
                         | SIEVE_CAPA_FCC          \
                         | SIEVE_CAPA_MAILBOXID    \
+                        | SIEVE_CAPA_LOG          \
                         )
 
 #define SIEVE_CAPA_IHAVE_INCOMPAT (SIEVE_CAPA_ENCODED_CHAR | SIEVE_CAPA_VARIABLES)

--- a/sieve/sieve-lex.l
+++ b/sieve/sieve-lex.l
@@ -436,6 +436,9 @@ weekday         [W|w][E|e][E|e][K|k][D|d][A|a][Y|y]
 <INITIAL>mailboxidexists       return MAILBOXIDEXISTS;
 <INITIAL>:mailboxid            return MAILBOXID;
 
+    /* x-cyrus-log */
+<INITIAL>log                   return LOG;
+
 <INITIAL>"/*"([^\*]|\*[^\/])*\*?"*/" ;  /* ignore bracketed comments */
 <INITIAL>#.* ;                /* ignore hash comments */
 <INITIAL>[ \t\n\r] ;          /* ignore whitespace */

--- a/sieve/sieve_interface.h
+++ b/sieve/sieve_interface.h
@@ -84,6 +84,8 @@ typedef int sieve_get_environment(void *script_context,
                                   const char *keyname, char **res);
 typedef int sieve_get_include(void *script_context, const char *script,
                               int isglobal, char *fpath, size_t size);
+typedef void sieve_logger(void *script_context, void *message_context,
+                          const char *text);
 typedef int sieve_list_validator(void *interp_context, const char *list);
 typedef int sieve_list_comparator(const char *text, size_t tlen,
                                   const char *list, strarray_t *match_vars,
@@ -190,6 +192,7 @@ void sieve_register_imapflags(sieve_interp_t *interp, const strarray_t *mark);
 void sieve_register_notify(sieve_interp_t *interp,
                            sieve_callback *f, const strarray_t *methods);
 void sieve_register_include(sieve_interp_t *interp, sieve_get_include *f);
+void sieve_register_logger(sieve_interp_t *interp, sieve_logger *f);
 
 /* add the callbacks for messages. again, undefined if used after
    sieve_script_parse */

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -723,6 +723,11 @@ static void dump2(bytecode_input_t *d, int bc_len)
             break;
 
 
+        case B_LOG:
+            printf("LOG TEXT(%s)", cmd.u.l.text);
+            break;
+
+
         case B_RETURN:
             printf("RETURN");
             break;

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -487,6 +487,11 @@ static int notify(void *ac, void *ic, void *sc __attribute__((unused)),
     return (*force_fail ? SIEVE_FAIL : SIEVE_OK);
 }
 
+void sieve_log(void *sc __attribute__((unused)), void *mc __attribute__((unused)), const char *text)
+{
+    printf("sieve log: text=%s\n", text);
+}
+
 static int mysieve_error(int lineno, const char *msg,
                          void *i __attribute__((unused)),
                          void *s __attribute__((unused)))
@@ -723,6 +728,7 @@ int main(int argc, char *argv[])
     sieve_register_environment(i, getenvironment);
     sieve_register_body(i, getbody);
     sieve_register_include(i, getinclude);
+    sieve_register_logger(i, sieve_log);
 
     res = sieve_register_vacation(i, &vacation);
     if (res != SIEVE_OK) {

--- a/sieve/tree.h
+++ b/sieve/tree.h
@@ -209,6 +209,9 @@ struct Commandlist {
             char *name;
             strarray_t *values;
         } dh;
+        struct { /* it's a log action */
+            char *text;
+        } l;
     } u;
     struct Commandlist *next;
 };

--- a/timsieved/timsieved.c
+++ b/timsieved/timsieved.c
@@ -405,6 +405,7 @@ static int build_sieve_interp(void)
     sieve_register_environment(interp, (sieve_get_environment *) &timsieved_generic_cb);
     sieve_register_body(interp, (sieve_get_body *) &timsieved_generic_cb);
     sieve_register_include(interp, (sieve_get_include *) &timsieved_generic_cb);
+    sieve_register_logger(interp, (sieve_logger *) &timsieved_generic_cb);
 
     res = sieve_register_vacation(interp, &timsieved_vacation_cbs);
     if (res != SIEVE_OK) {


### PR DESCRIPTION
Adds a `x-cyrus-log` capability, which adds a simple `log STRING` action. When encountered, sends the text along with user and message info to the server log.

This script:

```sieve
require "x-cyrus-log";
log "hello";
```

yields:

```
2019-04-13T20:59:36.695849-04:00 fastmail1 slotf1t01/lmtp[1369640]: sieve log: userid=robn@fastmaildev.com messageid=<ad564e7f-24ba-41c3-8968-a8efaae7e18d@www.fastmaildev.com> text=hello
```

I am not committed to naming of either the capability or the action.

There's no rate limiting or other controls, as it wasn't really obvious what any given deployment would want. Obviously there's little value in allowing users to write their own log actions. The value comes from script generators, which can now arrange for additional information to be logged so they can be correlated with rules from a rule builder, for example.

Closes #2281.