### PR TITLE
3.2: protect Blob/get and Email/matchMime behind jmap_nonstandard_extensions

### DIFF
--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -61,6 +61,7 @@
 #define JMAP_URN_VACATION   "urn:ietf:params:jmap:vacationresponse"
 #define JMAP_URN_WEBSOCKET  "urn:ietf:params:jmap:websocket"
 
+#define JMAP_BLOB_EXTENSION          "https://cyrusimap.org/ns/jmap/blob"
 #define JMAP_CONTACTS_EXTENSION      "https://cyrusimap.org/ns/jmap/contacts"
 #define JMAP_CALENDARS_EXTENSION     "https://cyrusimap.org/ns/jmap/calendars"
 #define JMAP_MAIL_EXTENSION          "https://cyrusimap.org/ns/jmap/mail"

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -156,6 +156,8 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
                 JMAP_PERFORMANCE_EXTENSION, json_object());
         json_object_set_new(settings->server_capabilities,
                 JMAP_DEBUG_EXTENSION, json_object());
+        json_object_set_new(settings->server_capabilities,
+                JMAP_BLOB_EXTENSION, json_object());
 
         for (mp = jmap_core_methods_nonstandard; mp->name; mp++) {
             hash_insert(mp->name, mp, &settings->methods);
@@ -178,6 +180,9 @@ HIDDEN void jmap_core_capabilities(json_t *account_capabilities)
 
         json_object_set_new(account_capabilities,
                 JMAP_DEBUG_EXTENSION, json_object());
+
+        json_object_set_new(account_capabilities,
+                JMAP_BLOB_EXTENSION, json_object());
     }
 }
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -59,11 +59,11 @@
 
 
 /* JMAP Core API Methods */
-static int jmap_blob_get(jmap_req_t *req);
 static int jmap_blob_copy(jmap_req_t *req);
 static int jmap_core_echo(jmap_req_t *req);
 
 /* JMAP extension methods */
+static int jmap_blob_get(jmap_req_t *req);
 static int jmap_quota_get(jmap_req_t *req);
 
 jmap_method_t jmap_core_methods_standard[] = {
@@ -85,7 +85,7 @@ jmap_method_t jmap_core_methods_standard[] = {
 jmap_method_t jmap_core_methods_nonstandard[] = {
     {
         "Blob/get",
-        JMAP_URN_CORE,  /* XXX  This should be changed to JMAP_BLOB_EXTENSION */
+        JMAP_BLOB_EXTENSION,
         &jmap_blob_get,
         JMAP_SHARED_CSTATE
     },

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -74,12 +74,6 @@ jmap_method_t jmap_core_methods_standard[] = {
         0/*flags*/
     },
     {
-        "Blob/get",
-        JMAP_URN_CORE,
-        &jmap_blob_get,
-        JMAP_SHARED_CSTATE
-    },
-    {
         "Core/echo",
         JMAP_URN_CORE,
         &jmap_core_echo,
@@ -89,6 +83,12 @@ jmap_method_t jmap_core_methods_standard[] = {
 };
 
 jmap_method_t jmap_core_methods_nonstandard[] = {
+    {
+        "Blob/get",
+        JMAP_URN_CORE,  /* XXX  This should be changed to JMAP_BLOB_EXTENSION */
+        &jmap_blob_get,
+        JMAP_SHARED_CSTATE
+    },
     {
         "Quota/get",
         JMAP_QUOTA_EXTENSION,

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -169,12 +169,6 @@ static jmap_method_t jmap_mail_methods_standard[] = {
         /*flags*/ 0
     },
     {
-        "Email/matchMime",
-        JMAP_MAIL_EXTENSION,
-        &jmap_email_matchmime_method,
-        JMAP_SHARED_CSTATE
-    },
-    {
         "SearchSnippet/get",
         JMAP_URN_MAIL,
         &jmap_searchsnippet_get,
@@ -196,6 +190,12 @@ static jmap_method_t jmap_mail_methods_standard[] = {
 };
 
 static jmap_method_t jmap_mail_methods_nonstandard[] = {
+    {
+        "Email/matchMime",
+        JMAP_MAIL_EXTENSION,
+        &jmap_email_matchmime_method,
+        JMAP_SHARED_CSTATE
+    },
     { NULL, NULL, NULL, 0}
 };
 


### PR DESCRIPTION
This is the full 3.2 fix for #3056 

@ksmurchison can you please cast an eye across this?  I think it's complete, but I'd like a second opinion :)