### PR TITLE
lib/: move some symbols to the Read-Only segment

### DIFF
--- a/lib/auth_unix.c
+++ b/lib/auth_unix.c
@@ -114,7 +114,7 @@ static int mymemberof(const struct auth_state *auth_state, const char *identifie
  * Identifiers don't require a digit, really, so that should probably be
  * relaxed, too.
  */
-static char allowedchars[256] = {
+static const char allowedchars[256] = {
  /* 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 00-0F */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 10-1F */

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3213,7 +3213,7 @@ EXPORTED const char *charset_decode_mimebody(const char *msg_base, size_t len, i
  * May be called with 'msg_base' as NULL to get the number of encoded
  * bytes for allocating 'retval' of the proper size.
  */
-static char base_64[] =
+static const char base_64[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 EXPORTED char *charset_encode_mimebody(const char *msg_base, size_t len,


### PR DESCRIPTION
lib/auth_unix.c:allowedchars and lib/charset.c:base_64.