### PR TITLE
Squatter: Don't crash on assert() in lib/cyrusdb_twoskip.c:fetch()->assert(keylen)

### DIFF
--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -427,8 +427,13 @@ static void expand_mboxnames(strarray_t *sa, int nmboxnames,
         else {
             /* Translate any separators in mailboxname */
             char *intname = mboxname_from_external(mboxnames[i], &squat_namespace, NULL);
-            int flags = recursive_flag ? 0 : MBOXTREE_SKIP_CHILDREN;
-            mboxlist_mboxtree(intname, addmbox, sa, flags);
+            if (!intname || *intname == '\0') {
+                fprintf(stderr, "Mailbox %s: %s\n",
+                        mboxnames[i], error_message(IMAP_MAILBOX_BADNAME));
+            } else {
+                int flags = recursive_flag ? 0 : MBOXTREE_SKIP_CHILDREN;
+                mboxlist_mboxtree(intname, addmbox, sa, flags);
+            }
             free(intname);
         }
 


### PR DESCRIPTION
This checks return value from mboxname_from_external() and if it is NULL
or empty string, just inform about the invalid mailbox name instead of
crashing.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1911689