### PR TITLE
Annotate usage(), service_abort() with __attribute__((noreturn))

### DIFF
--- a/backup/backupd.c
+++ b/backup/backupd.c
@@ -208,7 +208,7 @@ EXPORTED int service_init(int argc __attribute__((unused)),
 }
 
 /* Called by service API to shut down the service */
-EXPORTED void service_abort(int error)
+EXPORTED __attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/backup/ctl_backups.c
+++ b/backup/ctl_backups.c
@@ -75,7 +75,7 @@ EXPORTED void fatal(const char *error, int code)
 }
 
 static const char *argv0 = NULL;
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "    %s [options] compact [mode] backup...\n", argv0);

--- a/backup/cyr_backup.c
+++ b/backup/cyr_backup.c
@@ -78,7 +78,7 @@ EXPORTED void fatal(const char *error, int code)
 }
 
 static const char *argv0 = NULL;
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "    %s [options] [mode] backup list chunks\n", argv0);

--- a/backup/restore.c
+++ b/backup/restore.c
@@ -71,7 +71,7 @@ EXPORTED void fatal(const char *s, int code)
 }
 
 static const char *argv0 = NULL;
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "    %s [options] server [mode] backup [mboxname | uniqueid | guid]...\n", argv0);

--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -63,7 +63,7 @@
 #include "map.h"
 #include "xmalloc.h"
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "chk_cyrus [-C <altconfig>] partition\n");
     exit(-1);

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -118,7 +118,7 @@ static int compdb(const void *v1, const void *v2)
     return ((char *)db1->archiver - (char *)db2->archiver);
 }
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "ctl_cyrusdb [-C <altconfig>] -c\n");
     fprintf(stderr, "ctl_cyrusdb [-C <altconfig>] -r [-x]\n");

--- a/imap/ctl_deliver.c
+++ b/imap/ctl_deliver.c
@@ -59,7 +59,7 @@
 #include "util.h"
 #include "xmalloc.h"
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr,
             "ctl_deliver [-C <altconfig>] -d [-f <dbfile>]\n");

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -882,7 +882,7 @@ static void do_verify(void)
     mboxlist_allmbox("", &verify_cb, &found, MBOXTREE_TOMBSTONES);
 }
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "DUMP:\n");
     fprintf(stderr, "  ctl_mboxlist [-C <alt_config>] -d [-x] [-y] [-p partition] [-f filename]\n");

--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -76,7 +76,7 @@ const int config_need_data = 0;
 int verbose = 0;
 
 /* forward declarations */
-void usage(void);
+void usage(void) __attribute__((noreturn));
 void free_zoneinfo(void *data);
 void store_zoneinfo(const char *tzid, void *data, void *rock);
 void do_zonedir(const char *prefix, struct hash_table *tzentries,

--- a/imap/cvt_xlist_specialuse.c
+++ b/imap/cvt_xlist_specialuse.c
@@ -59,7 +59,7 @@
 static int verbose = 0;
 
 static const char *argv0 = NULL;
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "    %s [options] mailbox...\n", argv0);

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -61,7 +61,7 @@
 const char *MASTER_CONFIG_FILENAME = DEFAULT_MASTER_CONFIG_FILENAME;
 
 /* Print usage info on stderr and exit */
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "cyr_buildinfo [-C <file>] [format]\n");
     fprintf(stderr, "Where format is one of:\n");

--- a/imap/cyr_deny.c
+++ b/imap/cyr_deny.c
@@ -65,7 +65,7 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "Usage: cyr_deny [-C <altconfig>] [ -s services ] [ -m message ] user\n");
     fprintf(stderr, "       cyr_deny [-C <altconfig>] -a user\n");

--- a/imap/cyr_df.c
+++ b/imap/cyr_df.c
@@ -60,7 +60,7 @@ extern int optind;
 extern char *optarg;
 
 /* forward declarations */
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 static void get_part_stats(const char *key, const char *val, void *rock);
 
 int main(int argc, char *argv[])

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -207,7 +207,7 @@ static void cyr_expire_cleanup(struct cyr_expire_ctx *ctx)
     cyrus_done();
 }
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "Usage: %s [OPTIONS] {mailbox|users}\n", progname);
     fprintf(stderr, "Expire messages and duplicate delivery database entries.\n");

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -68,7 +68,7 @@ struct service_item {
     struct service_item *next;
 };
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "cyr_info [-C <altconfig>] [-M <cyrus.conf>] [-n servicename] [-s oldversion] command\n");
     fprintf(stderr, "\n");

