### PR TITLE
Remove terminating \n in syslog() calls

### DIFF
--- a/backup/backupd.c
+++ b/backup/backupd.c
@@ -913,7 +913,7 @@ static int cmd_apply_message(struct dlist *dl)
 
             message_guid_generate(&computed_guid, msg_base, msg_len);
             if (!message_guid_equal(guid, &computed_guid)) {
-                syslog(LOG_ERR, "%s: guid mismatch: header %s, derived %s\n",
+                syslog(LOG_ERR, "%s: guid mismatch: header %s, derived %s",
                     __func__, message_guid_encode(guid),
                     message_guid_encode(&computed_guid));
                 r = IMAP_PROTOCOL_ERROR;

--- a/backup/lcb.c
+++ b/backup/lcb.c
@@ -610,7 +610,7 @@ EXPORTED int backup_reindex(const char *name,
                 const char *error = prot_error(member);
                 if (error && 0 != strcmp(error, PROT_EOF_STRING)) {
                     syslog(LOG_ERR,
-                           "IOERROR: %s: error reading chunk at offset " OFF_T_FMT ", byte %i: %s\n",
+                           "IOERROR: %s: error reading chunk at offset " OFF_T_FMT ", byte %i: %s",
                            name, member_offset, prot_bytes_in(member), error);
 
                     if (out)
@@ -647,7 +647,7 @@ EXPORTED int backup_reindex(const char *name,
             r = backup_append(backup, dl, &ts, BACKUP_APPEND_NOFLUSH);
             if (r) {
                 // FIXME do something
-                syslog(LOG_ERR, "backup_append returned %d\n", r);
+                syslog(LOG_ERR, "backup_append returned %d", r);
                 fprintf(out, "backup_append returned %d\n", r);
             }
 

--- a/backup/lcb_append.c
+++ b/backup/lcb_append.c
@@ -147,7 +147,7 @@ HIDDEN int backup_real_append_start(struct backup *backup,
 
     r = sqldb_exec(backup->db, backup_index_start_sql, bval, NULL, NULL);
     if (r) {
-        syslog(LOG_ERR, "%s: something went wrong: %i\n", __func__, r);
+        syslog(LOG_ERR, "%s: something went wrong: %i", __func__, r);
         sqldb_rollback(backup->db, "backup_append");
         goto error;
     }
@@ -257,7 +257,7 @@ HIDDEN int backup_real_append_end(struct backup *backup, time_t ts)
     if (!(backup->append_state->mode & BACKUP_APPEND_INDEXONLY)) {
         r = gzflush(backup->append_state->gzfile, Z_FINISH);
         if (r != Z_OK) {
-            syslog(LOG_ERR, "IOERROR: gzflush %s failed: %i\n",
+            syslog(LOG_ERR, "IOERROR: gzflush %s failed: %i",
                             backup->data_fname, r);
             sqldb_rollback(backup->db, "backup_append");
             goto done;
@@ -280,7 +280,7 @@ HIDDEN int backup_real_append_end(struct backup *backup, time_t ts)
 
     r = sqldb_exec(backup->db, backup_index_end_sql, bval, NULL, NULL);
     if (r) {
-        syslog(LOG_ERR, "%s: something went wrong: %i\n", __func__, r);
+        syslog(LOG_ERR, "%s: something went wrong: %i", __func__, r);
         sqldb_rollback(backup->db, "backup_append");
     }
     else {

--- a/backup/lcb_compact.c
+++ b/backup/lcb_compact.c
@@ -521,7 +521,7 @@ EXPORTED int backup_compact(const char *name,
                 const char *error = prot_error(in);
                 if (error && 0 != strcmp(error, PROT_EOF_STRING)) {
                     syslog(LOG_ERR,
-                           "IOERROR: %s: error reading chunk at offset " OFF_T_FMT ", byte %i: %s\n",
+                           "IOERROR: %s: error reading chunk at offset " OFF_T_FMT ", byte %i: %s",
                            name, chunk->offset, prot_bytes_in(in), error);
 
                     if (out)

--- a/backup/lcb_indexr.c
+++ b/backup/lcb_indexr.c
@@ -94,7 +94,7 @@ EXPORTED int backup_get_mailbox_id(struct backup *backup, const char *uniqueid)
     int r = sqldb_exec(backup->db, backup_index_mailbox_select_uniqueid_sql,
                        bval, _get_mailbox_id_cb, &id);
     if (r) {
-        syslog(LOG_ERR, "%s: something went wrong: %i %s\n",
+        syslog(LOG_ERR, "%s: something went wrong: %i %s",
                         __func__, r, uniqueid);
     }
 
@@ -784,7 +784,7 @@ EXPORTED int backup_get_message_id(struct backup *backup, const char *guid)
     int r = sqldb_exec(backup->db, backup_index_message_select_guid_sql, bval,
                        _get_message_id_cb, &id);
     if (r) {
-        syslog(LOG_ERR, "%s: something went wrong: %i %s\n",
+        syslog(LOG_ERR, "%s: something went wrong: %i %s",
                         __func__, r, guid);
         return -1;
     }
@@ -857,7 +857,7 @@ EXPORTED struct backup_message *backup_get_message(struct backup *backup,
     int r = sqldb_exec(backup->db, backup_index_message_select_guid_sql, bval,
                        _message_row_cb, &mrock);
     if (r) {
-        syslog(LOG_ERR, "%s: something went wrong: %i %s\n",
+        syslog(LOG_ERR, "%s: something went wrong: %i %s",
                         __func__, r, message_guid_encode(guid));
         if (bm) backup_message_free(&bm);
         return NULL;

--- a/backup/lcb_indexw.c
+++ b/backup/lcb_indexw.c
@@ -101,7 +101,7 @@ HIDDEN int backup_index(struct backup *backup, struct dlist *dlist,
     else if (config_debug) {
         struct buf tmp = BUF_INITIALIZER;
         dlist_printbuf(dlist, 1, &tmp);
-        syslog(LOG_DEBUG, "ignoring unrecognised dlist: %s\n", buf_cstring(&tmp));
+        syslog(LOG_DEBUG, "ignoring unrecognised dlist: %s", buf_cstring(&tmp));
         buf_free(&tmp);
     }
 
@@ -111,7 +111,7 @@ HIDDEN int backup_index(struct backup *backup, struct dlist *dlist,
 static int _index_expunge(struct backup *backup, struct dlist *dl,
                           time_t ts, off_t dl_offset)
 {
-    syslog(LOG_DEBUG, "indexing EXPUNGE at " OFF_T_FMT "...\n", dl_offset);
+    syslog(LOG_DEBUG, "indexing EXPUNGE at " OFF_T_FMT "...", dl_offset);
 
     const char *mboxname;
     const char *uniqueid;
@@ -184,7 +184,7 @@ static int _get_magic_flags(struct dlist *flags, int *is_expunged)
 static int _index_mailbox(struct backup *backup, struct dlist *dl,
                           time_t ts, off_t dl_offset)
 {
-    syslog(LOG_DEBUG, "indexing MAILBOX at " OFF_T_FMT "...\n", dl_offset);
+    syslog(LOG_DEBUG, "indexing MAILBOX at " OFF_T_FMT "...", dl_offset);
 
     const char *uniqueid = NULL;
     const char *mboxname = NULL;
@@ -285,12 +285,12 @@ static int _index_mailbox(struct backup *backup, struct dlist *dl,
         r = sqldb_exec(backup->db, backup_index_mailbox_insert_sql,
                        mbox_bval, NULL, NULL);
         if (r) {
-            syslog(LOG_DEBUG, "%s: something went wrong: %i insert %s\n",
+            syslog(LOG_DEBUG, "%s: something went wrong: %i insert %s",
                               __func__, r, mboxname);
         }
     }
     else if (r) {
-        syslog(LOG_DEBUG, "%s: something went wrong: %i update %s\n",
+        syslog(LOG_DEBUG, "%s: something went wrong: %i update %s",
                           __func__, r, mboxname);
     }
 
@@ -329,7 +329,7 @@ static int _index_mailbox(struct backup *backup, struct dlist *dl,
             /* XXX should this search for guid+size rather than just guid? */
             message_id = backup_get_message_id(backup, guid);
             if (message_id == -1) {
-                syslog(LOG_DEBUG, "%s: something went wrong: %i %s %s\n",
+                syslog(LOG_DEBUG, "%s: something went wrong: %i %s %s",
                                   __func__, r, mboxname, guid);
                 goto error;
             }
@@ -337,7 +337,7 @@ static int _index_mailbox(struct backup *backup, struct dlist *dl,
                 /* can't link this record, we don't have a message */
                 /* possibly we're in compact, and have deleted it? */
                 /* XXX this should probably be an error too, but can't be until compact is smarter */
-                syslog(LOG_DEBUG, "%s: skipping %s record for %s: message not found\n",
+                syslog(LOG_DEBUG, "%s: skipping %s record for %s: message not found",
                                   __func__, mboxname, guid);
                 continue;
             }
@@ -349,13 +349,13 @@ static int _index_mailbox(struct backup *backup, struct dlist *dl,
                 _get_magic_flags(flags, &is_expunged);
 
                 if (is_expunged) {
-                    syslog(LOG_DEBUG, "%s: found expunge flag for message %s\n",
+                    syslog(LOG_DEBUG, "%s: found expunge flag for message %s",
                                       __func__, guid);
                     expunged = ts;
                 }
 
                 dlist_printbuf(flags, 0, &flags_buf);
-                syslog(LOG_DEBUG, "%s: found flags for message %s: %s\n",
+                syslog(LOG_DEBUG, "%s: found flags for message %s: %s",
                                   __func__, guid, buf_cstring(&flags_buf));
             }
 
@@ -393,12 +393,12 @@ static int _index_mailbox(struct backup *backup, struct dlist *dl,
                 r = sqldb_exec(backup->db, backup_index_mailbox_message_insert_sql,
                                record_bval, NULL, NULL);
                 if (r) {
-                    syslog(LOG_DEBUG, "%s: something went wrong: %i insert %s %s\n",
+                    syslog(LOG_DEBUG, "%s: something went wrong: %i insert %s %s",
                                       __func__, r, mboxname, guid);
                 }
             }
             else if (r) {
-                syslog(LOG_DEBUG, "%s: something went wrong: %i update %s %s\n",
+                syslog(LOG_DEBUG, "%s: something went wrong: %i update %s %s",
                                   __func__, r, mboxname, guid);
             }
 
@@ -409,12 +409,12 @@ static int _index_mailbox(struct backup *backup, struct dlist *dl,
         }
     }
 
-    syslog(LOG_DEBUG, "%s: committing index change: %s\n", __func__, mboxname);
+    syslog(LOG_DEBUG, "%s: committing index change: %s", __func__, mboxname);
     sqldb_commit(backup->db, __func__);
     return 0;
 
 error:
-    syslog(LOG_DEBUG, "%s: rolling back index change: %s\n", __func__, mboxname);
+    syslog(LOG_DEBUG, "%s: rolling back index change: %s", __func__, mboxname);
     sqldb_rollback(backup->db, __func__);
 
     return IMAP_INTERNAL;
@@ -423,7 +423,7 @@ error:
 static int _index_unmailbox(struct backup *backup, struct dlist *dl,
                             time_t ts, off_t dl_offset)
 {
-    syslog(LOG_DEBUG, "indexing UNMAILBOX at " OFF_T_FMT "...\n", dl_offset);
+    syslog(LOG_DEBUG, "indexing UNMAILBOX at " OFF_T_FMT "...", dl_offset);
 
     const char *mboxname = dl->sval;
 
@@ -436,7 +436,7 @@ static int _index_unmailbox(struct backup *backup, struct dlist *dl,
     int r = sqldb_exec(backup->db, backup_index_mailbox_delete_sql, bval, NULL,
                         NULL);
     if (r) {
-        syslog(LOG_DEBUG, "%s: something went wrong: %i %s\n",
+        syslog(LOG_DEBUG, "%s: something went wrong: %i %s",
                           __func__, r, mboxname);
     }
 
@@ -446,7 +446,7 @@ static int _index_unmailbox(struct backup *backup, struct dlist *dl,
 static int _index_message(struct backup *backup, struct dlist *dl,
                           time_t ts, off_t dl_offset, size_t dl_len)
 {
-    syslog(LOG_DEBUG, "indexing MESSAGE at " OFF_T_FMT " (" SIZE_T_FMT " bytes)...\n", dl_offset, dl_len);
+    syslog(LOG_DEBUG, "indexing MESSAGE at " OFF_T_FMT " (" SIZE_T_FMT " bytes)...", dl_offset, dl_len);
     (void) ts;
 
     struct dlist *di;
@@ -477,12 +477,12 @@ static int _index_message(struct backup *backup, struct dlist *dl,
             r = sqldb_exec(backup->db, backup_index_message_insert_sql, bval,
                            NULL, NULL);
             if (r) {
-                syslog(LOG_DEBUG, "%s: something went wrong: %i insert message %s\n",
+                syslog(LOG_DEBUG, "%s: something went wrong: %i insert message %s",
                        __func__, r, message_guid_encode(guid));
             }
         }
         else if (r) {
-            syslog(LOG_DEBUG, "%s: something went wrong: %i update message %s\n",
+            syslog(LOG_DEBUG, "%s: something went wrong: %i update message %s",
                    __func__, r, message_guid_encode(guid));
         }
     }
@@ -493,7 +493,7 @@ static int _index_message(struct backup *backup, struct dlist *dl,
 static int _index_rename(struct backup *backup, struct dlist *dl,
                          time_t ts, off_t dl_offset)
 {
-    syslog(LOG_DEBUG, "indexing RENAME at " OFF_T_FMT "\n", dl_offset);
+    syslog(LOG_DEBUG, "indexing RENAME at " OFF_T_FMT, dl_offset);
     (void) ts;
 
     const char *uniqueid = NULL;
@@ -529,7 +529,7 @@ static int _index_rename(struct backup *backup, struct dlist *dl,
                        mbox_bval, NULL, NULL);
 
     if (r) {
-        syslog(LOG_DEBUG, "%s: something went wrong: %i rename %s => %s\n",
+        syslog(LOG_DEBUG, "%s: something went wrong: %i rename %s => %s",
                __func__, r, oldmboxname, newmboxname);
     }
 
@@ -539,7 +539,7 @@ static int _index_rename(struct backup *backup, struct dlist *dl,
 static int _index_seen(struct backup *backup, struct dlist *dl,
                        time_t ts, off_t dl_offset)
 {
-    syslog(LOG_DEBUG, "indexing %s at " OFF_T_FMT "\n", dl->name, dl_offset);
+    syslog(LOG_DEBUG, "indexing %s at " OFF_T_FMT, dl->name, dl_offset);
     (void) ts;
 
     const char *uniqueid;
@@ -577,7 +577,7 @@ static int _index_seen(struct backup *backup, struct dlist *dl,
         r = sqldb_exec(backup->db, backup_index_seen_insert_sql, bval,
                        NULL, NULL);
         if (r) {
-            syslog(LOG_DEBUG, "%s: something went wrong: %i insert seen %s\n",
+            syslog(LOG_DEBUG, "%s: something went wrong: %i insert seen %s",
                    __func__, r, uniqueid);
         }
     }
@@ -592,7 +592,7 @@ static int _index_seen(struct backup *backup, struct dlist *dl,
 static int _index_sub(struct backup *backup, struct dlist *dl,
                       time_t ts, off_t dl_offset)
 {
-    syslog(LOG_DEBUG, "indexing %s at " OFF_T_FMT "\n", dl->name, dl_offset);
+    syslog(LOG_DEBUG, "indexing %s at " OFF_T_FMT, dl->name, dl_offset);
 
     const char *mboxname = NULL;
     int r;
@@ -623,7 +623,7 @@ static int _index_sub(struct backup *backup, struct dlist *dl,
         r = sqldb_exec(backup->db, backup_index_subscription_insert_sql, bval,
                        NULL, NULL);
         if (r) {
-            syslog(LOG_DEBUG, "%s: something went wrong: %i insert subscription %s\n",
+            syslog(LOG_DEBUG, "%s: something went wrong: %i insert subscription %s",
                    __func__, r, mboxname);
         }
     }
@@ -638,7 +638,7 @@ static int _index_sub(struct backup *backup, struct dlist *dl,
 static int _index_sieve(struct backup *backup, struct dlist *dl,
                         time_t ts, off_t dl_offset)
 {
-    syslog(LOG_DEBUG, "indexing %s at " OFF_T_FMT "\n", dl->name, dl_offset);
+    syslog(LOG_DEBUG, "indexing %s at " OFF_T_FMT, dl->name, dl_offset);
 
     const char *filename;
     int r;

--- a/backup/lcb_verify.c
+++ b/backup/lcb_verify.c
@@ -128,7 +128,7 @@ static int verify_chunk_checksums(struct backup *backup, struct backup_chunk *ch
     sha1_file(backup->fd, backup->data_fname, chunk->offset, file_sha1);
     r = strncmp(chunk->file_sha1, file_sha1, sizeof(file_sha1));
     if (r) {
-        syslog(LOG_DEBUG, "%s: %s (chunk %d) file checksum mismatch: %s on disk, %s in index\n",
+        syslog(LOG_DEBUG, "%s: %s (chunk %d) file checksum mismatch: %s on disk, %s in index",
                 __func__, backup->data_fname, chunk->id, file_sha1, chunk->file_sha1);
         if (out)
             fprintf(out, "file checksum mismatch for chunk %d: %s on disk, %s in index\n",
@@ -157,7 +157,7 @@ static int verify_chunk_checksums(struct backup *backup, struct backup_chunk *ch
     if (len != chunk->length) {
         syslog(LOG_DEBUG, "%s: %s (chunk %d) data length mismatch: "
                         SIZE_T_FMT " on disk,"
-                        SIZE_T_FMT " in index\n",
+                        SIZE_T_FMT " in index",
                 __func__, backup->data_fname, chunk->id, len, chunk->length);
         if (out)
             fprintf(out, "data length mismatch for chunk %d: "
@@ -177,7 +177,7 @@ static int verify_chunk_checksums(struct backup *backup, struct backup_chunk *ch
     assert(r == 2 * SHA1_DIGEST_LENGTH);
     r = strncmp(chunk->data_sha1, data_sha1, sizeof(data_sha1));
     if (r) {
-        syslog(LOG_DEBUG, "%s: %s (chunk %d) data checksum mismatch: %s on disk, %s in index\n",
+        syslog(LOG_DEBUG, "%s: %s (chunk %d) data checksum mismatch: %s on disk, %s in index",
                 __func__, backup->data_fname, chunk->id, data_sha1, chunk->data_sha1);
         if (out)
             fprintf(out, "data checksum mismatch for chunk %d: %s on disk, %s in index\n",
@@ -186,7 +186,7 @@ static int verify_chunk_checksums(struct backup *backup, struct backup_chunk *ch
     }
 
 done:
-    syslog(LOG_DEBUG, "%s: checksum %s!\n", __func__, r ? "failed" : "passed");
+    syslog(LOG_DEBUG, "%s: checksum %s!", __func__, r ? "failed" : "passed");
     if (out && verbose)
         fprintf(out, "%s\n", r ? "error" : "ok");
     return r;
@@ -330,7 +330,7 @@ static int verify_chunk_messages(struct backup *backup, struct backup_chunk *chu
         dlist_free(&vmrock.cached_dlist);
     }
 
-    syslog(LOG_DEBUG, "%s: chunk %d %s!\n", __func__, chunk->id,
+    syslog(LOG_DEBUG, "%s: chunk %d %s!", __func__, chunk->id,
             r ? "failed" : "passed");
     if (out && verbose)
         fprintf(out, "%s\n", r ? "error" : "ok");
@@ -407,7 +407,7 @@ static int mailbox_matches(const struct backup_mailbox *mailbox,
     if (synccrcs.annot != mailbox->sync_crc_annot)
         return 0;
 
-    syslog(LOG_DEBUG, "%s: %s matches!\n", __func__, mailbox->uniqueid);
+    syslog(LOG_DEBUG, "%s: %s matches!", __func__, mailbox->uniqueid);
     return 1;
 }
 
@@ -440,7 +440,7 @@ static int mailbox_message_matches(const struct backup_mailbox_message *mailbox_
         || !message_guid_equal(guid, &mailbox_message->guid))
         return 0;
 
-    syslog(LOG_DEBUG, "%s: %s:%u matches!\n", __func__,
+    syslog(LOG_DEBUG, "%s: %s:%u matches!", __func__,
             mailbox_message->mailbox_uniqueid, mailbox_message->uid);
     return 1;
 }
@@ -611,7 +611,7 @@ next_line:
     /* anything left in either of the lists is missing from the chunk data. bad! */
     mailbox = mailbox_list->head;
     while (mailbox) {
-        syslog(LOG_DEBUG, "%s: chunk %d missing mailbox data for %s (%s)\n",
+        syslog(LOG_DEBUG, "%s: chunk %d missing mailbox data for %s (%s)",
                 __func__, chunk->id, mailbox->uniqueid, mailbox->mboxname);
         if (out)
             fprintf(out, "chunk %d missing mailbox data for %s (%s)\n",
@@ -621,7 +621,7 @@ next_line:
 
     mailbox_message = mailbox_message_list->head;
     while (mailbox_message) {
-        syslog(LOG_DEBUG, "%s: chunk %d missing mailbox_message data for %s uid %u\n",
+        syslog(LOG_DEBUG, "%s: chunk %d missing mailbox_message data for %s uid %u",
                 __func__, chunk->id, mailbox_message->mailbox_uniqueid,
                 mailbox_message->uid);
         if (out)
@@ -643,7 +643,7 @@ done:
     backup_mailbox_message_list_empty(mailbox_message_list);
     free(mailbox_message_list);
 
-    syslog(LOG_DEBUG, "%s: chunk %d %s!\n", __func__, chunk->id,
+    syslog(LOG_DEBUG, "%s: chunk %d %s!", __func__, chunk->id,
             r ? "failed" : "passed");
     if (out && verbose)
         fprintf(out, "%s\n", r ? "error" : "ok");

--- a/contrib/sieve-spamassassin
+++ b/contrib/sieve-spamassassin
@@ -241,7 +241,7 @@ diff -cr cyrus-imapd-2.1.3-orig/imap/lmtpd.c cyrus-imapd-2.1.3/imap/lmtpd.c
 +     free (msg_buf);
 +     close (s);
 +
-+     syslog(LOG_DEBUG, "spam result: %d\n", ret);
++     syslog(LOG_DEBUG, "spam result: %d", ret);
 +     return ret;
 + }
 +
@@ -257,13 +257,13 @@ diff -cr cyrus-imapd-2.1.3-orig/imap/lmtpd.c cyrus-imapd-2.1.3/imap/lmtpd.c
 
 +     res = sieve_register_spam(sieve_interp, &spam);
 +     if (res != SIEVE_OK) {
-+       syslog(LOG_ERR, "sieve_register_spam() returns %d\n", res);
++       syslog(LOG_ERR, "sieve_register_spam() returns %d", res);
 +       fatal("sieve_register_spam()", EX_SOFTWARE);
 +     }
 +
       res = sieve_register_parse_error(sieve_interp, &sieve_parse_error_handler);
       if (res != SIEVE_OK) {
-        syslog(LOG_ERR, "sieve_register_parse_error() returns %d\n", res);
+        syslog(LOG_ERR, "sieve_register_parse_error() returns %d", res);
 ***************
 *** 1148,1154 ****
       mydata.notifyheader = generate_notify(msgdata);
@@ -452,11 +452,11 @@ diff -cr cyrus-imapd-2.1.3-orig/timsieved/scripttest.c cyrus-imapd-2.1.3/timsiev
 
 +     res = sieve_register_spam(i, (sieve_spam *) &foo);
 +     if (res != SIEVE_OK) {
-+       syslog (LOG_ERR, "sieve_register_spam() returns %d\n", res);
++       syslog (LOG_ERR, "sieve_register_spam() returns %d", res);
 +       return TIMSIEVE_FAIL;
 +     }
 +
       res = sieve_register_parse_error(i, &mysieve_error);
       if (res != SIEVE_OK) {
-        syslog(LOG_ERR, "sieve_register_parse_error() returns %d\n", res);
+        syslog(LOG_ERR, "sieve_register_parse_error() returns %d", res);
 

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -685,7 +685,7 @@ static int _annotate_getdb(const char *mboxname,
     if (r)
         goto error;
 #if DEBUG
-    syslog(LOG_ERR, "Opening annotations db %s\n", fname);
+    syslog(LOG_ERR, "Opening annotations db %s", fname);
 #endif
 
     r = cyrusdb_open(DB, fname, dbflags | CYRUSDB_CONVERT, &db);
@@ -738,7 +738,7 @@ static void annotate_closedb(annotate_db_t *d)
     detach_db(prev, d);
 
 #if DEBUG
-    syslog(LOG_ERR, "Closing annotations db %s\n", d->filename);
+    syslog(LOG_ERR, "Closing annotations db %s", d->filename);
 #endif
 
     r = cyrusdb_close(d->db);
@@ -810,7 +810,7 @@ static void annotate_abort(annotate_db_t *d)
 
     if (d->txn) {
 #if DEBUG
-        syslog(LOG_ERR, "Aborting annotations db %s\n", d->filename);
+        syslog(LOG_ERR, "Aborting annotations db %s", d->filename);
 #endif
         cyrusdb_abort(d->db, d->txn);
     }
@@ -827,7 +827,7 @@ static int annotate_commit(annotate_db_t *d)
 
     if (d->txn) {
 #if DEBUG
-        syslog(LOG_ERR, "Committing annotations db %s\n", d->filename);
+        syslog(LOG_ERR, "Committing annotations db %s", d->filename);
 #endif
         r = cyrusdb_commit(d->db, d->txn);
         if (r)

--- a/imap/append.c
+++ b/imap/append.c
@@ -1082,7 +1082,7 @@ EXPORTED int append_fromstage_full(struct appendstate *as, struct body **body,
             newflags = strarray_new();
         r = callout_run(fname, *body, &user_annots, &system_annots, newflags);
         if (r) {
-            syslog(LOG_ERR, "Annotation callout failed, ignoring\n");
+            syslog(LOG_ERR, "Annotation callout failed, ignoring");
             r = 0;
         }
         flags = newflags;
@@ -1135,7 +1135,7 @@ EXPORTED int append_fromstage_full(struct appendstate *as, struct body **body,
     if (in_object_storage) {  // must delete local file
         if (unlink(fname) != 0) // unlink should do it.
             if (!remove (fname))  // we must insist
-                syslog(LOG_ERR, "Removing local file <%s> error \n", fname);
+                syslog(LOG_ERR, "Removing local file <%s> error", fname);
     }
 
     /* Apply the annotations */

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -276,7 +276,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
                   O_CREAT|O_TRUNC|O_WRONLY,
                   S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     if (out_fd < 0 && errno != EEXIST) {
-        syslog(LOG_ERR, "autocreate_sieve: Error opening file %s :%m\n",
+        syslog(LOG_ERR, "autocreate_sieve: Error opening file %s :%m",
                script_names.bctmpname);
         goto failed_start;
     }
@@ -298,8 +298,8 @@ static int autocreate_sieve(const char *userid, const char *source_script)
                 xclose(out_fd);
                 xclose(in_fd);
             } else if (r < 0) {
-                syslog(LOG_ERR, "autocreate_sieve: Error reading"
-                       "compiled script %s: %m\n", compiled_source_script);
+                syslog(LOG_ERR, "autocreate_sieve: Error reading "
+                       "compiled script %s: %m", compiled_source_script);
                 xclose(in_fd);
                 do_compile = 1;
                 if (lseek(out_fd, 0, SEEK_SET)) {
@@ -442,7 +442,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
                       O_CREAT|O_EXCL|O_WRONLY,
                       S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
         if (out_fd < 0 && errno != EEXIST) {
-            syslog(LOG_ERR, "autocreate_sieve: Error opening file %s :%m\n",
+            syslog(LOG_ERR, "autocreate_sieve: Error opening file %s :%m",
                    script_names.tmpname2);
             xclose(in_fd);
             goto success;

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -333,7 +333,7 @@ static int get_annotation_value(const char *mboxname,
     buf_free(&attrib);
     free(buf);
 
-    syslog(LOG_DEBUG, "get_annotation_value: ret(%d):secondsp(%d)\n", ret, *secondsp);
+    syslog(LOG_DEBUG, "get_annotation_value: ret(%d):secondsp(%d)", ret, *secondsp);
     return ret;
 }
 
@@ -631,7 +631,7 @@ static void sighandler(int sig __attribute((unused)))
 static int do_archive(struct cyr_expire_ctx *ctx)
 {
     if (ctx->args.archive_seconds >= 0) {
-        syslog(LOG_DEBUG, ">> do_archive: archive_seconds(%d) >= 0\n",
+        syslog(LOG_DEBUG, ">> do_archive: archive_seconds(%d) >= 0",
                ctx->args.archive_seconds);
         ctx->arock.archive_mark = time(0) - ctx->args.archive_seconds;
 

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -221,7 +221,7 @@ int clamav_scanfile(void *state, const char *fname,
 
     default:
         printf("cl_scanfile error: %s\n", cl_strerror(r));
-        syslog(LOG_ERR, "cl_scanfile error: %s\n", cl_strerror(r));
+        syslog(LOG_ERR, "cl_scanfile error: %s", cl_strerror(r));
         break;
     }
 

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -394,7 +394,7 @@ static int meth_post(struct transaction_t *txn,
         ret = json_response(ret ? ret : HTTP_OK, txn, res);
     }
 
-    syslog(LOG_DEBUG, ">>>> jmap_post: Exit\n");
+    syslog(LOG_DEBUG, ">>>> jmap_post: Exit");
     return ret;
 }
 

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -51,7 +51,7 @@
 #include <libical/ical.h>
 #undef icalerror_warn
 #define icalerror_warn(message) \
-{syslog(LOG_WARNING, "icalerror: %s(), %s:%d: %s\n", __FUNCTION__, __FILE__, __LINE__, message);}
+{syslog(LOG_WARNING, "icalerror: %s(), %s:%d: %s", __FUNCTION__, __FILE__, __LINE__, message);}
 
 #include "mailbox.h"
 

--- a/imap/idled.c
+++ b/imap/idled.c
@@ -135,7 +135,7 @@ static void process_message(struct sockaddr_un *remote, idle_message_t *msg)
     switch (msg->which) {
     case IDLE_MSG_INIT:
         if (verbose || debugmode)
-            syslog(LOG_DEBUG, "imapd[%s]: IDLE_MSG_INIT '%s'\n",
+            syslog(LOG_DEBUG, "imapd[%s]: IDLE_MSG_INIT '%s'",
                    idle_id_from_addr(remote), msg->mboxname);
 
         /* add an ientry to list of those idling on mboxname */
@@ -149,7 +149,7 @@ static void process_message(struct sockaddr_un *remote, idle_message_t *msg)
 
     case IDLE_MSG_NOTIFY:
         if (verbose || debugmode)
-            syslog(LOG_DEBUG, "IDLE_MSG_NOTIFY '%s'\n", msg->mboxname);
+            syslog(LOG_DEBUG, "IDLE_MSG_NOTIFY '%s'", msg->mboxname);
 
         /* send a message to all clients idling on mboxname */
         t = (struct ientry *) hash_lookup(msg->mboxname, &itable);
@@ -160,13 +160,13 @@ static void process_message(struct sockaddr_un *remote, idle_message_t *msg)
                  * period, so it probably died.  Remove it from the list.
                  */
                 if (verbose || debugmode)
-                    syslog(LOG_DEBUG, "    TIMEOUT %s\n", idle_id_from_addr(&t->remote));
+                    syslog(LOG_DEBUG, "    TIMEOUT %s", idle_id_from_addr(&t->remote));
 
                 remove_ientry(msg->mboxname, &t->remote);
             }
             else { /* signal process to update */
                 if (verbose || debugmode)
-                    syslog(LOG_DEBUG, "    fwd NOTIFY %s\n", idle_id_from_addr(&t->remote));
+                    syslog(LOG_DEBUG, "    fwd NOTIFY %s", idle_id_from_addr(&t->remote));
 
                 /* forward the received msg onto our clients */
                 r = idle_send(&t->remote, msg);
@@ -182,7 +182,7 @@ static void process_message(struct sockaddr_un *remote, idle_message_t *msg)
                                         idle_id_from_addr(&t->remote),
                                         msg->mboxname, error_message(r));
                     if (verbose || debugmode)
-                        syslog(LOG_DEBUG, "    forgetting %s\n", idle_id_from_addr(&t->remote));
+                        syslog(LOG_DEBUG, "    forgetting %s", idle_id_from_addr(&t->remote));
                     remove_ientry(msg->mboxname, &t->remote);
                 }
             }
@@ -191,7 +191,7 @@ static void process_message(struct sockaddr_un *remote, idle_message_t *msg)
 
     case IDLE_MSG_DONE:
         if (verbose || debugmode)
-            syslog(LOG_DEBUG, "imapd[%s]: IDLE_MSG_DONE '%s'\n",
+            syslog(LOG_DEBUG, "imapd[%s]: IDLE_MSG_DONE '%s'",
                    idle_id_from_addr(remote), msg->mboxname);
 
         /* remove client from list of those idling on mboxname */
@@ -226,7 +226,7 @@ static void send_alert(const char *key,
 
         /* signal process to check ALERTs */
         if (verbose || debugmode)
-            syslog(LOG_DEBUG, "    ALERT %s\n", idle_id_from_addr(&t->remote));
+            syslog(LOG_DEBUG, "    ALERT %s", idle_id_from_addr(&t->remote));
 
         r = idle_send(&t->remote, &msg);
         if (r) {
@@ -241,7 +241,7 @@ static void send_alert(const char *key,
                                 idle_id_from_addr(&t->remote),
                                 msg.mboxname, error_message(r));
             if (verbose || debugmode)
-                syslog(LOG_DEBUG, "    forgetting %s\n", idle_id_from_addr(&t->remote));
+                syslog(LOG_DEBUG, "    forgetting %s", idle_id_from_addr(&t->remote));
             remove_ientry(key, &t->remote);
         }
     }
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
         sig = signals_poll();
         if (sig == SIGHUP && getenv("CYRUS_ISDAEMON")) {
             /* XXX maybe don't restart if we have clients? */
-            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully\n");
+            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully");
             shut_down(0);
         }
 
@@ -346,7 +346,7 @@ int main(int argc, char **argv)
         if (shutdown_file(NULL, 0)) {
             /* signal all processes to shutdown */
             if (verbose || debugmode)
-                syslog(LOG_DEBUG, "Detected shutdown file\n");
+                syslog(LOG_DEBUG, "Detected shutdown file");
             shut_down(1);
         }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -11958,7 +11958,7 @@ static int xfer_setquotaroot(struct xfer_header *xfer, const char *mboxname)
     r = getresult(xfer->sync_cs.backend->in, "Q01");
     if (r) syslog(LOG_ERR,
                   "Could not move mailbox: %s, " \
-                  "failed setting initial quota root\r\n",
+                  "failed setting initial quota root",
                   mboxname);
     return r;
 }

--- a/imap/index.c
+++ b/imap/index.c
@@ -1418,7 +1418,7 @@ static void prefetch_messages(struct index_state *state,
     const char *fname;
     struct index_record record;
 
-    syslog(LOG_ERR, "Prefetching initial parts of messages\n");
+    syslog(LOG_ERR, "Prefetching initial parts of messages");
 
     for (msgno = 1; msgno <= state->exists; msgno++) {
         im = &state->map[msgno-1];

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1958,7 +1958,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
 
     res = sieve_register_vacation(interp, &vacation);
     if (res != SIEVE_OK) {
-        syslog(LOG_ERR, "sieve_register_vacation() returns %d\n", res);
+        syslog(LOG_ERR, "sieve_register_vacation() returns %d", res);
         fatal("sieve_register_vacation()", EX_SOFTWARE);
     }
 
@@ -1966,7 +1966,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
         config_getduration(IMAPOPT_SIEVE_DUPLICATE_MAX_EXPIRATION, 's');
     res = sieve_register_duplicate(interp, &duplicate);
     if (res != SIEVE_OK) {
-        syslog(LOG_ERR, "sieve_register_duplicate() returns %d\n", res);
+        syslog(LOG_ERR, "sieve_register_duplicate() returns %d", res);
         fatal("sieve_register_duplicate()", EX_SOFTWARE);
     }
 

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -389,7 +389,7 @@ static int do_quota(struct findall_data *data, void *rock __attribute__((unused)
 
         if (stat(fname, &sbuf) != 0) {
             syslog(LOG_WARNING,
-                   "Can not open message file %s -- skipping\n", fname);
+                   "Can not open message file %s -- skipping", fname);
             continue;
         }
 

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -419,7 +419,7 @@ int service_init(int argc __attribute__((unused)),
     /* initialize duplicate delivery database */
     if (duplicate_init(NULL) != 0) {
         syslog(LOG_ERR,
-               "unable to init duplicate delivery database\n");
+               "unable to init duplicate delivery database");
         fatal("unable to init duplicate delivery database", EX_SOFTWARE);
     }
 

--- a/imap/objectstore_db.c
+++ b/imap/objectstore_db.c
@@ -273,7 +273,7 @@ static char *pack_other_message (char *sql_cmd, const char *msg_guid){   // used
 void sql_error (int rc, char *zErrMsg)
 {
     if( rc != SQLITE_OK ){
-        syslog(LOG_ERR, "SQL error: %s\n", zErrMsg);
+        syslog(LOG_ERR, "SQL error: %s", zErrMsg);
         sqlite3_free(zErrMsg);
     }
 }

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -737,14 +737,14 @@ int main(int argc, char **argv)
 
         sig = signals_poll();
         if (sig == SIGHUP && getenv("CYRUS_ISDAEMON")) {
-            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully\n");
+            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully");
             shut_down(0);
         }
 
         /* check for shutdown file */
         if (shutdown_file(NULL, 0)) {
             if (verbose || debugmode)
-                syslog(LOG_DEBUG, "Detected shutdown file\n");
+                syslog(LOG_DEBUG, "Detected shutdown file");
             shut_down(0);
         }
 

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -195,7 +195,7 @@ static struct opstack *opstack_push(SquatBuilderData *bb, int op)
 
 #if DEBUG
     if (bb->verbose > 1)
-        syslog(LOG_NOTICE, "Squat opstack_push(op=%s)\n", search_op_as_string(op));
+        syslog(LOG_NOTICE, "Squat opstack_push(op=%s)", search_op_as_string(op));
 #endif
 
     /* push a new op on the stack */
@@ -545,7 +545,7 @@ static void stop_stats(SquatStats *stats)
 static void print_stats(const char *which, const SquatStats *stats)
 {
     syslog(LOG_NOTICE, "squat: %s indexed %lu messages (%lu bytes) "
-            "into %lu index bytes in %d seconds\n",
+            "into %lu index bytes in %d seconds",
             which,
             stats->indexed_messages,
             stats->indexed_bytes,
@@ -628,7 +628,7 @@ static int do_append(SquatReceiverData *d, const struct buf *text)
     int s;          /* SQUAT error */
 
     if (d->verbose > 3)
-        syslog(LOG_ERR, "squat: writing %llu bytes into message %u\n",
+        syslog(LOG_ERR, "squat: writing %llu bytes into message %u",
                (unsigned long long)text->len, d->uid);
 
     s = squat_index_append_document(d->index, text->s, text->len);
@@ -660,7 +660,7 @@ static void append_text(search_text_receiver_t *rx,
 
         /* just went over the threshold */
         if (d->verbose > 2)
-            syslog(LOG_NOTICE, "squat: opening document part '%s'\n",
+            syslog(LOG_NOTICE, "squat: opening document part '%s'",
                     d->doc_name);
 
         s = squat_index_open_document(d->index, d->doc_name);

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -1041,7 +1041,7 @@ static int xapiandb_lock_open(struct mailbox *mailbox, struct xapiandb_lock *loc
     /* Get a shared lock */
     r = mboxname_lock(namelock_fname, &lock->namelock, LOCK_SHARED);
     if (r) {
-        syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
+        syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                 namelock_fname);
         goto out;
     }
@@ -2398,7 +2398,7 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
 
     r = mboxname_lock(namelock_fname, &tr->xapiandb_namelock, LOCK_SHARED);
     if (r) {
-        syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
+        syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                namelock_fname);
         goto out;
     }
@@ -2949,7 +2949,7 @@ static int list_files(const char *userid, strarray_t *files)
 
     r = mboxname_lock(namelock_fname, &xapiandb_namelock, LOCK_SHARED);
     if (r) {
-        syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
+        syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                namelock_fname);
         goto out;
     }
@@ -3530,7 +3530,7 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
         goto out;
     }
     if (r) {
-        syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
+        syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                namelock_fname);
         goto out;
     }
@@ -3619,7 +3619,7 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
     /* Get a shared name lock */
     r = mboxname_lock(namelock_fname, &xapiandb_namelock, LOCK_SHARED);
     if (r) {
-        syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
+        syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                namelock_fname);
         goto out;
     }
@@ -3761,7 +3761,7 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
     /* Get an exclusive namelock */
     r = mboxname_lock(namelock_fname, &xapiandb_namelock, LOCK_EXCLUSIVE);
     if (r) {
-        syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
+        syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                namelock_fname);
         goto out;
     }
@@ -3893,7 +3893,7 @@ static int delete_user(const char *userid)
     namelock_fname = xapiandb_namelock_fname_from_userid(userid);
     r = mboxname_lock(namelock_fname, &xapiandb_namelock, LOCK_EXCLUSIVE);
     if (r) {
-        syslog(LOG_ERR, "Could not acquire shared namelock on %s\n",
+        syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                namelock_fname);
         goto out;
     }

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -213,7 +213,7 @@ static int should_index(const char *name)
             printf("error looking up %s: %s\n",
                    extname, error_message(r));
         }
-        syslog(LOG_INFO, "error looking up %s: %s\n",
+        syslog(LOG_INFO, "error looking up %s: %s",
                extname, error_message(r));
 
         free(extname);
@@ -345,7 +345,7 @@ again:
         if (verbose) {
             printf("error opening %s: %s\n", extname, error_message(r));
         }
-        syslog(LOG_INFO, "error opening %s: %s\n", extname, error_message(r));
+        syslog(LOG_INFO, "error opening %s: %s", extname, error_message(r));
         free(extname);
 
         return r;
@@ -756,7 +756,7 @@ static void do_rolling(const char *channel)
         int sig = signals_poll();
 
         if (sig == SIGHUP && getenv("CYRUS_ISDAEMON")) {
-            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully\n");
+            syslog(LOG_DEBUG, "received SIGHUP, shutting down gracefully");
             sync_log_reader_end(slr);
             shut_down(0);
         }

--- a/lib/cyrusdb.c
+++ b/lib/cyrusdb.c
@@ -187,7 +187,7 @@ static int _myopen(const char *backend, const char *fname,
     r = db->backend->open(fname, flags, &db->engine, tid);
 
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB open(%s, %d) => %llx\n", fname, flags, (long long unsigned)db->engine);
+    syslog(LOG_NOTICE, "DEBUGDB open(%s, %d) => %llx", fname, flags, (long long unsigned)db->engine);
 #endif
 
 done:
@@ -213,7 +213,7 @@ EXPORTED int cyrusdb_lockopen(const char *backend, const char *fname,
 EXPORTED int cyrusdb_close(struct db *db)
 {
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB close(%llx)\n", (long long unsigned)db->engine);
+    syslog(LOG_NOTICE, "DEBUGDB close(%llx)", (long long unsigned)db->engine);
 #endif
 
     int r = db->backend->close(db->engine);
@@ -231,7 +231,7 @@ EXPORTED int cyrusdb_fetch(struct db *db,
     if (!db->backend->fetch)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB fetch(%llx, %.*s)\n", (long long unsigned)db->engine, (int)keylen, key);
+    syslog(LOG_NOTICE, "DEBUGDB fetch(%llx, %.*s)", (long long unsigned)db->engine, (int)keylen, key);
 #endif
     return db->backend->fetch(db->engine, key, keylen,
                               data, datalen, mytid);
@@ -245,7 +245,7 @@ EXPORTED int cyrusdb_fetchlock(struct db *db,
     if (!db->backend->fetchlock)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB fetchlock(%llx, %.*s)\n", (long long unsigned)db->engine, (int)keylen, key);
+    syslog(LOG_NOTICE, "DEBUGDB fetchlock(%llx, %.*s)", (long long unsigned)db->engine, (int)keylen, key);
 #endif
     return db->backend->fetchlock(db->engine, key, keylen,
                                   data, datalen, mytid);
@@ -260,7 +260,7 @@ EXPORTED int cyrusdb_fetchnext(struct db *db,
     if (!db->backend->fetchnext)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB fetchnext(%llx, %.*s)\n", (long long unsigned)db->engine, (int)keylen, key);
+    syslog(LOG_NOTICE, "DEBUGDB fetchnext(%llx, %.*s)", (long long unsigned)db->engine, (int)keylen, key);
 #endif
     return db->backend->fetchnext(db->engine, key, keylen,
                                   found, foundlen,
@@ -276,7 +276,7 @@ EXPORTED int cyrusdb_foreach(struct db *db,
     if (!db->backend->foreach)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB foreach(%llx, %.*s)\n", (long long unsigned)db->engine, (int)prefixlen, prefix);
+    syslog(LOG_NOTICE, "DEBUGDB foreach(%llx, %.*s)", (long long unsigned)db->engine, (int)prefixlen, prefix);
 #endif
     return db->backend->foreach(db->engine, prefix, prefixlen,
                                 p, cb, rock, tid);
@@ -291,7 +291,7 @@ EXPORTED int cyrusdb_forone(struct db *db,
     const char *data;
     size_t datalen;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB forone(%llx, %.*s)\n", (long long unsigned)db->engine, (int)keylen, key);
+    syslog(LOG_NOTICE, "DEBUGDB forone(%llx, %.*s)", (long long unsigned)db->engine, (int)keylen, key);
 #endif
     int r = cyrusdb_fetch(db, key, keylen, &data, &datalen, tid);
     if (r == CYRUSDB_NOTFOUND) return 0;
@@ -310,7 +310,7 @@ EXPORTED int cyrusdb_create(struct db *db,
     if (!db->backend->create)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB create(%llx, %.*s)\n", (long long unsigned)db->engine, (int)keylen, key);
+    syslog(LOG_NOTICE, "DEBUGDB create(%llx, %.*s)", (long long unsigned)db->engine, (int)keylen, key);
 #endif
     return db->backend->create(db->engine, key, keylen, data, datalen, tid);
 }
@@ -323,7 +323,7 @@ EXPORTED int cyrusdb_store(struct db *db,
     if (!db->backend->store)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB store(%llx, %.*s)\n", (long long unsigned)db->engine, (int)keylen, key);
+    syslog(LOG_NOTICE, "DEBUGDB store(%llx, %.*s)", (long long unsigned)db->engine, (int)keylen, key);
 #endif
     return db->backend->store(db->engine, key, keylen, data, datalen, tid);
 }
@@ -335,7 +335,7 @@ EXPORTED int cyrusdb_delete(struct db *db,
     if (!db->backend->delete_)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB delete(%llx, %.*s)\n", (long long unsigned)db->engine, (int)keylen, key);
+    syslog(LOG_NOTICE, "DEBUGDB delete(%llx, %.*s)", (long long unsigned)db->engine, (int)keylen, key);
 #endif
     return db->backend->delete_(db->engine, key, keylen, tid, force);
 }
@@ -345,7 +345,7 @@ EXPORTED int cyrusdb_commit(struct db *db, struct txn *tid)
     if (!db->backend->commit)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB commit(%llx)\n", (long long unsigned)db->engine);
+    syslog(LOG_NOTICE, "DEBUGDB commit(%llx)", (long long unsigned)db->engine);
 #endif
     return db->backend->commit(db->engine, tid);
 }
@@ -355,7 +355,7 @@ EXPORTED int cyrusdb_abort(struct db *db, struct txn *tid)
     if (!db->backend->abort)
         return CYRUSDB_NOTIMPLEMENTED;
 #ifdef DEBUGDB
-    syslog(LOG_NOTICE, "DEBUGDB abort(%llx)\n", (long long unsigned)db->engine);
+    syslog(LOG_NOTICE, "DEBUGDB abort(%llx)", (long long unsigned)db->engine);
 #endif
     return db->backend->abort(db->engine, tid);
 }

--- a/lib/cyrusdb_skiplist.c
+++ b/lib/cyrusdb_skiplist.c
@@ -536,7 +536,7 @@ static int read_header(struct dbengine *db)
 
     if (db->maxlevel > SKIPLIST_MAXLEVEL) {
         syslog(LOG_ERR,
-               "skiplist %s: MAXLEVEL %d in database beyond maximum %d\n",
+               "skiplist %s: MAXLEVEL %d in database beyond maximum %d",
                db->fname, db->maxlevel, SKIPLIST_MAXLEVEL);
         return CYRUSDB_IOERROR;
     }
@@ -545,7 +545,7 @@ static int read_header(struct dbengine *db)
 
     if (db->curlevel > db->maxlevel) {
         syslog(LOG_ERR,
-               "skiplist %s: CURLEVEL %d in database beyond maximum %d\n",
+               "skiplist %s: CURLEVEL %d in database beyond maximum %d",
                db->fname, db->curlevel, db->maxlevel);
         return CYRUSDB_IOERROR;
     }
@@ -1982,7 +1982,7 @@ static int myconsistent(struct dbengine *db, struct txn *tid, int locked)
             if (offset > db->map_size) {
                 syslog(LOG_ERR,
                         "skiplist inconsistent: %04X: ptr %d is %04X; "
-                        "eof is %04X\n",
+                        "eof is %04X",
                         (unsigned int) (ptr - db->map_base),
                         i, offset, (unsigned int) db->map_size);
                 if (!locked) unlock(db);
@@ -1998,7 +1998,7 @@ static int myconsistent(struct dbengine *db, struct txn *tid, int locked)
                 if (cmp >= 0) {
                     syslog(LOG_ERR,
                             "skiplist inconsistent: %04X: ptr %d is %04X; "
-                            "db->compar() = %d\n",
+                            "db->compar() = %d",
                             (unsigned int) (ptr - db->map_base),
                             i,
                             offset, cmp);

--- a/lib/iostat.c
+++ b/lib/iostat.c
@@ -19,9 +19,9 @@ EXPORTED void read_io_count(struct io_count *iocount) {
         return;
     }
     else {
-        syslog(LOG_ERR,"IOERROR: opening file /proc/self/io\n");
+        syslog(LOG_ERR,"IOERROR: opening file /proc/self/io");
         config_iolog = 0;
-        syslog(LOG_ERR,"I/O log has been deactivated\n");
+        syslog(LOG_ERR,"I/O log has been deactivated");
     }
 }
 

--- a/notifyd/notify_external.c
+++ b/notifyd/notify_external.c
@@ -88,7 +88,7 @@ char* notify_external(const char *class, const char *priority,
 
     if (pipe(fds) < 0) {
        syslog(LOG_ERR,
-              "notify_external: pipe() returned %s\n", strerror(errno));
+              "notify_external: pipe() returned %s", strerror(errno));
        return strdup("NO notify_external pipe failed");
     }
 

--- a/sieve/rebuild.c
+++ b/sieve/rebuild.c
@@ -208,7 +208,7 @@ EXPORTED int sieve_rebuild(const char *script_fname, const char *bc_fname,
                                 &version, NULL);
                 if (version == BYTECODE_VERSION) {
                     syslog(LOG_DEBUG,
-                           "%s: %s is up to date\n", __func__, bc_fname);
+                           "%s: %s is up to date", __func__, bc_fname);
                     r = SIEVE_OK;
                     sieve_script_unload(&exe);
                     goto done;

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -200,13 +200,13 @@ EXPORTED sieve_interp_t *sieve_build_nonexec_interp()
 
     res = sieve_register_vacation(interpreter, &stub_vacation);
     if (res != SIEVE_OK) {
-        syslog(LOG_ERR, "sieve_register_vacation() returns %d\n", res);
+        syslog(LOG_ERR, "sieve_register_vacation() returns %d", res);
         goto done;
     }
 
     res = sieve_register_duplicate(interpreter, &stub_duplicate);
     if (res != SIEVE_OK) {
-        syslog(LOG_ERR, "sieve_register_duplicate() returns %d\n", res);
+        syslog(LOG_ERR, "sieve_register_duplicate() returns %d", res);
         goto done;
     }
 


### PR DESCRIPTION
Per https://man7.org/linux/man-pages/man3/syslog.3.html “The format string need not include a terminating newline character.”

Transformed by:
```sh
sed -i 's/\(syslog.*\) "\\n"\(.*\)/\1\2/' `find -name '*.c*'`
sed -i 's/\(syslog.*\) \\n\(.*\)/\1\2/' `find -name '*.c*'`
sed -i 's/\(syslog.*\)\\n\(.*\)/\1\2/' `find -name '*.c*'`
```
and some manual work.