### PR TITLE
idled.c: squash comparison of integer expressions of different signedness

### DIFF
--- a/imap/idled.c
+++ b/imap/idled.c
@@ -168,7 +168,8 @@ static int notify_cb(sqlite3_stmt *stmt, void *rock)
     json_t *key = json_array_get(keys, 0);
     const char *keyval = json_string_value(key);
     mbentry_t *mbentry = NULL;
-    int i, notify = 0;
+    int notify = 0;
+    size_t i;
 
     /* Is it a mailbox in which the client has interest? */
     if (filter == FILTER_SELECTED) {


### PR DESCRIPTION
My local compiler (GCC 12.2.1 20221121) didn't complain, but this failed to build on Debian 10.2.1-6