### PR TITLE
Revert "jmap_calendar: add MBTYPE_JMAPNOTIFICATION"

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -225,9 +225,6 @@ EXPORTED const char *mboxlist_mbtype_to_string(uint32_t mbtype)
     case MBTYPE_ADDRESSBOOK:
         buf_putc(&buf, 'a');
         break;
-    case MBTYPE_JMAPNOTIFY:
-        buf_putc(&buf, 'j');
-        break;
     case MBTYPE_JMAPSUBMIT:
         buf_putc(&buf, 's');
         break;
@@ -468,9 +465,6 @@ EXPORTED uint32_t mboxlist_string_to_mbtype(const char *string)
         break;
     case 'e':
         mbtype = MBTYPE_EMAIL;
-        break;
-    case 'j':
-        mbtype = MBTYPE_JMAPNOTIFY;
         break;
     case 'n':
         mbtype = MBTYPE_NETNEWS;

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -65,7 +65,6 @@
 #define MBTYPE_NETNEWS      0x1    /* Netnews Mailbox - NO LONGER USED */
 #define MBTYPE_JMAPSUBMIT   0x2    /* JMAP Mail Submission Mailbox */
 #define MBTYPE_JMAPPUSHSUB  0x3    /* JMAP Push Subscriptions */
-#define MBTYPE_JMAPNOTIFY   0x4    /* JMAP Notifications */
 #define MBTYPE_SIEVE        0x5    /* Sieve Script Mailbox */
 
 #define MBTYPE_COLLECTION   0x8    /* WebDAV Collection Mailbox */

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1576,25 +1576,6 @@ EXPORTED int mboxname_isdavnotificationsmailbox(const char *name, int mbtype)
 }
 
 /*
- * If (internal) mailbox 'name' is a JMAPNOTIFICATIONS mailbox
- * returns boolean
- */
-EXPORTED int mboxname_isjmapnotificationsmailbox(const char *name, int mbtype)
-{
-    if (mbtype_isa(mbtype) == MBTYPE_JMAPNOTIFY) return 1;  /* Only works on backends */
-    int res = 0;
-
-    mbname_t *mbname = mbname_from_intname(name);
-    const strarray_t *boxes = mbname_boxes(mbname);
-    const char *prefix = config_getstring(IMAPOPT_JMAPNOTIFICATIONFOLDER);
-    if (strarray_size(boxes) && !strcmpsafe(prefix, strarray_nth(boxes, 0)))
-        res = 1;
-
-    mbname_free(&mbname);
-    return res;
-}
-
-/*
  * If (internal) mailbox 'name' is a user's "Notes" mailbox
  * returns boolean
  */
@@ -3083,14 +3064,6 @@ static modseq_t mboxname_domodseq(const char *fname,
             foldersmodseqp = isdelete ?
                 &counters.davnotificationfoldersdeletedmodseq :
                 &counters.davnotificationfoldersmodseq;
-        }
-        else if (mboxname_isjmapnotificationsmailbox(mboxname, mbtype)) {
-            typemodseqp = isdelete ?
-                &counters.jmapnotificationdeletedmodseq :
-                &counters.jmapnotificationmodseq;
-            foldersmodseqp = isdelete ?
-                &counters.jmapnotificationfoldersdeletedmodseq :
-                &counters.jmapnotificationfoldersmodseq;
         }
         else if (mboxname_issievemailbox(mboxname, mbtype)) {
             typemodseqp = isdelete ?

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -207,12 +207,6 @@ int mboxname_ispushsubscriptionmailbox(const char *name, int mbtype);
 int mboxname_isjmapuploadmailbox(const char *name, int mbtype);
 
 /*
- * If (internal) mailbox 'name' is a user's #jmap notifications mailbox
- * returns boolean
- */
-int mboxname_isjmapnotificationsmailbox(const char *name, int mbtype);
-
-/*
  * If (internal) mailbox 'name' is a user's #sieve mailbox
  * returns boolean
  */
@@ -226,7 +220,6 @@ int mboxname_issievemailbox(const char *name, int mbtype);
      || mboxname_issubmissionmailbox(name, mbtype)         \
      || mboxname_ispushsubscriptionmailbox(name, mbtype)   \
      || mboxname_isjmapuploadmailbox(name, mbtype)         \
-     || mboxname_isjmapnotificationsmailbox(name, mbtype)  \
      || mboxname_issievemailbox(name, mbtype))
 
 #define mboxname_isnondeliverymailbox(name, mbtype)        \

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1318,9 +1318,6 @@ Blank lines and lines beginning with ``#'' are ignored.
 { "jmappushsubscriptionfolder", "#jmappushsubscription", STRING, "3.1.8" }
 /* the name of the folder for JMAP Push Subscriptions (#jmappushsubscription) */
 
-{ "jmapnotificationfolder", "#jmapnotification", STRING, "3.3.0" }
-/* the name of the folder for JMAP notifications (#jmapnotification) */
-
 { "iolog", 0, SWITCH, "2.5.0" }
 /* Should cyrus output I/O log entries */
 


### PR DESCRIPTION
It only was committed on the main branch for integration testing.

This reverts commit 92a22afbe7073ba0481e07a5b4f758a021e82a3f.

Signed-off-by: Robert Stepanek <rsto@fastmailteam.com>