### PR TITLE
cassandane.ini: don't choke on repeated params

### DIFF
--- a/cassandane/cassandane.ini.dockertests
+++ b/cassandane/cassandane.ini.dockertests
@@ -56,9 +56,6 @@ suppress = Rename.rename_inbox JMAPBackup Sieve.snooze_tzid MboxEvent.tls_login_
 [gdb]
 
 [config]
-# need to revert the defaults for now because tests were built do old defaults.
-# remove this when they're fixed!
-unixhierarchysep = no
 zoneinfo_dir = /usr/local/cyruslibs/share/cyrus-timezones/zoneinfo
 
 [imaptest]

--- a/docsrc/imap/developer/developer-testing.rst
+++ b/docsrc/imap/developer/developer-testing.rst
@@ -81,12 +81,6 @@ Install and configure Cassandane
             [imaptest]
             basedir=/path/to/imaptest/imaptest
             suppress=append-binary urlauth-binary fetch-binary-mime fetch-binary-mime-qp
-    * Ensure that the following config items are off:
-
-      .. code-block:: ini
-
-         altnamespace = no
-         unixhierarchysep = no
 
 6. Create a ``cyrus`` user and matching group and also add ``cyrus`` to group ``mail``
 

--- a/docsrc/imap/developer/developer-testing.rst
+++ b/docsrc/imap/developer/developer-testing.rst
@@ -59,7 +59,7 @@ Install and configure Cassandane
         sudo cpan -i Mail::JMAPTalk
         sudo cpan -i Math::Int64
 
-3. Install Cassandane
+3. Build Cassandane's binary components
 
    .. code-block:: bash
 
@@ -164,12 +164,20 @@ If you're testing across versions, the binsymlinks is necessary as older Cyrus d
 Running the tests
 =================
 
-As user ``cyrus``, run the tests.
+Cassandane internals need to run as the ``cyrus`` user, but if you gave
+yourself passwordless sudo access as instructed above, then Cassandane will
+take care of switching to the ``cyrus`` user for you.  In which case, just run
+it as yourself.
+
+If you didn't give yourself this access, you will first need to become the
+``cyrus`` user by some other means, and then run it from there.
 
 .. code-block:: bash
 
     cd /path/to/cyrus-imapd/cassandane
-    sudo -u cyrus ./testrunner.pl -f pretty -j 8
+    ./testrunner.pl
+
+Do not run it as root.
 
 Debugging and stacktraces
 =========================
@@ -178,13 +186,23 @@ Check out the guide to :ref:`running Cyrus components under gdb <faqs-o-gdb>`.
 
 In the event of a crash, here's how to :ref:`generate a stacktrace <faqs-o-coredump>`.
 
+Core dumps will be owned by the ``cyrus`` user, but your source tree will
+probably be owned by yourself.  Copy the core dump somewhere convenient,
+change the ownership to yourself, and then you can open the core file in
+gdb for examination.
+
 Tips and Tricks
 ===============
 
-Read the script to see other options. If you're having problems, add more ``-v`` options to the testrunner to get more info out.
+Read the script to see other options. If you're having problems, add more
+``-v`` options to the testrunner to get more info out.
 
-**Looking for memory leaks?** Run with --valgrind to use valgrind (if it's installed). It is slower, which is why it doesn't need to be always used.
+**Looking for memory leaks?** Run with --valgrind to use valgrind (if it's
+installed). It is slower, which is why it doesn't need to be always used.
 
-Running with -v -v is very noisy, but gives a lot more data.  For example: all IMAP telemetry.
+Running with -v -v is very noisy, but gives a lot more data.  For example: all
+IMAP telemetry.
 
-Also helpful to run ``sudo tail -f /var/log/syslog``, and examine  /var/tmp/cass as root to examine log files and disk structures for failed tests.
+Also helpful to run ``sudo tail -f /var/log/syslog``, and examine
+/var/tmp/cass as ``cyrus`` to examine log files and disk structures for
+failed tests.


### PR DESCRIPTION
Fixes a bug where if a parameter in the `[config]` section of cassandane.ini was specified more than once, Cassandane would produce junk imapd.conf files, and then all tests would error out due to master aborting.

Now, if a parameter is specified multiple times, the last value read takes precedence, and a warning is logged saying so.  In verbose mode, all values for the offending item are logged.

In practice, this change only affects the `[config]` section; all other cassandane.ini parameters are read individually, and will continue doing whatever they already did.