### PR TITLE
jmap_mail: improve performance of inMailboxOtherThan queries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -646,7 +646,8 @@ cunit_TESTS = \
 	cunit/quota.testc \
 	cunit/rfc822tok.testc \
 	cunit/search_expr.testc \
-	cunit/seqset.testc
+	cunit/seqset.testc \
+	cunit/smallarrayu64.testc
 
 if SIEVE
 cunit_TESTS += cunit/sieve.testc
@@ -787,6 +788,7 @@ include_HEADERS = \
 	lib/retry.h \
 	lib/rfc822tok.h \
 	lib/signals.h \
+	lib/smallarrayu64.h \
 	lib/sqldb.h \
 	lib/strarray.h \
 	lib/strhash.h \
@@ -1530,6 +1532,7 @@ lib_libcyrus_min_la_SOURCES = \
 	lib/libconfig.c \
 	lib/mpool.c \
 	lib/retry.c \
+	lib/smallarrayu64.c \
 	lib/strarray.c \
 	lib/strhash.c \
 	lib/util.c \

--- a/cunit/smallarrayu64.testc
+++ b/cunit/smallarrayu64.testc
@@ -1,0 +1,82 @@
+#include "cunit/cyrunit.h"
+#include "xmalloc.h"
+#include "smallarrayu64.h"
+
+static void test_fini_null(void)
+{
+    /* _fini(NULL) is harmless */
+    smallarrayu64_fini(NULL);
+    /* _free(NULL) is harmless */
+    smallarrayu64_free(NULL);
+}
+
+static void test_append(void)
+{
+    smallarrayu64_t sa = SMALLARRAYU64_INITIALIZER;
+
+    /* Append small integers until prealloc buffer is full */
+    int i;
+    for (i = 0; i < SMALLARRAYU64_ALLOC; i++) {
+        smallarrayu64_append(&sa, i);
+        CU_ASSERT_EQUAL(smallarrayu64_size(&sa), i + 1);
+        CU_ASSERT_EQUAL(sa.use_spillover, i == SMALLARRAYU64_ALLOC - 1);
+        CU_ASSERT_EQUAL(sa.spillover.count, 0);
+    }
+
+    /* Append next integer */
+    smallarrayu64_append(&sa, SMALLARRAYU64_ALLOC);
+    CU_ASSERT_EQUAL(smallarrayu64_size(&sa), SMALLARRAYU64_ALLOC + 1);
+    CU_ASSERT_EQUAL(sa.count, SMALLARRAYU64_ALLOC);
+    CU_ASSERT_EQUAL(sa.use_spillover, 1);
+    CU_ASSERT_EQUAL(sa.spillover.count, 1);
+
+    smallarrayu64_fini(&sa);
+}
+
+static void test_append_largenum(void)
+{
+    smallarrayu64_t sa = SMALLARRAYU64_INITIALIZER;
+
+    smallarrayu64_append(&sa, 12);
+    smallarrayu64_append(&sa, 24);
+    smallarrayu64_append(&sa, 36);
+
+    CU_ASSERT_EQUAL(sa.count, 3);
+    CU_ASSERT_EQUAL(sa.use_spillover, 0);
+    CU_ASSERT_EQUAL(sa.spillover.count, 0);
+
+    smallarrayu64_append(&sa, 2222222L);
+
+    CU_ASSERT_EQUAL(sa.count, 3);
+    CU_ASSERT_EQUAL(sa.use_spillover, 1);
+    CU_ASSERT_EQUAL(sa.spillover.count, 1);
+
+    smallarrayu64_fini(&sa);
+}
+
+static void test_nth(void)
+{
+    smallarrayu64_t sa = SMALLARRAYU64_INITIALIZER;
+    uint64_t vals[] = { 12L, 24L, 36L, 2222222L, 48L };
+    ssize_t nvals = sizeof(vals) / sizeof(vals[0]);
+
+    ssize_t i;
+    for (i = 0; i < nvals; i++) {
+        smallarrayu64_append(&sa, vals[i]);
+    }
+    for (i = 0; i < nvals; i++) {
+        CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, i), vals[i]);
+    }
+
+    /* negative index */
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, -nvals), vals[0]);
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, -1), vals[nvals-1]);
+
+    /* out of index */
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, nvals), 0);
+    CU_ASSERT_EQUAL(smallarrayu64_nth(&sa, -nvals-1), 0);
+
+    smallarrayu64_fini(&sa);
+}
+
+/* vim: set ft=c: */

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1487,7 +1487,7 @@ struct emailsearch_folders_value {
 };
 
 static struct emailsearch_folders_value *
