### PR TITLE
developer-testing.rst: explain CI imaptest setup

### DIFF
--- a/docsrc/imap/developer/developer-testing.rst
+++ b/docsrc/imap/developer/developer-testing.rst
@@ -114,7 +114,19 @@ IMAPTest_ is a testing suite which uses libraries from the Dovecot installation.
     * ``./configure --with-dovecot=../dovecot-2.2 && make`` (No need for make install)
     * The ``--with-dovecot=<path>`` parameter is used to specify path to Dovecot v2.2 sources' root directory.
 
+This is not quite the same IMAPTest that CI uses.  The CI system uses
+a docker image, which among other things has Dovecot and IMAPTest already
+built in so that they don't need to be rebuilt every time CI runs.
+
+The docker image is built from Dockerfile_ in the cyrus-docker repo.  If you
+want to locally reproduce the same testing that CI runs, you can search it
+for "dovecot.git" and "imaptest.git" to see how these two components
+are fetched and built, and do the same yourself.  Briefly, Dovecot is built
+from a known commit id on the upstream repository, whereas IMAPTest is built
+from the "cyrus" branch of our own fork.
+
 .. _IMAPTest: http://www.imapwiki.org/ImapTest
+.. _Dockerfile: https://github.com/cyrusimap/cyrus-docker/blob/master/Debian/Dockerfile
 
 Rebuild Cyrus for Testing
 =========================


### PR DESCRIPTION
Updates the developer testing instructions, which advises building Dovecot and IMAPTest from nightly build tarballs, to explain how you can also build these from git by copying what the docker image build does, which will get you the same tests CI runs.

I didn't provide copy-and-pastable commands here, because it relies on checking out a known commit id on the Dovecot repository, and I don't want to have to try to keep this documentation synchronised.  Instead, I just link to the docker image build script, and advise the reader to copy what it does if they want to do the same thing.

Really, my main purpose in writing this is so that in a few years when we next need to update IMAPTest for CI, I don't get confused by our documentation saying one thing, but our process doing another.  I still think just using a matched pair of nightlies is the simplest approach, unless you're specifically trying to reproduce what CI does.