### PR TITLE
promstatsd: report usage information (take 2)

### DIFF
--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -58,6 +58,8 @@
 #include "lib/util.h"
 
 #include "imap/global.h"
+#include "imap/mboxlist.h"
+#include "imap/mboxname.h"
 #include "imap/prometheus.h"
 
 /* globals so that shut_down() can clean up */
@@ -295,6 +297,58 @@ static void do_collate_report(struct buf *buf)
     free_hash_table(&all_stats, free);
 }
 
+struct users_mailboxes_counts {
+    int64_t users;
+    int64_t mailboxes;
+    /* XXX deleted? shared? */
+};
+
+static int count_users_mailboxes(struct findall_data *data, void *rock)
+{
+    struct users_mailboxes_counts *umcounts = (struct users_mailboxes_counts *) rock;
+
+    /* don't want partial matches */
+    if (!data || !data->mbname) return 0;
+
+    if (mbname_userid(data->mbname) &&
+        !strarray_size(mbname_boxes(data->mbname))) {
+        syslog(LOG_DEBUG, "counting user: %s", mbname_intname(data->mbname));
+        umcounts->users ++;
+    }
+
+    syslog(LOG_DEBUG, "counting mailbox: %s", mbname_intname(data->mbname));
+    umcounts->mailboxes ++;
+
+    return 0;
+}
+
+static void do_collate_usage(struct buf *buf)
+{
+    struct users_mailboxes_counts umcounts = { 0, 0 };
+    int64_t now;
+    int r;
+
+    r = mboxlist_findall(NULL /* admin namespace */, "*", 1, NULL, NULL,
+                         count_users_mailboxes, &umcounts);
+    if (!r) {
+        now = now_ms();
+
+        buf_printf(buf, "# HELP %s %s\n",
+                        "cyrus_usage_users",
+                        "The number of Cyrus user accounts");
+        buf_appendcstr(buf, "# TYPE cyrus_usage_users gauge\n");
+        buf_printf(buf, "cyrus_usage_users %" PRId64 " %" PRId64 "\n",
+                        umcounts.users, now);
+
+        buf_printf(buf, "# HELP %s %s\n",
+                        "cyrus_usage_mailboxes",
+                        "The number of Cyrus mailboxes");
+        buf_appendcstr(buf, "# TYPE cyrus_usage_mailboxes gauge\n");
+        buf_printf(buf, "cyrus_usage_mailboxes %" PRId64 " %" PRId64 "\n",
+                        umcounts.mailboxes, now);
+    }
+}
+
 static void do_write_report(struct mappedfile *mf, const struct buf *report)
 {
     int r;
@@ -415,6 +469,7 @@ int main(int argc, char **argv)
         }
 
         do_collate_report(&report_buf);
+        do_collate_usage(&report_buf);
         do_write_report(report_file, &report_buf);
 
         /* then wait around a bit */

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -61,6 +61,7 @@
 #include "imap/mboxlist.h"
 #include "imap/mboxname.h"
 #include "imap/prometheus.h"
+#include "imap/quota.h"
 
 /* globals so that shut_down() can clean up */
 static struct buf report_buf = BUF_INITIALIZER;
@@ -322,9 +323,40 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
     return 0;
 }
 
+struct quota_bufs {
+    struct buf used;
+    struct buf limit;
+};
+
+static int format_quota(struct quota *quota, void *rock)
+{
+    struct quota_bufs *bufs = (struct quota_bufs *) rock;
+    int64_t now = now_ms();
+    int res;
+
+    /* XXX how should "unlimited" be represented to prometheus? */
+
+    for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
+        buf_printf(&bufs->used, "cyrus_usage_quota_used{quotaroot=\"%s\",resource=\"%s\"}",
+                                quota->root,
+                                quota_names[res]);
+        buf_printf(&bufs->used, " " QUOTA_T_FMT " %" PRId64 "\n",
+                                quota->useds[res], now);
+
+        buf_printf(&bufs->limit, "cyrus_usage_quota_limit{quotaroot=\"%s\",resource=\"%s\"}",
+                                 quota->root,
+                                 quota_names[res]);
+        buf_printf(&bufs->limit, " " QUOTA_T_FMT " %" PRId64 "\n",
+                                 quota->limits[res], now);
+    }
+
+    return 0;
+}
+
 static void do_collate_usage(struct buf *buf)
 {
     struct users_mailboxes_counts umcounts = { 0, 0 };
+    struct quota_bufs quota_bufs = { BUF_INITIALIZER, BUF_INITIALIZER };
     int64_t now;
     int r;
 
@@ -347,6 +379,25 @@ static void do_collate_usage(struct buf *buf)
         buf_printf(buf, "cyrus_usage_mailboxes %" PRId64 " %" PRId64 "\n",
                         umcounts.mailboxes, now);
     }
