### PR TITLE
vparse: unconditionally repair control characters in VCARD

### DIFF
--- a/cunit/vparse.testc
+++ b/cunit/vparse.testc
@@ -60,280 +60,258 @@ static void test_repair_version(void)
     vparse_free(&vparser);
 }
 
-static void test_control_chars(void)
+static void test_repair_control_chars(void)
 {
-#define TESTCASE(in, flag, wanterr) \
+#define TESTCASE(in, wanterr, wantout) \
     { \
         struct vparse_state vparser; \
         memset(&vparser, 0, sizeof(struct vparse_state)); \
         vparse_set_multival(&vparser, "adr", ';'); \
         vparser.base = (in); \
-        vparser.ctrl = flag; \
         int vr = vparse_parse(&vparser, 0); \
         CU_ASSERT_EQUAL(vr, (wanterr)); \
-        vparse_free(&vparser); \
-    }
-
-    char ctl_in_propname[] =
-        "BEGIN:VCARD\r\n"
-        "VERSION:3.0\r\n"
-        "N\bOTE:Weird control chars\r\n"
-        "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-
-    char ctl_in_propval1[] =
-        "BEGIN:VCARD\r\n"
-        "VERSION:3.0\r\n"
-        "NOTE:Weird control\b chars\r\n"
-        "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-
-    char ctl_in_propval2[] =
-        "BEGIN:VCARD\r\n"
-        "VERSION:3.0\r\n"
-        /* Newline forces parser to switch to property name state */
-        "NOTE:Weird control\n\bchars\r\n"
-        "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-
-    char ctl_in_propval3[] =
-        "BEGIN:VCARD\r\n"
-        "VERSION:3.0\r\n"
-        /* Multivalue field, separated by semicolon */
-        "ADR:;;123 Main Street;Any Town;CA;91921-1234;U.S.\x01\r\n"
-        "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-
-    char ctl_in_paraname[] =
-        "BEGIN:VCARD\r\n"
-        "VERSION:4.0\r\n"
-        "EMAIL;\x01TYPE\x03=work:foo@local\r\n"
-        "END:VCARD\r\n";
-
-    char ctl_in_paraval1[] =
-        "BEGIN:VCARD\r\n"
-        "VERSION:4.0\r\n"
-        "EMAIL;TYPE=w\x1bork:foo@local\r\n"
-        "END:VCARD\r\n";
-
-    char ctl_in_paraval2[] =
-        "BEGIN:VCARD\r\n"
-        "VERSION:4.0\r\n"
-        /* control char in quoted param value */
-        "EMAIL;TYPE=\"\x1bork\":foo@local\r\n"
-        "END:VCARD\r\n";
-
-    TESTCASE(ctl_in_propname, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR);
-    TESTCASE(ctl_in_propval1, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR);
-    TESTCASE(ctl_in_propval2, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR);
-    TESTCASE(ctl_in_propval3, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR);
-    TESTCASE(ctl_in_paraname, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR);
-    TESTCASE(ctl_in_paraval1, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR);
-    TESTCASE(ctl_in_paraval2, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR);
-
-    TESTCASE(ctl_in_propname, VPARSE_CTRL_SKIP, PE_OK);
-    TESTCASE(ctl_in_propval1, VPARSE_CTRL_SKIP, PE_OK);
-    TESTCASE(ctl_in_propval2, VPARSE_CTRL_SKIP, PE_NAME_EOL);
-    TESTCASE(ctl_in_propval3, VPARSE_CTRL_SKIP, PE_OK);
-    TESTCASE(ctl_in_paraname, VPARSE_CTRL_SKIP, PE_OK);
-    TESTCASE(ctl_in_paraval1, VPARSE_CTRL_SKIP, PE_OK);
-    TESTCASE(ctl_in_paraval2, VPARSE_CTRL_SKIP, PE_OK);
-
-#undef TESTCASE
-}
-
-static void test_crlf(void)
-{
-#define TESTCASE(in, wantctrl, wanterr, wantbuf) \
-    { \
-        struct vparse_state vparser; \
-        memset(&vparser, 0, sizeof(struct vparse_state)); \
-        vparse_set_multival(&vparser, "adr", ';'); \
-        vparser.base = (in); \
-        vparser.ctrl = (wantctrl); \
-        int vr = vparse_parse(&vparser, 0); \
-        CU_ASSERT_EQUAL(vr, (wanterr)); \
-        if (wantbuf != NULL) { \
+        if (wantout != NULL) { \
             struct buf *buf = buf_new(); \
             vparse_tobuf(vparser.card, buf); \
-            CU_ASSERT_STRING_EQUAL(wantbuf, buf_cstring(buf)); \
+            CU_ASSERT_STRING_EQUAL(wantout, buf_cstring(buf)); \
             buf_destroy(buf); \
         } \
         vparse_free(&vparser); \
     }
 
-    /* All lines end on CRLF */
-    char crlf[] =
+    struct testcase {
+        const char *in;
+        int wanterr;
+        const char *out;
+    } tests[] = {{
+        /* Control in property name */
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "N\bOTE:Weird control chars\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n",
+        PE_OK,
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "NOTE:Weird control chars\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n",
+    }, {
+        /* Control in property value */
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "NOTE:Weird control\b chars\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n",
+        PE_OK,
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "NOTE:Weird control chars\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n"
+    }, {
+        /* Newline forces parser to switch to property name state */
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "NOTE:Weird control\n\bchars\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n",
+        PE_NAME_EOL,
+        NULL
+    }, {
+        /* Multivalue field, separated by semicolon */
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "ADR:;;123 Main Street;Any Town;CA;91921-1234;U.S.\x01\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n",
+        PE_OK,
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "ADR:;;123 Main Street;Any Town;CA;91921-1234;U.S.\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n"
+    }, {
+        /* Control in parameter name */
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "EMAIL;\x01TYPE\x03=work:foo@local\r\n"
+        "END:VCARD\r\n",
+        PE_OK,
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "EMAIL;TYPE=work:foo@local\r\n"
+        "END:VCARD\r\n"
+    }, {
+        /* Control in parameter value */
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "EMAIL;TYPE=w\x1bork:foo@local\r\n"
+        "END:VCARD\r\n",
+        PE_OK,
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "EMAIL;TYPE=work:foo@local\r\n"
+        "END:VCARD\r\n"
+    }, {
+        /* Control char in quoted parameter value */
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FOO;BAR=\"x\x1b,y\":0\r\n"
+        "END:VCARD\r\n",
+        PE_OK,
+        "BEGIN:VCARD\r\n"
+        "VERSION:4.0\r\n"
+        "FOO;BAR=\"x,y\":0\r\n"
+        "END:VCARD\r\n",
+    }, {
+        /* End with CRLF */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:All lines end on CRLF\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    TESTCASE(crlf, VPARSE_CTRL_IGNORE, PE_OK, crlf);
-    TESTCASE(crlf, VPARSE_CTRL_SKIP, PE_OK, crlf);
-    TESTCASE(crlf, VPARSE_CTRL_REJECT, PE_OK, crlf);
-
-    /* All lines end on LF */
-    char lf_in[] =
+        "END:VCARD\r\n",
+        PE_OK,
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "NOTE:All lines end on CRLF\r\n"
+        "REV:2008-04-24T19:52:43Z\r\n"
+        "END:VCARD\r\n"
+    }, {
+        /* End with LF */
         "BEGIN:VCARD\n"
         "VERSION:3.0\n"
         "NOTE:All lines end on LF\n"
         "REV:2008-04-24T19:52:43Z\n"
-        "END:VCARD\n";
-    char lf_out[] =
+        "END:VCARD\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:All lines end on LF\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    TESTCASE(lf_in, VPARSE_CTRL_IGNORE, PE_OK, lf_out);
-    TESTCASE(lf_in, VPARSE_CTRL_SKIP, PE_OK, lf_out);
-    TESTCASE(lf_in, VPARSE_CTRL_REJECT, PE_OK, lf_out);
-
-
-    /* All lines end on CR */
-    /* This is all actually just one line */
-    char cr[] =
+        "END:VCARD\r\n"
+    }, {
+        /* End with CR */
         "BEGIN:VCARD\r"
         "VERSION:3.0\r"
         "NOTE:All lines end on CR\r"
         "REV:2008-04-24T19:52:43Z\r"
-        "END:VCARD\r";
-    TESTCASE(cr, VPARSE_CTRL_IGNORE, PE_FINISHED_EARLY, NULL);
-    TESTCASE(cr, VPARSE_CTRL_SKIP, PE_FINISHED_EARLY, NULL);
-    TESTCASE(cr, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR, NULL);
-
-    /* Some lines end on CRLF and some on LF */
-    char mixed_in[] =
+        "END:VCARD\r",
+        PE_FINISHED_EARLY,
+        NULL
+    }, {
+        /* End with either CR or CRLF */
         "BEGIN:VCARD\n"
         "VERSION:3.0\n"
         "NOTE:Some lines end on LF and some on CRLF\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\n";
-    char mixed_out[] =
+        "END:VCARD\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:Some lines end on LF and some on CRLF\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    TESTCASE(mixed_in, VPARSE_CTRL_IGNORE, PE_OK, mixed_out);
-    TESTCASE(mixed_in, VPARSE_CTRL_SKIP, PE_OK, mixed_out);
-    TESTCASE(mixed_in, VPARSE_CTRL_REJECT, PE_OK, mixed_out);
-
-    /* An extra CR before CRLF */
-    char extra_cr_in[] =
+        "END:VCARD\r\n"
+    }, {
+        /* Extra CR before CRLF */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:An extra CR before CRLF\r\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    char extra_cr_out[] =
+        "END:VCARD\r\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:An extra CR before CRLF\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    TESTCASE(extra_cr_in, VPARSE_CTRL_IGNORE, PE_OK, extra_cr_out);
-    TESTCASE(extra_cr_in, VPARSE_CTRL_SKIP, PE_OK, extra_cr_out);
-    TESTCASE(extra_cr_in, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR, NULL);
-
-    /* Two LF make one empty line */
-    char lflf_in[] =
+        "END:VCARD\r\n"
+    }, {
+        /* Two LF make one empty line */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:Two LF make one empty line\n\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    char lflf_out[] =
+        "END:VCARD\r\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:Two LF make one empty line\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    TESTCASE(lflf_in, VPARSE_CTRL_IGNORE, PE_OK, lflf_out);
-    TESTCASE(lflf_in, VPARSE_CTRL_SKIP, PE_OK, lflf_out);
-    TESTCASE(lflf_in, VPARSE_CTRL_REJECT, PE_OK, lflf_out);
-
-    /* One lonely CR in the middle of text */
-    /* Single-value */
-    char cr_val1[] =
+        "END:VCARD\r\n"
+    }, {
+        /* One lonely CR in the middle of text */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:One lonely \r in the middle of text\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    char cr_val1_skip[] =
+        "END:VCARD\r\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:One lonely  in the middle of text\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    /* Multi-value */
-    char cr_val2[] =
+        "END:VCARD\r\n"
+    }, {
+        /* One lonely CR in a multi-value property */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
-        "NOTE:One lonely CR in the middle of text\r\n"
         "ADR:;;123\r\\nMain Street;Any Town;CA;91921-1234;U.S.A\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    char cr_val2_skip[] =
+        "END:VCARD\r\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
-        "NOTE:One lonely CR in the middle of text\r\n"
         "ADR:;;123\\nMain Street;Any Town;CA;91921-1234;U.S.A\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    /* CR in key */
-    char cr_key[] =
+        "END:VCARD\r\n"
+    }, {
+        /* CR in key */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE\r:CR in key\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    char cr_key_skip[] =
+        "END:VCARD\r\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "NOTE:CR in key\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    /* CR in param name */
-    char cr_para1[] =
+        "END:VCARD\r\n"
+    }, {
+        /* CR in param name */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "EMAIL;TYPE\r=work:foo@local\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    char cr_para1_skip[] =
+        "END:VCARD\r\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "EMAIL;TYPE=work:foo@local\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    /* CR in param name */
-    char cr_para2[] =
+        "END:VCARD\r\n"
+    }, {
+        /* CR in param name */
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "EMAIL;TYPE=work\r:foo@local\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
-    char cr_para2_skip[] =
+        "END:VCARD\r\n",
+        PE_OK,
         "BEGIN:VCARD\r\n"
         "VERSION:3.0\r\n"
         "EMAIL;TYPE=work:foo@local\r\n"
         "REV:2008-04-24T19:52:43Z\r\n"
-        "END:VCARD\r\n";
+        "END:VCARD\r\n"
+    }, {
+        /* End of tests */
+        NULL, 0, NULL
+    }};
 
-    TESTCASE(cr_val1, VPARSE_CTRL_SKIP, PE_OK, cr_val1_skip);
-    TESTCASE(cr_val2, VPARSE_CTRL_SKIP, PE_OK, cr_val2_skip);
-    TESTCASE(cr_key, VPARSE_CTRL_SKIP, PE_OK, cr_key_skip);
-    TESTCASE(cr_para1, VPARSE_CTRL_SKIP, PE_OK, cr_para1_skip);
-    TESTCASE(cr_para2, VPARSE_CTRL_SKIP, PE_OK, cr_para2_skip);
-
-    TESTCASE(cr_val1, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR, NULL);
-    TESTCASE(cr_val2, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR, NULL);
-    TESTCASE(cr_key, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR, NULL);
-    TESTCASE(cr_para1, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR, NULL);
-    TESTCASE(cr_para2, VPARSE_CTRL_REJECT, PE_ILLEGAL_CHAR, NULL);
+    struct testcase *t;
+    for (t = tests; t->in; t++) {
+        TESTCASE(t->in, t->wanterr, t->out);
+    }
 
 #undef TESTCASE
 }
@@ -345,7 +323,7 @@ static void test_multiparam_type(void)
 {
 #define TESTCASE(card, wantbuf) \
     { \
-        struct vparse_card *vcard = vcard_parse_string(card, 0); \
+        struct vparse_card *vcard = vcard_parse_string(card); \
         CU_ASSERT_PTR_NOT_NULL(vcard); \
         struct buf *buf = vcard_as_buf(vcard); \
         CU_ASSERT_STRING_EQUAL(wantbuf, buf_cstring(buf)); \

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1470,7 +1470,7 @@ static int propfind_addrdata(const xmlChar *name, xmlNsPtr ns,
             /* Limit returned properties */
             struct vparse_card *vcard = fctx->obj;
 
-            if (!vcard) vcard = fctx->obj = vcard_parse_string(data, 1);
+            if (!vcard) vcard = fctx->obj = vcard_parse_string(data);
             prune_properties(vcard->objects, partial);
 
             /* Create vCard data from new vcard component */
@@ -1755,7 +1755,7 @@ static int apply_propfilter(struct prop_filter *propfilter,
             if (fctx->msg_buf.len) {
                 vcard = fctx->obj =
                     vcard_parse_string(buf_cstring(&fctx->msg_buf) +
-                                       fctx->record->header_size, 1);
+                                       fctx->record->header_size);
             }
             if (!vcard) return 0;
         }

--- a/imap/index.c
+++ b/imap/index.c
@@ -5210,7 +5210,7 @@ static int extract_vcardbuf(struct buf *raw, charset_t charset, int encoding,
         vcardbuf = raw;
     }
 
-    vcard = vcard_parse_string(buf_cstring(vcardbuf), /*repair*/1);
+    vcard = vcard_parse_string(buf_cstring(vcardbuf));
     if (!vcard || !vcard->objects) {
         r = IMAP_INTERNAL;
         goto done;

--- a/imap/vcard_support.c
+++ b/imap/vcard_support.c
@@ -48,7 +48,7 @@
 
 #include "global.h"
 
-EXPORTED struct vparse_card *vcard_parse_string(const char *str, int repair)
+EXPORTED struct vparse_card *vcard_parse_string(const char *str)
 {
     struct vparse_state vparser;
     struct vparse_card *vcard = NULL;
@@ -63,7 +63,6 @@ EXPORTED struct vparse_card *vcard_parse_string(const char *str, int repair)
     vparse_set_multival(&vparser, "nickname", ',');
     vparse_set_multival(&vparser, "categories", ',');
     vparse_set_multiparam(&vparser, "type");
-    vparser.ctrl = repair ? VPARSE_CTRL_SKIP : VPARSE_CTRL_REJECT;
     vr = vparse_parse(&vparser, 0);
     if (vr) {
         struct vparse_errorpos pos;
@@ -100,8 +99,7 @@ EXPORTED struct vparse_card *vcard_parse_string(const char *str, int repair)
 
 EXPORTED struct vparse_card *vcard_parse_buf(const struct buf *buf)
 {
-    int repair = config_getswitch(IMAPOPT_CARDDAV_REPAIR_VCARD);
-    return vcard_parse_string(buf_cstring(buf), repair);
+    return vcard_parse_string(buf_cstring(buf));
 }
 
 EXPORTED struct buf *vcard_as_buf(struct vparse_card *vcard)
@@ -121,7 +119,7 @@ EXPORTED struct vparse_card *record_to_vcard(struct mailbox *mailbox,
 
     /* Load message containing the resource and parse vcard data */
     if (!mailbox_map_record(mailbox, record, &buf)) {
-        vcard = vcard_parse_string(buf_cstring(&buf) + record->header_size, 1);
+        vcard = vcard_parse_string(buf_cstring(&buf) + record->header_size);
         buf_free(&buf);
     }
 

--- a/imap/vcard_support.h
+++ b/imap/vcard_support.h
@@ -52,7 +52,7 @@
 #include "message_guid.h"
 #include "util.h"
 
-extern struct vparse_card *vcard_parse_string(const char *str, int repair);
+extern struct vparse_card *vcard_parse_string(const char *str);
 extern struct vparse_card *vcard_parse_buf(const struct buf *buf);
 extern struct buf *vcard_as_buf(struct vparse_card *vcard);
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -636,7 +636,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    If not set (the default), the value of the "servername" option will
    be used.*/
 
-{ "carddav_repair_vcard", 0, SWITCH, "3.0.0" }
+{ "carddav_repair_vcard", 0, SWITCH, "3.0.0", "3.3.1" }
 /* If enabled, VCARDs with invalid content are attempted to be repaired
    during creation. */
 

--- a/lib/vparse.c
+++ b/lib/vparse.c
@@ -27,24 +27,12 @@ static char *buf_dup_cstring(struct buf *buf)
     (ch > 0 && ch <= 0x1f && ch != '\r' && ch != '\n' && ch != '\t')
 #define HANDLECTRL(state) \
 { \
-    if (state->ctrl != VPARSE_CTRL_IGNORE && IS_CTRL(*state->p)) { \
-        if (state->ctrl == VPARSE_CTRL_REJECT) \
-            return PE_ILLEGAL_CHAR; \
+    if (IS_CTRL(*state->p)) { \
         while (IS_CTRL(*state->p)) \
             state->p++; \
     } \
     if ((*state->p) == 0) \
         break; \
-}
-
-#define HANDLEBACKR(state) \
-{ \
-    if (state->p[1] != '\n') { \
-        if (state->ctrl == VPARSE_CTRL_REJECT) \
-            return PE_ILLEGAL_CHAR; \
-        if (state->ctrl == VPARSE_CTRL_IGNORE) \
-            PUTC('\r'); \
-    } \
 }
 
 /* just leaves it on the buffer */
@@ -110,7 +98,6 @@ static int _parse_param_quoted(struct vparse_state *state, int multiparam)
             break;
 
         case '\r':
-            HANDLEBACKR(state);
             INC(1);
             break; /* just skip */
         case '\n':
@@ -164,7 +151,6 @@ static int _parse_param_key(struct vparse_state *state, int *haseq)
             return 0;
 
         case '\r':
-            HANDLEBACKR(state);
             INC(1);
             break; /* just skip */
         case '\n':
@@ -290,7 +276,6 @@ repeat:
             goto repeat;
 
         case '\r':
-            HANDLEBACKR(state);
             INC(1);
             break; /* just skip */
         case '\n':
@@ -352,7 +337,6 @@ static int _parse_entry_key(struct vparse_state *state)
             break;
 
         case '\r':
-            HANDLEBACKR(state);
             INC(1);
             break; /* just skip */
         case '\n':
@@ -406,7 +390,6 @@ static int _parse_entry_multivalue(struct vparse_state *state, char splitchar)
             break;
 
         case '\r':
-            HANDLEBACKR(state);
             INC(1);
             break; /* just skip */
         case '\n':
@@ -472,7 +455,6 @@ static int _parse_entry_value(struct vparse_state *state)
             break;
 
         case '\r':
-            HANDLEBACKR(state);
             INC(1);
             break; /* just skip */
         case '\n':

--- a/lib/vparse.h
+++ b/lib/vparse.h
@@ -25,12 +25,6 @@ PE_ILLEGAL_CHAR,
 PE_NUMERR /* last */
 };
 
-enum parse_ctrl {
-    VPARSE_CTRL_IGNORE = 0,
-    VPARSE_CTRL_SKIP,
-    VPARSE_CTRL_REJECT
-};
-
 struct vparse_state {
     struct buf buf;
     const char *base;
@@ -40,7 +34,6 @@ struct vparse_state {
     strarray_t *multivalcomma;
     strarray_t *multiparam;
     int barekeys;
-    int ctrl;
 
     /* current items */
     struct vparse_card *card;


### PR DESCRIPTION
We introduced VCARD reparation about 3 years as optional, but today decided to make Cyrus unconditionally repair bogus input in VCARD (as far as we can). This patch updates the VCARD parser to leniently skip control characters in VCARD input.

The unit tests have been updated to reflect this change. For a list of test cases see https://github.com/cyrusimap/cyrus-imapd/blob/d69a61c946f2d8c719061a12bbed5929c2d69cd6/cunit/vparse.testc#L63