### PR TITLE
Handle Google iTIP Replies

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -5248,6 +5248,151 @@ EOF
                              $events->[0]{recurrenceOverrides}{'2021-10-21T15:30:00'}{participants}{'foo@example.net'}{scheduleStatus});
 }
 
+sub test_imip_reply_override_google
+    :needs_component_sieve :needs_component_httpd :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $IMAP = $self->{store}->get_client();
+    $self->{store}->_select();
+    $self->assert_num_equals(1, $IMAP->uid());
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+
+    xlog $self, "Create calendar user";
+    my $CalDAV = $self->{caldav};
+    my $CalendarId = 'Default';
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+    my $href = "$CalendarId/$uuid.ics";
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :outcome "outcome";
+    if string "\${outcome}" "updated" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    my $event = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+BEGIN:VEVENT
+CREATED:20210714T034327Z
+UID:$uuid
+TRANSP:OPAQUE
+SUMMARY:A Recurring Event
+DTSTART;TZID=America/New_York:20210714T153000
+DTEND;TZID=America/New_York:20210714T183000
+RRULE:FREQ=WEEKLY
+DTSTAMP:20210714T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Cassandane:MAILTO:cassandane\@example.com
+ATTENDEE;CN=Cassandane;PARTSTAT=ACCEPTED:MAILTO:cassandane\@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:foo\@example.net
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20210714T034327Z
+UID:$uuid
+TRANSP:OPAQUE
+SUMMARY:A Recurring Event
+DTSTART;TZID=America/New_York:20210722T153000
+DTEND;TZID=America/New_York:20210722T183000
+RECURRENCE-ID;TZID=America/New_York:20210721T153000
+DTSTAMP:20210714T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Cassandane:MAILTO:cassandane\@example.com
+ATTENDEE;CN=Cassandane;PARTSTAT=ACCEPTED:MAILTO:cassandane\@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:foo\@example.net
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Create an event on calendar";
+    $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
+
+    xlog $self, "Check that the event made it to calendar";
+    my $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('',
+                             $events->[0]{participants}{'foo@example.net'}{name});
+    $self->assert_str_equals('needs-action',
+                             $events->[0]{participants}{'foo@example.net'}{scheduleStatus});
+
+
+    my $imip = <<EOF;
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid\@example.net>
+Content-Type: text/calendar; method=REPLY; component=VEVENT
+X-Cassandane-Unique: $uuid
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REPLY
+BEGIN:VEVENT
+UID:$uuid
+DTSTAMP:20210723T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Cassandane:MAILTO:cassandane\@example.com
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED:MAILTO:foo\@example.net
+END:VEVENT
+BEGIN:VEVENT
+UID:$uuid
+DTSTAMP:20210714T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Cassandane:MAILTO:cassandane\@example.com
+ATTENDEE;CN=Test User;PARTSTAT=TENTATIVE:MAILTO:foo\@example.net
+RECURRENCE-ID:20210721T193000Z
+END:VEVENT
+BEGIN:VEVENT
+UID:$uuid
+DTSTAMP:20210723T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Cassandane:MAILTO:cassandane\@example.com
+ATTENDEE;CN=Test User;PARTSTAT=DECLINED:MAILTO:foo\@example.net
+RECURRENCE-ID:20210728T193000Z
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP reply";
+    my $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 1,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Check that the reply made it to calendar";
+    $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('Test User',
+                             $events->[0]{participants}{'foo@example.net'}{name});
+    $self->assert_str_equals('accepted',
+                             $events->[0]{participants}{'foo@example.net'}{scheduleStatus});
+
+    $self->assert_str_equals('2021-07-22T15:30:00',
+                             $events->[0]{recurrenceOverrides}{'2021-07-21T15:30:00'}{start});
+    $self->assert_str_equals('accepted',
+                             $events->[0]{recurrenceOverrides}{'2021-07-21T15:30:00'}{participants}{'cassandane@example.com'}{scheduleStatus});
+    $self->assert_str_equals('tentative',
+                             $events->[0]{recurrenceOverrides}{'2021-07-21T15:30:00'}{participants}{'foo@example.net'}{scheduleStatus});
+
+    $self->assert_str_equals('accepted',
+                             $events->[0]{recurrenceOverrides}{'2021-07-28T15:30:00'}{participants}{'cassandane@example.com'}{scheduleStatus});
+    $self->assert_str_equals('declined',
+                             $events->[0]{recurrenceOverrides}{'2021-07-28T15:30:00'}{participants}{'foo@example.net'}{scheduleStatus});
+}
+
 sub test_imip_reply_override_invalid
     :needs_component_sieve :needs_component_httpd :min_version_3_5
 {

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1908,7 +1908,8 @@ static void schedule_sub_updates(const char *userid, const strarray_t *schedule_
          * generate a synthetic one */
         icalcomponent *oldcomp = find_component(oldical, recurid);
         if (!oldcomp && oldmaster) {
-            oldcomp = freeme = master_to_recurrence(oldmaster, prop);
+            oldcomp = freeme = master_to_recurrence(oldmaster,
+                                                    icalproperty_clone(prop));
         }
 
         /* unchanged event - we don't need to send anything */

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -910,8 +910,11 @@ icalcomponent_get_recurrenceid_with_zone(icalcomponent *comp)
     icalproperty *prop =
         icalcomponent_get_first_property(comp, ICAL_RECURRENCEID_PROPERTY);
 
-    struct icaldatetimeperiodtype dtp = icalproperty_get_datetimeperiod(prop);
-    return dtp.time;
+    if (prop == 0) {
+        return icaltime_null_time();
+    }
+
+    return icalproperty_get_datetime_with_component(prop, comp);
 }
 
 

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -368,7 +368,8 @@ HIDDEN icalcomponent *master_to_recurrence(icalcomponent *master,
     struct icaltimetype newstart = _get_datetime(master, recurid);
 
     icaltimezone *startzone = (icaltimezone *)icaltime_get_timezone(start);
-    icalcomponent_set_dtstart(comp, icaltime_convert_to_zone(newstart, startzone));
+    icalproperty_set_dtstart(startprop,
+                             icaltime_convert_to_zone(newstart, startzone));
 
     if (endprop) {
         struct icaltimetype end = _get_datetime(master, endprop);
@@ -378,7 +379,8 @@ HIDDEN icalcomponent *master_to_recurrence(icalcomponent *master,
         struct icaltimetype newend = icaltime_add(newstart, diff);
 
         icaltimezone *endzone = (icaltimezone *)icaltime_get_timezone(end);
-        icalcomponent_set_dtend(comp, icaltime_convert_to_zone(newend, endzone));
+        icalproperty_set_dtend(endprop,
+                               icaltime_convert_to_zone(newend, endzone));
     }
     /* otherwise it will be a duration, which is still valid! */
 

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -361,7 +361,7 @@ HIDDEN icalcomponent *master_to_recurrence(icalcomponent *master,
     }
 
     /* Add RECURRENCE-ID */
-    icalcomponent_add_property(comp, icalproperty_clone(recurid));
+    icalcomponent_add_property(comp, recurid);
 
     /* calculate a new dtend based on recurid */
     struct icaltimetype start = _get_datetime(master, startprop);
@@ -456,7 +456,7 @@ static const char *deliver_merge_reply(icalcomponent *ical,
             }
 
             /* create a new recurrence from master component. */
-            comp = master_to_recurrence(master, prop);
+            comp = master_to_recurrence(master, icalproperty_clone(prop));
             icalcomponent_add_component(ical, comp);
 
             /* Replace SEQUENCE */

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -397,18 +397,29 @@ static const char *deliver_merge_reply(icalcomponent *ical,
     icalproperty *prop, *att;
     icalparameter *param;
     icalparameter_partstat partstat = ICAL_PARTSTAT_NONE;
-    const char *attendee = NULL, *cn = NULL;
+    const char *attendee = NULL, *cn = NULL, *tzid = NULL;
+    icaltimezone *utc_zone = icaltimezone_get_utc_timezone();
+    icaltimezone *startzone = NULL;
+    icaltimetype dtstart;
 
     /* Add each component of old object to hash table for comparison */
     construct_hash_table(&comp_table, 10, 1);
     comp = icalcomponent_get_first_real_component(ical);
     kind = icalcomponent_isa(comp);
     do {
-        prop = icalcomponent_get_first_property(comp, ICAL_RECURRENCEID_PROPERTY);
-        if (prop)
-            hash_insert(icalproperty_get_value_as_string(prop), comp, &comp_table);
-        else
+        icaltimetype recurid = icalcomponent_get_recurrenceid_with_zone(comp);
+
+        if (icaltime_is_null_time(recurid)) {
             master = comp;
+            dtstart = icalcomponent_get_dtstart(master);
+            startzone = (icaltimezone *) icaltime_get_timezone(dtstart);
+            tzid = icaltimezone_get_location(startzone);
+        }
+        else {
+            /* Convert RECURRENCE-ID to UTC */
+            recurid = icaltime_convert_to_zone(recurid, utc_zone);
+            hash_insert(icaltime_as_ical_string(recurid), comp, &comp_table);
+        }
 
     } while ((comp = icalcomponent_get_next_component(ical, kind)));
 
@@ -422,13 +433,17 @@ static const char *deliver_merge_reply(icalcomponent *ical,
             icalcomponent_get_first_property(itip, ICAL_SEQUENCE_PROPERTY);
         icalproperty *dtstamp =
             icalcomponent_get_first_property(itip, ICAL_DTSTAMP_PROPERTY);
+        icaltimetype recurid = icalcomponent_get_recurrenceid_with_zone(itip);
 
         /* Lookup this comp in the hash table */
-        prop = icalcomponent_get_first_property(itip, ICAL_RECURRENCEID_PROPERTY);
-        if (prop)
-            comp = hash_lookup(icalproperty_get_value_as_string(prop), &comp_table);
-        else
+        if (icaltime_is_null_time(recurid)) {
             comp = master;
+        }
+        else {
+            /* Convert RECURRENCE-ID to UTC */
+            recurid = icaltime_convert_to_zone(recurid, utc_zone);
+            comp = hash_lookup(icaltime_as_ical_string(recurid), &comp_table);
+        }
 
         if (!comp) {
             /* New recurrence overridden by attendee. */
@@ -438,14 +453,15 @@ static const char *deliver_merge_reply(icalcomponent *ical,
             }
 
             icaltimetype occur = icaltime_null_time();
-            icaltimetype recurid = icalproperty_get_recurrenceid(prop);
             icalproperty *rrule =
                 icalcomponent_get_first_property(master, ICAL_RRULE_PROPERTY);
 
             if (rrule) {
                 icalrecur_iterator *ritr =
-                    icalrecur_iterator_new(icalproperty_get_rrule(rrule),
-                                           icalcomponent_get_dtstart(master));
+                    icalrecur_iterator_new(icalproperty_get_rrule(rrule), dtstart);
+
+                /* Convert RECURRENCE-ID to DTSTART time zone */
+                recurid = icaltime_convert_to_zone(recurid, startzone);
 
                 icalrecur_iterator_set_start(ritr, recurid);
                 occur = icalrecur_iterator_next(ritr);
@@ -458,7 +474,11 @@ static const char *deliver_merge_reply(icalcomponent *ical,
             }
 
             /* create a new recurrence from master component. */
-            comp = master_to_recurrence(master, icalproperty_clone(prop));
+            icalproperty *recuridp = icalproperty_new_recurrenceid(recurid);
+            if (tzid) {
+                icalproperty_set_parameter(recuridp, icalparameter_new_tzid(tzid));
+            }
+            comp = master_to_recurrence(master, recuridp);
             icalcomponent_add_component(ical, comp);
 
             /* Replace SEQUENCE */

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -397,7 +397,7 @@ static const char *deliver_merge_reply(icalcomponent *ical,
     icalproperty *prop, *att;
     icalparameter *param;
     icalparameter_partstat partstat = ICAL_PARTSTAT_NONE;
-    const char *attendee = NULL, *cn = NULL, *tzid = NULL;
+    const char *attendee = NULL, *cn = NULL;
     icaltimezone *utc_zone = icaltimezone_get_utc_timezone();
     icaltimezone *startzone = NULL;
     icaltimetype dtstart;
@@ -413,7 +413,6 @@ static const char *deliver_merge_reply(icalcomponent *ical,
             master = comp;
             dtstart = icalcomponent_get_dtstart(master);
             startzone = (icaltimezone *) icaltime_get_timezone(dtstart);
-            tzid = icaltimezone_get_location(startzone);
         }
         else {
             /* Convert RECURRENCE-ID to UTC */
@@ -475,6 +474,7 @@ static const char *deliver_merge_reply(icalcomponent *ical,
 
             /* create a new recurrence from master component. */
             icalproperty *recuridp = icalproperty_new_recurrenceid(recurid);
+            const char *tzid = icaltimezone_get_location(startzone);
             if (tzid) {
                 icalproperty_set_parameter(recuridp, icalparameter_new_tzid(tzid));
             }


### PR DESCRIPTION
Google sends iTIP replies for RECURRENCE-IDs in UTC, even if DTSTART has a TZID.
This PR supports these replies by normalizing R-IDs to UTC for comparison and adjusts new R-IDs to the TZID of DTSTART.