### PR TITLE
JMAPEmail: include Trash unseen counts in threadKeyword search

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -19492,7 +19492,15 @@ EOF
     }, $res->[0][1]{list}[0]{mailboxIds});
     $self->assert_equals(JSON::false, $res->[1][1]{performance}{details}{isGuidSearch});
     $self->assert_deep_equals([], $res->[1][1]{ids});
-    $self->assert_equals(JSON::true, $res->[2][1]{performance}{details}{isGuidSearch});
+    my ($maj, $min) = Cassandane::Instance->get_version();
+    if ($maj < 3 || ($maj ==3 && $min < 5)) {
+        $self->assert_equals(JSON::true, $res->[2][1]{performance}{details}{isGuidSearch});
+    }
+    else {
+        # Due to improved JMAP Email query optimizer
+        $self->assert_equals(JSON::false, $res->[2][1]{performance}{details}{isGuidSearch});
+    }
+
     $self->assert_deep_equals([], $res->[2][1]{ids});
 
     xlog "Create message in inbox";

--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -22759,4 +22759,149 @@ sub test_email_set_multipart_related
     $self->assert($ct =~ /;type=\"text\/html\"$/);
 }
 
+sub test_email_query_convflags_seen_in_trash
+    :min_version_3_5 :needs_component_jmap :JMAPExtensions
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            create => {
+                mboxTrash => {
+                    name => 'Trash',
+                },
+            }
+        }, 'R2'],
+    ]);
+    my $mboxTrash = $res->[0][1]{created}{mboxTrash}{id};
+    $self->assert_not_null($mboxTrash);
+
+    $res = $jmap->CallMethods([
+        ['Email/set', {
+            create => {
+                emailInInbox => {
+                    mailboxIds => {
+                        '$inbox' => JSON::true,
+                    },
+                    messageId => ['emailInInbox@local'],
+                    subject => 'test',
+                    keywords => {
+                        '$seen' => JSON::true,
+                    },
+                    bodyStructure => {
+                        type => 'text/plain',
+                        partId => 'part1',
+                    },
+                    bodyValues => {
+                        part1 => {
+                            value => 'test inbox',
+                        }
+                    },
+                },
+            },
+        }, 'R1'],
+        ['Email/set', {
+            create => {
+                emailInTrash => {
+                    mailboxIds => {
+                        $mboxTrash => JSON::true,
+                    },
+                    messageId => ['emailInThrash@local'],
+                    subject => 'Re: test',
+                    references => ['emailInInbox@local'],
+                    bodyStructure => {
+                        type => 'text/plain',
+                        partId => 'part1',
+                    },
+                    bodyValues => {
+                        part1 => {
+                            value => 'test trash',
+                        }
+                    },
+                },
+            },
+        }, 'R2'],
+    ]);
+    $self->assert_not_null($res->[0][1]{created}{emailInInbox}{id});
+    $self->assert_not_null($res->[1][1]{created}{emailInTrash}{id});
+    $self->assert_str_equals($res->[0][1]{created}{emailInInbox}{threadId},
+        $res->[1][1]{created}{emailInTrash}{threadId});
+
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                operator => 'NOT',
+                conditions => [{
+                    allInThreadHaveKeyword => '$seen',
+                }],
+            },
+        }, 'R1'],
+        ['Email/query', {
+            filter => {
+                operator => 'AND',
+                conditions => [{
+                    operator => 'NOT',
+                    conditions => [{
+                        allInThreadHaveKeyword => '$seen',
+                    }],
+                }, {
+                    inMailboxOtherThan => [ $mboxTrash ],
+                }],
+            },
+        }, 'R2'],
+        ['Email/query', {
+            filter => {
+                operator => 'AND',
+                conditions => [{
+                    body => 'test',
+                }, {
+                    operator => 'NOT',
+                    conditions => [{
+                        allInThreadHaveKeyword => '$seen',
+                    }],
+                }],
+            },
+        }, 'R3'],
+        ['Email/query', {
+            filter => {
+                operator => 'AND',
+                conditions => [{
+                    body => 'test',
+                }, {
+                    operator => 'NOT',
+                    conditions => [{
+                        allInThreadHaveKeyword => '$seen',
+                    }],
+                }, {
+                    inMailboxOtherThan => [ $mboxTrash ],
+                }],
+            },
+        }, 'R4'],
+    ], [
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:mail',
+        'urn:ietf:params:jmap:submission',
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/debug',
+        'https://cyrusimap.org/ns/jmap/performance',
+    ]);
+
+    $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
+    $self->assert_num_equals(0, scalar @{$res->[1][1]{ids}});
+    $self->assert_num_equals(2, scalar @{$res->[2][1]{ids}});
+    $self->assert_num_equals(0, scalar @{$res->[3][1]{ids}});
+
+    $self->assert_equals(JSON::false,
+        $res->[0][1]{performance}{details}{isGuidSearch});
+    $self->assert_equals(JSON::false,
+        $res->[1][1]{performance}{details}{isGuidSearch});
+    $self->assert_equals(JSON::true,
+        $res->[2][1]{performance}{details}{isGuidSearch});
+    $self->assert_equals(JSON::true,
+        $res->[3][1]{performance}{details}{isGuidSearch});
+}
+
 1;

