### PR TITLE
configurable special-use mailboxes that may not contain children

### DIFF
--- a/cunit/strarray.testc
+++ b/cunit/strarray.testc
@@ -656,6 +656,132 @@ static void test_split(void)
 #undef WORD4
 }
 
+static void test_split_lcase(void)
+{
+    strarray_t *sa;
+#define WORD0   "LORem"
+#define WORD1   "ipSUM"
+#define WORD2   "DoLoR"
+#define WORD3   "siT"
+#define WORD4   "Amet"
+
+#define WORD0lc "lorem"
+#define WORD1lc "ipsum"
+#define WORD2lc "dolor"
+#define WORD3lc "sit"
+#define WORD4lc "amet"
+
+    /* 5 words, space separator */
+    sa = strarray_split(WORD0" "WORD1" "WORD2" "WORD3" "WORD4,
+                        " ", STRARRAY_LCASE);
+    CU_ASSERT_PTR_NOT_NULL(sa);
+    CU_ASSERT_EQUAL(sa->count, 5);
+    CU_ASSERT(sa->alloc >= sa->count);
+    CU_ASSERT_PTR_NOT_NULL(sa->data);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 0), WORD0lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 1), WORD1lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 2), WORD2lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 3), WORD3lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 4), WORD4lc);
+    strarray_free(sa);
+
+    /* 5 words, NULL separator (whitespace) */
+    sa = strarray_split(WORD0" "WORD1"\t"WORD2"\r"WORD3"\n"WORD4,
+                        NULL, STRARRAY_LCASE);
+    CU_ASSERT_PTR_NOT_NULL(sa);
+    CU_ASSERT_EQUAL(sa->count, 5);
+    CU_ASSERT(sa->alloc >= sa->count);
+    CU_ASSERT_PTR_NOT_NULL(sa->data);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 0), WORD0lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 1), WORD1lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 2), WORD2lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 3), WORD3lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 4), WORD4lc);
+    strarray_free(sa);
+
+    /* 5 words, several separators */
+    sa = strarray_split(WORD0"("WORD1")"WORD2"["WORD3"]"WORD4,
+                        "[]()", STRARRAY_LCASE);
+    CU_ASSERT_PTR_NOT_NULL(sa);
+    CU_ASSERT_EQUAL(sa->count, 5);
+    CU_ASSERT(sa->alloc >= sa->count);
+    CU_ASSERT_PTR_NOT_NULL(sa->data);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 0), WORD0lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 1), WORD1lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 2), WORD2lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 3), WORD3lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 4), WORD4lc);
+    strarray_free(sa);
+
+    /* splitm - takes ownership of a strdup()d argument */
+    sa = strarray_splitm(xstrdup(WORD0" "WORD1" "WORD2" "WORD3" "WORD4),
+                         " ", STRARRAY_LCASE);
+    CU_ASSERT_PTR_NOT_NULL(sa);
+    CU_ASSERT_EQUAL(sa->count, 5);
+    CU_ASSERT(sa->alloc >= sa->count);
+    CU_ASSERT_PTR_NOT_NULL(sa->data);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 0), WORD0lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 1), WORD1lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 2), WORD2lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 3), WORD3lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 4), WORD4lc);
+    strarray_free(sa);
+
+    /* nsplit - specify a byte range to copy and split */
+    sa = strarray_nsplit(WORD0" "WORD1" "WORD2" "WORD3" "WORD4,
+                         sizeof(WORD0)+sizeof(WORD1)+sizeof(WORD2),
+                         " ", STRARRAY_LCASE);
+    CU_ASSERT_PTR_NOT_NULL(sa);
+    CU_ASSERT_EQUAL(sa->count, 3);
+    CU_ASSERT(sa->alloc >= sa->count);
+    CU_ASSERT_PTR_NOT_NULL(sa->data);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 0), WORD0lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 1), WORD1lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 2), WORD2lc);
+    strarray_free(sa);
+
+    /* split with surrounding whitespace */
+    sa = strarray_split(WORD0"| "WORD1" | "WORD2" |"WORD3" | "WORD4"| ",
+                        "|", STRARRAY_LCASE);
+    CU_ASSERT_PTR_NOT_NULL(sa);
+    CU_ASSERT_EQUAL(sa->count, 6);
+    CU_ASSERT(sa->alloc >= sa->count);
+    CU_ASSERT_PTR_NOT_NULL(sa->data);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 0), WORD0lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 1), " "WORD1lc" ");
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 2), " "WORD2lc" ");
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 3), WORD3lc" ");
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 4), " "WORD4lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 5), " ");
+    strarray_free(sa);
+
+    /* trim surrounding whitespace */
+    sa = strarray_split(WORD0"| "WORD1" | "WORD2" |"WORD3" | "WORD4"| ",
+                        "|", STRARRAY_TRIM | STRARRAY_LCASE);
+    CU_ASSERT_PTR_NOT_NULL(sa);
+    CU_ASSERT_EQUAL(sa->count, 5);
+    CU_ASSERT(sa->alloc >= sa->count);
+    CU_ASSERT_PTR_NOT_NULL(sa->data);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 0), WORD0lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 1), WORD1lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 2), WORD2lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 3), WORD3lc);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(sa, 4), WORD4lc);
+    strarray_free(sa);
+
+#undef WORD0
+#undef WORD1
+#undef WORD2
+#undef WORD3
+#undef WORD4
+
+#undef WORD0lc
+#undef WORD1lc
+#undef WORD2lc
+#undef WORD3lc
+#undef WORD4lc
+}
+
 static void test_remove(void)
 {
     strarray_t sa = STRARRAY_INITIALIZER;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3466,6 +3466,23 @@ EXPORTED int specialuse_validate(const char *mboxname, const char *userid,
             }
         }
 
