### PR TITLE
Expire JMAP notifications using jmap_expire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ imap/imapd
 imap/ipurge
 imap/jmap_err.c
 imap/jmap_err.h
+imap/jmap_expire
 imap/lmtp_err.c
 imap/lmtp_err.h
 imap/lmtpd

--- a/Makefile.am
+++ b/Makefile.am
@@ -314,6 +314,10 @@ endif # SERVER
 
 endif # SIEVE
 
+if JMAP
+sbin_PROGRAMS += imap/jmap_expire
+endif # JMAP
+
 EXTRA_DIST = \
 	COPYING \
 	README.md \
@@ -952,6 +956,9 @@ imap_idled_LDADD = $(LD_UTILITY_ADD)
 
 imap_calalarmd_SOURCES = imap/calalarmd.c imap/mutex_fake.c
 imap_calalarmd_LDADD = $(LD_SERVER_ADD)
+
+imap_jmap_expire_SOURCES = imap/cli_fatal.c imap/jmap_expire.c imap/mutex_fake.c
+imap_jmap_expire_LDADD = $(LD_UTILITY_ADD)
 
 imap_imapd_SOURCES = \
 	imap/imap_proxy.c \

--- a/changes/next/cyr_expire_jmap
+++ b/changes/next/cyr_expire_jmap
@@ -1,0 +1,16 @@
+Description:
+
+Adds the jmap_expire executable to expire stale JMAP notifications.
+
+Config changes:
+
+None.
+
+Upgrade instructions:
+
+Installations using JMAP calendars should regularly run jmap_expire,
+similar to how they run cyr_expire.
+
+GitHub issue:
+
+If theres a github issue number for this, put it here.

