### PR TITLE
append.c: do not log missing ACL if no rights are missing

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -862,7 +862,7 @@ static int append_apply_flags(struct appendstate *as,
             mboxevent_add_flag(mboxevent, flag);
         }
 
-        if (!(as->myrights & need_rights)) {
+        if (need_rights && !(as->myrights & need_rights)) {
             // One or more ACLs were missing to set the flag
             char aclstr[ACL_STRING_MAX];
             cyrus_acl_masktostr(need_rights, aclstr);


### PR DESCRIPTION
It's misleading to log an error message for `need_rights=<>` which actually indicates that no rights are missing.