### PR TITLE
conversations.[ch] open_conversations is needed only in conversations.c

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -102,7 +102,7 @@
 
 #define CONVERSATIONS_VERSION 0
 
-struct conversations_open *open_conversations;
+static struct conversations_open *open_conversations;
 
 static conv_status_t NULLSTATUS = CONV_STATUS_INIT;
 

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -90,8 +90,6 @@ struct conversations_open {
     struct conversations_open *next;
 };
 
-extern struct conversations_open *open_conversations;
-
 typedef struct conversation conversation_t;
 typedef struct conv_folder  conv_folder_t;
 typedef struct conv_sender  conv_sender_t;


### PR DESCRIPTION
So there is no point to declare it in imap/openconversations.h.