### PR TITLE
fixes for leaks found by valgrinding cunit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -674,7 +674,7 @@ cunit_TESTS += cunit/ical_support.testc
 endif
 
 cunit_unit_SOURCES = $(cunit_FRAMEWORK) $(cunit_TESTS) \
-		imap/mutex_fake.c imap/spool.c
+		imap/mutex_fake.c imap/spool.c imap/search_expr.c
 cunit_unit_LDADD = $(LD_SIEVE_ADD) $(LD_UTILITY_ADD) -lcunit
 
 CUNIT_PL = $(top_srcdir)/cunit/cunit.pl --project $(CUNIT_PROJECT)

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -666,8 +666,6 @@ static void test_delete(void)
     int r;
     annotate_state_t *astate = NULL;
     struct mboxlist_entry mbentry;
-    strarray_t entries = STRARRAY_INITIALIZER;
-    strarray_t attribs = STRARRAY_INITIALIZER;
     struct entryattlist *ealist = NULL;
     struct buf val = BUF_INITIALIZER;
     struct buf val2 = BUF_INITIALIZER;
@@ -687,8 +685,6 @@ static void test_delete(void)
     mbentry.mbtype = 0;
     mbentry.partition = PARTITION;
     mbentry.acl = ACL;
-    strarray_append(&entries, COMMENT);
-    strarray_append(&attribs, VALUE_SHARED);
 
     /* set some values */
 
@@ -756,6 +752,7 @@ static void test_delete(void)
     CU_ASSERT_EQUAL(fexists(buf_cstring(&path)), 0);
     mailbox_close(&mailbox);
     buf_free(&val);
+    buf_free(&path);
 }
 
 static void test_rename(void)

--- a/cunit/hash.testc
+++ b/cunit/hash.testc
@@ -401,6 +401,8 @@ static void test_load_factor_warning(void)
     }
     CU_ASSERT_EQUAL(n_words, hash_numrecords(&ht));
     CU_ASSERT_SYSLOG(syslog_index, 2);
+
+    free_hash_table(&ht, NULL);
 }
 
 /* vim: set ft=c: */

--- a/cunit/proc.testc
+++ b/cunit/proc.testc
@@ -315,6 +315,7 @@ static void test_proc_foreach(void)
         /* better not see anything higher than those we created */
         CU_ASSERT((unsigned) found_pid < n_tests);
     }
+    strarray_free(keys);
 
     /* reset results */
     free_hash_table(&results, &free_procdata_fields);
@@ -371,6 +372,7 @@ static void test_proc_foreach(void)
         /* better not see anything higher than those we created */
         CU_ASSERT((unsigned) found_pid < n_tests);
     }
+    strarray_free(keys);
 
     /* reset results */
     free_hash_table(&results, &free_procdata_fields);

--- a/cunit/search_expr.testc
+++ b/cunit/search_expr.testc
@@ -18,6 +18,8 @@ static const char *userid = "fred";
 static struct auth_state *authstate = NULL;
 static int isadmin = 0;
 
+extern hash_table attrs_by_name; /* expose some search_expr internals */
+
 #define DATE1_RFC3501   "8-Dec-2012"
 #define DATE1_BEGIN     "1354885200"
 #define DATE1_MID       "1354928400"
@@ -1365,6 +1367,7 @@ static int set_up(void)
 {
     int r;
 
+    /* n.b. initalising like this skips the on-shutdown cleanup... */
     search_attr_init();
 
     libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
@@ -1384,6 +1387,15 @@ static int set_up(void)
 static int tear_down(void)
 {
     int r;
+
+    /* ... so we need to reach in deep and clean up ourselves */
+    hash_iter *iter = hash_table_iter(&attrs_by_name);
+    while (hash_iter_next(iter)) {
+        struct search_attr *attr = hash_iter_val(iter);
+        if (attr->freeattr) attr->freeattr(&attr);
+    }
+    hash_iter_free(&iter);
+    free_hash_table(&attrs_by_name, NULL);
 
     config_reset();
     restore_tz();

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -1255,10 +1255,14 @@ EXPORTED void backend_disconnect(struct backend *s)
     }
 
 #ifdef HAVE_SSL
-    /* Free tlsconn */
+    /* Free tlsconn and tlssess */
     if (s->tlsconn) {
         tls_reset_servertls(&s->tlsconn);
         s->tlsconn = NULL;
+    }
+    if (s->tlssess) {
+        SSL_SESSION_free(s->tlssess);
+        s->tlssess = NULL;
     }
 #endif /* HAVE_SSL */
 

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -2596,7 +2596,7 @@ static int search_seen_match(message_t *m,
 
 /* ====================================================================== */
 
-static hash_table attrs_by_name = HASH_TABLE_INITIALIZER;
+HIDDEN hash_table attrs_by_name = HASH_TABLE_INITIALIZER;
 
 static int search_attr_initialized = 0;
 


### PR DESCRIPTION
This fixes a handful of leaks that `make -j4 VG=1 check` detects.  Most of these are trivial but there's a couple of complicated ones:

* search_expr.testc was leaking internal state that's usually cleaned up by `cyrus_done()`, but which is missed in the tests because the way `set_up()` initialises it bypasses installing the done callback.  To fix this one, I tweaked some things to expose search_expr.c's internals to cunit, so that `tear_down()` could then reach in and clean up itself.  But perhaps it would have been better to just add a comment and a suppression rule instead?
* backend.c was leaking an `SSL_SESSION` object when disconnecting from a backend that we had used starttls when connecting to.  This one's a real leak in Cyrus, not just a leak in the tests.  The fix seems simple, and our tests all pass, but I'm not totally certain it's correct.  When reviewing this one, please look around, not just at the diff.  @ksmurchison recently fixed a similar SSL_SESSION leak in a3523d406.

Please pull this branch and valgrind the tests yourself if you can -- I expect there to be a bunch of "still reachable" leaks, but every time valgrind says anything, it should also say `ERROR SUMMARY: 0 errors from 0 contexts`, indicating that there's not anything that really needs fixing.  If your valgrind finds things mine doesn't, that would be useful to know about!

If you think I should dive in and track down the "still reachable" ones too, please say so -- I'm on the fence myself.  On the one hand, valgrind doesn't consider them to be errors; on the other hand, they're noise that makes real errors harder to see.