### PR TITLE
master: option to treat bind errors as fatal

### DIFF
--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1468,6 +1468,11 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* Notifyd(8) method to use for "MAIL" notifications.  If not set, "MAIL"
    notifications are disabled. */
 
+{ "master_bind_errors_fatal", 0, SWITCH, "3.1.10" }
+/* If enabled, failure to bind a port is treated as a fatal error, causing
+   master to shut down immediately.  The default is to keep running, with
+   the affected service disabled until the next SIGHUP causes it to retry. */
+
 { "maxheaderlines", 1000, INT, "2.3.17" }
 /* Maximum number of lines of header that will be processed into cache
    records.  Default 1000.  If set to zero, it is unlimited.

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1469,9 +1469,14 @@ Blank lines and lines beginning with ``#'' are ignored.
    notifications are disabled. */
 
 { "master_bind_errors_fatal", 0, SWITCH, "3.1.10" }
-/* If enabled, failure to bind a port is treated as a fatal error, causing
-   master to shut down immediately.  The default is to keep running, with
-   the affected service disabled until the next SIGHUP causes it to retry. */
+/* If enabled, failure to bind a port during startup is treated as a fatal
+   error, causing master to shut down immediately.  The default is to keep
+   running, with the affected service disabled until the next SIGHUP causes
+   it to retry.
+.PP
+   Note that this only applies during startup.  New services that fail to
+   come up in response to a reconfig+SIGHUP will just be logged and disabled
+   like the default behaviour, without causing master to exit. */
 
 { "maxheaderlines", 1000, INT, "2.3.17" }
 /* Maximum number of lines of header that will be processed into cache

--- a/master/master.c
+++ b/master/master.c
@@ -658,6 +658,14 @@ static void service_create(struct service *s)
         r = cap_bind(s->socket, res->ai_addr, res->ai_addrlen);
         umask(oldumask);
         if (r < 0) {
+            int e = errno;
+            if (config_getswitch(IMAPOPT_MASTER_BIND_ERRORS_FATAL)) {
+                struct buf buf = BUF_INITIALIZER;
+                buf_printf(&buf, "unable to bind to %s/%s socket: %s",
+                                 s->name, s->familyname, strerror(e));
+                fatal(buf_cstring(&buf), EX_UNAVAILABLE);
+            }
+
             syslog(LOG_ERR, "unable to bind to %s/%s socket: %m",
                 s->name, s->familyname);
             xclose(s->socket);


### PR DESCRIPTION
This is the least-overthinky implementation of #2902 

Questions presently unanswered:

* should errors from the other socket-setup calls (socket(2), listen(2)) on this code path also be fatal with this option, or only bind(2)?
* does a bind on one getaddrinfo result ever fail when a bind on a subsequent result would have succeeded? (I don't think so)
* if the bind fails while setting up new services in an existing master process (i.e. after SIGHUP to provoke a cyrus.conf reread), should this situation be treated differently somehow?
* if there are already service processes running, should these be shut down?