### PR TITLE
jmap_calendar: fix position argument for CalendarEvent/query fastpath

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-query-fastpath-position
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-query-fastpath-position
@@ -1,0 +1,54 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_query_fastpath_position
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+     my $using = [
+         'urn:ietf:params:jmap:core',
+         'urn:ietf:params:jmap:calendars',
+         'https://cyrusimap.org/ns/jmap/calendars',
+         'https://cyrusimap.org/ns/jmap/debug',
+     ];
+
+    my $events = {};
+
+    for my $i (0..9) {
+        $events->{"event$i"} = {
+            calendarIds => {
+                'Default' => JSON::true,
+            },
+            title => "event$i",
+            start => "2021-01-01T02:00:00",
+            timeZone => 'Europe/Berlin',
+            duration => 'PT1H',
+        };
+    }
+
+	my $numEvents = scalar keys %$events;
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => $events,
+        }, 'R1'],
+        ['CalendarEvent/query', {
+        }, 'R2'],
+    ], $using);
+    $self->assert_num_equals($numEvents, scalar keys %{$res->[0][1]{created}});
+
+    my $eventIds = $res->[1][1]{ids};
+    $self->assert_num_equals($numEvents, scalar @${eventIds});
+    $self->assert_equals(JSON::true, $res->[1][1]{debug}{isFastPath});
+
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/query', {
+			position => 3,
+        }, 'R1'],
+    ], $using);
+    my @wantIds = @{$eventIds}[3 .. ($numEvents-1)];
+    $self->assert_deep_equals(\@wantIds, $res->[0][1]{ids});
+    $self->assert_equals(JSON::true, $res->[0][1]{debug}{isFastPath});
+}


### PR DESCRIPTION
The conditional that sliced the query window by position was backwards,
so any positive position value returned an empty window.