### PR TITLE
imapd.c: fix command name in GETMETADATA error

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -11049,7 +11049,7 @@ static void cmd_getmetadata(const char *tag)
 
         if (c != '\n') {
             prot_printf(imapd_out,
-                        "%s BAD Unexpected extra arguments to Getannotation\r\n",
+                        "%s BAD Unexpected extra arguments to Getmetadata\r\n",
                         tag);
             eatline(imapd_in, c);
             goto freeargs;


### PR DESCRIPTION
Probably this code was copied from GETANNOTATION, and one instance of that command name got left in the new code.  Also, probably this code path is never entered, but… it should still be correct!