### PR TITLE
search_expr: make nnodes a non-static variable

### DIFF
--- a/changes/next/search_nonstatic_nnodes
+++ b/changes/next/search_nonstatic_nnodes
@@ -1,0 +1,11 @@
+Description:
+
+Prevents a bug in search, where queries may exceed the search normalization limit.
+
+Config changes:
+
+None. Implementations may want to revisit their search_normalisation_max settings, but its default value 1000 is a good conversative choice. Current server-grade hardware may use 20000 or more.
+
+Upgrade instructions:
+
+None.

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5257,8 +5257,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
     strarray_t perf_filters = STRARRAY_INITIALIZER;
     searchargs = new_searchargs(NULL/*tag*/, GETSEARCH_CHARSET_FIRST,
                                 &jmap_namespace, req->userid, req->authstate, 0);
-    searchargs->root = _email_buildsearch(req, filter, /*contactgroups*/NULL,
-            &perf_filters, NULL);
+    searchargs->root = _email_buildsearchexpr(req, filter, NULL, NULL, &perf_filters);
     strarray_fini(&perf_filters);
 
     /* Build the search query */

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2289,15 +2289,24 @@ static void convert_folderclause(search_expr_t *clause,
     }
 }
 
-static search_expr_t *_email_buildsearch(jmap_req_t *req, json_t *filter,
-                                         hash_table *contactgroups,
-                                         strarray_t *perf_filters,
-                                         int *is_imapfolderptr)
+static int _email_buildsearch(search_expr_t **rootp,
+                              jmap_req_t *req, json_t *filter,
+                              hash_table *contactgroups,
+                              strarray_t *perf_filters,
+                              int *is_imapfolderptr)
 {
-    search_expr_t *root = _email_buildsearchexpr(req, filter, /*parent*/NULL,
-                                                 contactgroups, perf_filters);
     if (is_imapfolderptr) *is_imapfolderptr = 0;
-    if (!root) return NULL;
+    *rootp = NULL;
+
+    search_expr_t *root = _email_buildsearchexpr(req, filter, NULL,
+                                        contactgroups, perf_filters);
+    if (!root) return 0;
+
+    /* Convert tree to DNF, it will converted in search_query anyway */
+    if (search_expr_normalise(&root) < 0) {
+        search_expr_free(root);
+        return IMAP_SEARCH_SLOW;
+    }
 
     /* Is there any JMAP folder expression we could optimize? */
     int has_jmapfolder_expr = 0;
@@ -2315,36 +2324,25 @@ static search_expr_t *_email_buildsearch(jmap_req_t *req, json_t *filter,
         }
     }
     ptrarray_fini(&work);
-    if (!has_jmapfolder_expr) {
-        return root;
-    }
 
-    /* Convert tree to DNF, it will converted in search_query anyway */
-    search_expr_t *original = search_expr_duplicate(root);
-    if (search_expr_normalise(&root) < 0) {
-        search_expr_free(root);
-        return original;
-    }
-    else {
-        search_expr_free(original);
-        original = NULL;
-    }
-
-    /* Now convert at most one inMailboxId expression in each clause to an
-     * IMAP folder search expression. Prefer to convert the same folders. */
-    strarray_t preferred_folders = STRARRAY_INITIALIZER;
-    if (root->op == SEOP_OR) {
-        search_expr_t *c;
-        for (c = root->children; c; c = c->next) {
-            convert_folderclause(c, &preferred_folders, is_imapfolderptr);
+    if (has_jmapfolder_expr) {
+        /* Convert at most one inMailboxId expression in each clause to an
+         * IMAP folder search expression. Prefer to convert the same folders. */
+        strarray_t preferred_folders = STRARRAY_INITIALIZER;
+        if (root->op == SEOP_OR) {
+            search_expr_t *c;
+            for (c = root->children; c; c = c->next) {
+                convert_folderclause(c, &preferred_folders, is_imapfolderptr);
+            }
         }
+        else {
+            convert_folderclause(root, &preferred_folders, is_imapfolderptr);
+        }
+        strarray_fini(&preferred_folders);
     }
-    else {
-        convert_folderclause(root, &preferred_folders, is_imapfolderptr);
-    }
-    strarray_fini(&preferred_folders);
 
-    return root;
+    *rootp = root;
+    return 0;
 }
 
 static void _email_contactfilter_initreq(jmap_req_t *req, struct email_contactfilter *cfilter)
@@ -2534,7 +2532,7 @@ struct emailsearch {
     struct index_init init;
 };
 
-static void _emailsearch_free(struct emailsearch *search)
+static void _emailsearch_fini(struct emailsearch *search)
 {
     if (!search) return;
 
@@ -2547,7 +2545,7 @@ static void _emailsearch_free(struct emailsearch *search)
     search_query_free(search->query);
     freesearchargs(search->args);
 
-    free(search);
+    memset(search, 0, sizeof(struct emailsearch));
 }
 
 static char *_emailsearch_hash(search_expr_t *expr, struct sortcrit *sort)
@@ -2601,18 +2599,20 @@ static int _jmap_checkfolder(const char *mboxname, void *rock)
     return 0;
 }
 
