### PR TITLE
imapd.c: Added FLAGS+ FETCH item to include Cyrus internal flags

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5010,6 +5010,9 @@ badannotation:
             else if (!inlist && !strcmp(fetchatt.s, "FULL")) {
                 fa->fetchitems |= FETCH_FULL;
             }
+            else if (!strcmp(fetchatt.s, "FLAGS+")) {
+                fa->fetchitems |= FETCH_FLAGS | FETCH_INTERNALFLAGS;
+            }
             else if (!strcmp(fetchatt.s, "FLAGS")) {
                 fa->fetchitems |= FETCH_FLAGS;
             }

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -141,6 +141,7 @@ enum {
     FETCH_MAILBOXES =           (1<<27),
     FETCH_PREVIEW =             (1<<28),
     FETCH_LASTUPDATED =         (1<<29),
+    FETCH_INTERNALFLAGS =       (1<<30),
 
     /* XXX fetchitems is an int, we're running low on bits */
 };

--- a/imap/index.c
+++ b/imap/index.c
@@ -142,7 +142,8 @@ static void index_fetchcacheheader(struct index_state *state, struct index_recor
                                    const strarray_t *headers, unsigned start_octet,
                                    unsigned octet_count);
 static void index_listflags(struct index_state *state);
-static void index_fetchflags(struct index_state *state, uint32_t msgno);
+static void index_fetchflags(struct index_state *state, uint32_t msgno,
+                             int include_internal);
 
 static int index_copysetup(struct index_state *state, uint32_t msgno,
                            struct copyargs *copyargs);
@@ -4000,7 +4001,7 @@ static int index_fetchmailboxids(struct index_state *state,
  * Also sends preceeding * FLAGS if necessary.
  */
 static void index_fetchflags(struct index_state *state,
-                             uint32_t msgno)
+                             uint32_t msgno, int include_internal)
 {
     int sepchar = '(';
     unsigned flag;
@@ -4029,7 +4030,18 @@ static void index_fetchflags(struct index_state *state,
         prot_printf(state->out, "%c\\Deleted", sepchar);
         sepchar = ' ';
     }
-    if (state->want_expunged && (im->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
+    if (include_internal) {
+        if (im->internal_flags & FLAG_INTERNAL_EXPUNGED) {
+            prot_printf(state->out, "%c\\Expunged", sepchar);
+            sepchar = ' ';
+        }
+        if (im->internal_flags & FLAG_INTERNAL_SNOOZED) {
+            prot_printf(state->out, "%c\\Snoozed", sepchar);
+            sepchar = ' ';
+        }
+    }
+    else if (state->want_expunged &&
+             (im->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
         prot_printf(state->out, "%c\\Expunged", sepchar);
         sepchar = ' ';
     }
@@ -4057,7 +4069,7 @@ static void index_printflags(struct index_state *state,
 {
     struct index_map *im = &state->map[msgno-1];
 
-    index_fetchflags(state, msgno);
+    index_fetchflags(state, msgno, /*include_internal*/0);
     /* http://www.rfc-editor.org/errata_search.php?rfc=5162
      * Errata ID: 1807 - MUST send UID and MODSEQ to all
      * untagged FETCH unsolicited responses */
@@ -4144,9 +4156,13 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
     }
     int ischanged = im->told_modseq < record.modseq;
 
+    if (fetchitems & FETCH_INTERNALFLAGS) {
+        index_fetchflags(state, msgno, /*include_internal*/1);
+        sepchar = ' ';
+    }
     /* display flags if asked _OR_ if they've changed */
-    if (fetchitems & FETCH_FLAGS || ischanged) {
-        index_fetchflags(state, msgno);
+    else if (fetchitems & FETCH_FLAGS || ischanged) {
+        index_fetchflags(state, msgno, /*include_internal*/0);
         sepchar = ' ';
     }
     else if ((fetchitems & ~FETCH_SETSEEN) || fetchargs->fsections ||


### PR DESCRIPTION
This PR along with the following patch would've caught the "not replicating \Snoozed flag" bug a lot sooner:

diff --git a/Cyrus/CheckReplication.pm b/Cyrus/CheckReplication.pm
index 038215f..7ec6420 100755
--- a/Cyrus/CheckReplication.pm
+++ b/Cyrus/CheckReplication.pm
@@ -321,8 +321,8 @@ sub CheckFolderFlags {
   my $Repeat = 0;
   RepeatCheck:
 
-  my $s1Flags = $Self->do_fetch($IMAPs1, $CyrusName, 'flags') || return;
-  my $s2Flags = $Self->do_fetch($IMAPs2, $CyrusName, 'flags') || return;
+  my $s1Flags = $Self->do_fetch($IMAPs1, $CyrusName, 'flags+') || return;
+  my $s2Flags = $Self->do_fetch($IMAPs2, $CyrusName, 'flags+') || return;
 
   my %ids = (%$s1Flags, %$s2Flags);