### PR TITLE
Replace `xzfree()` with `free()`

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1375,7 +1375,7 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
         break;
     case DLISTSAX_KVLISTEND:
         if (rock->doingacl) {
-            xzfree(rock->h->acl);
+            free(rock->h->acl);
             rock->h->acl = buf_release(&rock->aclbuf);
             rock->doingacl = 0;
         }
@@ -1404,23 +1404,23 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
             buf_putc(&rock->aclbuf, '\t');
         }
         else if (rock->doingflags) {
-            xzfree(rock->h->flagname[rock->nflags]);
+            free(rock->h->flagname[rock->nflags]);
             rock->h->flagname[rock->nflags++] = xstrdupnull(d->data);
         }
         else {
             if (!strcmp(key, "I")) {
-                xzfree(rock->h->uniqueid);
+                free(rock->h->uniqueid);
                 rock->h->uniqueid = xstrdupnull(d->data);
             }
             else if (!strcmp(key, "N")) {
-                xzfree(rock->h->name);
+                free(rock->h->name);
                 rock->h->name = xstrdupnull(d->data);
             }
             else if (!strcmp(key, "T")) {
                 rock->h->mbtype = mboxlist_string_to_mbtype(d->data);
             }
             else if (!strcmp(key, "Q")) {
-                xzfree(rock->h->quotaroot);
+                free(rock->h->quotaroot);
                 rock->h->quotaroot = xstrdupnull(d->data);
             }
         }
@@ -6583,7 +6583,7 @@ HIDDEN int mailbox_rename_nocopy(struct mailbox *oldmailbox,
     if (!silent) mailbox_modseq_dirty(oldmailbox);
 
     /* update the name in the header */
-    xzfree(oldmailbox->h.name);
+    free(oldmailbox->h.name);
     oldmailbox->h.name = xstrdup(newname);
     oldmailbox->header_dirty = 1;
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1794,7 +1794,7 @@ EXPORTED int mboxlist_promote_intermediary(const char *mboxname)
                                   &mbentry->partition);
     if (r) goto done;
     mbentry->mbtype &= ~MBTYPE_INTERMEDIATE;
-    xzfree(mbentry->acl);
+    free(mbentry->acl);
     mbentry->acl = xstrdupnull(parent->acl);
 
     r = mailbox_create(mboxname, mbentry->mbtype,
@@ -1809,7 +1809,7 @@ EXPORTED int mboxlist_promote_intermediary(const char *mboxname)
     if (r) goto done;
 
     // make sure all the fields are up-to-date
-    xzfree(mbentry->uniqueid);
+    free(mbentry->uniqueid);
     mbentry->uniqueid = xstrdupnull(mailbox_uniqueid(mailbox));
     mbentry->uidvalidity = mailbox->i.uidvalidity;
     mbentry->createdmodseq = mailbox->i.createdmodseq;

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -554,7 +554,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
     if (strcmpsafe(mailbox_uniqueid(mailbox), mbentry_byname->uniqueid)) {
         printf("Wrong uniqueid in mbentry, fixing %s (%s -> %s)\n",
                name, mbentry_byname->uniqueid, mailbox_uniqueid(mailbox));
-        xzfree(mbentry_byname->uniqueid);
+        free(mbentry_byname->uniqueid);
         mbentry_byname->uniqueid = xstrdupnull(mailbox_uniqueid(mailbox));
         mbentry_dirty = 1;
     }
@@ -574,7 +574,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
         printf("Wrong uniqueid! %s (should be %s)\n", mbentry_byid->name, name);
         if (updateuniqueids) {
             mailbox_make_uniqueid(mailbox);
-            xzfree(mbentry_byname->uniqueid);
+            free(mbentry_byname->uniqueid);
             mbentry_byname->uniqueid = xstrdupnull(mailbox_uniqueid(mailbox));
             mbentry_dirty = 1;
             syslog (LOG_ERR, "uniqueid clash with %s - changed %s (%s => %s)",
@@ -641,7 +641,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
         else {
             printf("Wrong acl in mbentry %s (%s %s)\n",
                    name, mbentry_byname->acl, mailbox_acl(mailbox));
-            xzfree(mbentry_byname->acl);
+            free(mbentry_byname->acl);
             mbentry_byname->acl = xstrdupnull(mailbox_acl(mailbox));
             mbentry_dirty = 1;
         }

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -387,7 +387,7 @@ static int cb_allmbox(const mbentry_t *mbentry, void *rock)
         if (!strcmpsafe(userid, prev_userid))
             goto done;
 
-        xzfree(prev_userid);
+        free(prev_userid);
         prev_userid = xstrdup(userid);
 
         r = sync_do_user(&sync_cs, userid, NULL);

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -60,7 +60,7 @@ EXPORTED void strarray_fini(strarray_t *sa)
     if (!sa)
         return;
     for (i = 0 ; i < sa->count ; i++) {
-        xzfree(sa->data[i]);
+        free(sa->data[i]);
     }
     xzfree(sa->data);
     sa->count = 0;


### PR DESCRIPTION
when the former has no added value.  That is, when a new value is assigned to the parameter on the next line.

In `strarray_fini()` the data is never read again, so there is need to zero it.