### PR TITLE
ctl_cyrusdb -r assertion on startup when mboxlist_db = skiplist

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3312,6 +3312,7 @@ EXPORTED int mboxlist_set_racls(int enabled)
 {
     struct txn *tid = NULL;
     int r = 0;
+    int modified_mbdb = 0;
 
     init_internal();
 
@@ -3320,6 +3321,7 @@ EXPORTED int mboxlist_set_racls(int enabled)
         /* remove */
         r = cyrusdb_foreach(mbdb, "$RACL", 5, NULL, del_cb, &tid, &tid);
         if (!r) have_racl = 0;
+        modified_mbdb = 1;
     }
     if (enabled && !have_racl) {
         /* add */
@@ -3332,11 +3334,14 @@ EXPORTED int mboxlist_set_racls(int enabled)
         if (r) {
             syslog(LOG_ERR, "ERROR: failed to add reverse acl support %s", error_message(r));
         }
+        modified_mbdb = 1;
         mboxlist_entry_free(&mbrock.mbentry);
         if (!r) r = cyrusdb_store(mbdb, "$RACL", 5, vbuf.s, vbuf.len, &tid);
         if (!r) have_racl = RACL_VERSION;
         buf_free(&vbuf);
     }
+
+    if (!modified_mbdb || !tid) return r;
 
     if (r)
         cyrusdb_abort(mbdb, tid);
@@ -3356,6 +3361,7 @@ EXPORTED int mboxlist_set_runiqueid(int enabled)
 {
     struct txn *tid = NULL;
     int r = 0;
+    int modified_mbdb = 0;
 
     init_internal();
 
@@ -3364,6 +3370,7 @@ EXPORTED int mboxlist_set_runiqueid(int enabled)
         /* remove */
         r = cyrusdb_foreach(mbdb, "$RUNQ", 5, NULL, del_cb, &tid, &tid);
         if (!r) have_runq = 0;
+        modified_mbdb = 1;
     }
     if (enabled && !have_runq) {
         /* add */
@@ -3376,11 +3383,14 @@ EXPORTED int mboxlist_set_runiqueid(int enabled)
         if (r) {
             syslog(LOG_ERR, "ERROR: failed to add reverse uniqueid support %s", error_message(r));
         }
+        modified_mbdb = 1;
         mboxlist_entry_free(&mbrock.mbentry);
         if (!r) r = cyrusdb_store(mbdb, "$RUNQ", 5, vbuf.s, vbuf.len, &tid);
         if (!r) have_runq = RUNQ_VERSION;
         buf_free(&vbuf);
     }
+
+    if (!modified_mbdb || !tid) return r;
 
     if (r)
         cyrusdb_abort(mbdb, tid);


### PR DESCRIPTION
Hi,

ctl_cyrusdb exits during startup:

% /usr/local/cyrus/sbin/ctl_cyrusdb -r
fatal error: Internal error: assertion failed: lib/cyrusdb_skiplist.c: 1469: db && tid
% /usr/local/cyrus/sbin/cyr_info version
cyrus-imapd 3.4.0
% uname -ro
FreeBSD 13.0-RELEASE

I believe this is due to mboxlist_set_racls() and mboxlist_set_runiqueid() may not have done any changes to the mailbox database, e.g. when reverse acls are enabled and have the latest version. In 3.2.x, tid is never NULL set as cyrusdb_fetch() is always called.

BR Felix
