### PR TITLE
Fix memory leaks issues 4060 4070

### DIFF
--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -145,6 +145,7 @@ static json_t *extract_value(json_t *val, const char *path, ptrarray_t *pool)
         }
         p = jmap_pointer_decode(path, top - path);
         if (*p == '\0') {
+            free(p);
             return NULL;
         }
 

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1955,6 +1955,7 @@ xapian_query_new_match(const xapian_db_t *db, int partnum, const char *str)
             Xapian::Query *qq = xapian_query_new_match_internal(db, partnum, mystr);
             if (qq && q) {
                 *q |= *qq;
+                delete qq;
             }
             else if (!q) q = qq;
         }


### PR DESCRIPTION
Fixes two memory leaks that @dilyanpalauzov found, one in the Xapian wrapper, one in the JMAP result references handling code.