### PR TITLE
promstatsd: can't accumulate stats from files that couldn't be locked

### DIFF
--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -177,10 +177,12 @@ static int promdir_foreach(promdir_foreach_cb *proc, enum promdir_foreach_mode m
         r = mappedfile_open(&mf, fname, 0);
         if (r) continue;
         r = mappedfile_readlock(mf);
-        if (!r) {
-            memcpy(&stats, mappedfile_base(mf), mappedfile_size(mf));
-            mappedfile_unlock(mf);
+        if (r) {
+            mappedfile_close(&mf);
+            continue;
         }
+        memcpy(&stats, mappedfile_base(mf), mappedfile_size(mf));
+        mappedfile_unlock(mf);
         mappedfile_close(&mf);
 
         r = proc(&stats, rock);


### PR DESCRIPTION
Found by @dilyanpalauzov using Clang's static analyser: if a stats file is successfully `mappedfile_open()`d, but then the subsequent `mappedfile_readlock()` failed, we would end up trying to read uninitialised memory and probably crash.

I'm not sure what it even means if `mappedfile_open()` succeeds and `mappedfile_readlock()` fails (though the `mappedfile_readlock()` will log an IOERROR explaining why)...

With this fix, if it ever happens, we'll just ignore that file this time, rather than crashing.  The resultant metrics report will be under-counted by whatever counts were in that file, but it should self-correct on the next update, assuming the cause was ephemeral.

Fixes #4054