### PR TITLE
IMAP::Shell: fix uninitialized value warning

### DIFF
--- a/perl/imap/IMAP/Shell.pm
+++ b/perl/imap/IMAP/Shell.pm
@@ -665,6 +665,7 @@ sub _sc_list {
     $lfh->[2]->print($$cyrref->error, "\n");
     return 1;
   }
+  $w = 0;
   foreach my $mbx (@res) {
     $l = $mbx->[0];
     if ($mbx->[1] ne '') {


### PR DESCRIPTION
From patch provided by @yaonos

Closes #4440