### PR TITLE
Clarifications specialusealways: 1

### DIFF
--- a/docsrc/imap/rfc-support.rst
+++ b/docsrc/imap/rfc-support.rst
@@ -608,8 +608,8 @@ The following is an inventory of RFCs supported by Cyrus IMAP.
 
     .. NOTE::
 
-        The LIST and LSUB commands return the special-use flags, unless the
-	``specialusealways`` configuration variable is explicitly turned off.
+        The unextended LIST and LSUB commands return the special-use flags, unless
+        the ``specialusealways`` configuration variable is explicitly turned off.
 
 :rfc:`6203`
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2853,8 +2853,8 @@ product version in the capabilities
    or renamed to have a different parent. Default is the built-in list*/
 
 { "specialusealways", 1, SWITCH, "3.1.1" }
-/* If enabled, this option causes LIST and LSUB output to always include
-   the XLIST "special-use" flags. */
+/* If enabled, this option causes unextended LIST and LSUB output to
+   include the "special-use" flags. */
 
 { "sql_database", NULL, STRING, "2.3.17" }
 /* Name of the database which contains the cyrusdb table(s). */


### PR DESCRIPTION
As of RFC 6154 Section 2 an IMAP server that supports the SPECIAL-USE extension MAY include any or all of the following attributes in responses to the non-extended IMAP LIST command…

The option `specialusealways` alters exactly the behaviour of the unextended LIST command.  Describing the behaviour of `specialusealways` in terms of the undocumented XLIST command is suboptimal.

https://github.com/cyrusimap/cyrus-imapd/issues/2410