-_emailsearch_folders_value_new(jmap_req_t *req,
+emailsearch_folders_value_new(jmap_req_t *req,
                               json_t *jmboxids,
                               int is_otherthan,
                               int want_expunged)
@@ -1519,7 +1519,7 @@ _emailsearch_folders_value_new(jmap_req_t *req,
     return val;
 }
 
-static void _emailsearch_folders_value_free(struct emailsearch_folders_value **valp)
+static void emailsearch_folders_value_free(struct emailsearch_folders_value **valp)
 {
     if (!valp || !*valp) return;
 
@@ -1532,24 +1532,24 @@ static void _emailsearch_folders_value_free(struct emailsearch_folders_value **v
     *valp = NULL;
 }
 
-struct _emailsearch_folders_internal
+struct emailsearch_folders_internal
 {
     struct conversations_state *cstate;
     int is_filtered_folder;
 };
 
-static void _emailsearch_folders_internalise(struct index_state *state,
+static void emailsearch_folders_internalise(struct index_state *state,
                                             const union search_value *v,
                                             void **internalisedp)
 {
     if (*internalisedp) {
-        struct _emailsearch_folders_internal *internal = *internalisedp;
+        struct emailsearch_folders_internal *internal = *internalisedp;
         free(internal);
         *internalisedp = NULL;
     }
     if (state && v) {
-        struct _emailsearch_folders_internal *internal =
-            xzmalloc(sizeof(struct _emailsearch_folders_internal));
+        struct emailsearch_folders_internal *internal =
+            xzmalloc(sizeof(struct emailsearch_folders_internal));
         internal->cstate = mailbox_get_cstate(state->mailbox);
 
         struct emailsearch_folders_value *val = v->v;
@@ -1581,7 +1581,7 @@ static void _emailsearch_folders_internalise(struct index_state *state,
     }
 }
 
-static int _emailsearch_folders_match_cb(const conv_guidrec_t *rec, void *rock)
+static int emailsearch_folders_match_cb(const conv_guidrec_t *rec, void *rock)
 {
     struct emailsearch_folders_value *val = rock;
     if (!val->want_expunged &&
@@ -1593,12 +1593,12 @@ static int _emailsearch_folders_match_cb(const conv_guidrec_t *rec, void *rock)
     return !isset == !val->is_otherthan ? 0 : IMAP_OK_COMPLETED;
 }
 
-static int _emailsearch_folders_match(message_t *m,
+static int emailsearch_folders_match(message_t *m,
                                      const union search_value *v,
                                      void *internalised,
                                      void *data1 __attribute__((unused)))
 {
-    struct _emailsearch_folders_internal *internal = internalised;
+    struct emailsearch_folders_internal *internal = internalised;
     struct emailsearch_folders_value *val = v->v;
 
     if ((internal->is_filtered_folder && !val->is_otherthan) ||
@@ -1613,11 +1613,11 @@ static int _emailsearch_folders_match(message_t *m,
     int r = message_get_guid(m, &guid);
     if (r) return 0;
     r = conversations_guid_foreach(internal->cstate,
-            message_guid_encode(guid), _emailsearch_folders_match_cb, val);
+            message_guid_encode(guid), emailsearch_folders_match_cb, val);
     return r == IMAP_OK_COMPLETED;
 }
 
-static void _emailsearch_folders_serialise(struct buf *buf,
+static void emailsearch_folders_serialise(struct buf *buf,
                                           const union search_value *v)
 {
     struct emailsearch_folders_value *val = v->v;
@@ -1640,7 +1640,7 @@ static void _emailsearch_folders_serialise(struct buf *buf,
     buf_putc(buf, ')');
 }
 
-static int _emailsearch_folders_unserialise(struct protstream* prot,
+static int emailsearch_folders_unserialise(struct protstream* prot,
                                            union search_value *v)
 {
     struct dlist *dl = NULL;
@@ -1665,7 +1665,7 @@ static int _emailsearch_folders_unserialise(struct protstream* prot,
     }
     else {
         xsyslog(LOG_ERR, "expected is_otherthan", NULL);
-        _emailsearch_folders_value_free(&val);
+        emailsearch_folders_value_free(&val);
         goto done;
     }
     if (dlist_print_iter_step(iter, &buf)) {
@@ -1675,7 +1675,7 @@ static int _emailsearch_folders_unserialise(struct protstream* prot,
     }
     else {
         xsyslog(LOG_ERR, "expected want_expunged", NULL);
-        _emailsearch_folders_value_free(&val);
+        emailsearch_folders_value_free(&val);
         goto done;
     }
     while (iter && dlist_print_iter_step(iter, &buf)) {
@@ -1692,7 +1692,7 @@ done:
     return c;
 }
 
-static void _emailsearch_folders_duplicate(union search_value *new,
+static void emailsearch_folders_duplicate(union search_value *new,
                                            const union search_value *old)
 {
     struct emailsearch_folders_value *newv =
@@ -1709,37 +1709,37 @@ static void _emailsearch_folders_duplicate(union search_value *new,
     new->v = newv;
 }
 
-static void _emailsearch_folders_free(union search_value *v)
+static void emailsearch_folders_free(union search_value *v)
 {
     struct emailsearch_folders_value *val = v->v;
-    _emailsearch_folders_value_free(&val);
+    emailsearch_folders_value_free(&val);
 }
 
-static const search_attr_t _emailsearch_folders_attr = {
+static const search_attr_t emailsearch_folders_attr = {
     "jmap_folders",
     SEA_MUTABLE,
     SEARCH_PART_NONE,
     SEARCH_COST_CONV,
-    _emailsearch_folders_internalise,
+    emailsearch_folders_internalise,
     /*cmp*/NULL,
-    _emailsearch_folders_match,
-    _emailsearch_folders_serialise,
-    _emailsearch_folders_unserialise,
+    emailsearch_folders_match,
+    emailsearch_folders_serialise,
+    emailsearch_folders_unserialise,
     /*get_countability*/NULL,
-    _emailsearch_folders_duplicate,
-    _emailsearch_folders_free,
+    emailsearch_folders_duplicate,
+    emailsearch_folders_free,
     (void*)0 /*is_otherthan*/
 };
 
 /* ====================================================================== */
 
-static void _emailsearch_headermatch_internalise(struct index_state *state __attribute__((unused)),
+static void emailsearch_headermatch_internalise(struct index_state *state __attribute__((unused)),
                                                  const union search_value *v __attribute__((unused)),
                                                  void **internalisedp __attribute__((unused)))
 {
 }
 
-static int _emailsearch_headermatch_match(message_t *msg,
+static int emailsearch_headermatch_match(message_t *msg,
                                           const union search_value *v,
                                           void *internalised __attribute__((unused)),
                                           void *data1 __attribute__((unused)))
@@ -1747,7 +1747,7 @@ static int _emailsearch_headermatch_match(message_t *msg,
     return jmap_headermatch_match((struct jmap_headermatch *)v->v, msg);
 }
 
-static void _emailsearch_headermatch_serialise(struct buf *buf,
+static void emailsearch_headermatch_serialise(struct buf *buf,
                                                const union search_value *v)
 {
     struct jmap_headermatch *hm = v->v;
@@ -1771,7 +1771,7 @@ static void _emailsearch_headermatch_serialise(struct buf *buf,
     dlist_free(&dl);
 }
 
-static int _emailsearch_headermatch_unserialise(struct protstream* prot,
+static int emailsearch_headermatch_unserialise(struct protstream* prot,
                                                 union search_value *v)
 {
     struct dlist *dl = NULL;
@@ -1799,48 +1799,48 @@ static int _emailsearch_headermatch_unserialise(struct protstream* prot,
     return c;
 }
 
-static void _emailsearch_headermatch_duplicate(union search_value *new,
+static void emailsearch_headermatch_duplicate(union search_value *new,
                                                const union search_value *old)
 {
     new->v = jmap_headermatch_dup((struct jmap_headermatch *)old->v);
 }
 
-static void _emailsearch_headermatch_free(union search_value *v)
+static void emailsearch_headermatch_free(union search_value *v)
 {
     struct jmap_headermatch *hm = v->v;
     jmap_headermatch_free(&hm);
     v->v = NULL;
 }
 
-static const search_attr_t _emailsearch_headermatch_attr_uncached = {
+static const search_attr_t emailsearch_headermatch_attr_uncached = {
     "jmap_headermatch_uncached",
     /*flags*/0,
     SEARCH_PART_NONE,
     SEARCH_COST_BODY,
-    _emailsearch_headermatch_internalise,
+    emailsearch_headermatch_internalise,
     /*cmp*/NULL,
-    _emailsearch_headermatch_match,
-    _emailsearch_headermatch_serialise,
-    _emailsearch_headermatch_unserialise,
+    emailsearch_headermatch_match,
+    emailsearch_headermatch_serialise,
+    emailsearch_headermatch_unserialise,
     /*get_countability*/NULL,
-    _emailsearch_headermatch_duplicate,
-    _emailsearch_headermatch_free,
+    emailsearch_headermatch_duplicate,
+    emailsearch_headermatch_free,
     NULL
 };
 
-static const search_attr_t _emailsearch_headermatch_attr_cached = {
+static const search_attr_t emailsearch_headermatch_attr_cached = {
     "jmap_headermatch_cached",
     /*flags*/0,
     SEARCH_PART_NONE,
     SEARCH_COST_CACHE,
-    _emailsearch_headermatch_internalise,
+    emailsearch_headermatch_internalise,
     /*cmp*/NULL,
-    _emailsearch_headermatch_match,
-    _emailsearch_headermatch_serialise,
-    _emailsearch_headermatch_unserialise,
+    emailsearch_headermatch_match,
+    emailsearch_headermatch_serialise,
+    emailsearch_headermatch_unserialise,
     /*get_countability*/NULL,
-    _emailsearch_headermatch_duplicate,
-    _emailsearch_headermatch_free,
+    emailsearch_headermatch_duplicate,
+    emailsearch_headermatch_free,
     NULL
 };
 
@@ -1974,8 +1974,8 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
             // use the right cost, the query optimizer will need it
             const search_attr_t *attr = search_attr_find_field(hdr);
             e->attr = attr->cost == SEARCH_COST_CACHE ?
-                &_emailsearch_headermatch_attr_cached :
-                &_emailsearch_headermatch_attr_uncached;
+                &emailsearch_headermatch_attr_cached :
+                &emailsearch_headermatch_attr_uncached;
             e->value.v = jmap_headermatch_new(hdr, str, cmp);
 
             _email_search_perf_attr(e->attr, perf_filters);
@@ -1985,10 +1985,10 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
             json_t *myval = json_array();
             json_array_append(myval, val);
             struct emailsearch_folders_value *v =
-                _emailsearch_folders_value_new(req, myval, 0, want_expunged);
+                emailsearch_folders_value_new(req, myval, 0, want_expunged);
             if (v) {
                 search_expr_t *e = search_expr_new(this, SEOP_MATCH);
-                e->attr = &_emailsearch_folders_attr;
+                e->attr = &emailsearch_folders_attr;
                 e->value.v = v;
                 strarray_add(perf_filters, "mailbox");
             }
@@ -2001,10 +2001,10 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
 
         if (JNOTNULL((val = json_object_get(filter, "inMailboxOtherThan")))) {
             struct emailsearch_folders_value *v =
-                _emailsearch_folders_value_new(req, val, 1, want_expunged);
+                emailsearch_folders_value_new(req, val, 1, want_expunged);
             if (v) {
                 search_expr_t *e = search_expr_new(this, SEOP_MATCH);
-                e->attr = &_emailsearch_folders_attr;
+                e->attr = &emailsearch_folders_attr;
                 e->value.v = v;
                 strarray_add(perf_filters, "mailbox");
             }
@@ -2127,7 +2127,7 @@ static int convert_foldermatch(search_expr_t *e,
     }
 
     char *folderm = strarray_pop(&val->foldernames);
-    _emailsearch_folders_value_free(&val);
+    emailsearch_folders_value_free(&val);
     e->attr = search_attr_find("folder");
     e->value.s = folderm;
 
@@ -2169,7 +2169,7 @@ static void convert_folderclause(search_expr_t *clause,
     }
 }
 
-static int _emailsearch_normalise(search_expr_t **rootp, int *is_imapfolderptr)
+static int emailsearch_normalise(search_expr_t **rootp, int *is_imapfolderptr)
 {
     if (is_imapfolderptr) *is_imapfolderptr = 0;
 
@@ -2403,7 +2403,7 @@ struct emailsearch {
     struct index_init init;
 };
 
-static void _emailsearch_fini(struct emailsearch *search)
+static void emailsearch_fini(struct emailsearch *search)
 {
     if (!search) return;
 
@@ -2430,7 +2430,7 @@ static int _jmap_checkfolder(const char *mboxname, void *rock)
     return 0;
 }
 
-static void _emailsearch_init(struct emailsearch *search,
+static void emailsearch_init(struct emailsearch *search,
                               jmap_req_t *req,
                               json_t *filter,
                               json_t *jsort,
@@ -2448,7 +2448,7 @@ static void _emailsearch_init(struct emailsearch *search,
 
     search->expr_dnf = search_expr_duplicate(search->expr_orig);
 
-    int r = _emailsearch_normalise(&search->expr_dnf, &search->is_imapfolder);
+    int r = emailsearch_normalise(&search->expr_dnf, &search->is_imapfolder);
     if (r == IMAP_SEARCH_SLOW) {
         *err = json_pack("{s:s s:s}", "type", "unsupportedFilter",
                 "description", "search too complex");
@@ -2850,7 +2850,7 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                     }
                     *need_folders = 1;
                 }
-                else if (e->attr == &_emailsearch_folders_attr) {
+                else if (e->attr == &emailsearch_folders_attr) {
                     // inMailbox or inMailboxOtherThan filter, JMAP-style
                     struct emailsearch_folders_value *val = e->value.v;
                     ge = xzmalloc(sizeof(struct guidsearch_expr));
@@ -3122,7 +3122,7 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
         case SEOP_MATCH:
             // check for supported MATCH expressions
             if (e->attr == search_attr_find("folder") ||
-                e->attr == &_emailsearch_folders_attr) {
+                e->attr == &emailsearch_folders_attr) {
                 /* inMailbox
                  * inMailboxOtherThan */
                 if (nonxapian_hash) {
@@ -3702,7 +3702,7 @@ static int emailquery_search(jmap_req_t *req,
     int r = 0;
 
     struct emailsearch search;
-    _emailsearch_init(&search, req, q->super.filter, q->super.sort,
+    emailsearch_init(&search, req, q->super.filter, q->super.sort,
             contactgroups, 0, q->want_partids, 0, errp);
     if (*errp) goto done;
 
@@ -3738,7 +3738,7 @@ static int emailquery_search(jmap_req_t *req,
     qr->is_guidsearch = is_guidsearch;
 
 done:
-    _emailsearch_fini(&search);
+    emailsearch_fini(&search);
     return r;
 }
 
@@ -4323,7 +4323,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     }
 
     struct emailsearch search;
-    _emailsearch_init(&search, req, query->filter, query->sort,
+    emailsearch_init(&search, req, query->filter, query->sort,
                       &contactfilter->contactgroups,
                       /*want_expunged*/1,
                       /*want_partids*/0,
@@ -4510,7 +4510,7 @@ done:
         }
         else *err = jmap_server_error(r);
     }
-    _emailsearch_fini(&search);
+    emailsearch_fini(&search);
 }
 
 static void _email_querychanges_uncollapsed(jmap_req_t *req,
@@ -4538,7 +4538,7 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     }
 
     struct emailsearch search;
-    _emailsearch_init(&search, req, query->filter, query->sort,
+    emailsearch_init(&search, req, query->filter, query->sort,
                       &contactfilter->contactgroups,
                       /*want_expunged*/1,
                       /*want_partids*/0,
@@ -4673,7 +4673,7 @@ done:
         }
         else *err = jmap_server_error(r);
     }
-    _emailsearch_fini(&search);
+    emailsearch_fini(&search);
 }
 
 static int jmap_email_querychanges(jmap_req_t *req)
@@ -4739,7 +4739,7 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes, json_t
     json_t *sort = json_pack("[{s:s}]", "property", "emailState");
 
     struct emailsearch search;
-    _emailsearch_init(&search, req, filter, sort,
+    emailsearch_init(&search, req, filter, sort,
                       /*contactgroups*/NULL,
                       /*want_expunged*/1,
                       /*want_partids*/0,
@@ -4826,7 +4826,7 @@ done:
         }
         else *err = jmap_server_error(r);
     }
-    _emailsearch_fini(&search);
+    emailsearch_fini(&search);
 }
 
 static int jmap_email_changes(jmap_req_t *req)
@@ -4870,7 +4870,7 @@ static void _thread_changes(jmap_req_t *req, struct jmap_changes *changes, json_
     json_t *sort = json_pack("[{s:s}]", "property", "emailState");
 
     struct emailsearch search;
-    _emailsearch_init(&search, req, filter, sort,
+    emailsearch_init(&search, req, filter, sort,
                       /*contactgroups*/NULL,
                       /*want_expunged*/1,
                       /*want_partids*/0,
@@ -4943,7 +4943,7 @@ done:
         }
         else *err = jmap_server_error(r);
     }
-    _emailsearch_fini(&search);
+    emailsearch_fini(&search);
 }
 
 static int jmap_thread_changes(jmap_req_t *req)

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -54,8 +54,7 @@
 #include "search_sort.h"
 
 typedef int (*search_hit_cb_t)(const char *mboxname, uint32_t uidvalidity,
-                               uint32_t uid, const strarray_t *partids,
-                               void *rock);
+                               uint32_t uid, const char *partid, void *rock);
 
 typedef int (*search_hitguid_cb_t)(const conv_guidrec_t *rec, size_t nguids,
                                    void *rock);

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -450,8 +450,7 @@ static int run(search_builder_t *bx, search_hit_cb_t proc, void *rock)
     for (uid = 1 ; uid <= bb->mailbox->i.last_uid; uid++) {
         if (bv_isset(&bb->stack[0].msg_vector, uid)) {
             r = proc(bb->mailbox->name,
-                     bb->mailbox->i.uidvalidity,
-                     uid, NULL, rock);
+                     bb->mailbox->i.uidvalidity, uid, NULL, rock);
             if (r) goto out;
         }
     }

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -528,8 +528,7 @@ error:
 }
 
 static int print_search_hit(const char *mboxname, uint32_t uidvalidity,
-                            uint32_t uid,
-                            const strarray_t *partids __attribute__((unused)),
+                            uint32_t uid, const char *partid __attribute__((unused)),
                             void *rock)
 {
     int single = *(int *)rock;

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1121,10 +1121,19 @@ Blank lines and lines beginning with ``#'' are ignored.
    the same has to be done (cyr_dbtool) for each subscription database
    See improved_mboxlist_sort.html.*/
 
-{ "jmap_emailsearch_db_path", NULL, STRING, "3.1.6" }
+{ "jmap_emailsearch_db_path", NULL, STRING, "3.1.6", "UNRELEASED" }
 /* The absolute path to the JMAP email search cache file.  If not
    specified, JMAP Email/query and Email/queryChanges will not
    cache email search results. */
+
+{ "jmap_querycache_max_age", "0m", DURATION, "UNRELEASED" }
+/* The duration after which unused cached JMAP query results
+   must be evicted from process memory. If non-zero, then the
+   full result of the last query (before windowing) is stored
+   in-memory. Subsequent queries with the same expression and
+   query state can then page through the cached result.
+   A zero value disables query result caching.
+   This feature currently only is enabled for Email/query. */
 
 { "jmap_preview_annot", NULL, STRING, "3.1.1" }
 /* The name of the per-message annotation, if any, to store message

--- a/lib/smallarrayu64.c
+++ b/lib/smallarrayu64.c
@@ -1,0 +1,69 @@
+#include <assert.h>
+#include <config.h>
+#include <string.h>
+
+#include "smallarrayu64.h"
+#include "xmalloc.h"
+
+EXPORTED smallarrayu64_t *smallarrayu64_new(void)
+{
+    return xzmalloc(sizeof(smallarrayu64_t));
+}
+
+EXPORTED void smallarrayu64_fini(smallarrayu64_t *sa)
+{
+    if (!sa) return;
+    arrayu64_fini(&sa->spillover);
+    sa->count = 0;
+    sa->use_spillover = 0;
+}
+
+EXPORTED void smallarrayu64_free(smallarrayu64_t *sa)
+{
+    if (!sa) return;
+    smallarrayu64_fini(sa);
+    free(sa);
+}
+
+EXPORTED int smallarrayu64_append(smallarrayu64_t *sa, uint64_t num)
+{
+    if (sa->count < SMALLARRAYU64_ALLOC && !sa->use_spillover) {
+        if (num <= UINT8_MAX) {
+            sa->data[sa->count++] = num;
+            if (sa->count == SMALLARRAYU64_ALLOC) {
+                sa->use_spillover = 1;
+            }
+            return sa->count;
+        }
+        /* can't store num in preallocated data */
+        sa->use_spillover = 1;
+    }
+    return arrayu64_append(&sa->spillover, num);
+}
+
+EXPORTED size_t smallarrayu64_size(smallarrayu64_t *sa)
+{
+    return sa->count + arrayu64_size(&sa->spillover);
+}
+
+static inline int adjust_index_ro(const smallarrayu64_t *sa, int idx)
+{
+    size_t count = sa->count + arrayu64_size(&sa->spillover);
+    if (idx >= 0 && (unsigned) idx >= count)
+        return -1;
+    else if (idx < 0)
+        idx += count;
+    return idx;
+}
+
+EXPORTED uint64_t smallarrayu64_nth(smallarrayu64_t *sa, int idx)
+{
+    if ((idx = adjust_index_ro(sa, idx)) < 0)
+        return 0;
+    if ((size_t)idx < sa->count) {
+        return sa->data[idx];
+    }
+    else {
+        return arrayu64_nth(&sa->spillover, idx - sa->count);
+    }
+}

--- a/lib/smallarrayu64.h
+++ b/lib/smallarrayu64.h
@@ -1,0 +1,78 @@
+/* smallarrayu64.h - an expanding array of 64 bit unsigned integers
+ *
+ * Copyright (c) 1994-2011 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Author: Greg Banks
+ * Start Date: 2011/01/11
+ */
+
+#ifndef __CYRUS_SMALLARRAYU64_H__
+#define __CYRUS_SMALLARRAYU64_H__
+
+#include <sys/types.h>
+
+#include <stdint.h>
+
+#include "arrayu64.h"
+
+#define SMALLARRAYU64_ALLOC 8
+
+typedef struct {
+    size_t count;
+    uint8_t data[SMALLARRAYU64_ALLOC];
+    arrayu64_t spillover;
+    int use_spillover;
+} smallarrayu64_t;
+
+#define SMALLARRAYU64_INITIALIZER { 0, { 0 }, ARRAYU64_INITIALIZER, 0 }
+
+#define smallarrayu64_init(sa)   (memset((sa), 0, sizeof(smallarrayu64_t)))
+extern void smallarrayu64_fini(smallarrayu64_t *sa);
+
+extern smallarrayu64_t *smallarrayu64_new(void);
+extern void smallarrayu64_free(smallarrayu64_t *);
+
+extern int smallarrayu64_append(smallarrayu64_t *sa, uint64_t num);
+
+extern size_t smallarrayu64_size(smallarrayu64_t *sa);
+
+extern uint64_t smallarrayu64_nth(smallarrayu64_t *sa, int idx);
+
+#endif /* __CYRUS_SMALLARRAYU64_H__ */


### PR DESCRIPTION
The current uidsearch inMailboxOtherThan filter unnecessarily checks every potentially matching message in conversations.db. This can result in search timeouts for very large mailboxes, and generally wastes too much time doing unecessary checks.

This patch fixes the uidsearch variant of inMailboxOtherThan to only check these messages, that actually are part of the filtered mailbox. For all others is trivially evaluates to true. In addition, rather than string comparing the message's mailboxes against the filter, it uses a bitset populated with the conversation.db-internal numeric mailbox ids.

The same bitvector is used in guidsearch.

This PR is built on https://github.com/cyrusimap/cyrus-imapd/pull/3460

This PR also includes a code hygiene commit that removes the leading underscore from the static emailsearch function names.