### PR TITLE
Note on specialstrings and annotations in concept documentation

### DIFF
--- a/docsrc/imap/concepts/overview_and_concepts.rst
+++ b/docsrc/imap/concepts/overview_and_concepts.rst
@@ -161,8 +161,8 @@ These are referred to as *negative rights*.
 Special Strings
 ===============
 
-The ACL may be combined of the special strings none, read (lrs), post (lrsp), append (lrsip), write(lrswipkxte), delete (lrxte), or all (lrswipkxte), or any combinations of the ACL codes when using the setacl methods 
-:ref:`imap-reference-manpages-systemcommands-cyradm-setaclmailbox`
+The ACL may be combined of the special strings none, read (``lrs``), post (``lrsp``), append (``lrsip``), write(``lrswipkxte``), delete (``lrxte``), or all (``lrswipkxte``), or any combinations of the ACL codes when using the setacl methods :ref:`imap-reference-manpages-systemcommands-cyradm-setaclmailbox`.
+The annotate Access Right ``n`` is not part of the special strings. 
 
 Calculating a Users' Rights
 ===========================

--- a/docsrc/imap/concepts/overview_and_concepts.rst
+++ b/docsrc/imap/concepts/overview_and_concepts.rst
@@ -158,6 +158,12 @@ Any of the above defined identifiers may be prefixed with a ``-``
 character. The associated rights are then removed from that identifier.
 These are referred to as *negative rights*.
 
+Special Strings
+===============
+
+The ACL may be combined of the special strings none, read (lrs), post (lrsp), append (lrsip), write(lrswipkxte), delete (lrxte), or all (lrswipkxte), or any combinations of the ACL codes when using the setacl methods 
+:ref:`imap-reference-manpages-systemcommands-cyradm-setaclmailbox`
+
 Calculating a Users' Rights
 ===========================
 


### PR DESCRIPTION
Add a concept documentation note on specialstrings and the (relatively new) Access Right "annotate" in these special strings.