### PR TITLE
Fixed CALDAV PUT requests while proxying

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -7097,7 +7097,7 @@ int meth_put(struct transaction_t *txn, void *params)
     }
 
     /* Make sure mailbox type is correct */
-    if (txn->req_tgt.mbentry->mbtype != txn->req_tgt.namespace->mboxtype)
+    if (txn->req_tgt.mbentry->mbtype != txn->req_tgt.namespace->mboxtype && txn->req_tgt.mbentry->mbtype != MBTYPE_REMOTE)
         return HTTP_FORBIDDEN;
 
     /* Make sure Content-Range isn't specified */


### PR DESCRIPTION
txn->req_tgt.namespace->mboxtype is MBTYPE_REMOTE in the proxy.

We have run into issues with proxying caldav requests. This patch allows a PUT request to be successfully proxied, however, we also noticed that autocreate is broken while proxing. Are you interested in getting this fixed, or are there better alternatives to proxying for CALDAV in a murder setup?