### PR TITLE
JMAP Email: destroying an already destroyed email should return notFound

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email-set-destroy
+++ b/cassandane/tiny-tests/JMAPEmail/email-set-destroy
@@ -75,4 +75,13 @@ sub test_email_set_destroy
     xlog $self, "Get emails";
     $res = $jmap->CallMethods([['Email/query', {}, "R1"]]);
     $self->assert_num_equals(0, scalar @{$res->[0][1]->{ids}});
+
+    my ($maj, $min) = Cassandane::Instance->get_version();
+    if ($maj > 3 || ($maj == 3 && $min >= 9)) {
+        xlog $self, "Attempt to destroy draft $id again";
+        $res = $jmap->CallMethods(
+            [ [ 'Email/set', { destroy => [ $id ] }, "R1" ] ],
+            );
+        $self->assert_not_null($id, $res->[0][1]{notDestroyed}{$id});
+    }
 }


### PR DESCRIPTION
Fixes an issue discovered by FM UI