### PR TITLE
jmap_contact_from_vcard() tautology with strarray_safenth()

### DIFF
--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1663,11 +1663,11 @@ static json_t *jmap_contact_from_vcard(const char *userid,
             buf_reset(&buf);
             if (*pobox) {
                 buf_appendcstr(&buf, pobox);
-                if (extended || street) buf_putc(&buf, '\n');
+                if (*extended || *street) buf_putc(&buf, '\n');
             }
             if (*extended) {
                 buf_appendcstr(&buf, extended);
-                if (street) buf_putc(&buf, '\n');
+                if (*street) buf_putc(&buf, '\n');
             }
             if (*street) {
                 buf_appendcstr(&buf, street);

--- a/lib/strarray.h
+++ b/lib/strarray.h
@@ -79,7 +79,7 @@ char *strarray_remove(strarray_t *, int idx);
 void strarray_remove_all(strarray_t *sa, const char *s);
 void strarray_remove_all_case(strarray_t *sa, const char *s);
 const char *strarray_nth(const strarray_t *sa, int idx);
-const char *strarray_safenth(const strarray_t *sa, int idx);
+__attribute__((nonnull(1), returns_nonnull)) const char *strarray_safenth(const strarray_t *sa, int idx);
 void strarray_truncate(strarray_t *sa, int newlen);
 strarray_t *strarray_dup(const strarray_t *);
 void strarray_cat(strarray_t *dest, const strarray_t *src);


### PR DESCRIPTION
strarray_safenth() cannot return NULL.

The change here presents the intended logic.

Affected are 3.8, 3.6, 3.4 and 3.2 branches.