### PR TITLE
cassandane: support custom cassandane.ini path in Makefile

### DIFF
--- a/cassandane/Cassandane/Cassini.pm
+++ b/cassandane/Cassandane/Cassini.pm
@@ -69,6 +69,11 @@ sub new
         # explicitly requested filename: just use it
         $filename = $params{filename};
     }
+    elsif (defined $ENV{CASSINI_FILENAME}) {
+        xlog "Using ini file from environment:"
+             . " filename=\"$ENV{CASSINI_FILENAME}\"";
+        $filename = $ENV{CASSINI_FILENAME};
+    }
     else {
         # check some likely places, in order
         foreach my $dir (q{.},


### PR DESCRIPTION
This updates the Cassini object to also look for its initialization file at the path defined in the optional CASSINI_FILENAME environment variable.

It has precedence over the standard cassandane.ini locations, but lower precedence than the `--config` command line argument.

Was: _This adds the CASSANDANE_INI variable to the cassandane Makefile. Before, cassandane builds only supported cassandane.ini file locations at one of the standard directories. Now, the location of a custom cassandane.ini file path can be defined before the build._