### PR TITLE
Reserve mailbox name (mbentry) before mailbox creation

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5691,7 +5691,7 @@ EXPORTED int mailbox_create(const char *name,
     int createfnames[] = { META_INDEX, META_HEADER, 0 };
     struct mailboxlist *listitem;
 
-    if (!uniqueid) uniqueid = makeuuid();
+    assert(uniqueid);
 
     /* if we already have this name open then that's an error too */
     listitem = find_listitem(name);
@@ -5776,26 +5776,6 @@ EXPORTED int mailbox_create(const char *name,
                          fname);
         r = IMAP_IOERROR;
         goto done;
-    }
-
-    /* create initial mbentry for new users --
-       the uniqueid in the record is required to open
-       user metadata files (conversations, counters) */
-    if (mboxname_isusermailbox(mailbox_name(mailbox), 1) &&
-        mboxlist_lookup_by_uniqueid(mailbox_uniqueid(mailbox), NULL, NULL) != 0) {
-        mbentry_t mbentry;
-
-        memset(&mbentry, 0, sizeof(mbentry_t));
-        mbentry.mbtype = mbtype | MBTYPE_INTERMEDIATE;
-        mbentry.name = (char *)mailbox_name(mailbox);
-        mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
-        r = mboxlist_update(&mbentry, 1 /* localonly */);
-        if (r) {
-            syslog(LOG_ERR, "IOERROR: creating initial mbentry %s %s",
-                   mailbox_name(mailbox), error_message(r));
-            r = IMAP_IOERROR;
-            goto done;
-        }
     }
 
     fname = mailbox_meta_fname(mailbox, META_INDEX);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1895,22 +1895,32 @@ EXPORTED int mboxlist_createmailbox(const mbentry_t *mbentry,
     else if (config_getswitch(IMAPOPT_MAILBOX_LEGACY_DIRS))
         mbtype |= MBTYPE_LEGACY_DIRS;
 
+    newmbentry = mboxlist_entry_create();
+    newmbentry->acl = xstrdupnull(acl);
+    newmbentry->mbtype = mbtype | MBTYPE_RESERVE;
+    newmbentry->partition = xstrdupnull(newpartition);
+    newmbentry->uniqueid = xstrdup(uniqueid ? uniqueid : makeuuid());
+
     if (!(flags & MBOXLIST_CREATE_DBONLY) && !isremote) {
-        /* Filesystem Operations */
-        r = mailbox_create(mboxname, mbtype, newpartition, acl, uniqueid,
-                           options, uidvalidity, createdmodseq, highestmodseq, &newmailbox);
-        if (r) goto done; /* CREATE failed */
-        r = mailbox_add_conversations(newmailbox, /*silent*/0);
+        /* Reserve the mailbox - we need this so that mboxname_conf_getpath()
+           during mailbox_create() will find an mbentry with uniqueid */
+        r = mboxlist_update_entry(mboxname, newmbentry, NULL);
         if (r) goto done;
+
+        /* Filesystem Operations */
+        r = mailbox_create(mboxname, mbtype, newpartition, acl, newmbentry->uniqueid,
+                           options, uidvalidity, createdmodseq, highestmodseq, &newmailbox);
+        if (!r) r = mailbox_add_conversations(newmailbox, /*silent*/0);
+        if (r) {
+            /* CREATE failed - remove mbentry */
+            mboxlist_delete(newmbentry);
+            goto done;
+        }
     }
 
     /* all is well - activate the mailbox */
-    newmbentry = mboxlist_entry_create();
-    newmbentry->acl = xstrdupnull(acl);
     newmbentry->mbtype = mbtype;
-    newmbentry->partition = xstrdupnull(newpartition);
     if (newmailbox) {
-        newmbentry->uniqueid = xstrdupnull(mailbox_uniqueid(newmailbox));
         newmbentry->uidvalidity = newmailbox->i.uidvalidity;
         newmbentry->createdmodseq = newmailbox->i.createdmodseq;
         newmbentry->foldermodseq = foldermodseq ? foldermodseq : newmailbox->i.highestmodseq;


### PR DESCRIPTION
Thinking that this might solve the issue of conv.db being created by name rather than by uuid when replicating a new user INBOX