### PR TITLE
httpd.c: deflatePending-free workaround typo

### DIFF
--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -189,7 +189,7 @@ HIDDEN int zlib_compress(struct transaction_t *txn, unsigned flags,
             }
 #else
             /* Even if we have used all input, this will return non-zero */
-            pending = deflateBound(zstrm, zstrm->avail_in));
+            pending = deflateBound(zstrm, zstrm->avail_in);
 #endif
 
             buf_ensure(&txn->zbuf, pending);


### PR DESCRIPTION
Somehow a typo escaped in the code that only activates on OpenBSD