### PR TITLE
send BYE from sync_server on clean shutdown

### DIFF
--- a/changes/next/sync-server-bye
+++ b/changes/next/sync-server-bye
@@ -1,0 +1,12 @@
+Description:
+
+sync_client can now recognise when the sync_server has been shut down cleanly
+instead of logging a bunch of errors
+
+Config changes:
+
+(none)
+
+Upgrade instructions:
+
+(none)


### PR DESCRIPTION
* When sync_server is shut down cleanly by a signal from master, it now writes "BYE shutting down" to the client socket, if it's connected, before shutting down normally.
* When sync_client sees "BYE shutting down" from sync_server, it knows to expect to be disconnected, and exits cleanly itself (instead of logging a lot of useless IOERRORS).

There are tests here (including infrastructure fixes to make this testable at all): https://github.com/cyrusimap/cassandane/compare/master...elliefm:v35/3401-sync-server-bye

This is upgrade safe:  when the master Cyrus is older than the replica, and doesn't recognise BYE, it IOERRORs about a bad command and bails out (without the BYE, it would have IOERRORed about the zero length command, and bailed out).  When the replica Cyrus is older, and doesn't send BYE, the master will IOERROR about the zero-length command and bail out like it always did.

This doesn't change anything about replication-over-imap, and maybe it should, but I haven't looked at it (yet).

Fixes #3401 