### PR TITLE
JMAP Calendars: only send iTIP for new or updated instances

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -19694,4 +19694,217 @@ EOF
         $res->[0][1]{list}[0]{participants}{plusuri}{participationStatus});
 }
 
+sub test_calendarevent_set_standalone_itip
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog "Clear notification cache";
+    $self->{instance}->getnotify();
+
+    xlog "Create scheduled standalone instance";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                instance1 => {
+                    calendarIds => {
+                        'Default' => JSON::true,
+                    },
+                    '@type' => 'Event',
+                    uid => 'event1uid',
+                    title => 'instance1',
+                    start => '2021-01-01T01:01:01',
+                    timeZone => 'Europe/Berlin',
+                    duration => 'PT1H',
+                    recurrenceId => '2021-01-01T01:01:01',
+                    recurrenceIdTimeZone => 'Europe/London',
+                    replyTo => {
+                        imip => 'mailto:organizer@example.com',
+                    },
+                    participants => {
+                        cassandane => {
+                            roles => {
+                                attendee => JSON::true,
+                            },
+                            sendTo => {
+                                imip => 'mailto:cassandane@example.com',
+                            },
+                            participationStatus => 'tentative',
+                            expectReply => JSON::true,
+                        },
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+    my $instance1Id = $res->[0][1]{created}{instance1}{id};
+    $self->assert_not_null($instance1Id);
+
+    xlog "Assert that iTIP notification is sent";
+    my $data = $self->{instance}->getnotify();
+    my ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_not_null($notif);
+    my $itip = decode_json($notif->{MESSAGE})->{ical};
+    my $ical = Data::ICal->new(data => $itip);
+
+    my @vevents = grep { $_->ical_entry_type() eq 'VEVENT' } @{$ical->entries()};
+    $self->assert_num_equals(1, scalar @vevents);
+
+    my $recurid = $vevents[0]->property('RECURRENCE-ID');
+    $self->assert_num_equals(1, scalar @{$recurid});
+    $self->assert_str_equals('20210101T010101', $recurid->[0]->value());
+
+    my $attendees = $vevents[0]->property('ATTENDEE');
+    $self->assert_num_equals(1, scalar @{$attendees});
+    $self->assert_str_equals('mailto:cassandane@example.com',
+        $attendees->[0]->value());
+    $self->assert_str_equals('TENTATIVE',
+        $attendees->[0]->parameters()->{'PARTSTAT'});
+
+    xlog "Clear notification cache";
+    $self->{instance}->getnotify();
+
+    xlog "Create another standalone instance for that UID";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                instance2 => {
+                    calendarIds => {
+                        'Default' => JSON::true,
+                    },
+                    '@type' => 'Event',
+                    uid => 'event1uid',
+                    title => 'instance1',
+                    start => '2022-02-02T02:02:02',
+                    timeZone => 'Europe/Berlin',
+                    duration => 'PT1H',
+                    recurrenceId => '2022-02-02T02:02:02',
+                    recurrenceIdTimeZone => 'Europe/London',
+                    replyTo => {
+                        imip => 'mailto:organizer@example.com',
+                    },
+                    participants => {
+                        cassandane => {
+                            roles => {
+                                attendee => JSON::true,
+                            },
+                            sendTo => {
+                                imip => 'mailto:cassandane@example.com',
+                            },
+                            participationStatus => 'accepted',
+                            expectReply => JSON::true,
+                        },
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+    my $instance2Id = $res->[0][1]{created}{instance2}{id};
+    $self->assert_not_null($instance2Id);
+
+    xlog "Assert iTIP notification just gets sent for new instance";
+    $data = $self->{instance}->getnotify();
+    ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_not_null($notif);
+    $itip = decode_json($notif->{MESSAGE})->{ical};
+    $ical = Data::ICal->new(data => $itip);
+
+    @vevents = grep { $_->ical_entry_type() eq 'VEVENT' } @{$ical->entries()};
+    $self->assert_num_equals(1, scalar @vevents);
+
+    $recurid = $vevents[0]->property('RECURRENCE-ID');
+    $self->assert_num_equals(1, scalar @{$recurid});
+    $self->assert_str_equals('20220202T020202', $recurid->[0]->value());
+
+    $attendees = $vevents[0]->property('ATTENDEE');
+    $self->assert_num_equals(1, scalar @{$attendees});
+    $self->assert_str_equals('mailto:cassandane@example.com',
+        $attendees->[0]->value());
+    $self->assert_str_equals('ACCEPTED',
+        $attendees->[0]->parameters()->{'PARTSTAT'});
+
+    xlog "Clear notification cache";
+    $self->{instance}->getnotify();
+
+    xlog "Update partstat in a standalone instance";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $instance2Id => {
+                    'participants/cassandane/participationStatus' => 'declined',
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$instance2Id});
+
+    xlog "Assert iTIP notification only is sent for updated instance";
+    $data = $self->{instance}->getnotify();
+    ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_not_null($notif);
+    $itip = decode_json($notif->{MESSAGE})->{ical};
+    $ical = Data::ICal->new(data => $itip);
+
+    @vevents = grep { $_->ical_entry_type() eq 'VEVENT' } @{$ical->entries()};
+    $self->assert_num_equals(1, scalar @vevents);
+
+    $recurid = $vevents[0]->property('RECURRENCE-ID');
+    $self->assert_num_equals(1, scalar @{$recurid});
+    $self->assert_str_equals('20220202T020202', $recurid->[0]->value());
+
+    $attendees = $vevents[0]->property('ATTENDEE');
+    $self->assert_num_equals(1, scalar @{$attendees});
+    $self->assert_str_equals('mailto:cassandane@example.com',
+        $attendees->[0]->value());
+    $self->assert_str_equals('DECLINED',
+        $attendees->[0]->parameters()->{'PARTSTAT'});
+
+    xlog "Clear notification cache";
+    $self->{instance}->getnotify();
+
+    xlog "Create another standalone instance where PARTSTAT=NEEDS-ACTION";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                instance2 => {
+                    calendarIds => {
+                        'Default' => JSON::true,
+                    },
+                    '@type' => 'Event',
+                    uid => 'event1uid',
+                    title => 'instance3',
+                    start => '2022-03-03T03:03:03',
+                    timeZone => 'Europe/Berlin',
+                    duration => 'PT1H',
+                    recurrenceId => '2022-03-03T03:03:03',
+                    recurrenceIdTimeZone => 'Europe/London',
+                    replyTo => {
+                        imip => 'mailto:organizer@example.com',
+                    },
+                    participants => {
+                        cassandane => {
+                            roles => {
+                                attendee => JSON::true,
+                            },
+                            sendTo => {
+                                imip => 'mailto:cassandane@example.com',
+                            },
+                            participationStatus => 'needs-action',
+                            expectReply => JSON::true,
+                        },
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+    my $instance3Id = $res->[0][1]{created}{instance2}{id};
+    $self->assert_not_null($instance2Id);
+
+    xlog "Assert no iTIP notification is sent";
+    $data = $self->{instance}->getnotify();
+    ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_null($notif);
+}
+
 1;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -5045,20 +5045,26 @@ static void updateevent_bump_sequence(json_t *old_event,
     json_object_set_new(update, "sequence", json_integer(new_seq));
 }
 
-/* XXX - the argument list of this function is insane */
+struct updateevent {
+    struct jmap_caleventid *eid;
+    json_t *event_patch;
+    int is_standalone;
+    json_t *serverset;
+
+    mbentry_t *mbentry;
+    struct caldav_data *cdata;
+    strarray_t *schedule_addresses;
+
+    json_t *old_event;
+    icalcomponent *oldical;
+    icalcomponent *newical;
+};
+
 static int updateevent_apply_patch(jmap_req_t *req,
-                                   icalcomponent *oldical,
-                                   json_t *event_patch,
-                                   int is_standalone,
-                                   mbentry_t *mbentry,
-                                   struct caldav_data *cdata,
-                                   struct jmap_caleventid *eid,
-                                   strarray_t *schedule_addresses,
-                                   json_t *invalid,
-                                   json_t **old_eventptr,
-                                   icalcomponent **newicalptr,
-                                   json_t *update,
-                                   json_t **err)
+                                   struct updateevent *update,
+                                   json_t *invalid, json_t **err)
+
+
 {
     json_t *new_event = NULL;
     json_t *old_event = NULL;
@@ -5066,27 +5072,27 @@ static int updateevent_apply_patch(jmap_req_t *req,
 
     int floatingtz_is_malloced = 0;
     icaltimezone *floatingtz =
-        calendarevent_get_floatingtz(mbentry, req->userid,
+        calendarevent_get_floatingtz(update->mbentry, req->userid,
                 &floatingtz_is_malloced);
 
-    if (eid->ical_recurid && !is_standalone) {
+    if (update->eid->ical_recurid && !update->is_standalone) {
         // XXX caldav.db version 15 stores standalone instances by their
         // recurrence id. But until the DAV databases got reconstructed,
         // we might encounter db records with an empty recurid column.
         icalcomponent *comp;
-        for (comp = icalcomponent_get_first_real_component(oldical);
+        for (comp = icalcomponent_get_first_real_component(update->oldical);
              comp && icalcomponent_get_first_property(comp, ICAL_RECURRENCEID_PROPERTY);
-             comp = icalcomponent_get_next_component(oldical,
+             comp = icalcomponent_get_next_component(update->oldical,
                  icalcomponent_isa(comp))) { }
 
-        is_standalone = !comp;
+        update->is_standalone = !comp;
     }
 
     // prepare iCalendar data
-    icalcomponent *myoldical = oldical;
-    if (is_standalone) {
+    icalcomponent *myoldical = update->oldical;
+    if (update->is_standalone) {
         // prune any other standalone instances from iCalendar data
-        myoldical = icalcomponent_clone(oldical);
+        myoldical = icalcomponent_clone(update->oldical);
         icalcomponent *comp, *nextcomp;
         for (comp = icalcomponent_get_first_real_component(myoldical);
              comp; comp = nextcomp) {
@@ -5098,13 +5104,13 @@ static int updateevent_apply_patch(jmap_req_t *req,
                     ICAL_RECURRENCEID_PROPERTY);
             if (!prop) {
                 // there is something very wrong here
-                is_standalone = 0;
+                update->is_standalone = 0;
                 icalcomponent_free(myoldical);
-                myoldical = oldical;
+                myoldical = update->oldical;
                 break;
             }
             const char *ical_recurid = icalproperty_get_value_as_string(prop);
-            if (strcmpsafe(eid->ical_recurid, ical_recurid)) {
+            if (strcmpsafe(update->eid->ical_recurid, ical_recurid)) {
                 icalcomponent_remove_component(myoldical, comp);
                 icalcomponent_free(comp);
             }
@@ -5112,60 +5118,63 @@ static int updateevent_apply_patch(jmap_req_t *req,
     }
 
     // Read old event
-    struct jmapical_ctx *jmapctx = jmapical_context_new(req, schedule_addresses);
-    jmapctx->to_ical.serverset = update;
-    context_begin_cdata(jmapctx, mbentry, cdata);
+    struct jmapical_ctx *jmapctx = jmapical_context_new(req,
+            update->schedule_addresses);
+    jmapctx->to_ical.serverset = update->serverset;
+    context_begin_cdata(jmapctx, update->mbentry, update->cdata);
     old_event = jmapical_tojmap(myoldical, NULL, jmapctx);
     if (!old_event) {
         r = IMAP_INTERNAL;
         goto done;
     }
-    *old_eventptr = json_deep_copy(old_event);
-
+    update->old_event = json_deep_copy(old_event);
 
     json_object_del(old_event, "updated");
 
     // Apply the patch
-    if (eid->ical_recurid && !is_standalone) {
+    if (update->eid->ical_recurid && !update->is_standalone) {
         /* Update or create an override */
-        updateevent_apply_patch_override(eid, old_event, event_patch,
-                myoldical, floatingtz, &new_event, invalid, err);
+        updateevent_apply_patch_override(update->eid, update->old_event,
+                update->event_patch, myoldical, floatingtz,
+                &new_event, invalid, err);
         if (!new_event) goto done;
     }
     else {
         // Validate privacy on shared calendars
         if (strcmp(req->accountid, req->userid)) {
             const char *new_privacy =
-                json_string_value(json_object_get(event_patch, "privacy"));
+                json_string_value(json_object_get(update->event_patch, "privacy"));
             if (new_privacy && strcmp(new_privacy, "public")) {
                 json_array_append_new(invalid, json_string("privacy"));
             }
         }
 
         /* Update a regular event or standalone instance */
-        updateevent_apply_patch_event(old_event, event_patch,
+        updateevent_apply_patch_event(update->old_event, update->event_patch,
                 myoldical, floatingtz, &new_event, invalid, err);
         if (!new_event) goto done;
     }
 
-    updateevent_validate_ids(old_event, new_event, invalid);
+    updateevent_validate_ids(update->old_event, new_event, invalid);
 
-    updateevent_bump_sequence(old_event, new_event, update, schedule_addresses);
+    updateevent_bump_sequence(update->old_event, new_event,
+            update->serverset, update->schedule_addresses);
 
     /* Convert to iCalendar */
     icalcomponent *newical = jmapical_toical(new_event, myoldical,
-            invalid, update, NULL, jmapctx);
+            invalid, update->serverset, NULL, jmapctx);
     if (!newical || json_array_size(invalid)) {
         if (newical) icalcomponent_free(newical);
         goto done;
     }
 
-    if (is_standalone)
-        merge_missing_vevents(newical, oldical);
-    *newicalptr = newical;
+    if (update->is_standalone)
+        merge_missing_vevents(newical, update->oldical);
+
+    update->newical = newical;
 
 done:
-    if (myoldical && myoldical != oldical)
+    if (myoldical && myoldical != update->oldical)
         icalcomponent_free(myoldical);
     if (floatingtz_is_malloced)
         icaltimezone_free(floatingtz, 1);
@@ -5187,28 +5196,27 @@ static void setcalendarevents_update(jmap_req_t *req,
                                      struct jmap_caleventid *eid,
                                      struct caldav_db *db,
                                      int send_scheduling_messages,
-                                     json_t *update,
+                                     json_t *serverset,
                                      json_t **err)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
     int r = 0;
 
-    // XXX - the whole CalendarEvent/set{update} needs a major clean-up
-
+    mbentry_t *mbentry = NULL;
     struct caldav_data *cdata = NULL;
     struct mailbox *mbox = NULL;
-    mbentry_t *mbentry = NULL;
     struct mailbox *dstmbox = NULL;
     mbentry_t *dstmbentry = NULL;
     struct mboxevent *mboxevent = NULL;
     char *resource = NULL;
-
-    icalcomponent *oldical = NULL;
-    icalcomponent *ical = NULL;
-    struct index_record record;
-    strarray_t schedule_addresses = STRARRAY_INITIALIZER;
     strarray_t del_imapflags = STRARRAY_INITIALIZER;
-    json_t *old_event = NULL;
+    strarray_t schedule_addresses = STRARRAY_INITIALIZER;
+
+    struct updateevent update = {
+        .event_patch = event_patch,
+        .eid = eid,
+        .serverset = serverset,
+    };
 
     static int icalendar_max_size = -1;
     if (icalendar_max_size < 0) {
@@ -5217,7 +5225,6 @@ static void setcalendarevents_update(jmap_req_t *req,
     }
 
     // Determine if event is a standalone recurrence instance
-    int is_standalone_instance = 0;
     if (eid->ical_recurid) {
         struct caldav_jscal_filter jscal_filter = {
             .ical_uid = eid->ical_uid,
@@ -5227,8 +5234,8 @@ static void setcalendarevents_update(jmap_req_t *req,
                 updateevent_check_exists_cb, NULL);
         if (r && r != CYRUSDB_DONE)
             goto done;
-        is_standalone_instance = r == CYRUSDB_DONE;
-        if (!is_standalone_instance) {
+        update.is_standalone = r == CYRUSDB_DONE;
+        if (!update.is_standalone) {
             // if it isn't there must be a main event
             jscal_filter.ical_recurid = "";
             r = caldav_foreach_jscal(db, NULL, &jscal_filter, NULL, 0,
@@ -5324,7 +5331,8 @@ static void setcalendarevents_update(jmap_req_t *req,
     }
 
     const char *sched_userid = req->accountid;
-    get_schedule_addresses(NULL, mbentry->name, sched_userid, &schedule_addresses);
+    get_schedule_addresses(NULL, mbentry->name, sched_userid,
+            &schedule_addresses);
 
     if (dstmbentry) {
         /* Validate permissions for move */
@@ -5339,7 +5347,7 @@ static void setcalendarevents_update(jmap_req_t *req,
     }
 
     /* Fetch index record for the resource */
-    memset(&record, 0, sizeof(struct index_record));
+    struct index_record record = { 0 };
     r = mailbox_find_index_record(mbox, cdata->dav.imap_uid, &record);
     if (r == IMAP_NOTFOUND) {
         jmap_parser_push(&parser, mbentry->name);
@@ -5353,8 +5361,8 @@ static void setcalendarevents_update(jmap_req_t *req,
         goto done;
     }
     /* Load VEVENT from record, personalizing as needed. */
-    oldical = caldav_record_to_ical(mbox, cdata, req->userid, NULL);
-    if (!oldical) {
+    update.oldical = caldav_record_to_ical(mbox, cdata, req->userid, NULL);
+    if (!update.oldical) {
         syslog(LOG_ERR, "record_to_ical failed for record %u:%s",
                 cdata->dav.imap_uid, mailbox_name(mbox));
         r = IMAP_INTERNAL;
@@ -5378,18 +5386,20 @@ static void setcalendarevents_update(jmap_req_t *req,
     }
 
     /* Apply patch */
-    r = updateevent_apply_patch(req, oldical, event_patch,
-            is_standalone_instance, mbentry, cdata, eid, &schedule_addresses,
-            parser.invalid, &old_event, &ical, update, err);
+    update.mbentry = mbentry;
+    update.cdata = cdata;
+    update.schedule_addresses = &schedule_addresses;
+    r = updateevent_apply_patch(req, &update, parser.invalid, err);
     if (json_array_size(parser.invalid) || *err) {
-
         r = 0;
         goto done;
     }
-    else if (icalendar_max_size != INT_MAX && ical &&
-        strlen(icalcomponent_as_ical_string(ical)) > (size_t) icalendar_max_size) {
-        r = IMAP_MESSAGE_TOO_LARGE;
-        goto done;
+    else if (icalendar_max_size != INT_MAX && update.newical) {
+        size_t ical_size = strlen(icalcomponent_as_ical_string(update.newical));
+        if (ical_size > (size_t) icalendar_max_size) {
+            r = IMAP_MESSAGE_TOO_LARGE;
+            goto done;
+        }
     }
     else if (r) goto done;
 
@@ -5420,7 +5430,7 @@ static void setcalendarevents_update(jmap_req_t *req,
 
 
     /* Remove METHOD property */
-    remove_itip_properties(ical);
+    remove_itip_properties(update.newical);
 
     /* Store the updated VEVENT. */
     struct transaction_t txn = {
@@ -5433,18 +5443,20 @@ static void setcalendarevents_update(jmap_req_t *req,
         syslog(LOG_ERR, "mlookup(%s) failed: %s", mailbox_name(mbox), error_message(r));
     }
     else {
-        r = caldav_store_resource(&txn, ical, mbox, resource, record.createdmodseq,
-                                  db, PERMS_NOKEEP, req->userid,
-                                  NULL, &del_imapflags, &schedule_addresses);
+        r = caldav_store_resource(&txn, update.newical,
+                mbox, resource, record.createdmodseq,
+                db, PERMS_NOKEEP, req->userid,
+                NULL, &del_imapflags, &schedule_addresses);
         if (r == HTTP_CREATED || r == HTTP_NO_CONTENT) {
             json_t *patch_copy = json_deep_copy(event_patch);
             jmapical_remove_peruserprops(patch_copy);
-            jmapical_remove_peruserprops(old_event);
+            jmapical_remove_peruserprops(update.old_event);
             if (json_object_size(patch_copy)) {
                 int r2 = jmap_create_caleventnotif(notifmbox, req->userid,
                         req->authstate, mailbox_name(mbox), "updated",
                         eid->ical_uid, &schedule_addresses, NULL,
-                        record.system_flags & FLAG_DRAFT, old_event, patch_copy);
+                        record.system_flags & FLAG_DRAFT,
+                        update.old_event, patch_copy);
                 if (r2) {
                     xsyslog(LOG_WARNING, "could not create notification",
                             "uid=%s error=%s", eid->ical_uid, error_message(r2));
@@ -5464,12 +5476,13 @@ static void setcalendarevents_update(jmap_req_t *req,
     /* Handle scheduling. */
     if (!(record.system_flags & FLAG_DRAFT) && send_scheduling_messages) {
         r = setcalendarevents_schedule(sched_userid, &schedule_addresses,
-                oldical, ical, JMAP_UPDATE);
+                update.oldical, update.newical, JMAP_UPDATE);
         if (r) goto done;
     }
 
     /* Manage attachments */
-    int ret = caldav_manage_attachments(req->accountid, ical, oldical);
+    int ret = caldav_manage_attachments(req->accountid,
+            update.newical, update.oldical);
     if (ret && ret != HTTP_NOT_FOUND) {
         syslog(LOG_ERR, "caldav_manage_attachments: %s", error_message(ret));
         r = IMAP_INTERNAL;
@@ -5479,7 +5492,7 @@ static void setcalendarevents_update(jmap_req_t *req,
     if (jmap_is_using(req, JMAP_CALENDARS_EXTENSION)) {
         struct index_record record;
         if (!mailbox_find_index_record(mbox, mbox->i.last_uid, &record)) {
-            add_calendarevent_blobids(update, mailbox_uniqueid(mbox),
+            add_calendarevent_blobids(serverset, mailbox_uniqueid(mbox),
                     mbox->i.last_uid, req->userid, &record.guid);
         }
     }
@@ -5513,12 +5526,15 @@ done:
         }
     }
 
+    if (update.newical)
+        icalcomponent_free(update.newical);
+    if (update.oldical)
+        icalcomponent_free(update.oldical);
+    json_decref(update.old_event);
+
     if (mbox) jmap_closembox(req, &mbox);
     if (dstmbox) jmap_closembox(req, &dstmbox);
-    if (ical) icalcomponent_free(ical);
-    if (oldical) icalcomponent_free(oldical);
     jmap_parser_fini(&parser);
-    json_decref(old_event);
     strarray_fini(&del_imapflags);
     strarray_fini(&schedule_addresses);
     mboxlist_entry_free(&mbentry);


### PR DESCRIPTION
Before, the iTIP notification contained all standalone instances having that iCalendar UID.

The PR also includes a code-hygiene commit of the CalendarEvent/set{update} code.
