### PR TITLE
Mboxevent jmap email v2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1013,6 +1013,8 @@ imap_libcyrus_imap_la_SOURCES = \
 	imap/imapparse.h \
 	imap/index.c \
 	imap/index.h \
+	imap/jmap_util.c \
+	imap/jmap_util.h \
 	imap/json_support.h \
 	imap/mailbox.c \
 	imap/mailbox.h \
@@ -1326,8 +1328,6 @@ nodist_imap_httpd_SOURCES += \
 	imap/jmap_err.h
 
 imap_libcyrus_imap_la_SOURCES += \
-	imap/jmap_util.c \
-	imap/jmap_util.h \
 	imap/json_support.c \
 	imap/json_support.h
 

--- a/changes/next/mboxevent_jmap_email
+++ b/changes/next/mboxevent_jmap_email
@@ -1,0 +1,17 @@
+Description:
+
+Adds the 'vnd.cmu.jmapEmail' selector to the 'event_extra_params' option
+which will include a JMAP Email object in the event message.
+
+Config changes:
+
+The 'vnd.cmu.jmapEmail' selector to the 'event_extra_params' option can be
+more parser friendly than 'vnd.cmu.envelope' and includes the same data,
+plus the 'emailId' and 'threadId' data items. 
+
+
+Upgrade instructions:
+
+When adding 'vnd.cmu.jmapEmail' it would make sense to remove all of
+'vnd.cmu.envelope', 'vnd.cmu.emailid', and 'vnd.cmu.threadid' as these
+would add redundant data to the event message.

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1104,27 +1104,6 @@ HIDDEN void jmap_closembox(jmap_req_t *req, struct mailbox **mboxp)
     syslog(LOG_INFO, "jmap: ignoring non-cached mailbox %s", (*mboxp)->name);
 }
 
