### PR TITLE
jmap_calendar: preserve custom timezones in CalendarEvent/set

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -20999,4 +20999,177 @@ sub test_calendarevent_get_isorigin
     $self->assert_equals(JSON::false, $res->[1][1]{list}[0]{isOrigin});
 }
 
+sub test_calendarevent_set_preserve_microsoft_timezone
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    xlog "Create event with Microsoft timezone via CalDAV";
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+PRODID:Microsoft Exchange Server 2010
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:AUS Eastern Standard Time
+BEGIN:STANDARD
+DTSTART:16010101T030000
+TZOFFSETFROM:+1100
+TZOFFSETTO:+1000
+RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=4
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T020000
+TZOFFSETFROM:+1000
+TZOFFSETTO:+1100
+RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=10
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:a0591c63-31c0-4c56-a8ab-9fe49dcbd3b0
+SUMMARY:test
+DTSTART;TZID=AUS Eastern Standard Time:20220412T080000
+DTEND;TZID=AUS Eastern Standard Time:20220412T083000
+SEQUENCE:1
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    my $ics = '/dav/calendars/user/cassandane/Default/test.ics';
+    $caldav->Request('PUT', $ics, $ical, 'Content-Type' => 'text/calendar');
+
+    xlog "Assert timeZone is mapped to IANA timezone";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/query', {
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'CalendarEvent/query',
+                path => '/ids'
+            },
+            properties => ['timeZone'],
+        }, 'R2'],
+    ]);
+    my $eventId = $res->[1][1]{list}[0]{id};
+    $self->assert_not_null($eventId);
+    $self->assert_str_equals('Australia/Sydney', $res->[1][1]{list}[0]{timeZone});
+
+    xlog "Update event title, keep timeZone untouched";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    title => 'updatedTitle',
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog "Assert VTIMEZONE is kept";
+    $res = $caldav->Request('GET', $ics);
+    $self->assert($res->{content} =~
+        m/DTSTART;TZID=AUS Eastern Standard Time:20220412T080000/);
+    $self->assert($res->{content} =~
+        m/TZID:AUS Eastern Standard Time/);
+
+    xlog "Update event timeZone to IANA identifier";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    timeZone => 'Europe/London',
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog "Assert VTIMEZONE got replaced";
+    $res = $caldav->Request('GET', $ics);
+    $self->assert(not $res->{content} =~
+        m/DTSTART;TZID=AUS Eastern Standard Time:20220412T080000/);
+    $self->assert(not $res->{content} =~
+        m/TZID:AUS Eastern Standard Time/);
+}
+
+sub test_calendarevent_set_no_preserve_iana_timezone
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    xlog "Create event with custom IANA timezone via CalDAV";
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+PRODID://Foo/Bar
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Europe/Vienna
+BEGIN:STANDARD
+DTSTART:16010101T030000
+TZOFFSETFROM:+1100
+TZOFFSETTO:+1000
+RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=4
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T020000
+TZOFFSETFROM:+1000
+TZOFFSETTO:+1100
+RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=10
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:a0591c63-31c0-4c56-a8ab-9fe49dcbd3b0
+SUMMARY:test
+DTSTART;TZID=Europe/Vienna:20220412T080000
+DTEND;TZID=Europe/Vienna:20220412T083000
+SEQUENCE:1
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    my $ics = '/dav/calendars/user/cassandane/Default/test.ics';
+    $caldav->Request('PUT', $ics, $ical, 'Content-Type' => 'text/calendar');
+
+    xlog "Assert timeZone and UTC times are correct";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/query', {
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'CalendarEvent/query',
+                path => '/ids'
+            },
+            properties => ['timeZone', 'utcStart', 'utcEnd'],
+        }, 'R2'],
+    ]);
+    my $eventId = $res->[1][1]{list}[0]{id};
+    $self->assert_not_null($eventId);
+    $self->assert_str_equals('Europe/Vienna', $res->[1][1]{list}[0]{timeZone});
+    $self->assert_str_equals('2022-04-12T06:00:00Z', $res->[1][1]{list}[0]{utcStart});
+    $self->assert_str_equals('2022-04-12T06:30:00Z', $res->[1][1]{list}[0]{utcEnd});
+
+    xlog "Update event title, keep timeZone untouched";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    title => 'updatedTitle',
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog "Assert VTIMEZONE got replaced";
+    $res = $caldav->Request('GET', $ics);
+    $self->assert(not $res->{content} =~ m/TZOFFSETFROM:\+1000/);
+    $self->assert($res->{content} =~ m/TZOFFSETFROM:\+0200/);
+}
+
 1;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3403,7 +3403,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
         icalcomponent_add_component(rock->ical, ical_instance);
     }
 
