### PR TITLE
squatter: add search_index_skip_domains and search_index_skip_users

### DIFF
--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -239,14 +239,14 @@ static int should_index(const char *name)
 
     // skip listed domains
     if (mbname_domain(mbname) && skip_domains &&
-        strarray_find(skip_domains, mbname_domain(mbname), 0) > 0) {
+        strarray_find(skip_domains, mbname_domain(mbname), 0) >= 0) {
         ret = 0;
         goto done;
     }
 
     // skip listed users
     if (mbname_userid(mbname) && skip_users &&
-        strarray_find(skip_users, mbname_userid(mbname), 0) > 0) {
+        strarray_find(skip_users, mbname_userid(mbname), 0) >= 0) {
         ret = 0;
         goto done;
     }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2204,13 +2204,13 @@ If all partitions are over that limit, this feature is not used anymore.
   Deprecated. No longer used.
  */
 
-{ "search_index_skip_domains", NULL, STRING, "3.3.0" }
+{ "search_index_skip_domains", NULL, STRING, "3.3.1" }
 /*
  A space separated list of domains - if set, any users in the listed domains
  will be skipped when indexing.
  */
 
-{ "search_index_skip_users", NULL, STRING, "3.3.0" }
+{ "search_index_skip_users", NULL, STRING, "3.3.1" }
 /*
  A space separated list of usernames - if set, any users in the list
  will be skipped when indexing.

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2204,6 +2204,18 @@ If all partitions are over that limit, this feature is not used anymore.
   Deprecated. No longer used.
  */
 
+{ "search_index_skip_domains", NULL, STRING, "3.3.0" }
+/*
+ A space separated list of domains - if set, any users in the listed domains
+ will be skipped when indexing.
+ */
+
+{ "search_index_skip_users", NULL, STRING, "3.3.0" }
+/*
+ A space separated list of usernames - if set, any users in the list
+ will be skipped when indexing.
+ */
+
 { "search_query_language", 0, SWITCH, "3.3.0", "3.3.0" }
 /*
   Deprecated. No longer used.


### PR DESCRIPTION
This is related to the 'pendingdelete' users that we create at Fastmail to rename users to when we delete them and support undo for a week.

Right now, we wind up reindexing the entire user when we rename it, even though we'll reindex it AGAIN when we rename back - this is wasteful, so let's just stop it.  I added the users option as well just because it parallels nicely.

this will be paired with a 'search_index_skip_domains: pendingdelete' imapd.conf setting.