### PR TITLE
relocate_by_id:main() frees statically allocated data

### DIFF
--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
                 /* Add sieve path */
                 path = user_sieve_path(userid);
                 if (*path) {
-                    strarray_append(oldpaths, path);
+                    strarray_append(oldpaths, xstrdup(path));
 
                     buf_setcstr(&buf, config_getstring(IMAPOPT_SIEVEDIR));
                     buf_printf(&buf, "/%s", userpath);


### PR DESCRIPTION
By just reading the code I found out, that user_sieve_path() returns pointer to statically allocated data.  In relocate_by_id.c:main() this data is appended into strarray_t *oldpaths, and finally strarray_free(oldpaths); is called.  The latter free()s that statically allocated data.