### PR TITLE
jmap_calendar: support FilterOperator in dav.db queries

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-query
@@ -8,134 +8,233 @@ sub test_calendarevent_query
 
     my $jmap = $self->{jmap};
     my $caldav = $self->{caldav};
+    my ($maj, $min) = Cassandane::Instance->get_version();
 
-    xlog $self, "create calendars A and B";
+    xlog $self, "create calendars";
     my $res = $jmap->CallMethods([
-            ['Calendar/set', {
-                    create => {
-                        "1" => {
-                            name => "A", color => "coral", sortOrder => 1, isVisible => JSON::true,
-                        },
-                        "2" => {
-                            name => "B", color => "blue", sortOrder => 1, isVisible => JSON::true
-                        }
-                    }}, "R1"]
-        ]);
-    my $calidA = $res->[0][1]{created}{"1"}{id};
-    my $calidB = $res->[0][1]{created}{"2"}{id};
-    my $state = $res->[0][1]{newState};
+        ['Calendar/set', {
+            create => {
+                calendarA => {
+                    name => "A",
+                },
+                calendarB => {
+                    name => "B",
+                }
+            }
+        }, "R1"]
+    ]);
+    my $calendarIdA = $res->[0][1]{created}{calendarA}{id};
+    $self->assert_not_null($calendarIdA);
+    my $calendarIdB = $res->[0][1]{created}{calendarB}{id};
+    $self->assert_not_null($calendarIdB);
 
-    xlog $self, "create event #1 in calendar $calidA and event #2 in calendar $calidB";
-    $res = $jmap->CallMethods([['CalendarEvent/set', {
-                    create => {
-                        "1" => {
-                            calendarIds => {
-                                $calidA => JSON::true,
-                            },
-                            "title" => "foo",
-                            "description" => "bar",
-                            "freeBusyStatus" => "busy",
-                            "showWithoutTime" => JSON::false,
-                            "start" => "2016-07-01T10:00:00",
-                            "timeZone" => "Europe/Vienna",
-                            "duration" => "PT1H",
-                        },
-                        "2" => {
-                            calendarIds => {
-                                $calidB => JSON::true,
-                            },
-                            "title" => "foo",
-                            "description" => "",
-                            "freeBusyStatus" => "busy",
-                            "showWithoutTime" => JSON::true,
-                            "start" => "2016-01-01T00:00:00",
-                            "duration" => "P2D",
-                            "timeZone" => undef,
-                        }
-                    }}, "R1"]]);
-    my $id1 = $res->[0][1]{created}{"1"}{id};
-    my $id2 = $res->[0][1]{created}{"2"}{id};
+    my %eventA1 = (
+        uid => 'a1-03df209b28-4005-a458-751e2f6058b5'
+    );
+    my %eventA2 = (
+        uid => 'a2-73e05c2f12fa-43c4-a17f-9c6e35ddd8'
+    );
+    my %eventB1 = (
+        uid => 'b1-8528b44b7cdd-4867-85f0-09746080d9'
+    );
+
+    xlog $self, "create events";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                eventA1 => {
+                    calendarIds => {
+                        $calendarIdA => JSON::true,
+                    },
+                    uid => $eventA1{uid},
+                    title => 'eventA1',
+                    description => 'test',
+                    start => '2023-01-01T01:00:00',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                },
+                eventB1 => {
+                    calendarIds => {
+                        $calendarIdB => JSON::true,
+                    },
+                    uid => $eventB1{uid},
+                    title => 'eventB1',
+                    description => 'test',
+                    start => '2023-02-01T01:00:00',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                },
+                eventA2 => {
+                    calendarIds => {
+                        $calendarIdA => JSON::true,
+                    },
+                    uid => $eventA2{uid},
+                    title => 'eventA2',
+                    description => 'test',
+                    start => '2023-03-01T01:00:00',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                },
+            }
+        }, 'R1']
+    ]);
+
+    $eventA1{id} = $res->[0][1]{created}{eventA1}{id};
+    $self->assert_not_null($eventA1{id});
+    $eventA2{id} = $res->[0][1]{created}{eventA2}{id};
+    $self->assert_not_null($eventA2{id});
+    $eventB1{id} = $res->[0][1]{created}{eventB1}{id};
+    $self->assert_not_null($eventB1{id});
 
     xlog $self, "Run squatter";
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
 
