### PR TITLE
grow dynamic arrays by doubling, rather than fixed size

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -617,6 +617,7 @@ cunit_TESTS = \
 	cunit/binhex.testc \
 	cunit/bitvector.testc \
 	cunit/buf.testc \
+	cunit/bufarray.testc \
 	cunit/byteorder.testc \
 	cunit/charset.testc \
 	cunit/command.testc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -612,6 +612,7 @@ cunit_FRAMEWORK = \
 cunit_TESTS = \
 	cunit/aaa-db.testc \
 	cunit/annotate.testc \
+	cunit/arrayu64.testc \
 	cunit/backend.testc \
 	cunit/binhex.testc \
 	cunit/bitvector.testc \

--- a/cunit/arrayu64.testc
+++ b/cunit/arrayu64.testc
@@ -1,0 +1,747 @@
+#include "cunit/cyrunit.h"
+#include "xmalloc.h"
+#include "bsearch.h"
+#include "arrayu64.h"
+
+static void test_fini_null(void)
+{
+    /* _fini(NULL) is harmless */
+    arrayu64_fini(NULL);
+    /* _free(NULL) is harmless */
+    arrayu64_free(NULL);
+}
+
+static void test_auto(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+    uint64_t u1;
+    uint64_t u2;
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    u1 = 1234567UL;
+    arrayu64_append(&a, u1);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), u1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), u1);
+
+    u2 = 7654321UL;
+    arrayu64_append(&a, u2);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 2);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), u1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), u2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), u2);
+
+    arrayu64_fini(&a);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT_EQUAL(a.alloc, 0);
+    CU_ASSERT_PTR_NULL(a.data);
+}
+
+static void test_heap(void)
+{
+    arrayu64_t *a = arrayu64_new();
+    uint64_t u1;
+    uint64_t u2;
+
+    CU_ASSERT_EQUAL(a->count, 0);
+    CU_ASSERT(a->alloc >= a->count);
+    CU_ASSERT_EQUAL(arrayu64_nth(a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(a, -1), 0UL);
+
+    u1 = 1234567UL;
+    arrayu64_append(a, u1);
+    CU_ASSERT_EQUAL(a->count, 1);
+    CU_ASSERT(a->alloc >= a->count);
+    CU_ASSERT_PTR_NOT_NULL(a->data);
+    CU_ASSERT_EQUAL(arrayu64_nth(a, 0), u1);
+    CU_ASSERT_EQUAL(arrayu64_nth(a, -1), u1);
+
+    u2 = 7654321UL;
+    arrayu64_append(a, u2);
+    CU_ASSERT_EQUAL(a->count, 2);
+    CU_ASSERT(a->alloc >= a->count);
+    CU_ASSERT_PTR_NOT_NULL(a->data);
+    CU_ASSERT_EQUAL(arrayu64_nth(a, 0), u1);
+    CU_ASSERT_EQUAL(arrayu64_nth(a, 1), u2);
+    CU_ASSERT_EQUAL(arrayu64_nth(a, -1), u2);
+
+    arrayu64_free(a);
+}
+
+static void test_set(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0        (1234567UL)
+#define VAL0REP     (2345678UL)
+#define VAL0REP2    (3456789UL)
+#define VAL1        (1111111UL)
+#define VAL2        (2222222UL)
+#define VAL2REP     (222UL)
+#define VAL3        (3333333UL)
+#define VAL4        (4444444UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_append(&a, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+
+    arrayu64_set(&a, 0, VAL0REP);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0REP);
+
+    arrayu64_set(&a, -1, VAL0REP2);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0REP2);
+
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL3);
+    arrayu64_append(&a, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 5);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0REP2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL4);
+
+    arrayu64_set(&a, 2, VAL2REP);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 5);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0REP2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2REP);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL4);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL0REP
+#undef VAL0REP2
+#undef VAL1
+#undef VAL2
+#undef VAL2REP
+#undef VAL3
+#undef VAL4
+}
+
+static void test_insert(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0   (111111UL)
+#define VAL1   (222222UL)
+#define VAL2   (333333UL)
+#define VAL3   (444444UL)
+#define VAL4   (555555UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_insert(&a, 0, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+
+    arrayu64_insert(&a, -1, VAL1);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 2);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL0);
+
+    arrayu64_insert(&a, 0, VAL2);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 3);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL0);
+
+    arrayu64_insert(&a, -1, VAL3);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 4);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL0);
+
+    arrayu64_insert(&a, 2, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 5);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL4);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL0);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+#undef VAL3
+#undef VAL4
+}
+
+/* test that _set(), _setm(), _insert() and _insertm() of a bad
+ * index will fail silently and leave no side effects including
+ * memory leaks */
+static void test_bad_index(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0   (111111UL)
+#define VAL1   (222222UL)
+#define VAL2   (333333UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    /* when the arrayu64 is empty, -1 is a bad index */
+
+    arrayu64_set(&a, -1, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_insert(&a, -1, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    /* a negative number larger than the (non-zero) count is a bad index */
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+
+    arrayu64_set(&a, -4, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), VAL2);
+
+    arrayu64_insert(&a, -4, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), VAL2);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+}
+
+/* test building a sparse array with _set() and _setm() */
+static void test_sparse_set(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0   (1111111UL)
+#define VAL1   (2222222UL)
+#define VAL2   (3333333UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_set(&a, 3, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 4);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), VAL0);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+}
+
+static void test_remove(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+    uint64_t u;
+#define VAL0   (1111111UL)
+#define VAL1   (2222222UL)
+#define VAL2   (3333333UL)
+#define VAL3   (4444444UL)
+#define VAL4   (5555555UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL3);
+    arrayu64_append(&a, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 5);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL4);
+
+    u = arrayu64_remove(&a, 2);
+    CU_ASSERT_EQUAL(u, VAL2);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 4);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL4);
+
+    u = arrayu64_remove(&a, 0);
+    CU_ASSERT_EQUAL(u, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 3);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL4);
+
+    u = arrayu64_remove(&a, -1);
+    CU_ASSERT_EQUAL(u, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 2);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL3);
+
+    u = arrayu64_remove(&a, 1);
+    CU_ASSERT_EQUAL(u, VAL3);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL1);
+
+    u = arrayu64_remove(&a, 0);
+    CU_ASSERT_EQUAL(u, VAL1);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+
+    u = arrayu64_remove(&a, 0);
+    CU_ASSERT_EQUAL(u, 0UL);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+#undef VAL3
+#undef VAL4
+}
+
+static void test_truncate(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0   (1111111UL)
+#define VAL1   (2222222UL)
+#define VAL2   (3333333UL)
+#define VAL3   (4444444UL)
+#define VAL4   (5555555UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL3);
+    arrayu64_append(&a, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 5);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL4);
+
+    /* expand the array */
+    arrayu64_truncate(&a, 7);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 7);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL4);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 5), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 6), 0UL);
+
+    /* shrink the array */
+    arrayu64_truncate(&a, 4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 4);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+
+    /* shrink the array harder */
+    arrayu64_truncate(&a, 3);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 3);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+
+    /* shrink the array to nothing */
+    arrayu64_truncate(&a, 0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    /* whether a.data is NULL is undefined at this time */
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+#undef VAL3
+#undef VAL4
+}
+
+static void test_find(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+    off_t i;
+#define VAL0    (1111111UL)
+#define VAL1    (2222222UL)
+#define VAL2    (3333333UL)
+#define VAL3    (4444444UL)
+#define VAL4    (5555555UL)
+#define NOTHERE (1234567UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL3);
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 6);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 5), VAL4);
+
+    /* search for something which isn't there */
+    i = arrayu64_find(&a, NOTHERE, 0);
+    CU_ASSERT_EQUAL(i, -1);
+
+    /* search for something which isn't there, starting off the end */
+    i = arrayu64_find(&a, NOTHERE, 7);
+    CU_ASSERT_EQUAL(i, -1);
+
+    /* search for something which is there */
+    i = arrayu64_find(&a, VAL1, 0);
+    CU_ASSERT_EQUAL(i, 1);
+    i = arrayu64_find(&a, VAL1, i+1);
+    CU_ASSERT_EQUAL(i, -1);
+
+    /* search for something which is there, starting off the end */
+    i = arrayu64_find(&a, VAL1, 7);
+    CU_ASSERT_EQUAL(i, -1);
+
+    /* search for something which is there multiple times */
+    i = arrayu64_find(&a, VAL0, 0);
+    CU_ASSERT_EQUAL(i, 0);
+    i = arrayu64_find(&a, VAL0, i+1);
+    CU_ASSERT_EQUAL(i, 4);
+    i = arrayu64_find(&a, VAL0, i+1);
+    CU_ASSERT_EQUAL(i, -1);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+#undef VAL3
+#undef VAL4
+#undef NOTHERE
+}
+
+static void test_dup(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+    arrayu64_t *dup;
+#define VAL0   (1111111UL)
+#define VAL1   (2222222UL)
+#define VAL2   (3333333UL)
+#define VAL3   (4444444UL)
+#define VAL4   (5555555UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+
+    /* dup an empty array */
+    dup = arrayu64_dup(&a);
+    CU_ASSERT_PTR_NOT_NULL(dup);
+    CU_ASSERT_PTR_NOT_EQUAL(dup, &a);
+    CU_ASSERT_EQUAL(dup->count, 0);
+    CU_ASSERT(dup->alloc >= dup->count);
+    arrayu64_free(dup);
+
+    /* dup a non-empty array */
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL3);
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 6);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 5), VAL4);
+
+    dup = arrayu64_dup(&a);
+    CU_ASSERT_PTR_NOT_NULL(dup);
+    CU_ASSERT_PTR_NOT_EQUAL(dup, &a);
+    CU_ASSERT_EQUAL(dup->count, 6);
+    CU_ASSERT(dup->alloc >= dup->count);
+    CU_ASSERT_PTR_NOT_NULL(dup->data);
+    CU_ASSERT_PTR_NOT_EQUAL(a.data, dup->data);
+    CU_ASSERT_EQUAL(arrayu64_nth(dup, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(dup, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(dup, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(dup, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(dup, 4), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(dup, 5), VAL4);
+    arrayu64_free(dup);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+#undef VAL3
+#undef VAL4
+}
+
+static void test_remove_all(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0   (1111111UL)
+#define VAL1   (2222222UL)
+#define VAL2   (3333333UL)
+#define VAL3   (4444444UL)
+#define VAL4   (5555555UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+
+    /* removing from an empty array */
+    arrayu64_remove_all(&a, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+
+    /* removing a single item from a non-empty array */
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL3);
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL4);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 6);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 5), VAL4);
+
+    arrayu64_remove_all(&a, VAL1);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 5);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL4);
+
+    /* removing an item that appears more than once */
+    arrayu64_remove_all(&a, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 3);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL4);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+#undef VAL3
+#undef VAL4
+}
+
+static void test_sort(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0   (1111111UL)
+#define VAL1   (2222222UL)
+#define VAL2   (5555555UL)
+#define VAL3   (4444444UL)
+#define VAL4   (3333333UL)
+
+    /* initialise */
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL1);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL3);
+    arrayu64_append(&a, VAL4);
+    /* duplicates */
+    arrayu64_append(&a, VAL0);
+    arrayu64_append(&a, VAL2);
+    arrayu64_append(&a, VAL1);
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 8);
+
+    /* normal sort */
+    arrayu64_sort(&a, NULL);
+
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL4);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 5), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 6), VAL2);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 7), VAL2);
+
+    /* uniq */
+    arrayu64_uniq(&a);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 5);
+
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL4);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 3), VAL3);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 4), VAL2);
+
+#undef VAL0
+#undef VAL1
+#undef VAL2
+#undef VAL3
+#undef VAL4
+}
+
+static void test_add(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+#define VAL0   (1111111UL)
+#define VAL1   (2222222UL)
+#define VAL2   (3333333UL)
+
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 0);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), 0UL);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, -1), 0UL);
+
+    /* _add() on an empty array appends */
+    arrayu64_add(&a, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+
+    /* _add() of an item already present is a no-op */
+    arrayu64_add(&a, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 1);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+
+    /* _add() of an item not already present appends */
+    arrayu64_add(&a, VAL1);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 2);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+
+    /* _add() of an item already present is a no-op */
+    arrayu64_add(&a, VAL0);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 2);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+
+    arrayu64_add(&a, VAL2);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 3);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+
+    arrayu64_add(&a, VAL1);
+    CU_ASSERT_EQUAL(arrayu64_size(&a), 3);
+    CU_ASSERT(a.alloc >= arrayu64_size(&a));
+    CU_ASSERT_PTR_NOT_NULL(a.data);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 0), VAL0);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 1), VAL1);
+    CU_ASSERT_EQUAL(arrayu64_nth(&a, 2), VAL2);
+
+    arrayu64_fini(&a);
+#undef VAL0
+#undef VAL1
+#undef VAL2
+}
+
+/* vim: set ft=c: */

