### PR TITLE
fix parsing of folded leading whitespace in headers

### DIFF
--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -279,6 +279,124 @@ static void test_folded_headers(void)
     unlink(tempfile);
 }
 
+static void test_empty_headers(void)
+{
+    static const char MSG[] =
+"From: " HFROM "\r\n"
+"Message-ID: " HMESSAGEID "\r\n"
+"Empty1:\r\n"                               /* not even a leading space */
+"Empty2: \r\n"                              /* leading space */
+"Empty3:\r\n \r\n"                          /* folded leading space */
+"Empty4:\r"                                 /* same, with bare CR */
+"Empty5: \r"
+"Empty6:\r \r"
+"Empty7:\n"                                 /* same, with bare LF */
+"Empty8: \n"
+"Empty9:\n \n"
+"\r\n"
+"Hello, World\r\n";
+
+    hdrcache_t cache;
+    const char **val;
+    int fd;
+    char tempfile[32];
+    int r;
+    struct protstream *pin;
+    FILE *fout;
+
+    /* Setup @pin to point to the start of a file open for (at least)
+     * reading containing the message. */
+    strcpy(tempfile, "/tmp/spooltestAXXXXXX");
+    fd = mkstemp(tempfile);
+    CU_ASSERT(fd >= 0);
+    r = retry_write(fd, MSG, sizeof(MSG)-1);
+    CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
+    lseek(fd, SEEK_SET, 0);
+    pin = prot_new(fd, /*read*/0);
+    CU_ASSERT_PTR_NOT_NULL(pin);
+
+    /* Setup @fout to ignore data written to it */
+    fout = fopen("/dev/null", "w");
+    CU_ASSERT_PTR_NOT_NULL(fout);
+
+    cache = spool_new_hdrcache();
+    CU_ASSERT_PTR_NOT_NULL(cache);
+
+    /* TODO: test non-NULL skipheaders */
+    r = spool_fill_hdrcache(pin, fout, cache, NULL);
+    CU_ASSERT_EQUAL(r, 0);
+
+    val = spool_getheader(cache, "Nonesuch");
+    CU_ASSERT_PTR_NULL(val);
+    val = spool_getheader(cache, "From");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HFROM);
+    CU_ASSERT_PTR_NULL(val[1]);
+    val = spool_getheader(cache, "fRoM");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HFROM);
+    CU_ASSERT_PTR_NULL(val[1]);
+    val = spool_getheader(cache, "from");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HFROM);
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "message-id");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty1");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty2");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty3");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty4");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty5");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty6");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty7");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty8");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "empty9");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], "");
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    spool_free_hdrcache(cache);
+    fclose(fout);
+    prot_free(pin);
+    unlink(tempfile);
+}
+
 /* BZ3640: headers with NULL bytes shall be rejected. */
 static void test_fill_null(void)
 {

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -15,6 +15,7 @@
 #define THIRD_RX    "Fri, 29 Oct 2010 13:01:01 +1100"
 #define SENT        "Thu, 28 Oct 2010 18:37:26 +1100"
 #define HFROM       "Fred Bloggs <fbloggs@fastmail.fm>"
+#define HFROMFOLD   "Fred Bloggs\r\n <fbloggs@fastmail.fm>"
 #define HFROM2      "Antoine Lavoisier <lavoisier@chemistry.fr>"
 #define HTO         "Sarah Jane Smith <sjsmith@gmail.com>"
 #define HDATE       SENT
@@ -207,6 +208,70 @@ static void test_fill(void)
     CU_ASSERT_STRING_EQUAL(val[1], HRECEIVED2);
     CU_ASSERT_STRING_EQUAL(val[2], HRECEIVED3);
     CU_ASSERT_PTR_NULL(val[3]);
+
+    spool_free_hdrcache(cache);
+    fclose(fout);
+    prot_free(pin);
+    unlink(tempfile);
+}
+
+static void test_folded_headers(void)
+{
+    static const char MSG[] =
+"From: " HFROMFOLD "\r\n"                   /* mid-value folding */
+"Message-ID:\r\n " HMESSAGEID "\r\n"        /* leading whitespace is folded */
+"\r\n"
+"Hello, World\r\n";
+
+    hdrcache_t cache;
+    const char **val;
+    int fd;
+    char tempfile[32];
+    int r;
+    struct protstream *pin;
+    FILE *fout;
+
+    /* Setup @pin to point to the start of a file open for (at least)
+     * reading containing the message. */
+    strcpy(tempfile, "/tmp/spooltestAXXXXXX");
+    fd = mkstemp(tempfile);
+    CU_ASSERT(fd >= 0);
+    r = retry_write(fd, MSG, sizeof(MSG)-1);
+    CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
+    lseek(fd, SEEK_SET, 0);
+    pin = prot_new(fd, /*read*/0);
+    CU_ASSERT_PTR_NOT_NULL(pin);
+
+    /* Setup @fout to ignore data written to it */
+    fout = fopen("/dev/null", "w");
+    CU_ASSERT_PTR_NOT_NULL(fout);
+
+    cache = spool_new_hdrcache();
+    CU_ASSERT_PTR_NOT_NULL(cache);
+
+    /* TODO: test non-NULL skipheaders */
+    r = spool_fill_hdrcache(pin, fout, cache, NULL);
+    CU_ASSERT_EQUAL(r, 0);
+
+    val = spool_getheader(cache, "Nonesuch");
+    CU_ASSERT_PTR_NULL(val);
+    val = spool_getheader(cache, "From");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HFROM);
+    CU_ASSERT_PTR_NULL(val[1]);
+    val = spool_getheader(cache, "fRoM");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HFROM);
+    CU_ASSERT_PTR_NULL(val[1]);
+    val = spool_getheader(cache, "from");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HFROM);
+    CU_ASSERT_PTR_NULL(val[1]);
+
+    val = spool_getheader(cache, "message-id");
+    CU_ASSERT_PTR_NOT_NULL(val);
+    CU_ASSERT_STRING_EQUAL(val[0], HMESSAGEID);
+    CU_ASSERT_PTR_NULL(val[1]);
 
     spool_free_hdrcache(cache);
     fclose(fout);

