### PR TITLE
3.6: use after free

### DIFF
--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -804,7 +804,7 @@ int sched_busytime_query(struct transaction_t *txn,
     xmlNodePtr root = NULL;
     xmlNsPtr ns[NUM_NAMESPACE];
     struct propfind_ctx fctx;
-    struct freebusy_filter calfilter;
+    struct freebusy_filter calfilter = {0};
     struct hash_table remote_table;
     struct caldav_sched_param *remote = NULL;
 
@@ -841,7 +841,6 @@ int sched_busytime_query(struct transaction_t *txn,
     ensure_ns(ns, NS_DAV, root, XML_NS_DAV, "D");
 
     /* Populate our filter and propfind context for local attendees */
-    memset(&calfilter, 0, sizeof(struct freebusy_filter));
     calfilter.start = icalcomponent_get_dtstart(comp);
     calfilter.end = icalcomponent_get_dtend(comp);
     calfilter.flags = CHECK_CAL_TRANSP | CHECK_USER_AVAIL;

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -332,21 +332,23 @@ static int jmap_parse_path(const char *path, struct request_target_t *tgt,
         char *inbox = mboxname_user_mbox(httpd_userid, NULL);
         int r = proxy_mlookup(inbox, &tgt->mbentry, NULL, NULL);
 
-        free(inbox);
-
         if (r) {
             syslog(LOG_ERR, "mlookup(%s) failed: %s", inbox, error_message(r));
+        }
+        free(inbox);
 
-            switch (r) {
-            case IMAP_PERMISSION_DENIED:
-                return HTTP_FORBIDDEN;
+        switch (r) {
+        case 0:
+            break;
 
-            case IMAP_MAILBOX_NONEXISTENT:
-                return HTTP_NOT_FOUND;
+        case IMAP_PERMISSION_DENIED:
+            return HTTP_FORBIDDEN;
 
-            default:
-                return HTTP_SERVER_ERROR;
-            }
+        case IMAP_MAILBOX_NONEXISTENT:
+            return HTTP_NOT_FOUND;
+
+        default:
+            return HTTP_SERVER_ERROR;
         }
     }
 

--- a/imap/jcal.c
+++ b/imap/jcal.c
@@ -184,8 +184,13 @@ static json_t *icalvalue_as_json_object(const icalvalue *value)
         struct icalgeotype geo = icalvalue_get_geo(value);
 
         obj = json_array();
+#ifdef ICAL_GEO_LEN
+        json_array_append_new(obj, json_real(atof(geo.lat)));
+        json_array_append_new(obj, json_real(atof(geo.lon)));
+#else
         json_array_append_new(obj, json_real(geo.lat));
         json_array_append_new(obj, json_real(geo.lon));
+#endif
         return obj;
     }
 
@@ -523,11 +528,16 @@ static icalvalue *json_object_to_icalvalue(json_t *jvalue,
                  i++);
             if (i == len) {
                 struct icalgeotype geo;
+                double lat = json_real_value(json_array_get(jvalue, 0));
+                double lon = json_real_value(json_array_get(jvalue, 1));
 
-                geo.lat =
-                    json_real_value(json_array_get(jvalue, 0));
-                geo.lon =
-                    json_real_value(json_array_get(jvalue, 1));
+#ifdef ICAL_GEO_LEN
+                snprintf(geo.lat, ICAL_GEO_LEN-1, "%lf", lat);
+                snprintf(geo.lon, ICAL_GEO_LEN-1, "%lf", lon);
+#else
+                geo.lat = lat;
+                geo.lon = lon;
+#endif
 
                 value = icalvalue_new_geo(geo);
             }

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -56,6 +56,7 @@
 #include "version.h"
 #include "xcal.h"
 #include "xml_support.h"
+#include "xstrlcpy.h"
 
 
 /*
@@ -355,10 +356,15 @@ static void icalproperty_add_value_as_xml_element(xmlNodePtr xprop,
     case ICAL_GEO_VALUE: {
         struct icalgeotype geo = icalvalue_get_geo(value);
 
+#ifdef ICAL_GEO_LEN
+        xmlNewTextChild(xtype, NULL, BAD_CAST "latitude", BAD_CAST geo.lat);
+        xmlNewTextChild(xtype, NULL, BAD_CAST "longitude", BAD_CAST geo.lon);
+#else
         snprintf(buf, sizeof(buf), "%f", geo.lat);
         xmlNewTextChild(xtype, NULL, BAD_CAST "latitude", BAD_CAST buf);
         snprintf(buf, sizeof(buf), "%f", geo.lon);
         xmlNewTextChild(xtype, NULL, BAD_CAST "longitude", BAD_CAST buf);
+#endif
         return;
     }
 
@@ -634,7 +640,11 @@ static icalvalue *xml_element_to_icalvalue(xmlNodePtr xtype,
         }
 
         content = xmlNodeGetContent(node);
+#ifdef ICAL_GEO_LEN
+        strlcpy(geo.lat, (const char *) content, ICAL_GEO_LEN);
+#else
         geo.lat = atof((const char *) content);
+#endif
 
         node = xmlNextElementSibling(node);
         if (!node) {
@@ -649,7 +659,11 @@ static icalvalue *xml_element_to_icalvalue(xmlNodePtr xtype,
 
         xmlFree(content);
         content = xmlNodeGetContent(node);
+#ifdef ICAL_GEO_LEN
+        strlcpy(geo.lon, (const char *) content, ICAL_GEO_LEN);
+#else
         geo.lon = atof((const char *) content);
+#endif
 
         value = icalvalue_new_geo(geo);
 


### PR DESCRIPTION
Backport from master to cyrus-imap-3.6:
* 02393e9456d7d1e5ace89f — https://github.com/cyrusimap/cyrus-imapd/issues/4044
* ac63b9846db220 — https://github.com/cyrusimap/cyrus-imapd/issues/4046
* 6c83c13a3ffc73 — jcal.c, xcal.c: support iCal GEO property as text