### PR TITLE
smtpclient: return NULL instead empty SMTP response text

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -1605,14 +1605,15 @@ static int process_futurerelease(struct caldav_alarm_data *data,
             /* Get the response code and error text.
                We treat anything other than 5xx as a temp failure */
             code = smtpclient_get_resp_code(sm);
+            if (code >= 500) {
+                /* Permanent failure */
+                cancel = 1;
+            }
+            err = NULL;
             if (code) {
                 err = smtpclient_get_resp_text(sm);
-                if (code >= 500) {
-                    /* Permanent failure */
-                    cancel = 1;
-                }
             }
-            else {
+            if (!err) {
                 err = error_message(r);
             }
             syslog(LOG_ERR, "smtpclient_send failed: %s", err);

--- a/imap/smtpclient.c
+++ b/imap/smtpclient.c
@@ -794,7 +794,7 @@ EXPORTED unsigned smtpclient_get_resp_code(smtpclient_t *sm)
 
 EXPORTED const char *smtpclient_get_resp_text(smtpclient_t *sm)
 {
-    return buf_cstring(&sm->resp.text);
+    return buf_cstringnull_ifempty(&sm->resp.text);
 }
 
 /* SMTP backend implementations */

--- a/imap/smtpclient.h
+++ b/imap/smtpclient.h
@@ -180,7 +180,7 @@ extern const char *smtpclient_has_ext(smtpclient_t *sm, const char *name);
 /* Return the code of the last SMTP response */
 extern unsigned smtpclient_get_resp_code(smtpclient_t *sm);
 
-/* Return the text of the last SMTP response */
+/* Return the text of the last SMTP response, or NULL if empty */
 extern const char *smtpclient_get_resp_text(smtpclient_t *sm);
 
 


### PR DESCRIPTION
Callers assume that the string returned by smtpclient_get_resp_text
actually contains a descriptive response, but the returned string
could have been empty.

Requires https://github.com/cyrusimap/cyrus-imapd/pull/4097 for proper testing.