### PR TITLE
Inherit attendee user data from master when creating iTIP override

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4349,6 +4349,13 @@ EOF
     $self->assert_equals(JSON::true, $events->[0]{showAsFree});
     $self->assert_not_null($events->[0]{alerts}{myalarm});
     $self->assert_str_equals('accepted', $events->[0]{participants}{'cassandane@example.com'}{scheduleStatus});    
+
+    $response = $CalDAV->Request('GET', $href);
+    $ical = Data::ICal->new(data => $response->{content});
+    $self->assert_str_equals('TRANSPARENT', $ical->{entries}[0]{properties}{transp}[0]{value});
+    $self->assert_str_equals('DISPLAY', $ical->{entries}[0]{entries}[0]{properties}{action}[0]{value});
+    $self->assert_str_equals('TRANSPARENT', $ical->{entries}[1]{properties}{transp}[0]{value});
+    $self->assert_str_equals('DISPLAY', $ical->{entries}[1]{entries}[0]{properties}{action}[0]{value});
 }
 
 sub test_imip_cancel


### PR DESCRIPTION
When the organizer sent an iTIP request with a new overridden instance the attendee's personal data (alarms, transparency) wasn't being inherited from the master component