### PR TITLE
Namespacelock mbentry updates

### DIFF
--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -2119,7 +2119,7 @@ static int set_up(void)
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;
-    r = mboxlist_update(&mbentry, /*localonly*/1);
+    r = mboxlist_updatelock(&mbentry, /*localonly*/1);
     if (r)
         return r;
 
@@ -2142,7 +2142,7 @@ static int set_up(void)
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;
-    r = mboxlist_update(&mbentry, /*localonly*/1);
+    r = mboxlist_updatelock(&mbentry, /*localonly*/1);
     if (r)
         return r;
 
@@ -2165,7 +2165,7 @@ static int set_up(void)
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;
-    r = mboxlist_update(&mbentry, /*localonly*/1);
+    r = mboxlist_updatelock(&mbentry, /*localonly*/1);
     if (r)
         return r;
 

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -159,10 +159,8 @@ static int fixmbox(const mbentry_t *mbentry,
             free(userid);
         }
         mbentry_t *copy = mboxlist_entry_copy(mbentry);
-        /* XXX - const correctness */
-        free(copy->legacy_specialuse);
-        copy->legacy_specialuse = NULL;
-        mboxlist_update(copy, /*localonly*/1);
+        xzfree(copy->legacy_specialuse);
+        mboxlist_updatelock(copy, /*localonly*/1);
         mboxlist_entry_free(&copy);
     }
 

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -485,7 +485,7 @@ static void do_dump(enum mboxop op, const char *part, int purge, int intermediar
             free(mbentry->server);
             mbentry->server = NULL;
             mbentry->mbtype &= ~(MBTYPE_MOVING|MBTYPE_REMOTE);
-            ret = mboxlist_update(mbentry, 1);
+            ret = mboxlist_updatelock(mbentry, 1);
             if (ret) {
                 fprintf(stderr,
                         "couldn't perform update to un-remote-flag %s\n",
@@ -626,7 +626,7 @@ static void do_undump(void)
         newmbentry->acl = xstrdupnull(acl);
         /* XXX - still missing all the new fields */
 
-        r = mboxlist_update(newmbentry, /*localonly*/1);
+        r = mboxlist_updatelock(newmbentry, /*localonly*/1);
         mboxlist_entry_free(&newmbentry);
 
         if (r) break;

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -183,7 +183,7 @@ static int dump_cb(const mbentry_t *mbentry, void *rockp)
             if (mbentry->server) printf("%s!", mbentry->server);
             printf("%s %s\n", mbentry->partition, mbentry->acl);
             if (d->purge) {
-                mboxlist_delete(mbentry->name);
+                mboxlist_deletelock(mbentry->name);
             }
         }
         break;

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -446,7 +446,7 @@ static int expire(const mbentry_t *mbentry, void *rock)
         if (mbentry->mtime < erock->tombstone_mark) {
             verbosep("Removing stale tombstone for %s\n", mbentry->name);
             syslog(LOG_NOTICE, "Removing stale tombstone for %s", mbentry->name);
-            mboxlist_delete(mbentry->name);
+            mboxlist_deletelock(mbentry->name);
         }
         goto done;
     }

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5819,7 +5819,6 @@ int meth_mkcol(struct transaction_t *txn, void *params)
             goto done;
         }
     }
