### PR TITLE
cassandane: skip tests that JMAP-TestSuite will have skipped anyway

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPTestSuite.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuite.pm
@@ -68,6 +68,13 @@ my %notbefore = (
     't:Email:import:one-fails-another-succeeds' => '3.8',
 );
 
+# Tests which JMAP-TestSuite will skip anyway when it detects it's
+# talking to Cyrus.
+my %notcyrus = map { $_ => 1 } (
+    't:Mailbox:get:no-existing-entities',
+    't:Mailbox:query:no-existing-entities',
+);
+
 sub cyrus_version_supports_jmap
 {
     my ($maj, $min) = Cassandane::Instance->get_version();
@@ -186,6 +193,7 @@ sub find_tests
             return unless -f "$file.t";
             $file =~ s/^$basedir\/?//;
             $file =~ s{/}{:}g;
+            return if $notcyrus{$file};
             return if $suppressed{$file};
             if (exists $notbefore{$file} and skip_before($notbefore{$file})) {
                 return;

--- a/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
@@ -69,6 +69,13 @@ my %notbefore = (
     't:Email:import:one-fails-another-succeeds' => '3.8',
 );
 
+# Tests which JMAPTestSuite will skip anyway when it detects it's
+# talking to Cyrus.
+my %notcyrus = map { $_ => 1 } (
+    't:Mailbox:get:no-existing-entities',
+    't:Mailbox:query:no-existing-entities',
+);
+
 sub cyrus_version_supports_jmap
 {
     my ($maj, $min) = Cassandane::Instance->get_version();
@@ -192,6 +199,7 @@ sub find_tests
             return unless -f "$file.t";
             $file =~ s/^$basedir\/?//;
             $file =~ s{/}{:}g;
+            return if $notcyrus{$file};
             return if $suppressed{$file};
             if (exists $notbefore{$file} and skip_before($notbefore{$file})) {
                 return;


### PR DESCRIPTION
There's a few tests that JMAP-TestSuite skips when it detects the backend is Cyrus, but Cassandane still has to set up and then tear down a Cyrus instance for these tests because it doesn't know they'll be skipped.

This PR gives knowledge of that to Cassandane, so it too can skip them.