### PR TITLE
JMAP: support Email/query for attachmentType=email

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1306,6 +1306,15 @@ static void _email_search_string(search_expr_t *parent,
 
 static void _email_search_type(search_expr_t *parent, const char *s, strarray_t *perf_filters)
 {
+    if (!strcasecmp(s, "email") || !strcasecmp(s, "message/rfc822")) {
+        // XXX these do not get indexed in Xapian
+        search_expr_t *e = search_expr_new(parent, SEOP_MATCH);
+        e->attr = search_attr_find("contenttype");
+        e->value.s = xstrdup("message/rfc822");
+        _email_search_perf_attr(e->attr, perf_filters);
+        return;
+    }
+
     strarray_t types = STRARRAY_INITIALIZER;
 
     /* Handle type wildcards */
@@ -1351,9 +1360,6 @@ static void _email_search_type(search_expr_t *parent, const char *s, strarray_t 
         strarray_append(&types, "application/vnd.oasis.opendocument.presentation-template");
         strarray_append(&types, "application/x-iwork-keynote-sffkey");
         strarray_append(&types, "application/vnd.apple.keynote");
-    }
-    else if (!strcasecmp(s, "email")) {
-        strarray_append(&types, "message/rfc822");
     }
     else if (!strcasecmp(s, "pdf")) {
         strarray_append(&types, "application/pdf");

--- a/imap/message.c
+++ b/imap/message.c
@@ -4750,18 +4750,19 @@ static int message_map_file(message_t *m, const char *fname)
 
 /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/
 
-static void body_get_leaf_types(struct body *body, strarray_t *types)
+static void body_get_types(struct body *body, strarray_t *types, int leafs_only)
 {
     int i;
 
-    if (strcmpsafe(body->type, "MULTIPART") &&
-        strcmpsafe(body->type, "MESSAGE")) {
+    if (!leafs_only ||
+            (strcmpsafe(body->type, "MULTIPART") &&
+             strcmpsafe(body->type, "MESSAGE"))) {
         strarray_append(types, body->type);
         strarray_append(types, body->subtype);
     }
 
     for (i = 0; i < body->numparts; i++) {
-        body_get_leaf_types(&body->subpart[i], types);
+        body_get_types(&body->subpart[i], types, leafs_only);
     }
 }
 
@@ -4880,7 +4881,15 @@ EXPORTED int message_get_leaf_types(message_t *m, strarray_t *types)
 {
     int r = message_need(m, M_CACHEBODY);
     if (r) return r;
-    body_get_leaf_types(m->body, types);
+    body_get_types(m->body, types, 1);
+    return 0;
+}
+
+EXPORTED int message_get_types(message_t *m, strarray_t *types)
+{
+    int r = message_need(m, M_CACHEBODY);
+    if (r) return r;
+    body_get_types(m->body, types, 0);
     return 0;
 }
 

--- a/imap/message.h
+++ b/imap/message.h
@@ -354,6 +354,7 @@ extern int message_foreach_section(message_t *m,
                                void *rock),
                    void *rock);
 extern int message_get_leaf_types(message_t *m, strarray_t *types);
+extern int message_get_types(message_t *m, strarray_t *types);
 
 
 /* less shitty interface */

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -1449,12 +1449,15 @@ out:
 
 /* ====================================================================== */
 
-static int search_contenttype_match(message_t *m, const union search_value *v,
+static int search_contenttype_match(message_t *m,
+                                    const union search_value *v __attribute__((unused)),
                                     void *internalised,
                                     void *data1 __attribute__((unused)))
 {
     int r;
-    comp_pat *pat = (comp_pat *)internalised;
+    struct search_string_internal *internal = internalised;
+    comp_pat *pat = internal->pat;
+    const char *s = internal->s;
     strarray_t types = STRARRAY_INITIALIZER;
     int i;
     char combined[128];
@@ -1465,16 +1468,16 @@ static int search_contenttype_match(message_t *m, const union search_value *v,
             const char *subtype = types.data[i+1];
 
             /* match against type */
-            r = charset_searchstring(v->s, pat, type, strlen(type), charset_flags);
+            r = charset_searchstring(s, pat, type, strlen(type), charset_flags);
             if (r) goto out;    // success
 
             /* match against subtype */
-            r = charset_searchstring(v->s, pat, subtype, strlen(subtype), charset_flags);
+            r = charset_searchstring(s, pat, subtype, strlen(subtype), charset_flags);
             if (r) goto out;    // success
 
             /* match against combined type_subtype */
             snprintf(combined, sizeof(combined), "%s/%s", type, subtype);
-            r = charset_searchstring(v->s, pat, combined, strlen(combined), charset_flags);
+            r = charset_searchstring(s, pat, combined, strlen(combined), charset_flags);
             if (r) goto out;    // success
         }
     }

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -1462,7 +1462,7 @@ static int search_contenttype_match(message_t *m,
     int i;
     char combined[128];
 
-    if (!message_get_leaf_types(m, &types)) {
+    if (!message_get_types(m, &types)) {
         for (i = 0 ; i < types.count ; i+= 2) {
             const char *type = types.data[i];
             const char *subtype = types.data[i+1];


### PR DESCRIPTION
This patch fixes an issue where search for "email" and "message/rfc822" did not return any results. As these content types are not indexed in Xapian, this patch lets search fall back to the cached bodystructure. It also fixes an invalid cast from void in contenttype_match.