### PR TITLE
http_caldav_sched.c: add caldav_send_partstat_updates option

### DIFF
--- a/changes/next/caldav_send_partstat_updates
+++ b/changes/next/caldav_send_partstat_updates
@@ -1,0 +1,15 @@
+
+Description:
+
+Allow control over whether updated invites are sent when an attendee changes
+their participation status.
+
+
+Config changes:
+
+Added 'caldav_send_partstat_updates' switch
+
+
+Upgrade instructions:
+
+None.

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1396,14 +1396,13 @@ void sched_deliver(const char *cal_ownerid, const char *sched_userid,
         r = sched_deliver_local(sched_userid, sender, recipient, NULL, &sparam,
                                 sched_data, authstate, &attendee, &ical);
 
-        /* XXX  Should this be a config option? - it might have perf implications */
         if (r == 1 && SCHED_IS_REPLY(sched_data)) {
             /* Send updates to attendees - skipping sender of reply */
             icalcomponent *comp = icalcomponent_get_first_real_component(ical);
             if (icalcomponent_isa(comp) == ICAL_VPOLL_COMPONENT)
                 sched_pollstatus(cal_ownerid, sched_userid,
                                  recipient, &sparam, ical, attendee);
-            else
+            else if (config_getswitch(IMAPOPT_CALDAV_SEND_PARTSTAT_UPDATES))
                 sched_request(cal_ownerid, sched_userid, NULL, recipient,
                               NULL, ical, sched_data->mech); // oldical?
         }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -623,6 +623,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    If not set (the default), the value of the "servername" option will
    be used.*/
 
+{ "caldav_send_partstat_updates", 1, SWITCH, "UNRELEASED" }
+/* If enabled, when an attendee replies to the organizer with their
+   participation status, an updated invite will be sent to all other
+   attendees. */
+
 { "calendarprefix", "#calendars", STRING, "2.5.0" }
 /* The prefix for the calendar mailboxes hierarchies.  The hierarchy
    delimiter will be automatically appended.  The public calendar


### PR DESCRIPTION
This was an attempt to solve the problem where we send a bunch of iMIP messages for every partstat change via JMAP CalendarEvent/participantReply.  However, this PR only works for replies that arrive via CalDAV.  JMAP uses its own plumbing and will be fixed in a separate PR.

Keeping this here as a draft in case we ever need/want this functionality for CalDAV.