### PR TITLE
Dav reconstruct audit

### DIFF
--- a/imap/calalarmd.c
+++ b/imap/calalarmd.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
     }
 
     if (runattime) {
-        caldav_alarm_process(runattime, NULL);
+        caldav_alarm_process(runattime, NULL, /*dryrun*/0);
         shut_down(0);
     }
 
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
         signals_poll();
 
         gettimeofday(&start, 0);
-        caldav_alarm_process(0, &interval);
+        caldav_alarm_process(0, &interval, /*dryrun*/0);
         gettimeofday(&end, 0);
 
         signals_poll();

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -279,6 +279,9 @@ EXPORTED int caldav_alarm_commit_reconstruct(const char *userid)
     else sqldb_rollback(alarmdb, "replace_alarms");
     caldav_alarm_close(alarmdb);
 
+    // if we succeeded, drop the copy of events in this DB
+    if (!r) r = sqldb_exec(db, "DROP TABLE events;", NULL, NULL, NULL);
+
     return r;
 }
 
@@ -289,6 +292,8 @@ EXPORTED void caldav_alarm_rollback_reconstruct()
     assert(refcount == 1);
     refcount = 0;
     my_alarmdb = NULL;
+
+    // we keep the events database in this copy for later examination
 }
 
 /*

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -946,7 +946,7 @@ static int process_valarms(struct mailbox *mailbox,
                          &prock, /* flags */ 0);
 
     data.lastrun = runtime;
-    write_lastalarm(mailbox, record, &data);
+    if (!dryrun) write_lastalarm(mailbox, record, &data);
 
     update_alarmdb(mailbox->name, record->uid, data.nextcheck);
 
@@ -1227,7 +1227,7 @@ static void process_one_record(struct caldav_alarm_data *data, time_t runtime, i
     syslog(LOG_DEBUG, "processing alarms for mailbox %s uid %u",
            data->mboxname, data->imap_uid);
 
-    r = mailbox_open_iwl(data->mboxname, &mailbox);
+    r = dryrun ? mailbox_open_irl(data->mboxname, &mailbox) : mailbox_open_iwl(data->mboxname, &mailbox);
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         syslog(LOG_ERR, "not found mailbox %s", data->mboxname);
         /* no record, no worries */
@@ -1461,9 +1461,7 @@ EXPORTED int caldav_alarm_upgrade()
                                                       runtime, runtime, /*dryrun*/1);
                     free(userid);
 
-                    struct lastalarm_data data = { runtime, nextcheck };
-                    write_lastalarm(mailbox, record, &data);
-                    update_alarmdb(mailbox->name, record->uid, data.nextcheck);
+                    update_alarmdb(mailbox->name, record->uid, nextcheck);
                 }
                 icalcomponent_free(ical);
             }

--- a/imap/caldav_alarm.h
+++ b/imap/caldav_alarm.h
@@ -56,6 +56,11 @@ int caldav_alarm_init(void);
 /* done with all caldav operations for this process */
 int caldav_alarm_done(void);
 
+/* reconstruct support */
+int caldav_alarm_set_reconstruct(sqldb_t *db);
+int caldav_alarm_commit_reconstruct(const char *userid);
+void caldav_alarm_rollback_reconstruct();
+
 /* add a calendar alarm */
 int caldav_alarm_add_record(struct mailbox *mailbox,
                             const struct index_record *record,

--- a/imap/caldav_alarm.h
+++ b/imap/caldav_alarm.h
@@ -84,7 +84,7 @@ int caldav_alarm_delete_mailbox(const char *mboxname);
 int caldav_alarm_delete_user(const char *userid);
 
 /* distribute alarms with triggers in the next minute */
-int caldav_alarm_process(time_t runtime, time_t *next);
+int caldav_alarm_process(time_t runtime, time_t *next, int dryrun);
 
 /* upgrade old databases */
 int caldav_alarm_upgrade();

--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -201,7 +201,7 @@ EXPORTED int caldav_close(struct caldav_db *caldavdb)
     buf_free(&caldavdb->sched_tag);
     buf_free(&caldavdb->jmapdata);
 
-    r = sqldb_close(&caldavdb->db);
+    r = dav_close(&caldavdb->db);
 
     free(caldavdb);
 

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -151,7 +151,7 @@ EXPORTED int carddav_close(struct carddav_db *carddavdb)
         buf_free(&carddavdb->bufs[i]);
     }
 
-    r = sqldb_close(&carddavdb->db);
+    r = dav_close(&carddavdb->db);
 
     free(carddavdb->userid);
     free(carddavdb);

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -350,7 +350,7 @@ static int _dav_reconstruct_mb(const mbentry_t *mbentry,
     return r;
 }
 
