### PR TITLE
Not all systems have futimes() or TIMESPEC_TO_TIMEVAL()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,7 +194,7 @@ CMU_GUESS_RUNPATH_SWITCH
 
 AC_CHECK_HEADERS(unistd.h sys/select.h sys/param.h stdarg.h)
 AC_REPLACE_FUNCS(memmove strcasecmp ftruncate strerror posix_fadvise strsep memmem)
-AC_CHECK_FUNCS(strlcat strlcpy strnchr getgrouplist fmemopen pselect)
+AC_CHECK_FUNCS(strlcat strlcpy strnchr getgrouplist fmemopen pselect futimens futimes)
 AC_HEADER_DIRENT
 
 dnl check whether to use getpassphrase or getpass

--- a/lib/util.c
+++ b/lib/util.c
@@ -604,10 +604,25 @@ static int _copyfile_helper(const char *from, const char *to, int flags)
     }
 
     if (keeptime) {
+        int ret;
+#if defined(HAVE_FUTIMENS)
+        struct timespec ts[2];
+
+        ts[0] = sbuf.st_atim;
+        ts[1] = sbuf.st_mtim;
+        ret = futimens(destfd, ts);
+#elif defined(HAVE_FUTIMES)
         struct timeval tv[2];
+
         TIMESPEC_TO_TIMEVAL(&tv[0], &sbuf.st_atim);
         TIMESPEC_TO_TIMEVAL(&tv[1], &sbuf.st_mtim);
-        if (futimes(destfd, tv)) {
+        ret = futimes(destfd, tv);
+#else
+        close(destfd);
+        destfd = -1;
+        ret = utimes(to, tv);
+#endif
+        if (ret) {
             syslog(LOG_ERR, "IOERROR: setting times on %s: %m", to);
             r = -1;
         }

--- a/lib/util.h
+++ b/lib/util.h
@@ -148,6 +148,13 @@ extern const unsigned char convert_to_uppercase[256];
 /* Calculate the number of entries in a vector */
 #define VECTOR_SIZE(vector) (sizeof(vector)/sizeof(vector[0]))
 
+#ifndef TIMESPEC_TO_TIMEVAL
+#define TIMESPEC_TO_TIMEVAL(tv, ts) { \
+        (tv)->tv_sec = (ts)->tv_sec; \
+        (tv)->tv_usec = (ts)->tv_nsec / 1000; \
+}
+#endif
+
 typedef struct keyvalue {
     char *key, *value;
 } keyvalue;


### PR DESCRIPTION
The `futimes()` function is not standardised and only available in Linux and some BSDs.

Check if it exists before using it, and fall back to alternatives.

The TIMESPEC_TO_TIMEVAL() macro is also not available on all platforms.