### PR TITLE
make 'check' etc fail on cunit valgrind errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -702,7 +702,11 @@ cunit/registers.h: $(CUNIT_PROJECT)
 	$(AM_V_GEN)$(CUNIT_PL) --generate-register-function $@
 
 # To run under Valgrind, do: make VG=1 check
-VALGRIND = libtool --mode=execute valgrind --tool=memcheck --leak-check=full --suppressions=vg.supp
+VALGRIND = libtool --mode=execute valgrind \
+            --tool=memcheck \
+            --leak-check=full \
+            --suppressions=vg.supp \
+            --error-exitcode=75
 
 check-local:
 	@echo "Running unit tests"
@@ -729,7 +733,7 @@ check-local:
 check-discrete: cunit/unit
 	@echo "Running unit tests, one at a time"
 	@vg= ; \
-		test -z "$$VG" || vg="$(VALGRIND) --quiet --error-exitcode=75 --log-fd=3" ; \
+		test -z "$$VG" || vg="$(VALGRIND) --quiet --log-fd=3" ; \
 		cd cunit ; \
 		fails=0 ; \
 		tests=0 ; \

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -2151,6 +2151,8 @@ static void test_canon_value(void)
         ealist = NULL;
     }
 
+    buf_free(&val);
+
     annotate_state_abort(&astate);
     mailbox_close(&mailbox);
     annotatemore_close();

--- a/cunit/strarray.testc
+++ b/cunit/strarray.testc
@@ -1726,6 +1726,8 @@ static void test_appendv(void)
     s = strarray_appendv(&sa, "ipsum");
     CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 1));
     CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+
+    strarray_fini(&sa);
 }
 
 static void test_addv(void)
@@ -1744,6 +1746,8 @@ static void test_addv(void)
     s = strarray_addv(&sa, "lorem");
     CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 0));
     CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+
+    strarray_fini(&sa);
 }
 
 static void test_add_casev(void)
@@ -1762,6 +1766,8 @@ static void test_add_casev(void)
     s = strarray_add_casev(&sa, "lOREm");
     CU_ASSERT_PTR_EQUAL(s, strarray_nth(&sa, 0));
     CU_ASSERT_EQUAL(strarray_size(&sa), 2);
+
+    strarray_fini(&sa);
 }
 
 /* vim: set ft=c: */


### PR DESCRIPTION
This makes it so that cunit-under-valgrind will fail if valgrind detects memory errors, instead of reporting the valgrind errors to the terminal but still succeeding.  This will be more useful for automated testing.
    
Specifically, this affects the following make targets:
* check
* check-local
* check-%
    
The check-discrete make target already behaved like this, and is no longer a special case.

Also fixes a few memory leaks that had snuck into our unit tests since last time I looked at them.

**Reviewers**: to test this, run `make VG=1 check` after introducing a memory leak somewhere (such as by temporarily reverting one of the testc fixes on this branch).  Expect `echo $?` to be non-zero afterwards.  For comparison, the same on the master branch would report the leak, but `echo $?` would be zero.