### PR TITLE
cyr_dbtool: document flags

### DIFF
--- a/imap/cyr_dbtool.c
+++ b/imap/cyr_dbtool.c
@@ -327,6 +327,11 @@ int main(int argc, char *argv[])
 
         fprintf(stderr, "\n");
         fprintf(stderr, "\n");
+        fprintf(stderr, "Options:\n");
+        fprintf(stderr, "  -c     convert database to named backend if not already\n");
+        fprintf(stderr, "  -M     use \"improved_mboxlist_sort\" order\n");
+        fprintf(stderr, "  -n     create the database if it doesn't exist\n");
+        fprintf(stderr, "\n");
         fprintf(stderr, "Actions:\n");
         fprintf(stderr, "* show [<prefix>]\n");
         fprintf(stderr, "* get <key>\n");


### PR DESCRIPTION
Not complete, as I don't quite understand what `-t` and `-T` are supposed to achieve (something about transactions). Also, I haven't actually tested that `-c` and `-M` even work (`-n` does, which is what I wanted). ALSO, `-c` sounds kinda destructive enough that it should perhaps be an explicit `convert` action and maybe shouldn't be neatly documented at all, but anyway, here we are!