### PR TITLE
xapian: look for starting list-id angle bracket from end of string

### DIFF
--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -930,14 +930,14 @@ static std::string parse_listid(const char *str)
     std::string val;
 
     /* Extract list-id */
-    const char *start = strchr(str, '<');
+    const char *start = strrchr(str, '<');
     if (start) {
-        /* RFC2919 list-id header */
+        /* RFC2919 list-id header (with optional closing bracket) */
         const char *end = strchr(++start, '>');
-        if (!end || end - start < 2) {
-            return std::string();
-        }
-        val = std::string(start, end - start);
+        if (end)
+            val = std::string(start, end - start);
+        else
+            val = std::string(start);
     }
     else {
         /* Groups-style header: 'list list-id[; contact list-contact]'


### PR DESCRIPTION
Some mail services use HTML tags in the phrase part of RFC2919
List-Id header values (and tend to forget the closing angle
bracket on the actual list-id). Treating the last '<' character
as starting angle bracket allows us to propertly extract the
list-id value from such headers.

This also works nicely with variants where clients cannot make
up their mind if their list-ids should be RFC2919 or Groups-style.