### PR TITLE
cyr_dbtool: fix batch mode leaks

### DIFF
--- a/imap/cyr_dbtool.c
+++ b/imap/cyr_dbtool.c
@@ -246,6 +246,13 @@ done:
         fprintf(stderr, "FAILED: line %d at cmd %.*s with error %s\n",
                 line, (int)cmd.len, cmd.s, error_message(r));
     }
+
+    prot_free(in);
+    prot_free(out);
+
+    buf_free(&cmd);
+    buf_free(&key);
+    buf_free(&val);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Fixes a few simple leaks in cyr_dbtool's batch mode, found by valgrinding Cassandane.

Looks like these leaks have existed for ages, but for some reason Cassandane only recently started triggering them -- probably due to the addition of the `run_dbcommand()` APIs that use it.