### PR TITLE
imap/spool.c: less xstrdup() calls

### DIFF
--- a/cassandane/tiny-tests/Sieve/editheader_basic
+++ b/cassandane/tiny-tests/Sieve/editheader_basic
@@ -44,8 +44,8 @@ EOF
 
     $msg1 = $res->{1}->{rfc822};
 
-    $self->assert_matches(qr/^X-Cassandane-Test: prepend1\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: append1\r\nX-Cassandane-Test: append3\r\nX-Cassandane-Test: append5\r\n\r\n/, $msg1);
+    $self->assert_matches(qr/^x-cassandane-test: prepend1\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: append1\r\nx-cassandane-test: append3\r\nx-cassandane-test: append5\r\n\r\n/, $msg1);
 
     $imaptalk->select($target);
     $res = $imaptalk->fetch(1, 'rfc822');

--- a/cassandane/tiny-tests/Sieve/editheader_complex
+++ b/cassandane/tiny-tests/Sieve/editheader_complex
@@ -58,14 +58,14 @@ EOF
 
     $msg1 = $res->{1}->{rfc822};
 
-    $self->assert_matches(qr/^X-Cassandane-Test: =\?UTF-8\?Q\?prepend1=0A=0A\?=\r\nX-Hello: =\?UTF-8\?Q\?World=E2=88=97\?=\r\nReturn-Path: /, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Unique: .*\r\nX-Cassandane-Test: append1\r\nX-Cassandane-Test: append3\r\nX-Cassandane-Test: append5\r\n\r\n/, $msg1);
+    $self->assert_matches(qr/^x-cassandane-test: =\?UTF-8\?Q\?prepend1=0A=0A\?=\r\nx-hello: =\?UTF-8\?Q\?World=E2=88=97\?=\r\nreturn-path: /, $msg1);
+    $self->assert_matches(qr/X-Cassandane-Unique: .*\r\nx-cassandane-test: append1\r\nx-cassandane-test: append3\r\nx-cassandane-test: append5\r\n\r\n/, $msg1);
 
     $imaptalk->select($target);
     $res = $imaptalk->fetch(1, 'rfc822');
 
     $msg1 = $res->{1}->{rfc822};
 
-    $self->assert_matches(qr/^X-Hello: =\?UTF-8\?Q\?World=E2=88=97\?=\r\nReturn-Path: /, $msg1);
+    $self->assert_matches(qr/^x-hello: =\?UTF-8\?Q\?World=E2=88=97\?=\r\nreturn-path: /, $msg1);
     $self->assert_matches(qr/X-Cassandane-Unique: .*\r\n\r\n/, $msg1);
 }

--- a/cassandane/tiny-tests/Sieve/editheader_encoded_address_list
+++ b/cassandane/tiny-tests/Sieve/editheader_encoded_address_list
@@ -38,9 +38,9 @@ EOF
 
     $msg1 = $res->{1}->{rfc822};
 
-    $self->assert_matches(qr/To: =\?UTF-8\?Q\?=22=E2=88=97=22\?= <aaa\@example.com>,\s+"BBB" <bbb\@example.net>,\s+ccc\@example.com\r\n/, $msg1);
-    $self->assert_matches(qr/X-Foo: =\?UTF-8\?Q\?must_encode_star_\(=E2=88=97\)\?=\r\n/, $msg1);
-    $self->assert_matches(qr/X-Bar: don't need to encode this\r\n/, $msg1);
-    $self->assert_matches(qr/X-Blah: =\?UTF-8\?Q\?can_encode_<ddd\@example.com>_in_non-list_=E2=88=97\?=\r\n\r\n/, $msg1);
+    $self->assert_matches(qr/to: =\?UTF-8\?Q\?=22=E2=88=97=22\?= <aaa\@example.com>,\s+"BBB" <bbb\@example.net>,\s+ccc\@example.com\r\n/, $msg1);
+    $self->assert_matches(qr/x-foo: =\?UTF-8\?Q\?must_encode_star_\(=E2=88=97\)\?=\r\n/, $msg1);
+    $self->assert_matches(qr/x-bar: don't need to encode this\r\n/, $msg1);
+    $self->assert_matches(qr/x-blah: =\?UTF-8\?Q\?can_encode_<ddd\@example.com>_in_non-list_=E2=88=97\?=\r\n\r\n/, $msg1);
 
 }

--- a/cassandane/tiny-tests/Sieve/variable_modifiers
+++ b/cassandane/tiny-tests/Sieve/variable_modifiers
@@ -56,19 +56,19 @@ EOF
 
     $msg1 = $res->{1}->{rfc822};
 
-    $self->assert_matches(qr/X-Cassandane-Test: len = "18"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: lower = "jumbled\?letters=\.\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: upper = "JUMBLED\?LETTERS=\.\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: lowerfirst = "juMBlEd\?lETteRS=\.\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: lowerfirst\+upper = "jUMBLED\?LETTERS=\.\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: upperfirst = "JuMBlEd\?lETteRS=\.\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: upperfirst\+lower = "Jumbled\?letters=\.\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: wild = "juMBlEd\\\?lETteRS=\.\\\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: regex = "juMBlEd\\\?lETteRS=\\\.\\\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: url = "juMBlEd%3FlETteRS%3D\.%2A"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: wild\+upper = "JUMBLED\\\?LETTERS=\.\\\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: regex\+upper = "JUMBLED\\\?LETTERS=\\\.\\\*"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: url\+upper = "JUMBLED%3FLETTERS%3D\.%2A"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: regex\+url\+upperfirst\+lower = "Jumbled%5C%3Fletters%3D%5C.%5C%2A"\r\n/, $msg1);
-    $self->assert_matches(qr/X-Cassandane-Test: regex\+url\+upper\+len = "33"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: len = "18"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: lower = "jumbled\?letters=\.\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: upper = "JUMBLED\?LETTERS=\.\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: lowerfirst = "juMBlEd\?lETteRS=\.\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: lowerfirst\+upper = "jUMBLED\?LETTERS=\.\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: upperfirst = "JuMBlEd\?lETteRS=\.\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: upperfirst\+lower = "Jumbled\?letters=\.\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: wild = "juMBlEd\\\?lETteRS=\.\\\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: regex = "juMBlEd\\\?lETteRS=\\\.\\\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: url = "juMBlEd%3FlETteRS%3D\.%2A"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: wild\+upper = "JUMBLED\\\?LETTERS=\.\\\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: regex\+upper = "JUMBLED\\\?LETTERS=\\\.\\\*"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: url\+upper = "JUMBLED%3FLETTERS%3D\.%2A"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: regex\+url\+upperfirst\+lower = "Jumbled%5C%3Fletters%3D%5C.%5C%2A"\r\n/, $msg1);
+    $self->assert_matches(qr/x-cassandane-test: regex\+url\+upper\+len = "33"\r\n/, $msg1);
 }

--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -304,11 +304,12 @@ static void test_comparator(void)
 static int getheader(void *mc, const char *name, const char ***body)
 {
     sieve_test_message_t *msg = (sieve_test_message_t *)mc;
+    char *lcasename = xstrduplcase(name);
 
-    *body = spool_getheader(msg->headers, name);
-    if (!*body)
-        return SIEVE_FAIL;
-    return SIEVE_OK;
+    *body = spool_getheader(msg->headers, lcasename);
+    free(lcasename);
+
+    return *body ? SIEVE_OK : SIEVE_FAIL;
 }
 
 static int getsize(void *mc, int *size)

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -25,6 +25,7 @@
 #define HRECEIVED1  "from mail.quux.com (mail.quux.com [10.0.0.1]) by mail.gmail.com (Software); " FIRST_RX
 #define HRECEIVED2  "from mail.bar.com (mail.bar.com [10.0.0.1]) by mail.quux.com (Software); " SECOND_RX
 #define HRECEIVED3  "from mail.fastmail.fm (mail.fastmail.fm [10.0.0.1]) by mail.bar.com (Software); " THIRD_RX
+#define SPOOL_GETHEADER(cache, header) lcasedheader = xstrduplcase(header); val = spool_getheader(cache, lcasedheader); free(lcasedheader);
 
 static int set_up(void)
 {
@@ -52,31 +53,32 @@ static void test_simple(void)
 {
     hdrcache_t cache;
     const char **val;
+    char *lcasedheader;
 
     cache = spool_new_hdrcache();
     CU_ASSERT_PTR_NOT_NULL(cache);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NULL(val);
 
     spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
@@ -89,37 +91,37 @@ static void test_simple(void)
     spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED2), cache);
     spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED3), cache);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "To");
+    SPOOL_GETHEADER(cache, "To");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HTO);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "Subject");
+    SPOOL_GETHEADER(cache, "Subject");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HSUBJECT);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "message-id");
+    SPOOL_GETHEADER(cache, "message-id");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "received");
+    SPOOL_GETHEADER(cache, "received");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HRECEIVED1);
     CU_ASSERT_STRING_EQUAL(val[1], HRECEIVED2);
@@ -145,6 +147,7 @@ static void test_fill(void)
 
     hdrcache_t cache;
     const char **val;
+    char *lcasedheader;
     int fd;
     char tempfile[32];
     int r;
@@ -173,37 +176,37 @@ static void test_fill(void)
     r = spool_fill_hdrcache(pin, fout, cache, NULL);
     CU_ASSERT_EQUAL(r, 0);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "To");
+    SPOOL_GETHEADER(cache, "To");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HTO);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "Subject");
+    SPOOL_GETHEADER(cache, "Subject");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HSUBJECT);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "message-id");
+    SPOOL_GETHEADER(cache, "message-id");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "received");
+    SPOOL_GETHEADER(cache, "received");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HRECEIVED1);
     CU_ASSERT_STRING_EQUAL(val[1], HRECEIVED2);
@@ -231,6 +234,7 @@ static void test_folded_headers(void)
     int r;
     struct protstream *pin;
     FILE *fout;
+    char *lcasedheader;
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
@@ -254,22 +258,22 @@ static void test_folded_headers(void)
     r = spool_fill_hdrcache(pin, fout, cache, NULL);
     CU_ASSERT_EQUAL(r, 0);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "message-id");
+    SPOOL_GETHEADER(cache, "message-id");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
     CU_ASSERT_PTR_NULL(val[1]);
@@ -304,6 +308,7 @@ static void test_empty_headers(void)
     int r;
     struct protstream *pin;
     FILE *fout;
+    char *lcasedheader;
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
@@ -327,67 +332,67 @@ static void test_empty_headers(void)
     r = spool_fill_hdrcache(pin, fout, cache, NULL);
     CU_ASSERT_EQUAL(r, 0);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "message-id");
+    SPOOL_GETHEADER(cache, "message-id");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty1");
+    SPOOL_GETHEADER(cache, "empty1");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty2");
+    SPOOL_GETHEADER(cache, "empty2");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty3");
+    SPOOL_GETHEADER(cache, "empty3");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty4");
+    SPOOL_GETHEADER(cache, "empty4");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty5");
+    SPOOL_GETHEADER(cache, "empty5");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty6");
+    SPOOL_GETHEADER(cache, "empty6");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty7");
+    SPOOL_GETHEADER(cache, "empty7");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty8");
+    SPOOL_GETHEADER(cache, "empty8");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "empty9");
+    SPOOL_GETHEADER(cache, "empty9");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], "");
     CU_ASSERT_PTR_NULL(val[1]);
@@ -458,6 +463,7 @@ static void test_bz3386(void)
     char body[128];
     char body2[128];    /* use a different buffer Just In Case */
     const char **val;
+    char *lcasedheader;
 
     cache = spool_new_hdrcache();
     CU_ASSERT_PTR_NOT_NULL(cache);
