### PR TITLE
docsrc: update for Sphinx 3.x

### DIFF
--- a/docsrc/exts/sphinxlocal/writers/manpage.py
+++ b/docsrc/exts/sphinxlocal/writers/manpage.py
@@ -26,7 +26,7 @@ if docutils_version_info < (0, 11):
 
 from sphinx import addnodes
 from sphinx.locale import admonitionlabels, _
-from sphinx.util.osutil import ustrftime
+from time import strftime
 
 class CyrusManualPageWriter(ManualPageWriter):
 
@@ -68,11 +68,7 @@ class CyrusManualPageTranslator(BaseTranslator):
 
         # docinfo set by other config values
         self._docinfo['title_upper'] = self._docinfo['title'].upper()
-        if builder.config.today:
-            self._docinfo['date'] = builder.config.today
-        else:
-            self._docinfo['date'] = ustrftime(builder.config.today_fmt
-                                              or _('%B %d, %Y'))
+        self._docinfo['date'] = builder.config.today or strftime(builder.config.today_fmt or _('%B %d, %Y'))
         self._docinfo['copyright'] = builder.config.copyright
         self._docinfo['version'] = builder.config.version
         self._docinfo['manual_group'] = builder.config.project


### PR DESCRIPTION
Sphinx 1.8 deprecates sphinx.util.osutil.ustrftime and https://github.com/sphinx-doc/sphinx/commit/61098a0ae2e696a804 removes the method.

- update docsrc/exts/sphinxlocal/writers/manpage.py to compile with Sphinx-doc 3.2.1.