### PR TITLE
Fix valgrind issues in the JMAP code

### DIFF
--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -5,6 +5,9 @@
 
 extern int charset_debug;
 
+#define CU_ASSERT_MEMEQUAL(actual, expected, sz) \
+    CU_ASSERT_EQUAL(memcmp(actual, expected, sz), 0)
+
 /* The Unicode Replacement character 0xfffd in UTF-8 encoding */
 #define UTF8_REPLACEMENT    "\357\277\275"
 /* The Replacement char after search normalisation */
@@ -1384,6 +1387,51 @@ static void test_qpencode_mimebody(void)
              "0123456789" "0123456789" "0123456789" "0123456789",
              "0123456789" "0123456789" "0123456789" "0123456789"
              "0123456789" "0123456789" "0123456789" "01=\r\n23456789", 1);
+
+#undef TESTCASE
+}
+
+static void test_encode_mimebody(void)
+{
+#define TESTCASE(in, want, wrap, wantlines) \
+    { \
+        size_t inlen = strlen(in); \
+        size_t wantlen = strlen(want); \
+        size_t preflight_outlen = 0xffee; \
+        int preflight_outlines = 0x1234; \
+        char *preflight_retval = charset_encode_mimebody(NULL, inlen, NULL, \
+            &preflight_outlen, &preflight_outlines, wrap); \
+        CU_ASSERT_PTR_NULL(preflight_retval); \
+        CU_ASSERT_EQUAL(wantlen, preflight_outlen); \
+        CU_ASSERT_EQUAL(wantlines, preflight_outlines); \
+        char *retval = malloc(preflight_outlen); \
+        size_t encode_outlen = 0x1234; \
+        int encode_outlines = 0xffee; \
+        char *encode_retval = charset_encode_mimebody(in, inlen, \
+                retval, &encode_outlen, &encode_outlines, wrap); \
+        CU_ASSERT_PTR_EQUAL(retval, encode_retval); \
+        CU_ASSERT_EQUAL(wantlen, encode_outlen); \
+        CU_ASSERT_MEMEQUAL(retval, want, wantlen); \
+        CU_ASSERT_EQUAL(wantlines, encode_outlines); \
+        free(retval); \
+    }
+
+    TESTCASE("a", "YQ==", 0, 1);
+    TESTCASE("ab", "YWI=", 0, 1);
+    TESTCASE("abc", "YWJj", 0, 1);
+    TESTCASE("abcd", "YWJjZA==", 0, 1);
+    TESTCASE("abcde", "YWJjZGU=", 0, 1);
+    TESTCASE("abcdef", "YWJjZGVm", 0, 1);
+
+
+    TESTCASE("012345678901234567890123456789012345678901234567890123",
+             "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIz\r\n",
+             1, 1);
+
+    TESTCASE("0123456789012345678901234567890123456789012345678901234",
+             "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIz\r\n"
+             "NA==\r\n",
+             1, 2);
 
 #undef TESTCASE
 }

--- a/cunit/jmap_util.testc
+++ b/cunit/jmap_util.testc
@@ -142,9 +142,11 @@ static void test_decode_to_utf8(void)
         int encoding;
         float confidence;
         const char *want_val;
-        int want_alloc;
         int want_is_encoding_problem;
     };
+
+
+    // this is all about "Adélaïde"
 
     struct testcase tcs[] = {{
         // ISO-8859-1 encoded data claims to be UTF-8, confidence 0.51
@@ -154,7 +156,6 @@ static void test_decode_to_utf8(void)
         ENCODING_NONE,
         0.51,
         "Ad""\xc3\xa9""la""\xc3\xaf""de",
-        1,
         1
 #else
         "Ad""\xe9""la""\xef""de",
@@ -162,7 +163,6 @@ static void test_decode_to_utf8(void)
         ENCODING_NONE,
         0.51,
         "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
-        1,
         1
 #endif
     }, {
@@ -172,7 +172,6 @@ static void test_decode_to_utf8(void)
         ENCODING_NONE,
         1.0,
         "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
-        1,
         1
     }, {
         // Fast-path valid UTF-8
@@ -181,7 +180,6 @@ static void test_decode_to_utf8(void)
         ENCODING_NONE,
         0.51,
         "Ad""\xc3\xa9""la""\xc3\xaf""de",
-        0,
         0
     }, {
         // Fast-path valid UTF-8 with replacement chars
@@ -190,29 +188,26 @@ static void test_decode_to_utf8(void)
         ENCODING_NONE,
         0.51,
         "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
-        0,
         0
     }, {
-        NULL, NULL, ENCODING_UNKNOWN, 0.0, NULL, 0, 0
+        NULL, NULL, ENCODING_UNKNOWN, 0.0, NULL, 0
     }};
 
