### PR TITLE
JMAP: only send alerts for VEVENTs

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -917,6 +917,12 @@ static time_t process_alarms(const char *mboxname, uint32_t imap_uid,
                              icalcomponent *ical, time_t lastrun,
                              time_t runtime, int dryrun)
 {
+    /* we don't send alarms for anything except VEVENTS */
+    icalcomponent *comp = icalcomponent_get_first_real_component(ical);
+    icalcomponent_kind kind = icalcomponent_isa(comp);
+    if (kind != ICAL_VEVENT_COMPONENT)
+        return 0;
+
     icalcomponent *myical = NULL;
 
     /* Add default alarms */


### PR DESCRIPTION
This will make dogfood less horrible for people in the meanwhile!

[ not to be merged:  problem will be solved with an alternate strategy ]