+
+    r = quota_foreach(NULL, format_quota, &quota_bufs, NULL);
+
+    if (!r) {
+        buf_printf(buf, "# HELP %s %s\n",
+                        "cyrus_usage_quota_used",
+                        "The amount of used quota");
+        buf_appendcstr(buf, "# TYPE cyrus_usage_quota_used gauge\n");
+        buf_append(buf, &quota_bufs.used);
+
+        buf_printf(buf, "# HELP %s %s\n",
+                        "cyrus_usage_quota_limit",
+                        "The quota limit");
+        buf_appendcstr(buf, "# TYPE cyrus_usage_quota_limit gauge\n");
+        buf_append(buf, &quota_bufs.limit);
+    }
+
+    buf_free(&quota_bufs.used);
+    buf_free(&quota_bufs.limit);
 }
 
 static void do_write_report(struct mappedfile *mf, const struct buf *report)

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -47,6 +47,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <sysexits.h>
@@ -334,20 +335,21 @@ static int format_quota(struct quota *quota, void *rock)
     int64_t now = now_ms();
     int res;
 
-    /* XXX how should "unlimited" be represented to prometheus? */
-
     for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
+        double dv;
+
         buf_printf(&bufs->used, "cyrus_usage_quota_used{quotaroot=\"%s\",resource=\"%s\"}",
                                 quota->root,
                                 quota_names[res]);
         buf_printf(&bufs->used, " " QUOTA_T_FMT " %" PRId64 "\n",
                                 quota->useds[res], now);
 
+        dv = quota->limits[res] == QUOTA_UNLIMITED ? INFINITY : quota->limits[res];
         buf_printf(&bufs->limit, "cyrus_usage_quota_limit{quotaroot=\"%s\",resource=\"%s\"}",
                                  quota->root,
                                  quota_names[res]);
-        buf_printf(&bufs->limit, " " QUOTA_T_FMT " %" PRId64 "\n",
-                                 quota->limits[res], now);
+        buf_printf(&bufs->limit, " %.0f %" PRId64 "\n",
+                                 dv, now);
     }
 
     return 0;

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -339,14 +339,12 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
     }
 
     if (mbname_isdeleted(data->mbname)) {
-        syslog(LOG_DEBUG, "counting deleted: %s", mbname_intname(data->mbname));
         pdata->n_deleted ++;
         pdata->timestamp = now_ms();
     }
     else if (mbname_category(data->mbname, mboxname_get_adminnamespace(), NULL)
              == MBNAME_SHARED) {
         const char *namespace = strarray_nth(mbname_boxes(data->mbname), 0);
-        syslog(LOG_DEBUG, "counting shared (namespace = %s)", namespace);
         int64_t *n_shared = hash_lookup(namespace, &pdata->shared);
         if (!n_shared) {
             n_shared = malloc(sizeof *n_shared);
@@ -359,13 +357,11 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
     }
     else if (mbname_userid(data->mbname) &&
         !strarray_size(mbname_boxes(data->mbname))) {
-        syslog(LOG_DEBUG, "counting user: %s", mbname_intname(data->mbname));
         pdata->n_users ++;
         pdata->n_mailboxes ++; /* an inbox is also a mailbox */
         pdata->timestamp = now_ms();
     }
     else {
-        syslog(LOG_DEBUG, "counting mailbox: %s", mbname_intname(data->mbname));
         pdata->n_mailboxes ++;
         pdata->timestamp = now_ms();
     }
@@ -418,8 +414,6 @@ static int quota_cb(struct findall_data *data, void *rock)
         struct quota *q = cbrock->quota;
         double dv = q->limits[res] < 0 ? INFINITY : q->limits[res];
 
-        syslog(LOG_DEBUG, "found quota commitment: quotaroot=%s res=%s partition=%s limit=%.0f",
-                          q->root, quota_names[res], partition, dv);
         pdata->quota_commitment[res] += dv;
     }
     pdata->timestamp = now_ms();
