### PR TITLE
Html tag colon

### DIFF
--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -1464,7 +1464,7 @@ sub test_html_only
         mime_type => "text/html",
         body => ""
           . "<html xmlns:o=\"urn:schemas-microsoft-com:office:office\">\r\n"
-          . "<div>This is an html <o:p>LL123</o:p> body.</div>\r\n"
+          . "<div>This is an html <o:p>LL123</o:p> <h11>xyzzy</h11> body.</div>\r\n"
           . "</html"
 
     ) || die;
@@ -1483,6 +1483,12 @@ sub test_html_only
 
     # make sure the real token gets indexed
     $uids = $talk->search('fuzzy', 'body', 'LL123') || die;
+    $self->assert_deep_equals([1], $uids);
+
+    # make sure the h11 doesn't leak
+    $uids = $talk->search('fuzzy', 'body', 'xyzzy1') || die;
+    $self->assert_deep_equals([], $uids);
+    $uids = $talk->search('fuzzy', 'body', 'xyzzy') || die;
     $self->assert_deep_equals([1], $uids);
 }
 

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -1505,7 +1505,8 @@ restart:
             html_pop(s);
             html_saw_tag(rock);
         }
-        else if (html_isalpha(c)) {
+        // might be a namespaced tag
+        else if (html_isalpha(c) || c == ':') {
             buf_putc(&s->name, c);
         }
         else {

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -1505,8 +1505,9 @@ restart:
             html_pop(s);
             html_saw_tag(rock);
         }
-        // might be a namespaced tag
-        else if (html_isalpha(c) || c == ':') {
+        // HTML only allows alpha and digit, but XML allows namespaces and at least
+        // outlook creates those, and we may as well handle - and _ as well.
+        else if (html_isalpha(c) || html_isdigit(c) || c == ':' || c == '-' || c == '_') {
             buf_putc(&s->name, c);
         }
         else {


### PR DESCRIPTION
The HTML parser wasn't handling : in tag names, which is legit because you can have namespaces in Outlook-generated emails.  This was found by a user who had an email very much like the test case I added as part of this.  Confirmed fixed by this test.