### PR TITLE
itip: remove CLASS property from iTIP messages

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/itip-remove-class-property
+++ b/cassandane/tiny-tests/JMAPCalendars/itip-remove-class-property
@@ -1,0 +1,151 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_itip_remove_class_property
+    :min_version_3_7 :needs_component_jmap :needs_component_sieve
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :deletecanceled :outcome "outcome";
+}
+EOF
+    );
+
+    xlog $self, "Organizer sends invite with CLASS=PRIVATE";
+
+    my $imip = <<'EOF';
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Sally Sender <sender@example.net>
+To: Cassandane <cassandane@example.com>
+Message-ID: <7e017102-0caf-490a-bbdf-422141d34e75@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:7e017102-0caf-490a-bbdf-422141d34e75
+TRANSP:OPAQUE
+SUMMARY:test
+CLASS:PRIVATE
+DTSTART;TZID=American/New_York:20210923T153000
+DURATION:PT1H
+DTSTAMP:20210923T034327Z
+RRULE:FREQ=DAILY;COUNT=3
+SEQUENCE:0
+ORGANIZER:MAILTO:organizer@example.net
+ATTENDEE;RSVP=TRUE;PARTSTAT=NEEDS-ACTION;X-JMAP-ID=cassandane:MAILTO:cassandane@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $self->{instance}->deliver(Cassandane::Message->new(raw => $imip));
+
+    xlog $self, "Assert privacy property is reset to default";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            properties => ['id', 'participants', 'privacy', 'x-href'],
+        }, 'R1'],
+    ]);
+    my $eventId = $res->[0][1]{list}[0]{id};
+    $self->assert_str_equals('public', $res->[0][1]{list}[0]->{privacy});
+    my $xhref = $res->[0][1]{list}[0]{'x-href'};
+    $self->assert_not_null($xhref);
+
+    xlog $self, "Assert CLASS property is not present in iCalendar";
+    my $caldavResponse = $caldav->Request('GET', $xhref);
+    $self->assert($caldavResponse->{content} !~ /CLASS:PRIVATE/);
+
+    xlog $self, "Clear notifications";
+    $self->{instance}->getnotify();
+
+    xlog $self, "Set privacy to 'secret' and accept invitation";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    'participants/cassandane/participationStatus' => 'accepted',
+                    'privacy' => 'secret',
+                },
+            }
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog $self, "Assert that iMIP message is sent";
+    my $data = $self->{instance}->getnotify();
+    my ($imip) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_not_null($imip);
+
+    xlog $self, "Assert CLASS property is not present in iTIP REPLY";
+    my $msg = decode_json($imip->{MESSAGE});
+    $self->assert($msg->{ical} !~ /CLASS:PRIVATE/);
+
+    xlog $self, "Organizer updates invite with recurrence override";
+
+    my $imip = <<'EOF';
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Sally Sender <sender@example.net>
+To: Cassandane <cassandane@example.com>
+Message-ID: <7e017102-0caf-490a-bbdf-422141d34e75@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:7e017102-0caf-490a-bbdf-422141d34e75
+TRANSP:OPAQUE
+SUMMARY:test
+CLASS:PRIVATE
+DTSTART;TZID=American/New_York:20210923T153000
+DURATION:PT1H
+DTSTAMP:20210923T034327Z
+RRULE:FREQ=DAILY;COUNT=3
+SEQUENCE:0
+ORGANIZER:MAILTO:organizer@example.net
+ATTENDEE;RSVP=TRUE;PARTSTAT=ACCEPTED;X-JMAP-ID=cassandane:MAILTO:cassandane@example.com
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:7e017102-0caf-490a-bbdf-422141d34e75
+TRANSP:OPAQUE
+SUMMARY:test
+CLASS:PRIVATE
+RECURRENCE-ID;TZID=American/New_York:20210924T153000
+DTSTART;TZID=American/New_York:20210924T163000
+DURATION:PT1H
+DTSTAMP:20210923T034327Z
+RRULE:FREQ=DAILY;COUNT=3
+SEQUENCE:0
+ORGANIZER:MAILTO:organizer@example.net
+ATTENDEE;RSVP=TRUE;PARTSTAT=NEEDS-ACTION;X-JMAP-ID=cassandane:MAILTO:cassandane@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $self->{instance}->deliver(Cassandane::Message->new(raw => $imip));
+
+    xlog $self, "Assert user-set privacy property is preserved";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            ids => [$eventId],
+            properties => ['id', 'privacy', 'recurrenceOverrides'],
+        }, 'R1'],
+    ]);
+    $self->assert_str_equals('secret', $res->[0][1]{list}[0]->{privacy});
+
+    xlog $self, "Assert privacy property on override matches main event";
+    $self->assert_null($res->[0][1]{list}[0]->{
+        recurrenceOverrides}{'2021-09-24T15:30:00'}{privacy});
+}

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1338,7 +1338,7 @@ static void clean_component(icalcomponent *comp)
 {
     icalproperty *prop;
 
-    /* Strip VALARMs, TRANSP, COLOR, and CATEGORIES (if color) */
+    /* Strip per-user properties */
     itip_strip_personal_data(comp);
 
     /* Replace DTSTAMP on component */


### PR DESCRIPTION
This patch removes the iCalendar CLASS property when receiving and sending iTIP messages. For JMAP Calendars, Cyrus enforces the access classification of the CLASS property for sharees of a calendar mailbox. It should be up to the calendar owner, not the ORGANIZER of an event, to set the desired access level.

One thing to decide before we actually merge this is if Cyrus should always enforce this, or only if configured to do so. Looking at the standards, it seems up to the server implementations how to deal with CLASS. The semantics of the CLASS property only are vaguely described in [RFC 5545, section 3.8.1.3.](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.1.3), and [RFC 5546 ](https://www.rfc-editor.org/rfc/rfc5546) explicitly allows CLASS to exist in iTIP messages, but allows implementation to ignore it as a fallback. We might add an imapd.conf option, or strip the CLASS property if Cyrus was built with JMAP support. My suggestion is to do the latter, as JMAP Calendars requires us to enforce the CLASS property with JMAP semantics.