### PR TITLE
3.2 - Sieve "include": :once and :optional flags in bytecode were being parsed in reverse

### DIFF
--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -376,8 +376,8 @@ enum bytecode_tags {
 };
 
 #define INC_LOCATION_MASK 0x3F
-#define INC_OPTIONAL_MASK 0x40
-#define INC_ONCE_MASK     0x80
+#define INC_ONCE_MASK     0x40
+#define INC_OPTIONAL_MASK 0x80
 
 #define SNOOZE_WDAYS_MASK 0x7F
 #define SNOOZE_IS_ID_MASK 0x80

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -725,8 +725,8 @@ static void dump2(bytecode_input_t *d, int bc_len)
 
         case B_INCLUDE:
             printf("INCLUDE LOCATION(%s) ONCE(%d) OPTIONAL(%d)",
-                   (cmd.u.inc.location = B_PERSONAL) ? "Personal" : "Global",
-                   cmd.u.inc.once, cmd.u.inc.optional);
+                   (cmd.u.inc.location == B_PERSONAL) ? "Personal" : "Global",
+                   !!cmd.u.inc.once, !!cmd.u.inc.optional);
             print_string("\n\tSCRIPT", cmd.u.inc.script);
             break;
 


### PR DESCRIPTION
Backport of d126b8e5a4e640cc2.