-    xlog $self, "get unfiltered calendar event list";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', { }, "R1"] ]);
-    $self->assert_num_equals(2, $res->[0][1]{total});
-    $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
+    my @testCases = ({
+        filter => undef,
+        wantIds => [$eventA1{id}, $eventA2{id}, $eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            before => '2023-03-01T01:00:00',
+        },
+        wantIds => [$eventA1{id}, $eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            after => '2023-01-01T02:00:00',
+        },
+        wantIds => [$eventA2{id}, $eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            after =>  '2023-01-01T02:00:00',
+            before => '2023-03-01T01:00:00',
+        },
+        wantIds => [$eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            operator => 'AND',
+            conditions => [{
+                after =>  '2023-01-01T02:00:00',
+            }, {
+                before => '2023-03-01T01:00:00',
+            }],
+        },
+        wantIds => [$eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            operator => 'NOT',
+            conditions => [{
+                after => '2023-01-01T02:00:00',
+            }],
+        },
+        wantIds => [$eventA1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            uid => $eventA2{uid},
+        },
+        wantIds => [$eventA2{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            operator => 'NOT',
+            conditions => [{
+                uid => $eventA2{uid},
+            }],
+        },
+        wantIds => [$eventA1{id}, $eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            operator => 'OR',
+            conditions => [{
+                uid => $eventA1{uid},
+            }, {
+                uid => $eventB1{uid},
+            }],
+        },
+        wantIds => [$eventA1{id}, $eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            inCalendars => [$calendarIdA, $calendarIdB],
+        },
+        wantIds => [$eventA1{id}, $eventA2{id}, $eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            operator => 'NOT',
+            conditions => [{
+                inCalendars => [$calendarIdA],
+            }],
+        },
+        wantIds => [$eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            operator => 'OR',
+            conditions => [{
+                inCalendars => [$calendarIdA, $calendarIdB],
+            }],
+        },
+        wantIds => [$eventA1{id}, $eventA2{id}, $eventB1{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => {
+            operator => 'AND',
+            conditions => [{
+                inCalendars => [$calendarIdA],
+            }, {
+                text => 'test',
+            }],
+        },
+        wantIds => [$eventA1{id}, $eventA2{id}],
+        wantFastPath => JSON::false,
+    }, {
+        filter => undef,
+        position => 1,
+        limit => 1,
+        wantTotal => 3,
+        wantIds => [$eventA2{id}],
+        wantFastPath => JSON::true,
+    }, {
+        filter => undef,
+        position => -1,
+        wantTotal => 3,
+        wantIds => [$eventB1{id}],
+        wantFastPath => JSON::false,
+    });
 
-    xlog $self, "get filtered calendar event list with flat filter";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', {
-                    "filter" => {
-                        "after" => "2015-12-31T00:00:00",
-                        "before" => "2016-12-31T23:59:59",
-                        "text" => "foo",
-                        "description" => "bar"
-                    }
-                }, "R1"] ]);
-    $self->assert_num_equals(1, $res->[0][1]{total});
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($id1, $res->[0][1]{ids}[0]);
+    for my $tc (@testCases) {
+        my $q = {
+            filter => $tc->{filter},
+            sort => [{
+                property => 'uid',
+            }],
+        };
 
-    xlog $self, "get filtered calendar event list";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', {
-                    "filter" => {
-                        "operator" => "AND",
-                        "conditions" => [
-                            {
-                                "after" => "2015-12-31T00:00:00",
-                                "before" => "2016-12-31T23:59:59"
-                            },
-                            {
-                                "text" => "foo",
-                                "description" => "bar"
-                            }
-                        ]
-                    }
-                }, "R1"] ]);
-    $self->assert_num_equals(1, $res->[0][1]{total});
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($id1, $res->[0][1]{ids}[0]);
+        if (defined $tc->{position}) {
+            $q->{position} = $tc->{position};
+        }
 
