### PR TITLE
rolling squatter: compact databases

### DIFF
--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -832,6 +832,9 @@ static void do_rolling(const char *channel)
 
         strarray_free(mboxnames);
         mboxnames = NULL;
+
+        // handle any delayed compaction runs
+        libcyrus_run_delayed();
     }
 
     /* XXX - we don't really get here... */


### PR DESCRIPTION
Twoskip now delays compacting databases until after the locks are released, but squatter wasn't ever calling this, leading to doing all the compacts on shutdown.  In particular, this meant trying to compact lots of cyrus.indexed.db files