### PR TITLE
Ignore privacy property default values

### DIFF
--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1008,10 +1008,10 @@ static int caldav_store_preprocess(struct transaction_t *txn,
         /* Extract personal info from user's resource and create vpatch */
         if (oldical) {
             /* Normalize existing resource for comparison */
-            icalcomponent_normalize(oldical);
+            icalcomponent_normalize_x(oldical);
 
             /* Normalize new resource for comparison */
-            icalcomponent_normalize(ical);
+            icalcomponent_normalize_x(ical);
         }
 
         /* Create UID for sharee VPATCH */

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -189,6 +189,9 @@ extern void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
 
 extern int ical_categories_is_color(icalproperty *cprop);
 
+/* Normalizes both standard and cyrus-extensions */
+extern void icalcomponent_normalize_x(icalcomponent *ical);
+
 /* Functions that should be declared in libical */
 #define icaltimezone_set_zone_directory set_zone_directory
 


### PR DESCRIPTION
The current implementation of JSCalendar.privacy always writes the privacy level to the custom X-JMAP-PRIVACY property. This isn't necessary and actually broke comparison of normalized iCalendar components. This patch fixes that and also adds a custom normalization method to normalize Cyrus extension property values.