### PR TITLE
message: fix mailbox cache for To: headers with quoted recipients

### DIFF
--- a/fix_write_searchaddr_quoted
+++ b/fix_write_searchaddr_quoted
@@ -1,0 +1,19 @@
+Description:
+
+Fixes a bug where multiple recipients in a To: header might not have
+been indexed properly in the mailbox cache and search indexes.
+
+This bug only occurred since January 21, 2021 and got fixed on March 11, 2021.
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+Actions are only required if installations were running Cyrus development
+versions between the time range mentioned in the Description section.
+
+If so, rewrite the mailbox cache using `reconstruct` and rewrite the search
+indexes using `squatter`.

--- a/imap/message.c
+++ b/imap/message.c
@@ -2687,7 +2687,7 @@ static void message_write_searchaddr(struct buf *buf,
                         buf_putc(&qtext, *c);
                     }
                     buf_putc(&qtext, '"');
-                    buf_copy(buf, &qtext);
+                    buf_append(buf, &qtext);
                     buf_free(&qtext);
                 }
                 else {


### PR DESCRIPTION
The original code overwrote the previous buffer for every recipient that required quotes around recipient names. This effectively truncated the list of recipients.

This bug got introduced in https://github.com/cyrusimap/cyrus-imapd/commit/171bbe6396d3eac4e3b5c544ad9d1e38377c2234

Tested in https://github.com/cyrusimap/cassandane/commit/e2f17363c34208e01c94f0afaf00688436a3483c