### PR TITLE
add xzrealloc

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -13027,12 +13027,11 @@ static int getsortcriteria(char *tag, struct sortcrit **sortcrit)
     for (;;) {
         if (n >= nsort - 1) {   /* leave room for implicit criterion */
             /* (Re)allocate an array for sort criteria */
-            nsort += SORTGROWSIZE;
-            *sortcrit =
-                (struct sortcrit *) xrealloc(*sortcrit,
-                                             nsort * sizeof(struct sortcrit));
-            /* Zero out the newly added sortcrit */
-            memset((*sortcrit)+n, 0, SORTGROWSIZE * sizeof(struct sortcrit));
+            int new_size = nsort + SORTGROWSIZE;
+            *sortcrit = xzrealloc(*sortcrit,
+                                  nsort * sizeof(struct sortcrit),
+                                  new_size * sizeof(struct sortcrit));
+            nsort = new_size;
         }
 
         lcase(criteria.s);

--- a/imap/message.c
+++ b/imap/message.c
@@ -3134,10 +3134,9 @@ static int message_read_body(struct protstream *strm, struct body *body, const c
 
         body->type = xstrdup("MULTIPART");
         do {
-            body->subpart =
-                (struct body *)xrealloc((char *)body->subpart,
-                                        (body->numparts+1)*sizeof(struct body));
-            memset(&body->subpart[body->numparts], 0, sizeof(struct body));
+            body->subpart = xzrealloc(body->subpart,
+                                      body->numparts * sizeof(struct body),
+                                      (body->numparts + 1) * sizeof(struct body));
             buf_reset(&buf);
             if (part_id) buf_printf(&buf, "%s.", part_id);
             buf_printf(&buf, "%d", body->numparts + 1);

--- a/imap/partlist.c
+++ b/imap/partlist.c
@@ -467,8 +467,9 @@ static void partlist_fill(const char *key, const char *value, void *rock)
         }
     }
 
-    part_list->items = (partitem_t *)xrealloc(part_list->items, (part_list->size+1) * sizeof(partitem_t));
-    memset(&part_list->items[part_list->size], 0, sizeof(partitem_t));
+    part_list->items = xzrealloc(part_list->items,
+                                 part_list->size * sizeof(partitem_t),
+                                 (part_list->size + 1) * sizeof(partitem_t));
     part_list->items[part_list->size].item = xstrdup(key + key_prefix_len);
     part_list->items[part_list->size].value = xstrdup(value);
     /* item usage data will be filled later */

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -343,10 +343,11 @@ static int fixquota_addroot(struct quota *q, void *rock)
 
     if (quota_num == quota_alloc) {
         /* Create new qr list entry */
-        quota_alloc += QUOTAGROW;
-        quotaroots = (struct quotaentry *)
-            xrealloc((char *)quotaroots, quota_alloc * sizeof(struct quotaentry));
-        memset(&quotaroots[quota_num], 0, QUOTAGROW * sizeof(struct quotaentry));
+        int new_alloc = quota_alloc + QUOTAGROW;
+        quotaroots = xzrealloc(quotaroots,
+                               quota_alloc * sizeof(struct quotaentry),
+                               new_alloc * sizeof(struct quotaentry));
+        quota_alloc = new_alloc;
     }
 
     quotaroots[quota_num].name = xstrdup(q->root);

--- a/imap/squat_build.c
+++ b/imap/squat_build.c
@@ -362,10 +362,11 @@ static void doc_ID_map_add(struct doc_ID_map *doc_ID_map, int exists)
     assert(doc_ID_map->max < doc_ID_map->alloc);
 
     if (doc_ID_map->max == doc_ID_map->alloc - 1) {
-        doc_ID_map->alloc *= 2;
-        doc_ID_map->map =
-            xrealloc(doc_ID_map->map, doc_ID_map->alloc * sizeof(int));
-        /* XXX maybe zero out the new bytes? */
+        int new_alloc = doc_ID_map->alloc * 2;
+        doc_ID_map->map = xzrealloc(doc_ID_map->map,
+                                    doc_ID_map->alloc * sizeof(int),
+                                    new_alloc * sizeof(int));
+        doc_ID_map->alloc = new_alloc;
     }
 
     if (exists) {
@@ -591,10 +592,11 @@ int squat_index_open_document(SquatIndex *index, char const *name)
 
     /* Grow the document ID array as necessary */
     if (index->current_doc_ID >= index->doc_ID_list_size) {
-        index->doc_ID_list_size *= 2;
-        index->doc_ID_list =
-            (char *)xrealloc(index->doc_ID_list,
-                             index->doc_ID_list_size * sizeof(SquatInt32));
+        int new_size = index->doc_ID_list_size * 2;
+        index->doc_ID_list = xzrealloc(index->doc_ID_list,
+                                       index->doc_ID_list_size * sizeof(SquatInt32),
+                                       new_size * sizeof(SquatInt32));
+        index->doc_ID_list_size = new_size;
     }
 
     /* Store the offset of the new document record into the array */

--- a/lib/arrayu64.c
+++ b/lib/arrayu64.c
@@ -91,8 +91,9 @@ static void ensure_alloc(arrayu64_t *au, size_t newalloc)
     if (newalloc <= au->alloc)
         return;
     newalloc = grow(au->alloc, newalloc);
-    au->data = xrealloc(au->data, sizeof(uint64_t) * newalloc);
-    memset(au->data + au->alloc, 0, sizeof(uint64_t) * (newalloc - au->alloc));
+    au->data = xzrealloc(au->data,
+                         sizeof(uint64_t) * au->alloc,
+                         sizeof(uint64_t) * newalloc);
     au->alloc = newalloc;
 }
 

--- a/lib/bitvector.c
+++ b/lib/bitvector.c
@@ -83,8 +83,7 @@ static void bv_ensure(bitvector_t *bv, unsigned int len)
             bv->bits.alloced = alloced;
         }
         else {
-            bv->bits.alloced = xrealloc(bv->bits.alloced, newalloc);
-            memset(bv->bits.alloced + bv->alloc, 0, newalloc - bv->alloc);
+            bv->bits.alloced = xzrealloc(bv->bits.alloced, bv->alloc, newalloc);
         }
         bv->alloc = newalloc;
     }

