### PR TITLE
Remove useless assignments

### DIFF
--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -199,7 +199,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
     bytecode_info_t *bc = NULL;
     char *err = NULL;
     FILE *in_stream = NULL, *out_fp;
-    int out_fd = -1, in_fd = -1, r, w;
+    int out_fd = -1, in_fd = -1, r;
     int do_compile = 0;
     const char *compiled_source_script = NULL;
     const char *sievename = get_script_name(source_script);
@@ -286,7 +286,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
         if ((in_fd = open(compiled_source_script, O_RDONLY)) != -1) {
             do {
                 r = read(in_fd, buf, sizeof(buf));
-                w = write(out_fd, buf, r);
+                int w = write(out_fd, buf, r);
                 if ( w < 0 || w != r) {
                     syslog(LOG_ERR, "autocreate_sieve: Error writing to file"
                            "%s: %m", script_names.bctmpname);
@@ -449,7 +449,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
         }
 
         while ((r = read(in_fd, buf, sizeof(buf))) > 0) {
-            if ((w = write(out_fd,buf,r)) < 0) {
+            if (write(out_fd, buf, r) < 0) {
                 syslog(LOG_WARNING, "autocreate_sieve: Error writing to file:"
                        "%s: %m", script_names.tmpname2);
                 xclose(out_fd);

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -1047,7 +1047,7 @@ static int process_valarms(struct mailbox *mailbox,
                             icaltimezone *floatingtz, time_t runtime,
                             int dryrun)
 {
-    icalcomponent *ical = ical = record_to_ical(mailbox, record, NULL);
+    icalcomponent *ical = record_to_ical(mailbox, record, NULL);
     const char *mboxname = mailbox_name(mailbox);
 
     if (!ical) {

--- a/imap/fetchnews.c
+++ b/imap/fetchnews.c
@@ -134,14 +134,14 @@ static void usage(void)
 int init_net(const char *host, char *port,
              struct protstream **in, struct protstream **out)
 {
-    int sock = -1, err;
+    int sock = -1;
     struct addrinfo hints, *res, *res0;
 
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = PF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = 0;
-    if ((err = getaddrinfo(host, port, &hints, &res0)) != 0) {
+    if (getaddrinfo(host, port, &hints, &res0) != 0) {
         syslog(LOG_ERR, "getaddrinfo(%s, %s) failed: %m", host, port);
         return -1;
     }

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -1419,8 +1419,6 @@ EXPORTED int http_proxy_check_input(struct http_connection *conn,
             }
 
             if (pout) {
-                const char *err;
-
                 do {
                     char buf[4096];
                     int c = prot_read(pin, buf, sizeof(buf));
@@ -1432,7 +1430,7 @@ EXPORTED int http_proxy_check_input(struct http_connection *conn,
                         prot_write(serverout, buf, c);
                 } while (pin->cnt > 0);
 
-                if ((err = prot_error(pin)) != NULL) {
+                if (prot_error(pin) != NULL) {
                     if (pin != clientin) {
                         /* we're pipelining, and the server connection closed */
                         ptrarray_remove(pipes, idx);

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -1233,8 +1233,7 @@ HIDDEN enum sched_deliver_outcome sched_deliver_local(const char *userid,
                     icalcomponent_get_first_property(comp,
                                                      ICAL_ORGANIZER_PROPERTY);
                 if (prop) {
-                    const char *organizer =
-                        organizer = icalproperty_get_organizer(prop);
+                    const char *organizer = icalproperty_get_organizer(prop);
                     if (organizer) {
                         if (!strncasecmp(organizer, "mailto:", 7)) organizer += 7;
                         if (strcasecmp(cdata->organizer, organizer)) reject = 1;

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -829,7 +829,7 @@ EXPORTED mbname_t *mbname_from_path(const char *path)
 
             if (!absolute) {
                 /* Add submailbox(es) */
-                strarray_t *subs = subs = strarray_split(path, "/", 0);
+                strarray_t *subs = strarray_split(path, "/", 0);
                 int i;
 
                 for (i = 0; i < strarray_size(subs); i++) {
@@ -3223,7 +3223,7 @@ EXPORTED modseq_t mboxname_readraclmodseq(const char *mboxname)
         return 0;  // raclmodseq is only defined on user inboxes
 
     mbname_t *mbname = mbname_from_intname(mboxname);
-    char *fname = fname = mboxname_conf_getpath(mbname, "counters");
+    char *fname = mboxname_conf_getpath(mbname, "counters");
 
     int r = mboxname_read_fcounters(fname, &counters);
 

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3539,7 +3539,7 @@ static void feedpeer(char *peer, message_data_t *msg)
     char *user, *pass, *host, *port, *wild, *path, *s;
     int oldform = 0;
     struct wildmat *wmat = NULL, *w;
-    int len, err, n, feed = 1;
+    int len, n, feed = 1;
     struct addrinfo hints, *res, *res0;
     int sock = -1;
     struct protstream *pin, *pout;
@@ -3621,7 +3621,7 @@ static void feedpeer(char *peer, message_data_t *msg)
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = 0;
     if (!port || !*port) port = "119";
-    if ((err = getaddrinfo(host, port, &hints, &res0)) != 0) {
+    if (getaddrinfo(host, port, &hints, &res0) != 0) {
         syslog(LOG_ERR, "getaddrinfo(%s, %s) failed: %m", host, port);
         return;
     }

--- a/imap/smmapd.c
+++ b/imap/smmapd.c
@@ -385,7 +385,7 @@ static int begin_handling(void)
             errstring = "request size doesn't match length";
             r = IMAP_PROTOCOL_ERROR;
         }
-        if (!r && (c = prot_getc(map_in)) != ',') {
+        if (!r && prot_getc(map_in) != ',') {
             errstring = "missing terminator";
             r = IMAP_PROTOCOL_ERROR;
         }
@@ -448,4 +448,3 @@ static int begin_handling(void)
 
     return 0;
 }
-

--- a/lib/imclient.c
+++ b/lib/imclient.c
@@ -624,15 +624,14 @@ static void imclient_input(struct imclient *imclient, char *buf, int len)
     struct imclient_cmdcallback **cmdcb, *cmdcbtemp;
     const char *plainbuf;
     unsigned plainlen;
-    int result;
 
     assert(imclient);
     assert(buf);
 
     if (imclient->saslcompleted == 1) {
         /* decrypt what we have */
-        if ((result = sasl_decode(imclient->saslconn, buf, len,
-                        &plainbuf, &plainlen)) != SASL_OK) {
+        if (sasl_decode(imclient->saslconn, buf, len,
+              &plainbuf, &plainlen) != SASL_OK) {
             (void) shutdown(imclient->fd, 0);
         }
 

--- a/lib/stristr.c
+++ b/lib/stristr.c
@@ -33,7 +33,6 @@ EXPORTED char *stristr(const char *String, const char *Pattern)
       size_t  slen, plen;
 
       for (start = (char *)String,
-           pptr  = (char *)Pattern,
            slen  = strlen(String),
            plen  = strlen(Pattern);
 


### PR DESCRIPTION
or, as the Clang Static Analyzer calls them, “Dead nested assignments”.