### PR TITLE
RENAME INBOX INBOX.foo fix

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7780,11 +7780,11 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location)
             state = imapd_index;
         }
         else {
-            struct index_init init;
-            memset(&init, 0, sizeof(init));
-            init.userid = imapd_userid;
-            init.authstate = imapd_authstate;
-            init.out = imapd_out;
+            struct index_init init = {
+                .out = imapd_out,
+                .userid = imapd_userid,
+                .authstate = imapd_authstate
+            };
             r = index_open(oldmailboxname, &init, &state);
             seqset_free(&init.vanishedlist);
         }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7780,7 +7780,13 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location)
             state = imapd_index;
         }
         else {
-            r = index_open(oldmailboxname, NULL, &state);
+            struct index_init init;
+            memset(&init, 0, sizeof(init));
+            init.userid = imapd_userid;
+            init.authstate = imapd_authstate;
+            init.out = imapd_out;
+            r = index_open(oldmailboxname, &init, &state);
+            seqset_free(&init.vanishedlist);
         }
 
         /* move all the emails to the new folder */


### PR DESCRIPTION
Need an index_init so index_check() has a protstream.
Fixes a bug in RENAME INBOX INBOX.foo if INBOX hasn't been selected.
This bug was reported by Sentry via an assert() 