### PR TITLE
Adapt annotation parsing regexps to version 3.2

### DIFF
--- a/perl/imap/IMAP/Admin.pm
+++ b/perl/imap/IMAP/Admin.pm
@@ -724,7 +724,7 @@ sub getinfo {
 			# this is the only possible response.
 
 		        if ($text =~
-			       /^\s*\"([^\"]*)\"\s+\"([^\"]*)\"\s+\(\"([^\"]*)\"\s+\"([^\"]*)\"\)/) {
+			       /^\s*(?|\"([^\"]*)\"|(\S+))\s+\"([^\"]*)\"\s+\(\"([^\"]*)\"\s+(?|\"([^\"]*)\"|(NIL)\s*)\)/) {
 			  # note that we require mailbox and entry to be qstrings
 			  # Single annotation, not literal,
 			  # but possibly multiple values
@@ -737,9 +737,9 @@ sub getinfo {
 			  }
 			  $d{-rock}{$key} = $4;
 		        }  elsif ($text =~
-			       /^\s*\"([^\"]*)\"\s+\"([^\"]*)\"\s+\(\"([^\"]*)\"\s+\{(.*)\}\r\n/) {
+			       /^\s*(?|\"([^\"]*)\"|(\S+))\s+\"([^\"]*)\"\s+\(\"([^\"]*)\"\s+\{(.*)\}\r\n/) {
 			  my $len = $3;
-			  $text =~ s/^\s*\"([^\"]*)\"\s+\"([^\"]*)\"\s+\(\"([^\"]*)\"\s+\{(.*)\}\r\n//s;
+			  $text =~ s/^\s*(?|\"([^\"]*)\"|(\S+))\s+\"([^\"]*)\"\s+\(\"([^\"]*)\"\s+\{(.*)\}\r\n//s;
 			  $text = substr($text, 0, $len);
 			  # note that we require mailbox and entry to be qstrings
 			  # Single annotation (literal style),


### PR DESCRIPTION
The enclosed commit unbreaks cyradm's info command when talking to version 3.2 servers, which omit the quotes around the mailbox name, and can also send unquoted ```NIL``` as can be seen in the following imtest excerpts:

```l00 getannotation user.test-user-32 "*" "value.shared"
* ANNOTATION user.test-user-32 "/vendor/cmu/cyrus-imapd/squat" ("value.shared" NIL)
* ANNOTATION user.test-user-32 "/vendor/cmu/cyrus-imapd/size" ("value.shared" "6007")
```
```l00 getannotation user.test-user-24 "*" "value.shared"
* ANNOTATION "user.test-user-24" "/vendor/cmu/cyrus-imapd/squat" ("value.shared" "true")
* ANNOTATION "user.test-user-24" "/vendor/cmu/cyrus-imapd/size" ("value.shared" "7006")
```
Sending it upstream, since I think it can help someone else's version migration.