### PR TITLE
xsyslog: don't log syserror/func fields for LOG_NOTICE/LOG_INFO

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -1088,7 +1088,6 @@ EXPORTED void message_parse_charset_params(const struct param *params,
             if (param->value && *param->value) {
                 charset_t cs = charset_lookupname(param->value);
                 if (cs == CHARSET_UNKNOWN_CHARSET) {
-                    errno = 0;
                     xsyslog(LOG_NOTICE, "unknown charset", "charset=<%s>", param->value);
                     continue;
                 }


### PR DESCRIPTION
This prevents confusion caused when automated diagnostic stuff (especially _wrong_ diagnostic stuff, like leaked errno values) winds up in informational log messages.

So far we've mostly used xsyslog for error conditions, but this makes it a little nicer to use for everything else too.

For whatever it's worth, the full set of syslog log levels is:

- LOG_EMERG      system is unusable
- LOG_ALERT      action must be taken immediately
- LOG_CRIT       critical conditions
- LOG_ERR        error conditions
- LOG_WARNING    warning conditions
- LOG_NOTICE     normal, but significant, condition
- LOG_INFO       informational message
- LOG_DEBUG      debug-level message

And I think we still want syserror=<> and func=<> for all of these, except LOG_NOTICE and LOG_INFO.

This also reverts a commit that was working around the problem by unconditionally resetting errno in one particular place.

Closes #3601 
