### PR TITLE
Avoid platform-dependent strerror(0)

### DIFF
--- a/com_err/et/error_message.c
+++ b/com_err/et/error_message.c
@@ -72,6 +72,14 @@ long code;
     int started = 0;
     char *cp;
 
+    /* Support for error number 0 differs among implementations of
+       strerror(). Linux/glibc returns "Success", which is nice, while
+       macOS returns "Undefined error: 0", which is rather confusing
+       in an LMTP success response "250 2.1.5 Undefined error: 0
+       SESSIONID=...". Return a known, consistent string instead. */
+    if (code == 0) {
+        return "Success";
+    }
     l_offset = code & ((1<<ERRCODE_RANGE)-1);
     offset = (int) l_offset;
     table_num = code - l_offset;


### PR DESCRIPTION
As discussed in #3035:

On macOS, the Cyrus LMTP server responds `250 2.1.5 Undefined error: 0 SESSIONID=<cyrus-...>` in case of success. While there is nothing technically wrong with that as the protocol allows anything in the human-readable part of the message, it is somewhat confusing to read the word “error” in a mail server log when there is nothing wrong.

This comes from `send_lmtp_error()` → `error_message()` → `strerror(0)`, which on macOS returns “Undefined error: 0”, whereas on Linux/glibc it returns an appropriate “Success”. Other platforms may return something different entirely, the standards do not seem to specify it.

Avoid this by returning a constant “Success” from `error_message(0)`, which, matching the most common platform Linux, appears to be a known-good value also in the few other places than `send_lmtp_error()` that can call `error_message()` with 0.