### PR TITLE
Always compile autocreate in

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -957,6 +957,8 @@ imap_calalarmd_SOURCES = imap/calalarmd.c imap/mutex_fake.c
 imap_calalarmd_LDADD = $(LD_SERVER_ADD)
 
 imap_imapd_SOURCES = \
+	imap/autocreate.h \
+	imap/autocreate.c \
 	imap/imap_proxy.c \
 	imap/imap_proxy.h \
 	imap/imapd.c \
@@ -967,12 +969,6 @@ imap_imapd_SOURCES = \
 	imap/sync_support.c \
 	imap/sync_support.h \
 	master/service.c
-
-if AUTOCREATE
-imap_imapd_SOURCES += \
-	imap/autocreate.h \
-	imap/autocreate.c
-endif
 
 imap_imapd_LDADD = $(LD_SIEVE_ADD) $(LD_SERVER_ADD)
 
@@ -1171,6 +1167,8 @@ endif
 endif
 
 imap_lmtpd_SOURCES = \
+	imap/autocreate.c \
+	imap/autocreate.h \
 	imap/lmtpd.c \
 	imap/lmtpd.h \
 	imap/lmtpengine.c \
@@ -1183,12 +1181,6 @@ imap_lmtpd_SOURCES = \
 	master/service.c
 
 nodist_imap_lmtpd_SOURCES = imap/lmtp_err.c
-
-if AUTOCREATE
-imap_lmtpd_SOURCES += \
-	imap/autocreate.c \
-	imap/autocreate.h
-endif # AUTOCREATE
 
 if SIEVE
 imap_lmtpd_SOURCES += imap/lmtp_sieve.c imap/lmtp_sieve.h imap/smtpclient.c
@@ -1351,18 +1343,14 @@ endif # CUNIT
 endif # JMAP
 
 imap_pop3d_SOURCES = \
+	imap/autocreate.c \
+	imap/autocreate.h \
 	imap/mutex_fake.c \
 	imap/pop3d.c \
 	imap/proxy.c \
 	imap/sync_support.c \
 	imap/sync_support.h \
 	master/service.c
-
-if AUTOCREATE
-imap_pop3d_SOURCES += \
-	imap/autocreate.c \
-	imap/autocreate.h
-endif # AUTOCREATE
 
 imap_pop3d_LDADD = $(LD_SIEVE_ADD) $(LD_SERVER_ADD)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1539,15 +1539,6 @@ MASTERPIDFILE="\"$MASTERPIDFILE\""
 AC_DEFINE_UNQUOTED(MASTER_PIDFILE, $MASTERPIDFILE,[Name of the pidfile for master])
 
 dnl
