### PR TITLE
cassandane: Add new_test_url() and Cassandane::Test::URL for easy HTT…

### DIFF
--- a/cassandane/Cassandane/Test/NewTestUrl.pm
+++ b/cassandane/Cassandane/Test/NewTestUrl.pm
@@ -1,0 +1,133 @@
+#!/usr/bin/perl
+
+package Cassandane::Test::NewTestUrl;
+use strict;
+use warnings;
+
+use JSON;
+use LWP::UserAgent;
+
+use lib '.';
+use base qw(Cassandane::Unit::TestCase);
+
+sub new
+{
+    my $class = shift;
+    my $self = $class->SUPER::new(@_);
+    return $self;
+}
+
+sub test_basic
+{
+    my ($self) = @_;
+
+    my $string_based_url = $self->new_test_url("string based");
+    my $code_based_url = $self->new_test_url(sub {
+        return [
+            201,
+            [],
+            [ "code based" ],
+        ],
+    });
+
+    my $lwp = LWP::UserAgent->new;
+
+    {
+        my $res = $lwp->get($string_based_url->url);
+        $self->assert_str_equals('200', $res->code);
+        $self->assert_str_equals('string based', $res->decoded_content);
+    }
+
+    {
+        my $res = $lwp->get($code_based_url->url);
+        $self->assert_str_equals('201', $res->code);
+        $self->assert_str_equals('code based', $res->decoded_content);
+    }
+
+    $string_based_url->unregister;
+
+    {
+        # Unregistering one shouldn't affect the other
+        my $res = $lwp->get($code_based_url->url);
+        $self->assert_str_equals('201', $res->code);
+        $self->assert_str_equals('code based', $res->decoded_content);
+    }
+
+    $code_based_url->update("newval");
+
+    {
+        my $res = $lwp->get($code_based_url->url);
+        $self->assert_str_equals('200', $res->code);
+        $self->assert_str_equals('newval', $res->decoded_content);
+    }
+
+    {
+        eval { $string_based_url->url };
+        my $err = $@;
+        $self->assert_matches(
+            qr/\QCannot call ->url after ->unregister has been called\E/,
+            $err,
+        );
+    }
+
+    {
+        eval { $string_based_url->update("foo") };
+        my $err = $@;
+        $self->assert_matches(
+            qr/\QCannot call ->update after ->unregister has been called\E/,
+            $err,
+        );
+    }
+
+    # Plack example
+    my $plack_based_url = $self->new_test_url(sub {
+        my $env = shift;
+        my $req = Plack::Request->new($env);
+
+        my $payload = decode_json($req->raw_body);
+
+        my $res;
+
+        if ($payload->{good}) {
+            $res = Plack::Response->new(200);
+            $res->content_type('application/json');
+            $res->body(encode_json({ good => "job" }));
+        } else {
+            $res = Plack::Response->new(400);
+            $res->content_type('application/json');
+            $res->body(encode_json({ tough => "luck" }));
+        }
+
+        return $res->finalize;
+    });
+
+    {
+        my $res = $lwp->post(
+            $plack_based_url->url,
+            Content => encode_json({ good => 1 }),
+        );
+        $self->assert_str_equals('200', $res->code);
+
+        my $json = decode_json($res->decoded_content);
+        $self->assert_deep_equals(
+            { good => "job" },
+            $json,
+        );
+    }
+
+    {
+        my $res = $lwp->post(
+            $plack_based_url->url,
+            Content => encode_json({ good => 0 }),
+        );
+        $self->assert_str_equals('400', $res->code);
+
+        my $json = decode_json($res->decoded_content);
+        $self->assert_deep_equals(
+            { tough => "luck" },
+            $json,
+        );
+    }
+}
+
+1;

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -46,6 +46,7 @@ use Data::Dumper;
 
 use lib '.';
 use Cassandane::Util::Log;
+use Cassandane::Util::TestUrl;
 
 my $enabled;
 my $buildinfo;
@@ -327,6 +328,14 @@ sub assert_num_lte
 
     $self->assert(($actual <= $expected),
                   "$actual is not less-than-or-equal-to $expected");
