### PR TITLE
sitemap.py: sort work list for a stable sitemap.xml

### DIFF
--- a/docsrc/exts/sphinxlocal/sitemap.py
+++ b/docsrc/exts/sphinxlocal/sitemap.py
@@ -30,7 +30,7 @@ def generate_sitemap(app, exception):
         raise errors.ExtensionError("Cannot generate sitemap. Set 'sitemap_website' in conf.py with website hostname")
 
     env = app.builder.env
-    for page in env.found_docs:
+    for page in sorted(env.found_docs):
         for site in website:
             url = {}
             url["loc"] = "{}{}.html".format(site, page)


### PR DESCRIPTION
The default ordering of `env.found_docs` seems to be unstable in newer Sphinx versions, resulting in sitemap.xml changes every single time the website builder runs, even if nothing actually changed.

With this list now processed in sorted order, sitemap.xml shouldn't change unless we've actually added, removed, or renamed documents.