### PR TITLE
fud: don't redefine MAXDOMNAME/MAXLOGNAME if already defined

### DIFF
--- a/imap/fud.c
+++ b/imap/fud.c
@@ -96,8 +96,10 @@ static void send_reply(struct sockaddr *sfrom, socklen_t sfromsiz, int status,
 
 static int soc = 0; /* inetd (master) has handed us the port as stdin */
 
-#ifndef MAXDOMNAME
+#ifndef MAXLOGNAME
 #define MAXLOGNAME 16           /* should find out for real */
+#endif
+#ifndef MAXDOMNAME
 #define MAXDOMNAME 20           /* should find out for real */
 #endif
 


### PR DESCRIPTION
A refinement of the previous change

Original author: Antoine Jacoutot, openbsd/ports@cb3a0ef