### PR TITLE
configure.ac: add AM_SILENT_RULES([yes])

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,7 @@ PKG_PROG_PKG_CONFIG
 
 AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability foreign dist-bzip2
                   no-installinfo subdir-objects silent-rules tar-ustar])
+AM_SILENT_RULES([yes])
 AC_CONFIG_LIBOBJ_DIR([lib])
 
 dnl Useful hook for distributions


### PR DESCRIPTION
This will make compiler warnings more visible by default.