### PR TITLE
docsrc/: Remove support for RFC 5465 IMAP NOTIFY Extension

### DIFF
--- a/docsrc/imap/rfc-support.rst
+++ b/docsrc/imap/rfc-support.rst
@@ -481,10 +481,6 @@ The following is an inventory of RFCs supported by Cyrus IMAP.
 
     The IMAP METADATA Extension
 
-:rfc:`5465`
-
-    The IMAP NOTIFY Extension
-
 :rfc:`5490`
 
     The Sieve Mail-Filtering Language -- Extensions for Checking Mailbox


### PR DESCRIPTION
https://lists.andrew.cmu.edu/pipermail/cyrus-devel/2020-March/004587.html

Per RFC 5465 page 7, the server-side support is announced with “ S: * OK [CAPABILITY IMAP4REV1 NOTIFY]”.  The CAPABILITY answer is generated in imap/imapd.c using “static struct capa_struct base_capabilities[]” in capa_response().  The latter contains no code to generate NOTIFY.