### PR TITLE
track the behavior seen by clients

### DIFF
--- a/cassandane/Cassandane/Cyrus/ID.pm
+++ b/cassandane/Cassandane/Cyrus/ID.pm
@@ -69,6 +69,9 @@ sub test_cmd_id
 {
     my ($self) = @_;
 
+    # Purge any syslog lines before this test runs.
+    $self->{instance}->getsyslog();
+
     my $imaptalk = $self->{store}->get_client();
 
     return if not $imaptalk->capability()->{id};
@@ -77,6 +80,22 @@ sub test_cmd_id
     xlog $self, Dumper $res;
 
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    # should have logged some timer output, which should include the sess id,
+    # and since we sent a client id via IMAP ID, we should get that, too!
+    if ($self->{instance}->{have_syslog_replacement}) {
+        # make sure that the connection is ended so that imapd reset happens
+        $imaptalk->logout();
+        undef $imaptalk;
+
+        my @lines = $self->{instance}->getsyslog();
+
+        my (@behavior_lines) = grep { /session ended/ } @lines;
+
+        $self->assert_num_gte(1, scalar @behavior_lines);
+
+        $self->assert_matches(qr/\bid\.name=<cassandane>/, $_) for @behavior_lines;
+    }
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -280,6 +280,10 @@ sub test_message
 
     # we enabled NOTIFY, so we should see it in client behaviors
     if ($self->{instance}->{have_syslog_replacement}) {
+        # make sure that the connection is ended so that imapd reset happens
+        $talk->logout();
+        undef $talk;
+
         my (@lines) = grep { /session ended/ && /notify=<1>/ }
                       $self->{instance}->getsyslog();
 

--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -277,6 +277,14 @@ sub test_message
     # Should get no unsolicited responses
     $res = $store->idle_response({}, 1);
     $self->assert(!$res, "no unsolicited responses");
+
+    # we enabled NOTIFY, so we should see it in client behaviors
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my (@lines) = grep { /session ended/ && /notify=<1>/ }
+                      $self->{instance}->getsyslog();
+
+        $self->assert_num_gte(1, scalar @lines);
+    }
 }
 
 sub test_mailbox

--- a/cassandane/Cassandane/Cyrus/Simple.pm
+++ b/cassandane/Cassandane/Cyrus/Simple.pm
@@ -195,11 +195,18 @@ sub test_cmdtimer_sessionid
 
     # should have logged some timer output, which should include the sess id
     if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = grep { m/\bcmdtimer:/ } $self->{instance}->getsyslog();
-        $self->assert_num_gte(1, scalar @lines);
-        foreach my $line (@lines) {
+        my @lines = $self->{instance}->getsyslog();
+
+        my @timer_lines = grep { m/\bcmdtimer:/ } @lines;
+        $self->assert_num_gte(1, scalar @timer_lines);
+        foreach my $line (@timer_lines) {
             $self->assert_matches(qr/sessionid=<[^ >]+>/, $line);
         }
+
+        my (@behavior_lines) = grep { /session ended/ && /notify=<[01]>/ }
+                               @lines;
+
+        $self->assert_num_gte(1, scalar @behavior_lines);
     }
 }
 

--- a/cassandane/Cassandane/Cyrus/Simple.pm
+++ b/cassandane/Cassandane/Cyrus/Simple.pm
@@ -195,6 +195,10 @@ sub test_cmdtimer_sessionid
 
     # should have logged some timer output, which should include the sess id
     if ($self->{instance}->{have_syslog_replacement}) {
+        # make sure that the connection is ended so that imapd reset happens
+        $imaptalk->logout();
+        undef $imaptalk;
+
         my @lines = $self->{instance}->getsyslog();
 
         my @timer_lines = grep { m/\bcmdtimer:/ } @lines;

--- a/cassandane/Cassandane/Cyrus/Simple.pm
+++ b/cassandane/Cassandane/Cyrus/Simple.pm
@@ -203,8 +203,7 @@ sub test_cmdtimer_sessionid
             $self->assert_matches(qr/sessionid=<[^ >]+>/, $line);
         }
 
-        my (@behavior_lines) = grep { /session ended/ && /notify=<[01]>/ }
-                               @lines;
+        my (@behavior_lines) = grep { /session ended/ } @lines;
 
         $self->assert_num_gte(1, scalar @behavior_lines);
     }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -11070,6 +11070,8 @@ static void cmd_getmetadata(const char *tag)
     struct getmetadata_options opts = OPTS_INITIALIZER;
     annotate_state_t *astate = NULL;
 
