### PR TITLE
caldav_db: resolve duplicate recurrence ids conflicts

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -17687,4 +17687,54 @@ EOF
     $self->assert_deep_equals($locations, $res->[0][1]{list}[0]{locations});
 }
 
+sub test_calendarevent_get_duplicate_recurrence_ids
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.9.5//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+RECURRENCE-ID;TZID=America/New_York:20210101T060000
+DTSTART;TZID=Europe/Berlin:20210101T120000
+DURATION:PT1H
+UID:2a358cee-6489-4f14-a57f-c104db4dc357
+DTSTAMP:20150928T132434Z
+CREATED:20150928T125212Z
+SUMMARY:instance1
+SEQUENCE:0
+LAST-MODIFIED:20150928T132434Z
+END:VEVENT
+BEGIN:VEVENT
+RECURRENCE-ID;TZID=America/New_York:20210101T060000
+DTSTART;TZID=Europe/Berlin:20210101T120000
+DURATION:PT1H
+UID:2a358cee-6489-4f14-a57f-c104db4dc357
+DTSTAMP:20150928T132434Z
+CREATED:20150928T125212Z
+SUMMARY:instance2
+SEQUENCE:0
+LAST-MODIFIED:20150928T132434Z
+END:VEVENT
+END:VCALENDAR
+EOF
+    $caldav->Request('PUT', 'Default/test.ics', $ical,
+        'Content-Type' => 'text/calendar');
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            properties => ['title', 'recurrenceId']
+        }, 'R1'],
+    ]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
+    $self->assert_str_equals('instance1', $res->[0][1]{list}[0]{title});
+    $self->assert_str_equals('2021-01-01T06:00:00',
+        $res->[0][1]{list}[0]{recurrenceId});
+}
+
 1;

--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -53,6 +53,7 @@
 #include "caldav_db.h"
 #include "cyrusdb.h"
 #include "dynarray.h"
+#include "hashset.h"
 #include "httpd.h"
 #include "http_dav.h"
 #include "ical_support.h"
@@ -680,15 +681,23 @@ static void check_mattach_cb(icalcomponent *comp, void *rock)
 }
 
 
-#define CMD_INSERT_JSCALOBJS                                            \
+#define CMD_UPSERT_JSCALOBJS                                            \
     "INSERT INTO jscal_objs ("                                          \
     "  rowid, ical_recurid, alive, modseq, createdmodseq,"              \
     "  dtstart, dtend, ical_guid )"                                     \
     " VALUES ("                                                         \
     "  :rowid, :ical_recurid, :alive, :modseq, :createdmodseq,"         \
-    "  :dtstart, :dtend, :ical_guid );"
+    "  :dtstart, :dtend, :ical_guid )"                                  \
+    " ON CONFLICT (rowid, ical_recurid) DO"                             \
+    " UPDATE SET"                                                       \
+    "  alive        = :alive,"                                          \
+    "  modseq       = :modseq,"                                         \
+    "  createdmodseq = :createdmodseq,"                                 \
+    "  dtstart      = :dtstart,"                                        \
+    "  dtend        = :dtend,"                                          \
+    "  ical_guid    = :ical_guid;"                                      \
 
-static int caldav_insert_jscal(struct caldav_db *caldavdb,
+static int caldav_upsert_jscal(struct caldav_db *caldavdb,
                                  struct caldav_jscal *jscal)
 {
     struct sqldb_bindval bvalinst[] = {
@@ -702,34 +711,7 @@ static int caldav_insert_jscal(struct caldav_db *caldavdb,
         { ":ical_guid",     SQLITE_TEXT,     { .s = jscal->ical_guid } },
         { NULL,             SQLITE_NULL,     { .s = NULL } } };
 
-    return sqldb_exec(caldavdb->db, CMD_INSERT_JSCALOBJS, bvalinst, NULL, NULL);
-}
-
-#define CMD_UPDATE_JSCALOBJS            \
-    "UPDATE jscal_objs SET"             \
-    "  alive        = :alive,"          \
-    "  modseq       = :modseq,"         \
-    "  createdmodseq = :createdmodseq," \
-    "  dtstart      = :dtstart,"        \
-    "  dtend        = :dtend,"          \
-    "  ical_guid    = :ical_guid"       \
-    " WHERE rowid = :rowid AND ical_recurid = :ical_recurid;"
-
-static int caldav_update_jscal(struct caldav_db *caldavdb,
-                                 struct caldav_jscal *jscal)
-{
-    struct sqldb_bindval bvalinst[] = {
-        { ":rowid",         SQLITE_INTEGER,  { .i = jscal->cdata.dav.rowid } },
-        { ":ical_recurid",  SQLITE_TEXT,     { .s = jscal->ical_recurid } },
-        { ":alive",         SQLITE_INTEGER,  { .i = jscal->alive } },
-        { ":modseq",        SQLITE_INTEGER,  { .i = jscal->modseq  } },
-        { ":createdmodseq", SQLITE_INTEGER,  { .i = jscal->createdmodseq } },
-        { ":dtstart",       SQLITE_TEXT,     { .s = jscal->dtstart } },
-        { ":dtend",         SQLITE_TEXT,     { .s = jscal->dtend } },
-        { ":ical_guid",     SQLITE_TEXT,     { .s = jscal->ical_guid } },
-        { NULL,             SQLITE_NULL,     { .s = NULL } } };
-
-    return sqldb_exec(caldavdb->db, CMD_UPDATE_JSCALOBJS, bvalinst, NULL, NULL);
+    return sqldb_exec(caldavdb->db, CMD_UPSERT_JSCALOBJS, bvalinst, NULL, NULL);
 }
 
 #define CMD_SELJSCALOBJS                                          \
@@ -970,6 +952,7 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
     if (r) goto done;
 
     /* Determine new JMAP objects, ordered ascending by recurid */
+    struct hashset *seen_recurids = hashset_new(sizeof(struct icaltimetype));
     icalcomponent_kind kind;
     for (comp = icalcomponent_get_first_real_component(ical);
          comp;
@@ -1003,8 +986,16 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
         }
 
         /* Found recurrence instance */
-        if (!utc) utc = icaltimezone_get_utc_timezone();
         icaltimetype recurid = icalproperty_get_recurrenceid(prop);
+
+        /* Resolve duplicate recurrence ids by picking the first */
+        icaltimetype hash_recurid = recurid;
+        hash_recurid.zone = NULL; // don't hash timezone pointers
+        if (!hashset_add(seen_recurids, &hash_recurid)) {
+            continue;
+        }
+
+        if (!utc) utc = icaltimezone_get_utc_timezone();
         icaltimetype dtstart = icalcomponent_get_dtstart(comp);
         dtstart = icaltime_convert_to_zone(dtstart, utc);
         icaltimetype dtend = icalcomponent_get_dtend(comp);
@@ -1022,12 +1013,12 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
         };
         dynarray_append(&new_jscals, &jscal);
     }
