### PR TITLE
imap/annotate: remove unused appendstrlistpat() and comp_pat from struct strlist

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -292,23 +292,6 @@ EXPORTED void appendstrlist(struct strlist **l, char *s)
 
     *tail = (struct strlist *)xmalloc(sizeof(struct strlist));
     (*tail)->s = xstrdup(s);
-    (*tail)->p = 0;
-    (*tail)->next = 0;
-}
-
-/*
- * Append 's' to the strlist 'l', compiling it as a pattern.
- * Caller must pass in memory that is freed when the strlist is freed.
- */
-EXPORTED void appendstrlistpat(struct strlist **l, char *s)
-{
-    struct strlist **tail = l;
-
-    while (*tail) tail = &(*tail)->next;
-
-    *tail = (struct strlist *)xmalloc(sizeof(struct strlist));
-    (*tail)->s = s;
-    (*tail)->p = charset_compilepat(s);
     (*tail)->next = 0;
 }
 
@@ -322,7 +305,6 @@ EXPORTED void freestrlist(struct strlist *l)
     while (l) {
         n = l->next;
         free(l->s);
-        if (l->p) charset_freepat(l->p);
         free((char *)l);
         l = n;
     }

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -59,7 +59,6 @@
 /* List of strings, for fetch and search argument blocks */
 struct strlist {
     char *s;                   /* String */
-    comp_pat *p;               /* Compiled pattern, for search */
     struct strlist *next;
 };
 
@@ -108,7 +107,6 @@ int annotate_state_set_message(annotate_state_t *state,
 
 /* String List Management */
 void appendstrlist(struct strlist **l, char *s);
-void appendstrlistpat(struct strlist **l, char *s);
 void freestrlist(struct strlist *l);
 
 /* Attribute Management (also used by ID) */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -513,7 +513,6 @@ static void appendfieldlist(struct fieldlist **l, char *section,
                      strarray_t *fields, char *trail,
                      void *d, size_t size);
 static void freefieldlist(struct fieldlist *l);
-void freestrlist(struct strlist *l);
 
 static int set_haschildren(const mbentry_t *entry, void *rock);
 static char *canonical_list_pattern(const char *reference,


### PR DESCRIPTION
• imap/imapd.c: remove unnecessary freestrlist declaration