### PR TITLE
github actions: report cyr_buildinfo details

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,9 @@ jobs:
         ./tools/build-with-cyruslibs.sh
     - name: report cyrus version
       shell: bash
-      run: /usr/cyrus/libexec/master -V
+      run: |
+        /usr/cyrus/libexec/master -V
+        /usr/cyrus/sbin/cyr_buildinfo
     - name: update jmap test suite
       working-directory: /srv/JMAP-TestSuite.git
       shell: bash


### PR DESCRIPTION
This adds the output of `cyr_buildinfo` to the "report cyrus version" section of CI.

It's not normally useful, but may be when diagnosing CI weirdnesses in the future.