### PR TITLE
Possible fix for failing SearchSquat.simple test on master

### DIFF
--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -629,6 +629,7 @@ EXPORTED void search_build_query(search_builder_t *bx, search_expr_t *e)
         bop = SEARCH_OP_OR;
         break;
 
+    case SEOP_MATCH:
     case SEOP_FUZZYMATCH:
         if (e->attr && search_can_match(e->op, e->attr->part)) {
             if (e->attr->flags & SEA_ISLIST) {


### PR DESCRIPTION
The test was broken by 5f6bc5eaaeca1fcc65fb3f55352a21a2a5c097ce, which among other things removed an `SEOP_MATCH:` case from `search_build_query()`.  I don't understand why it was removed, maybe it was accidental?  Restoring it seems to fix the broken test, while not breaking anything else.