### PR TITLE
jmap_ical: handle empty X-APPLE location property

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-empty-apple-location
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-empty-apple-location
@@ -1,0 +1,40 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_get_empty_apple_location
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.9.5//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTART:20160928T160000Z
+DURATION:PT1H
+UID:40d6fe3c-6a51-489e-823e-3ea22f427a3e
+DTSTAMP:20150928T132434Z
+CREATED:20150928T125212Z
+SUMMARY:test
+X-APPLE-STRUCTURED-LOCATION;VALUE=URI:
+LAST-MODIFIED:20150928T132434Z
+END:VEVENT
+END:VCALENDAR
+EOF
+    $caldav->Request('PUT',
+        '/dav/calendars/user/cassandane/Default/test.ics',
+        $ical, 'Content-Type' => 'text/calendar');
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/get', {
+            properties => ['locations'],
+        }, 'R2'],
+    ]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
+    $self->assert_null($res->[0][1]{list}[0]{locations});
+}

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -2980,7 +2980,7 @@ locations_from_ical(icalcomponent *comp, json_t *linksbyloc,
         /* X-APPLE-STRUCTURED-LOCATION */
         if (!strcmp(name, "X-APPLE-STRUCTURED-LOCATION")) {
             const char *uri = icalvalue_as_ical_string(icalproperty_get_value(prop));
-            if (strncmp(uri, "geo:", 4)) continue;
+            if (strncmpsafe(uri, "geo:", 4)) continue;
 
             struct buf title = BUF_INITIALIZER;
             const char *s = get_icalxparam_value(prop, JMAPICAL_XPARAM_TITLE);
@@ -6069,7 +6069,7 @@ static int geouri_parts_parse(const char *uri, struct geouri_parts *parts)
     const char *str = uri;
 
     // geo:
-    if (strncmp("geo:", str, 4)) return -1;
+    if (strncmpsafe("geo:", str, 4)) return -1;
     str += 4;
 
     // coord-a "," coord-b [ "," coord-c ]


### PR DESCRIPTION
Depending on how libical is compiled, it may return NULL for empty values. The JSCalendar converter expected
X-APPLE-STRUCTURED-LOCATION to be a non-empty geo: URI value.