### PR TITLE
relocate_by_id fixes

### DIFF
--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -1582,7 +1582,7 @@ sub test_sync_reset_legacy
     close(FH);
 
     xlog $self, "files exist";
-    $self->assert(@files);
+    $self->assert_not_equals(0, scalar @files);
 
     $self->{instance}->run_command({ cyrus => 1 }, 'sync_reset', '-f' => 'magicuser' );
 
@@ -1591,7 +1591,7 @@ sub test_sync_reset_legacy
     close(FH);
 
     xlog $self, "no files left for this user";
-    $self->assert(not @files);
+    $self->assert_equals(0, scalar @files);
 }
 
 sub test_sync_reset_nolegacy
@@ -1671,7 +1671,7 @@ sub test_relocate_legacy_nodomain
     close(FH);
 
     xlog $self, "files exist";
-    $self->assert(@files);
+    $self->assert_not_equals(0, scalar @files);
 
     $self->{instance}->run_command({ cyrus => 1 }, 'relocate_by_id', '-u' => "magicuser" );
 
@@ -1680,7 +1680,7 @@ sub test_relocate_legacy_nodomain
     close(FH);
 
     xlog $self, "no files left for this user";
-    $self->assert(not @files);
+    $self->assert_equals(0, scalar @files);
 }
 
 sub test_relocate_legacy_domain
@@ -1712,7 +1712,7 @@ sub test_relocate_legacy_domain
     close(FH);
 
     xlog $self, "files exist";
-    $self->assert(@files);
+    $self->assert_not_equals(0, scalar @files);
 
     $self->{instance}->run_command({ cyrus => 1 }, 'relocate_by_id', '-u' => "magicuser\@example.com" );
 
@@ -1721,7 +1721,7 @@ sub test_relocate_legacy_domain
     close(FH);
 
     xlog $self, "no files left for this user";
-    $self->assert(not @files);
+    $self->assert_equals(0, scalar @files);
 }
 
 sub test_relocate_messages_still_exist
@@ -1767,7 +1767,7 @@ sub test_relocate_messages_still_exist
     close(FH);
 
     xlog $self, "files exist";
-    $self->assert(@files);
+    $self->assert_not_equals(0, scalar @files);
 
     $self->{instance}->run_command({ cyrus => 1 }, 'relocate_by_id', '-u' => $username );
 
@@ -1776,7 +1776,7 @@ sub test_relocate_messages_still_exist
     close(FH);
 
     xlog $self, "no files left for this user";
-    $self->assert(not @files);
+    $self->assert_equals(0, scalar @files);
 
     $imaptalk = $self->{store}->get_client();
 

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -1724,6 +1724,50 @@ sub test_relocate_legacy_domain
     $self->assert_equals(0, scalar @files);
 }
 
