### PR TITLE
xunlink: error-logging wrapper around unlink

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -802,7 +802,8 @@ include_HEADERS = \
 	lib/tok.h \
 	lib/vparse.h \
 	lib/wildmat.h \
-	lib/xmalloc.h
+	lib/xmalloc.h \
+	lib/xunlink.h
 
 nodist_include_HEADERS = \
 	lib/imapopts.h
@@ -1579,7 +1580,8 @@ lib_libcyrus_min_la_SOURCES = \
 	lib/xmalloc.c \
 	lib/xstrlcat.c \
 	lib/xstrlcpy.c \
-	lib/xstrnchr.c
+	lib/xstrnchr.c \
+	lib/xunlink.c
 if !HAVE_SSL
 lib_libcyrus_min_la_SOURCES += lib/xsha1.c
 endif

--- a/backup/lcb_compact.c
+++ b/backup/lcb_compact.c
@@ -48,6 +48,7 @@
 
 #include "lib/gzuncat.h"
 #include "lib/libconfig.h"
+#include "lib/xunlink.h"
 
 #include "imap/imap_err.h"
 #include "imap/sync_support.h"
@@ -151,8 +152,8 @@ static int compact_closerename(struct backup **originalp,
 
     if (r) {
         /* on error, trash the new links and bail out */
-        unlink(buf_cstring(&ts_data_fname));
-        unlink(buf_cstring(&ts_index_fname));
+        xunlink(buf_cstring(&ts_data_fname));
+        xunlink(buf_cstring(&ts_index_fname));
         goto done;
     }
 
@@ -162,8 +163,8 @@ static int compact_closerename(struct backup **originalp,
 
     if (r) {
         /* on error, put original files back */
-        unlink(original->data_fname);
-        unlink(original->index_fname);
+        xunlink(original->data_fname);
+        xunlink(original->index_fname);
         if (link(buf_cstring(&ts_data_fname), original->data_fname))
             xsyslog(LOG_ERR, "IOERROR: failed to link file back!",
                              "source=<%s> dest=<%s>",
@@ -179,8 +180,8 @@ static int compact_closerename(struct backup **originalp,
 
     /* finally, clean up the timestamped ones */
     if (!config_getswitch(IMAPOPT_BACKUP_KEEP_PREVIOUS)) {
-        unlink(buf_cstring(&ts_data_fname));
-        unlink(buf_cstring(&ts_index_fname));
+        xunlink(buf_cstring(&ts_data_fname));
+        xunlink(buf_cstring(&ts_index_fname));
     }
 
     /* release our locks */

--- a/changes/next/xunlink
+++ b/changes/next/xunlink
@@ -1,0 +1,18 @@
+Description:
+
+Adds error-logging unlink wrapper
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -6,6 +6,7 @@
 #include "xmalloc.h"
 #include "retry.h"
 #include "util.h"
+#include "xunlink.h"
 #include "imap/global.h"
 #include "libcyr_cfg.h"
 #include "imap/annotate.h"
@@ -49,7 +50,7 @@ static void set_annotation_definitions(const char *s)
         close(fd);
     }
     else {
-        unlink(fname);
+        xunlink(fname);
     }
 
     imapopts[IMAPOPT_ANNOTATION_DEFINITIONS].val.s = fname;

--- a/cunit/command.testc
+++ b/cunit/command.testc
@@ -3,6 +3,7 @@
 #include "cunit/cyrunit.h"
 #include <sys/stat.h>
 #include "command.h"
+#include "xunlink.h"
 
 const char canary[] = "canary.txt";
 
@@ -12,7 +13,7 @@ static void test_run(void)
     struct stat sb;
 
     /* make sure the file isnt there */
-    r = unlink(canary);
+    r = xunlink(canary);
     if (r < 0) r = errno;
     if (r == ENOENT) r = 0;
     CU_ASSERT_EQUAL_FATAL(r, 0);
@@ -23,7 +24,7 @@ static void test_run(void)
     r = stat(canary, &sb);
     if (r < 0) r = errno;
     CU_ASSERT_EQUAL_FATAL(r, 0);
-    unlink(canary);
+    xunlink(canary);
 }
 
 static void test_popen_r(void)
@@ -59,7 +60,7 @@ static void test_popen_w(void)
     char buf[32];
 
     /* make sure the file isnt there */
-    r = unlink(canary);
+    r = xunlink(canary);
     if (r < 0) r = errno;
     if (r == ENOENT) r = 0;
     CU_ASSERT_EQUAL_FATAL(r, 0);
@@ -86,7 +87,7 @@ static void test_popen_w(void)
     CU_ASSERT_STRING_EQUAL(buf, WORD0);
     fclose(fp);
 
-    unlink(canary);
+    xunlink(canary);
 #undef WORD0
 }
 

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -11,6 +11,7 @@
 #include "lib/util.h"       /* for VECTOR_SIZE */
 //#include "message.h"      /* for VECTOR_SIZE */
 #include "xmalloc.h"
+#include "xunlink.h"
 
 #define DBDIR   "test-dbdir"
 #define DBNAME  DBDIR "/conversations.db"
@@ -1312,7 +1313,7 @@ static void test_dump(void)
     CU_ASSERT_EQUAL(r, 0);
 
     fclose(fp);
-    unlink(filename);
+    xunlink(filename);
     strarray_fini(&mboxnames);
     arrayu64_fini(&cids);
 #undef N_MSGID_TO_CID
@@ -1428,3 +1429,4 @@ static int tear_down(void)
 
     return r;
 }
+/* vim: set ft=c: */

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -9,6 +9,7 @@
 
 #include "charset.h"
 #include "util.h"
+#include "xunlink.h"
 
 #include "imap/http_jwt.h"
 
@@ -85,8 +86,8 @@ static void test_init_multi(void)
     CU_ASSERT_EQUAL(0, r);
     CU_ASSERT_EQUAL(1, http_jwt_is_enabled());
 
-    unlink(fnames[0]);
-    unlink(fnames[1]);
+    xunlink(fnames[0]);
+    xunlink(fnames[1]);
     free(fnames[0]);
     free(fnames[1]);
     rmdir(dname);
@@ -108,7 +109,7 @@ static void test_init_nokeys(void)
     CU_ASSERT_NOT_EQUAL(-1, r);
     CU_ASSERT_NOT_EQUAL(1, http_jwt_is_enabled());
 
-    unlink(fname);
+    xunlink(fname);
     free(fname);
     rmdir(dname);
     http_jwt_reset();
@@ -292,7 +293,7 @@ static void test_validate(void)
     buf_free(&tok);
 
     EVP_PKEY_free(pkey);
-    unlink(fname);
+    xunlink(fname);
     free(fname);
     rmdir(dname);
     http_jwt_reset();
@@ -359,8 +360,8 @@ static void test_auth(void)
     EVP_PKEY_free(pkey);
     BIO_free(bp);
 
-    unlink(fnames[0]);
-    unlink(fnames[1]);
+    xunlink(fnames[0]);
+    xunlink(fnames[1]);
     free(fnames[0]);
     free(fnames[1]);
     rmdir(dname);

--- a/cunit/mboxname.testc
+++ b/cunit/mboxname.testc
@@ -5,6 +5,7 @@
 #include "cunit/cyrunit.h"
 #include "lib/libconfig.h"
 #include "lib/libcyr_cfg.h"
+#include "lib/xunlink.h"
 #include "imap/mboxname.h"
 #include "imap/mailbox.h"
 #include "imap/global.h"
@@ -797,7 +798,7 @@ static void test_nextmodseq(void)
     /* ensure there is no file */
     mbname = mbname_from_intname(FREDNAME);
     fname = mboxname_conf_getpath(mbname, "modseq");
-    unlink(fname);
+    xunlink(fname);
     free(fname);
     mbname_free(&mbname);
 

--- a/cunit/prot.testc
+++ b/cunit/prot.testc
@@ -4,6 +4,7 @@
 #include "xmalloc.h"
 #include "prot.h"
 #include "imap/global.h"
+#include "xunlink.h"
 
 
 #define PROLOG \
@@ -25,7 +26,7 @@
         if ((n) >= 0) (b)[(n)] = '\0'; \
     }
 #define EPILOG \
