### PR TITLE
netnews/remotepurge.c: remove compiler warning

### DIFF
--- a/netnews/remotepurge.c
+++ b/netnews/remotepurge.c
@@ -473,7 +473,6 @@ static int purge_me(char *name, time_t when)
         }
     }
 
- after_search:
     /* close mailbox */
     imclient_send(imclient_conn, callback_finish, (void *)imclient_conn,
                   "CLOSE");


### PR DESCRIPTION
The label 'after_search' was never ever used by goto.