### PR TITLE
backend: update backend_version for 3.6 and 3.7

### DIFF
--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -340,7 +340,7 @@ static void test_backend_version(void)
         { "Cyrus IMAP 3.4.8", 17 },
         { "Cyrus IMAP 3.4.9", 17 },
 
-        /* 3.5 supported 17..?? but we don't bother detecting that microscopically */
+        /* 3.5 had just one */
         { "Cyrus IMAP 3.5.0", 17 },
         { "Cyrus IMAP 3.5.1", 17 },
         { "Cyrus IMAP 3.5.2", 17 },
@@ -351,6 +351,30 @@ static void test_backend_version(void)
         { "Cyrus IMAP 3.5.7", 17 },
         { "Cyrus IMAP 3.5.8", 17 },
         { "Cyrus IMAP 3.5.9", 17 },
+
+        /* 3.6 had just one */
+        { "Cyrus IMAP 3.6.0", 17 },
+        { "Cyrus IMAP 3.6.1", 17 },
+        { "Cyrus IMAP 3.6.2", 17 },
+        { "Cyrus IMAP 3.6.3", 17 },
+        { "Cyrus IMAP 3.6.4", 17 },
+        { "Cyrus IMAP 3.6.5", 17 },
+        { "Cyrus IMAP 3.6.6", 17 },
+        { "Cyrus IMAP 3.6.7", 17 },
+        { "Cyrus IMAP 3.6.8", 17 },
+        { "Cyrus IMAP 3.6.9", 17 },
+
+        /* 3.7 supported 17..?? but we don't bother detecting that microscopically */
+        { "Cyrus IMAP 3.7.0", 17 },
+        { "Cyrus IMAP 3.7.1", 17 },
+        { "Cyrus IMAP 3.7.2", 17 },
+        { "Cyrus IMAP 3.7.3", 17 },
+        { "Cyrus IMAP 3.7.4", 17 },
+        { "Cyrus IMAP 3.7.5", 17 },
+        { "Cyrus IMAP 3.7.6", 17 },
+        { "Cyrus IMAP 3.7.7", 17 },
+        { "Cyrus IMAP 3.7.8", 17 },
+        { "Cyrus IMAP 3.7.9", 17 },
     };
 
     default_conditions();

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -1306,12 +1306,23 @@ EXPORTED int backend_version(struct backend *be)
      * In 3.2 and earlier, this function lives in imapd.c
      */
 
-    /* It's like looking in the mirror and not suffering from schizophrenia */
+    /* identical banner? identical version! */
     if (strstr(be->banner, CYRUS_VERSION)) {
         return MAILBOX_MINOR_VERSION;
     }
 
-    /* unstable 3.5 series ranges from 17..?? */
+    /* unstable 3.7 series ranges from 17..?? */
+    if (strstr(be->banner, "Cyrus IMAP 3.7")) {
+        /* all versions of 3.7 support at least this version */
+        return 17;
+    }
+
+    /* version 3.6 is 17 */
+    if (strstr(be->banner, "Cyrus IMAP 3.6")) {
+        return 17;
+    }
+
+    /* unstable 3.5 series is 17 */
     if (strstr(be->banner, "Cyrus IMAP 3.5")) {
         /* all versions of 3.5 support at least this version */
         return 17;


### PR DESCRIPTION
So XFER between versions can recognise the new versions.

This will be cherry-picked to 3.6 and also backported to the older release branches (as far back as 2.4).