### PR TITLE
Give jmap_parse_path() a parse_path_t signature

### DIFF
--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -106,7 +106,7 @@ static int jmap_eventsource(struct transaction_t *txn);
 static ws_data_callback jmap_ws;
 
 static struct connect_params ws_params = {
-    JMAP_BASE_URL JMAP_WS_COL, JMAP_WS_PROTOCOL, &jmap_ws
+    &jmap_parse_path, { JMAP_BASE_URL JMAP_WS_COL, JMAP_WS_PROTOCOL, &jmap_ws }
 };
 
 

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -489,10 +489,13 @@ struct method_t {
 };
 
 struct connect_params {
-    /* WebSocket parameters */
-    const char *endpoint;
-    const char *subprotocol;
-    const void *data_cb;
+    parse_path_t parse_path;
+    struct {
+        /* WebSocket parameters */
+        const char *endpoint;
+        const char *subprotocol;
+        const void *data_cb;
+    } ws;
 };
 
 struct namespace_t {


### PR DESCRIPTION
This allows us to remove meth_options_jmap() in lieu of stock meth_options() and to be more inline with the other modules.

I will also be able to leverage the meth_connect() changes for #3564

Note that this allows both /jmap and /jmap/ as valid URLs.  Current Cyrus issues a 301 for the former, but I don't see that as being necessary