### PR TITLE
Cherry-pick Admin.pm: allow LIST command even when support_referrals is false to 2.5 branch

### DIFF
--- a/perl/imap/IMAP/Admin.pm
+++ b/perl/imap/IMAP/Admin.pm
@@ -370,6 +370,8 @@ sub listmailbox {
     } else {
       $list_cmd = 'RLIST';
     }
+  } else {
+    $list_cmd = 'LIST';
   }
 
   if(defined ($$opts{'-sel-special-use'}) && !$self->{support_list_special_use}) {


### PR DESCRIPTION
Ken's fix  for "cyradm: add LIST-EXTENDED and SPECIAL-USE support to listmailbox command" commit  9a94b5af03c2920f0ef2ea8e208257f559e28cec is needed for correct cyradm behavior in both this and cyrus-imapd-3.0 branches. Hope this couple of no brainer pull requests help in saving some upstream time.