### PR TITLE
Cassini: check environment for config overrides

### DIFF
--- a/cassandane/Cassandane/Cassini.pm
+++ b/cassandane/Cassandane/Cassini.pm
@@ -152,7 +152,11 @@ sub val
     #
     my $envname = "\UCASSINI $section $name\E";
     $envname =~ s{[^A-Z0-9]+}{_}g;
-    return $ENV{$envname} if defined $ENV{$envname};
+    if (defined $ENV{$envname}) {
+        xlog "Using configuration from environment:"
+             . " \$$envname=\"$ENV{$envname}\"";
+        return $ENV{$envname};
+    }
 
     # see the Config::IniFiles documentation for ->val()
     return $self->{inifile}->val($section, $name, $default);

--- a/cassandane/Cassandane/Cassini.pm
+++ b/cassandane/Cassandane/Cassini.pm
@@ -140,6 +140,20 @@ sub val
 {
     my ($self, $section, $name, $default) = @_;
 
+    # Allow overrides from specially-named environment variables.
+    #
+    # Examples:
+    #
+    # to override the "rootdir" option from the "[cassandane]" section,
+    # set: CASSINI_CASSANDANE_ROOTDIR=/some/different/value
+    #
+    # to override the "prefix" option from the "[cyrus default]" section,
+    # set: CASSINI_CYRUS_DEFAULT_PREFIX=/some/different/value
+    #
+    my $envname = "\UCASSINI $section $name\E";
+    $envname =~ s{[^A-Z0-9]+}{_}g;
+    return $ENV{$envname} if defined $ENV{$envname};
+
     # see the Config::IniFiles documentation for ->val()
     return $self->{inifile}->val($section, $name, $default);
 }

--- a/cassandane/Cassandane/Cassini.pm
+++ b/cassandane/Cassandane/Cassini.pm
@@ -138,10 +138,10 @@ sub instance
 
 sub val
 {
-    # Args are: section, name, default
+    my ($self, $section, $name, $default) = @_;
+
     # see the Config::IniFiles documentation for ->val()
-    my ($self, @args) = @_;
-    return $self->{inifile}->val(@args);
+    return $self->{inifile}->val($section, $name, $default);
 }
 
 sub bool_val

--- a/cassandane/cassandane.ini.example
+++ b/cassandane/cassandane.ini.example
@@ -40,6 +40,18 @@
 #  OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+# You can set (or override) any of the settings in this file by setting
+# an environment variable thus: CASSINI_SECTION_NAME=value
+# If an environment variable so named is defined, its value will be used
+# instead of the value from the cassandane.ini file
+#
+# e.g.
+# [cassandane].rootdir   -> CASSINI_CASSANDANE_ROOTDIR
+# [cyrus default].prefix -> CASSINI_CYRUS_DEFAULT_PREFIX
+#
+# See Cassandane::Cassini::val() for specific details of how
+# the environment variable name to look up is constructed
+
 # This section describes configurable properties of the
 # Cassandane infrastructure
 [cassandane]


### PR DESCRIPTION
This changes allows environment variables to take precedence over options specified in cassandane.ini

The main use case I imagine for this is where your Cyrus build wrapper installs Cyrus to a prefix named for the version of the build: in this case, it's annoying to have to edit cassandane.ini to update the `[cyrus default].prefix` path every time you want to test a new build.  With environment variables supported as configuration sources, you could have your build wrapper also scaffold a CASSINI_CYRUS_DEFAULT_PREFIX environment variable into place as it does the install, and let Cassandane use that to find Cyrus.

This adds a new occurrence of the string "9100", so if #3975 lands first I'll need to fix it up, or vice-versa.

I plan to backport this to the release branches, so that if I start using it in my setup, it doesn't break when I'm doing releases of older versions.