### PR TITLE
WS: use the actual txn for the stream/connection rather than creating a new one

### DIFF
--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -684,6 +684,7 @@ HIDDEN int http2_start_session(struct transaction_t *txn,
         strm->id = nghttp2_session_get_last_proc_stream_id(ctx->session);
         txn->strm_ctx = strm;
         txn->flags.ver = VER_2;
+        ptrarray_add(&txn->done_callbacks, &_end_stream);
     }
 
     /* Don't do telemetry logging in prot layer */

--- a/imap/http_h2.h
+++ b/imap/http_h2.h
@@ -87,6 +87,4 @@ extern int http2_data_chunk(struct transaction_t *txn,
 
 extern int32_t http2_get_streamid(void *http2_strm);
 
-extern void http2_end_stream(void *http2_strm);
-
 #endif /* HTTP_H2_H */

--- a/imap/http_h2.h
+++ b/imap/http_h2.h
@@ -59,18 +59,14 @@
 #include "md5.h"
 #include "util.h"
 
-extern void http2_init(struct buf *serverinfo);
+extern void http2_init(struct http_connection *conn, struct buf *serverinfo);
 
 extern int http2_enabled();
-
-extern void http2_done();
 
 extern int http2_preface(struct http_connection *conn);
 
 extern int http2_start_session(struct transaction_t *txn,
                                struct http_connection *conn);
-
-extern void http2_end_session(void **http2_ctx, const char *msg);
 
 extern void http2_input(struct transaction_t *txn);
 

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -1205,35 +1205,15 @@ static int jmap_get_session(struct transaction_t *txn)
  *   https://github.com/websockets/wscat
  *   https://chrome.google.com/webstore/detail/web-socket-client/lifhekgaodigcpmnakfhaaaboididbdn
  *
- * WebSockets over HTTP/2 currently only available in:
- *   https://www.google.com/chrome/browser/canary.html
+ * WebSockets over HTTP/2 currently only available in Chrome:
+ *   https://www.chromestatus.com/feature/6251293127475200
+ *   (using --enable-experimental-web-platform-features)
  */
-static int jmap_ws(enum wslay_opcode opcode,
-                   struct buf *inbuf, struct buf *outbuf,
-                   struct buf *logbuf, void **rock)
+static int jmap_ws(struct transaction_t *txn, enum wslay_opcode opcode,
+                   struct buf *inbuf, struct buf *outbuf, struct buf *logbuf)
 {
-    struct transaction_t **txnp = (struct transaction_t **) rock;
-    struct transaction_t *txn = *txnp;
     json_t *req = NULL, *res = NULL;
     int ret;
-
-    if (!txn) {
-        /* Create a transaction rock to use for API requests */
-        txn = *txnp = xzmalloc(sizeof(struct transaction_t));
-
-        /* Create header cache */
-        txn->req_hdrs = spool_new_hdrcache();
-        if (!txn->req_hdrs) {
-            free(txn);
-            return HTTP_SERVER_ERROR;
-        }
-    }
-    else if (!inbuf) {
-        /* Free transaction rock */
-        transaction_free(txn);
-        free(txn);
-        return 0;
-    }
 
     /* Only accept text frames */
     if (opcode != WSLAY_TEXT_FRAME) {

--- a/imap/http_ws.c
+++ b/imap/http_ws.c
@@ -658,6 +658,11 @@ static void parse_extensions(struct transaction_t *txn)
 }
 
 
+static void _end_channel(struct transaction_t *txn)
+{
+    ws_end_channel(&txn->ws_ctx, NULL);
+}
+
 HIDDEN int ws_start_channel(struct transaction_t *txn,
                             const char *protocol, ws_data_callback *data_cb)
 {
@@ -787,6 +792,7 @@ HIDDEN int ws_start_channel(struct transaction_t *txn,
     ctx->protocol = protocol;
     ctx->data_cb = data_cb;
     txn->ws_ctx = ctx;
+    ptrarray_add(&txn->done_callbacks, &_end_channel);
 
     /* Check for supported WebSocket extensions */
     parse_extensions(txn);

--- a/imap/http_ws.c
+++ b/imap/http_ws.c
@@ -93,7 +93,6 @@ struct ws_context {
     const char *accept_key;
     const char *protocol;
     ws_data_callback *data_cb;
-    void *cb_rock;
     struct buf log;
     int log_tail;
     unsigned ext;                    /* Bitmask of negotiated extension(s) */
@@ -492,7 +491,7 @@ static void on_msg_recv_cb(wslay_event_context_ptr ev,
         }
 
         /* Process the request */
-        r = ctx->data_cb(arg->opcode, &inbuf, &outbuf, &ctx->log, &ctx->cb_rock);
+        r = ctx->data_cb(txn, arg->opcode, &inbuf, &outbuf, &ctx->log);
         if (r) {
             switch (r) {
             case HTTP_NO_CONTENT:
@@ -894,11 +893,6 @@ HIDDEN void ws_end_channel(void **ws_ctx, const char *msg)
 
     wslay_event_context_free(ev);
     buf_free(&ctx->log);
-
-    if (ctx->cb_rock) {
-        /* Cleanup cb_rock */
-        ctx->data_cb(0, NULL, NULL, NULL, &ctx->cb_rock);
-    }
 
     ws_zlib_done(ctx);
 

--- a/imap/http_ws.h
+++ b/imap/http_ws.h
@@ -62,11 +62,9 @@ enum wslay_opcode {
 #define WS_TOKEN         "websocket"
 #define WS_VERSION       "13"
 
-extern void ws_init(struct buf *serverinfo);
+extern void ws_init(struct http_connection *conn, struct buf *serverinfo);
 
 extern int ws_enabled();
-
-extern void ws_done();
 
 typedef int ws_data_callback(enum wslay_opcode opcode,
                              struct buf *inbuf, struct buf *outbuf,

--- a/imap/http_ws.h
+++ b/imap/http_ws.h
@@ -66,9 +66,9 @@ extern void ws_init(struct http_connection *conn, struct buf *serverinfo);
 
 extern int ws_enabled();
 
-typedef int ws_data_callback(enum wslay_opcode opcode,
+typedef int ws_data_callback(struct transaction_t *txn, enum wslay_opcode opcode,
                              struct buf *inbuf, struct buf *outbuf,
-                             struct buf *logbuf, void **rock);
+                             struct buf *logbuf);
 
 extern int ws_start_channel(struct transaction_t *txn,
                             const char *sub_prot, ws_data_callback *data_cb);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -784,8 +784,6 @@ int service_init(int argc __attribute__((unused)),
                SASL_VERSION_MAJOR, SASL_VERSION_MINOR, SASL_VERSION_STEP,
                LIBXML_DOTTED_VERSION, JANSSON_VERSION);
 
-    memset(&http_conn, 0, sizeof(struct http_connection));
-
     http2_init(&http_conn, &serverinfo);
     ws_init(&http_conn, &serverinfo);
 

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -344,7 +344,18 @@ struct http_connection {
     void **ws_ctx;                      /* WebSocket context (HTTP/1.1 only) */
 
     xmlParserCtxtPtr xml;               /* XML parser content */
+
+    ptrarray_t reset_callbacks;         /* Array of functions to reset
+                                           auxiliary connection contexts
+                                           (e.g. TLS, HTTP/2, WebSockets) */
+
+    ptrarray_t shutdown_callbacks;      /* Array of functions to cleanup
+                                           auxiliary connection contexts
+                                           (e.g. TLS, HTTP/2, WebSockets) */
 };
+
+typedef void (*conn_reset_t)(struct http_connection *conn);
+typedef void (*conn_shutdown_t)(struct http_connection *conn, const char *msg);
 
 
 /* Transaction context */
@@ -385,10 +396,9 @@ struct transaction_t {
     void *brotli;                       /* Brotli compression context */
     void *zstd;                         /* Zstandard compression context */
 
-    ptrarray_t done_callbacks;          /* Array of auxiliary functions
-                                           to be called when freeing the txn.
-                                           Used to cleanup the commpression,
-                                           HTTP/2, WebSocket contexts. */
+    ptrarray_t done_callbacks;          /* Array of functions to cleanup
+                                           auxiliary stream contexts
+                                           (e.g. compression, HTTP/2, WS) */
 };
 
 typedef void (*txn_done_t)(struct transaction_t *txn);

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -352,6 +352,7 @@ struct transaction_t {
     struct http_connection *conn;       /* Global connection context */
     void *strm_ctx;                     /* HTTP/2+ stream context */
     void *ws_ctx;                       /* WebSocket channel context */
+
     unsigned meth;                      /* Index of Method to be performed */
     struct txn_flags_t flags;           /* Flags for this txn */
     struct request_line_t req_line;     /* Parsed request-line */
@@ -383,7 +384,15 @@ struct transaction_t {
     void *zstrm;                        /* Zlib compression context */
     void *brotli;                       /* Brotli compression context */
     void *zstd;                         /* Zstandard compression context */
+
+    ptrarray_t done_callbacks;          /* Array of auxiliary functions
+                                           to be called when freeing the txn.
+                                           Used to cleanup the commpression,
+                                           HTTP/2, WebSocket contexts. */
 };
+
+typedef void (*txn_done_t)(struct transaction_t *txn);
+
 
 /* HTTP version flags */
 enum {
@@ -596,11 +605,11 @@ extern int http_allow_noauth(struct transaction_t *txn);
 extern int http_allow_noauth_get(struct transaction_t *txn);
 extern int http_read_req_body(struct transaction_t *txn);
 
-extern void *zlib_init();
+extern void zlib_init(struct transaction_t *txn);
 extern int zlib_compress(struct transaction_t *txn, unsigned flags,
                          const char *buf, unsigned len);
 
-extern void *zstd_init();
-extern void *brotli_init();
+extern void brotli_init(struct transaction_t *txn);
+extern void zstd_init(struct transaction_t *txn);
 
 #endif /* HTTPD_H */


### PR DESCRIPTION
This removes an ugly hack where each WS connection would create its own new txn, separating itself from the txn used to bootstrap the WS connection.  The warts that forced this hack have been removed in previous commits on master.

Based on https://github.com/cyrusimap/cyrus-imapd/pull/3477