### PR TITLE
http_caldav_sched.c:propcmp() compare the DATE-TIME properties by absolute value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1624,6 +1624,8 @@ dnl
                 AC_MSG_ERROR([Need libical 3.0.0 for http]))
 
         dnl icalproperty_new_color was overlooked, and eventually added in 3.0.5
+        dnl If HAVE_RFC7986_COLOR is defined, then libical is at least 3.0.5 and http_caldav_sched.c:propcmp()
+        dnl assumes that icalproperty_get_datetime_with_component() is available, too.
         AC_CHECK_LIB(ical, icalproperty_new_color,
                 AC_DEFINE(HAVE_RFC7986_COLOR,[],
                         [Do we have built-in support for RFC7986 color prop?]))


### PR DESCRIPTION
The effect is that changing the DTSTART timezone and value do not trigget iTIP message, if the start/end/due times converted to UTC do not change.

Comparing only the value with icalproperty_get_value_as_string() ignores the TZ information and does not trigger a change, when the timezone changes, the relative value remains the same, but the value converted to UTC does change.