### PR TITLE
3.4: ensure mbentries have uniqueids

### DIFF
--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -184,12 +184,27 @@ sub test_recover_uniqueid_from_header
     $self->assert_matches(qr{mbentry had no uniqueid, setting from header},
                           $syslog);
 
-    # should be the same uniqueid as before
+    # header should have the same uniqueid as before
     $imaptalk = $self->{store}->get_client();
     $res = $imaptalk->getmetadata("INBOX", $entry);
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $self->assert_not_null($res);
     $self->assert_str_equals($uniqueid, $res->{INBOX}{$entry});
+
+    # mbentry should have the same uniqueid as before
+    (undef, $mbentry) = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        ['SHOW', 'user.cassandane']);
+    $dlist = Cyrus::DList->parse_string($mbentry);
+    $hash = $dlist->as_perl();
+    $self->assert_str_equals($uniqueid, $hash->{I});
+
+    # runq entry should be back
+    my ($key, $value) = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        ['SHOW', $runq]);
+    $self->assert_str_equals($runq, $key);
+    $self->assert_str_equals(q{}, $value);
 }
 
 sub test_recover_create_missing_uniqueid
@@ -268,8 +283,25 @@ sub test_recover_create_missing_uniqueid
     $res = $imaptalk->getmetadata("INBOX", $entry);
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $self->assert_not_null($res);
-    $self->assert_not_null($uniqueid, $res->{INBOX}{$entry});
-    $self->assert_str_not_equals($uniqueid, $res->{INBOX}{$entry});
+    $self->assert_not_null($res->{INBOX}{$entry});
+    my $newuniqueid = $res->{INBOX}{$entry};
+    $self->assert_str_not_equals($uniqueid, $newuniqueid);
+
+    # mbentry should have the new uniqueid
+    (undef, $mbentry) = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        ['SHOW', 'user.cassandane']);
+    $dlist = Cyrus::DList->parse_string($mbentry);
+    $hash = $dlist->as_perl();
+    $self->assert_str_equals($newuniqueid, $hash->{I});
+
+    # new runq entry should exist
+    my $newrunq = "\$RUNQ\$$newuniqueid\$user.cassandane";
+    my ($key, $value) = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        ['SHOW', $newrunq]);
+    $self->assert_str_equals($newrunq, $key);
+    $self->assert_str_equals(q{}, $value);
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -41,12 +41,15 @@ package Cassandane::Cyrus::CyrusDB;
 use strict;
 use warnings;
 use Data::Dumper;
+use File::Copy;
+use IO::File;
 
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;
 use Cyrus::DList;
