### PR TITLE
extend itip message format

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-encode-imip-uri
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-encode-imip-uri
@@ -6,6 +6,7 @@ sub test_calendarevent_encode_imip_uri
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
+    my $uid = 'event1uid';
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -26,6 +27,7 @@ EOF
                     calendarIds => {
                         Default => JSON::true,
                     },
+                    uid => $uid,
                     title => 'event1',
                     start => '2020-01-01T09:00:00',
                     timeZone => 'Europe/Vienna',
@@ -69,6 +71,9 @@ EOF
     my ($imipnotif) = grep { $_->{METHOD} eq 'imip' } @$data;
     my $payload = decode_json($imipnotif->{MESSAGE});
     $self->assert_str_equals('plus+uri@example.com', $payload->{recipient});
+    my $expect_id = encode_eventid($uid);
+    $self->assert_str_equals($expect_id, $payload->{id});
+    $self->assert_str_equals('REQUEST', $payload->{method});
 
     xlog "Assert the iTIP message has the encoded URI";
     my $itip = $payload->{ical};

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-set-destroy-itip
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-set-destroy-itip
@@ -10,9 +10,9 @@ sub test_calendarevent_set_destroy_itip
     my $caldav = $self->{caldav};
 
     my %expectNotif = (
-        'NEEDS-ACTION' => 0,
-        'TENTATIVE' => 1,
-        'ACCEPTED' => 1,
+        'NEEDS-ACTION' => undef,
+        'TENTATIVE' => 'REPLY',
+        'ACCEPTED' => 'REPLY',
     );
 
     while (my ($partstat, $wantNotif) = each %expectNotif) {
@@ -57,6 +57,11 @@ EOF
         if ($wantNotif) {
             xlog "Assert iTIP notification is sent";
             $self->assert_not_null($notif);
+
+            my $expect_id = encode_eventid($uid);
+            my $notif_payload = decode_json($notif->{MESSAGE});
+            $self->assert_str_equals($expect_id, $notif_payload->{id});
+            $self->assert_str_equals($wantNotif, $notif_payload->{method});
         } else {
             xlog "Assert no iTIP notification is sent";
             $self->assert_null($notif);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-set-standalone-itip
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-set-standalone-itip
@@ -6,6 +6,12 @@ sub test_calendarevent_set_standalone_itip
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
+    my $uid = 'event1uid',
+    my @details = (
+        { start => '2021-01-01T01:01:01', recurid => '20210101T010101' },
+        { start => '2022-02-02T02:02:02', recurid => '20220202T020202' },
+        { start => '2022-03-03T03:03:03', recurid => '20220303T030303' },
+    );
 
     xlog "Clear notification cache";
     $self->{instance}->getnotify();
@@ -19,12 +25,12 @@ sub test_calendarevent_set_standalone_itip
                         'Default' => JSON::true,
                     },
                     '@type' => 'Event',
-                    uid => 'event1uid',
+                    uid => $uid,
                     title => 'instance1',
-                    start => '2021-01-01T01:01:01',
+                    start => $details[0]->{start},
                     timeZone => 'Europe/Berlin',
                     duration => 'PT1H',
-                    recurrenceId => '2021-01-01T01:01:01',
+                    recurrenceId => $details[0]->{start},
                     recurrenceIdTimeZone => 'Europe/London',
                     replyTo => {
                         imip => 'mailto:organizer@example.com',
@@ -52,7 +58,8 @@ sub test_calendarevent_set_standalone_itip
     my $data = $self->{instance}->getnotify();
     my ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($notif);
-    my $itip = decode_json($notif->{MESSAGE})->{ical};
+    my $notif_payload = decode_json($notif->{MESSAGE});
+    my $itip = $notif_payload->{ical};
     my $ical = Data::ICal->new(data => $itip);
 
     my @vevents = grep { $_->ical_entry_type() eq 'VEVENT' } @{$ical->entries()};
@@ -60,7 +67,7 @@ sub test_calendarevent_set_standalone_itip
 
     my $recurid = $vevents[0]->property('RECURRENCE-ID');
     $self->assert_num_equals(1, scalar @{$recurid});
-    $self->assert_str_equals('20210101T010101', $recurid->[0]->value());
+    $self->assert_str_equals($details[0]->{recurid}, $recurid->[0]->value());
 
     my $attendees = $vevents[0]->property('ATTENDEE');
     $self->assert_num_equals(1, scalar @{$attendees});
@@ -68,6 +75,11 @@ sub test_calendarevent_set_standalone_itip
         $attendees->[0]->value());
     $self->assert_str_equals('TENTATIVE',
         $attendees->[0]->parameters()->{'PARTSTAT'});
+
+    my $expect_id = encode_eventid($uid, $details[0]->{recurid});
+    $self->assert_not_null($notif_payload->{id});
+    $self->assert_str_equals($expect_id, $notif_payload->{id});
+    $self->assert_str_equals('REPLY', $notif_payload->{method});
 
     xlog "Clear notification cache";
     $self->{instance}->getnotify();
@@ -83,10 +95,10 @@ sub test_calendarevent_set_standalone_itip
                     '@type' => 'Event',
                     uid => 'event1uid',
                     title => 'instance1',
-                    start => '2022-02-02T02:02:02',
+                    start => $details[1]->{start},
                     timeZone => 'Europe/Berlin',
                     duration => 'PT1H',
-                    recurrenceId => '2022-02-02T02:02:02',
+                    recurrenceId => $details[1]->{start},
                     recurrenceIdTimeZone => 'Europe/London',
                     replyTo => {
                         imip => 'mailto:organizer@example.com',
@@ -114,7 +126,8 @@ sub test_calendarevent_set_standalone_itip
     $data = $self->{instance}->getnotify();
     ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($notif);
-    $itip = decode_json($notif->{MESSAGE})->{ical};
+    $notif_payload = decode_json($notif->{MESSAGE});
+    $itip = $notif_payload->{ical};
     $ical = Data::ICal->new(data => $itip);
 
     @vevents = grep { $_->ical_entry_type() eq 'VEVENT' } @{$ical->entries()};
@@ -122,7 +135,7 @@ sub test_calendarevent_set_standalone_itip
 
     $recurid = $vevents[0]->property('RECURRENCE-ID');
     $self->assert_num_equals(1, scalar @{$recurid});
-    $self->assert_str_equals('20220202T020202', $recurid->[0]->value());
+    $self->assert_str_equals($details[1]->{recurid}, $recurid->[0]->value());
 
     $attendees = $vevents[0]->property('ATTENDEE');
     $self->assert_num_equals(1, scalar @{$attendees});
@@ -130,6 +143,11 @@ sub test_calendarevent_set_standalone_itip
         $attendees->[0]->value());
     $self->assert_str_equals('ACCEPTED',
         $attendees->[0]->parameters()->{'PARTSTAT'});
+
+    $expect_id = encode_eventid($uid, $details[1]->{recurid});
+    $self->assert_not_null($notif_payload->{id});
+    $self->assert_str_equals($expect_id, $notif_payload->{id});
+    $self->assert_str_equals('REPLY', $notif_payload->{method});
 
     xlog "Clear notification cache";
     $self->{instance}->getnotify();
@@ -150,7 +168,8 @@ sub test_calendarevent_set_standalone_itip
     $data = $self->{instance}->getnotify();
     ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($notif);
-    $itip = decode_json($notif->{MESSAGE})->{ical};
+    $notif_payload = decode_json($notif->{MESSAGE});
+    $itip = $notif_payload->{ical};
     $ical = Data::ICal->new(data => $itip);
 
     @vevents = grep { $_->ical_entry_type() eq 'VEVENT' } @{$ical->entries()};
@@ -158,7 +177,7 @@ sub test_calendarevent_set_standalone_itip
 
     $recurid = $vevents[0]->property('RECURRENCE-ID');
     $self->assert_num_equals(1, scalar @{$recurid});
-    $self->assert_str_equals('20220202T020202', $recurid->[0]->value());
+    $self->assert_str_equals($details[1]->{recurid}, $recurid->[0]->value());
 
     $attendees = $vevents[0]->property('ATTENDEE');
     $self->assert_num_equals(1, scalar @{$attendees});
@@ -166,6 +185,11 @@ sub test_calendarevent_set_standalone_itip
         $attendees->[0]->value());
     $self->assert_str_equals('DECLINED',
         $attendees->[0]->parameters()->{'PARTSTAT'});
