### PR TITLE
Not all systems have memrchr()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,7 @@ dnl check for -R, etc. switch
 CMU_GUESS_RUNPATH_SWITCH
 
 AC_CHECK_HEADERS(unistd.h sys/select.h sys/param.h stdarg.h)
-AC_REPLACE_FUNCS(memmove strcasecmp ftruncate strerror posix_fadvise strsep memmem)
+AC_REPLACE_FUNCS(memmove strcasecmp ftruncate strerror posix_fadvise strsep memmem memrchr)
 AC_CHECK_FUNCS(strlcat strlcpy strnchr getgrouplist fmemopen pselect futimens futimes)
 AC_HEADER_DIRENT
 
@@ -2354,6 +2354,10 @@ extern char *strsep(char **, const char *);
 
 #ifndef HAVE_MEMMEM
 extern void *memmem(const void *, size_t, const void *, size_t);
+#endif
+
+#ifndef HAVE_MEMRCHR
+extern void *memrchr(const void *, int, size_t);
 #endif
 
 /* compile time options; think carefully before modifying */

--- a/lib/memrchr.c
+++ b/lib/memrchr.c
@@ -1,0 +1,64 @@
+/* memrchr.c -- replacement memrchr() routine
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+/*
+ * Reverse memchr()
+ * memrchr() is a GNU extension and not available on all platforms
+ */
+void *
+memrchr(const void *s, int c1, size_t n)
+{
+    if (n != 0) {
+        const unsigned char *sp = (unsigned char *)s + n;
+        unsigned char c = (unsigned char)c1;
+
+        do {
+            if (*(--sp) == c)
+                return((void *)sp);
+        } while (--n != 0);
+    }
+    return NULL;
+}
+


### PR DESCRIPTION
I've just finished packaging Cyrus imapd for OmniOS which is an illumos (née OpenSolaris) distribution.

There were a few small compatibility changes needed, this is the first.