### PR TITLE
fix cass local month race bug

### DIFF
--- a/cassandane/Cassandane/Message.pm
+++ b/cassandane/Cassandane/Message.pm
@@ -42,13 +42,12 @@ use strict;
 use warnings;
 use base qw(Clone Exporter);
 use overload qw("") => \&as_string;
+use Math::Int64;
 
 use lib '.';
 use Cassandane::Util::Log;
 use Cassandane::Util::DateTime qw(to_rfc3501);
 use Cassandane::Util::SHA;
-
-use Math::Int64;
 
 our @EXPORT = qw(base_subject);
 

--- a/cassandane/Cassandane/Test/DateTime.pm
+++ b/cassandane/Cassandane/Test/DateTime.pm
@@ -64,4 +64,52 @@ sub test_basic
     $self->assert_str_equals('15-Oct-2010 03:19:52 +1100', to_rfc3501(DateTime->from_epoch(epoch => 1287073192)));
 }
 
+sub test_localtime_month_ahead_of_utc
+{
+    my ($self) = @_;
+
+    # early morning 2023-09-01 UTC+10
+    #  late evening 2023-08-31 UTC
+    my $dt = DateTime->new(
+        year => 2023,
+        month => 9,
+        day => 1,
+        hour => 9,
+        minute => 30,
+        second => 0,
+        time_zone => 'Australia/Sydney',
+    );
+    $dt->set_time_zone('Etc/UTC');
+
+    local $ENV{TZ} = 'Australia/Sydney';
+    $self->assert_str_equals('Fri, 01 Sep 2023 09:30:00 +1000',
+                             to_rfc822($dt));
+    $self->assert_str_equals(' 1-Sep-2023 09:30:00 +1000',
+                             to_rfc3501($dt));
+}
+
+sub test_localtime_month_behind_utc
+{
+    my ($self) = @_;
+
+    #  late evening 2023-08-31 UTC-4
+    # early morning 2023-09-01 UTC
+    my $dt = DateTime->new(
+        year => 2023,
+        month => 8,
+        day => 31,
+        hour => 22,
+        minute => 30,
+        second => 0,
+        time_zone => 'America/New_York',
+    );
+    $dt->set_time_zone('Etc/UTC');
+
+    local $ENV{TZ} = 'America/New_York';
+    $self->assert_str_equals('Thu, 31 Aug 2023 22:30:00 -0400',
+                             to_rfc822($dt));
+    $self->assert_str_equals('31-Aug-2023 22:30:00 -0400',
+                             to_rfc3501($dt));
+}
+
 1;

--- a/cassandane/Cassandane/Util/DateTime.pm
+++ b/cassandane/Cassandane/Util/DateTime.pm
@@ -250,7 +250,12 @@ sub from_rfc3501($)
 sub to_rfc3501($)
 {
     my ($dt) = @_;
-    return strftime("%e-" . $rfc822_months[$dt->month -1] . "-%Y %T %z", localtime($dt->epoch));
+
+    my @lt = localtime($dt->epoch);
+    return strftime("%e-"
+                    . $rfc822_months[$lt[4]]
+                    . "-%Y %T %z",
+                    @lt);
 }
 
 1;


### PR DESCRIPTION
Continuation of #4500 which github has become confused about

This fixes a bug whereby if you ran Cassandane when your local time month differed from the UTC month, a bunch of tests would fail due to expected timestamps not matching actual timestamps.  That is, if your local time is ahead of UTC, these tests would fail early in the morning on the first day of the month.  If your local time is behind UTC, it would be late at night on the last day of a the month.

This mostly only affected me, since my local TZ is far enough from UTC that the affected window overlaps my usual work hours.

Turns out the bug was in Cassandane's own `to_rfc3501()` function.  It looks like `to_rfc822()` was once afflicted by a similar bug, which was fixed a long time ago, but `to_rfc3501()` was overlooked at the time.  I've fixed `to_rfc3501()`, and added internal regression tests in both before/after timezones, for both functions.

There was an affected window this morning (1st day of month, before my local 10am), in which I tested both master and this PR branch, and verified for sure that a) master is still broken, and b) this PR fixes it.  (Though the new regression tests already proved it's fixed.)