### PR TITLE
jmap_mail: fix Email/parse to correctly parse top-level message

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7630,7 +7630,7 @@ static int jmap_email_parse(jmap_req_t *req)
         else if (part) {
             _email_from_rfc822body(req, &getargs, mr, part, &email);
         }
-        else if (body) {
+        else if (mr) {
             _email_from_record(req, &getargs, mr, &email);
         }
 


### PR DESCRIPTION
Tested in https://github.com/cyrusimap/cassandane/commit/c0e0b2a2888785186bec895369d0a5e96e2986f6

All Email/parse tests valgrind OK.