+}
+
+sub new_test_url {
+    my ($self, $content_or_app) = @_;
+
+    return Cassandane::Util::TestURL->new({
+        app => $content_or_app,
+    });
 }
 
 1;

--- a/cassandane/Cassandane/Util/TestUrl.pm
+++ b/cassandane/Cassandane/Util/TestUrl.pm
@@ -1,0 +1,112 @@
+package Cassandane::Util::TestURL;
+
+use Plack::Loader;
+use Plack::Request;
+use Plack::Response;
+
+use Test::TCP;
+use Carp qw(croak);
+
+use lib '.';
+use Cassandane::PortManager;
+
+sub new
+{
+    my ($pkg, $args) = @_;
+
+    my %attrs;
+
+    for my $required (qw(app)) {
+        $attrs{$required} = delete $args->{$required};
+        unless ($attrs{$required}) {
+            croak("'$required' required for Cassandane::Test::URL->new");
+        }
+    }
+
+    my $self = bless {}, __PACKAGE__;
+
+    $self->update($attrs{app});
+
+    return $self;
+}
+
+sub url
+{
+    my ($self) = @_;
+
+    if ($self->was_unregistered) {
+        croak("Cannot call ->url after ->unregister has been called!");
+    }
+
+    $self->{url};
+}
+
+sub _guard { shift->{_guard} }
+
+sub unregister
+{
+    my ($self) = @_;
+
+    delete $self->{_guard};
+    $self->{was_unregistered} = 1;
+}
+
+sub was_unregistered { shift->{was_unregistered} }
+
+sub update
+{
+    my ($self, $content_or_app) = @_;
+
+    unless (ref $content_or_app) {
+        my $content = $content_or_app;
+        # Plain ol' successful response
+        $content_or_app = sub {
+            return [
+                200,
+                [],
+                [ $content ],
+            ];
+        };
+    }
+
+    my $app = sub {
+        my $sock_or_port = shift;
+        my $server = Plack::Loader->auto(
+            host => '0.0.0.0',
+            port => $sock_or_port,
+        );
+        $server->run($content_or_app);
+        exit;
+    };
+
+    unless ($self->_guard) {
+        if ($self->was_unregistered) {
+            # We've already been unregistered. It's no longer safe to call
+            # update because our port may have been reused by someone else
+            # and our url is no longer useable
+            croak("Cannot call ->update after ->unregister has been called!");
+        }
+
+        my $host = "127.0.0.1";
+
+        my $guard = Test::TCP->new(
+            host => $host,
+            code => $app,
+            port => Cassandane::PortManager::alloc(),
+        );
+
+        my $port = $guard->port;
+
+        $self->{url} = "http://$host:$port/";
+        $self->{_guard} = $guard;
+    } else {
+        $self->_guard->{code} = $app;
+
+        $self->_guard->stop;
+        $self->_guard->start;
+    }
+
+    return;
+}
+
+1;

--- a/cassandane/doc/README.deps
+++ b/cassandane/doc/README.deps
@@ -2,6 +2,12 @@ SOFTWARE DEPENDENCIES
 
 Cassandane needs the following software to work:
 
+ * LWP::UserAgent
+ * Plack
+ * Test::TCP
+   Used for standing up local test HTTP servers for testing various bits of
+   Cyrus callout capabilities
+
  * Mail::IMAPTalk
     This is a fully featured IMAP client package, available on CPAN.
 


### PR DESCRIPTION
…P servers

See t/new-test-url.t for more examples, but basically this let's you:

    my $server = $self->new_test_url("some string response");

    # Now $server->url contains an http://... url to a running service
    # that will respond to HTTP requests

You can also have the http service running custom code (which is a Plack
application):

    my $server = $self->new_test_url(sub {
      my $env = shift;

      my $req = Plack::Request->new($env);

      # ...

      return [
        200,
        [ "Content-Type" => "text/plain" ],
        [ "The body" ],
      ];
    });

You may also update the responses:

    $server->update("new response");

... which does this by stopping/restarting the service with the new code.

These servers automatically go away when the object goes out of scope.
Alternatively, you can call $server->unregister to end them.