### PR TITLE
imap/spool.c: reduce amount of xstrdup() calls (3.0)

### DIFF
--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -287,8 +287,10 @@ static void test_comparator(void)
 static int getheader(void *mc, const char *name, const char ***body)
 {
     sieve_test_message_t *msg = (sieve_test_message_t *)mc;
+    char *lcasename = xstrduplcase(name);
 
-    *body = spool_getheader(msg->headers, name);
+    *body = spool_getheader(msg->headers, lcasename);
+    free(lcasename);
     if (!*body)
         return SIEVE_FAIL;
     return SIEVE_OK;

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -20,36 +20,38 @@
 #define HRECEIVED1  "from mail.quux.com (mail.quux.com [10.0.0.1]) by mail.gmail.com (Software); " FIRST_RX
 #define HRECEIVED2  "from mail.bar.com (mail.bar.com [10.0.0.1]) by mail.quux.com (Software); " SECOND_RX
 #define HRECEIVED3  "from mail.fastmail.fm (mail.fastmail.fm [10.0.0.1]) by mail.bar.com (Software); " THIRD_RX
+#define SPOOL_GETHEADER(cache, header) lcasedheader = xstrduplcase(header); val = spool_getheader(cache, lcasedheader); free(lcasedheader);
 
 static void test_simple(void)
 {
     hdrcache_t cache;
     const char **val;
+    char *lcasedheader;
 
     cache = spool_new_hdrcache();
     CU_ASSERT_PTR_NOT_NULL(cache);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NULL(val);
 
     spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
@@ -62,37 +64,37 @@ static void test_simple(void)
     spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED2), cache);
     spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED3), cache);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "To");
+    SPOOL_GETHEADER(cache, "To");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HTO);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "Subject");
+    SPOOL_GETHEADER(cache, "Subject");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HSUBJECT);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "message-id");
+    SPOOL_GETHEADER(cache, "message-id");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "received");
+    SPOOL_GETHEADER(cache, "received");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HRECEIVED1);
     CU_ASSERT_STRING_EQUAL(val[1], HRECEIVED2);
@@ -118,6 +120,7 @@ static void test_fill(void)
 
     hdrcache_t cache;
     const char **val;
+    char *lcasedheader;
     int fd;
     char tempfile[32];
     int r;
@@ -146,37 +149,37 @@ static void test_fill(void)
     r = spool_fill_hdrcache(pin, fout, cache, NULL);
     CU_ASSERT_EQUAL(r, 0);
 
-    val = spool_getheader(cache, "Nonesuch");
+    SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "fRoM");
+    SPOOL_GETHEADER(cache, "fRoM");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
-    val = spool_getheader(cache, "from");
+    SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "To");
+    SPOOL_GETHEADER(cache, "To");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HTO);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "Subject");
+    SPOOL_GETHEADER(cache, "Subject");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HSUBJECT);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "message-id");
+    SPOOL_GETHEADER(cache, "message-id");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    val = spool_getheader(cache, "received");
+    SPOOL_GETHEADER(cache, "received");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HRECEIVED1);
     CU_ASSERT_STRING_EQUAL(val[1], HRECEIVED2);
@@ -249,6 +252,7 @@ static void test_bz3386(void)
     char body[128];
     char body2[128];    /* use a different buffer Just In Case */
     const char **val;
+    char *lcasedheader;
 
     cache = spool_new_hdrcache();
     CU_ASSERT_PTR_NOT_NULL(cache);
@@ -264,7 +268,7 @@ static void test_bz3386(void)
     for (i = 0 ; i < N ; i++) {
         snprintf(name, sizeof(name), "X-Foo-%d-%c", i, 'A'+(i%26));
         snprintf(body2, sizeof(body2), "value %d %c", i, 'A'+(i%26));
-        val = spool_getheader(cache, name);
+        SPOOL_GETHEADER(cache, name);
         CU_ASSERT_PTR_NOT_NULL(val);
         CU_ASSERT_STRING_EQUAL(val[0], body2);
         CU_ASSERT_PTR_NULL(val[1]);
@@ -283,22 +287,23 @@ static void test_replace(void)
 #define FOOBAR4     "Foo and Drug Administration"
     hdrcache_t cache;
     const char **val;
+    char *lcasedheader;
 
     cache = spool_new_hdrcache();
     CU_ASSERT_PTR_NOT_NULL(cache);
 
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NULL(val);
 
     /* replace a single line */
     spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
     spool_replace_header(xstrdup("From"), xstrdup(HFROM2), cache);
-    val = spool_getheader(cache, "From");
+    SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM2);
     CU_ASSERT_PTR_NULL(val[1]);
@@ -307,7 +312,7 @@ static void test_replace(void)
     spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR1), cache);
     spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR2), cache);
     spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR3), cache);
-    val = spool_getheader(cache, "X-FooBar");
+    SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR1);
     CU_ASSERT_STRING_EQUAL(val[1], FOOBAR2);
@@ -315,7 +320,7 @@ static void test_replace(void)
     CU_ASSERT_PTR_NULL(val[3]);
 
     spool_replace_header(xstrdup("X-FooBar"), xstrdup(FOOBAR4), cache);
-    val = spool_getheader(cache, "X-FooBar");
+    SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR4);
     CU_ASSERT_PTR_NULL(val[1]);

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -304,7 +304,7 @@ static void test_replace(void)
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    spool_replace_header(xstrdup("From"), xstrdup(HFROM2), cache);
+    spool_replace_header("from", xstrdup(HFROM2), cache);
     SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM2);
@@ -321,7 +321,7 @@ static void test_replace(void)
     CU_ASSERT_STRING_EQUAL(val[2], FOOBAR3);
     CU_ASSERT_PTR_NULL(val[3]);
 
