### PR TITLE
Quota rename

### DIFF
--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -754,43 +754,7 @@ static void test_delete(void)
                mailbox->uniqueid[0], mailbox->uniqueid[1], mailbox->uniqueid);
     CU_ASSERT_EQUAL(fexists(buf_cstring(&path)), 0);
     mailbox_close(&mailbox);
-
-    /* delete all the entries associated with the mailbox */
-
-    r = mailbox_open_iwl(MBOXNAME1_INT, &mailbox);
-    CU_ASSERT_EQUAL_FATAL(r, 0);
-
-    r = annotate_delete_mailbox(mailbox);
-    CU_ASSERT_EQUAL(r, 0);
-
-    CU_ASSERT_EQUAL(fexists(buf_cstring(&path)), -ENOENT);
-
-    /* check that the values are gone */
-
-    r = annotatemore_msg_lookup(mailbox, 0, COMMENT, /*userid*/"", &val2);
-    CU_ASSERT_EQUAL_FATAL(r, 0);
-    CU_ASSERT_PTR_NULL_FATAL(val2.s);
-    buf_free(&val2);
-
-    r = annotatemore_msg_lookup(mailbox, 1, COMMENT, /*userid*/"", &val2);
-    CU_ASSERT_EQUAL_FATAL(r, 0);
-    CU_ASSERT_PTR_NULL_FATAL(val2.s);
-    buf_free(&val2);
-
-    r = annotatemore_msg_lookup(mailbox, 3, COMMENT, /*userid*/"", &val2);
-    CU_ASSERT_EQUAL_FATAL(r, 0);
-    CU_ASSERT_PTR_NULL_FATAL(val2.s);
-    buf_free(&val2);
-
-    annotatemore_close();
-
-    CU_ASSERT_EQUAL(fexists(buf_cstring(&path)), -ENOENT);
-    buf_free(&path);
-
-    strarray_fini(&entries);
-    strarray_fini(&attribs);
     buf_free(&val);
-    mailbox_close(&mailbox);
 }
 
 static void test_rename(void)

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -4058,18 +4058,9 @@ EXPORTED int annotate_delete_mailbox(struct mailbox *mailbox)
                               /*newuid*/0, /*newuserid*/NULL,
                               /*copy*/0);
         if (r && r != IMAP_MAILBOX_NONEXISTENT) goto out;
+
+        r = annotate_commit(d);
     }
