### PR TITLE
calcarddav_parse_path: clearer error message on % encoded URLs in MKCOL

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -783,7 +783,10 @@ HIDDEN int calcarddav_parse_path(const char *path,
         ret = mboxlist_createmailboxcheck(mboxname, 0, NULL, httpd_userisadmin,
                                           httpd_userid, httpd_authstate,
                                           NULL, NULL, 0 /* force */);
-        if (ret) goto done;
+        if (ret) {
+            *resultstr = "Invalid name.  Percent encodeded URLs are in theory valid, but in practice not supported.";
+            goto done;
+	}
 
         tgt->allow |= ALLOW_MKCOL;
     }


### PR DESCRIPTION
Evolution calls MKCOL with the user-provided Calendar-Name as WebDAV-Collection name, percent encoded when needed.  The percent encoded collections are rejected by Cyrus IMAP.  This change improves the error message returned to the CUA.

As far as I checked the code, `mboxname_policycheck()` validates, whether the mailbox name is valid.  It applies the same rules for IMAP and WebDAV mailboxes. `Modified UTF-7` as WebDAV collection name would be accepted, but percent encoded URL are rejected.  