### PR TITLE
JMAP: handle role updates in Mailbox/set

### DIFF
--- a/cunit/buf.testc
+++ b/cunit/buf.testc
@@ -98,6 +98,23 @@ static void test_initm(void)
     buf_free(&b);
 }
 
+static void test_initmcstr(void)
+{
+    struct buf b = BUF_INITIALIZER;
+    /* data thanks to hipsteripsum.me */
+    char *s = xstrdup("terry richardson fanny pack");
+
+    buf_initmcstr(&b, s);
+    CU_ASSERT_EQUAL(b.len, strlen(s));
+    CU_ASSERT_EQUAL(buf_len(&b), b.len);
+    CU_ASSERT(b.alloc >= b.len);
+    CU_ASSERT_PTR_NOT_NULL(b.s);
+    CU_ASSERT(!memcmp(b.s, s, strlen(s)));
+
+    /* we don't free(s) - the buf_free() should do that */
+    buf_free(&b);
+}
+
 static void test_long(void)
 {
     struct buf b = BUF_INITIALIZER;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3280,7 +3280,7 @@ static int annotation_set_pop3showafter(annotate_state_t *state,
 }
 
 EXPORTED int specialuse_validate(const char *mboxname, const char *userid,
-                                 const char *src, struct buf *dest)
+                                 const char *src, struct buf *dest, int allow_dups)
 {
     const char *specialuse_extra_opt = config_getstring(IMAPOPT_SPECIALUSE_EXTRA);
     char *strval = NULL;
@@ -3324,7 +3324,7 @@ EXPORTED int specialuse_validate(const char *mboxname, const char *userid,
     new_attribs = strarray_split(src, NULL, 0);
 
     for (i = 0; i < new_attribs->count; i++) {
-        int skip_mbcheck = 0;
+        int skip_mbcheck = allow_dups;
         const char *item = strarray_nth(new_attribs, i);
 
         for (j = 0; j < valid->count; j++) { /* can't use find here */
@@ -3390,7 +3390,7 @@ static int annotation_set_specialuse(annotate_state_t *state,
     }
 
     r = specialuse_validate(state->mailbox->name, state->userid,
-                            buf_cstring(&entry->priv), &res);
+                            buf_cstring(&entry->priv), &res, 0);
     if (r) goto done;
 
     r = write_entry(state->mailbox, state->uid, entry->name, state->userid,

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -279,6 +279,6 @@ void annotate_putdb(annotate_db_t **dbp);
 
 /* Maybe this isn't the right place - move later */
 int specialuse_validate(const char *mboxname, const char *userid,
-                        const char *src, struct buf *dest);
+                        const char *src, struct buf *dest, int allow_dups);
 
 #endif /* ANNOTATE_H */

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -133,7 +133,8 @@ static int fixmbox(const mbentry_t *mbentry,
 
     /* if MBTYPE_RESERVED, unset it & call mboxlist_delete */
     if (mbentry->mbtype & MBTYPE_RESERVE) {
-        r = mboxlist_deletemailboxlock(mbentry->name, 1, NULL, NULL, NULL, 0, 0, 1, 0);
+        r = mboxlist_deletemailboxlock(mbentry->name, 1, NULL, NULL, NULL,
+                                       MBOXLIST_DELETE_FORCE);
         if (r) {
             /* log the error */
             syslog(LOG_ERR,

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -530,11 +530,15 @@ static void do_dump(enum mboxop op, const char *part, int purge, int intermediar
             struct mboxlock *namespacelock = mboxname_usernamespacelock(me->mailbox);
 
             if (!mboxlist_delayed_delete_isenabled()) {
-                ret = mboxlist_deletemailbox(me->mailbox, 1, "", NULL, NULL, 0, 1, 1, 0);
+                ret = mboxlist_deletemailbox(me->mailbox, 1, "", NULL, NULL,
+                        MBOXLIST_DELETE_LOCALONLY|MBOXLIST_DELETE_FORCE);
             } else if (mboxname_isdeletedmailbox(me->mailbox, NULL)) {
-                ret = mboxlist_deletemailbox(me->mailbox, 1, "", NULL, NULL, 0, 1, 1, 0);
+                ret = mboxlist_deletemailbox(me->mailbox, 1, "", NULL, NULL,
+                        MBOXLIST_DELETE_LOCALONLY|MBOXLIST_DELETE_FORCE);
+
             } else {
-                ret = mboxlist_delayed_deletemailbox(me->mailbox, 1, "", NULL, NULL, 0, 1, 1, 0);
+                ret = mboxlist_delayed_deletemailbox(me->mailbox, 1, "", NULL, NULL,
+                        MBOXLIST_DELETE_LOCALONLY|MBOXLIST_DELETE_FORCE);
             }
 
             mboxname_release(&namespacelock);

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -758,7 +758,8 @@ static int do_delete(struct cyr_expire_ctx *ctx)
 
             verbosep("Removing: %s\n", name);
 
-            ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL, 0, 0, 0, 1);
+            ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL,
+                                             MBOXLIST_DELETE_KEEP_INTERMEDIARIES);
             /* XXX: Ignoring the return from mboxlist_deletemailbox() ??? */
             count++;
         }

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4283,17 +4283,13 @@ static int remove_collection(const mbentry_t *mbentry,
     if (mboxlist_delayed_delete_isenabled()) {
         r = mboxlist_delayed_deletemailbox(mbentry->name, 1, /* admin */
                                            httpd_userid, httpd_authstate,
-                                           NULL, 1 /* checkacl */,
-                                           0 /* localonly */, 0 /* force */,
-                                           0 /* keep_intermediaries */);
+                                           NULL, MBOXLIST_DELETE_CHECKACL);
 
     }
     else {
         r = mboxlist_deletemailbox(mbentry->name, 1, /* admin */
                                    httpd_userid, httpd_authstate,
-                                   NULL, 1 /* checkacl */,
-                                   0 /* localonly */, 0 /* force */,
-                                   0 /* keep_intermediaries */);
+                                   NULL, MBOXLIST_DELETE_CHECKACL);
     }
 
     return r;
@@ -4371,18 +4367,14 @@ static int dav_move_collection(struct transaction_t *txn,
             r = mboxlist_delayed_deletemailbox(newmailboxname,
                                                httpd_userisadmin,
                                                httpd_userid, httpd_authstate,
-                                               mboxevent, 1 /* checkacl */,
-                                               0 /* localonly*/, 0 /* force */,
-                                               0 /* keep_intermediaries */);
+                                               mboxevent, MBOXLIST_DELETE_CHECKACL);
 
         }
         else {
             r = mboxlist_deletemailbox(newmailboxname,
                                        httpd_userisadmin,
                                        httpd_userid, httpd_authstate,
-                                       mboxevent, 1 /* checkacl */,
-                                       0 /* localonly*/, 0 /* force */,
-                                       0 /* keep_intermediaries */);
+                                       mboxevent, MBOXLIST_DELETE_CHECKACL);
         }
 
         if (!r) mboxevent_notify(&mboxevent);
@@ -5015,16 +5007,13 @@ static int meth_delete_collection(struct transaction_t *txn,
         r = mboxlist_delayed_deletemailbox(txn->req_tgt.mbentry->name,
                                            httpd_userisadmin || httpd_userisproxyadmin,
                                            httpd_userid, httpd_authstate,
-                                           mboxevent, /*checkacl*/1,
-                                           /*localonly*/0, /*force*/0,
-                                           /* keep_intermediaries */0);
+                                           mboxevent, MBOXLIST_DELETE_CHECKACL);
     }
     else {
         r = mboxlist_deletemailbox(txn->req_tgt.mbentry->name,
                                    httpd_userisadmin || httpd_userisproxyadmin,
                                    httpd_userid, httpd_authstate, mboxevent,
-                                   /*checkacl*/1, /*localonly*/0, /*force*/0,
-                                   /* keep_intermediaries */0);
+                                   MBOXLIST_DELETE_CHECKACL);
     }
     if (!r) {
         r = caldav_update_shareacls(mbname_userid(mbname));
@@ -5773,8 +5762,7 @@ int meth_mkcol(struct transaction_t *txn, void *params)
             mailbox_close(&mailbox);
             mboxlist_deletemailbox(txn->req_tgt.mbentry->name,
                                    /*isadmin*/1, NULL, NULL, NULL,
-                                   /*checkacl*/0, /*localonly*/0, /*force*/1,
-                                   /*keep_intermediaries*/0);
+                                   MBOXLIST_DELETE_FORCE);
 
             if (!ret) {
                 /* Output the XML response */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6918,7 +6918,7 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
         }
         raw = strarray_join(su, " ");
         strarray_free(su);
