### PR TITLE
http_caldav: only create EventNotification for shared calendars

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -5191,4 +5191,76 @@ EOF
     $self->assert(not ($response->{content} =~ m/SCHEDULE-FORCE-SEND/));
 }
 
+sub test_calendareventnotification_no_sharee
+    :needs_component_httpd :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $admin = $self->{adminstore}->get_client();
+
+    $admin->create('user.cassandane.#jmapnotification') or die;
+    $admin->setacl('user.cassandane.#jmapnotification',
+        'cassandane' => 'lrswipkxtecdan') or die;
+
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $href = "$CalendarId/uid1.ics";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+DTEND:20160831T183000Z
+TRANSP:OPAQUE
+UID:uid1
+SUMMARY:foo
+DTSTART:20160831T153000Z
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    # annoyingly there's no "Request" that tells you the headers, so:
+  my %Headers = (
+    'Content-Type' => 'text/calendar',
+    'Authorization' => $CalDAV->auth_header(),
+  );
+
+  xlog "Create event";
+  my $Response = $CalDAV->{ua}->request('PUT', $CalDAV->request_url($href), {
+    content => $card,
+    headers => \%Headers,
+  });
+
+  $self->assert_num_equals(201, $Response->{status});
+  $self->assert_num_equals(0,
+      $admin->message_count('user.cassandane.#jmapnotification'));
+
+  xlog "Update event";
+  $card =~ s/foo/bar/s;
+  $Response = $CalDAV->{ua}->request('PUT', $CalDAV->request_url($href), {
+    content => $card,
+    headers => \%Headers,
+  });
+
+  $self->assert_num_equals(204, $Response->{status});
+  $self->assert_num_equals(0,
+      $admin->message_count('user.cassandane.#jmapnotification'));
+
+  xlog "Delete event";
+  $Response = $CalDAV->{ua}->request('DELETE', $CalDAV->request_url($href), {
+    headers => \%Headers,
+  });
+
+  $self->assert_num_equals(204, $Response->{status});
+  $self->assert_num_equals(0,
+      $admin->message_count('user.cassandane.#jmapnotification'));
+}
+
 1;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4506,29 +4506,6 @@ done:
     return r;
 }
 
-static int calendar_has_sharees(const mbentry_t *mbentry)
-{
-    if (!mbentry->acl) return 0;
-
-    mbname_t *mbname = mbname_from_intname(mbentry->name);
-    const char *ownerid = mbname_userid(mbname);
-
-    strarray_t *acls = strarray_split(mbentry->acl, "\t", STRARRAY_TRIM);
-    int has_sharees = 0;
-    for (int i = 0; i < strarray_size(acls); i += 2) {
-        const char *userid = strarray_nth(acls, i);
-        if (strcmp(ownerid, userid) && !is_system_user(userid)) {
-            has_sharees = 1;
-            break;
-        }
-    }
-
-    mbname_free(&mbname);
-    strarray_free(acls);
-
-    return has_sharees;
-}
-
 static int createevent_store(jmap_req_t *req,
                              struct jmap_parser *parser,
                              struct createevent *create,

--- a/imap/jmap_notif.c
+++ b/imap/jmap_notif.c
@@ -445,4 +445,25 @@ done:
     return r;
 }
 
+HIDDEN int calendar_has_sharees(const mbentry_t *mbentry)
+{
+    if (!mbentry->acl) return 0;
 
+    mbname_t *mbname = mbname_from_intname(mbentry->name);
+    const char *ownerid = mbname_userid(mbname);
+
+    strarray_t *acls = strarray_split(mbentry->acl, "\t", STRARRAY_TRIM);
+    int has_sharees = 0;
+    for (int i = 0; i < strarray_size(acls); i += 2) {
+        const char *userid = strarray_nth(acls, i);
+        if (strcmp(ownerid, userid) && !is_system_user(userid)) {
+            has_sharees = 1;
+            break;
+        }
+    }
+
+    mbname_free(&mbname);
+    strarray_free(acls);
+
+    return has_sharees;
+}

--- a/imap/jmap_notif.h
+++ b/imap/jmap_notif.h
@@ -78,4 +78,6 @@ extern int jmap_create_caldaveventnotif(struct transaction_t *txn,
                                         icalcomponent *oldical,
                                         icalcomponent *newical);
 
+extern int calendar_has_sharees(const mbentry_t *mbentry);
+
 #endif /* JMAP_NOTIF_H */


### PR DESCRIPTION
Before, an event notification was created for any PUT/DELETE
regardless if the calendar was shared to any user. This caused
notifications to pile up that no user ever sees before they get
expunged.