### PR TITLE
Add support for HAProxy protocol

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1037,6 +1037,8 @@ imap_libcyrus_imap_la_SOURCES = \
 	imap/duplicate.h \
 	imap/global.c \
 	imap/global.h \
+	imap/haproxy.c \
+	imap/haproxy.h \
 	imap/http_client.c \
 	imap/http_client.h \
 	imap/idle.c \

--- a/changes/next/proxy_protocol
+++ b/changes/next/proxy_protocol
@@ -1,0 +1,22 @@
+
+Description:
+
+Add support for the HAProxy protocol.
+
+https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+To enable support for the HAProxy protocol in imapd, pop3d, lmtpd, nntpd, httpd, or
+timesieved, add the 'H' command line option to the service in cyrus.conf.
+
+
+GitHub issue:
+
+None.

--- a/docsrc/assets/man-imapdproxyd.rst
+++ b/docsrc/assets/man-imapdproxyd.rst
@@ -8,7 +8,7 @@ Synopsis
 .. parsed-literal::
 
     **imapd** [ **-C** *config-file* ] [ **-U** *uses* ] [ **-T** *timeout* ] [ **-D** ]
-        [ **-s** ] [ **-N** ] [ **-p** *ssf* ]
+        [ **-H** ] [ **-s** ] [ **-N** ] [ **-p** *ssf* ]
 
 Description
 ===========
@@ -65,6 +65,10 @@ Options
 .. option:: -D
 
     Run external debugger specified in debug_command.
+
+.. option:: -H
+
+    Tell **imapd** to expect a HAProxy protocol header from the sender.
 
 .. option:: -s
 

--- a/docsrc/assets/man-imtest.rst
+++ b/docsrc/assets/man-imtest.rst
@@ -7,7 +7,8 @@ Synopsis
         [ **-a** *userid* ] [ **-u** *userid* ] [ **-k** *num* ] [ **-l** *num* ]
         [ **-r** *realm* ] [ **-f** *file* ] [ **-n** *num* ] [ **-s** ] [ **-q** ]
         [ **-c** ] [ **-i** ] [ **-z** ] [ **-v** ] [ **-I** *file* ] [ **-x** *file* ]
-        [ **-X** *file* ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ] *hostname*
+        [ **-X** *file* ] [ **-w** *passwd* ] [ **-o** *option*\ =\ *value* ]
+        [ **-H** *client-ip* ] *hostname*
 
 Description
 ===========
@@ -131,6 +132,13 @@ Options
 .. option:: -o option=value, --sasl-option=option=value
 
     Set the SASL *option* to *value*.
+
+.. option:: -H client-ip
+
+    Enable the HAProxy protocol and send the specified client IP
+    address in a v1 header.  If the address is "unknown", a v1 header
+    with UNKNOWN protocol will be sent.  If the address is "local",
+    a v2 header with LOCAL command will be sent.
 
 Examples
 ========

--- a/docsrc/assets/man-lmtpd.rst
+++ b/docsrc/assets/man-lmtpd.rst
@@ -3,7 +3,8 @@ Synopsis
 
 .. parsed-literal::
 
-    **lmtpd** [ **-C** *config-file* ]  [ **-U** *uses* ] [ **-T** *timeout* ] [ **-D** ] [ **-a** ]
+    **lmtpd** [ **-C** *config-file* ]  [ **-U** *uses* ] [ **-T** *timeout* ] [ **-D** ]
+        [ **-H** ] [ **-a** ]
 
 Description
 ===========
@@ -38,6 +39,10 @@ Options
 .. option:: -D
 
     Run external debugger specified in debug_command.
+
+.. option:: -H
+
+    Tell **lmtpd** to expect a HAProxy protocol header from the sender.
 
 .. option:: -a
 

--- a/docsrc/imap/reference/manpages/systemcommands/httpd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/httpd.rst
@@ -16,7 +16,7 @@ Synopsis
 .. parsed-literal::
 
     **httpd** [ **-C** *config-file* ] [ **-U** *uses* ] [ **-T** *timeout* ] [ **-D** ]
-        [ **-s** ] [ **-p** *ssf* ] [ **-q** ]
+        [ **-H** ] [ **-s** ] [ **-p** *ssf* ] [ **-q** ]
 
 Description
 ===========
@@ -56,6 +56,10 @@ Options
 .. option:: -D
 
     Run external debugger specified in debug_command.
+
+.. option:: -H
+
+    Tell **httpd** to expect a HAProxy protocol header from the sender.
 
 .. option:: -s
 

