### PR TITLE
dynarray: add dynamic array helper for same-sized members

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -657,7 +657,8 @@ cunit_TESTS += \
 	cunit/strconcat.testc \
 	cunit/times.testc \
 	cunit/tok.testc \
-	cunit/vparse.testc
+	cunit/vparse.testc \
+	cunit/dynarray.testc
 
 cunit_unit_SOURCES = $(cunit_FRAMEWORK) $(cunit_TESTS) \
 		imap/mutex_fake.c imap/spool.c
@@ -760,6 +761,7 @@ include_HEADERS = \
 	lib/cyr_lock.h \
 	lib/cyr_qsort_r.h \
 	lib/cyrusdb.h \
+	lib/dynarray.h \
 	lib/glob.h \
 	lib/gmtoff.h \
 	lib/hash.h \
@@ -1519,6 +1521,7 @@ lib_libcyrus_min_la_SOURCES = \
 	lib/assert.c \
 	lib/bufarray.c \
 	lib/byteorder.c \
+	lib/dynarray.c \
 	lib/hash.c \
 	lib/hashset.c \
 	lib/hashu64.c \

--- a/cunit/dynarray.testc
+++ b/cunit/dynarray.testc
@@ -1,0 +1,61 @@
+#include <stdint.h>
+#
+#include "cunit/cyrunit.h"
+#include "xmalloc.h"
+#include "dynarray.h"
+
+static void test_basic(void)
+{
+    struct dynarray *da = dynarray_new(sizeof(uint32_t));
+    uint32_t *valp;
+
+    CU_ASSERT_EQUAL(dynarray_size(da), 0);
+    CU_ASSERT_PTR_NULL(dynarray_nth(da, 0));
+    CU_ASSERT_PTR_NULL(dynarray_nth(da, -1));
+
+    uint32_t val1 = 0xbeefc0de;
+	dynarray_append(da, &val1);
+
+    CU_ASSERT_EQUAL(dynarray_size(da), 1);
+    valp = dynarray_nth(da, 0);
+    CU_ASSERT_EQUAL(*valp, val1);
+    valp = dynarray_nth(da, -1);
+    CU_ASSERT_EQUAL(*valp, val1);
+
+    uint32_t val2 = 0x00c0fefe;
+	dynarray_append(da, &val2);
+
+    CU_ASSERT_EQUAL(dynarray_size(da), 2);
+    valp = dynarray_nth(da, 1);
+    CU_ASSERT_EQUAL(*valp, val2);
+    valp = dynarray_nth(da, -1);
+    CU_ASSERT_EQUAL(*valp, val2);
+
+    dynarray_free(&da);
+    CU_ASSERT_PTR_NULL(da);
+}
+
+#define CU_ASSERT_MEMEQUAL(actual, expected, sz) \
+    CU_ASSERT_EQUAL(memcmp(actual, expected, sz), 0)
+
+static void test_truncate(void)
+{
+    struct dynarray *da = dynarray_new(sizeof(uint32_t));
+    uint32_t val;
+    for (val = 0; val < 64; val++) dynarray_append(da, &val);
+    CU_ASSERT_EQUAL(64, da->count);
+
+    val = 4;
+    CU_ASSERT_MEMEQUAL(da->data + sizeof(uint32_t)*4, &val, sizeof(uint32_t));
+
+    dynarray_truncate(da, 65);
+    CU_ASSERT_EQUAL(da->count, 65);
+    CU_ASSERT_MEMEQUAL(da->data + sizeof(uint32_t)*4, &val, sizeof(uint32_t));
+
+    dynarray_truncate(da, 3);
+    CU_ASSERT_EQUAL(da->count, 3);
+    val = 0;
+    CU_ASSERT_MEMEQUAL(da->data + sizeof(uint32_t)*4, &val, sizeof(uint32_t));
+}
+
+/* vim: set ft=c: */

