### PR TITLE
http_jwt: fix include of generated header

### DIFF
--- a/imap/http_jwt.c
+++ b/imap/http_jwt.c
@@ -55,8 +55,10 @@
 
 #include "assert.h"
 #include "global.h"
-#include "http_err.h"
 #include "util.h"
+
+/* generated headers are not necessarily in current directory */
+#include "imap/http_err.h"
 
 #include "http_jwt.h"
 


### PR DESCRIPTION
Fixes a niche build problem that occurs when the build directory is not the source directory.  Generated headers are created in the build directory, not the source directory (which might even be read-only in this situation), and so unless the include path is specified explicitly they can't be found.  Found by `make distcheck`.

I have vague plans to fix this properly sometime, but it's big and boring and will touch nearly every single source file, so I keep kicking it down the road.