### PR TITLE
message: use last valid charset parameter in Content-Type header

### DIFF
--- a/changes/next/message_parse_bogus_charset_params
+++ b/changes/next/message_parse_bogus_charset_params
@@ -1,0 +1,25 @@
+Description:
+
+Use last valid charset parameter in Content-Type header.
+
+The Content-Type header may have at most one charset parameter, but at
+least one MUA generates header values such as:
+
+   Content-Type: text/plain; charset=text/plain; charset=UTF-8
+
+Note both the bogus first parameter value and the duplicate charset parameters.
+Cyrus now leniently accepts such header values, and falls back to cache the
+last valid charset parameter value.
+
+Config changes:
+
+None.
+
+Upgrade instructions:
+
+Installations may already have bogus charset values like "text/plain" in
+the binary bodystructure caches. A rewrite of the cache is recommended.
+
+GitHub issue:
+
+3576

--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -1355,4 +1355,40 @@ static void test_cache_quotedaddr(void)
     buf_free(&buf);
 }
 
+static void test_parse_bogus_charset_params(void)
+{
+#define TESTCASE(charsetparams, want) \
+    { \
+        static const char msg[] = \
+            "From: Fred Bloggs <fbloggs@fastmail.fm>\r\n" \
+            "To: Sarah Jane Smith <sjsmith@gmail.com>\r\n" \
+            "Date: Wed, 27 Oct 2010 18:37:26 +1100\r\n" \
+            "Subject: Trivial testing email\r\n" \
+            "Message-ID: <fake800@fastmail.fm>\r\n" \
+            "Content-Type: text/plain; " charsetparams "\r\n" \
+            "X-Mailer: Norman\r\n" \
+            "\r\n" \
+            "Hello, World\n"; \
+        int r; \
+        struct body *body = xzmalloc(sizeof(struct body)); \
+        memset(body, 0x45, sizeof(struct body)); \
+        r = message_parse_mapped(msg, sizeof(msg)-1, body, NULL); \
+        CU_ASSERT_EQUAL(r, 0); \
+        if (want) \
+            CU_ASSERT_STRING_EQUAL(body->charset_id, want); \
+        else \
+            CU_ASSERT_PTR_NULL(body->charset_id); \
+        message_free_body(body); \
+        free(body); \
+    }
+
+    TESTCASE("charset=text/plain; charset=iso-8859-1", "iso-8859-1");
+    TESTCASE("charset=us-ascii; charset=iso-8859-1", "iso-8859-1");
+    TESTCASE("charset=iso-8859-1; charset=text/plain", "iso-8859-1");
+    TESTCASE("charset=iso-8859-1; charset=us-ascii", "us-ascii");
+    TESTCASE("charset=text/plain; charset=text/html", "us-ascii");
+
+#undef TESTCASE
+}
+
 /* vim: set ft=c: */

--- a/imap/message.h
+++ b/imap/message.h
@@ -197,6 +197,8 @@ extern void message_free_body(struct body *body);
 extern void message_parse_type(const char *hdr, char **typep, char **subtypep, struct param **paramp);
 extern void message_parse_disposition(const char *hdr, char **hdpr, struct param **paramp);
 
+extern void message_parse_charset_params(const struct param *params, charset_t *c_ptr);
+
 /* NOTE - scribbles on its input */
 extern void message_parse_env_address(char *str, struct address *addr);
 


### PR DESCRIPTION
The Content-Type header may have at most one charset parameter, but at least one MUA generates header values such as:

    Content-Type: text/plain; charset=text/plain; charset=UTF-8

Note both the bogus first parameter value and the duplicate charset parameters. Cyrus now leniently accepts such header values, and falls back to cache the last valid charset parameter value.

Bonus point: it unifies charset parameter parsing to single function, rather than three implementations in the same codebase.

Fixes #3576

JMAP test at https://github.com/cyrusimap/cassandane/commit/7ded3114bf5d355ff9ca10e8113952f462da68ba