--- a/cunit/bufarray.testc
+++ b/cunit/bufarray.testc
@@ -1,0 +1,239 @@
+#include "cunit/cyrunit.h"
+#include "xmalloc.h"
+#include "bsearch.h"
+#include "bufarray.h"
+
+/* XXX bufarray_nth does NOT follow the same semantics as the other
+ * XXX fooarray_nth's, so our tests need to be a little different too
+ */
+
+static void test_fini_null(void)
+{
+    /* _fini(NULL) is harmless */
+    bufarray_fini(NULL);
+    /* _free(NULL) is harmless */
+    bufarray_free(NULL);
+}
+
+static void test_auto(void)
+{
+    bufarray_t ba = BUFARRAY_INITIALIZER;
+    struct buf b1 = BUF_INITIALIZER;
+    struct buf b2 = BUF_INITIALIZER;
+
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 0);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+//    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, 0));
+//    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, -1));
+
+    buf_setcstr(&b1, "lorem ipsum");
+    bufarray_append(&ba, &b1);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 1);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    CU_ASSERT_PTR_NOT_NULL(ba.items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 0), &b1), 0);
+//    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, -1), &b1), 0);
+
+    buf_setcstr(&b2, "dolor sit");
+    bufarray_append(&ba, &b2);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 2);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    CU_ASSERT_PTR_NOT_NULL(ba.items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 0), &b1), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 1), &b2), 0);
+//    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, -1), &b2), 0);
+
+    bufarray_fini(&ba);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 0);
+    CU_ASSERT_EQUAL(ba.alloc, 0);
+    CU_ASSERT_PTR_NULL(ba.items);
+}
+
+static void test_heap(void)
+{
+    bufarray_t *ba = bufarray_new();
+    struct buf b1 = BUF_INITIALIZER;
+    struct buf b2 = BUF_INITIALIZER;
+
+    CU_ASSERT_EQUAL(ba->count, 0);
+    CU_ASSERT(ba->alloc >= ba->count);
+//    CU_ASSERT_PTR_NULL(bufarray_nth(ba, 0));
+//    CU_ASSERT_PTR_NULL(bufarray_nth(ba, -1));
+
+    buf_setcstr(&b1, "lorem ipsum");
+    bufarray_append(ba, &b1);
+    CU_ASSERT_EQUAL(ba->count, 1);
+    CU_ASSERT(ba->alloc >= ba->count);
+    CU_ASSERT_PTR_NOT_NULL(ba->items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(ba, 0), &b1), 0);
+//    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, -1), &b1), 0);
+
+    buf_setcstr(&b2, "dolor sit");
+    bufarray_append(ba, &b2);
+    CU_ASSERT_EQUAL(ba->count, 2);
+    CU_ASSERT(ba->alloc >= ba->count);
+    CU_ASSERT_PTR_NOT_NULL(ba->items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(ba, 0), &b1), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(ba, 1), &b2), 0);
+//    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(ba, -1), &b2), 0);
+
+    bufarray_free(&ba);
+}
+
+static void test_truncate(void)
+{
+    bufarray_t ba = BUFARRAY_INITIALIZER;
+    struct buf WORD0 = BUF_INITIALIZER;
+    struct buf WORD1 = BUF_INITIALIZER;
+    struct buf WORD2 = BUF_INITIALIZER;
+    struct buf WORD3 = BUF_INITIALIZER;
+    struct buf WORD4 = BUF_INITIALIZER;
+
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 0);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+//    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, 0));
+//    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, -1));
+
+    buf_setcstr(&WORD0, "lorem");
+    buf_setcstr(&WORD1, "ipsum");
+    buf_setcstr(&WORD2, "dolor");
+    buf_setcstr(&WORD3, "sit");
+    buf_setcstr(&WORD4, "amet");
+
+    bufarray_append(&ba, &WORD0);
+    bufarray_append(&ba, &WORD1);
+    bufarray_append(&ba, &WORD2);
+    bufarray_append(&ba, &WORD3);
+    bufarray_append(&ba, &WORD4);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 5);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    CU_ASSERT_PTR_NOT_NULL(ba.items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 0), &WORD0), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 1), &WORD1), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 2), &WORD2), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 3), &WORD3), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 4), &WORD4), 0);
+
+    /* expand the array */
+    bufarray_truncate(&ba, 7);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 7);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    CU_ASSERT_PTR_NOT_NULL(ba.items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 0), &WORD0), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 1), &WORD1), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 2), &WORD2), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 3), &WORD3), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 4), &WORD4), 0);
+    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, 5));
+    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, 6));
+
+    /* shrink the array */
+    bufarray_truncate(&ba, 4);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 4);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    CU_ASSERT_PTR_NOT_NULL(ba.items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 0), &WORD0), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 1), &WORD1), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 2), &WORD2), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 3), &WORD3), 0);
+
+    /* shrink the array harder */
+    bufarray_truncate(&ba, 3);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 3);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    CU_ASSERT_PTR_NOT_NULL(ba.items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 0), &WORD0), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 1), &WORD1), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 2), &WORD2), 0);
+
+    /* shrink the array to nothing */
+    bufarray_truncate(&ba, 0);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 0);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    /* whether ba.items is NULL is undefined at this time */
+//    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, 0));
+//    CU_ASSERT_PTR_NULL(bufarray_nth(&ba, -1));
+
+    bufarray_fini(&ba);
+
+    buf_free(&WORD0);
+    buf_free(&WORD1);
+    buf_free(&WORD2);
+    buf_free(&WORD3);
+    buf_free(&WORD4);
+}
+
+static void test_dup(void)
+{
+    bufarray_t ba = BUFARRAY_INITIALIZER;
+    bufarray_t *dup;
+    struct buf WORD0 = BUF_INITIALIZER;
+    struct buf WORD1 = BUF_INITIALIZER;
+    struct buf WORD2 = BUF_INITIALIZER;
+    struct buf WORD3 = BUF_INITIALIZER;
+    struct buf WORD4 = BUF_INITIALIZER;
+
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 0);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+
+    /* dup an empty array */
+    dup = bufarray_dup(&ba);
+    CU_ASSERT_PTR_NOT_NULL(dup);
+    CU_ASSERT_PTR_NOT_EQUAL(dup, &ba);
+    CU_ASSERT_EQUAL(dup->count, 0);
+    CU_ASSERT(dup->alloc >= dup->count);
+    bufarray_free(&dup);
+
+    buf_setcstr(&WORD0, "lorem");
+    buf_setcstr(&WORD1, "ipsum");
+    buf_setcstr(&WORD2, "dolor");
+    buf_setcstr(&WORD3, "sit");
+    buf_setcstr(&WORD4, "amet");
+
+    /* dup a non-empty array */
+    bufarray_append(&ba, &WORD0);
+    bufarray_append(&ba, &WORD1);
+    bufarray_append(&ba, &WORD2);
+    bufarray_append(&ba, &WORD3);
+    bufarray_append(&ba, &WORD0);
+    bufarray_append(&ba, &WORD4);
+    CU_ASSERT_EQUAL(bufarray_size(&ba), 6);
+    CU_ASSERT(ba.alloc >= bufarray_size(&ba));
+    CU_ASSERT_PTR_NOT_NULL(ba.items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 0), &WORD0), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 1), &WORD1), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 2), &WORD2), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 3), &WORD3), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 4), &WORD0), 0);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(&ba, 5), &WORD4), 0);
+
+    dup = bufarray_dup(&ba);
+    CU_ASSERT_PTR_NOT_NULL(dup);
+    CU_ASSERT_PTR_NOT_EQUAL(dup, &ba);
+    CU_ASSERT_EQUAL(dup->count, 6);
+    CU_ASSERT(dup->alloc >= dup->count);
+    CU_ASSERT_PTR_NOT_NULL(dup->items);
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(dup, 0), &WORD0), 0);
+    CU_ASSERT_PTR_NOT_EQUAL((void *)bufarray_nth(dup, 0), (void *)bufarray_nth(&ba, 0));
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(dup, 1), &WORD1), 0);
+    CU_ASSERT_PTR_NOT_EQUAL((void *)bufarray_nth(dup, 1), (void *)bufarray_nth(&ba, 1));
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(dup, 2), &WORD2), 0);
+    CU_ASSERT_PTR_NOT_EQUAL((void *)bufarray_nth(dup, 2), (void *)bufarray_nth(&ba, 2));
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(dup, 3), &WORD3), 0);
+    CU_ASSERT_PTR_NOT_EQUAL((void *)bufarray_nth(dup, 3), (void *)bufarray_nth(&ba, 3));
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(dup, 4), &WORD0), 0);
+    CU_ASSERT_PTR_NOT_EQUAL((void *)bufarray_nth(dup, 4), (void *)bufarray_nth(&ba, 4));
+    CU_ASSERT_EQUAL(buf_cmp(bufarray_nth(dup, 5), &WORD4), 0);
+    CU_ASSERT_PTR_NOT_EQUAL((void *)bufarray_nth(dup, 5), (void *)bufarray_nth(&ba, 5));
+    bufarray_free(&dup);
+
+    bufarray_fini(&ba);
+
+    buf_free(&WORD0);
+    buf_free(&WORD1);
+    buf_free(&WORD2);
+    buf_free(&WORD3);
+    buf_free(&WORD4);
+}
+
+/* vim: set ft=c: */

