### PR TITLE
UUID legacy paths

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -885,9 +885,7 @@ static int findstage_cb(const conv_guidrec_t *rec, void *vrock)
 
     if (!strcmp(rock->partition, mbentry->partition)) {
         struct stat sbuf;
-        const char *msgpath = mboxname_datapath(mbentry->partition,
-                                                mbentry->name,
-                                                mbentry->uniqueid, rec->uid);
+        const char *msgpath = mbentry_datapath(mbentry, rec->uid);
         if (msgpath && !stat(msgpath, &sbuf)) {
             /* link the first stage part to the existing message file */
             r = cyrus_copyfile(msgpath, rock->stagefile, 0/*flags*/);

--- a/imap/cyr_ls.c
+++ b/imap/cyr_ls.c
@@ -229,14 +229,10 @@ static int list_cb(struct findall_data *data, void *rock)
     const char *path;
 
     if (lrock->opts->meta) {
-        path = mboxname_metapath(data->mbentry->partition,
-                                 data->mbentry->name,
-                                 data->mbentry->uniqueid, 0, 0);
+        path = mbentry_metapath(data->mbentry, 0, 0);
     }
     else {
-        path = mboxname_datapath(data->mbentry->partition,
-                                 data->mbentry->name,
-                                 data->mbentry->uniqueid, 0);
+        path = mbentry_datapath(data->mbentry, 0);
     }
 
     printf("%s", !(lrock->count++ % lrock->opts->columns) ? "\n" : "    ");

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7754,12 +7754,6 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location)
              mboxname_isusermailbox(newmailboxname, 1) &&
              strcmp(oldmailboxname, newmailboxname) && /* different user */
              imapd_userisadmin) {
-        if (mbentry->mbtype & MBTYPE_LEGACY_DIRS) {
-            /* don't allow rename of a user using legacy (by name) dirs */
-            prot_printf(imapd_out, "%s NO %s\r\n",
-                        tag, error_message(IMAP_USER_LEGACY_DIRS));
-            goto done;
-        }
 
         rename_user = 1;
     }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1050,6 +1050,12 @@ static int mailbox_open_advanced(const char *name,
         goto done;
     }
 
