### PR TITLE
RelNotes: 2854 (squatter -F) is fixed in 3.2

### DIFF
--- a/docsrc/imap/download/release-notes/3.2/x/3.2.0.rst
+++ b/docsrc/imap/download/release-notes/3.2/x/3.2.0.rst
@@ -113,7 +113,7 @@ Security fixes
 Significant bugfixes
 ====================
 
-* Contains fix for :issue:`2839`
+* Contains fix for :issue:`2839` and :issue:`2854`.
 
 
 .. _Xapian: https://xapian.org


### PR DESCRIPTION
https://lists.andrew.cmu.edu/pipermail/cyrus-devel/2019-June/004488.html

“squatter -F increases index size” is likely fixed in 3.2.

On 3.0 `squatter -F` can increase the Xapian database, as discussed last June.