### PR TITLE
libconfig: reject durations longer than INT32_MAX seconds

### DIFF
--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -438,6 +438,7 @@ static const struct duration_parse_data duration_parse_tests[] = {
 
     { "-1", 0, -1 },
     { "-0", 0, 0 },
+    { "-", -1, 0xdeadbeef },
     { "--1", -1, 0xdeadbeef },
     { "-1s", 0, -1 },
     { "-1m", 0, -60 },
@@ -446,6 +447,14 @@ static const struct duration_parse_data duration_parse_tests[] = {
     { "1h1h", 0, 2 * 60 * 60 }, /* silly, but let it work */
     { "1hh", -1, 0xdeadbeef }, /* bogus, reject it */
     { "1hhh", -1, 0xdeadbeef }, /* bogus, reject it */
+
+    { "2147483647s", 0, INT32_MAX },    /* that's the maximum */
+    { "-2147483647s", 0, -INT32_MAX },  /* that's the minimum */
+    { "2147483648s", -1, 0xdeadbeef },  /* one too high */
+    { "-2147483648s", -1, 0xdeadbeef }, /* one too low */
+
+    { "24855d3h14m7s", 0, INT32_MAX },
+    { "24855d3h14m8s", -1, 0xdeadbeef },
 };
 
 static void test_duration_parse(void)

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -91,7 +91,8 @@ be summed together, for example \fB1h30m\fR is equivalent to \fB90m\fR.  If
 no unit is specified, an option-specific backward-compatible default unit
 is assumed (documented on an option-by-option basis).  These are simple time
 units: 1d=24h, 1h=60m, 1m=60s (daylight savings, timezones, leap adjustments,
-etc are not considered).
+etc are not considered). The minimum and maximum durations in seconds are
+-2147483647 and 2147483647, respectively.
 .PP
 Byte size options take the form of a number followed by a unit, for example
 \fB1KiB\fR (1 kibibyte).  Units are \fBB\fR (bytes), \fBKiB\fR (kibibytes),


### PR DESCRIPTION
We currently use these just for parsing imapd.conf but also want to use it for annotation values.