### PR TITLE
No more strlist

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -4211,10 +4211,10 @@ static int table_lookup(const struct annotate_attrib *table,
  * point further along in the buffer.  Returns the beginning of the
  * token or NULL (and whines to syslog) if an error was encountered.
  */
-static char *get_token(struct parse_state *state, const char *extra)
+static const char *get_token(struct parse_state *state, const char *extra)
 {
-    char *token;
-    char *p;
+    const char *token;
+    const char *p;
 
     token = tok_next(&state->tok);
     if (!token) {
@@ -4247,15 +4247,16 @@ static char *get_token(struct parse_state *state, const char *extra)
 static int parse_table_lookup_bitmask(const struct annotate_attrib *table,
                                       struct parse_state *state)
 {
-    char *token = get_token(state, ".-_/ ");
-    char *p;
+    const char *token = get_token(state, ".-_/ ");
+    const char *p;
     int i;
     int result = 0;
     tok_t tok;
 
     if (!token)
         return -1;
-    tok_initm(&tok, token, NULL, 0);
+    // NOTE: we're not freeing this tokeniser
+    tok_initm(&tok, (char *)token, NULL, 0);
 
     while ((p = tok_next(&tok))) {
         state->context = p;
@@ -4295,7 +4296,7 @@ static int normalise_attribs(struct parse_state *state, int attribs)
 /* Create array of allowed annotations, both internally & externally defined */
 static void init_annotation_definitions(void)
 {
-    char *p;
+    const char *p;
     char aline[ANNOT_DEF_MAXLINELEN];
     annotate_entrydesc_t *ae;
     int i;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -280,36 +280,6 @@ static void init_internal();
 static int annotate_initialized = 0;
 static int annotatemore_dbopen = 0;
 
-/* String List Management */
-/*
- * Append 's' to the strlist 'l'.
- */
-EXPORTED void appendstrlist(struct strlist **l, char *s)
-{
-    struct strlist **tail = l;
-
-    while (*tail) tail = &(*tail)->next;
-
-    *tail = (struct strlist *)xmalloc(sizeof(struct strlist));
-    (*tail)->s = xstrdup(s);
-    (*tail)->next = 0;
-}
-
-/*
- * Free the strlist 'l'
- */
-EXPORTED void freestrlist(struct strlist *l)
-{
-    struct strlist *n;
-
-    while (l) {
-        n = l->next;
-        free(l->s);
-        free((char *)l);
-        l = n;
-    }
-}
-
 /* Attribute Management (also used by the ID command) */
 
 /*

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -56,12 +56,6 @@
 #define IMAP_ANNOT_NS           "/vendor/cmu/cyrus-imapd/"
 #define DAV_ANNOT_NS            "/vendor/cmu/cyrus-httpd/"
 
-/* List of strings, for fetch and search argument blocks */
-struct strlist {
-    char *s;                   /* String */
-    struct strlist *next;
-};
-
 typedef struct annotate_db annotate_db_t;
 
 /* List of attrib-value pairs */
@@ -104,10 +98,6 @@ int annotate_state_set_mailbox_mbe(annotate_state_t *state,
 int annotate_state_set_message(annotate_state_t *state,
                                struct mailbox *mailbox,
                                unsigned int uid);
-
-/* String List Management */
-void appendstrlist(struct strlist **l, char *s);
-void freestrlist(struct strlist *l);
 
 /* Attribute Management (also used by ID) */
 void appendattvalue(struct attvaluelist **l, const char *attrib,

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -1045,7 +1045,7 @@ EXPORTED struct backend *backend_connect(struct backend *ret_backend, const char
 
             if ((p = strchr(service, '/'))) {
                 tok_t tok;
-                char *opt;
+                const char *opt;
 
                 *p++ = '\0';
                 tok_initm(&tok, p, "/", 0);

--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -150,8 +150,8 @@ int main(int argc, char **argv)
         /* Add INFO record (overall lastmod and TZ DB source version) */
         info = xzmalloc(sizeof(struct zoneinfo));
         info->type = ZI_INFO;
-        appendstrlist(&info->data, pub);
-        appendstrlist(&info->data, ver);
+        strarray_append(&info->data, pub);
+        strarray_append(&info->data, ver);
         hash_insert(INFO_TZID, info, &tzentries);
 
         /* Add LEAP record (last updated and hash) */
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
 
                         /* trim trailing whitespace */
                         for (p = hash + strlen(hash); isspace(*--p); *p = '\0');
-                        appendstrlist(&leap->data, hash);
+                        strarray_append(&leap->data, hash);
                     }
                 }
             }
@@ -386,7 +386,7 @@ void do_zonedir(const char *dir, struct hash_table *tzentries,
                 hash_insert(alias, zi, tzentries);
             }
             zi->type = ZI_LINK;
-            appendstrlist(&zi->data, tzid);
+            strarray_append(&zi->data, tzid);
 
             /* Create/update hash entry for tzid */
             if (!(zi = hash_lookup(tzid, tzentries))) {
@@ -394,7 +394,7 @@ void do_zonedir(const char *dir, struct hash_table *tzentries,
                 hash_insert(tzid, zi, tzentries);
             }
             zi->type = ZI_ZONE;
-            appendstrlist(&zi->data, alias);
+            strarray_append(&zi->data, alias);
         }
         else if (S_ISREG(sbuf.st_mode)) {
             /* Path is a regular file (zone) */
@@ -447,7 +447,7 @@ void do_zonedir(const char *dir, struct hash_table *tzentries,
 
             if (alias) {
                 /* Add alias to the list for this tzid */
-                appendstrlist(&zi->data, alias);
+                strarray_append(&zi->data, alias);
 
                 /* Create hash entry for alias */
                 if (!(zi = hash_lookup(alias, tzentries))) {
@@ -455,7 +455,7 @@ void do_zonedir(const char *dir, struct hash_table *tzentries,
                     hash_insert(alias, zi, tzentries);
                 }
                 zi->type = ZI_LINK;
-                appendstrlist(&zi->data, tzid);
+                strarray_append(&zi->data, tzid);
             }
         }
         else {
@@ -472,7 +472,7 @@ void free_zoneinfo(void *data)
 {
     struct zoneinfo *zi = (struct zoneinfo *) data;
 
-    freestrlist(zi->data);
+    strarray_fini(&zi->data);
     free(zi);
 }
 

--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -290,7 +290,7 @@ static int action_murder(struct transaction_t *txn)
         /* Add HTML header */
         const char *sep =
             txn->req_uri->path[strlen(txn->req_uri->path)-1] == '/' ? "" : "/";
-        char *server;
+        const char *server;
         tok_t tok;
 
         buf_reset(&resp);

--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -414,7 +414,7 @@ static int action_proc(struct transaction_t *txn)
     struct buf *body = &txn->resp_body.payload;
     piarray_t piarray;
     time_t now = time(0);
-    struct strlist *param;
+    const strarray_t *param;
     struct tm tnow;
     char key = 0;
     struct proc_columns {
@@ -448,10 +448,11 @@ static int action_proc(struct transaction_t *txn)
     /* Check for a sort key */
     param = hash_lookup("sort", &txn->req_qparams);
     if (param) {
-        char Ukey = toupper((int) *param->s);
+        const char *s = strarray_nth(param, 0);
+        char Ukey = toupper((int) *s);
         for (i = 0; columns[i].key; i++) {
             if (Ukey == columns[i].key) {
-                key = *param->s;
+                key = *s;
                 if (isupper((int) key)) columns[i].key = tolower((int) key);
                 break;
             }

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -99,7 +99,7 @@ static int meth_get_applepush(struct transaction_t *txn,
                               void *params __attribute__((unused)))
 {
     int rc = HTTP_BAD_REQUEST, r = 0;
-    struct strlist *vals = NULL;
+    const strarray_t *param = NULL;
     const char *token = NULL, *key = NULL, *aps_topic = NULL;
     const char *mailbox_userid = NULL, *mailbox_uniqueid = NULL;
     strarray_t *keyparts = NULL;
@@ -108,13 +108,13 @@ static int meth_get_applepush(struct transaction_t *txn,
     int mbtype = 0;
 
     /* unpack query params */
-    vals = hash_lookup("token", &txn->req_qparams);
-    if (!vals) goto done;
-    token = vals->s;
+    param = hash_lookup("token", &txn->req_qparams);
+    if (!param) goto done;
+    token = strarray_nth(param, 0);
 
-    vals = hash_lookup("key", &txn->req_qparams);
-    if (!vals) goto done;
-    key = vals->s;
+    param = hash_lookup("key", &txn->req_qparams);
+    if (!param) goto done;
+    key = strarray_nth(param, 0);
 
     /* decompose key to userid + mailbox uniqueid */
     keyparts = strarray_split(key, "/", 0);

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -687,7 +687,7 @@ static const struct cal_comp_t {
 static void my_caldav_init(struct buf *serverinfo)
 {
     const char *domains;
-    char *domain;
+    const char *domain;
     tok_t tok;
 
     buf_printf(serverinfo, " LibiCal/%s", ICAL_VERSION);

--- a/imap/http_caldav_sched.h
+++ b/imap/http_caldav_sched.h
@@ -153,7 +153,7 @@ enum {
 extern unsigned config_allowsched;
 extern const char *ical_prodid;
 extern icaltimezone *utc_zone;
-extern struct strlist *cua_domains;
+extern strarray_t cua_domains;
 extern icalarray *rscale_calendars;
 
 extern icalcomponent *busytime_query_local(struct transaction_t *txn,

--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -172,7 +172,7 @@ static int meth_get(struct transaction_t *txn,
 
     if ((urls = config_getstring(IMAPOPT_HTTPALLOWEDURLS))) {
         tok_t tok = TOK_INITIALIZER(urls, " \t", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while ((token = tok_next(&tok)) && strcmp(token, txn->req_uri->path));
         tok_fini(&tok);

--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -316,7 +316,7 @@ static int meth_get(struct transaction_t *txn,
 
             /* Reset the URI part of our current transaction */
             xmlFreeURI(txn->req_uri);
-            free_hash_table(&txn->req_qparams, (void (*)(void *)) &freestrlist);
+            free_hash_table(&txn->req_qparams, (void (*)(void *)) &strarray_free);
 
             /* Examine new request */
             ret = examine_request(txn, hdr[0]);

--- a/imap/http_client.c
+++ b/imap/http_client.c
@@ -118,7 +118,7 @@ EXPORTED int http_parse_framing(int http2, hdrcache_t hdrs,
 
         for (; *hdr; hdr++) {
             tok_t tok = TOK_INITIALIZER(*hdr, ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-            char *token;
+            const char *token;
 
             while ((token = tok_next(&tok))) {
                 if (body->te & TE_CHUNKED) {
@@ -450,7 +450,7 @@ EXPORTED int http_read_response(struct backend *be, unsigned meth,
     for (conn = spool_getheader(*hdrs, "Connection"); conn && *conn; conn++) {
         tok_t tok =
             TOK_INITIALIZER(*conn, ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while ((token = tok_next(&tok))) {
             if (!strcasecmp(token, "keep-alive")) body->flags &= ~BODY_CLOSE;

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -920,7 +920,7 @@ static int eval_list(char *list, struct mailbox *mailbox, const char *etag,
 {
     unsigned ret = 1;
     tok_t tok;
-    char *cond;
+    const char *cond;
 
     /* Process each condition, ANDing the results */
     tok_initm(&tok, list+1, "]>", TOK_TRIMLEFT|TOK_TRIMRIGHT);
@@ -976,7 +976,7 @@ static int eval_if(const char *hdr, struct meth_params *params,
 
     /* Process each list, ORing the results */
     tok_init(&tok, hdr, ")", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-    while ((list = tok_next(&tok))) {
+    while ((list = (char *)tok_next(&tok))) {
         struct mailbox *mailbox, *my_mailbox = NULL;
         const char *etag, *lock_token;
         struct buf buf = BUF_INITIALIZER;
@@ -1236,7 +1236,7 @@ EXPORTED unsigned get_preferences(struct transaction_t *txn)
         int i;
         for (i = 0; hdr[i]; i++) {
             tok_t tok;
-            char *token;
+            const char *token;
 
             tok_init(&tok, hdr[i], ",\r\n", TOK_TRIMLEFT|TOK_TRIMRIGHT);
             while ((token = tok_next(&tok))) {

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -197,7 +197,7 @@ static int meth_get_isched(struct transaction_t *txn,
                            void *params __attribute__((unused)))
 {
     int precond;
-    struct strlist *action;
+    const strarray_t *action;
     static struct message_guid prev_guid;
     struct message_guid guid;
     const char *etag;
@@ -214,7 +214,7 @@ static int meth_get_isched(struct transaction_t *txn,
 
     /* We don't handle GET on a anything other than ?action=capabilities */
     action = hash_lookup("action", &txn->req_qparams);
-    if (!action || action->next || strcmp(action->s, "capabilities")) {
+    if (strarray_size(action) != 1 || strcmp(strarray_nth(action, 0), "capabilities")) {
         txn->error.desc = "Invalid action";
         return HTTP_BAD_REQUEST;
     }

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -553,7 +553,7 @@ static int meth_post_isched(struct transaction_t *txn,
             for (i = 0; recipients[i]; i++) {
                 tok_t tok =
                     TOK_INITIALIZER(recipients[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-                char *recipient;
+                const char *recipient;
 
                 while ((recipient = tok_next(&tok))) {
                     /* Is recipient remote or local? */

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -705,9 +705,9 @@ static int jmap_download(struct transaction_t *txn)
 
     blobid = xstrndup(blobbase, bloblen);
 
-    struct strlist *param;
+    const strarray_t *param;
     if ((param = hash_lookup("accept", &txn->req_qparams))) {
-        accept_mime = xstrdup(param->s);
+        accept_mime = xstrdup(strarray_nth(param, 0));
     }
 
     const char **hdr;
@@ -1560,9 +1560,9 @@ static int jmap_eventsource(struct transaction_t *txn)
         lastmodseq = atomodseq_t(*hdr);
     }
 
-    struct strlist *param;
+    const strarray_t *param;
     if ((param = hash_lookup("types", &txn->req_qparams))) {
-        strarray_t *types = strarray_split(param->s, ",", STRARRAY_TRIM);
+        strarray_t *types = strarray_split(strarray_nth(param, 0), ",", STRARRAY_TRIM);
 
         jpush = jmap_push_init(txn, httpd_userid, types, lastmodseq, &es_push);
         strarray_free(types);
@@ -1573,12 +1573,12 @@ static int jmap_eventsource(struct transaction_t *txn)
     }
 
     if ((param = hash_lookup("closeafter", &txn->req_qparams)) &&
-        !strcmpsafe(param->s, "state")) {
+        !strcmpsafe(strarray_nth(param, 0), "state")) {
         jpush->closeafter = 1;
     }
 
     if ((param = hash_lookup("ping", &txn->req_qparams))) {
-        jpush->ping = atoi(param->s);
+        jpush->ping = atoi(strarray_nth(param, 0));
     }
     jpush->next_ping = (jpush->ping > 0) ? now + jpush->ping : INT_MAX;
 

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -529,7 +529,7 @@ EXPORTED void http_proto_host(hdrcache_t req_hdrs, const char **proto, const cha
          * and more importantly, we need the tokens available after tok_fini()
          */
         tok_t tok;
-        char *token;
+        const char *token;
 
         while (fwd[1]) ++fwd;  /* Skip to last Forwarded header */
 

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -153,8 +153,8 @@ static int meth_get(struct transaction_t *txn,
                     void *params __attribute__((unused)))
 {
     int ret = 0, r, rights;
-    struct strlist *param;
-    char *section = NULL;
+    const strarray_t *param;
+    const char *section = NULL;
     uint32_t uid = 0;
     struct mailbox *mailbox = NULL;
 
@@ -212,7 +212,7 @@ static int meth_get(struct transaction_t *txn,
 
         /* Check for section query param, if any */
         param = hash_lookup("section", &txn->req_qparams);
-        if (param) section = param->s;
+        if (param) section = strarray_nth(param, 0);
     }
 
     /* If no UID specified, list messages as an RSS feed */

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -656,7 +656,7 @@ static int webdav_put(struct transaction_t *txn, void *obj,
     struct webdav_data *wdata;
     struct index_record *oldrecord = NULL, record;
     const char **hdr;
-    char *filename = NULL;
+    const char *filename = NULL;
 
     /* Validate the data */
     if (!buf) return HTTP_FORBIDDEN;
@@ -684,7 +684,7 @@ static int webdav_put(struct transaction_t *txn, void *obj,
 
     /* Get filename of attachment */
     if ((hdr = spool_getheader(txn->req_hdrs, "Content-Disposition"))) {
-        char *dparam;
+        const char *dparam;
         tok_t tok;
 
         tok_initm(&tok, (char *) *hdr, ";", TOK_TRIMLEFT|TOK_TRIMRIGHT);
@@ -693,14 +693,15 @@ static int webdav_put(struct transaction_t *txn, void *obj,
                 filename = dparam+9;
                 if (*filename == '"') {
                     filename++;
-                    filename[strlen(filename)-1] = '\0';
+                    char *backdoor = (char *)filename;
+                    backdoor[strlen(backdoor)-1] = '\0';
                 }
                 break;
             }
         }
         tok_fini(&tok);
     }
-    else filename = (char *) resource;
+    else filename = resource;
 
     /* Create and cache RFC 5322 header fields for resource */
     if (filename) {

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -598,7 +598,7 @@ static int webdav_get(struct transaction_t *txn,
         return HTTP_NO_PRIVS;
     }
 
-    struct strlist *action = hash_lookup("action", &txn->req_qparams);
+    const strarray_t *action = hash_lookup("action", &txn->req_qparams);
     if (!action) {
         /* Send HTML with davmount link */
         buf_reset(body);
@@ -615,7 +615,7 @@ static int webdav_get(struct transaction_t *txn,
 
         txn->resp_body.type = "text/html; charset=utf-8";
     }
-    else if (action->next || strcmp(action->s, "davmount")) {
+    else if (strarray_size(action) != 1 || strcmp(strarray_nth(action, 0), "davmount")) {
         return HTTP_BAD_REQUEST;
     }
     else {

--- a/imap/http_ws.c
+++ b/imap/http_ws.c
@@ -282,7 +282,7 @@ static void ws_zlib_init(struct transaction_t *txn, tok_t *params)
 {
     struct ws_context *ctx = (struct ws_context *) txn->ws_ctx;
     unsigned client_max_wbits = MAX_WBITS;
-    char *token;
+    const char *token;
 
     ctx->pmce.deflate.max_wbits = MAX_WBITS;
 
@@ -636,13 +636,13 @@ static void parse_extensions(struct transaction_t *txn)
     /* Look for interesting extensions.  Unknown == ignore */
     for (i = 0; ext_hdr && ext_hdr[i]; i++) {
         tok_t ext = TOK_INITIALIZER(ext_hdr[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while ((token = tok_next(&ext))) {
             struct ws_extension *extp = extensions;
             tok_t param;
 
-            tok_initm(&param, token, ";", TOK_TRIMLEFT|TOK_TRIMRIGHT);
+            tok_init(&param, token, ";", TOK_TRIMLEFT|TOK_TRIMRIGHT);
             token = tok_next(&param);
 
             /* Locate a matching extension */
@@ -765,7 +765,7 @@ HIDDEN int ws_start_channel(struct transaction_t *txn,
 
         for (i = 0; !found && hdr[i]; i++) {
             tok_t tok = TOK_INITIALIZER(hdr[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-            char *token;
+            const char *token;
 
             while ((token = tok_next(&tok))) {
                 if (!strcmp(token, protocol)) {

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2316,7 +2316,7 @@ static int parse_expect(struct transaction_t *txn)
     /* Look for interesting expectations.  Unknown == error */
     for (i = 0; !ret && exp && exp[i]; i++) {
         tok_t tok = TOK_INITIALIZER(exp[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while (!ret && (token = tok_next(&tok))) {
             /* Check if client wants acknowledgment before sending body */ 
@@ -2347,7 +2347,7 @@ static void parse_upgrade(struct transaction_t *txn)
 
     for (i = 0; upgrade[i]; i++) {
         tok_t tok = TOK_INITIALIZER(upgrade[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while ((token = tok_next(&tok))) {
             if (!txn->conn->tls_ctx && httpd_tls_enabled &&
@@ -2402,7 +2402,7 @@ static int parse_connection(struct transaction_t *txn)
     /* Look for interesting connection tokens */
     for (i = 0; conn[i]; i++) {
         tok_t tok = TOK_INITIALIZER(conn[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while ((token = tok_next(&tok))) {
             switch (txn->flags.ver) {
@@ -2457,7 +2457,7 @@ struct accept *parse_accept(const char **hdr)
 
     for (i = 0; hdr && hdr[i]; i++) {
         tok_t tok = TOK_INITIALIZER(hdr[i], ";,", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while ((token = tok_next(&tok))) {
             if (!strncmp(token, "q=", 2)) {
@@ -2493,7 +2493,7 @@ void parse_query_params(struct transaction_t *txn, const char *query)
     assert(!buf_len(&txn->buf));  /* Unescape buffer */
 
     tok_init(&tok, query, "&", TOK_TRIMLEFT|TOK_TRIMRIGHT|TOK_EMPTY);
-    while ((param = tok_next(&tok))) {
+    while ((param = (char *)tok_next(&tok))) {
         struct strlist *vals;
         char *key, *value;
         size_t len;
@@ -4382,7 +4382,7 @@ static unsigned etag_match(const char *hdr[], const char *etag)
 {
     unsigned i, match = 0;
     tok_t tok;
-    char *token;
+    const char *token;
 
     for (i = 0; !match && hdr[i]; i++) {
         tok_init(&tok, hdr[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
@@ -4402,7 +4402,7 @@ static int parse_ranges(const char *hdr, unsigned long len,
     int ret = HTTP_BAD_RANGE;
     struct range *new, *tail = *ranges = NULL;
     tok_t tok;
-    char *token;
+    const char *token;
 
     if (!len) return HTTP_OK;  /* need to know length of representation */
 
@@ -4822,7 +4822,7 @@ static int meth_get(struct transaction_t *txn,
     /* Local content */
     if ((urls = config_getstring(IMAPOPT_HTTPALLOWEDURLS))) {
         tok_t tok = TOK_INITIALIZER(urls, " \t", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
 
         while ((token = tok_next(&tok)) && strcmp(token, txn->req_uri->path));
         tok_fini(&tok);

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -450,8 +450,8 @@ static int do_indexer(const strarray_t *mboxnames)
 static int squatter_build_query(search_builder_t *bx, const char *query)
 {
     tok_t tok = TOK_INITIALIZER(query, NULL, 0);
-    char *p;
-    char *q;
+    const char *p;
+    const char *q;
     int r = 0;
     int part;
     charset_t utf8 = charset_lookupname("utf-8");
@@ -510,9 +510,9 @@ static int squatter_build_query(search_builder_t *bx, const char *query)
         else
             goto error;
 
-        q = charset_convert(q, utf8, charset_flags);
-        bx->match(bx, part, q);
-        free(q);
+        char *val = charset_convert(q, utf8, charset_flags);
+        bx->match(bx, part, val);
+        free(val);
     }
     r = 0;
 

--- a/imap/userdeny_db.c
+++ b/imap/userdeny_db.c
@@ -121,7 +121,7 @@ EXPORTED int userdeny(const char *user, const char *service, char *msgbuf, size_
     char *wild = NULL;
     const char *msg = NULL;
     tok_t tok;
-    char *pat;
+    const char *pat;
     int not;
 
     init_internal();

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -167,10 +167,10 @@ void icalrecurrencetype_add_as_xxx(struct icalrecurrencetype *recur, void *obj,
 
     /* generate an iCal RRULE string */
     rrule = icalrecurrencetype_as_string_r(recur);
-    
+
     /* split string into rparts & values */
     tok_initm(&rparts, rrule, "=;", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-    while ((rpart = tok_next(&rparts))) {
+    while ((rpart = (char *)tok_next(&rparts))) {
         if (!strcmp(rpart, "UNTIL")) {
             /* need to translate date format to ISO */
             struct icaltimetype until = icaltime_from_string(tok_next(&rparts));
@@ -180,7 +180,8 @@ void icalrecurrencetype_add_as_xxx(struct icalrecurrencetype *recur, void *obj,
         else {
             /* assume the rpart has multiple values - split them */
             tok_t vlist;
-            char *val, *p;
+            const char *val;
+            char *p;
 
             tok_init(&vlist, tok_next(&rparts), ",",
                      TOK_TRIMLEFT|TOK_TRIMRIGHT);

--- a/imap/zoneinfo_db.c
+++ b/imap/zoneinfo_db.c
@@ -142,10 +142,11 @@ static int parse_zoneinfo(const char *data, int datalen,
     if (all && p < dend) {
         size_t len = dend - ++p;
         char *str = xstrndup(p, len);
+        const char *p;
         tok_t tok;
 
         tok_initm(&tok, str, "\t", TOK_FREEBUFFER);
-        while ((str = tok_next(&tok))) appendstrlist(&zi->data, str);
+        while ((p = tok_next(&tok))) appendstrlist(&zi->data, p);
         tok_fini(&tok);
     }
 

--- a/imap/zoneinfo_db.h
+++ b/imap/zoneinfo_db.h
@@ -73,7 +73,7 @@
 struct zoneinfo {
     unsigned type;
     time_t dtstamp;
-    struct strlist *data;
+    strarray_t data;
 };
 
 /* zoneinfo record types */

--- a/lib/tok.c
+++ b/lib/tok.c
@@ -66,7 +66,7 @@ EXPORTED void tok_fini(tok_t *t)
     memset(t, 0, sizeof(*t));
 }
 
-EXPORTED char *tok_next(tok_t *t)
+EXPORTED const char *tok_next(tok_t *t)
 {
     const char *sep;
     char *token;

--- a/lib/tok.h
+++ b/lib/tok.h
@@ -73,7 +73,7 @@ void tok_initm(tok_t *, char *buf, const char *sep, int flags);
 void tok_fini(tok_t *);
 
 /* advance to the next token and return it */
-char *tok_next(tok_t *);
+const char *tok_next(tok_t *);
 /* return offset into the buffer of the current token, for error messages */
 unsigned int tok_offset(const tok_t *);
 

--- a/sieve/sieve.y
+++ b/sieve/sieve.y
@@ -2416,7 +2416,7 @@ static commandlist_t *build_redirect(sieve_script_t *sscript,
     if (c->u.r.dsn_notify && !supported(SIEVE_CAPA_VARIABLES)) {
         tok_t tok =
             TOK_INITIALIZER(c->u.r.dsn_notify, ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
-        char *token;
+        const char *token;
         int never = 0;
 
         while ((token = tok_next(&tok))) {


### PR DESCRIPTION
Gonna ask both of you to review this.  Ken because you were the major user of strlist throughout the HTTP code, and ellie because you've been doing lots of really careful review and I appreciate it :)

There's two commits here - the first turns tok_next into a thing that returns a 'const char *', because mostly that's all we need, and it reminds us not to free or screw with it.  The couple of places that do make changes can then be much more carefully reviewed.

The second commit replaces 'struct strlist' with a strarray_t in the couple of places that it was being used.  It largely impacts the query arg parsing code and the timezone code.

This work is based on top of https://github.com/cyrusimap/cyrus-imapd/pull/3626 at which time strlist became a very boring type.