### PR TITLE
Sieve: remove support for legacy notify & denotify actions

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -267,7 +267,7 @@ sub test_vacation_with_following_rules
     xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
     $self->{instance}->install_sieve_script(<<'EOF'
 
-require ["fileinto", "reject", "vacation", "imap4flags", "notify", "envelope", "relational", "regex", "subaddress", "copy", "mailbox", "mboxmetadata", "servermetadata", "date", "index", "comparator-i;ascii-numeric", "variables"];
+require ["fileinto", "reject", "vacation", "imap4flags", "envelope", "relational", "regex", "subaddress", "copy", "mailbox", "mboxmetadata", "servermetadata", "date", "index", "comparator-i;ascii-numeric", "variables"];
 
 ### 5. Sieve generated for vacation responses
 if
@@ -2315,7 +2315,7 @@ sub test_github_issue_complex_variables
 
     xlog $self, "Install a sieve script with complex variable work";
     $self->{instance}->install_sieve_script(<<'EOF');
-require ["fileinto", "reject", "vacation", "notify", "envelope", "body", "relational", "regex", "subaddress", "copy", "mailbox", "mboxmetadata", "servermetadata", "date", "index", "comparator-i;ascii-numeric", "variables", "imap4flags", "editheader", "duplicate", "vacation-seconds"];
+require ["fileinto", "reject", "vacation", "envelope", "body", "relational", "regex", "subaddress", "copy", "mailbox", "mboxmetadata", "servermetadata", "date", "index", "comparator-i;ascii-numeric", "variables", "imap4flags", "editheader", "duplicate", "vacation-seconds"];
 
 ### BEGIN USER SIEVE
 ### GitHub
@@ -3659,15 +3659,14 @@ EOF
     $self->check_messages({ 1 => $msg1 }, check_guid => 0);
 }
 
