### PR TITLE
cyr_expire: add noexpire_until annotation

### DIFF
--- a/cassandane/Cassandane/Cyrus/Metadata.pm
+++ b/cassandane/Cassandane/Cyrus/Metadata.pm
@@ -363,6 +363,12 @@ sub test_shared
     if ($maj > 3 or ($maj == 3 and $min >= 3)) {
         $specific_entries{'/shared/vendor/cmu/cyrus-imapd/search-fuzzy-always'} = undef;
     }
+
+    # We introduced vendor/cmu/cyrus-imapd/noexpire_until in 3.9.0
+    if ($maj > 3 or ($maj == 3 and $min >= 9)) {
+        $specific_entries{'/shared/vendor/cmu/cyrus-imapd/noexpire_until'} = undef;
+    }
+
     $self->assert_deep_equals(\%specific_entries, $r);
 
     # individual item fetch:
@@ -1123,6 +1129,12 @@ sub test_private
     if ($maj > 3 or ($maj == 3 and $min >= 3)) {
         $specific_entries{'/private/vendor/cmu/cyrus-imapd/search-fuzzy-always'} = undef;
     }
+
+    # We introduced vendor/cmu/cyrus-imapd/noexpire_until in 3.9.0
+    if ($maj > 3 or ($maj == 3 and $min >= 9)) {
+        $specific_entries{'/private/vendor/cmu/cyrus-imapd/noexpire_until'} = undef;
+    }
+
     $self->assert_deep_equals(\%specific_entries, $r);
 
     $imaptalk->setmetadata('INBOX', "/private/comment", "This is a comment");

--- a/changes/next/cyr_expire_noexpire
+++ b/changes/next/cyr_expire_noexpire
@@ -1,0 +1,15 @@
+Description:
+
+Supports non-day durations in the archive/delete/expire annotations.
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+None
+
+GitHub issue:
+
+If theres a github issue number for this, put it here.

--- a/changes/next/cyr_expire_noexpire
+++ b/changes/next/cyr_expire_noexpire
@@ -2,6 +2,8 @@ Description:
 
 Supports non-day durations in the archive/delete/expire annotations.
 
+Adds the 'noexpire_until' annotation to disable cyr_expire per user.
+
 Config changes:
 
 None

--- a/changes/next/cyr_expire_noexpire
+++ b/changes/next/cyr_expire_noexpire
@@ -1,7 +1,7 @@
 Description:
 
 Supports non-day durations in the archive/delete/expire annotations.
-
+Removes support for fractional durations in cyr_expire arguments.
 Adds the 'noexpire_until' annotation to disable cyr_expire per user.
 
 Config changes:
@@ -10,7 +10,9 @@ None
 
 Upgrade instructions:
 
-None
+Installations that passed fractional durations such as "1.5d" to any of the
+-E, -X, -D, or -A arguments must adapt these to only use integer durations
+such as "1d12h".
 
 GitHub issue:
 

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -2053,6 +2053,112 @@ static int create_messages(struct mailbox *mailbox, int count)
     return 0;
 }
 
