### PR TITLE
caldav_alarm.c: don't crash if ATTENDEE doesn't have a PARTSTAT

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -522,7 +522,7 @@ static int process_alarm_cb(icalcomponent *comp,
             const char *partstat =
                 icalproperty_get_parameter_as_string(prop, "PARTSTAT");
 
-            if (!strcasecmp(partstat, "DECLINED")) {
+            if (!strcasecmpsafe(partstat, "DECLINED")) {
                 strarray_fini(&sched_addrs);
                 return 1;
             }


### PR DESCRIPTION
This fixes a crasher found in testing