### PR TITLE
JSON Web Token: support `nbf` and `exp` claims

### DIFF
--- a/changes/next/http_jwt_timeclaims
+++ b/changes/next/http_jwt_timeclaims
@@ -1,0 +1,18 @@
+Description:
+
+Adds support for the "exp" and "nbf" to JSON Web Token claims. Thanks to Bruno Thomas (bamthomas).
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/pull/4515

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -174,22 +174,13 @@ static void test_validate(void)
     struct buf tok = BUF_INITIALIZER;
     char out[256];
 
-    // valid token
+    // invalid token missing iat/exp
     token(&tok,
         "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
         "{\"sub\":\"test\"}", pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, sizeof(out));
-    CU_ASSERT_EQUAL(SASL_OK, r);
-    CU_ASSERT_STRING_EQUAL("test", out);
-
-    // valid token: ignored iat
-    token(&tok,
-        "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
-        "{\"sub\": \"test\", \"iat\":1516239022}",
-        pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_OK, r);
-    CU_ASSERT_STRING_EQUAL("test", out);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
 
     // invalid token: no signature
     token(&tok,
@@ -254,15 +245,6 @@ static void test_validate(void)
     CU_ASSERT_EQUAL(SASL_BADAUTH, r);
     CU_ASSERT_STRING_EQUAL("", out);
 
-    // invalid token: bad iat
-    token(&tok,
-        "{\"alg\": \"HS256\", \"typ\": \"XXX\"}",
-        "{\"sub\": \"test\", \"iat\":\"1516239022\"}",
-        pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
-
     // invalid token: bad JWS
     token(&tok,
         "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
@@ -299,6 +281,184 @@ static void test_validate(void)
     http_jwt_reset();
 }
 
+static void test_validate_claims_no_max_age(void)
+{
+    char dname[] = "/tmp/cyrus-cunit-XXXXXX";
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(dname));
+
+    char *fname = strconcat(dname, "/key.pem", NULL);
+    FILE *fp = fopen(fname, "w");
+    CU_ASSERT_PTR_NOT_NULL(fp);
+    fputs(HMAC_PEM, fp);
+    fclose(fp);
+
+    int r = http_jwt_init(dname, 0);
+    CU_ASSERT_EQUAL(0, r);
+    CU_ASSERT_NOT_EQUAL(0, http_jwt_is_enabled());
+
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, NULL,
+                    (unsigned char*)HMAC_KEY_RAW, strlen(HMAC_KEY_RAW));
+
+    struct buf tok = BUF_INITIALIZER;
+    char out[256];
+
+    time_t now = time(NULL);
+
+    // valid token: exp = now + 2s
+    int length = snprintf( NULL, 0, "%ld", now );
+    char p2[] = "{\"sub\": \"test\", \"exp\":%ld}";
+    char payloadTwoFields[strlen(p2) + length];
+    sprintf(payloadTwoFields, p2, now + 2);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadTwoFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
+
+    // valid token: exp OK iat not used and custom fields
+    char p5[] = "{\"sub\": \"test\", \"exp\":%ld, \"iat\": %ld, \"foo\": \"bar\", \"baz\": \"qux\"}";
+    char payloadFiveFields[strlen(p5) + 2 * length];
+    sprintf(payloadFiveFields, p5, now + 2, now);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadFiveFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
+
+    // valid token: exp and nbf OK
+    char p3[] = "{\"sub\": \"test\", \"exp\":%ld, \"nbf\": %ld}";
+    char payloadThreeFields[strlen(p3) + 2 * length];
+    sprintf(payloadThreeFields, p3, now + 2, now);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadThreeFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
+
+    // invalid token: bad iat
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+          "{\"sub\": \"test\", \"iat\":\"1516239022\"}",
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    // invalid token: outdated exp
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+          "{\"sub\": \"test\", \"exp\":\"1516239022\"}",
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    // invalid token: exp OK but nbf is in the future
+    sprintf(payloadThreeFields, p3, now + 2, now + 2);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadThreeFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    // invalid token no exp and no iat but nb claims >=2
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+          "{\"sub\": \"test\", \"foo\":\"bar\"}",
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    // invalid token iat without max_age
+    sprintf(payloadTwoFields, "{\"sub\": \"test\", \"iat\":%ld}", now);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadTwoFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    // invalid token more than MAX_JWT_PAYLOAD_FIELD_NB
+    char p6[] = "{\"sub\": \"test\", \"exp\":%ld, \"iat\": %ld, \"foo\": \"bar\", \"baz\": \"qux\", \"thud\": \"fred\"}";
+    char payloadSixFields[strlen(p6) + 2 * length];
+    sprintf(payloadSixFields, p6, now + 2, now);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadSixFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    buf_free(&tok);
+
+    EVP_PKEY_free(pkey);
+    xunlink(fname);
+    free(fname);
+    rmdir(dname);
+    http_jwt_reset();
+}
+
+static void test_validate_claims_with_max_age(void)
+{
+    char dname[] = "/tmp/cyrus-cunit-XXXXXX";
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(dname));
+
+    char *fname = strconcat(dname, "/key.pem", NULL);
+    FILE *fp = fopen(fname, "w");
+    CU_ASSERT_PTR_NOT_NULL(fp);
+    fputs(HMAC_PEM, fp);
+    fclose(fp);
+
+    int r = http_jwt_init(dname, 60);
+    CU_ASSERT_EQUAL(0, r);
+    CU_ASSERT_NOT_EQUAL(0, http_jwt_is_enabled());
+
+    EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, NULL,
+                      (unsigned char*)HMAC_KEY_RAW, strlen(HMAC_KEY_RAW));
+
+    struct buf tok = BUF_INITIALIZER;
+    char out[256];
+
+    // valid token with iat/max_age
+    time_t now = time(NULL);
+    long nowMinusTwoSecs = now - 2;
+    char p2[] = "{\"sub\": \"test\", \"iat\":%ld}";
+    int length = snprintf( NULL, 0, "%ld", nowMinusTwoSecs );
+    char payloadTwoFields[strlen(p2) + length];
+    sprintf(payloadTwoFields, p2, nowMinusTwoSecs);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadTwoFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
+
+    // valid token with outdated iat/max_age
+    // and valid exp : precedence for exp
+    char p3[] = "{\"sub\": \"test\", \"iat\":\"1516239022\", \"exp\":%ld}";
+    char payloadThreeFields[strlen(p3) + length];
+    sprintf(payloadThreeFields, p3, now + 2);
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadThreeFields,
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
+
+    buf_free(&tok);
+
+    EVP_PKEY_free(pkey);
+    xunlink(fname);
+    free(fname);
+    rmdir(dname);
+    http_jwt_reset();
+}
+
 static void test_auth(void)
 {
     char dname[] = "/tmp/cyrus-cunit-XXXXXX";
@@ -323,18 +483,18 @@ static void test_auth(void)
     CU_ASSERT_EQUAL(0, r);
     CU_ASSERT_EQUAL(1, http_jwt_is_enabled());
 
-#define TESTCASE(alg, pkey, emd) \
+#define TESTCASE(alg, pkey, emd, payload) \
     { \
         struct buf tok = BUF_INITIALIZER; \
         char out[256]; \
         token(&tok, \
                 "{\"alg\":\"" alg "\",\"typ\":\"JWT\"}", \
-                "{\"sub\":\"test\"}", pkey, emd); \
+                payload, pkey, emd); \
         r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, sizeof(out)); \
         CU_ASSERT_EQUAL(SASL_OK, r); \
         CU_ASSERT_STRING_EQUAL("test", out); \
         char c = buf_base(&tok)[buf_len(&tok)-1]; \
