### PR TITLE
conversations: zero out cids list if no match for message-id

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -776,6 +776,9 @@ EXPORTED int conversations_get_msgid(struct conversations_state *state,
     const char *data;
     int r;
 
+    /* make sure we don't leak old data */
+    arrayu64_truncate(cids, 0);
+
     r = check_msgid(msgid, 0, &keylen);
     if (r)
         return r;
@@ -787,9 +790,6 @@ EXPORTED int conversations_get_msgid(struct conversations_state *state,
 
     if (r == CYRUSDB_NOTFOUND)
         return 0; /* not an error, but nothing more to do */
-
-    /* make sure we don't leak old data */
-    arrayu64_truncate(cids, 0);
 
     if (!r) r = _conversations_parse(data, datalen, cids, NULL);
 


### PR DESCRIPTION
This was found by a user reporting that messages were being merged
despite having a different subject.  It was because the second one
had an x-me-message-id, and the lookup didn't find it - but the
`cids` list still had the value from the earlier references lookup,
which meant that `i == 3` was true but the message-id was wrong.