### PR TITLE
cyr_qsort_r: only compile fallback function if we need it

### DIFF
--- a/lib/cyr_qsort_r.c
+++ b/lib/cyr_qsort_r.c
@@ -1,5 +1,7 @@
 #include "cyr_qsort_r.h"
 
+#ifndef cyr_qsort_r
+
 #ifdef HAVE_FUNCTION_NESTING
 
 EXPORTED void cyr_qsort_r(void *base, size_t nmemb, size_t size,
@@ -35,4 +37,6 @@ EXPORTED void cyr_qsort_r(void *base, size_t nmemb, size_t size,
     qsort_r_compar = NULL;
 }
 
-#endif
+#endif /* HAVE_FUNCTION_NESTING */
+
+#endif /* cyr_qsort_r */


### PR DESCRIPTION
This is the fix for #3154, in which we discovered that we were accidentally (by way of macro expansion in cyr_qsort_r.c) replacing the real `qsort_r()` with our last resort fallback function, instead of simply having it as a last resort fallback.

The patch is fairly trivial and I think obviously correct (and works fine for me), BUT it has the "side effect" that we're now definitely using the real `qsort_r()`, whereas before we might not have been (depending on link order, I guess).

So I'd appreciate if we could all give this a thorough test before we merge it, just in case some new edge case shakes out from switching underlying implementations.