+use Cyrus::HeaderFile;
 
 sub new
 {
@@ -187,6 +190,86 @@ sub test_recover_uniqueid_from_header
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $self->assert_not_null($res);
     $self->assert_str_equals($uniqueid, $res->{INBOX}{$entry});
+}
+
+sub test_recover_create_missing_uniqueid
+    :min_version_3_4 :max_version_3_4
+{
+    my ($self) = @_;
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+
+    # first start will set up cassandane user
+    $self->_start_instances();
+    my $basedir = $self->{instance}->get_basedir();
+    my $mailboxes_db = "$basedir/conf/mailboxes.db";
+    $self->assert(-f $mailboxes_db, "$mailboxes_db not present");
+
+    # find out the uniqueid of the inbox
+    my $imaptalk = $self->{store}->get_client();
+    my $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $uniqueid = $res->{INBOX}{$entry};
+    $self->assert_not_null($uniqueid);
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    # stop service while tinkering
+    $self->{instance}->stop();
+    $self->{instance}->{re_use_dir} = 1;
+
+    # lose that uniqueid from mailboxes.db
+    my $runq = "\$RUNQ\$$uniqueid\$user.cassandane";
+    $self->{instance}->run_dbcommand($mailboxes_db, "twoskip",
+                                     [ 'DELETE', $runq ]);
+    my (undef, $mbentry) = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        ['SHOW', 'user.cassandane']);
+    my $dlist = Cyrus::DList->parse_string($mbentry);
+    my $hash = $dlist->as_perl();
+    $self->assert_str_equals($uniqueid, $hash->{I});
+    $hash->{I} = 'NIL';
+    $dlist = Cyrus::DList->new_perl('', $hash);
+    $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        [ 'SET', 'user.cassandane', $dlist->as_string() ]);
+
+    my %updated = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip", ['SHOW']);
+    xlog "updated mailboxes.db: " . Dumper \%updated;
+
+    # lose it from cyrus.header too
+    my $cyrus_header = $self->{instance}->folder_to_directory('INBOX')
+                       . '/cyrus.header';
+    $self->assert(-f $cyrus_header, "couldn't find cyrus.header file");
+    copy($cyrus_header, "$cyrus_header.OLD");
+    my $hf = Cyrus::HeaderFile->new_file("$cyrus_header.OLD");
+    $self->assert_str_equals($uniqueid, $hf->{header}->{UniqueId});
+    $hf->{header}->{UniqueId} = undef;
+    my $out = IO::File->new($cyrus_header, 'w');
+    $hf->write_header($out, $hf->{header});
+
+    # bring service back up
+    # ctl_cyrusdb -r should find and fix the missing uniqueid
+    $self->{instance}->getsyslog();
+    $self->{instance}->start();
+    my $syslog = join(q{}, $self->{instance}->getsyslog());
+
+    # expect to find it was missing in the header
+    $self->assert_matches(qr{mailbox header had no uniqueid, creating one},
+                          $syslog);
+
+    # expect to find it was missing from mbentry
+    $self->assert_matches(qr{mbentry had no uniqueid, setting from header},
+                          $syslog);
+
+    # should not be the same uniqueid as before
+    $imaptalk = $self->{store}->get_client();
+    $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_not_null($uniqueid, $res->{INBOX}{$entry});
+    $self->assert_str_not_equals($uniqueid, $res->{INBOX}{$entry});
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -40,11 +40,15 @@
 package Cassandane::Cyrus::Reconstruct;
 use strict;
 use warnings;
+use Data::Dumper;
+use File::Copy;
+use File::Slurp;
 
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;
+use Cyrus::HeaderFile;
 use Cyrus::IndexFile;
 use IO::File;
 use JSON;
@@ -313,6 +317,254 @@ sub test_reconstruct_snoozed
         }
     }
     close($fh);
