### PR TITLE
jmap_contact: decode VCARD text values to UTF-8

### DIFF
--- a/cunit/jmap_util.testc
+++ b/cunit/jmap_util.testc
@@ -134,4 +134,85 @@ static void test_patchobject_create(void)
 #undef TESTCASE
 }
 
+static void test_decode_to_utf8(void)
+{
+    struct testcase {
+        const char *data;
+        const char *charset;
+        int encoding;
+        float confidence;
+        const char *want_val;
+        int want_alloc;
+        int want_is_encoding_problem;
+    };
+
+    struct testcase tcs[] = {{
+        // ISO-8859-1 encoded data claims to be UTF-8, confidence 0.51
+#ifdef HAVE_LIBCHARDET
+        "Ad""\xe9""la""\xef""de",
+        "utf-8",
+        ENCODING_NONE,
+        0.51,
+        "Ad""\xc3\xa9""la""\xc3\xaf""de",
+        1,
+        1
+#else
+        "Ad""\xe9""la""\xef""de",
+        "utf-8",
+        ENCODING_NONE,
+        0.51,
+        "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
+        1,
+        1
+#endif
+    }, {
+        // ISO-8859-1 encoded data claims to be UTF-8, confidence 1.0
+        "Ad""\xe9""la""\xef""de",
+        "utf-8",
+        ENCODING_NONE,
+        1.0,
+        "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
+        1,
+        1
+    }, {
+        // Fast-path valid UTF-8
+        "Ad""\xc3\xa9""la""\xc3\xaf""de",
+        "utf-8",
+        ENCODING_NONE,
+        0.51,
+        "Ad""\xc3\xa9""la""\xc3\xaf""de",
+        0,
+        0
+    }, {
+        // Fast-path valid UTF-8 with replacement chars
+        "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
+        "utf-8",
+        ENCODING_NONE,
+        0.51,
+        "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
+        0,
+        0
+    }, {
+        NULL, NULL, ENCODING_UNKNOWN, 0.0, NULL, 0, 0
+    }};
+
+    struct testcase *tc;
+    for (tc = tcs; tc->data; tc++) {
+        char *cbuf = NULL;
+        int is_problem = 0;
+        const char *cval = jmap_decode_to_utf8(tc->charset, tc->encoding,
+            tc->data, strlen(tc->data), tc->confidence, &cbuf, &is_problem);
+        if (tc->want_val)
+            CU_ASSERT_STRING_EQUAL(tc->want_val, cval);
+        else
+            CU_ASSERT_PTR_NULL(cval);
+        if (tc->want_alloc)
+            CU_ASSERT_PTR_NOT_NULL(cbuf);
+        else
+            CU_ASSERT_PTR_NULL(cbuf);
+        CU_ASSERT_EQUAL(tc->want_is_encoding_problem, is_problem);
+        free(cbuf);
+    }
+}
+
 /* vim: set ft=c: */

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -45,6 +45,7 @@
 
 #include <string.h>
 #include <syslog.h>
+#include <assert.h>
 
 #include <sasl/saslutil.h>
 
@@ -58,6 +59,10 @@
 #include "search_query.h"
 #include "times.h"
 #include "xapian_wrap.h"
+
+#ifdef HAVE_LIBCHARDET
+#include <chardet/chardet.h>
+#endif
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -555,4 +560,139 @@ HIDDEN char *jmap_decode_base64_nopad(const char *b64, size_t b64len)
 
     free(myb64);
     return data;