-        c = c == 'A' ? 'B' : 'A'; \
+        c = c == 'A' ? '/' : 'A'; \
         buf_truncate(&tok, -1); \
         buf_putc(&tok, c); \
         r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, sizeof(out)); \
@@ -342,21 +502,26 @@ static void test_auth(void)
         CU_ASSERT_STRING_EQUAL("", out); \
         buf_free(&tok); \
     }
+    time_t nowPlusOneHour = time(NULL) + 3600;
+    int length = snprintf( NULL, 0, "%ld", nowPlusOneHour );
+    char p[] = "{\"sub\": \"test\", \"exp\":%ld}";
+    char payload[strlen(p) + length];
+    sprintf(payload, p, nowPlusOneHour);
 
     EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, NULL,
             (unsigned char*)HMAC_KEY_RAW, strlen(HMAC_KEY_RAW));
-    TESTCASE("HS256", pkey, EVP_sha256());
-    TESTCASE("HS384", pkey, EVP_sha384());
-    TESTCASE("HS512", pkey, EVP_sha512());
+    TESTCASE("HS256", pkey, EVP_sha256(), payload);
+    TESTCASE("HS384", pkey, EVP_sha384(), payload);
+    TESTCASE("HS512", pkey, EVP_sha512(), payload);
     EVP_PKEY_free(pkey);
 
     BIO *bp = BIO_new_mem_buf(RSA_PRIVATE_KEY_PEM, -1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(bp);
     pkey = PEM_read_bio_PrivateKey(bp, NULL, NULL, NULL);
     CU_ASSERT_PTR_NOT_NULL_FATAL(pkey);
-    TESTCASE("RS256", pkey, EVP_sha256());
-    TESTCASE("RS384", pkey, EVP_sha384());
-    TESTCASE("RS512", pkey, EVP_sha512());
+    TESTCASE("RS256", pkey, EVP_sha256(), payload);
+    TESTCASE("RS384", pkey, EVP_sha384(), payload);
+    TESTCASE("RS512", pkey, EVP_sha512(), payload);
     EVP_PKEY_free(pkey);
     BIO_free(bp);
 

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -191,6 +191,15 @@ static void test_validate(void)
     CU_ASSERT_EQUAL(SASL_OK, r);
     CU_ASSERT_STRING_EQUAL("test", out);
 
+    // valid token: ignore unknown claim
+    token(&tok,
+        "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+        "{\"sub\": \"test\", \"iss\":\"foo\"}",
+        pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
+
     // invalid token: no signature
     token(&tok,
         "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
@@ -267,15 +276,6 @@ static void test_validate(void)
     token(&tok,
         "{\"alg\": \"HS256\", \"typ\": \"JWT\", \"iss\":\"foo\"}",
         "{\"sub\": \"test\"}",
-        pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
-
-    // invalid token: unsupported claim
-    token(&tok,
-        "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
-        "{\"sub\": \"test\", \"iss\":\"foo\"}",
         pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_BADAUTH, r);

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "cunit/cyrunit.h"
 
+#include <jansson.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
@@ -317,6 +318,23 @@ static void test_validate(void)
     http_jwt_reset();
 }
 
+#define TEST_TIMECLAIMS(nbf, exp, iat, want_r) \
+    { \
+        json_t *jws = json_pack("{s:s}", "sub", "test"); \
+        if (nbf) json_object_set_new(jws, "nbf", json_integer(nbf)); \
+        if (exp) json_object_set_new(jws, "exp", json_integer(exp)); \
+        if (iat) json_object_set_new(jws, "iat", json_integer(iat)); \
+        char *s = json_dumps(jws, JSON_COMPACT); \
+        token(&tok, \
+            "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", s, pkey, EVP_sha256()); \
+        r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256); \
+        CU_ASSERT_EQUAL((want_r), r); \
+        CU_ASSERT_STRING_EQUAL((want_r == SASL_OK) ? "test" : "", out); \
+        free(s); \
+        json_decref(jws); \
+    }
+
+
 static void test_validate_claims_no_max_age(void)
 {
     char dname[] = "/tmp/cyrus-cunit-XXXXXX";
@@ -337,69 +355,31 @@ static void test_validate_claims_no_max_age(void)
 
     struct buf tok = BUF_INITIALIZER;
     char out[256];
-
     time_t now = time(NULL);
 
+    // valid token: no time claim set
+    TEST_TIMECLAIMS(0, 0, 0, SASL_OK);
+
+    // valid token: iat = now
+    TEST_TIMECLAIMS(0, 0, now, SASL_OK);
+
+    // valid token: iat < now
+    TEST_TIMECLAIMS(0, 0, now - 2, SASL_OK);
+
+    // valid token: iat > now ignored (no max_age)
+    TEST_TIMECLAIMS(0, 0, now + 2, SASL_OK);
+
     // valid token: exp = now + 2s
-    int length = snprintf( NULL, 0, "%ld", now );
-    char p2[] = "{\"sub\": \"test\", \"exp\":%ld}";
-    char payload_two_fields[strlen(p2) + length];
-    sprintf(payload_two_fields, p2, now + 2);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_two_fields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_OK, r);
-    CU_ASSERT_STRING_EQUAL("test", out);
+    TEST_TIMECLAIMS(0, now + 2, 0, SASL_OK);
 
-    // valid token: exp OK iat not used and custom fields
-    char p5[] = "{\"sub\": \"test\", \"exp\":%ld, \"iat\": %ld, \"foo\": \"bar\", \"baz\": \"qux\"}";
-    char payload_five_fields[strlen(p5) + 2 * length];
-    sprintf(payload_five_fields, p5, now + 2, now);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_five_fields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_OK, r);
-    CU_ASSERT_STRING_EQUAL("test", out);
+    // valid token: exp = now + 2s, nbf = now
+    TEST_TIMECLAIMS(now, now + 2, 0, SASL_OK);
 
-    // valid token: exp and nbf OK
-    char p3[] = "{\"sub\": \"test\", \"exp\":%ld, \"nbf\": %ld}";
-    char payload_three_fields[strlen(p3) + 2 * length];
-    sprintf(payload_three_fields, p3, now + 2, now);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_three_fields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_OK, r);
-    CU_ASSERT_STRING_EQUAL("test", out);
+    // invalid token: exp = now
+    TEST_TIMECLAIMS(0, now, 0, SASL_BADAUTH);
 
-    // invalid token: bad iat
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
-          "{\"sub\": \"test\", \"iat\":\"1516239022\"}",
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
-
-    // invalid token: outdated exp
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
-          "{\"sub\": \"test\", \"exp\":1516239022}",
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
-
-    // invalid token: exp OK but nbf is in the future
-    sprintf(payload_three_fields, p3, now + 2, now + 2);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_three_fields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
+    // invalid token: nbf > now
+    TEST_TIMECLAIMS(now + 2, now + 2, 0, SASL_BADAUTH);
 
     buf_free(&tok);
 
@@ -421,7 +401,9 @@ static void test_validate_claims_with_max_age(void)
     fputs(HMAC_PEM, fp);
     fclose(fp);
 
-    int r = http_jwt_init(dname, 60);
+    int max_age = 60;
+
+    int r = http_jwt_init(dname, max_age);
     CU_ASSERT_EQUAL(0, r);
     CU_ASSERT_NOT_EQUAL(0, http_jwt_is_enabled());
 
@@ -430,40 +412,28 @@ static void test_validate_claims_with_max_age(void)
 
     struct buf tok = BUF_INITIALIZER;
     char out[256];
-
-    // valid token with iat/max_age
     time_t now = time(NULL);
-    long now_minus_two_secs = now - 2;
-    char p2[] = "{\"sub\": \"test\", \"iat\":%ld}";
-    int length = snprintf( NULL, 0, "%ld", now_minus_two_secs );
-    char payload_two_fields[strlen(p2) + length];
-    sprintf(payload_two_fields, p2, now_minus_two_secs);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_two_fields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_OK, r);
-    CU_ASSERT_STRING_EQUAL("test", out);
 
