### PR TITLE
http_caldav: do not crash calendar home GET if calendaradmin is set

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -5856,4 +5856,18 @@ sub test_conditional_delete_collection
     $self->assert_str_equals('204', $res->{status});
 }
 
+sub test_calendaradmin_get
+    :min_version_3_8 :needs_component_httpd :AllowCalendarAdmin
+{
+    my ($self) = @_;
+    my $caldav = $self->{caldav};
+
+    my $res = $caldav->ua->request('GET', $caldav->request_url(""), {
+        headers => {
+            'Authorization' => $caldav->auth_header(),
+        }
+    });
+    $self->assert_str_equals('200', $res->{status});
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -445,6 +445,10 @@ magic(ArchiveNow => sub {
     $conf->config_set('archive_enabled' => 'yes');
     $conf->config_set('archive_after' => '0d');
 });
+magic(AllowCalendarAdmin => sub {
+    my $conf = shift;
+    $conf->config_set('caldav_allowcalendaradmin' => 'yes');
+});
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2271,7 +2271,7 @@ static int list_calendars(struct transaction_t *txn)
 
     memset(&lrock, 0, sizeof(struct list_cal_rock));
     lrock.scheddefault = caldav_scheddefault(httpd_userid, 0);
-    lrock.defaultlen = strlen(lrock.scheddefault);
+    lrock.defaultlen = lrock.scheddefault ? strlen(lrock.scheddefault) : 0;
     mboxlist_mboxtree(txn->req_tgt.mbentry->name,
                       list_cal_cb, &lrock, MBOXTREE_SKIP_ROOT);
     free(lrock.scheddefault);


### PR DESCRIPTION
Fixes #4523

Thanks to @sdalu