### PR TITLE
OpenSSL 3.0 fixes

### DIFF
--- a/backup/lcb_append.c
+++ b/backup/lcb_append.c
@@ -111,7 +111,7 @@ HIDDEN int backup_real_append_start(struct backup *backup,
     if (index_only) backup->append_state->mode |= BACKUP_APPEND_INDEXONLY;
 
     backup->append_state->wrote = 0;
-    SHA1_Init(&backup->append_state->sha_ctx);
+    SHA1Init(&backup->append_state->sha_ctx);
 
     char header[80];
     snprintf(header, sizeof(header), "# cyrus backup: chunk start\r\n");
@@ -134,7 +134,7 @@ HIDDEN int backup_real_append_start(struct backup *backup,
         if (r) goto error;
     }
 
-    SHA1_Update(&backup->append_state->sha_ctx, header, strlen(header));
+    SHA1Update(&backup->append_state->sha_ctx, header, strlen(header));
     backup->append_state->wrote += strlen(header);
 
     struct sqldb_bindval bval[] = {
@@ -200,7 +200,7 @@ EXPORTED int backup_append(struct backup *backup,
     iter = dlist_print_iter_new(dlist, 1);
     do {
         /* track the sha1sum */
-        SHA1_Update(&backup->append_state->sha_ctx, buf_cstring(&buf), buf_len(&buf));
+        SHA1Update(&backup->append_state->sha_ctx, buf_cstring(&buf), buf_len(&buf));
 
         /* if we're not in index-only mode, write the data out */
         if (!index_only) {
@@ -218,7 +218,7 @@ EXPORTED int backup_append(struct backup *backup,
 
     /* finally, end with "\r\n" */
     buf_setcstr(&buf, "\r\n");
-    SHA1_Update(&backup->append_state->sha_ctx, buf_cstring(&buf), buf_len(&buf));
+    SHA1Update(&backup->append_state->sha_ctx, buf_cstring(&buf), buf_len(&buf));
     if (!index_only) {
         r = retry_gzwrite(backup->append_state->gzfile,
                           buf_cstring(&buf), buf_len(&buf),
@@ -268,7 +268,7 @@ HIDDEN int backup_real_append_end(struct backup *backup, time_t ts)
 
     unsigned char sha1_raw[SHA1_DIGEST_LENGTH];
     char data_sha1[2 * SHA1_DIGEST_LENGTH + 1];
-    SHA1_Final(sha1_raw, &backup->append_state->sha_ctx);
+    SHA1Final(sha1_raw, &backup->append_state->sha_ctx);
     r = bin_to_hex(sha1_raw, SHA1_DIGEST_LENGTH, data_sha1, BH_LOWER);
     assert(r == 2 * SHA1_DIGEST_LENGTH);
 

--- a/backup/lcb_internal.h
+++ b/backup/lcb_internal.h
@@ -63,7 +63,7 @@ struct backup_append_state {
     gzFile gzfile;
     int chunk_id;
     size_t wrote;
-    SHA_CTX sha_ctx;
+    SHA1_CTX sha_ctx;
 };
 
 struct backup {

--- a/backup/lcb_verify.c
+++ b/backup/lcb_verify.c
@@ -143,13 +143,13 @@ static int verify_chunk_checksums(struct backup *backup, struct backup_chunk *ch
         fprintf(out, "  checking data length\n");
     char buf[8192]; /* FIXME whatever */
     size_t len = 0;
-    SHA_CTX sha_ctx;
-    SHA1_Init(&sha_ctx);
+    SHA1_CTX sha_ctx;
+    SHA1Init(&sha_ctx);
     gzuc_member_start_from(gzuc, chunk->offset);
     while (!gzuc_member_eof(gzuc)) {
         ssize_t n = gzuc_read(gzuc, buf, sizeof(buf));
         if (n >= 0) {
-            SHA1_Update(&sha_ctx, buf, n);
+            SHA1Update(&sha_ctx, buf, n);
             len += n;
         }
     }
@@ -172,7 +172,7 @@ static int verify_chunk_checksums(struct backup *backup, struct backup_chunk *ch
         fprintf(out, "  checking data checksum...\n");
     unsigned char sha1_raw[SHA1_DIGEST_LENGTH];
     char data_sha1[2 * SHA1_DIGEST_LENGTH + 1];
-    SHA1_Final(sha1_raw, &sha_ctx);
+    SHA1Final(sha1_raw, &sha_ctx);
     r = bin_to_hex(sha1_raw, SHA1_DIGEST_LENGTH, data_sha1, BH_LOWER);
     assert(r == 2 * SHA1_DIGEST_LENGTH);
     r = strncmp(chunk->data_sha1, data_sha1, sizeof(data_sha1));

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -956,16 +956,20 @@ EXPORTED int     tls_init_serverengine(const char *ident,
     SSL_CTX_set_tmp_dh(s_ctx, dh_params);
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x1000103fL) && (OPENSSL_VERSION_NUMBER < 0x30000000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x1000103fL)
     const char *ec = config_getstring(IMAPOPT_TLS_ECCURVE);
     int openssl_nid = OBJ_sn2nid(ec);
     if (openssl_nid != 0) {
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+        SSL_CTX_set1_curves(s_ctx, &openssl_nid, 1);
+#else
         EC_KEY *ecdh;
         ecdh = EC_KEY_new_by_curve_name(openssl_nid);
         if (ecdh != NULL) {
             SSL_CTX_set_tmp_ecdh(s_ctx, ecdh);
             EC_KEY_free(ecdh);
         }
+#endif
     }
 #endif
 

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -149,7 +149,7 @@ static int tls_serverengine = 0; /* server engine initialized? */
 static int tls_clientengine = 0; /* client engine initialized? */
 static int do_dump = 0;         /* actively dumping protocol? */
 
-#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL) && (OPENSSL_VERSION_NUMBER < 0x30000000L)
 static DH *dh_params = NULL;
 #endif
 
@@ -240,7 +240,7 @@ static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 }
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL) && (OPENSSL_VERSION_NUMBER < 0x30000000L)
 /* Logic copied from OpenSSL apps/s_server.c: give the TLS context
  * DH params to work with DHE-* cipher suites. Hardcoded fallback
  * in case no DH params in server_key or server_cert.
@@ -739,7 +739,6 @@ EXPORTED int     tls_init_serverengine(const char *ident,
     const char   *client_ca_file;
     const char   *server_ca_file;
     const char   *server_cert_file;
-    const char   *server_dhparam_file;
     const char   *server_key_file;
     const char   *crl_file_path;
     enum enum_value tls_client_certs;
@@ -883,7 +882,6 @@ EXPORTED int     tls_init_serverengine(const char *ident,
 
     server_ca_file = config_getstring(IMAPOPT_TLS_SERVER_CA_FILE);
     server_cert_file = config_getstring(IMAPOPT_TLS_SERVER_CERT);
-    server_dhparam_file = config_getstring(IMAPOPT_TLS_SERVER_DHPARAM);
     server_key_file = config_getstring(IMAPOPT_TLS_SERVER_KEY);
 
     if (config_debug) {
@@ -949,13 +947,16 @@ EXPORTED int     tls_init_serverengine(const char *ident,
     SSL_CTX_set_tmp_rsa_callback(s_ctx, tmp_rsa_cb);
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+    SSL_CTX_set_dh_auto(s_ctx, 1);
+#elif (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
     /* Load DH params for DHE-* key exchanges */
+    const char *server_dhparam_file = config_getstring(IMAPOPT_TLS_SERVER_DHPARAM);
     dh_params = load_dh_param(server_dhparam_file, server_key_file, server_cert_file);
     SSL_CTX_set_tmp_dh(s_ctx, dh_params);
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x1000103fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x1000103fL) && (OPENSSL_VERSION_NUMBER < 0x30000000L)
     const char *ec = config_getstring(IMAPOPT_TLS_ECCURVE);
     int openssl_nid = OBJ_sn2nid(ec);
     if (openssl_nid != 0) {
@@ -1086,20 +1087,22 @@ EXPORTED int     tls_init_serverengine(const char *ident,
 
 /* taken from OpenSSL apps/s_cb.c */
 
-static long bio_dump_cb(BIO * bio, int cmd, const char *argp, int argi,
-                        long argl __attribute__((unused)), long ret)
+static long bio_dump_cb(BIO * bio, int cmd, const char *argp,
+                        size_t len __attribute__((unused)), int argi,
+                        long argl __attribute__((unused)), int ret,
+                        size_t *processed __attribute__((unused)))
 {
     if (!do_dump)
         return (ret);
 
     if (cmd == (BIO_CB_READ | BIO_CB_RETURN)) {
-        printf("read from %08lX [%08lX] (%d bytes => %ld (0x%lX))",
+        printf("read from %08lX [%08lX] (%d bytes => %d (0x%X))",
                (unsigned long)bio, (unsigned long)argp,
                argi, ret, ret);
         tls_dump(argp, (int) ret);
         return (ret);
     } else if (cmd == (BIO_CB_WRITE | BIO_CB_RETURN)) {
-        printf("write to %08lX [%08lX] (%d bytes => %ld (0x%lX))",
+        printf("write to %08lX [%08lX] (%d bytes => %d (0x%X))",
                (unsigned long) bio, (unsigned long)argp,
                argi, ret, ret);
         tls_dump(argp, (int) ret);
@@ -1171,7 +1174,7 @@ EXPORTED int tls_start_servertls(int readfd, int writefd, int timeout,
      * created for us, so we can use it for debugging purposes.
      */
     if (var_imapd_tls_loglevel >= 3)
-        BIO_set_callback(SSL_get_rbio(tls_conn), bio_dump_cb);
+        BIO_set_callback_ex(SSL_get_rbio(tls_conn), bio_dump_cb);
 
     /* Dump the negotiation for loglevels 3 and 4*/
     if (var_imapd_tls_loglevel >= 3)
@@ -1402,7 +1405,7 @@ EXPORTED int tls_shutdown_serverengine(void)
             sess_dbopen = 0;
         }
 
-#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL) && (OPENSSL_VERSION_NUMBER < 0x30000000L)
         if (dh_params) DH_free(dh_params);
 #endif
     }
@@ -1658,7 +1661,7 @@ HIDDEN int tls_start_clienttls(int readfd, int writefd,
      * created for us, so we can use it for debugging purposes.
      */
     if (var_proxy_tls_loglevel >= 3)
-        BIO_set_callback(SSL_get_rbio(tls_conn), bio_dump_cb);
+        BIO_set_callback_ex(SSL_get_rbio(tls_conn), bio_dump_cb);
 
     /* Dump the negotiation for loglevels 3 and 4*/
     if (var_proxy_tls_loglevel >= 3)

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -630,20 +630,22 @@ static int tls_dump(const char *s, int len)
 
 /* taken from OpenSSL apps/s_cb.c */
 
-static long bio_dump_cb(BIO * bio, int cmd, const char *argp, int argi,
-                        long argl __attribute__((unused)), long ret)
+static long bio_dump_cb(BIO * bio, int cmd, const char *argp,
+                        size_t len __attribute__((unused)), int argi,
+                        long argl __attribute__((unused)), int ret,
+                        size_t *processed __attribute__((unused)))
 {
     if (!do_dump)
         return (ret);
 
     if (cmd == (BIO_CB_READ | BIO_CB_RETURN)) {
-        printf("read from %08lX [%08lX] (%d bytes => %ld (0x%lX))\n",
+        printf("read from %08lX [%08lX] (%d bytes => %d (0x%X))\n",
                (unsigned long) bio, (unsigned long) argp,
                argi, ret, ret);
         tls_dump(argp, (int) ret);
         return (ret);
     } else if (cmd == (BIO_CB_WRITE | BIO_CB_RETURN)) {
-        printf("write to %08lX [%08lX] (%d bytes => %ld (0x%lX))\n",
+        printf("write to %08lX [%08lX] (%d bytes => %d (0x%X))\n",
                (unsigned long) bio, (unsigned long) argp,
                argi, ret, ret);
         tls_dump(argp, (int) ret);
@@ -686,7 +688,7 @@ static int tls_start_clienttls(unsigned *layer, char **authid)
      * created for us, so we can use it for debugging purposes.
      */
     if (verbose==1)
-        BIO_set_callback(SSL_get_rbio(tls_conn), bio_dump_cb);
+        BIO_set_callback_ex(SSL_get_rbio(tls_conn), bio_dump_cb);
 
     /* Dump the negotiation for loglevels 3 and 4 */
     if (verbose==1)

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -127,7 +127,7 @@ struct search_state {
 };
 
 struct sha1_state {
-    SHA_CTX ctx;
+    SHA1_CTX ctx;
     uint8_t buf[4096];
     size_t len;
     size_t *outlen;
@@ -776,7 +776,7 @@ static void byte2sha1(struct convert_rock *rock, uint32_t c)
      * at a time (the internal block size) had overhead due to
      * to the upfront checks, so this is a good compromise size */
     if (state->len == 4096) {
-        SHA1_Update(&state->ctx, state->buf, state->len);
+        SHA1Update(&state->ctx, state->buf, state->len);
         if (state->outlen) *state->outlen += state->len;
         state->len = 0;
     }
@@ -1691,11 +1691,11 @@ static void sha1_cleanup(struct convert_rock *rock, int do_free)
     struct sha1_state *state = (struct sha1_state *)rock->state;
 
     if (state->len) {
-        SHA1_Update(&state->ctx, state->buf, state->len);
+        SHA1Update(&state->ctx, state->buf, state->len);
         if (state->outlen) *state->outlen += state->len;
     }
 
-    SHA1_Final(state->dest, &state->ctx);
+    SHA1Final(state->dest, &state->ctx);
 
     if (do_free) basic_free(rock);
 }
@@ -1955,7 +1955,7 @@ static struct convert_rock *sha1_init(uint8_t *dest, size_t *outlen)
     struct convert_rock *rock = xzmalloc(sizeof(struct convert_rock));
     struct sha1_state *state = xzmalloc(sizeof(struct sha1_state));
 
-    SHA1_Init(&state->ctx);
+    SHA1Init(&state->ctx);
     state->dest = dest;
     state->outlen = outlen;
 

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -38,10 +38,17 @@
 
 #ifdef HAVE_SSL
 #include <openssl/md5.h>
+#include <openssl/evp.h>
 
-#define MD5Init                     MD5_Init
-#define MD5Update                   MD5_Update
-#define MD5Final                    MD5_Final
+#define MD5_CTX           EVP_MD_CTX*
+
+#define MD5Init(c)        EVP_DigestInit((*c = EVP_MD_CTX_new()), EVP_md5())
+#define MD5Update(c,d,l)  EVP_DigestUpdate(*c, d, l)
+#define MD5Final(h,c)                  \
+    do {                               \
+        EVP_DigestFinal(*c, h, NULL);  \
+        EVP_MD_CTX_free(*c);           \
+    } while(0);
 
 #else
 

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -3,6 +3,8 @@
 #ifndef _CYRUS_MD5_H_
 #define _CYRUS_MD5_H_ 1
 
+#include <assert.h>
+
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -42,7 +44,8 @@
 
 #define MD5_CTX           EVP_MD_CTX*
 
-#define MD5Init(c)        EVP_DigestInit((*c = EVP_MD_CTX_new()), EVP_md5())
+#define MD5Init(c)        assert((*c = EVP_MD_CTX_new())           \
+                                 && EVP_DigestInit(*c, EVP_md5()))
 #define MD5Update(c,d,l)  EVP_DigestUpdate(*c, d, l)
 #define MD5Final(h,c)                  \
     do {                               \

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -3,11 +3,11 @@
 #ifndef _CYRUS_MD5_H_
 #define _CYRUS_MD5_H_ 1
 
-#include <assert.h>
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+
+#include "lib/assert.h"
 
 /*
  * This is gnarly, sorry :(  We might have been configured to build

--- a/lib/xsha1.c
+++ b/lib/xsha1.c
@@ -73,13 +73,6 @@
 /* to limit changes to the code below, set up the right types here */
 #include "lib/xsha1.h" /* for the typedefs and such */
 
-/* The SHA1 structure: */
-struct _SHA_CTX {
-    sha1_quadbyte   state[5];
-    sha1_quadbyte   count[2];
-    sha1_byte   buffer[SHA1_BLOCK_LENGTH];
-};
-
 /* Downloaded from http://www.aarongifford.com/computers/hmac_sha1.tar.gz
  * by Bron Gondwana <brong@fastmail.fm> on 2011-09-20
  */
@@ -160,7 +153,7 @@ static void SHA1_Transform(sha1_quadbyte state[5], const sha1_byte buffer[64]) {
 
 
 /* SHA1_Init - Initialize new context */
-EXPORTED int SHA1_Init(SHA_CTX* context) {
+EXPORTED int SHA1Init(SHA1_CTX* context) {
     /* SHA1 initialization constants */
     context->state[0] = 0x67452301;
     context->state[1] = 0xEFCDAB89;
@@ -173,7 +166,8 @@ EXPORTED int SHA1_Init(SHA_CTX* context) {
 }
 
 /* Run your data through this. */
-EXPORTED int SHA1_Update(SHA_CTX *context, const sha1_byte *data, unsigned int len) {
+EXPORTED int SHA1Update(SHA1_CTX *context, const void *vdata, unsigned int len) {
+    const sha1_byte *data = vdata;
     unsigned int    i, j;
 
     j = (context->count[0] >> 3) & 63;
@@ -195,7 +189,7 @@ EXPORTED int SHA1_Update(SHA_CTX *context, const sha1_byte *data, unsigned int l
 
 
 /* Add padding and return the message digest. */
-EXPORTED int SHA1_Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA_CTX *context) {
+EXPORTED int SHA1Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA1_CTX *context) {
     sha1_quadbyte   i, j;
     sha1_byte   finalcount[8];
 
@@ -203,12 +197,12 @@ EXPORTED int SHA1_Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA_CTX *context) 
         finalcount[i] = (sha1_byte)((context->count[(i >= 4 ? 0 : 1)]
          >> ((3-(i & 3)) * 8) ) & 255);  /* Endian independent */
     }
-    SHA1_Update(context, (sha1_byte *)"\200", 1);
+    SHA1Update(context, (sha1_byte *)"\200", 1);
     while ((context->count[0] & 504) != 448) {
-        SHA1_Update(context, (sha1_byte *)"\0", 1);
+        SHA1Update(context, (sha1_byte *)"\0", 1);
     }
     /* Should cause a SHA1_Transform() */
-    SHA1_Update(context, finalcount, 8);
+    SHA1Update(context, finalcount, 8);
     for (i = 0; i < SHA1_DIGEST_LENGTH; i++) {
         digest[i] = (sha1_byte)
          ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
@@ -230,13 +224,13 @@ EXPORTED int SHA1_Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA_CTX *context) 
 EXPORTED unsigned char *xsha1(const unsigned char *buf, unsigned long len,
                               sha1_byte dest[SHA1_DIGEST_LENGTH])
 {
-    SHA_CTX ctx;
+    SHA1_CTX ctx;
 
-    memset(&ctx, 0, sizeof(SHA_CTX));
+    memset(&ctx, 0, sizeof(SHA1_CTX));
 
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, buf, len);
-    SHA1_Final(dest, &ctx);
+    SHA1Init(&ctx);
+    SHA1Update(&ctx, buf, len);
+    SHA1Final(dest, &ctx);
 
     return dest;
 }

--- a/lib/xsha1.h
+++ b/lib/xsha1.h
@@ -43,8 +43,9 @@
 #ifndef LIB_XSHA1_H
 #define LIB_XSHA1_H
 
-#include <assert.h>
 #include <config.h>
+
+#include "lib/assert.h"
 
 #ifdef HAVE_SSL
 

--- a/lib/xsha1.h
+++ b/lib/xsha1.h
@@ -48,12 +48,23 @@
 #ifdef HAVE_SSL
 
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #ifndef SHA1_DIGEST_LENGTH
 #define SHA1_DIGEST_LENGTH (SHA_DIGEST_LENGTH)
 #endif
 
-#define xsha1 SHA1
+#define xsha1(d,l,h)       EVP_Digest(d, l, h, NULL, EVP_sha1(), NULL)
+
+#define SHA1_CTX           EVP_MD_CTX*
+
+#define SHA1Init(c)        EVP_DigestInit((*c = EVP_MD_CTX_new()), EVP_sha1())
+#define SHA1Update(c,d,l)  EVP_DigestUpdate(*c, d, l)
+#define SHA1Final(h,c)                 \
+    do {                               \
+        EVP_DigestFinal(*c, h, NULL);  \
+        EVP_MD_CTX_free(*c);           \
+    } while(0);
 
 #else /* HAVE_SSL */
 
@@ -66,12 +77,16 @@ typedef uint8_t sha1_byte;    /* single byte type */
 #define SHA1_DIGEST_LENGTH  20
 #define SHA_DIGEST_LENGTH (SHA1_DIGEST_LENGTH)
 
-/* opaque type for the SHA1 structure: */
-typedef struct _SHA_CTX SHA_CTX;
+/* The SHA1 structure: */
+typedef struct _SHA1_CTX {
+    sha1_quadbyte   state[5];
+    sha1_quadbyte   count[2];
+    sha1_byte   buffer[SHA1_BLOCK_LENGTH];
+} SHA1_CTX;
 
-int SHA1_Init(SHA_CTX* context);
-int SHA1_Update(SHA_CTX *context, const sha1_byte *data, unsigned int len);
-int SHA1_Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA_CTX *context);
+int SHA1Init(SHA1_CTX* context);
+int SHA1Update(SHA1_CTX *context, const void *data, unsigned int len);
+int SHA1Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA1_CTX *context);
 
 unsigned char *xsha1(const unsigned char *buf, unsigned long len,
               sha1_byte dest[SHA1_DIGEST_LENGTH]);

--- a/lib/xsha1.h
+++ b/lib/xsha1.h
@@ -43,6 +43,7 @@
 #ifndef LIB_XSHA1_H
 #define LIB_XSHA1_H
 
+#include <assert.h>
 #include <config.h>
 
 #ifdef HAVE_SSL
@@ -54,11 +55,12 @@
 #define SHA1_DIGEST_LENGTH (SHA_DIGEST_LENGTH)
 #endif
 
-#define xsha1(d,l,h)       EVP_Digest(d, l, h, NULL, EVP_sha1(), NULL)
+#define xsha1(d,l,h)       assert(EVP_Digest(d, l, h, NULL, EVP_sha1(), NULL))
 
 #define SHA1_CTX           EVP_MD_CTX*
 
-#define SHA1Init(c)        EVP_DigestInit((*c = EVP_MD_CTX_new()), EVP_sha1())
+#define SHA1Init(c)        assert((*c = EVP_MD_CTX_new())            \
+                                  && EVP_DigestInit(*c, EVP_sha1()))
 #define SHA1Update(c,d,l)  EVP_DigestUpdate(*c, d, l)
 #define SHA1Final(h,c)                 \
     do {                               \


### PR DESCRIPTION
This PR allows Cyrus to compile with OpenSSL 3.0.

Note that it really only fixes the issues with the MD5 and SHA1 APIs , by using the newer EVP APIs.

The issues with the TLS APIs have been largely avoided at this point by simply commenting out the code that uses legacy APIs.  Someone with a better understanding of DH params and elliptic curves (and the new APIs) will need to fix the rest.

@rsto @elliefm This (rewritten) code compiles both on my laptop with OpenSSL 3.0.2 and my desktop which still has OpenSSL 1.1.1n.  Please try this on your platforms.