--- a/lib/bufarray.c
+++ b/lib/bufarray.c
@@ -97,8 +97,9 @@ static void ba_ensure_alloc(bufarray_t *ba, size_t newalloc)
     if (newalloc < ba->alloc)
         return;
     newalloc = grow(ba->alloc, newalloc + 1);
-    ba->items = xrealloc(ba->items, sizeof(struct buf) * newalloc);
-    memset(ba->items + ba->alloc, 0, sizeof(struct buf) * (newalloc - ba->alloc));
+    ba->items = xzrealloc(ba->items,
+                          sizeof(struct buf) * ba->alloc,
+                          sizeof(struct buf) * newalloc);
     ba->alloc = newalloc;
 }
 

--- a/lib/dynarray.c
+++ b/lib/dynarray.c
@@ -98,8 +98,9 @@ static void ensure_alloc(struct dynarray *da, int newalloc)
     if (newalloc < da->alloc)
         return;
     newalloc = grow(da->alloc, newalloc + 1);
-    da->data = xrealloc(da->data, da->membsize * newalloc);
-    memset(da->data + da->alloc * da->membsize, 0, da->membsize * (newalloc-da->alloc));
+    da->data = xzrealloc(da->data,
+                         da->membsize * da->alloc,
+                         da->membsize * newalloc);
     da->alloc = newalloc;
 }
 

--- a/lib/ptrarray.c
+++ b/lib/ptrarray.c
@@ -92,8 +92,9 @@ static void ensure_alloc(ptrarray_t *pa, int newalloc)
     if (newalloc < pa->alloc)
         return;
     newalloc = grow(pa->alloc, newalloc + 1);
-    pa->data = xrealloc(pa->data, sizeof(void *) * newalloc);
-    memset(pa->data+pa->alloc, 0, sizeof(void *) * (newalloc-pa->alloc));
+    pa->data = xzrealloc(pa->data,
+                         sizeof(void *) * pa->alloc,
+                         sizeof(void *) * newalloc);
     pa->alloc = newalloc;
 }
 

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -96,8 +96,9 @@ static void ensure_alloc(strarray_t *sa, int newalloc)
     if (newalloc < sa->alloc)
         return;
     newalloc = grow(sa->alloc, newalloc + 1);
-    sa->data = xrealloc(sa->data, sizeof(char *) * newalloc);
-    memset(sa->data + sa->alloc, 0, sizeof(char *) * (newalloc - sa->alloc));
+    sa->data = xzrealloc(sa->data,
+                         sizeof(char *) * sa->alloc,
+                         sizeof(char *) * newalloc);
     sa->alloc = newalloc;
 }
 

