### PR TITLE
ctl_cyrusdb -r ("recover") uniqueid safety

### DIFF
--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -40,11 +40,13 @@
 package Cassandane::Cyrus::CyrusDB;
 use strict;
 use warnings;
+use Data::Dumper;
 
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;
+use Cyrus::DList;
 
 sub new
 {
@@ -116,6 +118,76 @@ sub test_mboxlistdb_skiplist
     $self->{instance}->start();
 
     # 'ctl_cyrusdb -r' will run on startup, and it should not crash!
+}
+
+sub test_recover_uniqueid_from_header_legacymb
+    :min_version_3_6 :MailboxLegacyDirs
+{
+    my ($self) = @_;
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+
+    # first start will set up cassandane user
+    $self->_start_instances();
+    my $basedir = $self->{instance}->get_basedir();
+    my $mailboxes_db = "$basedir/conf/mailboxes.db";
+    $self->assert(-f $mailboxes_db, "$mailboxes_db not present");
+
+    # find out the uniqueid of the inbox
+    my $imaptalk = $self->{store}->get_client();
+    my $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    my $uniqueid = $res->{INBOX}{$entry};
+    xlog "XXX got uniqueid: " . Dumper \$uniqueid;
+    $self->assert_not_null($uniqueid);
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    # stop service while tinkering
+    $self->{instance}->stop();
+    $self->{instance}->{re_use_dir} = 1;
+
+    # lose that uniqueid from mailboxes.db
+    my $I = "I$uniqueid";
+    my $N = "Nuser\x1fcassandane";
+    $self->{instance}->run_dbcommand($mailboxes_db, "twoskip",
+                                     [ 'DELETE', $I ]);
+    my (undef, $mbentry) = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        ['SHOW', $N]);
+    my $dlist = Cyrus::DList->parse_string($mbentry);
+    my $hash = $dlist->as_perl();
+    $self->assert_str_equals($uniqueid, $hash->{I});
+    $hash->{I} = undef;
+    $dlist = Cyrus::DList->new_perl('', $hash);
+    $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip",
+        [ 'SET', $N, $dlist->as_string() ]);
+
+    my %updated = $self->{instance}->run_dbcommand(
+        $mailboxes_db, "twoskip", ['SHOW']);
+    xlog "updated mailboxes.db: " . Dumper \%updated;
+
+    # bring service back up
+    # ctl_cyrusdb -r should find and fix the missing uniqueid
+    $self->{instance}->getsyslog();
+    $self->{instance}->start();
+    my $syslog = join(q{}, $self->{instance}->getsyslog());
+
+    # should have still existed in cyrus.header
+    $self->assert_does_not_match(
+        qr{mailbox header had no uniqueid, creating one}, $syslog);
+
+    # expect to find the log line
+    $self->assert_matches(qr{mbentry had no uniqueid, setting from header},
+                          $syslog);
+
+    # should be the same uniqueid as before
+    $imaptalk = $self->{store}->get_client();
+    $res = $imaptalk->getmetadata("INBOX", $entry);
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_not_null($res);
+    $self->assert_str_equals($uniqueid, $res->{INBOX}{$entry});
 }
 
 1;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1505,6 +1505,15 @@ sub send_sighup
     return 1;
 }
 