+static void test_canon_value(void)
+{
+    struct {
+        const char *annot;
+        const char *attrb;
+        const char *value;
+        int is_invalid;
+    } tests[] = {{
+        .annot = "/check",
+        .attrb = "value.shared",
+        .value = "true",
+    }, {
+        .annot = "/check",
+        .attrb = "value.shared",
+        .value = "false",
+    }, {
+        .annot = "/check",
+        .attrb = "value.shared",
+        .value = "yes",
+        .is_invalid = 1,
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/sortorder",
+        .attrb = "value.priv",
+        .value = "123",
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/sortorder",
+        .attrb = "value.priv",
+        .value = "12298189749871298739829873",
+        .is_invalid = 1
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/sortorder",
+        .attrb = "value.priv",
+        .value = "-1",
+        .is_invalid = 1
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/expire",
+        .attrb = "value.shared",
+        .value = "1",
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/expire",
+        .attrb = "value.shared",
+        .value = "1s",
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/expire",
+        .attrb = "value.shared",
+        .value = "1x",
+        .is_invalid = 1,
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/archive",
+        .attrb = "value.shared",
+        .value = "1",
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/archive",
+        .attrb = "value.shared",
+        .value = "1s",
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/archive",
+        .attrb = "value.shared",
+        .value = "1x",
+        .is_invalid = 1,
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/delete",
+        .attrb = "value.shared",
+        .value = "1",
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/delete",
+        .attrb = "value.shared",
+        .value = "1s",
+    }, {
+        .annot = "/vendor/cmu/cyrus-imapd/delete",
+        .attrb = "value.shared",
+        .value = "1x",
+        .is_invalid = 1,
+    }};
+
+    struct mailbox *mailbox = NULL;
+    annotate_state_t *astate = NULL;
+    struct entryattlist *ealist = NULL;
+    struct buf val = BUF_INITIALIZER;
+
+    annotate_init(NULL, NULL);
+    annotatemore_open();
+
+    int r = mailbox_open_iwl(MBOXNAME1_INT, &mailbox);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+
+    astate = annotate_state_new();
+    r = annotate_state_set_mailbox(astate, mailbox);
+    CU_ASSERT_EQUAL(r, 0);
+    annotate_state_set_auth(astate, isadmin, userid, auth_state);
+
+    /* validate value */
+    for (size_t i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+        buf_setcstr(&val, tests[i].value);
+        setentryatt(&ealist, tests[i].annot, tests[i].attrb, &val);
+        r = annotate_state_store(astate, ealist);
+        CU_ASSERT_EQUAL(r, tests[i].is_invalid ? IMAP_ANNOTATION_BADVALUE : 0);
+        freeentryatts(ealist);
+        ealist = NULL;
+    }
+
+    annotate_state_abort(&astate);
+    mailbox_close(&mailbox);
+    annotatemore_close();
+}
+
 
 static int set_up(void)
 {

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
@@ -43,8 +43,9 @@ There are various annotations that **cyr_expire** respects:
 - ``/vendor/cmu/cyrus-imapd/delete`` which controls the deletion of
   messages
 
-These mailbox annotations specify the age(in days) of messages in the
-given mailbox that should be expired/archived/deleted.
+These mailbox annotations specify the age of messages in the
+given mailbox that should be expired/archived/deleted. The
+age is specified as a duration, the default unit are days.
 
 The value of the ``/vendor/cmu/cyrus-imapd/expire`` annotation is
 inherited by all children of the mailbox on which it is set, so an

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
@@ -48,6 +48,7 @@ There are various annotations that **cyr_expire** respects:
 The first three mailbox annotations specify the age of messages in the
 given mailbox that should be expired/archived/deleted. The
 age is specified as a duration, the default unit are days.
+The duration format is defined in :cyrusman:`imapd.conf(5)`.
 
 The last mailbox annotation specifies the UNIX epoch time in seconds
 until which expiring messages or removing deleted mailboxes is blocked.
@@ -101,6 +102,8 @@ Options
     ``archivepartition-*`` has been set in your config.
     This value is only used for entries which do not have a
     corresponding ``/vendonr/cmu/cyrus-imapd/archive`` mailbox annotation.
+    The duration format is defined in :cyrusman:`imapd.conf(5)`. The default
+    unit are days.
 
     |v3-new-feature|
 
@@ -108,25 +111,25 @@ Options
 
     Remove previously deleted mailboxes older than *delete-duration*
     (when using the "delayed" delete mode).
-    The value can be a floating point number, and may have a suffix to
-    specify the unit of time.  If no suffix, the value is number of days.
-    Valid suffixes are **d** (days), **h** (hours), **m** (minutes) and
-    **s** (seconds).
     This value is only used for entries which do not have a
     corresponding ``/verdor/cmu/cyrus-imapd/delete`` mailbox annotation.
+    The duration format is defined in :cyrusman:`imapd.conf(5)`. The default
+    unit are days.
 
 .. option:: -E expire-duration, --expire-duration=expire-duration
 
     Prune the duplicate database of entries older than *expire-duration*.
     This value is only used for entries which do not have a corresponding
     ``/vendor/cmu/cyrus-imapd/expire`` mailbox annotation.
-    Format is the same as delete-duration.
+    The duration format is defined in :cyrusman:`imapd.conf(5)`. The default
+    unit are days.
 
 .. option:: -X expunge-duration, --expunge-duration=expunge-duration
 
     Expunge previously deleted messages older than *expunge-duration*
     (when using the "delayed" expunge mode).
-    Format is the same as delete-duration.
+    The duration format is defined in :cyrusman:`imapd.conf(5)`. The default
+    unit are days.
 
 .. option:: -c, --no-conversations
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_expire.rst
@@ -42,10 +42,18 @@ There are various annotations that **cyr_expire** respects:
   messages
 - ``/vendor/cmu/cyrus-imapd/delete`` which controls the deletion of
   messages
+- ``/vendor/cmu/cyrus-imapd/noexpire_until`` which disables the expire
+  and delete operations per user
 
-These mailbox annotations specify the age of messages in the
+The first three mailbox annotations specify the age of messages in the
 given mailbox that should be expired/archived/deleted. The
 age is specified as a duration, the default unit are days.
+
+The last mailbox annotation specifies the UNIX epoch time in seconds
+until which expiring messages or removing deleted mailboxes is blocked.
+The zero epoch time represents infinity. This annotation has precedence
+over any of the other annotations or command line flags. It must only
+be set on the user inbox and applies to all mailboxes of that user.
 
 The value of the ``/vendor/cmu/cyrus-imapd/expire`` annotation is
 inherited by all children of the mailbox on which it is set, so an

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -191,7 +191,8 @@ enum {
     ATTRIB_TYPE_STRING,
     ATTRIB_TYPE_BOOLEAN,
     ATTRIB_TYPE_UINT,
-    ATTRIB_TYPE_INT
+    ATTRIB_TYPE_INT,
+    ATTRIB_TYPE_DURATION
 };
 #define ATTRIB_NO_FETCH_ACL_CHECK   (1<<30)
 
@@ -2270,7 +2271,7 @@ static const annotate_entrydesc_t mailbox_builtin_entries[] =
         NULL
     },{
         IMAP_ANNOT_NS "archive",
-        ATTRIB_TYPE_UINT,
+        ATTRIB_TYPE_DURATION,
         BACKEND_ONLY,
         ATTRIB_VALUE_SHARED,
         ACL_ADMIN,
@@ -2280,7 +2281,7 @@ static const annotate_entrydesc_t mailbox_builtin_entries[] =
         NULL
     },{
         IMAP_ANNOT_NS "delete",
-        ATTRIB_TYPE_UINT,
+        ATTRIB_TYPE_DURATION,
         BACKEND_ONLY,
         ATTRIB_VALUE_SHARED,
         ACL_ADMIN,
@@ -2300,7 +2301,7 @@ static const annotate_entrydesc_t mailbox_builtin_entries[] =
         (void *)OPT_IMAP_DUPDELIVER
     },{
         IMAP_ANNOT_NS "expire",
-        ATTRIB_TYPE_UINT,
+        ATTRIB_TYPE_DURATION,
         BACKEND_ONLY,
         ATTRIB_VALUE_SHARED,
         ACL_ADMIN,
@@ -2574,7 +2575,7 @@ static const annotate_entrydesc_t server_builtin_entries[] =
         NULL
     },{
         IMAP_ANNOT_NS "expire",
-        ATTRIB_TYPE_UINT,
+        ATTRIB_TYPE_DURATION,
         PROXY_AND_BACKEND,
         ATTRIB_VALUE_SHARED,
         ACL_ADMIN,
@@ -3406,6 +3407,16 @@ static int annotate_canon_value(struct buf *value, int type)
                                         /* embedded NUL */
             || errno) {                 /* underflow/overflow */
             return IMAP_ANNOTATION_BADVALUE;
+        }
+        break;
+
+    case ATTRIB_TYPE_DURATION:
+        /* make sure it is a valid positive duration ( >= 0 ) */
+        {
+            buf_cstring(value);
+            int secs = -1;
+            if (config_parseduration(value->s, 'd', &secs) || secs < 0)
+                return IMAP_ANNOTATION_BADVALUE;
         }
         break;
 

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -2360,6 +2360,16 @@ static const annotate_entrydesc_t mailbox_builtin_entries[] =
         NULL,
         NULL
     },{
+        IMAP_ANNOT_NS "noexpire_until",
+        ATTRIB_TYPE_UINT,
+        BACKEND_ONLY,
+        ATTRIB_VALUE_SHARED,
+        ACL_ADMIN,
+        annotation_get_fromdb,
+        annotation_set_todb,
+        NULL,
+        NULL
+    },{
         IMAP_ANNOT_NS "partition",
         /* _get_partition does its own access control check */
         ATTRIB_TYPE_STRING | ATTRIB_NO_FETCH_ACL_CHECK,

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -319,7 +319,6 @@ static int get_annotation_value(const mbentry_t *mbentry,
     buf_free(&attrib);
     free(buf);
 
-    syslog(LOG_DEBUG, "get_annotation_value: ret(%d):secondsp(%d)", ret, *secondsp);
     return ret;
 }
 

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -305,7 +305,7 @@ static int get_annotation_value(const mbentry_t *mbentry,
      */
     do {
         buf_free(&attrib);
-        ret = annotatemore_lookup_mbe(mbentry, annot_entry, "", &attrib);
+        ret = annotatemore_lookup(buf, annot_entry, "", &attrib);
         if (ret ||              /* error */
             attrib.s)           /* found an entry */
             break;

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -89,6 +89,7 @@
 /* global state */
 static int verbose = 0;
 static const char *progname = NULL;
+static time_t progtime = 0;
 static struct namespace expire_namespace; /* current namespace */
 
 /* command line arguments */
@@ -282,43 +283,114 @@ static int parse_duration(const char *s, int *secondsp)
 }
 
 /*
- * Given an annotation, reads it, and converts it into 'seconds',
- * using `parse_duration`.
+ * Given an annotation, reads it from the mailbox or any of its
+ * parents if iterate is true.
  *
  * On Success: Returns 1
  * On Failure: Returns 0
  */
-static int get_annotation_value(const mbentry_t *mbentry,
+static int get_annotation_value(const char *mboxname,
                                 const char *annot_entry,
-                                int *secondsp, bool iterate)
+                                struct buf *annot_value,
+                                bool iterate)
 {
-    struct buf attrib = BUF_INITIALIZER;
     int ret = 0;
     /* mboxname needs to be copied since `mboxname_make_parent`
      * runs a strrchr() on it.
      */
-    char *buf = xstrdup(mbentry->name);
+    char *buf = xstrdup(mboxname);
 
     /*
      * Mailboxes inherit /vendo/cmu/cyrus-imapd/{expire, archive, delete},
      * so we need to iterate all the way up to "" (server entry).
      */
     do {
-        buf_free(&attrib);
-        ret = annotatemore_lookup(buf, annot_entry, "", &attrib);
+        buf_reset(annot_value);
+        ret = annotatemore_lookup(buf, annot_entry, "", annot_value);
         if (ret ||              /* error */
-            attrib.s)           /* found an entry */
+            buf_len(annot_value))           /* found an entry */
             break;
     } while (mboxname_make_parent(buf) && iterate);
 
-    if (attrib.s && parse_duration(attrib.s, secondsp))
-        ret = 1;
-    else
-        ret = 0;
-
-    buf_free(&attrib);
     free(buf);
 
+    return buf_len(annot_value) ? 1 : 0;
+}
+
+static int get_duration_annotation(const char *mboxname,
+                                   const char *annot_entry,
+                                   int *secondsp, bool iterate)
+{
+    struct buf attrib = BUF_INITIALIZER;
+    int ret = 0;
+
+    if (get_annotation_value(mboxname, annot_entry, &attrib, iterate) &&
+            parse_duration(buf_cstring(&attrib), secondsp))
+        ret = 1;
+
+    buf_free(&attrib);
+    return ret;
+}
+
+static int get_time_annotation(const char *mboxname,
+                               const char *annot_entry,
+                               time_t *timep, bool iterate)
+{
+    struct buf attrib = BUF_INITIALIZER;
+    int ret = 0;
+
+    if (get_annotation_value(mboxname, annot_entry, &attrib, iterate)) {
+        const char *end = NULL;
+        bit64 v64 = 0;
+        if (!parsenum(buf_cstring(&attrib), &end, 0, &v64) && !*end) {
+            *timep = v64;
+            ret = 1;
+        }
+    }
+
+    buf_free(&attrib);
+    return ret;
+}
+
+static int noexpire_mailbox(const mbentry_t *mbentry)
+{
+    int ret = 0;
+    mbname_t *mbname = mbname_from_intname(mbentry->name);
+
+    if (mbname_userid(mbname)) {
+        // Cache result for the last seen userid
+        static struct {
+            struct buf userid;
+            int has_noexpire;
+        } last_seen = { BUF_INITIALIZER, -1 };
+
+        if (!strcmp(mbname_userid(mbname), buf_cstring(&last_seen.userid))) {
+            ret = last_seen.has_noexpire;
+            goto done;
+        }
+
+        // Determine user inbox name
+        if (mbname_isdeleted(mbname)) {
+            mbname_t *tmp = mbname_from_userid(mbname_userid(mbname));
+            mbname_free(&mbname);
+            mbname = tmp;
+        }
+        mbname_truncate_boxes(mbname, 0);
+
+        // Lookup annotation, ignoring any pre-epoch timestamps
+        time_t until;
+        if (get_time_annotation(mbname_intname(mbname),
+                    IMAP_ANNOT_NS "noexpire_until", &until, false))
+            ret = !until || (until > 0 && progtime < until);
+
+        // Update cache
+        buf_setcstr(&last_seen.userid, mbname_userid(mbname));
+        last_seen.has_noexpire = ret;
+    }
+
+done:
+    if (ret) verbosep("(noexpire) %s", mbname_intname(mbname));
+    mbname_free(&mbname);
     return ret;
 }
 
@@ -378,7 +450,7 @@ static int archive(const mbentry_t *mbentry, void *rock)
 
     /* check /vendor/cmu/cyrus-imapd/archive */
     if (!arock->skip_annotate &&
-        get_annotation_value(mbentry, IMAP_ANNOT_NS "archive",
+        get_duration_annotation(mbentry->name, IMAP_ANNOT_NS "archive",
                              &archive_seconds, false)) {
         arock->archive_mark = archive_seconds ?
             time(0) - archive_seconds : 0;
@@ -462,12 +534,16 @@ static int expire(const mbentry_t *mbentry, void *rock)
         goto done;
     }
 
+    /* see if this mailbox should be ignored */
+    if (noexpire_mailbox(mbentry))
+        goto done;
+
     /* see if we need to expire messages.
      * since mailboxes inherit /vendor/cmu/cyrus-imapd/expire,
      * we need to iterate all the way up to "" (server entry)
      */
     if (!erock->skip_annotate &&
-        get_annotation_value(mbentry, IMAP_ANNOT_NS "expire",
+        get_duration_annotation(mbentry->name, IMAP_ANNOT_NS "expire",
                              &expire_seconds, true)) {
         /* add mailbox to table */
         erock->expire_mark = expire_seconds ?
@@ -539,9 +615,13 @@ static int delete(const mbentry_t *mbentry, void *rock)
     if (!mboxname_isdeletedmailbox(mbentry->name, &timestamp))
         goto done;
 
+    /* see if this mailbox should be ignored */
+    if (noexpire_mailbox(mbentry))
+        goto done;
+
     /* check /vendor/cmu/cyrus-imapd/delete */
     if (!drock->skip_annotate &&
-        get_annotation_value(mbentry, IMAP_ANNOT_NS "delete",
+        get_duration_annotation(mbentry->name, IMAP_ANNOT_NS "delete",
                              &delete_seconds, false)) {
         drock->delete_mark = delete_seconds ?
             time(0) - delete_seconds: 0;
@@ -886,6 +966,7 @@ int main(int argc, char *argv[])
     int r = 0;
 
     progname = basename(argv[0]);
+    progtime = time(NULL);
 
     if (parse_args(argc, argv, &ctx.args) != 0)
         exit(EXIT_FAILURE);


### PR DESCRIPTION
This PR includes fixes and enhancements for cyr_expire:

- It fixes a bug in which the `expire/delete/archive` mailbox annotations were only read for a given mailbox, rather than looking its value up in all the parent mailboxes.
- It removes a noisy and unhelpful debug message from logging
- It adds support for non-day durations in the `expire/delete/archive` annotations by use of the Cyrus-config supported duration format. cyr_expire already had included support to read such values, but they could only be set as command line flags.
- It adds the `noexpire_until` annotation that allows to block expiring and deleting until a given future date, or indefinitely.

This PR best is read commit by commit.