### PR TITLE
Reconstruct times

### DIFF
--- a/cunit/times.testc
+++ b/cunit/times.testc
@@ -474,22 +474,20 @@ test_rfc5322(void)
     CU_ASSERT_EQUAL(r, 31);
     CU_ASSERT_EQUAL(t, 0);
 
-    /* Zero Hour */
+    /* Zero Hour - we don't allow it any more, because the date returns negative */
     t = UNINIT_TIMET;
     r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29 -0500", &t, DATETIME_FULL); /* NYC */
-    CU_ASSERT_EQUAL(r, 31);
-    CU_ASSERT_EQUAL(t, 2189);
+    CU_ASSERT_EQUAL(r, -1);
 
     t = UNINIT_TIMET;
     r = time_from_rfc5322(" 1-JAN-1970 11:36:29 +1100", &t, DATETIME_FULL); /* MEL */
     CU_ASSERT_EQUAL(r, 26);
     CU_ASSERT_EQUAL(t, 2189);
 
-    /* Pre Jan 1 1970 */
+    /* Pre Jan 1 1970 - we don't allow */
     t = UNINIT_TIMET;
     r = time_from_rfc5322("WED, 31 DEC 1969 19:36:29", &t, DATETIME_FULL);
-    CU_ASSERT_EQUAL(r, 25);
-    CU_ASSERT_EQUAL(t, -15811);
+    CU_ASSERT_EQUAL(r, -1);
 
     /* Well-formed full RFC5322 format with 2-digit day
      * "dd-mmm-yyyy HH:MM:SS zzzzz" */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4082,6 +4082,10 @@ static void cmd_append(char *tag, char *name, const char *cur_name)
                 r = message_parse_binary_file(curstage->f, &body, NULL);
                 fclose(curstage->f);
                 curstage->f = NULL;
+                /* free this up again - that way we re-parse the fixed up file */
+                message_free_body(body);
+                free(body);
+                body = NULL;
             }
             if (!r) {
                 r = append_fromstage(&appendstate, &body, curstage->stage,
@@ -4090,8 +4094,6 @@ static void cmd_append(char *tag, char *name, const char *cur_name)
                                      &curstage->annotations);
             }
             if (body) {
-                /* Note: either the calls to message_parse_binary_file()
-                 * or append_fromstage() above, may create a body.  */
                 message_free_body(body);
                 free(body);
                 body = NULL;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6920,6 +6920,16 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
         else
             record->internaldate = time(NULL);
     }
+    if (!record->gmtime)
+        record->gmtime = record->internaldate;
+    if (!record->sentdate) {
+        struct tm *tm = localtime(&record->internaldate);
+        /* truncate to the day */
+        tm->tm_sec = 0;
+        tm->tm_min = 0;
+        tm->tm_hour = 0;
+        record->sentdate = mktime(tm);
+    }
 
     /* XXX - conditions under which modseq or uid or internaldate could be bogus? */
     if (record->modseq > mailbox->i.highestmodseq) {

--- a/lib/times.c
+++ b/lib/times.c
@@ -1368,7 +1368,8 @@ EXPORTED int time_from_rfc5322(const char *s, time_t *date,
     else
         tmp_time = mkgmtime(&tm);
 
-    if (tmp_time == -1)
+    /* -1 is an error, but anything else below zero is also a negative time which we can't handle */
+    if (tmp_time < 0)
         goto baddate;
 
     *date = tmp_time - tzone_offset;


### PR DESCRIPTION
This fixes so that 'reconstruct -G' works in Cassandane (and also for production).

If there date header is ahead of GMT and exactly zero, e.g:

Thu, 01 Jan 1970 10:00:00 +1000

Then the "gmtime" field was set to a massively high number instead of the past.  Oops.

Also, it didn't get reset properly from zero by the reconstruct code in the same way that the append code did, so a reconstruct would zero it again if there was no header in the message.

ALSO: I've added an unrelated commit except that `reconstruct -G` also found it, append-binary needs to re-parse the message after the parse_binary, because the cache structure is slightly different on the second parse - and we want to make sure the structure we store is the correct one for a reconstruct.  Passes the ImapTest.append-binary test again now.

Tested in https://github.com/cyrusimap/cassandane/pull/155