### PR TITLE
CardDAV without CalDAV bis

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -582,10 +582,17 @@ static int principal_parse_path(const char *path, struct request_target_t *tgt,
 
   mailbox:
     if (tgt->userid) {
-        /* Locate the INBOX */
-        char *mboxname = mboxname_user_mbox(tgt->userid, NULL);
-        int r = proxy_mlookup(mboxname, &tgt->mbentry, NULL, NULL);
+        /* Locate the home-set mailbox */
+        char *mboxname = NULL;
 
+        if (tgt->allow & ALLOW_CAL)
+            mboxname = mboxname_cal(tgt->userid, NULL);
+        else if (tgt->allow & ALLOW_CARD)
+            mboxname = mboxname_abook(tgt->userid, NULL);
+        else
+            mboxname = mboxname_drive(tgt->userid, NULL);
+
+        int r = proxy_mlookup(mboxname, &tgt->mbentry, NULL, NULL);
         if (r) {
             *resultstr = error_message(r);
             syslog(LOG_ERR, "mlookup(%s) failed: %s", mboxname, *resultstr);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1713,6 +1713,19 @@ EXPORTED char *mboxname_cal(const char *userid, const char *collection)
     return res;
 }
 
+EXPORTED char *mboxname_drive(const char *userid, const char *collection)
+{
+    mbname_t *mbname = mbname_from_userid(userid);
+
+    mbname_push_boxes(mbname, config_getstring(IMAPOPT_DAVDRIVEPREFIX));
+    if (collection) mbname_push_boxes(mbname, collection);
+
+    char *res = xstrdup(mbname_intname(mbname));
+    mbname_free(&mbname);
+
+    return res;
+}
+
 /*
  * Check whether two parts have the same userid.
  * Returns: 1 if the userids are the same, 0 if not.

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -253,6 +253,7 @@ char *mboxname_user_mbox(const char *userid, const char *subfolder);
 char *mboxname_user_mbox_external(const char *userid, const char *extsubfolder);
 char *mboxname_abook(const char *userid, const char *collection);
 char *mboxname_cal(const char *userid, const char *collection);
+char *mboxname_drive(const char *userid, const char *collection);
 
 /*
  * Check whether two mboxnames have the same userid.


### PR DESCRIPTION
This switches back to looking up a "home-set" collection when parsing principal URLs, defaulting to calendar-home-set if CalDAV is enabled, then dropping to addressbook-home-set if enabled, and finally using the root of a user's #drive hierarchy