### PR TITLE
squatter: do not hold mailbox locks while calling the attachment extract service

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -639,6 +639,7 @@ cunit_TESTS = \
 	cunit/mboxname.testc \
 	cunit/md5.testc \
 	cunit/message.testc \
+	cunit/message_guid.testc \
 	cunit/msgid.testc \
 	cunit/parseaddr.testc \
 	cunit/parse.testc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1011,6 +1011,8 @@ imap_libcyrus_imap_la_SOURCES = \
 	imap/annotate.h \
 	imap/append.c \
 	imap/append.h \
+	imap/attachextract.c \
+	imap/attachextract.h \
 	imap/backend.c \
 	imap/backend.h \
 	imap/conversations.c \

--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -1562,7 +1562,7 @@ sub test_striphtml_rfc822
 }
 
 sub test_squatter_partials
-    :min_version_3_3 :needs_search_xapian :SearchAttachmentExtractor
+    :min_version_3_3 :needs_search_xapian :SearchAttachmentExtractor :NoCheckSyslog
 {
     my ($self) = @_;
     my $instance = $self->{instance};
@@ -1632,7 +1632,6 @@ sub test_squatter_partials
     ) || die;
 
     xlog "Run squatter and allow partials";
-    $self->{instance}->{ignore_syslog} = 1;
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-p', '-Z');
 
     xlog "Assert text bodies of both messages are indexed";
@@ -1660,13 +1659,10 @@ sub test_squatter_partials
     xlog "Assert attachment of first message is indexed";
     $uids = $imap->search('fuzzy', 'xattachmentbody', 'attach1');
     $self->assert_deep_equals([1], $uids);
-
-    # clear syslog to not fail for expected IOERROR messages
-    $self->{instance}->getsyslog();
 }
 
 sub test_squatter_skip422
-    :min_version_3_3 :needs_search_xapian :SearchAttachmentExtractor
+    :min_version_3_3 :needs_search_xapian :SearchAttachmentExtractor :NoCheckSyslog
 {
     my ($self) = @_;
     my $instance = $self->{instance};
@@ -1719,7 +1715,6 @@ sub test_squatter_skip422
     ) || die;
 
     xlog "Run squatter and allow partials";
-    $self->{instance}->{ignore_syslog} = 1;
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-p', '-Z');
 
     xlog "Assert text bodies of both messages are indexed";
@@ -1733,9 +1728,6 @@ sub test_squatter_skip422
     xlog "Assert attachment of second message is not indexed";
     $uids = $imap->search('fuzzy', 'xattachmentbody', 'attach2');
     $self->assert_deep_equals([], $uids);
-
-    # clear syslog to not fail for expected IOERROR messages
-    $self->{instance}->getsyslog();
 }
 
 sub test_fuzzyalways_annot

--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -44,6 +44,7 @@ use Cwd qw(abs_path);
 use DateTime;
 use Data::Dumper;
 use File::Temp qw(tempdir);
+use File::stat;
 
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
@@ -1921,37 +1922,48 @@ sub test_reindex_mb_uniqueid
 
 sub start_echo_extractor
 {
-    my ($self, $tracedir, @squatterArgs) = @_;
+    my ($self, %params) = @_;
     my $instance = $self->{instance};
 
-    xlog "Start extractor server with tracedir $tracedir";
+    xlog "Start extractor server with tracedir $params{tracedir}";
     my $nrequests = 0;
     my $handler = sub {
         my ($conn, $req) = @_;
 
-        # determine guid of attachment
-        my @paths = split(q{/}, URI->new($req->uri)->path);
-        my $guid = pop(@paths);
-
-        # touch trace file
         $nrequests++;
-        my $fname = join(q{}, $tracedir, "/req", $nrequests, "_", $req->method, "_$guid");
-        open(my $fh, ">", $fname) or die "Can't open > $fname: $!";
-        close $fh;
+
+        if ($params{trace_delay_seconds}) {
+            sleep $params{trace_delay_seconds};
+        }
+
+        if ($params{tracedir}) {
+            # touch trace file in tracedir
+            my @paths = split(q{/}, URI->new($req->uri)->path);
+            my $guid = pop(@paths);
+            my $fname = join(q{},
+                $params{tracedir}, "/req", $nrequests, "_", $req->method, "_$guid");
+            open(my $fh, ">", $fname) or die "Can't open > $fname: $!";
+            close $fh;
+        }
+
+        my $res;
 
         if ($req->method eq 'HEAD') {
-            my $res = HTTP::Response->new(204);
+            $res = HTTP::Response->new(204);
             $res->content("");
-            $conn->send_response($res);
         } elsif ($req->method eq 'GET') {
-            my $res = HTTP::Response->new(404);
+            $res = HTTP::Response->new(404);
             $res->content("nope");
-            $conn->send_response($res);
         } else {
-            my $res = HTTP::Response->new(200);
+            $res = HTTP::Response->new(200);
             $res->content($req->content);
-            $conn->send_response($res);
         }
+
+        if ($params{response_delay_seconds}) {
+            sleep $params{response_delay_seconds};
+        }
+
+        $conn->send_response($res);
     };
 
     my $uri = URI->new($instance->{config}->get('search_attachment_extractor_url'));
@@ -2007,7 +2019,7 @@ sub test_squatter_attachextract_cache
     my $imap = $self->{store}->get_client();
 
     my $tracedir = tempdir(DIR => $instance->{basedir} . "/tmp");
-    $self->start_echo_extractor($tracedir);
+    $self->start_echo_extractor(tracedir => $tracedir);
 
     xlog "Create and index index messages";
     my $cachedir = tempdir(DIR => $instance->{basedir} . "/tmp");
@@ -2031,14 +2043,14 @@ sub test_squatter_attachextract_cache
 }
 
 sub test_squatter_attachextract_cachedir_noperm
-    :min_version_3_9 :needs_search_xapian :SearchAttachmentExtractor
+    :min_version_3_9 :needs_search_xapian :SearchAttachmentExtractor :NoCheckSyslog
 {
     my ($self) = @_;
     my $instance = $self->{instance};
     my $imap = $self->{store}->get_client();
 
     my $tracedir = tempdir(DIR => $instance->{basedir} . "/tmp");
-    $self->start_echo_extractor($tracedir);
+    $self->start_echo_extractor(tracedir => $tracedir);
 
     xlog "Run squatter with read-only cache directory";
     my $cachedir = tempdir(DIR => $instance->{basedir} . "/tmp");
@@ -2049,9 +2061,9 @@ sub test_squatter_attachextract_cachedir_noperm
     my $uids = $imap->search('fuzzy', 'body', 'bodyterm');
     $self->assert_deep_equals([1,2], $uids);
 
-    xlog "Assert attachments of both messages are indexed";
+    xlog "Assert attachments of both messages are not indexed";
     $uids = $imap->search('fuzzy', 'xattachmentbody', 'attachterm');
-    $self->assert_deep_equals([1,2], $uids);
+    $self->assert_deep_equals([], $uids);
 
     xlog "Assert extractor got called twice with attachment uploads";
     my @tracefiles = glob($tracedir."/*_PUT_*");
@@ -2071,7 +2083,7 @@ sub test_squatter_attachextract_cacheonly
     my $imap = $self->{store}->get_client();
 
     my $tracedir = tempdir(DIR => $instance->{basedir} . "/tmp");
-    $self->start_echo_extractor($tracedir);
+    $self->start_echo_extractor(tracedir => $tracedir);
 
     xlog "Instruct squatter to only use attachextract cache";
     my $cachedir = tempdir(DIR => $instance->{basedir} . "/tmp");
@@ -2093,6 +2105,76 @@ sub test_squatter_attachextract_cacheonly
     xlog "Assert cache contains no file";
     my @files = glob($cachedir."/*");
     $self->assert_num_equals(0, scalar @files);
+}
+
+sub test_squatter_attachextract_nolock
+    :min_version_3_9 :needs_search_xapian :SearchAttachmentExtractor
+{
+    my ($self) = @_;
+    my $instance = $self->{instance};
+    my $imap = $self->{store}->get_client();
+
+    my $tracedir = tempdir(DIR => $instance->{basedir} . "/tmp");
+    $self->start_echo_extractor(
+        tracedir => $tracedir,
+        trace_delay_seconds => 1,
+        response_delay_seconds => 1,
+    );
+
+    xlog $self, "Make plain text message";
+    $self->make_message("msg1",
+        mime_type => "text/plain",
+        body => "bodyterm");
+
+    xlog $self, "Make message with attachment";
+    $self->make_message("msg2",
+        mime_type => "multipart/related",
+        mime_boundary => "123456789abcdef",
+        body => ""
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: text/plain\r\n"
+        ."\r\n"
+        ."bodyterm"
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: application/pdf\r\n"
+        ."Content-Transfer-Encoding: base64\r\n"
+        ."\r\n"
+        # that's "attachterm"
+        ."YXR0YWNodGVybQo="
+        ."\r\n--123456789abcdef--\r\n");
+
+    xlog $self, "Clear syslog";
+    $self->{instance}->getsyslog();
+
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v');
+
+    xlog $self, "Inspect syslog and extractor trace files";
+    my @log = grep {
+        /squatter\[\d+\]: (released|reacquired) mailbox lock/
+    } $self->{instance}->getsyslog();
+
+    my ($released_timestamp) = ($log[0] =~ /released.+unixepoch=<(\d+)>/);
+    $self->assert_not_null($released_timestamp);
+
+    my @tracefiles = glob($tracedir."/*_PUT_*");
+    $self->assert_num_equals(1, scalar @tracefiles);
+    my $extractor_timestamp = stat($tracefiles[0])->ctime;
+    $self->assert_not_null($extractor_timestamp);
+
+    my ($reacquired_timestamp) = ($log[1] =~ /reacquired.+unixepoch=<(\d+)>/);
+    $self->assert_not_null($reacquired_timestamp);
+
+    xlog $self, "Assert extractor got called without mailbox lock";
+    $self->assert_num_lt($extractor_timestamp, $released_timestamp);
+    $self->assert_num_lt($reacquired_timestamp, $extractor_timestamp);
+
+    xlog $self, "Assert terms actually got indexed";
+    my $uids = $imap->search('fuzzy', 'body', 'bodyterm');
+    $self->assert_deep_equals([1,2], $uids);
+
+    $uids = $imap->search('fuzzy', 'xattachmentbody', 'attachterm');
+    $self->assert_deep_equals([2], $uids);
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -2177,4 +2177,56 @@ sub test_squatter_attachextract_nolock
     $self->assert_deep_equals([2], $uids);
 }
 
