### PR TITLE
Annotate dlist

### DIFF
--- a/cunit/dlist.testc
+++ b/cunit/dlist.testc
@@ -42,9 +42,10 @@ static void test_nil(void)
     dlist_setatom(dl, "STRING", "NIL");
     dlist_setatom(dl, "EMPTY", NULL);
     dlist_setatom(dl, "DOUBLEWHAMMY", "\"NIL\"");
+    dlist_setmap(dl, "BINARY", "\0NIL\0", 5);
     dlist_printbuf(dl, 0, &b);
 
-    CU_ASSERT_STRING_EQUAL(buf_cstring(&b), "(\"NIL\" NIL {5+}\r\n\"NIL\")");
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&b), "(\"NIL\" NIL {5+}\r\n\"NIL\" {5+}\r\n\0NIL\0)");
     dlist_free(&dl);
 
     r = dlist_parsemap(&dl, 0, 0, b.s, b.len);
@@ -65,6 +66,12 @@ static void test_nil(void)
     CU_ASSERT_PTR_NOT_NULL(item);
     CU_ASSERT_EQUAL(item->type, DL_BUF);
     CU_ASSERT_STRING_EQUAL(item->sval, "\"NIL\"");
+
+    item = dlist_getchildn(dl, 3);
+    CU_ASSERT_PTR_NOT_NULL(item);
+    CU_ASSERT_EQUAL(item->type, DL_BUF);
+    CU_ASSERT_EQUAL(item->nval, 5);
+    CU_ASSERT_STRING_EQUAL(item->sval, "\0NIL\0");
 
     dlist_free(&dl);
     buf_free(&b);

--- a/cunit/dlist.testc
+++ b/cunit/dlist.testc
@@ -40,9 +40,10 @@ static void test_nil(void)
     dlist_setatom(dl, "STRING", "NIL");
     dlist_setatom(dl, "EMPTY", NULL);
     dlist_setatom(dl, "DOUBLEWHAMMY", "\"NIL\"");
+    dlist_setmap(dl, "BINARY", "\0NIL\0", 5);
     dlist_printbuf(dl, 0, &b);
 
-    CU_ASSERT_STRING_EQUAL(buf_cstring(&b), "(\"NIL\" NIL {5+}\r\n\"NIL\")");
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&b), "(\"NIL\" NIL {5+}\r\n\"NIL\" {5+}\r\n\0NIL\0)");
     dlist_free(&dl);
 
     r = dlist_parsemap(&dl, 0, b.s, b.len);
@@ -63,6 +64,12 @@ static void test_nil(void)
     CU_ASSERT_PTR_NOT_NULL(item);
     CU_ASSERT_EQUAL(item->type, DL_BUF);
     CU_ASSERT_STRING_EQUAL(item->sval, "\"NIL\"");
+
+    item = dlist_getchildn(dl, 3);
+    CU_ASSERT_PTR_NOT_NULL(item);
+    CU_ASSERT_EQUAL(item->type, DL_BUF);
+    CU_ASSERT_EQUAL(item->nval, 5);
+    CU_ASSERT_STRING_EQUAL(item->sval, "\0NIL\0");
 
     dlist_free(&dl);
     buf_free(&b);

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -915,6 +915,55 @@ static const char *key_as_string(const annotate_db_t *d,
 }
 #endif
 
