### PR TITLE
various squat fixes

### DIFF
--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -279,6 +279,75 @@ sub test_nonincremental
     $self->assert_matches(qr{indexed $n messages}, $err);
 }
 
+sub test_incremental
+    :SearchEngineSquat
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+    my $err;
+
+    # some initial messages
+    for (1..5) {
+        $self->make_message();
+    }
+
+    # make a message with no subject, to, or from
+    # this used to trigger an indexing bug and produce a corrupt index,
+    # which would lead to a crash during incremental reindex
+    my $weird = $self->make_message(undef, to => undef, from => undef);
+    xlog "weird message:\n" . $weird->as_string();
+
+    sleep(1);
+
+    # initial non-incremental index
+    (undef, $err) = $self->run_squatter('-vv');
+    $self->assert_matches(qr{indexed 6 messages}, $err);
+
+    # incremental reindex with no changes to mailbox
+    (undef, $err) = $self->run_squatter('-i', '-vv');
+    $self->assert_matches(qr{indexed 0 messages}, $err);
+
+    # delete, expunge, and cyr_expire some messages
+    # n.b. this does not unindex the message in any way
+    $imap->store('5', '+flags', '(\\Deleted)');
+    $self->assert_str_equals('ok', $imap->get_last_completion_response());
+    $imap->expunge();
+    $self->assert_str_equals('ok', $imap->get_last_completion_response());
+    $self->{instance}->run_command({cyrus => 1}, 'cyr_expire', '-X', '0');
+
+    # incremental reindex after one message expunged
+    (undef, $err) = $self->run_squatter('-i', '-vv');
+    $self->assert_matches(qr{indexed 0 messages}, $err);
+
+    # make one new message
+    for (1) {
+        $self->make_message();
+    }
+    sleep(1);
+
+    # incremental reindex after one new message
+    (undef, $err) = $self->run_squatter('-i', '-vv');
+    $self->assert_matches(qr{indexed 1 messages}, $err);
+
+    # incremental reindex with no changes to mailbox
+    (undef, $err) = $self->run_squatter('-i', '-vv');
+    $self->assert_matches(qr{indexed 0 messages}, $err);
+
+    # make some new messages
+    for (1..10) {
+        $self->make_message();
+    }
+    sleep(1);
+
+    # incremental reindex after new messages
+    (undef, $err) = $self->run_squatter('-i', '-vv');
+    $self->assert_matches(qr{indexed 10 messages}, $err);
+
+    # incremental reindex with no changes to mailbox
+    (undef, $err) = $self->run_squatter('-i', '-vv');
+    $self->assert_matches(qr{indexed 0 messages}, $err);
+}
+
 sub test_relocate_legacy_searchdb
     :DelayedDelete :min_version_3_6 :MailboxLegacyDirs
     :Admin :SearchEngineSquat :NoAltNamespace :VirtDomains

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -47,6 +47,7 @@ use Data::Dumper;
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
+use Cassandane::Util::Slurp;
 
 sub new
 {
@@ -66,6 +67,27 @@ sub tear_down
 {
     my ($self) = @_;
     $self->SUPER::tear_down();
+}
+
+sub run_squatter
+{
+    my ($self, @args) = @_;
+
+    my $outfname = $self->{instance}->{basedir} . "/squatter.out";
+    my $errfname = $self->{instance}->{basedir} . "/squatter.err";
+
+    $self->{instance}->run_command({
+            cyrus => 1,
+            redirects => {
+                stdout => $outfname,
+                stderr => $errfname,
+            },
+        },
+        'squatter',
+        @args
+    );
+
+    return (slurp_file($outfname), slurp_file($errfname));
 }
 
 # XXX version gated to 3.4+ for now to keep travis happy, but if we
@@ -135,6 +157,36 @@ sub test_skip_unmodified
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-s', '0');
     @lines = $self->{instance}->getsyslog();
     $self->assert(grep /Squat skipping mailbox/, @lines);
+}
+
+sub test_nonincremental
+    :SearchEngineSquat
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+    my $n = 0;
+
+    for (1..5) {
+        # make a new message
+        $self->make_message();
+        $n++;
+
+        # do a full reindex
+        my (undef, $err) = $self->run_squatter('-vv');
+
+        # better have indexed them all, not just the new one!
+        $self->assert_matches(qr{indexed $n messages}, $err);
+    }
+
+    # make a message with no subject, to, or from
+    $self->make_message(undef, to => undef, from => undef);
+    $n++;
+
+    # do a full reindex
+    my (undef, $err) = $self->run_squatter('-vv');
+
+    # better have indexed them all, not just the new one!
+    $self->assert_matches(qr{indexed $n messages}, $err);
 }
 
 sub test_relocate_legacy_searchdb

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -123,6 +123,18 @@ sub test_simple
     }, {
         search => ['fuzzy', 'body', 'term4'],
         wantUids => [4],
+    }, {
+        # we don't index content-type, make sure we actually didn't
+        search => ['from', 'text/plain'],
+        wantUids => [],
+    }, {
+        # we don't index content-type, make sure we actually didn't
+        search => ['to', 'text/plain'],
+        wantUids => [],
+    }, {
+        # we don't index content-type, make sure we actually didn't
+        search => ['subject', 'text/plain'],
+        wantUids => [],
     });
 
     foreach (@tests) {

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1095,6 +1095,8 @@ sub make_message
 
     my $msg = $self->{gen}->generate(subject => $subject, %attrs);
     $msg->remove_headers('subject') if !defined $subject;
+    $msg->remove_headers('to') if exists $attrs{to} and not $attrs{to};
+    $msg->remove_headers('from') if exists $attrs{from} and not $attrs{from};
     $self->_save_message($msg, $store);
 
     return $msg;

--- a/changes/next/4660-squatdb-fixes
+++ b/changes/next/4660-squatdb-fixes
@@ -1,0 +1,21 @@
+Description:
+
+Fixed: squat db reindexes are no longer always incremental
+Fixed: squat db corruption from unintentional indexing of fields
+  intended to be skipped
+Fixed: squat db out of bounds access in incremental reindex docID map
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+Squat search databases may benefit from a full (non-incremental) reindex
+
+
+GitHub issue:
+
+#4660

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -124,7 +124,7 @@ extern search_snippet_markup_t default_snippet_markup;
 typedef struct search_text_receiver search_text_receiver_t;
 struct search_text_receiver {
     int (*begin_mailbox)(search_text_receiver_t *,
-                         struct mailbox *, int incremental);
+                         struct mailbox *, int flags);
     uint32_t (*first_unindexed_uid)(search_text_receiver_t *);
     /* returns the highest index level of msg. ties between equal index levels
      * are broken by choosing the index level without the partial bit set */

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -776,7 +776,7 @@ static int doc_check(void *closure, const SquatListDoc *doc)
 
 static int begin_mailbox(search_text_receiver_t *rx,
                          struct mailbox *mailbox,
-                         int incremental)
+                         int flags)
 {
     SquatReceiverData *d = (SquatReceiverData *)rx;
     SquatOptions options;
@@ -788,6 +788,7 @@ static int begin_mailbox(search_text_receiver_t *rx,
     SquatSearchIndex *old_index = NULL;
     int r = 0;      /* IMAP error code */
     int s = 0;      /* SQUAT error code */
+    int incremental = (flags & SEARCH_UPDATE_INCREMENTAL);
 
     bv_clearall(&d->indexed);
 

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -92,6 +92,7 @@ typedef struct {
 
 static const char *squat_strerror(int err);
 
+/* c.f. part_char_by_part below */
 static const char * const doctypes_by_part[SEARCH_NUM_PARTS] = {
     "msh", // SEARCH_PART_ANY
     "f",   // SEARCH_PART_FROM
@@ -110,6 +111,29 @@ static const char * const doctypes_by_part[SEARCH_NUM_PARTS] = {
     NULL,  // SEARCH_PART_LANGUAGE
     NULL   // SEARCH_PART_PRIORITY
 };
+
+/* c.f. doctypes_by_part above */
+static const char part_char_by_part[SEARCH_NUM_PARTS] = {
+    0,     // SEARCH_PART_ANY
+    'f',   // SEARCH_PART_FROM
+    't',   // SEARCH_PART_TO
+    'c',   // SEARCH_PART_CC
+    'b',   // SEARCH_PART_BCC
+    's',   // SEARCH_PART_SUBJECT
+    0,     // SEARCH_PART_LISTID
+    0,     // SEARCH_PART_TYPE
+    'h',   // SEARCH_PART_HEADERS
+    'm',   // SEARCH_PART_BODY
+    0,     // SEARCH_PART_LOCATION       -- XXX not indexed for some reason
+    0,     // SEARCH_PART_ATTACHMENTNAME -- XXX not indexed for some reason
+    0,     // SEARCH_PART_ATTACHMENTBODY
+    0,     // SEARCH_PART_DELIVEREDTO
+    0,     // SEARCH_PART_LANGUAGE
+    0,     // SEARCH_PART_PRIORITY
+};
+
+/* c.f. part_char_by_part above */
+static const char *const valid_part_chars = "ftcbshm";
 
 /* The document name is of the form
 
@@ -602,19 +626,9 @@ static void begin_part(search_text_receiver_t *rx, int part)
     char part_char = 0;
 
     /* Figure out what the name of the source document is going to be. */
-    switch (part) {
-    case SEARCH_PART_FROM: part_char = 'f'; break;
-    case SEARCH_PART_TO: part_char = 't'; break;
-    case SEARCH_PART_CC: part_char = 'c'; break;
-    case SEARCH_PART_BCC: part_char = 'b'; break;
-    case SEARCH_PART_SUBJECT: part_char = 's'; break;
-    case SEARCH_PART_HEADERS: part_char = 'h'; break;
-    case SEARCH_PART_BODY:
-        part_char = 'm';
-        break;
-    default:
-        return;
-    }
+    assert(part >= 0 && part < SEARCH_NUM_PARTS);
+    part_char = part_char_by_part[part];
+    if (!part_char) return;
 
     snprintf(d->doc_name, sizeof(d->doc_name), "%c%d", part_char, d->uid);
     d->doc_is_open = 0;
@@ -651,6 +665,9 @@ static int append_text(search_text_receiver_t *rx,
     SquatReceiverData *d = (SquatReceiverData *) rx;
     int r = 0;      /* IMAP error */
     int s = 0;      /* SQUAT error */
+
+    /* nothing to do here if begin_part() exited early or wasn't called */
+    if (!d->doc_name[0]) return 0;
 
     if (!d->doc_is_open) {
         if (text->len + d->pending_text.len < SQUAT_WORD_SIZE) {
@@ -703,6 +720,7 @@ static void end_part(search_text_receiver_t *rx,
         }
     }
     d->doc_is_open = 0;
+    memset(d->doc_name, 0, sizeof(d->doc_name));
     buf_reset(&d->pending_text);
 }
 
@@ -757,7 +775,7 @@ static int doc_check(void *closure, const SquatListDoc *doc)
         return (1);
     }
 
-    if (!strchr("tfcbsmh", doc->doc_name[0])) {
+    if (!strchr(valid_part_chars, doc->doc_name[0])) {
         syslog(LOG_ERR, "squat: invalid document name: %s", doc->doc_name);
         d->valid = 0;
         /* TODO: is this right?? */


### PR DESCRIPTION
Fixes three bugs found in the Squat search backend while investigating #4660  

1) Reindexes were always incremental, regardless of whether or not the `-i` option was passed to squatter.  The `flags` argument handling has been fixed.
2) Messages parts that weren't supposed to be indexed were indexed anyway due to state not being set/checked/cleared properly in `begin_part()`/`append_text()`/`end_part()`.  The affected text was indexed into the wrong document if you were lucky, or corrupted the index if you weren't.  The state management has been fixed by making sure to check and clear `d->doc_name`.
3) `doc_ID_map` started at zero, but its callers and bounds checks expected it to start at 1, leading to accesses past the end of the valid data, and the assertion failure from the original report, when attempting an incremental reindex of a mailbox containing corruption as per 2.  `doc_ID_map` now starts at one, and the functions for managing it assert their invariants.

**Reviewers:** this will make the most sense when reviewed commit-by-commit

Closes #4660 