### PR TITLE
jmap_api: ignore shared calendar/addressbook home for capabilities

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -7773,5 +7773,50 @@ EOF
     $self->assert_str_equals($defaultCalendarId, $res->[3][1]{list}[0]{calendarId});
 }
 
+sub test_calendar_session_no_calendarhome
+    :min_version_3_5 :needs_component_jmap :JMAPExtensions :NoAltNameSpace
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog $self, "create other user";
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->create('user.other');
+    $admintalk->setacl('user.other', admin => 'lrswipkxtecdan') or die;
+    $admintalk->setacl('user.other', other => 'lrswipkxtecdn') or die;
+
+    my $service = $self->{instance}->get_service("http");
+    my $otherJmap = Mail::JMAPTalk->new(
+        user => 'other',
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/jmap/',
+    );
+    $otherJmap->DefaultUsing([
+        'urn:ietf:params:jmap:core',
+        'https://cyrusimap.org/ns/jmap/calendars',
+    ]);
+
+    my $res = $otherJmap->CallMethods([
+        ['Calendar/get', {
+            properties => ['id'],
+        }, 'R1'],
+    ]);
+    $admintalk->setacl('user.other.#calendars', cassandane => 'lr') or die;
+
+    $res = $jmap->ua->get($jmap->uri(), {
+        headers => {
+            'Authorization' => $jmap->auth_header(),
+        },
+        content => '',
+    });
+    $self->assert_str_equals('200', $res->{status});
+    my $session = eval { decode_json($res->{content}) };
+    my $capabilities = $session->{accounts}{other}{accountCapabilities};
+    $self->assert_null($capabilities->{'https://cyrusimap.org/ns/jmap/calendars'});
+}
+
 
 1;

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -533,12 +533,12 @@ static int capabilities_cb(const mbentry_t *mbentry, void *vrock)
         rock->has_mail = mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL;
     }
     if (!rock->has_contacts) {
-        rock->has_contacts = strarray_size(boxes) >= 1 &&
+        rock->has_contacts = strarray_size(boxes) > 1 &&
             !strcmpsafe(config_getstring(IMAPOPT_ADDRESSBOOKPREFIX),
                     strarray_nth(boxes, 0));
     }
     if (!rock->has_calendars) {
-        rock->has_calendars = strarray_size(boxes) >= 1 &&
+        rock->has_calendars = strarray_size(boxes) > 1 &&
             !strcmpsafe(config_getstring(IMAPOPT_CALENDARPREFIX),
                     strarray_nth(boxes, 0));
     }


### PR DESCRIPTION
Before, if only the `#calendars` or `#addressbooks` mailboxes where shared, then the account still got reported to share calendars or addressbooks.