### PR TITLE
jmap_ical: only attempt to open managed attachments mailbox once

### DIFF
--- a/imap/jmap_ical.h
+++ b/imap/jmap_ical.h
@@ -108,6 +108,7 @@ struct jmapical_ctx {
         struct webdav_db *db;
         struct mailbox *mbox;
         int lock;
+        int err;
     } attachments;
     struct {
         char *emailrecipient;


### PR DESCRIPTION
The jmap context attempted to open the managed attachments mailbox
for each ATTACH property, until is succeeded. This can result in
long locks. Now the jmap context remembers if it failed once and
does not attempt to the mailbox anymore.

Signed-off-by: Robert Stepanek <rsto@fastmailteam.com>