### PR TITLE
sieve-lex.l: reject non-ASCII chars outside of strings and comments

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -471,6 +471,11 @@ sub badscript_common
     $self->assert_str_equals('failure', $res);
     $self->assert_matches(qr/syntax error/, $errs);
 
+    ($res, $errs) = $self->compile_sieve_script('badchar1',
+        "require [\"fileinto\"];\n☃;\nfileinto \"foo\";\n");
+    $self->assert_str_equals('failure', $res);
+    $self->assert_matches(qr/non-ASCII/, $errs);
+
     ($res, $errs) = $self->compile_sieve_script('goodfileinto7',
         "require [\"fileinto\",\"copy\"];\nfileinto \"foo\";\n");
     $self->assert_str_equals('success', $res);

--- a/sieve/sieve-lex.l
+++ b/sieve/sieve-lex.l
@@ -400,7 +400,15 @@ ws              [ \t]+
 <INITIAL>"/*"([^\*]|\*[^\/])*\*?"*/" ;  /* ignore bracketed comments */
 <INITIAL>#.* ;                /* ignore hash comments */
 <INITIAL>[ \t\n\r] ;          /* ignore whitespace */
-.                             return yytext[0];
+.                             {
+                                  /* RFC 5228: With the exceptions of strings
+                                     and comments, the language is limited to
+                                     US-ASCII characters. */
+                                  if (!isascii(yytext[0])) {
+                                      sieveerror(sscript, "non-ASCII character");
+                                  }
+                                  return yytext[0];
+                              }
 
 %%
 


### PR DESCRIPTION
Per RFC 5228:
   With the exceptions of strings and comments, the language is limited
   to US-ASCII characters.
