### PR TITLE
Allow cyrus to compile Sphinx documentation with Sphinx version 4..0 …

### DIFF
--- a/docsrc/exts/sphinxlocal/writers/manpage.py
+++ b/docsrc/exts/sphinxlocal/writers/manpage.py
@@ -38,7 +38,7 @@ class CyrusManualPageWriter(ManualPageWriter):
         self.builder = builder
 
     def translate(self):
-        visitor = CyrusManualPageTranslator(self.builder, self.document)
+        visitor = CyrusManualPageTranslator(self.document, self.builder)
         self.visitor = visitor
         self.document.walkabout(visitor)
         self.output = visitor.astext()
@@ -49,8 +49,8 @@ class CyrusManualPageTranslator(BaseTranslator):
     Custom translator.
     """
 
-    def __init__(self, builder, *args, **kwds):
-        BaseTranslator.__init__(self, builder, *args, **kwds)
+    def __init__(self, document, builder, *args, **kwds):
+        BaseTranslator.__init__(self, document, builder, *args, **kwds)
         self.builder = builder
 
         self.in_productionlist = 0


### PR DESCRIPTION
…or greater

When compiling cyrus-imap 3.8.0 on debian 12 with Sphinx documentation  cyrus  fails to compile with the following  error:

Exception occurred:
|   File "/usr/lib/python3/dist-packages/docutils/writers/manpage.py", line 171, in __init__
|     self.settings = settings = document.settings
| AttributeError: 'CyrusManualPageBuilder' object has no attribute 'settings'

Cause: 

CyrusManualPageTranslator inherits from Sphinx' ManualPageTranslator and calls the super-class constructor as follows:

 BaseTranslator.__init__(self, builder, *args, **kwds)

However, starting with Sphinx 2.0 it should be called with document as the first argument and builder as the second one. The old way of calling it raised a warning for some time and was completely removed in Sphinx 4.0.