### PR TITLE
lmtp_sieve.c:sieve_imip() call `zoneinfo_open(NULL)` during initialization

### DIFF
--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -81,6 +81,7 @@
 #include "xmalloc.h"
 #include "xstrlcpy.h"
 #include "xstrlcat.h"
+#include "imap/zoneinfo_db.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -2291,7 +2292,8 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     sieve_register_jmapquery(interp, &jmapquery);
 #endif
 #ifdef HAVE_ICAL
-    /* need timezones for sieve snooze */
+    /* need timezones for sieve snooze and stripping in processimip */
+    zoneinfo_open(NULL);
     ical_support_init();
     sieve_register_snooze(interp, &sieve_snooze);
 #ifdef WITH_DAV

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -99,6 +99,7 @@
 #include "xmalloc.h"
 #include "xstrlcpy.h"
 #include "xstrlcat.h"
+#include "imap/zoneinfo_db.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -1040,6 +1041,9 @@ void shut_down(int code)
 
     libcyrus_run_delayed();
 
+#if defined USE_SIEVE && defined HAVE_ICAL
+    zoneinfo_close(NULL);
+#endif
     /* close backend connections */
     for (i = 0; i < ptrarray_size(&backend_cached); i++) {
         struct backend *be = ptrarray_nth(&backend_cached, i);


### PR DESCRIPTION
Otherwise when `processimip` calls `caldav_store_resource()` → `strip_vtimezones()` → `zoneinfo_lookup()` the timezones are never found.  Then the known timezones are not stripped from the iCalendar object.