### PR TITLE
http_caldav.c: skip "mailto:" when comparing ORGANIZERs in components

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -4378,7 +4378,10 @@ static int caldav_put(struct transaction_t *txn, void *obj,
         goto done;
     }
     prop = icalcomponent_get_first_property(comp, ICAL_ORGANIZER_PROPERTY);
-    if (prop) organizer = icalproperty_get_organizer(prop);
+    if (prop) {
+        organizer = icalproperty_get_organizer(prop);
+        if (!strncasecmp(organizer, "mailto:", 7)) organizer += 7;
+    }
 
     /* Also make sure DTEND > DTSTART, and both values have value same type */
     dtend = icalcomponent_get_dtend(comp);
@@ -4414,7 +4417,10 @@ static int caldav_put(struct transaction_t *txn, void *obj,
 
         prop = icalcomponent_get_first_property(nextcomp,
                                                 ICAL_ORGANIZER_PROPERTY);
-        if (prop) nextorg = icalproperty_get_organizer(prop);
+        if (prop) {
+            nextorg = icalproperty_get_organizer(prop);
+            if (!strncasecmp(nextorg, "mailto:", 7)) nextorg += 7;
+        }
         /* if no toplevel organizer, use the one from here */
         if (!organizer && nextorg) organizer = nextorg;
         if (nextorg && strcmp(organizer, nextorg)) {


### PR DESCRIPTION
This fixes a bug where the ORGANIZER in the master component is "MAILTO:foo@example.com" and the ORGANIZER in an override is "mailto:foo@example.com"