### PR TITLE
http_dav.c: lookup INBOX when parsing principal URLs, rather than blindly looking up calendar-home-set

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -67,7 +67,6 @@
 #include "annotate.h"
 #include "acl.h"
 #include "append.h"
-#include "caldav_db.h"
 #include "dlist.h"
 #include "global.h"
 #include "http_dav.h"
@@ -582,11 +581,9 @@ static int principal_parse_path(const char *path, struct request_target_t *tgt,
     }
 
   mailbox:
-    /* Create mailbox name from the parsed path */
-
     if (tgt->userid) {
-        /* Locate the mailbox */
-        char *mboxname = caldav_mboxname(tgt->userid, NULL);
+        /* Locate the INBOX */
+        char *mboxname = mboxname_user_mbox(tgt->userid, NULL);
         int r = proxy_mlookup(mboxname, &tgt->mbentry, NULL, NULL);
 
         if (r) {


### PR DESCRIPTION
This allows the CardDAV module to be used indepedently of CalDAV.  All Cass tests still pass