### PR TITLE
relocate_by_id: do not implicitly cast from imapopt to enum value

### DIFF
--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
     struct buf buf = BUF_INITIALIZER;
     char *alt_config = NULL;
     mbentry_t *mbentry;
-    enum enum_value config_search_engine = IMAPOPT_ZERO;
+    enum enum_value config_search_engine = config_getenum(IMAPOPT_ZERO);
 
     progname = basename(argv[0]);
 


### PR DESCRIPTION
gcc (Debian 10.2.1-6) 10.2.1 20210110 rightly complains with `-Wall` about 

```
imap/relocate_by_id.c: In function ‘main’:
imap/relocate_by_id.c:114:44: error: implicit conversion from ‘enum imapopt’ to ‘enum enum_value’ [-Werror=enum-conversion]
  114 |     enum enum_value config_search_engine = IMAPOPT_ZERO;
      |                                            ^~~~~~~~~~~~
cc1: all warnings being treated as errors
```