### PR TITLE
squat: fix broken squat engine integration for indexed search

### DIFF
--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -81,6 +81,7 @@ static const struct search_engine default_search_engine = {
     NULL,
     NULL,
     NULL,
+    NULL,
     NULL
 };
 
@@ -342,4 +343,10 @@ const char *search_op_as_string(int op)
         snprintf(buf, sizeof(buf), "(%d)", op);
         return buf;
     }
+}
+
+EXPORTED int search_can_match(enum search_op matchop, int partnum)
+{
+    const struct search_engine *se = search_engine();
+    return (se->can_match ? se->can_match(matchop, partnum) : 0);
 }

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -183,6 +183,7 @@ struct search_engine {
     int (*deluser)(const char *userid);
     int (*check_config)(char **errstr);
     int (*langstats)(const char *userid, ptrarray_t *lstats, size_t *total_docs);
+    int (*can_match)(enum search_op matchop, int partnum);
 };
 
 /* Returns the configured search engine */
@@ -237,6 +238,7 @@ int search_compact(const char *userid, const strarray_t *reindextiers,
 int search_deluser(const char *userid);
 int search_check_config(char **errstr);
 
+int search_can_match(enum search_op matchop, int partnum);
 
 /* for debugging */
 extern const char *search_op_as_string(int op);

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -1046,9 +1046,10 @@ static int is_indexed_node(const search_expr_t *e)
 {
     if (e->op == SEOP_NOT)
         return is_indexed_node(e->children);
-    return (e->op == SEOP_FUZZYMATCH &&
-            e->attr &&
-            e->attr->part != SEARCH_PART_NONE);
+
+    return e->attr &&
+        ((e->op == SEOP_FUZZYMATCH && e->attr->part != SEARCH_PART_NONE) ||
+         (e->op == SEOP_MATCH && search_can_match(e->op, e->attr->part)));
 }
 
 static int is_folder_or_indexed(search_expr_t *e, void *rock __attribute__((unused)))

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -604,8 +604,9 @@ EXPORTED void search_build_query(search_builder_t *bx, search_expr_t *e)
         bop = SEARCH_OP_OR;
         break;
 
+    case SEOP_MATCH:
     case SEOP_FUZZYMATCH:
-        if (e->attr && e->attr->part >= 0) {
+        if (e->attr && search_can_match(e->op, e->attr->part)) {
             if (e->attr->flags & SEA_ISLIST) {
                 bx->matchlist(bx, e->attr->part, e->value.list);
             } else {

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -93,17 +93,22 @@ typedef struct {
 static const char *squat_strerror(int err);
 
 static const char * const doctypes_by_part[SEARCH_NUM_PARTS] = {
-    "mh",
-    "f",
-    "t",
-    "c",
-    "b",
-    "s",
-    "h",
-    "m",
-    "o",
-    "a",
-    "ab"
+    "msh", // SEARCH_PART_ANY
+    "f",   // SEARCH_PART_FROM
+    "t",   // SEARCH_PART_TO
+    "c",   // SEARCH_PART_CC
+    "b",   // SEARCH_PART_BCC
+    "s",   // SEARCH_PART_SUBJECT
+    NULL,  // SEARCH_PART_LISTID
+    NULL,  // SEARCH_PART_TYPE
+    "h",   // SEARCH_PART_HEADERS
+    "m",   // SEARCH_PART_BODY
+    "o",   // SEARCH_PART_LOCATION
+    "a",   // SEARCH_PART_ATTACHMENTNAME
+    NULL,  // SEARCH_PART_ATTACHMENTBODY
+    NULL,  // SEARCH_PART_DELIVEREDTO
+    NULL,  // SEARCH_PART_LANGUAGE
+    NULL   // SEARCH_PART_PRIORITY
 };
 
 /* The document name is of the form
@@ -432,10 +437,7 @@ static int run(search_builder_t *bx, search_hit_cb_t proc, void *rock)
     unsigned int uid;
     int r = 0;
 
-#if DEBUG
-    if (bb->verbose > 1)
-        syslog(LOG_NOTICE, "Squat end_search()");
-#endif
+    syslog(bb->verbose > 1 ? LOG_NOTICE : LOG_DEBUG, "Squat run()");
 
     /* check we had balanced ->begin_boolean and ->end_boolean calls */
     if (bb->depth != 1)
@@ -1013,6 +1015,12 @@ static int end_update(search_text_receiver_t *rx)
     return 0;
 }
 
+static int can_match(enum search_op matchop, int partnum)
+{
+    return (matchop == SEOP_MATCH || matchop == SEOP_FUZZYMATCH) &&
+        doctypes_by_part[partnum];
+}
+
 const struct search_engine squat_search_engine = {
     "SQUAT",
     0,
@@ -1028,6 +1036,7 @@ const struct search_engine squat_search_engine = {
     /* compact */NULL,
     /* deluser */NULL,
     /* check_config */NULL,
-    /* langstats */NULL
+    /* langstats */NULL,
+    can_match
 };
 

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -4169,6 +4169,11 @@ out:
     return r;
 }
 
+static int can_match(enum search_op matchop, int partnum)
+{
+    return matchop == SEOP_FUZZYMATCH && partnum != SEARCH_PART_NONE;
+}
+
 const struct search_engine xapian_search_engine = {
     "Xapian",
     SEARCH_FLAG_CAN_BATCH | SEARCH_FLAG_CAN_GUIDSEARCH,
@@ -4184,6 +4189,7 @@ const struct search_engine xapian_search_engine = {
     compact_dbs,
     delete_user,  /* XXX: fixme */
     check_config,
-    langstats
+    langstats,
+    can_match
 };
 


### PR DESCRIPTION
This PR aims to fix #2598 . As a consequence of the rewrite of the search API for Cyrus v3, text match search expressions were only regarded as indexed if the search operator is a FUZZYMATCH. Consequently, if Cyrus is configured to use the squat search backend, then all text queries are handled as MATCH expressions any text search results in a global scan rather than making make use of squat indexes.

The patch in this PR fixes the issue for the current master branch. I plan to backport it to the upcoming v3.5 release, but had trouble building it due to incompabilities with the sasl API. Is this a known issue, @elliefm ?

The branch https://github.com/cyrusimap/cassandane/tree/fix_squat_search adds a new SearchSquat test module which contains simple regression tests that assert if the squat engine actually is called.