+    struct buf buf = BUF_INITIALIZER;
     struct testcase *tc;
     for (tc = tcs; tc->data; tc++) {
-        char *cbuf = NULL;
         int is_problem = 0;
-        const char *cval = jmap_decode_to_utf8(tc->charset, tc->encoding,
-            tc->data, strlen(tc->data), tc->confidence, &cbuf, &is_problem);
+        buf_reset(&buf);
+
+        jmap_decode_to_utf8(tc->charset, tc->encoding,
+            tc->data, strlen(tc->data), tc->confidence, &buf, &is_problem);
         if (tc->want_val)
-            CU_ASSERT_STRING_EQUAL(tc->want_val, cval);
+            CU_ASSERT_STRING_EQUAL(tc->want_val, buf_cstring(&buf));
         else
-            CU_ASSERT_PTR_NULL(cval);
-        if (tc->want_alloc)
-            CU_ASSERT_PTR_NOT_NULL(cbuf);
-        else
-            CU_ASSERT_PTR_NULL(cbuf);
+            CU_ASSERT_EQUAL(0, buf_len(&buf));
         CU_ASSERT_EQUAL(tc->want_is_encoding_problem, is_problem);
-        free(cbuf);
     }
+    buf_free(&buf);
 }
 
 /* vim: set ft=c: */

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -524,7 +524,7 @@ static int jmap_getblob_default_handler(jmap_req_t *req,
 
     if (ctx->accept_mime) {
         /* XXX  Can we be smarter here and test against part->[sub]type ? */
-        ctx->content_type = xstrdup(ctx->accept_mime);
+        buf_setcstr(&ctx->content_type, ctx->accept_mime);
     }
 
     if (part) {
@@ -544,13 +544,13 @@ static int jmap_getblob_default_handler(jmap_req_t *req,
         }
         else if (decbuf) {
             buf_initm(&ctx->blob, decbuf, len);
-            ctx->encoding = xstrdup("BINARY");
+            buf_setcstr(&ctx->encoding, "BINARY");
         }
         else {
             /* Skip headers */
             buf_remove(&ctx->blob, 0, part->content_offset);
             buf_truncate(&ctx->blob, part->content_size);
-            ctx->encoding = xstrdup(part->encoding);
+            buf_setcstr(&ctx->encoding, part->encoding);
         }
     }
 
@@ -675,8 +675,8 @@ static int jmap_download(struct transaction_t *txn)
         txn->flags.cc |= CC_MAXAGE | CC_PRIVATE | CC_IMMUTABLE;
 
         /* Write body */
-        txn->resp_body.type =
-            ctx.content_type ? ctx.content_type : "application/octet-stream";
+        txn->resp_body.type = buf_len(&ctx.content_type) ?
+            buf_cstring(&ctx.content_type) : "application/octet-stream";
         txn->resp_body.len = buf_len(&ctx.blob);
         write_body(HTTP_OK, txn, buf_base(&ctx.blob), buf_len(&ctx.blob));
     }

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -3365,17 +3365,16 @@ HIDDEN void jmap_getblob_ctx_init(jmap_getblob_context_t *ctx,
 HIDDEN void jmap_getblob_ctx_reset(jmap_getblob_context_t *ctx)
 {
     buf_reset(&ctx->blob);
-    free(ctx->content_type);
-    free(ctx->encoding);
-
-    ctx->errstr = ctx->content_type = ctx->encoding = NULL;
+    buf_reset(&ctx->content_type);
+    buf_reset(&ctx->encoding);
+    ctx->errstr = NULL;
 }
 
 HIDDEN void jmap_getblob_ctx_fini(jmap_getblob_context_t *ctx)
 {
     buf_free(&ctx->blob);
-    free(ctx->content_type);
-    free(ctx->encoding);
+    buf_free(&ctx->content_type);
+    buf_free(&ctx->encoding);
 }
 
 EXPORTED mbentry_t *jmap_mbentry_from_dav(jmap_req_t *req, struct dav_data *dav)

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -174,8 +174,8 @@ typedef struct {
     const char *accept_mime;     // input to the handler
     unsigned decode : 1;         // input to the handler
     struct buf blob;             // output from the handler
-    char *content_type;          // output from the handler
-    char *encoding;              // output from the handler
+    struct buf content_type;     // output from the handler
+    struct buf encoding;         // output from the handler
     const char *errstr;          // output from the handler
 } jmap_getblob_context_t;
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1608,11 +1608,9 @@ static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *c
     if (userid) {
         /* Set Content headers */
         if (!ctx->accept_mime || !strcmp(ctx->accept_mime, "text/calendar")) {
-            struct buf buf = BUF_INITIALIZER;
-
-            buf_setcstr(&buf, "text/calendar");
-            if (comp_type) buf_printf(&buf, "; component=%s", comp_type);
-            ctx->content_type = buf_release(&buf);
+            buf_setcstr(&ctx->content_type, "text/calendar");
+            if (comp_type)
+                buf_printf(&ctx->content_type, "; component=%s", comp_type);
         }
 
         /* Write body */
@@ -1625,14 +1623,14 @@ static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *c
         const char *epilogue = "\r\nEnd of MIME multipart body.\r\n";
         char boundary[100];
         struct buf *blob = &ctx->blob;
-        struct buf buf = BUF_INITIALIZER;
 
         snprintf(boundary, sizeof(boundary), "%s-%ld-%ld-%ld",
                  *spool_getheader(req->txn->req_hdrs, ":authority"),
                  (long) getpid(), (long) time(0), (long) rand());
 
-        buf_printf(&buf, "multipart/mixed; boundary=\"%s\"", boundary);
-        ctx->content_type = buf_release(&buf);
+        buf_reset(&ctx->content_type);
+        buf_printf(&ctx->content_type,
+                "multipart/mixed; boundary=\"%s\"", boundary);
 
         buf_setcstr(blob, preamble);
 
@@ -1657,7 +1655,7 @@ static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *c
         buf_printf(blob, "\r\n--%s--\r\n%s", boundary, epilogue);
     }
 
-    ctx->encoding = xstrdup("8BIT");
+    buf_setcstr(&ctx->encoding, "8BIT");
 
     message_free_body(body);
     free(body);

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -246,10 +246,10 @@ static void strip_spurious_deletes(struct changes_rock *urock)
 
 static json_t *jmap_utf8string(const char *s)
 {
-    char *freeme = NULL;
-    json_t *jval = json_string(jmap_decode_to_utf8("utf-8", ENCODING_NONE,
-                s, strlen(s), 1.0, &freeme, NULL));
-    free(freeme);
+    struct buf buf = BUF_INITIALIZER;
+    jmap_decode_to_utf8("utf-8", ENCODING_NONE, s, strlen(s), 1.0, &buf, NULL);
+    json_t *jval = json_string(buf_cstring(&buf));
+    buf_free(&buf);
     return jval;
 }
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -374,12 +374,12 @@ static char *_decode_to_utf8(const char *charset,
                              int *is_encoding_problem)
 {
     /* XXX - keep confidence 0.0 for regression? */
-    char *cbuf = NULL;
-    const char *cval = jmap_decode_to_utf8(charset,
+    struct buf buf = BUF_INITIALIZER;
+    jmap_decode_to_utf8(charset,
             encoding_lookupname(encoding),
-            data, datalen, 0.0, &cbuf,
+            data, datalen, 0.0, &buf,
             is_encoding_problem);
-    return cbuf ? cbuf : xstrdupnull(cval);
+    return datalen && buf_len(&buf) ? buf_release(&buf) : NULL;
 }
 
 struct headers {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -9949,7 +9949,7 @@ static void _emailpart_blob_to_mime(jmap_req_t *req,
     content_size = buf_len(&ctx.blob);
 
     /* Determine target encoding */
-    encoding = src_encoding = ctx.encoding;
+    encoding = src_encoding = buf_cstring(&ctx.encoding);
 
     if (!strcasecmpsafe(emailpart->type, "MESSAGE")) {
         if (!strcasecmpsafe(src_encoding, "BASE64")) {
@@ -13555,9 +13555,9 @@ static int jmap_emailheader_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx
             goto done;
         }
 
-        ctx->content_type = xstrdup(ctx->accept_mime);
+        buf_setcstr(&ctx->content_type, ctx->accept_mime);
     }
-    else if (mimetype) ctx->content_type = xstrdup(mimetype);
+    else if (mimetype) buf_setcstr(&ctx->content_type, mimetype);
 
     /* Open mailbox, we need it now */
     if ((r = jmap_openmbox(req, mboxname, &mailbox, 0))) {
@@ -13598,14 +13598,14 @@ static int jmap_emailheader_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx
                               (char *) buf_base(blob), buf_len(blob), &outlen);
             if (r == SASL_OK) {
                 buf_truncate(blob, outlen);
-                ctx->encoding = xstrdup("BINARY");
+                buf_setcstr(&ctx->encoding, "BINARY");
             }
             else {
                 ctx->errstr = "failed to decode blob";
                 res = HTTP_SERVER_ERROR;
             }
         }
-        else ctx->encoding = xstrdup("BASE64");
+        else buf_setcstr(&ctx->encoding, "BASE64");
     }
     else {
         res = HTTP_NOT_FOUND;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1755,6 +1755,7 @@ static const search_attr_t emailsearch_folders_attr = {
     /*get_countability*/NULL,
     emailsearch_folders_duplicate,
     emailsearch_folders_free,
+    /*freeattr*/NULL,
     (void*)0 /*is_otherthan*/
 };
 
@@ -1852,6 +1853,7 @@ static const search_attr_t emailsearch_headermatch_attr_uncached = {
     /*get_countability*/NULL,
     emailsearch_headermatch_duplicate,
     emailsearch_headermatch_free,
+    /*freeattr*/NULL,
     NULL
 };
 
@@ -1868,6 +1870,7 @@ static const search_attr_t emailsearch_headermatch_attr_cached = {
     /*get_countability*/NULL,
     emailsearch_headermatch_duplicate,
     emailsearch_headermatch_free,
+    /*freeattr*/NULL,
     NULL
 };
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4157,7 +4157,6 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
         emailquery_cache.last_accessed = time(NULL);
         is_cached = 1;
     }
-    buf_free(&fingerprint);
 
     /* Build response */
     emailquery_buildresult(q, &emailquery_cache, errp);
@@ -4218,6 +4217,7 @@ done:
         }
         else *errp = jmap_server_error(r);
     }
