### PR TITLE
conversations: make subject normalisation regex not require PCRE

### DIFF
--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -1361,6 +1361,8 @@ static void test_subject_normalise(void)
              "foobar");
     TESTCASE("unmatched left] foobar [unmatched=[matched]",
              "foobar");
+    TESTCASE("no re: foobar", "nore:foobar");
+    TESTCASE("re: no re: foobar", "nore:foobar");
 }
 
 #undef TESTCASE

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -709,9 +709,9 @@ EXPORTED void conversation_normalise_subject(struct buf *s)
     if (!initialised_res) {
         r = regcomp(&whitespace_re, "([ \t\r\n]+|\xC2\xA0)", REG_EXTENDED);
         assert(r == 0);
-        r = regcomp(&bracket_re, "(\\[[^\\[\\]]*\\])|(^[^\\[]*\\])|(\\[[^\\]]*$)", REG_EXTENDED);
+        r = regcomp(&bracket_re, "(\\[[^]\\[]*])|(^[^\\[]*])|(\\[[^]]*$)", REG_EXTENDED);
         assert(r == 0);
-        r = regcomp(&relike_token_re, "^[ \\t]*[^\\s]+:", REG_EXTENDED);
+        r = regcomp(&relike_token_re, "^[ \\t]*[^ \\t\\r\\n\\f]+:", REG_EXTENDED);
         assert(r == 0);
         initialised_res = 1;
     }


### PR DESCRIPTION
We reworked conversation subject normalisation recently (4c643deb98e5cbcf47371eb1ee0ab74dbc4ba987) but the new regex did not work for builds with `--disable-pcre`. This patch rewrites the regex to be POSIX-compliant.