### PR TITLE
ical_support: do not use icaltimezone_get_tzid

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -377,7 +377,7 @@ static int send_alarm(struct get_alarm_rock *rock,
     else
         timezone = "[floating]";
     FILL_STRING_PARAM(event, EVENT_CALENDAR_TIMEZONE,
-                      xstrdup(timezone));
+                      xstrdupsafe(timezone));
     FILL_STRING_PARAM(event, EVENT_CALENDAR_START,
                       xstrdup(icaltime_as_ical_string(start)));
     FILL_STRING_PARAM(event, EVENT_CALENDAR_END,

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -371,9 +371,9 @@ static int send_alarm(struct get_alarm_rock *rock,
     if (!icaltime_is_date(start) && icaltime_is_utc(start))
         timezone = "UTC";
     else if (icaltime_get_timezone(start))
-        timezone = icaltime_get_tzid(start);
+        timezone = icaltime_get_location_tzid(start);
     else if (rock->floatingtz)
-        timezone = icaltimezone_get_tzid(rock->floatingtz);
+        timezone = icaltimezone_get_location_tzid(rock->floatingtz);
     else
         timezone = "[floating]";
     FILL_STRING_PARAM(event, EVENT_CALENDAR_TIMEZONE,

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -1502,7 +1502,7 @@ static void create_override(icalcomponent *master, struct icaltime_span *span,
 
             /* Add RECURRENCE-ID for this recurrence */
             prop = icalproperty_new_recurrenceid(dtstart);
-            tzid = icaltimezone_get_tzid((icaltimezone *) tz);
+            tzid = icaltimezone_get_location_tzid((icaltimezone *) tz);
             if (tzid) {
                 icalproperty_add_parameter(prop, icalparameter_new_tzid(tzid));
             }
@@ -1955,5 +1955,17 @@ EXPORTED icalproperty *icalproperty_new_color(const char *v)
 }
 
 #endif /* HAVE_RFC7986_COLOR */
+
+EXPORTED const char *icaltimezone_get_location_tzid(const icaltimezone *zone)
+{
+    const char *v = icaltimezone_get_location((icaltimezone*) zone);
+    if (!v) v = icaltimezone_get_tzid((icaltimezone*) zone);
+    return v;
+}
+
+EXPORTED const char *icaltime_get_location_tzid(icaltimetype t)
+{
+    return icaltimezone_get_location_tzid(t.zone);
+}
 
 #endif /* HAVE_ICAL */

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -137,6 +137,10 @@ extern int icalcomponent_apply_vpatch(icalcomponent *ical,
                                       icalcomponent *vpatch,
                                       int *num_changes, const char **errstr);
 
+/* Functions to work around libical TZID prefixes */
+extern const char *icaltimezone_get_location_tzid(const icaltimezone *zone);
+extern const char *icaltime_get_location_tzid(icaltimetype t);
+
 /* Functions that should be declared in libical */
 #define icaltimezone_set_zone_directory set_zone_directory
 


### PR DESCRIPTION
Both icaltime_get_tzid and icaltimezone_get_tzid cause libical to return timezone identifiers prefixed with the hardcoded value `/freeassociation.sourceforge.net/`.

This even happens if
* a custom zoneinfo directory is set
* the libical tzid_prefix is set to the empty string

Consequently, both functions should not be used within Cyrus.

We could patch our libical fork in cyruslibs, but this won't help installations that build on upstream libical versions.

Tested in https://github.com/cyrusimap/cassandane/pull/165