### PR TITLE
UUID bugfixes

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1060,8 +1060,10 @@ static int mboxlist_update_entry(const char *name,
 
                 if (strcmp(name, oldid->name)) {
                     /* Renamed mailbox */
-                    add_former_name(name_history, oldid->name,
+                    char *dbname = mboxname_to_dbname(oldid->name);
+                    add_former_name(name_history, dbname,
                                     time(NULL), oldid->foldermodseq);
+                    free(dbname);
                 }
                 mboxlist_entry_free(&oldid);
             }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1080,7 +1080,7 @@ static int mboxlist_update_entry(const char *name,
         dlist_free(&dl);
         buf_free(&mboxent);
 
-        if (!r && config_auditlog) {
+        if (!r && config_auditlog && (!old || strcmpsafe(old->acl, mbentry->acl))) {
             /* XXX is there a difference between "" and NULL? */
             xsyslog(LOG_NOTICE, "auditlog: acl",
                                 "sessionid=<%s> "


### PR DESCRIPTION
This is quite urgent!  Well, the two bugfixes are.  The boring syslog line fixer isn't.

This fixes two observed bugs when upgrading a server.

1) the name-history 'dbname' field was storing intname instead of dbname values.

2) when a DELETED mailbox was created by sync_server, it wasn't correctly finding that the INBOX was still legacy, because INBOX isn't a parent of the DELETED namespace.