### PR TITLE
Fix some spelling errors (Closes: #2753)

### DIFF
--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -620,7 +620,7 @@ static void test_rfc5051(void)
     char *s;
     static const char STR_RFC5051[] = {0xc7, 0x84, 0};
     static const char RES_RFC5051[] = {'D', 'z', 0xcc, 0x8c, 0};
-    int flags = 0; /* super complient */
+    int flags = 0; /* super compliant */
     charset_t cs;
 
     cs = charset_lookupname("utf-8");

--- a/doc/legacy/anoncvs.html
+++ b/doc/legacy/anoncvs.html
@@ -60,7 +60,7 @@
 
     <p>
       Please note that the version in the repository is not the version we are
-      running.  We have a seperate system that resembles version control for
+      running.  We have a separate system that resembles version control for
       releases of software on the Andrew system, and sometimes changes don't
       get propigated back to CVS.
 

--- a/doc/legacy/install-configure.html
+++ b/doc/legacy/install-configure.html
@@ -454,7 +454,7 @@ currently supported by the Cyrus IMAP server when it is compiled with
 OpenSSL.</p>
 
 <p>The alternative, a SSL wrapped connection, involves the client
-connected to a seperate port ("<tt>imaps</tt>") and negotiating a SSL
+connected to a separate port ("<tt>imaps</tt>") and negotiating a SSL
 session before starting the IMAP protocol.  Again, this is supported
 natively by the Cyrus IMAP server when it is compiled with
 OpenSSL.</p>

--- a/doc/legacy/install-upgrade.html
+++ b/doc/legacy/install-upgrade.html
@@ -706,7 +706,7 @@ the configuration document.
 
 <li>cyrus.seen conversion. The cyrus.seen file will be automatically
 upgraded as users read mail.  After some time, you might want to
-delete the cyrus.seen file in each mailbox; it is superceded by the
+delete the cyrus.seen file in each mailbox; it is superseded by the
 user/joe.seen file.
 
 <li>cyrus.index conversion.  The cyrus.index file will be

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_backups.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_backups.rst
@@ -156,7 +156,7 @@ Options that apply only to the **list** sub-command.
 
 .. option:: -t [hours]
 
-    List stale backups only, that is, backups that have recieved no updates
+    List stale backups only, that is, backups that have received no updates
     in *hours*.  If *hours* is unspecified, it defaults to 24.
 
 .. _ctl-backups-lock-options:

--- a/docsrc/imap/reference/manpages/systemcommands/deliver.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/deliver.rst
@@ -41,7 +41,7 @@ Options
 
 .. option:: -d
 
-    Ignored for compatability with **/bin/mail**.
+    Ignored for compatibility with **/bin/mail**.
 
 .. option:: -r  address
 

--- a/docsrc/imap/reference/manpages/systemcommands/fud.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/fud.rst
@@ -28,7 +28,7 @@ that user.
 **fud** |default-conf-text|
 
 **fud** will automatically proxy any and all FUD requests to the
-appropriate backend server if it is runing on a Cyrus Murder frontend
+appropriate backend server if it is running on a Cyrus Murder frontend
 machine.
 
 To set up the FUD daemon, add this to your cyrus.conf:
@@ -118,7 +118,7 @@ Also not really a bug, **fud** requires that the anonymous user has the
 0 is not a standard IMAP ACL bit.
 
 **fud** is an experimental interface meant to provide information to
-build a finger-like service around.  Eventually it should be superceded
+build a finger-like service around.  Eventually it should be superseded
 by a more standards-based protocol.
 
 

--- a/docsrc/imap/reference/manpages/systemcommands/imapd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/imapd.rst
@@ -39,7 +39,7 @@ first line contained in the file to clients upon connect as an ALERT
 message which IMAP-compliant clients are required to display.
 
 This option serves to annoy users mostly.  Unfortunately clients tend to
-connect far more frequently than is apparent, generating a seperate
+connect far more frequently than is apparent, generating a separate
 server ALERT for each connection.  Many clients do not display these
 properly, if they do anything with them at all.
 

--- a/docsrc/imap/reference/manpages/systemcommands/master.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/master.rst
@@ -56,7 +56,7 @@ Options
 
 .. option:: -j  janitor full-sweeps per second
 
-    Sets the amount of times per second the janitor should sweep the
+    Sets the number of times per second the janitor should sweep the
     entire child table.  Leave it at the default of 1 unless you have a
     really high fork rate (and you have not increased the child hash
     table size when you compiled Cyrus from its default of 10000

--- a/docsrc/imap/reference/manpages/systemcommands/nntpd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/nntpd.rst
@@ -29,7 +29,7 @@ connection.
 **nntpd** |default-conf-text|  The optional ``newsprefix`` setting
 specifies a prefix to be prepended to newsgroup names to make the
 corresponding IMAP mailbox names.  The optional ``newspostuser``
-setting specifies the special userid to be used when contructing the
+setting specifies the special userid to be used when constructing the
 *To:* header address for following up to articles when read via IMAP.
 The optional ``newspeer`` setting specifies the fully qualified hostname
 of the upstream news server to which articles are fed.  The optional

--- a/docsrc/imap/reference/manpages/usercommands/installsieve.rst
+++ b/docsrc/imap/reference/manpages/usercommands/installsieve.rst
@@ -34,7 +34,7 @@ Options
 
 .. option:: -v  name
 
-    View script with the given name. The script if retrieved sucessfully
+    View script with the given name. The script if retrieved successfully
     is output to standard output.
 
 .. option:: -l
@@ -51,7 +51,7 @@ Options
 .. option:: -i  file
 
     Install a file onto the server. If a script with the same name
-    already exists on the server it is overwritten. Upon sucessfully
+    already exists on the server it is overwritten. Upon successfully
     putting the script on the server the script is set active. If
     *file* has the extension .script it is chopped when put on the
     server since sieve names may not contain a '.'.

--- a/imap/append.c
+++ b/imap/append.c
@@ -279,7 +279,7 @@ EXPORTED int append_commit(struct appendstate *as)
      * duplicate DB consistency */
     r = mailbox_commit(as->mailbox);
     if (r) {
-        syslog(LOG_ERR, "IOERROR: commiting mailbox append %s: %s",
+        syslog(LOG_ERR, "IOERROR: committing mailbox append %s: %s",
                as->mailbox->name, error_message(r));
         append_abort(as);
         return r;

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -197,7 +197,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
     out_fd = open(sieve_bctmpname, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     if(out_fd < 0) {
         if(errno == EEXIST) {
-            syslog(LOG_WARNING,"autocreate_sieve: File %s already exists. Probaly left over. Ignoring",sieve_bctmpname);
+            syslog(LOG_WARNING,"autocreate_sieve: File %s already exists. Probably left over. Ignoring",sieve_bctmpname);
         } else if (errno == EACCES) {
             syslog(LOG_WARNING,"autocreate_sieve: No access to create file %s. Check permissions",sieve_bctmpname);
             fclose(in_stream);
@@ -270,7 +270,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
         }
 
         if(sieve_emit_bytecode(out_fd, bc) == TIMSIEVE_FAIL) {
-            syslog(LOG_WARNING,"autocreate_sieve: problem emiting sieve script");
+            syslog(LOG_WARNING,"autocreate_sieve: problem emitting sieve script");
             /* removing the copied script and cleaning up memory */
             unlink(sieve_bctmpname);
             sieve_free_bytecode(&bc);

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -1926,7 +1926,7 @@ EXPORTED int conversations_update_record(struct conversations_state *cstate,
 
     /* calculate the changes */
     if (old) {
-        /* decrease any relevent counts */
+        /* decrease any relevant counts */
         if (!(old->system_flags & FLAG_EXPUNGED)) {
             delta_exists--;
             delta_size -= old->size;

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -343,7 +343,7 @@ static int dump_cb(const mbentry_t *mbentry, void *rockp)
         r = mupdate_activate(d->h, mbentry->name, realpart, mbentry->acl);
 
         if (r == MUPDATE_NOCONN) {
-            fprintf(stderr, "permanant failure storing '%s'\n", mbentry->name);
+            fprintf(stderr, "permanent failure storing '%s'\n", mbentry->name);
             r = IMAP_IOERROR;
         } else if (r == MUPDATE_FAIL) {
             fprintf(stderr,

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -143,7 +143,7 @@ static int apns_enabled = 0;
 static const int ultraparanoid = 1; /* should we kick after every operation? */
 unsigned int proxy_cmdcnt;
 
-static int referral_kick = 0; /* kick after next command recieved, for
+static int referral_kick = 0; /* kick after next command received, for
                                  referrals that are likely to change the
                                  mailbox list */
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -3943,7 +3943,7 @@ HIDDEN int mailbox_repack_commit(struct mailbox_repack **repackptr)
 
     xclose(repack->newindex_fd);
 
-    /* NOTE: cache files need commiting before index is renamed */
+    /* NOTE: cache files need committing before index is renamed */
     for (i = 0; i < repack->caches.count; i++) {
         struct mappedfile *cachefile = ptrarray_nth(&repack->caches, i);
         r = mappedfile_commit(cachefile);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -789,7 +789,7 @@ EXPORTED int mboxlist_update(mbentry_t *mbentry, int localonly)
 
     if (r2) {
         syslog(LOG_ERR, "DBERROR: error %s txn in mboxlist_update: %s",
-               r ? "aborting" : "commiting", cyrusdb_strerror(r2));
+               r ? "aborting" : "committing", cyrusdb_strerror(r2));
     }
 
     return r;

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -534,7 +534,7 @@ EXPORTED int mupdate_noop(mupdate_handle *handle, mupdate_callback callback,
 
 #define CHECKNEWLINE(c, ch) do { if ((ch) == '\r') (ch)=prot_getc((c)->conn->in); \
                                  if ((ch) != '\n') { syslog(LOG_ERR, \
-                             "extra arguments recieved, aborting connection");\
+                             "extra arguments received, aborting connection");\
                                  r = MUPDATE_PROTOCOL_ERROR;\
                                  goto done; }} while(0)
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1409,7 +1409,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    When set, the Cyrus NNTP server will add the header(s) specified in
    the \fBnewsaddheaders\fR option to each incoming usenet article.
    The added header(s) will contain email delivery addresses
-   corresponding to each relevent newsgroup.  If not set, no headers
+   corresponding to each relevant newsgroup.  If not set, no headers
    are added to usenet articles. */
 
 { "newsprefix", NULL, STRING }
@@ -1820,7 +1820,7 @@ If all partitions are over that limit, this feature is not used anymore.
 { "search_skipdiacrit", 1, SWITCH }
 /* When searching, should diacriticals be stripped from the search
    terms.  The default is "true", a search for "hav" will match
-   "Håvard".  This is not RFC5051 complient, but it backwards
+   "Håvard".  This is not RFC5051 compliant, but it backwards
    compatible, and may be preferred by some sites. */
 
 { "search_skiphtml", 0, SWITCH }
@@ -2296,7 +2296,7 @@ product version in the capabilities
 
 { "tls_versions", "tls1_0 tls1_1 tls1_2", STRING }
 /* A list of SSL/TLS versions to not disable. Cyrus IMAP SSL/TLS starts
-   with all protocols, and substracts protocols not in this list. Newer
+   with all protocols, and subtracts protocols not in this list. Newer
    versions of SSL/TLS will need to be added here to allow them to get
    disabled. */
 

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -687,7 +687,7 @@ static void config_read_file(const char *filename)
                 ) {
 
                 sprintf(errbuf,
-                        "option '%s' was specified twice in config file (second occurance on line %d)",
+                        "option '%s' was specified twice in config file (second occurrence on line %d)",
                         fullkey, lineno);
                 fatal(errbuf, EC_CONFIG);
 
@@ -831,7 +831,7 @@ static void config_read_file(const char *filename)
             val = hash_insert(key, newval, &confighash);
             if (val != newval) {
                 snprintf(errbuf, sizeof(errbuf),
-                        "option '%s' was specified twice in config file (second occurance on line %d)",
+                        "option '%s' was specified twice in config file (second occurrence on line %d)",
                         fullkey, lineno);
                 fatal(errbuf, EC_CONFIG);
             }

--- a/lib/vparse.c
+++ b/lib/vparse.c
@@ -63,7 +63,7 @@ static int _parse_param_quoted(struct vparse_state *state, int multiparam)
             INC(1);
             return 0;
 
-        /* normal backslash quoting - NOTE, not strictly RFC complient,
+        /* normal backslash quoting - NOTE, not strictly RFC compliant,
          * but I figure anyone who generates one PROBABLY meant to escape
          * the next character because it's so common, and LABEL definitely
          * allows \n, so we have to handle that anyway */

--- a/perl/imap/IMAP.pm
+++ b/perl/imap/IMAP.pm
@@ -219,7 +219,7 @@ sub authenticate {
   $opts{-authz} = "" if (!defined($opts{-authz}));
   $rc = 0;
 
-  # Fetch all relevent capabilities
+  # Fetch all relevant capabilities
   $self->addcallback({-trigger => 'CAPABILITY',
                       -callback => sub {my %a = @_;
                                         map {
@@ -263,7 +263,7 @@ sub authenticate {
 
       $self->_starttls($opts{-tlskey}, $opts{-tlskey}, $opts{-cafile}, $opts{-capath});
 
-      # Refetch all relevent capabilities
+      # Refetch all relevant capabilities
       ($starttls, $logindisabled, $availmechs) = (0, 0, "");
       $self->send(undef, undef, 'CAPABILITY');
       $opts{-mechanism} = $availmechs if ($opts{-mechanism} eq '');
@@ -285,7 +285,7 @@ sub authenticate {
   if (!$rc && $logindisabled) {
     $self->_starttls('', '', $opts{-cafile}, $opts{-capath}) || return undef;
 
-    # Refetch all relevent capabilities
+    # Refetch all relevant capabilities
     ($starttls, $logindisabled, $availmechs) = (0, 0, "");
     $self->send(undef, undef, 'CAPABILITY');
 

--- a/tools/vzic/README
+++ b/tools/vzic/README
@@ -52,7 +52,7 @@ By default it outputs VTIMEZONEs that try to be compatible with Outlook
 VTIMEZONEs, such as RRULEs using BYMONTHDAY, so it has to adjust the RRULEs
 slightly to get Outlook to parse them. Unfortunately this means they are
 slightly wrong. If given the --pure option, vzic outputs the exact data,
-without worrying about compatability.
+without worrying about compatibility.
 
 NOTE: We don't convert all the Olson files. We skip 'backward', 'etcetera',
 'leapseconds', 'pacificnew', 'solar87', 'solar88' and 'solar89', 'factory'

--- a/tools/vzic/vzic-dump.pl
+++ b/tools/vzic/vzic-dump.pl
@@ -67,7 +67,7 @@ if (! -d "$OUTPUT_DIR/RulesPerl") {
 &ReadOlsonFile ("northamerica");
 &ReadOlsonFile ("southamerica");
 
-# These are backwards-compatability and weird stuff.
+# These are backwards-compatibility and weird stuff.
 #&ReadOlsonFile ("backward");
 #&ReadOlsonFile ("etcetera");
 #&ReadOlsonFile ("leapseconds");

--- a/tools/vzic/vzic-output.c
+++ b/tools/vzic/vzic-output.c
@@ -1327,7 +1327,7 @@ output_zone_components                  (FILE           *fp,
     if (VzicPureOutput) {
       output_component_start (start_buffer, vzictime, TRUE, only_one_change);
     } else {
-    /* For Outlook compatability we don't output the RDATE and use the same
+    /* For Outlook compatibility we don't output the RDATE and use the same
        TZOFFSET for TZOFFSETFROM and TZOFFSETTO. */
       vzictime->year         = RDATE_YEAR;
       vzictime->month        = 0;
@@ -1546,7 +1546,7 @@ check_for_rdates                (FILE           *fp,
           is_daylight_start ? "DAYLIGHT" : "");
 #endif
 
-  /* We want to go backwards through the array now, for Outlook compatability.
+  /* We want to go backwards through the array now, for Outlook compatibility.
      (It only looks at the first DTSTART/RDATE.) */
   for (i = idx + 1; i < changes->len; i++) {
     vzictime = &g_array_index (changes, VzicTime, i);
@@ -2078,15 +2078,15 @@ output_rrule                            (char           *rrule_buffer,
        at the moment anyway, so that isn't a big loss). */
     if (!VzicPureOutput) {
       if (day_number < 8) {
-        printf ("WARNING: %s: Outputting BYDAY=1SU instead of BYMONTHDAY=1-7 for Outlook compatability\n", CurrentZoneName);
+        printf ("WARNING: %s: Outputting BYDAY=1SU instead of BYMONTHDAY=1-7 for Outlook compatibility\n", CurrentZoneName);
         sprintf (buffer, "RRULE:FREQ=YEARLY;BYMONTH=%i;BYDAY=1SU",
                  month + 1);
       } else if (day_number < 15) {
-        printf ("WARNING: %s: Outputting BYDAY=2SU instead of BYMONTHDAY=8-14 for Outlook compatability\n", CurrentZoneName);
+        printf ("WARNING: %s: Outputting BYDAY=2SU instead of BYMONTHDAY=8-14 for Outlook compatibility\n", CurrentZoneName);
         sprintf (buffer, "RRULE:FREQ=YEARLY;BYMONTH=%i;BYDAY=2SU",
                  month + 1);
       } else if (day_number < 22) {
-        printf ("WARNING: %s: Outputting BYDAY=3SU instead of BYMONTHDAY=15-21 for Outlook compatability\n", CurrentZoneName);
+        printf ("WARNING: %s: Outputting BYDAY=3SU instead of BYMONTHDAY=15-21 for Outlook compatibility\n", CurrentZoneName);
         sprintf (buffer, "RRULE:FREQ=YEARLY;BYMONTH=%i;BYDAY=3SU",
                  month + 1);
       } else {
@@ -2111,7 +2111,7 @@ output_rrule                            (char           *rrule_buffer,
         exit (1);
       } else {
         /* We do 6 days at the end of this month, and 1 at the start of the
-           next. We can't do this if we want Outlook compatability, as it
+           next. We can't do this if we want Outlook compatibility, as it
            needs BYMONTHDAY, which Outlook doesn't support. */
 /*
         sprintf (buffer,
@@ -2174,14 +2174,14 @@ output_rrule                            (char           *rrule_buffer,
 #endif
 
       if (!VzicPureOutput) {
-        printf ("WARNING: %s: Modifying RRULE (last weekday) for Outlook compatability\n", CurrentZoneName);
+        printf ("WARNING: %s: Modifying RRULE (last weekday) for Outlook compatibility\n", CurrentZoneName);
         sprintf (buffer,
                  "RRULE:FREQ=YEARLY;BYMONTH=%i;BYDAY=-1%s",
                  month + 1, WeekDays[day_weekday]);
         printf ("  Outputting: %s\n", buffer);
       } else {
         /* We do 6 days at the end of this month, and 1 at the start of the
-           next. We can't do this if we want Outlook compatability, as it needs
+           next. We can't do this if we want Outlook compatibility, as it needs
            BYMONTHDAY, which Outlook doesn't support. */
 /*
         day_number = DaysInMonth[month];
@@ -2276,7 +2276,7 @@ output_rrule_2                          (char           *buffer,
              month + 1, WeekDays[day_weekday]);
 
   } else {
-    /* Can't convert to a correct RRULE. If we want Outlook compatability we
+    /* Can't convert to a correct RRULE. If we want Outlook compatibility we
        have to use a slightly incorrect RRULE, so the time change will be 1
        week out every 7 or so years. Alternatively we could possibly move the
        change by an hour or so so we would always be 1 or 2 hours out, but

--- a/tools/vzic/vzic-test.pl
+++ b/tools/vzic/vzic-test.pl
@@ -26,7 +26,7 @@
 
 #
 # This outputs an iCalendar file containing one event in each timezone,
-# as well as all the VTIMEZONEs. We use it for testing compatability with
+# as well as all the VTIMEZONEs. We use it for testing compatibility with
 # other iCalendar apps like Outlook, by trying to import it there.
 #
 # Currently we have 377 timezones (with tzdata2001d).

--- a/tools/vzic/vzic.c
+++ b/tools/vzic/vzic.c
@@ -169,7 +169,7 @@ main                            (int             argc,
   convert_olson_file ("northamerica", zones_hash);
   convert_olson_file ("southamerica", zones_hash);
 
-  /* These are backwards-compatability and weird stuff. */
+  /* These are backwards-compatibility and weird stuff. */
   convert_olson_file ("backward", zones_hash);
   convert_olson_file ("etcetera", zones_hash);
 #if 0


### PR DESCRIPTION
Hello,

this little patch fixes some spelling errors reported by [Lintian](https://lintian.debian.org/) _([Debian](https://debian.org/) QA tool)_. This fixes #2753.