### PR TITLE
cassandane: improve file test assertions

### DIFF
--- a/cassandane/Cassandane/Cyrus/Archive.pm
+++ b/cassandane/Cassandane/Cyrus/Archive.pm
@@ -104,36 +104,35 @@ sub test_archive_messages
     my $datadir = $data->{data};
     my $archivedir = $data->{archive};
 
-    $self->assert(-f "$datadir/1.");
-    $self->assert(-f "$datadir/2.");
-    $self->assert(-f "$datadir/3.");
+    $self->assert_file_test("$datadir/1.", "-f");
+    $self->assert_file_test("$datadir/2.", "-f");
+    $self->assert_file_test("$datadir/3.", "-f");
 
-    $self->assert(!-f "$archivedir/1.");
-    $self->assert(!-f "$archivedir/2.");
-    $self->assert(!-f "$archivedir/3.");
+    $self->assert_not_file_test("$archivedir/1.", "-f");
+    $self->assert_not_file_test("$archivedir/2.", "-f");
+    $self->assert_not_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire but no messages should move";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '7d' );
 
-    $self->assert(-f "$datadir/1.");
-    $self->assert(-f "$datadir/2.");
-    $self->assert(-f "$datadir/3.");
+    $self->assert_file_test("$datadir/1.", "-f");
+    $self->assert_file_test("$datadir/2.", "-f");
+    $self->assert_file_test("$datadir/3.", "-f");
 
-    $self->assert(!-f "$archivedir/1.");
-    $self->assert(!-f "$archivedir/2.");
-    $self->assert(!-f "$archivedir/3.");
-
+    $self->assert_not_file_test("$archivedir/1.", "-f");
+    $self->assert_not_file_test("$archivedir/2.", "-f");
+    $self->assert_not_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire to archive now";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '0' );
 
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 }
 
 sub test_archivenow_messages
@@ -167,35 +166,35 @@ sub test_archivenow_messages
     my $archivedir = $data->{archive};
 
     # already archived
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire with old and messages stay archived";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '7d' );
 
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire to archive now and messages stay archived";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '0' );
 
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 }
 
 1;
@@ -232,24 +231,24 @@ sub test_archive_messages_archive_annotation
     my $datadir = $data->{data};
     my $archivedir = $data->{archive};
 
-    $self->assert(-f "$datadir/1.");
-    $self->assert(-f "$datadir/2.");
-    $self->assert(-f "$datadir/3.");
+    $self->assert_file_test("$datadir/1.", "-f");
+    $self->assert_file_test("$datadir/2.", "-f");
+    $self->assert_file_test("$datadir/3.", "-f");
 
-    $self->assert(!-f "$archivedir/1.");
-    $self->assert(!-f "$archivedir/2.");
-    $self->assert(!-f "$archivedir/3.");
+    $self->assert_not_file_test("$archivedir/1.", "-f");
+    $self->assert_not_file_test("$archivedir/2.", "-f");
+    $self->assert_not_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire but no messages should move";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '7d' );
 
-    $self->assert(-f "$datadir/1.");
-    $self->assert(-f "$datadir/2.");
-    $self->assert(-f "$datadir/3.");
+    $self->assert_file_test("$datadir/1.", "-f");
+    $self->assert_file_test("$datadir/2.", "-f");
+    $self->assert_file_test("$datadir/3.", "-f");
 
-    $self->assert(!-f "$archivedir/1.");
-    $self->assert(!-f "$archivedir/2.");
-    $self->assert(!-f "$archivedir/3.");
+    $self->assert_not_file_test("$archivedir/1.", "-f");
+    $self->assert_not_file_test("$archivedir/2.", "-f");
+    $self->assert_not_file_test("$archivedir/3.", "-f");
 
     $admintalk->setmetadata('user.cassandane',
                             "/shared/vendor/cmu/cyrus-imapd/archive",
@@ -258,25 +257,24 @@ sub test_archive_messages_archive_annotation
     xlog $self, "Run cyr_expire asking to archive now, but it shouldn't";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '0' );
 
-    $self->assert(-f "$datadir/1.");
-    $self->assert(-f "$datadir/2.");
-    $self->assert(-f "$datadir/3.");
+    $self->assert_file_test("$datadir/1.", "-f");
+    $self->assert_file_test("$datadir/2.", "-f");
+    $self->assert_file_test("$datadir/3.", "-f");
 
