### PR TITLE
cassandane needs XML::Simple

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
       run: |
         cpanm IO::File::fcntl
         cpanm Digest::CRC
+        cpanm XML::Simple # XXX could be grabbed from apt by docker image
     - name: set up cassandane
       working-directory: cassandane
       shell: bash

--- a/cassandane/doc/README.deps
+++ b/cassandane/doc/README.deps
@@ -142,6 +142,7 @@ Cassandane needs the following software to work:
  * DateTime::Format::ISO8601
  * String::CRC32
  * XML::DOM
+ * XML::Simple
     These are available from CPAN
 
 Debian/Ubuntu copypasta:
@@ -159,7 +160,7 @@ Debian/Ubuntu copypasta:
        libdatetime-format-ical-perl libuniversal-require-perl \
        libtest-nowarnings-perl libtest-longstring-perl \
        libtest-warn-perl libnet-ldap-server-perl \
-       libdbd-sqlite3-perl libdigest-crc-perl
+       libdbd-sqlite3-perl libdigest-crc-perl libxml-simple-perl
 
   sudo cpan Math::Int64 Mail::JMAPTalk Mail::IMAPTalk \
        Net::CalDAVTalk Net::CardDAVTalk String::CRC32


### PR DESCRIPTION
Quick fix to get CI working again.  The better fix would be to have the docker image pull libxml-simple-perl from apt.