--- a/imap/spool.c
+++ b/imap/spool.c
@@ -103,9 +103,10 @@ typedef enum {
 /* we don't have to worry about dotstuffing here, since it's illegal
    for a header to begin with a dot!
 
-   returns 0 on success, filling in 'headname' and 'contents' with a static
-   pointer (blech).
-   on end of headers, returns 0 with NULL 'headname' and NULL 'contents'
+   returns 0 on success, filling in 'headname', 'contents', and 'rawvalue'
+   with malloced pointers (caller must free!).
+   on end of headers, returns 0 with NULL 'headname', NULL 'contents', and
+   NULL 'rawvalue'
 
    on error, returns < 0
 */


### PR DESCRIPTION
This mainly fixes stuff like this:

```
Message-ID:
 <foo@whatever>
```

being misparsed as `" <foo@whatever>"` rather than `"<foo@whatever>"` –  i.e. the leading whitespace was not eaten if it was also folded.  

One consequence of this was bad formatting of auditlogs for affected messages; another (user visible!) was that duplicate suppression would fail to detect the duplication if one copy was folded and the other not.

The misparsing of folded leading whitespace affects all headers in theory, but other headers usually contain other whitespace, and end up folded later instead of right at the start.  Message-ID is exceptional both in that it doesn't usually contain any other whitespace (so if the sender is going to fold it, they can only fold at the leading whitespace), and in that the value is significant to our handling of the message.

Added two cunit tests: one for this behaviour specifically, and a regression test for empty-header handling to make sure the fix didn't break that.

Obviously this won't do anything to fix up cache/etc for older messages, it'll only help for new incoming messages.  Is there something an admin can do to retroactively fix older messages?