### PR TITLE
jmap_email: return empty calendarEvents for multiple UIDs

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email-get-calendarevents
+++ b/cassandane/tiny-tests/JMAPEmail/email-get-calendarevents
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_email_get_calendarevents
-    :min_version_3_1 :needs_component_sieve :needs_component_jmap
+    :min_version_3_7 :needs_component_sieve :needs_component_jmap
     :JMAPExtensions
 {
     my ($self) = @_;
@@ -16,9 +16,6 @@ sub test_email_get_calendarevents
 
     my $store = $self->{store};
     my $talk = $store->get_client();
-
-    my $uid1 = "d9e7f7d6-ce1a-4a71-94c0-b4edd41e5959";
-    my $uid2 = "caf7f7d6-ce1a-4a71-94c0-b4edd41e5959";
 
     $self->make_message("foo",
         mime_type => "multipart/related",
@@ -60,18 +57,7 @@ sub test_email_get_calendarevents
           . "SEQUENCE:1\r\n"
           . "SUMMARY:K=C3=A4se\r\n"
           . "TRANSP:OPAQUE\r\n"
-          . "UID:$uid1\r\n"
-          . "END:VEVENT\r\n"
-          . "BEGIN:VEVENT\r\n"
-          . "CREATED:20180718T090306Z\r\n"
-          . "DTEND;TZID=Europe/Vienna:20180718T100000\r\n"
-          . "DTSTAMP:20180518T090306Z\r\n"
-          . "DTSTART;TZID=Europe/Vienna:20180718T190000\r\n"
-          . "LAST-MODIFIED:20180718T090306Z\r\n"
-          . "SEQUENCE:1\r\n"
-          . "SUMMARY:Foo\r\n"
-          . "TRANSP:OPAQUE\r\n"
-          . "UID:$uid2\r\n"
+          . "UID:d9e7f7d6-ce1a-4a71-94c0-b4edd41e5959\r\n"
           . "END:VEVENT\r\n"
           . "END:VCALENDAR\r\n"
           . "\r\n--boundary_1--\r\n"
@@ -92,17 +78,12 @@ sub test_email_get_calendarevents
     $self->assert_num_equals(1, scalar keys %{$msg->{calendarEvents}});
     my $partId = $msg->{attachments}[0]{partId};
 
-    my %jsevents_by_uid = map { $_->{uid} => $_ } @{$msg->{calendarEvents}{$partId}};
-    $self->assert_num_equals(2, scalar keys %jsevents_by_uid);
-    my $jsevent1 = $jsevents_by_uid{$uid1};
-    my $jsevent2 = $jsevents_by_uid{$uid2};
+    my @jsevents = @{$msg->{calendarEvents}{$partId}};
+    $self->assert_num_equals(1, scalar @jsevents);
+    my $jsevent = $jsevents[0];
 
-    $self->assert_not_null($jsevent1);
-    $self->assert_str_equals("K\N{LATIN SMALL LETTER A WITH DIAERESIS}se", $jsevent1->{title});
-    $self->assert_str_equals('2018-05-18T09:00:00', $jsevent1->{start});
-    $self->assert_str_equals('Europe/Vienna', $jsevent1->{timeZone});
-    $self->assert_str_equals('PT1H', $jsevent1->{duration});
-
-    $self->assert_not_null($jsevent2);
-    $self->assert_str_equals("Foo", $jsevent2->{title});
+    $self->assert_str_equals("K\N{LATIN SMALL LETTER A WITH DIAERESIS}se", $jsevent->{title});
+    $self->assert_str_equals('2018-05-18T09:00:00', $jsevent->{start});
+    $self->assert_str_equals('Europe/Vienna', $jsevent->{timeZone});
+    $self->assert_str_equals('PT1H', $jsevent->{duration});
 }

--- a/cassandane/tiny-tests/JMAPEmail/email-get-calendarevents-one-uid-only
+++ b/cassandane/tiny-tests/JMAPEmail/email-get-calendarevents-one-uid-only
@@ -1,0 +1,85 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_calendarevents_one_uid_only
+    :min_version_3_7 :needs_component_jmap :JMAPExtensions
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+    my $instance = $self->{instance};
+
+
+    my $using = [
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:mail',
+        'urn:ietf:params:jmap:submission',
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/debug',
+        'https://cyrusimap.org/ns/jmap/performance',
+    ];
+
+    my $mimeMessage = <<'EOF';
+From: from@local
+To: to@local
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: multipart/related;
+ boundary=c4683f7a320d4d20902b000486fbdf9b
+
+--c4683f7a320d4d20902b000486fbdf9b
+Content-Type: text/plain
+
+test
+
+--c4683f7a320d4d20902b000486fbdf9b
+Content-Type: text/calendar;charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.9.5//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTART;TZID=Europe/Vienna:20160928T160000
+DTEND;TZID=Europe/Vienna:20160928T170000
+UID:40d6fe3c-6a51-489e-823e-3ea22f427a3e
+DTSTAMP:20150928T132434Z
+CREATED:20150928T125212Z
+SUMMARY:event1
+LAST-MODIFIED:20150928T132434Z
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=Europe/Vienna:20170928T160000
+DTEND;TZID=Europe/Vienna:20170928T170000
+UID:b384fb45-afbd-4c25-b059-37f26b29e684
+DTSTAMP:20160928T132434Z
+CREATED:20160928T125212Z
+SUMMARY:event2
+LAST-MODIFIED:20160928T132434Z
+END:VEVENT
+END:VCALENDAR
+
+--c4683f7a320d4d20902b000486fbdf9b--
+EOF
+    $mimeMessage =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $mimeMessage) || die $@;
+
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $res = $jmap->CallMethods([
+        ['Email/query', {
+        }, 'R1'],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'Email/query',
+                path => '/ids',
+            },
+            properties => ['calendarEvents'],
+        }, 'R2'],
+    ], $using);
+
+    $self->assert_null($res->[1][1]{list}[0]{calendarEvents});
+}

--- a/imap/jmap_calendar.h
+++ b/imap/jmap_calendar.h
@@ -54,6 +54,7 @@
 extern json_t *jmap_calendar_events_from_msg(jmap_req_t *req,
                                              const char *mboxid, uint32_t uid,
                                              hash_table *icsbody_by_partid,
+                                             int allow_multiple_uids,
                                              const struct buf *mime);
 
 #endif /* JMAP_CALENDAR_H */

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7807,7 +7807,7 @@ static int _email_get_bodies(jmap_req_t *req,
             }
             events = jmap_calendar_events_from_msg(req,
                     mbox ? mailbox_uniqueid(mbox) : NULL, uid,
-                    &icsbody_by_partid, msg->mime);
+                    &icsbody_by_partid, 0, msg->mime);
         }
         json_object_set_new(email, "calendarEvents", events);
 


### PR DESCRIPTION
The purpose of the Email.calendarEvents property is to extract calendar event invitations from the email attachments. If an attached VCALENDAR instead contains calendar components with differing iCalendar UIDs, then this should be handled like a regular attachment and calendarEvents be empty.