### PR TITLE
user_sieve_path() needs to work around caret-escaped userids

### DIFF
--- a/imap/user.c
+++ b/imap/user.c
@@ -133,10 +133,21 @@ static int user_deleteacl(char *name, int matchlen, int category, void* rock)
 }
 #endif
 
-EXPORTED const char *user_sieve_path(const char *user)
+EXPORTED const char *user_sieve_path(const char *inuser)
 {
     static char sieve_path[2048];
     char hash, *domain;
+    char *user = xstrdupnull(inuser);
+    char *p;
+
+    /* Make sure it's a real userid, with no ^ escaping!
+     * XXX It's kinda bogus to be handling this here; it should be fixed
+     * XXX much further up somewhere, but that may require deep surgery.
+     */
+    for (p = user; p && *p; p++) {
+        if (*p == '^')
+            *p = '.';
+    }
 
     if (config_virtdomains && (domain = strchr(user, '@'))) {
         char d = (char) dir_hash_c(domain+1, config_fulldirhash);
@@ -154,6 +165,7 @@ EXPORTED const char *user_sieve_path(const char *user)
                  config_getstring(IMAPOPT_SIEVEDIR), hash, user);
     }
 
+    free(user);
     return sieve_path;
 }
 


### PR DESCRIPTION
This is the minimally-intrusive fix for #3169 that I plan to roll out for 3.2, and I would like to also add it to master so we don't get out of sync.  A real fix will probably take some surgery in the mbname API, which would be nice to do, but not for 3.2.

The problem hereby solved manifests when replicating from 2.4 with unixhierarchysep, which caret-escapes localpart dots in the sync USERID fields(!).  It's mostly quietly glossed over and not a problem; but if you're replicating sieve scripts specifically and you have fulldirhash enabled, then a modern-day replica hashes the caret-escaped version of the userid instead of the real userid, and puts the uploaded/activated scripts in the wrong on-disk location, where nothing else can find them.

My patch has been confirmed to fix the problem by the user that reported it.  But I would like some other eyes/brains on this before I merge it, in case there's a better unintrusive approach, or a subtlety I've missed and need to consider.