--- a/imap/cyr_synclog.c
+++ b/imap/cyr_synclog.c
@@ -57,7 +57,7 @@
 #include "util.h"
 #include "xmalloc.h"
 
-void usage(const char *name) {
+static __attribute__((noreturn)) void usage(const char *name) {
     fprintf(stderr, "Usage: %s [-C altconfig] [-{type}] value\n", name);
 
     fprintf(stderr, "\n");

--- a/imap/cyr_userseen.c
+++ b/imap/cyr_userseen.c
@@ -63,7 +63,7 @@
 /* config.c stuff */
 static int do_remove = 0;
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "cyr_userseen [-C <altconfig>] -d\n");
     exit(-1);

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -81,7 +81,7 @@ static struct namespace recon_namespace;
 const int config_need_data = 0;
 
 /* forward declarations */
-void usage(void);
+static void usage(void) __attribute__((noreturn));
 void shut_down(int code);
 
 static int code = 0;

--- a/imap/deliver.c
+++ b/imap/deliver.c
@@ -110,7 +110,7 @@ static int deliver_msg(char *return_path, char *authuser, int ignorequota,
                        char **users, int numusers, char *mailbox);
 static struct backend *init_net(const char *sockaddr);
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr,
             "421-4.3.0 usage: deliver [-C <alt_config> ] [-m mailbox]"
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
     return r;
 }
 
-static void just_exit(const char *msg)
+static __attribute__((noreturn)) void just_exit(const char *msg)
 {
     com_err(msg, 0, "%s", error_message(errno));
 

--- a/imap/fetchnews.c
+++ b/imap/fetchnews.c
@@ -123,7 +123,7 @@ static int newsrc_done(void)
     return r;
 }
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr,
             "fetchnews [-C <altconfig>] [-s <server>] [-n] [-y] [-w <wildmat>] [-f <tstamp file>]\n"

--- a/imap/fud.c
+++ b/imap/fud.c
@@ -165,7 +165,7 @@ int service_init(int argc, char **argv, char **envp)
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -480,7 +480,7 @@ ptrarray_t backend_cached = PTRARRAY_INITIALIZER;
 
 static int tls_init(int client_auth, struct buf *serverinfo);
 static void starttls(struct http_connection *conn, int timeout);
-void usage(void);
+void usage(void) __attribute__((noreturn));
 void shut_down(int code) __attribute__ ((noreturn));
 
 /* Enable the resetting of a sasl_conn_t */
