### PR TITLE
document that carddav httpmodule requires caldav

### DIFF
--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1053,7 +1053,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    at compile time due to missing dependencies (e.g. libical).
 .PP
    Note that "domainkey" depends on "ischedule" being enabled, and
-   that both "freebusy" and "ischedule" depend on "caldav" being
+   that "carddav", "freebusy", and "ischedule" depend on "caldav" being
    enabled. */
 
 { "httpprettytelemetry", 0, SWITCH, "2.5.0" }


### PR DESCRIPTION
This updates the description of `httpmodules` to reflect that the "carddav" module is dependent on the "caldav" module being enabled too.

Though I'm not sure if this is expected or not.  If they're supposed to be independent, then we have a bug to fix instead...