### PR TITLE
partial fixes for mailbox_legacy_dirs=yes problems

### DIFF
--- a/cassandane/Cassandane/Cyrus/Delete.pm
+++ b/cassandane/Cassandane/Cyrus/Delete.pm
@@ -492,7 +492,9 @@ EOF
     my ($maj, $min) = Cassandane::Instance->get_version();
 
     xlog $self, "Verify user data directories have been deleted";
-    if ($maj > 3 || ($maj == 3 && $min > 4)) {
+    if (($maj > 3 || ($maj == 3 && $min > 4))
+        && !$self->{instance}->{config}->get_bool('mailbox_legacy_dirs'))
+    {
         # Entire UUID-hashed directory should be removed
         $self->assert( !-e dirname($data->{user}{dav}));
     }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -11888,7 +11888,7 @@ static int xfer_delete(struct xfer_header *xfer)
         newentry->acl = xstrdupnull(item->mbentry->acl);
         newentry->server = xstrdupnull(item->mbentry->server);
         newentry->partition = xstrdupnull(item->mbentry->partition);
-        newentry->mbtype |= MBTYPE_DELETED;
+        newentry->mbtype = item->mbentry->mbtype | MBTYPE_DELETED;
         r = mboxlist_updatelock(newentry, 1);
         mboxlist_entry_free(&newentry);
 


### PR DESCRIPTION
Two small fixes, found by running cassandane with `mailbox_legacy_dirs: yes` in the `[config]` section.

Part of #3782.  There's more still to be fixed, but this is what I've tracked down so far.