+    client_behavior.did_metadata = 1;
+
     while (nlists < 3)
     {
         c = parse_metadata_string_or_list(tag, &lists[nlists], &is_list[nlists]);
@@ -11299,6 +11301,8 @@ static void cmd_setmetadata(const char *tag, char *mboxpat)
     int c, r = 0;
     struct entryattlist *entryatts = NULL;
     annotate_state_t *astate = NULL;
+
+    client_behavior.did_metadata = 1;
 
     c = parse_metadata_store_data(tag, &entryatts);
     if (c == EOF) {

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5525,6 +5525,9 @@ static void cmd_fetch(char *tag, char *sequence, int usinguid)
     if (usinguid)
         fetchargs.fetchitems |= FETCH_UID;
 
+    if (fetchargs.fetchitems & FETCH_ANNOTATION)
+        client_behavior.did_annotate = 1;
+
     r = index_fetch(imapd_index, sequence, usinguid, &fetchargs,
                 &fetchedsomething);
 
@@ -10821,6 +10824,8 @@ static void cmd_getannotation(const char *tag, char *mboxpat)
     strarray_t attribs = STRARRAY_INITIALIZER;
     annotate_state_t *astate = NULL;
 
+    client_behavior.did_annotate = 1;
+
     c = parse_annotate_fetch_data(tag, /*permessage_flag*/0, &entries, &attribs);
     if (c == EOF) {
         eatline(imapd_in, c);
@@ -11213,6 +11218,8 @@ static void cmd_setannotation(const char *tag, char *mboxpat)
     int c, r = 0;
     struct entryattlist *entryatts = NULL;
     annotate_state_t *astate = NULL;
+
+    client_behavior.did_annotate = 1;
 
     c = parse_annotate_store_data(tag, 0, &entryatts);
     if (c == EOF) {

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7106,6 +7106,8 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
     char *copyuid = NULL;
     mbentry_t *mbentry = NULL;
 
+    if (ismove) client_behavior.did_move = 1;
+
     char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
     r = mlookup(NULL, NULL, intname, &mbentry);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5531,6 +5531,9 @@ static void cmd_fetch(char *tag, char *sequence, int usinguid)
     if (fetchargs.fetchitems & FETCH_PREVIEW)
         client_behavior.did_preview = 1;
 
+    if (fetchargs.fetchitems & FETCH_SAVEDATE)
+        client_behavior.did_savedate = 1;
+
     r = index_fetch(imapd_index, sequence, usinguid, &fetchargs,
                 &fetchedsomething);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -870,14 +870,37 @@ static void imapd_reset(void)
     /* run delayed commands first before closing anything */
     libcyrus_run_delayed();
 
-    /* log the client behaviors */
+    /* log the client behaviors
+     *
+     * This slightly weird sprintf-ing is do that we only log the hits, not the
+     * misses.  Most connections, even those from clients that support
+     * SEARCHRES, won't use SEARCH SAVE, for example.  This pushes just a
+     * little complexity into the log processor, but should mean that the logs
+     * are a bit easier to skim and a bit smaller.
+     */
     xsyslog(LOG_NOTICE, "session ended",
                         "sessionid=<%s> userid=<%s>"
-                        " compress=<%u> notify=<%u>",
+                        "%s%s%s%s"
+                        "%s%s%s%s"
+                        "%s%s%s%s",
+
                         session_id(),
                         imapd_userid ? imapd_userid : "",
-                        client_behavior.did_compress,
-                        client_behavior.did_notify);
+
+                        client_behavior.did_annotate  ? " annotate=<1>"   : "",
+                        client_behavior.did_compress  ? " compress=<1>"   : "",
+                        client_behavior.did_condstore ? " condstore=<1>"  : "",
+                        client_behavior.did_idle      ? " idle=<1>"       : "",
+
+                        client_behavior.did_metadata  ? " metadata=<1>"   : "",
+                        client_behavior.did_move      ? " move=<1>"       : "",
+                        client_behavior.did_notify    ? " notify=<1>"     : "",
+                        client_behavior.did_preview   ? " preview=<1>"    : "",
+
+                        client_behavior.did_qresync   ? " qresync=<1>"    : "",
+                        client_behavior.did_replace   ? " replace=<1>"    : "",
+                        client_behavior.did_savedate  ? " savedate=<1>"   : "",
+                        client_behavior.did_searchres ? " searchres=<1>"  : "");
 
     memset(&client_behavior, 0, sizeof(client_behavior));
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -882,25 +882,28 @@ static void imapd_reset(void)
                         "sessionid=<%s> userid=<%s>"
                         "%s%s%s%s"
                         "%s%s%s%s"
-                        "%s%s%s%s",
+                        "%s%s%s%s"
+                        "%s",
 
                         session_id(),
                         imapd_userid ? imapd_userid : "",
 
-                        client_behavior.did_annotate  ? " annotate=<1>"   : "",
-                        client_behavior.did_compress  ? " compress=<1>"   : "",
-                        client_behavior.did_condstore ? " condstore=<1>"  : "",
-                        client_behavior.did_idle      ? " idle=<1>"       : "",
+                        client_behavior.did_annotate    ? " annotate=<1>"     : "",
+                        client_behavior.did_compress    ? " compress=<1>"     : "",
+                        client_behavior.did_condstore   ? " condstore=<1>"    : "",
+                        client_behavior.did_idle        ? " idle=<1>"         : "",
 
-                        client_behavior.did_metadata  ? " metadata=<1>"   : "",
-                        client_behavior.did_move      ? " move=<1>"       : "",
-                        client_behavior.did_notify    ? " notify=<1>"     : "",
-                        client_behavior.did_preview   ? " preview=<1>"    : "",
+                        client_behavior.did_metadata    ? " metadata=<1>"     : "",
+                        client_behavior.did_move        ? " move=<1>"         : "",
+                        client_behavior.did_multisearch ? " multisearch=<1>"  : "",
+                        client_behavior.did_notify      ? " notify=<1>"       : "",
 
-                        client_behavior.did_qresync   ? " qresync=<1>"    : "",
-                        client_behavior.did_replace   ? " replace=<1>"    : "",
-                        client_behavior.did_savedate  ? " savedate=<1>"   : "",
-                        client_behavior.did_searchres ? " searchres=<1>"  : "");
+                        client_behavior.did_preview     ? " preview=<1>"      : "",
+                        client_behavior.did_qresync     ? " qresync=<1>"      : "",
+                        client_behavior.did_replace     ? " replace=<1>"      : "",
+                        client_behavior.did_savedate    ? " savedate=<1>"     : "",
+
+                        client_behavior.did_searchres   ? " searchres=<1>"    : "");
 
     memset(&client_behavior, 0, sizeof(client_behavior));
 
@@ -6429,6 +6432,7 @@ static void cmd_search(char *tag, char *cmd)
 
     switch (cmd[0]) {
     case 'E':  // Esearch (multisearch)
+        client_behavior.did_multisearch = 1;
         state |= GETSEARCH_SOURCE;
 
         GCC_FALLTHROUGH

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4503,6 +4503,7 @@ static void cmd_select(char *tag, char *cmd, char *name)
             ucase(arg.s);
             if (!strcmp(arg.s, "CONDSTORE")) {
                 client_capa |= CAPA_CONDSTORE;
+                client_behavior.did_condstore = 1;
             }
             else if ((client_capa & CAPA_QRESYNC) &&
                      !strcmp(arg.s, "QRESYNC")) {
@@ -6123,6 +6124,8 @@ static void cmd_store(char *tag, char *sequence, int usinguid)
             c = getword(imapd_in, &storemod);
             ucase(storemod.s);
             if (!strcmp(storemod.s, "UNCHANGEDSINCE")) {
+                client_behavior.did_condstore = 1;
+
                 if (c != ' ') {
                     prot_printf(imapd_out,
                                 "%s BAD Missing required argument to %s %s\r\n",

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3487,6 +3487,8 @@ static void cmd_idle(char *tag)
     struct protstream *be_in = NULL;
     int extra_fd = idle_sock;
 
+    client_behavior.did_idle = 1;
+
     /* get idle timeout */
     if (idle_timeout == -1) {
         idle_timeout = config_getduration(IMAPOPT_IMAPIDLETIMEOUT, 'm');

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5528,6 +5528,9 @@ static void cmd_fetch(char *tag, char *sequence, int usinguid)
     if (fetchargs.fetchitems & FETCH_ANNOTATION)
         client_behavior.did_annotate = 1;
 
+    if (fetchargs.fetchitems & FETCH_PREVIEW)
+        client_behavior.did_preview = 1;
+
     r = index_fetch(imapd_index, sequence, usinguid, &fetchargs,
                 &fetchedsomething);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6420,6 +6420,9 @@ static void cmd_search(char *tag, char *cmd)
                                 &imapd_namespace, imapd_userid, imapd_authstate,
                                 imapd_userisadmin || imapd_userisproxyadmin);
 
+    if (searchargs->returnopts & SEARCH_RETURN_SAVE)
+      client_behavior.did_searchres = 1;
+
     /* Set FUZZY search according to config and quirks */
     static const char *annot = IMAP_ANNOT_NS "search-fuzzy-always";
     char *inbox = mboxname_user_mbox(imapd_userid, NULL);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -15513,6 +15513,8 @@ static void cmd_replace(char *tag, char *seqno, char *name, int usinguid)
     char *intname = NULL;
     int r = 0;
 
+    client_behavior.did_replace = 1;
+
     /* Need permission to delete message and seqno must be valid */
     if (backend_current) {
         static const int needrights = ACL_DELETEMSG|ACL_EXPUNGE;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4509,6 +4509,8 @@ static void cmd_select(char *tag, char *cmd, char *name)
                      !strcmp(arg.s, "QRESYNC")) {
                 char *p;
 
+                client_behavior.did_qresync = 1;
+
                 if (c != ' ') goto badqresync;
                 c = prot_getc(imapd_in);
                 if (c != '(') goto badqresync;

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -443,6 +443,7 @@ struct client_behavior_registry {
     unsigned int did_qresync  : 1;   /* gave QRESYNC on SELECT */
     unsigned int did_savedate : 1;   /* fetched SAVEDATE */
     unsigned int did_searchres: 1;   /* used SAVE on SEARCH */
+    unsigned int did_replace  : 1;   /* used REPLACE */
 };
 
 #endif /* INCLUDED_IMAPD_H */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -437,6 +437,7 @@ struct client_behavior_registry {
     unsigned int did_compress : 1;   /* started COMPRESS */
     unsigned int did_idle     : 1;   /* used IDLE */
     unsigned int did_notify   : 1;   /* used NOTIFY */
+    unsigned int did_preview  : 1;   /* fetched PREVIEW */
     unsigned int did_qresync  : 1;   /* gave QRESYNC on SELECT */
 };
 

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -436,6 +436,7 @@ struct client_behavior_registry {
     unsigned int did_compress : 1;   /* started COMPRESS */
     unsigned int did_idle     : 1;   /* used IDLE */
     unsigned int did_notify   : 1;   /* used NOTIFY */
+    unsigned int did_qresync  : 1;   /* gave QRESYNC on SELECT */
 };
 
 #endif /* INCLUDED_IMAPD_H */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -440,6 +440,7 @@ struct client_behavior_registry {
     unsigned int did_preview  : 1;   /* fetched PREVIEW */
     unsigned int did_qresync  : 1;   /* gave QRESYNC on SELECT */
     unsigned int did_savedate : 1;   /* fetched SAVEDATE */
+    unsigned int did_searchres: 1;   /* used SAVE on SEARCH */
 };
 
 #endif /* INCLUDED_IMAPD_H */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -436,6 +436,7 @@ struct client_behavior_registry {
     unsigned int did_condstore: 1;   /* gave CONDSTORE on SELECT */
     unsigned int did_compress : 1;   /* started COMPRESS */
     unsigned int did_idle     : 1;   /* used IDLE */
+    unsigned int did_move     : 1;   /* used MOVE */
     unsigned int did_notify   : 1;   /* used NOTIFY */
     unsigned int did_preview  : 1;   /* fetched PREVIEW */
     unsigned int did_qresync  : 1;   /* gave QRESYNC on SELECT */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -432,18 +432,19 @@ enum {
 extern struct protstream *imapd_out, *imapd_in;
 
 struct client_behavior_registry {
-    unsigned int did_annotate : 1;   /* called SETANNOTATION or FETCH-ed ANNOTATION */
-    unsigned int did_condstore: 1;   /* gave CONDSTORE on SELECT */
-    unsigned int did_compress : 1;   /* started COMPRESS */
-    unsigned int did_idle     : 1;   /* used IDLE */
-    unsigned int did_metadata : 1;   /* called GETMETADATA or SETMETADATA */
-    unsigned int did_move     : 1;   /* used MOVE */
-    unsigned int did_notify   : 1;   /* used NOTIFY */
-    unsigned int did_preview  : 1;   /* fetched PREVIEW */
-    unsigned int did_qresync  : 1;   /* gave QRESYNC on SELECT */
-    unsigned int did_savedate : 1;   /* fetched SAVEDATE */
-    unsigned int did_searchres: 1;   /* used SAVE on SEARCH */
-    unsigned int did_replace  : 1;   /* used REPLACE */
+    unsigned int did_annotate     : 1;   /* used SETANNOTATION or FETCH-ed ANNOTATION */
+    unsigned int did_condstore    : 1;   /* gave CONDSTORE on SELECT */
+    unsigned int did_compress     : 1;   /* started COMPRESS */
+    unsigned int did_idle         : 1;   /* used IDLE */
+    unsigned int did_metadata     : 1;   /* called GETMETADATA or SETMETADATA */
+    unsigned int did_multisearch  : 1;   /* called ESEARCH */
+    unsigned int did_move         : 1;   /* used MOVE */
+    unsigned int did_notify       : 1;   /* used NOTIFY */
+    unsigned int did_preview      : 1;   /* fetched PREVIEW */
+    unsigned int did_qresync      : 1;   /* gave QRESYNC on SELECT */
+    unsigned int did_savedate     : 1;   /* fetched SAVEDATE */
+    unsigned int did_searchres    : 1;   /* used SAVE on SEARCH */
+    unsigned int did_replace      : 1;   /* used REPLACE */
 };
 
 #endif /* INCLUDED_IMAPD_H */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -432,6 +432,7 @@ enum {
 extern struct protstream *imapd_out, *imapd_in;
 
 struct client_behavior_registry {
+    unsigned int did_annotate : 1;   /* called SETANNOTATION or FETCH-ed ANNOTATION */
     unsigned int did_condstore: 1;   /* gave CONDSTORE on SELECT */
     unsigned int did_compress : 1;   /* started COMPRESS */
     unsigned int did_idle     : 1;   /* used IDLE */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -431,4 +431,9 @@ enum {
 
 extern struct protstream *imapd_out, *imapd_in;
 
+struct client_behavior_registry {
+    unsigned int did_compress : 1;   /* client started COMPRESS */
+    unsigned int did_notify   : 1;   /* client used NOTIFY */
+};
+
 #endif /* INCLUDED_IMAPD_H */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -436,6 +436,7 @@ struct client_behavior_registry {
     unsigned int did_condstore: 1;   /* gave CONDSTORE on SELECT */
     unsigned int did_compress : 1;   /* started COMPRESS */
     unsigned int did_idle     : 1;   /* used IDLE */
+    unsigned int did_metadata : 1;   /* called GETMETADATA or SETMETADATA */
     unsigned int did_move     : 1;   /* used MOVE */
     unsigned int did_notify   : 1;   /* used NOTIFY */
     unsigned int did_preview  : 1;   /* fetched PREVIEW */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -432,8 +432,9 @@ enum {
 extern struct protstream *imapd_out, *imapd_in;
 
 struct client_behavior_registry {
-    unsigned int did_compress : 1;   /* client started COMPRESS */
-    unsigned int did_notify   : 1;   /* client used NOTIFY */
+    unsigned int did_compress : 1;   /* started COMPRESS */
+    unsigned int did_idle     : 1;   /* used IDLE */
+    unsigned int did_notify   : 1;   /* used NOTIFY */
 };
 
 #endif /* INCLUDED_IMAPD_H */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -432,6 +432,7 @@ enum {
 extern struct protstream *imapd_out, *imapd_in;
 
 struct client_behavior_registry {
+    unsigned int did_condstore: 1;   /* gave CONDSTORE on SELECT */
     unsigned int did_compress : 1;   /* started COMPRESS */
     unsigned int did_idle     : 1;   /* used IDLE */
     unsigned int did_notify   : 1;   /* used NOTIFY */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -439,6 +439,7 @@ struct client_behavior_registry {
     unsigned int did_notify   : 1;   /* used NOTIFY */
     unsigned int did_preview  : 1;   /* fetched PREVIEW */
     unsigned int did_qresync  : 1;   /* gave QRESYNC on SELECT */
+    unsigned int did_savedate : 1;   /* fetched SAVEDATE */
 };
 
 #endif /* INCLUDED_IMAPD_H */


### PR DESCRIPTION
The goal is, during an IMAP session, to keep track of interesting behavior, and then log it all at the end.  This reduces the need to put syslog lines in all over the place, and also reduces the need to correlate the lines to get a total picture of the session activity.

The real driver here is answering "Which IMAP clients use feature XYZ?"  If they identify with `ID` and we log that along with the behaviors seen, we can then:

* gather all the logs over a week or two
* group them by client id (by "name")
* union all the did-see-feature-X flags
* the end!

This means:
* making a new struct to track seen behaviors
* populating it as the session continues
* log it at session end
* reset it before new session begins