### PR TITLE
jmap_core: update all the Blob APIs to the latest draft-ietf-jmap-blob-04 draft

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -7426,9 +7426,9 @@ EOF
     my $res = $jmap->CallMethods([
         ['Blob/set',
            { create => {
-               "ical1" => { content => $ical1, type => 'text/calendar' },
-               "ical2" => { content => $ical2, type => 'text/calendar' },
-               "junk" => { content => 'foo bar', type => 'text/calendar' }
+               "ical1" => { 'data:asText' => $ical1, type => 'text/calendar' },
+               "ical2" => { 'data:asText' => $ical2, type => 'text/calendar' },
+               "junk" => { 'data:asText' => 'foo bar', type => 'text/calendar' }
              } }, 'R0'],
         ['CalendarEvent/parse', {
             blobIds => [ "#ical1", "foo", "#junk", "#ical2" ],

--- a/cassandane/Cassandane/Cyrus/JMAPContacts.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPContacts.pm
@@ -2241,7 +2241,7 @@ sub test_contact_set_avatar_singlecommand
 
     my $res = $jmap->CallMethods([
         ['Blob/set', { create => {
-            "img" => { content => 'some photo',
+            "img" => { 'data:asText' => 'some photo',
                        type => 'image/jpeg' } } }, 'R0'],
         ['Contact/set', {create => {"1" => $contact }}, "R1"],
         ['Contact/get', {}, "R2"]],
@@ -2309,7 +2309,7 @@ sub test_contact_set_avatar_from_deleted_contact
     xlog $self, "create initial card";
     my $res = $jmap->CallMethods([
         ['Blob/set', { create => {
-            "img" => { content => 'some photo',
+            "img" => { 'data:asText' => 'some photo',
                        type => 'image/jpeg' } } }, 'R0'],
         ['Contact/set', {create => {"1" => $contact }}, "R1"],
         ['Contact/get', {}, "R2"]],

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -786,7 +786,7 @@ sub test_blob_get
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/blob');
 
     xlog "Regular Blob/get works and returns a blobId";
-    $res = $jmap->CallMethods([['Blob/get', { ids => [$blobId], properties => [ 'data:asText', 'data:asHex', 'data:asBase64', 'size' ] }, 'R1']]);
+    $res = $jmap->CallMethods([['Blob/get', { ids => [$blobId], properties => [ 'data:asText', 'data:asBase64', 'size' ] }, 'R1']]);
     $self->assert_str_equals($res->[0][0], 'Blob/get');
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
     $self->assert_str_equals($blobId, $res->[0][1]{list}[0]{id});
@@ -806,7 +806,6 @@ sub test_blob_set_complex
 
     my $data = "The quick brown fox jumped over the lazy dog.";
     my $bdata = encode_base64($data, '');
-    my $hdata = unpack "H*", $data;
 
     my $res;
 
@@ -830,16 +829,6 @@ sub test_blob_set_complex
     $self->assert_str_equals($data, $res->[1][1]{list}[0]{'data:asText'});
     $self->assert_num_equals(length $data, $res->[1][1]{list}[0]{size});
 
-    xlog "Hex Blob/set works and returns the right data";
-    $res = $jmap->CallMethods([
-      ['Blob/set', { create => { b3 => { 'data:asHex' => $hdata } } }, 'S3'],
-      ['Blob/get', { ids => ['#b3'], properties => [ 'data:asText', 'size' ] }, 'G3'],
-    ]);
-    $self->assert_str_equals('Blob/set', $res->[0][0]);
-    $self->assert_str_equals('Blob/get', $res->[1][0]);
-    $self->assert_str_equals($data, $res->[1][1]{list}[0]{'data:asText'});
-    $self->assert_num_equals(length $data, $res->[1][1]{list}[0]{size});
-
     xlog "Complex catenate expression works and returns the right data";
     my $target = "How quick was that?";
     $res = $jmap->CallMethods([
@@ -847,7 +836,7 @@ sub test_blob_set_complex
       ['Blob/set', { create => { cat => { catenate => [
         { 'data:asText' => 'How' },                      # 'How'
         { 'blobId' => '#b4', offset => 3, length => 7 }, # ' quick '
-        { 'data:asHex' => unpack("H*", "was t") },       # 'was t'
+        { 'data:asText' => "was t" },                    # 'was t'
         { 'blobId' => '#b4', offset => 1, length => 1 }, # 'h'
         { 'data:asBase64' => encode_base64('at?', '') }, # 'at?'
       ] } } }, 'CAT'],

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -664,6 +664,7 @@ sub test_bearer_auth_jwt
         warn "JMAP " . Dumper($RawRequest, $RawResponse);
     }
     $self->assert_str_equals('401', $RawResponse->{status});
+}
 
 sub test_blob_set_basic
     :min_version_3_5 :needs_component_jmap :JMAPExtensions

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -779,16 +779,15 @@ sub test_blob_get
     $self->assert_not_null($blobId);
 
     xlog "Test without capability";
-    # XXX -> rename to Blob/get
-    $res = $jmap->CallMethods([['Blob/xget', { ids => [$blobId], properties => [ 'data:asText', 'size' ] }, 'R1']]);
+    $res = $jmap->CallMethods([['Blob/get', { ids => [$blobId], properties => [ 'data:asText', 'size' ] }, 'R1']]);
     $self->assert_str_equals($res->[0][0], 'error');
 
     # XXX: this will be replaced with the upstream one
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/blob');
 
     xlog "Regular Blob/get works and returns a blobId";
-    $res = $jmap->CallMethods([['Blob/xget', { ids => [$blobId], properties => [ 'data:asText', 'data:asHex', 'data:asBase64', 'size' ] }, 'R1']]);
-    $self->assert_str_equals($res->[0][0], 'Blob/xget');
+    $res = $jmap->CallMethods([['Blob/get', { ids => [$blobId], properties => [ 'data:asText', 'data:asHex', 'data:asBase64', 'size' ] }, 'R1']]);
+    $self->assert_str_equals($res->[0][0], 'Blob/get');
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
     $self->assert_str_equals($blobId, $res->[0][1]{list}[0]{id});
     $self->assert_str_equals($body, $res->[0][1]{list}[0]{'data:asText'});
@@ -814,30 +813,30 @@ sub test_blob_set_complex
     xlog "Regular Blob/set works and returns the right data";
     $res = $jmap->CallMethods([
       ['Blob/set', { create => { b1 => { 'data:asText' => $data } } }, 'S1'],
-      ['Blob/xget', { ids => ['#b1'], properties => [ 'data:asText', 'size' ] }, 'G1'],
+      ['Blob/get', { ids => ['#b1'], properties => [ 'data:asText', 'size' ] }, 'G1'],
     ]);
     $self->assert_str_equals('Blob/set', $res->[0][0]);
-    $self->assert_str_equals('Blob/xget', $res->[1][0]);
+    $self->assert_str_equals('Blob/get', $res->[1][0]);
     $self->assert_str_equals($data, $res->[1][1]{list}[0]{'data:asText'});
     $self->assert_num_equals(length $data, $res->[1][1]{list}[0]{size});
 
     xlog "Base64 Blob/set works and returns the right data";
     $res = $jmap->CallMethods([
       ['Blob/set', { create => { b2 => { 'data:asBase64' => $bdata } } }, 'S2'],
-      ['Blob/xget', { ids => ['#b2'], properties => [ 'data:asText', 'size' ] }, 'G2'],
+      ['Blob/get', { ids => ['#b2'], properties => [ 'data:asText', 'size' ] }, 'G2'],
     ]);
     $self->assert_str_equals('Blob/set', $res->[0][0]);
-    $self->assert_str_equals('Blob/xget', $res->[1][0]);
+    $self->assert_str_equals('Blob/get', $res->[1][0]);
     $self->assert_str_equals($data, $res->[1][1]{list}[0]{'data:asText'});
     $self->assert_num_equals(length $data, $res->[1][1]{list}[0]{size});
 
     xlog "Hex Blob/set works and returns the right data";
     $res = $jmap->CallMethods([
       ['Blob/set', { create => { b3 => { 'data:asHex' => $hdata } } }, 'S3'],
-      ['Blob/xget', { ids => ['#b3'], properties => [ 'data:asText', 'size' ] }, 'G3'],
+      ['Blob/get', { ids => ['#b3'], properties => [ 'data:asText', 'size' ] }, 'G3'],
     ]);
     $self->assert_str_equals('Blob/set', $res->[0][0]);
-    $self->assert_str_equals('Blob/xget', $res->[1][0]);
+    $self->assert_str_equals('Blob/get', $res->[1][0]);
     $self->assert_str_equals($data, $res->[1][1]{list}[0]{'data:asText'});
     $self->assert_num_equals(length $data, $res->[1][1]{list}[0]{size});
 
@@ -852,11 +851,11 @@ sub test_blob_set_complex
         { 'blobId' => '#b4', offset => 1, length => 1 }, # 'h'
         { 'data:asBase64' => encode_base64('at?', '') }, # 'at?'
       ] } } }, 'CAT'],
-      ['Blob/xget', { ids => ['#cat'], properties => [ 'data:asText', 'size' ] }, 'G4'],
+      ['Blob/get', { ids => ['#cat'], properties => [ 'data:asText', 'size' ] }, 'G4'],
     ]);
     $self->assert_str_equals('Blob/set', $res->[0][0]);
     $self->assert_str_equals('Blob/set', $res->[1][0]);
-    $self->assert_str_equals('Blob/xget', $res->[2][0]);
+    $self->assert_str_equals('Blob/get', $res->[2][0]);
     $self->assert_str_equals($target, $res->[2][1]{list}[0]{'data:asText'});
     $self->assert_num_equals(length $target, $res->[2][1]{list}[0]{size});
 }

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -725,23 +725,23 @@ sub test_blob_lookup
     $self->assert_not_null($mailboxId);
 
     xlog "Test without capability";