-dnl see if we're compiling with autocreate support
-dnl
-AC_ARG_ENABLE(autocreate,
-        [AS_HELP_STRING([--enable-autocreate], [enable autocreate support])],,[enable_autocreate="no";])
-AM_CONDITIONAL([AUTOCREATE], [test "$enable_autocreate" != "no"])
-if test "x$enable_autocreate" = "xyes"; then
-        AC_DEFINE(USE_AUTOCREATE,[],[Build with autocreate functionality])
-fi
-dnl
 dnl see if we're compiling with IMAP idled support
 dnl
 AC_ARG_ENABLE(idled,
@@ -2459,7 +2450,6 @@ echo "
 Cyrus Server configured components
 
    gssapi:             $gssapi
-   autocreate:         $enable_autocreate
    idled:              $enable_idled
    httpd:              $enable_http
    kerberos V4:        $krb4

--- a/contrib/drydock-tests/enable-all.sh
+++ b/contrib/drydock-tests/enable-all.sh
@@ -14,7 +14,6 @@ _git_checkout_commit
 _autoreconf
 
 ./configure \
-    --enable-autocreate \
     --enable-calalarmd \
     --enable-coverage \
     --enable-gssapi \

--- a/docsrc/imap/developer/compiling.rst
+++ b/docsrc/imap/developer/compiling.rst
@@ -302,7 +302,7 @@ Compile
     autoreconf -i -s   # generates a configure script, and its various dependencies
 
     ./configure CFLAGS="-W -Wno-unused-parameter -g -O0 -Wall -Wextra -Werror -fPIC" \
-    --enable-coverage --enable-calalarmd --enable-autocreate \
+    --enable-coverage --enable-calalarmd \
     --enable-nntp --enable-http --enable-unit-tests \
     --enable-replication --with-openssl=yes --enable-murder \
     --enable-idled --prefix=/usr/cyrus

--- a/docsrc/imap/developer/developer-testing.rst
+++ b/docsrc/imap/developer/developer-testing.rst
@@ -147,7 +147,7 @@ Configure the environment.
 .. code-block:: bash
 
     ./configure --prefix=/usr/cyrus --with-cyrus-prefix=/usr/cyrus \
-    --enable-autocreate --enable-http --enable-unit-tests \
+    --enable-http --enable-unit-tests \
     --enable-replication --enable-nntp --enable-murder \
     --enable-idled --enable-xapian --enable-calalarmd \
     --enable-backup

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -99,11 +99,6 @@ static json_t *buildinfo()
 #else
     json_object_set_new(component, "gssapi", json_false());
 #endif
-#ifdef USE_AUTOCREATE
-    json_object_set_new(component, "autocreate", json_true());
-#else
-    json_object_set_new(component, "autocreate", json_false());
-#endif
 #ifdef USE_IDLED
     json_object_set_new(component, "idled", json_true());
 #else

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -74,9 +74,7 @@
 #include "annotate.h"
 #include "append.h"
 #include "auth.h"
-#ifdef USE_AUTOCREATE
 #include "autocreate.h"
-#endif // USE_AUTOCREATE
 #include "assert.h"
 #include "backend.h"
 #include "bsearch.h"
@@ -2541,7 +2539,6 @@ done:
     cmd_syncrestart(NULL, &reserve_list, 0);
 }
 
-#ifdef USE_AUTOCREATE
 /*
  * Autocreate Inbox and subfolders upon login
  */
@@ -2558,7 +2555,6 @@ static void autocreate_inbox(void)
         autocreate_user(&imapd_namespace, imapd_userid);
     }
 }
-#endif // USE_AUTOCREATE
 
 static void authentication_success(void)
 {
@@ -2596,9 +2592,7 @@ static void authentication_success(void)
         mboxevent_free(&mboxevent);
     }
 
-#ifdef USE_AUTOCREATE
     autocreate_inbox();
-#endif // USE_AUTOCREATE
 }
 
 static int checklimits(const char *tag)
@@ -7169,7 +7163,6 @@ localcreate:
                                imapd_userid, imapd_authstate,
                                flags, &mailbox);
 
-#ifdef USE_AUTOCREATE
     // Clausing autocreate for the INBOX
     if (r == IMAP_PERMISSION_DENIED) {
         if (!strarray_size(mbname_boxes(mbname)) && !strcmpsafe(imapd_userid, mbname_userid(mbname))) {
@@ -7204,7 +7197,6 @@ localcreate:
             }
         }
     }
-#endif
 
     if (r) {
         prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
@@ -8212,9 +8204,7 @@ static void getlistargs(char *tag, struct listargs *listargs)
         goto freeargs;
     }
 
-#ifdef USE_AUTOCREATE
     autocreate_inbox();
-#endif // USE_AUTOCREATE
 
     return;
 

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -68,9 +68,7 @@
 #include "append.h"
 #include "assert.h"
 #include "auth.h"
-#ifdef USE_AUTOCREATE
 #include "autocreate.h"
-#endif
 #include "backend.h"
 #ifdef WITH_DAV
 #include "carddav_db.h"
@@ -125,9 +123,7 @@ void shut_down(int code);
 static FILE *spoolfile(message_data_t *msgdata);
 static void removespool(message_data_t *msgdata);
 
