### PR TITLE
Fix iter-startuid off by one issue

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -3367,8 +3367,10 @@ EXPORTED int index_copy_remote(struct index_state *state, char *sequence,
 /*
  * Returns the msgno of the message with UID corresponding to 'uid', based on 'mode'
  * If mode is EQ, msgno with             UID == 'uid', otherwise 0
- * If mode is GE, msgno with the lowest  UID >= 'uid'
- * If mode is LE, msgno with the highest UID <= 'uid'
+ * If mode is GE, msgno with the lowest  UID >= 'uid', which is never zero,
+ *                                                     but may be past the end
+ * If mode is LE, msgno with the highest UID <= 'uid', which may be zero,
+ *                                                     but never past the end
  */
 EXPORTED uint32_t index_finduid(struct index_state *state, uint32_t uid, int mode)
 {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2451,6 +2451,8 @@ static uint32_t mailbox_getuid(struct mailbox *mailbox, uint32_t recno)
  * Returns the recno of the message with UID 'uid'.
  * If no message with UID 'uid', returns the message with
  * the highest UID not greater than 'uid'.
+ * NOTE: this function can return 0 if 'uid' is less than
+ * the UID of the first record in the mailbox
  */
 static uint32_t mailbox_finduid(struct mailbox *mailbox, uint32_t uid)
 {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -7996,8 +7996,22 @@ EXPORTED struct mailbox_iter *mailbox_iter_init(struct mailbox *mailbox,
 
 EXPORTED void mailbox_iter_startuid(struct mailbox_iter *iter, uint32_t uid)
 {
-    struct mailbox *mailbox = iter->mailbox;
-    iter->recno = uid ? mailbox_finduid(mailbox, uid) : 1;
+    if (!uid) {
+        iter->recno = 1;
+        return;
+    }
+
+    iter->recno = mailbox_finduid(iter->mailbox, uid);
+    if (iter->recno) {
+        // check we're not looking at an earlier message again
+        message_set_from_mailbox(iter->mailbox, iter->recno, iter->msg);
+        const struct index_record *record = msg_record(iter->msg);
+        if (record->uid < uid) iter->recno++;
+    }
+    else {
+        // uid was before the UID of the first message, so begin there
+        iter->recno = 1;
+    }
 }
 
 EXPORTED void mailbox_iter_uidset(struct mailbox_iter *iter, seqset_t *seq)


### PR DESCRIPTION
This was completely breaking indexing mailboxes that didn't have UID 1 in them any more, because iter_startuid being called with `1` led to setting iter->recno to zero, and it mailbox_iter_step would return NULL immediately!

Also, if the called UID wasn't in the mailbox, it would replay the previous message, which isn't what we ever want.