### PR TITLE
calalarmd: Update nextcheck on floating time events when calendar/principal TZ changes

### DIFF
--- a/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
@@ -44,6 +44,7 @@ use DateTime;
 use DateTime::Format::ISO8601;
 use JSON::XS;
 use Net::CalDAVTalk 0.05;
+use Mail::JMAPTalk 0.13;
 use Data::Dumper;
 use POSIX;
 use Carp;
@@ -58,12 +59,15 @@ sub new
 
     my $config = Cassandane::Config->default()->clone();
     $config->set(caldav_realm => 'Cassandane');
-    $config->set(httpmodules => 'caldav');
+    $config->set(conversations => 'yes');
+    $config->set(httpmodules => 'caldav jmap tzdist');
     $config->set(httpallowcompress => 'no');
     $config->set(caldav_historical_age => -1);
     $config->set(calendar_minimum_alarm_interval => '61s');
+    $config->set(jmap_nonstandard_extensions => 'yes');
     return $class->SUPER::new({
         config => $config,
+        jmap => 1,
         adminstore => 1,
         services => ['imap', 'http'],
     }, @_);
@@ -84,6 +88,14 @@ sub set_up
         url => '/',
         expandurl => 1,
     );
+    $self->{jmap}->DefaultUsing([
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:calendars',
+        'urn:ietf:params:jmap:principals',
+        'urn:ietf:params:jmap:calendars:preferences',
+        'https://cyrusimap.org/ns/jmap/calendars',
+        'https://cyrusimap.org/ns/jmap/debug',
+    ]);
 }
 
 sub _can_match {
@@ -3162,6 +3174,167 @@ EOF
                          {summary => 'SECONDLY-61', start => $start },
                          {summary => "MINUTELY-2-$startsec", start => $start },
                          {summary => "HOURLY-1-$bymin_ok", start => $start });
+}
+
+sub test_recurring_allday_floating
+    :min_version_3_9 :needs_component_calalarmd :needs_component_jmap
+{
+    my ($self) = @_;
+
+    my $CalDAV = $self->{caldav};
+
+    my $jmap = $self->{jmap};
+
+my $UTC = <<EOF;
+BEGIN:VCALENDAR
+BEGIN:VTIMEZONE
+TZID:Etc/UTC
+BEGIN:STANDARD
+TZNAME:UTC
+TZOFFSETFROM:+0000
+TZOFFSETTO:+0000
+DTSTART:16010101T000000
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOF
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo', timeZone => $UTC});
+    $self->assert_not_null($CalendarId);
+
+    my $now = DateTime->today();
+    $now->set_time_zone('Etc/UTC');
+
+    # define the event to start next week
+    my $startdt = $now->clone();
+    $startdt->add(days => 7);
+    my $start = $startdt->strftime('%Y%m%d');
+
+    # set the trigger to notify us 5 hours before the event
+    my $trigger="-PT5H";
+
+    my $uuid = "574E2CD0-2D2A-4554-8B63-C7504481D3A9";
+    my $href = "$CalendarId/$uuid.ics";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:574E2CD0-2D2A-4554-8B63-C7504481D3A9
+TRANSP:OPAQUE
+SUMMARY:Simple
+DTSTART;VALUE=DATE:$start
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+RRULE:FREQ=WEEKLY
+BEGIN:VALARM
+TRIGGER:$trigger
+ACTION:EMAIL
+SUMMARY: My alarm
+DESCRIPTION:My alarm has triggered
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $CalDAV->Request('PUT', $href, $card, 'Content-Type' => 'text/calendar');
+
+    # clean notification cache
+    $self->{instance}->getnotify();
+
+    $now->subtract(hours => 5);
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'calalarmd', '-t' => $now->epoch() + 60 );
+
+    $self->assert_alarms();
+
+    $now->add(days => 7);
+
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'calalarmd', '-t' => $now->epoch() + 60);
+
+    $self->assert_alarms({summary => 'Simple', start => $start});
+
+    $now->add(days => 7);
+    $startdt->add(days => 7);
+    $start = $startdt->strftime('%Y%m%d');
+
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'calalarmd', '-t' => $now->epoch() + 60);
+
+    $self->assert_alarms({summary => 'Simple', start => $start});
+
+    # Change floating time zone on the calendar 2 hours to the east
+    my $xml = <<EOF;
+<?xml version="1.0" encoding="UTF-8"?>
+<D:propertyupdate xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:set>
+    <D:prop>
+      <C:calendar-timezone-id>Etc/GMT-2</C:calendar-timezone-id>
+    </D:prop>
+  </D:set>
+</D:propertyupdate>
+EOF
+
+    my $res = $CalDAV->Request('PROPPATCH',
+                               "/dav/calendars/user/cassandane/". $CalendarId,
+                               $xml, 'Content-Type' => 'text/xml');
+
+    $now->add(days => 7);
+    $startdt->add(days => 7);
+    $start = $startdt->strftime('%Y%m%d');
+
+    # Need to trigger 2 hours earlier
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'calalarmd', '-t' => $now->epoch() - 7200 + 60);
+
+    $self->assert_alarms({summary => 'Simple', start => $start});
+
+    # Change floating time zone on the calendar 2 more hours to the east
+    $res = $jmap->CallMethods([
+            ['Calendar/set', {update => {$CalendarId => {
+                            timeZone => "Etc/GMT-4"
+            }}}, "R1"]
+    ]);
+    $self->assert_not_null($res);
+    $self->assert_not_null($res->[0][1]{updated});
+
+    $now->add(days => 7);
+    $startdt->add(days => 7);
+    $start = $startdt->strftime('%Y%m%d');
+
+    # Need to trigger 4 hours earlier
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'calalarmd', '-t' => $now->epoch() - 14400 + 60);
+
+    $self->assert_alarms({summary => 'Simple', start => $start});
+
+    # Change floating time zone on the calendar back to original
+    $xml = <<EOF;
+<?xml version="1.0" encoding="UTF-8"?>
+<D:propertyupdate xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:set>
+    <D:prop>
+      <C:calendar-timezone>$UTC</C:calendar-timezone>
+    </D:prop>
+  </D:set>
+</D:propertyupdate>
+EOF
+
+    $res = $CalDAV->Request('PROPPATCH',
+                            "/dav/calendars/user/cassandane/". $CalendarId,
+                            $xml, 'Content-Type' => 'text/xml');
+
+    $now->add(days => 7);
+    $startdt->add(days => 7);
+    $start = $startdt->strftime('%Y%m%d');
+
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'calalarmd', '-t' => $now->epoch() + 60);
+
+    $self->assert_alarms({summary => 'Simple', start => $start});
 }
 
 1;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -80,6 +80,13 @@
 #include "tok.h"
 #include "quota.h"
 
