### PR TITLE
jmap_ical: omit trailing zeros from geo coordinates

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-locations-geo
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-locations-geo
@@ -11,5 +11,5 @@ sub test_calendarevent_get_locations_geo
     my $event = $self->putandget_vevent($id, $ical);
     my @locations = values %{$event->{locations}};
     $self->assert_num_equals(1, scalar @locations);
-    $self->assert_str_equals("geo:37.386013,-122.082930", $locations[0]{coordinates});
+    $self->assert_str_equals("geo:37.386013,-122.08293", $locations[0]{coordinates});
 }


### PR DESCRIPTION
This isn't strictly necessary, but makes the regression tests run on both the current and upcoming libical release.