### PR TITLE
jmap_contact.c: use length of adjusted Apple label for URL property

### DIFF
--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1763,10 +1763,11 @@ static json_t *jmap_contact_from_vcard(const char *userid,
             for (param = entry->params; param; param = param->next) {
                 if (!strcasecmp(param->name, "label")) {
                     label = param->value;
+                    label_len = strlen(label);
                 }
             }
             json_object_set_new(item, "type", json_string("uri"));
-            if (label) json_object_set_new(item, "label", json_string(label));
+            if (label) json_object_set_new(item, "label", json_stringn(label, label_len));
             json_object_set_new(item, "value", json_string(entry->v.value));
             json_array_append_new(online, item);
         }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1631,7 +1631,7 @@ static json_t *jmap_contact_from_vcard(const char *userid,
                 }
                 else if (!strcasecmp(param->name, "label")) {
                     label = param->value;
-                    label_len = strlen(label);
+                    if (label) label_len = strlen(label);
                 }
             }
             json_object_set_new(item, "type", json_string(type));
@@ -1706,7 +1706,7 @@ static json_t *jmap_contact_from_vcard(const char *userid,
                 }
                 else if (!strcasecmp(param->name, "label")) {
                     label = param->value;
-                    label_len = strlen(label);
+                    if (label) label_len = strlen(label);
                 }
             }
             json_object_set_new(item, "type", json_string(type));
@@ -1746,7 +1746,7 @@ static json_t *jmap_contact_from_vcard(const char *userid,
                 }
                 else if (!strcasecmp(param->name, "label")) {
                     label = param->value;
-                    label_len = strlen(label);
+                    if (label) label_len = strlen(label);
                 }
             }
             json_object_set_new(item, "type", json_string(type));
@@ -1763,7 +1763,7 @@ static json_t *jmap_contact_from_vcard(const char *userid,
             for (param = entry->params; param; param = param->next) {
                 if (!strcasecmp(param->name, "label")) {
                     label = param->value;
-                    label_len = strlen(label);
+                    if (label) label_len = strlen(label);
                 }
             }
             json_object_set_new(item, "type", json_string("uri"));


### PR DESCRIPTION
This was missed when adjusting EMAIL, ADR, TEL property labels