### PR TITLE
mbexamine: tighten up error handling

### DIFF
--- a/changes/next/mbexamine-error-handling
+++ b/changes/next/mbexamine-error-handling
@@ -1,0 +1,18 @@
+Description:
+
+Improves error handling and reporting from mbexamine
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+If you have custom tooling that calls mbexamine, it may need updating.
+
+
+GitHub issue:
+
+None

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -157,16 +157,10 @@ int main(int argc, char **argv)
     if (optind == argc) {
         strlcpy(buf, "*", sizeof(buf));
         r = mboxlist_findall(&mbexamine_namespace, buf, 1, 0, 0, cb, &ok_count);
-        if (r) {
-            fprintf(stderr, "%s: %s\n", buf, error_message(r));
-        }
     }
 
     for (i = optind; i < argc; i++) {
         r = mboxlist_findall(&mbexamine_namespace, argv[i], 1, 0, 0, cb, &ok_count);
-        if (r) {
-            fprintf(stderr, "%s: %s\n", argv[i], error_message(r));
-        }
     }
 
     cyrus_done();
@@ -224,7 +218,10 @@ static int do_examine(struct findall_data *data, void *rock)
 
     /* Open/lock header */
     r = mailbox_open_irl(name, &mailbox);
-    if (r) return r;
+    if (r) {
+        fprintf(stderr, "%s: %s\n", extname, error_message(r));
+        return r;
+    }
 
     printf(" Mailbox Header Info:\n");
     printf("  Path to mailbox: %s\n", mailbox_datapath(mailbox, 0));
@@ -399,7 +396,10 @@ static int do_quota(struct findall_data *data, void *rock)
 
     /* Open/lock header */
     r = mailbox_open_irl(name, &mailbox);
-    if (r) return r;
+    if (r) {
+        fprintf(stderr, "%s: %s\n", extname, error_message(r));
+        return r;
+    }
 
     struct mailbox_iter *iter = mailbox_iter_init(mailbox, 0, ITER_SKIP_EXPUNGED);
     const message_t *msg;
@@ -472,10 +472,14 @@ static int do_compare(struct findall_data *data, void *rock)
 
     /* Open/lock header */
     r = mailbox_open_irl(name, &mailbox);
-    if (r) return r;
+    if (r) {
+        fprintf(stderr, "%s: %s\n", extname, error_message(r));
+        return r;
+    }
 
     if (mailbox->i.minor_version < 7) {
-        printf("Mailbox version is too old for comparison\n");
+        fprintf(stderr, "%s: Mailbox version is too old for comparison\n",
+                        extname);
         goto done;
     }
 
@@ -607,6 +611,10 @@ static int do_compare(struct findall_data *data, void *rock)
     free(uids);
 
     if (!r && ok_count) (*ok_count) ++;
+
+    if (r) {
+        fprintf(stderr, "%s: %s\n", extname, error_message(r));
+    }
 
     return r;
 }


### PR DESCRIPTION
This is part of some work that @rjbs requested.   I'd like to get it merged now because otherwise it'll start to conflict with the long-options work that I'm also doing.

This:
* reports any errors that occur on stderr
* treats invocations that don't find any work to do (i.e. when there are no matches for the provided mailbox pattern) as failures rather than successes

We don't have any existing tests for mbexamine, and I haven't bothered to write any.  I expect this interface to change further when we do the big tool audit/update, so in my mind tests can wait.  Let me know if you disagree!