### PR TITLE
mboxlist: don't truncate over-long mailbox names

### DIFF
--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -2139,4 +2139,31 @@ sub test_splitbrain_different_uniqueid_used
     $self->assert_str_equals($mid, $rid);
 }
 
+sub test_delete_longname
+    :AllowMoves :Replication :SyncLog :DelayedDelete :min_version_3_3
+{
+    my ($self) = @_;
+
+    my $mtalk = $self->{master_store}->get_client();
+
+    #define MAX_MAILBOX_NAME 490
+    my $name = "INBOX.this is a really long name 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1.2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2.3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3.foo";
+    my ($success) = $mtalk->create($name);
+    die "Failed to create" unless $success;
+
+    # replicate and check initial state
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+
+    # reconnect
+    $mtalk = $self->{master_store}->get_client();
+
+    $mtalk->delete($name);
+
+    $self->run_replication(rolling => 1, inputfile => $synclogfname) if -f $synclogfname;
+
+    $self->check_replication('cassandane');
+}
+
 1;

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -57,8 +57,9 @@
 #include "seqset.h"
 #include "util.h"
 
-#define MAX_MAILBOX_NAME 490
+#define MAX_MAILBOX_CREATENAME 490
 /* enough space for all possible rewrites and DELETED.* and stuff */
+#define MAX_MAILBOX_NAME 510
 #define MAX_MAILBOX_BUFFER 1024
 #define MAX_MAILBOX_PATH 4096
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2494,7 +2494,7 @@ static int renamecheck(const mbentry_t *mbentry, void *rock)
 
     text->found++;
 
-    if((text->nl + strlen(mbentry->name + text->ol)) >= MAX_MAILBOX_NAME)
+    if((text->nl + strlen(mbentry->name + text->ol)) >= MAX_MAILBOX_CREATENAME)
         return IMAP_MAILBOX_BADNAME;
 
     strcpy(text->newname + text->nl, mbentry->name + text->ol);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1819,7 +1819,7 @@ EXPORTED int mboxname_policycheck(const char *name)
     if (mboxname_isdeletedmailbox(name, NULL))
         return 0;
 
-    if (namelen > MAX_MAILBOX_NAME)
+    if (namelen > MAX_MAILBOX_CREATENAME)
         return IMAP_MAILBOX_BADNAME;
 
     /* find the virtual domain, if any.  We don't sanity check domain


### PR DESCRIPTION
This fixes a crash where mailbox opens correctly, but the name in the mbentry doesn't match the name in the mailbox then when we close the mailbox, we can't find the listitem.