+sub test_squatter_attachextract_timeout
+    :min_version_3_9 :needs_search_xapian :SearchAttachmentExtractor :NoCheckSyslog
+{
+    my ($self) = @_;
+    my $instance = $self->{instance};
+    my $imap = $self->{store}->get_client();
+
+    my $tracedir = tempdir (DIR => $instance->{basedir} . "/tmp");
+
+    # SearchAttachmentExtractor magic configures Cyrus to
+    # wait at most 3 seconds for a response from extractor
+
+    $self->start_echo_extractor(
+        tracedir => $tracedir,
+        response_delay_seconds => 5,
+    );
+
+    xlog $self, "Make message with attachment";
+    $self->make_message("msg2",
+        mime_type => "multipart/related",
+        mime_boundary => "123456789abcdef",
+        body => ""
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: text/plain\r\n"
+        ."\r\n"
+        ."bodyterm"
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: application/pdf\r\n"
+        ."\r\n"
+        ."attachterm"
+        ."\r\n--123456789abcdef--\r\n");
+
+    xlog $self, "Clear syslog";
+    $self->{instance}->getsyslog();
+
+    xlog $self, "Run squatter (allowing partials)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-p');
+
+    xlog "Assert text body is indexed";
+    my $uids = $imap->search('fuzzy', 'body', 'bodyterm');
+    $self->assert_deep_equals([1], $uids);
+
+    xlog "Assert attachement is not indexed";
+    $uids = $imap->search('fuzzy', 'xattachmentbody', 'attachterm');
+    $self->assert_deep_equals([], $uids);
+
+    xlog "Assert extractor got only called once";
+    my @tracefiles = glob($tracedir."/*");
+    $self->assert_num_equals(1, scalar @tracefiles);
+    $self->assert_matches(qr/req1_GET_/, $tracefiles[0]);
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -2252,4 +2252,102 @@ sub test_squatter_attachextract_timeout
     $self->assert_matches(qr/req3_PUT_/, $tracefiles[2]);
 }
 
+sub test_squatter_attachextract_unprocessable_content
+    :min_version_3_9 :needs_search_xapian :SearchAttachmentExtractor :NoCheckSyslog
+{
+    my ($self) = @_;
+    my $instance = $self->{instance};
+    my $imap = $self->{store}->get_client();
+
+    my $tracedir = tempdir (DIR => $instance->{basedir} . "/tmp");
+    my $nrequests = 0;
+
+    xlog "Start extractor server";
+    my $handler = sub {
+        my ($conn, $req) = @_;
+
+        $nrequests++;
+
+        # touch trace file in tracedir
+        my @paths = split(q{/}, URI->new($req->uri)->path);
+        my $guid = pop(@paths);
+        my $fname = join(q{},
+            $tracedir, "/req", $nrequests, "_", $req->method, "_$guid");
+        open(my $fh, ">", $fname) or die "Can't open > $fname: $!";
+        close $fh;
+
+        my $res;
+
+        if ($req->method eq 'HEAD') {
+            $res = HTTP::Response->new(404);
+            $res->content("");
+        } elsif ($req->method eq 'GET') {
+            $res = HTTP::Response->new(404);
+            $res->content("nope");
+        } else {
+            # return HTTP 422 Unprocessable Content
+            $res = HTTP::Response->new(422);
+            $res->content("nope");
+        }
+
+        $conn->send_response($res);
+    };
+
+    my $uri = URI->new($instance->{config}->get('search_attachment_extractor_url'));
+    $instance->start_httpd($handler, $uri->port());
+
+    xlog $self, "Make message with unprocessable attachment";
+    $self->make_message("msg1",
+        mime_type => "multipart/related",
+        mime_boundary => "123456789abcdef",
+        body => ""
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: text/plain\r\n"
+        ."\r\n"
+        ."bodyterm"
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: application/octet-stream\r\n"
+        ."\r\n"
+        ."attachterm"
+        ."\r\n--123456789abcdef--\r\n");
+
+    xlog $self, "Clear syslog";
+    $self->{instance}->getsyslog();
+
+    xlog $self, "Run squatter (allowing partials)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-p');
+
+    xlog "Assert text body is indexed";
+    my $uids = $imap->search('fuzzy', 'body', 'bodyterm');
+    $self->assert_deep_equals([1], $uids);
+
+    xlog "Assert attachement is not indexed";
+    $uids = $imap->search('fuzzy', 'xattachmentbody', 'attachterm');
+    $self->assert_deep_equals([], $uids);
+
+    xlog "Assert extractor got called";
+    my @tracefiles = glob($tracedir."/*");
+    $self->assert_num_equals(2, scalar @tracefiles);
+    $self->assert_matches(qr/req1_GET_/, $tracefiles[0]);
+    $self->assert_matches(qr/req2_PUT_/, $tracefiles[1]);
+
+    xlog $self, "Rerun squatter for partials";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-i', '-P');
+
+    xlog "Assert text body is indexed";
+    $uids = $imap->search('fuzzy', 'body', 'bodyterm');
+    $self->assert_deep_equals([1], $uids);
+
+    xlog "Assert attachement is not indexed";
+    $uids = $imap->search('fuzzy', 'xattachmentbody', 'attachterm');
+    $self->assert_deep_equals([], $uids);
+
+    xlog "Assert extractor got called no more time";
+    @tracefiles = glob($tracedir."/*");
+    $self->assert_num_equals(2, scalar @tracefiles);
+    $self->assert_matches(qr/req1_GET_/, $tracefiles[0]);
+    $self->assert_matches(qr/req2_PUT_/, $tracefiles[1]);
+}
+
+
 1;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -451,6 +451,10 @@ magic(AllowCalendarAdmin => sub {
     my $conf = shift;
     $conf->config_set('caldav_allowcalendaradmin' => 'yes');
 });
+magic(NoCheckSyslog => sub {
+    my $self = shift;
+    $self->{no_check_syslog} = 1;
+});
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic
@@ -849,6 +853,11 @@ sub set_up
         xlog $self, "HTTP service objects not setup due to :NoStartInstances"
                     . " magic!";
     }
+
+    if ($self->{no_check_syslog}) {
+        xlog $self, "Disabling syslog checks for test instance";
+    }
+
     xlog $self, "Calling test function";
 }
 
