### PR TITLE
http_caldav: use userid argument to personalize iCalendar data

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2685,7 +2685,7 @@ EXPORTED icalcomponent *caldav_record_to_ical(struct mailbox *mailbox,
     if (userid && (namespace_calendar.allow & ALLOW_USERDATA)) {
         struct buf userdata = BUF_INITIALIZER;
 
-        if (caldav_is_personalized(mailbox, cdata, httpd_userid, &userdata)) {
+        if (caldav_is_personalized(mailbox, cdata, userid, &userdata)) {
             add_personal_data(ical, &userdata);
         }
 


### PR DESCRIPTION
Up until now it only used the userid argument as condition
if the iCalendar data should be personalized, but then
personalized for the authenticated HTTP user.

Passes the current Cassandane calendar test suites.