### PR TITLE
status: need to not dereference mbentry on error

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -9351,7 +9351,7 @@ static void cmd_status(char *tag, char *name)
     }
 
     // status of selected mailbox, we need to refresh
-    if (!strcmpsafe(mbentry->name, index_mboxname(imapd_index)))
+    if (!r && !strcmpsafe(mbentry->name, index_mboxname(imapd_index)))
         imapd_check(NULL, 0);
 
     if (!r) r = imapd_statusdata(mbentry, statusitems, &sdata);


### PR DESCRIPTION
This fixes a crash when you try to STATUS a folder that doesn't exist, introduced by 6a00f5b0b0402d7023bc7e5e6c0c49d23567c5a8