### PR TITLE
fix assert() definition

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -4492,7 +4492,7 @@ EXPORTED int mailbox_append_index_record(struct mailbox *mailbox,
     assert(mailbox_index_islocked(mailbox, 1));
 
     /* Append MUST be a higher UID than any we've yet seen */
-    assert(record->uid > mailbox->i.last_uid)
+    assert(record->uid > mailbox->i.last_uid);
 
     /* Append MUST have a message with data */
     assert(record->size);

--- a/imap/message.c
+++ b/imap/message.c
@@ -5070,13 +5070,13 @@ EXPORTED int message_get_priority(message_t *m, struct buf *buf)
 
 EXPORTED const struct index_record *msg_record(const message_t *m)
 {
-    assert(!message_need(m, M_RECORD))
+    assert(!message_need(m, M_RECORD));
     return &m->record;
 }
 
 EXPORTED struct mailbox *msg_mailbox(const message_t *m)
 {
-    assert(!message_need(m, M_MAILBOX))
+    assert(!message_need(m, M_MAILBOX));
     return m->mailbox;
 }
 
@@ -5096,7 +5096,7 @@ EXPORTED int message_get_size(message_t *m, uint32_t *sizep)
 
 EXPORTED uint32_t msg_size(const message_t *m)
 {
-    assert(!message_need(m, M_RECORD))
+    assert(!message_need(m, M_RECORD));
     return m->record.size;
 }
 
@@ -5110,7 +5110,7 @@ EXPORTED int message_get_uid(message_t *m, uint32_t *uidp)
 
 EXPORTED uint32_t msg_uid(const message_t *m)
 {
-    assert(!message_need(m, M_RECORD))
+    assert(!message_need(m, M_RECORD));
     return m->record.uid;
 }
 
@@ -5124,7 +5124,7 @@ EXPORTED int message_get_cid(message_t *m, conversation_id_t *cidp)
 
 EXPORTED conversation_id_t msg_cid(const message_t *m)
 {
-    assert(!message_need(m, M_RECORD))
+    assert(!message_need(m, M_RECORD));
     return m->record.cid;
 }
 
@@ -5138,7 +5138,7 @@ EXPORTED int message_get_modseq(message_t *m, modseq_t *modseqp)
 
 EXPORTED modseq_t msg_modseq(const message_t *m)
 {
-    assert(!message_need(m, M_RECORD))
+    assert(!message_need(m, M_RECORD));
     return m->record.modseq;
 }
 
@@ -5152,7 +5152,7 @@ EXPORTED int message_get_msgno(message_t *m, uint32_t *msgnop)
 
 EXPORTED uint32_t msg_msgno(const message_t *m)
 {
-    assert(!message_need(m, M_INDEX))
+    assert(!message_need(m, M_INDEX));
     return m->msgno;
 }
 
@@ -5174,7 +5174,7 @@ EXPORTED int message_get_guid(message_t *m, const struct message_guid **guidp)
 
 EXPORTED const struct message_guid *msg_guid(const message_t *m)
 {
-    assert(!message_need(m, M_RECORD))
+    assert(!message_need(m, M_RECORD));
     return &m->record.guid;
 }
 

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -43,11 +43,11 @@
 #ifndef INCLUDED_ASSERT_H
 #define INCLUDED_ASSERT_H
 
-#ifdef __STDC__
-#define assert(ex)      {if (!(ex))assertionfailed(__FILE__, __LINE__, #ex);}
 void assertionfailed(const char *file, int line, const char *expr);
-#else
-#define assert(ex)      {if (!(ex))assertionfailed(__FILE__, __LINE__, (char*)0);}
-#endif
+
+#define assert(expr)                                                \
+    ((expr)                                                         \
+     ? (void)(0)                                                    \
+     : assertionfailed(__FILE__, __LINE__, #expr))
 
 #endif /* INCLUDED_ASSERT_H */


### PR DESCRIPTION
This redefines our `assert()` macro to evaluate as an expression, rather than as a statement.  This makes it syntactically compatible with the C standard one, which means sub-components we link in that expect to have a C standard assert() available do not choke on ours being different.  As far as I know, this is mostly just perl, when building our XS modules.

While in there, I cleaned up an old `#ifdef __STDC__` check, whose else path would have failed to compile anyway, had it ever been hit.

Also had to fix a bunch of miscellaneous lines without semicolons, which the bad macro definition had previously allowed. 😅 

Fixes #4123, I think -- will need someone with perl 5.36 to test and confirm this please.

Once merged, this will be backported to 3.6 and 3.4.