### PR TITLE
sync_log: bring back sync_log_mailbox_double for copy/move

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -3046,9 +3046,12 @@ index_copy(struct index_state *state,
         seqset_free(seq);
     }
 
-    /* we log the first name to get GUID-copy magic */
-    if (!r)
+    if (!r) {
+        /* we log the first name to get GUID-copy magic */
         sync_log_mailbox_double(index_mboxname(state), name);
+        /* also want to log an append here, to make sure squatter notices */
+        sync_log_append(name);
+    }
 
 done:
     free(copyargs.records);

--- a/imap/index.c
+++ b/imap/index.c
@@ -3048,7 +3048,7 @@ index_copy(struct index_state *state,
 
     /* we log the first name to get GUID-copy magic */
     if (!r)
-        sync_log_rename(index_mboxname(state), name);
+        sync_log_mailbox_double(index_mboxname(state), name);
 
 done:
     free(copyargs.records);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7789,6 +7789,11 @@ static int _copy_msgrecords(struct auth_state *authstate,
     r = append_commit(&as);
     if (r) goto done;
 
+    /* we log the first name to get GUID-copy magic */
+    sync_log_mailbox_double(src->name, dst->name);
+    /* also want to log an append here, to make sure squatter notices */
+    sync_log_append(dst->name);
+
 done:
     return r;
 }

--- a/imap/sync_log.h
+++ b/imap/sync_log.h
@@ -78,7 +78,7 @@ void sync_log_reset();
     sync_log("UNMAILBOX %s\n", name)
 
 #define sync_log_mailbox_double(name1, name2) \
-    sync_log("MAILBOX %s %s\n", name1, name2)
+    sync_log("DOUBLEMAILBOX %s %s\n", name1, name2)
 
 #define sync_log_rename(name1, name2) \
     sync_log("RENAME %s %s\nMAILBOX %s\nMAILBOX %s\n", name1, name2, name1, name2)
@@ -114,7 +114,7 @@ void sync_log_reset();
     sync_log_channel(channel, "UNMAILBOX %s\n", name)
 
 #define sync_log_channel_mailbox_double(channel, name1, name2) \
-    sync_log_channel(channel, "MAILBOX %s %s\n", name1, name2)
+    sync_log_channel(channel, "DOUBLEMAILBOX %s %s\n", name1, name2)
 
 #define sync_log_channel_rename(channel, name1, name2) \
     sync_log_channel(channel, "RENAME %s %s\nMAILBOX %s\nMAILBOX %s\n", \

--- a/imap/sync_log.h
+++ b/imap/sync_log.h
@@ -77,6 +77,9 @@ void sync_log_reset();
 #define sync_log_unmailbox(name) \
     sync_log("UNMAILBOX %s\n", name)
 
+#define sync_log_mailbox_double(name1, name2) \
+    sync_log("MAILBOX %s %s\n", name1, name2)
+
 #define sync_log_rename(name1, name2) \
     sync_log("RENAME %s %s\nMAILBOX %s\nMAILBOX %s\n", name1, name2, name1, name2)
 
@@ -109,6 +112,9 @@ void sync_log_reset();
 
 #define sync_log_channel_unmailbox(channel, name) \
     sync_log_channel(channel, "UNMAILBOX %s\n", name)
+
+#define sync_log_channel_mailbox_double(channel, name1, name2) \
+    sync_log_channel(channel, "MAILBOX %s %s\n", name1, name2)
 
 #define sync_log_channel_rename(channel, name1, name2) \
     sync_log_channel(channel, "RENAME %s %s\nMAILBOX %s\nMAILBOX %s\n", \

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -7052,7 +7052,8 @@ int sync_do_reader(struct sync_client_state *sync_cs, sync_log_reader_t *slr)
         else if (!strcmp(args[0], "SIEVE"))
             sync_action_list_add(meta_list, NULL, args[1]);
         else if ((!strcmp(args[0], "APPEND")) /* just a mailbox event */
-                 || (!strcmp(args[0], "MAILBOX"))) {
+                 || (!strcmp(args[0], "MAILBOX"))
+                 || (!strcmp(args[0], "DOUBLEMAILBOX"))) {
             char *freeme = NULL;
             const char *userid;
             struct sync_action_list *mailbox_list;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -7066,6 +7066,15 @@ int sync_do_reader(struct sync_client_state *sync_cs, sync_log_reader_t *slr)
                 hash_insert(userid, mailbox_list, &user_mailboxes);
             }
             sync_action_list_add(mailbox_list, args[1], NULL);
+
+            if (args[2]) {
+                /* if there's a second MAILBOX recorded (i.e. a copy or move), add
+                 * it to the same user's mailbox_list (even if it's a diff user),
+                 * so that the order doesn't get lost.
+                 */
+                sync_action_list_add(mailbox_list, args[2], NULL);
+            }
+
             free(freeme);
         }
         else if (!strcmp(args[0], "RENAME")) {


### PR DESCRIPTION
886ee1537c1ef4527b573dd0917661e4260972a0 replaced all calls to `sync_log_mailbox_double()` with a new macro, `sync_log_rename()`, and added improved atomicity of replication of mailbox renames.

But, not all occurrences of `sync_log_mailbox_double()` were mailbox renames! Some were copies or moves of messages between folders -- which got confusing when reviewing sync_log, because it looked like lots of bad renames were happening when it was just people moving messages between folders.

This PR brings back `sync_log_mailbox_double()`, for use when two mailboxes need to be replicated together (but not due to a rename).

`sync_log_rename()` remains for actual renames