+    buf_free(&fingerprint);
     free(querystate);
     return res;
 }

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -2298,11 +2298,11 @@ static int jmap_sieve_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx)
             return HTTP_NOT_ACCEPTABLE;
         }
 
-        ctx->content_type = xstrdup(ctx->accept_mime);
+        buf_setcstr(&ctx->content_type, ctx->accept_mime);
     }
-    else ctx->content_type = xstrdup("application/sieve; charset=utf-8");
+    else buf_setcstr(&ctx->content_type, "application/sieve; charset=utf-8");
 
-    ctx->encoding = xstrdup("8BIT");
+    buf_setcstr(&ctx->encoding, "8BIT");
 
     /* Lookup scriptid */
     const char *sievedir =

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -113,26 +113,28 @@ extern json_t *jmap_server_error(int r);
 extern char *jmap_encode_base64_nopad(const char *data, size_t len);
 extern char *jmap_decode_base64_nopad(const char *b64, size_t b64len);
 
-/* Decode the text in data of datalen bytes to UTF-8 to a C-string.
+/* Decode the text in data of datalen bytes to UTF-8.
  *
- * Attempt to detect the right character encoding if conversion to
+ * Attempts to detect the right character encoding if conversion to
  * UTF-8 yields any invalid or replacement characters.
+ * UTF-8 input with replacement characters is considered valid input.
  *
  * Parameters:
  * - charset indicates the presumed character encoding.
  * - encoding must be one of the encodings defined in charset.h
+ * - data points to the encoded bytes
+ * - datalen indicates the byte length of data
  * - confidence indicates the threshold for charset detection (0 to 1.0)
- * - val holds any allocated memory to which the return value points to
+ * - dst points to a buffer for the decoded output. The buffer is NOT
+ *   reset to allow for consecutive decoding.
  * - (optional) is_encoding_problem is set for invalid byte sequences
  *
- * The return value MAY point to data if data is a C-string and does not
- * contain invalid UTF-8 (but may contain replacement) characters.
  */
