### PR TITLE
search: do not extract text after the search_maxsize limit

### DIFF
--- a/changes/next/search_large_text
+++ b/changes/next/search_large_text
@@ -1,0 +1,18 @@
+Description:
+
+Improves search index and snippet generation latency by stopping early
+for overlong text.
+
+Config changes:
+
+Adds the `search_maxsize` option. The formerly hardcoded maximum size of
+4Mb is kept as the default value.
+
+Includes the new `X-Truncate-Size` HTTP header in requests to the attachment
+body extractor service. The value of this header is `search_maxsize` in bytes.
+
+Upgrade instructions:
+
+The former implementation applied the search_maxsize limit to the total of
+email bodies that contain text. This patch changes this to apply the limit
+to each body part separately. This may result in larger search indexes.

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -774,12 +774,14 @@ struct text_rock {
     struct buf out;
 };
 
-static void append_text(const struct buf *text, void *rock)
+static int append_text(const struct buf *text, void *rock)
 {
     struct text_rock *tr = (struct text_rock *)rock;
 
     tr->ncalls++;
     buf_append(&tr->out, text);
+
+    return 0;
 }
 
 #define TESTCASE(in, cs, enc, st, exp) \
@@ -798,7 +800,7 @@ static void append_text(const struct buf *text, void *rock)
         buf_init_ro(&bin, _in, sizeof(_in)-1); \
  \
         r = charset_extract(append_text, &tr, &bin, _cs, _enc, _st, flags); \
-        CU_ASSERT_EQUAL(r, 1); \
+        CU_ASSERT_EQUAL(r, 0); \
         CU_ASSERT_EQUAL(tr.ncalls, 1); \
         CU_ASSERT_STRING_EQUAL(buf_cstring(&tr.out), _exp); \
  \

--- a/imap/global.c
+++ b/imap/global.c
@@ -114,6 +114,7 @@ EXPORTED const char *config_conversations_db;
 EXPORTED const char *config_backup_db;
 EXPORTED int charset_flags;
 EXPORTED int charset_snippet_flags;
+EXPORTED size_t config_search_maxsize;
 
 static char session_id_buf[MAX_SESSIONID_SIZE];
 static int session_id_time = 0;
@@ -322,6 +323,8 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
         /* All search engines other than Xapian require escaped HTML */
         charset_snippet_flags |= CHARSET_ESCAPEHTML;
     }
+
+    config_search_maxsize = 1024 * config_getint(IMAPOPT_SEARCH_MAXSIZE);
 
     if (!cyrus_init_nodb) {
         /* lookup the database backends */

--- a/imap/global.h
+++ b/imap/global.h
@@ -180,6 +180,7 @@ extern const char *config_conversations_db;
 extern const char *config_backup_db;
 extern int charset_flags;
 extern int charset_snippet_flags;
+extern size_t config_search_maxsize;
 
 /* Session ID */
 extern void session_new_id(void);

--- a/imap/index.c
+++ b/imap/index.c
@@ -5122,10 +5122,10 @@ static void stuff_part(search_text_receiver_t *receiver,
     receiver->end_part(receiver, part);
 }
 
-static void extract_cb(const struct buf *text, void *rock)
+static int extract_cb(const struct buf *text, void *rock)
 {
     struct getsearchtext_rock *str = (struct getsearchtext_rock *)rock;
-    str->receiver->append_text(str->receiver, text);
+    return str->receiver->append_text(str->receiver, text);
 }
 
 #ifdef USE_HTTPD
@@ -5476,10 +5476,11 @@ static int extract_attachment(const char *type, const char *subtype,
                 "Connection: Keep-Alive\r\n"
                 "Keep-Alive: timeout=%u\r\n"
                 "Accept: text/plain\r\n"
+                "X-Truncate-Length: " SIZE_T_FMT "\r\n"
                 "\r\n",
                 ext->path, guidstr, HTTP_VERSION,
                 (int) hostlen, be->hostname, CYRUS_VERSION,
-                IDLE_TIMEOUT);
+                IDLE_TIMEOUT, config_search_maxsize);
     prot_flush(be->out);
 
     /* Read GET response */
