### PR TITLE
sieveshell segfaults after quit command

### DIFF
--- a/perl/sieve/scripts/sieveshell.pl
+++ b/perl/sieve/scripts/sieveshell.pl
@@ -284,6 +284,7 @@ while(defined($_  = ($interactive ? $term->readline('> ') : <$filehandle>))){
         }
     } elsif (($words[0] eq "quit") || ($words[0] eq "q")) {
         sieve_logout($obj);
+        last;
     } elsif (($words[0] eq "help") || ($words[0] eq "?")) {
         show_help();
     } else {


### PR DESCRIPTION
Actual result:

```
% sieveshell localhost
connecting to localhost
Please enter your password: 
> quit
> list
segmentation fault
```

Expected result:

```
% sieveshell localhost
connecting to localhost
Please enter your password: 
> quit
% 
```

sieveshell should exit after receiving a `quit` command, because any further commands will segfault because sieve_logout() invalidates the object.

The problem appeared in #3281 and was already observed earlier in [Debian Bug #962362](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962362) when that patch was still in Debian and not upstreamed yet. The fix is from there, and I am not familiar enough with Perl to judge whether it is the correct fix, but it appears to work.