### PR TITLE
3.6 lmtp_sieve: fix use of uninitialized variable

### DIFF
--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1414,6 +1414,7 @@ static int sieve_imip(void *ac, void *ic, void *sc, void *mc,
     const char *originator = NULL, *recipient = NULL;
     strarray_t sched_addresses = STRARRAY_INITIALIZER;
     unsigned sched_flags = 0;
+    struct bodypart **parts = NULL;
     int ret = 0;
 
     prometheus_increment(CYRUS_LMTP_SIEVE_IMIP_TOTAL);
@@ -1438,7 +1439,6 @@ static int sieve_imip(void *ac, void *ic, void *sc, void *mc,
 
     /* XXX currently struct bodypart as defined in message.h is the same as
        sieve_bodypart_t as defined in sieve_interface.h, so we can typecast */
-    struct bodypart **parts = NULL;
     const char *content_types[] = { "text/calendar", NULL };
     message_fetch_part(mydata->content, content_types, &parts);
     if (parts && parts[0]) {


### PR DESCRIPTION
Signed-off-by: Robert Stepanek <rsto@fastmailteam.com>

backport of 18bd7d23e7456a57e8db14ac1ecde40ada7e033d