### PR TITLE
better cyrusdb / ctl_cyrusdb -r UX

### DIFF
--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -319,4 +319,45 @@ sub test_recover_create_missing_uniqueid_legacymb
     $self->assert_str_equals("user\x1fcassandane", $hash->{N});
 }
 
+sub test_recover_skipstamp
+{
+    my ($self) = @_;
+
+    my $dbdir = $self->{instance}->get_basedir() . "/conf/db";
+
+    # no 'ctl_cyrusdb -r' on startup
+    $self->{instance}->remove_start('recover');
+    $self->{instance}->start();
+
+    # expect skipstamp file to be missing
+    $self->assert_not_file_test("$dbdir/skipstamp", '-e');
+
+    # cyrus processes will whinge about missing skipstamp file
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my $syslog = join "\n", $self->{instance}->getsyslog();
+        $self->assert_matches(qr/skipstamp is missing/, $syslog);
+        $self->assert_matches(qr/DBERROR: skipstamp/, $syslog);
+    }
+
+    # shut down, enable recover, and restart
+    $self->{instance}->stop();
+    # n.b. no "re_use_dir" here, because we need cyrus.conf regenerated
+    $self->{instance}->add_recover();
+    $self->{instance}->start();
+
+    # skipstamp file should be present now
+    $self->assert_file_test("$dbdir/skipstamp", '-e');
+
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my $syslog = join "\n", $self->{instance}->getsyslog();
+
+        # recover should have logged itself updating skipstamp
+        $self->assert_matches(qr/updating recovery stamp/, $syslog);
+
+        # cyrus processes should not whinge about missing skipstamp file
+        $self->assert_does_not_match(qr/skipstamp is missing/, $syslog);
+        $self->assert_does_not_match(qr/DBERROR: skipstamp/, $syslog);
+    }
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -360,4 +360,85 @@ sub test_recover_skipstamp
     }
 }
 
+sub create_empty_file
+{
+    my ($fname) = @_;
+
+    open my $fh, '>', $fname
+        or die "create_empty_file($fname): $!";
+    close $fh;
+}
+
+sub test_recover_skipcleanshutdown
+{
+    my ($self) = @_;
+
+    my $dbdir = $self->{instance}->get_basedir() . "/conf/db";
+
+    # need to start up once to create a reusable basedir
+    $self->{instance}->start();
+    $self->{instance}->stop();
+    $self->{instance}->{re_use_dir} = 1;
+
+    # act like we were previously shut down cleanly by some rc script,
+    # but without a skipstamp somehow
+    create_empty_file("$dbdir/skipcleanshutdown");
+    unlink "$dbdir/skipstamp";
+    $self->assert_not_file_test("$dbdir/skipstamp", '-e');
+
+    # start 'er up
+    $self->{instance}->start();
+
+    # recover should have created a skipstamp file, despite skipcleanshutdown
+    $self->assert_file_test("$dbdir/skipstamp", '-e');
+    my $prev_skipstamp_mtime = (stat "$dbdir/skipstamp")[9];
+
+    # and skipcleanshutdown should have been removed
+    $self->assert_not_file_test("$dbdir/skipcleanshutdown", '-e');
+
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my $syslog = join "\n", $self->{instance}->getsyslog();
+
+        # recover should not claim this was a normal start
+        $self->assert_does_not_match(qr/starting normally/, $syslog);
+
+        # recover should have logged itself updating skipstamp
+        $self->assert_matches(qr/updating recovery stamp/, $syslog);
+
+        # cyrus processes should not whinge about missing skipstamp file
+        $self->assert_does_not_match(qr/skipstamp is missing/, $syslog);
+        $self->assert_does_not_match(qr/DBERROR: skipstamp/, $syslog);
+    }
+
+    # shut down "cleanly" again, but this time leaving skipstamp alone
+    $self->{instance}->stop();
+    $self->{instance}->{re_use_dir} = 1;
+    create_empty_file("$dbdir/skipcleanshutdown");
+
+    # restart
+    $self->{instance}->start();
+
+    # skipstamp file should be present and unmodified since previous run
+    $self->assert_file_test("$dbdir/skipstamp", '-e');
+    my $skipstamp_mtime = (stat "$dbdir/skipstamp")[9];
+    $self->assert_num_equals($prev_skipstamp_mtime, $skipstamp_mtime);
+
+    # and skipcleanshutdown should have been removed
+    $self->assert_not_file_test("$dbdir/skipcleanshutdown", '-e');
+
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my $syslog = join "\n", $self->{instance}->getsyslog();
+
+        # recover should claim this was a normal start
+        $self->assert_matches(qr/starting normally/, $syslog);
+
+        # recover should not have updated skipstamp
+        $self->assert_does_not_match(qr/updating recovery stamp/, $syslog);
+
+        # cyrus processes should not whinge about missing skipstamp file
+        $self->assert_does_not_match(qr/skipstamp is missing/, $syslog);
+        $self->assert_does_not_match(qr/DBERROR: skipstamp/, $syslog);
+    }
+}
+
 1;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -425,11 +425,7 @@ sub add_service
     # Add a hardcoded recover START if we're doing an actual IMAP test.
     if ($name =~ m/imap/)
     {
-        if (!grep { $_->{name} eq 'recover'; } @{$self->{starts}})
-        {
-            $self->add_start(name => 'recover',
-                             argv => [ qw(ctl_cyrusdb -r) ]);
-        }
+        $self->add_recover();
     }
 
     my $srv = Cassandane::ServiceFactory->create(instance => $self, %params);
