### PR TITLE
jmap_calendar: reset iCalendar iterator state for each calendar

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -20694,4 +20694,65 @@ EOF
     $self->assert_not_null($notif);
 }
 
+sub test_calendarevent_get_reset_iter
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog "Create events in calendar A and B, both have IMAP uid 1";
+    my $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            create => {
+                calendarA => {
+                    name => 'A',
+                },
+                calendarB => {
+                    name => 'B',
+                },
+            },
+        }, 'R1'],
+        ['CalendarEvent/set', {
+            create => {
+                eventA => {
+                    calendarIds => {
+                        '#calendarA' => JSON::true,
+                    },
+                    '@type' => 'Event',
+                    uid => 'eventA-uid',
+                    title => 'eventA',
+                    start => '2021-01-01T15:30:00',
+                    timeZone => 'Europe/Berlin',
+                    duration => 'PT1H',
+                },
+                eventB => {
+                    calendarIds => {
+                        '#calendarB' => JSON::true,
+                    },
+                    '@type' => 'Event',
+                    uid => 'eventB-uid',
+                    title => 'eventB',
+                    start => '2022-01-01T15:30:00',
+                    timeZone => 'Europe/Berlin',
+                    duration => 'PT1H',
+                },
+            },
+        }, 'R2'],
+        ['CalendarEvent/get', {
+                properties => ['calendarIds', 'uid', 'title', 'start'],
+        }, 'R2'],
+    ]);
+
+    xlog "Assert CalendarEvent/get iterator state is reset properly";
+    $self->assert_num_equals(2, scalar @{$res->[2][1]{list}});
+    $self->assert_str_not_equals((keys %{$res->[2][1]{list}[0]{calendarIds}})[0],
+        (keys %{$res->[2][1]{list}[1]{calendarIds}})[0]);
+    $self->assert_str_not_equals($res->[2][1]{list}[0]{uid},
+        $res->[2][1]{list}[1]{uid});
+    $self->assert_str_not_equals($res->[2][1]{list}[0]{title},
+        $res->[2][1]{list}[1]{title});
+    $self->assert_str_not_equals($res->[2][1]{list}[0]{start},
+        $res->[2][1]{list}[1]{start});
+}
+
 1;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -123,7 +123,7 @@ static int jmap_calendarpreferences_set(struct jmap_req *req);
 
 static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx);
 
-#define JMAPCACHE_CALVERSION 25
+#define JMAPCACHE_CALVERSION 26
 
 static jmap_method_t jmap_calendar_methods_standard[] = {
     {
@@ -3257,6 +3257,13 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
         strarray_truncate(&rock->schedule_addresses, 0);
         get_schedule_addresses(NULL, rock->mbentry->name, sched_userid,
                 &rock->schedule_addresses);
+
+        // reset ical iterator state
+        if (rock->ical) {
+            icalcomponent_free(rock->ical);
+            rock->ical = NULL;
+        }
+        rock->imap_uid = 0;
     }
 
     /* Check mailbox ACL rights */


### PR DESCRIPTION
This applies to CalendarEvent/get:

The iCalendar iterator state keeps the current iCalendar data
in-memory as long as the IMAP uid of the event resource remains
unchanged. But the iterator state was not reset when the iterator
switches to the next calendar mailbox.

Consequently, if the last IMAP uid of the previously processed calendar
matched the first IMAP uid in the new calendar, then CalendarEvent/get
erroneously returned the contents of the former event with only the
calendarIds and iCalendar uid having the correct value.

This patch also bumps the cache version of the JMAP CalendarEvent
cache, so that any cached bogus events are flushed from it.