### PR TITLE
jmap_ical: set managed attachment resource to Link blobId

### DIFF
--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -380,6 +380,8 @@ static int create_managedattach(struct jmapical_ctx *jmapctx,
     buf_printf(&preamble, "Date: %s\r\n", now);
     buf_appendcstr(&preamble, "Content-Type: application/octet-stream\r\n");
     buf_printf(&preamble, "Content-Length: %zu\r\n", buf_len(&getblobctx.blob));
+    buf_printf(&preamble, "Content-Disposition: attachment; filename=\"%s\"\r\n",
+            blobid[0] == 'G' ? blobid + 1 : blobid);
     buf_appendcstr(&preamble, "MIME-Version: 1.0\r\n");
 
     fwrite(buf_base(&preamble), buf_len(&preamble), 1, fp);


### PR DESCRIPTION
This fixes a regression that got introduced by 59ab8120175a6f3.
Before, the managed attachment resource name matched the blobId
because the JMAP upload handler already set it on the JMAP blob.
Now that the JMAP upload ignores the Content-Disposition header
during upload, it must be set when the attachment is created as
a copy of the JMAP blob.

The JMAPCalendars.calendarevent_set_linkblobid test asserts
that the regression got fixed.