@@ -438,7 +432,6 @@ static int count_quota_commitments(struct quota *quota, void *rock)
     strarray_t *patterns = strarray_new();
     int r;
 
-    syslog(LOG_DEBUG, "counting quota commitments for quotaroot=%s", quota->root);
     strarray_append(patterns, quota->root);
     snprintf(tmp, sizeof(tmp), "%s.*", quota->root);
     strarray_append(patterns, tmp);

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -308,7 +308,7 @@ struct partition_data {
     int64_t n_deleted;
     int64_t n_shared; /* XXX ??? */
 
-    double quota_commitment;
+    double quota_commitment[QUOTA_NUMRESOURCES];
 
     int64_t timestamp;
 };
@@ -349,35 +349,69 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
     return 0;
 }
 
-struct quota_bufs {
-    struct buf used;
-    struct buf limit;
+struct quota_cb_rock {
+    struct quota *quota;
+    hash_table *h;
 };
 
-static int format_quota(struct quota *quota, void *rock)
+static int quota_cb(struct findall_data *data, void *rock)
 {
-    struct quota_bufs *bufs = (struct quota_bufs *) rock;
-    int64_t now = now_ms();
+    static char *seen_partition = NULL;
+
+    struct quota_cb_rock *cbrock = (struct quota_cb_rock *) rock;
+    struct partition_data *pdata;
+    const char *partition;
     int res;
 
-    for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
-        double dv;
-
-        buf_printf(&bufs->used, "cyrus_usage_quota_used{quotaroot=\"%s\",resource=\"%s\"}",
-                                quota->root,
-                                quota_names[res]);
-        buf_printf(&bufs->used, " " QUOTA_T_FMT " %" PRId64 "\n",
-                                quota->useds[res], now);
-
-        dv = quota->limits[res] == QUOTA_UNLIMITED ? INFINITY : quota->limits[res];
-        buf_printf(&bufs->limit, "cyrus_usage_quota_limit{quotaroot=\"%s\",resource=\"%s\"}",
-                                 quota->root,
-                                 quota_names[res]);
-        buf_printf(&bufs->limit, " %.0f %" PRId64 "\n",
-                                 dv, now);
+    if (!data) {
+        /* just reset the seen_partition buffer */
+        if (seen_partition) free(seen_partition);
+        seen_partition = NULL;
+        return 0;
     }
 
+    /* don't want partial matches */
+    if (!data->mbname || !data->mbentry) return 0;
+
+    partition = data->mbentry->partition;
+    if (seen_partition && !strcmp(seen_partition, partition)) {
+        /* seen this one already, don't double count it */
+        return 0;
+    }
+
+    pdata = hash_lookup(partition, cbrock->h);
+
+    for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
+        struct quota *q = cbrock->quota;
+        double dv = q->limits[res] < 0 ? INFINITY : q->limits[res];
+
+        pdata->quota_commitment[res] += dv;
+    }
+    pdata->timestamp = now_ms();
+
+    if (seen_partition) free(seen_partition);
+    seen_partition = xstrdup(partition);
+
     return 0;
+}
+
+static int count_quota_commitments(struct quota *quota, void *rock)
+{
+    hash_table *h = (hash_table *) rock;
+    struct quota_cb_rock cbrock = { quota, h };
+    char tmp[MAX_MAILBOX_PATH];
+    strarray_t *patterns = strarray_new();
+    int r;
+
+    strarray_append(patterns, quota->root);
+    snprintf(tmp, sizeof(tmp), "%s.*", quota->root);
+    strarray_append(patterns, tmp);
+
+    r = mboxlist_findallmulti(NULL /* admin namespace */, patterns, 1, NULL, NULL,
+                              quota_cb, &cbrock);
+
+    strarray_free(patterns);
+    return r;
 }
 
 static void pname_cb(const char *key,
@@ -420,10 +454,34 @@ do {                                                                         \
     }                                                                        \
 } while(0)
 