--- a/changes/next/jmap_emailsearch_trash
+++ b/changes/next/jmap_emailsearch_trash
@@ -1,0 +1,19 @@
+Description:
+
+JMAP Email/query and XCONV IMAP extension commands now include
+the SEEN state of messages in mailbox "Trash" when evaluating
+conversation flags. Queries must explicitly exclude the "Trash"
+mailbox folder to ignore SEEN state of messages in "Trash".
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.
+
+GitHub issue:
+
+None.

--- a/cunit/search_expr.testc
+++ b/cunit/search_expr.testc
@@ -679,9 +679,9 @@ static void test_normalise(void)
      * under a NOT node is already in DNF.
      */
     TESTCASE("(not (false))",
-             "(not (false))");
+             "(true)");
     TESTCASE("(not (true))",
-             "(not (true))");
+             "(false)");
     TESTCASE("(not (match subject \"ETSY\"))",
              "(not (match subject \"ETSY\"))");
     TESTCASE("(not (le size 123))",
@@ -1053,6 +1053,115 @@ static void test_normalise(void)
                 " "
                 "(match subject \"ETSY\")"
              ")");
+
+    // Detrivialisation.
+
+    TESTCASE("(or "
+                "(not (true))"
+                " "
+                "(not (le size 123))"
+            ")",
+            "(not (le size 123))");
+
+    TESTCASE("(or "
+                "(and "
+                    "(true)"
+                    " "
+                    "(match subject \"ETSY\")"
+                    " "
+                    "(not (le size 789))"
+                ")"
+                " "
+                "(and "
+                    "(true)"
+                    " "
+                    "(not (true))"
+                    " "
+                    "(match subject \"ETSY\")"
+                ")"
+            ")",
+            "(and "
+                "(not (le size 789))"
+                " "
+                "(match subject \"ETSY\")"
+            ")");
+
+    TESTCASE("(or "
+                "(and "
+                    "(true)"
+                    " "
+                    "(not (le size 123))"
+                    " "
+                    "(match body \"COSBY\")"
+                ")"
+                " "
+                "(and "
+                    "(true)"
+                    " "
+                    "(not (true))"
+                    " "
+                    "(match body \"COSBY\")"
+                ")"
+            ")",
+            "(and "
+                "(not (le size 123))"
+                " "
+                "(match body \"COSBY\")"
+            ")");
+    TESTCASE("(or "
+                "(and "
+                    "(true)"
+                    " "
+                    "(true)"
+                    " "
+                    "(match subject \"ETSY\")"
+                    " "
+                    "(not (le size 789))"
+                    " "
+                    "(match body \"COSBY\")"
+                ")"
+                " "
+                "(and "
+                    "(true)"
+                    " "
+                    "(true)"
+                    " "
+                    "(not (true))"
+                    " "
+                    "(match body \"COSBY\")"
+                    " "
+                    "(match subject \"ETSY\")"
+                ")"
+            ")",
+            "(and "
+                "(not (le size 789))"
+                " "
+                "(match subject \"ETSY\")"
+                " "
+                "(match body \"COSBY\")"
+            ")");
+
+    TESTCASE("(or "
+                "(and "
+                    "(true)"
+                    " "
+                    "(ge size 5)"
+                ")"
+                " "
+                "(and "
+                    "(true)"
+                    " "
+                    "(le size 10)"
+                ")"
+            ")",
+            "(or "
+                "(le size 10)"
+                " "
+                "(ge size 5)"
+            ")");
+
+
+
 
 #undef TESTCASE
 }

--- a/imap/search_expr.h
+++ b/imap/search_expr.h
@@ -152,6 +152,7 @@ extern void search_expr_split_by_folder_and_index(search_expr_t *e,
                                                    void *rock),
                                         void *rock);
 extern char *search_expr_firstmailbox(const search_expr_t *);
+extern void search_expr_detrivialise(search_expr_t **ep);
 
 enum search_cost {
     SEARCH_COST_NONE = 0,


### PR DESCRIPTION
Up until now, evaluation of the threadKeyword query criteria did not take the `Seen` state of messages in the "Trash"
mailbox into account. The JMAP specification does not define this special treatment for the Trash mailbox.

This patch updates threadKeyword search to include the `Seen` state of messages within Trash. To preserve former behaviour, queries must explicitly exclude the "Trash" mailbox, using either an `inMailboxOtherThan` or a negated `inMailbox` criteria. For such queries, the `Seen` count of messages with "Trash" is ignored.

Note that this patch only applies to the hard-coded "Trash" mailbox name. Mailboxes with other name and `role=trash` always counted towards the total `Seen` count of a thread.

To make this work for guidsearch,  DNF search expression normalisation also removes trivial conditionals from the search tree.

Tested in https://github.com/cyrusimap/cassandane/pull/180