### PR TITLE
Force MIME-encode SUMMARY when creating Subject header field

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -5459,4 +5459,68 @@ EOF
       $admin->message_count('user.cassandane.#jmapnotification'));
 }
 
+sub test_summary_with_embedded_newlines
+    :needs_component_httpd :MagicPlus
+{
+    my ($self) = @_;
+
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $uuid = "574E2CD0-2D2A-4554-8B63-C7504481D3A9";
+    my $href = "$CalendarId/$uuid.ics";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:574E2CD0-2D2A-4554-8B63-C7504481D3A9
+DTEND:20160831T183000Z
+TRANSP:OPAQUE
+SUMMARY:Send image for 61st anniversary exhibition at gallery -- Include
+ your name\, the title and the media.  To be of appropriate quality\, the
+ ideal image file size should be 300 - 500 kilobytes.\\n\\nUse your last
+ name and an abbreviated title as the file name
+ (Lastname_Title.jpg).\\n\\nPlease send to:   foo\@example.net\\n\\n
+DTSTART:20160831T153000Z
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    my %Headers = (
+      'Content-Type' => 'text/calendar',
+      'Authorization' => $CalDAV->auth_header(),
+    );
+
+    xlog "Create event";
+    my $Response = $CalDAV->{ua}->request('PUT', $CalDAV->request_url($href), {
+      content => $card,
+      headers => \%Headers,
+    });
+
+    # This only succeeds if we properly encode the SUMMARY
+    # as a Subject header field when constructing the message on disk
+    $self->assert_num_equals(201, $Response->{status});
+
+    xlog "Check Subject header";
+    my $subject = "=?UTF-8?Q?Send_image_for_61st_anniversary_exhibition_at_gallery_--_Inclu?=\r\n";
+    $subject .= " =?UTF-8?Q?deyour_name,_the_title_and_the_media.__To_be_of_appropriate_q?=\r\n";
+    $subject .= " =?UTF-8?Q?uality,_theideal_image_file_size_should_be_300_-_500_kilobyte?=\r\n";
+    $subject .= " =?UTF-8?Q?s.=0A=0AUse_your_lastname_and_an_abbreviated_title_as_the_fil?=\r\n";
+    $subject .= " =?UTF-8?Q?e_name(Lastname=5FTitle.jpg).=0A=0APlease_send_to:___foo\@exam?=\r\n";
+    $subject .= " =?UTF-8?Q?ple.net=0A=0A?=";
+
+    my $store = $self->{instance}->get_service('imap')->create_store(username => 'cassandane+dav');
+    my $imaptalk = $store->get_client();
+    $imaptalk->select("INBOX.#calendars.$CalendarId");
+    $Response = $imaptalk->fetch(1, '(BODY.PEEK[HEADER.FIELDS (SUBJECT)])');
+    $self->assert_str_equals($Response->{1}->{headers}->{subject}[0], $subject);
+}
+
 1;

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -307,11 +307,12 @@ static void test_qp(void)
 static void test_encode_mimeheader(void)
 {
     /* corner cases in Quoted-Printable */
-#define TESTCASE(in, exp) \
+#define TESTCASE(in, exp, len) \
     { \
         static const char _in[] = (in); \
         static const char _exp[] = (exp); \
-        char *s = charset_encode_mimeheader(_in, 0, 0); \
+        int _len = (len); \
+        char *s = charset_encode_mimeheader(_in, _len, 0); \
         CU_ASSERT_PTR_NOT_NULL(s); \
         CU_ASSERT_STRING_EQUAL(s, _exp); \
         const char *p, *lf; \
@@ -325,41 +326,60 @@ static void test_encode_mimeheader(void)
         free(s); \
     }
 
-    TESTCASE("abc", "abc");
+    TESTCASE("abc", "abc", 0);
 
-    TESTCASE("abc\r\n", "=?UTF-8?Q?abc?=");
+    TESTCASE("abc\r\n", "=?UTF-8?Q?abc?=", 0);
 
     /* bogus indent */
-    TESTCASE("abc\r\nxyz", "=?UTF-8?Q?abc?=\r\n =?UTF-8?Q?xyz?=");
+    TESTCASE("abc\r\nxyz", "=?UTF-8?Q?abc?=\r\n =?UTF-8?Q?xyz?=", 0);
 
     /* wrap */
-    TESTCASE("abc\r\n xyz", "=?UTF-8?Q?abc?=\r\n =?UTF-8?Q?xyz?=");
+    TESTCASE("abc\r\n xyz", "=?UTF-8?Q?abc?=\r\n =?UTF-8?Q?xyz?=", 0);
 
     /* three-byte UTF-8 word barely fits line length limit */
     TESTCASE("0123456789012345678901234567890123456789012345678901234\xe2\x82\xac",
-             "=?UTF-8?Q?0123456789012345678901234567890123456789012345678901234=E2=82=AC?=");
+             "=?UTF-8?Q?0123456789012345678901234567890123456789012345678901234=E2=82=AC?=", 0);
 
     /* three-byte UTF-8 word must not be split */
     TESTCASE("01234567890123456789012345678901234567890123456789012345\xe2\x82\xac",
              "=?UTF-8?Q?01234567890123456789012345678901234567890123456789012345?="
-             "\r\n ""=?UTF-8?Q?=E2=82=AC?=");
+             "\r\n ""=?UTF-8?Q?=E2=82=AC?=", 0);
 
     /* only encode display-name of address */