@@ -976,31 +985,51 @@ sub tear_down
 
     if (defined $self->{instance})
     {
-        eval { push @stop_errors, $self->{instance}->stop() };
+        eval {
+            push @stop_errors, $self->{instance}->stop(
+                no_check_syslog => defined $self->{no_check_syslog}
+            );
+        };
         push @basedirs, $self->{instance}->get_basedir();
         $self->{instance} = undef;
     }
     if (defined $self->{backups})
     {
-        eval { push @stop_errors, $self->{backups}->stop() };
+        eval {
+            push @stop_errors, $self->{backups}->stop(
+                no_check_syslog => defined $self->{no_check_syslog}
+            );
+        };
         push @basedirs, $self->{backups}->get_basedir();
         $self->{backups} = undef;
     }
     if (defined $self->{backend2})
     {
-        eval { push @stop_errors, $self->{backend2}->stop() };
+        eval {
+            push @stop_errors, $self->{backend2}->stop(
+                no_check_syslog => defined $self->{no_check_syslog}
+            );
+        };
         push @basedirs, $self->{backend2}->get_basedir();
         $self->{backend2} = undef;
     }
     if (defined $self->{replica})
     {
-        eval { push @stop_errors, $self->{replica}->stop() };
+        eval {
+            push @stop_errors, $self->{replica}->stop(
+                no_check_syslog => defined $self->{no_check_syslog}
+            );
+        };
         push @basedirs, $self->{replica}->get_basedir();
         $self->{replica} = undef;
     }
     if (defined $self->{frontend})
     {
-        eval { push @stop_errors, $self->{frontend}->stop() };
+        eval {
+            push @stop_errors, $self->{frontend}->stop(
+                no_check_syslog => defined $self->{no_check_syslog}
+            );
+        };
         push @basedirs, $self->{frontend}->get_basedir();
         $self->{frontend} = undef;
     }

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -371,12 +371,14 @@ magic(JMAPExtensions => sub {
 });
 magic(SearchAttachmentExtractor => sub {
     my $port = Cassandane::PortManager::alloc("localhost");
-    shift->config_set('search_attachment_extractor_url' =>
+    my $self = shift;
+    $self->config_set('search_attachment_extractor_url' =>
         "http://localhost:$port/extractor");
+    $self->config_set('search_attachment_extractor_request_timeout' => '3s');
+    $self->config_set('search_attachment_extractor_idle_timeout' => '3s');
 });
 magic(SearchLanguage => sub {
-    my $self = shift;
-    $self->config_set('search_index_language' => 'yes');
+    shift->config_set('search_index_language' => 'yes');
 });
 magic(SieveUTF8Fileinto => sub {
     shift->config_set('sieve_utf8fileinto' => 'yes');

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1573,7 +1573,7 @@ sub send_sighup
 #
 sub stop
 {
-    my ($self) = @_;
+    my ($self, %params) = @_;
 
     $self->_init_basedir_and_name();
 
@@ -1610,7 +1610,7 @@ sub stop
 
     push @errors, $self->_check_valgrind_logs();
     push @errors, $self->_check_cores();
-    push @errors, $self->_check_syslog();
+    push @errors, $self->_check_syslog() unless $params{no_check_syslog};
 
     # filter out empty errors (shouldn't be any, but just in case)
     @errors = grep { $_ } @errors;

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -338,6 +338,22 @@ sub assert_num_lte
                   "$actual is not less-than-or-equal-to $expected");
 }
 
+sub assert_num_gt
+{
+    my ($self, $expected, $actual) = @_;
+
+    $self->assert(($actual > $expected),
+                  "$actual is not greater-than $expected");
+}
+
+sub assert_num_lt
+{
+    my ($self, $expected, $actual) = @_;
+
+    $self->assert(($actual < $expected),
+                  "$actual is not less-than $expected");
+}
+
 sub assert_date_matches
 {
     my ($self, $expected, $actual, $tolerance) = @_;

--- a/changes/next/squatter_nolock_attachment_text_extraction
+++ b/changes/next/squatter_nolock_attachment_text_extraction
@@ -1,0 +1,20 @@
+Description:
+
+Updates squatter to not lock a mailbox while extracting text
+from attachments.
+
+
+Config changes:
+
+search_attachment_extractor_request_timeout
+search_attachment_extractor_idle_timeout
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/cunit/message_guid.testc
+++ b/cunit/message_guid.testc
@@ -1,0 +1,13 @@
+#include "cunit/cyrunit.h"
+#include "imap/message_guid.h"
+
+static void test_clone(void)
+{
+    struct message_guid guid_a = MESSAGE_GUID_INITIALIZER;
+
+    message_guid_generate(&guid_a, "foobar", 6);
+    struct message_guid guid_b = message_guid_clone(&guid_a);
+
+    CU_ASSERT_EQUAL(0, memcmp(guid_a.value, guid_b.value, MESSAGE_GUID_SIZE));
+    CU_ASSERT_EQUAL(guid_a.status, guid_b.status);
+}

--- a/cunit/strarray.testc
+++ b/cunit/strarray.testc
@@ -1714,5 +1714,54 @@ static void test_swap(void)
 #undef WORD1
 }
 
+static void test_appendv(void)
+{
+    strarray_t sa = STRARRAY_INITIALIZER;
+    const char *s;
+
+    s = strarray_appendv(&sa, "lorem");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 0));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 1);
+
+    s = strarray_appendv(&sa, "ipsum");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 1));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+}
+
+static void test_addv(void)
+{
+    strarray_t sa = STRARRAY_INITIALIZER;
+    const char *s;
+
+    s = strarray_addv(&sa, "lorem");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 0));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 1);
+
+    s = strarray_addv(&sa, "ipsum");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 1));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+
+    s = strarray_addv(&sa, "lorem");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 0));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+}
+
+static void test_add_casev(void)
+{
+    strarray_t sa = STRARRAY_INITIALIZER;
+    const char *s;
+
+    s = strarray_add_casev(&sa, "lorem");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 0));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 1);
+
+    s = strarray_add_casev(&sa, "ipsum");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 1));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+
+    s = strarray_add_casev(&sa, "lOREm");
+    CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 0));
+    CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+}
 
 /* vim: set ft=c: */

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -215,6 +215,7 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
     const char **hdr, *p;
     char *cachefname = NULL;
     struct buf buf = BUF_INITIALIZER;
