### PR TITLE
JMAP Email/query must ignore $seen keyword for JMAP blobs

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -23976,4 +23976,80 @@ sub test_email_query_contactgroup_filter_no_dnf
     $self->assert_str_equals('msg-nocontact', $res->[1][1]{list}[0]{subject});
 }
 
+sub test_email_query_seen_ignore_jmapupload_folder
+    :min_version_3_7 :needs_component_jmap :JMAPExtensions :MagicPlus :AllowDeleted
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog 'Upload some blob to create upload folder';
+    $jmap->Upload('test', 'application/octets') or die;
+
+    xlog 'Upload MIME message';
+    my $mime = <<'EOF';
+From: 'Some Example Sender' <example@example.com>
+To: baseball@vitaead.com
+Subject: test email
+Date: Wed, 7 Dec 2016 00:21:50 -0500
+MIME-Version: 1.0
+Content-Type: text/plain; charset='UTF-8'
+Content-Transfer-Encoding: quoted-printable
+
+This is a test email.
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    my $blobId = $jmap->Upload($mime, 'message/rfc822')->{blobId};
+    $self->assert_not_null($blobId);
+
+    xlog "Undelete blobs in #jmap folder";
+    $self->{instance}->run_command({ cyrus => 1 },
+        'unexpunge', '-a', '-d', 'user.cassandane.#jmap');
+
+    xlog 'Import message';
+    my $res = $jmap->CallMethods([
+        ['Email/import', {
+            emails => {
+                email1 => {
+                    blobId => $blobId,
+                    mailboxIds => {
+                        '$inbox' => JSON::true,
+                    },
+                    keywords => {
+                        '$seen' => JSON::true,
+                    },
+                }
+            },
+        }, 'R1'],
+    ]);
+    my $emailId = $res->[0][1]{created}{email1}{id};
+    $self->assert_not_null($emailId);
+
+    xlog 'Query email by $seen';
+    $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                hasKeyword => '$seen',
+            },
+        }, 'R1'],
+        ['Email/query', {
+            filter => {
+                allInThreadHaveKeyword => '$seen',
+            },
+        }, 'R2'],
+        ['Email/query', {
+            filter => {
+                someInThreadHaveKeyword => '$seen',
+            },
+        }, 'R2'],
+        ['Email/query', {
+            filter => {
+                noneInThreadHaveKeyword => '$seen',
+            },
+        }, 'R4'],
+    ]);
+    $self->assert_deep_equals([$emailId], $res->[0][1]{ids});
+    $self->assert_deep_equals([$emailId], $res->[1][1]{ids});
+    $self->assert_deep_equals([$emailId], $res->[2][1]{ids});
+    $self->assert_deep_equals([], $res->[3][1]{ids});
+}
 1;

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -404,7 +404,8 @@ static void test_folder_rename(void)
     CU_ASSERT_PTR_NOT_NULL(conv);
 
     int f1 = conversation_folder_number(state, FOLDER1, 1);
