### PR TITLE
fix print format for timespec and timeval

### DIFF
--- a/imap/jmap_expire.c
+++ b/imap/jmap_expire.c
@@ -134,11 +134,11 @@ static void print_lock(const char *mboxname,
 {
     struct timespec now;
     if (clock_gettime(CLOCK_MONOTONIC, &now) == 0) {
-        verbosep("%s: lock info: start=%lld.%ld until=%lld.%ld now=%lld.%ld",
+        verbosep("%s: lock info: start=" TIME_T_FMT ".%.3ld until=" TIME_T_FMT ".%03ld now=" TIME_T_FMT ".%.3ld",
                 mboxname,
-                (long long)start.tv_sec, start.tv_nsec / 1000000L,
-                (long long)until.tv_sec, until.tv_nsec / 1000000L,
-                (long long)now.tv_sec, now.tv_nsec / 1000000L);
+                start.tv_sec, start.tv_nsec / 1000000L,
+                until.tv_sec, until.tv_nsec / 1000000L,
+                now.tv_sec, now.tv_nsec / 1000000L);
     }
 }
 

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2223,8 +2223,8 @@ EXPORTED void mboxname_todeleted(const char *name, char *result, int withtime)
     if (withtime) {
         struct timeval tv;
         gettimeofday( &tv, NULL );
-        snprintf(result+domainlen, MAX_MAILBOX_BUFFER-domainlen, "%s.%s.%X",
-                 deletedprefix, name+domainlen, (unsigned) tv.tv_sec);
+        snprintf(result+domainlen, MAX_MAILBOX_BUFFER-domainlen, "%s.%s.%llX",
+                 deletedprefix, name+domainlen, (unsigned long long) tv.tv_sec);
     } else {
         snprintf(result+domainlen, MAX_MAILBOX_BUFFER-domainlen, "%s.%s",
                  deletedprefix, name+domainlen);

--- a/imap/telemetry.c
+++ b/imap/telemetry.c
@@ -72,9 +72,9 @@ EXPORTED int telemetry_log(const char *userid, struct protstream *pin,
         gettimeofday(&tv, NULL);
 
         /* use sec.clocks */
-        snprintf(buf, sizeof(buf), "%s%s%s/%s-%lu.%lu",
+        snprintf(buf, sizeof(buf), "%s%s%s/%s-" TIME_T_FMT ".%.6lu",
                  config_dir, FNAME_LOGDIR, userid, config_ident,
-                 (unsigned long)tv.tv_sec, (unsigned long)tv.tv_usec);
+                 tv.tv_sec, (unsigned long)tv.tv_usec);
     }
     else if (config_getswitch(IMAPOPT_TELEMETRY_BYSESSIONID)) {
         const char *sid = session_id();
@@ -136,9 +136,9 @@ EXPORTED void telemetry_rusage(char *userid)
          * Some systems provide significantly more data, but POSIX
          * guarantees user & sys CPU time.
          */
-        syslog(LOG_NOTICE, "USAGE %s user: %lu.%.6d sys: %lu.%.6d", userid,
-               (unsigned long)user.tv_sec, (int)user.tv_usec,
-               (unsigned long)sys.tv_sec, (int)sys.tv_usec);
+        syslog(LOG_NOTICE, "USAGE %s user: " TIME_T_FMT ".%.6d sys: " TIME_T_FMT ".%.6d", userid,
+               user.tv_sec, (int)user.tv_usec,
+               sys.tv_sec, (int)sys.tv_usec);
 
         previous = current;
     }

--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -255,8 +255,8 @@ static int ptsmodule_connect(void)
 
         rc = ldap_set_option(ptsm->ld, LDAP_OPT_NETWORK_TIMEOUT, &(ptsm->timeout));
         if (rc != LDAP_OPT_SUCCESS) {
-                syslog(LOG_WARNING, "Unable to set LDAP_OPT_NETWORK_TIMEOUT %ld.%06d.",
-                       (long)ptsm->timeout.tv_sec, (int)ptsm->timeout.tv_usec);
+                syslog(LOG_WARNING, "Unable to set LDAP_OPT_NETWORK_TIMEOUT " TIME_T_FMT ".%06d.",
+                       ptsm->timeout.tv_sec, (int)ptsm->timeout.tv_usec);
         }
 
         rc = ldap_set_option(ptsm->ld, LDAP_OPT_SIZELIMIT, &(ptsm->size_limit));


### PR DESCRIPTION
Change to use `TIME_T_FMT` for `tv_sec` (time_t), and fix to zero prefix for `tv_nsec` and `tv_usec`.
Use `unsigned long long` for HEX format of `time_t`, `int` may be short.