### PR TITLE
cass: test that autocreate doesn't replace legacy mailboxes

### DIFF
--- a/cassandane/Cassandane/MasterEntry.pm
+++ b/cassandane/Cassandane/MasterEntry.pm
@@ -87,7 +87,7 @@ sub master_params
 {
     my ($self) = @_;
     my $params = {};
-    foreach my $a ('name', 'argv', $self->_otherparams())
+    foreach my $a ('name', 'argv', 'config', $self->_otherparams())
     {
         $params->{$a} = $self->{$a}
             if defined $self->{$a};
@@ -99,7 +99,7 @@ sub set_master_param
 {
     my ($self, $param, $value) = @_;
 
-    foreach my $a ('name', 'argv', $self->_otherparams())
+    foreach my $a ('name', 'argv', 'config', $self->_otherparams())
     {
         $self->{$a} = $value
             if ($a eq $param);

--- a/cassandane/Cassandane/Service.pm
+++ b/cassandane/Cassandane/Service.pm
@@ -57,13 +57,19 @@ sub new
         if (exists $params{host});
     my $port = delete $params{port};
     my $type = delete $params{type} || 'unknown';
+    my $instance = delete $params{instance};
 
     my $self = $class->SUPER::new(%params);
+
+    # GenericListener is a bit different from MasterEntry et al, and must
+    # always have a config specified, so pass through the default explicitly
+    my $listener_config = $params{config} || $instance->{config};
 
     $self->{_listener} = Cassandane::GenericListener->new(
                             name => $params{name},
                             host => $host,
-                            port => $port);
+                            port => $port,
+                            config => $listener_config);
     $self->{type} = $type;
 
     return $self;


### PR DESCRIPTION
This adds a test to verify that autocreate doesn't replace legacy mailboxes, which seems to show that the problem I suspected in #4532 does not exist.