### PR TITLE
Support Cyrus build on Debian arm64

### DIFF
--- a/imap/backend.c
+++ b/imap/backend.c
@@ -831,7 +831,7 @@ static int backend_login(struct backend *ret, const char *userid,
                      * automatically send capabilities, so we treat it
                      * as optional.
                      */
-                    char ch;
+                    int ch;
 
                     /* wait and probe for possible auto-capability response */
                     usleep(250000);

--- a/imap/cyr_ls.c
+++ b/imap/cyr_ls.c
@@ -71,6 +71,7 @@
 #include <sys/param.h>
 #include <pwd.h>
 #include <grp.h>
+#include <inttypes.h>
 
 #include "bsearch.h"
 #include "util.h"
@@ -182,7 +183,7 @@ static void long_list(struct stat *statp)
 
     strftime(datestr, 13, datefmt, localtime(&(statp->st_ctime)));
 
-    printf("%c%c%c%c%c%c%c%c%c%c %lu %-8s %-8s % 10ld %s ",
+    printf("%c%c%c%c%c%c%c%c%c%c %" PRIuMAX " %-8s %-8s % 10ld %s ",
            S_ISDIR(statp->st_mode) ? 'd' : '-',
            (statp->st_mode & S_IRUSR) ? 'r' : '-',
            (statp->st_mode & S_IWUSR) ? 'w' : '-',
@@ -193,7 +194,8 @@ static void long_list(struct stat *statp)
            (statp->st_mode & S_IROTH) ? 'r' : '-',
            (statp->st_mode & S_IWOTH) ? 'w' : '-',
            (statp->st_mode & S_IXOTH) ? 'x' : '-',
-           statp->st_nlink, pwd->pw_name, grp->gr_name,
+           (uintmax_t) statp->st_nlink, // int size differs by platform
+           pwd->pw_name, grp->gr_name,
            statp->st_size, datestr);
 }
 

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2969,7 +2969,14 @@ HIDDEN void log_request(long code, struct transaction_t *txn)
     }
     if (code == HTTP_SWITCH_PROT || code == HTTP_UPGRADE) {
         buf_printf(logbuf, "%supgrade=", sep);
+#pragma GCC diagnostic push
+// despite the name, this pragma is for clang. clang complains about
+// the va_list noargs variable being unitialized. And gcc complains
+// about an unknown pragma if we correctly address clang in the
+// pragma definition. So let clang just pick up the GCC pragma.
+#pragma GCC diagnostic ignored "-Wuninitialized"
         comma_list_body(logbuf, upgrd_tokens, txn->flags.upgrade, 0, noargs);
+#pragma GCC diagnostic pop
         sep = "; ";
     }
     if (txn->flags.te) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8832,7 +8832,7 @@ static json_t *_header_from_addresses(json_t *addrs,
                 enum name_type { ATOM, QUOTED_STRING, HIGH_BIT } name_type = ATOM;
                 const char *p;
                 for (p = name; *p; p++) {
-                    char c = *p;
+                    unsigned char c = *p;
                     /* Check for ATOM characters */
                     if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'))
                         continue;
@@ -8840,7 +8840,7 @@ static json_t *_header_from_addresses(json_t *addrs,
                         continue;
                     if (strchr("!#$%&'*+-/=?^_`{|}~", c))
                         continue;
-                    if (c < 0) {
+                    if (c > 127) {
                         /* Contains at least one high bit character. */
                         name_type = HIGH_BIT;
                         break;

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1414,6 +1414,7 @@ static int sieve_imip(void *ac, void *ic, void *sc, void *mc,
     const char *originator = NULL, *recipient = NULL;
     strarray_t sched_addresses = STRARRAY_INITIALIZER;
     unsigned sched_flags = 0;
+    struct bodypart **parts = NULL;
     int ret = 0;
 
     prometheus_increment(CYRUS_LMTP_SIEVE_IMIP_TOTAL);
@@ -1438,7 +1439,6 @@ static int sieve_imip(void *ac, void *ic, void *sc, void *mc,
 
     /* XXX currently struct bodypart as defined in message.h is the same as
        sieve_bodypart_t as defined in sieve_interface.h, so we can typecast */
-    struct bodypart **parts = NULL;
     const char *content_types[] = { "text/calendar", NULL };
     message_fetch_part(mydata->content, content_types, &parts);
     if (parts && parts[0]) {

--- a/imap/vcard_support.c
+++ b/imap/vcard_support.c
@@ -159,7 +159,7 @@ static const struct image_signature {
                       { 0, 0, { 0x00 } } } },
     { "image/webp", { { 0, 4, { 0x52, 0x49, 0x46, 0x46 } },             // "RIFF"
                       { 8, 4, { 0x57, 0x45, 0x42, 0x50 } } } },         // "WEBP"
-    { NULL }
+    { 0 }
 };
 
 /* Decode a base64-encoded binary vCard property and calculate a GUID.

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -3231,7 +3231,7 @@ int main(int argc, char **argv)
                      * automatically send capabilities, so we treat it
                      * as optional.
                      */
-                    char ch;
+                    int ch;
 
                     /* wait and probe for possible auto-capability response*/
                     usleep(250000);


### PR DESCRIPTION
Some sections in the Cyrus codebase implicitly include assumptions that are only guaranteed on the x86 platform. This patch changes these to work on both x86 and arm64. Also includes fixes that showed up when compiling with clang instead of gcc.

The test system used was

    Linux xxx 5.10.0-12-arm64 #1 SMP Debian 5.10.103-1 (2022-03-07) aarch64 GNU/Linux

All cunit and Cassandane tests pass on both platforms.