### PR TITLE
iTIP deliver request crasher fix

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4210,7 +4210,7 @@ EOF
     xlog $self, "Check that the message made it to INBOX";
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
-    xlog $self, "Check that the event was removed from calendar";
+    xlog $self, "Check that the event was updated on calendar";
     $events = $CalDAV->GetEvents($CalendarId);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
@@ -4369,6 +4369,161 @@ EOF
     $self->assert_str_equals('DISPLAY', $ical->{entries}[0]{entries}[0]{properties}{action}[0]{value});
     $self->assert_str_equals('TRANSPARENT', $ical->{entries}[1]{properties}{transp}[0]{value});
     $self->assert_str_equals('DISPLAY', $ical->{entries}[1]{entries}[0]{properties}{action}[0]{value});
+}
+
+sub test_imip_update_master_and_add_override
+    :needs_component_sieve :needs_component_httpd :min_version_3_5
+{
+    # this test is mainly here to test that a crasher caused by Cyrus using
+    # a libical component after it was freed
+    my ($self) = @_;
+
+    my $IMAP = $self->{store}->get_client();
+    $self->{store}->_select();
+    $self->assert_num_equals(1, $IMAP->uid());
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+
+    xlog $self, "Create calendar user";
+    my $CalDAV = $self->{caldav};
+    my $CalendarId = 'Default';
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :outcome "outcome";
+    if string "\${outcome}" "updated" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    my $imip = <<EOF;
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-0\@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+X-Cassandane-Unique: $uuid-0
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP invite";
+    my $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 1,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Expunge the message";
+    $IMAP->store('1', '+flags', '(\\Deleted)');
+    $IMAP->expunge();
+
+    xlog $self, "Check that the event made it to calendar";
+    my $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('An Event', $events->[0]{title});
+    $self->assert_str_equals('2021-09-23T15:30:00', $events->[0]{start});
+
+
+    xlog $self, "Get the event, set per-user data, and add an alarm";
+    my $alarm = <<EOF;
+BEGIN:VALARM
+UID:myalarm
+TRIGGER;RELATED=START:PT0S
+ACTION:DISPLAY
+DESCRIPTION:CYR-140
+END:VALARM
+EOF
+    my $href = $events->[0]{href};
+    my $response = $CalDAV->Request('GET', $href);
+    my $ical = $response->{content};
+    $ical =~ s/PARTSTAT=NEEDS-ACTION/PARTSTAT=ACCEPTED/;
+    $ical =~ s/END:VEVENT/TRANSP:TRANSPARENT\n${alarm}END:VEVENT/;
+
+    $CalDAV->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
+
+    $imip = <<EOF;
+Date: Thu, 24 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-1\@example.net>
+Content-Type: text/calendar; method=CANCEL; component=VEVENT
+X-Cassandane-Unique: $uuid-1
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210924T170000
+TRANSP:OPAQUE
+SUMMARY:An Updated Event
+DTSTART;TZID=American/New_York:20210924T140000
+DTSTAMP:20210923T034327Z
+SEQUENCE:1
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210924T183000
+TRANSP:OPAQUE
+SUMMARY:An Overridden Event
+DTSTART;TZID=American/New_York:20210924T153000
+DTSTAMP:20210924T034327Z
+SEQUENCE:0
+RECURRENCE-ID;TZID=American/New_York:20210924T153000
+LOCATION:location2
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP update";
+    $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 2,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Check that the event was updated on calendar";
+    $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('An Updated Event', $events->[0]{title});
+    $self->assert_str_equals('2021-09-24T14:00:00', $events->[0]{start});
 }
 
 sub test_imip_cancel_instance

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -582,7 +582,7 @@ static int deliver_merge_request(const char *attendee,
         if (prop) recurid = icalproperty_get_value_as_string(prop);
         else {
             recurid = "";
-            master = comp;
+            master = icalcomponent_clone(comp);
         }
 
         hash_insert(recurid, comp, &comp_table);
@@ -715,6 +715,7 @@ static int deliver_merge_request(const char *attendee,
     }
 
     free_hash_table(&comp_table, NULL);
+    if (master) icalcomponent_free(master);
 
     return deliver_inbox;
 }


### PR DESCRIPTION
This fixes a crasher diagnosed by alh:

deliver_merge_request first finds the old master event:

    for (; comp; comp = icalcomponent_get_next_component(ical, kind)) {
        prop =
            icalcomponent_get_first_property(comp, ICAL_RECURRENCEID_PROPERTY);
        if (prop) recurid = icalproperty_get_value_as_string(prop);
        else {
            recurid = "";
            master = comp;
        }

        hash_insert(recurid, comp, &comp_table);
    }

And pops it into comp_table
In the next loop below:

       comp = hash_lookup(recurid, &comp_table);

And

            /* Remove component from old object */
            icalcomponent_remove_component(ical, comp);
            icalcomponent_free(comp);

Which would account for a pvl_head failure on a component (the component has been freed!)