### PR TITLE
Fix to declare missing MAXLOGNAME properly

### DIFF
--- a/imap/fud.c
+++ b/imap/fud.c
@@ -60,6 +60,7 @@
 #include <netdb.h>
 #include <errno.h>
 #include <pwd.h>
+#include <limits.h>
 
 #include "acl.h"
 #include "mboxlist.h"
@@ -97,7 +98,11 @@ static void send_reply(struct sockaddr *sfrom, socklen_t sfromsiz, int status,
 static int soc = 0; /* inetd (master) has handed us the port as stdin */
 
 #ifndef MAXLOGNAME
+#  ifdef LOGIN_NAME_MAX
+#define MAXLOGNAME (LOGIN_NAME_MAX - 1)
+#  else
 #define MAXLOGNAME 16           /* should find out for real */
+#  endif
 #endif
 #ifndef MAXDOMNAME
 #define MAXDOMNAME 20           /* should find out for real */


### PR DESCRIPTION
Use LOGIN_NAME_MAX if it is available for the condition.