### PR TITLE
charset.c: properly QP encode address-list headers

### DIFF
--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -341,6 +341,9 @@ static void test_encode_mimeheader(void)
              "=?UTF-8?Q?01234567890123456789012345678901234567890123456789012345?="
              "\r\n ""=?UTF-8?Q?=E2=82=AC?=");
 
+    /* only encode display-name of address */
+    TESTCASE("\"abc\xe2\x88\x97xyz\" <foo@example.com>", "=?UTF-8?Q?\"abc=E2=88=97xyz\"?= <foo@example.com>");
+
 #undef TESTCASE
 }
 


### PR DESCRIPTION
This resolves a customer issue where they edit a To: header which contains a character that needs encoding.  We can't just blindly QP encode the entire header without breaking it for clients.  This patch encodes only the display-name portion of name-addrs, and leaves addr-spec, angle-addr, the "," separating the addresses, and any surrounding whitespace alone.