### PR TITLE
Fix PATH_MAX on GNU/Hurd

### DIFF
--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -99,6 +99,10 @@
 #define MAXHOSTNAMELEN 256
 #endif
 
+#ifndef MAXHOSTNAMELEN
+#define MAXHOSTNAMELEN
+#endif
+
 #ifdef HAVE_KRB
 /* kerberos des is purported to conflict with OpenSSL DES */
 #define DES_DEFS

--- a/master/master.c
+++ b/master/master.c
@@ -76,6 +76,10 @@
 #define PATH_MAX 4096
 #endif
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #ifndef INADDR_NONE
 #define INADDR_NONE 0xffffffff
 #endif

--- a/master/service.c
+++ b/master/service.c
@@ -77,6 +77,10 @@
 #define PATH_MAX 4096
 #endif
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 extern int optind, opterr;
 extern char *optarg;
 


### PR DESCRIPTION
This little patch is used in Debian for GNU/Hurd. See also f03b10ae