### PR TITLE
Conversations correct basecid

### DIFF
--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -344,8 +344,10 @@ sub test_reconstruct_splitconv
     my ($self) = @_;
     my %exp;
 
+    my $talk = $self->{store}->get_client();
+
     # check IMAP server has the XCONVERSATIONS capability
-    $self->assert($self->{store}->get_client()->capability()->{xconversations});
+    $self->assert($talk->capability()->{xconversations});
 
     xlog $self, "generating message A";
     $exp{A} = $self->make_message("Message A");
@@ -358,12 +360,18 @@ sub test_reconstruct_splitconv
       $exp{"A$_"}->set_attributes(uid => 1+$_, cid => $exp{A}->make_cid());
     }
 
+    $talk->create('foo');
+    $talk->copy('1:*', 'foo');
+
     $self->check_messages(\%exp, keyed_on => 'uid');
 
     # first run WITHOUT splitting
     $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-R', '-r');
 
     $self->check_messages(\%exp, keyed_on => 'uid');
+    $talk->select("foo");
+    $self->check_messages(\%exp, keyed_on => 'uid');
+    $talk->select("INBOX");
 
     # then run WITH splitting, and see the changed CIDs
     $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-R', '-r', '-S');
@@ -380,6 +388,22 @@ sub test_reconstruct_splitconv
     $exp{"A20"}->set_attributes(cid => $exp{"A20"}->make_cid(), basecid => $exp{A}->make_cid());
 
     $self->check_messages(\%exp, keyed_on => 'uid');
+    $talk->select("foo");
+    $self->check_messages(\%exp, keyed_on => 'uid');
+    $talk->select("INBOX");
+
+    # zero everything out
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-z', 'cassandane');
+
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-d', 'cassandane');
+
+    # rebuild
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-b', 'cassandane');
+
+    $self->check_messages(\%exp, keyed_on => 'uid');
+    $talk->select("foo");
+    $self->check_messages(\%exp, keyed_on => 'uid');
+    #$talk->select("INBOX");
 }
 
 #

--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -395,8 +395,6 @@ sub test_reconstruct_splitconv
     # zero everything out
     $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-z', 'cassandane');
 
-    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-d', 'cassandane');
-
     # rebuild
     $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-b', 'cassandane');
 

