### PR TITLE
lmtpd.c: internalseen is determined by the owner of the Sieve script

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -7243,4 +7243,36 @@ EOF
     $self->assert_num_equals(0, $talk->get_response_code('exists'));
 }
 
+sub test_plus_address_mark_read
+    :needs_component_sieve :NoAltNameSpace
+{
+    my ($self) = @_;
+
+    my $folder = "INBOX.foo";
+
+    xlog $self, "Create folders";
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create($folder)
+        or die "Cannot create $folder: $@";
+
+    $imaptalk->setacl($folder, 'anyone' => 'p');
+
+    xlog $self, "Install a script";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["imap4flags"];
+addflag "\\\\Seen";
+EOF
+    );
+
+    xlog $self, "Deliver a message to plus address";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg, user => "cassandane+foo");
+
+    xlog $self, "Check that the message made it to $folder";
+    $self->{store}->set_folder($folder);
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+    $msg->set_attribute(flags => [ '\\Recent', '\\Seen']);
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+}
+
 1;

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -582,6 +582,7 @@ int deliver_mailbox(FILE *f,
                     cyrus_acl_myrights(imap4flags->authstate, mailbox_acl(mailbox));
 
                 as.myrights |= (owner_rights & ~ACL_POST);
+                as.internalseen = mailbox_internal_seen(mailbox, user);
             }
         }
 


### PR DESCRIPTION
Fix for setting \Seen flag on a plus-addressed mailbox.  as->internalseen was being determined by the userid of the sender rather then the userid of the script owner, so we tried to write to seen.db and failed.