### PR TITLE
testing workflow: use bullseye, not buster, Cyrus docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-        image: cyrusimapdocker/cyrus-buster:latest
+        image: cyrusimapdocker/cyrus-bullseye:latest
         options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --init
     steps:
     - uses: actions/checkout@v3

--- a/cassandane/cassandane.ini.dockertests
+++ b/cassandane/cassandane.ini.dockertests
@@ -46,13 +46,8 @@ cleanup = no
 # We skip some tests that are either long-time known failures, or
 # are brittle and fail sporadically, to keep the CI integration
 # useful.
-#
 # This list last reviewed on 2020-08-07
-#
-# The final three (Sieve imip and Caldav implicit allday) fail on our current
-# Docker image, and we'll remove them from here when we upgrade the Docker
-# image.
-suppress = Rename.rename_inbox JMAPBackup Sieve.snooze_tzid MboxEvent.tls_login_event Sieve.imip_reply_override Sieve.imip_reply_override_google Caldav.invite_switch_implicit_allday_to_dtend
+suppress = Rename.rename_inbox JMAPBackup Sieve.snooze_tzid MboxEvent.tls_login_event
 
 [valgrind]
 


### PR DESCRIPTION
This updates to a new Bullseye-based Docker image, assuming I did everything correctly, which maybe I didn't.

The tests we disabled "because Buster" still fail, which suggests that more work might be needed.