### PR TITLE
Backport refactored IMAP URL encoding to cyrus-imapd-3.8

### DIFF
--- a/cunit/binhex.testc
+++ b/cunit/binhex.testc
@@ -1,17 +1,58 @@
 #include "cunit/cyrunit.h"
 #include "util.h"
 
+#define ASSERT_TO_HEX(BIN, HEX, hex, flags) \
+{ \
+    memset(hex, 0x45, sizeof(hex)); \
+    int r = bin_to_hex(BIN, sizeof(BIN), hex, flags); \
+    CU_ASSERT_EQUAL(r, sizeof(hex)-1); \
+    CU_ASSERT_STRING_EQUAL(hex, HEX); \
+    \
+    if (flags == BH_LOWER) { \
+        r = bin_to_lchex(BIN, sizeof(BIN), hex); \
+        CU_ASSERT_EQUAL(r, sizeof(hex)-1); \
+        CU_ASSERT_STRING_EQUAL(hex, HEX); \
+    } \
+    \
+    struct buf buf = BUF_INITIALIZER; \
+    r = buf_bin_to_hex(&buf, BIN, sizeof(BIN), flags); \
+    CU_ASSERT_EQUAL(r, sizeof(hex)-1); \
+    CU_ASSERT_EQUAL(r, buf_len(&buf)); \
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), HEX); \
+    buf_reset(&buf); \
+    \
+    if (flags == BH_LOWER) { \
+        r = buf_bin_to_lchex(&buf, BIN, sizeof(BIN)); \
+        CU_ASSERT_EQUAL(r, sizeof(hex)-1); \
+        CU_ASSERT_EQUAL(r, buf_len(&buf)); \
+        CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), HEX); \
+        buf_reset(&buf); \
+    } \
+    buf_free(&buf); \
+}
+
+
+#define ASSERT_TO_BIN(HEX, BIN, bin) \
+{ \
+    memset(bin, 0xff, sizeof(bin)); \
+    int r = hex_to_bin(HEX, sizeof(HEX)-1, bin); \
+    CU_ASSERT_EQUAL(r, sizeof(bin)); \
+    CU_ASSERT_EQUAL(memcmp(bin, BIN, sizeof(bin)), 0); \
+    \
+    struct buf buf = BUF_INITIALIZER; \
+    r = buf_hex_to_bin(&buf, HEX, sizeof(HEX)-1); \
+    CU_ASSERT_EQUAL(r, sizeof(bin)); \
+    CU_ASSERT_EQUAL(r, buf_len(&buf)); \
+    CU_ASSERT_EQUAL(memcmp(buf_base(&buf), BIN, buf_len(&buf)), 0); \
+    buf_free(&buf); \
+}
+
 static void test_bin_to_hex(void)
 {
     static const unsigned char BIN[4] = { 0xca, 0xfe, 0xba, 0xbe };
     static const char HEX[9] = "cafebabe";
-    int r;
     char hex[9];
-
-    memset(hex, 0x45, sizeof(hex));
-    r = bin_to_hex(BIN, sizeof(BIN), hex, BH_LOWER);
-    CU_ASSERT_EQUAL(r, sizeof(hex)-1);
-    CU_ASSERT_STRING_EQUAL(hex, HEX);
+    ASSERT_TO_HEX(BIN, HEX, hex, BH_LOWER);
 }
 
 static void test_bin_to_hex_long(void)
@@ -21,71 +62,59 @@ static void test_bin_to_hex_long(void)
         0x6f,0x9f,0xfa,0x77,0xe4,0x04,0x84,0x04,0xa0,0x02
     };
     static const char HEX[41] = "33ac18b6dc746e9ad7bd6f9ffa77e4048404a002";
-    int r;
     char hex[41];
