### PR TITLE
jmap_calendar: fix bug erasing default alerts on update

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar-set-defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar-set-defaultalerts
@@ -88,7 +88,6 @@ sub test_calendar_set_defaultalerts
                 $calendarId => {
                     "defaultAlertsWithTime/$alert1Id" => undef,
                     "defaultAlertsWithTime/$alert4Id" => $alert4,
-                    "defaultAlertsWithoutTime/$alert3Id/trigger/offset" => '-PT5M',
                 }
             }
         }, 'R1'],
@@ -98,17 +97,57 @@ sub test_calendar_set_defaultalerts
         }, 'R2']
                               ]);
     $self->assert(exists $res->[0][1]{updated}{$calendarId});
-    $self->assert_null($res->[1][1]{list}[0]{defaultAlertsWithTime}{$alert1Id});
-    $self->assert_deep_equals($alert4,
-        $res->[1][1]{list}[0]{defaultAlertsWithTime}{$alert4Id});
-    $self->assert_equals('-PT5M',
-                         $res->[1][1]{list}[0]{defaultAlertsWithoutTime}{$alert3Id}{trigger}{offset});
+
+    delete $defaultAlertsWithTime->{$alert1Id};
+    $defaultAlertsWithTime->{$alert4Id} = $alert4;
+    $self->assert_deep_equals($defaultAlertsWithTime,
+        $res->[1][1]{list}[0]{defaultAlertsWithTime});
+    $self->assert_deep_equals($defaultAlertsWithoutTime,
+        $res->[1][1]{list}[0]{defaultAlertsWithoutTime});
+
+    $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            update => {
+                $calendarId => {
+                    "defaultAlertsWithoutTime/$alert3Id/trigger/offset" => '-PT5M',
+                }
+            }
+        }, 'R1'],
+        ['Calendar/get', {
+            ids => [$calendarId],
+            properties => ['defaultAlertsWithTime', 'defaultAlertsWithoutTime'],
+        }, 'R2']
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$calendarId});
+
+    $defaultAlertsWithoutTime->{$alert3Id}{trigger}{offset} = '-PT5M';
+    $self->assert_deep_equals($defaultAlertsWithTime,
+        $res->[1][1]{list}[0]{defaultAlertsWithTime});
+    $self->assert_deep_equals($defaultAlertsWithoutTime,
+        $res->[1][1]{list}[0]{defaultAlertsWithoutTime});
 
     $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
                 $calendarId => {
                     defaultAlertsWithTime => undef,
+                }
+            }
+        }, 'R1'],
+        ['Calendar/get', {
+            ids => [$calendarId],
+            properties => ['defaultAlertsWithTime', 'defaultAlertsWithoutTime'],
+        }, 'R2']
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$calendarId});
+    $self->assert_null($res->[1][1]{list}[0]{defaultAlertsWithTime});
+    $self->assert_deep_equals($defaultAlertsWithoutTime,
+        $res->[1][1]{list}[0]{defaultAlertsWithoutTime});
+
+    $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            update => {
+                $calendarId => {
                     defaultAlertsWithoutTime => undef,
                 }
             }


### PR DESCRIPTION
This fixes a bug where updating just one of the Calendar defaultAlertsWithTime and defaultAlertsWithoutTime properties resulted in erasing the contents of the other.