### PR TITLE
http_dav: gracefully handle locked dav.db in REPORT

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -7653,6 +7653,11 @@ int report_sync_col(struct transaction_t *txn, struct meth_params *rparams,
 
     /* Open the DAV DB corresponding to the mailbox */
     fctx->davdb = rparams->davdb.open_db(fctx->mailbox);
+    if (!fctx->davdb) {
+        fctx->txn->error.desc = "Can't open database";
+        ret = HTTP_SERVER_ERROR;
+        goto done;
+    }
 
     /* Setup for chunked response */
     txn->flags.te |= TE_CHUNKED;


### PR DESCRIPTION
Handling a sync REPORT can run into a race where dav.db is locked by another process. This patch makes Cyrus not crash on this error but return a server error. Fixing the conditions that lead to the race is a work in progress.