### PR TITLE
cassandane: fix up "cleanup" bugs

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -46,6 +46,7 @@ use Scalar::Util qw(refaddr);
 use List::Util qw(uniq);
 use Digest::file qw(digest_file_hex);
 use File::Temp qw(tempfile);
+use File::Path qw(rmtree);
 
 use lib '.';
 use base qw(Cassandane::Unit::TestCase);
@@ -904,37 +905,40 @@ sub tear_down
     $self->{backend1_adminstore} = undef;
 
     my @stop_errors;
+    my @basedirs;
 
     if (defined $self->{instance})
     {
         eval { push @stop_errors, $self->{instance}->stop() };
-        $self->{instance}->cleanup();
+        push @basedirs, $self->{instance}->get_basedir();
         $self->{instance} = undef;
     }
     if (defined $self->{backups})
     {
         eval { push @stop_errors, $self->{backups}->stop() };
-        $self->{backups}->cleanup();
+        push @basedirs, $self->{backups}->get_basedir();
         $self->{backups} = undef;
     }
     if (defined $self->{backend2})
     {
         eval { push @stop_errors, $self->{backend2}->stop() };
-        $self->{backend2}->cleanup();
+        push @basedirs, $self->{backend2}->get_basedir();
         $self->{backend2} = undef;
     }
     if (defined $self->{replica})
     {
         eval { push @stop_errors, $self->{replica}->stop() };
-        $self->{replica}->cleanup();
+        push @basedirs, $self->{replica}->get_basedir();
         $self->{replica} = undef;
     }
     if (defined $self->{frontend})
     {
         eval { push @stop_errors, $self->{frontend}->stop() };
-        $self->{frontend}->cleanup();
+        push @basedirs, $self->{frontend}->get_basedir();
         $self->{frontend} = undef;
     }
+
+    $self->{cleanup_basedirs} = [@basedirs];
 
     # maybe there's multiple errors, but we can only die for one of them...
     die $stop_errors[0] if scalar @stop_errors;
@@ -944,7 +948,17 @@ sub tear_down
 
 sub post_tear_down
 {
-    my ($self) = @_;
+    my ($self, $result) = @_;
+
+    if ($result eq 'pass'
+        && ref $self->{cleanup_basedirs}
+        && Cassandane::Cassini->instance()->bool_val('cassandane', 'cleanup')
+    ) {
+        foreach my $basedir (@{$self->{cleanup_basedirs}}) {
+            xlog $self, "Cleaning up basedir " . $basedir;
+            rmtree $basedir;
+        }
+    }
 
     die "Found some stray processes"
         if (Cassandane::GenericDaemon::kill_processes_on_ports(

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1541,18 +1541,6 @@ sub stop
     return @errors;
 }
 
-sub cleanup
-{
-    my ($self) = @_;
-
-    if (Cassandane::Cassini->instance()->bool_val('cassandane', 'cleanup'))
-    {
-        # Remove all on-disk traces of this instance
-        xlog "Cleaning up basedir " . $self->{basedir};
-        rmtree $self->{basedir};
-    }
-}
-
 sub DESTROY
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -289,6 +289,8 @@ sub _make_instance_info
 
 sub _make_unique_instance_info
 {
+    # This must be kept in sync with cleanup_leftovers, which expects
+    # to be able to recognise instance directories by name for cleanup.
     if (!defined $stamp)
     {
         $stamp = to_iso8601(DateTime->now);
@@ -383,7 +385,15 @@ sub cleanup_leftovers
     my @dirs;
     while (my $e = readdir(ROOT))
     {
-        push(@dirs, $e) if ($e =~ m/^[0-9]{6}([A-Z]|)[0-9]{1,}$/);
+        # This must be kept in sync with _make_unique_instance_info,
+        # which is what names and creates these directories.
+        my $basedirpat = qr{
+            \d{6}               # UTC timestamp as HHMMSS
+            (?:[0-9A-F]{2,})?   # optional worker ID as 2+ hex digits
+            [0-9A-F]{2,}        # unique number as 2+ hex digits
+        }ax;
+
+        push(@dirs, $e) if $e =~ m/$basedirpat/;
     }
     closedir ROOT;
 

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -399,7 +399,9 @@ sub cleanup_leftovers
 
     map
     {
-        xlog "Cleaning up old basedir $rootdir/$_";
+        if (get_verbose) {
+            xlog "Cleaning up old basedir $rootdir/$_";
+        }
         rmtree "$rootdir/$_";
     } @dirs;
 }

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -802,7 +802,7 @@ sub _run_workitem
     {
         eval
         {
-            $test->post_tear_down();
+            $test->post_tear_down($witem->{result});
         };
         my $ex = $@;
         if ($ex)


### PR DESCRIPTION
Here's how the cleanup option is supposed to work, according to documentation:

https://github.com/cyrusimap/cyrus-imapd/blob/5b2bf0f12955469241a6c75c5d88f1781377c13c/cassandane/doc/running_tests.txt#L155-L160

> Firstly, it immediately cleans up any files left over in /var/tmp/cass/.

This wasn't working consistently, because I guess at some point we changed how we name the instance directories without changing the regex we use to recognise them at cleanup, and so they would only match (and be cleaned up) by accident.

The first commit here fixes the regex to match how these names are created, so that leftovers from previous runs are correctly removed at startup.  Also adds comments cross-referencing both places that need to be updated next time we change either.

It turns out this is obscenely noisy, so the second commit only logs that it's doing this if we're running verbosely.

> Secondly, it cleans up any such files after each test, unless the test fails.

This was a lie.  If cleanup was enabled, instance directories were always cleaned up after the test ran, regardless of whether it passed or failed.  This made the cleanup option pretty useless -- if some test failed, you couldn't debug it, because the state was already gone.

The third commit here fixes this by moving the cleanup out of `tear_down()`, which has no way of knowing the result, and into `post_tear_down()`, which does.  It's worth observing that `post_tear_down()` only applies to test suites that inherit from Cassandane::Cyrus::TestCase (not Cassandane::Unit::Testcase), but that's fine, because only Cassandane::Cyrus::TestCase tests create Instance objects in the first place.

I plan to backport this to 3.6, and maybe earlier.