+    unsigned statuscode = 0;
     int r = 0;
 
     if (!global_extractor) {
@@ -288,7 +289,6 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
     prot_settimeout(be->in, attachextract_idle_timeout);
 
     /* try to fetch previously extracted text */
-    unsigned statuscode = 0;
     prot_printf(be->out,
                 "GET %s/%s %s\r\n"
                 "Host: %.*s\r\n"

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -308,9 +308,9 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
         r = http_read_response(be, METH_GET,
                                &statuscode, &hdrs, &body, &errstr);
         if (r) {
-            syslog(LOG_ERR,
-                   "extract_attachment: failed to read response for GET %s/%s",
-                   ext->path, guidstr);
+            xsyslog(LOG_ERR,
+                   "failed to read response for GET", "url=<%s/%s> err=<%s>",
+                   ext->path, guidstr, error_message(r));
             statuscode = 599;
         }
     } while (statuscode < 200);
@@ -375,9 +375,9 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
             r = http_read_response(be, METH_PUT,
                                    &statuscode, &hdrs, &body, &errstr);
             if (r) {
-                syslog(LOG_ERR,
-                       "extract_attachment: failed to read response for PUT %s/%s",
-                       ext->path, guidstr);
+                xsyslog(LOG_ERR,
+                        "failed to read response for PUT", "url=<%s/%s> err=<%s>",
+                        ext->path, guidstr, error_message(r));
                 statuscode = 599;
             }
         } while (statuscode < 200);

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -1,0 +1,429 @@
+/* attachextract.c -- Routines for extracting text from attachments
+ *
+ * Copyright (c) 1994-2008 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+
+#include <string.h>
+#include <syslog.h>
+
+#include "backend.h"
+#include "global.h"
+#include "http_client.h"
+#include "util.h"
+
+/* generated headers are not necessarily in current directory */
+#include "imap/imap_err.h"
+
+#include "attachextract.h"
+
+struct extractor_ctx {
+    struct protstream *clientin;
+    char *hostname;
+    char *path;
+    struct backend *be;
+};
+
+static struct extractor_ctx *global_extractor = NULL;
+
+static void extractor_disconnect(struct extractor_ctx *ext)
+{
+    if (!ext) return;
+
+    struct backend *be = ext->be;
+    syslog(LOG_DEBUG, "extractor_disconnect(%p)", be);
+
+    if (!be || (be->sock == -1)) {
+        /* already disconnected */
+        return;
+    }
+
+    /* need to logout of server */
+    backend_disconnect(be);
+
+    /* remove the timeout */
+    if (be->timeout) prot_removewaitevent(be->clientin, be->timeout);
+    be->timeout = NULL;
+    be->clientin = NULL;
+}
+
+static struct prot_waitevent *
+extractor_timeout(struct protstream *s __attribute__((unused)),
+                  struct prot_waitevent *ev __attribute__((unused)),
+                  void *rock)
+{
+    struct extractor_ctx *ext = rock;
+
+    syslog(LOG_DEBUG, "extractor_timeout(%p)", ext);
+
+    /* too long since we last used the extractor - disconnect */
+    extractor_disconnect(ext);
+
+    return NULL;
+}
+
+
+#define IDLE_TIMEOUT (5 * 60)  /* 5 min */
+
+static int login(struct backend *s __attribute__((unused)),
+                 const char *userid __attribute__((unused)),
+                 sasl_callback_t *cb __attribute__((unused)),
+                 const char **status __attribute__((unused)),
+                 int noauth __attribute__((unused)))
+{
+    return 0;
+}
+
+static int ping(struct backend *s __attribute__((unused)),
+                const char *userid __attribute__((unused)))
+{
+    return 0;
+}
+
+static int logout(struct backend *s __attribute__((unused)))
+{
+    return 0;
+}
+
+
+static struct protocol_t http =
+{ "http", "HTTP", TYPE_SPEC, { .spec = { &login, &ping, &logout } } };
+
+static int extractor_connect(struct extractor_ctx *ext)
+{
+    struct backend *be;
+    time_t now = time(NULL);
+
+    syslog(LOG_DEBUG, "extractor_connect()");
+
+    be = ext->be;
+    if (be && be->sock != -1) {
+        // extend the timeout
+        if (be->timeout) be->timeout->mark = now + IDLE_TIMEOUT;
+        return 0;
+    }
+
+    // clean up any existing connection
+    extractor_disconnect(ext);
+    be = ext->be = backend_connect(be, ext->hostname,
+                                   &http, NULL, NULL, NULL, -1);
+
+    if (!be) {
+        syslog(LOG_ERR, "extract_connect: failed to connect to %s",
+               ext->hostname);
+        return IMAP_IOERROR;
+    }
+
+    if (ext->clientin) {
+        /* add a default timeout */
+        be->clientin = ext->clientin;
+        be->timeout = prot_addwaitevent(ext->clientin,
+                                        now + IDLE_TIMEOUT,
+                                        extractor_timeout, ext);
+    }
+
+    return 0;
+}
+
+EXPORTED int attachextract_extract_part(const char *type, const char *subtype,
+                                      const struct param *type_params,
+                                      const struct buf *data, int encoding,
+                                      const struct message_guid *content_guid,
+                                      search_text_receiver_t *receiver, int partnum)
+{
+    struct backend *be;
+    struct buf decbuf = BUF_INITIALIZER;
+    struct buf buf = BUF_INITIALIZER;
+    hdrcache_t hdrs = NULL;
+    struct body_t body = { 0, 0, 0, 0, 0, BUF_INITIALIZER };
+    const char *guidstr, *errstr = NULL;
+    size_t hostlen;
+    const char **hdr, *p;
+
+    if (!global_extractor) {
+        /* This is a legitimate case for sieve and lmtpd (so we don't need
+         * to spam the logs! */
+        xsyslog(LOG_DEBUG, "ignoring uninitialized extractor", NULL);
+        return 0;
+    }
+
+    if (message_guid_isnull(content_guid)) {
+        xsyslog(LOG_DEBUG, "ignoring null guid", "mime_type=<%s/%s>",
+               type ? type : "<null>", subtype ? subtype : "<null>");
+        return 0;
+    }
+
+    struct extractor_ctx *ext = global_extractor;
+    int r = extractor_connect(ext);
+    if (r) return r;
+    be = ext->be;
+
+    hostlen = strcspn(ext->hostname, "/");
+    guidstr = message_guid_encode(content_guid);
+
+    /* try to fetch previously extracted text */
+    unsigned statuscode = 0;
+    prot_printf(be->out,
+                "GET %s/%s %s\r\n"
+                "Host: %.*s\r\n"
+                "User-Agent: Cyrus/%s\r\n"
+                "Connection: Keep-Alive\r\n"
+                "Keep-Alive: timeout=%u\r\n"
+                "Accept: text/plain\r\n"
+                "X-Truncate-Length: " SIZE_T_FMT "\r\n"
+                "\r\n",
+                ext->path, guidstr, HTTP_VERSION,
+                (int) hostlen, be->hostname, CYRUS_VERSION,
+                IDLE_TIMEOUT, config_search_maxsize);
+    prot_flush(be->out);
+
+    /* Read GET response */
+    do {
+        r = http_read_response(be, METH_GET,
+                               &statuscode, &hdrs, &body, &errstr);
+        if (r) {
+            syslog(LOG_ERR,
+                   "extract_attachment: failed to read response for GET %s/%s",
+                   ext->path, guidstr);
+            statuscode = 599;
+        }
+    } while (statuscode < 200);
+
+    syslog(LOG_DEBUG, "extract_attachment: GET %s/%s: got status %u",
+           ext->path, guidstr, statuscode);
+
+    if (statuscode == 200) goto gotdata;
+
+    // otherwise we're going to try three times to PUT this request to the server!
+
+    /* Decode data */
+    if (encoding) {
+        if (charset_decode(&decbuf, buf_base(data), buf_len(data), encoding)) {
+            syslog(LOG_ERR, "extract_attachment: failed to decode data");
+            r = IMAP_IOERROR;
+            goto done;
+        }
+        data = &decbuf;
+    }
+
+    /* Build list of Content-Type parameters */
+    const struct param *param;
+    for (param = type_params; param && param->attribute; param = param->next) {
+        /* Ignore all but select parameters */
+        if (strcmp(param->attribute, "charset")) {
+            continue;
+        }
+        buf_putc(&buf, ';');
+        buf_appendcstr(&buf, param->attribute);
+        if (param->value) {
+            buf_putc(&buf, '=');
+            buf_appendcstr(&buf, param->value);
+        }
+    }
+
+    int retry;
+    for (retry = 0; retry < 3; retry++) {
+        if (retry) {
+            // second and third time around, sleep and reconnect
+            sleep(retry);
+            extractor_disconnect(ext);
+            r = extractor_connect(ext);
+            if (r) continue;
+            be = ext->be;
+        }
+
+        /* Send attachment to service for text extraction */
+        prot_printf(be->out,
+                    "PUT %s/%s %s\r\n"
+                    "Host: %.*s\r\n"
+                    "User-Agent: Cyrus/%s\r\n"
+                    "Connection: Keep-Alive\r\n"
+                    "Keep-Alive: timeout=%u\r\n"
+                    "Accept: text/plain\r\n"
+                    "Content-Type: %s/%s%s\r\n"
+                    "Content-Length: " SIZE_T_FMT "\r\n"
+                    "X-Truncate-Length: " SIZE_T_FMT "\r\n"
+                    "\r\n",
+                    ext->path, guidstr, HTTP_VERSION,
+                    (int) hostlen, be->hostname, CYRUS_VERSION, IDLE_TIMEOUT,
+                    type, subtype, buf_cstring(&buf), buf_len(data),
+                    config_search_maxsize);
+        prot_putbuf(be->out, data);
+        prot_flush(be->out);
+
+        /* Read PUT response */
+        body.flags = 0;
+        do {
+            r = http_read_response(be, METH_PUT,
+                                   &statuscode, &hdrs, &body, &errstr);
+            if (r) {
+                syslog(LOG_ERR,
+                       "extract_attachment: failed to read response for PUT %s/%s",
+                       ext->path, guidstr);
+                statuscode = 599;
+            }
+        } while (statuscode < 200);
+
+        syslog(LOG_DEBUG, "extract_attachment: PUT %s/%s: got status %u",
+               ext->path, guidstr, statuscode);
+
+        if (statuscode == 200 || statuscode == 201) {
+            // we got a result, yay
+            goto gotdata;
+        }
+
+        if (statuscode >= 400 && statuscode <= 499) {
+            /* indexer can't extract this for some reason, never try again */
+            goto done;
+        }
+
+        /* any other status code is an error */
+        syslog(LOG_ERR, "extract GOT STATUSCODE %d with timeout %d: %s", statuscode, IDLE_TIMEOUT, errstr);
+    }
+
+    // dropped out of the loop?  Then we failed!
+    r = IMAP_IOERROR;
+    goto done;
+
+gotdata:
+    /* Abide by server's timeout, if any */
+    if ((hdr = spool_getheader(hdrs, "Keep-Alive")) &&
+        (p = strstr(hdr[0], "timeout="))) {
+        int timeout = atoi(p+8);
+        if (be->timeout) be->timeout->mark = time(NULL) + timeout;
+    }
+
+    /* Append extracted text */
+    if (buf_len(&body.payload)) {
+        receiver->begin_part(receiver, partnum);
+        receiver->append_text(receiver, &body.payload);
+        receiver->end_part(receiver, partnum);
+    }
+
+done:
+    spool_free_hdrcache(hdrs);
+    buf_free(&body.payload);
+    buf_free(&buf);
+    buf_free(&decbuf);
+    return r;
+}
+
+EXPORTED void attachextract_init(struct protstream *clientin)
+{
+    const char *exturl =
+         config_getstring(IMAPOPT_SEARCH_ATTACHMENT_EXTRACTOR_URL);
+    if (!exturl) return;
+
+    syslog(LOG_DEBUG, "extractor_init(%p)", clientin);
+
+    char scheme[6], server[100], path[256], *p;
+    unsigned https, port;
+
+    /* Parse URL (cheesy parser without having to use libxml2) */
+    int n = sscanf(exturl, "%5[^:]://%99[^/]%255[^\n]",
+                   scheme, server, path);
+    if (n != 3 ||
+        strncmp(lcase(scheme), "http", 4) || (scheme[4] && scheme[4] != 's')) {
+        syslog(LOG_ERR,
+               "extract_attachment: unexpected non-HTTP URL %s", exturl);
+        return;
+    }
+
+    /* Normalize URL parts */
+    https = (scheme[4] == 's');
+    if (*(p = path + strlen(path) - 1) == '/') *p = '\0';
+    if ((p = strrchr(server, ':'))) {
+        *p++ = '\0';
+        port = atoi(p);
+    }
+    else port = https ? 443 : 80;
+
+    /* Build servername, port, and options */
+    struct buf buf = BUF_INITIALIZER;
+    buf_printf(&buf, "%s:%u%s/noauth", server, port, https ? "/tls" : "");
+
+    global_extractor = xzmalloc(sizeof(struct extractor_ctx));
+    global_extractor->clientin = clientin;
+    global_extractor->path = xstrdup(path);
+    global_extractor->hostname = buf_release(&buf);
+}
+
+EXPORTED void attachextract_destroy(void)
+{
+    struct extractor_ctx *ext = global_extractor;
+
+    syslog(LOG_DEBUG, "extractor_destroy(%p)", ext);
+
+    if (!ext) return;
+
+    extractor_disconnect(ext);
+    free(ext->be);
+    free(ext->hostname);
+    free(ext->path);
+    free(ext);
+
+    global_extractor = NULL;
+}
+
+
+EXPORTED int attachextract_supports_type(const char *type, const char *subtype)
+{
+    if (!strcasecmpsafe(type, "APPLICATION")) {
+        if (!strcasecmpsafe(subtype, "ICS")) {
+            // this gets handled like text/calendar
+            return 0;
+        }
+        else if (!strcasecmpsafe(subtype, "PKCS7-MIME") ||
+            !strcasecmpsafe(subtype, "PKCS7-ENCRYPTED") ||
+            !strcasecmpsafe(subtype, "PKCS7-SIGNATURE") ||
+            !strcasecmpsafe(subtype, "PGP-SIGNATURE") ||
+            !strcasecmpsafe(subtype, "PGP-KEYS") ||
+            !strcasecmpsafe(subtype, "PGP-ENCRYPTED")) {
+            // these are encrypted fields which aren't worth indexing
+            return 0;
+        }
+        else return 1;
+    }
+    else return !strcasecmpsafe(type, "TEXT");
+}
+
+
+

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -289,8 +289,10 @@ static int extractor_httpreq(struct extractor_ctx *ext,
                         method, url, res_err, error_message(r));
                 *res_statuscode = 599;
             }
