### PR TITLE
xapian: skip indexing of already indexed body parts

### DIFF
--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -205,6 +205,7 @@ extern void search_end_search(search_builder_t *);
 #define SEARCH_UPDATE_AUDIT (1<<4)
 #define SEARCH_UPDATE_ALLOW_PARTIALS (1<<5)
 #define SEARCH_UPDATE_REINDEX_PARTIALS (1<<6)
+#define SEARCH_UPDATE_ALLOW_DUPPARTS (1<<7)
 search_text_receiver_t *search_begin_update(int verbose);
 int search_update_mailbox(search_text_receiver_t *rx,
                           struct mailbox *mailbox,

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -102,6 +102,7 @@ static int recursive_flag = 0;
 static int annotation_flag = 0;
 static int sleepmicroseconds = 0;
 static int allow_partials = 0;
+static int allow_duplicateparts = 0;
 static int reindex_partials = 0;
 static int reindex_minlevel = 0;
 static search_text_receiver_t *rx = NULL;
@@ -278,6 +279,8 @@ static int index_one(const char *name, int blocking)
         flags |= SEARCH_UPDATE_ALLOW_PARTIALS;
     if (reindex_partials)
         flags |= SEARCH_UPDATE_REINDEX_PARTIALS;
+    if (allow_duplicateparts)
+        flags |= SEARCH_UPDATE_ALLOW_DUPPARTS;
 
     /* Convert internal name to external */
     char *extname = mboxname_to_external(name, &squat_namespace, NULL);
@@ -893,7 +896,7 @@ int main(int argc, char **argv)
 
     setbuf(stdout, NULL);
 
-    while ((opt = getopt(argc, argv, "C:N:RUBXZT:S:Fde:f:mn:riavpPL:Az:t:ouhl")) != EOF) {
+    while ((opt = getopt(argc, argv, "C:N:RUBXZDT:S:Fde:f:mn:riavpPL:Az:t:ouhl")) != EOF) {
         switch (opt) {
         case 'A':
             if (mode != UNKNOWN) usage(argv[0]);
@@ -936,6 +939,10 @@ int main(int argc, char **argv)
 
         case 'p':
             allow_partials = 1;
+            break;
+
+        case 'D':
+            allow_duplicateparts = 1;
             break;
 
         case 'N':

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1283,14 +1283,10 @@ uint8_t xapian_dbw_is_indexed(xapian_dbw_t *dbw, const struct message_guid *guid
     std::string key = "cyrusid." + std::string(buf_cstring(&buf));
     buf_free(&buf);
 
-    /* body parts have no index levels */
-    if (doctype == XAPIAN_WRAP_DOCTYPE_PART) {
-        return parse_indexlevel(dbw->database->get_metadata(key));
-    }
-
     /* indexed in the current DB? */
     uint8_t indexlevel = parse_indexlevel(dbw->database->get_metadata(key));
-    if (indexlevel == SEARCH_INDEXLEVEL_BEST) {
+    if (indexlevel == SEARCH_INDEXLEVEL_BEST ||
+            (indexlevel && doctype == XAPIAN_WRAP_DOCTYPE_PART)) {
         return indexlevel;
     }
 
@@ -1298,7 +1294,8 @@ uint8_t xapian_dbw_is_indexed(xapian_dbw_t *dbw, const struct message_guid *guid
     for (int i = 0; i < dbw->otherdbs.count; i++) {
         Xapian::Database *database = (Xapian::Database *)ptrarray_nth(&dbw->otherdbs, i);
         uint8_t level = parse_indexlevel(database->get_metadata(key));
-        if (level == SEARCH_INDEXLEVEL_BEST) {
+        if (level == SEARCH_INDEXLEVEL_BEST ||
+                (level && doctype == XAPIAN_WRAP_DOCTYPE_PART)) {
             return level;
         }
         else indexlevel = better_indexlevel(indexlevel, level);


### PR DESCRIPTION
New squatter -D option allows to skip duplicate part check.

Tested in https://github.com/cyrusimap/cassandane/commit/c0c5d37ce3c9e8b6cc47f9a8e684214396f29c69