-    $self->assert(!-f "$archivedir/1.");
-    $self->assert(!-f "$archivedir/2.");
-    $self->assert(!-f "$archivedir/3.");
-
+    $self->assert_not_file_test("$archivedir/1.", "-f");
+    $self->assert_not_file_test("$archivedir/2.", "-f");
+    $self->assert_not_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire asking to archive now, with skip annotation";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '0' , '-a');
 
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 }
 
 sub test_archivenow_reconstruct
@@ -310,47 +308,47 @@ sub test_archivenow_reconstruct
     my $archivedir = $data->{archive};
 
     # already archived
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire with old and messages stay archived";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '7d' );
 
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Run cyr_expire to archive now and messages stay archived";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-A' => '0' );
 
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 
     xlog $self, "Reconstruct doesn't lose files";
 
     $self->{instance}->run_command({ cyrus => 1 }, 'reconstruct', '-s');
 
-    $self->assert(!-f "$datadir/1.");
-    $self->assert(!-f "$datadir/2.");
-    $self->assert(!-f "$datadir/3.");
+    $self->assert_not_file_test("$datadir/1.", "-f");
+    $self->assert_not_file_test("$datadir/2.", "-f");
+    $self->assert_not_file_test("$datadir/3.", "-f");
 
-    $self->assert(-f "$archivedir/1.");
-    $self->assert(-f "$archivedir/2.");
-    $self->assert(-f "$archivedir/3.");
+    $self->assert_file_test("$archivedir/1.", "-f");
+    $self->assert_file_test("$archivedir/2.", "-f");
+    $self->assert_file_test("$archivedir/3.", "-f");
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/Autocreate.pm
+++ b/cassandane/Cassandane/Cyrus/Autocreate.pm
@@ -138,9 +138,9 @@ sub test_autocreate_sieve_script_generation
     my $talk = $store->get_client();
 
     my $sievedir = $self->{instance}->get_sieve_script_dir('foo');
-    $self->assert(-f "$sievedir/foo_sieve.script.script");
-    $self->assert(-f "$sievedir/defaultbc");
-    $self->assert(-f "$sievedir/foo_sieve.script.bc");
+    $self->assert_file_test("$sievedir/foo_sieve.script.script", '-f');
+    $self->assert_file_test("$sievedir/defaultbc", '-f');
+    $self->assert_file_test("$sievedir/foo_sieve.script.bc", '-f');
 }
 
 sub test_autocreate_acl

--- a/cassandane/Cassandane/Cyrus/Delete.pm
+++ b/cassandane/Cassandane/Cyrus/Delete.pm
@@ -448,14 +448,14 @@ EOF
 
     xlog $self, "Verify user data files/directories exist";
     my $data = $self->{instance}->run_mbpath('-u', 'cassandane');
-    $self->assert( -f $data->{user}{'sub'});
-    $self->assert( -f $data->{user}{seen});
-    $self->assert( -f $data->{user}{dav});
-    $self->assert( -f $data->{user}{counters});
-    $self->assert( -f $data->{user}{conversations});
-    $self->assert( -f $data->{user}{xapianactive});
-    $self->assert( -f "$data->{user}{sieve}/defaultbc");
-    $self->assert( -d $data->{xapian}{t1});
+    $self->assert_file_test($data->{user}{'sub'}, '-f');
+    $self->assert_file_test($data->{user}{seen}, '-f');
+    $self->assert_file_test($data->{user}{dav}, '-f');
+    $self->assert_file_test($data->{user}{counters}, '-f');
+    $self->assert_file_test($data->{user}{conversations}, '-f');
+    $self->assert_file_test($data->{user}{xapianactive}, '-f');
+    $self->assert_file_test("$data->{user}{sieve}/defaultbc", '-f');
+    $self->assert_file_test($data->{xapian}{t1}, '-d');
 
     xlog $self, "admin can delete $inbox";
     $admintalk->delete($inbox);
