### PR TITLE
global.c: leniently support message-ids without brackets

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_get_threadid_bogus_messageid
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_threadid_bogus_messageid
@@ -1,0 +1,143 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_threadid_nobracket_messageid
+    :min_version_3_7 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    xlog $self, "Set message-id without brackets";
+
+    my $raw = <<'EOF';
+From: addr1@local
+To: addr2@local, addr3@local, addr4@local, addr5@local
+Subject: hello
+Message-Id: bogus.addr1@message-id
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+hello
+EOF
+    $raw =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $raw) || die $@;
+
+    xlog $self, "Refer to it In-Reply-To with brackets";
+
+    $raw = <<'EOF';
+From: addr2@local
+To: addr1@local
+Subject: Re: hello
+Message-Id: <valid.addr2@message-id>
+In-Reply-To: <bogus.addr1@message-id>
+Date: Tue, 14 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+world
+EOF
+    $raw =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $raw) || die $@;
+
+    xlog $self, "Refer to it in References with brackets";
+
+    $raw = <<'EOF';
+From: addr3@local
+To: addr1@local
+Subject: Re: hello
+Message-Id: <valid.addr3@message-id>
+References: <bogus.addr1@message-id>
+Date: Tue, 14 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+world
+EOF
+    $raw =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $raw) || die $@;
+
+    xlog $self, "Refer to it in References without brackets";
+
+    $raw = <<'EOF';
+From: addr4@local
+To: addr1@local
+Subject: Re: hello
+Message-Id: <valid.addr4@message-id>
+References: bogus.addr1@message-id
+Date: Tue, 14 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+world
+EOF
+    $raw =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $raw) || die $@;
+
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $res = $jmap->CallMethods([
+        ['Email/query', { }, 'R1'],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'Email/query',
+                path => '/ids'
+            },
+            properties => ['threadId', 'subject', 'from']
+        }, 'R2'],
+    ]);
+    $self->assert_num_equals(4, scalar @{$res->[1][1]{list}});
+    my $threadId = $res->[1][1]{list}[0]{threadId};
+    $self->assert_not_null($threadId);
+
+    xlog $self, "Assert all messages thread together";
+
+    for my $i (1..3) {
+        $self->assert_str_equals($res->[1][1]{list}[0]{threadId},
+            $res->[1][1]{list}[$i]{threadId});
+        $self->assert_str_not_equals($res->[1][1]{list}[0]{id},
+            $res->[1][1]{list}[$i]{id});
+    }
+
+    xlog $self, "Refer to it In-Reply-To without brackets";
+
+    $raw = <<'EOF';
+From: addr5@local
+To: addr1@local
+Subject: Re: hello
+Message-Id: <valid.addr5@message-id>
+In-Reply-To: bogus.addr1@message-id
+Date: Tue, 14 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+world
+EOF
+    $raw =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $raw) || die $@;
+
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                from => 'addr5@local',
+            },
+        }, 'R1'],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'Email/query',
+                path => '/ids'
+            },
+            properties => ['threadId', 'subject', 'from']
+        }, 'R2'],
+    ]);
+
+    xlog $self, "Regression test: Assert malformed In-Reply-To gets own thread";
+
+    $self->assert_num_equals(1, scalar @{$res->[1][1]{list}});
+    $self->assert_str_not_equals($threadId, $res->[1][1]{list}[0]{threadId});
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_get_threadid_bogus_messageid
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_threadid_bogus_messageid
@@ -75,6 +75,40 @@ EOF
     $raw =~ s/\r?\n/\r\n/gs;
     $imap->append('INBOX', $raw) || die $@;
 
+    xlog $self, "Refer to it in X-ME-Message-ID with brackets";
+
+    $raw = <<'EOF';
+From: addr5@local
+To: addr1@local
+Subject: Re: hello
+Message-Id: <valid.addr5@message-id>
+X-ME-Message-ID: <bogus.addr1@message-id>
+Date: Tue, 14 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+world
+EOF
+    $raw =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $raw) || die $@;
+
+    xlog $self, "Refer to it in X-ME-Message-ID without brackets";
+
+    $raw = <<'EOF';
+From: addr6@local
+To: addr1@local
+Subject: Re: hello
+Message-Id: <valid.addr6@message-id>
+X-ME-Message-ID: bogus.addr1@message-id
+Date: Tue, 14 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+world
+EOF
+    $raw =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $raw) || die $@;
+
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
 
     my $res = $jmap->CallMethods([
@@ -88,13 +122,13 @@ EOF
             properties => ['threadId', 'subject', 'from']
         }, 'R2'],
     ]);
-    $self->assert_num_equals(4, scalar @{$res->[1][1]{list}});
+    $self->assert_num_equals(6, scalar @{$res->[1][1]{list}});
     my $threadId = $res->[1][1]{list}[0]{threadId};
     $self->assert_not_null($threadId);
 
     xlog $self, "Assert all messages thread together";
 
