### PR TITLE
Remove iTIP messages on CalendarEvent/set{update,destroy}

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4243,6 +4243,156 @@ EOF
     $self->assert_str_equals('2021-09-24T14:00:00', $events->[0]{start});
 }
 
+sub test_remove_itip_on_jmap_update
+    :needs_component_sieve :needs_component_httpd :min_version_3_5
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+
+    xlog $self, "Create calendar user";
+    my $CalDAV = $self->{caldav};
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :outcome "outcome";
+    if string "\${outcome}" "updated" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    my $imip = <<EOF;
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-0\@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+X-Cassandane-Unique: $uuid-0
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=America/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;X-JMAP-ID=cassandane:
+ MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP invite";
+    my $msg = Cassandane::Message->new(raw => $imip);
+    $self->{instance}->deliver($msg);
+
+
+    $imip = <<EOF;
+Date: Thu, 24 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-1\@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+X-Cassandane-Unique: $uuid-1
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210924T170000
+TRANSP:OPAQUE
+SUMMARY:An Updated Event
+DTSTART;TZID=America/New_York:20210924T140000
+DTSTAMP:20210923T034327Z
+SEQUENCE:1
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;X-JMAP-ID=cassandane:
+ MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP update";
+    $msg = Cassandane::Message->new(raw => $imip);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that 2 iTIP messages made it to Scheduling Inbox";
+    my $events = $CalDAV->GetEvents('Inbox');
+    $self->assert_equals(2, scalar @$events);
+
+    my $res = $jmap->CallMethods([['CalendarEvent/get', {}, "R1"]]);
+    my $event = $res->[0][1]{list}[0];
+    my $id = $event->{id};
+
+    xlog $self, "Update participationStatus";
+    $res = $jmap->CallMethods([['CalendarEvent/set',
+                                {update =>
+                                 {$id =>
+                                  { "participants/cassandane/participationStatus" => "accepted"}}},
+                                "R1"]]);
+    $self->assert_not_null($res->[0][1]{updated});
+
+    xlog $self, "Check that iTIP messages were removed from Scheduling Inbox";
+    $events = $CalDAV->GetEvents('Inbox');
+    $self->assert_equals(0, scalar @$events);
+
+
+    $imip = <<EOF;
+Date: Thu, 24 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid-1\@example.net>
+Content-Type: text/calendar; method=CANCEL; component=VEVENT
+X-Cassandane-Unique: $uuid-1
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:CANCEL
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTSTAMP:20210923T034327Z
+SEQUENCE:2
+STATUS:CANCELLED
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;X-JMAP-ID=cassandane:
+ MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP cancel";
+    $msg = Cassandane::Message->new(raw => $imip);
+    $self->{instance}->deliver($msg);
+    sleep 1;
+
+    xlog $self, "Delete canceled event";
+    $res = $jmap->CallMethods([['CalendarEvent/set', {destroy => [$id]}, "R2"]]);
+
+    xlog $self, "Check that iTIP messages were removed from Scheduling Inbox";
+    $events = $CalDAV->GetEvents('Inbox');
+    $self->assert_equals(0, scalar @$events);
+}
+
 sub test_imip_add
     :needs_component_sieve :needs_component_httpd :min_version_3_7
 {

--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4383,7 +4383,6 @@ EOF
     xlog $self, "Deliver iMIP cancel";
     $msg = Cassandane::Message->new(raw => $imip);
     $self->{instance}->deliver($msg);
-    sleep 1;
 
     xlog $self, "Delete canceled event";
     $res = $jmap->CallMethods([['CalendarEvent/set', {destroy => [$id]}, "R2"]]);

--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -835,13 +835,17 @@ EXPORTED int caldav_foreach_jscal(struct caldav_db *caldavdb,
     buf_setcstr(&stmt, cache_userid ?
             CMD_READFIELDS_JSCALOBJS : CMD_READFIELDS_JSCALOBJS_NOCACHE);
 
-    buf_appendcstr(&stmt, " WHERE mailbox != :inbox");
-
-    if (filter) {
+    if (!filter) {
+        buf_appendcstr(&stmt, " WHERE mailbox != :inbox");
+    }
+    else {
         if (filter->mbentry) {
-            buf_appendcstr(&stmt, " AND mailbox = :mailbox");
+            buf_appendcstr(&stmt, " WHERE mailbox = :mailbox");
             bval[0].val.s = caldavdb->db->version >= DB_MBOXID_VERSION ?
                 filter->mbentry->uniqueid : filter->mbentry->name;
+        }
+        else {
+            buf_appendcstr(&stmt, " WHERE mailbox != :inbox");
         }
         if (filter->ical_uid) {
             buf_appendcstr(&stmt, " AND ical_uid = :ical_uid");


### PR DESCRIPTION
This blindly removes all iTIP messages having the matching iCalendar UID.  The thought is that if the user updates the calendar via JMAP they probably don't need their CalDAV client to see any of the iTIP for that UID, even if they correspond to single instances.

An alternative to deleting these on CalendarEvent/set would be to just set an expiration time on the Scheudling Inbox (e.g. 1-2 weeks)