### PR TITLE
http_caldav:caldav_put() further checks for DTSTART and DTEND

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -4342,8 +4342,8 @@ static int caldav_put(struct transaction_t *txn, void *obj,
 
         if (icaltime_is_date(dtend) != icaltime_is_date(dtstart) ||
 //            !icaltime_get_timezone(dtend) != !icaltime_get_timezone(dtstart) ||
-            icaltime_compare(dtend, dtstart) < 0) {
-            txn->error.desc = "DTEND occurs before DTSTART";
+            icaltime_compare(dtend, dtstart) < 1) {
+            txn->error.desc = "DTEND must occur after DTSTART";
             txn->error.precond = CALDAV_VALID_DATA;
             ret = HTTP_FORBIDDEN;
             goto done;
@@ -4378,8 +4378,9 @@ static int caldav_put(struct transaction_t *txn, void *obj,
         if (!icaltime_is_null_time(dtend)) {
             dtstart = icalcomponent_get_dtstart(nextcomp);
 
-            if (icaltime_compare(dtend, dtstart) < 0) {
-                txn->error.desc = "DTEND occurs before DTSTART";
+            if (icaltime_is_date(dtend) != icaltime_is_date(dtstart) ||
+                icaltime_compare(dtend, dtstart) < 1) {
+                txn->error.desc = "DTEND must occur after DTSTART";
                 txn->error.precond = CALDAV_VALID_OBJECT;
                 ret = HTTP_FORBIDDEN;
                 goto done;


### PR DESCRIPTION
When on subsequent (not the first) real component DTSTART/DTEND have different value types, fail in the same way, as this is done for the first real component.

DTSTART is the inclusive start, DTEND is the non-inclusive end, so DTSTART cannot be equal to DTEND.  A CUA can unintentionally upload VEVENT where [DTSTART is the same as DTEND](https://gitlab.gnome.org/GNOME/evolution/-/issues/1073) .