### PR TITLE
hush IOERROR from squatter in uninteresting case

### DIFF
--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -774,6 +774,12 @@ static void do_rolling(const char *channel)
                     /* XXX: alternative, just append to strarray_t *mboxnames ... */
                     sync_log_channel_append(channel, mboxname);
                 }
+                else if (r == IMAP_MAILBOX_NONEXISTENT) {
+                    /* should_index() checked for this, but we lost a race.
+                     * not an IOERROR, just annoying!
+                     */
+                    syslog(LOG_DEBUG, "skipping nonexistent mailbox: %s", mboxname);
+                }
                 else if (r) {
                     syslog(LOG_ERR, "IOERROR: squatter failed to index and forgetting %s: %s",
                            mboxname, error_message(r));


### PR DESCRIPTION
This shushes the IOERROR from squatter when the mailbox it's trying to index doesn't exist anymore.  It's usually prevented anyway by the `if (!should_index(mboxname)) continue;` a few lines up, but sometimes it loses that race and the mboxname still existed when `should_index()` checked, but is gone a moment later when `index_one()` gets to it.

We still want to know if something real goes wrong here, but if it's merely that the mailbox isn't there anymore, it's not interesting.

I believe this will fix the sporadic CI errors from the JMAPTestSuite.t:Mailbox:set:... tests, which have a tendency to tickle this case by doing a few renames in quick succession (and then Cassandane complains about the IOERROR).