### PR TITLE
use the correct pattern when altnamespace is on

### DIFF
--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1018,8 +1018,17 @@ HIDDEN void jmap_accounts(json_t *accounts, json_t *primary_accounts)
 {
     /* Find shared accounts */
     strarray_t patterns = STRARRAY_INITIALIZER;
-    char *userpat = xstrdup("user.*");
-    userpat[4] = jmap_namespace.hier_sep;
+    char *userpat = NULL;
+    if (jmap_namespace.isalt) {
+        struct buf buf = BUF_INITIALIZER;
+        buf_printf(&buf, "%s%c*", config_getstring(IMAPOPT_USERPREFIX),
+                   jmap_namespace.hier_sep);
+        userpat = buf_release(&buf);
+    }
+    else {
+        userpat = xstrdup("user.*");
+        userpat[4] = jmap_namespace.hier_sep;
+    }
     strarray_append(&patterns, userpat);
     struct findaccounts_rock rock = {
         BUF_INITIALIZER, 0, accounts, httpd_userid
@@ -1828,7 +1837,7 @@ HIDDEN void jmap_get_parse(jmap_req_t *req,
         }
     }
 
-    /* Number of ids checked in validate_request() */ 
+    /* Number of ids checked in validate_request() */
 }
 
 HIDDEN void jmap_get_fini(struct jmap_get *get)


### PR DESCRIPTION
Signed-off-by: qyb <qiuyingbo@gmail.com>

more info: https://cyrus.topicbox.com/groups/info/T19bc8d3e0b073fec-M28948f2e1ef90f0c646d8c6f/cannot-get-shared-mailbox-info-in-jmap-session