### PR TITLE
fix broken delivery to shared mailboxes

### DIFF
--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -843,8 +843,10 @@ int deliver(message_data_t *msgdata, char *authuser,
             // lock conversations for the duration of delivery, so nothing else can read
             // the state of any mailbox while the delivery is half done
             struct conversations_state *state = NULL;
-            r = conversations_open_user(mbname_userid(mbname), 0/*shared*/, &state);
-            if (r) goto setstatus;
+            if (mbname_userid(mbname)) {
+                r = conversations_open_user(mbname_userid(mbname), 0/*shared*/, &state);
+                if (r) goto setstatus;
+            }
 
             /* local mailbox */
             mydata.cur_rcpt = n;


### PR DESCRIPTION
Plus address delivery to shared mailboxes (e.g. `<+shared/foo@domain.com>`, with no localpart) has been broken since we started locking the user's conversations database during delivery, since shared mailboxes don't have a conversations database.

This fixes it by only locking the conversations database if `mbname_userid(...)` is non-NULL.

Regression test is here: https://github.com/cyrusimap/cassandane/compare/master...elliefm:v35/3488-lmtp-shared-mailbox

Fixes #3488 