### PR TITLE
Make docsrc/exts/sphinxlocal/builders/manpage.py compilable.

### DIFF
--- a/docsrc/exts/sphinxlocal/builders/manpage.py
+++ b/docsrc/exts/sphinxlocal/builders/manpage.py
@@ -21,7 +21,6 @@ from docutils.frontend import OptionParser
 from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.builders import Builder
-from sphinx.environment import NoUri
 from sphinx.util.nodes import inline_all_toctrees
 from sphinx.util.console import bold, darkgreen
 from sphinx.writers.manpage import ManualPageWriter


### PR DESCRIPTION
The file docsrc/exts/sphinxlocal/builders/manpage.py extends the file sphinx/builders/manpage.py from the Sphinx 1.4 source.  The origin contains

from sphinx.environment import NoUri

and its code does raise the NoUri exception.  Later versions of Sphinx do not contain this line in sphinx/builders/manpage.py .

Per https://www.sphinx-doc.org/en/master/extdev/deprecated.html sphinx.environment.NoUri is deprecated and shall be replaced
by sphinx.errors.NoUri.  Sphinx 1.4 does not have sphinx.errors.NoUri.

While inteded for removal in 4.0, sphinx.environment.NoUri was in fact removed in a previous version: https://github.com/sphinx-doc/sphinx/issues/9032

That said:
- docsrc/exts/sphinxlocal/builders/manpage.py does not use sphinx.environment.NoUri, but contains it because of copy-paste oparations from the super class.

- Sphinx 3.x does not contain sphinx.environment.NoUri neither.