-    unlink(_fname); \
+    xunlink(_fname); \
     free(_fname); \
     close(_fd)
 

--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -24,6 +24,7 @@
 #include "xstrlcat.h"
 #include "xstrlcpy.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 #define DBDIR       "test-sieve-dbdir"
 #define PARTITION   "default"
@@ -631,7 +632,7 @@ static void context_setup(sieve_test_context_t *ctx,
     /* Now load the compiled bytecode */
     r = sieve_script_load(tempfile, &ctx->exe);
     CU_ASSERT_EQUAL(r, SIEVE_OK);
-    unlink(tempfile);
+    xunlink(tempfile);
 }
 
 static void context_cleanup(sieve_test_context_t *ctx)
@@ -753,7 +754,7 @@ static void message_free(sieve_test_message_t *msg)
     if (msg->content.body)
         message_free_body(msg->content.body);
     buf_free(&msg->content.map);
-    unlink(msg->filename);
+    xunlink(msg->filename);
     free(msg->filename);
     free(msg);
 }

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -7,6 +7,7 @@
 #include "lib/libconfig.h"
 #include "lib/libcyr_cfg.h"
 #include "imap/spool.h"
+#include "xunlink.h"
 
 #define DBDIR       "test-dbdir"
 #define DELIVERED   "Fri, 29 Oct 2010 13:07:07 +1100"
@@ -212,7 +213,7 @@ static void test_fill(void)
     spool_free_hdrcache(cache);
     fclose(fout);
     prot_free(pin);
-    unlink(tempfile);
+    xunlink(tempfile);
 }
 
 static void test_folded_headers(void)
@@ -276,7 +277,7 @@ static void test_folded_headers(void)
     spool_free_hdrcache(cache);
     fclose(fout);
     prot_free(pin);
-    unlink(tempfile);
+    xunlink(tempfile);
 }
 
 static void test_empty_headers(void)
@@ -394,7 +395,7 @@ static void test_empty_headers(void)
     spool_free_hdrcache(cache);
     fclose(fout);
     prot_free(pin);
-    unlink(tempfile);
+    xunlink(tempfile);
 }
 
 /* BZ3640: headers with NULL bytes shall be rejected. */
@@ -443,7 +444,7 @@ static void test_fill_null(void)
     spool_free_hdrcache(cache);
     fclose(fout);
     prot_free(pin);
-    unlink(tempfile);
+    xunlink(tempfile);
 }
 
 /* BZ3386: insert more unique headers than the internal limit of 4009

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -58,6 +58,7 @@
 
 #include "lib/retry.h"
 #include "lib/libconfig.h"
+#include "lib/xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "cunit/registers.h"
@@ -309,7 +310,7 @@ EXPORTED void config_read_string(const char *s)
     retry_write(fd, s, strlen(s));
     config_reset();
     config_read(fname, 0);
-    unlink(fname);
+    xunlink(fname);
     free(fname);
     close(fd);
 }

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -79,6 +79,7 @@
 #include "xstrlcat.h"
 #include "tok.h"
 #include "quota.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -3499,7 +3500,7 @@ static int annotation_set_tofile(annotate_state_t *state
 
     /* XXX how do we do this atomically with other annotations? */
     if (entry->shared.s == NULL)