+struct annotate_rock {
+    struct buf *value;
+    struct annotate_metadata *mdata;
+};
+
+static int _flags_from_str(const char *data)
+{
+    int val = 0;
+    int i = 0;
+
+    for (i = 0; data[i]; i++) {
+        if (data[i] == 'd')
+            val |= ANNOTATE_FLAG_DELETED;
+    }
+
+    return val;
+}
+
+static const char *_flags_to_str(int flags)
+{
+    static char val[2];
+    int i = 0;
+
+    if (flags & ANNOTATE_FLAG_DELETED)
+        val[i++] = 'd';
+
+    // terminate the string
+    val[i++] = '\0';
+
+    return val;
+}
+
+static int parsedlist_cb(int type, struct dlistsax_data *d)
+{
+    struct annotate_rock *rock = (struct annotate_rock *)d->rock;
+    const char *key = buf_cstring(&d->kbuf);
+
+    if (type != DLISTSAX_STRING) return 0;
+
+    if (!strcmp(key, "F"))
+        rock->mdata->flags = _flags_from_str(d->data);
+    else if (!strcmp(key, "M"))
+        rock->mdata->modseq = atomodseq_t(d->data);
+    else if (!strcmp(key, "V"))
+        buf_copy(rock->value, &d->buf);
+
+    return 0;
+}
+
 static int split_attribs(const char *data, int datalen,
                          struct buf *value, struct annotate_metadata *mdata)
 {
@@ -923,11 +972,18 @@ static int split_attribs(const char *data, int datalen,
     const char *end = data + datalen;
 
     /* initialize metadata */
+    buf_reset(value);
     memset(mdata, 0, sizeof(struct annotate_metadata));
 
     /* XXX sanity check the data? */
     if (datalen <= 0)
             return 1;
+
+    if (*data == '%') {
+        struct annotate_rock rock = { value, mdata };
+        return dlist_parsesax(data, datalen, 0, parsedlist_cb, &rock);
+    }
+
     /*
      * Sigh...this is dumb.  We take care to be machine independent by
      * storing the length in network byte order...but the size of the
@@ -3008,38 +3064,15 @@ static int make_entry(struct buf *data,
                       modseq_t modseq,
                       unsigned char flags)
 {
-    unsigned long l;
-    static const char contenttype[] = "text/plain"; /* fake */
-    unsigned long long nmodseq;
-
-    /* Make sure that native types are wide enough */
-    assert(sizeof(modseq_t) <= sizeof(unsigned long long));
-    nmodseq = htonll((unsigned long long) modseq);
-
-    l = htonl(value->len);
-    buf_appendmap(data, (const char *)&l, sizeof(l));
-
-    buf_appendmap(data, value->s ? value->s : "", value->len);
-    buf_putc(data, '\0');
-
-    /*
-     * Older versions of Cyrus expected content-type and
-     * modifiedsince fields after the value.  We don't support those
-     * but we write out default values just in case the database
-     * needs to be read by older versions of Cyrus
-     */
-    buf_appendcstr(data, contenttype);
-    buf_putc(data, '\0');
-
-    l = 0;  /* fake modifiedsince */
-    buf_appendmap(data, (const char *)&l, sizeof(l));
-
-    /* Append modseq at the end */
-    buf_appendmap(data, (const char *)&nmodseq, sizeof(nmodseq));
-
-    /* Append flags */
-    buf_putc(data, flags);
-
+    struct dlist *dl = dlist_newkvlist(NULL, "");
+    if (flags)
+        dlist_setatom(dl, "F", _flags_to_str(flags));
+    if (modseq)
+        dlist_setnum64(dl, "M", modseq);
+    if (buf_len(value))
+        dlist_setbuf(dl, "V", value);
+    dlist_printbuf(dl, 0, data);
+    dlist_free(&dl);
     return 0;
 }
 

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -877,7 +877,6 @@ struct dlistsax_state {
     dlistsax_cb_t *proc;
     int depth;
     struct dlistsax_data d;
-    struct buf buf;
     struct buf gbuf;
 };
 
@@ -1050,14 +1049,16 @@ static int _parsesax(struct dlistsax_state *s, int parsekey)
         }
     }
     else {
-        r = _parseitem(s, &s->buf);
+
+        backdoor = (struct buf *)(&s->d.buf);
+        r = _parseitem(s, backdoor);
         if (r == IMAP_ZERO_LENGTH_LITERAL)
             s->d.data = NULL; // NIL
         else if (r) return r;
         else
-            s->d.data = buf_cstring(&s->buf);
+            s->d.data = buf_cstring(backdoor);
         r = s->proc(DLISTSAX_STRING, &s->d);
-        s->d.data = NULL; // zero out for next call
+        buf_truncate(backdoor, 0);
         if (r) return r;
     }
 

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -479,6 +479,11 @@ EXPORTED void dlist_makemap(struct dlist *dl, const char *val, size_t len)
         dl->type = DL_NIL;
 }
 
