### PR TITLE
Sync rename delete safety

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -746,9 +746,9 @@ static int do_delete(struct cyr_expire_ctx *ctx)
 
         if (ctx->args.userid)
             mboxlist_usermboxtree(ctx->args.userid, NULL, delete,
-                                  &ctx->drock, MBOXTREE_DELETED);
+                                  &ctx->drock, MBOXTREE_DELETED|MBOXTREE_INTERMEDIATES);
         else
-            mboxlist_allmbox(ctx->args.mbox_prefix, delete, &ctx->drock, 0);
+            mboxlist_allmbox(ctx->args.mbox_prefix, delete, &ctx->drock, MBOXTREE_INTERMEDIATES);
 
         for (i = 0 ; i < ctx->drock.to_delete.count ; i++) {
             char *name = ctx->drock.to_delete.data[i];

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -758,7 +758,7 @@ static int do_delete(struct cyr_expire_ctx *ctx)
 
             verbosep("Removing: %s\n", name);
 
-            ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL, 0, 0, 0, 0);
+            ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL, 0, 0, 0, 1);
             /* XXX: Ignoring the return from mboxlist_deletemailbox() ??? */
             count++;
         }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7380,18 +7380,18 @@ static int delmbox(const mbentry_t *mbentry, void *rock __attribute__((unused)))
         r = mboxlist_deletemailbox(mbentry->name,
                                    imapd_userisadmin || imapd_userisproxyadmin,
                                    imapd_userid, imapd_authstate, NULL,
-                                   0, 0, 0, 0);
+                                   0, 0, 0, 1);
     } else if ((imapd_userisadmin || imapd_userisproxyadmin) &&
                mboxname_isdeletedmailbox(mbentry->name, NULL)) {
         r = mboxlist_deletemailbox(mbentry->name,
                                    imapd_userisadmin || imapd_userisproxyadmin,
                                    imapd_userid, imapd_authstate, NULL,
-                                   0, 0, 0, 0);
+                                   0, 0, 0, 1);
     } else {
         r = mboxlist_delayed_deletemailbox(mbentry->name,
                                            imapd_userisadmin || imapd_userisproxyadmin,
                                            imapd_userid, imapd_authstate, NULL,
-                                           0, 0, 0, 0);
+                                           0, 0, 0, 1);
     }
 
     if (r) {
@@ -7507,7 +7507,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
     if (!r && !localonly && delete_user) {
         const char *userid = mbname_userid(mbname);
         if (userid) {
-            r = mboxlist_usermboxtree(userid, NULL, delmbox, NULL, 0);
+            r = mboxlist_usermboxtree(userid, NULL, delmbox, NULL, MBOXTREE_INTERMEDIATES);
             if (!r) r = user_deletedata(userid, 1);
         }
     }
@@ -8011,12 +8011,11 @@ submboxes:
 
     /* take care of deleting old ACLs, subscriptions, seen state and quotas */
     if (!r && rename_user) {
+        /* user_deletedata takes care of logging the unuser */
         user_deletedata(olduser, 1);
         /* allow the replica to get the correct new quotaroot
          * and acls copied across */
         sync_log_user(newuser);
-        /* allow the replica to clean up the old meta files */
-        sync_log_unuser(olduser);
     }
 
     /* take care of intermediaries */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1716,12 +1716,12 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
         if (r) goto done;
     }
 
-    r = mboxlist_lookup(name, &mbentry, NULL);
+    r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
     if (r) goto done;
 
     /* check if user has Delete right (we've already excluded non-admins
      * from deleting a user mailbox) */
-    if (checkacl) {
+    if (checkacl && !(mbentry->mbtype & MBTYPE_INTERMEDIATE)) {
         myrights = cyrus_acl_myrights(auth_state, mbentry->acl);
         if (!(myrights & ACL_DELETEMBOX)) {
             /* User has admin rights over their own mailbox namespace */
@@ -1829,6 +1829,19 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
 
     r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
     if (r) goto done;
+
+    if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
+        // make it deleted and mark it done!
+        mbentry_t *newmbentry = mboxlist_entry_copy(mbentry);
+        newmbentry->mbtype = MBTYPE_DELETED;
+        if (!silent) {
+            newmbentry->foldermodseq = mboxname_nextmodseq(newmbentry->name, newmbentry->foldermodseq,
+                                                           newmbentry->mbtype, 1);
+        }
+        r = mboxlist_update(newmbentry, /*localonly*/1);
+        mboxlist_entry_free(&newmbentry);
+        goto done;
+    }
 
     isremote = mbentry->mbtype & MBTYPE_REMOTE;
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1183,8 +1183,8 @@ EXPORTED int mboxlist_update_intermediaries(const char *frommboxname,
     mbname_t *mbname = mbname_from_intname(frommboxname);
     int r = 0;
 
-    /* only use intermediates for non-deleted user mailboxes */
-    if (mbname_isdeleted(mbname) || !mbname_userid(mbname))
+    /* only use intermediates for user mailboxes */
+    if (!mbname_userid(mbname))
         goto out;
 
     for (; strarray_size(mbname_boxes(mbname)); free(mbname_pop_boxes(mbname))) {

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3681,7 +3681,7 @@ int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
     }
 
     strarray_truncate(list, 0);
-    r = mboxlist_usermboxtree(userid, NULL, addmbox_cb, list, MBOXTREE_DELETED);
+    r = mboxlist_usermboxtree(userid, NULL, addmbox_cb, list, 0);
     if (r) goto done;
 
     /* delete in reverse so INBOX is last */

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -220,7 +220,18 @@ static const char *_synclock_name(const char *hostname, const char *userid)
     if (!userid) userid = ""; // no userid == global lock
 
     buf_setcstr(&buf, "*S*");
-    if (hostname) buf_appendcstr(&buf, hostname);
+
+    for (p = hostname; *p; p++) {
+        switch(*p) {
+            case '.':
+                buf_putc(&buf, '^');
+                break;
+            default:
+                buf_putc(&buf, *p);
+                break;
+        }
+    }
+
     buf_putc(&buf, '*');
 
     for (p = userid; *p; p++) {

--- a/imap/user.c
+++ b/imap/user.c
@@ -79,6 +79,7 @@
 #include "quota.h"
 #include "search_engines.h"
 #include "seen.h"
+#include "sync_log.h"
 #include "user.h"
 #include "util.h"
 #include "xmalloc.h"
@@ -241,6 +242,9 @@ EXPORTED int user_deletedata(const char *userid, int wipe_user)
 #endif /* WITH_DAV */
 
     proc_killuser(userid);
+
+    // make sure it gets removed everywhere else
+    sync_log_unuser(userid);
 
     return 0;
 }


### PR DESCRIPTION
Hi Ken,

This is an exciting one!  It comes from all the bits that odd_mailboxes.pl and audit_slot.pl are finding still broken on our servers.

It fixes UNUSER to not wipe the DELETED mailboxes, then switches all deletes to all UNUSER so the meta files are cleaned up right.  It also fixes intermediate handling on deletion, due to me adding tests for all that in: https://github.com/cyrusimap/cassandane/pull/90

Hoping to run this in anger tomorrow :)

Cheers,

Bron.

