### PR TITLE
.gitignore: ignore some transient configure files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ backup/restore
 bench/cyrdbbench
 cmulocal/
 compile
+confdefs.h
 config.guess
 config.h
 config.h.in
@@ -42,6 +43,7 @@ config.status
 config.status.lineno
 config.sub
 configure
+conftest*
 com_err/et/compile_et
 coverage.xml
 cscope.out

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.gcda
 *.la
 *.lo
+*.loT
 *.o
 *.orig
 *.patch


### PR DESCRIPTION
Ignoring these transient files prevents `git status` from reporting "untracked files" while configure is running.  They're usually cleaned up when configure finishes anyway, which I guess is why we haven't previously noticed them.

My shell prompt includes repository status, and since cassandane and cyrus-imapd are the same repository now, I keep noticing and being distracted by these files popping in and out of existence when I'm doing stuff with cassandane while cyrus builds in another terminal.  And it's gotten annoying enough to just fix. :)