### PR TITLE
JMAP: bump modseq of alive JMAP emails in Mailbox/destroy

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -454,7 +454,7 @@ static void commitstatus_cb(const char *key, void *data, void *rock)
     conversation_storestatus(state, key, strlen(key), status);
     /* just in case convdb has a higher modseq for any reason (aka deleted and
      * recreated while a replica was still valid with the old user) */
-    mboxname_setmodseq(key+1, status->threadmodseq, /*mbtype */0, /*dofolder*/0);
+    mboxname_setmodseq(key+1, status->threadmodseq, /*mbtype */0, /*flags*/0);
     sync_log_mailbox(key+1); /* skip the leading F */
 }
 

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -804,8 +804,8 @@ static int jmap_backup_restore_contacts(jmap_req_t *req)
     else {
         r = mboxlist_mboxtree(addrhomeset, restore_addressbook_cb,
                               &rrock, MBOXTREE_SKIP_ROOT);
-        if (!r) mboxname_setdeletedmodseq(addrhomeset, rrock.deletedmodseq,
-                                          MBTYPE_ADDRESSBOOK, 0);
+        if (!r) mboxname_setmodseq(addrhomeset, rrock.deletedmodseq,
+                                   MBTYPE_ADDRESSBOOK, MBOXMODSEQ_ISDELETE);
     }
     free(addrhomeset);
     carddav_close(crock.carddavdb);
@@ -1257,8 +1257,8 @@ static int jmap_backup_restore_calendars(jmap_req_t *req)
     r = mboxlist_mboxtree(calhomeset, restore_calendar_cb, &rrock,
                           MBOXTREE_SKIP_ROOT | MBOXTREE_DELETED);
     if (!(r || (restore.mode & DRY_RUN))) {
-        mboxname_setdeletedmodseq(calhomeset,
-                                  rrock.deletedmodseq, MBTYPE_CALENDAR, 0);
+        mboxname_setmodseq(calhomeset, rrock.deletedmodseq,
+                           MBTYPE_CALENDAR, MBOXMODSEQ_ISDELETE);
     }
     free(calhomeset);
     free(crock.inboxname);
@@ -1346,8 +1346,8 @@ static int jmap_backup_restore_notes(jmap_req_t *req)
         r = mboxlist_mboxtree(notes, restore_collection_cb,
                               &rrock, MBOXTREE_SKIP_CHILDREN);
         if (!(r || (restore.mode & DRY_RUN))) {
-            mboxname_setdeletedmodseq(notes,
-                                      rrock.deletedmodseq, MBTYPE_EMAIL, 0);
+            mboxname_setmodseq(notes, rrock.deletedmodseq,
+                               MBTYPE_EMAIL, MBOXMODSEQ_ISDELETE);
         }
         free(notes);
     }
@@ -1906,8 +1906,8 @@ static int jmap_backup_restore_mail(jmap_req_t *req)
         hash_enumerate(&mailboxes, &restore_mailbox_cb, &rrock);
 
         if (!(restore.mode & DRY_RUN)) {
-            mboxname_setdeletedmodseq(inbox,
-                                      rrock.deletedmodseq, MBTYPE_EMAIL, 0);
+            mboxname_setmodseq(inbox, rrock.deletedmodseq,
+                               MBTYPE_EMAIL, MBOXMODSEQ_ISDELETE);
         }
     }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1077,7 +1077,7 @@ EXPORTED modseq_t mailbox_modseq_dirty(struct mailbox *mailbox)
     if (!mailbox->modseq_dirty) {
         mailbox->i.highestmodseq = mboxname_setmodseq(mailbox->name,
                                    mailbox->i.highestmodseq,
-                                   mailbox->mbtype, /*dofolder*/0);
+                                   mailbox->mbtype, /*flags*/0);
         mailbox->last_updated = time(0);
         mailbox->modseq_dirty = 1;
         mailbox_index_dirty(mailbox);
@@ -2707,7 +2707,7 @@ EXPORTED int mailbox_commit(struct mailbox *mailbox)
 
     mboxname_setmodseq(mailbox->name,
                        mailbox->i.highestmodseq,
-                       mailbox->mbtype, /*dofolder*/0);
+                       mailbox->mbtype, /*flags*/0);
 
     assert(mailbox_index_islocked(mailbox, 1));
 