+}
+
+sub test_reconstruct_uniqueid_from_header
+    :min_version_3_4 :max_version_3_4
+{
+    my ($self) = @_;
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+
+    # first start will set up cassandane user
+    my $basedir = $self->{instance}->get_basedir();
+    my $mailboxes_db = "$basedir/conf/mailboxes.db";
+    $self->assert(-f $mailboxes_db, "$mailboxes_db not present");
+
+    # find out the uniqueid of the inbox
+    my $imaptalk = $self->{store}->get_client();
+    my $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $uniqueid = $res->{INBOX}{$entry};
+    $self->assert_not_null($uniqueid);
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    # lose that uniqueid from mailboxes.db
+    my $runq = "\$RUNQ\$$uniqueid\$user.cassandane";
+    $self->{instance}->run_dbcommand($mailboxes_db, "twoskip",
+                                     [ 'DELETE', $runq ]);
+    my (undef, $mbentry) = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        ['SHOW', 'user.cassandane']);
+    my $dlist = Cyrus::DList->parse_string($mbentry);
+    my $hash = $dlist->as_perl();
+    $self->assert_str_equals($uniqueid, $hash->{I});
+    $hash->{I} = 'NIL';
+    $dlist = Cyrus::DList->new_perl('', $hash);
+    $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        [ 'SET', 'user.cassandane', $dlist->as_string() ]);
+
+    my %updated = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip", ['SHOW']);
+    xlog "updated mailboxes.db: " . Dumper \%updated;
+
+    # expect a "needs reconstruct" syslog when user opens mailbox
+    $self->{instance}->getsyslog();
+    $imaptalk = $self->{store}->get_client();
+    $imaptalk->select('INBOX');
+    $imaptalk->logout();
+    undef $imaptalk;
+    my $syslog = join(q{}, $self->{instance}->getsyslog());
+    $self->assert_matches(qr{mbentry has no uniqueid, needs reconstruct},
+                          $syslog);
+
+    # run reconstruct, expect it to put the uniqueid back
+    my $reconstruct_out = "$basedir/reconstruct.out";
+    my $reconstruct_err = "$basedir/reconstruct.err";
+    $self->{instance}->run_command(
+        { cyrus => 1,
+          redirects => {
+            stderr => $reconstruct_err,
+            stdout => $reconstruct_out,
+          },
+        },
+        'reconstruct', 'user.cassandane');
+    $self->assert(-z $reconstruct_err, "reconstruct reported errors");
+    $self->assert_matches(qr{user.cassandane: update uniqueid from header},
+                          scalar read_file($reconstruct_out));
+
+    # no more "needs reconstruct" syslog when user opens mailbox
+    $self->{instance}->getsyslog();
+    $imaptalk = $self->{store}->get_client();
+    $imaptalk->select('INBOX');
+    $imaptalk->logout();
+    undef $imaptalk;
+    $syslog = join(q{}, $self->{instance}->getsyslog());
+    $self->assert_does_not_match(
+        qr{mbentry has no uniqueid, needs reconstruct},
+        $syslog);
+}
+
+sub test_reconstruct_uniqueid_from_mbentry
+    :min_version_3_4 :max_version_3_4
+{
+    my ($self) = @_;
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+
+    # first start will set up cassandane user
+    my $basedir = $self->{instance}->get_basedir();
+    my $mailboxes_db = "$basedir/conf/mailboxes.db";
+    $self->assert(-f $mailboxes_db, "$mailboxes_db not present");
+
+    # find out the uniqueid of the inbox
+    my $imaptalk = $self->{store}->get_client();
+    my $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $uniqueid = $res->{INBOX}{$entry};
+    $self->assert_not_null($uniqueid);
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    # lose uniqueid from cyrus.header
+    # XXX really ought to do this with locking...
+    my $cyrus_header = $self->{instance}->folder_to_directory('INBOX')
+                       . '/cyrus.header';
+    $self->assert(-f $cyrus_header, "couldn't find cyrus.header file");
+    copy($cyrus_header, "$cyrus_header.OLD");
+    my $hf = Cyrus::HeaderFile->new_file("$cyrus_header.OLD");
+    $self->assert_str_equals($uniqueid, $hf->{header}->{UniqueId});
+    $hf->{header}->{UniqueId} = undef;
+    my $out = IO::File->new($cyrus_header, 'w');
+    $hf->write_header($out, $hf->{header});
+
+    # expect mailbox to not be selectable
+    $imaptalk = $self->{store}->get_client();
+    $imaptalk->select('INBOX');
+    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr{Mailbox has an invalid format},
+                          $imaptalk->get_last_error());
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    # will have logged an IOERROR, don't get stuck on it later!
+    $self->{instance}->getsyslog();
+
+    # reconstruct with -M to put the uniqueid back, using the mbentry copy
+    my $reconstruct_out = "$basedir/reconstruct.out";
+    my $reconstruct_err = "$basedir/reconstruct.err";
+    $self->{instance}->run_command(
+        { cyrus => 1,
+          redirects => {
+            stderr => $reconstruct_err,
+            stdout => $reconstruct_out,
+          },
+        },
+        'reconstruct', '-M', 'user.cassandane');
+    $self->assert(-z $reconstruct_err, "reconstruct reported errors");
+    # n.b. reconstruct doesn't change its report for the direction it
+    # occurred in...
+    $self->assert_matches(qr{user.cassandane: update uniqueid from header},
+                          scalar read_file($reconstruct_out));
+
+    # no more "needs reconstruct" syslog when user opens mailbox
+    $self->{instance}->getsyslog();
+    $imaptalk = $self->{store}->get_client();
+    $imaptalk->select('INBOX');
+    $imaptalk->logout();
+    undef $imaptalk;
+    my $syslog = join(q{}, $self->{instance}->getsyslog());
+    $self->assert_does_not_match(
+        qr{mbentry has no uniqueid, needs reconstruct},
+        $syslog);
+
+    # should be able to getmetadata the uniqueid, and it should match the
+    # original one
+    $imaptalk = $self->{store}->get_client();
+    $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_str_equals($uniqueid, $res->{INBOX}{$entry});
+}
+
+sub test_reconstruct_create_missing_uniqueid
+    :min_version_3_4 :max_version_3_4
+{
+    my ($self) = @_;
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+
+    # first start will set up cassandane user
+    my $basedir = $self->{instance}->get_basedir();
+    my $mailboxes_db = "$basedir/conf/mailboxes.db";
+    $self->assert(-f $mailboxes_db, "$mailboxes_db not present");
+
+    # find out the uniqueid of the inbox
+    my $imaptalk = $self->{store}->get_client();
+    my $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $uniqueid = $res->{INBOX}{$entry};
+    $self->assert_not_null($uniqueid);
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    # lose uniqueid from cyrus.header
+    # XXX really ought to do this with locking...
+    my $cyrus_header = $self->{instance}->folder_to_directory('INBOX')
+                       . '/cyrus.header';
+    $self->assert(-f $cyrus_header, "couldn't find cyrus.header file");
+    copy($cyrus_header, "$cyrus_header.OLD");
+    my $hf = Cyrus::HeaderFile->new_file("$cyrus_header.OLD");
+    $self->assert_str_equals($uniqueid, $hf->{header}->{UniqueId});
+    $hf->{header}->{UniqueId} = undef;
+    my $out = IO::File->new($cyrus_header, 'w');
+    $hf->write_header($out, $hf->{header});
+
+    # expect mailbox to not be selectable
+    $imaptalk = $self->{store}->get_client();
+    $imaptalk->select('INBOX');
+    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr{Mailbox has an invalid format},
+                          $imaptalk->get_last_error());
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    # will have logged an IOERROR, don't get stuck on it later!
+    $self->{instance}->getsyslog();
+
+    # reconstruct should ignore the mbentry and create a new uniqueid
+    my $reconstruct_out = "$basedir/reconstruct.out";
+    my $reconstruct_err = "$basedir/reconstruct.err";
+    $self->{instance}->run_command(
+        { cyrus => 1,
+          redirects => {
+            stderr => $reconstruct_err,
+            stdout => $reconstruct_out,
+          },
+        },
+        'reconstruct', 'user.cassandane');
+    $self->assert(-z $reconstruct_err, "reconstruct reported errors");
+    # n.b. reconstruct doesn't change its report for the direction it
+    # occurred in...
+    $self->assert_matches(qr{user.cassandane: update uniqueid from header},
+                          scalar read_file($reconstruct_out));
+
+    # no more "needs reconstruct" syslog when user opens mailbox
+    $self->{instance}->getsyslog();
+    $imaptalk = $self->{store}->get_client();
+    $imaptalk->select('INBOX');
+    $imaptalk->logout();
+    undef $imaptalk;
+    my $syslog = join(q{}, $self->{instance}->getsyslog());
+    $self->assert_does_not_match(
+        qr{mbentry has no uniqueid, needs reconstruct},
+        $syslog);
+
+    # should be able to getmetadata the uniqueid, and it should be different
+    $imaptalk = $self->{store}->get_client();
+    $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $newuniqueid = $res->{INBOX}{$entry};
+    $self->assert_str_not_equals($uniqueid, $newuniqueid);
+
+    # XXX look for the new uniqueid in mbentry!
+    my %updated = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip", ['SHOW']);
+    $self->assert_not_null($updated{'user.cassandane'});
+    $self->assert_matches(qr{\b$newuniqueid\b}, $updated{'user.cassandane'});
 }
 
 1;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1491,6 +1491,15 @@ sub send_sighup
     return 1;
 }
 
