### PR TITLE
Twoskip tidy

### DIFF
--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -1015,14 +1015,14 @@ static int find_loc(struct dbengine *db, const char *key, size_t keylen)
                          loc->keybuf.s, loc->keybuf.len);
         /* same place, and was exact.  Otherwise we're going back,
          * and the reverse pointers are no longer valid... */
-        if (db->loc.is_exactmatch && cmp == 0) {
+        if (loc->is_exactmatch && cmp == 0) {
             return 0;
         }
 
         /* we're looking after this record */
         if (cmp < 0) {
-            for (i = 0; i < db->loc.record.level; i++)
-                loc->backloc[i] = db->loc.record.offset;
+            for (i = 0; i < loc->record.level; i++)
+                loc->backloc[i] = loc->record.offset;
 
             /* read the next record */
             r = read_skipdelete(db, loc->forwardloc[0], &newrecord);
@@ -1030,7 +1030,7 @@ static int find_loc(struct dbengine *db, const char *key, size_t keylen)
 
             /* nothing afterwards? */
             if (!newrecord.offset) {
-                db->loc.is_exactmatch = 0;
+                loc->is_exactmatch = 0;
                 return 0;
             }
 
@@ -1040,8 +1040,8 @@ static int find_loc(struct dbengine *db, const char *key, size_t keylen)
 
             /* exact match? */
             if (cmp == 0) {
-                db->loc.is_exactmatch = 1;
-                db->loc.record = newrecord;
+                loc->is_exactmatch = 1;
+                loc->record = newrecord;
 
                 for (i = 0; i < newrecord.level; i++)
                     loc->forwardloc[i] = _getloc(db, &newrecord, i);
@@ -1052,7 +1052,7 @@ static int find_loc(struct dbengine *db, const char *key, size_t keylen)
 
             /* or in the gap */
             if (cmp > 0) {
-                db->loc.is_exactmatch = 0;
+                loc->is_exactmatch = 0;
                 return 0;
             }
         }

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -1924,7 +1924,7 @@ static int copy_cb(void *rock,
 {
     struct copy_rock *cr = (struct copy_rock *)rock;
 
-    return mystore(cr->db, key, keylen, val, vallen, &cr->tid, 0);
+    return skipwrite(cr->db, key, keylen, val, vallen, 0);
 }
 
 static int mycheckpoint(struct dbengine *db)

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -451,7 +451,7 @@ static int recovery2(struct dbengine *db, int *count);
 #define FNAME(db) mappedfile_fname((db)->mf)
 
 /* calculate padding size */
-static size_t roundup(size_t record_size, int howfar)
+static inline size_t roundup(size_t record_size, int howfar)
 {
     if (record_size % howfar)
         record_size += howfar - (record_size % howfar);
@@ -459,7 +459,7 @@ static size_t roundup(size_t record_size, int howfar)
 }
 
 /* choose a level appropriately randomly */
-static uint8_t randlvl(uint8_t lvl, uint8_t maxlvl)
+static inline uint8_t randlvl(uint8_t lvl, uint8_t maxlvl)
 {
     while (((float) rand() / (float) (RAND_MAX)) < PROB) {
         lvl++;

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -590,6 +590,8 @@ static int read_onerecord(struct dbengine *db, size_t offset,
 {
     const char *base = BASE(db);
     size_t size = SIZE(db);
+    const char *ptr = base + offset;
+    int i;
 
     memset(record, 0, sizeof(struct skiprecord));
 
@@ -601,9 +603,6 @@ static int read_onerecord(struct dbengine *db, size_t offset,
     /* need space for at least the header plus some details */
     if (record->offset + record->len > size)
         goto badsize;
-
-    const char *ptr = base + offset;
-    int i;
 
     /* read in the record header */
     record->type = ptr[0];


### PR DESCRIPTION
This work came out of a ZFS corruption event at Fastmail (true story) and trying to create an example of the IO patterns for a checkpoint.

This is almost all just optimising codepaths to avoid doing tests which are always false in this case, but there is one significant behaviour change - "opendb" will avoid taking and then releasing locks and just grab the locktype it eventually needs and keep it into the transaction where possible.