@@ -1069,7 +1069,7 @@ int service_main(int argc __attribute__((unused)),
 
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -387,7 +387,7 @@ static struct capa_struct base_capabilities[] = {
 
 
 static void motd_file(void);
-void shut_down(int code);
+void shut_down(int code) __attribute__((noreturn));
 void fatal(const char *s, int code);
 
 static void cmdloop(void);
@@ -1035,7 +1035,7 @@ int service_main(int argc __attribute__((unused)),
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }
@@ -1076,7 +1076,6 @@ out:
 /*
  * Cleanly shut down and exit
  */
-void shut_down(int code) __attribute__((noreturn));
 void shut_down(int code)
 {
     int i;

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -120,7 +120,7 @@ static int verify_user(const mbname_t *mbname,
                        struct auth_state *authstate);
 static char *generate_notify(message_data_t *m);
 
-void shut_down(int code);
+void shut_down(int code) __attribute__((noreturn));
 
 static FILE *spoolfile(message_data_t *msgdata);
 static void removespool(message_data_t *msgdata);
@@ -136,7 +136,7 @@ static struct lmtp_func mylmtp = { &deliver, &verify_user, &shut_down,
                             &spoolfile, &removespool, &lmtpd_namespace,
                             0, 1, 0 };
 
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 
 /* global state */
 const int config_need_data = CONFIG_NEED_PARTITION_DATA;
@@ -318,7 +318,7 @@ int service_main(int argc, char **argv,
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }
@@ -1001,7 +1001,6 @@ EXPORTED void fatal(const char* s, int code)
 /*
  * Cleanly shut down and exit
  */
-void shut_down(int code) __attribute__((noreturn));
 void shut_down(int code)
 {
     int i;

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -99,7 +99,7 @@ static struct namespace mbexamine_namespace;
 static int do_examine(struct findall_data *data, void *rock);
 static int do_quota(struct findall_data *data, void *rock);
 static int do_compare(struct findall_data *data, void *rock);
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 void shut_down(int code);
 
 static unsigned wantuid = 0;

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -97,7 +97,7 @@ static struct namespace mbtool_namespace;
 /* forward declarations */
 static int do_cmd(struct findall_data *data, void *rock);
 
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 void shut_down(int code);
 
 enum {

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -216,7 +216,7 @@ static void cmd_starttls(struct conn *C, const char *tag);
 #ifdef HAVE_ZLIB
 static void cmd_compress(struct conn *C, const char *tag, const char *alg);
 #endif
-void shut_down(int code);
+void shut_down(int code) __attribute__((noreturn));
 static int reset_saslconn(struct conn *c);
 static void database_init(void);
 static void sendupdates(struct conn *C, int flushnow);
@@ -596,7 +596,7 @@ int service_init(int argc, char **argv,
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+ __attribute__((noreturn)) void service_abort(int error)
 {
 #ifdef HAVE_SSL
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -2069,7 +2069,6 @@ void cmd_compress(struct conn *C __attribute__((unused)),
 }
 #endif /* HAVE_ZLIB */
 
-void shut_down(int code) __attribute__((noreturn));
 void shut_down(int code)
 {
     in_shutdown = 1;

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -227,7 +227,7 @@ static void cmd_starttls(int nntps);
 #ifdef HAVE_ZLIB
 static void cmd_compress(char *alg);
 #endif
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 void shut_down(int code) __attribute__ ((noreturn));
 
 extern int saslserver(sasl_conn_t *conn, const char *mech,
@@ -551,7 +551,7 @@ int service_main(int argc __attribute__((unused)),
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -204,7 +204,7 @@ static unsigned parse_msgno(char **ptr);
 static void uidl_msg(uint32_t msgno);
 static int msg_exists_or_err(uint32_t msgno);
 static int update_seen(void);
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 void shut_down(int code) __attribute__ ((noreturn));
 
 extern int saslserver(sasl_conn_t *conn, const char *mech,
@@ -581,7 +581,7 @@ int service_main(int argc __attribute__((unused)),
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -89,7 +89,7 @@ EXPORTED void fatal(const char *msg, int err)
 }
 
 static const char *argv0 = NULL;
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "    %s [-C alt_config] [-v] [-f frequency] [-d]\n", argv0);

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -101,7 +101,7 @@ struct quotaentry {
 };
 
 /* forward declarations */
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 static void reportquota(void);
 static int buildquotalist(char *domain, char **roots, int nroots, int isuser);
 static int fixquotas(char *domain, char **roots, int nroots, int isuser);

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -116,10 +116,10 @@ struct reconstruct_rock {
 static const char *progname = NULL;
 
 /* forward declarations */
-static void do_mboxlist(void);
+static void do_mboxlist(void) __attribute__((noreturn));
 static int do_reconstruct_p(const mbentry_t *mbentry, void *rock);
 static int do_reconstruct(struct findall_data *data, void *rock);
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 
 extern cyrus_acl_canonproc_t mboxlist_ensureOwnerRights;
 

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -86,7 +86,7 @@ static const char *progname = NULL;
 static int find_p(const mbentry_t *mbentry, void *rock);
 static void get_searchparts(const char *key, const char *val, void *rock);
 static int relocate(const char *old, const char *new);
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 
 static int quiet = 0;
 static int nochanges = 0;

--- a/imap/smmapd.c
+++ b/imap/smmapd.c
@@ -194,7 +194,7 @@ int service_init(int argc, char **argv, char **envp)
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -742,7 +742,7 @@ out:
     return r;
 }
 
-static void do_rolling(const char *channel)
+static __attribute__((noreturn)) void do_rolling(const char *channel)
 {
     strarray_t *mboxnames = NULL;
     sync_log_reader_t *slr;

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -150,7 +150,7 @@ static void cmd_apply(struct dlist *kl,
 static void cmd_restore(struct dlist *kin,
                         struct sync_reserve_list *reserve_list);
 
-static void usage(void);
+static void usage(void) __attribute__((noreturn));
 void shut_down(int code) __attribute__ ((noreturn));
 void shut_down_via_signal(int code) __attribute__ ((noreturn));
 
@@ -378,7 +378,7 @@ int service_main(int argc __attribute__((unused)),
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+ __attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/imap/tls_prune.c
+++ b/imap/tls_prune.c
@@ -51,7 +51,7 @@
 #include "util.h"
 #include "xmalloc.h"
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr, "tls_prune [-C <altconfig>]\n");
     exit(-1);

--- a/imap/unexpunge.c
+++ b/imap/unexpunge.c
@@ -75,7 +75,7 @@ static int verbose = 0;
 static int unsetdeleted = 0;
 static const char *addflag = NULL;
 
-static void usage(void)
+static __attribute__((noreturn)) void usage(void)
 {
     fprintf(stderr,
             "unexpunge [-C <altconfig>] -l <mailbox> [<uid>...]\n"

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -2687,7 +2687,7 @@ static int http_do_auth(struct sasl_cmd_t *sasl_cmd __attribute__((unused)),
 /*****************************************************************************/
 
 /* didn't give correct parameters; let's exit */
-static void usage(char *prog, char *prot)
+static __attribute__((noreturn)) void usage(char *prog, char *prot)
 {
     printf("Usage: %s [options] hostname\n", prog);
     printf("  -p port  : port to use (default=standard port for protocol)\n");

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -45,7 +45,7 @@
 
 #ifdef __STDC__
 #define assert(ex)      {if (!(ex))assertionfailed(__FILE__, __LINE__, #ex);}
-void assertionfailed(const char *file, int line, const char *expr);
+void assertionfailed(const char *file, int line, const char *expr) __attribute__((noreturn));
 #else
 #define assert(ex)      {if (!(ex))assertionfailed(__FILE__, __LINE__, (char*)0);}
 #endif

--- a/notifyd/notifyd.c
+++ b/notifyd/notifyd.c
@@ -217,7 +217,7 @@ EXPORTED void fatal(const char *s, int code)
     shut_down(code);
 }
 
-static void usage(void)
+static  __attribute__((noreturn)) void usage(void)
 {
     syslog(LOG_ERR, "usage: notifyd [-C <alt_config>]");
     exit(EX_USAGE);
@@ -254,7 +254,7 @@ EXPORTED int service_init(int argc, char **argv, char **envp __attribute__((unus
 }
 
 /* Called by service API to shut down the service */
-EXPORTED void service_abort(int error)
+EXPORTED __attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }

--- a/ptclient/ptloader.c
+++ b/ptclient/ptloader.c
@@ -174,7 +174,7 @@ int service_init(int argc, char *argv[], char **envp __attribute__((unused)))
 }
 
 /* Called by service API to shut down the service */
-void service_abort(int error)
+__attribute__((noreturn)) void service_abort(int error)
 {
     int r;
 

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -126,7 +126,7 @@ EXPORTED int sieve_script_parse(sieve_interp_t *interp, FILE *script,
     return _sieve_script_parse(interp, script_context, ret);
 }
 
-static void stub_generic(void)
+static __attribute__((noreturn)) void stub_generic(void)
 {
     fatal("stub function called", 0);
 }

--- a/timsieved/timsieved.c
+++ b/timsieved/timsieved.c
@@ -221,7 +221,7 @@ EXPORTED int service_init(int argc __attribute__((unused)),
 }
 
 /* Called by service API to shut down the service */
-EXPORTED void service_abort(int error)
+EXPORTED __attribute__((noreturn)) void service_abort(int error)
 {
     shut_down(error);
 }


### PR DESCRIPTION
as suggested by clang 12 -Wmissing-noreturn

Make dav_reconstruct.c:usage() and cyr_synclog.c:usage() static.

In imapd.c, lmtpd.c and mupdate.c the declarations of shut_down() were not correct.