### PR TITLE
JMAPTestSuite: don't leave behind defunct squatter procs

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
@@ -295,9 +295,19 @@ sub run_test
     local $ENV{JMTS_USE_WEBSOCKETS} = 1;
 
     # Needed so text based searching works in Email/query, etc...
-    my $squatter_pid = $self->{instance}->run_command(
-      { cyrus => 1, background => 1 },
-      'squatter', '-R', '-d',
+    my $squatter_pid = $self->{instance}->run_command({
+            cyrus => 1,
+            background => 1,
+            handlers => {
+                exited_abnormally => sub {
+                    my ($child, $code) = @_;
+                    return 0 if $code == 75; # ignore EX_TEMPFAIL
+                    my $desc = Cassandane::Instance::_describe_child($child);
+                    die "child process $desc exited with code $code";
+                },
+            },
+        },
+        'squatter', '-R', '-d',
     );
 
     $self->{instance}->run_command({
@@ -312,7 +322,7 @@ sub run_test
          "$basedir/$name.t",
     );
 
-    kill 'INT' => $squatter_pid || die "Failed to kill squatter $squatter_pid\n";
+    $self->{instance}->stop_command($squatter_pid);
 
     if ((!$status || get_verbose)) {
         if (-f $errfile) {


### PR DESCRIPTION
Noticed while investigating something else that JMAPTestSuite (and JMAPTestSuiteWS) create a lot of defunct squatter processes that don't get cleaned up until cassandane itself exits.  Turns out we were killing the process after each test, but not calling waitpid on it.

This arranges for it to be cleaned up properly, using the already existing mechanism.  Rolling squatter exits with EX_TEMPFAIL when shut down with SIGTERM, so it also needs the custom exited_abnormally that ignores EX_TEMPFAIL (but still dies for any other non-zero exit code).