### PR TITLE
jmap_util: do not guess charset of valid UTF-8 with replacement chars

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -22665,4 +22665,36 @@ sub test_email_set_copymove_no_permission_shared
     $self->assert_str_equals('forbidden', $res->[0][1]{notUpdated}{$email}{type});
 }
 
+sub test_email_get_utf8body_base64_with_replacement_char
+    :min_version_3_5 :needs_component_sieve :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    # MIME message contains a correctly encoded emoji and one UTF-8
+    # replacement character. The latter must not cause Cyrus to
+    # attempt guessing the source charset or report an encoding error.
+    open(my $F, '<', 'data/mime/utf8-base64-replacement.eml') || die $!;
+    $imap->append('INBOX', $F) || die $@;
+    close($F);
+
+    my $res = $jmap->CallMethods([
+        ['Email/query', { }, 'R1'],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'Email/query',
+                path => '/ids'
+            },
+            fetchAllBodyValues => JSON::true,
+            properties => ['bodyValues'],
+        }, 'R2'],
+    ]);
+    $self->assert_equals(JSON::false,
+        $res->[1][1]{list}[0]{bodyValues}{1}{isEncodingProblem});
+    $self->assert_str_equals("Hello \N{GRINNING FACE}, World \N{REPLACEMENT CHARACTER} !\n",
+        $res->[1][1]{list}[0]{bodyValues}{1}{value});
+}
+
 1;

--- a/cassandane/data/mime/utf8-base64-replacement.eml
+++ b/cassandane/data/mime/utf8-base64-replacement.eml
@@ -1,0 +1,9 @@
+From: test1@local>
+To: test2@local
+Subject: Test subject
+Date: Wed, 27 Apr 2019 13:21:50 -0500
+MIME-Version: 1.0
+Content-Type: text/plain;charset=utf-8
+Content-Transfer-Encoding: base64
+
+SGVsbG8g8J+YgCwgV29ybGQg77+9ICEK


### PR DESCRIPTION
Fixes a bug in the JMAP internal utf8 decoder, where replacement characters in a  base64-encoded UTF-8 MIME body could cause the decoder to incorrectly guess the source charset.

Tested in https://github.com/cyrusimap/cassandane/pull/183