### PR TITLE
sieve_db: use dav_close rather than sqldb_close

### DIFF
--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -172,7 +172,7 @@ EXPORTED int sievedb_close(struct sieve_db *sievedb)
     buf_free(&sievedb->name);
     buf_free(&sievedb->contentid);
 
-    r = sqldb_close(&sievedb->db);
+    r = dav_close(&sievedb->db);
 
     free(sievedb);
 


### PR DESCRIPTION
This fixes a crasher when running dav_reconstruct.  The problem is
that the mailbox_sieve_commit tries to close the DB, which is still
in a transaction and asserts.

dav_close is this:

```
EXPORTED int dav_close(sqldb_t **dbp)
{
    if (reconstruct_db) return 0;

    return sqldb_close(dbp);
}
```

Which precisely avoids this issue!  The other users of dav_db (caldav_db,
carddav_db) corretly use dav_close() in their close functions.