### PR TITLE
cassandane: slow test improvements

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPBackup.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPBackup.pm
@@ -880,7 +880,7 @@ sub test_restore_calendars_all_dryrun
     $self->assert_null($imip);
 }
 
-sub test_restore_calendars_batch_size_bug1_slow
+sub test_restore_calendars_batch_size_bug1
     :min_version_3_7 :needs_component_jmap
 {
     my ($self) = @_;
@@ -969,7 +969,7 @@ sub test_restore_calendars_batch_size_bug1_slow
     $self->assert_num_equals(513, $res->[0][1]{numDestroysUndone});
 }
 
-sub test_restore_calendars_batch_size_bug2_slow
+sub test_restore_calendars_batch_size_bug2
     :min_version_3_7 :needs_component_jmap
 {
     my ($self) = @_;
@@ -2355,7 +2355,7 @@ sub test_restore_notes_all_dryrun
     $self->assert_num_equals(0, scalar @{$res->[0][1]{destroyed}});
 }
 
-sub test_restore_mail_twice_slow
+sub test_restore_mail_twice
     :min_version_3_3 :needs_component_jmap :NoAltNameSpace
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -166,6 +166,12 @@ sub filter
             return 1 if $method =~ m/_slow$/;
             return;
         },
+        slow_only => sub
+        {
+            my ($method) = @_;
+            return 1 if $method !~ m/_slow$/;
+            return;
+        },
     };
 }
 

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -650,7 +650,12 @@ sub schedule
         my ($neg, $type, $path, $test) = _parse_test_spec($name);
 
         # slow test explicitly requested by name, so turn off the filter
-        if (defined $test and ! ref $test and $test =~ m/_slow$/ and ! $neg) {
+        if (defined $test
+            and ! ref $test
+            and $test =~ m/_slow$/
+            and ! $neg
+            and $self->{skip_slow})
+        {
             xlog "$name was explicitly requested. Enabling slow tests!";
             $self->{skip_slow} = 0;
         }

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -500,6 +500,7 @@ sub new
         log_directory => delete $opts{log_directory},
         maxworkers => delete $opts{maxworkers} || 1,
         skip_slow => delete $opts{skip_slow} // 1,
+        slow_only => delete $opts{slow_only} // 0,
     };
     die "Unknown options: " . join(' ', keys %opts)
         if scalar %opts;
@@ -658,6 +659,17 @@ sub schedule
         {
             xlog "$name was explicitly requested. Enabling slow tests!";
             $self->{skip_slow} = 0;
+        }
+
+        # non-slow test explicitly requested by name, so turn off slow-only
+        if (defined $test
+            and ! ref $test
+            and $test !~ m/_slow$/
+            and ! $neg
+            and $self->{slow_only})
+        {
+            xlog "$name was explicitly requested. Enabling regular tests!";
+            $self->{slow_only} = 0;
         }
 
         if ($type eq 'd')

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -64,6 +64,7 @@ my $do_list = 0;
 # The default really should be --no-keep-going like make
 my $keep_going = 1;
 my $skip_slow = 1;
+my $slow_only = 0;
 my $log_directory;
 my @names;
 
@@ -146,6 +147,7 @@ my %runners =
         my @filters = qw(x skip_version skip_missing_features
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
+        push @filters, 'slow_only' if $plan->{slow_only};
         $runner->filter(@filters);
         return $runner->do_run($plan, 0);
     },
@@ -157,6 +159,7 @@ my %runners =
         my @filters = qw(x skip_version skip_missing_features
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
+        push @filters, 'slow_only' if $plan->{slow_only};
         $runner->filter(@filters);
         return $runner->do_run($plan, 0);
     },
@@ -168,6 +171,7 @@ my %runners =
         my @filters = qw(x skip_version skip_missing_features
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
+        push @filters, 'slow_only' if $plan->{slow_only};
         $runner->filter(@filters);
         return $runner->do_run($plan, 0);
     },
@@ -198,6 +202,7 @@ eval
         my $runner = Cassandane::Unit::RunnerXML->new($output_dir);
         my @filters = qw(x skip_version skip_missing_features);
         push @filters, 'skip_slow' if $plan->{skip_slow};
+        push @filters, 'slow_only' if $plan->{slow_only};
         $runner->filter(@filters);
         $runner->start($plan);
         return $runner->all_tests_passed();
@@ -303,6 +308,11 @@ while (my $a = shift)
     {
         $skip_slow = 0;
     }
+    elsif ($a eq '--slow-only')
+    {
+        $skip_slow = 0;
+        $slow_only = 1;
+    }
     elsif ($a eq '--rerun')
     {
         $want_rerun = 1;
@@ -349,6 +359,7 @@ my $plan = Cassandane::Unit::TestPlan->new(
         maxworkers => $cassini->val('cassandane', 'maxworkers') || undef,
         log_directory => $log_directory,
         skip_slow => $skip_slow,
+        slow_only => $slow_only,
     );
 
 if ($do_list)

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-standalone-instances-multi
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-get-standalone-instances-multi
@@ -1,7 +1,7 @@
 #!perl
 use Cassandane::Tiny;
 
-sub test_calendarevent_get_standalone_instances_slow
+sub test_calendarevent_get_standalone_instances_multi
     :needs_component_httpd :needs_component_jmap :min_version_3_7
 {
     my ($self) = @_;

--- a/cassandane/tiny-tests/JMAPEmail/email-query-cached-evict
+++ b/cassandane/tiny-tests/JMAPEmail/email-query-cached-evict
@@ -1,7 +1,7 @@
 #!perl
 use Cassandane::Tiny;
 
-sub test_email_query_cached_evict_slow
+sub test_email_query_cached_evict
     :min_version_3_5 :needs_component_sieve :needs_component_jmap
     :JMAPQueryCacheMaxAge1s :JMAPExtensions
 {


### PR DESCRIPTION
Got curious and discovered many of our "_slow" tests run in ~5 seconds each; this doesn't seem slow enough to be worth the loss of regular regression coverage, so I've removed the "_slow" marker from the fast ones.

"calendarevent_get_standalone_instances_slow" got renamed to "calendarevent_get_standalone_instances_multi" along the way, because it turned out there was already a "calendarevent_get_standalone_instances" (which did the same thing, but only once).  The rest just lost their "_slow" marker.

While I was in there, I got frustrated at the difficulty of running just the slow tests, without everything else too, so I added a --slow-only option for testrunner.pl and plumbed it through.

Bug3072.copy_longset_slow (112 seconds) and ClamAV.remove_infected_slow (21 seconds) are still marked slow because they are slow, and are of low-importance IMO.  JMAPBackup.restore_mail_twice_slow is also still marked slow -- but because it fails (quickly), and I didn't want the distraction; I don't know how long it would take if it succeeded.