### PR TITLE
Mark some functions as HIDDEN

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -642,7 +642,7 @@ static int read_lastalarm(struct mailbox *mailbox,
 }
 
 /* add a calendar alarm */
-EXPORTED int caldav_alarm_add_record(struct mailbox *mailbox,
+HIDDEN int caldav_alarm_add_record(struct mailbox *mailbox,
                                      const struct index_record *record,
                                      icalcomponent *ical)
 {
@@ -677,7 +677,7 @@ EXPORTED int caldav_alarm_sync_nextcheck(struct mailbox *mailbox, const struct i
 }
 
 /* delete all alarms matching the event */
-EXPORTED int caldav_alarm_delete_record(const char *mboxname, uint32_t imap_uid)
+HIDDEN int caldav_alarm_delete_record(const char *mboxname, uint32_t imap_uid)
 {
     return update_alarmdb(mboxname, imap_uid, 0);
 }
@@ -688,7 +688,7 @@ EXPORTED int caldav_alarm_delete_record(const char *mboxname, uint32_t imap_uid)
     ";"
 
 /* delete all alarms matching the event */
-EXPORTED int caldav_alarm_delete_mailbox(const char *mboxname)
+HIDDEN int caldav_alarm_delete_mailbox(const char *mboxname)
 {
     struct sqldb_bindval bval[] = {
         { ":mboxname",  SQLITE_TEXT, { .s = mboxname  } },
@@ -708,7 +708,7 @@ EXPORTED int caldav_alarm_delete_mailbox(const char *mboxname)
     ";"
 
 /* delete all alarms matching the event */
-EXPORTED int caldav_alarm_delete_user(const char *userid)
+HIDDEN int caldav_alarm_delete_user(const char *userid)
 {
     mbname_t *mbname = mbname_from_userid(userid);
     const char *mboxname = mbname_intname(mbname);

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -904,7 +904,7 @@ EXPORTED int carddav_delete(struct carddav_db *carddavdb, unsigned rowid)
 
 #define CMD_DELMBOX "DELETE FROM vcard_objs WHERE mailbox = :mailbox;"
 
-EXPORTED int carddav_delmbox(struct carddav_db *carddavdb, const char *mailbox)
+HIDDEN int carddav_delmbox(struct carddav_db *carddavdb, const char *mailbox)
 {
     struct sqldb_bindval bval[] = {
         { ":mailbox", SQLITE_TEXT, { .s = mailbox } },

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -588,7 +588,7 @@ static int principal_parse_path(const char *path, struct request_target_t *tgt,
 
 
 /* Determine allowed methods in Cal/CardDAV namespace */
-EXPORTED unsigned long calcarddav_allow_cb(struct request_target_t *tgt)
+HIDDEN unsigned long calcarddav_allow_cb(struct request_target_t *tgt)
 {
     unsigned long allow = tgt->namespace->allow;
 
@@ -627,7 +627,7 @@ EXPORTED int dav_parse_req_target(struct transaction_t *txn,
 
 
 /* Parse a path in Cal/CardDAV namespace */
-EXPORTED int calcarddav_parse_path(const char *path,
+HIDDEN int calcarddav_parse_path(const char *path,
                                    struct request_target_t *tgt,
                                    const char *mboxprefix,
                                    const char **resultstr)

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -178,6 +178,7 @@ static bit32 mailbox_index_record_to_buf(struct index_record *record, int versio
 static int mailbox_lock_conversations(struct mailbox *mailbox, int locktype);
 
 #ifdef WITH_DAV
+static struct webdav_db *mailbox_open_webdav(struct mailbox *);
 static int mailbox_commit_dav(struct mailbox *mailbox);
 static int mailbox_abort_dav(struct mailbox *mailbox);
 static int mailbox_delete_dav(struct mailbox *mailbox);
@@ -2134,7 +2135,7 @@ static int mailbox_lock_conversations(struct mailbox *mailbox, int locktype)
 }
 
 #ifdef WITH_DAV
-EXPORTED struct caldav_db *mailbox_open_caldav(struct mailbox *mailbox)
+HIDDEN struct caldav_db *mailbox_open_caldav(struct mailbox *mailbox)
 {
     if (!mailbox->local_caldav) {
         mailbox->local_caldav = caldav_open_mailbox(mailbox);
@@ -2148,7 +2149,7 @@ EXPORTED struct caldav_db *mailbox_open_caldav(struct mailbox *mailbox)
     return mailbox->local_caldav;
 }
 
-EXPORTED struct carddav_db *mailbox_open_carddav(struct mailbox *mailbox)
+HIDDEN struct carddav_db *mailbox_open_carddav(struct mailbox *mailbox)
 {
     if (!mailbox->local_carddav) {
         mailbox->local_carddav = carddav_open_mailbox(mailbox);
@@ -2162,7 +2163,7 @@ EXPORTED struct carddav_db *mailbox_open_carddav(struct mailbox *mailbox)
     return mailbox->local_carddav;
 }
 
-EXPORTED struct webdav_db *mailbox_open_webdav(struct mailbox *mailbox)
+static struct webdav_db *mailbox_open_webdav(struct mailbox *mailbox)
 {
     if (!mailbox->local_webdav) {
         mailbox->local_webdav = webdav_open_mailbox(mailbox);

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -569,7 +569,6 @@ extern int mailbox_delete(struct mailbox **mailboxptr);
 
 struct caldav_db *mailbox_open_caldav(struct mailbox *mailbox);
 struct carddav_db *mailbox_open_carddav(struct mailbox *mailbox);
-struct webdav_db *mailbox_open_webdav(struct mailbox *mailbox);
 
 /* reading bits and pieces */
 extern int mailbox_refresh_index_header(struct mailbox *mailbox);

--- a/imap/message.c
+++ b/imap/message.c
@@ -541,7 +541,7 @@ EXPORTED int message_parse_mapped(const char *msg_base, unsigned long msg_len,
  * listed in headers or (if headers_not is non-empty) those headers
  * not in headers_not.
  */
-EXPORTED void message_pruneheader(char *buf, const strarray_t *headers,
+HIDDEN void message_pruneheader(char *buf, const strarray_t *headers,
                          const strarray_t *headers_not)
 {
     char *p, *colon, *nextheader;

--- a/imap/webdav_db.c
+++ b/imap/webdav_db.c
@@ -481,7 +481,7 @@ EXPORTED int webdav_delete(struct webdav_db *webdavdb, unsigned rowid)
 
 #define CMD_DELMBOX "DELETE FROM dav_objs WHERE mailbox = :mailbox;"
 
-EXPORTED int webdav_delmbox(struct webdav_db *webdavdb, const char *mailbox)
+HIDDEN int webdav_delmbox(struct webdav_db *webdavdb, const char *mailbox)
 {
     struct sqldb_bindval bval[] = {
         { ":mailbox", SQLITE_TEXT, { .s = mailbox } },


### PR DESCRIPTION
This allows compiler optimizations, leads to smaller binaries, smaller table of exported symbols and faster so-library loading.