### PR TITLE
docs: call manpages index "index"

### DIFF
--- a/docsrc/imap/reference/manpages/index.rst
+++ b/docsrc/imap/reference/manpages/index.rst
@@ -20,8 +20,6 @@ Man pages
 
     systemcommands/*
 
-
-
 (1) User Commands
 =================
 

--- a/docsrc/operations.rst
+++ b/docsrc/operations.rst
@@ -6,6 +6,6 @@ Operations
 .. toctree::
     :maxdepth: 2
 
-    imap/reference/manpages/commands
+    imap/reference/manpages/index
     imap/reference/admin
     imap/reference/faq


### PR DESCRIPTION
So that navigating to http://www.cyrusimap.org/imap/reference/manpages/ works!

It's currently called "[commands](https://www.cyrusimap.org/imap/reference/manpages/commands.html)", which is discoverable via the sidebar links but hard to find by typing in an address.

Not really sure what I expect a reviewer to do with this...