### PR TITLE
Cassini: option to permit environment-only config

### DIFF
--- a/cassandane/Cassandane/Cassini.pm
+++ b/cassandane/Cassandane/Cassini.pm
@@ -93,8 +93,7 @@ sub new
         }
     }
 
-    die "couldn't find a cassandane.ini file" if not $filename;
-    $filename = abs_path($filename);
+    $filename = abs_path($filename) if $filename;
 
     my $inifile = new Config::IniFiles();
     if ( -f $filename)
@@ -118,6 +117,13 @@ sub new
     };
 
     bless $self, $class;
+
+    if ((not $filename or not -f $filename)
+        and not $self->bool_val('cassandane', 'allow_noinifile', 'no'))
+    {
+        die "couldn't find a cassandane.ini file";
+    }
+
     $instance = $self
         unless defined $instance;
     return $self;

--- a/cassandane/Cassandane/Test/Cassini.pm
+++ b/cassandane/Cassandane/Test/Cassini.pm
@@ -303,6 +303,42 @@ sub test_environment_override
     );
 }
 
+sub test_environment_only
+{
+    my ($self) = @_;
+
+    local $CWD = tempdir(CLEANUP => 1);
+    local %ENV = (); # stop real environment from interfering!
+
+    my $cassini;
+
+    # n.b. did not create an ini file!
+
+    # allow_noinifile has not been set, so it should barf
+    eval { $cassini = new Cassandane::Cassini; };
+    my $e = $@;
+    $self->assert_matches(qr/couldn't find a cassandane\.ini file/, $e);
+
+    # set allow_noinifile and other config via environment
+    $ENV{CASSINI_CASSANDANE_ALLOW_NOINIFILE} = 'yes';
+    $ENV{CASSINI_CASSANDANE_ROOTDIR} = 'overridden!';
+
+    # should work this time
+    $cassini = new Cassandane::Cassini;
+
+    $self->assert_equals(1,
+        $cassini->bool_val('cassandane', 'allow_noinifile'));
+
+    $self->assert_str_equals(
+        'overridden!',
+        $cassini->val('cassandane', 'rootdir', 'ignored')
+    );
+
+    # we didn't change this one at all, and its default is 'no'
+    $self->assert_equals(0,
+        $cassini->bool_val('cassandane', 'cleanup'));
+}
+
 sub test_override
 {
     my ($self) = @_;

--- a/cassandane/cassandane.ini.example
+++ b/cassandane/cassandane.ini.example
@@ -87,7 +87,14 @@
 # A list of tests or suites which will be suppressed.  These tests
 # will still run if requested on the command line, but will not be
 # run by default.
-## suppress =
+##suppress =
+# Whether Cassandane should allow itself to start up without a
+# cassandane.ini file.  This doesn't make much sense to specify in
+# a cassandane.ini file, but if you enable it via the environment
+# variable CASSINI_CASSANDANE_ALLOW_NOINIFILE, it will permit you
+# to run Cassandane using only configuration from environment
+# variables (or defaults)
+##allow_noinifile = no
 
 # This section describes configurable properties of Valgrind.
 [valgrind]


### PR DESCRIPTION
Since 407000f0af, Cassandane has refused to start without a cassandane.ini, since its absence usually meant no configuration had been done, and nothing would work correctly.

Since #3979, Cassandane has been able to read configuration values from environment variables.  But it is still mandatory to have a cassandane.ini file somewhere, even if all your config was set in environment variables.

This PR adds a new option, "cassandane.allow_noinifile", which defaults to 'no'.  If it is set to 'yes', then Cassandane allows itself to start up, even though there is no cassandane.ini file to be found.  This means if you want to set up your entire config in the environment, without needing a cassandane.ini file, you can do so as long as CASSINI_CASSANDANE_ALLOW_NOINIFILE=yes is also in your environment.