### PR TITLE
imap/message.c: hide message_pruneheader()

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -479,7 +479,7 @@ EXPORTED int message_parse_mapped(const char *msg_base, unsigned long msg_len,
  * listed in headers or (if headers_not is non-empty) those headers
  * not in headers_not.
  */
-EXPORTED void message_pruneheader(char *buf, const strarray_t *headers,
+HIDDEN void message_pruneheader(char *buf, const strarray_t *headers,
                          const strarray_t *headers_not)
 {
     char *p, *colon, *nextheader;


### PR DESCRIPTION
message_pruneheader() is used only within imap/message.c and imap/index.c.  Both files are part of libcyrus_imap.la, so message_pruneheader() is used only within libcyrus_imap and its visibility can be “hidden”.