### PR TITLE
ptrarray: do not memset buffer that gets free()d anyway

### DIFF
--- a/lib/ptrarray.c
+++ b/lib/ptrarray.c
@@ -57,9 +57,8 @@ EXPORTED void ptrarray_fini(ptrarray_t *pa)
 {
     if (!pa)
         return;
-    memset(pa->data, 0, sizeof(void *) * pa->count);
-    free(pa->data);
-    pa->data = NULL;
+
+    xzfree(pa->data);
     pa->count = 0;
     pa->alloc = 0;
 }


### PR DESCRIPTION
This fixes a potential issue highlighted by @dilyanpalauzov in
https://github.com/cyrusimap/cyrus-imapd/pull/4206

ptrarray_fini calls memset to set the ptrarray data to zero,
irrespective if it points to NULL or an allocated buffer.
This is safe under normal conditions, as a ptrarray with null
data is expected to have a member count. It is unsafe if
this condition does not hold.

This patch removes the call to memset altogether, similar to
how fini is implemented for strarray.