### PR TITLE
Add sessionid field to cmdtimer: logs

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -2453,12 +2453,17 @@ static void cmdloop(void)
         if (commandmintimer && strcmp("idle", cmdname)) {
             double cmdtime, nettime;
             const char *mboxname = index_mboxname(imapd_index);
-            if (!mboxname) mboxname = "<none>";
             cmdtime_endtimer(&cmdtime, &nettime);
             if (cmdtime >= commandmintimerd) {
-                syslog(LOG_NOTICE, "cmdtimer: '%s' '%s' '%s' '%f' '%f' '%f'",
-                    imapd_userid ? imapd_userid : "<none>", cmdname, mboxname,
-                    cmdtime, nettime, cmdtime + nettime);
+                xsyslog(LOG_NOTICE, "cmdtimer",
+                                    "sessionid=<%s> userid=<%s> command=<%s>"
+                                    " mailbox=<%s> cmdtime=<%f> nettime=<%f>"
+                                    " total=<%f>",
+                                    session_id(),
+                                    imapd_userid ? imapd_userid : "",
+                                    cmdname,
+                                    mboxname ? mboxname : "",
+                                    cmdtime, nettime, cmdtime + nettime);
             }
         }
         continue;

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -670,8 +670,8 @@ Blank lines and lines beginning with ``#'' are ignored.
    assumed.  */
 
 { "commandmintimer", NULL, STRING, "2.4.0" }
-/* Time in seconds. Any imap command that takes longer than this
-   time is logged. */
+/* Time in floating point seconds. Any imap command that takes longer than
+   this time is logged. */
 
 { "configdirectory", NULL, STRING, "2.3.17" }
 /* The pathname of the IMAP configuration directory.  This field is


### PR DESCRIPTION
This adds a `sessionid=<...>` field to the "cmdtimer:" log lines, which was requested by @robn in #3592.  I also switched it to xsyslog while I was in there anyway.

I was briefly confused as to why the `commandmintimer` option (which controls this behaviour) was doing its own value parsing, rather than being an OPT_DURATION, until I realised this option accepts a floating point value.  So I also updated the docs for the option to make this clear.

Added a basic test in: https://github.com/cyrusimap/cassandane/pull/144

Since this is also an xsyslog conversion, which we know are prone to subtle typos, please do a build test of this -- in case your compiler catches anything mine didn't.

Thanks!