### PR TITLE
search_engines: do not return search builder for null mailbox

### DIFF
--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -128,6 +128,8 @@ EXPORTED int search_part_is_body(int part)
 
 EXPORTED search_builder_t *search_begin_search(struct mailbox *mailbox, int opts)
 {
+    if (!mailbox) return NULL;
+
     const struct search_engine *se = search_engine();
     return (se->begin_search ?
             se->begin_search(mailbox, opts) : NULL);

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -356,6 +356,8 @@ static search_builder_t *begin_search(struct mailbox *mailbox, int opts)
     const char *fname;
     int fd;
 
+    if (!mailbox) return NULL;
+
     if ((opts & SEARCH_MULTIPLE)) {
         syslog(LOG_ERR, "Squat does not support multiple-folder searches, sorry");
         /* although it could with some extra work, but why bother */

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2087,6 +2087,8 @@ static search_builder_t *begin_search(struct mailbox *mailbox, int opts)
     int r = check_config(NULL);
     if (r) return NULL;
 
+    if (!mailbox) return NULL;
+
     xapian_builder_t *bb = xzmalloc(sizeof(xapian_builder_t));
     bb->super.begin_boolean = begin_boolean;
     bb->super.end_boolean = end_boolean;


### PR DESCRIPTION
The search builder API requires a mailbox for initialization but did not do a proper NULL check of the argument. This could cause the Xapian and Squat search builders to crash.