### PR TITLE
Strip TRANSP property from incoming iTIP messages

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4294,8 +4294,7 @@ EOF
     my $response = $CalDAV->Request('GET', $href);
     my $ical = $response->{content};
     $ical =~ s/PARTSTAT=NEEDS-ACTION/PARTSTAT=ACCEPTED/;
-    $ical =~ s/OPAQUE/TRANSPARENT/;
-    $ical =~ s/END:VEVENT/${alarm}END:VEVENT/;
+    $ical =~ s/END:VEVENT/TRANSP:TRANSPARENT\n${alarm}END:VEVENT/;
 
     $CalDAV->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
 


### PR DESCRIPTION
This fixes a bug noted by neilj and alh where TRANSP in iTIP would overwrite what the recipient has set on the object.

Also reworked a bit of code so this works for all major component types, not just VEVENT