### PR TITLE
Do not reject updates on CalendarEvent standalone instances with floating time

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -17837,4 +17837,69 @@ EOF
     $self->assert_not_null($res->[0][1]{list}[0]{recurrenceOverrides}{'1996-09-23T14:30:00'});
 }
 
+sub test_calendarevent_set_standalone_instance_floatingtz
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Fastmail/2020.5/EN
+BEGIN:VEVENT
+CATEGORIES:CONFERENCE
+DESCRIPTION:Be there or be square
+DTSTAMP:19960704T120000Z
+DTSTART:19960919T143000
+DURATION:PT1H
+RECURRENCE-ID:19960919T143000
+SEQUENCE:0
+SUMMARY:Partyx
+TRANSP:OPAQUE
+UID:889i-uid1@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+    $caldav->Request('PUT',
+        '/dav/calendars/user/cassandane/Default/test.ics',
+        $ical, 'Content-Type' => 'text/calendar');
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            properties => [
+                'recurrenceId',
+                'recurrenceIdTimeZone',
+            ],
+        }, 'R1'],
+    ]);
+    $self->assert_not_null($res->[0][1]{list}[0]{recurrenceId});
+    $self->assert_null($res->[0][1]{list}[0]{recurrenceIdTimeZone});
+    my $eventId = $res->[0][1]{list}[0]{id};
+
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    title => 'xxx',
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            properties => [
+                'recurrenceId',
+                'recurrenceIdTimeZone'],
+        }, 'R1'],
+    ]);
+    $self->assert_not_null($res->[0][1]{list}[0]{recurrenceId});
+    $self->assert_null($res->[0][1]{list}[0]{recurrenceIdTimeZone});
+}
+
+
 1;

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -4057,7 +4057,7 @@ startend_to_ical(icalcomponent *comp, struct jmap_parser *parser,
         return;
 
     /* Check sanity of recurrence properties */
-    if (JNOTNULL(json_object_get(event, "recurrenceId")) !=
+    if (JNULL(json_object_get(event, "recurrenceId")) &&
         JNOTNULL(json_object_get(event, "recurrenceIdTimeZone"))) {
         jmap_parser_invalid(parser, "recurrenceId");
         jmap_parser_invalid(parser, "recurrenceIdTimeZone");

--- a/imap/json_support.h
+++ b/imap/json_support.h
@@ -51,6 +51,7 @@
 #include "util.h"
 
 #define JNOTNULL(item)          ((item) ? (json_is_null(item) == 0) : 0)
+#define JNULL(item)             ((item) ? (json_is_null(item)) : 1)
 
 /* jansson replacement functions for those missing in older versions */
 


### PR DESCRIPTION
RFC 8984 states at [4.3.2. ](https://www.rfc-editor.org/rfc/rfc8984.html#section-4.3.2)[recurrenceIdTimeZone](https://www.rfc-editor.org/rfc/rfc8984.html#name-recurrenceidtimezone)
```
Type: TimeZoneId|null (optional, default: null)
[...] This property MUST be set if the recurrenceId property is set. [...]
```
But that's wrong for floating time events.