### PR TITLE
Generate HTML content in “Standards Mode”

### DIFF
--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -72,9 +72,7 @@
 #define TLS_VERSION      "TLS/1.2"
 
 /* Supported HTML DOCTYPE */
-#define HTML_DOCTYPE \
-    "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" " \
-    "\"http://www.w3.org/TR/html4/loose.dtd\">"
+#define HTML_DOCTYPE "<!DOCTYPE html>"
 
 #define XML_DECLARATION \
     "<?xml version=\"1.0\" encoding=\"utf-8\"?>"


### PR DESCRIPTION
not in “Almost Standards Mode”.  Cf. https://hsivonen.fi/doctype/

This hides a warning on the browsers’ console for Cyrus IMAP generated webpages.