### PR TITLE
'special_nochildren' mailboxes should have \Noinferiors attribute

### DIFF
--- a/cassandane/Cassandane/Cyrus/List.pm
+++ b/cassandane/Cassandane/Cyrus/List.pm
@@ -2251,4 +2251,82 @@ sub test_no_inbox_tombstone
     $self->assert_str_equals('ok', $data); # no mailboxes listed
 }
 
+sub test_list_non_extended_trash_nochildren
+    :UnixHierarchySep :AltNamespace :NoStartInstances :min_version_3_7
+{
+    my ($self) = @_;
+
+    $self->{instance}->{config}->set('specialuse_nochildren' => '\\Trash');
+    $self->_start_instances();
+
+    my $imaptalk = $self->{store}->get_client();
+
+    $self->setup_mailbox_structure($imaptalk, [
+        [ 'create' => [qw( ToDo Projects Projects/Foo SentMail MyDrafts Trash Snoozed) ] ],
+    ]);
+
+    $imaptalk->setmetadata("SentMail", "/private/specialuse", "\\Sent");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    $imaptalk->setmetadata("MyDrafts", "/private/specialuse", "\\Drafts");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    $imaptalk->setmetadata("Trash", "/private/specialuse", "\\Trash");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    $imaptalk->setmetadata("Snoozed", "/private/specialuse", "\\Snoozed");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    my $alldata = $imaptalk->list("", "%");
+
+    $self->assert_mailbox_structure($alldata, '/', {
+        'INBOX'                 => [qw( \\HasNoChildren )],
+        'ToDo'                  => [qw( \\HasNoChildren )],
+        'Projects'              => [qw( \\HasChildren )],
+        'SentMail'              => [qw( \\Sent \\HasNoChildren )],
+        'MyDrafts'              => [qw( \\Drafts \\HasNoChildren )],
+        'Trash'                 => [qw( \\Trash \\HasNoChildren \\Noinferiors )],
+        'Snoozed'               => [qw( \\Snoozed \\HasNoChildren )],
+    });
+}
+
+sub test_list_return_subscribed_trash_nochildren
+    :UnixHierarchySep :AltNamespace :NoStartInstances :min_version_3_7
+{
+    my ($self) = @_;
+
+    $self->{instance}->{config}->set('specialuse_nochildren' => '\\Trash');
+    $self->_start_instances();
+
+    my $imaptalk = $self->{store}->get_client();
+
+    $self->setup_mailbox_structure($imaptalk, [
+        [ 'create' => [qw( ToDo Projects Projects/Foo SentMail MyDrafts Trash Snoozed) ] ],
+        [ 'subscribe' => [qw( SentMail Trash) ] ],
+    ]);
+
+    $imaptalk->setmetadata("SentMail", "/private/specialuse", "\\Sent");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    $imaptalk->setmetadata("MyDrafts", "/private/specialuse", "\\Drafts");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    $imaptalk->setmetadata("Trash", "/private/specialuse", "\\Trash");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    $imaptalk->setmetadata("Snoozed", "/private/specialuse", "\\Snoozed");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    my $alldata = $imaptalk->list([qw( SPECIAL-USE )], "", "*",
+                                  'RETURN', [qw(SUBSCRIBED)]);
+
+    xlog $self, Dumper $alldata;
+    $self->assert_mailbox_structure($alldata, '/', {
+        'SentMail'              => [qw( \\Sent \\HasNoChildren \\Subscribed )],
+        'MyDrafts'              => [qw( \\Drafts \\HasNoChildren )],
+        'Trash'                 => [qw( \\Trash \\Noinferiors \\Subscribed )],
+        'Snoozed'               => [qw( \\Snoozed \\HasNoChildren )],
+    });
+}
+
 1;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -268,6 +268,7 @@ struct list_rock {
     uint32_t last_attributes;
     int last_category;
     hash_table server_table;    /* for proxying */
+    strarray_t *special_nochildren;
 };
 
 /* Information about one mailbox name that LIST returns */
@@ -13328,6 +13329,34 @@ static void add_intermediates(const char *extname, struct list_rock *lrock)
     strarray_fini(&inter);
 }
 
