### PR TITLE
V31/2973 master daemon start stop order

### DIFF
--- a/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
+++ b/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
@@ -257,6 +257,48 @@ is exiting.
     The command (with options) to spawn as a child process.  This
     string argument is required.
 
+.. parsed-literal::
+
+    **wait=**\ 0
+
+..
+
+    Switch: whether or not :cyrusman:`master(8)` should wait for this
+    daemon to successfully start before continuing to load.
+
+    If *wait=n* (the default), the daemon will be started asynchronously
+    along with the service processes.  The daemon process will not have
+    file descriptor 3 open, and does not need to indicate its readiness.
+
+    If *wait=y*, the daemon MUST write "ok\\r\\n" to file descriptor 3
+    to indicate its readiness; if it does not do this, and master has
+    been told to wait, master will continue to wait.... If it writes
+    anything else to this descriptor, or closes it before writing
+    "ok\\r\\n", master will exit with an error.
+
+    Daemons with *wait=y* will be started sequentially in the order
+    they are listed in cyrus.conf, waiting for each to report readiness
+    before the next is started.
+
+    Service processes, and *wait=n* daemons, are not started until after
+    the *wait=y* daemons are all started and ready.
+
+    At shutdown, *wait=y* daemons will be terminated sequentially in the
+    reverse order they were started, commencing after all other services
+    and *wait=n* daemons have finished.
+
+    If a daemon that was started with *wait=y* exits unexpectedly, such
+    that master restarts it, master will restart it asynchronously,
+    without waiting for it to report its readiness.  In this case, file
+    descriptor 3 will not be open and the daemon should not try to write
+    to it.
+
+    If master is told to reread its config with a SIGHUP, this signal
+    will be passed on to *wait=y* daemons like any other service.  If the
+    daemon exits in response to the signal, master will restart it
+    asynchronously, without waiting for it to report its readiness. In
+    this case too, file descriptor 3 will not be open and the daemon
+    should not try to write to it.
 
 Examples
 ========

--- a/master/master.c
+++ b/master/master.c
@@ -2002,6 +2002,21 @@ static void add_waitdaemon(const char *name, struct entry *e, void *rock)
         fatal(buf, EX_CONFIG);
     }
 
+    /* make sure this name doesn't conflict with a service */
+    for (i = 0; i < nservices; i++) {
+        if (!strcmpsafe(Services[i].name, name) && Services[i].exec) {
+            char buf[256];
+            snprintf(buf, sizeof(buf), "multiple entries for waitdaemon '%s'", name);
+
+            if (ignore_err) {
+                syslog(LOG_WARNING, "WARNING: %s -- ignored", buf);
+                goto done;
+            }
+
+            fatal(buf, EX_CONFIG);
+        }
+    }
+
     /* see if we have an existing entry that can be reused */
     for (i = 0; i < nwaitdaemons; i++) {
         /* skip non-primary instances */
@@ -2093,6 +2108,21 @@ static void add_daemon(const char *name, struct entry *e, void *rock)
         fatal(buf, EX_CONFIG);
     }
 
+    /* make sure this name doesn't conflict with a waitdaemon */
+    for (i = 0; i < nwaitdaemons; i++) {
+        if (!strcmpsafe(WaitDaemons[i].name, name) && WaitDaemons[i].exec) {
+            char buf[256];
+            snprintf(buf, sizeof(buf), "multiple entries for service '%s'", name);
+
+            if (ignore_err) {
+                syslog(LOG_WARNING, "WARNING: %s -- ignored", buf);
+                goto done;
+            }
+
+            fatal(buf, EX_CONFIG);
+        }
+    }
+
     /* see if we have an existing entry that can be reused */
     for (i = 0; i < nservices; i++) {
         /* skip non-primary instances */
@@ -2182,6 +2212,21 @@ static void add_service(const char *name, struct entry *e, void *rock)
         }
 
         fatal(buf, EX_CONFIG);
+    }
+
+    /* make sure this name doesn't conflict with a waitdaemon */
+    for (i = 0; i < nwaitdaemons; i++) {
+        if (!strcmpsafe(WaitDaemons[i].name, name) && WaitDaemons[i].exec) {
+            char buf[256];
+            snprintf(buf, sizeof(buf), "multiple entries for service '%s'", name);
+
+            if (ignore_err) {
+                syslog(LOG_WARNING, "WARNING: %s -- ignored", buf);
+                goto done;
+            }
+
+            fatal(buf, EX_CONFIG);
+        }
     }
 
     /* see if we have an existing entry that can be reused */

--- a/master/master.c
+++ b/master/master.c
@@ -3047,6 +3047,7 @@ finished:
                 }
                 else {
                     const char *childexit;
+                    const char *coredumped = "";
                     int detail;
 
                     if (WIFEXITED(status)) {
@@ -3056,15 +3057,19 @@ finished:
                     else if (WIFSIGNALED(status)) {
                         childexit = "killed with signal";
                         detail = WTERMSIG(status);
+#ifdef WCOREDUMP
+                        if (WCOREDUMP(status))
+                            coredumped = " (core dumped)";
+#endif
                     }
                     else {
                         childexit = "is in unknown state";
                         detail = status;
                     }
                     syslog(LOG_NOTICE,
-                           "child %ld of %s/%s %s %d",
+                           "child %ld of %s/%s %s %d%s",
                            (long) c->pid, s->name, s->familyname,
-                           childexit, detail);
+                           childexit, detail, coredumped);
                 }
 
                 centry_set_state(c, SERVICE_STATE_DEAD);