-static struct emailsearch* _emailsearch_new(jmap_req_t *req,
-                                            json_t *filter,
-                                            json_t *jsort,
-                                            hash_table *contactgroups,
-                                            int want_expunged,
-                                            int want_partids,
-                                            int ignore_timer)
+static int _emailsearch_init(struct emailsearch *search,
+                             jmap_req_t *req,
+                             json_t *filter,
+                             json_t *jsort,
+                             hash_table *contactgroups,
+                             int want_expunged,
+                             int want_partids,
+                             int ignore_timer)
 {
-    struct emailsearch* search = xzmalloc(sizeof(struct emailsearch));
+    memset(search, 0, sizeof(struct emailsearch));
 
-    search->expr = _email_buildsearch(req, filter, contactgroups,
-            &search->perf_filters, &search->is_imapfolder);
+    int r = _email_buildsearch(&search->expr, req, filter, contactgroups,
+                               &search->perf_filters, &search->is_imapfolder);
+    if (r) return r;
 
     if (json_array_size(jsort)) {
         search->sort = _email_buildsort(jsort, &search->sort_savedate);
@@ -2635,7 +2635,7 @@ static struct emailsearch* _emailsearch_new(jmap_req_t *req,
     search->want_partids = want_partids;
     search->ignore_timer = ignore_timer;
 
-    return search;
+    return 0;
 }
 
 static int _emailsearch_run_uidsearch(jmap_req_t *req, struct emailsearch *search,
@@ -4175,16 +4175,10 @@ static void _email_query(jmap_req_t *req, struct jmap_emailquery *q,
                          hash_table *contactgroups,
                          json_t **err)
 {
-    struct emailsearch *search = _emailsearch_new(req, q->super.filter,
-                                                  q->super.sort,
-                                                  contactgroups, 0,
-                                                  q->want_partids, 0);
-    int r = 0;
-
-    if (!search) {
-        *err = jmap_server_error(IMAP_INTERNAL);
-        goto done;
-    }
+    struct emailsearch search;
+    int r = _emailsearch_init(&search, req, q->super.filter, q->super.sort,
+                              contactgroups, 0, q->want_partids, 0);
+    if (r) goto done;
 
     /* make query state */
     modseq_t modseq = jmap_highestmodseq(req, MBTYPE_EMAIL);
@@ -4195,8 +4189,8 @@ static void _email_query(jmap_req_t *req, struct jmap_emailquery *q,
     if (jmap_is_using(req, JMAP_PERFORMANCE_EXTENSION)) {
         int i;
         json_t *jfilters = json_array();
-        for (i = 0; i < strarray_size(&search->perf_filters); i++) {
-            const char *cost = strarray_nth(&search->perf_filters, i);
+        for (i = 0; i < strarray_size(&search.perf_filters); i++) {
+            const char *cost = strarray_nth(&search.perf_filters, i);
             json_array_append_new(jfilters, json_string(cost));
         }
         json_object_set_new(req->perf_details, "filters", jfilters);
@@ -4206,7 +4200,7 @@ static void _email_query(jmap_req_t *req, struct jmap_emailquery *q,
     int is_guidsearch = 0;
     if (!q->disable_guidsearch && !q->super.calculate_total &&
         (q->super.limit || !q->super.have_limit) && !q->want_partids) {
-        r = _email_query_guidsearch(req, q, search, err);
+        r = _email_query_guidsearch(req, q, &search, err);
         if (r == IMAP_SEARCH_NOT_SUPPORTED) {
             /* Fallback to UID search */
             r = 0;
@@ -4215,15 +4209,15 @@ static void _email_query(jmap_req_t *req, struct jmap_emailquery *q,
         else is_guidsearch = 1;
     }
     if (!is_guidsearch) {
-        r = _email_query_uidsearch(req, q, search, err);
+        r = _email_query_uidsearch(req, q, &search, err);
     }
 
-    q->super.can_calculate_changes = _email_query_is_mutable_search(search);
+    q->super.can_calculate_changes = _email_query_is_mutable_search(&search);
     q->super.query_state = _email_make_querystate(modseq, 0, addrbook_modseq);
 
     if (jmap_is_using(req, JMAP_PERFORMANCE_EXTENSION)) {
         json_object_set_new(req->perf_details, "isImapFolderSearch",
-                json_boolean(search->is_imapfolder));
+                json_boolean(search.is_imapfolder));
     }
 
 done:
@@ -4234,7 +4228,8 @@ done:
         }
         else *err = jmap_server_error(r);
     }
-    _emailsearch_free(search);
+
+    _emailsearch_fini(&search);
 }
 
 static int _email_queryargs_parse(jmap_req_t *req,
@@ -4378,16 +4373,15 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
         return;
     }
 
-    struct emailsearch *search = _emailsearch_new(req, query->filter, query->sort,
-                                                  &contactfilter->contactgroups,
-                                                  /*want_expunged*/1,
-                                                  /*want_partids*/0,
-                                                  /*ignore_timer*/0);
-    if (!search) {
-        *err = jmap_server_error(IMAP_INTERNAL);
-        goto done;
-    }
-    if (!_email_query_is_mutable_search(search)) {
+    struct emailsearch search;
+    int r = _emailsearch_init(&search, req, query->filter, query->sort,
+                              &contactfilter->contactgroups,
+                              /*want_expunged*/1,
+                              /*want_partids*/0,
+                              /*ignore_timer*/0);
+    if (r) goto done;
+
+    if (!_email_query_is_mutable_search(&search)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "mutable search");
         goto done;
@@ -4395,17 +4389,8 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
 
     /* Run search */
     const ptrarray_t *msgdata = NULL;
-    int r = _emailsearch_run_uidsearch(req, search, &msgdata);
-    if (r) {
-        if (r == IMAP_SEARCH_SLOW) {
-            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
-                                          "description", "search too slow");
-        }
-        else {
-            *err = jmap_server_error(r);
-        }
-        goto done;
-    }
+    r = _emailsearch_run_uidsearch(req, &search, &msgdata);
+    if (r) goto done;
 
     /* Prepare result loop */
     char email_id[JMAP_EMAILID_SIZE];
@@ -4441,7 +4426,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
 
         // for this phase, we only care that it has a change
         if (md->modseq <= since_modseq) {
-            if (search->is_mutable) {
+            if (search.is_mutable) {
                 modseq_t modseq = md->convmodseq;
                 if (!modseq) conversation_get_modseq(req->cstate, md->cid, &modseq);
                 if (modseq > since_modseq)
@@ -4479,7 +4464,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
             if (!(touched_id & 1)) goto doneloop;
 
             // could not possibly be old exemplar
-            if (!search->is_mutable && (touched_cid & 8)) goto doneloop;
+            if (!search.is_mutable && (touched_cid & 8)) goto doneloop;
 
             // add the destroy notice
             if (!(touched_id & 4)) {
@@ -4504,7 +4489,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
             // haven't told the exemplar yet?  This is the exemplar!
             if (!(touched_cid & 2)) {
                 // not yet told in any way, and this ID hasn't been told at all
-                if (touched_cid == 1 && touched_id == 0 && !search->is_mutable) {
+                if (touched_cid == 1 && touched_id == 0 && !search.is_mutable) {
                     // this is both old AND new exemplar, horray.  We don't
                     // need to tell anything
                     new_touched_cid |= 8;
@@ -4528,7 +4513,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
             // otherwise we've already told the exemplar.
 
             // could not possibly be old exemplar
-            if (!search->is_mutable && (touched_cid & 8)) goto doneloop;
+            if (!search.is_mutable && (touched_cid & 8)) goto doneloop;
 
             // OK, maybe this alive message WAS the old examplar
             if (!(touched_id & 4)) {
@@ -4555,7 +4540,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
             hashu64_insert(md->cid, (void*)new_touched_cid, &touched_cids);
         // if the search is mutable, later changes could have
         // been earlier once, so no up_to_id is possible
-        if (!found_up_to && !search->is_mutable
+        if (!found_up_to && !search.is_mutable
                          && query->up_to_id
                          && !strcmp(email_id, query->up_to_id)) {
             found_up_to = 1;
@@ -4569,7 +4554,14 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     query->new_querystate = _email_make_querystate(modseq, 0, addrbook_modseq);
 
 done:
-    _emailsearch_free(search);
+    if (r && *err == NULL) {
+        if (r == IMAP_SEARCH_SLOW) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search too slow");
+        }
+        else *err = jmap_server_error(r);
+    }
+    _emailsearch_fini(&search);
 }
 
 static void _email_querychanges_uncollapsed(jmap_req_t *req,
@@ -4595,16 +4587,15 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
         return;
     }
 
-    struct emailsearch *search = _emailsearch_new(req, query->filter, query->sort,
-                                                  &contactfilter->contactgroups,
-                                                  /*want_expunged*/1,
-                                                  /*want_partids*/0,
-                                                  /*ignore_timer*/0);
-    if (!search) {
-        *err = jmap_server_error(IMAP_INTERNAL);
-        goto done;
-    }
-    if (!_email_query_is_mutable_search(search)) {
+    struct emailsearch search;
+    int r = _emailsearch_init(&search, req, query->filter, query->sort,
+                              &contactfilter->contactgroups,
+                              /*want_expunged*/1,
+                              /*want_partids*/0,
+                              /*ignore_timer*/0);
+    if (r) goto done;
+
+    if (!_email_query_is_mutable_search(&search)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "mutable search");
         goto done;
@@ -4612,17 +4603,8 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
 
     /* Run search */
     const ptrarray_t *msgdata = NULL;
-    int r = _emailsearch_run_uidsearch(req, search, &msgdata);
-    if (r) {
-        if (r == IMAP_SEARCH_SLOW) {
-            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
-                                          "description", "search too slow");
-        }
-        else {
-            *err = jmap_server_error(r);
-        }
-        goto done;
-    }
+    r = _emailsearch_run_uidsearch(req, &search, &msgdata);
+    if (r) goto done;
 
     /* Prepare result loop */
     char email_id[JMAP_EMAILID_SIZE];
@@ -4691,7 +4673,7 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
 
         // if it's changed, tell about that
         if ((touched_id & 1)) {
-            if (!search->is_mutable && touched_id == 1 && md->modseq <= since_modseq) {
+            if (!search.is_mutable && touched_id == 1 && md->modseq <= since_modseq) {
                 // this is the exemplar, and it's unchanged,
                 // and we haven't told a removed yet, so we
                 // can just suppress everything
@@ -4721,7 +4703,7 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
             hash_insert(email_id, (void*)new_touched_id, &touched_ids);
         // if the search is mutable, later changes could have
         // been earlier once, so no up_to_id is possible
-        if (!found_up_to && !search->is_mutable
+        if (!found_up_to && !search.is_mutable
                          && query->up_to_id
                          && !strcmp(email_id, query->up_to_id)) {
             found_up_to = 1;
@@ -4734,7 +4716,14 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     query->new_querystate = _email_make_querystate(modseq, 0, addrbook_modseq);
 
 done:
-    _emailsearch_free(search);
+    if (r && *err == NULL) {
+        if (r == IMAP_SEARCH_SLOW) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search too slow");
+        }
+        else *err = jmap_server_error(r);
+    }
+    _emailsearch_fini(&search);
 }
 
 static int jmap_email_querychanges(jmap_req_t *req)
@@ -4797,22 +4786,17 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes, json_t
                                jmap_fmtstate(changes->since_modseq));
     json_t *sort = json_pack("[{s:s}]", "property", "emailState");
 
-    struct emailsearch *search = _emailsearch_new(req, filter, sort,
-                                                  /*contactgroups*/NULL,
-                                                  /*want_expunged*/1,
-                                                  /*want_partids*/0,
-                                                  /*ignore_timer*/1);
-    if (!search) {
-        *err = jmap_server_error(IMAP_INTERNAL);
-        goto done;
-    }
+    struct emailsearch search;
+    int r = _emailsearch_init(&search, req, filter, sort,
+                              /*contactgroups*/NULL,
+                              /*want_expunged*/1,
+                              /*want_partids*/0,
+                              /*ignore_timer*/1);
+    if (r) goto done;
 
     const ptrarray_t *msgdata = NULL;
-    int r = _emailsearch_run_uidsearch(req, search, &msgdata);
-    if (r) {
-        *err = jmap_server_error(r);
-        goto done;
-    }
+    r = _emailsearch_run_uidsearch(req, &search, &msgdata);
+    if (r) goto done;
 
     /* Process results */
     char email_id[JMAP_EMAILID_SIZE];
@@ -4883,7 +4867,14 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes, json_t
 done:
     json_decref(filter);
     json_decref(sort);
-    _emailsearch_free(search);
+    if (r && *err == NULL) {
+        if (r == IMAP_SEARCH_SLOW) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search too slow");
+        }
+        else *err = jmap_server_error(r);
+    }
+    _emailsearch_fini(&search);
 }
 
 static int jmap_email_changes(jmap_req_t *req)
@@ -4924,22 +4915,18 @@ static void _thread_changes(jmap_req_t *req, struct jmap_changes *changes, json_
     json_t *filter = json_pack("{s:o}", "sinceEmailState",
                                jmap_fmtstate(changes->since_modseq));
     json_t *sort = json_pack("[{s:s}]", "property", "emailState");
-    struct emailsearch *search = _emailsearch_new(req, filter, sort,
-                                                  /*contactgroups*/NULL,
-                                                  /*want_expunged*/1,
-                                                  /*want_partids*/0,
-                                                  /*ignore_timer*/1);
-    if (!search) {
-        *err = jmap_server_error(IMAP_INTERNAL);
-        goto done;
-    }
+
+    struct emailsearch search;
+    int r = _emailsearch_init(&search, req, filter, sort,
+                              /*contactgroups*/NULL,
+                              /*want_expunged*/1,
+                              /*want_partids*/0,
+                              /*ignore_timer*/1);
+    if (r) goto done;
 
     const ptrarray_t *msgdata = NULL;
-    int r = _emailsearch_run_uidsearch(req, search, &msgdata);
-    if (r) {
-        *err = jmap_server_error(r);
-        goto done;
-    }
+    r = _emailsearch_run_uidsearch(req, &search, &msgdata);
+    if (r) goto done;
 
     /* Process results */
     size_t changes_count = 0;
@@ -4996,7 +4983,14 @@ done:
     conversation_fini(&conv);
     json_decref(filter);
     json_decref(sort);
-    _emailsearch_free(search);
+    if (r && *err == NULL) {
+        if (r == IMAP_SEARCH_SLOW) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search too slow");
+        }
+        else *err = jmap_server_error(r);
+    }
+    _emailsearch_fini(&search);
 }
 
 static int jmap_thread_changes(jmap_req_t *req)

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2289,24 +2289,16 @@ static void convert_folderclause(search_expr_t *clause,
     }
 }
 
-static int _email_buildsearch(search_expr_t **rootp,
-                              jmap_req_t *req, json_t *filter,
-                              hash_table *contactgroups,
-                              strarray_t *perf_filters,
-                              int *is_imapfolderptr)
+static int _emailsearch_normalise(search_expr_t **rootp, int *is_imapfolderptr)
 {
     if (is_imapfolderptr) *is_imapfolderptr = 0;
-    *rootp = NULL;
-
-    search_expr_t *root = _email_buildsearchexpr(req, filter, NULL,
-                                        contactgroups, perf_filters);
-    if (!root) return 0;
 
     /* Convert tree to DNF, it will converted in search_query anyway */
-    if (search_expr_normalise(&root) < 0) {
-        search_expr_free(root);
+    if (search_expr_normalise(rootp) < 0) {
         return IMAP_SEARCH_SLOW;
     }
+
+    search_expr_t *root = *rootp;
 
     /* Is there any JMAP folder expression we could optimize? */
     int has_jmapfolder_expr = 0;
@@ -2341,7 +2333,6 @@ static int _email_buildsearch(search_expr_t **rootp,
         strarray_fini(&preferred_folders);
     }
 
-    *rootp = root;
     return 0;
 }
 
@@ -2519,7 +2510,8 @@ struct emailsearch {
     int want_partids;
     int ignore_timer;
     int is_mutable;
-    search_expr_t *expr;
+    search_expr_t *expr_dnf;
+    search_expr_t *expr_orig;
     struct sortcrit *sort;
     char *hash;
     strarray_t perf_filters;
@@ -2536,7 +2528,8 @@ static void _emailsearch_fini(struct emailsearch *search)
 {
     if (!search) return;
 
-    search_expr_free(search->expr);
+    search_expr_free(search->expr_dnf);
+    search_expr_free(search->expr_orig);
     freesortcrit(search->sort);
     strarray_fini(&search->perf_filters);
     free(search->hash);
@@ -2552,12 +2545,9 @@ static char *_emailsearch_hash(search_expr_t *expr, struct sortcrit *sort)
 {
     struct buf buf = BUF_INITIALIZER;
     if (expr) {
-        search_expr_t *mysearch = search_expr_duplicate(expr);
-        search_expr_normalise(&mysearch);
-        char *tmp = search_expr_serialise(mysearch);
+        char *tmp = search_expr_serialise(expr);
         buf_appendcstr(&buf, tmp);
         free(tmp);
-        search_expr_free(mysearch);
     }
     else {
         buf_appendcstr(&buf, "noquery");
@@ -2610,8 +2600,13 @@ static int _emailsearch_init(struct emailsearch *search,
 {
     memset(search, 0, sizeof(struct emailsearch));
 
-    int r = _email_buildsearch(&search->expr, req, filter, contactgroups,
-                               &search->perf_filters, &search->is_imapfolder);
+    search->expr_orig = _email_buildsearchexpr(req, filter, NULL,
+                                    contactgroups, &search->perf_filters);
+    if (!search->expr_orig) return 0;
+
+    search->expr_dnf = search_expr_duplicate(search->expr_orig);
+
+    int r = _emailsearch_normalise(&search->expr_dnf, &search->is_imapfolder);
     if (r) return r;
 
     if (json_array_size(jsort)) {
@@ -2629,8 +2624,8 @@ static int _emailsearch_init(struct emailsearch *search,
         search->sort = sort;
     }
 
-    search->hash = _emailsearch_hash(search->expr, search->sort);
-    search->is_mutable = search_is_mutable(search->sort, search->expr);
+    search->hash = _emailsearch_hash(search->expr_dnf, search->sort);
+    search->is_mutable = search_is_mutable(search->sort, search->expr_dnf);
     search->want_expunged = want_expunged;
     search->want_partids = want_partids;
     search->ignore_timer = ignore_timer;
@@ -2646,7 +2641,7 @@ static int _emailsearch_run_uidsearch(jmap_req_t *req, struct emailsearch *searc
     /* Build search args */
     search->args = new_searchargs(NULL/*tag*/, GETSEARCH_CHARSET_FIRST,
             &jmap_namespace, req->accountid, req->authstate, 0);
-    search->args->root = search_expr_duplicate(search->expr);
+    search->args->root = search_expr_duplicate(search->expr_dnf);
 
     /* Build index state */
     search->init.userid = req->accountid;
@@ -3446,9 +3441,9 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
 }
 
 static int guidsearch_rank_expr(struct conversations_state *cstate,
-                                const search_expr_t *_e)
+                                const search_expr_t *e)
 {
-    if (!_e) return 0;
+    if (!e) return 0;
 
     /*
      * Returns -1 for unsupported expressions or a bitmask of:
@@ -3456,28 +3451,19 @@ static int guidsearch_rank_expr(struct conversations_state *cstate,
      *  0x1  supported but does not require Xapian
      *  0x2  requires Xapian
      */
-
-    search_expr_t *e = search_expr_duplicate(_e);
-    if (search_expr_normalise(&e) == -1) {
-        return -1;
-    }
-    int rank = 0;
     if (e->op == SEOP_OR) {
+        int rank = 0;
         search_expr_t *child;
         for (child = e->children ; child ; child = child->next) {
             int childrank = guidsearch_rank_clause(cstate, child);
             if (childrank == 1 || childrank == -1) {
-                rank = -1;
-                goto done;
+                return -1;
             }
             rank |= childrank;
         }
+        return rank;
     }
-    else rank = guidsearch_rank_clause(cstate, e);
-
-done:
-    search_expr_free(e);
-    return rank;
+    return guidsearch_rank_clause(cstate, e);
 }
 
 static int is_guidsearch_sort(struct sortcrit *sort)
@@ -3559,7 +3545,7 @@ static int guidsearch_run_cb(const conv_guidrec_t *rec,
 static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
                           struct guidsearch_query *gsq)
 {
-    int exprrank = guidsearch_rank_expr(req->cstate, search->expr);
+    int exprrank = guidsearch_rank_expr(req->cstate, search->expr_dnf);
     if (exprrank < 2 || !is_guidsearch_sort(search->sort)) {
         return IMAP_SEARCH_NOT_SUPPORTED;
     }
@@ -3610,7 +3596,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         }
 
         int need_folders = 0;
-        gsq->matchexpr = guidsearch_expr_build(req->cstate, NULL, search->expr,
+        gsq->matchexpr = guidsearch_expr_build(req->cstate, NULL, search->expr_orig,
                                                &foldernum_by_mboxname,
                                                &need_folders);
         gsq->numfolders = need_folders ? numfolders : 0;
@@ -3640,7 +3626,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         goto done;
     }
 
-    search_build_query(bx, search->expr);
+    search_build_query(bx, search->expr_orig);
     r = bx->run_guidsearch(bx, guidsearch_run_cb, gsq);
     bv_fini(&gsq->readable_folders);
     if (r && r != IMAP_OK_COMPLETED) goto done;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3941,8 +3941,11 @@ static int _email_query_uidsearch(jmap_req_t *req,
     if (r) {
         switch (r) {
             case IMAP_SEARCH_NOT_SUPPORTED:
-            case IMAP_SEARCH_SLOW:
                 *err = json_pack("{s:s}", "type", "unsupportedFilter");
+                break;
+            case IMAP_SEARCH_SLOW:
+                *err = json_pack("{s:s s:s}", "type", "unsupportedFilter",
+                        "description", "search too slow");
                 break;
             default:
                 *err = jmap_server_error(r);
@@ -4226,7 +4229,8 @@ static void _email_query(jmap_req_t *req, struct jmap_emailquery *q,
 done:
     if (r && *err == NULL) {
         if (r == IMAP_SEARCH_SLOW) {
-            *err = json_pack("{s:s}", "type", "unsupportedFilter");
+            *err = json_pack("{s:s s:s}", "type", "unsupportedFilter",
+                    "description", "search too slow");
         }
         else *err = jmap_server_error(r);
     }

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -810,7 +810,8 @@ static int search_expr_normalise_nnodes(search_expr_t **ep, unsigned *nnodes)
 
 EXPORTED int search_expr_normalise(search_expr_t **ep)
 {
-    return search_expr_normalise_nnodes(ep, NULL);
+    unsigned nnodes = 0;
+    return search_expr_normalise_nnodes(ep, &nnodes);
 }
 
 /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
@@ -1168,8 +1169,7 @@ EXPORTED void search_expr_split_by_folder_and_index(search_expr_t *e,
     }
 
     copy = search_expr_duplicate(e);
-    unsigned nnodes = 0;
-    if (search_expr_normalise_nnodes(&copy, &nnodes) < 0)
+    if (search_expr_normalise(&copy) < 0)
     {
         /* We blew the complexity limit because the expression has too
          * many ORs.  Rats.  Give up and scan folders with the original


### PR DESCRIPTION
**NOTE**: we might not want to push this ever on the master branch and rather remove the nnodes checks from the search code altogether. This pull request should help us identifying if we can do that safely.

**Description**

Static variable nnodes increments whenever a search expression is allocated. Its purpose is to keep track of the number of search expressions that are created during search expression tree normalisation. While uid-based search resets the counter each time it is called, it may accumulate in process memory as long as only guidsearch is executed.

This could introduce hard-to-track bugs, as the JMAP email search code uses the search expression normalisation code independently from uid-based search.

To avoid this, let's make nnodes a function argument.