### PR TITLE
imap/xapian.cpp: more C++ tweaks

### DIFF
--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -1235,7 +1235,7 @@ static void optimise_nodes(struct opnode *parent, struct opnode *on)
     }
 }
 
-static xapian_query_t *opnode_to_query(const xapian_db_t *db, struct opnode *on, int opts)
+static xapian_query_t *opnode_to_query(xapian_db_t *db, struct opnode *on, int opts)
 {
     struct opnode *child;
     xapian_query_t *qq = NULL;
@@ -3760,13 +3760,10 @@ static int delete_user(const char *userid)
     char *activename = activefile_fname(mboxname);
     struct mappedfile *activefile = NULL;
     struct mboxlock *xapiandb_namelock = NULL;
-    char *namelock_fname = NULL;
-    int r = 0;
-
 
     /* Get an exclusive namelock */
-    namelock_fname = xapiandb_namelock_fname_from_userid(userid);
-    r = mboxname_lock(namelock_fname, &xapiandb_namelock, LOCK_EXCLUSIVE);
+    char *namelock_fname = xapiandb_namelock_fname_from_userid(userid);
+    int r = mboxname_lock(namelock_fname, &xapiandb_namelock, LOCK_EXCLUSIVE);
     if (r) {
         syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
                namelock_fname);

--- a/imap/xapian_wrap.h
+++ b/imap/xapian_wrap.h
@@ -74,7 +74,7 @@ extern int xapian_dbw_is_indexed(xapian_dbw_t *dbw, const struct message_guid *g
 /* query-side interface */
 extern int xapian_db_open(const char **paths, xapian_db_t **dbp);
 extern void xapian_db_close(xapian_db_t *);
-extern xapian_query_t *xapian_query_new_match(const xapian_db_t *, int num_part, const char *term);
+extern xapian_query_t *xapian_query_new_match(xapian_db_t *, int num_part, const char *term);
 extern xapian_query_t *xapian_query_new_compound(const xapian_db_t *, int is_or, xapian_query_t **children, int n);
 extern xapian_query_t *xapian_query_new_not(const xapian_db_t *, xapian_query_t *);
 extern xapian_query_t *xapian_query_new_has_doctype(const xapian_db_t *, char doctype, xapian_query_t *);


### PR DESCRIPTION
* xapian_dbw’s members stemmer and stopper are removed.  The former was not used.  The value of the latter was always nullptr and this value is passed to dbw→term_generator.set_stopper().

* set the visibility to "hidden" to internal symbols

* remove the word “struct” for defining a type, as it is not necessary in C++.