### PR TITLE
(3.4) use Date rather than UTCDate

### DIFF
--- a/lib/times.h
+++ b/lib/times.h
@@ -76,6 +76,7 @@ int time_to_rfc822(time_t t, char *buf, size_t len);
 /*
  * ISO8601 (RFC 3339) datetime format
  */
+#define ISO8601_DATETIME_MAX 30
 int time_from_iso8601(const char *s, time_t *);
 int time_to_iso8601(time_t t, char *buf, size_t len, int withsep);
 int timeval_to_iso8601(const struct timeval *t, enum timeval_precision tv_prec,


### PR DESCRIPTION
This updates 3.4 to pass the JMAPTestSuite.t:Email:get:header-header-field-name test, which was recently updated to expect Date objects rather than UTCDate objects.

I tried simply cherry-picking the relevant commit from master (e354baa53abf3a714f1c34b68a68e4b8d1b68d7b), but there is a whole rabbit trail of other commits it's dependent on, so instead of spending the day tracking them down, I just rewrote the same changes to the 3.4 code instead.

But, since I re-wrote it rather than just cherry-picking it, I'd like some eyes on it before I land it please. :)