### PR TITLE
search_xapian: handle version 2 mailbox keys in reindex_mb

### DIFF
--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -1859,4 +1859,33 @@ sub test_dedup_part_compact
     $self->assert_num_equals(3, scalar @$gdocs);
 }
 
+sub test_reindex_mb_uniqueid
+    :min_version_3_7 :needs_search_xapian
+{
+    my ($self) = @_;
+
+    my $xapdirs = ($self->{instance}->run_mbpath(-u => 'cassandane'))->{xapian};
+    my $basedir = $self->{instance}->{basedir};
+
+    $self->make_message('msgA', body => 'part1') || die;
+    $self->make_message('msgB', body => 'part1') || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-D');
+
+    xlog "compact and reindex tier";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-z', 't2', '-t', 't1', '-T', 't1:0');
+
+    xlog "dump t2:cyrus.indexed.db";
+    # assumes twoskip backend and version 2 format keys
+    my $srcfile = $xapdirs->{t2} . '/xapian/cyrus.indexed.db';
+    my $dstfile = $basedir . '/tmp/cyrus.indexed.db.flat';
+    $self->{instance}->run_command({cyrus => 1}, 'cvt_cyrusdb', $srcfile, 'twoskip', $dstfile, 'flat');
+
+    xlog "assert reindexed tier contains a mailbox key";
+    open(FH, "<$dstfile") || die;
+    my @mboxrows = grep { /^\*M\*[0-9a-zA-z\-_]+\*/ } <FH>;
+    close FH;
+    $self->assert_num_equals(1, scalar @mboxrows);
+}
+
+
 1;

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -3631,7 +3631,7 @@ done:
         strarray_free(tr->activetiers);
         seqset_free(&tr->indexed);
         if (tr->dbw) xapian_dbw_close(tr->dbw);
-        free_receiver(&tr->super);
+        end_update((search_text_receiver_t *)tr);
     }
     mailbox_close(&mailbox);
     for (i = 0; i < batch.count; i++) {

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -3440,7 +3440,7 @@ static int reindex_mb(void *rock,
                       const char *data, size_t datalen)
 {
     struct mbfilter *filter = (struct mbfilter *)rock;
-    char *mboxname = xstrndup(key, keylen);
+    char *mbkey = xstrndup(key, keylen);
     seqset_t *seq = parse_indexed(data, datalen);
     xapian_update_receiver_t *tr = NULL;
     struct mailbox *mailbox = NULL;
@@ -3448,25 +3448,53 @@ static int reindex_mb(void *rock,
     ptrarray_t batch = PTRARRAY_INITIALIZER;
     int verbose = SEARCH_VERBOSE(filter->flags);
     strarray_t alldirs = STRARRAY_INITIALIZER;
+    mbentry_t *mbentry = NULL;
     int r = 0;
     int i;
-    char *dot;
-    uint32_t uidvalidity;
 
-    dot = strrchr(mboxname, '.');
-    *dot++ = '\0';
-    uidvalidity = atol(dot);
+    /* Lookup mailbox */
+
+    if (mbkey[0] == '*' && mbkey[1] == 'M' && mbkey[2] == '*') {
+        // read *M*<uniqueid>*
+        char *end = strrchr(mbkey, '*');
+        if (end) {
+            *end = '\0';
+            r = mboxlist_lookup_by_uniqueid(mbkey + 3, &mbentry, NULL);
+        }
+    }
+    else if (mbkey[0] != '#') {
+        // read <mboxname>:<uidvalidity>
+        char *dot = strrchr(mbkey, '.');
+        if (dot) {
+            *dot++ = '\0';
+            uint32_t uidvalidity = atol(dot);
+            r = mboxlist_lookup(mbkey, &mbentry, NULL);
+            if (!r && uidvalidity != mbentry->uidvalidity) {
+                /* returns 0, nothing to index */
+                goto done;
+            }
+        }
+    }
+    else goto done;
+
+    if (r == IMAP_MAILBOX_NONEXISTENT) {
+        r = 0;  /* it's not an error to have a no-longer-exiting mailbox to index */
+        goto done;
+    }
+    else if (r) {
+        xsyslog(LOG_ERR, "can not lookup mailbox", "key=<%s> err=<%s>",
+                mbkey, error_message(r));
+        goto done;
+    }
 
     if (!seq) goto done;
 
-    r = mailbox_open_irl(mboxname, &mailbox);
+    r = mailbox_open_irl(mbentry->name, &mailbox);
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         r = 0;  /* it's not an error to have a no-longer-exiting mailbox to index */
         goto done;
     }
     if (r) goto done;
-
-    if (mailbox->i.uidvalidity != uidvalidity) goto done; /* returns 0, nothing to index */
 
     struct mailbox_iter *iter = mailbox_iter_init(mailbox, 0, ITER_SKIP_UNLINKED);
 
@@ -3611,7 +3639,8 @@ done:
         message_unref(&msg);
     }
     ptrarray_fini(&batch);
-    free(mboxname);
+    mboxlist_entry_free(&mbentry);
+    free(mbkey);
     seqset_free(&seq);
     strarray_fini(&alldirs);
     buf_free(&buf);


### PR DESCRIPTION
The reindex code still expected legacy version 1 keys in cyrus.indexed.db. It consequently failed for the current version 2 keys.