### PR TITLE
imap/ctl_zoneinfo.c: update synopsis

### DIFF
--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -327,7 +327,7 @@ int main(int argc, char **argv)
 void usage(void)
 {
     fprintf(stderr,
-            "usage: zoneinfo_reconstruct [-C <alt_config>] [-v]"
+            "usage: ctl_zoneinfo [-C <alt_config>] [-v]"
             " -r <publisher>:<version>\n");
     exit(EX_USAGE);
 }


### PR DESCRIPTION
It is called `ctl_zoneinfo` and not `zoneinfo_reconstruct`.