### PR TITLE
Remove useless assignments

### DIFF
--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -4564,7 +4564,7 @@ EXPORTED int check_precond(struct transaction_t *txn,
 
     /* Step 5 */
     if (txn->flags.ranges &&  /* Only if we support Range requests */
-        txn->meth == METH_GET && (hdr = spool_getheader(hdrcache, "Range"))) {
+        txn->meth == METH_GET && spool_getheader(hdrcache, "Range")) {
 
         if ((hdr = spool_getheader(hdrcache, "If-Range"))) {
             time_from_rfc5322(hdr[0], &since, DATETIME_FULL); /* error OK here, could be an etag */

--- a/imap/message.c
+++ b/imap/message.c
@@ -3130,7 +3130,7 @@ static int message_read_body(struct protstream *strm, struct body *body, const c
     if (c == EOF) goto done;
 
     /* check for multipart */
-    if ((c = prot_peek(strm)) == '(') {
+    if (prot_peek(strm) == '(') {
 
         body->type = xstrdup("MULTIPART");
         do {

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -2115,7 +2115,6 @@ int cmd_change(struct mupdate_mailboxdata *mdata,
     char *oldlocation = NULL;
     char *thislocation = NULL;
     char *tmp;
-    enum settype t = -1;
     int ret = 0;
 
     if (!mdata || !rock || !mdata->mailbox) return 1;
@@ -2133,7 +2132,7 @@ int cmd_change(struct mupdate_mailboxdata *mdata,
             /* ret = -1; */
             goto done;
         }
-        m->t = t = SET_DELETE;
+        m->t = SET_DELETE;
 
         oldlocation = xstrdup(m->location);
     } else {
@@ -2151,9 +2150,9 @@ int cmd_change(struct mupdate_mailboxdata *mdata,
             else m->acl[0] = '\0';
 
             if (!strncmp(rock, "MAILBOX", 6)) {
-                m->t = t = SET_ACTIVE;
+                m->t = SET_ACTIVE;
             } else if (!strncmp(rock, "RESERVE", 7)) {
-                m->t = t = SET_RESERVE;
+                m->t = SET_RESERVE;
             } else {
                 syslog(LOG_DEBUG,
                        "bad mupdate command in cmd_change: %s", rock);
@@ -2185,9 +2184,9 @@ int cmd_change(struct mupdate_mailboxdata *mdata,
             }
 
             if (!strncmp(rock, "MAILBOX", 6)) {
-                newm->t = t = SET_ACTIVE;
+                newm->t = SET_ACTIVE;
             } else if (!strncmp(rock, "RESERVE", 7)) {
-                newm->t = t = SET_RESERVE;
+                newm->t = SET_RESERVE;
             } else {
                 syslog(LOG_DEBUG,
                        "bad mupdate command in cmd_change: %s", rock);

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -2473,7 +2473,6 @@ static void list_proxy(const char *server,
 {
     struct enum_rock *erock = (struct enum_rock *) rock;
     struct backend *be;
-    int r;
     char *result;
 
     be = proxy_findserver(server, &nntp_protocol,
@@ -2483,9 +2482,8 @@ static void list_proxy(const char *server,
 
     prot_printf(be->out, "LIST %s %s\r\n", erock->cmd, erock->wild);
 
-    r = read_response(be, 0, &result);
-    if (!r && !strncmp(result, "215 ", 4)) {
-        while (!(r = read_response(be, 0, &result)) && result[0] != '.') {
+    if (!read_response(be, 0, &result) && !strncmp(result, "215 ", 4)) {
+        while (!read_response(be, 0, &result) && result[0] != '.') {
             prot_printf(nntp_out, "%s", result);
         }
     }

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -257,7 +257,6 @@ static void test_sync_wait(const char *mboxname)
     struct stat sb;
     clock_t start;
     int status = 0;
-    int r;
 #define TIMEOUT     (30 * CLOCKS_PER_SEC)
 
     if (!test_sync_mode)
@@ -269,7 +268,7 @@ static void test_sync_wait(const char *mboxname)
     filename = strconcat(config_dir, "/quota-sync/", mboxname, (char *)NULL);
     start = sclock();
 
-    while ((r = stat(filename, &sb)) < 0 && errno == ENOENT) {
+    while (stat(filename, &sb) < 0 && errno == ENOENT) {
         if (sclock() - start > TIMEOUT) {
             status = 2;
             break;

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -1615,7 +1615,6 @@ HIDDEN int tls_start_clienttls(int readfd, int writefd,
                         int *layerbits, char **authid, SSL **ret,
                         SSL_SESSION **sess)
 {
-    int     sts;
     const SSL_CIPHER *cipher;
     X509   *peer;
     const char *tls_protocol = NULL;
@@ -1668,7 +1667,7 @@ HIDDEN int tls_start_clienttls(int readfd, int writefd,
     if (sess && *sess)  /* Reuse a session if we have one */
         SSL_set_session(tls_conn, *sess);
 
-    if ((sts = SSL_connect(tls_conn)) <= 0) {
+    if (SSL_connect(tls_conn) <= 0) {
         SSL_SESSION *session = SSL_get_session(tls_conn);
         if (session) {
             SSL_CTX_remove_session(c_ctx, session);

--- a/lib/prot.c
+++ b/lib/prot.c
@@ -841,13 +841,13 @@ EXPORTED int prot_fill(struct protstream *s)
 EXPORTED int prot_flush(struct protstream *s)
 {
     if (!s->write) {
-        int c, save_dontblock = s->dontblock;
+        int save_dontblock = s->dontblock;
 
         /* Set stream to nonblocking mode */
         if (!save_dontblock) nonblock(s->fd, (s->dontblock = 1));
 
         /* Ingest any pending input */
-        while ((c = prot_fill(s)) != EOF);
+        while (prot_fill(s) != EOF);
 
         /* Reset stream to previous blocking mode */
         if (!save_dontblock) nonblock(s->fd, (s->dontblock = 0));


### PR DESCRIPTION
or, as the Clang Static Analyzer calls them, “Dead nested assignments”.