### PR TITLE
Refactor guidsearch to postprocess non-Xapian filter criteria

### DIFF
--- a/cunit/bitvector.testc
+++ b/cunit/bitvector.testc
@@ -29,46 +29,46 @@ static void test_basic(void)
     /* can set bit0 and get it back */
     bv_set(&bv, 0);
     CU_ASSERT_EQUAL(1, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 0));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 7));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 23));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 104));
     CU_ASSERT_EQUAL(1, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
 
     /* can set bit23 and get it back */
     bv_set(&bv, 23);
     CU_ASSERT_EQUAL(24, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 0));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 7));
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 23));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 104));
     CU_ASSERT_EQUAL(24, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
 
     /* can set all bits, does not change length */
     bv_setall(&bv);
     CU_ASSERT_EQUAL(24, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 0));
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 7));
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 23));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 104));
     CU_ASSERT_EQUAL(24, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
 
     /* can clear all bits, does not change length */
     bv_clearall(&bv);
     CU_ASSERT_EQUAL(24, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 0));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 7));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 23));
     CU_ASSERT_EQUAL(0, bv_isset(&bv, 104));
     CU_ASSERT_EQUAL(24, bv.length);
-    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv.alloc);
 
     /* can set the size, does not change existing bits */
     bv_set(&bv, 0);
@@ -83,6 +83,20 @@ static void test_basic(void)
     CU_ASSERT_EQUAL(105, bv.length);
     CU_ASSERT_NOT_EQUAL(0, bv.alloc);
 
+    /* bits are now heap-allocated */
+
+    /* can set bit63 and get it back */
+    bv_set(&bv, 63);
+    CU_ASSERT_EQUAL(105, bv.length);
+    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(1, bv_isset(&bv, 0));
+    CU_ASSERT_EQUAL(0, bv_isset(&bv, 7));
+    CU_ASSERT_EQUAL(1, bv_isset(&bv, 23));
+    CU_ASSERT_EQUAL(1, bv_isset(&bv, 63));
+    CU_ASSERT_EQUAL(0, bv_isset(&bv, 104));
+    CU_ASSERT_EQUAL(105, bv.length);
+    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+
     /* setall now works on the new size */
     bv_setall(&bv);
     CU_ASSERT_EQUAL(105, bv.length);
@@ -91,6 +105,28 @@ static void test_basic(void)
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 7));
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 23));
     CU_ASSERT_EQUAL(1, bv_isset(&bv, 104));
+    CU_ASSERT_EQUAL(105, bv.length);
+    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+
+    /* can set all bits, does not change length */
+    bv_setall(&bv);
+    CU_ASSERT_EQUAL(105, bv.length);
+    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(1, bv_isset(&bv, 0));
+    CU_ASSERT_EQUAL(1, bv_isset(&bv, 7));
+    CU_ASSERT_EQUAL(1, bv_isset(&bv, 23));
+    CU_ASSERT_EQUAL(1, bv_isset(&bv, 104));
+    CU_ASSERT_EQUAL(105, bv.length);
+    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+
+    /* can clear all bits, does not change length */
+    bv_clearall(&bv);
+    CU_ASSERT_EQUAL(105, bv.length);
+    CU_ASSERT_NOT_EQUAL(0, bv.alloc);
+    CU_ASSERT_EQUAL(0, bv_isset(&bv, 0));
+    CU_ASSERT_EQUAL(0, bv_isset(&bv, 7));
+    CU_ASSERT_EQUAL(0, bv_isset(&bv, 23));
+    CU_ASSERT_EQUAL(0, bv_isset(&bv, 104));
     CU_ASSERT_EQUAL(105, bv.length);
     CU_ASSERT_NOT_EQUAL(0, bv.alloc);
 

--- a/lib/bitvector.h
+++ b/lib/bitvector.h
@@ -49,16 +49,21 @@
 
 typedef struct bitvector bitvector_t;
 
+#define BV_NOALLOCSIZE 8
+
 struct bitvector
 {
     unsigned int length;
     unsigned int alloc;
     /* TODO: should use natural word size, uint32_t or uint64_t,
      * for faster searching in bv_next_set() */
-    unsigned char *bits;
+    union {
+        unsigned char *alloced;
+        unsigned char _noalloc[BV_NOALLOCSIZE];
+    } bits;
 };
 
-#define BV_INITIALIZER  { 0, 0, NULL }
+#define BV_INITIALIZER  { 0, 0, {0} }
 
 extern void bv_init(bitvector_t *);
 extern void bv_setsize(bitvector_t *, unsigned int i);


### PR DESCRIPTION
This PR fixes a bug in guidsearch using twoskip as a backend for conversations.db. If one of the xxxInThreadKeywords filter criteria was used, then the original code loaded conversation records from within the callback of guid_foreach. This worked fine for skiplist, but messed up the database-internal iterator state for twoskip.

The patch refactors guidsearch to first obtain all results from Xapian by use of the guid_foreach callback. Only after that, it reduces the result set by evaluating non-Xapian filter expression. This fixes the issue of interleaved conversation.db calls. However, where the original code could reuse one instance of a guidsearch_msg, the patched code now has to maintain a guidsearch_msg for each G record returned by Xapian.

To not get penalized for probably thousands of malloc() calls, the code:

- Allocates at once enough memory for all guidsearch_msg entries
- Applies all filtering and collapsing in-place
- Refactors bitvector_t to not heap-allocate memory if the highest bit value is less than 64. For inMailbox and inMailboxOtherThan filter criteria, this allows to not allocate memory if the inspected account does not have more than 64 mailboxes. An initial analysis showed this to be a reasonable amount, but we can still change that.

Furtehr, the guidsearch code was reorganized to help with future maintenance.