### PR TITLE
Makefile.am: remove http_caldav_js.h from nodist_imap_httpd_SOURCES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,8 +94,6 @@ CLEANFILES = \
 
 DISTCLEANFILES = \
 	com_err/et/compile_et \
-	imap/http_caldav_js.h \
-	imap/http_carddav_js.h \
 	imap/http_err.c \
 	imap/http_err.h \
 	imap/imap_err.c \
@@ -120,6 +118,8 @@ DISTCLEANFILES = \
 MAINTAINERCLEANFILES = \
 	doc/legacy/murder.png \
 	doc/legacy/netnews.png \
+	imap/http_caldav_js.h \
+	imap/http_carddav_js.h \
 	man/imapd.conf.5 \
 	man/sieveshell.1 \
 	sieve/addr.h \
@@ -1229,8 +1229,6 @@ imap_nntpd_SOURCES = \
 imap_nntpd_LDADD = $(LD_SIEVE_ADD) $(LD_SERVER_ADD)
 
 nodist_imap_httpd_SOURCES = \
-	imap/http_caldav_js.h \
-	imap/http_carddav_js.h \
 	imap/tz_err.c \
 	imap/tz_err.h
 


### PR DESCRIPTION
The imap/caldav_js.h and carddav_js.h files are generated by xxd from caldav.js and carddav.js .  xxd is not required as build dependency, therefore the files caldav_js.h and carddav_js.h must be included in the tarball on "make dist". Mentioning the files in imap_httpd_SOURCES achieves exactly this.

Mentioning the files in nodist_imap_httpd_SOURCES means the opposite: do not include the files in the "make dist” tarball.
As a matter of fact, the files were included in both nodist_imap_httpd_SOURCES and imap_httpd_SOURCES.

"make distclean" deletes files created by ./configure.  Since the caldav_js.h files are from the tarball and not generated
by ./configure, they shall not be clean by “make disclean” but by “make maintainer-clean”.