### PR TITLE
Reconcile DAV Sharing ACLs with JMAP

### DIFF
--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -991,8 +991,6 @@ static void add_part(ptrarray_t *found,
             /* found it */
             if (override) {
                 /* replace the path with the one containing cyrus.header */
-                if (entry->path)
-                    free(entry->path);
                 strcpy(entry->path, path);
             }
 

--- a/imap/http_dav_sharing.h
+++ b/imap/http_dav_sharing.h
@@ -49,8 +49,9 @@
 #define DAVSHARING_CONTENT_TYPE "application/davsharing+xml"
 
 /* Privileges assigned via WebDAV Sharing (draft-pot-webdav-resource-sharing) */
-#define DACL_SHARE      (DACL_READ|DACL_WRITEPROPS)
-#define DACL_SHARERW    (DACL_READ|DACL_WRITE)
+#define DACL_SHARE      ( DACL_READ   | DACL_READFB )
+#define DACL_SHARERW    ( DACL_SHARE  | DACL_WRITECONT    | DACL_WRITEPROPS |   \
+                          DACL_RMRSRC | DACL_WRITEOWNRSRC | DACL_UPDATEPRIVATE )
 
 #define SYSTEM_STATUS_NOTIFICATION  "systemstatus"
 #define SHARE_INVITE_NOTIFICATION   "share-invite-notification"


### PR DESCRIPTION
This change seems to make both FM UI and MacOS happy, as well as Fantastical (still allows r/w on a shared calendar)