### PR TITLE
Cassandane::Util::Log: highlight xlogs starting with XXX

### DIFF
--- a/cassandane/Cassandane/Util/Log.pm
+++ b/cassandane/Cassandane/Util/Log.pm
@@ -57,11 +57,19 @@ openlog('cassandane', '', LOG_LOCAL6)
 sub xlog
 {
     my $id;
+    my $highlight = 0;
+
     # if the first argument is an object with an id() method,
     # include the id it returns in the log message
     if (ref $_[0] && blessed $_[0] && $_[0]->can('id')) {
         my $obj = shift @_;
         $id = $obj->id();
+    }
+
+    # if the first output argument starts with XXX, highlight the
+    # whole line when printing to stderr
+    if ($_[0] =~ m/^XXX/) {
+        $highlight = 1;
     }
 
     # the current line number is in this frame
@@ -73,7 +81,12 @@ sub xlog
     my $msg = "[$$] =====> $sub\[$line] ";
     $msg .= "($id) " if $id;
     $msg .= join(' ', @_);
-    print STDERR "$msg\n";
+    if ($highlight) {
+        print STDERR "\033[33m" . $msg . "\033[0m\n";
+    }
+    else {
+        print STDERR "$msg\n";
+    }
     syslog(LOG_ERR, "$msg");
 }
 


### PR DESCRIPTION
When I'm writing and/or debugging Cassandane tests, I find myself writing temporary output like this all the time:

```
    xlog "XXX the whatsit is: " . Dumper $whatsit;
```

Though if I'm debugging, I'm also usually running with high verbosity, which is real noisy, so these lines are often still pretty hard to see.

I made this quick patch for xlog, such that logged lines starting with "XXX" are highlighted in colour, and it was an immediate improvement, so here it is for y'all to benefit from too. :)