### PR TITLE
http_carddav.c: strip ALL urn:uuid: prefixes from UID before comparing

### DIFF
--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1312,8 +1312,8 @@ static int carddav_put(struct transaction_t *txn, void *obj,
     carddav_lookup_resource(db, txn->req_tgt.mbentry, resource, &cdata, 0);
     
     const char *olduid = cdata->vcard_uid;
-    if (!strncmp(uid, "urn:uuid:", 9)) uid += 9;
-    if (!strncmpsafe(olduid, "urn:uuid:", 9)) olduid += 9;
+    while (!strncmp(uid, "urn:uuid:", 9)) uid += 9;
+    while (!strncmpsafe(olduid, "urn:uuid:", 9)) olduid += 9;
     if (cdata->dav.imap_uid && strcmpsafe(olduid, uid)) {
         /* CARDDAV:no-uid-conflict */
         char *owner;


### PR DESCRIPTION
This should fix an issue seen with emClient which sends UID:urn:uuid:urn:uuid:abc and we return a 403 with CARDDAV:no-uid-conflict