### PR TITLE
conversations: sort thread by createdmodseq if same internaldate

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_get_createdmodseq
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_createdmodseq
@@ -1,0 +1,51 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_createdmodseq
+    :min_version_3_9 :needs_component_jmap :JMAPExtensions
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+
+    xlog $self, "Append duplicate messages";
+    $mimeMessage = <<'EOF';
+From: <from@local>
+To: to@local
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+test
+EOF
+    $mimeMessage =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', '17-Aug-2023 15:13:54 +0200', $mimeMessage) || die $@;
+    $imap->append('INBOX', '17-Aug-2023 15:13:54 +0200', $mimeMessage) || die $@;
+
+    $imap->select('INBOX');
+    $fetch = $imap->fetch('1:2', ['INTERNALDATE', 'CREATEDMODSEQ']);
+    $self->assert_str_equals(
+        $fetch->{1}{internaldate}, $fetch->{2}{internaldate}
+    );
+    $self->assert_num_lt(
+        $fetch->{2}{createdmodseq}[0], $fetch->{1}{createdmodseq}[0]
+    );
+
+    # The createdModseq must be the lower modseq.
+    $res = $jmap->CallMethods([
+        ['Email/query', { }, "R1"],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'Email/query',
+                path => '/ids'
+            },
+            properties => ['createdModseq'],
+        }, 'R2' ],
+    ]);
+    $self->assert_num_equals(1, scalar @{$res->[1][1]{list}});
+    $self->assert_num_equals($fetch->{1}{createdmodseq}[0],
+        $res->[1][1]{list}[0]{createdModseq});
+}

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -125,6 +125,7 @@ struct conv_thread {
     struct message_guid guid;
     uint32_t exists;
     time_t internaldate;
+    modseq_t createdmodseq;
 };
 
 struct conv_folder {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6949,6 +6949,46 @@ static const char *_encode_emailheader_blobid(const char *emailid,
     return buf_cstring(dst);
 }
 
+struct email_get_createdmodseq_rock {
+    jmap_req_t *req;
+    modseq_t modseq;
+};
+
+static int _email_get_createdmodseq_cb(const conv_guidrec_t *rec, void *vrock)
+{
+    struct email_get_createdmodseq_rock *rock = vrock;
+    mbentry_t *mbentry = NULL;
+
+    if (rec->part) return 0;
+
+    if ((rec->system_flags & FLAG_DELETED) ||
+        (rec->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
+        goto done;
+    }
+
+    conv_guidrec_mbentry(rec, &mbentry);
+
+    if (!mbentry || mboxname_isnondeliverymailbox(mbentry->name, mbentry->mbtype) ||
+        !jmap_hasrights_mbentry(rock->req, mbentry, JACL_READITEMS)) {
+        goto done;
+    }
+
+    struct mailbox *mbox = NULL;
+    if (!jmap_openmbox_by_uniqueid(rock->req, mbentry->uniqueid, &mbox, 0)) {
+        struct index_record index_record = {0};
+        if (!mailbox_find_index_record(mbox, rec->uid, &index_record)) {
+            if (!rock->modseq || rock->modseq > index_record.createdmodseq) {
+                rock->modseq = index_record.createdmodseq;
+            }
+        }
+        jmap_closembox(rock->req, &mbox);
+    }
+
+done:
+    mboxlist_entry_free(&mbentry);
+    return 0;
+}
+
 static int _email_get_meta(jmap_req_t *req,
                            struct email_getargs *args,
                            struct cyrusmsg *msg,
@@ -6979,6 +7019,11 @@ static int _email_get_meta(jmap_req_t *req,
         }
         if (jmap_wantprop(props, "receivedAt"))
             json_object_set_new(email, "receivedAt", json_null());
+
+        if (jmap_wantprop(props, "createdModseq")) {
+            json_object_set_new(email, "createdModseq", json_integer(0));
+        }
+
         return 0;
     }
 
@@ -7124,6 +7169,16 @@ static int _email_get_meta(jmap_req_t *req,
         }
         json_object_set_new(email, "bimiBlobId", jval);
         buf_free(&buf);
+    }
+
+    if (jmap_wantprop(props, "createdModseq")) {
+        struct email_get_createdmodseq_rock rock = { req, 0 };
+
+        /* Look for the smalled createdmodseq for all index records */
+        conversations_guid_foreach(req->cstate, _guid_from_id(email_id),
+                                   _email_get_createdmodseq_cb, &rock);
+
+        json_object_set_new(email, "createdModseq", json_integer(rock.modseq));
     }
 
 done:
@@ -8294,6 +8349,11 @@ static const jmap_property_t email_props[] = {
         "bimiBlobId",
         JMAP_MAIL_EXTENSION,
         JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE | JMAP_PROP_SKIP_GET
+    },
+    {
+        "createdModseq",
+        JMAP_MAIL_EXTENSION,
+        JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE
     },
     { NULL, NULL, 0 }
 };


### PR DESCRIPTION
This gives us a stable sort when multiple external messages are appended very quickly, giving them the same internaldate.

This is being added without a new version number, as it extends a data structure in a backwards and forwards compatible way.  If not set, the CREATEDMODSEQ field will be zero, which is fine.  This will still lead to correct sorting for newly added emails on any thread.  The only slight weirdness might be if an existing message in a thread gets moved or copied into a new folder, which will lead to it getting a createdmodseq value, and hence sorting to the end for that internaldate. This will be very rare, and a convdb rebuild will fix it.