### PR TITLE
Lock ordering fixes

### DIFF
--- a/cassandane/Cassandane/Cyrus/Expunge.pm
+++ b/cassandane/Cassandane/Cyrus/Expunge.pm
@@ -261,6 +261,9 @@ sub test_ipurge_mboxevent
     );
     my $events = $self->{instance}->getnotify();
 
+    # if it stays selected you see the intermittent state
+    $talk->unselect();
+
     # the messages we just created should've been expunged
     $stat = $talk->status($shared_folder, '(highestmodseq unseen messages)');
     $self->assert_num_equals(0, $stat->{unseen});

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -375,15 +375,13 @@ EXPORTED int conversations_open_path(const char *fname, const char *userid, int 
     open_conversations = open;
 
     /* first ensure that the usernamespace is locked */
-    if (userid) {
-        int haslock = user_isnamespacelocked(userid);
-        if (haslock) {
-            if (!shared) assert(haslock != LOCK_SHARED);
-        }
-        else {
-            int locktype = shared ? LOCK_SHARED : LOCK_EXCLUSIVE;
-            open->local_namespacelock = user_namespacelock_full(userid, locktype);
-        }
+    int haslock = user_isnamespacelocked(userid);
+    if (haslock) {
+        if (!shared) assert(haslock != LOCK_SHARED);
+    }
+    else {
+        int locktype = shared ? LOCK_SHARED : LOCK_EXCLUSIVE;
+        open->local_namespacelock = user_namespacelock_full(userid, locktype);
     }
 
     /* open db */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -9734,7 +9734,7 @@ static void cmd_status(char *tag, char *name)
                                  &backend_current, &backend_inbox, imapd_in);
             if (!s) r = IMAP_SERVER_UNAVAILABLE;
 
-            imapd_check(s, 0);
+            imapd_check(s, 1);
 
             if (!r) {
                 prot_printf(s->out, "%s Status {" SIZE_T_FMT "+}\r\n%s ", tag,
@@ -9779,7 +9779,7 @@ static void cmd_status(char *tag, char *name)
 
     // status of selected mailbox, we need to refresh
     if (!r && !strcmpsafe(mbentry->name, index_mboxname(imapd_index)))
-        imapd_check(NULL, 0);
+        imapd_check(NULL, 1);
 
     if (statusitems & STATUS_HIGHESTMODSEQ)
         condstore_enabled("STATUS (HIGHESTMODSEQ)");

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7581,8 +7581,8 @@ localcreate:
     imapd_check(NULL, 0);
 
 done:
-    mboxname_release(&namespacelock);
     mailbox_close(&mailbox);
+    mboxname_release(&namespacelock);
     mboxlist_entry_free(&parent);
     buf_free(&specialuse);
     mbname_free(&mbname);
@@ -7737,12 +7737,12 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
     }
     mboxlist_entry_free(&mbentry);
 
-    mboxname_release(&namespacelock);
-
     if (!r && config_getswitch(IMAPOPT_DELETE_UNSUBSCRIBE)) {
         mboxlist_changesub(mbname_intname(mbname), imapd_userid, imapd_authstate,
                            /* add */ 0, /* force */ 0, /* notify? */ 1);
     }
+
+    mboxname_release(&namespacelock);
 
     imapd_check(NULL, 0);
 
@@ -8946,6 +8946,7 @@ static void cmd_setacl(char *tag, const char *name,
     mbentry_t *mbentry = NULL;
 
     char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(intname);
 
     /* is it remote? */
     r = mlookup(tag, name, intname, &mbentry);
@@ -8958,6 +8959,9 @@ static void cmd_setacl(char *tag, const char *name,
         /* remote mailbox */
         struct backend *s = NULL;
         int res;
+
+        // don't hold the lock locally, we're calling remote
+        mboxname_release(&namespacelock);
 
         s = proxy_findserver(mbentry->server, &imap_protocol,
                              proxy_userid, &backend_cached,
@@ -9022,11 +9026,9 @@ static void cmd_setacl(char *tag, const char *name,
             }
         }
 
-        struct mboxlock *namespacelock = mboxname_usernamespacelock(intname);
         r = mboxlist_setacl(&imapd_namespace, intname, identifier, rights,
                             imapd_userisadmin || imapd_userisproxyadmin,
                             proxy_userid, imapd_authstate);
-        mboxname_release(&namespacelock);
     }
 
     imapd_check(NULL, 0);
@@ -9045,6 +9047,7 @@ static void cmd_setacl(char *tag, const char *name,
     }
 
 done:
+    mboxname_release(&namespacelock);
     free(intname);
     mboxlist_entry_free(&mbentry);
 }
@@ -11332,18 +11335,15 @@ static void cmd_undump(char *tag, char *name)
 {
     int r = 0;
     mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbname_intname(mbname));
 
     /* administrators only please */
     if (!imapd_userisadmin)
         r = IMAP_PERMISSION_DENIED;
 
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbname_intname(mbname));
-
     if (!r) r = mlookup(tag, name, mbname_intname(mbname), NULL);
 
     if (!r) r = undump_mailbox(mbname_intname(mbname), imapd_in, imapd_out, imapd_authstate);
-
-    mboxname_release(&namespacelock);
 
     if (r) {
         prot_printf(imapd_out, "%s NO %s%s\r\n",
@@ -11354,10 +11354,13 @@ static void cmd_undump(char *tag, char *name)
                                                  imapd_userid, imapd_authstate,
                                                  NULL, NULL, 0) == 0)
                     ? "[TRYCREATE] " : "", error_message(r));
