### PR TITLE
mboxlist: allow RACL entries where 'l' permission exists

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -922,8 +922,8 @@ static int user_can_read(const strarray_t *aclbits, const char *user)
     int i;
     if (!aclbits) return 0;
     for (i = 0; i+1 < strarray_size(aclbits); i+=2) {
-        // skip ACLs without read bit
-        if (!strchr(strarray_nth(aclbits, i+1), 'r')) continue;
+        // skip ACLs with neither read nor lookup bit
+        if (!strpbrk(strarray_nth(aclbits, i+1), "lr")) continue;
         if (!strcmp(strarray_nth(aclbits, i), user)) return 1;
     }
     return 0;
@@ -967,7 +967,7 @@ static int mboxlist_update_racl(const char *dbname, const mbentry_t *oldmbentry,
     if (oldusers) {
         for (i = 0; i+1 < strarray_size(oldusers); i+=2) {
             const char *acluser = strarray_nth(oldusers, i);
-            if (!strchr(strarray_nth(oldusers, i+1), 'r')) continue;
+            if (!strpbrk(strarray_nth(oldusers, i+1), "lr")) continue;
             if (!strcmpsafe(userid, acluser)) continue;
             if (strarray_find(admins, acluser, 0) >= 0) continue;
             if (user_can_read(newusers, acluser)) continue;
@@ -981,7 +981,7 @@ static int mboxlist_update_racl(const char *dbname, const mbentry_t *oldmbentry,
     if (newusers) {
         for (i = 0; i+1 < strarray_size(newusers); i+=2) {
             const char *acluser = strarray_nth(newusers, i);
-            if (!strchr(strarray_nth(newusers, i+1), 'r')) continue;
+            if (!strpbrk(strarray_nth(newusers, i+1), "lr")) continue;
             if (!strcmpsafe(userid, acluser)) continue;
             if (strarray_find(admins, acluser, 0) >= 0) continue;
             if (user_can_read(oldusers, acluser)) continue;


### PR DESCRIPTION
Since ff1442271ae144fb84fcf58f0e258f54d8c11164 we have only stored RACL entries where the ACL contained the 'r' permission.  IMAP LIST needs to be able to return mailboxes where the user has 'l' but not 'r', but when reverseacls is enabled, it can't see them at all because there's no RACL entry.

This fix addresses the issue by creating RACL entries if either the 'r' or 'l' permission is present.

Added a lot of tests for this specific case: https://github.com/cyrusimap/cassandane/compare/master...elliefm:v34/3528-list-lookup-only

It doesn't seem to break anything else, by which I mean, none of our existing tests break with this change.  But if you can think of something that might break with this, we should add a test for it!

I thought RACL and RUNQ were versioned, and thought I might need to bump the RACL version as part of this, but it looks like that was reverted by 3d0abf7e0c.

Fixes #3528, needs to be picked back to 3.4 once merged.