-    // valid token with outdated iat/max_age
-    // and valid exp : precedence for exp
-    char p3[] = "{\"sub\": \"test\", \"iat\":1516239022, \"exp\":%ld}";
-    char payload_three_fields[strlen(p3) + length];
-    sprintf(payload_three_fields, p3, now + 2);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_three_fields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_OK, r);
-    CU_ASSERT_STRING_EQUAL("test", out);
+    // invalid token: no iat set, but max_age configured
+    TEST_TIMECLAIMS(0, 0, 0, SASL_BADAUTH);
 
-    // invalid token max_age without iat
-    token(&tok,
-          "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
-          "{\"sub\":\"test\"}", pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, sizeof(out));
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
+    // valid token: iat + max_age > now
+    TEST_TIMECLAIMS(0, 0, now - 2, SASL_OK);
+
+    // invalid token: iat + max_age <= now
+    TEST_TIMECLAIMS(0, 0, now - max_age, SASL_BADAUTH);
+
+    // invalid token: iat > now
+    TEST_TIMECLAIMS(0, 0, now + 2, SASL_BADAUTH);
+
+    // valid token: exp > now
+    TEST_TIMECLAIMS(0, now + 2, 0, SASL_OK);
+
+    // valid token: exp > now, even if iat+max_age expired
+    TEST_TIMECLAIMS(0, now + 2, now - max_age, SASL_OK);
+
+    // invalid token: exp == now, at+max_age expired
+    TEST_TIMECLAIMS(0, now, now - max_age, SASL_BADAUTH);
 
     buf_free(&tok);
 
