### PR TITLE
Fix build with disabled sieve

### DIFF
--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -64,8 +64,10 @@
 
 #include "master/masterconf.h"
 
+#ifdef USE_SIEVE
 #include "sieve/bytecode.h"
 #include "sieve/sieve_interface.h"
+#endif
 
 /* Make ld happy */
 const char *MASTER_CONFIG_FILENAME = DEFAULT_MASTER_CONFIG_FILENAME;
@@ -290,10 +292,12 @@ static json_t *buildinfo()
     json_object_set_new(search, "xapian_cjk_tokens", json_string(XAPIAN_CJK_TOKENS));
 
     /* Internal version numbers */
+#ifdef USE_SIEVE
     json_object_set_new(version, "BYTECODE_MIN_VERSION",
                                  json_integer(BYTECODE_MIN_VERSION));
     json_object_set_new(version, "BYTECODE_VERSION",
                                  json_integer(BYTECODE_VERSION));
+#endif
     json_object_set_new(version, "CONVERSATIONS_KEY_VERSION",
                                  json_integer(CONVERSATIONS_KEY_VERSION));
     json_object_set_new(version, "CONVERSATIONS_RECORD_VERSION",
@@ -310,8 +314,10 @@ static json_t *buildinfo()
                                  json_integer(MAILBOX_CACHE_MINOR_VERSION));
     json_object_set_new(version, "MAILBOX_MINOR_VERSION",
                                  json_integer(MAILBOX_MINOR_VERSION));
+#ifdef USE_SIEVE
     json_object_set_new(version, "SIEVE_VERSION",
                                  json_string(SIEVE_VERSION));
+#endif
     json_object_set_new(version, "STATUSCACHE_VERSION",
                                  json_integer(STATUSCACHE_VERSION));
     json_object_set_new(version, "ZONEINFO_VERSION",


### PR DESCRIPTION
When building without sieve (`./configure --disable-sieve`), compilation fails on imap/cyr_buildinfo.c because of missing headers and, in turn, missing symbols.
This simple patch (a bunch of #ifdefs) fixes the issue.
(Perhaps it's nonsense to build without sieve, I don't know, but I wanted actually just the CalDAV functionality + the minimum necessary requirements).