### PR TITLE
Add compatibility for Sphinx 2 (fixes #2732)

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('exts'))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.2'
+needs_sphinx = '1.3.2'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -301,7 +301,7 @@ current = os.path.abspath(os.getcwd())
 for tuple in pathset:
     os.chdir(tuple[0])
     for rstfile in glob.glob("*.rst"):
-        author = [("The Cyrus Team")]
+        authors = [("The Cyrus Team")]
         orphan = 'False';
         with io.open(rstfile,'r',encoding="utf8") as f:
             for line in f:
@@ -309,14 +309,14 @@ for tuple in pathset:
                     orphan = 'True';
                     break;
                 if line.startswith('.. author: '):
-                    author.append(line[11: len(line.strip())])
+                    authors.append(line[11: len(line.strip())])
             f.close()
         if orphan == 'False':
             man_pages.append(
                 (os.path.splitext(os.path.join(tuple[0],rstfile))[0],
                 os.path.splitext(rstfile)[0],
                 u'Cyrus IMAP documentation',
-                author,
+                authors,
                 tuple[1])
                 )
 

--- a/docsrc/exts/sphinxlocal/builders/manpage.py
+++ b/docsrc/exts/sphinxlocal/builders/manpage.py
@@ -32,6 +32,12 @@ from sphinx.builders.manpage import ManualPageBuilder
 # Translater in it.
 from sphinxlocal.writers.manpage import CyrusManualPageWriter
 
+try:
+    from sphinx.util import logging
+    logger = logging.getLogger(__name__)
+except:
+    logger = None
+
 class CyrusManualPageBuilder(ManualPageBuilder):
     """
     Builds groff output in manual page format.
@@ -44,8 +50,11 @@ class CyrusManualPageBuilder(ManualPageBuilder):
     #settings_defaults = {}
 
     def init(self):
+        global logger
+        if logger is None:
+            logger = self
         if not self.config.man_pages:
-            self.warn('no "man_pages" config value found; no manual pages '
+            logger.warn('no "man_pages" config value found; no manual pages '
                       'will be written')
 
     def write(self, *ignored):
@@ -56,7 +65,7 @@ class CyrusManualPageBuilder(ManualPageBuilder):
             components=(docwriter,),
             read_config_files=True).get_default_values()
 
-        self.info(bold('writing... '), nonl=True)
+        logger.info(bold('writing... '), nonl=True)
 
         for info in self.config.man_pages:
             docname, name, description, authors, section = info
@@ -67,7 +76,7 @@ class CyrusManualPageBuilder(ManualPageBuilder):
                     authors = []
 
             targetname = '%s.%s' % (name, section)
-            self.info(darkgreen(targetname) + ' { ', nonl=True)
+            logger.info(darkgreen(targetname) + ' { ', nonl=True)
             destination = FileOutput(
                 destination_path=path.join(self.outdir, targetname),
                 encoding='utf-8')
@@ -76,7 +85,7 @@ class CyrusManualPageBuilder(ManualPageBuilder):
             docnames = set()
             largetree = inline_all_toctrees(self, docnames, docname, tree,
                                             darkgreen, [docname])
-            self.info('} ', nonl=True)
+            logger.info('} ', nonl=True)
             self.env.resolve_references(largetree, docname, self)
             # remove pending_xref nodes
             for pendingnode in largetree.traverse(addnodes.pending_xref):
@@ -89,7 +98,7 @@ class CyrusManualPageBuilder(ManualPageBuilder):
             largetree.settings.section = section
 
             docwriter.write(largetree, destination)
-        self.info()
+        logger.info('')
 
 def setup(app):
     app.add_builder(CyrusManualPageBuilder)

--- a/docsrc/exts/sphinxlocal/roles/cyrusman.py
+++ b/docsrc/exts/sphinxlocal/roles/cyrusman.py
@@ -17,8 +17,17 @@ from docutils.parsers.rst.roles import set_classes
 from string import Template
 import re
 
+try:
+    from sphinx.util import logging
+    logger = logging.getLogger(__name__)
+except:
+    logger = None
+
 def setup(app):
-    app.info('Initializing cyrusman plugin')
+    global logger
+    if logger is None:
+        logger = app
+    logger.info('Initializing cyrusman plugin')
     app.add_crossref_type('cyrusman', 'cyrusman', '%s', nodes.generated)
     return
 

--- a/docsrc/exts/sphinxlocal/writers/manpage.py
+++ b/docsrc/exts/sphinxlocal/writers/manpage.py
@@ -12,12 +12,16 @@
     :license: BSD, see LICENSE for details.
 """
 
+import docutils
 from docutils import nodes
 from sphinx.writers.manpage import (
-    MACRO_DEF,
     ManualPageWriter,
     ManualPageTranslator as BaseTranslator
 )
+
+docutils_version_info = tuple(map(int, docutils.__version__.split('.')))
+if docutils_version_info < (0, 11):
+  from sphinx.writers.manpage import MACRO_DEF
 
 
 from sphinx import addnodes
@@ -73,8 +77,9 @@ class CyrusManualPageTranslator(BaseTranslator):
         self._docinfo['version'] = builder.config.version
         self._docinfo['manual_group'] = builder.config.project
 
-        # since self.append_header() is never called, need to do this here
-        self.body.append(MACRO_DEF)
+        # In docutils < 0.11 self.append_header() was never called
+        if docutils_version_info < (0, 11):
+          self.body.append(MACRO_DEF)
 
         # overwritten -- don't wrap literal_block with font calls
         self.defs['literal_block'] = ('.sp\n.nf\n', '\n.fi\n')


### PR DESCRIPTION
This allows the documentation to be generated using version 2 of Sphinx – which is particularly handy on rolling release distros like Arch where version 2 is the only version conveniently available from the repositories. Nearly all of the changes are directly based on changes in upstream Sphinx, however they have been adapted to also keep compatibility with version 1.3.2 (which is the minimum version required by the current configuration and not much older than 1.3.6 – the version used to generate the website. On that note, the conf.py in master incorrectly states a minimum version of 1.2, so I updated that while I was at it). Should that much backwards compatibility not actually be necessary, I could also simplify the changes quite a bit. I *think* with a minimum version of 1.6 none of the BC mechanisms should be needed.

If these changes are okay, it would be nice to have them in 3.0 as well.