### PR TITLE
mbpath: free string returned by user_hash_meta after use

### DIFF
--- a/imap/mbpath.c
+++ b/imap/mbpath.c
@@ -156,13 +156,33 @@ static void print_json(const mbname_t *mbname, const mbentry_t *mbentry)
     if (userid) {
         // user paths
         json_t *juser = json_object();
-        json_object_set_new(juser, "conversations", json_string(user_hash_meta(userid, "conversations")));
-        json_object_set_new(juser, "counters", json_string(user_hash_meta(userid, "counters")));
-        json_object_set_new(juser, "dav", json_string(user_hash_meta(userid, "dav")));
+        char *val; // jansson has no API to transfer string ownership
+
+        val = user_hash_meta(userid, "conversations");
+        json_object_set_new(juser, "conversations", json_string(val));
+        free(val);
+
+        val = user_hash_meta(userid, "counters");
+        json_object_set_new(juser, "counters", json_string(val));
+        free(val);
+
+        val = user_hash_meta(userid, "dav");
+        json_object_set_new(juser, "dav", json_string(val));
+        free(val);
+
         json_object_set_new(juser, "sieve", json_string(user_sieve_path(userid)));
-        json_object_set_new(juser, "seen", json_string(user_hash_meta(userid, "seen")));
-        json_object_set_new(juser, "sub", json_string(user_hash_meta(userid, "sub")));
-        json_object_set_new(juser, "xapianactive", json_string(user_hash_meta(userid, "xapianactive")));
+
+        val = user_hash_meta(userid, "seen");
+        json_object_set_new(juser, "seen", json_string(val));
+        free(val);
+
+        val = user_hash_meta(userid, "sub");
+        json_object_set_new(juser, "sub", json_string(val));
+        free(val);
+
+        val = user_hash_meta(userid, "xapianactive");
+        json_object_set_new(juser, "xapianactive", json_string(val));
+        free(val);
 
         json_object_set_new(jres, "user", juser);
 


### PR DESCRIPTION
Fixes a memory leak in mbpath. In a perfect world, jansson would provide us with an API to transfer ownership of string values to their JSON type. But [this section](https://github.com/akheron/jansson/blob/master/src/value.c#L747) in the upstream source suggests we won't get that. Defining our own `json_stringm` in json_support.h would allow us to fake this API, but this might mislead callers to assume no allocations are made.