### PR TITLE
RunnerPretty: colour the summary output too

### DIFF
--- a/cassandane/Cassandane/Unit/RunnerPretty.pm
+++ b/cassandane/Cassandane/Unit/RunnerPretty.pm
@@ -222,4 +222,28 @@ sub print_failures
     }
 }
 
+sub print_header {
+    my $self = shift;
+    my ($result) = @_;
+    if ($result->was_successful()) {
+        $self->_print("\n",
+                      $self->ansi([32], "OK"),
+                      " (", $result->run_count(), " tests)\n");
+    } else {
+        my $failure_count = $result->failure_count()
+                          ? $self->ansi([33], $result->failure_count)
+                          : "0";
+        my $error_count = $result->error_count()
+                        ? $self->ansi([31], $result->error_count)
+                        : "0";
+
+        $self->_print("\n", $self->ansi([31], "!!!FAILURES!!!"), "\n",
+                      "Test Results:\n",
+                      "Run: ", $result->run_count(),
+                      ", Failures: $failure_count",
+                      ", Errors: $error_count",
+                      "\n");
+    }
+}
+
 1;


### PR DESCRIPTION
This colours the summary output that appears at the end of a cassandane run.

The diff looks like new code, but it's actually overriding a method in the superclass (Test::Unit::TestRunner).  The method that's being overridden looked like this:

```
sub print_header {
    my $self = shift;
    my ($result) = @_;
    if ($result->was_successful()) {
        $self->_print("\n", "OK", " (", $result->run_count(), " tests)\n");
    } else {
        $self->_print("\n", "!!!FAILURES!!!", "\n",
                      "Test Results:\n",
                      "Run: ", $result->run_count(),
                      ", Failures: ", $result->failure_count(),
                      ", Errors: ", $result->error_count(),
                      "\n");
    }
}
```

So you can see the "new" code does basically the same thing it always did, but with colour injected in appropriate places, and some breaking up and rewrapping of lines that got too long.