-
-    memset(hex, 0x45, sizeof(hex));
-    r = bin_to_hex(BIN, sizeof(BIN), hex, BH_LOWER);
-    CU_ASSERT_EQUAL(r, sizeof(hex)-1);
-    CU_ASSERT_STRING_EQUAL(hex, HEX);
-    r = bin_to_lchex(BIN, sizeof(BIN), hex);
-    CU_ASSERT_EQUAL(r, sizeof(hex)-1);
-    CU_ASSERT_STRING_EQUAL(hex, HEX);
+    ASSERT_TO_HEX(BIN, HEX, hex, BH_LOWER);
 }
 
 static void test_bin_to_hex_short(void)
 {
     static const unsigned char BIN[1] = { 0x42 };
     static const char HEX[3] = "42";
-    int r;
     char hex[3];
-
-    memset(hex, 0x45, sizeof(hex));
-    r = bin_to_hex(BIN, sizeof(BIN), hex, BH_LOWER);
-    CU_ASSERT_EQUAL(r, sizeof(hex)-1);
-    CU_ASSERT_STRING_EQUAL(hex, HEX);
-    r = bin_to_lchex(BIN, sizeof(BIN), hex);
-    CU_ASSERT_EQUAL(r, sizeof(hex)-1);
-    CU_ASSERT_STRING_EQUAL(hex, HEX);
+    ASSERT_TO_HEX(BIN, HEX, hex, BH_LOWER);
 }
 
 static void test_bin_to_hex_sep(void)
 {
     static const unsigned char BIN[4] = { 0xca, 0xfe, 0xba, 0xbe };
     static const char HEX[12] = "ca:fe:ba:be";
-    int r;
     char hex[12];
+    ASSERT_TO_HEX(BIN, HEX, hex, (BH_LOWER|BH_SEPARATOR(':')));
+}
 
-    memset(hex, 0x45, sizeof(hex));
-    r = bin_to_hex(BIN, sizeof(BIN), hex, BH_LOWER|BH_SEPARATOR(':'));
-    CU_ASSERT_EQUAL(r, sizeof(hex)-1);
-    CU_ASSERT_STRING_EQUAL(hex, HEX);
+static void test_bin_to_hex_realloc(void)
+{
+    struct buf buf = BUF_INITIALIZER;
+    for (int i = 0; i < 30; i++) {
+        buf_putc(&buf, 'x');
+    }
+    CU_ASSERT_EQUAL(30, buf.len);
+    CU_ASSERT_EQUAL(32, buf.alloc);
+    CU_ASSERT_PTR_NOT_NULL(buf.s);
+
+    char c = 0xac;
+    buf_bin_to_hex(&buf, &c, 1, BH_UPPER);
+    CU_ASSERT_EQUAL(32, buf.len);
+    CU_ASSERT_EQUAL(64, buf.alloc);
+    CU_ASSERT_STRING_EQUAL("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxAC", buf_cstring(&buf));
+
+    buf_free(&buf);
 }
 
 static void test_hex_to_bin(void)
 {
     static const char HEX[9] = "cafebabe";
     static const unsigned char BIN[4] = { 0xca, 0xfe, 0xba, 0xbe };
-    int r;
     char bin[4];
-
-    memset(bin, 0xff, sizeof(bin));
-    r = hex_to_bin(HEX, sizeof(HEX)-1, bin);
-    CU_ASSERT_EQUAL(r, sizeof(bin));
-    CU_ASSERT_EQUAL(memcmp(bin, BIN, sizeof(bin)), 0);
+    ASSERT_TO_BIN(HEX, BIN, bin);
 }
 
 static void test_hex_to_bin_short(void)
 {
     static const char HEX[3] = "42";
     static const unsigned char BIN[1] = { 0x42 };
-    int r;
     char bin[1];
-
-    memset(bin, 0xff, sizeof(bin));
-    r = hex_to_bin(HEX, sizeof(HEX)-1, bin);
-    CU_ASSERT_EQUAL(r, sizeof(bin));
-    CU_ASSERT_EQUAL(memcmp(bin, BIN, sizeof(bin)), 0);
+    ASSERT_TO_BIN(HEX, BIN, bin);
 }
 
 static void test_hex_to_bin_long(void)
@@ -95,26 +124,16 @@ static void test_hex_to_bin_long(void)
         0x33,0xac,0x18,0xb6,0xdc,0x74,0x6e,0x9a,0xd7,0xbd,
         0x6f,0x9f,0xfa,0x77,0xe4,0x04,0x84,0x04,0xa0,0x02
     };
