### PR TITLE
caldav_db.c: initialize upsert ptrarray early

### DIFF
--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -936,6 +936,7 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
     dynarray_init(&old_jscals, sizeof(struct caldav_jscal));
     dynarray_init(&new_jscals, sizeof(struct caldav_jscal));
 
+    ptrarray_t upsert = PTRARRAY_INITIALIZER;
     strarray_t strpool = STRARRAY_INITIALIZER;
     icalcomponent *comp;
     icaltimezone *utc = NULL;
@@ -1018,7 +1019,6 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
             sizeof(struct caldav_jscal), jscal_cmp_ical_recurid);
 
     /* Determine which rows to insert and update. We never delete here. */
-    ptrarray_t upsert = PTRARRAY_INITIALIZER;
     int old_i = 0;
     int new_i = 0;
     while (old_i < dynarray_size(&old_jscals) &&


### PR DESCRIPTION
This fixes a crasher if CMD_SELJSCALOBJS fails and we goto done early