### PR TITLE
Annotatemore mboxname

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1207,7 +1207,7 @@ static int annotatemore_findall_full(const char *pattern, /* internal */
      * server annotations, which are recognised by an empty pattern by the
      * code below */
     if (!mailbox && !pattern && !*mboxname) {
-        mailbox = NULL;
+        mboxname = NULL;
         pattern = "";
     }
 

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1175,6 +1175,7 @@ static int _findall(struct findall_data *data, void *rock)
 
 static int annotatemore_findall_full(const char *pattern, /* internal */
                          const struct mailbox *mailbox,
+                         const char *mboxname,
                          unsigned int uid,
                          const char *entry,
                          modseq_t since_modseq,
@@ -1184,10 +1185,11 @@ static int annotatemore_findall_full(const char *pattern, /* internal */
 {
     int r;
     struct find_rock frock;
+    mbentry_t *mbentry = NULL;
 
     init_internal();
 
-    assert(pattern || mailbox);
+    assert(pattern || mailbox || mboxname);
     assert(entry);
 
     frock.pattern = pattern;
@@ -1201,22 +1203,22 @@ static int annotatemore_findall_full(const char *pattern, /* internal */
     frock.since_modseq = since_modseq;
     frock.flags = flags;
 
-    r = _annotate_getdb(mailbox ? mailbox_uniqueid(mailbox) : NULL, mailbox, uid, 0, &frock.d);
+    if (mailbox || mboxname) {
+        if (mailbox) mboxname = mailbox_name(mailbox);
+        r = mboxlist_lookup_allow_all(mboxname, &mbentry, NULL);
+        if (r) goto out;
+    }
+
+    r = _annotate_getdb(mbentry ? mbentry->uniqueid : NULL, mailbox, uid, 0, &frock.d);
     if (r) {
         if (r == CYRUSDB_NOTFOUND)
             r = 0;
         goto out;
     }
 
-    if (mailbox) {
-        /* Single mailbox entries */
-        mbentry_t *mbentry = NULL;
-        r = mboxlist_lookup_allow_all(mailbox_name(mailbox), &mbentry, NULL);
-        if (!r) {
-            struct findall_data data = { .mbentry = mbentry, .is_exactmatch = 1 };
-            r = _findall(&data, &frock);
-        }
-        mboxlist_entry_free(&mbentry);
+    if (mbentry) {
+        struct findall_data data = { .mbentry = mbentry, .is_exactmatch = 1 };
+        r = _findall(&data, &frock);
     }
     else if (!*pattern) {
         /* Server entries */
@@ -1229,6 +1231,7 @@ static int annotatemore_findall_full(const char *pattern, /* internal */
     }
 
 out:
+    mboxlist_entry_free(&mbentry);
     glob_free(&frock.eglob);
     annotate_putdb(&frock.d);
 
@@ -1243,7 +1246,7 @@ EXPORTED int annotatemore_findall_mailbox(const struct mailbox *mailbox,
                          void *rock,
                          int flags)
 {
-    return annotatemore_findall_full(NULL, mailbox, uid, entry, since_modseq, proc, rock, flags);
+    return annotatemore_findall_full(NULL, mailbox, NULL, uid, entry, since_modseq, proc, rock, flags);
 }
 
 EXPORTED int annotatemore_findall_pattern(const char *pattern,
@@ -1254,9 +1257,20 @@ EXPORTED int annotatemore_findall_pattern(const char *pattern,
                          void *rock,
                          int flags)
 {
-    return annotatemore_findall_full(pattern, NULL, uid, entry, since_modseq, proc, rock, flags);
+    return annotatemore_findall_full(pattern, NULL, NULL, uid, entry, since_modseq, proc, rock, flags);
 }
 
+
+EXPORTED int annotatemore_findall_mboxname(const char *mboxname,
+                         unsigned int uid,
+                         const char *entry,
+                         modseq_t since_modseq,
+                         annotatemore_find_proc_t proc,
+                         void *rock,
+                         int flags)
+{
+    return annotatemore_findall_full(NULL, NULL, mboxname, uid, entry, since_modseq, proc, rock, flags);
+}
 
 /***************************  Annotate State Management  ***************************/
 
@@ -2010,7 +2024,7 @@ static void annotation_get_fromdb(annotate_state_t *state,
 
     // if mailbox present, will be a mailbox fetch, otherwise will be a server fetch
     // with the blank pattern
-    annotatemore_findall_full("", state->mailbox, state->uid, entry->name, 0, &rw_cb, state, 0);
+    annotatemore_findall_full("", state->mailbox, NULL, state->uid, entry->name, 0, &rw_cb, state, 0);
 
     if (state->found != state->attribs &&
         (!strchr(entry->name, '%') && !strchr(entry->name, '*'))) {

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1203,6 +1203,14 @@ static int annotatemore_findall_full(const char *pattern, /* internal */
     frock.since_modseq = since_modseq;
     frock.flags = flags;
 
+    /* special case where mboxname is "" and others are empty, this means
+     * server annotations, which are recognised by an empty pattern by the
+     * code below */
+    if (!mailbox && !pattern && !*mboxname) {
+        mailbox = NULL;
+        pattern = "";
+    }
+
     if (mailbox || mboxname) {
         if (mailbox) mboxname = mailbox_name(mailbox);
         r = mboxlist_lookup_allow_all(mboxname, &mbentry, NULL);

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -173,6 +173,11 @@ EXPORTED int annotatemore_findall_pattern(const char *pattern,
                          modseq_t since_modseq,
                          annotatemore_find_proc_t proc, void *rock,
                          int flags);
+EXPORTED int annotatemore_findall_mboxname(const char *mboxname,
+                         uint32_t uid, const char *entry,
+                         modseq_t since_modseq,
+                         annotatemore_find_proc_t proc, void *rock,
+                         int flags);
 
 /* fetch annotations and output results */
 typedef void (*annotate_fetch_cb_t)(const char *mboxname, /* internal */

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1127,9 +1127,9 @@ static int recreate_calendar(const mbentry_t *mbentry,
         mbname_set_isdeleted(mbname, 0);
         free(mbname_pop_boxes(mbname));
         mbname_push_boxes(mbname, "%");
-        annotatemore_findall_pattern(mbname_intname(mbname), 0/*uid*/,
-                                     disp_annot, 0/*since_modseq*/,
-                                     &lookup_cal_by_dispname, &crock, 0/*flags*/);
+        annotatemore_findall_mboxname(mbname_intname(mbname), 0/*uid*/,
+                                      disp_annot, 0/*since_modseq*/,
+                                      &lookup_cal_by_dispname, &crock, 0/*flags*/);
         mbname_free(&mbname);
 
         if (crock.mboxname) {

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3091,7 +3091,7 @@ static int getannotation_cb(const char *mboxname,
 int sync_get_annotation(struct dlist *kin, struct sync_state *sstate)
 {
     const char *mboxname = kin->sval;
-    return annotatemore_findall_pattern(mboxname, 0, "*", /*modseq*/0,
+    return annotatemore_findall_mboxname(mboxname, 0, "*", /*modseq*/0,
                                 &getannotation_cb, (void *) sstate->pout,
                                 /*flags*/0);
 }
@@ -6504,7 +6504,7 @@ int sync_do_annotation(struct sync_client_state *sync_cs, const char *mboxname)
     r = do_getannotation(sync_cs, mboxname, replica_annot);
     if (r) goto bail;
 
-    r = annotatemore_findall_pattern(mboxname, 0, "*", /*modseq*/0, &do_annotation_cb,
+    r = annotatemore_findall_mboxname(mboxname, 0, "*", /*modseq*/0, &do_annotation_cb,
                              master_annot, /*flags*/0);
     if (r) {
         xsyslog(LOG_ERR, "IOERROR: fetching annotations failed",


### PR DESCRIPTION
Don't use mboxlist_findall for the mailbox name in replication for annotations.

Should hopefully fix https://github.com/cyrusimap/cyrus-imapd/issues/3771