### PR TITLE
Modification of the year of the launch of Cyrus' development

### DIFF
--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -32,7 +32,7 @@ Features
 
 Read more in our full :ref:`list of features <imap-features>`.
 
-Cyrus has been under active development since the year 1993 when the project was launch at Carnegie Mellon University. It's used in production
+Cyrus has been under active development since the year 1993 when the project was launched at Carnegie Mellon University. It's used in production
 systems around the world, at universities and in private enterprise.
 
 Need help? We have :ref:`active mailing lists <feedback-mailing-lists>`.

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -32,7 +32,7 @@ Features
 
 Read more in our full :ref:`list of features <imap-features>`.
 
-Cyrus has been under active development since the year 2000. It's used in production
+Cyrus has been under active development since the year 1993 when the project was launch at Carnegie Mellon University. It's used in production
 systems around the world, at universities and in private enterprise.
 
 Need help? We have :ref:`active mailing lists <feedback-mailing-lists>`.


### PR DESCRIPTION
In order not to confuse the beginning of Cyrus it is important to note that Cyrus has been under development since late 1993 and early 1994 as reported in the code history https://www.openhub.net/p/cyrus-imap/commits/summary