### PR TITLE
sieve-lex.l: fix undeclared function strncasecmp() warning

### DIFF
--- a/sieve/sieve-lex.l
+++ b/sieve/sieve-lex.l
@@ -47,6 +47,7 @@
 #include <config.h>
 #endif
 
+#include <strings.h>
 #include "util.h"
 
 #include "sieve/tree.h"


### PR DESCRIPTION
```
  CC       sieve/libcyrus_sieve_lex_la-sieve-lex.lo
../sieve/sieve-lex.l:489:14: error: call to undeclared library function 'strncasecmp' with type 'int (const char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
     if (!strncasecmp(cp, "hex:", 4)) {
             ^
 ../sieve/sieve-lex.l:489:14: note: include the header <strings.h> or explicitly provide a declaration for 'strncasecmp'
1 error generated.
```