### PR TITLE
jmap_ical: fix conditional using unrelated global variable

### DIFF
--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -4031,7 +4031,7 @@ startend_to_ical(icalcomponent *comp, struct jmap_parser *parser,
             jmap_parser_push(parser, id);
             endzone_location_id = id;
             const char *jstzid = json_string_value(json_object_get(jval, "timeZone"));
-            if (timezone) {
+            if (jstzid) {
                 tzend = jstimezones_lookup_jstzid(jstzones, jstzid);
                 if (!tzend || !tzstart) {
                     jmap_parser_invalid(parser, "timeZone");


### PR DESCRIPTION
The conditional erroneously checked the `timezone` variable, which
is defined in the libc time.h header and unrelated to the actual
control logic.

Signed-off-by: Robert Stepanek <rsto@fastmailteam.com>