+    hashset_free(&seen_recurids);
     qsort(new_jscals.data, new_jscals.count,
             sizeof(struct caldav_jscal), jscal_cmp_ical_recurid);
 
     /* Determine which rows to insert and update. We never delete here. */
-    ptrarray_t update = PTRARRAY_INITIALIZER;
-    ptrarray_t insert = PTRARRAY_INITIALIZER;
+    ptrarray_t upsert = PTRARRAY_INITIALIZER;
     int old_i = 0;
     int new_i = 0;
     while (old_i < dynarray_size(&old_jscals) &&
@@ -1039,7 +1030,7 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
         if (!cmp) {
             if (strcmp(old_jscal->ical_guid, new_jscal->ical_guid)) {
                 // instance or main event got updated
-                ptrarray_append(&update, new_jscal);
+                ptrarray_append(&upsert, new_jscal);
             }
             old_i++;
             new_i++;
@@ -1048,7 +1039,7 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
 
         if (!new_jscal->ical_recurid[0]) {
             // old standalone instances got replaced with main event
-            ptrarray_append(&insert, new_jscal);
+            ptrarray_append(&upsert, new_jscal);
             new_i++;
         }
         else if (cmp < 0) {
@@ -1056,47 +1047,44 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
             if (old_jscal->alive) {
                 old_jscal->alive = 0;
                 old_jscal->modseq = cdata->dav.modseq;
-                ptrarray_append(&update, old_jscal);
+                ptrarray_append(&upsert, old_jscal);
             }
             old_i++;
         }
         else {
             // new standalone instance got added
             new_jscal->createdmodseq = cdata->dav.modseq;
-            ptrarray_append(&insert, new_jscal);
+            ptrarray_append(&upsert, new_jscal);
             new_i++;
         }
     }
     for ( ; old_i < dynarray_size(&old_jscals); old_i++) {
+        // any old entry for which no new entry exists is not alive
         struct caldav_jscal *old_jscal = dynarray_nth(&old_jscals, old_i);
         if (old_jscal->alive) {
             old_jscal->alive = 0;
             old_jscal->modseq = cdata->dav.modseq;
-            ptrarray_append(&update, old_jscal);
+            ptrarray_append(&upsert, old_jscal);
         }
     }
     for ( ; new_i < dynarray_size(&new_jscals); new_i++) {
+        // any new entry for which no old entry exists it newly created
         struct caldav_jscal *new_jscal = dynarray_nth(&new_jscals, new_i);
         new_jscal->createdmodseq = cdata->dav.modseq;
-        ptrarray_append(&insert, new_jscal);
+        ptrarray_append(&upsert, new_jscal);
     }
 
     /* Write changes */
     int i;
-    for (i = 0; i < ptrarray_size(&insert); i++) {
-        r = caldav_insert_jscal(caldavdb, ptrarray_nth(&insert, i));
-        if (r) goto done;
-    }
-    for (i = 0; i < ptrarray_size(&update); i++) {
-        r = caldav_update_jscal(caldavdb, ptrarray_nth(&update, i));
+    for (i = 0; i < ptrarray_size(&upsert); i++) {
+        r = caldav_upsert_jscal(caldavdb, ptrarray_nth(&upsert, i));
         if (r) goto done;
     }
 
 done:
     dynarray_fini(&old_jscals);
     dynarray_fini(&new_jscals);
-    ptrarray_fini(&insert);
-    ptrarray_fini(&update);
+    ptrarray_fini(&upsert);
     strarray_fini(&strpool);
     return r;
 }


### PR DESCRIPTION
iCalendar allows multiple calendar objects with the same
recurrence id embedded within a VCALENDAR. But for JMAP
Calendars these duplicates are not allowed and cause the
jscal_objs table to raise a conflict.

Resolve such write conflicts by ignoring all but the first
recurrence id for all duplicate entries.

In order to gracefully handle any existing database entries,
use UPSERT rather than INSERT or UPDATE.