### PR TITLE
Fix IMAP SCAN on selected mailbox crasher

### DIFF
--- a/cassandane/Cassandane/Cyrus/List.pm
+++ b/cassandane/Cassandane/Cyrus/List.pm
@@ -2343,7 +2343,6 @@ sub test_scan
 
     xlog $self, "listing...";
     my $res = $imaptalk->list("", "*");
-warn Dumper($res);
 
     $self->assert_mailbox_structure($res, '.', {
         'INBOX'      => [qw( \\HasChildren )],

--- a/cassandane/Cassandane/Cyrus/List.pm
+++ b/cassandane/Cassandane/Cyrus/List.pm
@@ -2329,4 +2329,55 @@ sub test_list_return_subscribed_trash_nochildren
     });
 }
 
+sub test_scan
+    :min_version_3_9
+{
+    my ($self) = @_;
+
+    my $store = $self->{store};
+    my $imaptalk = $store->get_client();
+
+    $self->setup_mailbox_structure($imaptalk, [
+        [ 'create' => [qw( INBOX.a INBOX.b INBOX.c )] ],
+    ]);
+
+    xlog $self, "listing...";
+    my $res = $imaptalk->list("", "*");
+warn Dumper($res);
+
+    $self->assert_mailbox_structure($res, '.', {
+        'INBOX'      => [qw( \\HasChildren )],
+        'INBOX.a'    => [qw( \\HasNoChildren )],
+        'INBOX.b'    => [qw( \\HasNoChildren )],
+        'INBOX.c'    => [qw( \\HasNoChildren )],
+    }, 'strict');
+
+    xlog $self, "Generate some messages";
+    $store->set_folder('INBOX.a');
+    $self->make_message("foo");
+
+    $store->set_folder('INBOX.b');
+    $self->make_message("bar");
+
+    $store->set_folder('INBOX.c');
+    $self->make_message("baz", body => 'foo\r\n');
+
+    my @results = {};
+    xlog $self, "scan with a selected mailbox";
+    $res = $imaptalk->_imap_cmd('SCAN', 0, "list", "", "*", "foo");
+
+    $self->assert_mailbox_structure($res, '.', {
+        'INBOX.a'    => [qw( \\HasNoChildren )],
+        'INBOX.c'    => [qw( \\HasNoChildren )],
+    }, 'strict');
+
+    xlog $self, "scan with NO selected mailbox";
+    $res = $imaptalk->unselect();
+    $res = $imaptalk->_imap_cmd('SCAN', 0, "list", "", "*", "bar");
+
+    $self->assert_mailbox_structure($res, '.', {
+        'INBOX.b'    => [qw( \\HasNoChildren )],
+    }, 'strict');
+}
+
 1;

--- a/imap/index.c
+++ b/imap/index.c
@@ -1772,9 +1772,6 @@ EXPORTED int index_scan(struct index_state *state, const char *contents)
 
     if (!(contents && contents[0])) return(0);
 
-    if (index_check(state, 0))
-        return 0;
-
     if (state->exists <= 0) return 0;
 
     length = strlen(contents);

--- a/imap/index.c
+++ b/imap/index.c
@@ -1760,19 +1760,21 @@ static int index_scan_work(const char *s, unsigned long len,
  */
 EXPORTED int index_scan(struct index_state *state, const char *contents)
 {
-    unsigned *msgno_list;
+    unsigned *msgno_list = NULL;
     uint32_t msgno;
     int n = 0;
     int listindex;
     int listcount;
-    struct searchargs searchargs;
+    struct searchargs searchargs = {0};
     unsigned long length;
     struct mailbox *mailbox = state->mailbox;
     charset_t ascii = charset_lookupname("US-ASCII");
 
-    if (!(contents && contents[0])) return(0);
+    if (!(contents && contents[0]))
+        goto done;
 
-    if (state->exists <= 0) return 0;
+    if (state->exists <= 0)
+        goto done;
 
     length = strlen(contents);
 
@@ -1808,6 +1810,7 @@ EXPORTED int index_scan(struct index_state *state, const char *contents)
         buf_free(&buf);
     }
 
+done:
     charset_free(&ascii);
     search_expr_free(searchargs.root);
     free(msgno_list);


### PR DESCRIPTION
imapd.c: needs an open mailbox for index_scan(), imapd_index is released before every command is parsed, so we need to reopen the mailbox