### PR TITLE
Specialuse: test specialuse_nochildren create behaviour

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -77,14 +77,25 @@ sub new
     }, @args);
 }
 
-sub set_up
+sub setup_default_using
 {
     my ($self) = @_;
-    $self->SUPER::set_up();
     $self->{jmap}->DefaultUsing([
         'urn:ietf:params:jmap:core',
         'urn:ietf:params:jmap:mail',
     ]);
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+
+    if ($self->{jmap}) {
+        $self->setup_default_using();
+    }
+    # n.b. tests that use :NoStartInstances will need to call
+    # $self->setup_default_using() themselves!
 }
 
 sub getinbox

--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -54,6 +54,9 @@ use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 
+use lib '../perl/imap';
+use Cyrus::DList;
+
 use charnames ':full';
 
 sub new
@@ -5291,6 +5294,85 @@ sub test_mailbox_ignore_notes_subfolders
     $self->assert_deep_equals([$inboxId], $res->[0][1]{ids});
     $self->assert_num_equals(1, scalar @{$res->[1][1]{list}});
     $self->assert_str_equals($inboxId, $res->[1][1]{list}[0]{id});
+}
+
+sub test_mailbox_set_create_specialuse_nochildren
+    :min_version_3_7 :needs_component_jmap :NoStartInstances
+{
+    my ($self) = @_;
+
+    $self->{instance}->{config}->set('specialuse_nochildren' => '\\Trash');
+    $self->_start_instances();
+    $self->_setup_http_service_objects();
+    $self->setup_default_using();
+
+    my $jmap = $self->{jmap};
+    my $imaptalk = $self->{store}->get_client();
+
+    # set up a Trash folder with \Trash special-use annotation
+    my $res = $jmap->CallMethods([[ 'Mailbox/set', {
+        create => {
+            trashmbox => {
+                name => 'Trash',
+                role => 'trash',
+            }
+        }
+    }, 'R1']]);
+    my $trash_id = $res->[0][1]->{created}->{trashmbox}->{id};
+    $self->assert_not_null($trash_id);
+
+    # should not be able to create a child of \Trash
+    $res = $jmap->CallMethods([['Mailbox/set', {
+        create => {
+            1 => {
+                parentId => $trash_id,
+                name => 'child',
+            },
+        },
+    }, "R1"]]);
+
+    # XXX that syslogs an IOERROR, surprisingly -- ignore it
+    $self->{instance}->getsyslog();
+
+    $self->assert_null($res->[0][1]->{created});
+    $self->assert_deep_equals({ 1 => { type => 'forbidden' } },
+                              $res->[0][1]->{notCreated});
+
+    # what if we remove the annotation
+    # (doing this with IMAP because JMAP can't simply remove it)
+    $imaptalk->setmetadata("Trash", "/private/specialuse", undef);
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    # should be able to create the child now
+    $res = $jmap->CallMethods([['Mailbox/set', {
+        create => {
+            1 => {
+                parentId => $trash_id,
+                name => 'child',
+            },
+        },
+    }, "R1"]]);
+    $self->assert_not_null($res->[0][1]->{created}->{1}->{id});
+
+    # should not be able to add the annotation back
+    $imaptalk->setmetadata("Trash", "/private/specialuse", '\\Trash');
+    $self->assert_equals('no', $imaptalk->get_last_completion_response());
+
+    # should not be able to add the JMAP role back either
+    $res = $jmap->CallMethods([['Mailbox/set', {
+        update => {
+            $trash_id => {
+                role => 'trash',
+            }
+        }
+    }, "R1"]]);
+
+    $self->assert_not_null($res->[0][1]->{notUpdated}->{$trash_id});
+    $self->assert_null($res->[0][1]->{updated});
+    $self->assert_str_equals('invalidProperties',
+        $res->[0][1]->{notUpdated}{$trash_id}{type});
+    $self->assert_deep_equals(['role'],
+        $res->[0][1]->{notUpdated}{$trash_id}{properties});
 }
 
 1;

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -3354,7 +3354,7 @@ struct mboxset_state {
     int has_conflict;
     hash_table *id_by_imapname;
     hash_table *entry_by_id;
-    hash_table *siblings_by_parent_id;
+    hash_table *siblingnames_by_parent_id;
     hash_table *specialuses_by_id;
 };
 
