### PR TITLE
JMAP Backup relaxed locking

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -471,7 +471,6 @@ EXPORTED int conversations_open_mbox(const char *mboxname, int shared, struct co
     free(userid);
     free(path);
     return r;
-    return 0;
 }
 
 EXPORTED struct conversations_state *conversations_get_path(const char *fname)

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -80,30 +80,34 @@ jmap_method_t jmap_backup_methods_standard[] = {
     { NULL, NULL, NULL, 0}
 };
 
+/* NOTE: we don't set flags to require CSTATE, because that holds
+ * a user lock (exclusive if READ_WRITE is requested) for the entire
+ * time the method is running.  Backup restores can be quite slow,
+ * and we release locks in batches so that the user can keep working */
 jmap_method_t jmap_backup_methods_nonstandard[] = {
     {
         "Backup/restoreContacts",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_contacts,
-        JMAP_NEED_CSTATE | JMAP_READ_WRITE
+        /*flags*/0
     },
     {
         "Backup/restoreCalendars",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_calendars,
-        JMAP_NEED_CSTATE | JMAP_READ_WRITE
+        /*flags*/0
     },
     {
         "Backup/restoreNotes",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_notes,
-        JMAP_READ_WRITE
+        /*flags*/0
     },
     {
         "Backup/restoreMail",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_mail,
-        JMAP_NEED_CSTATE | JMAP_READ_WRITE
+        /*flags*/0
     },
     { NULL, NULL, NULL, 0}
 };

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1537,8 +1537,8 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
         if (rrock->jrestore->mode & UNDO_DRAFTS) {
             /* XXX  conversation ID is faster to lookup than Message-ID
                     so use it to make sure the message has a Message-ID */
-            struct conversations_state *cstate = mailbox_get_cstate(mailbox);
-            // cstate won't exists for DELETED mailboxes
+            struct conversations_state *cstate = mailbox_get_cstate_full(mailbox, /*allow_deleted*/1);
+            // if we still fail to get cstate, then we need to look up the msgid for sure
             if ((!cstate || conversations_guid_cid_lookup(cstate, guid)) &&
                 !message_get_messageid((message_t *) msg, &mrock->buf)) {
                 msgid = buf_cstring(&mrock->buf);

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1537,7 +1537,9 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
         if (rrock->jrestore->mode & UNDO_DRAFTS) {
             /* XXX  conversation ID is faster to lookup than Message-ID
                     so use it to make sure the message has a Message-ID */
-            if (conversations_guid_cid_lookup(rrock->req->cstate, guid) &&
+            struct conversations_state *cstate = mailbox_get_cstate(mailbox);
+            // cstate won't exists for DELETED mailboxes
+            if ((!cstate || conversations_guid_cid_lookup(cstate, guid)) &&
                 !message_get_messageid((message_t *) msg, &mrock->buf)) {
                 msgid = buf_cstring(&mrock->buf);
             }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2334,7 +2334,7 @@ EXPORTED int mailbox_read_basecid(struct mailbox *mailbox, const struct index_re
     return 0;
 }
 
-EXPORTED int mailbox_has_conversations(struct mailbox *mailbox)
+EXPORTED int mailbox_has_conversations_full(struct mailbox *mailbox, int allow_deleted)
 {
     char *path;
 
@@ -2343,7 +2343,7 @@ EXPORTED int mailbox_has_conversations(struct mailbox *mailbox)
         return 0;
 
     /* we never store data about deleted mailboxes */
-    if (mboxname_isdeletedmailbox(mailbox_name(mailbox), NULL))
+    if (!allow_deleted && mboxname_isdeletedmailbox(mailbox_name(mailbox), NULL))
         return 0;
 
     /* we never store data about submission mailboxes */
@@ -3924,9 +3924,9 @@ EXPORTED int mailbox_add_email_alarms(struct mailbox *mailbox)
 }
 #endif // WITH_JMAP
 
-EXPORTED struct conversations_state *mailbox_get_cstate(struct mailbox *mailbox)
+EXPORTED struct conversations_state *mailbox_get_cstate_full(struct mailbox *mailbox, int allow_deleted)
 {
-    if (!mailbox_has_conversations(mailbox))
+    if (!mailbox_has_conversations_full(mailbox, allow_deleted))
         return NULL;
 
     /* we already own it? */

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -717,9 +717,11 @@ extern int mailbox_cid_rename(struct mailbox *mailbox,
 extern int mailbox_add_conversations(struct mailbox *mailbox, int silent);
 extern int mailbox_get_xconvmodseq(struct mailbox *mailbox, modseq_t *);
 extern int mailbox_update_xconvmodseq(struct mailbox *mailbox, modseq_t, int force);
-extern int mailbox_has_conversations(struct mailbox *mailbox);
+#define mailbox_has_conversations(m) mailbox_has_conversations_full(m, 0)
+extern int mailbox_has_conversations_full(struct mailbox *mailbox, int allow_deleted);
 
-extern struct conversations_state *mailbox_get_cstate(struct mailbox *mailbox);
+#define mailbox_get_cstate(m) mailbox_get_cstate_full(m, 0)
+extern struct conversations_state *mailbox_get_cstate_full(struct mailbox *mailbox, int allow_deleted);
 
 typedef void mailbox_wait_cb_t(void *rock);
 extern void mailbox_set_wait_cb(mailbox_wait_cb_t *cb, void *rock);


### PR DESCRIPTION
Process messages in batches so we don't deadlock and/or hold locks for a long time.  All Cass tests succeed even with a batch size of 1