### PR TITLE
JMAP Calendar: preserve iCalendar x-properties in updated event

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1224,7 +1224,7 @@ imap_lmtpd_SOURCES += imap/caldav_util.c imap/itip_support.c
 if JMAP
 imap_lmtpd_SOURCES += \
 	imap/jmap_util.c imap/jmap_mail_query.c imap/jmap_mail_query_parse.c \
-	imap/dav_util.c imap/jmap_notif.c imap/jmap_ical.c
+	imap/dav_util.c imap/jmap_notif.c imap/jmap_ical.c imap/jcal.c imap/xcal.c
 endif # JMAP
 
 endif # HTTPD

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_icalxprops
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_icalxprops
@@ -1,0 +1,88 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_set_preserve_icalxprops
+    :min_version_3_9 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    xlog $self, "Create event with unknown x-properties";
+
+    my $mainevent_xprop = "X-MAINEVENT-PROP;X-FOO=1:foo";
+    my $recurevent_xprop = "X-RECUREVENT-PROP;X-BAR=2:bar";
+    my $alarm_xprop = "X-ALARM-PROP;X-BAZ=3:baz";
+
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.9.5//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTART:20230309T160000Z
+DURATION:PT1H
+RRULE:FREQ=DAILY
+UID:7F81A15D-9973-4BD7-AACA-FB15F20CD815
+SUMMARY:test
+$mainevent_xprop
+BEGIN:VALARM
+UID:E576FA39-51B6-45FA-AAF3-7CCE1F21802E
+ACTION:DISPLAY
+TRIGGER:-PT5M
+$alarm_xprop
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+RECURRENCE-ID:20230310T160000Z
+DTSTART:20230310T160000Z
+DURATION:PT1H
+RRULE:FREQ=DAILY
+UID:7F81A15D-9973-4BD7-AACA-FB15F20CD815
+SUMMARY:test
+$recurevent_xprop
+END:VEVENT
+END:VCALENDAR
+EOF
+    my $res = $caldav->Request('PUT',
+        '/dav/calendars/user/cassandane/Default/test.ics',
+        $ical, 'Content-Type' => 'text/calendar');
+
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/get', { }, 'R1']
+    ]);
+    my $eventId = $res->[0][1]{list}[0]{id};
+    $self->assert_not_null($eventId);
+
+    xlog $self, "Update some event property via JMAP";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => {
+                    title => 'test2',
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog $self, "Assert iCalendar still contains x-properties";
+
+    $res = $caldav->Request('GET', 'Default/test.ics');
+    $ical = Data::ICal->new(data => $res->{content});
+
+    my $mainevent = (grep {
+            ($_->ical_entry_type() eq 'VEVENT') and (scalar $_->property('RRULE'))
+    } @{$ical->entries()})[0];
+    $self->assert_matches(qr/$mainevent_xprop/, $mainevent->as_string());
+
+    my $valarm = (grep {
+            ($_->ical_entry_type() eq 'VALARM')
+    } @{$mainevent->entries()})[0];
+    $self->assert_matches(qr/$alarm_xprop/, $valarm->as_string());
+
+    my $recurevent = (grep {
+            ($_->ical_entry_type() eq 'VEVENT') and (scalar $_->property('RECURRENCE-ID'))
+    } @{$ical->entries()})[0];
+    $self->assert_matches(qr/$recurevent_xprop/, $recurevent->as_string());
+}

--- a/imap/global.c
+++ b/imap/global.c
@@ -116,6 +116,7 @@ EXPORTED const char *config_backup_db;
 EXPORTED int charset_flags;
 EXPORTED int charset_snippet_flags;
 EXPORTED size_t config_search_maxsize;
+EXPORTED int config_httpprettytelemetry;
 
 static char session_id_buf[MAX_SESSIONID_SIZE];
 static int session_id_time = 0;
@@ -324,6 +325,9 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
         /* All search engines other than Xapian require escaped HTML */
         charset_snippet_flags |= CHARSET_ESCAPEHTML;
     }
+
+    /* Configure HTTP */
+    config_httpprettytelemetry = config_getswitch(IMAPOPT_HTTPPRETTYTELEMETRY);
 
     config_search_maxsize = config_getbytesize(IMAPOPT_SEARCH_MAXSIZE, 'K');
 

--- a/imap/global.h
+++ b/imap/global.h
@@ -179,6 +179,7 @@ extern const char *config_userdeny_db;
 extern const char *config_zoneinfo_db;
 extern const char *config_conversations_db;
 extern const char *config_backup_db;
+extern int config_httpprettytelemetry;
 extern int charset_flags;
 extern int charset_snippet_flags;
 extern size_t config_search_maxsize;

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -427,7 +427,6 @@ static int httpd_tls_required = 0;
 static int httpd_tls_enabled = 0;
 static unsigned avail_auth_schemes = 0; /* bitmask of available auth schemes */
 unsigned long config_httpmodules;
-int config_httpprettytelemetry;
 
 static time_t compile_time;
 struct buf serverinfo = BUF_INITIALIZER;
@@ -841,8 +840,6 @@ int service_init(int argc __attribute__((unused)),
             usage();
         }
     }
-
-    config_httpprettytelemetry = config_getswitch(IMAPOPT_HTTPPRETTYTELEMETRY);
 
     httpd_log_headers = strarray_split(config_getstring(IMAPOPT_HTTPLOGHEADERS),
                                        " ", STRARRAY_TRIM | STRARRAY_LCASE);

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -578,7 +578,6 @@ extern struct auth_state *httpd_authstate;
 extern struct namespace httpd_namespace;
 extern const char *httpd_localip, *httpd_remoteip;
 extern unsigned long config_httpmodules;
