### PR TITLE
jmap_calendar: always use shared calendar owner schedule addresses

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -13898,7 +13898,7 @@ sub test_calendar_set_sharewith_acl
 }
 
 sub test_calendarevent_set_writeown
-    :min_version_3_5 :needs_component_jmap
+    :needs_component_jmap :min_version_0_0 :max_version_0_0
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -16348,7 +16348,7 @@ sub create_user
 }
 
 sub test_calendarevent_set_mayrsvp
-    :min_version_3_5 :needs_component_jmap :JMAPExtensions :NoAltNameSpace
+    :needs_component_jmap :JMAPExtensions :NoAltNameSpace :min_version_0_0 :max_version_0_0
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -16459,7 +16459,7 @@ sub test_calendarevent_set_mayrsvp
 }
 
 sub test_calendarevent_set_mayinviteself
-    :min_version_3_5 :needs_component_jmap :JMAPExtensions :NoAltNameSpace
+    :needs_component_jmap :JMAPExtensions :NoAltNameSpace :min_version_0_0 :max_version_0_0
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -16679,7 +16679,7 @@ sub test_calendarevent_set_mayinviteself
 }
 
 sub test_calendarevent_set_mayinviteothers
-    :min_version_3_5 :needs_component_jmap :JMAPExtensions :NoAltNameSpace
+    :needs_component_jmap :JMAPExtensions :NoAltNameSpace :min_version_0_0 :max_version_0_0
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
@@ -16989,7 +16989,7 @@ sub test_calendarevent_set_mayinvite_preserve_caldav
 }
 
 sub test_calendarevent_set_hideattendees_itip
-    :min_version_3_5 :needs_component_jmap
+    :needs_component_jmap :min_version_0_0 :max_version_0_0
 {
     my ($self) = @_;
 
@@ -17074,7 +17074,7 @@ sub test_calendarevent_set_hideattendees_itip
 }
 
 sub test_calendarevent_set_hideattendees
-    :min_version_3_5 :needs_component_jmap
+    :needs_component_jmap :min_version_0_0 :max_version_0_0
 {
     my ($self) = @_;
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3108,8 +3108,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
         mbname_free(&rock->mbname);
         rock->mbname = mbname_from_intname(rock->mbentry->name);
 
-        const char *sched_userid = caldav_is_secretarymode(rock->mbentry->name) ?
-            req->accountid : req->userid;
+        const char *sched_userid = req->accountid;
         strarray_truncate(&rock->schedule_addresses, 0);
         get_schedule_addresses(NULL, rock->mbentry->name, sched_userid,
                 &rock->schedule_addresses);
@@ -4159,8 +4158,7 @@ static int createevent_lookup_calendar(jmap_req_t *req,
         if (r == IMAP_MAILBOX_NONEXISTENT) r = 0;
     }
     else {
-        create->sched_userid = caldav_is_secretarymode(mboxname) ?
-            req->accountid : req->userid;
+        create->sched_userid = req->accountid;
         get_schedule_addresses(NULL, mboxname, create->sched_userid,
                 &create->schedule_addresses);
     }
@@ -5254,8 +5252,7 @@ static void setcalendarevents_update(jmap_req_t *req,
         else if (r) goto done;
     }
 
-    const char *sched_userid = caldav_is_secretarymode(mailbox_name(mbox)) ?
-        req->accountid : req->userid;
+    const char *sched_userid = req->accountid;
     get_schedule_addresses(NULL, mbentry->name, sched_userid, &schedule_addresses);
 
     if (dstmbentry) {
@@ -5567,8 +5564,7 @@ static int setcalendarevents_destroy(jmap_req_t *req,
     mboxname = xstrdup(mbentry->name);
     resource = xstrdup(cdata->dav.resource);
 
-    const char *sched_userid = caldav_is_secretarymode(mboxname) ?
-        req->accountid : req->userid;
+    const char *sched_userid = req->accountid;
     get_schedule_addresses(NULL, mboxname, sched_userid, &schedule_addresses);
 
     /* Check permissions. */


### PR DESCRIPTION
This emulates mixed mode for shared calendars:

- alerts and per-user properties act as if in team mode
- schedule addresses act as if in secretary mode

Also disables the tests for the new JMAP Calendars properties and
permissions:

- mayWriteOwn
- mayInviteSelf
- mayInviteOthers
- mayRSVP
- hideAttendees

until it is resolved how they should behave in mixed mode.