### PR TITLE
http_dav.c: don't need 'x'/'k' right on cal/abook to advertise [un]bind

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -5650,4 +5650,52 @@ EOF
     $self->assert_equals(1, scalar @$events);
 }
 
+sub test_dav_bind
+    :min_version_3_9 :needs_component_httpd
+{
+    my ($self) = @_;
+
+    my $CalDAV = $self->{caldav};
+
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $admintalk->create("user.manifold");
+    $admintalk->setacl("user.manifold", admin => 'lrswipkxtecdan');
+    $admintalk->setacl("user.manifold", manifold => 'lrswipkxtecdn');
+
+    my $service = $self->{instance}->get_service("http");
+    my $mantalk = Net::CalDAVTalk->new(
+        user => "manifold",
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    xlog $self, "create calendar";
+    my $CalendarId = $mantalk->NewCalendar({name => 'Manifold Calendar'});
+    $self->assert_not_null($CalendarId);
+
+    xlog $self, "share to user (without 'k' or 'x')";
+    $admintalk->setacl("user.manifold.#calendars.$CalendarId", "cassandane" => 'lrspwiten');
+
+    my $propfindXml = <<EOF;
+<?xml version="1.0" encoding="UTF-8"?>
+<D:propfind xmlns:D="DAV:">
+  <D:prop>
+    <D:current-user-privilege-set/>
+  </D:prop>
+</D:propfind>
+EOF
+
+    # Assert that {DAV:}bind and {DAV:}unbind are present.
+    my $res = $CalDAV->Request('PROPFIND', "/dav/calendars/user/cassandane/manifold.". $CalendarId,
+                               $propfindXml, 'Content-Type' => 'text/xml');
+    my $text = Dumper($res);
+    $self->assert_matches(qr/{DAV:}bind/, $text);
+    $self->assert_matches(qr/{DAV:}unbind/, $text);
+}
+
 1;


### PR DESCRIPTION
This fixes a bug where some clients wouldn't allow a sharee to delete events if the sharee didn't also have the right to delete the calendar