### PR TITLE
jmap_api: reject invalid sinceState with cannotCalculateChanges error

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -2818,8 +2818,7 @@ sub test_mailbox_changes
 
     xlog $self, "get mailbox updates (expect error)";
     $res = $jmap->CallMethods([['Mailbox/changes', { sinceState => 0 }, "R1"]]);
-    $self->assert_str_equals("invalidArguments", $res->[0][1]->{type});
-    $self->assert_str_equals("sinceState", $res->[0][1]->{arguments}[0]);
+    $self->assert_str_equals("cannotCalculateChanges", $res->[0][1]->{type});
 
     xlog $self, "get mailbox updates (expect no changes)";
     $res = $jmap->CallMethods([['Mailbox/changes', { sinceState => $state }, "R1"]]);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-changes-issue2558
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-changes-issue2558
@@ -11,7 +11,7 @@ sub test_calendarevent_changes_issue2558
     xlog $self, "get calendar event updates with bad state";
     my $res = $jmap->CallMethods([['CalendarEvent/changes', { sinceState => 'nonsense' }, "R1"]]);
     $self->assert_str_equals('error', $res->[0][0]);
-    $self->assert_str_equals('invalidArguments', $res->[0][1]{type});
+    $self->assert_str_equals('cannotCalculateChanges', $res->[0][1]{type});
     $self->assert_str_equals('R1', $res->[0][2]);
 
     xlog $self, "get calendar event updates without state";

--- a/cassandane/tiny-tests/JMAPEmail/email-changes
+++ b/cassandane/tiny-tests/JMAPEmail/email-changes
@@ -25,8 +25,7 @@ sub test_email_changes
 
     xlog $self, "get email updates (expect error)";
     $res = $jmap->CallMethods([['Email/changes', { sinceState => 0 }, "R1"]]);
-    $self->assert_str_equals("invalidArguments", $res->[0][1]->{type});
-    $self->assert_str_equals("sinceState", $res->[0][1]->{arguments}[0]);
+    $self->assert_str_equals("cannotCalculateChanges", $res->[0][1]->{type});
 
     xlog $self, "get email state";
     $res = $jmap->CallMethods([['Email/get', { ids => []}, "R1"]]);

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2068,9 +2068,6 @@ HIDDEN void jmap_changes_parse(jmap_req_t *req,
                 have_sincemodseq = 1;
                 changes->since_modseq = atomodseq_t(json_string_value(arg));
             }
-            else {
-                jmap_parser_invalid(parser, "sinceState");
-            }
         }
 
         /* maxChanges */
@@ -2093,11 +2090,11 @@ HIDDEN void jmap_changes_parse(jmap_req_t *req,
     }
     else if (!have_sincemodseq) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
-                                      "description", "no sinceModseq");
+                                      "description", "invalid sinceState");
     }
     else if (changes->since_modseq < minmodseq) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
-                                      "description", "outdated sinceModseq");
+                                      "description", "outdated sinceState");
     }
 }
 


### PR DESCRIPTION
Before, an invalid sinceState argument was rejected with an
invalidArguments error.