### PR TITLE
lcb_internal.c:parse_backup_line() last parameter is never null

### DIFF
--- a/backup/lcb_internal.c
+++ b/backup/lcb_internal.c
@@ -91,7 +91,7 @@ HIDDEN int parse_backup_line(struct protstream *in, time_t *ts,
         goto fail;
     }
 
-    if (kin) *kin = dl;
+    *kin = dl;
     if (cmd) buf_copy(cmd, &buf);
     if (ts) *ts = (time_t) t;
     buf_free(&buf);

--- a/backup/lcb_internal.h
+++ b/backup/lcb_internal.h
@@ -99,6 +99,7 @@ HIDDEN int backup_index(struct backup *backup, struct dlist *dlist,
                         time_t ts, off_t start, size_t len);
 
 /* parsing data from backup data stream files */
+__attribute__((nonnull(4)))
 int parse_backup_line(struct protstream *in, time_t *ts,
                       struct buf *cmd, struct dlist **kin);
 


### PR DESCRIPTION
If it is null, then the memory of dl would be leaked.