-#ifdef USE_AUTOCREATE
 static int autocreate_inbox(const mbname_t *mbname);
-#endif
 
 /* current namespace */
 static struct namespace lmtpd_namespace;
@@ -1051,7 +1047,6 @@ void shut_down(int code)
     exit(code);
 }
 
-#ifdef USE_AUTOCREATE
 /*
  * Autocreate Inbox and subfolders upon login
  */
@@ -1079,7 +1074,6 @@ int autocreate_inbox(const mbname_t *mbname)
 
     return autocreate_user(&lmtpd_namespace, userid);
 }
-#endif // USE_AUTOCREATE
 
 static int verify_user(const mbname_t *origmbname,
                        quota_t quotastorage_check, quota_t quotamessage_check,
@@ -1104,13 +1098,11 @@ static int verify_user(const mbname_t *origmbname,
      */
     r = proxy_mlookup(mbname_intname(mbname), &mbentry, NULL, NULL);
 
-#ifdef USE_AUTOCREATE
     /* If user mailbox does not exist, then invoke autocreate inbox function */
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         r = autocreate_inbox(mbname);
         if (!r) r = proxy_mlookup(mbname_intname(mbname), &mbentry, NULL, NULL);
     }
-#endif // USE_AUTOCREATE
 
     if (r == IMAP_MAILBOX_NONEXISTENT && !mbname_userid(mbname) &&
         config_getswitch(IMAPOPT_LMTP_FUZZY_MAILBOX_MATCH)) {

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -65,9 +65,7 @@
 
 #include "assert.h"
 #include "acl.h"
-#ifdef USE_AUTOCREATE
 #include "autocreate.h"
-#endif
 #include "util.h"
 #include "auth.h"
 #include "global.h"
@@ -1799,7 +1797,6 @@ int openinbox(void)
 
     r = mboxlist_lookup(mbname_intname(mbname), &mbentry, NULL);
 
-#ifdef USE_AUTOCREATE
     /* Try once again after autocreate_inbox */
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         /* NOTE - if we have a subfolder, autocreateinbox should still create
@@ -1807,7 +1804,6 @@ int openinbox(void)
         r = autocreate_user(&popd_namespace, popd_userid);
         if (!r) r = mboxlist_lookup(mbname_intname(mbname), &mbentry, NULL);
     }
-#endif
 
     if (!r && (config_popuseacl = config_getswitch(IMAPOPT_POPUSEACL)) &&
         (!mbentry->acl ||

--- a/tools/build-with-cyruslibs.sh
+++ b/tools/build-with-cyruslibs.sh
@@ -5,7 +5,7 @@ set -e
 : ${CYRUSLIBS:=cyruslibs}
 : ${LIBSDIR:=/usr/local/$CYRUSLIBS}
 : ${TARGET:=/usr/cyrus}
-: ${CONFIGOPTS:="--enable-http --enable-calalarmd --enable-unit-tests --enable-replication --enable-nntp --enable-murder --enable-idled --enable-xapian --enable-autocreate --enable-backup --enable-silent-rules"}
+: ${CONFIGOPTS:="--enable-http --enable-calalarmd --enable-unit-tests --enable-replication --enable-nntp --enable-murder --enable-idled --enable-xapian --enable-backup --enable-silent-rules"}
 export LDFLAGS="-L$LIBSDIR/lib/x86_64-linux-gnu -L$LIBSDIR/lib -Wl,-rpath,$LIBSDIR/lib/x86_64-linux-gnu -Wl,-rpath,$LIBSDIR/lib"
 export PKG_CONFIG_PATH="$LIBSDIR/lib/x86_64-linux-gnu/pkgconfig:$LIBSDIR/lib/pkgconfig:\$PKG_CONFIG_PATH"
 export CFLAGS="-g -fPIC -W -Wall -Wextra"


### PR DESCRIPTION
Since it requires config settings to actually enable it, and those are
off by default, there's no good reason to not have it always there.