### PR TITLE
Conversations missing folder fix

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -554,7 +554,9 @@ static void commitstatus_cb(const char *key, void *data, void *rock)
      * recreated while a replica was still valid with the old user) */
     if (!state->folders_byname) {
         mboxlist_lookup_by_uniqueid(folder, &mbentry, NULL);
-        folder = mbentry ? mbentry->name : "";
+        if (!mbentry) return;
+
+        folder = mbentry->name;
     }
     mboxname_setmodseq(folder, status->threadmodseq, /*mbtype */0, /*flags*/0);
     sync_log_mailbox(folder);


### PR DESCRIPTION
This avoids a crasher via an abort() when calling sync_log_mailbox("")

@brong confirmed via slack that mboxname_setmodseq("") also is nonsensical.
