### PR TITLE
XFER fixes

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -12109,7 +12109,8 @@ static void cmd_xfer(const char *tag, const char *name,
             list.allow_usersubs = 1;
         }
 
-        mboxlist_findall(NULL, mbname_intname(mbname), 1, NULL, NULL, xfer_addmbox, &list);
+        /* admin namespace, use original name */
+        mboxlist_findall(NULL, name, 1, NULL, NULL, xfer_addmbox, &list);
     }
 
     r = xfer_init(toserver, &xfer);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -12113,6 +12113,12 @@ static void cmd_xfer(const char *tag, const char *name,
         mboxlist_findall(NULL, name, 1, NULL, NULL, xfer_addmbox, &list);
     }
 
+    /* bail out if we didn't find anything to do */
+    if (!list.mboxes) {
+        r = IMAP_MAILBOX_NONEXISTENT;
+        goto done;
+    }
+
     r = xfer_init(toserver, &xfer);
     if (r) goto done;
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -12229,7 +12229,7 @@ static void cmd_xfer(const char *tag, const char *name,
         next = item->next;
         free(item);
 
-        if (xfer->userid || mbox_count > 1000) {
+        if (xfer->use_replication && (xfer->userid || mbox_count > 1000)) {
             /* RESTART after each user or after every 1000 mailboxes */
             mbox_count = 0;
 


### PR DESCRIPTION
This fixes two bugs and one source of confusion in XFER:

* The `name` argument was converted to the wrong namespace before the mboxlist_findall call, so if you specified a user or mailbox name (rather than a pattern or partition name), it wouldn't find anything to do.  This was already fixed in 3.0.15, but since we didn't have any tests for XFER at the time, it wasn't clear whether the same fix was necessary or correct to forward port, so I didn't and forgot about it.  We now have such tests, and it turns out to be necessary and correct!  This is aka #2383 
* If the destination backend did not support using the replication protocol for XFER, the XFER would mostly succeed, but it would try to send a sync restart when it was finished, and hang indefinitely waiting for a response.  We no longer try to send a sync restart unless we're using the replication protocol for the XFER.
* If the `name` argument didn't match anything (e.g. due to the first bug, or just user error), previously it would do nothing, and respond "OK Completed".  Now it responds "NO Mailbox does not exist".

I expect to backport these fixes as far back as 3.0 (and have already tested them, including back and forth in mixed-version setups).

2.5 remains a bad XFER target for various reasons, but it seems to be able to XFER out, at least to 3.0.

There is still more work to do, but this is a good foundation on which to build.  So I'd like to get this much merged before diving any deeper.

These commits are tiny; the much larger part of this PR is the new Cassandane tests for XFER:  https://github.com/cyrusimap/cassandane/pull/169