### PR TITLE
Fix #2599 renaming special use for cyrus-imapd master branch

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6897,8 +6897,8 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
     }
     use = dlist_getchild(extargs, "USE");
     if (use) {
-        /* only user mailboxes can have specialuse, and they must be user toplevel folders */
-        if (!mbname_userid(mbname) || strarray_size(mbname_boxes(mbname)) != 1) {
+        /* only user mailboxes can have specialuse, and if annotatemore is used they must be user toplevel folders */
+        if (!mbname_userid(mbname) || config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(mbname)) != 1) {
             r = IMAP_MAILBOX_SPECIALUSE;
             goto err;
         }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6898,7 +6898,7 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
     use = dlist_getchild(extargs, "USE");
     if (use) {
         /* only user mailboxes can have specialuse, and if annotatemore is used they must be user toplevel folders */
-        if (!mbname_userid(mbname) || config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(mbname)) != 1) {
+        if (!mbname_userid(mbname) || (config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(mbname)) != 1)) {
             r = IMAP_MAILBOX_SPECIALUSE;
             goto err;
         }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3905,7 +3905,7 @@ EXPORTED modseq_t mboxlist_foldermodseq_dirty(struct mailbox *mailbox)
 
     ret = mbentry->foldermodseq = mailbox_modseq_dirty(mailbox);
 
-    mboxlist_update(mbentry, 0);
+    mboxlist_update(mbentry, 1);
 
     mboxlist_entry_free(&mbentry);
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1928,8 +1928,8 @@ static int _rename_check_specialuse(const char *oldname, const char *newname)
         strarray_t *check = strarray_split(protect, NULL, STRARRAY_TRIM);
         strarray_t *uses = strarray_split(buf_cstring(&attrib), NULL, 0);
         if (strarray_intersect_case(uses, check)) {
-            /* then target must be a single-depth mailbox too */
-            if (strarray_size(mbname_boxes(new)) != 1)
+            /* if annotatemore is used then target must be a single-depth mailbox too */
+            if (config_getswitch(IMAPOPT_ANNOTATION_ENABLE_LEGACY_COMMANDS) && strarray_size(mbname_boxes(new)) != 1)
                 r = IMAP_MAILBOX_SPECIALUSE;
             /* and have a userid as well */
             if (!mbname_userid(new))


### PR DESCRIPTION
This is a proposed Fix for #2599 
also see #2977 

Some Information for the review:

- I was unable to compile the patch for the master branch
  because imap/http_err.h was missing. I did us configure with "--disable-http". I suspect either some missing dependency or somethig is broken with configure 

- I have no system to run the automated tests, so I could not test my patches for unintended effects.

- As far as I can tell mboxlist_foldermodseq_dirty() is only called for changes in annotations.
  IMHO these only require mboxlist_update with localonly=1.  
  This change prevents the incomplete entry for the old SPECIAL-USE folders getting pushed 
  on the mupdate master. But i am uncertain if this is the correct fix 

- I am also uncertain if the combination of Annotatemore (GET/SETANNOTATIONS)  [rfc5464](https://tools.ietf.org/html/rfc5464) and SPECIAL-USE [rfc6154](https://tools.ietf.org/html/rfc6154) requires the restriction that special use folders are only allowed as direct folders of the INBOX, or if this was a decision by the developer implementing the feature.  To be on the save side I use the configoption to disable Annotatemore as a switch for my change.