### PR TITLE
libcyrus(_min).so: move *_method_desc to read-only segments

### DIFF
--- a/lib/cyr_lock.h
+++ b/lib/cyr_lock.h
@@ -53,7 +53,7 @@
 
 #include <sys/stat.h>
 
-extern const char *lock_method_desc;
+extern const char lock_method_desc[];
 
 extern double debug_locks_longer_than;
 

--- a/lib/lock_fcntl.c
+++ b/lib/lock_fcntl.c
@@ -52,7 +52,7 @@
 #include <syslog.h>
 #include <time.h>
 
-EXPORTED const char *lock_method_desc = "fcntl";
+EXPORTED const char lock_method_desc[] = "fcntl";
 
 EXPORTED double debug_locks_longer_than = 0.0;
 

--- a/lib/lock_flock.c
+++ b/lib/lock_flock.c
@@ -51,7 +51,7 @@
 
 #include "cyr_lock.h"
 
-EXPORTED const char *lock_method_desc = "flock";
+EXPORTED const char lock_method_desc[] = "flock";
 
 /*
  * Block until we obtain an exclusive lock on the file descriptor 'fd',

--- a/lib/map.h
+++ b/lib/map.h
@@ -45,7 +45,7 @@
 
 #define MAP_UNKNOWN_LEN ((unsigned long)-1)
 
-extern const char *map_method_desc;
+extern const char map_method_desc[];
 
 /* Create a memory map
  *

--- a/lib/map_nommap.c
+++ b/lib/map_nommap.c
@@ -53,7 +53,7 @@
 
 #define SLOP (4*1024)
 
-EXPORTED const char *map_method_desc = "nommap";
+EXPORTED const char map_method_desc[] = "nommap";
 
 /*
  * Create/refresh mapping of file

--- a/lib/map_shared.c
+++ b/lib/map_shared.c
@@ -53,7 +53,7 @@
 
 #define SLOP (8*1024)
 
-EXPORTED const char *map_method_desc = "shared";
+EXPORTED const char map_method_desc[] = "shared";
 
 /*
  * Create/refresh mapping of file

--- a/lib/map_stupidshared.c
+++ b/lib/map_stupidshared.c
@@ -51,7 +51,7 @@
 #include "map.h"
 #include "xmalloc.h"
 
-EXPORTED const char *map_method_desc = "stupidshared";
+EXPORTED const char map_method_desc[] = "stupidshared";
 
 #ifndef MAP_FAILED
 #define MAP_FAILED ((void *)-1)

--- a/lib/nonblock.h
+++ b/lib/nonblock.h
@@ -43,7 +43,7 @@
 #ifndef INCLUDED_NONBLOCK_H
 #define INCLUDED_NONBLOCK_H
 
-extern const char *nonblock_method_desc;
+extern const char nonblock_method_desc[];
 
 extern void nonblock(int fd, int mode);
 

--- a/lib/nonblock_fcntl.c
+++ b/lib/nonblock_fcntl.c
@@ -59,7 +59,7 @@
 #define NON_BLOCKING_MODE FNDELAY
 #endif
 
-EXPORTED const char *nonblock_method_desc = "fcntl";
+EXPORTED const char nonblock_method_desc[] = "fcntl";
 
 /*
  * Modifies the non-blocking mode on the file descriptor 'fd'.  If

--- a/lib/nonblock_ioctl.c
+++ b/lib/nonblock_ioctl.c
@@ -49,7 +49,7 @@
 /* for fatal */
 #include "xmalloc.h"
 
-EXPORTED const char *nonblock_method_desc = "ioctl";
+EXPORTED const char nonblock_method_desc[] = "ioctl";
 
 /*
  * Modifies the non-blocking mode on the file descriptor 'fd'.  If


### PR DESCRIPTION
So that the users of the libraries do not get their own copy for the lock_method_desc, map_method_desc and nonblock_method_desc symbols.