+}
+
+EXPORTED const char *jmap_decode_to_utf8(const char *charset, int encoding,
+                                         const char *data, size_t datalen,
+                                         float confidence,
+                                         char **val,
+                                         int *is_encoding_problem)
+{
+    charset_t cs = charset_lookupname(charset);
+    char *text = NULL;
+    *val = NULL;
+    const char *charset_id = charset_canon_name(cs);
+    assert(confidence >= 0.0 && confidence <= 1.0);
+
+    /* Attempt fast path without allocation */
+    if (encoding == ENCODING_NONE && data[datalen] == '\0' &&
+            !strcasecmp(charset_id, "UTF-8")) {
+        struct char_counts counts = charset_count_validutf8(data, datalen);
+        if (!counts.invalid) {
+            charset_free(&cs);
+            return data;
+        }
+    }
+
+    /* Can't use fast path. Allocate and try to detect charset. */
+    if (cs == CHARSET_UNKNOWN_CHARSET || encoding == ENCODING_UNKNOWN) {
+        syslog(LOG_INFO, "decode_to_utf8 error (%s, %s)",
+                charset, encoding_name(encoding));
+        if (is_encoding_problem) *is_encoding_problem = 1;
+        goto done;
+    }
+    text = charset_to_utf8(data, datalen, cs, encoding);
+    if (!text) {
+        if (is_encoding_problem) *is_encoding_problem = 1;
+        goto done;
+    }
+
+    size_t textlen = strlen(text);
+    struct char_counts counts = charset_count_validutf8(text, textlen);
+    if (is_encoding_problem)
+        *is_encoding_problem = counts.invalid || counts.replacement;
+
+    if (!strncasecmp(charset_id, "UTF-32", 6)) {
+        /* Special-handle UTF-32. Some clients announce the wrong endianess. */
+        if (counts.invalid || counts.replacement) {
+            charset_t guess_cs = CHARSET_UNKNOWN_CHARSET;
+            if (!strcasecmp(charset_id, "UTF-32") || !strcasecmp(charset_id, "UTF-32BE"))
+                guess_cs = charset_lookupname("UTF-32LE");
+            else
+                guess_cs = charset_lookupname("UTF-32BE");
+            char *guess = charset_to_utf8(data, datalen, guess_cs, encoding);
+            if (guess) {
+                struct char_counts guess_counts = charset_count_validutf8(guess, strlen(guess));
+                if (guess_counts.valid > counts.valid) {
+                    free(text);
+                    text = guess;
+                    counts = guess_counts;
+                    textlen = strlen(text);
+                    charset_id = charset_canon_name(guess_cs);
+                }
+            }
+            charset_free(&guess_cs);
+        }
+    }
+    else if (!charset_id || !strcasecmp("US-ASCII", charset_id)) {
+        int has_cntrl = 0;
+        size_t i;
+        for (i = 0; i < textlen; i++) {
+            if (iscntrl(text[i])) {
+                has_cntrl = 1;
+                break;
+            }
+        }
+        if (has_cntrl) {
+            /* Could be ISO-2022-JP */
+            charset_t guess_cs = charset_lookupname("ISO-2022-JP");
+            if (guess_cs != CHARSET_UNKNOWN_CHARSET) {
+                char *guess = charset_to_utf8(data, datalen, guess_cs, encoding);
+                if (guess) {
+                    struct char_counts guess_counts = charset_count_validutf8(guess, strlen(guess));
+                    if (!guess_counts.invalid && !guess_counts.replacement) {
+                        free(text);
+                        text = guess;
+                        counts = guess_counts;
+                        textlen = strlen(text);
+                        charset_id = charset_canon_name(guess_cs);
+                    }
+                    else free(guess);
+                }
+                charset_free(&guess_cs);
+            }
+        }
+    }
+
+#ifdef HAVE_LIBCHARDET
+    if (counts.invalid || counts.replacement) {
+        static Detect *d = NULL;
+        if (!d) d = detect_init();
+
+        DetectObj *obj = detect_obj_init();
+        if (!obj) goto done;
+        detect_reset(&d);
+
+        struct buf buf = BUF_INITIALIZER;
+        charset_decode(&buf, data, datalen, encoding);
+        buf_cstring(&buf);
+        if (detect_handledata_r(&d, buf_base(&buf), buf_len(&buf), &obj) == CHARDET_SUCCESS) {
+            charset_t guess_cs = charset_lookupname(obj->encoding);
+            if (guess_cs != CHARSET_UNKNOWN_CHARSET) {
+                char *guess = charset_to_utf8(data, datalen, guess_cs, encoding);
+                if (guess) {
+                    struct char_counts guess_counts =
+                        charset_count_validutf8(guess, strlen(guess));
+                    if ((guess_counts.valid > counts.valid) &&
+                        (obj->confidence >= confidence)) {
+                        free(text);
+                        text = guess;
+                        counts = guess_counts;
+                    }
+                    else {
+                        free(guess);
+                    }
+                }
+                charset_free(&guess_cs);
+            }
+        }
+        detect_obj_free(&obj);
+        buf_free(&buf);
+    }
+#endif
+
+done:
+    charset_free(&cs);
+    *val = text;
+    return text;
 }

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -112,4 +112,25 @@ extern json_t *jmap_server_error(int r);
 extern char *jmap_encode_base64_nopad(const char *data, size_t len);
 extern char *jmap_decode_base64_nopad(const char *b64, size_t b64len);
 
+/* Decode the text in data of datalen bytes to UTF-8 to a C-string.
+ *
+ * Attempt to detect the right character encoding if conversion to
+ * UTF-8 yields any invalid or replacement characters.
+ *
+ * Parameters:
+ * - charset indicates the presumed character encoding.
+ * - encoding must be one of the encodings defined in charset.h
+ * - confidence indicates the threshold for charset detection (0 to 1.0)
+ * - val holds any allocated memory to which the return value points to
+ * - (optional) is_encoding_problem is set for invalid byte sequences
+ *
+ * The return value MAY point to data if data is a C-string and does not
+ * contain invalid UTF-8 (but may contain replacement) characters.
+ */
+extern const char *jmap_decode_to_utf8(const char *charset, int encoding,
+                                       const char *data, size_t datalen,
+                                       float confidence,
+                                       char **val,
+                                       int *is_encoding_problem);
+
 #endif /* JMAP_UTIL_H */


### PR DESCRIPTION
This patch changes Contact/get to handle invalid UTF-8 data in VCARD fields such as EMAIL, N, FN, etc.

However, in contrast to Email/get this does not allow for repairing bogus data: a couple of tests on libchardet reveal that it is likely to incorrectly guess the charset for very short text such as email addresses and other contact data. In contrast to Email/get the Contact/get method does not allow indicate to the client if any of the text values may have character encoding issues. To err on the safe side, this patch instructs the charset detector to always fall back to UTF-8 replacement characters for any invalid UTF-8 sequences. A Cassandane test highlights this issue https://github.com/cyrusimap/cassandane/commit/56ab4804233d560cbb7be793ae5a1b591c96727b (where we could repair the wrongly encoded data, but at the likely cost of returning bogus values for other cases).

This patch also refactors the charset detection helper used in Email/get for general use by the JMAP modules. The API allows to specify a minimum confidence [0.0,1.0] for the charset detection heuristic.