### PR TITLE
make libical 3.0.0+ and libicu mandatory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1791,7 +1791,10 @@ sieve_libcyrus_sieve_la_CFLAGS = $(AM_CFLAGS) $(CFLAG_VISIBILITY)
 sieve_sievec_LDADD = $(LD_SIEVE_ADD)
 sieve_sieved_LDADD = $(LD_SIEVE_ADD)
 
-sieve_test_SOURCES = sieve/test.c imap/mutex_fake.c imap/jmap_util.c imap/jmap_mail_query.c
+sieve_test_SOURCES = sieve/test.c imap/mutex_fake.c
+if JMAP
+sieve_test_SOURCES += imap/jmap_util.c imap/jmap_mail_query.c
+endif
 sieve_test_LDADD = $(LD_SIEVE_ADD) $(LD_UTILITY_ADD)
 
 sieve_test_mailbox_SOURCES = sieve/test_mailbox.c imap/mutex_fake.c

--- a/configure.ac
+++ b/configure.ac
@@ -1568,65 +1568,19 @@ dnl
                                 [Do we have support for xmlBufferDetach()?]))
                 ])
 
-        PKG_CHECK_MODULES([ICAL], [libical], [
+        PKG_CHECK_MODULES([ICAL], [libical >= 3.0.0], [
                 AC_DEFINE(HAVE_ICAL,[],[Build CalDAV support into httpd?])
                 LIBS="$LIBS ${ICAL_LIBS}"
                 with_ical=yes
                 ],
-                AC_MSG_ERROR([Need libical for http]))
+                AC_MSG_ERROR([Need libical 3.0.0 for http]))
 
-        AC_CHECK_DECLS([icalproperty_get_parent, ICAL_STATUS_DELETED,
-                        icalrecur_freq_to_string, icalrecur_weekday_to_string],
-                [], [], [[#include <libical/ical.h>]])
-
-        AC_CHECK_MEMBER(icaltimetype.is_utc,
-                AC_DEFINE(ICALTIME_HAS_IS_UTC,[],
-                        [Does icaltimetype have is_utc field?]),
-                        [], [#include <libical/ical.h>])
-
-        AC_CHECK_LIB(ical, icalproperty_new_tzuntil,
-                AC_DEFINE(HAVE_TZDIST_PROPS,[],
-                        [Do we have built-in support for TZdist props?]))
-
-        AC_CHECK_LIB(ical, icalproperty_new_acknowledged,
-                AC_DEFINE(HAVE_VALARM_EXT_PROPS,[],
-                        [Do we have built-in support for VALARM extensions props?]))
-
-        AC_CHECK_LIB(ical, icalproperty_new_name,
-                AC_DEFINE(HAVE_RFC7986_PROPS,[],
-                        [Do we have built-in support for RFC7986 props?]))
+        dnl icalproperty_new_color was overlooked, and eventually added in 3.0.5
         AC_CHECK_LIB(ical, icalproperty_new_color,
                 AC_DEFINE(HAVE_RFC7986_COLOR,[],
                         [Do we have built-in support for RFC7986 color prop?]))
 
-        AC_CHECK_LIB(ical, icalparameter_new_iana, [
-                AC_DEFINE(HAVE_IANA_PARAMS,[],
-                        [Do we have support for IANA params?])
-
-                AC_CHECK_LIB(ical, icalparameter_new_schedulestatus,
-                        AC_DEFINE(HAVE_SCHEDULING_PARAMS,[],
-                                [Do we have built-in support for scheduling params?]))
-
-                AC_CHECK_LIB(ical, icalparameter_new_managedid,
-                        AC_DEFINE(HAVE_MANAGED_ATTACH_PARAMS,[],
-                                [Do we have built-in support for managed attachment params?]))
-                ],
-                AC_MSG_NOTICE([Your version of libical can not support scheduling or managed attachments.  Consider upgrading to libical >= 0.48]))
-
-        AC_CHECK_LIB(ical, icaltimezone_set_builtin_tzdata,
-                AC_DEFINE(HAVE_TZ_BY_REF,[],
-                        [Build timezones by reference support into httpd?]),
-                AC_MSG_NOTICE([Your version of libical can not support timezones by reference.  Consider upgrading to libical >= 1.0.1]))
-
-        AC_CHECK_LIB(ical, icalcomponent_new_vavailability,
-                AC_DEFINE(HAVE_VAVAILABILITY,[],
-                        [Build VAVAILABILITY support into httpd?]),
-                AC_MSG_NOTICE([Your version of libical can not support availability.  Consider upgrading to libical >= 1.0.1]))
-
-        AC_CHECK_LIB(ical, icalcomponent_new_vvoter,
-                AC_DEFINE(HAVE_VPOLL,[], [Build VPOLL support into httpd?]),
-                AC_MSG_NOTICE([Your version of libical can not support consensus scheduling.  Consider upgrading to libical >= 2.0]))
-
+        dnl XXX should this be optional still?
         AC_CHECK_LIB(ical, icalrecurrencetype_rscale_is_supported, [
                 PKG_CHECK_MODULES([ICU4C], [icu-i18n], [
                         AC_DEFINE(HAVE_RSCALE,[], [Build RSCALE support into httpd?])
@@ -1637,15 +1591,7 @@ dnl
                 ],
                 AC_MSG_NOTICE([Your version of libical can not support non-gregorian recurrences.  Consider upgrading to libical >= 2.0]))
 
-        AC_CHECK_LIB(ical, icalcomponent_new_vpatch,
-                AC_DEFINE(HAVE_VPATCH,[],
-                        [Build VPATCH support into httpd?]),
-                AC_MSG_NOTICE([Your version of libical can not support per-user alarms on shared resources.  Consider upgrading to libical >= 3.0]))
-
-        AC_CHECK_LIB(ical, icalrecur_iterator_set_start,
-                AC_DEFINE(HAVE_RECUR_ITERATOR_START,[],
-                        [Do we have support for setting start point of recurrences?]))
-
+        dnl icalcomponent_clone will be new in libical 3.1.0
         AC_CHECK_LIB(ical, icalcomponent_clone,
                 AC_DEFINE(HAVE_NEW_CLONE_API,[],
                         [Do we have support for new clone API?]))

--- a/configure.ac
+++ b/configure.ac
@@ -1595,6 +1595,9 @@ dnl
         AC_CHECK_LIB(ical, icalproperty_new_name,
                 AC_DEFINE(HAVE_RFC7986_PROPS,[],
                         [Do we have built-in support for RFC7986 props?]))
+        AC_CHECK_LIB(ical, icalproperty_new_color,
+                AC_DEFINE(HAVE_RFC7986_COLOR,[],
+                        [Do we have built-in support for RFC7986 color prop?]))
 
         AC_CHECK_LIB(ical, icalparameter_new_iana, [
                 AC_DEFINE(HAVE_IANA_PARAMS,[],

--- a/configure.ac
+++ b/configure.ac
@@ -1427,6 +1427,19 @@ AC_CHECK_LIB([jansson], [json_dumpb],
 CFLAGS="$save_CFLAGS"
 
 dnl
+dnl Check for ICU library, needed for charset conversions and non-gregorian
+dnl rscale conversions
+dnl
+with_icu4c=no
+PKG_CHECK_MODULES([ICU], [icu-i18n icu-uc], [
+                    AC_DEFINE(HAVE_ICU, [], [Build with ICU support])
+                    with_icu4c=yes
+                  ],
+                  [AC_MSG_ERROR([Need ICU4C])])
+AC_SUBST([ICU_LIBS])
+AC_SUBST([ICU_CFLAGS])
+
+dnl
 dnl Check for zeroskip library, needed for zeroskip support
 dnl
 AC_ARG_WITH([zeroskip],
@@ -1537,7 +1550,6 @@ HTTP_CPPFLAGS=
 HTTP_LIBS=
 with_xml2=no
 with_ical=no
-with_icu4c=no
 with_shapelib=no
 with_brotli=no
 with_zstd=no
@@ -1580,16 +1592,10 @@ dnl
                 AC_DEFINE(HAVE_RFC7986_COLOR,[],
                         [Do we have built-in support for RFC7986 color prop?]))
 
-        dnl XXX should this be optional still?
-        AC_CHECK_LIB(ical, icalrecurrencetype_rscale_is_supported, [
-                PKG_CHECK_MODULES([ICU4C], [icu-i18n], [
-                        AC_DEFINE(HAVE_RSCALE,[], [Build RSCALE support into httpd?])
-                        LIBS="$LIBS ${ICU4C_LIBS}"
-                        with_icu4c=yes
-                        ],
-                        AC_MSG_ERROR([Need ICU4C for RSCALE support in httpd]))
-                ],
-                AC_MSG_NOTICE([Your version of libical can not support non-gregorian recurrences.  Consider upgrading to libical >= 2.0]))
+        dnl libical may have been built without RSCALE support
+        AC_CHECK_LIB(ical, icalrecurrencetype_rscale_is_supported,
+                [AC_DEFINE(HAVE_RSCALE,[], [Build RSCALE support into httpd?])],
+                [AC_MSG_NOTICE([Your version of libical can not support non-gregorian recurrences])])
 
         dnl icalcomponent_clone will be new in libical 3.1.0
         AC_CHECK_LIB(ical, icalcomponent_clone,
@@ -2424,11 +2430,6 @@ CMU_PERL_MAKEMAKER(perl/annotator)
 CMU_PERL_MAKEMAKER(perl/imap)
 CMU_PERL_MAKEMAKER(perl/sieve/managesieve)
 fi
-
-dnl check for libicu. we need this for charset conversions.
-PKG_CHECK_MODULES([ICU], [icu-uc], AC_DEFINE(HAVE_ICU, [], [Build with ICU support]), [])
-AC_SUBST([ICU_LIBS])
-AC_SUBST([ICU_CFLAGS])
 
 AC_OUTPUT
 echo "

--- a/docsrc/imap/developer/compiling.rst
+++ b/docsrc/imap/developer/compiling.rst
@@ -112,18 +112,15 @@ Alternate database formats
     Configure option: ``--with-mysql``, ``--with-mysql-incdir``, ``--with-mysql-libdir``"
     `postgresql`_, postgresql-dev, postgresql-devel, "no"
 
-CalDAV and/or CardDAV
-#####################
+CalDAV, CardDAV, or JMAP
+########################
 
 .. csv-table::
     :header: "Package", "Debian", "RedHat",  "Required for ``make check``?", "Notes"
     :widths: 20,15,15,5,45
 
-    `libical`_, libical-dev, libical-devel, "no", "libical >= 0.48 required for scheduling support.
-    **Note:** Linux distributions Enterprise Linux 6 and Debian Squeeze are
-    known to ship outdated **libical** packages versions 0.43 and
-    0.44 respectively. The platforms will not support scheduling."
-    `libxml`_, libxml2-dev, libxml2-devel, "", "no"
+    `libical`_, libical-dev, libical-devel, "no", "version 3.0.0 or higher"
+    `libxml`_, libxml2-dev, libxml2-devel, "no", ""
 
 Other
 #####
@@ -229,10 +226,10 @@ via configure.
 
 Sieve is enabled by default.
 
-CalDAV and CardDAV
-##################
+CalDAV, CardDAV, JMAP
+#####################
 
-    ``./configure --enable-http --enable-calalarmd``
+    ``./configure --enable-http --enable-calalarmd --enable-jmap``
 
 Murder
 ######

--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -722,9 +722,7 @@ EXPORTED int caldav_writeentry(struct caldav_db *caldavdb, struct caldav_data *c
     case ICAL_VJOURNAL_COMPONENT: mykind = CAL_COMP_VJOURNAL; break;
     case ICAL_VFREEBUSY_COMPONENT: mykind = CAL_COMP_VFREEBUSY; break;
     case ICAL_VAVAILABILITY_COMPONENT: mykind = CAL_COMP_VAVAILABILITY; break;
-#ifdef HAVE_VPOLL
     case ICAL_VPOLL_COMPONENT: mykind = CAL_COMP_VPOLL; break;
-#endif
     default: break;
     }
     cdata->comp_type = mykind;

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -272,10 +272,17 @@ EXPORTED int dav_attach_mailbox(sqldb_t *db, struct mailbox *mailbox)
 /*
  * mboxlist_usermboxtree() callback function to create DAV DB entries for a mailbox
  */
-static int _dav_reconstruct_mb(const mbentry_t *mbentry, void *rock)
+static int _dav_reconstruct_mb(const mbentry_t *mbentry,
+                               void *rock
+#ifndef WITH_JMAP
+                                          __attribute__((unused))
+#endif
+                              )
 {
+#ifdef WITH_JMAP
     const char *userid = (const char *) rock;
     struct buf attrib = BUF_INITIALIZER;
+#endif
     int (*addproc)(struct mailbox *) = NULL;
     int r = 0;
 

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -596,6 +596,7 @@ static int imip_send(struct sched_data *sched_data,
     const char *ical_str = icalcomponent_as_ical_string(sched_data->itip);
     json_t *jsevent, *patch;
 
+#ifdef WITH_JMAP
     if (sched_data->oldical) {
         jsevent = jmapical_tojmap(sched_data->oldical, NULL);
 
@@ -616,6 +617,10 @@ static int imip_send(struct sched_data *sched_data,
         jsevent = json_null();
         patch = jmapical_tojmap(sched_data->newical, NULL);
     }
+#else
+    jsevent = json_null();
+    patch = json_null();
+#endif
 
     json_t *val = json_pack("{s:s s:s s:s s:o s:o s:b}",
                             "recipient", recipient,

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1102,7 +1102,6 @@ static void sched_deliver_remote(const char *sender, const char *recipient,
 }
 
 
-#ifdef HAVE_VPOLL
 /*
  * deliver_merge_reply() helper function
  *
@@ -1300,34 +1299,6 @@ static void sched_pollstatus(const char *organizer,
     icalcomponent_free(itip);
     auth_freestate(authstate);
 }
-#else  /* HAVE_VPOLL */
-static void
-deliver_merge_vpoll_reply(icalcomponent *ical __attribute__((unused)),
-                          icalcomponent *reply __attribute__((unused)))
-{
-    return;
-}
-
-static void sched_vpoll_reply(icalcomponent *poll __attribute__((unused)))
-{
-    return;
-}
-
-static int
-deliver_merge_pollstatus(icalcomponent *ical __attribute__((unused)),
-                         icalcomponent *request __attribute__((unused)))
-{
-    return 0;
-}
-
-static void sched_pollstatus(const char *organizer __attribute__((unused)),
-                             struct caldav_sched_param *sparam __attribute__((unused)),
-                             icalcomponent *ical __attribute__((unused)),
-                             const char *voter __attribute__((unused)))
-{
-    return;
-}
-#endif  /* HAVE_VPOLL */
 
 /* annoying copypaste from libical because it's not exposed */
 static struct icaltimetype _get_datetime(icalcomponent *comp, icalproperty *prop)
@@ -1883,11 +1854,9 @@ static void sched_deliver_local(const char *sender, const char *recipient,
             case ICAL_VAVAILABILITY_COMPONENT:
                 if (cdata->comp_type != CAL_COMP_VAVAILABILITY) reject = 1;
                 break;
-#ifdef HAVE_VPOLL
             case ICAL_VPOLL_COMPONENT:
                 if (cdata->comp_type != CAL_COMP_VPOLL) reject = 1;
                 break;
-#endif
             default:
                 break;
             }

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -296,7 +296,6 @@ static int meth_get_isched(struct transaction_t *txn,
         meth = xmlNewChild(comp, NULL, BAD_CAST "method", NULL);
         xmlNewProp(meth, BAD_CAST "name", BAD_CAST "CANCEL");
 
-#ifdef HAVE_VPOLL
         comp = xmlNewChild(node, NULL, BAD_CAST "component", NULL);
         xmlNewProp(comp, BAD_CAST "name", BAD_CAST "VPOLL");
         meth = xmlNewChild(comp, NULL, BAD_CAST "method", NULL);
@@ -307,7 +306,6 @@ static int meth_get_isched(struct transaction_t *txn,
         xmlNewProp(meth, BAD_CAST "name", BAD_CAST "REPLY");
         meth = xmlNewChild(comp, NULL, BAD_CAST "method", NULL);
         xmlNewProp(meth, BAD_CAST "name", BAD_CAST "CANCEL");
-#endif /* HAVE_VPOLL */
 
         comp = xmlNewChild(node, NULL, BAD_CAST "component", NULL);
         xmlNewProp(comp, BAD_CAST "name", BAD_CAST "VFREEBUSY");

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -549,10 +549,8 @@ struct namespace_t *http_namespaces[] = {
     &namespace_principal,       /* MUST be after namespace_cal & addr & drive */
     &namespace_notify,          /* MUST be after namespace_principal */
     &namespace_applepush,       /* MUST be after namespace_cal & addr */
-#ifdef HAVE_IANA_PARAMS
     &namespace_ischedule,
     &namespace_domainkey,
-#endif /* HAVE_IANA_PARAMS */
 #endif /* WITH_DAV */
     &namespace_rss,
     &namespace_dblookup,

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -401,11 +401,9 @@ EXPORTED int icalcomponent_myforeach(icalcomponent *ical,
 
             if (!span_compare_range(&recur_span, &range_span)) {
                 rrule_itr = icalrecur_iterator_new(recur, dtstart);
-#ifdef HAVE_RECUR_ITERATOR_START
                 if (rrule_itr && (recur.count > 0)) {
                     icalrecur_iterator_set_start(rrule_itr, range.start);
                 }
-#endif
             }
         }
     }
@@ -756,9 +754,7 @@ icalcomponent_get_utc_timespan(icalcomponent *comp,
         }
         break;
 
-#ifdef HAVE_VPOLL
     case ICAL_VPOLL_COMPONENT:
-#endif
     case ICAL_VTODO_COMPONENT: {
         struct icaltimetype due = (kind == ICAL_VPOLL_COMPONENT) ?
             icalcomponent_get_dtend(comp) : icalcomponent_get_due(comp);
@@ -992,15 +988,10 @@ icalrecurrenceset_get_utc_timespan(icalcomponent *ical,
 
 EXPORTED void icaltime_set_utc(struct icaltimetype *t, int set)
 {
-#ifdef ICALTIME_HAS_IS_UTC
-    t->is_utc = set;
-#else
     icaltime_set_timezone(t, set ? icaltimezone_get_utc_timezone() : NULL);
-#endif
 }
 
 
-#ifdef HAVE_VPATCH
 enum {
     ACTION_UPDATE = 1,
     ACTION_DELETE,
@@ -1826,77 +1817,6 @@ EXPORTED int icalcomponent_apply_vpatch(icalcomponent *ical,
     return 0;
 }
 
-#else /* !HAVE_VPATCH */
-
-EXPORTED int icalcomponent_apply_vpatch(icalcomponent *ical __attribute__((unused)),
-                                        icalcomponent *vpatch __attribute__((unused)),
-                                        int *num_changes __attribute__((unused)),
-                                        const char **errstr __attribute__((unused)))
-{
-    fatal("icalcomponent_apply_vpatch() called, but no VPATCH", EX_SOFTWARE);
-}
-#endif /* HAVE_VPATCH */
-
-
-#ifndef HAVE_TZDIST_PROPS
-
-/* Functions to replace those not available in libical < v2.0 */
-
-EXPORTED icalproperty *icalproperty_new_tzidaliasof(const char *v)
-{
-    icalproperty *prop = icalproperty_new_x(v);
-    icalproperty_set_x_name(prop, "TZID-ALIAS-OF");
-    return prop;
-}
-
-EXPORTED icalproperty *icalproperty_new_tzuntil(struct icaltimetype v)
-{
-    icalproperty *prop = icalproperty_new_x(icaltime_as_ical_string(v));
-    icalproperty_set_x_name(prop, "TZUNTIL");
-    return prop;
-}
-
-#endif /* HAVE_TZDIST_PROPS */
-
-
-#ifndef HAVE_VALARM_EXT_PROPS
-
-/* Functions to replace those not available in libical < v1.0 */
-
-EXPORTED icalproperty *icalproperty_new_acknowledged(struct icaltimetype v)
-{
-    icalproperty *prop = icalproperty_new_x(icaltime_as_ical_string(v));
-    icalproperty_set_x_name(prop, "ACKNOWLEDGED");
-    return prop;
-}
-
-EXPORTED void icalproperty_set_acknowledged(icalproperty *prop,
-                                            struct icaltimetype v)
-{
-    icalproperty_set_x(prop, icaltime_as_ical_string(v));
-}
-
-EXPORTED struct icaltimetype
-icalproperty_get_acknowledged(const icalproperty *prop)
-{
-    return icaltime_from_string(icalproperty_get_x(prop));
-}
-
-#endif /* HAVE_VALARM_EXT_PROPS */
-
-
-#ifndef HAVE_RFC7986_PROPS
-
-/* Functions to replace those not available in libical < v2.0 */
-
-EXPORTED icalproperty *icalproperty_new_name(const char *v)
-{
-    icalproperty *prop = icalproperty_new_x(v);
-    icalproperty_set_x_name(prop, "NAME");
-    return prop;
-}
-
-#endif /* HAVE_RFC7986_PROPS */
 
 #ifndef HAVE_RFC7986_COLOR
 
@@ -1910,127 +1830,5 @@ EXPORTED icalproperty *icalproperty_new_color(const char *v)
 }
 
 #endif /* HAVE_RFC7986_COLOR */
-
-
-#ifdef HAVE_IANA_PARAMS
-
-#ifndef HAVE_MANAGED_ATTACH_PARAMS
-
-EXPORTED icalparameter*
-icalproperty_get_iana_parameter_by_name(icalproperty *prop,
-                                        const char *name)
-{
-    icalparameter *param;
-
-    for (param = icalproperty_get_first_parameter(prop, ICAL_IANA_PARAMETER);
-         param && strcmp(icalparameter_get_iana_name(param), name);
-         param = icalproperty_get_next_parameter(prop, ICAL_IANA_PARAMETER));
-
-    return param;
-}
-
-/* Functions to replace those not available in libical < v2.0 */
-
-EXPORTED icalparameter *icalparameter_new_filename(const char *fname)
-{
-    icalparameter *param = icalparameter_new(ICAL_IANA_PARAMETER);
-
-    icalparameter_set_iana_name(param, "FILENAME");
-    icalparameter_set_iana_value(param, fname);
-
-    return param;
-}
-
-EXPORTED void icalparameter_set_filename(icalparameter *param, const char *fname)
-{
-    icalparameter_set_iana_value(param, fname);
-}
-
-EXPORTED icalparameter *icalparameter_new_managedid(const char *id)
-{
-    icalparameter *param = icalparameter_new(ICAL_IANA_PARAMETER);
-
-    icalparameter_set_iana_name(param, "MANAGED-ID");
-    icalparameter_set_iana_value(param, id);
-
-    return param;
-}
-
-EXPORTED const char *icalparameter_get_managedid(icalparameter *param)
-{
-    return icalparameter_get_iana_value(param);
-}
-
-EXPORTED void icalparameter_set_managedid(icalparameter *param, const char *id)
-{
-    icalparameter_set_iana_value(param, id);
-}
-
-EXPORTED icalparameter *icalparameter_new_size(const char *sz)
-{
-    icalparameter *param = icalparameter_new(ICAL_IANA_PARAMETER);
-
-    icalparameter_set_iana_name(param, "SIZE");
-    icalparameter_set_iana_value(param, sz);
-
-    return param;
-}
-
-EXPORTED const char *icalparameter_get_size(icalparameter *param)
-{
-    return icalparameter_get_iana_value(param);
-}
-
-EXPORTED void icalparameter_set_size(icalparameter *param, const char *sz)
-{
-    icalparameter_set_iana_value(param, sz);
-}
-
-#endif /* HAVE_MANAGED_ATTACH_PARAMS */
-
-
-#ifndef HAVE_SCHEDULING_PARAMS
-
-/* Functions to replace those not available in libical < v1.0 */
-
-EXPORTED icalparameter_scheduleagent
-icalparameter_get_scheduleagent(icalparameter *param)
-{
-    const char *agent = NULL;
-
-    if (param) agent = icalparameter_get_iana_value(param);
-
-    if (!agent) return ICAL_SCHEDULEAGENT_NONE;
-    else if (!strcmp(agent, "SERVER")) return ICAL_SCHEDULEAGENT_SERVER;
-    else if (!strcmp(agent, "CLIENT")) return ICAL_SCHEDULEAGENT_CLIENT;
-    else return ICAL_SCHEDULEAGENT_X;
-}
-
-EXPORTED icalparameter_scheduleforcesend
-icalparameter_get_scheduleforcesend(icalparameter *param)
-{
-    const char *force = NULL;
-
-    if (param) force = icalparameter_get_iana_value(param);
-
-    if (!force) return ICAL_SCHEDULEFORCESEND_NONE;
-    else if (!strcmp(force, "REQUEST")) return ICAL_SCHEDULEFORCESEND_REQUEST;
-    else if (!strcmp(force, "REPLY")) return ICAL_SCHEDULEFORCESEND_REPLY;
-    else return ICAL_SCHEDULEFORCESEND_X;
-}
-
-EXPORTED icalparameter *icalparameter_new_schedulestatus(const char *stat)
-{
-    icalparameter *param = icalparameter_new(ICAL_IANA_PARAMETER);
-
-    icalparameter_set_iana_name(param, "SCHEDULE-STATUS");
-    icalparameter_set_iana_value(param, stat);
-
-    return param;
-}
-
-#endif /* HAVE_SCHEDULING_PARAMS */
-
-#endif /* HAVE_IANA_PARAMS */
 
 #endif /* HAVE_ICAL */

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -1896,6 +1896,12 @@ EXPORTED icalproperty *icalproperty_new_name(const char *v)
     return prop;
 }
 
+#endif /* HAVE_RFC7986_PROPS */
+
+#ifndef HAVE_RFC7986_COLOR
+
+/* Replacement for missing function in 3.0.0 <= libical < 3.0.5 */
+
 EXPORTED icalproperty *icalproperty_new_color(const char *v)
 {
     icalproperty *prop = icalproperty_new_x(v);
@@ -1903,7 +1909,7 @@ EXPORTED icalproperty *icalproperty_new_color(const char *v)
     return prop;
 }
 
-#endif /* HAVE_RFC7986_PROPS */
+#endif /* HAVE_RFC7986_COLOR */
 
 
 #ifdef HAVE_IANA_PARAMS

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -222,10 +222,16 @@ extern struct icaltimetype icalproperty_get_acknowledged(const icalproperty *pro
 /* Functions to replace those not available in libical < v2.0 */
 
 extern icalproperty *icalproperty_new_name(const char *v);
-extern icalproperty *icalproperty_new_color(const char *v);
 
 #endif /* HAVE_RFC7986_PROPS */
 
+#ifndef HAVE_RFC7986_COLOR
+
+/* Replacement for missing function in 3.0.0 <= libical < 3.0.5 */
+
+extern icalproperty *icalproperty_new_color(const char *v);
+
+#endif /* HAVE_RFC7986_COLOR */
 
 #ifndef HAVE_RSCALE
 

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -58,27 +58,6 @@
 #define PER_USER_CAL_DATA \
     DAV_ANNOT_NS "<" XML_NS_CYRUS ">per-user-calendar-data"
 
-#ifndef HAVE_VAVAILABILITY
-/* Allow us to compile without #ifdef HAVE_VAVAILABILITY everywhere */
-#define ICAL_VAVAILABILITY_COMPONENT  ICAL_X_COMPONENT
-#define ICAL_XAVAILABLE_COMPONENT     ICAL_X_COMPONENT
-#endif
-
-#ifndef HAVE_VPOLL
-/* Allow us to compile without #ifdef HAVE_VPOLL everywhere */
-#define ICAL_VPOLL_COMPONENT          ICAL_NO_COMPONENT
-#define ICAL_VVOTER_COMPONENT         ICAL_X_COMPONENT
-#define ICAL_METHOD_POLLSTATUS        ICAL_METHOD_NONE
-#define ICAL_VOTER_PROPERTY           ICAL_NO_PROPERTY
-#define icalproperty_get_voter        icalproperty_get_attendee
-#endif
-
-#ifndef HAVE_VPATCH
-/* Allow us to compile without #ifdef HAVE_VPATCH everywhere */
-#define ICAL_VPATCH_COMPONENT         ICAL_NO_COMPONENT
-#define ICAL_XPATCH_COMPONENT         ICAL_X_COMPONENT
-#endif
-
 #ifndef HAVE_NEW_CLONE_API
 /* Allow us to compile without #ifdef HAVE_NEW_CLONE_API everywhere */
 #define icalcomponent_clone           icalcomponent_new_clone
@@ -161,69 +140,11 @@ extern int icalcomponent_apply_vpatch(icalcomponent *ical,
 /* Functions that should be declared in libical */
 #define icaltimezone_set_zone_directory set_zone_directory
 
-
-/* Functions not declared in in libical < v2.0 */
-
-#if !HAVE_DECL_ICAL_STATUS_DELETED
-#define ICAL_STATUS_DELETED ICAL_STATUS_CANCELLED
-#endif
-
-#if !HAVE_DECL_ICALPROPERTY_GET_PARENT
-extern icalcomponent *icalproperty_get_parent(const icalproperty *property);
-#endif
-
-#if !HAVE_DECL_ICALRECUR_FREQ_TO_STRING
-extern const char *icalrecur_freq_to_string(icalrecurrencetype_frequency kind);
-#endif
-
-#if !HAVE_DECL_ICALRECUR_WEEKDAY_TO_STRING
-extern const char *icalrecur_weekday_to_string(icalrecurrencetype_weekday kind);
-#endif
-
-
-#ifdef HAVE_TZDIST_PROPS
-
 #define icalcomponent_get_tzuntil_property(comp) \
     icalcomponent_get_first_property(comp, ICAL_TZUNTIL_PROPERTY)
 
-#else /* !HAVE_TZDIST_PROPS */
-
-/* Functions to replace those not available in libical < v2.0 */
-
-#define icalcomponent_get_tzuntil_property(comp) \
-    icalcomponent_get_x_property_by_name(comp, "TZUNTIL")
-
-extern icalproperty *icalproperty_new_tzidaliasof(const char *v);
-extern icalproperty *icalproperty_new_tzuntil(struct icaltimetype v);
-
-#endif /* HAVE_TZDIST_PROPS */
-
-
-#ifdef HAVE_VALARM_EXT_PROPS
-
 #define icalcomponent_get_acknowledged_property(comp) \
     icalcomponent_get_first_property(comp, ICAL_ACKNOWLEDGED_PROPERTY)
-
-#else /* !HAVE_VALARM_EXT_PROPS */
-
-/* Functions to replace those not available in libical < v1.0 */
-
-#define icalcomponent_get_acknowledged_property(comp) \
-    icalcomponent_get_x_property_by_name(comp, "ACKNOWLEDGED")
-
-extern icalproperty *icalproperty_new_acknowledged(struct icaltimetype v);
-extern struct icaltimetype icalproperty_get_acknowledged(const icalproperty *prop);
-
-#endif /* HAVE_VALARM_EXT_PROPS */
-
-
-#ifndef HAVE_RFC7986_PROPS
-
-/* Functions to replace those not available in libical < v2.0 */
-
-extern icalproperty *icalproperty_new_name(const char *v);
-
-#endif /* HAVE_RFC7986_PROPS */
 
 #ifndef HAVE_RFC7986_COLOR
 
@@ -243,8 +164,6 @@ extern icalproperty *icalproperty_new_color(const char *v);
 #endif /* HAVE_RSCALE */
 
 
-#ifdef HAVE_MANAGED_ATTACH_PARAMS
-
 /* Wrappers to fetch managed attachment parameters by kind */
 
 #define icalproperty_get_filename_parameter(prop) \
@@ -256,69 +175,6 @@ extern icalproperty *icalproperty_new_color(const char *v);
 #define icalproperty_get_size_parameter(prop) \
     icalproperty_get_first_parameter(prop, ICAL_SIZE_PARAMETER)
 
-#elif defined(HAVE_IANA_PARAMS)
-
-/* Functions to replace those not available in libical < v2.0 */
-
-extern icalparameter* icalproperty_get_iana_parameter_by_name(icalproperty *prop,
-                                                              const char *name);
-
-extern icalparameter *icalparameter_new_filename(const char *fname);
-
-extern void icalparameter_set_filename(icalparameter *param, const char *fname);
-
-extern icalparameter *icalparameter_new_managedid(const char *id);
-
-extern const char *icalparameter_get_managedid(icalparameter *param);
-
-extern void icalparameter_set_managedid(icalparameter *param, const char *id);
-
-extern icalparameter *icalparameter_new_size(const char *sz);
-
-extern const char *icalparameter_get_size(icalparameter *param);
-
-extern void icalparameter_set_size(icalparameter *param, const char *sz);
-
-/* Wrappers to fetch managed attachment parameters by kind */
-
-#define icalproperty_get_filename_parameter(prop) \
-    icalproperty_get_iana_parameter_by_name(prop, "FILENAME")
-
-#define icalproperty_get_managedid_parameter(prop) \
-    icalproperty_get_iana_parameter_by_name(prop, "MANAGED-ID")
-
-#define icalproperty_get_size_parameter(prop) \
-    icalproperty_get_iana_parameter_by_name(prop, "SIZE")
-
-#else /* !HAVE_IANA_PARAMS */
-
-/* Dummy functions to allow compilation with libical < v0.48 */
-
-#define icalparameter_new_filename(fname) NULL
-
-#define icalparameter_set_filename(param, fname) (void) param
-
-#define icalparameter_new_managedid(id) NULL
-
-#define icalparameter_get_managedid(param) ""
-
-#define icalparameter_set_managedid(param, id) (void) param
-
-#define icalparameter_new_size(sz) NULL
-
-#define icalparameter_set_size(param, sz) (void) param
-
-#define icalproperty_get_filename_parameter(prop) NULL
-
-#define icalproperty_get_managedid_parameter(prop) NULL
-
-#define icalproperty_get_size_parameter(prop) NULL
-
-#endif /* HAVE_MANAGED_ATTACH_PARAMS */
-
-
-#ifdef HAVE_SCHEDULING_PARAMS
-
 /* Wrappers to fetch scheduling parameters by kind */
 
 #define icalproperty_get_scheduleagent_parameter(prop) \
@@ -329,66 +185,6 @@ extern void icalparameter_set_size(icalparameter *param, const char *sz);
 
 #define icalproperty_get_schedulestatus_parameter(prop) \
     icalproperty_get_first_parameter(prop, ICAL_SCHEDULESTATUS_PARAMETER)
-
-#else /* !HAVE_SCHEDULING_PARAMS */
-
-typedef enum {
-    ICAL_SCHEDULEAGENT_X,
-    ICAL_SCHEDULEAGENT_SERVER,
-    ICAL_SCHEDULEAGENT_CLIENT,
-    ICAL_SCHEDULEAGENT_NONE
-} icalparameter_scheduleagent;
-
-typedef enum {
-    ICAL_SCHEDULEFORCESEND_X,
-    ICAL_SCHEDULEFORCESEND_REQUEST,
-    ICAL_SCHEDULEFORCESEND_REPLY,
-    ICAL_SCHEDULEFORCESEND_NONE
-} icalparameter_scheduleforcesend;
-
-
-#ifdef HAVE_IANA_PARAMS
-
-/* Functions to replace those not available in libical < v1.0 */
-
-extern icalparameter_scheduleagent
-icalparameter_get_scheduleagent(icalparameter *param);
-
-extern icalparameter_scheduleforcesend
-icalparameter_get_scheduleforcesend(icalparameter *param);
-
-extern icalparameter *icalparameter_new_schedulestatus(const char *stat);
-
-/* Wrappers to fetch scheduling parameters by kind */
-
-#define icalproperty_get_scheduleagent_parameter(prop) \
-    icalproperty_get_iana_parameter_by_name(prop, "SCHEDULE-AGENT")
-
-#define icalproperty_get_scheduleforcesend_parameter(prop) \
-    icalproperty_get_iana_parameter_by_name(prop, "SCHEDULE-FORCE-SEND")
-
-#define icalproperty_get_schedulestatus_parameter(prop) \
-    icalproperty_get_iana_parameter_by_name(prop, "SCHEDULE-STATUS")
-
-#else /* !HAVE_IANA_PARAMS */
-
-/* Dummy functions to allow compilation with libical < v0.48 */
-
-#define icalparameter_get_scheduleagent(param) ICAL_SCHEDULEAGENT_NONE
-
-#define icalparameter_get_scheduleforcesend(param) ICAL_SCHEDULEFORCESEND_NONE
-
-#define icalparameter_new_schedulestatus(stat) ((void) stat, NULL)
-
-#define icalproperty_get_scheduleagent_parameter(prop) NULL
-
-#define icalproperty_get_scheduleforcesend_parameter(prop) NULL
-
-#define icalproperty_get_schedulestatus_parameter(prop) NULL
-
-#endif /* HAVE_IANA_PARAMS */
-
-#endif /* HAVE_SCHEDULING_PARAMS */
 
 #endif /* HAVE_ICAL */
 

--- a/imap/icu_wrap.cpp
+++ b/imap/icu_wrap.cpp
@@ -47,15 +47,12 @@ extern "C" {
 };
 
 
-#ifdef HAVE_ICU
 #include <unicode/ucnv.h>
 #include <unicode/unistr.h>
 #include <unicode/timezone.h>
-#endif
 
 extern "C" char *icu_getIDForWindowsID(const char *id)
 {
-#ifdef HAVE_ICU
     UErrorCode status = U_ZERO_ERROR;
 
     UConverter *utf8cnv = ucnv_open("utf-8", &status);
@@ -69,7 +66,6 @@ extern "C" char *icu_getIDForWindowsID(const char *id)
     std::string str;
     uID.toUTF8String(str);
     if (!str.empty()) return xstrdup(str.c_str());
-#endif
 
     if (!strcasecmp(id, "Mid-Atlantic Standard Time")) {
         /* ICU doesn't map this ID */

--- a/imap/index.c
+++ b/imap/index.c
@@ -6032,6 +6032,7 @@ MsgData **index_msgdata_load(struct index_state *state,
                 }
                 break;
             case SORT_SNOOZEDUNTIL:
+#ifdef WITH_JMAP
                 if ((record.internal_flags & FLAG_INTERNAL_SNOOZED) &&
                     !strcmpnull(mailbox->uniqueid, sortcrit[j].args.mailbox.id)) {
                     /* SAVEDATE == snoozed#until */
@@ -6051,6 +6052,7 @@ MsgData **index_msgdata_load(struct index_state *state,
                         }
                     }
                 }
+#endif
                 if (!cur->savedate) {
                     /* If not snoozed in mailboxId, we use receivedAt */
                     cur->internaldate = record.internaldate;

--- a/imap/jcal.c
+++ b/imap/jcal.c
@@ -249,11 +249,9 @@ static void icalparameter_as_json_object_member(icalparameter *param,
         kind_string = icalparameter_get_xname(param);
         break;
 
-#ifdef HAVE_IANA_PARAMS
     case ICAL_IANA_PARAMETER:
         kind_string = icalparameter_get_iana_name(param);
         break;
-#endif
 
     default:                    /* XXX: Is the default case here deliberate?? */
         kind_string = icalparameter_kind_to_string(kind);

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -25,10 +25,8 @@ extern "C" {
 #include "imap/imap_err.h"
 };
 
-#ifdef HAVE_ICU
 #include <unicode/unistr.h>
 #include <unicode/locid.h>
-#endif
 
 #include <xapian.h>
 
@@ -59,11 +57,6 @@ static std::map<std::string, std::unique_ptr<Xapian::Stopper>> stoppers;
 
 static const Xapian::Stopper* get_stopper(const std::string& iso)
 {
-#ifndef HAVE_ICU
-    syslog(LOG_ERR, "xapian: can't determine stopper language without libicu");
-    return NULL;
-#endif
-
     // Lookup cached entry.
     try {
         stoppers.at(iso).get();

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -256,11 +256,9 @@ static xmlNodePtr icalparameter_as_xml_element(icalparameter *param)
         kind_string = icalparameter_get_xname(param);
         break;
 
-#ifdef HAVE_IANA_PARAMS
     case ICAL_IANA_PARAMETER:
         kind_string = icalparameter_get_iana_name(param);
         break;
-#endif
 
     default:
         kind_string = icalparameter_kind_to_string(kind);

--- a/imap/xcal.h
+++ b/imap/xcal.h
@@ -50,11 +50,6 @@
 
 #include "util.h"
 
-#ifndef HAVE_VPOLL
-/* Allow us to compile without #ifdef HAVE_VPOLL everywhere */
-#define ICAL_POLLPROPERTIES_PROPERTY  ICAL_NO_PROPERTY
-#endif
-
 #define XML_NS_ICALENDAR        "urn:ietf:params:xml:ns:icalendar-2.0"
 
 extern const char *icalproperty_value_kind_as_string(icalproperty *prop);

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -434,6 +434,7 @@ static void print_test(test_t *test)
         print_stringlist(" KEYS", test->u.mm.keylist);
         break;
 
+#ifdef WITH_JMAP
     case BC_JMAPQUERY: {
         json_error_t jerr;
         json_t *jquery = json_loads(test->u.jquery, 0, &jerr);
@@ -445,6 +446,7 @@ static void print_test(test_t *test)
         free(json);
         break;
     }
+#endif
     }
 
     printf("\n");


### PR DESCRIPTION
This bumps our minimum supported libical up to 3.0.0+ (removing a lot of feature-detection and workarounds going back to pre-1.0), and consolidates our icu usage and making it explicitly mandatory at configure time.

It also fixes some stuff that didn't build right with `--disable-jmap`, because that was on the circuitous path I needed for testing this.

This works great on my machine (tested with both the cyruslibs libical, and also a vanilla libical-3.0.0 from the release tarball), but we're all running different compilers and different library environments, so I'd appreciate if y'all could try this branch out in your own environment(s) before I merge it down, in case there's some platform-specific detail I've missed.

Thanks!