@@ -5547,10 +5548,12 @@ static int extract_attachment(const char *type, const char *subtype,
                     "Accept: text/plain\r\n"
                     "Content-Type: %s/%s%s\r\n"
                     "Content-Length: " SIZE_T_FMT "\r\n"
+                    "X-Truncate-Length: " SIZE_T_FMT "\r\n"
                     "\r\n",
                     ext->path, guidstr, HTTP_VERSION,
                     (int) hostlen, be->hostname, CYRUS_VERSION, IDLE_TIMEOUT,
-                    type, subtype, buf_cstring(&buf), buf_len(data));
+                    type, subtype, buf_cstring(&buf), buf_len(data),
+                    config_search_maxsize);
         prot_putbuf(be->out, data);
         prot_flush(be->out);
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1211,7 +1211,7 @@ static char *_emailbodies_to_html(struct emailbodies *bodies, const struct buf *
     return buf_release(&buf);
 }
 
-static void _html_to_plain_cb(const struct buf *buf, void *rock)
+static int _html_to_plain_cb(const struct buf *buf, void *rock)
 {
     struct buf *dst = (struct buf*) rock;
     const char *p;
@@ -1229,6 +1229,8 @@ static void _html_to_plain_cb(const struct buf *buf, void *rock)
         }
         buf_appendmap(dst, p, 1);
     }
+
+    return 0;
 }
 
 static char *_html_to_plain(const char *html) {
@@ -5178,8 +5180,8 @@ static void _snippet_tr_begin_part(search_text_receiver_t *rx, int part)
     if (sr->next->begin_part) sr->next->begin_part(sr->next, part);
 }
 
-static void _snippet_tr_append_text(search_text_receiver_t *rx,
-                                    const struct buf *text)
+static int _snippet_tr_append_text(search_text_receiver_t *rx,
+                                   const struct buf *text)
 {
     struct snippet_receiver *sr = (struct snippet_receiver*) rx;
 
@@ -5189,7 +5191,9 @@ static void _snippet_tr_append_text(search_text_receiver_t *rx,
                     json_string(buf_cstring(text)));
         }
     }
