### PR TITLE
prevent cassandane message id clashes

### DIFF
--- a/cassandane/Cassandane/Generator.pm
+++ b/cassandane/Cassandane/Generator.pm
@@ -188,7 +188,11 @@ sub _generate_messageid
 {
     my ($self, $params) = @_;
     my $idsalt = int(rand(65536));
-    return "fake." . $params->{date}->epoch() . ".$idsalt\@" .  $params->{from}->domain();
+
+    return sprintf 'fake.%d.%d@%s',
+                   $params->{date}->epoch(),
+                   $idsalt,
+                   $params->{from}->domain();
 }
 
 sub _params_defaults

--- a/cassandane/Cassandane/Generator.pm
+++ b/cassandane/Cassandane/Generator.pm
@@ -40,6 +40,7 @@
 package Cassandane::Generator;
 use strict;
 use warnings;
+use feature qw(state);
 use Digest::MD5 qw(md5_hex);
 
 use lib '.';
@@ -187,10 +188,12 @@ sub _generate_to
 sub _generate_messageid
 {
     my ($self, $params) = @_;
+    state $counter = 0;
     my $idsalt = int(rand(65536));
 
-    return sprintf 'fake.%d.%d@%s',
+    return sprintf 'fake.%d.%d.%d@%s',
                    $params->{date}->epoch(),
+                   ++ $counter,
                    $idsalt,
                    $params->{from}->domain();
 }


### PR DESCRIPTION
Apparently Cassandane tests can fail randomly when the message-id generator duplicates a message-id within a single test.

The generator only uses 16 bits of randomness, which isn't much.  I thought about using more random bits, but a) that still wouldn't guarantee no repeats, and b) these only need to be unique within a single test anyway.  Instead, I added a monotonic counter to the generator.  Within a single test, each message-id is now guaranteed unique just by virtue of the counter, even if the random number generator spits out two identical numbers within the same clock second.

A neat side effect of using the counter is that the sequence messages were generated in is now encoded into the message-id, which might be useful for postmortem debugging.