@@ -473,7 +479,7 @@ static void test_bz3386(void)
     for (i = 0 ; i < N ; i++) {
         snprintf(name, sizeof(name), "X-Foo-%d-%c", i, 'A'+(i%26));
         snprintf(body2, sizeof(body2), "value %d %c", i, 'A'+(i%26));
-        val = spool_getheader(cache, name);
+        SPOOL_GETHEADER(cache, name);
         CU_ASSERT_PTR_NOT_NULL(val);
         CU_ASSERT_STRING_EQUAL(val[0], body2);
         CU_ASSERT_PTR_NULL(val[1]);
@@ -492,22 +498,23 @@ static void test_replace(void)
 #define FOOBAR4     "Foo and Drug Administration"
     hdrcache_t cache;
     const char **val;
+    char *lcasedheader;
 
     cache = spool_new_hdrcache();
     CU_ASSERT_PTR_NOT_NULL(cache);
 
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NULL(val);
 
     /* replace a single line */
     spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
     spool_replace_header(xstrdup("From"), xstrdup(HFROM2), cache);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM2);
     CU_ASSERT_PTR_NULL(val[1]);
@@ -516,7 +523,7 @@ static void test_replace(void)
     spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR1), cache);
     spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR2), cache);
     spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR3), cache);
-    val = spool_getheader(cache, "X-FooBar");
+    SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR1);
     CU_ASSERT_STRING_EQUAL(val[1], FOOBAR2);
@@ -524,7 +531,7 @@ static void test_replace(void)
     CU_ASSERT_PTR_NULL(val[3]);
 
     spool_replace_header(xstrdup("X-FooBar"), xstrdup(FOOBAR4), cache);
-    val = spool_getheader(cache, "X-FooBar");
+    SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR4);
     CU_ASSERT_PTR_NULL(val[1]);

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -67,7 +67,7 @@ static void test_simple(void)
     SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NULL(val);
 
-    spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
+    spool_cache_header("from", xstrdup(HFROM), cache);
     SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
     SPOOL_GETHEADER(cache, "From");
@@ -83,13 +83,13 @@ static void test_simple(void)
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    spool_cache_header(xstrdup("To"), xstrdup(HTO), cache);
-    spool_cache_header(xstrdup("Date"), xstrdup(HDATE), cache);
-    spool_cache_header(xstrdup("Subject"), xstrdup(HSUBJECT), cache);
-    spool_cache_header(xstrdup("Message-ID"), xstrdup(HMESSAGEID), cache);
-    spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED1), cache);
-    spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED2), cache);
-    spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED3), cache);
+    spool_cache_header("to", xstrdup(HTO), cache);
+    spool_cache_header("date", xstrdup(HDATE), cache);
+    spool_cache_header("subject", xstrdup(HSUBJECT), cache);
+    spool_cache_header("message-id", xstrdup(HMESSAGEID), cache);
+    spool_cache_header("received", xstrdup(HRECEIVED1), cache);
+    spool_cache_header("received", xstrdup(HRECEIVED2), cache);
+    spool_cache_header("received", xstrdup(HRECEIVED3), cache);
 
     SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
@@ -471,7 +471,9 @@ static void test_bz3386(void)
     for (i = 0 ; i < N ; i++) {
         snprintf(name, sizeof(name), "X-Foo-%d-%c", i, 'A'+(i%26));
         snprintf(body, sizeof(body), "value %d %c", i, 'A'+(i%26));
-        spool_cache_header(xstrdup(name), xstrdup(body), cache);
+        char *temp = xstrduplcase(name);
+        spool_cache_header(temp, xstrdup(body), cache);
+        free (temp);
     }
 
     strcpy(body, "Old Buffer");
@@ -507,7 +509,7 @@ static void test_replace(void)
     CU_ASSERT_PTR_NULL(val);
 
     /* replace a single line */
-    spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
+    spool_cache_header("from", xstrdup(HFROM), cache);
     SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
@@ -520,9 +522,9 @@ static void test_replace(void)
     CU_ASSERT_PTR_NULL(val[1]);
 
     /* replace multiple lines with one */
-    spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR1), cache);
-    spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR2), cache);
-    spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR3), cache);
+    spool_cache_header("x-foobar", xstrdup(FOOBAR1), cache);
+    spool_cache_header("x-foobar", xstrdup(FOOBAR2), cache);
+    spool_cache_header("x-foobar", xstrdup(FOOBAR3), cache);
     SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR1);

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -515,7 +515,7 @@ static void test_replace(void)
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    spool_replace_header(xstrdup("From"), xstrdup(HFROM2), cache);
+    spool_replace_header("from", xstrdup(HFROM2), cache);
     SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM2);
@@ -532,7 +532,7 @@ static void test_replace(void)
     CU_ASSERT_STRING_EQUAL(val[2], FOOBAR3);
     CU_ASSERT_PTR_NULL(val[3]);
 
-    spool_replace_header(xstrdup("X-FooBar"), xstrdup(FOOBAR4), cache);
+    spool_replace_header("x-foobar", xstrdup(FOOBAR4), cache);
     SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR4);

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -4519,8 +4519,7 @@ static void init_annotation_definitions(void)
         /* we implement case-insensitivity by lcase-and-compare, so make
          * sure the source is lcase'd!
          */
