### PR TITLE
Sieve: test_notify() works as far back as 3.2

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -3611,7 +3611,7 @@ EOF
 }
 
 sub test_notify
-    :needs_component_sieve :min_version_3_7
+    :needs_component_sieve :min_version_3_2
 {
     my ($self) = @_;
 


### PR DESCRIPTION
Trivial forward-port from 3.2.

Sieve.notify's `:min_version` was bumped by #4290, but that's now been backported as far back as 3.2.  I forgot to fix `:min_version` while backporting, until I got to 3.2, so now I've gotta go forward port it... sigh!

Doing it right this time, by changing on master then backporting from there...
