### PR TITLE
Jmap cache one at a time

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3995,12 +3995,6 @@ static void emailquery_fingerprint(struct buf *fingerprint,
         buf_putc(fingerprint, '>');
     }
 
-    if (q->super.calculate_total) {
-        buf_putc(fingerprint, '<');
-        buf_appendcstr(fingerprint, "calculate_total");
-        buf_putc(fingerprint, '>');
-    }
-
     if (q->want_partids) {
         buf_putc(fingerprint, '<');
         buf_appendcstr(fingerprint, "want_partids");


### PR DESCRIPTION
This changes the _next functions to only return a single item at a time, and will only process exactly as many records as needed to fill the requested window.