+#ifdef WITH_DAV
+#include "caldav_alarm.h"
+#include "dav_util.h"
+
+#define CAL_TZ_ANNOT  DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone"
+#endif
+
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
@@ -3168,6 +3175,16 @@ static int write_entry(struct mailbox *mailbox,
 
     if (!mailbox)
         sync_log_annotation("");
+#ifdef WITH_DAV
+    else if (!strncmp(entry, CAL_TZ_ANNOT, strlen(CAL_TZ_ANNOT))) {
+        char *freeme = NULL;
+
+        if (!userid || !*userid)
+            userid = freeme = mboxname_to_userid(mailbox_name(mailbox));
+        r = caldav_alarm_update_floating(mailbox, userid);
+        free(freeme);
+    }
+#endif
 
 out:
     annotate_putdb(&d);

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -678,29 +678,6 @@ static int update_alarmdb(const char *mboxname,
     return -1;
 }
 
-static icaltimezone *get_floatingtz(const char *mailbox, const char *userid)
-{
-    icaltimezone *floatingtz = NULL;
-
-    struct buf buf = BUF_INITIALIZER;
-    const char *annotname = DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone";
-    if (!annotatemore_lookupmask(mailbox, annotname, userid, &buf)) {
-        icalcomponent *comp = NULL;
-        comp = icalparser_parse_string(buf_cstring(&buf));
-        icalcomponent *subcomp =
-            icalcomponent_get_first_component(comp, ICAL_VTIMEZONE_COMPONENT);
-        if (subcomp) {
-            floatingtz = icaltimezone_new();
-            icalcomponent_remove_component(comp, subcomp);
-            icaltimezone_set_component(floatingtz, subcomp);
-        }
-        icalcomponent_free(comp);
-    }
-    buf_free(&buf);
-
-    return floatingtz;
-}
-
 static icalcomponent *vpatch_from_peruserdata(struct dlist *dl)
 {
     const char *icalstr;
@@ -1278,7 +1255,7 @@ static int process_peruser_alarms_cb(const char *mailbox, uint32_t uid,
     icalcomponent_free(vpatch);
 
     /* Fetch per-user timezone for floating events */
-    floatingtz = get_floatingtz(mailbox, userid);
+    floatingtz = caldav_get_calendar_tz(mailbox, userid);
 
     /* Process any VALARMs in the patched iCalendar resource */
     check = process_alarms(mailbox, uid, userid, floatingtz, myical,
@@ -2053,7 +2030,7 @@ static void process_one_record(struct caldav_alarm_data *data, time_t runtime, i
 
     switch (data->type) {
     case ALARM_CALENDAR: {
-        icaltimezone *floatingtz = get_floatingtz(mailbox_name(mailbox), "");
+        icaltimezone *floatingtz = caldav_get_calendar_tz(mailbox_name(mailbox), "");
         r = process_valarms(mailbox, &record, floatingtz, runtime, dryrun);
         if (floatingtz) icaltimezone_free(floatingtz, 1);
         break;
@@ -2230,7 +2207,7 @@ EXPORTED int caldav_alarm_upgrade()
         caldav_alarm_close(alarmdb);
         if (rc) continue;
 
-        icaltimezone *floatingtz = get_floatingtz(mailbox_name(mailbox), "");
+        icaltimezone *floatingtz = caldav_get_calendar_tz(mailbox_name(mailbox), "");
 
         /* add alarms for all records */
         struct mailbox_iter *iter =

--- a/imap/caldav_alarm.h
+++ b/imap/caldav_alarm.h
@@ -98,4 +98,7 @@ int caldav_alarm_process(time_t runtime, time_t *next, int dryrun);
 /* upgrade old databases */
 int caldav_alarm_upgrade();
 
+/* update nextcheck for floating events */
+int caldav_alarm_update_floating(struct mailbox *mailbox, const char *userid);
+
 #endif /* CALDAV_ALARM_H */

--- a/imap/caldav_db.c
+++ b/imap/caldav_db.c
@@ -1468,3 +1468,54 @@ EXPORTED const char *caldav_comp_type_as_string(unsigned comp_type)
     }
 }
 
+static icaltimezone *_get_calendar_tz(const char *mboxname, const char *userid)
+{
+    struct buf attrib = BUF_INITIALIZER;
+    icaltimezone *tz = NULL;
+
+    /*  Check for CALDAV:calendar-timezone-id */
+    const char *prop_annot =
+        DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone-id";
+
+    int r = annotatemore_lookupmask(mboxname, prop_annot, userid, &attrib);
+    if (!r && buf_len(&attrib)) {
+        tz = icaltimezone_get_builtin_timezone(buf_cstring(&attrib));
+        buf_free(&attrib);
+        if (tz) return icaltimezone_copy(tz);
+    }
+
+    /*  Check for CALDAV:calendar-timezone */
+    prop_annot = DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone";
+
+    r = annotatemore_lookupmask(mboxname, prop_annot, userid, &attrib);
+    if (!r && buf_len(&attrib)) {
+        icalcomponent *ical, *vtz;
+
+        ical = icalparser_parse_string(buf_cstring(&attrib));
+        vtz = icalcomponent_get_first_component(ical, ICAL_VTIMEZONE_COMPONENT);
+        icalcomponent_remove_component(ical, vtz);
+        icalcomponent_free(ical);
+        buf_free(&attrib);
+
+        tz = icaltimezone_new();
+        icaltimezone_set_component(tz, vtz);
+        return tz;
+    }
+
+    return NULL;
+}
+
+EXPORTED icaltimezone *caldav_get_calendar_tz(const char *mboxname,
+                                              const char *userid)
+{
+    icaltimezone *tz = _get_calendar_tz(mboxname, userid);
+
+    if (!tz) {
+        /* Try principal (calendar-home-set) */
+        char *homeset = caldav_mboxname(userid, NULL);
+        tz = _get_calendar_tz(homeset, userid);
+        free(homeset);
+    }
+
+    return tz;
+}

--- a/imap/caldav_db.h
+++ b/imap/caldav_db.h
@@ -243,4 +243,9 @@ int caldav_write_jscalcache(struct caldav_db *caldavdb, int rowid,
 extern icaltimezone *caldav_get_calendar_tz(const char *mboxname,
                                             const char *userid);
 
+/* fetch IMAP UIDs of all floating time events in calendar */
+int caldav_get_floating_events(struct caldav_db *caldavdb,
+                               const mbentry_t *mbentry,
+                               caldav_cb_t *cb, void *rock);
+
 #endif /* CALDAV_DB_H */

--- a/imap/caldav_db.h
+++ b/imap/caldav_db.h
@@ -239,4 +239,8 @@ int caldav_write_jscalcache(struct caldav_db *caldavdb, int rowid,
                             const char *recurid, const char *userid,
                             int version, const char *data);
 
+/* fetch time zone using for floating time events from calendar or principal */
+extern icaltimezone *caldav_get_calendar_tz(const char *mboxname,
+                                            const char *userid);
+
 #endif /* CALDAV_DB_H */

--- a/imap/caldav_util.h
+++ b/imap/caldav_util.h
@@ -169,8 +169,6 @@ extern int caldav_read_usedefaultalerts(struct dlist *dl,
                                         const struct index_record *record,
                                         icalcomponent **icalp);
 
-extern icaltimezone *caldav_get_calendar_tz(const char *mboxname, const char *userid);
-
 extern int caldav_is_secretarymode(const char *mboxname);
 
 #endif /* HTTP_CALDAV_H */


### PR DESCRIPTION
If a user changes the TZ on a floating time event with alarms, we may trigger the (next) alarm too late if the change in TZ has a greater offset from UTC (toward the east).