### PR TITLE
docs: upgrading to 3.6 requires 3.2.10 or 3.4.4 first

### DIFF
--- a/docsrc/imap/download/upgrade.rst
+++ b/docsrc/imap/download/upgrade.rst
@@ -22,6 +22,29 @@ Upgrading to 3.6
 
 Things to consider **before** you begin:
 
+Versions to upgrade from
+########################
+
+Before upgrading to 3.6, your deployment should be running either:
+
+* 3.2.10 (or later), or
+* 3.4.4 (or later)
+
+If your existing deployment predates these releases, you should first upgrade
+to one of these versions, let it run for a while, resolve any issues that
+come up, and only then upgrade to 3.6.
+
+3.2.x prior to 3.2.10, 3.4.x prior to 3.4.4, and all 3.0.x and 2.x releases
+have inconsistencies in their storage of an optional metadata field (mailbox
+uniqueids).  This was not previously a problem due to the field being optional.
+
+Architectural changes in 3.6 make mailbox uniqueids required for almost all
+operations.  If these are inconsistent or missing, the upgrade may not succeed,
+and the failure may be difficult to recover from.
+
+3.2.10 and 3.4.4 contain changes that detect, report, and fix up missing or
+inconsistent mailbox uniqueids, allowing for a safer upgrade to 3.6.
+
 Installation from tarball
 #########################
 


### PR DESCRIPTION
This updates the upgrade documentation for 3.6 to explain that one should already be running 3.2.10 or 3.4.4 before attempting to upgrade to 3.6.

I would usually just commit this straight to the 3.6 branch, but I'd like some people other than myself to read it and let me know whether it makes sense, or shake out points of confusion or ambiguity, so here's a PR.  Please have a read, and let me know what you think.

(Every future new version will also require an upgrade stopover at 3.2.10/3.4.4, so once we're happy with the wording and this PR is merged, I'll make similar changes on master so they're there ready for 3.8.)