### PR TITLE
cassandane.ini.dockertests: no longer suppress urlauth

### DIFF
--- a/cassandane/cassandane.ini.dockertests
+++ b/cassandane/cassandane.ini.dockertests
@@ -65,7 +65,8 @@ zoneinfo_dir = /usr/local/cyruslibs/share/cyrus-timezones/zoneinfo
 
 [imaptest]
 basedir = /srv/imaptest.git
-suppress = urlauth urlauth2
+# suppress list last reviewed 2023-05-03
+suppress = urlauth2
 
 
 [caldavtester]


### PR DESCRIPTION
"ImapTest.urlauth" no longer fails with current imaptest, so we can stop suppressing it.

Before this can merge:

* https://github.com/cyrusimap/cyrus-docker/pull/15 must be merged
* the "cyrus" branch of our imaptest fork must be updated to be based on its "master"  plus our "urlauth" branch (I have already updated its "master" from upstream to correspond with the Dovecot version in the cyrus-docker PR).
* and a new docker image published(???)

Marking this "do not merge" so it doesn't get accidentally merged without the coordinating steps.

Update: coordinating steps are complete, and this has been rebased on master and is ready to go whenever it's reviewed (assuming approved with passing CI)