@@ -473,6 +443,8 @@ static void test_validate_claims_with_max_age(void)
     rmdir(dname);
     http_jwt_reset();
 }
+
+#undef TEST_TIMECLAIMS
 
 static void test_auth(void)
 {

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -174,13 +174,22 @@ static void test_validate(void)
     struct buf tok = BUF_INITIALIZER;
     char out[256];
 
-    // invalid token missing iat/exp
+    // valid token
     token(&tok,
-        "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
-        "{\"sub\":\"test\"}", pkey, EVP_sha256());
+          "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
+          "{\"sub\":\"test\"}", pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, sizeof(out));
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
+
+    // valid token: ignored iat
+    token(&tok,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+          "{\"sub\": \"test\", \"iat\":1516239022}",
+          pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_OK, r);
+    CU_ASSERT_STRING_EQUAL("test", out);
 
     // invalid token: no signature
     token(&tok,
@@ -307,10 +316,10 @@ static void test_validate_claims_no_max_age(void)
     // valid token: exp = now + 2s
     int length = snprintf( NULL, 0, "%ld", now );
     char p2[] = "{\"sub\": \"test\", \"exp\":%ld}";
-    char payloadTwoFields[strlen(p2) + length];
-    sprintf(payloadTwoFields, p2, now + 2);
+    char payload_two_fields[strlen(p2) + length];
+    sprintf(payload_two_fields, p2, now + 2);
     token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadTwoFields,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_two_fields,
           pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_OK, r);
