### PR TITLE
charset: don't QP wrap for a single character

### DIFF
--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3446,7 +3446,7 @@ static char *qp_encode(const char *data, size_t len, int isheader,
                     cnt = 11;
                 }
             }
-            else if (cnt >= ENCODED_MAX_LINE_LEN) {
+            else if (cnt >= ENCODED_MAX_LINE_LEN && next != '\r' && next != '\n') {
                 /* add soft line break to body */
                 buf_appendcstr(&buf, "=\r\n");
                 cnt = 0;


### PR DESCRIPTION
So... it turns out that IETF's mail forwarder broke on a line with a single dot:

```
ACTION: discussion on list to confirm cases work, then clear AUTH48 ASAP=
.
```

Now, that's bogus.

But - be conservative in what you send.  If the next character is the end of line, then don't wrap.