### PR TITLE
treat cyr_expire and quota cmdline mboxprefix as admin namespace, not internal

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -109,6 +109,8 @@ struct arguments {
     const char *altconfig;
     const char *mbox_prefix;
     const char *userid;
+
+    char *freeme; /* for mbox_prefix */
 };
 
 struct archive_rock {
@@ -210,6 +212,8 @@ static void cyr_expire_init(const char *progname, struct cyr_expire_ctx *ctx)
 
 static void cyr_expire_cleanup(struct cyr_expire_ctx *ctx)
 {
+    if (ctx->args.freeme) free(ctx->args.freeme);
+
     free_hash_table(&ctx->erock.table, free);
     free_hash_table(&ctx->crock.seen, NULL);
     strarray_fini(&ctx->drock.to_delete);
@@ -892,6 +896,13 @@ int main(int argc, char *argv[])
     }
 
     mboxevent_setnamespace(&expire_namespace);
+
+    /* now that we have a namespace, convert mbox_prefix to internal ns */
+    if (ctx.args.mbox_prefix) {
+        char *intname = mboxname_from_external(ctx.args.mbox_prefix,
+                                               &expire_namespace, NULL);
+        ctx.args.mbox_prefix = ctx.args.freeme = intname;
+    }
 
     if (duplicate_init(NULL) != 0) {
         fprintf(stderr,

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -826,6 +826,7 @@ static int parse_args(int argc, char *argv[], struct arguments *args)
             break;
 
         case 'p':
+            if (args->userid) usage();
             args->mbox_prefix = optarg;
             break;
 
@@ -834,6 +835,7 @@ static int parse_args(int argc, char *argv[], struct arguments *args)
             break;
 
         case 'u':
+            if (args->mbox_prefix) usage();
             args->userid = optarg;
             break;
 

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -660,16 +660,16 @@ int fixquota_dopass(char *domain, char **roots, int nroots,
         if (isuser) {
             char *inbox = mboxname_user_mbox(roots[i], NULL);
             r = mboxlist_usermboxtree(roots[i], NULL, cb, inbox, /*flags*/0);
+            if (r) errmsg(IMAP_IOERROR, "processing user '%s'", inbox);
             free(inbox);
         }
         else {
             strlcpy(tail, roots[i], sizeof(buf) - domainlen);
             r = mboxlist_allmbox(buf, cb, buf, /*flags*/0);
+            if (r) errmsg(IMAP_IOERROR, "processing mbox list for '%s'", buf);
         }
-        if (r) {
-            errmsg(IMAP_IOERROR, "processing mbox list for '%s'", buf);
-            break;
-        }
+
+        if (r) break;
     }
 
     return r;

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -407,10 +407,13 @@ int buildquotalist(char *domain, char **roots, int nroots, int isuser)
             free(res);
         }
         else {
-            strlcpy(tail, roots[i], sizeof(buf) - domainlen);
+            char *intname = mboxname_from_external(roots[i], &quota_namespace, NULL);
+            strlcpy(tail, intname, sizeof(buf) - domainlen);
+            free(intname);
         }
-        /* XXX - namespace fixes here */
+
         r = quota_foreach(buf, fixquota_addroot, buf, NULL);
+
         if (r) {
             errmsg(IMAP_IOERROR, "failed building quota list for '%s'", buf);
             break;
@@ -664,9 +667,11 @@ int fixquota_dopass(char *domain, char **roots, int nroots,
             free(inbox);
         }
         else {
-            strlcpy(tail, roots[i], sizeof(buf) - domainlen);
+            char *intname = mboxname_from_external(roots[i], &quota_namespace, NULL);
+            strlcpy(tail, intname, sizeof(buf) - domainlen);
             r = mboxlist_allmbox(buf, cb, buf, /*flags*/0);
             if (r) errmsg(IMAP_IOERROR, "processing mbox list for '%s'", buf);
+            free(intname);
         }
 
         if (r) break;


### PR DESCRIPTION
Affects `cyr_expire [...] -p mboxprefix` and `quota [...] mboxprefix` (no `-u`).

Mostly only noticeable when unixhierarchysep and/or virtdomains is in use?

Fixes #1699