### PR TITLE
JMAP Email: ignore NUL bytes in Email/get bodyValues

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_crlf
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_crlf
@@ -1,0 +1,44 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_bodyvalues_crlf
+    :min_version_3_9 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    my $mimeMsg = <<'EOF';
+From: <from@local>
+To: to@local
+Bcc: bcc@local
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;charset=utf-8
+
+one
+two
+three
+EOF
+    $mimeMsg =~ s/\r?\n/\r\n/gs;
+    $mimeMsg =~ s/\r\n$//;
+    $imap->append('INBOX', $mimeMsg) || die $@;
+
+    $res = $jmap->CallMethods([
+        ['Email/query', { }, 'R1'],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'Email/query',
+                path => '/ids'
+            },
+            properties => ['bodyValues'],
+            fetchAllBodyValues => JSON::true,
+        }, 'R2'],
+    ]);
+
+    $self->assert_str_equals("one\ntwo\nthree",
+        $res->[1][1]{list}[0]{bodyValues}{1}{value});
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_nulbyte
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_nulbyte
@@ -1,0 +1,42 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_bodyvalues_nulbyte
+    :min_version_3_9 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    my $mimeMsg = <<'EOF';
+From: <from@local>
+To: to@local
+Bcc: bcc@local
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html;charset=utf-8
+
+<html><body>hello=00 world</body></html>
+EOF
+    $mimeMsg =~ s/\r?\n/\r\n/gs;
+    $mimeMsg =~ s/\r\n$//;
+    $imap->append('INBOX', $mimeMsg) || die $@;
+
+    $res = $jmap->CallMethods([
+        ['Email/query', { }, 'R1'],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'Email/query',
+                path => '/ids'
+            },
+            properties => ['bodyValues'],
+            fetchAllBodyValues => JSON::true,
+        }, 'R2'],
+    ]);
+
+    $self->assert_str_equals("<html><body>hello world</body></html>",
+        $res->[1][1]{list}[0]{bodyValues}{1}{value});
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_nulbyte
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_nulbyte
@@ -37,6 +37,9 @@ EOF
         }, 'R2'],
     ]);
 
+    my $bodyValue = $res->[1][1]{list}[0]{bodyValues}{1};
     $self->assert_str_equals("<html><body>hello world</body></html>",
-        $res->[1][1]{list}[0]{bodyValues}{1}{value});
+        $bodyValue->{value});
+    $self->assert_equals(JSON::true, $bodyValue->{isEncodingProblem});
+    $self->assert_equals(JSON::false, $bodyValue->{isTruncated});
 }

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -87,39 +87,39 @@ static void test_to_utf8(void)
     CU_ASSERT_PTR_NOT_NULL(cs);
 
     /* zero length input */
-    s = charset_to_utf8("", 0, cs, ENCODING_NONE);
+    s = charset_to_utf8cstr("", 0, cs, ENCODING_NONE);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, "");
     free(s);
 
     /* invalid encoding */
-    s = charset_to_utf8(ASCII_1, sizeof(ASCII_1), cs, 0xdeadbeef);
+    s = charset_to_utf8cstr(ASCII_1, sizeof(ASCII_1), cs, 0xdeadbeef);
     CU_ASSERT_PTR_NULL(s);
 
     /* invalid charset */
-    s = charset_to_utf8(ASCII_1, sizeof(ASCII_1), NULL, ENCODING_NONE);
+    s = charset_to_utf8cstr(ASCII_1, sizeof(ASCII_1), NULL, ENCODING_NONE);
     CU_ASSERT_PTR_NULL(s);
 
     /* simple ASCII string */
-    s = charset_to_utf8(ASCII_1, sizeof(ASCII_1)-1, cs, ENCODING_NONE);
+    s = charset_to_utf8cstr(ASCII_1, sizeof(ASCII_1)-1, cs, ENCODING_NONE);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, ASCII_1);
     free(s);
 
     /* ASCII string with an invalid character */
-    s = charset_to_utf8(ASCII_2, sizeof(ASCII_2)-1, cs, ENCODING_NONE);
+    s = charset_to_utf8cstr(ASCII_2, sizeof(ASCII_2)-1, cs, ENCODING_NONE);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, UTF8_2);
     free(s);
 
     /* base64 encoding */
-    s = charset_to_utf8(BASE64_3, sizeof(BASE64_3)-1, cs, ENCODING_BASE64);
+    s = charset_to_utf8cstr(BASE64_3, sizeof(BASE64_3)-1, cs, ENCODING_BASE64);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, ASCII_1);
     free(s);
 
     /* Quoted-printable encoding */
