### PR TITLE
include file name (where known) in errors from message_parse functions

### DIFF
--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -22,7 +22,7 @@ static void test_parse_trivial(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -106,7 +106,7 @@ static void test_parse_simple(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -277,7 +277,7 @@ static void test_parse_rxdate(void)
 
     /* Neither: no received_date */
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg_neither, sizeof(msg_neither)-1, &body);
+    r = message_parse_mapped(msg_neither, sizeof(msg_neither)-1, &body, NULL);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_PTR_NULL(body.received_date);
     message_free_body(&body);
@@ -285,7 +285,7 @@ static void test_parse_rxdate(void)
     /* Received only: first seen Received */
     memset(&body, 0x45, sizeof(body));
     r = message_parse_mapped(msg_only_received,
-                             sizeof(msg_only_received)-1, &body);
+                             sizeof(msg_only_received)-1, &body, NULL);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_STRING_EQUAL(body.received_date, FIRST_RX);
     message_free_body(&body);
@@ -293,7 +293,7 @@ static void test_parse_rxdate(void)
     /* X-DeliveredInternalDate only: use that */
     memset(&body, 0x45, sizeof(body));
     r = message_parse_mapped(msg_only_xdid,
-                             sizeof(msg_only_xdid)-1, &body);
+                             sizeof(msg_only_xdid)-1, &body, NULL);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_STRING_EQUAL(body.received_date, DELIVERED);
     message_free_body(&body);
@@ -301,7 +301,7 @@ static void test_parse_rxdate(void)
     /* both, Received first: use X-DeliveredInternalDate */
     memset(&body, 0x45, sizeof(body));
     r = message_parse_mapped(msg_received_then_xdid,
-                             sizeof(msg_received_then_xdid)-1, &body);
+                             sizeof(msg_received_then_xdid)-1, &body, NULL);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_STRING_EQUAL(body.received_date, DELIVERED);
     message_free_body(&body);
@@ -309,7 +309,7 @@ static void test_parse_rxdate(void)
     /* both, X-DeliveredInternalDate first: use X-DeliveredInternalDate */
     memset(&body, 0x45, sizeof(body));
     r = message_parse_mapped(msg_xdid_then_received,
-                             sizeof(msg_xdid_then_received)-1, &body);
+                             sizeof(msg_xdid_then_received)-1, &body, NULL);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_STRING_EQUAL(body.received_date, DELIVERED);
     message_free_body(&body);
