### PR TITLE
Freebsd admin proc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -650,6 +650,7 @@ cunit_TESTS = \
 	cunit/msgid.testc \
 	cunit/parseaddr.testc \
 	cunit/parse.testc \
+	cunit/procinfo.testc \
 	cunit/prot.testc \
 	cunit/ptrarray.testc \
 	cunit/quota.testc \
@@ -790,6 +791,7 @@ include_HEADERS = \
 	lib/murmurhash2.h \
 	lib/nonblock.h \
 	lib/parseaddr.h \
+	lib/procinfo.h \
 	lib/retry.h \
 	lib/rfc822tok.h \
 	lib/signals.h \
@@ -1470,6 +1472,7 @@ lib_libcyrus_la_SOURCES = \
 	lib/murmurhash.c \
 	lib/mkgmtime.c \
 	lib/parseaddr.c \
+	lib/procinfo.c \
 	lib/prot.c \
 	lib/ptrarray.c \
 	lib/rfc822tok.c \

--- a/cunit/procinfo.testc
+++ b/cunit/procinfo.testc
@@ -1,0 +1,163 @@
+/* unit test for lib/procinfo.c */
+#include <unistd.h> /* for getpid() */
+#include "config.h"
+#include "cunit/cyrunit.h"
+#include "lib/procinfo.h"
+
+static void test_init_piarray(void)
+{
+	piarray_t piarray;
+
+	init_piarray(&piarray);
+
+	CU_ASSERT_EQUAL(piarray.count, 0);
+	CU_ASSERT_EQUAL(piarray.alloc, 0);
+	CU_ASSERT_PTR_NULL(piarray.data);
+}
+
+#if 0
+static void not_test_add_procinfo_generic(void)
+{
+	piarray_t piarray;
+	struct proc_info *pinfo;
+
+	init_piarray(&piarray);
+
+	pinfo = add_procinfo_generic(&piarray, 2342, "service", "host",
+	                             "user", "mailbox", "command");
+
+	CU_ASSERT_PTR_NOT_NULL(pinfo);
+
+	CU_ASSERT_EQUAL(piarray.count, 1);
+	CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
+	CU_ASSERT_PTR_NOT_NULL(piarray.data);
+
+	CU_ASSERT_EQUAL(pinfo->pid, 2342);
+	CU_ASSERT_STRING_EQUAL(pinfo->servicename, "service");
+	CU_ASSERT_STRING_EQUAL(pinfo->user, "user");
+	CU_ASSERT_STRING_EQUAL(pinfo->host, "host");
+	CU_ASSERT_STRING_EQUAL(pinfo->mailbox, "mailbox");
+	CU_ASSERT_STRING_EQUAL(pinfo->cmdname, "command");
+}
+#endif
+
+static void test_add_procinfo(void)
+{
+	piarray_t piarray;
+	struct proc_info *pinfo;
+	int res;
+
+	init_piarray(&piarray);
+
+	res = add_procinfo(getpid(), "service", "host", "user",
+	                   "mailbox", "command", &piarray);
+
+	CU_ASSERT_EQUAL(res, 0);
+
+	CU_ASSERT_EQUAL(piarray.count, 1);
+	CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
+	CU_ASSERT_PTR_NOT_NULL(piarray.data);
+
+	pinfo = piarray.data[0];
+
+	CU_ASSERT_PTR_NOT_NULL(pinfo);
+	CU_ASSERT_EQUAL(pinfo->pid, getpid());
+	CU_ASSERT_STRING_EQUAL(pinfo->servicename, "service");
+	CU_ASSERT_STRING_EQUAL(pinfo->user, "user");
+	CU_ASSERT_STRING_EQUAL(pinfo->host, "host");
+	CU_ASSERT_STRING_EQUAL(pinfo->mailbox, "mailbox");
+	CU_ASSERT_STRING_EQUAL(pinfo->cmdname, "command");
+	CU_ASSERT_STRING_NOT_EQUAL(pinfo->state, "");
+	CU_ASSERT_NOT_EQUAL(pinfo->start, 0);
+	CU_ASSERT_TRUE((pinfo->start <= time(NULL)));
+	CU_ASSERT_TRUE((pinfo->vmsize > 0));
+}
+
+static void test_sort_procinfo(void)
+{
+	piarray_t piarray;
+	struct proc_info *pinfo1, *pinfo2, *pinfo3, *pinfo4;
+	int res;
+
+	init_piarray(&piarray);
+
+	res = add_procinfo(getpid(), "service1", "host1", "user1",
+	                   "mailbox1", "command1", &piarray);
+	CU_ASSERT_EQUAL(res, 0);
+	CU_ASSERT_EQUAL(piarray.count, 1);
+
+	res = add_procinfo(1, "service2", "host2", "user2",
+	                   "mailbox2", "command2", &piarray);
+	CU_ASSERT_EQUAL(res, 0);
+	CU_ASSERT_EQUAL(piarray.count, 2);
+
+	res = add_procinfo(getpid(), "service1", "host1", "user1",
+	                   "mailbox1", "command1", &piarray);
+	CU_ASSERT_EQUAL(res, 0);
+	CU_ASSERT_EQUAL(piarray.count, 3);
+
+	res = add_procinfo(1, "service2", "host2", "user2",
+	                   "mailbox2", "command2", &piarray);
+	CU_ASSERT_EQUAL(res, 0);
+	CU_ASSERT_EQUAL(piarray.count, 4);
+
+	pinfo1 = piarray.data[0];
+	pinfo2 = piarray.data[1];
+
+	snprintf(pinfo1->state, sizeof(pinfo1->state), "%s", "running1");
+	snprintf(pinfo2->state, sizeof(pinfo2->state), "%s", "running2");
+	pinfo1->start = 1;
+	pinfo2->start = 2;
+	pinfo1->vmsize = 1;
+	pinfo2->vmsize = 2;
+
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "p") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "s") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "q") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "t") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "v") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "h") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "u") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "r") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "c") > 0));
+
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "P") > 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "S") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "Q") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "T") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "V") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "H") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "U") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "R") < 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "C") < 0));
+
+	pinfo3 = piarray.data[2];
+	pinfo4 = piarray.data[3];
+
+	snprintf(pinfo3->state, sizeof(pinfo3->state), "%s", "running1");
+	snprintf(pinfo4->state, sizeof(pinfo4->state), "%s", "running2");
+	pinfo3->start = 1;
+	pinfo4->start = 2;
+	pinfo3->vmsize = 1;
+	pinfo4->vmsize = 2;
+
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "p") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "s") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "q") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "t") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "v") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "h") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "u") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "r") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "c") == 0));
+
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "P") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "S") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "Q") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "T") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "V") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "H") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "U") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "R") == 0));
+	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "C") == 0));
+}