-            else xsyslog(LOG_INFO, "read HTTP response",
-                    "method=<%s> url=<%s> statuscode=<%d>",
+            else xsyslog(
+                    (*res_statuscode == 200 || *res_statuscode == 201 ||
+                     *res_statuscode == 404) ? LOG_DEBUG : LOG_WARNING,
+                    "got HTTP response", "method=<%s> url=<%s> statuscode=<%d>",
                     method, url, *res_statuscode);
 
             if (*res_statuscode == 200 || *res_statuscode == 201) {
@@ -479,7 +481,9 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
     goto done;
 
 gotdata:
-    xsyslog(LOG_INFO, "extracted text from attachment",
+    xsyslog(LOG_DEBUG, is_cached ?
+            "read cached attachment extract" :
+            "extracted text from attachment",
             "guid=<%s> content_type=<%s> size=<%zu>",
             guidstr, ctype, buf_len(text));
 
@@ -514,7 +518,6 @@ gotdata:
 
 done:
     if (statuscode == 599) {
-        xsyslog(LOG_DEBUG, "could not read from backend", NULL);
         extractor_disconnect(ext);
     }
     free(cachefname);

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -323,6 +323,13 @@ done:
             "method=<%s> guid=<%s> statuscode=<%d> r=<%s>",
             method, guidstr, *res_statuscode, error_message(r));
 
+    if (r) {
+        xsyslog(LOG_WARNING, "failed HTTP request - resetting connection",
+                "method=<%s> guid=<%s> statuscode=<%d> r=<%s>",
+                method, guidstr, *res_statuscode, error_message(r));
+        extractor_disconnect(ext);
+    }
+
     spool_free_hdrcache(res_hdrs);
     buf_free(&req_buf);
     buf_free(&url_buf);

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -452,6 +452,11 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
         buf_copy(text, &body.payload);
         goto gotdata;
     }
+    else if (statuscode == 422) {
+        // handle unprocessable content like empty file
+        buf_reset(text);
+        goto gotdata;
+    }
 
     if (statuscode == 599) goto done;
 
@@ -481,6 +486,11 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
         if (statuscode == 200 || statuscode == 201) {
             // we got a result, yay
             buf_copy(text, &body.payload);
+            goto gotdata;
+        }
+        else if (statuscode == 422) {
+            // handle unprocessable content like empty file
+            buf_reset(text);
             goto gotdata;
         }
 

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -145,6 +145,13 @@ static int extractor_connect(struct extractor_ctx *ext)
         // extend the timeout
         if (be->timeout) {
             be->timeout->mark = now + attachextract_idle_timeout;
+            xsyslog(LOG_DEBUG, "keep using socket with timeout mark",
+                    "sockfd=<%d> timeout_mark=<" TIME_T_FMT ">",
+                    be->sock, be->timeout->mark);
+        }
+        else {
+            xsyslog(LOG_DEBUG, "keep using socket",
+                    "sockfd=<%d>", be->sock);
         }
         return 0;
     }

--- a/imap/attachextract.h
+++ b/imap/attachextract.h
@@ -45,20 +45,49 @@
 
 #include "prot.h"
 
+/**
+ * Initialize the attachextract backend.
+ *
+ * clientin is an optional protocol stream to wait for timeouts.
+ */
 extern void attachextract_init(struct protstream *clientin);
+
+/**
+ * Destroy the attachextract backend.
+ */
 extern void attachextract_destroy(void);
 
-extern int attachextract_supports_type(const char *type, const char *subtype);
-
+/**
+ * Identifies the content type of attachment data.
+ */
 struct attachextract_record {
-    const char *type;
-    const char *subtype;
-    struct message_guid guid;
+    const char *type;          // MIME content type
+    const char *subtype;       // MIME subtype
+    struct message_guid guid;  // content guid of undecoded data
 };
 
+/**
+ * Extracts text from attachment data.
+ *
+ * Data may be optionally encoded and its charset identifier specified.
+ *
+ * Returns 0 on success or an IMAP error.
+ */
 extern int attachextract_extract(const struct attachextract_record *record,
                                  const struct buf *data,
                                  int encoding, const char *charset,
                                  struct buf *text);
+
+/**
+ * Sets or gets where to read and cache extract in.
+ */
+extern void attachextract_set_cachedir(const char *cachedir);
+extern const char *attachextract_get_cachedir(void);
+
+/**
+ * Sets or gets if extracted text may only read from the cache.
+ */
+extern void attachextract_set_cacheonly(int cacheonly);
+extern int attachextract_get_cacheonly(void);
 
 #endif

--- a/imap/attachextract.h
+++ b/imap/attachextract.h
@@ -50,10 +50,15 @@ extern void attachextract_destroy(void);
 
 extern int attachextract_supports_type(const char *type, const char *subtype);
 
-extern int attachextract_extract_part(const char *type, const char *subtype,
-                                      const struct param *type_params,
-                                      const struct buf *data, int encoding,
-                                      const struct message_guid *content_guid,
-                                      search_text_receiver_t *receiver, int partnum);
+struct attachextract_record {
+    const char *type;
+    const char *subtype;
+    struct message_guid guid;
+};
+
+extern int attachextract_extract(const struct attachextract_record *record,
+                                 const struct buf *data,
+                                 int encoding, const char *charset,
+                                 struct buf *text);
 
 #endif

--- a/imap/attachextract.h
+++ b/imap/attachextract.h
@@ -1,0 +1,59 @@
+/* attachextract.h -- Routines for extracting text from attachments
+ *
+ * Copyright (c) 1994-2008 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef INCLUDED_ATTACHEXTRACT_H
+#define INCLUDED_ATTACHEXTRACT_H
+
+#include "prot.h"
+
+extern void attachextract_init(struct protstream *clientin);
+extern void attachextract_destroy(void);
+
+extern int attachextract_supports_type(const char *type, const char *subtype);
+
+extern int attachextract_extract_part(const char *type, const char *subtype,
+                                      const struct param *type_params,
+                                      const struct buf *data, int encoding,
+                                      const struct message_guid *content_guid,
+                                      search_text_receiver_t *receiver, int partnum);
+
+#endif

--- a/imap/attachextract.h
+++ b/imap/attachextract.h
@@ -69,13 +69,12 @@ struct attachextract_record {
 /**
  * Extracts text from attachment data.
  *
- * Data may be optionally encoded and its charset identifier specified.
+ * Data may be encoded with one of the charset ENCODING enums.
  *
  * Returns 0 on success or an IMAP error.
  */
 extern int attachextract_extract(const struct attachextract_record *record,
-                                 const struct buf *data,
-                                 int encoding, const char *charset,
+                                 const struct buf *data, int encoding,
                                  struct buf *text);
 
 /**

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -99,6 +99,7 @@
 #include "tok.h"
 #include "wildmat.h"
 #include "md5.h"
+#include "attachextract.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -707,7 +708,7 @@ static void httpd_reset(struct http_connection *conn)
     }
     ptrarray_fini(&backend_cached);
 
-    index_text_extractor_destroy();
+    attachextract_destroy();
 
     if (httpd_in) {
         prot_NONBLOCK(httpd_in);
@@ -1065,7 +1066,7 @@ int service_main(int argc __attribute__((unused)),
         }
     }
 
-    index_text_extractor_init(httpd_in);
+    attachextract_init(httpd_in);
 
     /* count the connection, now that it's established */
     prometheus_increment(CYRUS_HTTP_CONNECTIONS_TOTAL);
@@ -1149,7 +1150,7 @@ void shut_down(int code)
     }
     ptrarray_fini(&backend_cached);
 
