### PR TITLE
Userlock

### DIFF
--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -649,6 +649,7 @@ int autocreate_user(struct namespace *namespace, const char *userid)
     strarray_t *subscribe = NULL;
     int numcrt = 0;
     int numsub = 0;
+    struct mboxlock *namespacelock = user_namespacelock(userid);
 #ifdef USE_SIEVE
     const char *source_script;
 #endif
@@ -816,6 +817,7 @@ int autocreate_user(struct namespace *namespace, const char *userid)
 #endif
 
  done:
+    mboxname_release(&namespacelock);
     free(inboxname);
     strarray_free(create);
     strarray_free(subscribe);

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -133,7 +133,7 @@ static int fixmbox(const mbentry_t *mbentry,
 
     /* if MBTYPE_RESERVED, unset it & call mboxlist_delete */
     if (mbentry->mbtype & MBTYPE_RESERVE) {
-        r = mboxlist_deletemailbox(mbentry->name, 1, NULL, NULL, NULL, 0, 0, 1, 0);
+        r = mboxlist_deletemailboxlock(mbentry->name, 1, NULL, NULL, NULL, 0, 0, 1, 0);
         if (r) {
             /* log the error */
             syslog(LOG_ERR,

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -754,7 +754,7 @@ static int do_delete(struct cyr_expire_ctx *ctx)
 
             verbosep("Removing: %s\n", name);
 
-            ret = mboxlist_deletemailbox(name, 1, NULL, NULL, NULL, 0, 0, 0, 0);
+            ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL, 0, 0, 0, 0);
             /* XXX: Ignoring the return from mboxlist_deletemailbox() ??? */
             count++;
         }

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -408,7 +408,10 @@ static int create_notify_collection(const char *userid, struct mailbox **mailbox
     /* notifications collection */
     mbentry_t *mbentry = NULL;
     int r = lookup_notify_collection(userid, &mbentry);
-    if (r) return _create_notify_collection(userid, mailbox);
+    if (r) {
+        mboxlist_entry_free(&mbentry);
+        return _create_notify_collection(userid, mailbox);
+    }
 
     if (mailbox) {
         /* Open mailbox for writing */

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -694,7 +694,10 @@ HIDDEN int jmap_open_upload_collection(const char *accountid,
     /* upload collection */
     mbentry_t *mbentry = NULL;
     int r = lookup_upload_collection(accountid, &mbentry);
-    if (r) return _create_upload_collection(accountid, mailbox);
+    if (r) {
+        mboxlist_entry_free(&mbentry);
+        return _create_upload_collection(accountid, mailbox);
+    }
 
     if (mailbox) {
         /* Open mailbox for writing */

--- a/imap/http_jmap.h
+++ b/imap/http_jmap.h
@@ -49,7 +49,7 @@
 
 extern struct namespace jmap_namespace;
 
-extern int jmap_create_upload_collection(const char *accountid,
-                                         struct mailbox **mailbox);
+extern int jmap_open_upload_collection(const char *accountid,
+                                       struct mailbox **mailbox);
 
 #endif /* HTTP_JMAP_H */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6877,6 +6877,8 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
 
     mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
 
+    struct mboxlock *namespacelock = user_namespacelock(mbname_userid(mbname));
+
     const char *type = NULL;
 
     dlist_getatom(extargs, "PARTITION", &partition);
@@ -7236,6 +7238,7 @@ localcreate:
     imapd_check(NULL, 0);
 
 done:
+    mboxname_release(&namespacelock);
     mailbox_close(&mailbox);
     buf_free(&specialuse);
     mbname_free(&mbname);
@@ -7281,9 +7284,9 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
     int r;
     mbentry_t *mbentry = NULL;
     struct mboxevent *mboxevent = NULL;
+    mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
 
-    char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
-    r = mlookup(NULL, NULL, intname, &mbentry);
+    r = mlookup(NULL, NULL, mbname_intname(mbname), &mbentry);
 
     if (!r && (mbentry->mbtype & MBTYPE_REMOTE)) {
         /* remote mailbox */
@@ -7294,7 +7297,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
             imapd_refer(tag, mbentry->server, name);
             referral_kick = 1;
             mboxlist_entry_free(&mbentry);
-            free(intname);
+            mbname_free(&mbname);
             return;
         }
 
@@ -7327,28 +7330,30 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
             prot_printf(imapd_out, "%s %s", tag, s->last_result.s);
         }
 
-        free(intname);
+        mbname_free(&mbname);
         return;
     }
     mboxlist_entry_free(&mbentry);
+
+    struct mboxlock *namespacelock = user_namespacelock(mbname_userid(mbname));
 
     mboxevent = mboxevent_new(EVENT_MAILBOX_DELETE);
 
     /* local mailbox */
     if (!r) {
         if (localonly || !mboxlist_delayed_delete_isenabled()) {
-            r = mboxlist_deletemailbox(intname,
+            r = mboxlist_deletemailbox(mbname_intname(mbname),
                                        imapd_userisadmin || imapd_userisproxyadmin,
                                        imapd_userid, imapd_authstate, mboxevent,
                                        1-force, localonly, 0, 0);
         } else if ((imapd_userisadmin || imapd_userisproxyadmin) &&
-                   mboxname_isdeletedmailbox(intname, NULL)) {
-            r = mboxlist_deletemailbox(intname,
+                   mbname_isdeleted(mbname)) {
+            r = mboxlist_deletemailbox(mbname_intname(mbname),
                                        imapd_userisadmin || imapd_userisproxyadmin,
                                        imapd_userid, imapd_authstate, mboxevent,
                                        0 /* checkacl */, localonly, 0, 0);
         } else {
-            r = mboxlist_delayed_deletemailbox(intname,
+            r = mboxlist_delayed_deletemailbox(mbname_intname(mbname),
                                                imapd_userisadmin || imapd_userisproxyadmin,
                                                imapd_userid, imapd_authstate, mboxevent,
                                                1-force, 0, 0, 0);
@@ -7362,17 +7367,18 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
 
     /* was it a top-level user mailbox? */
     /* localonly deletes are only per-mailbox */
-    if (!r && !localonly && mboxname_isusermailbox(intname, 1)) {
-        char *userid = mboxname_to_userid(intname);
+    if (!r && !localonly && mboxname_isusermailbox(mbname_intname(mbname), 1)) {
+        const char *userid = mbname_userid(mbname);
         if (userid) {
             r = mboxlist_usermboxtree(userid, NULL, delmbox, NULL, 0);
             if (!r) r = user_deletedata(userid, 1);
-            free(userid);
         }
     }
 
+    mboxname_release(&namespacelock);
+
     if (!r && config_getswitch(IMAPOPT_DELETE_UNSUBSCRIBE)) {
-        mboxlist_changesub(intname, imapd_userid, imapd_authstate,
+        mboxlist_changesub(mbname_intname(mbname), imapd_userid, imapd_authstate,
                            /* add */ 0, /* force */ 0, /* notify? */ 1);
     }
 
@@ -7388,7 +7394,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
         prot_printf(imapd_out, "%s OK %s\r\n", tag,
                     error_message(IMAP_OK_COMPLETED));
     }
-    free(intname);
+    mbname_free(&mbname);
 }
 
 struct renrock
@@ -7555,6 +7561,18 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location)
 
     olduser = mboxname_to_userid(oldmailboxname);
     newuser = mboxname_to_userid(newmailboxname);
+
+    struct mboxlock *oldnamespacelock = NULL;
+    struct mboxlock *newnamespacelock = NULL;
+
+    if (strcmpsafe(olduser, newuser) < 0) {
+        oldnamespacelock = user_namespacelock(olduser);
+        newnamespacelock = user_namespacelock(newuser);
+    }
+    else {
+        newnamespacelock = user_namespacelock(newuser);
+        oldnamespacelock = user_namespacelock(olduser);
+    }
 
     /* Keep temporary copy: master is trashed */
     strcpy(oldmailboxname2, oldmailboxname);
@@ -7875,6 +7893,8 @@ submboxes:
     }
 
 done:
+    mboxname_release(&oldnamespacelock);
+    mboxname_release(&newnamespacelock);
     mboxlist_entry_free(&mbentry);
     free(oldextname);
     free(newextname);
@@ -10862,21 +10882,25 @@ static void cmd_dump(char *tag, char *name, int uid_start)
 static void cmd_undump(char *tag, char *name)
 {
     int r = 0;
-    char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
+    mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
 
     /* administrators only please */
     if (!imapd_userisadmin)
         r = IMAP_PERMISSION_DENIED;
 
-    if (!r) r = mlookup(tag, name, intname, NULL);
+    struct mboxlock *namespacelock = user_namespacelock(mbname_userid(mbname));
 
-    if (!r) r = undump_mailbox(intname, imapd_in, imapd_out, imapd_authstate);
+    if (!r) r = mlookup(tag, name, mbname_intname(mbname), NULL);
+
+    if (!r) r = undump_mailbox(mbname_intname(mbname), imapd_in, imapd_out, imapd_authstate);
+
+    mboxname_release(&namespacelock);
 
     if (r) {
         prot_printf(imapd_out, "%s NO %s%s\r\n",
                     tag,
                     (r == IMAP_MAILBOX_NONEXISTENT &&
-                     mboxlist_createmailboxcheck(intname, 0, 0,
+                     mboxlist_createmailboxcheck(mbname_intname(mbname), 0, 0,
                                                  imapd_userisadmin,
                                                  imapd_userid, imapd_authstate,
                                                  NULL, NULL, 0) == 0)
@@ -10885,7 +10909,7 @@ static void cmd_undump(char *tag, char *name)
         prot_printf(imapd_out, "%s OK %s\r\n", tag,
                     error_message(IMAP_OK_COMPLETED));
     }
-    free(intname);
+    mbname_free(&mbname);
 }
 
 static int getresult(struct protstream *p, const char *tag)
@@ -11852,7 +11876,7 @@ static int xfer_delete(struct xfer_header *xfer)
         /* note also that we need to remember to let proxyadmins do this */
         /* On a unified system, the subsequent MUPDATE PUSH on the remote
            should repopulate the local mboxlist entry */
-        r = mboxlist_deletemailbox(item->mbentry->name,
+        r = mboxlist_deletemailboxlock(item->mbentry->name,
                                    imapd_userisadmin || imapd_userisproxyadmin,
                                    imapd_userid, imapd_authstate, NULL, 0, 1, 0, 0);
         if (r) {
@@ -12031,7 +12055,7 @@ static void cmd_xfer(const char *tag, const char *name,
     struct xfer_header *xfer = NULL;
     struct xfer_list list = { &imapd_namespace, imapd_userid, NULL, 0, NULL };
     struct xfer_item *item, *next;
-    char *intname = NULL;
+    mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
 
     /* administrators only please */
     /* however, proxys can do this, if their authzid is an admin */
@@ -12052,20 +12076,13 @@ static void cmd_xfer(const char *tag, const char *name,
         mboxlist_findall(NULL, "*", 1, NULL, NULL, xfer_addmbox, &list);
     } else {
         /* mailbox pattern */
-        mbname_t *mbname;
-
-        intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
-
-        mbname = mbname_from_intname(intname);
         if (mbname_localpart(mbname) &&
             (mbname_isdeleted(mbname) || strarray_size(mbname_boxes(mbname)))) {
             /* targeted a user submailbox */
             list.allow_usersubs = 1;
         }
-        mbname_free(&mbname);
 
-        mboxlist_findall(NULL, intname, 1, NULL, NULL, xfer_addmbox, &list);
-        free(intname);
+        mboxlist_findall(NULL, mbname_intname(mbname), 1, NULL, NULL, xfer_addmbox, &list);
     }
 
     r = xfer_init(toserver, &xfer);
@@ -12078,11 +12095,10 @@ static void cmd_xfer(const char *tag, const char *name,
          * to the destination backend as an admin, we take advantage of the fact
          * that admins *always* use a consistent mailbox naming scheme.
          * So, 'name' should be used in any command we send to a backend, and
-         * 'intname' is the internal name to be used for mupdate and findall.
+         * 'mbentry->name' is the internal name to be used for mupdate and findall.
          */
 
         r = 0;
-        intname = mbentry->name;
         xfer->topart = xstrdup(topart ? topart : mbentry->partition);
 
         /* if we are not moving a user, just move the one mailbox */
@@ -12092,7 +12108,7 @@ static void cmd_xfer(const char *tag, const char *name,
                    mbentry->name, xfer->toserver, xfer->topart);
 
             /* is the selected mailbox the one we're moving? */
-            if (!strcmpsafe(intname, index_mboxname(imapd_index))) {
+            if (!strcmpsafe(mbentry->name, index_mboxname(imapd_index))) {
                 r = IMAP_MAILBOX_LOCKED;
                 goto next;
             }
@@ -12103,7 +12119,7 @@ static void cmd_xfer(const char *tag, const char *name,
 
             r = do_xfer(xfer);
         } else {
-            xfer->userid = mboxname_to_userid(intname);
+            xfer->userid = xstrdupnull(mbname_userid(mbname));
 
             syslog(LOG_INFO, "XFER: user '%s' -> %s!%s",
                    xfer->userid, xfer->toserver, xfer->topart);
@@ -12114,8 +12130,8 @@ static void cmd_xfer(const char *tag, const char *name,
             } else if (!strcmp(xfer->userid, imapd_userid)) {
                 /* don't move your own inbox, that could be troublesome */
                 r = IMAP_MAILBOX_NOTSUPPORTED;
-            } else if (!strncmpsafe(intname, index_mboxname(imapd_index),
-                             strlen(intname))) {
+            } else if (!strncmpsafe(mbentry->name, index_mboxname(imapd_index),
+                             strlen(mbentry->name))) {
                 /* selected mailbox is in the namespace we're moving */
                 r = IMAP_MAILBOX_LOCKED;
             }
@@ -12123,7 +12139,7 @@ static void cmd_xfer(const char *tag, const char *name,
 
             if (!xfer->use_replication) {
                 /* set the quotaroot if needed */
-                r = xfer_setquotaroot(xfer, intname);
+                r = xfer_setquotaroot(xfer, mbentry->name);
                 if (r) goto next;
 
                 /* backport the seen file if needed */
@@ -12136,15 +12152,18 @@ static void cmd_xfer(const char *tag, const char *name,
             r = mboxlist_usermboxtree(xfer->userid, NULL, xfer_addusermbox,
                                       xfer, MBOXTREE_DELETED);
 
+            struct mboxlock *namespacelock = user_namespacelock(xfer->userid);
             /* NOTE: mailboxes were added in reverse, so the inbox is
              * done last */
             r = do_xfer(xfer);
-            if (r) goto next;
 
-            /* this was a successful user move, and we need to delete
-               certain user meta-data (but not seen state!) */
-            syslog(LOG_INFO, "XFER: deleting user metadata");
-            user_deletedata(xfer->userid, 0);
+            if (!r) {
+                /* this was a successful user move, and we need to delete
+                   certain user meta-data (but not seen state!) */
+                syslog(LOG_INFO, "XFER: deleting user metadata");
+                user_deletedata(xfer->userid, 0);
+            }
+            mboxname_release(&namespacelock);
         }
 
       next:
@@ -12184,6 +12203,7 @@ static void cmd_xfer(const char *tag, const char *name,
     }
 
 done:
+    mbname_free(&mbname);
     if (xfer) xfer_done(&xfer);
 
     imapd_check(NULL, 0);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6875,7 +6875,9 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
         name[strlen(name)-1] = '\0';
     }
 
-    mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
+    char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
+    mbname_t *mbname = mbname_from_intname(intname);
+    free(intname);
 
     struct mboxlock *namespacelock = user_namespacelock(mbname_userid(mbname));
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -296,7 +296,7 @@ static int jmap_blob_copy(jmap_req_t *req)
     }
 
     /* Check if we can upload to toAccountId */
-    r = jmap_create_upload_collection(req->accountid, &to_mbox);
+    r = jmap_open_upload_collection(req->accountid, &to_mbox);
     if (r == IMAP_PERMISSION_DENIED) {
         json_array_foreach(copy.create, i, val) {
             json_object_set(copy.not_created, json_string_value(val),

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -65,6 +65,7 @@
 #include "msgrecord.h"
 #include "statuscache.h"
 #include "stristr.h"
+#include "user.h"
 #include "util.h"
 #include "xmalloc.h"
 
@@ -3344,8 +3345,9 @@ static int jmap_mailbox_set(jmap_req_t *req)
         set.super.old_state = xstrdup(json_string_value(jstate));
         json_decref(jstate);
     }
-
+    struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     _mboxset(req, &set);
+    mboxname_release(&namespacelock);
     jmap_ok(req, jmap_set_reply(&set.super));
 
 done:

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1885,6 +1885,25 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
     return r;
 }
 
+EXPORTED int mboxlist_deletemailboxlock(const char *name, int isadmin,
+                                    const char *userid,
+                                    const struct auth_state *auth_state,
+                                    struct mboxevent *mboxevent,
+                                    int checkacl,
+                                    int local_only, int force,
+                                    int keep_intermediaries)
+{
+    char *lockuser = mboxname_to_userid(name);
+    struct mboxlock *namespacelock = user_namespacelock(lockuser);
+    free(lockuser);
+
+    int r = mboxlist_deletemailbox(name, isadmin, userid, auth_state, mboxevent,
+                                   checkacl, local_only, force, keep_intermediaries);
+
+    mboxname_release(&namespacelock);
+    return r;
+}
+
 static int _rename_check_specialuse(const char *oldname, const char *newname)
 {
     const char *protect = config_getstring(IMAPOPT_SPECIALUSE_PROTECT);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1376,6 +1376,26 @@ done:
     return r;
 }
 
+EXPORTED int mboxlist_createmailboxlock(const char *name, int mbtype,
+                           const char *partition,
+                           int isadmin, const char *userid,
+                           const struct auth_state *auth_state,
+                           int localonly, int forceuser, int dbonly,
+                           int notify, struct mailbox **mailboxptr)
+{
+    char *lockuser = mboxname_to_userid(name);
+    struct mboxlock *namespacelock = user_namespacelock(lockuser);
+    free(lockuser);
+
+    int r = mboxlist_createmailbox_unq(name, mbtype, partition, isadmin,
+                                      userid, auth_state, localonly,
+                                      forceuser, dbonly, notify, NULL,
+                                      mailboxptr);
+
+    mboxname_release(&namespacelock);
+    return r;
+}
+
 EXPORTED int mboxlist_createmailbox(const char *name, int mbtype,
                            const char *partition,
                            int isadmin, const char *userid,

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -235,6 +235,12 @@ int mboxlist_deletemailbox(const char *name, int isadmin, const char *userid,
                            struct mboxevent *mboxevent,
                            int checkacl,
                            int local_only, int force, int keep_intermediaries);
+/* same but wrap with a namespacelock */
+int mboxlist_deletemailboxlock(const char *name, int isadmin, const char *userid,
+                           const struct auth_state *auth_state,
+                           struct mboxevent *mboxevent,
+                           int checkacl,
+                           int local_only, int force, int keep_intermediaries);
 
 /* rename a tree of mailboxes - renames mailbox plus any children */
 int mboxlist_renametree(const char *oldname, const char *newname,

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -176,6 +176,15 @@ int mboxlist_createmailbox(const char *name, int mbtype,
                            int localonly, int forceuser, int dbonly,
                            int notify, struct mailbox **mailboxptr);
 
+/* create mailbox with wrapping namespacelock */
+int mboxlist_createmailboxlock(const char *name, int mbtype,
+                           const char *partition,
+                           int isadmin, const char *userid,
+                           const struct auth_state *auth_state,
+                           int localonly, int forceuser, int dbonly,
+                           int notify, struct mailbox **mailboxptr);
+
+
 /* create mailbox with uniqueid */
 int mboxlist_createmailbox_unq(const char *name, int mbtype,
                            const char *partition,

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -259,6 +259,11 @@ EXPORTED void mboxname_release(struct mboxlock **mboxlockptr)
     remove_lockitem(lockitem);
 }
 
+EXPORTED int mboxname_islocked(const char *mboxname)
+{
+    return find_lockitem(mboxname) ? 1 : 0;
+}
+
 /******************** mbname stuff **********************/
 
 static void _mbdirty(mbname_t *mbname)

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -127,6 +127,7 @@ char *mboxname_to_external(const char *intname, const struct namespace *ns, cons
 int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
                   int locktype);
 void mboxname_release(struct mboxlock **mboxlockptr);
+int mboxname_islocked(const char *mboxname);
 
 /* Create namespace based on config options. */
 int mboxname_init_namespace(struct namespace *namespace, int isadmin);

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -293,7 +293,7 @@ int main(int argc, char **argv)
             char *intname = mboxname_from_external(argv[i], &recon_namespace, NULL);
 
             /* don't notify mailbox creation here */
-            r = mboxlist_createmailbox(intname, 0, start_part, 1,
+            r = mboxlist_createmailboxlock(intname, 0, start_part, 1,
                                        "cyrus", NULL, 0, 0, !xflag, 0, NULL);
             if (r) {
                 fprintf(stderr, "could not create %s\n", argv[i]);
@@ -360,7 +360,7 @@ int main(int argc, char **argv)
         /* create p (database only) and reconstruct it */
         /* partition is defined by the parent mailbox */
         /* don't notify mailbox creation here */
-        r = mboxlist_createmailbox(name, 0, NULL, 1,
+        r = mboxlist_createmailboxlock(name, 0, NULL, 1,
                                    "cyrus", NULL, 0, 0, !xflag, 0, NULL);
         if (r) {
             fprintf(stderr, "createmailbox %s: %s\n",

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -123,6 +123,7 @@ static int reset_single(const char *userid)
 {
     int r = 0;
     int i;
+    struct mboxlock *namespacelock = user_namespacelock(userid);
 
     /* XXX: adding an entry to userdeny_db here would avoid the need to
      * protect against new logins with external proxy rules - Cyrus could
@@ -160,6 +161,7 @@ static int reset_single(const char *userid)
     r = user_deletedata(userid, 1);
 
  fail:
+    mboxname_release(&namespacelock);
     strarray_free(mblist);
     strarray_free(sublist);
 

--- a/imap/user.c
+++ b/imap/user.c
@@ -193,6 +193,8 @@ EXPORTED int user_deletedata(const char *userid, int wipe_user)
 {
     char *fname;
 
+    assert(user_isnamespacelocked(userid));
+
     /* delete seen state and mbox keys */
     if(wipe_user) {
         seen_delete_user(userid);

--- a/imap/user.h
+++ b/imap/user.h
@@ -44,6 +44,7 @@
 #define INCLUDED_USER_H
 
 #include "auth.h"
+#include "mboxname.h"
 
 /* path to user's sieve directory */
 const char *user_sieve_path(const char *user);
@@ -75,5 +76,8 @@ char *user_hash_subs(const char *user);
 
 /* find any sort of file for the user */
 char *user_hash_meta(const char *userid, const char *suffix);
+
+struct mboxlock *user_namespacelock(const char *userid);
+int user_isnamespacelocked(const char *userid);
 
 #endif


### PR DESCRIPTION
As mentioned during the week Ken - this is the "wrap all user renames with a lock" stuff.

In some cases I've gone direct to the lock, but in others where it's called often, I wait for a "doesn't exist" and then take a lock, check if it's been created in the race, then do the create.  This removes some race conditions, which is nice!

Hopefully this won't screw with your uuid-mailbox stuff too much!  I'm hoping to deploy it next week :)