### PR TITLE
dlist: use xsyslog for IOERRORs

### DIFF
--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -165,7 +165,9 @@ EOF
 
         # sync server should have logged the write error
         @lines = $self->{replica}->getsyslog();
-        $self->assert_matches(qr/IOERROR: failed to upload file $canaryguid/,
+        $self->assert_matches(qr{IOERROR:\sfailed\sto\supload\sfile
+                                 (?:\s\(simulated\))?:\sguid=<$canaryguid>
+                              }x,
                               "@lines");
     }
 }
@@ -240,7 +242,9 @@ EOF
 
         # sync server should have logged the write error
         @lines = $self->{replica}->getsyslog();
-        $self->assert_matches(qr/IOERROR: failed to upload file $canaryguid/,
+        $self->assert_matches(qr{IOERROR:\sfailed\sto\supload\sfile
+                                 (?:\s\(simulated\))?:\sguid=<$canaryguid>
+                              }x,
                               "@lines");
 
         # contents of message 4 should not appear on the wire (or logs) as


### PR DESCRIPTION
More xsyslog conversions -- as usual for these, please build this, in case your compiler catches something mine didn't.  Thanks

Fixes #3784