### PR TITLE
httpd: don't warn for "end of file reached" when closing connection

### DIFF
--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2217,7 +2217,7 @@ static void cmdloop(struct http_connection *conn)
 
     } while (!conn->close);
 
-    if (conn->close_str) {
+    if (conn->close_str && strcmp(conn->close_str, PROT_EOF_STRING)) {
         syslog(LOG_WARNING, "%s, closing connection", conn->close_str);
     }
 


### PR DESCRIPTION
Looks like we usually skip the PROT_EOF_STRING ones when warning about closing connections, so doing the same here.

Closes #3700 