### PR TITLE
proppatch_todb(): do not mask the annotations for admins user

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1019,7 +1019,7 @@ static int proppatch_scheddefault(xmlNodePtr prop, unsigned set,
 
                 const strarray_t *boxes = mbname_boxes(mbname);
                 buf_setcstr(&pctx->buf, strarray_nth(boxes, strarray_size(boxes)-1));
-                r = annotate_state_writemask(astate, annotname, httpd_userid, &pctx->buf);
+                r = annotate_state_writemask(astate, annotname, httpd_userisadmin ? "" : httpd_userid, &pctx->buf);
             }
         }
         mailbox_close(&mailbox);
@@ -6444,7 +6444,7 @@ static int proppatch_timezone(xmlNodePtr prop, unsigned set,
             buf_reset(&pctx->buf);
             r = mailbox_get_annotate_state(pctx->mailbox, 0, &astate);
             if (!r) r = annotate_state_writemask(astate, prop_annot,
-                                                 httpd_userid, &pctx->buf);
+                                                 httpd_userisadmin ? "" : httpd_userid, &pctx->buf);
             if (!r) {
                 /* Set CALDAV:calendar-timezone */
                 proppatch_todb(prop, set, pctx, propstat, (void *) tz);
@@ -6746,7 +6746,7 @@ static int proppatch_tzid(xmlNodePtr prop, unsigned set,
             buf_reset(&pctx->buf);
             r = mailbox_get_annotate_state(pctx->mailbox, 0, &astate);
             if (!r) r = annotate_state_writemask(astate, prop_annot,
-                                                 httpd_userid, &pctx->buf);
+                                                 httpd_userisadmin ? "": httpd_userid, &pctx->buf);
 
             if (r) {
                 xml_add_prop(HTTP_SERVER_ERROR, pctx->ns[NS_DAV],

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3222,7 +3222,7 @@ static int proppatch_toresource(xmlNodePtr prop, unsigned set,
 
     r = mailbox_get_annotate_state(pctx->mailbox, pctx->record->uid, &astate);
     if (!r) r = annotate_state_writemask(astate, buf_cstring(&pctx->buf),
-                                         httpd_userid, &value);
+                                         httpd_userisadmin ? "" : httpd_userid, &value);
     /* we need to rewrite the record to update the modseq because the layering
      * of annotations and mailboxes is broken */
     if (!r) r = mailbox_rewrite_index_record(pctx->mailbox, pctx->record);
@@ -3378,7 +3378,7 @@ static int proppatch_todb_internal(xmlNodePtr prop, unsigned set,
     r = mailbox_get_annotate_state(pctx->mailbox, 0, &astate);
     if (!r) r = mask ?
         annotate_state_writemask(astate, buf_cstring(&pctx->buf),
-                httpd_userid, &value) :
+                httpd_userisadmin ? "" : httpd_userid, &value) :
         annotate_state_write(astate, buf_cstring(&pctx->buf),
                 httpd_userid, &value);
 
@@ -3712,7 +3712,7 @@ static int do_proppatch(struct proppatch_ctx *pctx, xmlNodePtr instr)
                                          DAV_PROT_PROP);
                             *pctx->ret = HTTP_FORBIDDEN;
                         }
-                        else if ((pctx->txn->meth == METH_PROPPATCH) &&
+                        else if ((pctx->txn->meth == METH_PROPPATCH) && !httpd_userisadmin &&
                                  !(rights & ((entry->flags & PROP_PERUSER) ?
                                              DACL_READ : DACL_PROPCOL))) {
                             /* DAV:need-privileges */

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -1145,7 +1145,7 @@ HIDDEN int notify_post(struct transaction_t *txn)
 
             buf_init_ro_cstr(&value, (char *) resp->name);
             r = annotate_state_writemask(astate, annot,
-                                         txn->req_tgt.userid, &value);
+                                         httpd_userisadmin ? "" : txn->req_tgt.userid, &value);
 
             if (mbtype_isa(mailbox_mbtype(shared)) == MBTYPE_CALENDAR) {
                 /* Sharee's copy of calendar SHOULD default to transparent */
@@ -1153,7 +1153,7 @@ HIDDEN int notify_post(struct transaction_t *txn)
                     DAV_ANNOT_NS "<" XML_NS_CALDAV ">schedule-calendar-transp";
                 buf_init_ro_cstr(&value, "transparent");
                 r = annotate_state_writemask(astate, annot,
-                                             txn->req_tgt.userid, &value);
+                                             httpd_userisadmin ? "" : txn->req_tgt.userid, &value);
             }
         }
 


### PR DESCRIPTION
Rationale: when an admin user sends PROPPATCH, then the annotations set by the mailbox owner shall be updated.  This permits the admin user to modify WebDAV properties without fighting with the annotations database directly or asking for the user’s password.

Admitted, not all cases for PROPPATCH are handled here.