### PR TITLE
http_caldav.c: Can't access NULL cdata after precondition failure

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -5807,4 +5807,37 @@ EOF
     $self->assert_matches(qr|RECURRENCE-ID;TZID=America/New_York:20230317T140000|, $newevent);
 }
 
+sub test_conditional_delete_collection
+    :needs_component_httpd
+{
+    my ($self) = @_;
+
+    my $caldav = $self->{caldav};
+
+    my $calid = $caldav->NewCalendar({name => 'foo'});
+    $self->assert_not_null($calid);
+
+    my $res = $caldav->GetCalendar($calid);
+    $self->assert_not_null($res);
+    my $synctoken = $res->{syncToken};
+
+    xlog $self, "Try to delete collection with bogus state token";
+    $res = $caldav->ua->request('DELETE', $caldav->request_url($calid), {
+        headers => {
+            'Authorization' => $caldav->auth_header(),
+            'If' => '(<foobar>)'
+        }
+    });
+    $self->assert_str_equals('412', $res->{status});
+
+    xlog $self, "Delete collection with bogus sync token";
+    $res = $caldav->ua->request('DELETE', $caldav->request_url($calid), {
+        headers => {
+            'Authorization' => $caldav->auth_header(),
+            'If' => "(<$synctoken>)"
+        }
+    });
+    $self->assert_str_equals('204', $res->{status});
+}
+
 1;

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1091,7 +1091,7 @@ static int caldav_check_precond(struct transaction_t *txn,
 
     /* Do normal WebDAV/HTTP checks (primarily for lock-token via If header) */
     precond = dav_check_precond(txn, params, mailbox, data, etag, lastmod);
-    if (precond == HTTP_PRECOND_FAILED &&
+    if (precond == HTTP_PRECOND_FAILED && cdata &&
         cdata->comp_flags.tzbyref && !cdata->organizer && cdata->sched_tag) {
         /* Resource has just had VTIMEZONEs stripped -
            check if conditional matches previous ETag */


### PR DESCRIPTION
Fixes a crasher when a conditional DELETE collection fails due to an invalid state token