### PR TITLE
Fix --disable-sieve --enable-jmap build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1082,7 +1082,7 @@ imap_libcyrus_imap_la_SOURCES = \
 	imap/sequence.c \
 	imap/sequence.h \
 	imap/setproctitle.c \
-        imap/sievedir.c \
+	imap/sievedir.c \
 	imap/sievedir.h \
 	imap/spool.c \
 	imap/spool.h \

--- a/imap/jmap_vacation.c
+++ b/imap/jmap_vacation.c
@@ -56,11 +56,14 @@
 #include "http_jmap.h"
 #include "json_support.h"
 #include "map.h"
-#include "sieve/sieve_interface.h"
-#include "sieve/bc_parse.h"
 #include "sync_support.h"
 #include "user.h"
 #include "util.h"
+
+#ifdef USE_SIEVE
+#include "sieve/sieve_interface.h"
+#include "sieve/bc_parse.h"
+#endif
 
 static int jmap_vacation_get(jmap_req_t *req);
 static int jmap_vacation_set(jmap_req_t *req);

--- a/imap/sievedir.c
+++ b/imap/sievedir.c
@@ -58,10 +58,13 @@
 #include "assert.h"
 #include "map.h"
 #include "sievedir.h"
-#include "sieve/bc_parse.h"
-#include "sieve/sieve_interface.h"
 #include "util.h"
 #include "xstrlcpy.h"
+
+#ifdef USE_SIEVE
+#include "sieve/bc_parse.h"
+#include "sieve/sieve_interface.h"
+#endif
 
 EXPORTED int sievedir_foreach(const char *sievedir, unsigned flags,
                               int (*func)(const char *sievedir,


### PR DESCRIPTION
Make would fail in imap/jmap_vacation.c and imap/sievedir.c when configured with --disable-sieve and --enable-jmap, because they were pulling in sieve headers that would try to include sieve_err.h, which hadn't been generated.

It looks like both of these source files are already conditionalised to handle sieve being unavailable, so I've just done the same for the sieve header includes.

Needed to update some Cassandane tests that would crash out during setup when timsieved didn't exist, those fixes are already merged.  Seems to pass everything else.

Fixes #3527 