### PR TITLE
jmap_calendar: don't special-case deletion of Default calendar

### DIFF
--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1388,29 +1388,8 @@ static int jmap_calendar_set(struct jmap_req *req)
             uid = newuid;
         }
 
-        /* Do not allow to remove the default calendar. */
-        char *mboxname = caldav_mboxname(req->accountid, NULL);
-        static const char *defaultcal_annot =
-            DAV_ANNOT_NS "<" XML_NS_CALDAV ">schedule-default-calendar";
-        struct buf attrib = BUF_INITIALIZER;
-        r = annotatemore_lookupmask(mboxname, defaultcal_annot,
-                                    req->accountid, &attrib);
-        free(mboxname);
-        const char *defaultcal = "Default";
-        if (!r && attrib.len) {
-            defaultcal = buf_cstring(&attrib);
-        }
-        if (!strcmp(uid, defaultcal)) {
-            /* XXX - The isDefault set error is not documented in the spec. */
-            json_t *err = json_pack("{s:s}", "type", "isDefault");
-            json_object_set_new(set.not_destroyed, uid, err);
-            buf_free(&attrib);
-            continue;
-        }
-        buf_free(&attrib);
-
         /* Make sure we don't delete special calendars */
-        mboxname = caldav_mboxname(req->accountid, uid);
+        char *mboxname = caldav_mboxname(req->accountid, uid);
         mbname_t *mbname = mbname_from_intname(mboxname);
         if (!mbname || jmap_calendar_isspecial(mbname)) {
             json_t *err = json_pack("{s:s}", "type", "notFound");


### PR DESCRIPTION
We hard-coded not to the Cyrus-created 'Default' calendar. But neither the CalDAV clients nor the JMAP clients or spec require the Default calendar to exist. So let's get rid of that.