### PR TITLE
append.c: require ACL_SETSEEN when setting \Seen flag

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -814,9 +814,11 @@ static int append_apply_flags(struct appendstate *as,
         long need_rights = 0; // keep track of required ACLs
 
         if (!strcasecmp(flag, "\\seen")) {
-            r = append_setseen(as, msgrec);
-            if (r) goto out;
-            mboxevent_add_flag(mboxevent, flag);
+            if (as->myrights & (need_rights = ACL_SETSEEN)) {
+                r = append_setseen(as, msgrec);
+                if (r) goto out;
+                mboxevent_add_flag(mboxevent, flag);
+            }
         }
         else if (!strcasecmp(flag, "\\expunged")) {
             /* NOTE - this is a fake internal name */


### PR DESCRIPTION
Up until now, the \Seen flag could be set in append without the ACL_SETSEEN permission being assigned to the authenticated user. All other flags already had their required ACLS checked, and this now also is enforced the Seen flag.

This passes all Cassandane and integration tests, which indicates there are no hidden assumptions that build on this.