### PR TITLE
conversations.[ch] open_conversations is needed only in conversations.c (3.0)

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -111,6 +111,7 @@ static int _conversations_set_key(struct conversations_state *state,
                                   const char *key, size_t keylen,
                                   const arrayu64_t *cids, time_t stamp);
 
+static struct conversations_open *open_conversations;
 EXPORTED void conversations_set_directory(const char *dir)
 {
     free(convdir);

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -77,7 +77,6 @@ struct conversations_open {
     struct conversations_open *next;
 };
 
-struct conversations_open *open_conversations;
 
 typedef struct conversation conversation_t;
 typedef struct conv_folder  conv_folder_t;


### PR DESCRIPTION
So there is no point to declare it in imap/openconversations.h.