### PR TITLE
Fix build with jmap disabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1207,12 +1207,12 @@ endif # AUTOCREATE
 
 if SIEVE
 imap_lmtpd_SOURCES += imap/lmtp_sieve.c imap/lmtp_sieve.h imap/smtpclient.c \
-                      imap/caldav_util.c imap/itip_support.c
+                      imap/caldav_util.c imap/itip_support.c imap/zoneinfo_db.c
 
 if JMAP
 imap_lmtpd_SOURCES += \
 	imap/jmap_util.c imap/jmap_mail_query.c imap/jmap_mail_query_parse.c \
-	imap/dav_util.c imap/zoneinfo_db.c imap/jmap_notif.c imap/jmap_ical.c
+	imap/dav_util.c imap/jmap_notif.c imap/jmap_ical.c
 endif # JMAP
 
 endif # SIEVE

--- a/Makefile.am
+++ b/Makefile.am
@@ -1206,13 +1206,13 @@ imap_lmtpd_SOURCES += \
 endif # AUTOCREATE
 
 if SIEVE
-imap_lmtpd_SOURCES += imap/lmtp_sieve.c imap/lmtp_sieve.h imap/smtpclient.c
+imap_lmtpd_SOURCES += imap/lmtp_sieve.c imap/lmtp_sieve.h imap/smtpclient.c \
+                      imap/caldav_util.c imap/itip_support.c
 
 if JMAP
 imap_lmtpd_SOURCES += \
 	imap/jmap_util.c imap/jmap_mail_query.c imap/jmap_mail_query_parse.c \
-	imap/caldav_util.c imap/dav_util.c imap/itip_support.c imap/zoneinfo_db.c \
-	imap/jmap_notif.c imap/jmap_ical.c
+	imap/dav_util.c imap/zoneinfo_db.c imap/jmap_notif.c imap/jmap_ical.c
 endif # JMAP
 
 endif # SIEVE

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -67,6 +67,7 @@
 #include "tree.h"
 #include "sieve/sieve.h"
 #include "imap/mailbox.h"
+#include "imap/mboxname.h"
 #include "imap/message.h"
 #include "imap/spool.h"
 #include "util.h"
@@ -78,7 +79,6 @@
 
 #ifdef WITH_JMAP
 #include "imap/jmap_mail_query.h"
-#include "imap/mboxname.h"
 #endif
 
 static char vacation_answer;


### PR DESCRIPTION
When jmap is disabled as compile option, build fails with missing includes and failed linking.