### PR TITLE
caldav_alarm: use same alertId encoding as for Event.alerts

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -422,9 +422,8 @@ static int send_alarm(struct get_alarm_rock *rock,
     }
     FILL_ARRAY_PARAM(event, EVENT_CALENDAR_ALARM_RECIPIENTS, recipients);
 
-    prop = icalcomponent_get_first_property(alarm, ICAL_UID_PROPERTY);
-    FILL_STRING_PARAM(event, EVENT_CALENDAR_ALERTID,
-            xstrdup(prop ? icalproperty_get_value_as_string(prop) : ""));
+    jmap_alertid_encode(alarm, &buf);
+    FILL_STRING_PARAM(event, EVENT_CALENDAR_ALERTID, buf_release(&buf));
 
     strarray_t *attendee_names = strarray_new();
     strarray_t *attendee_emails = strarray_new();

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -2603,10 +2603,7 @@ participants_from_ical(icalcomponent *comp, json_t *linksbyparticipant)
 
 HIDDEN json_t *jmapical_alert_from_ical(icalcomponent *valarm, struct buf *idbuf)
 {
-    const char *id = icalcomponent_get_uid(valarm);
-    char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
-    if (!id) id = sha1hexstr(icalcomponent_as_ical_string(valarm), keybuf);
-    buf_setcstr(idbuf, id);
+    jmap_alertid_encode(valarm, idbuf);
 
     /* Determine TRIGGER and RELATED parameter */
     struct icaltriggertype trigger = {

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1362,3 +1362,19 @@ EXPORTED char *jmap_role_to_specialuse(const char *role)
     specialuse[1] = toupper(specialuse[1]);
     return specialuse;
 }
+
+EXPORTED void jmap_alertid_encode(icalcomponent *valarm, struct buf *idbuf)
+{
+    buf_reset(idbuf);
+    const char *id = icalcomponent_get_uid(valarm);
+    char keybuf[2*SHA1_DIGEST_LENGTH+1];
+    if (!id) {
+        unsigned char dest[SHA1_DIGEST_LENGTH];
+        const char *val = icalcomponent_as_ical_string(valarm);
+        xsha1((const unsigned char *) val, strlen(val), dest);
+        bin_to_hex(dest, SHA1_DIGEST_LENGTH, keybuf, BH_LOWER);
+        keybuf[2*SHA1_DIGEST_LENGTH] = '\0';
+        id = keybuf;
+    }
+    buf_setcstr(idbuf, id);
+}

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -206,6 +206,8 @@ extern const char *jmap_caleventid_encode(const struct jmap_caleventid *eid, str
 
 extern void jmap_caleventid_free(struct jmap_caleventid **eidptr);
 
+extern void jmap_alertid_encode(icalcomponent *valarm, struct buf *buf);
+
 #define JMAP_NOTIF_CALENDAREVENT "jmap-notif-calendarevent"
 
 extern char *jmap_notifmboxname(const char *userid);


### PR DESCRIPTION
Signed-off-by: Robert Stepanek <rsto@fastmailteam.com>