### PR TITLE
Fix assertion failure in imapd listing subscriptions from twoskip db

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -4583,8 +4583,7 @@ EXPORTED strarray_t *mboxlist_sublist(const char *userid)
     r = mboxlist_opensubs(userid, &subs);
     if (r) goto done;
 
-    /* faster to do it all in a single slurp! */
-    r = cyrusdb_foreach(subs, "", 0, subsadd_cb, NULL, list, 0);
+    r = cyrusdb_foreach(subs, "", 0, NULL, subsadd_cb, list, 0);
 
     mboxlist_closesubs(subs);
 

--- a/imap/userdeny_db.c
+++ b/imap/userdeny_db.c
@@ -333,7 +333,7 @@ EXPORTED int denydb_foreach(denydb_proc_t proc, void *rock)
     dr.rock = rock;
 
     return cyrusdb_foreach(denydb, "", 0,
-                           denydb_foreach_cb, NULL, &dr,
+                           NULL, denydb_foreach_cb, &dr,
                            /* txn */NULL);
 }
 

--- a/lib/cyrusdb_flat.c
+++ b/lib/cyrusdb_flat.c
@@ -502,6 +502,8 @@ static int foreach(struct dbengine *db,
 
     struct buf prefixbuf = BUF_INITIALIZER;
 
+    assert(cb);
+
     r = starttxn_or_refetch(db, mytid);
     if (r) return r;
 

--- a/lib/cyrusdb_quotalegacy.c
+++ b/lib/cyrusdb_quotalegacy.c
@@ -581,6 +581,8 @@ static int foreach(struct dbengine *db,
     int i;
     char *tmpprefix = NULL, *p = NULL;
 
+    assert(cb);
+
     /* if we need to truncate the prefix, do so */
     if (prefix[prefixlen] != '\0') {
         tmpprefix = xmalloc(prefixlen + 1);

--- a/lib/cyrusdb_skiplist.c
+++ b/lib/cyrusdb_skiplist.c
@@ -1095,6 +1095,7 @@ static int myforeach(struct dbengine *db,
     int need_unlock = 0;
 
     assert(db != NULL);
+    assert(cb);
 
     /* Hacky workaround:
      *

--- a/lib/test/rnddb.c
+++ b/lib/test/rnddb.c
@@ -211,11 +211,11 @@ int main(int argc, char *argv[])
             count = 0;
             victim = NULL;
             txn = NULL;
-            TRY(cyrusdb_foreach(db, NULL, 0, &countem, NULL, NULL, &txn));
+            TRY(cyrusdb_foreach(db, NULL, 0, NULL, &countem, NULL, &txn));
 
             if (count == 0) continue;
 
-            TRY(cyrusdb_foreach(db, NULL, 0, &findvictim, NULL, NULL, &txn));
+            TRY(cyrusdb_foreach(db, NULL, 0, NULL, &findvictim, NULL, &txn));
 
             assert(victim != NULL);
 
@@ -245,11 +245,11 @@ int main(int argc, char *argv[])
             count = 0;
             victim = NULL;
             txn = NULL;
-            TRY(cyrusdb_foreach(db, NULL, 0, &countem, NULL, NULL, &txn));
+            TRY(cyrusdb_foreach(db, NULL, 0, NULL, &countem, NULL, &txn));
 
             if (count == 0) continue;
 
-            TRY(cyrusdb_foreach(db, NULL, 0, &findvictim, NULL, NULL, &txn));
+            TRY(cyrusdb_foreach(db, NULL, 0, NULL, &findvictim, NULL, &txn));
             assert(victim != NULL);
 
             /* delete it */


### PR DESCRIPTION
I find that running `listmailbox` in cyradm causes the servicing imapd process to immediately exit with an assertion failure.  (Running v3.2.5 on Arch Linux, but same with older versions on FreeBSD.)  I have a twoskip subscription database.

Looking in gdb, the problem seems to be that mboxlist_sublist() provides its callback pointer to cyrusdb_foreach() in the wrong position.  Parameters four and five to cyrusdb_foreach() are both callback pointers, but only parameter four may be null; the twoskip myforeach() asserts this is true, resulting in an assertion failure (in myforeach() in lib/cyrusdb_twoskip.c) if the subscription database is twoskip.

I guess most people don't see this since the subscription database is not twoskip by default.

This pull request swap arguments four and five in the cyrusdb_foreach() call in mboxlist_sublist() so we pass the callback where it is required.

Tested with v3.2.5: cyradm `listmailbox` works as expected.