### PR TITLE
http_caldav_sched.c:imip_send_sendmail() No need for <> in From: and To: when display-name is absent

### DIFF
--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -331,14 +331,18 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
     }
 
     /* Create multipart/mixed + multipart/alternative iMIP message */
-    buf_printf(&msgbuf, "From: %s <%s>\r\n",
-            originator->qpname ? originator->qpname : "", sender);
+    if (originator->qpname && strcasecmp(originator->qpname, sender))
+        buf_printf(&msgbuf, "From: %s <%s>\r\n", originator->qpname, sender);
+    else
+        buf_printf(&msgbuf, "From: %s\r\n", sender);
 
     for (recip = recipients; recip; recip = recip->next) {
         if (strcmp(recip->addr, sender) &&
             (!recipient || !strcasecmp(recip->addr, recipient))) {
-            buf_printf(&msgbuf, "To: %s <%s>\r\n",
-                    recip->qpname ? recip->qpname : "", recip->addr);
+            if (recip->qpname && strcasecmp(recip->qpname, recip->addr))
+                buf_printf(&msgbuf, "To: %s <%s>\r\n", recip->qpname, recip->addr);
+            else
+                buf_printf(&msgbuf, "To: %s\r\n", recip->addr);
         }
     }
 


### PR DESCRIPTION
No need to render the display-name, when it is identical to the email address.  The latter does happen, when some CUA inserts under ATTENDEE/ORGANIZER’s CN= property parameter value the property value (with mailto: stripped).