### PR TITLE
Email/changes: handle removed messages in invisible folder

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1266,6 +1266,7 @@ static int _email_is_expunged_cb(const conv_guidrec_t *rec, void *rock)
     if (rec->part) return 0;
 
     r = jmap_openmbox_by_guidrec(check->req, rec, &mbox, 0);
+    if (r == IMAP_MAILBOX_NONEXISTENT) return 0;
     if (r) return r;
 
     if (mbtype_isa(mailbox_mbtype(mbox)) == MBTYPE_EMAIL) {


### PR DESCRIPTION
Tests here: 

https://github.com/cyrusimap/cassandane/pull/171

Cyrus was returning an error "mailbox not found" when an email was moved from a folder that we can see into a folder that we can't see, in a shared account.