--- a/docsrc/imap/reference/manpages/systemcommands/nntpd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/nntpd.rst
@@ -16,7 +16,7 @@ Synopsis
 .. parsed-literal::
 
     **nntpd** [ **-C** *config-file* ] [ **-U** *uses* ] [ **-T** *timeout* ] [ **-D** ]
-        [ **-s** ] [ **-r** ] [ **-f** ] [ **-p** *ssf* ]
+        [ **-H** ] [ **-s** ] [ **-r** ] [ **-f** ] [ **-p** *ssf* ]
 
 Description
 ===========
@@ -67,6 +67,10 @@ Options
 .. option:: -D
 
     Run external debugger specified in debug_command.
+
+.. option:: -H
+
+    Tell **nntpd** to expect a HAProxy protocol header from the sender.
 
 .. option:: -s
 

--- a/docsrc/imap/reference/manpages/systemcommands/pop3d.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/pop3d.rst
@@ -16,7 +16,7 @@ Synopsis
 .. parsed-literal::
 
     **pop3d** [ **-C** *config-file* ] [ **-U** *uses* ] [ **-T** *timeout* ] [ **-D** ]
-        [ **-s** ] [ **-k** ] [ **-p** *ssf* ]
+        [ **-H** ] [ **-s** ] [ **-k** ] [ **-p** *ssf* ]
 
 Description
 ===========
@@ -58,6 +58,10 @@ Options
 .. option:: -D
 
     Run external debugger specified in debug_command.
+
+.. option:: -H
+
+    Tell **httpd** to expect a HAProxy protocol header from the sender.
 
 .. option:: -s
 

--- a/docsrc/imap/reference/manpages/systemcommands/pop3proxyd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/pop3proxyd.rst
@@ -9,4 +9,4 @@
 
 This is a hard linked copy of :cyrusman:`pop3d(8)`, retained for backwards compatibility from when a murder frontend used its own pop3d binaries.
 
-.. include:: /assets/man-lmtpd.rst
+.. include:: /assets/man-pop3d.rst

--- a/docsrc/imap/reference/manpages/systemcommands/timsieved.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/timsieved.rst
@@ -17,7 +17,7 @@ Synopsis
 
 .. parsed-literal::
 
-    **timsieved** [ **-C** *config-file* ]
+    **timsieved** [ **-C** *config-file* ] [ **-H** ]
 
 Description
 ===========
@@ -39,6 +39,10 @@ Options
 .. program:: timsieved
 
 .. option:: -C config-file
+
+.. option:: -H
+
+    Tell **timsievedd** to expect a HAProxy protocol header from the sender.
 
     |cli-dash-c-text|
 

--- a/imap/global.h
+++ b/imap/global.h
@@ -185,6 +185,7 @@ extern int config_httpprettytelemetry;
 extern int charset_flags;
 extern int charset_snippet_flags;
 extern size_t config_search_maxsize;
+extern int haproxy_protocol;
 
 /* Session ID */
 extern void session_new_id(void);

