### PR TITLE
sync_client: in -A mode, reconnect if error

### DIFF
--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -261,7 +261,7 @@ EOF
 # Test handling of replication when append fails due to disk error
 #
 sub test_syncall_failinguser
-    :NoStartInstances :min_version_3_5
+    :NoStartInstances :min_version_3_6
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -258,6 +258,121 @@ EOF
 }
 
 #
+# Test handling of replication when append fails due to disk error
+#
+sub test_syncall_failinguser
+    :NoStartInstances :min_version_3_5
+{
+    my ($self) = @_;
+
+    my $canary = << 'EOF';
+From: Fred J. Bloggs <fbloggs@fastmail.fm>
+To: Sarah Jane Smith <sjsmith@tard.is>
+Subject: this is just to say
+X-Cassandane-Unique: canary
+
+I have eaten
+the canary
+that was in
+the coal mine
+
+and which
+you were probably
+saving
+for emergencies
+
+Forgive me
+it was delicious
+so tweet
+and so coaled
+EOF
+    $canary =~ s/\n/\r\n/g;
+    my $canaryguid = "f2eaa91974c50ec3cfb530014362e92efb06a9ba";
+
+    $self->{replica}->{config}->set('debug_writefail_guid' => $canaryguid);
+    $self->_start_instances();
+
+    my $master_store = $self->{master_store};
+    my $replica_store = $self->{replica_store};
+
+    $self->{instance}->create_user("a_early");
+    $self->{instance}->create_user("z_late");
+
+    my $mastersvc = $self->{instance}->get_service('imap');
+    my $astore = $mastersvc->create_store(username => "a_early");
+    my $zstore = $mastersvc->create_store(username => "z_late");
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replica_astore = $replicasvc->create_store(username => "a_early");
+    my $replica_zstore = $replicasvc->create_store(username => "z_late");
+
+    xlog $self, "Creating a message in each user";
+    my %apreexp;
+    my %cpreexp;
+    my %zpreexp;
+    $apreexp{1} = $self->make_message("Message A", store => $astore);
+    $cpreexp{1} = $self->make_message("Message C", store => $master_store);
+    $zpreexp{1} = $self->make_message("Message Z", store => $zstore);
+
+    xlog $self, "Running all user replication";
+    $self->run_replication(allusers => 1);
+
+    xlog $self, "Creating a second message for each user (cassandane having the canary)";
+    my %aexp = %apreexp;
+    my %cexp = %cpreexp;
+    my %zexp = %zpreexp;
+    $aexp{2} = $self->make_message("Message A2", store => $astore);
+    $cexp{2} = Cassandane::Message->new(raw => $canary,
+                                       attrs => { UID => 2 }),
+    $self->_save_message($cexp{2}, $master_store);
+    $zexp{2} = $self->make_message("Message Z2", store => $zstore);
+
+    xlog $self, "new messages should be on master only";
+    $self->check_messages(\%aexp, keyed_on => 'uid', store => $astore);
+    $self->check_messages(\%apreexp, keyed_on => 'uid', store => $replica_astore);
+    $self->check_messages(\%cexp, keyed_on => 'uid', store => $master_store);
+    $self->check_messages(\%cpreexp, keyed_on => 'uid', store => $replica_store);
+    $self->check_messages(\%zexp, keyed_on => 'uid', store => $zstore);
+    $self->check_messages(\%zpreexp, keyed_on => 'uid', store => $replica_zstore);
+
+    xlog $self, "running replication...";
+    eval {
+        $self->run_replication(allusers => 1);
+    };
+    my $e = $@;
+
+    # sync_client should have exited with an error
+    $self->assert($e);
+    $self->assert_matches(qr/child\sprocess\s
+                            \(binary\ssync_client\spid\s\d+\)\s
+                            exited\swith\scode/x,
+                          $e->to_string());
+
+    if ($self->{instance}->{have_syslog_replacement}) {
+        # sync_client should have logged the BAD response
+        my @lines = $self->{instance}->getsyslog();
+        $self->assert_matches(qr/IOERROR: received bad response/, "@lines");
+
+        # sync server should have logged the write error
+        @lines = $self->{replica}->getsyslog();
+        $self->assert_matches(qr{IOERROR:\sfailed\sto\supload\sfile
+                                 (?:\s\(simulated\))?:\sguid=<$canaryguid>
+                              }x,
+                              "@lines");
+    }
+
+    xlog $self, "Check that cassandane user wasn't updated, both others were";
+    $self->check_replication('a_early');
+    $self->check_replication('z_late');
+
+    $self->check_messages(\%aexp, keyed_on => 'uid', store => $astore);
+    $self->check_messages(\%aexp, keyed_on => 'uid', store => $replica_astore);
+    $self->check_messages(\%cexp, keyed_on => 'uid', store => $master_store);
+    $self->check_messages(\%cpreexp, keyed_on => 'uid', store => $replica_store);
+    $self->check_messages(\%zexp, keyed_on => 'uid', store => $zstore);
+    $self->check_messages(\%zexp, keyed_on => 'uid', store => $replica_zstore);
+}
+
+#
 # Test replication of messages APPENDed to the master
 #
 sub test_splitbrain

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1159,10 +1159,12 @@ sub run_replication
     my $mailbox = delete $opts{mailbox};
     my $meta = delete $opts{meta};
     my $nosyncback = delete $opts{nosyncback};