@@ -318,10 +327,10 @@ static void test_validate_claims_no_max_age(void)
 
     // valid token: exp OK iat not used and custom fields
     char p5[] = "{\"sub\": \"test\", \"exp\":%ld, \"iat\": %ld, \"foo\": \"bar\", \"baz\": \"qux\"}";
-    char payloadFiveFields[strlen(p5) + 2 * length];
-    sprintf(payloadFiveFields, p5, now + 2, now);
+    char payload_five_fields[strlen(p5) + 2 * length];
+    sprintf(payload_five_fields, p5, now + 2, now);
     token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadFiveFields,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_five_fields,
           pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_OK, r);
@@ -329,10 +338,10 @@ static void test_validate_claims_no_max_age(void)
 
     // valid token: exp and nbf OK
     char p3[] = "{\"sub\": \"test\", \"exp\":%ld, \"nbf\": %ld}";
-    char payloadThreeFields[strlen(p3) + 2 * length];
-    sprintf(payloadThreeFields, p3, now + 2, now);
+    char payload_three_fields[strlen(p3) + 2 * length];
+    sprintf(payload_three_fields, p3, now + 2, now);
     token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadThreeFields,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_three_fields,
           pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_OK, r);
@@ -357,38 +366,9 @@ static void test_validate_claims_no_max_age(void)
     CU_ASSERT_STRING_EQUAL("", out);
 
     // invalid token: exp OK but nbf is in the future
-    sprintf(payloadThreeFields, p3, now + 2, now + 2);
+    sprintf(payload_three_fields, p3, now + 2, now + 2);
     token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadThreeFields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
-
-    // invalid token no exp and no iat but nb claims >=2
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
-          "{\"sub\": \"test\", \"foo\":\"bar\"}",
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
-
-    // invalid token iat without max_age
-    sprintf(payloadTwoFields, "{\"sub\": \"test\", \"iat\":%ld}", now);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadTwoFields,
-          pkey, EVP_sha256());
-    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
-    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
-    CU_ASSERT_STRING_EQUAL("", out);
-
-    // invalid token more than MAX_JWT_PAYLOAD_FIELD_NB
-    char p6[] = "{\"sub\": \"test\", \"exp\":%ld, \"iat\": %ld, \"foo\": \"bar\", \"baz\": \"qux\", \"thud\": \"fred\"}";
-    char payloadSixFields[strlen(p6) + 2 * length];
-    sprintf(payloadSixFields, p6, now + 2, now);
-    token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadSixFields,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_three_fields,
           pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_BADAUTH, r);
@@ -426,13 +406,13 @@ static void test_validate_claims_with_max_age(void)
 
     // valid token with iat/max_age
     time_t now = time(NULL);
-    long nowMinusTwoSecs = now - 2;
+    long now_minus_two_secs = now - 2;
     char p2[] = "{\"sub\": \"test\", \"iat\":%ld}";
-    int length = snprintf( NULL, 0, "%ld", nowMinusTwoSecs );
-    char payloadTwoFields[strlen(p2) + length];
-    sprintf(payloadTwoFields, p2, nowMinusTwoSecs);
+    int length = snprintf( NULL, 0, "%ld", now_minus_two_secs );
+    char payload_two_fields[strlen(p2) + length];
+    sprintf(payload_two_fields, p2, now_minus_two_secs);
     token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadTwoFields,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_two_fields,
           pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_OK, r);
@@ -441,14 +421,22 @@ static void test_validate_claims_with_max_age(void)
     // valid token with outdated iat/max_age
     // and valid exp : precedence for exp
     char p3[] = "{\"sub\": \"test\", \"iat\":\"1516239022\", \"exp\":%ld}";
