### PR TITLE
fix loss of replication protocol sync when APPLY MESSAGE fails to write to disk

### DIFF
--- a/changes/next/3360-apply-message-write-failure-desync
+++ b/changes/next/3360-apply-message-write-failure-desync
@@ -1,0 +1,11 @@
+Description:
+
+Bug fix for #3360
+
+Config changes:
+
+debug_writefail_guid
+
+Upgrade instructions:
+
+None required

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -2081,7 +2081,7 @@ static void cmdloop(void)
                     cmd_syncapply(tag.s, kl, reserve_list);
                     dlist_free(&kl);
                 }
-                else goto extraargs;
+                else goto badrepl;
             }
             else if (!strcmp(cmd.s, "Syncget")) {
                 if (!imapd_userisadmin) goto badcmd;
@@ -2092,7 +2092,7 @@ static void cmdloop(void)
                     cmd_syncget(tag.s, kl);
                     dlist_free(&kl);
                 }
-                else goto extraargs;
+                else goto badrepl;
             }
             else if (!strcmp(cmd.s, "Syncrestart")) {
                 if (!imapd_userisadmin) goto badcmd;
@@ -2111,7 +2111,7 @@ static void cmdloop(void)
                     cmd_syncrestore(tag.s, kl, reserve_list);
                     dlist_free(&kl);
                 }
-                else goto extraargs;
+                else goto badrepl;
             }
             else goto badcmd;
             break;
@@ -2517,6 +2517,12 @@ static void cmdloop(void)
         prot_printf(imapd_out,
                     "%s BAD Invalid partition name in %s\r\n", tag.s, cmd.s);
         eatline(imapd_in, c);
+        continue;
+
+    badrepl:
+        prot_printf(imapd_out,
+                    "%s BAD Replication parse failure in %s\r\n", tag.s, cmd.s);
+        /* n.b. sync_parseline already ate the bad line */
         continue;
     }
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -764,6 +764,9 @@ Blank lines and lines beginning with ``#'' are ignored.
    For backward compatibility, if no unit is specified, seconds is
    assumed. */
 
+{ "debug", 0, SWITCH, "2.5.0" }
+/* If enabled, allow syslog() to pass LOG_DEBUG messages. */
+
 { "debug_command", NULL, STRING, "2.3.17" }
 /* Debug command to be used by processes started with -D option.  The string
    is a C format string that gets 3 options: the first is the name of the
@@ -956,9 +959,6 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* If enabled, the partitions will also be hashed, in addition to the
    hashing done on configuration directories.  This is recommended if
    one partition has a very bushy mailbox tree. */
-
-{ "debug", 0, SWITCH, "2.5.0" }
-/* If enabled, allow syslog() to pass LOG_DEBUG messages. */
 
 # Commented out - there's no such thing as "hostname_mechs", but we need
 # this for the man page

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -777,7 +777,8 @@ Blank lines and lines beginning with ``#'' are ignored.
 { "debug_writefail_guid", NULL, STRING, "UNRELEASED" }
 /* If set, any arriving message with this guid will fail as if the underlying
    disk write had failed, pretending to be a disk full condition.  This is
-   mainly useful for regression testing certain edge case handling. */
+   mainly useful for regression testing certain edge case handling.
+   Currently only implemented for replication uploads. */
 
 { "defaultacl", "anyone lrs", STRING, "2.3.17" }
 /* The Access Control List (ACL) placed on a newly-created (non-user)

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -774,6 +774,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    is the pid (integer) and the third is the service ID.
    Example: /usr/local/bin/gdb /usr/cyrus/bin/%s %d */
 
+{ "debug_writefail_guid", NULL, STRING, "UNRELEASED" }
+/* If set, any arriving message with this guid will fail as if the underlying
+   disk write had failed, pretending to be a disk full condition.  This is
+   mainly useful for regression testing certain edge case handling. */
+
 { "defaultacl", "anyone lrs", STRING, "2.3.17" }
 /* The Access Control List (ACL) placed on a newly-created (non-user)
    mailbox that does not have a parent mailbox. */


### PR DESCRIPTION
* Fixes loss of protocol sync in APPLY MESSAGE by adding a `sync_eatline()` that can also consume the remaining dlist file literals correctly
* Also fixes a quiet bug whereby imapd would eatline() twice on sync failures, discarding the next command as well
* And adds a new imapd option "debug_writefail_guid" for simulating write failures for the given guid, to enable regression testing for this case

Corresponding Cassandane tests are here: https://github.com/cyrusimap/cassandane/compare/master...elliefm:v35/3360-apply-message-write-failure-desync

Fixes #3360 