### PR TITLE
imtest.c: resolve -Wdiscarded-qualifiers -Wwrite-strings warnings

### DIFF
--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -158,18 +158,18 @@ struct protocol_t;
 
 struct banner_t {
     u_char is_capa;     /* banner is capability response */
-    char *resp;         /* end of banner response */
+    const char *resp;   /* end of banner response */
     void *(*parse_banner)(char *str);
                         /* [OPTIONAL] parse banner, returns 'rock' */
 };
 
 struct capa_cmd_t {
-    char *cmd;          /* capability command string (NULL = no capa cmd) */
-    char *resp;         /* end of capability response */
-    char *tls;          /* [OPTIONAL] TLS capability string */
-    char *login;        /* [OPTIONAL] plaintext login cmd capability string */
-    char *auth;         /* [OPTIONAL] AUTH (SASL) capability string */
-    char *compress;     /* [OPTIONAL] COMPRESS capability string */
+    const char *cmd;      /* capability command string (NULL = no capa cmd) */
+    const char *resp;     /* end of capability response */
+    const char *tls;      /* [OPTIONAL] TLS capability string */
+    const char *login;    /* [OPTIONAL] plaintext login cmd capability string */
+    const char *auth;     /* [OPTIONAL] AUTH (SASL) capability string */
+    const char *compress; /* [OPTIONAL] COMPRESS capability string */
     void (*parse_mechlist)(struct buf *list, const char *str,
                            struct protocol_t *prot, unsigned long *capabilities);
                         /* [OPTIONAL] parse capability string,
@@ -177,22 +177,22 @@ struct capa_cmd_t {
 };
 
 struct tls_cmd_t {
-    char *cmd;          /* tls command string */
-    char *ok;           /* start tls prompt */
-    char *fail;         /* failure response */
+    const char *cmd;    /* tls command string */
+    const char *ok;     /* start tls prompt */
+    const char *fail;   /* failure response */
     u_char auto_capa;   /* capability response sent automatically after TLS */
 };
 
 struct sasl_cmd_t {
-    char *cmd;          /* auth command string */
+    const char *cmd;    /* auth command string */
     u_short maxlen;     /* maximum command line length,
                            (0 = initial response unsupported by protocol) */
     u_char quote;       /* quote arguments (literal for base64 data) */
-    char *ok;           /* success response string */
-    char *fail;         /* failure response string */
-    char *cont;         /* continue response string
+    const char *ok;     /* success response string */
+    const char *fail;   /* failure response string */
+    const char *cont;   /* continue response string
                            (NULL = send/receive literals) */
-    char *cancel;       /* cancel auth string */
+    const char *cancel; /* cancel auth string */
     char *(*parse_success)(char *str);
                         /* [OPTIONAL] parse response for success data */
     u_char auto_capa;   /* capability response sent automatically
@@ -200,20 +200,20 @@ struct sasl_cmd_t {
 };
 
 struct compress_cmd_t {
-    char *cmd;          /* compress command string */
-    char *ok;           /* success response string */
-    char *fail;         /* failure response string */
+    const char *cmd;    /* compress command string */
+    const char *ok;     /* success response string */
+    const char *fail;   /* failure response string */
 };
 
 struct logout_cmd_t {
-    char *cmd;          /* logout command string */
-    char *resp;         /* logout response */
+    const char *cmd;    /* logout command string */
+    const char *resp;   /* logout response */
 };
 
 struct protocol_t {
-    char *protocol;     /* protocol service name */
-    char *sprotocol;    /* SSL-wrapped service name (NULL = unsupported) */
-    char *service;      /* SASL service name */
+    const char *protocol;  /* protocol service name */
+    const char *sprotocol; /* SSL-wrapped service name (NULL = unsupported) */
+    const char *service;   /* SASL service name */
     int login_enabled;  /* [OPTIONAL] login command on/off by default;
                            toggled by capability string */
     struct banner_t banner;
@@ -222,11 +222,11 @@ struct protocol_t {
     struct sasl_cmd_t sasl_cmd;
     struct compress_cmd_t compress_cmd;
     int (*do_auth)(struct sasl_cmd_t *sasl_cmd, void *rock,
-                   int login_enabled, char *mech, const char *mechlist);
+                   int login_enabled, const char *mech, const char *mechlist);
                         /* [OPTIONAL] perform protocol-specific authentication;
                            based on rock, login_enabled, mech, mechlist */
     struct logout_cmd_t logout_cmd;
-    char *unauth_cmd;
+    const char *unauth_cmd;
 
     /* these 3 are used for maintaining connection state */
     void *(*init_conn)(void); /* generate a context (if needed). This context
@@ -328,7 +328,7 @@ static int      tls_cipher_algbits = 0;
  * This function is taken from OpenSSL apps/s_cb.c
  */
 
-static int set_cert_stuff(SSL_CTX * ctx, char *cert_file, char *key_file)
+static int set_cert_stuff(SSL_CTX * ctx, const char *cert_file, const char *key_file)
 {
     if (cert_file != NULL) {
         if (SSL_CTX_use_certificate_chain_file(ctx, cert_file) <= 0) {
@@ -423,7 +423,7 @@ static RSA *tmp_rsa_cb(SSL * s __attribute__((unused)),
 
 static void apps_ssl_info_callback(const SSL * s, int where, int ret)
 {
-    char   *str;
+    const char *str;
     int     w;
 
     if (verbose==0) return;
@@ -471,22 +471,22 @@ static int tls_rand_init(void)
 }
 
 
-static char *var_tls_CAfile="";
-static char *var_tls_CApath="";
+static const char *var_tls_CAfile="";
+static const char *var_tls_CApath="";
 /*
  * This is the setup routine for the SSL client.
  *
  * The skeleton of this function is taken from OpenSSL apps/s_client.c.
  */
 
-static int tls_init_clientengine(int verifydepth, char *var_tls_cert_file, char *var_tls_key_file)
+static int tls_init_clientengine(int verifydepth, const char *var_tls_cert_file, const char *var_tls_key_file)
 {
     int     off = 0;
     int     verify_flags = SSL_VERIFY_NONE;
-    char   *CApath;
-    char   *CAfile;
-    char   *c_cert_file;
-    char   *c_key_file;
+    const char   *CApath;
+    const char   *CAfile;
+    const char   *c_cert_file;
+    const char   *c_key_file;
 
 
     if (verbose==1)
@@ -748,7 +748,7 @@ static int tls_start_clienttls(unsigned *layer, char **authid)
     return IMTEST_OK;
 }
 
-static void do_starttls(int ssl, char *keyfile, unsigned *ssf)
+static void do_starttls(int ssl, const char *keyfile, unsigned *ssf)
 {
     int result;
     char *auth_id;
@@ -833,7 +833,7 @@ static sasl_security_properties_t *make_secprops(int min,int max)
 /*
  * Initialize SASL and set necessary options
  */
-static int init_sasl(char *service, char *serverFQDN, int minssf, int maxssf,
+static int init_sasl(const char *service, char *serverFQDN, int minssf, int maxssf,
                      unsigned flags)
 {
     int saslresult;
@@ -1027,7 +1027,7 @@ static void fillin_interactions(sasl_interact_t *tlist)
 
 }
 
-static char *waitfor(char *tag, char *tag2, int echo)
+static char *waitfor(const char *tag, const char *tag2, int echo)
 {
     static char str[1024];
 
@@ -1184,7 +1184,7 @@ static int auth_sasl(struct sasl_cmd_t *sasl_cmd, const char *mechlist)
 }
 
 /* initialize the network */
-static int init_net(char *serverFQDN, char *port)
+static int init_net(char *serverFQDN, const char *port)
 {
     struct addrinfo hints, *res0 = NULL, *res;
     int err;
@@ -1562,7 +1562,8 @@ static struct buf *ask_capability(struct protocol_t *prot,
                                   unsigned long *capabilities, int automatic)
 {
     char str[1024] = "";
-    char *tmp, *resp;
+    char *tmp;
+    const char *resp;
     static struct buf ret = BUF_INITIALIZER;
 
     buf_reset(&ret);
@@ -1749,7 +1750,7 @@ static int auth_imap(void)
     unsigned int userlen;
     char *pass;
     unsigned int passlen;
-    char *tag = "L01 ";
+    static const char tag[] = "L01 ";
 
     str[0] = '\0';
 
@@ -1784,7 +1785,7 @@ static int auth_imap(void)
 static int imap_do_auth(struct sasl_cmd_t *sasl_cmd,
                         void *rock __attribute__((unused)),
                         int login_enabled,
-                        char *mech, const char *mechlist)
+                        const char *mech, const char *mechlist)
 {
     int result = IMTEST_FAIL;
 
@@ -1796,7 +1797,7 @@ static int imap_do_auth(struct sasl_cmd_t *sasl_cmd,
                 result = auth_imap();
             }
         } else if (!mechlist || !stristr(mechlist, mech)) {
-            printf("[Server did not advertise AUTH=%s]\n", ucase(mech));
+            printf("[Server did not advertise AUTH=%s]\n", mech);
         } else {
             result = auth_sasl(sasl_cmd, mech);
         }
@@ -1921,7 +1922,7 @@ Message-Id: <B27397-0100000@Blurdybloop.COM>\r\n \
 MIME-Version: 1.0\r\n \
 Content-Type: TEXT/PLAIN; CHARSET=US-ASCII\r\n\r\n"
 
-static int append_msg(char *mbox, int size)
+static int append_msg(const char *mbox, int size)
 {
     int lup;
 
@@ -1955,7 +1956,7 @@ static int append_msg(char *mbox, int size)
 
 static void send_recv_test(void)
 {
-    char *mboxname="inbox.imtest";
+    static const char mboxname[]="inbox.imtest";
     time_t start, end;
     int lup;
 
@@ -2095,7 +2096,7 @@ static int auth_apop(char *apop_chal)
 }
 
 static int pop3_do_auth(struct sasl_cmd_t *sasl_cmd, void *apop_chal,
-                        int user_enabled, char *mech, const char *mechlist)
+                        int user_enabled, const char *mech, const char *mechlist)
 {
     int result = IMTEST_FAIL;
 
@@ -2113,7 +2114,7 @@ static int pop3_do_auth(struct sasl_cmd_t *sasl_cmd, void *apop_chal,
                 result = auth_pop();
             }
         } else if (!mechlist || !stristr(mechlist, mech)) {
-            printf("[Server did not advertise SASL %s]\n", ucase(mech));
+            printf("[Server did not advertise SASL %s]\n", mech);
         } else {
             result = auth_sasl(sasl_cmd, mech);
         }
@@ -2177,7 +2178,7 @@ static int auth_nntp()
 
 static int nntp_do_auth(struct sasl_cmd_t *sasl_cmd,
                         void *rock __attribute__((unused)),
-                        int user_enabled, char *mech, const char *mechlist)
+                        int user_enabled, const char *mech, const char *mechlist)
 {
     int result = IMTEST_OK;
 
@@ -2190,7 +2191,7 @@ static int nntp_do_auth(struct sasl_cmd_t *sasl_cmd,
                 result = auth_nntp();
             }
         } else if (!mechlist || !stristr(mechlist, mech)) {
-            printf("[Server did not advertise SASL %s]\n", ucase(mech));
+            printf("[Server did not advertise SASL %s]\n", mech);
             result = IMTEST_FAIL;
         } else {
             result = auth_sasl(sasl_cmd, mech);
@@ -2224,7 +2225,7 @@ static char *nntp_parse_success(char *str)
 static int xmtp_do_auth(struct sasl_cmd_t *sasl_cmd,
                         void *rock __attribute__((unused)),
                         int login_enabled __attribute__((unused)),
-                        char *mech, const char *mechlist)
+                        const char *mech, const char *mechlist)
 {
     int result = IMTEST_OK;
 
@@ -2343,10 +2344,9 @@ static void http_parse_mechlist(struct buf *ret, const char *str,
                                 struct protocol_t *prot __attribute__((unused)),
                                 unsigned long *capabilities)
 {
-    char *scheme;
     size_t len;
+    const char *scheme = strchr(str, ':');
 
-    scheme = strchr(str, ':');
     while (strchr(" \t", *++scheme)); /* trim options whitespace */
     len = strcspn(scheme, " \t\r\n"); /* end of scheme name */
 
@@ -2650,7 +2650,7 @@ static int auth_http_sasl(const char *servername, const char *mechlist)
 
 static int http_do_auth(struct sasl_cmd_t *sasl_cmd __attribute__((unused)),
                         void *servername, int basic_enabled,
-                        char *mech, const char *mechlist)
+                        const char *mech, const char *mechlist)
 {
     int result = IMTEST_OK;
 
@@ -2667,7 +2667,7 @@ static int http_do_auth(struct sasl_cmd_t *sasl_cmd __attribute__((unused)),
             else if (!strcasecmp(mech, "negotiate")) mech = "GSS-SPNEGO";
 
             if (!mechlist || !stristr(mechlist, mech)) {
-                printf("[Server did not advertise HTTP %s]\n", ucase(mech));
+                printf("[Server did not advertise HTTP %s]\n", mech);
                 result = IMTEST_FAIL;
             } else {
                 result = auth_http_sasl(servername, mech);
@@ -2687,7 +2687,7 @@ static int http_do_auth(struct sasl_cmd_t *sasl_cmd __attribute__((unused)),
 /*****************************************************************************/
 
 /* didn't give correct parameters; let's exit */
-static void usage(char *prog, char *prot)
+static void usage(char *prog, const char *prot)
 {
     printf("Usage: %s [options] hostname\n", prog);
     printf("  -p port  : port to use (default=standard port for protocol)\n");
@@ -2857,8 +2857,8 @@ int main(int argc, char **argv)
 #endif
 
     char *prog;
-    char *tls_keyfile WITH_SSL_ONLY = "";
-    char *port = "", *prot = "";
+    const char *tls_keyfile WITH_SSL_ONLY = "";
+    const char *port = "", *prot = "";
     int run_stress_test=0;
     int dotls WITH_SSL_ONLY = 0, dossl = 0, docompress WITH_ZLIB_ONLY = 0;
     unsigned long capabilities = 0;
@@ -2987,7 +2987,7 @@ int main(int argc, char **argv)
             if ((val = strchr(optarg, '=')))
                 *val++ = '\0';
             else
-                val = "1";
+                val = (char*)"1";
 
             /* insert the opt/val pair into the hash table */
             hash_insert(optarg, xstrdup(val), &confighash);
@@ -3186,7 +3186,7 @@ int main(int argc, char **argv)
             result = protocol->do_auth(&protocol->sasl_cmd,
                                        rock ? rock : servername,
                                        capabilities & CAPA_LOGIN,
-                                       mechanism, buf_cstring(mechlist));
+                                       mechanism ? ucase(mechanism) : NULL, buf_cstring(mechlist));
         else {
             if (mechanism) {
                 result = auth_sasl(&protocol->sasl_cmd, mechanism);


### PR DESCRIPTION
Compiling with CFLAGS set to the above produces many warnings on imtest.c .