### PR TITLE
Delayed actions - don't repack until we've replied to the user!

### DIFF
--- a/imap/calalarmd.c
+++ b/imap/calalarmd.c
@@ -159,6 +159,7 @@ int main(int argc, char **argv)
 
         gettimeofday(&start, 0);
         caldav_alarm_process(0, &interval, /*dryrun*/0);
+        libcyrus_run_delayed();
         gettimeofday(&end, 0);
 
         signals_poll();

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -408,6 +408,7 @@ static int archive(const mbentry_t *mbentry, void *rock)
 
 done:
     mailbox_close(&mailbox);
+    libcyrus_run_delayed();
 
     /* move on to the next mailbox regardless of errors */
     return 0;
@@ -534,6 +535,7 @@ static int expire(const mbentry_t *mbentry, void *rock)
 
 done:
     mailbox_close(&mailbox);
+    libcyrus_run_delayed();
     /* Even if we had a problem with one mailbox, continue with the others */
     return 0;
 }
@@ -544,7 +546,7 @@ static int delete(const mbentry_t *mbentry, void *rock)
     time_t timestamp;
     int delete_seconds = -1;
 
-    if (sigquit)
+    if (in_shutdown)
         return 1;
 
     if (mbentry->mbtype & MBTYPE_DELETED)
@@ -609,6 +611,7 @@ static int expire_conversations(const mbentry_t *mbentry, void *rock)
     if (!conversations_open_mbox(mbentry->name, 0/*shared*/, &state)) {
         conversations_prune(state, crock->expire_mark, &nseen, &ndeleted);
         conversations_commit(&state);
+        libcyrus_run_delayed();
     }
 
     hash_insert(filename, (void *)1, &crock->seen);
@@ -764,6 +767,7 @@ static int do_delete(struct cyr_expire_ctx *ctx)
 
             ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL,
                                              MBOXLIST_DELETE_KEEP_INTERMEDIARIES);
+            libcyrus_run_delayed();
             /* XXX: Ignoring the return from mboxlist_deletemailbox() ??? */
             count++;
         }

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -60,7 +60,6 @@
 #include <sys/stat.h>
 #include <sysexits.h>
 #include <syslog.h>
-#include <signal.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <libgen.h>
@@ -90,6 +89,7 @@
 static int verbose = 0;
 static const char *progname = NULL;
 static struct namespace expire_namespace; /* current namespace */
