### PR TITLE
Bad tombstone crashfix

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1041,6 +1041,10 @@ static int mailbox_open_advanced(const char *name,
     }
 
     r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
+
+    if (!r && mbentry->mbtype & MBTYPE_DELETED)
+        r = IMAP_MAILBOX_NONEXISTENT;
+
     if (r) {
         if (mailbox->local_namespacelock)
             mboxname_release(&mailbox->local_namespacelock);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2101,6 +2101,8 @@ char *mboxname_lockpath_suffix(const char *mboxname,
     const char *root = config_getstring(IMAPOPT_MBOXNAME_LOCKPATH);
     int len;
 
+    if (!mboxname) return NULL;
+
     if (!root) {
         snprintf(basepath, MAX_MAILBOX_PATH, "%s/lock", config_dir);
         root = basepath;


### PR DESCRIPTION
This fixes a crasher where there was a tombstone entry with just `%(T ed M 123456789)` and no uniqueid, which caused sync_server to abort rather than just believing that there's no local mailbox.