### PR TITLE
DEBUG: syslog lock ordering to track deadlocks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,7 @@ if HAVE_LDAP
 AM_CPPFLAGS += $(LDAP_CPPFLAGS)
 endif # HAVE_LDAP
 
-AM_LDFLAGS = $(COV_LDFLAGS) $(ICU_LIBS)
+AM_LDFLAGS = $(COV_LDFLAGS) $(ICU_LIBS) -ldl
 
 # have distcheck try to build with all optional components enabled, to aid
 # detection of missing files for these components
@@ -1569,6 +1569,7 @@ lib_libcyrus_min_la_SOURCES = \
 	lib/hashu64.c \
 	lib/libconfig.c \
 	lib/mpool.c \
+	lib/ptrarray.c \
 	lib/retry.c \
 	lib/smallarrayu64.c \
 	lib/strarray.c \

--- a/cassandane/Cassandane/Cyrus/Expunge.pm
+++ b/cassandane/Cassandane/Cyrus/Expunge.pm
@@ -261,6 +261,9 @@ sub test_ipurge_mboxevent
     );
     my $events = $self->{instance}->getnotify();
 
+    # if it stays selected you see the intermittent state
+    $talk->unselect();
+
     # the messages we just created should've been expunged
     $stat = $talk->status($shared_folder, '(highestmodseq unseen messages)');
     $self->assert_num_equals(0, $stat->{unseen});

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -375,15 +375,13 @@ EXPORTED int conversations_open_path(const char *fname, const char *userid, int 
     open_conversations = open;
 
     /* first ensure that the usernamespace is locked */
-    if (userid) {
-        int haslock = user_isnamespacelocked(userid);
-        if (haslock) {
-            if (!shared) assert(haslock != LOCK_SHARED);
-        }
-        else {
-            int locktype = shared ? LOCK_SHARED : LOCK_EXCLUSIVE;
-            open->local_namespacelock = user_namespacelock_full(userid, locktype);
-        }
+    int haslock = user_isnamespacelocked(userid);
+    if (haslock) {
+        if (!shared) assert(haslock != LOCK_SHARED);
+    }
+    else {
+        int locktype = shared ? LOCK_SHARED : LOCK_EXCLUSIVE;
+        open->local_namespacelock = user_namespacelock_full(userid, locktype);
     }
 
     /* open db */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -9616,7 +9616,7 @@ static void cmd_status(char *tag, char *name)
                                  &backend_current, &backend_inbox, imapd_in);
             if (!s) r = IMAP_SERVER_UNAVAILABLE;
 
-            imapd_check(s, 0);
+            imapd_check(s, 1);
 
             if (!r) {
                 prot_printf(s->out, "%s Status {" SIZE_T_FMT "+}\r\n%s ", tag,
@@ -9661,7 +9661,7 @@ static void cmd_status(char *tag, char *name)
 
     // status of selected mailbox, we need to refresh
     if (!r && !strcmpsafe(mbentry->name, index_mboxname(imapd_index)))
-        imapd_check(NULL, 0);
+        imapd_check(NULL, 1);
 
     if (!r) r = imapd_statusdata(mbentry, statusitems, &sdata);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7464,8 +7464,8 @@ localcreate:
     imapd_check(NULL, 0);
 
 done:
-    mboxname_release(&namespacelock);
     mailbox_close(&mailbox);
+    mboxname_release(&namespacelock);
     mboxlist_entry_free(&parent);
     buf_free(&specialuse);
     mbname_free(&mbname);
@@ -7620,12 +7620,12 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
     }
     mboxlist_entry_free(&mbentry);
 
-    mboxname_release(&namespacelock);
-
     if (!r && config_getswitch(IMAPOPT_DELETE_UNSUBSCRIBE)) {
         mboxlist_changesub(mbname_intname(mbname), imapd_userid, imapd_authstate,
                            /* add */ 0, /* force */ 0, /* notify? */ 1);
     }
+
+    mboxname_release(&namespacelock);
 
     imapd_check(NULL, 0);
 
@@ -8829,6 +8829,7 @@ static void cmd_setacl(char *tag, const char *name,
     mbentry_t *mbentry = NULL;
 
     char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(intname);
 
     /* is it remote? */
     r = mlookup(tag, name, intname, &mbentry);
@@ -8841,6 +8842,9 @@ static void cmd_setacl(char *tag, const char *name,
         /* remote mailbox */
         struct backend *s = NULL;
         int res;
+
+        // don't hold the lock locally, we're calling remote
+        mboxname_release(&namespacelock);
 
         s = proxy_findserver(mbentry->server, &imap_protocol,
                              proxy_userid, &backend_cached,
@@ -8905,11 +8909,9 @@ static void cmd_setacl(char *tag, const char *name,
             }
         }
 
-        struct mboxlock *namespacelock = mboxname_usernamespacelock(intname);
         r = mboxlist_setacl(&imapd_namespace, intname, identifier, rights,
                             imapd_userisadmin || imapd_userisproxyadmin,
                             proxy_userid, imapd_authstate);
-        mboxname_release(&namespacelock);
     }
 
     imapd_check(NULL, 0);
@@ -8928,6 +8930,7 @@ static void cmd_setacl(char *tag, const char *name,
     }
 
 done:
+    mboxname_release(&namespacelock);
     free(intname);
     mboxlist_entry_free(&mbentry);
 }
@@ -11211,18 +11214,15 @@ static void cmd_undump(char *tag, char *name)
 {
     int r = 0;
     mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbname_intname(mbname));
 
     /* administrators only please */
     if (!imapd_userisadmin)
         r = IMAP_PERMISSION_DENIED;
 
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbname_intname(mbname));
-
     if (!r) r = mlookup(tag, name, mbname_intname(mbname), NULL);
 
     if (!r) r = undump_mailbox(mbname_intname(mbname), imapd_in, imapd_out, imapd_authstate);
-
-    mboxname_release(&namespacelock);
 
     if (r) {
         prot_printf(imapd_out, "%s NO %s%s\r\n",
@@ -11233,10 +11233,13 @@ static void cmd_undump(char *tag, char *name)
                                                  imapd_userid, imapd_authstate,
                                                  NULL, NULL, 0) == 0)
                     ? "[TRYCREATE] " : "", error_message(r));
