### PR TITLE
index: use attachment extractor for text/rtf message bodies

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -5703,7 +5703,7 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
         /* PGP encrypted body part - we don't want to index this,
          * it's a ton of random base64 noise */
     }
-    else if (isbody && !strcmp(type, "TEXT")) {
+    else if (isbody && !strcmp(type, "TEXT") && strcmpsafe(subtype, "RTF")) {
 
         if (str->snippet_iteration >= 2) goto done;
 
@@ -5735,7 +5735,7 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
             str->receiver->end_part(str->receiver, SEARCH_PART_BODY);
         }
     }
-    else if (isbody && !strcmp(type, "APPLICATION")) {
+    else if (isbody && (!strcmp(type, "APPLICATION") || !strcmp(type, "TEXT"))) {
 
 #ifdef USE_HTTPD
         // application/ics is an alias for text/icalendar


### PR DESCRIPTION
Before,the raw RTF file including control words could end up in a search snippet preview.

Tested in https://github.com/cyrusimap/cassandane/commit/a95a1b05c1d418104c223bba7d08fe920b620968