### PR TITLE
Sieve user rename fix

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2630,7 +2630,10 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
 
     if (mailbox->has_changed) {
         if (updatenotifier) updatenotifier(mailbox_name(mailbox));
-        sync_log_mailbox(mailbox_name(mailbox));
+        if (mbtype_isa(mailbox_mbtype(mailbox)) != MBTYPE_SIEVE) {
+            /* Ignore #sieve mailbox - replicated via *SIEVE* commands */
+            sync_log_mailbox(mailbox_name(mailbox));
+        }
 
         if (!sdata) {
             status_fill_mailbox(mailbox, &mysdata);

--- a/imap/sieve_db.h
+++ b/imap/sieve_db.h
@@ -162,4 +162,7 @@ int sieve_ensure_folder(const char *userid, struct mailbox **mailboxptr);
 int sieve_script_rebuild(const char *userid,
                          const char *sievedir, const char *script);
 
+/* calculate a mailbox name */
+char *sieve_mboxname(const char *userid);
+
 #endif /* SIEVE_DB_H */

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3687,7 +3687,7 @@ int sync_apply_rename(struct dlist *kin, struct sync_state *sstate)
                                    mbname_userid(newmbname));
                 }
             }
-            mbname_free(&newmbname);
+            mbname_free(&oldmbname);
         }
         mbname_free(&newmbname);
     }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3652,6 +3652,46 @@ int sync_apply_rename(struct dlist *kin, struct sync_state *sstate)
                                        0/*move_subscription*/,
                                        1/*silent*/);
 
+    if (!r) {
+        mbname_t *newmbname = mbname_from_intname(newmboxname);
+
+        if (mbname_localpart(newmbname) &&
+            !mbname_isdeleted(newmbname) &&
+            !strarray_size(mbname_boxes(newmbname))) {
+            /* Renaming INBOX - also rename #sieve */
+            const char *sieve_folder = config_getstring(IMAPOPT_SIEVE_FOLDER);
+            mbname_t *oldmbname = mbname_from_intname(oldmboxname);
+
+            mbname_push_boxes(oldmbname, sieve_folder);
+            oldmboxname = mbname_intname(oldmbname);
+                
+            mbname_push_boxes(newmbname, sieve_folder);
+            newmboxname = mbname_intname(newmbname);
+
+            mboxlist_entry_free(&mbentry);
+
+            if (!mboxlist_lookup_allow_all(oldmboxname, &mbentry, 0)) {
+                r = mboxlist_renamemailbox(mbentry, newmboxname, partition,
+                                           uidvalidity, 1, sstate->userid,
+                                           sstate->authstate, NULL,
+                                           sstate->local_only, 1, 1,
+                                           1/*keep_intermediaries*/,
+                                           0/*move_subscription*/,
+                                           1/*silent*/);
+
+                if (!r) {
+                    /* Take care of changing quotaroot and ACL */
+                    user_copyquotaroot(oldmboxname, newmboxname);
+                    user_renameacl(NULL /*namespace*/, newmboxname,
+                                   mbname_userid(oldmbname),
+                                   mbname_userid(newmbname));
+                }
+            }
+            mbname_free(&newmbname);
+        }
+        mbname_free(&newmbname);
+    }
+
     mboxlist_entry_free(&mbentry);
     mboxname_release(&oldlock);
     mboxname_release(&newlock);


### PR DESCRIPTION
The change to sieve_db.c turned out to be unnecessary, since I didn't use it outside of that file.  I intended to use it in sync_support.c, but I thought it made sense to create a single mbname_t rather than using separate mboxname_*() functions that all create and destroy a private mbname_t.

Also, I wasn't sure how to actually check for the presence of INBOX.#sieve on the replica in the Cass test.  I verified that it indeed does exist by hand, but the test should be augmented.