### PR TITLE
docsrc: remove requirement of installing libdb(-dev)

### DIFF
--- a/docsrc/assets/cyrus-build-devpkg.rst
+++ b/docsrc/assets/cyrus-build-devpkg.rst
@@ -6,7 +6,7 @@ automated test facility.
 
     sudo apt-get install -y autoconf automake autotools-dev bash-completion bison build-essential comerr-dev \
         debhelper flex g++ git gperf groff heimdal-dev libbsd-resource-perl libclone-perl libconfig-inifiles-perl \
-        libcunit1-dev libdatetime-perl libbsd-dev libdb-dev libdigest-sha-perl libencode-imaputf7-perl \ libfile-chdir-perl libglib2.0-dev libical-dev libio-socket-inet6-perl \
+        libcunit1-dev libdatetime-perl libbsd-dev libdigest-sha-perl libencode-imaputf7-perl \ libfile-chdir-perl libglib2.0-dev libical-dev libio-socket-inet6-perl \
         libio-stringy-perl libldap2-dev libmysqlclient-dev \
         libnet-server-perl libnews-nntpclient-perl libpam0g-dev libpcre3-dev libsasl2-dev \
         libsqlite3-dev libssl-dev libtest-unit-perl libtool libunix-syslog-perl liburi-perl \

--- a/docsrc/imap/download/installation/distributions/ubuntu.rst
+++ b/docsrc/imap/download/installation/distributions/ubuntu.rst
@@ -36,7 +36,6 @@ system, issue the following command:
 
     *   db-util
     *   db-upgrade-util
-    *   libdb5.X (where X depends on OS version)
     *   libsasl2-2
     *   libsasl2-modules
     *   libcomerr2

--- a/docsrc/imap/download/upgrade.rst
+++ b/docsrc/imap/download/upgrade.rst
@@ -125,7 +125,7 @@ Fetch the libraries for your platform. The full list (including all optional pac
 
     sudo apt-get install -y autoconf automake autotools-dev bash-completion bison build-essential comerr-dev \
     debhelper flex g++ git gperf groff heimdal-dev libbsd-resource-perl libclone-perl libconfig-inifiles-perl \
-    libcunit1-dev libdatetime-perl libdb-dev libdigest-sha-perl libencode-imaputf7-perl libfile-chdir-perl \
+    libcunit1-dev libdatetime-perl libdigest-sha-perl libencode-imaputf7-perl libfile-chdir-perl \
     libglib2.0-dev libical-dev libio-socket-inet6-perl libio-stringy-perl libjansson-dev libldap2-dev \
     libmysqlclient-dev libnet-server-perl libnews-nntpclient-perl libpam0g-dev libpcre3-dev libsasl2-dev \
     libsqlite3-dev libssl-dev libtest-unit-perl libtool libunix-syslog-perl liburi-perl \


### PR DESCRIPTION
Since BDB is now ignored, the documentation shall not suggest any dependency on it, in order to use Cyrus IMAP.