### PR TITLE
configure.ac: detect xxd, error if needed and missing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1457,12 +1457,14 @@ imap_unexpunge_LDADD = $(LD_UTILITY_ADD)
 %_err.h %_err.c: %_err.et $(COMPILE_ET_DEP)
 	$(AM_V_GEN)(cd $(@D) && $(COMPILE_ET) $(realpath $<))
 
+if HAVE_XXD
 # xxd cannot have path details in its input filename, otherwise it junks up
 # the variable names in the output file.  so do a tricky directory change.
 # the /dev/null redirection on cd is to prevent shell environments with
 # CDPATH echoing the path change on stdout and consequently into the .h file
 %_js.h: %.js
-	$(AM_V_GEN)(cd $(<D) > /dev/null && xxd -i $(<F)) > $@.NEW && mv $@.NEW $@
+	$(AM_V_GEN)(cd $(<D) > /dev/null && $(XXD) -i $(<F)) > $@.NEW && mv $@.NEW $@
+endif
 
 if MAINTAINER_MODE
 imap/rfc822_header.c: imap/rfc822_header.st

--- a/configure.ac
+++ b/configure.ac
@@ -1601,6 +1601,13 @@ if test "x$enable_murder" = "xyes"; then
 fi
 
 dnl
+dnl See if we have an xxd available
+dnl
+AC_ARG_VAR([XXD], [Location of xxd])
+AC_PATH_PROG([XXD],[xxd])
+AM_CONDITIONAL([HAVE_XXD], [test -n "$XXD"])
+
+dnl
 dnl see if we're compiling with HTTP support
 dnl
 AC_ARG_ENABLE(http,
@@ -1619,6 +1626,8 @@ dnl
             use_sqlite="yes"
             AC_DEFINE(WITH_DAV,[],[Build *DAV support into httpd?])
         fi
+
+        AS_IF([test -z "$XXD"], [AC_MSG_ERROR([Need xxd for http])])
 
         PKG_CHECK_MODULES([XML2], [libxml-2.0], [
                 AC_DEFINE(HAVE_XML2, [], [Build with libxml support])
@@ -2588,4 +2597,5 @@ Build info:
    ldflags:            $LDFLAGS
    libm:               $LIBM
    unit tests (cunit): $enable_unit_tests
+   xxd:                $XXD
 "

--- a/docsrc/imap/developer/compiling.rst
+++ b/docsrc/imap/developer/compiling.rst
@@ -97,8 +97,6 @@ and included in the release, and do not normally need to be re-built.
     doc/legacy/netnews.png). One day it should be merged into the current
     documentation, cause then we can get rid of it: `issues/1769`_."
     `valgrind`_, valgrind, valgrind, "no", "Performance and memory testing."
-    `xxd`_,vim-common,vim-common, "no", "Needed for the _js.h files, for CalDAV
-    and CardDAV support."
 
 SASL Authentication
 ###################
@@ -162,6 +160,8 @@ CalDAV, CardDAV, or JMAP (httpd subsystem)
     `wslay`_, libwslay-dev, wslay-devel, "no", "It provides WebSockets support
     in httpd. Only used with **JMAP**, otherwise not needed. Version 1.1.1 or
     higher is required when using it."
+    `xxd`_, xxd, vim-common, "yes", "Needed for the _js.h files, for CalDAV
+    and CardDAV support."
     `zlib`_, zlib1g-dev, zlib-devel, "no", "It provides gzip compression
     support for http communications."
 


### PR DESCRIPTION
We weren't checking whether `xxd` existed, just crossing our fingers and hoping.  If it wasn't available, `configure` would still succeed, but then `make` would fail.  This PR fixes that.

The files we produce with xxd are included pre-generated in our release tarballs, so someone building from a release tarball could have technically not required xxd (as long as they didn't do anything that would cause those files to need to be rebuilt).  I initially tried a more complicated implementation so that such people wouldn't be forced to install xxd, but it was messy and didn't offer much real improvement, so I stripped it back out again.  It's not a difficult dependency to meet.