### PR TITLE
search: improve DNF normalization complexity checks

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email-query-empty-filter-conds
+++ b/cassandane/tiny-tests/JMAPEmail/email-query-empty-filter-conds
@@ -1,0 +1,47 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_empty_filter_conds
+    :min_version_3_7 :needs_component_sieve :needs_component_jmap :JMAPExtensions
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    $self->make_message('test');
+
+    xlog $self, 'run squatter';
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                operator => 'NOT',
+                conditions => [{ }],
+            },
+        }, 'R0'],
+        ['Email/query', {
+            filter => {
+                operator => 'NOT',
+                conditions => [],
+            },
+        }, 'R1'],
+        ['Email/query', {
+            filter => {
+                operator => 'AND',
+                conditions => [{ }],
+            },
+        }, 'R2'],
+        ['Email/query', {
+            filter => {
+                operator => 'AND',
+                conditions => [],
+            },
+        }, 'R3'],
+    ], $using);
+
+    $self->assert_num_equals(0, scalar @{$res->[0][1]{ids}});
+    $self->assert_num_equals(1, scalar @{$res->[1][1]{ids}});
+    $self->assert_num_equals(1, scalar @{$res->[2][1]{ids}});
+    $self->assert_num_equals(0, scalar @{$res->[3][1]{ids}});
+}

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2333,9 +2333,6 @@ HIDDEN void jmap_filter_parse(jmap_req_t *req, struct jmap_parser *parser,
             jmap_parser_invalid(parser, "operator");
         }
         arg = json_object_get(filter, "conditions");