+
+    $expect_id = encode_eventid($uid, $details[1]->{recurid});
+    $self->assert_not_null($notif_payload->{id});
+    $self->assert_str_equals($expect_id, $notif_payload->{id});
+    $self->assert_str_equals('REPLY', $notif_payload->{method});
 
     xlog "Clear notification cache";
     $self->{instance}->getnotify();
@@ -181,10 +205,10 @@ sub test_calendarevent_set_standalone_itip
                     '@type' => 'Event',
                     uid => 'event1uid',
                     title => 'instance3',
-                    start => '2022-03-03T03:03:03',
+                    start => $details[2]->{start},
                     timeZone => 'Europe/Berlin',
                     duration => 'PT1H',
-                    recurrenceId => '2022-03-03T03:03:03',
+                    recurrenceId => $details[2]->{start},
                     recurrenceIdTimeZone => 'Europe/London',
                     replyTo => {
                         imip => 'mailto:organizer@example.com',

--- a/cassandane/tiny-tests/JMAPCalendars/itip-request-tzid-change
+++ b/cassandane/tiny-tests/JMAPCalendars/itip-request-tzid-change
@@ -6,6 +6,7 @@ sub test_itip_request_tzid_change
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
+    my $uid = 'event1uid',
 
     xlog "Clear notifications";
     $self->{instance}->getnotify();
@@ -19,7 +20,7 @@ sub test_itip_request_tzid_change
                         'Default' => JSON::true,
                     },
                     '@type' => 'Event',