--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -65,6 +65,7 @@
 #include "http_proxy.h"
 #include "../master/masterconf.h"
 #include "proc.h"
+#include "procinfo.h"
 #include "proxy.h"
 #include "ptrarray.h"
 #include "time.h"
@@ -406,151 +407,16 @@ static int action_menu(struct transaction_t *txn)
 }
 
 
-struct proc_info {
-    pid_t pid;
-    char *servicename;
-    char *user;
-    char *host;
-    char *mailbox;
-    char *cmdname;
-    char state;
-    time_t start;
-    unsigned long vmsize;
-};
-
-typedef struct {
-    unsigned count;
-    unsigned alloc;
-    struct proc_info **data;
-} piarray_t;
-
-static int add_procinfo(pid_t pid,
-                        const char *servicename, const char *host,
-                        const char *user, const char *mailbox,
-                        const char *cmdname,
-                        void *rock)
-{
-    piarray_t *piarray = (piarray_t *) rock;
-    struct proc_info *pinfo;
-    char procpath[100];
-    struct stat sbuf;
-    FILE *f;
-
-    snprintf(procpath, sizeof(procpath), "/proc/%d", pid);
-    if (stat(procpath, &sbuf)) return 0;
-
-    if (piarray->count >= piarray->alloc) {
-        piarray->alloc += 100;
-        piarray->data = xrealloc(piarray->data,
-                                 piarray->alloc * sizeof(struct proc_info *));
-    }
-
-    pinfo = piarray->data[piarray->count++] =
-        (struct proc_info *) xzmalloc(sizeof(struct proc_info));
-    pinfo->pid = pid;
-    pinfo->servicename = xstrdupsafe(servicename);
-    pinfo->host = xstrdupsafe(host);
-    pinfo->user = xstrdupsafe(user);
-    pinfo->mailbox = xstrdupsafe(mailbox);
-    pinfo->cmdname = xstrdupsafe(cmdname);
-
-    strlcat(procpath, "/stat", sizeof(procpath));
-    f = fopen(procpath, "r");
-    if (f) {
-        int d;
-        long ld;
-        unsigned u;
-        unsigned long vmsize = 0, lu;
-        unsigned long long starttime = 0;
-        char state = 0, *s = NULL;
-
-        int c = fscanf(f, "%d %ms %c " /* 1-3 */
-               "%d %d %d %d %d %u " /* 4-9 */
-               "%lu %lu %lu %lu %lu %lu " /* 10-15 */
-               "%ld %ld %ld %ld %ld %ld " /* 16-21 */
-               "%llu %lu %ld", /* 22-24 */
-               &d, &s, &state,
-               &d, &d, &d, &d, &d, &u,
-               &lu, &lu, &lu, &lu, &lu, &lu,
-               &ld, &ld, &ld, &ld, &ld, &ld,
-               &starttime, &vmsize, &ld);
-
-        free(s);
-        fclose(f);
-
-        if (c != EOF) {
-            pinfo->state = state;
-            pinfo->vmsize = vmsize;
-            pinfo->start = starttime/sysconf(_SC_CLK_TCK);
-        }
-    }
-
-    return 0;
-}
-
-static int sort_procinfo QSORT_R_COMPAR_ARGS(
-                         const void *pa, const void *pb,
-                         void *k)
-{
-    int r;
-    const struct proc_info **a = (const struct proc_info**)pa;
-    const struct proc_info **b = (const struct proc_info**)pb;
-    char *key = (char*)k;
-    int rev = islower((int) *key);
-
-    switch (toupper((int) *key)) {
-    default:
-    case 'P':
-        r = (*a)->pid - (*b)->pid;
-        break;
-
-    case 'S':
-        r = strcmp((*a)->servicename, (*b)->servicename);
-        break;
-
-    case 'Q':
-        r = (*a)->state - (*b)->state;
-        break;
-
-    case 'T':
-        r = (*a)->start - (*b)->start;
-        break;
-
-    case 'V':
-        r = (*a)->vmsize - (*b)->vmsize;
-        break;
-
-    case 'H':
-        r = strcmp((*a)->host, (*b)->host);
-        break;
-
-    case 'U':
-        r = strcmp((*a)->user, (*b)->user);
-        break;
-
-    case 'R':
-        r = strcmp((*a)->mailbox, (*b)->mailbox);
-        break;
-
-    case 'C':
-        r = strcmp((*a)->cmdname, (*b)->cmdname);
-        break;
-    }
-
-    return (rev ? -r : r);
-}
-
 /* Perform a proc action */
 static int action_proc(struct transaction_t *txn)
 {
     unsigned level = 0, i;
     struct buf *body = &txn->resp_body.payload;
-    piarray_t piarray = { 0, 0, NULL };
-    time_t now = time(0), boot_time = 0;
+    piarray_t piarray;
+    time_t now = time(0);
     struct strlist *param;
     struct tm tnow;
     char key = 0;
-    FILE *f;
     struct proc_columns {
         char key;
         const char *name;
@@ -596,18 +462,7 @@ static int action_proc(struct transaction_t *txn)
         columns[0].key = 'p';
     }
 
-    /* Find boot time in /proc/stat (needed for calculating process start) */
-    f = fopen("/proc/stat", "r");
-    if (f) {
-        char buf[1024];
-
-        while (fgets(buf, sizeof(buf), f)) {
-            if (sscanf(buf, "btime %ld\n", &boot_time) == 1) break;
-            while (buf[strlen(buf)-1] != '\n' && fgets(buf, sizeof(buf), f)) {
-            }
-        }
-        fclose(f);
-    }
+    init_piarray(&piarray);
 
     /* Get and sort info for running processes */
     proc_foreach(add_procinfo, &piarray);
@@ -651,45 +506,29 @@ static int action_proc(struct transaction_t *txn)
         buf_printf_markup(body, level, "<td>%d</td>", (int) pinfo->pid);
         buf_printf_markup(body, level, "<td>%s</td>", pinfo->servicename);
 
-        if (pinfo->vmsize) {
-            const char *proc_states[] = {
-                /* A */ "", /* B */ "", /* C */ "",
-                /* D */ " (waiting)",
-                /* E */ "", /* F */ "", /* G */ "", /* H */ "", /* I */ "",
-                /* J */ "", /* K */ "", /* L */ "", /* M */ "", /* N */ "",
-                /* O */ "", /* P */ "", /* Q */ "",
-                /* R */ " (running)",
-                /* S */ " (sleeping)",
-                /* T */ " (stopped)",
-                /* U */ "", /* V */ "",
-                /* W */ " (paging)",
-                /* X */ "", /* Y */ "",
-                /* Z */ " (zombie)"
-            };
+        buf_printf_markup(body, level, "<td>%s</td>", pinfo->state);
 
-            buf_printf_markup(body, level, "<td>%c%s</td>", pinfo->state,
-                              isupper((int) pinfo->state) ?
-                              proc_states[pinfo->state - 'A'] : "");
+        if (pinfo->start) {
+            struct tm start;
 
-            if (boot_time) {
-                struct tm start;
-
-                pinfo->start += boot_time;
-                localtime_r(&pinfo->start, &start);
-                if (start.tm_yday != tnow.tm_yday) {
-                    buf_printf_markup(body, level, "<td>%s %02d</td>",
-                                      monthname[start.tm_mon], start.tm_mday);
-                }
-                else {
-                    buf_printf_markup(body, level, "<td>%02d:%02d</td>",
-                                      start.tm_hour, start.tm_min);
-                }
+            localtime_r(&pinfo->start, &start);
+            if (start.tm_yday != tnow.tm_yday) {
+                buf_printf_markup(body, level, "<td>%s %02d</td>",
+                                  monthname[start.tm_mon], start.tm_mday);
             }
-            else buf_printf_markup(body, level, "<td></td>");
-                              
-            buf_printf_markup(body, level, "<td>%lu</td>", pinfo->vmsize/1024);
+            else {
+                buf_printf_markup(body, level, "<td>%02d:%02d</td>",
+                                  start.tm_hour, start.tm_min);
+            }
+        } else {
+            buf_printf_markup(body, level, "<td></td>");
         }
-        else buf_printf_markup(body, level, "<td></td><td></td><td></td>");
+
+        if (pinfo->vmsize) {
+            buf_printf_markup(body, level, "<td>%lu</td>", pinfo->vmsize/1024);
+        } else {
+            buf_printf_markup(body, level, "<td></td>");
+        }
 
         buf_printf_markup(body, level, "<td>%s</td>", pinfo->host);
         buf_printf_markup(body, level, "<td>%s</td>", pinfo->user);
@@ -704,7 +543,8 @@ static int action_proc(struct transaction_t *txn)
         free(pinfo->cmdname);
         free(pinfo);
     }
-    free(piarray.data);
+
+    deinit_piarray(&piarray);
 
     /* Finish table */
     buf_printf_markup(body, --level, "</table>");

--- a/lib/procinfo.c
+++ b/lib/procinfo.c
@@ -1,0 +1,491 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include "procinfo.h"
+#include "xmalloc.h"
+#include "xstrlcat.h"
+
+static struct proc_info *
+add_procinfo_generic(piarray_t *piarray, pid_t pid, const char *servicename,
+                     const char *host, const char *user, const char *mailbox,
+                     const char *cmdname)
+{
+    struct proc_info *pinfo;
+
+    if (piarray->count >= piarray->alloc) {
+        piarray->alloc += 100;
+        piarray->data = xrealloc(piarray->data,
+                                 piarray->alloc * sizeof(struct proc_info *));
+    }
+
+    pinfo = piarray->data[piarray->count++] =
+        (struct proc_info *) xzmalloc(sizeof(struct proc_info));
+    pinfo->pid = pid;
+    pinfo->servicename = xstrdupsafe(servicename);
+    pinfo->host = xstrdupsafe(host);
+    pinfo->user = xstrdupsafe(user);
+    pinfo->mailbox = xstrdupsafe(mailbox);
+    pinfo->cmdname = xstrdupsafe(cmdname);
+
+    return pinfo;
+}
+
+EXPORTED int sort_procinfo QSORT_R_COMPAR_ARGS(
+                           const void *pa, const void *pb, void *k)
+{
+    int r;
+    const struct proc_info **a = (const struct proc_info**)pa;
+    const struct proc_info **b = (const struct proc_info**)pb;
+    char *key = (char*)k;
+    int rev = islower((int) *key);
+
+    switch (toupper((int) *key)) {
+    default:
+    case 'P':
+        r = (*a)->pid - (*b)->pid;
+        break;
+
+    case 'S':
+        r = strcmp((*a)->servicename, (*b)->servicename);
+        break;
+
+    case 'Q':
+        r = strcmp((*a)->state, (*b)->state);
+        break;
+
+    case 'T':
+        r = (*a)->start - (*b)->start;
+        break;
+
+    case 'V':
+        r = (*a)->vmsize - (*b)->vmsize;
+        break;
+
+    case 'H':
+        r = strcmp((*a)->host, (*b)->host);
+        break;
+
+    case 'U':
+        r = strcmp((*a)->user, (*b)->user);
+        break;
+
+    case 'R':
+        r = strcmp((*a)->mailbox, (*b)->mailbox);
+        break;
+
+    case 'C':
+        r = strcmp((*a)->cmdname, (*b)->cmdname);
+        break;
+    }
+
+    return (rev ? -r : r);
+}
+
+EXPORTED void deinit_piarray(piarray_t *piarray)
+{
+    free(piarray->data);
+}
+
+#if defined __OpenBSD__
+
+#include <fcntl.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+
+EXPORTED void init_piarray(piarray_t *piarray)
+{
+    size_t size;
+    static const int mib_ncpu[2] = { CTL_HW, HW_NCPU };
+
+    piarray->count = 0;
+    piarray->alloc = 0;
+    piarray->data = NULL;
+
+    size = sizeof(piarray->ncpu);
+    if (sysctl(mib_ncpu, sizeof(mib_ncpu)/sizeof(mib_ncpu[0]),
+               &piarray->ncpu, &size, NULL, 0) == -1) {
+        piarray->ncpu = 1;
+    }
+}
+
+EXPORTED int add_procinfo(pid_t pid, const char *servicename,
+                          const char *host, const char *user,
+                          const char *mailbox, const char *cmdname,
+                          void *rock)
+{
+    piarray_t *piarray = (piarray_t *) rock;
+    struct proc_info *pinfo;
+    struct kinfo_proc kip;
+    int cnt;
+    size_t size;
+    static const char *state_abbrev[] = {
+        "", "start", "run", "sleep", "stop", "zomb", "dead", "onproc"
+    };
+    int mib[6] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, 0, sizeof(kip), 1 };
+
+    mib[3] = pid;
+    size = sizeof(kip);
+    cnt = sysctl(mib, sizeof(mib)/sizeof(mib[0]), &kip, &size, NULL, 0);
+    if ((cnt == -1) || ((size / sizeof(kip)) != 1)) {
+        return 0;
+    }
+
+    pinfo = add_procinfo_generic(piarray, pid, servicename, host,
+                                 user, mailbox, cmdname);
+
+    pinfo->vmsize = kip.p_vm_rssize * sysconf(_SC_PAGESIZE);
+    pinfo->start = kip.p_ustart_sec;
+
+    /* based on OpenBSD's /usr/src/usr.bin/top/machine.c, rev 1.110 */
+    if (kip.p_wmesg[0]) {
+        snprintf(pinfo->state, sizeof(pinfo->state), "%s", kip.p_wmesg);
+    } else if ((piarray->ncpu > 1) && (kip.p_cpuid != KI_NOCPU)) {
+        snprintf(pinfo->state, sizeof(pinfo->state), "%s/%llu",
+                 state_abbrev[kip.p_stat], kip.p_cpuid);
+    } else {
+        snprintf(pinfo->state, sizeof(pinfo->state), "%s",
+                 state_abbrev[kip.p_stat]);
+    }
+
+    return 0;
+}
+
+#elif defined __NetBSD__
+
+#include <fcntl.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+
+EXPORTED void init_piarray(piarray_t *piarray)
+{
+    size_t size;
+    static const int mib_ncpu[2] = { CTL_HW, HW_NCPU };
+
+    piarray->count = 0;
+    piarray->alloc = 0;
+    piarray->data = NULL;
+
+    size = sizeof(piarray->ncpu);
+    if (sysctl(mib_ncpu, sizeof(mib_ncpu)/sizeof(mib_ncpu[0]),
+               &piarray->ncpu, &size, NULL, 0) == -1) {
+        piarray->ncpu = 1;
+    }
+}
+
+EXPORTED int add_procinfo(pid_t pid, const char *servicename,
+                          const char *host, const char *user,
+                          const char *mailbox, const char *cmdname,
+                          void *rock)
+{
+    piarray_t *piarray = (piarray_t *) rock;
+    struct proc_info *pinfo;
+    struct kinfo_proc2 kip;
+    int cnt;
+    size_t size;
+    static const char *state_abbrev[] = {
+        "", "IDLE", "RUN", "SLEEP", "STOP", "ZOMB", "DEAD", "CPU"
+    };
+    int mib[6] = { CTL_KERN, KERN_PROC2, KERN_PROC_PID, 0, sizeof(kip), 1 };
+
+    mib[3] = pid;
+    size = sizeof(kip);
+    cnt = sysctl(mib, sizeof(mib)/sizeof(mib[0]), &kip, &size, NULL, 0);
+    if ((cnt == -1) || ((size / sizeof(kip)) != 1)) {
+        return 0;
+    }
+
+    pinfo = add_procinfo_generic(piarray, pid, servicename, host,
+                                 user, mailbox, cmdname);
+
+    pinfo->vmsize = kip.p_vm_rssize * sysconf(_SC_PAGESIZE);
+    pinfo->start = kip.p_ustart_sec;
+
+    /* based on NetBSD's /usr/src/external/bsd/top/dist/machine/m_netbsd.c,
+       rev 1.23 */
+    if ((kip.p_cpuid != KI_NOCPU) && (piarray->ncpu > 1)) {
+        if (kip.p_stat == LSSLEEP) {
+            snprintf(pinfo->state, sizeof(pinfo->state), "%.6s/%lu",
+                     kip.p_wmesg, kip.p_cpuid);
+        } else {
+            snprintf(pinfo->state, sizeof(pinfo->state), "%.6s/%lu",
+                     state_abbrev[(unsigned)kip.p_stat], kip.p_cpuid);
+        }
+    } else if (kip.p_stat == LSSLEEP) {
+        snprintf(pinfo->state, sizeof(pinfo->state), "%s", kip.p_wmesg);
+    } else {
+        snprintf(pinfo->state, sizeof(pinfo->state), "%s",
+                 state_abbrev[(unsigned)kip.p_stat]);
+    }
+
+    return 0;
+}
+
+#elif defined __DragonFly__
+
+#include <fcntl.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/kinfo.h>
+#include <sys/thread.h>
+
+EXPORTED void init_piarray(piarray_t *piarray)
+{
+    piarray->count = 0;
+    piarray->alloc = 0;
+    piarray->data = NULL;
+}
+
+EXPORTED int add_procinfo(pid_t pid, const char *servicename,
+                          const char *host, const char *user,
+                          const char *mailbox, const char *cmdname,
+                          void *rock)
+{
+    piarray_t *piarray = (piarray_t *) rock;
+    struct proc_info *pinfo;
+    struct kinfo_proc kip;
+    int cnt;
+    size_t state, size;
+    static const char *state_abbrev[] = {
+        "", "START", "RUN", "SLEEP", "STOP", "ZOMB", "WAIT", "LOCK"
+    };
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, 0 };
+
+    mib[3] = pid;
+    size = sizeof(kip);
+    cnt = sysctl(mib, sizeof(mib)/sizeof(mib[0]), &kip, &size, NULL, 0);
+    if ((cnt == -1) || ((size / sizeof(kip)) != 1)) {
+        return 0;
+    }
+
+    pinfo = add_procinfo_generic(piarray, pid, servicename, host,
+                                 user, mailbox, cmdname);
+
+    pinfo->vmsize = kip.kp_vm_rssize * sysconf(_SC_PAGESIZE);
+    pinfo->start = kip.kp_start.tv_sec;
+
+    /* based on DragonFlyBSD's /usr/src/usr.bin/top/m_dragonfly.c,
+       HEAD from 2020-09-06 */
+    if (kip.kp_stat == SZOMB) {
+        snprintf(pinfo->state, sizeof(pinfo->state), "%s", "ZOMB");
+    } else {
+        switch (state = kip.kp_lwp.kl_stat) {
+        case LSRUN:
+            if (kip.kp_lwp.kl_tdflags & TDF_RUNNING) {
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "CPU%d", kip.kp_lwp.kl_cpuid);
+            } else {
+                snprintf(pinfo->state, sizeof(pinfo->state), "%s", "RUN");
+            }
+        break;
+        case LSSLEEP:
+            if (kip.kp_lwp.kl_wmesg != NULL) {
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "%.8s", kip.kp_lwp.kl_wmesg);
+                break;
+            }
+            /* fall through */
+        default:
+            if (state < sizeof(state_abbrev)/sizeof(state_abbrev[0])) {
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "%.6s", state_abbrev[state]);
+            } else {
+                snprintf(pinfo->state, sizeof(pinfo->state), "?%5lu", state);
+            }
+            break;
+        }
+    }
+
+    return 0;
+}
+
+#elif defined __FreeBSD__
+
+#include <fcntl.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/user.h>
+
+EXPORTED void init_piarray(piarray_t *piarray)
+{
+    size_t size;
+    static const int mib_ncpu[2] = { CTL_HW, HW_NCPU };
+
+    piarray->count = 0;
+    piarray->alloc = 0;
+    piarray->data = NULL;
+
+    size = sizeof(piarray->ncpu);
+    if (sysctl(mib_ncpu, sizeof(mib_ncpu)/sizeof(mib_ncpu[0]),
+               &piarray->ncpu, &size, NULL, 0) == -1) {
+        piarray->ncpu = 1;
+    }
+}
+
+EXPORTED int add_procinfo(pid_t pid, const char *servicename,
+                          const char *host, const char *user,
+                          const char *mailbox, const char *cmdname,
+                          void *rock)
+{
+    piarray_t *piarray = (piarray_t *) rock;
+    struct proc_info *pinfo;
+    struct kinfo_proc kip;
+    int cnt;
+    size_t state, size;
+    static const char *state_abbrev[] = {
+        "", "START", "RUN", "SLEEP", "STOP", "ZOMB", "WAIT", "LOCK"
+    };
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, 0 };
+
+    mib[3] = pid;
+    size = sizeof(kip);
+    cnt = sysctl(mib, sizeof(mib)/sizeof(mib[0]), &kip, &size, NULL, 0);
+    if ((cnt == -1) || ((size / sizeof(kip)) != 1)) {
+        return 0;
+    }
+
+    pinfo = add_procinfo_generic(piarray, pid, servicename, host,
+                                 user, mailbox, cmdname);
+
+    pinfo->vmsize = kip.ki_rssize * sysconf(_SC_PAGESIZE);
+    pinfo->start = kip.ki_start.tv_sec;
+
+    /* based on FreeBSD's /usr/src/usr.bin/top/machine.c
+       from 12.1-RELEASE-p9 */
+    switch (state = kip.ki_stat) {
+        case SRUN:
+            if (piarray->ncpu > 1 && kip.ki_oncpu != NOCPU)
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "CPU%d", kip.ki_oncpu);
+            else
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "%s", "RUN");
+            break;
+        case SLOCK:
+            if (kip.ki_kiflag & KI_LOCKBLOCK) {
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "*%s", kip.ki_lockname);
+                break;
+            }
+            /* fall through */
+        case SSLEEP:
+            snprintf(pinfo->state, sizeof(pinfo->state),
+                     "%.6s", kip.ki_wmesg);
+            break;
+        default:
+            if (state < sizeof(state_abbrev)/sizeof(state_abbrev[0])) {
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "%.6s", state_abbrev[state]);
+            } else {
+                snprintf(pinfo->state, sizeof(pinfo->state),
+                         "?%5zu", state);
+            }
+            break;
+    }
+
+    return 0;
+}
+
+#else /* xBSD */
+
+EXPORTED void init_piarray(piarray_t *piarray)
+{
+    FILE *f;
+    char buf[1024];
+
+    piarray->count = 0;
+    piarray->alloc = 0;
+    piarray->data = NULL;
+    piarray->boot_time = 0;
+
+    /* Find boot time in /proc/stat (needed for calculating process start) */
+    f = fopen("/proc/stat", "r");
+    if (f) {
+        while (fgets(buf, sizeof(buf), f)) {
+            if (sscanf(buf, "btime %ld\n", &piarray->boot_time) == 1) break;
+            while (buf[strlen(buf)-1] != '\n' && fgets(buf, sizeof(buf), f)) {
+            }
+        }
+        fclose(f);
+    }
+}
+
+EXPORTED int add_procinfo(pid_t pid, const char *servicename, const char *host,
+                          const char *user, const char *mailbox,
+                          const char *cmdname, void *rock)
+{
+    piarray_t *piarray = (piarray_t *) rock;
+    struct proc_info *pinfo;
+    char procpath[100];
+    struct stat sbuf;
+    FILE *f;
+    int res, d;
+    long ld;
+    unsigned u;
+    unsigned long vmsize = 0, lu;
+    unsigned long long starttime = 0;
+    char state = 0, *s = NULL;
+    static const char *proc_states[] = {
+        /* A */ "", /* B */ "", /* C */ "",
+        /* D */ " (waiting)",
+        /* E */ "", /* F */ "", /* G */ "", /* H */ "", /* I */ "",
+        /* J */ "", /* K */ "", /* L */ "", /* M */ "", /* N */ "",
+        /* O */ "", /* P */ "", /* Q */ "",
+        /* R */ " (running)",
+        /* S */ " (sleeping)",
+        /* T */ " (stopped)",
+        /* U */ "", /* V */ "",
+        /* W */ " (paging)",
+        /* X */ "", /* Y */ "",
+        /* Z */ " (zombie)"
+    };
+
+    snprintf(procpath, sizeof(procpath), "/proc/%d", pid);
+    if (stat(procpath, &sbuf)) {
+        return 0;
+    }
+
+    pinfo = add_procinfo_generic(piarray, pid, servicename, host,
+                                 user, mailbox, cmdname);
+
+    strlcat(procpath, "/stat", sizeof(procpath));
+    f = fopen(procpath, "r");
+    if (!f) {
+        return 0;
+    }
+
+    res = fscanf(f,
+                 "%d %ms %c " /* 1-3 */
+                 "%d %d %d %d %d %u " /* 4-9 */
+                 "%lu %lu %lu %lu %lu %lu " /* 10-15 */
+                 "%ld %ld %ld %ld %ld %ld " /* 16-21 */
+                 "%llu %lu %ld", /* 22-24 */
+                 &d, &s, &state,
+                 &d, &d, &d, &d, &d, &u,
+                 &lu, &lu, &lu, &lu, &lu, &lu,
+                 &ld, &ld, &ld, &ld, &ld, &ld,
+                 &starttime, &vmsize, &ld);
+
+    free(s);
+    fclose(f);
+
+    if (res == EOF) {
+        return 0;
+    }
+
+    snprintf(pinfo->state, sizeof(pinfo->state), "%c%s", state,
+             isupper((int) state) ? proc_states[state - 'A'] : "");
+    pinfo->vmsize = vmsize;
+
+    if (piarray->boot_time) {
+        pinfo->start = starttime/sysconf(_SC_CLK_TCK) + piarray->boot_time;
+    }
+
+    return 0;
+}
+
+#endif /* !xBSD */

