### PR TITLE
squatter: lock conversations db in mailbox_begin to fix lock ordering

### DIFF
--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2657,7 +2657,7 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
         struct conversations_state *cstate = mailbox_get_cstate(mailbox);
         if (!cstate) {
             xsyslog(LOG_INFO, "can't open conversations", "mailbox=<%s>",
-                    mailbox->name);
+                    mailbox_name(mailbox));
             r = IMAP_MAILBOX_NOTSUPPORTED;
             goto out;
         }


### PR DESCRIPTION
This should hopefully fix the remaining deadlock error I'm seeing in the logs!  Basically, it tries to lock conversations AFTER the xapianactive file is locked, but that reverses the ordering from when we do searches - so instead, always take the lock if we're XAPINDEXed.  Which should hopefully mean that is_indexed doesn't deadlock.  Yay.

[ not to be merged:  this is exploratory work ]