### PR TITLE
include unicode/ucnv.h outside of extern C wrapper

### DIFF
--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -4,7 +4,9 @@
 #include <string.h>
 #include <sys/types.h>
 #include <syslog.h>
+#ifdef HAVE_ICU
 #include <unicode/ucnv.h>
+#endif
 
 #include <fstream>
 #include <sstream>

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <syslog.h>
+#include <unicode/ucnv.h>
 
 #include <fstream>
 #include <sstream>


### PR DESCRIPTION
This fixes a compile error, "template with C linkage"

Fixes #2749