### PR TITLE
jmap_api: refactor JMAP state API to jmap_modseq function

### DIFF
--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1388,23 +1388,34 @@ HIDDEN modseq_t jmap_modseq(jmap_req_t *req, int mbtype, int flags)
     }
 
     modseq_t modseq;
+    int is_folder = flags & JMAP_MODSEQ_FOLDER;
 
     /* Determine current counter by mailbox type. */
     switch (mbtype_isa(mbtype)) {
         case MBTYPE_CALENDAR:
-            modseq = req->counters.caldavmodseq;
+            modseq = is_folder ?
+                req->counters.caldavfoldersmodseq :
+                req->counters.caldavmodseq;
             break;
         case MBTYPE_ADDRESSBOOK:
-            modseq = req->counters.carddavmodseq;
+            modseq = is_folder ?
+                req->counters.carddavfoldersmodseq :
+                req->counters.carddavmodseq;
             break;
         case MBTYPE_JMAPSUBMIT:
-            modseq = req->counters.submissionmodseq;
+            modseq = is_folder ?
+                req->counters.submissionfoldersmodseq :
+                req->counters.submissionmodseq;
             break;
         case MBTYPE_SIEVE:
-            modseq = req->counters.sievemodseq;
+            modseq = is_folder ?
+                req->counters.sievefoldersmodseq :
+                req->counters.sievemodseq;
             break;
         case MBTYPE_EMAIL:
-            modseq = req->counters.mailmodseq;
+            modseq = is_folder ?
+                req->counters.mailfoldersmodseq :
+                req->counters.mailmodseq;
             break;
         default:
             modseq = req->counters.highestmodseq;

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -320,6 +320,7 @@ extern int jmap_findblob_exact(jmap_req_t *req, const char *accountid,
                                struct buf *blob);
 
 #define JMAP_MODSEQ_RELOAD (1<<0)
+#define JMAP_MODSEQ_FOLDER (1<<1)
 extern modseq_t jmap_modseq(jmap_req_t *req, int mbtype, int flags);
 
 /* Helpers for DAV-based JMAP types */

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -319,11 +319,8 @@ extern int jmap_findblob_exact(jmap_req_t *req, const char *accountid,
                                struct mailbox **mbox, msgrecord_t **mr,
                                struct buf *blob);
 
-/* JMAP states */
-extern char *jmap_getstate(jmap_req_t *req, int mbtype, int refresh);
-extern json_t *jmap_fmtstate(modseq_t modseq);
-extern int jmap_cmpstate(jmap_req_t *req, json_t *state, int mbtype);
-extern modseq_t jmap_highestmodseq(jmap_req_t *req, int mbtype);
+#define JMAP_MODSEQ_RELOAD (1<<0)
+extern modseq_t jmap_modseq(jmap_req_t *req, int mbtype, int flags);
 
 /* Helpers for DAV-based JMAP types */
 extern char *jmap_xhref(const char *mboxname, const char *resource);

--- a/lib/util.c
+++ b/lib/util.c
@@ -2139,3 +2139,10 @@ EXPORTED void xsyslog_fn(int priority, const char *description,
     buf_free(&buf);
     errno = saved_errno;
 }
+
+EXPORTED char *modseqtoa(modseq_t modseq)
+{
+    struct buf buf = BUF_INITIALIZER;
+    buf_printf(&buf, MODSEQ_FMT, modseq);
+    return buf_release(&buf);
+}

--- a/lib/util.h
+++ b/lib/util.h
@@ -106,6 +106,7 @@ typedef unsigned long long int bit64;
 typedef unsigned long long int modseq_t;
 #define MODSEQ_FMT "%llu"
 #define atomodseq_t(s) strtoull(s, NULL, 10)
+char *modseqtoa(modseq_t modseq);
 
 #define Uisalnum(c) isalnum((int)((unsigned char)(c)))
 #define Uisalpha(c) isalpha((int)((unsigned char)(c)))


### PR DESCRIPTION
This reduces the current JMAP state handling API to the single function jmap_modseq. The former code was the result of multiple refactorings during the initial implementation of JMAP. The result were functions that handled state as opaque JSON strings, C string or as modseqs. This patch changes that to always handle JMAP state as modseq.