### PR TITLE
make bitfields in structs unsigned

### DIFF
--- a/imap/append.h
+++ b/imap/append.h
@@ -58,7 +58,7 @@ struct appendstate {
     /* mailbox we're appending to */
     struct mailbox *mailbox;
     /* do we own it? */
-    int close_mailbox_when_done:1;
+    unsigned int close_mailbox_when_done:1;
     int myrights;
     char userid[MAX_MAILBOX_BUFFER];
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1854,8 +1854,8 @@ struct emailsearch_folders_value {
     strarray_t foldernames;
     bitvector_t foldernums;
     int jmapupload_foldernum;
-    int is_otherthan : 1;
-    int want_expunged : 1;
+    unsigned int is_otherthan : 1;
+    unsigned int want_expunged : 1;
 };
 
 static void emailsearch_folders_value_free(struct emailsearch_folders_value **valp)

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -142,8 +142,8 @@ static struct msg {
     uint32_t uid;
     uint32_t recno;
     uint32_t size;
-    int deleted:1;
-    int seen:1;
+    unsigned int deleted:1;
+    unsigned int seen:1;
 } *popd_map = NULL;
 
 static struct io_count *io_count_start;


### PR DESCRIPTION
Fixes warnings like
```
../imap/jmap_mail.c:1705:32: warning: implicit truncation from 'int' to a one-bit wide bit-field changes value from 1 to -1 [-Wsingl t-bitfield-constant-conversion]
            val->want_expunged = 1;
                               ^ ~
```