--- a/doc/examples/cyrus_conf/normal-master.conf
+++ b/doc/examples/cyrus_conf/normal-master.conf
@@ -52,6 +52,11 @@ EVENTS {
 
   # this is only necessary if caching TLS sessions
   tlsprune      cmd="tls_prune" at=0400
+
+  # this is only necessary if CalDAV or JMAP are enabled
+  # expire JMAP notifications after 7 days and
+  # unlink expired JMAP notifications after 1 day
+  jmapprune     cmd="jmap_expire -E 7d -X 1d" at 0500
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/normal-replica.conf
+++ b/doc/examples/cyrus_conf/normal-replica.conf
@@ -52,6 +52,11 @@ EVENTS {
 
   # this is only necessary if caching TLS sessions
   tlsprune      cmd="tls_prune" at=0400
+
+  # this is only necessary if CalDAV or JMAP are enabled
+  # expire JMAP notifications after 7 days and
+  # unlink expired JMAP notifications after 1 day
+  jmapprune     cmd="jmap_expire -E 7d -X 1d" at 0500
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/normal.conf
+++ b/doc/examples/cyrus_conf/normal.conf
@@ -47,6 +47,11 @@ EVENTS {
 
   # this is only necessary if caching TLS sessions
   tlsprune      cmd="tls_prune" at=0400
+
+  # this is only necessary if CalDAV or JMAP are enabled
+  # expire JMAP notifications after 7 days and
+  # unlink expired JMAP notifications after 1 day
+  jmapprune     cmd="jmap_expire -E 7d -X 1d" at 0500
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/small.conf
+++ b/doc/examples/cyrus_conf/small.conf
@@ -31,6 +31,11 @@ EVENTS {
 
   # this is only necessary if caching TLS sessions
   tlsprune      cmd="tls_prune" at=0400
+
+  # this is only necessary if CalDAV or JMAP are enabled
+  # expire JMAP notifications after 7 days and
+  # unlink expired JMAP notifications after 1 day
+  jmapprune     cmd="jmap_expire -E 7d -X 1d" at 0500
 }
 
 DAEMON {

--- a/docsrc/imap/reference/manpages/systemcommands/jmap_expire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/jmap_expire.rst
@@ -17,7 +17,7 @@ Synopsis
 
     **jmap_expire** [ **-C** *config-file* ]
     [ **-E** *notif-expire-duration* ]
-    [ **-X** *notif-expunge-duration* ]
+    [ **-X** *notif-unlink-duration* ]
     [ **-h** or **--help**]
     [ **-l** or **--lock** *lock-duration*]
     [ **-u** *username* ]
@@ -29,7 +29,7 @@ Description
 **jmap_expire** is used to run a number of regular maintenance tasks for
 JMAP mailboxes and databases, specifically:
 
-- expires and expunges JMAP CalendarEventNotification objects
+- expires and unlinks JMAP CalendarEventNotification objects
 
 **jmap_expire** requires at least one of the **-E -X** optionss.
 
@@ -56,9 +56,9 @@ Options
     The duration must be zero or positive. Setting this flag causes the
     JMAP notification to not be visible anymore to JMAP methods, but preserves
     them on the file system. This is required to allow Cyrus replica to
-    synchronize their state. Also see the **--notif-expunge** option.
+    synchronize their state. Also see the **--notif-unlink** option.
 
-.. option:: -X duration, --notif-expunge=duration
+.. option:: -X duration, --notif-unlink=duration
 
     Removes already previously expired JMAP notifications in the
     *jmapnotificationfolder* mailbox if their last modification time
@@ -75,7 +75,7 @@ Options
 .. option:: -l --lock=duration
 
     Attempt to lock a mailbox at most *duration* seconds for each
-    operation (e.g expire, expunge). Without this option, each
+    operation (e.g expire, unlink). Without this option, each
     mailbox is exclusively locked as long as it takes to complete
     the requested operation. For large mailboxes, this may get other
     processes stuck waiting for the mailbox. With this option, the

--- a/docsrc/imap/reference/manpages/systemcommands/jmap_expire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/jmap_expire.rst
@@ -1,0 +1,138 @@
+.. cyrusman:: jmap_expire(8)
+
+.. author: Robert Stepanek (Fastmail)
+
+.. _imap-reference-manpages-systemcommands-jmap_expire:
+
+==============
+**jmap_expire**
+==============
+
+Expire stale JMAP data such as calendar event notifications.
+
+Synopsis
+========
+
+.. parsed-literal::
+
+    **jmap_expire** [ **-C** *config-file* ]
+    [ **-E** *notif-expire-duration* ]
+    [ **-X** *notif-expunge-duration* ]
+    [ **-h** or **--help**]
+    [ **-l** or **--lock** *lock-duration*]
+    [ **-u** *username* ]
+    [ **-v** ]
+
+Description
+===========
+
+**jmap_expire** is used to run a number of regular maintenance tasks for
+JMAP mailboxes and databases, specifically:
+
+- expires and expunges JMAP CalendarEventNotification objects
+
+**jmap_expire** requires at least one of the **-E -X** optionss.
+
+Option arguments that denote durations may be specified using any
+combination of zero or positive integers with the following units:
+seconds `s`, minutes `m`, hours `h`, days `d` (a 24 hour day without leap second).
+For example, the value `1d3m2s` denotes a duration of one day, three
+minutes and 2 seconds. The default unit is seconds.
+
+Options
+=======
+
+.. program:: jmap_expire
+
+.. option:: -C config-file
+
+    |cli-dash-c-text|
+
+.. option:: -E duration, --notif-expire=duration
+
+    Flags JMAP notifications in the *jmapnotificationfolder* mailbox as
+    expired if their creation time is older than *duration*.
+
+    The duration must be zero or positive. Setting this flag causes the
+    JMAP notification to not be visible anymore to JMAP methods, but preserves
+    them on the file system. This is required to allow Cyrus replica to
+    synchronize their state. Also see the **--notif-expunge** option.
+
+.. option:: -X duration, --notif-expunge=duration
+
+    Removes already previously expired JMAP notifications in the
+    *jmapnotificationfolder* mailbox if their last modification time
+    is older than *duration*.  This unlinks the notification from the file
+    system and is not reversible.
+
+    The duration must be zero or positive and should be higher than the
+    synchronization interval of any Cyrus replica.
+
+.. option:: -h, --help
+
+    Show help information how to use this program.
+
+.. option:: -l --lock=duration
+
+    Attempt to lock a mailbox at most *duration* seconds for each
+    operation (e.g expire, expunge). Without this option, each
+    mailbox is exclusively locked as long as it takes to complete
+    the requested operation. For large mailboxes, this may get other
+    processes stuck waiting for the mailbox. With this option, the
+    mailbox typically is unlocked after the given duration, but this
+    can not be guaranteed for mailboxes with hundreds of thousands
+    of entries.
+
+    The duration must be at least one second and at most one hour.
+
+    Any remaining work for the operation and mailbox is left until
+    the next execution of jmap_expire.
+
+.. option:: -u username, --user=username
+
+    Only process JMAP data belonging to this user, e.g.  "someone@example.com".
+    Multiple occurrences of this option cause **jmap_expire** to operate on
+    all given user names.
+
+.. option:: -v, --verbose
+
+    Enable verbose output. Multiple occurrences of this option increase
+    the verbosity level, up to 3 times.
+
+Examples
+========
+
+.. parsed-literal::
+
+    **jmap_expire** **-E** *7d* **-X** *1d*
+
+..
+
+        Expire JMAP notifications for all users where the notification
+        was created one week ago or earlier. Expunge all notifications
+        that were expired until yesterday.
+
+.. parsed-literal::
+
+    **jmap_expire** **--notif-expire**=*1d* **--lock=2s** **-u** *me@example.com*
+
+..
+
+        Expire JMAP notifications in the *jmapnotificationfolder* mailbox
+        of user *me@example.com*. Release the mailbox lock after at most
+        2 seconds and leave any remaining work for future runs of **jmap_expire**.
+
+History
+=======
+
+This was introduced in Cyrus version 3.7.
+
+Files
+=====
+
+/etc/imapd.conf
+
+See Also
+========
+
+:cyrusman:`imapd.conf(5)`, :cyrusman:`master(8)`

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -389,7 +389,7 @@ static int archive(const mbentry_t *mbentry, void *rock)
      * in imap/mailbox.c. This one takes the arock->archive_mark as the
      * callback data.
      */
-    mailbox_archive(mailbox, NULL, &arock->archive_mark, ITER_SKIP_EXPUNGED);
+    mailbox_archive(mailbox, NULL, NULL, &arock->archive_mark);
 
 done:
     mailbox_close(&mailbox);
@@ -482,7 +482,7 @@ static int expire(const mbentry_t *mbentry, void *rock)
                      mbentry->name,
                      ((double)expire_seconds/SECS_IN_A_DAY));
 
-            r = mailbox_expunge(mailbox, expire_cb, erock, NULL,
+            r = mailbox_expunge(mailbox, NULL, expire_cb, erock, NULL,
                                 EVENT_MESSAGE_EXPIRE);
             if (r)
                 syslog(LOG_ERR, "failed to expire old messages: %s", mbentry->name);
@@ -491,7 +491,7 @@ static int expire(const mbentry_t *mbentry, void *rock)
     }
 
     if (!did_expunge && erock->do_userflags) {
-        r = mailbox_expunge(mailbox, userflag_cb, erock, NULL,
+        r = mailbox_expunge(mailbox, NULL, userflag_cb, erock, NULL,
                             EVENT_MESSAGE_EXPIRE);
         if (r)
             syslog(LOG_ERR, "failed to scan user flags for %s: %s",
@@ -505,7 +505,7 @@ static int expire(const mbentry_t *mbentry, void *rock)
 
     verbosep("cleaning up expunged messages in %s", mbentry->name);
 
-    r = mailbox_expunge_cleanup(mailbox, erock->expunge_mark, &numexpunged);
+    r = mailbox_expunge_cleanup(mailbox, NULL, erock->expunge_mark, &numexpunged);
 
     erock->messages_expunged += numexpunged;
     erock->mailboxes_seen++;

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -487,7 +487,7 @@ int scan_me(struct findall_data *data, void *rock)
     srock->i_mbox = i_mbox;
 
     if (verbose) printf("Scanning %s...\n", name);
-    mailbox_expunge(mailbox, virus_check, srock, NULL, EVENT_MESSAGE_EXPUNGE);
+    mailbox_expunge(mailbox, NULL, virus_check, srock, NULL, EVENT_MESSAGE_EXPUNGE);
     if (srock->idx_state) index_close(&srock->idx_state);  /* closes mailbox */
     else mailbox_close(&mailbox);
 

--- a/imap/ipurge.c
+++ b/imap/ipurge.c
@@ -265,7 +265,7 @@ static int purge_one(const mbname_t *mbname)
         return r;
     }
 
-    mailbox_expunge(mailbox, purge_check, &stats, NULL, EVENT_MESSAGE_EXPUNGE);
+    mailbox_expunge(mailbox, NULL, purge_check, &stats, NULL, EVENT_MESSAGE_EXPUNGE);
 
     mailbox_close(&mailbox);
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -2554,7 +2554,7 @@ static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *c
         /* Write main component body */
         buf_printf(blob, "\r\n--%s\r\n", boundary);
         buf_appendcstr(blob, "Content-Type: text/calendar");
-        
+
         if (comp_type) buf_printf(blob, "; component=%s", comp_type);
         buf_appendcstr(blob, "\r\n");
 
@@ -3362,7 +3362,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
             // first time we see a recurrence instance for this ical data.
             // prepare for any further callback calls for the same UID
 
-            // step 1: count the number of instances and initialize the 
+            // step 1: count the number of instances and initialize the
             // standalone instance cache.
             // The database ensures that we only run into this case if there
             // is no main event available, so each component in the iCalendar
@@ -9583,7 +9583,6 @@ static void notif_set(struct jmap_req *req,
                       const mbentry_t *notifmb,
                       int set_seen,
                       modseq_t statemodseq,
-                      time_t expunge_all_before,
                       json_t **err)
 {
     struct mailbox *notifmbox = NULL;
@@ -9704,21 +9703,6 @@ static void notif_set(struct jmap_req *req,
         }
         /* seen.db won't bump the modseq, so force that here */
         mboxname_nextmodseq(notifmb->name, statemodseq, MBTYPE_JMAPNOTIFY, 0);
-    }
-
-    if (expunge_all_before) {
-        struct mailbox_iter *iter = mailbox_iter_init(notifmbox, 0, 0);
-        message_t *msg;
-        while ((msg = (message_t *) mailbox_iter_step(iter))) {
-            struct index_record record = *msg_record(msg);
-            if (record.internaldate < expunge_all_before &&
-                !(record.system_flags & FLAG_DELETED) &&
-                !(record.internal_flags & FLAG_INTERNAL_EXPUNGED)) {
-                    record.internal_flags |= FLAG_INTERNAL_EXPUNGED;
-                    mailbox_rewrite_index_record(notifmbox, &record);
-            }
-        }
-        mailbox_iter_done(&iter);
     }
 
 done:
@@ -10110,7 +10094,7 @@ static int jmap_sharenotification_set(struct jmap_req *req)
         goto done;
     }
 
-    notif_set(req, &set, notifmb, 0, req->counters.davnotificationmodseq, 0, &err);
+    notif_set(req, &set, notifmb, 0, req->counters.davnotificationmodseq, &err);
     if (err) {
         jmap_error(req, err);
         goto done;
@@ -10880,9 +10864,7 @@ static int jmap_calendareventnotification_set(struct jmap_req *req)
         goto done;
     }
 
-    time_t expunge_all_before = time(NULL) - 60 * 60 * 24 * 30; // TODO add config option?
-    notif_set(req, &set, notifmb, 1, req->counters.jmapnotificationmodseq,
-            expunge_all_before, &err);
+    notif_set(req, &set, notifmb, 1, req->counters.jmapnotificationmodseq, &err);
     if (err) {
         jmap_error(req, err);
         goto done;

--- a/imap/jmap_expire.c
+++ b/imap/jmap_expire.c
@@ -1,0 +1,446 @@
+/* jmap_expire.c -- Program to clean up stale JMAP data
+ *
+ * Copyright (c) 1994-2017 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+
+#include <errno.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <sysexits.h>
+
+#include "global.h"
+
+/* generated headers are not necessarily in current directory */
+#include "imap/imap_err.h"
+
+#define SECS_IN_A_MIN 60
+#define SECS_IN_AN_HR (60 * SECS_IN_A_MIN)
+#define SECS_IN_A_DAY (24 * SECS_IN_AN_HR)
+
+#define LOCK_MINSECS 1
+#define LOCK_MAXSECS SECS_IN_AN_HR
+
+/* global state */
+static int verbose = 0;
+static const char *progname = NULL;
+static struct namespace expire_namespace; /* current namespace */
+
+struct args {
+    const char *altconfig;
+    int expire_seconds;
+    int expunge_seconds;
+    int lock_seconds;
+    strarray_t userids;
+};
+
+#define VERBOSE_INFO  1
+#define VERBOSE_TRACE 2
+#define VERBOSE_DEBUG 3
+
+/* verbosep - a wrapper to print if the 'verbose' option is
+   turned on.  */
+__attribute__((format(printf, 1, 2)))
+static inline void verbosep(const char *fmt, ...)
+{
+    va_list params;
+
+    if (!verbose) return;
+
+    va_start(params, fmt);
+    vfprintf(stderr, fmt, params);
+    va_end(params);
+    fputc('\n', stderr);
+}
+
+struct jmapnotif_rock {
+    const struct args *args;
+    time_t expire_before;
+    time_t expunge_before;
+    unsigned lock_millis;
+    unsigned nexpired;
+};
+
+static unsigned expire_jmapnotifs_cb(struct mailbox *mailbox,
+                                     const struct index_record *record,
+                                     void *vrock)
+{
+    struct jmapnotif_rock *rock = vrock;
+
+    /* we're expiring messages by sent date */
+    if (record->gmtime < rock->expire_before) {
+        if (verbose >= VERBOSE_TRACE) {
+            verbosep("%s: expiring uid %d", mailbox_name(mailbox), record->uid);
+        }
+        rock->nexpired++;
+        return 1;
+    }
+
+    return 0;
+}
+
+static void add_millis(struct timespec *t, unsigned ms)
+{
+    t->tv_sec += ms / 1000L;
+    t->tv_nsec += (ms % 1000L) * 1000000L;
+    if (t->tv_nsec >= 1000000000L) {
+        t->tv_sec++;
+        t->tv_nsec %= 1000000000L;
+    }
+}
+
+static void print_lock(const char *mboxname,
+                       struct timespec start,
+                       struct timespec until)
+{
+    struct timespec now;
+    if (clock_gettime(CLOCK_MONOTONIC, &now) == 0) {
+        verbosep("%s: lock info: start=%lld.%ld until=%lld.%ld now=%lld.%ld",
+                mboxname,
+                (long long)start.tv_sec, start.tv_nsec / 1000000L,
+                (long long)until.tv_sec, until.tv_nsec / 1000000L,
+                (long long)now.tv_sec, now.tv_nsec / 1000000L);
+    }
+}
+
+static int expire_jmapnotifs(const mbentry_t *mbentry, void *vrock)
+{
+    signals_poll();
+
+    if (mbentry->mbtype & MBTYPE_DELETED)
+        return 0;
+
+    if (!mboxname_isjmapnotificationsmailbox(mbentry->name, mbentry->mbtype))
+        return 0;
+
+    struct jmapnotif_rock *rock = vrock;
+    const struct args *args = rock->args;
+    struct mailbox *mailbox = NULL;
+    unsigned lock_millis = args->lock_seconds * 1000L;
+
+    /* First, expunge previously expired notifications */
+
+    if (args->expunge_seconds >= 0) {
+        unsigned nexpunged = 0;
+        struct timespec start = {0};
+        struct timespec until = {0};
+
+        int r = mailbox_open_iwl(mbentry->name, &mailbox);
+        if (r) {
+            verbosep("%s: can not open mailbox: %s",
+                    mbentry->name, error_message(r));
+            goto done;
+        }
+
+        if (verbose >= VERBOSE_TRACE) {
+            verbosep("%s: expunging mailbox", mbentry->name);
+        }
+
+        struct mailbox_iter *iter = mailbox_iter_init(mailbox, 0, 0);
+        if (lock_millis) {
+            clock_gettime(CLOCK_MONOTONIC, &start);
+            until = start;
+            add_millis(&until, lock_millis);
+            mailbox_iter_timer(iter, until, 1000);
+        }
+        r = mailbox_expunge_cleanup(mailbox, iter,
+                rock->expunge_before, &nexpunged);
+        if (r) {
+            verbosep("%s: failed to expunge notifications %s",
+                mbentry->name, error_message(r));
+        }
+        mailbox_iter_done(&iter);
+
+        mailbox_close(&mailbox);
+
+        if (lock_millis && verbose >= VERBOSE_TRACE) {
+            print_lock(mbentry->name, start, until);
+        }
+
+        verbosep("%s: expunged %u notifications", mbentry->name, nexpunged);
+
+        libcyrus_run_delayed(); // TODO(rsto): this should support lock_millis
+    }
+
+    /* Next, expire stale notifications */
+
+    if (args->expire_seconds >= 0) {
+        rock->nexpired = 0;
+        struct timespec start = {0};
+        struct timespec until = {0};
+
+        int r = mailbox_open_iwl(mbentry->name, &mailbox);
+        if (r) {
+            verbosep("%s: can not open mailbox: %s",
+                    mbentry->name, error_message(r));
+            goto done;
+        }
+
+        if (verbose >= VERBOSE_TRACE) {
+            verbosep("%s: expiring mailbox", mbentry->name);
+        }
+
+        struct mailbox_iter *iter =
+            mailbox_iter_init(mailbox, 0, ITER_SKIP_EXPUNGED);
+        if (lock_millis) {
+            clock_gettime(CLOCK_MONOTONIC, &start);
+            until = start;
+            add_millis(&until, lock_millis);
+            mailbox_iter_timer(iter, until, 1000);
+        }
+        r = mailbox_expunge(mailbox, iter, expire_jmapnotifs_cb,
+                rock, NULL, EVENT_MESSAGE_EXPIRE);
+        mailbox_iter_done(&iter);
+        if (r) {
+            verbosep("%s: failed to expire notifications: %s",
+                mbentry->name, error_message(r));
+        }
+
+        mailbox_close(&mailbox);
+
+        if (lock_millis && verbose >= VERBOSE_TRACE) {
+            print_lock(mbentry->name, start, until);
+        }
+
+        verbosep("%s: expired %u notifications", mbentry->name, rock->nexpired);
+    }
+
+done:
+    mailbox_close(&mailbox);
+    return 0;
+}
+
+static void do_jmapnotifs(const struct args *args)
+{
+    struct jmapnotif_rock rock = {.args = args};
+
+    if (args->expire_seconds >= 0) {
+        rock.expire_before = time(0) - args->expire_seconds;
+    }
+
+    if (args->expunge_seconds >= 0) {
+        rock.expunge_before = time(0) - args->expunge_seconds;
+    }
+
+    if (strarray_size(&args->userids)) {
+        const char *folder = config_getstring(IMAPOPT_JMAPNOTIFICATIONFOLDER);
+        if (!folder) {
+            verbosep("no jmapnotificationfolder config found in imapd.conf");
+            return;
+        }
+
+        for (int i = 0; i < strarray_size(&args->userids); i++) {
+            const char *userid = strarray_nth(&args->userids, i);
+            mbname_t *mbname = mbname_from_userid(userid);
+            mbname_push_boxes(mbname, folder);
+            mbentry_t *mbentry = NULL;
+            int r = mboxlist_lookup_allow_all(mbname_intname(mbname), &mbentry, NULL);
+            if (!r) {
+                expire_jmapnotifs(mbentry, &rock);
+                mboxlist_entry_free(&mbentry);
+            }
+            else if (r == IMAP_MAILBOX_NONEXISTENT) {
+                if (verbose >= VERBOSE_TRACE) {
+                    verbosep("%s: ignoring inexistent mailbox",
+                            mbname_intname(mbname));
+                }
+            }
+            else {
+                verbosep("%s: can not open mailbox: %s",
+                        mbname_intname(mbname), error_message(r));
+            }
+            mbname_free(&mbname);
+        }
+    }
+    else {
+        mboxlist_allmbox(NULL, expire_jmapnotifs, &rock, MBOXTREE_SKIP_ROOT);
+    }
+}
+
+static void usage(void)
+{
+    fprintf(stderr, "Usage: %s [OPTIONS]\n", progname);
+    fprintf(stderr, "Expire stale JMAP data\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr,
+        "Mandatory arguments (at least one required):\n"
+        "-E --notif-expire=<dur>    expire notifications older than duration\n"
+        "-X --notif-expunge=<dur>   expunge notifications older than duration\n"
+        "\n"
+        "Optional arguments:\n"
+        "-C <config-file>          use <config-file> instead of config from imapd.conf\n"
+        "-l, --lock=<duration>     lock mailboxes at most duration seconds\n"
+        "-u --user=<userid>        process userid\n"
+        "-v, --verbose             enable verbose output\n");
+    fprintf(stderr, "\n");
+
+    exit(EX_USAGE);
+}
+
+static int parse_args(int argc, char *argv[], struct args *args)
+{
+    int opt;
+
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:E:X:l:hu:v";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        {"notif-expire", required_argument, NULL, 'E'},
+        {"notif-expunge", required_argument, NULL, 'X'},
+        {"lock", required_argument, NULL, 'l'},
+        {"user", required_argument, NULL, 'u'},
+        {"verbose", no_argument, NULL, 'v'},
+        {0, 0, 0, 0},
+    };
+
+    struct buf buf = BUF_INITIALIZER;
+    int dur;
+
+    while (-1 !=
+           (opt = getopt_long(argc, argv, short_options, long_options, NULL))) {
+        switch (opt) {
+        case 'C':
+            args->altconfig = optarg;
+            break;
+
+        case 'E':
+            if (config_parseduration(optarg, 's', &dur) < 0 || dur < 0)
+                usage();
+            args->expire_seconds = dur;
+            break;
+
+        case 'X':
+            if (config_parseduration(optarg, 's', &dur) < 0 || dur < 0)
+                usage();
+            args->expunge_seconds = dur;
+            break;
+
+        case 'l':
+            if (config_parseduration(optarg, 's', &dur) < 0 || dur < 0)
+                usage();
+            if (dur < LOCK_MINSECS || dur > LOCK_MAXSECS)
+                usage();
+            args->lock_seconds = dur;
+            break;
+
+        case 'u':
+            buf_setcstr(&buf, optarg);
+            buf_trim(&buf);
+            if (!buf_len(&buf)) {
+                fprintf(stderr, "Invalid userid: %s\n", optarg);
+                usage();
+            }
+            strarray_append(&args->userids, buf_cstring(&buf));
+            break;
+
+        case 'v':
+            verbose++;
+            break;
+
+        case 'h':
+        default:
+            usage();
+            break;
+        }
+    }
+
+    if (args->expire_seconds  == -1 &&
+        args->expunge_seconds == -1) {
+        fprintf(stderr, "Missing mandatory arguments\n\n");
+        usage();
+        return -EINVAL;
+    }
+
+    buf_free(&buf);
+
+    return 0;
+}
+
+static void init(const char *progname, struct args *args)
+{
+    signals_add_handlers(0);
+
+    cyrus_init(args->altconfig, progname, 0, 0);
+    global_sasl_init(1, 0, NULL);
+}
+
+static void fini(struct args *args)
+{
+    strarray_fini(&args->userids);
+}
+
+static void shut_down(int code) __attribute__((noreturn));
+static void shut_down(int code)
+{
+    in_shutdown = 1;
+
+    exit(code);
+}
+
+int main(int argc, char *argv[])
+{
+    int exitcode = 0;
+    struct args args = {0};
+    args.expire_seconds = -1;
+    args.expunge_seconds = -1;
+
+    progname = basename(argv[0]);
+    if (parse_args(argc, argv, &args) != 0) exit(EXIT_FAILURE);
+
+    init(progname, &args);
+
+    /* Set namespace -- force standard (internal) */
+    int r = mboxname_init_namespace(&expire_namespace, 1);
+    if (r) {
+        verbosep("can not initialize namespace: %s", error_message(r));
+        exitcode = EX_CONFIG;
+        goto done;
+    }
+
+    mboxevent_setnamespace(&expire_namespace);
+
+    do_jmapnotifs(&args);
+
+done:
+    fini(&args);
+    shut_down(exitcode);
+}

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -632,13 +632,13 @@ extern unsigned mailbox_count_unseen(struct mailbox *mailbox);
 extern int mailbox_lock_index(struct mailbox *mailbox, int locktype);
 extern int mailbox_index_islocked(struct mailbox *mailbox, int write);
 
-extern int mailbox_expunge_cleanup(struct mailbox *mailbox, time_t expunge_mark,
-                                   unsigned *ndeleted);
-extern int mailbox_expunge(struct mailbox *mailbox,
+extern int mailbox_expunge_cleanup(struct mailbox *mailbox, struct mailbox_iter *iter,
+                                   time_t expunge_mark, unsigned *ndeleted);
+extern int mailbox_expunge(struct mailbox *mailbox, struct mailbox_iter *iter,
                            mailbox_decideproc_t *decideproc, void *deciderock,
                            unsigned *nexpunged, int event_type);
-extern void mailbox_archive(struct mailbox *mailbox,
-                            mailbox_decideproc_t *decideproc, void *deciderock, unsigned flags);
+extern void mailbox_archive(struct mailbox *mailbox, struct mailbox_iter *iter,
+                            mailbox_decideproc_t *decideproc, void *deciderock);
 extern void mailbox_remove_files_from_object_storage(struct mailbox *mailbox, unsigned flags);
 extern void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *sd);
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -640,8 +640,6 @@ extern int mailbox_expunge(struct mailbox *mailbox,
 extern void mailbox_archive(struct mailbox *mailbox,
                             mailbox_decideproc_t *decideproc, void *deciderock, unsigned flags);
 extern void mailbox_remove_files_from_object_storage(struct mailbox *mailbox, unsigned flags);
-extern int mailbox_cleanup(struct mailbox *mailbox, int iscurrentdir,
-                           mailbox_decideproc_t *decideproc, void *deciderock);
 extern void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *sd);
 
 extern int mailbox_create(const char *name, uint32_t mbtype, const char *part, const char *acl,

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -716,6 +716,12 @@ extern int mailbox_annotation_lookupmask(struct mailbox *mailbox, uint32_t uid,
 extern struct mailbox_iter *mailbox_iter_init(struct mailbox *mailbox,
                                               modseq_t changedsince,
                                               unsigned flags);
+/* Set a timer on the iterator, after which it returns no more messages.
+ * The time is measured in CLOCK_MONOTONIC time as returned by
+ * clock_gettime. The nchecktime argument defines how many records are
+ * processed before the clock is checked again. */
+extern void mailbox_iter_timer(struct mailbox_iter *iter,
+                               struct timespec until, unsigned nchecktime);
 extern void mailbox_iter_startuid(struct mailbox_iter *iter, uint32_t uid);
 extern void mailbox_iter_uidset(struct mailbox_iter *iter, seqset_t *seq);
 extern const message_t *mailbox_iter_step(struct mailbox_iter *iter);


### PR DESCRIPTION
JMAP Calendars requires to generate a CalendarEventNotification for changes to CalendarEvent objects. These notifications are stored in Cyrus in the `#jmapnotification` mailbox, which may accumulate a large count of notifications over time.
This patch adds a new option to cyr_expire to delete notifications that are older than a user-defined age.