### PR TITLE
3.2 - xapian_wrap:get_stopper() use the cached stoppers

### DIFF
--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -55,7 +55,7 @@ static const Xapian::Stopper* get_stopper(const std::string& iso)
 {
     // Lookup cached entry.
     try {
-        stoppers.at(iso).get();
+        return stoppers.at(iso).get();
     } catch (const std::out_of_range&) {};
 
     // Lookup language name by ISO code.


### PR DESCRIPTION
Backport of 3ffaf02fba9a09b20

Broken since 8733b0bb3a.