### PR TITLE
github actions: get tags from upstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,8 @@ jobs:
     - name: configure and build
       run: |
         git fetch --unshallow
-        git fetch --tags
+        git remote add upstream https://github.com/cyrusimap/cyrus-imapd.git
+        git fetch --tags upstream
         ./tools/build-with-cyruslibs.sh
     - name: update jmap test suite
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         git remote add upstream https://github.com/cyrusimap/cyrus-imapd.git
         git fetch --tags upstream
         ./tools/build-with-cyruslibs.sh
+      shell: bash
     - name: update jmap test suite
       run: |
         cd /srv/JMAP-TestSuite.git
@@ -32,10 +33,12 @@ jobs:
         git clean -f -x -d
         cpanm --installdeps .
         cd -
+      shell: bash
     - name: install missing deps
       run: |
         cpanm IO::File::fcntl
         cpanm Digest::CRC
+      shell: bash
     - name: run cassandane
       run: |
         cd cassandane
@@ -44,6 +47,7 @@ jobs:
         make
         setpriv --reuid=cyrus --regid=mail --clear-groups --inh-caps='-chown,-dac_override,-dac_read_search,-fowner,-fsetid,-kill,-setgid,-setuid,-setpcap,-linux_immutable,-net_bind_service,-net_broadcast,-net_admin,-net_raw,-ipc_lock,-ipc_owner,-sys_module,-sys_rawio,-sys_chroot,-sys_ptrace,-sys_pacct,-sys_admin,-sys_boot,-sys_nice,-sys_resource,-sys_time,-sys_tty_config,-mknod,-lease,-audit_write,-audit_control,-setfcap,-mac_override,-mac_admin,-syslog,-wake_alarm,-block_suspend,-audit_read,-cap_38,-cap_39,-cap_40' ./testrunner.pl -f pretty -j 4 !Test::Core
         cd -
+      shell: bash
     - name: collect logs
       if: always()
       run: |


### PR DESCRIPTION
The build process depends on having access to the release tags to determine the version, and many of our tests need to examine the cyrus version, and will fail in annoying ways if the version is missing or incorrect.  When github actions run from a fork, rather than the main repository, our release tags are probably missing, and so a bunch of tests fail (unless the fork maintainer bothers to keep their fork updated with our release tags for some reason, but they shouldn't have to).

This updates it to fetch git tags directly from the cyrusimap/cyrus-imapd repository, even if the action is running from a fork.

It also updates the multiline run commands to use "shell: bash", which allegedly causes them to be run in bash's fast-fail mode (`set -eo pipefail`).  This should mean that if any command fails the whole job fails, whereas the default is apparently to ignore the exit status of all commands in a `run` except the last one.  Might be useful in the future when debugging github actions stuff.

I'm not sure if we still need the `git fetch --unshallow`, maybe it's redundant and can be removed now?  I read the documentation for unshallow and didn't get any closer to a decision, so I've left it alone for now.

I don't yet know if these changes will break when run from the main repo, but we'll find out after I click "Create pull request"...