### PR TITLE
Make RENAME not spit out all the intermediate folder names

### DIFF
--- a/cassandane/Cassandane/Cyrus/Rename.pm
+++ b/cassandane/Cassandane/Cyrus/Rename.pm
@@ -641,7 +641,7 @@ sub test_rename_deepuser
 
     $admintalk->create("user.cassandane.foo") || die;
     $admintalk->create("user.cassandane.bar") || die;
-    $admintalk->create("user.cassandane.bar.sub") || die;
+    $admintalk->create("user.cassandane.bar.sub folder") || die;
 
     # replicate and check initial state
     $self->run_replication(rolling => 1, inputfile => $synclogfname);
@@ -653,7 +653,7 @@ sub test_rename_deepuser
     my $res = $admintalk->rename('user.cassandane', 'user.newuser');
     $self->assert(not $admintalk->get_last_error());
 
-    $res = $admintalk->select("user.newuser.bar.sub");
+    $res = $admintalk->select("user.newuser.bar.sub folder");
     $self->assert(not $admintalk->get_last_error());
 
     # replicate and check the renames

--- a/cassandane/Cassandane/Cyrus/Rename.pm
+++ b/cassandane/Cassandane/Cyrus/Rename.pm
@@ -98,6 +98,29 @@ sub test_rename_asuser
     $self->assert_num_equals(1, scalar @postdata);
 }
 
+sub test_xrename
+	:min_version_3_8_2
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+
+    $imaptalk->create("INBOX.src") || die;
+    $self->{store}->set_folder("INBOX.src");
+    $self->{store}->write_begin();
+    my $msg1 = $self->{gen}->generate(subject => "subject 1");
+    $self->{store}->write_message($msg1, flags => ["\\Seen", "\$NotJunk"]);
+    $self->{store}->write_end();
+    $imaptalk->select("INBOX.src") || die;
+    my @predata = $imaptalk->search("SEEN");
+    $self->assert_num_equals(1, scalar @predata);
+
+    $imaptalk->_imap_cmd('XRENAME', 0, '', "INBOX.src", "INBOX.dst");
+    $imaptalk->select("INBOX.dst") || die;
+    my @postdata = $imaptalk->search("KEYWORD" => "\$NotJunk");
+    $self->assert_num_equals(1, scalar @postdata);
+}
+
 #
 # Test Bug #3586 - rename subfolders
 #

--- a/changes/next/xrename-command
+++ b/changes/next/xrename-command
@@ -1,0 +1,15 @@
+Description:
+
+RENAME no longer emits per-folder updates, new XRENAME command does
+
+
+Config changes:
+
+No config changes
+
+
+Upgrade instructions:
+
+If using a new Cyrus from a telnet connection, use XRENAME if you want
+to see the names of each folder as it renames.  NOTE, this is really quick
+these days with UUID mailboxes, you probably don't want to.


### PR DESCRIPTION
Found with a Fastmail user rename failing due to parse errors in Mail::IMAPTalk with a very odd folder name.  I figure we may as well astring quote them!  Makes for a more useful output.