-    struct emailcounts ecounts1 = { f1, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 }, BV_INITIALIZER };
+    struct emailcounts ecounts1 = { f1, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
+                                    BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
 
     conversation_update(state, conv,
                         &ecounts1,
@@ -413,7 +414,8 @@ static void test_folder_rename(void)
                         /*createdmodseq*/1);
 
     int f2 = conversation_folder_number(state, FOLDER2, 1);
-    struct emailcounts ecounts2 = { f2, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 }, BV_INITIALIZER };
+    struct emailcounts ecounts2 = { f2, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
+                                    BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
 
     conversation_update(state, conv,
                         &ecounts2,
@@ -517,7 +519,8 @@ static void test_folders(void)
     counts[1] = 0;
 
     int f1 = conversation_folder_number(state, FOLDER1, 1);
-    struct emailcounts ecounts1 = { f1, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 }, BV_INITIALIZER };
+    struct emailcounts ecounts1 = { f1, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
+                                    BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
     conversation_update(state, conv,
                         &ecounts1,
                         /*size*/0, counts,
@@ -584,7 +587,8 @@ static void test_folders(void)
     counts[1] = 2;
     /* some more updates should succeed */
     int f2 = conversation_folder_number(state, FOLDER2, 1);
-    struct emailcounts ecounts2 = { f2, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 1, 1, 1, 1 }, BV_INITIALIZER };
+    struct emailcounts ecounts2 = { f2, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 1, 1, 1, 1 },
+                                    BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
     conversation_update(state, conv,
                         &ecounts2,
                         /*size*/0, counts,
@@ -619,7 +623,8 @@ static void test_folders(void)
 
     counts[1] = 5;
     int f3 = conversation_folder_number(state, FOLDER3, 1);
-    struct emailcounts ecounts3 = { f3, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 0, 0, 1, 0, 0 }, BV_INITIALIZER };
+    struct emailcounts ecounts3 = { f3, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 0, 0, 1, 0, 0 },
+                                    BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
     conversation_update(state, conv,
                         &ecounts3,
                         /*size*/0, counts,
@@ -738,7 +743,8 @@ static void test_folders(void)
     /* decrementing a folder down to zero */
     counts[0] = -1;
     counts[1] = 0;
-    struct emailcounts ecountsneg1 = { f1, 0, -1, { 1, 1, 0, 1, 1, 0 }, { 0, 0, 0, 0, 0, 0 }, BV_INITIALIZER };
+    struct emailcounts ecountsneg1 = { f1, 0, -1, { 1, 1, 0, 1, 1, 0 }, { 0, 0, 0, 0, 0, 0 },
+                                       BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
     conversation_update(state, conv,
                         &ecountsneg1,
                         /*size*/0, counts,
@@ -853,7 +859,8 @@ static void test_folder_ordering(void)
 
     conv = conversation_new();
 
-    struct emailcounts ecounts1 = { f1, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 }, BV_INITIALIZER };
+    struct emailcounts ecounts1 = { f1, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
+                                       BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
     conversation_update(state, conv,
                         &ecounts1,
                         /*size*/0, counts,
@@ -861,7 +868,8 @@ static void test_folder_ordering(void)
                         /*createdmodseq*/0);
 
     /* add folders out of order */
-    struct emailcounts ecounts3 = { f3, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 }, BV_INITIALIZER };
+    struct emailcounts ecounts3 = { f3, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
+                                       BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
     conversation_update(state, conv,
                         &ecounts3,
                         /*size*/0, counts,
@@ -877,7 +885,8 @@ static void test_folder_ordering(void)
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_PTR_NOT_NULL(conv);
 
-    struct emailcounts ecounts2 = { f2, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 }, BV_INITIALIZER };
+    struct emailcounts ecounts2 = { f2, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
+                                       BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
     conversation_update(state, conv,
                         &ecounts2,
                         /*size*/0, counts,
@@ -1199,7 +1208,8 @@ static void test_dump(void)
         CU_ASSERT_PTR_NOT_NULL(conv);
         for (j = 0 ; j < mboxnames.count ; j++) {
             int f = conversation_folder_number(state, mboxnames.data[j], 1);
-            struct emailcounts ecounts = { f, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 }, BV_INITIALIZER };
+            struct emailcounts ecounts = { f, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
+                                            BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER };
             conversation_update(state, conv,
                                 &ecounts,
                                 /*size*/0, /*counts*/NULL,

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -209,9 +209,12 @@ struct emailcounts {
     struct emailcountitems pre;
     struct emailcountitems post;
     bitvector_t exists_foldernums;
+    bitvector_t mbtype_known;
+    bitvector_t mbtype_mail;
 };
 
-#define EMAILCOUNTS_INIT { -1, -1, 0, EMAILCOUNTITEMS_INIT, EMAILCOUNTITEMS_INIT, BV_INITIALIZER }
+#define EMAILCOUNTS_INIT { -1, -1, 0, EMAILCOUNTITEMS_INIT, EMAILCOUNTITEMS_INIT, \
+                           BV_INITIALIZER, BV_INITIALIZER, BV_INITIALIZER }
 
 extern void emailcounts_fini(struct emailcounts *ecounts);
 


### PR DESCRIPTION
A MIME message uploaded to the `#jmap` and then imported using Email/import still contributed to the $seen counts of the imported email. This could lead to false results in Email queries that made use of the `hasKeyword: $seen` or `xxxInThreadHaveKeyword: $seen` filter criteria. 