@@ -4643,8 +4643,8 @@ done:
 
         r = mailbox_repack_commit(&repack);
         if (!r) {
-            mboxname_setdeletedmodseq(mailbox->name,
-                                      deletedmodseq, mailbox->mbtype, 0);
+            mboxname_setmodseq(mailbox->name, deletedmodseq, mailbox->mbtype,
+                               MBOXMODSEQ_ISDELETE);
         }
     }       
 
@@ -5187,9 +5187,11 @@ EXPORTED int mailbox_create(const char *name,
 
     /* and highest modseq */
     if (!highestmodseq)
-        highestmodseq = mboxname_nextmodseq(mailbox->name, 0, mbtype, /*dofolder*/1);
+        highestmodseq = mboxname_nextmodseq(mailbox->name, 0, mbtype,
+                                            MBOXMODSEQ_ISFOLDER);
     else
-        mboxname_setmodseq(mailbox->name, highestmodseq, mbtype, /*dofolder*/1);
+        mboxname_setmodseq(mailbox->name, highestmodseq, mbtype,
+                           MBOXMODSEQ_ISFOLDER);
 
     /* and created modseq */
     if (!createdmodseq || createdmodseq > highestmodseq)
@@ -6554,7 +6556,7 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
         mailbox_index_dirty(mailbox);
         mailbox->i.highestmodseq = mboxname_setmodseq(mailbox->name,
                                                       record->modseq,
-                                                      mailbox->mbtype, /*dofolder*/0);
+                                                      mailbox->mbtype, /*flags*/0);
     }
 
     if (record->uid > mailbox->i.last_uid) {
@@ -7196,7 +7198,8 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags)
     if (!mailbox->i.highestmodseq) {
         if (make_changes) {
             mailbox_index_dirty(mailbox);
-            mailbox->i.highestmodseq = mboxname_nextmodseq(mailbox->name, 0, mailbox->mbtype, /*dofolder*/1);
+            mailbox->i.highestmodseq = mboxname_nextmodseq(mailbox->name, 0, mailbox->mbtype,
+                                                           MBOXMODSEQ_ISFOLDER);
         }
         syslog(LOG_ERR, "%s:  zero highestmodseq", mailbox->name);
     }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1675,6 +1675,7 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
                                int keep_intermediaries)
 {
     mbentry_t *mbentry = NULL;
+    mbentry_t *newmbentry = NULL;
     strarray_t existing = STRARRAY_INITIALIZER;
     char newname[MAX_MAILBOX_BUFFER];
     int r = 0;
@@ -1753,8 +1754,18 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
                                keep_intermediaries,
                                0 /* move_subscription */, 0 /* silent */);
 
+    if (r) goto done;
+
+    /* Bump the deletedmodseq of the entries of mbtype. Do not
+     * bump the folderdeletedmodseq, yet. We'll take care of
+     * that in mboxlist_deletemailbox_full. */
+    r = mboxlist_lookup_allow_all(newname, &newmbentry, NULL);
+    if (!r) mboxname_setmodseq(newname, newmbentry->foldermodseq,
+                               newmbentry->mbtype, MBOXMODSEQ_ISDELETE);
+
 done:
     strarray_fini(&existing);
+    mboxlist_entry_free(&newmbentry);
     mboxlist_entry_free(&mbentry);
     mbname_free(&mbname);
 
@@ -1839,7 +1850,7 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
             if (!silent) {
                 newmbentry->foldermodseq = mboxname_nextmodseq(newmbentry->name, newmbentry->foldermodseq,
                                                                newmbentry->mbtype,
-                                                               MBOXMODSEQ_ISFOLDER);
+                                                               MBOXMODSEQ_ISFOLDER|MBOXMODSEQ_ISDELETE);
             }
             r = mboxlist_update(newmbentry, /*localonly*/1);
             if (r) {
@@ -1923,6 +1934,13 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
             r = mboxlist_update_intermediaries(mbentry->name, mbentry->mbtype, newmbentry->foldermodseq);
         }
 
