### PR TITLE
imapd.conf BYTESIZE smart type

### DIFF
--- a/backup/lcb_compact.c
+++ b/backup/lcb_compact.c
@@ -67,12 +67,12 @@ static void compact_readconfig(void)
     /* read and normalise config values */
     if (compact_minsize == 0) {
         compact_minsize = (size_t)
-            MAX(0, 1024 * config_getint(IMAPOPT_BACKUP_COMPACT_MINSIZE));
+            MAX(0, config_getbytesize(IMAPOPT_BACKUP_COMPACT_MINSIZE, 'K'));
     }
 
     if (compact_maxsize == 0) {
         compact_maxsize = (size_t)
-            MAX(0, 1024 * config_getint(IMAPOPT_BACKUP_COMPACT_MAXSIZE));
+            MAX(0, config_getbytesize(IMAPOPT_BACKUP_COMPACT_MAXSIZE, 'K'));
     }
 
     if (compact_work_threshold == 0) {

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -121,7 +121,7 @@ sub new
                  sieve_utf8fileinto => 'yes',
                  sieve_use_lmtp_reject => 'no',
                  sievenotifier => 'mailto',
-                 sieve_maxscriptsize => '1024',
+                 sieve_maxscriptsize => '1024K',
                  sieve_vacation_min_response => '60',
                  specialusealways => 'yes',
                  specialuse_extra => '\\XChats \\XTemplates \\XNotes',

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -113,7 +113,7 @@ sub new
                  postmaster => 'postmaster@example.com',
                  quota_db => 'quotalegacy',
                  quota_use_conversations => 'yes',
-                 quotawarn => '98',
+                 quotawarnpercent => '98',
                  reverseacls => 'yes',
                  rfc3028_strict => 'no',
                  savedate => 'yes',

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -462,6 +462,128 @@ static void test_duration_parse(void)
     }
 }
 
+static void test_bytesize_value_gibibytes(void)
+{
+    int64_t archive_maxsize = -1LL;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "archive_maxsize: 1G\n"
+    );
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    CU_ASSERT_EQUAL(archive_maxsize, 1LL * 1024 * 1024 * 1024);
+}
+
+static void test_bytesize_value_mebibytes(void)
+{
+    int64_t archive_maxsize = -1LL;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "archive_maxsize: 3M\n"
+    );
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    CU_ASSERT_EQUAL(archive_maxsize, 3LL * 1024 * 1024);
+}
+
+static void test_bytesize_value_kibibytes(void)
+{
+    int64_t archive_maxsize = -1LL;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "archive_maxsize: 45K\n"
+    );
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    CU_ASSERT_EQUAL(archive_maxsize, 45LL * 1024);
+}
+
+static void test_bytesize_value_bytes(void)
+{
+    int64_t archive_maxsize = -1LL;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "archive_maxsize: 25B\n"
+    );
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'B');
+    CU_ASSERT_EQUAL(archive_maxsize, 25LL);
+}
+
+static void test_bytesize_value_nounits(void)
+{
+    int64_t archive_maxsize = -1LL;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "archive_maxsize: 13\n"
+    );
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'B');
+    CU_ASSERT_EQUAL(archive_maxsize, 13LL);
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    CU_ASSERT_EQUAL(archive_maxsize, 13LL * 1024);
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'M');
+    CU_ASSERT_EQUAL(archive_maxsize, 13LL * 1024 * 1024);
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'G');
+    CU_ASSERT_EQUAL(archive_maxsize, 13LL * 1024 * 1024 * 1024);
+}
+
+static void test_bytesize_value_negative(void)
+{
+    int64_t archive_maxsize = 0xdeadbeef;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "archive_maxsize: -1\n"
+    );
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'B');
+    CU_ASSERT_EQUAL(archive_maxsize, -1LL);
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    CU_ASSERT_EQUAL(archive_maxsize, -1LL * 1024);
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'M');
+    CU_ASSERT_EQUAL(archive_maxsize, -1LL * 1024 * 1024);
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'G');
+    CU_ASSERT_EQUAL(archive_maxsize, -1LL * 1024 * 1024 * 1024);
+}
+
+static void test_bytesize_default(void)
+{
+    int64_t archive_maxsize = -1LL;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        /* archive_maxsize: 1024 K (default) */
+    );
+
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    CU_ASSERT_EQUAL(archive_maxsize, 1024LL * 1024);
+}
+
+static void test_bytesize_invalid(void)
+{
+    CU_EXPECT_CYRFATAL_BEGIN
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "archive_maxsize: junk\n"
+    );
+    CU_EXPECT_CYRFATAL_END(
+        EX_CONFIG,
+        "unparsable byte size 'junk' for archive_maxsize in line 2"
+    );
+}
+
 struct bytesize_parse_data {
     const char *str;
     int expected_result;

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -780,51 +780,51 @@ static void test_magic_configdirectory_default(void)
 
 static void test_deprecated_int(void)
 {
-    /* { "autocreatequota", 0, INT, "2.5.0", "autocreate_quota" } */
+    /* { "autocreatequotamsg", -1, INT, "2.5.0", "2.5.0", "autocreate_quota_messages" } */
     int val;
 
     /* set the deprecated name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
-        "autocreatequota: 12\n"
+        "autocreatequotamsg: 12\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 1);
 
     /* should not be able to read the deprecated name */
     CU_EXPECT_CYRFATAL_BEGIN
-    val = config_getint(IMAPOPT_AUTOCREATEQUOTA);
+    val = config_getint(IMAPOPT_AUTOCREATEQUOTAMSG);
     CU_EXPECT_CYRFATAL_END(EX_SOFTWARE,
-        "Option 'autocreatequota' is deprecated in favor of "
-        "'autocreate_quota' since version 2.5.0.");
+        "Option 'autocreatequotamsg' is deprecated in favor of "
+        "'autocreate_quota_messages' since version 2.5.0.");
 
     /* should be able to read the value at the new name */
-    val = config_getint(IMAPOPT_AUTOCREATE_QUOTA);
+    val = config_getint(IMAPOPT_AUTOCREATE_QUOTA_MESSAGES);
     CU_ASSERT_EQUAL(val, 12);
 
     /* set the new name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
-        "autocreate_quota: 12\n"
+        "autocreate_quota_messages: 12\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 0);
 
     /* should be able to read it at the new name */
-    val = config_getint(IMAPOPT_AUTOCREATE_QUOTA);
+    val = config_getint(IMAPOPT_AUTOCREATE_QUOTA_MESSAGES);
     CU_ASSERT_EQUAL(val, 12);
 
     /* set both names to different values */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
-        "autocreatequota: 12\n"
-        "autocreate_quota: 15\n"
+        "autocreatequotamsg: 12\n"
+        "autocreate_quota_messages: 15\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 1);
 
     /* should read new value at the new name */
-    val = config_getint(IMAPOPT_AUTOCREATE_QUOTA);
+    val = config_getint(IMAPOPT_AUTOCREATE_QUOTA_MESSAGES);
     CU_ASSERT_EQUAL(val, 15);
 }
 

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -462,6 +462,172 @@ static void test_duration_parse(void)
     }
 }
 