-
-    /* remove the entire per-folder database */
-    r = annotate_dbname_mailbox(mailbox, &fname);
-    if (r) goto out;
-
-    /* (gnb)TODO: do we even need to do this?? */
-    if (unlink(fname) < 0 && errno != ENOENT) {
-        syslog(LOG_ERR, "cannot unlink %s: %m", fname);
-    }
-
-    r = annotate_commit(d);
 
 out:
     annotate_putdb(&d);

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -83,6 +83,8 @@ int caladdress_lookup(const char *addr, struct caldav_sched_param *param,
     const char *userid = addr;
     int i;
 
+    memset(param, 0, sizeof(struct caldav_sched_param));
+
     if (!addr) return HTTP_NOT_FOUND;
 
     if (!strncasecmp(userid, "mailto:", 7)) userid += 7;
@@ -92,8 +94,6 @@ int caladdress_lookup(const char *addr, struct caldav_sched_param *param,
            "caladdress_lookup(userid: '%s', schedule_addresses: '%s')",
            userid, addresses);
     free(addresses);
-
-    memset(param, 0, sizeof(struct caldav_sched_param));
 
     param->userid = xstrdup(userid);
 
@@ -829,6 +829,8 @@ int sched_busytime_query(struct transaction_t *txn,
     else
         org_authstate = auth_newstate(sparam.userid);
 
+    sched_param_fini(&sparam);
+
     /* Start construction of our schedule-response */
     if (!(root =
           init_xml_response("schedule-response",
@@ -1002,6 +1004,8 @@ int sched_busytime_query(struct transaction_t *txn,
 
             icalproperty_free(prop);
         }
+
+        sched_param_fini(&sparam);
     }
 
     buf_reset(&txn->buf);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7875,6 +7875,13 @@ submboxes:
         r = mboxlist_allmbox(oldmailboxname, renmbox, &rock, MBOXTREE_INTERMEDIATES);
     }
 
+
+    /* take care of deleting old quotas */
+    if (!r && rename_user) {
+        user_deletequotaroots(olduser);
+        sync_log_unuser(olduser);
+    }
+
     /* take care of intermediaries */
     mboxlist_update_intermediaries(oldmailboxname, mbtype, 0);
     mboxlist_update_intermediaries(newmailboxname, mbtype, 0);

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -536,15 +536,15 @@ static int recreate_resource(message_t *msg, struct mailbox *tomailbox,
 
         if (r) append_abort(&as);
         else {
-            r = append_commit(&as);
             /* If this resource was previously destroyed
                (not replaced by an update) we need to bump the deletedmodseq
                since we will no longer be able to differentiate between
                whether this resource has just been created or updated */
-            if (!r && !is_update && record->modseq > tomailbox->i.deletedmodseq) {
+            if (!is_update && record->modseq > tomailbox->i.deletedmodseq) {
                 tomailbox->i.deletedmodseq = record->modseq;
                 mailbox_index_dirty(tomailbox);
             }
+            r = append_commit(&as);
         }
     }
     append_removestage(stage);

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1474,7 +1474,9 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
         return r;
     }
 
-    mailbox_user_flag(mailbox, "$restored", &userflag, 0);
+    // if there's a flag named "$restored", we'll remove it from every
+    // message and then from the mailbox itself if not in DRYRUN
+    mailbox_user_flag(mailbox, "$restored", &userflag, /*create*/0);
 
     struct mailbox_iter *iter = mailbox_iter_init(mailbox, 0, 0);
     while ((msg = mailbox_iter_step(iter))) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6947,8 +6947,9 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
         record->user_flags[i] &= valid_user_flags[i];
     }
 
-    /* check if the snoozed status matches */
-    if (!!(record->internal_flags & FLAG_INTERNAL_SNOOZED) != !!has_snoozedannot) {
+    /* check if the snoozed status matches (unless expunged, which shouldn't be snoozed) */
+    if (!(record->internal_flags & FLAG_INTERNAL_EXPUNGED)
+      && !!(record->internal_flags & FLAG_INTERNAL_SNOOZED) != !!has_snoozedannot) {
         printf("%s uid %u snoozed mismatch\n", mailbox_name(mailbox), record->uid);
         syslog(LOG_ERR, "%s uid %u snoozed mismatch", mailbox_name(mailbox), record->uid);
         if (has_snoozedannot) record->internal_flags |= FLAG_INTERNAL_SNOOZED;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -7895,9 +7895,13 @@ HIDDEN int mailbox_changequotaroot(struct mailbox *mailbox,
     if (mailbox->quotaroot) {
         quota_t quota_diff[QUOTA_NUMRESOURCES];
 
-        if (root && strlen(mailbox->quotaroot) >= strlen(root)) {
-            /* Part of a child quota root - skip */
-            goto done;
+        if (root) {
+            size_t len = strlen(root);
+            if (strlen(mailbox->quotaroot) >= len && !strncmp(mailbox->quotaroot, root, len) &&
+                (mailbox->quotaroot[len] == '\0' || mailbox->quotaroot[len] == '.')) {
+                    /* Part of a child quota root - skip */
+                    goto done;
+            }
         }
 
         /* remove usage from the old quotaroot */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2001,8 +2001,8 @@ static int mailbox_buf_to_index_record(const char *buf, int version,
     stored_system_flags = ntohl(*((bit32 *)(buf+OFFSET_SYSTEM_FLAGS)));
 
     /* de-serialise system flags and internal flags */
-    record->system_flags = stored_system_flags & 0x000000ff;
-    record->internal_flags = stored_system_flags & 0xff000000;
+    record->system_flags = stored_system_flags & 0x0000ffff;
+    record->internal_flags = stored_system_flags & 0xffff0000;
 
     for (n = 0; n < MAX_USER_FLAGS/32; n++) {
         record->user_flags[n] = ntohl(*((bit32 *)(buf+OFFSET_USER_FLAGS+4*n)));

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -400,6 +400,13 @@ typedef enum _MsgFlags {
     FLAG_SEEN               = (1<<4),
 } MsgFlags;
 
+/* NOTE: you can only use up to 1<<15 for MsgFlags and down to 1<<16 for
+ * InternalFlags unless you change the code in mailbox_buf_to_index_record
+ * which is currently:
+ *     record->system_flags = stored_system_flags & 0x0000ffff;
+ *     record->internal_flags = stored_system_flags & 0xffff0000;
+ */
+
 typedef enum _MsgInternalFlags {
     FLAG_INTERNAL_SNOOZED            = (1<<26),
     FLAG_INTERNAL_SPLITCONVERSATION  = (1<<27),

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -417,11 +417,6 @@ typedef enum _MsgInternalFlags {
 } MsgInternalFlags;
 
 #define FLAGS_SYSTEM   (FLAG_ANSWERED|FLAG_FLAGGED|FLAG_DELETED|FLAG_DRAFT|FLAG_SEEN)
-#define FLAGS_INTERNAL (FLAG_INTERNAL_SPLITCONVERSATION |       \
-                        FLAG_INTERNAL_NEEDS_CLEANUP |           \
-                        FLAG_INTERNAL_ARCHIVED |                \
-                        FLAG_INTERNAL_UNLINKED |                \
-                        FLAG_INTERNAL_EXPUNGED)
 
 #define OPT_POP3_NEW_UIDL (1<<0)        /* added for Outlook stupidity */
 /* NOTE: not used anymore - but don't reuse it */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3530,7 +3530,7 @@ EXPORTED int mboxlist_allmbox(const char *prefix, mboxlist_cb *proc, void *rock,
 
     init_internal();
 
-    if (!prefix) prefix = "";
+    if (!prefix || !*prefix) prefix = "";
     else {
         mbname_t *mbname = mbname_from_intname(prefix);
         if (prefix[strlen(prefix)-1] == '.') {

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -172,6 +172,7 @@ EXPORTED void mboxlist_entry_free(mbentry_t **mbentryptr)
 
     former_name_t *fname;
     while ((fname = ptrarray_pop(&mbentry->name_history))) {
+        free(fname->name);
         free(fname);
     }
     ptrarray_fini(&mbentry->name_history);
@@ -1061,6 +1062,7 @@ static int mboxlist_update_entry(const char *name,
                     former_name_t *fname = ptrarray_shift(&oldid->name_history);
                     add_former_name(name_history, fname->name,
                                     fname->mtime, fname->foldermodseq);
+                    free(fname->name);
                     free(fname);
                 }
 

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -128,7 +128,7 @@ struct mboxlist_entry {
 typedef struct mboxlist_entry mbentry_t;
 
 typedef struct {
-    char dbname[MAX_MAILBOX_NAME+1];
+    char *name;
     modseq_t foldermodseq;
     time_t mtime;
 } former_name_t;

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2306,8 +2306,8 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
             if (!r) {
                 int i;
                 for (i = 0; i < ptrarray_size(&mbentry_byid->name_history); i++) {
-                    const former_name_t *fname = ptrarray_nth(&mbentry_byid->name_history, i);
-                    char *olduserid = mboxname_to_userid(fname->name);
+                    const former_name_t *histitem = ptrarray_nth(&mbentry_byid->name_history, i);
+                    char *olduserid = mboxname_to_userid(histitem->name);
                     char *oldinboxname = mboxname_user_mbox(olduserid, NULL);
                     r = mboxlist_lookup_allow_all(oldinboxname, &mbentry, NULL);
                     free(oldinboxname);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2319,7 +2319,7 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
             mboxlist_entry_free(&mbentry_byname);
         }
 
-        if (!r && !(mbentry->mbtype & MBTYPE_LEGACY_DIRS)) {
+        if (!r && mbentry && mbentry->uniqueid && !(mbentry->mbtype & MBTYPE_LEGACY_DIRS)) {
             fname = mboxid_conf_getpath(mbentry->uniqueid, suffix);
         }
 

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2292,11 +2292,32 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
     char *fname = NULL;
 
     if (mbname->localpart) {
-        char *mboxname = mboxname_user_mbox(mbname_userid(mbname), NULL);
+        char *inboxname = mboxname_user_mbox(mbname_userid(mbname), NULL);
         mbentry_t *mbentry = NULL;
+        int r = mboxlist_lookup_allow_all(inboxname, &mbentry, NULL);
+        free(inboxname);
 
-        int r = mboxlist_lookup_allow_all(mboxname, &mbentry, NULL);
-        free(mboxname);
+        if (r == IMAP_MAILBOX_NONEXISTENT) {
+            // look for the INBOX of previous names in order to see if we're mid-rename
+            mbentry_t *mbentry_byname = NULL;
+            mbentry_t *mbentry_byid = NULL;
+            r = mboxlist_lookup_allow_all(mbname_intname(mbname), &mbentry_byname, NULL);
+            if (!r) r = mboxlist_lookup_by_uniqueid(mbentry_byname->uniqueid, &mbentry_byid, NULL);
+            if (!r) {
+                int i;
+                for (i = 0; i < ptrarray_size(&mbentry_byid->name_history); i++) {
+                    const former_name_t *fname = ptrarray_nth(&mbentry_byid->name_history, i);
+                    char *olduserid = mboxname_to_userid(fname->name);
+                    char *oldinboxname = mboxname_user_mbox(olduserid, NULL);
+                    r = mboxlist_lookup_allow_all(oldinboxname, &mbentry, NULL);
+                    free(oldinboxname);
+                    free(olduserid);
+                    if (r != IMAP_MAILBOX_NONEXISTENT) break;
+                }
+            }
+            mboxlist_entry_free(&mbentry_byid);
+            mboxlist_entry_free(&mbentry_byname);
+        }
 
         if (!r && !(mbentry->mbtype & MBTYPE_LEGACY_DIRS)) {
             fname = mboxid_conf_getpath(mbentry->uniqueid, suffix);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2301,9 +2301,9 @@ EXPORTED char *mboxname_conf_getpath(const mbname_t *mbname, const char *suffix)
             // look for the INBOX of previous names in order to see if we're mid-rename
             mbentry_t *mbentry_byname = NULL;
             mbentry_t *mbentry_byid = NULL;
-            r = mboxlist_lookup_allow_all(mbname_intname(mbname), &mbentry_byname, NULL);
-            if (!r) r = mboxlist_lookup_by_uniqueid(mbentry_byname->uniqueid, &mbentry_byid, NULL);
-            if (!r) {
+            int r2 = mboxlist_lookup_allow_all(mbname_intname(mbname), &mbentry_byname, NULL);
+            if (!r2) r2 = mboxlist_lookup_by_uniqueid(mbentry_byname->uniqueid, &mbentry_byid, NULL);
+            if (!r2) {
                 int i;
                 for (i = 0; i < ptrarray_size(&mbentry_byid->name_history); i++) {
                     const former_name_t *histitem = ptrarray_nth(&mbentry_byid->name_history, i);

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -460,6 +460,10 @@ static int fixquota_dombox(const mbentry_t *mbentry, void *rock)
     int thisquota = -1;
     struct txn *txn = NULL;
 
+    // skip mailbox types that we don't look at
+    if (mbentry->mbtype & MBTYPE_REMOTE) return 0;
+    if (mbentry->mbtype & MBTYPE_INTERMEDIATE) return 0;
+
     test_sync_wait(mbentry->name);
 
     r = findroot(mbentry->name, &thisquota);

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -456,6 +456,9 @@ static int do_reconstruct(struct findall_data *data, void *rock)
     /* ignore intermediates */
     if ((data->mbentry->mbtype & MBTYPE_INTERMEDIATE))
         return 0;
+    /* ignore remote */
+    if ((data->mbentry->mbtype & MBTYPE_REMOTE))
+        return 0;
 
     signals_poll();
 

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -1251,6 +1251,13 @@ static int upgrade(const char *userid)
     }
 
 out:
+    strarray_free(active);
+    strarray_free(activedirs);
+    strarray_free(activetiers);
+    if (activefile) {
+        mappedfile_unlock(activefile);
+        mappedfile_close(&activefile);
+    }
     mailbox_close(&inbox);
     free(inboxname);
     buf_free(&buf);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -6363,6 +6363,7 @@ static int do_folders(struct sync_client_state *sync_cs,
             r = mboxlist_lookup_allow_all(rfolder->name, &tombstone, NULL);
 
             if (r == 0 && (tombstone->mbtype & MBTYPE_DELETED) == MBTYPE_DELETED) {
+                mboxlist_entry_free(&tombstone);
                 r = sync_do_folder_delete(sync_cs, rfolder->name);
                 if (r) {
                     syslog(LOG_ERR, "sync_do_folder_delete(): failed: %s '%s'",
@@ -6371,6 +6372,7 @@ static int do_folders(struct sync_client_state *sync_cs,
                 }
             }
             else {
+                mboxlist_entry_free(&tombstone);
                 syslog(LOG_ERR, "%s: no tombstone for deleted mailbox %s (%s)",
                                 __func__, rfolder->name, error_message(r));
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3264,12 +3264,10 @@ out:
 
 static int sync_mailbox_byuniqueid(const char *uniqueid, void *rock)
 {
-    char *name = mboxlist_find_uniqueid(uniqueid, NULL, NULL);
     mbentry_t *mbentry = NULL;
-    int r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
+    int r = mboxlist_lookup_by_uniqueid(uniqueid, &mbentry, NULL);
     if (!r) r = sync_mailbox_byentry(mbentry, rock);
     mboxlist_entry_free(&mbentry);
-    free(name);
     return r;
 }
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -7297,6 +7297,19 @@ static void split_user_mailboxes(const char *key __attribute__((unused)),
             continue;
 
         sync_name_list_add(mboxname_list, action->name);
+        mbentry_t *mbentry_byname = NULL;
+        mbentry_t *mbentry_byid = NULL;
+        int r = mboxlist_lookup_allow_all(action->name, &mbentry_byname, NULL);
+        if (!r) r = mboxlist_lookup_by_uniqueid(mbentry_byname->uniqueid, &mbentry_byid, NULL);
+        if (!r) {
+            int i;
+            for (i = 0; i < ptrarray_size(&mbentry_byid->name_history); i++) {
+                const former_name_t *fname = ptrarray_nth(&mbentry_byid->name_history, i);
+                sync_name_list_add(mboxname_list, fname->name);
+            }
+        }
+        mboxlist_entry_free(&mbentry_byid);
+        mboxlist_entry_free(&mbentry_byname);
     }
 
     if (mboxname_list->count) {

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -7306,8 +7306,8 @@ static void split_user_mailboxes(const char *key __attribute__((unused)),
         if (!r) {
             int i;
             for (i = 0; i < ptrarray_size(&mbentry_byid->name_history); i++) {
-                const former_name_t *fname = ptrarray_nth(&mbentry_byid->name_history, i);
-                sync_name_list_add(mboxname_list, fname->name);
+                const former_name_t *histitem = ptrarray_nth(&mbentry_byid->name_history, i);
+                sync_name_list_add(mboxname_list, histitem->name);
             }
         }
         mboxlist_entry_free(&mbentry_byid);

--- a/imap/user.c
+++ b/imap/user.c
@@ -564,7 +564,7 @@ static int find_cb(void *rockp __attribute__((unused)),
     return r;
 }
 
-int user_deletequotaroots(const char *userid)
+EXPORTED int user_deletequotaroots(const char *userid)
 {
     char *inbox = mboxname_user_mbox(userid, NULL);
     int r = quotadb_foreach(inbox, strlen(inbox), &find_p, &find_cb, inbox);


### PR DESCRIPTION
This fixes the issues identified by:  https://github.com/cyrusimap/cassandane/pull/146

There's also a bunch of other small improvements to the safety and behaviour of renames in uuidland, including:

* you can rename a subfolder, and it will still detect the right INBOX
* per-mailbox annotations won't get nerfed
* replication will detect and repair renamed folders so long as the change happened on the master first