### PR TITLE
http_caldav: add defaults alerts to events fetched with multi-get

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-multiget-defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-multiget-defaultalerts
@@ -1,0 +1,163 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_multiget_defaultalerts
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    xlog "share calendar";
+    my ($shareeJmap, $shareeCaldav) = $self->create_user('sharee');
+    my $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            update => {
+                Default => {
+                    shareWith => {
+                        sharee => {
+                            mayReadItems => JSON::true,
+                            mayWriteAll => JSON::true,
+                        },
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{Default});
+
+    xlog "Set default alert on calendar and personalized event";
+    my $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            update => {
+                Default => {
+                    defaultAlertsWithTime => {
+                        alert1 => {
+                            '@type' => 'Alert',
+                            trigger => {
+                                '@type' => 'OffsetTrigger',
+                                relativeTo => 'start',
+                                offset => '-PT5M',
+                            },
+                            action => 'display',
+                        },
+                    },
+                }
+            }
+        }, 'R1'],
+        ['CalendarEvent/set', {
+            create => {
+                1 => {
+                    uid => '5f0dec98-8952-418e-91fa-159cb2ba28da',
+                    calendarIds => {
+                        Default => JSON::true,
+                    },
+                    title => "event1",
+                    start => "2020-01-19T11:00:00",
+                    duration => "PT1H",
+                    timeZone => "Australia/Melbourne",
+                    useDefaultAlerts => JSON::true,
+                },
+            },
+        }, 'R2'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{Default});
+    my $eventId = $res->[1][1]{created}{1}{id};
+    $self->assert_not_null($eventId);
+    my $eventHref = $res->[1][1]{created}{1}{'x-href'};
+    $self->assert_not_null($eventHref);
+
+    xlog "Set per-user property to force per-user data split";
+    $res = $shareeJmap->CallMethods([
+        ['CalendarEvent/set', {
+            accountId => 'cassandane',
+            update => {
+                $eventId => {
+                    color => 'red',
+                }
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog "Assert alerts and ETag";
+
+    my $xmlMultiget = <<EOF;
+<?xml version="1.0" encoding="utf-8" ?>
+<C:calendar-multiget xmlns:D="DAV:"
+             xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:prop>
+    <D:getetag/>
+    <C:calendar-data/>
+  </D:prop>
+  <D:href>$eventHref</D:href>
+</C:calendar-multiget>
+EOF
+
+    xlog "Run multiget";
+    $mgRes = $caldav->Request('REPORT', 'Default', $xmlMultiget,
+        'Content-Type' => 'application/xml',
+    );
+    my $icaldata = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{urn:ietf:params:xml:ns:caldav}calendar-data'}{content};
+    $self->assert_matches(qr/TRIGGER;RELATED=START:-PT5M/, $icaldata);
+    my $mgEtag = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{DAV:}getetag'}{content};
+    $self->assert_not_null($mgEtag);
+
+    my $xmlCalQuery = <<EOF;
+<?xml version="1.0" encoding="utf-8" ?>
+<C:calendar-query xmlns:D="DAV:"
+                  xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:prop>
+    <D:getetag/>
+  </D:prop>
+</C:calendar-query>
+EOF
+
+    xlog "Run calendar query";
+    $qrRes = $caldav->Request('REPORT', 'Default', $xmlCalQuery,
+        'Content-Type' => 'application/xml',
+    );
+    my $qrEtag = $qrRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{DAV:}getetag'}{content};
+    $self->assert_str_equals($mgEtag, $qrEtag);
+
+    xlog "Update default alerts";
+    $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            update => {
+                Default => {
+                    defaultAlertsWithTime => {
+                        alert1 => {
+                            '@type' => 'Alert',
+                            trigger => {
+                                '@type' => 'OffsetTrigger',
+                                relativeTo => 'start',
+                                offset => '-PT15M',
+                            },
+                            action => 'display',
+                        },
+                    },
+                }
+            }
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{Default});
+
+    xlog "Assert iCalendar data and ETags changed";
+
+    xlog "Run multiget";
+    $mgRes = $caldav->Request('REPORT', 'Default', $xmlMultiget,
+        'Content-Type' => 'application/xml',
+    );
+    my $icaldata = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{urn:ietf:params:xml:ns:caldav}calendar-data'}{content};
+    $self->assert_matches(qr/TRIGGER;RELATED=START:-PT15M/, $icaldata);
+    my $newMgEtag = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{DAV:}getetag'}{content};
+    $self->assert_str_not_equals($mgEtag, $newMgEtag);
+
+    xlog "Run calendar query";
+    $qrRes = $caldav->Request('REPORT', 'Default', $xmlCalQuery,
+        'Content-Type' => 'application/xml',
+    );
+    my $newQrEtag = $qrRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{DAV:}getetag'}{content};
+    $self->assert_str_equals($newMgEtag, $newQrEtag);
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-multiget-defaultalerts-per-calendar
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-multiget-defaultalerts-per-calendar
@@ -1,0 +1,125 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_multiget_defaultalerts_per_calendar
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    xlog "Create two calendars with default alerts";
+    my $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            create => {
+                calendarA => {
+                    name => 'calendarA',
+                    defaultAlertsWithTime => {
+                        alert1 => {
+                            '@type' => 'Alert',
+                            trigger => {
+                                '@type' => 'OffsetTrigger',
+                                relativeTo => 'start',
+                                offset => '-PT1H',
+                            },
+                            action => 'display',
+                        },
+                    },
+                },
+                calendarB => {
+                    name => 'calendarB',
+                    defaultAlertsWithTime => {
+                        alert1 => {
+                            '@type' => 'Alert',
+                            trigger => {
+                                '@type' => 'OffsetTrigger',
+                                relativeTo => 'start',
+                                offset => '-PT2H',
+                            },
+                            action => 'display',
+                        },
+                    },
+                }
+            }
+        }, 'R1'],
+    ]);
+    my $calendarAId = $res->[0][1]{created}{calendarA}{id};
+    $self->assert_not_null($calendarAId);
+    my $calendarBId = $res->[0][1]{created}{calendarB}{id};
+    $self->assert_not_null($calendarBId);
+
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                eventA1 => {
+                    uid => '5f0dec98-8952-418e-91fa-159cb2ba28da',
+                    calendarIds => {
+                        $calendarAId => JSON::true,
+                    },
+                    title => "eventA1",
+                    start => "2020-01-19T11:00:00",
+                    duration => "PT1H",
+                    timeZone => "Australia/Melbourne",
+                    useDefaultAlerts => JSON::true,
+                },
+                eventA2 => {
+                    uid => '68b31869-889e-49f2-ac6a-f94ce0179635',
+                    calendarIds => {
+                        $calendarAId => JSON::true,
+                    },
+                    title => "eventA2",
+                    start => "2020-01-19T11:00:00",
+                    duration => "PT1H",
+                    timeZone => "Australia/Melbourne",
+                    useDefaultAlerts => JSON::true,
+                },
+                eventB1 => {
+                    uid => 'b58fcc34-aca6-4ae5-a7d0-97411d1166a4',
+                    calendarIds => {
+                        $calendarBId => JSON::true,
+                    },
+                    title => "eventB1",
+                    start => "2020-01-19T11:00:00",
+                    duration => "PT1H",
+                    timeZone => "Australia/Melbourne",
+                    useDefaultAlerts => JSON::true,
+                },
+            },
+        }, 'R1'],
+    ]);
+
+    my $eventA1Href = $res->[0][1]{created}{eventA1}{'x-href'};
+    $self->assert_not_null($eventA1Href);
+    my $eventA2Href = $res->[0][1]{created}{eventA2}{'x-href'};
+    $self->assert_not_null($eventA2Href);
+    my $eventB1Href = $res->[0][1]{created}{eventB1}{'x-href'};
+    $self->assert_not_null($eventB1Href);
+
+    xlog "Assert alerts and ETag";
+    my $xml = <<EOF;
+<?xml version="1.0" encoding="utf-8" ?>
+<C:calendar-multiget xmlns:D="DAV:"
+             xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:prop>
+    <D:getetag/>
+    <C:calendar-data/>
+  </D:prop>
+  <D:href>$eventA1Href</D:href>
+  <D:href>$eventA2Href</D:href>
+  <D:href>$eventB1Href</D:href>
+</C:calendar-multiget>
+EOF
+    $res = $caldav->Request('REPORT', 'Default', $xml,
+        'Content-Type' => 'application/xml',
+    );
+
+    my %icaldataPerHref = map {
+        $_->{'{DAV:}href'}{content} => $_->{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{urn:ietf:params:xml:ns:caldav}calendar-data'}{content}
+    } @{$res->{'{DAV:}response'}};
+
+
+    $self->assert_matches(qr/TRIGGER;RELATED=START:-PT1H/, $icaldataPerHref{$eventA1Href});
+    $self->assert_matches(qr/TRIGGER;RELATED=START:-PT1H/, $icaldataPerHref{$eventA2Href});
+    $self->assert_matches(qr/TRIGGER;RELATED=START:-PT2H/, $icaldataPerHref{$eventB1Href});
+}

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -160,7 +160,7 @@ EXPORTED void add_personal_data(icalcomponent *ical, struct buf *userdata)
 EXPORTED int caldav_read_usedefaultalerts(struct dlist *dl,
                                           struct mailbox *mailbox,
                                           const struct index_record *record,
-                                          icalcomponent **icalp)
+                                          icalcomponent *ical)
 {
     /* Read from annotation */
     if (dl) {
@@ -179,10 +179,7 @@ EXPORTED int caldav_read_usedefaultalerts(struct dlist *dl,
     }
 
     /* Read from client-supplied iCalendar data */
-    if (icalp && *icalp) {
-        int ret = icalcomponent_read_usedefaultalerts(*icalp);
-        if (ret >= 0) return ret;
-    }
+    if (ical) return icalcomponent_read_usedefaultalerts(ical);
 
     /* Read from record */
     if (!mailbox || !record) return 0;
@@ -192,10 +189,7 @@ EXPORTED int caldav_read_usedefaultalerts(struct dlist *dl,
 
     if (dl) add_personal_data_from_dl(myical, dl);
     ret = icalcomponent_read_usedefaultalerts(myical);
-    if (icalp) {
-        *icalp = myical;
-    }
-    else icalcomponent_free(myical);
+    icalcomponent_free(myical);
 
     return ret >= 0 ? ret : 0;
 }
@@ -280,12 +274,10 @@ EXPORTED int caldav_get_validators(struct mailbox *mailbox, void *data,
             message_guid_export(user_guid, buf+MESSAGE_GUID_SIZE);
 
             /* Read default alarm GUID from per-user data */
-            icalcomponent *ical = NULL;
-            int defaultalerts = caldav_read_usedefaultalerts(dl, mailbox, record, &ical);
+            int defaultalerts = caldav_read_usedefaultalerts(dl, mailbox, record, NULL);
             if (defaultalerts) {
                 add_defaultalarm_guid(mailbox_name(mailbox), userid, buf, &buf_len);
             }
-            icalcomponent_free(ical);
 
             /* Generate ETag */
             message_guid_generate(user_guid, buf, buf_len);

--- a/imap/caldav_util.h
+++ b/imap/caldav_util.h
@@ -167,7 +167,7 @@ extern void caldav_format_defaultalarms_annot(struct buf *dst, const char *icals
 extern int caldav_read_usedefaultalerts(struct dlist *dl,
                                         struct mailbox *mailbox,
                                         const struct index_record *record,
-                                        icalcomponent **icalp);
+                                        icalcomponent *ical);
 
 extern int caldav_is_secretarymode(const char *mboxname);
 

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5295,7 +5295,7 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
     const char *data = NULL;
     size_t datalen = 0;
 
-    if (!fctx) {
+    if (!prop) {
         /* Cleanup "property" request - free partial component structure */
         struct partial_comp_t *pcomp, *child, *sibling;
 

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2434,7 +2434,7 @@ static void personalize_and_add_defaultalerts(struct mailbox *mailbox,
         if (caldav_is_personalized(mailbox, cdata, httpd_userid, &userdata)) {
             dlist_parsemap(&dl, 1, 0, buf_base(&userdata), buf_len(&userdata));
             add_personal_data_from_dl(ical, dl);
-            has_defaultalerts = caldav_read_usedefaultalerts(dl, mailbox, record, &ical);
+            has_defaultalerts = caldav_read_usedefaultalerts(dl, mailbox, record, ical);
         }
     }
 

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1576,7 +1576,7 @@ static int propfind_addrdata(const xmlChar *name, xmlNsPtr ns,
     const char *data = NULL;
     size_t datalen = 0;
 
-    if (!fctx) {
+    if (!prop) {
         /* Cleanup "property" request - free partial property array */
         strarray_fini(partial);
 

--- a/imap/http_dav.h
+++ b/imap/http_dav.h
@@ -273,6 +273,7 @@ struct propfind_ctx {
     struct fctx_flags_t flags;          /* Return flags for this propfind */
     struct buf buf;                     /* Working buffer */
     xmlBufferPtr xmlbuf;                /* Buffer for dumping XML nodes */
+    hash_table per_prop_data;           /* Callback data by prop name */
 };
 
 /* Context for patching (writing) properties */
@@ -634,7 +635,7 @@ int expand_property(xmlNodePtr inroot, struct propfind_ctx *fctx,
                     xmlNodePtr root, int depth);
 
 int preload_proplist(xmlNodePtr proplist, struct propfind_ctx *fctx);
-void free_entry_list(struct propfind_entry_list *elist);
+void free_entry_list(struct propfind_ctx *fctx);
 
 void dav_precond_as_string(struct buf *buf, struct error_t *err);
 

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -1781,7 +1781,7 @@ HIDDEN int propfind_csnotify_collection(struct propfind_ctx *fctx,
     mboxlist_entry_free(&tgt.mbentry);
 
     /* Free the entry list */
-    free_entry_list(my_fctx.elist);
+    free_entry_list(&my_fctx);
 
     buf_free(&my_fctx.buf);
 

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -2289,6 +2289,10 @@ EXPORTED void icalcomponent_add_defaultalerts(icalcomponent *ical,
 
             icalcomponent *alerts = is_date ?  withdate : withtime;
 
+            /* Ignore empty list of default alerts */
+            if (!icalcomponent_get_first_component(alerts, ICAL_VALARM_COMPONENT))
+                break;
+
             /* Remove VALARMs in component */
             icalcomponent *curr, *next = NULL;
             for (curr = icalcomponent_get_first_component(comp, ICAL_VALARM_COMPONENT);


### PR DESCRIPTION
 Several CalDAV clients fetch events with the multi-get REPORT,
 but up until now the returned iCalendar data did not contain
 the default alerts that were set by the user.