### PR TITLE
mailbox_update_webdav: don't create resource names if no filename

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -3875,7 +3875,7 @@ static int mailbox_update_webdav(struct mailbox *mailbox,
         }
     }
     if (!buf_len(&resource))
-        buf_setcstr(&resource, makeuuid());
+	buf_printf(&resource, "imapuid-%u", new->uid);
 
     webdavdb = mailbox_open_webdav(mailbox);
 


### PR DESCRIPTION
This fixes a `#jmap` folder bug when we are zeroing CIDs.