### PR TITLE
Improve the efficiency of annotations DB lookups

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -720,14 +720,15 @@ error:
     return r;
 }
 
-HIDDEN int annotate_getdb(const char *mboxid, annotate_db_t **dbp)
+HIDDEN int annotate_getdb(const struct mailbox *mailbox, annotate_db_t **dbp)
 {
-    if (!mboxid || !*mboxid) {
-        syslog(LOG_ERR, "IOERROR: annotate_getdb called with no mboxid");
+    if (!mailbox) {
+        syslog(LOG_ERR, "IOERROR: annotate_getdb called with no mailbox");
         return IMAP_INTERNAL;   /* we don't return the global db */
     }
-    /* synthetic UID '1' forces per-mailbox mode */
-    return _annotate_getdb(mboxid, NULL, 1, CYRUSDB_CREATE, dbp);
+    /* ANNOTATE_ANY_UID forces UID mode */
+    return _annotate_getdb(mailbox_uniqueid(mailbox), mailbox, ANNOTATE_ANY_UID,
+                           CYRUSDB_CREATE, dbp);
 }
 
 static void annotate_closedb(annotate_db_t *d)

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1235,8 +1235,7 @@ EXPORTED int annotatemore_findall(const char *mboxname, /* internal */
     }
     else {
         /* Mailbox pattern */
-        r = mboxlist_findall(NULL, *mboxname ? mboxname : "*",
-                             1, NULL, NULL, &_findall, &frock);
+        r = mboxlist_findall(NULL, mboxname, 1, NULL, NULL, &_findall, &frock);
     }
 
 out:

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -607,7 +607,7 @@ static int annotate_dbname_mbentry(const mbentry_t *mbentry,
     return 0;
 }
 
-static int annotate_dbname_mailbox(struct mailbox *mailbox, char **fnamep)
+static int annotate_dbname_mailbox(const struct mailbox *mailbox, char **fnamep)
 {
     const char *conf_fname;
 

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -155,9 +155,16 @@ typedef int (*annotatemore_find_proc_t)(const char *mailbox,
 /* For findall() matches also tombstones */
 #define ANNOTATE_TOMBSTONES  (1<<0)
 
-/* 'proc'ess all annotations matching 'mailbox' and 'entry' */
-int annotatemore_findall(const char *mboxname, uint32_t uid,
-                         const char *entry,
+/* 'proc'ess all annotations matching 'mailbox' and 'entry'.
+ * if 'mailbox' is NULL, then 'pattern' is a pattern for
+ * mboxlist_findall and will return all matching entries.. */
+EXPORTED int annotatemore_findall_mailbox(const struct mailbox *mailbox,
+                         uint32_t uid, const char *entry,
+                         modseq_t since_modseq,
+                         annotatemore_find_proc_t proc, void *rock,
+                         int flags);
+EXPORTED int annotatemore_findall_pattern(const char *pattern,
+                         uint32_t uid, const char *entry,
                          modseq_t since_modseq,
                          annotatemore_find_proc_t proc, void *rock,
                          int flags);

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -285,7 +285,7 @@ void annotate_done(void);
  * annotations at all on the mailbox. These APIs are for performance
  * optimisations only; the other annotate APIs will manage their own
  * references internally. */
-int annotate_getdb(const char *mboxid, annotate_db_t **dbp);
+int annotate_getdb(const struct mailbox *mailbox, annotate_db_t **dbp);
 void annotate_putdb(annotate_db_t **dbp);
 
 /* Maybe this isn't the right place - move later */

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -674,7 +674,7 @@ static int has_alarms(icalcomponent *ical, struct mailbox *mailbox, uint32_t uid
 
     syslog(LOG_DEBUG, "checking per-user-data");
     mailbox_get_annotate_state(mailbox, uid, NULL);
-    annotatemore_findall(mailbox_name(mailbox), uid, PER_USER_CAL_DATA, /* modseq */ 0,
+    annotatemore_findall_mailbox(mailbox, uid, PER_USER_CAL_DATA, /* modseq */ 0,
                          &has_peruser_alarms_cb, &hrock, /* flags */ 0);
 
     return has_alarms;
@@ -943,7 +943,7 @@ static int process_valarms(struct mailbox *mailbox,
     syslog(LOG_DEBUG, "processing per-user alarms");
 
     mailbox_get_annotate_state(mailbox, record->uid, NULL);
-    annotatemore_findall(mailbox_name(mailbox), record->uid, PER_USER_CAL_DATA,
+    annotatemore_findall_mailbox(mailbox, record->uid, PER_USER_CAL_DATA,
                          /* modseq */ 0, &process_peruser_alarms_cb,
                          &prock, /* flags */ 0);
 

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -1664,8 +1664,8 @@ int xml_add_response(struct propfind_ctx *fctx, long code, unsigned precond,
             (fctx->mode == PROPFIND_ALL || fctx->mode == PROPFIND_NAME)) {
             struct allprop_rock arock = { fctx, propstat };
 
-            annotatemore_findall(mailbox_name(fctx->mailbox), 0, "*", /*modseq*/0,
-                                 allprop_cb, &arock, /*flags*/0);
+            annotatemore_findall_mailbox(fctx->mailbox, 0, "*", /*modseq*/0,
+                                         allprop_cb, &arock, /*flags*/0);
         }
 
         /* Check if we have any propstat elements */

--- a/imap/index.c
+++ b/imap/index.c
@@ -1105,7 +1105,7 @@ EXPORTED void index_fetchresponses(struct index_state *state,
     /* Keep an open reference on the per-mailbox db to avoid
      * doing too many slow database opens during the fetch */
     if ((fetchargs->fetchitems & FETCH_ANNOTATION))
-        annotate_getdb(mailbox_uniqueid(state->mailbox), &annot_db);
+        annotate_getdb(state->mailbox, &annot_db);
 
     start = 1;
     end = state->exists;

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1088,9 +1088,9 @@ static int recreate_calendar(const mbentry_t *mbentry,
         mbname_set_isdeleted(mbname, 0);
         free(mbname_pop_boxes(mbname));
         mbname_push_boxes(mbname, "%");
-        annotatemore_findall(mbname_intname(mbname), 0/*uid*/,
-                             disp_annot, 0/*since_modseq*/,
-                             &lookup_cal_by_dispname, &crock, 0/*flags*/);
+        annotatemore_findall_pattern(mbname_intname(mbname), 0/*uid*/,
+                                     disp_annot, 0/*since_modseq*/,
+                                     &lookup_cal_by_dispname, &crock, 0/*flags*/);
         mbname_free(&mbname);
 
         if (crock.mboxname) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1650,9 +1650,8 @@ static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *c
 
         /* Write userdata parts */
         struct calendarevent_getblob_rock rock = { boundary, blob };
-        annotatemore_findall(mailbox_name(mailbox), uid,
-                             PER_USER_CAL_DATA, 0, _calendarevent_getblob_cb,
-                             &rock, 0);
+        annotatemore_findall_mailbox(mailbox, uid, PER_USER_CAL_DATA, 0,
+                                     _calendarevent_getblob_cb, &rock, 0);
 
         /* Write close-delimiter and epilogue */
         buf_printf(blob, "\r\n--%s--\r\n%s", boundary, epilogue);

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -3804,8 +3804,8 @@ static int _mboxset_state_validate(jmap_req_t *req,
     struct buf pattern = BUF_INITIALIZER;
     buf_initmcstr(&pattern, mboxname_user_mbox(req->accountid, NULL));
     buf_putc(&pattern, '*');
-    annotatemore_findall(buf_cstring(&pattern), 0, "/specialuse", 0,
-                         _mboxset_state_find_specialuse_cb, state, 0);
+    annotatemore_findall_pattern(buf_cstring(&pattern), 0, "/specialuse", 0,
+                                 _mboxset_state_find_specialuse_cb, state, 0);
     buf_free(&pattern);
 
     /* Apply changes */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -288,7 +288,7 @@ static void remove_listitem(struct mailboxlist *remitem)
     fatal("didn't find item in list", EX_SOFTWARE);
 }
 
-EXPORTED const char *mailbox_meta_fname(struct mailbox *mailbox, int metafile)
+EXPORTED const char *mailbox_meta_fname(const struct mailbox *mailbox, int metafile)
 {
     static char fnamebuf[MAX_MAILBOX_PATH];
     uint32_t legacy_dirs = (mailbox_mbtype(mailbox) & MBTYPE_LEGACY_DIRS);
@@ -303,7 +303,7 @@ EXPORTED const char *mailbox_meta_fname(struct mailbox *mailbox, int metafile)
     return fnamebuf;
 }
 
-EXPORTED const char *mailbox_meta_newfname(struct mailbox *mailbox, int metafile)
+EXPORTED const char *mailbox_meta_newfname(const struct mailbox *mailbox, int metafile)
 {
     static char fnamebuf[MAX_MAILBOX_PATH];
     uint32_t legacy_dirs = (mailbox_mbtype(mailbox) & MBTYPE_LEGACY_DIRS);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1787,8 +1787,8 @@ EXPORTED struct entryattlist *mailbox_extract_annots(const struct mailbox *mailb
                                                      const struct index_record *record)
 {
     struct entryattlist *annots = NULL;
-    int r = annotatemore_findall(mailbox_name(mailbox), record->uid, "*", /*modseq*/0,
-                                 load_annot_cb, &annots, /*flags*/0);
+    int r = annotatemore_findall_mailbox(mailbox, record->uid, "*", /*modseq*/0,
+                                         load_annot_cb, &annots, /*flags*/0);
     if (r) return NULL;
     return annots;
 }
@@ -3352,7 +3352,7 @@ static void mailbox_annot_update_counts(struct mailbox *mailbox,
     /* expunged records don't count */
     if (record && record->internal_flags & FLAG_INTERNAL_EXPUNGED) return;
 
-    annotatemore_findall(mailbox_name(mailbox), record ? record->uid : 0, /* all entries*/"*",
+    annotatemore_findall_mailbox(mailbox, record ? record->uid : 0, /* all entries*/"*",
                          /*modseq*/0, calc_one_annot, &cr, /*flags*/0);
 
     if (record)
@@ -3396,7 +3396,7 @@ EXPORTED struct synccrcs mailbox_synccrcs(struct mailbox *mailbox, int force)
         crcs.annot ^= crc_virtannot(mailbox, record);
 
         struct annot_calc_rock cr = { mailbox, 0, 0 };
-        annotatemore_findall(mailbox_name(mailbox), record->uid, /* all entries*/"*",
+        annotatemore_findall_mailbox(mailbox, record->uid, /* all entries*/"*",
                              /*modseq*/0, calc_one_annot, &cr, /*flags*/0);
 
         crcs.annot ^= cr.annot;
@@ -7268,7 +7268,7 @@ static int find_annots(struct mailbox *mailbox, struct found_uids *annots)
 {
     int r = 0;
 
-    r = annotatemore_findall(mailbox_name(mailbox), ANNOTATE_ANY_UID, "*",
+    r = annotatemore_findall_mailbox(mailbox, ANNOTATE_ANY_UID, "*",
                              /*modseq*/0, addannot_uid, annots, /*flags*/0);
     if (r) return r;
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -524,8 +524,8 @@ extern mailbox_notifyproc_t *mailbox_get_updatenotifier(void);
 
 /* file names on disk */
 #define META_FNAME_NEW 1
-extern const char *mailbox_meta_fname(struct mailbox *mailbox, int metafile);
-extern const char *mailbox_meta_newfname(struct mailbox *mailbox, int metafile);
+extern const char *mailbox_meta_fname(const struct mailbox *mailbox, int metafile);
+extern const char *mailbox_meta_newfname(const struct mailbox *mailbox, int metafile);
 extern int mailbox_meta_rename(struct mailbox *mailbox, int metafile);
 
 extern const char *mailbox_record_fname(struct mailbox *mailbox,

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -609,7 +609,7 @@ EXPORTED int dump_mailbox(const char *tag, struct mailbox *mailbox, uint32_t uid
         struct dump_annotation_rock actx;
         actx.tag = tag;
         actx.pout = pout;
-        annotatemore_findall(mailbox_name(mailbox), 0, "*", /*modseq*/0,
+        annotatemore_findall_mailbox(mailbox, 0, "*", /*modseq*/0,
                              dump_annotations, (void *) &actx, /*flags*/0);
     }
 

--- a/imap/msgrecord.c
+++ b/imap/msgrecord.c
@@ -507,7 +507,7 @@ EXPORTED int msgrecord_annot_findall(msgrecord_t *mr,
 {
     int r = msgrecord_need(mr, M_MAILBOX|M_UID|M_ANNOTATIONS);
     if (r) return r;
-    return annotatemore_findall(mailbox_name(mr->mbox), mr->record.uid, entry, /*modseq*/0,
+    return annotatemore_findall_mailbox(mr->mbox, mr->record.uid, entry, /*modseq*/0,
                                 proc, rock, /*flags*/0);
 }
 

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -2638,7 +2638,7 @@ static void cmd_list(char *arg1, char *arg2)
 
         strcpy(pattern, newsprefix);
         strcat(pattern, "*");
-        annotatemore_findall(pattern, 0, "/comment", /*modseq*/0,
+        annotatemore_findall_pattern(pattern, 0, "/comment", /*modseq*/0,
                              newsgroups_cb, lrock.wild, /*flags*/0);
 
         prot_printf(nntp_out, ".\r\n");


### PR DESCRIPTION
It's probably worth looking at the diffs independently here.  Two are of particular interest - one changes the _annotate_getdb API, and the other splits the annotatemore_findall API.

There's still more work to do, but this is a couple of big ones :)