### PR TITLE
xapian_wrap:get_stopper() use the cached stoppers

### DIFF
--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -269,7 +269,7 @@ static const Xapian::Stopper* get_stopper(const std::string& iso)
 {
     // Lookup cached entry.
     try {
-        stoppers.at(iso).get();
+        return stoppers.at(iso).get();
     } catch (const std::out_of_range&) {};
 
     // Lookup language name by ISO code.


### PR DESCRIPTION
Broken since 8733b0bb3a.