### PR TITLE
ical_support.c: don't dereference a NULL string

### DIFF
--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -2961,10 +2961,12 @@ EXPORTED void icalcomponent_add_required_timezones(icalcomponent *ical)
 EXPORTED int ical_categories_is_color(icalproperty *cprop)
 {
     const char *categories = icalproperty_get_categories(cprop);
-    int i;
+
+    if (!categories) return 0;
 
     if (categories[0] == '#') {
         /* Is this #RRGGBB */
+        int i;
         for (i = 1; i <= 6 && isxdigit(categories[i]); i++);
 
         return (i == 7 && categories[7] == '\0');


### PR DESCRIPTION
*Should* fix a crasher seen in production