### PR TITLE
IMAP: forbid non-admins to delete non-IMAP mailboxes

### DIFF
--- a/cassandane/Cassandane/Cyrus/Delete.pm
+++ b/cassandane/Cassandane/Cyrus/Delete.pm
@@ -910,4 +910,17 @@ sub test_no_delete_with_children
     $self->assert_str_equals('no', $talk->get_last_completion_response());
 }
 
+sub test_no_delete_non_imap
+    :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $store = $self->{store};
+    my $talk = $store->get_client();
+
+    $talk->delete('INBOX.#calendars.Default');
+    $self->assert_str_equals('no', $talk->get_last_completion_response());
+    $self->assert_matches(qr/Permission denied/i, $talk->get_last_error());
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/Delete.pm
+++ b/cassandane/Cassandane/Cyrus/Delete.pm
@@ -921,6 +921,11 @@ sub test_no_delete_non_imap
     $talk->delete('INBOX.#calendars.Default');
     $self->assert_str_equals('no', $talk->get_last_completion_response());
     $self->assert_matches(qr/Permission denied/i, $talk->get_last_error());
+
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $admintalk->delete('user.cassandane.#calendars.Default');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
 }
 
 1;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2156,6 +2156,12 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
     r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
     if (r) goto done;
 
+    /* Don't allow users to delete non-IMAP mailboxes */
+    if (!isadmin && (mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL)) {
+        r = IMAP_PERMISSION_DENIED;
+        goto done;
+    }
+
     /* check if user has Delete right (we've already excluded non-admins
      * from deleting a user mailbox) */
     if (checkacl && !(mbentry->mbtype & MBTYPE_INTERMEDIATE)) {
@@ -2281,6 +2287,12 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
 
     r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
     if (r) goto done;
+
+    /* Don't allow users to delete non-IMAP mailboxes */
+    if (!isadmin && (mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL)) {
+        r = IMAP_PERMISSION_DENIED;
+        goto done;
+    }
 
     if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
         // make it deleted and mark it done!


### PR DESCRIPTION
Previously, a user could DELETE 'INBOX.#sieve' even though it was hidden from LIST