### PR TITLE
imported cassandane-only changes

### DIFF
--- a/cassandane/Cassandane/Cassini.pm
+++ b/cassandane/Cassandane/Cassini.pm
@@ -53,6 +53,8 @@ my $instance;
 sub homedir {
     my ($uid) = @_;
 
+    return undef if not $uid;
+
     my @pw = getpwuid($uid);
     return $pw[7]; # dir field
 }


### PR DESCRIPTION
Single-commit Cassandane bug fixes that don't have an accompanying Cyrus feature branch to become part of.  These were already approved on the Cassandane repo, as:

* https://github.com/cyrusimap/cassandane/pull/179
* https://github.com/cyrusimap/cassandane/pull/184

Here they are for Cyrus, as a single PR to minimise additional overhead.  Please rubber stamp (or just go ahead and merge!)