### PR TITLE
relocate_by_id: fix typo in initialisation

### DIFF
--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
     struct buf buf = BUF_INITIALIZER;
     char *alt_config = NULL;
     mbentry_t *mbentry;
-    enum enum_value config_search_engine = config_getenum(IMAPOPT_ZERO);
+    enum enum_value config_search_engine = IMAPOPT_ZERO;
 
     progname = basename(argv[0]);
 

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
     struct buf buf = BUF_INITIALIZER;
     char *alt_config = NULL;
     mbentry_t *mbentry;
-    enum enum_value config_search_engine = IMAPOPT_ZERO;
+    enum enum_value config_search_engine = IMAP_ENUM_ZERO;
 
     progname = basename(argv[0]);
 


### PR DESCRIPTION
Fixes a typo where an enum was zero-initialised using the wrong enum's constant.  Newer compilers than mine apparently have a warning about it (or an error with -Werror).

Replaces previous fix from #4028, which applied a function call to the typo to produce a correct value.  This fix just directly uses the correct value in the first place.

This should be good, but please compile check it, since my compiler couldn't see the original problem, so I can't definitively prove it's "fixed"