### PR TITLE
jmap_calendar: list empty Calendar list if ACL_LOOKUP is set

### DIFF
--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -575,7 +575,7 @@ static int has_calendars_cb(const mbentry_t *mbentry, void *rock)
 {
     jmap_req_t *req = rock;
     if (mbtype_isa(mbentry->mbtype) == MBTYPE_CALENDAR &&
-            jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
+            jmap_hasrights_mbentry(req, mbentry, JACL_LOOKUP)) {
         return CYRUSDB_DONE;
     }
     return 0;


### PR DESCRIPTION
Fixes a bug where a calendar with ACL 'l9' (lookup and freebusy) causes a JMAP session accountCapibilities to report the calendar capability for that account, but Calendar/get is rejected with an 'accountHasNoCalendars' error.

Tested in https://github.com/cyrusimap/cassandane/pull/170