### PR TITLE
3.0: Last parameter of icalcomponent_vanew() must be NULL, not 0

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5207,7 +5207,7 @@ static icalcomponent *expand_caldata(icalcomponent **ical,
         icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT,
                             icalproperty_new_version("2.0"),
                             icalproperty_new_prodid(ical_prodid),
-                            0);
+                            NULL);
 
     /* Copy over any CALSCALE property */
     icalproperty *prop =
@@ -7231,7 +7231,7 @@ icalcomponent *busytime_query_local(struct transaction_t *txn,
     ical = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT,
                                icalproperty_new_version("2.0"),
                                icalproperty_new_prodid(ical_prodid),
-                               0);
+                               NULL);
 
     if (method) icalcomponent_set_method(ical, method);
 
@@ -7241,7 +7241,7 @@ icalcomponent *busytime_query_local(struct transaction_t *txn,
                                          time(0), 0, utc_zone)),
                                  icalproperty_new_dtstart(fbfilter->start),
                                  icalproperty_new_dtend(fbfilter->end),
-                                 0);
+                                 NULL);
 
     icalcomponent_add_component(ical, fbcomp);
 

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1221,7 +1221,7 @@ static void sched_pollstatus(const char *organizer,
                                icalproperty_new_version("2.0"),
                                icalproperty_new_prodid(ical_prodid),
                                icalproperty_new_method(ICAL_METHOD_POLLSTATUS),
-                               0);
+                               NULL);
 
     /* Copy over any CALSCALE property */
     prop = icalcomponent_get_first_property(ical, ICAL_CALSCALE_PROPERTY);
@@ -1813,7 +1813,7 @@ static void sched_deliver_local(const char *recipient,
                    icalcomponent_get_uid(sched_data->itip));
 
         /* Create new attendee object */
-        ical = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT, 0);
+        ical = icalcomponent_vanew(ICAL_VCALENDAR_COMPONENT, NULL);
 
         /* Copy over VERSION property */
         prop = icalcomponent_get_first_property(sched_data->itip,
@@ -2327,7 +2327,7 @@ icalcomponent *make_itip(icalproperty_method method, icalcomponent *ical)
                                              icalproperty_new_version("2.0"),
                                              icalproperty_new_prodid(ical_prodid),
                                              icalproperty_new_method(method),
-                                             0);
+                                             NULL);
 
     /* XXX  Make sure SEQUENCE is incremented */
 


### PR DESCRIPTION
https://github.com/libical/libical/issues/585

Backport of https://github.com/cyrusimap/cyrus-imapd/pull/4278