### PR TITLE
conversations: when recalculating, upgrade to byid

### DIFF
--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -357,7 +357,7 @@ extern const char *conversation_id_encode(conversation_id_t cid);
 extern int conversation_id_decode(conversation_id_t *cid, const char *text);
 
 
-extern int conversations_zero_counts(struct conversations_state *state);
+extern int conversations_zero_counts(struct conversations_state *state, int wipe);
 extern int conversations_cleanup_zero(struct conversations_state *state);
 
 extern int conversations_rename_folder(struct conversations_state *state,

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -306,7 +306,10 @@ static int do_recalc(const char *userid)
     r = conversations_open_user(userid, 0/*shared*/, &state);
     if (r) return r;
 
-    r = conversations_zero_counts(state);
+    // wipe if it's currently folders_byname, will recreate with byid
+    int wipe = state->folders_byname;
+
+    r = conversations_zero_counts(state, wipe);
     if (r) goto err;
 
     r = mboxlist_usermboxtree(userid, NULL, recalc_counts_cb, NULL, 0);
@@ -671,7 +674,7 @@ static int do_audit(const char *userid)
         goto out;
     }
 
-    r = conversations_zero_counts(state_temp);
+    r = conversations_zero_counts(state_temp, /*wipe*/0);
     if (r) {
         fprintf(stderr, "Failed to zero counts in %s: %s\n",
                 filename_temp, error_message(r));


### PR DESCRIPTION
As discussed today - this allows for an atomic in-place conversationsdb rebuild, which will switch over to byid.  It just wipes every single key and then inserts new records for everything, such that we lose all the highestmodseq information and folder presence information from conversations and mailboxes.

This does mean that updates might be incorrect for the client over this one transition point, but a refresh fixes it, and they're good afterwards - and it's only in the rare case where the change was a record being entirely wiped (i.e. over the weekend) and that changing the result we would have sent to a user... so really approximately never!