### PR TITLE
Mailbox mbentry

### DIFF
--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -682,7 +682,7 @@ static void test_delete(void)
 
     memset(&mbentry, 0, sizeof(mbentry));
     mbentry.name = MBOXNAME1_INT;
-    mbentry.uniqueid = mailbox->uniqueid;
+    mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;
@@ -751,7 +751,7 @@ static void test_delete(void)
     buf_free(&val2);
 
     buf_printf(&path, "%s/data/uuid/%c/%c/%s/cyrus.annotations", DBDIR,
-               mailbox->uniqueid[0], mailbox->uniqueid[1], mailbox->uniqueid);
+               mailbox_uniqueid(mailbox)[0], mailbox_uniqueid(mailbox)[1], mailbox_uniqueid(mailbox));
     CU_ASSERT_EQUAL(fexists(buf_cstring(&path)), 0);
     mailbox_close(&mailbox);
     buf_free(&val);
@@ -848,10 +848,12 @@ static void test_rename(void)
     CU_ASSERT_STRING_EQUAL(buf_cstring(&val2), VALUE2);
     buf_free(&val2);
 
+    const char *u1 = mailbox_uniqueid(mailbox1);
     buf_printf(&path1, "%s/data/uuid/%c/%c/%s/cyrus.annotations", DBDIR,
-               mailbox1->uniqueid[0], mailbox1->uniqueid[1], mailbox1->uniqueid);
+               u1[0], u1[1], u1);
+    const char *u3 = mailbox_uniqueid(mailbox3);
     buf_printf(&path3, "%s/data/uuid/%c/%c/%s/cyrus.annotations", DBDIR,
-               mailbox3->uniqueid[0], mailbox3->uniqueid[1], mailbox3->uniqueid);
+               u3[0], u3[1], u3);
     CU_ASSERT_EQUAL(fexists(buf_cstring(&path1)), 0);
     CU_ASSERT_EQUAL(fexists(buf_cstring(&path3)), -ENOENT);
 
@@ -859,7 +861,7 @@ static void test_rename(void)
 
     r = annotate_rename_mailbox(mailbox1, mailbox3);
     CU_ASSERT_EQUAL(r, 0);
-    r = mailbox_copy_files(mailbox1, PARTITION, MBOXNAME3_INT, mailbox3->uniqueid);
+    r = mailbox_copy_files(mailbox1, PARTITION, MBOXNAME3_INT, mailbox_uniqueid(mailbox3));
     CU_ASSERT_EQUAL(r, 0);
     r = mailbox_rename_cleanup(&mailbox1, 0);
     CU_ASSERT_EQUAL(r, 0);
@@ -1139,10 +1141,12 @@ static void test_msg_copy(void)
     CU_ASSERT_EQUAL_FATAL(r, 0);
     CU_ASSERT_PTR_NULL_FATAL(val2.s);
 
+    const char *u1 = mailbox_uniqueid(mailbox1);
     buf_printf(&path1, "%s/data/uuid/%c/%c/%s/cyrus.annotations", DBDIR,
-               mailbox1->uniqueid[0], mailbox1->uniqueid[1], mailbox1->uniqueid);
+               u1[0], u1[1], u1);
+    const char *u2 = mailbox_uniqueid(mailbox2);
     buf_printf(&path2, "%s/data/uuid/%c/%c/%s/cyrus.annotations", DBDIR,
-               mailbox2->uniqueid[0], mailbox2->uniqueid[1], mailbox2->uniqueid);
+               u2[0], u2[1], u2);
     CU_ASSERT_EQUAL(fexists(buf_cstring(&path1)), 0);
     CU_ASSERT_EQUAL(fexists(buf_cstring(&path2)), 0);
     mailbox_close(&mailbox1);
@@ -2005,11 +2009,11 @@ static int create_messages(struct mailbox *mailbox, int count)
         struct buf buf = BUF_INITIALIZER;
 
         /* Write the message to the filesystem */