+static struct cyr_expire_ctx ctx;
 
 /* command line arguments */
 struct arguments {
@@ -156,10 +156,6 @@ struct cyr_expire_ctx {
     struct expire_rock erock;
 };
 
-static const struct cyr_expire_ctx zero_ctx;
-
-static void sighandler(int sig);
-
 /* verbosep - a wrapper to print if the 'verbose' option is
    turned on.
  */
@@ -179,18 +175,7 @@ static inline void verbosep(const char *fmt, ...)
 
 static void cyr_expire_init(const char *progname, struct cyr_expire_ctx *ctx)
 {
-    struct sigaction action;
-
-    /* Initialise signal handlers */
-    sigemptyset(&action.sa_mask);
-    action.sa_flags = 0;
-    action.sa_handler = sighandler;
-    if (sigaction(SIGQUIT, &action, NULL) < 0)
-        fatal("unable to install signal handler for SIGQUIT", EX_TEMPFAIL);
-    if (sigaction(SIGINT, &action, NULL) < 0)
-        fatal("unable to install signal handler for SIGINT", EX_TEMPFAIL);
-    if (sigaction(SIGTERM, &action, NULL) < 0)
-        fatal("unable to install signal handler for SIGTERM", EX_TEMPFAIL);
+    signals_add_handlers(0);
 
     construct_hash_table(&ctx->erock.table, 10000, 1);
     strarray_init(&ctx->drock.to_delete);
@@ -379,8 +364,7 @@ static int archive(const mbentry_t *mbentry, void *rock)
     struct mailbox *mailbox = NULL;
     int archive_seconds = -1;
 
-    if (in_shutdown)
-        return 1;
+    signals_poll();
 
     if (mbentry->mbtype & MBTYPE_DELETED)
         goto done;
@@ -451,10 +435,7 @@ static int expire(const mbentry_t *mbentry, void *rock)
     int expire_seconds = 0;
     int did_expunge = 0;
 
-    if (in_shutdown) {
-        /* don't care if we leak some memory, we are shutting down */
-        return 1;
-    }
+    signals_poll();
 
     /* Skip remote mailboxes */
     if (mbentry->mbtype & MBTYPE_REMOTE)
@@ -545,8 +526,7 @@ static int delete(const mbentry_t *mbentry, void *rock)
     time_t timestamp;
     int delete_seconds = -1;
 
-    if (in_shutdown)
-        return 1;
+    signals_poll();
 
     if (mbentry->mbtype & MBTYPE_DELETED)
         goto done;
@@ -586,8 +566,7 @@ static int expire_conversations(const mbentry_t *mbentry, void *rock)
     unsigned int nseen = 0, ndeleted = 0;
     char *filename = NULL;
 
-    if (in_shutdown)
-        return 1;
+    signals_poll();
 
     if (mbentry->mbtype & MBTYPE_DELETED)
         goto done;
@@ -622,12 +601,6 @@ static int expire_conversations(const mbentry_t *mbentry, void *rock)
 done:
     free(filename);
     return 0;
-}
-
-static void sighandler(int sig __attribute((unused)))
-{
-    in_shutdown = 1;
-    return;
 }
 
 static int do_archive(struct cyr_expire_ctx *ctx)
@@ -759,8 +732,7 @@ static int do_delete(struct cyr_expire_ctx *ctx)
         for (i = 0 ; i < ctx->drock.to_delete.count ; i++) {
             char *name = ctx->drock.to_delete.data[i];
 
-            if (in_shutdown)
-                return ret;         /* return from here, will quit in main. */
+            signals_poll();
 
             verbosep("Removing: %s\n", name);
 
@@ -876,10 +848,20 @@ static int parse_args(int argc, char *argv[], struct arguments *args)
     return 0;
 }
 
+static void shut_down(int code) __attribute__((noreturn));
+static void shut_down(int code)
+{
+    in_shutdown = 1;
+
+    cyr_expire_cleanup(&ctx);
+
+    exit(code);
+}
+
+
 int main(int argc, char *argv[])
 {
     int r = 0;
-    struct cyr_expire_ctx ctx = zero_ctx;
 
     progname = basename(argv[0]);
 
@@ -913,30 +895,16 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    r = do_archive(&ctx);
+    do_archive(&ctx);
 
-    if (in_shutdown)
-        goto finish;
+    do_expunge(&ctx);
 
-    r = do_expunge(&ctx);
+    do_cid_expire(&ctx);
 
-    if (in_shutdown)
-        goto finish;
-
-    r = do_cid_expire(&ctx);
-
-    if (in_shutdown)
-        goto finish;
-
-    r = do_delete(&ctx);
-
-    if (in_shutdown)
-        goto finish;
+    do_delete(&ctx);
 
     /* purge deliver.db entries of expired messages */
-    r = do_duplicate_prune(&ctx);
+    do_duplicate_prune(&ctx);
 
- finish:
-    cyr_expire_cleanup(&ctx);
-    exit(r);
+    shut_down(0);
 }

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -120,6 +120,7 @@ int main(int argc, char **argv)
     }
 
     cyrus_init(alt_config, "dav_reconstruct", 0, 0);
+    global_sasl_init(1,0,NULL);
 
     /* Set namespace -- force standard (internal) */
     if ((r = mboxname_init_namespace(&recon_namespace, 1)) != 0) {
@@ -146,6 +147,10 @@ int main(int argc, char **argv)
             do_user(argv[i], (void *)audit_tool);
     }
 
+    libcyrus_run_delayed();
+    sqldb_done();
+    cyrus_done();
+
     exit(code);
 }
 