-        ae->freeme = xstrdup(p);
-        lcase(ae->freeme);
+        ae->freeme = xstrduplcase(p);
         ae->name = ae->freeme;
 
         if (!(p = get_token(&state, ".-_/"))) goto bad;

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -280,7 +280,7 @@ static int extractor_httpreq(struct extractor_ctx *ext,
         // Reconnect if the connection expired
         else if (r == HTTP_TIMEOUT &&
                 (res_hdrs &&
-                 (hdr = spool_getheader(res_hdrs, "Connection")) &&
+                 (hdr = spool_getheader(res_hdrs, "connection")) &&
                  !strcasecmpsafe(hdr[0], "close") &&
                  time(NULL) < be->in->timeout_mark)) {
             xsyslog(LOG_DEBUG,
@@ -308,7 +308,7 @@ static int extractor_httpreq(struct extractor_ctx *ext,
                 /* Abide by server's timeout, if any */
                 const char *p;
                 if (res_hdrs &&
-                        (hdr = spool_getheader(res_hdrs, "Keep-Alive")) &&
+                        (hdr = spool_getheader(res_hdrs, "keep-alive")) &&
                         (p = strstr(hdr[0], "timeout="))) {
                     int timeout = atoi(p+8);
                     if (be->timeout) be->timeout->mark = time(NULL) + timeout;

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1174,7 +1174,7 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
             buf_printf(&txn->buf, "<%s>", organizer);
             mimehdr = charset_encode_mimeheader(buf_cstring(&txn->buf),
                                                 buf_len(&txn->buf), 0);
-            spool_replace_header(xstrdup("From"), mimehdr, txn->req_hdrs);
+            spool_replace_header("from", mimehdr, txn->req_hdrs);
             buf_reset(&txn->buf);
         }
     }
@@ -1189,16 +1189,16 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
         char *end = mimehdr + strlen(mimehdr) - 1;
         while (end >= mimehdr && isspace(*end)) *end-- = '\0';
 
-        spool_replace_header(xstrdup("Subject"), mimehdr, txn->req_hdrs);
+        spool_replace_header("subject", mimehdr, txn->req_hdrs);
     }
-    else spool_replace_header(xstrdup("Subject"),
+    else spool_replace_header("subject",
                             xstrdup(icalcomponent_kind_to_string(kind)),
                             txn->req_hdrs);
 
     if (strarray_size(schedule_addresses)) {
         char *value = strarray_join(schedule_addresses, ",");
         mimehdr = charset_encode_mimeheader(value, 0, 0);
-        spool_replace_header(xstrdup("X-Schedule-User-Address"),
+        spool_replace_header("x-schedule-user-address",
                              mimehdr, txn->req_hdrs);
         free(value);
     }
@@ -1206,14 +1206,14 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
     time_to_rfc5322(icaltime_as_timet_with_zone(icalcomponent_get_dtstamp(comp),
                                                utc_zone),
                    datestr, sizeof(datestr));
-    spool_replace_header(xstrdup("Date"), xstrdup(datestr), txn->req_hdrs);
+    spool_replace_header("date", xstrdup(datestr), txn->req_hdrs);
 
     /* Use SHA1(uid)@servername as Message-ID */
     struct message_guid uuid;
     message_guid_generate(&uuid, uid, strlen(uid));
     buf_printf(&txn->buf, "<%s@%s>",
                message_guid_encode(&uuid), config_servername);
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_setcstr(&txn->buf, ICALENDAR_CONTENT_TYPE);
@@ -1222,7 +1222,7 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
                    icalproperty_method_to_string(meth));
     }
     buf_printf(&txn->buf, "; component=%s", icalcomponent_kind_to_string(kind));
-    spool_replace_header(xstrdup("Content-Type"),
+    spool_replace_header("content-type",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     /* Since we use the iCalendar UID in the resource name,
@@ -1238,10 +1238,10 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
     if (cdata->comp_flags.shared) {
         buf_printf(&txn->buf, ";\r\n\tper-user-data=true");
     }
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
-    spool_remove_header(xstrdup("Content-Description"), txn->req_hdrs);
+    spool_remove_header("content-description", txn->req_hdrs);
 
     /* Store the resource */
     ret = dav_store_resource(txn, icalcomponent_as_ical_string(store_ical), 0,

--- a/imap/dav_util.c
+++ b/imap/dav_util.c
@@ -133,11 +133,11 @@ EXPORTED int dav_store_resource(struct transaction_t *txn,
     }
 
     /* Create RFC 5322 header for resource */
-    if ((hdr = spool_getheader(hdrcache, "User-Agent"))) {
+    if ((hdr = spool_getheader(hdrcache, "user-agent"))) {
         fprintf(f, "User-Agent: %s\r\n", hdr[0]);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "From"))) {
+    if ((hdr = spool_getheader(hdrcache, "from"))) {
         fprintf(f, "From: %s\r\n", hdr[0]);
     }
     else {
@@ -159,11 +159,11 @@ EXPORTED int dav_store_resource(struct transaction_t *txn,
         buf_reset(&txn->buf);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Subject"))) {
+    if ((hdr = spool_getheader(hdrcache, "subject"))) {
         fprintf(f, "Subject: %s\r\n", hdr[0]);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Date"))) {
+    if ((hdr = spool_getheader(hdrcache, "date"))) {
         fprintf(f, "Date: %s\r\n", hdr[0]);
     }
     else {
@@ -172,15 +172,15 @@ EXPORTED int dav_store_resource(struct transaction_t *txn,
         fprintf(f, "Date: %s\r\n", datestr);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Message-ID"))) {
+    if ((hdr = spool_getheader(hdrcache, "message-id"))) {
         fprintf(f, "Message-ID: %s\r\n", hdr[0]);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "X-Schedule-User-Address"))) {
+    if ((hdr = spool_getheader(hdrcache, "x-schedule-user-address"))) {
         fprintf(f, "X-Schedule-User-Address: %s\r\n", hdr[0]);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Content-Type"))) {
+    if ((hdr = spool_getheader(hdrcache, "content-type"))) {
         fprintf(f, "Content-Type: %s\r\n", hdr[0]);
     }
     else fputs("Content-Type: application/octet-stream\r\n", f);
@@ -194,11 +194,11 @@ EXPORTED int dav_store_resource(struct transaction_t *txn,
     }
     fprintf(f, "Content-Transfer-Encoding: %s\r\n", cte);
 
-    if ((hdr = spool_getheader(hdrcache, "Content-Disposition"))) {
+    if ((hdr = spool_getheader(hdrcache, "content-disposition"))) {
         fprintf(f, "Content-Disposition: %s\r\n", hdr[0]);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Content-Description"))) {
+    if ((hdr = spool_getheader(hdrcache, "content-description"))) {
         fprintf(f, "Content-Description: %s\r\n", hdr[0]);
     }
 

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -186,7 +186,7 @@ done:
 static int meth_post_applepush(struct transaction_t *txn, void *params)
 {
     /* Check Content-Type */
-    const char **hdr = spool_getheader(txn->req_hdrs, "Content-Type");
+    const char **hdr = spool_getheader(txn->req_hdrs, "content-type");
 
     if (hdr && is_mediatype("application/x-www-form-urlencoded", hdr[0])) {
         /* Read body */

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1101,7 +1101,7 @@ static int caldav_check_precond(struct transaction_t *txn,
     if (!(precond == HTTP_OK || precond == HTTP_PARTIAL)) return precond;
 
     /* Per RFC 6638, check Schedule-Tag */
-    if ((hdr = spool_getheader(txn->req_hdrs, "If-Schedule-Tag-Match"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "if-schedule-tag-match"))) {
         /* Special case for Apple 'If-Schedule-Tag-Match:' with no value
          * and also no schedule tag on the record - let that match */
         if (cdata && !stag && !hdr[0][0]) return precond;
@@ -1214,7 +1214,7 @@ static int _scheduling_enabled(struct transaction_t *txn,
     if (!strcasecmp(buf_cstring(&buf), "F"))
         is_enabled = 0;
 
-    const char **hdr = spool_getheader(txn->req_hdrs, "Scheduling-Enabled");
+    const char **hdr = spool_getheader(txn->req_hdrs, "scheduling-enabled");
     if (hdr && !strcasecmp(hdr[0], "F"))
         is_enabled = 0;
 
@@ -1537,7 +1537,7 @@ static int caldav_delete_cal(struct transaction_t *txn,
                 sched_request(cal_ownerid, sched_userid, &schedule_addresses,
                               cdata->organizer, ical, NULL, SCHED_MECH_CALDAV);
         }
-        else if (!(hdr = spool_getheader(txn->req_hdrs, "Schedule-Reply")) ||
+        else if (!(hdr = spool_getheader(txn->req_hdrs, "schedule-reply")) ||
                  strcasecmp(hdr[0], "F")) {
             /* Attendee scheduling object resource */
             if (_scheduling_enabled(txn, mailbox) && strarray_size(&schedule_addresses) && !is_draft)
@@ -1661,7 +1661,7 @@ static int export_calendar(struct transaction_t *txn)
 
     /* Check requested MIME type:
        1st entry in caldav_mime_types array MUST be default MIME type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+    if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
         mime = get_accept_type(hdr, caldav_mime_types);
     else mime = caldav_mime_types;
     if (!mime) return HTTP_NOT_ACCEPTABLE;
@@ -1727,7 +1727,7 @@ static int export_calendar(struct transaction_t *txn)
         /* Enhanced GET request */
         need_tz = 0;
 
-        if ((hdr = spool_getheader(txn->req_hdrs, "If-None-Match"))) {
+        if ((hdr = spool_getheader(txn->req_hdrs, "if-none-match"))) {
             /* Report only changed resources since ETag (sync-token) */
             uint32_t uidvalidity;
             char dquote[2];
@@ -1760,7 +1760,7 @@ static int export_calendar(struct transaction_t *txn)
             }
 
             /* Check for optional CalDAV-Timezones header */
-            hdr = spool_getheader(txn->req_hdrs, "CalDAV-Timezones");
+            hdr = spool_getheader(txn->req_hdrs, "caldav-timezones");
             if (hdr && !strcmp(hdr[0], "T")) need_tz = 1;
         }
     }
@@ -2489,7 +2489,7 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
         icalcomponent *ical = NULL;
 
         /* Check for optional CalDAV-Timezones header */
-        hdr = spool_getheader(txn->req_hdrs, "CalDAV-Timezones");
+        hdr = spool_getheader(txn->req_hdrs, "caldav-timezones");
         if (hdr && !strcmp(hdr[0], "T")) need_tz = 1;
 
         if (cdata->comp_flags.tzbyref) {
@@ -2758,7 +2758,7 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
     if ((return_rep = (get_preferences(txn) & PREFER_REP))) {
         /* Check requested MIME type:
            1st entry in gparams->mime_types array MUST be default MIME type */
-        if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+        if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
             mime = get_accept_type(hdr, caldav_mime_types);
         else mime = caldav_mime_types;
         if (!mime) return HTTP_NOT_ACCEPTABLE;
@@ -2977,7 +2977,7 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
         }
         buf_reset(&txn->buf);
 
-        if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
+        if ((hdr = spool_getheader(txn->req_hdrs, "content-type"))) {
             param = icalproperty_get_first_parameter(aprop,
                                                      ICAL_FMTTYPE_PARAMETER);
             if (param) icalparameter_set_fmttype(param, *hdr);
@@ -3132,7 +3132,7 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
                 sched_request(cal_ownerid, sched_userid, &schedule_addresses,
                               cdata->organizer, oldical, ical, SCHED_MECH_CALDAV);
         }
-        else if (!(hdr = spool_getheader(txn->req_hdrs, "Schedule-Reply")) ||
+        else if (!(hdr = spool_getheader(txn->req_hdrs, "schedule-reply")) ||
                  strcasecmp(hdr[0], "F")) {
             /* Attendee scheduling object resource */
             if (_scheduling_enabled(txn, calendar) && strarray_size(&schedule_addresses))
@@ -3217,7 +3217,7 @@ static int caldav_post_outbox(struct transaction_t *txn, int rights)
     strarray_t schedule_addresses = STRARRAY_INITIALIZER;
 
     /* Check Content-Type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-type"))) {
         for (mime = caldav_mime_types; mime->content_type; mime++) {
             if (is_mediatype(mime->content_type, hdr[0])) break;
         }
@@ -4034,7 +4034,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
 
     // Rewrite managed attachments in iTIP message
     if ((icalcomponent_get_method(ical) != ICAL_METHOD_NONE) ||
-            spool_getheader(txn->req_hdrs, "Schedule-Sender-Address")) {
+            spool_getheader(txn->req_hdrs, "schedule-sender-address")) {
         caldav_rewrite_attachments(txn->req_tgt.userid,
                 caldav_attachments_to_url, oldical, ical, &myoldical, &myical);
         if (myoldical) {
@@ -4062,7 +4062,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
             if (!strncasecmp(organizer, "mailto:", 7)) organizer += 7;
 
             if (cdata->organizer &&
-                !spool_getheader(txn->req_hdrs, "Allow-Organizer-Change")) {
+                !spool_getheader(txn->req_hdrs, "allow-organizer-change")) {
                 /* Don't allow ORGANIZER to be changed */
                 if (strcmp(cdata->organizer, organizer)) {
                     txn->error.desc = "Can not change organizer address";
@@ -4150,7 +4150,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
     }
 
     /* Set SENT-BY property */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Schedule-Sender-Address"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "schedule-sender-address"))) {
         const char *sentby = *hdr;
         if (!strncasecmp(sentby, "mailto:", 7)) {
             sentby += 7;
@@ -4186,7 +4186,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
             remove_etag = 1;
 
             int rewrite_usedefaultalerts = 1;
-            if ((hdr = spool_getheader(txn->req_hdrs, "X-Cyrus-rewrite-usedefaultalerts"))) {
+            if ((hdr = spool_getheader(txn->req_hdrs, "x-cyrus-rewrite-usedefaultalerts"))) {
                 rewrite_usedefaultalerts = strcasecmpsafe("f", *hdr) &&
                                            strcasecmpsafe("false", *hdr);
             }
@@ -5502,7 +5502,7 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
 
         /* Check for optional CalDAV-Timezones header */
         const char **hdr =
-            spool_getheader(fctx->txn->req_hdrs, "CalDAV-Timezones");
+            spool_getheader(fctx->txn->req_hdrs, "caldav-timezones");
         if (hdr && !strcmp(hdr[0], "T")) need_tz = 1;
         else need_tz = 0;
 
@@ -7857,7 +7857,7 @@ static int report_fb_query(struct transaction_t *txn,
 
     /* Check requested MIME type:
        1st entry in caldav_mime_types array MUST be default MIME type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+    if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
         mime = get_accept_type(hdr, caldav_mime_types);
     else mime = caldav_mime_types;
     if (!mime) return HTTP_NOT_ACCEPTABLE;

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -3000,7 +3000,7 @@ void caldav_get_schedule_addresses(hdrcache_t req_hdrs, const char *mboxname,
 {
     /* allow override of schedule-address per-message (FM specific) */
     const char **hdr = req_hdrs ?
-        spool_getheader(req_hdrs, "Schedule-Address") : NULL;
+        spool_getheader(req_hdrs, "schedule-address") : NULL;
 
     if (hdr) {
         if (!strncasecmp(hdr[0], "mailto:", 7))

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -686,7 +686,7 @@ static int carddav_store_resource(struct transaction_t *txn,
 
     /* Create and cache RFC 5322 header fields for resource */
     mimehdr = charset_encode_mimeheader(fullname, 0, 0);
-    spool_replace_header(xstrdup("Subject"), mimehdr, txn->req_hdrs);
+    spool_replace_header("subject", mimehdr, txn->req_hdrs);
 
     /* Use SHA1(uid)@servername as Message-ID */
     struct message_guid uuid;
@@ -694,12 +694,12 @@ static int carddav_store_resource(struct transaction_t *txn,
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, "<%s@%s>",
                message_guid_encode(&uuid), config_servername);
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, "text/vcard; version=%s; charset=utf-8", version);
-    spool_replace_header(xstrdup("Content-Type"),
+    spool_replace_header("content-type",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_setcstr(&txn->buf, "attachment");
@@ -707,10 +707,10 @@ static int carddav_store_resource(struct transaction_t *txn,
                               CHARSET_PARAM_XENCODE | CHARSET_PARAM_NEWLINE,
                               "filename",
                               resource);
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
-    spool_remove_header(xstrdup("Content-Description"), txn->req_hdrs);
+    spool_remove_header("content-description", txn->req_hdrs);
 
     /* Store the resource */
     r = dav_store_resource(txn, buf_cstring(buf), 0,
@@ -809,7 +809,7 @@ static int carddav_store_resource(struct transaction_t *txn,
 
     /* Create and cache RFC 5322 header fields for resource */
     mimehdr = charset_encode_mimeheader(fullname, 0, 0);
-    spool_replace_header(xstrdup("Subject"), mimehdr, txn->req_hdrs);
+    spool_replace_header("subject", mimehdr, txn->req_hdrs);
 
     /* Use SHA1(uid)@servername as Message-ID */
     struct message_guid uuid;
@@ -817,12 +817,12 @@ static int carddav_store_resource(struct transaction_t *txn,
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, "<%s@%s>",
                message_guid_encode(&uuid), config_servername);
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, "text/vcard; version=%s; charset=utf-8", version);
-    spool_replace_header(xstrdup("Content-Type"),
+    spool_replace_header("content-type",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_setcstr(&txn->buf, "attachment");
@@ -830,10 +830,10 @@ static int carddav_store_resource(struct transaction_t *txn,
                               CHARSET_PARAM_XENCODE | CHARSET_PARAM_NEWLINE,
                               "filename",
                               resource);
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
-    spool_remove_header(xstrdup("Content-Description"), txn->req_hdrs);
+    spool_remove_header("content-description", txn->req_hdrs);
 
     /* Store the resource */
     int r = dav_store_resource(txn, buf_cstring(buf), 0,

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1401,7 +1401,7 @@ static int carddav_put(struct transaction_t *txn, void *obj,
     int error_count = 0;
 
     /* Sanity check Content-Type */
-    const char **hdr = spool_getheader(txn->req_hdrs, "Content-Type");
+    const char **hdr = spool_getheader(txn->req_hdrs, "content-type");
     if (hdr && hdr[0]) {
         const char *profile = NULL;
         struct param *param;
@@ -1789,7 +1789,7 @@ static int carddav_put(struct transaction_t *txn, void *obj,
     const char *want_ver = NULL;
 
     /* Sanity check Content-Type */
-    const char **hdr = spool_getheader(txn->req_hdrs, "Content-Type");
+    const char **hdr = spool_getheader(txn->req_hdrs, "content-type");
     if (hdr && hdr[0]) {
         const char *profile = NULL;
         struct param *param;

--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -207,10 +207,10 @@ static int meth_get(struct transaction_t *txn,
 
     /* Construct environment for script */
     buf_setcstr(&txn->buf, "GATEWAY_INTERFACE=CGI/1.1");
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Length"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-length"))) {
         buf_printf(&txn->buf, "\tCONTENT_LENGTH=%s", hdr[0]);
     }
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-type"))) {
         buf_printf(&txn->buf, "\tCONTENT_TYPE=%s", hdr[0]);
     }
     buf_printf(&txn->buf, "\tPATH_INFO=%s", extra ? extra : "");
@@ -282,7 +282,7 @@ static int meth_get(struct transaction_t *txn,
 
         if (!ret) {
             /* Check for and read response body */
-            hdr = spool_getheader(resp_hdrs, "Content-Type");
+            hdr = spool_getheader(resp_hdrs, "content-type");
             if (hdr) {
                 txn->resp_body.type = hdr[0];
 
@@ -304,11 +304,11 @@ static int meth_get(struct transaction_t *txn,
     if (ret) goto done;
 
     /* Check for a status code */
-    hdr = spool_getheader(resp_hdrs, "Status");
+    hdr = spool_getheader(resp_hdrs, "status");
     if (hdr) code = http_status_to_code(atoi(hdr[0]));
 
     /* Check the type of the CGI response */
-    hdr = spool_getheader(resp_hdrs, "Location");
+    hdr = spool_getheader(resp_hdrs, "location");
     if (hdr) {
         /* Redirect */
         if (hdr[0][0] == '/') {

--- a/imap/http_client.c
+++ b/imap/http_client.c
@@ -115,7 +115,7 @@ EXPORTED int http_parse_framing(int http2, hdrcache_t hdrs,
     body->max = max_msgsize;
 
     /* Check for Transfer-Encoding */
-    if ((hdr = spool_getheader(hdrs, "Transfer-Encoding"))) {
+    if ((hdr = spool_getheader(hdrs, "transfer-encoding"))) {
         if (http2) {
             *errstr = "Transfer-Encoding not allowed in HTTP/2";
             return HTTP_BAD_REQUEST;
@@ -174,7 +174,7 @@ EXPORTED int http_parse_framing(int http2, hdrcache_t hdrs,
     }
 
     /* Check for Content-Length */
-    else if ((hdr = spool_getheader(hdrs, "Content-Length"))) {
+    else if ((hdr = spool_getheader(hdrs, "content-length"))) {
         if (hdr[1]) {
             *errstr = "Multiple Content-Length header fields";
             return HTTP_BAD_REQUEST;
@@ -380,13 +380,13 @@ EXPORTED int http_read_body(struct protstream *pin, hdrcache_t hdrs,
         if (body->flags & BODY_DECODE) {
             const char **hdr;
 
-            if (!(hdr = spool_getheader(hdrs, "Content-Encoding"))) {
+            if (!(hdr = spool_getheader(hdrs, "content-encoding"))) {
                 /* nothing to see here */
             }
 
 #ifdef HAVE_ZLIB
             else if (!strcasecmp(hdr[0], "deflate")) {
-                const char **ua = spool_getheader(hdrs, "User-Agent");
+                const char **ua = spool_getheader(hdrs, "user-agent");
 
                 /* Try to detect Microsoft's broken deflate */
                 if (ua && strstr(ua[0], "; MSIE "))
@@ -454,7 +454,7 @@ EXPORTED int http_read_response(struct backend *be, unsigned meth,
 
     /* Check connection persistence */
     if (version == 0) body->flags |= BODY_CLOSE;
-    for (conn = spool_getheader(*hdrs, "Connection"); conn && *conn; conn++) {
+    for (conn = spool_getheader(*hdrs, "connection"); conn && *conn; conn++) {
         tok_t tok =
             TOK_INITIALIZER(*conn, ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
         char *token;

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -6284,7 +6284,7 @@ EXPORTED int meth_propfind(struct transaction_t *txn, void *params)
         }
 
         /* Add propfind type to our header cache */
-        spool_cache_header(xstrdup(":type"), xstrdup((const char *) cur->name),
+        spool_cache_header(":type", xstrdup((const char *) cur->name),
                            txn->req_hdrs);
 
         /* Make sure it is a known element */
@@ -7631,7 +7631,7 @@ int report_sync_col(struct transaction_t *txn, struct meth_params *rparams,
             if (!xmlStrcmp(node->name, BAD_CAST "sync-token") &&
                 (str = xmlNodeListGetString(inroot->doc, node->children, 1))) {
                 /* Add sync-token to our header cache */
-                spool_cache_header(xstrdup(":token"),
+                spool_cache_header(":token",
                                    xstrdup((const char *) str), txn->req_hdrs);
 
                 /* Parse sync-token */
@@ -8232,7 +8232,7 @@ int meth_report(struct transaction_t *txn, void *params)
     if (ret) goto done;
 
     /* Add report type to our header cache */
-    spool_cache_header(xstrdup(":type"), xstrdup((const char *) inroot->name),
+    spool_cache_header(":type", xstrdup((const char *) inroot->name),
                        txn->req_hdrs);
 
     /* Check the report type against our supported list */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4592,7 +4592,7 @@ int meth_copy_move(struct transaction_t *txn, void *params)
     }
 
     /* Replace cached Destination header with just the absolute path */
-    spool_replace_header(xstrdup("Destination"),
+    spool_replace_header("destination",
                          xstrdup(dest_tgt.path), txn->req_hdrs);
 
     /* Check for optional Overwrite header */

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -931,7 +931,7 @@ static int dav_send_notification(xmlDocPtr doc, struct dlist *extradata,
         goto done;
     }
 
-    spool_cache_header(xstrdup("Content-Type"),
+    spool_cache_header("content-type",
                        xstrdup(DAVNOTIFICATION_CONTENT_TYPE), txn.req_hdrs);
 
     r = dav_store_notification(&txn, doc, extradata,

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -844,23 +844,23 @@ static int dav_store_notification(struct transaction_t *txn,
 
     const char *type;
     if (dlist_getatom(dl, "T", &type)) {
-        spool_replace_header(xstrdup("Subject"),
+        spool_replace_header("subject",
                              xstrdup((char *) type), txn->req_hdrs);
 
         struct buf buf = BUF_INITIALIZER;
         dlist_printbuf(dl, 1, &buf);
         dlist_free(&dl);
-        spool_replace_header(xstrdup("Content-Description"),
+        spool_replace_header("content-description",
                 buf_release(&buf), txn->req_hdrs);
     }
 
     buf_reset(&txn->buf);
     buf_printf(&txn->buf, "<%s-%ld@%s>", resource, time(0), config_servername);
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_printf(&txn->buf, "attachment;\r\n\tfilename=\"%s\"", resource);
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     /* Dump XML response tree into a text buffer */

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -488,7 +488,7 @@ static int notify_get(struct transaction_t *txn, struct mailbox *mailbox,
 
     if (!record || !record->uid) return HTTP_NO_CONTENT;
 
-    if ((hdr = spool_getheader(txn->req_hdrs, "Accept")) &&
+    if ((hdr = spool_getheader(txn->req_hdrs, "accept")) &&
         is_mediatype(DAVSHARING_CONTENT_TYPE, hdr[0])) {
         return HTTP_CONTINUE;
     }

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -316,7 +316,7 @@ static int meth_get_db(struct transaction_t *txn,
     if (userhdrs[1]) return HTTP_NOT_ALLOWED;
     if (keyhdrs[1]) return HTTP_NOT_ALLOWED;
 
-    spool_cache_header(xstrdup(":dblookup"),
+    spool_cache_header(":dblookup",
                       strconcat(userhdrs[0], "/", keyhdrs[0], (char *)NULL),
                       txn->req_hdrs);
 

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -140,7 +140,7 @@ static int get_email2uids(struct transaction_t *txn __attribute__((unused)),
     const char *mailbox = "Default";
     mbentry_t *mbentry = NULL;
 
-    mailboxhdrs = spool_getheader(txn->req_hdrs, "Mailbox");
+    mailboxhdrs = spool_getheader(txn->req_hdrs, "mailbox");
     if (mailboxhdrs) {
         mailbox = mailboxhdrs[0];
     }
@@ -196,7 +196,7 @@ static int get_email2details(struct transaction_t *txn __attribute__((unused)),
     mbentry_t *mbentry = NULL;
     int ispinned = 0;
 
-    mailboxhdrs = spool_getheader(txn->req_hdrs, "Mailbox");
+    mailboxhdrs = spool_getheader(txn->req_hdrs, "mailbox");
     if (mailboxhdrs) {
         mailbox = mailboxhdrs[0];
     }
@@ -255,12 +255,12 @@ static int get_uid2groups(struct transaction_t *txn,
     const char *mailbox = "Default";
     mbentry_t *mbentry = NULL;
 
-    otheruserhdrs = spool_getheader(txn->req_hdrs, "OtherUser");
+    otheruserhdrs = spool_getheader(txn->req_hdrs, "otheruser");
     if (otheruserhdrs) {
         otheruser = otheruserhdrs[0];
     }
 
-    mailboxhdrs = spool_getheader(txn->req_hdrs, "Mailbox");
+    mailboxhdrs = spool_getheader(txn->req_hdrs, "mailbox");
     if (mailboxhdrs) {
         mailbox = mailboxhdrs[0];
     }
@@ -307,8 +307,8 @@ static int meth_get_db(struct transaction_t *txn,
     const char **userhdrs;
     const char **keyhdrs;
 
-    userhdrs = spool_getheader(txn->req_hdrs, "User");
-    keyhdrs = spool_getheader(txn->req_hdrs, "Key");
+    userhdrs = spool_getheader(txn->req_hdrs, "user");
+    keyhdrs = spool_getheader(txn->req_hdrs, "key");
 
     if (!userhdrs) return HTTP_BAD_REQUEST;
     if (!keyhdrs) return HTTP_BAD_REQUEST;

--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -137,7 +137,7 @@ static int begin_headers_cb(nghttp2_session *session,
 
     /* Tell syslog our stream-id */
     buf_printf(&txn->buf, "%d", strm->id);
-    spool_replace_header(xstrdup(":stream-id"),
+    spool_replace_header(":stream-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     nghttp2_session_set_stream_user_data(session, frame->hd.stream_id, txn);
@@ -880,7 +880,7 @@ HIDDEN int http2_start_session(struct transaction_t *txn,
 
         /* Tell syslog our stream-id */
         buf_printf(buf, "%d", strm->id);
-        spool_replace_header(xstrdup(":stream-id"),
+        spool_replace_header(":stream-id",
                              buf_release(&txn->buf), txn->req_hdrs);
     }
 

--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -191,6 +191,7 @@ static int header_cb(nghttp2_session *session,
     }
 
     spool_cache_header(my_name, my_value, txn->req_hdrs);
+    free(my_name);
 
     return 0;
 }

--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -839,7 +839,7 @@ HIDDEN int http2_start_session(struct transaction_t *txn,
         struct buf *buf = &txn->buf;
         unsigned outlen;
 
-        const char **hdr = spool_getheader(txn->req_hdrs, "HTTP2-Settings");
+        const char **hdr = spool_getheader(txn->req_hdrs, "http2-settings");
         if (!hdr || hdr[1]) return 0;
 
         /* base64url decode the settings.

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -417,14 +417,14 @@ static int meth_post_isched(struct transaction_t *txn,
     txn->flags.cc |= CC_NOCACHE;
 
     /* Check iSchedule-Version */
-    if (!(hdr = spool_getheader(txn->req_hdrs, "iSchedule-Version")) ||
+    if (!(hdr = spool_getheader(txn->req_hdrs, "ischedule-version")) ||
         strcmp(hdr[0], "1.0")) {
         txn->error.precond = ISCHED_UNSUPP_VERSION;
         return HTTP_BAD_REQUEST;
     }
 
     /* Check Content-Type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-type"))) {
         for (mime = isched_mime_types; mime->content_type; mime++) {
             if (is_mediatype(mime->content_type, hdr[0])) break;
         }
@@ -435,7 +435,7 @@ static int meth_post_isched(struct transaction_t *txn,
     }
 
     /* Check Originator */
-    if (!(hdr = spool_getheader(txn->req_hdrs, "Originator"))) {
+    if (!(hdr = spool_getheader(txn->req_hdrs, "originator"))) {
         txn->error.precond = ISCHED_ORIG_MISSING;
         return HTTP_BAD_REQUEST;
     }
@@ -446,7 +446,7 @@ static int meth_post_isched(struct transaction_t *txn,
     }
 
     /* Check Recipients */
-    if (!(recipients = spool_getheader(txn->req_hdrs, "Recipient"))) {
+    if (!(recipients = spool_getheader(txn->req_hdrs, "recipient"))) {
         txn->error.precond = ISCHED_RECIP_MISSING;
         return HTTP_BAD_REQUEST;
     }
@@ -471,7 +471,7 @@ static int meth_post_isched(struct transaction_t *txn,
         /* Allow frontends to HTTP auth to backends and use iSchedule */
         authd = 1;
     }
-    else if (!spool_getheader(txn->req_hdrs, "DKIM-Signature")) {
+    else if (!spool_getheader(txn->req_hdrs, "dkim-signature")) {
         if (!config_getswitch(IMAPOPT_ISCHEDULE_DKIM_REQUIRED)) authd = 1;
         else txn->error.desc = "No signature";
     }
@@ -808,7 +808,7 @@ int isched_send(struct caldav_sched_param *sparam, const char *recipient,
         case 302:
         case 307:
         case 308:  /* Redirection */
-            uri = spool_getheader(txn.req_hdrs, "Location")[0];
+            uri = spool_getheader(txn.req_hdrs, "location")[0];
             if (txn.req_body.flags & BODY_CLOSE) {
                 proxy_downserver(be);
                 be = proxy_findserver(buf_cstring(&txn.buf), &http_protocol,

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -501,7 +501,7 @@ static int meth_post(struct transaction_t *txn,
     txn->req_body.flags |= BODY_DECODE;
 
     /* Check Content-Type */
-    const char **hdr = spool_getheader(txn->req_hdrs, "Content-Type");
+    const char **hdr = spool_getheader(txn->req_hdrs, "content-type");
     if (!hdr ||
         !is_mediatype("application/json", hdr[0])) {
         txn->error.desc = "This method requires a JSON request body";
@@ -732,7 +732,7 @@ static int jmap_download(struct transaction_t *txn)
     }
 
     const char **hdr;
-    if (!accept_mime && (hdr = spool_getheader(txn->req_hdrs, "Accept"))) {
+    if (!accept_mime && (hdr = spool_getheader(txn->req_hdrs, "accept"))) {
         accept_mime = parse_accept_header(hdr);
     }
 
@@ -1084,7 +1084,7 @@ static int jmap_upload(struct transaction_t *txn)
         goto done;
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Content-Type"))) {
+    if ((hdr = spool_getheader(hdrcache, "content-type"))) {
         // Strip any parameters from Content-Type header
         char *maintype = NULL, *subtype = NULL;
         struct param *param = NULL;
@@ -1118,11 +1118,11 @@ static int jmap_upload(struct transaction_t *txn)
     }
 
     /* Create RFC 5322 header for resource */
-    if ((hdr = spool_getheader(hdrcache, "User-Agent"))) {
+    if ((hdr = spool_getheader(hdrcache, "user-agent"))) {
         fprintf(f, "User-Agent: %s\r\n", hdr[0]);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "From"))) {
+    if ((hdr = spool_getheader(hdrcache, "from"))) {
         fprintf(f, "From: %s\r\n", hdr[0]);
     }
     else {
@@ -1144,11 +1144,11 @@ static int jmap_upload(struct transaction_t *txn)
         buf_reset(&txn->buf);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Subject"))) {
+    if ((hdr = spool_getheader(hdrcache, "subject"))) {
         fprintf(f, "Subject: %s\r\n", hdr[0]);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Date"))) {
+    if ((hdr = spool_getheader(hdrcache, "date"))) {
         fprintf(f, "Date: %s\r\n", hdr[0]);
     }
     else {
@@ -1157,7 +1157,7 @@ static int jmap_upload(struct transaction_t *txn)
         fprintf(f, "Date: %s\r\n", datestr);
     }
 
-    if ((hdr = spool_getheader(hdrcache, "Message-ID"))) {
+    if ((hdr = spool_getheader(hdrcache, "message-id"))) {
         fprintf(f, "Message-ID: %s\r\n", hdr[0]);
     }
 
@@ -1629,7 +1629,7 @@ static int jmap_eventsource(struct transaction_t *txn)
 
     const char **hdr;
     if (txn->req_hdrs &&
-        (hdr = spool_getheader(txn->req_hdrs, "Last-Event-Id"))) {
+        (hdr = spool_getheader(txn->req_hdrs, "last-event-id"))) {
         lastmodseq = atomodseq_t(*hdr);
     }
 

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -1461,14 +1461,14 @@ static int jmap_ws(struct transaction_t *txn, enum wslay_opcode opcode,
         }
         else if (!strcmpsafe(type, "WebSocketPushEnable")) {
             /* Log request */
-            spool_replace_header(xstrdup(":jmap"),
+            spool_replace_header(":jmap",
                                  xstrdup("WebSocketPushEnable"), txn->req_hdrs);
             ws_push_enable(txn, req);
             ret = HTTP_NO_CONTENT;
         }
         else if (!strcmpsafe(type, "WebSocketPushDisable")) {
             /* Log request */
-            spool_replace_header(xstrdup(":jmap"),
+            spool_replace_header(":jmap",
                                  xstrdup("WebSocketPushDisable"), txn->req_hdrs);
             jmap_push_done(txn);
             ret = HTTP_NO_CONTENT;

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -291,12 +291,12 @@ static int login(struct backend *s, const char *userid,
             break;
 
         case 200: /* OK */
-            if ((hdr = spool_getheader(hdrs, "Authentication-Info"))) { 
+            if ((hdr = spool_getheader(hdrs, "authentication-info"))) {
                 /* Default handling of success data */
                 serverin = hdr[0];
             }
             else if (scheme && (scheme->flags & AUTH_SUCCESS_WWW) &&
-                     (hdr = spool_getheader(hdrs, "WWW-Authenticate"))) {
+                     (hdr = spool_getheader(hdrs, "www-authenticate"))) {
                 /* Special handling of success data for this scheme */
                 serverin = strchr(hdr[0], ' ');
                 if (serverin) serverin++;
@@ -317,7 +317,7 @@ static int login(struct backend *s, const char *userid,
             if (!serverin) {
                 int i = 0;
 
-                hdr = spool_getheader(hdrs, "WWW-Authenticate");
+                hdr = spool_getheader(hdrs, "www-authenticate");
 
                 if (!scheme) {
                     unsigned avail_auth_schemes = 0;
@@ -523,7 +523,7 @@ EXPORTED void http_proto_host(hdrcache_t req_hdrs, const char **proto, const cha
     const char **fwd;
 
     if (config_mupdate_server && config_getstring(IMAPOPT_PROXYSERVERS) &&
-        (fwd = spool_getheader(req_hdrs, "Forwarded"))) {
+        (fwd = spool_getheader(req_hdrs, "forwarded"))) {
         /* Proxied request - parse last Forwarded header for proto and host */
         /* XXX  This is destructive of the header but we don't care
          * and more importantly, we need the tokens available after tok_fini()
@@ -551,8 +551,8 @@ EXPORTED void http_proto_host(hdrcache_t req_hdrs, const char **proto, const cha
 static void write_forwarding_hdrs(struct transaction_t *txn, hdrcache_t hdrs,
                                   const char *version, const char *proto)
 {
-    const char **via = spool_getheader(hdrs, "Via");
-    const char **fwd = spool_getheader(hdrs, "Forwarded");
+    const char **via = spool_getheader(hdrs, "via");
+    const char **fwd = spool_getheader(hdrs, "forwarded");
 
     /* Add any existing Via headers */
     for (; via && *via; via++) simple_hdr(txn, "Via", "%s", *via);
@@ -655,18 +655,18 @@ static void send_response(struct transaction_t *txn, long code,
         /* Empty body -- use  payload headers from response, if any */
         const char **hdr;
 
-        if ((hdr = spool_getheader(hdrs, "Transfer-Encoding"))) {
+        if ((hdr = spool_getheader(hdrs, "transfer-encoding"))) {
             txn->flags.te = TE_CHUNKED;
 
             if (txn->flags.ver == VER_1_1) {
                 simple_hdr(txn, "Transfer-Encoding", "%s", hdr[0]);
             }
-            if ((hdr = spool_getheader(hdrs, "Trailer"))) {
+            if ((hdr = spool_getheader(hdrs, "trailer"))) {
                 txn->flags.trailer = TRAILER_PROXY;
                 simple_hdr(txn, "Trailer", "%s", hdr[0]);
             }
         }
-        else if ((hdr = spool_getheader(hdrs, "Content-Length"))) {
+        else if ((hdr = spool_getheader(hdrs, "content-length"))) {
             txn->resp_body.len = strtoul(hdr[0], NULL, 10);
 
             if (txn->flags.ver != VER_2) {
@@ -825,7 +825,7 @@ static void log_proxy_request(long code, txn_t *txn,
     txn->flags.te = resp_body->te;
     txn->resp_body.len = resp_body->len;
 
-    const char **hdr = spool_getheader(resp_hdrs, "Content-Encoding");
+    const char **hdr = spool_getheader(resp_hdrs, "content-encoding");
     if (hdr) {
         int i;
         for (i = 0; ce_strings[i]; i++) {
@@ -888,13 +888,13 @@ EXPORTED int http_pipe_req_resp(struct backend *be, struct transaction_t *txn)
         comma_list_hdr(&be_txn, "Upgrade", upgrade_tokens, txn->flags.upgrade);
     }
     spool_enum_hdrcache(txn->req_hdrs, &write_cachehdr, &be_txn);
-    if ((hdr = spool_getheader(txn->req_hdrs, "TE"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "te"))) {
         for (; *hdr; hdr++) prot_printf(be->out, "TE: %s\r\n", *hdr);
     }
     if (http_methods[txn->meth].flags & METH_NOBODY)
         prot_puts(be->out, "Content-Length: 0\r\n");
-    else if (spool_getheader(txn->req_hdrs, "Transfer-Encoding") ||
-        spool_getheader(txn->req_hdrs, "Content-Length")) {
+    else if (spool_getheader(txn->req_hdrs, "transfer-encoding") ||
+        spool_getheader(txn->req_hdrs, "content-length")) {
         prot_puts(be->out, "Expect: 100-continue\r\n");
         prot_puts(be->out, "Transfer-Encoding: chunked\r\n");
     }
@@ -1025,10 +1025,10 @@ EXPORTED int http_proxy_copy(struct backend *src_be, struct backend *dest_be,
                                  "User-Agent: Cyrus/%s\r\n",
                     txn->req_tgt.path, HTTP_VERSION,
                     src_be->hostname, CYRUS_VERSION);
-        write_hdr(src_be->out, "If", txn->req_hdrs);
-        write_hdr(src_be->out, "If-Match", txn->req_hdrs);
-        write_hdr(src_be->out, "If-Unmodified-Since", txn->req_hdrs);
-        write_hdr(src_be->out, "If-Schedule-Tag-Match", txn->req_hdrs);
+        write_hdr(src_be->out, "if", txn->req_hdrs);
+        write_hdr(src_be->out, "if-match", txn->req_hdrs);
+        write_hdr(src_be->out, "if-unmodified-since", txn->req_hdrs);
+        write_hdr(src_be->out, "if-schedule-tag-match", txn->req_hdrs);
 
         assert(!buf_len(&txn->buf));
         buf_printf_markup(&txn->buf, 0,
@@ -1062,7 +1062,7 @@ EXPORTED int http_proxy_copy(struct backend *src_be, struct backend *dest_be,
         } while (code < 200);
 
         /* Get lock token */
-        if ((hdr = spool_getheader(resp_hdrs, "Lock-Token")))
+        if ((hdr = spool_getheader(resp_hdrs, "lock-token")))
             lock = xstrdup(*hdr);
 
         switch (code) {
@@ -1101,10 +1101,10 @@ EXPORTED int http_proxy_copy(struct backend *src_be, struct backend *dest_be,
                 txn->req_tgt.path, HTTP_VERSION,
                 src_be->hostname, CYRUS_VERSION);
     if (txn->meth != METH_MOVE) {
-        write_hdr(src_be->out, "If", txn->req_hdrs);
-        write_hdr(src_be->out, "If-Match", txn->req_hdrs);
-        write_hdr(src_be->out, "If-Unmodified-Since", txn->req_hdrs);
-        write_hdr(src_be->out, "If-Schedule-Tag-Match", txn->req_hdrs);
+        write_hdr(src_be->out, "if", txn->req_hdrs);
+        write_hdr(src_be->out, "if-match", txn->req_hdrs);
+        write_hdr(src_be->out, "if-unmodified-since", txn->req_hdrs);
+        write_hdr(src_be->out, "if-schedule-tag-match", txn->req_hdrs);
     }
     prot_puts(src_be->out, "\r\n");
     prot_flush(src_be->out);
@@ -1142,20 +1142,20 @@ EXPORTED int http_proxy_copy(struct backend *src_be, struct backend *dest_be,
                               "Host: %s\r\n"
                               "User-Agent: Cyrus/%s\r\n"
                               "Expect: 100-continue\r\n",
-                *spool_getheader(txn->req_hdrs, "Destination"), HTTP_VERSION,
+                *spool_getheader(txn->req_hdrs, "destination"), HTTP_VERSION,
                 dest_be->hostname, CYRUS_VERSION);
-    hdr = spool_getheader(txn->req_hdrs, "Overwrite");
+    hdr = spool_getheader(txn->req_hdrs, "overwrite");
     if (hdr && !strcmp(*hdr, "F"))
         prot_puts(dest_be->out, "If-None-Match: *\r\n");
-    write_hdr(dest_be->out, "TE", txn->req_hdrs);
-    write_hdr(dest_be->out, "Prefer", txn->req_hdrs);
-    write_hdr(dest_be->out, "Accept", txn->req_hdrs);
-    write_hdr(dest_be->out, "Accept-Charset", txn->req_hdrs);
-    write_hdr(dest_be->out, "Accept-Encoding", txn->req_hdrs);
-    write_hdr(dest_be->out, "Accept-Language", txn->req_hdrs);
-    write_hdr(dest_be->out, "Content-Type", resp_hdrs);
-    write_hdr(dest_be->out, "Content-Encoding", resp_hdrs);
-    write_hdr(dest_be->out, "Content-Language", resp_hdrs);
+    write_hdr(dest_be->out, "te", txn->req_hdrs);
+    write_hdr(dest_be->out, "prefer", txn->req_hdrs);
+    write_hdr(dest_be->out, "accept", txn->req_hdrs);
+    write_hdr(dest_be->out, "accept-charset", txn->req_hdrs);
+    write_hdr(dest_be->out, "accept-encoding", txn->req_hdrs);
+    write_hdr(dest_be->out, "accept-language", txn->req_hdrs);
+    write_hdr(dest_be->out, "content-type", resp_hdrs);
+    write_hdr(dest_be->out, "content-encoding", resp_hdrs);
+    write_hdr(dest_be->out, "content-language", resp_hdrs);
     prot_printf(dest_be->out, "Content-Length: %u\r\n\r\n",
                 (unsigned)buf_len(&resp_body.payload));
     prot_flush(dest_be->out);

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -1240,7 +1240,7 @@ static int action_get(struct transaction_t *txn)
              mime->content_type && !is_mediatype(mime->content_type, param->s);
              mime++);
     }
-    else if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+    else if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
         mime = get_accept_type(hdr, tz_mime_types);
     else mime = tz_mime_types;
 

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -697,19 +697,19 @@ static int webdav_put(struct transaction_t *txn, void *obj,
 
     /* Create and cache RFC 5322 header fields for resource */
     if (filename) {
-        spool_replace_header(xstrdup("Subject"),
+        spool_replace_header("subject",
                              xstrdup(filename), txn->req_hdrs);
-        spool_replace_header(xstrdup("Content-Description"),
+        spool_replace_header("content-description",
                              xstrdup(filename), txn->req_hdrs);
     }
 
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, "<%s@%s>", resource, config_servername);
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_printf(&txn->buf, "attachment;\r\n\tfilename=\"%s\"", resource);
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     /* Store the resource */

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -676,7 +676,7 @@ static int webdav_put(struct transaction_t *txn, void *obj,
     }
 
     /* Get filename of attachment */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Disposition"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-disposition"))) {
         char *dparam;
         tok_t tok;
 

--- a/imap/http_ws.c
+++ b/imap/http_ws.c
@@ -631,7 +631,7 @@ static void parse_extensions(struct transaction_t *txn)
 {
     struct ws_context *ctx = (struct ws_context *) txn->ws_ctx;
     const char **ext_hdr =
-        spool_getheader(txn->req_hdrs, "Sec-WebSocket-Extensions");
+        spool_getheader(txn->req_hdrs, "sec-websocket-extensions");
     int i;
 
     /* Look for interesting extensions.  Unknown == ignore */
@@ -741,7 +741,7 @@ HIDDEN int ws_start_channel(struct transaction_t *txn,
     };
 
     /* Check for supported WebSocket version */
-    hdr = spool_getheader(txn->req_hdrs, "Sec-WebSocket-Version");
+    hdr = spool_getheader(txn->req_hdrs, "sec-websocket-version");
     if (!hdr) {
         txn->error.desc = "Missing WebSocket version";
         return HTTP_BAD_REQUEST;
@@ -759,7 +759,7 @@ HIDDEN int ws_start_channel(struct transaction_t *txn,
         /* Check for supported WebSocket subprotocol */
         int i, found = 0;
 
-        hdr = spool_getheader(txn->req_hdrs, "Sec-WebSocket-Protocol");
+        hdr = spool_getheader(txn->req_hdrs, "sec-websocket-protocol");
         if (!hdr) {
             txn->error.desc = "Missing WebSocket protocol";
             return HTTP_BAD_REQUEST;
@@ -787,7 +787,7 @@ HIDDEN int ws_start_channel(struct transaction_t *txn,
         unsigned char sha1buf[SHA1_DIGEST_LENGTH];
 
         /* Check for WebSocket client key */
-        hdr = spool_getheader(txn->req_hdrs, "Sec-WebSocket-Key");
+        hdr = spool_getheader(txn->req_hdrs, "sec-websocket-key");
         if (!hdr) {
             txn->error.desc = "Missing WebSocket client key";
             return HTTP_BAD_REQUEST;
@@ -863,11 +863,11 @@ HIDDEN int ws_start_channel(struct transaction_t *txn,
     /* Add client data */
     buf_printf(&ctx->log, "%s", txn->conn->clienthost);
     if (httpd_userid) buf_printf(&ctx->log, " as \"%s\"", httpd_userid);
-    if ((hdr = spool_getheader(txn->req_hdrs, "User-Agent"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "user-agent"))) {
         buf_printf(&ctx->log, " with \"%s\"", hdr[0]);
-        if ((hdr = spool_getheader(txn->req_hdrs, "X-Client")))
+        if ((hdr = spool_getheader(txn->req_hdrs, "x-client")))
             buf_printf(&ctx->log, " by \"%s\"", hdr[0]);
-        else if ((hdr = spool_getheader(txn->req_hdrs, "X-Requested-With")))
+        else if ((hdr = spool_getheader(txn->req_hdrs, "x-requested-with")))
             buf_printf(&ctx->log, " by \"%s\"", hdr[0]);
     }
 

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2502,7 +2502,7 @@ dynarray_t *parse_accept(const char **hdr)
             if (type)
                 accept.token = lcase(strconcat(type, "/", subtype, NULL));
             else
-                accept.token = lcase(xstrdup(token));
+                accept.token = xstrduplcase(token);
 
             for (param = params; param; param = param->next) {
                 if (!strcasecmp(param->attribute, "q")) {

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1534,7 +1534,7 @@ static int preauth_check_hdrs(struct transaction_t *txn)
         }
 
         /* Create an :authority pseudo header from Host */
-        spool_cache_header(xstrdup(":authority"),
+        spool_cache_header(":authority",
                            xstrdup(hdr[0]), txn->req_hdrs);
     }
     else {
@@ -1555,7 +1555,7 @@ static int preauth_check_hdrs(struct transaction_t *txn)
             }
             else buf_setcstr(&txn->buf, config_servername);
 
-            spool_cache_header(xstrdup(":authority"),
+            spool_cache_header(":authority",
                                buf_release(&txn->buf), txn->req_hdrs);
             break;
 

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -1126,10 +1126,10 @@ HIDDEN enum sched_deliver_outcome sched_deliver_local(const char *userid,
     if (!sched_sender_address)
         sched_sender_address = xstrdupnull(sender);
     if (sched_sender_address)
-        spool_append_header(xstrdup("Schedule-Sender-Address"),
+        spool_append_header("schedule-sender-address",
                 sched_sender_address, txn.req_hdrs);
     if (mailfrom && mailfrom->name)
-        spool_append_header(xstrdup("Schedule-Sender-Name"),
+        spool_append_header("schedule-sender-name",
                 xstrdup(mailfrom->name), txn.req_hdrs);
 
     /* Check ACL of sender on recipient's Scheduling Inbox */

--- a/imap/jmap_admin.c
+++ b/imap/jmap_admin.c
@@ -200,7 +200,7 @@ static int rewrite_calevent_privacy(const char *userid, void *vrock)
 
     rock->txn.userid = userid;
     rock->txn.req_hdrs = spool_new_hdrcache();
-    spool_append_header(xstrdup("Schedule-Reply"), xstrdup("F"),
+    spool_append_header("schedule-reply", xstrdup("F"),
             rock->txn.req_hdrs);
 
     caldavdb = caldav_open_userid(userid);

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -862,7 +862,7 @@ HIDDEN int jmap_api(struct transaction_t *txn,
 
   done:
     /* tell syslog which methods were called */
-    spool_replace_header(xstrdup(":jmap"),
+    spool_replace_header(":jmap",
                          strarray_join(&methods, ","), txn->req_hdrs);
 
     {

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -1755,7 +1755,7 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
     json_t *recur = json_pack("{s:s}", "@type", "RecurrenceRule");
 
     /* frequency */
-    s = lcase(xstrdup(icalrecur_freq_to_string(rrule.freq)));
+    s = xstrduplcase(icalrecur_freq_to_string(rrule.freq));
     json_object_set_new(recur, "frequency", json_string(s));
     free(s);
 
@@ -1764,8 +1764,7 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
 #ifdef HAVE_RSCALE
     /* rscale */
     if (rrule.rscale) {
-        s = xstrdup(rrule.rscale);
-        s = lcase(s);
+        s = xstrduplcase(rrule.rscale);
         json_object_set_new(recur, "rscale", json_string(s));
         free(s);
     } else json_object_set_new(recur, "rscale", json_string("gregorian"));
@@ -1788,8 +1787,7 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
 #endif
 
     /* firstDayOfWeek */
-    s = xstrdup(icalrecur_weekday_to_string(rrule.week_start));
-    s = lcase(s);
+    s = xstrduplcase(icalrecur_weekday_to_string(rrule.week_start));
     json_object_set_new(recur, "firstDayOfWeek", json_string(s));
     free(s);
 
@@ -1807,8 +1805,7 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
         jday = json_object();
         weekday = icalrecurrencetype_day_day_of_week(rrule.by_day[i]);
 
-        s = xstrdup(icalrecur_weekday_to_string(weekday));
-        s = lcase(s);
+        s = xstrduplcase(icalrecur_weekday_to_string(weekday));
         json_object_set_new(jday, "day", json_string(s));
         free(s);
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -467,7 +467,7 @@ static void _headers_shift_new(struct headers *headers, json_t *header)
 
 static json_t* _headers_get(struct headers *headers, const char *name)
 {
-    char *lcasename = lcase(xstrdup(name));
+    char *lcasename = xstrduplcase(name);
     json_t *jheader = json_object_get(headers->all, lcasename);
     free(lcasename);
     return jheader;
@@ -714,7 +714,7 @@ static struct header_prop *_header_parseprop(const char *s)
             /* fallthrough */
         case 1:
             f0 = strarray_nth(fields, 0);
-            lcasename = lcase(xstrdup(f0));
+            lcasename = xstrduplcase(f0);
             name = xstrdup(f0);
             break;
         default:
@@ -7739,7 +7739,7 @@ static json_t *_email_get_bodypart(jmap_req_t *req,
     if (jmap_wantprop(bodyprops, "disposition")) {
         json_t *jdisp = json_null();
         if (part->disposition) {
-            char *disp = lcase(xstrdup(part->disposition));
+            char *disp = xstrduplcase(part->disposition);
             jdisp = json_string(disp);
             free(disp);
         }

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -1498,7 +1498,7 @@ HIDDEN struct jmap_headermatch *jmap_headermatch_new(const char *header,
     else {
         hm->op = HEADERMATCH_CONTAINS;
     }
-    hm->header = lcase(xstrdup(header));
+    hm->header = xstrduplcase(header);
     buf_setcstr(val, value);
     headermatch_normalize(hm, val);
     hm->len = buf_len(val);

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -301,8 +301,7 @@ static char *_mbox_get_role(jmap_req_t *req, const mbname_t *mbname)
              * return the first specialuse flag. */
             const char *use = strarray_nth(uses, 0);
             if (use[0] == '\\') {
-                role = xstrdup(use+1);
-                lcase(role);
+                role = xstrduplcase(use+1);
             }
         }
         strarray_free(uses);

--- a/imap/jmap_notif.c
+++ b/imap/jmap_notif.c
@@ -448,13 +448,13 @@ HIDDEN int jmap_create_caldaveventnotif(struct transaction_t *txn,
     const char **hdr;
     char *from = NULL;
 
-    if ((hdr = spool_getheader(txn->req_hdrs, "Schedule-Sender-Address"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "schedule-sender-address"))) {
         byemail = *hdr;
         if (!strncasecmp(byemail, "mailto:", 7)) {
             byemail += 7;
         }
         from = strconcat("<", byemail, ">", NULL);
-        if ((hdr = spool_getheader(txn->req_hdrs, "Schedule-Sender-name"))) {
+        if ((hdr = spool_getheader(txn->req_hdrs, "schedule-sender-name"))) {
             char *val = charset_decode_mimeheader(*hdr, CHARSET_KEEPCASE);
             if (val) buf_initmcstr(&byname, val);
         }

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1289,18 +1289,14 @@ static void fill_cache(message_data_t *m)
 static int getheader(void *v, const char *phead, const char ***body)
 {
     message_data_t *m = (message_data_t *) v;
-
-    *body = NULL;
+    char *lcasedhead = xstrduplcase(phead);
 
     if (!m->cache_full) fill_cache(m);
 
-    *body = spool_getheader(m->cache, phead);
+    *body = spool_getheader(m->cache, lcasedhead);
+    free(lcasedhead);
 
-    if (*body) {
-        return SIEVE_OK;
-    } else {
-        return SIEVE_FAIL;
-    }
+    return *body ? SIEVE_OK : SIEVE_FAIL;
 }
 
 static int getheadersection(void *mc __attribute__((unused)),

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1731,14 +1731,14 @@ static int deleteheader(void *mc, const char *head, int index)
     json_t *args = json_object();
 
     if (index) {
-        spool_remove_header_instance(xstrdup(head), index, m->cache);
+        spool_remove_header_instance(head, index, m->cache);
 
         json_object_set_new(args, "index", json_integer(abs(index)));
         if (index < 0)
             json_object_set_new(args, "last", json_true());
     }
     else {
-        spool_remove_header(xstrdup(head), m->cache);
+        spool_remove_header(head, m->cache);
     }
 
     json_array_append_new(m->actions,

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1702,18 +1702,20 @@ static int addheader(void *mc, const char *head, const char *body, int index)
     if (!m->cache_full) fill_cache(m);
 
     json_t *args = json_object();
+    char *lcasedhead = xstrduplcase(head);
 
     if (index < 0) {
-        spool_append_header(xstrdup(head), xstrdup(body), m->cache);
+        spool_append_header(lcasedhead, xstrdup(body), m->cache);
 
         json_object_set_new(args, "last", json_true());
     }
     else {
-        spool_prepend_header(xstrdup(head), xstrdup(body), m->cache);
+        spool_prepend_header(lcasedhead, xstrdup(body), m->cache);
     }
 
     json_array_append_new(m->actions,
                           json_pack("[s o [s s]]", "addheader", args, head, body));
+    free(lcasedhead);
 
     return SIEVE_OK;
 }

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -172,8 +172,8 @@ static int deleteheader(void *mc, const char *head, int index)
 
     if (head == NULL) return SIEVE_FAIL;
 
-    if (!index) spool_remove_header(xstrdup(head), m->hdrcache);
-    else spool_remove_header_instance(xstrdup(head), index, m->hdrcache);
+    if (!index) spool_remove_header(head, m->hdrcache);
+    else spool_remove_header_instance(head, index, m->hdrcache);
 
     return SIEVE_OK;
 }

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -154,10 +154,13 @@ static int addheader(void *mc, const char *head, const char *body, int index)
 
     if (head == NULL || body == NULL) return SIEVE_FAIL;
 
+    char *lcasedhead = xstrduplcase(head);
     if (index < 0)
-        spool_append_header(xstrdup(head), xstrdup(body), m->hdrcache);
+        spool_append_header(lcasedhead, xstrdup(body), m->hdrcache);
     else
-        spool_prepend_header(xstrdup(head), xstrdup(body), m->hdrcache);
+        spool_prepend_header(lcasedhead, xstrdup(body), m->hdrcache);
+
+    free(lcasedhead);
 
     return SIEVE_OK;
 }

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -120,13 +120,11 @@ static int getheader(void *v, const char *phead, const char ***body)
     message_data_t *m = ((deliver_data_t *) v)->m;
 
     if (phead==NULL) return SIEVE_FAIL;
-    *body = msg_getheader(m, phead);
+    char *lcasedheader = xstrduplcase(phead);
+    *body = msg_getheader(m, lcasedheader);
+    free (lcasedheader);
 
-    if (*body) {
-        return SIEVE_OK;
-    } else {
-        return SIEVE_FAIL;
-    }
+    return *body ? SIEVE_OK : SIEVE_FAIL;
 }
 
 static void getheaders_cb(const char *name, const char *value,

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -1203,7 +1203,7 @@ done:
     return r;
 }
 
-static const char *notifyheaders[] = { "From", "Subject", "To", 0 };
+static const char *notifyheaders[] = { "from", "subject", "to", 0 };
 /* returns a malloc'd string that should be sent to users for successful
    delivery of 'm'. */
 char *generate_notify(message_data_t *m)

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -610,7 +610,7 @@ static int savemsg(struct clientdata *cd,
         sprintf(addbody, "<%s%s%s>",
                 rpath, hostname ? "@" : "", hostname ? hostname : "");
         fprintf(f, "Return-Path: %s\r\n", addbody);
-        spool_cache_header(xstrdup("Return-Path"), addbody, m->hdrcache);
+        spool_cache_header("return-path", addbody, m->hdrcache);
     }
 
     /* add a received header */
@@ -663,18 +663,20 @@ static int savemsg(struct clientdata *cd,
     }
     buf_printf(&rbuf, "%s\r\n", p);
     fputs(buf_cstring(&rbuf), f);
-    spool_append_header_raw(xstrdup("Received"), addbody, buf_release(&rbuf), m->hdrcache);
+    spool_append_header_raw("received", addbody, buf_release(&rbuf), m->hdrcache);
 
     char *sid = xstrdup(session_id());
     fprintf(f, "X-Cyrus-Session-Id: %s\r\n", sid);
-    spool_cache_header(xstrdup("X-Cyrus-Session-Id"), sid, m->hdrcache);
+    spool_cache_header("x-cyrus-session-id", sid, m->hdrcache);
 
     /* add any requested headers */
     if (func->addheaders) {
         struct addheader *h;
         for (h = func->addheaders; h && h->name; h++) {
             fprintf(f, "%s: %s\r\n", h->name, h->body);
-            spool_cache_header(xstrdup(h->name), xstrdup(h->body), m->hdrcache);
+            char *temp = xstrduplcase(h->name);
+            spool_cache_header(temp, xstrdup(h->body), m->hdrcache);
+            free(temp);
         }
     }
 
@@ -696,7 +698,7 @@ static int savemsg(struct clientdata *cd,
         sprintf(m->id, "<cmu-lmtpd-%d-%d-%u@%s>", p, (int) now,
                 msgid_count++, config_servername);
         fprintf(f, "Message-ID: %s\r\n", m->id);
-        spool_cache_header(xstrdup("Message-ID"), xstrdup(m->id), m->hdrcache);
+        spool_cache_header("message-id", xstrdup(m->id), m->hdrcache);
     }
 
     /* get date */
@@ -705,7 +707,7 @@ static int savemsg(struct clientdata *cd,
         addbody = xstrdup(datestr);
         m->date = xstrdup(datestr);
         fprintf(f, "Date: %s\r\n", addbody);
-        spool_cache_header(xstrdup("Date"), addbody, m->hdrcache);
+        spool_cache_header("date", addbody, m->hdrcache);
     }
     else {
         m->date = xstrdup(body[0]);

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -2972,7 +2972,7 @@ static void add_header(const char *destname, const char **dest,
         }
         else {
             /* add the new header to the cache */
-            spool_cache_header(xstrdup(destname), newdest, hdrcache);
+            spool_cache_header(destname, newdest, hdrcache);
         }
     } else if (dest) {
         /* no source header, use original dest header */
@@ -3033,7 +3033,7 @@ static int savemsg(message_data_t *m, FILE *f)
         m->path = strconcat(config_servername, "!",
                             nntp_userid ? nntp_userid : "anonymous",
                             (char *)NULL);
-        spool_cache_header(xstrdup("Path"), xstrdup(m->path), m->hdrcache);
+        spool_cache_header("path", xstrdup(m->path), m->hdrcache);
     }
     fprintf(f, "Path: %s\r\n", m->path);
 
@@ -3048,7 +3048,7 @@ static int savemsg(message_data_t *m, FILE *f)
         sprintf(m->id, "<cmu-nntpd-%d-%d-%d@%s>", p, (int) now,
                 post_count++, config_servername);
         fprintf(f, "Message-ID: %s\r\n", m->id);
-        spool_cache_header(xstrdup("Message-ID"), xstrdup(m->id), m->hdrcache);
+        spool_cache_header("message-id", xstrdup(m->id), m->hdrcache);
     }
 
     /* get date */
@@ -3059,7 +3059,7 @@ static int savemsg(message_data_t *m, FILE *f)
         time_to_rfc5322(now, datestr, sizeof(datestr));
         m->date = xstrdup(datestr);
         fprintf(f, "Date: %s\r\n", datestr);
-        spool_cache_header(xstrdup("Date"), xstrdup(datestr), m->hdrcache);
+        spool_cache_header("date", xstrdup(datestr), m->hdrcache);
     }
     else {
         m->date = xstrdup(body[0]);
@@ -3101,7 +3101,7 @@ static int savemsg(message_data_t *m, FILE *f)
                     (newsaddheaders & IMAP_ENUM_NEWSADDHEADERS_TO)) {
                     to = groups;
                 }
-                add_header("To", body, to, newspostuser, m->hdrcache, f);
+                add_header("to", body, to, newspostuser, m->hdrcache, f);
 
                 /* add Reply-To: header to spooled message file,
                    optionally adding "post" email addr based on newsgroup */
@@ -3120,7 +3120,7 @@ static int savemsg(message_data_t *m, FILE *f)
                         else replyto = spool_getheader(m->hdrcache, "from");
                     }
                 }
-                add_header("Reply-To", body, replyto, newspostuser,
+                add_header("reply-to", body, replyto, newspostuser,
                            m->hdrcache, f);
             }
         } else {

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -2968,7 +2968,7 @@ static void add_header(const char *destname, const char **dest,
 
         if (dest) {
             /* replace the existing cached header */
-            spool_replace_header(xstrdup(destname), newdest, hdrcache);
+            spool_replace_header(destname, newdest, hdrcache);
         }
         else {
             /* add the new header to the cache */
@@ -3027,7 +3027,7 @@ static int savemsg(message_data_t *m, FILE *f)
     if ((body = spool_getheader(m->hdrcache, "path")) != NULL) {
         /* prepend to the cached path */
         m->path = strconcat(config_servername, "!", body[0], (char *)NULL);
-        spool_replace_header(xstrdup("Path"), xstrdup(m->path), m->hdrcache);
+        spool_replace_header("path", xstrdup(m->path), m->hdrcache);
     } else {
         /* no path, create one */
         m->path = strconcat(config_servername, "!",

--- a/imap/spool.c
+++ b/imap/spool.c
@@ -366,17 +366,17 @@ EXPORTED void spool_append_header(const char *name, char *body, hdrcache_t cache
     spool_append_header_raw(name, body, NULL, cache);
 }
 
-EXPORTED void spool_replace_header(char *name, char *body, hdrcache_t cache)
+EXPORTED void spool_replace_header(const char *name, char *body, hdrcache_t cache)
 {
-    spool_remove_header(xstrdup(name), cache);
+    spool_remove_header(name, cache);
     spool_append_header(name, body, cache);
 }
 
-static void __spool_remove_header(char *name, int first, int last,
+static void __spool_remove_header(const char *name, int first, int last,
                                   hdrcache_t cache)
 {
     ptrarray_t *contents =
-        (ptrarray_t *) hash_lookup(lcase(name), &cache->cache);
+        (ptrarray_t *) hash_lookup(name, &cache->cache);
 
     if (contents) {
         int idx;
@@ -406,16 +406,14 @@ static void __spool_remove_header(char *name, int first, int last,
             free(hdr);
         }
     }
-
-    free(name);
 }
 
-EXPORTED void spool_remove_header(char *name, hdrcache_t cache)
+EXPORTED void spool_remove_header(const char *name, hdrcache_t cache)
 {
     __spool_remove_header(name, 0, -1, cache);
 }
 
-EXPORTED void spool_remove_header_instance(char *name, int n, hdrcache_t cache)
+EXPORTED void spool_remove_header_instance(const char *name, int n, hdrcache_t cache)
 {
     if (!n) return;
     if (n > 0) n--; /* normalize to zero */

--- a/imap/spool.c
+++ b/imap/spool.c
@@ -454,18 +454,12 @@ EXPORTED int spool_fill_hdrcache(struct protstream *fin, FILE *fout,
 
 EXPORTED const char **spool_getheader(hdrcache_t cache, const char *phead)
 {
-    char *head;
     ptrarray_t *contents;
 
     assert(cache && phead);
 
-    head = xstrdup(phead);
-    lcase(head);
-
     /* check the cache */
-    contents = (ptrarray_t *) hash_lookup(head, &cache->cache);
-
-    free(head);
+    contents = (ptrarray_t *) hash_lookup(phead, &cache->cache);
 
     if (contents && ptrarray_size(contents)) {
         strarray_t *array = strarray_new();

--- a/imap/spool.h
+++ b/imap/spool.h
@@ -61,6 +61,7 @@ void spool_remove_header(char *name, hdrcache_t cache);
 void spool_remove_header_instance(char *name, int n, hdrcache_t cache);
 int spool_fill_hdrcache(struct protstream *fin, FILE *fout, hdrcache_t cache,
                         const char **skipheaders);
+/* phead must be lower-cased */
 const char **spool_getheader(hdrcache_t cache, const char *phead);
 void spool_free_hdrcache(hdrcache_t cache);
 void spool_enum_hdrcache(hdrcache_t cache,

--- a/imap/spool.h
+++ b/imap/spool.h
@@ -54,11 +54,12 @@ void spool_prepend_header_raw(const char *name, char *body, char *raw, hdrcache_
 void spool_append_header(const char *name, char *body, hdrcache_t cache);
 void spool_append_header_raw(const char *name, char *body, char *raw, hdrcache_t cache);
 #define spool_cache_header(n, b, c) spool_append_header(n, b, c)
-void spool_replace_header(char *name, char *newvalue, hdrcache_t cache);
-/* remove all instances of header 'name' */
-void spool_remove_header(char *name, hdrcache_t cache);
-/* remove nth instance of header 'name'.  1 = first, -1 = last */
-void spool_remove_header_instance(char *name, int n, hdrcache_t cache);
+/* name must be lower-cased */
+void spool_replace_header(const char *name, char *newvalue, hdrcache_t cache);
+/* remove all instances of lower-cased header 'name' */
+void spool_remove_header(const char *name, hdrcache_t cache);
+/* remove nth instance of lower-cased header 'name'.  1 = first, -1 = last */
+void spool_remove_header_instance(const char *name, int n, hdrcache_t cache);
 int spool_fill_hdrcache(struct protstream *fin, FILE *fout, hdrcache_t cache,
                         const char **skipheaders);
 /* phead must be lower-cased */

--- a/imap/spool.h
+++ b/imap/spool.h
@@ -49,10 +49,10 @@
 typedef struct hdrcache_t *hdrcache_t;
 
 hdrcache_t spool_new_hdrcache(void);
-void spool_prepend_header(char *name, char *body, hdrcache_t cache);
-void spool_prepend_header_raw(char *name, char *body, char *raw, hdrcache_t cache);
-void spool_append_header(char *name, char *body, hdrcache_t cache);
-void spool_append_header_raw(char *name, char *body, char *raw, hdrcache_t cache);
+void spool_prepend_header(const char *name, char *body, hdrcache_t cache);
+void spool_prepend_header_raw(const char *name, char *body, char *raw, hdrcache_t cache);
+void spool_append_header(const char *name, char *body, hdrcache_t cache);
+void spool_append_header_raw(const char *name, char *body, char *raw, hdrcache_t cache);
 #define spool_cache_header(n, b, c) spool_append_header(n, b, c)
 void spool_replace_header(char *name, char *newvalue, hdrcache_t cache);
 /* remove all instances of header 'name' */

--- a/lib/xmalloc.c
+++ b/lib/xmalloc.c
@@ -46,6 +46,7 @@
 #include <string.h>
 #include <sysexits.h>
 #include "xmalloc.h"
+#include "lib/util.h"
 
 
 EXPORTED void *xmalloc(size_t size)
@@ -96,6 +97,15 @@ EXPORTED char *xstrdup(const char* str)
 {
     char *p = xmalloc(strlen(str)+1);
     strcpy(p, str);
+    return p;
+}
+
+EXPORTED char *xstrduplcase(const char* str) {
+    char *p = xmalloc(strlen(str)+1);
+    int i;
+    for (i = 0; str[i]; i++)
+        p[i] = TOLOWER(str[i]);
+    p[i] = '\0';
     return p;
 }
 

--- a/lib/xmalloc.h
+++ b/lib/xmalloc.h
@@ -56,6 +56,7 @@ extern void *xcalloc(size_t nmemb, size_t size);
 extern void *xrealloc(void *ptr, size_t size);
 extern void *xzrealloc(void *ptr, size_t orig_size, size_t new_size);
 extern char *xstrdup(const char *str);
+extern char *xstrduplcase(const char *str);
 extern char *xstrdupnull(const char *str);
 extern char *xstrdupsafe(const char *str);
 extern char *xstrndup(const char *str, size_t len);

--- a/sieve/sieve_interface.h
+++ b/sieve/sieve_interface.h
@@ -79,7 +79,7 @@ typedef int sieve_get_headersection(void *message_context,
 typedef int sieve_add_header(void *message_context,
                              const char *header, const char *contents, int index);
 typedef int sieve_delete_header(void *message_context,
-                                const char *header, int index);
+                                const char *header /* is lower-cased */, int index);
 typedef int sieve_get_fname(void *message_context, const char **fname);
 typedef int sieve_get_envelope(void *message_context,
                                const char *field,

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -203,14 +203,13 @@ static int deleteheader(void *mc, const char *head, int index)
     message_data_t *m = (message_data_t *) mc;
 
     if (head == NULL) return SIEVE_FAIL;
-
     if (!index) {
         printf("removing all headers '%s'\n", head);
-        spool_remove_header(xstrdup(head), m->cache);
+        spool_remove_header(head, m->cache);
     }
     else {
         printf("removing header '%s[%d]'\n", head, index);
-        spool_remove_header_instance(xstrdup(head), index, m->cache);
+        spool_remove_header_instance(head , index, m->cache);
     }
 
     return SIEVE_OK;

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -182,15 +182,17 @@ static int addheader(void *mc, const char *head, const char *body, int index)
     message_data_t *m = (message_data_t *) mc;
 
     if (head == NULL || body == NULL) return SIEVE_FAIL;
+    char *lcasedhead = xstrduplcase(head);
 
     if (index < 0) {
         printf("appending header '%s: %s'\n", head, body);
-        spool_append_header(xstrdup(head), xstrdup(body), m->cache);
+        spool_append_header(lcasedhead, xstrdup(body), m->cache);
     }
     else {
         printf("prepending header '%s: %s'\n", head, body);
-        spool_prepend_header(xstrdup(head), xstrdup(body), m->cache);
+        spool_prepend_header(lcasedhead, xstrdup(body), m->cache);
     }
+    free(lcasedhead);
 
     return SIEVE_OK;
 }

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -144,20 +144,16 @@ static int getenvelope(void *mc, const char *field, const char ***contents)
 static int getheader(void *v, const char *phead, const char ***body)
 {
     message_data_t *m = (message_data_t *) v;
-
-    *body = NULL;
+    char *lcasedhead = xstrduplcase(phead);
 
     if (!m->cache_full) {
         fill_cache(m);
     }
 
-    *body = spool_getheader(m->cache, phead);
+    *body = spool_getheader(m->cache, lcasedhead);
+    free(lcasedhead);
 
-    if (*body) {
-        return SIEVE_OK;
-    } else {
-        return SIEVE_FAIL;
-    }
+    return *body ? SIEVE_OK : SIEVE_FAIL;
 }
 
 static void getheaders_cb(const char *name, const char *value,

--- a/sieve/test_mailbox.c
+++ b/sieve/test_mailbox.c
@@ -176,14 +176,16 @@ static int addheader(void *mc, const char *head, const char *body, int index)
 
     if (head == NULL || body == NULL) return SIEVE_FAIL;
 
+    char *lcasedhead = xstrduplcase(head);
     if (index < 0) {
         printf("appending header '%s: %s'\n", head, body);
-        spool_append_header(xstrdup(head), xstrdup(body), m->cache);
+        spool_append_header(lcasedhead, xstrdup(body), m->cache);
     }
     else {
         printf("prepending header '%s: %s'\n", head, body);
-        spool_prepend_header(xstrdup(head), xstrdup(body), m->cache);
+        spool_prepend_header(lcasedhead, xstrdup(body), m->cache);
     }
+    free(lcasedhead);
 
     return SIEVE_OK;
 }

--- a/sieve/test_mailbox.c
+++ b/sieve/test_mailbox.c
@@ -137,20 +137,16 @@ static int getenvelope(void *mc, const char *field, const char ***contents)
 static int getheader(void *v, const char *phead, const char ***body)
 {
     message_data_t *m = (message_data_t *) v;
-
-    *body = NULL;
+    char *lcasedhead = xstrduplcase(phead);
 
     if (!m->cache_full) {
         fill_cache(m);
     }
 
-    *body = spool_getheader(m->cache, phead);
+    *body = spool_getheader(m->cache, lcasedhead);
+    free(lcasedhead);
 
-    if (*body) {
-        return SIEVE_OK;
-    } else {
-        return SIEVE_FAIL;
-    }
+    return *body ? SIEVE_OK : SIEVE_FAIL;
 }
 
 static void getheaders_cb(const char *name, const char *value,

--- a/sieve/test_mailbox.c
+++ b/sieve/test_mailbox.c
@@ -199,11 +199,11 @@ static int deleteheader(void *mc, const char *head, int index)
 
     if (!index) {
         printf("removing all headers '%s'\n", head);
-        spool_remove_header(xstrdup(head), m->cache);
+        spool_remove_header(head, m->cache);
     }
     else {
         printf("removing header '%s[%d]'\n", head, index);
-        spool_remove_header_instance(xstrdup(head), index, m->cache);
+        spool_remove_header_instance(head, index, m->cache);
     }
 
     return SIEVE_OK;


### PR DESCRIPTION
* introduce xstrduplcase(), which is faster than lcase(xstrdup())
* make sure the header names passed to spool_getheader(), spool_append_header(), spool_prepend_header(), spool_replace_header() are lower cased, so that the function does not have to make a copy of the parameter, lower-case it, use it, and free() the copy
* make sure the header names passed do spool_remove_header() are lower-cased and spool_remove_header() does not free() the header name.  In turn, the caller does not have to duplicatethe header name, before passing it to the function.