### PR TITLE
Sieve: all tests require :needs_component_httpd

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -3890,6 +3890,7 @@ EOF
 
 sub test_date_local_zone
     :needs_component_sieve :min_version_3_9
+    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -7219,6 +7220,7 @@ EOF
 
 sub test_redirect_address_with_phrase
     :needs_component_sieve
+    :needs_component_httpd
 {
     my ($self) = @_;
 


### PR DESCRIPTION
due to `services => [ ..., 'http' ]` in constructor.

If httpd has been compiled out, the tests can't work because set_up won't be able to start the requested http service, and will error out.  This fix stops these tests from trying to run when they're not going to be able to, and follows on from #4412.

We could fix this more neatly by not requesting the http service in the constructor, and instead only starting the service for the individual tests that need it.  But we don't yet have any syntactic sugar for that, so it'd be messy and annoying, and for not much real benefit.