### PR TITLE
allow "UNRELEASED" as imapoptions version string

### DIFF
--- a/tools/config2header
+++ b/tools/config2header
@@ -128,6 +128,7 @@ EXPORTED struct imapopt_s imapopts[] =
 EOF
     ;
 
+my $__warned_unreleased = 0;
 sub parse_last_modified
 {
     my ($version) = @_;
@@ -140,6 +141,23 @@ sub parse_last_modified
         die "revision too large: $rev" if $rev > 255;
 
         return sprintf "0x%2.2X%2.2X%2.2X00", $maj, $min, $rev;
+    }
+    elsif ($version eq 'UNRELEASED') {
+        if (not $__warned_unreleased) {
+            # This warning is to remind the release manager to replace
+            # "UNRELEASED" strings in lib/imapoptions with the version
+            # number that is about to be released.
+            # If you're not building a release, ignore it. :)
+            my $w = join q{ },
+                    "$0:",
+                    -t STDERR ? "\033[33;1mwarning:\033[0m" : 'warning:',
+                    'build contains UNRELEASED config options';
+            print STDERR "$w\n";
+
+            $__warned_unreleased ++;
+        }
+
+        return "0xFFFFFFFF";
     }
     else {
         die "unparseable version: $version";
@@ -301,15 +319,19 @@ while (<STDIN>) {
             # option is deprecated
             if ($6 =~ m|
                     ,\s*            # comma and optional whitespace
-                    (\"[^,]+\")     # $1: 'deprecated since' version string
+                    \"([^,]+)\"     # $1: 'deprecated since' version string
                     \s*             # optional whitespace
                     (               # $2: (unused)
                         ,\s*        # comma and optional whitespace
                         \"(.+)\"    # $3: 'in favour of' option name
                     )?
                 |x) {
-                $depver = $1;
+                $depver = qq{"$1"};
                 $newopt = $3 if $3;
+
+                # we don't use the parsed value here, but we do still want to
+                # detect and report if "UNRELEASED" is seen
+                (undef) = parse_last_modified($1);
             } else {
                 #chomp;
                 #print "rejected '$6'\n";


### PR DESCRIPTION
This resolves the annoying problem of needing to guess what the next Cyrus release version will be when making changes in `lib/imapoptions`, and then needing to keep this updated in your branch if new releases are made before it's merged -- which is becoming more of a nuisance now as our work is likely to sit in a PR for a while before it lands on master.

From now on (well, once this is merged), if you're adding, changing, or deprecating an imapd.conf option, instead of trying to anticipate the next version number, just enter it as the magic string `"UNRELEASED"`.  This works equally well for both the "last_modified" field and the "deprecated_since" field.  Note that the double quotes are required, just as they are for normal version strings.

Part of the process for future releases will be to update these entries with the real release version number, once it is known (i.e. just before release).  The "UNRELEASED" string provides a clear target of which things are new and need to be set correctly.

When building Cyrus, if there are updated config options like this, you will see a warning from make:

```
  GEN      lib/imapopts.c
./tools/config2header: warning: build contains UNRELEASED config options
```

If you're not building a new release, you can ignore this warning.  If you _are_ building a release, you need to resolve this warning (by replacing the "UNRELEASED"s with the new version number) before tagging it.

When using `cyr_info`'s `-s version` switch to look for changed options, UNRELEASED options will have the version 255.255.255, because they needed to have something, and programmatically guessing a version number seemed to defeat the purpose of not guessing a version number...