@@ -496,19 +496,19 @@ EOF
         && !$self->{instance}->{config}->get_bool('mailbox_legacy_dirs'))
     {
         # Entire UUID-hashed directory should be removed
-        $self->assert( !-e dirname($data->{user}{dav}));
+        $self->assert_not_file_test(dirname($data->{user}{dav}), '-e');
     }
     else {
         # Name-hashed directory will be left behind, so check individual files
-        $self->assert( !-e $data->{user}{'sub'});
-        $self->assert( !-e $data->{user}{seen});
-        $self->assert( !-e $data->{user}{dav});
-        $self->assert( !-e $data->{user}{counters});
-        $self->assert( !-e $data->{user}{conversations});
-        $self->assert( !-e $data->{user}{xapianactive});
+        $self->assert_not_file_test($data->{user}{'sub'}, '-e');
+        $self->assert_not_file_test($data->{user}{seen}, '-e');
+        $self->assert_not_file_test($data->{user}{dav}, '-e');
+        $self->assert_not_file_test($data->{user}{counters}, '-e');
+        $self->assert_not_file_test($data->{user}{conversations}, '-e');
+        $self->assert_not_file_test($data->{user}{xapianactive}, '-e');
     }
-    $self->assert( !-e $data->{user}{sieve});
-    $self->assert( !-e $data->{xapian}{t1});
+    $self->assert_not_file_test($data->{user}{sieve}, '-e');
+    $self->assert_not_file_test($data->{xapian}{t1}, '-e');
 }
 
 sub test_admin_inbox_del
@@ -697,7 +697,7 @@ sub test_cyr_expire_delete
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0' );
 
     # the folder should not exist now!
-    $self->assert(!-d $datapath);
+    $self->assert_not_file_test($datapath, '-d');
 
     # and not exist from mbpath either...
     $self->assert_null($self->{instance}->folder_to_deleted_directories("user.cassandane.$subfoldername"));
@@ -804,15 +804,15 @@ sub test_cyr_expire_delete_with_annotation
     $self->check_messages(\%msg_inbox);
 
     my ($path) = $self->{instance}->folder_to_deleted_directories("user.cassandane.$subfoldername");
-    $self->assert(-d "$path");
+    $self->assert_file_test($path, '-d');
 
     xlog $self, "Run cyr_expire -D now, it shouldn't delete.";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0' );
-    $self->assert(-d "$path");
+    $self->assert_file_test($path, '-d');
 
     xlog $self, "Run cyr_expire -D now, with -a, skipping annotation.";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0', '-a' );
-    $self->assert(!-d "$path");
+    $self->assert_not_file_test($path, '-d');
 }
 
 # https://github.com/cyrusimap/cyrus-imapd/issues/2413
@@ -857,7 +857,7 @@ sub test_cyr_expire_dont_resurrect_convdb
 
     # expect user has a conversations database
     my $convdbfile = $self->{instance}->get_conf_user_file("cassandane", "conversations");
-    $self->assert(-f $convdbfile);
+    $self->assert_file_test($convdbfile, '-f');
 
     # log cassandane user out before it gets thrown out anyway
     undef $talk;
@@ -868,7 +868,7 @@ sub test_cyr_expire_dont_resurrect_convdb
     $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
 
     # expect user does not have a conversations database
-    $self->assert(!-f $convdbfile);
+    $self->assert_not_file_test($convdbfile, '-f');
     $self->check_folder_not_ondisk($inbox);
     $self->check_folder_ondisk($inbox, deleted => 1);
 
@@ -877,14 +877,14 @@ sub test_cyr_expire_dont_resurrect_convdb
     $self->check_folder_ondisk($inbox, deleted => 1);
 
     # expect user does not have a conversations database
-    $self->assert(!-f $convdbfile);
+    $self->assert_not_file_test($convdbfile, '-f');
 
     xlog $self, "Run cyr_expire -D now.";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0' );
     $self->check_folder_not_ondisk($inbox, deleted => 1);
 
     # expect user does not have a conversations database
-    $self->assert(!-f $convdbfile);
+    $self->assert_not_file_test($convdbfile, '-f');
 }
 
 sub test_no_delete_with_children

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -719,8 +719,8 @@ sub test_rename_deepfolder_intermediates
 
     xlog $self, "Make sure there are no files left with cassandane in the name";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{instance}{basedir}/conf/user/c/cassandane.*"));
