### PR TITLE
JMAP Email: do not QP-encode text headers if they only need folding

### DIFF
--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -347,6 +347,20 @@ static void test_encode_mimeheader(void)
     /* only encode display-name of address */
     TESTCASE("\"abc\xe2\x88\x97xyz\" <foo@example.com>", "=?UTF-8?Q?=22abc=E2=88=97xyz=22?= <foo@example.com>");
 
+    /* fold long lines with whitespace */
+    TESTCASE("012345678 " "012345678 " "012345678 " "012345678 "
+             "012345678 " "012345678 " "012345678 " "0123456789",
+             "012345678 " "012345678 " "012345678 " "012345678 "
+             "012345678 " "012345678 " "012345678" "\r\n "
+             "0123456789");
+
+    /* encode long lines with no whitespace */
+    TESTCASE("0123456789" "0123456789" "0123456789" "0123456789"
+             "0123456789" "0123456789" "0123456789" "0123456789",
+             "=?UTF-8?Q?" "0123456789" "0123456789" "0123456789" "0123456789"
+             "0123456789" "0123456789" "01?=\r\n "
+             "=?UTF-8?Q?" "2345678901" "23456789?=");
+
 #undef TESTCASE
 }
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8601,14 +8601,11 @@ static json_t *_header_from_text(json_t *jtext,
 {
     /* Parse a Text header into raw form */
     if (json_is_string(jtext)) {
-        size_t prefix_len = strlen(header_name) + 2;
         const char *s = json_string_value(jtext);
-        /* Q-encoding will fold lines for us */
-        int force_quote = prefix_len + strlen(s) > MIME_MAX_HEADER_LENGTH;
-        char *tmp = charset_encode_mimeheader(s, strlen(s), force_quote);
+        char *tmp = charset_encode_mimeheader(s, strlen(s), 0);
         struct buf val = BUF_INITIALIZER;
-        /* If text got force-quoted the first line of the Q-encoded
-         * text might spill over the soft 78-character limit due to
+        /* If text got folded, then the first line of the encoded
+         * header might spill over the soft 78-character limit due to
          * the Header name prefix. Looking at how most of the mail
          * clients are doing this, this seems not to be an issue and
          * allows us to not start the header value with a line fold. */

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3393,6 +3393,7 @@ static char *qp_encode(const char *data, size_t len, int isheader,
 
     if (!force_quote) {
         size_t prev_lf = 0;
+        size_t last_sp = 0;
         for (n = 0; n < len; n++) {
             unsigned char this = data[n];
             unsigned char next = (n < len - 1) ? data[n+1] : '\0';
@@ -3400,10 +3401,17 @@ static char *qp_encode(const char *data, size_t len, int isheader,
             if (QPSAFECHAR[this] || this == '=' || this == ' ' || this == '\t') {
                 /* per RFC 5322: printable ASCII (decimal 33 - 126), SP, HTAB */
                 /* but only if the line doesn't exceed the 76 octet limit */
+
+                if (this == ' ' || this == '\t')
+                    last_sp = n;
+
                 if (n - prev_lf <= 74) continue;
 
                 if (isheader) {
-                    need_fold = 1;
+                    if (n - last_sp > 74)
+                        need_quote = 1;
+                    else
+                        need_fold = 1;
                     continue;
                 }
             }


### PR DESCRIPTION
Up until now, JMAP Email text headers that exceeded the 78 character line length limit were QP-encoded and folded. This patch changes that to omit QP-encoding if text is 7bit-safe and contains whitespace for folding.
