### PR TITLE
cassandane: murder tests require --enable-murder

### DIFF
--- a/cassandane/Cassandane/Cyrus/MurderIMAP.pm
+++ b/cassandane/Cassandane/Cyrus/MurderIMAP.pm
@@ -202,6 +202,7 @@ sub check_user
 }
 
 sub test_aaasetup
+    :needs_component_murder
 {
     my ($self) = @_;
 
@@ -210,6 +211,7 @@ sub test_aaasetup
 }
 
 sub test_frontend_commands
+    :needs_component_murder
 {
     my ($self) = @_;
     my $result;
@@ -250,6 +252,7 @@ sub test_frontend_commands
 }
 
 sub test_list_specialuse
+    :needs_component_murder
 {
     my ($self) = @_;
 
@@ -317,6 +320,7 @@ sub test_list_specialuse
 }
 
 sub test_xlist
+    :needs_component_murder
 {
     my ($self) = @_;
 
@@ -386,6 +390,7 @@ sub test_xlist
 }
 
 sub test_move_to_backend_nonexistent
+    :needs_component_murder
 {
     my ($self) = @_;
 
@@ -435,6 +440,7 @@ sub test_move_to_backend_nonexistent
 }
 
 sub test_move_to_nonexistent
+    :needs_component_murder
 {
     my ($self) = @_;
 
@@ -476,7 +482,7 @@ sub test_move_to_nonexistent
 }
 
 sub test_rename_with_location
-    :AllowMoves
+    :needs_component_murder :AllowMoves
 {
     my ($self) = @_;
 
@@ -506,7 +512,7 @@ sub test_rename_with_location
 }
 
 sub test_xfer_nonexistent_unixhs
-    :UnixHierarchySep
+    :needs_component_murder :UnixHierarchySep
 {
     my ($self) = @_;
 
@@ -544,7 +550,7 @@ sub test_xfer_nonexistent_unixhs
 
 sub test_xfer_user_altns_unixhs
     :AllowMoves :AltNamespace :UnixHierarchySep
-    :min_version_3_2
+    :needs_component_murder :min_version_3_2
 {
     my ($self) = @_;
 
@@ -647,7 +653,7 @@ sub test_xfer_user_altns_unixhs
 
 sub test_xfer_user_noaltns_nounixhs
     :AllowMoves :NoAltNamespace
-    :min_version_3_2
+    :needs_component_murder :min_version_3_2
 {
     my ($self) = @_;
 
@@ -750,7 +756,7 @@ sub test_xfer_user_noaltns_nounixhs
 
 sub test_xfer_user_altns_unixhs_virtdom
     :AllowMoves :AltNamespace :UnixHierarchySep :VirtDomains
-    :min_version_3_2
+    :needs_component_murder :min_version_3_2
 {
     my ($self) = @_;
 
@@ -866,7 +872,7 @@ sub test_xfer_user_altns_unixhs_virtdom
 
 sub test_xfer_user_noaltns_nounixhs_virtdom
     :AllowMoves :NoAltNamespace :VirtDomains
-    :min_version_3_2
+    :needs_component_murder :min_version_3_2
 {
     my ($self) = @_;
 
@@ -982,7 +988,7 @@ sub test_xfer_user_noaltns_nounixhs_virtdom
 
 sub test_xfer_mailbox_altns_unixhs
     :AllowMoves :AltNamespace :UnixHierarchySep
-    :min_version_3_2 :max_version_3_4
+    :needs_component_murder :min_version_3_2 :max_version_3_4
 {
     my ($self) = @_;
 
@@ -1115,7 +1121,7 @@ sub test_xfer_mailbox_altns_unixhs
 
 sub test_xfer_no_user_intermediates
     :AllowMoves :AltNamespace :UnixHierarchySep
-    :min_version_3_5
+    :needs_component_murder :min_version_3_5
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/MurderJMAP.pm
+++ b/cassandane/Cassandane/Cyrus/MurderJMAP.pm
@@ -78,6 +78,7 @@ sub tear_down
 }
 
 sub test_aaa_setup
+    :needs_component_murder
 {
     my ($self) = @_;
 
@@ -89,6 +90,7 @@ sub test_aaa_setup
 # XXX at once, but renaming out the "bogus" and running it, and it failing,
 # XXX proves the infrastructure to prevent requesting both works.
 sub bogustest_aaa_imapjmap_setup
+    :needs_component_murder
     :IMAPMurder
 {
     my ($self) = @_;
@@ -98,7 +100,7 @@ sub bogustest_aaa_imapjmap_setup
 }
 
 sub test_frontend_commands
-    :needs_component_jmap :min_version_3_5
+    :needs_component_murder :needs_component_jmap :min_version_3_5
 {
     my ($self) = @_;
     my $result;
@@ -143,7 +145,7 @@ sub test_frontend_commands
 }
 
 sub test_backend1_commands
-    :needs_component_jmap :min_version_3_5
+    :needs_component_murder :needs_component_jmap :min_version_3_5
 {
     my ($self) = @_;
     my $result;
@@ -182,7 +184,7 @@ sub test_backend1_commands
 }
 
 sub test_backend2_commands
-    :needs_component_jmap :min_version_3_5
+    :needs_component_murder :needs_component_jmap :min_version_3_5
 {
     my ($self) = @_;
     my $result;


### PR DESCRIPTION
Turns out Cassandane::Instance breaks really badly if it tries to start up with murder configuration and there's no "mupdate" binary...

This fix simply annotates the MurderIMAP and MurderJMAP tests with the :need_component_murder feature test, so that if the installed Cyrus was built without --enable-murder, they won't try to run (and no Cassandane::Instances will be instantiated).

