### PR TITLE
quota.c: mention -J and -n in usage message

### DIFF
--- a/imap/quota.c
+++ b/imap/quota.c
@@ -227,7 +227,7 @@ int main(int argc,char **argv)
 static void usage(void)
 {
     fprintf(stderr,
-            "usage: quota [-C <alt_config>] [-d <domain>] [-f] [-q] [-u] [mailbox-spec]...\n");
+            "usage: quota [-C <alt_config>] [-d <domain>] [-f] [-q] [-J] [-n] [-u] [mailbox-spec]...\n");
     exit(EX_USAGE);
 }
 


### PR DESCRIPTION
I typed -j instead of -J and then saw that neither was in the error message!