+        /* Bump the modseq of entries of mbtype. There's still a tombstone
+         * for this mailbox, so don't bump the folderdeletedmodseq, yet. */
+        if (!r) {
+            mboxname_setmodseq(mbentry->name, newmbentry->foldermodseq,
+                               mbentry->mbtype, MBOXMODSEQ_ISDELETE);
+        }
+
         mboxlist_entry_free(&newmbentry);
     }
     else {
@@ -1934,6 +1952,11 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
                    name, cyrusdb_strerror(r));
             r = IMAP_IOERROR;
             if (!force) goto done;
+        }
+        /* This mailbox is gone completely, so mark its modseq */
+        if (!r && !isremote && mboxname_isdeletedmailbox(name, NULL)) {
+            mboxname_setmodseq(name, mailbox->foldermodseq, mbentry->mbtype,
+                               MBOXMODSEQ_ISFOLDER|MBOXMODSEQ_ISDELETE);
         }
         if (r && !force) goto done;
     }
@@ -2166,6 +2189,9 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
     char *newpartition = NULL;
     mupdate_handle *mupdate_h = NULL;
     mbentry_t *newmbentry = NULL;
+    int modseqflags = MBOXMODSEQ_ISFOLDER;
+    if (mboxname_isdeletedmailbox(newname, NULL))
+        modseqflags |= MBOXMODSEQ_ISDELETE;
 
     init_internal();
 
@@ -2182,8 +2208,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
         newmbentry->name = xstrdupnull(newname);
         if (!silent) {
             newmbentry->foldermodseq = mboxname_nextmodseq(newname, newmbentry->foldermodseq,
-                                                           newmbentry->mbtype,
-                                                           MBOXMODSEQ_ISFOLDER);
+                                                           newmbentry->mbtype, modseqflags);
         }
 
         /* skip ahead to the database update */
@@ -2259,8 +2284,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
         newmbentry->createdmodseq = oldmailbox->i.createdmodseq;
         newmbentry->foldermodseq = silent ? oldmailbox->foldermodseq
                                           : mboxname_nextmodseq(newname, oldmailbox->foldermodseq,
-                                                                oldmailbox->mbtype,
-                                                                MBOXMODSEQ_ISFOLDER);
+                                                                oldmailbox->mbtype, modseqflags);
 
         r = mboxlist_update_entry(newname, newmbentry, &tid);
         if (r) goto done;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -864,7 +864,8 @@ EXPORTED int mboxlist_update(mbentry_t *mbentry, int localonly)
     r = mboxlist_update_entry(mbentry->name, mbentry, &tid);
 
     if (!r)
-        mboxname_setmodseq(mbentry->name, mbentry->foldermodseq, mbentry->mbtype, /*dofolder*/1);
+        mboxname_setmodseq(mbentry->name, mbentry->foldermodseq, mbentry->mbtype,
+                           MBOXMODSEQ_ISFOLDER);
 
     /* commit the change to mupdate */
     if (!r && !localonly && config_mupdate_server) {
@@ -1215,7 +1216,7 @@ EXPORTED int mboxlist_update_intermediaries(const char *frommboxname,
                 /* bump modseq, we're removing a thing that can be seen */
                 if (!modseq)
                     modseq = mboxname_nextmodseq(mboxname, mbentry->foldermodseq,
-                                                 mbtype, 1 /* dofolder */);
+                                                 mbtype, MBOXMODSEQ_ISFOLDER);
 
                 mbentry_t *newmbentry = mboxlist_entry_copy(mbentry);
                 newmbentry->mbtype = MBTYPE_DELETED;
@@ -1246,7 +1247,7 @@ EXPORTED int mboxlist_update_intermediaries(const char *frommboxname,
         if (!modseq)
             modseq = mboxname_nextmodseq(mboxname,
                                          mbentry ? mbentry->foldermodseq : 0,
-                                         mbtype, 1 /* dofolder */);
+                                         mbtype, MBOXMODSEQ_ISFOLDER);
 
         mbentry_t *newmbentry = mboxlist_entry_create();
         newmbentry->uniqueid = xstrdupnull(makeuuid());
@@ -1837,7 +1838,8 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
             newmbentry->mbtype = MBTYPE_DELETED;
             if (!silent) {
                 newmbentry->foldermodseq = mboxname_nextmodseq(newmbentry->name, newmbentry->foldermodseq,
-                                                               newmbentry->mbtype, 1);
+                                                               newmbentry->mbtype,
+                                                               MBOXMODSEQ_ISFOLDER);
             }
             r = mboxlist_update(newmbentry, /*localonly*/1);
             if (r) {
@@ -2180,7 +2182,8 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
         newmbentry->name = xstrdupnull(newname);
         if (!silent) {
             newmbentry->foldermodseq = mboxname_nextmodseq(newname, newmbentry->foldermodseq,
-                                                           newmbentry->mbtype, 1);
+                                                           newmbentry->mbtype,
+                                                           MBOXMODSEQ_ISFOLDER);
         }
 
         /* skip ahead to the database update */
