### PR TITLE
html tag parse fix

### DIFF
--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -1210,6 +1210,18 @@ static void test_extract(void)
     TESTCASE("<img src='cat.png' alt=\"A cat\"/><img src='dog.png' alt=\"A dog\"/>",
              "us-ascii", ENCODING_NONE, "HTML",
              "<CAT.PNG> (A CAT)<DOG.PNG> (A DOG)");
+    // multiple hrefs in same A tag (invalid!)
+    TESTCASE("<a href=\"https://foo/bar\" href=\"https://baz/qum\"/>",
+             "us-ascii", ENCODING_NONE, "HTML",
+             "<HTTPS://BAZ/QUM>"); /* last value seen is kept */
+    // multiple alt in same IMG tag (invalid!)
+    TESTCASE("<img src='cat.png' alt=\"A cat\" alt='A tabby cat'/>",
+             "us-ascii", ENCODING_NONE, "HTML",
+             "<CAT.PNG> (A TABBY CAT)"); /* last value seen is kept */
+    // multiple src in same IMG tag (invalid!)
+    TESTCASE("<img src='cat.png' src='tabby.png' alt='A tabby cat'/>",
+             "us-ascii", ENCODING_NONE, "HTML",
+             "<TABBY.PNG> (A TABBY CAT)"); /* last value seen is kept */
 }
 #undef TESTCASE
 

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -1323,6 +1323,10 @@ static void html_attr_start(struct striphtml_state *s)
             s->attr.typ = HATTR_ALT;
         }
     }
+
+    if (s->attr.typ != HATTR_NONE) {
+        dynarray_truncate(&s->attr.vals[s->attr.typ], 0);
+    }
 }
 
 static void html_attr_putc(struct striphtml_state *s, uint32_t c)
@@ -1400,6 +1404,7 @@ static void html_saw_tag(struct convert_rock *rock)
                 html_attr_cat(s, rock->next, HATTR_HREF);
                 convert_putc(rock->next, '>');
 
+                /* n.b. we only acknowledge img alt when it also has a src */
                 if (html_attr_have(s, HATTR_ALT)) {
                     convert_putc(rock->next, ' ');
                     convert_putc(rock->next, '(');


### PR DESCRIPTION
This tests and fixes (I think) a bug @robmueller and @wolfsage tracked down from, where the html_attr state wasn't being reset between tags (there's a big writeup in Linear).

I don't know lib/charset especially well, so my confidence isn't high that I haven't missed a detail...

I found a couple of surprising-but-unrelated things while in here, so I've added failing cunit tests for them (as WIP commits).  Do we want to address those too?  If not, I'll just drop those commits.  In the meantime, CI will fail on this PR because of those failing tests...

@rsto I've marked this as a draft for now until we know what (if anything) we want to do with the two WIP commits, but please review now anyway.