### PR TITLE
Fastmail-only: rollback jmap-calendars-01 deployment

### DIFF
--- a/imap/caldav_db.h
+++ b/imap/caldav_db.h
@@ -86,6 +86,7 @@ struct comp_flags {
     unsigned tzbyref      : 1;          /* VTIMEZONEs by reference */
     unsigned mattach      : 1;          /* Has managed ATTACHment(s) */
     unsigned shared       : 1;          /* Is shared (per-user-data stripped) */
+    unsigned reserved     : 3;          /* reserved for jmap-calendars-01 */
 };
 
 /* Status values */

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -243,6 +243,11 @@
 
 #define CMD_DBUPGRADEv14 CMD_CREATE_SIEVE
 
+#define CMD_DBROLLBACKv15 \
+    "DROP TABLE IF EXISTS jscal_objs;" \
+    "DROP TABLE IF EXISTS jscal_cache;" \
+    CMD_CREATE_CALCACHE
+
 struct sqldb_upgrade davdb_upgrade[] = {
   { 2, CMD_DBUPGRADEv2, NULL },
   { 3, CMD_DBUPGRADEv3, NULL },
@@ -257,10 +262,13 @@ struct sqldb_upgrade davdb_upgrade[] = {
   /* Don't upgrade to version 12.  This was an intermediate Sieve DB version */
   /* Don't upgrade to version 13.  This was an intermediate Sieve DB version */
   { 14, CMD_DBUPGRADEv14, &sievedb_upgrade },
+  /* Version 15 is reserved for the jmap-calendars-01 branch */
+  { 16, CMD_DBROLLBACKv15, NULL },
+
   { 0, NULL, NULL }
 };
 
-#define DB_VERSION 14
+#define DB_VERSION 16
 
 static sqldb_t *reconstruct_db;
 


### PR DESCRIPTION
This PR is not meant to merge on the main branch. It rolls back dav.db changes of the jmap-calendars-01 branch which were introduced in version 15 and sets the current version to 16.

I manually (and only rudimentary) tested this by running CalendarEvent/get on this branch both on a Cyrus environment with current master and jmap-calendars-01.

This should cover the majority of changes introduced by jmap-calendars-01. It does not rollback newly introduced ACLs (like mayUpdatePrivate), so these only should be set once we are sure to not want to rollback (or defined a downgrade path for ACLs).

This PR is more a work in progress, but I'd appreciate an early review.