### PR TITLE
Add some nonnull/returns_nonnull/warn_unused_result attributes

### DIFF
--- a/imap/smtpclient.h
+++ b/imap/smtpclient.h
@@ -181,7 +181,7 @@ extern const char *smtpclient_has_ext(smtpclient_t *sm, const char *name);
 extern unsigned smtpclient_get_resp_code(smtpclient_t *sm);
 
 /* Return the text of the last SMTP response, or NULL if empty */
-extern const char *smtpclient_get_resp_text(smtpclient_t *sm);
+__attribute__((nonnull)) const char *smtpclient_get_resp_text(smtpclient_t *sm);
 
 
 #endif

--- a/lib/util.h
+++ b/lib/util.h
@@ -289,13 +289,13 @@ struct buf {
 #define buf_ensure(b, n) do { if ((b)->alloc < (b)->len + (n)) _buf_ensure((b), (n)); } while (0)
 #define buf_putc(b, c) do { buf_ensure((b), 1); (b)->s[(b)->len++] = (c); } while (0)
 
-void _buf_ensure(struct buf *buf, size_t len);
-const char *buf_cstring(const struct buf *buf);
-const char *buf_cstringnull(const struct buf *buf);
-const char *buf_cstringnull_ifempty(const struct buf *buf);
-char *buf_release(struct buf *buf);
-char *buf_newcstring(struct buf *buf);
-char *buf_releasenull(struct buf *buf);
+__attribute__((nonnull)) void _buf_ensure(struct buf *buf, size_t len);
+__attribute__((nonnull, returns_nonnull)) const char *buf_cstring(const struct buf *buf);
+__attribute__((nonnull)) const char *buf_cstringnull(const struct buf *buf);
+__attribute__((nonnull)) const char *buf_cstringnull_ifempty(const struct buf *buf);
+__attribute__((nonnull, returns_nonnull, warn_unused_result)) char *buf_release(struct buf *buf);
+__attribute__((nonnull, returns_nonnull, warn_unused_result)) char *buf_newcstring(struct buf *buf);
+__attribute__((nonnull, warn_unused_result)) char *buf_releasenull(struct buf *buf);
 void buf_getmap(struct buf *buf, const char **base, size_t *len);
 int buf_getline(struct buf *buf, FILE *fp);
 size_t buf_len(const struct buf *buf);

--- a/lib/xmalloc.h
+++ b/lib/xmalloc.h
@@ -48,15 +48,15 @@
 /* for free() */
 #include <stdlib.h>
 
-extern void *xmalloc (size_t size);
-extern void *xzmalloc (size_t size);
-extern void *xcalloc (size_t nmemb, size_t size);
-extern void *xrealloc (void *ptr, size_t size);
-extern char *xstrdup (const char *str);
+__attribute__((malloc, warn_unused_result)) void *xmalloc (size_t size);
+__attribute__((malloc, warn_unused_result)) void *xzmalloc (size_t size);
+__attribute__((malloc, warn_unused_result)) void *xcalloc (size_t nmemb, size_t size);
+__attribute__((warn_unused_result)) void *xrealloc (void *ptr, size_t size);
+__attribute__((malloc, warn_unused_result)) char *xstrdup (const char *str);
 extern char *xstrdupnull (const char *str);
-extern char *xstrdupsafe (const char *str);
-extern char *xstrndup (const char *str, size_t len);
-extern void *xmemdup (const void *ptr, size_t size);
+__attribute__((malloc, warn_unused_result)) char *xstrdupsafe (const char *str);
+__attribute__((malloc, warn_unused_result)) char *xstrndup (const char *str, size_t len);
+__attribute__((malloc, warn_unused_result)) void *xmemdup (const void *ptr, size_t size);
 
 // free a pointer and also zero it
 #define xzfree(ptr) do { \


### PR DESCRIPTION
This allows the compilers to emit more warnings.