### PR TITLE
VALARM absolute trigger fix

### DIFF
--- a/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
@@ -235,6 +235,77 @@ EOF
     $self->assert_alarms({summary => 'Simple', start => $start, timezone => 'Australia/Sydney'});
 }
 
+sub test_recurring_absolute_trigger
+    :min_version_3_7 :needs_component_calalarmd
+{
+    my ($self) = @_;
+
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $now = DateTime->now();
+    $now->set_time_zone('Australia/Sydney');
+    # bump everything forward so a slow run (say: valgrind)
+    # doesn't cause things to magically fire...
+    $now->add(DateTime::Duration->new(seconds => 300));
+
+    # define the event to start in a few seconds
+    my $startdt = $now->clone();
+    $startdt->add(DateTime::Duration->new(seconds => 2));
+    my $start = $startdt->strftime('%Y%m%dT%H%M%SZ');
+
+    my $enddt = $startdt->clone();
+    $enddt->add(DateTime::Duration->new(seconds => 15));
+    my $end = $enddt->strftime('%Y%m%dT%H%M%SZ');
+
+    # set the trigger to notify us at the start of the event
+    my $triggerdt = $startdt->clone();
+    $triggerdt->add(DateTime::Duration->new(hours => -11));
+    my $trigger = $triggerdt->strftime('%Y%m%dT%H%M%SZ');
+
+    my $uuid = "574E2CD0-2D2A-4554-8B63-C7504481D3A9";
+    my $href = "$CalendarId/$uuid.ics";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:574E2CD0-2D2A-4554-8B63-C7504481D3A9
+DTEND:$end
+TRANSP:OPAQUE
+SUMMARY:Simple
+DTSTART:$start
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+RRULE:FREQ=DAILY
+BEGIN:VALARM
+TRIGGER;VALUE=DATE-TIME:$trigger
+ACTION:DISPLAY
+SUMMARY: My alarm
+DESCRIPTION:My alarm has triggered
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $CalDAV->Request('PUT', $href, $card, 'Content-Type' => 'text/calendar');
+
+    # clean notification cache
+    $self->{instance}->getnotify();
+
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() - 60 );
+
+    $self->assert_alarms();
+
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 60 );
+
+    $self->assert_alarms({summary => 'Simple', start => $start});
+}
+
 sub test_simple_reconstruct
     :min_version_3_0 :needs_component_calalarmd
 {

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -476,7 +476,8 @@ static int process_alarm_cb(icalcomponent *comp, icaltimetype start,
         /* XXX validate trigger */
 
         icaltimetype alarmtime = icaltime_null_time();
-        if (icalvalue_isa(val) == ICAL_DURATION_VALUE) {
+        unsigned is_duration = (icalvalue_isa(val) == ICAL_DURATION_VALUE);
+        if (is_duration) {
             icalparameter *param =
                 icalproperty_get_first_parameter(prop, ICAL_RELATED_PARAMETER);
             icaltimetype base = start;
@@ -534,6 +535,12 @@ static int process_alarm_cb(icalcomponent *comp, icaltimetype start,
             time_t next = data->now + 86400*30;
             if (!data->nextcheck || next < data->nextcheck)
                 data->nextcheck = next;
+            return 0;
+        }
+        else if (!is_duration) {
+            /* alarms with absolute triggers can only fire once,
+               so stop recurrence expansion */
+            syslog(LOG_DEBUG, "XXX  absolute trigger - stop recurrence expansion");
             return 0;
         }
     }


### PR DESCRIPTION
calalarmd would spin on a non-terminating recurring event  having an alarm with an absolute trigger, because we would never hit the exit clause (an alarm more than 2 months in the future)

E.g.:

BEGIN:VTODO
CREATED:20211011T104314Z
DTSTAMP:20220201T203307Z
DTSTART;TZID=America/Toronto:20220202T113000
DUE;TZID=America/Toronto:20220202T113000
LAST-MODIFIED:20220201T203257Z
RRULE:FREQ=DAILY
STATUS:NEEDS-ACTION
SUMMARY:D3 pill
UID:8F8917BD-0DD4-4B7B-9245-AF8BBC42E493
X-APPLE-SORT-ORDER:3
BEGIN:VALARM
ACTION:DISPLAY
DESCRIPTION:Reminder
TRIGGER;VALUE=DATE-TIME:20220202T163000Z
UID:C9C19C74-EA8E-4A22-8BD2-C68C970644E0
X-WR-ALARMUID:C9C19C74-EA8E-4A22-8BD2-C68C970644E0
END:VALARM
END:VTODO
