### PR TITLE
Sieve: protect against missing/invalid sievedir

### DIFF
--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -127,6 +127,16 @@ static jmap_method_t jmap_sieve_methods_nonstandard[] = {
 
 HIDDEN void jmap_sieve_init(jmap_settings_t *settings)
 {
+    if (config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR)) {
+        xsyslog(LOG_NOTICE, "%s", "can't use home directories");
+        return;
+    }
+
+    if (!sievedir_valid_path(config_getstring(IMAPOPT_SIEVEDIR))) {
+        xsyslog(LOG_NOTICE, "%s", "sievedir option is not defined/valid");
+        return;
+    }
+
     jmap_method_t *mp;
     for (mp = jmap_sieve_methods_standard; mp->name; mp++) {
         hash_insert(mp->name, mp, &settings->methods);

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -128,12 +128,12 @@ static jmap_method_t jmap_sieve_methods_nonstandard[] = {
 HIDDEN void jmap_sieve_init(jmap_settings_t *settings)
 {
     if (config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR)) {
-        xsyslog(LOG_NOTICE, "%s", "can't use home directories");
+        xsyslog(LOG_NOTICE, "can't use home directories", NULL);
         return;
     }
 
     if (!sievedir_valid_path(config_getstring(IMAPOPT_SIEVEDIR))) {
-        xsyslog(LOG_NOTICE, "%s", "sievedir option is not defined/valid");
+        xsyslog(LOG_NOTICE, "sievedir option is not defined/valid", NULL);
         return;
     }
 

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -128,12 +128,15 @@ static jmap_method_t jmap_sieve_methods_nonstandard[] = {
 HIDDEN void jmap_sieve_init(jmap_settings_t *settings)
 {
     if (config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR)) {
-        xsyslog(LOG_NOTICE, "can't use home directories", NULL);
+        xsyslog(LOG_NOTICE,
+                "can't use home directories -- disabling module", NULL);
         return;
     }
 
     if (!sievedir_valid_path(config_getstring(IMAPOPT_SIEVEDIR))) {
-        xsyslog(LOG_NOTICE, "sievedir option is not defined/valid", NULL);
+        xsyslog(LOG_NOTICE,
+                "sievedir option is not defined or invalid -- disabling module",
+                NULL);
         return;
     }
 

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -128,13 +128,13 @@ static jmap_method_t jmap_sieve_methods_nonstandard[] = {
 HIDDEN void jmap_sieve_init(jmap_settings_t *settings)
 {
     if (config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR)) {
-        xsyslog(LOG_NOTICE,
+        xsyslog(LOG_WARNING,
                 "can't use home directories -- disabling module", NULL);
         return;
     }
 
     if (!sievedir_valid_path(config_getstring(IMAPOPT_SIEVEDIR))) {
-        xsyslog(LOG_NOTICE,
+        xsyslog(LOG_WARNING,
                 "sievedir option is not defined or invalid -- disabling module",
                 NULL);
         return;

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -2200,8 +2200,8 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     sieve_usehomedir = config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR);
     if (!sieve_usehomedir) {
         if (!sievedir_valid_path(config_getstring(IMAPOPT_SIEVEDIR))) {
-            xsyslog(LOG_ERR, "sievedir option is not defined/valid", NULL);
-            fatal("sievedir option is not defined/valid", EX_SOFTWARE);
+            xsyslog(LOG_ERR, "sievedir option is not defined or invalid", NULL);
+            fatal("sievedir option is not defined or invalid", EX_SOFTWARE);
         }
     }
 

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -87,7 +87,6 @@
 #include "imap/lmtp_err.h"
 
 static int sieve_usehomedir = 0;
-static const char *sieve_dir = NULL;
 
 /* data per script */
 typedef struct script_data {
@@ -2200,9 +2199,10 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
 
     sieve_usehomedir = config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR);
     if (!sieve_usehomedir) {
-        sieve_dir = config_getstring(IMAPOPT_SIEVEDIR);
-    } else {
-        sieve_dir = NULL;
+        if (!sievedir_valid_path(config_getstring(IMAPOPT_SIEVEDIR))) {
+            xsyslog(LOG_ERR, "%s", "sievedir option is not defined/valid");
+            fatal("sievedir option is not defined/valid", EX_SOFTWARE);
+        }
     }
 
     interp = sieve_interp_alloc(ctx);

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -2200,7 +2200,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     sieve_usehomedir = config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR);
     if (!sieve_usehomedir) {
         if (!sievedir_valid_path(config_getstring(IMAPOPT_SIEVEDIR))) {
-            xsyslog(LOG_ERR, "%s", "sievedir option is not defined/valid");
+            xsyslog(LOG_ERR, "sievedir option is not defined/valid", NULL);
             fatal("sievedir option is not defined/valid", EX_SOFTWARE);
         }
     }

--- a/imap/sievedir.h
+++ b/imap/sievedir.h
@@ -85,4 +85,6 @@ int sievedir_delete_script(const char *sievedir, const char *name);
 int sievedir_rename_script(const char *sievedir,
                            const char *oldname, const char *newname);
 
+int sievedir_valid_path(const char *sievedir);
+
 #endif /* INCLUDED_SIEVEDIR_H */

--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -92,7 +92,7 @@ int actions_init(void)
     if (!sieve_usehomedir) {
         sieve_dir_config = (char *) config_getstring(IMAPOPT_SIEVEDIR);
         if (!sievedir_valid_path(sieve_dir_config)) {
-            xsyslog(LOG_ERR, "sievedir option is not defined/valid", NULL);
+            xsyslog(LOG_ERR, "sievedir option is not defined on invalid", NULL);
         }
     } else {
         /* can't use home directories with timsieved */

--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -92,7 +92,9 @@ int actions_init(void)
     if (!sieve_usehomedir) {
         sieve_dir_config = (char *) config_getstring(IMAPOPT_SIEVEDIR);
         if (!sievedir_valid_path(sieve_dir_config)) {
-            xsyslog(LOG_ERR, "sievedir option is not defined on invalid", NULL);
+            xsyslog(LOG_ERR, "sievedir option is not defined or invalid", NULL);
+
+            return TIMSIEVE_FAIL;
         }
     } else {
         /* can't use home directories with timsieved */

--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -91,9 +91,12 @@ int actions_init(void)
 
     if (!sieve_usehomedir) {
         sieve_dir_config = (char *) config_getstring(IMAPOPT_SIEVEDIR);
+        if (!sievedir_valid_path(sieve_dir_config)) {
+            xsyslog(LOG_ERR, "%s", "sievedir option is not defined/valid");
+        }
     } else {
         /* can't use home directories with timsieved */
-        syslog(LOG_ERR, "can't use home directories");
+        xsyslog(LOG_ERR, "%s", "can't use home directories");
 
         return TIMSIEVE_FAIL;
     }

--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -92,11 +92,11 @@ int actions_init(void)
     if (!sieve_usehomedir) {
         sieve_dir_config = (char *) config_getstring(IMAPOPT_SIEVEDIR);
         if (!sievedir_valid_path(sieve_dir_config)) {
-            xsyslog(LOG_ERR, "%s", "sievedir option is not defined/valid");
+            xsyslog(LOG_ERR, "sievedir option is not defined/valid", NULL);
         }
     } else {
         /* can't use home directories with timsieved */
-        xsyslog(LOG_ERR, "%s", "can't use home directories");
+        xsyslog(LOG_ERR, "can't use home directories", NULL);
 
         return TIMSIEVE_FAIL;
     }


### PR DESCRIPTION
We had a case where dav_reconstruct tried to create a bytecode file in root