### PR TITLE
<libgen.h> is required for basename(3)

### DIFF
--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -54,6 +54,7 @@
 #include <syslog.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <libgen.h>
 
 #include "dav_db.h"
 #include "global.h"


### PR DESCRIPTION
From missing a header,  `basename()` may be recognized as return type `int`. 