### PR TITLE
processimip: ignore iTIP send from and to the same address

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -5305,6 +5305,101 @@ EOF
     $self->assert_deep_equals($events, []);
 }
 
+sub test_imip_cancel_to_organizer
+    :needs_component_sieve :needs_component_httpd :min_version_3_5
+{
+    my ($self) = @_;
+
+    my $IMAP = $self->{store}->get_client();
+    $self->{store}->_select();
+    $self->assert_num_equals(1, $IMAP->uid());
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+
+    xlog $self, "Create calendar user";
+    my $CalDAV = $self->{caldav};
+    my $CalendarId = 'Default';
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :outcome "outcome";
+    if string "\${outcome}" "updated" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=America/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+STATUS:TENTATIVE
+ORGANIZER:MAILTO:cassandane\@example.com
+ATTENDEE;CN=Test User;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+    my $href = "/dav/calendars/user/cassandane/$CalendarId/$uuid.ics";
+    $CalDAV->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
+
+    xlog $self, "Check that the event made it to calendar";
+    my $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('tentative', $events->[0]{status});
+
+
+    my $imip = <<EOF;
+Date: Thu, 24 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-1\@example.net>
+Content-Type: text/calendar; method=CANCEL; component=VEVENT
+X-Cassandane-Unique: $uuid-1
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:CANCEL
+BEGIN:VEVENT
+CREATED:20210924T034327Z
+UID:$uuid
+DTSTAMP:20210924T034327Z
+SEQUENCE:1
+ORGANIZER:MAILTO:cassandane\@example.com
+ATTENDEE;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP cancel";
+    my $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 2,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Make sure that the event was NOT canceled";
+    $events = $CalDAV->GetEvents($CalendarId);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('tentative', $events->[0]{status});
+    $self->assert_equals(0, $events->[0]{sequence});
+}
+
 sub test_imip_reply
     :needs_component_sieve :needs_component_httpd :min_version_3_5
 {

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1489,6 +1489,7 @@ static int sieve_imip(void *ac, void *ic, void *sc, void *mc,
         goto done;
     }
     organizer = icalproperty_get_organizer(prop);
+    if (!strncasecmp(organizer, "mailto:", 7)) organizer += 7;
 
     if (strchr(ctx->userid, '@')) {
         strarray_add(&sched_addresses, ctx->userid);
@@ -1584,6 +1585,7 @@ static int sieve_imip(void *ac, void *ic, void *sc, void *mc,
                 goto done;
             }
             originator = icalproperty_get_invitee(prop);
+            if (!strncasecmp(originator, "mailto:", 7)) originator += 7;
 
             sched_flags |= SCHEDFLAG_IS_REPLY;
             break;


### PR DESCRIPTION
Fixes a problem that we have seen in the wild with a CANCEL message being redirected back to the ORGANIZER