### PR TITLE
mboxevent.c: properly handle DAV URLs with percent-encoded UTF-8 chars

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -110,6 +110,8 @@ sub new
     $config->set(httpallowcompress => 'no');
     $config->set(caldav_historical_age => -1);
     $config->set(icalendar_max_size => 100000);
+    $config->set(event_extra_params => 'vnd.cmu.davFilename vnd.cmu.davUid');
+    $config->set(event_groups => 'calendar');
     return $class->SUPER::new({
         config => $config,
         adminstore => 1,
@@ -6109,6 +6111,7 @@ EOF
 
     utf8::encode($event);
 
+    # This will fail if the UTF-8 resource name isn't handled properly
     my $res = $CalDAV->{ua}->request('PUT', $href, {
         headers => \%headers,
         content => $event

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -1104,6 +1104,7 @@ EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *
          mboxevent_expected_param(event->type, EVENT_DAV_UID))) {
         const char *resource = NULL;
         struct param *param;
+        char *xval = NULL;
 
         if (!body) {
             if (mailbox_cacherecord(mailbox, record))
@@ -1114,6 +1115,9 @@ EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *
         for (param = body->disposition_params; param; param = param->next) {
             if (!strcmp(param->attribute, "FILENAME")) {
                 resource = param->value;
+            }
+            else if (!strcmp(param->attribute, "FILENAME*")) {
+                resource = xval = charset_parse_mimexvalue(param->value, NULL);
             }
         }
 
@@ -1145,6 +1149,8 @@ EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *
                 FILL_STRING_PARAM(event, EVENT_DAV_UID, xstrdup(""));
             }
         }
+
+        free(xval);
     }
 #endif // WITH_DAV
 
@@ -1303,6 +1309,7 @@ EXPORTED void mboxevent_extract_msgrecord(struct mboxevent *event, msgrecord_t *
          mboxevent_expected_param(event->type, EVENT_DAV_UID))) {
         const char *resource = NULL;
         struct param *param;
+        char *xval = NULL;
 
         if (!body) {
             r = msgrecord_extract_bodystructure(msgrec, &body);
@@ -1315,6 +1322,9 @@ EXPORTED void mboxevent_extract_msgrecord(struct mboxevent *event, msgrecord_t *
         for (param = body->disposition_params; param; param = param->next) {
             if (!strcmp(param->attribute, "FILENAME")) {
                 resource = param->value;
+            }
+            else if (!strcmp(param->attribute, "FILENAME*")) {
+                resource = xval = charset_parse_mimexvalue(param->value, NULL);
             }
         }
 
@@ -1346,6 +1356,8 @@ EXPORTED void mboxevent_extract_msgrecord(struct mboxevent *event, msgrecord_t *
                 FILL_STRING_PARAM(event, EVENT_DAV_UID, xstrdup(""));
             }
         }
+
+        free(xval);
     }
 #endif // WITH_DAV
 


### PR DESCRIPTION
This wasn't caught by the initial Cass test because it wasn't requesting the DAV UID for the event