### PR TITLE
Format specifier fixes

### DIFF
--- a/cmulocal/cyr_inttype.m4
+++ b/cmulocal/cyr_inttype.m4
@@ -1,0 +1,71 @@
+# SYNOPSIS
+#
+#   CYR_INTTYPE([TYPE-NAME], [BUILD-PREREQS])
+#
+# DESCRIPTION
+#
+#   Figures out the underlying integer type of TYPE-NAME and the appropriate
+#   printf format string to use for it.
+#
+#   BUILD-PREREQS is whatever C code is required for this type to be defined.
+#   This is probably a #include statement!
+#
+#   Sets two cache variables:
+#
+#   * $cyr_cv_type_foo    => the underlying integer type for the type "foo"
+#   * $cyr_cv_format_foo  => the format string to use for type "foo"
+#
+#   Example:
+#
+#       CYR_INTTYPE([time_t], [#include <time.h>])
+#       AC_DEFINE_UNQUOTED([TIME_T_FMT], ["$cyr_cv_format_time_t"], [...])
+#
+AC_DEFUN([CYR_INTTYPE],[
+    dnl First, figure out what type of integer it is, by exploiting the
+    dnl behaviour that redefining a variable name as the same type is only
+    dnl a warning, but redefining it as a different type is an error.
+    AC_CACHE_CHECK(
+        [underlying integer type of `$1'],
+        [AS_TR_SH([cyr_cv_type_$1])],
+        [
+            AC_LANG_PUSH([C])
+            saved_CFLAGS=$CFLAGS
+            CFLAGS=-Wno-error
+            found=no
+            for t in "int" "long int" "long long int" \
+                    "unsigned int" "unsigned long int" "unsigned long long int"
+            do
+                AC_COMPILE_IFELSE(
+                    [AC_LANG_PROGRAM([$2], [extern $1 foo; extern $t foo;])],
+                    [AS_TR_SH([cyr_cv_type_$1])=$t; found=yes; break]
+                )
+            done
+            AS_IF([test "x$found" != "xyes"],
+                  [eval AS_TR_SH([cyr_cv_type_$1])=unknown])
+            CFLAGS=$saved_CFLAGS
+            AC_LANG_POP([C])
+        ]
+    )
+    AS_IF([test "x$AS_TR_SH([cyr_cv_type_$1])" = "xunknown"],
+          [AC_MSG_ERROR([Unable to determine underlying integer type of `$1'])])
+
+    dnl Then, a quick table lookup to turn the known types into the
+    dnl appropriate format string.
+    AC_CACHE_CHECK(
+        [printf format string for `$1'],
+        [AS_TR_SH([cyr_cv_format_$1])],
+        [
+            AS_CASE([$AS_TR_SH([cyr_cv_type_$1])],
+                ["int"], [eval AS_TR_SH([cyr_cv_format_$1])=%d],
+                ["long int"], [eval AS_TR_SH([cyr_cv_format_$1])=%ld],
+                ["long long int"], [eval AS_TR_SH([cyr_cv_format_$1])=%lld],
+                ["unsigned int"], [eval AS_TR_SH([cyr_cv_format_$1])=%u],
+                ["unsigned long int"], [eval AS_TR_SH([cyr_cv_format_$1])=%lu],
+                ["unsigned long long int"], [eval AS_TR_SH([cyr_cv_format_$1])=%llu],
+                [eval AS_TR_SH([cyr_cv_format_$1])=unknown]
+            )
+        ]
+    )
+    AS_IF([test "x$AS_TR_SH([cyr_cv_format_$1])" = "xunknown"],
+          [AC_MSG_ERROR([Unable to determine printf format string for `$1'])])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -247,14 +247,20 @@ AC_FUNC_VPRINTF
 CYR_INTTYPE([time_t], [#include <time.h>])
 AC_DEFINE_UNQUOTED([TIME_T_FMT], ["$cyr_cv_format_time_t"],
                    [printf formatter for time_t])
+AC_DEFINE_UNQUOTED([strtotimet(a,b,c)], [$cyr_cv_parse_time_t(a,b,c)],
+                   [strtol-like parse function for time_t])
 
 CYR_INTTYPE([size_t], [#include <stdlib.h>])
 AC_DEFINE_UNQUOTED([SIZE_T_FMT], ["$cyr_cv_format_size_t"],
                    [printf formatter for size_t])
+AC_DEFINE_UNQUOTED([strtosizet(a,b,c)], [$cyr_cv_parse_size_t(a,b,c)],
+                   [strtol-like parse function for size_t])
 
 CYR_INTTYPE([off_t], [#include <sys/types.h>])
 AC_DEFINE_UNQUOTED([OFF_T_FMT], ["$cyr_cv_format_off_t"],
                    [printf formatter for off_t])
+AC_DEFINE_UNQUOTED([strtoofft(a,b,c)], [$cyr_cv_parse_off_t(a,b,c)],
+                   [strtol-like parse function for off_t])
 
 dnl function for doing each of the database backends
 dnl parameters: backend name, variable to set, withval

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,12 @@ AC_DEFINE_UNQUOTED([OFF_T_FMT], ["$cyr_cv_format_off_t"],
 AC_DEFINE_UNQUOTED([strtoofft(a,b,c)], [$cyr_cv_parse_off_t(a,b,c)],
                    [strtol-like parse function for off_t])
 
+CYR_INTTYPE([rlim_t], [#include <sys/resource.h>])
+AC_DEFINE_UNQUOTED([RLIM_T_FMT], ["$cyr_cv_format_rlim_t"],
+                   [printf formatter for rlim_t])
+AC_DEFINE_UNQUOTED([strtorlimt(a,b,c)], [$cyr_cv_parse_rlim_t(a,b,c)],
+                   [strtol-like parse function for rlim_t])
+
 dnl function for doing each of the database backends
 dnl parameters: backend name, variable to set, withval
 

--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,18 @@ AC_SUBST(CPPFLAGS)
 AC_SUBST(LOCALDEFS)
 AC_FUNC_VPRINTF
 
+CYR_INTTYPE([time_t], [#include <time.h>])
+AC_DEFINE_UNQUOTED([TIME_T_FMT], ["$cyr_cv_format_time_t"],
+                   [printf formatter for time_t])
+
+CYR_INTTYPE([size_t], [#include <stdlib.h>])
+AC_DEFINE_UNQUOTED([SIZE_T_FMT], ["$cyr_cv_format_size_t"],
+                   [printf formatter for size_t])
+
+CYR_INTTYPE([off_t], [#include <sys/types.h>])
+AC_DEFINE_UNQUOTED([OFF_T_FMT], ["$cyr_cv_format_off_t"],
+                   [printf formatter for off_t])
+
 dnl function for doing each of the database backends
 dnl parameters: backend name, variable to set, withval
 
@@ -2320,27 +2332,6 @@ struct sockaddr_storage {
 
 #ifndef HAVE_SHUTDOWN
 #define shutdown(fd, mode) 0
-#endif
-
-/* *printf() macros */
-#if (SIZEOF_SIZE_T == SIZEOF_INT)
-#define SIZE_T_FMT "%u"
-#elif (SIZEOF_SIZE_T == SIZEOF_LONG)
-#define SIZE_T_FMT "%lu"
-#elif (SIZEOF_SIZE_T == SIZEOF_LONG_LONG_INT)
-#define SIZE_T_FMT "%llu"
-#else
-#error dont know what to use for SIZE_T_FMT
-#endif
-
-#if (SIZEOF_OFF_T == SIZEOF_LONG)
-#define OFF_T_FMT "%ld"
-#define strtoofft(nptr, endptr, base) strtol(nptr, endptr, base)
-#elif (SIZEOF_OFF_T == SIZEOF_LONG_LONG_INT)
-#define OFF_T_FMT "%lld"
-#define strtoofft(nptr, endptr, base) strtoll(nptr, endptr, base)
-#else
-#error dont know what to use for OFF_T_FMT
 #endif
 
 #ifndef HAVE_POSIX_FADVISE

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -451,7 +451,7 @@ static int update_alarmdb(const char *mboxname,
     if (!alarmdb) return -1;
     int rc = SQLITE_OK;
 
-    syslog(LOG_DEBUG, "update_alarmdb(%s:%u, %ld)",
+    syslog(LOG_DEBUG, "update_alarmdb(%s:%u, " TIME_T_FMT ")",
            mboxname, imap_uid, nextcheck);
 
     if (nextcheck)
@@ -603,7 +603,7 @@ static int write_lastalarm(struct mailbox *mailbox,
            mailbox->name, record->uid);
 
     if (data) {
-        buf_printf(&annot_buf, "%ld %ld", data->lastrun, data->nextcheck);
+        buf_printf(&annot_buf, TIME_T_FMT " " TIME_T_FMT, data->lastrun, data->nextcheck);
     }
     syslog(LOG_DEBUG, "data: %s", buf_cstring(&annot_buf));
 
@@ -632,7 +632,7 @@ static int read_lastalarm(struct mailbox *mailbox,
                             annotname, "", &annot_buf);
 
     if (annot_buf.len &&
-        sscanf(buf_cstring(&annot_buf), "%ld %ld",
+        sscanf(buf_cstring(&annot_buf), TIME_T_FMT " " TIME_T_FMT,
                &data->lastrun, &data->nextcheck) == 2) {
         r = 0;
     }

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -583,7 +583,7 @@ static int _conversations_set_key(struct conversations_state *state,
         if (i) buf_putc(&buf, ',');
         buf_printf(&buf, CONV_FMT, cid);
     }
-    buf_printf(&buf, " %lu", stamp);
+    buf_printf(&buf, " " TIME_T_FMT, stamp);
 
     r = cyrusdb_store(state->db,
                       key, keylen,

--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -602,7 +602,7 @@ static int action_proc(struct transaction_t *txn)
         char buf[1024];
 
         while (fgets(buf, sizeof(buf), f)) {
-            if (sscanf(buf, "btime %ld\n", &boot_time) == 1) break;
+            if (sscanf(buf, "btime " TIME_T_FMT "\n", &boot_time) == 1) break;
             while (buf[strlen(buf)-1] != '\n' && fgets(buf, sizeof(buf), f)) {
             }
         }

--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -255,7 +255,7 @@ static int action_murder(struct transaction_t *txn)
        and the config file size/mtime */
     assert(!buf_len(&txn->buf));
     stat(config_filename, &sbuf);
-    buf_printf(&txn->buf, "%ld-%ld-%ld", (long) compile_time,
+    buf_printf(&txn->buf, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT, compile_time,
                sbuf.st_mtime, sbuf.st_size);
 
     message_guid_generate(&guid, buf_cstring(&txn->buf), buf_len(&txn->buf));
@@ -341,7 +341,7 @@ static int action_menu(struct transaction_t *txn)
      * Extend this to include config file size/mtime if we add run-time options.
      */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%ld", (long) compile_time);
+    buf_printf(&txn->buf, TIME_T_FMT, compile_time);
     message_guid_generate(&guid, buf_cstring(&txn->buf), buf_len(&txn->buf));
     etag = message_guid_encode(&guid);
 
@@ -793,7 +793,7 @@ static int action_df(struct transaction_t *txn)
        and the config file size/mtime */
     assert(!buf_len(&txn->buf));
     stat(config_filename, &sbuf);
-    buf_printf(&txn->buf, "%ld-%ld-%ld", (long) compile_time,
+    buf_printf(&txn->buf, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT, compile_time,
                sbuf.st_mtime, sbuf.st_size);
 
     message_guid_generate(&guid, buf_cstring(&txn->buf), buf_len(&txn->buf));
@@ -1125,7 +1125,7 @@ static int action_conf(struct transaction_t *txn)
        and the config file size/mtime */
     assert(!buf_len(&txn->buf));
     stat(config_filename, &sbuf);
-    buf_printf(&txn->buf, "%ld-%ld-%ld", (long) compile_time,
+    buf_printf(&txn->buf, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT, compile_time,
                sbuf.st_mtime, sbuf.st_size);
 
     message_guid_generate(&guid, buf_cstring(&txn->buf), buf_len(&txn->buf));

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2347,13 +2347,13 @@ static int list_calendars(struct transaction_t *txn)
     stat(mboxlist, &sbuf);
     lastmod = MAX(compile_time, sbuf.st_mtime);
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%ld-%ld-%ld",
+    buf_printf(&txn->buf, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT,
                compile_time, sbuf.st_mtime, sbuf.st_size);
 
     /* stat() config file for Last-Modified and ETag */
     stat(config_filename, &sbuf);
     lastmod = MAX(lastmod, sbuf.st_mtime);
-    buf_printf(&txn->buf, "-%ld-%ld", sbuf.st_mtime, sbuf.st_size);
+    buf_printf(&txn->buf, "-" TIME_T_FMT "-" OFF_T_FMT, sbuf.st_mtime, sbuf.st_size);
     etag = buf_cstring(&txn->buf);
 
     /* Check any preconditions */

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -348,7 +348,7 @@ static int imip_send_sendmail(icalcomponent *ical, const char *sender,
     time_to_rfc5322(t, datestr, sizeof(datestr));
     buf_printf(&msgbuf, "Date: %s\r\n", datestr);
 
-    buf_printf(&msgbuf, "Message-ID: <cyrus-caldav-%u-%ld-%u@%s>\r\n",
+    buf_printf(&msgbuf, "Message-ID: <cyrus-caldav-%u-" TIME_T_FMT "-%u@%s>\r\n",
             p, t, send_count++, config_servername);
 
     /* Create multipart boundary */

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -953,13 +953,13 @@ static int list_addressbooks(struct transaction_t *txn)
     stat(mboxlist, &sbuf);
     lastmod = MAX(compile_time, sbuf.st_mtime);
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%ld-%ld-%ld",
+    buf_printf(&txn->buf, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT,
                compile_time, sbuf.st_mtime, sbuf.st_size);
 
     /* stat() config file for Last-Modified and ETag */
     stat(config_filename, &sbuf);
     lastmod = MAX(lastmod, sbuf.st_mtime);
-    buf_printf(&txn->buf, "-%ld-%ld", sbuf.st_mtime, sbuf.st_size);
+    buf_printf(&txn->buf, "-" TIME_T_FMT "-" OFF_T_FMT, sbuf.st_mtime, sbuf.st_size);
     etag = buf_cstring(&txn->buf);
 
     /* Check any preconditions */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -1474,7 +1474,7 @@ void xml_add_lockdisc(xmlNodePtr node, const char *root, struct dav_data *data)
             }
         }
 
-        snprintf(tbuf, sizeof(tbuf), "Second-%lu", data->lock_expire - now);
+        snprintf(tbuf, sizeof(tbuf), "Second-" TIME_T_FMT, data->lock_expire - now);
         xmlNewChild(active, NULL, BAD_CAST "timeout", BAD_CAST tbuf);
 
         node1 = xmlNewChild(active, NULL, BAD_CAST "locktoken", NULL);

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -8674,7 +8674,7 @@ static void my_dav_init(struct buf *serverinfo)
     stat(config_filename, &sbuf);
     server_info_lastmod = MAX(compile_time, sbuf.st_mtime);
 
-    buf_printf(&server_info_token, "%ld-%ld-%ld", (long) compile_time,
+    buf_printf(&server_info_token, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT, compile_time,
                sbuf.st_mtime, sbuf.st_size);
     message_guid_generate(&guid, buf_cstring(&server_info_token),
                           buf_len(&server_info_token));

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -1139,7 +1139,7 @@ static int notify_put(struct transaction_t *txn, void *obj,
     }
 
     buf_reset(&txn->buf);
-    buf_printf(&txn->buf, "<%s-%ld@%s>", resource, time(0), config_servername);
+    buf_printf(&txn->buf, "<%s-" TIME_T_FMT "@%s>", resource, time(0), config_servername);
     spool_replace_header(xstrdup("Message-ID"),
                          buf_release(&txn->buf), txn->req_hdrs);
 

--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -325,7 +325,7 @@ static int frame_recv_cb(nghttp2_session *session,
         logbuf = &txn->conn->logbuf;
 
         buf_reset(logbuf);
-        buf_printf(logbuf, "<%ld<", time(NULL));   /* timestamp */
+        buf_printf(logbuf, "<" TIME_T_FMT "<", time(NULL));   /* timestamp */
         write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
     }
 
@@ -777,7 +777,7 @@ HIDDEN void http2_begin_headers(struct transaction_t *txn)
         struct buf *logbuf = &txn->conn->logbuf;
 
         buf_reset(logbuf);
-        buf_printf(logbuf, ">%ld>", time(NULL));  /* timestamp */
+        buf_printf(logbuf, ">" TIME_T_FMT ">", time(NULL));  /* timestamp */
         write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
     }
 }
@@ -915,7 +915,7 @@ HIDDEN int http2_data_chunk(struct transaction_t *txn,
         int niov = 0;
 
         buf_reset(logbuf);
-        buf_printf(logbuf, ">%ld>", time(NULL));  /* timestamp */
+        buf_printf(logbuf, ">" TIME_T_FMT ">", time(NULL));  /* timestamp */
         WRITEV_ADD_TO_IOVEC(iov, niov,
                             buf_base(logbuf), buf_len(logbuf));
         WRITEV_ADD_TO_IOVEC(iov, niov, data, datalen);
@@ -1062,4 +1062,3 @@ HIDDEN int32_t http2_get_streamid(void *http2_strm __attribute__((unused)))
 HIDDEN void http2_end_stream(void *http2_strm __attribute__((unused))) {}
 
 #endif /* HAVE_NGHTTP2 */
-

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -222,7 +222,7 @@ static int meth_get_isched(struct transaction_t *txn,
     /* Generate ETag based on compile date/time of this source file,
        the number of available RSCALEs and the config file size/mtime */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%ld-%zu-%ld-%ld", (long) compile_time,
+    buf_printf(&txn->buf, TIME_T_FMT "-" SIZE_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT, compile_time,
                rscale_calendars ? (size_t)rscale_calendars->num_elements : 0,
                sbuf.st_mtime, sbuf.st_size);
 

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -269,7 +269,7 @@ static int meth_get_isched(struct transaction_t *txn,
         capa = xmlNewChild(root, NULL, BAD_CAST "capabilities", NULL);
 
         buf_reset(&txn->buf);
-        buf_printf(&txn->buf, "%ld", txn->resp_body.iserial);
+        buf_printf(&txn->buf, TIME_T_FMT, txn->resp_body.iserial);
         xmlNewChild(capa, NULL, BAD_CAST "serial-number",
                            BAD_CAST buf_cstring(&txn->buf));
 
@@ -660,7 +660,7 @@ int isched_send(struct caldav_sched_param *sparam, const char *recipient,
         buf_printf(&hdrs, "User-Agent: %s\r\n", buf_cstring(&serverinfo));
     }
     buf_printf(&hdrs, "iSchedule-Version: 1.0\r\n");
-    buf_printf(&hdrs, "iSchedule-Message-ID: <cmu-ischedule-%u-%ld-%u@%s>\r\n",
+    buf_printf(&hdrs, "iSchedule-Message-ID: <cmu-ischedule-%u-" TIME_T_FMT "-%u@%s>\r\n",
                getpid(), time(NULL), send_count++, config_servername);
     buf_printf(&hdrs, "Content-Type: text/calendar; charset=utf-8");
 

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -613,12 +613,12 @@ static int list_feeds(struct transaction_t *txn)
     snprintf(mboxlist, MAX_MAILBOX_PATH, "%s%s", config_dir, FNAME_MBOXLIST);
     stat(mboxlist, &sbuf);
     lastmod = MAX(lastmod, sbuf.st_mtime);
-    buf_printf(&txn->buf, "-%ld-%ld", sbuf.st_mtime, sbuf.st_size);
+    buf_printf(&txn->buf, "-" TIME_T_FMT "-" OFF_T_FMT, sbuf.st_mtime, sbuf.st_size);
 
     /* stat() imapd.conf for Last-Modified and ETag */
     stat(config_filename, &sbuf);
     lastmod = MAX(lastmod, sbuf.st_mtime);
-    buf_printf(&txn->buf, "-%ld-%ld", sbuf.st_mtime, sbuf.st_size);
+    buf_printf(&txn->buf, "-" TIME_T_FMT "-" OFF_T_FMT, sbuf.st_mtime, sbuf.st_size);
 
     /* Check any preconditions */
     precond = check_precond(txn, buf_cstring(&txn->buf), lastmod);

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -778,7 +778,7 @@ static int action_capa(struct transaction_t *txn)
      * Extend this to include config file size/mtime if we add run-time options.
      */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%ld", (long) compile_time);
+    buf_printf(&txn->buf, TIME_T_FMT, compile_time);
     message_guid_generate(&guid, buf_cstring(&txn->buf), buf_len(&txn->buf));
     etag = message_guid_encode(&guid);
 

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -1033,7 +1033,7 @@ static int list_cb(const char *tzid, int tzidlen,
         hash_insert(tzidbuf, (void *) 0xDEADBEEF, lrock->tztable);
     }
 
-    sprintf(etag, "%u-%ld", strhash(tzidbuf), zi->dtstamp);
+    sprintf(etag, "%u-" TIME_T_FMT, strhash(tzidbuf), zi->dtstamp);
     time_to_rfc3339(zi->dtstamp, lastmod, RFC3339_DATETIME_MAX);
 
     tz = json_pack("{s:s s:s s:s s:s s:s}",
@@ -1140,7 +1140,7 @@ static int action_list(struct transaction_t *txn)
         }
 
         /* Parse and sanity check the changedsince token */
-        sscanf(param->s, "%u-%ld", &prefix, &changedsince);
+        sscanf(param->s, "%u-" TIME_T_FMT, &prefix, &changedsince);
         if (prefix != synctoken_prefix || changedsince > info.dtstamp) {
             changedsince = 0;
         }
@@ -1151,7 +1151,7 @@ static int action_list(struct transaction_t *txn)
 
     /* Generate ETag & Last-Modified from info record */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%u-%ld", synctoken_prefix, info.dtstamp);
+    buf_printf(&txn->buf, "%u-" TIME_T_FMT, synctoken_prefix, info.dtstamp);
     lastmod = info.dtstamp;
 
     /* Check any preconditions, including range request */
@@ -1830,7 +1830,7 @@ static int action_get(struct transaction_t *txn)
 
     /* Generate ETag & Last-Modified from info record */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%u-%ld", strhash(tzid), zi.dtstamp);
+    buf_printf(&txn->buf, "%u-" TIME_T_FMT, strhash(tzid), zi.dtstamp);
     lastmod = zi.dtstamp;
     freestrlist(zi.data);
 
@@ -2037,7 +2037,7 @@ static int action_expand(struct transaction_t *txn)
 
     /* Generate ETag & Last-Modified from info record */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%u-%ld", strhash(tzid), zi.dtstamp);
+    buf_printf(&txn->buf, "%u-" TIME_T_FMT, strhash(tzid), zi.dtstamp);
     lastmod = zi.dtstamp;
     freestrlist(zi.data);
 

--- a/imap/http_ws.c
+++ b/imap/http_ws.c
@@ -436,7 +436,7 @@ static void on_msg_recv_cb(wslay_event_context_ptr ev,
             int niov = 0;
 
             assert(!buf_len(&txn->buf));
-            buf_printf(&txn->buf, "<%ld<", time(NULL));  /* timestamp */
+            buf_printf(&txn->buf, "<" TIME_T_FMT "<", time(NULL));  /* timestamp */
             WRITEV_ADD_TO_IOVEC(iov, niov,
                                 buf_base(&txn->buf), buf_len(&txn->buf));
             WRITEV_ADD_TO_IOVEC(iov, niov, buf_base(&inbuf), buf_len(&inbuf));
@@ -460,7 +460,7 @@ static void on_msg_recv_cb(wslay_event_context_ptr ev,
             int niov = 0;
 
             assert(!buf_len(&txn->buf));
-            buf_printf(&txn->buf, ">%ld>", time(NULL));  /* timestamp */
+            buf_printf(&txn->buf, ">" TIME_T_FMT ">", time(NULL));  /* timestamp */
             WRITEV_ADD_TO_IOVEC(iov, niov,
                                 buf_base(&txn->buf), buf_len(&txn->buf));
             WRITEV_ADD_TO_IOVEC(iov, niov, buf_base(&outbuf), buf_len(&outbuf));

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2711,7 +2711,7 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
         simple_hdr(txn, "iSchedule-Version", "1.0");
 
         if (resp_body->iserial) {
-            simple_hdr(txn, "iSchedule-Capabilities", "%ld", resp_body->iserial);
+            simple_hdr(txn, "iSchedule-Capabilities", TIME_T_FMT, resp_body->iserial);
         }
     }
     if (resp_body->patch) {
@@ -3803,7 +3803,7 @@ static int auth_success(struct transaction_t *txn, const char *userid)
 
     /* Recreate telemetry log entry for request (w/ credentials redacted) */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "<%ld<", time(NULL));         /* timestamp */
+    buf_printf(&txn->buf, "<" TIME_T_FMT "<", time(NULL)); /* timestamp */
     buf_printf(&txn->buf, "%s %s %s\r\n",               /* request-line*/
                txn->req_line.meth, txn->req_line.uri, txn->req_line.ver);
     spool_enum_hdrcache(txn->req_hdrs,                  /* header fields */
@@ -4438,7 +4438,7 @@ static int list_well_known(struct transaction_t *txn)
     /* stat() imapd.conf for Last-Modified and ETag */
     stat(config_filename, &sbuf);
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, "%ld-%ld-%ld",
+    buf_printf(&txn->buf, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT,
                compile_time, sbuf.st_mtime, sbuf.st_size);
     sbuf.st_mtime = MAX(compile_time, sbuf.st_mtime);
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -5491,7 +5491,7 @@ static int extract_attachment(const char *type, const char *subtype,
                     "Keep-Alive: timeout=%u\r\n"
                     "Accept: text/plain\r\n"
                     "Content-Type: %s/%s%s\r\n"
-                    "Content-Length: %ld\r\n"
+                    "Content-Length: " SIZE_T_FMT "\r\n"
                     "\r\n",
                     ext->path, guidstr, HTTP_VERSION,
                     (int) hostlen, be->hostname, CYRUS_VERSION, IDLE_TIMEOUT,

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2992,7 +2992,7 @@ static uint32_t crc_basic(const struct mailbox *mailbox,
         flagcrc ^= crc32_cstring(buf);
     }
 
-    snprintf(buf, sizeof(buf), "%u " MODSEQ_FMT " %lu (%u) %lu %s",
+    snprintf(buf, sizeof(buf), "%u " MODSEQ_FMT " " TIME_T_FMT " (%u) " TIME_T_FMT " %s",
             record->uid, record->modseq, record->last_updated,
             flagcrc,
             record->internaldate,
@@ -3052,7 +3052,7 @@ static uint32_t crc_virtannot(struct mailbox *mailbox,
     }
 
     if (record->savedate && mailbox->i.minor_version >= 15) {
-        buf_printf(&buf, "%lu", record->savedate);
+        buf_printf(&buf, TIME_T_FMT, record->savedate);
         crc ^= crc_annot(record->uid, IMAP_ANNOT_NS "savedate", "", &buf);
         buf_reset(&buf);
     }
@@ -4677,7 +4677,7 @@ static int mailbox_index_repack(struct mailbox *mailbox, int version)
         if (mailbox->i.minor_version >= 15 && repack->newmailbox.i.minor_version < 15) {
             if (record->savedate) {
                 buf_reset(&buf);
-                buf_printf(&buf, "%lu", record->savedate);
+                buf_printf(&buf, TIME_T_FMT, record->savedate);
                 r = annotate_state_writesilent(astate, IMAP_ANNOT_NS "savedate", "", &buf);
                 if (r) goto done;
             }

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -231,7 +231,7 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
            mailbox->i.start_offset, mailbox->i.record_size);
     printf("  Number of Messages: %u  Mailbox Size: " QUOTA_T_FMT " bytes  Annotations Size: " QUOTA_T_FMT " bytes\n",
            mailbox->i.exists, mailbox->i.quota_mailbox_used, mailbox->i.quota_annot_used);
-    printf("  Last Append Date: (%lu) %s",
+    printf("  Last Append Date: (" TIME_T_FMT ") %s",
            mailbox->i.last_appenddate, ctime(&mailbox->i.last_appenddate));
     printf("  UIDValidity: %u  Last UID: %u\n",
            mailbox->i.uidvalidity, mailbox->i.last_uid);
@@ -255,8 +255,8 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
         }
     }
     printf("\n");
-    printf("  Last POP3 Login: (%ld) %s", mailbox->i.pop3_last_login,
-           ctime((const long *) &mailbox->i.pop3_last_login));
+    printf("  Last POP3 Login: (" TIME_T_FMT ") %s", mailbox->i.pop3_last_login,
+           ctime((const time_t *) &mailbox->i.pop3_last_login));
     printf("  Highest Mod Sequence: " MODSEQ_FMT "\n",
            mailbox->i.highestmodseq);
 
@@ -277,10 +277,10 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
         }
 
         printf("%06u> UID:%08u"
-               "   INT_DATE:%lu SENTDATE:%lu SAVEDATE:%lu SIZE:%-6u\n",
+               "   INT_DATE:" TIME_T_FMT " SENTDATE:" TIME_T_FMT " SAVEDATE:" TIME_T_FMT " SIZE:%-6u\n",
                msgno, record->uid, record->internaldate,
                record->sentdate, record->savedate, record->size);
-        printf("      > HDRSIZE:%-6u LASTUPD :%lu SYSFLAGS:%08X",
+        printf("      > HDRSIZE:%-6u LASTUPD :" TIME_T_FMT " SYSFLAGS:%08X",
                record->header_size, record->last_updated,
                record->system_flags);
 

--- a/imap/seen_db.c
+++ b/imap/seen_db.c
@@ -295,7 +295,7 @@ EXPORTED int seen_write(struct seen *seendb, const char *uniqueid, struct seenda
                seendb->user, uniqueid);
     }
 
-    snprintf(data, sz, "%d %lu %u %lu %s", SEEN_VERSION,
+    snprintf(data, sz, "%d " TIME_T_FMT " %u " TIME_T_FMT " %s", SEEN_VERSION,
             sd->lastread, sd->lastuid,
             sd->lastchange, sd->seenuids);
     datalen = strlen(data);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -5190,7 +5190,7 @@ static void log_record(const char *name, struct mailbox *mailbox,
                        struct index_record *record)
 {
     syslog(LOG_NOTICE, "SYNCNOTICE: %s uid:%u modseq:" MODSEQ_FMT " "
-          "last_updated:%lu internaldate:%lu flags:(%s) cid:" CONV_FMT,
+          "last_updated:" TIME_T_FMT " internaldate:" TIME_T_FMT " flags:(%s) cid:" CONV_FMT,
            name, record->uid, record->modseq,
            record->last_updated, record->internaldate,
            make_flags(mailbox, record), record->cid);

--- a/imap/zoneinfo_db.c
+++ b/imap/zoneinfo_db.c
@@ -188,7 +188,7 @@ EXPORTED int zoneinfo_store(const char *tzid, struct zoneinfo *zi, struct txn **
 
     /* version SP type SP dtstamp SP (string *(TAB string)) */
     buf_reset(&databuf);
-    buf_printf(&databuf, "%u %u %ld ", ZONEINFO_VERSION, zi->type, zi->dtstamp);
+    buf_printf(&databuf, "%u %u " TIME_T_FMT " ", ZONEINFO_VERSION, zi->type, zi->dtstamp);
     for (sl = zi->data, sep = ""; sl; sl = sl->next, sep = "\t")
         buf_printf(&databuf, "%s%s", sep, sl->s);
 

--- a/imap/zoneinfo_db.c
+++ b/imap/zoneinfo_db.c
@@ -137,7 +137,7 @@ static int parse_zoneinfo(const char *data, int datalen,
     if (version != ZONEINFO_VERSION) return CYRUSDB_IOERROR;
 
     if (p < dend) zi->type = strtoul(p, &p, 10);
-    if (p < dend) zi->dtstamp = strtol(p, &p, 10);
+    if (p < dend) zi->dtstamp = strtotimet(p, &p, 10);
 
     if (all && p < dend) {
         size_t len = dend - ++p;

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -1980,7 +1980,7 @@ static void send_recv_test(void)
 
     end=time(NULL);
 
-    printf("took %ld seconds\n", end - start);
+    printf("took " TIME_T_FMT " seconds\n", end - start);
 }
 
 /*********************************** POP3 ************************************/

--- a/lib/auth_pts.c
+++ b/lib/auth_pts.c
@@ -53,6 +53,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/uio.h>
+#include <inttypes.h>
 
 #include "auth_pts.h"
 #include "cyrusdb.h"
@@ -400,7 +401,7 @@ static int ptload(const char *identifier, struct auth_state **state)
 
         syslog(LOG_DEBUG,
                "ptload(): fetched cache record (%s)" \
-               "(mark %ld, current %ld, limit %ld)", identifier,
+               "(mark " TIME_T_FMT ", current " TIME_T_FMT ", limit " TIME_T_FMT ")", identifier,
                fetched->mark, now, now - timeout);
 
         if (fetched->mark > (now - timeout)) {

--- a/lib/prot.c
+++ b/lib/prot.c
@@ -810,7 +810,7 @@ EXPORTED int prot_fill(struct protstream *s)
         char timebuf[20];
 
         time(&newtime);
-        snprintf(timebuf, sizeof(timebuf), "<%ld<", newtime);
+        snprintf(timebuf, sizeof(timebuf), "<" TIME_T_FMT "<", newtime);
         n = write(s->logfd, timebuf, strlen(timebuf));
 
         left = s->cnt;
@@ -873,7 +873,7 @@ static void prot_flush_log(struct protstream *s)
         char timebuf[20];
 
         time(&newtime);
-        snprintf(timebuf, sizeof(timebuf), ">%ld>", newtime);
+        snprintf(timebuf, sizeof(timebuf), ">" TIME_T_FMT ">", newtime);
         n = write(s->logfd, timebuf, strlen(timebuf));
 
         do {

--- a/master/master.c
+++ b/master/master.c
@@ -1952,13 +1952,13 @@ static void limit_fds(rlim_t x)
     }
 
     if (verbose > 1) {
-        syslog(LOG_DEBUG, "set maximum file descriptors to %ld/%ld",
+        syslog(LOG_DEBUG, "set maximum file descriptors to " RLIM_T_FMT "/" RLIM_T_FMT,
                rl.rlim_cur, rl.rlim_max);
     }
 
     if (setrlimit(RLIMIT_NUMFDS, &rl) < 0) {
         syslog(LOG_ERR,
-               "setrlimit: Unable to set file descriptors limit to %ld: %m",
+               "setrlimit: Unable to set file descriptors limit to " RLIM_T_FMT ": %m",
                rl.rlim_cur);
     }
 }

--- a/notifyd/notify_mailto.c
+++ b/notifyd/notify_mailto.c
@@ -110,7 +110,7 @@ char* notify_mailto(const char *class,
         return strdup("NO mailto could not spawn sendmail process");
 
     t = time(NULL);
-    snprintf(outmsgid, sizeof(outmsgid), "<cmu-sieve-%d-%lu-%d@%s>",
+    snprintf(outmsgid, sizeof(outmsgid), "<cmu-sieve-%d-" TIME_T_FMT "-%d@%s>",
              (int) sm_pid, t, global_outgoing_count++, config_servername);
 
     fprintf(sm, "Message-ID: %s\r\n", outmsgid);

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -58,6 +58,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <netinet/in.h>
+#include <inttypes.h>
 
 #include <string.h>
 
@@ -173,7 +174,7 @@ static void print_stringlist(const char *label, strarray_t *list)
 
 static void print_time(uint64_t t)
 {
-    printf(" %02lu:%02lu:%02lu", t / 3600, (t % 3600) / 60, t % 60);
+    printf(" %02" PRIu64 ":%02" PRIu64 ":%02" PRIu64, t / 3600, (t % 3600) / 60, t % 60);
 }
 
 static void print_vallist(const char *label, arrayu64_t *list,
@@ -188,7 +189,7 @@ static void print_vallist(const char *label, arrayu64_t *list,
 
         if (!(x % 5)) printf("\n\t\t");
         if (print_cb) print_cb(i);
-        else printf(" %lu", i);
+        else printf(" %" PRIu64, i);
     }
     printf("\n\t]");
 


### PR DESCRIPTION
@elliefm, @obache, all,

I tried to pay a lot of attention to the details, but please check this PR exhaustively, each change separately, as there are many small details with a single char changing the entire meaning.

@elliefm, also please test-run this PR on as much platforms and OS as possible.

On the other hand, I have some observations:
 * please check the commit msg of the 1st commit in the PR. The `configure.am` checks don't make much sense for a _real_ detection of the specifier, but I proceeded as was suggested by @elliefm.
 * **imap/mailbox.c**, **imap/sync_support.c**, etc.: it was `%lu`, now it is `%ld`/`%lld`, i.e. signed/unsigned change. Not sure why it was unsigned as `time_t` is a signed data type.
 * **imap/mbexamine.c** line 259: why was that cast instead of `time_t`?
 * **master/master.c**: is `PRIu64` the correct specifier?