-    $res = $jmap->CallMethods([['Blob/lookup', { ids => [$blobId, 'unknown'], types => ['Mailbox', 'Thread', 'Email'] }, 'R1']]);
+    $res = $jmap->CallMethods([['Blob/lookup', { ids => [$blobId, 'unknown'], typeNames => ['Mailbox', 'Thread', 'Email'] }, 'R1']]);
     $self->assert_str_equals($res->[0][0], 'error');
 
     # XXX: this will be replaced with the upstream one
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/blob');
 
     xlog "Regular Blob/lookup works";
-    $res = $jmap->CallMethods([['Blob/lookup', { ids => [$blobId, 'unknown'], types => ['Mailbox', 'Thread', 'Email'] }, 'R1']]);
+    $res = $jmap->CallMethods([['Blob/lookup', { ids => [$blobId, 'unknown'], typeNames => ['Mailbox', 'Thread', 'Email'] }, 'R1']]);
     $self->assert_str_equals($res->[0][0], 'Blob/lookup');
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
     $self->assert_str_equals($blobId, $res->[0][1]{list}[0]{id});
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}[0]{types}{Mailbox}});
-    $self->assert_str_equals($mailboxId, $res->[0][1]{list}[0]{types}{Mailbox}[0]);
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}[0]{types}{Thread}});
-    $self->assert_str_equals($threadId, $res->[0][1]{list}[0]{types}{Thread}[0]);
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}[0]{types}{Email}});
-    $self->assert_str_equals($emailId, $res->[0][1]{list}[0]{types}{Email}[0]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}[0]{matchedIds}{Mailbox}});
+    $self->assert_str_equals($mailboxId, $res->[0][1]{list}[0]{matchedIds}{Mailbox}[0]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}[0]{matchedIds}{Thread}});
+    $self->assert_str_equals($threadId, $res->[0][1]{list}[0]{matchedIds}{Thread}[0]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}[0]{matchedIds}{Email}});
+    $self->assert_str_equals($emailId, $res->[0][1]{list}[0]{matchedIds}{Email}[0]);
     $self->assert_num_equals(1, scalar @{$res->[0][1]{notFound}});
     $self->assert_str_equals('unknown', $res->[0][1]{notFound}[0]);
 }

