### PR TITLE
retry.c: rewrite retry_writev() to properly handle an initial failure

### DIFF
--- a/lib/retry.c
+++ b/lib/retry.c
@@ -136,33 +136,9 @@ EXPORTED ssize_t retry_writev(int fd, const struct iovec *srciov, int iovcnt)
         len += srciov[i].iov_len;
     }
 
-    n = written = writev(fd, srciov, iovcnt > iov_max ? iov_max : iovcnt);
-
-    /* did we get lucky and write it all? */
-    if (written == len)
-        return written;
-
-    /* oh well, welcome to the slow path - we have copies */
-    baseiov = iov = (struct iovec *)xmalloc(iovcnt * sizeof(struct iovec));
-    for (i = 0; i < iovcnt; i++) {
-        iov[i].iov_base = srciov[i].iov_base;
-        iov[i].iov_len = srciov[i].iov_len;
-    }
-
     for (;;) {
-        for (i = 0; i < iovcnt; i++) {
-            if (iov[i].iov_len > (size_t)n) {
-                iov[i].iov_base += n;
-                iov[i].iov_len -= n;
-                break;
-            }
-            n -= iov[i].iov_len;
-            iov++;
-            iovcnt--;
-            if (!iovcnt) fatal("ran out of iov", EX_SOFTWARE);
-        }
-
-        n = writev(fd, iov, iovcnt > iov_max ? iov_max : iovcnt);
+        /* Try to write the (remaining) iov */
+        n = writev(fd, srciov, iovcnt > iov_max ? iov_max : iovcnt);
         if (n == -1) {
             if (errno == EINVAL && iov_max > 10) {
                 iov_max /= 2;
@@ -176,6 +152,29 @@ EXPORTED ssize_t retry_writev(int fd, const struct iovec *srciov, int iovcnt)
         written += n;
 
         if (written == len) break;
+
+        /* Oh well, welcome to the slow path - we have copies */
+        if (!baseiov) {
+            iov = baseiov = xmalloc(iovcnt * sizeof(struct iovec));
+            for (i = 0; i < iovcnt; i++) {
+                iov[i].iov_base = srciov[i].iov_base;
+                iov[i].iov_len = srciov[i].iov_len;
+            }
+        }
+
+        /* Skip any iov that may have been written in full */
+        while ((size_t) n >= iov->iov_len) {
+            n -= iov->iov_len;
+            iov++;
+            iovcnt--;
+            if (!iovcnt) fatal("ran out of iov", EX_SOFTWARE);
+        }
+
+        /* Skip whatever portion of the current iov that has been written */
+        iov->iov_base += n;
+        iov->iov_len -= n;
+
+        srciov = iov;
     }
 
     free(baseiov);


### PR DESCRIPTION
So, I think any issues that we may have seen with this function is if the initial writev() failed and returned -1.  We would then use that value in adjusting the iov which would result in an invalid iov_base pointer