### PR TITLE
fix sasl callback cleanup

### DIFF
--- a/imap/mupdate.h
+++ b/imap/mupdate.h
@@ -62,6 +62,7 @@
 #include "imap/mupdate_err.h"
 
 struct mupdate_handle_s {
+    sasl_callback_t *sasl_cb;
     struct backend *conn;
 
     /* For keeping track of what tag # is next */


### PR DESCRIPTION
This is the same thing as #3312 (2.4), but for master, which already had some, but not all, of the fixes it contained.

* fixes use after free crash in mupdate-client
* fixes memory leaks in backend when sasl_client_new or sasl_setprop fail

Once this is reviewed and merged I'll cherry-pick it to the other branches

Closes #3320 