-    $self->assert(not -d "$self->{instance}{basedir}/data/c/user/cassandane");
-    $self->assert(not -f "$self->{instance}{basedir}/conf/quota/c/user.cassandane");
+    $self->assert_not_file_test("$self->{instance}{basedir}/data/c/user/cassandane", "-d");
+    $self->assert_not_file_test("$self->{instance}{basedir}/conf/quota/c/user.cassandane", "-f");
 
     # replicate and check the renames
     $self->run_replication(rolling => 1, inputfile => $synclogfname);
@@ -730,8 +730,8 @@ sub test_rename_deepfolder_intermediates
 
     xlog $self, "Make sure there are no files left with cassandane in the name on the replica";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{replica}{basedir}/conf/user/c/cassandane.*"));
-    $self->assert(not -d "$self->{replica}{basedir}/data/c/user/cassandane");
-    $self->assert(not -f "$self->{replica}{basedir}/conf/quota/c/user.cassandane");
+    $self->assert_not_file_test("$self->{replica}{basedir}/data/c/user/cassandane", "-d");
+    $self->assert_not_file_test("$self->{replica}{basedir}/conf/quota/c/user.cassandane", "-f");
 
     xlog $self, "Now clean up all the deleted mailboxes";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0', '-a' );
@@ -1319,8 +1319,8 @@ sub test_rename_deepfolder_intermediates_rightnow
 
     xlog $self, "Make sure there are no files left with cassandane in the name";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{instance}{basedir}/conf/user/c/cassandane.*"));
-    $self->assert(not -d "$self->{instance}{basedir}/data/c/user/cassandane");
-    $self->assert(not -f "$self->{instance}{basedir}/conf/quota/c/user.cassandane");
+    $self->assert_not_file_test("$self->{instance}{basedir}/data/c/user/cassandane", "-d");
+    $self->assert_not_file_test("$self->{instance}{basedir}/conf/quota/c/user.cassandane", "-d");
 
     # replicate and check the renames
     @syslog = $self->{replica}->getsyslog();
@@ -1329,8 +1329,8 @@ sub test_rename_deepfolder_intermediates_rightnow
 
     xlog $self, "Make sure there are no files left with cassandane in the on the replica";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{replica}{basedir}/conf/user/c/cassandane.*"));
-    $self->assert(not -d "$self->{replica}{basedir}/data/c/user/cassandane");
-    $self->assert(not -f "$self->{replica}{basedir}/conf/quota/c/user.cassandane");
+    $self->assert_not_file_test("$self->{replica}{basedir}/data/c/user/cassandane", "-d");
+    $self->assert_not_file_test("$self->{replica}{basedir}/conf/quota/c/user.cassandane", "-f");
 
     xlog $self, "Now clean up all the deleted mailboxes";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0', '-a' );
@@ -1461,7 +1461,7 @@ sub test_cyr_expire_delete_findpaths_legacy
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0' );
 
     # the folder should not exist now!
-    $self->assert(!-d $datapath);
+    $self->assert_not_file_test($datapath, "-d");
 
     # Delete the entire user!
     $admintalk->delete($inbox);
@@ -1536,7 +1536,7 @@ sub test_cyr_expire_delete_findpaths_nolegacy
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0' );
 
     # the folder should not exist now!
-    $self->assert(!-d $datapath);
+    $self->assert_not_file_test($datapath, "-d");
 
     # Delete the entire user!
     $admintalk->delete($inbox);

--- a/cassandane/Cassandane/Cyrus/HTTPPTS.pm
+++ b/cassandane/Cassandane/Cyrus/HTTPPTS.pm
@@ -142,8 +142,8 @@ sub test_alternate_ptscache_db_path
         $admintalk->get_last_completion_response());
 
     my $confdir = $self->{instance}->{basedir} . "/conf";
-    $self->assert(-e $confdir . "/non-default-ptscache.db");
-    $self->assert(not -e $confdir . "/ptclient/ptscache.db");
+    $self->assert_file_test($confdir . "/non-default-ptscache.db");
+    $self->assert_not_file_test($confdir . "/ptclient/ptscache.db");
 }
 
 sub test_setacl_groupid

--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -456,7 +456,7 @@ sub icalfile
     my ($self, $name) = @_;
 
     my $path = abs_path("data/icalendar/$name.ics");