--- a/lib/dynarray.c
+++ b/lib/dynarray.c
@@ -1,0 +1,184 @@
+/* dynarray.c -- an expanding array of same-size members
+ *
+ * Copyright (c) 1994-2020 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include <assert.h>
+#include <memory.h>
+
+#include "dynarray.h"
+#include "util.h"
+#include "xmalloc.h"
+
+EXPORTED void dynarray_init(struct dynarray *da, size_t membsize)
+{
+    assert(membsize);
+    memset(da, 0, sizeof(struct dynarray));
+    da->membsize = membsize;
+}
+
+EXPORTED void dynarray_fini(struct dynarray *da)
+{
+    free(da->data);
+    memset(da, 0, sizeof(struct dynarray));
+}
+
+EXPORTED struct dynarray *dynarray_new(size_t membsize)
+{
+    struct dynarray *da = xmalloc(sizeof(struct dynarray));
+    dynarray_init(da, membsize);
+    return da;
+}
+
+EXPORTED void dynarray_free(struct dynarray **dap)
+{
+    if (!dap || *dap == NULL) return;
+    free((*dap)->data);
+    free(*dap);
+    *dap = NULL;
+}
+
+/*
+ * Ensure the index @newalloc exists in the array, if necessary expanding the
+ * array, and if necessary NULL-filling all the intervening elements.
+ * Note that we always ensure an empty slot past the last reported
+ * index, so that we can pass data[] to execve() or other routines that
+ * assume a NULL terminator.
+ */
+#define QUANTUM     16
+static void ensure_alloc(struct dynarray *da, int newalloc)
+{
+    assert(newalloc >= 0);
+    if (newalloc)
+        newalloc++;
+    if (newalloc <= da->alloc)
+        return;
+    newalloc = ((newalloc + QUANTUM-1) / QUANTUM) * QUANTUM;
+    da->data = xrealloc(da->data, da->membsize * newalloc);
+    memset(da->data + da->alloc * da->membsize, 0, da->membsize * (newalloc-da->alloc));
+    da->alloc = newalloc;
+}
+
+
+static inline int adjust_index_ro(const struct dynarray *da, int idx)
+{
+    if (idx >= da->count)
+        return -1;
+    else if (idx < 0)
+        idx += da->count;
+    return idx;
+}
+
+static inline int adjust_index_rw(struct dynarray *da, int idx, int len)
+{
+    if (idx >= da->count) {
+        ensure_alloc(da, idx+len);
+    } else if (idx < 0) {
+        idx += da->count;
+        if (idx >= 0 && len)
+            ensure_alloc(da, da->count+len);
+    } else if (len) {
+        ensure_alloc(da, da->count+len);
+    }
+    return idx;
+}
+
+EXPORTED int dynarray_size(struct dynarray *da)
+{
+    return da->count;
+}
+
+__attribute__((unused))
+static char *dump(struct dynarray *da)
+{
+    struct buf buf = BUF_INITIALIZER;
+    buf_printf(&buf, "{membsize=%zu count=%d alloc=%d data=%p: ", da->membsize, da->count, da->alloc, da->data);
+    int i;
+    for (i = 0; i < da->alloc; i++) {
+        void *memb = da->data + i * da->membsize;
+        buf_putc(&buf, '[');
+        size_t j;
+        for (j = 0; j < da->membsize; j++) {
+            buf_printf(&buf, "%02x", *((unsigned char*) memb + j) & 0xff);
+            if (j < da->membsize - 1) buf_putc(&buf, ' ');
+        }
+        buf_putc(&buf, ']');
+    }
+    buf_cstring(&buf);
+    return buf_release(&buf);
+}
+
+EXPORTED void dynarray_append(struct dynarray *da, void *memb)
+{
+    ensure_alloc(da, da->count+1);
+    memcpy(da->data + da->count * da->membsize, memb, da->membsize);
+    da->count++;
+}
+
+EXPORTED void dynarray_set(struct dynarray *da, int idx, void *memb)
+{
+    if ((idx = adjust_index_rw(da, idx, 0)) < 0)
+        return;
+    memcpy(da->data + idx * da->membsize, memb, da->membsize);
+}
+
+EXPORTED void *dynarray_nth(const struct dynarray *da, int idx)
+{
+    if ((idx = adjust_index_ro(da, idx)) < 0)
+        return NULL;
+    return da->data + idx * da->membsize;
+}
+
+EXPORTED void dynarray_truncate(struct dynarray *da, int newlen)
+{
+    if (newlen == da->count)
+        return;
+
+    if (newlen > da->count) {
+        ensure_alloc(da, newlen);
+    } else {
+        int i;
+        for (i = newlen ; i < da->count ; i++) {
+            memset(da->data + i * da->membsize, 0, da->membsize);
+        }
+    }
+    da->count = newlen;
+}

--- a/lib/dynarray.h
+++ b/lib/dynarray.h
@@ -1,0 +1,67 @@
+/* dynarray.h -- an expanding array of same-size members
+ *
+ * Copyright (c) 1994-2020 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#ifndef __CYRUS_DYNARRAY_H__
+#define __CYRUS_DYNARRAY_H__
+
+typedef struct dynarray {
+    size_t membsize;
+    int count;
+    int alloc;
+    void *data;
+} dynarray_t;
+
+extern void dynarray_init(struct dynarray *da, size_t membsize);
+extern void dynarray_fini(struct dynarray *da);
+
+extern struct dynarray *dynarray_new(size_t membsize);
+extern void dynarray_free(struct dynarray **dap);
+
+extern void dynarray_append(struct dynarray *da, void *memb);
+extern void dynarray_set(struct dynarray *, int idx, void *memb);
+extern void *dynarray_nth(const struct dynarray *da, int idx);
+extern int dynarray_size(struct dynarray *da);
+extern void dynarray_truncate(struct dynarray *da, int newlen);
+
+
+#endif /* __CYRUS_DYNARRAY_H__ */


### PR DESCRIPTION
dynarray is a more cache-friendly variant of good old ptrarray. In almost all cases, we currently use ptrarray with same-sized members. Each member is alloced and freed separately, resulting in both CPU overhead and memory fragmentation. dynarray addresses both of the deficiencies by keeping its members in a contiguous memory buffer.

dynarray got introduced in the jmap-calendars-01 branch but I find it more and more useful to also include in other feature branches already.