--- a/lib/xmalloc.c
+++ b/lib/xmalloc.c
@@ -75,8 +75,7 @@ EXPORTED void *xrealloc(void *ptr, size_t size)
 {
     void *ret;
 
-    /* xrealloc (NULL, size) behaves like xmalloc (size), as in ANSI C */
-    ret = (!ptr ? malloc(size) : realloc(ptr, size));
+    ret = realloc(ptr, size);
     if (ret != NULL) return ret;
 
     fatal("Virtual memory exhausted", EX_TEMPFAIL);

--- a/lib/xmalloc.c
+++ b/lib/xmalloc.c
@@ -48,7 +48,7 @@
 #include "xmalloc.h"
 
 
-EXPORTED void* xmalloc(size_t size)
+EXPORTED void *xmalloc(size_t size)
 {
     void *ret;
 
@@ -59,7 +59,7 @@ EXPORTED void* xmalloc(size_t size)
     return 0; /*NOTREACHED*/
 }
 
-EXPORTED void* xzmalloc(size_t size)
+EXPORTED void *xzmalloc(size_t size)
 {
     void *ret = xmalloc(size);
     memset(ret, 0, size);
@@ -71,12 +71,12 @@ EXPORTED void *xcalloc(size_t nmemb, size_t size)
     return xzmalloc(nmemb * size);
 }
 
-EXPORTED void *xrealloc (void* ptr, size_t size)
+EXPORTED void *xrealloc(void *ptr, size_t size)
 {
     void *ret;
 
     /* xrealloc (NULL, size) behaves like xmalloc (size), as in ANSI C */
-    ret = (!ptr ? malloc (size) : realloc (ptr, size));
+    ret = (!ptr ? malloc(size) : realloc(ptr, size));
     if (ret != NULL) return ret;
 
     fatal("Virtual memory exhausted", EX_TEMPFAIL);

--- a/lib/xmalloc.c
+++ b/lib/xmalloc.c
@@ -82,6 +82,16 @@ EXPORTED void *xrealloc(void *ptr, size_t size)
     return 0; /*NOTREACHED*/
 }
 
+EXPORTED void *xzrealloc(void *ptr, size_t orig_size, size_t new_size)
+{
+    void *ret = xrealloc(ptr, new_size);
+
+    if (orig_size < new_size)
+        memset(ret + orig_size, 0, new_size - orig_size);
+
+    return ret;
+}
+
 EXPORTED char *xstrdup(const char* str)
 {
     char *p = xmalloc(strlen(str)+1);

--- a/lib/xmalloc.h
+++ b/lib/xmalloc.h
@@ -52,6 +52,7 @@ extern void *xmalloc(size_t size);
 extern void *xzmalloc(size_t size);
 extern void *xcalloc(size_t nmemb, size_t size);
 extern void *xrealloc(void *ptr, size_t size);
+extern void *xzrealloc(void *ptr, size_t orig_size, size_t new_size);
 extern char *xstrdup(const char *str);
 extern char *xstrdupnull(const char *str);
 extern char *xstrdupsafe(const char *str);

--- a/lib/xmalloc.h
+++ b/lib/xmalloc.h
@@ -48,15 +48,15 @@
 /* for free() */
 #include <stdlib.h>
 
-extern void *xmalloc (size_t size);
-extern void *xzmalloc (size_t size);
-extern void *xcalloc (size_t nmemb, size_t size);
-extern void *xrealloc (void *ptr, size_t size);
-extern char *xstrdup (const char *str);
-extern char *xstrdupnull (const char *str);
-extern char *xstrdupsafe (const char *str);
-extern char *xstrndup (const char *str, size_t len);
-extern void *xmemdup (const void *ptr, size_t size);
+extern void *xmalloc(size_t size);
+extern void *xzmalloc(size_t size);
+extern void *xcalloc(size_t nmemb, size_t size);
+extern void *xrealloc(void *ptr, size_t size);
+extern char *xstrdup(const char *str);
+extern char *xstrdupnull(const char *str);
+extern char *xstrdupsafe(const char *str);
+extern char *xstrndup(const char *str, size_t len);
+extern void *xmemdup(const void *ptr, size_t size);
 
 // free a pointer and also zero it
 #define xzfree(ptr) do { \


### PR DESCRIPTION
Adds an `xzrealloc()` function that's like `xrealloc()` but also zeroes out the newly allocated bytes if the allocation grew in size.  n.b. It needs one more argument than regular `xrealloc()`, so it's not a drop-in replacement.