### PR TITLE
Add clang-format configuration to unify code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,5 +6,6 @@ AllowShortLoopsOnASingleLine: true
 BinPackArguments: false
 BraceWrapping:
   BeforeElse:      true
+BreakBeforeBraces: Stroustrup
 IndentCaseLabels: true
 IndentWidth:     4

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: LLVM
+# not supported in v7.0.1: AllowShortBlocksOnASingleLine: Empty
+# not supported in v7.0.1: AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+BinPackArguments: false
+BraceWrapping:
+  BeforeElse:      true
+IndentCaseLabels: true
+IndentWidth:     4

--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,10 @@
 BasedOnStyle: LLVM
-# not supported in v7.0.1: AllowShortBlocksOnASingleLine: Empty
-# not supported in v7.0.1: AllowShortIfStatementsOnASingleLine: WithoutElse
-AllowShortIfStatementsOnASingleLine: true
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AllowShortBlocksOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
-BinPackArguments: false
+BinPackArguments: true
 BraceWrapping:
   BeforeElse:      true
 BreakBeforeBraces: Stroustrup


### PR DESCRIPTION
The Cyrus codebase currently uses a variety of code styles. This is a proposal for a single code style across all of the C and C++ source files.

It it currently a draft, and I suggest we all experiment with it.

The list of style options is documented at https://clang.llvm.org/docs/ClangFormatStyleOptions.html

Unfortunately my Debian development box only includes an ancient clang-format version (v7), which does not support a couple of options that I deem relevant. If we decide on a more recent version, I will be happy to update my local clang tools.

In the top-level cyrus-imapd directory, run ` clang-format -style=file <your source file here>` to check it out