--- a/cunit/dynarray.testc
+++ b/cunit/dynarray.testc
@@ -14,7 +14,7 @@ static void test_basic(void)
     CU_ASSERT_PTR_NULL(dynarray_nth(da, -1));
 
     uint32_t val1 = 0xbeefc0de;
-	dynarray_append(da, &val1);
+    dynarray_append(da, &val1);
 
     CU_ASSERT_EQUAL(dynarray_size(da), 1);
     valp = dynarray_nth(da, 0);
@@ -23,7 +23,7 @@ static void test_basic(void)
     CU_ASSERT_EQUAL(*valp, val1);
 
     uint32_t val2 = 0x00c0fefe;
-	dynarray_append(da, &val2);
+    dynarray_append(da, &val2);
 
     CU_ASSERT_EQUAL(dynarray_size(da), 2);
     valp = dynarray_nth(da, 1);
@@ -37,6 +37,40 @@ static void test_basic(void)
 
 #define CU_ASSERT_MEMEQUAL(actual, expected, sz) \
     CU_ASSERT_EQUAL(memcmp(actual, expected, sz), 0)
+
+static void test_set(void)
+{
+    struct dynarray *da = dynarray_new(sizeof(uint32_t));
+    uint32_t val;
+    const uint32_t zero = 0;
+
+    CU_ASSERT_EQUAL(da->count, 0);
+    CU_ASSERT_PTR_NULL(dynarray_nth(da, 0));
+    CU_ASSERT_PTR_NULL(dynarray_nth(da, -1));
+
+    val = 0xdeadbeef;
+    dynarray_set(da, 5, &val);
+    CU_ASSERT(da->count >= 6);
+    CU_ASSERT(da->alloc >= da->count);
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 0), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 1), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 2), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 3), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 4), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 5), &val, sizeof(val));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, -1), &val, sizeof(val));
+
+    dynarray_set(da, 2, &val);
+    CU_ASSERT(da->count >= 3);
+    CU_ASSERT(da->alloc >= da->count);
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 0), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 1), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 2), &val, sizeof(val));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 3), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 4), &zero, sizeof(zero));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, 5), &val, sizeof(val));
+    CU_ASSERT_MEMEQUAL(dynarray_nth(da, -1), &val, sizeof(val));
+}
 
 static void test_truncate(void)
 {

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -570,7 +570,7 @@ static int _conversations_set_key(struct conversations_state *state,
     int r;
     struct buf buf = BUF_INITIALIZER;
     int version = CONVERSATIONS_KEY_VERSION;
-    int i;
+    size_t i;
 
     /* XXX: should this be a delete operation? */
     assert(cids->count);

--- a/imap/message.c
+++ b/imap/message.c
@@ -3645,7 +3645,7 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
     char *msubj = NULL;
     char *msubj_oldstyle = NULL;
     int i;
-    int j;
+    size_t j;
     int r = 0;
     struct mailbox *local_mailbox = NULL;
 

--- a/lib/arrayu64.c
+++ b/lib/arrayu64.c
@@ -48,6 +48,7 @@
 #include <string.h>
 
 #include "arrayu64.h"
+#include "util.h"
 #include "xmalloc.h"
 
 EXPORTED arrayu64_t *arrayu64_new(void)
@@ -74,11 +75,22 @@ EXPORTED void arrayu64_free(arrayu64_t *au)
 }
 
 #define QUANTUM     16
+static inline size_t grow(size_t have, size_t want)
+{
+    size_t x = MAX(QUANTUM, have);
+    while (x < want)
+        x *= 2;
+    return x;
+}
+
+/* XXX n.b. unlike some other ensure_allocs, this one doesn't always
+ * XXX leave an extra NULL at the end.
+ */
 static void ensure_alloc(arrayu64_t *au, size_t newalloc)
 {
     if (newalloc <= au->alloc)
         return;
-    newalloc = ((newalloc + QUANTUM-1) / QUANTUM) * QUANTUM;
+    newalloc = grow(au->alloc, newalloc);
     au->data = xrealloc(au->data, sizeof(uint64_t) * newalloc);
     memset(au->data + au->alloc, 0, sizeof(uint64_t) * (newalloc - au->alloc));
     au->alloc = newalloc;

--- a/lib/arrayu64.h
+++ b/lib/arrayu64.h
@@ -52,8 +52,8 @@
 
 typedef struct
 {
-    int count;
-    int alloc;
+    size_t count;
+    size_t alloc;
     uint64_t *data;
 } arrayu64_t;
 
@@ -72,7 +72,7 @@ uint64_t arrayu64_remove(arrayu64_t *, int idx);
 /* returns number removed */
 int arrayu64_remove_all(arrayu64_t *, uint64_t);
 uint64_t arrayu64_nth(const arrayu64_t *, int idx);
-void arrayu64_truncate(arrayu64_t *, int newlen);
+void arrayu64_truncate(arrayu64_t *, size_t newlen);
 arrayu64_t *arrayu64_dup(const arrayu64_t *);
 
 uint64_t arrayu64_max(const arrayu64_t *);

--- a/lib/bufarray.c
+++ b/lib/bufarray.c
@@ -72,7 +72,7 @@ EXPORTED void bufarray_fini(bufarray_t *ba)
 
 EXPORTED void bufarray_free(bufarray_t **ba)
 {
-    if (!*ba)
+    if (!ba || !*ba)
         return;
     bufarray_fini(*ba);
     free(*ba);
@@ -101,6 +101,7 @@ EXPORTED bufarray_t *bufarray_dup(const bufarray_t *ba)
 
     bufarray_truncate(new, ba->count);
     for (i = 0 ; i < ba->count ; i++) {
+        new->items[i] = buf_new();
         buf_setmap(new->items[i], ba->items[i]->s, ba->items[i]->len);
     }
 

--- a/lib/bufarray.c
+++ b/lib/bufarray.c
@@ -79,16 +79,24 @@ EXPORTED void bufarray_free(bufarray_t **ba)
     *ba = NULL;
 }
 
+#define QUANTUM     16
+static inline size_t grow(size_t have, size_t want)
+{
+    size_t x = MAX(QUANTUM, have);
+    while (x < want)
+        x *= 2;
+    return x;
+}
+
 /*
- * Ensure the index @idx exists in the array, if necessary expanding the
+ * Ensure the index @newalloc exists in the array, if necessary expanding the
  * array, and if necessary NULL-filling all the intervening elements.
  */
-#define QUANTUM     16
 static void ba_ensure_alloc(bufarray_t *ba, size_t newalloc)
 {
     if (newalloc < ba->alloc)
         return;
-    newalloc = ((newalloc + QUANTUM) / QUANTUM) * QUANTUM;
+    newalloc = grow(ba->alloc, newalloc + 1);
     ba->items = xrealloc(ba->items, sizeof(struct buf) * newalloc);
     memset(ba->items + ba->alloc, 0, sizeof(struct buf) * (newalloc - ba->alloc));
     ba->alloc = newalloc;

--- a/lib/dynarray.c
+++ b/lib/dynarray.c
@@ -158,6 +158,8 @@ EXPORTED void dynarray_set(struct dynarray *da, int idx, void *memb)
     if ((idx = adjust_index_rw(da, idx, 0)) < 0)
         return;
     memcpy(da->data + idx * da->membsize, memb, da->membsize);
+    if (idx >= da->count)
+        da->count = idx + 1;
 }
 
 EXPORTED void *dynarray_nth(const struct dynarray *da, int idx)

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -75,19 +75,27 @@ EXPORTED void strarray_free(strarray_t *sa)
     free(sa);
 }
 
+#define QUANTUM     16
+static inline int grow(int have, int want)
+{
+    int x = MAX(QUANTUM, have);
+    while (x < want)
+        x *= 2;
+    return x;
+}
+
 /*
- * Ensure the index @idx exists in the array, if necessary expanding the
+ * Ensure the index @newalloc exists in the array, if necessary expanding the
  * array, and if necessary NULL-filling all the intervening elements.
  * Note that we always ensure an empty slot past the last reported
  * index, so that we can pass data[] to execve() or other routines that
  * assume a NULL terminator.
  */
-#define QUANTUM     16
 static void ensure_alloc(strarray_t *sa, int newalloc)
 {
     if (newalloc < sa->alloc)
         return;
-    newalloc = ((newalloc + QUANTUM) / QUANTUM) * QUANTUM;
+    newalloc = grow(sa->alloc, newalloc + 1);
     sa->data = xrealloc(sa->data, sizeof(char *) * newalloc);
     memset(sa->data + sa->alloc, 0, sizeof(char *) * (newalloc - sa->alloc));
     sa->alloc = newalloc;


### PR DESCRIPTION
This changes our dynamic array types to double in size each time they need to grow, rather than always growing by 16 elements at a time.  This potentially costs a little more memory usage, but reduces reallocation overheads.  The first allocation is still always 16 elements -- we're not wasting time stepping up through 1, 2, 4, 8 first!

Specifically, these modules have been changed to double in size:

- lib/arrayu64.c
- lib/bufarray.c
- lib/dynarray.c
- lib/ptrarray.c
- lib/strarray.c

I have left lib/bitvector.c alone for now, even though its growth is similar (256 bits at a time), because it's more complicated and I'm not sure it's useful to change -- though let me know if you disagree!

I've added tests for arrayu64 and bufarray, which previously didn't have any, and dynarray, which had very low coverage, and then fixed some bugs that the new tests exposed.

There's a lot of API variation between these modules, especially wrt using `int` vs `size_t`, whether `fooarray_nth()` accepts a perl-style negative index, whether or not there's always a NULL element at the end, etc, even though they're superficially similar.  It would be nice to consolidate them sometime, but that feels like a rabbit hole and I'm leaving it alone for now.

Reviewers: please build this and also run the tests.  Thanks :)

Closes #3439