-    int r;
     char bin[20];
-
-    memset(bin, 0xff, sizeof(bin));
-    r = hex_to_bin(HEX, sizeof(HEX)-1, bin);
-    CU_ASSERT_EQUAL(r, sizeof(bin));
-    CU_ASSERT_EQUAL(memcmp(bin, BIN, sizeof(bin)), 0);
+    ASSERT_TO_BIN(HEX, BIN, bin);
 }
 
 static void test_hex_to_bin_capitals(void)
 {
     static const char HEX[9] = "CAFEBABE";
     static const unsigned char BIN[4] = { 0xca, 0xfe, 0xba, 0xbe };
-    int r;
     char bin[4];
-
-    memset(bin, 0xff, sizeof(bin));
-    r = hex_to_bin(HEX, sizeof(HEX)-1, bin);
-    CU_ASSERT_EQUAL(r, sizeof(bin));
-    CU_ASSERT_EQUAL(memcmp(bin, BIN, sizeof(bin)), 0);
+    ASSERT_TO_BIN(HEX, BIN, bin);
 }
 
 static void test_hex_to_bin_odd(void)
@@ -130,6 +149,12 @@ static void test_hex_to_bin_odd(void)
     CU_ASSERT_EQUAL(bin[1], 0xff);
     CU_ASSERT_EQUAL(bin[2], 0xff);
     CU_ASSERT_EQUAL(bin[3], 0xff);
+
+    struct buf buf = BUF_INITIALIZER;
+    r = buf_hex_to_bin(&buf, HEX, sizeof(HEX)-1);
+    CU_ASSERT_EQUAL(r, -1);
+    CU_ASSERT_EQUAL(buf_len(&buf), 0);
+    buf_free(&buf);
 }
 
 static void test_hex_to_bin_nonxdigit(void)
@@ -141,6 +166,12 @@ static void test_hex_to_bin_nonxdigit(void)
     memset(bin, 0xff, sizeof(bin));
     r = hex_to_bin(HEX, sizeof(HEX)-1, bin);
     CU_ASSERT_EQUAL(r, -1);
+
+    struct buf buf = BUF_INITIALIZER;
+    r = buf_hex_to_bin(&buf, HEX, sizeof(HEX)-1);
+    CU_ASSERT_EQUAL(r, -1);
+    CU_ASSERT_EQUAL(buf_len(&buf), 0);
+    buf_free(&buf);
 }
 
 static void test_hex_to_bin_whitespace(void)
@@ -152,19 +183,20 @@ static void test_hex_to_bin_whitespace(void)
     memset(bin, 0xff, sizeof(bin));
     r = hex_to_bin(HEX, sizeof(HEX)-1, bin);
     CU_ASSERT_EQUAL(r, -1);
+
+    struct buf buf = BUF_INITIALIZER;
+    r = buf_hex_to_bin(&buf, HEX, sizeof(HEX)-1);
+    CU_ASSERT_EQUAL(r, -1);
+    CU_ASSERT_EQUAL(buf_len(&buf), 0);
+    buf_free(&buf);
 }
 
 static void test_hex_to_bin_nolength(void)
 {
     static const char HEX[9] = "cafebabe";
     static const unsigned char BIN[4] = { 0xca, 0xfe, 0xba, 0xbe };
-    int r;
     char bin[4];
-
-    memset(bin, 0xff, sizeof(bin));
-    r = hex_to_bin(HEX, 0, bin);
-    CU_ASSERT_EQUAL(r, sizeof(bin));
-    CU_ASSERT_EQUAL(memcmp(bin, BIN, sizeof(bin)), 0);
+    ASSERT_TO_BIN(HEX, BIN, bin);
 }
 
 static void test_hex_to_bin_null(void)
@@ -176,6 +208,14 @@ static void test_hex_to_bin_null(void)
     r = hex_to_bin(NULL, 0, bin);
     CU_ASSERT_EQUAL(r, -1);
     CU_ASSERT_EQUAL(bin[0], 0xff);
+
+    struct buf buf = BUF_INITIALIZER;
+    r = buf_hex_to_bin(&buf, NULL, 0);
+    CU_ASSERT_EQUAL(r, -1);
+    CU_ASSERT_EQUAL(buf_len(&buf), 0);
+    buf_free(&buf);
 }
