### PR TITLE
dav_db:CMD_DBUPGRADEv10 — DROP INDEX IF EXISTS idx_res_uid

### DIFF
--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -218,7 +218,8 @@
 #define CMD_DBUPGRADEv10                                        \
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_ical_imapuid ON ical_objs ( mailbox, imap_uid );" \
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_vcard_imapuid ON vcard_objs ( mailbox, imap_uid );" \
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_object_imapuid ON dav_objs ( mailbox, imap_uid );"
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_object_imapuid ON dav_objs ( mailbox, imap_uid );" \
+    "DROP INDEX IF EXISTS idx_res_uid;"
 
 struct sqldb_upgrade davdb_upgrade[] = {
   { 2, CMD_DBUPGRADEv2, NULL },


### PR DESCRIPTION
Since d35f0dac07904bef the index is not created for new setups.  The index was however not removed from older setups.

This change does not help for upgrades to 3.4, which upgrades were performed before this change.  For such setups, thas is if you already run 3.4, the command

> for x in $(find /var/imap -name '*.dav'); do sqlite3 $x "DROP INDEX IF EXISTS idx_res_uid"; done

executed under the 'cyrus' user, does perform the change, where '/var/imap' is the configdirectory in imapd.conf .

Fixes https://github.com/cyrusimap/cyrus-imapd/issues/3756.