### PR TITLE
jmap_util: charset detection must not decrease printable characters  …

### DIFF
--- a/cunit/jmap_util.testc
+++ b/cunit/jmap_util.testc
@@ -145,7 +145,6 @@ static void test_decode_to_utf8(void)
         int want_is_encoding_problem;
     };
 
-
     // this is all about "Adélaïde"
 
     struct testcase tcs[] = {{
@@ -189,6 +188,18 @@ static void test_decode_to_utf8(void)
         0.51,
         "Ad""\xef\xbf\xbd""la""\xef\xbf\xbd""de",
         0
+    }, {
+        // Multi-byte UTF-8 with invalid byte sequence:
+        // "Hello,😛🪐world🍎🏓!💾," "\xc3\x28"
+        "SGVsbG8s8J+Ym/CfqpB3b3JsZPCfjY7wn4+TIfCfkr4swyg=",
+        "utf-8",
+        ENCODING_BASE64,
+        0.0,
+        "\x48\x65\x6c\x6c\x6f\x2c\xf0\x9f\x98\x9b\xf0\x9f"
+        "\xaa\x90\x77\x6f\x72\x6c\x64\xf0\x9f\x8d\x8e\xf0"
+        "\x9f\x8f\x93\x21\xf0\x9f\x92\xbe"
+        "," "\xef\xbf\xbd" "(",
+        1
     }, {
         NULL, NULL, ENCODING_UNKNOWN, 0.0, NULL, 0
     }};

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3982,7 +3982,7 @@ EXPORTED struct char_counts charset_count_validutf8(const char *data, size_t dat
         datalen = INT32_MAX;
     }
 
-    struct char_counts counts = { 0, 0, 0 };
+    struct char_counts counts = { 0 };
     int32_t i = 0;
     int32_t length = (int32_t) datalen;
     const uint8_t *data8 = (const uint8_t *) data;
@@ -3990,10 +3990,14 @@ EXPORTED struct char_counts charset_count_validutf8(const char *data, size_t dat
     while (i < length) {
         UChar32 c;
         U8_NEXT(data8, i, length, c);
+        counts.total++;
         if (c == 0xfffd)
             counts.replacement++;
-        else if (c >= 0)
+        else if (c >= 0) {
             counts.valid++;
+            if (u_iscntrl(c))
+                counts.cntrl++;
+        }
         else
             counts.invalid++;
     }

--- a/lib/charset.h
+++ b/lib/charset.h
@@ -176,9 +176,11 @@ extern int charset_extract(int (*cb)(const struct buf *text, void *rock),
 EXPORTED char *charset_extract_plain(const char *html);
 
 struct char_counts {
+    size_t total;
     size_t valid;
     size_t replacement;
     size_t invalid;
+    size_t cntrl;
 };
 
 /* Count the number of valid, invalid and replacement UTF-8 characters


### PR DESCRIPTION
In some cases, the charset detection library might erroneously
guess a text to be encoded in a single byte encoding such as
ISO-8859-2. The resulting UTF-8 string then trivially contains no
invalid or replacement byte sequences but a large number of
single byte control characters.

To prevent this, this patch adds the heuristic that the amount of
printable characters must not decrease in relation to the total
number of all valid characters.