### PR TITLE
Fix two use after free segfaults

### DIFF
--- a/imap/backend.h
+++ b/imap/backend.h
@@ -71,6 +71,7 @@ struct backend {
     struct prot_waitevent *timeout; /* event for idle timeout */
 
     sasl_conn_t *saslconn;
+    sasl_callback_t *sasl_cb;
 #ifdef HAVE_SSL
     SSL *tlsconn;
     SSL_SESSION *tlssess;

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -105,7 +105,6 @@ int mupdate_connect(const char *server,
 		    sasl_callback_t *cbs)
 {
     mupdate_handle *h = NULL;
-    int local_cbs = 0;
     const char *status = NULL;
     
     if(!handle)
@@ -122,21 +121,21 @@ int mupdate_connect(const char *server,
     h = xzmalloc(sizeof(mupdate_handle));
     *handle = h;
 
+    h->sasl_cb = NULL;
     if(!cbs) {
-	local_cbs = 1;
 	cbs = mysasl_callbacks(config_getstring(IMAPOPT_MUPDATE_USERNAME),
 			       config_getstring(IMAPOPT_MUPDATE_AUTHNAME),
 			       config_getstring(IMAPOPT_MUPDATE_REALM),
 			       config_getstring(IMAPOPT_MUPDATE_PASSWORD));
+        h->sasl_cb = cbs;
     }
 
     h->conn = backend_connect(NULL, server, &mupdate_protocol,
 			      "", cbs, &status);
 
-    /* xxx unclear that this is correct, but it prevents a memory leak */
-    if (local_cbs) free_callbacks(cbs);
-
     if (!h->conn) {
+        free_callbacks(h->sasl_cb);
+        h->sasl_cb = NULL;
         syslog(LOG_ERR, "mupdate_connect failed: %s", status ? status : "no auth status");
 	return MUPDATE_NOCONN;
     }
@@ -156,6 +155,9 @@ void mupdate_disconnect(mupdate_handle **hp)
 
     backend_disconnect(h->conn);
     free(h->conn);
+
+    free_callbacks(h->sasl_cb);
+    h->sasl_cb = NULL;
 
     buf_free(&(h->tag));
     buf_free(&(h->cmd));

--- a/imap/mupdate.h
+++ b/imap/mupdate.h
@@ -62,6 +62,7 @@
 #include "global.h"
 
 struct mupdate_handle_s {
+    sasl_callback_t *sasl_cb;
     struct backend *conn;
 
     /* For keeping track of what tag # is next */


### PR DESCRIPTION
This PR resolves two use after free conditions in cyrus-imapd 2.4 concerning the libsasl callback data structures, which lead to arbitrary segfaults.