+
+#undef ASSERT_TO_HEX
 
 /* vim: set ft=c: */

--- a/cunit/imapurl.testc
+++ b/cunit/imapurl.testc
@@ -188,44 +188,44 @@ static void test_tourl(void)
 {
     static const char URL[] = "imap://jeeves/deverill";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.server = "jeeves";
     iurl.mailbox = "deverill";
 
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_tourl_server(void)
 {
     static const char URL[] = "imap://jeeves";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.server = "jeeves";
 
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_tourl_user(void)
 {
     static const char URL[] = "imap://wooster@jeeves/deverill";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.user = "wooster";
     iurl.server = "jeeves";
     iurl.mailbox = "deverill";
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_tourl_options(void)
@@ -236,7 +236,7 @@ static void test_tourl_options(void)
                               "/;SECTION=1.4"
                               "/;PARTIAL=1.1023";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.server = "jeeves";
@@ -247,9 +247,9 @@ static void test_tourl_options(void)
     iurl.start_octet = 1;
     iurl.octet_count = 1023;
 
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_tourl_urlauth(void)
@@ -259,7 +259,7 @@ static void test_tourl_urlauth(void)
                               ";EXPIRE=2010-11-24T06:57:26Z"
                               ";URLAUTH=submit+fred:internal:91354a473744909de610943775f92038";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.server = "jeeves";
@@ -270,9 +270,9 @@ static void test_tourl_urlauth(void)
     iurl.urlauth.token = "91354a473744909de610943775f92038";
     iurl.urlauth.expire = 1290581846;
 
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_tourl_ampersand(void)
@@ -284,15 +284,15 @@ static void test_tourl_ampersand(void)
      */
     static const char URL[] = "imap://goons/Goosey%26Bawks";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.server = "goons";
     iurl.mailbox = "Goosey&-Bawks";
 
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_tourl_urlunsafe(void)
@@ -303,15 +303,15 @@ static void test_tourl_urlunsafe(void)
      */
     static const char URL[] = "imap://gibberish/%20%22%23%25%2B%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E%60%7B%7C%7D";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.server = "gibberish";
     iurl.mailbox = " \"#%+:;<=>?@[\\]^`{|}";
 
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_tourl_utf7_high(void)
@@ -331,15 +331,15 @@ static void test_tourl_utf7_high(void)
      */
     static const char URL[] = "imap://uruk/%F0%92%81%B3%F0%92%80%A0%F0%92%84%A9";
     struct imapurl iurl;
-    char buf[300];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(iurl));
     iurl.server = "uruk";
     iurl.mailbox = "&2Ajcc9gI3CDYCN0p-";
 
-    memset(buf, 0x45, sizeof(buf));
-    imapurl_toURL(buf, &iurl);
-    CU_ASSERT_STRING_EQUAL(buf, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
+    buf_free(&buf);
 }
 
 static void test_fromurl_utf2_high(void)
@@ -375,7 +375,7 @@ static void test_cycle(void)
     struct imapurl iurl2;
     static const char URL[] = "imap://;AUTH=*@server/%C3%A4%20%C3%84;UIDVALIDITY=1234567890";
     int r;
-    char url[400];
+    struct buf buf = BUF_INITIALIZER;
 
     memset(&iurl, 0, sizeof(struct imapurl));
     iurl.server = "server";
@@ -383,15 +383,16 @@ static void test_cycle(void)
     iurl.mailbox = "&AOQ- &AMQ-";  /* "ä Ä" */
     iurl.uidvalidity = 1234567890;
 
-    memset(url, 0x45, sizeof(url));
-    imapurl_toURL(url, &iurl);
-    CU_ASSERT_STRING_EQUAL(url, URL);
+    imapurl_toURL(&buf, &iurl);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), URL);
 
-    r = imapurl_fromURL(&iurl2, url);
+    r = imapurl_fromURL(&iurl2, buf_cstring(&buf));
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_STRING_EQUAL(iurl2.mailbox, "&AOQ- &AMQ-");
     CU_ASSERT_EQUAL(iurl2.uidvalidity, 1234567890);
     free(iurl2.freeme);