-extern const char *jmap_decode_to_utf8(const char *charset, int encoding,
-                                       const char *data, size_t datalen,
-                                       float confidence,
-                                       char **val,
-                                       int *is_encoding_problem);
+extern void jmap_decode_to_utf8(const char *charset, int encoding,
+                                const char *data, size_t datalen,
+                                float confidence,
+                                struct buf *buf,
+                                int *is_encoding_problem);
 
 extern const char *jmap_encode_rawdata_blobid(const char prefix,
                                               const char *mboxid,

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -2416,6 +2416,12 @@ static hash_table attrs_by_name = HASH_TABLE_INITIALIZER;
 static int search_attr_initialized = 0;
 
 static void done_cb(void *rock __attribute__((unused))) {
+    hash_iter *iter = hash_table_iter(&attrs_by_name);
+    while (hash_iter_next(iter)) {
+        struct search_attr *attr = hash_iter_val(iter);
+        if (attr->freeattr) attr->freeattr(attr);
+    }
+    hash_iter_free(&iter);
     free_hash_table(&attrs_by_name, NULL);
 }
 
@@ -2448,6 +2454,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_list_duplicate,
             search_list_free,
+            /*freeattr*/NULL,
             (void *)message_get_bcc
         },{
             "cclist",
@@ -2462,6 +2469,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_list_duplicate,
             search_list_free,
+            /*freeattr*/NULL,
             (void *)message_get_cc
         },{
             "fromlist",
@@ -2476,6 +2484,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_list_duplicate,
             search_list_free,
+            /*freeattr*/NULL,
             (void *)message_get_from
         },{
             "tolist",
@@ -2490,6 +2499,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_list_duplicate,
             search_list_free,
+            /*freeattr*/NULL,
             (void *)message_get_to
         },{
             "bcc",
@@ -2504,6 +2514,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_bcc
         },{
             "deliveredto",
@@ -2518,6 +2529,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_deliveredto
         },{
             "cc",
@@ -2532,6 +2544,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_cc
         },{
             "from",
@@ -2546,6 +2559,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_from
         },{
             "message-id",
@@ -2560,6 +2574,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_messageid
         },{
             "listid",
@@ -2574,6 +2589,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             NULL
         },{
             "contenttype",
@@ -2588,6 +2604,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             NULL
         },{
             "subject",
@@ -2602,6 +2619,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_subject
         },{
             "to",
@@ -2616,6 +2634,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_to
         },{
             "msgno",
@@ -2630,6 +2649,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_msgno
         },{
             "uid",
@@ -2644,6 +2664,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_uid
         },{
             "systemflags",
@@ -2658,6 +2679,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_systemflags
         },{
             "indexflags",
@@ -2672,6 +2694,7 @@ EXPORTED void search_attr_init(void)
             search_indexflags_get_countability,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_indexflags
         },{
             "keyword",
@@ -2686,6 +2709,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             NULL
         },{
             "convflags",
@@ -2700,6 +2724,7 @@ EXPORTED void search_attr_init(void)
             search_convflags_get_countability,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             NULL
         },{
             "allconvflags",
@@ -2714,6 +2739,7 @@ EXPORTED void search_attr_init(void)
             search_convflags_get_countability,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             NULL
         },{
             "convmodseq",
@@ -2728,6 +2754,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             NULL
         },{
             "modseq",
@@ -2742,6 +2769,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_modseq
         },{
             "cid",
@@ -2756,6 +2784,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_cid
         },{
             "emailid",
@@ -2770,6 +2799,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)NULL
         },{
             "threadid",
@@ -2784,6 +2814,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)NULL
         },{
             "folder",
@@ -2798,6 +2829,7 @@ EXPORTED void search_attr_init(void)
             search_folder_get_countability,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)NULL
         },{
             "annotation",
@@ -2812,6 +2844,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_annotation_duplicate,
             search_annotation_free,
+            /*freeattr*/NULL,
             (void *)NULL
         },{
             "size",
@@ -2826,6 +2859,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_size
         },{
             "internaldate",
@@ -2840,6 +2874,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_internaldate
         },{
             "savedate",
@@ -2854,6 +2889,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_savedate
         },{
             "indexversion",
@@ -2868,6 +2904,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_indexversion
         },{
             "sentdate",
@@ -2882,6 +2919,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_sentdate
         },{
             "spamscore",
@@ -2896,6 +2934,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_spamscore
         },{
             "body",
@@ -2910,6 +2949,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)1       /* skipheader flag */
         },{
             "text",
@@ -2924,6 +2964,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)0       /* skipheader flag */
         },{
             "date",
@@ -2938,6 +2979,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             /*duplicate*/NULL,
             /*free*/NULL,
+            /*freeattr*/NULL,
             (void *)message_get_gmtime
         },{
             "location",     /* for iCalendar */
@@ -2952,6 +2994,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)0
         },{
             "attachmentname",
@@ -2966,6 +3009,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)0
         },{
             "attachmentbody",
@@ -2980,6 +3024,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)0       /* skipheader flag */
         },{
             "language",
@@ -2994,6 +3039,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)0
         }, {
             "priority",
@@ -3008,6 +3054,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)message_get_priority
         },{
             "seen",
@@ -3022,6 +3069,7 @@ EXPORTED void search_attr_init(void)
             /*get_countability*/NULL,
             search_string_duplicate,
             search_string_free,
+            /*freeattr*/NULL,
             (void *)0
         }
     };
