### PR TITLE
annotate.testc: mailbox_create() caller must supply uniqueid

### DIFF
--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -2107,8 +2107,10 @@ static int set_up(void)
 
     struct mboxlock *namespacelock = mboxname_usernamespacelock(MBOXNAME1_INT);
 
+    /* XXX API abuse? perhaps this should just call mboxlist_create,
+     * XXX rather than the low level APIs. */
     r = mailbox_create(MBOXNAME1_INT, /*mbtype*/0, PARTITION, ACL,
-                       /*uniqueid*/NULL,
+                       makeuuid(),
                        /*options*/0, /*uidvalidity*/0,
                        /*createdmodseq*/0,
                        /*highestmodseq*/0, &mailbox);
@@ -2135,7 +2137,7 @@ static int set_up(void)
     namespacelock = mboxname_usernamespacelock(MBOXNAME2_INT);
 
     r = mailbox_create(MBOXNAME2_INT, /*mbtype*/0, PARTITION, ACL,
-                       /*uniqueid*/NULL,
+                       makeuuid(),
                        /*options*/0, /*uidvalidity*/0,
                        /*createdmodseq*/0,
                        /*highestmodseq*/0, &mailbox);
@@ -2162,7 +2164,7 @@ static int set_up(void)
     namespacelock = mboxname_usernamespacelock(MBOXNAME3_INT);
 
     r = mailbox_create(MBOXNAME3_INT, /*mbtype*/0, PARTITION, ACL,
-                       /*uniqueid*/NULL,
+                       makeuuid(),
                        /*options*/0, /*uidvalidity*/0,
                        /*createdmodseq*/0,
                        /*highestmodseq*/0, &mailbox);


### PR DESCRIPTION
This fixes a bunch of annotate.testc failures introduced in #4180

I don't think this is the _best_ fix, but it is _a_ fix.  A better fix might be for this to use `mboxlist_createmailbox()` to create the mailboxes it wants, rather than using `mailbox_create()` and `mboxlist_updatelock()` directly -- but maybe calling the deeper APIs directly was a deliberate choice.