--- a/imap/haproxy.c
+++ b/imap/haproxy.c
@@ -1,0 +1,156 @@
+/* haproxy.c -- HAProxy protocol functions.
+ *
+ * XXX  This code is mostly lifted directly from:
+ *
+ * https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt
+ */
+
+#include <config.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+
+#include "haproxy.h"
+
+/* returns 0 on success, <0 upon error */
+EXPORTED int haproxy_read_hdr(int s, struct sockaddr *to, struct sockaddr *from)
+{
+    const char v2sig[12] = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A";
+
+    union {
+        struct {
+            char line[108];
+        } v1;
+        struct {
+            uint8_t sig[12];
+            uint8_t ver_cmd;
+            uint8_t fam;
+            uint16_t len;
+            union {
+                struct {  /* for TCP/UDP over IPv4, len = 12 */
+                    uint32_t src_addr;
+                    uint32_t dst_addr;
+                    uint16_t src_port;
+                    uint16_t dst_port;
+                } ip4;
+                struct {  /* for TCP/UDP over IPv6, len = 36 */
+                    uint8_t  src_addr[16];
+                    uint8_t  dst_addr[16];
+                    uint16_t src_port;
+                    uint16_t dst_port;
+                } ip6;
+                struct {  /* for AF_UNIX sockets, len = 216 */
+                    uint8_t src_addr[108];
+                    uint8_t dst_addr[108];
+                } unx;
+            } addr;
+        } v2;
+    } hdr;
+
+    int size, ret;
+
+    do {
+        ret = recv(s, &hdr, sizeof(hdr), MSG_PEEK);
+    } while (ret == -1 && errno == EINTR);
+
+    if (ret == -1)
+        return -1;
+
+    if (ret >= 16 && memcmp(&hdr.v2, v2sig, 12) == 0 &&
+        (hdr.v2.ver_cmd & 0xF0) == 0x20) {
+        size = 16 + ntohs(hdr.v2.len);
+        if (ret < size)
+            return -1; /* truncated or too large header */
+
+        switch (hdr.v2.ver_cmd & 0xF) {
+        case 0x01: /* PROXY command */
+            switch (hdr.v2.fam) {
+            case 0x11:  /* TCPv4 */
+                ((struct sockaddr_in *) from)->sin_family = AF_INET;
+                ((struct sockaddr_in *) from)->sin_addr.s_addr =
+                    hdr.v2.addr.ip4.src_addr;
+                ((struct sockaddr_in *) from)->sin_port =
+                    hdr.v2.addr.ip4.src_port;
+                ((struct sockaddr_in *) to)->sin_family = AF_INET;
+                ((struct sockaddr_in *) to)->sin_addr.s_addr =
+                    hdr.v2.addr.ip4.dst_addr;
+                ((struct sockaddr_in *) to)->sin_port =
+                    hdr.v2.addr.ip4.dst_port;
+                goto done;
+            case 0x21:  /* TCPv6 */
+                ((struct sockaddr_in6 *) from)->sin6_family = AF_INET6;
+                memcpy(&((struct sockaddr_in6 *) from)->sin6_addr,
+                       hdr.v2.addr.ip6.src_addr, 16);
+                ((struct sockaddr_in6 *) from)->sin6_port =
+                    hdr.v2.addr.ip6.src_port;
+                ((struct sockaddr_in6 *) to)->sin6_family = AF_INET6;
+                memcpy(&((struct sockaddr_in6 *) to)->sin6_addr,
+                       hdr.v2.addr.ip6.dst_addr, 16);
+                ((struct sockaddr_in6 *) to)->sin6_port =
+                    hdr.v2.addr.ip6.dst_port;
+                goto done;
+            }
+            /* unsupported protocol, keep local connection address */
+            break;
+        case 0x00: /* LOCAL command */
+            /* keep local connection address for LOCAL */
+            break;
+        default:
+            return -1; /* not a supported command */
+        }
+    }
+    else if (ret >= 8 && memcmp(hdr.v1.line, "PROXY", 5) == 0) {
+        char *end = memchr(hdr.v1.line, '\r', ret - 1);
+        if (!end || end[1] != '\n')
+            return -1; /* partial or invalid header */
+        *end = '\0'; /* terminate the string to ease parsing */
+        size = end + 2 - hdr.v1.line; /* skip header + CRLF */
+        /* parse the V1 header using favorite address parsers like inet_pton.
+         * return -1 upon error, or simply fall through to accept.
+         */
+        char *proto = NULL, lipbuf[NI_MAXHOST], ripbuf[NI_MAXHOST];
+        uint16_t lport, rport;
+        int n = sscanf(hdr.v1.line, "PROXY %ms %s %s %hu %hu",
+                       &proto, ripbuf, lipbuf, &rport, &lport);
+        if (n >= 1 && !strcmp(proto, "UNKNOWN")) {
+            ret = 1;
+        }
+        else if (n == 5 && !strcmp(proto, "TCP4")) {
+            ((struct sockaddr_in *) from)->sin_family = AF_INET;
+            ((struct sockaddr_in *) from)->sin_port = rport;
+            ret = inet_pton(AF_INET, ripbuf,
+                            &((struct sockaddr_in *) from)->sin_addr);
+        }
+        else if (n == 5 && !strcmp(proto, "TCP6")) {
+            ((struct sockaddr_in6 *) from)->sin6_family = AF_INET6;
+            ((struct sockaddr_in6 *) from)->sin6_port = rport;
+            ret = inet_pton(AF_INET6, ripbuf,
+                            &((struct sockaddr_in6 *) from)->sin6_addr);
+        }
+        else {
+            ret = -1;
+        }
+        free(proto);
+
+        if (ret != 1) {
+            /* invalid header */
+            return -1;
+        }
+    }
+    else {
+        /* Wrong protocol */
+        return -1;
+    }
+
+ done:
+    /* we need to consume the appropriate amount of data from the socket */
+    do {
+        ret = recv(s, &hdr, size, 0);
+    } while (ret == -1 && errno == EINTR);
+
+    return (ret != size ? -1 : 0);
+}

