### PR TITLE
mailbox_get_xconvemodseq() is never called with NULL for *modseqp

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -4387,9 +4387,6 @@ EXPORTED int mailbox_get_xconvmodseq(struct mailbox *mailbox, modseq_t *modseqp)
     conv_status_t status = CONV_STATUS_INIT;
     int r;
 
-    if (modseqp)
-        *modseqp = 0;
-
     struct conversations_state *cstate = mailbox_get_cstate(mailbox);
     if (!cstate) return 0;
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -748,7 +748,7 @@ extern int mailbox_cid_rename(struct mailbox *mailbox,
                               conversation_id_t from_cid,
                               conversation_id_t to_cid);
 extern int mailbox_add_conversations(struct mailbox *mailbox, int silent);
-extern int mailbox_get_xconvmodseq(struct mailbox *mailbox, modseq_t *);
+__attribute__((nonnull)) int mailbox_get_xconvmodseq(struct mailbox *mailbox, modseq_t *);
 extern int mailbox_update_xconvmodseq(struct mailbox *mailbox, modseq_t, int force);
 #define mailbox_has_conversations(m) mailbox_has_conversations_full(m, 0)
 extern int mailbox_has_conversations_full(struct mailbox *mailbox, int allow_deleted);


### PR DESCRIPTION
The way the function was written implied that the parameter modseqp could be NULL. If it were NULL, then “*modseqp = status.threadmodseq;” would cause NULL-dereference.

In practice the function is never called with NULL as last parameter.

This silences a warning from the Clang Static Analyzer.