### PR TITLE
imap/cyr_expire.c: fix compiler warning with clang 12

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -89,7 +89,6 @@
 static int verbose = 0;
 static const char *progname = NULL;
 static struct namespace expire_namespace; /* current namespace */
-static struct cyr_expire_ctx ctx;
 
 /* command line arguments */
 struct arguments {
@@ -155,6 +154,8 @@ struct cyr_expire_ctx {
     struct delete_rock drock;
     struct expire_rock erock;
 };
+
+static struct cyr_expire_ctx ctx;
 
 /* verbosep - a wrapper to print if the 'verbose' option is
    turned on.


### PR DESCRIPTION
Define first the type cyr_expire_ctx, then variables from the type.

imap/cyr_expire.c:92:30: warning: tentative definition of variable with internal linkage has incomplete non-array type 'struct cyr_expire_ctx' [-Wtentative-definition-incomplete-type]
static struct cyr_expire_ctx ctx;
                             ^
imap/cyr_expire.c:92:15: note: forward declaration of 'struct cyr_expire_ctx'
static struct cyr_expire_ctx ctx;
              ^