### PR TITLE
conversations: cache altrep (uniqueid or name) in the conversations object

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -879,7 +879,7 @@ static int findstage_cb(const conv_guidrec_t *rec, void *vrock)
     // no point copying from archive, spool is on data
     if (rec->internal_flags & FLAG_INTERNAL_ARCHIVED) return 0;
 
-    int r = mboxlist_lookup_by_guidrec(rec, &mbentry, NULL);
+    int r = conv_guidrec_mbentry(rec, &mbentry);
     if (r) return 0;
 
     if (!strcmp(rock->partition, mbentry->partition)) {

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -289,6 +289,8 @@ EXPORTED const char *conversations_folder_mboxname(const struct conversations_st
                                                    int foldernum)
 {
     const char *val = strarray_nth(state->folders, foldernum);
+    if (!strcmpsafe(val, "-")) return NULL;  // tombstone
+
     if (state->folders_byname)
         return val;
 
@@ -313,6 +315,8 @@ EXPORTED const char *conversations_folder_uniqueid(const struct conversations_st
                                                    int foldernum)
 {
     const char *val = strarray_nth(state->folders, foldernum);
+    if (!strcmpsafe(val, "-")) return NULL;  // tombstone
+
     if (!state->folders_byname)
         return val;
 

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -296,17 +296,17 @@ EXPORTED const char *conversations_folder_mboxname(const struct conversations_st
 
     // make it writeable even though const, because we're fiddling cache
     struct conversations_state *backdoor = (struct conversations_state *)state;
-    if (!backdoor->altnames) backdoor->altnames = strarray_new();
-    const char *res = strarray_nth(backdoor->altnames, foldernum);
+    if (!backdoor->altrep) backdoor->altrep = strarray_new();
+    const char *res = strarray_nth(backdoor->altrep, foldernum);
     if (!res) {
         if (!val) return NULL;
         // cache lookup
         mbentry_t *mbentry = NULL;
         int r = mboxlist_lookup_by_uniqueid(val, &mbentry, NULL);
         if (r || !mbentry) return NULL;
-        strarray_set(backdoor->altnames, foldernum, mbentry->name);
+        strarray_set(backdoor->altrep, foldernum, mbentry->name);
         mboxlist_entry_free(&mbentry);
-        res = strarray_nth(backdoor->altnames, foldernum);
+        res = strarray_nth(backdoor->altrep, foldernum);
     }
     return res;
 }
@@ -322,17 +322,17 @@ EXPORTED const char *conversations_folder_uniqueid(const struct conversations_st
 
     // make it writeable even though const, because we're fiddling cache
     struct conversations_state *backdoor = (struct conversations_state *)state;
-    if (!backdoor->altnames) backdoor->altnames = strarray_new();
-    const char *res = strarray_nth(backdoor->altnames, foldernum);
+    if (!backdoor->altrep) backdoor->altrep = strarray_new();
+    const char *res = strarray_nth(backdoor->altrep, foldernum);
     if (!res) {
         if (!val) return NULL;
         // cache lookup
         mbentry_t *mbentry = NULL;
         int r = mboxlist_lookup(val, &mbentry, NULL);
         if (r || !mbentry) return NULL;
-        strarray_set(backdoor->altnames, foldernum, mbentry->name);
+        strarray_set(backdoor->altrep, foldernum, mbentry->name);
         mboxlist_entry_free(&mbentry);
-        res = strarray_nth(backdoor->altnames, foldernum);
+        res = strarray_nth(backdoor->altrep, foldernum);
     }
     return res;
 }
@@ -524,8 +524,8 @@ static void _conv_remove(struct conversations_state *state)
                 strarray_free(cur->s.counted_flags);
             if (cur->s.folders)
                 strarray_free(cur->s.folders);
-            if (cur->s.altnames)
-                strarray_free(cur->s.altnames);
+            if (cur->s.altrep)
+                strarray_free(cur->s.altrep);
             if (cur->local_namespacelock)
                 mboxname_release(&cur->local_namespacelock);
             free(cur);

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -289,7 +289,8 @@ EXPORTED const char *conversations_folder_mboxname(const struct conversations_st
                                                    int foldernum)
 {
     const char *val = strarray_nth(state->folders, foldernum);
-    if (!strcmpsafe(val, "-")) return NULL;  // tombstone
+    if (!val) return NULL; // missing?  Weird - we've requested past the end of the list
+    if (!strcmp(val, "-")) return NULL;  // tombstone
 
     if (state->folders_byname)
         return val;
@@ -299,7 +300,6 @@ EXPORTED const char *conversations_folder_mboxname(const struct conversations_st
     if (!backdoor->altrep) backdoor->altrep = strarray_new();
     const char *res = strarray_nth(backdoor->altrep, foldernum);
     if (!res) {
-        if (!val) return NULL;
         // cache lookup
         mbentry_t *mbentry = NULL;
         int r = mboxlist_lookup_by_uniqueid(val, &mbentry, NULL);
@@ -315,7 +315,8 @@ EXPORTED const char *conversations_folder_uniqueid(const struct conversations_st
                                                    int foldernum)
 {
     const char *val = strarray_nth(state->folders, foldernum);
-    if (!strcmpsafe(val, "-")) return NULL;  // tombstone
+    if (!val) return NULL; // missing?  Weird - we've requested past the end of the list
+    if (!strcmp(val, "-")) return NULL;  // tombstone
 
     if (!state->folders_byname)
         return val;
@@ -325,7 +326,6 @@ EXPORTED const char *conversations_folder_uniqueid(const struct conversations_st
     if (!backdoor->altrep) backdoor->altrep = strarray_new();
     const char *res = strarray_nth(backdoor->altrep, foldernum);
     if (!res) {
-        if (!val) return NULL;
         // cache lookup
         mbentry_t *mbentry = NULL;
         int r = mboxlist_lookup(val, &mbentry, NULL);

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -97,7 +97,7 @@ struct conversations_state {
     char *annotmboxname;
     strarray_t *counted_flags;
     strarray_t *folders;
-    strarray_t *altnames;  // cache the alternative mboxname or uniqueid
+    strarray_t *altrep;  // cache the alternative mboxname or uniqueid
     hash_table folderstatus;
     struct conv_quota quota;
     int trashfolder;

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -97,6 +97,7 @@ struct conversations_state {
     char *annotmboxname;
     strarray_t *counted_flags;
     strarray_t *folders;
+    strarray_t *altnames;  // cache the alternative mboxname or uniqueid
     hash_table folderstatus;
     struct conv_quota quota;
     int trashfolder;
@@ -139,8 +140,8 @@ struct conv_folder {
 #define CONV_GUIDREC_BYNAME_VERSION 0x1   // last folders byname version
 
 struct conv_guidrec {
+    const struct conversations_state *cstate;  // this conversationsdb!
     const char      *guidrep; // [MESSAGE_GUID_SIZE*2], hex-encoded
-    const char      *mailbox;       // if version >= 2 mboxid, else mboxname
     int             foldernum;
     uint32_t        uid;
     const char      *part;
@@ -230,8 +231,10 @@ extern struct conversations_state *conversations_get_user(const char *username);
 extern struct conversations_state *conversations_get_mbox(const char *mboxname);
 
 extern int conversations_num_folders(struct conversations_state *state);
-extern const char* conversations_folder_name(struct conversations_state *state,
-                                             int foldernum);
+extern const char* conversations_folder_mboxname(const struct conversations_state *state,
+                                                 int foldernum);
+extern const char* conversations_folder_uniqueid(const struct conversations_state *state,
+                                                 int foldernum);
 extern int conversation_folder_number(struct conversations_state *state,
                                       const char *name,
                                       int create_flag);
@@ -253,9 +256,6 @@ extern conv_folder_t *conversation_get_folder(conversation_t *conv,
 extern void conversation_normalise_subject(struct buf *);
 
 /* G record */
-#define conversations_guid_mbox_cmp(guidrec, m) \
-    strcmp(guidrec->mailbox,                       \
-           guidrec->version > CONV_GUIDREC_BYNAME_VERSION ? mailbox_uniqueid(m) : mailbox_name(m))
 extern int conversations_guid_exists(struct conversations_state *state,
                                      const char *guidrep);
 extern int conversations_guid_foreach(struct conversations_state *state,
@@ -269,6 +269,19 @@ extern int conversations_iterate_searchset(struct conversations_state *state,
 extern conversation_id_t conversations_guid_cid_lookup(struct conversations_state *state,
                                                        const char *guidrep);
 
+/* lookup the matching name or uniqueid */
+#define conv_guidrec_mboxname(rec) conversations_folder_mboxname((rec)->cstate, (rec)->foldernum)
+#define conv_guidrec_uniqueid(rec) conversations_folder_uniqueid((rec)->cstate, (rec)->foldernum)
+#define conv_guidrec_mbentry(rec, mbentryp) ( \
+  ((rec)->version > CONV_GUIDREC_BYNAME_VERSION) ? \
+   mboxlist_lookup_by_uniqueid(conv_guidrec_uniqueid(rec), mbentryp, NULL) : \
+   mboxlist_lookup(conv_guidrec_mboxname(rec), mbentryp, NULL) \
+ )
+#define conv_guidrec_mboxcmp(rec, mbox) ( \
+  ((rec)->version > CONV_GUIDREC_BYNAME_VERSION) ? \
+   strcmpsafe(conv_guidrec_uniqueid(rec), (mbox)->uniqueid) : \
+   strcmpsafe(conv_guidrec_mboxname(rec), (mbox)->name) \
+ )
 /* F record items */
 extern int conversation_getstatus(struct conversations_state *state,
                                   const char *mailbox,

--- a/imap/index.c
+++ b/imap/index.c
@@ -3978,7 +3978,7 @@ static int fetch_mailbox_cb(const conv_guidrec_t *rec, void *rock)
     }
 
     /* make sure we have appropriate rights */
-    r = mboxlist_lookup_by_guidrec(rec, &mbentry, NULL);
+    r = conv_guidrec_mbentry(rec, &mbentry);
     if (r) goto done;
     myrights = cyrus_acl_myrights(fmb_rock->state->authstate, mbentry->acl);
     if ((myrights & needrights) != needrights)

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1167,9 +1167,9 @@ static int findblob_cb(const conv_guidrec_t *rec, void *rock)
         if (rec->part) return 0;
     }
 
-    r = mboxlist_lookup_by_guidrec(rec, &mbentry, NULL);
+    r = conv_guidrec_mbentry(rec, &mbentry);
     if (r) {
-        syslog(LOG_ERR, "jmap_findblob: no mbentry for %s", rec->mailbox);
+        syslog(LOG_ERR, "jmap_findblob: no mbentry for %s", conv_guidrec_mboxname(rec));
         return r;
     }
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -381,12 +381,14 @@ static int getblob_cb(const conv_guidrec_t* rec, void* vrock)
 {
     struct getblob_cb_rock *rock = vrock;
 
+    const char *uniqueid = conv_guidrec_uniqueid(rec);
+    if (!uniqueid) return 0;
+
     struct getblob_rec *getblob = xzmalloc(sizeof(struct getblob_rec));
     getblob->blob_id = rock->blob_id;
     getblob->uid = rec->uid;
     getblob->part = xstrdupnull(rec->part);
 
-    const char *uniqueid = conv_guidrec_uniqueid(rec);
     ptrarray_t *getblobs = hash_lookup(uniqueid, rock->getblobs_by_uniqueid);
     if (!getblobs) {
         getblobs = ptrarray_new();

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -374,7 +374,7 @@ struct getblob_rec {
 struct getblob_cb_rock {
     jmap_req_t *req;
     const char *blob_id;
-    hash_table *getblobs_by_mailbox;
+    hash_table *getblobs_by_uniqueid;
 };
 
 static int getblob_cb(const conv_guidrec_t* rec, void* vrock)
@@ -386,10 +386,11 @@ static int getblob_cb(const conv_guidrec_t* rec, void* vrock)
     getblob->uid = rec->uid;
     getblob->part = xstrdupnull(rec->part);
 
-    ptrarray_t *getblobs = hash_lookup(rec->mailbox, rock->getblobs_by_mailbox);
+    const char *uniqueid = conv_guidrec_uniqueid(rec);
+    ptrarray_t *getblobs = hash_lookup(uniqueid, rock->getblobs_by_uniqueid);
     if (!getblobs) {
         getblobs = ptrarray_new();
-        hash_insert(rec->mailbox, getblobs, rock->getblobs_by_mailbox);
+        hash_insert(uniqueid, getblobs, rock->getblobs_by_uniqueid);
     }
     ptrarray_append(getblobs, getblob);
 
@@ -432,12 +433,12 @@ static int jmap_blob_get(jmap_req_t *req)
     }
 
     /* Sort blob lookups by mailbox */
-    hash_table getblobs_by_mailbox = HASH_TABLE_INITIALIZER;
-    construct_hash_table(&getblobs_by_mailbox, 128, 0);
+    hash_table getblobs_by_uniqueid = HASH_TABLE_INITIALIZER;
+    construct_hash_table(&getblobs_by_uniqueid, 128, 0);
     json_array_foreach(get.ids, i, jval) {
         const char *blob_id = json_string_value(jval);
         if (*blob_id == 'G') {
-            struct getblob_cb_rock rock = { req, blob_id, &getblobs_by_mailbox };
+            struct getblob_cb_rock rock = { req, blob_id, &getblobs_by_uniqueid };
             int r = conversations_guid_foreach(req->cstate, blob_id + 1, getblob_cb, &rock);
             if (r) {
                 syslog(LOG_ERR, "jmap_blob_get: can't lookup guid %s: %s",
@@ -448,18 +449,13 @@ static int jmap_blob_get(jmap_req_t *req)
 
     /* Lookup blobs by mailbox */
     json_t *found = json_object();
-    hash_iter *iter = hash_table_iter(&getblobs_by_mailbox);
+    hash_iter *iter = hash_table_iter(&getblobs_by_uniqueid);
     while (hash_iter_next(iter)) {
-        const char *mailbox = hash_iter_key(iter);
+        const char *uniqueid = hash_iter_key(iter);
         ptrarray_t *getblobs = hash_iter_val(iter);
         struct mailbox *mbox = NULL;
-        mbentry_t *mbentry = NULL;
+        const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, uniqueid);
         int r = 0;
-
-        if (req->cstate->folders_byname)
-            jmap_mboxlist_lookup(mailbox, &mbentry, NULL);
-        else
-            mbentry = jmap_mbentry_by_uniqueid_copy(req, mailbox);
 
         /* Open mailbox */
         if (!jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
@@ -472,7 +468,6 @@ static int jmap_blob_get(jmap_req_t *req)
                        mbentry->name, error_message(r));
             }
         }
-        mboxlist_entry_free(&mbentry);
         if (r) continue;
 
         int j;
@@ -544,7 +539,7 @@ static int jmap_blob_get(jmap_req_t *req)
         ptrarray_free(getblobs);
     }
     hash_iter_free(&iter);
-    free_hash_table(&getblobs_by_mailbox, NULL);
+    free_hash_table(&getblobs_by_uniqueid, NULL);
 
     /* Report found blobs */
     if (json_object_size(found)) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3421,6 +3421,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         uint32_t num;
         for (num = 0; num < numfolders; num++) {
             const char *mboxname = conversations_folder_mboxname(req->cstate, num);
+            if (!mboxname) continue;
             if (jmap_hasrights(req, mboxname, ACL_READ|ACL_LOOKUP)) {
                 bv_set(&gsq->readable_folders, num);
             }
@@ -3430,12 +3431,13 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         // all user-owned mailboxes are readable
         bv_setall(&gsq->readable_folders);
     }
+
     // filter all folders that aren't regular mailboxes
     uint32_t num;
     for (num = 0; num < numfolders; num++) {
         const char *mboxname = conversations_folder_mboxname(req->cstate, num);
         mbentry_t *mbentry = NULL;
-        if (mboxname_isnondeliverymailbox(mboxname, 0) ||
+        if (!mboxname || mboxname_isnondeliverymailbox(mboxname, 0) ||
             mboxlist_lookup_allow_all(mboxname, &mbentry, NULL) ||
             mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL) {
             bv_clear(&gsq->readable_folders, num);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3450,6 +3450,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         uint32_t num;
         for (num = 0; num < numfolders; num++) {
             const char *mboxname = conversations_folder_mboxname(req->cstate, num);
+            if (!mboxname) continue;
             hash_insert(mboxname, (void*)((uintptr_t)num+1), &foldernum_by_mboxname);
         }
 

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -2818,7 +2818,7 @@ static int in_otherfolder_cb(const conv_guidrec_t *rec, void *rock)
 
     if (rec->version < 1) {
         syslog(LOG_ERR, "%s:%s: outdated guid record in mailbox %s",
-                __FILE__, __func__, rec->mailbox);
+                __FILE__, __func__, conv_guidrec_mboxname(rec));
         return IMAP_INTERNAL;
     }
 

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -102,11 +102,6 @@
 
 #define HOSTNAME_SIZE 512
 
-#define mboxlist_lookup_by_guidrec(guidrec, mbentry, tid)       \
-    (guidrec->version > CONV_GUIDREC_BYNAME_VERSION ?           \
-     mboxlist_lookup_by_uniqueid(rec->mailbox, mbentry, tid) :  \
-     mboxlist_lookup(rec->mailbox, mbentry, tid))
-
 /* each mailbox has the following data */
 struct mboxlist_entry {
     char *name;

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -1779,30 +1779,12 @@ static int xapian_run_guid_cb(const conv_guidrec_t *rec, void *vrock)
     xapian_builder_t *bb = rock->bb;
 
     if (!(bb->opts & SEARCH_MULTIPLE)) {
-        if (conversations_guid_mbox_cmp(rec, bb->mailbox))
+        if (conv_guidrec_mboxcmp(rec, bb->mailbox))
             return 0;
     }
 
-    const char *mboxname;
-    if (rec->version > CONV_GUIDREC_BYNAME_VERSION) {
-        mboxname = strarray_nth(&rock->mboxname_by_foldernum, rec->foldernum);
-        if (!mboxname) {
-            mbentry_t *mbentry = NULL;
-            int r = mboxlist_lookup_by_guidrec(rec, &mbentry, NULL);
-            if (r) {
-                xsyslog(LOG_ERR, "failed to lookup mbentry", "uniqueid=<%s>",
-                        rec->mailbox);
-                return r;
-            }
-            char *mymboxname = xstrdup(mbentry->name);
-            mboxlist_entry_free(&mbentry);
-            strarray_setm(&rock->mboxname_by_foldernum, rec->foldernum, mymboxname);
-            mboxname = mymboxname;
-        }
-    }
-    else mboxname = rec->mailbox;
-
-    return bb->proc(mboxname, 0, rec->uid, rec->part, bb->rock);
+    // XXX: update this API to work with uniqueids?
+    return bb->proc(conv_guidrec_mboxname(rec), 0, rec->uid, rec->part, bb->rock);
 }
 
 
@@ -2781,24 +2763,27 @@ static int is_indexed_cb(const conv_guidrec_t *rec, void *rock)
 
     if (doctype == XAPIAN_WRAP_DOCTYPE_MSG && rec->part) return 0;
 
-    /* Is this a part in the message we are just indexing? */
-    if (doctype == XAPIAN_WRAP_DOCTYPE_PART && rec->uid == tr->super.uid &&
-         !strcmp(rec->mailbox, (rec->version > CONV_GUIDREC_BYNAME_VERSION) ?
-                 mailbox_uniqueid(tr->super.mailbox) : mailbox_name(tr->super.mailbox))) {
-        return 0;
-    }
+    int same_mailbox = !conv_guidrec_mboxcmp(rec, tr->super.mailbox);
 
-    /* Is this GUID record in the mailbox we are currently indexing? */
-    if (!conversations_guid_mbox_cmp(rec, tr->super.mailbox)) {
+    if (same_mailbox) {
+        /* Is this a part in the message we are just indexing? */
+        if (doctype == XAPIAN_WRAP_DOCTYPE_PART && rec->uid == tr->super.uid)
+            return 0;
+
+        /* Is it in our known indexed list? */
         if (seqset_ismember(tr->indexed, rec->uid) ||
             seqset_ismember(tr->oldindexed, rec->uid)) {
             return CYRUSDB_DONE;
         }
+
+        /* otherwise clearly not */
         return 0;
     }
 
+    const char *uniqueid = conv_guidrec_uniqueid(rec);
+
     /* Is this GUID record in an already cached sequence set? */
-    seqset_t *seq = hash_lookup(rec->mailbox, &tr->cached_seqs);
+    seqset_t *seq = hash_lookup(uniqueid, &tr->cached_seqs);
     if (seq) {
         return seqset_ismember(seq, rec->uid) ? CYRUSDB_DONE : 0;
     }
@@ -2807,37 +2792,16 @@ static int is_indexed_cb(const conv_guidrec_t *rec, void *rock)
     seq = seqset_init(0, SEQ_MERGE);
     int r = 0;
 
-    const char *mboxuniqueid;
-    mbentry_t *mbentry = NULL;
-    if (rec->version > CONV_GUIDREC_BYNAME_VERSION) {
-        mboxuniqueid = rec->mailbox;
-    }
-    else {
-        r = mboxlist_lookup(rec->mailbox, &mbentry, NULL);
-        if (r) {
-            syslog(LOG_ERR, "is_indexed_cb: mboxlist_lookup %s failed: %s",
-                    rec->mailbox, error_message(r));
-            goto out;
-        }
-        mboxuniqueid = mbentry->uniqueid;
-    }
-
     r = read_indexed(mbname_userid(tr->super.mbname),
             tr->activedirs, tr->activetiers,
-            mboxuniqueid, seq, /*do_cache*/1, tr->super.verbose);
-    if (mbentry) mboxlist_entry_free(&mbentry);
+            uniqueid, seq, /*do_cache*/1, tr->super.verbose);
     if (r) {
         syslog(LOG_ERR, "is_indexed_cb: read_indexed %s failed: %s",
-                rec->mailbox, error_message(r));
-        goto out;
-    }
-
-out:
-    if (r) {
+               uniqueid, error_message(r));
         seqset_free(&seq);
         return 0;
     }
-    hash_insert(rec->mailbox, seq, &tr->cached_seqs);
+    hash_insert(uniqueid, seq, &tr->cached_seqs);
     return seqset_ismember(seq, rec->uid) ? CYRUSDB_DONE : 0;
 }
 

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -1783,8 +1783,11 @@ static int xapian_run_guid_cb(const conv_guidrec_t *rec, void *vrock)
             return 0;
     }
 
+    const char *mboxname = conv_guidrec_mboxname(rec);
+    if (!mboxname) return 0;
+
     // XXX: update this API to work with uniqueids?
-    return bb->proc(conv_guidrec_mboxname(rec), 0, rec->uid, rec->part, bb->rock);
+    return bb->proc(mboxname, 0, rec->uid, rec->part, bb->rock);
 }
 
 
@@ -2781,6 +2784,7 @@ static int is_indexed_cb(const conv_guidrec_t *rec, void *rock)
     }
 
     const char *uniqueid = conv_guidrec_uniqueid(rec);
+    if (!uniqueid) return 0;
 
     /* Is this GUID record in an already cached sequence set? */
     seqset_t *seq = hash_lookup(uniqueid, &tr->cached_seqs);


### PR DESCRIPTION
This seems like a much nicer central cache, and it means we can always get the name or the uniqueid and we don't need to prework if not asked for it.