### PR TITLE
Remove unused ptrarray_takevf()

### DIFF
--- a/cunit/ptrarray.testc
+++ b/cunit/ptrarray.testc
@@ -306,40 +306,6 @@ static void test_remove(void)
     ptrarray_fini(&pa);
 }
 
-static void test_takevf(void)
-{
-    ptrarray_t *pa;
-    void **pp;
-
-    pa = ptrarray_new();
-    CU_ASSERT_PTR_NOT_NULL(pa);
-    ptrarray_append(pa, PTR0);
-    ptrarray_append(pa, PTR1);
-    ptrarray_append(pa, PTR2);
-    ptrarray_append(pa, PTR3);
-    ptrarray_append(pa, PTR4);
-    CU_ASSERT_EQUAL(pa->count, 5);
-    CU_ASSERT(pa->alloc >= pa->count);
-    CU_ASSERT_PTR_NOT_NULL(pa->data);
-    CU_ASSERT_PTR_EQUAL(ptrarray_nth(pa, 0), PTR0);
-    CU_ASSERT_PTR_EQUAL(ptrarray_nth(pa, 1), PTR1);
-    CU_ASSERT_PTR_EQUAL(ptrarray_nth(pa, 2), PTR2);
-    CU_ASSERT_PTR_EQUAL(ptrarray_nth(pa, 3), PTR3);
-    CU_ASSERT_PTR_EQUAL(ptrarray_nth(pa, 4), PTR4);
-
-    pp = ptrarray_takevf(pa);
-    /* note: takevf frees the ptrarray itself */
-    CU_ASSERT_PTR_NOT_NULL(pp);
-    CU_ASSERT_PTR_EQUAL(pp[0], PTR0);
-    CU_ASSERT_PTR_EQUAL(pp[1], PTR1);
-    CU_ASSERT_PTR_EQUAL(pp[2], PTR2);
-    CU_ASSERT_PTR_EQUAL(pp[3], PTR3);
-    CU_ASSERT_PTR_EQUAL(pp[4], PTR4);
-    CU_ASSERT_PTR_NULL(pp[5]);
-
-    free(pp);
-}
-
 static void test_truncate(void)
 {
     ptrarray_t pa = PTRARRAY_INITIALIZER;

--- a/lib/ptrarray.c
+++ b/lib/ptrarray.c
@@ -193,15 +193,6 @@ EXPORTED void *ptrarray_nth(const ptrarray_t *pa, int idx)
     return pa->data[idx];
 }
 
-EXPORTED void **ptrarray_takevf(ptrarray_t *pa)
-{
-    void **d = pa->data;
-    pa->data = NULL;
-    pa->count = pa->alloc = 0;
-    ptrarray_free(pa);
-    return d;
-}
-
 EXPORTED int ptrarray_find(const ptrarray_t *pa, void *match, int starting)
 {
     if (!pa) return -1;

--- a/lib/ptrarray.h
+++ b/lib/ptrarray.h
@@ -80,8 +80,6 @@ void ptrarray_truncate(ptrarray_t *pa, int newlen);
 #define ptrarray_tail(pa)           ptrarray_nth((pa), -1)
 #define ptrarray_head(pa)           ptrarray_nth((pa), 0)
 
-void **ptrarray_takevf(ptrarray_t *pa);
-
 int ptrarray_find(const ptrarray_t *pa, void *match,
                   int starting);
 


### PR DESCRIPTION
Calling ptrarray_takevf() executes
```c
pa->data = NULL;
memset(pa->data, …);
```
and the first parameter of memset() may not be null.