### PR TITLE
Fix #2599 renaming special use for cyrus-imapd-3.0

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -324,9 +324,9 @@ static struct capa_struct base_capabilities[] = {
     { "THREAD=ORDEREDSUBJECT", 2 },
     { "THREAD=REFERENCES",     2 },
     { "THREAD=REFS",           2 }, /* draft-ietf-morg-inthread */
-    { "ANNOTATEMORE",          2 },
+    { "ANNOTATEMORE",          2 }, /* legacy SETANNOTATION/GETANNOTATION commands */
     { "ANNOTATE-EXPERIMENT-1", 2 },
-    { "METADATA",              2 },
+    { "METADATA",              2 }, /* RFC 5464 */
     { "LIST-EXTENDED",         2 },
     { "LIST-STATUS",           2 },
     { "LIST-MYRIGHTS",         2 }, /* not standard */
@@ -3322,6 +3322,10 @@ static void capa_response(int flags)
         /* Don't show "MAILBOX-REFERRALS" if disabled by config */
         if (config_getswitch(IMAPOPT_PROXYD_DISABLE_MAILBOX_REFERRALS) &&
             !strcmp(capa, "MAILBOX-REFERRALS"))
+            continue;
+        /* Don't show "ANNOTATEMORE" if not enabled by config */
+        if (!config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) &&
+            !strcmp(capa, "ANNOTATEMORE"))
             continue;
         /* Don't show if they're not shown at this level of login */
         if (!(base_capabilities[i].mask & flags))
@@ -9737,26 +9741,32 @@ static void cmd_getannotation(const char *tag, char *mboxpat)
         goto freeargs;
     }
 
-    astate = annotate_state_new();
-    annotate_state_set_auth(astate,
-                            imapd_userisadmin || imapd_userisproxyadmin,
-                            imapd_userid, imapd_authstate);
-    if (!*mboxpat) {
-        r = annotate_state_set_server(astate);
-        if (!r)
-            r = annotate_state_fetch(astate, &entries, &attribs,
-                                     getannotation_response, NULL);
+    if (config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS)) {
+        astate = annotate_state_new();
+        annotate_state_set_auth(astate,
+                                imapd_userisadmin || imapd_userisproxyadmin,
+                                imapd_userid, imapd_authstate);
+        if (!*mboxpat) {
+            r = annotate_state_set_server(astate);
+            if (!r)
+                r = annotate_state_fetch(astate, &entries, &attribs,
+                                        getannotation_response, NULL);
+        }
+        else {
+            struct annot_fetch_rock arock;
+            arock.entries = &entries;
+            arock.attribs = &attribs;
+            arock.callback = getannotation_response;
+            arock.cbrock = NULL;
+            r = apply_mailbox_pattern(astate, mboxpat, annot_fetch_cb, &arock);
+        }
+        /* we didn't write anything */
+        annotate_state_abort(&astate);
     }
     else {
-        struct annot_fetch_rock arock;
-        arock.entries = &entries;
-        arock.attribs = &attribs;
-        arock.callback = getannotation_response;
-        arock.cbrock = NULL;
-        r = apply_mailbox_pattern(astate, mboxpat, annot_fetch_cb, &arock);
+        /* nope, sorry */
+        r = IMAP_PERMISSION_DENIED;
     }
-    /* we didn't write anything */
-    annotate_state_abort(&astate);
 
     imapd_check(NULL, 0);
 
@@ -10125,25 +10135,31 @@ static void cmd_setannotation(const char *tag, char *mboxpat)
         goto freeargs;
     }
 
