### PR TITLE
docs: fix doc build errors from typos

### DIFF
--- a/docsrc/imap/download/installation/http/caldav.rst
+++ b/docsrc/imap/download/installation/http/caldav.rst
@@ -374,7 +374,7 @@ The TZID property can have a vendor prefix, that is fixed when compiling vzic by
 ``TZID_PREFIX`` Makefile variable, which defaults to `/citadel.org/%D_1/`.  Cyrus
 IMAP requires that the vendor prefix is the empty string.
 
-The `cyrus-timezones package<https://github.com/cyrusimap/cyrus-timezones>`_ provides
+The `cyrus-timezones package <https://github.com/cyrusimap/cyrus-timezones>`_ provides
 a vzic, which sets TZID_PREFIX to the emtpy string.
 
 The steps to populate the ``zoneinfo_dir`` directory are:

--- a/docsrc/imap/reference/manpages/systemcommands/jmap_expire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/jmap_expire.rst
@@ -4,9 +4,9 @@
 
 .. _imap-reference-manpages-systemcommands-jmap_expire:
 
-==============
+===============
 **jmap_expire**
-==============
+===============
 
 Expire stale JMAP data such as calendar event notifications.
 


### PR DESCRIPTION
Couple of typos that are resulting in noise when building docs.

General rule of thumb:  if you edit any RST files, please `make doc` and check that you haven't introduced any new warnings or errors.  RST looks forgiving, like markdown, but it's actually annoyingly fussy, like XML.

I'm not sure how far this needs to be backported, so I'm just hitting it with all the backport labels, and I'll figure it out when I get there...