### PR TITLE
JMAP Mail Submission: sanitize recent change to smtpclient_get_resp_text

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -1609,7 +1609,6 @@ static int process_futurerelease(struct caldav_alarm_data *data,
                 /* Permanent failure */
                 cancel = 1;
             }
-            err = NULL;
             if (code) {
                 err = smtpclient_get_resp_text(sm);
             }

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -854,32 +854,35 @@ static void _emailsubmission_create(jmap_req_t *req,
             char *err = NULL;
             const char *p;
 
-            if (smtpclient_has_ext(*sm, "ENHANCEDSTATUSCODES")) {
-                p = strchr(desc, ' ');
-                if (p) {
-                    desc = p+1;
-                    while (*desc == ' ') desc++;  /* trim leading whitespace */
+            if (desc) {
+                if (smtpclient_has_ext(*sm, "ENHANCEDSTATUSCODES")) {
+                    p = strchr(desc, ' ');
+                    if (p) {
+                        desc = p+1;
+                        while (*desc == ' ') desc++;  /* trim leading whitespace */
+                    }
                 }
-            }
-            if ((p = strstr(desc, "[jmapError:"))) {
-                p += 11;
-                const char *q = strchr(p, ']');
-                if (q) {
-                    err = xstrndup(p, q - p);
-                    desc = q+1;
-                    while (*desc == ' ') desc++;  /* trim leading whitespace */
+                if ((p = strstr(desc, "[jmapError:"))) {
+                    p += 11;
+                    const char *q = strchr(p, ']');
+                    if (q) {
+                        err = xstrndup(p, q - p);
+                        desc = q+1;
+                        while (*desc == ' ') desc++;  /* trim leading whitespace */
+                    }
                 }
             }
             if (!err) err = xstrdup("forbiddenToSend");
             *set_err = json_pack("{s:s s:s}",
-                                 "type", err, "description", desc);
+                                 "type", err,
+                                 "description", desc ? desc : error_message(r));
             free(err);
             break;
         }
 
         default:
             *set_err = json_pack("{s:s s:s}", "type", "forbiddenToSend",
-                                 "description", desc);
+                                 "description", desc ? desc : error_message(r));
             break;
         }
     }


### PR DESCRIPTION
Recent change f5258901cb66e4b0084da9035309630ff26ca17d introduced a NULL-pointer read which now is fixed. Also, both @ksmurchison and @dilyanpalauzov noticed an unnecessary assignment during code review, so let's just remove it.