### PR TITLE
Allow changing text uuid <-> urn:uuid

### DIFF
--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1293,10 +1293,14 @@ static int carddav_put(struct transaction_t *txn, void *obj,
         goto done;
     }
 
-    /* Check for changed UID */
+    /* Check for changed UID -- Allow for text uuid <-> urn:uuid */
     struct carddav_data *cdata;
     carddav_lookup_resource(db, txn->req_tgt.mbentry, resource, &cdata, 0);
-    if (cdata->dav.imap_uid && strcmpsafe(cdata->vcard_uid, uid)) {
+    
+    const char *olduid = cdata->vcard_uid;
+    if (!strncmp(uid, "urn:uuid:", 9)) uid += 9;
+    if (!strncmpsafe(olduid, "urn:uuid:", 9)) olduid += 9;
+    if (cdata->dav.imap_uid && strcmpsafe(olduid, uid)) {
         /* CARDDAV:no-uid-conflict */
         char *owner;
         const char *mboxname;


### PR DESCRIPTION
User ran into an issue where they create a contact via Fastmail UI which writes a v3 vCard having UID with a text value uuid.
emClient tries to update this contact via CardDAV as a v4 vCard having a UID with a urn:uuid (with same uuid).

Cyrus would previously reject this thinking the client is trying to change the UID value, but in actuality the default UID value type for v3 is text and for v4 is URL.