### PR TITLE
backups: use xsyslog for IOERRORs

### DIFF
--- a/backup/backupd.c
+++ b/backup/backupd.c
@@ -721,7 +721,8 @@ static void cmdloop(void)
 
         }
 
-        syslog(LOG_ERR, "IOERROR: received bad command: %s", cmd.s);
+        xsyslog(LOG_ERR, "IOERROR: received bad command",
+                         "command=<%s>", cmd.s);
         prot_printf(backupd_out, "BAD IMAP_PROTOCOL_ERROR Unrecognized command\r\n");
         eatline(backupd_in, c);
         continue;
@@ -923,7 +924,8 @@ static int cmd_apply_message(struct dlist *dl)
             close(fd);
         }
         else {
-            syslog(LOG_ERR, "IOERROR: %s open %s: %m", __func__, fname);
+            xsyslog(LOG_ERR, "IOERROR: open failed",
+                             "filename=<%s>", fname);
             r = IMAP_IOERROR;
         }
 

--- a/backup/lcb.c
+++ b/backup/lcb.c
@@ -159,7 +159,8 @@ HIDDEN int backup_real_open(struct backup **backupp,
                 r = IMAP_MAILBOX_NONEXISTENT;
                 break;
             default:
-                syslog(LOG_ERR, "IOERROR: open %s: %m", backup->data_fname);
+                xsyslog(LOG_ERR, "IOERROR: open failed",
+                                 "filename=<%s>", backup->data_fname);
                 r = IMAP_IOERROR;
                 break;
             }
@@ -173,7 +174,8 @@ HIDDEN int backup_real_open(struct backup **backupp,
                 r = IMAP_MAILBOX_LOCKED;
             }
             else {
-                syslog(LOG_ERR, "IOERROR: lock_setlock: %s: %m", backup->data_fname);
+                xsyslog(LOG_ERR, "IOERROR: lock_setlock failed",
+                                 "filename=<%s>", backup->data_fname);
                 r = IMAP_IOERROR;
             }
             goto error;
