### PR TITLE
README.md: master branch is now 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Welcome
 =======
 
-This is the Cyrus IMAP Server, developer version 3.5.  This version is under
+This is the Cyrus IMAP Server, developer version 3.7.  This version is under
 active development, and is not considered "stable".
 
 The current stable series is 3.4.


### PR DESCRIPTION
This just updates README.md to no longer say it's "3.5".

There'll be another update to this file soon, when 3.6 is released, but for the time being it's still correct to say the current stable version is 3.4.