-    $self->assert(-f $path);
+    $self->assert_file_test($path, '-f');
     my $data = slurp_file($path);
 
     my ($id) = ($data =~ m/^UID:(\S+)\r?$/m);

--- a/cassandane/Cassandane/Cyrus/LDAP.pm
+++ b/cassandane/Cassandane/Cyrus/LDAP.pm
@@ -125,8 +125,8 @@ sub test_alternate_ptscache_db_path
         $admintalk->get_last_completion_response());
 
     my $confdir = $self->{instance}->{basedir} . "/conf";
-    $self->assert(-e $confdir . "/non-default-ptscache.db");
-    $self->assert(not -e $confdir . "/ptclient/ptscache.db");
+    $self->assert_file_test($confdir . "/non-default-ptscache.db");
+    $self->assert_not_file_test($confdir . "/ptclient/ptscache.db");
 }
 
 sub test_setacl_groupid

--- a/cassandane/Cassandane/Cyrus/Metadata.pm
+++ b/cassandane/Cassandane/Cyrus/Metadata.pm
@@ -2924,46 +2924,46 @@ sub test_cvt_cyrusdb
     my $format = $self->{instance}->{config}->get('annotation_db');
     $format = $format // 'twoskip';
 
-    $self->assert(( ! -f $global_flat ));
+    $self->assert_not_file_test($global_flat, '-f');
     $self->{instance}->run_command({ cyrus => 1 },
                                    'cvt_cyrusdb',
                                    $global_db, $format,
                                    $global_flat, 'flat');
-    $self->assert(( -f $global_flat ));
+    $self->assert_file_test($global_flat, '-f');
 
     xlog $self, "Convert the mailbox annotation db to flat";
     my $datapath = $self->{instance}->folder_to_directory('user.cassandane');
     my $mailbox_db = "$datapath/cyrus.annotations";
     my $mailbox_flat = "$basedir/xcassann.txt";
 
-    $self->assert(( ! -f $mailbox_flat ));
+    $self->assert_not_file_test($mailbox_flat, '-f');
     $self->{instance}->run_command({ cyrus => 1 },
                                    'cvt_cyrusdb',
                                    $mailbox_db, $format,
                                    $mailbox_flat, 'flat');
-    $self->assert(( -f $mailbox_flat ));
+    $self->assert_file_test($mailbox_flat, '-f');
 
     xlog $self, "Move aside the original annotation dbs";
     rename($global_db, "$global_db.NOT")
         or die "Cannot rename $global_db to $global_db.NOT: $!";
     rename($mailbox_db, "$mailbox_db.NOT")
         or die "Cannot rename $mailbox_db to $mailbox_db.NOT: $!";
-    $self->assert(( ! -f $global_db ));
-    $self->assert(( ! -f $mailbox_db ));
+    $self->assert_not_file_test($global_db, '-f');
+    $self->assert_not_file_test($mailbox_db, '-f');
 
     xlog $self, "restore the global annotation db from flat";
     $self->{instance}->run_command({ cyrus => 1 },
                                    'cvt_cyrusdb',
                                    $global_flat, 'flat',
                                    $global_db, $format);
-    $self->assert(( -f $global_db ));
+    $self->assert_file_test($global_db, '-f');
 
     xlog $self, "restore the mailbox annotation db from flat";
     $self->{instance}->run_command({ cyrus => 1 },
                                    'cvt_cyrusdb',
                                    $mailbox_flat, 'flat',
                                    $mailbox_db, $format);
-    $self->assert(( -f $mailbox_db ));
+    $self->assert_file_test($mailbox_db, '-f');
 
     xlog $self, "Start the instance up again and reconnect";
     $self->{instance}->start();

--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -146,7 +146,7 @@ sub test_reportfile_exists
 
     my $reportfile_name = "$self->{instance}->{basedir}/conf/stats/report.txt";
 
-    $self->assert(-f $reportfile_name);
+    $self->assert_file_test($reportfile_name, '-f');
 
     my $report = parse_report(scalar read_file $reportfile_name);
 
@@ -189,7 +189,7 @@ sub test_disabled
 
     # no stats directory
     my $stats_dir = "$self->{instance}->{basedir}/conf/stats";
-    $self->assert(! -d $stats_dir);
+    $self->assert_not_file_test($stats_dir, '-d');
 
     # no http report
     my $response = $self->http_report();

