### PR TITLE
Add test showing query cache isn't invalidated by squatter

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email-query-cached-negative
+++ b/cassandane/tiny-tests/JMAPEmail/email-query-cached-negative
@@ -1,0 +1,101 @@
+#!perl
+use Cassandane::Tiny;
+
+# If an email arrives and we manage to query for it *before* 
+# squatter indexes it, our query will be cached and we'll never
+# see the result (until some other mailbox state change invalidates
+# the cache)
+
+sub test_email_query_cached_negative
+    :min_version_3_1 :needs_component_sieve :needs_component_jmap
+    :JMAPQueryCacheMaxAge1s
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my $account = undef;
+    my $store = $self->{store};
+    my $mboxprefix = "INBOX";
+    my $talk = $store->get_client();
+
+    my $res = $jmap->CallMethods([['Mailbox/get', { accountId => $account }, "R1"]]);
+    my $inboxid = $res->[0][1]{list}[0]{id};
+
+    xlog $self, "run squatter once to maybe set things up";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $using = [
+        'https://cyrusimap.org/ns/jmap/performance',
+        'https://cyrusimap.org/ns/jmap/debug',
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:mail',
+    ];
+
+    xlog $self, "create an email in inbox";
+
+    my %params;
+    my $dtfoo = DateTime->new(
+        year       => 2016,
+        month      => 11,
+        day        => 1,
+        hour       => 7,
+        time_zone  => 'Etc/UTC',
+    );
+    my $bodyfoo = "A rather short email";
+    %params = (
+        date => $dtfoo,
+        body => $bodyfoo,
+        store => $store,
+    );
+    $res = $self->make_message("foo", %params) || die;
+
+    my $query = sub {
+        $res = $jmap->CallMethods([
+            ['Email/query', {
+                accountId => $account,
+                filter => {
+                    operator => 'AND',
+                    conditions => [
+                        { text => "short" },
+                    ],
+                },
+                position => 0,
+                limit => 30,
+                sort => [{ property => "receivedAt", isAscending => JSON::false, }],
+            }, 'R1'],
+            ['Email/get', {
+                accountId => $account,
+               '#ids' => { resultOf => 'R1', name => 'Email/query', path => '/ids' }
+            }, 'R2'],
+        ], $using);
+    };
+
+    # Prime the cache
+    $query->();
+
+    # No messages, not cached
+    $self->assert_equals(JSON::false, $res->[0][1]{performance}{details}{isCached});
+    $self->assert_num_equals(0, scalar @{$res->[0][1]->{ids}});
+    $self->assert_num_equals(0, scalar @{$res->[1][1]->{list}});
+
+    # Query again and confirm our query is cached
+    $query->();
+
+    # No messages, cached
+    $self->assert_equals(JSON::true, $res->[0][1]{performance}{details}{isCached});
+    $self->assert_num_equals(0, scalar @{$res->[0][1]->{ids}});
+    $self->assert_num_equals(0, scalar @{$res->[1][1]->{list}});
+
+    # Now run squatter
+    xlog $self, "run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    # We *should* see the message now
+    $query->();
+
+    # Not cached, 1 message
+    $self->assert_equals(JSON::false, $res->[0][1]{performance}{details}{isCached});
+    $self->assert_num_equals(1, scalar @{$res->[0][1]->{ids}});
+    $self->assert_num_equals(1, scalar @{$res->[1][1]->{list}});
+
+}


### PR DESCRIPTION
That is... if you manage to query for something before squatter has a chance to process the latest changes to your mailbox, that query will be cached and you won't see the results until the cache is invalidated (by the next mailbox stage change or by the cache record expiring).