### PR TITLE
http_dav.c:principal_search() utilize DAV:displayname from the annotations

### DIFF
--- a/changes/next/dispayname_on_principal-property-search_report
+++ b/changes/next/dispayname_on_principal-property-search_report
@@ -1,0 +1,11 @@
+Description:
+
+The DAV:principal-property-search REPORT honours the previously set DAV:displayname property on matches
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+None

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -1877,7 +1877,7 @@ HIDDEN void dav_get_principalname(const char *userid, struct buf *buf)
     buf_reset(buf);
 
     if (userid) {
-        const char *annotname = DAV_ANNOT_NS "<" XML_NS_DAV ">displayname";
+        static const char annotname[] = DAV_ANNOT_NS "<" XML_NS_DAV ">displayname";
         char *mailboxname = caldav_mboxname(userid, NULL);
         int r = annotatemore_lookupmask(mailboxname, annotname, userid, buf);
 
@@ -7987,7 +7987,8 @@ static int principal_search(const char *userid, void *rock)
 
         for (prop = search_crit->props; prop; prop = prop->next) {
             if (!strcmp(prop->s, "displayname")) {
-                if (!xmlStrcasestr(BAD_CAST userid,
+                dav_get_principalname(userid, &fctx->buf);
+                if (!xmlStrcasestr(BAD_CAST buf_cstring(&fctx->buf),
                                    search_crit->match)) return 0;
             }
             else if (!strcmp(prop->s, "calendar-user-address-set")) {


### PR DESCRIPTION
When calling [REPORT principal-property-search](https://tools.ietf.org/html/rfc3744#section-9.4) and the search criterion is `DAV:displayname`, take the `displayname` from the annotatitonsDB, if available.
```sh
curl -XREPORT -H"content-type:application/xml" -uaaa:bbb --data-binary @- <<EOF https://SERVER/dav/principals/user

<principal-property-search xmlns="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
   <apply-to-principal-collection-set/>
   <property-search>
     <prop>
         <displayname/>
     </prop>
     <match>aaa</match>
   </property-search>
   <prop>
     <c:calendar-user-address-set/>
     <c:calendar-home-set/>
     <c:calendar-user-type/>
     <displayname/>
   </prop>
 </principal-property-search>
```