### PR TITLE
CaldavAlarm: fix inf loop in test_disable_high_freq

### DIFF
--- a/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
@@ -3113,9 +3113,9 @@ EOF
     #
     # byminute=startmin and +2 should succeed since there is a 120s interval
     #
-    my $bymin_ok = $startmin + 2;
-    for (my $bymin = $startmin + 1; $bymin < $startmin + 3; $bymin += 1) {
-        $bymin = $bymin % 60;
+    my $bymin_ok = ($startmin + 2) % 60;
+    foreach my $addend (1..2) {
+        my $bymin = ($startmin + $addend) % 60;
 
         my $freq = 'HOURLY';
         my $int  = 1;


### PR DESCRIPTION
```
# create hourly occurring events with a set of byminute
```

There was a bug in the counter for this loop that caused the test to loop forever if it happened to start at a time whose minutes value was 52, 53, or 54.  This was because the loop condition would end up checking for `$bymin <` 60, 61, or 62, which it always is because of the `% 60` in the loop body.

There was also a bug in how the test results were examined, which was being masked by the test never reaching the assertion that would expose it.

There's 3 minutes each hour when the bug can be reproduced on master, or the fix can be confirmed on this branch.  I've done both myself; you may wish to do so too.