-        if (!(fp = append_newstage(mailbox->name, internaldate, 0, &stage))) {
-            fprintf(stderr, "append_newstage(%s) failed", mailbox->name);
+        if (!(fp = append_newstage(mailbox_name(mailbox), internaldate, 0, &stage))) {
+            fprintf(stderr, "append_newstage(%s) failed", mailbox_name(mailbox));
             return r;
         }
-        buf_printf(&buf, msgtmpl, i, mailbox->name, i, i, mailbox->name);
+        buf_printf(&buf, msgtmpl, i, mailbox_name(mailbox), i, i, mailbox_name(mailbox));
         fwrite(buf_base(&buf), 1, buf_len(&buf), fp);
         buf_free(&buf);
         if (fclose(fp)) {
@@ -2022,13 +2026,13 @@ static int create_messages(struct mailbox *mailbox, int count)
         r = append_setup_mbox(&as, mailbox, userid, auth_state,
                 0, qdiffs, 0, 0, EVENT_MESSAGE_NEW);
         if (r) {
-            fprintf(stderr, "append_setup_mbox(%s) failed: %s", mailbox->name,
+            fprintf(stderr, "append_setup_mbox(%s) failed: %s", mailbox_name(mailbox),
                     strerror(errno));
             return r;
         }
         r = append_fromstage(&as, &body, stage, internaldate, 0, NULL, 0, NULL);
         if (r) {
-            fprintf(stderr, "append_fromstage(%s) failed: %s", mailbox->name,
+            fprintf(stderr, "append_fromstage(%s) failed: %s", mailbox_name(mailbox),
                     error_message(r));
             append_abort(&as);
             return r;
@@ -2039,7 +2043,7 @@ static int create_messages(struct mailbox *mailbox, int count)
         append_removestage(stage);
         r = append_commit(&as);
         if (r) {
-            fprintf(stderr, "append_commit(%s) failed: %s", mailbox->name,
+            fprintf(stderr, "append_commit(%s) failed: %s", mailbox_name(mailbox),
                     error_message(r));
             return r;
         }
@@ -2111,7 +2115,7 @@ static int set_up(void)
 
     memset(&mbentry, 0, sizeof(mbentry));
     mbentry.name = MBOXNAME1_INT;
-    mbentry.uniqueid = mailbox->uniqueid;
+    mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;
@@ -2134,7 +2138,7 @@ static int set_up(void)
 
     memset(&mbentry, 0, sizeof(mbentry));
     mbentry.name = MBOXNAME2_INT;
-    mbentry.uniqueid = mailbox->uniqueid;
+    mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;
@@ -2157,7 +2161,7 @@ static int set_up(void)
 
     memset(&mbentry, 0, sizeof(mbentry));
     mbentry.name = MBOXNAME3_INT;
-    mbentry.uniqueid = mailbox->uniqueid;
+    mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;

--- a/imap/append.c
+++ b/imap/append.c
@@ -1494,14 +1494,14 @@ EXPORTED int append_copy(struct mailbox *mailbox, struct appendstate *as,
 
             for (userflag = 0; userflag < MAX_USER_FLAGS; userflag++) {
                 bit32 flagmask = src_user_flags[userflag/32];
-                if (mailbox->flagname[userflag] && (flagmask & (1<<(userflag&31)))) {
+                if (mailbox->h.flagname[userflag] && (flagmask & (1<<(userflag&31)))) {
                     int num;
-                    r = mailbox_user_flag(as->mailbox, mailbox->flagname[userflag], &num, 1);
+                    r = mailbox_user_flag(as->mailbox, mailbox->h.flagname[userflag], &num, 1);
                     if (r)
                         xsyslog(LOG_ERR, "IOERROR: unable to copy flag",
                                          "flag=<%s> src_mailbox=<%s> dest_mailbox=<%s>"
                                          " uid=<%u> error=<%s>",
-                                         mailbox->flagname[userflag],
+                                         mailbox->h.flagname[userflag],
                                          mailbox_name(mailbox),
                                          mailbox_name(as->mailbox),
                                          src_uid,

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2747,10 +2747,10 @@ EXPORTED void conversation_fini(conversation_t *conv)
     conv_sender_t *sender;
     while ((sender = conv->senders)) {
         conv->senders = sender->next;
-        xfree(sender->name);
-        xfree(sender->route);
-        xfree(sender->mailbox);
-        xfree(sender->domain);
+        free(sender->name);
+        free(sender->route);
+        free(sender->mailbox);
+        free(sender->domain);
         free(sender);
     }
 

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -279,8 +279,8 @@ extern conversation_id_t conversations_guid_cid_lookup(struct conversations_stat
  )
 #define conv_guidrec_mboxcmp(rec, mbox) ( \
   ((rec)->version > CONV_GUIDREC_BYNAME_VERSION) ? \
-   strcmpsafe(conv_guidrec_uniqueid(rec), (mbox)->uniqueid) : \
-   strcmpsafe(conv_guidrec_mboxname(rec), (mbox)->name) \
+   strcmpsafe(conv_guidrec_uniqueid(rec), mailbox_uniqueid(mbox)) : \
+   strcmpsafe(conv_guidrec_mboxname(rec), mailbox_name(mbox)) \
  )
 /* F record items */
 extern int conversation_getstatus(struct conversations_state *state,

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -345,10 +345,10 @@ static int expunge_userflags(struct mailbox *mailbox, struct expire_rock *erock)
     for (i = 0; i < MAX_USER_FLAGS; i++) {
         if (erock->userflags[i/32] & 1<<(i&31))
             continue;
-        if (!mailbox->flagname[i])
+        if (!mailbox->h.flagname[i])
             continue;
         verbosep("Expunging userflag %u (%s) from %s\n",
-                        i, mailbox->flagname[i], mailbox_name(mailbox));
+                        i, mailbox->h.flagname[i], mailbox_name(mailbox));
         r = mailbox_remove_user_flag(mailbox, i);
         if (r) return r;
         erock->userflags_expunged++;

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -2931,11 +2931,12 @@ EXPORTED int propfind_quota(const xmlChar *name, xmlNsPtr ns,
                             void *rock __attribute__((unused)))
 {
     static char prevroot[MAX_MAILBOX_BUFFER];
-    char foundroot[MAX_MAILBOX_BUFFER], *qr = NULL;
+    char foundroot[MAX_MAILBOX_BUFFER];
+    const char *qr = NULL;
 
     if (fctx->mailbox) {
         /* Use the quotaroot as specified in mailbox header */
-        qr = fctx->mailbox->quotaroot;
+        qr = mailbox_quotaroot(fctx->mailbox);
     }
     else if (fctx->req_tgt->mbentry) {
         /* Find the quotaroot governing this hierarchy */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4164,8 +4164,8 @@ int meth_acl(struct transaction_t *txn, void *params)
     }
 
     r = mboxlist_sync_setacls(txn->req_tgt.mbentry->name, buf_cstring(&acl), mailbox_modseq_dirty(mailbox));
-    if (!r) r = mailbox_set_acl(mailbox, buf_cstring(&acl));
     if (!r) {
+        mailbox_set_acl(mailbox, buf_cstring(&acl));
         char *userid = mboxname_to_userid(txn->req_tgt.mbentry->name);
         r = caldav_update_shareacls(userid);
         free(userid);

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -851,11 +851,7 @@ static int _create_upload_collection(const char *accountid,
                 }
                 else {
                     /* ok, change the backup in cyrus.header */
-                    r = mailbox_set_acl(*mailbox, newacl);
-                    if (r) {
-                        syslog(LOG_ERR, "mailbox_set_acl(%s) failed: %s",
-                               mbentry->name, error_message(r));
-                    }
+                    mailbox_set_acl(*mailbox, newacl);
                 }
                 free(newacl);
             }

--- a/imap/index.c
+++ b/imap/index.c
@@ -3040,7 +3040,7 @@ index_copy(struct index_state *state,
     int checkquota = !ismove && !config_getswitch(IMAPOPT_QUOTA_USE_CONVERSATIONS);
 
     /* not moving or different quota root - need to check quota */
-    if (checkquota || strcmpsafe(srcmailbox->quotaroot, destmailbox->quotaroot)) {
+    if (checkquota || strcmpsafe(mailbox_quotaroot(srcmailbox), mailbox_quotaroot(destmailbox))) {
         for (i = 0; i < copyargs.nummsg; i++)
             qdiffs[QUOTA_STORAGE] += copyargs.records[i].size;
         qdiffs[QUOTA_MESSAGE] = copyargs.nummsg;

--- a/imap/index.c
+++ b/imap/index.c
@@ -290,12 +290,12 @@ EXPORTED void index_close(struct index_state **stateptr)
 
     index_release(state);
 
-    xfree(state->map);
-    xfree(state->mboxname);
-    xfree(state->userid);
+    free(state->map);
+    free(state->mboxname);
+    free(state->userid);
     for (i = 0; i < MAX_USER_FLAGS; i++)
-        xfree(state->flagname[i]);
-    xfree(state);
+        free(state->flagname[i]);
+    free(state);
 
     *stateptr = NULL;
 }
@@ -358,9 +358,9 @@ EXPORTED int index_open_mailbox(struct mailbox *mailbox, struct index_init *init
     return 0;
 
 fail:
-    xfree(state->mboxname);
-    xfree(state->userid);
-    xfree(state);
+    free(state->mboxname);
+    free(state->userid);
+    free(state);
     return r;
 }
 
@@ -6988,15 +6988,15 @@ void index_msgdata_free(MsgData **msgdata, unsigned int n)
 
         if (!md) continue;
 
-        xfree(md->cc);
-        xfree(md->from);
-        xfree(md->to);
-        xfree(md->displayfrom);
-        xfree(md->displayto);
-        xfree(md->xsubj);
-        xfree(md->msgid);
-        xfree(md->listid);
-        xfree(md->contenttype);
+        free(md->cc);
+        free(md->from);
+        free(md->to);
+        free(md->displayfrom);
+        free(md->displayto);
+        free(md->xsubj);
+        free(md->msgid);
+        free(md->listid);
+        free(md->contenttype);
         strarray_fini(&md->ref);
         strarray_fini(&md->annot);
     }

--- a/imap/index.c
+++ b/imap/index.c
@@ -1381,7 +1381,7 @@ EXPORTED int index_store(struct index_state *state, char *sequence,
                 if (flagsset == NULL)
                     flagsset = mboxevent_enqueue(EVENT_FLAGS_SET, &mboxevents);
 
-                mboxevent_add_flags(flagsset, mailbox->flagname,
+                mboxevent_add_flags(flagsset, mailbox->h.flagname,
                                     modified_flags.added_system_flags,
                                     modified_flags.added_user_flags);
                 mboxevent_extract_msgrecord(flagsset, msgrec);
@@ -1390,7 +1390,7 @@ EXPORTED int index_store(struct index_state *state, char *sequence,
                 if (flagsclear == NULL)
                     flagsclear = mboxevent_enqueue(EVENT_FLAGS_CLEAR, &mboxevents);
 
-                mboxevent_add_flags(flagsclear, mailbox->flagname,
+                mboxevent_add_flags(flagsclear, mailbox->h.flagname,
                                     modified_flags.removed_system_flags,
                                     modified_flags.removed_user_flags);
                 mboxevent_extract_msgrecord(flagsclear, msgrec);
@@ -3778,19 +3778,19 @@ EXPORTED void index_checkflags(struct index_state *state, int print, int dirty)
 
     for (i = 0; i < MAX_USER_FLAGS; i++) {
         /* both empty */
-        if (!mailbox->flagname[i] && !state->flagname[i])
+        if (!mailbox->h.flagname[i] && !state->flagname[i])
             continue;
 
         /* both same */
-        if (mailbox->flagname[i] && state->flagname[i] &&
-            !strcmp(mailbox->flagname[i], state->flagname[i]))
+        if (mailbox->h.flagname[i] && state->flagname[i] &&
+            !strcmp(mailbox->h.flagname[i], state->flagname[i]))
             continue;
 
         /* ok, got something to change! */
         if (state->flagname[i])
             free(state->flagname[i]);
-        if (mailbox->flagname[i])
-            state->flagname[i] = xstrdup(mailbox->flagname[i]);
+        if (mailbox->h.flagname[i])
+            state->flagname[i] = xstrdup(mailbox->h.flagname[i]);
         else
             state->flagname[i] = NULL;
 

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -3013,11 +3013,7 @@ static int set_upload_rights(const char *accountid)
     }
     else {
         /* ok, change the backup in cyrus.header */
-        r = mailbox_set_acl(mbox, newacl);
-        if (r) {
-            syslog(LOG_ERR, "mailbox_set_acl(%s) failed: %s",
-                   mailbox_name(mbox), error_message(r));
-        }
+        mailbox_set_acl(mbox, newacl);
     }
 
     mailbox_close(&mbox);
@@ -3150,14 +3146,7 @@ HIDDEN int jmap_set_sharewith(struct mailbox *mbox,
     }
     else {
         /* ok, change the backup in cyrus.header */
-        r = mailbox_set_acl(mbox, newacl);
-        if (r) {
-            syslog(LOG_ERR, "mailbox_set_acl(%s) failed: %s",
-                   mailbox_name(mbox), error_message(r));
-        }
-    }
-
-    if (!r) {
+        mailbox_set_acl(mbox, newacl);
         /* Set proper access rights on JMAP upload folder */
         r = set_upload_rights(owner);
     }

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1579,11 +1579,11 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
         if (!(rrock->jrestore->mode & DRY_RUN) && userflag >= 0
             && (record->user_flags[userflag/32] & (1<<userflag%31))) {
             struct mailbox_plan *plan =
-                hash_lookup(mailbox->name, mrock->mailboxes);
+                hash_lookup(mailbox_name(mailbox), mrock->mailboxes);
             if (!plan) {
                 /* Create a plan for this mailbox */
                 plan = xzmalloc(sizeof(struct mailbox_plan));
-                hash_insert(mailbox->name, plan, mrock->mailboxes);
+                hash_insert(mailbox_name(mailbox), plan, mrock->mailboxes);
             }
 
             /* Add this UID to the unflag array */
@@ -1996,7 +1996,7 @@ static void restore_mailbox_cb(const char *mboxname, void *data, void *rock)
                 if (r) {
                     syslog(LOG_ERR,
                            "IOERROR: failed to rewrite index record for %s:%u",
-                           mailbox->name, record.uid);
+                           mailbox_name(mailbox), record.uid);
                 }
             }
             if (restore) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5830,8 +5830,8 @@ static int _email_keywords_add_msgrecord(struct email_keywords *keywords,
     struct buf buf = BUF_INITIALIZER;
     int i;
     for (i = 0 ; i < MAX_USER_FLAGS ; i++) {
-        if (mbox->flagname[i] && (user_flags[i/32] & 1<<(i&31))) {
-            buf_setcstr(&buf, mbox->flagname[i]);
+        if (mbox->h.flagname[i] && (user_flags[i/32] & 1<<(i&31))) {
+            buf_setcstr(&buf, mbox->h.flagname[i]);
             _email_keywords_add_keyword(keywords, buf_lcase(&buf));
         }
     }
@@ -12082,14 +12082,14 @@ static void _email_bulkupdate_exec_setflags(struct email_bulkupdate *bulk)
                                     add_seenseq, del_seenseq, &modflags);
             if (!r) {
                 if (modflags.added_flags) {
-                    mboxevent_add_flags(flagsset, plan->mbox->flagname,
+                    mboxevent_add_flags(flagsset, plan->mbox->h.flagname,
                                         modflags.added_system_flags,
                                         modflags.added_user_flags);
                     mboxevent_extract_msgrecord(flagsset, mrw);
                     notify_flagsset = 1;
                 }
                 if (modflags.removed_flags) {
-                    mboxevent_add_flags(flagsclear, plan->mbox->flagname,
+                    mboxevent_add_flags(flagsclear, plan->mbox->h.flagname,
                                         modflags.removed_system_flags,
                                         modflags.removed_user_flags);
                     mboxevent_extract_msgrecord(flagsclear, mrw);
@@ -12950,14 +12950,14 @@ static int _email_copy_writeprops_cb(const conv_guidrec_t* rec, void* _rock)
         if (!r) {
             if (modflags.added_flags) {
                 mboxevent_extract_msgrecord(flagsset, mr);
-                mboxevent_add_flags(flagsset, mbox->flagname,
+                mboxevent_add_flags(flagsset, mbox->h.flagname,
                                     modflags.added_system_flags,
                                     modflags.added_user_flags);
                 notify_flagsset = 1;
             }
             if (modflags.removed_flags) {
                 mboxevent_extract_msgrecord(flagsclear, mr);
-                mboxevent_add_flags(flagsclear, mbox->flagname,
+                mboxevent_add_flags(flagsclear, mbox->h.flagname,
                                     modflags.removed_system_flags,
                                     modflags.removed_user_flags);
                 notify_flagsclear = 1;

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -327,7 +327,9 @@ EXPORTED void jmap_emailsubmission_envelope_to_smtp(smtp_envelope_t *smtpenv,
 EXPORTED json_t *jmap_fetch_snoozed(const char *mbox, uint32_t uid)
 {
     /* get the snoozed annotation */
-    struct mailbox mailbox = { .name = (char *) mbox, .uniqueid = NULL };
+    mbentry_t mbentry = MBENTRY_INITIALIZER;
+    mbentry.name = (char *)mbox;
+    struct mailbox mailbox = { .mbentry = &mbentry };
     const char *annot = IMAP_ANNOT_NS "snoozed";
     struct buf value = BUF_INITIALIZER;
     json_t *snooze = NULL;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -7929,8 +7929,7 @@ HIDDEN int mailbox_changequotaroot(struct mailbox *mailbox,
     }
 
     /* update (or set) the quotaroot */
-    r = mailbox_set_quotaroot(mailbox, root);
-    if (r) goto done;
+    mailbox_set_quotaroot(mailbox, root);
 
     if (root) {
         /* update the new quota root */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1167,6 +1167,11 @@ EXPORTED modseq_t mailbox_foldermodseq(const struct mailbox *mailbox)
     return mailbox->foldermodseq;
 }
 
+EXPORTED const char *mailbox_quotaroot(const struct mailbox *mailbox)
+{
+    return mailbox->quotaroot;
+}
+
 EXPORTED void mailbox_index_dirty(struct mailbox *mailbox)
 {
     assert(mailbox_index_islocked(mailbox, 1));
@@ -2870,7 +2875,7 @@ HIDDEN int mailbox_commit_quota(struct mailbox *mailbox)
     mailbox->quota_dirty = 0;
 
     /* no quota root means we don't track quota.  That's OK */
-    if (!mailbox->quotaroot)
+    if (!mailbox_quotaroot(mailbox))
         return 0;
 
     mailbox_get_usage(mailbox, quota_usage);
@@ -2886,7 +2891,7 @@ HIDDEN int mailbox_commit_quota(struct mailbox *mailbox)
 
     assert(mailbox_index_islocked(mailbox, 1));
 
-    quota_update_useds(mailbox->quotaroot, quota_usage,
+    quota_update_useds(mailbox_quotaroot(mailbox), quota_usage,
                        mailbox_name(mailbox), mailbox->silentchanges);
     /* XXX - fail upon issue?  It's tempting */
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -600,9 +600,10 @@ extern int mailbox_read_basecid(struct mailbox *mailbox,
                                 const struct index_record *record);
 
 
-extern void mailbox_set_uniqueid(struct mailbox *mailbox, const char *uniqueid);
+// header updates
 extern void mailbox_set_acl(struct mailbox *mailbox, const char *acl);
 extern void mailbox_set_quotaroot(struct mailbox *mailbox, const char *quotaroot);
+
 extern int mailbox_user_flag(struct mailbox *mailbox, const char *flag,
                              int *flagnum, int create);
 extern int mailbox_remove_user_flag(struct mailbox *mailbox, int flagnum);

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -570,6 +570,7 @@ extern const char *mailbox_name(const struct mailbox *mailbox);
 extern const char *mailbox_uniqueid(const struct mailbox *mailbox);
 extern const char *mailbox_partition(const struct mailbox *mailbox);
 extern const char *mailbox_acl(const struct mailbox *mailbox);
+extern const char *mailbox_quotaroot(const struct mailbox *mailbox);
 extern uint32_t mailbox_mbtype(const struct mailbox *mailbox);
 extern modseq_t mailbox_foldermodseq(const struct mailbox *mailbox);
 
@@ -664,7 +665,7 @@ extern int mailbox_setversion(struct mailbox *mailbox, int version);
 extern int mailbox_index_recalc(struct mailbox *mailbox);
 
 #define mailbox_quota_check(mailbox, delta) \
-        (mailbox->quotaroot ? quota_check_useds((mailbox)->quotaroot, delta) : 0)
+        (mailbox_quotaroot(mailbox) ? quota_check_useds(mailbox_quotaroot(mailbox), delta) : 0)
 void mailbox_get_usage(struct mailbox *mailbox,
                         quota_t usage[QUOTA_NUMRESOURCES]);
 void mailbox_annot_changed(struct mailbox *mailbox,

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -240,6 +240,15 @@ struct index_change {
 
 #define INDEX_MAP_SIZE 65536
 
+struct mailbox_header {
+    char *name;
+    char *acl;
+    char *uniqueid;
+    char *quotaroot;
+    char *flagname[MAX_USER_FLAGS];
+    int mbtype;
+};
+
 struct mailbox {
     int index_fd;
     int header_fd;
@@ -259,19 +268,14 @@ struct mailbox {
     size_t index_size;
 
     /* Information in mailbox list */
-    char *name;
-    uint32_t mbtype;
-    char *part;
-    char *acl;
-    modseq_t foldermodseq;
+    struct mboxlist_entry *mbentry;
 
     struct index_header i;
 
     /* Information in header */
-    char *uniqueid;
-    char *quotaroot;
-    char *flagname[MAX_USER_FLAGS];
+    struct mailbox_header h;
 
+    /* track open time */
     struct timeval starttime;
 
     /* annotations */
@@ -597,8 +601,8 @@ extern int mailbox_read_basecid(struct mailbox *mailbox,
 
 
 extern void mailbox_set_uniqueid(struct mailbox *mailbox, const char *uniqueid);
-extern int mailbox_set_acl(struct mailbox *mailbox, const char *acl);
-extern int mailbox_set_quotaroot(struct mailbox *mailbox, const char *quotaroot);
+extern void mailbox_set_acl(struct mailbox *mailbox, const char *acl);
+extern void mailbox_set_quotaroot(struct mailbox *mailbox, const char *quotaroot);
 extern int mailbox_user_flag(struct mailbox *mailbox, const char *flag,
                              int *flagnum, int create);
 extern int mailbox_remove_user_flag(struct mailbox *mailbox, int flagnum);

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -1282,7 +1282,7 @@ EXPORTED int undump_mailbox(const char *mbname,
         }
 
         /* update the quota if necessary */
-        if (mailbox->quotaroot) {
+        if (mailbox_quotaroot(mailbox)) {
             quota_t quota_usage[QUOTA_NUMRESOURCES];
             int res;
             int changed = 0;
@@ -1296,7 +1296,7 @@ EXPORTED int undump_mailbox(const char *mbname,
             }
 
             if (changed) {
-                r = quota_update_useds(mailbox->quotaroot, quota_usage, NULL, 0);
+                r = quota_update_useds(mailbox_quotaroot(mailbox), quota_usage, NULL, 0);
                 if (r) goto done2;
             }
         }

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -216,8 +216,8 @@ static int do_examine(struct findall_data *data, void *rock __attribute__((unuse
     printf("  User Flags: ");
 
     for (i = 0; i < MAX_USER_FLAGS; i++) {
-        if (!mailbox->flagname[i]) break;
-        printf("%s ", mailbox->flagname[i]);
+        if (!mailbox->h.flagname[i]) break;
+        printf("%s ", mailbox->h.flagname[i]);
     }
 
     if (!i) printf("[none]");

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3168,9 +3168,12 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
 {
     struct mailbox *mailbox = NULL;
     int r = mailbox_open_iwl(name, &mailbox);
-    if (!r) r = mboxlist_sync_setacls(name, newacl, mailbox_modseq_dirty(mailbox));
-    if (!r) mailbox_set_acl(mailbox, newacl);
-    if (!r) r = mailbox_commit(mailbox);
+    if (!r)
+        r = mboxlist_sync_setacls(name, newacl, mailbox_modseq_dirty(mailbox));
+    if (!r) {
+        mailbox_set_acl(mailbox, newacl);
+        r = mailbox_commit(mailbox);
+    }
     mailbox_close(&mailbox);
     return r;
 }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2556,7 +2556,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
          * codepaths: INBOX -> INBOX.foo, user rename, regular rename
          * and of course this one, partition move */
         newpartition = xstrdup(partition);
-        r = mailbox_copy_files(oldmailbox, newpartition, newname, oldmailbox->mbtype & MBTYPE_LEGACY_DIRS ? NULL : mailbox_uniqueid(oldmailbox));
+        r = mailbox_copy_files(oldmailbox, newpartition, newname, mailbox_mbtype(oldmailbox) & MBTYPE_LEGACY_DIRS ? NULL : mailbox_uniqueid(oldmailbox));
         if (r) goto done;
         newmbentry = mboxlist_entry_create();
         newmbentry->mbtype = mailbox_mbtype(oldmailbox);
@@ -2862,10 +2862,10 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
                     mboxevent_extract_mailbox(mboxevent, oldmailbox);
                 else {
                     /* New maibox is the same as old, except for the name */
-                    oldname = mailbox_name(oldmailbox);
-                    oldmailbox->name = (char *) newname;
+                    char *name = oldmailbox->mbentry->name;
+                    oldmailbox->mbentry->name = (char *) newname;
                     mboxevent_extract_mailbox(mboxevent, oldmailbox);
-                    oldmailbox->name = (char *) oldname;
+                    oldmailbox->mbentry->name = name;
 
                     mboxevent_extract_old_mailbox(mboxevent, oldmailbox);
                 }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1632,12 +1632,12 @@ EXPORTED int mboxlist_promote_intermediary(const char *mboxname)
 
     mbentry->mbtype |= (parent->mbtype & MBTYPE_LEGACY_DIRS);
 
-    xfree(mbentry->partition);
+    xzfree(mbentry->partition);
     r = mboxlist_create_partition(mboxname, parent->partition,
                                   &mbentry->partition);
     if (r) goto done;
     mbentry->mbtype &= ~MBTYPE_INTERMEDIATE;
-    xfree(mbentry->acl);
+    xzfree(mbentry->acl);
     mbentry->acl = xstrdupnull(parent->acl);
 
     r = mailbox_create(mboxname, mbentry->mbtype,
@@ -1652,7 +1652,7 @@ EXPORTED int mboxlist_promote_intermediary(const char *mboxname)
     if (r) goto done;
 
     // make sure all the fields are up-to-date
-    xfree(mbentry->uniqueid);
+    xzfree(mbentry->uniqueid);
     mbentry->uniqueid = xstrdupnull(mailbox_uniqueid(mailbox));
     mbentry->uidvalidity = mailbox->i.uidvalidity;
     mbentry->createdmodseq = mailbox->i.createdmodseq;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -4554,8 +4554,8 @@ static int mboxlist_rmquota(const mbentry_t *mbentry, void *rock)
     r = mailbox_open_iwl(mbentry->name, &mailbox);
     if (r) goto done;
 
-    if (mailbox->quotaroot) {
-        if (strcmp(mailbox->quotaroot, oldroot)) {
+    if (mailbox_quotaroot(mailbox)) {
+        if (strcmp(mailbox_quotaroot(mailbox), oldroot)) {
             /* Part of a different quota root */
             goto done;
         }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3169,7 +3169,7 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
     struct mailbox *mailbox = NULL;
     int r = mailbox_open_iwl(name, &mailbox);
     if (!r) r = mboxlist_sync_setacls(name, newacl, mailbox_modseq_dirty(mailbox));
-    if (!r) r = mailbox_set_acl(mailbox, newacl);
+    if (!r) mailbox_set_acl(mailbox, newacl);
     if (!r) r = mailbox_commit(mailbox);
     mailbox_close(&mailbox);
     return r;
@@ -4560,7 +4560,7 @@ static int mboxlist_rmquota(const mbentry_t *mbentry, void *rock)
             goto done;
         }
 
-        r = mailbox_set_quotaroot(mailbox, NULL);
+        mailbox_set_quotaroot(mailbox, NULL);
     }
 
  done:

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -232,16 +232,23 @@ static int do_reid(const mbname_t *mbname)
     r = mailbox_open_iwl(name, &mailbox);
     if (r) return r;
 
-    mailbox_make_uniqueid(mailbox);
+    if (mailbox_mbtype(mailbox) & MBTYPE_LEGACY_DIRS) {
+        mailbox_make_uniqueid(mailbox);
+    }
+    else {
+        printf("Non-legacy mailbox, cannot reid: %s", extname);
+        goto done;
+    }
 
     r = mboxlist_lookup(name, &mbentry, NULL);
-    if (r) return r;
+    if (r) goto done;
 
     free(mbentry->uniqueid);
     mbentry->uniqueid = xstrdup(mailbox_uniqueid(mailbox));
 
     mboxlist_update(mbentry, 0);
 
+done:
     mailbox_close(&mailbox);
 
     /* printf("did reid %s\n", mboxname); */

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -481,9 +481,9 @@ static int fixquota_dombox(const mbentry_t *mbentry, void *rock)
     if (thisquota == -1) {
         /* no matching quotaroot exists, remove from
          * mailbox if present */
-        if (mailbox->quotaroot) {
+        if (mailbox_quotaroot(mailbox)) {
             /* unless it's outside the current prefix of course */
-            if (strlen(mailbox->quotaroot) < prefixlen) goto done;
+            if (strlen(mailbox_quotaroot(mailbox)) < prefixlen) goto done;
             r = fixquota_fixroot(mailbox, NULL);
             if (r) goto done;
         }
@@ -496,8 +496,7 @@ static int fixquota_dombox(const mbentry_t *mbentry, void *rock)
 
         /* matching quotaroot exists, ensure mailbox has the
          * correct root */
-        if (!mailbox->quotaroot ||
-            strcmp(mailbox->quotaroot, root) != 0) {
+        if (strcmpsafe(mailbox_quotaroot(mailbox), root)) {
             r = fixquota_fixroot(mailbox, root);
             if (r) goto done;
         }
@@ -539,8 +538,9 @@ int fixquota_fixroot(struct mailbox *mailbox,
 {
     int r;
 
+    const char *oldroot = mailbox_quotaroot(mailbox);
     fprintf(stderr, "%s: quota root %s --> %s\n", mailbox_name(mailbox),
-           mailbox->quotaroot ? mailbox->quotaroot : "(none)",
+           oldroot ? oldroot : "(none)",
            root ? root : "(none)");
 
     r = mailbox_set_quotaroot(mailbox, root);

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -536,17 +536,14 @@ done:
 int fixquota_fixroot(struct mailbox *mailbox,
                      const char *root)
 {
-    int r;
-
     const char *oldroot = mailbox_quotaroot(mailbox);
     fprintf(stderr, "%s: quota root %s --> %s\n", mailbox_name(mailbox),
            oldroot ? oldroot : "(none)",
            root ? root : "(none)");
 
-    r = mailbox_set_quotaroot(mailbox, root);
-    if (r) errmsg(r, "failed writing header for mailbox '%s'", mailbox_name(mailbox));
+    mailbox_set_quotaroot(mailbox, root);
 
-    return r;
+    return 0;
 }
 
 /*

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -499,7 +499,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
     if (strcmpsafe(mailbox_uniqueid(mailbox), mbentry_byname->uniqueid)) {
         printf("Wrong uniqueid in mbentry, fixing %s (%s -> %s)\n",
                name, mbentry_byname->uniqueid, mailbox_uniqueid(mailbox));
-        xfree(mbentry_byname->uniqueid);
+        xzfree(mbentry_byname->uniqueid);
         mbentry_byname->uniqueid = xstrdupnull(mailbox_uniqueid(mailbox));
         mbentry_dirty = 1;
     }
@@ -519,7 +519,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
         printf("Wrong uniqueid! %s (should be %s)\n", mbentry_byid->name, name);
         if (updateuniqueids) {
             mailbox_make_uniqueid(mailbox);
-            xfree(mbentry_byname->uniqueid);
+            xzfree(mbentry_byname->uniqueid);
             mbentry_byname->uniqueid = xstrdupnull(mailbox_uniqueid(mailbox));
             mbentry_dirty = 1;
             syslog (LOG_ERR, "uniqueid clash with %s - changed %s (%s => %s)",
@@ -581,14 +581,14 @@ static int do_reconstruct(struct findall_data *data, void *rock)
         if (prefer_mbentry) {
             printf("Wrong partition in mailbox %s (%s %s)\n",
                    name, mbentry_byname->partition, mailbox_partition(mailbox));
-            xfree(mailbox->part);
+            xzfree(mailbox->part);
             mailbox->part = xstrdupnull(mbentry_byname->partition);
             mailbox->header_dirty = 1;
         }
         else {
             printf("Wrong partition in mbentry %s (%s %s)\n",
                    name, mailbox_partition(mailbox), mbentry_byname->partition);
-            xfree(mbentry_byname->partition);
+            xzfree(mbentry_byname->partition);
             mbentry_byname->partition = xstrdupnull(mailbox_partition(mailbox));
             mbentry_dirty = 1;
         }
@@ -604,7 +604,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
         else {
             printf("Wrong acl in mbentry %s (%s %s)\n",
                    name, mbentry_byname->acl, mailbox_acl(mailbox));
-            xfree(mbentry_byname->acl);
+            xzfree(mbentry_byname->acl);
             mbentry_byname->acl = xstrdupnull(mailbox_acl(mailbox));
             mbentry_dirty = 1;
         }

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -576,24 +576,6 @@ static int do_reconstruct(struct findall_data *data, void *rock)
         }
     }
 
-    // how can this even happen?  Dunno, but here for completeness
-    if (strcmpsafe(mailbox_partition(mailbox), mbentry_byname->partition)) {
-        if (prefer_mbentry) {
-            printf("Wrong partition in mailbox %s (%s %s)\n",
-                   name, mbentry_byname->partition, mailbox_partition(mailbox));
-            xzfree(mailbox->part);
-            mailbox->part = xstrdupnull(mbentry_byname->partition);
-            mailbox->header_dirty = 1;
-        }
-        else {
-            printf("Wrong partition in mbentry %s (%s %s)\n",
-                   name, mailbox_partition(mailbox), mbentry_byname->partition);
-            xzfree(mbentry_byname->partition);
-            mbentry_byname->partition = xstrdupnull(mailbox_partition(mailbox));
-            mbentry_dirty = 1;
-        }
-    }
-
     if (strcmpsafe(mailbox_acl(mailbox), mbentry_byname->acl)) {
         if (prefer_mbentry) {
             printf("Wrong acl in mbentry %s (%s %s)\n",

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
 
                     r = mailbox_open_iwl(mbentry->name, &mailbox);
                     if (!r) {
-                        mailbox->mbtype = mbentry->mbtype;
+                        mailbox->h.mbtype = mbentry->mbtype;
                         mailbox->header_dirty = 1;
                         mailbox_close(&mailbox);
                     }

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -2366,7 +2366,7 @@ static void search_seen_internalise(struct index_state *state,
             int r = seen_open(v->s, SEEN_SILENT, &seendb);
             if (!r) {
                 struct seendata sd = SEENDATA_INITIALIZER;
-                r = seen_read(seendb, state->mailbox->uniqueid, &sd);
+                r = seen_read(seendb, mailbox_uniqueid(state->mailbox), &sd);
                 if (!r) {
                     seen = seqset_parse(sd.seenuids, NULL, sd.lastuid);
                     seen_freedata(&sd);
@@ -2375,7 +2375,7 @@ static void search_seen_internalise(struct index_state *state,
                 else {
                     xsyslog(LOG_WARNING, "can not read seen data",
                             "userid=<%s> mboxid=<%s> err=<%s>",
-                            v->s, state->mailbox->uniqueid, error_message(r));
+                            v->s, mailbox_uniqueid(state->mailbox), error_message(r));
                 }
             }
             else {

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3084,8 +3084,8 @@ int sync_apply_mailbox(struct dlist *kin,
 
     /* always take the ACL from the master, it's not versioned */
     r = mboxlist_sync_setacls(mboxname, acl, foldermodseq ? foldermodseq : highestmodseq);
-    if (!r) r = mailbox_set_acl(mailbox, acl);
     if (r) goto done;
+    mailbox_set_acl(mailbox, acl);
 
     /* take all mailbox (not message) annotations - aka metadata,
      * they're not versioned either */

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -1720,11 +1720,11 @@ void sync_print_flags(struct dlist *kl,
 
     /* print user flags in mailbox order */
     for (flag = 0; flag < MAX_USER_FLAGS; flag++) {
-        if (!mailbox->flagname[flag])
+        if (!mailbox->h.flagname[flag])
             continue;
         if (!(record->user_flags[flag/32] & (1<<(flag&31))))
             continue;
-        dlist_setflag(fl, "FLAG", mailbox->flagname[flag]);
+        dlist_setflag(fl, "FLAG", mailbox->h.flagname[flag]);
     }
 }
 
@@ -5322,11 +5322,11 @@ static const char *make_flags(struct mailbox *mailbox, struct index_record *reco
 
     /* print user flags in mailbox order */
     for (flag = 0; flag < MAX_USER_FLAGS; flag++) {
-        if (!mailbox->flagname[flag])
+        if (!mailbox->h.flagname[flag])
             continue;
         if (!(record->user_flags[flag/32] & (1<<(flag&31))))
             continue;
-        snprintf(buf, 4096, "%s%s", sep, mailbox->flagname[flag]);
+        snprintf(buf, 4096, "%s%s", sep, mailbox->h.flagname[flag]);
         sep = " ";
     }
 
@@ -5991,7 +5991,7 @@ static int update_mailbox_once(struct sync_client_state *sync_cs,
     /* bump the foldermodseq if it's higher on the replica */
     if (remote && remote->foldermodseq > mailbox_foldermodseq(mailbox)) {
         mboxlist_sync_setacls(mailbox_name(mailbox), mailbox_acl(mailbox), remote->foldermodseq);
-        mailbox->foldermodseq = remote->foldermodseq;
+        mailbox->mbentry->foldermodseq = remote->foldermodseq;
     }
 
     /* nothing changed - nothing to send */

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2052,8 +2052,8 @@ static int sync_prepare_dlists(struct mailbox *mailbox,
     dlist_setatom(kl, "PARTITION", topart);
     dlist_setatom(kl, "ACL", mailbox_acl(mailbox));
     dlist_setatom(kl, "OPTIONS", sync_encode_options(mailbox->i.options));
-    if (mailbox->quotaroot)
-        dlist_setatom(kl, "QUOTAROOT", mailbox->quotaroot);
+    if (mailbox_quotaroot(mailbox))
+        dlist_setatom(kl, "QUOTAROOT", mailbox_quotaroot(mailbox));
 
     if (mailbox->i.createdmodseq)
         dlist_setnum64(kl, "CREATEDMODSEQ", mailbox->i.createdmodseq);
@@ -3276,8 +3276,8 @@ static int sync_mailbox_byentry(const mbentry_t *mbentry, void *rock)
     /* and make it hold a transaction open */
     annotate_state_begin(astate);
 
-    if (qrl && mailbox->quotaroot)
-        sync_name_list_add(qrl, mailbox->quotaroot);
+    if (qrl && mailbox_quotaroot(mailbox))
+        sync_name_list_add(qrl, mailbox_quotaroot(mailbox));
 
     r = sync_prepare_dlists(mailbox, NULL, NULL, NULL, NULL, kl, NULL, 0,
                             /*XXX fullannots*/1, 0);
@@ -6632,9 +6632,8 @@ static int do_mailbox_info(const mbentry_t *mbentry, void *rock)
     }
     if (r) goto done;
 
-    if (info->quotalist && mailbox->quotaroot) {
-        sync_name_list_add(info->quotalist, mailbox->quotaroot);
-    }
+    if (info->quotalist && mailbox_quotaroot(mailbox))
+        sync_name_list_add(info->quotalist, mailbox_quotaroot(mailbox));
 
     sync_name_list_add(info->mboxlist, mbentry->name);
 

--- a/lib/hashset.c
+++ b/lib/hashset.c
@@ -122,6 +122,6 @@ EXPORTED int hashset_exists(struct hashset *hs, const void *data)
 
 EXPORTED void hashset_free(struct hashset **hsp)
 {
-    xfree((*hsp)->data);
+    free((*hsp)->data);
     xzfree(*hsp);
 }

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -204,12 +204,12 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
           int cmpresult = u64cmp(key, ptr->key);
           if (!cmpresult)
           {
-              if (last != NULL )
+              if (last != NULL)
               {
-                  data = ptr -> data;
-                  last -> next = ptr -> next;
+                  data = ptr->data;
+                  last->next = ptr->next;
                   if(!table->pool) {
-                      xfree(ptr);
+                      free(ptr);
                   }
                   return data;
               }
@@ -227,7 +227,7 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
                   data = ptr->data;
                   (table->table)[val] = ptr->next;
                   if(!table->pool) {
-                      xfree(ptr);
+                      free(ptr);
                   }
                   return data;
               }
@@ -271,7 +271,7 @@ EXPORTED void free_hashu64_table(hashu64_table *table, void (*func)(void *))
                   if (func)
                       func(temp->data);
                   if(!table->pool) {
-                      xfree(temp);
+                      free(temp);
                   }
               }
           }
@@ -282,7 +282,7 @@ EXPORTED void free_hashu64_table(hashu64_table *table, void (*func)(void *))
           free_mpool(table->pool);
           table->pool = NULL;
       } else {
-          xfree(table->table);
+          free(table->table);
       }
       table->table = NULL;
       table->size = 0;

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -195,7 +195,7 @@ EXPORTED int strarray_appendm(strarray_t *sa, char *s)
 
 static void _strarray_set(strarray_t *sa, int idx, char *s)
 {
-    xfree(sa->data[idx]);
+    free(sa->data[idx]);
     sa->data[idx] = s;
     /* adjust the count if we just sparsely expanded the array */
     if (s && idx >= sa->count)

--- a/lib/xmalloc.h
+++ b/lib/xmalloc.h
@@ -58,12 +58,7 @@ extern char *xstrdupsafe (const char *str);
 extern char *xstrndup (const char *str, size_t len);
 extern void *xmemdup (const void *ptr, size_t size);
 
-// this can be used on lvalues (e.g. function returns)
-#define xfree(ptr) do { \
-  void *x = ptr; if (x) { free(x); } \
-} while (0)
-
-// NOTE - can not be used on things that can't be lvalues :)
+// free a pointer and also zero it
 #define xzfree(ptr) do { \
   if (ptr) { free(ptr); ptr = NULL; } \
 } while (0)


### PR DESCRIPTION
This is the stuff I was working on a couple of weeks ago and shelved.  The big part is the commit which stores a separate sub-struct for the header data, and an `mbentry_t *` directly inside `struct mailbox`.

Apologies for the one big messy commit which makes a couple of changes all together, I've separated out what I can as practical individual changes.

The IMPORTANT bit is that we can handle gaps in `flagnames` correctly now - it was buggy before (both UUID and pre-UUID I think), and would forget all the names after the first gap.

This all passes Cassandane still.