### PR TITLE
backend: forward-safe backend_version()

### DIFF
--- a/changes/next/4380-backend-version-bump-watermark
+++ b/changes/next/4380-backend-version-bump-watermark
@@ -1,0 +1,21 @@
+Description:
+
+XFER to newer backends now assumes at least the current mailbox version,
+rather than the oldest supported mailbox version.
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+This is the future absence of an upgrade instruction: a server containing
+this change no longer needs to be upgraded to a version that specifically
+recognises newer backends prior to XFERing mailboxes to them.
+
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/issues/4380

--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -440,6 +440,7 @@ static void test_unrecognised_backend_version(void)
     struct backend_version_data data[] = {
         { "BOGUS", 6 }, /* completely unrecognised */
         { "Cyrus IMAP v2.3.B (OGUS)", 6 }, /* junk 2.3 revision */
+        { "Cyrus IMAP 10.0.0", MAILBOX_MINOR_VERSION }, /* unknown future version */
     };
 
     default_conditions();
@@ -467,7 +468,7 @@ static void test_unrecognised_backend_version(void)
         CU_ASSERT_EQUAL(server_state->is_authenticated, 1);
         CU_ASSERT_EQUAL(server_state->is_tls, 0);
 
-        CU_SYSLOG_MATCH("Assuming index version 6!");
+        CU_SYSLOG_MATCH("Assuming index version [0-9]+!");
         got_version = backend_version(be);
         CU_ASSERT_EQUAL(got_version, data[i].version);
         CU_ASSERT_SYSLOG(/*all*/0, 1);

--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -201,7 +201,7 @@ struct backend_version_data {
     int version;
 };
 
-static void test_backend_version(void)
+static void backend_version_common(void)
 {
     size_t i, n_tests;
     struct backend_version_data data[] = {
@@ -401,8 +401,6 @@ static void test_backend_version(void)
         { "Cyrus IMAP 3.9.9", 17 },
     };
 
-    default_conditions();
-
     /* XXX there's something wrong with the toy test server that results in
      * XXX the banner not being set with auto_capa enabled???
      */
@@ -434,7 +432,23 @@ static void test_backend_version(void)
     }
 }
 
-static void test_unrecognised_backend_version(void)
+static void test_backend_version_multiline_caps(void)
+{
+    default_conditions();
+    server_state->config.caps_one_per_line = 1;
+    test_prot.u.std.capa_cmd.formatflags = CAPAF_ONE_PER_LINE|CAPAF_SKIP_FIRST_WORD;
+    backend_version_common();
+}
+
+static void test_backend_version_oneline_caps(void)
+{
+    default_conditions();
+    server_state->config.caps_one_per_line = 0;
+    test_prot.u.std.capa_cmd.formatflags = CAPAF_MANY_PER_LINE;
+    backend_version_common();
+}
+
+static void unrecognised_backend_version_common(void)
 {
     size_t i, n_tests;
     struct backend_version_data data[] = {
@@ -442,8 +456,6 @@ static void test_unrecognised_backend_version(void)
         { "Cyrus IMAP v2.3.B (OGUS)", 6 }, /* junk 2.3 revision */
         { "Cyrus IMAP 10.0.0", MAILBOX_MINOR_VERSION }, /* unknown future version */
     };
-
-    default_conditions();
 
     /* XXX there's something wrong with the toy test server that results in
      * XXX the banner not being set with auto_capa enabled???
@@ -476,6 +488,22 @@ static void test_unrecognised_backend_version(void)
         backend_disconnect(be);
         free(be);
     }
+}
+
+static void test_unrecognised_backend_version_multiline_caps(void)
+{
+    default_conditions();
+    server_state->config.caps_one_per_line = 1;
+    test_prot.u.std.capa_cmd.formatflags = CAPAF_ONE_PER_LINE|CAPAF_SKIP_FIRST_WORD;
+    unrecognised_backend_version_common();
+}
+
+static void test_unrecognised_backend_version_oneline_caps(void)
+{
+    default_conditions();
+    server_state->config.caps_one_per_line = 0;
+    test_prot.u.std.capa_cmd.formatflags = CAPAF_MANY_PER_LINE;
+    unrecognised_backend_version_common();
 }
 
 /*

--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -46,7 +46,7 @@ struct server_state {
 
     /* global state */
     int rend_sock;
-    char banner[32];
+    char banner[64];
 
     /* per-connection state */
     int is_connected;
@@ -197,7 +197,7 @@ static void test_badservice(void)
  * Test that backend_version detects the remote version correctly.
  */
 struct backend_version_data {
-    char banner[32];
+    char banner[64];
     int version;
 };
 
@@ -399,6 +399,14 @@ static void backend_version_common(void)
         { "Cyrus IMAP 3.9.7", 17 },
         { "Cyrus IMAP 3.9.8", 17 },
         { "Cyrus IMAP 3.9.9", 17 },
+
+        /* better test some pre-release version strings too, would be bad if
+         * the parser chokes on them!
+         */
+        { "Cyrus IMAP 3.0.0-rc1", 13 },
+        { "Cyrus IMAP 3.2.0-beta4", 16 },
+        { "Cyrus IMAP 3.6.0-beta2", 17 },
+        { "Cyrus IMAP 3.7.0-alpha0-1155-gf86d12f44a", 17 },
     };
 
     /* XXX there's something wrong with the toy test server that results in
@@ -455,6 +463,8 @@ static void unrecognised_backend_version_common(void)
         { "BOGUS", 6 }, /* completely unrecognised */
         { "Cyrus IMAP v2.3.B (OGUS)", 6 }, /* junk 2.3 revision */
         { "Cyrus IMAP 10.0.0", MAILBOX_MINOR_VERSION }, /* unknown future version */