--- a/imap/haproxy.h
+++ b/imap/haproxy.h
@@ -1,0 +1,10 @@
+/* haproxy.h -- Header for HAProxy protocol functions. */
+
+#ifndef INCLUDED_HAPROXY_H
+#define INCLUDED_HAPROXY_H
+
+#include <sys/socket.h>
+
+extern int haproxy_read_hdr(int s, struct sockaddr *to, struct sockaddr *from);
+
+#endif /* INCLUDED_HAPROXY_H */

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -821,8 +821,12 @@ int service_init(int argc __attribute__((unused)),
 
     mboxevent_setnamespace(&httpd_namespace);
 
-    while ((opt = getopt(argc, argv, "sp:q")) != EOF) {
+    while ((opt = getopt(argc, argv, "Hsp:q")) != EOF) {
         switch(opt) {
+        case 'H': /* expect HAProxy protocol header */
+            haproxy_protocol = 1;
+            break;
+
         case 's': /* https (do TLS right away) */
             https = 1;
             break;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1090,8 +1090,11 @@ int service_init(int argc, char **argv, char **envp)
     apns_enabled =
       (events & EVENT_APPLEPUSHSERVICE) && config_getstring(IMAPOPT_APS_TOPIC);
 
-    while ((opt = getopt(argc, argv, "Np:sq")) != EOF) {
+    while ((opt = getopt(argc, argv, "HNp:sq")) != EOF) {
         switch (opt) {
+        case 'H': /* expect HAProxy protocol header */
+            haproxy_protocol = 1;
+            break;
         case 's': /* imaps (do starttls right away) */
             imaps = 1;
             if (!tls_enabled()) {

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -275,8 +275,12 @@ int service_main(int argc, char **argv,
     prot_setflushonread(deliver_in, deliver_out);
     prot_settimeout(deliver_in, 360);
 
-    while ((opt = getopt(argc, argv, "a")) != EOF) {
+    while ((opt = getopt(argc, argv, "Ha")) != EOF) {
         switch(opt) {
+        case 'H': /* expect HAProxy protocol header */
+            haproxy_protocol = 1;
+            break;
+
         case 'a':
             mylmtp.preauth = 1;
             break;

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -425,8 +425,12 @@ int service_init(int argc __attribute__((unused)),
     /* setup for sending IMAP IDLE notifications */
     idle_init();
 
-    while ((opt = getopt(argc, argv, "srfp:")) != EOF) {
+    while ((opt = getopt(argc, argv, "Hsrfp:")) != EOF) {
         switch(opt) {
+        case 'H': /* expect HAProxy protocol header */
+            haproxy_protocol = 1;
+            break;
+
         case 's': /* nntps (do starttls right away) */
             nntps = 1;
             if (!tls_enabled()) {

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -409,8 +409,7 @@ static void popd_reset(void)
  * run once when process is forked;
  * MUST NOT exit directly; must return with non-zero error code
  */
-int service_init(int argc __attribute__((unused)),
-                 char **argv __attribute__((unused)),
+int service_init(int argc, char **argv,
                  char **envp __attribute__((unused)))
 {
     int r;
@@ -437,8 +436,12 @@ int service_init(int argc __attribute__((unused)),
 
     mboxevent_setnamespace(&popd_namespace);
 
-    while ((opt = getopt(argc, argv, "skp:")) != EOF) {
+    while ((opt = getopt(argc, argv, "Hskp:")) != EOF) {
         switch(opt) {
+        case 'H': /* expect HAProxy protocol header */
+            haproxy_protocol = 1;
+            break;
+
         case 's': /* pop3s (do starttls right away) */
             pop3s = 1;
             if (!tls_enabled()) {

--- a/timsieved/timsieved.c
+++ b/timsieved/timsieved.c
@@ -207,15 +207,27 @@ static struct sasl_callback mysasl_cb[] = {
     { SASL_CB_LIST_END, NULL, NULL }
 };
 
-EXPORTED int service_init(int argc __attribute__((unused)),
-                 char **argv __attribute__((unused)),
+EXPORTED int service_init(int argc, char **argv,
                  char **envp __attribute__((unused)))
 {
+    int opt;
+
     global_sasl_init(1, 1, mysasl_cb);
 
     /* build interpreter for compiling */
     interp = sieve_build_nonexec_interp();
     if (interp == NULL) shut_down(EX_SOFTWARE);
+
+    while ((opt = getopt(argc, argv, "H")) != EOF) {
+        switch(opt) {
+        case 'H': /* expect HAProxy protocol header */
+            haproxy_protocol = 1;
+            break;
+
+        default:
+            break;
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt

Currently just plumbed into httpd since it can be tested with curl.

I'm also not sure if -P is the best choice for the command line switch, but don't have any other ideas.