### PR TITLE
mboxlist: make space for a full 490 character folder name

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -590,7 +590,7 @@ static int mboxlist_parse_entry(mbentry_t **mbentryptr,
 
     if (name) {
       /* copy name */
-        snprintf(mboxname, MAX_MAILBOX_NAME+1, "%.*s",
+        snprintf(mboxname, sizeof(mboxname), "%.*s",
                  (int) (namelen ? namelen : strlen(name)), name);
         mbentry->name = mboxname_from_dbname(mboxname);
     }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -590,7 +590,7 @@ static int mboxlist_parse_entry(mbentry_t **mbentryptr,
 
     if (name) {
       /* copy name */
-        snprintf(mboxname, MAX_MAILBOX_NAME, "%.*s",
+        snprintf(mboxname, MAX_MAILBOX_NAME+1, "%.*s",
                  (int) (namelen ? namelen : strlen(name)), name);
         mbentry->name = mboxname_from_dbname(mboxname);
     }


### PR DESCRIPTION
This caused a problem for a user with a mailbox that's exactly 490 characters long!  The name got trimmed by one character by this function because `snprintf` needs the entire space PLUS an extra byte for the `\0`.  The size to `snprintf` should be the entire size of the buffer, not one fewer.

```
       The functions snprintf() and vsnprintf() write at most size bytes (including the terminating null byte ('\0')) to str.
```

This fixes the broken user sync.