### PR TITLE
cyr_info BYTESIZE suppport

### DIFF
--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -103,9 +103,6 @@ sub default
             'partition-default' => '@basedir@/data',
             sasl_mech_list => 'PLAIN LOGIN',
             allowplaintext => 'yes',
-            # config options used at FastMail - may as well be testing our stuff
-            expunge_mode => 'delayed',
-            delete_mode => 'delayed',
             # for debugging - see cassandane.ini.example
             debug_command => '@prefix@/utils/gdbtramp %s %d',
             # everyone should be running this

--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -61,10 +61,8 @@ my %bitfields = (
 );
 my $bitfields_fixed = 0;
 
-sub new
+sub init_bitfields
 {
-    my $class = shift;
-
     if (!$bitfields_fixed) {
         while (my ($key, $allvalues) = each %bitfields) {
             $bitfields{$key} = {};
@@ -74,6 +72,13 @@ sub new
         }
         $bitfields_fixed = 1;
     }
+}
+
+sub new
+{
+    my $class = shift;
+
+    init_bitfields();
 
     my $self = {
         parent => undef,
@@ -361,6 +366,37 @@ sub generate
         }
     }
     close CONF;
+}
+
+sub is_bitfield
+{
+    my ($name) = @_;
+
+    init_bitfields();
+
+    return defined $bitfields{$name};
+}
+
+sub is_bitfield_bit
+{
+    my ($name, $value) = @_;
+
+    init_bitfields();
+
+    die "$name is not a bitfield option" if not exists $bitfields{$name};
+
+    return defined $bitfields{$name}->{$value};
+}
+
+sub get_bitfield_bits
+{
+    my ($name) = @_;
+
+    init_bitfields();
+
+    die "$name is not a bitfield option" if not exists $bitfields{$name};
+
+    return sort keys %{$bitfields{$name}};
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/Info.pm
+++ b/cassandane/Cassandane/Cyrus/Info.pm
@@ -136,6 +136,48 @@ sub test_info_conf
     $self->assert_deep_equals(\%imapd_conf, \%cyr_info_conf);
 }
 
+sub test_info_conf_all
+{
+    my ($self) = @_;
+
+    my %imapd_conf;
+    my $filename = $self->{instance}->_imapd_conf();
+    open my $fh, '<', $filename
+        or die "Cannot open $filename for reading: $!";
+    while (my $line = <$fh>) {
+        chomp $line;
+        my ($name, $value) = split /\s*:\s*/, $line, 2;
+        if (Cassandane::Config::is_bitfield($name)) {
+            my @values = split /\s+/, $value;
+            $imapd_conf{$name} = join q{ }, sort @values;
+        }
+        else {
+            $imapd_conf{$name} = $value;
+        }
+    }
+    close $fh;
+
+    my %cyr_info_conf;
+    foreach my $line ($self->run_cyr_info('conf-all')) {
+        chomp $line;
+        my ($name, $value) = split /\s*:\s*/, $line, 2;
+
+        # conf-all outputs ALL configured values (including defaults)
+        # but we can only really test for the ones we know we put there
+        next if not exists $imapd_conf{$name};
+
+        if (Cassandane::Config::is_bitfield($name)) {
+            my @values = split /\s+/, $value;
+            $cyr_info_conf{$name} = join q{ }, sort @values;
+        }
+        else {
+            $cyr_info_conf{$name} = $value;
+        }
+    }
+
+    $self->assert_deep_equals(\%imapd_conf, \%cyr_info_conf);
+}
+
 sub test_info_lint
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Cyrus/Info.pm
+++ b/cassandane/Cassandane/Cyrus/Info.pm
@@ -99,7 +99,7 @@ sub run_cyr_info
     return @res;
 }
 
-sub test_info_conf
+sub test_conf
 {
     my ($self) = @_;
 
@@ -136,7 +136,7 @@ sub test_info_conf
     $self->assert_deep_equals(\%imapd_conf, \%cyr_info_conf);
 }
 