+    my $allusers = delete $opts{allusers};
     $nmodes++ if $user;
     $nmodes++ if $rolling;
     $nmodes++ if $mailbox;
     $nmodes++ if $meta;
+    $nmodes++ if $allusers;
 
     # pass through run_command options
     my $handlers = delete $opts{handlers};
@@ -1191,6 +1193,7 @@ sub run_replication
     push(@cmd, '-O') if defined $nosyncback;
     push(@cmd, '-u', $user) if defined $user;
     push(@cmd, '-m', $mailbox) if defined $mailbox;
+    push(@cmd, '-A') if defined $allusers;
 
     my %run_options;
     $run_options{cyrus} = 1;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1193,7 +1193,7 @@ sub run_replication
     push(@cmd, '-O') if defined $nosyncback;
     push(@cmd, '-u', $user) if defined $user;
     push(@cmd, '-m', $mailbox) if defined $mailbox;
-    push(@cmd, '-A') if defined $allusers;
+    push(@cmd, '-A') if $allusers;  # n.b. boolean
 
     my %run_options;
     $run_options{cyrus} = 1;

--- a/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
@@ -20,7 +20,7 @@ Synopsis
     **sync_client** [ **-v** ] [ **-l** ] [ **-L** ] [ **-z** ] [ **-C** *config-file* ] [ **-S** *server-name* ]
         [ **-f** *input-file* ] [ **-F** *shutdown_file* ] [ **-w** *wait_interval* ]
         [ **-t** *timeout* ] [ **-d** *delay* ] [ **-r** ] [ **-n** *channel* ] [ **-u** ] [ **-m** ]
-        [ **-p** *partition* ] [ **-A** ] [ **-s** ] [ **-O** ] *objects*...
+        [ **-p** *partition* ] [ **-A** ] [ **-N** ] [ **-s** ] [ **-O** ] *objects*...
 
 Description
 ===========
@@ -91,6 +91,11 @@ Options
     channels are specified in ``sync_log_channels`` then use one of them.
     This option is probably best combined with **-S** to connect to a
     different server with each channel.
+
+.. option:: -N
+
+    Use non-blocking sync_lock (combination of IP address and username)
+    to skip over any users who are currently syncing.
 
 .. option:: -o
 

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -407,7 +407,12 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
 
 done:
     free(userid);
-    if (r) *exit_rcp = 1;
+    if (r) {
+        *exit_rcp = 1;
+        // reconnect!
+        replica_disconnect();
+        replica_connect();
+    }
     return 0; // but keep going anyway
 }
 

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -384,16 +384,18 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
             goto done;
 
         /* only sync if we haven't just done the user */
