### PR TITLE
CalDAV Scheduling busytime query fixes

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -3423,6 +3423,7 @@ static int caldav_post_outbox(struct transaction_t *txn, int rights)
     icalproperty *prop = NULL;
     const char *uid = NULL, *organizer = NULL;
     struct caldav_sched_param sparam;
+    strarray_t schedule_addresses = STRARRAY_INITIALIZER;
 
     /* Check Content-Type */
     if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
@@ -3479,7 +3480,10 @@ static int caldav_post_outbox(struct transaction_t *txn, int rights)
         ret = HTTP_FORBIDDEN;
         goto done;
     }
-    r = caladdress_lookup(organizer, &sparam, NULL); // XXX: this needs to lookup the user's principal
+
+    get_schedule_addresses(txn->req_hdrs, txn->req_tgt.mbentry->name,
+                           txn->req_tgt.userid, &schedule_addresses);
+    r = caladdress_lookup(organizer, &sparam, &schedule_addresses);
     if (r) {
         txn->error.precond = CALDAV_VALID_ORGANIZER;
         ret = HTTP_FORBIDDEN;
@@ -3518,6 +3522,7 @@ static int caldav_post_outbox(struct transaction_t *txn, int rights)
 
   done:
     if (ical) icalcomponent_free(ical);
+    strarray_fini(&schedule_addresses);
 
     return ret;
 }


### PR DESCRIPTION
This fixes 2 bugs:

- The first patch fetches the user's schedule_addresses for comparison against the ORGANIZER property in the request, so we can properly set 'isyou'
- The second patch properly sets the scheduling userid of local users (strip domain from CUA) when virtdomains is disabled or defaultdomain is set

Tested with https://github.com/cyrusimap/cassandane/pull/143