### PR TITLE
admin/sieve.rst: update on former drafts

### DIFF
--- a/docsrc/imap/reference/admin/sieve.rst
+++ b/docsrc/imap/reference/admin/sieve.rst
@@ -235,8 +235,6 @@ Cyrus supports a subset of these:
 * IMAP flag Extension :rfc:`5232`
 * Body Extension :rfc:`5173`
 
-Note that the final RFCs of these last sieve extensions have significant
-changes that are not currently supported.
 
 Sieve Tools
 -----------


### PR DESCRIPTION
Commit 175cb0ff0f232 added:
```
+* Regular Expression Extension `Draft RFC <http://tools.ietf.org/html/draft-ietf-sieve-regex-01>`_ 
+* Checking mailbox status and accessing mailbox metadata :rfc:`5490` +* Notify Extension :rfc:`5435`
+* IMAP flag Extension `Draft imap flags RFC <http://tools.ietf.org/html/draft-ietf-sieve-imapflags-05>`_ 
+* Body Extension `Draft body extension RFC <http://tools.ietf.org/html/draft-ietf-sieve-body-02>`_ 
+
+Note that the final RFCs of these last sieve extensions have significant changes that are not currently supported.
```
RFC 5232 Sieve: Imap4flags Extension and RFC 5173 Sieve: Body Extension are implemented since at least c2676ba133ed507, that is year 2015. The removed text means the IETF-drafts cited above.

This change shall be backported to cyrus-imapd-3.4.