### PR TITLE
WIP syslog wrapper

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -1442,9 +1442,14 @@ EXPORTED int append_copy(struct mailbox *mailbox, struct appendstate *as,
                     int num;
                     r = mailbox_user_flag(as->mailbox, mailbox->flagname[userflag], &num, 1);
                     if (r)
-                        syslog(LOG_ERR, "IOERROR: unable to copy flag %s from %s to %s for UID %u: %s",
-                               mailbox->flagname[userflag], mailbox->name, as->mailbox->name,
-                               src_uid, error_message(r));
+                        xsyslog(LOG_ERR, "IOERROR: unable to copy flag",
+                                         "flag=<%s> src_mailbox=<%s> dest_mailbox=<%s>"
+                                         " uid=<%s> error=<%s>",
+                                         mailbox->flagname[userflag],
+                                         mailbox->name,
+                                         as->mailbox->name,
+                                         src_uid,
+                                         error_message(r));
                     else
                         dst_user_flags[num/32] |= 1<<(num&31);
                 }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1201,9 +1201,10 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
                req->accountid, uid);
         r = carddav_remove(mailbox, olduid, /*isreplace*/0, req->accountid);
         if (r) {
-            syslog(LOG_ERR, "IOERROR: Contact%s/set remove failed for %s %u",
-                   kind == CARDDAV_KIND_GROUP ? "Group" : "",
-                   mailbox->name, olduid);
+            xsyslog(LOG_ERR, "IOERROR: carddav remove failed",
+                             "kind=<%s> mailbox=<%s> olduid=<%u>",
+                             kind == CARDDAV_KIND_GROUP ? "group" : "contact",
+                             mailbox->name, olduid);
             goto done;
         }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -713,14 +713,18 @@ static int mailbox_cacherecord_internal(struct mailbox *mailbox,
 
 err:
     if (!cachefile)
-        syslog(LOG_ERR, "IOERROR: missing cache file for %s uid %u",
-               mailbox->name, record->uid);
+        xsyslog(LOG_ERR, "IOERROR: missing cache file",
+                         "mailbox=<%s> uid=<%u>",
+                         mailbox->name, record->uid);
     else if (!record->cache_offset)
-        syslog(LOG_ERR, "IOERROR: missing cache offset for %s uid %u",
-               mailbox->name, record->uid);
+        xsyslog(LOG_ERR, "IOERROR: missing cache offset",
+                         "mailbox=<%s> uid=<%u>",
+                         mailbox->name, record->uid);
     else if (r)
-        syslog(LOG_ERR, "IOERROR: invalid cache record for %s uid %u (%s) %d at %llu",
-               mailbox->name, record->uid, error_message(r), crc, (long long unsigned)record->cache_offset);
+        xsyslog(LOG_ERR, "IOERROR invalid cache record",
+                         "mailbox=<%s> uid=<%u> error=<%s> crc=<%d> cache_offset=<%llu>",
+                         mailbox->name, record->uid, error_message(r),
+                         crc, (unsigned long long) record->cache_offset);
 
     if (rewrite == MBCACHE_NOPARSE)
         return r;
@@ -730,16 +734,18 @@ err:
     /* parse directly into the cache for this record */
     const char *fname = mailbox_record_fname(mailbox, record);
     if (!fname) {
-        syslog(LOG_ERR, "IOERROR: no spool file for %s uid %u",
-               mailbox->name, record->uid);
+        xsyslog(LOG_ERR, "IOERROR: no spool file",
+                         "mailbox=<%s> uid=<%u>",
+                         mailbox->name, record->uid);
         return IMAP_IOERROR;
     }
 
     /* parse into the file and zero the cache offset */
     r = message_parse(fname, backdoor);
     if (r) {
-        syslog(LOG_ERR, "IOERROR: failed to parse message for %s uid %u",
-               mailbox->name, record->uid);
+        xsyslog(LOG_ERR, "IOERROR: failed to parse message",
+                         "mailbox=<%s> uid=<%u>",
+                         mailbox->name, record->uid);
         return r;
     }
     backdoor->cache_offset = 0;
@@ -747,8 +753,9 @@ err:
     if (rewrite == MBCACHE_REWRITE) {
         r = mailbox_append_cache(mailbox, backdoor);
         if (r) {
-            syslog(LOG_ERR, "IOERROR: failed to append cache for %s uid %u",
-                   mailbox->name, record->uid);
+            xsyslog(LOG_ERR, "IOERROR: failed to append cache",
+                             "mailbox=<%s> uid=<%u>",
+                             mailbox->name, record->uid);
             return r;
         }
     }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -832,9 +832,10 @@ static int mboxlist_update_entry(const char *name, const mbentry_t *mbentry, str
 
         if (!r && config_auditlog) {
             /* XXX is there a difference between "" and NULL? */
-            syslog(LOG_NOTICE, "auditlog: acl sessionid=<%s> "
-                               "mailbox=<%s> uniqueid=<%s> mbtype=<%s> "
-                               "oldacl=<%s> acl=<%s> foldermodseq=<%llu>",
+            xsyslog(LOG_NOTICE, "auditlog: acl",
+                                "sessionid=<%s> "
+                                "mailbox=<%s> uniqueid=<%s> mbtype=<%s> "
+                                "oldacl=<%s> acl=<%s> foldermodseq=<%llu>",
                    session_id(),
                    name, mbentry->uniqueid, mboxlist_mbtype_to_string(mbentry->mbtype),
                    old ? old->acl : "NONE", mbentry->acl, mbentry->foldermodseq);

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -558,8 +558,9 @@ static int do_compact(const strarray_t *mboxnames, const strarray_t *srctiers,
         for (retry = 1; retry <= 3; retry++) {
             int r = compact_mbox(userid, srctiers, desttier, flags);
             if (!r) break;
-            syslog(LOG_ERR, "IOERROR: failed to compact %s (%d): %s",
-                   userid, retry, error_message(r));
+            xsyslog(LOG_ERR, "IOERROR: failed to compact",
+                             "userid=<%s> retry=<%d> error=<%s>",
+                             userid, retry, error_message(r));
         }
 
         free(prev_userid);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3677,7 +3677,8 @@ int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
 
     /* nothing to do if there's no userid */
     if (!userid || !userid[0]) {
-        syslog(LOG_WARNING, "ignoring attempt to %s() without userid", __func__);
+        xsyslog(LOG_WARNING, "ignoring attempt to sync_apply_unuser() without userid",
+                             NULL);
         return 0;
     }
 

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -165,7 +165,7 @@ EXPORTED int tls_enabled(void)
     if (!val || !strcasecmp(val, "disabled")) return 0;
 
     if (config_getswitch(IMAPOPT_CHATTY))
-            syslog(LOG_INFO, "TLS is available.");
+            xsyslog(LOG_INFO, "TLS is available.", NULL);
 
     return 1;
 }

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -2091,11 +2091,13 @@ static int myconsistent(struct dbengine *db, struct txn *tid)
         cmp = db->compar(KEY(db, &record), record.keylen,
                          KEY(db, &prevrecord), prevrecord.keylen);
         if (cmp <= 0) {
-            syslog(LOG_ERR, "DBERROR: twoskip out of order %s: %.*s (%08llX) <= %.*s (%08llX)",
-                   FNAME(db), (int)record.keylen, KEY(db, &record),
-                   (LLU)record.offset,
-                   (int)prevrecord.keylen, KEY(db, &prevrecord),
-                   (LLU)prevrecord.offset);
+            xsyslog(LOG_ERR, "DBERROR: twoskip out of order",
+                    "fname=<%s> key=<%.*s> offset=<%08llX>"
+                    " prevkey=<%.*s> prevoffset=<%08llX)",
+                    FNAME(db), (int)record.keylen, KEY(db, &record),
+                    (LLU)record.offset,
+                    (int)prevrecord.keylen, KEY(db, &prevrecord),
+                    (LLU)prevrecord.offset);
             return CYRUSDB_INTERNAL;
         }
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -2078,7 +2078,7 @@ EXPORTED void xsyslog_fn(int priority, const char *description,
         buf_putc(&buf, ' ');
     }
     if (saved_errno) {
-        buf_appendmap(&buf, "error=<", 7);
+        buf_appendmap(&buf, "syserror=<", 7);
         buf_appendcstr(&buf, strerror(saved_errno));
         buf_appendmap(&buf, "> ", 2);
     }

--- a/lib/util.c
+++ b/lib/util.c
@@ -2060,8 +2060,7 @@ EXPORTED void tcp_disable_nagle(int fd)
 }
 
 EXPORTED void xsyslog_fn(int priority, const char *description,
-                         const char *file_loc, int line_loc,
-                         const char *extra_fmt, ...)
+                         const char *func, const char *extra_fmt, ...)
 {
     static struct buf buf = BUF_INITIALIZER;
     int saved_errno = errno;
@@ -2081,7 +2080,7 @@ EXPORTED void xsyslog_fn(int priority, const char *description,
     if (saved_errno) {
         buf_printf(&buf, "error=<%s> ", strerror(saved_errno));
     }
-    buf_printf(&buf, "srcfile=<%s> srcline=<%d>", file_loc, line_loc);
+    buf_printf(&buf, "func=<%s>", func);
 
     syslog(priority, "%s", buf_cstring(&buf));
     buf_free(&buf);

--- a/lib/util.c
+++ b/lib/util.c
@@ -2078,9 +2078,13 @@ EXPORTED void xsyslog_fn(int priority, const char *description,
         buf_putc(&buf, ' ');
     }
     if (saved_errno) {
-        buf_printf(&buf, "error=<%s> ", strerror(saved_errno));
+        buf_appendmap(&buf, "error=<", 7);
+        buf_appendcstr(&buf, strerror(saved_errno));
+        buf_appendmap(&buf, "> ", 2);
     }
-    buf_printf(&buf, "func=<%s>", func);
+    buf_appendmap(&buf, "func=<", 6);
+    if (func) buf_appendcstr(&buf, func);
+    buf_putc(&buf, '>');
 
     syslog(priority, "%s", buf_cstring(&buf));
     buf_free(&buf);

--- a/lib/util.h
+++ b/lib/util.h
@@ -415,6 +415,12 @@ const char *makeuuid();
 void tcp_enable_keepalive(int fd);
 void tcp_disable_nagle(int fd);
 
+void xsyslog_fn(int priority, const char *description,
+                const char *file_loc, int line_loc,
+                const char *extra_fmt, ...);
+#define xsyslog(pri, desc, ...)  \
+    xsyslog_fn(pri, desc, __FILE__, __LINE__, __VA_ARGS__)
+
 /*
  * GCC_VERSION macro usage:
  * #if GCC_VERSION > 60909    //GCC version 7 and above

--- a/lib/util.h
+++ b/lib/util.h
@@ -416,10 +416,9 @@ void tcp_enable_keepalive(int fd);
 void tcp_disable_nagle(int fd);
 
 void xsyslog_fn(int priority, const char *description,
-                const char *file_loc, int line_loc,
-                const char *extra_fmt, ...);
+                const char *func, const char *extra_fmt, ...);
 #define xsyslog(pri, desc, ...)  \
-    xsyslog_fn(pri, desc, __FILE__, __LINE__, __VA_ARGS__)
+    xsyslog_fn(pri, desc, __func__, __VA_ARGS__)
 
 /*
  * GCC_VERSION macro usage:

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -505,9 +505,11 @@ EXPORTED int sieve_script_load(const char *fname, sieve_execute_t **ret)
 
     if (stat(fname, &sbuf) == -1) {
         if (errno == ENOENT) {
-            syslog(LOG_DEBUG, "WARNING: sieve script %s doesn't exist: %m", fname);
+            xsyslog(LOG_DEBUG, "WARNING: sieve script doesn't exist",
+                               "fname=<%s>", fname);
         } else {
-            syslog(LOG_DEBUG, "IOERROR: fstating sieve script %s: %m", fname);
+            xsyslog(LOG_DEBUG, "IOERROR: fstating sieve script",
+                               "fname=<%s>", fname);
         }
         return SIEVE_FAIL;
     }
@@ -534,12 +536,14 @@ EXPORTED int sieve_script_load(const char *fname, sieve_execute_t **ret)
         /* new script -- load it */
         fd = open(fname, O_RDONLY);
         if (fd == -1) {
-            syslog(LOG_ERR, "IOERROR: can not open sieve script %s: %m", fname);
+            xsyslog(LOG_ERR, "IOERROR: can not open sieve script",
+                             "fname=<%s>", fname);
             if (dofree) free(ex);
             return SIEVE_FAIL;
         }
         if (fstat(fd, &sbuf) == -1) {
-            syslog(LOG_ERR, "IOERROR: fstating sieve script %s: %m", fname);
+            xsyslog(LOG_ERR, "IOERROR: fstating sieve script",
+                             "fname=<%s>", fname);
             close(fd);
             if (dofree) free(ex);
             return SIEVE_FAIL;


### PR DESCRIPTION
This is a prototype of the syslog wrapper we've been talking about for standardising Cyrus's log output.

We've talked about this a few times recently, and each time the details of what we want have been slightly different.  I've thrown something together that broadly seems to do what we want, expecting that some of the specifics will be subject to further discussion and refinement.

I've called it `xsyslog()`, because I want to be able to naively search sources for "syslog" and find legacy and new kinds of log output, and because I want the casual reader to understand that this macro is roughly analogous to `syslog()`.

Some points for consideration:

* Automatic inclusion of the file and line number, but not the function name.  I'm reluctant to clutter it up with too much noise, and the full trifecta seems over the top.  Which are most useful?  (I would usually just include the function name myself, but someone else asked for file/line, so I went with that for now.)
* Automatic inclusion of the "%m" error string, if errno is non-zero.  A bunch of our existing syslogging only needs printf-style formatting to include this, so I just made it a freebie.  The implementation is careful to not alter errno.
* We've talked about "category" a bunch, and it's not clear to me whether that means the "IOERROR/DBERROR/SYNCERROR/etc" part, or the "easily matchable constant string description of the error with no embedded variables" part, or some combination of both.  I've guessed the latter, and called it "description", cause that's what made sense to me at the time (but on reflection I'd probably prefer to call it "message" instead...).  Do we want "IOERROR/etc" to be a separate argument, or to keep baking it in like we currently do?
* Some of the discussion maybe implies an expectation of automatically doing "foo=&lt;foo&gt;" formatting of arbitrary variables?  But C lacks the introspective capacity to do this any better than printf already does, so I'm assuming this part of the discussion was about code style rather than implementation detail, and that the distinction was lost in the meeting minutes.
* ~~The `struct buf buf` could potentially be declared `static`, which might save us some malloc/free churn on its internals.  But we don't generally log in hot loops, so maybe it doesn't matter?  I don't have a strong opinion either way.~~

There's currently two commits here:

* the first one adds the `xsyslog()` macro and the `xsyslog_fn()` function that implements it.
* the second one updates a small but hopefully representative set of old `syslog()` lines to use the new macro, to test/demonstrate how it's used and how it differs from what we had.