### PR TITLE
[docs] Update URL for weekly meetings

### DIFF
--- a/docsrc/imap/support/feedback-meetings.rst
+++ b/docsrc/imap/support/feedback-meetings.rst
@@ -8,4 +8,4 @@ Join us online!
 
 Regular contributors catch up online weekly, both as a status checkpoint and to make sure we're all alive!
 
-Meetings are currently held at **Monday 11:00 UTC** via `Google Hangouts <https://plus.google.com/hangouts/_/g4xnqjjb5zvomzeb4kqvja3fz4a>`_. It's worth checking on :ref:`IRC <feedback-irc>` to confirm the time and URL if nobody else seems to be online.
+Meetings are currently held at **Monday 11:00 UTC** via `Zoom <https://zoom.us/j/598343302>`_. It's worth checking on :ref:`IRC <feedback-irc>` to confirm the time and URL if nobody else seems to be online.


### PR DESCRIPTION
According to <https://lists.andrew.cmu.edu/pipermail/cyrus-devel/2019-August/004505.html> weekly meetings now happen on Zoom.