### PR TITLE
Support iCal GEO property as text

### DIFF
--- a/imap/jcal.c
+++ b/imap/jcal.c
@@ -184,8 +184,13 @@ static json_t *icalvalue_as_json_object(const icalvalue *value)
         struct icalgeotype geo = icalvalue_get_geo(value);
 
         obj = json_array();
+#ifdef ICAL_GEO_LEN
+        json_array_append_new(obj, json_real(atof(geo.lat)));
+        json_array_append_new(obj, json_real(atof(geo.lon)));
+#else
         json_array_append_new(obj, json_real(geo.lat));
         json_array_append_new(obj, json_real(geo.lon));
+#endif
         return obj;
     }
 
@@ -523,11 +528,16 @@ static icalvalue *json_object_to_icalvalue(json_t *jvalue,
                  i++);
             if (i == len) {
                 struct icalgeotype geo;
+                double lat = json_real_value(json_array_get(jvalue, 0));
+                double lon = json_real_value(json_array_get(jvalue, 1));
 
-                geo.lat =
-                    json_real_value(json_array_get(jvalue, 0));
-                geo.lon =
-                    json_real_value(json_array_get(jvalue, 1));
+#ifdef ICAL_GEO_LEN
+                snprintf(geo.lat, ICAL_GEO_LEN-1, "%lf", lat);
+                snprintf(geo.lon, ICAL_GEO_LEN-1, "%lf", lon);
+#else
+                geo.lat = lat;
+                geo.lon = lon;
+#endif
 
                 value = icalvalue_new_geo(geo);
             }

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -56,6 +56,7 @@
 #include "version.h"
 #include "xcal.h"
 #include "xml_support.h"
+#include "xstrlcpy.h"
 
 
 /*
@@ -355,10 +356,15 @@ static void icalproperty_add_value_as_xml_element(xmlNodePtr xprop,
     case ICAL_GEO_VALUE: {
         struct icalgeotype geo = icalvalue_get_geo(value);
 
+#ifdef ICAL_GEO_LEN
+        xmlNewTextChild(xtype, NULL, BAD_CAST "latitude", BAD_CAST geo.lat);
+        xmlNewTextChild(xtype, NULL, BAD_CAST "longitude", BAD_CAST geo.lon);
+#else
         snprintf(buf, sizeof(buf), "%f", geo.lat);
         xmlNewTextChild(xtype, NULL, BAD_CAST "latitude", BAD_CAST buf);
         snprintf(buf, sizeof(buf), "%f", geo.lon);
         xmlNewTextChild(xtype, NULL, BAD_CAST "longitude", BAD_CAST buf);
+#endif
         return;
     }
 
@@ -634,7 +640,11 @@ static icalvalue *xml_element_to_icalvalue(xmlNodePtr xtype,
         }
 
         content = xmlNodeGetContent(node);
+#ifdef ICAL_GEO_LEN
+        strlcpy(geo.lat, (const char *) content, ICAL_GEO_LEN);
+#else
         geo.lat = atof((const char *) content);
+#endif
 
         node = xmlNextElementSibling(node);
         if (!node) {
@@ -649,7 +659,11 @@ static icalvalue *xml_element_to_icalvalue(xmlNodePtr xtype,
 
         xmlFree(content);
         content = xmlNodeGetContent(node);
+#ifdef ICAL_GEO_LEN
+        strlcpy(geo.lon, (const char *) content, ICAL_GEO_LEN);
+#else
         geo.lon = atof((const char *) content);
+#endif
 
         value = icalvalue_new_geo(geo);
 


### PR DESCRIPTION
Latest libical switched from using floats to text strings for GEO property