-    spool_replace_header(xstrdup("X-FooBar"), xstrdup(FOOBAR4), cache);
+    spool_replace_header("x-foobar", xstrdup(FOOBAR4), cache);
     SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR4);

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -40,7 +40,7 @@ static void test_simple(void)
     SPOOL_GETHEADER(cache, "from");
     CU_ASSERT_PTR_NULL(val);
 
-    spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
+    spool_cache_header("from", xstrdup(HFROM), cache);
     SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
     SPOOL_GETHEADER(cache, "From");
@@ -56,13 +56,13 @@ static void test_simple(void)
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
     CU_ASSERT_PTR_NULL(val[1]);
 
-    spool_cache_header(xstrdup("To"), xstrdup(HTO), cache);
-    spool_cache_header(xstrdup("Date"), xstrdup(HDATE), cache);
-    spool_cache_header(xstrdup("Subject"), xstrdup(HSUBJECT), cache);
-    spool_cache_header(xstrdup("Message-ID"), xstrdup(HMESSAGEID), cache);
-    spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED1), cache);
-    spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED2), cache);
-    spool_cache_header(xstrdup("Received"), xstrdup(HRECEIVED3), cache);
+    spool_cache_header("to", xstrdup(HTO), cache);
+    spool_cache_header("date", xstrdup(HDATE), cache);
+    spool_cache_header("subject", xstrdup(HSUBJECT), cache);
+    spool_cache_header("message-id", xstrdup(HMESSAGEID), cache);
+    spool_cache_header("received", xstrdup(HRECEIVED1), cache);
+    spool_cache_header("received", xstrdup(HRECEIVED2), cache);
+    spool_cache_header("received", xstrdup(HRECEIVED3), cache);
 
     SPOOL_GETHEADER(cache, "Nonesuch");
     CU_ASSERT_PTR_NULL(val);
@@ -260,7 +260,9 @@ static void test_bz3386(void)
     for (i = 0 ; i < N ; i++) {
         snprintf(name, sizeof(name), "X-Foo-%d-%c", i, 'A'+(i%26));
         snprintf(body, sizeof(body), "value %d %c", i, 'A'+(i%26));
-        spool_cache_header(xstrdup(name), xstrdup(body), cache);
+        char *temp = xstrduplcase(name);
+        spool_cache_header(temp, xstrdup(body), cache);
+        free (temp);
     }
 
     strcpy(body, "Old Buffer");
@@ -296,7 +298,7 @@ static void test_replace(void)
     CU_ASSERT_PTR_NULL(val);
 
     /* replace a single line */
-    spool_cache_header(xstrdup("From"), xstrdup(HFROM), cache);
+    spool_cache_header("from", xstrdup(HFROM), cache);
     SPOOL_GETHEADER(cache, "From");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], HFROM);
@@ -309,9 +311,9 @@ static void test_replace(void)
     CU_ASSERT_PTR_NULL(val[1]);
 
     /* replace multiple lines with one */
