### PR TITLE
quota: accept -n flag

### DIFF
--- a/imap/quota.c
+++ b/imap/quota.c
@@ -132,7 +132,7 @@ int main(int argc,char **argv)
     int do_report = 1;
     char *alt_config = NULL, *domain = NULL;
 
-    while ((opt = getopt(argc, argv, "C:d:fqJZu")) != EOF) {
+    while ((opt = getopt(argc, argv, "C:d:fqJnZu")) != EOF) {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;


### PR DESCRIPTION
The `-n` flag for `quota` was implemented and documented in 23d6ef9, but not actually accepted.

Actual result:
```
$ cyrus/sbin/quota -f -n -q
cyrus/sbin/quota: illegal option -- n
usage: quota [-C <alt_config>] [-d <domain>] [-f] [-q] [-J] [-n] [-u] [mailbox-spec]...
```

Expected result:
```
$ cyrus/sbin/quota -f -n -q
user.test: MESSAGE usage was 0, now 189
…
```

Tested on macOS 12.4.