+        /* some attributes may not be set on mailboxes containing children */
+        if (mboxname && config_getstring(IMAPOPT_SPECIALUSE_NOCHILDREN)) {
+            strarray_t *forbidden = strarray_split(
+                config_getstring(IMAPOPT_SPECIALUSE_NOCHILDREN),
+                NULL,
+                STRARRAY_TRIM
+            );
+
+            if (strarray_find(forbidden, strarray_nth(valid, j), 0) != -1
+                && mboxlist_haschildren(mboxname))
+            {
+                r = IMAP_MAILBOX_HASCHILDREN;
+            }
+
+            strarray_free(forbidden);
+        }
+
         /* normalise the value */
         strarray_set(new_attribs, i, strarray_nth(valid, j));
     }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2539,6 +2539,11 @@ product version in the capabilities
    extending that list in the future or adding your own
    if needed. */
 
+{ "specialuse_nochildren", NULL, STRING, "3.3.2" }
+/* Whitespace separated list of special-use attributes that may not contain
+   child folders.  If set, mailboxes with any of these attributes may not
+   have child folders created. */
+
 { "specialuse_protect", "\\Archive \\Drafts \\Important \\Junk \\Sent \\Trash", STRING, "3.1.7" }
 /* Whitespace separated list of special-use attributes
    to protect the mailboxes for.  If set, don't allow

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2542,7 +2542,8 @@ product version in the capabilities
 { "specialuse_nochildren", NULL, STRING, "3.3.2" }
 /* Whitespace separated list of special-use attributes that may not contain
    child folders.  If set, mailboxes with any of these attributes may not
-   have child folders created. */
+   have child folders created, and these attributes cannot be added to
+   mailboxes that already have children.. */
 
 { "specialuse_protect", "\\Archive \\Drafts \\Important \\Junk \\Sent \\Trash", STRING, "3.1.7" }
 /* Whitespace separated list of special-use attributes

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -446,6 +446,7 @@ EXPORTED int strarray_find_case(const strarray_t *sa, const char *match, int sta
 
 EXPORTED int strarray_intersect(const strarray_t *sa, const strarray_t *sb)
 {
+    /* XXX O(n^2)... but we don't have a proper set type */
     int i;
     for (i = 0; i < sa->count; i++)
         if (strarray_find(sb, strarray_nth(sa, i), 0) >= 0)
@@ -455,6 +456,7 @@ EXPORTED int strarray_intersect(const strarray_t *sa, const strarray_t *sb)
 
 EXPORTED int strarray_intersect_case(const strarray_t *sa, const strarray_t *sb)
 {
+    /* XXX O(n^2)... but we don't have a proper set type */
     int i;
     for (i = 0; i < sa->count; i++)
         if (strarray_find_case(sb, strarray_nth(sa, i), 0) >= 0)


### PR DESCRIPTION
Adds a "specialuse_nochildren" imapd.conf option and a corresponding check in `mboxlist_create_namecheck()`.  If the immediate parent of the mailbox to be created has a special-use attribute listed in `specialuse_nochildren`, the create is rejected (IMAP_PERMISSION_DENIED).

This restriction does not apply to admins (so replication to a server with different configuration can still succeed), but does apply to ordinary users with implicit admin rights to their own mailboxes.

To-do: we talked about restricting attempts to setmetadata special-use attributes in this list on mailboxes that already have children.  I'm not yet sure where to hook this in; guidance appreciated!

Open questions:
* should we somehow prevent/complain/ignore if "\Inbox" is set in this list?
* any weird cases I haven't anticipated/tested for?

Corresponding Cassandane tests at https://github.com/cyrusimap/cassandane/compare/master...elliefm:no-junktrash-subfolders