### PR TITLE
httpd/parse_accept() is never called with NULL parameter

### DIFF
--- a/imap/http_dav.h
+++ b/imap/http_dav.h
@@ -601,7 +601,7 @@ int dav_check_precond(struct transaction_t *txn, struct meth_params *params,
                       const char *etag, time_t lastmod);
 int dav_premethod(struct transaction_t *txn);
 unsigned get_preferences(struct transaction_t *txn);
-struct mime_type_t *get_accept_type(const char **hdr, struct mime_type_t *types);
+struct mime_type_t *get_accept_type(const char **hdr, struct mime_type_t *types) __attribute__((nonnull(1)));
 
 int parse_xml_body(struct transaction_t *txn, xmlNodePtr *root,
                    const char *mimetype);

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -538,7 +538,7 @@ static int meth_post(struct transaction_t *txn,
  * JMAP Requests
  */
 
-static char *parse_accept_header(const char **hdr)
+__attribute__((nonnull)) static char *parse_accept_header(const char **hdr)
 {
     char *val = NULL;
     struct accept *accept = parse_accept(hdr);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2464,7 +2464,7 @@ struct accept *parse_accept(const char **hdr)
     struct accept *ret = NULL;
 #define GROW_ACCEPT 10;
 
-    for (i = 0; hdr && hdr[i]; i++) {
+    for (i = 0; hdr[i]; i++) {
         tok_t tok = TOK_INITIALIZER(hdr[i], ",", TOK_TRIMLEFT|TOK_TRIMRIGHT);
         char *token;
 

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -587,7 +587,7 @@ extern int ws_enabled;
 
 extern xmlURIPtr parse_uri(unsigned meth, const char *uri, unsigned path_reqd,
                            const char **errstr);
-extern struct accept *parse_accept(const char **hdr);
+struct accept *parse_accept(const char **hdr) __attribute__((nonnull));
 extern void free_accept(struct accept *a);
 extern void parse_query_params(struct transaction_t *txn, const char *query);
 extern time_t calc_compile_time(const char *time, const char *date);


### PR DESCRIPTION
The Clang Static Analyzer claims in the call of parse_accept(NULL), that qsort(NULL, …) will be executed, while the first parameter of qsort() may not be null.

This changeset tells the compiler, that the invocation of parse_accept(), or its callers, will not pass NULL as parameter.