### PR TITLE
lib/lock_flock.c: export debug_locks_longer_than

### DIFF
--- a/lib/lock_flock.c
+++ b/lib/lock_flock.c
@@ -53,6 +53,8 @@
 
 EXPORTED const char lock_method_desc[] = "flock";
 
+EXPORTED double debug_locks_longer_than = 0.0;
+
 /*
  * Block until we obtain an exclusive lock on the file descriptor 'fd',
  * opened for reading and writing on the file named 'filename'.  If


### PR DESCRIPTION
Fixes a problem when flock(2) is used instead of fcnlt(2).

The symbol `debug_locks_longer_than` is required by imap/global.c.

lib/lock_flock.c does not log long locks.