### PR TITLE
master ready file

### DIFF
--- a/changes/next/master-ready-file
+++ b/changes/next/master-ready-file
@@ -1,0 +1,20 @@
+Description:
+
+master(8) now touches a ready file to indicate it is "ready for work"
+
+
+Config changes:
+
+* master_ready_file
+
+
+Upgrade instructions:
+
+If you have something that monitors syslog looking for master's
+"ready for work" message, you might consider switching to monitoring
+the master.ready file instead, perhaps using Linux inotify.
+
+
+GitHub issue:
+
+N/A

--- a/changes/next/master-ready-file
+++ b/changes/next/master-ready-file
@@ -1,10 +1,12 @@
 Description:
 
 master(8) now touches a ready file to indicate it is "ready for work"
+master(8) now gets its pidfile name from master_pid_file imapd.conf option
 
 
 Config changes:
 
+* master_pid_file
 * master_ready_file
 
 
@@ -14,6 +16,12 @@ If you have something that monitors syslog looking for master's
 "ready for work" message, you might consider switching to monitoring
 the master.ready file instead, perhaps using Linux inotify.
 
+The master pidfile name is now read from imapd.conf, and defaults
+to ``{configdirectory}/master.pid``.  If you have something that
+looks for this file, you should either update it to look in the new
+default location, or set ``master_pid_file`` in :cyrusman:`imapd.conf(5)`
+to override the default.  The ``-p`` option to :cyrusman:`master(8)`
+can still be used to override it.
 
 GitHub issue:
 

--- a/configure.ac
+++ b/configure.ac
@@ -1550,16 +1550,6 @@ AC_SUBST([GUESSTZ_CFLAGS])
 AM_CONDITIONAL([HAVE_GUESSTZ], [test "x$with_guesstz" = xyes])
 
 dnl
-dnl Set pidfile location
-dnl
-AC_ARG_WITH(pidfile,
-        [AS_HELP_STRING([--with-pidfile=DIR], [pidfile in DIR [/var/run/cyrus-master.pid]])],
-        [MASTERPIDFILE="$withval"],
-        [MASTERPIDFILE="/var/run/cyrus-master.pid"])
-MASTERPIDFILE="\"$MASTERPIDFILE\""
-AC_DEFINE_UNQUOTED(MASTER_PIDFILE, $MASTERPIDFILE,[Name of the pidfile for master])
-
-dnl
 dnl see if we're compiling with autocreate support
 dnl
 AC_ARG_ENABLE(autocreate,

--- a/docsrc/imap/reference/manpages/systemcommands/master.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/master.rst
@@ -64,7 +64,8 @@ Options
 .. option:: -p  pidfile
 
     Use *pidfile* as the pidfile.  If not specified, defaults to
-    ``/var/run/master.pid``
+    ``master_pid_file`` from :cyrusman:`imapd.conf(5)`, which
+    defaults to ``{configdirectory}/master.pid``
 
 .. option:: -r  ready_file
 

--- a/docsrc/imap/reference/manpages/systemcommands/master.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/master.rst
@@ -16,7 +16,7 @@ Synopsis
 .. parsed-literal::
 
     **master** [ **-C** *config-file* ] [ **-M** *alternate cyrus.conf* ]
-        [ **-l** *listen queue* ] [ **-p** *pidfile* ]
+        [ **-l** *listen queue* ] [ **-p** *pidfile* ] [ **-r** *ready_file* ]
         [ **-j** *janitor period* ] [ **-d** | **-D** ] [ **-L** *logfile* ]
 
 Description
@@ -65,6 +65,12 @@ Options
 
     Use *pidfile* as the pidfile.  If not specified, defaults to
     ``/var/run/master.pid``
+
+.. option:: -r  ready_file
+
+    Use *ready_file* as the ready file.  If not specified, uses
+    ``master_ready_file`` from :cyrusman:`imapd.conf(5)`, which
+    defaults to ``{configdirectory}/master.ready``
 
 .. option:: -d
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1701,6 +1701,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    come up in response to a reconfig+SIGHUP will just be logged and disabled
    like the default behaviour, without causing master to exit. */
 
+{ "master_ready_file", "{configdirectory}/master.ready", STRING, "UNRELEASED" }
+/* The path to a file that master(8) will update to indicate that it is
+   ready to accept client connections.  This file will be created if it does
+   not already exist, or truncated if it does.  */
+
 { "maxheaderlines", 1000, INT, "2.3.17" }
 /* Maximum number of lines of header that will be processed into cache
    records.  Default 1000.  If set to zero, it is unlimited.

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1701,6 +1701,10 @@ Blank lines and lines beginning with ``#'' are ignored.
    come up in response to a reconfig+SIGHUP will just be logged and disabled
    like the default behaviour, without causing master to exit. */
 
+{ "master_pid_file", "{configdirectory}/master.pid", STRING, "UNRELEASED" }
+/* The path to a file that master(8) will write its PID to when running
+   as a daemon. */
+
 { "master_ready_file", "{configdirectory}/master.ready", STRING, "UNRELEASED" }
 /* The path to a file that master(8) will update to indicate that it is
    ready to accept client connections.  This file will be created if it does

--- a/master/master.c
+++ b/master/master.c
@@ -2888,6 +2888,7 @@ int main(int argc, char **argv)
 
     const char *pidfile = MASTER_PIDFILE;
     char *pidfile_lock = NULL;
+    const char *ready_file = NULL;
 
     int startup_pipe[2] = { -1, -1 };
     int pidlock_fd = -1;
@@ -2907,7 +2908,7 @@ int main(int argc, char **argv)
 
     p = getenv("CYRUS_VERBOSE");
     if (p) verbose = atoi(p) + 1;
-    while ((opt = getopt(argc, argv, "C:L:M:p:l:Ddj:vV")) != EOF) {
+    while ((opt = getopt(argc, argv, "C:L:M:p:r:l:Ddj:vV")) != EOF) {
         switch (opt) {
         case 'C': /* alt imapd.conf file */
             alt_config = optarg;
@@ -2922,6 +2923,10 @@ int main(int argc, char **argv)
         case 'p':
             /* Set the pidfile name */
             pidfile = optarg;
+            break;
+        case 'r':
+            /* Set the ready file name */
+            ready_file = optarg;
             break;
         case 'd':
             /* Daemon Mode */
@@ -3196,7 +3201,7 @@ int main(int argc, char **argv)
     }
 
     /* ok, we're going to start spawning like mad now */
