### PR TITLE
user_sieve_path(): never return "" -- always return a sensible path

### DIFF
--- a/imap/user.c
+++ b/imap/user.c
@@ -201,8 +201,7 @@ EXPORTED const char *user_sieve_path(const char *inuser)
         int r = mboxlist_lookup(inboxname, &mbentry, NULL);
         free(inboxname);
 
-        if (r) sieve_path = "";
-        else if (mbentry->mbtype & MBTYPE_LEGACY_DIRS) {
+        if (r || (mbentry->mbtype & MBTYPE_LEGACY_DIRS)) {
             legacy = 1;
         }
         else {


### PR DESCRIPTION
This should fix an issue where mailbox_open_sieve() via dav_reconstruct would try to write to root