### PR TITLE
Reconstruct repair mboxlist

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3556,7 +3556,7 @@ static int find_desc_store(annotate_state_t *state,
     }
 
     /* check for DAV annotations */
-    if (state->mailbox && (state->mailbox->mbtype & MBTYPES_DAV) &&
+    if (state->mailbox && mbtypes_dav(state->mailbox->mbtype) &&
         !strncmp(name, DAV_ANNOT_NS, strlen(DAV_ANNOT_NS))) {
         *descp = db_entry;
         return 0;

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -1268,13 +1268,13 @@ static void process_one_record(struct caldav_alarm_data *data, time_t runtime, i
         goto done;
     }
 
-    if (mailbox->mbtype == MBTYPE_CALENDAR) {
+    if (mbtype_isa(mailbox->mbtype) == MBTYPE_CALENDAR) {
         icaltimezone *floatingtz = get_floatingtz(mailbox->name, "");
         r = process_valarms(mailbox, &record, floatingtz, runtime, dryrun);
         if (floatingtz) icaltimezone_free(floatingtz, 1);
     }
 #ifdef WITH_JMAP
-    else if (mailbox->mbtype == MBTYPE_SUBMISSION) {
+    else if (mbtype_isa(mailbox->mbtype) == MBTYPE_JMAPSUBMIT) {
         if (record.internaldate > runtime || dryrun) {
             update_alarmdb(data->mboxname, data->imap_uid, record.internaldate);
             goto done;

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -178,6 +178,9 @@ static int fixmbox(const mbentry_t *mbentry,
 
 static void process_mboxlist(void)
 {
+    /* upgrade database to new mailboxes-by-id records */
+    mboxlist_upgrade(NULL);
+
     /* build a list of mailboxes - we're using internal names here */
     mboxlist_allmbox(NULL, fixmbox, NULL, MBOXTREE_INTERMEDIATES);
 

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -312,7 +312,7 @@ static int _dav_reconstruct_mb(const mbentry_t *mbentry,
 
     signals_poll();
 
-    switch (mbentry->mbtype) {
+    switch (mbtype_isa(mbentry->mbtype)) {
 #ifdef WITH_DAV
     case MBTYPE_CALENDAR:
     case MBTYPE_COLLECTION:
@@ -321,7 +321,7 @@ static int _dav_reconstruct_mb(const mbentry_t *mbentry,
         break;
 #endif
 #ifdef WITH_JMAP
-    case MBTYPE_SUBMISSION:
+    case MBTYPE_JMAPSUBMIT:
         addproc = &mailbox_add_email_alarms;
         break;
 

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -1699,3 +1699,9 @@ EXPORTED const char *dlist_lastkey(void)
 {
     return lastkey;
 }
+
+EXPORTED void dlist_rename(struct dlist *dl, const char *name)
+{
+    free(dl->name);
+    dl->name = xstrdup(name);
+}

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -266,6 +266,32 @@ error:
 
 /* DLIST STUFF */
 
+EXPORTED void dlist_push(struct dlist *parent, struct dlist *child)
+{
+    assert(!child->next);
+
+    if (parent->head) {
+        child->next = parent->head;
+        parent->head = child;
+    }
+    else {
+        parent->head = parent->tail = child;
+    }
+}
+
+EXPORTED struct dlist *dlist_pop(struct dlist *parent)
+{
+    struct dlist *child;
+
+    assert(parent->head);
+
+    child = parent->head;
+    parent->head = parent->head->next;
+    child->next = NULL;
+
+    return child;
+}
+
 EXPORTED void dlist_stitch(struct dlist *parent, struct dlist *child)
 {
     assert(!child->next);

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -231,6 +231,8 @@ typedef int dlistsax_cb_t(int type, struct dlistsax_data *data);
 int dlist_parsesax(const char *base, size_t len, int parsekey,
                    dlistsax_cb_t *proc, void *rock);
 
+void dlist_push(struct dlist *parent, struct dlist *child);
+struct dlist *dlist_pop(struct dlist *parent);
 void dlist_stitch(struct dlist *parent, struct dlist *child);
 void dlist_unstitch(struct dlist *parent, struct dlist *child);
 struct dlist *dlist_splice(struct dlist *parent, int num);

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -245,6 +245,8 @@ struct dlist *dlist_getchildn(struct dlist *dl, int num);
 struct dlist *dlist_getkvchild_bykey(struct dlist *dl,
                                      const char *key, const char *val);
 
+void dlist_rename(struct dlist *dl, const char *name);
+
 const char *dlist_lastkey(void);
 
 /* print a dlist iteratively rather than recursively */

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -141,7 +141,7 @@ static int meth_get_applepush(struct transaction_t *txn,
     }
 
     /* mailbox must be calendar or addressbook */
-    mbtype = mbentry->mbtype;
+    mbtype = mbtype_isa(mbentry->mbtype);
     if (mbtype != MBTYPE_CALENDAR && mbtype != MBTYPE_ADDRESSBOOK)
         goto done;
 

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2207,7 +2207,7 @@ static int list_cal_cb(const mbentry_t *mbentry, void *rock)
     if (!outboxlen) outboxlen = strlen(SCHED_OUTBOX) - 1;
 
     /* Make sure its a calendar */
-    if (mbentry->mbtype != MBTYPE_CALENDAR) goto done;
+    if (mbtype_isa(mbentry->mbtype) != MBTYPE_CALENDAR) goto done;
 
     /* Make sure its readable */
     rights = httpd_myrights(httpd_authstate, mbentry);
@@ -5394,7 +5394,7 @@ static int propfind_restype(const xmlChar *name, xmlNsPtr ns,
         xmlNewChild(node, NULL, BAD_CAST "collection", NULL);
 
         if (fctx->req_tgt->collection &&
-            fctx->mbentry->mbtype == MBTYPE_CALENDAR) {
+            mbtype_isa(fctx->mbentry->mbtype) == MBTYPE_CALENDAR) {
             ensure_ns(fctx->ns, NS_CALDAV,
                       resp ? resp->parent : node->parent, XML_NS_CALDAV, "C");
             if (!strcmp(fctx->req_tgt->collection, SCHED_INBOX)) {

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -862,7 +862,7 @@ static int list_addr_cb(const mbentry_t *mbentry, void *rock)
     if (!defaultlen) defaultlen = strlen(DEFAULT_ADDRBOOK);
 
     /* Make sure its a addrendar */
-    if (mbentry->mbtype != MBTYPE_ADDRESSBOOK) goto done;
+    if (mbtype_isa(mbentry->mbtype) != MBTYPE_ADDRESSBOOK) goto done;
 
     /* Make sure its readable */
     rights = httpd_myrights(httpd_authstate, mbentry);

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5997,7 +5997,8 @@ int propfind_by_collection(const mbentry_t *mbentry, void *rock)
     if ((rights & fctx->reqd_privs) != fctx->reqd_privs) goto done;
 
     /* We only match known types */
-    if (!(mbentry->mbtype & fctx->req_tgt->namespace->mboxtype)) goto done;
+    if (mbtype_isa(mbentry->mbtype) !=
+        fctx->req_tgt->namespace->mboxtype) goto done;
 
     p = strrchr(mboxname, '.');
     if (!p) goto done;
@@ -7104,7 +7105,7 @@ int meth_put(struct transaction_t *txn, void *params)
     }
 
     /* Make sure mailbox type is correct */
-    if (txn->req_tgt.mbentry->mbtype != txn->req_tgt.namespace->mboxtype)
+    if (mbtype_isa(txn->req_tgt.mbentry->mbtype) != txn->req_tgt.namespace->mboxtype)
         return HTTP_FORBIDDEN;
 
     /* Make sure Content-Range isn't specified */

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -925,7 +925,7 @@ HIDDEN int notify_post(struct transaction_t *txn)
             r = annotate_state_writemask(astate, annot,
                                          txn->req_tgt.userid, &value);
 
-            if (shared->mbtype == MBTYPE_CALENDAR) {
+            if (mbtype_isa(shared->mbtype) == MBTYPE_CALENDAR) {
                 /* Sharee's copy of calendar SHOULD default to transparent */
                 annot =
                     DAV_ANNOT_NS "<" XML_NS_CALDAV ">schedule-calendar-transp";

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -702,8 +702,12 @@ static int has_shared_rw_rights_cb(const mbentry_t *mbentry, void *vrock)
     int *rights = (int *) vrock;
 
     /* skip any special use folders */
-    if (mbentry->mbtype &&
-        !(mbentry->mbtype & (MBTYPE_CALENDAR | MBTYPE_ADDRESSBOOK))) {
+    switch (mbtype_isa(mbentry->mbtype)) {
+    case MBTYPE_EMAIL:
+    case MBTYPE_CALENDAR:
+    case MBTYPE_ADDRESSBOOK:
+        break;
+    default:
         return 0;
     }
 

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -4973,7 +4973,7 @@ EXPORTED int httpd_myrights(struct auth_state *authstate, const mbentry_t *mbent
     if (mbentry && mbentry->acl) {
         rights = cyrus_acl_myrights(authstate, mbentry->acl);
 
-        if (mbentry->mbtype == MBTYPE_CALENDAR &&
+        if (mbtype_isa(mbentry->mbtype) == MBTYPE_CALENDAR &&
             (rights & DACL_READ) == DACL_READ) {
             rights |= DACL_READFB;
         }

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -474,7 +474,7 @@ struct namespace_t {
     const char *well_known;     /* Any /.well-known/ URI */
     int (*need_auth)(txn_t *);  /* Function run prior to unauthorized requests */
     unsigned auth_schemes;      /* Bitmask of allowed auth schemes, 0 for any */
-    int mboxtype;               /* What mbtype can be seen in this namespace? */
+    uint32_t mboxtype;          /* What mbtype can be seen in this namespace? */
     unsigned long allow;        /* Bitmask of allowed features/methods */
     void (*init)(struct buf *); /* Function run during service startup */
     int (*auth)(const char *);  /* Function run after authentication */

--- a/imap/index.c
+++ b/imap/index.c
@@ -331,11 +331,11 @@ EXPORTED int index_open_mailbox(struct mailbox *mailbox, struct index_init *init
                                                     state->userid);
     }
 
-    if (state->mailbox->mbtype & MBTYPES_NONIMAP) {
+    if (mbtype_isa(state->mailbox->mbtype) != MBTYPE_EMAIL) {
         if (state->want_dav) {
             /* User logged in using imapmagicplus token "dav" */
         }
-        else if (state->mailbox->mbtype == state->want_mbtype) {
+        else if (mbtype_isa(state->mailbox->mbtype) == state->want_mbtype) {
             /* Caller explicitly asks for this NONIMAP type */
         }
         else {

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -520,7 +520,7 @@ static int capabilities_cb(const mbentry_t *mbentry, void *vrock)
     mbname_t *mbname = mbname_from_intname(mbentry->name);
     const strarray_t *boxes = mbname_boxes(mbname);
     if (!rock->has_mail) {
-        rock->has_mail = mbentry->mbtype == MBTYPE_EMAIL;
+        rock->has_mail = mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL;
     }
     if (!rock->has_contacts) {
         rock->has_contacts = strarray_size(boxes) >= 1 &&

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1083,6 +1083,20 @@ HIDDEN int jmap_openmbox(jmap_req_t *req, const char *name,
     return 0;
 }
 
+HIDDEN int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,
+                                     struct mailbox **mboxp, int rw)
+{
+    mbentry_t *mbentry = NULL;
+
+    int r = mboxlist_lookup_by_uniqueid(id, &mbentry, NULL);
+
+    if (!r && mbentry) r = jmap_openmbox(req, mbentry->name, mboxp, rw);
+
+    mboxlist_entry_free(&mbentry);
+
+    return r;
+}
+
 HIDDEN int jmap_isopenmbox(jmap_req_t *req, const char *name)
 {
 

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1342,14 +1342,14 @@ HIDDEN int jmap_cmpstate(jmap_req_t* req, json_t *state, int mbtype)
         }
         modseq_t client_modseq = atomodseq_t(s);
         modseq_t server_modseq = 0;
-        switch (mbtype) {
+        switch (mbtype_isa(mbtype)) {
          case MBTYPE_CALENDAR:
              server_modseq = req->counters.caldavmodseq;
              break;
          case MBTYPE_ADDRESSBOOK:
              server_modseq = req->counters.carddavmodseq;
              break;
-         case MBTYPE_SUBMISSION:
+         case MBTYPE_JMAPSUBMIT:
              server_modseq = req->counters.submissionmodseq;
              break;
          default:
@@ -1370,17 +1370,17 @@ HIDDEN modseq_t jmap_highestmodseq(jmap_req_t *req, int mbtype)
     modseq_t modseq;
 
     /* Determine current counter by mailbox type. */
-    switch (mbtype) {
+    switch (mbtype_isa(mbtype)) {
         case MBTYPE_CALENDAR:
             modseq = req->counters.caldavmodseq;
             break;
         case MBTYPE_ADDRESSBOOK:
             modseq = req->counters.carddavmodseq;
             break;
-        case MBTYPE_SUBMISSION:
+        case MBTYPE_JMAPSUBMIT:
             modseq = req->counters.submissionmodseq;
             break;
-        case 0:
+        case MBTYPE_EMAIL:
             modseq = req->counters.mailmodseq;
             break;
         default:
@@ -1478,7 +1478,7 @@ HIDDEN int jmap_mbtype(jmap_req_t *req, const char *mboxname)
     }
     else mbtype = mbstate->mbtype;
 
-    return mbtype;
+    return mbtype_isa(mbtype);
 }
 
 // gotta have them all
@@ -2743,7 +2743,7 @@ HIDDEN json_t *jmap_get_sharewith(const mbentry_t *mbentry)
 {
     char *aclstr = xstrdupnull(mbentry->acl);
     char *owner = mboxname_to_userid(mbentry->name);
-    int iscalendar = (mbentry->mbtype & MBTYPE_CALENDAR);
+    int iscalendar = mbtype_isa(mbentry->mbtype) == MBTYPE_CALENDAR;
 
     json_t *sharewith = json_null();
 
@@ -3007,8 +3007,8 @@ HIDDEN int jmap_set_sharewith(struct mailbox *mbox,
                               json_t *shareWith, int overwrite)
 {
     hash_table user_access = HASH_TABLE_INITIALIZER;
-    int isdav = (mbox->mbtype & MBTYPES_DAV);
-    int iscalendar = (mbox->mbtype & MBTYPE_CALENDAR);
+    int isdav = mbtypes_dav(mbox->mbtype);
+    int iscalendar = mbtype_isa(mbox->mbtype) == MBTYPE_CALENDAR;
     char *owner = mboxname_to_userid(mbox->name);
     char *acl = xstrdup(mbox->acl);
     struct acl_change *change;
@@ -3152,7 +3152,7 @@ HIDDEN int jmap_set_sharewith(struct mailbox *mbox,
         /* Find the DAV namespace for this mailbox */
         if (iscalendar)
             irock.tgt.namespace = &namespace_calendar;
-        else if (mbox->mbtype & MBTYPE_ADDRESSBOOK)
+        else if (mbtype_isa(mbox->mbtype) == MBTYPE_ADDRESSBOOK)
             irock.tgt.namespace = &namespace_addressbook;
         else
             irock.tgt.namespace = &namespace_drive;

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -938,8 +938,12 @@ static int findaccounts_cb(struct findall_data *data, void *vrock)
     const mbentry_t *mbentry = data->mbentry;
 
     /* Skip any special use folders (#jmap, #calendars, #notifications, etc.) */
-    if (mbentry->mbtype &&
-        !(mbentry->mbtype & (MBTYPE_CALENDAR | MBTYPE_ADDRESSBOOK))) {
+    switch (mbtype_isa(mbentry->mbtype)) {
+    case MBTYPE_EMAIL:
+    case MBTYPE_CALENDAR:
+    case MBTYPE_ADDRESSBOOK:
+        break;
+    default:
         return 0;
     }
 
@@ -2909,13 +2913,18 @@ static int sharedrights_cb(const mbentry_t *mbentry, void *vrock)
     const char *userid;
     char *nextid = NULL;
 
-    /* skip any special use folders */
-    if (mbentry->mbtype &&
-        !(mbentry->mbtype & (MBTYPE_CALENDAR | MBTYPE_ADDRESSBOOK))) {
+    /* Skip any special use folders (#jmap, #calendars, #notifications, etc.) */
+    switch (mbtype_isa(mbentry->mbtype)) {
+    case MBTYPE_EMAIL:
+    case MBTYPE_CALENDAR:
+    case MBTYPE_ADDRESSBOOK:
+        break;
+    default:
         return 0;
     }
+
     /* make sure we skip the upload folder itself */
-    else if (!strcmp(mbentry->name, srock->upload_mboxname)) {
+    if (!strcmp(mbentry->name, srock->upload_mboxname)) {
         return 0;
     }
 

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -260,6 +260,8 @@ extern void jmap_accounts(json_t *accounts, json_t *primary_accounts);
 /* Request-scoped mailbox cache */
 extern int  jmap_openmbox(jmap_req_t *req, const char *name,
                           struct mailbox **mboxp, int rw);
+extern int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,
+                                     struct mailbox **mboxp, int rw);
 extern int  jmap_isopenmbox(jmap_req_t *req, const char *name);
 extern void jmap_closembox(jmap_req_t *req, struct mailbox **mboxp);
 

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -269,7 +269,7 @@ static json_t *jmap_restore_reply(struct jmap_restore *restore)
 struct restore_rock {
     jmap_req_t *req;
     struct jmap_restore *jrestore;
-    int mbtype;
+    uint32_t mbtype;
     modseq_t deletedmodseq;
     char *(*resource_name_cb)(message_t *, void *);
     int (*restore_cb)(message_t *, message_t *, jmap_req_t *, void *, int);
@@ -348,7 +348,7 @@ static int restore_collection_cb(const mbentry_t *mbentry, void *rock)
     syslog(log_level, "restore_collection_cb: processing '%s'  (type = 0x%03x)",
            mbentry->name, mbentry->mbtype);
 
-    if ((mbentry->mbtype & rrock->mbtype) != rrock->mbtype) {
+    if (mbtype_isa(mbentry->mbtype) != rrock->mbtype) {
         syslog(log_level, "skipping '%s': not type 0x%03x",
                mbentry->name, rrock->mbtype);
 
@@ -754,7 +754,7 @@ static int restore_addressbook_cb(const mbentry_t *mbentry, void *rock)
     struct mailbox *mailbox = NULL;
     int r;
 
-    if ((mbentry->mbtype & rrock->mbtype) != rrock->mbtype) return 0;
+    if (mbtype_isa(mbentry->mbtype) != rrock->mbtype) return 0;
 
     /* Open mailbox here since we need it later and it gets referenced counted */
     r = jmap_openmbox(rrock->req, mbentry->name, &mailbox, /*rw*/1);
@@ -1193,7 +1193,7 @@ static int restore_calendar_cb(const mbentry_t *mbentry, void *rock)
     time_t timestamp = 0;
     int r = 0;
 
-    if ((mbentry->mbtype & rrock->mbtype) != rrock->mbtype) return 0;
+    if (mbtype_isa(mbentry->mbtype) != rrock->mbtype) return 0;
     if (!jmap_hasrights_mbentry(rrock->req, mbentry, JACL_ADDITEMS)) return 0;
 
     if (!strcmp(mbentry->name, crock->inboxname) ||
@@ -1430,7 +1430,7 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
     syslog(log_level, "restore_message_list_cb: processing '%s'  (type = 0x%03x)",
            mbentry->name, mbentry->mbtype);
 
-    if (mbentry->mbtype != MBTYPE_EMAIL) {
+    if (mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL) {
         syslog(log_level, "skipping '%s': not type EMAIL", mbentry->name);
 
         return 0;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -260,7 +260,7 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
     int r = 0;
 
     /* Only calendars... */
-    if (!(mbentry->mbtype & MBTYPE_CALENDAR)) return 0;
+    if (mbtype_isa(mbentry->mbtype) != MBTYPE_CALENDAR) return 0;
 
     /* ...which are at least readable or visible... */
     if (!jmap_hasrights_mbentry(rock->req, mbentry, JACL_READITEMS))

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1542,7 +1542,7 @@ static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *c
 
     const mbentry_t *mbentry;
     if (ctx->from_accountid) {
-        mboxlist_lookup_by_uniqueid(mboxid, &freeme);
+        mboxlist_lookup_by_uniqueid(mboxid, &freeme, NULL);
         mbentry = freeme;
     }
     else {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -574,7 +574,7 @@ static const jmap_property_t calendar_props[] = {
 static int has_calendars_cb(const mbentry_t *mbentry, void *rock)
 {
     jmap_req_t *req = rock;
-    if (mbentry->mbtype == MBTYPE_CALENDAR &&
+    if (mbtype_isa(mbentry->mbtype) == MBTYPE_CALENDAR &&
             jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
         return CYRUSDB_DONE;
     }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -577,7 +577,7 @@ static void cachecards_cb(uint64_t rowid, void *payload, void *vrock)
 static int has_addressbooks_cb(const mbentry_t *mbentry, void *rock)
 {
     jmap_req_t *req = rock;
-    if (mbentry->mbtype == MBTYPE_ADDRESSBOOK &&
+    if (mbtype_isa(mbentry->mbtype) == MBTYPE_ADDRESSBOOK &&
             jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
         return CYRUSDB_DONE;
     }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1874,7 +1874,7 @@ static int jmap_contact_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx)
 
     const mbentry_t *mbentry;
     if (ctx->from_accountid) {
-        mboxlist_lookup_by_uniqueid(mboxid, &freeme);
+        mboxlist_lookup_by_uniqueid(mboxid, &freeme, NULL);
         mbentry = freeme;
     }
     else {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -714,7 +714,7 @@ static int _email_mailboxes_cb(const conv_guidrec_t *rec, void *rock)
     if (r) return r;
 
     // we only want regular mailboxes!
-    if (mbox->mbtype & MBTYPES_NONIMAP) goto done;
+    if (mbtype_isa(mbox->mbtype) != MBTYPE_EMAIL) goto done;
 
     r = msgrecord_find(mbox, rec->uid, &mr);
     if (r) goto done;
@@ -1089,7 +1089,7 @@ static int _email_find_cb(const conv_guidrec_t *rec, void *rock)
                rec->mboxname, error_message(r));
         goto done;
     }
-    if (mbox->mbtype != MBTYPE_EMAIL) {
+    if (mbtype_isa(mbox->mbtype) != MBTYPE_EMAIL) {
         goto done;
     }
 
@@ -1236,7 +1236,7 @@ static int _email_is_expunged_cb(const conv_guidrec_t *rec, void *rock)
     r = jmap_openmbox(check->req, rec->mboxname, &mbox, 0);
     if (r) return r;
 
-    if (mbox->mbtype == MBTYPE_EMAIL) {
+    if (mbtype_isa(mbox->mbtype) == MBTYPE_EMAIL) {
         r = msgrecord_find(mbox, rec->uid, &mr);
         if (!r) {
             uint32_t internal_flags;
@@ -1821,7 +1821,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
             strarray_t *folders = strarray_new();
             const char *mboxid = json_string_value(val);
             const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mboxid);
-            if (mbentry && mbentry->mbtype == MBTYPE_EMAIL &&
+            if (mbentry && mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL &&
                     jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP)) {
                 strarray_append(folders, mbentry->name);
             }
@@ -1844,7 +1844,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
             json_array_foreach(val, i, jmboxid) {
                 const char *mboxid = json_string_value(jmboxid);
                 const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mboxid);
-                if (mbentry && mbentry->mbtype == MBTYPE_EMAIL &&
+                if (mbentry && mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL &&
                         jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP)) {
                     strarray_append(folders, mbentry->name);
                 }
@@ -3350,7 +3350,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         mbentry_t *mbentry = NULL;
         if (mboxname_isnondeliverymailbox(mboxname, 0) ||
             mboxlist_lookup_allow_all(mboxname, &mbentry, NULL) ||
-            mbentry->mbtype != MBTYPE_EMAIL) {
+            mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL) {
             bv_clear(&gsq->readable_folders, num);
         }
         mboxlist_entry_free(&mbentry);
@@ -4017,7 +4017,7 @@ static int _email_queryargs_parse(jmap_req_t *req,
         int is_valid = 0;
         if (!mboxlist_lookup(addrbookname, &mbentry, NULL)) {
             is_valid = jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP) &&
-                       mbentry->mbtype == MBTYPE_ADDRESSBOOK;
+                mbtype_isa(mbentry->mbtype) == MBTYPE_ADDRESSBOOK;
         }
         mboxlist_entry_free(&mbentry);
         free(addrbookname);
@@ -5689,7 +5689,7 @@ static int _email_get_keywords_cb(const conv_guidrec_t *rec, void *vrock)
     int r = jmap_openmbox(req, rec->mboxname, &mbox, 0);
     if (r) return r;
 
-    if (mbox->mbtype != MBTYPE_EMAIL) goto done;
+    if (mbtype_isa(mbox->mbtype) != MBTYPE_EMAIL) goto done;
 
     r = msgrecord_find(mbox, rec->uid, &mr);
     if (r) goto done;
@@ -7235,7 +7235,7 @@ static int _warmup_mboxcache_cb(const conv_guidrec_t *rec, void* vrock)
     struct mailbox *mbox = NULL;
     int r = jmap_openmbox(rock->req, rec->mboxname, &mbox, /*rw*/0);
     if (!r) {
-        if (mbox->mbtype == MBTYPE_EMAIL) {
+        if (mbtype_isa(mbox->mbtype) == MBTYPE_EMAIL) {
             ptrarray_append(&rock->mboxes, mbox);
         }
         else jmap_closembox(rock->req, &mbox);
@@ -10127,7 +10127,7 @@ static int _email_mboxrecs_read_cb(const conv_guidrec_t *rec, void *_rock)
         if (r) return r;
 
         // we only want regular mailboxes!
-        if (mbentry->mbtype & MBTYPES_NONIMAP) {
+        if (mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL) {
             mboxlist_entry_free(&mbentry);
             return 0;
         }
@@ -12602,7 +12602,7 @@ static int _email_copy_writeprops_cb(const conv_guidrec_t* rec, void* _rock)
 
     /* Overwrite message record */
     int r = jmap_openmbox(rock->req, rec->mboxname, &mbox, /*rw*/1);
-    if (r || mbox->mbtype != MBTYPE_EMAIL) {
+    if (r || mbtype_isa(mbox->mbtype) != MBTYPE_EMAIL) {
         goto done;
     }
     if (!r) r = msgrecord_find(mbox, rec->uid, &mr);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1821,7 +1821,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
             strarray_t *folders = strarray_new();
             const char *mboxid = json_string_value(val);
             const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mboxid);
-            if (mbentry && mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL &&
+            if (mbentry && mbentry->mbtype == MBTYPE_EMAIL &&
                     jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP)) {
                 strarray_append(folders, mbentry->name);
             }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1822,6 +1822,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
             const char *mboxid = json_string_value(val);
             const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mboxid);
             if (mbentry && mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL &&
+                !(mbentry->mbtype & MBTYPE_INTERMEDIATE) &&
                     jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP)) {
                 strarray_append(folders, mbentry->name);
             }
@@ -1845,6 +1846,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
                 const char *mboxid = json_string_value(jmboxid);
                 const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mboxid);
                 if (mbentry && mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL &&
+                    !(mbentry->mbtype & MBTYPE_INTERMEDIATE) &&
                         jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP)) {
                     strarray_append(folders, mbentry->name);
                 }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1821,7 +1821,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
             strarray_t *folders = strarray_new();
             const char *mboxid = json_string_value(val);
             const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mboxid);
-            if (mbentry && mbentry->mbtype == MBTYPE_EMAIL &&
+            if (mbentry && mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL &&
                     jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP)) {
                 strarray_append(folders, mbentry->name);
             }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -12557,7 +12557,8 @@ static int _email_copy_checkmbox_cb(const mbentry_t *mbentry, void *_rock)
     struct _email_copy_checkmbox_rock *rock = _rock;
 
     /* Ignore anything but regular and intermediate mailboxes */
-    if (!mbentry || (mbentry->mbtype & ~MBTYPE_INTERMEDIATE)) {
+    if (!mbentry || mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL ||
+        mbtypes_unavailable(mbentry->mbtype)) {
         return 0;
     }
     if (!json_object_get(rock->dst_mboxids, mbentry->uniqueid)) {

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -339,7 +339,7 @@ static int ensure_submission_collection(const char *accountid,
 
         int options = config_getint(IMAPOPT_MAILBOX_DEFAULT_OPTIONS)
             | OPT_POP3_NEW_UIDL | OPT_IMAP_HAS_ALARMS;
-        r = mboxlist_createmailbox_opts(mbentry->name, MBTYPE_SUBMISSION,
+        r = mboxlist_createmailbox_opts(mbentry->name, MBTYPE_JMAPSUBMIT,
                                         NULL, 1 /* admin */, accountid,
                                         httpd_authstate,
                                         options, 0, 0, 0, 0, NULL, NULL);
@@ -1259,7 +1259,7 @@ static int jmap_emailsubmission_get(jmap_req_t *req)
     if (mbox) jmap_closembox(req, &mbox);
 
     /* Build response */
-    json_t *jstate = jmap_getstate(req, MBTYPE_SUBMISSION, /*refresh*/ created);
+    json_t *jstate = jmap_getstate(req, MBTYPE_JMAPSUBMIT, /*refresh*/ created);
     get.state = xstrdup(json_string_value(jstate));
     json_decref(jstate);
     jmap_ok(req, jmap_get_reply(&get));
@@ -1402,7 +1402,7 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
     if (set.if_in_state) {
         /* TODO rewrite state function to use char* not json_t* */
         json_t *jstate = json_string(set.if_in_state);
-        if (jmap_cmpstate(req, jstate, MBTYPE_SUBMISSION)) {
+        if (jmap_cmpstate(req, jstate, MBTYPE_JMAPSUBMIT)) {
             jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
             json_decref(jstate);
             goto done;
@@ -1411,7 +1411,7 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
         set.old_state = xstrdup(set.if_in_state);
     }
     else {
-        json_t *jstate = jmap_getstate(req, MBTYPE_SUBMISSION, /*refresh*/0);
+        json_t *jstate = jmap_getstate(req, MBTYPE_JMAPSUBMIT, /*refresh*/0);
         set.old_state = xstrdup(json_string_value(jstate));
         json_decref(jstate);
     }
@@ -1477,7 +1477,7 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
 
     // TODO refactor jmap_getstate to return a string, once
     // all code has been migrated to the new JMAP parser.
-    json_t *jstate = jmap_getstate(req, MBTYPE_SUBMISSION, /*refresh*/1);
+    json_t *jstate = jmap_getstate(req, MBTYPE_JMAPSUBMIT, /*refresh*/1);
     set.new_state = xstrdup(json_string_value(jstate));
     json_decref(jstate);
 
@@ -1557,7 +1557,7 @@ static int jmap_emailsubmission_changes(jmap_req_t *req)
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         mboxlist_entry_free(&mbentry);
         r = 0;
-        changes.new_modseq = jmap_highestmodseq(req, MBTYPE_SUBMISSION);
+        changes.new_modseq = jmap_highestmodseq(req, MBTYPE_JMAPSUBMIT);
         jmap_ok(req, jmap_changes_reply(&changes));
         goto done;
     }
@@ -1620,7 +1620,7 @@ static int jmap_emailsubmission_changes(jmap_req_t *req)
     // if we issued a query for changes since 6, max_changes 1 - we'd get back
     // has_more_changes: true, new_modseq 15, and we'd never see UID=4 as having changed.
     changes.new_modseq = changes.has_more_changes ?
-        highest_modseq : jmap_highestmodseq(req, MBTYPE_SUBMISSION);
+        highest_modseq : jmap_highestmodseq(req, MBTYPE_JMAPSUBMIT);
 
     jmap_ok(req, jmap_changes_reply(&changes));
 
@@ -1980,7 +1980,7 @@ static int jmap_emailsubmission_query(jmap_req_t *req)
         mboxlist_entry_free(&mbentry);
         r = 0;
         /* Build response */
-        json_t *jstate = jmap_getstate(req, MBTYPE_SUBMISSION, /*refresh*/ created);
+        json_t *jstate = jmap_getstate(req, MBTYPE_JMAPSUBMIT, /*refresh*/ created);
         query.query_state = xstrdup(json_string_value(jstate));
         json_decref(jstate);
         query.result_position = 0;
@@ -2093,7 +2093,7 @@ static int jmap_emailsubmission_query(jmap_req_t *req)
     free(sortcrit);
 
     /* Build response */
-    json_t *jstate = jmap_getstate(req, MBTYPE_SUBMISSION, /*refresh*/ created);
+    json_t *jstate = jmap_getstate(req, MBTYPE_JMAPSUBMIT, /*refresh*/ created);
     query.query_state = xstrdup(json_string_value(jstate));
     json_decref(jstate);
     query.result_position = query.position;

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4129,7 +4129,7 @@ static int _mbox_changes_cb(const mbentry_t *mbentry, void *rock)
     jmap_req_t *req = data->req;
 
     /* Ignore anything but regular mailboxes */
-    if (mbentry->mbtype & ~(MBTYPE_DELETED | MBTYPE_INTERMEDIATE)) {
+    if (mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL) {
         return 0;
     }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1050,6 +1050,7 @@ static int mailbox_open_advanced(const char *name,
     mailbox->acl = xstrdup(mbentry->acl);
     mailbox->mbtype = mbentry->mbtype;
     mailbox->foldermodseq = mbentry->foldermodseq;
+    mailbox->legacy_dir = mbentry->legacy_dir;
 
     mboxlist_entry_free(&mbentry);
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -264,7 +264,6 @@ struct mailbox {
     char *part;
     char *acl;
     modseq_t foldermodseq;
-    int legacy_dir;
 
     struct index_header i;
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -458,6 +458,7 @@ typedef enum _MsgInternalFlags {
 #define RECONSTRUCT_REMOVE_ODDFILES (1<<7)
 #define RECONSTRUCT_IGNORE_ODDFILES (1<<8)
 #define RECONSTRUCT_PREFER_MBOXLIST (1<<9)
+#define RECONSTRUCT_REPAIR_MBOXLIST (1<<10)
 
 #define MAX_CACHED_HEADER_SIZE 32 /* Max size of a cached header name */
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -264,6 +264,7 @@ struct mailbox {
     char *part;
     char *acl;
     modseq_t foldermodseq;
+    int legacy_dir;
 
     struct index_header i;
 

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -1051,7 +1051,7 @@ EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *
 
 #ifdef WITH_DAV
     /* add caldav items */
-    if ((mailbox->mbtype & (MBTYPES_DAV)) &&
+    if (mbtypes_dav(mailbox->mbtype) &&
         (mboxevent_expected_param(event->type, EVENT_DAV_FILENAME) ||
          mboxevent_expected_param(event->type, EVENT_DAV_UID))) {
         const char *resource = NULL;
@@ -1074,14 +1074,16 @@ EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *
         }
 
         if (mboxevent_expected_param(event->type, EVENT_DAV_UID)) {
-            if (mailbox->mbtype & MBTYPE_ADDRESSBOOK) {
+            unsigned mbtype = mbtype_isa(mailbox->mbtype);
+
+            if (mbtype == MBTYPE_ADDRESSBOOK) {
                 struct carddav_db *carddavdb = NULL;
                 struct carddav_data *cdata = NULL;
                 carddavdb = mailbox_open_carddav(mailbox);
                 carddav_lookup_resource(carddavdb, mailbox->name, resource, &cdata, 1);
                 FILL_STRING_PARAM(event, EVENT_DAV_UID, xstrdup(cdata->vcard_uid));
             }
-            else if (mailbox->mbtype & MBTYPE_CALENDAR) {
+            else if (mbtype == MBTYPE_CALENDAR) {
                 struct caldav_db *caldavdb = NULL;
                 struct caldav_data *cdata = NULL;
                 caldavdb = mailbox_open_caldav(mailbox);
@@ -1246,7 +1248,7 @@ EXPORTED void mboxevent_extract_msgrecord(struct mboxevent *event, msgrecord_t *
     r = msgrecord_get_mailbox(msgrec, &mailbox);
     if (r) return;
 
-    if ((mailbox->mbtype & (MBTYPES_DAV)) &&
+    if (mbtypes_dav(mailbox->mbtype) &&
         (mboxevent_expected_param(event->type, EVENT_DAV_FILENAME) ||
          mboxevent_expected_param(event->type, EVENT_DAV_UID))) {
         const char *resource = NULL;
@@ -1271,14 +1273,16 @@ EXPORTED void mboxevent_extract_msgrecord(struct mboxevent *event, msgrecord_t *
         }
 
         if (mboxevent_expected_param(event->type, EVENT_DAV_UID)) {
-            if (mailbox->mbtype & MBTYPE_ADDRESSBOOK) {
+            unsigned mbtype = mbtype_isa(mailbox->mbtype);
+
+            if (mbtype == MBTYPE_ADDRESSBOOK) {
                 struct carddav_db *carddavdb = NULL;
                 struct carddav_data *cdata = NULL;
                 carddavdb = mailbox_open_carddav(mailbox);
                 carddav_lookup_resource(carddavdb, mailbox->name, resource, &cdata, 1);
                 FILL_STRING_PARAM(event, EVENT_DAV_UID, xstrdup(cdata->vcard_uid));
             }
-            else if (mailbox->mbtype & MBTYPE_CALENDAR) {
+            else if (mbtype == MBTYPE_CALENDAR) {
                 struct caldav_db *caldavdb = NULL;
                 struct caldav_data *cdata = NULL;
                 caldavdb = mailbox_open_caldav(mailbox);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -883,16 +883,14 @@ static void mboxlist_racl_key(int isuser, const char *keyuser,
 {
     buf_reset(buf);
     buf_putc(buf, KEY_TYPE_ACL);
-    if (keyuser || dbname) {
-        buf_putc(buf, isuser ? 'U' : 'S');
+    buf_putc(buf, isuser ? 'U' : 'S');
+    buf_putc(buf, ACL_RECORDSEP_CHAR);
+    if (keyuser) {
+        buf_appendcstr(buf, keyuser);
         buf_putc(buf, ACL_RECORDSEP_CHAR);
-        if (keyuser) {
-            buf_appendcstr(buf, keyuser);
-            buf_putc(buf, ACL_RECORDSEP_CHAR);
-        }
-        if (dbname) {
-            buf_appendcstr(buf, dbname);
-        }
+    }
+    if (dbname) {
+        buf_appendcstr(buf, dbname);
     }
 }
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -239,7 +239,7 @@ EXPORTED const char *mboxlist_mbtype_to_string(uint32_t mbtype)
     return buf_cstring(&buf);
 }
 
-static char *mboxlist_entry_cstring(const mbentry_t *mbentry)
+static char *mboxlist_name_entry_cstring(const mbentry_t *mbentry)
 {
     struct buf buf = BUF_INITIALIZER;
     struct dlist *dl = dlist_newkvlist(NULL, mbentry->name);
@@ -269,6 +269,20 @@ static char *mboxlist_entry_cstring(const mbentry_t *mbentry)
         dlist_setnum64(dl, "F", mbentry->foldermodseq);
 
     dlist_setdate(dl, "M", time(NULL));
+
+    dlist_printbuf(dl, 0, &buf);
+
+    dlist_free(&dl);
+
+    return buf_release(&buf);
+}
+
+static char *mboxlist_id_entry_cstring(const char *id, const char *name)
+{
+    struct buf buf = BUF_INITIALIZER;
+    struct dlist *dl = dlist_newkvlist(NULL, id);
+
+    dlist_setatom(dl, "N", name);
 
     dlist_printbuf(dl, 0, &buf);
 
@@ -318,17 +332,18 @@ static void mboxlist_id_to_key(const char *id, struct buf *key)
 /*
  * read a single _N_ame record from the mailboxes.db and return a pointer to it
  */
-static int mboxlist_read(const char *name, const char **dataptr, size_t *datalenptr,
-                         struct txn **tid, int wrlock)
+static int mboxlist_read_name(const char *dbname,
+                              const char **dataptr, size_t *datalenptr,
+                              struct txn **tid, int wrlock)
 {
     struct buf key = BUF_INITIALIZER;
-    int namelen = strlen(name);
+    int namelen = strlen(dbname);
     int r;
 
     if (!namelen)
         return IMAP_MAILBOX_NONEXISTENT;
 
-    mboxlist_dbname_to_key(name, namelen, &key);
+    mboxlist_dbname_to_key(dbname, namelen, &key);
 
     if (wrlock) {
         r = cyrusdb_fetchlock(mbdb, buf_base(&key), buf_len(&key),
@@ -354,7 +369,7 @@ static int mboxlist_read(const char *name, const char **dataptr, size_t *datalen
 
     default:
     {
-        char *intname = mboxname_from_dbname(name);
+        char *intname = mboxname_from_dbname(dbname);
         xsyslog(LOG_ERR, "DBERROR: error fetching mboxlist",
                          "mailbox=<%s> error=<%s>",
                          intname, cyrusdb_strerror(r));
@@ -427,7 +442,7 @@ struct parseentry_rock {
     int doingacl;
 };
 
-int parseentry_cb(int type, struct dlistsax_data *d)
+static int parse_name_entry_cb(int type, struct dlistsax_data *d)
 {
     struct parseentry_rock *rock = (struct parseentry_rock *)d->rock;
 
@@ -480,7 +495,7 @@ int parseentry_cb(int type, struct dlistsax_data *d)
 }
 
 /*
- * parse a record read from the mailboxes.db into its parts.
+ * parse a name record read from the mailboxes.db into its parts.
  *
  * full dlist format is:
  *  A: _a_cl
@@ -493,9 +508,9 @@ int parseentry_cb(int type, struct dlistsax_data *d)
  *  T: _t_ype
  *  V: uid_v_alidity
  */
-EXPORTED int mboxlist_parse_entry(mbentry_t **mbentryptr,
-                                  const char *name, size_t namelen,
-                                  const char *data, size_t datalen)
+static int mboxlist_parse_name_entry(mbentry_t **mbentryptr,
+                                     const char *name, size_t namelen,
+                                     const char *data, size_t datalen)
 {
     static struct buf aclbuf;
     int r = IMAP_MAILBOX_BADFORMAT;
@@ -520,7 +535,7 @@ EXPORTED int mboxlist_parse_entry(mbentry_t **mbentryptr,
         rock.mbentry = mbentry;
         rock.aclbuf = &aclbuf;
         aclbuf.len = 0;
-        r = dlist_parsesax(data, datalen, 0, parseentry_cb, &rock);
+        r = dlist_parsesax(data, datalen, 0, parse_name_entry_cb, &rock);
         if (!r) mbentry->acl = buf_newcstring(&aclbuf);
         goto done;
     }
@@ -577,6 +592,58 @@ done:
     return r;
 }
 
+static int parse_id_entry_cb(int type, struct dlistsax_data *d)
+{
+    struct parseentry_rock *rock = (struct parseentry_rock *)d->rock;
+    const char *key;
+
+    switch(type) {
+    case DLISTSAX_STRING:
+        key = buf_cstring(&d->kbuf);
+
+        if (!strcmp(key, "N")) {
+            rock->mbentry->name = mboxname_from_dbname(d->data);
+        }
+        break;
+    }
+
+    return 0;
+}
+
+/*
+ * parse an id record read from the mailboxes.db into its parts.
+ *
+ * full dlist format is:
+ *  N: _n_ame
+ */
+static int mboxlist_parse_id_entry(mbentry_t **mbentryptr,
+                                   const char *id, size_t idlen,
+                                   const char *data, size_t datalen)
+{
+    int r = IMAP_MAILBOX_BADFORMAT;
+    mbentry_t *mbentry = mboxlist_entry_create();
+
+    if (!datalen)
+        goto done;
+
+    /* copy id */
+    if (idlen)
+        mbentry->uniqueid = xstrndup(id, idlen);
+    else
+        mbentry->uniqueid = xstrdup(id);
+
+    struct parseentry_rock rock;
+    memset(&rock, 0, sizeof(struct parseentry_rock));
+    rock.mbentry = mbentry;
+    r = dlist_parsesax(data, datalen, 0, parse_id_entry_cb, &rock);
+
+done:
+    if (!r && mbentryptr)
+        *mbentryptr = mbentry;
+    else mboxlist_entry_free(&mbentry);
+    return r;
+}
+
 /* read a record and parse into parts */
 static int mboxlist_mylookup(const char *dbname,
                              mbentry_t **mbentryptr,
@@ -589,10 +656,10 @@ static int mboxlist_mylookup(const char *dbname,
 
     init_internal();
 
-    r = mboxlist_read(dbname, &data, &datalen, tid, wrlock);
+    r = mboxlist_read_name(dbname, &data, &datalen, tid, wrlock);
     if (r) return r;
 
-    r = mboxlist_parse_entry(&entry, dbname, 0, data, datalen);
+    r = mboxlist_parse_name_entry(&entry, dbname, 0, data, datalen);
     if (r) return r;
 
     if (!allow_all) {
@@ -738,15 +805,22 @@ EXPORTED char *mboxlist_find_uniqueid(const char *uniqueid,
     int r;
     const char *data;
     size_t datalen;
-    char dbname[MAX_MAILBOX_NAME];
+    mbentry_t *mbentry = NULL;
+    char *mbname;
 
     init_internal();
 
     r = mboxlist_read_uniqueid(uniqueid, &data, &datalen, NULL, 0);
     if (r) return NULL;
 
-    snprintf(dbname, sizeof(dbname), "%.*s", (int) datalen, data);
-    return mboxname_from_dbname(dbname);
+    r = mboxlist_parse_id_entry(&mbentry, uniqueid, 0, data, datalen);
+    if (r) return NULL;
+
+    mbname = mbentry->name;
+    mbentry->name = NULL;
+    mboxlist_entry_free(&mbentry);
+
+    return mbname;
 }
 
 /* given a mailbox name, find the staging directory.  XXX - this should
@@ -894,7 +968,7 @@ static int mboxlist_update_name(const char *dbname,
     mboxlist_dbname_to_key(dbname, strlen(dbname), &key);
 
     if (mbentry) {
-        char *mboxent = mboxlist_entry_cstring(mbentry);
+        char *mboxent = mboxlist_name_entry_cstring(mbentry);
         r = cyrusdb_store(mbdb, buf_base(&key), buf_len(&key),
                           mboxent, strlen(mboxent), txn);
         free(mboxent);
@@ -920,8 +994,10 @@ static int mboxlist_update_id(const char *id,
     mboxlist_id_to_key(id, &key);
 
     if (dbname) {
+        char *mboxent = mboxlist_id_entry_cstring(id, dbname);
         r = cyrusdb_store(mbdb, buf_base(&key), buf_len(&key),
-                          dbname, strlen(dbname), txn);
+                          mboxent, strlen(mboxent), txn);
+        free(mboxent);
     }
     else {
         r = cyrusdb_delete(mbdb, buf_base(&key), buf_len(&key),
@@ -3184,9 +3260,9 @@ static int find_p(void *rockp,
         goto good;
 
     /* ignore entirely deleted records */
-    if (mboxlist_parse_entry(&rock->mbentry,
-                             buf_cstring(&dbname), buf_len(&dbname),
-                             data, datalen))
+    if (mboxlist_parse_name_entry(&rock->mbentry,
+                                  buf_cstring(&dbname), buf_len(&dbname),
+                                  data, datalen))
         goto nomatch;
 
     /* nobody sees tombstones */
@@ -3311,9 +3387,9 @@ static int allmbox_cb(void *rock,
         struct buf dbname = BUF_INITIALIZER;
 
         mboxlist_dbname_from_key(key, keylen, &dbname);
-        int r = mboxlist_parse_entry(&mbrock->mbentry,
-                                     buf_base(&dbname), buf_len(&dbname),
-                                     data, datalen);
+        int r = mboxlist_parse_name_entry(&mbrock->mbentry,
+                                          buf_base(&dbname), buf_len(&dbname),
+                                          data, datalen);
         buf_free(&dbname);
         if (r) return r;
     }
@@ -3338,8 +3414,9 @@ static int allmbox_p(void *rock,
     mboxlist_entry_free(&mbrock->mbentry);
 
     mboxlist_dbname_from_key(key, keylen, &dbname);
-    r = mboxlist_parse_entry(&mbrock->mbentry,
-                             buf_base(&dbname), buf_len(&dbname), data, datalen);
+    r = mboxlist_parse_name_entry(&mbrock->mbentry,
+                                  buf_base(&dbname), buf_len(&dbname),
+                                  data, datalen);
     buf_free(&dbname);
     if (r) return 0;
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1021,12 +1021,10 @@ static int mboxlist_update_entry(const char *name,
             mbentry_t *oldid = NULL;
             struct dlist *name_history = dlist_newlist(NULL, "H");
 
-            /* Remove I field from N record value */
-            struct dlist *id = dlist_pop(dl);
-            dlist_free(&id);
-
-            /* Add N field for I record value */
-            dlist_push(dl, dlist_setatom(NULL, "N", dbname));
+            /* Rebrand I field as N field for I record value */
+            struct dlist *c = dlist_getchild(dl, "I");
+            dlist_rename(c, "N");
+            dlist_makeatom(c, dbname);
 
             mboxlist_lookup_by_uniqueid(mbentry->uniqueid, &oldid, txn);
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1068,7 +1068,7 @@ static int mboxlist_update_entry(const char *name,
     }
     else {
         r = cyrusdb_delete(mbdb, buf_base(&key), buf_len(&key), txn, /*force*/1);
-        if (!r && old->uniqueid) {
+        if (!r && old && old->uniqueid) {
             mboxlist_id_to_key(old->uniqueid, &key);
             r = cyrusdb_delete(mbdb, buf_base(&key), buf_len(&key),
                                txn, /*force*/1);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -166,6 +166,8 @@ EXPORTED void mboxlist_entry_free(mbentry_t **mbentryptr)
 
     free(mbentry->legacy_specialuse);
 
+    ptrarray_fini(&mbentry->synonyms);
+
     free(mbentry);
 
     *mbentryptr = NULL;
@@ -428,20 +430,26 @@ struct parseentry_rock {
 static int parseentry_cb(int type, struct dlistsax_data *d)
 {
     struct parseentry_rock *rock = (struct parseentry_rock *)d->rock;
+    const char *key = buf_cstring(&d->kbuf);
 
     switch(type) {
+    case DLISTSAX_LISTSTART:
+        if (!strcmp(key, "Y")) rock->doingsyns = 1;
+        break;
+    case DLISTSAX_LISTEND:
+        if (rock->doingsyns) rock->doingsyns = 0;
+        break;
     case DLISTSAX_KVLISTSTART:
-        if (!strcmp(buf_cstring(&d->kbuf), "A")) {
+        if (!strcmp(key, "A")) {
             rock->doingacl = 1;
         }
-        else if (!strcmp(buf_cstring(&d->kbuf), "Y")) {
-            rock->doingsyns = 1;
-            rock->mbentry->synonyms = dlist_newkvlist(NULL, "Y");
+        else if (rock->doingsyns) {
+            ptrarray_append(&rock->mbentry->synonyms,
+                            xzmalloc(sizeof(synonym_t)));
         }
         break;
     case DLISTSAX_KVLISTEND:
         if (rock->doingacl) rock->doingacl = 0;
-        else if (rock->doingsyns) rock->doingsyns = 0;
         break;
     case DLISTSAX_STRING:
         if (rock->doingacl) {
@@ -451,11 +459,19 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
             buf_putc(rock->aclbuf, '\t');
         }
         else if (rock->doingsyns) {
-            dlist_setatom(rock->mbentry->synonyms,
-                          buf_cstring(&d->kbuf), d->data);
+            synonym_t *syn = ptrarray_tail(&rock->mbentry->synonyms);
+
+            if (!strcmp(key, "F")) {
+                syn->foldermodseq = atoll(d->data);
+            }
+            else if (!strcmp(key, "M")) {
+                syn->mtime = atoi(d->data);
+            }
+            else if (!strcmp(key, "N")) {
+                xstrncpy(syn->dbname, d->data, MAX_MAILBOX_NAME);
+            }
         }
         else {
-            const char *key = buf_cstring(&d->kbuf);
             if (!strcmp(key, "C")) {
                 rock->mbentry->createdmodseq = atomodseq_t(d->data);
             }
@@ -930,6 +946,18 @@ static int mboxlist_update_racl(const char *dbname, const mbentry_t *oldmbentry,
     return r;
 }
 
+static void add_synonym(struct dlist *synonyms,
+                        const char *dbname, time_t mtime, modseq_t foldermodseq)
+{
+    struct dlist *syn = dlist_newkvlist(NULL, "");
+
+    dlist_setatom(syn, "N", dbname);
+    dlist_setnum64(syn, "F", foldermodseq);
+    dlist_setdate(syn, "M", mtime);
+
+    dlist_push(synonyms, syn);
+}
+
 static int mboxlist_update_entry(const char *name,
                                  const mbentry_t *mbentry, struct txn **txn)
 {
@@ -959,7 +987,7 @@ static int mboxlist_update_entry(const char *name,
         if (!r && mbentry->uniqueid &&
             !(old && (old->mbtype & MBTYPE_DELETED) && (mbentry->mbtype & MBTYPE_DELETED))) {
             mbentry_t *oldid = NULL;
-            struct dlist *synonyms = NULL;
+            struct dlist *synonyms = dlist_newlist(NULL, "Y");
 
             /* Remove I field from N record value */
             struct dlist *id = dlist_pop(dl);
@@ -971,19 +999,25 @@ static int mboxlist_update_entry(const char *name,
             mboxlist_lookup_by_uniqueid(mbentry->uniqueid, &oldid, txn);
 
             if (oldid) {
-                synonyms = oldid->synonyms;
-                oldid->synonyms = NULL;
+                /* Existing mailbox */
+                int i;
+                for (i = 0; i < oldid->synonyms.count; i++) {
+                    synonym_t *syn = ptrarray_nth(&oldid->synonyms, i);
+                    add_synonym(synonyms,
+                                syn->dbname, syn->mtime, syn->foldermodseq);
+                    free(syn);
+                }
 
                 if (strcmp(name, oldid->name)) {
                     /* Renamed mailbox */
-                    dlist_setnum64(synonyms, dbname, mbentry->foldermodseq);
+                    add_synonym(synonyms,
+                                dbname, time(NULL), mbentry->foldermodseq);
                 }
                 mboxlist_entry_free(&oldid);
             }
             else {
                 /* New mailbox */
-                synonyms = dlist_newkvlist(NULL, "Y");
-                dlist_setnum64(synonyms, dbname, mbentry->foldermodseq);
+                add_synonym(synonyms, dbname, time(NULL), mbentry->foldermodseq);
             }
 
             /* Add Y field for I record value */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -493,6 +493,7 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
  *  A: _a_cl
  *  C  _c_reatedmodseq
  *  F: _f_oldermodseq
+ *  H: _h_istory (TODO)
  *  I: unique_i_d
  *  M: _m_time
  *  N: _n_ame

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -89,7 +89,7 @@
 
 #define KEY_TYPE_NAME 'N'
 #define KEY_TYPE_ID   'I'
-#define KEY_TYPE_RACL 'R'
+#define KEY_TYPE_ACL  'A'
 
 #define DB_DOMAINSEP_STR    "\x1D"  /* group separator (GS) */
 #define DB_DOMAINSEP_CHAR   DB_DOMAINSEP_STR[0]
@@ -881,7 +881,7 @@ static void mboxlist_racl_key(int isuser, const char *keyuser,
                               const char *dbname, struct buf *buf)
 {
     buf_reset(buf);
-    buf_putc(buf, KEY_TYPE_RACL);
+    buf_putc(buf, KEY_TYPE_ACL);
     if (keyuser || dbname) {
         buf_putc(buf, isuser ? 'U' : 'S');
         buf_putc(buf, '$');

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -985,7 +985,7 @@ static int mboxlist_update_entry(const char *name,
         r = cyrusdb_store(mbdb, buf_base(&key), buf_len(&key),
                           buf_cstring(&mboxent), buf_len(&mboxent), txn);
         if (!r && mbentry->uniqueid &&
-            !(old && (old->mbtype & MBTYPE_DELETED) && (mbentry->mbtype & MBTYPE_DELETED))) {
+            !(old && (old->mbtype & mbentry->mbtype & MBTYPE_DELETED))) {
             mbentry_t *oldid = NULL;
             struct dlist *synonyms = dlist_newlist(NULL, "Y");
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -214,33 +214,50 @@ EXPORTED const char *mboxlist_mbtype_to_string(uint32_t mbtype)
 
     buf_reset(&buf);
 
+    /* mailbox types */
+    switch (mbtype_isa(mbtype)) {
+    case MBTYPE_EMAIL:
+        buf_putc(&buf, 'e');
+        break;
+    case MBTYPE_NETNEWS:
+        buf_putc(&buf, 'n');
+        break;
+    case MBTYPE_COLLECTION:
+        buf_putc(&buf, 'b');
+        break;
+    case MBTYPE_CALENDAR:
+        buf_putc(&buf, 'c');
+        break;
+    case MBTYPE_ADDRESSBOOK:
+        buf_putc(&buf, 'a');
+        break;
+    case MBTYPE_JMAPNOTIFY:
+        buf_putc(&buf, 'j');
+        break;
+    case MBTYPE_JMAPSUBMIT:
+        buf_putc(&buf, 's');
+        break;
+    case MBTYPE_JMAPPUSHSUB:
+        buf_putc(&buf, 'p');
+        break;
+    }
+
+    /* mailbox flags */
     if (mbtype & MBTYPE_DELETED)
         buf_putc(&buf, 'd');
     if (mbtype & MBTYPE_MOVING)
         buf_putc(&buf, 'm');
-    if (mbtype & MBTYPE_NETNEWS)
-        buf_putc(&buf, 'n');
     if (mbtype & MBTYPE_REMOTE)
         buf_putc(&buf, 'r');
     if (mbtype & MBTYPE_RESERVE)
         buf_putc(&buf, 'z');
-    if (mbtype & MBTYPE_CALENDAR)
-        buf_putc(&buf, 'c');
-    if (mbtype & MBTYPE_COLLECTION)
-        buf_putc(&buf, 'b');
-    if (mbtype & MBTYPE_ADDRESSBOOK)
-        buf_putc(&buf, 'a');
     if (mbtype & MBTYPE_INTERMEDIATE)
         buf_putc(&buf, 'i');
-    if (mbtype & MBTYPE_SUBMISSION)
-        buf_putc(&buf, 's');
-    if (mbtype & MBTYPE_PUSHSUBSCRIPTION)
-        buf_putc(&buf, 'p');
-    if (mbtype & MBTYPE_JMAPNOTIFICATION)
-        buf_putc(&buf, 'j');
+    if (mbtype & MBTYPE_LEGACY_DIRS)
+        buf_putc(&buf, 'l');
 
     /* make sure we didn't forget to set a character for every interesting bit */
-    if (mbtype) assert(buf_len(&buf));
+    assert(buf_len(&buf));
 
     return buf_cstring(&buf);
 }
@@ -275,9 +292,6 @@ static struct dlist *mboxlist_entry_dlist(const char *dbname,
 
     if (mbentry->acl)
         _write_acl(dl, mbentry->acl);
-
-    if (mbentry->legacy_dir)
-        dlist_setnum32(dl, "L", 1);
 
     return dl;
 }
@@ -381,39 +395,49 @@ EXPORTED uint32_t mboxlist_string_to_mbtype(const char *string)
     if (!string) return 0; /* null just means default */
 
     for (; *string; string++) {
+        /* mailbox types */
         switch (*string) {
         case 'a':
-            mbtype |= MBTYPE_ADDRESSBOOK;
+            mbtype = MBTYPE_ADDRESSBOOK;
             break;
         case 'b':
-            mbtype |= MBTYPE_COLLECTION;
+            mbtype = MBTYPE_COLLECTION;
             break;
         case 'c':
-            mbtype |= MBTYPE_CALENDAR;
+            mbtype = MBTYPE_CALENDAR;
             break;
+        case 'e':
+            mbtype = MBTYPE_EMAIL;
+            break;
+        case 'j':
+            mbtype = MBTYPE_JMAPNOTIFY;
+            break;
+        case 'n':
+            mbtype = MBTYPE_NETNEWS;
+            break;
+        case 'p':
+            mbtype = MBTYPE_JMAPPUSHSUB;
+            break;
+        case 's':
+            mbtype = MBTYPE_JMAPSUBMIT;
+            break;
+
+            
+        /* mailbox flags */
         case 'd':
             mbtype |= MBTYPE_DELETED;
             break;
         case 'i':
             mbtype |= MBTYPE_INTERMEDIATE;
             break;
-        case 'j':
-            mbtype |= MBTYPE_JMAPNOTIFICATION;
+        case 'l':
+            mbtype |= MBTYPE_LEGACY_DIRS;
             break;
         case 'm':
             mbtype |= MBTYPE_MOVING;
             break;
-        case 'n':
-            mbtype |= MBTYPE_NETNEWS;
-            break;
         case 'r':
             mbtype |= MBTYPE_REMOTE;
-            break;
-        case 'p':
-            mbtype |= MBTYPE_PUSHSUBSCRIPTION;
-            break;
-        case 's':
-            mbtype |= MBTYPE_SUBMISSION;
             break;
         case 'z':
             mbtype |= MBTYPE_RESERVE;
@@ -487,9 +511,6 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
             }
             else if (!strcmp(key, "I")) {
                 rock->mbentry->uniqueid = xstrdupnull(d->data);
-            }
-            else if (!strcmp(key, "L")) {
-                rock->mbentry->legacy_dir = 1;
             }
             else if (!strcmp(key, "M")) {
                 rock->mbentry->mtime = atoi(d->data);
@@ -1481,7 +1502,8 @@ EXPORTED int mboxlist_update_intermediaries(const char *frommboxname,
                                                  mbtype, MBOXMODSEQ_ISFOLDER);
 
                 mbentry_t *newmbentry = mboxlist_entry_copy(mbentry);
-                newmbentry->mbtype = MBTYPE_DELETED;
+                newmbentry->mbtype &= ~MBTYPE_INTERMEDIATE;
+                newmbentry->mbtype |= MBTYPE_DELETED;
                 newmbentry->foldermodseq = modseq;
 
                 syslog(LOG_NOTICE,
@@ -1515,7 +1537,7 @@ EXPORTED int mboxlist_update_intermediaries(const char *frommboxname,
         newmbentry->uniqueid = xstrdupnull(makeuuid());
         newmbentry->createdmodseq = modseq;
         newmbentry->foldermodseq = modseq;
-        newmbentry->mbtype = MBTYPE_INTERMEDIATE;
+        newmbentry->mbtype |= MBTYPE_INTERMEDIATE;
         newmbentry->foldermodseq = modseq;
 
         syslog(LOG_NOTICE,
@@ -2199,7 +2221,7 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
         int haschildren = mboxlist_haschildren(name);
         mbentry_t *newmbentry = mboxlist_entry_create();
         newmbentry->name = xstrdupnull(name);
-        newmbentry->mbtype = haschildren ? MBTYPE_INTERMEDIATE : MBTYPE_DELETED;
+        newmbentry->mbtype |= haschildren ? MBTYPE_INTERMEDIATE : MBTYPE_DELETED;
         if (mailbox) {
             newmbentry->uniqueid = xstrdupnull(mailbox->uniqueid);
             newmbentry->uidvalidity = mailbox->i.uidvalidity;
@@ -2629,7 +2651,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
             /* store a DELETED marker */
             mbentry_t *oldmbentry = mboxlist_entry_create();
             oldmbentry->name = xstrdupnull(mbentry->name);
-            oldmbentry->mbtype = MBTYPE_DELETED;
+            oldmbentry->mbtype |= MBTYPE_DELETED;
             oldmbentry->uidvalidity = mbentry->uidvalidity;
             oldmbentry->uniqueid = xstrdupnull(mbentry->uniqueid);
             oldmbentry->createdmodseq = mbentry->createdmodseq;
@@ -5161,7 +5183,7 @@ static int _upgrade_cb(void *rock,
 
     buf_setmap(urock->namebuf, key, keylen);
     mbentry->name = mboxname_to_dbname(buf_cstring(urock->namebuf));
-    mbentry->legacy_dir = 1;
+    mbentry->mbtype |= MBTYPE_LEGACY_DIRS;
     r = mboxlist_update_entry(mbentry->name, mbentry, urock->tid);
 
     mboxlist_entry_free(&mbentry);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -442,11 +442,13 @@ EXPORTED uint32_t mboxlist_string_to_mbtype(const char *string)
         case 'z':
             mbtype |= MBTYPE_RESERVE;
             break;
+
+        default:
+            /* make sure we didn't forget to handle every expected character */
+            assert(0);
+            break;
         }
     }
-
-    /* make sure we didn't forget to set a character for every interesting bit */
-    assert(mbtype);
 
     return mbtype;
 }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -946,7 +946,8 @@ static int mboxlist_update_entry(const char *name,
         dlist_printbuf(dl, 0, &mboxent);
         r = cyrusdb_store(mbdb, buf_base(&key), buf_len(&key),
                           buf_cstring(&mboxent), buf_len(&mboxent), txn);
-        if (!r && mbentry->uniqueid && !(old && (old->mbtype & MBTYPE_DELETED))) {
+        if (!r && mbentry->uniqueid &&
+            !(old && (old->mbtype & MBTYPE_DELETED) && (mbentry->mbtype & MBTYPE_DELETED))) {
             /* Remove I field from N record value */
             struct dlist *id = dlist_pop(dl);
             dlist_free(&id);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1084,9 +1084,14 @@ static int mboxlist_update_entry(const char *name,
     else {
         r = cyrusdb_delete(mbdb, buf_base(&key), buf_len(&key), txn, /*force*/1);
         if (!r && old && old->uniqueid) {
-            mboxlist_id_to_key(old->uniqueid, &key);
-            r = cyrusdb_delete(mbdb, buf_base(&key), buf_len(&key),
-                               txn, /*force*/1);
+            mbentry_t *mbentry = NULL;
+            int r1 = mboxlist_lookup_by_uniqueid(old->uniqueid, &mbentry, txn);
+            if (!r1 && !strcmp(old->name, mbentry->name)) {
+                mboxlist_id_to_key(old->uniqueid, &key);
+                r = cyrusdb_delete(mbdb, buf_base(&key), buf_len(&key),
+                                   txn, /*force*/1);
+            }
+            mboxlist_entry_free(&mbentry);
         }
     }
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5207,8 +5207,7 @@ static int _upgrade_cb(void *rock,
     r = mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
     if (r) return r;
 
-    buf_setmap(urock->namebuf, key, keylen);
-    mbentry->name = mboxname_to_dbname(buf_cstring(urock->namebuf));
+    mbentry->name = xstrndup(key, keylen);
     mbentry->mbtype |= MBTYPE_LEGACY_DIRS;
     r = mboxlist_update_entry(mbentry->name, mbentry, urock->tid);
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -810,7 +810,7 @@ EXPORTED char *mboxlist_find_uniqueid(const char *uniqueid,
     const char *data;
     size_t datalen;
     mbentry_t *mbentry = NULL;
-    char *mbname;
+    char *mbname = NULL;
 
     init_internal();
 
@@ -820,8 +820,12 @@ EXPORTED char *mboxlist_find_uniqueid(const char *uniqueid,
     r = mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
     if (r) return NULL;
 
-    mbname = mbentry->name;
-    mbentry->name = NULL;
+    // only note the name down if it's not deleted
+    if (!(mbentry->mbtype & MBTYPE_DELETED)) {
+        mbname = mbentry->name;
+        mbentry->name = NULL;
+    }
+
     mboxlist_entry_free(&mbentry);
 
     return mbname;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -812,7 +812,10 @@ EXPORTED int mboxlist_lookup_by_uniqueid(const char *uniqueid,
         return IMAP_MAILBOX_RESERVED;
     }
 
-    if (entryptr) *entryptr = entry;
+    if (entryptr) {
+        entry->uniqueid = xstrdup(uniqueid);
+        *entryptr = entry;
+    }
     else mboxlist_entry_free(&entry);
 
     return 0;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5198,9 +5198,9 @@ static int _upgrade_cb(void *rock,
     mbentry_t *mbentry = NULL;
     int r;
 
-    /* skip $RACL$ or $RUNQ$ keys */
-    if (keylen >= 6 &&
-        (!strncmp(key, "$RACL$", 6) || !strncmp(key, "$RUNQ$", 6))) {
+    /* skip $RACL and $RUNQ keys */
+    if (keylen >= 5 &&
+        (!strncmp(key, "$RACL", 5) || !strncmp(key, "$RUNQ", 5))) {
         return CYRUSDB_OK;
     }
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -266,6 +266,8 @@ static struct dlist *mboxlist_entry_dlist(const char *dbname,
 {
     struct dlist *dl = dlist_newkvlist(NULL, dbname);
 
+    dlist_setatom(dl, "T", mboxlist_mbtype_to_string(mbentry->mbtype));
+
     if (mbentry->uniqueid)
         dlist_setatom(dl, "I", mbentry->uniqueid);
 
@@ -274,9 +276,6 @@ static struct dlist *mboxlist_entry_dlist(const char *dbname,
 
     if (mbentry->server)
         dlist_setatom(dl, "S", mbentry->server);
-
-    if (mbentry->mbtype)
-        dlist_setatom(dl, "T", mboxlist_mbtype_to_string(mbentry->mbtype));
 
     if (mbentry->uidvalidity)
         dlist_setnum32(dl, "V", mbentry->uidvalidity);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -166,6 +166,10 @@ EXPORTED void mboxlist_entry_free(mbentry_t **mbentryptr)
 
     free(mbentry->legacy_specialuse);
 
+    synonym_t *syn;
+    while ((syn = ptrarray_pop(&mbentry->synonyms))) {
+        free(syn);
+    }
     ptrarray_fini(&mbentry->synonyms);
 
     free(mbentry);
@@ -1003,9 +1007,8 @@ static int mboxlist_update_entry(const char *name,
 
             if (oldid) {
                 /* Existing mailbox */
-                int i;
-                for (i = 0; i < oldid->synonyms.count; i++) {
-                    synonym_t *syn = ptrarray_nth(&oldid->synonyms, i);
+                while (oldid->synonyms.count) {
+                    synonym_t *syn = ptrarray_shift(&oldid->synonyms);
                     add_synonym(synonyms,
                                 syn->dbname, syn->mtime, syn->foldermodseq);
                     free(syn);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -165,11 +165,11 @@ EXPORTED void mboxlist_entry_free(mbentry_t **mbentryptr)
 
     free(mbentry->legacy_specialuse);
 
-    synonym_t *syn;
-    while ((syn = ptrarray_pop(&mbentry->synonyms))) {
-        free(syn);
+    former_name_t *fname;
+    while ((fname = ptrarray_pop(&mbentry->name_history))) {
+        free(fname);
     }
-    ptrarray_fini(&mbentry->synonyms);
+    ptrarray_fini(&mbentry->name_history);
 
     free(mbentry);
 
@@ -454,7 +454,7 @@ struct parseentry_rock {
     struct mboxlist_entry *mbentry;
     struct buf *aclbuf;
     int doingacl;
-    int doingsyns;
+    int doinghistory;
 };
 
 static int parseentry_cb(int type, struct dlistsax_data *d)
@@ -464,18 +464,18 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
 
     switch(type) {
     case DLISTSAX_LISTSTART:
-        if (!strcmp(key, "Y")) rock->doingsyns = 1;
+        if (!strcmp(key, "H")) rock->doinghistory = 1;
         break;
     case DLISTSAX_LISTEND:
-        if (rock->doingsyns) rock->doingsyns = 0;
+        if (rock->doinghistory) rock->doinghistory = 0;
         break;
     case DLISTSAX_KVLISTSTART:
         if (!strcmp(key, "A")) {
             rock->doingacl = 1;
         }
-        else if (rock->doingsyns) {
-            ptrarray_append(&rock->mbentry->synonyms,
-                            xzmalloc(sizeof(synonym_t)));
+        else if (rock->doinghistory) {
+            ptrarray_append(&rock->mbentry->name_history,
+                            xzmalloc(sizeof(former_name_t)));
         }
         break;
     case DLISTSAX_KVLISTEND:
@@ -488,17 +488,17 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
             buf_appendcstr(rock->aclbuf, d->data);
             buf_putc(rock->aclbuf, '\t');
         }
-        else if (rock->doingsyns) {
-            synonym_t *syn = ptrarray_tail(&rock->mbentry->synonyms);
+        else if (rock->doinghistory) {
+            former_name_t *fname = ptrarray_tail(&rock->mbentry->name_history);
 
             if (!strcmp(key, "F")) {
-                syn->foldermodseq = atomodseq_t(d->data);
+                fname->foldermodseq = atomodseq_t(d->data);
             }
             else if (!strcmp(key, "M")) {
-                syn->mtime = atoi(d->data);
+                fname->mtime = atoi(d->data);
             }
             else if (!strcmp(key, "N")) {
-                xstrncpy(syn->dbname, d->data, MAX_MAILBOX_NAME);
+                xstrncpy(fname->dbname, d->data, MAX_MAILBOX_NAME);
             }
         }
         else {
@@ -543,6 +543,7 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
  *  A: _a_cl
  *  C  _c_reatedmodseq
  *  F: _f_oldermodseq
+ *  H: name_h_istory
  *  I: unique_i_d
  *  M: _m_time
  *  N: _n_ame
@@ -550,7 +551,6 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
  *  S: _s_erver
  *  T: _t_ype
  *  V: uid_v_alidity
- *  Y: s_y_nonyms
  */
 static int mboxlist_parse_entry(mbentry_t **mbentryptr,
                                 const char *name, size_t namelen,
@@ -979,16 +979,16 @@ static int mboxlist_update_racl(const char *dbname, const mbentry_t *oldmbentry,
     return r;
 }
 
-static void add_synonym(struct dlist *synonyms,
-                        const char *dbname, time_t mtime, modseq_t foldermodseq)
+static void add_former_name(struct dlist *name_history, const char *dbname,
+                            time_t mtime, modseq_t foldermodseq)
 {
-    struct dlist *syn = dlist_newkvlist(NULL, "");
+    struct dlist *fname = dlist_newkvlist(NULL, "");
 
-    dlist_setatom(syn, "N", dbname);
-    dlist_setnum64(syn, "F", foldermodseq);
-    dlist_setdate(syn, "M", mtime);
+    dlist_setatom(fname, "N", dbname);
+    dlist_setnum64(fname, "F", foldermodseq);
+    dlist_setdate(fname, "M", mtime);
 
-    dlist_push(synonyms, syn);
+    dlist_push(name_history, fname);
 }
 
 static int mboxlist_update_entry(const char *name,
@@ -1020,7 +1020,7 @@ static int mboxlist_update_entry(const char *name,
         if (!r && mbentry->uniqueid &&
             !(old && (old->mbtype & mbentry->mbtype & MBTYPE_DELETED))) {
             mbentry_t *oldid = NULL;
-            struct dlist *synonyms = dlist_newlist(NULL, "Y");
+            struct dlist *name_history = dlist_newlist(NULL, "H");
 
             /* Remove I field from N record value */
             struct dlist *id = dlist_pop(dl);
@@ -1033,27 +1033,28 @@ static int mboxlist_update_entry(const char *name,
 
             if (oldid) {
                 /* Existing mailbox */
-                while (oldid->synonyms.count) {
-                    synonym_t *syn = ptrarray_shift(&oldid->synonyms);
-                    add_synonym(synonyms,
-                                syn->dbname, syn->mtime, syn->foldermodseq);
-                    free(syn);
+                while (oldid->name_history.count) {
+                    former_name_t *fname = ptrarray_shift(&oldid->name_history);
+                    add_former_name(name_history, fname->dbname,
+                                    fname->mtime, fname->foldermodseq);
+                    free(fname);
                 }
 
                 if (strcmp(name, oldid->name)) {
                     /* Renamed mailbox */
-                    add_synonym(synonyms,
-                                dbname, time(NULL), mbentry->foldermodseq);
+                    add_former_name(name_history, name,
+                                    time(NULL), mbentry->foldermodseq);
                 }
                 mboxlist_entry_free(&oldid);
             }
             else {
                 /* New mailbox */
-                add_synonym(synonyms, dbname, time(NULL), mbentry->foldermodseq);
+                add_former_name(name_history, name,
+                                time(NULL), mbentry->foldermodseq);
             }
 
-            /* Add Y field for I record value */
-            dlist_stitch(dl, synonyms);
+            /* Add H field for I record value */
+            dlist_stitch(dl, name_history);
 
             buf_reset(&mboxent);
             dlist_printbuf(dl, 0, &mboxent);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -114,6 +114,8 @@ static int have_racl = 0;
 static int mboxlist_opensubs(const char *userid, struct db **ret);
 static void mboxlist_closesubs(struct db *sub);
 
+static int mboxlist_upgrade_subs(const char *subsfname, struct db **ret);
+
 static int mboxlist_rmquota(const mbentry_t *mbentry, void *rock);
 static int mboxlist_changequota(const mbentry_t *mbentry, void *rock);
 
@@ -4669,6 +4671,9 @@ mboxlist_opensubs(const char *userid,
     flags = CYRUSDB_CREATE;
 
     r = cyrusdb_open(SUBDB, subsfname, flags, ret);
+    if (r == CYRUSDB_OK) {
+        r = mboxlist_upgrade_subs(subsfname, ret);
+    }
     if (r != CYRUSDB_OK) {
         r = IMAP_IOERROR;
     }
@@ -5181,6 +5186,7 @@ static int _check_rec_cb(void *rock,
 
 struct upgrade_rock {
     struct buf *namebuf;
+    struct db *db;
     struct txn **tid;
 };
 
@@ -5217,7 +5223,7 @@ EXPORTED int mboxlist_upgrade(int *upgraded)
     struct buf buf = BUF_INITIALIZER;
     struct db *backup = NULL;
     struct txn *tid = NULL;
-    struct upgrade_rock urock = { &buf, &tid };
+    struct upgrade_rock urock = { &buf, NULL, &tid };
     char *fname;
 
     if (upgraded) *upgraded = 0;
@@ -5280,6 +5286,123 @@ EXPORTED int mboxlist_upgrade(int *upgraded)
     if (!r && upgraded) *upgraded = 1;
 
   done:
+    buf_free(&buf);
+
+    return r;
+}
+
+
+static int _check_subs_cb(void *rock, const char *key, size_t keylen,
+                          const char *data __attribute__((unused)),
+                          size_t datalen __attribute__((unused)))
+{
+    int *do_upgrade = (int *) rock;
+
+    /* check for version record */
+    if (keylen == 5 && !strncmp(key, DB_HIERSEP_STR "VER" DB_HIERSEP_STR, 5)) {
+        *do_upgrade = 0;
+    }
+
+    return CYRUSDB_DONE;
+}
+
+static int _upgrade_subs_cb(void *rock, const char *key, size_t keylen,
+                            const char *data __attribute__((unused)),
+                            size_t datalen __attribute__((unused)))
+{
+    struct upgrade_rock *urock = (struct upgrade_rock *) rock;
+    struct buf *namebuf = urock->namebuf;
+    char *dbname = NULL;
+    int r;
+
+    buf_setmap(namebuf, key, keylen);
+    dbname = mboxname_to_dbname(buf_cstring(namebuf));
+    mboxlist_dbname_to_key(dbname, strlen(dbname), namebuf);
+    free(dbname);
+
+    r = cyrusdb_store(urock->db,
+                      buf_base(namebuf), buf_len(namebuf), "", 0, urock->tid);
+
+    return (r == CYRUSDB_OK ? 0 : IMAP_IOERROR);
+}
+
+static int mboxlist_upgrade_subs(const char *subsfname, struct db **subs)
+{
+    int r, r2 = 0, do_upgrade = 1;
+    char *newsubsfname = NULL;
+    struct buf buf = BUF_INITIALIZER;
+    struct db *newsubs = NULL;
+    struct txn *tid = NULL;
+    struct upgrade_rock urock = { &buf, NULL, &tid };
+
+    /* check if we need to upgrade */
+    r = cyrusdb_foreach(*subs, "", 0, NULL, _check_subs_cb, &do_upgrade, NULL);
+
+    if (r != CYRUSDB_DONE) return r;
+    if (!do_upgrade) return 0;
+
+    /* create new db file name */
+    buf_setcstr(&buf, subsfname);
+    buf_appendcstr(&buf, ".NEW");
+    newsubsfname = buf_release(&buf);
+
+    /* open new db file */
+    r = cyrusdb_open(SUBDB, newsubsfname, CYRUSDB_CREATE, &newsubs);
+    if (!r) {
+        /* add version record */
+        r = cyrusdb_store(newsubs,
+                          DB_HIERSEP_STR "VER" DB_HIERSEP_STR, 5, "2", 1, &tid);
+    }
+    if (r) {
+        syslog(LOG_ERR, "DBERROR: opening %s: %s", newsubsfname,
+               cyrusdb_strerror(r));
+        fatal("can't open new subscriptions file", EX_TEMPFAIL);
+    }
+
+    /* perform upgrade from old to new db */
+    urock.db = newsubs;
+    r = cyrusdb_foreach(*subs, "", 0, NULL, _upgrade_subs_cb, &urock, NULL);
+
+    r2 = cyrusdb_close(*subs);
+    if (r2) {
+        syslog(LOG_ERR, "DBERROR: error closing %s: %s", subsfname,
+               cyrusdb_strerror(r2));
+        if (!r) r = r2;
+    }
+    *subs = NULL;
+
+    /* complete txn on new db */
+    if (tid) {
+        if (r) {
+            r2 = cyrusdb_abort(newsubs, tid);
+        } else {
+            r2 = cyrusdb_commit(newsubs, tid);
+        }
+
+        if (r2) {
+            syslog(LOG_ERR, "DBERROR: error %s txn in mboxlist_upgrade_subs: %s",
+                   r ? "aborting" : "committing", cyrusdb_strerror(r2));
+        }
+    }
+
+    r2 = cyrusdb_close(newsubs);
+    if (r2) {
+        syslog(LOG_ERR, "DBERROR: error closing %s: %s", newsubsfname,
+               cyrusdb_strerror(r2));
+        if (!r) r = r2;
+    }
+
+    if (!r) {
+        /* rename new db file */
+        r = rename(newsubsfname, subsfname);
+        if (!r) {
+            /* reopen upgraded db under regular name */
+            r = cyrusdb_open(SUBDB, subsfname, 0, subs);
+        }
+    }
+
+    unlink(newsubsfname);
+    free(newsubsfname);
     buf_free(&buf);
 
     return r;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -903,6 +903,8 @@ static int mboxlist_update_id(const char *id,
     struct buf key = BUF_INITIALIZER;
     int r;
 
+    if (!id) return 0;  // DB doesn't store mailbox ids (MUPDATE)
+
     mboxlist_id_to_key(id, &key);
 
     if (dbname) {

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -466,7 +466,7 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
             synonym_t *syn = ptrarray_tail(&rock->mbentry->synonyms);
 
             if (!strcmp(key, "F")) {
-                syn->foldermodseq = atoll(d->data);
+                syn->foldermodseq = atomodseq_t(d->data);
             }
             else if (!strcmp(key, "M")) {
                 syn->mtime = atoi(d->data);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -394,36 +394,42 @@ EXPORTED uint32_t mboxlist_string_to_mbtype(const char *string)
 
     if (!string) return 0; /* null just means default */
 
-    for (; *string; string++) {
-        /* mailbox types */
-        switch (*string) {
-        case 'a':
-            mbtype = MBTYPE_ADDRESSBOOK;
-            break;
-        case 'b':
-            mbtype = MBTYPE_COLLECTION;
-            break;
-        case 'c':
-            mbtype = MBTYPE_CALENDAR;
-            break;
-        case 'e':
-            mbtype = MBTYPE_EMAIL;
-            break;
-        case 'j':
-            mbtype = MBTYPE_JMAPNOTIFY;
-            break;
-        case 'n':
-            mbtype = MBTYPE_NETNEWS;
-            break;
-        case 'p':
-            mbtype = MBTYPE_JMAPPUSHSUB;
-            break;
-        case 's':
-            mbtype = MBTYPE_JMAPSUBMIT;
-            break;
+    /* mailbox type - ALWAYS first character */
+    switch (*string) {
+    case 'a':
+        mbtype = MBTYPE_ADDRESSBOOK;
+        break;
+    case 'b':
+        mbtype = MBTYPE_COLLECTION;
+        break;
+    case 'c':
+        mbtype = MBTYPE_CALENDAR;
+        break;
+    case 'e':
+        mbtype = MBTYPE_EMAIL;
+        break;
+    case 'j':
+        mbtype = MBTYPE_JMAPNOTIFY;
+        break;
+    case 'n':
+        mbtype = MBTYPE_NETNEWS;
+        break;
+    case 'p':
+        mbtype = MBTYPE_JMAPPUSHSUB;
+        break;
+    case 's':
+        mbtype = MBTYPE_JMAPSUBMIT;
+        break;
 
+    default:
+        /* make sure we didn't forget to handle every expected character */
+        assert(0);
+        break;
+    }
             
+    for (++string; *string; string++) {
         /* mailbox flags */
+        switch (*string) {
         case 'd':
             mbtype |= MBTYPE_DELETED;
             break;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2138,7 +2138,7 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
         // make it deleted and mark it done!
         if (!mboxname_isdeletedmailbox(name, NULL)) {
             mbentry_t *newmbentry = mboxlist_entry_copy(mbentry);
-            newmbentry->mbtype = MBTYPE_DELETED;
+            newmbentry->mbtype |= MBTYPE_DELETED;
             if (!silent) {
                 newmbentry->foldermodseq = mboxname_nextmodseq(newmbentry->name, newmbentry->foldermodseq,
                                                                newmbentry->mbtype,
@@ -2644,7 +2644,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
             /* store a DELETED marker */
             mbentry_t *oldmbentry = mboxlist_entry_create();
             oldmbentry->name = xstrdupnull(mbentry->name);
-            oldmbentry->mbtype |= MBTYPE_DELETED;
+            oldmbentry->mbtype = mbentry->mbtype | MBTYPE_DELETED;
             oldmbentry->uidvalidity = mbentry->uidvalidity;
             oldmbentry->uniqueid = xstrdupnull(mbentry->uniqueid);
             oldmbentry->createdmodseq = mbentry->createdmodseq;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -732,13 +732,15 @@ EXPORTED char *mboxlist_find_uniqueid(const char *uniqueid,
     int r;
     const char *data;
     size_t datalen;
+    char dbname[MAX_MAILBOX_NAME];
 
     init_internal();
 
     r = mboxlist_read_uniqueid(uniqueid, &data, &datalen, NULL, 0);
     if (r) return NULL;
 
-    return xstrndup(data, datalen);
+    snprintf(dbname, sizeof(dbname), "%.*s", (int) datalen, data);
+    return mboxname_from_dbname(dbname);
 }
 
 /* given a mailbox name, find the staging directory.  XXX - this should

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -395,7 +395,7 @@ EXPORTED uint32_t mboxlist_string_to_mbtype(const char *string)
     if (!string) return 0; /* null just means default */
 
     /* mailbox type - ALWAYS first character */
-    switch (*string) {
+    switch (*string++) {
     case 'a':
         mbtype = MBTYPE_ADDRESSBOOK;
         break;
@@ -422,12 +422,13 @@ EXPORTED uint32_t mboxlist_string_to_mbtype(const char *string)
         break;
 
     default:
-        /* make sure we didn't forget to handle every expected character */
-        assert(0);
+        /* Assume this is a mailbox flag .
+           This should only happen for a legacy email entry with no 'e' */
+        string--;
         break;
     }
             
-    for (++string; *string; string++) {
+    for (; *string; string++) {
         /* mailbox flags */
         switch (*string) {
         case 'd':

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3556,7 +3556,12 @@ static int racls_del_cb(void *rock,
 static int racls_add_cb(const mbentry_t *mbentry, void *rock)
 {
     struct txn **txn = (struct txn **)rock;
-    return mboxlist_update_racl(mbentry->name, NULL, mbentry, txn);
+    char *dbname = mboxname_to_dbname(mbentry->name);
+
+    int r = mboxlist_update_racl(dbname, NULL, mbentry, txn);
+
+    free(dbname);
+    return r;
 }
 
 EXPORTED int mboxlist_set_racls(int enabled)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -948,7 +948,7 @@ static int mboxlist_update_entry(const char *name,
         char *mboxent = mboxlist_entry_cstring(dbname, mbentry);
         r = cyrusdb_store(mbdb, buf_base(&key), buf_len(&key),
                           mboxent, strlen(mboxent), txn);
-        if (!r && mbentry->uniqueid) {
+        if (!r && mbentry->uniqueid && !(old && (old->mbtype & MBTYPE_DELETED))) {
             mboxlist_id_to_key(mbentry->uniqueid, &key);
             r = cyrusdb_store(mbdb, buf_base(&key), buf_len(&key),
                               mboxent, strlen(mboxent), txn);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1037,15 +1037,10 @@ static int mboxlist_update_entry(const char *name,
 
                 if (strcmp(name, oldid->name)) {
                     /* Renamed mailbox */
-                    add_former_name(name_history, name,
-                                    time(NULL), mbentry->foldermodseq);
+                    add_former_name(name_history, oldid->name,
+                                    time(NULL), oldid->foldermodseq);
                 }
                 mboxlist_entry_free(&oldid);
-            }
-            else {
-                /* New mailbox */
-                add_former_name(name_history, name,
-                                time(NULL), mbentry->foldermodseq);
             }
 
             /* Add H field for I record value */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -276,6 +276,9 @@ static struct dlist *mboxlist_entry_dlist(const char *dbname,
     if (mbentry->acl)
         _write_acl(dl, mbentry->acl);
 
+    if (mbentry->legacy_dir)
+        dlist_setnum32(dl, "L", 1);
+
     return dl;
 }
 
@@ -485,6 +488,9 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
             else if (!strcmp(key, "I")) {
                 rock->mbentry->uniqueid = xstrdupnull(d->data);
             }
+            else if (!strcmp(key, "L")) {
+                rock->mbentry->legacy_dir = 1;
+            }
             else if (!strcmp(key, "M")) {
                 rock->mbentry->mtime = atoi(d->data);
             }
@@ -518,6 +524,7 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
  *  C  _c_reatedmodseq
  *  F: _f_oldermodseq
  *  I: unique_i_d
+ *  L: _l_egacydir
  *  M: _m_time
  *  N: _n_ame
  *  P: _p_artition
@@ -5154,6 +5161,7 @@ static int _upgrade_cb(void *rock,
 
     buf_setmap(urock->namebuf, key, keylen);
     mbentry->name = mboxname_to_dbname(buf_cstring(urock->namebuf));
+    mbentry->legacy_dir = 1;
     r = mboxlist_update_entry(mbentry->name, mbentry, urock->tid);
 
     mboxlist_entry_free(&mbentry);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -544,7 +544,6 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
  *  C  _c_reatedmodseq
  *  F: _f_oldermodseq
  *  I: unique_i_d
- *  L: _l_egacydir
  *  M: _m_time
  *  N: _n_ame
  *  P: _p_artition

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1654,7 +1654,7 @@ static int mboxlist_createmailbox_full(const char *mboxname, int mbtype,
     /* all is well - activate the mailbox */
     newmbentry = mboxlist_entry_create();
     newmbentry->acl = xstrdupnull(acl);
-    newmbentry->mbtype = mbtype;
+    newmbentry->mbtype = mbtype | MBTYPE_LEGACY_DIRS;
     newmbentry->partition = xstrdupnull(newpartition);
     if (newmailbox) {
         newmbentry->uniqueid = xstrdupnull(newmailbox->uniqueid);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5337,7 +5337,7 @@ static int mboxlist_upgrade_subs(const char *subsfname, struct db **subs)
     /* check if we need to upgrade */
     r = cyrusdb_foreach(*subs, "", 0, NULL, _check_subs_cb, &do_upgrade, NULL);
 
-    if (r != CYRUSDB_DONE) return r;
+    if (r != CYRUSDB_OK && r != CYRUSDB_DONE) return r;
     if (!do_upgrade) return 0;
 
     /* create new db file name */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -877,6 +877,8 @@ HIDDEN int mboxlist_findstage(const char *name, char *stagedir, size_t sd_len)
     return 0;
 }
 
+#define ACL_RECORDSEP_CHAR      '\x1E'  /* record separator (RS) */
+
 static void mboxlist_racl_key(int isuser, const char *keyuser,
                               const char *dbname, struct buf *buf)
 {
@@ -884,11 +886,10 @@ static void mboxlist_racl_key(int isuser, const char *keyuser,
     buf_putc(buf, KEY_TYPE_ACL);
     if (keyuser || dbname) {
         buf_putc(buf, isuser ? 'U' : 'S');
-        buf_putc(buf, '$');
-
+        buf_putc(buf, ACL_RECORDSEP_CHAR);
         if (keyuser) {
             buf_appendcstr(buf, keyuser);
-            buf_putc(buf, '$');
+            buf_putc(buf, ACL_RECORDSEP_CHAR);
         }
         if (dbname) {
             buf_appendcstr(buf, dbname);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -4641,7 +4641,10 @@ EXPORTED void mboxlist_open(const char *fname)
 
     mboxlist_dbopen = 1;
 
-    have_racl = !cyrusdb_fetch(mbdb, "$RACL", 5, NULL, NULL, NULL);
+    struct buf key = BUF_INITIALIZER;
+    mboxlist_racl_key(0, NULL, NULL, &key);
+    have_racl = !cyrusdb_fetch(mbdb, buf_base(&key), buf_len(&key), NULL, NULL, NULL);
+    buf_free(&key);
 }
 
 EXPORTED void mboxlist_close(void)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5140,20 +5140,48 @@ static int _check_rec_cb(void *rock,
                          const char *data, size_t datalen)
 {
     int *do_upgrade = (int *) rock;
+    int r = CYRUSDB_OK;
 
-    if (keylen && key[0] == KEY_TYPE_ID) {
+    if (!keylen) return r;
+
+    switch (key[0]) {
+    case '$':
+        /* Verify that we have a $RACL$ or $RUNQ$ record */
+        if (keylen >= 6 &&
+            (!strncmp(key, "$RACL$", 6) || !strncmp(key, "$RUNQ$", 6))) {
+            *do_upgrade = 1;
+            r = CYRUSDB_DONE;
+        }
+        break;
+
+    case KEY_TYPE_ACL: {
+        /* Verify that we have a valid A record */
+        struct buf aclkey = BUF_INITIALIZER;
+
+        mboxlist_racl_key(0, NULL, NULL, &aclkey);
+        if (keylen >= buf_len(&aclkey) &&
+            !strncmp(key, buf_cstring(&aclkey), buf_len(&aclkey))) {
+            *do_upgrade = 0;
+            r = CYRUSDB_DONE;
+        }
+        break;
+    }
+
+    case KEY_TYPE_ID: {
         /* Verify that we have a valid I record */
         mbentry_t *mbentry = NULL;
 
-        int r = mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
-        if (r) return r;
-
-        *do_upgrade = (mbentry->name == NULL);
-        mboxlist_entry_free(&mbentry);
+        r = mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
+        if (!r) {
+            *do_upgrade = (mbentry->name == NULL);
+            mboxlist_entry_free(&mbentry);
+            r = CYRUSDB_DONE;
+        }
+        break;
     }
-    else *do_upgrade = 1;
+    }
 
-    return CYRUSDB_DONE;
+    return r;
 }
 
 struct upgrade_rock {
@@ -5169,8 +5197,11 @@ static int _upgrade_cb(void *rock,
     mbentry_t *mbentry = NULL;
     int r;
 
-    /* skip $RACL or other $ space keys */
-    if (key[0] == '$') return CYRUSDB_OK;
+    /* skip $RACL$ or $RUNQ$ keys */
+    if (keylen >= 6 &&
+        (!strncmp(key, "$RACL$", 6) || !strncmp(key, "$RUNQ$", 6))) {
+        return CYRUSDB_OK;
+    }
 
     r = mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
     if (r) return r;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -976,14 +976,14 @@ static int mboxlist_update_entry(const char *name,
 
                 if (strcmp(name, oldid->name)) {
                     /* Renamed mailbox */
-                    dlist_setnum64(synonyms, name, mbentry->foldermodseq);
+                    dlist_setnum64(synonyms, dbname, mbentry->foldermodseq);
                 }
                 mboxlist_entry_free(&oldid);
             }
             else {
                 /* New mailbox */
                 synonyms = dlist_newkvlist(NULL, "Y");
-                dlist_setnum64(synonyms, name, mbentry->foldermodseq);
+                dlist_setnum64(synonyms, dbname, mbentry->foldermodseq);
             }
 
             /* Add Y field for I record value */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -110,7 +110,6 @@ static int mboxlist_dbopen = 0;
 static int mboxlist_initialized = 0;
 
 static int have_racl = 0;
-static int have_runq = 0;
 
 static int mboxlist_opensubs(const char *userid, struct db **ret);
 static void mboxlist_closesubs(struct db *sub);
@@ -4643,7 +4642,6 @@ EXPORTED void mboxlist_open(const char *fname)
     mboxlist_dbopen = 1;
 
     have_racl = !cyrusdb_fetch(mbdb, "$RACL", 5, NULL, NULL, NULL);
-    have_runq = !cyrusdb_fetch(mbdb, "$RUNQ", 5, NULL, NULL, NULL);
 }
 
 EXPORTED void mboxlist_close(void)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1563,7 +1563,7 @@ EXPORTED int mboxlist_promote_intermediary(const char *mboxname)
     r = mboxlist_create_partition(mboxname, parent->partition,
                                   &mbentry->partition);
     if (r) goto done;
-    mbentry->mbtype = 0; // intermediaries are always standard
+    mbentry->mbtype &= ~MBTYPE_INTERMEDIATE;
     free(mbentry->acl);
     mbentry->acl = xstrdupnull(parent->acl);
 

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -120,6 +120,8 @@ struct mboxlist_entry {
     char *uniqueid;
     /* legacy upgrade support */
     char *legacy_specialuse;
+    /* replication support */
+    struct dlist *synonyms;
 };
 
 typedef struct mboxlist_entry mbentry_t;

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -121,10 +121,16 @@ struct mboxlist_entry {
     /* legacy upgrade support */
     char *legacy_specialuse;
     /* replication support */
-    struct dlist *synonyms;
+    ptrarray_t synonyms;
 };
 
 typedef struct mboxlist_entry mbentry_t;
+
+typedef struct {
+    char dbname[MAX_MAILBOX_NAME+1];
+    modseq_t foldermodseq;
+    time_t mtime;
+} synonym_t;
 
 mbentry_t *mboxlist_entry_create();
 

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -120,6 +120,7 @@ struct mboxlist_entry {
     char *uniqueid;
     /* legacy upgrade support */
     char *legacy_specialuse;
+    int legacy_dir;
     /* replication support */
     ptrarray_t synonyms;
 };

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -118,7 +118,7 @@ struct mboxlist_entry {
     /* legacy upgrade support */
     char *legacy_specialuse;
     /* replication support */
-    ptrarray_t synonyms;
+    ptrarray_t name_history;
 };
 
 typedef struct mboxlist_entry mbentry_t;
@@ -127,7 +127,7 @@ typedef struct {
     char dbname[MAX_MAILBOX_NAME+1];
     modseq_t foldermodseq;
     time_t mtime;
-} synonym_t;
+} former_name_t;
 
 mbentry_t *mboxlist_entry_create();
 

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -423,4 +423,6 @@ int mboxlist_delayed_delete_isenabled(void);
 /* Promote an intermediary mailbox to a real mailbox. */
 int mboxlist_promote_intermediary(const char *mboxname);
 
+int mboxlist_upgrade(int *upgraded);
+
 #endif

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -129,10 +129,6 @@ mbentry_t *mboxlist_entry_create();
 char *mbentry_metapath(const struct mboxlist_entry *mbentry, int metatype, int isnew);
 char *mbentry_datapath(const struct mboxlist_entry *mbentry, uint32_t);
 
-int mboxlist_parse_entry(mbentry_t **mbentryptr,
-                         const char *name, size_t namelen,
-                         const char *data, size_t datalen);
-
 mbentry_t *mboxlist_entry_copy(const mbentry_t *src);
 
 void mboxlist_entry_free(mbentry_t **mbentryptr);

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -143,7 +143,8 @@ int mboxlist_lookup(const char *name, mbentry_t **mbentryptr,
 int mboxlist_lookup_allow_all(const char *name,
                                    mbentry_t **mbentryptr,
                                    struct txn **tid);
-int mboxlist_lookup_by_uniqueid(const char *uniqueid, mbentry_t **entryptr);
+int mboxlist_lookup_by_uniqueid(const char *uniqueid,
+                                mbentry_t **entryptr, struct txn **tid);
 
 char *mboxlist_find_specialuse(const char *use, const char *userid);
 char *mboxlist_find_uniqueid(const char *uniqueid, const char *userid,

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1405,7 +1405,7 @@ EXPORTED int mboxname_isdeletedmailbox(const char *name, time_t *timestampp)
  */
 EXPORTED int mboxname_iscalendarmailbox(const char *name, int mbtype)
 {
-    if (mbtype & MBTYPE_CALENDAR) return 1;  /* Only works on backends */
+    if (mbtype_isa(mbtype) == MBTYPE_CALENDAR) return 1;  /* Only works on backends */
     int res = 0;
 
     mbname_t *mbname = mbname_from_intname(name);
@@ -1424,7 +1424,7 @@ EXPORTED int mboxname_iscalendarmailbox(const char *name, int mbtype)
  */
 EXPORTED int mboxname_isaddressbookmailbox(const char *name, int mbtype)
 {
-    if (mbtype & MBTYPE_ADDRESSBOOK) return 1;  /* Only works on backends */
+    if (mbtype_isa(mbtype) == MBTYPE_ADDRESSBOOK) return 1;  /* Only works on backends */
     int res = 0;
 
     mbname_t *mbname = mbname_from_intname(name);
@@ -1443,7 +1443,7 @@ EXPORTED int mboxname_isaddressbookmailbox(const char *name, int mbtype)
  */
 EXPORTED int mboxname_isdavdrivemailbox(const char *name, int mbtype)
 {
-    if (mbtype & MBTYPE_COLLECTION) return 1;  /* Only works on backends */
+    if (mbtype_isa(mbtype) == MBTYPE_COLLECTION) return 1;  /* Only works on backends */
     int res = 0;
 
     mbname_t *mbname = mbname_from_intname(name);
@@ -1462,7 +1462,7 @@ EXPORTED int mboxname_isdavdrivemailbox(const char *name, int mbtype)
  */
 EXPORTED int mboxname_isdavnotificationsmailbox(const char *name, int mbtype)
 {
-    if (mbtype & MBTYPE_COLLECTION) return 1;  /* Only works on backends */
+    if (mbtype_isa(mbtype) == MBTYPE_COLLECTION) return 1;  /* Only works on backends */
     int res = 0;
 
     mbname_t *mbname = mbname_from_intname(name);
@@ -1481,7 +1481,7 @@ EXPORTED int mboxname_isdavnotificationsmailbox(const char *name, int mbtype)
  */
 EXPORTED int mboxname_isjmapnotificationsmailbox(const char *name, int mbtype)
 {
-    if (mbtype & MBTYPE_JMAPNOTIFICATION) return 1;  /* Only works on backends */
+    if (mbtype_isa(mbtype) == MBTYPE_JMAPNOTIFY) return 1;  /* Only works on backends */
     int res = 0;
 
     mbname_t *mbname = mbname_from_intname(name);
@@ -1518,7 +1518,7 @@ EXPORTED int mboxname_isnotesmailbox(const char *name, int mbtype __attribute__(
  */
 EXPORTED int mboxname_issubmissionmailbox(const char *name, int mbtype)
 {
-    if (mbtype & MBTYPE_SUBMISSION) return 1;  /* Only works on backends */
+    if (mbtype_isa(mbtype) == MBTYPE_JMAPSUBMIT) return 1;  /* Only works on backends */
     int res = 0;
 
     mbname_t *mbname = mbname_from_intname(name);
@@ -1537,7 +1537,7 @@ EXPORTED int mboxname_issubmissionmailbox(const char *name, int mbtype)
  */
 EXPORTED int mboxname_ispushsubscriptionmailbox(const char *name, int mbtype)
 {
-    if (mbtype & MBTYPE_PUSHSUBSCRIPTION) return 1;  /* Only works on backends */
+    if (mbtype_isa(mbtype) == MBTYPE_JMAPPUSHSUB) return 1;  /* Only works on backends */
     int res = 0;
 
     mbname_t *mbname = mbname_from_intname(name);

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1401,7 +1401,7 @@ static void database_log(const struct mbent *mb, struct txn **mytid)
         break;
 
     case SET_RESERVE:
-        mbentry->mbtype = MBTYPE_RESERVE;
+        mbentry->mbtype |= MBTYPE_RESERVE;
         mboxlist_insertremote(mbentry, mytid);
         break;
 
@@ -2388,7 +2388,7 @@ int mupdate_synchronize(struct mbent_queue *remote_boxes, struct mpool *pool)
                 } else {
                     mbentry_t *mbentry = mboxlist_entry_create();
                     mbentry->name = xstrdupnull(r->mailbox);
-                    mbentry->mbtype = (r->t == SET_RESERVE ? MBTYPE_RESERVE : 0);
+                    mbentry->mbtype |= (r->t == SET_RESERVE ? MBTYPE_RESERVE : 0);
                     mbentry->server = xstrdupnull(r->location);
 
                     c = strchr(mbentry->server, '!');
@@ -2432,7 +2432,7 @@ int mupdate_synchronize(struct mbent_queue *remote_boxes, struct mpool *pool)
             /* Remote without corresponding local, insert it */
             mbentry_t *mbentry = mboxlist_entry_create();
             mbentry->name = xstrdupnull(r->mailbox);
-            mbentry->mbtype = (r->t == SET_RESERVE ? MBTYPE_RESERVE : 0);
+            mbentry->mbtype |= (r->t == SET_RESERVE ? MBTYPE_RESERVE : 0);
             mbentry->server = xstrdupnull(r->location);
 
             c = strchr(mbentry->server, '!');
@@ -2467,7 +2467,7 @@ int mupdate_synchronize(struct mbent_queue *remote_boxes, struct mpool *pool)
         while (r) {
             mbentry_t *mbentry = mboxlist_entry_create();
             mbentry->name = xstrdupnull(r->mailbox);
-            mbentry->mbtype = (r->t == SET_RESERVE ? MBTYPE_RESERVE : 0);
+            mbentry->mbtype |= (r->t == SET_RESERVE ? MBTYPE_RESERVE : 0);
             mbentry->server = xstrdupnull(r->location);
 
             c = strchr(mbentry->server, '!');

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -268,7 +268,6 @@ static search_folder_t *query_get_valid_folder(search_query_t *query,
                                                uint32_t uidvalidity)
 {
     search_folder_t *folder;
-    uint32_t have_mbtype = 0;
 
     // check if we want to process this mailbox
     if (query->checkfolder &&
@@ -276,18 +275,20 @@ static search_folder_t *query_get_valid_folder(search_query_t *query,
         return NULL;
     }
 
-    if (mboxname_isdeletedmailbox(mboxname, 0))
-        have_mbtype = MBTYPE_DELETED;
-
-    if (mboxname_iscalendarmailbox(mboxname, 0))
-        have_mbtype = MBTYPE_CALENDAR;
-
-    if (mboxname_isaddressbookmailbox(mboxname, 0))
-        have_mbtype = MBTYPE_ADDRESSBOOK;
-
-    /* not the type we want?  Abort now */
-    if (have_mbtype != query->want_mbtype)
+    if (mboxname_isdeletedmailbox(mboxname, 0) &&
+        !(query->want_mbtype & MBTYPE_DELETED)) {
         return NULL;
+    }
+
+    if (mboxname_iscalendarmailbox(mboxname, 0) &&
+        mbtype_isa(query->want_mbtype) != MBTYPE_CALENDAR) {
+        return NULL;
+    }
+
+    if (mboxname_isaddressbookmailbox(mboxname, 0) &&
+        mbtype_isa(query->want_mbtype) != MBTYPE_ADDRESSBOOK) {
+        return NULL;
+    }
 
     folder = query_get_folder(query, mboxname);
     if (uidvalidity) {

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -234,7 +234,7 @@ static int should_index(const char *name)
     }
 
     // skip COLLECTION mailboxes (just files)
-    if (mbentry->mbtype & MBTYPE_COLLECTION) {
+    if (mbtype_isa(mbentry->mbtype) == MBTYPE_COLLECTION) {
         ret = 0;
         goto done;
     }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -1644,7 +1644,7 @@ out:
 
     if (record) {
 #ifdef USE_CALALARMD
-        if (mailbox->mbtype & MBTYPE_CALENDAR) {
+        if (mbtype_isa(mailbox->mbtype) == MBTYPE_CALENDAR) {
             // NOTE: this is because we don't pass the annotations through
             // with the record as we create it, so we can't update the alarm
             // database properly.  Instead, we don't set anything when we append


### PR DESCRIPTION
@brong This is a (maybe too?) simple fix but it seems to work in my testing.  The only possible downside is that the modseqs for both records get bumped when inserted.

This PR is against one of my intermediate branches, and the only commits worth looking at are the last two.

The penultimate commit is to reconstruct to insert missing I records.
The last commit should fix the issue of deleting an I record for a renamed mailbox.  I was unable to get cyr_expire to attempt to do the deletion, so this fix is untested.