### PR TITLE
proxy: don't cache the same backend multiple times

### DIFF
--- a/imap/proxy.c
+++ b/imap/proxy.c
@@ -192,7 +192,7 @@ EXPORTED struct backend * proxy_findserver(const char *server,          /* hostn
     ret->inbox = inbox;
 
     /* insert server in list of cache connections */
-    if (cache) ptrarray_append(cache, ret);
+    if (cache) ptrarray_add(cache, ret);
 
     return ret;
 }


### PR DESCRIPTION
This fixes a double-free crash on cleanup because the same backend was being cached multiple times, introduced in #3560.

I _think_ this is the only place this needs to be changed, but I'm not entirely certain, so even though this is only a one-line fix, please look closely 😅 