+
+    buf_free(&buf);
 }
 
 /* vim: set ft=c: */

--- a/imap/cyrdump.c
+++ b/imap/cyrdump.c
@@ -172,7 +172,6 @@ static int dump_me(struct findall_data *data, void *rock)
     int r;
     char boundary[128];
     struct imapurl url;
-    char imapurl[MAX_MAILBOX_PATH+1];
     struct incremental_record *irec = (struct incremental_record *) rock;
     struct searchargs searchargs;
     struct index_state *state;
@@ -208,11 +207,14 @@ static int dump_me(struct findall_data *data, void *rock)
     memset(&url, 0, sizeof(struct imapurl));
     url.server = config_servername;
     url.mailbox = name;
-    imapurl_toURL(imapurl, &url);
-    printf("  <mailbox-url>%s</mailbox-url>\n", imapurl);
+
+    struct buf urlbuf = BUF_INITIALIZER;
+    imapurl_toURL(&urlbuf, &url);
+    printf("  <mailbox-url>%s</mailbox-url>\n", buf_cstring(&urlbuf));
     printf("  <incremental-uid>%d</incremental-uid>\n", irec->incruid);
     printf("  <nextuid>%u</nextuid>\n", state->mailbox->i.last_uid + 1);
     printf("\n");
+    buf_free(&urlbuf);
 
     memset(&searchargs, 0, sizeof(struct searchargs));
     searchargs.root = search_expr_new(NULL, SEOP_TRUE);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -679,19 +679,20 @@ static void imapd_refer(const char *tag,
                         const char *mailbox)
 {
     struct imapurl imapurl;
-    char url[MAX_MAILBOX_PATH+1];
+    struct buf url = BUF_INITIALIZER;
 
     memset(&imapurl, 0, sizeof(struct imapurl));
     imapurl.server = server;
     imapurl.mailbox = mailbox;
     imapurl.auth = !strcmp(imapd_userid, "anonymous") ? "anonymous" : "*";
 
-    imapurl_toURL(url, &imapurl);
+    imapurl_toURL(&url, &imapurl);
 
     prot_printf(imapd_out, "%s NO [REFERRAL %s] Remote mailbox.\r\n",
-                tag, url);
+                tag, buf_cstring(&url));
 
     free(imapurl.freeme);
+    buf_free(&url);
 }
 
 /* wrapper for mboxlist_lookup that will force a referral if we are remote

--- a/lib/imapurl.h
+++ b/lib/imapurl.h
@@ -42,6 +42,8 @@
 #ifndef IMAPURL_H
 #define IMAPURL_H
 
+#include "util.h"
+
 struct imapurl {
     char *freeme;               /* copy of original URL + decoded mailbox;
                                    caller must free() */
@@ -76,13 +78,12 @@ extern int URLtoMailbox(char *dst, const char *src);
 #define UTF8_to_mUTF7(dst, src) URLtoMailbox(dst, src)
 
 /* Convert an IMAP mailbox to a URL path
- *  dst needs to have roughly 4 times the storage space of mailbox
  *    Hex encoding can triple the size of the input
  *    UTF-7 can be slightly denser than UTF-8
  *     (worst case: 8 octets UTF-7 becomes 9 octets UTF-8)
  *
  *  it is valid for mechname to be NULL (implies anonymous mech)
  */
-extern void imapurl_toURL(char *dst, const struct imapurl *url);
+extern void imapurl_toURL(struct buf *dst, const struct imapurl *url);
 
 #endif /* IMAPURL_H */

--- a/lib/util.c
+++ b/lib/util.c
@@ -1779,6 +1779,17 @@ EXPORTED int bin_to_hex(const void *bin, size_t binlen, char *hex, int flags)
     return p-hex;
 }
 
