### PR TITLE
Add 'caldav_accept_invalid_rrules' option.

### DIFF
--- a/changes/next/invalid_rrule_handling
+++ b/changes/next/invalid_rrule_handling
@@ -1,0 +1,13 @@
+Description:
+
+Adds a setting to accept invalid RRULEs rather than rejecting them.
+
+
+Config changes:
+
+Adds 'caldav_accept_invalid_rrules' option.
+
+
+Upgrade instructions:
+
+None.

--- a/configure.ac
+++ b/configure.ac
@@ -1638,6 +1638,11 @@ dnl
                 AC_DEFINE(HAVE_NEW_CLONE_API,[],
                         [Do we have support for new clone API?]))
 
+        dnl ical_set_invalid_rrule_handling_setting, was added in libical 3.0.9
+        AC_CHECK_LIB(ical, ical_set_invalid_rrule_handling_setting,
+                AC_DEFINE(HAVE_INVALID_RRULE_HANDLING,[],
+                        [Do we have support for controlling invalid RRULE handline?]))
+
 dnl  Don't bother checking for DKIM until iSchedule gains traction
 dnl        PKG_CHECK_MODULES([DKIM], [opendkim >= 2.7.0],
 dnl                AC_EGREP_HEADER(DKIM_CANON_ISCHEDULE, dkim.h,

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -719,6 +719,15 @@ static void my_caldav_init(struct buf *serverinfo)
     if (config_getswitch(IMAPOPT_CALDAV_ALLOWATTACH))
         namespace_calendar.allow |= ALLOW_CAL_ATTACH;
 
+    if (config_getswitch(IMAPOPT_CALDAV_ACCEPT_INVALID_RRULES)) {
+#ifdef HAVE_INVALID_RRULE_HANDLING
+        ical_set_invalid_rrule_handling_setting(ICAL_RRULE_IGNORE_INVALID);
+#else
+        syslog(LOG_WARNING,
+               "Your version of libical can not accept invalid RRULEs");
+#endif
+    }
+
     if (namespace_tzdist.enabled) {
         namespace_calendar.allow |= ALLOW_CAL_NOTZ;
     }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -560,6 +560,10 @@ Blank lines and lines beginning with ``#'' are ignored.
    layers of MIME structure.  The default of 1000 is much higher
    than any sane message should have. */
 
+{ "caldav_accept_invalid_rrules", 0, SWITCH, "UNRELEASED" }
+/* Accept invalid RRULEs (e.g. FREQ=WEEKLY;BYMONTHDAY=15)
+  rather than rejecting them as errors. */
+
 { "caldav_allowattach", 1, SWITCH, "3.0.0" }
 /* Enable managed attachments support on the CalDAV server. */
 


### PR DESCRIPTION
Adds a setting to accept invalid RRULEs (e.g. FREQ=WEEKLY;BYMONTHDAY=15) rather than rejecting them.