### PR TITLE
Calalarmd use our own VTIMEZONEs

### DIFF
--- a/imap/calalarmd.c
+++ b/imap/calalarmd.c
@@ -117,6 +117,9 @@ int main(int argc, char **argv)
 
     cyrus_init(alt_config, "calalarmd", 0, 0);
 
+    /* Initialize libical */
+    ical_support_init();
+
     mboxname_init_namespace(&calalarmd_namespace, /*isadmin*/1);
     mboxevent_setnamespace(&calalarmd_namespace);
 


### PR DESCRIPTION
calalarmd needs to call ical_support_init() to use our own VTIMEZONEs