### PR TITLE
sieve-lex.l: fix warning for using function without prototype

### DIFF
--- a/sieve/sieve-lex.l
+++ b/sieve/sieve-lex.l
@@ -409,7 +409,7 @@ ws              [ \t]+
                                   /* RFC 5228: With the exceptions of strings
                                      and comments, the language is limited to
                                      US-ASCII characters. */
-                                  if (!isascii(yytext[0])) {
+                                  if (yytext[0] & ~0x7f) {
                                       sieveerror(sscript, "non-ASCII character");
                                   }
                                   return yytext[0];


### PR DESCRIPTION
I cannot get the warning disappear by any other way.