### PR TITLE
cassandane: verify that smtp service actually started

### DIFF
--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -604,8 +604,10 @@ sub _list_pid_files
     my ($self) = @_;
 
     my $rundir = $self->{basedir} . "/run";
-    opendir(RUNDIR, $rundir)
-        or die "Cannot open run directory $rundir: $!";
+    if (!opendir(RUNDIR, $rundir)) {
+        return if $!{ENOENT}; # no run dir? never started
+        die "Cannot open run directory $rundir: $!";
+    }
 
     my @pidfiles;
     while ($_ = readdir(RUNDIR))
@@ -1498,7 +1500,7 @@ sub stop
 
     $self->_init_basedir_and_name();
 
-    return if ($self->{_stopped});
+    return if ($self->{_stopped} || !$self->{_started});
     $self->{_stopped} = 1;
 
     my @errors;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1050,7 +1050,8 @@ sub set_smtpd {
     }
 }
 
-sub _start_smtpd {
+sub _start_smtpd
+{
     my ($self) = @_;
 
     my $basedir = $self->{basedir};
@@ -1085,19 +1086,28 @@ sub _start_smtpd {
     }
 
     # Parent process.
-    $self->{smtphost} = $host . ':' . $port;
 
-    # XXX give the child a moment to actually start up before we start
-    # XXX assuming it has
+    # give the child a moment to actually start up
     sleep 1;
 
-    xlog "started smtpd as $smtppid";
-    push @{$self->{_shutdowncallbacks}}, sub {
-        local *__ANON__ = "kill_smtpd";
-        my $self = shift;
-        xlog "killing smtpd $smtppid";
-        kill(15, $smtppid);
-        waitpid($smtppid, 0);
+    # and then make sure it did!
+    my $waitstatus = waitpid($smtppid, WNOHANG);
+    if ($waitstatus == 0) {
+        $self->{smtphost} = $host . ':' . $port;
+
+        xlog "started smtpd as $smtppid";
+        push @{$self->{_shutdowncallbacks}}, sub {
+            local *__ANON__ = "kill_smtpd";
+            my $self = shift;
+            xlog "killing smtpd $smtppid";
+            kill(15, $smtppid);
+            waitpid($smtppid, 0);
+        };
+    }
+    else {
+        # child process already exited, something has gone wrong
+        Cassandane::PortManager::free($port);
+        die "smtpd with pid=$smtppid failed to start";
     }
 }
 

--- a/cassandane/Cassandane/PortManager.pm
+++ b/cassandane/Cassandane/PortManager.pm
@@ -74,6 +74,15 @@ sub alloc
     die "No ports remaining";
 }
 
+sub free
+{
+    my ($port) = @_;
+
+    return unless defined $base_port;
+
+    $allocated{$port} = 0;
+}
+
 sub free_all
 {
     return unless defined $base_port;


### PR DESCRIPTION
Previously, if Cassandane's fake smtp service failed to start for any reason (e.g. the assigned port was already in use), we wouldn't actually notice this.  We would naively record the port we tried to use as the smtp port, and then tests which required the smtp service would connect to whatever was there... with interesting results depending on what, if anything, was listening.

This PR makes sure the smtpd actually starts, and bails out the whole test if it didn't.

There's a couple of other tweaks to make sure that bailing out during `start()` is safe -- without them, Cassandane's internal worker pool state gets confused, and it can't shut itself down properly.