### PR TITLE
http_dav.c: can't multiget from a non-mailbox (e.g., /dav/addressbooks/)

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -7391,6 +7391,9 @@ int report_multiget(struct transaction_t *txn, struct meth_params *rparams,
                 tgt.namespace = txn->req_tgt.namespace;
 
                 r = rparams->parse_path(uri->path, &tgt, &resultstr);
+                if (!r && !tgt.mbentry) {
+                    r = HTTP_FORBIDDEN;
+                }
                 xmlFreeURI(uri);
             }
             if (r) {


### PR DESCRIPTION
Fixes a crasher for a DAV:multiget request for /dav/addressbooks