### PR TITLE
squatter: support running as a wait daemon

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
@@ -129,6 +129,7 @@ sub new
         return $class->SUPER::new({
             config => $config,
             adminstore => 1,
+            squatter => 1,
             services => ['imap', 'http'],
         }, @_);
     }
@@ -294,22 +295,6 @@ sub run_test
     local $ENV{JMTS_TELEMETRY} = 1 if get_verbose >= 3;
     local $ENV{JMTS_USE_WEBSOCKETS} = 1;
 
-    # Needed so text based searching works in Email/query, etc...
-    my $squatter_pid = $self->{instance}->run_command({
-            cyrus => 1,
-            background => 1,
-            handlers => {
-                exited_abnormally => sub {
-                    my ($child, $code) = @_;
-                    return 0 if $code == 75; # ignore EX_TEMPFAIL
-                    my $desc = Cassandane::Instance::_describe_child($child);
-                    die "child process $desc exited with code $code";
-                },
-            },
-        },
-        'squatter', '-R', '-d',
-    );
-
     $self->{instance}->run_command({
             redirects => { stderr => $errfile, stdout => $outfile },
             workingdir => $basedir,
@@ -321,8 +306,6 @@ sub run_test
         "perl", '-I' => "$basedir/lib",
          "$basedir/$name.t",
     );
-
-    $self->{instance}->stop_command($squatter_pid);
 
     if ((!$status || get_verbose)) {
         if (-f $errfile) {

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -103,6 +103,7 @@ sub new
         deliver => 0,
         jmap => 0,
         install_certificates => 0,
+        squatter => 0,
     };
     map {
         $want->{$_} = delete $params->{$_}
@@ -593,6 +594,17 @@ sub _create_instances
         $self->{instance}->add_services(@{$want->{services}});
         $self->{instance}->_setup_for_deliver()
             if ($want->{deliver});
+
+        if ($want->{squatter}) {
+            $self->{instance}->add_daemon(
+                name => 'squatter',
+                argv => [
+                    'squatter',
+                    '-R',
+                ],
+                wait => 'y',
+            );
+        }
 
         if ($want->{replica} || $want->{csyncreplica})
         {

--- a/changes/next/jmaptestsuite-squatter-race
+++ b/changes/next/jmaptestsuite-squatter-race
@@ -1,0 +1,19 @@
+Description:
+
+squatter now supports the "wait=y" cyrus.conf option when started in
+rolling mode from the DAEMON section
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None


### PR DESCRIPTION
This PR adds support for rolling squatter running as a wait daemon.  Which is to say, when invoked from the DAEMON section of cyrus.conf, `squatter -R` now behaves correctly when the wait=y cyrus.conf parameter is present.

It also adds the ability for Cassandane test suites to request such a squatter setup, rather than needing to arrange to start and stop squatter themselves, and updates JMAPTestSuite and JMAPTestSuiteWS to use this feature.

There was a race condition whereby some no-op JMAP-TestSuite tests would fail when run under valgrind.  They were finishing and returning before squatter had fully started (specifically, it hadn't installed its signal handlers yet).  The test being over, Cassandane would signal squatter to shut down, squatter would exit immediately due to the unhandled signal, and then Cassandane would complain about its exit code being incorrect.  With squatter now running as a wait daemon for these tests, it's already properly started before the main test body runs, so a fast test can't outpace the setup.