--- a/changes/next/conversations-basecid-on-copy
+++ b/changes/next/conversations-basecid-on-copy
@@ -1,0 +1,23 @@
+Description:
+
+Copying/moving messages from split conversations is now correct.
+
+
+Config changes:
+
+No config changes needed.
+
+
+Upgrade instructions:
+
+This is all backwards compatible, but a conversations DB rebuild will
+be good, e.g. `ctl_conversationsdb -R -r -v`.
+
+If a user remains broken, you can wipe and recreate all their CIDs with
+`ctl_conversationsdb -z $username` followed by
+`ctl_conversationsdb -b $username`
+
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/issues/4654

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2197,7 +2197,7 @@ struct cidlookupdata {
 static int _getcid(const conv_guidrec_t *rec, void *rock)
 {
     struct cidlookupdata *data = (struct cidlookupdata *)rock;
-    if (!rec->part) {
+    if (!rec->part && rec->cid) {
         if (data->record) {
             data->record->cid = rec->cid;
             data->record->basecid = rec->basecid;
@@ -2378,6 +2378,8 @@ struct read_emailcounts_rock {
 static int _read_emailcounts_cb(const conv_guidrec_t *rec, void *rock)
 {
     if (rec->part) return 0;
+    // only count records with cids, otherwise the zero and rebuild fails
+    if (!rec->cid) return 0;
 
     struct emailcounts *ecounts = ((struct read_emailcounts_rock*)rock)->ecounts;
     struct conversations_state *cstate = ((struct read_emailcounts_rock*)rock)->cstate;

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -1944,29 +1944,6 @@ EXPORTED void conversation_update_sender(conversation_t *conv,
     conv->flags |= CONV_ISDIRTY;
 }
 
-static int _match1(void *rock,
-                   const char *key __attribute__((unused)),
-                   size_t keylen __attribute__((unused)),
-                   const char *data __attribute__((unused)),
-                   size_t datalen __attribute__((unused)))
-{
-    int *match = (int *)rock;
-    *match = 1;
-    return CYRUSDB_DONE;
-}
-
-EXPORTED int conversations_guid_exists(struct conversations_state *state,
-                                       const char *guidrep)
-{
-    int match = 0;
-
-    char *key = strconcat("G", guidrep, (char *)NULL);
-    cyrusdb_foreach(state->db, key, strlen(key), NULL, _match1, &match, NULL);
-    free(key);
-
-    return match;
-}
-
 struct guid_foreach_rock {
     struct conversations_state *state;
     int(*cb)(const conv_guidrec_t *, void *);

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -138,8 +138,8 @@ struct conv_folder {
     uint32_t        prev_exists;
 };
 
-#define CONV_GUIDREC_VERSION 0x2          // (must be <= 127)
-#define CONV_GUIDREC_BYNAME_VERSION 0x1   // last folders byname version
+#define CONV_GUIDREC_VERSION 3          // (must be <= 127)
+#define CONV_GUIDREC_BYNAME_VERSION 1   // last folders byname version
 
 struct conv_guidrec {
     const struct conversations_state *cstate;  // this conversationsdb!
@@ -148,6 +148,7 @@ struct conv_guidrec {
     uint32_t        uid;
     const char      *part;
     conversation_id_t cid;
+    conversation_id_t basecid;
     char            version;
     uint32_t        system_flags;   // if version >= 1
     uint32_t        internal_flags; // if version >= 1

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -264,8 +264,6 @@ extern conv_folder_t *conversation_get_folder(conversation_t *conv,
 extern void conversation_normalise_subject(struct buf *);
 
 /* G record */
-extern int conversations_guid_exists(struct conversations_state *state,
-                                     const char *guidrep);
 extern int conversations_guid_foreach(struct conversations_state *state,
                                       const char *guidrep,
                                       int(*cb)(const conv_guidrec_t*,void*),

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -273,8 +273,8 @@ extern int conversations_iterate_searchset(struct conversations_state *state,
                                            const void *data, size_t n,
                                            int(*cb)(const conv_guidrec_t*,void*),
                                            void *rock);
-extern conversation_id_t conversations_guid_cid_lookup(struct conversations_state *state,
-                                                       const char *guidrep);
+extern int conversations_guid_cid_lookup(struct conversations_state *state,
+                                         const char *guidrep, struct index_record *record);
 
 /* lookup the matching name or uniqueid */
 #define conv_guidrec_mboxname(rec) conversations_folder_mboxname((rec)->cstate, (rec)->foldernum)

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1586,7 +1586,7 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
                     so use it to make sure the message has a Message-ID */
             struct conversations_state *cstate = mailbox_get_cstate_full(mailbox, /*allow_deleted*/1);
             // if we still fail to get cstate, then we need to look up the msgid for sure
-            if ((!cstate || conversations_guid_cid_lookup(cstate, guid)) &&
+            if ((!cstate || conversations_guid_cid_lookup(cstate, guid, NULL)) &&
                 !message_get_messageid((message_t *) msg, &mrock->buf)) {
                 msgid = buf_cstring(&mrock->buf);
             }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2242,19 +2242,19 @@ static int _commit_one(struct mailbox *mailbox, struct index_change *change)
             /* note: messageid doesn't have <> wrappers because it already includes them */
             syslog(LOG_NOTICE, "auditlog: append sessionid=<%s> "
                    "mailbox=<%s> uniqueid=<%s> uid=<%u> modseq=<%llu> "
-                   "sysflags=<%s> guid=<%s> messageid=%s size=<%u>",
+                   "sysflags=<%s> guid=<%s> cid=<%s> messageid=%s size=<%u>",
                    session_id(), mailbox_name(mailbox), mailbox_uniqueid(mailbox), record->uid,
                    record->modseq, flagstr,
-                   message_guid_encode(&record->guid), change->msgid,
-                   record->size);
+                   message_guid_encode(&record->guid), conversation_id_encode(record->cid),
+                   change->msgid, record->size);
 
         if ((record->internal_flags & FLAG_INTERNAL_EXPUNGED) && !(change->flags & CHANGE_WASEXPUNGED))
             syslog(LOG_NOTICE, "auditlog: expunge sessionid=<%s> "
                    "mailbox=<%s> uniqueid=<%s> uid=<%u> modseq=<%llu> "
-                   "sysflags=<%s> guid=<%s> size=<%u>",
+                   "sysflags=<%s> guid=<%s> cid=<%s> size=<%u>",
                    session_id(), mailbox_name(mailbox), mailbox_uniqueid(mailbox), record->uid,
                    record->modseq, flagstr,
-                   message_guid_encode(&record->guid),
+                   message_guid_encode(&record->guid), conversation_id_encode(record->cid),
                    record->size);
 
         if ((record->internal_flags & FLAG_INTERNAL_UNLINKED) && !(change->flags & CHANGE_WASUNLINKED))

--- a/imap/message.c
+++ b/imap/message.c
@@ -3886,11 +3886,7 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
     /* calculate the CID if needed */
     if (!record->silentupdate) {
         /* match for GUID, it always has the same CID */
-        conversation_id_t currentcid = conversations_guid_cid_lookup(state, message_guid_encode(&record->guid));
-        if (currentcid) {
-            // would love to have this, but might hit bogus broken existing data...
-            // assert(record->cid == 0 || record->cid == currentcid);
-            record->cid = currentcid;
+        if (conversations_guid_cid_lookup(state, message_guid_encode(&record->guid), record)) {
             mustkeep = 1;
         }
         if (!record->cid) record->cid = arrayu64_max(&matchlist);


### PR DESCRIPTION
OK - this turned out to be surprisingly complex!

Rob M reported to me that a user was seeing blank messages in the Fastmail UI.  Symptom was "Email/query returns emailIds that Email/get says notFound for".

I discovered that there were messages with a missing basecid - the same GUID was in two separate folders, and in one it had a basecid, in the other not.  This was for a split conversation.  I quickly realised that the fix I put in a while back for copying the CID for the same GUID wasn't also copying the basecid.

So, I fixed that - but realised to get the basecid, we needed to store it in every G key.  So I added that (only if you have uuid folders, I figured that was better than doing some odd/even version magic).

Then I found more issues when testing.  Turns out, if there was more than one copy, the "B" keys weren't being cleaned up correctly, because the exists count kept finding the other zeroed out record.

Also, when you zero, we should also nuke all the newcid records on the `#splitconversations` folder.  There was an XXX comment to that effect, but it contained incorrect code, so I fixed that too.

In all, I'd say I've spent a solid 8 hours on this.  Damn.  But it's looking really solid now, and the test case includes copying the same message to two folders and the CIDs and BASECIDs matching across the lot now.

When we update servers, the G key parser is actually backwards compatible, so it's going to be safe to downgrade, though not safe to upgrade again if we change the G key datastructure format AND reuse the version number, so let's don't do that.

I also discovered that `ctl_conversationsdb -R` writes the G keys a few times, but I believe it's because it's working on two copies of the database so I'm not too stressed about that (yep, I scatted syslogs in places)

This MR also adds cid=<> logging to append and expunge.  We already log it for touched, so it just adds a tiny bit more logging and you can see CID changes more easily.