-        return unlink(path);
+        return xunlink(path);
     else {
         r = cyrus_mkdir(path, 0755);
         if (r)

--- a/imap/append.c
+++ b/imap/append.c
@@ -73,6 +73,7 @@
 #include "retry.h"
 #include "quota.h"
 #include "util.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -344,7 +345,7 @@ EXPORTED FILE *append_newstage_full(const char *mailboxname, time_t internaldate
     strlcat(stagefile, stage->fname, sizeof(stagefile));
 
     /* create this file and put it into stage->parts[0] */
-    unlink(stagefile);
+    xunlink(stagefile);
     if (sourcefile) {
         r = mailbox_copyfile(sourcefile, stagefile, 0);
         if (r) {
@@ -1001,7 +1002,7 @@ EXPORTED int append_fromstage_full(struct appendstate *as, struct body **body,
 
             xsyslog(LOG_ERR, "IOERROR: creating message file",
                              "filename=<%s>", stagefile);
-            unlink(stagefile);
+            xunlink(stagefile);
             goto out;
         }
 
@@ -1133,7 +1134,7 @@ EXPORTED int append_fromstage_full(struct appendstate *as, struct body **body,
     if (r) goto out;
 
     if (in_object_storage) {  // must delete local file
-        if (unlink(fname) != 0) // unlink should do it.
+        if (xunlink(fname) != 0) // unlink should do it.
             if (!remove (fname))  // we must insist
                 syslog(LOG_ERR, "Removing local file <%s> error", fname);
     }
@@ -1190,7 +1191,7 @@ EXPORTED int append_removestage(struct stagemsg *stage)
 
     while ((p = strarray_pop(&stage->parts))) {
         /* unlink the staging file */
-        if (unlink(p) != 0) {
+        if (xunlink(p) != 0) {
             xsyslog(LOG_ERR, "IOERROR: error unlinking file",
                              "filename=<%s>", p);
         }
@@ -1243,7 +1244,7 @@ EXPORTED int append_fromstream(struct appendstate *as, struct body **body,
     if (r) goto out;
     as->nummsg++;
 
-    unlink(fname);
+    xunlink(fname);
     destfile = fopen(fname, "w+");
     if (!destfile) {
         xsyslog(LOG_ERR, "IOERROR: creating message file",

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -66,6 +66,7 @@
 #include "xmalloc.h"
 #include "mailbox.h"
 #include "mboxlist.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -401,7 +402,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
     if (rename(script_names.bctmpname, script_names.bcscriptname)) {
         syslog(LOG_ERR, "autocreate_sieve: rename %s -> %s failed: %m",
                script_names.bctmpname, script_names.bcscriptname);
-        unlink(script_names.bcscriptname);
+        xunlink(script_names.bcscriptname);
         goto failed2;
     }
 
@@ -409,8 +410,8 @@ static int autocreate_sieve(const char *userid, const char *source_script)
     if (symlink(script_names.bclinkname, script_names.defaultname)) {
         if (errno != EEXIST) {
             syslog(LOG_WARNING, "autocreate_sieve: error the symlink-ing %m.");
-            unlink(script_names.scriptname);
-            unlink(script_names.bcscriptname);
+            xunlink(script_names.scriptname);
+            xunlink(script_names.bcscriptname);
         }
     }
 
@@ -454,7 +455,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
                        "%s: %m", script_names.tmpname2);
                 xclose(out_fd);
                 xclose(in_fd);
-                unlink(script_names.tmpname2);
+                xunlink(script_names.tmpname2);
                 goto success;
            }
         } /* while */
@@ -467,15 +468,15 @@ static int autocreate_sieve(const char *userid, const char *source_script)
                        "%s: %m", script_names.bcscriptname);
                 xclose(out_fd);
                 xclose(in_fd);
-                unlink(script_names.tmpname2);
+                xunlink(script_names.tmpname2);
                 goto success;
         } /* if else if */
 
         /* rename the temporary created sieve script to its final name. */
         if (rename(script_names.tmpname2, compiled_source_script)) {
             if (errno != EEXIST) {
-                unlink(script_names.tmpname2);
-                unlink(compiled_source_script);
+                xunlink(script_names.tmpname2);
+                xunlink(compiled_source_script);
             } /* if (errno) */
             goto success;
         }
@@ -488,9 +489,9 @@ static int autocreate_sieve(const char *userid, const char *source_script)
     return 0;
 
  failed3:
-    unlink(script_names.tmpname1);
+    xunlink(script_names.tmpname1);
  failed2:
-    unlink(script_names.bctmpname);
+    xunlink(script_names.bctmpname);
     xclose(in_fd);
  failed1:
     xclose(out_fd);

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -63,6 +63,7 @@
 #include "message.h"
 #include "util.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -659,7 +660,7 @@ static int do_audit(const char *userid)
     assert(strcmp(filename_temp, filename_real));
 
     /* Initialise the temp copy of the database */
-    unlink(filename_temp);
+    xunlink(filename_temp);
     r = cyrusdb_copyfile(filename_real, filename_temp);
     if (r) {
         fprintf(stderr, "Cannot make temp copy of conversations db %s: %s\n",

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -84,6 +84,7 @@
 #include "util.h"
 #include "xmalloc.h"
 #include "xstrlcpy.h"
+#include "xunlink.h"
 
 #ifdef ENABLE_BACKUP
 #include "backup/backup.h"
@@ -417,7 +418,7 @@ int main(int argc, char *argv[])
                     while ((dirent = readdir(dirp)) != NULL) {
                         if (dirent->d_name[0] == '.') continue;
                         file = strconcat(backup2, "/", dirent->d_name, (char *)NULL);
-                        unlink(file);
+                        xunlink(file);
                         free(file);
                     }
 

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -63,6 +63,7 @@
 #include "user.h"
 #include "util.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -501,13 +502,13 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
         if (audit_tool) {
             printf("Not auditing %s, reconstruct failed %s\n", userid, error_message(r));
         }
-        unlink(buf_cstring(&newfname));
+        xunlink(buf_cstring(&newfname));
     }
     else {
         syslog(LOG_NOTICE, "dav_reconstruct_user: %s SUCCEEDED", userid);
         if (audit_tool) {
             run_audit_tool(audit_tool, userid, buf_cstring(&fname), buf_cstring(&newfname));
-            unlink(buf_cstring(&newfname));
+            xunlink(buf_cstring(&newfname));
         }
         else {
             rename(buf_cstring(&newfname), buf_cstring(&fname));

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -70,6 +70,7 @@
 #include "message.h"
 #include "util.h"
 #include "prot.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -207,7 +208,7 @@ static int reservefile(struct protstream *in, const char *part,
     *fname = dlist_reserve_path(part, isarchive, isbackup, guid);
 
     /* remove any duplicates if they're still here */
-    unlink(*fname);
+    xunlink(*fname);
 
     file = fopen(*fname, "w+");
     if (!file) {
@@ -271,7 +272,7 @@ static int reservefile(struct protstream *in, const char *part,
 error:
     if (file) {
         fclose(file);
-        unlink(*fname);
+        xunlink(*fname);
         *fname = NULL;
     }
     return r;
@@ -745,7 +746,7 @@ EXPORTED void dlist_unlink_files(struct dlist *dl)
     if (!dl->sval) return;
 
     syslog(LOG_DEBUG, "%s: unlinking %s", __func__, dl->sval);
-    unlink(dl->sval);
+    xunlink(dl->sval);
 }
 
 EXPORTED void dlist_free(struct dlist **dlp)

--- a/imap/idlemsg.c
+++ b/imap/idlemsg.c
@@ -59,6 +59,7 @@
 #include "xstrlcat.h"
 #include "idlemsg.h"
 #include "global.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -124,7 +125,7 @@ EXPORTED int idle_init_sock(const struct sockaddr_un *local)
     }
 
     /* bind it to a local file */
-    unlink(local->sun_path);
+    xunlink(local->sun_path);
     len = sizeof(local->sun_family) + strlen(local->sun_path) + 1;
 
     oldumask = umask((mode_t) 0); /* for Linux */
@@ -147,7 +148,7 @@ EXPORTED void idle_done_sock(void)
 {
     if (idle_sock >= 0) {
         close(idle_sock);
-        unlink(idle_local.sun_path);
+        xunlink(idle_local.sun_path);
         memset(&idle_local, 0, sizeof(struct sockaddr_un));
     }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -119,6 +119,7 @@
 #include "xstrlcpy.h"
 #include "ptrarray.h"
 #include "xstats.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -15034,7 +15035,7 @@ static void cmd_syncrestart(const char *tag, struct sync_reserve_list **reserve_
             if (!msg->fname) continue;
             pl = partition_list_add(res->part, pl);
 
-            unlink(msg->fname);
+            xunlink(msg->fname);
         }
     }
     sync_reserve_list_free(reserve_listp);

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -73,6 +73,7 @@
 #include "xstrlcat.h"
 #include "xstrlcpy.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
@@ -2174,7 +2175,7 @@ done:
     buf_free(&buf);
     if (tmpname) {
         /* Remove temp bytecode file */
-        unlink(tmpname);
+        xunlink(tmpname);
     }
     return 0;
 }

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -78,6 +78,7 @@
 #include "user.h"
 #include "util.h"
 #include "index.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -252,7 +253,7 @@ static int dump_index(struct mailbox *mailbox, int oldversion,
 
     close(oldindex_fd);
     r = dump_file(first, sync, pin, pout, oldname, "cyrus.index", NULL, 0);
-    unlink(oldname);
+    xunlink(oldname);
     if (r) return r;
 
     /* create cyrus.expunge */
@@ -283,7 +284,7 @@ static int dump_index(struct mailbox *mailbox, int oldversion,
 
         close(oldindex_fd);
         r = dump_file(first, sync, pin, pout, oldname, "cyrus.expunge", NULL, 0);
-        unlink(oldname);
+        xunlink(oldname);
         if (r) return r;
     }
 
@@ -292,7 +293,7 @@ static int dump_index(struct mailbox *mailbox, int oldversion,
 fail:
     if (oldindex_fd != -1)
         close(oldindex_fd);
-    unlink(oldname);
+    xunlink(oldname);
 
     return IMAP_IOERROR;
 }
@@ -1216,7 +1217,7 @@ EXPORTED int undump_mailbox(const char *mbname,
 
             free(seen_file);
             seen_file = NULL;
-            unlink(fnamebuf);
+            xunlink(fnamebuf);
 
             if (r) goto done;
         }
@@ -1226,7 +1227,7 @@ EXPORTED int undump_mailbox(const char *mbname,
             free(mboxkey_file);
             mboxkey_file = NULL;
 
-            unlink(fnamebuf);
+            xunlink(fnamebuf);
         }
 
         c = prot_getc(pin);

--- a/imap/mboxkey.c
+++ b/imap/mboxkey.c
@@ -64,6 +64,7 @@
 #include "xmalloc.h"
 #include "mailbox.h"
 #include "mboxkey.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -338,7 +339,7 @@ EXPORTED int mboxkey_delete_user(const char *user)
     }
 
     /* erp! */
-    r = unlink(fname);
+    r = xunlink(fname);
     if (r < 0 && errno == ENOENT) {
         syslog(LOG_DEBUG, "cannot unlink %s: %m", fname);
         /* but maybe the user just never read anything? */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -73,6 +73,7 @@
 #include "partlist.h"
 #include "xstrlcat.h"
 #include "user.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -5575,7 +5576,7 @@ EXPORTED int mboxlist_upgrade(int *upgraded)
     }
 
     /* open a new db file */
-    unlink(newfname);
+    xunlink(newfname);
     mboxlist_open(newfname);
 
     /* perform upgrade from backup to new db */
@@ -5713,7 +5714,7 @@ static int mboxlist_upgrade_subs_work(const char *userid, const char *subsfname,
         db_r = cyrusdb_open(SUBDB, subsfname, 0, subs);
     }
 
-    unlink(newsubsfname);
+    xunlink(newsubsfname);
     free(newsubsfname);
     buf_free(&buf);
 

--- a/imap/mupdate-slave.c
+++ b/imap/mupdate-slave.c
@@ -68,6 +68,7 @@
 #include "global.h"
 #include "mpool.h"
 #include "mupdate.h"
+#include "xunlink.h"
 
 /* Returns file descriptor of kick socket (or does not return) */
 static int open_kick_socket(void)
@@ -86,7 +87,7 @@ static int open_kick_socket(void)
     strlcpy(fnamebuf, config_dir, sizeof(fnamebuf));
     strlcat(fnamebuf, FNAME_MUPDATE_TARGET_SOCK, sizeof(fnamebuf));
 
-    (void) unlink(fnamebuf);
+    (void) xunlink(fnamebuf);
     memset((char *)&srvaddr, 0, sizeof(srvaddr));
     srvaddr.sun_family = AF_UNIX;
     strlcpy(srvaddr.sun_path, fnamebuf, sizeof(srvaddr.sun_path));

--- a/imap/proc.c
+++ b/imap/proc.c
@@ -59,6 +59,7 @@
 #include "retry.h"
 #include "util.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 #ifdef HAVE_DIRENT_H
 # include <dirent.h>
@@ -157,7 +158,7 @@ EXPORTED int proc_register(const char *servicename, const char *clienthost,
 
     if (rename(newfname, procfname)) {
         syslog(LOG_ERR, "IOERROR: renaming %s to %s: %m", newfname, procfname);
-        unlink(newfname);
+        xunlink(newfname);
         fatal("can't write proc file", EX_IOERR);
     }
 
@@ -170,7 +171,7 @@ EXPORTED int proc_register(const char *servicename, const char *clienthost,
 EXPORTED void proc_cleanup(void)
 {
     if (procfname) {
-        unlink(procfname);
+        xunlink(procfname);
         free(procfname);
         procfname = NULL;
     }

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -58,6 +58,7 @@
 #include "lib/map.h"
 #include "lib/ptrarray.h"
 #include "lib/util.h"
+#include "lib/xunlink.h"
 
 #include "imap/global.h"
 #include "imap/imap_err.h"
@@ -223,7 +224,7 @@ static void prometheus_done(void *rock __attribute__((unused)))
     mappedfile_unlock(promhandle->mf);
 
     /* unlink per-process stats file, we don't need it anymore */
-    r = unlink(mappedfile_fname(promhandle->mf));
+    r = xunlink(mappedfile_fname(promhandle->mf));
     if (r && errno != ENOENT) goto done;
     unlinked = 1;
 
@@ -261,7 +262,7 @@ done:
 
     /* release .doneprocs.lock */
     if (doneprocs_lock_fd != -1) {
-        unlink(doneprocs_lock_fname);
+        xunlink(doneprocs_lock_fname);
         lock_unlock(doneprocs_lock_fd, doneprocs_lock_fname);
         close(doneprocs_lock_fd);
     }

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -60,6 +60,7 @@
 #include "lib/retry.h"
 #include "lib/strarray.h"
 #include "lib/util.h"
+#include "lib/xunlink.h"
 
 #include "imap/global.h"
 #include "imap/mboxlist.h"
@@ -131,7 +132,7 @@ static int do_cleanup(void)
             continue;
         }
 
-        unlink(path);
+        xunlink(path);
     }
 
     closedir(dh);
@@ -280,7 +281,7 @@ static void do_collate_report(struct buf *buf)
                       hash_numrecords(&all_stats));
 
     /* release .doneprocs.lock */
-    unlink(doneprocs_lock_fname);
+    xunlink(doneprocs_lock_fname);
     lock_unlock(doneprocs_lock_fd, doneprocs_lock_fname);
     close(doneprocs_lock_fd);
     free(doneprocs_lock_fname);
@@ -728,7 +729,7 @@ int main(int argc, char **argv)
     report_fname = strconcat(prometheus_stats_dir(), FNAME_PROM_REPORT, NULL);
     syslog(LOG_DEBUG, "updating %s every %d seconds", report_fname, frequency);
 
-    unlink(report_fname);
+    xunlink(report_fname);
     r = mappedfile_open(&report_file, report_fname, MAPPEDFILE_CREATE | MAPPEDFILE_RW);
     free(report_fname);
     if (r) fatal("couldn't open report file", EX_IOERR);

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -84,6 +84,7 @@
 #include "quota.h"
 #include "convert_code.h"
 #include "util.h"
+#include "xunlink.h"
 #include <jansson.h>
 
 /* generated headers are not necessarily in current directory */
@@ -322,7 +323,7 @@ static void test_sync_done(const char *mboxname)
     syslog(LOG_ERR, "quota -Z done with %s", mboxname);
 
     filename = strconcat(config_dir, "/quota-sync/", mboxname, (char *)NULL);
-    unlink(filename);
+    xunlink(filename);
     free(filename);
 }
 

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -72,6 +72,7 @@
 #include "cyr_lock.h"
 #include "xapian_wrap.h"
 #include "command.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -263,7 +264,7 @@ static int activefile_write(struct mappedfile *mf, const strarray_t *new)
     if (r) goto done;
 
     r = mappedfile_rename(newfile, mappedfile_fname(mf));
-    if (r) unlink(newname);
+    if (r) xunlink(newname);
 
     /* we lose control over the lock here, so we have to release */
     mappedfile_unlock(mf);
@@ -4231,7 +4232,7 @@ static int delete_user(const mbentry_t *mbentry)
 
     struct delete_rock drock = { mbentry, mbname };
     config_foreachoverflowstring(delete_one, &drock);
-    unlink(activename);
+    xunlink(activename);
 
 out:
     if (activefile) {

--- a/imap/seen_db.c
+++ b/imap/seen_db.c
@@ -65,6 +65,7 @@
 #include "seen.h"
 #include "sync_log.h"
 #include "imparse.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -399,7 +400,7 @@ HIDDEN int seen_delete_user(const char *user)
                user);
     }
 
-    if (unlink(fname) && errno != ENOENT) {
+    if (xunlink(fname) && errno != ENOENT) {
         syslog(LOG_ERR, "error unlinking %s: %m", fname);
         r = IMAP_IOERROR;
     }

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -60,6 +60,7 @@
 #include "user.h"
 #include "util.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 #include "sieve/bytecode.h"
 #include "sieve/bc_parse.h"
@@ -846,7 +847,7 @@ static int migrate_cb(const char *sievedir,
 
             /* delete script */
             snprintf(path, sizeof(path), "%s/%s", sievedir, fname);
-            unlink(path);
+            xunlink(path);
 
             if (deletebc) {
                 sievedir_delete_script(sievedir, myname);

--- a/imap/sievedir.c
+++ b/imap/sievedir.c
@@ -60,6 +60,7 @@
 #include "sievedir.h"
 #include "util.h"
 #include "xstrlcpy.h"
+#include "xunlink.h"
 
 #ifdef USE_SIEVE
 #include "sieve/bc_parse.h"
@@ -244,7 +245,7 @@ EXPORTED int sievedir_activate_script(const char *sievedir, const char *name)
     if (rename(tmp, active) < 0) {
         xsyslog(LOG_ERR, "IOERROR: failed to rename active script link",
                 "oldpath=<%s> newpath=<%s>", tmp, active);
-        unlink(tmp);
+        xunlink(tmp);
         return SIEVEDIR_IOERROR;
     }
 
@@ -258,7 +259,7 @@ EXPORTED int sievedir_deactivate_script(const char *sievedir)
     assert(sievedir);
 
     snprintf(active, sizeof(active), "%s/defaultbc", sievedir);
-    if (unlink(active) != 0 && errno != ENOENT) {
+    if (xunlink(active) != 0 && errno != ENOENT) {
         xsyslog(LOG_ERR, "IOERROR: failed to delete active script link",
                 "link=<%s>", active);
         return SIEVEDIR_IOERROR;
@@ -275,7 +276,7 @@ EXPORTED int sievedir_delete_script(const char *sievedir, const char *name)
 
     /* delete bytecode */
     snprintf(path, sizeof(path), "%s/%s%s", sievedir, name, BYTECODE_SUFFIX);
-    if (unlink(path) != 0 && errno != ENOENT) {
+    if (xunlink(path) != 0 && errno != ENOENT) {
         xsyslog(LOG_ERR, "IOERROR: failed to delete bytecode file",
                 "path=<%s>", path);
         return SIEVEDIR_IOERROR;
@@ -344,7 +345,7 @@ EXPORTED int sievedir_put_script(const char *sievedir, const char *name,
     }
 
     /* make sure no stray hardlink is lying around */
-    unlink(new_bcpath);
+    xunlink(new_bcpath);
 
     /* open the new bytecode file */
     fd = open(new_bcpath, O_CREAT | O_TRUNC | O_WRONLY, 0600);
@@ -381,7 +382,7 @@ EXPORTED int sievedir_put_script(const char *sievedir, const char *name,
  done:
     if (fd >= 0) {
         close(fd);
-        if (r) unlink(new_bcpath);
+        if (r) xunlink(new_bcpath);
     }
     if (bc) sieve_free_bytecode(&bc);
     if (s) sieve_script_free(&s);

--- a/imap/squat_build.c
+++ b/imap/squat_build.c
@@ -103,6 +103,7 @@
 #include "util.h"
 #include "index.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 /* A simple write-buffering module which avoids copying of the output data. */
 
@@ -537,7 +538,7 @@ static int init_write_buffer_to_temp(SquatIndex *index,
         return SQUAT_ERR;
     }
 
-    if (unlink(tmp_path) < 0) {
+    if (xunlink(tmp_path) < 0) {
         squat_set_last_error(SQUAT_ERR_SYSERR);
         goto cleanup_fd;
     }

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -85,6 +85,7 @@
 #include "signals.h"
 #include "cyrusdb.h"
 #include "hash.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -196,7 +197,7 @@ static int do_daemon_work(const char *sync_shutdown_file,
 
         /* Check for shutdown file */
         if (sync_shutdown_file && !stat(sync_shutdown_file, &sbuf)) {
-            unlink(sync_shutdown_file);
+            xunlink(sync_shutdown_file);
             /* Have to exit with r == 0 or do_daemon() will call us again.
              * The value of r is unknown from calls to sync_log_reader_begin() below.
              */

--- a/imap/sync_log.c
+++ b/imap/sync_log.c
@@ -68,6 +68,7 @@
 #include "util.h"
 #include "xmalloc.h"
 #include "xstrlcpy.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -618,7 +619,7 @@ EXPORTED int sync_log_reader_end(sync_log_reader_t *slr)
          * log file we rename()d to the work file.  Now that
          * we've done with the work file we can unlink it.
          * Further checks at this point are just paranoia. */
-        if (slr->work_file && unlink(slr->work_file) < 0) {
+        if (slr->work_file && xunlink(slr->work_file) < 0) {
             syslog(LOG_ERR, "Unlink %s failed: %m", slr->work_file);
             return IMAP_IOERROR;
         }

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -99,6 +99,7 @@
 #include "version.h"
 #include "xmalloc.h"
 #include "xstrlcat.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -957,7 +958,7 @@ static void cmd_restart(struct sync_reserve_list **reserve_listp, int re_alloc)
         for (msg = res->list->head; msg; msg = msg->next) {
             if (!msg->fname) continue;
             pl = partition_list_add(res->part, pl);
-            unlink(msg->fname);
+            xunlink(msg->fname);
         }
     }
     sync_reserve_list_free(reserve_listp);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -81,6 +81,7 @@
 #include "strarray.h"
 #include "ptrarray.h"
 #include "sievedir.h"
+#include "xunlink.h"
 
 #ifdef USE_CALALARMD
 #include "caldav_alarm.h"
@@ -3320,7 +3321,7 @@ static int remove_cb(const char *sievedir, const char *fname,
     }
 
     snprintf(path, sizeof(path), "%s/%s", sievedir, fname);
-    unlink(path);
+    xunlink(path);
 
     return SIEVEDIR_OK;
 }

--- a/imap/user.c
+++ b/imap/user.c
@@ -87,6 +87,7 @@
 #include "xstrlcat.h"
 #include "xstrlcpy.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -233,7 +234,7 @@ static int delete_cb(const char *sievedir, const char *name,
 
     snprintf(path, sizeof(path), "%s/%s", sievedir, name);
 
-    unlink(path);
+    xunlink(path);
 
     return SIEVEDIR_OK;
 }

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -81,6 +81,7 @@
 #include "xmalloc.h"
 #include "xstrlcat.h"
 #include "xstrlcpy.h"
+#include "xunlink.h"
 
 #ifdef HAVE_SSL
 #include <openssl/ssl.h>
@@ -252,7 +253,7 @@ imtest_fatal(const char *msg, ...)
     if (output_socket && output_socket_opened &&
         stat(output_socket, &sbuf) != -1 &&
         sbuf.st_ino == output_socket_ino) {
-        unlink(output_socket);
+        xunlink(output_socket);
     }
     if (msg != NULL) {
         va_list ap;
@@ -1295,7 +1296,7 @@ static void interactive(struct protocol_t *protocol, char *filename)
         /* can't have this and a file for input */
         sunsock.sun_family = AF_UNIX;
         strlcpy(sunsock.sun_path, output_socket, sizeof(sunsock.sun_path));
-        unlink(output_socket);
+        xunlink(output_socket);
 
         listen_sock = socket(AF_UNIX, SOCK_STREAM, 0);
         if(listen_sock < 0) imtest_fatal("could not create output socket");
@@ -1524,7 +1525,7 @@ static void interactive(struct protocol_t *protocol, char *filename)
 
         if(stat(output_socket, &sbuf) != -1
            && sbuf.st_ino == output_socket_ino) {
-            unlink(output_socket);
+            xunlink(output_socket);
         }
     }
 

--- a/lib/cyrusdb.c
+++ b/lib/cyrusdb.c
@@ -61,6 +61,7 @@
 #include "libcyr_cfg.h"
 #include "xmalloc.h"
 #include "xstrlcpy.h"
+#include "xunlink.h"
 
 //#define DEBUGDB 1
 
@@ -543,7 +544,7 @@ EXPORTED int cyrusdb_convert(const char *fromfname, const char *tofname,
         tofname = newfname = strconcat(fromfname, ".NEW", NULL);
 
     /* remove any rubbish lying around */
-    unlink(tofname);
+    xunlink(tofname);
 
     r = cyrusdb_open(tobackend, tofname, CYRUSDB_CREATE, &todb);
     if (r) goto err;
@@ -583,7 +584,7 @@ err:
     if (fromtid) cyrusdb_abort(fromdb, fromtid);
     if (fromdb) cyrusdb_close(fromdb);
 
-    unlink(tofname);
+    xunlink(tofname);
     free(newfname);
 
     return r;
@@ -715,7 +716,7 @@ HIDDEN int cyrusdb_generic_noarchive(const strarray_t *fnames __attribute__((unu
 HIDDEN int cyrusdb_generic_unlink(const char *fname, int flags __attribute__((unused)))
 {
     if (fname)
-        unlink(fname);
+        xunlink(fname);
     /* XXX - check that it exists unless FORCE flag? */
     return 0;
 }

--- a/lib/cyrusdb_flat.c
+++ b/lib/cyrusdb_flat.c
@@ -65,6 +65,7 @@
 #include "xmalloc.h"
 #include "xstrlcpy.h"
 #include "xstrlcat.h"
+#include "xunlink.h"
 
 /* we have the file locked iff we have an outstanding transaction */
 
@@ -173,7 +174,7 @@ static int abort_txn(struct dbengine *db, struct txn *tid)
 
     /* cleanup done while lock is held */
     if (tid->fnamenew) {
-        unlink(tid->fnamenew);
+        xunlink(tid->fnamenew);
         free(tid->fnamenew);
         rw = 1;
     }
@@ -681,7 +682,7 @@ static int mystore(struct dbengine *db,
         strlcat(fnamebuf, ".NEW", sizeof(fnamebuf));
     }
 
-    unlink(fnamebuf);
+    xunlink(fnamebuf);
     r = writefd = open(fnamebuf, O_RDWR | O_CREAT, 0666);
     if (r < 0) {
         syslog(LOG_ERR, "opening %s for writing failed: %m", fnamebuf);

--- a/lib/cyrusdb_quotalegacy.c
+++ b/lib/cyrusdb_quotalegacy.c
@@ -93,6 +93,7 @@
 #include "xmalloc.h"
 #include "xstrlcpy.h"
 #include "xstrlcat.h"
+#include "xunlink.h"
 #include "strarray.h"
 
 #define FNAME_QUOTADIR "/quota/"
@@ -205,7 +206,7 @@ static int abort_subtxn(const char *fname, struct subtxn *tid)
 
     /* cleanup done while lock is held */
     if (tid->fnamenew) {
-        unlink(tid->fnamenew);
+        xunlink(tid->fnamenew);
         free(tid->fnamenew);
     }
 
@@ -262,7 +263,7 @@ static int commit_subtxn(const char *fname, struct subtxn *tid)
         free(tid->fnamenew);
     } else if (tid->delete) {
         /* delete file */
-        r = unlink(fname);
+        r = xunlink(fname);
         if (r == -1) {
             xsyslog(LOG_ERR, "IOERROR: unlink failed",
                              "fname=<%s>",
@@ -760,7 +761,7 @@ static int mystore(struct dbengine *db,
             strlcpy(new_quota_path, quota_path, sizeof(new_quota_path));
             strlcat(new_quota_path, ".NEW", sizeof(new_quota_path));
 
-            unlink(new_quota_path);
+            xunlink(new_quota_path);
             newfd = open(new_quota_path, O_CREAT | O_TRUNC | O_RDWR, 0666);
             if (newfd == -1 && errno == ENOENT) {
                 if (cyrus_mkdir(new_quota_path, 0755) != -1)

--- a/lib/cyrusdb_skiplist.c
+++ b/lib/cyrusdb_skiplist.c
@@ -68,6 +68,7 @@
 #include "retry.h"
 #include "util.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 #define PROB (0.5)
 
@@ -235,7 +236,7 @@ static int myinit(const char *dbdir, int myflags)
          * everything */
         if (stat(cleanfile, &sbuf) == 0) {
             syslog(LOG_NOTICE, "skiplist: clean shutdown detected, starting normally");
-            unlink(cleanfile);
+            xunlink(cleanfile);
             goto normal;
         }
 
@@ -1853,7 +1854,7 @@ static int mycheckpoint(struct dbengine *db)
         /* clean up */
         close(db->fd);
         db->fd = oldfd;
-        unlink(fname);
+        xunlink(fname);
     }
     else {
         struct stat sbuf;

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -61,6 +61,7 @@
 #include "mappedfile.h"
 #include "util.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 
 /*
  * twoskip disk format.
@@ -1944,7 +1945,7 @@ static int mycheckpoint(struct dbengine *db)
 
     /* open fname.NEW */
     snprintf(newfname, sizeof(newfname), "%s.NEW", FNAME(db));
-    unlink(newfname);
+    xunlink(newfname);
 
     cr.db = NULL;
     cr.tid = NULL;
@@ -1999,7 +2000,7 @@ static int mycheckpoint(struct dbengine *db)
 
  err:
     if (cr.tid) myabort(cr.db, cr.tid);
-    unlink(FNAME(cr.db));
+    xunlink(FNAME(cr.db));
     dispose_db(cr.db);
     unlock(db);
     return CYRUSDB_IOERROR;
@@ -2251,7 +2252,7 @@ static int recovery2(struct dbengine *db, int *count)
 
     /* open fname.NEW */
     snprintf(newfname, sizeof(newfname), "%s.NEW", FNAME(db));
-    unlink(newfname);
+    xunlink(newfname);
 
     r = opendb(newfname, db->open_flags | CYRUSDB_CREATE, &newdb, NULL);
     if (r) return r;
@@ -2326,7 +2327,7 @@ static int recovery2(struct dbengine *db, int *count)
     return 0;
 
  err:
-    unlink(FNAME(newdb));
+    xunlink(FNAME(newdb));
     myclose(newdb);
     return r;
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -78,6 +78,7 @@
 #include "util.h"
 #include "assert.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 #ifdef HAVE_ZLIB
 #include "zlib.h"
 #endif
@@ -479,7 +480,7 @@ EXPORTED int create_tempfile(const char *path)
     pattern = strconcat(path, "/cyrus_tmpfile_XXXXXX", (char *)NULL);
 
     fd = mkstemp(pattern);
-    if (fd >= 0 && unlink(pattern) == -1) {
+    if (fd >= 0 && xunlink(pattern) == -1) {
         close(fd);
         fd = -1;
     }
@@ -570,7 +571,7 @@ static int _copyfile_helper(const char *from, const char *to, int flags)
     if (!nolink) {
         if (link(from, to) == 0) return 0;
         if (errno == EEXIST) {
-            if (unlink(to) == -1) {
+            if (xunlink(to) == -1) {
                 xsyslog(LOG_ERR, "IOERROR: unlinking to recreate failed",
                                  "filename=<%s>", to);
                 return -1;
@@ -618,7 +619,7 @@ static int _copyfile_helper(const char *from, const char *to, int flags)
         xsyslog(LOG_ERR, "IOERROR: retry_write failed",
                          "filename=<%s>", to);
         r = -1;
-        unlink(to);  /* remove any rubbish we created */
+        xunlink(to);  /* remove any rubbish we created */
         goto done;
     }
 
@@ -677,7 +678,7 @@ EXPORTED int cyrus_copyfile(const char *from, const char *to, int flags)
 
     if (!r && (flags & COPYFILE_RENAME)) {
         /* remove the original file if the copy succeeded */
-        unlink(from);
+        xunlink(from);
     }
 
     return r;

--- a/lib/xunlink.c
+++ b/lib/xunlink.c
@@ -1,0 +1,99 @@
+/* xunlink.c -- error-logging unlink wrapper
+ *
+ * Copyright (c) 1994-2023 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+
+#include <errno.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+#include "lib/xunlink.h"
+
+EXPORTED int xunlink_fn(const char *sfile, int sline, const char *sfunc,
+                        const char *pathname)
+{
+    int saved_errno, r;
+
+    r = unlink(pathname);
+    saved_errno = errno;
+
+    if (r && saved_errno != ENOENT) {
+        /* n.b. not simply using xsyslog, because we want to log our caller's
+         * location, but xsyslog would log ours
+         */
+        syslog(LOG_ERR, "IOERROR: unlink failed: pathname=<%s> syserror=<%s>"
+                        " file=<%s> line=<%d> func=<%s>",
+                        pathname, strerror(saved_errno),
+                        sfile, sline, sfunc);
+
+        /* if you want to abort() on unlink failure, patch that in here */
+    }
+
+    errno = saved_errno;
+    return r;
+}
+
+EXPORTED int xunlinkat_fn(const char *sfile, int sline, const char *sfunc,
+                          int dirfd, const char *pathname, int flags)
+{
+    int saved_errno, r;
+
+    r = unlinkat(dirfd, pathname, flags);
+    saved_errno = errno;
+
+    if (r && saved_errno != ENOENT) {
+        /* n.b. not simply using xsyslog, because we want to log our caller's
+         * location, but xsyslog would log ours
+         */
+        syslog(LOG_ERR, "IOERROR: unlinkat failed:"
+                        " dirfd=<%d> pathname=<%s> flags=<%d> syserror=<%s>"
+                        " file=<%s> line=<%d> func=<%s>",
+                        dirfd, pathname, flags, strerror(saved_errno),
+                        sfile, sline, sfunc);
+
+        /* if you want to abort() on unlinkat failure, patch that in here */
+    }
+
+    errno = saved_errno;
+    return r;
+}

--- a/lib/xunlink.h
+++ b/lib/xunlink.h
@@ -1,0 +1,67 @@
+/* xunlink.h -- error-logging unlink wrapper
+ *
+ * Copyright (c) 1994-2023 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef INCLUDED_XUNLINK_H
+#define INCLUDED_XUNLINK_H
+
+/**
+ * Error-logging wrappers for unlink(2) and unlinkat(2).
+ *
+ * N.B. These are NOT "error-handling" wrappers; you still must check the
+ * return value, errno, etc, and handle errors accordingly!
+ *
+ * These wrappers present the same interface as the original functions,
+ * but will also log an error if the original function did anything
+ * other than succeed or fail-due-to-ENOENT
+ **/
+
+#define xunlink(pathname)                                                     \
+    xunlink_fn(__FILE__, __LINE__, __func__, (pathname))
+#define xunlinkat(dirfd, pathname, flags)                                     \
+    xunlinkat_fn(__FILE__, __LINE__, __func__, (dirfd), (pathname), (flags))
+
+extern int xunlink_fn(const char *sfile, int sline, const char *sfunc,
+                      const char *pathname);
+extern int xunlinkat_fn(const char *sfile, int sline, const char *sfunc,
+                        int dirfd, const char *pathname, int flags);
+
+#endif

--- a/master/master.c
+++ b/master/master.c
@@ -98,6 +98,7 @@
 #include "retry.h"
 #include "util.h"
 #include "xmalloc.h"
+#include "xunlink.h"
 #include "strarray.h"
 
 enum {
@@ -546,7 +547,7 @@ static void service_create(struct service *s, int is_startup)
                   "over-long listen path not detected earlier!",
                   EX_SOFTWARE);
         }
-        unlink(s->listen);
+        xunlink(s->listen);
     } else { /* inet socket */
         char *port;
         char *listen_addr;
@@ -2932,7 +2933,7 @@ int main(int argc, char **argv)
      *     exit(failure)
      * [B] write pid to pidfile
      * [B] write success code to pipe & finish starting up
-     * [A] unlink pidfile.lock and exit(code read from pipe)
+     * [A] xunlink pidfile.lock and exit(code read from pipe)
      *
      */
     if(daemon_mode) {
@@ -2986,10 +2987,10 @@ int main(int argc, char **argv)
             /* Parent, wait for child */
             if(read(startup_pipe[0], &exit_code, sizeof(exit_code)) == -1) {
                 syslog(LOG_ERR, "could not read from startup_pipe (%m)");
-                unlink(pidfile_lock);
+                xunlink(pidfile_lock);
                 exit(EX_OSERR);
             } else {
-                unlink(pidfile_lock);
+                xunlink(pidfile_lock);
                 exit(exit_code);
             }
         }

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -75,6 +75,7 @@
 #include "xmalloc.h"
 #include "xstrlcat.h"
 #include "xstrlcpy.h"
+#include "xunlink.h"
 #include "hash.h"
 #include "times.h"
 
@@ -826,7 +827,7 @@ int main(int argc, char *argv[])
 
     if (tmpscript) {
         /* Remove temp bytecode file */
-        unlink(tmpscript);
+        xunlink(tmpscript);
     }
 
     if (message) {

--- a/sieve/test_mailbox.c
+++ b/sieve/test_mailbox.c
@@ -76,6 +76,7 @@
 #include "xmalloc.h"
 #include "xstrlcat.h"
 #include "xstrlcpy.h"
+#include "xunlink.h"
 #include "hash.h"
 #include "times.h"
 
@@ -733,7 +734,7 @@ int main(int argc, char *argv[])
 
     if (tmpscript) {
         /* Remove temp bytecode file */
-        unlink(tmpscript);
+        xunlink(tmpscript);
     }
 
     if (extname) {


### PR DESCRIPTION
@brong suspects a weird problem we saw last week may have been due to ZFS rejecting an `unlink()`, and then things being left behind that we assumed were gone.  We can't tell though, because most of our code never even checks whether `unlink()` succeeded or not.  This is bad, but is a big and tricky problem to fix properly.

This PR doesn't fix it, but it does add logging to every `unlink()` call (and every `unlinkat()` call, but we don't currently use that), such that if the result is anything other than "success" or "failed because the file to unlink didn't exist", we'll log an IOERROR.  And if it happens again, it'll be in the logs.

It tries hard to present _exactly the same_ interface as `unlink()` itself, so that if/when we do add proper error handling, the code to do so should be identical regardless

No tests, because cunit can't mock system calls, so I can't usefully fake unlink errors :(

**Note to reviewers**: I'd suggest reviewing this commit-by-commit.  The first commit contains the new code, is interesting, and needs careful review; the second is the mind-numbing update of every extant call to `unlink()`, which also needs careful review, but is boring :)