### PR TITLE
feat: allow size >= 2 for jwt payload

### DIFF
--- a/imap/http_jwt.c
+++ b/imap/http_jwt.c
@@ -503,7 +503,7 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
         goto done;
     }
 
-    if (json_object_size(jws) == 2) {
+    if (json_object_size(jws) >= 2) {
         json_t *jiat = json_object_get(jws, "iat");
         if (!json_is_integer(jiat)) {
             if (jiat) {


### PR DESCRIPTION
Hello,

Could we change the check for the number of fields of the JWT payload to greater or equal to 2 instead of 2. I can't see any drawbacks of doing this, but maybe I'm missing something. There should be `iat` and `sub` fields, but why couldn't we use more?

The tests are green with the change but I didn't add a test on this.

In our app we use `exp` for expiration timestamp for example and a `role` field as well.

Thanks for your answers.