### PR TITLE
For DAV:principal-property-search REPORT match the calendar-user-address-set request with the annotations

### DIFF
--- a/changes/next/get_calendar_user_address_set_for_principal
+++ b/changes/next/get_calendar_user_address_set_for_principal
@@ -1,0 +1,11 @@
+Description:
+
+Honour the real CalDAV:calendar-user-address-set WebDAV property for matches in the DAV:principal-property-search report.
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+None

--- a/imap/http_caldav_sched.h
+++ b/imap/http_caldav_sched.h
@@ -178,6 +178,7 @@ extern xmlNodePtr xml_add_schedresponse(xmlNodePtr root, xmlNsPtr dav_ns,
                                         xmlChar *recipient, xmlChar *status);
 extern int caladdress_lookup(const char *addr, struct caldav_sched_param *param,
                              const strarray_t *schedule_addresses);
+extern strarray_t* get_calendar_user_address_set_for_principal(const char *);
 extern void get_schedule_addresses(hdrcache_t req_hdrs, const char *mboxname,
                                    const char *userid, strarray_t *addresses);
 

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -3801,32 +3801,9 @@ alerts_to_ical(icalcomponent *comp, struct jmap_parser *parser, json_t *alerts)
 
         if (action == ICAL_ACTION_EMAIL) {
             /* ATTENDEE */
-            const char *annotname = DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-user-address-set";
-            char *mailboxname = caldav_mboxname(httpd_userid, NULL);
-            struct buf buf = BUF_INITIALIZER;
-            int r = annotatemore_lookupmask(mailboxname, annotname, httpd_userid, &buf);
-
-            char *recipient = NULL;
-
-            if (!r && buf_len(&buf)) {
-                strarray_t *values = strarray_split(buf_cstring(&buf), ",", STRARRAY_TRIM);
-                const char *item = strarray_nth(values, 0);
-                if (!strncasecmp(item, "mailto:", 7)) item += 7;
-                recipient = strconcat("mailto:", item, NULL);
-                strarray_free(values);
-            }
-            else if (strchr(httpd_userid, '@')) {
-                recipient = strconcat("mailto:", httpd_userid, NULL);
-            }
-            else {
-                recipient = strconcat("mailto:", httpd_userid, "@", config_defdomain, NULL);
-            }
-
-            icalcomponent_add_property(alarm, icalproperty_new_attendee(recipient));
-            free(recipient);
-
-            buf_free(&buf);
-            free(mailboxname);
+            strarray_t *values = get_calendar_user_address_set_for_principal(httpd_userid);
+            icalcomponent_add_property(alarm, icalproperty_new_attendee(strarray_nth(values, 0)));
+            strarray_free(values);
 
             /* SUMMARY */
             const char *summary = icalcomponent_get_summary(comp);

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -423,13 +423,13 @@ EXPORTED void strarray_uniq(strarray_t *sa)
 }
 
 /* common generic routine for the _find family */
-static int strarray_findg(const strarray_t *sa, const char *match, int starting,
-                          int (*compare)(const char *, const char *))
+EXPORTED int strarray_findg(const strarray_t *sa, const char *match, int starting,
+                            int (*compare)(const char *, const char *))
 {
     int i;
 
     for (i = starting ; i < sa->count ; i++)
-        if (!compare(match, sa->data[i]))
+        if (!compare(/* haystack */ sa->data[i], /* needle */ match))
             return i;
     return -1;
 }

--- a/lib/strarray.h
+++ b/lib/strarray.h
@@ -108,6 +108,8 @@ void strarray_uniq(strarray_t *);
 char **strarray_safetakevf(strarray_t *sa);
 char **strarray_takevf(strarray_t *sa);
 
+int strarray_findg(const strarray_t *sa, const char *match, int starting,
+                   int (*compare)(const char *, const char *));
 int strarray_find(const strarray_t *sa, const char *match,
                   int starting);
 int strarray_find_case(const strarray_t *sa, const char *match,


### PR DESCRIPTION
This change fixes errors, reduces the total number of lines and introduces new feature at the same time.

* introduce get_calendar_user_address_set_for_principal()

* jmap_calendars.c:get_schedule_address_set() used "#calendars" instead of config_getstring(IMAPOPT_CALENDARPREFIX)

* in jmap_calendars.c:get_schedule_address_set() the code used to honour the annotations for httpd_userid, but if they were missing then use the passed userid to generate the default schedule addresses.  This makes no sense.  This changes the behaviour to always check the annotations for "userid" and not for "httpd_userid".

* jmap_calendars.c:get_schedule_address_set() has not iterated over cua_domains.