### PR TITLE
JMAP Sieve: do not decode valid UTF-8 strings in MIME headers

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_sieve_8bit_header
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sieve_8bit_header
@@ -1,0 +1,60 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_sieve_8bit_header
+    :min_version_3_9 :needs_component_jmap :needs_component_sieve :NoMunge8Bit :RFC2047_UTF8
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    $imap->create("matches") or die;
+
+    xlog "Assert that message got moved into INBOX.matches";
+    $imap->select('matches');
+    $self->assert_num_equals(0, $imap->get_response_code('exists'));
+    $imap->unselect();
+
+    # "subject" : "płatność"
+
+use utf8;
+    $self->{instance}->install_sieve_script(<<'EOF'
+require ["x-cyrus-jmapquery", "x-cyrus-log", "variables", "fileinto"];
+if
+  allof( not string :is "${stop}" "Y",
+    jmapquery text:
+  {
+    "subject" : "płatność"
+  }
+.
+  )
+{
+  fileinto "matches";
+}
+EOF
+    );
+
+    my $mime = <<'EOF';
+From: from@local
+To: to@local
+Subject: test płatność
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;charset=us-ascii
+Content-Transfer-Encoding: 7bit
+
+hello
+
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+no utf8;
+
+    my $msg = Cassandane::Message->new();
+    $msg->set_lines(split /\n/, $mime);
+    $self->{instance}->deliver($msg);
+
+    xlog "Assert that message got moved into INBOX.matches";
+    $imap->select('matches');
+    $self->assert_num_equals(1, $imap->get_response_code('exists'));
+    $imap->unselect();
+}

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -1475,6 +1475,11 @@ static void test_count_validutf8(void)
     CU_ASSERT_EQUAL(5, counts.valid);
     CU_ASSERT_EQUAL(0, counts.replacement);
     CU_ASSERT_EQUAL(0, counts.invalid);
+    CU_ASSERT_EQUAL(0, counts.bytelen[0]);
+    CU_ASSERT_EQUAL(0, counts.bytelen[1]);
+    CU_ASSERT_EQUAL(4, counts.bytelen[2]);
+    CU_ASSERT_EQUAL(1, counts.bytelen[3]);
+    CU_ASSERT_EQUAL(0, counts.bytelen[4]);
 
     /* Two continuation bytes */
     data = "a \x80\xbf\x80 text";
@@ -1482,6 +1487,11 @@ static void test_count_validutf8(void)
     CU_ASSERT_EQUAL(7, counts.valid);
     CU_ASSERT_EQUAL(0, counts.replacement);
     CU_ASSERT_EQUAL(3, counts.invalid);
+    CU_ASSERT_EQUAL(3, counts.bytelen[0]);
+    CU_ASSERT_EQUAL(7, counts.bytelen[1]);
+    CU_ASSERT_EQUAL(0, counts.bytelen[2]);
+    CU_ASSERT_EQUAL(0, counts.bytelen[3]);
+    CU_ASSERT_EQUAL(0, counts.bytelen[4]);
 
     /* Lonely start character, followed by 3-byte char, plus replacement char */
     data = "\xfc\xe2\x82\xac \xef\xbf\xbd";
@@ -1489,6 +1499,11 @@ static void test_count_validutf8(void)
     CU_ASSERT_EQUAL(2, counts.valid);
     CU_ASSERT_EQUAL(1, counts.replacement);
     CU_ASSERT_EQUAL(1, counts.invalid);
+    CU_ASSERT_EQUAL(1, counts.bytelen[0]);
+    CU_ASSERT_EQUAL(1, counts.bytelen[1]);
+    CU_ASSERT_EQUAL(0, counts.bytelen[2]);
+    CU_ASSERT_EQUAL(2, counts.bytelen[3]);
+    CU_ASSERT_EQUAL(0, counts.bytelen[4]);
 }
 
 static void test_qpencode_mimebody(void)

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -4338,6 +4338,7 @@ EXPORTED struct char_counts charset_count_validutf8(const char *data, size_t dat
         UChar32 c;
         U8_NEXT(data8, i, length, c);
         counts.total++;
+        counts.bytelen[U8_LENGTH(c)]++;
         if (c == 0xfffd)
             counts.replacement++;
         else if (c >= 0) {

--- a/lib/charset.h
+++ b/lib/charset.h
@@ -187,6 +187,7 @@ struct char_counts {
     size_t replacement;
     size_t invalid;
     size_t cntrl;
+    size_t bytelen[5]; // n-th position = count of n-byte chars, position 0 counts surrogates and invalid code points
 };
 
 /* Count the number of valid, invalid and replacement UTF-8 characters


### PR DESCRIPTION
This fixes an issue with malformed MIME headers where implementations store arbitrary UTF-8 strings without encoding them as defined in RFC 2047. This impacts JMAP Email/query filters during Sieve evaluation.

Such headers already were handled leniently for stored messages, e.g. ones having a cache record. Now messages without cache record also allow undecoded UTF-8 values.