-    xlog $self, "filter by calendar $calidA";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', {
-                    "filter" => {
-                        "inCalendars" => [ $calidA ],
-                    }
-                }, "R1"] ]);
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($id1, $res->[0][1]{ids}[0]);
+        if (defined $tc->{limit}) {
+            $q->{limit} = $tc->{limit};
+        }
 
-    xlog $self, "filter by calendar $calidA or $calidB";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', {
-                    "filter" => {
-                        "inCalendars" => [ $calidA, $calidB ],
-                    }
-                }, "R1"] ]);
-    $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
+        $res = $jmap->CallMethods([
+            ['CalendarEvent/query', $q, 'R1'],
+        ]);
+        my $wantTotal = defined $tc->{wantTotal} ?
+            $tc->{wantTotal} : scalar @{$tc->{wantIds}};
+        $self->assert_num_equals($wantTotal, $res->[0][1]{total});
+        $self->assert_deep_equals($tc->{wantIds}, $res->[0][1]{ids});
 
-    xlog $self, "filter by calendar NOT in $calidA and $calidB";
-    $res = $jmap->CallMethods([['CalendarEvent/query', {
-                    "filter" => {
-                        "operator" => "NOT",
-                        "conditions" => [{
-                                "inCalendars" => [ $calidA, $calidB ],
-                            }],
-                    }}, "R1"]]);
-    $self->assert_num_equals(0, scalar @{$res->[0][1]{ids}});
-
-    xlog $self, "limit results";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', { limit => 1 }, "R1"] ]);
-    $self->assert_num_equals(2, $res->[0][1]{total});
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
-
-    xlog $self, "skip result a position 1";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', { position => 1 }, "R1"] ]);
-    $self->assert_num_equals(2, $res->[0][1]{total});
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
-
-    xlog $self, "set negative position";
-    $res = $jmap->CallMethods([ ['CalendarEvent/query', { position => -1 }, "R1"] ]);
-    $self->assert_num_equals(2, $res->[0][1]{total});
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
+        if ($maj > 3 || ($maj == 3 && $min > 8)) {
+            $self->assert_equals($tc->{wantFastPath},
+                $res->[0][1]{debug}{isFastPath});
+        }
+    }
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unsupported
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unsupported
@@ -1,0 +1,39 @@
+#!perl
+use Cassandane::Tiny;
+use Data::UUID;
+
+sub test_calendarevent_query_unsupported
+    :min_version_3_9 :needs_component_jmap
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+    my $uuidgen = Data::UUID->new;
+
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $filter = {
+        operator => 'OR',
+        conditions => []
+    };
+
+    # evoke a sqlite error for too complex expression trees.
+    # this filter is non-
+    for (1 .. 1001) { # this is the internal sqlite3 limit
+        push(@{$filter->{conditions}}, {
+            uid => $uuidgen->create_str,
+            after => '2023-03-04T14:00:00',
+        });
+    }
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/query', {
+            filter => $filter
+        }, 'R1'],
+    ]);
+    $self->assert_str_equals("unsupportedFilter", $res->[0][1]{type});
+
+    $self->{instance}->getsyslog(); # ignore seen.db DBERROR
+}