--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -14753,27 +14753,22 @@ sub test_blob_get
     my $blobId = $res->[1][1]{list}[0]{blobId};
     $self->assert_not_null($blobId);
 
-    my $wantMailboxIds = $res->[1][1]{list}[0]{mailboxIds};
-    my $wantEmailIds = {
-        $res->[1][1]{list}[0]{id} => JSON::true
-    };
-    my $wantThreadIds = {
-        $res->[1][1]{list}[0]{threadId} => JSON::true
-    };
+    my $wantMailboxIds = [keys %{$res->[1][1]{list}[0]{mailboxIds}}];
+    my $wantEmailIds = [$res->[1][1]{list}[0]{id}];
+    my $wantThreadIds = [$res->[1][1]{list}[0]{threadId}];
 
     my @using = @{ $jmap->DefaultUsing() };
     push @using, 'https://cyrusimap.org/ns/jmap/blob';
     $jmap->DefaultUsing(\@using);
 
     $res = $jmap->CallMethods([
-        ['Blob/get', { ids => [$blobId]}, "R1"],
+        ['Blob/lookup', { ids => [$blobId], types => ['Mailbox', 'Thread', 'Email']}, "R1"],
     ]);
 
     my $blob = $res->[0][1]{list}[0];
-    $self->assert_deep_equals($wantMailboxIds, $blob->{mailboxIds});
-    $self->assert_deep_equals($wantEmailIds, $blob->{emailIds});
-    $self->assert_deep_equals($wantThreadIds, $blob->{threadIds});
-
+    $self->assert_deep_equals($wantMailboxIds, $blob->{types}{Mailbox});
+    $self->assert_deep_equals($wantEmailIds, $blob->{types}{Email});
+    $self->assert_deep_equals($wantThreadIds, $blob->{types}{Thread});
 }
 
 sub test_email_set_mimeversion

