### PR TITLE
ptloader valgrind fixes

### DIFF
--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -1154,7 +1154,7 @@ static int ptsmodule_make_authstate_attribute(
 
             *dsize = sizeof(struct auth_state) +
                 (numvals * sizeof(struct auth_ident));
-            *newstate = xmalloc(*dsize);
+            *newstate = xzmalloc(*dsize);
             if (*newstate == NULL) {
                 *reply = "no memory";
                 rc = PTSM_FAIL;
@@ -1188,7 +1188,7 @@ static int ptsmodule_make_authstate_attribute(
                 if (numvals == 1) {
                     if(!*newstate) {
                         *dsize = sizeof(struct auth_state);
-                        *newstate = xmalloc(*dsize);
+                        *newstate = xzmalloc(*dsize);
 
                         if (*newstate == NULL) {
                             *reply = "no memory";
@@ -1212,7 +1212,7 @@ static int ptsmodule_make_authstate_attribute(
 
     if(!*newstate) {
         *dsize = sizeof(struct auth_state);
-        *newstate = xmalloc(*dsize);
+        *newstate = xzmalloc(*dsize);
         if (*newstate == NULL) {
             *reply = "no memory";
             rc = PTSM_FAIL;
@@ -1306,7 +1306,7 @@ static int ptsmodule_make_authstate_filter(
 
     *dsize = sizeof(struct auth_state) + (n * sizeof(struct auth_ident));
 
-    *newstate = xmalloc(*dsize);
+    *newstate = xzmalloc(*dsize);
 
     if (*newstate == NULL) {
         *reply = "no memory";
@@ -1525,7 +1525,7 @@ static int ptsmodule_make_authstate_group(
 
     *dsize = sizeof(struct auth_state) +
              (n * sizeof(struct auth_ident));
-    *newstate = xmalloc(*dsize);
+    *newstate = xzmalloc(*dsize);
     if (*newstate == NULL) {
         *reply = "no memory";
         rc = PTSM_FAIL;

--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -1489,20 +1489,16 @@ static int ptsmodule_make_authstate_group(
                 }
             }
         }
-    } else {
-        rc = ptsmodule_expand_tokens(ptsm->group_base, canon_id, NULL, &base);
-        if (rc != PTSM_OK)
-            goto done;
     }
 
-    syslog(LOG_DEBUG, "(groups) about to search %s for %s", base, filter);
-
-
+    /* XXX i guess canon_id+6 skips over leading "group:" */
     rc = ptsmodule_expand_tokens(ptsm->group_base, canon_id+6, NULL, &base);
     if (rc != PTSM_OK) {
         *reply = "ptsmodule_expand_tokens() failed for group search base";
         goto done;
     }
+
+    syslog(LOG_DEBUG, "(groups) about to search %s for %s", base, filter);
 
     rc = ldap_search_st(ptsm->ld, base, ptsm->group_scope, filter, attrs, 0, &(ptsm->timeout), &res);
     if (rc != LDAP_SUCCESS) {


### PR DESCRIPTION
This fixes a bunch of memory errors and leaks in ptloader, found by valgrinding Cassandane.

Notably, they're all in the LDAP PTS module, because this is the only PTS module we have any tests for...

This particular source file is pretty ghastly.  I've tried to make the smallest fixes possible, rather than getting bogged down refactoring for weeks/months...