### PR TITLE
preload string comparisons that will the same for every message

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -6121,6 +6121,7 @@ MsgData **index_msgdata_load(struct index_state *state,
     struct index_record record;
     struct conversations_state *cstate = NULL;
     conversation_t conv = CONVERSATION_INIT;
+    int *preload = NULL;
 
     if (!n) return NULL;
 
@@ -6131,6 +6132,32 @@ MsgData **index_msgdata_load(struct index_state *state,
 
     if (found_anchor)
         *found_anchor = 0;
+
+    /* set mailbox level states */
+    for (j = 0; sortcrit[j].key; j++); // count how many we need
+    preload = xzmalloc(j * sizeof(int));
+    for (j = 0; sortcrit[j].key; j++) {
+        label = sortcrit[j].key;
+        switch(label) {
+        case SORT_SAVEDATE:
+#ifdef WITH_JMAP
+        case SORT_SNOOZEDUNTIL:
+#endif
+            preload[j] = !strcmpnull(mailbox_uniqueid(mailbox), sortcrit[j].args.mailbox.id);
+            break;
+
+        case SORT_HASCONVFLAG:
+            preload[j] = -1;
+            if (!cstate) cstate = conversations_get_mbox(index_mboxname(state));
+            assert(cstate);
+            if (cstate->counted_flags)
+                preload[j] = strarray_find_case(cstate->counted_flags, sortcrit[j].args.flag.name, 0);
+            break;
+
+        default:
+            break;
+        }
+    }
 
     for (i = 0 ; i < n ; i++) {
         cur = &md[i];
@@ -6248,7 +6275,7 @@ MsgData **index_msgdata_load(struct index_state *state,
                 break;
             }
             case SORT_SAVEDATE:
-                if (!strcmpnull(mailbox_uniqueid(mailbox), sortcrit[j].args.mailbox.id)) {
+                if (preload[j]) {
                     cur->savedate = record.savedate;
                 }
                 else {
@@ -6258,8 +6285,7 @@ MsgData **index_msgdata_load(struct index_state *state,
                 break;
             case SORT_SNOOZEDUNTIL:
 #ifdef WITH_JMAP
-                if ((record.internal_flags & FLAG_INTERNAL_SNOOZED) &&
-                    !strcmpnull(mailbox_uniqueid(mailbox), sortcrit[j].args.mailbox.id)) {
+                if (preload[j] && (record.internal_flags & FLAG_INTERNAL_SNOOZED)) {
                     /* SAVEDATE == snoozed#until */
                     cur->savedate = record.savedate;
 
@@ -6308,10 +6334,7 @@ MsgData **index_msgdata_load(struct index_state *state,
                 break;
             }
             case SORT_HASCONVFLAG: {
-                const char *name = sortcrit[j].args.flag.name;
-                int idx = -1;
-                if (cstate->counted_flags)
-                    idx = strarray_find_case(cstate->counted_flags, name, 0);
+                int idx = preload[j];
                 /* flag exists in the conversation at all */
                 if (idx >= 0 && conv.counts[idx] > 0 && j < 31)
                     cur->hasflag |= (1<<j);
@@ -6335,6 +6358,8 @@ MsgData **index_msgdata_load(struct index_state *state,
         free(tmpenv);
         conversation_fini(&conv);
     }
+
+    free(preload);
 
     return ptrs;
 }

--- a/imap/index.c
+++ b/imap/index.c
@@ -6135,7 +6135,7 @@ MsgData **index_msgdata_load(struct index_state *state,
 
     /* set mailbox level states */
     for (j = 0; sortcrit[j].key; j++); // count how many we need
-    preload = xzmalloc(j * sizeof(int));
+    if (j) preload = xzmalloc(j * sizeof(int));
     for (j = 0; sortcrit[j].key; j++) {
         label = sortcrit[j].key;
         switch(label) {


### PR DESCRIPTION
This speeds up index_msgdata_load for the very common request which the Fastmail UI uses to load every single mailbox!

```
        "sort": [
          {
            "property": "snoozedUntil",
            "isAscending": false,
            "mailboxId": "567d9ea54215e1e9"
          },
          {
            "isAscending": false,
            "property": "receivedAt"
          }
        ],
```

Instead of having to do a strcmp of the mailbox_uniqueid against the parameter for every single record in the mailbox, it's done just once at the top of the loop.

I also picked out the other two cases where we do string comparisons that aren't going to change for every message in the mailbox, because why not!