### PR TITLE
HTTP: return 503 if a user autheticates but doesn't have an INBOX

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -926,4 +926,42 @@ sub test_blob_upload_type
     $self->assert_str_equals("application/octet-stream", $res->{type});
 }
 
+sub test_get_session_rename_race
+    :AllowMoves :min_version_3_7 :needs_component_jmap
+{
+    # Test fetching the JMAP session during/after a user has been renamed
+    # but before the authentication credentials have been changed.
+    # In this case, we should return 503 rather than 500.
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+    my $admintalk = $self->{adminstore}->get_client();
+
+    # GET session
+    my $RawRequest = {
+        headers => {
+            'Authorization' => $jmap->auth_header(),
+        },
+        content => '',
+    };
+    my $RawResponse = $jmap->ua->get($jmap->uri(), $RawRequest);
+    if ($ENV{DEBUGJMAP}) {
+        warn "JMAP " . Dumper($RawRequest, $RawResponse);
+    }
+    $self->assert_str_equals('200', $RawResponse->{status});
+    my $session = eval { decode_json($RawResponse->{content}) };
+    $self->assert_not_null($session);
+
+    my $res = $admintalk->rename('user.cassandane', 'user.newuser');
+    $self->assert(not $admintalk->get_last_error());
+
+    # Try to GET session
+    $RawResponse = $jmap->ua->get($jmap->uri(), $RawRequest);
+    if ($ENV{DEBUGJMAP}) {
+        warn "JMAP " . Dumper($RawRequest, $RawResponse);
+    }
+    $self->assert_str_equals('503', $RawResponse->{status});
+    $self->assert_not_null($RawResponse->{headers}{'retry-after'});
+}
+
 1;

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -810,6 +810,14 @@ static int my_caldav_auth(const char *userid)
     if (r) {
         syslog(LOG_ERR, "could not autoprovision calendars for userid %s: %s",
                 userid, error_message(r));
+        if (r == IMAP_INVALID_USER) {
+            /* We successfully authenticated, but don't have a user INBOX.
+               Assume that the user has yet to be fully provisioned,
+               or the user is being renamed.
+            */
+            return HTTP_UNAVAILABLE;
+        }
+        
         return HTTP_SERVER_ERROR;
     }
 

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -531,6 +531,14 @@ static int my_carddav_auth(const char *userid)
     if (r) {
         syslog(LOG_ERR, "could not autoprovision addressbook for userid %s: %s",
                 userid, error_message(r));
+        if (r == IMAP_INVALID_USER) {
+            /* We successfully authenticated, but don't have a user INBOX.
+               Assume that the user has yet to be fully provisioned,
+               or the user is being renamed.
+            */
+            return HTTP_UNAVAILABLE;
+        }
+        
         return HTTP_SERVER_ERROR;
     }
     return 0;

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -361,6 +361,15 @@ static int my_webdav_auth(const char *userid)
         else {
             syslog(LOG_ERR, "could not autoprovision DAV drive for userid %s: %s",
                    userid, error_message(r));
+            if (r == IMAP_INVALID_USER) {
+                /* We successfully authenticated, but don't have a user INBOX.
+                   Assume that the user has yet to be fully provisioned,
+                   or the user is being renamed.
+                */
+                return HTTP_UNAVAILABLE;
+            }
+        
+            return HTTP_SERVER_ERROR;
         }
 
         mboxname_release(&namespacelock);

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -331,6 +331,7 @@ struct txn_flags_t {
     unsigned long vary     : 6;         /* Headers on which response can vary */
     unsigned long trailer  : 3;         /* Headers which will be in trailer */
     unsigned long redirect : 1;         /* CGI local redirect */
+    unsigned long retry    : 1;         /* Retry-After */
 };
 
 /* HTTP connection context */


### PR DESCRIPTION
(this can occur during a user rename if the old auth creds still exist)

This issue has been seen in production and a 503 makes more sense than 500