### PR TITLE
doc generation: stop using custom manpage builder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1978,7 +1978,7 @@ clean-docsrc:
 
 ## XXX doesn't detect if other rst sources are updated...
 man/.sphinx-build.stamp: docsrc/.sphinx-build.stamp
-	$(AM_V_GEN)DOCSRC=$(top_builddir)/docsrc $(SPHINX_BUILD) $(SPHINX_OPTS) -b cyrman $(top_builddir)/docsrc $(top_builddir)/man
+	$(AM_V_GEN)DOCSRC=$(top_builddir)/docsrc $(SPHINX_BUILD) $(SPHINX_OPTS) -b man $(top_builddir)/docsrc $(top_builddir)/man
 	@touch $@
 
 clean-man:

--- a/docsrc/make.bat
+++ b/docsrc/make.bat
@@ -176,7 +176,7 @@ if "%1" == "text" (
 )
 
 if "%1" == "man" (
-	%SPHINXBUILD% -b cyrman %ALLSPHINXOPTS% %BUILDDIR%/man
+	%SPHINXBUILD% -b man %ALLSPHINXOPTS% %BUILDDIR%/man
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Build finished. The manual pages are in %BUILDDIR%/man.


### PR DESCRIPTION
Why is the current one broken with newer libraries?

I don't know!  But we also no longer know why we had a customer builder, either.  At first glance, the output without the custom code seems fine. We should inspect it more, and then we can decide if we can go forward with this and also delete the custom code!