### PR TITLE
jmap_calendar: expose JMAP metadata and UTC times for private events

### DIFF
--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3162,6 +3162,7 @@ static void getcalendarevents_del_privateprops(json_t *jsevent)
     static json_t *publicprops = NULL;
     if (!publicprops) {
         publicprops = json_object();
+        json_object_set_new(publicprops, "calendarIds", json_true());
         json_object_set_new(publicprops, "created", json_true());
         json_object_set_new(publicprops, "due", json_true());
         json_object_set_new(publicprops, "duration", json_true());
@@ -3170,6 +3171,7 @@ static void getcalendarevents_del_privateprops(json_t *jsevent)
         json_object_set_new(publicprops, "excludedRecurrenceRules", json_true());
         json_object_set_new(publicprops, "freeBusyStatus", json_true());
         json_object_set_new(publicprops, "id", json_true());
+        json_object_set_new(publicprops, "isDraft", json_true());
         json_object_set_new(publicprops, "privacy", json_true());
         json_object_set_new(publicprops, "recurrenceId", json_true());
         json_object_set_new(publicprops, "recurrenceIdTimeZone", json_true());
@@ -3182,6 +3184,8 @@ static void getcalendarevents_del_privateprops(json_t *jsevent)
         json_object_set_new(publicprops, "timeZones", json_true());
         json_object_set_new(publicprops, "uid", json_true());
         json_object_set_new(publicprops, "updated", json_true());
+        json_object_set_new(publicprops, "utcStart", json_true());
+        json_object_set_new(publicprops, "utcEnd", json_true());
     }
 
     const char *key;


### PR DESCRIPTION
The JMAP Calendars specification requires the following properties
to be public:

- calendarIds
- isDraft
- utcStart
- utcEnd