-    TESTCASE("\"abc\xe2\x88\x97xyz\" <foo@example.com>", "=?UTF-8?Q?=22abc=E2=88=97xyz=22?= <foo@example.com>");
+    TESTCASE("\"abc\xe2\x88\x97xyz\" <foo@example.com>", "=?UTF-8?Q?=22abc=E2=88=97xyz=22?= <foo@example.com>", 0);
 
     /* fold long lines with whitespace */
     TESTCASE("012345678 " "012345678 " "012345678 " "012345678 "
              "012345678 " "012345678 " "012345678 " "0123456789",
              "012345678 " "012345678 " "012345678 " "012345678 "
              "012345678 " "012345678 " "012345678" "\r\n "
-             "0123456789");
+             "0123456789", 0)
+
+    /* fold long lines with whitespace (truncated) */
+    TESTCASE("012345678 " "012345678 " "012345678 " "012345678 "
+             "012345678 " "012345678 " "012345678 " "0123456789",
+             "012345678 " "012345678 " "012345678 " "012345678 "
+             "012345678 " "012345678 " "012345678" "\r\n "
+             "012345678", 79);
+
+    /* truncate long lines */
+    TESTCASE("012345678 " "012345678 " "012345678 " "012345678 "
+             "012345678 " "012345678 " "012345678 " "0123456789",
+             "012345678 " "012345678 " "01234", 25);
 
     /* encode long lines with no whitespace */
     TESTCASE("0123456789" "0123456789" "0123456789" "0123456789"
              "0123456789" "0123456789" "0123456789" "0123456789",
              "=?UTF-8?Q?" "0123456789" "0123456789" "0123456789" "0123456789"
              "0123456789" "0123456789" "01?=\r\n "
-             "=?UTF-8?Q?" "2345678901" "23456789?=");
+             "=?UTF-8?Q?" "2345678901" "23456789?=", 0);
+
+    /* encode long lines with no whitespace (truncated) */
+    TESTCASE("0123456789" "0123456789" "0123456789" "0123456789"
+             "0123456789" "0123456789" "0123456789" "0123456789",
+             "=?UTF-8?Q?" "0123456789" "0123456789" "0123456789" "0123456789"
+             "0123456789" "0123456789" "01?=\r\n "
+             "=?UTF-8?Q?" "2345678901" "2345678?=", 79);
 
 #undef TESTCASE
 }

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3739,7 +3739,7 @@ static char *qp_encode(const char *data, size_t len, int isheader,
             }
             last_wsp = j++;
         }
-        buf_appendcstr(&buf, data + i);
+        buf_appendmap(&buf, data + i, len - i);
     }
     else {
         buf_setmap(&buf, data, len);


### PR DESCRIPTION
This fixes an issue where embedded newlines in the SUMMARY property would cause us to create a Subject header which would prematurely signal the end of the header section of our constructed message.  This resulted in our message parser never reaching the Content-Disposition header field, thereby NOT parsing our CalDAV resource name and subsequently violating the resource NOT NULL constraint in the ical_objs SQL table.