### PR TITLE
httpd: print slash after LibXML in the version info footer (3.0)

### DIFF
--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -953,7 +953,7 @@ int service_init(int argc __attribute__((unused)),
     buf_printf(&serverinfo, " Brotli/%u.%u.%u",
                (version >> 24) & 0xfff, (version >> 12) & 0xfff, version & 0xfff);
 #endif
-    buf_printf(&serverinfo, " LibXML%s", LIBXML_DOTTED_VERSION);
+    buf_printf(&serverinfo, " LibXML/%s", LIBXML_DOTTED_VERSION);
 
     /* Do any namespace specific initialization */
     config_httpmodules = config_getbitfield(IMAPOPT_HTTPMODULES);


### PR DESCRIPTION
All other software uses slashes, like: ` Cyrus-HTTP/3.0.10 Cyrus-SASL/2.1.27 OpenSSL/1.1 Zlib/1.2.11 Brotli/1.0.7 LibXML2.9.9 SQLite/3.29.0 LibiCal/3.0 ICU4C/63.1 Jansson/2.12 Server at …`