### PR TITLE
Cassandane: Test that we can bind to ports before using them

### DIFF
--- a/cassandane/Cassandane/Cyrus/LDAP.pm
+++ b/cassandane/Cassandane/Cyrus/LDAP.pm
@@ -84,7 +84,7 @@ sub set_up
 
     $self->SUPER::set_up();
 
-    $self->{ldapport} = Cassandane::PortManager::alloc();
+    $self->{ldapport} = Cassandane::PortManager::alloc("localhost");
 
     $self->{instance}->{config}->set(
         ldap_uri => "ldap://localhost:$self->{ldapport}/",

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -327,7 +327,7 @@ magic(JMAPExtensions => sub {
     shift->config_set('jmap_nonstandard_extensions' => 'yes');
 });
 magic(SearchAttachmentExtractor => sub {
-    my $port = Cassandane::PortManager::alloc();
+    my $port = Cassandane::PortManager::alloc("localhost");
     shift->config_set('search_attachment_extractor_url' =>
         "http://localhost:$port/extractor");
 });
@@ -478,7 +478,7 @@ sub _create_instances
 
         if ($want->{replica} || $want->{csyncreplica})
         {
-            $sync_port = Cassandane::PortManager::alloc();
+            $sync_port = Cassandane::PortManager::alloc("localhost");
             $conf->set(
                 # sync_client will find the port in the config
                 sync_host => 'localhost',
@@ -491,8 +491,8 @@ sub _create_instances
 
         if ($want->{imapmurder} || $want->{httpmurder})
         {
-            $mupdate_port = Cassandane::PortManager::alloc();
-            $backend1_service_port = Cassandane::PortManager::alloc();
+            $mupdate_port = Cassandane::PortManager::alloc("localhost");
+            $backend1_service_port = Cassandane::PortManager::alloc("localhost");
 
             $conf->set(
                 servername => "localhost:$backend1_service_port",
@@ -513,7 +513,7 @@ sub _create_instances
 
         if ($want->{backups})
         {
-            $backupd_port = Cassandane::PortManager::alloc();
+            $backupd_port = Cassandane::PortManager::alloc("localhost");
             $conf->set(
                 backup_sync_host => "localhost",
                 backup_sync_port => $backupd_port,
@@ -569,8 +569,8 @@ sub _create_instances
 
         if ($want->{imapmurder} || $want->{httpmurder})
         {
-            $frontend_service_port = Cassandane::PortManager::alloc();
-            $backend2_service_port = Cassandane::PortManager::alloc();
+            $frontend_service_port = Cassandane::PortManager::alloc("localhost");
+            $backend2_service_port = Cassandane::PortManager::alloc("localhost");
 
             # set up a front end on which we also run the mupdate master
             my $frontend_conf = $self->{_config}->clone();

--- a/cassandane/Cassandane/GenericDaemon.pm
+++ b/cassandane/Cassandane/GenericDaemon.pm
@@ -104,7 +104,7 @@ sub set_port
         $port = $self->{config}->substitute($port);
     }
 
-    $port ||= Cassandane::PortManager::alloc();
+    $port ||= Cassandane::PortManager::alloc($self->host);
     $self->{port} = $port;
 }
 

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1059,7 +1059,7 @@ sub _start_smtpd
 
     my $host = 'localhost';
 
-    my $port = Cassandane::PortManager::alloc();
+    my $port = Cassandane::PortManager::alloc($host);
 
     my $smtppid = fork();
     unless ($smtppid) {
@@ -1118,7 +1118,7 @@ sub start_httpd {
     my $basedir = $self->{basedir};
 
     my $host = 'localhost';
-    $port ||= Cassandane::PortManager::alloc();
+    $port ||= Cassandane::PortManager::alloc($host);
 
     my $httpdpid = fork();
     unless ($httpdpid) {

--- a/cassandane/Cassandane/Util/TestUrl.pm
+++ b/cassandane/Cassandane/Util/TestUrl.pm
@@ -81,6 +81,8 @@ sub update
       }
     }
 
+    my $host = "127.0.0.1";
+
     my $app = sub {
         # No matter how we we leave this block, the $guard will go out
         # of scope while in the run phase, which means it can exit Perl
@@ -96,7 +98,7 @@ sub update
 
         my $sock_or_port = shift;
         my $server = Plack::Loader->auto(
-            host => '0.0.0.0',
+            host => $host,
             port => $sock_or_port,
         );
 
@@ -111,12 +113,10 @@ sub update
             croak("Cannot call ->update after ->unregister has been called!");
         }
 
-        my $host = "127.0.0.1";
-
         my $guard = Test::TCP->new(
             host => $host,
             code => $app,
-            port => Cassandane::PortManager::alloc(),
+            port => Cassandane::PortManager::alloc($host),
         );
 
         my $port = $guard->port;


### PR DESCRIPTION
This will make tests more resilient when running on servers where other services are using ports cassandane overlaps with.