+struct bytesize_parse_data {
+    const char *str;
+    int expected_result;
+    int64_t expected_bytesize;
+};
+
+static const struct bytesize_parse_data bytesize_parse_tests[] = {
+    /* no digits */
+    { "", -1, 0xdeadbeefLL },
+    { "B", -1, 0xdeadbeefLL },
+    { "KB", -1, 0xdeadbeefLL },
+    { "KiB", -1, 0xdeadbeefLL },
+    { "-B", -1, 0xdeadbeefLL },
+    { "-KB", -1, 0xdeadbeefLL },
+    { "-KiB", -1, 0xdeadbeefLL },
+
+    /* no suffix */
+    { "0",      0,     0LL },
+    { "1",      0,     1LL },
+    { "9876",   0,  9876LL },
+    { "-1234",  0, -1234LL },
+
+    /* bytes suffix */
+    { "0b",     0,     0LL },
+    { "0B",     0,     0LL },
+    { "1b",     0,     1LL },
+    { "1B",     0,     1LL },
+    { "9876b",  0,  9876LL },
+    { "9876B",  0,  9876LL },
+    { "-1234b", 0, -1234LL },
+    { "-1234B", 0, -1234LL },
+
+    /* no such thing as "ibibytes"! */
+    { "0ib",     -1, 0xdeadbeefLL },
+    { "0iB",     -1, 0xdeadbeefLL },
+    { "1ib",     -1, 0xdeadbeefLL },
+    { "1iB",     -1, 0xdeadbeefLL },
+    { "9876ib",  -1, 0xdeadbeefLL },
+    { "9876iB",  -1, 0xdeadbeefLL },
+    { "-1234ib", -1, 0xdeadbeefLL },
+    { "-1234iB", -1, 0xdeadbeefLL },
+
+    /* K suffix */
+    { "0k",     0,     0LL * 1024 },
+    { "0K",     0,     0LL * 1024 },
+    { "1k",     0,     1LL * 1024 },
+    { "1K",     0,     1LL * 1024 },
+    { "9876k",  0,  9876LL * 1024 },
+    { "9876K",  0,  9876LL * 1024 },
+    { "-1234k", 0, -1234LL * 1024 },
+    { "-1234K", 0, -1234LL * 1024 },
+
+    /* KB suffix */
+    { "0kb",     0,     0LL * 1024 },
+    { "0KB",     0,     0LL * 1024 },
+    { "1kb",     0,     1LL * 1024 },
+    { "1KB",     0,     1LL * 1024 },
+    { "9876kb",  0,  9876LL * 1024 },
+    { "9876KB",  0,  9876LL * 1024 },
+    { "-1234kb", 0, -1234LL * 1024 },
+    { "-1234KB", 0, -1234LL * 1024 },
+
+    /* KiB suffix */
+    { "0kib",     0,     0LL * 1024 },
+    { "0KiB",     0,     0LL * 1024 },
+    { "1kib",     0,     1LL * 1024 },
+    { "1KiB",     0,     1LL * 1024 },
+    { "9876kib",  0,  9876LL * 1024 },
+    { "9876KiB",  0,  9876LL * 1024 },
+    { "-1234kib", 0, -1234LL * 1024 },
+    { "-1234KiB", 0, -1234LL * 1024 },
+
+    /* M suffix */
+    { "0m",      0,     0LL * 1024 * 1024 },
+    { "0M",      0,     0LL * 1024 * 1024 },
+    { "1m",      0,     1LL * 1024 * 1024 },
+    { "1M",      0,     1LL * 1024 * 1024 },
+    { "9876m",   0,  9876LL * 1024 * 1024 },
+    { "9876M",   0,  9876LL * 1024 * 1024 },
+    { "-1234m",  0, -1234LL * 1024 * 1024 },
+    { "-1234M",  0, -1234LL * 1024 * 1024 },
+
+    /* MB suffix */
+    { "0mb",     0,     0LL * 1024 * 1024 },
+    { "0MB",     0,     0LL * 1024 * 1024 },
+    { "1mb",     0,     1LL * 1024 * 1024 },
+    { "1MB",     0,     1LL * 1024 * 1024 },
+    { "9876mb",  0,  9876LL * 1024 * 1024 },
+    { "9876MB",  0,  9876LL * 1024 * 1024 },
+    { "-1234mb", 0, -1234LL * 1024 * 1024 },
+    { "-1234MB", 0, -1234LL * 1024 * 1024 },
+
+    /* MiB suffix */
+    { "0mib",     0,     0LL * 1024 * 1024 },
+    { "0MiB",     0,     0LL * 1024 * 1024 },
+    { "1mib",     0,     1LL * 1024 * 1024 },
+    { "1MiB",     0,     1LL * 1024 * 1024 },
+    { "9876mib",  0,  9876LL * 1024 * 1024 },
+    { "9876MiB",  0,  9876LL * 1024 * 1024 },
+    { "-1234mib", 0, -1234LL * 1024 * 1024 },
+    { "-1234MiB", 0, -1234LL * 1024 * 1024 },
+
+    /* G suffix */
+    { "0g",     0,     0LL * 1024 * 1024 * 1024 },
+    { "0G",     0,     0LL * 1024 * 1024 * 1024 },
+    { "1g",     0,     1LL * 1024 * 1024 * 1024 },
+    { "1G",     0,     1LL * 1024 * 1024 * 1024 },
+    { "9876g",  0,  9876LL * 1024 * 1024 * 1024 },
+    { "9876G",  0,  9876LL * 1024 * 1024 * 1024 },
+    { "-1234g", 0, -1234LL * 1024 * 1024 * 1024 },
+    { "-1234G", 0, -1234LL * 1024 * 1024 * 1024 },
+
+    /* GB suffix */
+    { "0gb",     0,     0LL * 1024 * 1024 * 1024 },
+    { "0GB",     0,     0LL * 1024 * 1024 * 1024 },
+    { "1gb",     0,     1LL * 1024 * 1024 * 1024 },
+    { "1GB",     0,     1LL * 1024 * 1024 * 1024 },
+    { "9876gb",  0,  9876LL * 1024 * 1024 * 1024 },
+    { "9876GB",  0,  9876LL * 1024 * 1024 * 1024 },
+    { "-1234gb", 0, -1234LL * 1024 * 1024 * 1024 },
+    { "-1234GB", 0, -1234LL * 1024 * 1024 * 1024 },
+
+    /* GiB suffix */
+    { "0gib",     0,     0LL * 1024 * 1024 * 1024 },
+    { "0GiB",     0,     0LL * 1024 * 1024 * 1024 },
+    { "1gib",     0,     1LL * 1024 * 1024 * 1024 },
+    { "1GiB",     0,     1LL * 1024 * 1024 * 1024 },
+    { "9876gib",  0,  9876LL * 1024 * 1024 * 1024 },
+    { "9876GiB",  0,  9876LL * 1024 * 1024 * 1024 },
+    { "-1234gib", 0, -1234LL * 1024 * 1024 * 1024 },
+    { "-1234GiB", 0, -1234LL * 1024 * 1024 * 1024 },
+
+    /* trailing junk */
+    { "23MB my friends", -1, 0xdeadbeefLL },
+
+    /* unrecognised multiplier */
+    { "6TB", -1, 0xdeadbeefLL },
+    { "6PB", -1, 0xdeadbeefLL },
+
+    /* i case insensitivity */
+    { "25KiB", 0, 25LL * 1024 },
+    { "25KIB", 0, 25LL * 1024 },
+
+    /* optional whitespace between number and multiplier */
+    { "12 K",    0, 12LL * 1024 },
+    { "12 KB",   0, 12LL * 1024 },
+    { "12 KiB",  0, 12LL * 1024 },
+    { "12  K",   0, 12LL * 1024 },
+    { "12  KB",  0, 12LL * 1024 },
+    { "12  KiB", 0, 12LL * 1024 },
+};
+
+static void test_bytesize_parse(void)
+{
+    const size_t n = sizeof(bytesize_parse_tests) / sizeof(bytesize_parse_tests[0]);
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        const struct bytesize_parse_data *test = &bytesize_parse_tests[i];
+        int64_t bytesize = 0xdeadbeefLL;
+        int r = config_parsebytesize(test->str, 'B', &bytesize);
+        CU_ASSERT_EQUAL(r, test->expected_result);
+        CU_ASSERT_EQUAL(bytesize, test->expected_bytesize);
+    }
+}
+
 static void test_magic_configdirectory_value(void)
 {
     const char *idlesocket = NULL;

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -988,4 +988,55 @@ static void test_deprecated_duration(void)
     CU_ASSERT_EQUAL(val, 12 * 24 * 60 * 60);
 }
 
+static void test_deprecated_bytesize(void)
+{
+    /* { "autocreatequota", NULL, BYTESIZE, "UNRELEASED", "2.5.0", "autocreate_quota" } */
+    /* { "autocreate_quota", "-1", BYTESIZE, "UNRELEASED" } */
+    int64_t val;
+
+    /* set the deprecated name only */
+    CU_SYSLOG_MATCH("Option '.*' is deprecated");
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "autocreatequota: 8\n"
+    );
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    /* should not be able to read the deprecated name */
+    CU_EXPECT_CYRFATAL_BEGIN;
+    val = config_getbytesize(IMAPOPT_AUTOCREATEQUOTA, 'K');
+    CU_EXPECT_CYRFATAL_END(EX_SOFTWARE,
+        "Option 'autocreatequota' is deprecated in favor of "
+        "'autocreate_quota' since version 2.5.0.");
+
+    /* should be able to read it at the new name */
+    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+    CU_ASSERT_EQUAL(val, 8LL * 1024);
+
+    /* set the new name */
+    CU_SYSLOG_MATCH("Option '.*' is deprecated");
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "autocreate_quota: 12M\n"
+    );
+    CU_ASSERT_SYSLOG(/*all*/0, 0);
+
+    /* should be able to read it at the new name */
+    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+    CU_ASSERT_EQUAL(val, 12LL * 1024 * 1024);
+
+    /* set both names to different values */
+    CU_SYSLOG_MATCH("Option '.*' is deprecated");
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "autocreatequota: 7\n"
+        "autocreate_quota: 12M\n"
+    );
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    /* should read new value at the new name */
+    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+    CU_ASSERT_EQUAL(val, 12LL * 1024 * 1024);
+}
+
 /* vim: set ft=c: */

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -69,12 +69,12 @@ static int tear_down(void)
 static void test_int(void)
 {
     int boundary_limit = -1;
-    int archive_maxsize = -1;
+    int conversations_max_thread = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
         "boundary_limit: 120\n"
-        /* archive_maxsize: 1024 (default) */
+        /* conversations_max_thread: 100 (default) */
     );
 
     /* test a value that has been set */
@@ -82,8 +82,8 @@ static void test_int(void)
     CU_ASSERT_EQUAL(boundary_limit, 120);
 
     /* test a value that is defaulted */
-    archive_maxsize = config_getint(IMAPOPT_ARCHIVE_MAXSIZE);
-    CU_ASSERT_EQUAL(archive_maxsize, 1024);
+    conversations_max_thread = config_getint(IMAPOPT_CONVERSATIONS_MAX_THREAD);
+    CU_ASSERT_EQUAL(conversations_max_thread, 100);
 }
 
 static void test_string(void)

--- a/doc/legacy/overview.html
+++ b/doc/legacy/overview.html
@@ -525,7 +525,8 @@ When a user selects a mailbox whose quota root has usage that is close
 to or over the limit and the user has "<TT>d</TT>" rights on the mailbox, the
 server will issue an alert notifying the user that usage is close to
 or over the limit.  The threshold of usage at which the server will
-issue quota warnings is set by the "<TT>quotawarn</TT>" configuration option.
+issue quota warnings is set by the "<TT>quotawarnpercent</TT>" configuration
+option.
 
 <p>The server only issues warnings when the user has "<TT>d</TT>"
 rights because only users with "<TT>d</TT>" rights are capable of

--- a/docsrc/imap/concepts/overview_and_concepts.rst
+++ b/docsrc/imap/concepts/overview_and_concepts.rst
@@ -321,9 +321,14 @@ the sender.
 Quota Warnings Upon Select When User Has ``d`` Rights
 =====================================================
 
-When a user selects a mailbox whose quota root has usage that is close to or over the limit and the user has ``d`` rights on the mailbox, the server will issue an alert notifying the user that usage is close to or over the limit. The threshold of usage at which the server will issue quota warnings is set by the ``quotawarn`` configuration option.
+When a user selects a mailbox whose quota root has usage that is close to or
+over the limit and the user has ``d`` rights on the mailbox, the server will
+issue an alert notifying the user that usage is close to or over the limit.
+The threshold of usage at which the server will issue quota warnings is set
+by the ``quotawarnpercent`` configuration option.
 
