### PR TITLE
whitespace_re: take as much "simple" whitespace as possible before recursing

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -727,7 +727,7 @@ EXPORTED void conversation_normalise_subject(struct buf *s)
     int r;
 
     if (!initialised_res) {
-        r = regcomp(&whitespace_re, "([ \t\r\n]|\xC2\xA0)+", REG_EXTENDED);
+        r = regcomp(&whitespace_re, "([ \t\r\n]+|\xC2\xA0)+", REG_EXTENDED);
         assert(r == 0);
         r = regcomp(&relike_token_re, "^[ \t]*[A-Za-z0-9]+(\\[[0-9]+\\])?:", REG_EXTENDED);
         assert(r == 0);


### PR DESCRIPTION
Every alternation adds a couple of stack frames for backtracking, and since we're only taking one space at a time, a long run of spaces can easily blow the stack.

Its still possible to break this by doing a long run of non-breaking spaces, or alternating simple whitespace & nbsp, and there's not an easy way to fix that because you can't include the \xC2\xA0 sequence in a character class. Improvements might include use of `[:space:]` or `\p{Z}` if PCRE's POSIX compat mode supports, or use of things like atomic groups if we were willing to switch to using PCRE proper.

Related: #2729.