### PR TITLE
bring back sync_client --connect-once

### DIFF
--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -2063,7 +2063,7 @@ sub test_rolling_retry_wait_limit
     # get a rolling sync_client started, which won't be able to connect
     # XXX can't just run_replication bc it expects sync_client to finish
     my $errfile = "$self->{instance}->{basedir}/stderr.out";
-    my @cmd = qw( sync_client -v -v -o -R );
+    my @cmd = qw( sync_client -v -v -R );
     my $sync_client_pid = $self->{instance}->run_command(
         {
             cyrus => 1,

--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -2100,6 +2100,51 @@ sub test_rolling_retry_wait_limit
     $self->assert_deep_equals([ 15, 20, 20, 20 ], \@waits);
 }
 
+sub test_connect_once
+    :CSyncReplication :min_version_3_9
+    :needs_component_replication
+{
+    my ($self) = @_;
+
+    # stop the replica
+    $self->{replica}->stop();
+
+    # start a sync_client, which won't be able to connect
+    # n.b. can't just run_replication bc it expects sync_client to finish
+    my $errfile = "$self->{instance}->{basedir}/stderr.out";
+    my @cmd = qw( sync_client -v -v -o -m user.cassandane );
+    my $sync_client_pid = $self->{instance}->run_command(
+        {
+            cyrus => 1,
+            background => 1,
+            handlers => {
+                exited_abnormally => sub {
+                    my ($child, $code) = @_;
+                    xlog "child process $child->{binary}\[$child->{pid}\]"
+                        . " exited with code $code";
+                    return $code;
+                },
+            },
+            redirects => { stderr => $errfile },
+        },
+        @cmd);
+
+    # give sync_client time to fail to connect
+    sleep 10;
+
+    # clean up whatever's left of it
+    my $ec = $self->{instance}->stop_command($sync_client_pid);
+
+    # if it exited itself due to being unable to connect, this will be 1.
+    # if it was shut down by stop_command, 75
+    $self->assert_not_equals(75, $ec);
+    $self->assert_equals(1, $ec);
+
+    my $output = slurp_file($errfile);
+    $self->assert_matches(qr/Can not connect to server/, $output);
+    $self->assert_does_not_match(qr/retrying in \d+ seconds/, $output);
+}
+
 #
 # Test empty mailbox gets overwritten
 #

--- a/changes/next/bring-back-sync-client-connect-once
+++ b/changes/next/bring-back-sync-client-connect-once
@@ -1,0 +1,18 @@
+Description:
+
+Restores functionality of the sync_client -o/--connect-once option
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+Nothing required
+
+
+GitHub issue:
+
+None

--- a/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/sync_client.rst
@@ -99,8 +99,11 @@ Options
 
 .. option:: -o, --connect-once
 
-    Only attempt to connect to the backend server once rather than
-    waiting up to 1000 seconds before giving up.
+    Only attempt to connect to the backend server once.
+
+    Without this option, **sync_client** will retry failed connections
+    indefinitely, waiting up to ``sync_reconnect_maxwait`` (default: 20m)
+    between attempts.
 
 .. option:: -O, --no-copyback
 

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -272,7 +272,7 @@ static void replica_connect(void)
 
     for (wait = 15;; wait *= 2) {
         int r = sync_connect(&sync_cs);
-        if (r != IMAP_AGAIN) break;
+        if (r != IMAP_AGAIN || connect_once) break;
 
         signals_poll();
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -8035,7 +8035,7 @@ EXPORTED int sync_connect(struct sync_client_state *sync_cs)
                               &csync_protocol, "", cb, NULL,
                               (verbose > 1 ? fileno(stderr) : -1));
 
-    // auth_status means there was an error
+    // no backend means there was an error
     if (!backend) {
         free_callbacks(cb);
         return IMAP_AGAIN;

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2880,11 +2880,11 @@ product version in the capabilities
    Prefix with a channel name to only apply for that channel */
 
 { "sync_reconnect_maxwait", "20m", DURATION, "3.6.0" }
-/* When a rolling sync_client cannot connect to the replica, it enters
-   a retry loop with an exponential backoff between attempts.  This
-   option sets the upper limit on that exponential backoff: no matter
-   how long the replica has been down so far, sync_client will never
-   wait longer than sync_reconnect_maxwait between retries.
+/* When sync_client cannot connect to the replica, it enters a retry
+   loop with an exponential backoff between attempts.  This option sets
+   the upper limit on that exponential backoff: no matter how long the
+   replica has been down so far, sync_client will never wait longer than
+   sync_reconnect_maxwait between retries.
 .PP
    If this is zero or negative, the backoff duration will be allowed
    to increase indefinitely (not recommended).


### PR DESCRIPTION
`sync_client` has a `-o/--connect-once` option that's supposed to make it fail if the connection to the replica fails, rather than retrying the connection until it succeeds.  It was accidentally broken a while ago during a refactor.

This PR adds the behaviour back, adds a regression test, and fixes some documentation details that were out of date.