### PR TITLE
Lockfixes

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8254,7 +8254,9 @@ static void _email_append(jmap_req_t *req,
 
         /* Convert intermediary mailbox to real mailbox */
         if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
+            struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
             r = mboxlist_promote_intermediary(mbentry->name);
+            mboxname_release(&namespacelock);
             if (r) goto done;
         }
 
@@ -11738,7 +11740,9 @@ static int _email_bulkupdate_open(jmap_req_t *req, struct email_bulkupdate *bulk
             const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mboxrec->mbox_id);
             int r = 0;
             if (mbentry && mbentry->mbtype & MBTYPE_INTERMEDIATE) {
+                struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
                 r = mboxlist_promote_intermediary(mbentry->name);
+                mboxname_release(&namespacelock);
             }
             else if (!mbentry) {
                 r = IMAP_MAILBOX_NONEXISTENT;
@@ -11813,7 +11817,9 @@ static int _email_bulkupdate_open(jmap_req_t *req, struct email_bulkupdate *bulk
             if (mbentry) {
                 int r = 0;
                 if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
+                    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
                     r = mboxlist_promote_intermediary(mbentry->name);
+                    mboxname_release(&namespacelock);
                 }
                 if (!r) jmap_openmbox(req, mbentry->name, &mbox, /*rw*/1);
             }
@@ -13244,7 +13250,9 @@ static void _email_copy(jmap_req_t *req, json_t *copy_email,
         mbentry_t *mbentry = NULL;
         r = jmap_mboxlist_lookup(dst_mboxname, &mbentry, NULL);
         if (!r && (mbentry->mbtype & MBTYPE_INTERMEDIATE)) {
-            r = mboxlist_promote_intermediary(dst_mboxname);
+            struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+            r = mboxlist_promote_intermediary(mbentry->name);
+            mboxname_release(&namespacelock);
         }
         if (!r) {
             struct mailbox *dst_mbox = NULL;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1124,10 +1124,6 @@ EXPORTED int mboxlist_update(const mbentry_t *mbentry, int localonly)
 
     r = mboxlist_update_entry(mbentry->name, mbentry, &tid);
 
-    if (!r)
-        mboxname_setmodseq(mbentry->name, mbentry->foldermodseq, mbentry->mbtype,
-                           MBOXMODSEQ_ISFOLDER);
-
     /* commit the change to mupdate */
     if (!r && !localonly && config_mupdate_server) {
         mupdate_handle *mupdate_h = NULL;
@@ -1164,6 +1160,9 @@ EXPORTED int mboxlist_update(const mbentry_t *mbentry, int localonly)
                 xsyslog(LOG_ERR, "DBERROR: error committing transaction",
                                  "error=<%s>", cyrusdb_strerror(r2));
         }
+        if (!r)
+            mboxname_setmodseq(mbentry->name, mbentry->foldermodseq, mbentry->mbtype,
+                               MBOXMODSEQ_ISFOLDER);
     }
 
     return r;

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -437,7 +437,9 @@ static int find_p(const mbentry_t *mbentry, void *rock)
             if (!quiet) printf("\nPromoting intermediary: %s\n", extname);
 
             if (!nochanges) {
+                struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
                 r = mboxlist_promote_intermediary(mbentry->name);
+                mboxname_release(&namespacelock);
                 if (r) {
                     fprintf(stderr,
                             "\tFailed to promote intermediary %s: %s\n",


### PR DESCRIPTION
This fixes a bunch of lock inversion, mostly by making less happen within the locked sections!

(it's also a step towards reduction of mboxname lookups in the counters code - but mostly hoisting the name lookup outside the locked section).