### PR TITLE
jmap_ical.c: don't add RECURRENCE-ID property for recurrenceId:null

### DIFF
--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -4246,7 +4246,7 @@ startend_to_ical(icalcomponent *comp, struct jmap_parser *parser,
         icalcomponent_add_property(comp, prop);
     }
 
-    if (json_object_get(event, "recurrenceId")) {
+    if (!jmapical_datetime_has_zero_time(&recurid)) {
         /* Add RECURRENCE-ID */
         struct icaltimetype icalrecurid = is_date ?
             jmapical_datetime_to_icaldate(&recurid) :


### PR DESCRIPTION
This fixes a bug where JSCalendar event id would end up being something like id:"ER-00000000T000000-abcd"