### PR TITLE
trivial "make dist" fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1255,7 +1255,6 @@ imap_httpd_SOURCES = \
 	imap/http_admin.c \
 	imap/http_applepush.c \
 	imap/http_caldav.c \
-	imap/http_caldav.h \
 	imap/http_caldav_js.h \
 	imap/http_caldav_sched.c \
 	imap/http_caldav_sched.h \

--- a/imap/rfc822_header.c
+++ b/imap/rfc822_header.c
@@ -1,5 +1,5 @@
-/* ANSI-C code produced by gperf version 3.0.4 */
-/* Command-line: gperf /tmp/compile_st_NBXFPK.gperf  */
+/* ANSI-C code produced by gperf version 3.1 */
+/* Command-line: gperf /tmp/compile_st_5cSAcK.gperf  */
 /* Computed positions: -k'1,10,$' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
@@ -26,7 +26,7 @@
       && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
       && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
 /* The character set is not based on ISO-646.  */
-#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
 #endif
 
 
@@ -70,7 +70,7 @@ static unsigned char gperf_downcase[256] =
 #ifndef GPERF_CASE_STRNCMP
 #define GPERF_CASE_STRNCMP 1
 static int
-gperf_case_strncmp (register const char *s1, register const char *s2, register unsigned int n)
+gperf_case_strncmp (register const char *s1, register const char *s2, register size_t n)
 {
   for (; n > 0;)
     {
@@ -95,7 +95,7 @@ inline
 #endif
 #endif
 static unsigned int
-hash (register const char *str, register unsigned int len)
+hash (register const char *str, register size_t len)
 {
   static const unsigned char asso_values[] =
     {
@@ -126,7 +126,7 @@ hash (register const char *str, register unsigned int len)
       34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
       34, 34, 34, 34, 34, 34
     };
-  register int hval = len;
+  register unsigned int hval = len;
 
   switch (hval)
     {
@@ -148,14 +148,8 @@ hash (register const char *str, register unsigned int len)
   return hval + asso_values[(unsigned char)str[len - 1]];
 }
 
-#ifdef __GNUC__
-__inline
-#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
-__attribute__ ((__gnu_inline__))
-#endif
-#endif
 const struct rfc822_header_desc *
-__rfc822_header_lookup (register const char *str, register unsigned int len)
+__rfc822_header_lookup (register const char *str, register size_t len)
 {
   static const struct rfc822_header_desc wordlist[] =
     {
@@ -192,9 +186,9 @@ __rfc822_header_lookup (register const char *str, register unsigned int len)
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      register int key = hash (str, len);
+      register unsigned int key = hash (str, len);
 
-      if (key <= MAX_HASH_VALUE && key >= 0)
+      if (key <= MAX_HASH_VALUE)
         {
           register const char *s = wordlist[key].name;
 
@@ -220,28 +214,28 @@ enum rfc822_header rfc822_header_from_string_len(const char *s, size_t len)
 const char *rfc822_header_to_string(enum rfc822_header v)
 {
     static const char * const strs[] = {
-        "Bcc", /* RFC822_BCC */
-        "Cc", /* RFC822_CC */
-        "Content-Description", /* RFC822_CONTENT_DESCRIPTION */
-        "Content-Disposition", /* RFC822_CONTENT_DISPOSITION */
-        "Content-Id", /* RFC822_CONTENT_ID */
-        "Content-Language", /* RFC822_CONTENT_LANGUAGE */
-        "Content-Location", /* RFC822_CONTENT_LOCATION */
-        "Content-MD5", /* RFC822_CONTENT_MD5 */
-        "Content-Transfer-Encoding", /* RFC822_CONTENT_TRANSFER_ENCODING */
-        "Content-Type", /* RFC822_CONTENT_TYPE */
-        "Date", /* RFC822_DATE */
-        "From", /* RFC822_FROM */
-        "In-Reply-To", /* RFC822_IN_REPLY_TO */
-        "Message-ID", /* RFC822_MESSAGE_ID */
-        "Reply-To", /* RFC822_REPLY_TO */
-        "Received", /* RFC822_RECEIVED */
-        "References", /* RFC822_REFERENCES */
-        "Subject", /* RFC822_SUBJECT */
-        "Sender", /* RFC822_SENDER */
-        "To", /* RFC822_TO */
-        "X-Deliveredinternaldate", /* RFC822_X_DELIVEREDINTERNALDATE */
-        "X-ME-Message-ID", /* RFC822_X_ME_MESSAGE_ID */
+	"Bcc", /* RFC822_BCC */
+	"Cc", /* RFC822_CC */
+	"Content-Description", /* RFC822_CONTENT_DESCRIPTION */
+	"Content-Disposition", /* RFC822_CONTENT_DISPOSITION */
+	"Content-Id", /* RFC822_CONTENT_ID */
+	"Content-Language", /* RFC822_CONTENT_LANGUAGE */
+	"Content-Location", /* RFC822_CONTENT_LOCATION */
+	"Content-MD5", /* RFC822_CONTENT_MD5 */
+	"Content-Transfer-Encoding", /* RFC822_CONTENT_TRANSFER_ENCODING */
+	"Content-Type", /* RFC822_CONTENT_TYPE */
+	"Date", /* RFC822_DATE */
+	"From", /* RFC822_FROM */
+	"In-Reply-To", /* RFC822_IN_REPLY_TO */
+	"Message-ID", /* RFC822_MESSAGE_ID */
+	"Reply-To", /* RFC822_REPLY_TO */
+	"Received", /* RFC822_RECEIVED */
+	"References", /* RFC822_REFERENCES */
+	"Subject", /* RFC822_SUBJECT */
+	"Sender", /* RFC822_SENDER */
+	"To", /* RFC822_TO */
+	"X-Deliveredinternaldate", /* RFC822_X_DELIVEREDINTERNALDATE */
+	"X-ME-Message-ID", /* RFC822_X_ME_MESSAGE_ID */
     };
     return (v >= 0 && v < (int)(sizeof(strs)/sizeof(strs[0])) ? strs[v] : NULL);
 }


### PR DESCRIPTION
Well, one fix, one itch scratched:

* `make dist` was failing because imap/http_caldav.h no longer exists (was renamed to "caldav_util.h"), but it was still listed in a `..._SOURCES` line in Makefile.am.  So make would try to include it in the tarball, not find it, try to build it, not find a rule to build it, and complain that there was no rule...  
* imap/rfc822_header.c is automatically generated, but we keep it in the repository for the reasons described in 4f4c46d388.  Since I updated to buster (and a newer `gperf` that produces slightly different code), every time I make a release, my repository ends up dirty, which confuses me for a moment.  So this time I'm committing the new version to save myself the confusion for a while.  We previously did the same thing in 6ed3e47e95.