### PR TITLE
3.6: backport "lock ordering fixes"

### DIFF
--- a/cassandane/Cassandane/Cyrus/Expunge.pm
+++ b/cassandane/Cassandane/Cyrus/Expunge.pm
@@ -261,6 +261,9 @@ sub test_ipurge_mboxevent
     );
     my $events = $self->{instance}->getnotify();
 
+    # if it stays selected you see the intermittent state
+    $talk->unselect();
+
     # the messages we just created should've been expunged
     $stat = $talk->status($shared_folder, '(highestmodseq unseen messages)');
     $self->assert_num_equals(0, $stat->{unseen});

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -375,15 +375,13 @@ EXPORTED int conversations_open_path(const char *fname, const char *userid, int 
     open_conversations = open;
 
     /* first ensure that the usernamespace is locked */
-    if (userid) {
-        int haslock = user_isnamespacelocked(userid);
-        if (haslock) {
-            if (!shared) assert(haslock != LOCK_SHARED);
-        }
-        else {
-            int locktype = shared ? LOCK_SHARED : LOCK_EXCLUSIVE;
-            open->local_namespacelock = user_namespacelock_full(userid, locktype);
-        }
+    int haslock = user_isnamespacelocked(userid);
+    if (haslock) {
+        if (!shared) assert(haslock != LOCK_SHARED);
+    }
+    else {
+        int locktype = shared ? LOCK_SHARED : LOCK_EXCLUSIVE;
+        open->local_namespacelock = user_namespacelock_full(userid, locktype);
     }
 
     /* open db */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -9390,7 +9390,7 @@ static void cmd_status(char *tag, char *name)
                                  &backend_current, &backend_inbox, imapd_in);
             if (!s) r = IMAP_SERVER_UNAVAILABLE;
 
-            imapd_check(s, 0);
+            imapd_check(s, 1);
 
             if (!r) {
                 prot_printf(s->out, "%s Status {" SIZE_T_FMT "+}\r\n%s ", tag,
@@ -9435,7 +9435,7 @@ static void cmd_status(char *tag, char *name)
 
     // status of selected mailbox, we need to refresh
     if (!r && !strcmpsafe(mbentry->name, index_mboxname(imapd_index)))
-        imapd_check(NULL, 0);
+        imapd_check(NULL, 1);
 
     if (!r) r = imapd_statusdata(mbentry, statusitems, &sdata);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6103,6 +6103,9 @@ static void cmd_search(char *tag, int usinguid)
         return;
     }
 
+    // this refreshes the index, we may be looking at it in our search
+    imapd_check(NULL, 0);
+
     if (searchargs->charset == CHARSET_UNKNOWN_CHARSET) {
         prot_printf(imapd_out, "%s NO %s\r\n", tag,
                error_message(IMAP_UNRECOGNIZED_CHARSET));

--- a/imap/index.c
+++ b/imap/index.c
@@ -2393,7 +2393,6 @@ EXPORTED int index_convmultisort(struct index_state *state,
     query = search_query_new(state, searchargs);
     query->multiple = 1;
     query->need_ids = 1;
-    query->need_expunge = 1;
     query->sortcrit = sortcrit;
 
     r = search_query_run(query);

--- a/imap/index.c
+++ b/imap/index.c
@@ -1170,16 +1170,17 @@ EXPORTED int index_fetch(struct index_state *state,
     struct index_map *im;
     uint32_t msgno;
     int r;
-    struct mboxevent *mboxevent = NULL;
+    // if FETCH_SETSEEN and ACLs permit, we need a writelock
+    int readonly = !(fetchargs->fetchitems & FETCH_SETSEEN && !state->examining && state->myrights & ACL_SETSEEN);
 
-    r = index_lock(state, /*readonly*/0);  // can't be readonly because of FETCH_SETSEEN
+    r = index_lock(state, readonly);
     if (r) return r;
 
     seq = _parse_sequence(state, sequence, usinguid);
 
     /* set the \Seen flag if necessary - while we still have the lock */
-    if (fetchargs->fetchitems & FETCH_SETSEEN && !state->examining && state->myrights & ACL_SETSEEN) {
-        mboxevent = mboxevent_new(EVENT_MESSAGE_READ);
+    if (!readonly) {
+        struct mboxevent *mboxevent = mboxevent_new(EVENT_MESSAGE_READ);
 
         for (msgno = 1; msgno <= state->exists; msgno++) {
             im = &state->map[msgno-1];
@@ -1193,6 +1194,10 @@ EXPORTED int index_fetch(struct index_state *state,
         mboxevent_set_access(mboxevent, NULL, NULL, state->userid, mailbox_name(state->mailbox), 1);
         mboxevent_set_numunseen(mboxevent, state->mailbox,
                                 state->numunseen);
+
+        /* send MessageRead event notification for successfully rewritten records */
+        mboxevent_notify(&mboxevent);
+        mboxevent_free(&mboxevent);
     }
 
     if (fetchargs->vanished) {
@@ -1207,10 +1212,6 @@ EXPORTED int index_fetch(struct index_state *state,
     }
 
     index_unlock(state);
-
-    /* send MessageRead event notification for successfully rewritten records */
-    mboxevent_notify(&mboxevent);
-    mboxevent_free(&mboxevent);
 
     index_checkflags(state, 1, 0);
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -1830,13 +1830,8 @@ static int index_lock(struct index_state *state, int readonly)
 
 EXPORTED int index_status(struct index_state *state, struct statusdata *sdata)
 {
-    int r = index_lock(state, /*readonly*/1);
-    if (r) return r;
-
     status_fill_mailbox(state->mailbox, sdata);
     status_fill_seen(state->userid, sdata, state->numrecent, state->numunseen);
-
-    index_unlock(state);
     return 0;
 }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1280,7 +1280,8 @@ static void _delayed_cleanup(void *rock)
      * if we are in the middle of a shutdown */
     if (in_shutdown) goto done;
 
-    int r = mailbox_open_exclusive(mboxname, &mailbox);
+    int r = mailbox_open_advanced(mboxname, LOCK_EXCLUSIVE|LOCK_NONBLOCK,
+                                  LOCK_EXCLUSIVE, &mailbox);
     if (r) goto done;
 
     if (mailbox->i.options & OPT_MAILBOX_NEEDS_REPACK) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1040,16 +1040,14 @@ static int mailbox_open_advanced(const char *name,
 
     // lock the user namespace FIRST before the mailbox namespace
     char *userid = mboxname_to_userid(name);
-    if (userid) {
-        int haslock = user_isnamespacelocked(userid);
-        if (haslock) {
-            if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
-        }
-        else {
-            mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
-        }
-        free(userid);
+    int haslock = user_isnamespacelocked(userid);
+    if (haslock) {
+        if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
     }
+    else {
+        mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
+    }
+    free(userid);
 
     if (mbe) mbentry = mboxlist_entry_copy(mbe);
     else r = mboxlist_lookup_allow_all(name, &mbentry, NULL);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1277,7 +1277,7 @@ static void _delayed_cleanup(void *rock)
     if (in_shutdown) goto done;
 
     int r = mailbox_open_advanced(mboxname, LOCK_EXCLUSIVE|LOCK_NONBLOCK,
-                                  LOCK_EXCLUSIVE, &mailbox);
+                                  LOCK_EXCLUSIVE, NULL, &mailbox);
     if (r) goto done;
 
     if (mailbox->i.options & OPT_MAILBOX_NEEDS_REPACK) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1021,9 +1021,9 @@ static int mailbox_open_advanced(const char *name,
     /* already open?  just use this one */
     if (listitem) {
         /* can't reuse an exclusive locked mailbox */
-        if (listitem->l->locktype == LOCK_EXCLUSIVE)
+        if (listitem->l->locktype & LOCK_EXCLUSIVE)
             return IMAP_MAILBOX_LOCKED;
-        if (locktype == LOCK_EXCLUSIVE)
+        if (locktype & LOCK_EXCLUSIVE)
             return IMAP_MAILBOX_LOCKED;
         /* can't reuse an already locked index */
         if (listitem->m.index_locktype)
@@ -1043,11 +1043,10 @@ static int mailbox_open_advanced(const char *name,
     if (userid) {
         int haslock = user_isnamespacelocked(userid);
         if (haslock) {
-            if (index_locktype != LOCK_SHARED) assert(haslock != LOCK_SHARED);
+            if (!(index_locktype & LOCK_SHARED)) assert(!(haslock & LOCK_SHARED));
         }
         else {
-            int locktype = index_locktype;
-            mailbox->local_namespacelock = user_namespacelock_full(userid, locktype);
+            mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
         }
         free(userid);
     }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1043,7 +1043,7 @@ static int mailbox_open_advanced(const char *name,
     if (userid) {
         int haslock = user_isnamespacelocked(userid);
         if (haslock) {
-            if (!(index_locktype & LOCK_SHARED)) assert(!(haslock & LOCK_SHARED));
+            if (index_locktype & LOCK_EXCLUSIVE) assert(haslock & LOCK_EXCLUSIVE);
         }
         else {
             mailbox->local_namespacelock = user_namespacelock_full(userid, index_locktype);
@@ -1054,7 +1054,18 @@ static int mailbox_open_advanced(const char *name,
     if (mbe) mbentry = mboxlist_entry_copy(mbe);
     else r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
 
+    /* pre-check for some conditions which mean that we don't want
+       to go ahead and open this mailbox */
     if (!r && mbentry->mbtype & MBTYPE_DELETED)
+        r = IMAP_MAILBOX_NONEXISTENT;
+
+    if (!r && mbentry->mbtype & MBTYPE_MOVING)
+        r = IMAP_MAILBOX_MOVED;
+
+    if (!r && mbentry->mbtype & MBTYPE_INTERMEDIATE)
+        r = IMAP_MAILBOX_NONEXISTENT;
+
+    if (!r && !mbentry->partition)
         r = IMAP_MAILBOX_NONEXISTENT;
 
     if (r) {
@@ -1091,21 +1102,6 @@ static int mailbox_open_advanced(const char *name,
 
     if (!mbentry->name) mbentry->name = xstrdup(name);
     mailbox->mbentry = mbentry;
-
-    if (mbentry->mbtype & MBTYPE_MOVING) {
-        r = IMAP_MAILBOX_MOVED;
-        goto done;
-    }
-
-    if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
-        r = IMAP_MAILBOX_NONEXISTENT;
-        goto done;
-    }
-
-    if (!mbentry->partition) {
-        r = IMAP_MAILBOX_NONEXISTENT;
-        goto done;
-    }
 
     if (index_locktype == LOCK_SHARED)
         mailbox->is_readonly = 1;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3061,12 +3061,11 @@ static int mboxlist_have_admin_rights(const char *rights) {
  * pointer, removes the ACL entry for 'identifier'.   'isadmin' is
  * nonzero if user is a mailbox admin.  'userid' is the user's login id.
  *
- * 1. Start transaction
- * 2. Check rights
- * 3. Set db entry
- * 4. Change backup copy (cyrus.header)
- * 5. Commit transaction
- * 6. Change mupdate entry
+ * 1. Open and writelock mailbox
+ * 2. Update ACL in mailbox header
+ * 4. Commit mailbox
+ * 3. Update db entry
+ * 5. Change mupdate entry
  *
  */
 EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((unused)),
@@ -3076,6 +3075,7 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
                     const struct auth_state *auth_state)
 {
     mbentry_t *mbentry = NULL;
+    modseq_t foldermodseq = 0;
     int r;
     int myrights;
     int mode = ACL_MODE_SET;
@@ -3085,18 +3085,18 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
     int ensure_owner_rights = 0;
     int mask;
     const char *mailbox_owner = NULL;
-    struct mailbox *mailbox = NULL;
     char *newacl = NULL;
-    struct txn *tid = NULL;
 
     init_internal();
+
+    // the namespacelock will protect us from all races on the local mailboxes.db
+    // so we can just read away and know it won't change under us.
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
 
     /* round trip identifier to potentially strip domain */
     mbname_t *idname = mbname_from_userid(identifier);
     /* XXX - enforce cross domain restrictions */
     identifier = mbname_userid(idname);
-
-    char *dbname = mboxname_to_dbname(name);
 
     /* checks if the mailbox belongs to the user who is trying to change the
        access rights */
@@ -3120,40 +3120,16 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
        the identifier */
     ensure_owner_rights = isusermbox || isidentifiermbox;
 
-    /* 1. Start Transaction */
-    /* lookup the mailbox to make sure it exists and get its acl */
-    do {
-        r = mboxlist_mylookup(dbname, &mbentry, &tid, 1, 1);
-    } while(r == IMAP_AGAIN);
+    r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
+    if (r) goto done;
 
     /* Can't do this to an in-transit or reserved mailbox */
-    if (!r && mbentry->mbtype & (MBTYPE_MOVING | MBTYPE_RESERVE | MBTYPE_DELETED)) {
+    if (mbentry->mbtype & (MBTYPE_MOVING | MBTYPE_RESERVE | MBTYPE_DELETED)) {
         r = IMAP_MAILBOX_NOTSUPPORTED;
+        goto done;
     }
 
-    /* if it is not a remote mailbox, we need to unlock the mailbox list,
-     * lock the mailbox, and re-lock the mailboxes list */
-    /* we must do this to obey our locking rules */
-    if (!r && !(mbentry->mbtype & MBTYPE_REMOTE)) {
-        cyrusdb_abort(mbdb, tid);
-        tid = NULL;
-        mboxlist_entry_free(&mbentry);
-
-        /* open & lock mailbox header */
-        r = mailbox_open_iwl(name, &mailbox);
-
-        if (!r) {
-            do {
-                /* lookup the mailbox to make sure it exists and get its acl */
-                r = mboxlist_mylookup(dbname, &mbentry, &tid, 1, 1);
-            } while (r == IMAP_AGAIN);
-        }
-
-        if(r) goto done;
-    }
-
-    /* 2. Check Rights */
-    if (!r && !isadmin) {
+    if (!isadmin) {
         myrights = cyrus_acl_myrights(auth_state, mbentry->acl);
         if (!(myrights & ACL_ADMIN)) {
             r = (myrights & ACL_LOOKUP) ?
@@ -3162,111 +3138,102 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
         }
     }
 
-    /* 2.1 Only admin user can set 'anyone' rights if config says so */
-    if (!r && !isadmin && !anyoneuseracl && !strncmp(identifier, "anyone", 6)) {
-      r = IMAP_PERMISSION_DENIED;
-      goto done;
+    if (!isadmin && !anyoneuseracl && !strncmp(identifier, "anyone", 6)) {
+        r = IMAP_PERMISSION_DENIED;
+        goto done;
     }
 
-    /* 3. Set DB Entry */
-    if(!r) {
-        /* Make change to ACL */
-        newacl = xstrdup(mbentry->acl);
-        if (rights && *rights) {
-            /* rights are present and non-empty */
-            mode = ACL_MODE_SET;
-            if (*rights == '+') {
-                rights++;
-                mode = ACL_MODE_ADD;
-            }
-            else if (*rights == '-') {
-                rights++;
-                mode = ACL_MODE_REMOVE;
-            }
-            /* do not allow non-admin user to remove the admin rights from mailbox owner */
-            if (!isadmin && isidentifiermbox && mode != ACL_MODE_ADD) {
-                int has_admin_rights = mboxlist_have_admin_rights(rights);
-                if ((has_admin_rights && mode == ACL_MODE_REMOVE) ||
-                   (!has_admin_rights && mode != ACL_MODE_REMOVE)) {
-                    syslog(LOG_ERR, "Denied removal of admin rights on "
-                           "folder \"%s\" (owner: %s) by user \"%s\"", name,
-                           mailbox_owner, userid);
-                    r = IMAP_PERMISSION_DENIED;
-                    goto done;
-                }
-            }
-
-            r = cyrus_acl_strtomask(rights, &mask);
-
-            if (!r && cyrus_acl_set(&newacl, identifier, mode, mask,
-                                    ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
-                                    (void *)mailbox_owner)) {
-                r = IMAP_INVALID_IDENTIFIER;
-            }
-        } else {
-            /* do not allow to remove the admin rights from mailbox owner */
-            if (!isadmin && isidentifiermbox) {
+    /* generate new rights string */
+    newacl = xstrdup(mbentry->acl);
+    if (rights && *rights) {
+        /* rights are present and non-empty */
+        mode = ACL_MODE_SET;
+        if (*rights == '+') {
+            rights++;
+            mode = ACL_MODE_ADD;
+        }
+        else if (*rights == '-') {
+            rights++;
+            mode = ACL_MODE_REMOVE;
+        }
+        /* do not allow non-admin user to remove the admin rights from mailbox owner */
+        if (!isadmin && isidentifiermbox && mode != ACL_MODE_ADD) {
+            int has_admin_rights = mboxlist_have_admin_rights(rights);
+            if ((has_admin_rights && mode == ACL_MODE_REMOVE) ||
+               (!has_admin_rights && mode != ACL_MODE_REMOVE)) {
                 syslog(LOG_ERR, "Denied removal of admin rights on "
                        "folder \"%s\" (owner: %s) by user \"%s\"", name,
                        mailbox_owner, userid);
                 r = IMAP_PERMISSION_DENIED;
                 goto done;
             }
+        }
 
-            if (cyrus_acl_remove(&newacl, identifier,
-                                 ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
-                                 (void *)mailbox_owner)) {
-                r = IMAP_INVALID_IDENTIFIER;
-            }
+        r = cyrus_acl_strtomask(rights, &mask);
+
+        if (!r && cyrus_acl_set(&newacl, identifier, mode, mask,
+                                ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
+                                (void *)mailbox_owner)) {
+            r = IMAP_INVALID_IDENTIFIER;
         }
     }
+    else {
+        /* do not allow to remove the admin rights from mailbox owner */
+        if (!isadmin && isidentifiermbox) {
+            syslog(LOG_ERR, "Denied removal of admin rights on "
+                   "folder \"%s\" (owner: %s) by user \"%s\"", name,
+                   mailbox_owner, userid);
+            r = IMAP_PERMISSION_DENIED;
+            goto done;
+        }
 
-    if (!r) {
-        /* ok, change the database */
-        free(mbentry->acl);
-        mbentry->acl = xstrdupnull(newacl);
-        mbentry->foldermodseq = mailbox_modseq_dirty(mailbox);
-
-        r = mboxlist_update_entry(name, mbentry, &tid);
-
-        if (r) {
-            xsyslog(LOG_ERR, "DBERROR: error updating acl",
-                             "mailbox=<%s> error=<%s>",
-                             name, cyrusdb_strerror(r));
-            r = IMAP_IOERROR;
+        if (cyrus_acl_remove(&newacl, identifier,
+                             ensure_owner_rights ? mboxlist_ensureOwnerRights : 0,
+                             (void *)mailbox_owner)) {
+            r = IMAP_INVALID_IDENTIFIER;
         }
     }
+    if (r) goto done;
 
-    /* 4. Commit transaction */
-    if (!r) {
-        if((r = cyrusdb_commit(mbdb, tid)) != 0) {
-            xsyslog(LOG_ERR, "DBERROR: failed on commit",
-                             "error=<%s>",
-                             cyrusdb_strerror(r));
-            r = IMAP_IOERROR;
+    /* if it is not a remote mailbox, we need to update the copy in the mailbox header */
+    if (!(mbentry->mbtype & MBTYPE_REMOTE)) {
+        struct mailbox *mailbox = NULL;
+        r = mailbox_open_iwl(name, &mailbox);
+        if (!r) {
+            foldermodseq = mailbox_modseq_dirty(mailbox);
+            mailbox_set_acl(mailbox, newacl);
+
+            /* send a AclChange event notification */
+            struct mboxevent *mboxevent = mboxevent_new(EVENT_ACL_CHANGE);
+            mboxevent_extract_mailbox(mboxevent, mailbox);
+            mboxevent_set_acl(mboxevent, identifier, rights);
+            mboxevent_set_access(mboxevent, NULL, NULL, userid, mailbox_name(mailbox), 0);
+            mboxevent_notify(&mboxevent);
+            mboxevent_free(&mboxevent);
+
+            r = mailbox_commit(mailbox);
+            mailbox_close(&mailbox);
         }
-        tid = NULL;
+        if (r) goto done;
     }
 
-    /* 5. Change backup copy (cyrus.header) */
-    /* we already have it locked from above */
-    if (!r && !(mbentry->mbtype & MBTYPE_REMOTE)) {
-        mailbox_set_acl(mailbox, newacl);
-        /* want to commit immediately to ensure ordering */
-        r = mailbox_commit(mailbox);
+    /* change the local database */
+    free(mbentry->acl);
+    mbentry->acl = xstrdupnull(newacl);
+    if (mbentry->foldermodseq < foldermodseq)
+        mbentry->foldermodseq = foldermodseq;
 
-        /* send a AclChange event notification */
-        struct mboxevent *mboxevent = mboxevent_new(EVENT_ACL_CHANGE);
-        mboxevent_extract_mailbox(mboxevent, mailbox);
-        mboxevent_set_acl(mboxevent, identifier, rights);
-        mboxevent_set_access(mboxevent, NULL, NULL, userid, mailbox_name(mailbox), 0);
-
-        mboxevent_notify(&mboxevent);
-        mboxevent_free(&mboxevent);
+    r = mboxlist_update_entry(name, mbentry, NULL);
+    if (r) {
+        xsyslog(LOG_ERR, "DBERROR: error updating acl",
+                         "mailbox=<%s> error=<%s>",
+                         name, cyrusdb_strerror(r));
+        r = IMAP_IOERROR;
+        goto done;
     }
 
-    /* 6. Change mupdate entry  */
-    if (!r && config_mupdate_server) {
+    /* Update the remote database */
+    if (config_mupdate_server) {
         mupdate_handle *mupdate_h = NULL;
         /* commit the update to MUPDATE */
         char buf[MAX_PARTITION_LEN + HOSTNAME_SIZE + 2];
@@ -3274,11 +3241,12 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
         snprintf(buf, sizeof(buf), "%s!%s", config_servername, mbentry->partition);
 
         r = mupdate_connect(config_mupdate_server, NULL, &mupdate_h, NULL);
-        if(r) {
+        if (r) {
             syslog(LOG_ERR,
                    "cannot connect to mupdate server for setacl on '%s'",
                    name);
-        } else {
+        }
+        else {
             r = mupdate_activate(mupdate_h, name, buf, newacl);
             if(r) {
                 syslog(LOG_ERR,
@@ -3290,20 +3258,10 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
     }
 
   done:
-    if (r && tid) {
-        /* if we are mid-transaction, abort it! */
-        int r2 = cyrusdb_abort(mbdb, tid);
-        if (r2) {
-            syslog(LOG_ERR,
-                   "DBERROR: error aborting txn in mboxlist_setacl: %s",
-                   cyrusdb_strerror(r2));
-        }
-    }
-    mailbox_close(&mailbox);
     free(newacl);
     mboxlist_entry_free(&mbentry);
     mbname_free(&idname);
-    free(dbname);
+    mboxname_release(&namespacelock);
 
     return r;
 }
@@ -3311,15 +3269,24 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
 /* change the ACL for mailbox 'name' when we have nothing but the name and the new value */
 EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
 {
+    // the namespacelock will protect us from all races on the local mailboxes.db
+    // so we can just read away and know it won't change under us.
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
+
     struct mailbox *mailbox = NULL;
+    modseq_t foldermodseq = 0;
+
     int r = mailbox_open_iwl(name, &mailbox);
-    if (!r)
-        r = mboxlist_sync_setacls(name, newacl, mailbox_modseq_dirty(mailbox));
     if (!r) {
+        foldermodseq = mailbox_modseq_dirty(mailbox);
         mailbox_set_acl(mailbox, newacl);
         r = mailbox_commit(mailbox);
     }
     mailbox_close(&mailbox);
+
+    if (!r) r = mboxlist_sync_setacls(name, newacl, foldermodseq);
+
+    mboxname_release(&namespacelock);
     return r;
 }
 
@@ -3337,18 +3304,15 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
 EXPORTED int
 mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodseq)
 {
+    // the namespacelock will protect us from all races on the local mailboxes.db
+    // so we can just read away and know it won't change under us.
+    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
     mbentry_t *mbentry = NULL;
     int r;
-    struct txn *tid = NULL;
-    char *dbname = mboxname_to_dbname(name);
 
     init_internal();
 
-    /* 1. Start Transaction */
-    /* lookup the mailbox to make sure it exists and get its acl */
-    do {
-        r = mboxlist_mylookup(dbname, &mbentry, &tid, 1, 1);
-    } while(r == IMAP_AGAIN);
+    r = mboxlist_lookup_allow_all(name, &mbentry, NULL);
     if (r) goto done;
 
     // nothing to change, great
@@ -3367,7 +3331,7 @@ mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodse
     if (mbentry->foldermodseq < foldermodseq)
         mbentry->foldermodseq = foldermodseq;
 
-    r = mboxlist_update_entry(name, mbentry, &tid);
+    r = mboxlist_update_entry(name, mbentry, NULL);
 
     if (r) {
         xsyslog(LOG_ERR, "DBERROR: error updating acl",
@@ -3376,17 +3340,6 @@ mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodse
         r = IMAP_IOERROR;
         goto done;
     }
-
-    /* 3. Commit transaction */
-    r = cyrusdb_commit(mbdb, tid);
-    if (r) {
-        xsyslog(LOG_ERR, "DBERROR: failed on commit",
-                         "mailbox=<%s> error=<%s>",
-                         name, cyrusdb_strerror(r));
-        r = IMAP_IOERROR;
-        goto done;
-    }
-    tid = NULL;
 
     /* 4. Change mupdate entry  */
     if (config_mupdate_server) {
@@ -3412,19 +3365,8 @@ mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodse
     }
 
 done:
-    free(dbname);
-
-    if (tid) {
-        /* if we are mid-transaction, abort it! */
-        int r2 = cyrusdb_abort(mbdb, tid);
-        if (r2) {
-            syslog(LOG_ERR,
-                   "DBERROR: error aborting txn in sync_setacls %s: %s",
-                   name, cyrusdb_strerror(r2));
-        }
-    }
-
     mboxlist_entry_free(&mbentry);
+    mboxname_release(&namespacelock);
 
     return r;
 }

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -329,12 +329,10 @@ static int query_begin_index(search_query_t *query,
                              struct index_state **statep)
 {
     int r = 0;
-    int needs_refresh = 0;
 
     /* open an index_state */
     if (!strcmp(index_mboxname(query->state), mboxname)) {
         *statep = query->state;
-        needs_refresh = 1;
     }
     else {
         struct index_init init;
@@ -359,11 +357,6 @@ static int query_begin_index(search_query_t *query,
         /* make sure \Deleted messages are expunged.  Will also lock the
          * mailbox state and read any new information */
         r = index_expunge(*statep, NULL, 1);
-        if (r) goto out;
-    }
-    else if (needs_refresh) {
-        /* Expunge considered unhelpful - just refresh */
-        r = index_refresh(*statep);
         if (r) goto out;
     }
 

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -353,13 +353,6 @@ static int query_begin_index(search_query_t *query,
         index_checkflags(*statep, 0, 0);
     }
 
-    if (query->need_expunge) {
-        /* make sure \Deleted messages are expunged.  Will also lock the
-         * mailbox state and read any new information */
-        r = index_expunge(*statep, NULL, 1);
-        if (r) goto out;
-    }
-
     r = cmd_cancelled(!query->ignore_timer);
 
 out:

--- a/imap/search_query.h
+++ b/imap/search_query.h
@@ -110,7 +110,6 @@ struct search_query {
     const struct sortcrit *sortcrit;
     int multiple;
     int need_ids;
-    int need_expunge;
     int want_expunged;
     uint32_t want_mbtype;
     int verbose;

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -897,16 +897,7 @@ EXPORTED int sieve_ensure_folder(const char *userid, struct mailbox **mailboxptr
         r = mboxlist_lookup(mboxname, NULL, NULL);
     }
 
-    if (!r && mailboxptr) {
-        r = mailbox_open_iwl(mboxname, mailboxptr);
-        if (r) {
-            syslog(LOG_ERR, "IOERROR: failed to open %s (%s)",
-                   mboxname, error_message(r));
-            goto done;
-        }
-    }
-
-    else if (r == IMAP_MAILBOX_NONEXISTENT) {
+    if (r == IMAP_MAILBOX_NONEXISTENT) {
         /* Create locally */
         struct mailbox *mailbox = NULL;
         mbentry_t mbentry = MBENTRY_INITIALIZER;
@@ -930,8 +921,19 @@ EXPORTED int sieve_ensure_folder(const char *userid, struct mailbox **mailboxptr
 
         free(mrock.active);
 
-        if (mailboxptr) *mailboxptr = mailbox;
-        else mailbox_close(&mailbox);
+        // close the mailbox here, we'll re-open once we've released the namespace lock
+        mailbox_close(&mailbox);
+    }
+
+    mboxname_release(&namespacelock);
+
+    if (!r && mailboxptr) {
+        r = mailbox_open_iwl(mboxname, mailboxptr);
+        if (r) {
+            syslog(LOG_ERR, "IOERROR: failed to open %s (%s)",
+                   mboxname, error_message(r));
+            goto done;
+        }
     }
 
   done:


### PR DESCRIPTION
Backport of #4359 for 3.6, because we need a164795dc to fix #4611.

Most of this cherry-picked reasonably cleanly, the only commits I'm not confident about are the last two:

* imapd: always refresh index on SEARCH

This was 74a6462be, and updated the combined SEARCH/ESEARCH code from #4321, which 3.6 doesn't have.  I think I've distilled the essence out correctly for the older code, but I'm not sure.

* search_query: need_expunge is bogus

Not sure if I want this on 3.6, it doesn't seem locking-related, more of a while-we're-in-here-anyway.  I'm a little concerned that it "weirds CONVMULTISORT".