### PR TITLE
docsrc/conf.py: use absolute dev release notes link

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -453,7 +453,7 @@ rst_prolog = """
 
 .. |imap_development_release_notes| raw:: html
 
-    <a href="3.9/x/3.9.0-alpha0.html">3.9.0-alpha0</a>
+    <a href="https://www.cyrusimap.org/dev/imap/download/release-notes/3.9/x/3.9.0-alpha0.html">3.9.0-alpha0</a>
 
 """
 


### PR DESCRIPTION
so that older branches (and future older branches) don't end up with a dead link to release notes they don't have, and don't need to be kept up to date with current dev release notes either

(3.6 and earlier already got this change during release of 3.8.0; this is a forward port from there)