### PR TITLE
JMAPCalendars: fix rscale_in_jmap_hidden_in_caldav

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -6470,7 +6470,7 @@ sub test_rscale_in_jmap_hidden_in_caldav
             count => 12,
             frequency => 'monthly',
         },
-        $events->[0]->{recurrenceRules},
+        $events->[0]->{recurrenceRule},
     );
 }
 


### PR DESCRIPTION
Looks like the recurrenceRule->recurrenceRules JMAP rename was mistakenly applied to a CalDAV query as well, causing this test to fail