### PR TITLE
imapd: flush output when starting output so changes are told immediately

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3279,6 +3279,7 @@ static void cmd_idle(char *tag)
         idling = 1;
 
         index_release(imapd_index);
+        prot_flush(imapd_out);
         while ((flags = idle_wait(imapd_in->fd))) {
             if (deadline_exceeded(&deadline)) {
                 syslog(LOG_DEBUG, "timeout for user '%s' while idling",


### PR DESCRIPTION
This fix is good to backport to 3.0, 3.2 and 3.4 as well.

As discovered in https://bugzilla.mozilla.org/show_bug.cgi?id=1708981