### PR TITLE
cyr_expire --jmap-notif: Don't expire #sieve files

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -780,7 +780,7 @@ static int jnotif_cb(const mbentry_t *mbentry, void *vrock)
 {
     struct jnotif_rock *rock = vrock;
 
-    if ((mbentry->mbtype & MBTYPE_JMAPNOTIFY) == 0) return 0;
+    if (mbtype_isa(mbentry->mbtype) != MBTYPE_JMAPNOTIFY) return 0;
 
     // Lock the mailbox.
     struct mailbox *mbox = NULL;


### PR DESCRIPTION
Both MBTYPE_JMAPNOTIFY and MBTYPE_SIEVE have 1 << 2 set:

    #define MBTYPE_JMAPNOTIFY   0x4    /* JMAP Notifications */
    #define MBTYPE_SIEVE        0x5    /* Sieve Script Mailbox */

Mailbox types in the lowest 4 bits must be compared exactly, not
as individual bit flags.