### PR TITLE
lib/imapoptions: add deprecated entry for reverseuniqueuids

### DIFF
--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2156,6 +2156,9 @@ If all partitions are over that limit, this feature is not used anymore.
 /* At startup time, ctl_cyrusdb -r will check this value and it
    will either add or remove reverse ACL pointers from mailboxes.db */
 
+{ "reverseuniqueids", 1, SWITCH, "UNRELEASED", "UNRELEASED" }
+/* Deprecated. No longer used */
+
 { "rfc2046_strict", 0, SWITCH, "2.3.17" }
 /* If enabled, imapd will be strict (per RFC 2046) when matching MIME
    boundary strings.  This means that boundaries containing other


### PR DESCRIPTION
Accidentally removed entirely by bfb0061cf64ff878b27e0d3e8e2d5549c77b563f
(#3484), when it should have been updated with a deprecated-since version
instead.

Fixes #3616