+EXPORTED void dlist_makebuf(struct dlist *dl, const struct buf *buf)
+{
+    return dlist_makemap(dl, buf_base(buf), buf_len(buf));
+}
+
 EXPORTED struct dlist *dlist_newkvlist(struct dlist *parent, const char *name)
 {
     struct dlist *dl = dlist_child(parent, name);
@@ -548,6 +553,14 @@ EXPORTED struct dlist *dlist_setmap(struct dlist *parent, const char *name,
 {
     struct dlist *dl = dlist_child(parent, name);
     dlist_makemap(dl, val, len);
+    return dl;
+}
+
+EXPORTED struct dlist *dlist_setbuf(struct dlist *parent, const char *name,
+                                    const struct buf *buf)
+{
+    struct dlist *dl = dlist_child(parent, name);
+    dlist_makebuf(dl, buf);
     return dl;
 }
 
@@ -622,6 +635,14 @@ struct dlist *dlist_updatemap(struct dlist *parent, const char *name,
 {
     struct dlist *dl = dlist_updatechild(parent, name);
     dlist_makemap(dl, val, len);
+    return dl;
+}
+
+struct dlist *dlist_updatebuf(struct dlist *parent, const char *name,
+                              const struct buf *buf)
+{
+    struct dlist *dl = dlist_updatechild(parent, name);
+    dlist_makebuf(dl, buf);
     return dl;
 }
 
@@ -1175,7 +1196,7 @@ EXPORTED int dlist_parse(struct dlist **dlp, int parsekey, int isbackup,
         prot_ungetc(c, in);
         /* could be binary in a literal */
         c = getbastring(in, NULL, &vbuf);
-        dl = dlist_setmap(NULL, kbuf.s, vbuf.s, vbuf.len);
+        dl = dlist_setbuf(NULL, buf_cstring(&kbuf), &vbuf);
     }
     else if (c == '\\') { /* special case for flags */
         prot_ungetc(c, in);
@@ -1185,7 +1206,7 @@ EXPORTED int dlist_parse(struct dlist **dlp, int parsekey, int isbackup,
     else {
         prot_ungetc(c, in);
         c = getnastring(in, NULL, &vbuf);
-        dl = dlist_setatom(NULL, kbuf.s, vbuf.s);
+        dl = dlist_setbuf(NULL, buf_cstring(&kbuf), &vbuf);
     }
 
     /* success */
@@ -1404,6 +1425,17 @@ HIDDEN int dlist_tomap(struct dlist *dl, const char **valp, size_t *lenp)
     if (lenp) *lenp = dl->nval;
 
     return 1;
+}
+
+HIDDEN int dlist_tobuf(struct dlist *dl, struct buf *buf)
+{
+    const char *v = NULL;
+    size_t l = 0;
+    if (dlist_tomap(dl, &v, &l)) {
+        buf_init_ro(buf, v, l);
+        return 1;
+    }
+    return 0;
 }
 
 /* ensure value is exactly one number */
@@ -1667,15 +1699,10 @@ EXPORTED int dlist_getmap(struct dlist *parent, const char *name,
 }
 
 EXPORTED int dlist_getbuf(struct dlist *parent, const char *name,
-                          struct buf *value)
+                          struct buf *buf)
 {
-    const char *v = NULL;
-    size_t l = 0;
-    if (dlist_getmap(parent, name, &v, &l)) {
-        buf_init_ro(value, v, l);
-        return 1;
-    }
-    return 0;
+    struct dlist *child = dlist_getchild(parent, name);
+    return dlist_tobuf(child, buf);
 }
 
 int dlist_getfile(struct dlist *parent, const char *name,

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -1206,7 +1206,8 @@ EXPORTED int dlist_parse(struct dlist **dlp, int parsekey, int isbackup,
     else {
         prot_ungetc(c, in);
         c = getnastring(in, NULL, &vbuf);
-        dl = dlist_setbuf(NULL, buf_cstring(&kbuf), &vbuf);
+        // can't use buf_string for value, it may be NIL => NULL
+        dl = dlist_setatom(NULL, buf_cstring(&kbuf), vbuf.s);
     }
 
     /* success */

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -450,6 +450,11 @@ EXPORTED void dlist_makemap(struct dlist *dl, const char *val, size_t len)
         dl->type = DL_NIL;
 }
 
+EXPORTED void dlist_makebuf(struct dlist *dl, const struct buf *buf)
+{
+    return dlist_makemap(dl, buf_base(buf), buf_len(buf));
+}
+
 EXPORTED struct dlist *dlist_newkvlist(struct dlist *parent, const char *name)
 {
     struct dlist *dl = dlist_child(parent, name);
@@ -519,6 +524,14 @@ EXPORTED struct dlist *dlist_setmap(struct dlist *parent, const char *name,
 {
     struct dlist *dl = dlist_child(parent, name);
     dlist_makemap(dl, val, len);
+    return dl;
+}
+
+EXPORTED struct dlist *dlist_setbuf(struct dlist *parent, const char *name,
+                                    const struct buf *buf)
+{
+    struct dlist *dl = dlist_child(parent, name);
+    dlist_makebuf(dl, buf);
     return dl;
 }
 
@@ -593,6 +606,14 @@ EXPORTED struct dlist *dlist_updatemap(struct dlist *parent, const char *name,
 {
     struct dlist *dl = dlist_updatechild(parent, name);
     dlist_makemap(dl, val, len);
+    return dl;
+}
+
+EXPORTED struct dlist *dlist_updatebuf(struct dlist *parent, const char *name,
+                                       const struct buf *buf)
+{
+    struct dlist *dl = dlist_updatechild(parent, name);
+    dlist_makebuf(dl, buf);
     return dl;
 }
 
@@ -1149,7 +1170,7 @@ EXPORTED int dlist_parse(struct dlist **dlp, unsigned flags,
         prot_ungetc(c, in);
         /* could be binary in a literal */
         c = getbastring(in, NULL, &vbuf);
-        dl = dlist_setmap(NULL, kbuf.s, vbuf.s, vbuf.len);
+        dl = dlist_setbuf(NULL, buf_cstring(&kbuf), &vbuf);
     }
     else if (c == '\\') { /* special case for flags */
         prot_ungetc(c, in);
@@ -1159,7 +1180,7 @@ EXPORTED int dlist_parse(struct dlist **dlp, unsigned flags,
     else {
         prot_ungetc(c, in);
         c = getnastring(in, NULL, &vbuf);
-        dl = dlist_setatom(NULL, kbuf.s, vbuf.s);
+        dl = dlist_setbuf(NULL, buf_cstring(&kbuf), &vbuf);
     }
 
     /* success */
@@ -1381,6 +1402,17 @@ HIDDEN int dlist_tomap(struct dlist *dl, const char **valp, size_t *lenp)
     if (lenp) *lenp = dl->nval;
 
     return 1;
+}
+
+HIDDEN int dlist_tobuf(struct dlist *dl, struct buf *buf)
+{
+    const char *v = NULL;
+    size_t l = 0;
+    if (dlist_tomap(dl, &v, &l)) {
+        buf_init_ro(buf, v, l);
+        return 1;
+    }
+    return 0;
 }
 
 /* ensure value is exactly one number */
@@ -1644,15 +1676,10 @@ EXPORTED int dlist_getmap(struct dlist *parent, const char *name,
 }
 
 EXPORTED int dlist_getbuf(struct dlist *parent, const char *name,
-                          struct buf *value)
+                          struct buf *buf)
 {
-    const char *v = NULL;
-    size_t l = 0;
-    if (dlist_getmap(parent, name, &v, &l)) {
-        buf_init_ro(value, v, l);
-        return 1;
-    }
-    return 0;
+    struct dlist *child = dlist_getchild(parent, name);
+    return dlist_tobuf(child, buf);
 }
 
 int dlist_getfile(struct dlist *parent, const char *name,

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -1180,7 +1180,8 @@ EXPORTED int dlist_parse(struct dlist **dlp, unsigned flags,
     else {
         prot_ungetc(c, in);
         c = getnastring(in, NULL, &vbuf);
-        dl = dlist_setbuf(NULL, buf_cstring(&kbuf), &vbuf);
+        // can't use buf_string for value, it may be NIL => NULL
+        dl = dlist_setatom(NULL, buf_cstring(&kbuf), vbuf.s);
     }
 
     /* success */

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -848,7 +848,6 @@ struct dlistsax_state {
     dlistsax_cb_t *proc;
     int depth;
     struct dlistsax_data d;
-    struct buf buf;
     struct buf gbuf;
 };
 
@@ -1021,14 +1020,16 @@ static int _parsesax(struct dlistsax_state *s, int parsekey)
         }
     }
     else {
-        r = _parseitem(s, &s->buf);
+
+        backdoor = (struct buf *)(&s->d.buf);
+        r = _parseitem(s, backdoor);
         if (r == IMAP_ZERO_LENGTH_LITERAL)
             s->d.data = NULL; // NIL
         else if (r) return r;
         else
-            s->d.data = buf_cstring(&s->buf);
+            s->d.data = buf_cstring(backdoor);
         r = s->proc(DLISTSAX_STRING, &s->d);
-        s->d.data = NULL; // zero out for next call
+        buf_truncate(backdoor, 0);
         if (r) return r;
     }
 

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -66,7 +66,8 @@ enum dlistsax_t {
 
 struct dlistsax_data {
     const struct buf kbuf;
-    const char *data;
+    const struct buf buf;
+    const char *data; // cstring buffer or NULL for NIL
     void *rock;
 };
 

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -108,6 +108,7 @@ void dlist_makenum64(struct dlist *dl, bit64 val);
 void dlist_makedate(struct dlist *dl, time_t val);
 void dlist_makehex64(struct dlist *dl, bit64 val);
 void dlist_makemap(struct dlist *dl, const char *val, size_t len);
+void dlist_makebuf(struct dlist *dl, const struct buf *buf);
 void dlist_makeguid(struct dlist *dl, const struct message_guid *guid);
 void dlist_makefile(struct dlist *dl,
                     const char *part, const struct message_guid *guid,
@@ -122,6 +123,8 @@ int dlist_todate(struct dlist *dl, time_t *valp);
 int dlist_tohex32(struct dlist *dl, uint32_t *valp);
 int dlist_tohex(struct dlist *dl, bit64 *valp);
 int dlist_tomap(struct dlist *dl, const char **valp, size_t *lenp);
+int dlist_tobuf(struct dlist *dl, struct buf *buf);
+
 /* these two don't actually do anything except check type */
 int dlist_tolist(struct dlist *dl, struct dlist **valp);
 int dlist_tokvlist(struct dlist *dl, struct dlist **valp);
@@ -161,6 +164,8 @@ struct dlist *dlist_sethex64(struct dlist *parent, const char *name,
                              bit64 val);
 struct dlist *dlist_setmap(struct dlist *parent, const char *name,
                            const char *val, size_t len);
+struct dlist *dlist_setbuf(struct dlist *parent, const char *name,
+                           const struct buf *buf);
 struct dlist *dlist_setguid(struct dlist *parent, const char *name,
                             const struct message_guid *guid);
 struct dlist *dlist_setfile(struct dlist *parent, const char *name,
@@ -181,6 +186,8 @@ struct dlist *dlist_updatehex64(struct dlist *parent, const char *name,
                                 bit64 val);
 struct dlist *dlist_updatemap(struct dlist *parent, const char *name,
                               const char *val, size_t len);
+struct dlist *dlist_updatebuf(struct dlist *parent, const char *name,
+                              const struct buf *buf);
 struct dlist *dlist_updateguid(struct dlist *parent, const char *name,
                                const struct message_guid *guid);
 struct dlist *dlist_updatefile(struct dlist *parent, const char *name,

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -67,6 +67,7 @@ void dlist_makenum64(struct dlist *dl, bit64 val);
 void dlist_makedate(struct dlist *dl, time_t val);
 void dlist_makehex64(struct dlist *dl, bit64 val);
 void dlist_makemap(struct dlist *dl, const char *val, size_t len);
+void dlist_makebuf(struct dlist *dl, const struct buf *buf);
 void dlist_makeguid(struct dlist *dl, const struct message_guid *guid);
 void dlist_makefile(struct dlist *dl,
                     const char *part, const struct message_guid *guid,
@@ -81,6 +82,8 @@ int dlist_todate(struct dlist *dl, time_t *valp);
 int dlist_tohex32(struct dlist *dl, uint32_t *valp);
 int dlist_tohex(struct dlist *dl, bit64 *valp);
 int dlist_tomap(struct dlist *dl, const char **valp, size_t *lenp);
+int dlist_tobuf(struct dlist *dl, struct buf *buf);
+
 /* these two don't actually do anything except check type */
 int dlist_tolist(struct dlist *dl, struct dlist **valp);
 int dlist_tokvlist(struct dlist *dl, struct dlist **valp);
@@ -120,6 +123,8 @@ struct dlist *dlist_sethex64(struct dlist *parent, const char *name,
                              bit64 val);
 struct dlist *dlist_setmap(struct dlist *parent, const char *name,
                            const char *val, size_t len);
+struct dlist *dlist_setbuf(struct dlist *parent, const char *name,
+                           const struct buf *buf);
 struct dlist *dlist_setguid(struct dlist *parent, const char *name,
                             const struct message_guid *guid);
 struct dlist *dlist_setfile(struct dlist *parent, const char *name,
@@ -140,6 +145,8 @@ struct dlist *dlist_updatehex64(struct dlist *parent, const char *name,
                                 bit64 val);
 struct dlist *dlist_updatemap(struct dlist *parent, const char *name,
                               const char *val, size_t len);
+struct dlist *dlist_updatebuf(struct dlist *parent, const char *name,
+                              const struct buf *buf);
 struct dlist *dlist_updateguid(struct dlist *parent, const char *name,
                                const struct message_guid *guid);
 struct dlist *dlist_updatefile(struct dlist *parent, const char *name,

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -25,7 +25,8 @@ enum dlistsax_t {
 
 struct dlistsax_data {
     const struct buf kbuf;
-    const char *data;
+    const struct buf buf;
+    const char *data; // cstring buffer or NULL for NIL
     void *rock;
 };
 


### PR DESCRIPTION
This is amazingly totally independent of the other sync stuff!  But this makes the annotation format a dlist, which is much nicer - along with some dlist module API updates too.