### PR TITLE
fix FETCH BINARY response for unknown CTE

### DIFF
--- a/cassandane/Cassandane/Cyrus/Fetch.pm
+++ b/cassandane/Cassandane/Cyrus/Fetch.pm
@@ -1007,4 +1007,63 @@ sub test_preview_args
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
 }
 
+sub test_unknown_cte
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+
+    my $ct = "multipart/mixed";
+    my $boundary = "mitomycin";
+
+    # Subpart 1
+    my $body = ""
+    . "--$boundary\r\n"
+    . "Content-Type: text/plain; charset=\"utf8\"\r\n"
+    . "\r\n"
+    . "The attachment to this email is meaningless gibberish\r\n";
+
+    # Subpart 2
+    $body .= ""
+    . "--$boundary\r\n"
+    . "Content-Disposition: attachment; filename=\"gibberish.dat\"\r\n"
+    . "Content-Type: application/octet-stream; name=\"gibberish.dat\"\r\n"
+    . "Content-Transfer-Encoding: x-no-such-encoding\r\n"
+    . "\r\n"
+    . "There'll never be a decoder for this encoding, so this\r\n"
+    . "text can't possibly ever decode to something coherent.\r\n"
+    . "--$boundary--\r\n";
+
+    my $msg = $self->make_message("foo",
+        mime_type => $ct,
+        mime_boundary => $boundary,
+        body => $body
+    );
+    my $uid = $msg->{attrs}->{uid};
+    my $res;
+
+    # fetch BINARY.PEEK should fail
+    $res = $imaptalk->fetch('1', '(BINARY.PEEK[2])');
+    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr{UNKNOWN-CTE}, $imaptalk->get_last_error());
+
+    # fetch BINARY.SIZE should fail
+    $res = $imaptalk->fetch('1', '(BINARY.SIZE[2])');
+    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr{UNKNOWN-CTE}, $imaptalk->get_last_error());
+
+    # enable UID mode...
+    $imaptalk->uid(1);
+
+    # UID fetch BINARY.PEEK should fail
+    $res = $imaptalk->fetch($uid, '(BINARY.PEEK[2])');
+    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr{UNKNOWN-CTE}, $imaptalk->get_last_error());
+
+    # UID fetch BINARY.SIZE should fail
+    $res = $imaptalk->fetch($uid, '(BINARY.SIZE[2])');
+    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr{UNKNOWN-CTE}, $imaptalk->get_last_error());
+}
+
 1;

--- a/imap/index.c
+++ b/imap/index.c
@@ -1097,15 +1097,16 @@ static int _fetch_setseen(struct index_state *state,
 }
 
 /* seq can be NULL - means "ALL" */
-EXPORTED void index_fetchresponses(struct index_state *state,
-                          seqset_t *seq,
-                          int usinguid,
-                          const struct fetchargs *fetchargs,
-                          int *fetchedsomething)
+EXPORTED int index_fetchresponses(struct index_state *state,
+                                  seqset_t *seq,
+                                  int usinguid,
+                                  const struct fetchargs *fetchargs,
+                                  int *fetchedsomething)
 {
     uint32_t msgno, start, end;
     struct index_map *im;
     int fetched = 0;
+    int r = 0;
     annotate_db_t *annot_db = NULL;
 
     /* Keep an open reference on the per-mailbox db to avoid
@@ -1159,7 +1160,7 @@ EXPORTED void index_fetchresponses(struct index_state *state,
             continue;
         }
 
-        if (index_fetchreply(state, msgno, fetchargs))
+        if ((r = index_fetchreply(state, msgno, fetchargs)))
             break;
         fetched = 1;
     }
@@ -1169,6 +1170,8 @@ EXPORTED void index_fetchresponses(struct index_state *state,
 
     if (fetchedsomething) *fetchedsomething = fetched;
     annotate_putdb(&annot_db);
+
+    return r;
 }
 
 /*
@@ -1259,7 +1262,7 @@ EXPORTED int index_fetch(struct index_state *state,
 
     seqset_free(&vanishedlist);
 
-    index_fetchresponses(state, seq, usinguid, fetchargs, fetchedsomething);
+    r = index_fetchresponses(state, seq, usinguid, fetchargs, fetchedsomething);
 
     if (seq != state->searchres) seqset_free(&seq);
 
@@ -4461,8 +4464,8 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
     }
     if ((fetchitems & FETCH_ANNOTATION)) {
         prot_printf(state->out, "%cANNOTATION (", sepchar);
-        r = index_fetchannotations(state, msgno, fetchargs);
-        r = 0;
+        /* ignoring the result anyway, so don't conceal prior errors */
+        index_fetchannotations(state, msgno, fetchargs);
         prot_printf(state->out, ")");
         sepchar = ' ';
     }
