### PR TITLE
global: initialize libical zoneinfo directory in cyrus_init

### DIFF
--- a/imap/calalarmd.c
+++ b/imap/calalarmd.c
@@ -117,9 +117,6 @@ int main(int argc, char **argv)
 
     cyrus_init(alt_config, "calalarmd", 0, 0);
 
-    /* Initialize libical */
-    ical_support_init();
-
     mboxname_init_namespace(&calalarmd_namespace, /*isadmin*/1);
     mboxevent_setnamespace(&calalarmd_namespace);
 

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -132,9 +132,6 @@ int main(int argc, char **argv)
     signals_add_handlers(0);
     sqldb_init();
 
-    /* Initialize libical */
-    ical_support_init();
-
     if (allusers) {
         mboxlist_alluser(do_user, (void *)audit_tool);
     }

--- a/imap/global.c
+++ b/imap/global.c
@@ -68,6 +68,7 @@
 #include "gmtoff.h"
 #include "iptostring.h"
 #include "global.h"
+#include "ical_support.h"
 #include "libconfig.h"
 #include "libcyr_cfg.h"
 #include "mboxlist.h"
@@ -395,6 +396,11 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
     if (locktime) {
         debug_locks_longer_than = atof(locktime);
     }
+
+#ifdef HAVE_ICAL
+    /* Initialize libical */
+    ical_support_init();
+#endif
 
     return 0;
 }

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -144,11 +144,6 @@ int main(int argc, char **argv)
 
 #ifdef WITH_DAV
     sqldb_init();
-
-#ifdef HAVE_ICAL
-    /* Initialize libical */
-    ical_support_init();
-#endif
 #endif
 
     /* Normal Operation */


### PR DESCRIPTION
Timezones are required in almost all Cyrus services, so let's make it simple to not forget their initialization.

We leave it to httpd and lmtpd to initialize libical as these daemon already do their own custom initialization.

Passes the Cassandane test suites.