-    s = charset_to_utf8(QP_4, sizeof(QP_4)-1, cs, ENCODING_QP);
+    s = charset_to_utf8cstr(QP_4, sizeof(QP_4)-1, cs, ENCODING_QP);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, ASCII_4);
     free(s);
@@ -143,7 +143,7 @@ static void test_to_imaputf7(void)
         s = charset_to_imaputf7(_in, strlen(_in), csu8, ENCODING_NONE); \
         CU_ASSERT_PTR_NOT_NULL(s); \
         CU_ASSERT_STRING_EQUAL(s, _want); \
-        q = charset_to_utf8(s, strlen(s), csu7, ENCODING_NONE); \
+        q = charset_to_utf8cstr(s, strlen(s), csu7, ENCODING_NONE); \
         CU_ASSERT_PTR_NOT_NULL(q); \
         CU_ASSERT_STRING_EQUAL(q, _in); \
         free(q); \
@@ -189,7 +189,7 @@ static void test_misc_charsets(void)
         static const char _want[] = (want); \
         charset_t cs = charset_lookupname(alias); \
         CU_ASSERT_PTR_NOT_NULL(cs); \
-        s = charset_to_utf8(_in, strlen(_in), cs, ENCODING_NONE); \
+        s = charset_to_utf8cstr(_in, strlen(_in), cs, ENCODING_NONE); \
         CU_ASSERT_PTR_NOT_NULL(s); \
         CU_ASSERT_STRING_EQUAL(s, _want); \
         free(s); \
@@ -271,7 +271,7 @@ static void test_qp(void)
         charset_t _cs = charset_lookupname(cs); \
         CU_ASSERT_PTR_NOT_NULL(_cs); \
         int _enc = (enc); \
-        char *s = charset_to_utf8(_in, sizeof(_in)-1, _cs, _enc); \
+        char *s = charset_to_utf8cstr(_in, sizeof(_in)-1, _cs, _enc); \
         CU_ASSERT_PTR_NOT_NULL(s); \
         CU_ASSERT_STRING_EQUAL(s, _exp); \
         free(s); \
@@ -1337,7 +1337,7 @@ static void test_broken_length_hint(void)
     cs = charset_lookupname("iso-8859-1");
     CU_ASSERT_PTR_NOT_NULL(cs);
 
-    s = charset_to_utf8(body, strlen(body), cs, ENCODING_QP);
+    s = charset_to_utf8cstr(body, strlen(body), cs, ENCODING_QP);
     CU_ASSERT_STRING_EQUAL(body, s);
     charset_free(&cs);
     free(s);

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -72,6 +72,9 @@ static void test_to_utf8(void)
 {
     charset_t cs;
     char *s;
+    struct buf buf = BUF_INITIALIZER;
+    int r;
+
     static const char ASCII_1[] = "Hello World";
     static const char ASCII_2[] = "Hello W\370rld";
     static const char UTF8_2[] = "Hello W" UTF8_REPLACEMENT "rld";
@@ -91,40 +94,66 @@ static void test_to_utf8(void)
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, "");
     free(s);
+    r = charset_to_utf8(&buf, "", 0, cs, ENCODING_NONE);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(buf_len(&buf), 0);
 
     /* invalid encoding */
     s = charset_to_utf8cstr(ASCII_1, sizeof(ASCII_1), cs, 0xdeadbeef);
     CU_ASSERT_PTR_NULL(s);
+    r = charset_to_utf8(&buf, ASCII_1, sizeof(ASCII_1), cs, 0xdeadbeef);
+    CU_ASSERT_EQUAL(r, -1);
+    CU_ASSERT_EQUAL(buf_len(&buf), 0);
 
     /* invalid charset */
     s = charset_to_utf8cstr(ASCII_1, sizeof(ASCII_1), NULL, ENCODING_NONE);
     CU_ASSERT_PTR_NULL(s);
+    r = charset_to_utf8(&buf, ASCII_1, sizeof(ASCII_1), NULL, ENCODING_NONE);
+    CU_ASSERT_EQUAL(r, -1);
+    CU_ASSERT_EQUAL(buf_len(&buf), 0);
 
     /* simple ASCII string */
     s = charset_to_utf8cstr(ASCII_1, sizeof(ASCII_1)-1, cs, ENCODING_NONE);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, ASCII_1);
     free(s);
+    r = charset_to_utf8(&buf, ASCII_1, sizeof(ASCII_1)-1, cs, ENCODING_NONE);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(buf_len(&buf), strlen(ASCII_1));
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), ASCII_1);
 
     /* ASCII string with an invalid character */
     s = charset_to_utf8cstr(ASCII_2, sizeof(ASCII_2)-1, cs, ENCODING_NONE);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, UTF8_2);
     free(s);
