### PR TITLE
cyrus_icalrestriction_check() strip all X-LIC-ERROR properties from the input

### DIFF
--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -106,6 +106,8 @@ EXPORTED int cyrus_icalrestriction_check(icalcomponent *ical)
     icalcomponent *comp;
     icalproperty *prop;
 
+    icalcomponent_strip_errors(ical);
+
     for (comp = icalcomponent_get_first_component(ical, ICAL_ANY_COMPONENT);
          comp;
          comp = icalcomponent_get_next_component(ical, ICAL_ANY_COMPONENT)) {


### PR DESCRIPTION
When the CUA PUTs an iCalendar object with X-LIC-ERROR property, Cyrus IMAP rejects the upload, as the iCalendar object is assumed to contain errors.  It does however not contain errors.

This can happen, when the CUA uses libical compiled with ICAL_ALLOW_EMPTY_PROPERTIES=OFF and the CUA receives an iCalendar object (per email) with LOCATION: property without value.  libical transforms then the empty LOCATION: property in X-LIC-ERROR property.