-    mboxname_release(&namespacelock);
 
     if (!r) {
         if (mparams->mkcol.proc) r = mparams->mkcol.proc(mailbox);
@@ -5842,6 +5841,7 @@ int meth_mkcol(struct transaction_t *txn, void *params)
   done:
     buf_free(&pctx.buf);
     mailbox_close(&mailbox);
+    mboxname_release(&namespacelock);
 
     sync_checkpoint(txn->conn->pin);
 

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4874,9 +4874,11 @@ static int meth_delete_collection(struct transaction_t *txn,
     /* if FastMail sharing, we need to remove ACLs */
     if (config_getswitch(IMAPOPT_FASTMAILSHARING) &&
         !mboxname_userownsmailbox(httpd_userid, txn->req_tgt.mbentry->name)) {
+        struct mboxlock *namespacelock = mboxname_usernamespacelock(txn->req_tgt.mbentry->name);
         r = mboxlist_setacl(&httpd_namespace, txn->req_tgt.mbentry->name,
                             httpd_userid, /*rights*/NULL, /*isadmin*/1,
                             httpd_userid, httpd_authstate);
+        mboxname_release(&namespacelock);
         if (r) {
             syslog(LOG_ERR, "meth_delete(%s) failed to remove acl: %s",
                    txn->req_tgt.mbentry->name, error_message(r));

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -1913,6 +1913,7 @@ HIDDEN int dav_post_share(struct transaction_t *txn, struct meth_params *pparams
     }
 
     /* Local mailbox */
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(txn->req_tgt.mbentry->name);
 
     /* Read body */
     ret = parse_xml_body(txn, &root, DAVSHARING_CONTENT_TYPE);
@@ -2074,6 +2075,7 @@ HIDDEN int dav_post_share(struct transaction_t *txn, struct meth_params *pparams
     if (root) xmlFreeDoc(root->doc);
     if (notify) xmlFreeDoc(notify->doc);
     buf_free(&resource);
+    mboxname_release(&namespacelock);
 
     return ret;
 }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8662,9 +8662,11 @@ static void cmd_setacl(char *tag, const char *name,
             }
         }
 
+        struct mboxlock *namespacelock = mboxname_usernamespacelock(intname);
         r = mboxlist_setacl(&imapd_namespace, intname, identifier, rights,
                             imapd_userisadmin || imapd_userisproxyadmin,
                             proxy_userid, imapd_authstate);
+        mboxname_release(&namespacelock);
     }
 
     imapd_check(NULL, 0);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -11432,7 +11432,7 @@ static int xfer_undump(struct xfer_header *xfer)
         newentry->server = xstrdupnull(xfer->toserver);
         newentry->partition = xstrdupnull(xfer->topart);
         newentry->mbtype = item->mbentry->mbtype|MBTYPE_MOVING;
-        r = mboxlist_update(newentry, 1);
+        r = mboxlist_updatelock(newentry, 1);
         mboxlist_entry_free(&newentry);
 
         if (r) {
@@ -11877,7 +11877,7 @@ static int xfer_delete(struct xfer_header *xfer)
         newentry->server = xstrdupnull(item->mbentry->server);
         newentry->partition = xstrdupnull(item->mbentry->partition);
         newentry->mbtype |= MBTYPE_DELETED;
-        r = mboxlist_update(newentry, 1);
+        r = mboxlist_updatelock(newentry, 1);
         mboxlist_entry_free(&newentry);
 
         if (r) {
@@ -11918,7 +11918,7 @@ static void xfer_recover(struct xfer_header *xfer)
         case XFER_UNDUMPED:
         case XFER_LOCAL_MOVING:
             /* Unset mailbox as MOVING on local server */
-            r = mboxlist_update(item->mbentry, 1);
+            r = mboxlist_updatelock(item->mbentry, 1);
 
             if (r) {
                 syslog(LOG_ERR,

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1143,7 +1143,6 @@ static int recreate_calendar(const mbentry_t *mbentry,
     if (!r && !*newmailbox) {
         /* Create the calendar */
         char *newmboxname = caldav_mboxname(req->accountid, makeuuid());
-        struct mboxlock *namespacelock = user_namespacelock(req->accountid);
         mbentry_t newmbentry = MBENTRY_INITIALIZER;
         newmbentry.name = newmboxname;
         newmbentry.mbtype = MBTYPE_CALENDAR;
@@ -1151,7 +1150,6 @@ static int recreate_calendar(const mbentry_t *mbentry,
         r = mboxlist_createmailbox(&newmbentry, 0/*options*/, 0/*highestmodseq*/,
                                    0/*isadmin*/, req->accountid, req->authstate,
                                    0/*flags*/, newmailbox);
-        mboxname_release(&namespacelock);
 
         if (r) {
             syslog(LOG_ERR, "IOERROR: failed to create mailbox %s: %s",
@@ -1275,6 +1273,7 @@ static int restore_calendar_cb(const mbentry_t *mbentry, void *rock)
             /* Calendar was destroyed after cutoff -
                restore calendar and resources */
             struct mailbox *newmailbox = NULL;
+            struct mboxlock *namespacelock = user_namespacelock(req->accountid);
 
             if (!(rrock->jrestore->mode & DRY_RUN)) {
                 r = recreate_calendar(mbentry, rrock, &newmailbox);
@@ -1287,10 +1286,11 @@ static int restore_calendar_cb(const mbentry_t *mbentry, void *rock)
 
             if (!r && !(rrock->jrestore->mode & DRY_RUN)) {
                 /* XXX  Do we want to do this? */
-                r = mboxlist_deletemailboxlock(mbentry->name, /*isadmin*/0,
-                                               req->accountid, req->authstate,
-                                               /*mboxevent*/NULL, /*flags*/0);
+                r = mboxlist_deletemailbox(mbentry->name, /*isadmin*/0,
+                                           req->accountid, req->authstate,
+                                           /*mboxevent*/NULL, /*flags*/0);
             }
+            mboxname_release(&namespacelock);
         }
         else {
             /* Calendar was destroyed before cutoff - not interested */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -4491,6 +4491,8 @@ EXPORTED int mboxlist_update_foldermodseq(const char *name, modseq_t foldermodse
 
     init_internal();
 
+    assert_namespacelocked(name);
+
     int r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
     if (r) return r;
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -454,7 +454,7 @@ EXPORTED uint32_t mboxlist_string_to_mbtype(const char *string)
         string--;
         break;
     }
-            
+
     for (; *string; string++) {
         /* mailbox flags */
         switch (*string) {
@@ -950,14 +950,14 @@ static int user_can_read(const strarray_t *aclbits, const char *user)
 
 static int mboxlist_update_raclmodseq(const char *acluser)
 {
-    char *aclusermbox = mboxname_user_mbox(acluser, NULL);
+    char *acluserinbox = mboxname_user_mbox(acluser, NULL);
     mbentry_t *raclmbentry = NULL;
-    if (mboxlist_lookup(aclusermbox, &raclmbentry, NULL) == 0) {
-        mboxname_nextraclmodseq(aclusermbox, 0);
-        sync_log_mailbox(aclusermbox);
+    if (mboxlist_lookup(acluserinbox, &raclmbentry, NULL) == 0) {
+        mboxname_nextraclmodseq(acluserinbox, 0);
+        sync_log_mailbox(acluserinbox);
     }
     mboxlist_entry_free(&raclmbentry);
-    free(aclusermbox);
+    free(acluserinbox);
     return 0;
 }
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1148,6 +1148,14 @@ static int mboxlist_update_entry(const char *name,
     return r;
 }
 
+EXPORTED int mboxlist_deletelock(const char *name)
+{
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
+    int r = mboxlist_update_entry(name, NULL, NULL);
+    mboxname_release(&namespacelock);
+    return r;
+}
+
 EXPORTED int mboxlist_delete(const char *name)
 {
     return mboxlist_update_entry(name, NULL, NULL);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1144,6 +1144,14 @@ EXPORTED int mboxlist_delete(const char *name)
     return mboxlist_update_entry(name, NULL, NULL);
 }
 
+EXPORTED int mboxlist_updatelock(const mbentry_t *mbentry, int localonly)
+{
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+    int r = mboxlist_update(mbentry, localonly);
+    mboxname_release(&namespacelock);
+    return r;
+}
+
 EXPORTED int mboxlist_update(const mbentry_t *mbentry, int localonly)
 {
     int r = 0, r2 = 0;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1041,6 +1041,8 @@ static int mboxlist_update_entry(const char *name,
     struct buf key = BUF_INITIALIZER;
     mbentry_t *old = NULL;
     int r = 0;
+    struct txn *mytid = NULL;
+    if (!txn) txn = &mytid;
 
     mboxlist_mylookup(dbname, &old, txn, 0, 1); // ignore errors, it will be NULL
 
@@ -1127,6 +1129,10 @@ static int mboxlist_update_entry(const char *name,
     }
 
  done:
+    if (mytid) {
+        if (r) cyrusdb_abort(mbdb, mytid);
+        else cyrusdb_commit(mbdb, mytid);
+    }
     mboxlist_entry_free(&old);
     buf_free(&key);
     free(dbname);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -150,6 +150,21 @@ EXPORTED mbentry_t *mboxlist_entry_copy(const mbentry_t *src)
 
     copy->legacy_specialuse = xstrdupnull(src->legacy_specialuse);
 
+    size_t numhistory = ptrarray_size(&src->name_history);
+    size_t i;
+    // this is kind of pointless, but we know the target size so may as
+    // well ensure all the space even though it'll only be one alloc
+    // normally anyway
+    ptrarray_truncate(&copy->name_history, numhistory);
+    for (i = 0; i < numhistory; i++) {
+        const former_name_t *item = ptrarray_nth(&src->name_history, i);
+        former_name_t *tgt = xzmalloc(sizeof(former_name_t));
+        tgt->foldermodseq = item->foldermodseq;
+        tgt->mtime = item->mtime;
+        tgt->name = xstrdupnull(item->name);
+        ptrarray_set(&copy->name_history, i, tgt);
+    }
+
     return copy;
 }
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1686,13 +1686,13 @@ EXPORTED int mboxlist_createmailbox(const mbentry_t *mbentry,
     int isremote = mbtype & MBTYPE_REMOTE;
     mbentry_t *usermbentry = NULL, *newmbentry = NULL;
 
+    init_internal();
+
     r = mboxlist_create_namecheck(mboxname, userid, auth_state,
                                   isadmin, (flags & MBOXLIST_CREATE_FORCEUSER));
     if (r) goto done;
 
     assert_namespacelocked(mboxname);
-
-    init_internal();
 
     if (!(flags & MBOXLIST_CREATE_SYNC)) {
         options |= config_getint(IMAPOPT_MAILBOX_DEFAULT_OPTIONS)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1034,6 +1034,13 @@ static void add_former_name(struct dlist *name_history, const char *name,
     free(dbname);
 }
 
+static void assert_namespacelocked(const char *mboxname)
+{
+    char *userid = mboxname_to_userid(mboxname);
+    assert(user_isnamespacelocked(userid));
+    free(userid);
+}
+
 static int mboxlist_update_entry(const char *name,
                                  const mbentry_t *mbentry, struct txn **txn)
 {
@@ -1043,6 +1050,8 @@ static int mboxlist_update_entry(const char *name,
     int r = 0;
     struct txn *mytid = NULL;
     if (!txn) txn = &mytid;
+
+    assert_namespacelocked(name);
 
     mboxlist_mylookup(dbname, &old, txn, 0, 1); // ignore errors, it will be NULL
 
@@ -1203,13 +1212,6 @@ EXPORTED int mboxlist_update(const mbentry_t *mbentry, int localonly)
     }
 
     return r;
-}
-
-static void assert_namespacelocked(const char *mboxname)
-{
-    char *userid = mboxname_to_userid(mboxname);
-    assert(user_isnamespacelocked(userid));
-    free(userid);
 }
 
 static int _findparent(mbname_t *mbname, mbentry_t **mbentryp, int allow_all)

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -147,6 +147,7 @@ const char *mboxlist_mbtype_to_string(uint32_t mbtype);
 uint32_t mboxlist_string_to_mbtype(const char *string);
 
 int mboxlist_delete(const char *name);
+int mboxlist_deletelock(const char *name);
 /* Lookup 'name' in the mailbox list. */
 int mboxlist_lookup(const char *name, mbentry_t **mbentryptr,
                     struct txn **tid);

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -167,6 +167,8 @@ int mboxlist_deleteremote(const char *name, struct txn **in_tid);
 
 /* Update a mailbox's entry */
 int mboxlist_update(const mbentry_t *mbentry, int localonly);
+/* Update but take the usernamespace lock first */
+int mboxlist_updatelock(const mbentry_t *mbentry, int localonly);
 
 /* check user's ability to create mailbox */
 int mboxlist_createmailboxcheck(const char *name, int mbtype,


### PR DESCRIPTION
This whole series of commits is (apart from a couple of bugfixes at the top) all about making sure that there's a namespace lock held every time we update the mailboxes.db.  It also wrap a transaction around all the updates related to a single mbentry (N key, I key, ACLs).

This is a precursor to the work to make renames atomic.  We need the namelocks coming in, so a lot of the commits are bugfixes around the namelocking further out in the callers.