-extern int config_httpprettytelemetry;
 extern strarray_t *httpd_log_headers;
 extern char *httpd_altsvc;
 

--- a/imap/jcal.c
+++ b/imap/jcal.c
@@ -372,7 +372,7 @@ static json_t *icalproperty_as_json_array(icalproperty *prop)
 /*
  * Construct a JSON array for an iCalendar component.
  */
-static json_t *icalcomponent_as_json_array(icalcomponent *comp)
+EXPORTED json_t *icalcomponent_as_jcal_array(icalcomponent *comp)
 {
     icalcomponent *c;
     icalproperty *p;
@@ -423,7 +423,7 @@ static json_t *icalcomponent_as_json_array(icalcomponent *comp)
          c;
          c = icalcomponent_get_next_component(comp, ICAL_ANY_COMPONENT)) {
 
-        json_array_append_new(jsubs, icalcomponent_as_json_array(c));
+        json_array_append_new(jsubs, icalcomponent_as_jcal_array(c));
     }
     json_array_append_new(jcomp, jsubs);
 
@@ -443,7 +443,7 @@ struct buf *icalcomponent_as_jcal_string(icalcomponent *ical)
 
     if (!ical) return NULL;
 
-    jcal = icalcomponent_as_json_array(ical);
+    jcal = icalcomponent_as_jcal_array(ical);
 
     flags |= (config_httpprettytelemetry ? JSON_INDENT(2) : JSON_COMPACT);
     buf = json_dumps(jcal, flags);
@@ -763,7 +763,7 @@ static icalproperty *json_array_to_icalproperty(json_t *jprop)
 /*
  * Construct an iCalendar component from a JSON object.
  */
-static icalcomponent *json_object_to_icalcomponent(json_t *jobj)
+EXPORTED icalcomponent *jcal_array_as_icalcomponent(json_t *jobj)
 {
     json_t *jtype, *jprops, *jsubs;
     const char *type;
@@ -815,7 +815,7 @@ static icalcomponent *json_object_to_icalcomponent(json_t *jobj)
     /* Add sub-components */
     for (i = 0; i < json_array_size(jsubs); i++) {
         icalcomponent *sub =
-            json_object_to_icalcomponent(json_array_get(jsubs, i));
+            jcal_array_as_icalcomponent(json_array_get(jsubs, i));
 
         if (!sub) goto error;
 
@@ -848,7 +848,7 @@ EXPORTED icalcomponent *jcal_string_as_icalcomponent(const struct buf *buf)
         return NULL;
     }
 
-    ical = json_object_to_icalcomponent(jcal);
+    ical = jcal_array_as_icalcomponent(jcal);
 
     json_decref(jcal);
 

--- a/imap/jcal.c
+++ b/imap/jcal.c
@@ -47,7 +47,7 @@
 #include <stddef.h> /* for offsetof() macro */
 #include <syslog.h>
 
-#include "httpd.h"
+#include "global.h"
 #include "ical_support.h"
 #include "json_support.h"
 #include "jcal.h"

--- a/imap/jcal.h
+++ b/imap/jcal.h
@@ -50,6 +50,10 @@
 
 extern struct buf *icalcomponent_as_jcal_string(icalcomponent* comp);
 extern icalcomponent *jcal_string_as_icalcomponent(const struct buf *);
+
+extern json_t *icalcomponent_as_jcal_array(icalcomponent* comp);
+extern icalcomponent *jcal_array_as_icalcomponent(json_t *);
+
 extern const char *begin_jcal(struct buf *buf, struct mailbox *mailbox,
                               const char *prodid, const char *name,
                               const char *desc, const char *color);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -5224,6 +5224,7 @@ static int updateevent_apply_patch(jmap_req_t *req,
     jmapctx->to_ical.serverset = update->serverset;
     jmapctx->timezones.no_guess = 1;
     jmapctx->timezones.ignore_orphans = 1;
+    jmapctx->from_ical.want_icalprops = 1;
     context_begin_cdata(jmapctx, update->mbentry, update->cdata);
     old_event = jmapical_tojmap(myoldical, NULL, jmapctx);
     if (!old_event) {

--- a/imap/jmap_ical.h
+++ b/imap/jmap_ical.h
@@ -97,6 +97,7 @@ extern "C" {
 
 /* Custom JSCalendar properties */
 #define JMAPICAL_JSPROP_TIMEZONES     "cyrusimap.org:timeZones"
+#define JMAPICAL_JSPROP_ICALPROPS     "cyrusimap.org:iCalProps"
 
 typedef struct jstimezones jstimezones_t;
 
@@ -125,6 +126,9 @@ struct jmapical_ctx {
         int allow_method;
         json_t *replyto;
     } to_ical;
+    struct {
+        int want_icalprops;
+    } from_ical;
     struct {
         int no_guess;
         int ignore_orphans;

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -49,7 +49,7 @@
 
 #include <libxml/tree.h>
 
-#include "httpd.h"
+#include "global.h"
 #include "ical_support.h"
 #include "tok.h"
 #include "util.h"


### PR DESCRIPTION
This changes the CalendarEvent/set{update} to preserve unknown iCalendar x-properties of the original iCalendar resource.

While implemented as a Cyrus extension property in the JSCalendar object, this property only is exposed Cyrus-internally.