### PR TITLE
jmap_mail: replace Email/query on-disk cache with in-memory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -646,7 +646,8 @@ cunit_TESTS = \
 	cunit/quota.testc \
 	cunit/rfc822tok.testc \
 	cunit/search_expr.testc \
-	cunit/seqset.testc
+	cunit/seqset.testc \
+	cunit/smallarrayu64.testc
 
 if SIEVE
 cunit_TESTS += cunit/sieve.testc
@@ -787,6 +788,7 @@ include_HEADERS = \
 	lib/retry.h \
 	lib/rfc822tok.h \
 	lib/signals.h \
+	lib/smallarrayu64.h \
 	lib/sqldb.h \
 	lib/strarray.h \
 	lib/strhash.h \
@@ -1530,6 +1532,7 @@ lib_libcyrus_min_la_SOURCES = \
 	lib/libconfig.c \
 	lib/mpool.c \
 	lib/retry.c \
+	lib/smallarrayu64.c \
 	lib/strarray.c \
 	lib/strhash.c \
 	lib/util.c \

--- a/cunit/smallarrayu64.testc
+++ b/cunit/smallarrayu64.testc
@@ -1,0 +1,82 @@
+#include "cunit/cyrunit.h"
+#include "xmalloc.h"
+#include "smallarrayu64.h"
+
+static void test_fini_null(void)
+{
+    /* _fini(NULL) is harmless */
+    smallarrayu64_fini(NULL);
+    /* _free(NULL) is harmless */
+    smallarrayu64_free(NULL);
+}
+
+static void test_append(void)
+{
+    smallarrayu64_t sa = SMALLARRAYU64_INITIALIZER;
+
+    /* Append small integers until prealloc buffer is full */
+    int i;
+    for (i = 0; i < SMALLARRAYU64_ALLOC; i++) {
+        smallarrayu64_append(&sa, i);
+        CU_ASSERT_EQUAL(smallarrayu64_size(&sa), i + 1);
+        CU_ASSERT_EQUAL(sa.use_spillover, i == SMALLARRAYU64_ALLOC - 1);
+        CU_ASSERT_EQUAL(sa.spillover.count, 0);
+    }
+
+    /* Append next integer */
+    smallarrayu64_append(&sa, SMALLARRAYU64_ALLOC);
+    CU_ASSERT_EQUAL(smallarrayu64_size(&sa), SMALLARRAYU64_ALLOC + 1);
+    CU_ASSERT_EQUAL(sa.count, SMALLARRAYU64_ALLOC);
+    CU_ASSERT_EQUAL(sa.use_spillover, 1);
+    CU_ASSERT_EQUAL(sa.spillover.count, 1);
+
+    smallarrayu64_fini(&sa);
+}
+
+static void test_append_largenum(void)
+{
+    smallarrayu64_t sa = SMALLARRAYU64_INITIALIZER;
+
+    smallarrayu64_append(&sa, 12);
+    smallarrayu64_append(&sa, 24);
+    smallarrayu64_append(&sa, 36);
+
+    CU_ASSERT_EQUAL(sa.count, 3);
+    CU_ASSERT_EQUAL(sa.use_spillover, 0);
+    CU_ASSERT_EQUAL(sa.spillover.count, 0);
+
+    smallarrayu64_append(&sa, 2222222L);
+
+    CU_ASSERT_EQUAL(sa.count, 3);
+    CU_ASSERT_EQUAL(sa.use_spillover, 1);
+    CU_ASSERT_EQUAL(sa.spillover.count, 1);
+
+    smallarrayu64_fini(&sa);
+}
+
+static void test_nth(void)
+{
+    smallarrayu64_t sa = SMALLARRAYU64_INITIALIZER;
+    uint64_t vals[] = { 12L, 24L, 36L, 2222222L, 48L };
+    ssize_t nvals = sizeof(vals) / sizeof(vals[0]);
+
+    ssize_t i;
+    for (i = 0; i < nvals; i++) {
+        smallarrayu64_append(&sa, vals[i]);
+    }
+    for (i = 0; i < nvals; i++) {
+        CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, i), vals[i]);
+    }
+
+    /* negative index */
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, -nvals), vals[0]);
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, -1), vals[nvals-1]);
+
+    /* out of index */
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, nvals), 0);
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, -nvals-1), 0);
+
+    smallarrayu64_fini(&sa);
+}
+
+/* vim: set ft=c: */

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -54,8 +54,7 @@
 #include "search_sort.h"
 
 typedef int (*search_hit_cb_t)(const char *mboxname, uint32_t uidvalidity,
-                               uint32_t uid, const strarray_t *partids,
-                               void *rock);
+                               uint32_t uid, const char *partid, void *rock);
 
 typedef int (*search_hitguid_cb_t)(const conv_guidrec_t *rec, size_t nguids,
                                    void *rock);

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -450,8 +450,7 @@ static int run(search_builder_t *bx, search_hit_cb_t proc, void *rock)
     for (uid = 1 ; uid <= bb->mailbox->i.last_uid; uid++) {
         if (bv_isset(&bb->stack[0].msg_vector, uid)) {
             r = proc(bb->mailbox->name,
-                     bb->mailbox->i.uidvalidity,
-                     uid, NULL, rock);
+                     bb->mailbox->i.uidvalidity, uid, NULL, rock);
             if (r) goto out;
         }
     }

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -528,8 +528,7 @@ error:
 }
 
 static int print_search_hit(const char *mboxname, uint32_t uidvalidity,
-                            uint32_t uid,
-                            const strarray_t *partids __attribute__((unused)),
+                            uint32_t uid, const char *partid __attribute__((unused)),
                             void *rock)
 {
     int single = *(int *)rock;

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1121,10 +1121,19 @@ Blank lines and lines beginning with ``#'' are ignored.
    the same has to be done (cyr_dbtool) for each subscription database
    See improved_mboxlist_sort.html.*/
 
-{ "jmap_emailsearch_db_path", NULL, STRING, "3.1.6" }
+{ "jmap_emailsearch_db_path", NULL, STRING, "3.1.6", "UNRELEASED" }
 /* The absolute path to the JMAP email search cache file.  If not
    specified, JMAP Email/query and Email/queryChanges will not
    cache email search results. */
+
+{ "jmap_querycache_max_age", "0m", DURATION, "UNRELEASED" }
+/* The duration after which unused cached JMAP query results
+   must be evicted from process memory. If non-zero, then the
+   full result of the last query (before windowing) is stored
+   in-memory. Subsequent queries with the same expression and
+   query state can then page through the cached result.
+   A zero value disables query result caching.
+   This feature currently only is enabled for Email/query. */
 
 { "jmap_preview_annot", NULL, STRING, "3.1.1" }
 /* The name of the per-message annotation, if any, to store message

--- a/lib/smallarrayu64.c
+++ b/lib/smallarrayu64.c
@@ -1,0 +1,69 @@
+#include <assert.h>
+#include <config.h>
+#include <string.h>
+
+#include "smallarrayu64.h"
+#include "xmalloc.h"
+
+EXPORTED smallarrayu64_t *smallarrayu64_new(void)
+{
+    return xzmalloc(sizeof(smallarrayu64_t));
+}
+
+EXPORTED void smallarrayu64_fini(smallarrayu64_t *sa)
+{
+    if (!sa) return;
+    arrayu64_fini(&sa->spillover);
+    sa->count = 0;
+    sa->use_spillover = 0;
+}
+
+EXPORTED void smallarrayu64_free(smallarrayu64_t *sa)
+{
+    if (!sa) return;
+    smallarrayu64_fini(sa);
+    free(sa);
+}
+
+EXPORTED int smallarrayu64_append(smallarrayu64_t *sa, uint64_t num)
+{
+    if (sa->count < SMALLARRAYU64_ALLOC && !sa->use_spillover) {
+        if (num <= UINT8_MAX) {
+            sa->data[sa->count++] = num;
+            if (sa->count == SMALLARRAYU64_ALLOC) {
+                sa->use_spillover = 1;
+            }
+            return sa->count;
+        }
+        /* can't store num in preallocated data */
+        sa->use_spillover = 1;
+    }
+    return arrayu64_append(&sa->spillover, num);
+}
+
+EXPORTED size_t smallarrayu64_size(smallarrayu64_t *sa)
+{
+    return sa->count + arrayu64_size(&sa->spillover);
+}
+
+static inline int adjust_index_ro(const smallarrayu64_t *sa, int idx)
+{
+    size_t count = sa->count + arrayu64_size(&sa->spillover);
+    if (idx >= 0 && (unsigned) idx >= count)
+        return -1;
+    else if (idx < 0)
+        idx += count;
+    return idx;
+}
+
+EXPORTED uint64_t smallarrayu64_nth(smallarrayu64_t *sa, int idx)
+{
+    if ((idx = adjust_index_ro(sa, idx)) < 0)
+        return 0;
+    if ((size_t)idx < sa->count) {
+        return sa->data[idx];
+    }
+    else {
+        return arrayu64_nth(&sa->spillover, idx - sa->count);
+    }
+}

