### PR TITLE
caldav_sched: send iTIP REPLY if ORGANIZER changed

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -20447,4 +20447,108 @@ EOF
     }
 }
 
+sub test_itip_rsvp_organizer_change
+    :min_version_3_7 :needs_component_jmap :needs_component_sieve
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :deletecanceled :outcome "outcome";
+}
+EOF
+    );
+
+    my $imip = <<'EOF';
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Sally Sender <sender@example.net>
+To: Cassandane <cassandane@example.com>
+Message-ID: <7e017102-0caf-490a-bbdf-422141d34e75@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+X-Cassandane-Unique: $uuid
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:7e017102-0caf-490a-bbdf-422141d34e75
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:test
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Test User;X-JMAP-ID=organizerA:MAILTO:organizerA@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;X-JMAP-ID=cassandane:MAILTO:cassandane@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP invite";
+    $self->{instance}->deliver(Cassandane::Message->new(raw => $imip));
+
+    xlog "Clear notifications";
+    $self->{instance}->getnotify();
+
+    xlog "Accept invitation in JMAP";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            properties => ['id', 'participants'],
+        }, 'R1'],
+    ]);
+    my $eventId = $res->[0][1]{list}[0]{id};
+    $self->assert_not_null($eventId);
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    'participants/cassandane/participationStatus' => 'accepted',
+                },
+            }
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog "Assert that iTIP notification is sent";
+    my $data = $self->{instance}->getnotify();
+    my ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_not_null($notif);
+
+    xlog "Clear notifications";
+    $self->{instance}->getnotify();
+
+    xlog "Change organizer in JMAP";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    replyTo => {
+                        imip => 'mailto:organizerB@example.net',
+                    },
+                    'participants/organizerA' => undef,
+                },
+            }
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            ids => [ $eventId ],
+            properties => [ 'replyTo' ],
+        }, 'R2'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+    $self->assert_deep_equals({
+        imip => 'mailto:organizerB@example.net',
+    }, $res->[1][1]{list}[0]{replyTo});
+
+    xlog "Assert that iTIP notification is sent";
+    $data = $self->{instance}->getnotify();
+    ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_not_null($notif);
+}
+
+
 1;

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -100,6 +100,7 @@ HIDDEN icalproperty *find_attendee(icalcomponent *comp, const char *match)
 
 HIDDEN const char *get_organizer(icalcomponent *comp)
 {
+    if (!comp) return NULL;
     icalproperty *prop =
         icalcomponent_get_first_property(comp, ICAL_ORGANIZER_PROPERTY);
     const char *organizer = icalproperty_get_organizer(prop);
@@ -129,6 +130,11 @@ HIDDEN int partstat_changed(icalcomponent *oldcomp,
 {
     if (!attendee) return 1; // something weird is going on, treat it as a change
     return (get_partstat(oldcomp, attendee) != get_partstat(newcomp, attendee));
+}
+
+HIDDEN int organizer_changed(icalcomponent *oldcomp, icalcomponent *newcomp)
+{
+    return strcmpsafe(get_organizer(oldcomp), get_organizer(newcomp));
 }
 
 struct pick_scheddefault_rock {

--- a/imap/itip_support.h
+++ b/imap/itip_support.h
@@ -153,6 +153,7 @@ extern icalproperty *find_attendee(icalcomponent *comp, const char *match);
 extern const char *get_organizer(icalcomponent *comp);
 extern int partstat_changed(icalcomponent *oldcomp,
                             icalcomponent *newcomp, const char *attendee);
+extern int organizer_changed(icalcomponent *oldcomp, icalcomponent *newcomp);
 
 extern icalcomponent *master_to_recurrence(icalcomponent *master,
                                            icalproperty *recurid);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4056,30 +4056,6 @@ static int setcalendarevents_schedule(const char *sched_userid,
     const char *organizer = icalproperty_get_organizer(prop);
     if (!organizer) goto done;
     if (!strncasecmp(organizer, "mailto:", 7)) organizer += 7;
-
-    /* Validate create/update. */
-    if (oldical && (mode & (JMAP_CREATE|JMAP_UPDATE))) {
-        /* Don't allow ORGANIZER to be updated */
-        const char *oldorganizer = NULL;
-
-        icalcomponent *oldcomp = NULL;
-        icalproperty *prop = NULL;
-        oldcomp =
-            icalcomponent_get_first_component(oldical, ICAL_VEVENT_COMPONENT);
-        if (oldcomp) {
-            prop = icalcomponent_get_first_property(oldcomp,
-                                                    ICAL_ORGANIZER_PROPERTY);
-        }
-        if (prop) oldorganizer = icalproperty_get_organizer(prop);
-        if (oldorganizer) {
-            if (!strncasecmp(oldorganizer, "mailto:", 7)) oldorganizer += 7;
-            if (strcasecmp(oldorganizer, organizer)) {
-                /* XXX This should become a set error. */
-                goto done;
-            }
-        }
-    }
-
     if (organizer &&
             /* XXX Hack for Outlook */ icalcomponent_get_first_invitee(comp)) {
 


### PR DESCRIPTION
Each calendar in Google Calendar has a separate organizer. If the
owner of a scheduled event moves their event from one calendar
to the other, an invite with the new ORGANIZER is sent out.

The processimip code rejects this change, but a Cyrus user may add
the updated event to their calendar. In this case, send out a
REPLY as otherwise the invitee would not show up as attending in
Google Calendar.

Signed-off-by: Robert Stepanek <rsto@fastmailteam.com>