### PR TITLE
http_caldav_sched.c:imip_send_sendmail: print less redundant information in the text/plain part about attendees

### DIFF
--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -387,8 +387,12 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
     buf_appendcstr(&msgbuf, "Content-Type: text/plain; charset=utf-8\r\n");
     buf_appendcstr(&msgbuf, "Content-Disposition: inline\r\n");
 
-    buf_printf(&plainbuf, "You have received %s from %s <%s>\r\n\r\n", msg_type,
-               originator->name ? originator->name : "", originator->addr);
+    if (originator->name && strcasecmp(originator->name, originator->addr))
+        buf_printf(&plainbuf, "You have received %s from %s <%s>\r\n\r\n",
+                msg_type, originator->name, originator->addr);
+    else
+        buf_printf(&plainbuf, "You have received %s from %s\r\n\r\n", msg_type,
+                originator->addr);
     if (summary) {
         buf_setcstr(&tmpbuf, summary);
         buf_replace_all(&tmpbuf, "\n", "\r\n" TEXT_INDENT);
@@ -408,8 +412,10 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
         if (status) buf_printf(&plainbuf, "Status     : %s\r\n", status);
 
         for (cp = "Attendees  : ", recip=recipients; recip; recip=recip->next) {
-            buf_printf(&plainbuf, "%s* %s <%s>",
-                       cp, recip->name ? recip->name : "", recip->addr);
+            if (recip->name && strcasecmp(recip->name, recip->addr))
+                buf_printf(&plainbuf, "%s* %s <%s>", cp, recip->name, recip->addr);
+            else
+                buf_printf(&plainbuf, "%s* %s", cp, recip->addr);
             if (recip->role) buf_printf(&plainbuf, "\t(%s)", recip->role);
             buf_appendcstr(&plainbuf, "\r\n");
 


### PR DESCRIPTION
When the email address (property value) and name (CN= property parameter) of an attendee/organizer coincide, print only the email address.