### PR TITLE
proof of concept: don't allow "timezone" as a name

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2322,6 +2322,15 @@ AH_BOTTOM([
 # endif
 #endif
 
+/* time.h declares a `timezone` global which causes stupid problems
+ * when we accidentally use it as a local name too, but mess up the
+ * scoping.  So, make sure we can not use it as a local name too,
+ * except very carefully!
+ */
+#ifndef REALLY_USE_LIBC_TIMEZONE
+#define timezone /* dont call things this! */
+#endif
+
 /* com_err.h, as needed */
 #ifndef IN_COM_ERR
 #ifdef HAVE_ET_COM_ERR_H

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -384,17 +384,17 @@ static int send_alarm(struct get_alarm_rock *rock,
     FILL_STRING_PARAM(event, EVENT_CALENDAR_ORGANIZER,
                       xstrdup(prop ? icalproperty_get_value_as_string(prop) : ""));
 
-    const char *timezone = NULL;
+    const char *tz = NULL;
     if (!icaltime_is_date(start) && icaltime_is_utc(start))
-        timezone = "UTC";
+        tz = "UTC";
     else if (icaltime_get_timezone(start))
-        timezone = icaltime_get_location_tzid(start);
+        tz = icaltime_get_location_tzid(start);
     else if (rock->floatingtz)
-        timezone = icaltimezone_get_location_tzid(rock->floatingtz);
+        tz = icaltimezone_get_location_tzid(rock->floatingtz);
     else
-        timezone = "[floating]";
+        tz = "[floating]";
     FILL_STRING_PARAM(event, EVENT_CALENDAR_TIMEZONE,
-                      xstrdupsafe(timezone));
+                      xstrdupsafe(tz));
     FILL_STRING_PARAM(event, EVENT_CALENDAR_START,
                       xstrdup(icaltime_as_ical_string(start)));
     FILL_STRING_PARAM(event, EVENT_CALENDAR_END,

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -7910,7 +7910,7 @@ struct principalfilter_expr {
     xapian_query_t *name;
     xapian_query_t *text;
     const char *type;
-    const char *timezone;
+    const char *tz;
 };
 
 struct principalfilter {
@@ -7973,7 +7973,7 @@ static struct principalfilter_expr *principalfilter_buildexpr(json_t *jfilter,
         }
         if ((s = json_string_value(json_object_get(jfilter, "timeZone")))) {
             hash_insert("timeZone", (void*)0x1, &filter->props);
-            expr->timezone = s;
+            expr->tz = s;
         }
     }
 
@@ -8099,9 +8099,9 @@ static int principalfilter_matchexpr(json_t *jp,
                 return 0;
             }
         }
-        if (expr->timezone) {
+        if (expr->tz) {
             const char *s = json_string_value(json_object_get(jp, "timeZone"));
-            if (strcmpsafe(expr->timezone, s)) {
+            if (strcmpsafe(expr->tz, s)) {
                 return 0;
             }
         }

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -2818,9 +2818,9 @@ static json_t* location_from_ical(icalproperty *prop, json_t *links,
     }
 
     /* timeZone */
-    const char *timezone = get_icalxparam_value(prop, JMAPICAL_XPARAM_TZID);
-    if (jstimezones_lookup_jstzid(jstzones, timezone)) {
-        json_object_set_new(loc, "timeZone", json_string(timezone));
+    const char *tz = get_icalxparam_value(prop, JMAPICAL_XPARAM_TZID);
+    if (jstimezones_lookup_jstzid(jstzones, tz)) {
+        json_object_set_new(loc, "timeZone", json_string(tz));
     }
 
     /* coordinates */


### PR DESCRIPTION
libc's time.h gives us this:

```
#if defined __USE_MISC || defined __USE_XOPEN
extern int daylight;
extern long int timezone;
#endif
```

We don't use it, but since we always include time.h (via config.h), we always have this `timezone` name kicking around in the global scope.  We do a lot of work with timezones, and problems with names or scoping can slip beneath the radar when this global exists as a fallback -- e.g. the bug fixed by #3945, which the compiler couldn't detect because `timezone` was valid (but irrelevant).

This fix defines `timezone` to be a comment, so that it's no longer a usable name.  There were a few places where we did try to use timezone as a local variable name; these have been renamed to `tz`.  If some source file ever needs to use the libc global (seems unlikely), it can access it by `#define REALLY_USE_LIBC_TIMEZONE` before including config.h.

With this fix, new code that tries to use `timezone` as a variable name will fail to compile, a bit like this:

```
imap/caldav_alarm.c: In function ‘send_alarm’:
imap/caldav_alarm.c:387:26: error: expected identifier or ‘(’ before ‘=’ token
     const char *timezone = NULL;
                          ^
```

I would really like a more helpful message here, but I haven't yet come up with a clever way to provoke one.  I am very open to suggestions!

What do we think of this?

An alternate possibility might be to `#undef __USE_MISC` or `#undef __USE_XOPEN` before including time.h.  That way time.h wouldn't give us the global `timezone`, and the problem would go away.  But I'm not sure what else we would lose.