-    spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR1), cache);
-    spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR2), cache);
-    spool_cache_header(xstrdup("X-FooBar"), xstrdup(FOOBAR3), cache);
+    spool_cache_header("x-foobar", xstrdup(FOOBAR1), cache);
+    spool_cache_header("x-foobar", xstrdup(FOOBAR2), cache);
+    spool_cache_header("x-foobar", xstrdup(FOOBAR3), cache);
     SPOOL_GETHEADER(cache, "X-FooBar");
     CU_ASSERT_PTR_NOT_NULL(val);
     CU_ASSERT_STRING_EQUAL(val[0], FOOBAR1);

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -182,7 +182,7 @@ done:
 static int meth_post_applepush(struct transaction_t *txn, void *params)
 {
     /* Check Content-Type */
-    const char **hdr = spool_getheader(txn->req_hdrs, "Content-Type");
+    const char **hdr = spool_getheader(txn->req_hdrs, "content-type");
 
     if (hdr && is_mediatype("application/x-www-form-urlencoded", hdr[0])) {
         /* Read body */

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -7506,7 +7506,7 @@ int caldav_store_resource(struct transaction_t *txn, icalcomponent *ical,
             buf_printf(&txn->buf, "<%s>", organizer);
             mimehdr = charset_encode_mimeheader(buf_cstring(&txn->buf),
                                                 buf_len(&txn->buf));
-            spool_replace_header(xstrdup("From"), mimehdr, txn->req_hdrs);
+            spool_replace_header("from", mimehdr, txn->req_hdrs);
             buf_reset(&txn->buf);
         }
     }
@@ -7522,22 +7522,22 @@ int caldav_store_resource(struct transaction_t *txn, icalcomponent *ical,
     prop = icalcomponent_get_first_property(comp, ICAL_SUMMARY_PROPERTY);
     if (prop) {
         mimehdr = charset_encode_mimeheader(icalproperty_get_summary(prop), 0);
-        spool_replace_header(xstrdup("Subject"), mimehdr, txn->req_hdrs);
+        spool_replace_header("subject", mimehdr, txn->req_hdrs);
     }
-    else spool_replace_header(xstrdup("Subject"),
+    else spool_replace_header("subject",
                             xstrdup(icalcomponent_kind_to_string(kind)),
                             txn->req_hdrs);
 
     if (schedule_address) {
         mimehdr = charset_encode_mimeheader(schedule_address, 0);
-        spool_replace_header(xstrdup("X-Schedule-User-Address"),
+        spool_replace_header("x-schedule-user-address",
                              mimehdr, txn->req_hdrs);
     }
 
     time_to_rfc822(icaltime_as_timet_with_zone(icalcomponent_get_dtstamp(comp),
                                                utc_zone),
                    datestr, sizeof(datestr));
-    spool_replace_header(xstrdup("Date"), xstrdup(datestr), txn->req_hdrs);
+    spool_replace_header("date", xstrdup(datestr), txn->req_hdrs);
 
     buf_reset(&txn->buf);
 
@@ -7548,7 +7548,7 @@ int caldav_store_resource(struct transaction_t *txn, icalcomponent *ical,
     else {
         buf_printf(&txn->buf, "<%s@%s>", uid, config_servername);
     }
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_setcstr(&txn->buf, ICALENDAR_CONTENT_TYPE);
@@ -7557,16 +7557,16 @@ int caldav_store_resource(struct transaction_t *txn, icalcomponent *ical,
                    icalproperty_method_to_string(meth));
     }
     buf_printf(&txn->buf, "; component=%s", icalcomponent_kind_to_string(kind));
-    spool_replace_header(xstrdup("Content-Type"),
+    spool_replace_header("content-type",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_printf(&txn->buf, "attachment;\r\n\tfilename=\"%s\"", resource);
     if (sched_tag) buf_printf(&txn->buf, ";\r\n\tschedule-tag=%s", sched_tag);
     if (tzbyref) buf_printf(&txn->buf, ";\r\n\ttz-by-ref=true");
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
-    spool_remove_header(xstrdup("Content-Description"), txn->req_hdrs);
+    spool_remove_header("content-description", txn->req_hdrs);
 
     /* Store the resource */
     ret = dav_store_resource(txn, icalcomponent_as_ical_string(ical), 0,

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -930,7 +930,7 @@ static int caldav_check_precond(struct transaction_t *txn,
     if (!(precond == HTTP_OK || precond == HTTP_PARTIAL)) return precond;
 
     /* Per RFC 6638, check Schedule-Tag */
-    if ((hdr = spool_getheader(txn->req_hdrs, "If-Schedule-Tag-Match"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "if-schedule-tag-match"))) {
         /* Special case for Apple 'If-Schedule-Tag-Match:' with no value
          * and also no schedule tag on the record - let that match */
         if (cdata && !stag && !hdr[0][0]) return precond;
@@ -1043,7 +1043,7 @@ static int _scheduling_enabled(struct transaction_t *txn,
     if (!strcasecmp(buf_cstring(&buf), "F"))
         is_enabled = 0;
 
-    const char **hdr = spool_getheader(txn->req_hdrs, "Scheduling-Enabled");
+    const char **hdr = spool_getheader(txn->req_hdrs, "scheduling-enabled");
     if (hdr && !strcasecmp(hdr[0], "F"))
         is_enabled = 0;
 
@@ -1275,7 +1275,7 @@ static void get_schedule_addresses(struct transaction_t *txn,
     struct buf buf = BUF_INITIALIZER;
 
     /* allow override of schedule-address per-message (FM specific) */
-    const char **hdr = spool_getheader(txn->req_hdrs, "Schedule-Address");
+    const char **hdr = spool_getheader(txn->req_hdrs, "schedule-address");
 
     if (hdr) {
         if (!strncasecmp(hdr[0], "mailto:", 7))
@@ -1372,7 +1372,7 @@ static int caldav_delete_cal(struct transaction_t *txn,
             if (_scheduling_enabled(txn, mailbox))
                 sched_request(userid, schedule_address, ical, NULL);
         }
-        else if (!(hdr = spool_getheader(txn->req_hdrs, "Schedule-Reply")) ||
+        else if (!(hdr = spool_getheader(txn->req_hdrs, "schedule-reply")) ||
                  strcasecmp(hdr[0], "F")) {
             /* Attendee scheduling object resource */
             schedule_address = xstrdupnull(strarray_nth(&schedule_addresses, 0));
@@ -1424,7 +1424,7 @@ static int export_calendar(struct transaction_t *txn)
 
     /* Check requested MIME type:
        1st entry in caldav_mime_types array MUST be default MIME type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+    if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
         mime = get_accept_type(hdr, caldav_mime_types);
     else mime = caldav_mime_types;
     if (!mime) return HTTP_NOT_ACCEPTABLE;
@@ -2109,7 +2109,7 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
         int ret = HTTP_CONTINUE;
 
         /* Check for optional CalDAV-Timezones header */
-        hdr = spool_getheader(txn->req_hdrs, "CalDAV-Timezones");
+        hdr = spool_getheader(txn->req_hdrs, "caldav-timezones");
         if (hdr && !strcmp(hdr[0], "T")) need_tz = 1;
 
         if (cdata->comp_flags.tzbyref) {
@@ -2331,7 +2331,7 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
     if ((return_rep = (get_preferences(txn) & PREFER_REP))) {
         /* Check requested MIME type:
            1st entry in gparams->mime_types array MUST be default MIME type */
-        if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+        if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
             mime = get_accept_type(hdr, caldav_mime_types);
         else mime = caldav_mime_types;
         if (!mime) return HTTP_NOT_ACCEPTABLE;
@@ -2557,7 +2557,7 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
         }
         buf_reset(&txn->buf);
 
-        if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
+        if ((hdr = spool_getheader(txn->req_hdrs, "content-type"))) {
             param = icalproperty_get_first_parameter(aprop,
                                                      ICAL_FMTTYPE_PARAMETER);
             if (param) icalparameter_set_fmttype(param, *hdr);
@@ -2754,7 +2754,7 @@ static int caldav_post_outbox(struct transaction_t *txn, int rights)
     struct caldav_sched_param sparam;
 
     /* Check Content-Type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-type"))) {
         for (mime = caldav_mime_types; mime->content_type; mime++) {
             if (is_mediatype(mime->content_type, hdr[0])) break;
         }
@@ -4083,7 +4083,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
 
             if (!strncasecmp(organizer, "mailto:", 7)) organizer += 7;
 
-            if (cdata->organizer && !spool_getheader(txn->req_hdrs, "Allow-Organizer-Change")) {
+            if (cdata->organizer && !spool_getheader(txn->req_hdrs, "allow-organizer-change")) {
                 /* Don't allow ORGANIZER to be changed */
                 if (strcmp(cdata->organizer, organizer)) {
                     txn->error.desc = "Can not change organizer address";
@@ -5401,7 +5401,7 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
 
         /* Check for optional CalDAV-Timezones header */
         const char **hdr =
-            spool_getheader(fctx->txn->req_hdrs, "CalDAV-Timezones");
+            spool_getheader(fctx->txn->req_hdrs, "caldav-timezones");
         if (hdr && !strcmp(hdr[0], "T")) need_tz = 1;
         else need_tz = 0;
 
@@ -7287,7 +7287,7 @@ static int report_fb_query(struct transaction_t *txn,
 
     /* Check requested MIME type:
        1st entry in caldav_mime_types array MUST be default MIME type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+    if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
         mime = get_accept_type(hdr, caldav_mime_types);
     else mime = caldav_mime_types;
     if (!mime) return HTTP_NOT_ACCEPTABLE;

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -634,8 +634,8 @@ static int export_addressbook(struct transaction_t *txn)
     struct mime_type_t *mime = NULL;
 
     /* Check requested MIME type:
-       1st entry in caldav_mime_types array MUST be default MIME type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+       1st entry in carddav_mime_types array MUST be default MIME type */
+    if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
         mime = get_accept_type(hdr, carddav_mime_types);
     else mime = carddav_mime_types;
     if (!mime) return HTTP_NOT_ACCEPTABLE;

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -577,30 +577,30 @@ static int store_resource(struct transaction_t *txn,
 
     /* Create and cache RFC 5322 header fields for resource */
     mimehdr = charset_encode_mimeheader(fullname, 0);
-    spool_replace_header(xstrdup("Subject"), mimehdr, txn->req_hdrs);
+    spool_replace_header("subject", mimehdr, txn->req_hdrs);
 
     /* XXX - validate uid for mime safety? */
     if (strchr(uid, '@')) {
-        spool_replace_header(xstrdup("Message-ID"),
+        spool_replace_header("message-id",
                              xstrdup(uid), txn->req_hdrs);
     }
     else {
         assert(!buf_len(&txn->buf));
         buf_printf(&txn->buf, "<%s@%s>", uid, config_servername);
-        spool_replace_header(xstrdup("Message-ID"),
+        spool_replace_header("message-id",
                              buf_release(&txn->buf), txn->req_hdrs);
     }
 
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, "text/vcard; version=%s; charset=utf-8", version);
-    spool_replace_header(xstrdup("Content-Type"),
+    spool_replace_header("content-type",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_printf(&txn->buf, "attachment;\r\n\tfilename=\"%s\"", resource);
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
-    spool_remove_header(xstrdup("Content-Description"), txn->req_hdrs);
+    spool_remove_header("content-description", txn->req_hdrs);
 
     /* Store the resource */
     struct buf *buf = vcard_as_buf(vcard);

--- a/imap/http_client.c
+++ b/imap/http_client.c
@@ -110,7 +110,7 @@ EXPORTED int http_parse_framing(int http2, hdrcache_t hdrs,
     body->max = max_msgsize;
 
     /* Check for Transfer-Encoding */
-    if ((hdr = spool_getheader(hdrs, "Transfer-Encoding"))) {
+    if ((hdr = spool_getheader(hdrs, "transfer-encoding"))) {
         if (http2) {
             *errstr = "Transfer-Encoding not allowed in HTTP/2";
             return HTTP_BAD_REQUEST;
@@ -169,7 +169,7 @@ EXPORTED int http_parse_framing(int http2, hdrcache_t hdrs,
     }
 
     /* Check for Content-Length */
-    else if ((hdr = spool_getheader(hdrs, "Content-Length"))) {
+    else if ((hdr = spool_getheader(hdrs, "content-length"))) {
         if (hdr[1]) {
             *errstr = "Multiple Content-Length header fields";
             return HTTP_BAD_REQUEST;
@@ -390,13 +390,13 @@ EXPORTED int http_read_body(struct protstream *pin, struct protstream *pout,
         if (body->flags & BODY_DECODE) {
             const char **hdr;
 
-            if (!(hdr = spool_getheader(hdrs, "Content-Encoding"))) {
+            if (!(hdr = spool_getheader(hdrs, "content-encoding"))) {
                 /* nothing to see here */
             }
 
 #ifdef HAVE_ZLIB
             else if (!strcasecmp(hdr[0], "deflate")) {
-                const char **ua = spool_getheader(hdrs, "User-Agent");
+                const char **ua = spool_getheader(hdrs, "user-agent");
 
                 /* Try to detect Microsoft's broken deflate */
                 if (ua && strstr(ua[0], "; MSIE "))
@@ -462,7 +462,7 @@ EXPORTED int http_read_response(struct backend *be, unsigned meth,
 
     /* Check connection persistence */
     if (!strncmp(statbuf, "HTTP/1.0 ", 9)) body->flags |= BODY_CLOSE;
-    for (conn = spool_getheader(*hdrs, "Connection"); conn && *conn; conn++) {
+    for (conn = spool_getheader(*hdrs, "connection"); conn && *conn; conn++) {
         tok_t tok =
             TOK_INITIALIZER(*conn, ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
         char *token;

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5592,7 +5592,7 @@ EXPORTED int meth_propfind(struct transaction_t *txn, void *params)
         }
 
         /* Add propfind type to our header cache */
-        spool_cache_header(xstrdup(":type"), xstrdup((const char *) cur->name),
+        spool_cache_header(":type", xstrdup((const char *) cur->name),
                            txn->req_hdrs);
 
         /* Make sure its a known element */
@@ -6097,7 +6097,7 @@ static int send_notification(struct transaction_t *top_txn, xmlDocPtr doc,
         goto done;
     }
 
-    spool_cache_header(xstrdup("Content-Type"),
+    spool_cache_header("content-type",
                        xstrdup(DAVNOTIFICATION_CONTENT_TYPE), txn.req_hdrs);
 
     r = notify_put(&txn, doc, mailbox, resource, webdavdb, 0);
@@ -7932,7 +7932,7 @@ int meth_report(struct transaction_t *txn, void *params)
     if (ret) goto done;
 
     /* Add report type to our header cache */
-    spool_cache_header(xstrdup(":type"), xstrdup((const char *) inroot->name),
+    spool_cache_header(":type", xstrdup((const char *) inroot->name),
                        txn->req_hdrs);
 
     /* Check the report type against our supported list */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4004,7 +4004,7 @@ int meth_copy_move(struct transaction_t *txn, void *params)
     }
 
     /* Replace cached Destination header with just the absolute path */
-    spool_replace_header(xstrdup("Destination"),
+    spool_replace_header("destination",
                          xstrdup(dest_tgt.path), txn->req_hdrs);
 
     /* Check for optional Overwrite header */
@@ -9492,7 +9492,7 @@ static int notify_put(struct transaction_t *txn, void *obj,
         struct dlist *dl, *al;
         xmlAttrPtr attr;
 
-        spool_replace_header(xstrdup("Subject"),
+        spool_replace_header("subject",
                              xstrdup((char *) type->name), txn->req_hdrs);
 
         /* Create a dlist representing type, namespace, and attribute(s) */
@@ -9541,17 +9541,17 @@ static int notify_put(struct transaction_t *txn, void *obj,
 
         dlist_printbuf(dl, 1, &buf);
         dlist_free(&dl);
-        spool_replace_header(xstrdup("Content-Description"),
+        spool_replace_header("content-description",
                              buf_release(&buf), txn->req_hdrs);
     }
 
     buf_reset(&txn->buf);
     buf_printf(&txn->buf, "<%s-%ld@%s>", resource, time(0), config_servername);
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_printf(&txn->buf, "attachment;\r\n\tfilename=\"%s\"", resource);
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     /* Dump XML response tree into a text buffer */

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -136,7 +136,7 @@ static int get_email2uids(struct transaction_t *txn __attribute__((unused)),
     const char **mailboxhdrs;
     const char *mailbox = "Default";
 
-    mailboxhdrs = spool_getheader(txn->req_hdrs, "Mailbox");
+    mailboxhdrs = spool_getheader(txn->req_hdrs, "mailbox");
     if (mailboxhdrs) {
         mailbox = mailboxhdrs[0];
     }
@@ -186,12 +186,12 @@ static int get_uid2groups(struct transaction_t *txn,
     const char **mailboxhdrs;
     const char *mailbox = "Default";
 
-    otheruserhdrs = spool_getheader(txn->req_hdrs, "OtherUser");
+    otheruserhdrs = spool_getheader(txn->req_hdrs, "otheruser");
     if (otheruserhdrs) {
         otheruser = otheruserhdrs[0];
     }
 
-    mailboxhdrs = spool_getheader(txn->req_hdrs, "Mailbox");
+    mailboxhdrs = spool_getheader(txn->req_hdrs, "mailbox");
     if (mailboxhdrs) {
         mailbox = mailboxhdrs[0];
     }
@@ -272,8 +272,8 @@ static int meth_get_db(struct transaction_t *txn,
     char *p;
     mbname_t *mbname = NULL;
 
-    userhdrs = spool_getheader(txn->req_hdrs, "User");
-    keyhdrs = spool_getheader(txn->req_hdrs, "Key");
+    userhdrs = spool_getheader(txn->req_hdrs, "user");
+    keyhdrs = spool_getheader(txn->req_hdrs, "key");
 
     if (!userhdrs) return HTTP_BAD_REQUEST;
     if (!keyhdrs) return HTTP_BAD_REQUEST;

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -412,14 +412,14 @@ static int meth_post_isched(struct transaction_t *txn,
     txn->flags.cc |= CC_NOCACHE;
 
     /* Check iSchedule-Version */
-    if (!(hdr = spool_getheader(txn->req_hdrs, "iSchedule-Version")) ||
+    if (!(hdr = spool_getheader(txn->req_hdrs, "ischedule-version")) ||
         strcmp(hdr[0], "1.0")) {
         txn->error.precond = ISCHED_UNSUPP_VERSION;
         return HTTP_BAD_REQUEST;
     }
 
     /* Check Content-Type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-type"))) {
         for (mime = isched_mime_types; mime->content_type; mime++) {
             if (is_mediatype(mime->content_type, hdr[0])) break;
         }
@@ -430,7 +430,7 @@ static int meth_post_isched(struct transaction_t *txn,
     }
 
     /* Check Originator */
-    if (!(hdr = spool_getheader(txn->req_hdrs, "Originator"))) {
+    if (!(hdr = spool_getheader(txn->req_hdrs, "originator"))) {
         txn->error.precond = ISCHED_ORIG_MISSING;
         return HTTP_BAD_REQUEST;
     }
@@ -441,7 +441,7 @@ static int meth_post_isched(struct transaction_t *txn,
     }
 
     /* Check Recipients */
-    if (!(recipients = spool_getheader(txn->req_hdrs, "Recipient"))) {
+    if (!(recipients = spool_getheader(txn->req_hdrs, "recipient"))) {
         txn->error.precond = ISCHED_RECIP_MISSING;
         return HTTP_BAD_REQUEST;
     }
@@ -467,7 +467,7 @@ static int meth_post_isched(struct transaction_t *txn,
         /* Allow frontends to HTTP auth to backends and use iSchedule */
         authd = 1;
     }
-    else if (!spool_getheader(txn->req_hdrs, "DKIM-Signature")) {
+    else if (!spool_getheader(txn->req_hdrs, "dkim-signature")) {
         txn->error.desc = "No signature";
     }
     else {
@@ -772,7 +772,7 @@ int isched_send(struct caldav_sched_param *sparam, const char *recipient,
         case 302:
         case 307:
         case 308:  /* Redirection */
-            uri = spool_getheader(txn.req_hdrs, "Location")[0];
+            uri = spool_getheader(txn.req_hdrs, "location")[0];
             if (txn.req_body.flags & BODY_CLOSE) {
                 proxy_downserver(be);
                 be = proxy_findserver(buf_cstring(&txn.buf), &http_protocol,

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -1765,7 +1765,7 @@ static int action_get(struct transaction_t *txn)
              mime->content_type && !is_mediatype(mime->content_type, param->s);
              mime++);
     }
-    else if ((hdr = spool_getheader(txn->req_hdrs, "Accept")))
+    else if ((hdr = spool_getheader(txn->req_hdrs, "accept")))
         mime = get_accept_type(hdr, tz_mime_types);
     else mime = tz_mime_types;
 

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -628,19 +628,19 @@ static int webdav_put(struct transaction_t *txn, void *obj,
 
     /* Create and cache RFC 5322 header fields for resource */
     if (filename) {
-        spool_replace_header(xstrdup("Subject"),
+        spool_replace_header("subject",
                              xstrdup(filename), txn->req_hdrs);
-        spool_replace_header(xstrdup("Content-Description"),
+        spool_replace_header("content-description",
                              xstrdup(filename), txn->req_hdrs);
     }
 
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, "<%s@%s>", resource, config_servername);
-    spool_replace_header(xstrdup("Message-ID"),
+    spool_replace_header("message-id",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     buf_printf(&txn->buf, "attachment;\r\n\tfilename=\"%s\"", resource);
-    spool_replace_header(xstrdup("Content-Disposition"),
+    spool_replace_header("content-disposition",
                          buf_release(&txn->buf), txn->req_hdrs);
 
     /* Store the resource */

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -607,7 +607,7 @@ static int webdav_put(struct transaction_t *txn, void *obj,
     }
 
     /* Get filename of attachment */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Disposition"))) {
+    if ((hdr = spool_getheader(txn->req_hdrs, "content-disposition"))) {
         char *dparam;
         tok_t tok;
 

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -321,7 +321,7 @@ static int http2_header_cb(nghttp2_session *session,
 
     if (!txn) return 0;
 
-    my_name = xstrndup((const char *) name, namelen);
+    my_name = lcase(xstrndup((const char *) name, namelen));
     my_value = xstrndup((const char *) value, valuelen);
 
     syslog(LOG_DEBUG, "http2_header_cb(%s: %s)", my_name, my_value);
@@ -345,6 +345,7 @@ static int http2_header_cb(nghttp2_session *session,
     }
 
     spool_cache_header(my_name, my_value, txn->req_hdrs);
+    free (my_name);
 
     return 0;
 }
@@ -1553,7 +1554,7 @@ static int examine_request(struct transaction_t *txn)
         case VER_2:
             /* HTTP/2 - create a Host header from :authority */
             hdr = spool_getheader(txn->req_hdrs, ":authority");
-            spool_cache_header(xstrdup("Host"), xstrdup(hdr[0]), txn->req_hdrs);
+            spool_cache_header("host", xstrdup(hdr[0]), txn->req_hdrs);
             break;
 
         case VER_1_0:
@@ -1565,7 +1566,7 @@ static int examine_request(struct transaction_t *txn)
             }
             else buf_setcstr(&txn->buf, config_servername);
 
-            spool_cache_header(xstrdup("Host"),
+            spool_cache_header("host",
                                xstrdup(buf_cstring(&txn->buf)), txn->req_hdrs);
             buf_reset(&txn->buf);
             break;

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -110,7 +110,9 @@ static int getheader(void *v, const char *phead, const char ***body)
     message_data_t *m = ((deliver_data_t *) v)->m;
 
     if (phead==NULL) return SIEVE_FAIL;
-    *body = msg_getheader(m, phead);
+    char *lcasedhead = xstrduplcase(phead);
+    *body = msg_getheader(m, lcasedhead);
+    free(lcasedhead);
 
     if (*body) {
         return SIEVE_OK;

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -1087,7 +1087,9 @@ char *generate_notify(message_data_t *m)
 
     for (i = 0; notifyheaders[i]; i++) {
         const char *h = notifyheaders[i];
-        body = msg_getheader(m, h);
+        char *lcasedheader = xstrduplcase(h);
+        body = msg_getheader(m, lcasedheader);
+        free (lcasedheader);
         if (body) {
             int j;
 

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -649,7 +649,7 @@ static int savemsg(struct clientdata *cd,
         sprintf(addbody, "<%s%s%s>",
                 rpath, hostname ? "@" : "", hostname ? hostname : "");
         fprintf(f, "Return-Path: %s\r\n", addbody);
-        spool_cache_header(xstrdup("Return-Path"), addbody, m->hdrcache);
+        spool_cache_header("return-path", addbody, m->hdrcache);
     }
 
     /* add a received header */
@@ -700,18 +700,20 @@ static int savemsg(struct clientdata *cd,
         fprintf(f, "%.*s\r\n\t", (int) (fold[i] - p), p);
     }
     fprintf(f, "%s\r\n", p);
-    spool_cache_header(xstrdup("Received"), addbody, m->hdrcache);
+    spool_cache_header("received", addbody, m->hdrcache);
 
     char *sid = xstrdup(session_id());
     fprintf(f, "X-Cyrus-Session-Id: %s\r\n", sid);
-    spool_cache_header(xstrdup("X-Cyrus-Session-Id"), sid, m->hdrcache);
+    spool_cache_header("x-cyrus-session-id", sid, m->hdrcache);
 
     /* add any requested headers */
     if (func->addheaders) {
         struct addheader *h;
         for (h = func->addheaders; h && h->name; h++) {
             fprintf(f, "%s: %s\r\n", h->name, h->body);
-            spool_cache_header(xstrdup(h->name), xstrdup(h->body), m->hdrcache);
+            char *temp = xstrduplcase(h->name);
+            spool_cache_header(temp, xstrdup(h->body), m->hdrcache);
+            free (temp);
         }
     }
 
@@ -737,7 +739,7 @@ static int savemsg(struct clientdata *cd,
         sprintf(m->id, "<cmu-lmtpd-%d-%d-%u@%s>", p, (int) now,
                 msgid_count++, config_servername);
         fprintf(f, "Message-ID: %s\r\n", m->id);
-        spool_cache_header(xstrdup("Message-ID"), xstrdup(m->id), m->hdrcache);
+        spool_cache_header("message-id", xstrdup(m->id), m->hdrcache);
     }
 
     /* get date */
@@ -746,7 +748,7 @@ static int savemsg(struct clientdata *cd,
         addbody = xstrdup(datestr);
         m->date = xstrdup(datestr);
         fprintf(f, "Date: %s\r\n", addbody);
-        spool_cache_header(xstrdup("Date"), addbody, m->hdrcache);
+        spool_cache_header("date", addbody, m->hdrcache);
     }
     else {
         m->date = xstrdup(body[0]);

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3033,7 +3033,7 @@ static void add_header(const char *destname, const char **dest,
         }
         else {
             /* add the new header to the cache */
-            spool_cache_header(xstrdup(destname), newdest, hdrcache);
+            spool_cache_header(destname, newdest, hdrcache);
         }
     } else if (dest) {
         /* no source header, use original dest header */
@@ -3088,13 +3088,13 @@ static int savemsg(message_data_t *m, FILE *f)
     if ((body = spool_getheader(m->hdrcache, "path")) != NULL) {
         /* prepend to the cached path */
         m->path = strconcat(config_servername, "!", body[0], (char *)NULL);
-        spool_replace_header(xstrdup("Path"), xstrdup(m->path), m->hdrcache);
+        spool_replace_header(xstrdup("path"), xstrdup(m->path), m->hdrcache);
     } else {
         /* no path, create one */
         m->path = strconcat(config_servername, "!",
                             nntp_userid ? nntp_userid : "anonymous",
                             (char *)NULL);
-        spool_cache_header(xstrdup("Path"), xstrdup(m->path), m->hdrcache);
+        spool_cache_header("path", xstrdup(m->path), m->hdrcache);
     }
     fprintf(f, "Path: %s\r\n", m->path);
 
@@ -3109,7 +3109,7 @@ static int savemsg(message_data_t *m, FILE *f)
         sprintf(m->id, "<cmu-nntpd-%d-%d-%d@%s>", p, (int) now,
                 post_count++, config_servername);
         fprintf(f, "Message-ID: %s\r\n", m->id);
-        spool_cache_header(xstrdup("Message-ID"), xstrdup(m->id), m->hdrcache);
+        spool_cache_header("message-id", xstrdup(m->id), m->hdrcache);
     }
 
     /* get date */
@@ -3120,7 +3120,7 @@ static int savemsg(message_data_t *m, FILE *f)
         time_to_rfc822(now, datestr, sizeof(datestr));
         m->date = xstrdup(datestr);
         fprintf(f, "Date: %s\r\n", datestr);
-        spool_cache_header(xstrdup("Date"), xstrdup(datestr), m->hdrcache);
+        spool_cache_header("date", xstrdup(datestr), m->hdrcache);
     }
     else {
         m->date = xstrdup(body[0]);
@@ -3162,7 +3162,7 @@ static int savemsg(message_data_t *m, FILE *f)
                     (newsaddheaders & IMAP_ENUM_NEWSADDHEADERS_TO)) {
                     to = groups;
                 }
-                add_header("To", body, to, newspostuser, m->hdrcache, f);
+                add_header("to", body, to, newspostuser, m->hdrcache, f);
 
                 /* add Reply-To: header to spooled message file,
                    optionally adding "post" email addr based on newsgroup */
@@ -3181,7 +3181,7 @@ static int savemsg(message_data_t *m, FILE *f)
                         else replyto = spool_getheader(m->hdrcache, "from");
                     }
                 }
-                add_header("Reply-To", body, replyto, newspostuser,
+                add_header("reply-to", body, replyto, newspostuser,
                            m->hdrcache, f);
             }
         } else {

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3029,7 +3029,7 @@ static void add_header(const char *destname, const char **dest,
 
         if (dest) {
             /* replace the existing cached header */
-            spool_replace_header(xstrdup(destname), newdest, hdrcache);
+            spool_replace_header(destname, newdest, hdrcache);
         }
         else {
             /* add the new header to the cache */
@@ -3088,7 +3088,7 @@ static int savemsg(message_data_t *m, FILE *f)
     if ((body = spool_getheader(m->hdrcache, "path")) != NULL) {
         /* prepend to the cached path */
         m->path = strconcat(config_servername, "!", body[0], (char *)NULL);
-        spool_replace_header(xstrdup("path"), xstrdup(m->path), m->hdrcache);
+        spool_replace_header("path", xstrdup(m->path), m->hdrcache);
     } else {
         /* no path, create one */
         m->path = strconcat(config_servername, "!",

--- a/imap/spool.c
+++ b/imap/spool.c
@@ -247,23 +247,20 @@ static int parseheader(struct protstream *fin, FILE *fout,
     /* Note: xstrdup()ing the string ensures we return
      * a minimal length string with no allocation slack
      * at the end */
-    if (headname != NULL) *headname = xstrdup(name.s);
+    if (headname != NULL) *headname = xstrduplcase(name.s);
     if (contents != NULL) *contents = xstrdup(body.s);
 
     return 0;
 }
 
-EXPORTED void spool_cache_header(char *name, char *body, hdrcache_t cache)
+EXPORTED void spool_cache_header(const char *name, char *body, hdrcache_t cache)
 {
     strarray_t *contents;
-
-    lcase(name);
 
     contents = (strarray_t *)hash_lookup(name, cache);
     if (!contents)
         contents = hash_insert(name, strarray_new(), cache);
     strarray_appendm(contents, body);
-    free(name);
 }
 
 EXPORTED void spool_replace_header(char *name, char *body, hdrcache_t cache)

--- a/imap/spool.c
+++ b/imap/spool.c
@@ -263,11 +263,9 @@ EXPORTED void spool_cache_header(const char *name, char *body, hdrcache_t cache)
     strarray_appendm(contents, body);
 }
 
-EXPORTED void spool_replace_header(char *name, char *body, hdrcache_t cache)
+EXPORTED void spool_replace_header(const char *name, char *body, hdrcache_t cache)
 {
     strarray_t *contents;
-
-    lcase(name);
 
     contents = (strarray_t *)hash_lookup(name, cache);
     if (!contents)
@@ -275,18 +273,14 @@ EXPORTED void spool_replace_header(char *name, char *body, hdrcache_t cache)
     else
         strarray_truncate(contents, 0);
     strarray_appendm(contents, body);
-    free(name);
 }
 
-EXPORTED void spool_remove_header(char *name, hdrcache_t cache)
+EXPORTED void spool_remove_header(const char *name, hdrcache_t cache)
 {
     strarray_t *contents;
 
-    lcase(name);
-
     contents = (strarray_t *)hash_del(name, cache);
     if (contents) strarray_free(contents);
-    free(name);
 }
 
 EXPORTED int spool_fill_hdrcache(struct protstream *fin, FILE *fout, hdrcache_t cache,

--- a/imap/spool.c
+++ b/imap/spool.c
@@ -319,18 +319,12 @@ EXPORTED int spool_fill_hdrcache(struct protstream *fin, FILE *fout, hdrcache_t 
 
 EXPORTED const char **spool_getheader(hdrcache_t cache, const char *phead)
 {
-    char *head;
     strarray_t *contents;
 
     assert(cache && phead);
 
-    head = xstrdup(phead);
-    lcase(head);
-
     /* check the cache */
-    contents = (strarray_t *)hash_lookup(head, cache);
-
-    free(head);
+    contents = (strarray_t *) hash_lookup(phead, cache);
 
     return contents ? (const char **)contents->data : NULL;
 }

--- a/imap/spool.h
+++ b/imap/spool.h
@@ -51,8 +51,8 @@ typedef hash_table *hdrcache_t;
 
 hdrcache_t spool_new_hdrcache(void);
 void spool_cache_header(const char *name, char *body, hdrcache_t cache);
-void spool_replace_header(char *name, char *newvalue, hdrcache_t cache);
-void spool_remove_header(char *name, hdrcache_t cache);
+void spool_replace_header(const char *name, char *newvalue, hdrcache_t cache);
+void spool_remove_header(const char *name, hdrcache_t cache);
 int spool_fill_hdrcache(struct protstream *fin, FILE *fout, hdrcache_t cache,
                         const char **skipheaders);
 const char **spool_getheader(hdrcache_t cache, const char *phead);

--- a/imap/spool.h
+++ b/imap/spool.h
@@ -50,7 +50,7 @@
 typedef hash_table *hdrcache_t;
 
 hdrcache_t spool_new_hdrcache(void);
-void spool_cache_header(char *name, char *body, hdrcache_t cache);
+void spool_cache_header(const char *name, char *body, hdrcache_t cache);
 void spool_replace_header(char *name, char *newvalue, hdrcache_t cache);
 void spool_remove_header(char *name, hdrcache_t cache);
 int spool_fill_hdrcache(struct protstream *fin, FILE *fout, hdrcache_t cache,

--- a/lib/xmalloc.c
+++ b/lib/xmalloc.c
@@ -45,6 +45,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "xmalloc.h"
+#include "lib/util.h"
 
 #include "exitcodes.h"
 
@@ -94,6 +95,15 @@ EXPORTED char *xstrdup(const char* str)
 {
     char *p = xmalloc(strlen(str)+1);
     strcpy(p, str);
+    return p;
+}
+
+EXPORTED char *xstrduplcase(const char* str) {
+    char *p = xmalloc(strlen(str)+1);
+    int i;
+    for (i = 0; str[i]; i++)
+        p[i] = TOLOWER(str[i]);
+    p[i] = '\0';
     return p;
 }
 

--- a/lib/xmalloc.h
+++ b/lib/xmalloc.h
@@ -53,6 +53,7 @@ extern void *xzmalloc (size_t size);
 extern void *xcalloc (size_t nmemb, size_t size);
 extern void *xrealloc (void *ptr, size_t size);
 extern char *xstrdup (const char *str);
+extern char *xstrduplcase (const char *str);
 extern char *xstrdupnull (const char *str);
 extern char *xstrdupsafe (const char *str);
 extern char *xstrndup (const char *str, size_t len);

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -243,7 +243,7 @@ static int getheader(void *v, const char *phead, const char ***body)
 {
     message_data_t *m = (message_data_t *) v;
     strarray_t *contents;
-    char *head;
+    char *lcasedhead = xstrduplcase(phead);
 
     *body = NULL;
 
@@ -251,16 +251,12 @@ static int getheader(void *v, const char *phead, const char ***body)
         fill_cache(m);
     }
 
-    /* copy header parameter so we can mangle it */
-    head = xstrdup(phead);
-    lcase(head);
-
     /* check the cache */
-    contents = (strarray_t *)hash_lookup(head, &m->cache);
+    contents = (strarray_t *)hash_lookup(lcasedhead, &m->cache);
     if (contents)
         *body = (const char **) contents->data;
 
-    free(head);
+    free(lcasedhead);
 
     if (*body) {
         return SIEVE_OK;


### PR DESCRIPTION
* Introduce xstrduplcase(), which is faster than lcase(xstrdup())

* Make sure the header names passed to spool_getheader()  are lower cased, so that the function does not have to make a copy of the parameter, lower-case it, use it, and free() the copy

* Make sure the header names passed do spool_cache_header(), spool_remove_header() and spool_replace_header() are lower-cased and spool_remove_header() does not free() the header name. In turn, the caller does not have to duplicate the header name, before passing it to the functions.