### PR TITLE
jmap_mail_submission.c: don't use a non-stancdard error code

### DIFF
--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -835,7 +835,7 @@ static void _emailsubmission_create(jmap_req_t *req,
         }
 
         default:
-            *set_err = json_pack("{s:s s:s}", "type", "smtpProtocolError",
+            *set_err = json_pack("{s:s s:s}", "type", "forbiddenToSend",
                                  "description", desc);
             break;
         }


### PR DESCRIPTION
Simple fix, assuming there isn't a better code that we should use