### PR TITLE
Remove 'static const struct buf' tripping hazard

### DIFF
--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -1482,7 +1482,7 @@ int apply_annotations(struct mailbox *mailbox,
     const struct sync_annot *local = (local_annots ? local_annots->head : NULL);
     const struct sync_annot *remote = (remote_annots ? remote_annots->head : NULL);
     const struct sync_annot *chosen;
-    static const struct buf novalue = BUF_INITIALIZER;
+    const struct buf novalue = BUF_INITIALIZER;
     const struct buf *value;
     int r = 0;
     int diff;


### PR DESCRIPTION
Fixes #3813 

Variables declared `static const` are stored in read-only memory, but the `buf_...()` functions expect to be able to change a buf's in-memory representation, even when they offer `const` as a promise the data itself won't change.  If the buf in question is in read-only memory, they'll crash when they try.

This PR removes the `static` keyword from the one `static const struct buf` that we had -- before we accidentally treat it like any other struct buf and crash!