+EXPORTED int buf_bin_to_hex(struct buf *hex, const void *bin, size_t binlen, int flags)
+{
+    size_t seplen = _BH_GETSEP(flags) && binlen ? binlen - 1 : 0;
+    size_t newlen = hex->len + binlen * 2 + seplen;
+    buf_ensure(hex, newlen - hex->len + 1);
+    int r = bin_to_hex(bin, binlen, hex->s + hex->len, flags);
+    buf_truncate(hex, newlen);
+    buf_cstring(hex);
+    return r;
+}
+
 EXPORTED int bin_to_lchex(const void *bin, size_t binlen, char *hex)
 {
     uint16_t *p = (void *)hex;
@@ -1788,6 +1799,16 @@ EXPORTED int bin_to_lchex(const void *bin, size_t binlen, char *hex)
         *p++ = lchexchars[*v++];
     hex[binlen*2] = '\0';
     return 2 * binlen;
+}
+
+EXPORTED int buf_bin_to_lchex(struct buf *hex, const void *bin, size_t binlen)
+{
+    size_t newlen = hex->len + 2 * binlen;
+    buf_ensure(hex, newlen - hex->len + 1);
+    int r = bin_to_lchex(bin, binlen, hex->s + hex->len);
+    buf_truncate(hex, newlen);
+    buf_cstring(hex);
+    return r;
 }
 
 EXPORTED int hex_to_bin(const char *hex, size_t hexlen, void *bin)
@@ -1815,6 +1836,25 @@ EXPORTED int hex_to_bin(const char *hex, size_t hexlen, void *bin)
     }
 
     return (unsigned char *)v - (unsigned char *)bin;
+}
+
+EXPORTED int buf_hex_to_bin(struct buf *bin, const char *hex, size_t hexlen)
+{
+    if (hex == NULL)
+        return -1;
+    if (hexlen == 0)
+        hexlen = strlen(hex);
+    if (hexlen % 2)
+        return -1;
+
+    size_t newlen = bin->len + hexlen / 2;
+    buf_ensure(bin, newlen - bin->len + 1);
+    int r = hex_to_bin(hex, hexlen, bin->s + bin->len);
+    if (r >= 0) {
+        buf_truncate(bin, newlen);
+        buf_cstring(bin);
+    }
+    return r;
 }
 
 #ifdef HAVE_ZLIB

--- a/lib/util.h
+++ b/lib/util.h
@@ -369,6 +369,10 @@ int bin_to_hex(const void *bin, size_t binlen, char *hex, int flags);
 int bin_to_lchex(const void *bin, size_t binlen, char *hex);
 int hex_to_bin(const char *hex, size_t hexlen, void *bin);
 
+int buf_bin_to_hex(struct buf *hex, const void *bin, size_t binlen, int flags);
+int buf_bin_to_lchex(struct buf *hex, const void *bin, size_t binlen);
+int buf_hex_to_bin(struct buf *bin, const char *hex, size_t hexlen);
+
 /* use getpassphrase on machines which support it */
 #ifdef HAVE_GETPASSPHRASE
 #define cyrus_getpass getpassphrase

--- a/perl/imap/IMAP.xs
+++ b/perl/imap/IMAP.xs
@@ -717,26 +717,23 @@ imclient_toURL(client,server,box)
         char *server
         char *box
 PREINIT:
-        char *out_buf;
-        int len;
+        struct buf buf = BUF_INITIALIZER;
         struct imapurl imapurl;
 PPCODE:
-        len = strlen(server)+strlen(box);
-        out_buf = safemalloc(4*len);
-
         memset(&imapurl, 0, sizeof(struct imapurl));
         imapurl.server = server;
         imapurl.mailbox = box;
-        imapurl_toURL(out_buf, &imapurl);
+        imapurl_toURL(&buf, &imapurl);
+        buf_cstring(&buf);
 
-        if(!out_buf[0]) {
-                safefree(out_buf);
+        if(!buf_len(&buf)) {
+                buf_free(&buf);
                 XSRETURN_UNDEF;
         }
 
-        XPUSHs(sv_2mortal(newSVpv(out_buf, 0)));
+        XPUSHs(sv_2mortal(newSVpv(buf_cstring(&buf), 0)));
 
         /* newSVpv copies this */
-        safefree(out_buf);
+        buf_free(&buf);
 
         XSRETURN(1);


### PR DESCRIPTION
This backports https://github.com/cyrusimap/cyrus-imapd/pull/4436 to the 3.8 version