-sub test_info_conf_all
+sub test_conf_all
 {
     my ($self) = @_;
 
@@ -178,7 +178,7 @@ sub test_info_conf_all
     $self->assert_deep_equals(\%imapd_conf, \%cyr_info_conf);
 }
 
-sub test_info_conf_default
+sub test_conf_default
 {
     my ($self) = @_;
 
@@ -202,7 +202,7 @@ sub test_info_conf_default
     }
 }
 
-sub test_info_lint
+sub test_lint
 {
     my ($self) = @_;
 
@@ -216,7 +216,7 @@ Cassandane::Cyrus::TestCase::magic(ConfigJunk => sub {
     shift->config_set(trust_fund => 'street art');
 });
 
-sub test_info_lint_junk
+sub test_lint_junk
     :ConfigJunk
 {
     my ($self) = @_;
@@ -227,7 +227,7 @@ sub test_info_lint_junk
     $self->assert_deep_equals(["trust_fund: street art\n"], \@output);
 }
 
-sub test_info_lint_channels
+sub test_lint_channels
     :min_version_3_2 :NoStartInstances
 {
     my ($self) = @_;
@@ -254,7 +254,7 @@ sub test_info_lint_channels
     );
 }
 
-sub test_info_lint_partitions
+sub test_lint_partitions
     :min_version_3_0 :NoStartInstances
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Cyrus/Info.pm
+++ b/cassandane/Cassandane/Cyrus/Info.pm
@@ -178,6 +178,30 @@ sub test_info_conf_all
     $self->assert_deep_equals(\%imapd_conf, \%cyr_info_conf);
 }
 
+sub test_info_conf_default
+{
+    my ($self) = @_;
+
+    # conf-default spits out all the defaults.  can't do much to
+    # check the actual contents, short of duplicating lib/imapoptions
+    # in here, but we can at least make sure it runs without crashing
+    # and its output looks reasonably sane
+
+    foreach my $line ($self->run_cyr_info('conf-default')) {
+        chomp $line;
+        my ($name, $value) = split /\s*:\s*/, $line, 2;
+
+        $self->assert_not_null($name);
+        $self->assert_not_null($value);
+
+        if (Cassandane::Config::is_bitfield($name)) {
+            foreach my $v (split /\s+/, $value) {
+                $self->assert_not_null(Cassandane::Config::is_bitfield_bit($name, $v));
+            }
+        }
+    }
+}
+
 sub test_info_lint
 {
     my ($self) = @_;

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -150,6 +150,7 @@ static void do_conf(int only_changed, int want_since, uint32_t since)
                 printf("\n");
                 break;
 
+            case OPT_BYTESIZE:
             case OPT_DURATION:
                 if (only_changed) {
                     if (0 == strcmpsafe(imapopts[i].def.s, imapopts[i].val.s))
@@ -264,6 +265,7 @@ static void do_defconf(int want_since, uint32_t since)
                 printf("%s: %ld\n", imapopts[i].optname, imapopts[i].def.i);
                 break;
 
+            case OPT_BYTESIZE:
             case OPT_DURATION:
             case OPT_STRING:
             case OPT_STRINGLIST:


### PR DESCRIPTION
`cyr_info` was overlooked when adding BYTESIZE support, leading to `abort()` on the unrecognised option type when the `conf`, `conf-all`, or `conf-default` sub-commands were executed.

The fix itself is trivial -- `OPT_BYTESIZE` just needs to be handled the same as `OPT_DURATION` in these functions (`do_conf()` and `do_defconf()`).  The greater part of this PR is in updating our tests to detect this class of problem in the future.

We used to have a test for `cyr_info conf` that would have exposed the crash, but our config handling changed at some point, the test was disabled rather than updated, and so we no longer had such a test.  The changes here bring that test back and update it for current reality, as well as add similar tests for `cyr_info conf-all` and `cyr_info conf-default`.

If we add another new option type in the future, and forget to update cyr_info to know about it, these tests will fail due to the core files left behind when it aborts, and we'll know we've missed it.

Fixes #4650 

**Reviewers:** This is most easily read commit-by-commit, the single diff winds up a shambles.