@@ -2256,7 +2259,8 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
         newmbentry->createdmodseq = oldmailbox->i.createdmodseq;
         newmbentry->foldermodseq = silent ? oldmailbox->foldermodseq
                                           : mboxname_nextmodseq(newname, oldmailbox->foldermodseq,
-                                                                oldmailbox->mbtype, 1);
+                                                                oldmailbox->mbtype,
+                                                                MBOXMODSEQ_ISFOLDER);
 
         r = mboxlist_update_entry(newname, newmbentry, &tid);
         if (r) goto done;

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -315,8 +315,10 @@ struct mboxname_counters {
 };
 
 int mboxname_read_counters(const char *mboxname, struct mboxname_counters *vals);
-modseq_t mboxname_nextmodseq(const char *mboxname, modseq_t last, int mbtype, int dofolder);
-modseq_t mboxname_setmodseq(const char *mboxname, modseq_t val, int mbtype, int dofolder);
+#define MBOXMODSEQ_ISFOLDER (1<<0)
+#define MBOXMODSEQ_ISDELETE (1<<1)
+modseq_t mboxname_nextmodseq(const char *mboxname, modseq_t last, int mbtype, int flags);
+modseq_t mboxname_setmodseq(const char *mboxname, modseq_t val, int mbtype, int flags);
 uint32_t mboxname_readuidvalidity(const char *mboxname);
 uint32_t mboxname_nextuidvalidity(const char *mboxname, uint32_t last);
 uint32_t mboxname_setuidvalidity(const char *mboxname, uint32_t val);
@@ -326,7 +328,5 @@ modseq_t mboxname_setquotamodseq(const char *mboxname, modseq_t val);
 modseq_t mboxname_readraclmodseq(const char *mboxname);
 modseq_t mboxname_nextraclmodseq(const char *mboxname, modseq_t last);
 modseq_t mboxname_setraclmodseq(const char *mboxname, modseq_t val);
-modseq_t mboxname_setdeletedmodseq(const char *mboxname, modseq_t val,
-                                   int mbtype, int dofolder);
 
 #endif

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3023,7 +3023,7 @@ int sync_apply_mailbox(struct dlist *kin,
                          (mailbox->i.options & ~MAILBOX_OPTIONS_MASK);
 
     /* always set the highestmodseq */
-    mboxname_setmodseq(mailbox->name, highestmodseq, mailbox->mbtype, /*dofolder*/0);
+    mboxname_setmodseq(mailbox->name, highestmodseq, mailbox->mbtype, /*flags*/0);
 
     /* this happens rarely, so let us know */
     if (mailbox->i.uidvalidity != uidvalidity) {


### PR DESCRIPTION
Calling Mailbox/destroy with onDestroyRemoveMessages deletes all messages in that mailbox and the mailbox itself, as expected. However, a subsequent call to Email/changes does not report emails that were either destroyed or updated due to the mailbox destruction.

This patch bumps the deleted modseq counters in delayed mailbox deletion, as moving a mailbox in the DELETED namespace throws away requirement information to calculate email changes. This causes Email/changes to return "cannotCalculateChanges". Mailbox/changes still has the required mailbox tombstone and continues to work as currently. Only when a mailbox is deleted from the filesystem the folderdeleted modseq is bumped in counters, also invalidating Mailbox/changes.

Similarly, the calendars and contacts JMAP code is updated. JMAP backups seem to use deleted modseq counters as a mechanism to force cannotCalculateChanges errors, and all its tests pass with this patch.

There's a test at https://github.com/cyrusimap/cassandane/tree/mailbox_destroy_email_changes