### PR TITLE
Don't let callers pass INT_MAX as a length to snprintf()

### DIFF
--- a/lib/times.c
+++ b/lib/times.c
@@ -45,6 +45,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
+#include <sys/param.h>
 
 #include "assert.h"
 #include "times.h"
@@ -562,7 +563,7 @@ static int breakdown_time_to_iso8601(const struct timeval *t, struct tm *tm,
 
         /* UTC can be written "Z" or "+00:00" */
         if (gmtoff == 0)
-            rlen += snprintf(buf+rlen, len-rlen, "Z");
+            rlen += snprintf(buf+rlen, MIN(len-rlen, 2), "Z");
         else
             rlen += snprintf(buf+rlen, len-rlen, "%c%.2lu:%.2lu",
                              gmtnegative ? '-' : '+', gmtoff/60, gmtoff%60);


### PR DESCRIPTION
There's a lot of code history here that leads to callers passing buffers two levels down through the code to snprintf() without knowing their size and therefore passing (approximately) INT_MAX as a length argument to snprintf().

This is clearly incorrect but has worked up until now since the data written falls well within the actual size of the buffer so there are no buffer overflows.  But changes in how boundary checking is implemented in glibc 2.37 mean this is now failing on (at least) armhf.

Instead of telling snprintf() we have unlimited space in which to write our two characters, set an upper bound so snprintf() knows we need NO MORE THAN two bytes.

This is a workaround for the incorrect length argument still being passed in from up the stack.  A correct solution would fix the API to not let callers pass buffers of undeclared length down into string manipulation functions and use the overflow protection features of the language instead of relying on out-of-band promises in code comments that buffers are "big enough".

Bug-Ubuntu: https://bugs.launchpad.net/bugs/2011326