### PR TITLE
Jmap move deleted parent

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -1375,6 +1375,79 @@ sub test_mailbox_set_order
     $self->assert_null($res->[0][1]{notDestroyed});
 }
 
+sub test_mailbox_move_to_deleted_parent
+    :min_version_3_8 :needs_component_jmap
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+
+    # Assert mailboxes are created in the right order.
+    my $RawRequest = {
+        headers => {
+            'Authorization' => $jmap->auth_header(),
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        },
+        content => '{
+            "using" : ["urn:ietf:params:jmap:mail"],
+            "methodCalls" : [["Mailbox/set", {
+                "create" : {
+                    "C" : {
+                        "name" : "C", "parentId" : "#B", "role" : null
+                    },
+                    "B" : {
+                        "name" : "B", "parentId" : null, "role" : null
+                    },
+                    "A" : {
+                        "name" : "A", "parentId" : null, "role" : null
+                    }
+                }
+            }, "R1"]]
+        }',
+    };
+    my $RawResponse = $jmap->ua->post($jmap->uri(), $RawRequest);
+    if ($ENV{DEBUGJMAP}) {
+        warn "JMAP " . Dumper($RawRequest, $RawResponse);
+    }
+    $self->assert($RawResponse->{success});
+
+    my $res = eval { decode_json($RawResponse->{content}) };
+    $res = $res->{methodResponses};
+    $self->assert_not_null($res->[0][1]{created}{A});
+    $self->assert_not_null($res->[0][1]{created}{B});
+    $self->assert_not_null($res->[0][1]{created}{C});
+    my $idA = $res->[0][1]{created}{A}{id};
+    my $idB = $res->[0][1]{created}{B}{id};
+    my $idC = $res->[0][1]{created}{C}{id};
+
+    # Destroy "A"
+    $res = $jmap->CallMethods([['Mailbox/set', {
+        destroy => [ $idA ],
+    }, "R1"]]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{destroyed}});
+    $self->assert_null($res->[0][1]{notDestroyed});
+
+    # Try to move "B" under a non-existant mailbox
+    $res = $jmap->CallMethods([['Mailbox/set', {
+        update => {
+            $idB => { parentId => "nosuchid" },
+        }
+    }, "R1"]]);
+    $self->assert_null($res->[0][1]{updated});
+    $self->assert_not_null($res->[0][1]{notUpdated});
+
+    # Try to move "B" under "A"
+    $res = $jmap->CallMethods([['Mailbox/set', {
+        update => {
+            $idB => { parentId => $idA },
+        }
+    }, "R1"]]);
+    $self->assert_null($res->[0][1]{updated});
+    $self->assert_not_null($res->[0][1]{notUpdated});
+
+}
+
 sub test_mailbox_set_inbox_children
     :min_version_3_1 :needs_component_jmap :NoAltNameSpace
 {

--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -1376,7 +1376,7 @@ sub test_mailbox_set_order
 }
 
 sub test_mailbox_move_to_deleted_parent
-    :min_version_3_8 :needs_component_jmap
+    :min_version_3_6 :needs_component_jmap
 {
     my ($self) = @_;
 

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -3224,6 +3224,7 @@ static const mbentry_t *_mbentry_by_uniqueid(jmap_req_t *req,
     if (!mbentry) {
         int r = mboxlist_lookup_by_uniqueid(id, &mbentry, NULL);
         if (r || !mbentry || (mbentry->mbtype & MBTYPE_DELETED) ||
+            mboxname_isdeletedmailbox(mbentry->name, NULL) ||
             /* make sure the user can "see" the mailbox */
             !(jmap_myrights_mbentry(req, mbentry) & JACL_LOOKUP) ||
             /* keep the lookup scoped to accountid */


### PR DESCRIPTION
Just tagging all for whoever feels like reviewing :)  This was triggered by a user breaking replication horribly by the faulty "rename under the DELETED namespace".  We should maybe actually plumb a "kill this with fire" check down a level too in mboxlist_renamemailbox(), but this fix certainly seems right anyway.

My only issue would be whether it somehow breaks "Mailbox/changes", but the other existing tests seem to indicate it's OK!