### PR TITLE
Fix fromAnyContact Email filters to work with shared addressbooks

### DIFF
--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -688,7 +688,7 @@ static int groupmembers_cb(sqlite3_stmt *stmt, void *rock)
 
 EXPORTED strarray_t *carddav_getgroup(struct carddav_db *carddavdb,
                                       const mbentry_t *mbentry, const char *group,
-                                      mbname_t *othermb)
+                                      const mbentry_t *othermb)
 {
     int r = 0;
     int isshared = 0;
@@ -703,12 +703,17 @@ EXPORTED strarray_t *carddav_getgroup(struct carddav_db *carddavdb,
     const char *mailbox = !mbentry ? NULL :
         (carddavdb->db->version >= DB_MBOXID_VERSION) ?
         mbentry->uniqueid : mbentry->name;
+
+    const char *othermailbox = !othermb ? NULL :
+        (carddavdb->db->version >= DB_MBOXID_VERSION) ?
+        othermb->uniqueid : othermb->name;
+
     struct sqldb_bindval bval[] = {
         { ":mailbox",      SQLITE_TEXT,    { .s = mailbox } },
         { ":group",        SQLITE_TEXT,    { .s = group   } },
         { ":kind",         SQLITE_INTEGER, { .i = CARDDAV_KIND_GROUP } },
-        { ":otheruser",    SQLITE_TEXT,    { .s = othermb ? mbname_userid(othermb) : NULL } },
-        { ":othermailbox", SQLITE_TEXT,    { .s = othermb ? mbname_intname(othermb) : NULL } },
+        { ":otheruser",    SQLITE_TEXT,    { .s = othermailbox } },
+        { ":othermailbox", SQLITE_TEXT,    { .s = othermailbox } },
         { NULL,            SQLITE_NULL,    { .s = NULL    } }
     };
 

--- a/imap/carddav_db.h
+++ b/imap/carddav_db.h
@@ -130,7 +130,7 @@ strarray_t *carddav_getuid2groups(struct carddav_db *carddavdb, const char *key,
    returns emails of its members (if any) */
 strarray_t *carddav_getgroup(struct carddav_db *carddavdb,
                              const mbentry_t *mbentry, const char *group,
-                             mbname_t *othermb);
+                             const mbentry_t *othermb);
 
 /* get a list of groups the given uid is a member of */
 strarray_t *carddav_getuid_groups(struct carddav_db *carddavdb, const char *uid);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2247,7 +2247,8 @@ static int emailsearch_normalise(search_expr_t **rootp, int *is_imapfolderptr)
 static void _email_contactfilter_initreq(jmap_req_t *req, struct email_contactfilter *cfilter)
 {
     const char *addressbookid = json_string_value(json_object_get(req->args, "addressbookId"));
-    jmap_email_contactfilter_init(req->accountid, addressbookid, cfilter);
+    jmap_email_contactfilter_init(req->accountid, req->authstate,
+            &jmap_namespace, addressbookid, cfilter);
 }
 
 static void _email_parse_filter_cb(jmap_req_t *req,
@@ -13464,8 +13465,9 @@ static int jmap_email_matchmime_method(jmap_req_t *req)
     struct buf mime = BUF_INITIALIZER;
     buf_setcstr(&mime, json_string_value(jmime));
     matchmime_t *matchmime = jmap_email_matchmime_new(&mime, &err);
-    int matches = matchmime ? jmap_email_matchmime(matchmime, jfilter,
-            req->cstate, req->accountid, time(NULL), &err) : 0;
+    int matches = matchmime ? jmap_email_matchmime(matchmime, jfilter, 
+            req->cstate, req->accountid,
+            req->authstate, &jmap_namespace, time(NULL), &err) : 0;
     jmap_email_matchmime_free(&matchmime);
     buf_free(&mime);
     if (!err) {

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -604,6 +604,7 @@ static xapian_query_t *_email_matchmime_contactgroup(const char *groupid,
                 xq = xapian_query_new_compound(db, /*is_or*/1,
                         (xapian_query_t **) xsubqs.data, xsubqs.count);
             }
+            ptrarray_fini(&xsubqs);
         }
     }
     if (!xq) {

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -106,11 +106,15 @@ static int _email_threadkeyword_is_valid(const char *keyword)
 #include "times.h"
 
 HIDDEN void jmap_email_contactfilter_init(const char *accountid,
+                                          const struct auth_state *authstate,
+                                          const struct namespace *namespace,
                                           const char *addressbookid,
                                           struct email_contactfilter *cfilter)
 {
     memset(cfilter, 0, sizeof(struct email_contactfilter));
     cfilter->accountid = accountid;
+    cfilter->authstate = authstate;
+    cfilter->namespace = namespace;
     if (addressbookid) {
         cfilter->addrbook = carddav_mboxname(accountid, addressbookid);
     }
@@ -126,33 +130,37 @@ HIDDEN void jmap_email_contactfilter_fini(struct email_contactfilter *cfilter)
 }
 
 
-static int _get_sharedaddressbook_cb(const mbentry_t *mbentry, void *rock)
+static int _get_sharedaddressbook_cb(struct findall_data *data, void *rock)
 {
-    mbname_t **mbnamep = rock;
-    if (!mbentry) return 0;
-    if (!(mbentry->mbtype & MBTYPE_ADDRESSBOOK)) return 0;
-    mbname_t *mbname = mbname_from_intname(mbentry->name);
-    if (!strcmpsafe(strarray_nth(mbname_boxes(mbname), -1), "Shared")) {
-        *mbnamep = mbname;
-        return CYRUSDB_DONE;
-    }
-    mbname_free(&mbname);
-    return 0;
+    mbentry_t **mbentryp = rock;
+    if (!data || !data->mbentry) return 0;
+    *mbentryp = mboxlist_entry_copy(data->mbentry);
+    return CYRUSDB_DONE;
 }
 
-
-static mbname_t *_get_sharedaddressbookuser(const char *userid)
+static mbentry_t *_get_sharedaddressbook(const char *userid,
+                                         const struct auth_state *authstate,
+                                         const struct namespace *namespace)
 {
-    mbname_t *res = NULL;
-    int flags = MBOXTREE_PLUS_RACL|MBOXTREE_SKIP_ROOT|MBOXTREE_SKIP_CHILDREN;
-    // XXX - do we need to pass req->authstate right through??
-    int r = mboxlist_usermboxtree(userid, NULL, _get_sharedaddressbook_cb, &res, flags);
-    if (r == CYRUSDB_DONE)
-        return res;
-    mbname_free(&res);
-    return NULL;
-}
+    mbentry_t *res = NULL;
 
+    strarray_t patterns = STRARRAY_INITIALIZER;
+    struct buf pattern = BUF_INITIALIZER;
+    buf_setcstr(&pattern, "user");
+    buf_putc(&pattern, namespace->hier_sep);
+    buf_putc(&pattern, '*');
+    buf_putc(&pattern, namespace->hier_sep);
+    buf_appendcstr(&pattern, config_getstring(IMAPOPT_ADDRESSBOOKPREFIX));
+    buf_putc(&pattern, namespace->hier_sep);
+    buf_appendcstr(&pattern, "Shared");
+    buf_cstring(&pattern);
+    strarray_appendm(&patterns, buf_release(&pattern));
+    mboxlist_findallmulti((struct namespace*)namespace, &patterns, 0, userid,
+            authstate, _get_sharedaddressbook_cb, &res);
+    strarray_fini(&patterns);
+
+    return res;
+}
 
 static const struct contactfilters_t {
     const char *field;
@@ -175,7 +183,7 @@ HIDDEN int jmap_email_contactfilter_from_filtercondition(struct jmap_parser *par
 {
     int havefield = 0;
     const struct contactfilters_t *c;
-    mbname_t *othermb = NULL;
+    mbentry_t *othermb = NULL;
     int r = 0;
 
     /* prefilter to see if there are any fields that we will need to look up */
@@ -206,11 +214,13 @@ HIDDEN int jmap_email_contactfilter_from_filtercondition(struct jmap_parser *par
         }
     }
 
-    othermb = _get_sharedaddressbookuser(cfilter->accountid);
+    othermb = _get_sharedaddressbook(cfilter->accountid, cfilter->authstate, cfilter->namespace);
     if (othermb) {
-        int r2 = carddav_set_otheruser(cfilter->carddavdb, mbname_userid(othermb));
+        mbname_t *mbname = mbname_from_intname(othermb->name);
+        int r2 = carddav_set_otheruser(cfilter->carddavdb, mbname_userid(mbname));
         if (r2) syslog(LOG_NOTICE, "DBNOTICE: failed to open otheruser %s contacts for %s",
-                 mbname_userid(othermb), cfilter->accountid);
+                 mbname_userid(mbname), cfilter->accountid);
+        mbname_free(&mbname);
     }
 
     /* fetch members for each filter referenced */
@@ -239,7 +249,7 @@ HIDDEN int jmap_email_contactfilter_from_filtercondition(struct jmap_parser *par
     }
 
 done:
-    mbname_free(&othermb);
+    mboxlist_entry_free(&othermb);
     return r;
 }
 
@@ -1255,6 +1265,8 @@ HIDDEN int jmap_email_matchmime(matchmime_t *matchmime,
                                 json_t *jfilter,
                                 struct conversations_state *cstate,
                                 const char *accountid,
+                                const struct auth_state *authstate,
+                                const struct namespace *namespace,
                                 time_t internaldate,
                                 json_t **err)
 {
@@ -1281,7 +1293,7 @@ HIDDEN int jmap_email_matchmime(matchmime_t *matchmime,
     jmap_email_filter_parse(jfilter, &parse_ctx);
 
     /* Gather contactgroup ids */
-    jmap_email_contactfilter_init(accountid, /*addressbookid*/NULL, &cfilter);
+    jmap_email_contactfilter_init(accountid, authstate, namespace, NULL, &cfilter);
     ptrarray_t work = PTRARRAY_INITIALIZER;
     ptrarray_push(&work, jfilter);
     json_t *jf;

--- a/imap/jmap_mail_query.h
+++ b/imap/jmap_mail_query.h
@@ -55,6 +55,7 @@
 
 #include <time.h>
 
+#include "auth.h"
 #include "hash.h"
 #include "ptrarray.h"
 
@@ -64,12 +65,16 @@
 
 struct email_contactfilter {
     const char *accountid;
+    const struct auth_state *authstate;
+    const struct namespace *namespace;
     struct carddav_db *carddavdb;
     char *addrbook;
     hash_table contactgroups; /* maps groupid to emails (strarray) */
 };
 
 extern void jmap_email_contactfilter_init(const char *accountid,
+                                          const struct auth_state *authstate,
+                                          const struct namespace *namespace,
                                           const char *addressbookid,
                                           struct email_contactfilter *cfilter);
 extern void jmap_email_contactfilter_fini(struct email_contactfilter *cfilter);
@@ -133,6 +138,8 @@ extern int jmap_email_matchmime(matchmime_t *matchmime,
                                 json_t *jfilter,
                                 struct conversations_state *cstate,
                                 const char *accountid,
+                                const struct auth_state *authstate,
+                                const struct namespace *ns,
                                 time_t internaldate,
                                 json_t **err);
 

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1634,8 +1634,11 @@ static int jmapquery(void *ic, void *sc, void *mc, const char *json)
 
     /* Run query */
     if (md->content.matchmime)
-        matches = jmap_email_matchmime(md->content.matchmime, jfilter,
-                                       ctx->cstate, userid, time(NULL), &err);
+        matches = jmap_email_matchmime(md->content.matchmime,
+                                       jfilter, ctx->cstate, userid,
+                                       sd->authstate,
+                                       sd->ns,
+                                       time(NULL), &err);
 
     if (err) {
         char *errstr = json_dumps(err, JSON_COMPACT);

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1846,8 +1846,8 @@ static int jmapquery(void *ic, void *sc, void *mc, const char *json)
 
     /* Run query */
     if (content->matchmime && !err)
-        matches = jmap_email_matchmime(content->matchmime, jfilter,
-                ctx->cstate, userid, time(NULL), &err);
+        matches = jmap_email_matchmime(content->matchmime, jfilter, ctx->cstate, userid,
+                sd->authstate, sd->ns, time(NULL), &err);
 
     if (err) {
         const char *type = json_string_value(json_object_get(err, "type"));

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -83,6 +83,9 @@
 
 static char vacation_answer;
 
+/* current namespace */
+static struct namespace test_namespace;
+
 typedef struct {
     char *name;
     FILE *data;
@@ -100,6 +103,8 @@ typedef struct {
     const char *host;
     const char *remotehost;
     const char *remoteip;
+    struct auth_state *authstate;
+    struct namespace *ns;
     int edited_header;
 } script_data_t;
 
@@ -649,7 +654,7 @@ int main(int argc, char *argv[])
     static strarray_t e_from = STRARRAY_INITIALIZER;
     static strarray_t e_to = STRARRAY_INITIALIZER;
     char *alt_config = NULL;
-    script_data_t sd = { NULL, NULL, "", NULL, 0 };
+    script_data_t sd = { NULL, NULL, "", NULL, NULL, NULL, 0 };
     FILE *f;
 
     /* prevent crashes if -e or -t aren't specified */
@@ -706,6 +711,11 @@ int main(int argc, char *argv[])
 
     /* Load configuration file. */
     config_read(alt_config, 0);
+
+    mboxname_init_namespace(&test_namespace, /*isadmin*/0);
+    sd.ns = &test_namespace;
+    // anyone authstate
+    sd.authstate = auth_newstate("anyone");
 
     if (!sd.host) sd.host = config_servername;
 
@@ -859,6 +869,7 @@ int main(int argc, char *argv[])
         free_msg(m);
     strarray_fini(&e_from);
     strarray_fini(&e_to);
+    auth_freestate(sd.authstate);
 
     return 0;
 }

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -597,8 +597,8 @@ static int jmapquery(void *ic __attribute__((unused)), void *sc, void *mc, const
 
     /* Run query */
     if (md->content.matchmime)
-        matches = jmap_email_matchmime(md->content.matchmime, jfilter,
-                NULL, userid, time(NULL), &err);
+        matches = jmap_email_matchmime(md->content.matchmime, jfilter, NULL, userid,
+                sd->authstate, sd->ns, time(NULL), &err);
 
     if (err) {
         char *errstr = json_dumps(err, JSON_COMPACT);


### PR DESCRIPTION
The Cyrus JMAP email extension supports lookup of emails, where a sender (recipient) may match any contact of that user, including shared addressbooks. However, shared addressbook lookup was broken, both because

- the carddav API was still using mailboxnames for lookup
- the shared addressbook routines where missing an authstate