--- a/lib/smallarrayu64.h
+++ b/lib/smallarrayu64.h
@@ -1,0 +1,78 @@
+/* smallarrayu64.h - an expanding array of 64 bit unsigned integers
+ *
+ * Copyright (c) 1994-2011 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Author: Greg Banks
+ * Start Date: 2011/01/11
+ */
+
+#ifndef __CYRUS_SMALLARRAYU64_H__
+#define __CYRUS_SMALLARRAYU64_H__
+
+#include <sys/types.h>
+
+#include <stdint.h>
+
+#include "arrayu64.h"
+
+#define SMALLARRAYU64_ALLOC 8
+
+typedef struct {
+    size_t count;
+    uint8_t data[SMALLARRAYU64_ALLOC];
+    arrayu64_t spillover;
+    int use_spillover;
+} smallarrayu64_t;
+
+#define SMALLARRAYU64_INITIALIZER { 0, { 0 }, ARRAYU64_INITIALIZER, 0 }
+
+#define smallarrayu64_init(sa)   (memset((sa), 0, sizeof(smallarrayu64_t)))
+extern void smallarrayu64_fini(smallarrayu64_t *sa);
+
+extern smallarrayu64_t *smallarrayu64_new(void);
+extern void smallarrayu64_free(smallarrayu64_t *);
+
+extern int smallarrayu64_append(smallarrayu64_t *sa, uint64_t num);
+
+extern size_t smallarrayu64_size(smallarrayu64_t *sa);
+
+extern uint64_t smallarrayu64_nth(smallarrayu64_t *sa, int idx);
+
+#endif /* __CYRUS_SMALLARRAYU64_H__ */


### PR DESCRIPTION
Replaces the on-disk Email/query cache with an in-memory cache. This allows to speed up consecutive email queries that page through the overall result.

As the cache is stored in memory, this only benefits requests over web sockets or kept-alive HTTP connections.

Config changes:

Deprecates the `jmap_emailsearch_db_path` option.
Introduces the `jmap_querycache_max_age` option.

Tested in https://github.com/cyrusimap/cassandane/tree/jmap_emailquery_cache_inprocess
