### PR TITLE
3.2 - timsieved/actions.c: fix memory leak

### DIFF
--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -78,7 +78,7 @@ extern sieve_interp_t *interp;
 
 static char *sieve_dir_config = NULL;
 
-static const char *sieved_userid = NULL;
+static char *sieved_userid = NULL;
 
 int actions_init(void)
 {
@@ -106,6 +106,7 @@ int actions_setuser(const char *userid)
 
   char *sieve_dir = (char *) xzmalloc(size+1);
 
+  free(sieved_userid);
   sieved_userid = xstrdup(userid);
   user = (char *) userid;
   if (config_virtdomains && strchr(user, '@')) {


### PR DESCRIPTION
When UNAUTHENTICATE + AUTHENTICATE is called, the variable `sieved_userid` is leaked.

Backport of 43e145ab7b9f.