### PR TITLE
JMAPCalendars: fix calendarevent-get-locations-geo match

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-locations-geo
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-locations-geo
@@ -11,5 +11,6 @@ sub test_calendarevent_get_locations_geo
     my $event = $self->putandget_vevent($id, $ical);
     my @locations = values %{$event->{locations}};
     $self->assert_num_equals(1, scalar @locations);
-    $self->assert_str_equals("geo:37.38601,-122.08290", $locations[0]{coordinates});
+    $self->assert_matches(qr{\Ageo:37\.38601\d*,-122\.08290\d*\Z},
+                          $locations[0]{coordinates});
 }


### PR DESCRIPTION
Makes the test less sensitive to the number of decimal positions returned by libical, which apparently can vary between versions.

This test was failing on my system, where I haven't updated libical recently.  With this change the test now passes.

**Note to reviewers**: please build and run this test to ensure my change hasn't accidentally broken it in the other direction