### PR TITLE
carddav: leniently accept whitespace in VCARD VERSION property

### DIFF
--- a/cunit/vparse.testc
+++ b/cunit/vparse.testc
@@ -38,6 +38,28 @@ static void test_wrap_onechar(void)
     // XXX test value
 }
 
+static void test_repair_version(void)
+{
+    char card[] = "BEGIN:VCARD\n"
+                  "VERSION: 3.0 \r\n"
+                  "UID:abc\n"
+                  "END:VCARD\r\n";
+
+    char wantbuf[] = "BEGIN:VCARD\r\n"
+                  "VERSION:3.0\r\n"
+                  "UID:abc\r\n"
+                  "END:VCARD\r\n";
+    struct vparse_state vparser;
+    memset(&vparser, 0, sizeof(struct vparse_state));
+    vparser.base = card;
+    int vr = vparse_parse(&vparser, 0);
+    CU_ASSERT_EQUAL(vr, 0);
+    struct buf *buf = buf_new(); \
+    vparse_tobuf(vparser.card, buf); \
+    CU_ASSERT_STRING_EQUAL(wantbuf, buf_cstring(buf)); \
+    vparse_free(&vparser);
+}
+
 static void test_control_chars(void)
 {
 #define TESTCASE(in, flag, wanterr) \


### PR DESCRIPTION
As seen in the wild: a VERSION property ` 3.0` (note that leading whitespace). This patch silently accepts this bogus value. It does not rewrite the property value. We could make it so if `carddav_repair_vcard` is enabled, but this option is not enabled currently and we should first agree on if this is dead code, actually.