### PR TITLE
In REPORT DAV:principal-property-search verify the xml-namespace for the searched properties

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -7955,8 +7955,10 @@ static int report_prin_prop_search(struct transaction_t *txn,
 
                                     for (entry = prin_search_props;
                                          entry->name &&
+                                            (xmlStrcmp(fctx->ns[entry->ns]->href,
+                                                       prop->ns->href) ||
                                              xmlStrcmp(prop->name,
-                                                       BAD_CAST entry->name);
+                                                       BAD_CAST entry->name));
                                          entry++);
 
                                     if (!entry->name) {


### PR DESCRIPTION
```xml
<principal-property-search xmlns="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
   <property-search>
     <prop>
<!-- this one has to fail -->         <c:displayname/>
     </prop>
     <match>f</match>
   </property-search>
   <prop>
     <displayname/>
   </prop>
 </principal-property-search>
```