-    char payloadThreeFields[strlen(p3) + length];
-    sprintf(payloadThreeFields, p3, now + 2);
+    char payload_three_fields[strlen(p3) + length];
+    sprintf(payload_three_fields, p3, now + 2);
     token(&tok,
-          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payloadThreeFields,
+          "{\"alg\": \"HS256\", \"typ\": \"JWT\"}", payload_three_fields,
           pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_OK, r);
     CU_ASSERT_STRING_EQUAL("test", out);
+
+    // invalid token max_age without iat
+    token(&tok,
+          "{\"alg\":\"HS256\",\"typ\":\"JWT\"}",
+          "{\"sub\":\"test\"}", pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, sizeof(out));
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
 
     buf_free(&tok);
 
@@ -483,13 +471,13 @@ static void test_auth(void)
     CU_ASSERT_EQUAL(0, r);
     CU_ASSERT_EQUAL(1, http_jwt_is_enabled());
 
-#define TESTCASE(alg, pkey, emd, payload) \
+#define TESTCASE(alg, pkey, emd) \
     { \
         struct buf tok = BUF_INITIALIZER; \
         char out[256]; \
         token(&tok, \
                 "{\"alg\":\"" alg "\",\"typ\":\"JWT\"}", \
-                payload, pkey, emd); \
+                "{\"sub\":\"test\"}", pkey, emd); \
         r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, sizeof(out)); \
         CU_ASSERT_EQUAL(SASL_OK, r); \
         CU_ASSERT_STRING_EQUAL("test", out); \
@@ -502,26 +490,21 @@ static void test_auth(void)
         CU_ASSERT_STRING_EQUAL("", out); \
         buf_free(&tok); \
     }
-    time_t nowPlusOneHour = time(NULL) + 3600;
-    int length = snprintf( NULL, 0, "%ld", nowPlusOneHour );
-    char p[] = "{\"sub\": \"test\", \"exp\":%ld}";
-    char payload[strlen(p) + length];
-    sprintf(payload, p, nowPlusOneHour);
 
     EVP_PKEY *pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_HMAC, NULL,
             (unsigned char*)HMAC_KEY_RAW, strlen(HMAC_KEY_RAW));
