### PR TITLE
Remove some references to Berkeley DB

### DIFF
--- a/imap/cvt_cyrusdb.c
+++ b/imap/cvt_cyrusdb.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 
     if (old_db[0] != '/' || new_db[0] != '/') {
         printf("\nSorry, you cannot use this tool with relative path names.\n"
-               "This is because some database backends (mainly berkeley) do not\n"
+               "This is because some database backends do not\n"
                "always do what you would expect with them.\n"
                "\nPlease use absolute pathnames instead.\n\n");
         exit(EX_OSERR);

--- a/imap/cyr_dbtool.c
+++ b/imap/cyr_dbtool.c
@@ -332,7 +332,7 @@ int main(int argc, char *argv[])
 
     if(fname[0] != '/') {
         printf("\nSorry, you cannot use this tool with relative path names.\n"
-               "This is because some database backends (mainly berkeley) do not\n"
+               "This is because some database backends do not\n"
                "always do what you would expect with them.\n"
                "\nPlease use absolute pathnames instead.\n\n");
         exit(EX_OSERR);

--- a/imap/seen_db.c
+++ b/imap/seen_db.c
@@ -1,4 +1,4 @@
-/* seen_db.c -- implementation of seen database using per-user berkeley db
+/* seen_db.c -- implementation of seen database using per-user db
  *
  * Copyright (c) 1994-2008 Carnegie Mellon University.  All rights reserved.
  *

--- a/lib/cyrusdb_flat.c
+++ b/lib/cyrusdb_flat.c
@@ -157,8 +157,8 @@ static void decode(const char *ps, int len, struct buf *buf)
         else
             buf_putc(buf, *p);
     }
-    /* Note: buf is not NUL-terminated.  It happens that neither
-     * skiplist nor berkeley backends guarantee any such thing,
+    /* Note: buf is not NUL-terminated.  It happens that the
+     * skiplist backend does not guarantee any such thing,
      * and so code that depends on it is quite broken anyway */
 }
 

--- a/lib/test/run
+++ b/lib/test/run
@@ -58,21 +58,16 @@ sub runone {
 
 runone("cyrusdb", undef, "-DBACKEND=cyrusdb_flat -ldb ${libs}");
 runone("cyrusdb", undef, "-DBACKEND=cyrusdb_skiplist -ldb ${libs}", "cyrusdb_skiplist");
-runone("cyrusdb", undef, "-DBACKEND=cyrusdb_berkeley -ldb ${libs}", "cyrusdb_berkeley");
 
 runone("cyrusdb", undef, "-DBACKEND=cyrusdb_flat -ldb ${libs}",
        "cyrusdbtxn_flat", "cyrusdbtxn");
 runone("cyrusdb", undef, "-DBACKEND=cyrusdb_skiplist -ldb ${libs}",
        "cyrusdbtxn_skiplist", "cyrusdbtxn");
-runone("cyrusdb", undef, "-DBACKEND=cyrusdb_berkeley -ldb ${libs}",
-       "cyrusdbtxn_berkeley", "cyrusdbtxn");
 
 runone("cyrusdb", undef, "-DBACKEND=cyrusdb_flat -ldb ${libs}",
        "cyrusdblong_flat", "cyrusdblong");
 runone("cyrusdb", undef, "-DBACKEND=cyrusdb_skiplist -ldb ${libs}",
        "cyrusdblong_skiplist", "cyrusdblong");
-runone("cyrusdb", undef, "-DBACKEND=cyrusdb_berkeley -ldb ${libs}",
-       "cyrusdblong_berkeley", "cyrusdblong");
 
 runone("rnddb", undef, "-DBACKEND=cyrusdb_skiplist -ldb ${libs}",
        "rndskip", "rnddb");


### PR DESCRIPTION
Remove some referencs to Berkeley DB.

Can now the restriction about the absolute file names in cvt_cyrusdb and cyr_dbtool now be removed?