+static void format_usage_quota_commitment(struct buf *buf,
+                                          const strarray_t *pnames,
+                                          hash_table *h)
+{
+    int i, res;
+    buf_printf(buf, "# HELP %s %s\n",
+                    "cyrus_usage_quota_commitment",
+                    "The amount of quota committed");
+    buf_appendcstr(buf, "# TYPE cyrus_usage_quota_commitment gauge\n");
+
+    for (i = 0; i < strarray_size(pnames); i++) {
+        struct partition_data *pdata = hash_lookup(strarray_nth(pnames, i), h);
+
+        for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
+            buf_printf(buf, "%s{partition=\"%s\",resource=\"%s\"}",
+                            "cyrus_usage_quota_commitment",
+                            strarray_nth(pnames, i),
+                            quota_names[res]);
+            buf_printf(buf, " %.0f %" PRId64 "\n",
+                            pdata->quota_commitment[res],
+                            pdata->timestamp);
+        }
+    }
+}
+
 static void do_collate_usage(struct buf *buf)
 {
     hash_table h = HASH_TABLE_INITIALIZER;
-    struct quota_bufs quota_bufs = { BUF_INITIALIZER, BUF_INITIALIZER };
     strarray_t *partition_names = NULL;
     int r;
 
@@ -431,6 +489,10 @@ static void do_collate_usage(struct buf *buf)
 
     r = mboxlist_findall(NULL /* admin namespace */, "*", 1, NULL, NULL,
                          count_users_mailboxes, &h);
+    if (!r)
+        r = quota_foreach(NULL, count_quota_commitments, &h, NULL);
+
+    /* need to invert the hash table on output, so build a list of its keys */
     partition_names = get_partition_names(&h);
 
     FORMAT_USAGE_INT64("cyrus_usage_deleted_mailboxes", "gauge",
@@ -449,27 +511,10 @@ static void do_collate_usage(struct buf *buf)
                        buf, partition_names, &h);
     /* XXX shared ??? */
 
+    format_usage_quota_commitment(buf, partition_names, &h);
+
     strarray_free(partition_names);
     free_hash_table(&h, free);
-
-    r = quota_foreach(NULL, format_quota, &quota_bufs, NULL);
-
-    if (!r) {
-        buf_printf(buf, "# HELP %s %s\n",
-                        "cyrus_usage_quota_used",
-                        "The amount of used quota");
-        buf_appendcstr(buf, "# TYPE cyrus_usage_quota_used gauge\n");
-        buf_append(buf, &quota_bufs.used);
-
-        buf_printf(buf, "# HELP %s %s\n",
-                        "cyrus_usage_quota_limit",
-                        "The quota limit");
-        buf_appendcstr(buf, "# TYPE cyrus_usage_quota_limit gauge\n");
-        buf_append(buf, &quota_bufs.limit);
-    }
-
-    buf_free(&quota_bufs.used);
-    buf_free(&quota_bufs.limit);
 }
 
 static void do_write_report(struct mappedfile *mf, const struct buf *report)

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -337,6 +337,7 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
         !strarray_size(mbname_boxes(data->mbname))) {
         syslog(LOG_DEBUG, "counting user: %s", mbname_intname(data->mbname));
         pdata->n_users ++;
+        pdata->n_mailboxes ++; /* an inbox is also a mailbox */
         pdata->timestamp = now_ms();
     }
     /* XXX shared ? */

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -306,7 +306,7 @@ struct partition_data {
     int64_t n_users;
     int64_t n_mailboxes;
     int64_t n_deleted;
-    int64_t n_shared; /* XXX ??? */
+    hash_table shared;
 
     double quota_commitment[QUOTA_NUMRESOURCES];
 
@@ -325,12 +325,27 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
     if (!pdata) {
         pdata = malloc(sizeof *pdata);
         memset(pdata, 0, sizeof *pdata);
+        construct_hash_table(&pdata->shared, 10, 0); /* 10 shared namespaces probably enough */
         hash_insert(data->mbentry->partition, pdata, h);
     }
 
     if (mbname_isdeleted(data->mbname)) {
         syslog(LOG_DEBUG, "counting deleted: %s", mbname_intname(data->mbname));
         pdata->n_deleted ++;
+        pdata->timestamp = now_ms();
+    }
+    else if (mbname_category(data->mbname, mboxname_get_adminnamespace(), NULL)
+             == MBNAME_SHARED) {
+        const char *namespace = strarray_nth(mbname_boxes(data->mbname), 0);
+        syslog(LOG_DEBUG, "counting shared (namespace = %s)", namespace);
+        int64_t *n_shared = hash_lookup(namespace, &pdata->shared);
+        if (!n_shared) {
+            n_shared = malloc(sizeof *n_shared);
+            *n_shared = 0;
+            hash_insert(namespace, n_shared, &pdata->shared);
+        }
+
+        (*n_shared)++;
         pdata->timestamp = now_ms();
     }
     else if (mbname_userid(data->mbname) &&
@@ -340,7 +355,6 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
         pdata->n_mailboxes ++; /* an inbox is also a mailbox */
         pdata->timestamp = now_ms();
     }
-    /* XXX shared ? */
     else {
         syslog(LOG_DEBUG, "counting mailbox: %s", mbname_intname(data->mbname));
         pdata->n_mailboxes ++;
@@ -467,6 +481,51 @@ do {                                                                         \
     }                                                                        \
 } while(0)
 
+struct shared_mailbox_rock {
+    struct buf *buf;
+    char *partition;
+    int64_t timestamp;
+};
+
+static void format_usage_shared_mailbox(const char *key, void *data, void *rock)
+{
+    struct shared_mailbox_rock *smrock = (struct shared_mailbox_rock *) rock;
+    int64_t n_shared = *(int64_t *) data;
+
+    buf_printf(smrock->buf, "%s{partition=\"%s\",namespace=\"%s\"}",
+                            "cyrus_usage_shared_mailboxes",
+                            smrock->partition,
+                            key);
+    buf_printf(smrock->buf, " %" PRId64 " %" PRId64 "\n",
+                            n_shared,
+                            smrock->timestamp);
+}
+
+static void format_usage_shared_mailboxes(struct buf *buf,
+                                          const strarray_t *pnames,
+                                          hash_table *h)
+{
+    int i;
+
+    buf_printf(buf, "# HELP %s %s\n",
+                    "cyrus_usage_shared_mailboxes",
+                    "The number of shared Cyrus mailboxes");
+    buf_appendcstr(buf, "# TYPE cyrus_usage_shared_mailboxes gauge\n");
+
+    for (i = 0; i < strarray_size(pnames); i++) {
+        struct shared_mailbox_rock smrock;
+        struct partition_data *pdata;
+
+        smrock.buf = buf;
+        smrock.partition = (char *) strarray_nth(pnames, i); /* n.b. casting away const */
+
+        pdata = hash_lookup(smrock.partition, h);
+        smrock.timestamp = pdata->timestamp;
+
+        hash_enumerate(&pdata->shared, format_usage_shared_mailbox, &smrock);
+    }
+}
+
 static void format_usage_quota_commitment(struct buf *buf,
                                           const strarray_t *pnames,
                                           hash_table *h)
@@ -522,7 +581,8 @@ static void do_collate_usage(struct buf *buf)
                        "The number of Cyrus mailboxes",
                        n_mailboxes,
                        buf, partition_names, &h);
