### PR TITLE
TestCase: add assert_date_matches()

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-set-updated-scheduled-source
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-set-updated-scheduled-source
@@ -93,5 +93,5 @@ sub test_calendarevent_set_updated_scheduled_source
         }, 'R2'],
     ]);
     $self->assert(exists $res->[0][1]{updated}{$eventId});
-    $self->assert_str_equals($updated, $res->[1][1]{list}[0]{updated});
+    $self->assert_date_matches($updated, $res->[1][1]{list}[0]{updated}, 2);
 }


### PR DESCRIPTION
A date assertion with tolerance, to hopefully avoid bogus failures from timing quirks.

There's room for future improvement -- ideally we'd also reject matches if they have different time zones, or if one has a timezone and the other doesn't.  This is commented but not implemented.  The DateTime timezone API looks like a hassle to deal with, so in my mind that detail can wait until we actually need it.

In the time since I started working on this, every transient CI failure that I've personally observed has been due to JMAPCalendars.calendarevent_set_updated_scheduled_source being off by one second.  So I've updated that one test to use this new assertion, with a tolerance of two seconds.

I was originally planning on doing a big audit of all the date matching tests and converting them in a batch, but that's long and boring and I haven't even tried to make any progress on it.  But in the meantime, that one test is still being a nuisance.  So this PR now scratches the immediate itch, and makes the new assertion available for use in new tests.  I figure we can easily address the rest of the existing tests whack-a-mole style as they pop up.