### PR TITLE
Update 3.6.0 release notes

### DIFF
--- a/docsrc/imap/download/release-notes/3.6/x/3.6.0-beta1.rst
+++ b/docsrc/imap/download/release-notes/3.6/x/3.6.0-beta1.rst
@@ -20,7 +20,7 @@ Major changes since the 3.4 series
 * XFER will no longer move individual mailboxes that would leave unselectable
   mailboxes behind in the user heirarchy.
 * Update IMAP PREVIEW extension from
-  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`
+  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`
 * Always return 'blobId' and 'size' in Contact/setcreate, Contact/setupdate,
   and Contact/get responses.
@@ -50,7 +50,7 @@ Major changes since the 3.4 series
   :cyrusman:`imapd.conf(5)` option.
 * :cyrusman:`sync_client(8)` now recognises when the remote
   :cyrusman:`sync_server(8)` has been shut down cleanly, and doesn't log a
-  bunch of disconnection errors about it
+  bunch of disconnection errors about it.
 * Added an inactivity timeout for WebSocket connections, configurable with
   the `websocket_timeout` :cyrusman:`imapd.conf(5)` option.
 * Mailboxes and user metadata directories are now organised on disk by UUID

--- a/docsrc/imap/download/release-notes/3.6/x/3.6.0-beta2.rst
+++ b/docsrc/imap/download/release-notes/3.6/x/3.6.0-beta2.rst
@@ -20,7 +20,7 @@ Major changes since the 3.4 series
 * XFER will no longer move individual mailboxes that would leave unselectable
   mailboxes behind in the user heirarchy.
 * Update IMAP PREVIEW extension from
-  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`
+  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`
 * Always return 'blobId' and 'size' in Contact/setcreate, Contact/setupdate,
   and Contact/get responses.

--- a/docsrc/imap/download/release-notes/3.6/x/3.6.0-beta3.rst
+++ b/docsrc/imap/download/release-notes/3.6/x/3.6.0-beta3.rst
@@ -20,7 +20,7 @@ Major changes since the 3.4 series
 * XFER will no longer move individual mailboxes that would leave unselectable
   mailboxes behind in the user heirarchy.
 * Update IMAP PREVIEW extension from
-  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`
+  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`
 * Always return 'blobId' and 'size' in Contact/setcreate, Contact/setupdate,
   and Contact/get responses.
@@ -50,7 +50,7 @@ Major changes since the 3.4 series
   :cyrusman:`imapd.conf(5)` option.
 * :cyrusman:`sync_client(8)` now recognises when the remote
   :cyrusman:`sync_server(8)` has been shut down cleanly, and doesn't log a
-  bunch of disconnection errors about it
+  bunch of disconnection errors about it.
 * :cyrusman:`sync_client(8)` `-A` mode now keeps processing subsequent
   mailboxes after errors (reconnecting to the replica if necessary), instead
   of bailing out at the first error.  This means everything that can be
@@ -153,7 +153,7 @@ Significant bugfixes
   mailboxes.db entries.  The intermediary file format is now JSON.  This change
   makes it possible to follow the procedure
   for switching `improved_mboxlist_sort` described in
-  :ref:`enabling improved mboxlist sort`
+  :ref:`enabling improved mboxlist sort`.
 * Fixed :issue:`4035`: `ctl_cyrusdb -r` now recovers from mailboxes.db
   records with missing uniqueids, instead of crashing.  A new `-P` option to
   :cyrusman:`reconstruct(8)` enables repairing mailboxes whose header files

--- a/docsrc/imap/download/release-notes/3.6/x/3.6.0-rc1.rst
+++ b/docsrc/imap/download/release-notes/3.6/x/3.6.0-rc1.rst
@@ -20,7 +20,7 @@ Major changes since the 3.4 series
 * XFER will no longer move individual mailboxes that would leave unselectable
   mailboxes behind in the user heirarchy.
 * Update IMAP PREVIEW extension from
-  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`
+  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`
 * Always return 'blobId' and 'size' in Contact/setcreate, Contact/setupdate,
   and Contact/get responses.
@@ -50,7 +50,7 @@ Major changes since the 3.4 series
   :cyrusman:`imapd.conf(5)` option.
 * :cyrusman:`sync_client(8)` now recognises when the remote
   :cyrusman:`sync_server(8)` has been shut down cleanly, and doesn't log a
-  bunch of disconnection errors about it
+  bunch of disconnection errors about it.
 * :cyrusman:`sync_client(8)` `-A` mode now keeps processing subsequent
   mailboxes after errors (reconnecting to the replica if necessary), instead
   of bailing out at the first error.  This means everything that can be
@@ -153,7 +153,7 @@ Significant bugfixes
   mailboxes.db entries.  The intermediary file format is now JSON.  This change
   makes it possible to follow the procedure
   for switching `improved_mboxlist_sort` described in
-  :ref:`enabling improved mboxlist sort`
+  :ref:`enabling improved mboxlist sort`.
 * Fixed :issue:`4035`: `ctl_cyrusdb -r` now recovers from mailboxes.db
   records with missing uniqueids, instead of crashing.  A new `-P` option to
   :cyrusman:`reconstruct(8)` enables repairing mailboxes whose header files

--- a/docsrc/imap/download/release-notes/3.6/x/3.6.0-rc2.rst
+++ b/docsrc/imap/download/release-notes/3.6/x/3.6.0-rc2.rst
@@ -20,7 +20,7 @@ Major changes since the 3.4 series
 * XFER will no longer move individual mailboxes that would leave unselectable
   mailboxes behind in the user heirarchy.
 * Update IMAP PREVIEW extension from
