### PR TITLE
jmap_mail: do not create or move emails in deleted mailboxes

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -22833,6 +22833,107 @@ sub test_email_set_multipart_related
     $self->assert($ct =~ /;type=\"text\/html\"$/);
 }
 
+sub test_email_set_delayed_deleted_mailbox
+    :min_version_3_7 :needs_component_jmap :JMAPExtensions
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog "Create mailbox A";
+    my $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            create => {
+                mboxA => {
+                    name => 'A',
+                },
+            }
+        }, 'R1'],
+    ]);
+    my $mboxA = $res->[0][1]{created}{mboxA}{id};
+    $self->assert_not_null($mboxA);
+
+    xlog "Create an email in Inbox";
+    $res = $jmap->CallMethods([
+        ['Email/set', {
+            create => {
+                email1 => {
+                    mailboxIds => {
+                        '$inbox' => JSON::true,
+                    },
+                    messageId => ['email1@local'],
+                    subject => 'test',
+                    keywords => {
+                        '$seen' => JSON::true,
+                    },
+                    bodyStructure => {
+                        type => 'text/plain',
+                        partId => 'part1',
+                    },
+                    bodyValues => {
+                        part1 => {
+                            value => 'test',
+                        }
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+    my $email1 = $res->[0][1]{created}{email1}{id};
+    $self->assert_not_null($email1);
+
+    xlog "Destroy mailbox A";
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            destroy => [ $mboxA ],
+        }, 'R2'],
+    ]);
+    $self->assert_deep_equals([$mboxA], $res->[0][1]{destroyed});
+
+    xlog "Can't move email to destroyed mailbox A";
+    $res = $jmap->CallMethods([
+        ['Email/set', {
+            update => {
+                $email1 => {
+                    mailboxIds => {
+                        $mboxA => JSON::true,
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert_deep_equals(['mailboxIds'],
+        $res->[0][1]{notUpdated}{$email1}{properties});
+
+    xlog "Can't create an email in destroyed mailbox A";;
+    $res = $jmap->CallMethods([
+        ['Email/set', {
+            create => {
+                email2 => {
+                    mailboxIds => {
+                        $mboxA => JSON::true,
+                    },
+                    messageId => ['email2@local'],
+                    subject => 'test',
+                    keywords => {
+                        '$seen' => JSON::true,
+                    },
+                    bodyStructure => {
+                        type => 'text/plain',
+                        partId => 'part1',
+                    },
+                    bodyValues => {
+                        part1 => {
+                            value => 'test',
+                        }
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert_deep_equals(['mailboxIds'],
+            $res->[0][1]{notCreated}{email2}{properties});
+}
+
 sub test_email_query_convflags_seen_in_trash
     :min_version_3_5 :needs_component_jmap :JMAPExtensions
 {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -10361,7 +10361,9 @@ static void _append_validate_mboxids(jmap_req_t *req,
             if (mbox_id) {
                 mbentry = jmap_mbentry_by_uniqueid(req, mbox_id);
             }
-            if (!mbentry || !jmap_hasrights_mbentry(req, mbentry, need_rights)) {
+            if (!mbentry || mbentry->mbtype == MBTYPE_DELETED ||
+                    mboxname_isdeletedmailbox(mbentry->name, NULL) ||
+                    !jmap_hasrights_mbentry(req, mbentry, need_rights)) {
                 jmap_parser_invalid(parser, NULL);
                 is_valid = 0;
             }
@@ -11973,7 +11975,8 @@ static int _email_bulkupdate_open(jmap_req_t *req, struct email_bulkupdate *bulk
         json_object_foreach_safe(update->mailboxids, tmp, mbox_id, jval) {
             struct mailbox *mbox = NULL;
             const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, mbox_id);
-            if (mbentry) {
+            if (mbentry && mbentry->mbtype != MBTYPE_DELETED &&
+                    !mboxname_isdeletedmailbox(mbentry->name, NULL)) {
                 int r = 0;
                 if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
                     struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);


### PR DESCRIPTION
The code didn't take delayed delete for mailboxes into account.