+    r = charset_to_utf8(&buf, ASCII_2, sizeof(ASCII_2)-1, cs, ENCODING_NONE);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(buf_len(&buf), strlen(UTF8_2));
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), UTF8_2);
 
     /* base64 encoding */
     s = charset_to_utf8cstr(BASE64_3, sizeof(BASE64_3)-1, cs, ENCODING_BASE64);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, ASCII_1);
     free(s);
+    r = charset_to_utf8(&buf, BASE64_3, sizeof(BASE64_3)-1, cs, ENCODING_BASE64);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(buf_len(&buf), strlen(ASCII_1));
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), ASCII_1);
 
     /* Quoted-printable encoding */
     s = charset_to_utf8cstr(QP_4, sizeof(QP_4)-1, cs, ENCODING_QP);
     CU_ASSERT_PTR_NOT_NULL(s);
     CU_ASSERT_STRING_EQUAL(s, ASCII_4);
     free(s);
+    r = charset_to_utf8(&buf, QP_4, sizeof(QP_4)-1, cs, ENCODING_QP);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(buf_len(&buf), strlen(ASCII_4));
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), ASCII_4);
     
     charset_free(&cs);
+    buf_free(&buf);
 }
 
 static void test_to_imaputf7(void)

--- a/imap/cyr_ls.c
+++ b/imap/cyr_ls.c
@@ -127,7 +127,7 @@ static int print_name(const char *name, int utf8)
 
     if (utf8) {
         charset_t imaputf7 = charset_lookupname("imap-mailbox-name");
-        utf8name = charset_to_utf8(name, strlen(name), imaputf7, ENCODING_NONE);
+        utf8name = charset_to_utf8cstr(name, strlen(name), imaputf7, ENCODING_NONE);
         name = utf8name;
     }
 

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -1235,7 +1235,7 @@ static void display_part(struct transaction_t *txn,
                 charset = charset_lookupname("us-ascii");
             }
             body->decoded_body =