+    if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
+        mboxlist_entry_free(&mbentry);
+        r = IMAP_MAILBOX_NONEXISTENT;
+        goto done;
+    }
+
     if (!mbentry->partition) {
         mboxlist_entry_free(&mbentry);
         r = IMAP_MAILBOX_NONEXISTENT;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6359,7 +6359,7 @@ static int find_files(struct mailbox *mailbox, struct found_uids *files,
     int r;
     int i;
 
-    strarray_add(&paths, mailbox_datapath(mailbox, 0));
+    strarray_add(&paths, mailbox_spool_fname(mailbox, 0));
 
 #if defined ENABLE_OBJECTSTORE
     if (config_getswitch(IMAPOPT_OBJECT_STORAGE_ENABLED))
@@ -6373,7 +6373,7 @@ static int find_files(struct mailbox *mailbox, struct found_uids *files,
     }
     else
 #endif
-        strarray_add(&paths, mboxname_archivepath(mailbox->part, mailbox->name, mailbox->uniqueid, 0));
+        strarray_add(&paths, mailbox_archive_fname(mailbox, 0));
 
     for (i = 0; i < paths.count; i++) {
         const char *dirpath = strarray_nth(&paths, i);
@@ -6954,8 +6954,6 @@ static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int
     struct index_record record;
     struct stat sbuf;
     int make_changes = flags & RECONSTRUCT_MAKE_CHANGES;
-    const char *uniqueid =
-        !(mailbox->mbtype & MBTYPE_LEGACY_DIRS) ? mailbox->uniqueid : NULL;
 
     memset(&record, 0, sizeof(struct index_record));
 
@@ -6966,9 +6964,9 @@ static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int
 #endif
 
     if (isarchive && !object_storage_enabled)
-        fname = mboxname_archivepath(mailbox->part, mailbox->name, uniqueid, uid);
+        fname = mailbox_archive_fname(mailbox, uid);
     else
-        fname = mboxname_datapath(mailbox->part, mailbox->name, uniqueid, uid);
+        fname = mailbox_spool_fname(mailbox, uid);
 
 #if defined ENABLE_OBJECTSTORE
     if (object_storage_enabled)
@@ -6993,7 +6991,10 @@ static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int
     if (!uid) {
         /* filthy hack - copy the path to '1.' and replace 1 with 0 */
         char *hack;
-        fname = mboxname_datapath(mailbox->part, mailbox->name, uniqueid, 1);
+        if (isarchive && !object_storage_enabled)
+            fname = mailbox_archive_fname(mailbox, 1);
+        else
+            fname = mailbox_spool_fname(mailbox, 1);
         hack = (char *)fname;
         hack[strlen(fname)-2] = '0';
     }
@@ -7370,8 +7371,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
         while (files.pos < files.nused && files.found[files.pos].uid == record.uid) {
             if (have_file) {
                 /* we can just unlink this one, already processed one copy */
-                const char *fname = mboxname_archivepath(mailbox->part, mailbox->name,
-                                                         mailbox->uniqueid, record.uid);
+                const char *fname = mailbox_archive_fname(mailbox, record.uid);
                 printf("Removing duplicate archive file %s\n", fname);
                 unlink(fname);
             }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1558,6 +1558,7 @@ EXPORTED int mboxlist_update_intermediaries(const char *frommboxname,
         }
 
         mbentry_t *newmbentry = mboxlist_entry_create();
+        newmbentry->name = xstrdupnull(mboxname);
         newmbentry->uniqueid = xstrdupnull(makeuuid());
         newmbentry->partition = xstrdupnull(partition);
         newmbentry->createdmodseq = modseq;
@@ -1569,13 +1570,11 @@ EXPORTED int mboxlist_update_intermediaries(const char *frommboxname,
                "mboxlist: creating intermediate with children: %s (%s)",
                mboxname, newmbentry->uniqueid);
         r = mboxlist_update_entry(mboxname, newmbentry, NULL);
-        if (!r && !(newmbentry->mbtype & MBTYPE_LEGACY_DIRS)) {
+        if (!r) {
             /* create [meta]data directories for mbpath-by-id */
-            const char *path = mboxname_datapath(newmbentry->partition, mboxname,
-                                                 newmbentry->uniqueid, 1);
+            const char *path = mbentry_datapath(newmbentry, 1);
             if (path) cyrus_mkdir(path, 0755);
-            path = mboxname_metapath(newmbentry->partition, mboxname,
-                                     newmbentry->uniqueid, META_HEADER, 0);
+            path = mbentry_metapath(newmbentry, META_HEADER, 0);
             if (path) cyrus_mkdir(path, 0755);
         }
         mboxlist_entry_free(&newmbentry);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2613,7 +2613,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
          * codepaths: INBOX -> INBOX.foo, user rename, regular rename
          * and of course this one, partition move */
         newpartition = xstrdup(partition);
-        r = mailbox_copy_files(oldmailbox, newpartition, newname, oldmailbox->uniqueid);
+        r = mailbox_copy_files(oldmailbox, newpartition, newname, oldmailbox->mbtype & MBTYPE_LEGACY_DIRS ? NULL : oldmailbox->uniqueid);
         if (r) goto done;
         newmbentry = mboxlist_entry_create();
         newmbentry->mbtype = oldmailbox->mbtype;


### PR DESCRIPTION
This fixed MOST of the legacy paths handling.

There's still a serious bug with user_deletedata, where it doesn't know the correct paths any more because we've already nuked the mailboxes.db entry.  In general, we're going to have to change all the underlying APIs so we can get a clean userid -> path mapping cheaply and reliably.  Possibly even store the user's uniqueid into every mailbox header file.