### PR TITLE
Jmap getblob handlers v2

### DIFF
--- a/changes/next/jmap_getblob_handlers_v2
+++ b/changes/next/jmap_getblob_handlers_v2
@@ -1,0 +1,22 @@
+Description:
+
+This PR changes the profile of the jmap_getblob_handler()s to only return the blob
+data and content-type, and leaves the final disposition of the data (output on the
+wire or otherwise) up to the calling process.
+
+This PR also removes support for the 'G' conv.db hack to support blobIds for the
+image data in vCard PHOTO properties and replaces it with a new variant of the
+'V' smart blobId which is more jmap_getblob_handler() friendly.
+
+Finally, this rework allows the use of blobs other than those that are uploaded
+to be used as contact avatars (vCard PHOTOs), such as BIMI indicator blobs.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2211,32 +2211,6 @@ static int conversations_set_guid(struct conversations_state *state,
                               record->system_flags, record->internal_flags,
                               record->internaldate, body, base, add);
 
-#ifdef WITH_DAV
-    if (!r && (mailbox->mbtype == MBTYPE_ADDRESSBOOK) &&
-        !strcmp(body->type, "TEXT") && !strcmp(body->subtype, "VCARD")) {
-
-        struct vparse_card *vcard = record_to_vcard(mailbox, record);
-
-        if (vcard) {
-            struct message_guid guid;
-            struct vparse_entry *photo =
-                vparse_get_entry(vcard->objects, NULL, "photo");
-
-            if (photo && vcard_prop_decode_value(photo, NULL, NULL, &guid)) {
-                buf_printf(&item, "[%s/VCARD#PHOTO]", body->part_id);
-                r = conversations_guid_setitem(state, message_guid_encode(&guid),
-                                               buf_cstring(&item), 0 /*cid*/,
-                                               record->system_flags,
-                                               record->internal_flags,
-                                               record->internaldate,
-                                               add);
-            }
-
-            vparse_free_card(vcard);
-        }
-    }
-#endif /* WITH_DAV */
-
     message_free_body(body);
     free(body);
     buf_free(&item);

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -502,6 +502,8 @@ HIDDEN int jmap_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx)
 {
     int res = 0;
 
+    if (!ctx->blobid) return HTTP_NOT_FOUND;
+
     /* Call getblob handlers */
     int i;
     for (i = 0; i < ptrarray_size(&my_jmap_settings.getblob_handlers); i++) {

--- a/imap/http_jmap.h
+++ b/imap/http_jmap.h
@@ -52,4 +52,9 @@ extern struct namespace jmap_namespace;
 extern int jmap_open_upload_collection(const char *accountid,
                                        struct mailbox **mailbox);
 
+extern int jmap_getblob(jmap_req_t *req, const char *from_accountid,
+                        const char *blobid, const char *accept_mime,
+                        struct buf *blob, const char **content_type,
+                        const char **errstr);
+
 #endif /* HTTP_JMAP_H */

--- a/imap/http_jmap.h
+++ b/imap/http_jmap.h
@@ -52,9 +52,6 @@ extern struct namespace jmap_namespace;
 extern int jmap_open_upload_collection(const char *accountid,
                                        struct mailbox **mailbox);
 
-extern int jmap_getblob(jmap_req_t *req, const char *from_accountid,
-                        const char *blobid, const char *accept_mime,
-                        struct buf *blob, const char **content_type,
-                        const char **errstr);
+extern int jmap_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx);
 
 #endif /* HTTP_JMAP_H */

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1329,11 +1329,6 @@ static int _jmap_findblob(jmap_req_t *req, const char *from_accountid,
                 break;
             }
             if (!mypart->subpart) {
-                if (data.mbox->mbtype == MBTYPE_ADDRESSBOOK &&
-                    (mypart = jmap_contact_findblob(&content_guid, data.part_id,
-                                                    data.mbox, data.mr, blob))) {
-                    break;
-                }
                 continue;
             }
             ptrarray_push(&parts, mypart->subpart);

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1291,8 +1291,10 @@ static int _jmap_findblob(jmap_req_t *req, const char *from_accountid,
         }
     }
 
