### PR TITLE
Properly count how many components are canceled via iTIP

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4358,6 +4358,126 @@ EOF
     $self->assert_str_equals('DISPLAY', $ical->{entries}[1]{entries}[0]{properties}{action}[0]{value});
 }
 
+sub test_imip_cancel_instance
+    :needs_component_sieve :needs_component_httpd :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $IMAP = $self->{store}->get_client();
+    $self->{store}->_select();
+    $self->assert_num_equals(1, $IMAP->uid());
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+
+    xlog $self, "Create calendar user";
+    my $CalDAV = $self->{caldav};
+    my $CalendarId = 'Default';
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :deletecanceled :outcome "outcome";
+    if string "\${outcome}" "updated" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    my $imip = <<EOF;
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-0\@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+X-Cassandane-Unique: $uuid-0
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+RRULE:FREQ=WEEKLY
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP invite";
+    my $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 1,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Expunge the message";
+    $IMAP->store('1', '+flags', '(\\Deleted)');
+    $IMAP->expunge();
+
+    xlog $self, "Check that the event made it to calendar";
+    my $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('An Event', $events->[0]{title});
+    $self->assert_str_equals('2021-09-23T15:30:00', $events->[0]{start});
+    my $href = $events->[0]{href};
+
+    $imip = <<EOF;
+Date: Thu, 24 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-1\@example.net>
+Content-Type: text/calendar; method=CANCEL; component=VEVENT
+X-Cassandane-Unique: $uuid-1
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:CANCEL
+BEGIN:VEVENT
+UID:$uuid
+DTSTAMP:20210924T034327Z
+SEQUENCE:1
+STATUS:CANCELLED
+RECURRENCE-ID;TZID=American/New_York:20210923T153000
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP cancel";
+    $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 2,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Check that the updated event made it to calendar";
+    $events = $CalDAV->GetEvents($CalendarId);
+
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_equals(JSON::null,
+                         $events->[0]{recurrenceOverrides}{'2021-09-23T15:30:00'});
+}
+
 sub test_imip_preserve_alerts
     :needs_component_sieve :needs_component_httpd :min_version_3_5
 {

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -743,6 +743,7 @@ static int deliver_merge_cancel(const char *recipient,
         }
         else {
             master_comp = comp;
+            hash_insert("", comp, &comp_table);
         }
     }
 
@@ -794,9 +795,12 @@ static int deliver_merge_cancel(const char *recipient,
         }
     }
 
+    /* Did we cancel all instances? */
+    int ret = (num_canceled >= hash_numrecords(&comp_table));
+
     free_hash_table(&comp_table, NULL);
 
-    return (num_canceled >= hash_numrecords(&comp_table));
+    return ret;
 }
 
 
@@ -1068,9 +1072,9 @@ HIDDEN enum sched_deliver_outcome sched_deliver_local(const char *userid,
 
     switch (method) {
     case ICAL_METHOD_CANCEL: {
-        int entire_comp = deliver_merge_cancel(recipient, ical, itip);
+        int all_instances = deliver_merge_cancel(recipient, ical, itip);
 
-        if (entire_comp && SCHED_DELETE_CANCELED(sched_data)) {
+        if (all_instances && SCHED_DELETE_CANCELED(sched_data)) {
             /* Expunge the resource */
             struct index_record record;
             int r;


### PR DESCRIPTION
This fixes a bug where `processimip :deletecanceled` would delete the entire resource when just a single instance was canceled