### PR TITLE
jmap_mail: do not dereference NULL pointer in Email/parse

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_parse_inmemory_blob
+++ b/cassandane/tiny-tests/JMAPEmail/email_parse_inmemory_blob
@@ -1,0 +1,45 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_parse_inmemory_blob
+    :min_version_3_9 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    # XXX: replace with the upstream one once RFC 9404 is finished
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/blob');
+
+    my $mimeMsg = <<'EOF';
+From: <from@local>
+To: to@local
+Bcc: bcc@local
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+hello
+EOF
+    $mimeMsg =~ s/\r?\n/\r\n/gs;
+
+    # XXX: can't use a result reference in array
+    my $blobId = 'G67501cd2e1eaaf65d25e6f3b49554d2193f06ee8';
+
+    $res = $jmap->CallMethods([
+        ['Blob/upload', {
+            create => {
+                b1 => {
+                    data => [{'data:asText' => $mimeMsg}]
+                },
+            },
+        }, 'R1'],
+        ['Email/parse', {
+            blobIds => [$blobId],
+            properties => ['subject', 'bodyStructure'],
+        }, 'R2'],
+    ]);
+    $self->assert_str_equals('Blob/upload', $res->[0][0]);
+    $self->assert_not_null($res->[0][1]{created}{b1}{id});
+    $self->assert_str_equals('test', $res->[1][1]{parsed}{$blobId}{subject});
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8444,7 +8444,7 @@ static int jmap_email_parse(jmap_req_t *req)
 
         struct buf *inmem = hash_lookup(blobid, req->inmemory_blobs);
         if (inmem) {
-            r = _email_from_buf(req, &getargs, inmem, part->encoding, &email);
+            r = _email_from_buf(req, &getargs, inmem, NULL, &email);
             if (r) {
                 syslog(LOG_ERR, "jmap: Email/parse(%s): %s", blobid, error_message(r));
             }


### PR DESCRIPTION
Fixes #4574

Thanks to @dilyanpalauzov