### PR TITLE
Revert "jmap_core: move Blob/get to JMAP_BLOB_EXTENSION capability"

### DIFF
--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -60,11 +60,11 @@
 
 
 /* JMAP Core API Methods */
+static int jmap_blob_get(jmap_req_t *req);
 static int jmap_blob_copy(jmap_req_t *req);
 static int jmap_core_echo(jmap_req_t *req);
 
 /* JMAP extension methods */
-static int jmap_blob_get(jmap_req_t *req);
 static int jmap_blob_set(jmap_req_t *req);
 static int jmap_quota_get(jmap_req_t *req);
 
@@ -87,7 +87,7 @@ jmap_method_t jmap_core_methods_standard[] = {
 jmap_method_t jmap_core_methods_nonstandard[] = {
     {
         "Blob/get",
-        JMAP_BLOB_EXTENSION,
+        JMAP_URN_CORE,  /* XXX  This should be changed to JMAP_BLOB_EXTENSION */
         &jmap_blob_get,
         JMAP_SHARED_CSTATE
     },


### PR DESCRIPTION
The master branch now has 5f5909037d, forward-ported from 3.2 as part of #3056.

This PR reverts it for FM, until our middleware is ready for it.