-    /* XXX shared ??? */
+
+    format_usage_shared_mailboxes(buf, partition_names, &h);
 
     format_usage_quota_commitment(buf, partition_names, &h);
 

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -313,6 +313,15 @@ struct partition_data {
     int64_t timestamp;
 };
 
+static void free_partition_data(void *ptr)
+{
+    struct partition_data *pdata = (struct partition_data *) ptr;
+
+    free_hash_table(&pdata->shared, free);
+    memset(pdata, 0, sizeof *pdata);
+    free(pdata);
+}
+
 static int count_users_mailboxes(struct findall_data *data, void *rock)
 {
     hash_table *h = (hash_table *) rock;
@@ -587,7 +596,7 @@ static void do_collate_usage(struct buf *buf)
     format_usage_quota_commitment(buf, partition_names, &h);
 
     strarray_free(partition_names);
-    free_hash_table(&h, free);
+    free_hash_table(&h, free_partition_data);
 }
 
 static void do_write_report(struct mappedfile *mf, const struct buf *report)

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -361,6 +361,7 @@ static int quota_cb(struct findall_data *data, void *rock)
     struct quota_cb_rock *cbrock = (struct quota_cb_rock *) rock;
     struct partition_data *pdata;
     const char *partition;
+    char qroot[MAX_MAILBOX_NAME];
     int res;
 
     if (!data) {
@@ -372,6 +373,14 @@ static int quota_cb(struct findall_data *data, void *rock)
 
     /* don't want partial matches */
     if (!data->mbname || !data->mbentry) return 0;
+
+    /* stop if we reach a new quotaroot */
+    if (quota_findroot(qroot, sizeof(qroot), mbname_intname(data->mbname))
+        && strcmp(qroot, cbrock->quota->root) != 0) {
+        if (seen_partition) free(seen_partition);
+        seen_partition = NULL;
+        return 1;
+    }
 
     partition = data->mbentry->partition;
     if (seen_partition && !strcmp(seen_partition, partition)) {
@@ -385,6 +394,8 @@ static int quota_cb(struct findall_data *data, void *rock)
         struct quota *q = cbrock->quota;
         double dv = q->limits[res] < 0 ? INFINITY : q->limits[res];
 
+        syslog(LOG_DEBUG, "found quota commitment: quotaroot=%s res=%s partition=%s limit=%.0f",
+                          q->root, quota_names[res], partition, dv);
         pdata->quota_commitment[res] += dv;
     }
     pdata->timestamp = now_ms();
@@ -403,6 +414,7 @@ static int count_quota_commitments(struct quota *quota, void *rock)
     strarray_t *patterns = strarray_new();
     int r;
 
+    syslog(LOG_DEBUG, "counting quota commitments for quotaroot=%s", quota->root);
     strarray_append(patterns, quota->root);
     snprintf(tmp, sizeof(tmp), "%s.*", quota->root);
     strarray_append(patterns, tmp);

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -54,8 +54,11 @@
 #include <syslog.h>
 #include <unistd.h>
 
+#include "lib/bsearch.h"
 #include "lib/cyr_lock.h"
+#include "lib/hash.h"
 #include "lib/retry.h"
+#include "lib/strarray.h"
 #include "lib/util.h"
 
 #include "imap/global.h"
@@ -299,27 +302,49 @@ static void do_collate_report(struct buf *buf)
     free_hash_table(&all_stats, free);
 }
 