-    master_ready(NULL); /* ready for work */
+    master_ready(ready_file); /* ready for work */
 
     for (;;) {
         int i, maxfd, ready_fds, total_children = 0;

--- a/master/master.c
+++ b/master/master.c
@@ -2886,7 +2886,7 @@ int main(int argc, char **argv)
 {
     static const char lock_suffix[] = ".lock";
 
-    const char *pidfile = MASTER_PIDFILE;
+    const char *pidfile = NULL;
     char *pidfile_lock = NULL;
     const char *ready_file = NULL;
 
@@ -2982,6 +2982,9 @@ int main(int argc, char **argv)
                 fatalf(2, "couldn't open %s: %m", file);
         }
     }
+
+    if (!pidfile) pidfile = config_getstring(IMAPOPT_MASTER_PID_FILE);
+    if (!pidfile) fatal("couldn't determine pidfile name", EX_CONFIG);
 
     /* Pidfile Algorithm in Daemon Mode.  This is a little subtle because
      * we want to ensure that we can report an error to our parent if the

--- a/master/master.c
+++ b/master/master.c
@@ -530,7 +530,7 @@ static void service_create(struct service *s, int is_startup)
         res0 = (struct addrinfo *)xzmalloc(sizeof(struct addrinfo));
         res0->ai_flags = AI_PASSIVE;
         res0->ai_family = PF_UNIX;
-        if(!strcmp(s->proto, "tcp")) {
+        if (!strcmp(s->proto, "tcp")) {
             res0->ai_socktype = SOCK_STREAM;
         } else {
             /* udp */
