### PR TITLE
message: cache mail address names as quoted-string, if necessary

### DIFF
--- a/changes/next/message_cache_quotedaddr
+++ b/changes/next/message_cache_quotedaddr
@@ -1,0 +1,11 @@
+Description:
+
+Fix a bug in cached email address fields, where names where stored without quotes.
+
+Config changes:
+
+None.
+
+Upgrade instructions:
+
+Existing mailbox caches need to be reconstructed and search indexes must be reindexed. It is recommeded to upgrade. If not, installations may continue without upgrading, but this may result in false negative and false positive search results, or other unknown issues.

--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -1296,4 +1296,61 @@ static void test_cache_appleheaders(void)
     message_free_body(&body);
 }
 
+static void test_cache_quotedaddr(void)
+{
+    static const char msg[] =
+"From: \"Fred (Bloggs)\" <fbloggs@fastmail.fm>\r\n"
+"To: Sarah Smith <sjsmith@gmail.com>\r\n"
+"Cc: \"Al \\\"Scarface\\\" Capone\" <al@speakeasy.com>\r\n"
+"Bcc: =?ISO-8859-1?q?Caf=E9_del_Mar?= <cafe@delmar>\r\n"
+"Date: Wed, 27 Oct 2010 18:37:26 +1100\r\n"
+"Subject: Trivial testing email\r\n"
+"Message-ID: <fake800@fastmail.fm>\r\n"
+"Content-Type: text/plain\r\n"
+"X-Mailer: Norman\r\n"
+"\r\n"
+"Hello, World\n";
+    int r;
+    struct body *body = xzmalloc(sizeof(struct body));
+
+    memset(body, 0x45, sizeof(struct body));
+    r = message_parse_mapped(msg, sizeof(msg)-1, body, NULL);
+
+    CU_ASSERT_EQUAL(r, 0);
+
+    struct index_record record;
+    r = message_write_cache(&record, body);
+    CU_ASSERT_EQUAL(r, 0);
+
+    message_free_body(body);
+    free(body);
+
+    struct buf buf = BUF_INITIALIZER;
+
+    /* Needs quotes */
+    struct cacheitem item = record.crec.item[CACHE_FROM];
+    buf_setmap(&buf, record.crec.buf->s + item.offset, item.len);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "\"Fred (Bloggs)\" <fbloggs@fastmail.fm>");
+
+    item = record.crec.item[CACHE_CC];
+    buf_setmap(&buf, record.crec.buf->s + item.offset, item.len);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "\"Al \\\"Scarface\\\" Capone\" <al@speakeasy.com>");
+
+    /* Needs quotes, with UTF-8 */
+    item = record.crec.item[CACHE_BCC];
+    buf_setmap(&buf, record.crec.buf->s + item.offset, item.len);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "\"Café del Mar\" <cafe@delmar>");
+    struct address *addr = NULL;
+    parseaddr_list(buf_cstring(&buf), &addr);
+    CU_ASSERT_STRING_EQUAL(addr->name, "Café del Mar");
+    parseaddr_free(addr);
+
+    /* Does not need quotes */
+    item = record.crec.item[CACHE_TO];
+    buf_setmap(&buf, record.crec.buf->s + item.offset, item.len);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "Sarah Smith <sjsmith@gmail.com>");
+
+    buf_free(&buf);
+}
+
 /* vim: set ft=c: */

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -80,7 +80,7 @@
  * versions placed this function in imapd.c FYI!
  */
 #define MAILBOX_MINOR_VERSION   17
-#define MAILBOX_CACHE_MINOR_VERSION 10
+#define MAILBOX_CACHE_MINOR_VERSION 11
 
 #define FNAME_HEADER "/cyrus.header"
 #define FNAME_INDEX "/cyrus.index"

--- a/imap/message.c
+++ b/imap/message.c
@@ -2652,7 +2652,34 @@ static void message_write_searchaddr(struct buf *buf,
 
             if (addrlist->name) {
                 tmp = charset_parse_mimeheader(addrlist->name, charset_flags);
-                buf_appendcstr(buf, tmp);
+                /* Determine if name is an atext or quoted-string */
+                static const char *atext_specials = "!#$%&'*+-/=?^_`{|}~";
+                const char *c;
+                for (c = tmp; *c; c++) {
+                    // see RFC 5322, section 3.2.3
+                    if (!isalpha(*c) && !isdigit(*c) && !isspace(*c) &&
+                            !strchr(atext_specials, *c)) {
+                        break;
+                    }
+                }
+                int need_quote = *c;
+                /* Write name */
+                if (need_quote) {
+                    struct buf qtext = BUF_INITIALIZER;
+                    buf_ensure(&qtext, strlen(tmp) + 2);
+                    buf_putc(&qtext, '"');
+                    for (c = tmp; *c; c++) {
+                        if (*c == '\\' || *c == '"')
+                            buf_putc(&qtext, '\\');
+                        buf_putc(&qtext, *c);
+                    }
+                    buf_putc(&qtext, '"');
+                    buf_copy(buf, &qtext);
+                    buf_free(&qtext);
+                }
+                else {
+                    buf_appendcstr(buf, tmp);
+                }
                 free(tmp); tmp = NULL;
                 buf_putc(buf, ' ');
             }


### PR DESCRIPTION
This patch fixes a bug where email addresses with quoted-string names were stored in the index cacherecord without quotes. If such an cached address is reparsed, then the parseaddr lib drops the invalid atoms from the name. In other words: the result of reading an address from cache may differ from the address that was written. This has shown to be a problem in search indexing, but it may just as well have resulted in bugs in other parts of Cyrus.

The cunit tests were updated. In addition, the mailbox minor cache version was bumped.

Addendum: Independently, we may want to make parseaddr more lenient with regards to invalid [atext](https://tools.ietf.org/html/rfc5322#section-3.2.3) names.