### PR TITLE
Add xml_support.c to ctl_zoneinfo dependencies

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -859,7 +859,7 @@ imap_ctl_deliver_LDADD = $(LD_UTILITY_ADD)
 imap_ctl_mboxlist_SOURCES = imap/cli_fatal.c imap/ctl_mboxlist.c imap/mutex_fake.c
 imap_ctl_mboxlist_LDADD = $(LD_UTILITY_ADD)
 
-imap_ctl_zoneinfo_SOURCES = imap/cli_fatal.c imap/ctl_zoneinfo.c imap/mutex_fake.c imap/zoneinfo_db.c
+imap_ctl_zoneinfo_SOURCES = imap/cli_fatal.c imap/ctl_zoneinfo.c imap/mutex_fake.c imap/zoneinfo_db.c imap/xml_support.c
 imap_ctl_zoneinfo_LDADD = $(LD_UTILITY_ADD)
 
 imap_cvt_cyrusdb_SOURCES = imap/cli_fatal.c imap/cvt_cyrusdb.c imap/mutex_fake.c


### PR DESCRIPTION
Build failure while building on Ubuntu 20.04.1 LTS. I added the dependency into `Makefile.am` and the build passed. I might not have added the dependency in the correct place, though?

## Following the headings in [Reporting bugs](https://www.cyrusimap.org/imap/support/feedback-bugs.html):

### Your platform, and if applicable, your distribution and the distribution version.

Ubuntu 20.04.1 LTS VM.

### The exact version of Cyrus IMAP or SASL you are using.

Behaviour the same on imapd-cyrus-3.2.2 and master (d037fc409).

### If a packaged version is used, the source of the packaged version.

git repository used.

### If a custom version is used, any options that may have specified during the build process.

N/A

### If relevant, are you using altnamespace, unixhierarchysep, or virtdomains?

Not relevant.

### If relevant, are you in a murder configuration? (In which case please provide information for all hosts)

Not relevant.

### What did you do?

I built from a clean clone as follows:

```bash
git clone https://github.com/cyrusimap/cyrus-imapd.git
cd cyrus-imapd
git checkout cyrus-imapd-3.2.2 # Missed this step when building from master
export CYRUSLIBS=/usr/local/cyruslibs
export PKG_CONFIG_PATH="$CYRUSLIBS/lib/pkgconfig:$PKG_CONFIG_PATH"
export LDFLAGS="-Wl,-rpath,$CYRUSLIBS/lib -Wl,-rpath,$CYRUSLIBS/lib/x86_64-linux-gnu"
export XAPIAN_CONFIG="$CYRUSLIBS/bin/xapian-config-1.5"
autoreconf -i
./configure CFLAGS="-W -Wno-unused-parameter -g -O0 -Wall -Wextra -Werror -fPIC" --enable-http --enable-calalarmd --enable-jmap --enable-idled --prefix=/usr/cyrus --enable-xapian
make
```

### What did you expect to happen, and what actually happened?

I expected to see the build complete without errors.

I saw this instead:
```
/bin/bash ./libtool  --tag=CC   --mode=link gcc -fPIC  -W -Wno-unused-parameter -g -O0 -Wall -Wextra -Werror -fPIC  -L/usr/local/cyruslibs/lib -licui18n -licuuc -licudata -lxml2  -L/usr/local/cyruslibs
/lib -lical -licalss -licalvcal  -L/usr/local/cyruslibs/lib -ljansson  -L/usr/local/cyruslibs/lib -lwslay    -lm -L/usr/local/cyruslibs/lib -lchardet -L/usr/local/cyruslibs/lib -ljansson -Wl,-rpath,/us
r/local/cyruslibs/lib -Wl,-rpath,/usr/local/cyruslibs/lib/x86_64-linux-gnu -o imap/ctl_zoneinfo imap/cli_fatal.o imap/ctl_zoneinfo.o imap/mutex_fake.o imap/zoneinfo_db.o imap/libcyrus_imap.la lib/libcy
rus.la lib/libcyrus_min.la -ljansson    -lpcre -lpcreposix -lz -lxml2 -L/usr/local/cyruslibs/lib -lical -licalss -licalvcal  -lsqlite3 -lsasl2 -lssl -lcrypto -lssl -lcrypto   com_err/et/libcyrus_com_er
r.la -ljansson    -lpcre -lpcreposix -lz -lxml2 -L/usr/local/cyruslibs/lib -lical -licalss -licalvcal  -lsqlite3
libtool: link: gcc -fPIC -W -Wno-unused-parameter -g -O0 -Wall -Wextra -Werror -fPIC -Wl,-rpath -Wl,/usr/local/cyruslibs/lib -Wl,-rpath -Wl,/usr/local/cyruslibs/lib/x86_64-linux-gnu -o imap/.libs/ctl_z
oneinfo imap/cli_fatal.o imap/ctl_zoneinfo.o imap/mutex_fake.o imap/zoneinfo_db.o  -L/usr/local/cyruslibs/lib -licui18n -licuuc -licudata /usr/local/cyruslibs/lib/libwslay.so -lm /usr/local/cyruslibs/l
ib/libchardet.so imap/.libs/libcyrus_imap.so lib/.libs/libcyrus.so lib/.libs/libcyrus_min.so -lsasl2 -lssl -lcrypto com_err/et/.libs/libcyrus_com_err.so /usr/local/cyruslibs/lib/libjansson.so -lpcre -l
pcreposix -lz -lxml2 -lical -licalss -licalvcal /usr/lib/x86_64-linux-gnu/libsqlite3.so -Wl,-rpath -Wl,/usr/local/cyruslibs/lib -Wl,-rpath -Wl,/usr/cyrus/lib
/usr/bin/ld: imap/ctl_zoneinfo.o: in function `main':
/home/jwrm/src/cyrus-imapd-dev/imap/ctl_zoneinfo.c:237: undefined reference to `xmlGetNextNode'
/usr/bin/ld: /home/jwrm/src/cyrus-imapd-dev/imap/ctl_zoneinfo.c:239: undefined reference to `xmlGetNextNode'
/usr/bin/ld: /home/jwrm/src/cyrus-imapd-dev/imap/ctl_zoneinfo.c:245: undefined reference to `xmlGetNextNode'
/usr/bin/ld: /home/jwrm/src/cyrus-imapd-dev/imap/ctl_zoneinfo.c:256: undefined reference to `xmlGetNextNode'
/usr/bin/ld: /home/jwrm/src/cyrus-imapd-dev/imap/ctl_zoneinfo.c:258: undefined reference to `xmlGetNextNode'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:4258: imap/ctl_zoneinfo] Error 1
make[2]: Leaving directory '/home/jwrm/src/cyrus-imapd-dev'
make[1]: *** [Makefile:6921: all-recursive] Error 1
make[1]: Leaving directory '/home/jwrm/src/cyrus-imapd-dev'
make: *** [Makefile:3223: all] Error 2
```

### If Cyrus crashed, please provide a backtrace of the core dump.

Not applicable.