-    jstzones = jstimezones_new(rock->ical);
+    jstzones = jstimezones_new(rock->ical, 0);
 
     /* Convert to JMAP */
     context_begin_cdata(jmapctx, rock->mbentry, cdata);
@@ -4940,7 +4940,7 @@ static void updateevent_apply_patch_event(json_t *old_event,
                                           json_t *invalid,
                                           json_t **err)
 {
-    jstimezones_t *jstzones = jstimezones_new(oldical);
+    jstimezones_t *jstzones = jstimezones_new(oldical, 1);
     json_t *new_event = NULL;
 
     if (eventpatch_updates_recurrenceoverrides(event_patch)) {
@@ -5253,6 +5253,8 @@ static int updateevent_apply_patch(jmap_req_t *req,
     struct jmapical_ctx *jmapctx = jmapical_context_new(req,
             update->schedule_addresses);
     jmapctx->to_ical.serverset = update->serverset;
+    jmapctx->timezones.no_guess = 1;
+    jmapctx->timezones.ignore_orphans = 1;
     context_begin_cdata(jmapctx, update->mbentry, update->cdata);
     old_event = jmapical_tojmap(myoldical, NULL, jmapctx);
     if (!old_event) {

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -70,6 +70,7 @@
 #include "http_jmap.h"
 #include "http_proxy.h"
 #include "ical_support.h"
+#include "icu_wrap.h"
 #include "json_support.h"
 #include "mailbox.h"
 #include "mboxlist.h"
@@ -230,12 +231,14 @@ typedef struct jstimezones {
     hash_table bytzid;
     hash_table byjstzid;
     ptrarray_t entries;
+    int no_guess;
 } jstimezones_t;
 
 #define JSTIMEZONES_INITIALIZER { \
     HASH_TABLE_INITIALIZER, \
     HASH_TABLE_INITIALIZER, \
-    PTRARRAY_INITIALIZER \
+    PTRARRAY_INITIALIZER, \
+    0 \
 }
 
 /* Forward declarations */
@@ -793,6 +796,32 @@ static int jstimezones_add_standard_timezone(jstimezones_t *jstzones, icaltimezo
     return jstimezones_add_timezone(jstzones, tz, tzid, tzid, 0);
 }
 
+static icaltimezone *get_cyrus_timezone_from_tzid(const char *tzid, int no_guess)
+{
+    if (!tzid)
+        return NULL;
+
+    /* Use UTC singleton for Etc/UTC */
+    if (!strcmp(tzid, "Etc/UTC") || !strcmp(tzid, "UTC"))
+        return icaltimezone_get_utc_timezone();
+
+    icaltimezone *tz = icaltimezone_get_builtin_timezone(tzid);
+    if (tz == NULL)
+        tz = icaltimezone_get_builtin_timezone_from_tzid(tzid);
+    if (tz == NULL && !no_guess) {
+        /* see if its a MS Windows TZID */
+        char *icutzid = icu_getIDForWindowsID(tzid);
+        if (icutzid) {
+            tz = icaltimezone_get_builtin_timezone(icutzid);
+            if (tz == NULL)
+                tz = icaltimezone_get_builtin_timezone_from_tzid(icutzid);
+            free(icutzid);
+        }
+    }
+    return tz;
+}
+
+
 HIDDEN icaltimezone *jstimezones_lookup_tzid(jstimezones_t *jstzones, const char *tzid)
 {
     if (!tzid) return NULL;
@@ -809,7 +838,8 @@ HIDDEN icaltimezone *jstimezones_lookup_tzid(jstimezones_t *jstzones, const char
     }
 
     /* Lookup in standard timezones */
-    icaltimezone *stdtz = icaltimezone_get_cyrus_timezone_from_tzid(tzid);
+    icaltimezone *stdtz = get_cyrus_timezone_from_tzid(tzid,
+            jstzones ? jstzones->no_guess : 0);
     if (jstzones && stdtz) {
         jstimezones_add_standard_timezone(jstzones, stdtz);
     }
@@ -864,7 +894,7 @@ static const char *jstimezones_get_jstzid(jstimezones_t *jstzones, const char *t
         }
     }
     if (!stdtz) {
-        stdtz = icaltimezone_get_cyrus_timezone_from_tzid(tzid);
+        stdtz = get_cyrus_timezone_from_tzid(tzid, jstzones ? jstzones->no_guess : 0);
         if (jstzones && stdtz) {
             jstimezones_add_standard_timezone(jstzones, stdtz);
         }
@@ -887,45 +917,50 @@ static void jstimezones_add_vtimezones(jstimezones_t *jstzones, icalcomponent *i
          vtz;
          vtz = icalcomponent_get_next_component(ical, ICAL_VTIMEZONE_COMPONENT)) {
 
-        /* Ignore IANA and Windows timezone ids */
         prop = icalcomponent_get_first_property(vtz, ICAL_TZID_PROPERTY);
         if (!prop) continue;
         const char *tzid = icalproperty_get_tzid(prop);
         if (!tzid || !*tzid) continue;
-        icaltimezone *tz = icaltimezone_get_cyrus_timezone_from_tzid(tzid);
+
+        icaltimezone *tz = get_cyrus_timezone_from_tzid(tzid, jstzones->no_guess);
         if (tz) {
             // cache standard timezone
             jstimezones_add_standard_timezone(jstzones, tz);
             continue;
         }
+
         // found a custom timezone
         count++;
     }
     if (!count) return;
 
 #ifdef HAVE_GUESSTZ
-    /* Determine the timespan of the event */
-    const icaltimezone *utc = icaltimezone_get_utc_timezone();
-    unsigned is_recurring = 0;
-    icalcomponent *comp = icalcomponent_get_first_real_component(ical);
-    if (!comp) return;
-    struct icalperiodtype span = icalrecurrenceset_get_utc_timespan(ical,
-            icalcomponent_isa(comp), NULL, &is_recurring, NULL, NULL);
-    if (icaltime_as_timet_with_zone(span.end, utc) == caldav_epoch) {
-        span.end = icaltime_null_time();
-    }
-
-    /* Open database to guess IANA timezones */
     guesstz_t *gtz = NULL;
-    if (config_getstring(IMAPOPT_ZONEINFO_DIR)) {
-        char *fname = strconcat(config_getstring(IMAPOPT_ZONEINFO_DIR),
-                                "/guesstz.db", NULL);
-        gtz = guesstz_open(fname);
-        free(fname);
-        if (guesstz_error(gtz)) {
-            xsyslog(LOG_ERR, "can't open guesstz database",
-                    "err<%s>", guesstz_error(gtz));
-            guesstz_close(&gtz);
+    struct icalperiodtype guess_span;
+
+    if (!jstzones->no_guess) {
+        /* Determine the timespan of the event */
+        const icaltimezone *utc = icaltimezone_get_utc_timezone();
+        unsigned is_recurring = 0;
+        icalcomponent *comp = icalcomponent_get_first_real_component(ical);
+        if (!comp) return;
+        guess_span = icalrecurrenceset_get_utc_timespan(ical,
+                icalcomponent_isa(comp), NULL, &is_recurring, NULL, NULL);
+        if (icaltime_as_timet_with_zone(guess_span.end, utc) == caldav_epoch) {
+            guess_span.end = icaltime_null_time();
+        }
+
+        /* Open database to guess IANA timezones */
+        if (config_getstring(IMAPOPT_ZONEINFO_DIR)) {
+            char *fname = strconcat(config_getstring(IMAPOPT_ZONEINFO_DIR),
+                    "/guesstz.db", NULL);
+            gtz = guesstz_open(fname);
+            free(fname);
+            if (guesstz_error(gtz)) {
+                xsyslog(LOG_ERR, "can't open guesstz database",
+                        "err<%s>", guesstz_error(gtz));
+                guesstz_close(&gtz);
+            }
         }
     }
 #endif
@@ -938,11 +973,11 @@ static void jstimezones_add_vtimezones(jstimezones_t *jstzones, icalcomponent *i
          vtz;
          vtz = icalcomponent_get_next_component(ical, ICAL_VTIMEZONE_COMPONENT)) {
 
-        /* Ignore IANA and Windows timezone ids */
+        /* Ignore standard timezones */
         prop = icalcomponent_get_first_property(vtz, ICAL_TZID_PROPERTY);
         if (!prop) continue;
         const char *tzid = icalproperty_get_tzid(prop);
-        if (!tzid || !*tzid || icaltimezone_get_cyrus_timezone_from_tzid(tzid)) {
+        if (!tzid || !*tzid || get_cyrus_timezone_from_tzid(tzid, jstzones->no_guess)) {
             continue;
         }
 
@@ -959,7 +994,7 @@ static void jstimezones_add_vtimezones(jstimezones_t *jstzones, icalcomponent *i
         if (!jstzid) {
 #ifdef HAVE_GUESSTZ
             if (gtz) {
-                char *ianaid = guesstz_guess(gtz, myvtz, span.start, span.end);
+                char *ianaid = guesstz_guess(gtz, myvtz, guess_span.start, guess_span.end);
                 if (ianaid) buf_setcstr(&idbuf, ianaid);
                 free(ianaid);
             }
@@ -1006,9 +1041,10 @@ static void jstimezones_fini(jstimezones_t *jstzones)
     ptrarray_fini(&jstzones->entries);
 }
 
-HIDDEN jstimezones_t *jstimezones_new(icalcomponent *ical)
+HIDDEN jstimezones_t *jstimezones_new(icalcomponent *ical, int no_guess)
 {
     jstimezones_t *jstzones = xzmalloc(sizeof(struct jstimezones));
+    jstzones->no_guess = no_guess;
     jstimezones_add_vtimezones(jstzones, ical);
     return jstzones;
 }
@@ -1337,7 +1373,7 @@ static const char *tzid_from_icalprop(icalproperty *prop, int guess,
             icalvalue *val = icalproperty_get_value(prop);
             icaltimetype dt = icalvalue_get_datetime(val);
             tzid = dt.zone ? icaltimezone_get_location((icaltimezone*) dt.zone) : NULL;
-            tzid = tzid && icaltimezone_get_cyrus_timezone_from_tzid(tzid) ? tzid : NULL;
+            tzid = tzid && jstimezones_lookup_tzid(jstzones, tzid) ? tzid : NULL;
         } else if (tz == icaltimezone_get_utc_timezone()) {
             /* XXX  libical may not set tzid or location */
             return tzid;
@@ -1402,7 +1438,7 @@ static struct icaltimetype dtend_from_ical(icalcomponent *comp,
     if (end_prop) {
         dtend = icalproperty_get_dtend(end_prop);
         const char *tzid = tzid_from_icalprop(end_prop, 1, jstzones);
-        icaltimezone* tz = icaltimezone_get_cyrus_timezone_from_tzid(tzid);
+        icaltimezone* tz = jstimezones_lookup_tzid(jstzones, tzid);
         if (tz && tz != dtend.zone) {
             icaltimezone *utc = icaltimezone_get_utc_timezone();
             if (dtend.zone != utc) {
@@ -3372,6 +3408,7 @@ calendarevent_from_ical(icalcomponent *comp,
 
     /* Read custom timezones */
     if (!jstzones) {
+        myjstzones.no_guess = jmapctx ? jmapctx->timezones.no_guess : 0;
         icalcomponent *ical = icalcomponent_get_parent(comp);
         jstimezones_add_vtimezones(&myjstzones, ical);
         jstzones = &myjstzones;
@@ -6655,7 +6692,8 @@ static void timezonerule_to_ical(icalcomponent *tzrule, struct jmap_parser *pars
 static void timezones_to_ical(icalcomponent *ical,
                               struct jmap_parser *parser,
                               json_t *jevent,
-                              json_t *jtimezones)
+                              json_t *jtimezones,
+                              struct jmapical_ctx *jmapctx)
 {
     icaltimezone *utc = icaltimezone_get_utc_timezone();
 
@@ -6671,18 +6709,12 @@ static void timezones_to_ical(icalcomponent *ical,
 
         jmap_parser_push(parser, jstzid);
 
-        size_t invalid_count = json_array_size(parser->invalid);
-
         icalcomponent *tzcomp = icalcomponent_new_vtimezone();
 
         validate_type(parser, jtimezone, "TimeZone");
 
         const char *tzid = json_string_value(json_object_get(jtimezone, "tzId"));
-        /* Don't allow IANA and Windows timezone ids */
-        if (icaltimezone_get_cyrus_timezone_from_tzid(tzid)) {
-            jmap_parser_invalid(parser, "tzId");
-        }
-        else if (tzid) {
+        if (tzid) {
             icalcomponent_add_property(tzcomp, icalproperty_new_tzid(tzid));
         }
         else jmap_parser_invalid(parser, "tzId");
@@ -6779,13 +6811,16 @@ static void timezones_to_ical(icalcomponent *ical,
             jmap_parser_invalid(parser, "daylight");
         }
 
-        if (invalid_count == json_array_size(parser->invalid)) {
-            if (strarray_find(&custom_jstzids, jstzid, 0) < 0) {
-                jmap_parser_invalid(parser, NULL);
-            }
-        }
-
         jmap_parser_pop(parser);
+
+        if (strarray_find(&custom_jstzids, jstzid, 0) < 0) {
+            // this timezone is not referenced by any known property
+            if (jmapctx && !jmapctx->timezones.ignore_orphans) {
+                jmap_parser_invalid(parser, jstzid);
+            }
+            icalcomponent_free(tzcomp);
+            continue;
+        }
 
         icalcomponent_add_component(ical, tzcomp);
     }
@@ -7113,11 +7148,12 @@ static void calendarevent_to_ical(icalcomponent *comp,
     icalcomponent *ical = icalcomponent_get_parent(comp);
     jprop = json_object_get(event, "timeZones");
     if (json_is_object(jprop)) {
-        timezones_to_ical(ical, parser, event, jprop);
+        timezones_to_ical(ical, parser, event, jprop, jmapctx);
     } else if (JNOTNULL(jprop)) {
         jmap_parser_invalid(parser, "timeZones");
     }
     if (!jstzones) {
+        myjstzones.no_guess = jmapctx ? jmapctx->timezones.no_guess : 0;
         jstimezones_add_vtimezones(&myjstzones, ical);
         jstzones = &myjstzones;
     }

--- a/imap/jmap_ical.h
+++ b/imap/jmap_ical.h
@@ -119,6 +119,10 @@ struct jmapical_ctx {
         int allow_method;
         json_t *replyto;
     } to_ical;
+    struct {
+        int no_guess;
+        int ignore_orphans;
+    } timezones;
     const strarray_t *schedule_addresses;
 };
 
@@ -174,8 +178,10 @@ void icalcomponent_add_required_timezones(icalcomponent *ical);
  * iCalendar data that embeds non-standard VTIMEZONES */
 typedef struct jstimezones jstimezones_t;
 
-/* Create a resolver for VTIMEZONEs embedded in VCALENDAR ical. */
-extern jstimezones_t *jstimezones_new(icalcomponent *ical);
+/* Create a resolver for VTIMEZONEs embedded in VCALENDAR ical.
+ * If no_guess is true, then the resolver does not attempt to
+ * guess IANA timezone identifiers for non-IANA timezones. */
+extern jstimezones_t *jstimezones_new(icalcomponent *ical, int no_guess);
 
 /* Resolve tzid to a timezone.
  *


### PR DESCRIPTION
Before, the event timezones got rewritten to IANA timezones
even if the client did only update non-time related properties.