### PR TITLE
lib/auth_krb.c: there is no HAVE_BDB

### DIFF
--- a/lib/auth_krb.c
+++ b/lib/auth_krb.c
@@ -57,16 +57,7 @@
 #include <sys/types.h>
 
 #include <krb.h>
-#ifdef HAVE_BDB
-#ifdef HAVE_DB_185_H
-#include <db_185.h>
-#else
-#include <db.h>
-#endif
-#else
 #include <ndbm.h>
-#endif
-#include <krb.h>
 
 #ifndef KRB_MAPNAME
 #define KRB_MAPNAME (SYSCONF_DIR "/krb.equiv")


### PR DESCRIPTION
since 808c31614512a.