### PR TITLE
Add long-options support to command line tools

### DIFF
--- a/backup/ctl_backups.c
+++ b/backup/ctl_backups.c
@@ -49,6 +49,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <getopt.h>
 #include <jansson.h>
 #include <stdlib.h>
 #include <string.h>
@@ -352,7 +353,35 @@ int main(int argc, char **argv)
     struct ctlbu_cmd_options options = {0};
     options.wait = BACKUP_OPEN_NONBLOCK;
 
-    while ((opt = getopt(argc, argv, ":AC:DFPSVcfjmpst:x:uvw")) != EOF) {
+    /* keep in alphabetical order */
+    static const char *const short_options = ":AC:DFPSVcfjmpst:uvwx:";
+
+    static const struct option long_options[] = {
+        { "all", no_argument, NULL, 'A' },
+        /* n.b. no long-option for -C */
+        { "domains", no_argument, NULL, 'D' },
+        { "force", no_argument, NULL, 'F' },
+        { "prefixes", no_argument, NULL, 'P' },
+        { "stop-on-error", no_argument, NULL, 'S' },
+        { "no-verify", no_argument, NULL, 'V' },
+        { "create", no_argument, NULL, 'c' },
+        { "filenames", no_argument, NULL, 'f' },
+        { "json", no_argument, NULL, 'j' },
+        { "mailboxes", no_argument, NULL, 'm' },
+        { "pause", no_argument, NULL, 'p' },
+        { "sqlite3", no_argument, NULL, 's' },
+        { "stale", optional_argument, NULL, 't' },
+        { "userids", no_argument, NULL, 'u' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "wait-for-locks", no_argument, NULL, 'w' },
+        { "execute", required_argument, NULL, 'x' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'A':
             if (options.mode != CTLBU_MODE_UNSPECIFIED) usage();

--- a/backup/cyr_backup.c
+++ b/backup/cyr_backup.c
@@ -49,6 +49,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <getopt.h>
 #include <jansson.h>
 #include <stdlib.h>
 #include <string.h>
@@ -263,7 +264,22 @@ int main(int argc, char **argv)
     mbname_t *mbname = NULL;
     int i, opt, r = 0;
 
-    while ((opt = getopt(argc, argv, "C:fmuv")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:fmuv";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "filename", no_argument, NULL, 'f' },
+        { "mailbox", no_argument, NULL, 'm' },
+        { "userid", no_argument, NULL, 'u' },
+        { "verbose", no_argument, NULL, 'v' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C':
             alt_config = optarg;

--- a/backup/restore.c
+++ b/backup/restore.c
@@ -44,6 +44,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -197,7 +198,36 @@ int main(int argc, char **argv)
     struct dlist *upload = NULL;
     int opt, r = 0;
 
-    while ((opt = getopt(argc, argv, ":A:C:DF:LM:P:UXaf:m:nru:vw:xz")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = ":A:C:DF:LM:P:UXaf:m:nru:vw:xz";
+
+    static const struct option long_options[] = {
+        { "override-acl", optional_argument, NULL, 'A' },
+        /* n.b. no long option for -C */
+        { "keep-deletedprefix", no_argument, NULL, 'D' },
+        { "input-file", required_argument, NULL, 'F' },
+        { "local-only", no_argument, NULL, 'L' },
+        { "dest-mailbox", required_argument, NULL, 'M' },
+        { "dest-partition", required_argument, NULL, 'P' },
+        { "keep-uidvalidity", no_argument, NULL, 'U' },
+        { "skip-expunged", no_argument, NULL, 'X' },
+        { "all-mailboxes", no_argument, NULL, 'a' },
+        { "file", required_argument, NULL, 'f' },
+        { "mailbox", required_argument, NULL, 'm' },
+        { "dry-run", no_argument, NULL, 'n' },
+        { "recursive", no_argument, NULL, 'r' },
+        { "userid", required_argument, NULL, 'u' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "delayed-startup", required_argument, NULL, 'w' },
+        { "only-expunged", no_argument, NULL, 'x' },
+        { "require-compression", no_argument, NULL, 'z' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'A':
             if (options.keep_uidvalidity) usage();

--- a/docsrc/assets/man-imtest.rst
+++ b/docsrc/assets/man-imtest.rst
@@ -24,31 +24,31 @@ Options
 
 .. program:: imtest
 
-.. option:: -t  keyfile
+.. option:: -t keyfile, --keyfile=keyfile
 
     Enable TLS.  *keyfile* contains the TLS public and private keys.
     Specify **""** to negotiate a TLS encryption layer but not use TLS
     authentication.
 
-.. option:: -p  port
+.. option:: -p port, --port=port
 
     Port to connect to. If left off this defaults to **imap** as defined
     in ``/etc/services``.
 
-.. option:: -m  mechanism
+.. option:: -m mechanism, --mechanism=mechanism
 
     Force **imtest** to use *mechanism* for authentication. If not
     specified the strongest authentication mechanism supported by the
     server is chosen.  Specify *login* to use the LOGIN command instead
     of AUTHENTICATE.
 
-.. option:: -a  userid
+.. option:: -a userid, --authname=userid
 
     Userid to use for authentication; defaults to the current user.
     This is the userid whose password or credentials will be presented to
     the server for verification.
 
-.. option:: -u  userid
+.. option:: -u userid, --username=userid
 
     Userid to use for authorization; defaults to the current user.
     This is the userid whose identity will be assumed after
@@ -58,11 +58,11 @@ Options
         This is only used with SASL mechanisms that allow proxying
         (e.g. PLAIN, DIGEST-MD5).
 
-.. option:: -k  num
+.. option:: -k num, --minssf=num
 
     Minimum protection layer required.
 
-.. option:: -l  num
+.. option:: -l num, --maxssf=num
 
     Maximum protection layer to use (**0**\ =none; **1**\ =integrity;
     etc).  For example if you are using the KERBEROS_V4 authentication
@@ -70,66 +70,66 @@ Options
     and specifying **1** will force it to use the integrity layer.  By
     default the maximum supported protection layer will be used.
 
-.. option:: -r  realm
+.. option:: -r realm, --realm=realm
 
     Specify the *realm* to use. Certain authentication mechanisms
     (e.g. DIGEST-MD5) may require one to specify the realm.
 
-.. option:: -f  file
+.. option:: -f file, --input-filename=file
 
     Pipe *file* into connection after authentication.
 
-.. option:: -n  num
+.. option:: -n num, --reauth-attempts=num
 
     Number of authentication attempts; default = 1.  The client will
     attempt to do SSL/TLS session reuse and/or fast reauth
     (e.g. DIGEST-MD5), if possible.
 
-.. option:: -s
+.. option:: -s, --require-tls
 
     Enable SSL over chosen protocol.
 
-.. option:: -q
+.. option:: -q, --require-compression
 
     Enable IMAP COMPRESSion (after authentication).
 
-.. option:: -c
+.. option:: -c, --do-challenge
 
     Enable challenge prompt callbacks.  This will cause the OTP mechanism
     to ask for the one-time password instead of the secret pass-phrase
     (library generates the correct response).
 
-.. option:: -i
+.. option:: -i, --no-initial-response
 
     Don't send an initial client response for SASL mechanisms, even if
     the protocol supports it.
 
-.. option:: -I  file
+.. option:: -I file, --pidfile=file
 
     Echo the PID of the running process into *file* (This can be useful
     with -X).
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Verbose. Print out more information than usual.
 
-.. option:: -z
+.. option:: -z, --run-stress-test
 
     Timing test.
 
-.. option:: -x  file
+.. option:: -x file, --output-socket=file
 
     Open the named socket for the interactive portion.
 
-.. option:: -X  file
+.. option:: -X file
 
     Like -x, only close all file descriptors & daemonize the process.
 
-.. option:: -w passwd
+.. option:: -w password, --password=password
 
     Password to use (if not supplied, we will prompt).
 
-.. option:: -o  option=value
+.. option:: -o option=value, --sasl-option=option=value
 
     Set the SASL *option* to *value*.
 

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -201,6 +201,7 @@ html_static_path = ['_static']
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 html_use_smartypants = False
+smartquotes = False
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {'**' : ['localtoc.html', 'searchbox.html', 'buildstatus.html']}

--- a/docsrc/imap/reference/manpages/systemcommands/arbitron.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/arbitron.rst
@@ -58,21 +58,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -o
-
-    Report "the old way" -- not including subscribers.
-
-.. option:: -l
-
-    Enable long reporting (comma delimited table consisting of mbox,
-    userid, r/s, start time, end time).
-
-.. option:: -d days
-
-    Count as a reader an authorization identity which has used the
-    mailbox within the past *days* days.
-
-.. option:: -D mmddyyyy[:mmddyyyy]
+.. option:: -D mmddyyyy[:mmddyyyy], --date=mmddyyyy[:mmddyyyy]
 
     Count as a reader an authorization identity which has used the
     mailbox within the given date range.
@@ -88,10 +74,30 @@ Options
         Please note that the date notation is American [\ *mmddyyyy*\ ]
         not [\ *ddmmyyyy*\ ].
 
-.. option:: -p months
+.. option:: -d days, --days=days
+
+    Count as a reader an authorization identity which has used the
+    mailbox within the past *days* days.
+
+.. option:: -l, --detailed
+
+    Enable long reporting (comma delimited table consisting of mbox,
+    userid, r/s, start time, end time).
+
+.. option:: -o, --no-subscribers
+
+    Report "the old way" -- not including subscribers.
+
+.. option:: -p months, --prune-seen=months
 
     Prune ``\Seen`` state for users who have not used the mailbox within
     the past *months* months. The default is infinity.
+
+.. option:: -u, --include-userids
+
+    Include userids of mailbox readers in the report.  If the report
+    will contain mailbox subscribers (see **--no-subscribers**), also
+    include userids of the subscribers.
 
 Examples
 ========

--- a/docsrc/imap/reference/manpages/systemcommands/chk_cyrus.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/chk_cyrus.rst
@@ -38,11 +38,11 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -P partition
+.. option:: -P partition, --partition=partition
 
     Limit to partition *partition*.  May not be specified with **-M**.
 
-.. option:: -M mailbox
+.. option:: -M mailbox, --mailbox=mailbox
 
     Only check mailbox *mailbox*.  May not be specified with **-P**.
 

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_backups.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_backups.rst
@@ -111,12 +111,12 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -F
+.. option:: -F, --force
 
     Force the operation to occur, even if it is determined to be unnecessary.
     This is mostly useful with the **compact** sub-command.
 
-.. option:: -S
+.. option:: -S, --stop-on-error
 
     Stop-on-error.  With this option, if a sub-command fails for any
     particular backup, **ctl_backups** will immediately exit with an error,
@@ -124,7 +124,7 @@ Options
 
     The default is to log the error, and continue with the next backup.
 
-.. option:: -V
+.. option:: -V, --no-verify
 
     Don't verify backup checksums for read-only operations.
 
@@ -135,15 +135,15 @@ Options
 
     With this option, the verification step will be skipped.
 
-.. option:: -j
+.. option:: -j, --json
 
     Produce output in JSON format.  The default is plain text.
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Increase the verbosity.  Can be specified multiple times.
 
-.. option:: -w
+.. option:: -w, --wait-for-locks
 
     Wait for locks.  With this option, if a backup named on the command line is
     locked, execution will block until the lock becomes available.
@@ -158,7 +158,7 @@ List Options
 
 Options that apply only to the **list** sub-command.
 
-.. option:: -t [hours]
+.. option:: -t [hours], --stale[=hours]
 
     List stale backups only, that is, backups that have received no updates
     in *hours*.  If *hours* is unspecified, it defaults to 24.
@@ -170,26 +170,26 @@ Lock Options
 
 Options that apply only to the **lock** sub-command.
 
-.. option:: -c
+.. option:: -c, --create
 
     Exclusively create the named backup while obtaining the lock.  Exits
     immediately with an error if the named backup already exists.
 
     When the lock is successfully obtained, continue as per the other options.
 
-.. option:: -p
+.. option:: -p, --pause
 
     Locks the named backup, and then waits for EOF on the standard input
     stream.  Unlocks the backup and exits once EOF is received.  This is the
     default mode of operation.
 
-.. option:: -s
+.. option:: -s, --sqlite3
 
     Locks the named backup, and with the lock held, opens its index file in
     the :manpage:`sqlite3(1)` program.  The lock is automatically released when
     sqlite3 exits.
 
-.. option:: -x command
+.. option:: -x command, --execute=command
 
     Locks the named backup, and with the lock held, executes *command* using
     **/bin/sh** (as per :manpage:`system(3)`).  The lock is automatically
@@ -204,35 +204,35 @@ Options that apply only to the **lock** sub-command.
 Modes
 =====
 
-.. option:: -A
+.. option:: -A, --all
 
     Run sub-command over all known backups.
 
     Known backups are recorded in the database specified by the **backup_db**
     and **backup_db_path** configuration options.
 
-.. option:: -D
+.. option:: -D, --domains
 
     Backups specified on the command line are interpreted as domains.  Run
     sub-command over known backups for users in these domains.
 
-.. option:: -P
+.. option:: -P, --prefixes
 
     Backups specified on the command line are interpreted as userid prefixes.
     Run sub-command over known backups for users matching these prefixes.
 
-.. option:: -f
+.. option:: -f, --filenames
 
     Backups specified on the command line are interpreted as filenames.  Run
     sub-command over the matching backup files.  The backup files do not need
     to be known about in the backups database.
 
-.. option:: -m
+.. option:: -m, --mailboxes
 
     Backups specified on the command line are interpreted as mailbox names.
     Run sub-command over known backups containing these mailboxes.
 
-.. option:: -u
+.. option:: -u, --userids
 
     Backups specified on the command line are interpreted as userids.  Run
     sub-command over known backups for matching users.

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
@@ -54,36 +54,36 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -d userid
+.. option:: -d, --dump
 
     Dump the conversations database which corresponds to the user *userid*
     to standard output in an ASCII format.  The resulting file can be
     used to recreate a database using the **-u** option.
 
-.. option:: -u userid
+.. option:: -u, --undump
 
     "Undumps" the conversations database corresponding to the user *userid*,
     i.e. replaces all the entries with data from ASCII records parsed
     from standard input.  The output from the **-d** option can be used
     as input.
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Be more verbose when running.
 
-.. option:: -r
+.. option:: -r, --recursive
 
     Be recursive; apply the main operation to every user.  Warning: do
     not combine with **-u**, it will not do what you expect.
 
-.. option:: -z
+.. option:: -z, --clear
 
     Remove all conversation information from the conversations database
     for user *userid*, and from all the user's mailboxes.  The
     information can all be recalculated (eventually) from message
     headers, using the **-b** option.
 
-.. option:: -b
+.. option:: -b, --rebuild
 
     Rebuild all conversation information in the conversations database
     for user *userid*, and in all the user's mailboxes, from the header
@@ -97,17 +97,17 @@ Options
     from *cyrus.cache* files so it does not need to read every single
     message file.
 
-.. option:: -R
+.. option:: -R, --update-counts
 
     Recalculate counts of messages stored in existing conversations in
     the conversations database for user *userid*.  This is a limited
     subset of **-b**; in particular it does not create conversations or
     assign messages to conversations.
 
-.. option:: -S
+.. option:: -S, --split
 
     If given with **-b**, allows splitting of conversations during the
-    rewrite.   Only do this is changing the maximum conversation size
+    rewrite.   Only do this if changing the maximum conversation size
     and you need to split those existing conversations.
 
 Examples

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_deliver.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_deliver.rst
@@ -36,12 +36,12 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -d
+.. option:: -d, --dump
 
     Dump the contents of the database to standard output in a portable
     flat-text format.
 
-.. option:: -f filename
+.. option:: -f filename, --filename=filename
 
     Use the database specified by *filename* instead of the default
     (*configdirectory*/**deliver.db**).

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_mboxlist.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_mboxlist.rst
@@ -40,37 +40,37 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -d
+.. option:: -d, --dump
 
     Dump the contents of the database to standard output in JSON format.
 
-.. option:: -x
+.. option:: -x, --remove-dumped
 
     When performing a dump, remove the mailboxes dumped from the mailbox
     list (mostly useful when specified with **-p**).
 
-.. option:: -y
+.. option:: -y, --include-intermediaries
 
     When performing a dump, also list intermediary mailboxes which would
     be hidden from IMAP.
 
-.. option:: -p partition
+.. option:: -p partition, --partition=partition
 
     When performing a dump, dump only those mailboxes that live on
     *partition*.
 
-.. option:: -f filename
+.. option:: -f filename, --filename=filename
 
     Use the database specified by *filename* instead of the default
     (*configdirectory/mailboxes.db**).
 
-.. option:: -L
+.. option:: -L, --legacy
 
     When performing an undump, use the legacy dump parser instead of the
     JSON parser.  This might be useful for importing a dump produced
     by an older version of Cyrus.
 
-.. option:: -u
+.. option:: -u, --undump
 
     Load ("undump") the contents of the database from standard input.  The
     input MUST be a valid JSON file, unless the -L option is also supplied.
@@ -83,12 +83,12 @@ Options
         dump file, but it can't do much to protect you from a valid file
         containing bad data.
 
-.. option:: -m
+.. option:: -m, --sync-mupdate
 
     For backend servers in the Cyrus Murder, synchronize the local
     mailbox list file with the MUPDATE server.
 
-.. option:: -a
+.. option:: -a, --authoritative
 
     When used with **-m**, assume the local mailboxes file is authoritative,
     that is, only change the mupdate server, do not delete any local
@@ -98,17 +98,17 @@ Options
         USE THIS OPTION WITH CARE, as it allows namespace collisions into
         the murder.
 
-.. option:: -w
+.. option:: -w, --warn-only
 
     When used with **-m**, print out what would be done but do not perform
     the operations.
 
-.. option:: -i
+.. option:: -i, --interactive
 
     When used with **-m**, asks for verification before deleting local
     mailboxes.
 
-.. option:: -v
+.. option:: -v, --verify
 
     Verify the consistency of the mailbox list database and the spool
     partition(s). Mailboxes present in the database and not located on a

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_zoneinfo.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_zoneinfo.rst
@@ -36,11 +36,11 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Enable verbose output.
 
-.. option:: -r version-string
+.. option:: -r version-string, --rebuild=version-string
 
     Rebuild the zoneinfo database based on the directory structure of
     *configdirectory*/**zoneinfo**.  The database to be rebuilt will be
@@ -51,7 +51,7 @@ Options
     by the *tzdist* module of :manpage:`httpd(8)`.  The *version-string*
     must contain a colon between the description and the version.
 
-.. option:: -w file
+.. option:: -w file, --windows-zone-xml=file
 
     Reads Windows Zone XML file.
 

--- a/docsrc/imap/reference/manpages/systemcommands/cvt_xlist_specialuse.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cvt_xlist_specialuse.rst
@@ -32,7 +32,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Produce verbose output
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_backup.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_backup.rst
@@ -101,7 +101,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Increase the verbosity.  Can be specified multiple times.
 
@@ -110,12 +110,12 @@ Options
 Modes
 =====
 
-.. option:: -f
+.. option:: -f, --filename
 
     *backup* is interpreted as a filename.  The named file does not need to be
     known about in the backups database.
 
-.. option:: -m
+.. option:: -m, --mailbox
 
     *backup* is interpreted as a mailbox name.  There must be a known backup
     for the user whose mailbox this is.
@@ -123,7 +123,7 @@ Modes
     Known backups are recorded in the database specified by the **backup_db**
     and **backup_db_path** configuration options.
 
-.. option:: -u
+.. option:: -u, --userid
 
     *backup* is interpreted as a userid.  There must be a known backup for
     the specified user.

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
@@ -76,11 +76,6 @@ Options
 
     Create the database file if it doesn't already exist.
 
-.. option:: -o
-
-    Store all the output in memory and only print it once the transaction
-    is completed.
-
 .. option:: -T
 
     Use a transaction to do the action (most especially for 'show') - the

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
@@ -68,15 +68,15 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -M
+.. option:: -M, --improved-mboxlist-sort
 
     Uses improved MBOX list sort
 
-.. option:: -n
+.. option:: -n, --create
 
     Create the database file if it doesn't already exist.
 
-.. option:: -T
+.. option:: -T, --use-transaction
 
     Use a transaction to do the action (most especially for 'show') - the
     default used to be transactions.

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_deny.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_deny.rst
@@ -40,24 +40,24 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -a user
+.. option:: -a, --allow
 
     Allow access to all services for user *user* (remove any entry
     from the deny database).
 
-.. option:: -s services
+.. option:: -s services, --services=services
 
     Deny access only to the given *services*, which is a
     comma-separated list of wildcard patterns.  The default is "*"
     which denies access to all services.
 
 
-.. option:: -m message
+.. option:: -m message, --message=message
 
     Provide a message which is sent to the user to explain why access is
     being denied.  A default message is used if none is specified.
 
-.. option:: -l
+.. option:: -l, --list
 
     List the entries in the deny database.
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_df.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_df.rst
@@ -35,7 +35,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -m
+.. option:: -m, --metadata
 
     Report on metadata partitions rather than message file partitions.
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
@@ -84,7 +84,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -A archive-duration
+.. option:: -A archive-duration, --archive-duration=archive-duration
 
     Archive non-flagged messages older than *archive-duration* to the
     archive partition, allowing mailbox messages to be split between fast
@@ -95,7 +95,7 @@ Options
 
     |v3-new-feature|
 
-.. option:: -D delete-duration
+.. option:: -D delete-duration, --delete-duration=delete-duration
 
     Remove previously deleted mailboxes older than *delete-duration*
     (when using the "delayed" delete mode).
@@ -106,53 +106,53 @@ Options
     This value is only used for entries which do not have a
     corresponding ``/verdor/cmu/cyrus-imapd/delete`` mailbox annotation.
 
-.. option:: -E expire-duration
+.. option:: -E expire-duration, --expire-duration=expire-duration
 
     Prune the duplicate database of entries older than *expire-duration*.
     This value is only used for entries which do not have a corresponding
     ``/vendor/cmu/cyrus-imapd/expire`` mailbox annotation.
     Format is the same as delete-duration.
 
-.. option:: -X expunge-duration
+.. option:: -X expunge-duration, --expunge-duration=expunge-duration
 
     Expunge previously deleted messages older than *expunge-duration*
     (when using the "delayed" expunge mode).
     Format is the same as delete-duration.
 
-.. option:: -c
+.. option:: -c, --no-conversations
 
     Do not expire conversation database entries, even if the conversations
     feature is enabled.
 
     |v3-new-feature|
 
-.. option:: -x
+.. option:: -x, --no-expunge
 
     Do not expunge messages even if using delayed expunge mode.  This
     reduces IO traffic considerably, allowing ``cyr_expire`` to be run
     frequently to clean up the duplicate database without overloading
     the machine.
 
-.. option:: -p mailbox-prefix
+.. option:: -p mailbox-prefix, --prefix=mailbox-prefix
 
     Only find mailboxes starting with this prefix,  e.g.
     "user.justgotspammedlots".
 
-.. option:: -u userid
+.. option:: -u userid, --userid=userid
 
     Only find mailboxes belonging to this user,  e.g.
     "justgotspammedlots@example.com".
 
-.. option:: -t
+.. option:: -t, --prune-userflags
 
     Remove any user flags which are not used by remaining (not expunged)
     messages.
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Enable verbose output.
 
-.. option:: -a
+.. option:: -a, --ignore-annotations
 
     Skip the annotation lookup, so all ``/vendor/cmu/cyrus-imapd/expire``
     annotations are ignored entirely.  It behaves as if they were not

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
@@ -81,11 +81,11 @@ Options
 
     Read service specifications from *config-file* (cyrus.conf format).
 
-.. option:: -n servicename
+.. option:: -n name, --service=name
 
     Read the configuration as if for the service named *name*.
 
-.. option:: -s version
+.. option:: -s version, --since=version
 
     Highlight configuration options that have been added or whose behaviour
     has been modified since *version*.  Use this option after a server upgrade,

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_ls.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_ls.rst
@@ -35,20 +35,20 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -l
+.. option:: -l, --long
 
     Use a long listing format.
 
-.. option:: -m
+.. option:: -m, --metadata
 
     Output the path to the metadata files (if different from the
     message files).
 
-.. option:: -R
+.. option:: -R, --recursive
 
     List submailboxes recursively.
 
-.. option:: -1
+.. option:: -1, --one-per-line
 
     List one file per line.
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_synclog.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_synclog.rst
@@ -38,27 +38,27 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -u   user
+.. option:: -u, --user          user
 
-.. option:: -U   unuser
+.. option:: -U, --unuser        unuser
 
-.. option:: -v   sieve
+.. option:: -v, --sieve         sieve
 
-.. option:: -m   mailbox
+.. option:: -m, --mailbox       mailbox
 
-.. option:: -M   unmailbox
+.. option:: -M, --unmailbox     unmailbox
 
-.. option:: -a   append
+.. option:: -a, --append        append
 
-.. option:: -c   acl
+.. option:: -c, --acl           acl
 
-.. option:: -q   quota
+.. option:: -q, --quota         quota
 
-.. option:: -n   annotation
+.. option:: -n, --annotation    annotation
 
-.. option:: -s   seen
+.. option:: -s, --seen          seen
 
-.. option:: -b   subscription
+.. option:: -b, --subscription  subscription
 
 Examples
 ========

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_userseen.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_userseen.rst
@@ -42,7 +42,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -d
+.. option:: -d, --delete
 
     Actually delete all user seen state information.
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_virusscan.rst
@@ -62,21 +62,21 @@ Options
     |cli-dash-c-text|
 
 
-.. option:: -n
+.. option:: -n, --notify
 
     Notify mailbox owner of deleted messages via email.  This flag is
     only operable in combination with **-r**.
 
-.. option:: -r
+.. option:: -r, --remove-infected
 
     Remove infected messages.
 
-.. option:: -s imap-search-string
+.. option:: -s imap-search-string, --search=imap-search-string
 
     Rather than scanning for viruses, messages matching the search
     criteria will be treated as infected.
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Produce more verbose output
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyrdump.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyrdump.rst
@@ -30,7 +30,7 @@ Options
 
     Alternate config file.
     
-.. option:: -v
+.. option:: -v, --verbose
 
     Produce verbose output on errors.
 

--- a/docsrc/imap/reference/manpages/systemcommands/deliver.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/deliver.rst
@@ -43,15 +43,15 @@ Options
 
     Ignored for compatibility with **/bin/mail**.
 
-.. option:: -r  address
+.. option:: -r address, --return-path=address
 
     Insert a **Return-Path:** header containing *address*.
 
-.. option:: -f  address
+.. option:: -f address
 
     Insert a **Return-Path:** header containing *address*.
 
-.. option:: -m  mailbox
+.. option:: -m mailbox, --mailbox=mailbox
 
     Deliver to **mailbox**.  If any *userid*\ s are specified, attempts
     to deliver to ``user.``\ *userid*\ ``.mailbox`` for each *userid*\ .
@@ -63,15 +63,15 @@ Options
     . If the ACL on *mailbox* does not grant the sender the "p" right,
     the delivery fails.
 
-.. option:: -a  auth-id
+.. option:: -a auth-id, --auth-id=auth-id
 
     Specify the authorization id of the sender.  Defaults to "anonymous".
 
-.. option:: -q  user-id
+.. option:: -q, --ignore-quota
 
     Deliver message even when receiving mailbox is over quota.
 
-.. option:: -l
+.. option:: -l, --lmtp
 
     Accept messages using the LMTP protocol.
 

--- a/docsrc/imap/reference/manpages/systemcommands/fetchnews.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/fetchnews.rst
@@ -38,39 +38,39 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -s  servername
+.. option:: -s servername, --server=servername
 
     Hostname of the Cyrus server (with optional port) to which articles
     should be fed.  Defaults to "localhost:nntp".
 
-.. option:: -n
+.. option:: -n, --no-newnews
 
     Don't use the NEWNEWS command. **fetchnews** will keep track of the
     high and low water marks for each group and use them to fetch new
     articles.
 
-.. option:: -y
+.. option:: -y, --yyyy
 
     Use 4 instead of 2 digits for year. 2-digits are :rfc:`977` - but not
     y2k-compliant.
 
-.. option:: -w  wildmat
+.. option:: -w wildmat, --groups=wildmat
 
     Wildmat pattern specifying which newsgroups to search for new
     articles.  Defaults to "*".
 
 
-.. option:: -f  tstampfile
+.. option:: -f tstampfile, --newsstamp-file=tstampfile
 
     File in which to read/write the timestamp of when articles were
     last retrieved.  Defaults to ``<configdirectory>/newsstamp`` as
     specified by the configuration options.
 
-.. option:: -a  authname
+.. option:: -a authname, --auth-id=authname
 
     Userid to use for authentication.
 
-.. option:: -p  password
+.. option:: -p password, --password=password
 
     Password to use for authentication.
 

--- a/docsrc/imap/reference/manpages/systemcommands/ipurge.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ipurge.rst
@@ -47,52 +47,52 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -f
+.. option:: -f, --include-user-mailboxes
 
     Force ipurge to examine mailboxes below INBOX.* and user.*.
 
-.. option:: -d days
+.. option:: -d days, --days=days
 
     Age of message in *days*.
 
-.. option:: -b bytes
+.. option:: -b bytes, --bytes=bytes
 
     Size of message in *bytes*.
 
-.. option:: -k Kbytes
+.. option:: -k Kbytes, --kbytes=Kbytes
 
     Size of message in *Kbytes* (2^10 bytes).
 
-.. option:: -m Mbytes
+.. option:: -m Mbytes, --mbytes=Mbytes
 
     Size of message in *Mbytes* (2^20 bytes).
 
-.. option:: -x
+.. option:: -x, --exact-match
 
     Perform an exact match on age or size (instead of older or larger).
 
-.. option:: -X
+.. option:: -X, --delivery-time
 
     Use delivery time instead of Date: header for date matches.
 
-.. option:: -i
+.. option:: -i, --invert-match
 
     Invert match logic: -x means not equal, date is for newer, size is
     for smaller.
 
-.. option:: -s
+.. option:: -s, --skip-flagged
 
     Skip over messages that have the \\Flagged flag set.
 
-.. option:: -o
+.. option:: -o, --only-deleted
 
     Only purge messages that have the \\Deleted flag set.
 
-.. option:: -n
+.. option:: -n, --dry-run
 
     Only print messages that would be deleted (dry run).
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Enable verbose output/logging.
 

--- a/docsrc/imap/reference/manpages/systemcommands/mbexamine.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/mbexamine.rst
@@ -40,21 +40,21 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -u  uid
+.. option:: -u  uid, --uid=uid
 
     Dump information for the given uid only.
 
-.. option:: -s  seqnum
+.. option:: -s  seqnum, --seq=seqnum
 
     Dump information for the given sequence number only.
 
-.. option:: -q
+.. option:: -q, --check-quota
 
     Compare the quota usage in cyrus.index to the actual message file
     sizes and report any differences.  If there are differences, the
     mailbox SHOULD be reconstructed.
 
-.. option:: -c
+.. option:: -c, --check-message-files
 
     Compare the records in cyrus.index to the actual message files
     report any differences.  This can help detect issues if messages

--- a/docsrc/imap/reference/manpages/systemcommands/mbpath.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/mbpath.rst
@@ -37,7 +37,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -l
+.. option:: -l, --local-only
 
     Local mailboxes only (exits with error for remote or nonexistent mailboxes)
 
@@ -46,46 +46,46 @@ Options
     Output the path to the metadata files (if different from the
     message files).  Legacy, use **-M**.
 
-.. option:: -q
+.. option:: -q, --quiet
 
     Suppress any error output.
 
-.. option:: -s
+.. option:: -s, --stop
 
     If any error occurs, stop processing the list of mailboxes and exit.
 
-.. option:: -u
+.. option:: -u, --userids
 
-    The specified *mailbox-names* are users, not mailboxes.
+    The specified *mailbox-names* are userids, not mailboxes.
 
-.. option:: -p
+.. option:: -p, --paths
 
     The specified *mailbox-names* are UNIX mailbox paths, not mailboxes.
 
 Selectors
 =========
 
-.. option:: -A
+.. option:: -A, --archive
 
     Show the mailbox archive path
 
-.. option:: -D
+.. option:: -D, --data
 
     Show the mailbox data path (*default*)
 
-.. option:: -M
+.. option:: -M, --metadata
 
     Show the mailbox metadata path (same as **-m**)
 
-.. option:: -S
+.. option:: -S, --sieve
 
     Show the user sieve scripts path
 
-.. option:: -U
+.. option:: -U, --user-files
 
     Show the user files path (seen, sub, etc)
 
-.. option:: -a
+.. option:: -a, --all
 
     Show all paths, as if all selectors were specified
 

--- a/docsrc/imap/reference/manpages/systemcommands/mbtool.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/mbtool.rst
@@ -41,16 +41,17 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -t
+.. option:: -t, --normalize-internaldate
 
     Normalize ``internaldate`` on all index records of all listed
     *mailbox*\ es to match the *Date:* header if they're off by more
     than a day, which can be used to fix up a mailbox which has been
     restored from backup and lost its internaldate information.
 
-.. option:: -r
+.. option:: -r, --new-uniqueid
 
-    Create a new unique ID for all listed *mailbox*\ es.
+    Create a new unique ID for all listed *mailbox*\ es.  Only works
+    for legacy mailboxes.
 
 Examples
 ========

--- a/docsrc/imap/reference/manpages/systemcommands/ptdump.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ptdump.rst
@@ -8,7 +8,7 @@
 **ptdump**
 ==========
 
-Program to to dump the current PTS (protection database authorization)
+Program to dump the current PTS (protection database authorization)
 cache.
 
 Synopsis

--- a/docsrc/imap/reference/manpages/systemcommands/ptexpire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ptexpire.rst
@@ -15,14 +15,14 @@ Synopsis
 
 .. parsed-literal::
 
-    **ptexpire** [**-C** *filename*] [**-E** *time*]
+    **ptexpire** [**-C** *filename*] [**-E** *seconds*]
 
 Description
 ===========
 
-The **ptexpire** program sweeps the ``ptscache_db`` database, expiring
-entries older than the time specified on the command line (default 3
-hours).
+The **ptexpire** program sweeps the ``ptscache_db`` database, deleting
+entries older than the expiry duration, which defaults to 5400 seconds
+(3 hours).  The expiry duration can be changed with the **-E** option.
 
 **ptexpire** |default-conf-text|
 
@@ -35,10 +35,9 @@ Options
 
   |cli-dash-c-text|
 
-.. option::  -E time
+.. option::  -E seconds, --expire-duration=seconds
 
-  Expire entries older than this time.
-  Default: 3 hours
+  Set the expiry duration to *seconds*.
 
 Files
 =====

--- a/docsrc/imap/reference/manpages/systemcommands/quota.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/quota.rst
@@ -55,30 +55,30 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -d domain
+.. option:: -d domain, --domain domain
 
     List and/or fix quota only in *domain*.
 
-.. option:: -f
+.. option:: -f, --fix
 
-    Fix any inconsistencies in the quota subsystem before generating a
-    report.
+    Detect and fix any inconsistencies in the quota subsystem before generating
+    a report.
 
-.. option:: -n
+.. option:: -n, --report-only
 
     Check for any inconsistencies in the quota subsystem but don't actually
     fix them.  Use with **-f** and **-q** to only see what's incorrect.
 
-.. option:: -q
+.. option:: -q, --quiet
 
     Operate quietly. If **-f** is specified, then don't print the quota
     values, only print messages when things are changed.
 
-.. option:: -J
+.. option:: -J, --json
 
     Output the quota values as JSON for automated tooling support
 
-.. option:: -u
+.. option:: -u, --userids
 
     Interpret *mailbox-spec* arguments as userids.  The default is to
     interpret them as mailbox prefixes

--- a/docsrc/imap/reference/manpages/systemcommands/relocate_by_id.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/relocate_by_id.rst
@@ -36,15 +36,15 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -n
+.. option:: -n, --dry-run
 
     Do NOT make any changes.  Just list which directories will be relocated.
 
-.. option:: -q
+.. option:: -q, --quiet
 
     Run quietly.  Suppress any error output.
 
-.. option:: -u
+.. option:: -u, --userids
 
     The specified *mailbox-names* are users, not mailboxes.
     User metadata directories will also be relocated.

--- a/docsrc/imap/reference/manpages/systemcommands/restore.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/restore.rst
@@ -67,7 +67,7 @@ restoring into mailboxes that already exists) will not have their ACLs altered.
 Options
 =======
 
-.. option:: -A [acl]
+.. option:: -A [acl], --override-acl[=acl]
 
     Apply specified *acl* to restored mailboxes, rather than their ACLs as
     stored in the backup.
@@ -81,7 +81,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -D
+.. option:: -D, --keep-deletedprefix
 
     Don't trim **deletedprefix** from mailbox names prior to restoring.  This
     is mainly useful for rebuilding failed servers, where deleted mailboxes
@@ -96,7 +96,7 @@ Options
     See :cyrusman:`imapd.conf(5)` for information about the **deletedprefix**
     and **delete_mode** configuration options.
 
-.. option:: -F input-file
+.. option:: -F input-file, --input-file=input-file
 
     Get the list of mailboxes or messages from *input-file* instead of from
     the command line arguments.
@@ -105,7 +105,7 @@ Options
     a *uniqueid*, or a *guid*) per line.  Empty lines, and lines beginning with
     a '#' character, are ignored.
 
-.. option:: -L
+.. option:: -L, --local-only
 
     Local operations only.  Actions required to restore the requested mailboxes
     and messages will be performed on the destination server only.
@@ -116,7 +116,7 @@ Options
 
     This option has no effect if the destination server is not part of a murder.
 
-.. option:: -M mboxname
+.. option:: -M mboxname, --dest-mailbox=mboxname
 
     Messages are restored to the mailbox with the specified *mboxname*.  If no
     mailbox of this name exists, one will be created.
@@ -132,11 +132,11 @@ Options
     The default when restoring individual messages is to restore them into
     their original mailboxes.
 
-.. option:: -P partition
+.. option:: -P partition, --dest-partition=partition
 
     Restore mailboxes to the specified *partition*
 
-.. option:: -U
+.. option:: -U, --keep-uidvalidity
 
     Try to preserve uidvalidity and other related fields, such that the
     restored mailboxes and messages appear like they never left, and IMAP
@@ -150,17 +150,17 @@ Options
     appended as if newly delivered, regardless of whether the **-U** option
     was specified.
 
-.. option:: -X
+.. option:: -X, --skip-expunged
 
     Do not restore messages that are marked as expunged in the *backup*.
 
     See also **-x**.
 
-.. option:: -a
+.. option:: -a, --all-mailboxes
 
     Try to restore all mailboxes in the specified *backup*.
 
-.. option:: -n
+.. option:: -n, --dry-run
 
     Do nothing.  The work required to perform the restoration will be
     calculated (and reported depending on verbosity level), but no
@@ -169,23 +169,23 @@ Options
 
     Note that the *server* argument is still mandatory with this option.
 
-.. option:: -r
+.. option:: -r, --recursive
 
     Recurse into submailboxes.  When restoring mailboxes, also restore
     any mailboxes contained within them.
 
     The default is to restore only explicitly-specified mailboxes.
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Increase the verbosity level.  This option can be specified multiple times
     for additional verbosity.
 
-.. option:: -w seconds
+.. option:: -w seconds, --delayed-startup=seconds
 
     Wait *seconds* before starting.  This is useful for attaching a debugger.
 
-.. option:: -x
+.. option:: -x, --only-expunged
 
     Only restore messages that are marked as expunged in the *backup*.
 
@@ -195,7 +195,7 @@ Options
 
     See also **-X**.
 
-.. option:: -z
+.. option:: -z, --require-compression
 
     Require compression for server connection.  The restore will abort
     if compression is unavailable.
@@ -205,12 +205,12 @@ Options
 Modes
 =====
 
-.. option:: -f
+.. option:: -f backup, --file=backup
 
     *backup* is interpreted as a filename.  The named file does not need to be
     known about in the backups database.
 
-.. option:: -m
+.. option:: -m backup, --mailbox=backup
 
     *backup* is interpreted as a mailbox name.  There must be a known backup
     for the user whose mailbox this is.
@@ -218,7 +218,7 @@ Modes
     Known backups are recorded in the database specified by the **backup_db**
     and **backup_db_path** configuration options.
 
-.. option:: -u
+.. option:: -u backup, --userid=backup
 
     *backup* is interpreted as a userid.  There must be a known backup for
     the specified user.

--- a/docsrc/imap/reference/manpages/systemcommands/sieved.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/sieved.rst
@@ -6,25 +6,31 @@
 **sieved**
 ==========
 
-Script to decompile a sieve script back from bytecode.
+Tool to decompile a sieve script back from bytecode.
 
 Synopsis
 ========
 
 .. parsed-literal::
 
-    **sieved** *scriptfile*
+    **sieved** [OPTIONS] *bytcodefile*
 
 Description
 ===========
 
-**sieved** decompiles the given script at *scriptfile* from bytecode, writing output to stdout.
+**sieved** decompiles the given *bytecodefile*, writing output to stdout.
 
+By default, the output is a descriptive version of the bytecode.  With the
+**-s** option, an equivalent sieve script is produced instead.
 
 Options
 =======
 
 .. program:: sieved
+
+.. option:: -s, --as-sieve
+
+   Produce a sieve script rather than describing the bytecode.
 
 See Also
 ========

--- a/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
@@ -41,14 +41,14 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -A
+.. option:: -A, --all-users
 
     All users mode.
     Sync every user on the server to the replica (doesn't do non-user
     mailboxes at all... this could be considered a bug and maybe it
     should do those mailboxes independently)
 
-.. option:: -d delay
+.. option:: -d delay, --delay=delay
 
     Minimum delay between replication runs in rolling replication mode.
     Larger values provide better efficiency as transactions can be
@@ -56,14 +56,14 @@ Options
     date and that you don't end up with large blocks of replication
     transactions as a single group. Default: 3 seconds.
 
-.. option:: -f input-file
+.. option:: -f input-file, --input-file=input-file
 
     In mailbox or user replication mode: provides list of users or
     mailboxes to replicate.  In rolling replication mode, specifies an
     alternate log file (**sync_client** will exit after processing the
     log file).
 
-.. option:: -F shutdown-file
+.. option:: -F shutdown-file, --shutdown-file=shutdown-file
 
     Rolling replication checks for this file at the end of each
     replication cycle and shuts down if it is present. Used to request
@@ -71,106 +71,114 @@ Options
     removed on shutdown. Overrides ``sync_shutdown_file`` option in
     :cyrusman:`imapd.conf(5)`.
 
-.. option:: -l
+.. option:: -l, --verbose-logging
 
     Verbose logging mode.
 
-.. option:: -L
+.. option:: -L, --local-only
 
     Perform only local mailbox operations (do not do mupdate operations).
     |v3-new-feature|
 
-.. option:: -m
+.. option:: -m, --mailboxes
 
     Mailbox mode.
     Remaining arguments are list of mailboxes which should be replicated.
 
-.. option:: -n channel
+.. option:: -n channel, --channel=channel
 
     Use the named channel for rolling replication mode.  If multiple
     channels are specified in ``sync_log_channels`` then use one of them.
     This option is probably best combined with **-S** to connect to a
     different server with each channel.
 
-.. option:: -N
+.. option:: -N, --skip-locked
 
     Use non-blocking sync_lock (combination of IP address and username)
     to skip over any users who are currently syncing.
 
-.. option:: -o
+.. option:: -o, --connect-once
 
     Only attempt to connect to the backend server once rather than
     waiting up to 1000 seconds before giving up.
 
-.. option:: -O
+.. option:: -O, --no-copyback
 
     No copyback mode. Replication will stop if the replica reports a CRC
     error, rather than doing a full mailbox sync. Useful if moving users to a
     new server, where you don't want any errors to cause the source servers
     to change the account.
 
-.. option:: -p partition
+.. option:: -p partition, --dest-partition=partition
 
     In mailbox or user replication mode: provides the name of the
     partition on the replica to which the mailboxes/users should be
     replicated.
 
-.. option:: -r
+.. option:: -r, --rolling
 
     Rolling (repeat) replication mode. Pick up a list of actions
     recorded by the :cyrusman:`lmtpd(8)`, :cyrusman:`imapd(8)`,
     :cyrusman:`pop3d(8)` and :cyrusman:`nntpd(8)` daemons from the file
     specified in ``sync_log_file``. Repeat until ``sync_shutdown_file``
-    appears.
+    appears.  Alternative log and shutdown files can be specified with
+    **-f** and **-F**.
 
-.. option:: -1
+    In this invocation, sync_client will background itself to run as a
+    daemon.
 
-    Like rolling replication, but only process a single file before exiting.
+.. option:: -R, --foreground-rolling
 
-.. option:: -s
+    As for **-r**, but without backgrounding.
+
+.. option:: -1, --rolling-once
+
+    As for **-R**, but only process a single log file before exiting.
+
+.. option:: -s, --sieve-mode
 
     Sieve mode.
     Remaining arguments are list of users whose Sieve files should be
     replicated. Principally used for debugging purposes: not exposed to
     :cyrusman:`sync_client(8)`.
 
-.. option:: -S servername
+.. option:: -S servername, --server=servername
 
     Tells **sync_client** with which server to communicate.  Overrides
     the ``sync_host`` configuration option.
 
-.. option:: -t timeout
+.. option:: -t timeout, --timeout=timeout
 
     Timeout for single replication run in rolling replication.
     **sync_client** will negotiate a restart after this many seconds.
     Default: 600 seconds
 
-.. option:: -u
+.. option:: -u, --userids
 
     User mode.
     Remaining arguments are list of users who should be replicated.
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Verbose mode.  Use twice (**-v -v**) to log all protocol traffic to
     stderr.
 
-.. option:: -w interval
+.. option:: -w interval, --delayed-startup=interval
 
     Wait this long before starting. This option is typically used so
     that we can attach a debugger to one end of the replication system
     or the other.
 
-.. option:: -z
+.. option:: -z, --require-compression
 
     Require compression.
     The replication protocol will always try to enable deflate
     compression if both ends support it.  Set this flag when you want
     to abort if compression is not available.
 
-.. option:: -a
+.. option:: -a, --stage-to-archive
 
-    Request the replicate-to-archive feature. If the remote end has the
+    Request the stage-to-archive feature. If the remote end has the
     ``archive_enabled`` option set, then it will stage incoming replication on
     the archive partition instead of the spool partition. If the remote end
     does not support it, replication will proceed as though **-a** was not

--- a/docsrc/imap/reference/manpages/systemcommands/sync_reset.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/sync_reset.rst
@@ -37,11 +37,11 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -v
+.. option:: -v, --verbose
 
   Verbose mode.
 
-.. option:: -f
+.. option:: -f, --force
 
   Force operation. Without this flag **sync_reset** just bails out with
   an error.  Principally here to try and prevent accidents with command

--- a/docsrc/imap/reference/manpages/systemcommands/unexpunge.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/unexpunge.rst
@@ -42,40 +42,40 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -l
+.. option:: -l, --list
 
     List the expunged messages in the specified mailbox which are
     available for restoration.
     Optionally, only list the messages in the mailbox matching the
     UIDs in the space\-separated list at the end of the command invocation.
 
-.. option:: -t time-interval
+.. option:: -t time-interval, --within-time-interval=time-interval
 
-    Unexpunge messages which where expunged within the last
+    Unexpunge messages which were expunged within the last
     ``time-interval`` seconds.
     Use one of the trailing modifiers -- ``m`` (minutes), ``h`` (hours),
     ``d`` (days) or ``w`` (weeks) -- to specify a different time unit.
 
-.. option:: -a
+.. option:: -a, --all
 
     Restore **all** of the expunged messages in the specified mailbox.
 
-.. option:: -u
+.. option:: -u, --uids
 
     Restore only messages matching the UIDs, in a space-separated list
     at the end of the command invocation, in the specified mailbox.
 
-.. option:: -d
+.. option:: -d, --unset-deleted
 
     Unset the *\\Deleted* flag on any restored messages.
 
-.. option:: -f flagname
+.. option:: -f flagname, --set-flag=flagname
 
     Set the user flag *\\flagname* on the messages restored, making it
     easier for the user(s) to find the restored messages and operate on
     them (in a batch).
 
-.. option:: -v
+.. option:: -v, --verbose
 
     Enable verbose output/logging.
 

--- a/docsrc/imap/reference/manpages/usercommands/dav_reconstruct.rst
+++ b/docsrc/imap/reference/manpages/usercommands/dav_reconstruct.rst
@@ -31,13 +31,14 @@ Options
 
     Alternative config file with cyrus settings.
 
-.. option:: -a
+.. option:: -a, --all
 
     Process all users on this store.
 
-.. option:: -A \<audit tool\>
+.. option:: -A audit-tool, --audit-tool=audit-tool
 
-   Name of a program to take two sqlite databases and compare them. This option currently does not work.
+   Name of a program to take two sqlite databases and compare them. This option
+   currently does not work.
 
 .. option:: userid_list
 

--- a/imap/arbitron.c
+++ b/imap/arbitron.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -107,7 +108,7 @@ static void process_seen(const char *path, const char *user);
 static void process_subs(const char *path, const char *user);
 static int do_mailbox(struct findall_data *data, void *rock);
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
     int opt, r;
     int report_days = 30;
@@ -116,11 +117,27 @@ int main(int argc,char **argv)
     char *alt_config = NULL;
     time_t now = time(0);
 
+    /* keep these in alphabetical order */
+    static const char *const short_options = "C:D:d:lop:u";
+
+    static const struct option long_options[] = {
+        /* n.b. no long form for -C option */
+        { "date", required_argument, NULL, 'D' },
+        { "days", required_argument, NULL, 'd' },
+        { "detailed", no_argument, NULL, 'l' },
+        { "no-subscribers", no_argument, NULL, 'o' },
+        { "prune-seen", required_argument, NULL, 'p' },
+        { "include-userids", no_argument, NULL, 'u' },
+        { 0, 0, 0, 0 },
+    };
+
     strcpy(pattern, "*");
 
     report_end_time = now;
 
-    while ((opt = getopt(argc, argv, "C:oud:D:p:l")) != EOF) {
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -42,6 +42,7 @@
 
 #include <config.h>
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -108,11 +109,22 @@ int main(int argc, char **argv)
     char *alt_config = NULL;
     char pattern[2] = { '*', '\0' };
     const char *mailbox = NULL;
-
-    extern char *optarg;
     int opt;
 
-    while ((opt = getopt(argc, argv, "C:P:M:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:M:P:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "mailbox", required_argument, NULL, 'M' },
+        { "partition", required_argument, NULL, 'P' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -44,6 +44,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
@@ -838,7 +839,28 @@ int main(int argc, char **argv)
     const char *userid = NULL;
     int recursive = 0;
 
-    while ((c = getopt(argc, argv, "durzSAbvRFC:T:")) != EOF) {
+    /* keep in alphabetical order */
+    static const char *const short_options = "AC:FRST:bdruvz";
+
+    static const struct option long_options[] = {
+        { "audit", no_argument, NULL, 'A' },
+        /* n.b. no long option for -C */
+        { "check-folders", no_argument, NULL, 'F' },
+        { "update-counts", no_argument, NULL, 'R' },
+        { "split", no_argument, NULL, 'S' },
+        { "audit-temp-directory", required_argument, NULL, 'T' },
+        { "rebuild", no_argument, NULL, 'b' },
+        { "dump", no_argument, NULL, 'd' },
+        { "recursive", no_argument, NULL, 'r' },
+        { "undump", no_argument, NULL, 'u' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "clear", no_argument, NULL, 'z' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (c = getopt_long(argc, argv,
+                                  short_options, long_options, NULL)))
+    {
         switch (c) {
         case 'd':
             if (mode != UNKNOWN)

--- a/imap/ctl_deliver.c
+++ b/imap/ctl_deliver.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     char *days = NULL;
     enum { DUMP, PRUNE, NONE } op = NONE;
 
-    while ((opt = getopt(argc, argv, "C:drE:f:")) != EOF) {
+    while ((opt = getopt(argc, argv, "C:dE:f:")) != EOF) {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/ctl_deliver.c
+++ b/imap/ctl_deliver.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -75,7 +76,21 @@ int main(int argc, char *argv[])
     char *days = NULL;
     enum { DUMP, PRUNE, NONE } op = NONE;
 
-    while ((opt = getopt(argc, argv, "C:dE:f:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:E:df:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        /* n.b. no long option for "deprecated" -E */
+        { "dump", no_argument, NULL, 'd' },
+        { "filename", required_argument, NULL, 'f' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -65,6 +65,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <inttypes.h>
 #include <sysexits.h>
 #include <syslog.h>
@@ -88,9 +89,6 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 #include "imap/mupdate_err.h"
-
-extern int optind;
-extern char *optarg;
 
 enum mboxop { DUMP,
               M_POPULATE,
@@ -1222,7 +1220,30 @@ int main(int argc, char *argv[])
     int dointermediary = 0;
     int undump_legacy = 0;
 
-    while ((opt = getopt(argc, argv, "C:Lawmdurcxf:p:viy")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:Ladf:imp:uvwxy";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "legacy", no_argument, NULL, 'L' },
+        { "authoritative", no_argument, NULL, 'a' },
+        { "dump", no_argument, NULL, 'd' },
+        { "filename", required_argument, NULL, 'f' },
+        { "interactive", no_argument, NULL, 'i' },
+        { "sync-mupdate", no_argument, NULL, 'm' },
+        { "partition", required_argument, NULL, 'p' },
+        { "undump", no_argument, NULL, 'u' },
+        { "verify", no_argument, NULL, 'v' },
+        { "warn-only", no_argument, NULL, 'w' },
+        { "remove-dumped", no_argument, NULL, 'x' },
+        { "include-intermediaries", no_argument, NULL, 'y' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -47,6 +47,7 @@
 #include <unistd.h>
 #endif
 #include <errno.h>
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -66,9 +67,6 @@
 #include "xmalloc.h"
 #include "xml_support.h"
 #include "zoneinfo_db.h"
-
-extern int optind;
-extern char *optarg;
 
 /* config.c stuff */
 const int config_need_data = 0;
@@ -91,7 +89,20 @@ int main(int argc, char **argv)
     const char *zoneinfo_dir = NULL;
     enum { REBUILD, WINZONES, NONE } op = NONE;
 
-    while ((opt = getopt(argc, argv, "C:r:vw:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:r:vw:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "rebuild", required_argument, NULL, 'r' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "windows-zone-xml", required_argument, NULL, 'w' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cvt_cyrusdb.c
+++ b/imap/cvt_cyrusdb.c
@@ -42,6 +42,7 @@
 
 #include <config.h>
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -74,7 +75,17 @@ int main(int argc, char *argv[])
     int opt;
     char *alt_config = NULL;
 
-    while ((opt = getopt(argc, argv, "C:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cvt_xlist_specialuse.c
+++ b/imap/cvt_xlist_specialuse.c
@@ -43,6 +43,7 @@
 
 #include <config.h>
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sysexits.h>
@@ -161,7 +162,18 @@ int main (int argc, char **argv)
     hash_table xlist = HASH_TABLE_INITIALIZER;
     strarray_t patterns = STRARRAY_INITIALIZER;
 
-    while ((opt = getopt(argc, argv, "C:v")) != -1) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:v";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "verbose", no_argument, NULL, 'v' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C':
             alt_config = optarg;

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -331,8 +332,18 @@ int main(int argc, char *argv[])
     struct buf buf = BUF_INITIALIZER;
     json_t *bi;
 
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { 0, 0, 0, 0 },
+    };
+
     /* Parse arguments */
-    while ((opt = getopt(argc, argv, "C:")) != EOF) {
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file. We don't care but don't bark for -C. */
             break;

--- a/imap/cyr_dbtool.c
+++ b/imap/cyr_dbtool.c
@@ -42,6 +42,7 @@
 
 #include <config.h>
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -274,7 +275,22 @@ int main(int argc, char *argv[])
     struct txn *tid = NULL;
     struct txn **tidp = NULL;
 
-    while ((opt = getopt(argc, argv, "C:MntTc")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:MTcnt";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "improved-mboxlist-sort", no_argument, NULL, 'M' },
+        { "use-transaction", no_argument, NULL, 'T' },
+        { "convert", no_argument, NULL, 'c' }, /* XXX undocumented */
+        { "create", no_argument, NULL, 'n' },
+        { "no-transaction", no_argument, NULL, 't' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_deny.c
+++ b/imap/cyr_deny.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -185,7 +186,21 @@ int main(int argc, char **argv)
     const char *services = NULL;
     int r;
 
-    while ((opt = getopt(argc, argv, "C:alm:s:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:alm:s:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "allow", no_argument, NULL, 'a' },
+        { "list", no_argument, NULL, 'l' },
+        { "message", required_argument, NULL, 'm' },
+        { "services", required_argument, NULL, 's' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_df.c
+++ b/imap/cyr_df.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
@@ -56,9 +57,6 @@
 #include "util.h"
 #include "xmalloc.h"
 
-extern int optind;
-extern char *optarg;
-
 /* forward declarations */
 static void usage(void);
 static void get_part_stats(const char *key, const char *val, void *rock);
@@ -69,7 +67,18 @@ int main(int argc, char *argv[])
     char *alt_config = NULL;
     int meta = 0;
 
-    while ((opt = getopt(argc, argv, "C:m")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:m";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "metadata", no_argument, NULL, 'm' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -53,6 +53,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -763,8 +764,27 @@ static int do_duplicate_prune(struct cyr_expire_ctx *ctx)
 
 static int parse_args(int argc, char *argv[], struct arguments *args)
 {
-    extern char *optarg;
     int opt;
+
+    /* keep this in alphabetical order */
+    static const char *const short_options = "A:C:D:E:X:achp:tu:vx";
+
+    static const struct option long_options[] = {
+        { "archive-duration", required_argument, NULL, 'A' },
+        /* n.b. no long option for -C */
+        { "delete-duration", required_argument, NULL, 'D' },
+        { "expire-duration", required_argument, NULL, 'E' },
+        { "expunge-duration", required_argument, NULL, 'X' },
+        { "ignore-annotations", no_argument, NULL, 'a' },
+        { "no-conversations", no_argument, NULL, 'c' },
+        { "help", no_argument, NULL, 'h' },
+        { "prefix", required_argument, NULL, 'p' },
+        { "prune-userflags", required_argument, NULL, 't' },
+        { "userid", required_argument, NULL, 'u' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "no-expunge", no_argument, NULL, 'x' },
+        { 0, 0, 0, 0 },
+    };
 
     args->archive_seconds = -1;
     args->delete_seconds = -1;
@@ -773,7 +793,9 @@ static int parse_args(int argc, char *argv[], struct arguments *args)
     args->do_expunge = true;
     args->do_cid_expire = -1;
 
-    while ((opt = getopt(argc, argv, "C:D:E:X:A:p:u:vaxtch")) != EOF) {
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'A':
             if (!parse_duration(optarg, &args->archive_seconds)) usage();

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -459,14 +460,26 @@ static uint32_t parse_since_version(const char *str)
 
 int main(int argc, char *argv[])
 {
-    extern char *optarg;
     int opt;
     const char *alt_config = NULL;
     const char *srvname = "cyr_info";
     uint32_t since = 0;
     int want_since = 0;
 
-    while ((opt = getopt(argc, argv, "C:M:n:s:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:M:n:s:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        /* n.b. no long option for -M */
+        { "service", required_argument, NULL, 'n' },
+        { "since", required_argument, NULL, 's' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_ls.c
+++ b/imap/cyr_ls.c
@@ -62,6 +62,7 @@
 # endif
 #endif
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -83,9 +84,6 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-
-extern int optind;
-extern char *optarg;
 
 /* current namespace */
 static struct namespace cyr_ls_namespace;
@@ -350,12 +348,28 @@ int main(int argc, char **argv)
     char *alt_config = NULL;
     int is_path = 0;
 
+    /* keep this in alphabetical order */
+    static const char *const short_options = "17C:Rilmp";
+
+    static const struct option long_options[] = {
+        { "one-per-line", no_argument, NULL, '1' },
+        { "no-utf8", no_argument, NULL, '7' }, /* XXX undocumented */
+        /* n.b. no long option for -C */
+        { "recursive", no_argument, NULL, 'R' },
+        { "long", no_argument, NULL, 'l' },
+        { "metadata", no_argument, NULL, 'm' },
+        { "path", no_argument, NULL, 'p' }, /* XXX undocumented */
+        { 0, 0, 0, 0 },
+    };
+
     // capture options
     struct list_opts opts =
         { 1 /* default to UTF8 */, 0, 0, 0, 0,
           isatty(STDOUT_FILENO), 4 /* default to 4 columns */, 0 };
 
-    while ((opt = getopt(argc, argv, "C:7milR1p")) != EOF) {
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch(opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_pwd.c
+++ b/imap/cyr_pwd.c
@@ -46,6 +46,7 @@
 #include <unistd.h>
 #endif
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -55,9 +56,6 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-
-extern int optind;
-extern char *optarg;
 
 /* current namespace */
 static struct namespace cyr_pwd_namespace;
@@ -79,7 +77,17 @@ int main(int argc, char **argv)
     int opt;
     char *alt_config = NULL;
 
-    while ((opt = getopt(argc, argv, "C:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch(opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_synclog.c
+++ b/imap/cyr_synclog.c
@@ -44,6 +44,7 @@
 
 #include <config.h>
 
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sysexits.h>
@@ -84,7 +85,28 @@ int main(int argc, char *argv[])
     char cmd = '\0';
     int opt;
 
-    while ((opt = getopt(argc, argv, "C:uUvmMacqnsb")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:MUabcmnqsuv";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "unmailbox", no_argument, NULL, 'M' },
+        { "unuser", no_argument, NULL, 'U' },
+        { "append", no_argument, NULL, 'a' },
+        { "subscription", no_argument, NULL, 'b' },
+        { "acl", no_argument, NULL, 'c' },
+        { "mailbox", no_argument, NULL, 'm' },
+        { "annotation", no_argument, NULL, 'n' },
+        { "quota", no_argument, NULL, 'q' },
+        { "seen", no_argument, NULL, 's' },
+        { "user", no_argument, NULL, 'u' },
+        { "sieve", no_argument, NULL, 'v' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_userseen.c
+++ b/imap/cyr_userseen.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -93,11 +94,21 @@ done:
 
 int main(int argc, char *argv[])
 {
-    extern char *optarg;
     int opt;
     char *alt_config = NULL;
 
-    while ((opt = getopt(argc, argv, "C:d")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:d";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "delete", no_argument, NULL, 'd' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
@@ -99,12 +100,6 @@ struct scan_rock {
     int total_infected;
     int mailboxes_scanned;
 };
-
-/* globals for getopt routines */
-extern char *optarg;
-extern int  optind;
-extern int  opterr;
-extern int  optopt;
 
 /* globals for callback functions */
 int disinfect = 0;
@@ -275,7 +270,7 @@ static const char *default_notification_template =
 
 int main (int argc, char *argv[])
 {
-    int option;         /* getopt() returns an int */
+    int opt;
     char *alt_config = NULL;
     char *search_str = NULL;
     struct scan_rock srock;
@@ -283,8 +278,22 @@ int main (int argc, char *argv[])
     struct namespace scan_namespace;
     int r;
 
-    while ((option = getopt(argc, argv, "C:s:rnv")) != EOF) {
-        switch (option) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:nrs:v";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "notify", no_argument, NULL, 'n' },
+        { "remove-infected", no_argument, NULL, 'r' },
+        { "search", required_argument, NULL, 's' },
+        { "verbose", no_argument, NULL, 'v' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
+        switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
             break;

--- a/imap/cyrdump.c
+++ b/imap/cyrdump.c
@@ -44,6 +44,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <libgen.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -79,15 +80,26 @@ struct incremental_record {
 
 int main(int argc, char *argv[])
 {
-    int option;
+    int opt;
     int i;
     char *alt_config = NULL;
     struct incremental_record irec;
 
     progname = basename(argv[0]);
 
-    while ((option = getopt(argc, argv, "vC:")) != EOF) {
-        switch (option) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:v";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "verbose", no_argument, NULL, 'v' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
+        switch (opt) {
         case 'v':
             verbose++;
             break;

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -46,6 +46,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -70,9 +71,6 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-
-extern int optind;
-extern char *optarg;
 
 /* current namespace */
 static struct namespace recon_namespace;
@@ -100,7 +98,19 @@ int main(int argc, char **argv)
     int allusers = 0;
     const char *audit_tool = NULL;
 
-    while ((opt = getopt(argc, argv, "C:A:a")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:A:a";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "all", no_argument, NULL, 'a' },
+        { "audit-tool", required_argument, NULL, 'A' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/deliver.c
+++ b/imap/deliver.c
@@ -46,6 +46,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -74,9 +75,6 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-
-extern int optind;
-extern char *optarg;
 
 static int logdebug = 0;
 
@@ -169,7 +167,23 @@ int main(int argc, char **argv)
     char buf[1024];
     char *alt_config = NULL;
 
-    while ((opt = getopt(argc, argv, "C:df:r:m:a:F:eE:lqD")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:DE:F:a:def:lm:qr:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "debug", no_argument, NULL, 'D' }, /* XXX undocumented */
+        { "auth-id", required_argument, NULL, 'a' },
+        { "lmtp", no_argument, NULL, 'l' },
+        { "mailbox", required_argument, NULL, 'm' },
+        { "ignore-quota", no_argument, NULL, 'q' },
+        { "return-path", required_argument, NULL, 'r' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch(opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/fetchnews.c
+++ b/imap/fetchnews.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdio.h>
 #include <string.h>
 #include <sysexits.h>
@@ -251,7 +252,6 @@ static int fetch(char *msgid, int bymsgid,
 
 int main(int argc, char *argv[])
 {
-    extern char *optarg;
     int opt;
     char *alt_config = NULL, *port = "119";
     const char *peer = NULL, *server = "localhost", *wildmat = "*";
@@ -266,7 +266,24 @@ int main(int argc, char *argv[])
     int newnews = 1;
     int y2k_compliant_date_format = 0;
 
-    while ((opt = getopt(argc, argv, "C:s:w:f:a:p:ny")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:a:f:np:s:w:y";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "auth-id", required_argument, NULL, 'a' },
+        { "newsstamp-file", required_argument, NULL, 'f' },
+        { "no-newnews", no_argument, NULL, 'n' },
+        { "password", required_argument, NULL, 'p' },
+        { "server", required_argument, NULL, 's' },
+        { "groups", required_argument, NULL, 'w' },
+        { "yyyy", no_argument, NULL, 'y' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/ipurge.c
+++ b/imap/ipurge.c
@@ -48,6 +48,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
@@ -64,12 +65,6 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-
-/* globals for getopt routines */
-extern char *optarg;
-extern int  optind;
-extern int  opterr;
-extern int  optopt;
 
 /* globals for callback functions */
 static int days = -1;
@@ -106,13 +101,35 @@ static void print_record(struct mailbox *mailbox,
 static void print_stats(mbox_stats_t *stats);
 
 int main (int argc, char *argv[]) {
-    int option;           /* getopt() returns an int */
     char *alt_config = NULL;
     int matchmailbox = 0;
-    int r;
+    int r, opt;
 
-    while ((option = getopt(argc, argv, "C:hxd:b:k:m:fsMXionv")) != EOF) {
-        switch (option) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:MXb:d:fhik:m:nosvx";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "no-recursive", no_argument, NULL, 'M' },
+        { "delivery-time", no_argument, NULL, 'X' },
+        { "bytes", required_argument, NULL, 'b' },
+        { "days", required_argument, NULL, 'd' },
+        { "include-user-mailboxes", no_argument, NULL, 'f' },
+        { "invert-match", no_argument, NULL, 'i' },
+        { "kbytes", required_argument, NULL, 'k' },
+        { "mbytes", required_argument, NULL, 'm' },
+        { "dry-run", no_argument, NULL, 'n' },
+        { "only-deleted", no_argument, NULL, 'o' },
+        { "skip-flagged", no_argument, NULL, 's' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "exact-match", no_argument, NULL, 'x' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
+        switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
             break;

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -89,9 +90,6 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
-extern int optind;
-extern char *optarg;
-
 /* current namespace */
 static struct namespace mbexamine_namespace;
 
@@ -113,7 +111,22 @@ int main(int argc, char **argv)
     int (*cb)(struct findall_data *, void *) = &do_examine;
     int ok_count = 0;
 
-    while ((opt = getopt(argc, argv, "C:u:s:qc")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:cqs:u:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "check-message-files", no_argument, NULL, 'c' },
+        { "check-quota", no_argument, NULL, 'q' },
+        { "seq", required_argument, NULL, 's' },
+        { "uid", required_argument, NULL, 'u' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/mbpath.c
+++ b/imap/mbpath.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -66,9 +67,6 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-
-extern int optind;
-extern char *optarg;
 
 /* current namespace */
 static struct namespace mbpath_namespace;
@@ -325,13 +323,37 @@ static int imap_err_to_exit_code(int r)
 int main(int argc, char **argv)
 {
     int r, i;
-    int opt;              /* getopt() returns an int */
+    int opt;
     char *alt_config = NULL;
 
     // capture options
     struct options_t opts = { 0, 0, 0, 0, 0, 0, 1 /* default to UTF8 */ };
 
-    while ((opt = getopt(argc, argv, "C:7ajlmqsupADMSU")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "7AC:DMSUajlmpqsu";
+
+    static const struct option long_options[] = {
+        { "no-utf8", no_argument, NULL, '7' }, /* XXX undocumented */
+        { "archive", no_argument, NULL, 'A' },
+        /* n.b. no long option for -C */
+        { "data", no_argument, NULL, 'D' },
+        { "metadata", no_argument, NULL, 'M' },
+        { "sieve", no_argument, NULL, 'S' },
+        { "user-files", no_argument, NULL, 'U' },
+        { "all", no_argument, NULL, 'a' },
+        { "json", no_argument, NULL, 'j' }, /* XXX undocumented */
+        { "local-only", no_argument, NULL, 'l' },
+        { "paths", no_argument, NULL, 'p' },
+        { "quiet", no_argument, NULL, 'q' },
+        { "stop", no_argument, NULL, 's' },
+        { "userids", no_argument, NULL, 'u' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch(opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -88,9 +89,6 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
-extern int optind;
-extern char *optarg;
-
 /* current namespace */
 static struct namespace mbtool_namespace;
 
@@ -111,7 +109,20 @@ int main(int argc, char **argv)
     int cmd = 0;
     char *alt_config = NULL;
 
-    while ((opt = getopt(argc, argv, "C:rt")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:rt";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "new-uniqueid", no_argument, NULL, 'r' },
+        { "normalize-internaldate", no_argument, NULL, 't' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -88,9 +89,6 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
-extern int optind;
-extern char *optarg;
-
 /* current namespace */
 static struct namespace quota_namespace;
 
@@ -132,7 +130,25 @@ int main(int argc,char **argv)
     int do_report = 1;
     char *alt_config = NULL, *domain = NULL;
 
-    while ((opt = getopt(argc, argv, "C:d:fqJnZu")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:JZd:fnqu";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "json", no_argument, NULL, 'J' },
+        { "test-sync-mode", no_argument, NULL, 'Z' },
+        { "domain", required_argument, NULL, 'd' },
+        { "fix", no_argument, NULL, 'f' },
+        { "report-only", no_argument, NULL, 'n' },
+        { "quiet", no_argument, NULL, 'q' },
+        { "userids", no_argument, NULL, 'u' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -69,9 +70,6 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-
-extern int optind;
-extern char *optarg;
 
 /* current namespace */
 static struct namespace reloc_namespace;
@@ -115,7 +113,21 @@ int main(int argc, char **argv)
 
     progname = basename(argv[0]);
 
-    while ((opt = getopt(argc, argv, "C:qnu")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:nqu";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "dry-run", no_argument, NULL, 'n' },
+        { "quiet", no_argument, NULL, 'q' },
+        { "userids", no_argument, NULL, 'u' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -48,6 +48,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
@@ -91,9 +92,6 @@
 /* ====================================================================== */
 
 /* Static global variables and support routines for sync_client */
-
-extern char *optarg;
-extern int optind;
 
 static const char *servername = NULL;
 static struct sync_client_state sync_cs = SYNC_CLIENT_STATE_INITIALIZER;
@@ -470,7 +468,41 @@ int main(int argc, char **argv)
 
     setbuf(stdout, NULL);
 
-    while ((opt = getopt(argc, argv, "C:vlLS:F:f:w:t:d:n:rRNumsozOAp:1a")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "1AC:F:LNORS:ad:f:lmn:op:rst:uvw:z";
+
+    static const struct option long_options[] = {
+        { "rolling-once", no_argument, NULL, '1' },
+        { "all-users", no_argument, NULL, 'A' },
+        /* n.b. no long option for -C */
+        { "shutdown-file", required_argument, NULL, 'F' },
+        { "local-only", no_argument, NULL, 'L' },
+        { "skip-locked", no_argument, NULL, 'N' },
+        { "no-copyback", no_argument, NULL, 'O' },
+        { "foreground-rolling", no_argument, NULL, 'R' }, /* XXX better name? */
+        { "server", required_argument, NULL, 'S' },
+        { "stage-to-archive", no_argument, NULL, 'a' },
+        { "delay", required_argument, NULL, 'd' },
+        { "input-file", required_argument, NULL, 'f' },
+        { "verbose-logging", no_argument, NULL, 'l' },
+        { "mailboxes", no_argument, NULL, 'm' },
+        { "channel", required_argument, NULL, 'n' },
+        { "connect-once", no_argument, NULL, 'o' },
+        { "dest-partition", required_argument, NULL, 'p' },
+        { "rolling", no_argument, NULL, 'r' },
+        { "sieve-mode", no_argument, NULL, 's' },
+        { "timeout", required_argument, NULL, 't' },
+        { "userids", no_argument, NULL, 'u' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "delayed-startup", required_argument, NULL, 'w' },
+        { "require-compression", no_argument, NULL, 'z' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -48,6 +48,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
@@ -78,9 +79,6 @@
 #include "imap/imap_err.h"
 
 /* Static global variables and support routines for sync_reset */
-
-extern char *optarg;
-extern int optind;
 
 static struct namespace sync_namespace;
 static struct namespace *sync_namespacep = &sync_namespace;
@@ -192,7 +190,21 @@ main(int argc, char **argv)
 
     setbuf(stdout, NULL);
 
-    while ((opt = getopt(argc, argv, "C:vfL")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:Lfv";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "local-only", no_argument, NULL, 'L' },
+        { "force", no_argument, NULL, 'f' },
+        { "verbose", no_argument, NULL, 'v' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/tls_prune.c
+++ b/imap/tls_prune.c
@@ -42,6 +42,7 @@
 
 #include <config.h>
 
+#include <getopt.h>
 #include <stdio.h>
 #include <sysexits.h>
 #include <unistd.h>
@@ -63,7 +64,18 @@ int main(int argc, char *argv[])
     int opt,r;
     char *alt_config = NULL;
 
-    while ((opt = getopt(argc, argv, "C:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/unexpunge.c
+++ b/imap/unexpunge.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -294,7 +295,25 @@ int main(int argc, char *argv[])
     unsigned long *uids = NULL;
     unsigned nuids = 0;
 
-    while ((opt = getopt(argc, argv, "C:laudt:f:v")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:adf:lt:uv";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "all", no_argument, NULL, 'a' },
+        { "unset-deleted", no_argument, NULL, 'd' },
+        { "set-flag", required_argument, NULL, 'f' },
+        { "list", no_argument, NULL, 'l' },
+        { "within-time-interval", required_argument, NULL, 't' },
+        { "uids", no_argument, NULL, 'u' },
+        { "verbose", no_argument, NULL, 'v' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/ptclient/ptdump.c
+++ b/ptclient/ptdump.c
@@ -40,6 +40,7 @@
  */
 
 #include <config.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -71,13 +72,23 @@ static int dump_cb(void *rockp __attribute__((unused)),
 int main(int argc, char *argv[])
 {
     struct db *ptdb;
-    extern char *optarg;
     int opt;
     int r;
     const char *fname;
     char *alt_config = NULL, *tofree = NULL;
 
-    while ((opt = getopt(argc, argv, "C:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
@@ -110,7 +121,7 @@ int main(int argc, char *argv[])
 
     if (tofree) free(tofree);
 
-    /* iterate through db, wiping expired entries */
+    /* iterate through db, printing entries */
     cyrusdb_foreach(ptdb, "", 0, NULL, dump_cb, ptdb, NULL);
 
     cyrusdb_close(ptdb);

--- a/ptclient/ptexpire.c
+++ b/ptclient/ptexpire.c
@@ -54,6 +54,7 @@
 #define MAXPATHLEN MAXPATHNAMELEN
 #endif
 
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -102,7 +103,6 @@ static int expire_cb(void *rockp,
 int main(int argc, char *argv[])
 {
     struct db *ptdb;
-    extern char *optarg;
     int opt;
     int r;
     const char *fname;
@@ -110,7 +110,19 @@ int main(int argc, char *argv[])
 
     openlog("ptexpire", LOG_PID, SYSLOG_FACILITY);
 
-    while ((opt = getopt(argc, argv, "C:E:")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:E:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "expire-duration", required_argument, NULL, 'E' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/sieve/sievec.c
+++ b/sieve/sievec.c
@@ -54,6 +54,7 @@
 #include "script.h"
 #include "util.h"
 #include "assert.h"
+#include <getopt.h>
 #include <string.h>
 #include <stdlib.h>
 #include <sys/file.h>
@@ -72,11 +73,21 @@ int main(int argc, char **argv)
     char *err = NULL;
     sieve_script_t *s = NULL;
     bytecode_info_t *bc = NULL;
-    int c, fd, usage_error = 0;
+    int opt, fd, usage_error = 0;
     char *alt_config = NULL;
 
-    while ((c = getopt(argc, argv, "C:")) != EOF)
-        switch (c) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
+        switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
             break;
@@ -84,6 +95,7 @@ int main(int argc, char **argv)
             usage_error = 1;
             break;
         }
+    }
 
     if (usage_error || (argc - optind) < 2) {
         fprintf(stderr, "Syntax: %s [-C <altconfig>] <filename> <outputfile>\n",

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -56,6 +56,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <unistd.h>
 #include <netinet/in.h>
 #include <inttypes.h>
@@ -102,12 +103,23 @@ int main(int argc, char * argv[])
 {
     bytecode_input_t *bc = NULL;
     int script_fd;
-    int c, usage_error = 0, gen_script = 0;
+    int opt, usage_error = 0, gen_script = 0;
 
     unsigned long len;
 
-    while ((c = getopt(argc, argv, "s")) != EOF)
-        switch (c) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "s";
+
+    static const struct option long_options[] = {
+        { "as-sieve", no_argument, NULL, 's' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
+        switch (opt) {
         case 's':
             gen_script = 1;
             break;
@@ -115,6 +127,7 @@ int main(int argc, char * argv[])
             usage_error = 1;
             break;
         }
+    }
 
     if (usage_error || (argc - optind) < 1) {
         fprintf(stderr, "Syntax: %s [-s] <bytecode-file>\n",


### PR DESCRIPTION
This adds long-options support to the command line tools, with the exception of `ctl_cyrusdb` and `reconstruct`.  I'll do those separately later, once the uniqueid safety work is finished, to avoid a bunch of rebasing.

This is one of those annoying ones where the lion's share of changes are in strings, which the compiler can't check for spelling or consistency.  We also don't have any tests for the majority of these commands!  So please review with a very close eye.

I have tried to not change any existing behaviour, but simply add long-option synonyms for the existing short options.

I have _not_ added a long-option synonym for `-C altconfig`, because that needs to remain consistent with the service binaries, and this PR does not touch the service binaries.