### PR TITLE
silence erroneous RLIMIT_NUMFDS-related log messages

### DIFF
--- a/master/master.c
+++ b/master/master.c
@@ -1968,7 +1968,7 @@ static void limit_fds(rlim_t x)
     struct rlimit rl;
 
 #ifdef HAVE_GETRLIMIT
-    if (!getrlimit(RLIMIT_NUMFDS, &rl)) {
+    if (getrlimit(RLIMIT_NUMFDS, &rl) >= 0) {
         if (x != RLIM_INFINITY && rl.rlim_max != RLIM_INFINITY && x > rl.rlim_max) {
             syslog(LOG_WARNING,
                    "limit_fds: requested %" PRIu64 ", but capped to %" PRIu64,
@@ -1987,7 +1987,7 @@ static void limit_fds(rlim_t x)
                rl.rlim_cur, rl.rlim_max);
     }
 
-    if (setrlimit(RLIMIT_NUMFDS, &rl) < 0) {
+    if (setrlimit(RLIMIT_NUMFDS, &rl) < 0 && x != RLIM_INFINITY) {
         syslog(LOG_ERR,
                "setrlimit: Unable to set file descriptors limit to %ld: %m",
                rl.rlim_cur);


### PR DESCRIPTION
Debian author comment:
> Fixes setrlimit(RLIMIT_NUMFDS) handling to be less obnoxious and not barf error messages to syslog incorrectly, nor log nonsense if getrlimit(RLIMIT_NUMFDS) failed.