+#
+# n.b. If you are stopping the instance intending to restart it again later,
+# you must set:
+#     $instance->{'re_use_dir'} => 1
+# before restarting, otherwise it will wipe and re-initialise its basedir
+# during startup, probably ruining whatever you were trying to do.  It
+# will still use the same directory name though, so it won't be obvious
+# from the logs that this is happening!
+#
 sub stop
 {
     my ($self) = @_;

--- a/cassandane/Cyrus/HeaderFile.pm
+++ b/cassandane/Cyrus/HeaderFile.pm
@@ -77,14 +77,19 @@ sub make_header {
   my $Self = shift;
   my $ds = shift;
 
+  # NOTE: no tab separator if no uniqueid!
+  my $qr_uuid = $ds->{QuotaRoot};
+  $qr_uuid .= "\t$ds->{UniqueId}" if $ds->{UniqueId};
+
   # NOTE: acl and flags should have '' as the last element!
   my $flags = join(" ", @{$ds->{Flags}}, '');
   my $acl = join("\t", @{$ds->{ACL}}, '');
+
   my $buf = <<EOF;
 $HL1
 $HL2
 $HL3
-$ds->{QuotaRoot}	$ds->{UniqueId}
+$qr_uuid
 $flags
 $acl
 EOF

--- a/cassandane/Cyrus/HeaderFile.pm
+++ b/cassandane/Cyrus/HeaderFile.pm
@@ -1,0 +1,151 @@
+#!/usr/bin/perl -c
+
+# Package to handle Cyrus Header files
+
+package Cyrus::HeaderFile;
+
+use strict;
+use warnings;
+
+use IO::File;
+use IO::File::fcntl;
+use IO::Handle;
+use File::Temp;
+use Data::Dumper;
+use Cyrus::DList;
+
+our $HL1 = qq{\241\002\213\015Cyrus mailbox header};
+our $HL2 = qq{"The best thing about this system was that it had lots of goals."};
+our $HL3 = qq{\t--Jim Morris on Andrew};
+
+# PUBLIC API
+
+sub new {
+  my $class = shift;
+  my $handle = shift;
+
+  # read header
+  local $/ = undef;
+  my $body = <$handle>;
+
+  my $Self = bless {}, ref($class) || $class;
+  $Self->{handle} = $handle; # keep for locking
+  $Self->{rawheader} = $body;
+  $Self->{header} = $Self->parse_header($body);
+
+  return $Self;
+}
+
+sub new_file {
+  my $class = shift;
+  my $file = shift;
+  my $lockopts = shift; 
+
+  my $fh;
+  if ($lockopts) {
+    $lockopts = ['lock_ex'] unless ref($lockopts) eq 'ARRAY';
+    $fh = IO::File::fcntl->new($file, '+<', @$lockopts)
+          || die "Can't open $file for locked read: $!";
+  } else {
+    $fh = IO::File->new("< $file")
+          || die "Can't open $file for read: $!";
+  }
+
+  return $class->new($fh);
+}
+
+sub header {
+  my $Self = shift;
+  my $Field = shift;
+
+  if ($Field) {
+    return $Self->{header}{$Field};
+  }
+
+  return $Self->{header};
+}
+
+sub write_header {
+  my $Self = shift;
+  my $fh = shift;
+  my $header = shift;
+
+  $fh->print($Self->make_header($header));
+}
+
+sub make_header {
+  my $Self = shift;
+  my $ds = shift;
+
+  # NOTE: acl and flags should have '' as the last element!
+  my $flags = join(" ", @{$ds->{Flags}}, '');
+  my $acl = join("\t", @{$ds->{ACL}}, '');
+  my $buf = <<EOF;
+$HL1
+$HL2
+$HL3
+$ds->{QuotaRoot}	$ds->{UniqueId}
+$flags
+$acl
+EOF
+  return $buf;
+}
+
+sub parse_header {
+  my $Self = shift;
+  my $body = shift;
+
+  my @lines = split /\n/, $body;
+
+  die "Not a mailbox header file" unless $lines[0] eq $HL1;
+  die "Not a mailbox header file" unless $lines[1] eq $HL2;
+  die "Not a mailbox header file" unless $lines[2] eq $HL3;
+  if ($lines[3] =~ m/^%/) {
+    # new style!
+    my $dlist = Cyrus::DList->parse_string($lines[3], 0);
+    my %res;
+    my @flags;
+    my @acls;
+    foreach my $item (@{$dlist->{data}}) {
+      if ($item->{key} eq 'A') {
+        foreach my $sub (@{$item->{data}}) {
+          push @acls, $sub->{data};
+        }
+      }
+      if ($item->{key} eq 'T') {
+        $res{MBType} = $item->{data};
+      }
+      if ($item->{key} eq 'N') {
+        $res{DBName} = $item->{data};
+      }
+      if ($item->{key} eq 'I') {
+        $res{UniqueId} = $item->{data};
+      }
+      if ($item->{key} eq 'Q') {
+        $res{QuotaRoot} = $item->{data};
+      }
+      if ($item->{key} eq 'U') {
+        foreach my $sub (@{$item->{data}}) {
+          push @flags, $sub->{data};
+        }
+      }
+    }
+    $res{ACL} = \@acls;
+    $res{Flags} = \@flags;
+    return \%res;
+  }
+
+  # legacy format
+  my ($quotaroot, $uniqueid) = split /\t/, $lines[3];
+  my (@flags) = split / /, $lines[4];
+  my (@acl) = split /\t/, $lines[5];
+
+  return {
+    QuotaRoot => $quotaroot,
+    UniqueId => $uniqueid,
+    Flags => \@flags,
+    ACL => \@acl,
+  };
+}
+
+1;

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -129,7 +129,7 @@ static void usage(void)
 static int fixmbox(const mbentry_t *mbentry,
                    void *rock __attribute__((unused)))
 {
-    int r;
+    int r, r2;
 
     /* if MBTYPE_RESERVED, unset it & call mboxlist_delete */
     if (mbentry->mbtype & MBTYPE_RESERVE) {
@@ -173,12 +173,69 @@ static int fixmbox(const mbentry_t *mbentry,
                mbentry->name, cyrusdb_strerror(r));
     }
 
+    /* make sure every mbentry has a uniqueid!  */
+    if (!mbentry->uniqueid) {
+        struct mailbox *mailbox = NULL;
+        struct mboxlock *namespacelock = NULL;
+        mbentry_t *copy = NULL;
+
+        r = mailbox_open_iwl(mbentry->name, &mailbox);
+        if (r) {
+            /* XXX what does it mean if there's an mbentry, but the mailbox
+             * XXX was not openable?
+             */
+            syslog(LOG_DEBUG, "%s: mailbox_open_iwl %s returned %s",
+                              __func__, mbentry->name, error_message(r));
+            goto skip_uniqueid;
+        }
+
+        if (!mailbox->uniqueid) {
+            /* yikes, no uniqueid in header either! */
+            mailbox_make_uniqueid(mailbox);
+            xsyslog(LOG_INFO, "mailbox header had no uniqueid, creating one",
+                              "mboxname=<%s> newuniqueid=<%s>",
+                              mbentry->name, mailbox->uniqueid);
+        }
+
+        copy = mboxlist_entry_copy(mbentry);
+        copy->uniqueid = xstrdup(mailbox->uniqueid);
+        xsyslog(LOG_INFO, "mbentry had no uniqueid, setting from header",
+                          "mboxname=<%s> newuniqueid=<%s>",
+                          copy->name, copy->uniqueid);
+
+        namespacelock = mboxname_usernamespacelock(copy->name);
+        r = mboxlist_update(copy, /*localonly*/1);
+        mboxname_release(&namespacelock);
+        if (r) {
+            xsyslog(LOG_ERR, "failed to update mboxlist",
+                             "mboxname=<%s> error=<%s>",
+                             mbentry->name, error_message(r));
+            r2 = mailbox_abort(mailbox);
+            if (r2) {
+                xsyslog(LOG_ERR, "DBERROR: error aborting transaction",
+                                 "error=<%s>", cyrusdb_strerror(r2));
+            }
+        }
+        else {
+            r2 = mailbox_commit(mailbox);
+            if (r2) {
+                xsyslog(LOG_ERR, "DBERROR: error committing transaction",
+                                 "error=<%s>", cyrusdb_strerror(r2));
+            }
+        }
+        mailbox_close(&mailbox);
+        mboxlist_entry_free(&copy);
+
+skip_uniqueid:
+        ;   /* hush "label at end of compound statement" warning */
+    }
+
     return 0;
 }
 
 static void process_mboxlist(void)
 {
-    /* build a list of mailboxes - we're using internal names here */
+    /* run fixmbox across all mboxlist entries */
     mboxlist_allmbox(NULL, fixmbox, NULL, MBOXTREE_INTERMEDIATES);
 
     /* enable or disable RACLs per config */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1042,6 +1042,11 @@ static int mailbox_open_advanced(const char *name,
         goto done;
     }
 
+    if (!mbentry->uniqueid) {
+        xsyslog(LOG_NOTICE, "mbentry has no uniqueid, needs reconstruct",
+                            "mboxname=<%s>", mailbox->name);
+    }
+
     mailbox->part = xstrdup(mbentry->partition);
 
     /* Note that the header does have the ACL information, but it is only
@@ -1356,7 +1361,12 @@ static int mailbox_read_header(struct mailbox *mailbox, char **aclptr)
         if (!tab || tab > eol) tab = eol;
         mailbox->uniqueid = xstrndup(p, tab - p);
     }
-    /* else, uniqueid needs to be generated when we know the uidvalidity */
+    else {
+        /* ancient cyrus.header file without a uniqueid field! */
+        xsyslog(LOG_NOTICE, "mailbox header has no uniqueid, needs reconstruct",
+                            "mboxname=<%s>",
+                            mailbox->name);
+    }
 
     /* Read names of user flags */
     p = eol + 1;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6362,6 +6362,9 @@ static int mailbox_reconstruct_uniqueid(struct mailbox *mailbox, int flags)
                 mailbox_set_uniqueid(mailbox, mbentry->uniqueid);
             }
             else {
+                if (!mailbox->uniqueid) {
+                    mailbox_make_uniqueid(mailbox);
+                }
                 free(mbentry->uniqueid);
                 mbentry->uniqueid = xstrdup(mailbox->uniqueid);
                 r = mboxlist_update(mbentry, 0);


### PR DESCRIPTION
This improves the safety of upgrades from 3.4 to 3.6+, by making 3.4 fastidious about keeping uniqueid present and up to date (even though 3.4 itself doesn't strictly need it, unlike 3.6+).

Reviewers: please pay close attention to the locking and ordering of the mbentry/mailbox updates.  I think I got it correct, but I'm not totally confident.

* `ctl_cyrusdb -r` will now ensure every mbentry has a uniqueid field at startup.  It will use the one from the cyrus.header if the cyrus.header has one, otherwise it will generate a new uniqueid and save it to both
* `reconstruct` will do the same thing.  This is important for handling the case where an old uniqueid-less mailbox has been restored from backup (though it would also be taken care of by `ctl_cyrusdb -r` at next restart, this can avoid needing a restart)
* `reconstruct -M` ("prefer mailboxes.db") will write the mbentry's uniqueid down to the cyrus.header, if it was missing.  (If both are missing, then same as before: generate a new one, write it to both locations.)
* We now log (LOG_NOTICE) a message any time we open a mailbox and discover that it is missing a uniqueid from either location
* Cassandane tests exercising all cases
* Imported Cyrus::HeaderFile from Fastmail-internal repository, for use by the Cassandane tests

This is complementary to the fixes in #4096 and is part of the solution to #4035 

Once approved and merged, I plan to backport these changes to 3.2, and make new releases from both branches.

I also plan to forward port whatever's possible to forward port for 3.6 and master, once this and #4096 have both independently landed.