### PR TITLE
squatter: change -s option to require an argument

### DIFF
--- a/changes/next/squatter_s_argument_required
+++ b/changes/next/squatter_s_argument_required
@@ -1,0 +1,12 @@
+Description:
+
+Changes the squatter -s option to require an argument
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None. Optional argument handling of the -s option was broken already.

--- a/docsrc/imap/reference/manpages/systemcommands/squatter.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/squatter.rst
@@ -237,17 +237,18 @@ Options
     Recursively create indexes for all sub-mailboxes of the user,
     mailboxes or mailbox prefixes given as arguments.
 
-.. option:: -s, --squat-skip[=delta]
+.. option:: -s delta, --squat-skip=delta
 
     Skip mailboxes that have not been modified since last index. This is
     achieved by comparing the last modification time of a mailbox to
     the last time the squat index of this mailbox got updated. If the
-    mailbox modification time (plus delta) is less than the squat
-    index modification time, then the mailbox is skipped. The optional
-    argument value delta is defined in seconds and must be equal to or
-    higher than zero, the default value is 60.
+    mailbox modification time plus delta is less than the squat
+    index modification time, then the mailbox is skipped. The argument
+    value delta is defined in seconds and must be greater than or equal
+    to zero. The historical default delta was 60, and this remains a
+    good general choice, but for technical reasons it must now be
+    specified explicitly.
     Squat only.
-    |master-new-feature|
 
 .. option:: -S seconds, --sleep=seconds
 

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -965,7 +965,7 @@ int main(int argc, char **argv)
 
         /* squat flags */
         {"squat-annot", no_argument, 0, 'a' },
-        {"squat-skip", optional_argument, 0, 's' },
+        {"squat-skip", required_argument, 0, 's' },
 
         /* synclog-mode flags */
         {"synclog", required_argument, 0, 'f' },
@@ -1106,16 +1106,13 @@ int main(int argc, char **argv)
 
         case 's':
             if (mode != UNKNOWN && mode != INDEXER) usage(argv[0]);
-            if (optarg) {
+            {
                 char *end;
                 long val = strtol(optarg, &end, 10);
                 if (val < 0 || val > INT_MAX || *end) {
                     usage(argv[0]);
                 }
                 skip_unmodified = (int) val;
-            }
-            else {
-                skip_unmodified = 60;
             }
             mode = INDEXER;
             break;


### PR DESCRIPTION
It didn't work with optional arguments anyway.

Fixes #3496