### PR TITLE
configure: search for GitPython with Python 2 and 3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2228,10 +2228,17 @@ AX_PROG_PERL_MODULES([Pod::POM::View::Restructured],
                        have_ppvr=no
                      ])
 
-AX_PYTHON_MODULE([git], [], [python])
+AX_PYTHON_MODULE([git], [], [python2])
 AS_CASE([$HAVE_PYMOD_GIT],
         [yes],  [],
-        [*],    [AC_MSG_WARN([GitPython not found, won't be able to regenerate docs])])
+        [*],    [
+    unset PYTHON # work around AX_PYTHON_MODULE not cleaning up
+    AX_PYTHON_MODULE([git], [], [python3])
+    AS_CASE([$HAVE_PYMOD_GIT],
+            [yes],  [],
+            [*],    [
+         AC_MSG_WARN([GitPython not found, won't be able to regenerate docs])])
+])
 
 AM_CONDITIONAL([HAVE_SPHINX_BUILD],
     [ test -n "$SPHINX_BUILD" -a x"$have_ppvr" = xyes -a x"$HAVE_PYMOD_GIT" = xyes])


### PR DESCRIPTION
Debian 11 (bullseye) is now shipping the Python 3 versions of Sphinx and
GitPython, which aren't detected using the "default" python. This looks
for it under both names.

All this is doing is deciding if the package is available so that
sphinx-build can actually work, so there's no further work required to
link it in or anything.

The downside here is that if the sphinx-build on PATH is the Python 2
version and GitPython is Python 3 (or vice-versa), this could still end
up with the configure "succeeding" and then sphinx-build failing later.
A better test for all of this would be to test sphinx-build with a
minimal document that requires the wanted modules explicitly, and see if
that succeeds (exactly like what the AC_CHECK_ macros do by generating
and compiling a small C program). That's a bunch more work right now for
a situation that isn't likely to happen (you're likely to be all-in on
one complete version of Python or the other), so I'm punting on that.