-The server only issues warnings when the user has ``d`` rights because only users with ``d`` rights are capable of correcting the problem.
+The server only issues warnings when the user has ``d`` rights because only
+users with ``d`` rights are capable of correcting the problem.
 
 Quotas and Partitions
 =====================

--- a/docsrc/imap/reference/admin/quotas.rst
+++ b/docsrc/imap/reference/admin/quotas.rst
@@ -47,8 +47,8 @@ sites, via the use of several settings in :cyrusman:`imapd.conf(5)`:
 
 
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst
-        :start-after: startblob quotawarnkb
-        :end-before: endblob quotawarnkb
+        :start-after: startblob quotawarnsize
+        :end-before: endblob quotawarnsize
 
 
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst

--- a/docsrc/imap/reference/admin/quotas.rst
+++ b/docsrc/imap/reference/admin/quotas.rst
@@ -42,8 +42,8 @@ sites, via the use of several settings in :cyrusman:`imapd.conf(5)`:
 
 
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst
-        :start-after: startblob quotawarn
-        :end-before: endblob quotawarn
+        :start-after: startblob quotawarnpercent
+        :end-before: endblob quotawarnpercent
 
 
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -699,7 +699,7 @@ done:
 int autocreate_user(struct namespace *namespace, const char *userid)
 {
     int r = IMAP_MAILBOX_NONEXISTENT; /* default error if we break early */
-    int autocreatequota = config_getint(IMAPOPT_AUTOCREATE_QUOTA);
+    int64_t autocreatequota = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
     int autocreatequotamessage = config_getint(IMAPOPT_AUTOCREATE_QUOTA_MESSAGES);
     int n;
     struct auth_state *auth_state = NULL;
@@ -790,8 +790,8 @@ int autocreate_user(struct namespace *namespace, const char *userid)
         for (res = 0 ; res < QUOTA_NUMRESOURCES ; res++)
             newquotas[res] = QUOTA_UNLIMITED;
 
-        if (autocreatequota)
-            newquotas[QUOTA_STORAGE] = autocreatequota;
+        if (autocreatequota > 0)
+            newquotas[QUOTA_STORAGE] = autocreatequota / 1024;
 
         if (autocreatequotamessage)
             newquotas[QUOTA_MESSAGE] = autocreatequotamessage;

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -1184,12 +1184,12 @@ EXPORTED int carddav_store(struct mailbox *mailbox, struct vparse_card *vcard,
     time_t now = time(0);
     char *freeme = NULL;
     char datestr[80];
-    static int vcard_max_size = -1;
+    static int64_t vcard_max_size = -1;
     char *mbuserid = NULL;
 
     if (vcard_max_size < 0) {
-        vcard_max_size = config_getint(IMAPOPT_VCARD_MAX_SIZE);
-        if (vcard_max_size <= 0) vcard_max_size = INT_MAX;
+        vcard_max_size = config_getbytesize(IMAPOPT_VCARD_MAX_SIZE, 'B');
+        if (vcard_max_size <= 0) vcard_max_size = BYTESIZE_UNLIMITED;
     }
 
     init_internal();

--- a/imap/global.c
+++ b/imap/global.c
@@ -325,7 +325,7 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
         charset_snippet_flags |= CHARSET_ESCAPEHTML;
     }
 
-    config_search_maxsize = 1024 * config_getint(IMAPOPT_SEARCH_MAXSIZE);
+    config_search_maxsize = config_getbytesize(IMAPOPT_SEARCH_MAXSIZE, 'K');
 
     if (!cyrus_init_nodb) {
         /* lookup the database backends */

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -2196,8 +2196,9 @@ static void caldav_rewrite_attachprop_to_binary(struct mailbox *attachments,
     }
     if (!buf_len(b64val)) goto done;
 
-    size_t max_size = config_getint(IMAPOPT_WEBDAV_ATTACHMENTS_MAX_BINARY_ATTACH_SIZE);
-    if (max_size && buf_len(b64val) > max_size * 1024) goto done;
+    int64_t max_size = config_getbytesize(
+        IMAPOPT_WEBDAV_ATTACHMENTS_MAX_BINARY_ATTACH_SIZE, 'K');
+    if (max_size > 0 && buf_len(b64val) > (size_t) max_size) goto done;
 
     // Rewrite ATTACH property
     icalattach *newattach = icalattach_new_from_data(buf_cstring(b64val), NULL, 0);

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -90,7 +90,7 @@
 #include "imap/imap_err.h"
 
 static time_t compile_time;
-static int vcard_max_size;
+static int64_t vcard_max_size;
 
 static void my_carddav_init(struct buf *serverinfo);
 static int my_carddav_auth(const char *userid);
@@ -415,8 +415,8 @@ static void my_carddav_init(struct buf *serverinfo __attribute__((unused)))
 
     compile_time = calc_compile_time(__TIME__, __DATE__);
 
-    vcard_max_size = config_getint(IMAPOPT_VCARD_MAX_SIZE);
-    if (vcard_max_size <= 0) vcard_max_size = INT_MAX;
+    vcard_max_size = config_getbytesize(IMAPOPT_VCARD_MAX_SIZE, 'B');
+    if (vcard_max_size <= 0) vcard_max_size = BYTESIZE_UNLIMITED;
 }
 
 
@@ -1746,7 +1746,7 @@ static int propfind_maxsize(const xmlChar *name, xmlNsPtr ns,
     if (!fctx->req_tgt->collection) return HTTP_NOT_FOUND;
 
     buf_reset(&fctx->buf);
-    buf_printf(&fctx->buf, "%d", vcard_max_size);
+    buf_printf(&fctx->buf, "%" PRIi64, vcard_max_size);
     xml_add_prop(HTTP_OK, fctx->ns[NS_DAV], &propstat[PROPSTAT_OK],
                  name, ns, BAD_CAST buf_cstring(&fctx->buf), 0);
 

--- a/imap/http_client.c
+++ b/imap/http_client.c
@@ -97,11 +97,16 @@ EXPORTED int http_parse_framing(int http2, hdrcache_t hdrs,
     static unsigned max_msgsize = 0;
     const char **hdr;
 
-    if (!max_msgsize) {
-        max_msgsize = config_getint(IMAPOPT_MAXMESSAGESIZE);
+    if (max_msgsize == 0) {
+        int64_t val = config_getbytesize(IMAPOPT_MAXMESSAGESIZE, 'B');
 
-        /* If max_msgsize is 0, allow any size */
-        if (!max_msgsize) max_msgsize = INT_MAX;
+        /* 0 means "unlimited", which really means our internally-defined limit */
+        if (val <= 0) val = BYTESIZE_UNLIMITED;
+
+        /* XXX constrained by other variable sizes here */
+        if (val > BYTESIZE_UNLIMITED) val = BYTESIZE_UNLIMITED;
+
+        max_msgsize = val;
     }
 
     body->framing = FRAMING_LENGTH;

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -259,7 +259,8 @@ static int meth_get_isched(struct transaction_t *txn,
         struct mime_type_t *mime;
         struct icaltimetype date;
         icaltimezone *utc = icaltimezone_get_utc_timezone();
-        int i, n, maxlen;
+        int i, n;
+        int64_t maxlen;
 
         /* Start construction of our query-result */
         if (!(root = init_xml_response("query-result", NS_ISCHED, NULL, ns))) {
@@ -344,10 +345,10 @@ static int meth_get_isched(struct transaction_t *txn,
             }
         }
 
-        maxlen = config_getint(IMAPOPT_MAXMESSAGESIZE);
-        if (!maxlen) maxlen = INT_MAX;
+        maxlen = config_getbytesize(IMAPOPT_MAXMESSAGESIZE, 'B');
+        if (maxlen <= 0) maxlen = BYTESIZE_UNLIMITED;
         buf_reset(&txn->buf);
-        buf_printf(&txn->buf, "%d", maxlen);
+        buf_printf(&txn->buf, "%" PRIi64, maxlen);
         xmlNewChild(capa, NULL, BAD_CAST "max-content-length",
                     BAD_CAST buf_cstring(&txn->buf));
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -135,7 +135,7 @@ static int imaps = 0;
 static sasl_ssf_t extprops_ssf = 0;
 static int nosaslpasswdcheck = 0;
 static int apns_enabled = 0;
-static size_t maxsize = 0;
+static int64_t maxsize = 0;
 
 /* PROXY STUFF */
 /* we want a list of our outgoing connections here and which one we're
@@ -914,8 +914,8 @@ int service_init(int argc, char **argv, char **envp)
 
     prometheus_increment(CYRUS_IMAP_READY_LISTENERS);
 
-    maxsize = config_getint(IMAPOPT_MAXMESSAGESIZE);
-    if (!maxsize) maxsize = UINT32_MAX;
+    maxsize = config_getbytesize(IMAPOPT_MAXMESSAGESIZE, 'B');
+    if (maxsize <= 0) maxsize = BYTESIZE_UNLIMITED;
 
     return 0;
 }
@@ -3519,7 +3519,7 @@ static void capa_response(int flags)
         prot_printf(imapd_out, " IDLE");
     }
 
-    prot_printf(imapd_out, " APPENDLIMIT=%zu", maxsize);
+    prot_printf(imapd_out, " APPENDLIMIT=%" PRIi64, maxsize);
 }
 
 /*

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4199,7 +4199,7 @@ static void warn_about_quota(const char *quotaroot)
     int res;
     int r;
     int thresholds[QUOTA_NUMRESOURCES];
-    int pc_threshold = config_getint(IMAPOPT_QUOTAWARN);
+    int pc_threshold = config_getint(IMAPOPT_QUOTAWARNPERCENT);
     int pc_usage;
     struct buf msg = BUF_INITIALIZER;
     static char lastqr[MAX_MAILBOX_PATH+1] = "";

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4185,12 +4185,12 @@ cleanup:
  * Warn if mailbox is close to or over any quota resource.
  *
  * Warn if the following possibilities occur:
- * - quotawarnkb not set + quotawarn hit
- * - quotawarnkb set larger than mailbox + quotawarn hit
- * - quotawarnkb set + hit + quotawarn hit
- * - quotawarnmsg not set + quotawarn hit
- * - quotawarnmsg set larger than mailbox + quotawarn hit
- * - quotawarnmsg set + hit + quotawarn hit
+ * - quotawarnsize not set + quotawarnpercent hit
+ * - quotawarnsize set larger than mailbox + quotawarnpercent hit
+ * - quotawarnsize set + hit + quotawarnpercent hit
+ * - quotawarnmsg not set + quotawarnpercent hit
+ * - quotawarnmsg set larger than mailbox + quotawarnpercent hit
+ * - quotawarnmsg set + hit + quotawarnpercent hit
  */
 static void warn_about_quota(const char *quotaroot)
 {
@@ -4220,9 +4220,9 @@ static void warn_about_quota(const char *quotaroot)
         goto out;           /* failed to read */
 
     memset(thresholds, 0, sizeof(thresholds));
-    thresholds[QUOTA_STORAGE] = config_getint(IMAPOPT_QUOTAWARNKB);
+    thresholds[QUOTA_STORAGE] = config_getbytesize(IMAPOPT_QUOTAWARNSIZE, 'K') / 1024;
     thresholds[QUOTA_MESSAGE] = config_getint(IMAPOPT_QUOTAWARNMSG);
-    thresholds[QUOTA_ANNOTSTORAGE] = config_getint(IMAPOPT_QUOTAWARNKB);
+    thresholds[QUOTA_ANNOTSTORAGE] = config_getbytesize(IMAPOPT_QUOTAWARNSIZE, 'K') / 1024;
 
     for (res = 0 ; res < QUOTA_NUMRESOURCES ; res++) {
         if (q.limits[res] < 0)

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -125,7 +125,7 @@ enum {
 typedef struct {
     hash_table methods;
     json_t *server_capabilities;
-    long limits[JMAP_NUM_LIMITS];
+    int64_t limits[JMAP_NUM_LIMITS];
     // internal state
     ptrarray_t getblob_handlers; // array of jmap_getblob_handler
     ptrarray_t event_handlers; // array of (malloced) jmap_handlers

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4520,10 +4520,10 @@ static int createevent_store(jmap_req_t *req,
     };
     int r = 0;
 
-    static int icalendar_max_size = -1;
+    static int64_t icalendar_max_size = -1;
     if (icalendar_max_size < 0) {
-        icalendar_max_size = config_getint(IMAPOPT_ICALENDAR_MAX_SIZE);
-        if (icalendar_max_size <= 0) icalendar_max_size = INT_MAX;
+        icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE, 'B');
+        if (icalendar_max_size <= 0) icalendar_max_size = BYTESIZE_UNLIMITED;
     }
 
     // Make event id. Main events use empty string as recurrence id.
@@ -4550,12 +4550,10 @@ static int createevent_store(jmap_req_t *req,
     if (r || json_array_size(parser->invalid)) goto done;
 
     // Sanity-check iCalendar data
-    if (icalendar_max_size != INT_MAX) {
-        size_t ical_len = strlen(icalcomponent_as_ical_string(create->ical));
-        if (ical_len > (size_t) icalendar_max_size) {
-            r = IMAP_MESSAGE_TOO_LARGE;
-            goto done;
-        }
+    size_t ical_len = strlen(icalcomponent_as_ical_string(create->ical));
+    if (ical_len > (size_t) icalendar_max_size) {
+        r = IMAP_MESSAGE_TOO_LARGE;
+        goto done;
     }
 
     // Process managed attachments
@@ -5376,10 +5374,10 @@ static void setcalendarevents_update(jmap_req_t *req,
         .serverset = serverset,
     };
 
-    static int icalendar_max_size = -1;
+    static int64_t icalendar_max_size = -1;
     if (icalendar_max_size < 0) {
-        icalendar_max_size = config_getint(IMAPOPT_ICALENDAR_MAX_SIZE);
-        if (icalendar_max_size <= 0) icalendar_max_size = INT_MAX;
+        icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE, 'B');
+        if (icalendar_max_size <= 0) icalendar_max_size = BYTESIZE_UNLIMITED;
     }
 
     // Determine if event is a standalone recurrence instance
@@ -5570,7 +5568,7 @@ static void setcalendarevents_update(jmap_req_t *req,
         r = 0;
         goto done;
     }
-    else if (icalendar_max_size != INT_MAX && update.newical) {
+    else if (update.newical) {
         size_t ical_size = strlen(icalcomponent_as_ical_string(update.newical));
         if (ical_size > (size_t) icalendar_max_size) {
             r = IMAP_MESSAGE_TOO_LARGE;

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -142,9 +142,8 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
     } \
 } while (0)
 
-    _read_int_opt(settings->limits[MAX_SIZE_UPLOAD],
-                  IMAPOPT_JMAP_MAX_SIZE_UPLOAD);
-    settings->limits[MAX_SIZE_UPLOAD] *= 1024;
+    _read_bytesize_opt(settings->limits[MAX_SIZE_UPLOAD],
+                       IMAPOPT_JMAP_MAX_SIZE_UPLOAD, 'K');
     _read_int_opt(settings->limits[MAX_CONCURRENT_UPLOAD],
                   IMAPOPT_JMAP_MAX_CONCURRENT_UPLOAD);
     _read_int_opt(settings->limits[MAX_SIZE_REQUEST],

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -124,34 +124,47 @@ static jmap_method_t jmap_core_methods_nonstandard[] = {
 
 HIDDEN void jmap_core_init(jmap_settings_t *settings)
 {
-#define _read_opt(val, optkey) \
+#define _read_int_opt(val, optkey) do { \
     val = config_getint(optkey); \
     if (val <= 0) { \
         syslog(LOG_ERR, "jmap: invalid property value: %s", \
                 imapopts[optkey].optname); \
         val = 0; \
-    }
-    _read_opt(settings->limits[MAX_SIZE_UPLOAD],
-              IMAPOPT_JMAP_MAX_SIZE_UPLOAD);
+    } \
+} while (0)
+
+#define _read_bytesize_opt(val, optkey, defunit) do { \
+    val = config_getbytesize(optkey, defunit); \
+    if (val <= 0) { \
+        syslog(LOG_ERR, "jmap: invalid property value: %s", \
+               imapopts[optkey].optname); \
+        val = 0; \
+    } \
+} while (0)
+
+    _read_int_opt(settings->limits[MAX_SIZE_UPLOAD],
+                  IMAPOPT_JMAP_MAX_SIZE_UPLOAD);
     settings->limits[MAX_SIZE_UPLOAD] *= 1024;
-    _read_opt(settings->limits[MAX_CONCURRENT_UPLOAD],
-              IMAPOPT_JMAP_MAX_CONCURRENT_UPLOAD);
-    _read_opt(settings->limits[MAX_SIZE_REQUEST],
-              IMAPOPT_JMAP_MAX_SIZE_REQUEST);
+    _read_int_opt(settings->limits[MAX_CONCURRENT_UPLOAD],
+                  IMAPOPT_JMAP_MAX_CONCURRENT_UPLOAD);
+    _read_int_opt(settings->limits[MAX_SIZE_REQUEST],
+                  IMAPOPT_JMAP_MAX_SIZE_REQUEST);
     settings->limits[MAX_SIZE_REQUEST] *= 1024;
-    _read_opt(settings->limits[MAX_CONCURRENT_REQUESTS],
-              IMAPOPT_JMAP_MAX_CONCURRENT_REQUESTS);
-    _read_opt(settings->limits[MAX_CALLS_IN_REQUEST],
-              IMAPOPT_JMAP_MAX_CALLS_IN_REQUEST);
-    _read_opt(settings->limits[MAX_OBJECTS_IN_GET],
-              IMAPOPT_JMAP_MAX_OBJECTS_IN_GET);
-    _read_opt(settings->limits[MAX_OBJECTS_IN_SET],
-              IMAPOPT_JMAP_MAX_OBJECTS_IN_SET);
-    _read_opt(settings->limits[MAX_SIZE_BLOB_SET],
-              IMAPOPT_JMAP_MAX_SIZE_BLOB_SET);
-    _read_opt(settings->limits[MAX_CATENATE_ITEMS],
-              IMAPOPT_JMAP_MAX_CATENATE_ITEMS);
-#undef _read_opt
+    _read_int_opt(settings->limits[MAX_CONCURRENT_REQUESTS],
+                  IMAPOPT_JMAP_MAX_CONCURRENT_REQUESTS);
+    _read_int_opt(settings->limits[MAX_CALLS_IN_REQUEST],
+                  IMAPOPT_JMAP_MAX_CALLS_IN_REQUEST);
+    _read_int_opt(settings->limits[MAX_OBJECTS_IN_GET],
+                  IMAPOPT_JMAP_MAX_OBJECTS_IN_GET);
+    _read_int_opt(settings->limits[MAX_OBJECTS_IN_SET],
+                  IMAPOPT_JMAP_MAX_OBJECTS_IN_SET);
+    _read_int_opt(settings->limits[MAX_SIZE_BLOB_SET],
+                  IMAPOPT_JMAP_MAX_SIZE_BLOB_SET);
+    _read_int_opt(settings->limits[MAX_CATENATE_ITEMS],
+                  IMAPOPT_JMAP_MAX_CATENATE_ITEMS);
+
+#undef _read_int_opt
+#undef _read_bytesize_opt
 
     json_object_set_new(settings->server_capabilities,
             JMAP_URN_CORE,

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -157,8 +157,8 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
                   IMAPOPT_JMAP_MAX_OBJECTS_IN_GET);
     _read_int_opt(settings->limits[MAX_OBJECTS_IN_SET],
                   IMAPOPT_JMAP_MAX_OBJECTS_IN_SET);
-    _read_int_opt(settings->limits[MAX_SIZE_BLOB_SET],
-                  IMAPOPT_JMAP_MAX_SIZE_BLOB_SET);
+    _read_bytesize_opt(settings->limits[MAX_SIZE_BLOB_SET],
+                       IMAPOPT_JMAP_MAX_SIZE_BLOB_SET, 'K');
     _read_int_opt(settings->limits[MAX_CATENATE_ITEMS],
                   IMAPOPT_JMAP_MAX_CATENATE_ITEMS);
 
@@ -212,7 +212,7 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
                 JMAP_BLOB_EXTENSION,
                 json_pack("{s:i, s:i, s:o, s:o}",
                     "maxSizeBlobSet",
-                    settings->limits[MAX_SIZE_BLOB_SET],
+                    settings->limits[MAX_SIZE_BLOB_SET] / 1024,
                     "maxCatenateItems",
                     settings->limits[MAX_CATENATE_ITEMS],
                     "supportedTypeNames",

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -146,9 +146,8 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
                        IMAPOPT_JMAP_MAX_SIZE_UPLOAD, 'K');
     _read_int_opt(settings->limits[MAX_CONCURRENT_UPLOAD],
                   IMAPOPT_JMAP_MAX_CONCURRENT_UPLOAD);
-    _read_int_opt(settings->limits[MAX_SIZE_REQUEST],
-                  IMAPOPT_JMAP_MAX_SIZE_REQUEST);
-    settings->limits[MAX_SIZE_REQUEST] *= 1024;
+    _read_bytesize_opt(settings->limits[MAX_SIZE_REQUEST],
+                       IMAPOPT_JMAP_MAX_SIZE_REQUEST, 'K');
     _read_int_opt(settings->limits[MAX_CONCURRENT_REQUESTS],
                   IMAPOPT_JMAP_MAX_CONCURRENT_REQUESTS);
     _read_int_opt(settings->limits[MAX_CALLS_IN_REQUEST],

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -333,10 +333,9 @@ HIDDEN void jmap_mail_capabilities(json_t *account_capabilities, int mayCreateTo
         json_array_append_new(sortopts, json_string(sp->name));
     }
 
-    long max_size_attachments_per_email =
-        config_getint(IMAPOPT_JMAP_MAIL_MAX_SIZE_ATTACHMENTS_PER_EMAIL);
+    int64_t max_size_attachments_per_email =
+        config_getbytesize(IMAPOPT_JMAP_MAIL_MAX_SIZE_ATTACHMENTS_PER_EMAIL, 'K');
 
-    max_size_attachments_per_email *= 1024;
     if (max_size_attachments_per_email <= 0) {
         syslog(LOG_ERR, "jmap: invalid property value: %s",
                 imapopts[IMAPOPT_JMAP_MAIL_MAX_SIZE_ATTACHMENTS_PER_EMAIL].optname);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7887,7 +7887,8 @@ static int _email_get_bodies(jmap_req_t *req,
                 free(html);
             }
             if (text) {
-                size_t len = config_getint(IMAPOPT_JMAP_PREVIEW_LENGTH);
+                int64_t len = config_getbytesize(IMAPOPT_JMAP_PREVIEW_LENGTH, 'B');
+                if (len < 0) len = 0;
                 char *preview = _email_extract_preview(text, len);
                 json_object_set_new(email, "preview", json_string(preview));
                 free(preview);

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -155,7 +155,7 @@ HIDDEN void jmap_sieve_init(jmap_settings_t *settings)
     }
 
     maxscripts = config_getint(IMAPOPT_SIEVE_MAXSCRIPTS);
-    maxscriptsize = config_getint(IMAPOPT_SIEVE_MAXSCRIPTSIZE) * 1024;
+    maxscriptsize = config_getbytesize(IMAPOPT_SIEVE_MAXSCRIPTSIZE, 'K');
 }
 
 HIDDEN void jmap_sieve_capabilities(json_t *account_capabilities)

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -1071,7 +1071,7 @@ int autocreate_inbox(const mbname_t *mbname)
     /*
      * Check for autocreatequota and createonpost
      */
-    if (config_getint(IMAPOPT_AUTOCREATE_QUOTA) < 0)
+    if (config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K') < 0)
         return IMAP_MAILBOX_NONEXISTENT;
 
     if (!config_getswitch(IMAPOPT_AUTOCREATE_POST))

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5280,8 +5280,9 @@ EXPORTED unsigned mailbox_should_archive(struct mailbox *mailbox,
     time_t cutoff = time(0) - archive_after;
     if (rock) cutoff = *((time_t *)rock);
 
-    int archive_size = config_getint(IMAPOPT_ARCHIVE_MAXSIZE);
-    size_t maxsize = archive_size * 1024;
+    int64_t archive_size = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    if (archive_size < 0) archive_size = 0;
+    size_t maxsize = archive_size;
 
     int keepflagged = config_getswitch(IMAPOPT_ARCHIVE_KEEPFLAGGED);
 

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -1383,8 +1383,9 @@ void mboxevent_extract_content_msgrec(struct mboxevent *event,
                                msgrecord_t *msgrec, FILE* content)
 {
     const char *base = NULL;
-    size_t offset, size, truncate, len = 0;
+    size_t offset, size, len = 0;
     uint32_t record_size, header_size;
+    int64_t truncate;
 
     if (!event)
         return;
@@ -1398,7 +1399,8 @@ void mboxevent_extract_content_msgrec(struct mboxevent *event,
         return;
     }
 
-    truncate = config_getint(IMAPOPT_EVENT_CONTENT_SIZE);
+    truncate = config_getbytesize(IMAPOPT_EVENT_CONTENT_SIZE, 'B');
+    if (truncate < 0) truncate = 0;
 
     switch (config_getenum(IMAPOPT_EVENT_CONTENT_INCLUSION_MODE)) {
     /*  include message up to 'truncate' in size with the notification */
@@ -1452,7 +1454,8 @@ void mboxevent_extract_content(struct mboxevent *event,
                                const struct index_record *record, FILE* content)
 {
     const char *base = NULL;
-    size_t offset, size, truncate, len = 0;
+    size_t offset, size, len = 0;
+    int64_t truncate;
 
     if (!event)
         return;
@@ -1460,7 +1463,8 @@ void mboxevent_extract_content(struct mboxevent *event,
     if (!mboxevent_expected_param(event->type, EVENT_MESSAGE_CONTENT))
         return;
 
-    truncate = config_getint(IMAPOPT_EVENT_CONTENT_SIZE);
+    truncate = config_getbytesize(IMAPOPT_EVENT_CONTENT_SIZE, 'B');
+    if (truncate < 0) truncate = 0;
 
     switch (config_getenum(IMAPOPT_EVENT_CONTENT_INCLUSION_MODE)) {
     /*  include message up to 'truncate' in size with the notification */

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -333,9 +333,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    assumed.  */
 */
 
-{ "archive_maxsize", 1024, INT, "3.0.0" }
-/* The size in kilobytes of the largest message that won't be archived
-   immediately.  Default is 1Mb */
+{ "archive_maxsize", "1024 K", BYTESIZE, "UNRELEASED" }
+/* The size of the largest message that won't be archived immediately.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed.  */
 
 { "archive_keepflagged", 0, SWITCH, "3.0.0" }
 /* If set, messages with the \\Flagged system flag won't be archived,

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -3103,11 +3103,14 @@ product version in the capabilities
    character '.'. Note that with the newnews separator, no dots may
    occur in mailbox names.  The default switched in 3.0 from off to on. */
 
-{ "vcard_max_size", 0, INT, "3.6.0" }
+{ "vcard_max_size", "0", BYTESIZE, "UNRELEASED" }
 /* Maximum allowed vCard size.
    If non-zero, CardDAV and JMAP will reject storage of contacts whose
-   vCard representation is larger than \fIvcard_max_size\fR bytes.
-   If set to 0, this will allow vCards of any size (the default). */
+   vCard representation is larger than \fIvcard_max_size\fR.
+.PP
+   If set to 0 (the default), a large internally-defined limit will be applied.
+.PP
+   If no unit is specified, bytes is assumed. */
 
 { "virtdomains", "off", ENUM("off", "userid", "on"), "3.1.8" }
 /* Configure virtual domain support.

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2173,7 +2173,10 @@ If all partitions are over that limit, this feature is not used anymore.
    conversations quota counts, which count multiple copies of exactly the
    same message (by GUID) as only one */
 
-{ "quotawarn", 90, INT, "2.3.17" }
+{ "quotawarn", 90, INT, "UNRELEASED", "UNRELEASED", "quotawarnpercent" }
+/* Deprecated in favour of \fIquotawarnpercent\fR. */
+
+{ "quotawarnpercent", 90, INT, "UNRELEASED" }
 /* The percent of quota utilization over which the server generates
    warnings. */
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -520,17 +520,23 @@ Blank lines and lines beginning with ``#'' are ignored.
    partition pathname MUST be specified if backups are in use.  Note that
    there is no relationship between spool partitions and backup partitions. */
 
-{ "backup_compact_minsize", 0, INT, "3.0.0" }
-/* The minimum size in kilobytes of chunks in each backup.  The compact tool
+{ "backup_compact_minsize", "0", BYTESIZE, "UNRELEASED" }
+/* The minimum size of chunks in each backup.  The compact tool
    will try to combine adjacent chunks that are smaller than this.
 .PP
-   Setting this value to zero or negative disables combining of chunks. */
+   Setting this value to zero or negative disables combining of chunks.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed. */
 
-{ "backup_compact_maxsize", 0, INT, "3.0.0" }
-/* The maximum size in kilobytes of chunks in each backup.  The compact tool
+{ "backup_compact_maxsize", "0", BYTESIZE, "UNRELEASED" }
+/* The maximum size of chunks in each backup.  The compact tool
    will try to split chunks larger than this into smaller chunks.
 .PP
-   Setting this value to zero or negative disables splitting of chunks. */
+   Setting this value to zero or negative disables splitting of chunks.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed. */
 
 { "backup_compact_work_threshold", 1, INT, "3.0.0" }
 /* The number of chunks that must obviously need compaction before the compact

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1324,10 +1324,13 @@ Blank lines and lines beginning with ``#'' are ignored.
    Returned as the maxObjectsInSet property value of the
    JMAP \"urn:ietf:params:jmap:core\" capabilities object. */
 
-{ "jmap_mail_max_size_attachments_per_email", 10240, INT, "3.1.6" }
-/* The value (in kilobytes) to return for the maxSizeAttachmentsPerEmail
-   property of the JMAP \"urn:ietf:params:jmap:mail\" capabilities object. The Cyrus
-   JMAP implementation does not enforce this size limit. Default is 10 Mb.*/
+{ "jmap_mail_max_size_attachments_per_email", "10M", BYTESIZE, "UNRELEASED" }
+/* The value to return for the maxSizeAttachmentsPerEmail property of the JMAP
+   \"urn:ietf:params:jmap:mail\" capabilities object. The Cyrus JMAP
+   implementation does not enforce this size limit.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is assumed.
+   */
 
 { "jmap_nonstandard_extensions", 0, SWITCH, "3.1.9" }
 /* If enabled, support non-standard JMAP extensions.  If not enabled,

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1716,8 +1716,10 @@ Blank lines and lines beginning with ``#'' are ignored.
 .PP
    If no unit is specified, bytes is assumed. */
 
-{ "maxword", 131072, INT, "2.3.17" }
-/* Maximum size of a single word for the parser.  Default 128k */
+{ "maxword", "128K", BYTESIZE, "UNRELEASED" }
+/* Maximum size of a single word for the parser.
+.PP
+   If no unit is specified, bytes is assumed. */
 
 { "mboxkey_db", "twoskip", STRINGLIST("skiplist", "twoskip", "zeroskip"), "3.1.6" }
 /* The cyrusdb backend to use for mailbox keys. */

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -92,6 +92,15 @@ no unit is specified, an option-specific backward-compatible default unit
 is assumed (documented on an option-by-option basis).  These are simple time
 units: 1d=24h, 1h=60m, 1m=60s (daylight savings, timezones, leap adjustments,
 etc are not considered).
+.PP
+Byte size options take the form of a number followed by a unit, for example
+\fB1KiB\fR (1 kibibyte).  Units are \fBB\fR (bytes), \fBKiB\fR (kibibytes),
+\fBMiB\fR (mebibytes), and \fBGiB\fR (gibibytes), which may also be spelt
+\fBKB\fR, \fBMB\fR, and \fBGB\fR.  Units are parsed without regard to case.
+Note that regardless of spelling, these units are always powers of 2, and
+never metric.  That is, 1GiB = 1024MiB, 1MiB = 1024KiB, 1KiB = 1024B.  If no
+unit is specified, an option-specific backward-compatible default unit is
+assumed (documented on an option-by-option basis).
 .SH FIELD DESCRIPTIONS
 .PP
 The sections below detail options that can be placed in the

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1251,9 +1251,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    Note that the Content-ID key must be URL-unescaped and enclosed in
    angular brackets, as defined in RFC 2392. */
 
-{ "jmap_preview_length", 64, INT, "3.1.1" }
-/* The maximum byte length of dynamically generated message previews. Previews
-   stored in jmap_preview_annot take precedence. */
+{ "jmap_preview_length", "64B", BYTESIZE, "UNRELEASED" }
+/* The maximum length of dynamically generated message previews. Previews
+   stored in jmap_preview_annot take precedence.
+.PP
+   If no unit is specified, bytes is assumed. */
 
 { "jmap_max_catenate_items", 100, INT, "3.6.0" }
 /* The maximum number of items that can be catenated together by

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1271,11 +1271,13 @@ Blank lines and lines beginning with ``#'' are ignored.
    For backward compatibility, if no unit is specified, kibibytes is assumed.
    */
 
-{ "jmap_max_size_blob_set", 4096, INT, "3.3.0" }
-/* The maximum size (in kilobytes) that the JMAP API accepts
-   for Blob/set. Returned as the maxSizeBlobSet property
-   value of the JMAP \"https://cyrusimap.org/ns/jmap/blob\" capabilities object.
-   Default is 4Mb. */
+{ "jmap_max_size_blob_set", "4M", BYTESIZE, "UNRELEASED" }
+/* The maximum size that the JMAP API accepts for Blob/set. Returned as the
+   maxSizeBlobSet property value of the JMAP
+   \"https://cyrusimap.org/ns/jmap/blob\" capabilities object.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is assumed.
+   */
 
 { "jmap_max_concurrent_upload", 5, INT, "3.1.6" }
 /* The value to return for the maxConcurrentUpload property of

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1711,8 +1711,10 @@ Blank lines and lines beginning with ``#'' are ignored.
 .PP
    If no unit is specified, bytes is assumed. */
 
-{ "maxquoted", 131072, INT, "2.3.17" }
-/* Maximum size of a single quoted string for the parser.  Default 128k */
+{ "maxquoted", "128K", BYTESIZE, "UNRELEASED" }
+/* Maximum size of a single quoted string for the parser.
+.PP
+   If no unit is specified, bytes is assumed. */
 
 { "maxword", 131072, INT, "2.3.17" }
 /* Maximum size of a single word for the parser.  Default 128k */

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1702,10 +1702,14 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* Maximum number of logged in sessions allowed per user,
    zero means no limit */
 
-{ "maxmessagesize", 0, INT, "2.3.17" }
-/* Maximum incoming LMTP message size.  If non-zero, lmtpd will reject
-   messages larger than \fImaxmessagesize\fR bytes.  If set to 0, this
-   will allow messages of any size (the default). */
+{ "maxmessagesize", "0", BYTESIZE, "UNRELEASED" }
+/* Maximum size of messages that will be accepted by Cyrus.  This affects LMTP
+   deliveries, IMAP appends, DAV uploads, etc.  Messages larger than this will
+   be rejected.
+.PP
+   If set to 0 (the default), a large internally-defined limit will be applied.
+.PP
+   If no unit is specified, bytes is assumed. */
 
 { "maxquoted", 131072, INT, "2.3.17" }
 /* Maximum size of a single quoted string for the parser.  Default 128k */

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2180,10 +2180,19 @@ If all partitions are over that limit, this feature is not used anymore.
 /* The percent of quota utilization over which the server generates
    warnings. */
 
-{ "quotawarnkb", 0, INT, "2.3.17" }
-/* The maximum amount of free space (in kB) at which to give a quota
-   warning (if this value is 0, or if the quota is smaller than this
-   amount, then warnings are always given). */
+{ "quotawarnkb", NULL, BYTESIZE, "UNRELEASED", "UNRELEASED", "quotawarnsize" }
+/* Deprecated in favour of \fIquotawarnsize\fR. */
+
+{ "quotawarnsize", "0", BYTESIZE, "UNRELEASED" }
+/* The maximum amount of free space at which to give a quota warning
+   (if this value is 0, or if the quota is smaller than this
+   amount, then warnings are always given).
+.PP
+   Note that quota has kibibyte granularity.  Values specified here will
+   be truncated to the nearest whole kibibyte.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed.  */
 
 { "quotawarnmsg", 0, INT, "2.5.0" }
 /* The maximum amount of messages at which to give a quota warning

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -365,7 +365,7 @@ Blank lines and lines beginning with ``#'' are ignored.
 { "autocreateinboxfolders", NULL, STRING, "2.5.0", "2.5.0", "autocreate_inbox_folders" }
 /* Deprecated in favor of \fIautocreate_inbox_folders\fR. */
 
-{ "autocreatequota", 0, INT, "2.5.0", "2.5.0", "autocreate_quota" }
+{ "autocreatequota", NULL, BYTESIZE, "UNRELEASED", "2.5.0", "autocreate_quota" }
 /* Deprecated in favor of \fIautocreate_quota\fR. */
 
 { "autocreatequotamsg", -1, INT, "2.5.0", "2.5.0", "autocreate_quota_messages" }
@@ -433,7 +433,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    INBOX that does not exist, then the INBOX is automatically created
    by \fIlmtpd(8)\fR and delivery of the message continues. */
 
-{ "autocreate_quota", -1, INT, "2.5.0" }
+{ "autocreate_quota", "-1", BYTESIZE, "UNRELEASED" }
 /* If set to a value of zero or higher, users have their INBOX folders
    created upon a successful login event or upon \fIlmtpd(8)\fR
    message delivery if \fIautocreate_post\fR is enabled, provided their
@@ -442,7 +442,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    The user's quota is set to the value if it is greater than zero,
    otherwise the user has unlimited quota.
 .PP
-   Note that quota is specified in kilobytes. */
+   Note that quota has kibibyte granularity.  Values specified here will
+   be truncated to the nearest whole kibibyte.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed. */
 
 { "autocreate_quota_messages", -1, INT, "3.0.0" }
 /* If set to a value of zero or higher, users who have their INBOX

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -3162,12 +3162,14 @@ of the incoming network interface, or if no record is found, the
    the attachment will be used. For JMAP, the Link.blobId property of
    JSCalendar objects will be disabled. */
 
-{ "webdav_attachments_max_binary_attach_size", 1024, INT, "3.6.0" }
-/* The maximum byte length (in kilobytes) of an ATTACH property value
-   when managed attachment URIs get rewritten to BINARY during iTIP processing.
-   Any attachment that exceeds this byte size keeps its managed attachment
-   URI as ATTACH value. A zero size limit causes attachments of any size
-   be rewritten as BINARY. */
+{ "webdav_attachments_max_binary_attach_size", "1024K", BYTESIZE, "UNRELEASED" }
+/* The maximum byte length of an ATTACH property value when managed attachment
+   URIs get rewritten to BINARY during iTIP processing.  Any attachment that
+   exceeds this byte size keeps its managed attachment URI as ATTACH value. A
+   zero size limit causes attachments of any size be rewritten as BINARY. */
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed.  */
 
 { "xbackup_enabled", 0, SWITCH, "3.0.0" }
 /* Enable support for the XBACKUP command in imapd.  If enabled, admin

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1284,11 +1284,13 @@ Blank lines and lines beginning with ``#'' are ignored.
    the JMAP \"urn:ietf:params:jmap:core\" capabilities object. The Cyrus JMAP
    implementation does not enforce this rate-limit. */
 
-{ "jmap_max_size_request", 10240, INT, "3.1.6" }
-/* The maximum size (in kilobytes) that the JMAP API accepts
-   for requests at the API endpoint. Returned as the
-   maxSizeRequest property value of the JMAP \"urn:ietf:params:jmap:core\"
-   capabilities object. Default is 10Mb. */
+{ "jmap_max_size_request", "10M", BYTESIZE, "UNRELEASED" }
+/* The maximum size that the JMAP API accepts for requests at the API endpoint.
+   Returned as the maxSizeRequest property value of the JMAP
+   \"urn:ietf:params:jmap:core\" capabilities object.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is assumed.
+   */
 
 { "jmap_max_concurrent_requests", 5, INT, "3.1.6" }
 /* The value to return for the maxConcurrentRequests property of

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2410,11 +2410,13 @@ If all partitions are over that limit, this feature is not used anymore.
 /* The maximum number of seconds to run a search for before aborting.  Default
    of no value means search "forever" until other timeouts. */
 
-{ "search_maxsize", 4096, INT, "3.6.0" }
-/* The maximum size in kilobytes to index for each message part. Message
-   contents that occur after this byte offset will not be indexed or
-   search snippets generated from.
-   Default is 4Mb. Xapian-only. */
+{ "search_maxsize", "4M", BYTESIZE, "UNRELEASED" }
+/* The maximum size to index for each message part. Message contents that
+   occur after this byte offset will not be indexed nor used to generate
+   search snippets. Xapian-only.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed.  */
 
 { "search_queryscan", 5000, INT, "3.1.7" }
 /* The minimum number of records require to do a direct scan of all G keys

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1142,11 +1142,13 @@ Blank lines and lines beginning with ``#'' are ignored.
    The zero value disables validation of the "iat" JWS claim.
 */
 
-{ "icalendar_max_size", 0, INT, "3.6.0" }
-/* Maximum allowed iCalendar size.
-   If non-zero, CalDAV and JMAP will reject storage of resources whose
-   iCalendar representation is larger than \fIicalendar_max_size\fR bytes.
-   If set to 0, this will allow iCalendar resources of any size (the default). */
+{ "icalendar_max_size", "0", BYTESIZE, "UNRELEASED" }
+/* Maximum allowed iCalendar size. CalDAV and JMAP will reject storage of
+   resources whose iCalendar representation is larger than this.
+.PP
+   If set to 0 (the default), a large internally-defined limit will be applied.
+.PP
+   If no unit is specified, bytes is assumed. */
 
 { "idlesocket", "{configdirectory}/socket/idle", STRING, "2.3.17" }
 /* Unix domain socket that idled listens on. */

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2571,9 +2571,12 @@ product version in the capabilities
 { "sieve_folder", "#sieve", STRING, "3.6.0" }
 /* The name of the folder for storing Sieve scripts (#sieve) */
 
-{ "sieve_maxscriptsize", 32, INT, "2.3.17" }
-/* Maximum size (in kilobytes) any sieve script can be, enforced at
-   submission by timsieved(8). */
+{ "sieve_maxscriptsize", "32K", BYTESIZE, "UNRELEASED" }
+/* Maximum size any sieve script can be, enforced at submission by
+   timsieved(8) and JMAP.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is
+   assumed.  */
 
 { "sieve_maxscripts", 5, INT, "2.3.17" }
 /* Maximum number of sieve scripts any user may have, enforced at

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1263,11 +1263,13 @@ Blank lines and lines beginning with ``#'' are ignored.
    value of the JMAP \"urn:ietf:params:jmap:blob\" capabilities object.
    Default value is 100. */
 
-{ "jmap_max_size_upload", 1048576, INT, "3.1.6" }
-/* The maximum size (in kilobytes) that the JMAP API accepts
-   for blob uploads. Returned as the maxSizeUpload property
-   value of the JMAP \"urn:ietf:params:jmap:core\" capabilities object.
-   Default is 1Gb. */
+{ "jmap_max_size_upload", "1G", BYTESIZE, "UNRELEASED" }
+/* The maximum size that the JMAP API accepts for blob uploads. Returned as
+   the maxSizeUpload property value of the JMAP \"urn:ietf:params:jmap:core\"
+   capabilities object.
+.PP
+   For backward compatibility, if no unit is specified, kibibytes is assumed.
+   */
 
 { "jmap_max_size_blob_set", 4096, INT, "3.3.0" }
 /* The maximum size (in kilobytes) that the JMAP API accepts

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -926,9 +926,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    to a size. In "headerbody" mode, it includes full headers and body truncated
    to a size */
 
-{ "event_content_size", 0, INT, "2.5.0" }
+{ "event_content_size", "0", BYTESIZE, "UNRELEASED" }
 /* Truncate the message content that may be included with MessageAppend and
-   MessageNew. Set 0 to include the entire message itself */
+   MessageNew. Set 0 to include the entire message itself.
+.PP
+   If no unit is specified, bytes is assumed. */
 
 { "event_exclude_flags", NULL, STRING, "2.5.0" }
 /* Don't send event notification for given IMAP flag(s) */

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -287,6 +287,128 @@ EXPORTED int config_getduration(enum imapopt opt, int defunit)
     return duration;
 }
 
+/* Parse a size value, converted to bytes.
+ *
+ * On success, 0 is returned and the size in bytes is written to
+ * out_bytesize (if provided).
+ *
+ * On error, -1 is returned and out_bytesize is unchanged.
+ */
+EXPORTED int config_parsebytesize(const char *str,
+                                  int defunit,
+                                  int64_t *out_bytesize)
+{
+    const size_t len = strlen(str);
+    int64_t bytesize;
+    int i_allowed = 0, r = 0;
+    char *copy = NULL, *p;
+
+    assert(strchr("BKMG", defunit) != NULL); /* n.b. also permits \0 */
+
+    /* the default default unit is bytes */
+    if (!defunit) defunit = 'B';
+
+    /* make a copy and append the default unit if necessary */
+    copy = xzmalloc(len + 2);
+    strlcpy(copy, str, len + 2);
+    if (len > 0 && cyrus_isdigit(copy[len-1]))
+        copy[len] = defunit;
+
+    /* start parsing */
+    errno = 0;
+    bytesize = strtoll(copy, &p, 10);
+    if (errno) {
+        xsyslog(LOG_ERR, "unable to parse byte size from string",
+                         "value=<%s>", str);
+        errno = 0;
+        r = -1;
+        goto done;
+    }
+
+    /* better be some digits */
+    if (p == copy) {
+        struct buf msg = BUF_INITIALIZER;
+
+        buf_appendcstr(&msg, "no digit ");
+        if (*p) {
+            buf_printf(&msg, "before '%c' ", *p);
+        }
+        buf_printf(&msg, "in '%s'", str);
+
+        syslog(LOG_DEBUG, "%s: %s", __func__, buf_cstring(&msg));
+        buf_free(&msg);
+
+        r = -1;
+        goto done;
+    }
+
+    /* optional space for readability */
+    while (isspace(*p)) p++;
+
+    /* optional G, M, K multiplier */
+    switch (*p) {
+    case 'g':
+    case 'G':
+        bytesize *= 1024;
+        /* fall through */
+    case 'm':
+    case 'M':
+        bytesize *= 1024;
+        /* fall through */
+    case 'k':
+    case 'K':
+        bytesize *= 1024;
+        i_allowed = 1;
+        p++;
+        break;
+    }
+
+    /* allow multiplier to be spelt as Gi, Mi, Ki */
+    if (i_allowed && (*p == 'i' || *p == 'I')) p++;
+
+    /* optional B suffix */
+    if (*p == 'b' || *p == 'B') p++;
+
+    /* we'd better be at end of string! */
+    if (*p) {
+        syslog(LOG_DEBUG, "%s: bad unit '%c' in %s",
+                          __func__, *p, str);
+        r = -1;
+        goto done;
+    }
+
+done:
+    if (!r && out_bytesize) *out_bytesize = bytesize;
+
+    free(copy);
+    return r;
+}
+
+/* Get a size value, converted to bytes. */
+EXPORTED int64_t config_getbytesize(enum imapopt opt, int defunit)
+{
+    int64_t bytesize;
+
+    assert(config_loaded);
+    assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
+    assert(imapopts[opt].t == OPT_BYTESIZE);
+    assert_not_deprecated(opt);
+    assert(strchr("BKMG", defunit) != NULL); /* n.b. also permits \0 */
+
+    if (imapopts[opt].val.s == NULL) return 0;
+
+    if (config_parsebytesize(imapopts[opt].val.s, defunit, &bytesize)) {
+        /* should have been rejected by config_read_file, but just in case */
+        char errbuf[1024];
+        snprintf(errbuf, sizeof(errbuf),
+                 "%s: %s: couldn't parse byte size '%s'",
+                 __func__, imapopts[opt].optname, imapopts[opt].val.s);
+        fatal(errbuf, EX_CONFIG);
+    }
+
+    return bytesize;
+}
+
 EXPORTED const char *config_getoverflowstring(const char *key, const char *def)
 {
     char buf[256];
@@ -439,6 +561,7 @@ static void config_option_deprecate(const int dopt)
     case OPT_STRINGLIST:
     case OPT_STRING:
     case OPT_DURATION:
+    case OPT_BYTESIZE:
         imapopts[opt].val.s = imapopts[dopt].val.s;
         imapopts[dopt].val.s = NULL;
         break;
@@ -480,7 +603,9 @@ EXPORTED void config_reset(void)
 
     /* reset all the options */
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
-        if ((imapopts[opt].t == OPT_STRING || imapopts[opt].t == OPT_DURATION) &&
+        if ((imapopts[opt].t == OPT_STRING ||
+             imapopts[opt].t == OPT_DURATION ||
+             imapopts[opt].t == OPT_BYTESIZE) &&
             (imapopts[opt].seen ||
              (imapopts[opt].def.s &&
               imapopts[opt].val.s != imapopts[opt].def.s &&
@@ -882,7 +1007,8 @@ static void config_read_file(const char *filename)
              * to free the current string if there is one */
             if (imapopts[opt].seen
                 && (imapopts[opt].t == OPT_STRING
-                    || imapopts[opt].t == OPT_DURATION))
+                    || imapopts[opt].t == OPT_DURATION
+                    || imapopts[opt].t == OPT_BYTESIZE))
                 free((char *)imapopts[opt].val.s);
 
             if (service_specific)
@@ -1016,6 +1142,23 @@ static void config_read_file(const char *filename)
 
                 /* but then store it unparsed, it will be parsed again by
                  * config_getduration() where the caller knows the appropriate
+                 * default units */
+                imapopts[opt].val.s = xstrdup(p);
+                break;
+            }
+            case OPT_BYTESIZE:
+            {
+                /* make sure it's parseable, though we don't know the default units */
+                if (config_parsebytesize(p, '\0', NULL)) {
+                    imapopts[opt].seen = 0; /* not seen after all */
+                    snprintf(errbuf, sizeof(errbuf),
+                             "unparsable byte size '%s' for %s in line %d",
+                             p, imapopts[opt].optname, lineno);
+                    fatal(errbuf, EX_CONFIG);
+                }
+
+                /* but then store it unparsed, it will be parsed again by
+                 * config_getbytesize() where the caller knows the appropriate
                  * default units */
                 imapopts[opt].val.s = xstrdup(p);
                 break;

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -647,6 +647,7 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
     char buf[4096];
     char *p;
     int ival;
+    int64_t i64val;
 
     config_loaded = 1;
 
@@ -790,7 +791,11 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
     config_serverinfo = config_getenum(IMAPOPT_SERVERINFO);
 
     /* set some limits */
-    config_maxquoted = config_getint(IMAPOPT_MAXQUOTED);
+    i64val = config_getbytesize(IMAPOPT_MAXQUOTED, 'B');
+    if (i64val <= 0 || i64val > BYTESIZE_UNLIMITED) {
+        i64val = BYTESIZE_UNLIMITED;
+    }
+    config_maxquoted = i64val;
     config_maxword = config_getint(IMAPOPT_MAXWORD);
 
     ival = config_getenum(IMAPOPT_QOSMARKING);

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -796,7 +796,11 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
         i64val = BYTESIZE_UNLIMITED;
     }
     config_maxquoted = i64val;
-    config_maxword = config_getint(IMAPOPT_MAXWORD);
+    i64val = config_getbytesize(IMAPOPT_MAXWORD, 'B');
+    if (i64val <= 0 || i64val > BYTESIZE_UNLIMITED) {
+        i64val = BYTESIZE_UNLIMITED;
+    }
+    config_maxword = i64val;
 
     ival = config_getenum(IMAPOPT_QOSMARKING);
     config_qosmarking = qos[ival];

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -55,6 +55,7 @@ extern int config_getswitch(enum imapopt opt);
 extern enum enum_value config_getenum(enum imapopt opt);
 extern unsigned long config_getbitfield(enum imapopt opt);
 extern int config_getduration(enum imapopt opt, int defunit);
+extern int64_t config_getbytesize(enum imapopt opt, int defunit);
 
 /* these work on additional strings that are not defined in the
  * imapoptions table */
@@ -67,9 +68,14 @@ extern const char *config_archivepartitiondir(const char *partition);
 
 extern const char *config_backupstagingpath(void);
 
-/* for parsing a duration-format string obtained elsewhere,
+/* for parsing duration/bytesize-format strings obtained elsewhere,
  * such as from an overflow string */
-extern int config_parseduration(const char *str, int defunit, int *out_duration);
+extern int config_parseduration(const char *str,
+                                int defunit,
+                                int *out_duration);
+extern int config_parsebytesize(const char *str,
+                                int defunit,
+                                int64_t *out_bytesize);
 
 /* for parsing boolean switch values, returns -1 on error */
 extern int config_parse_switch(const char *p);
@@ -96,5 +102,8 @@ extern int config_debug;
 
 /* config requirement flags */
 #define CONFIG_NEED_PARTITION_DATA (1<<0)
+
+/* what it really means when a byte size option treats 0 as "unlimited" */
+#define BYTESIZE_UNLIMITED (INT_MAX)
 
 #endif /* INCLUDED_LIBCONFIG_H */

--- a/timsieved/lex.c
+++ b/timsieved/lex.c
@@ -136,7 +136,7 @@ void lex_setrecovering(void)
 
 void lex_init(void)
 {
-  maxscriptsize = config_getint(IMAPOPT_SIEVE_MAXSCRIPTSIZE) * 1024;
+  maxscriptsize = config_getbytesize(IMAPOPT_SIEVE_MAXSCRIPTSIZE, 'K');
 
   buffer = (char *) xmalloc(maxscriptsize);
 }

--- a/tools/config2header
+++ b/tools/config2header
@@ -80,8 +80,9 @@ print HFILE "#include <stdint.h>\n";
 print HFILE "\n";
 
 # prototypes
-my @opttype = ("OPT_NOTOPT","OPT_STRING","OPT_INT","OPT_SWITCH",
-               "OPT_ENUM","OPT_STRINGLIST","OPT_BITFIELD", "OPT_DURATION");
+my @opttype = ("OPT_NOTOPT", "OPT_STRING", "OPT_INT", "OPT_SWITCH",
+               "OPT_ENUM", "OPT_STRINGLIST", "OPT_BITFIELD", "OPT_DURATION",
+               "OPT_BYTESIZE");
 print HFILE "enum opttype {\n";
 while (my $opt = pop (@opttype)) {
     if ($#opttype == -1) {
@@ -309,6 +310,10 @@ while (<STDIN>) {
             $def = $use_gcc_extension
                         ? "U_CFG_V((const char *) $2)"
                         : "{(void *)($2)}";
+        } elsif ($3 eq "BYTESIZE") {
+            $def = $use_gcc_extension
+                        ? "U_CFG_V((const char *) $2)"
+                        : "{(void *)($2)}";
         } else {
             $def = $use_gcc_extension
                         ? "U_CFG_V((long) $2)"
@@ -371,7 +376,7 @@ print HFILE <<EOF
 
 union config_value {
     $dummy_field
-    const char *s;      /* OPT_STRING, OPT_STRINGLIST, OPT_DURATION */
+    const char *s;      /* OPT_STRING, OPT_STRINGLIST, OPT_DURATION, OPT_BYTESIZE */
     long i;             /* OPT_INT */
     long b;             /* OPT_SWITCH */
     enum enum_value e;  /* OPT_ENUM */


### PR DESCRIPTION
**Note for reviewers**: 

This will be a nuisance to review, because it's lots of small and repetitive changes that need to be correct, and the compiler can't notice semantic mistakes.  I strongly suggest stepping through one commit at a time.  Please pay particular attention to:

* Do the documentation updates match the code updates?  e.g. if the documentation says "the default unit is kibibytes", does the `config_getbytesize()` call specify `'K'`?
* Did I get the magnitude conversions correct?  Lots of these options used to be measured in KB.  Some of them used KB in the config file only, but multiplied it to bytes internally; some used KB internally too.  They're all bytes internally now.  Quota is measured in KB, so the quota-related options now need to convert _backwards_ from bytes, whereas before they didn't.  And so on.
* Does any option names need to be changed?  I have only changed the very obvious ones.
* Please compile this and run all the tests.  I think I have the oldest compiler of the group at the moment, so yours may catch things mine didn't.

-----

This adds a BYTESIZE smart type to the imapd.conf parser.  BYTESIZE options take a suffix like "B", "KB", "MB", "GB", etc to allow the admin to specify readable values at a sensible scale.  Internally, they are all converted to bytes.  It's very similar to the existing DURATION smart type.

The BYTESIZE type's numeric representation is `int64_t` (all other types still use `int` or `long` internally), which allows it to represent values of "2GB" and over.

The units are all powers of two, never multiples of 1000.  Strictly, these are "kibibytes" etc in today's nomenclature.  The parser treats "K", "KB", and "KiB" the same (and case-insensitively) -- as `x * 1024` (and so on for the larger units), and this is documented.

The documentation uses the "kibibytes" etc naming, but I'm not wedded to it.  If we actually want to call them "kilobytes", then I'll do so.

Existing options have been converted to use the BYTESIZE type where appropriate.  In some cases the old option name forced a unit (e.g. `quotawarnkb`) -- these have been renamed (e.g. to `quotawarnsize`), and the old name deprecated.  Note that relevant deprecated names have also been converted to BYTESIZE -- this is the only way the deprecation can work, since it cannot convert between types.

A bunch of these options historically used 0-or-negative values to represent "unlimited", and handled that using `INT_MAX` as either an actual limit or a sentinel value.  I considered changing these to use `INT64_MAX`, but:

* many parts of our code aren't 64-bit clean, especially the older sections, and can't be expected to handle large values even though the config parser now can
* some of these are limits that are published to clients, such as the APPENDLIMIT capabilities response, and it would be inappropriate for us to represent that APPEND can support up to 9000 petabyte uploads when it almost certainly cannot, but that is what would happen if we used `INT64_MAX` and an admin left `maxmessagesize` at its default `"0"`

So instead I have added `#define BYTESIZE_UNLIMITED (INT_MAX)`, and the options that previously used `INT_MAX` to represent "unlimited" now use `BYTESIZE_UNLIMITED` for the same purpose (and with the same internal value).  An admin can choose to set an explicit larger value if they wish (and if it breaks they can keep both parts), but the default behaviour, and the documented "unlimited" behaviour, will continue to work as they have.  The documentation for these options has been updated to reflect that "unlimited" is really a large internally-defined limit.