### PR TITLE
3.6 ctl_mboxlist don't free static data 

### DIFF
--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -993,8 +993,6 @@ static void add_part(ptrarray_t *found,
             /* found it */
             if (override) {
                 /* replace the path with the one containing cyrus.header */
-                if (entry->path)
-                    free(entry->path);
                 strcpy(entry->path, path);
             }
 


### PR DESCRIPTION
backport of 3be3f16999d724b44c1f009f2eb9c3fe06458825