-        r = specialuse_validate(NULL, imapd_userid, raw, &specialuse);
+        r = specialuse_validate(NULL, imapd_userid, raw, &specialuse, 0);
         free(raw);
         if (r) {
             prot_printf(imapd_out, "%s NO [USEATTR] %s\r\n", tag, error_message(r));

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1210,9 +1210,7 @@ static int restore_calendar_cb(const mbentry_t *mbentry, void *rock)
                 /* XXX  Do we want to do this? */
                 r = mboxlist_deletemailboxlock(mbentry->name, /*isadmin*/0,
                                                req->accountid, req->authstate,
-                                               /*mboxevent*/NULL, /*checkacl*/0,
-                                               /*localonly*/0, /*force*/0,
-                                               /*keep_intermediaries*/0);
+                                               /*mboxevent*/NULL, /*flags*/0);
             }
         }
         else {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -979,14 +979,12 @@ static int setcalendars_destroy(jmap_req_t *req, const char *mboxname)
         r = mboxlist_delayed_deletemailbox(mboxname,
                 httpd_userisadmin || httpd_userisproxyadmin,
                 httpd_userid, req->authstate, mboxevent,
-                1 /* checkacl */, 0 /* local_only */, 0 /* force */,
-                0 /* keep_intermediaries */);
+                MBOXLIST_DELETE_CHECKACL);
     } else {
         r = mboxlist_deletemailbox(mboxname,
                 httpd_userisadmin || httpd_userisproxyadmin,
                 httpd_userid, req->authstate, mboxevent,
-                1 /* checkacl */, 0 /* local_only */, 0 /* force */,
-                0 /* keep_intermediaries */);
+                MBOXLIST_DELETE_CHECKACL);
     }
     mboxevent_free(&mboxevent);
 

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -2960,15 +2960,13 @@ static void _mbox_destroy(jmap_req_t *req, const char *mboxid,
         r = mboxlist_delayed_deletemailbox(mbentry->name,
                 httpd_userisadmin || httpd_userisproxyadmin,
                 req->userid, req->authstate, mboxevent,
-                1 /* checkacl */, 0 /* local_only */, 0 /* force */,
-                1 /* keep_intermediaries */);
+                MBOXLIST_DELETE_CHECKACL|MBOXLIST_DELETE_KEEP_INTERMEDIARIES);
     }
     else {
         r = mboxlist_deletemailbox(mbentry->name,
                 httpd_userisadmin || httpd_userisproxyadmin,
                 req->userid, req->authstate, mboxevent,
-                1 /* checkacl */, 0 /* local_only */, 0 /* force */,
-                1 /* keep_intermediaries */);
+                MBOXLIST_DELETE_CHECKACL|MBOXLIST_DELETE_KEEP_INTERMEDIARIES);
     }
     mboxevent_free(&mboxevent);
 

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1176,7 +1176,7 @@ static int sieve_fileinto(void *ac,
             if (fc->specialuse) {
                 /* Attempt to add special-use flag to newly created mailbox */
                 struct buf specialuse = BUF_INITIALIZER;
-                int r = specialuse_validate(NULL, userid, fc->specialuse, &specialuse);
+                int r = specialuse_validate(NULL, userid, fc->specialuse, &specialuse, 0);
 
                 if (!r) {
                     annotatemore_write(intname, "/specialuse",
@@ -1348,7 +1348,7 @@ static int sieve_snooze(void *ac,
                     /* Attempt to add special-use flag to newly created mailbox */
                     struct buf specialuse = BUF_INITIALIZER;
                     int r2 = specialuse_validate(NULL, userid,
-                                                 sn->awaken_spluse, &specialuse);
+                                                 sn->awaken_spluse, &specialuse, 0);
 
                     if (!r2) {
                         annotatemore_write(awaken, "/specialuse",
@@ -1638,7 +1638,7 @@ static void do_fcc(script_data_t *sdata, sieve_fileinto_context_t *fcc,
                 /* Attempt to add special-use flag to newly created mailbox */
                 struct buf specialuse = BUF_INITIALIZER;
                 int r2 = specialuse_validate(NULL, userid,
-                                             fcc->specialuse, &specialuse);
+                                             fcc->specialuse, &specialuse, 0);
 
                 if (!r2) {
                     annotatemore_write(intname, "/specialuse",

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1682,6 +1682,7 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
     int localonly = flags & MBOXLIST_DELETE_LOCALONLY;
     int force = flags & MBOXLIST_DELETE_FORCE;
     int keep_intermediaries = flags & MBOXLIST_DELETE_KEEP_INTERMEDIARIES;
+    int unprotect_specialuse = flags & MBOXLIST_DELETE_UNPROTECT_SPECIALUSE;
 
     init_internal();
 
@@ -1702,7 +1703,7 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
         }
     }
 
-    if (!isadmin && mbname_userid(mbname)) {
+    if (!isadmin && mbname_userid(mbname) && !unprotect_specialuse) {
         const char *protect = config_getstring(IMAPOPT_SPECIALUSE_PROTECT);
         if (protect) {
             struct buf attrib = BUF_INITIALIZER;
@@ -1805,6 +1806,7 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
     int force = flags & MBOXLIST_DELETE_FORCE;
     int keep_intermediaries = flags & MBOXLIST_DELETE_KEEP_INTERMEDIARIES;
     int silent = flags & MBOXLIST_DELETE_SILENT;
+    int unprotect_specialuse = flags & MBOXLIST_DELETE_UNPROTECT_SPECIALUSE;
 
     init_internal();
 
@@ -1827,7 +1829,7 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
         }
     }
 
-    if (!isadmin && mbname_userid(mbname)) {
+    if (!isadmin && mbname_userid(mbname) && !unprotect_specialuse) {
         const char *protect = config_getstring(IMAPOPT_SPECIALUSE_PROTECT);
         if (protect) {
             struct buf attrib = BUF_INITIALIZER;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1669,10 +1669,7 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
                                const char *userid,
                                const struct auth_state *auth_state,
                                struct mboxevent *mboxevent,
-                               int checkacl,
-                               int localonly,
-                               int force,
-                               int keep_intermediaries)
+                               int flags)
 {
     mbentry_t *mbentry = NULL;
     mbentry_t *newmbentry = NULL;
@@ -1680,6 +1677,11 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
     char newname[MAX_MAILBOX_BUFFER];
     int r = 0;
     long myrights;
+
+    int checkacl = flags & MBOXLIST_DELETE_CHECKACL;
+    int localonly = flags & MBOXLIST_DELETE_LOCALONLY;
+    int force = flags & MBOXLIST_DELETE_FORCE;
+    int keep_intermediaries = flags & MBOXLIST_DELETE_KEEP_INTERMEDIARIES;
 
     init_internal();
 
@@ -1758,7 +1760,7 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
 
     /* Bump the deletedmodseq of the entries of mbtype. Do not
      * bump the folderdeletedmodseq, yet. We'll take care of
-     * that in mboxlist_deletemailbox_full. */
+     * that in mboxlist_deletemailbox. */
     r = mboxlist_lookup_allow_all(newname, &newmbentry, NULL);
     if (!r) mboxname_setmodseq(newname, newmbentry->foldermodseq,
                                newmbentry->mbtype, MBOXMODSEQ_ISDELETE);
@@ -1785,13 +1787,11 @@ done:
  * 7. delete from mupdate
  *
  */
-EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
-                                         const char *userid,
-                                         const struct auth_state *auth_state,
-                                         struct mboxevent *mboxevent,
-                                         int checkacl,
-                                         int local_only, int force,
-                                         int keep_intermediaries, int silent)
+EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
+                                    const char *userid,
+                                    const struct auth_state *auth_state,
+                                    struct mboxevent *mboxevent,
+                                    int flags)
 {
     mbentry_t *mbentry = NULL;
     int r = 0;
@@ -1799,6 +1799,12 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
     struct mailbox *mailbox = NULL;
     int isremote = 0;
     mupdate_handle *mupdate_h = NULL;
+
+    int checkacl = flags & MBOXLIST_DELETE_CHECKACL;
+    int localonly = flags & MBOXLIST_DELETE_LOCALONLY;
+    int force = flags & MBOXLIST_DELETE_FORCE;
+    int keep_intermediaries = flags & MBOXLIST_DELETE_KEEP_INTERMEDIARIES;
+    int silent = flags & MBOXLIST_DELETE_SILENT;
 
     init_internal();
 
@@ -1897,7 +1903,7 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
     if (r && !force) goto done;
 
     /* remove from mupdate */
-    if (!isremote && !local_only && config_mupdate_server) {
+    if (!isremote && !localonly && config_mupdate_server) {
         /* delete the mailbox in MUPDATE */
         r = mupdate_connect(config_mupdate_server, NULL, &mupdate_h, NULL);
         if (r) {
@@ -1984,31 +1990,15 @@ EXPORTED int mboxlist_deletemailbox_full(const char *name, int isadmin,
     return r;
 }
 
-EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
-                                    const char *userid,
-                                    const struct auth_state *auth_state,
-                                    struct mboxevent *mboxevent,
-                                    int checkacl,
-                                    int local_only, int force,
-                                    int keep_intermediaries)
-{
-    return mboxlist_deletemailbox_full(name, isadmin, userid, auth_state,
-                                       mboxevent, checkacl, local_only, force,
-                                       keep_intermediaries, /*silent*/0);
-}
-
 EXPORTED int mboxlist_deletemailboxlock(const char *name, int isadmin,
                                     const char *userid,
                                     const struct auth_state *auth_state,
                                     struct mboxevent *mboxevent,
-                                    int checkacl,
-                                    int local_only, int force,
-                                    int keep_intermediaries)
+                                    int flags)
 {
     struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
 
-    int r = mboxlist_deletemailbox(name, isadmin, userid, auth_state, mboxevent,
-                                   checkacl, local_only, force, keep_intermediaries);
+    int r = mboxlist_deletemailbox(name, isadmin, userid, auth_state, mboxevent, flags);
 
     mboxname_release(&namespacelock);
     return r;

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -217,40 +217,33 @@ int mboxlist_createsync(const char *name, int mbtype, const char *partition,
                         int keep_intermediaries,
                         struct mailbox **mboxptr);
 
+#define MBOXLIST_DELETE_CHECKACL            (1<<0)
+/* setting local_only disables any communication with the mupdate server
+ * and deletes the mailbox from the filesystem regardless of if it is
+ * MBTYPE_REMOTE or not */
+#define MBOXLIST_DELETE_LOCALONLY           (1<<1)
+/* force ignores errors and just tries to wipe the mailbox off the face of
+ * the planet */
+#define MBOXLIST_DELETE_FORCE               (1<<2)
+#define MBOXLIST_DELETE_KEEP_INTERMEDIARIES (1<<3)
+/* silently delete, do not bump modseq */
+#define MBOXLIST_DELETE_SILENT              (1<<4)
 /* delated delete */
 /* Translate delete into rename */
 /* prepare MailboxDelete notification if mboxevent is not NULL */
 int
 mboxlist_delayed_deletemailbox(const char *name, int isadmin, const char *userid,
                                const struct auth_state *auth_state,
-                               struct mboxevent *mboxevent,
-                               int checkacl,
-                               int localonly, int force, int keep_intermediaries);
+                               struct mboxevent *mboxevent, int flags);
 /* Delete a mailbox. */
-/* setting local_only disables any communication with the mupdate server
- * and deletes the mailbox from the filesystem regardless of if it is
- * MBTYPE_REMOTE or not */
-/* force ignores errors and just tries to wipe the mailbox off the face of
- * the planet */
 /* prepare MailboxDelete notification if mboxevent is not NULL */
 int mboxlist_deletemailbox(const char *name, int isadmin, const char *userid,
                            const struct auth_state *auth_state,
-                           struct mboxevent *mboxevent,
-                           int checkacl,
-                           int local_only, int force, int keep_intermediaries);
-/* same but with silent */
-int mboxlist_deletemailbox_full(const char *name, int isadmin, const char *userid,
-                           const struct auth_state *auth_state,
-                           struct mboxevent *mboxevent,
-                           int checkacl,
-                           int local_only, int force,
-                           int keep_intermediaries, int silent);
+                           struct mboxevent *mboxevent, int flags);
 /* same but wrap with a namespacelock */
 int mboxlist_deletemailboxlock(const char *name, int isadmin, const char *userid,
                            const struct auth_state *auth_state,
-                           struct mboxevent *mboxevent,
-                           int checkacl,
-                           int local_only, int force, int keep_intermediaries);
+                           struct mboxevent *mboxevent, int flags);
 
 /* rename a tree of mailboxes - renames mailbox plus any children */
 int mboxlist_renametree(const char *oldname, const char *newname,

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -228,7 +228,9 @@ int mboxlist_createsync(const char *name, int mbtype, const char *partition,
 #define MBOXLIST_DELETE_KEEP_INTERMEDIARIES (1<<3)
 /* silently delete, do not bump modseq */
 #define MBOXLIST_DELETE_SILENT              (1<<4)
-/* delated delete */
+/* unprotect_specialuse ignores the specialuse_protect config */
+#define MBOXLIST_DELETE_UNPROTECT_SPECIALUSE (1<<5)
+/* delayed delete */
 /* Translate delete into rename */
 /* prepare MailboxDelete notification if mboxevent is not NULL */
 int

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3404,7 +3404,7 @@ static int rmgroup(message_data_t *msg)
 
     if (!r) r = mboxlist_deletemailbox(mailboxname, 0,
                                        newsmaster, newsmaster_authstate,
-                                       1, 0, 0, 0);
+                                       MBOXLIST_DELETE_CHECKACL);
 
     if (!r) sync_log_mailbox(mailboxname);
 

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -146,8 +146,8 @@ static int reset_single(const char *userid)
 
     for (i = mblist->count; i; i--) {
         const char *name = strarray_nth(mblist, i-1);
-        r = mboxlist_deletemailbox(name, 1, sync_userid,
-                                   sync_authstate, NULL, 0, 1, 1, 0);
+        r = mboxlist_deletemailbox(name, 1, sync_userid, sync_authstate, NULL,
+                MBOXLIST_DELETE_LOCALONLY|MBOXLIST_DELETE_FORCE);
         if (r == IMAP_MAILBOX_NONEXISTENT) {
             printf("skipping already removed mailbox %s\n", name);
         }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3383,10 +3383,11 @@ int sync_apply_unmailbox(struct dlist *kin, struct sync_state *sstate)
     struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
 
     /* Delete with admin privileges */
-    int r = mboxlist_deletemailbox_full(mboxname, sstate->userisadmin,
-                                        sstate->userid, sstate->authstate,
-                                        NULL, 0, sstate->local_only, 1, 0,
-                                        /*silent*/1);
+    int delflags = MBOXLIST_DELETE_FORCE | MBOXLIST_DELETE_SILENT;
+    if (sstate->local_only) delflags |= MBOXLIST_DELETE_LOCALONLY;
+    int r = mboxlist_deletemailbox(mboxname, sstate->userisadmin,
+                                   sstate->userid, sstate->authstate,
+                                   NULL, delflags);
 
     mboxname_release(&namespacelock);
 
@@ -3696,11 +3697,13 @@ int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
     if (r) goto done;
 
     /* delete in reverse so INBOX is last */
+    int delflags = MBOXLIST_DELETE_FORCE;
+    if (sstate->local_only) delflags |= MBOXLIST_DELETE_LOCALONLY;
     for (i = list->count; i; i--) {
         const char *name = strarray_nth(list, i-1);
         r = mboxlist_deletemailbox(name, sstate->userisadmin,
                                    sstate->userid, sstate->authstate,
-                                   NULL, 0, sstate->local_only, 1, 0);
+                                   NULL, delflags);
         if (r) goto done;
     }
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -1534,6 +1534,14 @@ EXPORTED void buf_initm(struct buf *buf, char *base, int len)
 }
 
 /*
+ * Initialise a struct buf to point to writable c string str.
+ */
+EXPORTED void buf_initmcstr(struct buf *buf, char *str)
+{
+    buf_initm(buf, str, strlen(str));
+}
+
+/*
  * Initialise a struct buf to point to a read-only C string.
  */
 EXPORTED void buf_init_ro_cstr(struct buf *buf, const char *str)

--- a/lib/util.h
+++ b/lib/util.h
@@ -334,6 +334,7 @@ int buf_findchar(const struct buf *, unsigned int off, int c);
 int buf_findline(const struct buf *buf, const char *line);
 void buf_init_ro(struct buf *buf, const char *base, size_t len);
 void buf_initm(struct buf *buf, char *base, int len);
+void buf_initmcstr(struct buf *buf, char *str);
 void buf_init_ro_cstr(struct buf *buf, const char *str);
 void buf_refresh_mmap(struct buf *buf, int onceonly, int fd,
                    const char *fname, size_t size, const char *mboxname);


### PR DESCRIPTION
This patch makes mailbox role updates in Mailbox/set more sophisticated:

- Similar to changes to the mailbox tree, it predicts the final state of Mailbox roles after all operations in the Mailbox/set method were applied.
If the final state is valid, it suppresses Cyrus regular specialuse checks during mailbox renames and deletes, so that all operations can be applied.
If the final state is invalid, it rejects all operations that would alter a mailbox with specialuse, even if some of these operations would be valid.

IMAP specialuse rules and JMAP roles semantically differ and they impose different rules. This patch only accepts a final mailbox state to be valid if the restrictions of both IMAP and JMAP are satisfied. As a consequence a single role update might require the caller to first "clean up" the whole mailbox tree role assignments to qualify as a valid final mailbox state. This patch attempts to provide as much error description as possible to aid clients with this.

Cassandane tests have been updated at https://github.com/cyrusimap/cassandane/tree/mboxset_role