### PR TITLE
improve our errno discipline

### DIFF
--- a/imap/idle.c
+++ b/imap/idle.c
@@ -106,6 +106,8 @@ static void idle_notify(const char *mboxname)
                         "NOTIFY to idled for mailbox %s: %s.",
                         mboxname, error_message(r));
     }
+    if (errno == ENOENT)
+        errno = 0;
 }
 
 /*

--- a/lib/cyrusdb_quotalegacy.c
+++ b/lib/cyrusdb_quotalegacy.c
@@ -387,8 +387,11 @@ static int myfetch(struct dbengine *db, char *quota_path,
         /* just check if the key exists */
         struct stat sbuf;
 
-        if (stat(quota_path, &sbuf) == -1)
+        if (stat(quota_path, &sbuf) == -1) {
+            if (errno == ENOENT)
+                errno = 0;
             return CYRUSDB_NOTFOUND;
+        }
 
         return 0;
     }
@@ -406,6 +409,7 @@ static int myfetch(struct dbengine *db, char *quota_path,
         if (quota_fd == -1) {
             if (errno == ENOENT) {
                 /* key doesn't exist */
+                errno = 0;
                 return CYRUSDB_NOTFOUND;
             }
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -535,6 +535,8 @@ EXPORTED int cyrus_mkdir(const char *pathname, mode_t mode __attribute__((unused
                 return -1;
             }
         }
+        if (errno == EEXIST)
+            errno = 0;
         *p = '/';
     }
 


### PR DESCRIPTION
The new `xsyslog()` automatically includes a `syserror=<...>` field when `errno` is non-zero at the time the message was logged, which means we don't need to explicitly log `%m` anymore.

But, it's exposing places where some syscall has failed and been ignored, and the irrelevant errno value left lying around to trip over later.  We can't deal with this from within `xsyslog()`, because it doesn't know the context where `errno` was set.

Generally, if we call something that will set `errno` on failures, and then treat some of those failure cases as successes, we should also reset `errno = 0` in those cases to indicate to our future selves that the "failure" has been handled.  The next successful syscall will usually reset it to zero (or to whatever error _it_ detected), so, if you're immediately making some other syscall anyway, you can skip explicitly resetting it.  But if you're about to return to the caller, and you know `errno` might be junk, clean it up.

I wrote this patch a month ago, and then got distracted with something else, and I no longer remember what I was doing to find these cases.  So here, at least, is a patch that fixes the ones I found quickly, hopefully reducing some noise/confusion!  And we can fix more in the future as we trip over them...