### PR TITLE
Add sync_support for delayed delete mode (master)

### DIFF
--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3811,6 +3811,7 @@ bail:
 int sync_apply_unmailbox(struct dlist *kin, struct sync_state *sstate)
 {
     const char *mboxname = kin->sval;
+    int r;
 
     struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
 
@@ -3818,9 +3819,20 @@ int sync_apply_unmailbox(struct dlist *kin, struct sync_state *sstate)
     int delflags = MBOXLIST_DELETE_FORCE | MBOXLIST_DELETE_SILENT;
     if (sstate->flags & SYNC_FLAG_LOCALONLY)
         delflags |= MBOXLIST_DELETE_LOCALONLY;
-    int r = mboxlist_deletemailbox(mboxname, sstate->userisadmin,
+
+    if (!mboxlist_delayed_delete_isenabled()) {
+        r = mboxlist_deletemailbox(mboxname, sstate->userisadmin,
                                    sstate->userid, sstate->authstate,
                                    NULL, delflags);
+    } else if (mboxname_isdeletedmailbox(mboxname, NULL)) {
+        r = mboxlist_deletemailbox(mboxname, sstate->userisadmin,
+                                   sstate->userid, sstate->authstate,
+                                   NULL, delflags);
+    } else {
+        r = mboxlist_delayed_deletemailbox(mboxname, sstate->userisadmin,
+                                           sstate->userid, sstate->authstate,
+                                           NULL, delflags);
+    }
 
     mboxname_release(&namespacelock);
 
@@ -4155,11 +4167,24 @@ int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
     int delflags = MBOXLIST_DELETE_FORCE | MBOXLIST_DELETE_SILENT;
     if (sstate->flags & SYNC_FLAG_LOCALONLY)
         delflags |= MBOXLIST_DELETE_LOCALONLY;
+
     for (i = list->count; i; i--) {
         const char *name = strarray_nth(list, i-1);
-        r = mboxlist_deletemailbox(name, sstate->userisadmin,
-                                   sstate->userid, sstate->authstate,
-                                   NULL, delflags);
+
+        if (!mboxlist_delayed_delete_isenabled()) {
+            r = mboxlist_deletemailbox(name, sstate->userisadmin,
+                                       sstate->userid, sstate->authstate,
+                                       NULL, delflags);
+        } else if (mboxname_isdeletedmailbox(name, NULL)) {
+            r = mboxlist_deletemailbox(name, sstate->userisadmin,
+                                       sstate->userid, sstate->authstate,
+                                       NULL, delflags);
+        } else {
+            r = mboxlist_delayed_deletemailbox(name, sstate->userisadmin,
+                                               sstate->userid, sstate->authstate,
+                                               NULL, delflags);
+        }
+
         if (r) goto done;
     }
 


### PR DESCRIPTION
In sync_apply_unmailbox() and sync_apply_unuser(), the call to mboxlist_deletemailbox() is currently independent of whether delete_mode: delayed is configured, creating a risk of data-loss.

Under certain circumstances, in an A<->B two-way replication scenario for high availability, where B may have failed to synchronize a mailbox user/john to A, and A has a user/john mailbox created, the initial A->B "mailbox" replication is refused, but A will promote the synchronization to become of the "user" level, which B appears to accept; it'd remove the existing user/john mailbox, including the file-system hierarchy, resulting in (effectively) data-loss, before recreating the user/john mailbox.

From PR #4337, with @elliefm requesting the PR is rebased against master.