### PR TITLE
squatter: add experimental -M and -D options

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5247,7 +5247,8 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
             _snippet_tr_flush,
             _snippet_tr_audit_mailbox,
             _snippet_tr_index_charset_flags,
-            _snippet_tr_index_message_format
+            _snippet_tr_index_message_format,
+            NULL
         },
         NULL, NULL, NULL, 0, BUF_INITIALIZER, NULL
     };

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -979,7 +979,8 @@ HIDDEN matchmime_t *jmap_email_matchmime_init(const struct buf *mime, json_t **e
             _matchmime_tr_flush,
             _matchmime_tr_audit_mailbox,
             _matchmime_tr_index_charset_flags,
-            _matchmime_tr_index_message_format
+            _matchmime_tr_index_message_format,
+            NULL /* set_basedir */
         },
         matchmime->dbw, BUF_INITIALIZER
     };

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2132,7 +2132,9 @@ EXPORTED int mboxname_contains_parent(const char *mboxname, const char *prev)
 
 /* NOTE: caller must free, which is different from almost every
  * other interface in the whole codebase.  Grr */
-EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
+EXPORTED char *mboxname_conf_getpath_confdir(const mbname_t *mbname,
+                                             const char *suffix,
+                                             const char *confdir)
 {
     char *fname = NULL;
     char c[2], d[2];
@@ -2140,7 +2142,7 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
     if (mbname->domain) {
         if (mbname->localpart) {
             if (suffix) {
-                fname = strconcat(config_dir,
+                fname = strconcat(confdir,
                                   FNAME_DOMAINDIR,
                                   dir_hash_b(mbname->domain, config_fulldirhash, d),
                                   "/", mbname->domain,
@@ -2150,7 +2152,7 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
                                   (char *)NULL);
             }
             else {
-                fname = strconcat(config_dir,
+                fname = strconcat(confdir,
                                   FNAME_DOMAINDIR,
                                   dir_hash_b(mbname->domain, config_fulldirhash, d),
                                   "/", mbname->domain,
@@ -2161,7 +2163,7 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
         }
         else {
             if (suffix) {
-                fname = strconcat(config_dir,
+                fname = strconcat(confdir,
                                   FNAME_DOMAINDIR,
                                   dir_hash_b(mbname->domain, config_fulldirhash, d),
                                   "/", mbname->domain,
@@ -2169,7 +2171,7 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
                                   (char *)NULL);
             }
             else {
-                fname = strconcat(config_dir,
+                fname = strconcat(confdir,
                                   FNAME_DOMAINDIR,
                                   dir_hash_b(mbname->domain, config_fulldirhash, d),
                                   "/", mbname->domain,
@@ -2180,14 +2182,14 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
     else {
         if (mbname->localpart) {
             if (suffix) {
-                fname = strconcat(config_dir,
+                fname = strconcat(confdir,
                                   FNAME_USERDIR,
                                   dir_hash_b(mbname->localpart, config_fulldirhash, c),
                                   "/", mbname->localpart, ".", suffix,
                                   (char *)NULL);
             }
             else {
-                fname = strconcat(config_dir,
+                fname = strconcat(confdir,
                                   FNAME_USERDIR,
                                   dir_hash_b(mbname->localpart, config_fulldirhash, c),
                                   (char *)NULL);
@@ -2195,17 +2197,23 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
         }
         else {
             if (suffix) {
-                fname = strconcat(config_dir,
+                fname = strconcat(confdir,
                                   "/", FNAME_SHAREDPREFIX, ".", suffix,
                                   (char *)NULL);
             }
             else {
-                fname = xstrdup(config_dir);
+                fname = xstrdup(confdir);
             }
         }
     }
 
     return fname;
+}
+
+EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname,
+                                     const char *suffix)
+{
+    return mboxname_conf_getpath_confdir(mbname, suffix, config_dir);
 }
 
 /* ========================= COUNTERS ============================ */

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -286,6 +286,10 @@ int mboxname_make_parent(char *namebuf);
 char *mboxname_conf_getpath(const mbname_t *mbname,
                             const char *suffix);
 
+char *mboxname_conf_getpath_confdir(const mbname_t *mbname,
+                                    const char *suffix,
+                                    const char *confdir);
+
 /* ======================== COUNTERS ==================== */
 
 struct mboxname_counters {

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -206,6 +206,7 @@ static int flush_batch(search_text_receiver_t *rx,
 
 EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
                                    struct mailbox *mailbox,
+                                   struct seqset *uids,
                                    int min_indexlevel,
                                    int flags)
 {
@@ -229,6 +230,10 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
 
     while ((msg = mailbox_iter_step(iter))) {
         const struct index_record *record = msg_record(msg);
+
+        if (uids && !seqset_ismember(uids, record->uid))
+            continue;
+
         if ((flags & SEARCH_UPDATE_BATCH) && batch.count >= batch_size) {
             syslog(LOG_INFO, "search_update_mailbox batching %u messages to %s",
                    batch.count, mailbox->name);

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -220,6 +220,7 @@ extern void search_end_search(search_builder_t *);
 search_text_receiver_t *search_begin_update(int verbose);
 int search_update_mailbox(search_text_receiver_t *rx,
                           struct mailbox *mailbox,
+                          struct seqset *uids, // or NULL
                           int min_indexlevel, int flags);
 int search_end_update(search_text_receiver_t *rx);
 

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -148,6 +148,7 @@ struct search_text_receiver {
     int (*audit_mailbox)(search_text_receiver_t *, bitvector_t *unindexed);
     int (*index_charset_flags)(int base_flags);
     int (*index_message_format)(int format, int is_snippet);
+    void (*set_basedir)(search_text_receiver_t *, const char *dir);
 };
 
 struct search_langstat {


### PR DESCRIPTION
-M allows to define a seqset of UIDs to consider during indexing. Multiple -M options may be specified. The UID sequence set is evaluated across mailboxes.

-D allows to define an alternative directory to generate the activefile and search indexes in.

Both options are experimental and mainly useful for debugging.

Basic tests are at: https://github.com/cyrusimap/cassandane/tree/squatter_indexmsg