--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -19625,7 +19625,7 @@ EOF
 
     xlog $self, "do the lot!";
     $res = $jmap->CallMethods([
-            ['Blob/set', { create => { "a" => { content => $email } } }, 'R0'],
+            ['Blob/set', { create => { "a" => { 'data:asText' => $email } } }, 'R0'],
             ['Email/import', {
             emails => {
                 "1" => {
@@ -19649,7 +19649,7 @@ EOF
     close(FH);
 
     $res = $jmap->CallMethods([
-            ['Blob/set', { create => { "img" => { content64 => encode_base64($binary, ''), type => 'image/gif' } } }, 'R0'],
+            ['Blob/set', { create => { "img" => { 'data:asBase64' => encode_base64($binary, ''), type => 'image/gif' } } }, 'R0'],
             ['Email/set', {
             create => {
                 "2" => {

--- a/cassandane/Cassandane/Cyrus/JMAPSieve.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPSieve.pm
@@ -206,7 +206,7 @@ EOF
     $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => $script2 }
+               "A" => { 'data:asText' => $script2 }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -276,7 +276,7 @@ EOF
     $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "B" => { content => $script3 }
+               "B" => { 'data:asText' => $script3 }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -364,7 +364,7 @@ EOF
     $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => $script2 }
+               "A" => { 'data:asText' => $script2 }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -443,7 +443,7 @@ EOF
     $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "B" => { content => $script3 }
+               "B" => { 'data:asText' => $script3 }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -541,7 +541,7 @@ sub test_sieve_set_bad_script
     $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => "keep;" }
+               "A" => { 'data:asText' => "keep;" }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -581,10 +581,10 @@ sub test_sieve_query
     my $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => "keep;" },
-               "B" => { content => "discard;" },
-               "C" => { content => "redirect \"test\@example.com\";" },
-               "D" => { content => "stop;"}
+               "A" => { 'data:asText' => "keep;" },
+               "B" => { 'data:asText' => "discard;" },
+               "C" => { 'data:asText' => "redirect \"test\@example.com\";" },
+               "D" => { 'data:asText' => "stop;"}
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -739,8 +739,8 @@ sub test_sieve_validate
     my $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => "keepme;" },
-               "B" => { content => "keep;" }
+               "A" => { 'data:asText' => "keepme;" },
+               "B" => { 'data:asText' => "keep;" }
             }
          }, "R0"],
         ['SieveScript/validate', {
@@ -793,7 +793,7 @@ EOF
     my $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => $script }
+               "A" => { 'data:asText' => $script }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -985,9 +985,9 @@ EOF
     my $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-                "1" => { content => $email1 },
-                "3" => { content => $email2 },
-                "2" => { content => $script },
+                "1" => { 'data:asText' => $email1 },
+                "3" => { 'data:asText' => $email2 },
+                "2" => { 'data:asText' => $script },
             }}, 'R0'],
         ['SieveScript/test', {
             emailBlobIds => [ '#1', 'foobar', '#3' ],
@@ -1036,7 +1036,7 @@ sub test_sieve_blind_replace_active
     my $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => "keep;" }
+               "A" => { 'data:asText' => "keep;" }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -1091,7 +1091,7 @@ sub test_sieve_blind_replace_active
     $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "B" => { content => "discard;" }
+               "B" => { 'data:asText' => "discard;" }
             }
          }, "R0"],
         ['SieveScript/set', {
@@ -1162,7 +1162,7 @@ sub test_deliver_compile
     my $res = $jmap->CallMethods([
         ['Blob/set', {
             create => {
-               "A" => { content => "require [\"fileinto\"];\r\nfileinto \"$target\";\r\n" }
+               "A" => { 'data:asText' => "require [\"fileinto\"];\r\nfileinto \"$target\";\r\n" }
             }
          }, "R0"],
         ['SieveScript/set', {

--- a/changes/next/blob-rfc
+++ b/changes/next/blob-rfc
@@ -1,0 +1,19 @@
+Description:
+
+JMAP Blob handling updated to draft-ietf-jmap-blob-02
+
+NOTE: this is still an incomplete draft, and we're not doing all
+the capabilities yet, and we also have Blob/xget for now
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+No upgrade changes.  If you were relying on old behaviour of
+Blob/get or Blob/set then you need to update your client to match
+
+GitHub issue:
+
+None

--- a/changes/next/blob-rfc
+++ b/changes/next/blob-rfc
@@ -1,9 +1,9 @@
 Description:
 
-JMAP Blob handling updated to draft-ietf-jmap-blob-02
+JMAP Blob handling updated to draft-ietf-jmap-blob-04
 
-NOTE: this is still an incomplete draft, and we're not doing all
-the capabilities yet, and we also have Blob/xget for now
+NOTE: this is in working group last call.  There may be further
+changes before it's totally standard.
 
 Config changes:
 

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -85,6 +85,7 @@ enum {
     MAX_SIZE_UPLOAD,
     MAX_CONCURRENT_UPLOAD,
     MAX_SIZE_BLOB_SET,
+    MAX_CATENATE_ITEMS,
     JMAP_NUM_LIMITS  /* MUST be last */
 };
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -182,11 +182,19 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
                 JMAP_PERFORMANCE_EXTENSION, json_object());
         json_object_set_new(settings->server_capabilities,
                 JMAP_DEBUG_EXTENSION, json_object());
+        json_t *typenames = json_array();
+        // XXX - have a way to register these from each object?  Would
+        // also need to register the lookup logic at the same time though
+        json_array_append_new(typenames, json_string("Mailbox"));
+        json_array_append_new(typenames, json_string("Thread"));
+        json_array_append_new(typenames, json_string("Email"));
         json_object_set_new(settings->server_capabilities,
                 JMAP_BLOB_EXTENSION,
-                json_pack("{s:i}",
+                json_pack("{s:i, s:o}",
                     "maxSizeBlobSet",
-                    settings->limits[MAX_SIZE_BLOB_SET]));
+                    settings->limits[MAX_SIZE_BLOB_SET],
+                    "supportedTypeNames",
+                    typenames));
         json_object_set_new(settings->server_capabilities,
                 JMAP_USERCOUNTERS_EXTENSION, json_object());
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -1042,6 +1042,11 @@ static int _set_arg_to_buf(struct jmap_req *req, struct buf *buf, json_t *arg, i
         jitem = json_object_get(arg, "catenate");
         if (JNOTNULL(jitem) && json_is_array(jitem)) {
             if (seen_one++) return IMAP_MAILBOX_EXISTS;
+            size_t limit = config_getint(IMAPOPT_JMAP_MAX_CATENATE_ITEMS);
+            if (json_array_size(jitem) > limit) {
+                *errp = json_string("too many catenate items");
+                return IMAP_QUOTA_EXCEEDED;
+            }
             size_t i;
             json_t *val;
             json_array_foreach(jitem, i, val) {

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -1236,7 +1236,7 @@ static int jmap_blob_set(struct jmap_req *req)
 
         if (r || !buf_base(buf)) {
             jerr = json_pack("{s:s}", "type", "invalidProperties");
-            json_object_set_new(set.not_updated, key, jerr);
+            json_object_set_new(set.not_created, key, jerr);
             buf_destroy(buf);
             continue;
         }

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -149,6 +149,8 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
               IMAPOPT_JMAP_MAX_OBJECTS_IN_SET);
     _read_opt(settings->limits[MAX_SIZE_BLOB_SET],
               IMAPOPT_JMAP_MAX_SIZE_BLOB_SET);
+    _read_opt(settings->limits[MAX_CATENATE_ITEMS],
+              IMAPOPT_JMAP_MAX_CATENATE_ITEMS);
 #undef _read_opt
 
     json_object_set_new(settings->server_capabilities,
@@ -194,7 +196,7 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
                     "maxSizeBlobSet",
                     settings->limits[MAX_SIZE_BLOB_SET],
                     "maxCatenateItems",
-                    100,
+                    settings->limits[MAX_CATENATE_ITEMS],
                     "supportedTypeNames",
                     typenames));
         json_object_set_new(settings->server_capabilities,
@@ -503,7 +505,6 @@ static int jmap_blob_get(jmap_req_t *req)
     /* Lookup the content for each blob */
     json_array_foreach(get.ids, i, jval) {
         int is_truncated = 0;
-        int is_nonutf8 = 0;
         const char *blob_id = json_string_value(jval);
         jmap_getblob_context_t ctx;
         jmap_getblob_ctx_init(&ctx, req->accountid, blob_id, NULL, 1);

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -906,16 +906,6 @@ static const jmap_property_t blob_set_props[] = {
         JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE | JMAP_PROP_ALWAYS_GET
     },
     {
-        "content",
-        NULL,
-        0
-    },
-    {
-        "content64",
-        NULL,
-        0
-    },
-    {
         "data:asText",
         NULL,
         0
@@ -951,14 +941,12 @@ static int _set_arg_to_buf(struct jmap_req *req, struct buf *buf, json_t *arg, i
 
     // plain text only
     jitem = json_object_get(arg, "data:asText");
-    if (!jitem) jitem = json_object_get(arg, "content"); // legacy
     if (JNOTNULL(jitem) && json_is_string(jitem)) {
         buf_init_ro(buf, json_string_value(jitem), json_string_length(jitem));
     }
 
     // base64 text
     jitem = json_object_get(arg, "data:asBase64");
-    if (!jitem) jitem = json_object_get(arg, "content64");
     if (JNOTNULL(jitem) && json_is_string(jitem)) {
         if (seen_one++) return IMAP_MAILBOX_EXISTS;
         int r = charset_decode(buf, json_string_value(jitem),
@@ -1034,6 +1022,7 @@ static int _set_arg_to_buf(struct jmap_req *req, struct buf *buf, json_t *arg, i
             json_t *val;
             json_array_foreach(jitem, i, val) {
                 struct buf subbuf = BUF_INITIALIZER;
+                // XXX: we might need to validate the properties here too?
                 int r = _set_arg_to_buf(req, &subbuf, val, 1, errp);
                 buf_appendmap(buf, buf_base(&subbuf), buf_len(&subbuf));
                 buf_free(&subbuf);

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -706,6 +706,7 @@ static int jmap_blob_lookup(jmap_req_t *req)
         goto done;
     }
 
+    // we'll just make this 'matchedIds' later
     const char *resname = json_object_get(req->args, "typeNames") ? "matchedIds" : "types";
 
     /* Sort blob lookups by mailbox */
@@ -903,7 +904,6 @@ static int jmap_blob_lookup(jmap_req_t *req)
                     json_array_append_new(list, json_string(strarray_nth(ids, k)));
                 json_object_set_new(dtvalue, item->name, list);
             }
-            // XXX: replace the following two lines with this one line:
             json_array_append_new(get.list, json_pack("{s:s, s:o}", "id", blob_id, resname, dtvalue));
         }
         else {

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -1095,6 +1095,26 @@ static const jmap_property_t blob_set_props[] = {
         0
     },
     {
+        "data:asText",
+        NULL,
+        0
+    },
+    {
+        "data:asBase64",
+        NULL,
+        0
+    },
+    {
+        "data:asHex",
+        NULL,
+        0
+    },
+    {
+        "catenate",
+        NULL,
+        0
+    },
+    {
         "type",
         NULL,
         0

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -427,11 +427,6 @@ static const jmap_property_t blob_xprops[] = {
         JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE | JMAP_PROP_SKIP_GET
     },
     {
-        "data:asHex",
-        NULL,
-        JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE | JMAP_PROP_SKIP_GET
-    },
-    {
         "data:asBase64",
         NULL,
         JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE | JMAP_PROP_SKIP_GET
@@ -568,18 +563,6 @@ static int jmap_blob_get(jmap_req_t *req)
                 }
                 else {
                     json_object_set_new(item, "data:asBase64", json_string(""));
-                }
-            }
-
-            if (jmap_wantprop(get.props, "data:asHex")) {
-                if (len) {
-                    char *encbuf = xzmalloc(len*2);
-                    bin_to_lchex(base, len, encbuf);
-                    json_object_set_new(item, "data:asHex", json_stringn(encbuf, len*2));
-                    free(encbuf);
-                }
-                else {
-                    json_object_set_new(item, "data:asHex", json_string(""));
                 }
             }
 
@@ -940,11 +923,6 @@ static const jmap_property_t blob_set_props[] = {
         0
     },
     {
-        "data:asHex",
-        NULL,
-        0
-    },
-    {
         "catenate",
         NULL,
         0
@@ -978,19 +956,6 @@ static int _set_arg_to_buf(struct jmap_req *req, struct buf *buf, json_t *arg, i
         if (r) {
             *errp = json_string("base64 decode failed");
             return r;
-        }
-    }
-
-    // hex text
-    jitem = json_object_get(arg, "data:asHex");
-    if (JNOTNULL(jitem) && json_is_string(jitem)) {
-        if (seen_one++) return IMAP_MAILBOX_EXISTS;
-        char *out = xzmalloc(json_string_length(jitem)/2);
-        int done = hex_to_bin(json_string_value(jitem), json_string_length(jitem), out);
-        buf_initm(buf, out, json_string_length(jitem)/2);
-        if (done < 0) {
-            *errp = json_string("hex decode failed");
-            return done;
         }
     }
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -1156,6 +1156,8 @@ static int _set_arg_to_buf(struct jmap_req *req, struct buf *buf, json_t *arg, i
         jitem = json_object_get(arg, "blobId");
         if (JNOTNULL(jitem) && json_is_string(jitem)) {
             const char *blobid = json_string_value(jitem);
+            if (blobid && blobid[0] == '#')
+                blobid = jmap_lookup_id(req, blobid + 1);
             // map in the existing blob, if there is one
             jmap_getblob_context_t ctx;
             jmap_getblob_ctx_init(&ctx, req->accountid, blobid, NULL, 1);

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1219,6 +1219,12 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* The maximum byte length of dynamically generated message previews. Previews
    stored in jmap_preview_annot take precedence. */
 
+{ "jmap_max_catenate_items", 100, INT, "3.5.0" }
+/* The maximum number of items that can be catenated together by
+   a JMAP Blob/set action.  Returned as the maxCatenateItems property
+   value of the JMAP \"urn:ietf:params:jmap:blob\" capabilities object.
+   Default value is 100. */
+
 { "jmap_max_size_upload", 1048576, INT, "3.1.6" }
 /* The maximum size (in kilobytes) that the JMAP API accepts
    for blob uploads. Returned as the maxSizeUpload property


### PR DESCRIPTION
This changes Blob/get to Blob/lookup, and adds the new Blob/get and Blob/set logic from the IETF draft.

