### PR TITLE
cass: now depends on DateTime::Format::Mail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
       run: |
         cpanm IO::File::fcntl
         cpanm Digest::CRC
+        cpanm DateTime::Format::Mail
       shell: bash
     - name: run cassandane
       run: |

--- a/cassandane/doc/README.deps
+++ b/cassandane/doc/README.deps
@@ -45,6 +45,11 @@ Cassandane needs the following software to work:
     Ubuntu package libdatetime-perl
     RH/CentOS package perl-DateTime
 
+ * DateTime::Format::Mail
+    Convert between DateTime and RFC2822/822 formats
+    CPAN package https://metacpan.org/pod/DateTime::Format::Mail
+    Ubuntu package libdatetime-format-mail-perl
+
  * BSD::Resource
     Allows Cyrus to generate core dumps at all
     CPAN package http://search.cpan.org/dist/BSD-Resource/
@@ -159,7 +164,8 @@ Debian/Ubuntu copypasta:
        libdatetime-format-ical-perl libuniversal-require-perl \
        libtest-nowarnings-perl libtest-longstring-perl \
        libtest-warn-perl libnet-ldap-server-perl \
-       libdbd-sqlite3-perl libdigest-crc-perl
+       libdbd-sqlite3-perl libdigest-crc-perl \
+       libdatetime-format-mail-perl
 
   sudo cpan Math::Int64 Mail::JMAPTalk Mail::IMAPTalk \
        Net::CalDAVTalk Net::CardDAVTalk String::CRC32


### PR DESCRIPTION
Adds the missing dependency to Cassandane's README.deps, and installs it during the github actions CI run.

Cassandane has a lot more dependencies than those which are installed from the workflow script, which I'm not sure where they come from, but I guess they get bundled into the docker image.  Adding DateTime::Format::Mail like this is a workaround to get CI working again.