@@ -164,6 +169,8 @@ void shut_down(int code) __attribute__((noreturn));
 void shut_down(int code)
 {
     in_shutdown = 1;
+
+    libcyrus_run_delayed();
 
     mboxlist_close();
     mboxlist_done();

--- a/imap/global.c
+++ b/imap/global.c
@@ -93,7 +93,7 @@ static enum {
 
 static int cyrus_init_nodb = 0;
 
-EXPORTED int in_shutdown = 0;
+EXPORTED volatile sig_atomic_t in_shutdown = 0;
 
 EXPORTED int config_fulldirhash;                                /* 0 */
 EXPORTED int config_implicitrights;                     /* "lkxa" */

--- a/imap/global.h
+++ b/imap/global.h
@@ -50,6 +50,7 @@
 #include "mboxname.h"
 #include "signals.h"
 #include "imapparse.h"
+#include "libcyr_cfg.h"
 #include "util.h"
 
 #ifdef HAVE_SSL

--- a/imap/global.h
+++ b/imap/global.h
@@ -161,7 +161,7 @@ extern int saslprops_set_tls(struct saslprops_t *saslprops,
                              sasl_conn_t *saslconn);
 
 /* Misc globals */
-extern int in_shutdown;
+extern volatile sig_atomic_t in_shutdown;
 extern int config_fulldirhash;
 extern int config_implicitrights;
 extern unsigned long config_metapartition_files;

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -683,6 +683,9 @@ static void httpd_reset(struct http_connection *conn)
     int bytes_in = 0;
     int bytes_out = 0;
 
+    /* run any delayed actions */
+    libcyrus_run_delayed();
+
     /* Do any namespace specific cleanup */
     for (i = 0; http_namespaces[i]; i++) {
         if (http_namespaces[i]->enabled && http_namespaces[i]->reset)
@@ -1097,6 +1100,8 @@ void shut_down(int code)
     int bytes_out = 0;
 
     in_shutdown = 1;
+
+    libcyrus_run_delayed();
 
     if (allow_cors) free_wildmats(allow_cors);
 
@@ -2137,6 +2142,9 @@ static void cmdloop(struct http_connection *conn)
             /* Flush any buffered output */
             prot_flush(httpd_out);
             if (backend_current) prot_flush(backend_current->out);
+
+            /* Run delayed actions from this command */
+            libcyrus_run_delayed();
 
             /* Check for shutdown file */
             if (shutdown_file(txn.buf.s, txn.buf.alloc) ||

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -744,6 +744,9 @@ static void imapd_reset(void)
     int bytes_in = 0;
     int bytes_out = 0;
 
+    /* run delayed commands first before closing anything */
+    libcyrus_run_delayed();
+
     proc_cleanup();
 
     /* close backend connections */
@@ -1083,6 +1086,9 @@ void shut_down(int code)
 
     in_shutdown = 1;
 
+    /* run delayed commands before we take away all the environment */
+    libcyrus_run_delayed();
+
     proc_cleanup();
 
     for (i = 0; i < ptrarray_size(&backend_cached); i++) {
@@ -1279,6 +1285,9 @@ static void cmdloop(void)
 
         /* command no longer running */
         proc_register(config_ident, imapd_clienthost, imapd_userid, index_mboxname(imapd_index), NULL);
+
+        /* run any delayed cleanup while a user isn't waiting on a reply */
+        libcyrus_run_delayed();
 
         /* Check for shutdown file */
         if ( !imapd_userisadmin && imapd_userid &&

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -286,6 +286,7 @@ int service_main(int argc, char **argv,
     prometheus_increment(CYRUS_LMTP_CONNECTIONS_TOTAL);
 
     lmtpmode(&mylmtp, deliver_in, deliver_out, 0);
+    libcyrus_run_delayed();
 
     prometheus_decrement(CYRUS_LMTP_ACTIVE_CONNECTIONS);
 
@@ -1007,6 +1008,8 @@ void shut_down(int code)
 
     /* set flag */
     in_shutdown = 1;
+
+    libcyrus_run_delayed();
 
     /* close backend connections */
     for (i = 0; i < ptrarray_size(&backend_cached); i++) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1299,8 +1299,7 @@ EXPORTED void mailbox_close(struct mailbox **mailboxptr)
                                        (mailbox_mbtype(mailbox) & MBTYPE_LEGACY_DIRS) ?
                                        NULL : mailbox_uniqueid(mailbox));
             else if (mailbox->i.options & OPT_MAILBOX_NEEDS_REPACK)
-
-                mailbox_index_repack(mailbox, mailbox->i.minor_version);
+                return mailbox_index_repack(mailbox->i.minor_version, &mailbox);
             else if (mailbox->i.options & OPT_MAILBOX_NEEDS_UNLINK)
                 mailbox_index_unlink(mailbox);
             /* or we missed out - someone else beat us to it */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1310,7 +1310,7 @@ EXPORTED void mailbox_close(struct mailbox **mailboxptr)
     else if (!in_shutdown && (mailbox->i.options & MAILBOX_CLEANUP_MASK)) {
         // there's cleanup to do!  Schedule it for after we've replied to the user
         libcyrus_delayed_action(mailbox_meta_fname(mailbox, META_HEADER),
-                                _delayed_cleanup, free, xstrdup(mailbox->name));
+                                _delayed_cleanup, free, xstrdup(mailbox_name(mailbox)));
     }
 
     mailbox_release_resources(mailbox);

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -572,6 +572,8 @@ void shut_down(int code)
 
     in_shutdown = 1;
 
+    libcyrus_run_delayed();
+
     proc_cleanup();
 
     /* close local mailbox */
@@ -728,6 +730,8 @@ static void cmdloop(void)
         signals_poll();
 
         proc_register(config_ident, nntp_clienthost, nntp_userid, index_mboxname(group_state), NULL);
+
+        libcyrus_run_delayed();
 
         if (!proxy_check_input(protin, nntp_in, nntp_out,
                                backend_current ? backend_current->in : NULL,

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -603,6 +603,8 @@ void shut_down(int code)
 
     in_shutdown = 1;
 
+    libcyrus_run_delayed();
+
     proc_cleanup();
 
     /* close local mailbox */
@@ -859,6 +861,8 @@ static void cmdloop(void)
 
         /* register process */
         proc_register(config_ident, popd_clienthost, popd_userid, popd_mailbox ? mailbox_name(popd_mailbox) : NULL, NULL);
+
+        libcyrus_run_delayed();
 
         if (backend) {
             /* create a pipe from client to backend */

--- a/imap/smmapd.c
+++ b/imap/smmapd.c
@@ -137,6 +137,8 @@ static void smmapd_reset(void)
     map_in = map_out = NULL;
 
     cyrus_reset_stdio();
+
+    libcyrus_run_delayed();
 }
 
 void shut_down(int code) __attribute__((noreturn));

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -117,6 +117,8 @@ static void shut_down(int code)
 {
     in_shutdown = 1;
 
+    libcyrus_run_delayed();
+
     seen_done();
     cyrus_done();
     exit(code);
@@ -333,6 +335,7 @@ static void do_daemon(const char *sync_shutdown_file,
             if (!backend_ping(sync_cs.backend, NULL)) restart = 1;
         }
         replica_disconnect();
+        libcyrus_run_delayed();
     }
 }
 
@@ -741,6 +744,8 @@ int main(int argc, char **argv)
     }
 
     buf_free(&tagbuf);
+
+    libcyrus_run_delayed();
 
     shut_down(exit_rc);
 }

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -95,10 +95,14 @@ static void shut_down(int code)
 {
     in_shutdown = 1;
 
+    libcyrus_run_delayed();
+
     if (sync_userid)    free(sync_userid);
     if (sync_authstate) auth_freestate(sync_authstate);
 
     seen_done();
+
+    cyrus_done();
 
     exit(code);
 }
@@ -235,6 +239,8 @@ main(int argc, char **argv)
             break;
         }
     }
+
+    libcyrus_run_delayed();
 
     shut_down(0);
 }

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -395,10 +395,9 @@ static void usage(void)
  */
 void shut_down(int code)
 {
-    /* run any delayed commands before we go into shutdown */
-    libcyrus_run_delayed();
-
     in_shutdown = 1;
+
+    libcyrus_run_delayed();
 
     proc_cleanup();
 

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -395,6 +395,9 @@ static void usage(void)
  */
 void shut_down(int code)
 {
+    /* run any delayed commands before we go into shutdown */
+    libcyrus_run_delayed();
+
     in_shutdown = 1;
 
     proc_cleanup();
@@ -499,6 +502,8 @@ static void cmdloop(void)
 
     for (;;) {
         prot_flush(sync_out);
+
+        libcyrus_run_delayed();
 
         /* Parse command name */
         if ((c = getword(sync_in, &cmd)) == EOF)

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -1739,6 +1739,40 @@ static int skipwrite(struct dbengine *db,
     return 0;
 }
 
+struct dcrock {
+    char *fname;
+    int flags;
+};
+
+static void _delayed_checkpoint_free(void *rock)
+{
+    struct dcrock *drock = rock;
+    free(drock->fname);
+    free(drock);
+}
+
+static void _delayed_checkpoint(void *rock)
+{
+    struct dcrock *drock = rock;
+    struct dbengine *db = NULL;
+    struct txn *txn = NULL;
+    int r = myopen(drock->fname, drock->flags, &db, &txn);
+    if (r) {
+        syslog(LOG_ERR, "DBERROR: opening %s for checkpoint: %s",
+               drock->fname, cyrusdb_strerror(r));
+    }
+    else if (db->header.current_size > MINREWRITE
+             && db->header.current_size > 2 * db->header.repack_size) {
+        mycheckpoint(db);
+    }
+    else {
+        syslog(LOG_INFO, "twoskip: delayed checkpoint not needed for %s (%llu %llu)",
+               drock->fname, (LLU)db->header.repack_size, (LLU)db->header.current_size);
+        myabort(db, txn);
+    }
+    myclose(db);
+}
+
 static int mycommit(struct dbengine *db, struct txn *tid)
 {
     struct skiprecord newrecord;
@@ -1773,6 +1807,18 @@ static int mycommit(struct dbengine *db, struct txn *tid)
     db->header.current_size = db->end;
     db->header.flags &= ~DIRTY;
     r = commit_header(db);
+    if (r) goto done;
+
+    if (!(db->open_flags & CYRUSDB_NOCOMPACT)
+           && db->header.current_size > MINREWRITE
+           && db->header.current_size > 2 * db->header.repack_size) {
+        // delay the checkpoint until the user isn't waiting
+        struct dcrock *drock = xzmalloc(sizeof(struct dcrock));
+        drock->fname = xstrdup(FNAME(db));
+        drock->flags = db->open_flags;
+        libcyrus_delayed_action(drock->fname, _delayed_checkpoint,
+                                _delayed_checkpoint_free, drock);
+    }
 
  done:
     if (r) {
@@ -1787,20 +1833,7 @@ static int mycommit(struct dbengine *db, struct txn *tid)
         }
     }
     else {
-        if (db->current_txn && !db->current_txn->shared
-            && !(db->open_flags & CYRUSDB_NOCOMPACT)
-            && db->header.current_size > MINREWRITE
-            && db->header.current_size > 2 * db->header.repack_size) {
-            int r2 = mycheckpoint(db);
-            if (r2) {
-                syslog(LOG_NOTICE, "twoskip: failed to checkpoint %s: %m",
-                       FNAME(db));
-            }
-        }
-        else {
-            unlock(db);
-        }
-
+        unlock(db);
         free(tid);
         db->current_txn = NULL;
     }

--- a/lib/libcyr_cfg.c
+++ b/lib/libcyr_cfg.c
@@ -243,7 +243,7 @@ EXPORTED void libcyrus_delayed_action(const char *key, void (*cb)(void *),
         // check if we already have this event on our list
         for (action = delayed_actions; action; action = action->next) {
             if (!strcmpsafe(key, action->key)) {
-                myfree(rock);
+                if (myfree) myfree(rock);
                 return;
             }
         }
@@ -263,7 +263,7 @@ EXPORTED void libcyrus_run_delayed(void)
         struct delayed_action *action = delayed_actions;
         delayed_actions = action->next;
         action->cb(action->rock);
-        action->myfree(action->rock);
+        if (action->myfree) action->myfree(action->rock);
         free(action);
     }
 }

--- a/lib/libcyr_cfg.c
+++ b/lib/libcyr_cfg.c
@@ -49,6 +49,8 @@
 #include "assert.h"
 #include "libcyr_cfg.h"
 #include "cyrusdb.h"
+#include "xmalloc.h"
+#include "util.h"
 
 #if defined(__GNUC__) && __GNUC__ > 1
 /* We can use the GCC union constructor extension */
@@ -56,6 +58,16 @@
 #else
 #define CFGVAL(t,v)     {(void *)(v)}
 #endif
+
+struct delayed_action {
+    struct delayed_action *next;
+    char *key;
+    void (*cb)(void *rock);
+    void (*myfree)(void *rock);
+    void *rock;
+};
+
+static struct delayed_action *delayed_actions;
 
 static struct cyrusopt_s cyrus_options[] = {
     { CYRUSOPT_ZERO, { NULL }, CYRUS_OPT_NOTOPT },
@@ -213,6 +225,49 @@ EXPORTED void libcyrus_config_setswitch(enum cyrus_opt opt, int val)
     cyrus_options[opt].val.b = val;
 }
 
+/* This keeps a list of functions to call at an opportune time when the
+ * user is not waiting.
+ * Arguments:
+ *  dedup key: if provided, don't add this callback again if there's
+ *             already one for this key.
+ *  cb:        callback to call with rock passed
+ *  free:      function to call with rock after the callback to free it,
+               if NULL there is nothing to free.
+ *  rock:      arguments for the callback
+ */
+EXPORTED void libcyrus_delayed_action(const char *key, void (*cb)(void *),
+                                      void (*myfree)(void *), void *rock)
+{
+    struct delayed_action *action;
+    if (key) {
+        // check if we already have this event on our list
+        for (action = delayed_actions; action; action = action->next) {
+            if (!strcmpsafe(key, action->key)) {
+                myfree(rock);
+                return;
+            }
+        }
+    }
+    action = xzmalloc(sizeof(struct delayed_action));
+    action->key = xstrdupnull(key);
+    action->cb = cb;
+    action->myfree = myfree;
+    action->rock = rock;
+    action->next = delayed_actions;
+    delayed_actions = action;
+}
+
+EXPORTED void libcyrus_run_delayed(void)
+{
+    while (delayed_actions) {
+        struct delayed_action *action = delayed_actions;
+        delayed_actions = action->next;
+        action->cb(action->rock);
+        action->myfree(action->rock);
+        free(action);
+    }
+}
+
 EXPORTED void libcyrus_init(void)
 {
     cyrusdb_init();
@@ -220,5 +275,6 @@ EXPORTED void libcyrus_init(void)
 
 EXPORTED void libcyrus_done(void)
 {
+    libcyrus_run_delayed();
     cyrusdb_done();
 }

--- a/lib/libcyr_cfg.h
+++ b/lib/libcyr_cfg.h
@@ -134,6 +134,9 @@ void libcyrus_config_setstring(enum cyrus_opt opt, const char *val);
 void libcyrus_config_setint(enum cyrus_opt opt, int val);
 void libcyrus_config_setswitch(enum cyrus_opt opt, int val);
 
+extern void libcyrus_delayed_action(const char *key, void (*cb)(void *), void (*free)(void *), void *rock);
+extern void libcyrus_run_delayed(void);
+
 /* Start/Stop the Library */
 /* Should be done AFTER setting configuration options */
 void libcyrus_init(void);


### PR DESCRIPTION
This set of commits creates a list of "delayed actions" deep in libcyrus, where all the libraries can call it.  It then runs them either during shutdown, or you can call them at any time.  By doing this, both mailbox cleanup and twoskip checkpoints can be delayed until after we've replied to the user, meaning that the user doesn't have to wait on background tasks.

an alternative option is to log all these things somewhere and have a maintenance job that reads the log file sync_log style and does the actions, but this seems a nice sweet spot that doesn't require another daemon.