-        if (!json_array_size(arg)) {
-            jmap_parser_invalid(parser, "conditions");
-        }
         json_array_foreach(arg, i, val) {
             jmap_parser_push_index(parser, "conditions", i, NULL);
             jmap_filter_parse(req, parser, val, unsupported, parse_condition, cond_rock, err);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2241,7 +2241,7 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
                                              ptrarray_t *search_attrs,
                                              strarray_t *perf_filters)
 {
-    search_expr_t *this, *e;
+    search_expr_t *this;
     json_t *val;
     const char *s;
     size_t i;
@@ -2252,28 +2252,56 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
     }
 
     if ((s = json_string_value(json_object_get(filter, "operator")))) {
-        enum search_op op = SEOP_UNKNOWN;
+        json_t *conditions = json_object_get(filter, "conditions");
+        int is_not = 0;
 
+        // Build operator node
         if (!strcmp("AND", s)) {
-            op = SEOP_AND;
+            if (!json_array_size(conditions)) {
+                return search_expr_new(parent, SEOP_FALSE);
+            }
+            this = search_expr_new(parent, SEOP_AND);
         } else if (!strcmp("OR", s)) {
-            op = SEOP_OR;
+            if (!json_array_size(conditions)) {
+                return search_expr_new(parent, SEOP_FALSE);
+            }
+            this = search_expr_new(parent, SEOP_OR);
         } else if (!strcmp("NOT", s)) {
-            op = SEOP_NOT;
+            if (!json_array_size(conditions)) {
+                return search_expr_new(parent, SEOP_TRUE);
+            }
+            this = search_expr_new(parent, SEOP_AND);
+            is_not = 1;
+        } else {
+            return search_expr_new(parent, SEOP_UNKNOWN);
         }
 
-        this = search_expr_new(parent, op);
-        e = op == SEOP_NOT ? search_expr_new(this, SEOP_OR) : this;
+        // Build operand nodes, skip empty conditions
+        json_array_foreach(conditions, i, val) {
+            if (json_object_size(val)) {
+                search_expr_t *e = is_not ? search_expr_new(this, SEOP_NOT) : this;
+                _email_buildsearchexpr(req, val, e, contactgroups, want_expunged,
+                        search_attrs, perf_filters);
+            }
+        }
 
-        json_array_foreach(json_object_get(filter, "conditions"), i, val) {
-            _email_buildsearchexpr(req, val, e, contactgroups, want_expunged,
-                    search_attrs, perf_filters);
+        // Reduce empty operator nodes
+        if (!this->children) {
+            enum search_op op = is_not ? SEOP_FALSE : SEOP_TRUE;
+            if (parent) {
+                search_expr_detach(parent, this);
+            }
+            search_expr_free(this);
+            return search_expr_new(parent, op);
         }
     } else {
-        this = search_expr_new(parent, SEOP_AND);
+        if (!json_object_size(filter)) {
+            /* zero properties evaluate to true */
+            return search_expr_new(parent, SEOP_TRUE);
+        }
 
-        /* zero properties evaluate to true */
-        search_expr_new(this, SEOP_TRUE);
+        this = search_expr_new(parent, SEOP_AND);
+        search_expr_t *e;
 
         if ((s = json_string_value(json_object_get(filter, "after")))) {
             time_from_iso8601(s, &t);

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -847,16 +847,25 @@ static int _email_matchmime_evaluate(json_t *filter,
         int matches;
 
         if (!strcasecmpsafe(strop, "AND")) {
+            if (!json_array_size(conditions))
+                return 0;
+
             op = SEOP_AND;
             matches = 1;
         }
         else if (!strcasecmpsafe(strop, "OR")) {
+            if (!json_array_size(conditions))
+                return 0;
+
             op = SEOP_OR;
-            matches = json_array_size(conditions) == 0;
+            matches = 0;
         }
         else if (!strcasecmpsafe(strop, "NOT")) {
+            if (!json_array_size(conditions))
+                return 1;
+
             op = SEOP_NOT;
-            matches = json_array_size(conditions) != 0;
+            matches = 1;
         }
         else return 0;
 

--- a/imap/jmap_mail_query_parse.c
+++ b/imap/jmap_mail_query_parse.c
@@ -233,9 +233,6 @@ HIDDEN void jmap_email_filter_parse(json_t *filter,
             ctx->invalid_field("operator", ctx->rock);
         }
         json_t *jconds = json_object_get(filter, "conditions");
-        if (!json_array_size(jconds)) {
-            ctx->invalid_field("conditions", ctx->rock);
-        }
         size_t i;
         json_t *jcond;
         json_array_foreach(jconds, i, jcond) {

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -201,17 +201,13 @@ EXPORTED void search_expr_append(search_expr_t *parent, search_expr_t *e)
     append(parent, e);
 }
 
-/*
- * Recursively free a search expression tree including the given node
- * and all descendent nodes.
- */
-EXPORTED void search_expr_free(search_expr_t *e)
+static void search_expr_free_nnodes(search_expr_t *e, unsigned *nnodes)
 {
     if (!e) return;
     while (e->children) {
         search_expr_t *child = e->children;
         search_expr_detach(e, child);
-        search_expr_free(child);
+        search_expr_free_nnodes(child, nnodes);
     }
     if (e->attr) {
         if (e->attr->internalise) e->attr->internalise(NULL, NULL,
@@ -220,7 +216,17 @@ EXPORTED void search_expr_free(search_expr_t *e)
             e->attr->free(&e->value, (struct search_attr**)&e->attr);
         }
     }
+    if (nnodes && *nnodes > 0) *nnodes -= 1;
     free(e);
+}
+
+/*
+ * Recursively free a search expression tree including the given node
+ * and all descendent nodes.
+ */
+EXPORTED void search_expr_free(search_expr_t *e)
+{
+    search_expr_free_nnodes(e, NULL);
 }
 
 /*
@@ -541,7 +547,7 @@ static int apply_demorgan(search_expr_t **ep, search_expr_t **prevp, unsigned *n
     child->op = (child->op == SEOP_AND ? SEOP_OR : SEOP_AND);
     for (grandp = &child->children ; *grandp ; grandp = &(*grandp)->next)
         interpolate(grandp, SEOP_NOT, nnodes);
-    search_expr_free(elide(ep));
+    search_expr_free_nnodes(elide(ep), nnodes);
 
     return complexity_check(1, nnodes);
 }
@@ -567,8 +573,8 @@ static int apply_distribution(search_expr_t **ep, search_expr_t **prevp, unsigne
         append(newor, newand);
     }
 
-    search_expr_free(and);
-    search_expr_free(or);
+    search_expr_free_nnodes(and, nnodes);
+    search_expr_free_nnodes(or, nnodes);
 
     return complexity_check(r, nnodes);
 }
@@ -582,23 +588,23 @@ static int invert(search_expr_t **ep, search_expr_t **prevp, unsigned *nnodes)
 }
 
 /* combine compatible boolean parent and child nodes */
-static void combine(search_expr_t **ep, search_expr_t **prevp)
+static void combine(search_expr_t **ep, search_expr_t **prevp, unsigned *nnodes)
 {
     switch ((*ep)->op) {
     case SEOP_NOT:
-        search_expr_free(elide(prevp));
-        search_expr_free(elide(ep));
+        search_expr_free_nnodes(elide(prevp), nnodes);
+        search_expr_free_nnodes(elide(ep), nnodes);
         break;
     case SEOP_AND:
     case SEOP_OR:
-        search_expr_free(elide(prevp));
+        search_expr_free_nnodes(elide(prevp), nnodes);
         break;
     default:
         break;
     }
 }
 
-static int detrivialise(search_expr_t **ep)
+static int detrivialise(search_expr_t **ep, unsigned *nnodes)
 {
     if (!ep || !*ep) return 0;
 
@@ -608,7 +614,7 @@ static int detrivialise(search_expr_t **ep)
     search_expr_t *c, *next;
     for (c = e->children; c; c = next) {
         next = c->next;
-        int r2 = detrivialise(&c);
+        int r2 = detrivialise(&c, nnodes);
         if (!r2) r = r2;
     }
 
@@ -633,7 +639,7 @@ static int detrivialise(search_expr_t **ep)
                     }
                     else if (c->op == noop) {
                         search_expr_detach(e, c);
-                        search_expr_free(c);
+                        search_expr_free_nnodes(c, nnodes);
                         r = 1;
                     }
                 }
@@ -657,7 +663,7 @@ static int detrivialise(search_expr_t **ep)
 
     for (c = detached_children; c; c = next) {
         next = c->next;
-        search_expr_free(c);
+        search_expr_free_nnodes(c, nnodes);
     }
 
     if (e->op == SEOP_AND || e->op == SEOP_OR) {
@@ -668,7 +674,7 @@ static int detrivialise(search_expr_t **ep)
                 c = e->children;
                 e->children = NULL;
                 search_expr_detach(e->parent, e);
-                search_expr_free(e);
+                search_expr_free_nnodes(e, nnodes);
                 c->next = p->children;
                 p->children = c;
                 c->parent = p;
@@ -676,7 +682,7 @@ static int detrivialise(search_expr_t **ep)
             else {
                 *ep = e->children;
                 e->children = NULL;
-                search_expr_free(e);
+                search_expr_free_nnodes(e, nnodes);
             }
             r = 1;
         }
@@ -691,22 +697,36 @@ static int detrivialise(search_expr_t **ep)
 
 EXPORTED void search_expr_detrivialise(search_expr_t **ep)
 {
-    detrivialise(ep); // ignore return code
+    detrivialise(ep, NULL); // ignore return code
 }
 
 /*
  * Top-level normalisation step.  Returns 1 if it changed the subtree, 0
  * if it didn't, and -1 on error (such as exceeding a complexity limit).
  */
-static int normalise(search_expr_t **ep, unsigned *nnodes)
+static int normalise(search_expr_t **ep, unsigned *nnodes, unsigned *nnodes_last_collect)
 {
     search_expr_t **prevp;
     int depth;
     int changed = -1;
     int r;
+    char is_root = !nnodes_last_collect;
+    if (is_root) {
+        unsigned nnodes_last_collect_value = *nnodes;
+        nnodes_last_collect = &nnodes_last_collect_value;
+    }
 
 restart:
     changed++;
+
+    if (*nnodes > 2 * *nnodes_last_collect + 1) {
+        if (!is_root) return -2;
+
+        r = detrivialise(ep, nnodes);
+        *nnodes_last_collect = *nnodes;
+        if (r < 0) return -1;
+        if (r > 0) changed++;
+    }
 
 #if DEBUG
     the_focus = *ep;
@@ -720,7 +740,7 @@ restart:
     if (!has_enough_children(*ep)) {
         /* eliminate trivial nodes: AND and ORs with
          * a single child, NOTs with none */
-        search_expr_free(elide(ep));
+        search_expr_free_nnodes(elide(ep), nnodes);
         goto restart;
     }
 
@@ -729,7 +749,7 @@ restart:
     {
         int child_depth = dnf_depth(*prevp);
         if (child_depth == depth) {
-            combine(ep, prevp);
+            combine(ep, prevp, nnodes);
             goto restart;
         }
         if (child_depth < depth) {
@@ -737,7 +757,11 @@ restart:
             if (r < 0) return -1;
             goto restart;
         }
-        r = normalise(prevp, nnodes);
+        r = normalise(prevp, nnodes, nnodes_last_collect);
+        if (r == -2) {
+            if (is_root) goto restart;
+            return -2;
+        }
         if (r < 0) return -1;
         if (r > 0) goto restart;
     }
@@ -900,9 +924,9 @@ static int search_expr_normalise_nnodes(search_expr_t **ep, unsigned *nnodes)
 #if DEBUG
     the_rootp = ep;
 #endif
-    r = normalise(ep, nnodes);
+    r = normalise(ep, nnodes, NULL);
     if (r >= 0) {
-        int r2 = detrivialise(ep);
+        int r2 = detrivialise(ep, nnodes);
         if (!r) r = r2;
     }
     sort_children(*ep);


### PR DESCRIPTION
This is a slightly modified version of https://github.com/cyrusimap/cyrus-imapd/pull/4121 which got submitted by @mildred. In contrast to the original pull request it more leniently handles DNF subtrees that double during search expression normalization. In addition, it also aligns evaluation of empty conditions and operator nodes in the Sieve and JMAP handler implementations.

Passes the full Cassandane suite.