### PR TITLE
Synclock

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -12138,6 +12138,8 @@ static void cmd_xfer(const char *tag, const char *name,
             }
             if (r) goto next;
 
+            struct mboxlock *namespacelock = user_namespacelock(xfer->userid);
+
             if (!xfer->use_replication) {
                 /* set the quotaroot if needed */
                 r = xfer_setquotaroot(xfer, mbentry->name);
@@ -12153,7 +12155,6 @@ static void cmd_xfer(const char *tag, const char *name,
             r = mboxlist_usermboxtree(xfer->userid, NULL, xfer_addusermbox,
                                       xfer, MBOXTREE_DELETED);
 
-            struct mboxlock *namespacelock = user_namespacelock(xfer->userid);
             /* NOTE: mailboxes were added in reverse, so the inbox is
              * done last */
             r = do_xfer(xfer);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -11771,7 +11771,7 @@ static int xfer_finalsync(struct xfer_header *xfer)
                     sync_name_list_add(master_quotaroots, mailbox->quotaroot);
                 }
 
-                r = sync_do_annotation(mailbox->name, xfer->be, flags);
+                r = sync_do_annotation(mailbox->name, xfer->be, NULL, flags);
                 if (r) {
                     syslog(LOG_ERR, "Could not move mailbox: %s,"
                            " sync_do_annotation() failed %s",

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -373,7 +373,7 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
         if (!action->active)
             continue;
 
-        r = sync_do_quota(action->name, sync_backend, flags);
+        r = sync_do_quota(action->name, sync_backend, channelp, flags);
         if (channelp && r == IMAP_MAILBOX_LOCKED) {
             sync_log_channel_quota(*channelp, action->name);
             report_verbose("  Deferred: QUOTA %s\n", action->name);
@@ -393,7 +393,7 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
         /* NOTE: ANNOTATION "" is a special case - it's a server
          * annotation, hence the check for a character at the
          * start of the name */
-        r = sync_do_annotation(action->name, sync_backend, flags);
+        r = sync_do_annotation(action->name, sync_backend, channelp, flags);
         if (!*action->name) continue;
 
         if (channelp && r == IMAP_MAILBOX_LOCKED) {
@@ -412,7 +412,7 @@ static int do_sync(sync_log_reader_t *slr, const char **channelp)
         if (!action->active)
             continue;
 
-        r = sync_do_seen(action->user, action->name, sync_backend, flags);
+        r = sync_do_seen(action->user, action->name, sync_backend, channelp, flags);
         if (channelp && r == IMAP_MAILBOX_LOCKED) {
             sync_log_channel_seen(*channelp, action->user, action->name);
             report_verbose("  Deferred: SEEN %s %s\n",

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -485,9 +485,11 @@ const char *sync_restore(struct dlist *kin,
 #define SYNC_FLAG_NO_COPYBACK (1<<4)
 
 int sync_do_seen(const char *userid, char *uniqueid, struct backend *sync_be,
-                 unsigned flags);
-int sync_do_quota(const char *root, struct backend *sync_be, unsigned flags);
-int sync_do_annotation(char *mboxname, struct backend *sync_be, unsigned flags);
+                 const char **channelp, unsigned flags);
+int sync_do_quota(const char *root, struct backend *sync_be,
+                  const char **channelp, unsigned flags);
+int sync_do_annotation(char *mboxname, struct backend *sync_be,
+                       const char **channelp, unsigned flags);
 int sync_do_mailboxes(struct sync_name_list *mboxname_list,
                       const char *topart, struct backend *sync_be,
                       const char **channelp, unsigned flags);


### PR DESCRIPTION
I've noticed that if you have two sync_clients running concurrently (e.g. one by hand and one rolling) and they race, the second will get a bail out due to the remote changing between first and second query.

To work around that, this takes a named lock on the userid and channel any time it's replicating something for a user, and hence the second will wait and discover nothing to do.  This is more efficient and all around better :)