+        { "Cyrus IMAP 10.0.0-rc1", MAILBOX_MINOR_VERSION },
+        { "Cyrus IMAP 10.0.0-alpha0-57-g1f6140ee54", MAILBOX_MINOR_VERSION },
     };
 
     /* XXX there's something wrong with the toy test server that results in

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -1292,7 +1292,7 @@ EXPORTED void backend_disconnect(struct backend *s)
 
 EXPORTED int backend_version(struct backend *be)
 {
-    const char *two_three_minor;
+    const char *banner_version, *two_three_minor;
     int major, minor;
 
     /* IMPORTANT:
@@ -1313,8 +1313,15 @@ EXPORTED int backend_version(struct backend *be)
     }
 
     /* contemporary numbering */
-    if (2 == sscanf(be->banner, "OK Cyrus IMAP %d.%d.%*d server ready",
-                                &major, &minor))
+    banner_version = strstr(be->banner, "Cyrus IMAP ");
+    if (banner_version != NULL
+        && (2 == sscanf(banner_version,
+                        "Cyrus IMAP %d.%d.%*d server ready",
+                        &major, &minor)
+            || 2 == sscanf(banner_version,
+                           "Cyrus IMAP %d.%d.%*d-%*s server ready",
+                           &major, &minor)
+       ))
     {
         if (major > 3) {
             /* unrecognised future version surely supports at least whatever

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -1292,7 +1292,8 @@ EXPORTED void backend_disconnect(struct backend *s)
 
 EXPORTED int backend_version(struct backend *be)
 {
-    const char *minor;
+    const char *two_three_minor;
+    int major, minor;
 
     /* IMPORTANT:
      *
@@ -1311,59 +1312,34 @@ EXPORTED int backend_version(struct backend *be)
         return MAILBOX_MINOR_VERSION;
     }
 
-    /* unstable 3.9 series ranges from 17..?? */
-    if (strstr(be->banner, "Cyrus IMAP 3.9")) {
-        /* all versions of 3.9 support at least this version */
-        return 17;
-    }
-
-    /* version 3.8 is 17 */
-    if (strstr(be->banner, "Cyrus IMAP 3.8")) {
-        return 17;
-    }
-
-    /* unstable 3.7 series is 17 */
-    if (strstr(be->banner, "Cyrus IMAP 3.7")) {
-        /* all versions of 3.7 support at least this version */
-        return 17;
-    }
-
-    /* version 3.6 is 17 */
-    if (strstr(be->banner, "Cyrus IMAP 3.6")) {
-        return 17;
-    }
-
-    /* unstable 3.5 series is 17 */
-    if (strstr(be->banner, "Cyrus IMAP 3.5")) {
-        /* all versions of 3.5 support at least this version */
-        return 17;
-    }
-
-    /* version 3.4 is 17 */
-    if (strstr(be->banner, "Cyrus IMAP 3.4")) {
-        return 17;
-    }
-
-    /* unstable 3.3 series is 17 */
-    if (strstr(be->banner, "Cyrus IMAP 3.3")) {
-        /* all versions of 3.3 support at least this version */
-        return 17;
-    }
-
-    /* version 3.2 is 16 */
-    if (strstr(be->banner, "Cyrus IMAP 3.2")) {
-        return 16;
-    }
-
-    /* unstable 3.1 series ranges from 13..16 */
-    if (strstr(be->banner, "Cyrus IMAP 3.1")) {
-        /* all versions of 3.1 support at least this version */
-        return 13;
-    }
-
-    /* version 3.0 is 13 */
-    if (strstr(be->banner, "Cyrus IMAP 3.0")) {
-        return 13;
+    /* contemporary numbering */
+    if (2 == sscanf(be->banner, "OK Cyrus IMAP %d.%d.%*d server ready",
+                                &major, &minor))
+    {
+        if (major > 3) {
+            /* unrecognised future version surely supports at least whatever
+             * this version supports, which is a much better assumption than 6
+             */
+            syslog(LOG_INFO, "%s: did not recognise remote Cyrus version from "
+                             "banner \"%s\". Assuming index version %d!",
+                             __func__, be->banner, MAILBOX_MINOR_VERSION);
+            return MAILBOX_MINOR_VERSION;
+        }
+        else if (major == 3) {
+            if (minor >= 3) {
+                /* all versions since 3.3 have been 17 so far */
+                return 17;
+            }
+            else if (minor == 2) {
+                /* version 3.2 is 16 */
+                return 16;
+            }
+            else {
+                /* version 3.0 and 3.1 are 13 */
+                return 13;
+            }
+        }
+        /* didn't recognise it? fall through to specific checks */
     }
 
     /* version 2.5 is 13 */
@@ -1378,16 +1354,16 @@ EXPORTED int backend_version(struct backend *be)
         return 12;
     }
 
-    minor = strstr(be->banner, "v2.3.");
-    if (!minor) goto unrecognised;
-    minor += strlen("v2.3.");
+    two_three_minor = strstr(be->banner, "v2.3.");
+    if (!two_three_minor) goto unrecognised;
+    two_three_minor += strlen("v2.3.");
 
     /* at least version 2.3.10 */
-    if (minor[1] != ' ') {
+    if (two_three_minor[1] != ' ') {
         return 10;
     }
     /* single digit version, figure out which */
-    switch (minor[0]) {
+    switch (two_three_minor[0]) {
     case '0':
     case '1':
     case '2':

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -76,9 +76,7 @@
  * changed to be able to convert both backwards and forwards between the
  * new version and all supported previous versions.
  * If you change MAILBOX_MINOR_VERSION you MUST also make corresponding
- * changes to backend_version() in backend.c, AND backport those changes to
- * all supported older versions, to avoid breaking XFER.  Annoyingly, older
- * versions placed this function in imapd.c FYI!
+ * changes to backend_version() in backend.c.
  */
 #define MAILBOX_MINOR_VERSION   17
 #define MAILBOX_CACHE_MINOR_VERSION 11


### PR DESCRIPTION
If the backend's banner version looks sensible, but is larger than anything we know about, infer that it supports at least the same MAILBOX_MINOR_VERSION that this server does.

This fixes forever the problem where XFER would downgrade and lose data when sending mailboxes to a backend newer than it recognised; and removes the need to update backend_version(), backport it, and do releases from all the older branches, every time a new Cyrus version is created.

backend_version() still needs to be updated appropriately any time MAILBOX_MINOR_VERSION changes, but only when it changes.

This also simplifies handling of banner versions from 3.0 forward.

This needs to be backported to all the usual branches (including 3.0, 2.5, and 2.4), but that will be the last time it needs to happen.