### PR TITLE
syslog: Don't define syslog() if glibc already provides a macro

### DIFF
--- a/cunit/syslog.c
+++ b/cunit/syslog.c
@@ -157,6 +157,11 @@ __syslog_chk(int prio, int whatever __attribute__((unused)),
     vlog(prio, fmt, args);
     va_end(args);
 }
+
+/* glibc might define a syslog() macro, which is not wanted here */
+#ifdef syslog
+#undef syslog
+#endif
 #endif
 
 EXPORTED void syslog(int prio, const char *fmt, ...)


### PR DESCRIPTION
If the compiler in use does not support `__va_arg_pack()`, GLIBC defines `syslog()` as a macro, and redefining it here breaks the build.