### PR TITLE
message.c: allow 8-bit chars in MIME parameter values

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -1438,7 +1438,11 @@ static void message_parse_params(const char *hdr, struct param **paramp)
                     }
                     else break;
                 }
-                if (*hdr < ' ' && *hdr != '\t') {
+                if (*hdr & 0x80) {
+                    /* Allow unencoded non-ASCII characters */
+                    /* XXX  Do we want to RFC2231-encode this parameter? */
+                }
+                else if (*hdr < ' ' && *hdr != '\t') {
                     /* Reject control characters */
                     goto skip;
                 }
@@ -1467,7 +1471,7 @@ skip:
         /* Save attribute/value pair */
         *paramp = param = (struct param *)xzmalloc(sizeof(struct param));
         param->attribute = message_ucase(xstrndup(attribute, attributelen));
-        param->value = xmalloc(valuelen + 1);
+        param->value = xzmalloc(valuelen + 1);
         if (*value == '\"') {
             p = param->value;
             value++;
@@ -1479,7 +1483,7 @@ skip:
             *p = '\0';
         }
         else {
-            strlcpy(param->value, value, valuelen + 1);
+            memcpy(param->value, value, valuelen);
         }
 
         /* Get ready to parse the next parameter */

--- a/imap/message.c
+++ b/imap/message.c
@@ -1440,7 +1440,7 @@ static void message_parse_params(const char *hdr, struct param **paramp)
                 }
                 if (*hdr & 0x80) {
                     /* Allow unencoded non-ASCII characters */
-                    /* XXX  Do we want to RFC2231-encode this parameter? */
+                    /* XXX  We should probably make sure this is valid UTF-8 */
                 }
                 else if (*hdr < ' ' && *hdr != '\t') {
                     /* Reject control characters */
@@ -1471,7 +1471,7 @@ skip:
         /* Save attribute/value pair */
         *paramp = param = (struct param *)xzmalloc(sizeof(struct param));
         param->attribute = message_ucase(xstrndup(attribute, attributelen));
-        param->value = xzmalloc(valuelen + 1);
+        param->value = xzmalloc(valuelen + 1);  /* xzmalloc for trailing NUL */
         if (*value == '\"') {
             p = param->value;
             value++;


### PR DESCRIPTION
We have seen email messages with a Content-Type: name= parameter value which is unencoded UTF8(?)  This just blindly allows these chars.  We could also properly encode them as UTF8 as we build the MIME structure but then the IMAP envelope wouldn't match the raw message.