### PR TITLE
jmap_mailbox: unify mboxlist callback filters for /query and /get

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -13003,7 +13003,7 @@ static int _email_copy_checkmbox_cb(const mbentry_t *mbentry, void *_rock)
 
     /* Ignore anything but regular and intermediate mailboxes */
     if (!mbentry || mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL ||
-        mbtypes_unavailable(mbentry->mbtype)) {
+        mbtypes_unavailable(mbentry->mbtype) || (mbentry->mbtype & MBTYPE_DELETED)) {
         return 0;
     }
     if (!json_object_get(rock->dst_mboxids, mbentry->uniqueid)) {

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -95,7 +95,7 @@
 #define mbtype_isa(mbtype)          ((mbtype) & 0xf)
 #define mbtypes_dav(mbtype)         ((mbtype) & 0x8)
 #define mbtypes_unavailable(mbtype) \
-  ((mbtype) & (MBTYPE_REMOTE | MBTYPE_RESERVE | MBTYPE_MOVING | MBTYPE_DELETED))
+  ((mbtype) & (MBTYPE_REMOTE | MBTYPE_RESERVE | MBTYPE_MOVING))
 #define mbtypes_sync(mbtype)        ((mbtype) & ~MBTYPE_LEGACY_DIRS)
 
 /* master name of the mailboxes file */


### PR DESCRIPTION
We want both methods to operate on the same set of mboxlist entries. Currently, the gap is a missing check for `mbtypes_unavailable` in Mailbox/query, which might have caused a (non-reproducible) issue a couple of weeks ago. Using the same logic in Mailbox/query and /get should avoid such errors also for future changes.

Passes all JMAP Cassandane tests.