### PR TITLE
DAV Sharing: add ACL_WRITE for read-only so JMAP account isReadOnly=false

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar-set-shared-sort-order
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar-set-shared-sort-order
@@ -1,0 +1,64 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_set_shared_sort_order
+    :min_version_3_9 :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $caldav = $self->{caldav};
+    my $admintalk = $self->{adminstore}->get_client();
+    my $service = $self->{instance}->get_service("http");
+    my ($maj, $min) = Cassandane::Instance->get_version();
+
+    xlog $self, "create shared account";
+    $admintalk->create("user.manifold");
+
+    my $mantalk = Net::CalDAVTalk->new(
+        user => "manifold",
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    $admintalk->setacl("user.manifold", admin => 'lrswipkxtecdan');
+    $admintalk->setacl("user.manifold", manifold => 'lrswipkxtecdn');
+
+    xlog $self, "create calendars";
+    my $CalendarId1 = $mantalk->NewCalendar({name => 'Manifold Calendar1'});
+    $self->assert_not_null($CalendarId1);
+    my $CalendarId2 = $mantalk->NewCalendar({name => 'Manifold Calendar2'});
+    $self->assert_not_null($CalendarId2);
+
+    xlog $self, "share $CalendarId1 and $CalendarId2 read-only to user";
+    $admintalk->setacl("user.manifold.#calendars.$CalendarId1", "cassandane" => 'lrw') or die;
+    $admintalk->setacl("user.manifold.#calendars.$CalendarId2", "cassandane" => 'lrw') or die;
+
+    xlog $self, "Verify shared account is NOT isReadOnly";
+    my $RawRequest = {
+        headers => {
+            'Authorization' => $jmap->auth_header(),
+        },
+        content => '',
+    };
+    my $RawResponse = $jmap->ua->get($jmap->uri(), $RawRequest);
+    $self->assert_str_equals('200', $RawResponse->{status});
+    my $session = eval { decode_json($RawResponse->{content}) };
+    $self->assert_equals(JSON::false, $session->{accounts}{manifold}{isReadOnly});
+
+    xlog $self, "Set sortOrder on a calendar";
+    $res = $jmap->CallMethods([
+            ['Calendar/set', {
+                    accountId => 'manifold',
+                    update => {
+                        $CalendarId1 => {
+                            sortOrder => 2
+                        }
+                    }
+             }, "R1"]
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$CalendarId1});
+}

--- a/imap/http_dav_sharing.h
+++ b/imap/http_dav_sharing.h
@@ -48,8 +48,12 @@
 
 #define DAVSHARING_CONTENT_TYPE "application/davsharing+xml"
 
-/* Privileges assigned via WebDAV Sharing (draft-pot-webdav-resource-sharing) */
-#define DACL_SHARE      ( DACL_READ   | DACL_READFB )
+/* Privileges assigned via WebDAV Sharing (draft-pot-webdav-resource-sharing)
+ *
+ * JMAP can always set calendar properties for read-only calendars,
+ * but need to flag the account as isReadOnly=false, so include ACL_WRITE.
+ */
+#define DACL_SHARE      ( DACL_READ   | DACL_READFB       | ACL_WRITE )
 #define DACL_SHARERW    ( DACL_SHARE  | DACL_WRITECONT    | DACL_WRITEPROPS |   \
                           DACL_RMRSRC | DACL_WRITEOWNRSRC | DACL_UPDATEPRIVATE )
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -608,7 +608,8 @@ calendar_sharewith_to_rights_iter:
     }
     if (++iteration == 2) goto calendar_sharewith_to_rights_iter;
 
-    /* Allow to set calendar properties */
+    /* Can always set calendar properties for read-only calendars,
+       but we need to flag the account as isReadOnly=false, so include ACL_WRITE. */
     if (newrights & ~JACL_READFB) {
         newrights |= ACL_WRITE;
     }


### PR DESCRIPTION
Fixes an issue where sharing via DAV (Apple clients) wouldn't allow JMAP clients to update calendar properties, e.g. sortOrder