-struct users_mailboxes_counts {
-    int64_t users;
-    int64_t mailboxes;
-    /* XXX deleted? shared? */
+struct partition_data {
+    int64_t n_users;
+    int64_t n_mailboxes;
+    int64_t n_deleted;
+    int64_t n_shared; /* XXX ??? */
+
+    double quota_commitment;
+
+    int64_t timestamp;
 };
 
 static int count_users_mailboxes(struct findall_data *data, void *rock)
 {
-    struct users_mailboxes_counts *umcounts = (struct users_mailboxes_counts *) rock;
+    hash_table *h = (hash_table *) rock;
+    struct partition_data *pdata;
 
     /* don't want partial matches */
-    if (!data || !data->mbname) return 0;
+    if (!data || !data->mbname || !data->mbentry) return 0;
 
-    if (mbname_userid(data->mbname) &&
-        !strarray_size(mbname_boxes(data->mbname))) {
-        syslog(LOG_DEBUG, "counting user: %s", mbname_intname(data->mbname));
-        umcounts->users ++;
+    pdata = hash_lookup(data->mbentry->partition, h);
+    if (!pdata) {
+        pdata = malloc(sizeof *pdata);
+        memset(pdata, 0, sizeof *pdata);
+        hash_insert(data->mbentry->partition, pdata, h);
     }
 
-    syslog(LOG_DEBUG, "counting mailbox: %s", mbname_intname(data->mbname));
-    umcounts->mailboxes ++;
+    if (mbname_isdeleted(data->mbname)) {
+        syslog(LOG_DEBUG, "counting deleted: %s", mbname_intname(data->mbname));
+        pdata->n_deleted ++;
+        pdata->timestamp = now_ms();
+    }
+    else if (mbname_userid(data->mbname) &&
+        !strarray_size(mbname_boxes(data->mbname))) {
+        syslog(LOG_DEBUG, "counting user: %s", mbname_intname(data->mbname));
+        pdata->n_users ++;
+        pdata->timestamp = now_ms();
+    }
+    /* XXX shared ? */
+    else {
+        syslog(LOG_DEBUG, "counting mailbox: %s", mbname_intname(data->mbname));
+        pdata->n_mailboxes ++;
+        pdata->timestamp = now_ms();
+    }
 
     return 0;
 }
@@ -355,32 +380,77 @@ static int format_quota(struct quota *quota, void *rock)
     return 0;
 }
 
+static void pname_cb(const char *key,
+                     void *data __attribute__((unused)),
+                     void *rock)
+{
+    strarray_append((strarray_t *) rock, key);
+}
+
+static strarray_t *get_partition_names(hash_table *h)
+{
+    strarray_t *names = strarray_new();
+    hash_enumerate(h, pname_cb, names);
+    strarray_sort(names, cmpstringp_raw);
+    return names;
+}
+
+#define FORMAT_USAGE_INT64(metric, type, help, member, buf, pnames, h) \
+do {                                                                         \
+    const char *___metric = (metric);                                        \
+    const char *___type = (type);                                            \
+    const char *___help = (help);                                            \
+    struct buf *___buf = (buf);                                              \
+    const strarray_t *___pnames = (pnames);                                  \
+    hash_table *___h = (h);                                                  \
+    int i;                                                                   \
+                                                                             \
+    buf_printf(___buf, "# HELP %s %s\n", ___metric, ___help);                \
+    buf_printf(___buf, "# TYPE %s %s\n", ___metric, ___type);                \
+                                                                             \
+    for (i = 0; i < strarray_size(___pnames); i++) {                         \
+        struct partition_data *pdata =                                       \
+            hash_lookup(strarray_nth(___pnames, i), ___h);                   \
+                                                                             \
+        buf_printf(___buf, "%s{partition=\"%s\"} %" PRId64 " %" PRId64 "\n", \
+                        ___metric,                                           \
+                        strarray_nth(___pnames, i),                          \
+                        pdata->member,                                       \
+                        pdata->timestamp);                                   \
+    }                                                                        \
+} while(0)
+
 static void do_collate_usage(struct buf *buf)
 {
-    struct users_mailboxes_counts umcounts = { 0, 0 };
+    hash_table h = HASH_TABLE_INITIALIZER;
     struct quota_bufs quota_bufs = { BUF_INITIALIZER, BUF_INITIALIZER };
-    int64_t now;
+    strarray_t *partition_names = NULL;
     int r;
 
+    construct_hash_table(&h, 10, 0); /* 10 partitions is probably enough right */
+
     r = mboxlist_findall(NULL /* admin namespace */, "*", 1, NULL, NULL,
-                         count_users_mailboxes, &umcounts);
-    if (!r) {
-        now = now_ms();
+                         count_users_mailboxes, &h);
+    partition_names = get_partition_names(&h);
 
-        buf_printf(buf, "# HELP %s %s\n",
-                        "cyrus_usage_users",
-                        "The number of Cyrus user accounts");
-        buf_appendcstr(buf, "# TYPE cyrus_usage_users gauge\n");
-        buf_printf(buf, "cyrus_usage_users %" PRId64 " %" PRId64 "\n",
-                        umcounts.users, now);
+    FORMAT_USAGE_INT64("cyrus_usage_deleted_mailboxes", "gauge",
+                       "The number of deleted Cyrus mailboxes",
+                       n_deleted,
+                       buf, partition_names, &h);
 
-        buf_printf(buf, "# HELP %s %s\n",
-                        "cyrus_usage_mailboxes",
-                        "The number of Cyrus mailboxes");
-        buf_appendcstr(buf, "# TYPE cyrus_usage_mailboxes gauge\n");
-        buf_printf(buf, "cyrus_usage_mailboxes %" PRId64 " %" PRId64 "\n",
-                        umcounts.mailboxes, now);
-    }
+    FORMAT_USAGE_INT64("cyrus_usage_users", "gauge",
+                       "The number of Cyrus user Inboxes",
+                       n_users,
+                       buf, partition_names, &h);
+
+    FORMAT_USAGE_INT64("cyrus_usage_mailboxes", "gauge",
+                       "The number of Cyrus mailboxes",
+                       n_mailboxes,
+                       buf, partition_names, &h);
+    /* XXX shared ??? */
+
+    strarray_free(partition_names);
+    free_hash_table(&h, free);
 
     r = quota_foreach(NULL, format_quota, &quota_bufs, NULL);
 


### PR DESCRIPTION
This is basically the same as #2219 (with a conflict fixed), but with the syslogs in the hot loops removed.

This _should_ remove the main barrier we had to enabling this at FM, but the only "realish-load" test we've seen was with the syslog IO load killing it, so it might still be inadequately performant for some other reason.

There's some additional optimisations still to be had, but they require supporting work in underlying APIs (e.g. #2834), which will be separate PRs as they shake out.