-HIDDEN void jmap_set_blobid(const struct message_guid *guid, char *buf)
-{
-    buf[0] = 'G';
-    memcpy(buf+1, message_guid_encode(guid), 40);
-    buf[41] = '\0';
-}
-
-HIDDEN void jmap_set_emailid(const struct message_guid *guid, char *buf)
-{
-    buf[0] = 'M';
-    // appends NULL for us
-    bin_to_lchex(&guid->value, 12, buf+1);
-}
-
-HIDDEN void jmap_set_threadid(conversation_id_t cid, char *buf)
-{
-    buf[0] = 'T';
-    memcpy(buf+1, conversation_id_encode(cid), 16);
-    buf[17] = 0;
-}
-
 struct findblob_data {
     jmap_req_t *req;
     const char *from_accountid;

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -289,15 +289,6 @@ extern int jmap_findblob_exact(jmap_req_t *req, const char *accountid,
                                struct mailbox **mbox, msgrecord_t **mr,
                                struct buf *blob);
 
-#define JMAP_BLOBID_SIZE 42
-extern void jmap_set_blobid(const struct message_guid *guid, char *buf);
-
-#define JMAP_EMAILID_SIZE 26
-extern void jmap_set_emailid(const struct message_guid *guid, char *buf);
-
-#define JMAP_THREADID_SIZE 18
-extern void jmap_set_threadid(conversation_id_t cid, char *buf);
-
 /* JMAP states */
 extern json_t* jmap_getstate(jmap_req_t *req, int mbtype, int refresh);
 extern json_t *jmap_fmtstate(modseq_t modseq);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -361,45 +361,10 @@ static char *_decode_to_utf8(const char *charset,
     return cbuf ? cbuf : xstrdupnull(cval);
 }
 
-static char *_decode_mimeheader(const char *raw)
-{
-    if (!raw) return NULL;
-
-    int is_8bit = 0;
-    const char *p;
-    for (p = raw; *p; p++) {
-        if (*p & 0x80) {
-            is_8bit = 1;
-            break;
-        }
-    }
-
-    char *val = NULL;
-    if (is_8bit) {
-        int err = 0;
-        val = _decode_to_utf8("utf-8", raw, strlen(raw), NULL, &err);
-    }
-    if (!val) {
-        val = charset_decode_mimeheader(raw, CHARSET_KEEPCASE);
-    }
-    return val;
-}
-
 struct headers {
     json_t *raw; /* JSON array of EmailHeader */
     json_t *all; /* JSON object: lower-case header name => list of values */
     struct buf buf;
-};
-
-enum header_form {
-    HEADER_FORM_UNKNOWN          = 0, /* MUST be zero so we can cast to void* */
-    HEADER_FORM_RAW              = 1 << 0,
-    HEADER_FORM_TEXT             = 1 << 1,
-    HEADER_FORM_ADDRESSES        = 1 << 2,
-    HEADER_FORM_GROUPEDADDRESSES = 1 << 3,
-    HEADER_FORM_MESSAGEIDS       = 1 << 4,
-    HEADER_FORM_DATE             = 1 << 5,
-    HEADER_FORM_URLS             = 1 << 6
 };
 
 #define HEADERS_INITIALIZER \
@@ -482,257 +447,6 @@ static int _headers_from_mime_cb(const char *key, const char *val, void *_rock)
 static void _headers_from_mime(const char *base, size_t len, struct headers *headers)
 {
     message_foreach_header(base, len, _headers_from_mime_cb, headers);
-}
-
-static json_t *_header_as_raw(const char *raw, enum header_form form __attribute__((unused)))
-{
-    if (!raw) return json_null();
-    size_t len = strlen(raw);
-    if (len > 1 && raw[len-1] == '\n' && raw[len-2] == '\r') len -= 2;
-    return json_stringn(raw, len);
-}
-
-static json_t *_header_as_date(const char *raw, enum header_form form __attribute__((unused)))
-{
-    if (!raw) return json_null();
-
-    time_t t;
-    if (time_from_rfc5322(raw, &t, DATETIME_FULL) == -1) {
-        if (!strchr(raw, '\r')) return json_null();
-        char *tmp = charset_unfold(raw, strlen(raw), CHARSET_UNFOLD_SKIPWS);
-        int r = time_from_rfc5322(tmp, &t, DATETIME_FULL);
-        free(tmp);
-        if (r == -1) return json_null();
-    }
-
-    char cbuf[RFC3339_DATETIME_MAX+1];
-    cbuf[RFC3339_DATETIME_MAX] = '\0';
-    time_to_rfc3339(t, cbuf, RFC3339_DATETIME_MAX+1);
-    return json_string(cbuf);
-}
-
-static json_t *_header_as_text(const char *raw, enum header_form form __attribute__((unused)))
-{
-    if (!raw) return json_null();
-
-    /* TODO this could be optimised to omit unfolding, decoding
-     * or normalisation, or all, if ASCII */
-    /* Unfold and remove CRLF */
-    char *unfolded = charset_unfold(raw, strlen(raw), 0);
-    char *p = strchr(unfolded, '\r');
-    while (p && *(p + 1) != '\n') {
-        p = strchr(p + 1, '\r');
-    }
-    if (p) *p = '\0';
-
-    /* Trim starting SP */
-    const char *trimmed = unfolded;
-    while (isspace(*trimmed)) {
-        trimmed++;
-    }
-
-    /* Decode header */
-    char *decoded = _decode_mimeheader(trimmed);
-
-    /* Convert to Unicode NFC */
-    char *normalized = charset_utf8_normalize(decoded);
-
-    json_t *result = json_string(normalized);
-    free(normalized);
-    free(decoded);
-    free(unfolded);
-    return result;
-}
-
-static void _remove_ws(char *s)
-{
-    char *d = s;
-    do {
-        while (isspace(*s))
-            s++;
-    } while ((*d++ = *s++));
-}
-
-static json_t *_header_as_messageids(const char *raw, enum header_form form __attribute__((unused)))
-{
-    if (!raw) return json_null();
-    json_t *msgids = json_array();
-    char *unfolded = charset_unfold(raw, strlen(raw), CHARSET_UNFOLD_SKIPWS);
-
-    const char *p = unfolded;
-
-    while (*p) {
-        /* Skip preamble */
-        while (isspace(*p) || *p == ',') p++;
-        if (!*p) break;
-
-        /* Find end of id */
-        const char *q = p;
-        if (*p == '<') {
-            while (*q && *q != '>') q++;
-        }
-        else {
-            while (*q && !isspace(*q)) q++;
-        }
-
-        /* Read id */
-        char *val = xstrndup(*p == '<' ? p + 1 : p,
-                             *q == '>' ? q - p - 1 : q - p);
-        if (*p == '<') {
-            _remove_ws(val);
-        }
-        if (*val) {
-            /* calculate the value that would be created if this was
-             * fed back into an Email/set and make sure it would
-             * validate */
-            char *msgid = strconcat("<", val, ">", NULL);
-            int r = conversations_check_msgid(msgid, strlen(msgid));
-            if (!r) json_array_append_new(msgids, json_string(val));
-            free(msgid);
-        }
-        free(val);
-
-        /* Reset iterator */
-        p = *q ? q + 1 : q;
-    }
-
-
-    if (!json_array_size(msgids)) {
-        json_decref(msgids);
-        msgids = json_null();
-    }
-    free(unfolded);
-    return msgids;
-}
-
-static json_t *_emailaddresses_from_addr(struct address *addr, enum header_form form)
-{
-    if (!addr) return json_null();
-
-    json_t *result = json_array();
-
-    const char *groupname = NULL;
-    json_t *addresses = json_array();
-
-    struct buf buf = BUF_INITIALIZER;
-    while (addr) {
-        const char *domain = addr->domain;
-        if (!strcmpsafe(domain, "unspecified-domain")) {
-            domain = NULL;
-        }
-        if (!addr->name && addr->mailbox && !domain) {
-            /* Start of group. */
-            if (form == HEADER_FORM_GROUPEDADDRESSES) {
-                if (form == HEADER_FORM_GROUPEDADDRESSES) {
-                    if (groupname || json_array_size(addresses)) {
-                        json_t *group = json_object();
-                        json_object_set_new(group, "name",
-                                groupname ? json_string(groupname) : json_null());
-                        json_object_set_new(group, "addresses", addresses);
-                        json_array_append_new(result, group);
-                        addresses = json_array();
-                    }
-                    groupname = NULL;
-                }
-                groupname = addr->mailbox;
-            }
-        }
-        else if (!addr->name && !addr->mailbox) {
-            /* End of group */
-            if (form == HEADER_FORM_GROUPEDADDRESSES) {
-                if (groupname || json_array_size(addresses)) {
-                    json_t *group = json_object();
-                    json_object_set_new(group, "name",
-                            groupname ? json_string(groupname) : json_null());
-                    json_object_set_new(group, "addresses", addresses);
-                    json_array_append_new(result, group);
-                    addresses = json_array();
-                }
-                groupname = NULL;
-            }
-        }
-        else {
-            /* Regular address */
-            json_t *jemailaddr = json_object();
-            if (addr->name) {
-                char *tmp = _decode_mimeheader(addr->name);
-                if (tmp) json_object_set_new(jemailaddr, "name", json_string(tmp));
-                free(tmp);
-            } else {
-                json_object_set_new(jemailaddr, "name", json_null());
-            }
-            if (addr->mailbox) {
-                buf_setcstr(&buf, addr->mailbox);
-                if (domain) {
-                    buf_putc(&buf, '@');
-                    buf_appendcstr(&buf, domain);
-                }
-                json_object_set_new(jemailaddr, "email", json_string(buf_cstring(&buf)));
-                buf_reset(&buf);
-            } else {
-                json_object_set_new(jemailaddr, "email", json_null());
-            }
-            json_array_append_new(addresses, jemailaddr);
-        }
-        addr = addr->next;
-    }
-    buf_free(&buf);
-
-    if (form == HEADER_FORM_GROUPEDADDRESSES) {
-        if (groupname || json_array_size(addresses)) {
-            json_t *group = json_object();
-            json_object_set_new(group, "name",
-                    groupname ? json_string(groupname) : json_null());
-            json_object_set_new(group, "addresses", addresses);
-            json_array_append_new(result, group);
-        }
-        else json_decref(addresses);
-    }
-    else {
-        json_decref(result);
-        result = addresses;
-    }
-
-    return result;
-}
-
-
-static json_t *_header_as_addresses(const char *raw, enum header_form form)
-{
-    if (!raw) return json_null();
-
-    struct address *addrs = NULL;
-    parseaddr_list(raw, &addrs);
-    json_t *result = _emailaddresses_from_addr(addrs, form);
-    parseaddr_free(addrs);
-    return result;
-}
-
-static json_t *_header_as_urls(const char *raw, enum header_form form __attribute__((unused)))
-{
-    if (!raw) return json_null();
-
-    /* A poor man's implementation of RFC 2369, returning anything
-     * between < and >. */
-    json_t *urls = json_array();
-    const char *base = raw;
-    const char *top = raw + strlen(raw);
-    while (base < top) {
-        const char *lo = strchr(base, '<');
-        if (!lo) break;
-        const char *hi = strchr(lo, '>');
-        if (!hi) break;
-        char *tmp = charset_unfold(lo + 1, hi - lo - 1, CHARSET_UNFOLD_SKIPWS);
-        _remove_ws(tmp);
-        if (*tmp) json_array_append_new(urls, json_string(tmp));
-        free(tmp);
-        base = hi + 1;
-    }
-    if (!json_array_size(urls)) {
-        json_decref(urls);
-        urls = json_null();
-    }
-    return urls;
 }
 
 struct header_prop {
@@ -6370,31 +6084,31 @@ static json_t * _email_get_header(struct cyrusmsg *msg,
         json_t *jval = NULL;
         if (!strcmp("messageId", lcasename)) {
             jval = want_form == HEADER_FORM_MESSAGEIDS ?
-                _header_as_messageids(part->message_id, want_form) : json_null();
+                jmap_header_as_messageids(part->message_id, want_form) : json_null();
         }
         else if (!strcmp("inReplyTo", lcasename)) {
             jval = want_form == HEADER_FORM_MESSAGEIDS ?
-                _header_as_messageids(part->in_reply_to, want_form) : json_null();
+                jmap_header_as_messageids(part->in_reply_to, want_form) : json_null();
         }
         if (!strcmp("subject", lcasename)) {
             jval = want_form == HEADER_FORM_TEXT ?
-                _header_as_text(part->subject, want_form) : json_null();
+                jmap_header_as_text(part->subject, want_form) : json_null();
         }
         if (!strcmp("from", lcasename)) {
             jval = want_form & (HEADER_FORM_ADDRESSES|HEADER_FORM_GROUPEDADDRESSES) ?
-                _emailaddresses_from_addr(part->from, want_form) : json_null();
+                jmap_emailaddresses_from_addr(part->from, want_form) : json_null();
         }
         else if (!strcmp("to", lcasename)) {
             jval = want_form & (HEADER_FORM_ADDRESSES|HEADER_FORM_GROUPEDADDRESSES) ?
-                _emailaddresses_from_addr(part->to, want_form) : json_null();
+                jmap_emailaddresses_from_addr(part->to, want_form) : json_null();
         }
         else if (!strcmp("cc", lcasename)) {
             jval = want_form & (HEADER_FORM_ADDRESSES|HEADER_FORM_GROUPEDADDRESSES) ?
-                _emailaddresses_from_addr(part->cc, want_form) : json_null();
+                jmap_emailaddresses_from_addr(part->cc, want_form) : json_null();
         }
         else if (!strcmp("bcc", lcasename)) {
             jval = want_form & (HEADER_FORM_ADDRESSES|HEADER_FORM_GROUPEDADDRESSES) ?
-                _emailaddresses_from_addr(part->bcc, want_form) : json_null();
+                jmap_emailaddresses_from_addr(part->bcc, want_form) : json_null();
         }
         else if (!strcmp("sentAt", lcasename)) {
             jval = json_null();
@@ -6414,23 +6128,23 @@ static json_t * _email_get_header(struct cyrusmsg *msg,
     json_t* (*conv)(const char *raw, enum header_form want_form);
     switch (want_form) {
         case HEADER_FORM_TEXT:
-            conv = _header_as_text;
+            conv = jmap_header_as_text;
             break;
         case HEADER_FORM_DATE:
-            conv = _header_as_date;
+            conv = jmap_header_as_date;
             break;
         case HEADER_FORM_ADDRESSES:
         case HEADER_FORM_GROUPEDADDRESSES:
-            conv = _header_as_addresses;
+            conv = jmap_header_as_addresses;
             break;
         case HEADER_FORM_MESSAGEIDS:
-            conv = _header_as_messageids;
+            conv = jmap_header_as_messageids;
             break;
         case HEADER_FORM_URLS:
-            conv = _header_as_urls;
+            conv = jmap_header_as_urls;
             break;
         default:
-            conv = _header_as_raw;
+            conv = jmap_header_as_raw;
     }
 
     /* Try to read the value from the index record or header cache */
@@ -6750,37 +6464,37 @@ static int _email_get_headers(jmap_req_t *req __attribute__((unused)),
     /* messageId */
     if (jmap_wantprop(props, "messageId")) {
         json_object_set_new(email, "messageId",
-                _header_as_messageids(part->message_id, HEADER_FORM_MESSAGEIDS));
+                jmap_header_as_messageids(part->message_id, HEADER_FORM_MESSAGEIDS));
     }
     /* inReplyTo */
     if (jmap_wantprop(props, "inReplyTo")) {
         json_object_set_new(email, "inReplyTo",
-                _header_as_messageids(part->in_reply_to, HEADER_FORM_MESSAGEIDS));
+                jmap_header_as_messageids(part->in_reply_to, HEADER_FORM_MESSAGEIDS));
     }
     /* from */
     if (jmap_wantprop(props, "from")) {
         json_object_set_new(email, "from",
-                _emailaddresses_from_addr(part->from, HEADER_FORM_ADDRESSES));
+                jmap_emailaddresses_from_addr(part->from, HEADER_FORM_ADDRESSES));
     }
     /* to */
     if (jmap_wantprop(props, "to")) {
         json_object_set_new(email, "to",
-                _emailaddresses_from_addr(part->to, HEADER_FORM_ADDRESSES));
+                jmap_emailaddresses_from_addr(part->to, HEADER_FORM_ADDRESSES));
     }
     /* cc */
     if (jmap_wantprop(props, "cc")) {
         json_object_set_new(email, "cc",
-                _emailaddresses_from_addr(part->cc, HEADER_FORM_ADDRESSES));
+                jmap_emailaddresses_from_addr(part->cc, HEADER_FORM_ADDRESSES));
     }
     /* bcc */
     if (jmap_wantprop(props, "bcc")) {
         json_object_set_new(email, "bcc",
-                _emailaddresses_from_addr(part->bcc, HEADER_FORM_ADDRESSES));
+                jmap_emailaddresses_from_addr(part->bcc, HEADER_FORM_ADDRESSES));
     }
     /* subject */
     if (jmap_wantprop(props, "subject")) {
         json_object_set_new(email, "subject",
-                _header_as_text(part->subject, HEADER_FORM_TEXT));
+                jmap_header_as_text(part->subject, HEADER_FORM_TEXT));
     }
     /* sentAt */
     if (jmap_wantprop(props, "sentAt")) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6113,12 +6113,7 @@ static json_t * _email_get_header(struct cyrusmsg *msg,
         else if (!strcmp("sentAt", lcasename)) {
             jval = json_null();
             if (want_form == HEADER_FORM_DATE) {
-                struct offsettime t;
-                if (offsettime_from_rfc5322(part->date, &t, DATETIME_FULL) != -1) {
-                    char datestr[30];
-                    offsettime_to_iso8601(&t, datestr, 30, 1);
-                    jval = json_string(datestr);
-                }
+                jval = jmap_header_as_date(part->date, HEADER_FORM_DATE);
             }
         }
         if (jval) return jval;
@@ -6498,14 +6493,8 @@ static int _email_get_headers(jmap_req_t *req __attribute__((unused)),
     }
     /* sentAt */
     if (jmap_wantprop(props, "sentAt")) {
-        json_t *jsent_at = json_null();
-        struct offsettime t;
-        if (offsettime_from_rfc5322(part->date, &t, DATETIME_FULL) != -1) {
-            char datestr[30];
-            offsettime_to_iso8601(&t, datestr, 30, 1);
-            jsent_at = json_string(datestr);
-        }
-        json_object_set_new(email, "sentAt", jsent_at);
+        json_object_set_new(email, "sentAt",
+                            jmap_header_as_date(part->date, HEADER_FORM_DATE));
     }
 
     return r;

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -849,3 +849,286 @@ done:
     }
     return is_valid;
 }
