### PR TITLE
Metadata: userrawquota is now a shared annotation

### DIFF
--- a/cassandane/Cassandane/Cyrus/Metadata.pm
+++ b/cassandane/Cassandane/Cyrus/Metadata.pm
@@ -321,6 +321,7 @@ sub test_shared
             '/shared/vendor/cmu/cyrus-imapd/lastpop' => undef,
             '/shared/vendor/cmu/cyrus-imapd/expire' => undef,
             '/shared/vendor/cmu/cyrus-imapd/duplicatedeliver' => 'false',
+            '/shared/vendor/cmu/cyrus-imapd/userrawquota' => undef,
             '/shared/specialuse' => undef,
             '/shared/thread' => undef,
             '/shared/sort' => undef,


### PR DESCRIPTION
Updates a test (Metadata.shared) that should have been updated by #4203, but was missed