### PR TITLE
jmap_contact.c: libicalvcard will escape comma in JSCOMPS separator

### DIFF
--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -9069,8 +9069,6 @@ static vcardproperty *_jscomps_to_vcard(struct jmap_parser *parser, json_t *obj,
                 /* Add separator entry to JSCOMPS */
                 sep = val;
                 buf_setcstr(&buf, sep);
-                buf_replace_all(&buf, ";", "\\;");
-                buf_replace_all(&buf, ",", "\\,");
                 entry = vcardstrarray_new(2);
                 vcardstrarray_append(entry, "s");
                 vcardstrarray_append(entry, buf_cstring(&buf));


### PR DESCRIPTION
This is dependent on https://github.com/libical/libical/pull/584/commits/7991a1b24786cec871664e380064afba17f2098a

@rsto please review the libicalvcard change as well