@@ -338,7 +338,7 @@ static void test_mime_trivial(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -430,7 +430,7 @@ HTML_PART "\r\n"
     struct bodypart **parts = NULL;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -542,7 +542,7 @@ static void test_rfc2231_continuations(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -591,7 +591,7 @@ static void test_rfc2231_extended_continuations(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -629,7 +629,7 @@ static void test_references(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -662,7 +662,7 @@ static void test_x_me_message_id(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -737,7 +737,7 @@ HTML_PART "\r\n"
     struct bodypart **parts = NULL;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -876,7 +876,7 @@ HTML_PART "\r\n"
     struct body *part;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -1091,7 +1091,7 @@ static void test_cache_simple(void)
     struct body *body = xzmalloc(sizeof(struct body));
 
     memset(body, 0x45, sizeof(struct body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 
@@ -1129,7 +1129,7 @@ static void test_cache_appleheaders(void)
     struct body body;
 
     memset(&body, 0x45, sizeof(body));
-    r = message_parse_mapped(msg, sizeof(msg)-1, &body);
+    r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
 
     CU_ASSERT_EQUAL(r, 0);
 

--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -330,7 +330,8 @@ static int getbody(void *mc, const char **content_types, sieve_bodypart_t ***par
         r = message_parse_file(fp,
                                &msg->content.base,
                                &msg->content.len,
-                               &msg->content.body);
+                               &msg->content.body,
+                               msg->filename);
         CU_ASSERT_EQUAL(r, 0);
         fclose(fp);
     }

--- a/imap/append.c
+++ b/imap/append.c
@@ -899,7 +899,7 @@ EXPORTED int append_fromstage_full(struct appendstate *as, struct body **body,
     if (!*body) {
         FILE *file = fopen(stage->parts.data[0], "r");
         if (file) {
-            r = message_parse_file(file, NULL, NULL, body);
+            r = message_parse_file(file, NULL, NULL, body, stage->parts.data[0]);
             fclose(file);
         }
         else
@@ -1204,7 +1204,7 @@ EXPORTED int append_fromstream(struct appendstate *as, struct body **body,
     r = message_copy_strict(messagefile, destfile, size, 0);
     if (!r) {
         if (!*body || (as->nummsg - 1))
-            r = message_parse_file(destfile, NULL, NULL, body);
+            r = message_parse_file(destfile, NULL, NULL, body, fname);
         if (!r) r = msgrecord_set_bodystructure(msgrec, *body);
 
         /* messageContent may be included with MessageAppend and MessageNew */
@@ -1275,7 +1275,7 @@ HIDDEN int append_run_annotator(struct appendstate *as,
         goto out;
     }
 
-    r = message_parse_file(f, NULL, NULL, &body);
+    r = message_parse_file(f, NULL, NULL, &body, fname);
     if (r) goto out;
 
     fclose(f);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4123,7 +4123,9 @@ static void cmd_append(char *tag, char *name, const char *cur_name)
             curstage = stages.data[i];
             body = NULL;
             if (curstage->binary) {
-                r = message_parse_binary_file(curstage->f, &body);
+                /* XXX we might have fname here, but it's hidden inside opaque
+                 * curstage->stage field */
+                r = message_parse_binary_file(curstage->f, &body, NULL);
                 fclose(curstage->f);
                 curstage->f = NULL;
             }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4682,7 +4682,7 @@ static int _cyrusmsg_from_buf(const struct buf *buf, struct cyrusmsg **msgptr)
     if (r) goto done;
 
     /* Parse message */
-    r = message_parse_mapped(buf_base(buf), buf_len(buf), mybody);
+    r = message_parse_mapped(buf_base(buf), buf_len(buf), mybody, NULL);
     if (r || !mybody->subpart) {
         r = IMAP_MESSAGE_BADHEADER;
         goto done;

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -381,7 +381,8 @@ static int getbody(void *mc, const char **content_types,
     if (!mydata->content->body) {
         /* parse the message body if we haven't already */
         r = message_parse_file(m->f, &mydata->content->base,
-                               &mydata->content->len, &mydata->content->body);
+                               &mydata->content->len, &mydata->content->body,
+                               NULL);
     }
 
     /* XXX currently struct bodypart as defined in message.h is the same as

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -576,7 +576,8 @@ int deliver_mailbox(FILE *f,
     if (!r && !content->body) {
         /* parse the message body if we haven't already,
            and keep the file mmap'ed */
-        r = message_parse_file(f, &content->base, &content->len, &content->body);
+        r = message_parse_file(f, &content->base, &content->len,
+                               &content->body, NULL);
         /* If the body contains received_date, we should always use that. */
         if (content->body->received_date)
             time_from_rfc5322(content->body->received_date, &internaldate,

--- a/imap/message.h
+++ b/imap/message.h
@@ -43,14 +43,6 @@
 #ifndef INCLUDED_MESSAGE_H
 #define INCLUDED_MESSAGE_H
 
-#ifndef P
-#ifdef __STDC__
-#define P(x) x
-#else
-#define P(x) ()
-#endif
-#endif
-
 #include <stdio.h>
 
 #include "prot.h"
@@ -144,8 +136,8 @@ struct param {
 };
 extern void param_free(struct param **paramp);
 
-extern int message_copy_strict P((struct protstream *from, FILE *to,
-                                  unsigned size, int allow_null));
+extern int message_copy_strict(struct protstream *from, FILE *to,
+                               unsigned size, int allow_null);
 
 extern int message_parse(const char *fname, struct index_record *record);
 
@@ -162,30 +154,30 @@ struct bodypart {
 };
 
 
-extern void parse_cached_envelope P((char *env, char *tokens[], int tokens_size));
+extern void parse_cached_envelope(char *env, char *tokens[], int tokens_size);
 
-extern int message_parse_mapped P((const char *msg_base, unsigned long msg_len,
-                                   struct body *body));
-extern int message_parse_binary_file P((FILE *infile, struct body **body));
-extern int message_parse_file P((FILE *infile,
-                                 const char **msg_base, size_t *msg_len,
-                                 struct body **body));
+extern int message_parse_mapped(const char *msg_base, unsigned long msg_len,
+                                struct body *body);
+extern int message_parse_binary_file(FILE *infile, struct body **body);
+extern int message_parse_file(FILE *infile,
+                              const char **msg_base, size_t *msg_len,
+                              struct body **body);
 extern void message_parse_string(const char *hdr, char **hdrp);
 extern void message_pruneheader(char *buf, const strarray_t *headers,
                                 const strarray_t *headers_not);
-extern void message_fetch_part P((struct message_content *msg,
-                                  const char **content_types,
-                                  struct bodypart ***parts));
+extern void message_fetch_part(struct message_content *msg,
+                               const char **content_types,
+                               struct bodypart ***parts);
 extern void message_write_nstring(struct buf *buf, const char *s);
 extern void message_write_nstring_map(struct buf *buf, const char *s, unsigned int len);
 extern void message_write_body(struct buf *buf, const struct body *body,
                                   int newformat);
 extern void message_write_xdrstring(struct buf *buf, const struct buf *s);
-extern int message_write_cache P((struct index_record *record, const struct body *body));
+extern int message_write_cache(struct index_record *record, const struct body *body);
 
-extern int message_create_record P((struct index_record *message_index,
-                                    const struct body *body));
-extern void message_free_body P((struct body *body));
+extern int message_create_record(struct index_record *message_index,
+                                 const struct body *body);
+extern void message_free_body(struct body *body);
 
 extern void message_parse_type(const char *hdr, char **typep, char **subtypep, struct param **paramp);
 extern void message_parse_disposition(const char *hdr, char **hdpr, struct param **paramp);

--- a/imap/message.h
+++ b/imap/message.h
@@ -157,11 +157,13 @@ struct bodypart {
 extern void parse_cached_envelope(char *env, char *tokens[], int tokens_size);
 
 extern int message_parse_mapped(const char *msg_base, unsigned long msg_len,
-                                struct body *body);
-extern int message_parse_binary_file(FILE *infile, struct body **body);
+                                struct body *body, const char *efname);
+extern int message_parse_binary_file(FILE *infile, struct body **body,
+                                     const char *efname);
 extern int message_parse_file(FILE *infile,
                               const char **msg_base, size_t *msg_len,
-                              struct body **body);
+                              struct body **body,
+                              const char *efname);
 extern void message_parse_string(const char *hdr, char **hdrp);
 extern void message_pruneheader(char *buf, const strarray_t *headers,
                                 const strarray_t *headers_not);

--- a/lib/cyr_lock.h
+++ b/lib/cyr_lock.h
@@ -43,14 +43,6 @@
 #ifndef INCLUDED_LOCK_H
 #define INCLUDED_LOCK_H
 
-#ifndef P
-#ifdef __STDC__
-#define P(x) x
-#else
-#define P(x) ()
-#endif
-#endif
-
 #include <sys/stat.h>
 
 extern const char lock_method_desc[];
@@ -63,8 +55,8 @@ extern int lock_reopen_ex(int fd, const char *filename,
 #define lock_reopen(fd, filename, sbuf, failaction) \
         lock_reopen_ex(fd, filename, sbuf, failaction, NULL)
 
-extern int lock_setlock (int fd, int ex, int nb, const char *filename);
-extern int lock_unlock (int fd, const char *filename);
+extern int lock_setlock(int fd, int ex, int nb, const char *filename);
+extern int lock_unlock(int fd, const char *filename);
 
 /* compatibility defines for the older API */
 #define lock_blocking(fd, fn) \

--- a/lib/mkgmtime.h
+++ b/lib/mkgmtime.h
@@ -43,16 +43,8 @@
 #ifndef INCLUDED_MKGMTIME_H
 #define INCLUDED_MKGMTIME_H
 
-#ifndef P
-#ifdef __STDC__
-#define P(x) x
-#else
-#define P(x) ()
-#endif
-#endif
-
 #include <time.h>
 
-extern time_t mkgmtime P((struct tm * const tmp));
+extern time_t mkgmtime(struct tm * const tmp);
 
 #endif /* INCLUDED_MKGMTIME_H */

--- a/lib/retry.h
+++ b/lib/retry.h
@@ -43,20 +43,12 @@
 #ifndef INCLUDED_RETRY_H
 #define INCLUDED_RETRY_H
 
-#ifndef P
-#ifdef __STDC__
-#define P(x) x
-#else
-#define P(x) ()
-#endif
-#endif
-
 #include <sys/types.h>
 #include <sys/uio.h>
 
-extern ssize_t retry_read P((int fd, void *buf, size_t nbyte));
-extern ssize_t retry_write P((int fd, const void *buf, size_t nbyte));
-extern ssize_t retry_writev P((int fd, const struct iovec *iov, int iovcnt));
+extern ssize_t retry_read(int fd, void *buf, size_t nbyte);
+extern ssize_t retry_write(int fd, const void *buf, size_t nbyte);
+extern ssize_t retry_writev(int fd, const struct iovec *iov, int iovcnt);
 
 /* add a buffer 's' of length 'len' to iovec 'iov' */
 #define WRITEV_ADD_TO_IOVEC(iov, num_iov, s, len) \

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -278,7 +278,7 @@ static int getbody(void *mc, const char **content_types, sieve_bodypart_t ***par
     if (!m->content.body) {
         /* parse the message body if we haven't already */
         r = message_parse_file(m->data, &m->content.base,
-                               &m->content.len, &m->content.body);
+                               &m->content.len, &m->content.body, NULL);
     }
 
     /* XXX currently struct bodypart as defined in message.h is the same as

--- a/sieve/test_mailbox.c
+++ b/sieve/test_mailbox.c
@@ -283,7 +283,7 @@ static int getbody(void *mc, const char **content_types, sieve_bodypart_t ***par
     if (!m->content.body) {
         /* parse the message body if we haven't already */
         r = message_parse_file(m->data, &m->content.base,
-                               &m->content.len, &m->content.body);
+                               &m->content.len, &m->content.body, NULL);
     }
 
     /* XXX currently struct bodypart as defined in message.h is the same as


### PR DESCRIPTION
If you've got opinions on the text of the error messages, sing out

I haven't yet tried to backport this for 3.0, but once it lands on master I'll look at that (and if it's easy and unintrusive to backport, I'll do so).

This closes #2782