### PR TITLE
Sieve :matches fix

### DIFF
--- a/sieve/comparator.c
+++ b/sieve/comparator.c
@@ -297,7 +297,10 @@ static int octet_matches_(const char *text, size_t tlen,
             set_var(var_num, val_start, t, match_vars);
             break;
         case '\\':
-            c = *p++;
+            if (*p == '?' || *p == '*') {
+                /* escaped wildcard character */
+                c = *p++;
+            }
             /* falls through */
         default:
             if ((c == *t) || (casemap && (toupper(c) == toupper(*t)))) {


### PR DESCRIPTION
A script like 

if header :matches "subject" `"\\\\foo"` {

was NOT matching 

Subject: \\foo

The reason was that we were skipping '\' regardless of the following character.

Strings in :matches only need to escape '?' and '*' (match explicity against themselves).

If correct, this fix should be backported.