--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -2642,7 +2642,7 @@ sub test_reconstruct
     xlog $self, "Moving the cyrus.index file out of the way";
     my $datadir = $self->{instance}->folder_to_directory('user.cassandane');
     my $cyrus_index = "$datadir/cyrus.index";
-    $self->assert(( -f $cyrus_index ));
+    $self->assert_file_test($cyrus_index, '-f');
     rename($cyrus_index, $cyrus_index . '.NOT')
         or die "Cannot rename $cyrus_index: $!";
 
@@ -2769,7 +2769,7 @@ sub test_reconstruct_orphans
     xlog $self, "Moving the cyrus.index file out of the way";
     my $datadir = $self->{instance}->folder_to_directory('user.cassandane');
     my $cyrus_index = "$datadir/cyrus.index";
-    $self->assert(( -f $cyrus_index ));
+    $self->assert_file_test($cyrus_index, '-f');
     rename($cyrus_index, $cyrus_index . '.NOT')
         or die "Cannot rename $cyrus_index: $!";
 

--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -1553,7 +1553,7 @@ sub assert_user_sub_exists
 
     xlog $self, "Looking for subscriptions file $subs";
 
-    $self->assert(( -f $subs ));
+    $self->assert_file_test($subs, '-f');
 }
 
 sub assert_user_sub_not_exists
@@ -1564,7 +1564,7 @@ sub assert_user_sub_not_exists
 
     xlog $self, "Looking for subscriptions file $subs";
 
-    $self->assert(( ! -f $subs ));
+    $self->assert_not_file_test($subs, '-f');
 }
 
 sub test_subscriptions
@@ -2338,12 +2338,12 @@ sub test_toarchive
 
     foreach my $id (1..6) {
         if ($id > 3) {
-            $self->assert(-f "$mdatadir/$id.");
-            $self->assert(! -f "$marchivedir/$id.");
+            $self->assert_file_test("$mdatadir/$id.", '-f');
+            $self->assert_not_file_test("$marchivedir/$id.", '-f');
         }
         else {
-            $self->assert(! -f "$mdatadir/$id.");
-            $self->assert(-f "$marchivedir/$id.");
+            $self->assert_not_file_test("$mdatadir/$id.", '-f');
+            $self->assert_file_test("$marchivedir/$id.", '-f');
         }
     }
 
@@ -2380,12 +2380,12 @@ sub test_toarchive
 
     foreach my $id (1..6) {
         if ($id > 3) {
-            $self->assert(-f "$rdatadir/$id.");
-            $self->assert(! -f "$rarchivedir/$id.");
+            $self->assert_file_test("$rdatadir/$id.", '-f');
+            $self->assert_not_file_test("$rarchivedir/$id.", '-f');
         }
         else {
-            $self->assert(! -f "$rdatadir/$id.");
-            $self->assert(-f "$rarchivedir/$id.");
+            $self->assert_not_file_test("$rdatadir/$id.", '-f');
+            $self->assert_file_test("$rarchivedir/$id.", '-f');
         }
     }
 }
@@ -2441,7 +2441,7 @@ sub test_toarchive_noarchive
 
     # all messages in same place
     foreach my $id (1..6) {
-        $self->assert(-f "$mdatadir/$id.");
+        $self->assert_file_test("$mdatadir/$id.", '-f');
     }
 
     $self->{replica}->getsyslog(); # discard setup noise
@@ -2480,11 +2480,11 @@ sub test_toarchive_noarchive
 
     # all messages in same place
     foreach my $id (1..6) {
-        $self->assert(-f "$rdatadir/$id.");
+        $self->assert_file_test("$rdatadir/$id.", '-f');
     }
 
     foreach my $id (1..6) {
-        $self->assert(-f "$rdatadir/$id.");
+        $self->assert_file_test("$rdatadir/$id.", '-f');
     }
 }
 

--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -151,9 +151,9 @@ sub compile_sievec
 
     xlog $self, "Checking preconditions for compiling sieve script $name";
 
