### PR TITLE
caldav_alarm:get_floatingtz() do not try to parse missing calendar-timezone as timezone

### DIFF
--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -575,8 +575,7 @@ static icaltimezone *get_floatingtz(const char *mailbox, const char *userid)
     icaltimezone *floatingtz = NULL;
 
     struct buf buf = BUF_INITIALIZER;
-    const char *annotname = DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone";
-    if (!annotatemore_lookupmask(mailbox, annotname, userid, &buf)) {
+    if (!annotatemore_lookupmask(mailbox, DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone", userid, &buf) && buf_len(&buf)) {
         icalcomponent *comp = NULL;
         comp = icalparser_parse_string(buf_cstring(&buf));
         icalcomponent *subcomp =


### PR DESCRIPTION
In (cyrus-imapd-3.6) imap/caldav_alarm.c:get_floatingtz()
```c
static icaltimezone *get_floatingtz(const char *mailbox, const char *userid)
{
    icaltimezone *floatingtz = NULL;

    struct buf buf = BUF_INITIALIZER;
    const char *annotname = DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone";
    if (!annotatemore_lookupmask(mailbox, annotname, userid, &buf)) {
        icalcomponent *comp = NULL;
        comp = icalparser_parse_string(buf_cstring(&buf));
```
can call `icalparser_parse_string("")` which produces during `dav_reconstruct -a` many such warnings:
```
Reconstructing DAV DB for abc@def.gh...
../src/libical/icalerror.c:116: BADARG: Bad argument to function
/usr/local/lib/../lib64/libical.so.3(ical_bt+0x21) [0x7f1797e55711]
/usr/local/lib/../lib64/libical.so.3(icalcomponent_get_first_component+0x7f) [0x7f1797e59cef]
/usr/local/lib/libcyrus_imap.so.0(+0xc8f72) [0x7f179b016f72]
/usr/local/lib/libcyrus_imap.so.0(+0xcaa74) [0x7f179b018a74]
/usr/local/lib/libcyrus_imap.so.0(caldav_alarm_process+0x32e) [0x7f179b01986e]
/usr/local/lib/libcyrus_imap.so.0(dav_reconstruct_user+0x1f9) [0x7f179afa0869]
/usr/local/lib/libcyrus_imap.so.0(+0x84a11) [0x7f179afd2a11]
/usr/local/lib/libcyrus.so.0(+0x928d8) [0x7f179ac5b8d8]
/usr/local/lib/libcyrus_imap.so.0(mboxlist_allmbox+0xf2) [0x7f179afd83e2]
/usr/local/lib/libcyrus_imap.so.0(mboxlist_alluser+0x45) [0x7f179afd84f5]
dav_reconstruct() [0x4012db]
/lib64/libc.so.6(+0x23677) [0x7f17979fd677]
/lib64/libc.so.6(__libc_start_main+0x85) [0x7f17979fd735]
dav_reconstruct() [0x401301]
../src/libical/icalerror.c:116: BADARG: Bad argument to function
/usr/local/lib/../lib64/libical.so.3(ical_bt+0x21) [0x7f1797e55711]
/usr/local/lib/libcyrus_imap.so.0(+0xc8fa3) [0x7f179b016fa3]
/usr/local/lib/libcyrus_imap.so.0(+0xcaa74) [0x7f179b018a74]
/usr/local/lib/libcyrus_imap.so.0(caldav_alarm_process+0x32e) [0x7f179b01986e]
/usr/local/lib/libcyrus_imap.so.0(dav_reconstruct_user+0x1f9) [0x7f179afa0869]
/usr/local/lib/libcyrus_imap.so.0(+0x84a11) [0x7f179afd2a11]
/usr/local/lib/libcyrus.so.0(+0x928d8) [0x7f179ac5b8d8]
/usr/local/lib/libcyrus_imap.so.0(mboxlist_allmbox+0xf2) [0x7f179afd83e2]
/usr/local/lib/libcyrus_imap.so.0(mboxlist_alluser+0x45) [0x7f179afd84f5]
dav_reconstruct() [0x4012db]
/lib64/libc.so.6(+0x23677) [0x7f17979fd677]
/lib64/libc.so.6(__libc_start_main+0x85) [0x7f17979fd735]
dav_reconstruct() [0x401301]
```

This change is likely relevant for cyrus-imapd-3.8 and irrelevant for master.