### PR TITLE
ical_support: configure libical to omit CONTROL characters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1673,6 +1673,14 @@ dnl
                 AC_DEFINE(HAVE_GET_COMPONENT_NAME,[],
                         [Do we have support for fetching X- component names?]))
 
+        dnl Check if libical parser allows setting CONTROL char handling
+        AC_CHECK_LIB(ical, icalparser_get_ctrl,
+            [
+                AC_DEFINE(HAVE_ICALPARSER_CTRL,[], [Can we omit CONTROL characters?])
+                have_ical_ctrl=yes
+            ],
+            have_ical_ctrl=no)
+
         dnl Check for libicalvcard
         AC_CHECK_LIB(icalvcard, vcardcomponent_new, [
                  AC_DEFINE(HAVE_LIBICALVCARD,[],[Do we have the icalvcard library?])
@@ -2589,6 +2597,9 @@ Search engine:
    squat:              $enable_squat
    xapian:             $enable_xapian
    xapian_cjk_tokens:  $xapian_cjk_tokens
+
+iCalendar features:
+   ctrl:               $have_ical_ctrl
 
 Documentation dependencies:
    sphinx-build:       $SPHINX_BUILD

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -96,11 +96,13 @@ static json_t *buildinfo()
     json_t *hardware = json_object();
     json_t *buildconf = json_object();
     json_t *version = json_object();
+    json_t *ical = json_object();
 
     json_object_set_new(buildconf, "component", component);
     json_object_set_new(buildconf, "dependency", dependency);
     json_object_set_new(buildconf, "database", database);
     json_object_set_new(buildconf, "search", search);
+    json_object_set_new(buildconf, "ical", ical);
     json_object_set_new(buildconf, "hardware", hardware);
     json_object_set_new(buildconf, "version", version);
 
@@ -295,6 +297,13 @@ static json_t *buildinfo()
     json_object_set_new(search, "xapian", json_false());
 #endif
     json_object_set_new(search, "xapian_cjk_tokens", json_string(XAPIAN_CJK_TOKENS));
+
+    /* iCalendar features */
+#ifdef HAVE_ICALPARSER_CTRL
+    json_object_set_new(ical, "ctrl", json_true());
+#else
+    json_object_set_new(ical, "ctrl", json_false());
+#endif
 
     /* Internal version numbers */
 #ifdef USE_SIEVE

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -102,6 +102,10 @@ EXPORTED void ical_support_init(void)
               EX_CONFIG);
     }
 
+#ifdef HAVE_ICALPARSER_CTRL
+    icalparser_set_ctrl(ICALPARSER_CTRL_OMIT);
+#endif
+
     syslog(LOG_DEBUG, "%s: found " SIZE_T_FMT " timezones",
                        __func__, timezones->num_elements);
 


### PR DESCRIPTION
This changes the libical parser to silently discard invalid CONTROL characters from iCalendar data. Before, it silently accepted such invalid bytes and Cyrus then served invalid data to CalDAV clients.

This requires https://github.com/libical/libical/pull/651