### PR TITLE
Return proper error codes for erroneous search state

### DIFF
--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2663,6 +2663,13 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
         goto out;
     }
 
+    if (mboxname_isdeletedmailbox(mailbox_name(mailbox), NULL)) {
+        syslog(LOG_ERR, "Refusing to index deleted mailbox %s",
+                mailbox_name(mailbox));
+        r = IMAP_MAILBOX_NONEXISTENT;
+        goto out;
+    }
+
     /* make sure the conversations are open before we start indexing
      * to avoid deadlocking against the search state */
     struct conversations_state *cstate = mailbox_get_cstate(mailbox);
@@ -2684,12 +2691,6 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
     if (r) {
         syslog(LOG_ERR, "Could not acquire shared namelock on %s",
                namelock_fname);
-        goto out;
-    }
-
-    if (mboxname_isdeletedmailbox(mailbox_name(mailbox), NULL)) {
-        syslog(LOG_ERR, "Refusing to index deleted mailbox %s",
-                mailbox_name(mailbox));
         goto out;
     }
 

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2749,6 +2749,7 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
     // this should never be able to fail here, because the first item will always exist!
     if (!tr->activedirs || !tr->activedirs->count) {
         syslog(LOG_ERR, "Failed to resolve activedir for %s", mailbox_name(mailbox));
+        r = IMAP_INTERNAL;
         goto out;
     }
 


### PR DESCRIPTION
This fixes a potential null pointer read if a mailbox got deleted in between squatter selecting it for search indexing and actually indexing its messages. Returning non-zero error codes will signal the caller of the search backend to skip indexing this mailbox.
Reproducing this condition in a test harness would require synchronizing squatter execution with some arbitrary process, and effectively would add dead code for testing.
Instead, the changes in this pull request have been vetted with manual testing as well as running the full test suites. No issues have shown up.