### PR TITLE
Sieve include and implicit keep fix

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -5810,4 +5810,32 @@ EOF
     }, $res->[0][1]{list}[1]{calendarIds});
 }
 
+sub test_include_cancel_implicit_keep
+    :needs_component_sieve
+{
+    my ($self) = @_;
+
+    xlog $self, "Install a script which includes another";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["include"];
+include "foo";
+EOF
+    );
+
+    xlog $self, "Install a script to be included";
+    $self->{instance}->install_sieve_script(<<EOF
+# This should cancel implicit keep
+discard;
+EOF
+    , name=>'foo');
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that no messages are in INBOX";
+    $self->{store}->set_folder('INBOX');
+    $self->check_messages({}, check_guid => 0);
+}
+
 1;

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -1643,7 +1643,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
     int op;
     int version;
     int requires = 0;
-    int implicit_keep = 1;
 
     sieve_bytecode_t *bc_cur = exe->bc_cur;
     bytecode_input_t *bc = (bytecode_input_t *) bc_cur->data;
@@ -1727,8 +1726,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
             res = do_keep(i, sc, actions, actionflags, headers);
             if (res == SIEVE_RUN_ERROR)
                 *errmsg = "Keep can not be used with Reject";
-            else
-                implicit_keep = 0;
 
             actionflags = NULL;
             break;
@@ -1738,8 +1735,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
         case B_DISCARD:
             res = do_discard(actions);
 
-            if (res == SIEVE_OK)
-                implicit_keep = 0;
             break;
 
 
@@ -1758,8 +1753,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
 
             if (res == SIEVE_RUN_ERROR)
                 *errmsg = "[e]Reject can not be used with any other action";
-            else
-                implicit_keep = 0;
 
             break;
         }
@@ -1799,8 +1792,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
 
             if (res == SIEVE_RUN_ERROR)
                 *errmsg = "Fileinto can not be used with Reject";
-            else if (!cmd.u.f.copy)
-                implicit_keep = 0;
 
             actionflags = NULL;
             break;
@@ -1850,8 +1841,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
 
             if (res == SIEVE_RUN_ERROR)
                 *errmsg = "Snooze can not be used with Reject";
-            else
-                implicit_keep = 0;
 
             actionflags = NULL;
             break;
@@ -1926,8 +1915,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
 
             if (res == SIEVE_RUN_ERROR)
                 *errmsg = "Redirect can not be used with Reject";
-            else if (!cmd.u.r.copy)
-                implicit_keep = 0;
 
             break;
         }
@@ -2522,17 +2509,6 @@ int sieve_eval_bc(sieve_execute_t *exe, int is_incl, sieve_interp_t *i,
 
   done:
     bc_cur->is_executing = 0;
-
-    if (!res && implicit_keep) {
-        strarray_t *actionflags = strarray_dup(variables->var);
-        struct buf *headers = NULL;
-
-        if (i->edited_headers) i->getheadersection(m, &headers);
-
-        res = do_keep(i, sc, actions, actionflags, headers);
-
-        implicit_keep = 0;
-    }
 
     return res;
 }


### PR DESCRIPTION
sieve_eval_bc() should not be handling implicit keep. Implicit keep is handled by do_action_list() and do_sieve_error().
This fixes an issue where implicit keep was being done on an included script rather than just the toplevel script