### PR TITLE
Don't allow XFER to create intermediates in the user tree

### DIFF
--- a/changes/next/3705-xfer-no-intermediates
+++ b/changes/next/3705-xfer-no-intermediates
@@ -1,0 +1,19 @@
+Description:
+
+XFER will no longer move individual mailboxes that would leave intermediates
+behind in the user heirarchy.
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+Nothing required
+
+
+GitHub issue:
+
+#3705


### PR DESCRIPTION
Tests in https://github.com/cyrusimap/cassandane/pull/174

Since 3.5 we haven't been allowing "intermediate" mailboxes, instead requiring that all mailboxes are real mailboxes.

XFER in a murder environment allows this to be gummed up though, because it permits moving individual mailboxes around, leaving their ancestors and children behind.  The origin backend gets an intermediate entry where the mailbox used to be, and the destination backend gets a tree of intermediate entries where the ancestors would have been.  The mupdate master knows where all the "real" mailboxes are, so maybe it's okay in practice, but it breaks our new assumption that there are no more intermediates, which means we'll trip over it forever.

XFER is invoked on the origin backend like this:
`. XFER name destination [destpartition]`

`name` can be an exact partition name on the origin (in which case every user on that partition is fully moved), or it can be a mailbox pattern (in the admin namespace).  For each of the mailboxes the pattern matches:
* if it's a user's INBOX, the entire user account is moved (ok)
* otherwise, just that single mailbox is moved

Moving entire users around is fine; the problem is the single mailbox behaviour.

There's two scenarios to think about here:

1. XFER of a single mailbox from an older backend to a 3.5 backend
2. XFER of a single mailbox from a 3.5 backend to an older one

(1) is already taken care of for any origin that's 3.0+ or greater, because in this case both ends support xfer-over-replication, and so replication will be used.  The 3.5 destination doesn't allow a single mailbox to be replicated in (though I don't know whether this is deliberate or accidental), so the XFER fails at initial sync, and is aborted.  I'm not sure what happens when a 2.5 or earlier origin attempts this -- it will use the old LOCALCREATE/UNDUMP-style XFER... I guess the LOCALCREATE might fail and abort the whole thing, but I guess I need to test more...

(2) is the problem that this PR addresses.  As it currently stands, a 3.5 origin will allow the single mailbox XFER attempt as valid, and an older destination will accept the replication.  The 3.5 origin will be left with an intermediate in the tree.  The 3.5 origin couldn't just "fix it up later" by creating a real mailbox, because that one mailbox _does exist_, just not on that backend, and mupdate will refuse it.  (And if mupdate doesn't refuse it, then we're in an even bigger mess...)

The problem is resolved in this PR by removing support for the invocation of XFER whereby `name` could specify a user mailbox that is not an INBOX.  This type of request will now be rejected as invalid ("operation is not supported on mailbox").  To move user mailboxes around, the whole user must be moved.  This turns out to be a small, simple change, because we're just undoing an old special case.

The behaviour is untouched for shared mailboxes (that is, mailboxes outside the `user/` tree).  These can still be XFER'd around individually, and intermediates will still be created if the moved mailbox left children behind, or lacked ancestors at the destination.  Fixing this would be a much bigger change, and would collide with the atomic rename work, so I'm leaving it alone for now...

Previously, it was permitted to XFER `DELETED/*` user mailboxes around.  I don't know if it worked, we don't have any tests for it.  This PR now refuses these too, because it was the smallest change.  I could probably make it allow them, if it makes sense to do so, but I haven't thought through the corner cases -- it might be non-trivial, idk.

This is a draft for now.  If we like this approach as is, I'll tidy up the WIP commits.  If the scope needs to grow, then they're notes to myself.

I would particularly like feedback from both @brong and @ksmurchison on this.  Thanks!