### PR TITLE
parseaddr: ignore control characters in quoted names

### DIFF
--- a/cunit/parseaddr.testc
+++ b/cunit/parseaddr.testc
@@ -236,15 +236,25 @@ static void test_quoted_name_crlf(void)
     parseaddr_list("\"Akira\r\n\r\nYoshizawa\" <akira@origami.jp>", &a);
     CU_ASSERT_PTR_NULL_FATAL(a);
 
-    /* A lone CR is invalid and the parse should fail */
+    /* A lone CR is replaced with space */
     a = NULL;
     parseaddr_list("\"Akira\rYoshizawa\" <akira@origami.jp>", &a);
-    CU_ASSERT_PTR_NULL_FATAL(a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->name, "Akira Yoshizawa");
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "akira");
+    CU_ASSERT_STRING_EQUAL(a->domain, "origami.jp");
+    CU_ASSERT_PTR_NULL(a->next);
+    parseaddr_free(a);
 
-    /* A lone LF is invalid and the parse should fail */
+    /* A lone LF is replaced with space */
     a = NULL;
     parseaddr_list("\"Akira\nYoshizawa\" <akira@origami.jp>", &a);
-    CU_ASSERT_PTR_NULL_FATAL(a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->name, "Akira Yoshizawa");
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "akira");
+    CU_ASSERT_STRING_EQUAL(a->domain, "origami.jp");
+    CU_ASSERT_PTR_NULL(a->next);
+    parseaddr_free(a);
 }
 
 
@@ -705,7 +715,7 @@ static void test_quoted_crlf(void)
     struct address *head, *a;
 
     a = NULL;
-    parseaddr_list("foo@example.com, bar@example.com,\r\n  \"Baz\\\r\n Baz\" <baz@example.com>,\r\n  bam@example.com", &a);
+    parseaddr_list("foo@example.com, bar@example.com,\r\n  \"Baz\\\r\n Baz\" <baz@example.com>,\r\n  bam@example.com, \"A\rB" "\x07" "C\" <abc@example.com>", &a);
     CU_ASSERT_PTR_NOT_NULL_FATAL(a);
     head = a;
 
@@ -729,6 +739,12 @@ static void test_quoted_crlf(void)
     a = a->next;
     CU_ASSERT_PTR_NULL(a->name);
     CU_ASSERT_STRING_EQUAL(a->mailbox, "bam");
+    CU_ASSERT_STRING_EQUAL(a->domain, "example.com");
+    CU_ASSERT_PTR_NOT_NULL(a->next);
+
+    a = a->next;
+    CU_ASSERT_STRING_EQUAL(a->name, "A BC");
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "abc");
     CU_ASSERT_STRING_EQUAL(a->domain, "example.com");
     CU_ASSERT_PTR_NULL(a->next);
 

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -986,11 +986,9 @@ static int add_listid_part(xapian_dbw_t *dbw, const struct buf *part, int partnu
 static int add_email_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
 {
     std::string prefix(get_term_prefix(XAPIAN_DB_CURRENT_VERSION, partnum));
-    struct buf mypart = BUF_INITIALIZER;
-    buf_copy(&mypart, part);
-    buf_lcase(&mypart);
+    std::string lpart = Xapian::Unicode::tolower(buf_cstring(part));
     struct address_itr itr;
-    address_itr_init(&itr, buf_cstring(&mypart), 0);
+    address_itr_init(&itr, lpart.c_str(), 0);
 
     const struct address *addr;
     while ((addr = address_itr_next(&itr))) {
@@ -1038,7 +1036,6 @@ static int add_email_part(xapian_dbw_t *dbw, const struct buf *part, int partnum
         }
     }
 
-    buf_free(&mypart);
     address_itr_fini(&itr);
     return 0;
 }

--- a/lib/parseaddr.c
+++ b/lib/parseaddr.c
@@ -258,7 +258,12 @@ static int parseaddr_phrase(char **inp, char **phrasep, const char *specials)
                      * field, which means we have an unbalanced " */
                     goto fail;
                 }
-                if (c == '\r' || c == '\n') goto fail;  /* invalid chars */
+                else if (iscntrl(c)) {
+                    if (c == '\r' || c == '\n')
+                        c = ' '; // replace CR and LF with space
+                    else if (c != '\t')
+                        continue; // else ignore anything but TAB
+                }
                 if (c == '"') break;        /* end of quoted string */
                 if (c == '\\') {
                     if (!(c = *src)) goto fail;


### PR DESCRIPTION
This showed up while debugging a failing JMAP query sieve script: a message with a stray CR in the (non-ASCII) email address name part was indexed properly in Xapian. But when matching the same email address in a Sieve JMAP query the filter failed. This is because the message.c code handles lone CR and LFs, but our email address parser in Xapian did just pass the bogus header value on to parseaddr.

I suggest we make parseaddr lenient with regards to control characters: it preserves TAB, replaces lone CR and LR with space and ignores all other control characters.