### PR TITLE
Fastmail-only: ignore RFC-draft calendars capability

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -7858,5 +7858,21 @@ sub test_no_shared_calendar
     $self->assert_deep_equals([], $res->[3][1]{list});
 }
 
+sub test_calendarevent_get_ignore_ietf_calendars_capability
+    :min_version_3_5 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', { }, 'R1'],
+    ], [
+        'urn:ietf:params:jmap:core',
+        'https://cyrusimap.org/ns/jmap/calendars',
+        'urn:ietf:params:jmap:calendars',
+    ]);
+    $self->assert_deep_equals([], $res->[0][1]{list});
+}
+
 
 1;

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -314,6 +314,9 @@ static int validate_request(struct transaction_t *txn, const json_t *req,
         else if (!strcmp(s, "ietf:jmapmail")) {
             syslog(LOG_DEBUG, "old capability %s used", s);
         }
+        else if (!strcmp(s, "urn:ietf:params:jmap:calendars")) {
+            syslog(LOG_DEBUG, "future capability %s used", s);
+        }
         else if (!json_object_get(settings->server_capabilities, s))  {
             buf_printf(&txn->buf, "The Request object used capability '%s',"
                        " which is not supported by this server.", s);


### PR DESCRIPTION
Ignores the future JMAP Calendars IETF capability rather than rejecting requests.

Do not merge this PR.