+static int is_noinferiors(struct findall_data *data, struct list_rock *rock)
+{
+    int r = 0;
+
+    if (data->mb_category == MBNAME_ALTINBOX)
+        r = 1;
+
+    else if (strarray_size(rock->special_nochildren)) {
+        struct buf attrib = BUF_INITIALIZER;
+
+        annotatemore_lookup(mbname_intname(data->mbname), "/specialuse",
+                            mbname_userid(data->mbname), &attrib);
+
+        if (buf_len(&attrib)) {
+            strarray_t *uses = strarray_split(buf_cstring(&attrib), NULL, 0);
+
+            if (strarray_intersect(uses, rock->special_nochildren))
+                r = 1;
+
+            strarray_free(uses);
+        }
+
+        buf_free(&attrib);
+    }
+
+    return r;
+}
+
 /* callback for mboxlist_findall
  * used when the SUBSCRIBED selection option is NOT given */
 static int list_cb(struct findall_data *data, void *rockp)
@@ -13381,7 +13410,7 @@ static int list_cb(struct findall_data *data, void *rockp)
     if (!data->is_exactmatch)
         rock->last_attributes |= MBOX_ATTRIBUTE_HASCHILDREN | MBOX_ATTRIBUTE_NONEXISTENT;
 
-    else if (data->mb_category == MBNAME_ALTINBOX)
+    else if (is_noinferiors(data, rock))
         rock->last_attributes |= MBOX_ATTRIBUTE_NOINFERIORS;
 
     return 0;
@@ -13419,7 +13448,7 @@ static int subscribed_cb(struct findall_data *data, void *rockp)
         rock->last_attributes |= MBOX_ATTRIBUTE_SUBSCRIBED;
         if (mboxlist_lookup(mbname_intname(data->mbname), NULL, NULL))
             rock->last_attributes |= MBOX_ATTRIBUTE_NONEXISTENT;
-        if (data->mb_category == MBNAME_ALTINBOX)
+        if (is_noinferiors(data, rock))
             rock->last_attributes |= MBOX_ATTRIBUTE_NOINFERIORS;
     }
     else if (rock->listargs->cmd == LIST_CMD_LSUB) {
@@ -13688,6 +13717,10 @@ static void list_data(struct listargs *listargs)
         memset(&rock, 0, sizeof(struct list_rock));
         rock.listargs = listargs;
 
+        rock.special_nochildren =
+            strarray_split(config_getstring(IMAPOPT_SPECIALUSE_NOCHILDREN),
+                           NULL, STRARRAY_TRIM);
+
         if (listargs->sel & LIST_SEL_SUBSCRIBED) {
             mboxlist_findsubmulti(&imapd_namespace, &listargs->pat,
                                   imapd_userisadmin, imapd_userid,
@@ -13714,6 +13747,7 @@ static void list_data(struct listargs *listargs)
         }
 
         if (rock.last_name) free(rock.last_name);
+        strarray_free(rock.special_nochildren);
     }
 }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -13334,23 +13334,21 @@ static int is_noinferiors(struct findall_data *data, struct list_rock *rock)
     int r = 0;
 
     if (data->mb_category == MBNAME_ALTINBOX)
-        r = 1;
+        return 1;
 
-    else if (strarray_size(rock->special_nochildren)) {
+    if (strarray_size(rock->special_nochildren)) {
         struct buf attrib = BUF_INITIALIZER;
 
         annotatemore_lookup(mbname_intname(data->mbname), "/specialuse",
                             mbname_userid(data->mbname), &attrib);
-
         if (buf_len(&attrib)) {
             strarray_t *uses = strarray_split(buf_cstring(&attrib), NULL, 0);
 
-            if (strarray_intersect(uses, rock->special_nochildren))
+            if (strarray_intersect(uses, rock->special_nochildren)) {
                 r = 1;
-
+            }
             strarray_free(uses);
         }
-
         buf_free(&attrib);
     }
 


### PR DESCRIPTION
If we don't allow children to be created, then the mailbox should have \Noinferiors