### PR TITLE
testsaslauthd needs socket path info (-f)

### DIFF
--- a/docsrc/assets/setup-sasl-sasldb.rst
+++ b/docsrc/assets/setup-sasl-sasldb.rst
@@ -36,6 +36,6 @@ the user exists and is set up correctly:
 
 ::
 
-    testsaslauthd -u imapuser -p secret
+    testsaslauthd -u imapuser -p secret -f /var/run/saslauthd/mux
 
 You should get an ``0: OK "Success."`` message.


### PR DESCRIPTION
testsaslauthd will complain with "connect() : No such file or directory" if it doesn't know the socket path via (-f).