+
+EXPORTED json_t *jmap_header_as_raw(const char *raw,
+                                    enum header_form form __attribute__((unused)))
+{
+    if (!raw) return json_null();
+
+    size_t len = strlen(raw);
+    if (len > 1 && raw[len-1] == '\n' && raw[len-2] == '\r') len -= 2;
+    return json_stringn(raw, len);
+}
+
+static char *_decode_mimeheader(const char *raw)
+{
+    if (!raw) return NULL;
+
+    int is_8bit = 0;
+    const char *p;
+    for (p = raw; *p; p++) {
+        if (*p & 0x80) {
+            is_8bit = 1;
+            break;
+        }
+    }
+
+    char *val = NULL;
+    if (is_8bit) {
+        int r = 0;
+        const char *cval = jmap_decode_to_utf8("utf-8", ENCODING_NONE,
+                                               raw, strlen(raw), 0.0, &val, &r);
+        if (!val) val = xstrdupnull(cval);
+    }
+    if (!val) {
+        val = charset_decode_mimeheader(raw, CHARSET_KEEPCASE);
+    }
+    return val;
+}
+
+EXPORTED json_t *jmap_header_as_text(const char *raw,
+                                     enum header_form form __attribute__((unused)))
+{
+    if (!raw) return json_null();
+
+    /* TODO this could be optimised to omit unfolding, decoding
+     * or normalisation, or all, if ASCII */
+    /* Unfold and remove CRLF */
+    char *unfolded = charset_unfold(raw, strlen(raw), 0);
+    char *p = strchr(unfolded, '\r');
+    while (p && *(p + 1) != '\n') {
+        p = strchr(p + 1, '\r');
+    }
+    if (p) *p = '\0';
+
+    /* Trim starting SP */
+    const char *trimmed = unfolded;
+    while (isspace(*trimmed)) {
+        trimmed++;
+    }
+
+    /* Decode header */
+    char *decoded = _decode_mimeheader(trimmed);
+
+    /* Convert to Unicode NFC */
+    char *normalized = charset_utf8_normalize(decoded);
+
+    json_t *result = json_string(normalized);
+    free(normalized);
+    free(decoded);
+    free(unfolded);
+    return result;
+}
+
+EXPORTED json_t *jmap_header_as_date(const char *raw,
+                                     enum header_form form __attribute__((unused)))
+{
+    if (!raw) return json_null();
+
+    time_t t;
+    if (time_from_rfc5322(raw, &t, DATETIME_FULL) == -1) {
+        if (!strchr(raw, '\r')) return json_null();
+        char *tmp = charset_unfold(raw, strlen(raw), CHARSET_UNFOLD_SKIPWS);
+        int r = time_from_rfc5322(tmp, &t, DATETIME_FULL);
+        free(tmp);
+        if (r == -1) return json_null();
+    }
+
+    char cbuf[RFC3339_DATETIME_MAX+1];
+    cbuf[RFC3339_DATETIME_MAX] = '\0';
+    time_to_rfc3339(t, cbuf, RFC3339_DATETIME_MAX+1);
+    return json_string(cbuf);
+}
+
+static void _remove_ws(char *s)
+{
+    char *d = s;
+    do {
+        while (isspace(*s))
+            s++;
+    } while ((*d++ = *s++));
+}
+
+EXPORTED json_t *jmap_header_as_urls(const char *raw,
+                                     enum header_form form __attribute__((unused)))
+{
+    if (!raw) return json_null();
+
+    /* A poor man's implementation of RFC 2369, returning anything
+     * between < and >. */
+    json_t *urls = json_array();
+    const char *base = raw;
+    const char *top = raw + strlen(raw);
+    while (base < top) {
+        const char *lo = strchr(base, '<');
+        if (!lo) break;
+        const char *hi = strchr(lo, '>');
+        if (!hi) break;
+        char *tmp = charset_unfold(lo + 1, hi - lo - 1, CHARSET_UNFOLD_SKIPWS);
+        _remove_ws(tmp);
+        if (*tmp) json_array_append_new(urls, json_string(tmp));
+        free(tmp);
+        base = hi + 1;
+    }
+    if (!json_array_size(urls)) {
+        json_decref(urls);
+        urls = json_null();
+    }
+    return urls;
+}
+
+EXPORTED json_t *jmap_header_as_messageids(const char *raw,
+                                           enum header_form form __attribute__((unused)))
+{
+    if (!raw) return json_null();
+    json_t *msgids = json_array();
+    char *unfolded = charset_unfold(raw, strlen(raw), CHARSET_UNFOLD_SKIPWS);
+
+    const char *p = unfolded;
+
+    while (*p) {
+        /* Skip preamble */
+        while (isspace(*p) || *p == ',') p++;
+        if (!*p) break;
+
+        /* Find end of id */
+        const char *q = p;
+        if (*p == '<') {
+            while (*q && *q != '>') q++;
+        }
+        else {
+            while (*q && !isspace(*q)) q++;
+        }
+
+        /* Read id */
+        char *val = xstrndup(*p == '<' ? p + 1 : p,
+                             *q == '>' ? q - p - 1 : q - p);
+        if (*p == '<') {
+            _remove_ws(val);
+        }
+        if (*val) {
+            /* calculate the value that would be created if this was
+             * fed back into an Email/set and make sure it would
+             * validate */
+            char *msgid = strconcat("<", val, ">", NULL);
+            int r = conversations_check_msgid(msgid, strlen(msgid));
+            if (!r) json_array_append_new(msgids, json_string(val));
+            free(msgid);
+        }
+        free(val);
+
+        /* Reset iterator */
+        p = *q ? q + 1 : q;
+    }
+
+
+    if (!json_array_size(msgids)) {
+        json_decref(msgids);
+        msgids = json_null();
+    }
+    free(unfolded);
+    return msgids;
+}
+
+EXPORTED json_t *jmap_header_as_addresses(const char *raw, enum header_form form)
+{
+    if (!raw) return json_null();
+
+    struct address *addrs = NULL;
+    parseaddr_list(raw, &addrs);
+    json_t *result = jmap_emailaddresses_from_addr(addrs, form);
+    parseaddr_free(addrs);
+    return result;
+}
+
+EXPORTED json_t *jmap_emailaddresses_from_addr(struct address *addr,
+                                               enum header_form form)
+{
+    if (!addr) return json_null();
+
+    json_t *result = json_array();
+
+    const char *groupname = NULL;
+    json_t *addresses = json_array();
+
+    struct buf buf = BUF_INITIALIZER;
+    while (addr) {
+        const char *domain = addr->domain;
+        if (!strcmpsafe(domain, "unspecified-domain")) {
+            domain = NULL;
+        }
+        if (!addr->name && addr->mailbox && !domain) {
+            /* Start of group. */
+            if (form == HEADER_FORM_GROUPEDADDRESSES) {
+                if (form == HEADER_FORM_GROUPEDADDRESSES) {
+                    if (groupname || json_array_size(addresses)) {
+                        json_t *group = json_object();
+                        json_object_set_new(group, "name",
+                                groupname ? json_string(groupname) : json_null());
+                        json_object_set_new(group, "addresses", addresses);
+                        json_array_append_new(result, group);
+                        addresses = json_array();
+                    }
+                    groupname = NULL;
+                }
+                groupname = addr->mailbox;
+            }
+        }
+        else if (!addr->name && !addr->mailbox) {
+            /* End of group */
+            if (form == HEADER_FORM_GROUPEDADDRESSES) {
+                if (groupname || json_array_size(addresses)) {
+                    json_t *group = json_object();
+                    json_object_set_new(group, "name",
+                            groupname ? json_string(groupname) : json_null());
+                    json_object_set_new(group, "addresses", addresses);
+                    json_array_append_new(result, group);
+                    addresses = json_array();
+                }
+                groupname = NULL;
+            }
+        }
+        else {
+            /* Regular address */
+            json_t *jemailaddr = json_object();
+            if (addr->name) {
+                char *tmp = _decode_mimeheader(addr->name);
+                if (tmp) json_object_set_new(jemailaddr, "name", json_string(tmp));
+                free(tmp);
+            } else {
+                json_object_set_new(jemailaddr, "name", json_null());
+            }
+            if (addr->mailbox) {
+                buf_setcstr(&buf, addr->mailbox);
+                if (domain) {
+                    buf_putc(&buf, '@');
+                    buf_appendcstr(&buf, domain);
+                }
+                json_object_set_new(jemailaddr, "email", json_string(buf_cstring(&buf)));
+                buf_reset(&buf);
+            } else {
+                json_object_set_new(jemailaddr, "email", json_null());
+            }
+            json_array_append_new(addresses, jemailaddr);
+        }
+        addr = addr->next;
+    }
+    buf_free(&buf);
+
+    if (form == HEADER_FORM_GROUPEDADDRESSES) {
+        if (groupname || json_array_size(addresses)) {
+            json_t *group = json_object();
+            json_object_set_new(group, "name",
+                    groupname ? json_string(groupname) : json_null());
+            json_object_set_new(group, "addresses", addresses);
+            json_array_append_new(result, group);
+        }
+        else json_decref(addresses);
+    }
+    else {
+        json_decref(result);
+        result = addresses;
+    }
+
+    return result;
+}

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -850,8 +850,7 @@ done:
     return is_valid;
 }
 
