### PR TITLE
3.6: Last parameter of icalcomponent_vanew() must be NULL, not 0

### DIFF
--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -396,7 +396,7 @@ static int extract_personal_data(icalcomponent *ical, icalcomponent *oldical,
                     patch = icalcomponent_vanew(ICAL_XPATCH_COMPONENT,
                                                 icalproperty_new_patchtarget(
                                                     buf_cstring(path)),
-                                                0);
+                                                NULL);
                     icalcomponent_add_component(vpatch, patch);
                 }
 
@@ -473,7 +473,7 @@ static int extract_personal_data(icalcomponent *ical, icalcomponent *oldical,
                     patch = icalcomponent_vanew(ICAL_XPATCH_COMPONENT,
                                                 icalproperty_new_patchtarget(
                                                     buf_cstring(path)),
-                                                0);
+                                                NULL);
                     icalcomponent_add_component(vpatch, patch);
                 }
 
@@ -642,7 +642,7 @@ static int personalize_resource(struct transaction_t *txn,
                                                                   0,
                                                                   utc_zone)),
                                 icalproperty_new_uid(buf_cstring(&txn->buf)),
-                                0);
+                                NULL);
         buf_reset(&txn->buf);
 
         /* Extract personal info from owner's resource and create vpatch */
@@ -689,7 +689,7 @@ static int personalize_resource(struct transaction_t *txn,
                                                                   0,
                                                                   utc_zone)),
                                 icalproperty_new_uid(buf_cstring(&txn->buf)),
-                                0);
+                                NULL);
         buf_reset(&txn->buf);
 
         /* Extract personal info from new resource and add to vpatch */

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -4904,7 +4904,7 @@ static icalcomponent *expand_caldata(icalcomponent **ical,
         icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT,
                             icalproperty_new_version("2.0"),
                             icalproperty_new_prodid(ical_prodid),
-                            0);
+                            NULL);
 
     /* Copy over any CALSCALE property */
     icalproperty *prop =
@@ -5861,7 +5861,7 @@ static int propfind_timezone(const xmlChar *name, xmlNsPtr ns,
                                             icalproperty_new_version("2.0"),
                                             icalproperty_new_prodid(ical_prodid),
                                             vtz,
-                                            0);
+                                            NULL);
 
                     data = icalcomponent_as_ical_string(ical);
                     datalen = strlen(data);
@@ -7180,7 +7180,7 @@ icalcomponent *busytime_query_local(struct transaction_t *txn,
     ical = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT,
                                icalproperty_new_version("2.0"),
                                icalproperty_new_prodid(ical_prodid),
-                               0);
+                               NULL);
 
     if (method) icalcomponent_set_method(ical, method);
 
@@ -7190,7 +7190,7 @@ icalcomponent *busytime_query_local(struct transaction_t *txn,
                                          time(0), 0, utc_zone)),
                                  icalproperty_new_dtstart(fbfilter->start),
                                  icalproperty_new_dtend(fbfilter->end),
-                                 0);
+                                 NULL);
 
     icalcomponent_add_component(ical, fbcomp);
 

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1165,7 +1165,7 @@ static void sched_pollstatus(const char *organizer,
                                icalproperty_new_version("2.0"),
                                icalproperty_new_prodid(ical_prodid),
                                icalproperty_new_method(ICAL_METHOD_POLLSTATUS),
-                               0);
+                               NULL);
 
     /* Copy over any CALSCALE property */
     prop = icalcomponent_get_first_property(ical, ICAL_CALSCALE_PROPERTY);
@@ -1578,7 +1578,7 @@ icalcomponent *make_itip(icalproperty_method method, icalcomponent *ical)
                                              icalproperty_new_version("2.0"),
                                              icalproperty_new_prodid(ical_prodid),
                                              icalproperty_new_method(method),
-                                             0);
+                                             NULL);
 
     /* XXX  Make sure SEQUENCE is incremented */
 

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -596,7 +596,7 @@ EXPORTED icalcomponent *icalcomponent_new_stream(struct mailbox *mailbox,
                                    icaltime_from_timet_with_zone(mailbox->index_mtime,
                                                                  0, NULL)),
                                icalproperty_new_name(name),
-                               0);
+                               NULL);
 
     buf_free(&buf);
 

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -856,7 +856,7 @@ HIDDEN enum sched_deliver_outcome sched_deliver_local(const char *userid,
                    icalcomponent_get_uid(sched_data->itip));
 
         /* Create new attendee object */
-        ical = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT, 0);
+        ical = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT, NULL);
 
         /* Copy over VERSION property */
         prop = icalcomponent_get_first_property(sched_data->itip,


### PR DESCRIPTION
https://github.com/libical/libical/issues/585

Backport of https://github.com/cyrusimap/cyrus-imapd/pull/4278