### PR TITLE
http_caldav.c: Strip overrides that occur before start of RRULE

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -5698,4 +5698,88 @@ EOF
     $self->assert_matches(qr/{DAV:}unbind/, $text);
 }
 
+sub test_fantastical_strip_prior_overrides
+    :needs_component_httpd :min_version_3_9
+{
+    my ($self) = @_;
+
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $uuid = "BB19B9E8-CDFB-4163-873E-EE0B9714F919";
+    my $href = "$CalendarId/$uuid.ics";
+    my $event = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Flexibits Inc./Fantastical for Mac 3.7.8//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTAMP:20230314T130600Z
+UID:$uuid
+DTEND;TZID=America/New_York:20230316T150000
+TRANSP:OPAQUE
+SUMMARY:Test
+LAST-MODIFIED:20230314T130600Z
+CREATED:20230314T130529Z
+DTSTART;TZID=America/New_York:20230316T140000
+SEQUENCE:0
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+RRULE:FREQ=DAILY
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20230314T130537Z
+UID:$uuid
+DTEND;TZID=America/New_York:20230313T163000
+TRANSP:OPAQUE
+SUMMARY:Test
+LAST-MODIFIED:20230314T130537Z
+CREATED:20230314T130529Z
+DTSTART;TZID=America/New_York:20230313T153000
+SEQUENCE:0
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+RECURRENCE-ID;TZID=America/New_York:20230313T140000
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20230314T130547Z
+UID:$uuid
+DTEND;TZID=America/New_York:20230315T170000
+TRANSP:OPAQUE
+SUMMARY:Test
+LAST-MODIFIED:20230314T130547Z
+CREATED:20230314T130529Z
+DTSTART;TZID=America/New_York:20230315T160000
+SEQUENCE:0
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+RECURRENCE-ID;TZID=America/New_York:20230315T140000
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20230314T130547Z
+UID:$uuid
+DTEND;TZID=America/New_York:20230317T170000
+TRANSP:OPAQUE
+SUMMARY:Test
+LAST-MODIFIED:20230314T130547Z
+CREATED:20230314T130529Z
+DTSTART;TZID=America/New_York:20230317T160000
+SEQUENCE:0
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+RECURRENCE-ID;TZID=America/New_York:20230317T140000
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Add event with overrides prior to start of RRULE";
+    $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
+
+    xlog $self, "Make sure prior overrides are removed but subsequent remain";
+    my $response = $CalDAV->Request('GET', $href);
+    my $newevent = $response->{content};
+
+    $self->assert_does_not_match(qr|RECURRENCE-ID;TZID=America/New_York:20230313T140000|, $newevent);
+    $self->assert_does_not_match(qr|RECURRENCE-ID;TZID=America/New_York:20230315T140000|, $newevent);
+    $self->assert_matches(qr|RECURRENCE-ID;TZID=America/New_York:20230317T140000|, $newevent);
+}
+
 1;


### PR DESCRIPTION
This is a bugfix for Fantastical when splitting a recurring event with existing overrides prior to the split.
Tested with Fantastical 3.7.8