+#
+# n.b. If you are stopping the instance intending to restart it again later,
+# you must set:
+#     $instance->{'re_use_dir'} => 1
+# before restarting, otherwise it will wipe and re-initialise its basedir
+# during startup, probably ruining whatever you were trying to do.  It
+# will still use the same directory name though, so it won't be obvious
+# from the logs that this is happening!
+#
 sub stop
 {
     my ($self) = @_;

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -164,8 +164,8 @@ static int fixmbox(const mbentry_t *mbentry,
         mboxlist_entry_free(&copy);
     }
 
-    /* make sure every mbentry has a uniqueid!  */
-    if (!mbentry->uniqueid) {
+    /* make sure every local mbentry has a uniqueid!  */
+    if (!mbentry->uniqueid && mbentry_is_local_mailbox(mbentry)) {
         struct mailbox *mailbox = NULL;
         mbentry_t *copy = NULL;
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1065,6 +1065,14 @@ static int mailbox_open_advanced(const char *name,
         return r;
     }
 
+    if (!mbentry->uniqueid) {
+        /* Theoretically it shouldn't be possible for an mbentry to not
+         * have a uniqueid... so if it happens, complain loudly.
+         */
+        xsyslog(LOG_ERR, "mbentry has no uniqueid, needs reconstruct",
+                         "mboxname=<%s>", name);
+    }
+
     uint32_t legacy_dirs = (mbentry->mbtype & MBTYPE_LEGACY_DIRS);
     r = mboxname_lock(legacy_dirs ? name : mbentry->uniqueid, &listitem->l, locktype);
     if (r) {
@@ -1553,7 +1561,12 @@ static int mailbox_read_header(struct mailbox *mailbox)
         if (!tab || tab > eol) tab = eol;
         mailbox->h.uniqueid = xstrndup(p, tab - p);
     }
-    /* else, uniqueid needs to be generated when we know the uidvalidity */
+    else {
+        /* ancient cyrus.header file without a uniqueid field! */
+        xsyslog(LOG_ERR, "mailbox header has no uniqueid, needs reconstruct",
+                         "mboxname=<%s>",
+                         mailbox_name(mailbox));
+    }
 
     /* Read names of user flags */
     p = eol + 1;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1065,7 +1065,8 @@ static int mailbox_open_advanced(const char *name,
         return r;
     }
 
-    if (!mbentry->uniqueid) {
+    /* XXX can we even get here for remote mbentries? */
+    if (!mbentry->uniqueid && mbentry_is_local_mailbox(mbentry)) {
         /* Theoretically it shouldn't be possible for an mbentry to not
          * have a uniqueid... so if it happens, complain loudly.
          */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5405,6 +5405,19 @@ static int _check_rec_cb(void *rock,
         }
         break;
     }
+
+    case KEY_TYPE_NAME: {
+        /* Verify that we have a valid N record */
+        mbentry_t *mbentry = NULL;
+
+        r = mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
+        if (!r) {
+            *do_upgrade = 0;
+            mboxlist_entry_free(&mbentry);
+            r = CYRUSDB_DONE;
+        }
+        break;
+    }
     }
 
     return r;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -346,6 +346,26 @@ EXPORTED char *mbentry_archivepath(const struct mboxlist_entry *mbentry, uint32_
                                 uid);
 }
 
+EXPORTED int mbentry_is_local_mailbox(const struct mboxlist_entry *mbentry)
+{
+    if (config_mupdate_server && !config_getstring(IMAPOPT_PROXYSERVERS)) {
+        /* dedicated frontends never have local mailboxes */
+        return 0;
+    }
+    else if ((mbentry->mbtype & MBTYPE_REMOTE)) {
+        /* mbentry has the remote flag set */
+        return 0;
+    }
+    else if (mbentry->server
+             && 0 != strcmpsafe(mbentry->server, config_servername))
+    {
+        /* it's on some server that is not this one */
+        return 0;
+    }
+
+    return 1;
+}
+
 static void mboxlist_dbname_to_key(const char *dbname, size_t len,
                                    const char *userid, struct buf *key)
 {

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -151,6 +151,9 @@ char *mbentry_metapath(const struct mboxlist_entry *mbentry, int metatype, int i
 char *mbentry_datapath(const struct mboxlist_entry *mbentry, uint32_t);
 char *mbentry_archivepath(const struct mboxlist_entry *mbentry, uint32_t);
 
+int mbentry_is_local_mailbox(const struct mboxlist_entry *mbentry);
+#define mbentry_is_remote_mailbox(mbentry) (!mbentry_is_local_mailbox(mbentry))
+
 mbentry_t *mboxlist_entry_copy(const mbentry_t *src);
 
 void mboxlist_entry_free(mbentry_t **mbentryptr);

--- a/perl/imap/Cyrus/DList.pm
+++ b/perl/imap/Cyrus/DList.pm
@@ -93,6 +93,15 @@ sub add_perl {
 
   elsif (ref($val) eq 'HASH') {
     my $child = $Self->add_kvlist($key);
+    my $order = delete $val->{__kvlist_order};
+
+    if ($order) {
+      die "Unknown order " . ref($order) if ref($order) ne 'ARRAY';
+      foreach my $k (grep { exists $val->{$_} } @{$order}) {
+        $child->add_perl($k, delete $val->{$k});
+      }
+    }
+
     $child->add_perl($_, $val->{$_}) for sort keys %$val;
   }
 
@@ -307,7 +316,16 @@ sub as_perl {
   my $Self = shift;
 
   if ($Self->{type} eq 'kvlist') {
-    return { map { $_->{key} => $_->as_perl() } @{$Self->{data}} };
+    my $kvlist = {};
+    my @order;
+
+    foreach my $datum (@{$Self->{data}}) {
+      push @order, $datum->{key};
+      $kvlist->{$datum->{key}} = $datum->as_perl();
+    }
+
+    $kvlist->{__kvlist_order} = [ @order ];
+    return $kvlist;
   }
   elsif ($Self->{type} eq 'list') {
     return [ map { $_->as_perl() } @{$Self->{data}} ];

--- a/perl/imap/Cyrus/HeaderFile.pm
+++ b/perl/imap/Cyrus/HeaderFile.pm
@@ -126,14 +126,19 @@ sub make_header {
   my $Self = shift;
   my $ds = shift || $Self->header();
 
+  # NOTE: no tab separator if no uniqueid!
+  my $qr_uuid = $ds->{QuotaRoot};
+  $qr_uuid .= "\t$ds->{UniqueId}" if $ds->{UniqueId};
+
   # NOTE: acl and flags should have '' as the last element!
   my $flags = join(" ", @{$ds->{Flags}}, '');
   my $acl = join("\t", @{$ds->{ACL}}, '');
+
   my $buf = <<EOF;
 $HL1
 $HL2
 $HL3
-$ds->{QuotaRoot}        $ds->{UniqueId}
+$qr_uuid
 $flags
 $acl
 EOF

--- a/perl/imap/Cyrus/HeaderFile.pm
+++ b/perl/imap/Cyrus/HeaderFile.pm
@@ -13,6 +13,8 @@ use IO::Handle;
 use File::Temp;
 use Data::Dumper;
 
+use Cyrus::DList;
+
 =pod
 
 =head1 NAME
@@ -122,6 +124,7 @@ sub write_header {
   $fh->print($Self->make_header($header));
 }
 
+# XXX still writes old-style header!
 sub make_header {
   my $Self = shift;
   my $ds = shift || $Self->header();
@@ -154,9 +157,36 @@ sub parse_header {
   die "Not a mailbox header file" unless $lines[0] eq $HL1;
   die "Not a mailbox header file" unless $lines[1] eq $HL2;
   die "Not a mailbox header file" unless $lines[2] eq $HL3;
-  my ($quotaroot, $uniqueid) = split /\t/, $lines[3];
-  my (@flags) = split / /, $lines[4];
-  my (@acl) = split /\t/, $lines[5];
+
+  my ($quotaroot, $uniqueid, @flags, @acl);
+
+  if (substr($lines[3], 0, 1) eq '%') {
+    # new dlist-style header
+    $Self->{dlistheader} = $lines[3];
+    my $dlist = Cyrus::DList->parse_string($lines[3]);
+    my $hash = $dlist->as_perl();
+
+    $quotaroot = $hash->{Q} // '';
+    $uniqueid = $hash->{I};
+    @flags = @{$hash->{U}} if ref $hash->{U};
+    if (ref $hash->{A}) {
+        my $order = delete $hash->{A}->{__kvlist_order};
+
+        if ($order && ref $order eq 'ARRAY') {
+            foreach my $k (@{$order}) {
+                my $v = delete $hash->{A}->{$k};
+                push @acl, $k, $v;
+            }
+        }
+
+        push @acl, %{$hash->{A}};
+    }
+  }
+  else {
+    ($quotaroot, $uniqueid) = split /\t/, $lines[3];
+    @flags = split / /, $lines[4];
+    @acl = split /\t/, $lines[5];
+  }
 
   return {
     QuotaRoot => $quotaroot,


### PR DESCRIPTION
This is a partial forward port of work I did previously for 3.4, as #4100 and #4139, and is part of the solution to #4035 

It contains the `ctl_cyrusdb -r` ("recover") updates, and everything needed to support those updates, and their tests; but it does not contain the `reconstruct` updates, which are more complex and Ken will be pursuing separately.

The updates allow `ctl_cyrusdb -r` to fix up mailboxes.db records for legacy mailboxes (i.e. stored on disk by name) that are missing a uniqueid.  If the mailbox header contains a uniqueid, that value is used; if the header doesn't have one either, then a new one is generated and set in both places.

It does _not_ recover from:

  * mbentry and header have uniqueids that differ
  * mbentry has a uniqueid but the header does not

because detecting either of these cases would require examining every header file on disk, which is beyond what `ctl_cyrusdb -r` does.

`mailbox_open_advanced()` and `mailbox_read_header()` are updated to detect missing uniqueid situations at run time, and syslog a message that the mailbox "needs reconstruct"... though `reconstruct` won't be able to fix it until it's had similar updates.

It also can't recover from any of these situations for uuid-mailboxes, because without already knowing the uniqueid, it can't obtain a namelock.  We'll probably need to fix this in the future, but it's separate work, not just a "simple" forward-port of my 3.4 work.