### PR TITLE
imapd: don't check index if status on a different mailbox

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -9326,8 +9326,6 @@ static void cmd_status(char *tag, char *name)
 
     /* local mailbox */
 
-    imapd_check(NULL, 0);
-
     c = parse_statusitems(&statusitems, &errstr);
     if (c == EOF) {
         prot_printf(imapd_out, "%s BAD %s\r\n", tag, errstr);
@@ -9351,6 +9349,10 @@ static void cmd_status(char *tag, char *name)
                 IMAP_PERMISSION_DENIED : IMAP_MAILBOX_NONEXISTENT;
         }
     }
+
+    // status of selected mailbox, we need to refresh
+    if (!strcmpsafe(mbentry->name, index_mboxname(imapd_index)))
+        imapd_check(NULL, 0);
 
     if (!r) r = imapd_statusdata(mbentry, statusitems, &sdata);
 


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1708981

The likelyhood that a client is waiting on this data and
won't issue a NOOP or otherwise check for it is much lower
than the likelyhood that the client won't think to look in
the status response to a different mailbox for an update to
the index state.

If we are doing a STATUS on the selected mailbox, we still
need to do the `index_check` though, because that will make
sure the data is up-to-date.

... this passes all the Cassandane tests (ImapTest, Idle and Expunge being the most interesting probably)