-    TESTCASE("HS256", pkey, EVP_sha256(), payload);
-    TESTCASE("HS384", pkey, EVP_sha384(), payload);
-    TESTCASE("HS512", pkey, EVP_sha512(), payload);
+    TESTCASE("HS256", pkey, EVP_sha256());
+    TESTCASE("HS384", pkey, EVP_sha384());
+    TESTCASE("HS512", pkey, EVP_sha512());
     EVP_PKEY_free(pkey);
 
     BIO *bp = BIO_new_mem_buf(RSA_PRIVATE_KEY_PEM, -1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(bp);
     pkey = PEM_read_bio_PrivateKey(bp, NULL, NULL, NULL);
     CU_ASSERT_PTR_NOT_NULL_FATAL(pkey);
-    TESTCASE("RS256", pkey, EVP_sha256(), payload);
-    TESTCASE("RS384", pkey, EVP_sha384(), payload);
-    TESTCASE("RS512", pkey, EVP_sha512(), payload);
+    TESTCASE("RS256", pkey, EVP_sha256());
+    TESTCASE("RS384", pkey, EVP_sha384());
+    TESTCASE("RS512", pkey, EVP_sha512());
     EVP_PKEY_free(pkey);
     BIO_free(bp);
 

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -281,6 +281,33 @@ static void test_validate(void)
     CU_ASSERT_EQUAL(SASL_BADAUTH, r);
     CU_ASSERT_STRING_EQUAL("", out);
 
+    // invalid token: non-number iat claim
+    token(&tok,
+        "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+        "{\"sub\": \"test\", \"iat\": \"xxx\"}",
+        pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    // invalid token: non-number nbf claim
+    token(&tok,
+        "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+        "{\"sub\": \"test\", \"nbf\": \"xxx\"}",
+        pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
+    // invalid token: non-number exp claim
+    token(&tok,
+        "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
+        "{\"sub\": \"test\", \"exp\": \"xxx\"}",
+        pkey, EVP_sha256());
+    r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
+    CU_ASSERT_EQUAL(SASL_BADAUTH, r);
+    CU_ASSERT_STRING_EQUAL("", out);
+
     buf_free(&tok);
 
     EVP_PKEY_free(pkey);
@@ -359,7 +386,7 @@ static void test_validate_claims_no_max_age(void)
     // invalid token: outdated exp
     token(&tok,
           "{\"alg\": \"HS256\", \"typ\": \"JWT\"}",
-          "{\"sub\": \"test\", \"exp\":\"1516239022\"}",
+          "{\"sub\": \"test\", \"exp\":1516239022}",
           pkey, EVP_sha256());
     r = http_jwt_auth(buf_base(&tok), buf_len(&tok), out, 256);
     CU_ASSERT_EQUAL(SASL_BADAUTH, r);
@@ -420,7 +447,7 @@ static void test_validate_claims_with_max_age(void)
 
     // valid token with outdated iat/max_age
     // and valid exp : precedence for exp
-    char p3[] = "{\"sub\": \"test\", \"iat\":\"1516239022\", \"exp\":%ld}";
+    char p3[] = "{\"sub\": \"test\", \"iat\":1516239022, \"exp\":%ld}";
     char payload_three_fields[strlen(p3) + length];
     sprintf(payload_three_fields, p3, now + 2);
     token(&tok,

--- a/imap/http_jwt.c
+++ b/imap/http_jwt.c
@@ -503,7 +503,7 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
         goto done;
     }
 
-    if (json_object_size(jws) == 2) {
+    if (json_object_size(jws) >= 2) {
         json_t *jiat = json_object_get(jws, "iat");
         if (!json_is_integer(jiat)) {
             if (jiat) {

--- a/imap/http_jwt.c
+++ b/imap/http_jwt.c
@@ -68,7 +68,6 @@
 static int is_enabled = 0;
 
 static ptrarray_t pkeys = PTRARRAY_INITIALIZER;
-static const size_t MAX_JWT_PAYLOAD_FIELD_NB = 5;
 
 static time_t max_age = 0;
 
@@ -493,7 +492,7 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
     int ret = 0;
 
     json_t *jws = json_loads(buf_cstring(&jwt->buf), JSON_REJECT_DUPLICATES, NULL);
-    if (!json_object_size(jws) || json_object_size(jws) > MAX_JWT_PAYLOAD_FIELD_NB) {
+    if (!json_object_size(jws)) {
         xsyslog(LOG_ERR, "Unexpected JWS payload structure", NULL);
         goto done;
     }
@@ -522,7 +521,8 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
                 xsyslog(LOG_ERR, "Out-of-range \"exp\" claim", NULL);
                 goto done;
             }
-        } else {
+        }
+        else {
             json_t *jiat = json_object_get(jws, "iat");
             if (json_is_integer(jiat)) {
                 if (max_age) {
@@ -533,9 +533,6 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
                         free(val);
                         goto done;
                     }
-                } else {
-                    xsyslog(LOG_ERR, "Missing \"max_age\" parameter with \"iat\" claim", NULL);
-                    goto done;
                 }
             } else {
                 if (jiat) {
@@ -547,8 +544,9 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
                 goto done;
             }
         }
-    } else {
-        xsyslog(LOG_ERR, "Missing \"iat\" or \"exp\" claim", NULL);
+    }
+    else if (max_age) {
+        xsyslog(LOG_ERR, "Missing \"iat\" claim", NULL);
         goto done;
     }
 

--- a/imap/http_jwt.c
+++ b/imap/http_jwt.c
@@ -68,6 +68,7 @@
 static int is_enabled = 0;
 
 static ptrarray_t pkeys = PTRARRAY_INITIALIZER;
+static const size_t MAX_JWT_PAYLOAD_FIELD_NB = 5;
 
 static time_t max_age = 0;
 
@@ -492,7 +493,7 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
     int ret = 0;
 
     json_t *jws = json_loads(buf_cstring(&jwt->buf), JSON_REJECT_DUPLICATES, NULL);
-    if (!json_object_size(jws) || json_object_size(jws) > 2) {
+    if (!json_object_size(jws) || json_object_size(jws) > MAX_JWT_PAYLOAD_FIELD_NB) {
         xsyslog(LOG_ERR, "Unexpected JWS payload structure", NULL);
         goto done;
     }
@@ -504,30 +505,50 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
     }
 
     if (json_object_size(jws) >= 2) {
-        json_t *jiat = json_object_get(jws, "iat");
-        if (!json_is_integer(jiat)) {
-            if (jiat) {
-                char *val = json_dumps(jiat, JSON_COMPACT|JSON_ENCODE_ANY);
-                xsyslog(LOG_ERR, "Invalid \"iat\" claim", "iat=<%s>", val);
-                free(val);
-            }
-            else xsyslog(LOG_ERR, "JWT contains unsupported claims", NULL);
-            goto done;
-        }
-
-        if (max_age) {
-            time_t iat = json_integer_value(jiat);
-            time_t now = time(NULL);
-            if (iat + max_age <= now || iat > now) {
-                char *val = json_dumps(jiat, JSON_COMPACT|JSON_ENCODE_ANY);
-                xsyslog(LOG_ERR, "Out-of-range \"iat\" claim", "iat=<%s>", val);
-                free(val);
+        time_t now = time(NULL);
+        json_t *jnbf = json_object_get(jws, "nbf");
+        if (json_is_integer(jnbf)) {
+            time_t nbf = json_integer_value(jnbf);
+            if (!(now >= nbf)) {
+                xsyslog(LOG_ERR, "Out-of-range \"nbf\" claim", NULL);
                 goto done;
             }
         }
-    }
-    else if (max_age) {
-        xsyslog(LOG_ERR, "Missing \"iat\" claim", NULL);
+
+        json_t *jexp = json_object_get(jws, "exp");
+        if (json_is_integer(jexp)) {
+            time_t exp = json_integer_value(jexp);
+            if (!(now < exp)) {
+                xsyslog(LOG_ERR, "Out-of-range \"exp\" claim", NULL);
+                goto done;
+            }
+        } else {
+            json_t *jiat = json_object_get(jws, "iat");
+            if (json_is_integer(jiat)) {
+                if (max_age) {
+                    time_t iat = json_integer_value(jiat);
+                    if (iat + max_age <= now || iat > now) {
+                        char *val = json_dumps(jiat, JSON_COMPACT|JSON_ENCODE_ANY);
+                        xsyslog(LOG_ERR, "Out-of-range \"iat\" claim", "iat=<%s>", val);
+                        free(val);
+                        goto done;
+                    }
+                } else {
+                    xsyslog(LOG_ERR, "Missing \"max_age\" parameter with \"iat\" claim", NULL);
+                    goto done;
+                }
+            } else {
+                if (jiat) {
+                    char *val = json_dumps(jiat, JSON_COMPACT|JSON_ENCODE_ANY);
+                    xsyslog(LOG_ERR, "Invalid \"iat\" claim", "iat=<%s>", val);
+                    free(val);
+                }
+                else xsyslog(LOG_ERR, "JWT contains unsupported claims", NULL);
+                goto done;
+            }
+        }
+    } else {
+        xsyslog(LOG_ERR, "Missing \"iat\" or \"exp\" claim", NULL);
         goto done;
     }
 

--- a/imap/http_jwt.c
+++ b/imap/http_jwt.c
@@ -534,13 +534,10 @@ static int validate_payload(struct jwt *jwt, char *out, size_t outlen)
                         goto done;
                     }
                 }
-            } else {
-                if (jiat) {
-                    char *val = json_dumps(jiat, JSON_COMPACT|JSON_ENCODE_ANY);
-                    xsyslog(LOG_ERR, "Invalid \"iat\" claim", "iat=<%s>", val);
-                    free(val);
-                }
-                else xsyslog(LOG_ERR, "JWT contains unsupported claims", NULL);
+            } else if (jiat) {
+                char *val = json_dumps(jiat, JSON_COMPACT|JSON_ENCODE_ANY);
+                xsyslog(LOG_ERR, "Invalid \"iat\" claim", "iat=<%s>", val);
+                free(val);
                 goto done;
             }
         }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1148,9 +1148,12 @@ Blank lines and lines beginning with ``#'' are ignored.
    "iat" claim of the JWS Payload and ends after the duration of this
    option value has passed. Tokens without an "iat" claim,
    or with an issue date in the future, are rejected. There is no leeway
-   for clock skew.
+   for clock skew. Starting from Cyrus version 3.8, the "iat" claim
+   only is validated if no "exp" claim is present.
 
    The zero value disables validation of the "iat" JWS claim.
+
+   Starting from Cyrus 3.8, the "nbf" and "exp" claims always are validated.
 */
 
 { "icalendar_max_size", "0", BYTESIZE, "3.8.0" }


### PR DESCRIPTION
This updates the JSON Web Token code to

- validate the `nbf` claim
- validate the `exp` claim
- ignore unknown claims, as stated in [Section 4 of RFC7519](https://www.rfc-editor.org/rfc/rfc7519#section-4)

The initial code was contributed by @bamthomas in https://github.com/cyrusimap/cyrus-imapd/pull/4515. Thanks! This PR adds more strict validation invalid JSON claims and makes the cunit test code more maintainable.