### PR TITLE
Propfind data crasher fix

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5124,16 +5124,20 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
         if (cdata->comp_flags.tzbyref) {
             if (need_tz) {
                 /* Add VTIMEZONE components for known TZIDs */
-                if (!fctx->obj) fctx->obj = icalparser_parse_string(data);
-                ical = fctx->obj;
+                if (!fctx->obj) {
+                    ical = fctx->obj = icalparser_parse_string(data);
+                    if (!ical) return HTTP_SERVER_ERROR;
+                }
 
                 icalcomponent_add_required_timezones(ical);
             }
         }
         else if (!need_tz && (namespace_calendar.allow & ALLOW_CAL_NOTZ)) {
             /* Strip all VTIMEZONE components for known TZIDs */
-            if (!fctx->obj) fctx->obj = icalparser_parse_string(data);
-            ical = fctx->obj;
+            if (!fctx->obj) {
+                ical = fctx->obj = icalparser_parse_string(data);
+                if (!ical) return HTTP_SERVER_ERROR;
+            }
 
             strip_vtimezones(ical);
         }
@@ -5144,8 +5148,10 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
 
             if (caldav_is_personalized(fctx->mailbox, fctx->data,
                                        httpd_userid, &userdata)) {
-                if (!fctx->obj) fctx->obj = icalparser_parse_string(data);
-                ical = fctx->obj;
+                if (!fctx->obj) {
+                    ical = fctx->obj = icalparser_parse_string(data);
+                    if (!ical) return HTTP_SERVER_ERROR;
+                }
 
                 add_personal_data(ical, &userdata);
                 buf_free(&userdata);
@@ -5154,8 +5160,10 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
 
         if (!icaltime_is_null_time(partial->range.start)) {
             /* Expand/limit recurrence set */
-            if (!fctx->obj) fctx->obj = icalparser_parse_string(data);
-            ical = fctx->obj;
+            if (!fctx->obj) {
+                ical = fctx->obj = icalparser_parse_string(data);
+                if (!ical) return HTTP_SERVER_ERROR;
+            }
 
             if (partial->expand) {
                 fctx->obj = expand_caldata(&ical, partial->range);
@@ -5165,8 +5173,11 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
 
         if (partial->comp) {
             /* Limit returned properties */
-            if (!fctx->obj) fctx->obj = icalparser_parse_string(data);
-            ical = fctx->obj;
+            if (!fctx->obj) {
+                ical = fctx->obj = icalparser_parse_string(data);
+                if (!ical) return HTTP_SERVER_ERROR;
+            }
+
             prune_properties(ical, partial->comp);
         }
 

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5118,7 +5118,7 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
             mailbox_map_record(fctx->mailbox, fctx->record, &fctx->msg_buf);
         if (!fctx->msg_buf.len) return HTTP_SERVER_ERROR;
 
-        data = fctx->msg_buf.s + fctx->record->header_size;
+        data = buf_cstring(&fctx->msg_buf) + fctx->record->header_size;
         datalen = fctx->record->size - fctx->record->header_size;
 
         if (cdata->comp_flags.tzbyref) {

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1599,7 +1599,7 @@ static int propfind_addrdata(const xmlChar *name, xmlNsPtr ns,
             mailbox_map_record(fctx->mailbox, fctx->record, &fctx->msg_buf);
         if (!fctx->msg_buf.len) return HTTP_SERVER_ERROR;
 
-        data = fctx->msg_buf.s + fctx->record->header_size;
+        data = buf_cstring(&fctx->msg_buf) + fctx->record->header_size;
         datalen = fctx->record->size - fctx->record->header_size;
 
         want_ver = (out_type->version[0] == '4') ? 4 : 3;
@@ -1608,10 +1608,7 @@ static int propfind_addrdata(const xmlChar *name, xmlNsPtr ns,
             /* Translate between vCard versions */
             vcard = fctx->obj;
 
-            if (!vcard) {
-                vcard = fctx->obj = vcard_parse_string(data);
-                if (!vcard) return HTTP_SERVER_ERROR;
-            }
+            if (!vcard) vcard = fctx->obj = vcard_parse_string(data);
 
             if (want_ver == 4) vcard_to_v4(vcard);
             else vcard_to_v3(vcard);
@@ -1621,11 +1618,7 @@ static int propfind_addrdata(const xmlChar *name, xmlNsPtr ns,
             /* Limit returned properties */
             vcard = fctx->obj;
 
-            if (!vcard) {
-                vcard = fctx->obj = vcard_parse_string(data);
-                if (!vcard) return HTTP_SERVER_ERROR;
-            }
-
+            if (!vcard) vcard = fctx->obj = vcard_parse_string(data);
             prune_properties(vcard->objects, partial);
         }
 

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1608,7 +1608,10 @@ static int propfind_addrdata(const xmlChar *name, xmlNsPtr ns,
             /* Translate between vCard versions */
             vcard = fctx->obj;
 
-            if (!vcard) vcard = fctx->obj = vcard_parse_string(data);
+            if (!vcard) {
+                vcard = fctx->obj = vcard_parse_string(data);
+                if (!vcard) return HTTP_SERVER_ERROR;
+            }
 
             if (want_ver == 4) vcard_to_v4(vcard);
             else vcard_to_v3(vcard);
@@ -1618,7 +1621,11 @@ static int propfind_addrdata(const xmlChar *name, xmlNsPtr ns,
             /* Limit returned properties */
             vcard = fctx->obj;
 
-            if (!vcard) vcard = fctx->obj = vcard_parse_string(data);
+            if (!vcard) {
+                vcard = fctx->obj = vcard_parse_string(data);
+                if (!vcard) return HTTP_SERVER_ERROR;
+            }
+
             prune_properties(vcard->objects, partial);
         }
 


### PR DESCRIPTION
We had a crasher in a CARDDAV:addressbook-query REPORT in which we trying to fetch the CARDDAV:address_data property.  vcard_parse_string() was returning NULL, which we then try to dereference.

The first 2 commits will now return a DAV:propstat with a DAV:status of 501 in such a case rather than crash.

We believe the crash was a result of parsing non-NULL-terminated data, which should be fixed by the last 2 commits.
