### PR TITLE
HTTP2 empty body leak fix

### DIFF
--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -728,7 +728,10 @@ static int resp_body_chunk(struct transaction_t *txn,
     syslog(LOG_DEBUG, "http2_resp_data_chunk(datalen=%u, last=%d)",
            datalen, last_chunk);
 
-    if (!datalen && !last_chunk) return 0;
+    if (!(datalen || (txn->flags.te && last_chunk))) {
+        /* Nothing to send */
+        return 0;
+    }
 
     if (txn->conn->logfd != -1) {
         /* telemetry log */

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -3678,6 +3678,11 @@ EXPORTED void write_body(long code, struct transaction_t *txn,
 
         default:
             if (txn->meth == METH_HEAD) return;
+
+            if (!outlen && last_chunk) {
+                /* Zero-length body */
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
This plugs a leak of a readmap protstream when returning a zero-length body via HTTP2.

The http_h2.c commit actually plugs the leak.
The httpd.c commit is just an optimization.  It would also plug the leak, but would hide the underlying issue.