### PR TITLE
no uniqueid fix for murder frontends (3.4)

### DIFF
--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -173,8 +173,8 @@ static int fixmbox(const mbentry_t *mbentry,
                mbentry->name, cyrusdb_strerror(r));
     }
 
-    /* make sure every mbentry has a uniqueid!  */
-    if (!mbentry->uniqueid) {
+    /* make sure every local mbentry has a uniqueid!  */
+    if (!mbentry->uniqueid && mbentry_is_local_mailbox(mbentry)) {
         struct mailbox *mailbox = NULL;
         struct mboxlock *namespacelock = NULL;
         mbentry_t *copy = NULL;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1042,7 +1042,8 @@ static int mailbox_open_advanced(const char *name,
         goto done;
     }
 
-    if (!mbentry->uniqueid) {
+    /* XXX can we even get here for remote mbentries? */
+    if (!mbentry->uniqueid && mbentry_is_local_mailbox(mbentry)) {
         xsyslog(LOG_NOTICE, "mbentry has no uniqueid, needs reconstruct",
                             "mboxname=<%s>", mailbox->name);
     }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -276,6 +276,26 @@ EXPORTED char *mbentry_datapath(const struct mboxlist_entry *mbentry, uint32_t u
                              uid);
 }
 
+EXPORTED int mbentry_is_local_mailbox(const struct mboxlist_entry *mbentry)
+{
+    if (config_mupdate_server && !config_getstring(IMAPOPT_PROXYSERVERS)) {
+        /* dedicated frontends never have local mailboxes */
+        return 0;
+    }
+    else if ((mbentry->mbtype & MBTYPE_REMOTE)) {
+        /* mbentry has the remote flag set */
+        return 0;
+    }
+    else if (mbentry->server
+             && 0 != strcmpsafe(mbentry->server, config_servername))
+    {
+        /* it's on some server that is not this one */
+        return 0;
+    }
+
+    return 1;
+}
+
 /*
  * read a single record from the mailboxes.db and return a pointer to it
  */

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -124,6 +124,9 @@ mbentry_t *mboxlist_entry_create();
 char *mbentry_metapath(const struct mboxlist_entry *mbentry, int metatype, int isnew);
 char *mbentry_datapath(const struct mboxlist_entry *mbentry, uint32_t);
 
+int mbentry_is_local_mailbox(const struct mboxlist_entry *mbentry);
+#define mbentry_is_remote_mailbox(mbentry) (!mbentry_is_local_mailbox(mbentry))
+
 int mboxlist_parse_entry(mbentry_t **mbentryptr,
                          const char *name, size_t namelen,
                          const char *data, size_t datalen);


### PR DESCRIPTION
uniqueid is not one of the fields synchronised by mupdate, which I think means the mbentries for remote mailboxes (i.e. on murder frontends) won't and can't have uniqueids.

This PR builds upon the work from #4100, such that it won't complain about nor try to "fix" missing uniqueids for remote mailboxes.

This PR is for 3.4 only.  I think master/3.6 will need a similar shape of change in `mboxlist.c:_foreach_cb()` following #4096, but I have not thought about the ramifications there yet.

No tests (yet?), cause I haven't figured out how I would prove to myself that it works.  Am open to ideas!