### PR TITLE
jmap_query_parse() and jmap_querychanges_parse(): parameter err is never NULL

### DIFF
--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2374,7 +2374,7 @@ HIDDEN void jmap_query_parse(jmap_req_t *req, struct jmap_parser *parser,
                                   filter_cb, filter_rock, err);
                 jmap_parser_pop(parser);
                 query->filter = arg;
-                if (err && *err) {
+                if (*err) {
                     goto done;
                 }
             }
@@ -2391,7 +2391,7 @@ HIDDEN void jmap_query_parse(jmap_req_t *req, struct jmap_parser *parser,
                     jmap_comparator_parse(req, parser, val, unsupported_sort,
                                           comp_cb, comp_rock, err);
                     jmap_parser_pop(parser);
-                    if (err && *err) {
+                    if (*err) {
                         goto done;
                     }
                 }
@@ -2543,7 +2543,7 @@ HIDDEN void jmap_querychanges_parse(jmap_req_t *req,
                                   filter_cb, filter_rock, err);
                 jmap_parser_pop(parser);
                 query->filter = arg;
-                if (err && *err) {
+                if (*err) {
                     goto done;
                 }
             }

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -520,7 +520,7 @@ extern void jmap_comparator_parse(jmap_req_t *req, struct jmap_parser *parser,
                                   jmap_comparator_parse_cb comp_cb, void *comp_rock,
                                   json_t **err);
 
-extern void jmap_query_parse(jmap_req_t *req, struct jmap_parser *parser,
+__attribute__((nonnull(10))) void jmap_query_parse(jmap_req_t *req, struct jmap_parser *parser,
                              jmap_args_parse_cb args_parse, void *args_rock,
                              jmap_filter_parse_cb filter_cb, void *filter_rock,
                              jmap_comparator_parse_cb comp_cb, void *comp_rock,
@@ -549,7 +549,7 @@ struct jmap_querychanges {
     json_t *added;
 };
 
-extern void jmap_querychanges_parse(jmap_req_t *req,
+__attribute__((nonnull(10))) void jmap_querychanges_parse(jmap_req_t *req,
                                     struct jmap_parser *parser,
                                     jmap_args_parse_cb args_parse, void *args_rock,
                                     jmap_filter_parse_cb filter_cb, void *filter_rock,


### PR DESCRIPTION
In all invocations of `jmap_querychanges_parse()` and `jmap_query_parse()` the last parameter err is never `NULL`.  When `err` is compared with NULL in the code the clang static analyzer assumes that err can be `NULL`.  On later `*err=` assignments the analyzer thinks that err can be NULL and reports

> Dereference of null pointer (loaded from variable 'err')