### PR TITLE
jmap_mail: do not use guidsearch for divergent non-Xapian criteria

### DIFF
--- a/changes/next/guidsearch_mixed_clauses
+++ b/changes/next/guidsearch_mixed_clauses
@@ -1,0 +1,14 @@
+Description:
+
+Fixes a bug in guidsearch where a query may return false results if its DNF clauses contain divergent non-Xapian criteria.
+
+This reduces the number of queries that can be handled by guidsearch and may result in search latency regressions for such queries.
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.


### PR DESCRIPTION
Fixes a bug in guidsearch where a query may return false results if its DNF clauses contain divergent non-Xapian criteria.                                                                                       

This reduces the number of queries that can be handled by guidsearch and may result in search latency regressions for such queries. 

Tested in https://github.com/cyrusimap/cassandane/commit/89616c9787881e3b20004b66e3d5429e0ec678b5