### PR TITLE
cassandane: add :want_foo magic for per-test configuration of test properties

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -91,7 +91,7 @@ sub new
             config => $config,
             deliver => 1,
             jmap => 1,
-            services => [ 'imap', 'sieve', 'http' ],
+            services => [ 'imap', 'sieve' ],
             adminstore => 1,
     }, @_);
 }
@@ -257,7 +257,6 @@ sub compile_sieve_script
 
 sub test_vacation_with_following_rules
     :needs_component_sieve :min_version_3_0
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -299,7 +298,7 @@ EOF
 }
 
 sub test_deliver
-    :needs_component_sieve :needs_component_httpd
+    :needs_component_sieve
 {
     my ($self) = @_;
 
@@ -341,7 +340,6 @@ sub test_deliver_specialuse
     :min_version_3_0
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -378,7 +376,6 @@ EOF
 sub test_deliver_compile
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -494,7 +491,6 @@ sub badscript_common
 
 sub test_badscript_sievec
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -505,7 +501,6 @@ sub test_badscript_sievec
 
 sub test_badscript_timsieved
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -516,7 +511,6 @@ sub test_badscript_timsieved
 
 sub test_dup_keep_keep
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -545,7 +539,6 @@ EOF
 
 sub test_dup_keep_fileinto
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -569,7 +562,6 @@ EOF
 
 sub test_dup_fileinto_implicit_keep_flags
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -595,7 +587,6 @@ EOF
 
 sub test_deliver_fileinto_autocreate_globalshared
     :needs_component_sieve :NoStartInstances :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -630,7 +621,6 @@ EOF
 
 sub test_deliver_fileinto_autocreate_otheruser
     :needs_component_sieve :NoStartInstances :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -668,7 +658,6 @@ EOF
 
 sub test_deliver_fileinto_autocreate_newuser
     :needs_component_sieve :NoStartInstances :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -702,7 +691,6 @@ EOF
 
 sub test_deliver_fileinto_create_globalshared
     :needs_component_sieve :min_version_3_0 :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -734,7 +722,6 @@ EOF
 
 sub test_deliver_fileinto_create_otheruser
     :needs_component_sieve :min_version_3_0 :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -769,7 +756,6 @@ EOF
 
 sub test_deliver_fileinto_create_newuser
     :needs_component_sieve :min_version_3_0 :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -800,7 +786,6 @@ EOF
 
 sub test_deliver_fileinto_create_nonimap
     :needs_component_sieve :min_version_3_0 :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -832,7 +817,6 @@ EOF
 sub test_deliver_fileinto_dot
     :UnixHierarchySep
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -881,7 +865,6 @@ EOF
 sub XXXtest_shared_delivery_addflag
     :Admin
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -934,7 +917,6 @@ EOF
 sub test_rfc5490_create
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -987,7 +969,6 @@ EOF
 sub test_rfc5490_mailboxexists
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1045,7 +1026,6 @@ EOF
 sub test_rfc5490_mailboxexists_variables
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1105,7 +1085,6 @@ EOF
 sub test_rfc5490_metadata
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1161,7 +1140,6 @@ EOF
 sub test_rfc5490_metadata_matches
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1220,7 +1198,6 @@ EOF
 sub test_rfc5490_metadataexists
     :min_version_3_0 :AnnotationAllowUndefined
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1276,7 +1253,6 @@ EOF
 sub test_rfc5490_servermetadata
     :min_version_3_0 :AnnotationAllowUndefined
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1336,7 +1312,6 @@ EOF
 sub test_rfc5490_servermetadataexists
     :min_version_3_0 :AnnotationAllowUndefined
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1394,7 +1369,6 @@ EOF
 sub test_variables_basic
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1451,7 +1425,6 @@ EOF
 sub test_sieve_setflag
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1493,7 +1466,6 @@ EOF
 sub test_variables_regex
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1549,7 +1521,6 @@ EOF
 
 sub test_nested_tests_and_discard
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1578,7 +1549,6 @@ EOF
 sub test_editheader_basic
     :min_version_3_1
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1634,7 +1604,6 @@ EOF
 sub test_editheader_complex
     :min_version_3_3
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1704,7 +1673,6 @@ EOF
 sub test_editheader_encoded_address_list
     :min_version_3_3
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1749,7 +1717,6 @@ EOF
 sub test_duplicate
     :min_version_3_1
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1798,7 +1765,6 @@ EOF
 sub test_ereject
     :min_version_3_1
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1826,7 +1792,6 @@ sub test_specialuse_exists
     :min_version_3_1
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1885,7 +1850,6 @@ sub test_specialuse
     :min_version_3_1
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1918,7 +1882,6 @@ EOF
 sub test_specialuse_create
     :min_version_3_1
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1948,7 +1911,6 @@ sub test_vacation_with_fcc
     :min_version_3_1
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -1991,7 +1953,6 @@ sub test_vacation_with_fcc_specialuse
     :min_version_3_1
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2034,7 +1995,6 @@ sub test_vacation_with_explicit_subject
     :min_version_3_1
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2080,7 +2040,6 @@ sub test_vacation_with_long_origsubject
     :min_version_3_1
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2148,7 +2107,6 @@ sub test_vacation_with_long_encoded_origsubject
     :min_version_3_1
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2227,7 +2185,6 @@ sub test_vacation_with_nonfoldable_origsubject
     :min_version_3_5
     :needs_component_sieve
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2306,7 +2263,6 @@ EOF
 sub test_github_issue_complex_variables
     :min_version_3_1
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2410,7 +2366,6 @@ EOF
 
 sub test_discard_match_on_body_raw
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2552,7 +2507,6 @@ EOF
 
 sub test_discard_match_on_body_text
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2695,7 +2649,6 @@ EOF
 sub test_fileinto_mailboxidexists
     :min_version_3_1
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2776,7 +2729,6 @@ EOF
 sub test_fileinto_mailboxid
     :min_version_3_1
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2855,7 +2807,6 @@ EOF
 sub test_fileinto_mailboxid_variable
     :min_version_3_5
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2934,7 +2885,6 @@ EOF
 
 sub test_encoded_char_variable_in_mboxname
     :needs_component_sieve :min_version_3_1 :SieveUTF8Fileinto
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -2968,7 +2918,6 @@ EOF
 
 sub test_utf8_mboxname
     :needs_component_sieve :min_version_3_1 :SieveUTF8Fileinto
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3004,7 +2953,6 @@ sub test_snooze
     :needs_component_jmap
     :min_version_3_1
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3064,7 +3012,6 @@ sub test_snooze_mailboxid
     :needs_component_jmap
     :min_version_3_1
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3127,7 +3074,6 @@ sub test_snooze_specialuse
     :needs_component_jmap
     :min_version_3_3
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3188,7 +3134,6 @@ sub test_snooze_specialuse_create
     :needs_component_jmap
     :min_version_3_3
     :NoAltNameSpace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3245,7 +3190,6 @@ sub test_snooze_tzid
     :needs_component_jmap
     :min_version_3_3
     :NoAltNamespace
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3297,7 +3241,6 @@ EOF
 sub test_utf8_subject_encoded
     :min_version_3_0
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3338,7 +3281,6 @@ EOF
 sub test_utf8_subject_raw
     :min_version_3_0
     :needs_component_sieve :NoMunge8bit
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3378,7 +3320,6 @@ EOF
 
 sub test_error_flag
     :needs_component_sieve :min_version_3_3
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3426,7 +3367,6 @@ EOF
 
 sub test_double_require
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3468,7 +3408,6 @@ EOF
 
 sub test_jmapquery
     :min_version_3_3 :needs_component_sieve :needs_component_jmap
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3541,7 +3480,6 @@ EOF
 
 sub test_jmapquery_multiple_to_cross_domain
     :min_version_3_3 :needs_component_sieve :needs_component_jmap
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3598,7 +3536,6 @@ EOF
 sub test_jmapquery_attachmentindexing
     :min_version_3_3 :needs_component_sieve :needs_component_jmap
     :needs_search_xapian :SearchAttachmentExtractor :JMAPExtensions
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3677,7 +3614,6 @@ EOF
 
 sub test_notify
     :needs_component_sieve :min_version_3_2
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3706,7 +3642,6 @@ EOF
 
 sub test_variable_modifiers
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3779,7 +3714,6 @@ EOF
 
 sub test_date
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3849,7 +3783,7 @@ EOF
 
 sub test_date_iana_tzid
     :needs_component_sieve :min_version_3_7
-    :needs_component_httpd
+    :needs_dependency_ical
 {
     my ($self) = @_;
 
@@ -3890,7 +3824,6 @@ EOF
 
 sub test_date_local_zone
     :needs_component_sieve :min_version_3_9
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -3958,7 +3891,7 @@ EOF
 
 sub test_imip_publish
     :needs_component_sieve :needs_component_httpd :min_version_3_7
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4027,7 +3960,7 @@ EOF
 
 sub test_imip_invite
     :needs_component_sieve :needs_component_httpd :min_version_3_5
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4098,7 +4031,7 @@ EOF
 
 sub test_imip_invite_base64
     :needs_component_sieve :needs_component_httpd :min_version_3_5
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4176,7 +4109,7 @@ EOF
 
 sub test_imip_invite_funky_uid
     :needs_component_sieve :needs_component_httpd :min_version_3_7
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4256,7 +4189,7 @@ EOF
 
 sub test_imip_invite_multipart
     :needs_component_sieve :needs_component_httpd :min_version_3_5
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4340,7 +4273,7 @@ EOF
 
 sub test_imip_invite_calendarid
     :needs_component_sieve :needs_component_httpd :min_version_3_5
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4413,7 +4346,7 @@ EOF
 
 sub test_imip_invite_updatesonly
     :needs_component_sieve :needs_component_httpd :min_version_3_5
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4483,7 +4416,7 @@ EOF
 
 sub test_imip_update
     :needs_component_sieve :needs_component_httpd :min_version_3_5
-    :needs_component_httpd
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4605,6 +4538,7 @@ EOF
 
 sub test_remove_itip_on_jmap_update
     :needs_component_sieve :needs_component_httpd :needs_component_jmap :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4853,6 +4787,7 @@ EOF
 
 sub test_imip_add
     :needs_component_sieve :needs_component_httpd :min_version_3_7
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -4970,6 +4905,7 @@ EOF
 
 sub test_imip_override
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -5123,6 +5059,7 @@ EOF
 
 sub test_imip_invite_single_then_master
     :needs_component_sieve :needs_component_httpd :min_version_3_7
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -5241,6 +5178,7 @@ EOF
 
 sub test_imip_update_master_and_add_override
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     # this test is mainly here to test that a crasher caused by Cyrus using
     # a libical component after it was freed
@@ -5396,6 +5334,7 @@ EOF
 
 sub test_imip_cancel_instance
     :needs_component_sieve :needs_component_httpd :min_version_3_7
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -5516,6 +5455,7 @@ EOF
 
 sub test_imip_strip_personal_data
     :needs_component_sieve :needs_component_httpd :min_version_3_7
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -5598,6 +5538,7 @@ EOF
 
 sub test_imip_preserve_alerts
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -5770,6 +5711,7 @@ EOF
 
 sub test_imip_cancel
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -5886,6 +5828,7 @@ EOF
 
 sub test_imip_cancel_delete
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -5997,6 +5940,7 @@ EOF
 
 sub test_imip_cancel_to_organizer
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6092,6 +6036,7 @@ EOF
 
 sub test_imip_reply
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6194,6 +6139,7 @@ EOF
 
 sub test_imip_reply_with_alarm
     :needs_component_sieve :needs_component_httpd :min_version_3_9
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6302,6 +6248,7 @@ EOF
 
 sub test_imip_reply_no_organizer
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6406,6 +6353,7 @@ EOF
 
 sub test_imip_reply_override
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6523,6 +6471,7 @@ EOF
 
 sub test_imip_reply_override_rdate
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6638,6 +6587,7 @@ EOF
 
 sub test_imip_reply_override_google
     :needs_component_sieve :needs_component_httpd :min_version_3_7
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6783,6 +6733,7 @@ EOF
 
 sub test_imip_reply_override_invalid
     :needs_component_sieve :needs_component_httpd :min_version_3_5
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -6979,6 +6930,7 @@ EOF
 
 sub test_imip_move_event
     :min_version_3_7 :needs_component_jmap :needs_component_sieve
+    :want_service_http
 {
     my ($self) = @_;
 
@@ -7157,7 +7109,6 @@ EOF
 
 sub test_include_cancel_implicit_keep
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -7186,7 +7137,6 @@ EOF
 
 sub test_include_fileinto_implicit_keep_flags
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 
@@ -7221,7 +7171,6 @@ EOF
 
 sub test_redirect_address_with_phrase
     :needs_component_sieve
-    :needs_component_httpd
 {
     my ($self) = @_;
 

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -143,7 +143,8 @@ my %runners =
         my ($plan, $fh) = @_;
         local *__ANON__ = "runner_tap";
         my $runner = Cassandane::Unit::Runner->new($fh);
-        my @filters = qw(x skip_version skip_missing_features);
+        my @filters = qw(x skip_version skip_missing_features
+                         enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         $runner->filter(@filters);
         return $runner->do_run($plan, 0);
@@ -153,7 +154,8 @@ my %runners =
         my ($plan, $fh) = @_;
         local *__ANON__ = "runner_pretty";
         my $runner = Cassandane::Unit::RunnerPretty->new({}, $fh);
-        my @filters = qw(x skip_version skip_missing_features);
+        my @filters = qw(x skip_version skip_missing_features
+                         enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         $runner->filter(@filters);
         return $runner->do_run($plan, 0);
@@ -163,7 +165,8 @@ my %runners =
         my ($plan, $fh) = @_;
         local *__ANON__ = "runner_prettier";
         my $runner = Cassandane::Unit::RunnerPretty->new({quiet=>1}, $fh);
-        my @filters = qw(x skip_version skip_missing_features);
+        my @filters = qw(x skip_version skip_missing_features
+                         enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         $runner->filter(@filters);
         return $runner->do_run($plan, 0);


### PR DESCRIPTION
This PR adds `:want_foo` and `:want_service_foo` magic to Cassandane::Cyrus::TestCase.  These allow properties controlled by the `want` hash to be set easily on a test-by-test basis.  Previously, you had to either set them in the constructor (affecting the whole suite); or mark individual tests with `:NoStartInstances`, and then tinker around with the options prior to calling `$self->_start_instances()`.

The list of wantable things (and their defaults) is defined as `$want` in `sub new` (unchanged).  The list of recognised service names is defined in Cassandane::ServiceFactory (also unchanged).

I have updated the Sieve test suite to make use of the new behaviour.  This suite particularly needs a http service for some, but not all, of its tests.  With the new attribute magic, the tests that need a http service can arrange to have one (or be skipped), and the tests that don't need a http service aren't skipped when Cyrus was built without http support for whatever reason.

This feature is not available for test modules that subclass directly from the Cassandane::Unit::TestCase superclass (n.b. "Unit" vs "Cyrus"), as that class has no concept of "want", and is mostly only used directly by Cassandane's self-tests anyway.

First part of #4461 