### PR TITLE
Email/set should ignore expunged messages

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
@@ -1649,6 +1649,13 @@ sub test_emailsubmission_scheduled_send
     $self->assert_null($res->[2][1]->{list}[0]->{mailboxIds}{$schedid});
 
     
+    xlog $self, "Destroy canceled email submission 2 (now in Drafts) ";
+    $res = $jmap->CallMethods( [ [ 'Email/set', {
+        destroy => [ $emailid2 ],
+    }, "R1" ] ] );
+    $self->assert_str_equals($emailid2, $res->[0][1]->{destroyed}[0]);
+
+
     xlog $self, "Verify an event was removed from the alarmdb";
     $alarmdata = $self->{instance}->getalarmdb();
     $self->assert_num_equals(1, scalar @$alarmdata);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -10908,6 +10908,12 @@ static int _email_mboxrecs_read_cb(const conv_guidrec_t *rec, void *_rock)
     /* don't process emails that have this email attached! */
     if (rec->part) goto done;
 
+    /* don't process emails that have been expunged */
+    if ((rec->system_flags & FLAG_DELETED) ||
+        (rec->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
+        goto done;
+    }
+
     conv_guidrec_mbentry(rec, &mbentry);
 
     if (!jmap_hasrights_mbentry(rock->req, mbentry, JACL_READITEMS)) {


### PR DESCRIPTION
This solves a problem where a canceled scheduled send message that has been moved back to the Drafts mailbox can't be destroyed.
This happens because the already-expunged message in the Scheduled mailbox is found and we prohibit direct Email/Set on anything in Scheduled.
