### PR TITLE
HTTP: add missing SEARCH method processors to all namespaces

### DIFF
--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -118,6 +118,7 @@ struct namespace_t namespace_admin = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -82,6 +82,7 @@ struct namespace_t namespace_applepush = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { NULL,                 NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -646,6 +646,7 @@ struct namespace_t namespace_calendar = {
         { &meth_proppatch,      &caldav_params },       /* PROPPATCH    */
         { &meth_put,            &caldav_params },       /* PUT          */
         { &meth_report,         &caldav_params },       /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          &caldav_parse_path },   /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { &meth_unlock,         &caldav_params }        /* UNLOCK       */

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -389,6 +389,7 @@ struct namespace_t namespace_addressbook = {
         { &meth_proppatch,      &carddav_params },      /* PROPPATCH    */
         { &meth_put,            &carddav_params },      /* PUT          */
         { &meth_report,         &carddav_params },      /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          &carddav_parse_path },  /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { &meth_unlock,         &carddav_params }       /* UNLOCK       */

--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -95,6 +95,7 @@ struct namespace_t namespace_cgi = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -322,6 +322,7 @@ struct namespace_t namespace_principal = {
         { &meth_proppatch,      &princ_params },        /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { &meth_report,         &princ_params },        /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -294,6 +294,7 @@ struct namespace_t namespace_notify = {
         { NULL,                 NULL },                /* PROPPATCH    */
         { NULL,                 NULL },                /* PUT          */
         { &meth_report,         &notify_params },      /* REPORT       */
+        { NULL,                 NULL },                /* SEARCH       */
         { &meth_trace,          &notify_parse_path },  /* TRACE        */
         { NULL,                 NULL },                /* UNBIND       */
         { NULL,                 NULL },                /* UNLOCK       */

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -81,6 +81,7 @@ struct namespace_t namespace_dblookup = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { NULL,                 NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -141,6 +141,7 @@ struct namespace_t namespace_ischedule = {
         { NULL,                 NULL }, /* PROPPATCH    */
         { NULL,                 NULL }, /* PUT          */
         { NULL,                 NULL }, /* REPORT       */
+        { NULL,                 NULL }, /* SEARCH       */
         { &meth_trace,          NULL }, /* TRACE        */
         { NULL,                 NULL }, /* UNBIND       */
         { NULL,                 NULL }  /* UNLOCK       */

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -136,6 +136,7 @@ struct namespace_t namespace_jmap = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_prometheus.c
+++ b/imap/http_prometheus.c
@@ -88,6 +88,7 @@ struct namespace_t namespace_prometheus = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL },                 /* UNLOCK       */

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -132,6 +132,7 @@ struct namespace_t namespace_rss = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          &rss_parse_path },      /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -155,6 +155,7 @@ struct namespace_t namespace_tzdist = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL }                  /* UNLOCK       */

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -284,6 +284,7 @@ struct namespace_t namespace_drive = {
         { &meth_proppatch,      &webdav_params },      /* PROPPATCH    */
         { &meth_put,            &webdav_params },      /* PUT          */
         { &meth_report,         &webdav_params },      /* REPORT       */
+        { NULL,                 NULL },                /* SEARCH       */
         { &meth_trace,          &webdav_parse_path },  /* TRACE        */
         { NULL,                 NULL },                /* UNBIND       */
         { &meth_unlock,         &webdav_params }       /* UNLOCK       */

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -569,6 +569,7 @@ static struct namespace_t namespace_default = {
         { NULL,                 NULL },                 /* PROPPATCH    */
         { NULL,                 NULL },                 /* PUT          */
         { NULL,                 NULL },                 /* REPORT       */
+        { NULL,                 NULL },                 /* SEARCH       */
         { &meth_trace,          NULL },                 /* TRACE        */
         { NULL,                 NULL },                 /* UNBIND       */
         { NULL,                 NULL },                 /* UNLOCK       */


### PR DESCRIPTION
This was causing TRACE, and more importantly, *DAV UNLOCK to fail