### PR TITLE
tools/build-with-cyruslibs.sh: add -Werror to CFLAGS and CXXFLAGS

### DIFF
--- a/tools/build-with-cyruslibs.sh
+++ b/tools/build-with-cyruslibs.sh
@@ -8,7 +8,8 @@ set -e
 : ${CONFIGOPTS:="--enable-jmap --enable-http --enable-calalarmd --enable-unit-tests --enable-replication --enable-nntp --enable-murder --enable-idled --enable-xapian --enable-autocreate --enable-backup --enable-silent-rules"}
 export LDFLAGS="-L$LIBSDIR/lib/x86_64-linux-gnu -L$LIBSDIR/lib -Wl,-rpath,$LIBSDIR/lib/x86_64-linux-gnu -Wl,-rpath,$LIBSDIR/lib"
 export PKG_CONFIG_PATH="$LIBSDIR/lib/x86_64-linux-gnu/pkgconfig:$LIBSDIR/lib/pkgconfig:\$PKG_CONFIG_PATH"
-export CFLAGS="-g -fPIC -W -Wall -Wextra"
+export CFLAGS="-g -fPIC -W -Wall -Wextra -Werror"
+export CXXFLAGS="-g -fPIC -W -Wall -Wextra -Werror"
 export PATH="$LIBSDIR/bin:$PATH"
 autoreconf -v -i
 echo "./configure --prefix=$TARGET $CONFIGOPTS XAPIAN_CONFIG=$LIBSDIR/bin/xapian-config-1.5"


### PR DESCRIPTION
This will make CI builds fail if our changes result in compiler warnings