### PR TITLE
JMAP mboxid_byrole hash

### DIFF
--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -167,6 +167,7 @@ typedef struct jmap_req {
     hash_table *created_ids;
     hash_table *inmemory_blobs;
     hash_table *mbentry_byid;
+    hash_table *mboxid_byrole;
     ptrarray_t *method_calls;
     const strarray_t *using_capabilities;
 } jmap_req_t;
@@ -590,5 +591,8 @@ extern void jmap_mbentry_cache_free(jmap_req_t *req);
 extern const mbentry_t *jmap_mbentry_by_uniqueid(jmap_req_t *req, const char *id);
 extern mbentry_t *jmap_mbentry_by_uniqueid_copy(jmap_req_t *req, const char *id);
 extern mbentry_t *jmap_mbentry_from_dav(jmap_req_t *req, struct dav_data *dav);
+
+extern int jmap_findmbox_role(jmap_req_t *req, const char *role,
+                              const mbentry_t **mbentryptr);
 
 #endif /* JMAP_API_H */

--- a/imap/jmap_mail.h
+++ b/imap/jmap_mail.h
@@ -64,7 +64,4 @@ extern void jmap_emailsubmission_capabilities(json_t *jcapabilities);
 extern void jmap_mailbox_init(jmap_settings_t *settings);
 extern void jmap_mailbox_capabilities(json_t *jcapabilities);
 
-extern int jmap_mailbox_find_role(jmap_req_t *req, const char *role,
-                                  char **mboxnameptr, char **uniqueid);
-
 #endif /* JMAP_MAIL_H */

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1353,3 +1353,12 @@ EXPORTED const char *jmap_caleventid_encode(const struct jmap_caleventid *eid, s
 
     return buf_cstring(buf);
 }
+
+EXPORTED char *jmap_role_to_specialuse(const char *role)
+{
+    if (!role) return NULL;
+    if (!role[0]) return NULL;
+    char *specialuse = strconcat("\\", role, (char *)NULL);
+    specialuse[1] = toupper(specialuse[1]);
+    return specialuse;
+}

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -93,6 +93,8 @@ extern json_t *jmap_fetch_snoozed(const char *mbox, uint32_t uid);
 extern int jmap_email_keyword_is_valid(const char *keyword);
 extern const char *jmap_keyword_to_imap(const char *keyword);
 
+extern char *jmap_role_to_specialuse(const char *role);
+
 /* JMAP request parser */
 struct jmap_parser {
     struct buf buf;


### PR DESCRIPTION
Introduce mboxid_byrole hash and use it for jmap_mailbox_find_role()

Note that is might be easier to view this by ignoring whitespace