### PR TITLE
cunit: don't interpolate the arguments into the format string!

### DIFF
--- a/cunit/cyrunit.h
+++ b/cunit/cyrunit.h
@@ -76,8 +76,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     long long _a = (actual), _e = (expected);                           \
     CU_assertFormatImplementation((_a == _e), __LINE__,                 \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_EQUAL(" #actual "=%lld," #expected "=%lld)",         \
-        _a, _e);                                                        \
+        "CU_ASSERT_EQUAL(%s=%lld,%s=%lld)",                             \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_EQUAL_FATAL
@@ -85,8 +85,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     long long _a = (actual), _e = (expected);                           \
     CU_assertFormatImplementation((_a == _e), __LINE__,                 \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_EQUAL_FATAL(" #actual "=%lld," #expected "=%lld)",   \
-        _a, _e);                                                        \
+        "CU_ASSERT_EQUAL_FATAL(%s=%lld,%s=%lld)",                       \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_NOT_EQUAL
@@ -94,8 +94,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     long long _a = (actual), _e = (expected);                           \
     CU_assertFormatImplementation((_a != _e), __LINE__,                 \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_NOT_EQUAL(" #actual "=%lld," #expected "=%lld)",     \
-        _a, _e);                                                        \
+        "CU_ASSERT_NOT_EQUAL(%s=%lld,%s=%lld)",                         \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_NOT_EQUAL_FATAL
@@ -103,8 +103,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     long long _a = (actual), _e = (expected);                           \
     CU_assertFormatImplementation((_a != _e), __LINE__,                 \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_NOT_EQUAL_FATAL(" #actual "=%lld," #expected "=%lld)", \
-        _a, _e);                                                        \
+        "CU_ASSERT_NOT_EQUAL_FATAL(%s=%lld,%s=%lld)",                   \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 
@@ -114,8 +114,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation((_a == _e), __LINE__,                 \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_PTR_EQUAL(" #actual "=%p," #expected "=%p)",         \
-        _a, _e);                                                        \
+        "CU_ASSERT_PTR_EQUAL(%s=%p,%s=%p)",                             \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_PTR_EQUAL_FATAL
@@ -123,8 +123,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation((_a == _e), __LINE__,                 \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_PTR_EQUAL_FATAL(" #actual "=%p," #expected "=%p)",   \
-        _a, _e);                                                        \
+        "CU_ASSERT_PTR_EQUAL_FATAL(%s=%p,%s=%p)",                       \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_PTR_NOT_EQUAL
@@ -132,8 +132,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation((_a != _e), __LINE__,                 \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_PTR_NOT_EQUAL(" #actual "=%p," #expected "=%p)",     \
-        _a, _e);                                                        \
+        "CU_ASSERT_PTR_NOT_EQUAL(%s=%p,%s=%p)",                         \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_PTR_NOT_EQUAL_FATAL
@@ -141,8 +141,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation((_a != _e), __LINE__,                 \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_PTR_NOT_EQUAL_FATAL(" #actual "=%p," #expected "=%p)", \
-        _a, _e);                                                        \
+        "CU_ASSERT_PTR_NOT_EQUAL_FATAL(%s=%p,%s=%p)",                   \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_PTR_NULL
@@ -150,7 +150,7 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual);                                          \
     CU_assertFormatImplementation(!(_a), __LINE__,                      \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_PTR_NULL(" #actual ")");                             \
+        "CU_ASSERT_PTR_NULL(%s)", #actual);                             \
 } while(0)
 
 #undef CU_ASSERT_PTR_NULL_FATAL
@@ -158,7 +158,7 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual);                                          \
     CU_assertFormatImplementation(!(_a), __LINE__,                      \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_PTR_NULL_FATAL(" #actual ")");                       \
+        "CU_ASSERT_PTR_NULL(%s)", #actual);                             \
 } while(0)
 
 #undef CU_ASSERT_PTR_NOT_NULL
@@ -166,7 +166,7 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual);                                          \
     CU_assertFormatImplementation(!!(_a), __LINE__,                     \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_PTR_NOT_NULL(" #actual ")");                         \
+        "CU_ASSERT_PTR_NULL(%s)", #actual);                             \
 } while(0)
 
 #undef CU_ASSERT_PTR_NOT_NULL_FATAL
@@ -174,7 +174,7 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const void *_a = (actual);                                          \
     CU_assertFormatImplementation(!!(_a), __LINE__,                     \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_PTR_NOT_NULL_FATAL(" #actual ")");                   \
+        "CU_ASSERT_PTR_NULL(%s)", #actual);                             \
 } while(0)
 
 #undef CU_ASSERT_STRING_EQUAL
@@ -182,8 +182,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const char *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation(!strcmp(_a?_a:"",_e?_e:""), __LINE__, \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_STRING_EQUAL(" #actual "=\"%s\"," #expected "=\"%s\")", \
-        _a, _e);                                                        \
+        "CU_ASSERT_STRING_EQUAL(%s=\"%s\",%s=\"%s\")",                  \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_STRING_EQUAL_FATAL
@@ -191,8 +191,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const char *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation(!strcmp(_a?_a:"",_e?_e:""), __LINE__, \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_STRING_EQUAL_FATAL(" #actual "=\"%s\"," #expected "=\"%s\")", \
-        _a, _e);                                                        \
+        "CU_ASSERT_STRING_EQUAL_FATAL(%s=\"%s\",%s=\"%s\")",            \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_STRING_NOT_EQUAL
@@ -200,8 +200,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const char *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation(!!strcmp(_a?_a:"",_e?_e:""),          \
         __LINE__, __FILE__, "", CU_FALSE,                               \
-        "CU_ASSERT_STRING_NOT_EQUAL(" #actual "=\"%s\"," #expected "=\"%s\")", \
-        _a, _e);                                                        \
+        "CU_ASSERT_STRING_NOT_EQUAL(%s=\"%s\",%s=\"%s\")",              \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #undef CU_ASSERT_STRING_NOT_EQUAL_FATAL
@@ -209,8 +209,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     const char *_a = (actual), *_e = (expected);                        \
     CU_assertFormatImplementation(!!strcmp(_a?_a:"",_e?_e:""),          \
         __LINE__, __FILE__, "", CU_TRUE,                                \
-        "CU_ASSERT_STRING_NOT_EQUAL_FATAL(" #actual "=\"%s\"," #expected "=\"%s\")", \
-        _a, _e);                                                        \
+        "CU_ASSERT_STRING_NOT_EQUAL_FATAL(%s=\"%s\",%s=\"%s\")",        \
+        #actual, _a, #expected, _e);                                    \
 } while(0)
 
 #define CU_SYSLOG_MATCH(re) \
@@ -221,7 +221,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     _a = CU_syslogMatchEnd((match), &_s);                               \
     CU_assertFormatImplementation((_a == _e), __LINE__,                 \
         __FILE__, "", CU_FALSE,                                         \
-        "CU_ASSERT_SYSLOG(/%s/=%u, " #expected "=%u)", _s, _a, _e);     \
+        "CU_ASSERT_SYSLOG(/%s/=%u, %s=%u)",                             \
+        _s, _a, #expected, _e);                                         \
 } while(0)
 
 #define CU_ASSERT_SYSLOG_FATAL(match, expected) do {                    \
@@ -229,8 +230,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     _a = CU_syslogMatchEnd((match), &_s);                               \
     CU_assertFormatImplementation((_a == _e), __LINE__,                 \
         __FILE__, "", CU_TRUE,                                          \
-        "CU_ASSERT_SYSLOG_FATAL(/%s/=%u, " #expected "=%u)",            \
-        _s, _a, _e);                                                    \
+        "CU_ASSERT_SYSLOG_FATAL(/%s/=%u, %s=%u)",                       \
+        _s, _a, #expected, _e);                                         \
 } while(0)
 
 extern jmp_buf fatal_jbuf;


### PR DESCRIPTION
This was causing crashers with newer compilers.  It's such an obnoxious thing.

Much better to pass the strings to the formatter as separate strings.