### PR TITLE
jmap_api: initialize jmap_changes struct to zero

### DIFF
--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -421,6 +421,8 @@ struct jmap_changes {
     json_t *destroyed;
 };
 
+#define JMAP_CHANGES_INITIALIZER {0}
+
 extern void jmap_changes_parse(jmap_req_t *req, struct jmap_parser *parser,
                                modseq_t minmodseq,
                                jmap_args_parse_cb args_parse, void *args_rock,

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1099,7 +1099,7 @@ done:
 static int jmap_calendar_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     json_t *err = NULL;
     int r = 0;
 
@@ -6348,7 +6348,7 @@ done:
 static int jmap_calendarevent_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     json_t *err = NULL;
     struct caldav_db *db;
     struct geteventchanges_rock rock = {
@@ -8555,7 +8555,7 @@ done:
 static int jmap_principal_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     json_t *err = NULL;
 
     jmap_changes_parse(req, &parser, 0, NULL, NULL, &changes, &err);
@@ -10135,7 +10135,7 @@ done:
 static int jmap_sharenotification_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     mbentry_t *notifmb = NULL;
     json_t *err = NULL;
 
@@ -10908,7 +10908,7 @@ done:
 static int jmap_calendareventnotification_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     json_t *err = NULL;
 
     jmap_changes_parse(req, &parser, req->counters.jmapnotificationdeletedmodseq,
@@ -11141,7 +11141,7 @@ done:
 static int jmap_participantidentity_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     json_t *err = NULL;
 
     jmap_changes_parse(req, &parser, req->counters.caldavfoldersdeletedmodseq,

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -779,7 +779,7 @@ static int _contacts_changes(struct jmap_req *req, int kind)
     }
 
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     json_t *err = NULL;
     struct carddav_db *db = NULL;
     mbentry_t *mbentry = NULL;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5316,7 +5316,7 @@ done:
 static int jmap_email_changes(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
 
     /* Parse request */
     json_t *err = NULL;
@@ -5433,7 +5433,7 @@ done:
 static int jmap_thread_changes(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
 
     /* Parse request */
     json_t *err = NULL;

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4301,7 +4301,7 @@ done:
 static int jmap_mailbox_changes(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     json_t *err = NULL;
 
     /* Parse request */

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -978,7 +978,7 @@ static int change_cmp(const void **a, const void **b)
 static int jmap_note_changes(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     struct mailbox *mbox = NULL;
     mbentry_t *mbentry = NULL;
     int userflag;


### PR DESCRIPTION
Initialization of the jmap_changes struct is left to the handler function first calling jmap_changes_parse. But in at least one occasion this could get skipped with an early return. Since the compiler did not report this during compilation let's better make sure we zero the structs memory properly.