-    astate = annotate_state_new();
-    annotate_state_set_auth(astate, imapd_userisadmin,
-                            imapd_userid, imapd_authstate);
-    if (!r) {
-        if (!*mboxpat) {
-            r = annotate_state_set_server(astate);
-            if (!r)
-                r = annotate_state_store(astate, entryatts);
+    if (config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS)) {
+        astate = annotate_state_new();
+        annotate_state_set_auth(astate, imapd_userisadmin,
+                                imapd_userid, imapd_authstate);
+        if (!r) {
+            if (!*mboxpat) {
+                r = annotate_state_set_server(astate);
+                if (!r)
+                    r = annotate_state_store(astate, entryatts);
+            }
+            else {
+                struct annot_store_rock arock;
+                arock.entryatts = entryatts;
+                r = apply_mailbox_pattern(astate, mboxpat, annot_store_cb, &arock);
+            }
         }
-        else {
-            struct annot_store_rock arock;
-            arock.entryatts = entryatts;
-            r = apply_mailbox_pattern(astate, mboxpat, annot_store_cb, &arock);
-        }
+        if (!r)
+            annotate_state_commit(&astate);
+        else
+            annotate_state_abort(&astate);
     }
-    if (!r)
-        annotate_state_commit(&astate);
-    else
-        annotate_state_abort(&astate);
+    else {
+        /* nope, sorry */
+        r = IMAP_PERMISSION_DENIED;
+    }
 
     imapd_check(NULL, 0);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6617,7 +6617,7 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
     use = dlist_getchild(extargs, "USE");
     if (use) {
         /* only user mailboxes can have specialuse, and if annotatemore is used they must be user toplevel folders */
-        if (!mbname_userid(mbname) || config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(mbname)) != 1) {
+        if (!mbname_userid(mbname) || (config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(mbname)) != 1)) {
             r = IMAP_MAILBOX_SPECIALUSE;
             goto err;
         }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6616,8 +6616,8 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
     }
     use = dlist_getchild(extargs, "USE");
     if (use) {
-        /* only user mailboxes can have specialuse, and they must be user toplevel folders */
-        if (!mbname_userid(mbname) || strarray_size(mbname_boxes(mbname)) != 1) {
+        /* only user mailboxes can have specialuse, and if annotatemore is used they must be user toplevel folders */
+        if (!mbname_userid(mbname) || config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(mbname)) != 1) {
             r = IMAP_MAILBOX_SPECIALUSE;
             goto err;
         }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1542,8 +1542,8 @@ static int _rename_check_specialuse(const char *oldname, const char *newname)
         annotatemore_lookup(oldname, "/specialuse", mbname_userid(old), &attrib);
     /* we have specialuse? */
     if (attrib.len) {
-        /* then target must be a single-depth mailbox too */
-        if (strarray_size(mbname_boxes(new)) != 1)
+        /* if annotatemore is used then target must be a single-depth mailbox too */
+        if (config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(new)) != 1)
             r = IMAP_MAILBOX_SPECIALUSE;
         /* and have a userid as well */
         if (!mbname_userid(new))

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3174,7 +3174,7 @@ EXPORTED modseq_t mboxlist_foldermodseq_dirty(struct mailbox *mailbox)
 
     ret = mbentry->foldermodseq = mailbox_modseq_dirty(mailbox);
 
-    mboxlist_update(mbentry, 0);
+    mboxlist_update(mbentry, 1);
 
     mboxlist_entry_free(&mbentry);
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -274,7 +274,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    socket.  */
 { "annotation_callout_disable_append", 0, SWITCH }
 /* Disables annotations on append with xrunannotator */
-{ "annotation_enable_legacy_commands", 0, SWITCH }
+{ "annotation_enable_legacy_commands", 1, SWITCH }
 /* Whether to enable the legacy GETANNOTATION/SETANNOTATION commands.
    These commands are deprecated and will be removed in the future,
    but might be useful in the meantime for supporting old clients that

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -272,6 +272,13 @@ Blank lines and lines beginning with ``#'' are ignored.
    or flags to a message when it is appended to a mailbox.  The path can
    be either an executable (including a script), or a UNIX domain
    socket.  */
+{ "annotation_callout_disable_append", 0, SWITCH }
+/* Disables annotations on append with xrunannotator */
+{ "annotation_enable_legacy_commands", 0, SWITCH }
+/* Whether to enable the legacy GETANNOTATION/SETANNOTATION commands.
+   These commands are deprecated and will be removed in the future,
+   but might be useful in the meantime for supporting old clients that
+   do not implement the RFC5464 IMAP METADATA extension. */
 
 { "aps_topic", NULL, STRING }
 /* Topic for Apple Push Service registration. */


### PR DESCRIPTION
This is a proposed Fix for #2599 

Some Information for the review:

- I have no system to run the automated tests, so I could not test my patches for unintended effects.

- As far as I can tell mboxlist_foldermodseq_dirty() is only called for changes in annotations.
  IMHO these only require mboxlist_update with localonly=1.  
  This change prevents the incomplete entry for the old SPECIAL-USE folders getting pushed 
  on the mupdate master. But i am uncertain if this is the correct fix 

- I am also uncertain if the combination of Annotatemore (GET/SETANNOTATIONS)  [rfc5464](https://tools.ietf.org/html/rfc5464) and SPECIAL-USE [rfc6154](https://tools.ietf.org/html/rfc6154) requires the restriction that special use folders are only allowed as direct folders of the INBOX, or if this was a decision by the developer implementing the feature.  To be on the save side I backported/cherry-picked ellie's patch to disable Annotatemore and used it as a switch for my change.