-    if (sr->next->append_text) sr->next->append_text(sr->next, text);
+
+    return (sr->next->append_text) ?
+        sr->next->append_text(sr->next, text) : 0;
 }
 
 static void _snippet_tr_end_part(search_text_receiver_t *rx, int part)

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -416,18 +416,22 @@ static void _matchmime_tr_begin_part(search_text_receiver_t *rx __attribute__((u
 {
 }
 
-static void _matchmime_tr_append_text(search_text_receiver_t *rx,
+static int _matchmime_tr_append_text(search_text_receiver_t *rx,
                                       const struct buf *text)
 {
     struct matchmime_receiver *tr = (struct matchmime_receiver *) rx;
 
-    if (buf_len(&tr->buf) >= SEARCH_MAX_PARTS_SIZE) return;
+    if (buf_len(&tr->buf) >= config_search_maxsize) {
+        return IMAP_MESSAGE_TOO_LARGE;
+    }
 
-    size_t n = SEARCH_MAX_PARTS_SIZE - buf_len(&tr->buf);
+    size_t n = config_search_maxsize - buf_len(&tr->buf);
     if (n > buf_len(text)) {
         n = buf_len(text);
     }
     buf_appendmap(&tr->buf, buf_base(text), n);
+
+    return 0;
 }
 
 static void _matchmime_tr_end_part(search_text_receiver_t *rx, int part)

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -93,11 +93,6 @@ typedef struct search_snippet_markup {
 
 extern search_snippet_markup_t default_snippet_markup;
 
-/* Maximum size of a query, determined empirically, is a little bit
- * under 8MB.  That seems like more than enough, so let's limit the
- * total amount of parts text to 4 MB. */
-#define SEARCH_MAX_PARTS_SIZE      (4*1024*1024)
-
 /* The functions in search_text_receiver_t get called at least once for each part of every message.
    The invocations form a sequence:
        begin_message(message_t)
@@ -134,7 +129,8 @@ struct search_text_receiver {
                           const struct message_guid *content_guid,
                           const char *type, const char *subtype);
     void (*begin_part)(search_text_receiver_t *, int part);
-    void (*append_text)(search_text_receiver_t *, const struct buf *);
+    /* Returns IMAP_MESSAGE_TOO_LARGE if no more bytes are accepted */
+    int  (*append_text)(search_text_receiver_t *, const struct buf *);
     void (*end_part)(search_text_receiver_t *, int part);
     void (*end_bodypart)(search_text_receiver_t *);
 #define SEARCH_INDEXLEVEL_BASIC 1

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -644,7 +644,7 @@ static int do_append(SquatReceiverData *d, const struct buf *text)
     return 0;
 }
 
-static void append_text(search_text_receiver_t *rx,
+static int append_text(search_text_receiver_t *rx,
                         const struct buf *text)
 {
     SquatReceiverData *d = (SquatReceiverData *) rx;
@@ -655,7 +655,7 @@ static void append_text(search_text_receiver_t *rx,
         if (text->len + d->pending_text.len < SQUAT_WORD_SIZE) {
             /* not enough text yet */
             buf_append(&d->pending_text, text);
-            return;
+            return 0;
         }
 
         /* just went over the threshold */
@@ -669,7 +669,7 @@ static void append_text(search_text_receiver_t *rx,
                             "for mailbox %s: %s",
                             d->doc_name, d->mailbox->name,
                             squat_strerror(s));
-            return;
+            return IMAP_IOERROR;
         }
         d->doc_is_open = 1;
 
@@ -682,7 +682,7 @@ static void append_text(search_text_receiver_t *rx,
     if (!r)
         r = do_append(d, text);
 
-    /* TODO: propagate an error to the caller */
+    return r;
 }
 
 static void end_part(search_text_receiver_t *rx,

--- a/lib/charset.h
+++ b/lib/charset.h
@@ -142,11 +142,17 @@ extern char *charset_unfold(const char *s, size_t len, int flags);
 
 extern int charset_decode(struct buf *dst, const char *src, size_t len, int encoding);
 
-/* Extract the body text for the message denoted by 'uid', convert its
-   text to the canonical form for searching, and pass the converted text
-   down in a series of invocations of the callback 'cb'.  This is
-   called by index_getsearchtext to extract the MIME body parts. */
-extern int charset_extract(void (*cb)(const struct buf *text, void *rock),
+/* Extract the body text contained in 'data' and with character encoding
+ * 'charset' and body-part encoding 'encoding'. The 'subtype' argument
+ * defines the MIME subtype (assuming that the main type is 'text').
+ * Extraction is done by a series of invocations of the callback 'cb'.
+ * Extraction stops when either the body text is fully extracted, or
+ * 'cb' returns a non-zero value, which is then returned to the caller.
+ * If 'charset' is unknown, then the function returns early without
+ * error and never calls 'cb'.
+ * Note: This function is called by index_getsearchtext to extract
+ * the MIME body parts. */
+extern int charset_extract(int (*cb)(const struct buf *text, void *rock),
                            void *rock,
                            const struct buf *data,
                            charset_t charset, int encoding,

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2264,6 +2264,12 @@ If all partitions are over that limit, this feature is not used anymore.
 /* The maximum number of seconds to run a search for before aborting.  Default
    of no value means search "forever" until other timeouts. */
 
+{ "search_maxsize", 4096, INT, "3.5.0" }
+/* The maximum size in kilobytes to index for each message part. Message
+   contents that occur after this byte offset will not be indexed or
+   search snippets generated from.
+   Default is 4Mb. Xapian-only. */
+
 { "search_queryscan", 5000, INT, "3.1.7" }
 /* The minimum number of records require to do a direct scan of all G keys
  * rather than indexed lookups.  A value of 0 means always do indexed lookups.


### PR DESCRIPTION
This updates the indexing and search snippet code to stop extracting text when at most `search_maxsize` limit octets have been read. Any bytes after that limit already have been ignored during indexing and snippet generation, but the decoder ran through the complete message part, before throwing away the excess bytes.

Before, the limit was hardcoded to 4MB, now it is configurable in imapd.conf.

For discussion: this patch also changes the limit to apply not the the total bytes extracted from a message, but to each message part separately. This has the potential to increase the search index database, but prevents text being omitted depending on the order in which message parts are processed.

Tested in https://github.com/cyrusimap/cassandane/tree/search_large_text