### PR TITLE
Append guid archive

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -883,10 +883,11 @@ static int findstage_cb(const conv_guidrec_t *rec, void *vrock)
     if (r) return 0;
 
     if (!strcmp(rock->partition, mbentry->partition)) {
+        struct stat sbuf;
         const char *msgpath = mboxname_datapath(mbentry->partition,
                                                 mbentry->name,
                                                 mbentry->uniqueid, rec->uid);
-        if (msgpath) {
+        if (msgpath && !stat(msgpath, &sbuf)) {
             /* link the first stage part to the existing message file */
             r = cyrus_copyfile(msgpath, rock->stagefile, 0/*flags*/);
             if (r) {

--- a/imap/append.c
+++ b/imap/append.c
@@ -876,6 +876,8 @@ static int findstage_cb(const conv_guidrec_t *rec, void *vrock)
     mbentry_t *mbentry = NULL;
 
     if (rec->part) return 0;
+    // no point copying from archive, spool is on data
+    if (rec->internal_flags & FLAG_INTERNAL_ARCHIVED) return 0;
 
     int r = mboxlist_lookup(rec->mboxname, &mbentry, NULL);
     if (r) return 0;


### PR DESCRIPTION
This looks like the minimal fixes :)  There's no point trying to link the copy on archive, because the spool is always on data for now.  A better fix would be to discover the copy on data, and spool there so there's no data copying, but that's for another day.