### PR TITLE
Server annotation replication

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -2878,24 +2878,24 @@ static int write_entry(struct mailbox *mailbox,
 
     keylen = make_key(mboxname, uid, entry, userid, key, sizeof(key));
 
-    if (mailbox) {
-        struct annotate_metadata oldmdata;
-        r = read_old_value(d, key, keylen, &oldval, &oldmdata);
+    struct annotate_metadata oldmdata;
+    r = read_old_value(d, key, keylen, &oldval, &oldmdata);
+    if (r) goto out;
+
+    /* if the value is identical, don't touch the mailbox */
+    if (oldval.len == value->len && (!value->len || !memcmp(oldval.s, value->s, value->len)))
+        goto out;
+
+    if (!maywrite) {
+        r = IMAP_PERMISSION_DENIED;
         if (r) goto out;
+    }
 
-        /* if the value is identical, don't touch the mailbox */
-        if (oldval.len == value->len && (!value->len || !memcmp(oldval.s, value->s, value->len)))
-            goto out;
-
+    if (mailbox) {
         if (!ignorequota) {
             quota_t qdiffs[QUOTA_NUMRESOURCES] = QUOTA_DIFFS_DONTCARE_INITIALIZER;
             qdiffs[QUOTA_ANNOTSTORAGE] = value->len - (quota_t)oldval.len;
             r = mailbox_quota_check(mailbox, qdiffs);
-            if (r) goto out;
-        }
-
-        if (!maywrite) {
-            r = IMAP_PERMISSION_DENIED;
             if (r) goto out;
         }
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3479,19 +3479,26 @@ int sync_apply_annotation(struct dlist *kin, struct sync_state *sstate)
         return IMAP_PROTOCOL_BAD_PARAMETERS;
     buf_init_ro(&value, mapval, maplen);
 
-    r = mailbox_open_iwl(mboxname, &mailbox);
-    if (!r) r = sync_mailbox_version_check(&mailbox);
-    if (r) goto done;
-
     appendattvalue(&attvalues,
                    *userid ? "value.priv" : "value.shared",
                    &value);
     appendentryatt(&entryatts, entry, attvalues);
+
     astate = annotate_state_new();
+    if (*mboxname) {
+        r = mailbox_open_iwl(mboxname, &mailbox);
+        if (r) goto done;
+        r = sync_mailbox_version_check(&mailbox);
+        if (r) goto done;
+        r = annotate_state_set_mailbox(astate, mailbox);
+        if (r) goto done;
+    }
+    else {
+        r = annotate_state_set_server(astate);
+        if (r) goto done;
+    }
     annotate_state_set_auth(astate,
                             sstate->userisadmin, userid, sstate->authstate);
-    r = annotate_state_set_mailbox(astate, mailbox);
-    if (r) goto done;
 
     r = annotate_state_store(astate, entryatts);
 
@@ -3530,21 +3537,26 @@ int sync_apply_unannotation(struct dlist *kin, struct sync_state *sstate)
     if (!dlist_getatom(kin, "USERID", &userid))
         return IMAP_PROTOCOL_BAD_PARAMETERS;
 
-    r = mailbox_open_iwl(mboxname, &mailbox);
-    if (!r)
-        r = sync_mailbox_version_check(&mailbox);
-    if (r)
-        goto done;
-
     appendattvalue(&attvalues,
                    *userid ? "value.priv" : "value.shared",
                    &empty);
     appendentryatt(&entryatts, entry, attvalues);
+
     astate = annotate_state_new();
+    if (*mboxname) {
+        r = mailbox_open_iwl(mboxname, &mailbox);
+        if (r) goto done;
+        r = sync_mailbox_version_check(&mailbox);
+        if (r) goto done;
+        r = annotate_state_set_mailbox(astate, mailbox);
+        if (r) goto done;
+    }
+    else {
+        r = annotate_state_set_server(astate);
+        if (r) goto done;
+    }
     annotate_state_set_auth(astate,
                             sstate->userisadmin, userid, sstate->authstate);
-    r = annotate_state_set_mailbox(astate, mailbox);
-    if (r) goto done;
 
     r = annotate_state_store(astate, entryatts);
 


### PR DESCRIPTION
We ran into a production bug where a client was setting a per-server annotation to track some config for itself (a JSON blob).  It turns out that replication died on that.  Ouch.

This fixes this issue, and a related permissions issue found by the associated cassandane tests in https://github.com/cyrusimap/cassandane/pull/114