@@ -725,7 +725,7 @@ static void service_create(struct service *s, int is_startup)
         nsocket++;
     }
     if (res0) {
-        if(res0_is_local)
+        if (res0_is_local)
             free(res0);
         else
             freeaddrinfo(res0);
@@ -1274,7 +1274,7 @@ static void spawn_schedule(struct timeval now)
     while (a && a != schedule) {
         /* if a->exec is NULL, we just used the event to wake up,
          * so we actually don't need to exec anything at the moment */
-        if(a->exec) {
+        if (a->exec) {
             get_executable(path, sizeof(path), a->exec);
             switch (p = fork()) {
             case -1:
@@ -1328,7 +1328,7 @@ static void spawn_schedule(struct timeval now)
         /* reschedule as needed */
         b = a->next;
         if (a->period) {
-            if(a->periodic) {
+            if (a->periodic) {
                 a->mark = now;
                 a->mark.tv_sec += a->period;
             } else {
@@ -2238,8 +2238,8 @@ static void add_service(const char *name, struct entry *e, void *rock)
     int reconfig = 0;
     int i, j;
 
-    if(babysit && prefork == 0) prefork = 1;
-    if(babysit && maxforkrate == 0) maxforkrate = 10; /* reasonable safety */
+    if (babysit && prefork == 0) prefork = 1;
+    if (babysit && maxforkrate == 0) maxforkrate = 10; /* reasonable safety */
 
     if (!strcmp(cmd,"") || !strcmp(listen,"")) {
         char buf[256];
@@ -2943,7 +2943,7 @@ int main(int argc, char **argv)
         case 'j':
             /* Janitor frequency */
             janitor_frequency = atoi(optarg);
-            if(janitor_frequency < 1)
+            if (janitor_frequency < 1)
                 fatal("The janitor period must be at least 1 second", EX_CONFIG);
             break;
         case 'v':
@@ -2998,25 +2998,25 @@ int main(int argc, char **argv)
      * [A] xunlink pidfile.lock and exit(code read from pipe)
      *
      */
-    if(daemon_mode) {
+    if (daemon_mode) {
         /* Daemonize */
         pid_t pid = -1;
 
         pidfile_lock = strconcat(pidfile, lock_suffix, (char *)NULL);
 
         pidlock_fd = open(pidfile_lock, O_CREAT|O_TRUNC|O_RDWR, 0644);
-        if(pidlock_fd == -1) {
+        if (pidlock_fd == -1) {
             syslog(LOG_ERR, "can't open pidfile lock: %s (%m)", pidfile_lock);
             exit(EX_OSERR);
         } else {
-            if(lock_nonblocking(pidlock_fd, pidfile)) {
+            if (lock_nonblocking(pidlock_fd, pidfile)) {
                 syslog(LOG_ERR, "can't get exclusive lock on %s",
                        pidfile_lock);
                 exit(EX_TEMPFAIL);
             }
         }
 
-        if(pipe(startup_pipe) == -1) {
+        if (pipe(startup_pipe) == -1) {
             syslog(LOG_ERR, "can't create startup pipe (%m)");
             exit(EX_OSERR);
         }
@@ -3047,7 +3047,7 @@ int main(int argc, char **argv)
             int exit_code;
 
             /* Parent, wait for child */
-            if(read(startup_pipe[0], &exit_code, sizeof(exit_code)) == -1) {
+            if (read(startup_pipe[0], &exit_code, sizeof(exit_code)) == -1) {
                 syslog(LOG_ERR, "could not read from startup_pipe (%m)");
                 xunlink(pidfile_lock);
                 exit(EX_OSERR);
@@ -3080,7 +3080,7 @@ int main(int argc, char **argv)
 
     /* Write out the pidfile */
     pidfd = open(pidfile, O_CREAT|O_RDWR, 0644);
-    if(pidfd == -1) {
+    if (pidfd == -1) {
         int exit_result = EX_OSERR;
 
         syslog(LOG_ERR, "can't open pidfile: %m");
@@ -3094,7 +3094,7 @@ int main(int argc, char **argv)
     } else {
         char buf[100];
 
-        if(lock_nonblocking(pidfd, pidfile)) {
+        if (lock_nonblocking(pidfd, pidfile)) {
             int exit_result = EX_OSERR;
 
             /* Tell our parent that we failed. */
@@ -3123,9 +3123,10 @@ int main(int argc, char **argv)
 
             /* Write PID */
             snprintf(buf, sizeof(buf), "%lu\n", (unsigned long int)getpid());
-            if(lseek(pidfd, 0, SEEK_SET) == -1 ||
-               ftruncate(pidfd, 0) == -1 ||
-               write(pidfd, buf, strlen(buf)) == -1) {
+            if (lseek(pidfd, 0, SEEK_SET) == -1 ||
+                ftruncate(pidfd, 0) == -1 ||
+                write(pidfd, buf, strlen(buf)) == -1)
+            {
                 int exit_result = EX_OSERR;
 
                 syslog(LOG_ERR, "unable to write to pidfile: %m");
@@ -3142,7 +3143,7 @@ int main(int argc, char **argv)
         }
     }
 
-    if(daemon_mode) {
+    if (daemon_mode) {
         int exit_result = 0;
 
         /* success! */


### PR DESCRIPTION
This makes master(8) write out a ready file at the same time as it logs its "ready for work" message.  For things that want to know when master is ready to start servicing clients, monitoring the ready file (perhaps with inotify) should be a bit cleaner than tailing syslog looking for the message.

Adds `master_ready_file` to imapd.conf, defaulting to `{configdirectory}/master.ready`.  Also adds a `-r ready_file` option to master to override the configured path.

Adds cassandane tests for the case where the ready file does not yet exist, and the case where it already exists.  No test for the `-r ready_file` option, because it would take a lot to plumb that through.