### PR TITLE
Make 'verbose' variables static

### DIFF
--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -71,7 +71,7 @@ const int config_need_data = CONFIG_NEED_PARTITION_DATA;
 
 enum { UNKNOWN, DUMP, UNDUMP, ZERO, BUILD, RECALC, AUDIT, CHECKFOLDERS };
 
-int verbose = 0;
+static int verbose = 0;
 
 int mode = UNKNOWN;
 static const char *audit_temp_directory;

--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -73,7 +73,7 @@ extern char *optarg;
 /* config.c stuff */
 const int config_need_data = 0;
 
-int verbose = 0;
+static int verbose = 0;
 
 /* forward declarations */
 void usage(void);

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -112,7 +112,7 @@ int email_notification = 0;
 struct infected_mbox *public = NULL;
 struct infected_mbox *user = NULL;
 
-int verbose = 0;
+static int verbose = 0;
 
 /* abstract definition of a virus scan engine */
 struct scan_engine {

--- a/imap/message_test.c
+++ b/imap/message_test.c
@@ -69,7 +69,7 @@
 
 static int usage(const char *name);
 
-int verbose = 0;
+static int verbose = 0;
 enum { PART_TREE, TEXT_SECTIONS, TEXT_RECEIVER } dump_mode = PART_TREE;
 
 /*-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-*/

--- a/imap/search_test.c
+++ b/imap/search_test.c
@@ -68,7 +68,7 @@
 
 static int usage(const char *name);
 
-int verbose = 0;
+static int verbose = 0;
 
 /* ====================================================================== */
 


### PR DESCRIPTION
as suggested by clang -Wmissing-variable-declarations