@@ -3431,10 +3431,10 @@ static void _mboxset_state_conflict_cb(const char *id, void *data, void *rock)
     if (entry->parent_id) parent_id = entry->parent_id;
 
     /* A mailbox must not have siblings with the same name. */
-    strarray_t *siblings = hash_lookup(parent_id, state->siblings_by_parent_id);
+    strarray_t *siblings = hash_lookup(parent_id, state->siblingnames_by_parent_id);
     if (!siblings) {
         siblings = strarray_new();
-        hash_insert(parent_id, siblings, state->siblings_by_parent_id);
+        hash_insert(parent_id, siblings, state->siblingnames_by_parent_id);
     }
     int i;
     for (i = 0; i < strarray_size(siblings); i++) {
@@ -3775,9 +3775,9 @@ static int _mboxset_state_validate(jmap_req_t *req,
     construct_hash_table(&entry_by_id, 1024, 0);
     state->entry_by_id = &entry_by_id;
 
-    hash_table siblings_by_parent_id = HASH_TABLE_INITIALIZER;
-    construct_hash_table(&siblings_by_parent_id, 1024, 0);
-    state->siblings_by_parent_id = &siblings_by_parent_id;
+    hash_table siblingnames_by_parent_id = HASH_TABLE_INITIALIZER;
+    construct_hash_table(&siblingnames_by_parent_id, 1024, 0);
+    state->siblingnames_by_parent_id = &siblingnames_by_parent_id;
 
     mboxlist_usermboxtree(req->accountid, NULL, _mboxset_state_mboxlist_cb, state,
                           MBOXTREE_INTERMEDIATES);
@@ -3807,7 +3807,7 @@ static int _mboxset_state_validate(jmap_req_t *req,
     /* Clean up state */
     free_hash_table(&entry_by_id, _mboxset_entry_free);
     free_hash_table(&id_by_imapname, free);
-    free_hash_table(&siblings_by_parent_id, (void(*)(void*))strarray_free);
+    free_hash_table(&siblingnames_by_parent_id, (void(*)(void*))strarray_free);
     free_hash_table(&specialuses_by_id, (void(*)(void*))strarray_free);
     free(state);
 

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -3687,7 +3687,7 @@ static void _mboxset_state_update_specialuse(struct mboxset_state *state,
     }
 
     /* Validate: no children for specialuse_nochildren roles */
-    if (config_getstring(IMAPOPT_SPECIALUSE_NOCHILDREN)) {
+    if (!state->has_conflict && config_getstring(IMAPOPT_SPECIALUSE_NOCHILDREN)) {
         strarray_t *nochildren =
             strarray_split(config_getstring(IMAPOPT_SPECIALUSE_NOCHILDREN),
                 NULL, STRARRAY_TRIM);
@@ -3711,6 +3711,7 @@ static void _mboxset_state_update_specialuse(struct mboxset_state *state,
         strarray_free(nochildren);
         hash_iter_free(&iter);
     }
+
     /* Handle conflicts */
     if (state->has_conflict) {
         struct buf desc = BUF_INITIALIZER;


### PR DESCRIPTION
Adds a test for this behaviour:

> **specialuse_nochildren: \Scheduled \Snooze**
> 
> Whitespace separated list of special-use attributes that may not  contain
> child  folders.   If  set, mailboxes with any of these attributes may not
> have child folders created, and these attributes cannot be added to mail‐
> boxes that already have children..

We thought there might be an edge case allowing creation of mailboxes under the `\Trash` mailbox even though `specialuse_nochildren: \Trash` has been configured.  This test shows that there isn't such an edge case, or at least, not one that's simple to reproduce.