-EXPORTED json_t *jmap_header_as_raw(const char *raw,
-                                    enum header_form form __attribute__((unused)))
+EXPORTED json_t *jmap_header_as_raw(const char *raw)
 {
     if (!raw) return json_null();
 
@@ -886,8 +885,7 @@ static char *_decode_mimeheader(const char *raw)
     return val;
 }
 
-EXPORTED json_t *jmap_header_as_text(const char *raw,
-                                     enum header_form form __attribute__((unused)))
+EXPORTED json_t *jmap_header_as_text(const char *raw)
 {
     if (!raw) return json_null();
 
@@ -920,8 +918,7 @@ EXPORTED json_t *jmap_header_as_text(const char *raw,
     return result;
 }
 
-EXPORTED json_t *jmap_header_as_date(const char *raw,
-                                        enum header_form form __attribute__((unused)))
+EXPORTED json_t *jmap_header_as_date(const char *raw)
 {
     if (!raw) return json_null();
 
@@ -948,8 +945,7 @@ static void _remove_ws(char *s)
     } while ((*d++ = *s++));
 }
 
-EXPORTED json_t *jmap_header_as_urls(const char *raw,
-                                     enum header_form form __attribute__((unused)))
+EXPORTED json_t *jmap_header_as_urls(const char *raw)
 {
     if (!raw) return json_null();
 
@@ -976,8 +972,7 @@ EXPORTED json_t *jmap_header_as_urls(const char *raw,
     return urls;
 }
 
-EXPORTED json_t *jmap_header_as_messageids(const char *raw,
-                                           enum header_form form __attribute__((unused)))
+EXPORTED json_t *jmap_header_as_messageids(const char *raw)
 {
     if (!raw) return json_null();
     json_t *msgids = json_array();
@@ -1029,7 +1024,7 @@ EXPORTED json_t *jmap_header_as_messageids(const char *raw,
     return msgids;
 }
 
-EXPORTED json_t *jmap_header_as_addresses(const char *raw, enum header_form form)
+static json_t *_header_as_addresses(const char *raw, enum header_form form)
 {
     if (!raw) return json_null();
 
@@ -1038,6 +1033,16 @@ EXPORTED json_t *jmap_header_as_addresses(const char *raw, enum header_form form
     json_t *result = jmap_emailaddresses_from_addr(addrs, form);
     parseaddr_free(addrs);
     return result;
+}
+
+EXPORTED json_t *jmap_header_as_addresses(const char *raw)
+{
+    return _header_as_addresses(raw, HEADER_FORM_ADDRESSES);
+}
+
+EXPORTED json_t *jmap_header_as_groupedaddresses(const char *raw)
+{
+    return _header_as_addresses(raw, HEADER_FORM_GROUPEDADDRESSES);
 }
 
 EXPORTED json_t *jmap_emailaddresses_from_addr(struct address *addr,

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -921,22 +921,21 @@ EXPORTED json_t *jmap_header_as_text(const char *raw,
 }
 
 EXPORTED json_t *jmap_header_as_date(const char *raw,
-                                     enum header_form form __attribute__((unused)))
+                                        enum header_form form __attribute__((unused)))
 {
     if (!raw) return json_null();
 
-    time_t t;
-    if (time_from_rfc5322(raw, &t, DATETIME_FULL) == -1) {
+    struct offsettime t;
+    if (offsettime_from_rfc5322(raw, &t, DATETIME_FULL) == -1) {
         if (!strchr(raw, '\r')) return json_null();
         char *tmp = charset_unfold(raw, strlen(raw), CHARSET_UNFOLD_SKIPWS);
-        int r = time_from_rfc5322(tmp, &t, DATETIME_FULL);
+        int r = offsettime_from_rfc5322(tmp, &t, DATETIME_FULL);
         free(tmp);
         if (r == -1) return json_null();
     }
 
-    char cbuf[RFC3339_DATETIME_MAX+1];
-    cbuf[RFC3339_DATETIME_MAX] = '\0';
-    time_to_rfc3339(t, cbuf, RFC3339_DATETIME_MAX+1);
+    char cbuf[ISO8601_DATETIME_MAX+1] = "";
+    offsettime_to_iso8601(&t, cbuf, sizeof(cbuf), 1);
     return json_string(cbuf);
 }
 

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1131,3 +1131,24 @@ EXPORTED json_t *jmap_emailaddresses_from_addr(struct address *addr,
 
     return result;
 }
+
+EXPORTED void jmap_set_blobid(const struct message_guid *guid, char *buf)
+{
+    buf[0] = 'G';
+    memcpy(buf+1, message_guid_encode(guid), JMAP_BLOBID_SIZE-2);
+    buf[JMAP_BLOBID_SIZE-1] = '\0';
+}
+
+EXPORTED void jmap_set_emailid(const struct message_guid *guid, char *buf)
+{
+    buf[0] = 'M';
+    memcpy(buf+1, message_guid_encode(guid), JMAP_EMAILID_SIZE-2);
+    buf[JMAP_EMAILID_SIZE-1] = '\0';
+}
+
+EXPORTED void jmap_set_threadid(conversation_id_t cid, char *buf)
+{
+    buf[0] = 'T';
+    memcpy(buf+1, conversation_id_encode(cid), JMAP_THREADID_SIZE-2);
+    buf[JMAP_THREADID_SIZE-1] = 0;
+}

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -168,4 +168,13 @@ extern json_t *jmap_header_as_addresses(const char *raw, enum header_form form);
 extern json_t *jmap_emailaddresses_from_addr(struct address *addr,
                                              enum header_form form);
 
+#define JMAP_BLOBID_SIZE 42
+extern void jmap_set_blobid(const struct message_guid *guid, char *buf);
+
+#define JMAP_EMAILID_SIZE 26
+extern void jmap_set_emailid(const struct message_guid *guid, char *buf);
+
+#define JMAP_THREADID_SIZE 18
+extern void jmap_set_threadid(conversation_id_t cid, char *buf);
+
 #endif /* JMAP_UTIL_H */

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -159,12 +159,13 @@ enum header_form {
     HEADER_FORM_GROUPEDADDRESSES = 1 << 6
 };
 
-extern json_t *jmap_header_as_raw(const char *raw, enum header_form form);
-extern json_t *jmap_header_as_text(const char *raw, enum header_form form);
-extern json_t *jmap_header_as_date(const char *raw, enum header_form form);
-extern json_t *jmap_header_as_urls(const char *raw, enum header_form form);
-extern json_t *jmap_header_as_messageids(const char *raw, enum header_form form);
-extern json_t *jmap_header_as_addresses(const char *raw, enum header_form form);
+extern json_t *jmap_header_as_raw(const char *raw);
+extern json_t *jmap_header_as_text(const char *raw);
+extern json_t *jmap_header_as_date(const char *raw);
+extern json_t *jmap_header_as_urls(const char *raw);
+extern json_t *jmap_header_as_messageids(const char *raw);
+extern json_t *jmap_header_as_addresses(const char *raw);
+extern json_t *jmap_header_as_groupedaddresses(const char *raw);
 extern json_t *jmap_emailaddresses_from_addr(struct address *addr,
                                              enum header_form form);
 

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -48,6 +48,7 @@
 
 #include "hash.h"
 #include "message.h"
+#include "parseaddr.h"
 #include "smtpclient.h"
 
 #define JMAP_SUBMISSION_HDR "Content-Description"
@@ -146,5 +147,25 @@ extern int jmap_decode_rawdata_blobid(const char *blobid,
                                       char **useridptr,
                                       char **subpartptr,
                                       struct message_guid *guid);
+
+enum header_form {
+    HEADER_FORM_UNKNOWN          = 0, /* MUST be zero so we can cast to void* */
+    HEADER_FORM_RAW              = 1 << 0,
+    HEADER_FORM_TEXT             = 1 << 1,
+    HEADER_FORM_DATE             = 1 << 2,
+    HEADER_FORM_URLS             = 1 << 3,
+    HEADER_FORM_MESSAGEIDS       = 1 << 4,
+    HEADER_FORM_ADDRESSES        = 1 << 5,
+    HEADER_FORM_GROUPEDADDRESSES = 1 << 6
+};
+
+extern json_t *jmap_header_as_raw(const char *raw, enum header_form form);
+extern json_t *jmap_header_as_text(const char *raw, enum header_form form);
+extern json_t *jmap_header_as_date(const char *raw, enum header_form form);
+extern json_t *jmap_header_as_urls(const char *raw, enum header_form form);
+extern json_t *jmap_header_as_messageids(const char *raw, enum header_form form);
+extern json_t *jmap_header_as_addresses(const char *raw, enum header_form form);
+extern json_t *jmap_emailaddresses_from_addr(struct address *addr,
+                                             enum header_form form);
 
 #endif /* JMAP_UTIL_H */

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -930,10 +930,8 @@ static json_t *jmap_email(struct message_guid *guid, bit64 cid, struct body *bod
     return json_pack("{ s:s s:s s:o s:o s:o s:o s:o s:o s:o s:o s:o s:o }",
                      "id", emailid,
                      "threadId", threadid(cid),
-                     "sentAt",
-                     jmap_header_as_date(body->date, HEADER_FORM_DATE),
-                     "subject",
-                     jmap_header_as_text(body->subject, HEADER_FORM_TEXT),
+                     "sentAt", jmap_header_as_date(body->date),
+                     "subject", jmap_header_as_text(body->subject),
                      "from",
                      jmap_emailaddresses_from_addr(body->from,
                                                    HEADER_FORM_ADDRESSES),
@@ -953,11 +951,9 @@ static json_t *jmap_email(struct message_guid *guid, bit64 cid, struct body *bod
                      jmap_emailaddresses_from_addr(body->bcc,
                                                    HEADER_FORM_ADDRESSES),
                      "inReplyTo",
-                     jmap_header_as_messageids(body->in_reply_to,
-                                               HEADER_FORM_MESSAGEIDS),
+                     jmap_header_as_messageids(body->in_reply_to),
                      "messageId",
-                     jmap_header_as_messageids(body->message_id,
-                                               HEADER_FORM_MESSAGEIDS));
+                     jmap_header_as_messageids(body->message_id));
 }
 
 EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *mailbox,

--- a/imap/mboxevent.h
+++ b/imap/mboxevent.h
@@ -45,6 +45,8 @@
 #ifndef _MBOXEVENT_H
 #define _MBOXEVENT_H
 
+#include <jansson.h>
+
 #include "strarray.h"
 
 #include "mailbox.h"
@@ -139,6 +141,7 @@ enum event_param {
     EVENT_COUNTERS,
     EVENT_MESSAGE_EMAILID,
     EVENT_MESSAGE_THREADID,
+    EVENT_JMAP_EMAIL,
     EVENT_CALENDAR_ALARM_TIME,
     EVENT_CALENDAR_ALARM_RECIPIENTS,
     EVENT_CALENDAR_USER_ID,
@@ -177,7 +180,8 @@ enum event_param {
 enum event_param_type {
     EVENT_PARAM_INT,
     EVENT_PARAM_STRING,
-    EVENT_PARAM_ARRAY
+    EVENT_PARAM_ARRAY,
+    EVENT_PARAM_JSON
 };
 
 struct event_parameter {
@@ -188,6 +192,7 @@ struct event_parameter {
         char *s;
         uint64_t u;
         strarray_t *a;
+        json_t *j;
     } value;
     int filled;
 };
@@ -222,6 +227,11 @@ struct mboxevent {
 #define FILL_UNSIGNED_PARAM(e,p,v) do { \
     e->params[p].value.u = v; \
     e->params[p].type = EVENT_PARAM_INT; \
+    e->params[p].filled = 1; \
+} while (0)
+#define FILL_JSON_PARAM(e,p,v) do { \
+    e->params[p].value.j = v; \
+    e->params[p].type = EVENT_PARAM_JSON; \
     e->params[p].filled = 1; \
 } while (0)
 
@@ -300,6 +310,7 @@ void mboxevent_set_acl(struct mboxevent *event, const char *identifier,
  * - vnd.cmu.midset from Message-Id in ENVELOPE structure
  * - messageSize
  * - bodyStructure
+ * - vnd.cmu.jmapEmail
  *
  * Called once per message and always before mboxevent_extract_mailbox
  */
@@ -313,6 +324,7 @@ void mboxevent_extract_record(struct mboxevent *event,
  * - vnd.cmu.midset from Message-Id in ENVELOPE structure
  * - messageSize
  * - bodyStructure
+ * - vnd.cmu.jmapEmail
  *
  * Called once per message and always before mboxevent_extract_mailbox
  */

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -904,7 +904,7 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* Don't send event notification for folder with given special-use attributes.
    Set ALL for any folder */
 
-{ "event_extra_params", "timestamp", BITFIELD("bodyStructure", "clientAddress", "diskUsed", "flagNames", "messageContent", "messageSize", "messages", "modseq", "service", "timestamp", "uidnext", "vnd.cmu.midset", "vnd.cmu.unseenMessages", "vnd.cmu.envelope", "vnd.cmu.sessionId", "vnd.cmu.mailboxACL", "vnd.cmu.mbtype", "vnd.cmu.davFilename", "vnd.cmu.davUid", "vnd.fastmail.clientId", "vnd.fastmail.sessionId", "vnd.fastmail.convExists", "vnd.fastmail.convUnseen", "vnd.fastmail.cid", "vnd.fastmail.counters", "vnd.cmu.emailid", "vnd.cmu.threadid"), "3.1.6" }
+{ "event_extra_params", "timestamp", BITFIELD("bodyStructure", "clientAddress", "diskUsed", "flagNames", "messageContent", "messageSize", "messages", "modseq", "service", "timestamp", "uidnext", "vnd.cmu.midset", "vnd.cmu.unseenMessages", "vnd.cmu.envelope", "vnd.cmu.sessionId", "vnd.cmu.mailboxACL", "vnd.cmu.mbtype", "vnd.cmu.davFilename", "vnd.cmu.davUid", "vnd.fastmail.clientId", "vnd.fastmail.sessionId", "vnd.fastmail.convExists", "vnd.fastmail.convUnseen", "vnd.fastmail.cid", "vnd.fastmail.counters", "vnd.cmu.emailid", "vnd.cmu.threadid", "vnd.cmu.jmapEmail"), "3.1.6" }
 /* Space-separated list of extra parameters to add to any appropriated event. */
 
 { "event_groups", "message mailbox", BITFIELD("message", "quota", "flags", "access", "mailbox", "subscription", "calendar", "applepushservice" ), "3.0.0" }


### PR DESCRIPTION
Redo of previous PR.

Adds the 'vnd.cmu.jmapEmail' selector to the 'event_extra_params' option
which will includes a JMAP Email object in the event message.

Also fixes header:asDate to return a Date type rather than a UTCDate type.

Fix for existing Cass test is here: https://github.com/cyrusimap/cassandane/pull/116