### PR TITLE
mailbox.c: remove "stale" index records when reconstructing DAV records

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -136,7 +136,7 @@ struct mailbox_iter {
     uint32_t num_records;
     unsigned skipflags;
     seqset_t *uidset;
-    int step_inc;
+    int32_t step_inc;
 };
 
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -4337,7 +4337,7 @@ static int mailbox_update_indexes(struct mailbox *mailbox,
 
 #ifdef WITH_DAV
     r = mailbox_update_dav(mailbox, old, new);
-    if (r) return r;
+    if (r && r != IMAP_NO_MSGGONE) return r;
 #endif
 
 #ifdef WITH_JMAP
@@ -5962,6 +5962,11 @@ EXPORTED int mailbox_add_dav(struct mailbox *mailbox)
         r = mailbox_update_dav(mailbox, NULL, record);
 
         if (r == IMAP_NO_MSGGONE) {
+            if (record->internal_flags & FLAG_INTERNAL_EXPUNGED) {
+                /* Already expunged */
+                continue;
+            }
+
             struct index_record copyrecord = *record;
             copyrecord.internal_flags |= FLAG_INTERNAL_EXPUNGED;
             copyrecord.silentupdate = 1;

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -312,7 +312,8 @@ struct mailbox {
 
 #define ITER_SKIP_UNLINKED (1<<0)
 #define ITER_SKIP_EXPUNGED (1<<1)
-#define ITER_SKIP_DELETED (1<<2)
+#define ITER_SKIP_DELETED  (1<<2)
+#define ITER_STEP_BACKWARD (1<<3)
 
 /* pre-declare message_t to avoid circular dependency problems */
 typedef struct message message_t;


### PR DESCRIPTION
For dav_reconstruct, iterate from most recent to least recent index records so that if we find an index record with a lower UID than the DAV DB record for that object (the object has been replaced), we can remove the "stale" index record.

The question is, do we want to do this for normal DAV updates or just on reconstruct?  newrecord->uid < cdara->dav.imap_uid is probably always bogus.