### PR TITLE
fix sync_client crash when racing against script updates

### DIFF
--- a/imap/sievedir.c
+++ b/imap/sievedir.c
@@ -87,10 +87,14 @@ EXPORTED int sievedir_foreach(const char *sievedir,
 
     while ((dir = readdir(dp)) != NULL) {
         const char *name = dir->d_name;
+        const char *dot;
         char target[PATH_MAX] = "";
         struct stat sbuf;
 
         if (!strcmp(name, ".") || !strcmp(name, "..")) continue;
+
+        /* ignore transient .NEW files */
+        if ((dot = strrchr(name, '.')) && !strcmp(dot, ".NEW")) continue;
 
         strlcpy(path + dir_len, name, sizeof(path) - dir_len);
 

--- a/imap/sievedir.c
+++ b/imap/sievedir.c
@@ -166,7 +166,10 @@ EXPORTED struct buf *sievedir_get_script(const char *sievedir,
     buf_printf(&buf, "%s/%s", sievedir, script);
 
     int fd = open(buf_cstring(&buf), 0);
-    if (fd < 0) return NULL;
+    if (fd < 0) {
+        buf_free(&buf);
+        return NULL;
+    }
 
     buf_free(&buf);
     buf_refresh_mmap(&buf, 1, fd, script, MAP_UNKNOWN_LEN, "sieve");

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -952,7 +952,7 @@ static int list_cb(const char *sievedir,
         /* calculate the sha1 on the fly, relatively cheap */
         struct buf *buf = sievedir_get_script(sievedir, name);
 
-        if (buf_len(buf)) {
+        if (buf && buf_len(buf)) {
             struct message_guid guid;
 
             message_guid_generate(&guid, buf_base(buf), buf_len(buf));


### PR DESCRIPTION
Found by Sentry.  What happened was that sync_client went to build a list of the current sieve scripts for a user, while an update was being applied to (one of) that user's script(s).  `sieve_foreach()` saw the "websieve.script.NEW" in `readdir()` and passed it through to the callback; the callback called `sievedir_get_script()` on it, which returned NULL because that filename was already gone; and then the callback crashed because it didn't expect a NULL there.

This does three things:

* The `list_cb()` callback now ignores NULL returns from `sievedir_get_script()` instead of crashing (but perhaps it should also log them?)
* The `sievedir_foreach()` function now ignores filenames ending in ".NEW" -- I believe we don't want this API to see them.  Is that right?
* Fixes an unrelated memory leak in `sievedir_get_script()` when it returns NULL.

This seems to be the smallest change to fix this particular race/crash, but perhaps what we really want is some locking here, I'm not sure.  What do you think?