-    for my $i (1..3) {
+    for my $i (1..5) {
         $self->assert_str_equals($res->[1][1]{list}[0]{threadId},
             $res->[1][1]{list}[$i]{threadId});
         $self->assert_str_not_equals($res->[1][1]{list}[0]{id},
@@ -104,10 +138,10 @@ EOF
     xlog $self, "Refer to it In-Reply-To without brackets";
 
     $raw = <<'EOF';
-From: addr5@local
+From: addr7@local
 To: addr1@local
 Subject: Re: hello
-Message-Id: <valid.addr5@message-id>
+Message-Id: <valid.addr7@message-id>
 In-Reply-To: bogus.addr1@message-id
 Date: Tue, 14 Apr 2020 15:34:03 +0200
 MIME-Version: 1.0
@@ -123,7 +157,7 @@ EOF
     my $res = $jmap->CallMethods([
         ['Email/query', {
             filter => {
-                from => 'addr5@local',
+                from => 'addr7@local',
             },
         }, 'R1'],
         ['Email/get', {

--- a/changes/next/find_msgid_no_angle_bracket
+++ b/changes/next/find_msgid_no_angle_bracket
@@ -1,0 +1,21 @@
+Submitting a PR?  Create a file in this directory with the same name as your
+branch, and add the following details (you can use this file as a template).
+
+Description:
+
+Accept message ids even if they lack enclosing angle brackets.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/cunit/msgid.testc
+++ b/cunit/msgid.testc
@@ -448,13 +448,15 @@ static void test_malformed_angles(void)
 {
 #define C_MSGID1    "<604.05.00006@example.com>"
 #define C_MSGID2    "<607.08.09@gmail.com"
-#define C_MSGID3    "<6000A-0B-0000C@apple.com>"
+#define C_MSGID3    "607.08.10@yahoo.com"
+#define C_MSGID4    "<6000A-0B-0000C@apple.com>"
     static const char C_MSGIDS[] =
-        C_MSGID1 " " C_MSGID2 " " C_MSGID3;
+        C_MSGID1 " " C_MSGID2 " " C_MSGID3 "\t" C_MSGID4;
     char *s;
     char *m1;
     char *m2;
     char *m3;
+    char *m4;
 
     /* We checked in the "simple" test that buffers are unmolested,
      * so this time just pass find_msgid() a const variable */
@@ -468,20 +470,29 @@ static void test_malformed_angles(void)
     CU_ASSERT_STRING_EQUAL(m1, C_MSGID1);
     CU_ASSERT(s >= C_MSGIDS && s <= C_MSGIDS+sizeof(C_MSGIDS));
 
+    /* we skipped C_MSGID2 */
+
     m2 = find_msgid(s, &s);
     CU_ASSERT_PTR_NOT_NULL(m2);
-    CU_ASSERT_STRING_EQUAL(m2, C_MSGID3);
+    CU_ASSERT_STRING_EQUAL(m2, "<" C_MSGID3 ">");
     CU_ASSERT(s >= C_MSGIDS && s <= C_MSGIDS+sizeof(C_MSGIDS));
 
-    /* we stop seeing msgids after 2nd msgid */
     m3 = find_msgid(s, &s);
-    CU_ASSERT_PTR_NULL(m3);
+    CU_ASSERT_PTR_NOT_NULL(m3);
+    CU_ASSERT_STRING_EQUAL(m3, C_MSGID4);
+    CU_ASSERT(s >= C_MSGIDS && s <= C_MSGIDS+sizeof(C_MSGIDS));
+
+    /* we found three msgids */
+    m4 = find_msgid(s, &s);
+    CU_ASSERT_PTR_NULL(m4);
 
     /* check the returned msgids are all distinct */
     CU_ASSERT_PTR_NOT_EQUAL(m1, m2);
+    CU_ASSERT_PTR_NOT_EQUAL(m1, m3);
 
     free(m1);
     free(m2);
+    free(m3);
 #undef C_MSGID1
 #undef C_MSGID2
 #undef C_MSGID3

--- a/imap/message.c
+++ b/imap/message.c
@@ -3643,7 +3643,7 @@ static int extract_convdata(struct conversations_state *state,
                             arrayu64_t *matchlist,
                             char **msubjp)
 {
-    char *hdrs[4];
+    char *hdrs[4] = { 0 };
     char *c_refs = NULL, *c_env = NULL, *c_me_msgid = NULL;
     char *c_inreplyto = NULL, *c_msgid = NULL;
     arrayu64_t cids = ARRAYU64_INITIALIZER;
@@ -3745,6 +3745,12 @@ static int extract_convdata(struct conversations_state *state,
     }
     strarray_set(&want, 0, "x-me-message-id");
     message_pruneheader(c_me_msgid, &want, 0);
+    if (!strncasecmp(c_me_msgid, "x-me-message-id:", 16)) {
+        buf_setcstr(&buf, c_me_msgid + 16);
+        buf_trim(&buf);
+        free(c_me_msgid);
+        c_me_msgid = xstrdup(buf_cstring(&buf));
+    }
     hdrs[3] = c_me_msgid;
 
     /* get Subject */

--- a/imap/message.c
+++ b/imap/message.c
@@ -3686,6 +3686,12 @@ static int extract_convdata(struct conversations_state *state,
     }
     strarray_append(&want, "references");
     message_pruneheader(c_refs, &want, 0);
+    if (!strncasecmp(c_refs, "references:", 11)) {
+        buf_setcstr(&buf, c_refs + 11);
+        buf_trim(&buf);
+        free(c_refs);
+        c_refs = xstrdup(buf_cstring(&buf));
+    }
     hdrs[0] = c_refs;
 
     /* get In-Reply-To, Message-ID out of the envelope


### PR DESCRIPTION
RFC 5322 is clear: A valid message-id must be enclosed in "<" and ">" brackets.

Unfortunately, some email implementations do not get this right and dump message-ids without brackets in their Message-Id and References headers.

This patch updates the find_msgid function to accept such malformed message-ids iff they are of the form

    WSP dot-atom-text '@' dot-atom-text [WSP|EOF]

and return them with proper closing and end brackets.

This does not apply to the In-Reply-To header, because broken MUAs tend to dump email addresses in that header.