### PR TITLE
configurable cyr_virusscan notification text

### DIFF
--- a/cunit/buf.testc
+++ b/cunit/buf.testc
@@ -1592,6 +1592,51 @@ static void test_appendoverlap(void)
     buf_free(&buf);
 }
 
+static void test_tocrlf(void)
+{
+    struct testcase {
+        char *input;
+        char *expect;
+    };
+
+    struct testcase testcases[] = {
+        { "\rleading bare cr", "\r\nleading bare cr" },
+        { "\nleading bare lf", "\r\nleading bare lf" },
+        { "\r\nleading crlf", "\r\nleading crlf" },
+        { "bare\rcr", "bare\r\ncr" },
+        { "bare\nlf", "bare\r\nlf" },
+        { "correct\r\ncrlf", "correct\r\ncrlf" },
+        { "trailing bare cr\r", "trailing bare cr\r\n" },
+        { "trailing bare lf\n", "trailing bare lf\r\n" },
+        { "trailing crlf\r\n", "trailing crlf\r\n" },
+        { "multiple\rbare\rcr", "multiple\r\nbare\r\ncr" },
+        { "multiple\nbare\nlf", "multiple\r\nbare\r\nlf" },
+        { "multiple\r\ncrlf\r\n", "multiple\r\ncrlf\r\n" },
+        { "mixed cr\rand\nlf", "mixed cr\r\nand\r\nlf" },
+        { "mixed bare\rcr, bare\nlf and\r\ncrlf",
+           "mixed bare\r\ncr, bare\r\nlf and\r\ncrlf" },
+        { "adjacent\r\rbare cr", "adjacent\r\n\r\nbare cr" },
+        { "adjacent\n\nbare lf", "adjacent\r\n\r\nbare lf" },
+        { "adjacent\r\n\r\ncrlf", "adjacent\r\n\r\ncrlf" },
+        { "more adjacent\r\r\rbare cr", "more adjacent\r\n\r\n\r\nbare cr" },
+        { "more adjacent\n\n\nbare lf", "more adjacent\r\n\r\n\r\nbare lf" },
+        { "more adjacent\r\n\r\n\r\ncrlf", "more adjacent\r\n\r\n\r\ncrlf" },
+        { "adjacent\n\nbare\r\rmixed", "adjacent\r\n\r\nbare\r\n\r\nmixed" },
+        { "tricksy\r\r\n\nsplit", "tricksy\r\n\r\n\r\nsplit" },
+    };
+
+    struct buf buf = BUF_INITIALIZER;
+    size_t i;
+    for (i = 0; i < sizeof(testcases) / sizeof(testcases[0]); i++) {
+        struct testcase tc = testcases[i];
+        buf_setcstr(&buf, tc.input);
+        buf_tocrlf(&buf);
+        CU_ASSERT_STRING_EQUAL(tc.expect, buf_cstring(&buf));
+        buf_reset(&buf);
+    }
+    buf_free(&buf);
+}
+
 /* TODO: test the Copy-On-Write feature of buf_ensure()...if anyone
  * actually uses it */
 /* vim: set ft=c: */

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
@@ -176,7 +176,7 @@ Examples
 
             Message-ID: <201308131519.r7DFJM9K083763@tselina.kiev.ua>
             Date: Tue, 13 Aug 2013 18:19:22 +0300 (EEST)
-            From: ("FEDEX Thomas Cooper" NIL "thomas_cooper94" "themovieposterpage.com")
+            From: "FEDEX Thomas Cooper" <thomas_cooper94@themovieposterpage.com>
             Subject: Problem with the delivery of parcel
             IMAP UID: 17426
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
@@ -1,5 +1,7 @@
 .. cyrusman:: cyr_virusscan(8)
 
+.. highlight:: none
+
 .. author: Nic Bernstein (Onlight)
 
 .. _imap-reference-manpages-systemcommands-cyr_virusscan:
