### PR TITLE
cyr_buildinfo: add version category with some version details

### DIFF
--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -52,11 +52,20 @@
 #include <sysexits.h>
 #include <jansson.h>
 
-#include "global.h"
-#include "proc.h"
-#include "util.h"
-#include "../master/masterconf.h"
-#include "xmalloc.h"
+#include "lib/util.h"
+#include "lib/xmalloc.h"
+
+#include "imap/conversations.h"
+#include "imap/global.h"
+#include "imap/mailbox.h"
+#include "imap/proc.h"
+#include "imap/statuscache.h"
+#include "imap/zoneinfo_db.h"
+
+#include "master/masterconf.h"
+
+#include "sieve/bytecode.h"
+#include "sieve/sieve_interface.h"
 
 /* Make ld happy */
 const char *MASTER_CONFIG_FILENAME = DEFAULT_MASTER_CONFIG_FILENAME;
@@ -84,12 +93,14 @@ static json_t *buildinfo()
     json_t *search = json_object();
     json_t *hardware = json_object();
     json_t *buildconf = json_object();
+    json_t *version = json_object();
 
     json_object_set_new(buildconf, "component", component);
     json_object_set_new(buildconf, "dependency", dependency);
     json_object_set_new(buildconf, "database", database);
     json_object_set_new(buildconf, "search", search);
     json_object_set_new(buildconf, "hardware", hardware);
+    json_object_set_new(buildconf, "version", version);
 
     /* Yikes... */
 
@@ -278,6 +289,35 @@ static json_t *buildinfo()
 #endif
     json_object_set_new(search, "xapian_cjk_tokens", json_string(XAPIAN_CJK_TOKENS));
 
+    /* Internal version numbers */
+    json_object_set_new(version, "BYTECODE_MIN_VERSION",
+                                 json_integer(BYTECODE_MIN_VERSION));
+    json_object_set_new(version, "BYTECODE_VERSION",
+                                 json_integer(BYTECODE_VERSION));
+    json_object_set_new(version, "CONVERSATIONS_KEY_VERSION",
+                                 json_integer(CONVERSATIONS_KEY_VERSION));
+    json_object_set_new(version, "CONVERSATIONS_RECORD_VERSION",
+                                 json_integer(CONVERSATIONS_RECORD_VERSION));
+    json_object_set_new(version, "CONVERSATIONS_STATUS_VERSION",
+                                 json_integer(CONVERSATIONS_STATUS_VERSION));
+    json_object_set_new(version, "CONV_GUIDREC_BYNAME_VERSION",
+                                 json_integer(CONV_GUIDREC_BYNAME_VERSION));
+    json_object_set_new(version, "CONV_GUIDREC_VERSION",
+                                 json_integer(CONV_GUIDREC_VERSION));
+    json_object_set_new(version, "CYRUS_VERSION",
+                                 json_string(CYRUS_VERSION));
+    json_object_set_new(version, "MAILBOX_CACHE_MINOR_VERSION",
+                                 json_integer(MAILBOX_CACHE_MINOR_VERSION));
+    json_object_set_new(version, "MAILBOX_MINOR_VERSION",
+                                 json_integer(MAILBOX_MINOR_VERSION));
+    json_object_set_new(version, "SIEVE_VERSION",
+                                 json_string(SIEVE_VERSION));
+    json_object_set_new(version, "STATUSCACHE_VERSION",
+                                 json_integer(STATUSCACHE_VERSION));
+    json_object_set_new(version, "ZONEINFO_VERSION",
+                                 json_integer(ZONEINFO_VERSION));
+
+    /* Whew ... */
     return buildconf;
 }
 


### PR DESCRIPTION
Add some version details to the data output by cyr_buildinfo

Build wrappers might use this to detect unexpected version changes