### PR TITLE
Access deleted data

### DIFF
--- a/imap/arbitron.c
+++ b/imap/arbitron.c
@@ -242,6 +242,7 @@ static void usage(void)
 static int do_mailbox(struct findall_data *data, void *rock __attribute__((unused)))
 {
     if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
     int r;
     struct mailbox *mailbox = NULL;
     const char *name = mbname_intname(data->mbname);

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -516,6 +516,7 @@ struct changesub_rock_st {
 static int autochangesub(struct findall_data *data, void *rock)
 {
     if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
     struct changesub_rock_st *crock = (struct changesub_rock_st *)rock;
     const char *userid = crock->userid;
     struct auth_state *auth_state = crock->auth_state;

--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -74,6 +74,7 @@ static const char *check_part = NULL; /* partition we are checking */
 static int chkmbox(struct findall_data *data, void *rock __attribute__((unused)))
 {
     if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
     int r;
     mbentry_t *mbentry = NULL;
     const char *name = mbname_intname(data->mbname);

--- a/imap/cvt_xlist_specialuse.c
+++ b/imap/cvt_xlist_specialuse.c
@@ -115,8 +115,7 @@ static int set_specialuse(struct findall_data *data, void *rock)
     int r;
 
     if (!data) return 0;
-
-    if (!data->mbname) return 0; /* XXX what does this mean? */
+    if (!data->is_exactmatch) return 0;
 
     if (!mbname_userid(data->mbname)) return 0;
 

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -374,7 +374,9 @@ static void print_header(void)
 
 int scan_me(struct findall_data *data, void *rock)
 {
-    if (!data || !data->mbname) return 0;
+    if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
+
     struct mailbox *mailbox = NULL;
     int r;
     struct infected_mbox *i_mbox = NULL;

--- a/imap/cyrdump.c
+++ b/imap/cyrdump.c
@@ -170,7 +170,8 @@ static int dump_me(struct findall_data *data, void *rock)
     unsigned msgno;
 
     /* don't want partial matches */
-    if (!data || !data->mbname) return 0;
+    if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
 
     const char *name = mbname_intname(data->mbname);
 

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -536,7 +536,7 @@ static int do_list(const char *name, void *rock)
 
 static int list_cb(struct findall_data *data, void *rock)
 {
-    if (data && data->mbname)
+    if (data && data->is_exactmatch)
         return do_list(mbname_intname(data->mbname), rock);
     return do_list(NULL, rock);
 }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4335,13 +4335,13 @@ static void cmd_select(char *tag, char *cmd, char *name)
                  */
                 ;
             }
-            else if (allowdeleted && !strcmp(arg.s, "VENDOR.FM-INCLUDE-EXPUNGED")) {
+            else if (allowdeleted && !strcmp(arg.s, "VENDOR.CMU-INCLUDE-EXPUNGED")) {
                 init.want_expunged = 1;
             }
-            else if (allowdeleted && !strcmp(arg.s, "VENDOR.FM-ALLOW-DELETED")) {
+            else if (allowdeleted && !strcmp(arg.s, "VENDOR.CMU-ALLOW-DELETED")) {
                 select_deleted = 1;
             }
-            else if (!strcmp(arg.s, "VENDOR.FM-INCLUDE-DAV")) {
+            else if (!strcmp(arg.s, "VENDOR.CMU-DAV")) {
                 init.want_dav = 1;
             }
             else {
@@ -12515,7 +12515,7 @@ static int getlistselopts(char *tag, struct listargs *args)
             args->ret |= LIST_RET_SUBSCRIBED;
         } else if (!strcmp(buf.s, "vendor.cmu-dav")) {
             args->sel |= LIST_SEL_DAV;
-        } else if (!strcmp(buf.s, "vendor.fm-include-deleted")) {
+        } else if (!strcmp(buf.s, "vendor.cmu-include-deleted")) {
             args->sel |= LIST_SEL_DELETED;
         } else if (!strcmp(buf.s, "vendor.fm-include-nonexistent")) {
             args->sel |= LIST_SEL_INTERMEDIATES;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -12514,6 +12514,8 @@ static int getlistselopts(char *tag, struct listargs *args)
             args->ret |= LIST_RET_SUBSCRIBED;
         } else if (!strcmp(buf.s, "vendor.cmu-dav")) {
             args->sel |= LIST_SEL_DAV;
+        } else if (!strcmp(buf.s, "vendor.fm-include-deleted")) {
+            args->sel |= LIST_SEL_DELETED;
         } else if (!strcmp(buf.s, "vendor.fm-include-nonexistent")) {
             args->sel |= LIST_SEL_INTERMEDIATES;
         } else if (!strcmp(buf.s, "remote")) {

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4930,6 +4930,13 @@ badannotation:
             else goto badatt;
             break;
 
+        case 'L':
+            if (!strcmp(fetchatt.s, "LASTUPDATED")) {
+                fa->fetchitems |= FETCH_LASTUPDATED;
+            }
+            else goto badatt;
+            break;
+
         case 'M':
             if (config_getswitch(IMAPOPT_CONVERSATIONS)
                 && !strcmp(fetchatt.s, "MAILBOXES")) {

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5499,12 +5499,8 @@ done:
 static int xbackup_addmbox(struct findall_data *data, void *rock)
 {
     if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
     ptrarray_t *list = (ptrarray_t *) rock;
-
-    if (!data->mbname) {
-        /* No partial matches */ /* FIXME ??? */
-        return 0;
-    }
 
     /* Only add shared mailboxes or user INBOXes */
     if (!mbname_localpart(data->mbname) ||
@@ -9928,13 +9924,11 @@ struct apply_rock {
 static int apply_cb(struct findall_data *data, void* rock)
 {
     if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
+
     struct apply_rock *arock = (struct apply_rock *)rock;
     annotate_state_t *state = arock->state;
     int r;
-
-    /* Suppress any output of a partial match */
-    if (!data->mbname)
-        return 0;
 
     strlcpy(arock->lastname, mbname_intname(data->mbname), sizeof(arock->lastname));
 
@@ -11946,12 +11940,8 @@ struct xfer_list {
 static int xfer_addmbox(struct findall_data *data, void *rock)
 {
     if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
     struct xfer_list *list = (struct xfer_list *) rock;
-
-    if (!data->mbentry || !data->mbname) {
-        /* No partial matches */
-        return 0;
-    }
 
     if (list->part && strcmp(data->mbentry->partition, list->part)) {
         /* Not on specified partition */
@@ -13179,7 +13169,7 @@ static int list_cb(struct findall_data *data, void *rockp)
      * if they're required but not yet set, but it's a little cheaper to
      * precalculate them now while we're iterating the mailboxes anyway.
      */
-    if (last_name_is_ancestor || (rock->last_name && !data->mbname && !strcmp(rock->last_name, extname)))
+    if (last_name_is_ancestor || (rock->last_name && !data->is_exactmatch && !strcmp(rock->last_name, extname)))
         rock->last_attributes |= MBOX_ATTRIBUTE_HASCHILDREN;
 
     else if (!(rock->last_attributes & MBOX_ATTRIBUTE_HASCHILDREN))
@@ -13197,7 +13187,7 @@ static int list_cb(struct findall_data *data, void *rockp)
     if (!perform_output(data->extname, data->mbentry, rock))
         return 0;
 
-    if (!data->mbname)
+    if (!data->is_exactmatch)
         rock->last_attributes |= MBOX_ATTRIBUTE_HASCHILDREN | MBOX_ATTRIBUTE_NONEXISTENT;
 
     else if (data->mb_category == MBNAME_ALTINBOX)
@@ -13226,10 +13216,10 @@ static int subscribed_cb(struct findall_data *data, void *rockp)
     list_callback_calls++;
 
     if (last_name_is_ancestor ||
-        (rock->last_name && !data->mbname && !strcmp(rock->last_name, extname)))
+        (rock->last_name && !data->is_exactmatch && !strcmp(rock->last_name, extname)))
         rock->last_attributes |= MBOX_ATTRIBUTE_HASCHILDREN;
 
-    if (data->mbname) { /* exact match */
+    if (data->is_exactmatch) {
         mbentry_t *mbentry = NULL;
         mboxlist_lookup(mbname_intname(data->mbname), &mbentry, NULL);
         perform_output(extname, mbentry, rock);
@@ -13404,7 +13394,7 @@ static int recursivematch_cb(struct findall_data *data, void *rockp)
     }
 
 
-    if (data->mbname) { /* exact match */
+    if (data->is_exactmatch) {
         entry->attributes |= MBOX_ATTRIBUTE_SUBSCRIBED;
         if (!data->mbentry) {
             mboxlist_lookup(mbname_intname(data->mbname), &entry->mbentry, NULL);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -13149,6 +13149,13 @@ static void add_intermediates(const char *extname, struct list_rock *lrock)
 static int list_cb(struct findall_data *data, void *rockp)
 {
     struct list_rock *rock = (struct list_rock *)rockp;
+
+    // skip anything DELETED unless explicitly asked for
+    if (data && !imapd_userisadmin
+             && !(rock->listargs->sel & LIST_SEL_DELETED)
+             && mbname_isdeleted(data->mbname))
+        return 0;
+
     if (!data) {
         if (!(rock->last_attributes & MBOX_ATTRIBUTE_HASCHILDREN))
             rock->last_attributes |= MBOX_ATTRIBUTE_HASNOCHILDREN;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4333,6 +4333,10 @@ static void cmd_select(char *tag, char *cmd, char *name)
                  */
                 ;
             }
+            else if (!strcmp(arg.s, "EXPUNGED")) {
+                /* include EXPUNGED messages */
+                init.want_expunged = 1;
+            }
             else {
                 prot_printf(imapd_out, "%s BAD Invalid %s modifier %s\r\n",
                             tag, cmd, arg.s);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4340,6 +4340,9 @@ static void cmd_select(char *tag, char *cmd, char *name)
             else if (!strcmp(arg.s, "VENDOR.FM-ALLOW-DELETED")) {
                 allow_deleted = 1;
             }
+            else if (!strcmp(arg.s, "VENDOR.FM-INCLUDE-DAV")) {
+                init.want_dav = 1;
+            }
             else {
                 prot_printf(imapd_out, "%s BAD Invalid %s modifier %s\r\n",
                             tag, cmd, arg.s);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4333,8 +4333,7 @@ static void cmd_select(char *tag, char *cmd, char *name)
                  */
                 ;
             }
-            else if (!strcmp(arg.s, "EXPUNGED")) {
-                /* include EXPUNGED messages */
+            else if (!strcmp(arg.s, "VENDOR.FM-INCLUDE-EXPUNGED")) {
                 init.want_expunged = 1;
             }
             else {

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -383,7 +383,8 @@ enum {
     LIST_SEL_SPECIALUSE =       (1<<3),
     LIST_SEL_DAV =              (1<<4),
     LIST_SEL_METADATA =         (1<<5),
-    LIST_SEL_INTERMEDIATES =    (1<<6)
+    LIST_SEL_INTERMEDIATES =    (1<<6),
+    LIST_SEL_DELETED =          (1<<7)
     /* New options MUST be handled in imapd.c:list_data_remote() */
 };
 

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -139,6 +139,7 @@ enum {
     FETCH_MAILBOXIDS =          (1<<26),
     FETCH_MAILBOXES =           (1<<27),
     FETCH_PREVIEW =             (1<<28),
+    FETCH_LASTUPDATED =         (1<<29),
 
     /* XXX fetchitems is an int, we're running low on bits */
 };

--- a/imap/index.c
+++ b/imap/index.c
@@ -3962,6 +3962,10 @@ static void index_fetchflags(struct index_state *state,
         prot_printf(state->out, "%c\\Deleted", sepchar);
         sepchar = ' ';
     }
+    if (state->want_expunged && (im->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
+        prot_printf(state->out, "%c\\Expunged", sepchar);
+        sepchar = ' ';
+    }
     if (im->isseen) {
         prot_printf(state->out, "%c\\Seen", sepchar);
         sepchar = ' ';

--- a/imap/index.c
+++ b/imap/index.c
@@ -5845,6 +5845,11 @@ static int index_copysetup(struct index_state *state, uint32_t msgno,
     else
         copyargs->records[copyargs->nummsg].system_flags &= ~FLAG_SEEN;
 
+    if (state->want_expunged && (im->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
+        copyargs->records[copyargs->nummsg].system_flags &= ~FLAG_DELETED;
+        copyargs->records[copyargs->nummsg].internal_flags &= ~FLAG_INTERNAL_EXPUNGED;
+    }
+
     copyargs->nummsg++;
 
     return 0;

--- a/imap/index.c
+++ b/imap/index.c
@@ -4108,6 +4108,18 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
                     sepchar, datebuf);
         sepchar = ' ';
     }
+
+    if (fetchitems & FETCH_LASTUPDATED) {
+        time_t msgdate = record.last_updated;
+        char datebuf[RFC3501_DATETIME_MAX+1];
+
+        time_to_rfc3501(msgdate, datebuf, sizeof(datebuf));
+
+        prot_printf(state->out, "%cLASTUPDATED \"%s\"",
+                    sepchar, datebuf);
+        sepchar = ' ';
+    }
+
     if (fetchitems & FETCH_MODSEQ || (ischanged && (client_capa & CAPA_CONDSTORE))) {
         prot_printf(state->out, "%cMODSEQ (" MODSEQ_FMT ")",
                     sepchar, record.modseq);

--- a/imap/ipurge.c
+++ b/imap/ipurge.c
@@ -259,7 +259,8 @@ static int purge_one(const mbname_t *mbname)
 
 static int purge_findall(struct findall_data *data, void *rock __attribute__((unused)))
 {
-    if (!data || !data->mbname) return 0;
+    if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
     return purge_one(data->mbname);
 }
 

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -194,7 +194,8 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
     int j;
 
     /* don't want partial matches */
-    if (!data || !data->mbname) return 0;
+    if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
 
     signals_poll();
 
@@ -362,7 +363,8 @@ static int do_quota(struct findall_data *data, void *rock __attribute__((unused)
     struct stat sbuf;
 
     /* don't want partial matches */
-    if (!data || !data->mbname) return 0;
+    if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
 
     signals_poll();
 
@@ -432,7 +434,8 @@ static int do_compare(struct findall_data *data, void *rock __attribute__((unuse
     uint32_t *uids = NULL, nalloc, count = 0, msgno;
 
     /* don't want partial matches */
-    if (!data || !data->mbname) return 0;
+    if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
 
     signals_poll();
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2832,10 +2832,6 @@ static int find_p(void *rockp,
 
     /* check acl */
     if (!rock->isadmin) {
-        /* always suppress deleted for non-admin */
-        if (mbname_isdeleted(rock->mbname)) goto nomatch;
-
-        /* check the acls */
         if (!(cyrus_acl_myrights(rock->auth_state, rock->mbentry->acl) & ACL_LOOKUP)) goto nomatch;
     }
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2841,10 +2841,10 @@ static int find_p(void *rockp,
 
 good:
     if (rock->p) {
-        struct findall_data fdata = { extname, 0, rock->mbentry, NULL };
+        struct findall_data fdata = { extname, 0, rock->mbentry, rock->mbname, 0 };
         /* mbname confirms that it's an exact match */
         if (rock->matchlen == (int) strlen(extname))
-            fdata.mbname = rock->mbname;
+            fdata.is_exactmatch = 1;
         if (!rock->p(&fdata, rock->procrock)) goto nomatch;
         return 1;
     }
@@ -2881,7 +2881,7 @@ static int find_cb(void *rockp,
     const char *extname = mbname_extname(rock->mbname, rock->namespace, rock->userid);
     testname = xstrndup(extname, rock->matchlen);
 
-    struct findall_data fdata = { testname, rock->mb_category, rock->mbentry, NULL };
+    struct findall_data fdata = { testname, rock->mb_category, rock->mbentry, rock->mbname, 0 };
 
     if (rock->singlepercent) {
         char sep = rock->namespace->hier_sep;
@@ -2910,7 +2910,7 @@ static int find_cb(void *rockp,
 
     /* mbname confirms that it's an exact match */
     if (rock->matchlen == (int)strlen(extname))
-        fdata.mbname = rock->mbname;
+        fdata.is_exactmatch = 1;
 
     r = (*rock->cb)(&fdata, rock->procrock);
 

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -249,6 +249,7 @@ struct findall_data {
     int mb_category;
     const mbentry_t *mbentry;
     const mbname_t *mbname;
+    int is_exactmatch;
 };
 
 typedef int findall_p(struct findall_data *data, void *rock);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1131,8 +1131,8 @@ EXPORTED const char *mbname_extname(const mbname_t *mbname, const struct namespa
         goto end;
     }
 
-    /* other users */
-    if (strcmpsafe(mbname_userid(mbname), userid)) {
+    /* other users or DELETED */
+    if (mbname->is_deleted || strcmpsafe(mbname_userid(mbname), userid)) {
         buf_appendcstr(&buf, "user");
         buf_putc(&buf, ns->hier_sep);
         _append_extbuf(ns, &buf, mbname_localpart(mbname));

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -920,7 +920,10 @@ EXPORTED const char *mbname_recipient(const mbname_t *mbname, const struct names
 EXPORTED int mbname_category(const mbname_t *mbname, const struct namespace *ns, const char *userid)
 {
     if (!mbname_localpart(mbname)) return MBNAME_SHARED;
-    if (mbname_isdeleted(mbname)) return MBNAME_SHARED;
+    if (mbname_isdeleted(mbname)) {
+        if (strcmpsafe(mbname_userid(mbname), userid)) return MBNAME_OTHERDELETED;
+        return MBNAME_OWNERDELETED;
+    }
 
     if (strcmpsafe(mbname_userid(mbname), userid)) return MBNAME_OTHERUSER;
 

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -64,7 +64,9 @@ enum { MBNAME_INBOX = 1,
        MBNAME_ALTPREFIX = 4,
        MBNAME_OWNER = 5,
        MBNAME_OTHERUSER = 6,
-       MBNAME_SHARED = 7 };
+       MBNAME_SHARED = 7,
+       MBNAME_OWNERDELETED = 8,
+       MBNAME_OTHERDELETED = 9 };
 
 /* structure holding server namespace info */
 struct namespace {

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -252,12 +252,14 @@ static int do_reid(const mbname_t *mbname)
 int do_cmd(struct findall_data *data, void *rock)
 {
     if (!data) return 0;
+    if (!data->is_exactmatch) return 0;
+
     int *valp = (int *)rock;
 
-    if (*valp == CMD_TIME && data->mbname != NULL)
+    if (*valp == CMD_TIME)
         return do_timestamp(data->mbname);
 
-    if (*valp == CMD_REID && data->mbname != NULL)
+    if (*valp == CMD_REID)
         return do_reid(data->mbname);
 
     return 0;

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -332,7 +332,7 @@ static int count_users_mailboxes(struct findall_data *data, void *rock)
     struct partition_data *pdata;
 
     /* don't want partial matches */
-    if (!data || !data->mbname || !data->mbentry) return 0;
+    if (!data || !data->is_exactmatch) return 0;
 
     /* don't want intermediates XXX unless we do? in which case count them! */
     if (!data->mbentry->partition) return 0;

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -444,7 +444,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
     const char *name = NULL;
 
     /* ignore partial matches */
-    if (!data->mbname) return 0;
+    if (!data->is_exactmatch) return 0;
 
     signals_poll();
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -141,6 +141,9 @@ are listed with ``<none>''.
   backend (e.g., sasldb), and that the system can provide enough entropy
   (e.g., from /dev/urandom) to create a challenge in the banner. */
 
+{ "allowdeleted", 0, SWITCH }
+/* Allow access to deleted and expunged data via vendor.cmu-* access */
+
 { "allownewnews", 0, SWITCH }
 /* Allow use of the NNTP NEWNEWS command.
 .PP


### PR DESCRIPTION
This branch adds the ability to:

* list deleted mailboxes using VENDOR.FM-INCLUDE-DELETED
* select deleted mailboxes using VENDOR.FM-ALLOW-DELETED
* see \Expunged messages by selecting mailboxes using VENDOR.FM-INCLUDE-EXPUNGED

There isn't a place (yet) in Alt Namespace for these DELETED folders to appear, but maybe one day we will create one.

The intent of this is a framework on which to build restore tools.