### PR TITLE
Add «style='color-scheme:dark light'» to some HTML output

### DIFF
--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -231,7 +231,7 @@ static int action_murder(struct transaction_t *txn)
         /* Add HTML header */
         buf_reset(&resp);
         buf_printf_markup(&resp, level, HTML_DOCTYPE);
-        buf_printf_markup(&resp, level++, "<html>");
+        buf_printf_markup(&resp, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(&resp, level++, "<head>");
         buf_printf_markup(&resp, level, "<title>%s</title>",
                           "Available Backend Servers");
@@ -296,7 +296,7 @@ static int action_murder(struct transaction_t *txn)
 
         buf_reset(&resp);
         buf_printf_markup(&resp, level, HTML_DOCTYPE);
-        buf_printf_markup(&resp, level++, "<html>");
+        buf_printf_markup(&resp, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(&resp, level++, "<head>");
         buf_printf_markup(&resp, level, "<title>%s</title>",
                           "Available Backend Servers");
@@ -377,7 +377,7 @@ static int action_menu(struct transaction_t *txn)
 
         buf_reset(&resp);
         buf_printf_markup(&resp, level, HTML_DOCTYPE);
-        buf_printf_markup(&resp, level++, "<html>");
+        buf_printf_markup(&resp, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(&resp, level++, "<head>");
         buf_printf_markup(&resp, level, "<title>%s</title>", actions[0].desc);
         buf_printf_markup(&resp, --level, "</head>");
@@ -474,7 +474,7 @@ static int action_proc(struct transaction_t *txn)
     /* Send HTML header */
     buf_reset(body);
     buf_printf_markup(body, level, HTML_DOCTYPE);
-    buf_printf_markup(body, level++, "<html>");
+    buf_printf_markup(body, level++, "<html style='color-scheme:dark light'>");
     buf_printf_markup(body, level++, "<head>");
     buf_printf_markup(body, level, "<meta http-equiv=\"%s\" content=\"%s\">",
                       "Refresh", "1");
@@ -670,7 +670,7 @@ static int action_df(struct transaction_t *txn)
 
         buf_reset(&resp);
         buf_printf_markup(&resp, level, HTML_DOCTYPE);
-        buf_printf_markup(&resp, level++, "<html>");
+        buf_printf_markup(&resp, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(&resp, level++, "<head>");
         buf_printf_markup(&resp, level, "<title>%s</title>", actions[2].desc);
         buf_printf_markup(&resp, --level, "</head>");
@@ -1007,7 +1007,7 @@ static int action_conf(struct transaction_t *txn)
 
         buf_reset(&resp);
         buf_printf_markup(&resp, level, HTML_DOCTYPE);
-        buf_printf_markup(&resp, level++, "<html>");
+        buf_printf_markup(&resp, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(&resp, level++, "<head>");
         buf_printf_markup(&resp, level, "<title>%s</title>", actions[3].desc);
         buf_printf_markup(&resp, --level, "</head>");

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2178,7 +2178,7 @@ static int list_calendars(struct transaction_t *txn)
     /* Send HTML header */
     buf_reset(body);
     buf_printf_markup(body, level, HTML_DOCTYPE);
-    buf_printf_markup(body, level++, "<html>");
+    buf_printf_markup(body, level++, "<html style='color-scheme:dark light'>");
     buf_printf_markup(body, level++, "<head>");
     buf_printf_markup(body, level, "<title>%s</title>", "Available Calendars");
     buf_printf_markup(body, level++, "<script type=\"text/javascript\">");

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -453,7 +453,7 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
     buf_appendcstr(&msgbuf, "Content-Disposition: inline\r\n");
     buf_appendcstr(&msgbuf, "\r\n");
 
-    buf_appendcstr(&msgbuf, HTML_DOCTYPE "\r\n<html><head><title></title></head><body>\r\n");
+    buf_appendcstr(&msgbuf, HTML_DOCTYPE "\r\n<html style='color-scheme:dark light'><head><title></title></head><body>\r\n");
 
     if (originator->name) {
         HTMLencode(&tmpbuf, originator->name);

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -988,7 +988,7 @@ static int list_addressbooks(struct transaction_t *txn)
     /* Send HTML header */
     buf_reset(body);
     buf_printf_markup(body, level, HTML_DOCTYPE);
-    buf_printf_markup(body, level++, "<html>");
+    buf_printf_markup(body, level++, "<html style='color-scheme:dark light'>");
     buf_printf_markup(body, level++, "<head>");
     buf_printf_markup(body, level, "<title>%s</title>", "Available Addressbooks");
     buf_printf_markup(body, level++, "<script type=\"text/javascript\">");

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -596,7 +596,7 @@ static int webdav_get(struct transaction_t *txn,
         /* Send HTML with davmount link */
         buf_reset(body);
         buf_printf_markup(body, level, HTML_DOCTYPE);
-        buf_printf_markup(body, level++, "<html>");
+        buf_printf_markup(body, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(body, level++, "<head>");
         buf_printf_markup(body, level, "<title>%s</title>", txn->req_tgt.path);
         buf_printf_markup(body, --level, "</head>");

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -395,7 +395,7 @@ static int zstd_compress(struct transaction_t *txn __attribute__((unused)),
 
 static const char tls_message[] =
     HTML_DOCTYPE
-    "<html>\n<head>\n<title>TLS Required</title>\n</head>\n" \
+    "<html style='color-scheme:dark light'>\n<head>\n<title>TLS Required</title>\n</head>\n" \
     "<body>\n<h2>TLS is required prior to authentication</h2>\n" \
     "Use <a href=\"%s\">%s</a> instead.\n" \
     "</body>\n</html>\n";
@@ -3906,7 +3906,7 @@ EXPORTED void error_response(long code, struct transaction_t *txn)
         }
 
         buf_printf_markup(html, level, HTML_DOCTYPE);
-        buf_printf_markup(html, level++, "<html>");
+        buf_printf_markup(html, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(html, level++, "<head>");
         buf_printf_markup(html, level, "<title>%s</title>",
                           error_message(code));
@@ -4709,7 +4709,7 @@ static int list_well_known(struct transaction_t *txn)
         /* Start HTML */
         buf_reset(&body);
         buf_printf_markup(&body, level, HTML_DOCTYPE);
-        buf_printf_markup(&body, level++, "<html>");
+        buf_printf_markup(&body, level++, "<html style='color-scheme:dark light'>");
         buf_printf_markup(&body, level++, "<head>");
         buf_printf_markup(&body, level,
                           "<title>%s</title>", "Well-Known Locations");


### PR DESCRIPTION
This permits rendering of the webpages and iMIP messages nicely in dark mode.

In http_rss.c I have not changed it, as [I cannot get it running](https://github.com/cyrusimap/cyrus-imapd/issues/4616).

If the task of jmap_mail:_html_concat_div() is to prepare HTML-mails for rendering in an embedded element, and the html email has `<html style='color-scheme: dark light'>` then to me it seems that the color-scheme information will be lost.

In jmap_mail.c:_emailbodies_to_html() there is one more occurrence of `<html`.