### PR TITLE
sieve: 'include :once' means 'include :optional' and vice versa

### DIFF
--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -675,8 +675,8 @@ enum bytecode_tags {
 };
 
 #define INC_LOCATION_MASK 0x3F
-#define INC_OPTIONAL_MASK 0x40
-#define INC_ONCE_MASK     0x80
+#define INC_OPTIONAL_MASK 0x80
+#define INC_ONCE_MASK     0x40
 
 #define SNOOZE_WDAYS_MASK 0x7F
 #define SNOOZE_IS_ID_MASK 0x80

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -745,8 +745,8 @@ static void dump2(bytecode_input_t *d, int bc_len)
 
         case B_INCLUDE:
             printf("INCLUDE LOCATION(%s) ONCE(%d) OPTIONAL(%d)",
-                   (cmd.u.inc.location = B_PERSONAL) ? "Personal" : "Global",
-                   cmd.u.inc.once, cmd.u.inc.optional);
+                   (cmd.u.inc.location == B_PERSONAL) ? "Personal" : "Global",
+                   cmd.u.inc.once ? 1 : 0, cmd.u.inc.optional ? 1 : 0);
             print_string("\n\tSCRIPT", cmd.u.inc.script);
             break;
 


### PR DESCRIPTION
as opposed to 'include :global', which is decompiled to ':personal', but interpreted as ':global'.

Does not need recompiling the sieve scripts, as only the interpretation of the bytecode is adjusted.