@@ -35,9 +37,10 @@ A table of infected messages will be output.
 To remove infected messages, use the **-r** flag. Infected messages will be expunged
 from the user's mailbox.
 
-With the notify flag, **-n**, notifications will be appended to the inbox of the mailbox owner,
-containing message digest information for the affected mail.  This
-flag is only works in combination with **-r**.
+With the notify flag, **-n**, notifications will be appended to the inbox of
+the mailbox owner, containing message digest information for the affected mail.
+This flag only works in combination with **-r**.  The notification message
+can by customised by template, for details see `Notifications`_ below.
 
 **cyr_virusscan** can be configured to run periodically by cron(8)
 via crontab(5) or your preferred method (i.e. /etc/cron.hourly), or by
@@ -77,6 +80,44 @@ Options
 
     Produce more verbose output
 
+Notifications
+=============
+
+When the **-n** flag is provided, notifications are sent to mailbox owners
+when infected messages are removed.  One notification is sent per owner,
+containing a digest of each message that was deleted from any of their
+mailboxes.
+
+The default notification subject is "Automatically deleted mail", which
+can be overridden by setting ``virusscan_notification_subject`` in
+:cyrusman:`imapd.conf(5)` to a UTF-8 value.
+
+Each infected message will be described according to the following template::
+
+	The following message was deleted from mailbox '%MAILBOX%'
+	because it was infected with virus '%VIRUS%'
+
+	    Message-ID: %MSG_ID%
+	    Date: %MSG_DATE%
+	    From: %MSG_FROM%
+	    Subject: %MSG_SUBJECT%
+	    IMAP UID: %MSG_UID%
+
+To use a custom template, create a UTF-8 file containing your desired text
+and using the same %-delimited substitutions as above, and set the
+``virusscan_notification_template`` option in :cyrusman:`imapd.conf(5)` to
+its path.
+
+The notification message will be properly MIME-encoded at delivery. Do not
+pre-encode the template file or the subject!
+
+When **cyr_virusscan** starts up, if notifications have been requested (with
+the **-n** flag), a basic sanity check of the template will be performed
+prior to initialising the antivirus engine.  If it appears that the
+resultant notifications would be undeliverable for some reason,
+**cyr_virusscan** will exit immediately with an error, rather than risk
+deleting messages without notifying.
+
 Examples
 ========
 
@@ -114,7 +155,7 @@ Examples
 ..
 
         Scan mailbox *user/bovik*, removing infected messages and append
-        notifications to bovik's inbox.
+        notifications to Bovik's inbox.
 
 .. only:: html
 
@@ -130,7 +171,7 @@ Examples
 
     ::
 
