### PR TITLE
httpd.c: zlib_compress() rewrite to handle lack of deflatePending()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1340,6 +1340,9 @@ if test "$with_zlib" != "no"; then
     AC_DEFINE(HAVE_ZLIB,[],[Do we have zlib?])
     ZLIB="-lz"
     HAVE_ZLIB=1
+
+    AC_CHECK_LIB(z, deflatePending,
+            AC_DEFINE(HAVE_DEFLATE_PENDING,[], [Do we have deflatePending()?]))
 else
     CPPFLAGS=$save_CPPFLAGS
     LDFLAGS=$save_LDFLAGS


### PR DESCRIPTION
This is a proposed fix for platforms that don't yet have a version of zlib that has deflatePending() (e.g. OpenBSD).
In my brief testing, none of the paths to zlib_compress() (length-delimited response, chunked response, WebSockets PMCE) triggered avail_out == 0, but I didn't want to remove the condition entirely.  I chose a fallback of pending=7 because its >6 per the comment, but we could bump this to 16/32/1024/etc.
I'd like to deploy this on a FM test server for a while to see if I broke anything.