### PR TITLE
JMAP Calendars: fix bogus and slow handling of standalone recurrence instances

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -70,7 +70,6 @@ sub new
                  httpmodules => 'carddav caldav jmap',
                  httpallowcompress => 'no',
                  sync_log => 'yes',
-                 icalendar_max_size => 100000,
                  jmap_nonstandard_extensions => 'yes',
                  defaultdomain => 'example.com');
 
@@ -7744,7 +7743,7 @@ EOF
 }
 
 sub test_calendarevent_set_too_large
-    :min_version_3_5 :needs_component_jmap
+    :min_version_3_5 :needs_component_jmap :iCalendarMaxSize10k
 {
     my ($self) = @_;
 
@@ -18122,6 +18121,61 @@ EOF
         }, 'R1'],
     ]);
     $self->assert_num_equals(1, scalar @{$res->[0][1]{created}});
+}
+
+sub test_calendarevent_get_standalone_instances_slow
+    :needs_component_httpd :min_version_3_7
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    my $now = DateTime->now();
+    $now->set_time_zone('Etc/UTC');
+    my $dtstamp = $now->strftime('%Y%m%dT%H%M%SZ');
+    $now->set_time_zone('Australia/Sydney');
+
+    my $n = 700;
+
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+EOF
+
+    for (my $i = 0; $i < $n; $i++) {
+        my $t = $now->clone();
+        $t->add(DateTime::Duration->new(days => $i));
+        my $recurid = $t->strftime('%Y%m%dT%H%M%S');
+
+        $ical .= <<EOF;
+BEGIN:VEVENT
+RECURRENCE-ID;TZID=Australia/Sydney:$recurid
+UID:6de280c9-edff-4019-8ebd-cfebc73f8201
+DURATION:PT1H
+SUMMARY:event$i
+DTSTART;TZID=Australia/Sydney:$recurid
+CREATED:$dtstamp
+DTSTAMP:$dtstamp
+END:VEVENT
+EOF
+    }
+
+    $ical .= <<EOF;
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $caldav->Request('PUT',
+        '/dav/calendars/user/cassandane/Default/test.ics',
+        $ical, 'Content-Type' => 'text/calendar');
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            properties => ['recurrenceId'],
+        }, 'R1'],
+    ]);
+    $self->assert_num_equals($n, scalar @{$res->[0][1]{list}});
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -377,6 +377,9 @@ magic(HttpJWTAuthRSA => sub {
     $self->config_set(http_jwt_key_dir => '@basedir@/conf/certs/http_jwt');
     $self->want('install_certificates');
 });
+magic(iCalendarMaxSize10k => sub {
+    shift->config_set(icalendar_max_size => 100000);
+});
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic

--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -1004,14 +1004,21 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
 
         struct caldav_jscal jscal = {
             .cdata.dav.rowid = cdata->dav.rowid,
-            .ical_recurid = icaltime_as_ical_string(recurid),
-            .dtstart = icaltime_as_ical_string(dtstart),
-            .dtend = icaltime_as_ical_string(dtend),
             .alive = cdata->dav.alive,
             .modseq = cdata->dav.modseq,
             .createdmodseq = cdata->dav.createdmodseq,
             .ical_guid = ical_guid,
         };
+
+        strarray_append(&strpool, icaltime_as_ical_string(recurid));
+        jscal.ical_recurid = strarray_nth(&strpool, -1);
+
+        strarray_append(&strpool, icaltime_as_ical_string(dtstart));
+        jscal.dtstart = strarray_nth(&strpool, -1);
+
+        strarray_append(&strpool, icaltime_as_ical_string(dtend));
+        jscal.dtend = strarray_nth(&strpool, -1);
+
         dynarray_append(&new_jscals, &jscal);
     }
     hashset_free(&seen_recurids);

--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -936,6 +936,7 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
     dynarray_init(&old_jscals, sizeof(struct caldav_jscal));
     dynarray_init(&new_jscals, sizeof(struct caldav_jscal));
 
+    ptrarray_t upsert = PTRARRAY_INITIALIZER;
     strarray_t strpool = STRARRAY_INITIALIZER;
     icalcomponent *comp;
     icaltimezone *utc = NULL;
@@ -1018,7 +1019,6 @@ EXPORTED int caldav_writeical_jmap(struct caldav_db *caldavdb,
             sizeof(struct caldav_jscal), jscal_cmp_ical_recurid);
 
     /* Determine which rows to insert and update. We never delete here. */
-    ptrarray_t upsert = PTRARRAY_INITIALIZER;
     int old_i = 0;
     int new_i = 0;
     while (old_i < dynarray_size(&old_jscals) &&


### PR DESCRIPTION
The commit messages say it all, but in summary:

- large numbers of standalone recurrence instances caused the libical string garbage collector invalidate data when writing to caldav.db. We use a string pool now
- CalendarEvent/get for many standalone instances was unnecessarily slow, because it reopened the same index record lots of times. We cache the last-processed iCalendar data now.