### PR TITLE
sqldb_rollbackl() fix

### DIFF
--- a/lib/sqldb.c
+++ b/lib/sqldb.c
@@ -483,6 +483,8 @@ EXPORTED int sqldb_commit(sqldb_t *open, const char *name)
 
 EXPORTED int sqldb_rollback(sqldb_t *open, const char *name)
 {
+    if (!open->writelock) return 0;
+
     assert(open->trans.count);
     char *prev = strarray_pop(&open->trans);
     if (name) assert(!strcmp(prev, name));


### PR DESCRIPTION
We had a httpd crasher via assert() in mailbox_open_webdav() -> webdav_abort() -> sqldb_rollback(), presumably because we failed to obtain a writelock and therefore didn't execute a SAVEPOINT command.  This patch bails out of sqldb_rollback() entirely if we don't have a writelock, because we can't have a transaction without one.