+sub test_relocate_legacy_nosearchdb
+    :DelayedDelete :min_version_3_5 :MailboxLegacyDirs
+{
+    my ($self) = @_;
+
+    my $adminstore = $self->{adminstore};
+    my $admintalk = $adminstore->get_client();
+
+    my $inbox = "user.magicuser\@example.com";
+    my $subfolder = "user.magicuser.foo\@example.com";
+
+    $admintalk->create($inbox);
+    $admintalk->setacl($inbox, admin => 'lrswipkxtecdan');
+    $admintalk->create($subfolder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $adminstore->set_folder($subfolder);
+    $self->make_message("Email", store => $adminstore) or die;
+
+    # Don't create the search database!
+    # A user who's never been indexed should still relocate cleanly
+
+    my $basedir = $self->{instance}{basedir};
+    open(FH, "-|", "find", $basedir);
+    my @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "files exist";
+    $self->assert_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 }, 'relocate_by_id', '-u' => "magicuser\@example.com" );
+
+    open(FH, "-|", "find", $basedir);
+    @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "no files left for this user";
+    $self->assert_equals(0, scalar @files);
+
+    # Hopefully squatter still works!
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+}
+
 sub test_relocate_messages_still_exist
     :DelayedDelete :min_version_3_5 :MailboxLegacyDirs
 {

--- a/cassandane/Cassandane/Cyrus/RelocateById.pm
+++ b/cassandane/Cassandane/Cyrus/RelocateById.pm
@@ -1,0 +1,305 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2022-2022 FastMail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Cyrus::RelocateById;
+use strict;
+use warnings;
+use Data::Dumper;
+
+use lib '.';
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+
+sub new
+{
+    my ($class, @args) = @_;
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(
+        conversations => 'yes',
+        mailbox_legacy_dirs => 'yes',
+        delete_mode => 'delayed',
+        unixhierarchysep => 'no', # XXX need a :NoUnixHierarchySep
+    );
+    return $class->SUPER::new({
+        config => $config,
+        adminstore => 1,
+    }, @args);
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+    $self->SUPER::tear_down();
+}
+
+sub test_user_nomatch
+    :min_version_3_6
+{
+    my ($self) = @_;
+
+    my $errfile = $self->{instance}->get_basedir() . '/relocate.err';
+
+    my $user = 'nonexistent';
+
+    $self->{instance}->run_command({
+        cyrus => 1,
+        redirects => {
+            stderr => $errfile,
+        },
+    }, 'relocate_by_id', '-u', $user);
+
+    my $output;
+
+    { # XXX we should dedup all these slurps sometime...
+        local $/;
+        open my $fh, '<', $errfile
+            or die "Cannot open $errfile for reading: $!";
+        $output = <$fh>;
+        close $fh;
+    }
+
+    # better complain if the user requested doesn't exist!
+    $self->assert_matches(qr{$user: user not found}, $output);
+}
+
+sub test_mailbox_nomatch
+    :min_version_3_6
+{
+    my ($self) = @_;
+
+    my $errfile = $self->{instance}->get_basedir() . '/relocate.err';
+
+    my $mailbox = 'user.nonexistent';
+
+    $self->{instance}->run_command({
+        cyrus => 1,
+        redirects => {
+            stderr => $errfile,
+        },
+    }, 'relocate_by_id', $mailbox);
+
+    my $output;
+
+    { # XXX we should dedup all these slurps sometime...
+        local $/;
+        open my $fh, '<', $errfile
+            or die "Cannot open $errfile for reading: $!";
+        $output = <$fh>;
+        close $fh;
+    }
+
+    # better complain if the mailbox requested doesn't exist!
+    $self->assert_matches(qr{$mailbox: mailbox not found}, $output);
+}
+
+sub test_mailbox_inbox_domain
+    :min_version_3_6 :NoAltNamespace :VirtDomains
+{
+    my ($self) = @_;
+
+    my $adminstore = $self->{adminstore};
+    my $admintalk = $adminstore->get_client();
+
+    my $inbox = "user.magicuser\@example.com";
+    my $subfolder = "user.magicuser.foo\@example.com";
+
+    $admintalk->create($inbox);
+    $admintalk->setacl($inbox, admin => 'lrswipkxtecdan');
+    $admintalk->create($subfolder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $adminstore->set_folder($subfolder);
+    $self->make_message("Email", store => $adminstore) or die;
+
+    # Create the search database.
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $basedir = $self->{instance}{basedir};
+    open(FH, "-|", "find", $basedir);
+    my @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "files exist";
+    $self->assert_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 },
+        'relocate_by_id', "user.magicuser\@example.com" );
+
+    open(FH, "-|", "find", $basedir);
+    @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "no files left for this user";
+    $self->assert_equals(0, scalar @files);
+}
+
+sub test_mailbox_inbox_nodomain
+    :min_version_3_6
+{
+    my ($self) = @_;
+
+    my $adminstore = $self->{adminstore};
+    my $admintalk = $adminstore->get_client();
+
+    my $inbox = "user.magicuser";
+    my $subfolder = "user.magicuser.foo";
+
+    $admintalk->create($inbox);
+    $admintalk->setacl($inbox, admin => 'lrswipkxtecdan');
+    $admintalk->create($subfolder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $adminstore->set_folder($subfolder);
+    $self->make_message("Email", store => $adminstore) or die;
+
+    # Create the search database.
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $basedir = $self->{instance}{basedir};
+    open(FH, "-|", "find", $basedir);
+    my @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "files exist";
+    $self->assert_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 },
+        'relocate_by_id', "user.magicuser" );
+
+    open(FH, "-|", "find", $basedir);
+    @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "no files left for this user";
+    $self->assert_equals(0, scalar @files);
+}
+
+sub test_mailbox_shared_domain
+    :min_version_3_6 :NoAltNamespace :VirtDomains
+{
+    my ($self) = @_;
+
+    my $adminstore = $self->{adminstore};
+    my $admintalk = $adminstore->get_client();
+
+    my $mbox = "shared.magic\@example.com";
+    my $subfolder = "shared.magic.foo\@example.com";
+
+    $admintalk->create($mbox);
+    $admintalk->setacl($mbox, admin => 'lrswipkxtecdan');
+    $admintalk->create($subfolder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $adminstore->set_folder($subfolder);
+    $self->make_message("Email", store => $adminstore) or die;
+
+    # Create the search database.
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $basedir = $self->{instance}{basedir};
+    open(FH, "-|", "find", $basedir);
+    my @files = grep { m{/magic/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "files exist";
+    $self->assert_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 },
+        'relocate_by_id', $mbox );
+
+    open(FH, "-|", "find", $basedir);
+    @files = grep { m{/magic/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "no files left for this hierarchy";
+    $self->assert_equals(0, scalar @files);
+}
+
+sub test_mailbox_shared_nodomain
+    :min_version_3_6
+{
+    my ($self) = @_;
+
+    my $adminstore = $self->{adminstore};
+    my $admintalk = $adminstore->get_client();
+
+    my $mbox = "shared.magic";
+    my $subfolder = "shared.magic.foo";
+
+    $admintalk->create($mbox);
+    $admintalk->setacl($mbox, admin => 'lrswipkxtecdan');
+    $admintalk->create($subfolder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $adminstore->set_folder($subfolder);
+    $self->make_message("Email", store => $adminstore) or die;
+
+    # Create the search database.
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $basedir = $self->{instance}{basedir};
+    open(FH, "-|", "find", $basedir);
+    my @files = grep { m{/magic/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "files exist";
+    $self->assert_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 },
+        'relocate_by_id', $mbox );
+
+    open(FH, "-|", "find", $basedir);
+    @files = grep { m{/magic/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "no files left for this user";
+    $self->assert_equals(0, scalar @files);
+}
+
+1;

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -137,4 +137,87 @@ sub test_skip_unmodified
     $self->assert(grep /Squat skipping mailbox/, @lines);
 }
 
+sub test_relocate_legacy_searchdb
+    :DelayedDelete :min_version_3_6 :MailboxLegacyDirs
+    :Admin :SearchEngineSquat :NoAltNamespace :VirtDomains
+{
+    my ($self) = @_;
+
+    my $adminstore = $self->{adminstore};
+    my $admintalk = $adminstore->get_client();
+
+    my $inbox = "user.magicuser\@example.com";
+    my $subfolder = "user.magicuser.foo\@example.com";
+
+    $admintalk->create($inbox);
+    $admintalk->setacl($inbox, admin => 'lrswipkxtecdan');
+    $admintalk->create($subfolder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $adminstore->set_folder($subfolder);
+    $self->make_message("Email", store => $adminstore) or die;
+
+    # Create the search database.
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $basedir = $self->{instance}{basedir};
+    open(FH, "-|", "find", $basedir);
+    my @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "files exist";
+    $self->assert_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 }, 'relocate_by_id', '-u' => "magicuser\@example.com" );
+
+    open(FH, "-|", "find", $basedir);
+    @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "no files left for this user";
+    $self->assert_equals(0, scalar @files);
+}
+
+sub test_relocate_legacy_nosearchdb
+    :DelayedDelete :min_version_3_6 :MailboxLegacyDirs
+    :Admin :SearchEngineSquat :NoAltNamespace :VirtDomains
+{
+    my ($self) = @_;
+
+    my $adminstore = $self->{adminstore};
+    my $admintalk = $adminstore->get_client();
+
+    my $inbox = "user.magicuser\@example.com";
+    my $subfolder = "user.magicuser.foo\@example.com";
+
+    $admintalk->create($inbox);
+    $admintalk->setacl($inbox, admin => 'lrswipkxtecdan');
+    $admintalk->create($subfolder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $adminstore->set_folder($subfolder);
+    $self->make_message("Email", store => $adminstore) or die;
+
+    # Don't create the search database!
+    # A user who's never been indexed should still relocate cleanly
+
+    my $basedir = $self->{instance}{basedir};
+    open(FH, "-|", "find", $basedir);
+    my @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "files exist";
+    $self->assert_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 }, 'relocate_by_id', '-u' => "magicuser\@example.com" );
+
+    open(FH, "-|", "find", $basedir);
+    @files = grep { m{/magicuser/} and not m{/conf/lock/} } <FH>;
+    close(FH);
+
+    xlog $self, "no files left for this user";
+    $self->assert_equals(0, scalar @files);
+}
+
 1;

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -106,6 +106,7 @@ int main(int argc, char **argv)
     struct buf buf = BUF_INITIALIZER;
     char *alt_config = NULL;
     mbentry_t *mbentry;
+    enum enum_value config_search_engine = IMAPOPT_ZERO;
 
     progname = basename(argv[0]);
 
@@ -134,6 +135,7 @@ int main(int argc, char **argv)
 
     cyrus_init(alt_config, "relocate_by_id", 0, CONFIG_NEED_PARTITION_DATA);
     global_sasl_init(1, 0, NULL);
+    config_search_engine = config_getenum(IMAPOPT_SEARCH_ENGINE);
 
     /* Set namespace -- force standard (internal) */
     if ((r = mboxname_init_namespace(&reloc_namespace, 1)) != 0) {
@@ -264,9 +266,12 @@ int main(int argc, char **argv)
                     strarray_append(newpaths, buf_cstring(&buf));
                 }
 
-                /* Add xapian tier paths */
-                r = add_xapian_paths(userid, userpath, oldpaths, newpaths);
-                if (r) goto cleanup;
+                if (config_search_engine == IMAP_ENUM_SEARCH_ENGINE_XAPIAN) {
+                    /* Add xapian tier paths */
+                    r = add_xapian_paths(userid, userpath, oldpaths, newpaths);
+                    if (r) goto cleanup;
+                }
+                /* squat index, if any, was taken care of earlier as metadata */
             }
 
             /* Relocate our list of paths */

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -163,10 +163,14 @@ int main(int argc, char **argv)
             MBOXTREE_TOMBSTONES | MBOXTREE_DELETED | MBOXTREE_INTERMEDIATES;
 
         /* Make a list of all mailboxes in tree */
-        if (dousers)
+        if (dousers) {
             r = mboxlist_usermboxtree(argv[i], NULL, find_p, &mboxlist_rock, flags);
-        else
-            r = mboxlist_mboxtree(argv[i], find_p, &mboxlist_rock, flags);
+        }
+        else {
+            char *intname = mboxname_from_external(argv[i], &reloc_namespace, NULL);
+            r = mboxlist_mboxtree(intname, find_p, &mboxlist_rock, flags);
+            free(intname);
+        }
 
         /* Make sure we have some work to do */
         if (!mboxlist_rock.matched) {

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -493,7 +493,8 @@ static int add_xapian_paths(const char *userid, const char *userpath,
     struct mappedfile *activefile = NULL;
     int r;
 
-    r = mappedfile_open(&activefile, activefname, 0);
+    r = mappedfile_open(&activefile, activefname,
+                        MAPPEDFILE_CREATE | MAPPEDFILE_RW);
     if (r) {
         fprintf(stderr,
                 "Failed to open activefile for %s: %s\n",


### PR DESCRIPTION
This fixes a few edge case and UX bugs in `relocate_by_id`.  It's probably easiest to review by stepping through a commit at a time, since there's a few not-entirely-related changes to the same code in this one PR.

* It would fail to relocate a user who didn't have a xapian active file (#4005), probably due to the user not having been indexed yet.  I've fixed this by having the mappedfile_open call just create the file if it's missing, which seems to be fine -- the newly created active file is empty, so the subsequent loop over its contents does nothing.  I could instead make it skip the xapian work if it's missing, let me know which you prefer.
* If we're not search_engine=xapian, we definitely won't have a xapian active file, but also shouldn't create one.  So it now checks for search_engine=xapian before doing any xapian work.
* It didn't do namespace handling of mailbox arguments, so admins were expected to provide mailbox arguments in the internal namespace, rather than the admin namespace the other tools want (#4014).  It now does the namespace handling, and therefore accepts admin namespace mailbox arguments.
* If the user or mailbox you asked it to relocate didn't exist (perhaps you provided it the admin namespace instead of the internal namespace it previously expected) it would do nothing, say nothing, and exit success (#4014).  It now tells you if your user/mailbox arguments don't match anything, or the thing they match has already been relocated.


Fixes #4005 
Fixes #4014