### PR TITLE
Snooze error handling

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -11682,7 +11682,7 @@ static void _email_bulkupdate_exec_snooze(struct email_bulkupdate *bulk)
 
                 if (uidrec->is_snoozed) {
                     /* Set/update annotation */
-                    char *json = json_dumps(update->snoozed, JSON_COMPACT);
+                    char *json = json_dumps(update->snoozed, JSON_COMPACT|JSON_SORT_KEYS);
 
                     buf_initm(&val, json, strlen(json));
 

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1367,7 +1367,7 @@ static int sieve_snooze(void *ac,
     const char *annot = IMAP_ANNOT_NS "snoozed";
     const char *attrib = "value.shared";
     struct buf buf = BUF_INITIALIZER;
-    char *json = json_dumps(snoozed, JSON_COMPACT);
+    char *json = json_dumps(snoozed, JSON_COMPACT|JSON_SORT_KEYS);
 
     json_decref(snoozed);
     buf_initm(&buf, json, strlen(json));


### PR DESCRIPTION
This adds error handling to unsnooze.  In particular, if it fails it tries again in 5 minutes rather than stopping forever, and if it fails at all, it aborts the mailbox changes.

This means it has to reopen the mailbox every time (or at least commit and relock!) because otherwise the conversations DB and mailbox state can get out of sync because something got aborted from one and not the other.  *sigh*.  Roll on single DB.