### PR TITLE
imap/caldav_db.c: change to use unitptr_t for hash variable

### DIFF
--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -912,8 +912,8 @@ static int _add_shareacls(const mbentry_t *mbentry, void *rock)
 
         cyrus_acl_strtomask(rightstr, &access);
 
-        unsigned long long have = (unsigned long long)hash_lookup(userid, &share->user_access);
-        unsigned long long set = have;
+        uintptr_t have = (uintptr_t)hash_lookup(userid, &share->user_access);
+        uintptr_t set = have;
 
         // if it's the principal, we have each user with principal read access
         if (isprincipal) {
@@ -943,7 +943,7 @@ static int _add_shareacls(const mbentry_t *mbentry, void *rock)
 static void _update_acls(const char *userid, void *data, void *rock)
 {
     struct shareacls_rock *share = rock;
-    unsigned long long aclstatus = (unsigned long long)data;
+    uintptr_t aclstatus = (uintptr_t)data;
 
     if ((aclstatus & CALSHARE_WANTSCHED) && !(aclstatus & CALSHARE_HAVESCHED)) {
         cyrus_acl_set(&share->newoutboxacl, userid, ACL_MODE_ADD, (DACL_INVITE|DACL_REPLY), NULL, NULL);


### PR DESCRIPTION
Hash variables willl be stored as void*, but It is unsure that
sizeof(unsigned long long) == sizeof(void*).