### PR TITLE
jmap_mail: return AttachmentMatch in SearchSnippet/get

### DIFF
--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -401,9 +401,18 @@ static int _matchmime_tr_begin_message(search_text_receiver_t *rx, message_t *ms
     return xapian_dbw_begin_doc(tr->dbw, guid, 'G');
 }
 
+static int _matchmime_tr_begin_bodypart(search_text_receiver_t *rx __attribute__((unused)),
+                                        const char *partid __attribute__((unused)),
+                                        const struct message_guid *content_guid __attribute__((unused)),
+                                        const char *type __attribute__((unused)),
+                                        const char *subtype __attribute__((unused)))
+
+{
+    return 0;
+}
+
 static void _matchmime_tr_begin_part(search_text_receiver_t *rx __attribute__((unused)),
-                                     int part __attribute__((unused)),
-                                     const struct message_guid *content_guid __attribute__((unused)))
+                                     int part __attribute__((unused)))
 {
 }
 
@@ -426,6 +435,10 @@ static void _matchmime_tr_end_part(search_text_receiver_t *rx, int part)
     struct matchmime_receiver *tr = (struct matchmime_receiver *) rx;
     xapian_dbw_doc_part(tr->dbw, &tr->buf, part);
     buf_reset(&tr->buf);
+}
+
+static void _matchmime_tr_end_bodypart(search_text_receiver_t *rx __attribute__((unused)))
+{
 }
 
 static int _matchmime_tr_end_message(search_text_receiver_t *rx, uint8_t indexlevel)
@@ -973,9 +986,11 @@ HIDDEN matchmime_t *jmap_email_matchmime_init(const struct buf *mime, json_t **e
             _matchmime_tr_first_unindexed_uid,
             _matchmime_tr_is_indexed,
             _matchmime_tr_begin_message,
+            _matchmime_tr_begin_bodypart,
             _matchmime_tr_begin_part,
             _matchmime_tr_append_text,
             _matchmime_tr_end_part,
+            _matchmime_tr_end_bodypart,
             _matchmime_tr_end_message,
             _matchmime_tr_end_mailbox,
             _matchmime_tr_flush,

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -584,8 +584,16 @@ static int begin_message(search_text_receiver_t *rx,
     return 0;
 }
 
-static void begin_part(search_text_receiver_t *rx, int part,
-                       const struct message_guid *content_guid __attribute__((unused)))
+static int begin_bodypart(search_text_receiver_t *rx __attribute__((unused)),
+                          const char *partid __attribute__((unused)),
+                          const struct message_guid *content_guid __attribute__((unused)),
+                          const char *type __attribute__((unused)),
+                          const char *subtype __attribute__((unused)))
+{
+    return 0;
+}
+
+static void begin_part(search_text_receiver_t *rx, int part)
 {
     SquatReceiverData *d = (SquatReceiverData *) rx;
     char part_char = 0;
@@ -694,6 +702,11 @@ static void end_part(search_text_receiver_t *rx,
     d->doc_is_open = 0;
     buf_reset(&d->pending_text);
 }
+
+static void end_bodypart(search_text_receiver_t *rx __attribute__((unused)))
+{
+}
+
 
 static int end_message(search_text_receiver_t *rx,
                        uint8_t indexlevel __attribute__((unused)))
@@ -984,9 +997,11 @@ static search_text_receiver_t *begin_update(int verbose)
     d->super.first_unindexed_uid = first_unindexed_uid;
     d->super.is_indexed = is_indexed;
     d->super.begin_message = begin_message;
+    d->super.begin_bodypart = begin_bodypart;
     d->super.begin_part = begin_part;
     d->super.append_text = append_text;
     d->super.end_part = end_part;
+    d->super.end_bodypart = end_bodypart;
     d->super.end_message = end_message;
     d->super.end_mailbox = end_mailbox;
     d->super.index_charset_flags = squat_charset_flags;


### PR DESCRIPTION
If clients requested SearchSnippets with the non-standard partIds argument, then we now return a new field in the response:
the `attachments` property includes the file name and type of all attachments that matched the query. If the query text matches the attachment file name, then the `name` property of the respective AttachMatch is highlighted.

This patch bears a slight risk of regression:

- We change the API for search callbacks, so there is a potential to introduce bugs in the indexing process. However, the changes are small: rather than passing the content guid of the indexed body part along with the indexed search part, we have a new API call that passes the content guid.

- Previously, we passed a NULL content guid for non-body search parts. Now we check the search party type when preparing the text segments for indexing: https://github.com/cyrusimap/cyrus-imapd/blob/jmap_searchsnippet_attachmentmatch/imap/search_xapian.c#L2437

Tested in https://github.com/cyrusimap/cassandane/commit/45ffe47cd628fb1f3fa039cb724598348a5f65f0