### PR TITLE
imap/icu_wrap.cpp: C++ tweaks

### DIFF
--- a/imap/icu_wrap.cpp
+++ b/imap/icu_wrap.cpp
@@ -57,21 +57,18 @@ extern "C" char *icu_getIDForWindowsID(const char *id)
 {
 #ifdef HAVE_ICU
     UErrorCode status = U_ZERO_ERROR;
-    UConverter *utf8cnv = NULL;
-    icu::UnicodeString uWinID, uID;
+    icu::UnicodeString uID;
     std::string str;
-    const char *tzid;
 
-    utf8cnv = ucnv_open("utf-8", &status);
+    UConverter *utf8cnv = ucnv_open("utf-8", &status);
     if (U_FAILURE(status)) return NULL;
-    uWinID = icu::UnicodeString(id, -1, utf8cnv, status);
+    icu::UnicodeString uWinID {id, -1, utf8cnv, status};
     ucnv_close(utf8cnv);
 
     icu::TimeZone::getIDForWindowsID(uWinID, NULL, uID, status);
     uID.toUTF8String(str);
-    tzid = str.c_str();
 
-    if (tzid && *tzid) return xstrdup(tzid);
+    if (!str.empty()) return xstrdup(str.c_str());
 #endif
 
     if (!strcasecmp(id, "Mid-Atlantic Standard Time")) {


### PR DESCRIPTION
The result of string.c_str() cannot be NULL, so
  tzid = str.c_str()
  if (tzid)
does nothing.

Remove variable char *tzid, as it is not really needed.

Call only one constructor for uWinID.

There is no point to assign NULL to utf8cnv, as the value is never read.