-        The following message was deleted from mailbox 'Inbox.bovik'
+        The following message was deleted from mailbox 'INBOX'
         because it was infected with virus 'Email.Trojan.Trojan-1051'
 
             Message-ID: <201308131519.r7DFJM9K083763@tselina.kiev.ua>

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -253,7 +253,8 @@ unsigned virus_check(struct mailbox *mailbox,
 void append_notifications();
 
 
-int main (int argc, char *argv[]) {
+int main (int argc, char *argv[])
+{
     int option;         /* getopt() returns an int */
     char *alt_config = NULL;
     char *search_str = NULL;

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -133,6 +133,7 @@ struct clamav_state {
 void *clamav_init()
 {
     unsigned int sigs = 0;
+    int64_t starttime;
     int r;
 
     /* initialise ClamAV library */
@@ -153,12 +154,14 @@ void *clamav_init()
 
     /* load all available databases from default directory */
     if (verbose) puts("Loading virus signatures...");
+    starttime = now_ms();
     if ((r = cl_load(cl_retdbdir(), st->av_engine, &sigs, CL_DB_STDOPT))) {
         syslog(LOG_ERR, "cl_load: %s", cl_strerror(r));
         fatal(cl_strerror(r), EX_SOFTWARE);
     }
 
-    printf("Loaded %d virus signatures.\n", sigs);
+    printf("Loaded %d virus signatures (%.3f seconds).\n",
+           sigs, (now_ms() - starttime)/1000.0);
 
     /* build av_engine */
     if ((r = cl_engine_compile(st->av_engine))) {

--- a/imap/message.c
+++ b/imap/message.c
@@ -2759,7 +2759,7 @@ EXPORTED char *parse_nstring(char **str)
     return val;
 }
 
-HIDDEN void message_parse_env_address(char *str, struct address *addr)
+EXPORTED void message_parse_env_address(char *str, struct address *addr)
 {
     if (*str == '(') str++; /* skip ( */
     addr->name = parse_nstring(&str);

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2700,6 +2700,12 @@ of the incoming network interface, or if no record is found, the
 /* The text used in the subject of email notifications created by
    \fBcyr_virusscan(8)\fR when deleting infected mail. */
 
+{ "virusscan_notification_template", NULL, STRING }
+/* The absolute path to a file containing a template to use to describe
+   infected messages that have been deleted by \fBcyr_virusscan(8)\fR.
+   See \fBcyr_virusscan(8)\fR for specification of the format of this file.
+   If not specified, the builtin default template will be used. */
+
 { "xbackup_enabled", 0, SWITCH }
 /* Enable support for the XBACKUP command in imapd.  If enabled, admin
    users can use this command to provoke a replication of specified users

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2696,6 +2696,10 @@ of the incoming network interface, or if no record is found, the
 .PP
     */
 
+{ "virusscan_notification_subject", "Automatically deleted mail", STRING }
+/* The text used in the subject of email notifications created by
+   \fBcyr_virusscan(8)\fR when deleting infected mail. */
+
 { "xbackup_enabled", 0, SWITCH }
 /* Enable support for the XBACKUP command in imapd.  If enabled, admin
    users can use this command to provoke a replication of specified users

--- a/lib/util.c
+++ b/lib/util.c
@@ -1637,6 +1637,27 @@ EXPORTED const char *buf_ucase(struct buf *buf)
     return buf->s;
 }
 
+EXPORTED const char *buf_tocrlf(struct buf *buf)
+{
+    size_t i;
+
+    buf_cstring(buf);
+
+    for (i = 0; i < buf->len; i++) {
+        if (buf->s[i] == '\r' && buf->s[i+1] != '\n') {
+            /* bare \r: add a \n after it */
+            buf_insertcstr(buf, i+1, "\n");
+        }
+        else if (buf->s[i] == '\n') {
+            if (i == 0 || buf->s[i-1] != '\r') {
+                buf_insertcstr(buf, i, "\r");
+            }
+        }
+    }
+
+    return buf->s;
+}
+
 EXPORTED void buf_trim(struct buf *buf)
 {
     size_t i;

--- a/lib/util.h
+++ b/lib/util.h
@@ -319,6 +319,7 @@ void buf_free(struct buf *buf);
 void buf_move(struct buf *dst, struct buf *src);
 const char *buf_lcase(struct buf *buf);
 const char *buf_ucase(struct buf *buf);
+const char *buf_tocrlf(struct buf *buf);
 void buf_trim(struct buf *buf);
 
 /*


### PR DESCRIPTION
Adds two new imapd.conf options, for the notification subject and a template digest chunk respectively.  The defaults are the same as the old version, but converted to use the template style message construction.

Fixes the "From:" field of the digest chunks to look like a normal from header, instead of a dlist straight out of mailbox cache.

Fixes how the "mailbox" is reported to calculate an extname correctly

Failure to append a notification is now logged(!), and the template is checked early so if it looks un-appendable, we can bail out before deleting messages, instead of deleting them then being unable to notify that we did so

Notification messages are now properly MIME-encoded (I think!), so non-ascii mailbox names won't produce an invalid notification, and the custom template is expected to be in utf-8 so non-English notifications should Just Work.

Cassandane tests in https://github.com/cyrusimap/cassandane/compare/master...elliefm:v31/2516-virusscan-custom-notification-text

Closes #2516 and #1845 