### PR TITLE
search_engines: fix batching

### DIFF
--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -418,6 +418,7 @@ static void build_batch(search_text_receiver_t *rx,
             syslog(LOG_INFO, "search_update_mailbox batching %u messages to %s",
                     batch->count, mailbox_name(mailbox));
             *is_incomplete = 1;
+            break;
         }
 
         message_t *msg = message_new_from_record(mailbox, record);


### PR DESCRIPTION
This was lost in ba7fc3ab14f0a843df3f95ec1249115fa7744c54 when refactoring to allow better lock handling.