### PR TITLE
Compatibility for missing icalcomponent_get_component_name()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1659,6 +1659,11 @@ dnl
                 AC_DEFINE(HAVE_INVALID_RRULE_HANDLING,[],
                         [Do we have support for controlling invalid RRULE handline?]))
 
+        dnl icalcomponent_get_component_name will be new in libical 3.1.0
+        AC_CHECK_LIB(ical, icalcomponent_get_component_name,
+                AC_DEFINE(HAVE_GET_COMPONENT_NAME,[],
+                        [Do we have support for fetching X- component names?]))
+
 dnl  Don't bother checking for DKIM until iSchedule gains traction
 dnl        PKG_CHECK_MODULES([DKIM], [opendkim >= 2.7.0],
 dnl                AC_EGREP_HEADER(DKIM_CANON_ISCHEDULE, dkim.h,

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -67,6 +67,12 @@
 #define icalparameter_clone           icalparameter_new_clone
 #endif
 
+#ifndef HAVE_GET_COMPONENT_NAME
+/* This should never match anything in the wild
+   which means that we can't patch X- components */
+#define icalcomponent_get_component_name(comp)  "X-CYR-"
+#endif
+
 /* Initialize libical timezones. */
 extern void ical_support_init(void);
 


### PR DESCRIPTION
Should be a fix for #3934 