### PR TITLE
Replicate to archive

### DIFF
--- a/backup/backupd.c
+++ b/backup/backupd.c
@@ -645,7 +645,7 @@ static void cmdloop(void)
             if (!backupd_userid) goto nologin;
             if (!strcmp(cmd.s, "Apply")) {
                 struct dlist *dl = NULL;
-                c = dlist_parse(&dl, /*parsekeys*/ 1, /*isbackup*/ 1, backupd_in);
+                c = dlist_parse(&dl, /*parsekeys*/ 1, /*isarchive*/ 0, /*isbackup*/ 1, backupd_in);
                 if (c == EOF) goto missingargs;
                 if (c == '\r') c = prot_getc(backupd_in);
                 if (c != '\n') goto extraargs;
@@ -681,7 +681,7 @@ static void cmdloop(void)
             if (!backupd_userid) goto nologin;
             if (!strcmp(cmd.s, "Get")) {
                 struct dlist *dl = NULL;
-                c = dlist_parse(&dl, /*parsekeys*/ 1, /*isbackup*/ 1, backupd_in);
+                c = dlist_parse(&dl, /*parsekeys*/ 1, /*isarchive*/ 0, /*isbackup*/ 1, backupd_in);
                 if (c == EOF) goto missingargs;
                 if (c == '\r') c = prot_getc(backupd_in);
                 if (c != '\n') goto extraargs;

--- a/backup/lcb_internal.c
+++ b/backup/lcb_internal.c
@@ -77,7 +77,7 @@ HIDDEN int parse_backup_line(struct protstream *in, time_t *ts,
     if (c == EOF)
         goto fail;
 
-    c = dlist_parse(&dl, /*parsekeys*/ 1, 1, in);
+    c = dlist_parse(&dl, /*parsekeys*/ 1, /*isarchive*/ 0, 1, in);
 
     if (!dl) {
         fprintf(stderr, "\ndidn't parse dlist, error %i\n", c);

--- a/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
@@ -168,6 +168,17 @@ Options
     compression if both ends support it.  Set this flag when you want
     to abort if compression is not available.
 
+.. option:: -a
+
+    Request the replicate-to-archive feature. If the remote end has the
+    ``archive_enabled`` option set, then it will stage incoming replication on
+    the archive partition instead of the spool partition. If the remote end
+    does not support it, replication will proceed as though **-a** was not
+    provided.  This option is useful when standing up a new replica of an
+    existing server, as most of the stored mail is likely older than the
+    archive threshold and so is destined for the archive partition anyway. By
+    staging on that partition, Cyrus can avoid a cross-partition copy for every
+    message.
 
 Examples
 ========

--- a/imap/append.c
+++ b/imap/append.c
@@ -439,7 +439,7 @@ static int callout_receive_reply(const char *callout,
     prot_setisclient(p, 1);
 
     /* read and parse the reply as a dlist */
-    c = dlist_parse(results, /*parsekeys*/0, /*isbackup*/0, p);
+    c = dlist_parse(results, /*parsekeys*/0, /*isarchive*/0, /*isbackup*/0, p);
     r = (c == EOF ? IMAP_SYS_ERROR : 0);
 
 out:

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -219,7 +219,7 @@ void dlist_print(const struct dlist *dl, int printkeys,
                  struct protstream *out);
 void dlist_printbuf(const struct dlist *dl, int printkeys,
                     struct buf *outbuf);
-int dlist_parse(struct dlist **dlp, int parsekeys, int isbackup,
+int dlist_parse(struct dlist **dlp, int parsekeys, int isarchive, int isbackup,
                  struct protstream *in);
 int dlist_parse_asatomlist(struct dlist **dlp, int parsekey,
                             struct protstream *in);

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -102,6 +102,7 @@ struct protocol_t imap_protocol =
           { "SASL-IR", CAPA_SASL_IR },
           { "X-REPLICATION", CAPA_REPLICATION },
           { "X-SIEVE-MAILBOX", CAPA_SIEVE_MAILBOX },
+          { "X-REPLICATION-ARCHIVE", CAPA_REPLICATION_ARCHIVE },
           /* Need to bump MAX_CAPA in protocol.h if this array is extended */
           { NULL, 0 } } },
       { "S01 STARTTLS", "S01 OK", "S01 NO", 0 },

--- a/imap/imap_proxy.h
+++ b/imap/imap_proxy.h
@@ -57,15 +57,16 @@ enum {
 
 enum {
     /* IMAP capabilities */
-    CAPA_IDLE           = (1 << 3),
-    CAPA_MUPDATE        = (1 << 4),
-    CAPA_MULTIAPPEND    = (1 << 5),
-    CAPA_ACLRIGHTS      = (1 << 6),
-    CAPA_LISTEXTENDED   = (1 << 7),
-    CAPA_SASL_IR        = (1 << 8),
-    CAPA_REPLICATION    = (1 << 9),
-    CAPA_METADATA       = (1 << 10),
-    CAPA_SIEVE_MAILBOX  = (1 << 11),
+    CAPA_IDLE                = (1 << 3),
+    CAPA_MUPDATE             = (1 << 4),
+    CAPA_MULTIAPPEND         = (1 << 5),
+    CAPA_ACLRIGHTS           = (1 << 6),
+    CAPA_LISTEXTENDED        = (1 << 7),
+    CAPA_SASL_IR             = (1 << 8),
+    CAPA_REPLICATION         = (1 << 9),
+    CAPA_METADATA            = (1 << 10),
+    CAPA_SIEVE_MAILBOX       = (1 << 11),
+    CAPA_REPLICATION_ARCHIVE = (1 << 12),
 };
 
 extern struct protocol_t imap_protocol;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -2082,7 +2082,7 @@ static void cmdloop(void)
             else if (!strcmp(cmd.s, "Syncapply")) {
                 if (!imapd_userisadmin) goto badcmd;
 
-                struct dlist *kl = sync_parseline(imapd_in);
+                struct dlist *kl = sync_parseline(imapd_in, /*isarchive*/ 0);
 
                 if (kl) {
                     cmd_syncapply(tag.s, kl, reserve_list);
@@ -2093,7 +2093,7 @@ static void cmdloop(void)
             else if (!strcmp(cmd.s, "Syncget")) {
                 if (!imapd_userisadmin) goto badcmd;
 
-                struct dlist *kl = sync_parseline(imapd_in);
+                struct dlist *kl = sync_parseline(imapd_in, /*isarchive*/ 0);
 
                 if (kl) {
                     cmd_syncget(tag.s, kl);
@@ -2112,7 +2112,7 @@ static void cmdloop(void)
             else if (!strcmp(cmd.s, "Syncrestore")) {
                 if (!imapd_userisadmin) goto badcmd;
 
-                struct dlist *kl = sync_parseline(imapd_in);
+                struct dlist *kl = sync_parseline(imapd_in, /*isarchive*/ 0);
 
                 if (kl) {
                     cmd_syncrestore(tag.s, kl, reserve_list);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -381,6 +381,7 @@ static struct capa_struct base_capabilities[] = {
     { "X-CREATEDMODSEQ",       2 }, /* Cyrus custom */
     { "X-REPLICATION",         2 }, /* Cyrus custom */
     { "X-SIEVE-MAILBOX",       2 }, /* Cyrus custom */
+    { "X-REPLICATION-ARCHIVE", 2 }, /* Cyrus custom */
     { "XLIST",                 2 }, /* not standard */
     { "XMOVE",                 2 }, /* not standard */
 

--- a/imap/notify.c
+++ b/imap/notify.c
@@ -137,7 +137,7 @@ static void notify_dlist(const char *sockpath, const char *method,
     prot_printf(out, "\r\n");
     prot_flush(out);
 
-    c = dlist_parse(&res, 1, 0, in);
+    c = dlist_parse(&res, 1, 0, 0, in);
     if (c == '\r') c = prot_getc(in);
     /* XXX - do something with the response?  Like have NOTIFY answer */
     if (c == '\n' && res && res->name) {

--- a/imap/protocol.h
+++ b/imap/protocol.h
@@ -54,7 +54,7 @@ enum {
 struct stdprot_t;
 struct backend;
 
-#define MAX_CAPA 12
+#define MAX_CAPA 13
 
 enum {
     /* generic capabilities */

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -109,6 +109,7 @@ static int sync_once       = 0;
 static int background      = 0;
 static int do_compress     = 0;
 static int no_copyback     = 0;
+static int archive         = 0;
 
 static char *prev_userid;
 
@@ -469,7 +470,7 @@ int main(int argc, char **argv)
 
     setbuf(stdout, NULL);
 
-    while ((opt = getopt(argc, argv, "C:vlLS:F:f:w:t:d:n:rRNumsozOAp:1")) != EOF) {
+    while ((opt = getopt(argc, argv, "C:vlLS:F:f:w:t:d:n:rRNumsozOAp:1a")) != EOF) {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
@@ -580,6 +581,10 @@ int main(int argc, char **argv)
             partition = optarg;
             break;
 
+        case 'a':
+            archive = 1;
+            break;
+
         default:
             usage("sync_client", NULL);
         }
@@ -591,6 +596,7 @@ int main(int argc, char **argv)
     if (verbose) flags |= SYNC_FLAG_VERBOSE;
     if (verbose_logging) flags |= SYNC_FLAG_LOGGING;
     if (no_copyback) flags |= SYNC_FLAG_NO_COPYBACK;
+    if (archive) flags |= SYNC_FLAG_ARCHIVE;
 
     /* fork if required */
     if (background && !input_filename && !getenv("CYRUS_ISDAEMON")) {

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -300,6 +300,10 @@ static void dobanner(void)
 #endif
 
         prot_printf(sync_out, "* SIEVE-MAILBOX\r\n");
+
+        if (config_getswitch(IMAPOPT_ARCHIVE_ENABLED)) {
+            prot_printf(sync_out, "* REPLICATION-ARCHIVE\r\n");
+        }
     }
 
     prot_printf(sync_out,

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -557,7 +557,7 @@ static void cmdloop(void)
             }
             if (!sync_userid) goto nologin;
             if (!strcmp(cmd.s, "Apply")) {
-                kl = sync_parseline(sync_in);
+                kl = sync_parseline(sync_in, /*isarchive*/ 0);
                 if (kl) {
                     cmd_apply(kl, reserve_list);
                     dlist_free(&kl);
@@ -585,7 +585,7 @@ static void cmdloop(void)
         case 'G':
             if (!sync_userid) goto nologin;
             if (!strcmp(cmd.s, "Get")) {
-                kl = sync_parseline(sync_in);
+                kl = sync_parseline(sync_in, /*isarchive*/ 0);
                 if (kl) {
                     cmd_get(kl);
                     dlist_free(&kl);
@@ -629,7 +629,7 @@ static void cmdloop(void)
             }
             if (!sync_userid) goto nologin;
             if (!strcmp(cmd.s, "Restore")) {
-                kl = sync_parseline(sync_in);
+                kl = sync_parseline(sync_in, /*isarchive*/ 0);
                 if (kl) {
                     cmd_restore(kl, reserve_list);
                     dlist_free(&kl);

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -969,6 +969,13 @@ static void cmd_restart(struct sync_reserve_list **reserve_listp, int re_alloc)
         snprintf(buf, MAX_MAILBOX_PATH, "%s/sync./%lu",
                  config_partitiondir(p->name), (unsigned long)getpid());
         rmdir(buf);
+
+        if (config_getswitch(IMAPOPT_ARCHIVE_ENABLED)) {
+            /* and the archive partition too */
+            snprintf(buf, MAX_MAILBOX_PATH, "%s/sync./%lu",
+                    config_archivepartitiondir(p->name), (unsigned long)getpid());
+            rmdir(buf);
+        }
     }
     partition_list_free(pl);
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -1830,12 +1830,12 @@ void sync_eatline(struct protstream *pin, int c)
     }
 }
 
-struct dlist *sync_parseline(struct protstream *in)
+struct dlist *sync_parseline(struct protstream *in, int isarchive)
 {
     struct dlist *dl = NULL;
     int c;
 
-    c = dlist_parse(&dl, 1, 0, in);
+    c = dlist_parse(&dl, 1, isarchive, 0, in);
 
     /* end line - or fail */
     if (c == '\r') c = prot_getc(in);
@@ -2051,7 +2051,7 @@ int sync_parse_response(const char *cmd, struct protstream *in,
 
     kl = dlist_newlist(NULL, cmd);
     while (!strcmp(response.s, "*")) {
-        struct dlist *item = sync_parseline(in);
+        struct dlist *item = sync_parseline(in, /*isarchive*/ 0);
         if (!item) goto parse_err;
         dlist_stitch(kl, item);
         if ((c = getword(in, &response)) == EOF)

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -124,6 +124,7 @@ struct protocol_t imap_csync_protocol =
           { "SASL-IR", CAPA_SASL_IR },
           { "X-REPLICATION", CAPA_REPLICATION },
           { "X-SIEVE-MAILBOX", CAPA_SIEVE_MAILBOX },
+          { "X-REPLICATION-ARCHIVE", CAPA_REPLICATION_ARCHIVE },
           { NULL, 0 } } },
       { "S01 STARTTLS", "S01 OK", "S01 NO", 0 },
       { "A01 AUTHENTICATE", 0, 0, "A01 OK", "A01 NO", "+ ", "*",
@@ -142,6 +143,7 @@ struct protocol_t csync_protocol =
           { "STARTTLS", CAPA_STARTTLS },
           { "COMPRESS=DEFLATE", CAPA_COMPRESS },
           { "SIEVE-MAILBOX", CAPA_SIEVE_MAILBOX },
+          { "REPLICATION-ARCHIVE", CAPA_REPLICATION_ARCHIVE },
           { NULL, 0 } } },
       { "STARTTLS", "OK", "NO", 1 },
       { "AUTHENTICATE", USHRT_MAX, 0, "OK", "NO", "+ ", "*", NULL, 0 },
@@ -4174,6 +4176,13 @@ int sync_apply_capabilities(struct dlist *kin, struct sync_state *sstate)
             sstate->flags |= SYNC_FLAG_SIEVE_MAILBOX;
             dlist_setatom(kout, NULL, capa);
         }
+
+        if (!strcasecmp(capa, "REPLICATION-ARCHIVE")) {
+            if (config_getswitch(IMAPOPT_ARCHIVE_ENABLED)) {
+                sstate->flags |= SYNC_FLAG_ARCHIVE;
+                dlist_setatom(kout, NULL, capa);
+            }
+        }
     }
 
     sync_send_response(kout, sstate->pout);
@@ -8048,9 +8057,31 @@ connected:
     }
 #endif
 
+    unsigned capabilities = 0;
+
     if (CAPA(backend, CAPA_SIEVE_MAILBOX)) {
         syslog(LOG_INFO, "Destination supports #sieve mailbox");
-        sync_do_enable(sync_cs, CAPA_SIEVE_MAILBOX);
+        capabilities |= CAPA_SIEVE_MAILBOX;
+    }
+
+    if (sync_cs->flags & SYNC_FLAG_ARCHIVE) {
+        if (CAPA(backend, CAPA_REPLICATION_ARCHIVE)) {
+            syslog(LOG_INFO, "Destination supports replication to archive");
+            capabilities |= CAPA_REPLICATION_ARCHIVE;
+            sync_cs->flags &= ~SYNC_FLAG_ARCHIVE;
+        }
+        else {
+            syslog(LOG_NOTICE, "Destination doesn't support replication to archive");
+        }
+    }
+
+    if (capabilities) {
+        sync_do_enable(sync_cs, capabilities);
+
+        if (capabilities & CAPA_REPLICATION_ARCHIVE && !(sync_cs->flags & SYNC_FLAG_ARCHIVE)) {
+            syslog(LOG_NOTICE, "Replication to archive requested but destination didn't enable it");
+            return IMAP_REMOTE_DENIED;
+        }
     }
 
     /* Set inactivity timer */
@@ -8167,6 +8198,9 @@ int sync_do_enable(struct sync_client_state *sync_cs, unsigned capabilities)
     if (capabilities & CAPA_SIEVE_MAILBOX) {
         dlist_setatom(kl, NULL, "SIEVE-MAILBOX");
     }
+    if (capabilities & CAPA_REPLICATION_ARCHIVE) {
+        dlist_setatom(kl, NULL, "REPLICATION-ARCHIVE");
+    }
 
     sync_send_apply(kl, sync_cs->backend->out);
     dlist_free(&kl);
@@ -8188,6 +8222,8 @@ int sync_do_enable(struct sync_client_state *sync_cs, unsigned capabilities)
 
                 if (!strcasecmp(capa, "SIEVE-MAILBOX"))
                     sync_cs->flags |= SYNC_FLAG_SIEVE_MAILBOX;
+                if (!strcasecmp(capa, "REPLICATION-ARCHIVE"))
+                    sync_cs->flags |= SYNC_FLAG_ARCHIVE;
             }
         }
     }

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -382,7 +382,7 @@ void sync_send_lookup(struct dlist *kl, struct protstream *out);
 void sync_send_restart(struct protstream *out);
 void sync_send_restore(struct dlist *kl, struct protstream *out);
 
-struct dlist *sync_parseline(struct protstream *in);
+struct dlist *sync_parseline(struct protstream *in, int isarchive);
 
 /* ====================================================================== */
 

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -481,6 +481,7 @@ const char *sync_restore(struct dlist *kin,
 #define SYNC_FLAG_BATCH (1<<5)
 #define SYNC_FLAG_SIEVE_MAILBOX (1<<6)
 #define SYNC_FLAG_NONBLOCK (1<<7)
+#define SYNC_FLAG_ARCHIVE (1<<8)
 
 int sync_do_seen(struct sync_client_state *sync_cs, const char *userid, char *uniqueid);
 int sync_do_quota(struct sync_client_state *sync_cs, const char *root);


### PR DESCRIPTION
This adds a capability to the replication protocol that, when enabled, causes sync files to be written to the archive partition instead of the main spool. Closes #3830.

This compiles and has been lightly tested by hand in a test environment. I have tested:

- setting/clearing `archive_enabled`, confirming the the `REPLICATION-ARCHIVE` capability is offered correctly
- running `sync_client` with and without `-a`, and confirming with `strace` that `sync_server` stores and deletes incoming files to the correct sync dir.
- running `sync_server` without `archive_enabled` set, and confirming with `strace` that `sync_server` stores and deletes incoming files to the main spool regardless of the presence or absence of the `-a` switch.

So I'm inclined to say this is plausibly correct, but I don't know the fine details of the replication system and would love someone to read it through properly.

I haven't tested `imapd`-based replication at all as I'm totally unfamiliar with it.

As you see, there's no automated testing here as I'm not sure where to start. All guidance welcome!

I didn't really love the way I've done it, but I think there's no choice but to plumb the archive flag down through the dlist parser, since that's where the sync file stuff is all handled. Switching between the global and `sync_state` flag seems weird too; I've pretty much copied the sieve-mailbox model for that. I guess what I'm saying is, this is a bit yuck, but not new forms of yuck, and nothing that can be fixed without reworking a bit of internals, which is definitely not why I'm here!