### PR TITLE
imapoptions: document requirements when changing delete_mode

### DIFF
--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -834,6 +834,10 @@ Blank lines and lines beginning with ``#'' are ignored.
 .PP
     In \fIimmediate\fR mode, the mailbox is removed from the filesystem
     immediately.
+.PP
+    If planning to switch from \fIdelayed\fR mode to \fIimmediate\fR
+    mode, you should first clean up any previously-deleted mailboxes
+    using \fBcyr_expire(8)\fR.
 */
 
 { "delete_unsubscribe", 0, SWITCH, "3.0.0" }


### PR DESCRIPTION
This came up in #3874.  If you have `delete_mode: immediate` but you _used to have_ `delete_mode: delayed`, and you still have previously-deleted mailboxes lying around under deletedprefix, cyr_expire won't clean them up because it doesn't expect them to exist.  Probably most other things either ignore them or are confused by them.

Draft for now, there's some cass tests I'd like to have (or check if we already have), and maybe a safety patch or two.  It'd be nice to prevent creations under deletedprefix in immediate mode, for example -- which we might already do, I haven't looked.  If it's already prevented, then it might be safe for cyr_expire to clean up even in immediate mode