@@ -459,6 +455,23 @@ sub add_start
 {
     my ($self, %params) = @_;
     push(@{$self->{starts}}, Cassandane::MasterStart->new(%params));
+}
+
+sub remove_start
+{
+    my ($self, $name) = @_;
+    $self->{starts} = [ grep { $_->{name} ne $name } @{$self->{starts}} ];
+}
+
+sub add_recover
+{
+    my ($self) = @_;
+
+    if (!grep { $_->{name} eq 'recover'; } @{$self->{starts}})
+    {
+        $self->add_start(name => 'recover',
+                         argv => [ qw(ctl_cyrusdb -r) ]);
+    }
 }
 
 sub add_event

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -663,7 +663,6 @@ sub _build_skeleton
         'conf',
         'conf/certs',
         'conf/cores',
-        'conf/db',
         'conf/sieve',
         'conf/socket',
         'conf/proc',

--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -1579,7 +1579,6 @@ static int set_up(void)
 {
     char buf[PATH_MAX];
     static const char * const reldirs[] = {
-        "db",
         "conf",
         "conf/lock/",
         "conf/lock/user",

--- a/lib/cyrusdb.c
+++ b/lib/cyrusdb.c
@@ -396,9 +396,16 @@ EXPORTED void cyrusdb_init(void)
     char dbdir[1024];
     const char *confdir = libcyrus_config_getstring(CYRUSOPT_CONFIG_DIR);
     int initflags = libcyrus_config_getint(CYRUSOPT_DB_INIT_FLAGS);
+    struct stat statbuf;
 
     strcpy(dbdir, confdir);
     strcat(dbdir, FNAME_DBDIR);
+
+    if (stat(dbdir, &statbuf)) {
+        char *path = strconcat(dbdir, "/dummy", NULL);
+        cyrus_mkdir(path, 0755 /* n.b. mode is unused */);
+        free(path);
+    }
 
     for (i=0; _backends[i]; i++) {
         r = (_backends[i])->init(dbdir, initflags);

--- a/lib/cyrusdb_skiplist.c
+++ b/lib/cyrusdb_skiplist.c
@@ -230,14 +230,21 @@ static int myinit(const char *dbdir, int myflags)
         struct stat sbuf;
         char cleanfile[1024];
 
+        /* n.b. nothing in cyrus creates this file, but presumably some
+         * init.d or systemd script does
+         */
         snprintf(cleanfile, sizeof(cleanfile), "%s/skipcleanshutdown", dbdir);
 
         /* if we had a clean shutdown, we don't need to run recovery on
-         * everything */
+         * everything, unless we've never previously run it */
         if (stat(cleanfile, &sbuf) == 0) {
-            syslog(LOG_NOTICE, "skiplist: clean shutdown detected, starting normally");
             xunlink(cleanfile);
-            goto normal;
+
+            if (stat(sfile, &sbuf) == 0) {
+                syslog(LOG_NOTICE, "skiplist: clean shutdown detected,"
+                                   " starting normally");
+                goto normal;
+            }
         }
 
         syslog(LOG_NOTICE, "skiplist: clean shutdown file missing, updating recovery stamp");


### PR DESCRIPTION
**Reviewers:** this has grown into a collection of small related things rather than a single thing.  Probably easiest to review commit-by-commit.

If `ctl_cyrusdb -r` was not run during Cyrus startup (or failed in a particular way, see further on), then your logs will be full of errors like this from every single Cyrus process:

> DBERROR: read failed, assuming the worst: filename=</path/to/confdir/db/skipstamp> [...]

Would you be able to guess from that that the problem was that you'd forgotten to add `ctl_cyrusdb -r` to your cyrus.conf START section?  Me either!

This PR adjusts the logging such that if the reason the skipstamp file is unreadable is that it doesn't exist, then an informational message is also logged advising the need for `ctl_cyrusdb -r`.  I've kept the new log message concise, but hopefully mentioning ctl_cyrusdb is enough to prompt someone to read the man page and learn that they need to add it to their startup.  I've also tidied up the errno handling so as to not leak noise into xsyslog later.

I've also added a test that confirms the behaviour, and logging about, the missing skipstamp file.  Next time someone asks about these errors, it'll be easy to see from the test how it's supposed to work, rather than needing to read the source.

I've also updated the handling of the "skipcleanshutdown" file.  When this file is present,  `ctl_cyrusdb -r` did not regenerate the skipstamp file -- which, if it somehow didn't already exist, could lead to it never being created.  It now also checks for the existence of the skipstamp file, and if it's missing, then skipcleanshutdown is ignored and skipstamp is regenerated as usual.  And there's a new test for this behaviour too.

In the end, it turned out the person complaining about all the "assuming the worst" errors had forgotten or not realised that they need to manually create configdir/db when provisioning a system (and so had I, and the log line that reports the missing directory only happens once when `ctl_cyrusdb -r` runs at startup, and is drowned out by the spew of "assuming the worst" errors).  Manually creating this directory seems like a ridiculous requirement when a computer could do such a trivial task itself, so I've made cyrusdb just create the damn directory itself if it's missing, and made Cassandane and cunit _not_ pre-create it (so if cyrusdb ever starts failing to create it, lots of tests will fail due to syslog errors from it not being there).