### PR TITLE
jmap: support inThreadHaveKeyword criteria in guidsearch

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2148,9 +2148,6 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
         }
 
         if (JNOTNULL((val = json_object_get(filter, "allInThreadHaveKeyword")))) {
-            /* This shouldn't happen, validate_sort should have reported
-             * allInThreadHaveKeyword as unsupported. Let's ignore this
-             * filter and return false positives. */
             _email_search_threadkeyword(this, json_string_value(val), 1, perf_filters);
         }
         if (JNOTNULL((val = json_object_get(filter, "someInThreadHaveKeyword")))) {


### PR DESCRIPTION
This patch adds support for allInThreadHaveKeyword, someInThreadHaveKeyword, noneInThreadHaveKeyword Email/query filter criteria to guidsearch.

The Cassandane test is at: https://github.com/cyrusimap/cassandane/tree/jmap_guidsearch_threadkeywords