### PR TITLE
fix up locking for conversations DB

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -320,7 +320,6 @@ EXPORTED int conversations_open_path(const char *fname, const char *userid, int 
     if (r) {
         cyrusdb_abort(open->s.db, open->s.txn);
         _conv_remove(&open->s);
-        free(open);
         return r;
     }
 

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -200,9 +200,9 @@ static int _init_counted(struct conversations_state *state,
 
 int _saxfolder(int type, struct dlistsax_data *d)
 {
-    struct conversations_open *open = (struct conversations_open *)d->rock;
+    strarray_t *list = (strarray_t *)d->rock;
     if (type == DLISTSAX_STRING)
-        strarray_append(open->s.folder_names, d->data);
+        strarray_append(list, d->data);
     return 0;
 }
 
@@ -327,9 +327,10 @@ EXPORTED int conversations_open_path(const char *fname, const char *userid, int 
     open->s.folder_names = strarray_new();
 
     /* if there's a value, parse as a dlist */
-    if (!cyrusdb_fetch(open->s.db, FNKEY, strlen(FNKEY),
-                   &val, &vallen, &open->s.txn)) {
-        dlist_parsesax(val, vallen, 0, _saxfolder, open);
+    vallen = 0;
+    cyrusdb_fetch(open->s.db, FNKEY, strlen(FNKEY), &val, &vallen, &open->s.txn);
+    if (vallen) {
+        dlist_parsesax(val, vallen, 0, _saxfolder, open->s.folder_names);
     }
 
     if (userid)

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -99,6 +99,11 @@
 
 #define DB config_conversations_db
 
+struct conversations_open {
+    struct conversations_state s;
+    struct conversations_open *next;
+};
+
 static struct conversations_open *open_conversations;
 
 static conv_status_t NULLSTATUS = CONV_STATUS_INIT;

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -99,11 +99,6 @@ struct conversations_state {
     unsigned is_shared:1;
 };
 
-struct conversations_open {
-    struct conversations_state s;
-    struct conversations_open *next;
-};
-
 typedef struct conversation conversation_t;
 typedef struct conv_folder  conv_folder_t;
 typedef struct conv_sender  conv_sender_t;

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -370,6 +370,7 @@ static int meth_post(struct transaction_t *txn,
 
     /* ensure we didn't leak anything! */
     assert(!open_mailboxes_exist());
+    assert(!open_mboxlocks_exist());
 
     // checkpoint before we reply
     sync_checkpoint(httpd_in);
@@ -969,6 +970,7 @@ done:
 
     /* ensure we didn't leak anything! */
     assert(!open_mailboxes_exist());
+    assert(!open_mboxlocks_exist());
 
     // checkpoint before replying
     sync_checkpoint(httpd_in);
@@ -1068,6 +1070,7 @@ static int jmap_ws(struct buf *inbuf, struct buf *outbuf,
 
     /* ensure we didn't leak anything! */
     assert(!open_mailboxes_exist());
+    assert(!open_mboxlocks_exist());
 
     // checkpoint before we reply
     sync_checkpoint(httpd_in);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1995,6 +1995,7 @@ static void cmdloop(struct http_connection *conn)
 
         /* make sure nothing leaked */
         assert(!open_mailboxes_exist());
+        assert(!open_mboxlocks_exist());
 
         sync_log_reset();
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1271,6 +1271,7 @@ static void cmdloop(void)
 
         /* ensure we didn't leak anything! */
         assert(!open_mailboxes_exist());
+        assert(!open_mboxlocks_exist());
 
         sync_log_reset();
 

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2042,6 +2042,7 @@ HIDDEN void jmap_changes_parse(jmap_req_t *req,
     json_t *jargs = req->args;
     const char *key;
     json_t *arg;
+    int have_sincemodseq = 0;
 
     memset(changes, 0, sizeof(struct jmap_changes));
     changes->created = json_array();
@@ -2056,6 +2057,7 @@ HIDDEN void jmap_changes_parse(jmap_req_t *req,
         /* sinceState */
         else if (!strcmp(key, "sinceState")) {
             if (json_is_string(arg)) {
+                have_sincemodseq = 1;
                 changes->since_modseq = atomodseq_t(json_string_value(arg));
             }
             else {
@@ -2081,7 +2083,7 @@ HIDDEN void jmap_changes_parse(jmap_req_t *req,
         *err = json_pack("{s:s s:O}", "type", "invalidArguments",
                 "arguments", parser->invalid);
     }
-    else if (!changes->since_modseq || changes->since_modseq < minmodseq) {
+    else if (!have_sincemodseq || changes->since_modseq < minmodseq) {
         *err = json_pack("{s:s}", "type", "cannotCalculateChanges");
     }
 }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5871,12 +5871,12 @@ HIDDEN int mailbox_rename_copy(struct mailbox *oldmailbox,
      * the records in the target user.  Sorry, was too complex
      * otherwise handling all the special cases */
     if (mailbox_has_conversations(oldmailbox)) {
-        oldcstate = conversations_get_mbox(oldmailbox->name);
+        oldcstate = mailbox_get_cstate(oldmailbox);
         assert(oldcstate);
     }
 
     if (mailbox_has_conversations(newmailbox)) {
-        newcstate = conversations_get_mbox(newmailbox->name);
+        newcstate = mailbox_get_cstate(newmailbox);
         assert(newcstate);
     }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -100,6 +100,7 @@
 #include "proc.h"
 #include "retry.h"
 #include "seen.h"
+#include "user.h"
 #include "util.h"
 #include "sequence.h"
 #include "statuscache.h"
@@ -222,12 +223,11 @@ EXPORTED int open_mailboxes_exist()
 
 static struct mailboxlist *create_listitem(const char *name)
 {
-    struct mailboxlist *item = xmalloc(sizeof(struct mailboxlist));
+    struct mailboxlist *item = xzmalloc(sizeof(struct mailboxlist));
     item->next = open_mailboxes;
     open_mailboxes = item;
 
     item->nopen = 1;
-    item->l = NULL;
     zeromailbox(item->m);
     item->m.name = xstrdup(name);
     /* ensure we never print insane times */
@@ -928,7 +928,7 @@ static int mailbox_open_index(struct mailbox *mailbox)
     return 0;
 }
 
-static int mailbox_mboxlock_reopen(struct mailboxlist *listitem, int locktype)
+static int mailbox_mboxlock_reopen(struct mailboxlist *listitem, int locktype, int index_locktype)
 {
     struct mailbox *mailbox = &listitem->m;
     int r;
@@ -936,6 +936,20 @@ static int mailbox_mboxlock_reopen(struct mailboxlist *listitem, int locktype)
     mailbox_release_resources(mailbox);
 
     mboxname_release(&listitem->l);
+    mboxname_release(&mailbox->local_namespacelock);
+
+    char *userid = mboxname_to_userid(mailbox->name);
+    if (userid) {
+        int haslock = user_isnamespacelocked(userid);
+        if (haslock) {
+            if (index_locktype != LOCK_SHARED) assert(haslock != LOCK_SHARED);
+        }
+        else {
+            mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
+        }
+        free(userid);
+    }
+
     r = mboxname_lock(mailbox->name, &listitem->l, locktype);
     if (r) return r;
 
@@ -979,6 +993,20 @@ static int mailbox_open_advanced(const char *name,
 
     listitem = create_listitem(name);
     mailbox = &listitem->m;
+
+    // lock the user namespace FIRST before the mailbox namespace
+    char *userid = mboxname_to_userid(name);
+    if (userid) {
+        int haslock = user_isnamespacelocked(userid);
+        if (haslock) {
+            if (index_locktype != LOCK_SHARED) assert(haslock != LOCK_SHARED);
+        }
+        else {
+            int locktype = index_locktype;
+            mailbox->local_namespacelock = user_namespacelock_full(userid, locktype);
+        }
+        free(userid);
+    }
 
     r = mboxname_lock(name, &listitem->l, locktype);
     if (r) {
@@ -1110,7 +1138,7 @@ EXPORTED int mailbox_setversion(struct mailbox *mailbox, int version)
         /* we need an exclusive lock on the listitem because we're renaming
          * index files, so release locks and then go full exclusive */
         mailbox_unlock_index(mailbox, NULL);
-        r = mailbox_mboxlock_reopen(listitem, LOCK_EXCLUSIVE);
+        r = mailbox_mboxlock_reopen(listitem, LOCK_EXCLUSIVE, LOCK_EXCLUSIVE);
 
         /* we need to re-open the index because we dropped the mboxname lock,
          * so the file may have changed */
@@ -1184,7 +1212,7 @@ EXPORTED void mailbox_close(struct mailbox **mailboxptr)
         /* if we deleted the mailbox we MUST clean it up or the files will leak,
          * so wait until the other locks are cleared */
         if (mailbox->i.options & OPT_MAILBOX_DELETED) locktype = LOCK_EXCLUSIVE;
-        int r = mailbox_mboxlock_reopen(listitem, locktype);
+        int r = mailbox_mboxlock_reopen(listitem, locktype, LOCK_EXCLUSIVE);
         /* we need to re-open the index because we dropped the mboxname lock,
          * so the file may have changed */
         if (!r) r = mailbox_open_index(mailbox);
@@ -1224,6 +1252,9 @@ EXPORTED void mailbox_close(struct mailbox **mailboxptr)
     }
 
     if (listitem->l) mboxname_release(&listitem->l);
+
+    if (mailbox->local_namespacelock)
+        mboxname_release(&mailbox->local_namespacelock);
 
     remove_listitem(listitem);
 }
@@ -2250,7 +2281,20 @@ static int mailbox_lock_index_internal(struct mailbox *mailbox, int locktype)
     assert(mailbox->index_fd != -1);
     assert(!mailbox->index_locktype);
 
-    r = 0;
+    char *userid = mboxname_to_userid(mailbox->name);
+    if (userid) {
+        if (!user_isnamespacelocked(userid)) {
+            struct mailboxlist *listitem = find_listitem(mailbox->name);
+            assert(listitem);
+            assert(&listitem->m == mailbox);
+            r = mailbox_mboxlock_reopen(listitem, LOCK_SHARED, locktype);
+            if (locktype == LOCK_SHARED)
+                mailbox->is_readonly = 1;
+            if (!r) r = mailbox_open_index(mailbox);
+        }
+        free(userid);
+        if (r) return r;
+    }
 
     if (locktype == LOCK_EXCLUSIVE) {
         /* handle read-only case cleanly - we need to re-open read-write first! */
@@ -2420,6 +2464,11 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
         if (r)
             syslog(LOG_ERR, "Error committing to conversations database for mailbox %s: %s",
                    mailbox->name, error_message(r));
+    }
+
+    // release the namespacelock here
+    if (mailbox->local_namespacelock) {
+        mboxname_release(&mailbox->local_namespacelock);
     }
 }
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -280,6 +280,9 @@ struct mailbox {
     /* conversations */
     struct conversations_state *local_cstate;
 
+    /* namespace lock */
+    struct mboxlock *local_namespacelock;
+
 #ifdef WITH_DAV
     struct caldav_db *local_caldav;
     struct carddav_db *local_carddav;

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -124,6 +124,10 @@ static const char index_mod64[256] = {
 
 #define FNAME_SHAREDPREFIX "shared"
 
+EXPORTED int open_mboxlocks_exist(void)
+{
+    return open_mboxlocks ? 1 : 0;
+}
 
 static struct mboxlocklist *create_lockitem(const char *name)
 {

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -261,7 +261,9 @@ EXPORTED void mboxname_release(struct mboxlock **mboxlockptr)
 
 EXPORTED int mboxname_islocked(const char *mboxname)
 {
-    return find_lockitem(mboxname) ? 1 : 0;
+    struct mboxlocklist *lockitem = find_lockitem(mboxname);
+    if (!lockitem) return 0;
+    return lockitem->l.locktype;
 }
 
 EXPORTED struct mboxlock *mboxname_usernamespacelock(const char *mboxname)

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -126,6 +126,7 @@ char *mboxname_from_external(const char *extname, const struct namespace *ns, co
 char *mboxname_to_external(const char *intname, const struct namespace *ns, const char *userid);
 
 
+int open_mboxlocks_exist(void);
 int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
                   int locktype);
 void mboxname_release(struct mboxlock **mboxlockptr);

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -626,6 +626,7 @@ void shut_down(int code)
 
     /* make sure we didn't leak */
     assert(!open_mailboxes_exist());
+    assert(!open_mboxlocks_exist());
 
     sync_log_reset();
 

--- a/imap/user.c
+++ b/imap/user.c
@@ -523,11 +523,11 @@ static const char *_namelock_name_from_userid(const char *userid)
     return buf_cstring(&buf);
 }
 
-EXPORTED struct mboxlock *user_namespacelock(const char *userid)
+EXPORTED struct mboxlock *user_namespacelock_full(const char *userid, int locktype)
 {
     struct mboxlock *namelock;
     const char *name = _namelock_name_from_userid(userid);
-    int r = mboxname_lock(name, &namelock, LOCK_EXCLUSIVE);
+    int r = mboxname_lock(name, &namelock, locktype);
     if (r) return NULL;
     return namelock;
 }

--- a/imap/user.h
+++ b/imap/user.h
@@ -77,7 +77,9 @@ char *user_hash_subs(const char *user);
 /* find any sort of file for the user */
 char *user_hash_meta(const char *userid, const char *suffix);
 
-struct mboxlock *user_namespacelock(const char *userid);
+/* default to exclusive lock! */
+struct mboxlock *user_namespacelock_full(const char *userid, int locktype);
+#define user_namespacelock(userid) user_namespacelock_full(userid, LOCK_EXCLUSIVE)
 int user_isnamespacelocked(const char *userid);
 
 #endif


### PR DESCRIPTION
This puts a user namespace lock into either conversations.db or mailbox, whichever opens first!  Since that blocks either of the other from opening, it means we can't have lock ordering problems, I hope!

The most complex bit is in mailbox_lock_index(), where the lock could have been dropped, because mailbox_unlock_index() drops it to mean long running IMAP fetches don't block other actions.  This means that if there's no namespacelock, we need to drop everything and relock.  There's already logic for that when changing locktype, so I hooked this in.  Pretty sure it's correct.