### PR TITLE
small cyradm fixes

### DIFF
--- a/perl/imap/Makefile.PL.in
+++ b/perl/imap/Makefile.PL.in
@@ -91,7 +91,7 @@ WriteMakefile(
     'LD'       => $Config{ld} . ' @GCOV_LDFLAGS@',
     'OBJECT'    => 'IMAP.o',
     'MYEXTLIB'  => '@top_builddir@/perl/.libs/libcyrus.a @top_builddir@/perl/.libs/libcyrus_min.a',
-    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @ZLIB@ @GCOV_LIBS@ @LIBCAP_LIBS@"],
+    'LIBS'	=> [ "$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @LIB_REGEX@ @ZLIB@ @GCOV_LIBS@ @LIBCAP_LIBS@"],
     'DEFINE'	=> '-DPERL_POLLUTE',    # e.g., '-DHAVE_SOMETHING'
     'INC'	=> "-I@top_srcdir@ -I@top_srcdir@/com_err/et @SASLFLAGS@ @SSL_CPPFLAGS@ @GCOV_CFLAGS@ -I@top_srcdir@/perl/imap",
     'EXE_FILES' => [cyradm],

--- a/tools/fixsearchpath.pl
+++ b/tools/fixsearchpath.pl
@@ -75,6 +75,8 @@ my @dirvars = (
 
 my $boilerplate = << 'EOT'
 ## Boilerplate added by Cyrus fixsearchpath.pl
+## XXX This might all be for naught because the top-level Cyrus build does
+## XXX not pass DESTDIR down to the perl modules anyway.
 my $__cyrus_destdir;
 BEGIN {
     $__cyrus_destdir = '';
@@ -82,7 +84,9 @@ BEGIN {
         my $d = $0;
 EOT
 ;
-$boilerplate .= "       my \$bindir = " . quote($configure_bindir) . ";\n";
+$boilerplate .= "        my \$bindir = "
+                . quote($configure_prefix . $configure_bindir)
+                . ";\n";
 $boilerplate .= << 'EOT'
         # remove the filename, $d is now the installed bindir
         $d =~ s/\/[^\/]+$//;
@@ -103,7 +107,7 @@ foreach my $dv (@dirvars) {
         # Expect to be installed into a non-default location
         # because Cyrus was built with a non-default --prefix
         my $install_prefix = normalise($Config{$dv->{prefix}});
-        $dir = $configure_prefix . substr($dir, length($install_prefix))
+        $dir = $configure_prefix . substr($dir, length($install_prefix));
     }
     $boilerplate .= 'use lib $__cyrus_destdir . ' . quote($dir) .  ";\n";
 }


### PR DESCRIPTION
This fixes a couple of problems that were making `cyradm` not work on my system:

IMAP.so (for Cyrus::IMAP) needs to be linked with the regex library, but wasn't.

The boilerplate added to perl scripts by `tools/fixsearchpath.pl` (to detect and compensate when Cyrus has been installed with a `DESTDIR`) was assuming `$bindir` contains the full path, when it actually just contains the path relative to `$prefix`.  As a result, it was mistaking `$prefix` for `DESTDIR`, trying to compensate for it, and then being unable to find its dependencies.  The fix is to use the full `"$prefix$bindir"` path where the full path is expected.

I guess we've never really noticed this because we don't use `cyradm`, and others are probably installing to a standard prefix that perl already knows to look in, in which case their `cyradm` is able to find its dependencies despite the bogus path compensation.  Though I have no idea how it works for them when the regex library isn't linked properly.