### PR TITLE
mailbox_iter_startuid() needs to initialize recno to 1 rather than 0 (zero)

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -7977,7 +7977,7 @@ EXPORTED struct mailbox_iter *mailbox_iter_init(struct mailbox *mailbox,
 EXPORTED void mailbox_iter_startuid(struct mailbox_iter *iter, uint32_t uid)
 {
     struct mailbox *mailbox = iter->mailbox;
-    iter->recno = uid ? mailbox_finduid(mailbox, uid-1) : 0;
+    iter->recno = uid ? mailbox_finduid(mailbox, uid) : 1;
 }
 
 EXPORTED void mailbox_iter_uidset(struct mailbox_iter *iter, seqset_t *seq)


### PR DESCRIPTION
#4253 changed mailbox_iter_inti() to initialize iter->recno to 1 rather than zero, but the same wasn't done for mailbox_iter_startuid()

This was causing messages to not get Xapian indexed (amongst other possible bugs) and leading to Cassandane failures