### PR TITLE
Fix Blob/lookup for smart blobs

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -18012,4 +18012,51 @@ sub test_calendarevent_set_itip_preserve_partstat
         $res->[0][1]{list}[0]{participants}{other}{participationStatus});
 }
 
+sub test_calendarevent_blob_lookup
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                event1 => {
+                    calendarIds => {
+                        Default => JSON::true,
+                    },
+                    title => 'event1',
+                    start => '2020-01-01T09:00:00',
+                    timeZone => 'Europe/Vienna',
+                    duration => 'PT1H',
+                },
+            },
+        }, 'R1'],
+    ]);
+    my $eventId = $res->[0][1]{created}{event1}{id};
+    $self->assert_not_null($eventId);
+    my $blobId = $res->[0][1]{created}{event1}{blobId};
+    $self->assert_not_null($blobId);
+
+    $res = $jmap->CallMethods([
+        ['Blob/lookup', {
+            typeNames => [
+                'CalendarEvent',
+            ],
+            ids => [$blobId],
+        }, 'R1'],
+    ], [
+        'urn:ietf:params:jmap:core',
+        'https://cyrusimap.org/ns/jmap/blob',
+    ]);
+    $self->assert_deep_equals([{
+        id => $blobId,
+        matchedIds => {
+            CalendarEvent => [
+                $eventId,
+            ],
+        },
+    }], $res->[0][1]{list});
+}
+
 1;

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -659,7 +659,7 @@ static void _free_found(void *data)
 {
     int i;
     strarray_t *values = data;
-    for (i = 0; i < NUM_DATATYPES; i++) {
+    for (i = 0; i < NUM_DATATYPES + 1; i++) {
         strarray_t *ids = values + i;
         strarray_fini(ids);
     }
@@ -799,7 +799,7 @@ static int jmap_blob_lookup(jmap_req_t *req)
                  * one item for this blobid */
                 strarray_t *values = hash_lookup(getblob->blob_id, &found);
                 if (!values) {
-                    values = xzmalloc(sizeof(strarray_t) * NUM_DATATYPES);
+                    values = xzmalloc(sizeof(strarray_t) * (NUM_DATATYPES + 1));
                     hash_insert(getblob->blob_id, values, &found);
                 }
                 strarray_t *ids = values + i;

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -868,7 +868,9 @@ EXPORTED int jmap_decode_rawdata_blobid(const char *blobid,
     val++;
     char *c = strchr(val, ':');
     if (!c || c == val) goto done;
-    *mboxidptr = xstrndup(val, c - val);
+    if (mboxidptr) {
+        *mboxidptr = xstrndup(val, c - val);
+    }
     val = c + 1;
 
     /* Decode message UID */
@@ -881,7 +883,9 @@ EXPORTED int jmap_decode_rawdata_blobid(const char *blobid,
         val++;
         c = strchr(val, ']');
         if (!c || c == val) goto done;
-        *partidptr = xstrndup(val, c - val);
+        if (partidptr) {
+            *partidptr = xstrndup(val, c - val);
+        }
         val = c + 1;
     }
 
@@ -891,7 +895,9 @@ EXPORTED int jmap_decode_rawdata_blobid(const char *blobid,
         val += 2;
         c = strchr(val, '>');
         if (!c || c == val) goto done;
-        *useridptr = xstrndup(val, c - val);
+        if (useridptr) {
+            *useridptr = xstrndup(val, c - val);
+        }
         val = c + 1;
     }
 
@@ -900,7 +906,9 @@ EXPORTED int jmap_decode_rawdata_blobid(const char *blobid,
         val++;
         c = strchr(val, '[');
         size_t len = c ? (size_t) (c - val) : strlen(val);
-        *subpartptr = xstrndup(val, len);
+        if (subpartptr) {
+            *subpartptr = xstrndup(val, len);
+        }
         val += len;
         /* Decode guid */
         if (val[0] == '[') {
@@ -908,7 +916,9 @@ EXPORTED int jmap_decode_rawdata_blobid(const char *blobid,
             c = strchr(val, ']');
             if (!c || c == val) goto done;
             buf_setmap(&buf, val, c - val);
-            if (!message_guid_decode(guidptr, buf_cstring(&buf))) goto done;
+            if (guidptr) {
+                if (!message_guid_decode(guidptr, buf_cstring(&buf))) goto done;
+            }
             buf_reset(&buf);
             val = c + 1;
         }


### PR DESCRIPTION
A recent change in the blob id parser introduced a null pointer derefence. This patch reverts that regression.

While testing for CalendarEvent, this also revealed an off-by-one error as well as Blob/lookup not returning the latest format for CalendarEvent identifiers.