-                    uid => 'event1uid',
+                    uid => $uid,
                     title => 'event',
                     start => '2021-01-01T15:30:00',
                     timeZone => 'Europe/Berlin',
@@ -54,6 +55,10 @@ sub test_itip_request_tzid_change
     my $data = $self->{instance}->getnotify();
     my ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($notif);
+    my $notif_payload = decode_json($notif->{MESSAGE});
+    my $expect_id = encode_eventid($uid);
+    $self->assert_str_equals($expect_id, $notif_payload->{id});
+    $self->assert_str_equals('REQUEST', $notif_payload->{method});
 
     xlog "Clear notifications";
     $self->{instance}->getnotify();
@@ -74,4 +79,7 @@ sub test_itip_request_tzid_change
     $data = $self->{instance}->getnotify();
     ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($notif);
+    $notif_payload = decode_json($notif->{MESSAGE});
+    $self->assert_str_equals($expect_id, $notif_payload->{id});
+    $self->assert_str_equals('REQUEST', $notif_payload->{method});
 }

--- a/cassandane/tiny-tests/JMAPCalendars/itip-rsvp-organizer-change
+++ b/cassandane/tiny-tests/JMAPCalendars/itip-rsvp-organizer-change
@@ -6,6 +6,7 @@ sub test_itip_rsvp_organizer_change
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
+    my $uid = '7e017102-0caf-490a-bbdf-422141d34e75';
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -72,6 +73,10 @@ EOF
     my $data = $self->{instance}->getnotify();
     my ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($notif);
+    my $notif_payload = decode_json($notif->{MESSAGE});
+    my $expect_id = encode_eventid($uid);
+    $self->assert_str_equals($expect_id, $notif_payload->{id});
+    $self->assert_str_equals('REPLY', $notif_payload->{method});
 
     xlog "Clear notifications";
     $self->{instance}->getnotify();
@@ -102,4 +107,7 @@ EOF
     $data = $self->{instance}->getnotify();
     ($notif) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($notif);
+    $notif_payload = decode_json($notif->{MESSAGE});
+    $self->assert_str_equals($expect_id, $notif_payload->{id});
+    $self->assert_str_equals('REPLY', $notif_payload->{method});
 }

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -641,9 +641,13 @@ static int imip_send(const char *userid, struct sched_data *sched_data,
     const char *ical_str = icalcomponent_as_ical_string(sched_data->itip);
     if (!ical_str) goto done;
 
-    json_t *val = json_pack("{s:s s:s s:s s:o s:o s:b}",
+    const char *imip_method = icalproperty_method_to_string(
+                                  icalcomponent_get_method(sched_data->itip));
+
+    json_t *val = json_pack("{s:s s:s s:s s:s s:o s:o s:b}",
                             "recipient", buf_cstring(&recipient),
                             "sender", sender,
+                            "method", imip_method,
                             "ical", ical_str,
                             "jsevent", jsevent,
                             "patch", patch,


### PR DESCRIPTION
This extends `imip_send()` to include the JMAP id (as `id:`) and ITIP method (as `method:`) fields in IMIP notifications.  I did this by adding these as individual new fields, though...

Michael said:
> Actually, it would be really useful to just have the same thing we have when we include `calendarEvents` in Email/get, which comes from `jmap_calendar_events_from_msg`.

I had a look at this as an option, and both things end up in `jmapical_tojmap_all()` anyway.  So it's not clear to me why `jmap_calendar_events_from_msg()` would be producing additional fields beyond what `imip_send()` already was?

I'd like to add some tests, I'm concerned that recurid seems to always be NULL in what I've looked at so far... but maybe that's expected for IMIP, I dunno.  I'd appreciate some guidance in identifying which tests I should copy and modify, there's a lot with "itip" or "imip" in the name already, but they all pass, which means none of them cared much about the structure that I've changed.

There's also a bunch of junk debug logging in here, which I'll rebase out once I don't need it anymore.