### PR TITLE
caldav_db: update jscal_objs table records also if 'alive' changed

### DIFF
--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -1037,7 +1037,8 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
         int cmp = strcmp(old_jscal->ical_recurid, new_jscal->ical_recurid);
 
         if (!cmp) {
-            if (strcmp(old_jscal->ical_guid, new_jscal->ical_guid)) {
+            if (strcmp(old_jscal->ical_guid, new_jscal->ical_guid) ||
+                old_jscal->alive != new_jscal->alive) {
                 // instance or main event got updated
                 ptrarray_append(&update, new_jscal);
             }


### PR DESCRIPTION
If Cyrus replicates a calendar event, if first marks the existing
ical_objs entry as expunged, setting alive to 0. This alive status
propagates into the jscal_objs table.

Later on, the jscal_objs handling code only updates an existing
jscal_objs entry, if the contents of the iCalendar data changed.
This caused replication to leave standalone instance entries in
that table as not alive, when on the main store they are alive.