### PR TITLE
squatter: add -L option to reindex messages by minimum index level

### DIFF
--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -205,6 +205,7 @@ static int flush_batch(search_text_receiver_t *rx,
 
 EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
                                    struct mailbox *mailbox,
+                                   int min_indexlevel,
                                    int flags)
 {
     int r = 0;                  /* Using IMAP_* not SQUAT_* return codes here */
@@ -237,7 +238,9 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
         message_t *msg = message_new_from_record(mailbox, record);
 
         uint8_t indexlevel = rx->is_indexed(rx, msg);
-        if (reindex_partials && (indexlevel & SEARCH_INDEXLEVEL_PARTIAL)) {
+        if ((reindex_partials && (indexlevel & SEARCH_INDEXLEVEL_PARTIAL)) ||
+            (min_indexlevel && indexlevel < min_indexlevel)) {
+            /* Reindex that message */
             indexlevel = 0;
         }
 

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -129,8 +129,9 @@ struct search_text_receiver {
     void (*end_part)(search_text_receiver_t *, int part);
 #define SEARCH_INDEXLEVEL_BASIC 1
 #define SEARCH_INDEXLEVEL_ATTACH 3
-#define SEARCH_INDEXLEVEL_BEST SEARCH_INDEXLEVEL_ATTACH /* must be <= 127 */
 #define SEARCH_INDEXLEVEL_PARTIAL 0x80 /*  high bit indicates a partial */
+#define SEARCH_INDEXLEVEL_BEST SEARCH_INDEXLEVEL_ATTACH
+#define SEARCH_INDEXLEVEL_MAX (SEARCH_INDEXLEVEL_PARTIAL - 1)
     int (*end_message)(search_text_receiver_t *, uint8_t indexlevel);
     int (*end_mailbox)(search_text_receiver_t *, struct mailbox *);
     int (*flush)(search_text_receiver_t *);
@@ -206,7 +207,7 @@ extern void search_end_search(search_builder_t *);
 search_text_receiver_t *search_begin_update(int verbose);
 int search_update_mailbox(search_text_receiver_t *rx,
                           struct mailbox *mailbox,
-                          int flags);
+                          int min_indexlevel, int flags);
 int search_end_update(search_text_receiver_t *rx);
 
 /* Create a search text receiver for snippets. For each non-empty


### PR DESCRIPTION
Currently, a message has index level 3 if an extractor url is configured (regardless if that message actually contains attachments). If no extractor url is configured, then Cyrus falls back to using the legacy index level 1 for that message, meaning: "We don't know if that message contains attachments with text". As a consequence, installations may have databases with mixed index levels 1 and 3 if they turned the extractor url config on and off over time.

The new -L argument for squatter allows to reindex all messages that are below a certain index level. As it currently stands, it only makes sense to pass -L 3 to force reindexing messages that have indexlevel 1.

As an exception, this patch does not have a corresponding Cassandane test. There's too many dependencies and assumptions to make (Search::Xapian, install path of xapian binaries, etc.) to make this worthwhile. I tested it manually.