-        if (strcmpsafe(userid, prev_userid)) {
-            r = sync_do_user(&sync_cs, userid, NULL);
-            if (r) {
-                if (verbose)
-                    fprintf(stderr, "Error from do_user(%s): bailing out!\n", userid);
-                syslog(LOG_ERR, "Error in do_user(%s): bailing out!", userid);
-                goto done;
-            }
-            xzfree(prev_userid);
-            prev_userid = xstrdup(userid);
+        if (!strcmpsafe(userid, prev_userid))
+            goto done;
+
+        xzfree(prev_userid);
+        prev_userid = xstrdup(userid);
+
+        r = sync_do_user(&sync_cs, userid, NULL);
+        if (r) {
+            if (verbose)
+                fprintf(stderr, "Error from do_user(%s): bailing out!\n", userid);
+            syslog(LOG_ERR, "Error in do_user(%s): bailing out!", userid);
+            goto done;
         }
     }
     else {

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -457,7 +457,7 @@ int main(int argc, char **argv)
 
     setbuf(stdout, NULL);
 
-    while ((opt = getopt(argc, argv, "C:vlLS:F:f:w:t:d:n:rRumsozOAp:1")) != EOF) {
+    while ((opt = getopt(argc, argv, "C:vlLS:F:f:w:t:d:n:rRNumsozOAp:1")) != EOF) {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
@@ -516,6 +516,10 @@ int main(int argc, char **argv)
             if (mode != MODE_UNKNOWN)
                 usage("sync_client", "Mutually exclusive options defined");
             mode = MODE_REPEAT;
+            break;
+
+        case 'N': // return LOCKED if this user is already sync locked
+            flags |= SYNC_FLAG_NONBLOCK;
             break;
 
         case 'A':

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -392,7 +392,7 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
                 syslog(LOG_ERR, "Error in do_user(%s): bailing out!", userid);
                 goto done;
             }
-            free(prev_userid);
+            xzfree(prev_userid);
             prev_userid = xstrdup(userid);
         }
     }
@@ -675,6 +675,8 @@ int main(int argc, char **argv)
 
         if (mboxlist_allmbox(optind < argc ? argv[optind] : NULL, cb_allmbox, &exit_rc, 0))
             exit_rc = 1;
+
+        xzfree(prev_userid);
 
         replica_disconnect();
         break;

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -374,6 +374,9 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
 
     char *userid = mboxname_to_userid(mbentry->name);
 
+    // reconnect if we've been disconnected
+    if (!sync_cs.backend) replica_connect();
+
     if (userid) {
         /* skip deleted mailboxes only because the are out of order, and you would
          * otherwise have to sync the user twice thanks to our naive logic */
@@ -408,10 +411,10 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
 done:
     free(userid);
     if (r) {
-        *exit_rcp = 1;
-        // reconnect!
+        // disconnect on errors
         replica_disconnect();
-        replica_connect();
+        // remember that we had an error for the exit code
+        *exit_rcp = 1;
     }
     return 0; // but keep going anyway
 }

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -391,6 +391,11 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
         prev_userid = xstrdup(userid);
 
         r = sync_do_user(&sync_cs, userid, NULL);
+        if (r == IMAP_MAILBOX_LOCKED) {
+            if (verbose)
+                fprintf(stderr, "Skipping locked user %s\n", userid);
+            r = 0;
+        }
         if (r) {
             if (verbose)
                 fprintf(stderr, "Error from do_user(%s): bailing out!\n", userid);
@@ -402,6 +407,11 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
         /* all shared mailboxes, including DELETED ones, sync alone */
         /* XXX: batch in hundreds? */
         r = do_mailbox(mbentry->name);
+        if (r == IMAP_MAILBOX_LOCKED) {
+            if (verbose)
+                fprintf(stderr, "Skipping locked mailbox %s\n", mbentry->name);
+            r = 0;
+        }
         if (r) {
             if (verbose)
                 fprintf(stderr, "Error from do_user(%s): bailing out!\n", mbentry->name);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -260,7 +260,10 @@ static struct mboxlock *sync_lock(struct sync_client_state *sync_cs,
 {
     const char *name = _synclock_name(sync_cs->servername, userid);
     struct mboxlock *lock = NULL;
-    int r = mboxname_lock(name, &lock, LOCK_EXCLUSIVE);
+    int flags = LOCK_EXCLUSIVE;
+    if (sync_cs->flags & SYNC_FLAG_NONBLOCK)
+        flags |= LOCK_NONBLOCK;
+    int r = mboxname_lock(name, &lock, flags);
     return r ? NULL : lock;
 }
 

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -480,6 +480,7 @@ const char *sync_restore(struct dlist *kin,
 #define SYNC_FLAG_NO_COPYBACK (1<<4)
 #define SYNC_FLAG_BATCH (1<<5)
 #define SYNC_FLAG_SIEVE_MAILBOX (1<<6)
+#define SYNC_FLAG_NONBLOCK (1<<7)
 
 int sync_do_seen(struct sync_client_state *sync_cs, const char *userid, char *uniqueid);
 int sync_do_quota(struct sync_client_state *sync_cs, const char *root);


### PR DESCRIPTION
I added the "don't bail on error" code a few months back, but if the error caused the connection to be dropped by the replica, we just keep trying over and over on a dead connection.  Instead, if there's an error we should reconnect before moving along to the next user.