### PR TITLE
Doc: update Travis CI links

### DIFF
--- a/docsrc/exts/themes/cyrus/buildstatus.html
+++ b/docsrc/exts/themes/cyrus/buildstatus.html
@@ -1,5 +1,5 @@
 {%- if builder != 'singlehtml' %}
 <div class="buildstatus">
-    <a href="https://travis-ci.org/cyrusimap/cyrus-imapd" target="_blank">{{ theme_travis_version }}: <img src="https://travis-ci.org/cyrusimap/cyrus-imapd.svg?branch={{ theme_travis_version }}"></a>
+    <a href="https://travis-ci.com/github/cyrusimap/cyrus-imapd" target="_blank">{{ theme_travis_version }}: <img src="https://travis-ci.com/cyrusimap/cyrus-imapd.svg?branch={{ theme_travis_version }}"></a>
 </div>
 {%- endif %}


### PR DESCRIPTION
The repository was migrated from travis-ci.org to travis-ci.com. The old page now displays: "This repository was migrated and is now building on travis-ci.com".