### PR TITLE
Normalize the authentication ID

### DIFF
--- a/imap/global.c
+++ b/imap/global.c
@@ -346,6 +346,8 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
                                   config_getswitch(IMAPOPT_UNIX_GROUP_ENABLE));
         libcyrus_config_setswitch(CYRUSOPT_USERNAME_TOLOWER,
                                   config_getswitch(IMAPOPT_USERNAME_TOLOWER));
+	libcyrus_config_setswitch(CYRUSOPT_NORMALIZEUID,
+				  config_getswitch(CYRUSOPT_NORMALIZEUID));
         libcyrus_config_setswitch(CYRUSOPT_SKIPLIST_UNSAFE,
                                   config_getswitch(IMAPOPT_SKIPLIST_UNSAFE));
         libcyrus_config_setstring(CYRUSOPT_TEMP_PATH,

--- a/lib/auth_unix.c
+++ b/lib/auth_unix.c
@@ -150,9 +150,11 @@ static char allowedchars[256] = {
 static const char *mycanonifyid(const char *identifier, size_t len)
 {
     static char retbuf[81];
+    char backup[81];
     struct group *grp;
     char *p;
     int username_tolower = 0;
+    int ic,rbc;
 
     if (!len) len = strlen(identifier);
     if (len >= sizeof(retbuf)) return NULL;
@@ -192,6 +194,22 @@ static const char *mycanonifyid(const char *identifier, size_t len)
         default:
             break;
         }
+    }
+
+    if( (libcyrus_config_getswitch(CYRUSOPT_NORMALIZEUID) == 1) ) {
+        strcpy(backup,retbuf);
+       /* remove leading blanks */
+       for(ic=0; isblank(backup[ic]); ic++);
+       for(rbc=0; backup[ic]; ic++) {
+            retbuf[rbc] = ( isalpha(backup[ic]) ?
+                 tolower(backup[ic]) : backup[ic] );
+            rbc++;
+       }
+       retbuf[rbc] = '\0';
+       /* remove trailing blanks */
+       for(--rbc; isblank(retbuf[rbc]); rbc--) {
+            retbuf[rbc] = '\0';
+       }
     }
 
     return retbuf;

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2919,6 +2919,11 @@ of the incoming network interface, or if no record is found, the
 { "fastmailsharing", 0, SWITCH, "3.0.0" }
 /* If enabled, use FastMail style sharing (oldschool full server paths) */
 
+{ "normalizeuid", 0, SWITCH }
+/* Lowercase uid and strip leading and trailing blanks. It is recommended
+   to set this to yes, especially if OpenLDAP is used as authentication
+   source. */
+
 /*
 .SH SEE ALSO
 .PP

--- a/lib/libcyr_cfg.c
+++ b/lib/libcyr_cfg.c
@@ -144,6 +144,10 @@ static struct cyrusopt_s cyrus_options[] = {
       CFGVAL(long, 1),
       CYRUS_OPT_SWITCH },
 
+    { CYRUSOPT_NORMALIZEUID,
+      CFGVAL(long, 1),
+      CYRUS_OPT_SWITCH },
+
     { CYRUSOPT_LAST, { NULL }, CYRUS_OPT_NOTOPT }
 };
 

--- a/lib/libcyr_cfg.h
+++ b/lib/libcyr_cfg.h
@@ -105,6 +105,8 @@ enum cyrus_opt {
     CYRUSOPT_SQL_USESSL,
     /* Checkpoint after every recovery (OFF) */
     CYRUSOPT_SKIPLIST_ALWAYS_CHECKPOINT,
+    /* Lowercase uid and strip leading and trailing blanks (OFF) */
+    CYRUSOPT_NORMALIZEUID,
 
     CYRUSOPT_LAST
 


### PR DESCRIPTION
Debian author comment:
> By normalize, it is intended that;
>  1. Authentication IDs all can be lowercased for more accurate comparison without being volatile to, say, user error, and
>  2. Any leading or trailing blank space can be stripped