### PR TITLE
DAV DB v12 -> v14 upgrade fix

### DIFF
--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -1071,8 +1071,6 @@ EXPORTED int sieve_script_rebuild(const char *userid,
     " WHERE rowid = :rowid;"
 
 #define CMD_UPDATE_v13_TABLE             \
-    "DELETE FROM sieve_scripts WHERE (rowid, modseq) NOT IN" \
-    " (SELECT rowid, MAX(modseq) FROM sieve_scripts GROUP BY imap_uid);" \
     "UPDATE sieve_scripts SET mailbox = :mailbox;"
 
 

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -1071,6 +1071,8 @@ EXPORTED int sieve_script_rebuild(const char *userid,
     " WHERE rowid = :rowid;"
 
 #define CMD_UPDATE_v13_TABLE             \
+    "DELETE FROM sieve_scripts WHERE (rowid, modseq) NOT IN" \
+    " (SELECT rowid, MAX(modseq) FROM sieve_scripts GROUP BY imap_uid);" \
     "UPDATE sieve_scripts SET mailbox = :mailbox;"
 
 

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -1104,19 +1104,19 @@ EXPORTED int sievedb_upgrade(sqldb_t *db)
         { ":mailbox",   SQLITE_TEXT,    { .s = NULL } },
         { NULL,         SQLITE_NULL,    { .s = NULL } } };
     mbentry_t *mbentry = NULL;
-    int rowid, r;
+    int rowid;
+    int r = 0;
 
-    if (db->version < 12) return 0;
-    if (db->version > 13) return 0;
+    sdata.mailbox = NULL;
 
     if (db->version == 12) {
         /* Rename 'content' -> 'contentid' */
         r = sqldb_exec(db, CMD_ALTER_v12_TABLE, NULL, NULL, NULL);
-        if (r) return r;
+        if (r) goto done;
 
         /* Create an array of SHA1 for the content in each record */
         r = sqldb_exec(db, CMD_GETFIELDS, NULL, &read_cb, &rrock);
-        if (r || !strarray_size(&sha1)) goto done;
+        if (r) goto done;
 
         /* Rewrite 'contentid' columns with actual ids (SHA1) */
         for (rowid = 1; rowid < strarray_size(&sha1); rowid++) {
@@ -1131,10 +1131,14 @@ EXPORTED int sievedb_upgrade(sqldb_t *db)
         /* Fetch mailbox name from first record */
         rrock.cb = NULL;
         sdata.mailbox = NULL;
-        r = sqldb_exec(db, CMD_GETFIELDS " WHERE rowid = 1;",
+        r = sqldb_exec(db, CMD_GETFIELDS " LIMIT 1;",
                        NULL, &read_cb, &rrock);
-        if (r || !sdata.mailbox) goto done;
+        if (r) goto done;
     }
+
+    // this will only be set if we are upgrading from v12 or v13 and there are
+    // records with a mailbox on them
+    if (!sdata.mailbox) goto done;
 
     r = mboxlist_lookup_allow_all(sdata.mailbox, &mbentry, NULL);
     if (r) goto done;

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -1116,9 +1116,10 @@ EXPORTED int sievedb_upgrade(sqldb_t *db)
 
         /* Create an array of SHA1 for the content in each record */
         r = sqldb_exec(db, CMD_GETFIELDS, NULL, &read_cb, &rrock);
+        if (r || !strarray_size(&sha1)) goto done;
 
         /* Rewrite 'contentid' columns with actual ids (SHA1) */
-        for (rowid = 1; !r && rowid < strarray_size(&sha1); rowid++) {
+        for (rowid = 1; rowid < strarray_size(&sha1); rowid++) {
             bval[0].val.i = rowid;
             bval[1].val.s = strarray_nth(&sha1, rowid);
 
@@ -1127,6 +1128,7 @@ EXPORTED int sievedb_upgrade(sqldb_t *db)
         }
     }
     else if (db->version == 13) {
+        /* Fetch mailbox name from first record */
         rrock.cb = NULL;
         sdata.mailbox = NULL;
         r = sqldb_exec(db, CMD_GETFIELDS " WHERE rowid = 1;",


### PR DESCRIPTION
Upgrading an empty v12 sieve_scripts table was causing a crash: mboxlist_lookup_allow_all() on a NULL mboxname fails, causing sievedb_upgrade() to fail, causing sqldb_open() to return a NULL DB handle to mailbox_update_dav|sieve()