### PR TITLE
client behavior: expand logging for uses of ENABLE

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -15200,12 +15200,17 @@ static void cmd_enable(char *tag)
             eatline(imapd_in, c);
             return;
         }
-        if (!strcasecmp(arg.s, "condstore"))
+        if (!strcasecmp(arg.s, "condstore")) {
+            client_behavior.did_condstore = 1;
             new_capa |= CAPA_CONDSTORE;
-        else if (!strcasecmp(arg.s, "qresync"))
+        }
+        else if (!strcasecmp(arg.s, "qresync")) {
+            client_behavior.did_qresync = 1;
             new_capa |= CAPA_QRESYNC | CAPA_CONDSTORE;
-        else if (!strcasecmp(arg.s, "imap4rev2"))
+        }
+        else if (!strcasecmp(arg.s, "imap4rev2")) {
             new_capa |= CAPA_IMAP4REV2;
+        }
     } while (c == ' ');
 
     /* check for CRLF */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -886,7 +886,7 @@ static void imapd_log_client_behavior(void)
                         "%s%s%s%s"
                         "%s%s%s%s"
                         "%s%s%s%s"
-                        "%s",
+                        "%s%s",
 
                         session_id(),
                         imapd_userid ? imapd_userid : "",
@@ -897,16 +897,17 @@ static void imapd_log_client_behavior(void)
                         client_behavior.did_condstore   ? " condstore=<1>"    : "",
                         client_behavior.did_idle        ? " idle=<1>"         : "",
 
+                        client_behavior.did_imap4rev2   ? " imap4rev2=<1>"    : "",
                         client_behavior.did_metadata    ? " metadata=<1>"     : "",
                         client_behavior.did_move        ? " move=<1>"         : "",
                         client_behavior.did_multisearch ? " multisearch=<1>"  : "",
-                        client_behavior.did_notify      ? " notify=<1>"       : "",
 
+                        client_behavior.did_notify      ? " notify=<1>"       : "",
                         client_behavior.did_preview     ? " preview=<1>"      : "",
                         client_behavior.did_qresync     ? " qresync=<1>"      : "",
                         client_behavior.did_replace     ? " replace=<1>"      : "",
-                        client_behavior.did_savedate    ? " savedate=<1>"     : "",
 
+                        client_behavior.did_savedate    ? " savedate=<1>"     : "",
                         client_behavior.did_searchres   ? " searchres=<1>"    : "");
 }
 
@@ -15209,6 +15210,7 @@ static void cmd_enable(char *tag)
             new_capa |= CAPA_QRESYNC | CAPA_CONDSTORE;
         }
         else if (!strcasecmp(arg.s, "imap4rev2")) {
+            client_behavior.did_imap4rev2 = 1;
             new_capa |= CAPA_IMAP4REV2;
         }
     } while (c == ' ');

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -445,6 +445,7 @@ struct client_behavior_registry {
     unsigned int did_savedate     : 1;   /* fetched SAVEDATE */
     unsigned int did_searchres    : 1;   /* used SAVE on SEARCH */
     unsigned int did_replace      : 1;   /* used REPLACE */
+    unsigned int did_imap4rev2    : 1;   /* used ENABLE IMAP4rev2  */
 };
 
 #endif /* INCLUDED_IMAPD_H */


### PR DESCRIPTION
This adds client behavior logging for ENABLE of QRESYNC, CONDSTORE, or IMAP4rev2.