@@ -182,7 +184,8 @@ HIDDEN int backup_real_open(struct backup **backupp,
         r = fstat(fd, &sbuf1);
         if (!r) r = stat(backup->data_fname, &sbuf2);
         if (r) {
-            syslog(LOG_ERR, "IOERROR: (f)stat %s: %m", backup->data_fname);
+            xsyslog(LOG_ERR, "IOERROR: stat failed",
+                             "filename=<%s>", backup->data_fname);
             r = IMAP_IOERROR;
             close(fd);
             goto error;
@@ -205,7 +208,9 @@ HIDDEN int backup_real_open(struct backup **backupp,
 
         r = rename(backup->index_fname, oldindex_fname);
         if (r && errno != ENOENT) {
-            syslog(LOG_ERR, "IOERROR: rename %s %s: %m", backup->index_fname, oldindex_fname);
+            xsyslog(LOG_ERR, "IOERROR: rename failed",
+                             "source=<%s> dest=<%s>",
+                             backup->index_fname, oldindex_fname);
             r = IMAP_IOERROR;
             goto error;
         }
@@ -218,7 +223,8 @@ HIDDEN int backup_real_open(struct backup **backupp,
         struct stat data_statbuf;
         r = fstat(backup->fd, &data_statbuf);
         if (r) {
-            syslog(LOG_ERR, "IOERROR: fstat %s: %m", backup->data_fname);
+            xsyslog(LOG_ERR, "IOERROR: fstat failed",
+                             "filename=<%s>", backup->data_fname);
             r = IMAP_IOERROR;
             goto error;
         }
@@ -226,13 +232,15 @@ HIDDEN int backup_real_open(struct backup **backupp,
             struct stat index_statbuf;
             r = stat(backup->index_fname, &index_statbuf);
             if (r && errno != ENOENT) {
-                syslog(LOG_ERR, "IOERROR: stat %s: %m", backup->index_fname);
+                xsyslog(LOG_ERR, "IOERROR: stat failed",
+                                 "filename=<%s>", backup->index_fname);
                 r = IMAP_IOERROR;
                 goto error;
             }
 
             if ((r && errno == ENOENT) || index_statbuf.st_size == 0) {
-                syslog(LOG_ERR, "reindex needed: %s", backup->index_fname);
+                xsyslog(LOG_ERR, "IOERROR: reindex needed",
+                                 "filename=<%s>", backup->index_fname);
                 r = IMAP_MAILBOX_BADFORMAT;
                 goto error;
             }
@@ -531,13 +539,15 @@ EXPORTED int backup_stat(const struct backup *backup,
 
     r = fstat(backup->fd, &data_statbuf);
     if (r) {
-        syslog(LOG_ERR, "IOERROR: fstat %s: %m", backup->data_fname);
+        xsyslog(LOG_ERR, "IOERROR: fstat failed",
+                         "filename=<%s>", backup->data_fname);
         return IMAP_IOERROR;
     }
 
     r = stat(backup->index_fname, &index_statbuf);
     if (r) {
-        syslog(LOG_ERR, "IOERROR: stat %s: %m", backup->index_fname);
+        xsyslog(LOG_ERR, "IOERROR: stat failed",
+                         "filename=<%s>", backup->index_fname);
         return IMAP_IOERROR;
     }
 
@@ -555,7 +565,8 @@ static ssize_t _prot_fill_cb(unsigned char *buf, size_t len, void *rock)
     int r = gzuc_read(gzuc, buf, len);
 
     if (r < 0)
-        syslog(LOG_ERR, "IOERROR: gzuc_read returned %i", r);
+        xsyslog(LOG_ERR, "IOERROR: gzuc_read failed",
+                         "return=<%d>", r);
     if (r < -1)
         errno = EIO;
 
@@ -741,7 +752,8 @@ EXPORTED int backup_rename(const mbname_t *old_mbname, const mbname_t *new_mbnam
                   O_RDWR | O_APPEND, /* no O_CREAT */
                   S_IRUSR | S_IWUSR);
     if (old.fd < 0) {
-        syslog(LOG_ERR, "IOERROR: open %s: %m", old.fname);
+        xsyslog(LOG_ERR, "IOERROR: open failed",
+                         "filename=<%s>", old.fname);
         r = -1;
         goto error;
     }
@@ -749,7 +761,8 @@ EXPORTED int backup_rename(const mbname_t *old_mbname, const mbname_t *new_mbnam
     /* non-blocking, to avoid deadlock */
     r = lock_setlock(old.fd, /*excl*/ 1, /*nb*/ 1, old.fname);
     if (r) {
-        syslog(LOG_ERR, "IOERROR: lock_setlock: %s: %m", old.fname);
+        xsyslog(LOG_ERR, "IOERROR: lock_setlock failed",
+                         "filename=<%s>", old.fname);
         goto error;
     }
 

--- a/backup/lcb_append.c
+++ b/backup/lcb_append.c
@@ -76,7 +76,9 @@ static int retry_gzwrite(gzFile gzfile, const char *str, size_t len, const char 
         else {
             int r;
             const char *err = gzerror(gzfile, &r);
-            syslog(LOG_ERR, "IOERROR: %s gzwrite %s: %s", __func__, fname, err);
+            xsyslog(LOG_ERR, "IOERROR: gzwrite failed",
+                             "filename=<%s> error=<%s>",
+                             fname, err);
 
             if (r == Z_STREAM_ERROR)
                 fatal("gzwrite: invalid stream", EX_IOERR);

--- a/backup/lcb_compact.c
+++ b/backup/lcb_compact.c
@@ -165,9 +165,15 @@ static int compact_closerename(struct backup **originalp,
         unlink(original->data_fname);
         unlink(original->index_fname);
         if (link(buf_cstring(&ts_data_fname), original->data_fname))
-            syslog(LOG_ERR, "IOERROR: failed to link file back (%s %s)!", buf_cstring(&ts_data_fname), original->data_fname);
+            xsyslog(LOG_ERR, "IOERROR: failed to link file back!",
+                             "source=<%s> dest=<%s>",
+                             buf_cstring(&ts_data_fname),
+                             original->data_fname);
         if (link(buf_cstring(&ts_index_fname), original->index_fname))
-            syslog(LOG_ERR, "IOERROR: failed to link file back (%s %s)!", buf_cstring(&ts_index_fname), original->index_fname);
+            xsyslog(LOG_ERR, "IOERROR: failed to link file back!",
+                             "source=<%s> dest=<%s>",
+                             buf_cstring(&ts_index_fname),
+                             original->index_fname);
         goto done;
     }
 
@@ -419,7 +425,8 @@ static ssize_t _prot_fill_cb(unsigned char *buf, size_t len, void *rock)
     int r = gzuc_read(gzuc, buf, len);
 
     if (r < 0)
-        syslog(LOG_ERR, "IOERROR: gzuc_read returned %i", r);
+        xsyslog(LOG_ERR, "IOERROR: gzuc_read failed",
+                         "return=<%d>", r);
     if (r < -1)
         errno = EIO;
 

--- a/backup/lcb_read.c
+++ b/backup/lcb_read.c
@@ -208,10 +208,11 @@ EXPORTED int backup_prepare_message_upload(struct backup *backup,
             prot_free(ps);
             ps = NULL;
             if (c == EOF) {
-                syslog(LOG_ERR, "IOERROR: couldn't parse message %s from chunk %d of backup %s",
-                       message_guid_encode(&msgid->guid),
-                       chunk->id,
-                       backup->data_fname);
+                xsyslog(LOG_ERR, "IOERROR: parse_backup_line failed",
+                                 "guid=<%s> chunk=<%d> backup=<%s>",
+                                 message_guid_encode(&msgid->guid),
+                                 chunk->id,
+                                 backup->data_fname);
                 r = IMAP_IOERROR;
             }
         }

--- a/backup/lcb_verify.c
+++ b/backup/lcb_verify.c
@@ -286,7 +286,8 @@ static int _verify_message_cb(const struct backup_message *message, void *rock)
                     close(fd);
                 }
                 else {
-                    syslog(LOG_ERR, "IOERROR: %s open %s: %m", __func__, fname);
+                    xsyslog(LOG_ERR, "IOERROR: open failed",
+                                     "filename=<%s>", fname);
                     if (out)
                         fprintf(out, "error reading staging file for message %i\n", message->id);
                     r = -1;


### PR DESCRIPTION
As usual, please both read and build test this.  This is the old replication-backups stuff, not the JMAP one.