### PR TITLE
http_caldav.c:propfind_timezone: don’t crash, if the mailbox does not exist (3.0)

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5984,8 +5984,10 @@ static int propfind_timezone(const xmlChar *name, xmlNsPtr ns,
             prop_annot = DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone-id";
 
             buf_free(&attrib);
-            r = annotatemore_lookupmask(fctx->mailbox->name, prop_annot,
-                                        httpd_userid, &attrib);
+
+            if (fctx->mailbox)
+                r = annotatemore_lookupmask(fctx->mailbox->name, prop_annot,
+                                            httpd_userid, &attrib);
 
             if (r) r = HTTP_SERVER_ERROR;
             else if (!attrib.len) r = HTTP_NOT_FOUND;


### PR DESCRIPTION
Only a few lines earlier, the code calls annotatemore_lookup(fctx->mailbox->name, …), after checking that fctx->mailbox is not NULL.  At the place that is checked here, fctx->mailbox can be null.