### PR TITLE
JMAPMailbox.pm: add test_mailbox_set_destroy_twice

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -5448,4 +5448,33 @@ sub test_mailbox_set_create_specialuse_nochildren
         $res->[0][1]->{notUpdated}{$trash_id}{properties});
 }
 
+sub test_mailbox_set_destroy_twice
+    :min_version_3_8 :needs_component_jmap
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+
+    xlog $self, "create mailbox";
+    my $res = $jmap->CallMethods([
+            ['Mailbox/set', { create => { "1" => {
+                            name => "foo",
+                            role => undef
+             }}}, "R1"]
+    ]);
+    my $id = $res->[0][1]{created}{"1"}{id};
+
+    xlog $self, "destroy mailbox";
+    $res = $jmap->CallMethods([
+            ['Mailbox/set', { destroy => [ $id ] }, "R1"]
+    ]);
+    $self->assert_str_equals($id, $res->[0][1]{destroyed}[0]);
+
+    xlog $self, "destroy mailbox";
+    $res = $jmap->CallMethods([
+            ['Mailbox/set', { destroy => [ $id ] }, "R1"]
+    ]);
+    $self->assert_str_equals("notFound", $res->[0][1]{notDestroyed}{$id}{type});
+}
+
 1;


### PR DESCRIPTION
This proves that a previously reported crasher has been fixed, presumably by 
https://github.com/cyrusimap/cyrus-imapd/commit/adfce43072fc3e03da282a28f63f4b5245cb87c3