### PR TITLE
github actions: workaround "dubious ownership" failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,10 @@ jobs:
       with:
         fetch-depth: 0
     - name: configure and build
-      run: ./tools/build-with-cyruslibs.sh
+      run: |
+        git config --global --add safe.directory /__w/cyrus-imapd/cyrus-imapd
+        echo "building cyrus version" $(./tools/git-version.sh)
+        ./tools/build-with-cyruslibs.sh
       shell: bash
     - name: update jmap test suite
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,10 @@ jobs:
         options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --init
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: configure and build
-      run: |
-        git fetch --unshallow
-        git remote add upstream https://github.com/cyrusimap/cyrus-imapd.git
-        git fetch --tags upstream
-        ./tools/build-with-cyruslibs.sh
+      run: ./tools/build-with-cyruslibs.sh
       shell: bash
     - name: update jmap test suite
       run: |


### PR DESCRIPTION
We recently built a new cyrus-buster docker image, with updated dovecot and imaptest builds, to resolve the problem with ImapTest.notify failing every CI run.  The new docker image seems to have gotten an updated git that contains a security fix which complains when the directory ownership looks sketchy -- which, it does when running github actions on docker images! https://github.com/actions/runner/issues/2033

Initially, this was failing on the post-checkout fiddling we were doing to make the git tags available to the build (which needs them for versioning), so the first commit here removes the post-checkout fiddling and instead configures the checkout step to get everything we need in the first place.  But we need the `git describe` command during the build to determine the version number, which fails for the same reason, so the second commit adds the workaround anyway.