### PR TITLE
.travis.yml: notify every success on slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ notifications:
     on_failure: always
   slack:
     on_pull_requests: false
-    on_success: change
+    on_success: always
     on_failure: always
     rooms:
       - secure: bh4PiwcHYwn2qjKgidSKX6Ibq/Gt8+q6IL7YDWlfpDPYCuzdzSHBpm8qMpmBIjTemnsragJeR4pO9XEX20nhE9Lr7915wiBmYWqcmvcJGpJ1/nJz2lJYtBKl/dKZguQn3g4A+JgjUuXgzllI4ZsbbRkzL8dBC+py34p4ANtMKycXeGCwysnPfHav5VxQQnOsJUbIKDJiJPON2cR7e8quE6WpS1mEzUD+kaRWMUImKktMX1hrQH/71tNNMTqv0eHewci1akaZecFtXQi8D9Yfh1YBm8yxdLI9EgnglonEgbBCGG6WRODcxu/gEJlvXFMN+c4ojoyq4lNGnEqzLjDDVI1LoCNUcWbMFFhIGAA1SE+71fwDlKjLxUzodgJPb/yrWy4uwx8eBM3W8PIhFgZyo0irlV/0U3zNFWjjNPTRXUNNIZQu2XDLAhpiRZbMn4zsvydq2ngWnTdJfgpycYiBfL5zNdwdPpAQomQLl1JakWqyMSBZtz3Hbv3vRmb4rIogh5AHuwxKQrK5JNI9eZ5yPI7eUEpTq1nYD7syZPDj3gddjdteBx8ShjHH6ddteQX2OSUXwtiF90cEgYq0z8j2HxaNRIVrkeUNyeRTZXZ0wxWM7Fcz0Z7fRzsv1CXZwjDPmxARiIhbVhXxTgbED9+i2aCH9aZNrMTqoRUQWjLzgXw=


### PR DESCRIPTION
We've gotten used to "silence means success", but these days silence
usually means "travis is out of credit and builds are no longer
running".

This makes success noisy too, so when things get quiet we're probably
out of credits.