### PR TITLE
search_query: fix filtering unindexed messages in squat backend

### DIFF
--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -438,4 +438,28 @@ sub test_relocate_legacy_nosearchdb
     $self->assert_equals(0, scalar @files);
 }
 
+sub test_unindexed
+    :SearchEngineSquat :min_version_3_4
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+
+    $self->make_message("needle 1", body => "needle") || die;
+    $self->make_message("xxxxxx 2", body => "xxxxxx") || die;
+
+    $self->run_squatter;
+
+    my $uids = $imap->search('fuzzy', 'body', 'needle') || die;
+    $self->assert_deep_equals([1], $uids);
+
+    $self->make_message("needle 3", body => "needle") || die;
+    $self->make_message("xxxxxx 4", body => "xxxxxx") || die;
+
+    # Do not rerun squatter. Make sure search only returns
+    # a matching unindexed message.
+
+    $uids = $imap->search('fuzzy', 'body', 'needle') || die;
+    $self->assert_deep_equals([1,3], $uids);
+}
+
 1;

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -137,6 +137,11 @@ EXPORTED void search_query_free(search_query_t *query)
 
 /* ====================================================================== */
 
+static int subquery_run_one_folder(search_query_t *query,
+                                   const char *mboxname,
+                                   search_expr_t *e);
+
+/* ---------------------------------------------------------------------- */
 
 /*
  * Find the named folder folder.  Returns NULL if there are no
@@ -485,6 +490,25 @@ static void subquery_post_enginesearch(const char *key, void *data, void *rock)
     if (query->error) return;
     if (!folder->found_dirty) return;
 
+    if (config_getenum(IMAPOPT_SEARCH_ENGINE) == IMAP_ENUM_SEARCH_ENGINE_SQUAT) {
+        /*
+         * When using the squat backend, the search expression is inside
+         * sub->indexed, while sub->expr holds a constant SEOP_TRUE.
+         * In this case let sub->expr point to sub->indexed.
+         */
+        assert(sub->expr && sub->expr->op == SEOP_TRUE);
+        search_expr_t *parent = NULL;
+        if (sub->expr->parent) {
+            parent = sub->expr->parent;
+            search_expr_detach(sub->expr->parent, sub->expr);
+        }
+        search_expr_free(sub->expr);
+        sub->expr = search_expr_duplicate(sub->indexed);
+        if (parent) {
+            search_expr_append(parent, sub->expr);
+        }
+    }
+
     if (sub->expr && query->verbose) {
         char *s = search_expr_serialise(sub->expr);
         syslog(LOG_INFO, "Folder %s: applying scan expression: %s",
@@ -724,7 +748,12 @@ static void subquery_run_indexed(const char *key __attribute__((unused)),
 
     bx = search_begin_search(query->state->mailbox, opts);
     if (!bx) {
-        r = IMAP_INTERNAL;
+        if (config_getenum(IMAPOPT_SEARCH_ENGINE) == IMAP_ENUM_SEARCH_ENGINE_SQUAT) {
+            r = subquery_run_one_folder(query, index_mboxname(query->state), sub->indexed);
+        }
+        else {
+            r = IMAP_INTERNAL;
+        }
         goto out;
     }
 


### PR DESCRIPTION
The squat backend returns false positives for unindexed messages, but filtering these messages has been broken.

This patch fixes that based on a contribution of @gbulfon. Thanks!

Fixes #4692