@@ -3050,6 +3098,12 @@ EXPORTED const search_attr_t *search_attr_find(const char *name)
     return hash_lookup(tmp, &attrs_by_name);
 }
 
+static void field_attr_free(search_attr_t *attr)
+{
+    free((char*)attr->name);
+    free(attr);
+}
+
 /*
  * Find and return a search attribute for the named header field.  Used
  * when building comparison nodes for the HEADER search criterion in a
@@ -3074,6 +3128,7 @@ EXPORTED const search_attr_t *search_attr_find_field(const char *field)
         /*get_countability*/NULL,
         search_string_duplicate,
         search_string_free,
+        field_attr_free,
         NULL
     };
 
@@ -3099,6 +3154,7 @@ EXPORTED const search_attr_t *search_attr_find_field(const char *field)
                    ? SEARCH_COST_CACHE : SEARCH_COST_BODY;
         attr->part = (config_getswitch(IMAPOPT_SEARCH_INDEX_HEADERS)
                         ? SEARCH_PART_HEADERS : -1);
+        attr->freeattr = field_attr_free;
         attr->data1 = strchr(key, ':')+1;
         hash_insert(attr->name, (void *)attr, &attrs_by_name);
         key = NULL;     /* attr takes this over */

--- a/imap/search_expr.h
+++ b/imap/search_expr.h
@@ -101,6 +101,7 @@ struct search_attr {
     unsigned int (*get_countability)(const union search_value *);
     void (*duplicate)(union search_value *, const union search_value *);
     void (*free)(union search_value *);
+    void (*freeattr)(struct search_attr *);
     void *data1;        /* extra data for the functions above */
 };
 

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3273,6 +3273,8 @@ EXPORTED char *charset_encode_mimebody(const char *msg_base, size_t len,
         } else {
             /* byte 3: pad */
             d[2] = '=';
+            /* byte 4: pad */
+            d[3] = '=';
         }
     }
 


### PR DESCRIPTION
This fixes a bunch of memory issues found by valgrind when running the following Cassandane test suites:

- JMAPBackup
- JMAPCalendars
- JMAPContacts
- JMAPCore
- JMAPEmail
- JMAPEmailSubmission
- JMAPMailbox
- JMAPSieve