### PR TITLE
master:reap_child() survive SIGINT

### DIFF
--- a/master/master.c
+++ b/master/master.c
@@ -1067,7 +1067,14 @@ static void reap_child(void)
     struct service *s;
     int failed;
 
-    while ((pid = waitpid((pid_t) -1, &status, WNOHANG)) > 0) {
+    while ((pid = waitpid((pid_t) -1, &status, WNOHANG)) > -1) {
+        if (pid == 0) {
+            if (errno == EINTR) {
+                errno = 0;
+                continue;
+            }
+            break;
+        }
 
         /* account for the child */
         c = centry_find(pid);


### PR DESCRIPTION
When the master process receives SIGINT, it shall recycle all children and then exit.  If the signal is recieved while waitpid() in reap_child() is executed, waitpid() returns 0, the child exit status is not consumed and the centry is not updated.

Later on, the janitor utilizes 100% the CPU by iterating over its slots, to see if the process, whose centry was not updated, is in the meantime terminated.  The child is in fact terminated, but due the interruption of waitpid() the master process never updates its internal status for the child.