### PR TITLE
Update documentation for user_deny.db

### DIFF
--- a/docsrc/imap/concepts/deployment/databases.rst
+++ b/docsrc/imap/concepts/deployment/databases.rst
@@ -160,7 +160,7 @@ File type can be: `twoskip`_ (default), `skiplist`_, or `sql`_.
 User Access (user_deny.db)
 --------------------------
 
-This database contains a list of users that are denied access to Cyrus services. The database is indexed by userid and each data record contains the database version number (currently 2), a list of wildmat patterns specifying Cyrus services to be denied, and a text message to be displayed to the user upon denial. The service names to be matched are those as used in cyrus.conf(5). The format of each record is as follows::
+This database contains a list of users that are denied access to Cyrus services. The database is indexed by userid and each data record contains the database version number (currently 2), a list of `wildmat <https://tools.ietf.org/html/rfc3977#section-4>`_ patterns specifying Cyrus services to be denied, and a text message to be displayed to the user upon denial. The service names to be matched are those as used in :cyrusman:`cyrus.conf(5)`. The format of each record is as follows::
 
     Key: <Userid>
 

--- a/docsrc/imap/reference/admin/sop/userdeny.rst
+++ b/docsrc/imap/reference/admin/sop/userdeny.rst
@@ -3,6 +3,8 @@ Managing user_deny.db
 
 The user_deny database allows you to deny access via POP/IMAP even if the user can authenticate to the Cyrus server. For example, if the authentication data is also used for other network services.
 
+Use :cyrusman:`cyr_deny(8)` to manage the database.
+
 If the user_deny.db file doesn't exist in %configdirectory% (often /var/lib/imap) then you'll need to create it. In the example below, /var/lib/imap/ is used.
 
 ::
@@ -11,18 +13,14 @@ If the user_deny.db file doesn't exist in %configdirectory% (often /var/lib/imap
     # /usr/lib/cyrus-imapd/cvt_cyrusdb /tmp/user_deny.flat flat /var/lib/imap/user_deny.db skiplist
     # chown cyrus:cyrus /var/lib/imap/user_deny.db
 
-The database specification can be found at http://cyrusimap.org/docs/cyrus-imapd/2.4.17/internal/database-formats.php
-
-**Key:** <Userid>
-
-**Data:** <Version>TAB<Deny List (comma-separated wildmat patterns)>TAB<Deny Message>
+The database specification can be found at :ref:`imap-concepts-deployment-db-userdeny`.
 
 ::
 
     # su - cyrus
-    $ cyr_dbtool /var/lib/imap/user_deny.db skiplist set **username** "2     pop3    Can't use pop."
+    $ cyr_dbtool /var/lib/imap/user_deny.db skiplist set **username** "2<tab>pop3<tab>Can't use pop."
 
-In order to type a tab character, you will need to escape your tabs. In bash, this is done by typing CTRL-v and then pressing Tab.
+Here `pop3` is the service name as spelled in :cyrusman:`cyrus.conf(5)`.  In order to type a tab character, you will need to escape your tabs. In bash, this is done by typing CTRL-v and then pressing Tab.
 
 If you got it right, when you authenticate via pop3 you should see something like the following::
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
@@ -97,7 +97,8 @@ is typically a Cyrus "flat" format database.
 database version number (currently 2), a list of "wildmat" patterns
 specifying Cyrus services to be denied, and a text message to be
 displayed to the user upon denial. The service names to be matched are
-those as used in :cyrusman:`cyrus.conf(5)`.
+those as used in :cyrusman:`cyrus.conf(5)`.  :cyrusman:`cyr_deny(8)`
+provides more convenient way to manage *user_deny.db*.
 
 .. Note::
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_deny.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_deny.rst
@@ -26,7 +26,8 @@ Description
 The first synopsis denies user *user* access to Cyrus services, the
 second synopsis allows access again.  **cyr_deny** works by adding an
 entry to the Cyrus ``user_deny.db`` database; the third synopsis lists
-the entries in the database.
+the entries in the database.  The service names to be matched are those
+as used in :cyrusman:`cyrus.conf(5)`.
 
 **cyr_deny** |default-conf-text|
 


### PR DESCRIPTION
Recommend cyr_deny instead of cyr_dbtool for managing user_deny.db.

Do not use the online documentation for cyrus imap 2.4.17 to reference the user_deny database format.