### PR TITLE
lmtp_sieve.c: strip phrase from redirect address (addr-spec only)

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -7133,4 +7133,31 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 }
 
+sub test_redirect_address_with_phrase
+    :needs_component_sieve
+{
+    my ($self) = @_;
+
+    xlog $self, "Install a script";
+    $self->{instance}->install_sieve_script(<<EOF
+redirect "Foo <foo\@example.com>";
+EOF
+    );
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    # Verify that message was redirected (no RCPT TO error)
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my @lines = $self->{instance}->getsyslog();
+        $self->assert_does_not_match(qr/RCPT TO: code=553 text=5.1.1/, "@lines");
+    }
+
+    xlog $self, "Make sure that message is NOT in INBOX (due to runtime error)";
+    my $talk = $self->{store}->get_client();
+    $talk->select("INBOX");
+    $self->assert_num_equals(0, $talk->get_response_code('exists'));
+}
+
 1;

--- a/cassandane/Cassandane/Net/SMTPServer.pm
+++ b/cassandane/Cassandane/Net/SMTPServer.pm
@@ -74,7 +74,7 @@ sub rcpt_to {
     $Self->{_rcpt_to_count}++;
     if ($Self->{_rcpt_to_count} > 10) {
         $Self->send_client_resp(550, "5.5.3 Too many recipients");
-    } elsif ($To =~ /\@fail\.to\.deliver$/i) {
+    } elsif ($To =~ /[<>]/ || $To =~ /\@fail\.to\.deliver$/i) {
         $Self->send_client_resp(553, "5.1.1 Bad destination mailbox address");
         $Self->mylog("SMTP: 553 5.1.1");
     } else {

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -785,7 +785,22 @@ static int send_forward(sieve_redirect_context_t *rc,
 #endif
     }
     else {
-        smtp_envelope_add_rcpt(&sm_env, rc->addr);
+        struct address *addr = NULL;
+        char *rcpt = NULL;
+
+        parseaddr_list(rc->addr, &addr);
+        if (addr) {
+            rcpt = address_get_all(addr, 1);
+            parseaddr_free(addr);
+        }
+        if (rcpt) {
+            smtp_envelope_add_rcpt(&sm_env, rcpt);
+            free(rcpt);
+        }
+        else {
+            r = SIEVE_FAIL;
+            goto done;
+        }
     }
 
     if (srs_return_path) free(srs_return_path);


### PR DESCRIPTION
Can't use addresses like "Foo <foo@example.com>" in SMTP RCPT TO

This is a simple fix, but how to test?  I don't know how to check for SMTP pass/fail in Cassandane