-    $self->assert(( ! -f "$basedir/$name.script" ));
-    $self->assert(( ! -f "$basedir/$name.bc" ));
-    $self->assert(( ! -f "$basedir/$name.errors" ));
+    $self->assert_not_file_test("$basedir/$name.script", '-f');
+    $self->assert_not_file_test("$basedir/$name.bc", '-f');
+    $self->assert_not_file_test("$basedir/$name.errors", '-f');
 
     open(FH, '>', "$basedir/$name.script")
         or die "Cannot open $basedir/$name.script for writing: $!";
@@ -178,14 +178,14 @@ sub compile_sievec
     if ($result eq 'success')
     {
         xlog $self, "Checking that sievec wrote the output .bc file";
-        $self->assert(( -f "$basedir/$name.bc" ));
+        $self->assert_file_test("$basedir/$name.bc", '-f');
         xlog $self, "Checking that sievec didn't write anything to stderr";
         $self->assert_equals(0, scalar(@errors));
     }
     elsif ($result eq 'failure')
     {
         xlog $self, "Checking that sievec didn't write the output .bc file";
-        $self->assert(( ! -f "$basedir/$name.bc" ));
+        $self->assert_not_file_test("$basedir/$name.bc", '-f');
     }
 
     return ($result, join("\n", @errors));
@@ -202,8 +202,8 @@ sub compile_timsieved
 
     xlog $self, "Checking preconditions for compiling sieve script $name";
 
-    $self->assert(( ! -f "$basedir/$name.script" ));
-    $self->assert(( ! -f "$basedir/$name.errors" ));
+    $self->assert_not_file_test("$basedir/$name.script", '-f');
+    $self->assert_not_file_test("$basedir/$name.errors", '-f');
 
     open(FH, '>', "$basedir/$name.script")
         or die "Cannot open $basedir/$name.script for writing: $!";
@@ -3652,7 +3652,7 @@ EOF
     $instance->deliver($msg1);
 
     xlog "Assert that extractor did NOT get called";
-    $self->assert(not -e $filename);
+    $self->assert_not_file_test($filename);
 
     xlog "Assert that message got moved into INBOX.matches";
     $self->{store}->set_folder('INBOX.matches');

--- a/cassandane/Cassandane/Test/Core.pm
+++ b/cassandane/Cassandane/Test/Core.pm
@@ -99,7 +99,7 @@ sub _test_core_files_with_size
     if (not -f $core) {
         $core = "$instance->{basedir}/conf/cores/core";
     }
-    $self->assert(-f $core);
+    $self->assert_file_test($core, '-f');
     my $size = -s $core;
 
     # clean up the core we expected, so we don't barf on it existing!

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -390,7 +390,35 @@ sub assert_date_matches
     $self->assert((abs($diff) <= $tolerance), $msg);
 }
 
-sub new_test_url {
+sub assert_file_test
+{
+    my ($self, $path, $test_type) = @_;
+
+    # see `perldoc -f -X` for valid test types
+    $test_type ||= '-e';
+    my $test = "$test_type \$path";
+    xlog "XXX test=<$test> path=<$path>";
+    my $result = eval $test;
+    die $@ if $@;
+    $self->assert($result, "'$path' failed '$test_type' test");
+}
+
+sub assert_not_file_test
+{
+    my ($self, $path, $test_type) = @_;
+
+    # see `perldoc -f -X` for valid test types
+    $test_type ||= '-e';
+    my $test = "$test_type \$path";
+    xlog "XXX test=<$test> path=<$path>";
+    my $result = eval $test;
+    die $@ if $@;
+    $self->assert(!$result,
+                  "'$path' unexpectedly passed '$test_type' test");
+}
+
+sub new_test_url
+{
     my ($self, $content_or_app) = @_;
 
     return Cassandane::Util::TestURL->new({


### PR DESCRIPTION
This adds two new assertion functions to Cassandane: `assert_file_test()` and `assert_not_file_test()`, for assertions based on the `perldoc -f -X` filename tests (i.e. `-e`, `-f`, `-x`, etc) with helpful messages, and then updates a bunch of our tests to use them.

There's a handful of tests that consistently fail when the local month is different from the UTC month, and some of those were using bare file test assertions without descriptive messages, making it hard to track down the cause of the failures.  This PR makes it so those tests will fail with better messages, so that next time I might finally be able to track down and fix whatever is actually causing the failure.

I started working on the test failures as #4500, but this chunk stands on its own, so I'm splitting it out to get it landed early.