### PR TITLE
jmap_mail: fix 'hasKeyword:$seen' queries for shared mailboxes

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1414,13 +1414,16 @@ static void _email_search_type(search_expr_t *parent, const char *s, strarray_t 
     strarray_fini(&types);
 }
 
-static void _email_search_keyword(search_expr_t *parent, const char *keyword, strarray_t *perf_filters)
+static void _email_search_keyword(search_expr_t *parent,
+                                  const char *keyword,
+                                  const char *userid,
+                                  strarray_t *perf_filters)
 {
     search_expr_t *e;
     if (!strcasecmp(keyword, "$Seen")) {
         e = search_expr_new(parent, SEOP_MATCH);
-        e->attr = search_attr_find("indexflags");
-        e->value.u = MESSAGE_SEEN;
+        e->attr = search_attr_find("seen");
+        e->value.s = xstrdup(userid);
     }
     else if (!strcasecmp(keyword, "$Draft")) {
         e = search_expr_new(parent, SEOP_MATCH);
@@ -1914,11 +1917,11 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
         }
 
         if (JNOTNULL((val = json_object_get(filter, "hasKeyword")))) {
-            _email_search_keyword(this, json_string_value(val), perf_filters);
+            _email_search_keyword(this, json_string_value(val), req->userid, perf_filters);
         }
         if (JNOTNULL((val = json_object_get(filter, "notKeyword")))) {
             e = search_expr_new(this, SEOP_NOT);
-            _email_search_keyword(e, json_string_value(val), perf_filters);
+            _email_search_keyword(e, json_string_value(val), req->userid, perf_filters);
         }
 
         if (JNOTNULL((val = json_object_get(filter, "maxSize")))) {


### PR DESCRIPTION
This patch adds a new `seen` search attribute which correctly determines if to read the `\Seen` flag from the index record or seen database. The Email/query `hasKeyword:$seen` filter is updated to make use of this new attribute.

The implementation is somewhat lacking in that it opens the seen database for each inspected mailbox. This unnecessarily incurs CRC check costs. However, the current search attribute design does not allow for stateful attributes across a whole query. We might need to come up with such, if the CRC checks are proofing to be to costly. 

Tested in https://github.com/cyrusimap/cassandane/pull/131