### PR TITLE
testrunner.pl: exit early if binary components missing

### DIFF
--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -67,6 +67,29 @@ my $skip_slow = 1;
 my $log_directory;
 my @names;
 
+# Make sure our binary components have been built already
+# -- get their names from the Makefile
+open my $mf, '<', 'utils/Makefile'
+    or die "Can't read utils/Makefile: $!";
+my $pat = qr{^(?:PROGRAMS|LIBS)=};
+my $missing_binaries = 0;
+foreach my $match (grep { m/$pat/ } <$mf>) {
+    chomp $match;
+    $match =~ s/$pat//;
+    foreach my $binary (split /\s+/, $match) {
+        my $filename = "utils/$binary";
+        if (! -e $filename || ! -x $filename) {
+            print STDERR "$filename is not executable or is missing\n";
+            $missing_binaries ++;
+        }
+    }
+}
+close $mf;
+if ($missing_binaries) {
+    print STDERR "Did you run 'make' yet?\n";
+    exit 1;
+}
+
 # This disgusting hack makes Test::Unit report a useful stack trace for
 # it's assert failures instead of just a file name and line number.
 {


### PR DESCRIPTION
If you've forgotten to run "make" in the cassandane directory before running testrunner.pl, a bunch of tests will fail due to binary components being missing -- but you won't know that until the run finishes and you get the report.

This makes testrunner.pl look for these files at startup and exit right away with an error message if they're missing, instead of running the tests and wasting twenty minutes

You can test this by running `make -C utils clean` in the cassandane directory to remove the built components, and then run testrunner.pl as usual to see the new error messages.

Fixes #4109

Once reviewed/approved/merged, I'll cherry pick this to the older branches too.