### PR TITLE
Matchmime tempdir

### DIFF
--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -940,12 +940,6 @@ out:
 
 /* ====================================================================== */
 
-/* XXX - replace with cyrus_mkdir and cyrus_copyfile */
-static void remove_dir(const char *dir)
-{
-    run_command(RM_BIN, "-rf", dir, (char *)NULL);
-}
-
 static int copy_files(const char *fromdir, const char *todir)
 {
     char *fromdir2 = strconcat(fromdir, "/", (char *)NULL);
@@ -3463,7 +3457,7 @@ static void cleanup_xapiandirs(const char *mboxname, const char *partition, stra
         char *path = activefile_path(mboxname, partition, item, /*dostat*/0);
         if (verbose)
             printf("Removing unreferenced item %s (%s)\n", item, path);
-        remove_dir(path);
+        removedir(path);
         free(path);
     }
 
@@ -3471,7 +3465,7 @@ static void cleanup_xapiandirs(const char *mboxname, const char *partition, stra
         const char *path = strarray_nth(&bogus, i);
         if (verbose)
             printf("Removing bogus path %s\n", path);
-        remove_dir(path);
+        removedir(path);
     }
 
     strarray_fini(&found);
@@ -3643,7 +3637,7 @@ static int compact_dbs(const char *userid, const char *tempdir,
     r = cyrus_mkdir(buf_cstring(&mytempdir), 0755);
     if (r) goto out;
     /* and doesn't contain any junk */
-    remove_dir(buf_cstring(&mytempdir));
+    removedir(buf_cstring(&mytempdir));
     r = mkdir(buf_cstring(&mytempdir), 0755);
     if (r) goto out;
 
@@ -3652,7 +3646,7 @@ static int compact_dbs(const char *userid, const char *tempdir,
             printf("only one source, copying directly to %s\n", tempdestdir);
         }
         cyrus_mkdir(tempdestdir, 0755);
-        remove_dir(tempdestdir);
+        removedir(tempdestdir);
         r = copy_files(strarray_nth(srcdirs, 0), tempdestdir);
         if (r) goto out;
         created_something = 1;
@@ -3702,7 +3696,7 @@ static int compact_dbs(const char *userid, const char *tempdir,
             r = search_reindex(userid, toreindex, newdirs, newtiers, flags);
             if (r) {
                 printf("ERROR: failed to reindex to %s", tempreindexdir);
-                remove_dir(tempreindexdir);
+                removedir(tempreindexdir);
                 goto out;
             }
             // remove tempreindexdir from newdirs again, it's going to be compacted instead
@@ -3740,9 +3734,9 @@ static int compact_dbs(const char *userid, const char *tempdir,
                         printf("copying from tempdir to destination\n");
                     }
                     cyrus_mkdir(tempdestdir, 0755);
-                    remove_dir(tempdestdir);
+                    removedir(tempdestdir);
                     r = copy_files(buf_cstring(&mytempdir), tempdestdir);
-                    remove_dir(buf_cstring(&mytempdir));
+                    removedir(buf_cstring(&mytempdir));
                     if (r) {
                         printf("Failed to rsync from %s to %s", buf_cstring(&mytempdir), tempdestdir);
                         goto out;
@@ -3753,7 +3747,7 @@ static int compact_dbs(const char *userid, const char *tempdir,
         }
 
         if (tempreindexdir) {
-            remove_dir(tempreindexdir);
+            removedir(tempreindexdir);
             free(tempreindexdir);
             tempreindexdir = NULL;
         }
@@ -3792,7 +3786,7 @@ static int compact_dbs(const char *userid, const char *tempdir,
         if (verbose) {
             printf("renaming tempdir into place\n");
         }
-        remove_dir(destdir);
+        removedir(destdir);
         r = rename(tempdestdir, destdir);
         if (r) {
             printf("ERROR: failed to rename into place %s to %s\n", tempdestdir, destdir);
@@ -3819,7 +3813,7 @@ static int compact_dbs(const char *userid, const char *tempdir,
 
     /* And finally remove all directories on disk of the source dbs */
     for (i = 0; i < srcdirs->count; i++)
-        remove_dir(strarray_nth(srcdirs, i));
+        removedir(strarray_nth(srcdirs, i));
 
     /* remove any other files that are still lying around! */
     cleanup_xapiandirs(mboxname, mbentry->partition, active, verbose);
@@ -3880,7 +3874,7 @@ static void delete_one(const char *key, const char *val __attribute__((unused)),
 
     xapian_basedir(tier, mboxname, partition, NULL, &basedir);
     if (basedir)
-        remove_dir(basedir);
+        removedir(basedir);
 
     free(basedir);
     free(tier);

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -446,25 +446,6 @@ int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp, int mode)
     return 0;
 }
 
-int xapian_dbw_openmem(struct xapian_dbw **dbwp)
-{
-    xapian_dbw_t *dbw = (xapian_dbw_t *)xzmalloc(sizeof(xapian_dbw_t));
-    dbw->is_inmemory = true;
-
-    dbw->database = new Xapian::WritableDatabase{"", Xapian::DB_BACKEND_INMEMORY};
-    std::set<int> db_versions {XAPIAN_DB_CURRENT_VERSION};
-    set_db_versions(*dbw->database, db_versions);
-
-    int r = xapian_dbw_init(dbw);
-    if (r) {
-        xapian_dbw_close(dbw);
-        dbw = NULL;
-    }
-
-    *dbwp = dbw;
-    return r;
-}
-
 void xapian_dbw_close(xapian_dbw_t *dbw)
 {
     if (!dbw) return;

--- a/imap/xapian_wrap.h
+++ b/imap/xapian_wrap.h
@@ -62,7 +62,6 @@ extern void xapian_check_if_needs_reindex(const strarray_t *sources, strarray_t 
 #define XAPIAN_DBW_CONVINDEXED 0
 #define XAPIAN_DBW_XAPINDEXED 1
 extern int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp, int mode);
-extern int xapian_dbw_openmem(xapian_dbw_t **dbwp);
 extern void xapian_dbw_close(xapian_dbw_t *dbw);
 extern int xapian_dbw_begin_txn(xapian_dbw_t *dbw);
 extern int xapian_dbw_commit_txn(xapian_dbw_t *dbw);

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2677,8 +2677,9 @@ product version in the capabilities
    For backward compatibility, if no unit is specified, seconds is
    assumed. */
 
-{ "temp_path", "/tmp", STRING, "2.3.17" }
-/* The pathname to store temporary files in */
+{ "temp_path", "/tmp", STRING, "3.2.1" }
+/* The pathname to store temporary files in. It is recommended to
+   use an in-memory filesystem such as tmpfs for this path. */
 
 { "telemetry_bysessionid", 0, SWITCH, "3.0.0" }
 /* If true, log by sessionid instead of PID for telemetry */

--- a/lib/util.h
+++ b/lib/util.h
@@ -203,6 +203,17 @@ extern char *dir_hash_b(const char *name, int full, char buf[2]);
  */
 extern int create_tempfile(const char *path);
 
+/* create a temporary directory at path and return the directory
+ * name "cyrus-subname-XXXXXX", where subname defaults to "tmpdir"
+ * and XXXXXX is a string that makes the directory name unique.
+ * */
+extern char *create_tempdir(const char *path, const char *subname);
+
+/* recursively call remove(3) on path and its descendants, except
+ * symlinks. Returns zero on sucess, or the first non-zero return
+ * value of remove on error. */
+extern int removedir(const char *path);
+
 /* Close a network filedescriptor the "safe" way */
 extern int cyrus_close_sock(int fd);
 


### PR DESCRIPTION
We came to realize that the in-memory Xapian database is way less efficient than the on-disk backends. Let's switch to using the default backend when evaluating a message against a JMAP Sieve rule. Cyrus installations should point their imapd.conf temp_path option to a tmpfs filesystem.