-sub test_notify
+sub test_enotify
     :needs_component_sieve :min_version_3_2
 {
     my ($self) = @_;
 
     $self->{instance}->install_sieve_script(<<'EOF'
-require ["notify", "enotify"];
+require ["enotify"];
 
-notify :method "addcal" :options ["calendarId","6ae6a9e0-53f5-4559-8c5a-520208f86cfd"];
 notify "https://cyrusimap.org/notifiers/updatecal";
 notify "mailto:foo@example.com";
 EOF
@@ -3678,11 +3677,9 @@ EOF
     $self->{instance}->deliver($msg1);
 
     my $data = $self->{instance}->getnotify();
-    my ($addcal) = grep { $_->{METHOD} eq 'addcal' } @$data;
     my ($updatecal) = grep { $_->{METHOD} eq 'updatecal' } @$data;
     my ($mailto) = grep { $_->{METHOD} eq 'mailto' } @$data;
 
-    $self->assert_not_null($addcal);
     $self->assert_not_null($updatecal);
     $self->assert_not_null($mailto);
 }

--- a/changes/next/deprecate_sieve_notify
+++ b/changes/next/deprecate_sieve_notify
@@ -1,0 +1,18 @@
+Description:
+
+Removes support for parsing and generating bytecode for the deprecated
+denotify action and notify actions using the legacy (pre-RFC5435) syntax.
+Existing bytecode containing these actions will still be executed.
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+Scripts that contain the deprecated denotify action should be rewritten
+to remove them.
+Scripts that contain notify actions using the legacy syntax should be rewritten
+to use the syntax in RFC5435.

--- a/docsrc/imap/reference/manpages/systemcommands/sieved.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/sieved.rst
@@ -31,6 +31,8 @@ Options
 .. option:: -s, --as-sieve
 
    Produce a sieve script rather than describing the bytecode.
+   Note that if the bytecode contains deprecated features,
+   the resulting script will not be compilable without changes.
 
 See Also
 ========

--- a/docsrc/imap/rfc-support.rst
+++ b/docsrc/imap/rfc-support.rst
@@ -948,10 +948,6 @@ draft-ietf-sieve-regex
 
     Sieve Email Filtering -- Regular Expression Extension
 
-draft-martin-sieve-notify
-
-    Sieve -- An extension for providing instant notifications
-
 draft-york-vpoll
 
     VPOLL: Consensus Scheduling Component for iCalendar

--- a/sieve/bc_emit.c
+++ b/sieve/bc_emit.c
@@ -512,8 +512,6 @@ static int bc_action_emit(int fd, int codep, int stopcodep,
         case B_ADDFLAG:
         case B_REMOVEFLAG:
         case B_ENOTIFY:
-        case B_NOTIFY:
-        case B_DENOTIFY:
         case B_VACATION:
         case B_INCLUDE:
         case B_SET:

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -212,13 +212,13 @@ enum bytecode {
 
                                    <flag-list: string-list>                    */
 
-    B_NOTIFY,                   /* require "notify"
+    B_NOTIFY,                   /* require "notify" (deprecated - eval only)
 
                                    <method: string> <id: string>
                                    <options: string-list> <priority: int>
                                    <message: string>                           */
 
-    B_DENOTIFY,                 /* require "notify"
+    B_DENOTIFY,                 /* require "notify" (deprecated - eval only)
                                    <priority: int>
                                    <match-type: int> <relational-match: int>
                                    <pattern: string>                           */

--- a/sieve/interp.c
+++ b/sieve/interp.c
@@ -492,7 +492,7 @@ static const struct sieve_capa_t {
 
     /* Notifications - RFC 5435 */
     { "enotify", SIEVE_CAPA_ENOTIFY },
-    { "notify",  SIEVE_CAPA_NOTIFY }, /* draft-martin-sieve-notify-01 */
+    { "notify",  SIEVE_CAPA_NOTIFY }, /* deprecated draft-martin-sieve-notify-01 */
 
     /* Ihave - RFC 5463 */
     { "ihave", SIEVE_CAPA_IHAVE },

--- a/sieve/interp.h
+++ b/sieve/interp.h
@@ -160,7 +160,7 @@ enum sieve_capa_flag {
 
     /* Notifications - RFC 5435 */
     SIEVE_CAPA_ENOTIFY      = 1LL<<23,
-    SIEVE_CAPA_NOTIFY       = 1LL<<24, /* draft-martin-sieve-notify-01 */
+    SIEVE_CAPA_NOTIFY       = 0LL<<24, /* deprecated draft-martin-sieve-notify-01 */
 
     /* Ihave - RFC 5463 */
     SIEVE_CAPA_IHAVE        = 1LL<<25,

--- a/sieve/sieve-lex.l
+++ b/sieve/sieve-lex.l
@@ -311,14 +311,6 @@ ws              [ \t]+
                                                "invalid importance %s", yytext);
                               }
 
-    /* notify - draft-martin-sieve-notify-01 */
-<INITIAL>denotify             return DENOTIFY;
-<INITIAL>:method              return METHOD;
-<INITIAL>:id                  return NID;
-<INITIAL>:low                 return yylval->nval = LOW;
-<INITIAL>:normal              return yylval->nval = NORMAL;
-<INITIAL>:high                return yylval->nval = HIGH;
-
     /* ihave - RFC 5463 */
 <INITIAL>ihave                return IHAVE;
 <INITIAL>error                return ERROR;

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -1492,6 +1492,13 @@ static int generate_block(bytecode_input_t *bc, int pos, int end,
             break;
 
         case B_DENOTIFY:
+            generate_token("/*\n", indent, buf);
+            generate_token(" * NOTE: The DENOTIFY action has been deprecated since Cyrus v3.9.\n",
+                           indent, buf);
+            generate_token(" *       This script will no longer compile.\n",
+                           indent, buf);
+            generate_token(" */\n", indent, buf);
+
             *requires |= SIEVE_CAPA_NOTIFY;
             generate_token("denotify", indent, buf);
             if (cmd.u.d.pattern) {
@@ -1518,6 +1525,15 @@ static int generate_block(bytecode_input_t *bc, int pos, int end,
             break;
 
         case B_NOTIFY:
+            generate_token("/*\n", indent, buf);
+            generate_token(" * NOTE: This form of the NOTIFY action has been deprecated since Cyrus v3.9.\n",
+                           indent, buf);
+            generate_token(" *       This script will no longer compile.\n",
+                           indent, buf);
+            generate_token(" *       Update this action to use the syntax in RFC 5435. */\n",
+                           indent, buf);
+            generate_token(" */\n", indent, buf);
+
             *requires |= SIEVE_CAPA_NOTIFY;
             generate_token("notify", indent, buf);
             generate_string(":method", cmd.u.n.method, buf);

--- a/sieve/tree.c
+++ b/sieve/tree.c
@@ -268,17 +268,9 @@ commandlist_t *new_command(int type, sieve_script_t *parse_script)
         supported = parse_script->support & SIEVE_CAPA_IMAP4FLAGS;
         break;
 
-    case B_DENOTIFY:
-        capability = "notify";
-        supported = parse_script->support & SIEVE_CAPA_NOTIFY;
-        init_comptags(&p->u.d.comp);
-        p->u.d.comp.collation = B_ASCIICASEMAP;
-        p->u.d.priority = -1;
-        break;
-
-    case B_NOTIFY:
     case B_ENOTIFY:
-        /* actual type and availability will be determined by parser */
+        capability = "enotify";
+        supported = parse_script->support & SIEVE_CAPA_ENOTIFY;
         p->u.n.priority = -1;
         break;
 


### PR DESCRIPTION
This removes parsing and generating bytecode for the legacy and notify and denotify actions, but will still execute them in already compiled bytecode.

The only outstanding question is if `sieved -s` should spit out legacy notify/denotify actions or replace denotify with a comment and update notify to use enotify syntax.

DO NOT merge this until the Fastmail UI has been updated to using enotify syntax.