### PR TITLE
Fix missing libcap in Perl module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1525,7 +1525,7 @@ else
 lib_libcyrus_min_la_SOURCES += lib/map_nommap.c
 endif
 endif
-lib_libcyrus_min_la_LIBADD = $(LTLIBOBJS) $(LIB_UUID) $(GCOV_LIBS)
+lib_libcyrus_min_la_LIBADD = $(LTLIBOBJS) $(LIB_UUID) $(GCOV_LIBS) $(LIBCAP_LIBS)
 lib_libcyrus_min_la_CFLAGS = $(AM_CFLAGS) $(CFLAG_VISIBILITY)
 
 lib/chartable.c: lib/mkchartable.pl lib/charset/unifix.txt \

--- a/configure.ac
+++ b/configure.ac
@@ -1384,6 +1384,7 @@ AC_ARG_WITH([libcap],
         with_libcap="${withval}")
 
 have_libcap=no
+LIBCAP_LIBS=""
 case $host_os in
 linux*)
         if test "x$with_libcap" = "xyes"; then
@@ -1391,13 +1392,14 @@ linux*)
                 AC_CHECK_HEADERS([sys/capability.h sys/prctl.h], , have_libcap=no)
                 if test "$have_libcap" = "yes"; then
                         AC_DEFINE(HAVE_LIBCAP, [], [Do we have libcap system capabilities handling (Linux systems only)?])
-                        LIBS="$LIBS -lcap"
+                        LIBCAP_LIBS="-lcap"
                 fi
         fi
         ;;
 *)
         ;;
 esac
+AC_SUBST(LIBCAP_LIBS)
 
 AC_MSG_CHECKING(for libcap)
 AC_MSG_RESULT($have_libcap)

--- a/perl/imap/Makefile.PL.in
+++ b/perl/imap/Makefile.PL.in
@@ -91,7 +91,7 @@ WriteMakefile(
     'LD'       => $Config{ld} . ' @GCOV_LDFLAGS@',
     'OBJECT'    => 'IMAP.o',
     'MYEXTLIB'  => '@top_builddir@/perl/.libs/libcyrus.a @top_builddir@/perl/.libs/libcyrus_min.a',
-    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @ZLIB@ @GCOV_LIBS@"],
+    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @ZLIB@ @GCOV_LIBS@ @LIBCAP_LIBS@"],
     'DEFINE'	=> '-DPERL_POLLUTE',    # e.g., '-DHAVE_SOMETHING'
     'INC'	=> "-I@top_srcdir@ -I@top_srcdir@/com_err/et @SASLFLAGS@ @SSL_CPPFLAGS@ @GCOV_CFLAGS@ -I@top_srcdir@/perl/imap",
     'EXE_FILES' => [cyradm],


### PR DESCRIPTION
Right now, the IMAP perl module is linked with libcyrus_min, which, if enabled, uses libcap, however the Perl module is _never_ linked to libcap. This leads to an error when loading the module:

```console
$ cyradm
Can't load '/usr/lib/perl5/5.30/vendor_perl/auto/Cyrus/IMAP/IMAP.so' for module Cyrus::IMAP: /usr/lib/perl5/5.30/vendor_perl/auto/Cyrus/IMAP/IMAP.so: undefined symbol: cap_set_proc at /usr/lib/perl5/5.30/core_perl/DynaLoader.pm line 193.
 at /usr/lib/perl5/5.30/vendor_perl/Cyrus/IMAP/Admin.pm line 43.
Compilation failed in require at /usr/lib/perl5/5.30/vendor_perl/Cyrus/IMAP/Admin.pm line 43.
BEGIN failed--compilation aborted at /usr/lib/perl5/5.30/vendor_perl/Cyrus/IMAP/Admin.pm line 43.
Compilation failed in require at /usr/lib/perl5/5.30/vendor_perl/Cyrus/IMAP/Shell.pm line 59.
BEGIN failed--compilation aborted at /usr/lib/perl5/5.30/vendor_perl/Cyrus/IMAP/Shell.pm line 59.
Compilation failed in require at /usr/bin/vendor_perl/cyradm line 66.
BEGIN failed--compilation aborted at /usr/bin/vendor_perl/cyradm line 66.
```

To fix this issue, this PR splits the libcap library out of LIBS (to avoid bloat), then adds it to the Perl module.