### PR TITLE
caldav_put() DUE must be after DTSTART in VTODO, both must have the same value-type

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -4409,7 +4409,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
         rrule = icalcomponent_get_first_property(comp, ICAL_RRULE_PROPERTY);
     }
 
-    /* Make sure DTEND|DUE > DTSTART, and both values have value same type */
+    /* Make sure DTEND|DUE > DTSTART, and both have the value same type */
     ret = check_endtime(comp, &txn->error.desc);
     if (ret) {
         txn->error.precond = CALDAV_VALID_DATA;
@@ -4458,8 +4458,8 @@ static int caldav_put(struct transaction_t *txn, void *obj,
             goto done;
         }
 
-        /* Make sure DTEND|DUE > DTSTART, and both values have value same type */
-        ret = check_endtime(comp, &txn->error.desc);
+        /* Make sure DTEND|DUE > DTSTART, and both have the value same type */
+        ret = check_endtime(nextcomp, &txn->error.desc);
         if (ret) {
             txn->error.precond = CALDAV_VALID_DATA;
             goto done;

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -4308,13 +4308,13 @@ static int personalize_resource(struct transaction_t *txn,
 
 
 static const struct endtime_errors_t {
-    const char *type_mismatch;
-    const char *bad_value;
+    const char type_mismatch[43];
+    const char bad_value[31];
 } endtime_errors[] = {
     { "DTEND must have same value type as DTSTART",
       "DTEND must occur after DTSTART" },
     { "DUE must have same value type as DTSTART",
-      "DUE must occur after DTSTART"}
+      "DUE must occur after DTSTART" }
 };
 
 /* Make sure DTEND|DUE > DTSTART, and both values have value same type */


### PR DESCRIPTION
This is postulated by [RFC 5545 Section 3.8.2.3 Date-Time Due](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.3).

[Evolution can use](https://gitlab.gnome.org/GNOME/evolution/-/issues/1715) different value-types.

(This is a replacement for #3795 )