### PR TITLE
3.6 imtest: memory leak

### DIFF
--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -947,6 +947,8 @@ static imt_stat getauthline(struct sasl_cmd_t *sasl_cmd, char **line, int *linel
         saslresult = sasl_decode64(str, strlen(str),
                                    *line, len, (unsigned *) linelen);
         if (saslresult != SASL_OK && saslresult != SASL_CONTINUE) {
+            xzfree(*line);
+            *linelen = 0;
             printf("base64 decoding error\n");
             return STAT_NO;
         }


### PR DESCRIPTION
cherry-pick c512f481cc940b74b7ac41

This backports a fix for a memory leak.