--- a/master/master.c
+++ b/master/master.c
@@ -2528,6 +2528,13 @@ static void do_prom_report(struct timeval now)
         buf_printf(&report, " %d %" PRId64 "\n",
                             s->ready_workers, last_updated);
     }
+    for (i = 0; i < nwaitdaemons; i++) {
+        const struct service *s = &WaitDaemons[i];
+        buf_printf(&report, "cyrus_master_ready_workers{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %d %" PRId64 "\n",
+                            s->ready_workers, last_updated);
+    }
 
     buf_printf(&report, "# HELP %s %s\n",
                         "cyrus_master_forks_total",
@@ -2535,6 +2542,13 @@ static void do_prom_report(struct timeval now)
     buf_appendcstr(&report, "# TYPE cyrus_master_forks_total counter\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];
+        buf_printf(&report, "cyrus_master_forks_total{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %d %" PRId64 "\n",
+                            s->nforks, last_updated);
+    }
+    for (i = 0; i < nwaitdaemons; i++) {
+        const struct service *s = &WaitDaemons[i];
         buf_printf(&report, "cyrus_master_forks_total{service=\"%s\",family=\"%s\"}",
                             s->name, s->familyname);
         buf_printf(&report, " %d %" PRId64 "\n",
@@ -2552,6 +2566,13 @@ static void do_prom_report(struct timeval now)
         buf_printf(&report, " %d %" PRId64 "\n",
                             s->nactive, last_updated);
     }
+    for (i = 0; i < nwaitdaemons; i++) {
+        const struct service *s = &WaitDaemons[i];
+        buf_printf(&report, "cyrus_master_active_children{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %d %" PRId64 "\n",
+                            s->nactive, last_updated);
+    }
 
     buf_printf(&report, "# HELP %s %s\n",
                         "cyrus_master_max_children",
@@ -2559,6 +2580,13 @@ static void do_prom_report(struct timeval now)
     buf_appendcstr(&report, "# TYPE cyrus_master_max_children gauge\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];
+        buf_printf(&report, "cyrus_master_max_children{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %d %" PRId64 "\n",
+                            s->max_workers, last_updated);
+    }
+    for (i = 0; i < nwaitdaemons; i++) {
+        const struct service *s = &WaitDaemons[i];
         buf_printf(&report, "cyrus_master_max_children{service=\"%s\",family=\"%s\"}",
                             s->name, s->familyname);
         buf_printf(&report, " %d %" PRId64 "\n",
@@ -2578,6 +2606,13 @@ static void do_prom_report(struct timeval now)
         buf_printf(&report, " %g %" PRId64 "\n",
                             s->forkrate, last_updated);
     }
+    for (i = 0; i < nwaitdaemons; i++) {
+        const struct service *s = &WaitDaemons[i];
+        buf_printf(&report, "cyrus_master_forks_per_second{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %g %" PRId64 "\n",
+                            s->forkrate, last_updated);
+    }
 
     buf_printf(&report, "# HELP %s %s\n",
                         "cyrus_master_max_forks_per_second",
@@ -2585,6 +2620,13 @@ static void do_prom_report(struct timeval now)
     buf_appendcstr(&report, "# TYPE cyrus_master_max_forks_per_second gauge\n");
     for (i = 0; i < nservices; i++) {
         const struct service *s = &Services[i];
+        buf_printf(&report, "cyrus_master_max_forks_per_second{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %u %" PRId64 "\n",
+                            s->maxforkrate, last_updated);
+    }
+    for (i = 0; i < nwaitdaemons; i++) {
+        const struct service *s = &WaitDaemons[i];
         buf_printf(&report, "cyrus_master_max_forks_per_second{service=\"%s\",family=\"%s\"}",
                             s->name, s->familyname);
         buf_printf(&report, " %u %" PRId64 "\n",
@@ -2602,8 +2644,13 @@ static void do_prom_report(struct timeval now)
         buf_printf(&report, " %d %" PRId64 "\n",
                             s->nreadyfails, last_updated);
     }
-
-    /* XXX count details for WaitDaemons */
+    for (i = 0; i < nwaitdaemons; i++) {
+        const struct service *s = &WaitDaemons[i];
+        buf_printf(&report, "cyrus_master_ready_fails_total{service=\"%s\",family=\"%s\"}",
+                            s->name, s->familyname);
+        buf_printf(&report, " %d %" PRId64 "\n",
+                            s->nreadyfails, last_updated);
+    }
 
     /* write it out */
     retry_write(fd, buf_cstring(&report), buf_len(&report));

--- a/master/master.c
+++ b/master/master.c
@@ -813,8 +813,7 @@ static void run_startup(const char *name, const strarray_t *cmd)
 static void fcntl_unset(int fd, int flag)
 {
     int fdflags = fcntl(fd, F_GETFD, 0);
-    if (fdflags != -1) fdflags = fcntl(STATUS_FD, F_SETFD,
-                                       fdflags & ~flag);
+    if (fdflags != -1) fdflags = fcntl(fd, F_SETFD, fdflags & ~flag);
     if (fdflags == -1) {
         syslog(LOG_ERR, "fcntl(): unable to unset %d: %m", flag);
     }

--- a/master/master.c
+++ b/master/master.c
@@ -3220,8 +3220,12 @@ finished:
                 }
 
                 r = kill(c->pid, SIGTERM);
-                if (r && errno != ESRCH)
-                    fatalf(EX_OSERR, "kill %ld: %m", (long) c->pid);
+                if (r && errno != ESRCH) {
+                    syslog(LOG_ERR, "kill child %ld of %s/%s: %m",
+                                    (long) c->pid, s->name, s->familyname);
+                    centry_set_state(c, SERVICE_STATE_DEAD);
+                    continue;
+                }
 
                 syslog(LOG_NOTICE, "waiting for child %ld of %s/%s to exit...",
                         (long) c->pid, s->name, s->familyname);

--- a/master/master.c
+++ b/master/master.c
@@ -1050,7 +1050,12 @@ static void spawn_service(struct service *s, int si, int wdi)
          * the child unblocks and can carry on, now that its pgid is set
          */
         r = pipe(wdpgid_pipe);
-        if (r) fatalf(EX_OSERR, "pipe failed: %m");
+        if (r) {
+            syslog(LOG_ERR,
+                   "ERROR: unable to respawn waitdaemon %s/%s: pipe failed: %m",
+                   s->name, s->familyname);
+            return;
+        }
     }
 
     switch (p = fork()) {

--- a/master/master.c
+++ b/master/master.c
@@ -838,14 +838,13 @@ static int service_is_fork_limited(struct service *s)
     return 0;
 }
 
-static void spawn_service(int si)
+static void spawn_service(struct service *s, int si)
 {
     pid_t p;
     int i;
     char path[PATH_MAX];
     static char name_env[100], name_env2[100], name_env3[100];
     struct centry *c;
-    struct service *s = &Services[si];
 
     if (!s->name) {
         fatal("Serious software bug found: spawn_service() called on unnamed service!",
@@ -2587,7 +2586,7 @@ int main(int argc, char **argv)
                     }
 
                     while (j-- > 0) {
-                        spawn_service(i);
+                        spawn_service(&Services[i], i);
                     }
                 } else if (Services[i].exec
                           && Services[i].babysit
@@ -2596,7 +2595,7 @@ int main(int argc, char **argv)
                           "lost all children for service: %s/%s.  " \
                           "Applying babysitter.",
                           Services[i].name, Services[i].familyname);
-                    spawn_service(i);
+                    spawn_service(&Services[i], i);
                 } else if (!Services[i].exec /* disabled */ &&
                           Services[i].name /* not yet removed */ &&
                           Services[i].nactive == 0) {
@@ -2737,7 +2736,7 @@ int main(int argc, char **argv)
                     y >= 0 && FD_ISSET(y, &rfds))
                 {
                     /* huh, someone wants to talk to us */
-                    spawn_service(i);
+                    spawn_service(&Services[i], i);
                 }
             }
         }


### PR DESCRIPTION
(#2973)

This is almost done, so I'm putting it up for code review now

It adds a "wait" switch option (default: off) to entries in the DAEMON section of cyrus.conf, which toggles the new behaviour when on.  See the changes to docsrc/.../cyrus.conf.rst for how it works.

I have two remaining open questions:

1. If a wait=y daemon takes "too long" to report its readiness, should master complain and bail out?  At the moment, if a wait=y daemon hangs at startup, master will also hang at startup.  This makes sense, because "wait=y" means "refuse to start anything else until this thing is successfully started".  It might be useful for master to detect a hang and fatal out?  But I'm not currently convinced the added complexity would be worth it.

2. If a wait=y daemon successfully starts up at startup, and later exits for any reason (maybe it crashed, maybe Cyrus was SIGHUP'd by the operator), master will restart it automatically, like a normal daemon (i.e. without the ordering constraint, or the wait-for-readiness behaviour).  If it fails to restart for some reason, or restarts and crashes again soon after, etc, what should we do?  For normal DAEMON and SERVICE entries, if it fails more than MAX_READY_FAILS(5) times within MAX_READY_FAIL_INTERVAL(10) seconds, then it will disable that entry, and not try to start it again until the next SIGHUP.  But "wait=y" means "this needs to always be running as long as Cyrus is", and disabling it would invalidate that.  At the moment, master simply never gives up trying to restart it.  Should it fatal out instead?

Cassandane tests are here:
https://github.com/cyrusimap/cassandane/compare/master...elliefm:waitdaemons

`utils/waitdaemon.pl` in the Cassandane branch demonstrates how to make a perl script that conforms to the wait=y api