### PR TITLE
mboxname: uniquer mboxname_todeleted suffixes

### DIFF
--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1958,7 +1958,7 @@ EXPORTED void mboxname_todeleted(const char *name, char *result, int withtime)
         struct timeval tv;
         gettimeofday( &tv, NULL );
         snprintf(result+domainlen, MAX_MAILBOX_BUFFER-domainlen, "%s.%s.%X",
-                 deletedprefix, name+domainlen, (unsigned) tv.tv_sec);
+                 deletedprefix, name+domainlen, (unsigned) (tv.tv_sec ^ tv.tv_usec));
     } else {
         snprintf(result+domainlen, MAX_MAILBOX_BUFFER-domainlen, "%s.%s",
                  deletedprefix, name+domainlen);


### PR DESCRIPTION
If the same mboxname gets deleted twice in the same second (i.e. delete-create-delete) the latter would get the same new name and be refused (NO).

This is not a real problem, but imaptest runs fast enough to tickle it and the false positives are annoying.

Mixing the timestamp's microseconds into the existing suffix (rather than appending or something else) to avoid breaking middleware that wants to pattern match these filenames (FM has some of these)