### PR TITLE
Make sure socket paths in example configuration match

### DIFF
--- a/doc/examples/cyrus_conf/cmu-backend.conf
+++ b/doc/examples/cyrus_conf/cmu-backend.conf
@@ -8,7 +8,7 @@ START {
   mupdatepush   cmd="ctl_mboxlist -m"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/sockets
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # add or remove based on preferences
   imap          cmd="imapd" listen="imap" prefork=5

--- a/doc/examples/cyrus_conf/cmu-frontend.conf
+++ b/doc/examples/cyrus_conf/cmu-frontend.conf
@@ -4,7 +4,7 @@ START {
   mboxlist      cmd="ctl_cyrusdb -r"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/sockets
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # mupdate database service - must prefork atleast 1
   mupdate       cmd="/usr/cyrus/bin/mupdate" listen=2004 prefork=1

--- a/doc/examples/cyrus_conf/murder-backend.conf
+++ b/doc/examples/cyrus_conf/murder-backend.conf
@@ -10,7 +10,7 @@ START {
   mupdatepush   cmd="ctl_mboxlist -m"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/socket
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # add or remove based on preferences
   imap          cmd="imapd" listen="imap" prefork=0
@@ -29,10 +29,10 @@ SERVICES {
 
   # at least one LMTP is required for delivery
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
-  lmtpunix      cmd="lmtpd" listen="/var/imap/socket/lmtp" prefork=0
+  lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
   # this is required if using notifications
-#  notify        cmd="notifyd" listen="/var/imap/socket/notify" proto="udp" prefork=1
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {

--- a/doc/examples/cyrus_conf/murder-frontend.conf
+++ b/doc/examples/cyrus_conf/murder-frontend.conf
@@ -5,7 +5,7 @@ START {
   recover       cmd="ctl_cyrusdb -r"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/socket
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
 	# proxies that will connect to the backends, add or remove based on
   # site preferences (lmtp below)
@@ -32,7 +32,7 @@ SERVICES {
 	mupdate       cmd="mupdate" listen="mupdate" prefork=1
 
   # this is required if using notifications
-#  notify        cmd="notifyd" listen="/var/imap/socket/notify" proto="udp" prefork=1
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {

--- a/doc/examples/cyrus_conf/normal-master.conf
+++ b/doc/examples/cyrus_conf/normal-master.conf
@@ -10,7 +10,7 @@ START {
   offsitesync   cmd="sync_client -r -n offsite"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/socket
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # add or remove based on preferences
   imap          cmd="imapd" listen="imap" prefork=0
@@ -29,13 +29,13 @@ SERVICES {
 
   # at least one LMTP is required for delivery
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
-  lmtpunix      cmd="lmtpd" listen="/var/imap/socket/lmtp" prefork=0
+  lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
   # this is requied if using socketmap
-#  smmap         cmd="smmapd" listen="/var/imap/socket/smmap" prefork=0
+#  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=0
 
   # this is required if using notifications
-#  notify        cmd="notifyd" listen="/var/imap/socket/notify" proto="udp" prefork=1
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {

--- a/doc/examples/cyrus_conf/normal-replica.conf
+++ b/doc/examples/cyrus_conf/normal-replica.conf
@@ -5,7 +5,7 @@ START {
   recover       cmd="ctl_cyrusdb -r"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/socket
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # add or remove based on preferences
   imap          cmd="imapd" listen="imap" prefork=0
@@ -24,10 +24,10 @@ SERVICES {
 
   # at least one LMTP is required for delivery
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
-  lmtpunix      cmd="lmtpd" listen="/var/imap/socket/lmtp" prefork=0
+  lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
   # this is requied if using socketmap
-#  smmap         cmd="smmapd" listen="/var/imap/socket/smmap" prefork=0
+#  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=0
 
 	# Synchronization for remote replication.
   # Note: This usage is deprecated. Modern (post 3.0) Cyrus supports
@@ -35,7 +35,7 @@ SERVICES {
 #  syncserver    cmd="sync_server" listen="csync"
   
   # this is required if using notifications
-#  notify        cmd="notifyd" listen="/var/imap/socket/notify" proto="udp" prefork=1
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {

--- a/doc/examples/cyrus_conf/normal.conf
+++ b/doc/examples/cyrus_conf/normal.conf
@@ -5,7 +5,7 @@ START {
   recover       cmd="ctl_cyrusdb -r"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/socket
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # add or remove based on preferences
   imap          cmd="imapd" listen="imap" prefork=0
@@ -24,13 +24,13 @@ SERVICES {
 
   # at least one LMTP is required for delivery
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
-  lmtpunix      cmd="lmtpd" listen="/var/imap/socket/lmtp" prefork=0
+  lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
   # this is requied if using socketmap
-#  smmap         cmd="smmapd" listen="/var/imap/socket/smmap" prefork=0
+#  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=0
 
   # this is required if using notifications
-#  notify        cmd="notifyd" listen="/var/imap/socket/notify" proto="udp" prefork=1
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {

--- a/doc/examples/cyrus_conf/prefork.conf
+++ b/doc/examples/cyrus_conf/prefork.conf
@@ -5,7 +5,7 @@ START {
   recover       cmd="ctl_cyrusdb -r"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/sockets
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # add or remove based on preferences
   imap          cmd="imapd" listen="imap" prefork=5
@@ -24,13 +24,13 @@ SERVICES {
 
   # at least one LMTP is required for delivery
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
-  lmtpunix      cmd="lmtpd" listen="/var/imap/socket/lmtp" prefork=1
+  lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=1
 
   # this is requied if using socketmap
-#  smmap         cmd="smmapd" listen="/var/imap/socket/smmap" prefork=1
+#  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=1
 
   # this is only necessary if using notifications
-#  notify        cmd="notifyd" listen="/var/imap/socket/notify" proto="udp" prefork=1
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {

--- a/doc/examples/cyrus_conf/small.conf
+++ b/doc/examples/cyrus_conf/small.conf
@@ -5,17 +5,17 @@ START {
   recover       cmd="ctl_cyrusdb -r"
 }
 
-# UNIX sockets start with a slash and are put into /var/imap/sockets
+# UNIX sockets start with a slash and are put into /run/cyrus/socket
 SERVICES {
   # add or remove based on preferences
   imap          cmd="imapd" listen="imap" prefork=0
   pop3          cmd="pop3d" listen="pop3" prefork=0
 
   # LMTP is required for delivery
-  lmtpunix      cmd="lmtpd" listen="/var/imap/socket/lmtp" prefork=0
+  lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
   # this is only necessary if using notifications
-#  notify        cmd="notifyd" listen="/var/imap/socket/notify" proto="udp" prefork=1
+#  notify        cmd="notifyd" listen="/run/cyrus/socket/notify" proto="udp" prefork=1
 }
 
 EVENTS {


### PR DESCRIPTION
Currently the example configuration files for cyrus.conf and imapd.conf use different socket paths, even though the imapd.conf examples themselves explicitly state that they should match. This PR adjusts the paths in cyrus.conf examples (/var/imap/socket) to match those in imapd.conf examples (/run/cyrus/socket), since the latter seem to be a bit more commonly referred to in the documentation.