-    } else {
+    }
+    else {
         prot_printf(imapd_out, "%s OK %s\r\n", tag,
                     error_message(IMAP_OK_COMPLETED));
     }
+
+    mboxname_release(&namespacelock);
     mbname_free(&mbname);
 }
 
@@ -12453,26 +12456,36 @@ static void cmd_xfer(const char *tag, const char *name,
             if (!xfer->use_replication) {
                 /* set the quotaroot if needed */
                 r = xfer_setquotaroot(xfer, mbentry->name);
-                if (r) goto next;
+                if (r) {
+                    mboxname_release(&namespacelock);
+                    goto next;
+                }
 
                 /* backport the seen file if needed */
                 if (xfer->remoteversion < 12) {
                     r = seen_open(xfer->userid, SEEN_CREATE, &xfer->seendb);
-                    if (r) goto next;
+                    if (r) {
+                        mboxname_release(&namespacelock);
+                        goto next;
+                    }
                 }
             }
             mbentry_t *inbox_mbentry = NULL;
             char *inbox = mboxname_user_mbox(xfer->userid, 0);
             r = mboxlist_lookup_allow_all(inbox, &inbox_mbentry, NULL);
             free(inbox);
-            if (r) goto next;
+            if (r) {
+                mboxname_release(&namespacelock);
+                mboxlist_entry_free(&inbox_mbentry);
+                goto next;
+            }
 
             r = mboxlist_usermboxtree(xfer->userid, NULL, xfer_addusermbox,
                                       xfer, MBOXTREE_DELETED);
 
             /* NOTE: mailboxes were added in reverse, so the inbox is
              * done last */
-            r = do_xfer(xfer);
+            if (!r) r = do_xfer(xfer);
 
             if (!r) {
                 /* this was a successful user move, and we need to delete

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6198,6 +6198,9 @@ static void cmd_search(char *tag, char *cmd)
         goto done;
     }
 
+    // this refreshes the index, we may be looking at it in our search
+    imapd_check(NULL, 0);
+
     if (searchargs->filter) {
         /* Multisearch */
         if ((searchargs->filter & SEARCH_SOURCE_SELECTED) && !imapd_index) {
@@ -6312,7 +6315,7 @@ static void cmd_search(char *tag, char *cmd)
         search_expr_free(mrock.expr);
         free_hash_table(&mrock.mailboxes, NULL);
     }
-    else if (!index_check(imapd_index, 0, 0)) {  /* update the index */
+    else {
         n = index_search(imapd_index, searchargs, usinguid);
     }
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -1876,13 +1876,8 @@ static int index_lock(struct index_state *state, int readonly)
 
 EXPORTED int index_status(struct index_state *state, struct statusdata *sdata)
 {
-    int r = index_lock(state, /*readonly*/1);
-    if (r) return r;
-
     status_fill_mailbox(state->mailbox, sdata);
     status_fill_seen(state->userid, sdata, state->numrecent, state->numunseen);
-
-    index_unlock(state);
     return 0;
 }
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -1179,9 +1179,10 @@ EXPORTED int index_fetch(struct index_state *state,
     struct index_map *im;
     uint32_t msgno;
     int r;
-    struct mboxevent *mboxevent = NULL;
+    // if FETCH_SETSEEN and ACLs permit, we need a writelock
+    int readonly = !(fetchargs->fetchitems & FETCH_SETSEEN && !state->examining && state->myrights & ACL_SETSEEN);
 
-    r = index_lock(state, /*readonly*/0);  // can't be readonly because of FETCH_SETSEEN
+    r = index_lock(state, readonly);
     if (r) return r;
 
     if (!strcmp("$", sequence)) {
@@ -1205,8 +1206,8 @@ EXPORTED int index_fetch(struct index_state *state,
     }
 
     /* set the \Seen flag if necessary - while we still have the lock */
-    if (fetchargs->fetchitems & FETCH_SETSEEN && !state->examining && state->myrights & ACL_SETSEEN) {
-        mboxevent = mboxevent_new(EVENT_MESSAGE_READ);
+    if (!readonly) {
+        struct mboxevent *mboxevent = mboxevent_new(EVENT_MESSAGE_READ);
 
         for (msgno = 1; msgno <= state->exists; msgno++) {
             im = &state->map[msgno-1];
@@ -1220,6 +1221,10 @@ EXPORTED int index_fetch(struct index_state *state,
         mboxevent_set_access(mboxevent, NULL, NULL, state->userid, mailbox_name(state->mailbox), 1);
         mboxevent_set_numunseen(mboxevent, state->mailbox,
                                 state->numunseen);
+
+        /* send MessageRead event notification for successfully rewritten records */
+        mboxevent_notify(&mboxevent);
+        mboxevent_free(&mboxevent);
     }
 
     if (fetchargs->vanished) {
@@ -1234,10 +1239,6 @@ EXPORTED int index_fetch(struct index_state *state,
     }
 
     index_unlock(state);
-
-    /* send MessageRead event notification for successfully rewritten records */
-    mboxevent_notify(&mboxevent);
-    mboxevent_free(&mboxevent);
 
     index_checkflags(state, 1, 0);
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -2531,7 +2531,6 @@ EXPORTED int index_convmultisort(struct index_state *state,
     query = search_query_new(state, searchargs);
     query->multiple = 1;
     query->need_ids = 1;
-    query->need_expunge = 1;
     query->sortcrit = sortcrit;
 
     r = search_query_run(query);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1286,7 +1286,8 @@ static void _delayed_cleanup(void *rock)
      * if we are in the middle of a shutdown */
     if (in_shutdown) goto done;
 
-    int r = mailbox_open_exclusive(mboxname, &mailbox);
+    int r = mailbox_open_advanced(mboxname, LOCK_EXCLUSIVE|LOCK_NONBLOCK,
+                                  LOCK_EXCLUSIVE, &mailbox);
     if (r) goto done;
 
     if (mailbox->i.options & OPT_MAILBOX_NEEDS_REPACK) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1283,7 +1283,7 @@ static void _delayed_cleanup(void *rock)
     if (in_shutdown) goto done;
 
     int r = mailbox_open_advanced(mboxname, LOCK_EXCLUSIVE|LOCK_NONBLOCK,
-                                  LOCK_EXCLUSIVE, &mailbox);
+                                  LOCK_EXCLUSIVE, NULL, &mailbox);
     if (r) goto done;
 
     if (mailbox->i.options & OPT_MAILBOX_NEEDS_REPACK) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1041,16 +1041,14 @@ static int mailbox_open_advanced(const char *name,
 
     // lock the user namespace FIRST before the mailbox namespace
     char *userid = mboxname_to_userid(name);
-    if (userid) {
-        int haslock = user_isnamespacelocked(userid);
-        if (haslock) {
-            if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
-        }
-        else {
-            mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
-        }
-        free(userid);
+    int haslock = user_isnamespacelocked(userid);
+    if (haslock) {
+        if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
     }
+    else {
+        mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
+    }
+    free(userid);
 
     if (mbe) mbentry = mboxlist_entry_copy(mbe);
     else r = mboxlist_lookup_allow_all(name, &mbentry, NULL);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1022,9 +1022,9 @@ static int mailbox_open_advanced(const char *name,
     /* already open?  just use this one */
     if (listitem) {
         /* can't reuse an exclusive locked mailbox */
-        if (listitem->l->locktype == LOCK_EXCLUSIVE)
+        if (listitem->l->locktype & LOCK_EXCLUSIVE)
             return IMAP_MAILBOX_LOCKED;
-        if (locktype == LOCK_EXCLUSIVE)
+        if (locktype & LOCK_EXCLUSIVE)
             return IMAP_MAILBOX_LOCKED;
         /* can't reuse an already locked index */
         if (listitem->m.index_locktype)
@@ -1044,11 +1044,10 @@ static int mailbox_open_advanced(const char *name,
     if (userid) {
         int haslock = user_isnamespacelocked(userid);
         if (haslock) {
-            if (index_locktype != LOCK_SHARED) assert(haslock != LOCK_SHARED);
+            if (!(index_locktype & LOCK_SHARED)) assert(!(haslock & LOCK_SHARED));
         }
         else {
-            int locktype = index_locktype;
-            mailbox->local_namespacelock = user_namespacelock_full(userid, locktype);
+            mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
         }
         free(userid);
     }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1044,7 +1044,7 @@ static int mailbox_open_advanced(const char *name,
     if (userid) {
         int haslock = user_isnamespacelocked(userid);
         if (haslock) {
-            if (!(index_locktype & LOCK_SHARED)) assert(!(haslock & LOCK_SHARED));
+            if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
         }
         else {
             mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
@@ -1055,7 +1055,18 @@ static int mailbox_open_advanced(const char *name,
     if (mbe) mbentry = mboxlist_entry_copy(mbe);
     else r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
 
+    /* pre-check for some conditions which mean that we don't want
+       to go ahead and open this mailbox */
     if (!r && mbentry->mbtype & MBTYPE_DELETED)
+        r = IMAP_MAILBOX_NONEXISTENT;
+
+    if (!r && mbentry->mbtype & MBTYPE_MOVING)
+        r = IMAP_MAILBOX_MOVED;
+
+    if (!r && mbentry->mbtype & MBTYPE_INTERMEDIATE)
+        r = IMAP_MAILBOX_NONEXISTENT;
+
+    if (!r && !mbentry->partition)
         r = IMAP_MAILBOX_NONEXISTENT;
 
     if (r) {
@@ -1092,21 +1103,6 @@ static int mailbox_open_advanced(const char *name,
 
     if (!mbentry->name) mbentry->name = xstrdup(name);
     mailbox->mbentry = mbentry;
-
-    if (mbentry->mbtype & MBTYPE_MOVING) {
-        r = IMAP_MAILBOX_MOVED;
-        goto done;
-    }
-
-    if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
-        r = IMAP_MAILBOX_NONEXISTENT;
-        goto done;
-    }
-
-    if (!mbentry->partition) {
-        r = IMAP_MAILBOX_NONEXISTENT;
-        goto done;
-    }
 
     if (index_locktype == LOCK_SHARED)
         mailbox->is_readonly = 1;

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -329,12 +329,10 @@ static int query_begin_index(search_query_t *query,
                              struct index_state **statep)
 {
     int r = 0;
-    int needs_refresh = 0;
 
     /* open an index_state */
     if (!strcmp(index_mboxname(query->state), mboxname)) {
         *statep = query->state;
-        needs_refresh = 1;
     }
     else {
         struct index_init init;
@@ -359,11 +357,6 @@ static int query_begin_index(search_query_t *query,
         /* make sure \Deleted messages are expunged.  Will also lock the
          * mailbox state and read any new information */
         r = index_expunge(*statep, NULL, 1);
-        if (r) goto out;
-    }
-    else if (needs_refresh) {
-        /* Expunge considered unhelpful - just refresh */
-        r = index_refresh(*statep);
         if (r) goto out;
     }
 

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -353,13 +353,6 @@ static int query_begin_index(search_query_t *query,
         index_checkflags(*statep, 0, 0);
     }
 
-    if (query->need_expunge) {
-        /* make sure \Deleted messages are expunged.  Will also lock the
-         * mailbox state and read any new information */
-        r = index_expunge(*statep, NULL, 1);
-        if (r) goto out;
-    }
-
     r = cmd_cancelled(!query->ignore_timer);
 
 out:

--- a/imap/search_query.h
+++ b/imap/search_query.h
@@ -110,7 +110,6 @@ struct search_query {
     const struct sortcrit *sortcrit;
     int multiple;
     int need_ids;
-    int need_expunge;
     int want_expunged;
     uint32_t want_mbtype;
     int verbose;

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -897,16 +897,7 @@ EXPORTED int sieve_ensure_folder(const char *userid, struct mailbox **mailboxptr
         r = mboxlist_lookup(mboxname, NULL, NULL);
     }
 
-    if (!r && mailboxptr) {
-        r = mailbox_open_iwl(mboxname, mailboxptr);
-        if (r) {
-            syslog(LOG_ERR, "IOERROR: failed to open %s (%s)",
-                   mboxname, error_message(r));
-            goto done;
-        }
-    }
-
-    else if (r == IMAP_MAILBOX_NONEXISTENT) {
+    if (r == IMAP_MAILBOX_NONEXISTENT) {
         /* Create locally */
         struct mailbox *mailbox = NULL;
         mbentry_t mbentry = MBENTRY_INITIALIZER;
@@ -930,8 +921,19 @@ EXPORTED int sieve_ensure_folder(const char *userid, struct mailbox **mailboxptr
 
         free(mrock.active);
 
-        if (mailboxptr) *mailboxptr = mailbox;
-        else mailbox_close(&mailbox);
+        // close the mailbox here, we'll re-open once we've released the namespace lock
+        mailbox_close(&mailbox);
+    }
+
+    mboxname_release(&namespacelock);
+
+    if (!r && mailboxptr) {
+        r = mailbox_open_iwl(mboxname, mailboxptr);
+        if (r) {
+            syslog(LOG_ERR, "IOERROR: failed to open %s (%s)",
+                   mboxname, error_message(r));
+            goto done;
+        }
     }
 
   done:

--- a/lib/cyr_lock.h
+++ b/lib/cyr_lock.h
@@ -58,6 +58,8 @@ extern int lock_reopen_ex(int fd, const char *filename,
 extern int lock_setlock(int fd, int ex, int nb, const char *filename);
 extern int lock_unlock(int fd, const char *filename);
 
+extern void clearlocks(void);
+
 /* compatibility defines for the older API */
 #define lock_blocking(fd, fn) \
     lock_setlock((fd), /*exclusive*/1, /*blocking*/0, (fn))

--- a/lib/lock_fcntl.c
+++ b/lib/lock_fcntl.c
@@ -46,11 +46,134 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <string.h>
 
 #include "cyr_lock.h"
+#include "ptrarray.h"
+#include "util.h"
 
+#include <dlfcn.h>
 #include <syslog.h>
 #include <time.h>
+
+struct lockitem_struct {
+    char *filename;
+    int fd;
+    char ex;
+};
+
+static ptrarray_t heldlocks = PTRARRAY_INITIALIZER;
+
+static void printlocks(void)
+{
+    if (ptrarray_size(&heldlocks) < 2) return;
+    struct buf buf = BUF_INITIALIZER;
+    int i;
+    int haveindex = 0;
+    int haveuser = 0;
+    int haveconv = 0;
+    int havemb = 0;
+    for (i = 0; i < ptrarray_size(&heldlocks); i++) {
+        struct lockitem_struct *item = ptrarray_nth(&heldlocks, i);
+        if (i) buf_putc(&buf, ' ');
+        buf_printf(&buf, "%d=<%c:%d:%s>",
+                   i, item->ex, item->fd, item->filename);
+        if (strstr(item->filename, "*U*")) {
+            haveuser = 1;
+        }
+        if (strstr(item->filename, "cyrus.index") && ! strstr(item->filename, "cyrus.indexed.db")) {
+            haveindex = 1;
+            if (!haveuser) syslog(LOG_ERR, "LOCKERROR: INDEX WITHOUT USER");
+            if (havemb) syslog(LOG_ERR, "LOCKERROR: INDEX INSIDE MB");
+        }
+        if (strstr(item->filename, "conversations.db")) {
+            haveconv = 1;
+            if (!haveuser) syslog(LOG_ERR, "LOCKERROR: CONV WITHOUT USER");
+            if (havemb) syslog(LOG_ERR, "LOCKERROR: CONV INSIDE MB");
+        }
+        if (strstr(item->filename, "mailboxes.db")) {
+            havemb = 1;
+        }
+        if (haveconv && havemb && haveindex && haveuser) {
+            syslog(LOG_NOTICE, "megalocked");
+        }
+    }
+    syslog(LOG_NOTICE, "LOCKORDER: %s", buf_cstring(&buf));
+    buf_free(&buf);
+}
+
+static void addlock(const char *filename, int fd, int exclusive)
+{
+    int i;
+    for (i = 0; i < ptrarray_size(&heldlocks); i++) {
+        struct lockitem_struct *item = ptrarray_nth(&heldlocks, i);
+        if (item->fd != fd) continue;
+        syslog(LOG_NOTICE, "LOCKNOTICE: double add %s (%d) - ignoring", filename, fd);
+        return; // don't double-lock
+    }
+    struct lockitem_struct *item = xzmalloc(sizeof(struct lockitem_struct));
+    item->filename = xstrdupnull(filename);
+    item->fd = fd;
+    item->ex = exclusive ? 'E' : 'S';
+    ptrarray_append(&heldlocks, item);
+    printlocks();
+}
+
+static void rmlock(const char *filename, int fd)
+{
+    int i;
+    for (i = 0; i < ptrarray_size(&heldlocks); i++) {
+        struct lockitem_struct *item = ptrarray_nth(&heldlocks, i);
+        if (item->fd != fd) continue;
+        ptrarray_remove(&heldlocks, i);
+        if (i < ptrarray_size(&heldlocks))
+            syslog(LOG_ERR, "LOCKNOTICE: remove out of order %d=<%c:%d:%s>",
+                   i, item->ex, item->fd, item->filename);
+        free(item->filename);
+        free(item);
+        printlocks();
+        return;
+    }
+    syslog(LOG_ERR, "LOCKNOTICE: missing %d:%s", fd, filename);
+
+}
+
+EXPORTED int close(int fd)
+{
+    int i;
+    static int (* fptr)() = 0;
+    if (!fptr) {
+        fptr = (int (*)())dlsym(RTLD_NEXT, "close");
+    }
+
+    for (i = 0; i < ptrarray_size(&heldlocks); i++) {
+        struct lockitem_struct *item = ptrarray_nth(&heldlocks, i);
+        if (item->fd != fd) continue;
+        syslog(LOG_NOTICE, "LOCKNOTICE: removed by close %d", fd);
+        ptrarray_remove(&heldlocks, i);
+        if (i < ptrarray_size(&heldlocks))
+            syslog(LOG_ERR, "LOCKNOTICE: remove out of order %d=<%c:%d:%s>",
+                   i, item->ex, item->fd, item->filename);
+        free(item->filename);
+        free(item);
+    }
+
+    return ((*fptr)(fd));
+}
+
+
+EXPORTED void clearlocks(void)
+{
+    int i;
+    for (i = 0; i < ptrarray_size(&heldlocks); i++) {
+        struct lockitem_struct *item = ptrarray_nth(&heldlocks, i);
+        syslog(LOG_ERR, "LOCKCLEAR: forgetting %d=<%c:%d:%s>",
+               i, item->ex, item->fd, item->filename);
+        free(item->filename);
+        free(item);
+    }
+    ptrarray_truncate(&heldlocks, 0);
+}
 
 EXPORTED const char lock_method_desc[] = "fcntl";
 
@@ -96,6 +219,7 @@ EXPORTED int lock_reopen_ex(int fd, const char *filename,
             if (failaction) *failaction = "locking";
             return -1;
         }
+        addlock(filename, fd, /*exclusive*/1);
 
         r = fstat(fd, sbuf);
         if (!r) r = stat(filename, &sbuffile);
@@ -157,6 +281,7 @@ EXPORTED int lock_setlock(int fd, int exclusive, int nonblock,
         fl.l_len = 0;
         r = fcntl(fd, cmd, &fl);
         if (r != -1) {
+            addlock(filename, fd, exclusive);
             if (debug_locks_longer_than) {
                 struct timeval endtime;
                 gettimeofday(&endtime, 0);
@@ -168,6 +293,11 @@ EXPORTED int lock_setlock(int fd, int exclusive, int nonblock,
             return 0;
         }
         if (errno == EINTR) continue;
+        if (nonblock) {
+            syslog(LOG_NOTICE, "LOCKNOTICE: nonblocking attempt <%c:%d:%s>",
+                   exclusive ? 'E' : 'S', fd, filename);
+            printlocks();
+        }
         return -1;
     }
 }
@@ -175,7 +305,7 @@ EXPORTED int lock_setlock(int fd, int exclusive, int nonblock,
 /*
  * Release any lock on 'fd'.  Always returns success.
  */
-EXPORTED int lock_unlock(int fd, const char *filename __attribute__((unused)))
+EXPORTED int lock_unlock(int fd, const char *filename)
 {
     struct flock fl;
     int r;
@@ -187,7 +317,10 @@ EXPORTED int lock_unlock(int fd, const char *filename __attribute__((unused)))
 
     for (;;) {
         r = fcntl(fd, F_SETLKW, &fl);
-        if (r != -1) return 0;
+        if (r != -1) {
+            rmlock(filename, fd);
+            return 0;
+        }
         if (errno == EINTR) continue;
         /* xxx help! */
         return -1;


### PR DESCRIPTION
NOT FOR INCLUSION IN UPSTREAM.

This is a useful thing to add to debug builds for tracking the order in which locks are created.