### PR TITLE
prot_waitevent-leak-fix

### DIFF
--- a/imap/proxy.c
+++ b/imap/proxy.c
@@ -168,6 +168,12 @@ EXPORTED struct backend * proxy_findserver(const char *server,          /* hostn
                 /* ping/noop the server */
                 if ((ret->sock != -1) && backend_ping(ret, userid)) {
                     backend_disconnect(ret);
+
+                    /* remove the timeout */
+                    if (ret->timeout)
+                        prot_removewaitevent(ret->clientin, ret->timeout);
+                    ret->timeout = NULL;
+                    ret->clientin = NULL;
                 }
                 break;
             }


### PR DESCRIPTION
proxy.c: don't leak prot_waitevent when a connection to a backend has gone away