-    index_text_extractor_destroy();
+    attachextract_destroy();
 
     annotatemore_close();
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -109,6 +109,7 @@
 #include "sync_log.h"
 #include "sync_support.h"
 #include "telemetry.h"
+#include "attachextract.h"
 #include "tls.h"
 #include "user.h"
 #include "userdeny.h"
@@ -887,7 +888,7 @@ static void imapd_reset(void)
     disable_referrals = 0;
     supports_referrals = 0;
 
-    index_text_extractor_destroy();
+    attachextract_destroy();
 
     event_groups_free(&notify_event_groups);
     if (idle_sock != PROT_NO_FD)
@@ -1142,7 +1143,7 @@ int service_main(int argc __attribute__((unused)),
     mboxname_init_namespace(&imapd_namespace, NAMESPACE_OPTION_ADMIN);
     mboxevent_setnamespace(&imapd_namespace);
 
-    index_text_extractor_init(imapd_in);
+    attachextract_init(imapd_in);
 
     cmdloop();
 
@@ -1246,7 +1247,7 @@ void shut_down(int code)
     ptrarray_fini(&backend_cached);
     if (mupdate_h) mupdate_disconnect(&mupdate_h);
 
-    index_text_extractor_destroy();
+    attachextract_destroy();
 
     event_groups_free(&notify_event_groups);
     if (idle_sock != PROT_NO_FD)

--- a/imap/index.c
+++ b/imap/index.c
@@ -5528,27 +5528,29 @@ done:
 
 EXPORTED int index_want_attachextract(const char *type, const char *subtype)
 {
-    if (!strcasecmpsafe(type, "APPLICATION")) {
-        if (!strcasecmpsafe(subtype, "ICS")) {
-            // this gets handled like text/calendar
-            return 0;
-        }
-        else if (!strcasecmpsafe(subtype, "PKCS7-MIME") ||
-            !strcasecmpsafe(subtype, "PKCS7-ENCRYPTED") ||
-            !strcasecmpsafe(subtype, "PKCS7-SIGNATURE") ||
-            !strcasecmpsafe(subtype, "PGP-SIGNATURE") ||
-            !strcasecmpsafe(subtype, "PGP-KEYS") ||
-            !strcasecmpsafe(subtype, "PGP-ENCRYPTED")) {
-            // these are encrypted fields which aren't worth indexing
-            return 0;
-        }
-        else return 1;
-    }
-    else return !strcasecmpsafe(type, "TEXT") &&
-        strcasecmpsafe(subtype, "PLAIN") &&
-        strcasecmpsafe(subtype, "HTML") &&
-        strcasecmpsafe(subtype, "CALENDAR") &&
-        strcasecmpsafe(subtype, "VCARD");
+    return ((!strcasecmpsafe(type, "APPLICATION") &&
+                // this gets handled like text/calendar
+                strcasecmpsafe(subtype, "ICS") &&
+                // crypto isn't worth indexing
+                strcasecmpsafe(subtype, "PKCS7-MIME") &&
+                strcasecmpsafe(subtype, "PKCS7-ENCRYPTED") &&
+                strcasecmpsafe(subtype, "PKCS7-SIGNATURE") &&
+                strcasecmpsafe(subtype, "PGP-SIGNATURE") &&
+                strcasecmpsafe(subtype, "PGP-KEYS") &&
+                strcasecmpsafe(subtype, "PGP-ENCRYPTED") &&
+                // don't index executables
+                strcasecmpsafe(subtype, "X-MSDOWNLOAD") &&
+                strcasecmpsafe(subtype, "X-SHAREDLIB") &&
+                strcasecmpsafe(subtype, "X-ELF") &&
+                strcasecmpsafe(subtype, "X-OBJECT") &&
+                strcasecmpsafe(subtype, "X-EXECUTABLE") &&
+                strcasecmpsafe(subtype, "X-COREDUMP") &&
+                // other unwanted attachments
+                strcasecmpsafe(subtype, "MBOX") &&
+                strcasecmpsafe(subtype, "MP4")) ||
+            // only text/rtf
+            (!strcasecmpsafe(type, "TEXT") &&
+                !strcasecmpsafe(subtype, "RTF")));
 }
 
 static int getsearchtext_cb(int isbody, charset_t charset, int encoding,

--- a/imap/index.c
+++ b/imap/index.c
@@ -86,6 +86,7 @@
 #include "seen.h"
 #include "statuscache.h"
 #include "strhash.h"
+#include "attachextract.h"
 #include "user.h"
 #include "util.h"
 #include "xstats.h"
@@ -100,8 +101,6 @@
 #include "imap/imap_err.h"
 
 EXPORTED unsigned client_capa;
-
-static struct extractor_ctx *index_text_extractor = NULL;
 
 /* Forward declarations */
 static void index_refresh_locked(struct index_state *state);
@@ -5292,13 +5291,6 @@ EXPORTED int index_search_evaluate(struct index_state *state,
     return match;
 }
 
-struct extractor_ctx {
-    struct protstream *clientin;
-    char *hostname;
-    char *path;
-    struct backend *be;
-};
-
 struct getsearchtext_rock
 {
     search_text_receiver_t *receiver;
@@ -5306,7 +5298,6 @@ struct getsearchtext_rock
     int charset_flags;
     const strarray_t *partids;
     int snippet_iteration; /* 0..no snippet, 1..first run, 2..second run */
-    struct extractor_ctx *ext;
     strarray_t striphtml; /* strip HTML from these plain text body part ids */
     uint8_t indexlevel;
     int flags;
@@ -5535,347 +5526,6 @@ done:
 
 #endif /* USE_HTTPD */
 
-
-#define IDLE_TIMEOUT (5 * 60)  /* 5 min */
-
-static int login(struct backend *s __attribute__((unused)),
-                 const char *userid __attribute__((unused)),
-                 sasl_callback_t *cb __attribute__((unused)),
-                 const char **status __attribute__((unused)),
-                 int noauth __attribute__((unused)))
-{
-    return 0;
-}
-
-static int ping(struct backend *s __attribute__((unused)),
-                const char *userid __attribute__((unused)))
-{
-    return 0;
-}
-
-static int logout(struct backend *s __attribute__((unused)))
-{
-    return 0;
-}
-
-static void extractor_disconnect(struct extractor_ctx *ext)
-{
-    if (!ext) return;
-
-    struct backend *be = ext->be;
-    syslog(LOG_DEBUG, "extractor_disconnect(%p)", be);
-
-    if (!be || (be->sock == -1)) {
-        /* already disconnected */
-        return;
-    }
-
-    /* need to logout of server */
-    backend_disconnect(be);
-
-    /* remove the timeout */
-    if (be->timeout) prot_removewaitevent(be->clientin, be->timeout);
-    be->timeout = NULL;
-    be->clientin = NULL;
-}
-
-static struct prot_waitevent *
-extractor_timeout(struct protstream *s __attribute__((unused)),
-                  struct prot_waitevent *ev __attribute__((unused)),
-                  void *rock)
-{
-    struct extractor_ctx *ext = rock;
-
-    syslog(LOG_DEBUG, "extractor_timeout(%p)", ext);
-
-    /* too long since we last used the extractor - disconnect */
-    extractor_disconnect(ext);
-
-    return NULL;
-}
-
-static struct protocol_t http =
-{ "http", "HTTP", TYPE_SPEC, { .spec = { &login, &ping, &logout } } };
-
-static int extractor_connect(struct extractor_ctx *ext)
-{
-    struct backend *be;
-    time_t now = time(NULL);
-
-    syslog(LOG_DEBUG, "extractor_connect()");
-
-    be = ext->be;
-    if (be && be->sock != -1) {
-        // extend the timeout
-        if (be->timeout) be->timeout->mark = now + IDLE_TIMEOUT;
-        return 0;
-    }
-
-    // clean up any existing connection
-    extractor_disconnect(ext);
-    be = ext->be = backend_connect(be, ext->hostname,
-                                   &http, NULL, NULL, NULL, -1);
-
-    if (!be) {
-        syslog(LOG_ERR, "extract_connect: failed to connect to %s",
-               ext->hostname);
-        return IMAP_IOERROR;
-    }
-
-    if (ext->clientin) {
-        /* add a default timeout */
-        be->clientin = ext->clientin;
-        be->timeout = prot_addwaitevent(ext->clientin,
-                                        now + IDLE_TIMEOUT,
-                                        extractor_timeout, ext);
-    }
-
-    return 0;
-}
-
-static int extract_attachment(const char *type, const char *subtype,
-                              const struct param *type_params,
-                              const struct buf *data, int encoding,
-                              const struct message_guid *content_guid,
-                              struct getsearchtext_rock *str)
-{
-    struct backend *be;
-    struct buf decbuf = BUF_INITIALIZER;
-    struct buf buf = BUF_INITIALIZER;
-    hdrcache_t hdrs = NULL;
-    struct body_t body = { 0, 0, 0, 0, 0, BUF_INITIALIZER };
-    const char *guidstr, *errstr = NULL;
-    size_t hostlen;
-    const char **hdr, *p;
-    int r = 0;
-
-    if (!index_text_extractor) {
-        /* This is a legitimate case for sieve and lmtpd (so we don't need
-         * to spam the logs! */
-        syslog(LOG_DEBUG, "%s: ignoring uninitialized extractor",
-                __func__);
-        return 0;
-    }
-
-    if (message_guid_isnull(content_guid)) {
-        syslog(LOG_DEBUG, "extract_attachment: ignoring null guid for %s/%s",
-               type ? type : "<null>", subtype ? subtype : "<null>");
-        return 0;
-    }
-
-    struct extractor_ctx *ext = str->ext = index_text_extractor;
-
-    r = extractor_connect(ext);
-    if (r) return r;
-    be = ext->be;
-
-    hostlen = strcspn(ext->hostname, "/");
-    guidstr = message_guid_encode(content_guid);
-
-    /* try to fetch previously extracted text */
-    unsigned statuscode = 0;
-    prot_printf(be->out,
-                "GET %s/%s %s\r\n"
-                "Host: %.*s\r\n"
-                "User-Agent: Cyrus/%s\r\n"
-                "Connection: Keep-Alive\r\n"
-                "Keep-Alive: timeout=%u\r\n"
-                "Accept: text/plain\r\n"
-                "X-Truncate-Length: " SIZE_T_FMT "\r\n"
-                "\r\n",
-                ext->path, guidstr, HTTP_VERSION,
-                (int) hostlen, be->hostname, CYRUS_VERSION,
-                IDLE_TIMEOUT, config_search_maxsize);
-    prot_flush(be->out);
-
-    /* Read GET response */
-    do {
-        r = http_read_response(be, METH_GET,
-                               &statuscode, &hdrs, &body, &errstr);
-        if (r) {
-            syslog(LOG_ERR,
-                   "extract_attachment: failed to read response for GET %s/%s",
-                   ext->path, guidstr);
-            statuscode = 599;
-        }
-    } while (statuscode < 200);
-
-    syslog(LOG_DEBUG, "extract_attachment: GET %s/%s: got status %u",
-           ext->path, guidstr, statuscode);
-
-    if (statuscode == 200) goto gotdata;
-
-    // otherwise we're going to try three times to PUT this request to the server!
-
-    /* Decode data */
-    if (encoding) {
-        if (charset_decode(&decbuf, buf_base(data), buf_len(data), encoding)) {
-            syslog(LOG_ERR, "extract_attachment: failed to decode data");
-            r = IMAP_IOERROR;
-            goto done;
-        }
-        data = &decbuf;
-    }
-
-    /* Build list of Content-Type parameters */
-    const struct param *param;
-    for (param = type_params; param && param->attribute; param = param->next) {
-        /* Ignore all but select parameters */
-        if (strcmp(param->attribute, "charset")) {
-            continue;
-        }
-        buf_putc(&buf, ';');
-        buf_appendcstr(&buf, param->attribute);
-        if (param->value) {
-            buf_putc(&buf, '=');
-            buf_appendcstr(&buf, param->value);
-        }
-    }
-
-    int retry;
-    for (retry = 0; retry < 3; retry++) {
-        if (retry) {
-            // second and third time around, sleep and reconnect
-            sleep(retry);
-            extractor_disconnect(ext);
-            r = extractor_connect(ext);
-            if (r) continue;
-            be = ext->be;
-        }
-
-        /* Send attachment to service for text extraction */
-        prot_printf(be->out,
-                    "PUT %s/%s %s\r\n"
-                    "Host: %.*s\r\n"
-                    "User-Agent: Cyrus/%s\r\n"
-                    "Connection: Keep-Alive\r\n"
-                    "Keep-Alive: timeout=%u\r\n"
-                    "Accept: text/plain\r\n"
-                    "Content-Type: %s/%s%s\r\n"
-                    "Content-Length: " SIZE_T_FMT "\r\n"
-                    "X-Truncate-Length: " SIZE_T_FMT "\r\n"
-                    "\r\n",
-                    ext->path, guidstr, HTTP_VERSION,
-                    (int) hostlen, be->hostname, CYRUS_VERSION, IDLE_TIMEOUT,
-                    type, subtype, buf_cstring(&buf), buf_len(data),
-                    config_search_maxsize);
-        prot_putbuf(be->out, data);
-        prot_flush(be->out);
-
-        /* Read PUT response */
-        body.flags = 0;
-        do {
-            r = http_read_response(be, METH_PUT,
-                                   &statuscode, &hdrs, &body, &errstr);
-            if (r) {
-                syslog(LOG_ERR,
-                       "extract_attachment: failed to read response for PUT %s/%s",
-                       ext->path, guidstr);
-                statuscode = 599;
-            }
-        } while (statuscode < 200);
-
-        syslog(LOG_DEBUG, "extract_attachment: PUT %s/%s: got status %u",
-               ext->path, guidstr, statuscode);
-
-        if (statuscode == 200 || statuscode == 201) {
-            // we got a result, yay
-            goto gotdata;
-        }
-
-        if (statuscode >= 400 && statuscode <= 499) {
-            /* indexer can't extract this for some reason, never try again */
-            goto done;
-        }
-
-        /* any other status code is an error */
-        syslog(LOG_ERR, "extract GOT STATUSCODE %d with timeout %d: %s", statuscode, IDLE_TIMEOUT, errstr);
-    }
-
-    // dropped out of the loop?  Then we failed!
-    r = IMAP_IOERROR;
-    goto done;
-
-gotdata:
-    /* Abide by server's timeout, if any */
-    if ((hdr = spool_getheader(hdrs, "Keep-Alive")) &&
-        (p = strstr(hdr[0], "timeout="))) {
-        int timeout = atoi(p+8);
-        if (be->timeout) be->timeout->mark = time(NULL) + timeout;
-    }
-    /* Append extracted text */
-    if (buf_len(&body.payload)) {
-        str->receiver->begin_part(str->receiver, SEARCH_PART_ATTACHMENTBODY);
-        str->receiver->append_text(str->receiver, &body.payload);
-        str->receiver->end_part(str->receiver, SEARCH_PART_ATTACHMENTBODY);
-    }
-
-done:
-    spool_free_hdrcache(hdrs);
-    buf_free(&body.payload);
-    buf_free(&buf);
-    buf_free(&decbuf);
-    return r;
-}
-
-EXPORTED void index_text_extractor_init(struct protstream *clientin)
-{
-    const char *exturl =
-         config_getstring(IMAPOPT_SEARCH_ATTACHMENT_EXTRACTOR_URL);
-    if (!exturl) return;
-
-    syslog(LOG_DEBUG, "extractor_init(%p)", clientin);
-
-    char scheme[6], server[100], path[256], *p;
-    unsigned https, port;
-
-    /* Parse URL (cheesy parser without having to use libxml2) */
-    int n = sscanf(exturl, "%5[^:]://%99[^/]%255[^\n]",
-                   scheme, server, path);
-    if (n != 3 ||
-        strncmp(lcase(scheme), "http", 4) || (scheme[4] && scheme[4] != 's')) {
-        syslog(LOG_ERR,
-               "extract_attachment: unexpected non-HTTP URL %s", exturl);
-        return;
-    }
-
-    /* Normalize URL parts */
-    https = (scheme[4] == 's');
-    if (*(p = path + strlen(path) - 1) == '/') *p = '\0';
-    if ((p = strrchr(server, ':'))) {
-        *p++ = '\0';
-        port = atoi(p);
-    }
-    else port = https ? 443 : 80;
-
-    /* Build servername, port, and options */
-    struct buf buf = BUF_INITIALIZER;
-    buf_printf(&buf, "%s:%u%s/noauth", server, port, https ? "/tls" : "");
-
-    index_text_extractor = xzmalloc(sizeof(struct extractor_ctx));
-    index_text_extractor->clientin = clientin;
-    index_text_extractor->path = xstrdup(path);
-    index_text_extractor->hostname = buf_release(&buf);
-}
-
-EXPORTED void index_text_extractor_destroy(void)
-{
-    struct extractor_ctx *ext = index_text_extractor;
-
-    syslog(LOG_DEBUG, "extractor_destroy(%p)", ext);
-
-    if (!ext) return;
-
-    extractor_disconnect(ext);
-    free(ext->be);
-    free(ext->hostname);
-    free(ext->path);
-    free(ext);
-
-    index_text_extractor = NULL;
-}
-
-
 static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
                             const char *type, const char *subtype,
                             const struct param *type_params __attribute__((unused)),
@@ -5992,23 +5642,13 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
             str->receiver->end_part(str->receiver, SEARCH_PART_BODY);
         }
     }
-    else if (isbody && (!strcmp(type, "APPLICATION") || !strcmp(type, "TEXT"))) {
-
 #ifdef USE_HTTPD
+    else if (isbody && (!strcmp(type, "APPLICATION") && !strcmp(subtype, "ICS"))) {
         // application/ics is an alias for text/icalendar
-        if (!strcmp(subtype, "ICS")) {
-            extract_icalbuf(data, charset, encoding, str);
-            goto done;
-        }
+        extract_icalbuf(data, charset, encoding, str);
+    }
 #endif /* USE_HTTPD */
-
-        // these are encrypted fields which aren't worth indexing
-        if (!strcmp(subtype, "PKCS7-MIME")) goto done;
-        if (!strcmp(subtype, "PKCS7-ENCRYPTED")) goto done;
-        if (!strcmp(subtype, "PKCS7-SIGNATURE")) goto done;
-        if (!strcmp(subtype, "PGP-SIGNATURE")) goto done;
-        if (!strcmp(subtype, "PGP-KEYS")) goto done;
-        if (!strcmp(subtype, "PGP-ENCRYPTED")) goto done;
+    else if (isbody && attachextract_supports_type(type, subtype)) {
 
         /* Ignore attachments in first snippet generation pass */
         if (str->snippet_iteration == 1) goto done;
@@ -6022,8 +5662,8 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
             goto done;
         }
 
-        r = extract_attachment(type, subtype, type_params, data, encoding,
-                               content_guid, str);
+        r = attachextract_extract_part(type, subtype, type_params, data, encoding,
+                content_guid, str->receiver, SEARCH_PART_ATTACHMENTBODY);
         if (r) {
             syslog(LOG_ERR, "IOERROR index: can't extract attachment %s (%s/%s): %s",
                     message_guid_encode(content_guid),

--- a/imap/index.c
+++ b/imap/index.c
@@ -5693,16 +5693,7 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
             .guid = message_guid_clone(content_guid),
         };
 
-        const char *charset_param = NULL;
-        const struct param *param;
-        for (param = type_params; param && param->attribute; param = param->next) {
-            if (!strcmp(param->attribute, "charset")) {
-                charset_param = param->value;
-                break;
-            }
-        }
-
-        r = attachextract_extract(&axrecord, data, encoding, charset_param, &text);
+        r = attachextract_extract(&axrecord, data, encoding, &text);
 
         if (!r && buf_len(&text)) {
             /* Append extracted text */

--- a/imap/index.h
+++ b/imap/index.h
@@ -367,9 +367,7 @@ extern int index_reload_record(struct index_state *state,
                                uint32_t msgno,
                                struct index_record *record);
 
-extern void index_text_extractor_init(struct protstream *clientin);
-extern void index_text_extractor_destroy(void);
-
 extern int insert_into_mailbox_allowed(struct mailbox *mailbox);
+
 
 #endif /* INDEX_H */

--- a/imap/index.h
+++ b/imap/index.h
@@ -369,5 +369,6 @@ extern int index_reload_record(struct index_state *state,
 
 extern int insert_into_mailbox_allowed(struct mailbox *mailbox);
 
+extern int index_want_attachextract(const char *type, const char *subtype);
 
 #endif /* INDEX_H */

--- a/imap/message_guid.c
+++ b/imap/message_guid.c
@@ -100,6 +100,19 @@ EXPORTED void message_guid_copy(struct message_guid *dst, const struct message_g
     memcpy(dst, src, sizeof(struct message_guid));
 }
 
+/* message_guid_clone() **************************************************
+ *
+ * Copy GUID and return copy
+ *
+ ************************************************************************/
+
+EXPORTED struct message_guid message_guid_clone(const struct message_guid *src)
+{
+    struct message_guid guid = MESSAGE_GUID_INITIALIZER;
+    message_guid_copy(&guid, src);
+    return guid;
+}
+
 /* message_guid_equal() **************************************************
  *
  * Compare a pair of GUIDs: Returns 1 => match.

--- a/imap/message_guid.h
+++ b/imap/message_guid.h
@@ -68,6 +68,7 @@ void message_guid_generate(struct message_guid *guid,
 
 /* Copy a GUID */
 void message_guid_copy(struct message_guid *dst, const struct message_guid *src);
+struct message_guid message_guid_clone(const struct message_guid *src);
 
 /* Compare a pair of GUIDs: Returns 1 => match. */
 int message_guid_equal(const struct message_guid *guid1,

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -221,9 +221,10 @@ extern void search_end_search(search_builder_t *);
 #define SEARCH_UPDATE_ALLOW_PARTIALS (1<<5)
 #define SEARCH_UPDATE_REINDEX_PARTIALS (1<<6)
 #define SEARCH_UPDATE_ALLOW_DUPPARTS (1<<7)
+#define SEARCH_UPDATE_VERBOSE (1<<8)
 search_text_receiver_t *search_begin_update(int verbose);
 int search_update_mailbox(search_text_receiver_t *rx,
-                          struct mailbox *mailbox,
+                          struct mailbox **mailboxptr,
                           int min_indexlevel, int flags);
 int search_end_update(search_text_receiver_t *rx);
 

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -309,6 +309,8 @@ static int index_one(const char *name, int blocking)
         flags |= SEARCH_UPDATE_REINDEX_PARTIALS;
     if (allow_duplicateparts)
         flags |= SEARCH_UPDATE_ALLOW_DUPPARTS;
+    if (verbose)
+        flags |= SEARCH_UPDATE_VERBOSE;
 
     /* Convert internal name to external */
     char *extname = mboxname_to_external(name, &squat_namespace, NULL);
@@ -396,7 +398,7 @@ again:
         }
     }
 
-    r = search_update_mailbox(rx, mailbox, reindex_minlevel, flags);
+    r = search_update_mailbox(rx, &mailbox, reindex_minlevel, flags);
 
     mailbox_close(&mailbox);
 

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -85,6 +85,7 @@
 #include "message.h"
 #include "util.h"
 #include "itip_support.h"
+#include "attachextract.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -921,7 +922,7 @@ static void shut_down(int code)
 
     cyrus_done();
 
-    index_text_extractor_destroy();
+    attachextract_destroy();
 
     exit(code);
 }
@@ -1207,7 +1208,7 @@ int main(int argc, char **argv)
         signals_add_handlers(0);
     }
 
-    index_text_extractor_init(NULL);
+    attachextract_init(NULL);
 
     const char *conf;
     conf = config_getstring(IMAPOPT_SEARCH_INDEX_SKIP_DOMAINS);

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -247,6 +247,18 @@ static int should_index(const char *name)
         goto done;
     }
 
+    // skip JMAP blobs
+    if (mboxname_isjmapuploadmailbox(mbentry->name, mbentry->mbtype)) {
+        ret = 0;
+        goto done;
+    }
+
+    // skip JMAP notifications
+    if (mboxname_isjmapnotificationsmailbox(mbentry->name, mbentry->mbtype)) {
+        ret = 0;
+        goto done;
+    }
+
     // skip COLLECTION mailboxes (just files)
     if (mbtype_isa(mbentry->mbtype) == MBTYPE_COLLECTION) {
         ret = 0;

--- a/lib/dynarray.h
+++ b/lib/dynarray.h
@@ -51,6 +51,8 @@ typedef struct dynarray {
     void *data;
 } dynarray_t;
 
+#define DYNARRAY_INITIALIZER(membsize) { (membsize), 0, 0, NULL }
+
 extern void dynarray_init(struct dynarray *da, size_t membsize);
 extern void dynarray_fini(struct dynarray *da);
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2364,7 +2364,20 @@ If all partitions are over that limit, this feature is not used anymore.
    to the extractor.
    Xapian only.
  */
+{ "search_attachment_extractor_request_timeout", "5m", DURATION, "UNRELEASED" }
+/* Defines the duration after which to cancel non-responding
+   requests to the search attachment extractor service.
 
+   If no unit is specified, seconds is assumed. */
+ */
+{ "search_attachment_extractor_idle_timeout", "5m", DURATION, "UNRELEASED" }
+/* Defines the duration after which to close unused connections to
+   the search attachment extractor service. If the idle timeout is
+   less than search_attachment_extractor_request_timeout, then it
+   is ignored and request timeout used instead.
+
+   If no unit is specified, seconds is assumed. */
+ */
 { "search_index_language", 0, SWITCH, "3.3.1" }
 /*
   If enabled, then messages bodies are stemmed by detected language

--- a/lib/strarray.h
+++ b/lib/strarray.h
@@ -63,6 +63,10 @@ void strarray_fini(strarray_t *);
 strarray_t *strarray_new(void);
 void strarray_free(strarray_t *);
 
+#define strarray_appendv(sa, s) strarray_nth((sa), strarray_append((sa), (s)))
+#define strarray_addv(sa, s) strarray_nth((sa), strarray_add((sa), (s)))
+#define strarray_add_casev(sa, s) strarray_nth((sa), strarray_add_case((sa), (s)))
+
 int strarray_append(strarray_t *, const char *);
 int strarray_add(strarray_t *, const char *);
 int strarray_add_case(strarray_t *, const char *);


### PR DESCRIPTION
This updates squatter to not lock a mailbox while extracting text from attachments. To do so, the attachment extraction module now supports an optional file-system based cache. By default, squatter uses a temporary cache. The newly added experimental squatter argument options v`--attachextract-cache-dir` and `--attachextract-cache-only` allow to use user-defined cache directory, as well as instruct squatter to only lookup extracted attachment text in the cache.

In addition, handling of timeouts when calling the extractor service has changed: rather than attempting to connect up to 4 times, an error now is returned after the first timeout. 

This pull request best is read commit by commit, where the first two commits are refactoring only.