### PR TITLE
fix 3.6 bare "./configure" build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1207,13 +1207,17 @@ endif # AUTOCREATE
 
 if SIEVE
 imap_lmtpd_SOURCES += imap/lmtp_sieve.c imap/lmtp_sieve.h imap/smtpclient.c \
-                      imap/caldav_util.c imap/itip_support.c imap/zoneinfo_db.c
+                      imap/zoneinfo_db.c
+if HTTPD
+imap_lmtpd_SOURCES += imap/caldav_util.c imap/itip_support.c
 
 if JMAP
 imap_lmtpd_SOURCES += \
 	imap/jmap_util.c imap/jmap_mail_query.c imap/jmap_mail_query_parse.c \
 	imap/dav_util.c imap/jmap_notif.c imap/jmap_ical.c
 endif # JMAP
+
+endif # HTTPD
 
 endif # SIEVE
 

--- a/configure.ac
+++ b/configure.ac
@@ -671,6 +671,12 @@ AC_ARG_ENABLE(pcre,
 if test "$enable_sieve" != "no"; then
         AC_DEFINE(USE_SIEVE,[],[Build in Sieve support?])
 
+        if test "x$HAVE_SQLITE" != x1; then
+            AC_MSG_ERROR([Need sqlite3 for sieve])
+        else
+            use_sqlite="yes"
+        fi
+
         dnl Sieve configure stuff
         AC_PROG_YACC
         AM_PROG_LEX

--- a/imap/mbpath.c
+++ b/imap/mbpath.c
@@ -180,12 +180,15 @@ static void print_json(const mbname_t *mbname, const mbentry_t *mbentry)
         json_object_set_new(juser, "sub", json_string(val));
         free(val);
 
+#ifdef USE_XAPIAN
         val = user_hash_meta(userid, "xapianactive");
         json_object_set_new(juser, "xapianactive", json_string(val));
         free(val);
+#endif /* USE_XAPIAN */
 
         json_object_set_new(jres, "user", juser);
 
+#ifdef USE_XAPIAN
         // xapian tiers
         json_t *jxapian = json_object();
         strarray_t tiers = STRARRAY_INITIALIZER;
@@ -202,6 +205,7 @@ static void print_json(const mbname_t *mbname, const mbentry_t *mbentry)
         strarray_fini(&tiers);
 
         json_object_set_new(jres, "xapian", jxapian);
+#endif /* USE_XAPIAN */
     }
 
     // mailbox paths


### PR DESCRIPTION
Part of #4072 

This fixes a bare "./configure" (with no arguments) build for the 3.6 branch.  I'm opening the PR against master, since master will also need the same fixes (and then some).  Once it's approved/merged, I'll backport it to 3.6.

This _does not_ completely fix a bare "./configure" build of the master branch.  See linked issue for details.