### PR TITLE
jmap_expire: need libgen.h for POSIX basename behaviour

### DIFF
--- a/imap/jmap_expire.c
+++ b/imap/jmap_expire.c
@@ -44,6 +44,7 @@
 
 #include <errno.h>
 #include <getopt.h>
+#include <libgen.h>
 #include <stdlib.h>
 #include <sysexits.h>
 


### PR DESCRIPTION
Full details in #4689.  tl;dr: on Linux, `basename()` behaves differently depending on whether or not libgen.h was included.  We want the POSIX behaviour, not the GNU behaviour.