### PR TITLE
message: reset spurious errno value before xsyslog

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -1088,6 +1088,7 @@ EXPORTED void message_parse_charset_params(const struct param *params,
             if (param->value && *param->value) {
                 charset_t cs = charset_lookupname(param->value);
                 if (cs == CHARSET_UNKNOWN_CHARSET) {
+                    errno = 0;
                     xsyslog(LOG_NOTICE, "unknown charset", "charset=<%s>", param->value);
                     continue;
                 }


### PR DESCRIPTION
xsyslog reports a syserror that's unrelated to the logged message. See #3576