### PR TITLE
lib/imapoptions: deprecate sieve_sasl_send_unsolicited_capability

### DIFF
--- a/changes/next/deprecate_sieve_sasl_send_unsolicited_capability
+++ b/changes/next/deprecate_sieve_sasl_send_unsolicited_capability
@@ -1,0 +1,13 @@
+Description:
+
+Deprecate sieve_sasl_send_unsolicited_capability in lib/imapoptions and toggle its default.
+
+Config changes:
+
+This enables the RFC 5804 behaviour by default. The old behaviour - per
+draft-martin-managesieve-08 - is not available anymore.
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/pull/3346
+

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2727,9 +2727,8 @@ product version in the capabilities
    \fIfileinto\fR action in scripts to use UTF8 encoding.  Otherwise,
    modified UTF7 encoding should be used. */
 
-{ "sieve_sasl_send_unsolicited_capability", 0, SWITCH, "2.3.17" }
-/* If enabled, timsieved will emit a capability response after a successful
-   SASL authentication, per draft-martin-managesieve-12.txt . */
+{ "sieve_sasl_send_unsolicited_capability", 1, SWITCH, "UNRELEASED", "UNRELEASED" }
+/* Deprecated: this option does nothing. */
 
 { "sieve_use_lmtp_reject", 1, SWITCH, "3.1.1" }
 /* Enabled by default.  If reject can be done via LMTP, then return a 550

--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -890,8 +890,7 @@ static int cmd_authenticate(struct protstream *sieved_out,
   sasl_getprop(sieved_saslconn, SASL_SSF, &val);
   sasl_ssf = *((sasl_ssf_t *) val);
 
-  if (sasl_ssf &&
-      config_getswitch(IMAPOPT_SIEVE_SASL_SEND_UNSOLICITED_CAPABILITY)) {
+  if (sasl_ssf) {
       capabilities(sieved_out, sieved_saslconn, starttls_done, authenticated,
                    sasl_ssf);
       prot_flush(sieved_out);


### PR DESCRIPTION
It comply with [RFC 5804 A Protocol for Remotely Managing Sieve Scripts](https://tools.ietf.org/html/rfc5804) this option must be off.