### PR TITLE
Add long-options support to ctl_cyrusdb and reconstruct

### DIFF
--- a/backup/ctl_backups.c
+++ b/backup/ctl_backups.c
@@ -354,7 +354,7 @@ int main(int argc, char **argv)
     options.wait = BACKUP_OPEN_NONBLOCK;
 
     /* keep in alphabetical order */
-    static const char *const short_options = ":AC:DFPSVcfjmpst:uvwx:";
+    static const char short_options[] = ":AC:DFPSVcfjmpst:uvwx:";
 
     static const struct option long_options[] = {
         { "all", no_argument, NULL, 'A' },

--- a/backup/cyr_backup.c
+++ b/backup/cyr_backup.c
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
     int i, opt, r = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:fmuv";
+    static const char short_options[] = "C:fmuv";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/backup/restore.c
+++ b/backup/restore.c
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
     int opt, r = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = ":A:C:DF:LM:P:UXaf:m:nru:vw:xz";
+    static const char short_options[] = ":A:C:DF:LM:P:UXaf:m:nru:vw:xz";
 
     static const struct option long_options[] = {
         { "override-acl", optional_argument, NULL, 'A' },

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_cyrusdb.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_cyrusdb.rst
@@ -37,7 +37,7 @@ Options
 
     |cli-dash-c-text|
 
-.. option:: -r
+.. option:: -r, --recover
 
     Recover the database after an application or system failure. Also
     performs database cleanups like removing mailbox reservations (and
@@ -53,12 +53,12 @@ Options
     in the database, but the ``reverseacls`` option is disabled, then the
     entries will be cleaned up.
 
-.. option:: -x
+.. option:: -x, --no-cleanup
 
     Used with ``-r`` to only recover the database, and prevent any
     cleanup.
 
-.. option:: -c
+.. option:: -c, --checkpoint
 
     Checkpoint and archive (a copy of) the database.
 

--- a/docsrc/imap/reference/manpages/systemcommands/reconstruct.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/reconstruct.rst
@@ -140,8 +140,9 @@ Options
 
 .. option:: -o, --ignore-odd-files
 
-    Ignore odd files in your mailbox disk directories.  Probably useful
-    if you are using some tool which adds additional tracking files.
+    Ignore odd files in your mailbox disk directories, instead of
+    complaining about them.  Probably useful if you are using some
+    tool which adds additional tracking files.
 
 .. option:: -O, --delete-odd-files
 

--- a/docsrc/imap/reference/manpages/systemcommands/reconstruct.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/reconstruct.rst
@@ -65,17 +65,17 @@ Options
 
 .. program:: reconstruct
 
-.. option:: -C  config-file
+.. option:: -C config-file
 
     |cli-dash-c-text|
 
-.. option:: -p  partition
+.. option:: -p partition, --partition=partition
 
     Search for the listed (non-existant) mailboxes on the indicated
     *partition*. Create the mailboxes in the database in addition to
     reconstructing them. (not compatible with the use of wildcards)
 
-.. option:: -x
+.. option:: -x, --ignore-disk-metadata
 
     When processing a mailbox which is not in the mailbox list (e.g.
     via the **-p** or **-f** options), do not import the metadata from
@@ -83,52 +83,52 @@ Options
     least the mailbox's seen state unique identifier, user flags, and
     ACL).
 
-.. option:: -r
+.. option:: -r, --recursive
 
     Recursively reconstruct all sub-mailboxes of the mailboxes or
     mailbox prefixes given as arguments.
 
-.. option:: -f
+.. option:: -f, --scan-filesystem
 
     Examine the filesystem underneath mailbox, adding all directories
     with a ``cyrus.header`` found there as new mailboxes.  Useful for
     restoring mailboxes from backups.
 
-.. option:: -s
+.. option:: -s, --no-stat
 
     Don't stat underlying files.  This makes reconstruct run faster, at
     the expense of not noticing some issues (like zero byte files or
     size mismatches).  "**reconstruct -s**" should be quite fast.
 
-.. option:: -q
+.. option:: -q, --quiet
 
     Emit less verbose information to syslog.
 
-.. option:: -n
+.. option:: -n, --dry-run
 
     Don't make any changes.  Problems are reported, but not fixed.
 
-.. option:: -G
+.. option:: -G, --force-reparse
 
     Force re-parsing of the underlying message (checks GUID
     correctness). Reconstruct with -G should fix all possible
     individual message issues, including corrupted data files.
 
-.. option:: -I
+.. option:: -I, --update-uniqueids
 
     If two mailboxes exist with the same UNIQUEID and reconstruct visits
     both of them, -I will cause the second mailbox to have a new UNIQUEID
     created for it.  If you don't specify -I, you will just get a syslog
     entry telling you of the clash.
 
-.. option:: -R
+.. option:: -R, --guid-mismatch-keep
 
     Perform a UID upgrade operation on GUID mismatch files.  Use this
     option if you think your index is corrupted rather than your
     message files, or if all backup attempts have failed and you're
     happy to be served the missing files.
 
-.. option:: -U
+.. option:: -U, --guid-mismatch-discard
 
     Use this option if you have corrupt message files in your spool and
     have been unable to restore them from backup.  This will make the
@@ -138,33 +138,33 @@ Options
     this deletes corrupt message files for ever - so make sure you've
     exhausted other options first!
 
-.. option:: -o
+.. option:: -o, --ignore-odd-files
 
     Ignore odd files in your mailbox disk directories.  Probably useful
     if you are using some tool which adds additional tracking files.
 
-.. option:: -O
+.. option:: -O, --delete-odd-files
 
     Delete odd files.  This is the opposite of **-o**.
 
-.. option:: -M
+.. option:: -M, --prefer-mboxlist
 
     Prefer mailboxes.db over cyrus.header - will rewrite ACL or
     uniqueid from the mailboxes.db into the header file rather than the
     other way around.  |v3-new-feature|
 
-.. option:: -V version
+.. option:: -V version, --set-version=version
 
     Change the ``cyrus.index`` minor version to a specific *version*.
     This can be useful for upgrades or downgrades. Use a magical
     version of *max* to upgrade to the latest available database format
     version.
 
-.. option:: -u
+.. option:: -u, --userids
 
-    Instead of mailbox prefixes, give usernames on the command line
+    Instead of mailbox prefixes, give userids on the command line
 
-.. option:: -P
+.. option:: -P, --header-paths
 
     Instead of mailbox prefixes, give paths to cyrus.header files on
     the command line.  The paths can be mailbox directories, or

--- a/imap/arbitron.c
+++ b/imap/arbitron.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
     time_t now = time(0);
 
     /* keep these in alphabetical order */
-    static const char *const short_options = "C:D:d:lop:u";
+    static const char short_options[] = "C:D:d:lop:u";
 
     static const struct option long_options[] = {
         /* n.b. no long form for -C option */

--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
     int opt;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:M:P:";
+    static const char short_options[] = "C:M:P:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -840,7 +840,7 @@ int main(int argc, char **argv)
     int recursive = 0;
 
     /* keep in alphabetical order */
-    static const char *const short_options = "AC:FRST:bdruvz";
+    static const char short_options[] = "AC:FRST:bdruvz";
 
     static const struct option long_options[] = {
         { "audit", no_argument, NULL, 'A' },

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -296,8 +297,7 @@ static void check_convert(struct cyrusdb *db, const char *fname)
 
 int main(int argc, char *argv[])
 {
-    extern char *optarg;
-    int opt, r, r2;
+    int opt, r = 0, r2 = 0;
     char *alt_config = NULL;
     int reserve_flag = 1;
     enum { RECOVER, CHECKPOINT, NONE } op = NONE;
@@ -306,9 +306,21 @@ int main(int argc, char *argv[])
     char *msg = "";
     int i, rotated = 0;
 
-    r = r2 = 0;
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:crx";
 
-    while ((opt = getopt(argc, argv, "C:rxc")) != EOF) {
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "checkpoint", no_argument, NULL, 'c' },
+        { "recover", no_argument, NULL, 'r' },
+        { "no-cleanup", no_argument, NULL, 'x' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -307,7 +307,7 @@ int main(int argc, char *argv[])
     int i, rotated = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:crx";
+    static const char short_options[] = "C:crx";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/ctl_deliver.c
+++ b/imap/ctl_deliver.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     enum { DUMP, PRUNE, NONE } op = NONE;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:E:df:";
+    static const char short_options[] = "C:E:df:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -1221,7 +1221,7 @@ int main(int argc, char *argv[])
     int undump_legacy = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:Ladf:imp:uvwxy";
+    static const char short_options[] = "C:Ladf:imp:uvwxy";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
     enum { REBUILD, WINZONES, NONE } op = NONE;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:r:vw:";
+    static const char short_options[] = "C:r:vw:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cvt_cyrusdb.c
+++ b/imap/cvt_cyrusdb.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
     char *alt_config = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:";
+    static const char short_options[] = "C:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cvt_xlist_specialuse.c
+++ b/imap/cvt_xlist_specialuse.c
@@ -163,7 +163,7 @@ int main (int argc, char **argv)
     strarray_t patterns = STRARRAY_INITIALIZER;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:v";
+    static const char short_options[] = "C:v";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
     json_t *bi;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:";
+    static const char short_options[] = "C:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_dbtool.c
+++ b/imap/cyr_dbtool.c
@@ -276,7 +276,7 @@ int main(int argc, char *argv[])
     struct txn **tidp = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:MTcnt";
+    static const char short_options[] = "C:MTcnt";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_deny.c
+++ b/imap/cyr_deny.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
     int r;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:alm:s:";
+    static const char short_options[] = "C:alm:s:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_df.c
+++ b/imap/cyr_df.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     int meta = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:m";
+    static const char short_options[] = "C:m";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -767,7 +767,7 @@ static int parse_args(int argc, char *argv[], struct arguments *args)
     int opt;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "A:C:D:E:X:achp:tu:vx";
+    static const char short_options[] = "A:C:D:E:X:achp:tu:vx";
 
     static const struct option long_options[] = {
         { "archive-duration", required_argument, NULL, 'A' },

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -467,7 +467,7 @@ int main(int argc, char *argv[])
     int want_since = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:M:n:s:";
+    static const char short_options[] = "C:M:n:s:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_ls.c
+++ b/imap/cyr_ls.c
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
     int is_path = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "17C:Rilmp";
+    static const char short_options[] = "17C:Rilmp";
 
     static const struct option long_options[] = {
         { "one-per-line", no_argument, NULL, '1' },

--- a/imap/cyr_pwd.c
+++ b/imap/cyr_pwd.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
     char *alt_config = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:";
+    static const char short_options[] = "C:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_synclog.c
+++ b/imap/cyr_synclog.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     int opt;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:MUabcmnqsuv";
+    static const char short_options[] = "C:MUabcmnqsuv";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_userseen.c
+++ b/imap/cyr_userseen.c
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
     char *alt_config = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:d";
+    static const char short_options[] = "C:d";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -279,7 +279,7 @@ int main (int argc, char *argv[])
     int r;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:nrs:v";
+    static const char short_options[] = "C:nrs:v";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/cyrdump.c
+++ b/imap/cyrdump.c
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     progname = basename(argv[0]);
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:v";
+    static const char short_options[] = "C:v";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
     const char *audit_tool = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:A:a";
+    static const char short_options[] = "C:A:a";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/deliver.c
+++ b/imap/deliver.c
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
     char *alt_config = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:DE:F:a:def:lm:qr:";
+    static const char short_options[] = "C:DE:F:a:def:lm:qr:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/fetchnews.c
+++ b/imap/fetchnews.c
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
     int y2k_compliant_date_format = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:a:f:np:s:w:y";
+    static const char short_options[] = "C:a:f:np:s:w:y";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/ipurge.c
+++ b/imap/ipurge.c
@@ -106,7 +106,7 @@ int main (int argc, char *argv[]) {
     int r, opt;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:MXb:d:fhik:m:nosvx";
+    static const char short_options[] = "C:MXb:d:fhik:m:nosvx";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
     int ok_count = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:cqs:u:";
+    static const char short_options[] = "C:cqs:u:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/mbpath.c
+++ b/imap/mbpath.c
@@ -330,7 +330,7 @@ int main(int argc, char **argv)
     struct options_t opts = { 0, 0, 0, 0, 0, 0, 1 /* default to UTF8 */ };
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "7AC:DMSUajlmpqsu";
+    static const char short_options[] = "7AC:DMSUajlmpqsu";
 
     static const struct option long_options[] = {
         { "no-utf8", no_argument, NULL, '7' }, /* XXX undocumented */

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
     char *alt_config = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:rt";
+    static const char short_options[] = "C:rt";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -131,7 +131,7 @@ int main(int argc,char **argv)
     char *alt_config = NULL, *domain = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:JZd:fnqu";
+    static const char short_options[] = "C:JZd:fnqu";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -45,6 +45,7 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <getopt.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -102,9 +103,6 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
-extern int optind;
-extern char *optarg;
-
 /* current namespace */
 static struct namespace recon_namespace;
 
@@ -159,7 +157,35 @@ int main(int argc, char **argv)
 
     progname = basename(argv[0]);
 
-    while ((opt = getopt(argc, argv, "C:p:rmfsxGqRUMIoOnV:uP")) != EOF) {
+    /* keep this in alphabetical order */
+    static const char *const short_options = "C:GIMOPRUV:fmnop:qrsux";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "force-reparse", no_argument, NULL, 'G' },
+        { "update-uniqueids", no_argument, NULL, 'I' },
+        { "prefer-mboxlist", no_argument, NULL, 'M' },
+        { "delete-odd-files", no_argument, NULL, 'O' },
+        { "header-paths", no_argument, NULL, 'P' },
+        { "guid-mismatch-keep", no_argument, NULL, 'R' },
+        { "guid-mismatch-discard", no_argument, NULL, 'U' },
+        { "set-version", required_argument, NULL, 'V' },
+        { "scan-filesystem", no_argument, NULL, 'f' },
+        { "dry-run", no_argument, NULL, 'n' },
+        { "ignore-odd-files", no_argument, NULL, 'o' },
+        { "partition", required_argument, NULL, 'p' },
+        { "quiet", no_argument, NULL, 'q' },
+        { "recursive", no_argument, NULL, 'r' },
+        { "no-stat", no_argument, NULL, 's' },
+        { "userids", no_argument, NULL, 'u' },
+        { "ignore-disk-metadata", no_argument, NULL, 'x' },
+
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
     progname = basename(argv[0]);
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:GIMOPRUV:fmnop:qrsux";
+    static const char short_options[] = "C:GIMOPRUV:fmnop:qrsux";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
 
     progname = basename(argv[0]);
 
-    while ((opt = getopt(argc, argv, "C:kp:rmfsxdgGqRUMIoOnV:uP")) != EOF) {
+    while ((opt = getopt(argc, argv, "C:p:rmfsxGqRUMIoOnV:uP")) != EOF) {
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
@@ -189,10 +189,6 @@ int main(int argc, char **argv)
             reconstruct_flags &= ~RECONSTRUCT_MAKE_CHANGES;
             break;
 
-        case 'g':
-            fprintf(stderr, "reconstruct: deprecated option -g ignored\n");
-            break;
-
         case 'G':
             reconstruct_flags |= RECONSTRUCT_ALWAYS_PARSE;
             break;
@@ -203,10 +199,6 @@ int main(int argc, char **argv)
 
         case 'x':
             xflag = 1;
-            break;
-
-        case 'k':
-            fprintf(stderr, "reconstruct: deprecated option -k ignored\n");
             break;
 
         case 's':
@@ -432,7 +424,6 @@ static void usage(void)
 
     fprintf(stderr, "-C <config-file>   use <config-file> instead of config from imapd.conf");
     fprintf(stderr, "-p <partition>     use this indicated partition for search\n");
-    fprintf(stderr, "-d                 check mailboxes database and insert missing entries\n");
     fprintf(stderr, "-x                 do not import metadata, create new\n");
     fprintf(stderr, "-r                 recursively reconstruct\n");
     fprintf(stderr, "-f                 examine filesystem underneath the mailbox\n");

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     progname = basename(argv[0]);
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:nqu";
+    static const char short_options[] = "C:nqu";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -942,7 +942,7 @@ int main(int argc, char **argv)
     setbuf(stdout, NULL);
 
     /* Keep these in alphabetic order */
-    static const char *short_options = "ABC:DFL:N:PRS:T:UXZade:f:hilmn:oprs:t:uvz:";
+    static const char short_options[] = "ABC:DFL:N:PRS:T:UXZade:f:hilmn:oprs:t:uvz:";
 
     /* Keep these ordered by mode */
     static struct option long_options[] = {

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -469,7 +469,7 @@ int main(int argc, char **argv)
     setbuf(stdout, NULL);
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "1AC:F:LNORS:ad:f:lmn:op:rst:uvw:z";
+    static const char short_options[] = "1AC:F:LNORS:ad:f:lmn:op:rst:uvw:z";
 
     static const struct option long_options[] = {
         { "rolling-once", no_argument, NULL, '1' },

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -191,7 +191,7 @@ main(int argc, char **argv)
     setbuf(stdout, NULL);
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:Lfv";
+    static const char short_options[] = "C:Lfv";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/tls_prune.c
+++ b/imap/tls_prune.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     char *alt_config = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:";
+    static const char short_options[] = "C:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imap/unexpunge.c
+++ b/imap/unexpunge.c
@@ -296,7 +296,7 @@ int main(int argc, char *argv[])
     unsigned nuids = 0;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:adf:lt:uv";
+    static const char short_options[] = "C:adf:lt:uv";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -2887,7 +2887,7 @@ int main(int argc, char **argv)
     prog = strrchr(argv[0], '/') ? strrchr(argv[0], '/')+1 : argv[0];
 
     /* keep this in alphabetical order */
-    static const char *const short_options =
+    static const char short_options[] =
         "?I:P:X:a:cf:hik:l:m:n:o:p:qr:st:u:vw:x:z";
 
     static const struct option long_options[] = {

--- a/ptclient/ptdump.c
+++ b/ptclient/ptdump.c
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
     char *alt_config = NULL, *tofree = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:";
+    static const char short_options[] = "C:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/ptclient/ptexpire.c
+++ b/ptclient/ptexpire.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
     openlog("ptexpire", LOG_PID, SYSLOG_FACILITY);
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:E:";
+    static const char short_options[] = "C:E:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/sieve/sievec.c
+++ b/sieve/sievec.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
     char *alt_config = NULL;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "C:";
+    static const char short_options[] = "C:";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -108,7 +108,7 @@ int main(int argc, char * argv[])
     unsigned long len;
 
     /* keep this in alphabetical order */
-    static const char *const short_options = "s";
+    static const char short_options[] = "s";
 
     static const struct option long_options[] = {
         { "as-sieve", no_argument, NULL, 's' },


### PR DESCRIPTION
This finishes the work started in #4196, by adding long-options support to the  `ctl_cyrusdb` and `reconstruct` command line tools.

This is one of those annoying ones where the lion's share of changes are in strings, which the compiler can't check for spelling or consistency.  We also don't have any tests for the majority of these commands!  So please review with a very close eye.  I'd suggest stepping through commit-by-commit.

I have tried to not change any existing behaviour, but simply add long-option synonyms for the existing short options.

I have _not_ added a long-option synonym for `-C altconfig`, because that needs to remain consistent with the service binaries, and this work does not touch the service binaries.