--- a/lib/procinfo.h
+++ b/lib/procinfo.h
@@ -1,0 +1,38 @@
+#ifndef INCLUDED_PROCINFO_H
+#define INCLUDED_PROCINFO_H
+
+#include <config.h>
+#include <sys/types.h>
+#include <time.h>
+
+#include "cyr_qsort_r.h"
+
+struct proc_info {
+    pid_t pid;
+    char *servicename;
+    char *user;
+    char *host;
+    char *mailbox;
+    char *cmdname;
+    char state[22];
+    time_t start;
+    unsigned long vmsize; /* in bytes */
+};
+
+typedef struct {
+    unsigned count;
+    unsigned alloc;
+    struct proc_info **data;
+    time_t boot_time; /* not used on xBSD */
+    int ncpu; /* not used on Linux */
+} piarray_t;
+
+extern void init_piarray(piarray_t *piarray);
+extern void deinit_piarray(piarray_t *piarray);
+extern int add_procinfo(pid_t pid, const char *servicename, const char *host,
+                        const char *user, const char *mailbox,
+                        const char *cmdname, void *rock);
+extern int sort_procinfo QSORT_R_COMPAR_ARGS(
+                         const void *pa, const void *pb, void *k);
+
+#endif /* INCLUDED_PROCINFO_H */


### PR DESCRIPTION
On FreeBSD, /admin/proc displays no values for state, start, and vmsize:

![Bildschirmfoto_2020-08-31_23-47-32](https://user-images.githubusercontent.com/14083054/91893338-42e76f80-ec94-11ea-8208-468074896340.png)

The /proc filesystem is not mounted on a default system, and if so, there's no /proc/stat, and also no /proc/$pid/stat. There are /proc/$pid/status entries, but these do not offer a vmsize nor a full process state.
This patch makes use of the libkvm library (see `man 3 kvm`) to gather process details like top(1) or procstat(1) do. kvm has been available since FreeBSD 9. Sample output:

![Bildschirmfoto_2020-09-01_01-43-43](https://user-images.githubusercontent.com/14083054/91893538-91950980-ec94-11ea-9d7a-42aa1951952a.png)

I never used autoconf/automake before, and i'm not happy with all the `#ifdef HAVE_LIBKVM` in imap/http_admin.c. Also, both `imap/index.h` and `/usr/include/sys/proc.h` define a `struct thread`. So, what would be the best way to get this right? Two OS specific imap/http_admin_linux.c and http_admin_freebsd.c, each with its own add_procinfo() and output routines?