### PR TITLE
iTIP REQUEST Fix

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4507,7 +4507,7 @@ EOF
     xlog $self, "Check that the message made it to INBOX";
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
-    xlog $self, "Check that the updated event made it to calendar";
+    xlog $self, "Check that the standalone instance was dropped from the calendar";
     $events = $CalDAV->GetEvents($CalendarId);
 
     $self->assert_equals(1, scalar @$events);

--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4328,6 +4328,20 @@ CREATED:20210923T034327Z
 UID:$uuid
 DTEND;TZID=America/New_York:20210923T183000
 TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+RRULE:FREQ=WEEKLY
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
 SUMMARY:An Overridden Event
 DTSTART;TZID=American/New_York:20210923T153000
 DTSTAMP:20210924T034327Z
@@ -4369,6 +4383,138 @@ EOF
     $self->assert_str_equals('DISPLAY', $ical->{entries}[0]{entries}[0]{properties}{action}[0]{value});
     $self->assert_str_equals('TRANSPARENT', $ical->{entries}[1]{properties}{transp}[0]{value});
     $self->assert_str_equals('DISPLAY', $ical->{entries}[1]{entries}[0]{properties}{action}[0]{value});
+}
+
+sub test_imip_invite_single_then_master
+    :needs_component_sieve :needs_component_httpd :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $IMAP = $self->{store}->get_client();
+    $self->{store}->_select();
+    $self->assert_num_equals(1, $IMAP->uid());
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+
+    xlog $self, "Create calendar user";
+    my $CalDAV = $self->{caldav};
+    my $CalendarId = 'Default';
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :outcome "outcome";
+    if string "\${outcome}" "updated" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    my $imip = <<EOF;
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-0\@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+X-Cassandane-Unique: $uuid-0
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+RECURRENCE-ID;TZID=American/New_York:20210923T153000
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP invite";
+    my $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 1,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Expunge the message";
+    $IMAP->store('1', '+flags', '(\\Deleted)');
+    $IMAP->expunge();
+
+    xlog $self, "Check that the event made it to calendar";
+    my $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_null($events->[0]{recurrenceRule});
+    $self->assert_not_null($events->[0]{recurrenceOverrides});
+
+    xlog $self, "Get and accept the event";
+    my $href = $events->[0]{href};
+    my $response = $CalDAV->Request('GET', $href);
+    my $ical = $response->{content};
+    $ical =~ s/PARTSTAT=NEEDS-ACTION/PARTSTAT=ACCEPTED/;
+
+    $CalDAV->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
+
+    $imip = <<EOF;
+Date: Thu, 24 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-1\@example.net>
+Content-Type: text/calendar; method=CANCEL; component=VEVENT
+X-Cassandane-Unique: $uuid-1
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Overridden Event
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210924T034327Z
+SEQUENCE:0
+RRULE:FREQ=WEEKLY
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP update";
+    $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 2,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Check that the updated event made it to calendar";
+    $events = $CalDAV->GetEvents($CalendarId);
+
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_not_null($events->[0]{recurrenceRule});
+    $self->assert_null($events->[0]{recurrenceOverrides});
+    $self->assert_str_equals('needs-action', $events->[0]{participants}{'cassandane@example.com'}{scheduleStatus});    
 }
 
 sub test_imip_update_master_and_add_override
@@ -4723,6 +4869,20 @@ CREATED:20210923T034327Z
 UID:$uuid
 DTEND;TZID=America/New_York:20210923T183000
 TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+RRULE:FREQ=WEEKLY
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
 SUMMARY:An Overridden Event
 DTSTART;TZID=American/New_York:20210923T153000
 DTSTAMP:20210924T034327Z
@@ -4781,6 +4941,21 @@ DTSTART;TZID=American/New_York:20210923T153000
 DTSTAMP:20210925T034327Z
 SEQUENCE:0
 RRULE:FREQ=WEEKLY
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:bar\@example.net
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Overridden Event
+DTSTART;TZID=American/New_York:20210923T153000
+DTSTAMP:20210924T034327Z
+SEQUENCE:0
+RECURRENCE-ID;TZID=American/New_York:20210923T153000
 LOCATION:location2
 ORGANIZER;CN=Test User:MAILTO:foo\@example.net
 ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
@@ -5578,6 +5753,19 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
 METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+RECURRENCE-ID;TZID=America/New_York:20210923T153000
+TRANSP:OPAQUE
+SUMMARY:instance1
+DTSTART;TZID=America/New_York:20210923T153000
+DURATION:PT1H
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;X-JMAP-ID=cassandane:MAILTO:cassandane\@example.com
+END:VEVENT
 BEGIN:VEVENT
 CREATED:20210923T034327Z
 UID:$uuid

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -594,7 +594,10 @@ static int deliver_merge_request(const char *attendee,
     for (; itip; itip = icalcomponent_get_next_component(request, kind)) {
         icalcomponent *new_comp = icalcomponent_clone(itip);
 
-        /* Lookup and remove this comp from the hash table */
+        /* Lookup this iTIP comp in the hash table of old object components.
+           We acually remove it from the hash table because those that are
+           left behind are those that will be removed from the old object
+           (see end of loop). */
         prop =
             icalcomponent_get_first_property(itip, ICAL_RECURRENCEID_PROPERTY);
         if (prop) recurid = icalproperty_get_value_as_string(prop);
@@ -714,7 +717,8 @@ static int deliver_merge_request(const char *attendee,
         icalcomponent_add_component(ical, new_comp);
     }
 
-    /* Remove components of old object that still remain in the hash table */
+    /* Remove components of old object that are not present in the iTIP request
+       (those that still remain in the old component hash table). */
     comp = icalcomponent_get_first_real_component(ical);
     for (; comp; comp = next) {
         next = icalcomponent_get_next_component(ical, kind);


### PR DESCRIPTION
Organizers MUST send the entire per-attendee view of an event in an iTIP REQUEST.
Therefore, any component NOT in the request MUST be removed from the attendee's existing iCalendar resource.

This PR also fixes existing Cass tests to properly include ALL components in each iTIP REQUEST.