### PR TITLE
github actions: split cass run into several steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,35 +22,40 @@ jobs:
       with:
         fetch-depth: 0
     - name: configure and build
+      shell: bash
       run: |
         git config --global --add safe.directory /__w/cyrus-imapd/cyrus-imapd
         echo "building cyrus version" $(./tools/git-version.sh)
         ./tools/build-with-cyruslibs.sh
-      shell: bash
     - name: update jmap test suite
+      working-directory: /srv/JMAP-TestSuite.git
+      shell: bash
       run: |
-        cd /srv/JMAP-TestSuite.git
         git fetch
         git checkout origin/master
         git clean -f -x -d
         cpanm --installdeps .
-        cd -
-      shell: bash
     - name: install missing deps
+      shell: bash
       run: |
         cpanm IO::File::fcntl
         cpanm Digest::CRC
+    - name: set up cassandane
+      working-directory: cassandane
       shell: bash
-    - name: run cassandane
       run: |
-        cd cassandane
         cp -af cassandane.ini.dockertests cassandane.ini
         chown cyrus:mail cassandane.ini
         make
-        setpriv --reuid=cyrus --regid=mail --clear-groups --inh-caps='-chown,-dac_override,-dac_read_search,-fowner,-fsetid,-kill,-setgid,-setuid,-setpcap,-linux_immutable,-net_bind_service,-net_broadcast,-net_admin,-net_raw,-ipc_lock,-ipc_owner,-sys_module,-sys_rawio,-sys_chroot,-sys_ptrace,-sys_pacct,-sys_admin,-sys_boot,-sys_nice,-sys_resource,-sys_time,-sys_tty_config,-mknod,-lease,-audit_write,-audit_control,-setfcap,-mac_override,-mac_admin,-syslog,-wake_alarm,-block_suspend,-audit_read,-cap_38,-cap_39,-cap_40' ./testrunner.pl -f pretty -j 4 !Test::Core
-        cd -
-      shell: bash
+    - name: run cassandane quietly
+      id: cass1
+      continue-on-error: true
+      working-directory: cassandane
+      run: setpriv --reuid=cyrus --regid=mail --clear-groups --inh-caps='-chown,-dac_override,-dac_read_search,-fowner,-fsetid,-kill,-setgid,-setuid,-setpcap,-linux_immutable,-net_bind_service,-net_broadcast,-net_admin,-net_raw,-ipc_lock,-ipc_owner,-sys_module,-sys_rawio,-sys_chroot,-sys_ptrace,-sys_pacct,-sys_admin,-sys_boot,-sys_nice,-sys_resource,-sys_time,-sys_tty_config,-mknod,-lease,-audit_write,-audit_control,-setfcap,-mac_override,-mac_admin,-syslog,-wake_alarm,-block_suspend,-audit_read,-cap_38,-cap_39,-cap_40' ./testrunner.pl -f prettier -j 4 !Test::Core
+    - name: rerun cassandane failures noisily
+      if: ${{ steps.cass1.outcome == 'failure' }}
+      working-directory: cassandane
+      run: setpriv --reuid=cyrus --regid=mail --clear-groups --inh-caps='-chown,-dac_override,-dac_read_search,-fowner,-fsetid,-kill,-setgid,-setuid,-setpcap,-linux_immutable,-net_bind_service,-net_broadcast,-net_admin,-net_raw,-ipc_lock,-ipc_owner,-sys_module,-sys_rawio,-sys_chroot,-sys_ptrace,-sys_pacct,-sys_admin,-sys_boot,-sys_nice,-sys_resource,-sys_time,-sys_tty_config,-mknod,-lease,-audit_write,-audit_control,-setfcap,-mac_override,-mac_admin,-syslog,-wake_alarm,-block_suspend,-audit_read,-cap_38,-cap_39,-cap_40' ./testrunner.pl -f pretty -j 4 --rerun
     - name: collect logs
       if: always()
-      run: |
-        cat /tmp/cass/*/conf/log/syslog
+      run: cat /tmp/cass/*/conf/log/syslog

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       id: cass1
       continue-on-error: true
       working-directory: cassandane
-      run: setpriv --reuid=cyrus --regid=mail --clear-groups --inh-caps='-chown,-dac_override,-dac_read_search,-fowner,-fsetid,-kill,-setgid,-setuid,-setpcap,-linux_immutable,-net_bind_service,-net_broadcast,-net_admin,-net_raw,-ipc_lock,-ipc_owner,-sys_module,-sys_rawio,-sys_chroot,-sys_ptrace,-sys_pacct,-sys_admin,-sys_boot,-sys_nice,-sys_resource,-sys_time,-sys_tty_config,-mknod,-lease,-audit_write,-audit_control,-setfcap,-mac_override,-mac_admin,-syslog,-wake_alarm,-block_suspend,-audit_read,-cap_38,-cap_39,-cap_40' ./testrunner.pl -f prettier -j 4 !Test::Core
+      run: setpriv --reuid=cyrus --regid=mail --clear-groups --inh-caps='-chown,-dac_override,-dac_read_search,-fowner,-fsetid,-kill,-setgid,-setuid,-setpcap,-linux_immutable,-net_bind_service,-net_broadcast,-net_admin,-net_raw,-ipc_lock,-ipc_owner,-sys_module,-sys_rawio,-sys_chroot,-sys_ptrace,-sys_pacct,-sys_admin,-sys_boot,-sys_nice,-sys_resource,-sys_time,-sys_tty_config,-mknod,-lease,-audit_write,-audit_control,-setfcap,-mac_override,-mac_admin,-syslog,-wake_alarm,-block_suspend,-audit_read,-cap_38,-cap_39,-cap_40' ./testrunner.pl --slow -f prettier -j 4 !Test::Core
     - name: rerun cassandane failures noisily
       if: ${{ steps.cass1.outcome == 'failure' }}
       working-directory: cassandane

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         cp -af cassandane.ini.dockertests cassandane.ini
         chown cyrus:mail cassandane.ini
-        make
+        make -j4
     - name: run cassandane quietly
       id: cass1
       continue-on-error: true


### PR DESCRIPTION
Splits the cassandane part of the github actions workflow into separate steps:

1. build and check all the cassandane components
2. run cassandane quietly (-f prettier)
3. only if the first cass run failed: rerun with --rerun and -f pretty to get noisy output for only the failing tests

Each named step is folded separately in the web interface, so splitting it like this makes it easier to jump to the detail you care about, without having to scroll through all the output for the entire cassandane run.

Re-running the failed tests and only failing the workflow if there's still failures might also reduce false negatives from transient test failures, which are almost never related to the PR being evaluated anyway.

I have no idea whether this will work or not, but I think I need to create a pull request to even find out, so here goes...