### PR TITLE
Ignore . and .. while iterating through the directories holding usernames

### DIFF
--- a/tools/translatesieve
+++ b/tools/translatesieve
@@ -204,6 +204,9 @@ if ($altnamespace > $OPT_WasAlt) {
 chdir $sievedir or die "couldn't change to $sievedir";
 opendir (H, ".");
 while (my $i = readdir H) {
+    if ($i eq "." || $i eq "..") {
+        next;
+    }
     if (-d $i) {
         if (! chdir $i) {
             ouch "couldn't chdir to $i";


### PR DESCRIPTION
This is necessary on FreeBSD otherwise it goes back up a directory and gets lost.
