### PR TITLE
Conversations read nocrc

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -304,7 +304,7 @@ EXPORTED int conversations_open_path(const char *fname, const char *userid, int 
 
     /* open db */
     open->s.is_shared = shared;
-    int flags = CYRUSDB_CREATE | (shared ? CYRUSDB_SHARED : CYRUSDB_CONVERT);
+    int flags = CYRUSDB_CREATE | (shared ? (CYRUSDB_SHARED|CYRUSDB_NOCRC) : CYRUSDB_CONVERT);
     r = cyrusdb_lockopen(DB, fname, flags, &open->s.db, &open->s.txn);
     if (r || open->s.db == NULL) {
         free(open);

--- a/lib/cyrusdb.h
+++ b/lib/cyrusdb.h
@@ -75,7 +75,8 @@ enum cyrusdb_openflags {
     CYRUSDB_MBOXSORT  = 0x02,    /* Use mailbox sort order ('.' sorts 1st) */
     CYRUSDB_CONVERT   = 0x04,    /* Convert to the named format if not already */
     CYRUSDB_NOCOMPACT = 0x08,    /* Don't run any database compaction routines */
-    CYRUSDB_SHARED    = 0x10     /* Open in shared lock mode */
+    CYRUSDB_SHARED    = 0x10,    /* Open in shared lock mode */
+    CYRUSDB_NOCRC     = 0x20     /* Don't check CRC32 on read */
 };
 
 typedef int foreach_p(void *rock,


### PR DESCRIPTION
This allows conversationsdb to skip the CRC32 checks when in shared mode (i.e. reading only).  This is because we have users with millions of emails where over 50% of the CPU usage is just crc32 despite us using a really efficient one - so this skips doing those checks when it's just a read, while still having the checks when we're doing writes.