### PR TITLE
http_ws: fix invalid read during clientless shutdown

### DIFF
--- a/imap/http_ws.c
+++ b/imap/http_ws.c
@@ -708,6 +708,14 @@ static void _end_channel(struct transaction_t *txn)
 
     free(ctx);
 
+    /* conn's lifetime is much longer than txn's; the pointer
+     * into txn will be invalid after txn goes out of scope.
+     * We know now that it's no longer useful, so clean it up
+     * while we're here.
+     */
+    if (txn->conn && txn->conn->ws_ctx == &txn->ws_ctx)
+        txn->conn->ws_ctx = NULL;
+
     txn->ws_ctx = NULL;
 }
 


### PR DESCRIPTION
I'm not sure if this is the _best_ fix, but it does seem to be _a_ fix.

We save a pointer to the transaction's ws_ctx in the connection so it can be cleaned up properly (if it's still around) during an unexpected shutdown, but that pointer isn't valid anymore once cmdloop finishes and the transaction goes out of scope.  Which means if there was a client connected, but isn't currently, and we're shutting down, `_h1_shutdown` trying to check if `*conn->ws_ptr` is set is an invalid read from out of scope memory, here:

```
static void _h1_shutdown(struct http_connection *conn)
{
    if (!conn->ws_ctx || !*conn->ws_ctx) return;

    [...]
```

In this case, we've already cleaned up the ws_ctx in `_end_channel` anyway, and `_h1_shutdown` is about to decide it doesn't need to do anything.  So the fix just makes `_end_channel` also remove the connection's pointer to it at the same time.