### PR TITLE
docs: remove post-upgrade survey link

### DIFF
--- a/docsrc/imap/download/upgrade.rst
+++ b/docsrc/imap/download/upgrade.rst
@@ -455,17 +455,7 @@ full list.
 10. Upgrade complete
 --------------------
 
-Your upgrade is complete! We have a super-quick survey (3 questions only,
-anonymous responses) we would love for you to fill out, so we can get a feel for
-how many Cyrus installations are out there, and how the upgrade process went.
-
-|3.8 survey link|
-
-.. |3.8 survey link| raw:: html
-
-    <a href="https://cyrusimap.typeform.com/to/YI9P0f" target="_blank">
-    I'll fill in the survey right now</a> (opens in a new window)
-
+Your upgrade is complete, congratulations!
 
 Special note for Murder configurations
 --------------------------------------


### PR DESCRIPTION
we're not doing anything useful with the responses anyway