### PR TITLE
docs: remove references to jmap_guesstz_fname

### DIFF
--- a/docsrc/imap/download/release-notes/3.8/x/3.8.0-beta1.rst
+++ b/docsrc/imap/download/release-notes/3.8/x/3.8.0-beta1.rst
@@ -26,8 +26,7 @@ Major changes since the 3.6 series
 * Adds support for IMAP Saved Search Results (:rfc:`5182`).
 * Advertise support for IMAP URL-PARTIAL (:rfc:`5550`).
 * Implements the JMAP calendars specification
-  (:draft:`draft-ietf-jmap-calendars`).  See the "jmap_guesstz_fname" option
-  in :cyrusman:`imapd.conf(5)`.
+  (:draft:`draft-ietf-jmap-calendars`).
 * Adds support for a new read-only ``\Scheduled`` mailbox that contains
   emails created via JMAP EmailSubmission/set that are to be sent
   at a later date/time.  Also extends the JMAP EmailSubmission object

--- a/docsrc/imap/download/release-notes/3.8/x/3.8.0-beta2.rst
+++ b/docsrc/imap/download/release-notes/3.8/x/3.8.0-beta2.rst
@@ -26,8 +26,7 @@ Major changes since the 3.6 series
 * Adds support for IMAP Saved Search Results (:rfc:`5182`).
 * Advertise support for IMAP URL-PARTIAL (:rfc:`5550`).
 * Implements the JMAP calendars specification
-  (:draft:`draft-ietf-jmap-calendars`).  See the "jmap_guesstz_fname" option
-  in :cyrusman:`imapd.conf(5)`.
+  (:draft:`draft-ietf-jmap-calendars`).
 * Adds support for a new read-only ``\Scheduled`` mailbox that contains
   emails created via JMAP EmailSubmission/set that are to be sent
   at a later date/time.  Also extends the JMAP EmailSubmission object

--- a/docsrc/imap/download/release-notes/3.8/x/3.8.0-rc1.rst
+++ b/docsrc/imap/download/release-notes/3.8/x/3.8.0-rc1.rst
@@ -26,8 +26,7 @@ Major changes since the 3.6 series
 * Adds support for IMAP Saved Search Results (:rfc:`5182`).
 * Advertise support for IMAP URL-PARTIAL (:rfc:`5550`).
 * Implements the JMAP calendars specification
-  (:draft:`draft-ietf-jmap-calendars`).  See the "jmap_guesstz_fname" option
-  in :cyrusman:`imapd.conf(5)`.
+  (:draft:`draft-ietf-jmap-calendars`).
 * Adds support for a new read-only ``\Scheduled`` mailbox that contains
   emails created via JMAP EmailSubmission/set that are to be sent
   at a later date/time.  Also extends the JMAP EmailSubmission object

--- a/docsrc/imap/download/release-notes/3.8/x/3.8.0.rst
+++ b/docsrc/imap/download/release-notes/3.8/x/3.8.0.rst
@@ -26,8 +26,7 @@ Major changes since the 3.6 series
 * Adds support for IMAP Saved Search Results (:rfc:`5182`).
 * Advertise support for IMAP URL-PARTIAL (:rfc:`5550`).
 * Implements the JMAP calendars specification
-  (:draft:`draft-ietf-jmap-calendars`).  See the "jmap_guesstz_fname" option
-  in :cyrusman:`imapd.conf(5)`.
+  (:draft:`draft-ietf-jmap-calendars`).
 * Adds support for a new read-only ``\Scheduled`` mailbox that contains
   emails created via JMAP EmailSubmission/set that are to be sent
   at a later date/time.  Also extends the JMAP EmailSubmission object


### PR DESCRIPTION
This was an option that existed briefly on a feature branch, but was rebased out before the feature landed.  A reference to it accidentally hung around in documentation, and wound up in release notes.