--- a/imap/caldav_db.h
+++ b/imap/caldav_db.h
@@ -222,6 +222,9 @@ struct caldav_jscal_filter {
     uint32_t imap_uid;
     const time_t *after;
     const time_t *before;
+};
+
+struct caldav_jscal_window {
     modseq_t aftermodseq;
     int tombstones;
     size_t maxcount;
@@ -232,6 +235,7 @@ typedef int caldav_jscal_cb_t(void *rock, struct caldav_jscal *jscal);
 int caldav_foreach_jscal(struct caldav_db *caldavdb,
                          const char *cache_userid,
                          struct caldav_jscal_filter *filter,
+                         struct caldav_jscal_window *window,
                          enum caldav_sort* sort, size_t nsort,
                          caldav_jscal_cb_t *cb, void *rock);
 

--- a/imap/caldav_db.h
+++ b/imap/caldav_db.h
@@ -215,14 +215,28 @@ struct caldav_jscal {
     const char *cachedata;
 };
 
-struct caldav_jscal_filter {
-    const mbentry_t *mbentry;
-    const char *ical_uid;
-    const char *ical_recurid;
-    uint32_t imap_uid;
-    const time_t *after;
-    const time_t *before;
+enum caldav_jscal_filterop {
+    CALDAV_JSCAL_NOOP = 0,
+    CALDAV_JSCAL_AND,
+    CALDAV_JSCAL_OR,
+    CALDAV_JSCAL_NOT,
+    CALDAV_JSCAL_FALSE // never matches
 };
+
+struct caldav_jscal_filter {
+    ptrarray_t mbentries; // any of
+    char *ical_uid;
+    char *ical_recurid;
+    uint32_t imap_uid;
+    time_t *after;
+    time_t *before;
+
+    enum caldav_jscal_filterop op;
+    ptrarray_t subfilters;
+};
+
+// Frees heap-allocated fields, including subfilters
+void caldav_jscal_filter_fini(struct caldav_jscal_filter *);
 
 struct caldav_jscal_window {
     modseq_t aftermodseq;

--- a/imap/caldav_db.h
+++ b/imap/caldav_db.h
@@ -52,6 +52,7 @@ extern time_t caldav_eternity;
 #include <libical/ical.h>
 
 #include "dav_db.h"
+#include "dynarray.h"
 #include "ical_support.h"
 #include "mboxlist.h"
 
@@ -223,20 +224,54 @@ enum caldav_jscal_filterop {
     CALDAV_JSCAL_FALSE // never matches
 };
 
-struct caldav_jscal_filter {
-    ptrarray_t mbentries; // any of
+struct caldav_jscal_id {
     char *ical_uid;
     char *ical_recurid;
+};
+
+struct caldav_jscal_filter {
+    ptrarray_t mbentries; // any of
+    dynarray_t jscal_ids; // any of
     uint32_t imap_uid;
-    time_t *after;
-    time_t *before;
+    time_t after;
+    time_t before;
 
     enum caldav_jscal_filterop op;
     ptrarray_t subfilters;
+
+    int _have_after : 1;
+    int _have_before: 1;
 };
 
-// Frees heap-allocated fields, including subfilters
-void caldav_jscal_filter_fini(struct caldav_jscal_filter *);
+#define CALDAV_JSCAL_FILTER_INITIALIZER { \
+    .mbentries = PTRARRAY_INITIALIZER, \
+    .jscal_ids = { .membsize =  sizeof(struct caldav_jscal_id)}, \
+    .subfilters = PTRARRAY_INITIALIZER \
+}
+
+extern struct caldav_jscal_filter *caldav_jscal_filter_new(void);
+
+extern void caldav_jscal_filter_by_ical_uid(struct caldav_jscal_filter*,
+	const char *ical_uid, const char *ical_recurid);
+
+extern void caldav_jscal_filter_by_mbentry(struct caldav_jscal_filter*,
+	const mbentry_t *mbentry);
+
+extern void caldav_jscal_filter_by_mbentrym(struct caldav_jscal_filter*,
+	mbentry_t *mbentry);
+
+extern void caldav_jscal_filter_by_imap_uid(struct caldav_jscal_filter*,
+	uint32_t imap_uid);
+
+extern void caldav_jscal_filter_by_before(struct caldav_jscal_filter*,
+	const time_t *before);
+
+extern void caldav_jscal_filter_by_after(struct caldav_jscal_filter*,
+	const time_t *after);
+
+extern void caldav_jscal_filter_fini(struct caldav_jscal_filter *);
+
+extern void caldav_jscal_filter_free(struct caldav_jscal_filter **);
 
 struct caldav_jscal_window {
     modseq_t aftermodseq;

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -934,7 +934,7 @@ static int jmap_blob_lookup(jmap_req_t *req)
                     };
                     struct caleventid_rock rock = { &buf, ids };
                     caldav_foreach_jscal(caldav_db, req->accountid, &filter,
-                            NULL, 0, caleventid_cb, &rock);
+                            NULL, NULL, 0, caleventid_cb, &rock);
                     buf_reset(&buf);
                     break;
                     }

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -929,12 +929,14 @@ static int jmap_blob_lookup(jmap_req_t *req)
 
                 case DATATYPE_CALENDAREVENT: {
                     struct caldav_jscal_filter filter = {
-                        .mbentry = mbentry,
                         .imap_uid = getblob->uid,
                     };
+                    ptrarray_push(&filter.mbentries,
+                            mboxlist_entry_copy(mbentry));
                     struct caleventid_rock rock = { &buf, ids };
                     caldav_foreach_jscal(caldav_db, req->accountid, &filter,
                             NULL, NULL, 0, caleventid_cb, &rock);
+                    caldav_jscal_filter_fini(&filter);
                     buf_reset(&buf);
                     break;
                     }

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -928,15 +928,14 @@ static int jmap_blob_lookup(jmap_req_t *req)
                     break;
 
                 case DATATYPE_CALENDAREVENT: {
-                    struct caldav_jscal_filter filter = {
-                        .imap_uid = getblob->uid,
-                    };
-                    ptrarray_push(&filter.mbentries,
-                            mboxlist_entry_copy(mbentry));
+                    struct caldav_jscal_filter jscal_filter =
+                        CALDAV_JSCAL_FILTER_INITIALIZER;
+                    caldav_jscal_filter_by_imap_uid(&jscal_filter, getblob->uid);
+                    caldav_jscal_filter_by_mbentry(&jscal_filter, mbentry);
                     struct caleventid_rock rock = { &buf, ids };
-                    caldav_foreach_jscal(caldav_db, req->accountid, &filter,
+                    caldav_foreach_jscal(caldav_db, req->accountid, &jscal_filter,
                             NULL, NULL, 0, caleventid_cb, &rock);
-                    caldav_jscal_filter_fini(&filter);
+                    caldav_jscal_filter_fini(&jscal_filter);
                     buf_reset(&buf);
                     break;
                     }

--- a/lib/sqldb.h
+++ b/lib/sqldb.h
@@ -52,7 +52,7 @@
 struct sqldb_bindval {
     const char *name;
     int type;
-    union {
+    union sqldb_sqlval {
         sqlite3_int64 i;
         const char *s;
         struct buf b;

--- a/lib/sqldb.h
+++ b/lib/sqldb.h
@@ -89,6 +89,11 @@ int sqldb_done(void);
 
 #define SQLDB_DEFAULT_TIMEOUT  20000 /* 20 seconds is an eternity */
 
+#define SQLDB_DONE         1
+#define SQLDB_OK           0
+#define SQLDB_ERR_UNKNOWN -1
+#define SQLDB_ERR_LIMIT   -2
+
 sqldb_t *sqldb_open(const char *fname, const char *initsql,
                    int version, const struct sqldb_upgrade *upgradesql,
                    int timeout_ms);


### PR DESCRIPTION
CalendarEvent/query filters using any of the AND/OR/NOT operators were not supported using dav.db. This now supports such queries, allowing both for faster lookup and for previously unsupported queries such as OR(uid1,uid2,uid2).