### PR TITLE
HTTPPTS: don't leak server port

### DIFF
--- a/cassandane/Cassandane/Cyrus/HTTPPTS.pm
+++ b/cassandane/Cassandane/Cyrus/HTTPPTS.pm
@@ -122,6 +122,10 @@ sub tear_down
 {
     my ($self) = @_;
 
+    # clean this up as soon as we're done with it, cause it's holding a
+    # port open!
+    delete $self->{server};
+
     $self->SUPER::tear_down();
 }
 


### PR DESCRIPTION
Fixes an issue where tests that ran after `HTTPPTS` and `Idle` would experience "port already in use" errors.

The first part of the problem (which this PR fixes) was that the port in use as the server test url was being leaked.  The object is allocated and assigned to `$self->{server}` in `set_up()`, but was not removed in `tear_down()`.  If it weren't for the port resource, this wouldn't be a problem, it all gets cleaned up later anyway.  But for a test's `$self`, "later" is quite late!  And in the meantime, other tests have tried to run, and been confused by the port still being in use.  Cleaning it up explicitly in `tear_down()` means it's freed as soon as it's no longer in use, instead of hanging around.

Theoretically, PortManager should have prevented this sort of thing from being a problem, by not re-using the port numbers while they were still in use.  Not sure exactly how `Idle` amplifies it into a real problem, but it has a few tricky tests that kill things early, and maybe they don't take enough care in doing so.

Anyway, doing the right thing, and balancing the object creation in `set_up()` with a corresponding destruction in `tear_down()`, stops the problem occurring in the first place.