### PR TITLE
dav*: don't open the sqldb during init

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -122,7 +122,6 @@ static int rscale_cmp(const void *a, const void *b)
 #endif /* HAVE_RSCALE */
 
 
-static struct caldav_db *auth_caldavdb = NULL;
 static time_t compile_time;
 static struct buf ical_prodid_buf = BUF_INITIALIZER;
 static int icalendar_max_size;
@@ -940,18 +939,10 @@ static int my_caldav_auth(const char *userid)
         /* admin or proxy from frontend - won't have DAV database */
         return 0;
     }
+
     if (config_mupdate_server && !config_getstring(IMAPOPT_PROXYSERVERS)) {
         /* proxy-only server - won't have DAV database */
         return 0;
-    }
-    else {
-        /* Open CalDAV DB for 'userid' */
-        my_caldav_reset();
-        auth_caldavdb = caldav_open_userid(userid);
-        if (!auth_caldavdb) {
-            syslog(LOG_ERR, "Unable to open CalDAV DB for userid %s", userid);
-            return HTTP_UNAVAILABLE;
-        }
     }
 
     /* Auto-provision calendars for 'userid' */
@@ -967,8 +958,7 @@ static int my_caldav_auth(const char *userid)
 
 static void my_caldav_reset(void)
 {
-    if (auth_caldavdb) caldav_close(auth_caldavdb);
-    auth_caldavdb = NULL;
+    // nothing to do
 }
 
 static void my_caldav_shutdown(void)

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -89,7 +89,6 @@
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
 
-static struct carddav_db *auth_carddavdb = NULL;
 static time_t compile_time;
 static int vcard_max_size;
 
@@ -509,18 +508,10 @@ static int my_carddav_auth(const char *userid)
         /* admin, anonymous, or proxy from frontend - won't have DAV database */
         return 0;
     }
-    else if (config_mupdate_server && !config_getstring(IMAPOPT_PROXYSERVERS)) {
+
+    if (config_mupdate_server && !config_getstring(IMAPOPT_PROXYSERVERS)) {
         /* proxy-only server - won't have DAV databases */
         return 0;
-    }
-    else {
-        /* Open CardDAV DB for 'userid' */
-        my_carddav_reset();
-        auth_carddavdb = carddav_open_userid(userid);
-        if (!auth_carddavdb) {
-            syslog(LOG_ERR, "Unable to open CardDAV DB for userid: %s", userid);
-            return HTTP_UNAVAILABLE;
-        }
     }
 
     /* Auto-provision an addressbook for 'userid' */
@@ -536,8 +527,7 @@ static int my_carddav_auth(const char *userid)
 
 static void my_carddav_reset(void)
 {
-    if (auth_carddavdb) carddav_close(auth_carddavdb);
-    auth_carddavdb = NULL;
+    // nothing
 }
 
 

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -63,8 +63,6 @@
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
 
-static struct webdav_db *auth_webdavdb = NULL;
-
 static void my_webdav_init(struct buf *serverinfo);
 static int my_webdav_auth(const char *userid);
 static void my_webdav_reset(void);
@@ -315,18 +313,10 @@ static int my_webdav_auth(const char *userid)
         /* admin, anonymous, or proxy from frontend - won't have DAV database */
         return 0;
     }
-    else if (config_mupdate_server && !config_getstring(IMAPOPT_PROXYSERVERS)) {
+
+    if (config_mupdate_server && !config_getstring(IMAPOPT_PROXYSERVERS)) {
         /* proxy-only server - won't have DAV databases */
         return 0;
-    }
-    else {
-        /* Open WebDAV DB for 'userid' */
-        my_webdav_reset();
-        auth_webdavdb = webdav_open_userid(userid);
-        if (!auth_webdavdb) {
-            syslog(LOG_ERR, "Unable to open WebDAV DB for userid: %s", userid);
-            return HTTP_UNAVAILABLE;
-        }
     }
 
     /* Auto-provision toplevel DAV drive collection for 'userid' */
@@ -382,8 +372,7 @@ static int my_webdav_auth(const char *userid)
 
 static void my_webdav_reset(void)
 {
-    if (auth_webdavdb) webdav_close(auth_webdavdb);
-    auth_webdavdb = NULL;
+    // nothing
 }
 
 


### PR DESCRIPTION
We don't actually use it for anything, so it's just an obnoxious extra copy lying around, and has the bug that in a long running websockets connection, it could hold a file descriptor to the OLD database which is now deleted.

Instead, we just open the sqldb when we need it, which is always under a user lock, so we're safe against having things fiddled under us!