### PR TITLE
docs: update weekly meeting time

### DIFF
--- a/docsrc/imap/support/feedback-meetings.rst
+++ b/docsrc/imap/support/feedback-meetings.rst
@@ -9,5 +9,5 @@ Join us online!
 Regular contributors catch up online weekly, both as a status checkpoint and
 to make sure we're all alive!
 
-Meetings are currently held at **Monday 21:00 UTC** via
+Meetings are currently held at **Monday 11:00 UTC** via
 `Zoom <https://zoom.us/j/598343302>`_.


### PR DESCRIPTION
What it says on the tin, just switching over to the mid-year meeting time

I'll need to cherry-pick this back to all the stable branches too