### PR TITLE
Sync empty names

### DIFF
--- a/imap/cyr_synclog.c
+++ b/imap/cyr_synclog.c
@@ -51,6 +51,7 @@
 #include <unistd.h>
 #endif
 
+#include "assert.h"
 #include "global.h"
 #include "sync_log.h"
 #include "util.h"

--- a/imap/sync_log.h
+++ b/imap/sync_log.h
@@ -72,7 +72,7 @@ void sync_log_reset();
     sync_log("APPEND %s\n", name)
 
 #define sync_log_mailbox(name) \
-    sync_log("MAILBOX %s\n", name)
+    do { assert(*name); sync_log("MAILBOX %s\n", name); } while (0)
 
 #define sync_log_unmailbox(name) \
     sync_log("UNMAILBOX %s\n", name)


### PR DESCRIPTION
Replication has been bailing out on:

MAILBOX ""

We're not quite sure where those are coming from - so by adding an assertion we'll find out :)

Also, fix the reader so it just skips such bogus entries.