### PR TITLE
annotate: fix bug with server-level annotations in lookup

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1984,7 +1984,9 @@ static void annotation_get_fromdb(annotate_state_t *state,
 {
     state->found = 0;
 
-    annotatemore_findall_mailbox(state->mailbox, state->uid, entry->name, 0, &rw_cb, state, 0);
+    // if mailbox present, will be a mailbox fetch, otherwise will be a server fetch
+    // with the blank pattern
+    annotatemore_findall_full("", state->mailbox, state->uid, entry->name, 0, &rw_cb, state, 0);
 
     if (state->found != state->attribs &&
         (!strchr(entry->name, '%') && !strchr(entry->name, '*'))) {

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3103,7 +3103,6 @@ static int getannotation_cb(const char *mboxname,
 int sync_get_annotation(struct dlist *kin, struct sync_state *sstate)
 {
     const char *mboxname = kin->sval;
-    assert (!*mboxname); // we can only get server annotations with this function
     return annotatemore_findall_pattern(mboxname, 0, "*", /*modseq*/0,
                                 &getannotation_cb, (void *) sstate->pout,
                                 /*flags*/0);


### PR DESCRIPTION
This was just a bad piece of API usage - sorry I clearly didn't run the cunit test after I finished refactoring this API call.