### PR TITLE
more mailbox_legacy_dirs fixes

### DIFF
--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -708,7 +708,7 @@ sub test_rename_deepfolder_intermediates
     $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
 
     xlog $self, "Make sure there are no files left with cassandane in the name";
-    $self->assert_null(glob "$self->{instance}{basedir}/conf/user/c/cassandane.*");
+    $self->assert_str_equals(q{}, join(q{ }, glob "$self->{instance}{basedir}/conf/user/c/cassandane.*"));
     $self->assert(not -d "$self->{instance}{basedir}/data/c/user/cassandane");
     $self->assert(not -f "$self->{instance}{basedir}/conf/quota/c/user.cassandane");
 
@@ -718,8 +718,8 @@ sub test_rename_deepfolder_intermediates
     $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
     $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
 
-    xlog $self, "Make sure there are no files left with cassandane in the on the replica";
-    $self->assert_null(glob "$self->{replica}{basedir}/conf/user/c/cassandane.*");
+    xlog $self, "Make sure there are no files left with cassandane in the name on the replica";
+    $self->assert_str_equals(q{}, join(q{ }, glob "$self->{replica}{basedir}/conf/user/c/cassandane.*"));
     $self->assert(not -d "$self->{replica}{basedir}/data/c/user/cassandane");
     $self->assert(not -f "$self->{replica}{basedir}/conf/quota/c/user.cassandane");
 
@@ -1308,7 +1308,7 @@ sub test_rename_deepfolder_intermediates_rightnow
     $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
 
     xlog $self, "Make sure there are no files left with cassandane in the name";
-    $self->assert_null(glob "$self->{instance}{basedir}/conf/user/c/cassandane.*");
+    $self->assert_str_equals(q{}, join(q{ }, glob "$self->{instance}{basedir}/conf/user/c/cassandane.*"));
     $self->assert(not -d "$self->{instance}{basedir}/data/c/user/cassandane");
     $self->assert(not -f "$self->{instance}{basedir}/conf/quota/c/user.cassandane");
 
@@ -1318,7 +1318,7 @@ sub test_rename_deepfolder_intermediates_rightnow
     $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
 
     xlog $self, "Make sure there are no files left with cassandane in the on the replica";
-    $self->assert_null(glob "$self->{replica}{basedir}/conf/user/c/cassandane.*");
+    $self->assert_str_equals(q{}, join(q{ }, glob "$self->{replica}{basedir}/conf/user/c/cassandane.*"));
     $self->assert(not -d "$self->{replica}{basedir}/data/c/user/cassandane");
     $self->assert(not -f "$self->{replica}{basedir}/conf/quota/c/user.cassandane");
 

--- a/cassandane/Cassandane/Cyrus/List.pm
+++ b/cassandane/Cassandane/Cyrus/List.pm
@@ -2184,8 +2184,8 @@ sub test_no_tombstones
         $mbtype_deleted = 1 << 4;
     }
 
-    $self->assert_num_equals($mbtype_deleted,
-                             $mailboxesdb->{$tombstone_name}->{mbtype});
+    $self->assert_bits_set($mbtype_deleted,
+                           $mailboxesdb->{$tombstone_name}->{mbtype});
 
     # basic list
     my $data = $imaptalk->list("", "*");
@@ -2239,8 +2239,8 @@ sub test_no_inbox_tombstone
         $mbtype_deleted = 1 << 4;
     }
 
-    $self->assert_num_equals($mbtype_deleted,
-                             $mailboxesdb->{$tombstone_name}->{mbtype});
+    $self->assert_bits_set($mbtype_deleted,
+                           $mailboxesdb->{$tombstone_name}->{mbtype});
 
     my $imaptalk = $self->{store}->get_client();
 

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -276,6 +276,43 @@ sub apply_parameter_setting
     }
 }
 
+# n.b. it's okay for unexpected bits to also be set!
+# if you need to test that ONLY specific bits are set, try:
+#
+#   assert_bits_set($want, $got);
+#   assert_bits_not_set(~$want, $got);
+#
+sub assert_bits_set
+{
+    my ($self, $expected_bits, $actual_bitfield) = @_;
+
+    # force args to be numeric
+    # XXX use feature 'bitwise';
+    $expected_bits += 0;
+    $actual_bitfield += 0;
+
+    my $fail_msg = sprintf("%#.8b does not have all of %#.8b bits set",
+                           $actual_bitfield, $expected_bits);
+
+    $self->assert((($actual_bitfield & $expected_bits) == $expected_bits),
+                  $fail_msg);
+}
+
+sub assert_bits_not_set
+{
+    my ($self, $expected_bits, $actual_bitfield) = @_;
+
+    # force args to be numeric
+    # XXX use feature 'bitwise';
+    $expected_bits += 0;
+    $actual_bitfield += 0;
+
+    my $fail_msg = sprintf("%#.8b has some of %#.8b bits set",
+                           $actual_bitfield, $expected_bits);
+
+    $self->assert((($actual_bitfield & $expected_bits) == 0), $fail_msg);
+}
+
 sub assert_num_gte
 {
     my ($self, $expected, $actual) = @_;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6474,13 +6474,9 @@ HIDDEN int mailbox_rename_copy(struct mailbox *oldmailbox,
     newmailbox->h.uniqueid = xstrdup(newuniqueid);
     newmailbox->header_dirty = 1;
 
-    /* copy any mailbox annotations (but keep the known quota
-     * amount, because we already counted that usage.  XXX horrible
-     * hack */
-    quota_t annotused = newmailbox->i.quota_annot_used;
+    /* update mailbox annotations if necessary */
     r = annotate_rename_mailbox(oldmailbox, newmailbox);
     if (r) goto fail;
-    newmailbox->i.quota_annot_used = annotused;
 
     /* mark the "used" back to zero, so it updates the new quota! */
     mailbox_set_quotaroot(newmailbox, newquotaroot);


### PR DESCRIPTION
This fixes most (but not all) of the errors found by running cassandane with "mailbox_legacy_dirs = yes" (#3782).  Specifically, it fixes:

* quota_annot_used getting out of sync when "displayname" annotation is removed during rename
* List "tombstones" tests checking for MBTYPE_DELETED incorrectly, and failing when the MBTYPE_LEGACY_DIRS bit was also set

It also updates the FastMail.rename_deepfolder_intermediates and FastMail.rename_deepfolder_intermediates_rightnow tests to produce a useful error message for the particular failure they're experiencing -- I have no insight to the underlying problem yet, but at least now the errors are comprehensible for future debugging.

We might be able to do the quota_annot_used fix better, perhaps by adding a `delete_cb()` instead of continuing to abuse `rename_cb()`, but for now this works and is heavily commented.

I'll update #3782 with the status of the remaining failures.