### PR TITLE
lmtp_sieve: ignore VTIMEZONE errors for IANA timezones

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/itip_ignore_invalid_timezone
+++ b/cassandane/tiny-tests/JMAPCalendars/itip_ignore_invalid_timezone
@@ -1,0 +1,83 @@
+#!perl
+use Cassandane::Tiny;
+use Data::UUID;
+
+sub test_itip_ignore_invalid_timezone
+    :min_version_3_9 :needs_component_jmap :needs_component_sieve
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "vnd.cyrus.imip"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processimip :outcome "outcome";
+}
+EOF
+    );
+
+    my @testCases = ({
+        tzid => 'UTC', # can handle as 'Etc/UTC'
+        wantAdded => 1,
+    }, {
+        tzid => 'Europe/Vienna', # already is IANA name
+        wantAdded => 1,
+    }, {
+        tzid => 'Pacific Standard Time', # can map to IANA name
+        wantAdded => 1,
+    }, {
+        tzid => 'Foo', # can't map to IANA, reject
+        wantAdded => 0,
+    });
+
+    for my $tc (@testCases) {
+
+        my $uid = (Data::UUID->new)->create_str();
+
+        xlog $self, "Send iMIP message with invalid VTIMEZONE having name $tc->{tzid}";
+        my $imip = <<"EOF";
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Sally Sender <sender\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uid\@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:$tc->{tzid}
+X-LIC-LOCATION:$tc->{tzid}
+END:VTIMEZONE
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uid
+TRANSP:OPAQUE
+SUMMARY:test
+DTSTART;TZID=$tc->{tzid}:20210923T153000
+DURATION:PT1H
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+ORGANIZER:MAILTO:organizer\@example.net
+ATTENDEE;RSVP=TRUE;PARTSTAT=NEEDS-ACTION:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+        $self->{instance}->deliver(Cassandane::Message->new(raw => $imip));
+
+        my $res = $jmap->CallMethods([
+            ['CalendarEvent/get', {
+                ids => [encode_eventid($uid)]
+            }, 'R1']
+        ]);
+
+        if ($tc->{wantAdded}) {
+            $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
+        } else {
+            $self->assert_num_equals(1, scalar @{$res->[0][1]{notFound}});
+        }
+    }
+}

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -3462,7 +3462,7 @@ static int caldav_import(struct transaction_t *txn, void *obj,
             return HTTP_FORBIDDEN;
         }
         cyrus_icalrestriction_check(ical);
-        if ((txn->error.desc = get_icalcomponent_errstr(ical))) {
+        if ((txn->error.desc = get_icalcomponent_errstr(ical, ICAL_SUPPORT_STRICT))) {
             buf_setcstr(&txn->buf, txn->error.desc);
             txn->error.desc = buf_cstring(&txn->buf);
             txn->error.precond = CALDAV_VALID_DATA;
@@ -3626,9 +3626,10 @@ static int caldav_patch(struct transaction_t *txn, void *obj)
         ret = HTTP_BAD_REQUEST;
     }
     else if (!icalrestriction_check(pdoc) || icalcomponent_count_errors(pdoc)) {
-        if ((txn->error.desc = get_icalcomponent_errstr(pdoc)) ||
+        if ((txn->error.desc = get_icalcomponent_errstr(pdoc, ICAL_SUPPORT_STRICT)) ||
             (txn->error.desc =
-             get_icalcomponent_errstr(icalcomponent_get_first_real_component(pdoc)))) {
+             get_icalcomponent_errstr(icalcomponent_get_first_real_component(pdoc),
+                 ICAL_SUPPORT_STRICT))) {
             buf_setcstr(&txn->buf, txn->error.desc);
             txn->error.desc = buf_cstring(&txn->buf);
         }
@@ -3781,7 +3782,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
     }
 
     cyrus_icalrestriction_check(ical);
-    if ((txn->error.desc = get_icalcomponent_errstr(ical))) {
+    if ((txn->error.desc = get_icalcomponent_errstr(ical, ICAL_SUPPORT_STRICT))) {
         buf_setcstr(&txn->buf, txn->error.desc);
         txn->error.desc = buf_cstring(&txn->buf);
         txn->error.precond = CALDAV_VALID_DATA;

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -491,7 +491,7 @@ static int meth_post_isched(struct transaction_t *txn,
     }
 
     icalrestriction_check(ical);
-    if ((txn->error.desc = get_icalcomponent_errstr(ical))) {
+    if ((txn->error.desc = get_icalcomponent_errstr(ical, ICAL_SUPPORT_STRICT))) {
         assert(!buf_len(&txn->buf));
         buf_setcstr(&txn->buf, txn->error.desc);
         txn->error.desc = buf_cstring(&txn->buf);

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -166,7 +166,9 @@ extern icalcomponent *record_to_ical(struct mailbox *mailbox,
                                      const struct index_record *record,
                                      strarray_t *schedule_addresses);
 
-extern const char *get_icalcomponent_errstr(icalcomponent *ical);
+#define ICAL_SUPPORT_STRICT 0
+#define ICAL_SUPPORT_ALLOW_INVALID_IANA_TIMEZONE (1<<0)
+extern const char *get_icalcomponent_errstr(icalcomponent *ical, unsigned flags);
 
 extern void icalcomponent_remove_invitee(icalcomponent *comp,
                                          icalproperty *prop);

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1502,7 +1502,8 @@ static int sieve_imip(void *ac, void *ic, void *sc, void *mc,
     }
 
     cyrus_icalrestriction_check(itip);
-    if ((errstr = get_icalcomponent_errstr(itip)) &&
+    if ((errstr = get_icalcomponent_errstr(itip,
+                    ICAL_SUPPORT_ALLOW_INVALID_IANA_TIMEZONE)) &&
         ((meth != ICAL_METHOD_REPLY && meth != ICAL_METHOD_PUBLISH) ||
          (!strstr(errstr, "Failed iTIP restrictions for ORGANIZER property") &&
           !strstr(errstr, "No value for ORGANIZER property")))) {

--- a/imap/zoneinfo_db.c
+++ b/imap/zoneinfo_db.c
@@ -74,6 +74,9 @@ EXPORTED int zoneinfo_open(const char *fname)
     int ret;
     char *tofree = NULL;
 
+    if (zoneinfo_dbopen)
+        return 0;
+
     if (!fname) fname = config_getstring(IMAPOPT_ZONEINFO_DB_PATH);
 
     /* create db file name */


### PR DESCRIPTION
Sometimes a client send iTIP requests containing invalid VTIMEZONE definitions such as

   BEGIN:VTIMEZONE
   TZID:UTC
   END:VTIMEZONE

Cyrus is perfectly capable of making sense of this VTIMEZONE, so let's leniently accept bogus VTIMEZONEs in iTIP messages if they can be mapped to an IANA timezone. This only applies for iTIP, such iCalendar data still gets rejected during PUT and import.
