### PR TITLE
jmap: option to allow relaxed IDs in createdIds

### DIFF
--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -330,6 +330,7 @@ static int validate_request(struct transaction_t *txn, const json_t *req,
 HIDDEN int jmap_is_valid_id(const char *id)
 {
     if (!id || *id == '\0') return 0;
+    if (config_getswitch(IMAPOPT_JMAP_RELAXEDIDS)) return 1;
     const char *p;
     for (p = id; *p; p++) {
         if (('0' <= *p && *p <= '9'))

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1307,6 +1307,9 @@ Blank lines and lines beginning with ``#'' are ignored.
 .PP
    If no unit is specified, seconds is assumed. */
 
+{ "jmap_relaxedids", 0, SWITCH, "3.6.0" }
+/* If enabled, allow invalid characters in JMAP ids */
+
 { "jmap_set_has_attachment", 1, SWITCH, "3.1.5" }
 /* If enabled, the $hasAttachment flag is determined and set for new messages
    created with the JMAP Email/set or Email/import methods. This option should


### PR DESCRIPTION
This was lying around on my desktop - it seems it might be generally useful to merge.