### PR TITLE
imap/imapd.c: IMAPOPT_MAXMESSAGESIZE is bytes, not kilobytes

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -911,7 +911,7 @@ int service_init(int argc, char **argv, char **envp)
 
     prometheus_increment(CYRUS_IMAP_READY_LISTENERS);
 
-    maxsize = config_getint(IMAPOPT_MAXMESSAGESIZE) * 1024;
+    maxsize = config_getint(IMAPOPT_MAXMESSAGESIZE);
     if (!maxsize) maxsize = UINT32_MAX;
 
     return 0;


### PR DESCRIPTION
I think this was a mistake added in bf28aa3fb6 when replacing
IMAPOPT_APPEND_MAXSIZE.