### PR TITLE
misc: don't use __GNUC_PREREQ() when checking for GCC features

### DIFF
--- a/lib/byteorder.h
+++ b/lib/byteorder.h
@@ -61,7 +61,7 @@
 #  define ntohll(x) (x)
 
 #else /* small-endian machines */
-#  if defined(__GNUC__) && __GNUC_PREREQ(4, 3)
+#  if defined(__GNUC__) && ((__GNU__ == 4 && __GNUC_MINOR >= 3) || __GNU__ > 4)
      /* Remove existing macros if present */
 #    undef ntohl
 #    undef htonl

--- a/lib/crc32.c
+++ b/lib/crc32.c
@@ -613,7 +613,7 @@ static const uint32_t crc32_lookup[16][256] =
 
 #if BYTE_ORDER != LITTLE_ENDIAN
 /* swap endianness */
-# if defined(__GNUC__) && __GNUC_PREREQ(4, 3)
+# if defined(__GNUC__) && ((__GNU__ == 4 && __GNUC_MINOR >= 3) || __GNU__ > 4)
 #  define swap(x) __builtin_bswap32(x)
 # else
 #  ifdef HAVE_DECLARE_OPTIMIZE


### PR DESCRIPTION
This macro is provided by glibc, not gcc, so using it winds up implicitly checking for "gcc+glibc" rather than just "gcc".

Fixes #3462

Need this for 3.4... I would just push it directly to both branches, but I wanted to submit a PR to make sure the DCO exception for org members is working correctly