### PR TITLE
NOTIFY & IDLE fixes

### DIFF
--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -536,4 +536,72 @@ sub test_idle
     $self->assert_str_equals('INBOX.foo', $list->[0][2]);
 }
 
+sub test_selected_delayed
+    :needs_component_idled :min_version_3_9
+{
+    my ($self) = @_;
+
+    xlog $self, "Selected-delayed test of the NOTIFY command (idled required)";
+
+    $self->{instance}->{config}->set(imapidlepoll => '2');
+    $self->{instance}->add_start(name => 'idled',
+                                 argv => [ 'idled' ]);
+    $self->{instance}->start();
+
+    my $svc = $self->{instance}->get_service('imap');
+
+    my $store = $svc->create_store();
+    my $talk = $store->get_client();
+
+    my $otherstore = $svc->create_store();
+    my $othertalk = $otherstore->get_client();
+
+    xlog $self, "The server should report the NOTIFY capability";
+    $self->assert($talk->capability()->{notify});
+
+    xlog $self, "Enable Notify";
+    my $res = $talk->_imap_cmd('NOTIFY', 0, 'STATUS', 'SET',
+                               "(SELECTED-DELAYED (MessageNew MessageExpunge FlagChange))");
+
+    xlog $self, "Examine INBOX";
+    $talk->examine("INBOX");
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    # Should get EXISTS, RECENT response
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    $self->assert_num_equals(1, $talk->get_response_code('exists'));
+    $self->assert_num_equals(1, $talk->get_response_code('recent'));
+
+    xlog $self, "EXPUNGE message from INBOX in other session";
+    $othertalk->select("INBOX");
+    $res = $othertalk->store('1', '+flags', '(\\Deleted)');
+    $res = $othertalk->expunge();
+
+    # Should get FETCH response, but NO EXPUNGE response
+    $res = $store->idle_response('FETCH', 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    my $fetch = $talk->get_response_code('fetch');
+    $self->assert_num_equals(1, $fetch->{1}{uid});
+    $self->assert_str_equals('\\Recent', $fetch->{1}{flags}[0]);
+    $self->assert_str_equals('\\Deleted', $fetch->{1}{flags}[1]);
+
+    xlog $self, "Poll for changes";
+    $talk->noop();
+
+    # Should get EXPUNGE response
+    $self->assert_num_equals(1, $talk->get_response_code('expunge'));
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -604,4 +604,84 @@ sub test_selected_delayed
     $self->assert_num_equals(1, $talk->get_response_code('expunge'));
 }
 
+sub test_change_selected
+    :needs_component_idled :min_version_3_9
+{
+    my ($self) = @_;
+
+    xlog $self, "Test of NOTIFY events following SELECTED mailbox";
+
+    $self->{instance}->{config}->set(imapidlepoll => '2');
+    $self->{instance}->add_start(name => 'idled',
+                                 argv => [ 'idled' ]);
+    $self->{instance}->start();
+
+    my $svc = $self->{instance}->get_service('imap');
+
+    my $store = $svc->create_store();
+    my $talk = $store->get_client();
+
+    my $otherstore = $svc->create_store();
+    my $othertalk = $otherstore->get_client();
+
+    xlog $self, "The server should report the NOTIFY capability";
+    $self->assert($talk->capability()->{notify});
+
+    xlog $self, "Create another mailbox";
+    $talk->create("INBOX.foo");
+
+    xlog $self, "Enable Notify";
+    my $res = $talk->_imap_cmd('NOTIFY', 0, "", 'SET',
+                               "(SELECTED (MessageNew MessageExpunge))",
+                               "(PERSONAL (MessageNew MessageExpunge))");
+
+    xlog $self, "Examine INBOX";
+    $talk->examine("INBOX");
+    $self->assert_num_equals(0, $talk->get_response_code('exists'));
+    $self->assert_num_equals(0, $talk->get_response_code('recent'));
+    $self->assert_num_equals(1, $talk->get_response_code('uidnext'));
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    # Should get EXISTS, RECENT response
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    $self->assert_num_equals(1, $talk->get_response_code('exists'));
+    $self->assert_num_equals(1, $talk->get_response_code('recent'));
+
+    xlog $self, "Examine INBOX.foo";
+    $talk->examine("INBOX.foo");
+    $self->assert_num_equals(0, $talk->get_response_code('exists'));
+    $self->assert_num_equals(0, $talk->get_response_code('recent'));
+    $self->assert_num_equals(1, $talk->get_response_code('uidnext'));
+
+    xlog $self, "MOVE message from INBOX to INBOX.foo in other session";
+    $othertalk->select("INBOX");
+    $res = $othertalk->move('1', "INBOX.foo");
+
+    # Should get EXISTS, RECENT response for INBOX.foo and STATUS response for INBOX
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response('STATUS', 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    $self->assert_num_equals(1, $talk->get_response_code('exists'));
+    $self->assert_num_equals(1, $talk->get_response_code('recent'));
+
+    my $status = $talk->get_response_code('status');
+    $self->assert_num_equals(0, $status->{'INBOX'}{messages});
+    $self->assert_num_equals(2, $status->{'INBOX'}{uidnext});
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -308,4 +308,154 @@ sub test_mailbox
     $self->assert(!$res, "no unsolicited responses");
 }
 
+sub test_idle
+    :needs_component_idled :min_version_3_9
+{
+    my ($self) = @_;
+
+    xlog $self, "Message test of the NOTIFY command (idled required)";
+
+    $self->{instance}->{config}->set(imapidlepoll => '2');
+    $self->{instance}->add_start(name => 'idled',
+                                 argv => [ 'idled' ]);
+    $self->{instance}->start();
+
+    my $svc = $self->{instance}->get_service('imap');
+
+    my $store = $svc->create_store();
+    my $talk = $store->get_client();
+
+    my $otherstore = $svc->create_store();
+    my $othertalk = $otherstore->get_client();
+
+    xlog $self, "The server should report the NOTIFY capability";
+    $self->assert($talk->capability()->{notify});
+
+    xlog $self, "Enable Notify";
+    my $res = $talk->_imap_cmd('NOTIFY', 0, "", 'SET',#'STATUS', 'SET', 'STATUS',
+                               "(SELECTED (MessageNew" .
+                               " (UID BODY.PEEK[HEADER.FIELDS (From Subject)])" .
+                               " MessageExpunge))",
+                               "(PERSONAL (MessageNew MailboxName))");
+
+    # Should NOT get STATUS response for INBOX
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    xlog $self, "Examine INBOX";
+    $talk->examine("INBOX");
+    $self->assert_num_equals(0, $talk->get_response_code('exists'));
+    $self->assert_num_equals(0, $talk->get_response_code('recent'));
+    $self->assert_num_equals(1, $talk->get_response_code('uidnext'));
+
+    xlog $self, "Sending the IDLE command";
+    $store->idle_begin()
+        or die "IDLE failed: $@";
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    # Should get EXISTS, RECENT, FETCH response
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response('FETCH', 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    $self->assert_num_equals(1, $talk->get_response_code('exists'));
+    $self->assert_num_equals(1, $talk->get_response_code('recent'));
+
+    my $fetch = $talk->get_response_code('fetch');
+    $self->assert_num_equals(1, $fetch->{1}{uid});
+    $self->assert_str_equals('Message 1', $fetch->{1}{headers}{subject}[0]);
+
+    xlog $self, "Create mailbox in other session";
+    $othertalk->create("INBOX.foo");
+
+    # Should get LIST response
+    $res = $store->idle_response('LIST', 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    my $list = $talk->get_response_code('list');
+    $self->assert_str_equals('INBOX.foo', $list->[0][2]);
+
+    xlog $self, "MOVE message from INBOX to INBOX.foo in other session";
+    $othertalk->select("INBOX");
+    $res = $othertalk->move('1', "INBOX.foo");
+
+    # Should get STATUS response for INBOX.foo and EXPUNGE response for INBOX
+    $res = $store->idle_response('STATUS', 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    my $status = $talk->get_response_code('status');
+    $self->assert_num_equals(1, $status->{'INBOX.foo'}{messages});
+    $self->assert_num_equals(2, $status->{'INBOX.foo'}{uidnext});
+    $self->assert_num_equals(1, $talk->get_response_code('expunge'));
+
+    xlog $self, "Sending DONE continuation";
+    $store->idle_end({});
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    xlog $self, "Deliver a message";
+    $msg = $self->{gen}->generate(subject => "Message 2");
+    $self->{instance}->deliver($msg);
+
+    # Should get EXISTS, RECENT, FETCH response
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response('FETCH', 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    $self->assert_num_equals(1, $talk->get_response_code('exists'));
+    $self->assert_num_equals(1, $talk->get_response_code('recent'));
+
+    $fetch = $talk->get_response_code('fetch');
+    $self->assert_num_equals(2, $fetch->{1}{uid});
+    $self->assert_str_equals('Message 2', $fetch->{1}{headers}{subject}[0]);
+
+    xlog $self, "Unselect INBOX";
+    $talk->unselect();
+
+    xlog $self, "Deliver a message";
+    $msg = $self->{gen}->generate(subject => "Message 3");
+    $self->{instance}->deliver($msg);
+
+    # Should get STATUS response for INBOX
+    $res = $store->idle_response('STATUS', 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    $status = $talk->get_response_code('status');
+    $self->assert_num_equals(2, $status->{'INBOX'}{messages});
+    $self->assert_num_equals(4, $status->{'INBOX'}{uidnext});
+
+    xlog $self, "Delete mailbox in other session";
+    $othertalk->delete("INBOX.foo");
+
+    # Should get LIST response with \NonExistent
+    $res = $store->idle_response({}, 3);
+    $self->assert($res, "received an unsolicited response");
+    $res = $store->idle_response({}, 1);
+    $self->assert(!$res, "no more unsolicited responses");
+
+    $list = $talk->get_response_code('list');
+    $self->assert_str_equals('\\NonExistent', $list->[0][0][0]);
+    $self->assert_str_equals('INBOX.foo', $list->[0][2]);
+}
+
 1;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -258,9 +258,6 @@ static struct index_state *imapd_index;
 /* current namespace */
 struct namespace imapd_namespace;
 
-/* track if we're idling */
-static int idling = 0;
-
 const struct mbox_name_attribute mbox_name_attributes[] = {
     /* from RFC 3501 */
     { MBOX_ATTRIBUTE_NOINFERIORS,   "\\Noinferiors"   },
@@ -3492,10 +3489,6 @@ static void cmd_idle(char *tag)
 
         idle_start(IMAP_NOTIFY_MESSAGE, time(NULL) + idle_timeout,
                    FILTER_SELECTED, &key);
-
-        /* Use this flag so if getc causes a shutdown due to
-           connection abort we tell idled about it */
-        idling = 1;
     }
 
     /* Tell client we are idling and waiting for end of command */
@@ -3551,7 +3544,6 @@ static void cmd_idle(char *tag)
         /* If NOTIFY has NOT already been enabled,
            tell idled to stop sending message updates */
         idle_stop(FILTER_SELECTED);
-        idling = 0;
     }
 
     if (shutdown) {

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3484,8 +3484,9 @@ static void cmd_idle(char *tag)
             return;
         }
     }
-    else if (imapd_index && idle_sock != PROT_NO_FD) {
-        /* Tell idled to start sending message updates */
+    else if (imapd_index && idle_sock != PROT_NO_FD && !notify_event_groups) {
+        /* If NOTIFY has NOT already been enabled,
+           tell idled to start sending message updates */
         const char *mboxid = index_mboxid(imapd_index);
         strarray_t key = { 1, 0, (char **) &mboxid }; // avoid memory alloc
 
@@ -3547,7 +3548,8 @@ static void cmd_idle(char *tag)
         pipe_until_tag(backend_current, tag, 0);
     }
     else if (idle_sock != PROT_NO_FD && !notify_event_groups) {
-        /* Stop message updates */
+        /* If NOTIFY has NOT already been enabled,
+           tell idled to stop sending message updates */
         idle_stop(FILTER_SELECTED);
         idling = 0;
     }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1362,6 +1362,10 @@ static void imapd_check(struct backend *be, unsigned tell_flags)
     }
     else {
         /* local mailbox */
+        if (notify_event_groups &&
+            !(notify_event_groups->selected.events & IMAP_NOTIFY_FLAG_CHANGE))
+            tell_flags |= TELL_SILENT;
+
         index_check(imapd_index, tell_flags);
     }
 }
@@ -3263,7 +3267,7 @@ static void cmd_noop(char *tag, char *cmd)
         return;
     }
 
-    index_check(imapd_index, TELL_EXPUNGED);
+    imapd_check(NULL, TELL_EXPUNGED);
 
     prot_printf(imapd_out, "%s OK %s\r\n", tag,
                 error_message(IMAP_OK_COMPLETED));
@@ -15929,7 +15933,7 @@ static void cmd_notify(char *tag, int set)
             key.data = (char **) &mboxid;
             idle_start(new_egroups->selected.events, 0, FILTER_SELECTED, &key);
 
-            index_check(imapd_index, TELL_EXPUNGED | TELL_UID);
+            imapd_check(NULL, TELL_EXPUNGED | TELL_UID);
 
             if (srock.mboxnames) {
                 hash_insert(index_mboxname(imapd_index),
@@ -16099,7 +16103,7 @@ static void push_updates(void)
                     !(etype & (EVENT_MESSAGE_EXPUNGE | EVENT_MESSAGE_EXPIRE)))
                     tell_flags &= ~TELL_EXPUNGED;
 
-                index_check(imapd_index, tell_flags);
+                imapd_check(NULL, tell_flags);
             }
 
             goto done;

--- a/imap/index.c
+++ b/imap/index.c
@@ -893,7 +893,7 @@ EXPORTED void index_select(struct index_state *state, struct index_init *init)
 /*
  * Check for and report updates
  */
-EXPORTED int index_check(struct index_state *state, int usinguid, int printuid)
+EXPORTED int index_check(struct index_state *state, unsigned tell_flags)
 {
     int r;
 
@@ -931,8 +931,7 @@ EXPORTED int index_check(struct index_state *state, int usinguid, int printuid)
 
     if (r) return r;
 
-    index_tellchanges(state,
-                      (usinguid ? TELL_EXPUNGED : 0) | (printuid ? TELL_UID : 0));
+    index_tellchanges(state, tell_flags);
     index_unlock(state);
 
     return r;
@@ -1774,7 +1773,7 @@ EXPORTED int index_scan(struct index_state *state, const char *contents)
 
     if (!(contents && contents[0])) return(0);
 
-    if (index_check(state, 0, 0))
+    if (index_check(state, 0))
         return 0;
 
     if (state->exists <= 0) return 0;
@@ -2197,7 +2196,7 @@ EXPORTED int index_sort(struct index_state *state,
     int r;
 
     /* update the index */
-    if (index_check(state, 0, 0))
+    if (index_check(state, 0))
         return 0;
 
     highestmodseq = needs_modseq(searchargs, NULL);
@@ -3052,7 +3051,7 @@ EXPORTED int index_thread(struct index_state *state, int algorithm,
     int r;
 
     /* update the index */
-    if (index_check(state, 0, 0))
+    if (index_check(state, 0))
         return 0;
 
     highestmodseq = needs_modseq(searchargs, NULL);
@@ -3143,7 +3142,7 @@ index_copy(struct index_state *state,
     if (is_same_user < 0)
         return is_same_user;
 
-    r = index_check(state, usinguid, usinguid);
+    r = index_check(state, usinguid ? TELL_UID|TELL_EXPUNGED : 0);
     if (r) return r;
 
     srcmailbox = state->mailbox;
@@ -3358,7 +3357,7 @@ EXPORTED int index_copy_remote(struct index_state *state, char *sequence,
     struct index_map *im;
     int r;
 
-    r = index_check(state, usinguid, usinguid);
+    r = index_check(state, usinguid ? TELL_UID|TELL_EXPUNGED : 0);
     if (r) return r;
 
     seq = _parse_sequence(state, sequence, usinguid);

--- a/imap/index.h
+++ b/imap/index.h
@@ -313,7 +313,7 @@ extern uint32_t index_finduid(struct index_state *state, uint32_t uid, int mode)
 extern uint32_t index_getuid(struct index_state *state, uint32_t msgno);
 extern void index_tellchanges(struct index_state *state, unsigned tell_flags);
 extern modseq_t index_highestmodseq(struct index_state *state);
-extern int index_check(struct index_state *state, int usinguid, int printuid);
+extern int index_check(struct index_state *state, unsigned tell_flags);
 extern seqset_t *index_vanished(struct index_state *state,
                                     struct vanished_params *params);
 extern int index_urlfetch(struct index_state *state, uint32_t msgno,


### PR DESCRIPTION
- This PR is best reviewed commit-by-commit.
- The first commit fixes the SQLite UNIQUE constraint noise cause by using IDLE after NOTIFY.
- A couple commits are cleanup and refactor for subsequent commits.
- Most of the remaining commits are fixes/tests for NOTIFY.
- The last commit is an IDLE tweak when polling due to lack of idled (or lack of IDLE on backend) and some code cleanup/reorganization.