### PR TITLE
mboxlist: add 'p' callback to mboxlist_find*() API

### DIFF
--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -251,6 +251,7 @@ struct findall_data {
     const mbname_t *mbname;
 };
 
+typedef int findall_p(struct findall_data *data, void *rock);
 typedef int findall_cb(struct findall_data *data, void *rock);
 
 /* Find all mailboxes that match 'pattern'. */
@@ -266,6 +267,19 @@ int mboxlist_findone(struct namespace *namespace,
                      const char *intname, int isadmin,
                      const char *userid, const struct auth_state *auth_state,
                      findall_cb *proc, void *rock);
+
+int mboxlist_findall_withp(struct namespace *namespace,
+                     const char *pattern, int isadmin,
+                     const char *userid, const struct auth_state *auth_state,
+                     findall_p *p, findall_cb *cb, void *rock);
+int mboxlist_findallmulti_withp(struct namespace *namespace,
+                          const strarray_t *patterns, int isadmin,
+                          const char *userid, const struct auth_state *auth_state,
+                          findall_p *p, findall_cb *cb, void *rock);
+int mboxlist_findone_withp(struct namespace *namespace,
+                     const char *intname, int isadmin,
+                     const char *userid, const struct auth_state *auth_state,
+                     findall_p *p, findall_cb *cb, void *rock);
 
 /* Find a mailbox's parent (if any) */
 int mboxlist_findparent(const char *mboxname,
@@ -305,6 +319,17 @@ int mboxlist_findsubmulti(struct namespace *namespace,
                           const strarray_t *patterns, int isadmin,
                           const char *userid, const struct auth_state *auth_state,
                           findall_cb *proc, void *rock,
+                          int force);
+
+int mboxlist_findsub_withp(struct namespace *namespace,
+                     const char *pattern, int isadmin,
+                     const char *userid, const struct auth_state *auth_state,
+                     findall_p *p, findall_cb *cb, void *rock,
+                     int force);
+int mboxlist_findsubmulti_withp(struct namespace *namespace,
+                          const strarray_t *patterns, int isadmin,
+                          const char *userid, const struct auth_state *auth_state,
+                          findall_p *p, findall_cb *cb, void *rock,
                           int force);
 
 /* given a mailbox 'name', where should we stage messages for it?


### PR DESCRIPTION
Exposes the 'p' callback from the cyrusdb_foreach API via the mboxlist_find* APIs, so that if you need to do a cheap custom check on matches before calling the expensive callback, you can.

Nothing uses this at the moment, so all the interesting changes in this PR are the ones in mboxlist.[ch], everything else is just noise due to the number of params changing.

It'll be useful for #2833 and closes #2834