### PR TITLE
Ensure manpages for optional features are always included in release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1680,18 +1680,18 @@ dist_man8_MANS += \
 	man/httpd.8
 endif # HTTPD
 
-if BENCH
-check_PROGRAMS += bench/cyrdbbench
-bench_cyrdbbench_SOURCES = bench/cyrdbbench.c imap/mutex_fake.c
-bench_cyrdbbench_LDADD = $(LD_BASIC_ADD)
-endif # BENCH
-
 if REPLICATION
 dist_man8_MANS += \
 	man/sync_client.8 \
 	man/sync_reset.8 \
 	man/sync_server.8
-endif
+endif # REPLICATION
+
+if BENCH
+check_PROGRAMS += bench/cyrdbbench
+bench_cyrdbbench_SOURCES = bench/cyrdbbench.c imap/mutex_fake.c
+bench_cyrdbbench_LDADD = $(LD_BASIC_ADD)
+endif # BENCH
 
 master_master_SOURCES = \
 	master/master.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1687,6 +1687,19 @@ dist_man8_MANS += \
 	man/sync_server.8
 endif # REPLICATION
 
+if MAINTAINER_MODE
+## make sure feature-dependent man pages are included in distribution
+dist_man8_MANS += \
+	man/ctl_zoneinfo.8 \
+	man/fetchnews.8 \
+	man/httpd.8 \
+	man/nntpd.8 \
+	man/squatter.8 \
+	man/sync_client.8 \
+	man/sync_reset.8 \
+	man/sync_server.8
+endif # MAINTAINER_MODE
+
 if BENCH
 check_PROGRAMS += bench/cyrdbbench
 bench_cyrdbbench_SOURCES = bench/cyrdbbench.c imap/mutex_fake.c


### PR DESCRIPTION
Turns out (#3843) our release tarballs have not included man pages for fetchnews, nntpd, and some others, because they're for "optional" features, and when making a release we don't turn on or off the optional features, because we're not building any code and the distribution shouldn't depend on them...

This change makes sure that in maintainer mode (used for releases) the man pages for these features are included in the release tarball, regardless of whether the feature has been "enabled" or not.

When an end user extracts the tarball and runs configure themselves (not in maintainer mode), the pre-generated man pages will be present, ready to be installed if the feature they're for has been enabled.

We plan to make most of these optional features non-optional sooner or later, but right now I'm fixing the bug as it exists.

This will be backported to the various older branches too.