-static void run_audit_tool(const char *tool, const char *srcdb, const char *dstdb)
+static void run_audit_tool(const char *tool, const char *userid, const char *srcdb, const char *dstdb)
 {
     pid_t pid = fork();
     if (pid < 0)
@@ -358,7 +358,7 @@ static void run_audit_tool(const char *tool, const char *srcdb, const char *dstd
 
     if (pid == 0) {
         /* child */
-        execl(tool, tool, srcdb, dstdb, (void *)NULL);
+        execl(tool, tool, "-C", config_filename, "-u", userid, srcdb, dstdb, (void *)NULL);
         exit(-1);
     }
 
@@ -413,7 +413,7 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
     else {
         syslog(LOG_NOTICE, "dav_reconstruct_user: %s SUCCEEDED", userid);
         if (audit_tool) {
-            run_audit_tool(audit_tool, buf_cstring(&fname), buf_cstring(&newfname));
+            run_audit_tool(audit_tool, userid, buf_cstring(&fname), buf_cstring(&newfname));
             unlink(buf_cstring(&newfname));
         }
         else {

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -60,6 +60,7 @@
 #include "dav_db.h"
 #include "imap_err.h"
 #include "global.h"
+#include "user.h"
 #include "util.h"
 #include "xmalloc.h"
 
@@ -377,6 +378,8 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
     dav_getpath_byuserid(&newfname, userid);
     buf_printf(&newfname, ".NEW");
 
+    struct mboxlock *namespacelock = user_namespacelock(userid);
+
     int r = IMAP_IOERROR;
     reconstruct_db = sqldb_open(buf_cstring(&newfname), CMD_CREATE, DB_VERSION, davdb_upgrade,
                                 config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT, 's') * 1000);
@@ -416,6 +419,8 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
             rename(buf_cstring(&newfname), buf_cstring(&fname));
         }
     }
+
+    mboxname_release(&namespacelock);
 
     buf_free(&newfname);
     buf_free(&fname);

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -387,6 +387,8 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
         // reconstruct everything
         if (!r) r = mboxlist_usermboxtree(userid, NULL,
                                           _dav_reconstruct_mb, (void *) userid, 0);
+        // make sure all the alarms are resolved
+        if (!r) r = caldav_alarm_process(0, NULL, /*dryrun*/1);
         // commit events over to ther alarm database if we're keeping them
         if (!r && !audit_tool) r = caldav_alarm_commit_reconstruct(userid);
         else caldav_alarm_rollback_reconstruct();

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -342,8 +342,7 @@ static int _dav_reconstruct_mb(const mbentry_t *mbentry,
     if (addproc) {
         struct mailbox *mailbox = NULL;
         /* Open/lock header */
-        r = mailbox_open_iwl(mbentry->name, &mailbox);
-        // needs to be writable to remove bogus lastalarm data
+        r = mailbox_open_irl(mbentry->name, &mailbox);
         if (!r) r = addproc(mailbox);
         mailbox_close(&mailbox);
     }

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -275,6 +275,11 @@ EXPORTED int dav_attach_mailbox(sqldb_t *db, struct mailbox *mailbox)
     return r;
 }
 
+EXPORTED int dav_close(sqldb_t **dbp)
+{
+    return sqldb_close(dbp);
+}
+
 
 /*
  * mboxlist_usermboxtree() callback function to create DAV DB entries for a mailbox

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -377,12 +377,6 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
     dav_getpath_byuserid(&newfname, userid);
     buf_printf(&newfname, ".NEW");
 
-    /* XXX - this still means that alarms can go missing if this
-     * task is interrupted, but we can't afford to keep the
-     * alarm database locked for the entire time, it's a single
-     * blocking database over the entire server */
-    caldav_alarm_delete_user(userid);
-
     int r = IMAP_IOERROR;
     reconstruct_db = sqldb_open(buf_cstring(&newfname), CMD_CREATE, DB_VERSION, davdb_upgrade,
                                 config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT, 's') * 1000);

--- a/imap/dav_db.h
+++ b/imap/dav_db.h
@@ -67,6 +67,7 @@ struct dav_data {
 /* get a database handle corresponding to mailbox */
 sqldb_t *dav_open_userid(const char *userid);
 sqldb_t *dav_open_mailbox(struct mailbox *mailbox);
+int dav_close(sqldb_t **dbp);
 
 /* delete database corresponding to mailbox */
 int dav_delete(struct mailbox *mailbox);

--- a/imap/webdav_db.c
+++ b/imap/webdav_db.c
@@ -173,7 +173,7 @@ EXPORTED int webdav_close(struct webdav_db *webdavdb)
     buf_free(&webdavdb->subtype);
     buf_free(&webdavdb->res_uid);
 
-    r = sqldb_close(&webdavdb->db);
+    r = dav_close(&webdavdb->db);
 
     free(webdavdb->userid);
     free(webdavdb);


### PR DESCRIPTION
This adds extra smarts around the audit tool for dav-reconstruct, so we know which slot it's running on and which user it's for from the command line.

This will be paired with a Perl tool which can then read said config and actually diff the two databases.