### PR TITLE
Imapd no jmapnotification

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -13047,14 +13047,8 @@ static int perform_output(const char *extname, const mbentry_t *mbentry, struct 
                                                           &imapd_namespace,
                                                           imapd_userid);
             }
-            if (mboxname_iscalendarmailbox(intname, mbtype)    ||
-                mboxname_isaddressbookmailbox(intname, mbtype) ||
-                mboxname_isdavdrivemailbox(intname, mbtype)    ||
-                mboxname_issubmissionmailbox(intname, mbtype)    ||
-                mboxname_ispushsubscriptionmailbox(intname, mbtype)    ||
-                mboxname_isdavnotificationsmailbox(intname, mbtype)) {
+            if (mboxname_isnonimapmailbox(intname, mbtype))
                 skip = 1;
-            }
             free(freeme);
 
             if (skip) return 0;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3577,7 +3577,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     for (num = 0; num < numfolders; num++) {
         const char *mboxname = conversations_folder_name(req->cstate, num);
         mbentry_t *mbentry = NULL;
-        if (mboxname_isnonimapmailbox(mboxname, 0) ||
+        if (mboxname_isnondeliverymailbox(mboxname, 0) ||
             mboxlist_lookup_allow_all(mboxname, &mbentry, NULL) ||
             mbentry->mbtype != MBTYPE_EMAIL) {
             bv_clear(&gsq->readable_folders, num);

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1517,9 +1517,7 @@ static int getmailboxidexists(void *sc, const char *extname)
     char *intname = mboxlist_find_uniqueid(extname, sd->userid, sd->authstate);
     int exists = 0;
 
-    if (intname &&
-        !mboxname_isdeletedmailbox(intname, NULL) &&
-        !mboxname_isnonimapmailbox(intname, 0)) {
+    if (intname && !mboxname_isnondeliverymailbox(intname, 0)) {
         exists = 1;
     }
 

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -193,9 +193,7 @@ static int getmailboxidexists(void *sc, const char *extname)
     char *intname = mboxlist_find_uniqueid(extname, userid, sd->authstate);
     int exists = 0;
 
-    if (intname &&
-        !mboxname_isdeletedmailbox(intname, NULL) &&
-        !mboxname_isnonimapmailbox(intname, 0)) {
+    if (intname && !mboxname_isnondeliverymailbox(intname, 0)) {
         exists = 1;
     }
 
@@ -1089,9 +1087,7 @@ static int sieve_fileinto(void *ac,
     else {
         if (fc->mailboxid) {
             intname = mboxlist_find_uniqueid(fc->mailboxid, userid, sd->authstate);
-            if (intname &&
-                (mboxname_isdeletedmailbox(intname, NULL) ||
-                 mboxname_isnonimapmailbox(intname, 0))) {
+            if (intname && mboxname_isnondeliverymailbox(intname, 0)) {
                 free(intname);
                 intname = NULL;
             }
@@ -1584,9 +1580,7 @@ static void do_fcc(script_data_t *sdata, sieve_fileinto_context_t *fcc,
     if (fcc->mailboxid) {
         intname = mboxlist_find_uniqueid(fcc->mailboxid, userid,
                                          sdata->authstate);
-        if (intname &&
-            (mboxname_isdeletedmailbox(intname, NULL) ||
-             mboxname_isnonimapmailbox(intname, 0))) {
+        if (intname && mboxname_isnondeliverymailbox(intname, 0)) {
             free(intname);
             intname = NULL;
         }

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -502,8 +502,7 @@ int deliver_mailbox(FILE *f,
     time_t internaldate = 0;
 
     /* make sure we have an IMAP mailbox */
-    if (mboxname_isdeletedmailbox(mailboxname, NULL) ||
-        mboxname_isnonimapmailbox(mailboxname, 0/*mbtype*/)) {
+    if (mboxname_isnondeliverymailbox(mailboxname, 0/*mbtype*/)) {
         return IMAP_MAILBOX_NOTSUPPORTED;
     }
 

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -220,6 +220,11 @@ int mboxname_isjmapnotificationsmailbox(const char *name, int mbtype);
      || mboxname_isjmapuploadmailbox(name, mbtype)         \
      || mboxname_isjmapnotificationsmailbox(name, mbtype))
 
+#define mboxname_isnondeliverymailbox(name, mbtype)        \
+    (mboxname_isnonimapmailbox(name, mbtype)               \
+     || mboxname_isnotesmailbox(name, mbtype)              \
+     || mboxname_isdeletedmailbox(name, NULL))
+
 /* check if one mboxname is a parent or same as the other */
 int mboxname_is_prefix(const char *longstr, const char *shortstr);
 /* check if one mboxname contains the parent of the other mboxname */

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -215,7 +215,6 @@ int mboxname_isjmapnotificationsmailbox(const char *name, int mbtype);
      || mboxname_isaddressbookmailbox(name, mbtype)        \
      || mboxname_isdavdrivemailbox(name, mbtype)           \
      || mboxname_isdavnotificationsmailbox(name, mbtype)   \
-     || mboxname_isnotesmailbox(name, mbtype)              \
      || mboxname_issubmissionmailbox(name, mbtype)         \
      || mboxname_ispushsubscriptionmailbox(name, mbtype)   \
      || mboxname_isjmapuploadmailbox(name, mbtype)         \

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -204,6 +204,12 @@ int mboxname_ispushsubscriptionmailbox(const char *name, int mbtype);
  */
 int mboxname_isjmapuploadmailbox(const char *name, int mbtype);
 
+/*
+ * If (internal) mailbox 'name' is a user's #jmap notifications mailbox
+ * returns boolean
+ */
+int mboxname_isjmapnotificationsmailbox(const char *name, int mbtype);
+
 #define mboxname_isnonimapmailbox(name, mbtype)            \
     (mboxname_iscalendarmailbox(name, mbtype)              \
      || mboxname_isaddressbookmailbox(name, mbtype)        \
@@ -211,8 +217,9 @@ int mboxname_isjmapuploadmailbox(const char *name, int mbtype);
      || mboxname_isdavnotificationsmailbox(name, mbtype)   \
      || mboxname_isnotesmailbox(name, mbtype)              \
      || mboxname_issubmissionmailbox(name, mbtype)         \
-     || mboxname_ispushsubscriptionmailbox(name, mbtype)  \
-     || mboxname_isjmapuploadmailbox(name, mbtype))
+     || mboxname_ispushsubscriptionmailbox(name, mbtype)   \
+     || mboxname_isjmapuploadmailbox(name, mbtype)         \
+     || mboxname_isjmapnotificationsmailbox(name, mbtype))
 
 /* check if one mboxname is a parent or same as the other */
 int mboxname_is_prefix(const char *longstr, const char *shortstr);


### PR DESCRIPTION
We were missing the header definitions for 'mboxname_isjmapnotificationmailbox' and the inclusion in isnonimapmailbox - but also imapd had the list hard-coded too!  Fix both of those.

Found by inspection on Fastmail dogfood server :)