### PR TITLE
imap/http_cgi.c: exactly declare `extern char **environment`

### DIFF
--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -163,6 +163,7 @@ static int meth_get(struct transaction_t *txn,
     hdrcache_t resp_hdrs = NULL;
     struct body_t resp_body;
     long code = 0;
+    extern char **environ;
     
     memset(&resp_body, 0, sizeof(struct body_t));
 


### PR DESCRIPTION
From the standard specifications, it must be declared by the user if
it is to be used directly.