-                charset_to_utf8(buf_base(msg_buf) + body->content_offset,
+                charset_to_utf8cstr(buf_base(msg_buf) + body->content_offset,
                                 body->content_size, charset, encoding);
             charset_free(&charset);
             if (!ishtml) buf_printf_markup(buf, level, "<pre>");

--- a/imap/index.c
+++ b/imap/index.c
@@ -5336,9 +5336,11 @@ static int extract_icalbuf(struct buf *raw, charset_t charset, int encoding,
     /* Parse the message into an iCalendar object */
     const struct buf *icalbuf = NULL;
     if (encoding || strcasecmp(charset_canon_name(charset), "utf-8")) {
-        char *tmp = charset_to_utf8(buf_cstring(raw), buf_len(raw), charset, encoding);
-        if (!tmp) return 0; /* could be a bogus header - ignore */
-        buf_initm(&buf, tmp, strlen(tmp));
+        if (charset_to_utf8(&buf, buf_cstring(raw), buf_len(raw), charset, encoding)) {
+        /* could be a bogus header - ignore */
+            buf_free(&buf);
+            goto done;
+        }
         icalbuf = &buf;
     }
     else {
@@ -5476,9 +5478,10 @@ static int extract_vcardbuf(struct buf *raw, charset_t charset, int encoding,
     /* Parse the message into a vcard object */
     const struct buf *vcardbuf = NULL;
     if (encoding || strcasecmp(charset_canon_name(charset), "utf-8")) {
-        char *tmp = charset_to_utf8(buf_cstring(raw), buf_len(raw), charset, encoding);
-        if (!tmp) return 0; /* could be a bogus header - ignore */
-        buf_initm(&buf, tmp, strlen(tmp));
+        if (charset_to_utf8(&buf, buf_cstring(raw), buf_len(raw), charset, encoding)) {
+            /* could be a bogus header - ignore */
+            goto done;
+        }
         vcardbuf = &buf;
     }
     else {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -391,7 +391,11 @@ static char *decode_to_utf8cstr(const char *charset,
             j++;
         }
     }
-    buf_truncate(&buf, j);
+    if (j != buf_len(&buf)) {
+        buf_truncate(&buf, j);
+        if (is_encoding_problem)
+            *is_encoding_problem = 1;
+    }
 
     return buf_len(&buf) ? buf_release(&buf) : NULL;
 }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -369,18 +369,31 @@ typedef enum MsgType {
  * Emails
  */
 
-static char *_decode_to_utf8(const char *charset,
-                             const char *data, size_t datalen,
-                             const char *encoding,
-                             int *is_encoding_problem)
+static char *decode_to_utf8cstr(const char *charset,
+                                const char *data, size_t datalen,
+                                const char *encoding,
+                                int *is_encoding_problem)
 {
+    if (!datalen) return NULL;
+
     /* XXX - keep confidence 0.0 for regression? */
     struct buf buf = BUF_INITIALIZER;
     jmap_decode_to_utf8(charset,
             encoding_lookupname(encoding),
             data, datalen, 0.0, &buf,
             is_encoding_problem);
-    return datalen && buf_len(&buf) ? buf_release(&buf) : NULL;
+
+    // Filter nul bytes from UTF-8 text
+    size_t j = 0;
+    for (size_t i = 0; i < buf.len; i++) {
+        if (buf.s[i] != '\0') {
+            if (i != j) buf.s[j] = buf.s[i];
+            j++;
+        }
+    }
+    buf_truncate(&buf, j);
+
+    return buf_len(&buf) ? buf_release(&buf) : NULL;
 }
 
 struct headers {
@@ -811,7 +824,7 @@ static char *_emailbodies_to_plain(struct emailbodies *bodies, const struct buf 
         struct body *part = ptrarray_nth(&bodies->textlist, 0);
         if (!strcasecmp(part->type, "TEXT") &&
                 !strcasecmpsafe(part->subtype, "PLAIN")) {
-            return _decode_to_utf8(part->charset_id,
+            return decode_to_utf8cstr(part->charset_id,
                     msg_buf->s + part->content_offset,
                     part->content_size,
                     part->encoding,
@@ -831,7 +844,7 @@ static char *_emailbodies_to_plain(struct emailbodies *bodies, const struct buf 
         if (!strcasecmp(part->type, "TEXT") &&
                 !strcasecmpsafe(part->subtype, "PLAIN")) {
             int is_encoding_problem = 0;
-            char *t = _decode_to_utf8(part->charset_id,
+            char *t = decode_to_utf8cstr(part->charset_id,
                                       msg_buf->s + part->content_offset,
                                       part->content_size,
                                       part->encoding,
@@ -922,7 +935,7 @@ static char *_emailbodies_to_html(struct emailbodies *bodies, const struct buf *
     if (bodies->htmllist.count == 1) {
         const struct body *part = ptrarray_nth(&bodies->htmllist, 0);
         int is_encoding_problem = 0;
-        char *html = _decode_to_utf8(part->charset_id,
+        char *html = decode_to_utf8cstr(part->charset_id,
                                      msg_buf->s + part->content_offset,
                                      part->content_size,
                                      part->encoding,
@@ -949,7 +962,7 @@ static char *_emailbodies_to_html(struct emailbodies *bodies, const struct buf *
             buf_appendcstr(&buf, "<html>"); // XXX use HTML5?
 
         int is_encoding_problem = 0;
-        char *t = _decode_to_utf8(part->charset_id,
+        char *t = decode_to_utf8cstr(part->charset_id,
                                   msg_buf->s + part->content_offset,
                                   part->content_size,
                                   part->encoding,
@@ -7538,7 +7551,7 @@ static json_t * _email_get_bodyvalue(struct body *part,
     struct buf buf = BUF_INITIALIZER;
 
     /* Decode into UTF-8 buffer */
-    char *raw = _decode_to_utf8(part->charset_id,
+    char *raw = decode_to_utf8cstr(part->charset_id,
             msg_buf->s + part->content_offset,
             part->content_size, part->encoding,
             &is_encoding_problem);

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -321,8 +321,8 @@ static char *_mbox_get_name(const char *account_id __attribute__((unused)),
         extname = xstrdup(strarray_nth(boxes, strarray_size(boxes)-1));
         /* Decode extname from IMAP UTF-7 to UTF-8. Or fall back to extname. */
         charset_t cs = charset_lookupname("imap-utf-7");
-        char *decoded = charset_to_utf8(extname, strlen(extname),
-                                        cs, ENCODING_NONE);
+        char *decoded = charset_to_utf8cstr(extname, strlen(extname),
+                                            cs, ENCODING_NONE);
         if (decoded) {
             free(extname);
             extname = decoded;

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -314,8 +314,8 @@ static int _note_get(message_t *msg, json_t *note, hash_table *props,
 
         charset = charset_lookupname(charset_id);
         if (encoding || strcasecmp(charset_canon_name(charset), "utf-8")) {
-            char *dec = charset_to_utf8(buf_cstring(buf), buf_len(buf),
-                                        charset, encoding);
+            char *dec = charset_to_utf8cstr(buf_cstring(buf), buf_len(buf),
+                                            charset, encoding);
             buf_setcstr(buf, dec);
             free(dec);
         }

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -622,21 +622,21 @@ HIDDEN char *jmap_decode_base64_nopad(const char *b64, size_t b64len)
 EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
                                   const char *data, size_t datalen,
                                   float confidence,
-                                  struct buf *dst,
+                                  struct buf *text,
                                   int *is_encoding_problem)
 {
     charset_t cs = charset_lookupname(charset);
-    char *text = NULL;
-    size_t textlen = 0;
     struct char_counts counts = { 0 };
     const char *charset_id = charset_canon_name(cs);
     assert(confidence >= 0.0 && confidence <= 1.0);
+
+    buf_reset(text);
 
     /* Attempt fast path if data claims to be UTF-8 */
     if (encoding == ENCODING_NONE && !strcasecmp(charset_id, "UTF-8")) {
         struct char_counts counts = charset_count_validutf8(data, datalen);
         if (!counts.invalid) {
-            buf_setmap(dst, data, datalen);
+            buf_setmap(text, data, datalen);
             goto done;
         }
     }
@@ -652,35 +652,28 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
     /* Decode source data, converting charset if not already in UTF-8 */
     size_t nreplacement = 0;
     if (!strcasecmp(charset_id, "UTF-8")) {
-        struct buf buf = BUF_INITIALIZER;
-        if (charset_decode(&buf, data, datalen, encoding)) {
+        if (charset_decode(text, data, datalen, encoding)) {
             xsyslog(LOG_INFO, "failed to decode UTF-8 data",
                     "encoding=<%s>", encoding_name(encoding));
-            buf_free(&buf);
             if (is_encoding_problem) *is_encoding_problem = 1;
             goto done;
         }
-        textlen = buf_len(&buf);
-        text = buf_release(&buf);
-        counts = charset_count_validutf8(text, textlen);
+        counts = charset_count_validutf8(buf_base(text), buf_len(text));
         if (counts.invalid) {
             // Source UTF-8 data contains invalid characters.
             // Need to run data through charset_to_utf8
             // to insert replacement characters for these bytes.
             nreplacement = counts.replacement;
-            xzfree(text);
-            textlen = 0;
+            buf_reset(text);
         }
         else counts.replacement = 0; // ignore replacement in source data
     }
-    if (!text) {
-        text = charset_to_utf8cstr(data, datalen, cs, encoding);
-        if (!text) {
+    if (!buf_len(text)) {
+        if (charset_to_utf8(text, data, datalen, cs, encoding)) {
             if (is_encoding_problem) *is_encoding_problem = 1;
             goto done;
         }
-        textlen = strlen(text);
-        counts = charset_count_validutf8(text, textlen);
+        counts = charset_count_validutf8(buf_base(text), buf_len(text));
         if (counts.replacement > nreplacement)
             counts.replacement -= nreplacement;
     }
@@ -696,18 +689,19 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
                 guess_cs = charset_lookupname("UTF-32LE");
             else
                 guess_cs = charset_lookupname("UTF-32BE");
-            char *guess = charset_to_utf8cstr(data, datalen, guess_cs, encoding);
-            if (guess) {
-                struct char_counts guess_counts = charset_count_validutf8(guess, strlen(guess));
+
+            struct buf guess = BUF_INITIALIZER;
+            if (!charset_to_utf8(&guess, data, datalen, guess_cs, encoding)) {
+                struct char_counts guess_counts =
+                    charset_count_validutf8(buf_base(&guess), buf_len(&guess));
                 if (guess_counts.valid > counts.valid) {
-                    free(text);
-                    text = guess;
+                    buf_copy(text, &guess);
                     counts = guess_counts;
-                    textlen = strlen(text);
                     charset_id = charset_canon_name(guess_cs);
                 }
             }
             charset_free(&guess_cs);
+            buf_free(&guess);
         }
     }
     else if (!charset_id || !strcasecmp("US-ASCII", charset_id)) {
@@ -715,19 +709,18 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
             /* Could be ISO-2022-JP */
             charset_t guess_cs = charset_lookupname("ISO-2022-JP");
             if (guess_cs != CHARSET_UNKNOWN_CHARSET) {
-                char *guess = charset_to_utf8cstr(data, datalen, guess_cs, encoding);
-                if (guess) {
-                    struct char_counts guess_counts = charset_count_validutf8(guess, strlen(guess));
+                struct buf guess = BUF_INITIALIZER;
+                if (!charset_to_utf8(&guess, data, datalen, guess_cs, encoding)) {
+                    struct char_counts guess_counts =
+                        charset_count_validutf8(buf_base(&guess), buf_len(&guess));
                     if (!guess_counts.invalid && !guess_counts.replacement) {
-                        free(text);
-                        text = guess;
+                        buf_copy(text, &guess);
                         counts = guess_counts;
-                        textlen = strlen(text);
                         charset_id = charset_canon_name(guess_cs);
                     }
-                    else free(guess);
                 }
                 charset_free(&guess_cs);
+                buf_free(&guess);
             }
         }
     }
@@ -748,10 +741,10 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
         if (detect_handledata_r(&d, buf_base(&buf), buf_len(&buf), &obj) == CHARDET_SUCCESS) {
             charset_t guess_cs = charset_lookupname(obj->encoding);
             if (guess_cs != CHARSET_UNKNOWN_CHARSET) {
-                char *guess = charset_to_utf8cstr(data, datalen, guess_cs, encoding);
-                if (guess) {
+                struct buf guess = BUF_INITIALIZER;
+                if (!charset_to_utf8(&guess, data, datalen, guess_cs, encoding)) {
                     struct char_counts guess_counts =
-                        charset_count_validutf8(guess, strlen(guess));
+                        charset_count_validutf8(buf_base(&guess), buf_len(&guess));
                     if ((guess_counts.valid > counts.valid) &&
                             (obj->confidence >= confidence)) {
                         // libchardet might have guessed a single-byte character encoding,
@@ -769,15 +762,13 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
                         if ((guess_counts.replacement <= counts.replacement) &&
                             (!guess_counts.invalid || guess_counts.invalid < counts.invalid) &&
                                 guess_printable >= printable) {
-                            free(text);
-                            text = guess;
-                            guess = NULL;
+                            buf_copy(text, &guess);
                             counts = guess_counts;
                         }
                     }
-                    free(guess);
                 }
                 charset_free(&guess_cs);
+                buf_free(&guess);
             }
         }
         detect_obj_free(&obj);
@@ -787,8 +778,6 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
 
 done:
     charset_free(&cs);
-    if (text) buf_setcstr(dst, text);
-    free(text);
 }
 
 /*

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -674,7 +674,7 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
         else counts.replacement = 0; // ignore replacement in source data
     }
     if (!text) {
-        text = charset_to_utf8(data, datalen, cs, encoding);
+        text = charset_to_utf8cstr(data, datalen, cs, encoding);
         if (!text) {
             if (is_encoding_problem) *is_encoding_problem = 1;
             goto done;
@@ -696,7 +696,7 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
                 guess_cs = charset_lookupname("UTF-32LE");
             else
                 guess_cs = charset_lookupname("UTF-32BE");
-            char *guess = charset_to_utf8(data, datalen, guess_cs, encoding);
+            char *guess = charset_to_utf8cstr(data, datalen, guess_cs, encoding);
             if (guess) {
                 struct char_counts guess_counts = charset_count_validutf8(guess, strlen(guess));
                 if (guess_counts.valid > counts.valid) {
@@ -715,7 +715,7 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
             /* Could be ISO-2022-JP */
             charset_t guess_cs = charset_lookupname("ISO-2022-JP");
             if (guess_cs != CHARSET_UNKNOWN_CHARSET) {
-                char *guess = charset_to_utf8(data, datalen, guess_cs, encoding);
+                char *guess = charset_to_utf8cstr(data, datalen, guess_cs, encoding);
                 if (guess) {
                     struct char_counts guess_counts = charset_count_validutf8(guess, strlen(guess));
                     if (!guess_counts.invalid && !guess_counts.replacement) {
@@ -748,7 +748,7 @@ EXPORTED void jmap_decode_to_utf8(const char *charset, int encoding,
         if (detect_handledata_r(&d, buf_base(&buf), buf_len(&buf), &obj) == CHARDET_SUCCESS) {
             charset_t guess_cs = charset_lookupname(obj->encoding);
             if (guess_cs != CHARSET_UNKNOWN_CHARSET) {
-                char *guess = charset_to_utf8(data, datalen, guess_cs, encoding);
+                char *guess = charset_to_utf8cstr(data, datalen, guess_cs, encoding);
                 if (guess) {
                     struct char_counts guess_counts =
                         charset_count_validutf8(guess, strlen(guess));

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -137,15 +137,14 @@ extern char *jmap_decode_base64_nopad(const char *b64, size_t b64len);
  * - data points to the encoded bytes
  * - datalen indicates the byte length of data
  * - confidence indicates the threshold for charset detection (0 to 1.0)
- * - dst points to a buffer for the decoded output. The buffer is NOT
- *   reset to allow for consecutive decoding.
+ * - dst points to a buffer for the decoded output. This buffer is reset
  * - (optional) is_encoding_problem is set for invalid byte sequences
  *
  */
 extern void jmap_decode_to_utf8(const char *charset, int encoding,
                                 const char *data, size_t datalen,
                                 float confidence,
-                                struct buf *buf,
+                                struct buf *dst,
                                 int *is_encoding_problem);
 
 extern const char *jmap_encode_rawdata_blobid(const char prefix,

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1305,9 +1305,9 @@ EXPORTED const char *mbname_extname(const mbname_t *mbname, const struct namespa
     if (ns->isutf8) {
         /* Decode extname from IMAP UTF-7 to UTF-8. */
         charset_t cs = charset_lookupname("imap-utf-7");
-        char *decoded = charset_to_utf8(backdoor->extname,
-                                        strlen(backdoor->extname),
-                                        cs, ENCODING_NONE);
+        char *decoded = charset_to_utf8cstr(backdoor->extname,
+                                            strlen(backdoor->extname),
+                                            cs, ENCODING_NONE);
         if (decoded) {
             free(backdoor->extname);
             backdoor->extname = decoded;

--- a/imap/message.c
+++ b/imap/message.c
@@ -651,7 +651,7 @@ static void message_find_part(struct body *body, const char *section,
             if (charset == CHARSET_UNKNOWN_CHARSET)
                 /* try ASCII */
                 charset = charset_lookupname("us-ascii");
-            body->decoded_body = charset_to_utf8(
+            body->decoded_body = charset_to_utf8cstr(
                 msg_base + body->content_offset, body->content_size,
                 charset, encoding); /* returns a cstring */
             charset_free(&charset);

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -2498,6 +2498,13 @@ static int convert_to_name(struct buf *dst,
     n = ucnv_convert(to_name, from, dst->s, 0, src, len, &err) + 1;
     if (err != U_BUFFER_OVERFLOW_ERROR)
         return -1;
+
+    /* ucnv_convert return value includes size with NUL byte */
+    if (n < 2) {
+        buf_cstring(dst);
+        buf_reset(dst);
+        return 0;
+    }
     buf_ensure(dst, n);
 
     /* run the conversion */
@@ -2507,7 +2514,7 @@ static int convert_to_name(struct buf *dst,
         return -1;
     }
 
-    buf_truncate(dst, n);
+    buf_truncate(dst, n - 1);
     buf_cstring(dst);
     return 0;
 }

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -2481,12 +2481,13 @@ static struct convert_rock *unorm_init(struct convert_rock *next)
     return rock;
 }
 
-static char* convert_to_name(const char *to, charset_t charset,
-                             const char *src, size_t len)
+static int convert_to_name(struct buf *dst,
+                           const char *to_name,
+                           charset_t charset,
+                           const char *src, size_t len)
 {
     UErrorCode err = U_ZERO_ERROR;
     const char *from;
-    char *res = NULL;
     size_t n;
 
     /* determine the name of the source encoding */
@@ -2494,19 +2495,21 @@ static char* convert_to_name(const char *to, charset_t charset,
 
     /* allocate the target buffer */
     /* we preflight to compromise between memory and runtime efficiency */
-    n = ucnv_convert(to, from, res, 0, src, len, &err) + 1;
-    if (err != U_BUFFER_OVERFLOW_ERROR) return NULL;
-    res = xmalloc(n);
+    n = ucnv_convert(to_name, from, dst->s, 0, src, len, &err) + 1;
+    if (err != U_BUFFER_OVERFLOW_ERROR)
+        return -1;
+    buf_ensure(dst, n);
 
     /* run the conversion */
     err = U_ZERO_ERROR;
-    ucnv_convert(to, from, res, n, src, len, &err);
+    ucnv_convert(to_name, from, dst->s, n, src, len, &err);
     if (U_FAILURE(err)) {
-        free(res);
-        return NULL;
+        return -1;
     }
 
-    return res;
+    buf_truncate(dst, n);
+    buf_cstring(dst);
+    return 0;
 }
 
 static charset_t lookup_buf(const char *buf, size_t len)
@@ -2764,8 +2767,14 @@ EXPORTED char *charset_to_imaputf7(const char *msg_base, size_t len, charset_t c
         return xstrdup("");
 
     /* check if we can convert the whole block at once */
-    if (encoding == ENCODING_NONE)
-        return convert_to_name("imap-mailbox-name", charset, msg_base, len);
+    if (encoding == ENCODING_NONE) {
+        struct buf buf = BUF_INITIALIZER;
+        if (convert_to_name(&buf, "imap-mailbox-name", charset, msg_base, len) < 0) {
+            buf_free(&buf);
+            return NULL;
+        }
+        else return buf_release(&buf);
+    }
 
     /* set up the conversion path */
     imaputf7 = charset_lookupname("imap-mailbox-name");
@@ -2905,27 +2914,30 @@ done:
     return ret;
 }
 
-/* Convert from a given charset and encoding into utf8 */
-EXPORTED char *charset_to_utf8(const char *msg_base, size_t len, charset_t charset, int encoding)
+EXPORTED int charset_to_utf8(struct buf *dst, const char *src, size_t len, charset_t charset, int encoding)
 {
     struct convert_rock *input, *tobuffer;
-    char *res = NULL;
     charset_t utf8;
 
+    buf_reset(dst);
+
     /* Initialize character set mapping */
-    if (charset == CHARSET_UNKNOWN_CHARSET) return NULL;
+    if (charset == CHARSET_UNKNOWN_CHARSET) return -1;
 
     /* check for trivial search */
     if (len == 0)
-        return xstrdup("");
+        return 0;
 
     /* check if we can convert the whole block at once */
-    if (encoding == ENCODING_NONE)
-        return convert_to_name("utf-8", charset, msg_base, len);
+    if (encoding == ENCODING_NONE) {
+        return convert_to_name(dst, "utf-8", charset, src, len);
+    }
 
     /* set up the conversion path */
     utf8 = charset_lookupname("utf-8");
     tobuffer = buffer_init(len);
+    buffer_setbuf(tobuffer, dst);
+
     input = convert_init(utf8, 0/*to_uni*/, tobuffer);
     input = convert_init(charset, 1/*to_uni*/, input);
 
@@ -2950,17 +2962,29 @@ EXPORTED char *charset_to_utf8(const char *msg_base, size_t len, charset_t chars
         /* Don't know encoding--nothing can match */
         convert_free(input);
         charset_free(&utf8);
-        return 0;
+        return -1;
     }
 
-    if (!convert_catn(input, msg_base, len))
-        res = buffer_cstring(tobuffer);
+    int r = convert_catn(input, src, len);
+    buf_cstring(dst);
 
     convert_free(input);
     charset_free(&utf8);
 
-    return res;
+    return r;
 }
+
+/* Convert from a given charset and encoding into utf8 */
+EXPORTED char *charset_to_utf8cstr(const char *msg_base, size_t len, charset_t charset, int encoding)
+{
+    struct buf buf = BUF_INITIALIZER;
+    if (charset_to_utf8(&buf, msg_base, len, charset, encoding)) {
+        buf_free(&buf);
+        return NULL;
+    }
+    return buf_release(&buf);
+}
+
 
 /* Decode bytes from src into buffer dst */
 EXPORTED int charset_decode(struct buf *dst, const char *src, size_t len, int encoding)
@@ -3389,7 +3413,7 @@ EXPORTED char *charset_parse_mimexvalue(const char *s, struct buf *lang)
             buf_appendmap(&buf, p++, 1);
         }
     }
-    ret = charset_to_utf8(buf_base(&buf), buf_len(&buf), cs, 0);
+    ret = charset_to_utf8cstr(buf_base(&buf), buf_len(&buf), cs, 0);
 
 done:
     charset_free(&cs);

--- a/lib/charset.h
+++ b/lib/charset.h
@@ -142,8 +142,10 @@ extern char *charset_encode_mimebody(const char *msg_base, size_t len,
                                      int *outlines, int wrap);
 extern char *charset_qpencode_mimebody(const char *msg_base, size_t len,
                                        int force_quote, size_t *outlen);
-extern char *charset_to_utf8(const char *msg_base, size_t len, charset_t charset, int encoding);
+extern char *charset_to_utf8cstr(const char *msg_base, size_t len, charset_t charset, int encoding);
 extern char *charset_to_imaputf7(const char *msg_base, size_t len, charset_t charset, int encoding);
+
+extern int charset_to_utf8(struct buf *dst, const char *src, size_t len, charset_t charset, int encoding);
 
 extern int charset_search_mimeheader(const char *substr, comp_pat *pat, const char *s, int flags);
 


### PR DESCRIPTION
Sometimes we see HTML emails containing body parts with NUL bytes, e.g. 

    Content-Transfer-Encoding: quoted-printable
    Content-Type: text/html;charset=utf-8
    
    <html><body>hello=00 world</body></html>

This currently makes Cyrus truncate this body value at the first occurrence of a NUL byte.

I'm not entirely convinced NUL is legit in HTML, looking at its current definition of the [PLAINTEXT state](https://html.spec.whatwg.org/multipage/parsing.html#plaintext-state) and the ilk. But in any case we should do what everyone else is doing, which is omitting these bytes from the decoded body.

This PR just does that.