### PR TITLE
tools/compile_st.pl: strip 'Command-line' from gperf output

### DIFF
--- a/imap/rfc822_header.c
+++ b/imap/rfc822_header.c
@@ -1,5 +1,4 @@
 /* ANSI-C code produced by gperf version 3.1 */
-/* Command-line: gperf /tmp/compile_st_5cSAcK.gperf  */
 /* Computed positions: -k'1,10,$' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \

--- a/tools/compile_st.pl
+++ b/tools/compile_st.pl
@@ -294,12 +294,15 @@ if ($c_flag)
     open GPERF,'-|',@cmd
         or die "Couldn't run gperf";
 
-    # Post-process to fix warnings due to missing
-    # initializers in the wordlist.
+    # Post-process to fix warnings due to missing initializers in the wordlist,
+    # and remove Command-line from output.
     my $s = 0;
+    my $cmdline_pat = qr{^\/\* \s Command-line: \s gperf \s $filename \s+ \*\/$}x;
     while (<GPERF>)
     {
         chomp;
+
+        next if m/$cmdline_pat/;
 
         next if m/^#line/;
         s/{""}/{"", 0}/g if ($s);


### PR DESCRIPTION
We version control the output file from this command (as `imap/rfc822_header.c`), and having the name of the tempfile used to generate it embedded in the output made it show up as different every time it was regenerated, even though usually the only difference was the name of the tempfile.

Now it will only show up as different when something interesting changed.

The file in question is only regenerated in maintainer mode, so you probably don't notice it unless you're doing releases, but it's been annoying me for years...