### PR TITLE
http_dav: fix meth_mkcol leak when mailbox is remote

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5731,10 +5731,11 @@ int meth_mkcol(struct transaction_t *txn, void *params)
             txn->error.precond = mparams->mkcol.location_precond;
             ret = HTTP_FORBIDDEN;
             goto done;
-	}
+        }
 
         be = proxy_findserver(parent->server, &http_protocol, httpd_userid,
                               &backend_cached, NULL, NULL, httpd_in);
+        mboxlist_entry_free(&parent);
 
         if (!be) ret = HTTP_UNAVAILABLE;
         else ret = http_pipe_req_resp(be, txn);


### PR DESCRIPTION
Initially found by valgrinding cassandane on 3.8, but reproducible on master.  Not sure why @rsto's master valgrinds didn't find this but mine did.

(Also replaces a hard tab that had somehow snuck in nearby.)