### PR TITLE
PROPFIND <c:schedule-calendar-transp>

### DIFF
--- a/changes/next/propfind_caltransp
+++ b/changes/next/propfind_caltransp
@@ -1,0 +1,11 @@
+Description:
+
+Return on PROPFIND <C:schedule-calendar-transp> XML element instead of text
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+None


### PR DESCRIPTION
The value of the schedule-calendar-transp property is not a string with possible text values “transparent” or “opaque”, but an XML element in the CalDAV namespace: https://tools.ietf.org/html/rfc6638#section-9.1.

- on PROPPATCH of the transarent property validate the namespace of the value