### PR TITLE
ctl_zoneinfo.c: avoid calling readdir(NULL)

### DIFF
--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -347,6 +347,7 @@ void do_zonedir(const char *dir, struct hash_table *tzentries,
     dirp = opendir(dir);
     if (!dirp) {
         fprintf(stderr, "can't open zoneinfo directory %s\n", dir);
+        return;
     }
 
     while ((dirent = readdir(dirp))) {


### PR DESCRIPTION
This avoids a clang-warning, since readdir() has a `nonnull` attribute.

Closes https://github.com/cyrusimap/cyrus-imapd/issues/4148