### PR TITLE
caldav_sched: pass the acting userid through to the imip sender

### DIFF
--- a/imap/http_caldav_sched.h
+++ b/imap/http_caldav_sched.h
@@ -169,9 +169,9 @@ extern int isched_send(struct caldav_sched_param *sparam, const char *recipient,
 
 extern int sched_busytime_query(struct transaction_t *txn,
                                 struct mime_type_t *mime, icalcomponent *comp);
-extern void sched_request(const char *onuserid, const strarray_t *schedule_addresses, const char *organizer,
+extern void sched_request(const char *userid, const strarray_t *schedule_addresses, const char *organizer,
                           icalcomponent *oldical, icalcomponent *newical);
-extern void sched_reply(const char *onuserid, const strarray_t *schedule_addresses,
+extern void sched_reply(const char *userid, const strarray_t *schedule_addresses,
                         icalcomponent *oldical, icalcomponent *newical);
 extern void sched_deliver(const char *userid, const char *sender, const char *recipient,
                           void *data, void *rock);

--- a/imap/http_caldav_sched.h
+++ b/imap/http_caldav_sched.h
@@ -173,7 +173,8 @@ extern void sched_request(const char *onuserid, const strarray_t *schedule_addre
                           icalcomponent *oldical, icalcomponent *newical);
 extern void sched_reply(const char *onuserid, const strarray_t *schedule_addresses,
                         icalcomponent *oldical, icalcomponent *newical);
-extern void sched_deliver(const char *sender, const char *recipient, void *data, void *rock);
+extern void sched_deliver(const char *userid, const char *sender, const char *recipient,
+                          void *data, void *rock);
 extern xmlNodePtr xml_add_schedresponse(xmlNodePtr root, xmlNsPtr dav_ns,
                                         xmlChar *recipient, xmlChar *status);
 extern int caladdress_lookup(const char *addr, struct caldav_sched_param *param,

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -565,7 +565,7 @@ static int meth_post_isched(struct transaction_t *txn,
                     sched_param_fini(&sparam);
 
                     if (r) sched_data.status = REQSTAT_NOUSER;
-                    else sched_deliver(httpd_userid, recipient, &sched_data, authstate);
+                    else sched_deliver(httpd_userid, httpd_userid, recipient, &sched_data, authstate);
 
                     xml_add_schedresponse(root, NULL, BAD_CAST recipient,
                                           BAD_CAST sched_data.status);


### PR DESCRIPTION
This came up today with calendar invitations on shared calendars being rejected because they were authenticated as the person creating the request rather than the calendar owner.

Given how calendar requests are created, I think the correct answer is to just authenticate as the calendar owner.  You can only send as them if you have the `8` ACL on their Outbox, but after that the email is coming from the calendar owner for all intents and purposes, so the system should authenticate as them.