### PR TITLE
Prevent deadlock between SEARCH and squatter

### DIFF
--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -164,16 +164,12 @@ static int search_batch_size(void)
  * Returns an IMAP error code or 0 on success.
  */
 static int flush_batch(search_text_receiver_t *rx,
-                       struct mailbox *mailbox,
                        int flags,
                        ptrarray_t *batch)
 {
     int i;
     int r = 0;
     int indexflags = 0;
-
-    /* give someone else a chance */
-    mailbox_unlock_index(mailbox, NULL);
 
     /* prefetch files */
     for (i = 0 ; i < batch->count ; i++) {
@@ -256,7 +252,7 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
     mailbox_iter_done(&iter);
 
     if (batch.count)
-        r = flush_batch(rx, mailbox, flags, &batch);
+        r = flush_batch(rx, flags, &batch);
 
  done:
     ptrarray_fini(&batch);


### PR DESCRIPTION
This aligns the lock acquisition order of the SEARCH command and squatter to prevent a deadlock between them running concurrently on the same user and mailbox.

The deadlock occurred when squatter had acquired a lock on conversations.db and wanted to acquire an exclusive lock on xapianactive.db. Meanwhile, SEARCH had acquired a lock on xapianactive.db and wanted to acquire an exclusive lock conversations.db.

This patch aligns their lock acquisition order to prevent this deadlock.

Testing this currently is only done manually. A brute-force test is to runs hundreds of SEARCHes and squatters on the same user to hit the deadlock. A better test is done by use of special-purpose tool that I built that traces the acquired locks of a Cyrus process across its lifetime. I do plan to integrate this tool into our automated tests but I don't want this patch to wait until then.