@@ -4588,15 +4591,15 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
     if (config_getswitch(IMAPOPT_CONVERSATIONS)) {
         if (fetchitems & FETCH_MAILBOXES) {
             prot_printf(state->out, "%cMAILBOXES (", sepchar);
-            r = index_fetchmailboxes(state, msgno, fetchargs);
-            r = 0;
+            /* ignoring the result anyway, so don't conceal prior errors */
+            index_fetchmailboxes(state, msgno, fetchargs);
             prot_printf(state->out, ")");
             sepchar = ' ';
         }
         if (fetchitems & FETCH_MAILBOXIDS) {
             prot_printf(state->out, "%cMAILBOXIDS (", sepchar);
-            r = index_fetchmailboxids(state, msgno, fetchargs);
-            r = 0;
+            /* ignoring the result anyway, so don't conceal prior errors */
+            index_fetchmailboxids(state, msgno, fetchargs);
             prot_printf(state->out, ")");
             sepchar = ' ';
         }
@@ -4717,13 +4720,15 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
 
         loadbody(mailbox, &record, &body);
         if (body) {
-            r = index_fetchsection(state, respbuf, &buf,
-                    section->name, body, record.size,
-                    (fetchitems & FETCH_IS_PARTIAL) ?
-                    fetchargs->start_octet : oi->start_octet,
-                    (fetchitems & FETCH_IS_PARTIAL) ?
-                    fetchargs->octet_count : oi->octet_count);
-            if (!r) sepchar = ' ';
+            /* n.b. success should not conceal an earlier error */
+            int r2 = index_fetchsection(state, respbuf, &buf,
+                                        section->name, body, record.size,
+                                        (fetchitems & FETCH_IS_PARTIAL) ?
+                                         fetchargs->start_octet : oi->start_octet,
+                                        (fetchitems & FETCH_IS_PARTIAL) ?
+                                         fetchargs->octet_count : oi->octet_count);
+            if (!r2) sepchar = ' ';
+            if (!r) r = r2;
         }
     }
     for (section = fetchargs->binsections; section; section = section->next) {
@@ -4738,13 +4743,15 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
         loadbody(mailbox, &record, &body);
         if (body) {
             oi = &section->octetinfo;
-            r = index_fetchsection(state, respbuf, &buf,
-                                   section->name, body, record.size,
-                                   (fetchitems & FETCH_IS_PARTIAL) ?
-                                    fetchargs->start_octet : oi->start_octet,
-                                   (fetchitems & FETCH_IS_PARTIAL) ?
-                                    fetchargs->octet_count : oi->octet_count);
-            if (!r) sepchar = ' ';
+            /* n.b. success should not conceal an earlier error */
+            int r2 = index_fetchsection(state, respbuf, &buf,
+                                        section->name, body, record.size,
+                                        (fetchitems & FETCH_IS_PARTIAL) ?
+                                         fetchargs->start_octet : oi->start_octet,
+                                        (fetchitems & FETCH_IS_PARTIAL) ?
+                                         fetchargs->octet_count : oi->octet_count);
+            if (!r2) sepchar = ' ';
+            if (!r) r = r2;
         }
     }
     for (section = fetchargs->sizesections; section; section = section->next) {
@@ -4758,14 +4765,17 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
 
         loadbody(mailbox, &record, &body);
         if (body) {
-            r = index_fetchsection(state, respbuf, &buf,
-                                   section->name, body, record.size,
-                                   fetchargs->start_octet, fetchargs->octet_count);
-            if (!r) sepchar = ' ';
+            /* n.b. success should not conceal an earlier error */
+            int r2 = index_fetchsection(state, respbuf, &buf,
+                                        section->name, body, record.size,
+                                        fetchargs->start_octet,
+                                        fetchargs->octet_count);
+            if (!r2) sepchar = ' ';
+            if (!r) r = r2;
         }
     }
     if (sepchar != '(') {
-        /* finsh the response if we have one */
+        /* finish the response if we have one */
         prot_printf(state->out, ")\r\n");
     }
     buf_free(&buf);

--- a/imap/index.h
+++ b/imap/index.h
@@ -240,11 +240,11 @@ enum index_changes_flags
 
 /* non-locking, non-updating - just do a fetch on the state
  * we already have */
-void index_fetchresponses(struct index_state *state,
-                                 seqset_t *seq,
-                                 int usinguid,
-                                 const struct fetchargs *fetchargs,
-                                 int *fetchedsomething);
+int index_fetchresponses(struct index_state *state,
+                         seqset_t *seq,
+                         int usinguid,
+                         const struct fetchargs *fetchargs,
+                         int *fetchedsomething);
 extern int index_fetch(struct index_state *state,
                        const char* sequence,
                        int usinguid,


### PR DESCRIPTION
FETCH of BINARY, BINARY.PEEK, or BINARY.SIZE are supposed to fail and report `[UNKNOWN-CTE]` if the requested message section has an unknown Content-Transfer-Encoding.  For FETCH, we were failing and reporting "No matching messages".  For UID FETCH, we were succeeding(!) but not outputting the requested section.

We already detected and returned the `IMAP_NO_UNKNOWN_CTE` error condition in `index_fetchsection()`, but the result was discarded by `void index_fetchresponses()` on the way back up the stack, and never sent to the client.

This PR changes `index_fetchresponses()` to return `int`, and plumbs the error through  so that `cmd_fetch()` can eventually send the correct response back to the client.  It also ensures that if some part of the fetch has failed, other parts succeeding do not conceal the error.  A new test verifies the correct behaviour for BINARY.PEEK and BINARY.SIZE.  I didn't bother testing plain BINARY, because it's the same as BINARY.PEEK except that it also sets the \Seen flag, which leads to an unsolicited flags response, which would complicate the test in an uninteresting way.

Fixes #4567 