### PR TITLE
xapian: remove support for experimental v4 legacy indexes

### DIFF
--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -762,7 +762,7 @@ static int _email_matchmime_evaluate(json_t *filter,
         int matches = 0;
         xapian_query_t *xq = xapian_query_new_compound(db, /*is_or*/0,
                 (xapian_query_t **) xqs.data, xqs.count);
-        xapian_query_run(db, xq, 0, _email_matchmime_evaluate_xcb, &matches);
+        xapian_query_run(db, xq, _email_matchmime_evaluate_xcb, &matches);
         xapian_query_free(xq);
         size_t xqs_count = xqs.count;
         ptrarray_fini(&xqs);

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1324,7 +1324,6 @@ struct xapian_db
 {
     std::string *paths;
     Xapian::Database *database; // all but version 4 databases
-    Xapian::Database *legacydbv4; // version 4 databases
     std::vector<Xapian::Database> *subdbs; // all database subdbs
     Xapian::Stem *default_stemmer;
     const Xapian::Stopper* default_stopper;
@@ -1341,7 +1340,6 @@ static int xapian_db_init(xapian_db_t *db)
     try {
         db->parser = new Xapian::QueryParser;
         db->parser->set_default_op(Xapian::Query::OP_AND);
-        db->parser->set_database(db->database ? *db->database : *db->legacydbv4);
         db->default_stemmer = new Xapian::Stem(new CyrusSearchStemmer);
         db->default_stopper = get_stopper("en");
 
@@ -1390,16 +1388,15 @@ int xapian_db_open(const char **paths, xapian_db_t **dbp)
             if (!db->db_versions)
                 db->db_versions = new std::set<int>;
             db->db_versions->insert(db_versions.begin(), db_versions.end());
-            // Databases with version 4 split indexing by doctype.
+            // Check for experimental v4 indexes, they were bogus.
             if (db_versions.find(4) != db_versions.end()) {
-                if (!db->legacydbv4) db->legacydbv4 = new Xapian::Database;
-                db->legacydbv4->add_database(subdb);
+                xsyslog(LOG_WARNING, "deprecated v4 index detected, "
+                        "search may return wrong results",
+                        "db=<%s>", thispath);
             }
-            // Databases with any but version 4 are regular dbs.
-            if (db_versions.size() > 1 || db_versions.find(4) == db_versions.end()) {
-                if (!db->database) db->database = new Xapian::Database;
-                db->database->add_database(subdb);
-            }
+            // Add database.
+            if (!db->database) db->database = new Xapian::Database;
+            db->database->add_database(subdb);
 
             // Xapian database has no API to access subdbs.
             if (!db->subdbs) db->subdbs = new std::vector<Xapian::Database>;
@@ -1409,7 +1406,7 @@ int xapian_db_open(const char **paths, xapian_db_t **dbp)
         }
         thispath = "(unknown)";
 
-        if (!db->database && !db->legacydbv4) {
+        if (!db->database) {
             r = IMAP_NOTFOUND;
             goto done;
         }
@@ -1460,7 +1457,6 @@ void xapian_db_close(xapian_db_t *db)
     if (!db) return;
     try {
         if (!db->dbw) delete db->database;
-        delete db->legacydbv4;
         delete db->parser;
         delete db->paths;
         delete db->db_versions;
@@ -1508,16 +1504,6 @@ int xapian_db_langstats(xapian_db_t *db, ptrarray_t* lstats, size_t *nolang)
 void xapian_query_add_stemmer(xapian_db_t *db, const char *iso_lang)
 {
     if (strcmp(iso_lang, "en")) db->stem_languages->insert(iso_lang);
-}
-
-int xapian_db_has_otherthan_v4_index(const xapian_db_t *db)
-{
-    return db->database != NULL;
-}
-
-int xapian_db_has_legacy_v4_index(const xapian_db_t *db)
-{
-    return db->legacydbv4 != NULL;
 }
 
 static Xapian::Query* query_new_textmatch(const xapian_db_t *db,
@@ -2040,17 +2026,17 @@ void xapian_query_free(xapian_query_t *qq)
     }
 }
 
-int xapian_query_run(const xapian_db_t *db, const xapian_query_t *qq, int is_legacy,
+int xapian_query_run(const xapian_db_t *db, const xapian_query_t *qq,
                      int (*cb)(void *data, size_t n, void *rock), void *rock)
 {
     const Xapian::Query *query = (const Xapian::Query *)qq;
     void *data = NULL;
     size_t n = 0;
 
-    if ((is_legacy && !db->legacydbv4) || (!is_legacy && !db->database)) return 0;
+    if (!db->database) return 0;
 
     try {
-        Xapian::Database *database = is_legacy ? db->legacydbv4 : db->database;
+        Xapian::Database *database = db->database;
         Xapian::Enquire enquire(*database);
         enquire.set_query(*query);
         enquire.set_sort_by_value(0, false); // sort by cyrusid ascending

--- a/imap/xapian_wrap.h
+++ b/imap/xapian_wrap.h
@@ -87,7 +87,7 @@ extern xapian_query_t *xapian_query_new_matchall(const xapian_db_t *);
 extern xapian_query_t *xapian_query_new_not(const xapian_db_t *, xapian_query_t *);
 extern xapian_query_t *xapian_query_new_has_doctype(const xapian_db_t *, char doctype, xapian_query_t *);
 extern void xapian_query_free(xapian_query_t *);
-extern int xapian_query_run(const xapian_db_t *, const xapian_query_t *query, int is_legacy,
+extern int xapian_query_run(const xapian_db_t *, const xapian_query_t *query,
                             int (*cb)(void *base, size_t n, void *rock), void *rock);
 /* snippets interface */
 extern xapian_snipgen_t *xapian_snipgen_new(xapian_db_t *db, const char *hi_start, const char *hi_end, const char *omit);
@@ -101,9 +101,6 @@ extern int xapian_snipgen_end_doc(xapian_snipgen_t *snipgen, struct buf *);
 extern int xapian_filter(const char *dest, const char **sources,
                          int (*cb)(const char *cyrusid, void *rock),
                          void *rock);
-/* XXX legacy version 4 DB support */
-extern int xapian_db_has_legacy_v4_index(const xapian_db_t *);
-extern int xapian_db_has_otherthan_v4_index(const xapian_db_t *);
 
 /* Language indexing support */
 extern int xapian_db_langstats(xapian_db_t*, ptrarray_t*, size_t*);


### PR DESCRIPTION
Couple of years ago we experimented with indexing email body parts solely with their content guid. That didn't work out well with queries that filter by both email headers and bodies. We quickly introduced a new version index version 5 that undid the bug, but kept code to deal with the bogus index. Now it is time to get rid of it, as we don't want to keep dead code.

@elliefm this patch cherry-picks cleanly on the 3.4 branch. It passes JMAPEmail and SearchFuzzy tests on both the master and 3.4 branches.