-  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`
+  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`
 * Always return 'blobId' and 'size' in Contact/setcreate, Contact/setupdate,
   and Contact/get responses.
@@ -50,7 +50,7 @@ Major changes since the 3.4 series
   :cyrusman:`imapd.conf(5)` option.
 * :cyrusman:`sync_client(8)` now recognises when the remote
   :cyrusman:`sync_server(8)` has been shut down cleanly, and doesn't log a
-  bunch of disconnection errors about it
+  bunch of disconnection errors about it.
 * :cyrusman:`sync_client(8)` `-A` mode now keeps processing subsequent
   mailboxes after errors (reconnecting to the replica if necessary), instead
   of bailing out at the first error.  This means everything that can be
@@ -153,7 +153,7 @@ Significant bugfixes
   mailboxes.db entries.  The intermediary file format is now JSON.  This change
   makes it possible to follow the procedure
   for switching `improved_mboxlist_sort` described in
-  :ref:`enabling improved mboxlist sort`
+  :ref:`enabling improved mboxlist sort`.
 * Fixed :issue:`4035`: `ctl_cyrusdb -r` now recovers from mailboxes.db
   records with missing uniqueids, instead of crashing.  A new `-P` option to
   :cyrusman:`reconstruct(8)` enables repairing mailboxes whose header files

--- a/docsrc/imap/download/release-notes/3.6/x/3.6.0.rst
+++ b/docsrc/imap/download/release-notes/3.6/x/3.6.0.rst
@@ -20,7 +20,11 @@ Major changes since the 3.4 series
 * XFER will no longer move individual mailboxes that would leave unselectable
   mailboxes behind in the user heirarchy.
 * Update IMAP PREVIEW extension from
-  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`
+  :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
+* Update IMAP SAVEDATE extension from
+  :draft:`draft-ietf-extra-imap-savedate` to :rfc:`8514`.
+* Update IMAP OBJECTID extension from
+  :draft:`draft-ietf-extra-imap-objectid` to :rfc:`8474`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`
 * Always return 'blobId' and 'size' in Contact/setcreate, Contact/setupdate,
   and Contact/get responses.
@@ -50,7 +54,7 @@ Major changes since the 3.4 series
   :cyrusman:`imapd.conf(5)` option.
 * :cyrusman:`sync_client(8)` now recognises when the remote
   :cyrusman:`sync_server(8)` has been shut down cleanly, and doesn't log a
-  bunch of disconnection errors about it
+  bunch of disconnection errors about it.
 * :cyrusman:`sync_client(8)` `-A` mode now keeps processing subsequent
   mailboxes after errors (reconnecting to the replica if necessary), instead
   of bailing out at the first error.  This means everything that can be
@@ -89,6 +93,7 @@ Major changes since the 3.4 series
 * JMAP Contacts avatars can now reference any valid blob, not only blobs
   originally uploaded via JMAP.
 * Preliminary support for building with OpenSSL 3.
+* Support converting vCards 3.0⇔4.0 based on CARDDAV:address-data.
 
 
 .. _relnotes_3.6.0_storage_changes:
@@ -153,7 +158,7 @@ Significant bugfixes
   mailboxes.db entries.  The intermediary file format is now JSON.  This change
   makes it possible to follow the procedure
   for switching `improved_mboxlist_sort` described in
-  :ref:`enabling improved mboxlist sort`
+  :ref:`enabling improved mboxlist sort`.
 * Fixed :issue:`4035`: `ctl_cyrusdb -r` now recovers from mailboxes.db
   records with missing uniqueids, instead of crashing.  A new `-P` option to
   :cyrusman:`reconstruct(8)` enables repairing mailboxes whose header files

--- a/docsrc/imap/rfc-support.rst
+++ b/docsrc/imap/rfc-support.rst
@@ -139,17 +139,9 @@ The following is an inventory of RFCs supported by Cyrus IMAP.
 
     A MIME Content-Type for Directory Information
 
-    .. NOTE::
-
-	See the comment behind RFC 6352 below.
-
 :rfc:`2426`
 
     vCard MIME Directory Profile
-
-    .. NOTE::
-
-	See the comment behind RFC 6352 below.
 
 :rfc:`2444`
 
@@ -639,23 +631,10 @@ The following is an inventory of RFCs supported by Cyrus IMAP.
 
     vCard Format Specification
 
-    .. NOTE::
-
-	See the comment behind RFC 6352 below.
-
 :rfc:`6352`
 
     CardDAV: vCard Extensions to Web Distributed Authoring and
     Versioning (WebDAV)
-
-    .. NOTE::
-
-       Cyrus IMAP accepts over CardDAV both vCard 3.0 and vCard 4.0, but
-       does not advertise over CARDDAV:supported-address-data vCard 4.0
-       support, announces only vCard 3.0.  Moreover, Cyrus IMAP does not
-       convert between vCard 3.0 and vCard 4.0.  It is applications’
-       responsibility not to misinterpret the vCard version and damage
-       the data.
 
 :rfc:`6376`
 


### PR DESCRIPTION
Mention IMAP SAVEDATE and OBJECTID extensions.

Based on `git diff cyrus-imapd-3.4..cyrus-imapd-3.6 imap/imapd.c`.

The CARDDAV:address-data conversions are implemented in b39dddff2e5bf72528752de and f232075061cdede1a93292.

- update rfc-support.rst on current CardDAV implementation.