-    } else {
+    }
+    else {
         prot_printf(imapd_out, "%s OK %s\r\n", tag,
                     error_message(IMAP_OK_COMPLETED));
     }
+
+    mboxname_release(&namespacelock);
     mbname_free(&mbname);
 }
 
@@ -12574,26 +12577,36 @@ static void cmd_xfer(const char *tag, const char *name,
             if (!xfer->use_replication) {
                 /* set the quotaroot if needed */
                 r = xfer_setquotaroot(xfer, mbentry->name);
-                if (r) goto next;
+                if (r) {
+                    mboxname_release(&namespacelock);
+                    goto next;
+                }
 
                 /* backport the seen file if needed */
                 if (xfer->remoteversion < 12) {
                     r = seen_open(xfer->userid, SEEN_CREATE, &xfer->seendb);
-                    if (r) goto next;
+                    if (r) {
+                        mboxname_release(&namespacelock);
+                        goto next;
+                    }
                 }
             }
             mbentry_t *inbox_mbentry = NULL;
             char *inbox = mboxname_user_mbox(xfer->userid, 0);
             r = mboxlist_lookup_allow_all(inbox, &inbox_mbentry, NULL);
             free(inbox);
-            if (r) goto next;
+            if (r) {
+                mboxname_release(&namespacelock);
+                mboxlist_entry_free(&inbox_mbentry);
+                goto next;
+            }
 
             r = mboxlist_usermboxtree(xfer->userid, NULL, xfer_addusermbox,
                                       xfer, MBOXTREE_DELETED);
 
             /* NOTE: mailboxes were added in reverse, so the inbox is
              * done last */
-            r = do_xfer(xfer);
+            if (!r) r = do_xfer(xfer);
 
             if (!r) {
                 /* this was a successful user move, and we need to delete

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6303,6 +6303,9 @@ static void cmd_search(char *tag, char *cmd)
         goto done;
     }
 
+    // this refreshes the index, we may be looking at it in our search
+    imapd_check(NULL, 0);
+
     if (searchargs->filter) {
         /* Multisearch */
         if ((searchargs->filter & SEARCH_SOURCE_SELECTED) && !imapd_index) {
@@ -6417,7 +6420,7 @@ static void cmd_search(char *tag, char *cmd)
         search_expr_free(mrock.expr);
         free_hash_table(&mrock.mailboxes, NULL);
     }
-    else if (!index_check(imapd_index, 0, 0)) {  /* update the index */
+    else {
         n = index_search(imapd_index, searchargs, usinguid);
     }
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -1880,13 +1880,8 @@ static int index_lock(struct index_state *state, int readonly)
 
 EXPORTED int index_status(struct index_state *state, struct statusdata *sdata)
 {
-    int r = index_lock(state, /*readonly*/1);
-    if (r) return r;
-
     status_fill_mailbox(state->mailbox, sdata);
     status_fill_seen(state->userid, sdata, state->numrecent, state->numunseen);
-
-    index_unlock(state);
     return 0;
 }
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -1179,9 +1179,10 @@ EXPORTED int index_fetch(struct index_state *state,
     struct index_map *im;
     uint32_t msgno;
     int r;
-    struct mboxevent *mboxevent = NULL;
+    // if FETCH_SETSEEN and ACLs permit, we need a writelock
+    int readonly = !(fetchargs->fetchitems & FETCH_SETSEEN && !state->examining && state->myrights & ACL_SETSEEN);
 
-    r = index_lock(state, /*readonly*/0);  // can't be readonly because of FETCH_SETSEEN
+    r = index_lock(state, readonly);
     if (r) return r;
 
     if (!strcmp("$", sequence)) {
@@ -1205,8 +1206,8 @@ EXPORTED int index_fetch(struct index_state *state,
     }
 
     /* set the \Seen flag if necessary - while we still have the lock */
-    if (fetchargs->fetchitems & FETCH_SETSEEN && !state->examining && state->myrights & ACL_SETSEEN) {
-        mboxevent = mboxevent_new(EVENT_MESSAGE_READ);
+    if (!readonly) {
+        struct mboxevent *mboxevent = mboxevent_new(EVENT_MESSAGE_READ);
 
         for (msgno = 1; msgno <= state->exists; msgno++) {
             im = &state->map[msgno-1];
@@ -1220,6 +1221,10 @@ EXPORTED int index_fetch(struct index_state *state,
         mboxevent_set_access(mboxevent, NULL, NULL, state->userid, mailbox_name(state->mailbox), 1);
         mboxevent_set_numunseen(mboxevent, state->mailbox,
                                 state->numunseen);
+
+        /* send MessageRead event notification for successfully rewritten records */
+        mboxevent_notify(&mboxevent);
+        mboxevent_free(&mboxevent);
     }
 
     if (fetchargs->vanished) {
@@ -1234,10 +1239,6 @@ EXPORTED int index_fetch(struct index_state *state,
     }
 
     index_unlock(state);
-
-    /* send MessageRead event notification for successfully rewritten records */
-    mboxevent_notify(&mboxevent);
-    mboxevent_free(&mboxevent);
 
     index_checkflags(state, 1, 0);
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -2535,7 +2535,6 @@ EXPORTED int index_convmultisort(struct index_state *state,
     query = search_query_new(state, searchargs);
     query->multiple = 1;
     query->need_ids = 1;
-    query->need_expunge = 1;
     query->sortcrit = sortcrit;
 
     r = search_query_run(query);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1289,7 +1289,8 @@ static void _delayed_cleanup(void *rock)
      * if we are in the middle of a shutdown */
     if (in_shutdown) goto done;
 
-    int r = mailbox_open_exclusive(mboxname, &mailbox);
+    int r = mailbox_open_advanced(mboxname, LOCK_EXCLUSIVE|LOCK_NONBLOCK,
+                                  LOCK_EXCLUSIVE, &mailbox);
     if (r) goto done;
 
     if (mailbox->i.options & OPT_MAILBOX_NEEDS_REPACK) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1286,7 +1286,7 @@ static void _delayed_cleanup(void *rock)
     if (in_shutdown) goto done;
 
     int r = mailbox_open_advanced(mboxname, LOCK_EXCLUSIVE|LOCK_NONBLOCK,
-                                  LOCK_EXCLUSIVE, &mailbox);
+                                  LOCK_EXCLUSIVE, NULL, &mailbox);
     if (r) goto done;
 
     if (mailbox->i.options & OPT_MAILBOX_NEEDS_REPACK) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1044,16 +1044,14 @@ static int mailbox_open_advanced(const char *name,
 
     // lock the user namespace FIRST before the mailbox namespace
     char *userid = mboxname_to_userid(name);
-    if (userid) {
-        int haslock = user_isnamespacelocked(userid);
-        if (haslock) {
-            if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
-        }
-        else {
-            mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
-        }
-        free(userid);
+    int haslock = user_isnamespacelocked(userid);
+    if (haslock) {
+        if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
     }
+    else {
+        mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
+    }
+    free(userid);
 
     if (mbe) mbentry = mboxlist_entry_copy(mbe);
     else r = mboxlist_lookup_allow_all(name, &mbentry, NULL);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1025,9 +1025,9 @@ static int mailbox_open_advanced(const char *name,
     /* already open?  just use this one */
     if (listitem) {
         /* can't reuse an exclusive locked mailbox */
-        if (listitem->l->locktype == LOCK_EXCLUSIVE)
+        if (listitem->l->locktype & LOCK_EXCLUSIVE)
             return IMAP_MAILBOX_LOCKED;
-        if (locktype == LOCK_EXCLUSIVE)
+        if (locktype & LOCK_EXCLUSIVE)
             return IMAP_MAILBOX_LOCKED;
         /* can't reuse an already locked index */
         if (listitem->m.index_locktype)
@@ -1047,11 +1047,10 @@ static int mailbox_open_advanced(const char *name,
     if (userid) {
         int haslock = user_isnamespacelocked(userid);
         if (haslock) {
-            if (index_locktype != LOCK_SHARED) assert(haslock != LOCK_SHARED);
+            if (!(index_locktype & LOCK_SHARED)) assert(!(haslock & LOCK_SHARED));
         }
         else {
-            int locktype = index_locktype;
-            mailbox->local_namespacelock = user_namespacelock_full(userid, locktype);
+            mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
         }
         free(userid);
     }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3094,12 +3094,11 @@ static int mboxlist_have_admin_rights(const char *rights) {
  * pointer, removes the ACL entry for 'identifier'.   'isadmin' is
  * nonzero if user is a mailbox admin.  'userid' is the user's login id.
  *
- * 1. Start transaction
- * 2. Check rights
- * 3. Set db entry
- * 4. Change backup copy (cyrus.header)
- * 5. Commit transaction
- * 6. Change mupdate entry
+ * 1. Open and writelock mailbox
+ * 2. Update ACL in mailbox header
+ * 4. Commit mailbox
+ * 3. Update db entry
+ * 5. Change mupdate entry
  *
  */
 EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((unused)),
@@ -3109,6 +3108,7 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
                     const struct auth_state *auth_state)
 {
     mbentry_t *mbentry = NULL;
+    modseq_t foldermodseq = 0;
     int r;
     int myrights;
     int mode = ACL_MODE_SET;
@@ -3118,18 +3118,18 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
     int ensure_owner_rights = 0;
     int mask;
     const char *mailbox_owner = NULL;
-    struct mailbox *mailbox = NULL;
     char *newacl = NULL;
-    struct txn *tid = NULL;
 
     init_internal();
+
+    // the namespacelock will protect us from all races on the local mailboxes.db
+    // so we can just read away and know it won't change under us.
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
 
     /* round trip identifier to potentially strip domain */
     mbname_t *idname = mbname_from_userid(identifier);
     /* XXX - enforce cross domain restrictions */
     identifier = mbname_userid(idname);
-
-    char *dbname = mboxname_to_dbname(name);
 
     /* checks if the mailbox belongs to the user who is trying to change the
        access rights */
@@ -3153,40 +3153,16 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
        the identifier */
     ensure_owner_rights = isusermbox || isidentifiermbox;
 
-    /* 1. Start Transaction */
-    /* lookup the mailbox to make sure it exists and get its acl */
-    do {
-        r = mboxlist_mylookup(dbname, &mbentry, &tid, 1, 1);
-    } while(r == IMAP_AGAIN);
+    r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
+    if (r) goto done;
 
     /* Can't do this to an in-transit or reserved mailbox */
-    if (!r && mbentry->mbtype & (MBTYPE_MOVING | MBTYPE_RESERVE | MBTYPE_DELETED)) {
+    if (mbentry->mbtype & (MBTYPE_MOVING | MBTYPE_RESERVE | MBTYPE_DELETED)) {
         r = IMAP_MAILBOX_NOTSUPPORTED;
+        goto done;
     }
 
-    /* if it is not a remote mailbox, we need to unlock the mailbox list,
-     * lock the mailbox, and re-lock the mailboxes list */
-    /* we must do this to obey our locking rules */
-    if (!r && !(mbentry->mbtype & MBTYPE_REMOTE)) {
-        cyrusdb_abort(mbdb, tid);
-        tid = NULL;
-        mboxlist_entry_free(&mbentry);
-
-        /* open & lock mailbox header */
-        r = mailbox_open_iwl(name, &mailbox);
-
-        if (!r) {
-            do {
-                /* lookup the mailbox to make sure it exists and get its acl */
-                r = mboxlist_mylookup(dbname, &mbentry, &tid, 1, 1);
-            } while (r == IMAP_AGAIN);
-        }
-
-        if(r) goto done;
-    }
-
-    /* 2. Check Rights */
-    if (!r && !isadmin) {
+    if (!isadmin) {
         myrights = cyrus_acl_myrights(auth_state, mbentry->acl);
         if (!(myrights & ACL_ADMIN)) {
             r = (myrights & ACL_LOOKUP) ?
@@ -3195,111 +3171,102 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
         }
     }
 
-    /* 2.1 Only admin user can set 'anyone' rights if config says so */
-    if (!r && !isadmin && !anyoneuseracl && !strncmp(identifier, "anyone", 6)) {
-      r = IMAP_PERMISSION_DENIED;
-      goto done;
+    if (!isadmin && !anyoneuseracl && !strncmp(identifier, "anyone", 6)) {
+        r = IMAP_PERMISSION_DENIED;
+        goto done;
     }
 
-    /* 3. Set DB Entry */
-    if(!r) {
-        /* Make change to ACL */
-        newacl = xstrdup(mbentry->acl);
-        if (rights && *rights) {
-            /* rights are present and non-empty */
-            mode = ACL_MODE_SET;
-            if (*rights == '+') {
-                rights++;
-                mode = ACL_MODE_ADD;
-            }
-            else if (*rights == '-') {
-                rights++;
-                mode = ACL_MODE_REMOVE;
-            }
-            /* do not allow non-admin user to remove the admin rights from mailbox owner */
-            if (!isadmin && isidentifiermbox && mode != ACL_MODE_ADD) {
-                int has_admin_rights = mboxlist_have_admin_rights(rights);
-                if ((has_admin_rights && mode == ACL_MODE_REMOVE) ||
-                   (!has_admin_rights && mode != ACL_MODE_REMOVE)) {
-                    syslog(LOG_ERR, "Denied removal of admin rights on "
-                           "folder \"%s\" (owner: %s) by user \"%s\"", name,
-                           mailbox_owner, userid);
-                    r = IMAP_PERMISSION_DENIED;
-                    goto done;
-                }
-            }
-
-            r = cyrus_acl_strtomask(rights, &mask);
-
-            if (!r && cyrus_acl_set(&newacl, identifier, mode, mask,
-                                    ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
-                                    (void *)mailbox_owner)) {
-                r = IMAP_INVALID_IDENTIFIER;
-            }
-        } else {
-            /* do not allow to remove the admin rights from mailbox owner */
-            if (!isadmin && isidentifiermbox) {
+    /* generate new rights string */
+    newacl = xstrdup(mbentry->acl);
+    if (rights && *rights) {
+        /* rights are present and non-empty */
+        mode = ACL_MODE_SET;
+        if (*rights == '+') {
+            rights++;
+            mode = ACL_MODE_ADD;
+        }
+        else if (*rights == '-') {
+            rights++;
+            mode = ACL_MODE_REMOVE;
+        }
+        /* do not allow non-admin user to remove the admin rights from mailbox owner */
+        if (!isadmin && isidentifiermbox && mode != ACL_MODE_ADD) {
+            int has_admin_rights = mboxlist_have_admin_rights(rights);
+            if ((has_admin_rights && mode == ACL_MODE_REMOVE) ||
+               (!has_admin_rights && mode != ACL_MODE_REMOVE)) {
                 syslog(LOG_ERR, "Denied removal of admin rights on "
                        "folder \"%s\" (owner: %s) by user \"%s\"", name,
                        mailbox_owner, userid);
                 r = IMAP_PERMISSION_DENIED;
                 goto done;
             }
+        }
 
-            if (cyrus_acl_remove(&newacl, identifier,
-                                 ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
-                                 (void *)mailbox_owner)) {
-                r = IMAP_INVALID_IDENTIFIER;
-            }
+        r = cyrus_acl_strtomask(rights, &mask);
+
+        if (!r && cyrus_acl_set(&newacl, identifier, mode, mask,
+                                ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
+                                (void *)mailbox_owner)) {
+            r = IMAP_INVALID_IDENTIFIER;
         }
     }
+    else {
+        /* do not allow to remove the admin rights from mailbox owner */
+        if (!isadmin && isidentifiermbox) {
+            syslog(LOG_ERR, "Denied removal of admin rights on "
+                   "folder \"%s\" (owner: %s) by user \"%s\"", name,
+                   mailbox_owner, userid);
+            r = IMAP_PERMISSION_DENIED;
+            goto done;
+        }
 
-    if (!r) {
-        /* ok, change the database */
-        free(mbentry->acl);
-        mbentry->acl = xstrdupnull(newacl);
-        mbentry->foldermodseq = mailbox_modseq_dirty(mailbox);
-
-        r = mboxlist_update_entry(name, mbentry, &tid);
-
-        if (r) {
-            xsyslog(LOG_ERR, "DBERROR: error updating acl",
-                             "mailbox=<%s> error=<%s>",
-                             name, cyrusdb_strerror(r));
-            r = IMAP_IOERROR;
+        if (cyrus_acl_remove(&newacl, identifier,
+                             ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
+                             (void *)mailbox_owner)) {
+            r = IMAP_INVALID_IDENTIFIER;
         }
     }
+    if (r) goto done;
 
-    /* 4. Commit transaction */
-    if (!r) {
-        if((r = cyrusdb_commit(mbdb, tid)) != 0) {
-            xsyslog(LOG_ERR, "DBERROR: failed on commit",
-                             "error=<%s>",
-                             cyrusdb_strerror(r));
-            r = IMAP_IOERROR;
+    /* if it is not a remote mailbox, we need to update the copy in the mailbox header */
+    if (!(mbentry->mbtype & MBTYPE_REMOTE)) {
+        struct mailbox *mailbox = NULL;
+        r = mailbox_open_iwl(name, &mailbox);
+        if (!r) {
+            foldermodseq = mailbox_modseq_dirty(mailbox);
+            mailbox_set_acl(mailbox, newacl);
+
+            /* send a AclChange event notification */
+            struct mboxevent *mboxevent = mboxevent_new(EVENT_ACL_CHANGE);
+            mboxevent_extract_mailbox(mboxevent, mailbox);
+            mboxevent_set_acl(mboxevent, identifier, rights);
+            mboxevent_set_access(mboxevent, NULL, NULL, userid, mailbox_name(mailbox), 0);
+            mboxevent_notify(&mboxevent);
+            mboxevent_free(&mboxevent);
+
+            r = mailbox_commit(mailbox);
+            mailbox_close(&mailbox);
         }
-        tid = NULL;
+        if (r) goto done;
     }
 
-    /* 5. Change backup copy (cyrus.header) */
-    /* we already have it locked from above */
-    if (!r && !(mbentry->mbtype & MBTYPE_REMOTE)) {
-        mailbox_set_acl(mailbox, newacl);
-        /* want to commit immediately to ensure ordering */
-        r = mailbox_commit(mailbox);
+    /* change the local database */
+    free(mbentry->acl);
+    mbentry->acl = xstrdupnull(newacl);
+    if (mbentry->foldermodseq < foldermodseq)
+        mbentry->foldermodseq = foldermodseq;
 
-        /* send an AclChange event notification */
-        struct mboxevent *mboxevent = mboxevent_new(EVENT_ACL_CHANGE);
-        mboxevent_extract_mailbox(mboxevent, mailbox);
-        mboxevent_set_acl(mboxevent, identifier, rights);
-        mboxevent_set_access(mboxevent, NULL, NULL, userid, mailbox_name(mailbox), 0);
-
-        mboxevent_notify(&mboxevent);
-        mboxevent_free(&mboxevent);
+    r = mboxlist_update_entry(name, mbentry, NULL);
+    if (r) {
+        xsyslog(LOG_ERR, "DBERROR: error updating acl",
+                         "mailbox=<%s> error=<%s>",
+                         name, cyrusdb_strerror(r));
+        r = IMAP_IOERROR;
+        goto done;
     }
 
-    /* 6. Change mupdate entry  */
-    if (!r && config_mupdate_server) {
+    /* Update the remote database */
+    if (config_mupdate_server) {
         mupdate_handle *mupdate_h = NULL;
         /* commit the update to MUPDATE */
         char buf[MAX_PARTITION_LEN + HOSTNAME_SIZE + 2];
@@ -3307,11 +3274,12 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
         snprintf(buf, sizeof(buf), "%s!%s", config_servername, mbentry->partition);
 
         r = mupdate_connect(config_mupdate_server, NULL, &mupdate_h, NULL);
-        if(r) {
+        if (r) {
             syslog(LOG_ERR,
                    "cannot connect to mupdate server for setacl on '%s'",
                    name);
-        } else {
+        }
+        else {
             r = mupdate_activate(mupdate_h, name, buf, newacl);
             if(r) {
                 syslog(LOG_ERR,
@@ -3323,20 +3291,10 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
     }
 
   done:
-    if (r && tid) {
-        /* if we are mid-transaction, abort it! */
-        int r2 = cyrusdb_abort(mbdb, tid);
-        if (r2) {
-            syslog(LOG_ERR,
-                   "DBERROR: error aborting txn in mboxlist_setacl: %s",
-                   cyrusdb_strerror(r2));
-        }
-    }
-    mailbox_close(&mailbox);
     free(newacl);
     mboxlist_entry_free(&mbentry);
     mbname_free(&idname);
-    free(dbname);
+    mboxname_release(&namespacelock);
 
     return r;
 }
@@ -3344,15 +3302,24 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
 /* change the ACL for mailbox 'name' when we have nothing but the name and the new value */
 EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
 {
+    // the namespacelock will protect us from all races on the local mailboxes.db
+    // so we can just read away and know it won't change under us.
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
+
     struct mailbox *mailbox = NULL;
+    modseq_t foldermodseq = 0;
+
     int r = mailbox_open_iwl(name, &mailbox);
-    if (!r)
-        r = mboxlist_sync_setacls(name, newacl, mailbox_modseq_dirty(mailbox));
     if (!r) {
+        foldermodseq = mailbox_modseq_dirty(mailbox);
         mailbox_set_acl(mailbox, newacl);
         r = mailbox_commit(mailbox);
     }
     mailbox_close(&mailbox);
+
+    if (!r) r = mboxlist_sync_setacls(name, newacl, foldermodseq);
+
+    mboxname_release(&namespacelock);
     return r;
 }
 
@@ -3370,18 +3337,15 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
 EXPORTED int
 mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodseq)
 {
+    // the namespacelock will protect us from all races on the local mailboxes.db
+    // so we can just read away and know it won't change under us.
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
     mbentry_t *mbentry = NULL;
     int r;
-    struct txn *tid = NULL;
-    char *dbname = mboxname_to_dbname(name);
 
     init_internal();
 
-    /* 1. Start Transaction */
-    /* lookup the mailbox to make sure it exists and get its acl */
-    do {
-        r = mboxlist_mylookup(dbname, &mbentry, &tid, 1, 1);
-    } while(r == IMAP_AGAIN);
+    r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
     if (r) goto done;
 
     // nothing to change, great
@@ -3400,7 +3364,7 @@ mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodse
     if (mbentry->foldermodseq < foldermodseq)
         mbentry->foldermodseq = foldermodseq;
 
-    r = mboxlist_update_entry(name, mbentry, &tid);
+    r = mboxlist_update_entry(name, mbentry, NULL);
 
     if (r) {
         xsyslog(LOG_ERR, "DBERROR: error updating acl",
@@ -3409,17 +3373,6 @@ mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodse
         r = IMAP_IOERROR;
         goto done;
     }
-
-    /* 3. Commit transaction */
-    r = cyrusdb_commit(mbdb, tid);
-    if (r) {
-        xsyslog(LOG_ERR, "DBERROR: failed on commit",
-                         "mailbox=<%s> error=<%s>",
-                         name, cyrusdb_strerror(r));
-        r = IMAP_IOERROR;
-        goto done;
-    }
-    tid = NULL;
 
     /* 4. Change mupdate entry  */
     if (config_mupdate_server) {
@@ -3445,19 +3398,8 @@ mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodse
     }
 
 done:
-    free(dbname);
-
-    if (tid) {
-        /* if we are mid-transaction, abort it! */
-        int r2 = cyrusdb_abort(mbdb, tid);
-        if (r2) {
-            syslog(LOG_ERR,
-                   "DBERROR: error aborting txn in sync_setacls %s: %s",
-                   name, cyrusdb_strerror(r2));
-        }
-    }
-
     mboxlist_entry_free(&mbentry);
+    mboxname_release(&namespacelock);
 
     return r;
 }

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -328,12 +328,10 @@ static int query_begin_index(search_query_t *query,
                              struct index_state **statep)
 {
     int r = 0;
-    int needs_refresh = 0;
 
     /* open an index_state */
     if (!strcmp(index_mboxname(query->state), mboxname)) {
         *statep = query->state;
-        needs_refresh = 1;
     }
     else {
         struct index_init init;
@@ -358,11 +356,6 @@ static int query_begin_index(search_query_t *query,
         /* make sure \Deleted messages are expunged.  Will also lock the
          * mailbox state and read any new information */
         r = index_expunge(*statep, NULL, 1);
-        if (r) goto out;
-    }
-    else if (needs_refresh) {
-        /* Expunge considered unhelpful - just refresh */
-        r = index_refresh(*statep);
         if (r) goto out;
     }
 

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -352,13 +352,6 @@ static int query_begin_index(search_query_t *query,
         index_checkflags(*statep, 0, 0);
     }
 
-    if (query->need_expunge) {
-        /* make sure \Deleted messages are expunged.  Will also lock the
-         * mailbox state and read any new information */
-        r = index_expunge(*statep, NULL, 1);
-        if (r) goto out;
-    }
-
     r = cmd_cancelled(!query->ignore_timer);
 
 out:

--- a/imap/search_query.h
+++ b/imap/search_query.h
@@ -110,7 +110,6 @@ struct search_query {
     const struct sortcrit *sortcrit;
     int multiple;
     int need_ids;
-    int need_expunge;
     int want_expunged;
     uint32_t want_mbtype;
     int verbose;


### PR DESCRIPTION
Hey Ken,

Here's, I THINK, all the lock ordering fixes that we need.  You can check the logic I used to test them with the top commit on https://github.com/cyrusimap/cyrus-imapd/pull/3179 which I just rebased on top of this, and which does all the LOCKERROR syslogs for cases where we try to lock any index files while not holding a user lock.

I've also rebased this on top of https://github.com/cyrusimap/cyrus-imapd/pull/3859, which already messed with some locking and has been include-in-fastmail for a while.

In my Cassandane tests, this all works with the lock tracking in place.  The big changes are:

1) we take a global blank username lock for shared folders
2) we don't do mailboxes.db locking any more for ACL changes, instead we just lock the owner's user lock for everything - this simplifies the locking considerably for ACL changes - that's the first thing I found in Nottingham
3) we make sure we NEVER try to lock again once we've unlocked an index to stream a fetch response.

There's also a nice little performance improvement, any FETCH command which doesn't have an implicit SETSEEN doesn't ever need to take an exclusive lock, so it's been changed to only take a shared lock if it's just doing a fetch without a SETSEEN.





