### PR TITLE
httpd.c: add precondition error to log line

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -451,6 +451,31 @@ static const struct precond_t {
     { "max-resource-size", NS_CARDDAV },
 };
 
+void dav_precond_as_string(struct buf *buf, struct error_t *err)
+{
+    const struct precond_t *precond = &preconds[err->precond];
+
+    switch (precond->ns) {
+    case NS_DAV:
+        buf_appendcstr(buf, "DAV:");
+        break;
+    case NS_CALDAV:
+        buf_appendcstr(buf, "CALDAV:");
+        break;
+    case NS_CARDDAV:
+        buf_appendcstr(buf, "CARDDAV:");
+        break;
+    case NS_ISCHED:
+        buf_appendcstr(buf, "ISCHED:");
+        break;
+    case NS_MECOM:
+        buf_appendcstr(buf, "MECOM:");
+        break;
+    }
+
+    buf_appendcstr(buf, precond->name);
+}
+
 
 /* Check ACL on userid's principal (Inbox): ACL_LOOKUP right gives access */
 static int principal_acl_check(const char *userid, struct auth_state *authstate)

--- a/imap/http_dav.h
+++ b/imap/http_dav.h
@@ -740,6 +740,8 @@ int expand_property(xmlNodePtr inroot, struct propfind_ctx *fctx,
 int preload_proplist(xmlNodePtr proplist, struct propfind_ctx *fctx);
 void free_entry_list(struct propfind_entry_list *elist);
 
+void dav_precond_as_string(struct buf *buf, struct error_t *err);
+
 /* DAV method processing functions */
 int meth_acl(struct transaction_t *txn, void *params);
 int meth_copy_move(struct transaction_t *txn, void *params);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2917,6 +2917,13 @@ HIDDEN void log_request(long code, struct transaction_t *txn)
         buf_printf(logbuf, "%sallow-origin", sep);
         sep = "; ";
     }
+#ifdef WITH_DAV
+    else if (txn->error.precond) {
+        buf_printf(logbuf, "%sprecond=", sep);
+        dav_precond_as_string(logbuf, &txn->error);
+        sep = "; ";
+    }
+#endif
     else if (txn->error.desc) {
         buf_printf(logbuf, "%serror=%s", sep, txn->error.desc);
         sep = "; ";


### PR DESCRIPTION
This might aid in diagnosing client issues without having to enable telemetry