-    if (blobid[0] != 'G')
+    if (blobid[0] != 'G' || strlen(blobid) != 41) {
+        /* incomplete or incorrect blobid */
         return IMAP_NOTFOUND;
+    }
 
     if (strcmp(req->accountid, accountid)) {
         cstate = conversations_get_user(accountid);

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -156,18 +156,21 @@ typedef struct jmap_req {
     const strarray_t *using_capabilities;
 } jmap_req_t;
 
-/* Write the contents of the blob identified by blobid on the
- * HTTP transaction embedded in JMAP request req.
+/* Fetch the contents of the blob identified by blobid,
+ * optionally returning a content type and an error string.
+ *
  * If not NULL, accept_mime defines the requested MIME type,
  * either defined in the Accept header or {type} URI template
  * parameter.
  *
- * Return HTTP_OK if the blob has been written or any other
+ * Return HTTP_OK if the blob has been found or any other
  * HTTP status on error.
- * Return zero if the next blob handler should be called. */
-typedef int jmap_getblob_handler(jmap_req_t *req,
-                                 const char *blobid,
-                                 const char *accept_mime);
+ * Return zero if the next blob handler should be called.
+ */
+typedef int jmap_getblob_handler(jmap_req_t *req, const char *from_accountid,
+                                 const char *blobid, const char *accept_mime,
+                                 struct buf *blob, const char **content_type,
+                                 const char **errstr);
 
 typedef struct {
     hash_table methods;

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -167,10 +167,16 @@ typedef struct jmap_req {
  * HTTP status on error.
  * Return zero if the next blob handler should be called.
  */
-typedef int jmap_getblob_handler(jmap_req_t *req, const char *from_accountid,
-                                 const char *blobid, const char *accept_mime,
-                                 struct buf *blob, const char **content_type,
-                                 const char **errstr);
+typedef struct {
+    const char *from_accountid;
+    const char *blobid;
+    const char *accept_mime;
+    struct buf blob;
+    const char *content_type;
+    const char *errstr;
+} jmap_getblob_context_t;
+
+typedef int jmap_getblob_handler(jmap_req_t *req, jmap_getblob_context_t *ctx);
 
 typedef struct {
     hash_table methods;

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -168,12 +168,12 @@ typedef struct jmap_req {
  * Return zero if the next blob handler should be called.
  */
 typedef struct {
-    const char *from_accountid;
-    const char *blobid;
-    const char *accept_mime;
-    struct buf blob;
-    const char *content_type;
-    const char *errstr;
+    const char *from_accountid;  // input to the handler
+    const char *blobid;          // input to the handler
+    const char *accept_mime;     // input to the handler
+    struct buf blob;             // output from the handler
+    const char *content_type;    // output from the handler
+    const char *errstr;          // output from the handler
 } jmap_getblob_context_t;
 
 typedef int jmap_getblob_handler(jmap_req_t *req, jmap_getblob_context_t *ctx);

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -269,12 +269,6 @@ extern int jmap_findblob_exact(jmap_req_t *req, const char *accountid,
                                struct mailbox **mbox, msgrecord_t **mr,
                                struct buf *blob);
 
-extern const struct body *jmap_contact_findblob(struct message_guid *content_guid,
-                                                const char *part_id,
-                                                struct mailbox *mbox,
-                                                msgrecord_t *mr,
-                                                struct buf *blob);
-
 #define JMAP_BLOBID_SIZE 42
 extern void jmap_set_blobid(const struct message_guid *guid, char *buf);
 

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -4050,50 +4050,6 @@ static int jmap_contact_set(struct jmap_req *req)
     return 0;
 }
 
-const struct body *jmap_contact_findblob(struct message_guid *content_guid,
-                                         const char *part_id,
-                                         struct mailbox *mbox,
-                                         msgrecord_t *mr,
-                                         struct buf *blob)
-{
-    const struct body *ret = NULL;
-    struct index_record record;
-    struct vparse_card *vcard;
-    const char *proppath = strstr(part_id, "/VCARD#");
-
-    if (!proppath) return NULL;
-
-    msgrecord_get_index_record(mr, &record);
-    vcard = record_to_vcard(mbox, &record);
-
-    if (vcard) {
-        static struct body subpart;
-        char *type = NULL;
-        struct vparse_entry *entry =
-            vparse_get_entry(vcard->objects, NULL, proppath+7);
-
-        memset(&subpart, 0, sizeof(struct body));
-
-        if (entry &&
-            vcard_prop_decode_value(entry, blob, &type, &subpart.content_guid) &&
-            !message_guid_cmp(content_guid, &subpart.content_guid)) {
-            /* Build a body part for the property */
-            subpart.charset_enc = ENCODING_NONE;
-            subpart.encoding = "BINARY";
-            subpart.header_offset = 0;
-            subpart.header_size = 0;
-            subpart.content_offset = 0;
-            subpart.content_size = buf_len(blob);
-            ret = &subpart;
-        }
-
-        free(type);
-        vparse_free_card(vcard);
-    }
-
-    return ret;
-}
-
 static void _contact_copy(jmap_req_t *req,
                           json_t *jcard,
                           struct carddav_db *src_db,

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -84,10 +84,15 @@ static int jmap_contact_query(struct jmap_req *req);
 static int jmap_contact_set(struct jmap_req *req);
 static int jmap_contact_copy(struct jmap_req *req);
 
+typedef struct {
+    json_t *invalid;
+    json_t *blobNotFound;
+} jmap_contact_errors_t;
+
 static int _contact_set_create(jmap_req_t *req, unsigned kind,
                                json_t *jcard, struct carddav_data *cdata,
                                struct mailbox **mailbox, json_t *item,
-                               json_t *invalid);
+                               jmap_contact_errors_t *errors);
 static int required_set_rights(json_t *props);
 static int _json_to_card(struct jmap_req *req,
                          struct carddav_data *cdata,
@@ -95,7 +100,7 @@ static int _json_to_card(struct jmap_req *req,
                          json_t *arg, strarray_t *flags,
                          struct entryattlist **annotsp,
                          json_t **item,
-                         json_t *invalid);
+                         jmap_contact_errors_t *errors);
 
 static json_t *jmap_contact_from_vcard(struct vparse_card *card,
                                        struct mailbox *mailbox,
@@ -903,9 +908,10 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
     json_t *arg;
     json_object_foreach(set.create, key, arg) {
         json_t *invalid = json_pack("[]");
+        jmap_contact_errors_t errors = { invalid, NULL };
         json_t *item = json_pack("{}");
         r = _contact_set_create(req, kind, arg,
-                                NULL, &mailbox, item, invalid);
+                                NULL, &mailbox, item, &errors);
         if (r) {
             json_t *err;
             switch (r) {
@@ -930,10 +936,20 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
                                     "type", "invalidProperties",
                                     "properties", invalid);
             json_object_set_new(set.not_created, key, err);
+            json_decref(errors.blobNotFound);
             json_decref(item);
             continue;
         }
         json_decref(invalid);
+
+        if (errors.blobNotFound) {
+            json_t *err = json_pack("{s:s s:o}",
+                                    "type", "blobNotFound",
+                                    "notFound", errors.blobNotFound);
+            json_object_set_new(set.not_created, key, err);
+            json_decref(item);
+            continue;
+        }
 
         /* Report contact as created. */
         json_object_set_new(set.created, key, item);
@@ -1016,6 +1032,7 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
         strarray_t *flags = NULL;
 
         json_t *invalid = json_pack("[]");
+        jmap_contact_errors_t errors = { invalid, NULL };
         json_t *item = NULL;
 
         /* Load message containing the resource and parse vcard data */
@@ -1101,7 +1118,7 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
             flags = mailbox_extract_flags(mailbox, &record, req->accountid);
             annots = mailbox_extract_annots(mailbox, &record);
 
-            r = _json_to_card(req, cdata, card, arg, flags, &annots, &item, invalid);
+            r = _json_to_card(req, cdata, card, arg, flags, &annots, &item, &errors);
             if (r == HTTP_NO_CONTENT) {
                 r = 0;
                 if (!newmailbox) {
@@ -1125,7 +1142,7 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
             }
         }
 
-        if (!r && !json_array_size(invalid)) {
+        if (!r && !json_array_size(invalid) && !errors.blobNotFound) {
             syslog(LOG_NOTICE, "jmap: update %s %s/%s",
                    kind == CARDDAV_KIND_GROUP ? "group" : "contact",
                    req->accountid, resource);
@@ -1141,6 +1158,13 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
             json_t *err = json_pack("{s:s s:O}",
                                     "type", "invalidProperties",
                                     "properties", invalid);
+            json_object_set_new(set.not_updated, uid, err);
+            goto finish;
+        }
+        else if (errors.blobNotFound) {
+            json_t *err = json_pack("{s:s s:O}",
+                                    "type", "blobNotFound",
+                                    "notFound", errors.blobNotFound);
             json_object_set_new(set.not_updated, uid, err);
             goto finish;
         }
@@ -1171,6 +1195,7 @@ static void _contacts_set(struct jmap_req *req, unsigned kind)
         free(resource);
         json_decref(jupdated);
         json_decref(invalid);
+        json_decref(errors.blobNotFound);
         r = 0;
     }
 
@@ -3564,26 +3589,37 @@ static int _kv_to_card(struct vparse_card *card, const char *key, json_t *jval)
     return 0;
 }
 
-static int _blob_to_card(struct jmap_req *req, json_t *file,
+static int _blob_to_card(struct jmap_req *req,
+                         const char *key, json_t *file,
                          struct vparse_card *card, const char *prop,
-                         struct buf *new_blobid)
+                         json_t **item, jmap_contact_errors_t *errors)
 {
     const char *blobid = NULL;
     const char *accountid = NULL;
     const char *accept_mime = NULL;
     char *encbuf = NULL;
     char *decbuf = NULL;
-    json_t *val;
+    json_t *jblobId;
     int r = 0;
     const char *base = NULL;
     size_t len = 0;
+    struct buf buf = BUF_INITIALIZER;
 
-    if (!file) return HTTP_BAD_REQUEST;
+    if (!file) {
+        json_array_append_new(errors->invalid, json_string(key));
+        return HTTP_BAD_REQUEST;
+    }
 
     /* Extract blobId */
-    val = json_object_get(file, "blobId");
-    if (val) blobid = jmap_id_string_value(req, val);
-    if (!blobid) return HTTP_NOT_FOUND;
+    jblobId = json_object_get(file, "blobId");
+    if (!json_is_string(jblobId)) {
+        buf_printf(&buf, "%s/blobId", key);
+        json_array_append_new(errors->invalid, json_string(buf_cstring(&buf)));
+        buf_free(&buf);
+        return HTTP_BAD_REQUEST;
+    }
+    
+    blobid = jmap_id_string_value(req, jblobId);
 
     accountid = json_string_value(json_object_get(file, "accountId"));
     accept_mime = json_string_value(json_object_get(file, "type"));
@@ -3592,7 +3628,27 @@ static int _blob_to_card(struct jmap_req *req, json_t *file,
     jmap_getblob_context_t ctx =
         { accountid, blobid, accept_mime, BUF_INITIALIZER, NULL, NULL };
     r = jmap_getblob(req, &ctx);
-    if (r) goto done;
+
+    switch (r) {
+    case 0: 
+        if (!ctx.content_type || strchr(ctx.content_type, '/')) break;
+
+        /* Fall through */
+        GCC_FALLTHROUGH
+
+    case HTTP_NOT_ACCEPTABLE:
+        buf_printf(&buf, "%s/type", key);
+        json_array_append_new(errors->invalid, json_string(buf_cstring(&buf)));
+        buf_free(&buf);
+        r = HTTP_NOT_ACCEPTABLE;
+        goto done;
+
+    default:
+        /* Not found, or system error */
+        if (!errors->blobNotFound) errors->blobNotFound = json_array();
+        json_array_append(errors->blobNotFound, jblobId);
+        goto done;
+    }
 
     base = buf_base(&ctx.blob);
     len = buf_len(&ctx.blob);
@@ -3624,12 +3680,17 @@ static int _blob_to_card(struct jmap_req *req, json_t *file,
     /* Generate our new blobId */
     struct message_guid guid = MESSAGE_GUID_INITIALIZER;
     message_guid_generate(&guid, buf_base(&ctx.blob), buf_len(&ctx.blob));
-    _encode_contact_blobid(vparse_stringval(card, "uid"), 0,
-                           prop, &guid, new_blobid);
+    _encode_contact_blobid(vparse_stringval(card, "uid"), 0, prop, &guid, &buf);
+
+    /* Report new blobId in created/updated object */
+    if (!*item) *item = json_object();
+    json_object_set_new(*item, "avatar",
+                        json_pack("{s:s}", "blobId", buf_cstring(&buf)));
 
   done:
     free(decbuf);
     free(encbuf);
+    buf_free(&buf);
     buf_free(&ctx.blob);
 
     return r;
@@ -3680,8 +3741,9 @@ static int _json_to_card(struct jmap_req *req,
                          json_t *arg, strarray_t *flags,
                          struct entryattlist **annotsp,
                          json_t **item,
-                         json_t *invalid)
+                         jmap_contact_errors_t *errors)
 {
+    json_t *invalid = errors->invalid;
     const char *key;
     json_t *jval;
     struct vparse_entry *n = vparse_get_entry(card, NULL, "N");
@@ -3763,22 +3825,10 @@ static int _json_to_card(struct jmap_req *req,
         }
         else if (!strcmp(key, "avatar")) {
             if (!json_is_null(jval)) {
-                struct buf new_blobid = BUF_INITIALIZER;
-                int r = _blob_to_card(req, jval, card, "PHOTO", &new_blobid);
+                int r = _blob_to_card(req, key, jval, card, "PHOTO", item, errors);
                 if (r) {
-                    if (r == HTTP_BAD_REQUEST)
-                        json_array_append_new(invalid, json_string("avatar"));
-                    else if (r == HTTP_NOT_ACCEPTABLE)
-                        json_array_append_new(invalid, json_string("avatar/type"));
-                    else
-                        json_array_append_new(invalid, json_string("avatar/blobId"));
                     continue;
                 }
-                if (!*item) *item = json_object();
-                json_object_set_new(*item, "avatar",
-                                    json_pack("{s:s}", "blobId",
-                                              buf_cstring(&new_blobid)));
-                buf_free(&new_blobid);
                 record_is_dirty = 1;
             }
         }
@@ -3920,7 +3970,7 @@ static int _json_to_card(struct jmap_req *req,
         }
     }
 
-    if (json_array_size(invalid)) return -1;
+    if (json_array_size(invalid) || errors->blobNotFound) return -1;
 
     if (name_is_dirty) {
         _make_fn(card);
@@ -3966,8 +4016,9 @@ static int required_set_rights(json_t *props)
 static int _contact_set_create(jmap_req_t *req, unsigned kind,
                                json_t *jcard, struct carddav_data *cdata,
                                struct mailbox **mailbox, json_t *item,
-                               json_t *invalid)
+                               jmap_contact_errors_t *errors)
 {
+    json_t *invalid = errors->invalid;
     struct entryattlist *annots = NULL;
     strarray_t *flags = NULL;
     struct vparse_card *card = NULL;
@@ -4073,12 +4124,12 @@ static int _contact_set_create(jmap_req_t *req, unsigned kind,
     }
     else {
         flags = strarray_new();
-        r = _json_to_card(req, cdata, card, jcard, flags, &annots, &item, invalid);
+        r = _json_to_card(req, cdata, card, jcard, flags, &annots, &item, errors);
 
         logfmt = "jmap: create contact %s/%s (%s)";
     }
 
-    if (r || json_array_size(invalid)) {
+    if (r || json_array_size(invalid) || errors->blobNotFound) {
         r = 0;
         goto done;
     }
@@ -4184,15 +4235,24 @@ static void _contact_copy(jmap_req_t *req,
 
     /* Create vcard */
     json_t *invalid = json_array();
+    jmap_contact_errors_t errors = { invalid, NULL };
     json_t *item = json_object();
     r = _contact_set_create(req, CARDDAV_KIND_CONTACT, dst_card,
-                            NULL, &dst_mbox, item, invalid);
-    if (r || json_array_size(invalid)) {
-        if (!r) {
+                            NULL, &dst_mbox, item, &errors);
+    if (r || json_array_size(invalid) || errors.blobNotFound) {
+        if (json_array_size(invalid)) {
             *set_err = json_pack("{s:s s:o}", "type", "invalidProperties",
                                               "properties", invalid);
+            json_decref(errors.blobNotFound);
         }
-        else json_decref(invalid);
+        else {
+            json_decref(invalid);
+
+            if (errors.blobNotFound) {
+                *set_err = json_pack("{s:s s:o}", "type", "blobNotFound",
+                                     "notFound", errors.blobNotFound);
+            }
+        }
         json_decref(item);
         goto done;
     }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1446,11 +1446,14 @@ static int _email_find_in_account(jmap_req_t *req,
 }
 
 HIDDEN int jmap_email_find(jmap_req_t *req,
+                           const char *from_accountid,
                            const char *email_id,
                            char **mboxnameptr,
                            uint32_t *uidptr)
 {
-    return _email_find_in_account(req, req->accountid, email_id, mboxnameptr, uidptr);
+    const char *accountid = from_accountid ?  from_accountid : req->accountid;
+
+    return _email_find_in_account(req, accountid, email_id, mboxnameptr, uidptr);
 }
 
 struct email_getcid_rock {
@@ -5291,7 +5294,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
 
         const char *msgid = json_string_value(val);
 
-        r = jmap_email_find(req, msgid, &mboxname, &uid);
+        r = jmap_email_find(req, NULL, msgid, &mboxname, &uid);
         if (r) {
             if (r == IMAP_NOTFOUND) {
                 json_array_append_new(*notfound, json_string(msgid));
@@ -7497,7 +7500,7 @@ static void jmap_email_get_full(jmap_req_t *req, struct jmap_get *get, struct em
         struct mailbox *mbox = NULL;
 
         uint32_t uid;
-        int r = jmap_email_find(req, id, &mboxname, &uid);
+        int r = jmap_email_find(req, NULL, id, &mboxname, &uid);
         if (!r) {
             r = jmap_openmbox(req, mboxname, &mbox, 0);
             if (!r) {
@@ -8309,7 +8312,7 @@ static void _email_append(jmap_req_t *req,
      *  visible for the authenticated user. */
     char *exist_mboxname = NULL;
     uint32_t exist_uid;
-    r = jmap_email_find(req, detail->email_id, &exist_mboxname, &exist_uid);
+    r = jmap_email_find(req, NULL, detail->email_id, &exist_mboxname, &exist_uid);
     free(exist_mboxname);
     if (r != IMAP_NOTFOUND) {
         if (!r) r = IMAP_MAILBOX_EXISTS;
@@ -13434,7 +13437,7 @@ static int jmap_emailheader_getblob(jmap_req_t *req,
     }
 
     /* Lookup emailid */
-    r = jmap_email_find(req, emailid, &mboxname, &uid);
+    r = jmap_email_find(req, NULL, emailid, &mboxname, &uid);
     if (r) {
         if (r == IMAP_NOTFOUND) res = HTTP_NOT_FOUND;
         else {

--- a/imap/jmap_mail.h
+++ b/imap/jmap_mail.h
@@ -53,6 +53,7 @@
 #include "msgrecord.h"
 
 extern int jmap_email_find(jmap_req_t *req, const char *email_id,
+                           const char *from_accountid,
                            char **mboxnameptr, uint32_t *uidptr);
 extern int jmap_email_get_with_props(jmap_req_t *req, hash_table *props,
                                      msgrecord_t *mr, json_t **msgp);

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -597,7 +597,7 @@ static void _emailsubmission_create(jmap_req_t *req,
     int fd_msg = -1;
 
     /* Lookup the message */
-    r = jmap_email_find(req, msgid, &mboxname, &uid);
+    r = jmap_email_find(req, NULL, msgid, &mboxname, &uid);
     if (r) {
         if (r == IMAP_NOTFOUND) {
             *set_err = json_pack("{s:s}", "type", "emailNotFound");

--- a/imap/jmap_mdn.c
+++ b/imap/jmap_mdn.c
@@ -255,7 +255,7 @@ static json_t *generate_mdn(struct jmap_req *req,
     buf_reset(msgbuf);
 
     /* Lookup the message */
-    r = jmap_email_find(req, mdn->emailid, &mboxname, &uid);
+    r = jmap_email_find(req, NULL, mdn->emailid, &mboxname, &uid);
     if (r) {
         if (r == IMAP_NOTFOUND) {
             err = json_pack("{s:s}", "type", "emailNotFound");


### PR DESCRIPTION
This has multiple changes related to Contacts avatars all with the goal of allowing blobIds of any type to be used for an avatar (e.g. BIMI header blobIds).  To do this the getblob handlers have been made to put the blob content in a struct buf, with the output for an actual download to be handled by jmap_download().  It also gets rid of the hack to conv.db 'G' records to keep track of blobIds for vCard PHOTO properties, which has now been moved to a variant of the 'V' smart blobIds.  As as result, we need to report out that the blobId for an avatar changes from a 'G' or 'H' blobId to a new 'V' blobId during /set{create,update}.