### PR TITLE
Convdb zero singlecid

### DIFF
--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -407,9 +407,12 @@ sub test_reconstruct_splitconv
     my ($maj, $min) = Cassandane::Instance->get_version();
     return if ($maj < 3 or ($maj == 3 and $min < 8));
 
-    # zero out ONLY one CID
-    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-Z' => $exp{"A15"}->make_cid(), 'cassandane');
-    for (15..19) {
+    # zero out ONLY two CIDs
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb',
+                                    '-Z' => $exp{"A15"}->make_cid(),
+                                    '-Z' => $exp{"A10"}->make_cid(),
+                                    'cassandane');
+    for (10..19) {
       $exp{"A$_"}->set_attributes(cid => undef, basecid => undef);
     }
 

--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -401,7 +401,22 @@ sub test_reconstruct_splitconv
     $self->check_messages(\%exp, keyed_on => 'uid');
     $talk->select("foo");
     $self->check_messages(\%exp, keyed_on => 'uid');
-    #$talk->select("INBOX");
+    $talk->select("INBOX");
+
+    # support for -Z was added after 3.8
+    my ($maj, $min) = Cassandane::Instance->get_version();
+    return if ($maj < 3 or ($maj == 3 and $min < 8));
+
+    # zero out ONLY one CID
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-Z' => $exp{"A15"}->make_cid(), 'cassandane');
+    for (15..19) {
+      $exp{"A$_"}->set_attributes(cid => undef, basecid => undef);
+    }
+
+    $self->check_messages(\%exp, keyed_on => 'uid');
+    $talk->select("foo");
+    $self->check_messages(\%exp, keyed_on => 'uid');
+    $talk->select("INBOX");
 }
 
 #

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
@@ -83,6 +83,13 @@ Options
     information can all be recalculated (eventually) from message
     headers, using the **-b** option.
 
+.. option:: -Z, --clearcid
+
+    Remove all conversation information from the conversations database
+    for user *userid*, and from all the user's mailboxes for conversations
+    matching one CID only.  The information can all be recalculated
+    (eventually) from message headers, using the **-b** option.
+
 .. option:: -b, --rebuild
 
     Rebuild all conversation information in the conversations database

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
@@ -83,12 +83,15 @@ Options
     information can all be recalculated (eventually) from message
     headers, using the **-b** option.
 
-.. option:: -Z, --clearcid
+.. option:: -Z, --clearcids cid,...
 
     Remove all conversation information from the conversations database
     for user *userid*, and from all the user's mailboxes for conversations
-    matching one CID only.  The information can all be recalculated
-    (eventually) from message headers, using the **-b** option.
+    matching the comma separated list of cids in hex format.  Can be
+    specified more than once.
+
+    The information can all be recalculated (eventually) from message
+    headers, using the **-b** option.
 
 .. option:: -b, --rebuild
 

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -196,14 +196,12 @@ static int delannot_cb(const char *mboxname,
 	remove = 0;
 
         // is the value this CID, remove this
-        if (value->len == 16) {
-            cid = strtoull(value->s, 0, 16);
-            if (zerocid == cid) remove = 1;
-        }
+        parsehex(value->s, NULL, 16, &cid);
+        if (zerocid == cid) remove = 1;
 
         // is the key this CID, remove this, 
-        if (conversation_id_decode(&cid, entry + strlen(IMAP_ANNOT_NS) + strlen("newcid/")))
-            if (zerocid == cid) remove = 1;
+	parsehex(entry + strlen(IMAP_ANNOT_NS) + 7, NULL, 16, &cid);
+        if (zerocid == cid) remove = 1;
     }
     if (!remove) return 0;
     return annotatemore_write(mboxname, entry, userid, (const struct buf *)rock);

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -79,7 +79,7 @@ int mode = UNKNOWN;
 static const char *audit_temp_directory;
 
 int recalc_silent = 1;
-conversation_id_t zerocid = 0;
+hashu64_table *zerocids = NULL;
 
 static int do_dump(const char *fname, const char *userid)
 {
@@ -165,8 +165,9 @@ static int zero_cid_cb(const mbentry_t *mbentry,
         /* already zero, fine */
         if (record->cid == NULLCONVERSATION)
             continue;
-        /* if we're just doing one cid, only do this one */
-        if (zerocid && record->cid != zerocid)
+
+        /* if we're only doing some cids, check if this is one */
+        if (zerocids && !hashu64_lookup(record->cid, zerocids))
             continue;
 
         struct index_record oldrecord = *record;
@@ -190,20 +191,17 @@ static int delannot_cb(const char *mboxname,
                        const struct annotate_metadata *mdata __attribute__((unused)),
                        void *rock)
 {
-    int remove = 1;
-    if (zerocid) {
-        conversation_id_t cid = NULLCONVERSATION;
-	remove = 0;
+    if (zerocids) {
+        conversation_id_t keycid = NULLCONVERSATION;
+        conversation_id_t valuecid = NULLCONVERSATION;
 
-        // is the value this CID, remove this
-        parsehex(value->s, NULL, 16, &cid);
-        if (zerocid == cid) remove = 1;
+        parsehex(entry + strlen(IMAP_ANNOT_NS) + 7, NULL, 16, &keycid);
+        parsehex(value->s, NULL, 16, &valuecid);
 
-        // is the key this CID, remove this, 
-	parsehex(entry + strlen(IMAP_ANNOT_NS) + 7, NULL, 16, &cid);
-        if (zerocid == cid) remove = 1;
+        // if neither are being zeroed, leave them
+        if (!hashu64_lookup(keycid, zerocids) && !hashu64_lookup(valuecid, zerocids))
+            return 0;
     }
-    if (!remove) return 0;
     return annotatemore_write(mboxname, entry, userid, (const struct buf *)rock);
 }
 
@@ -921,8 +919,20 @@ int main(int argc, char **argv)
             if (mode != UNKNOWN)
                 usage(argv[0]);
             mode = ZERO;
-            if (!conversation_id_decode(&zerocid, optarg))
-                usage(argv[0]);
+            if (!zerocids) {
+                zerocids = xzmalloc(sizeof(hashu64_table));
+                construct_hashu64_table(zerocids, 256, 0);
+            }
+            strarray_t *ids = strarray_split(optarg, ",", 0);
+            int i;
+            for (i = 0; i < strarray_size(ids); i++) {
+                conversation_id_t cid = NULLCONVERSATION;
+                if (!conversation_id_decode(&cid, optarg))
+                    usage(argv[0]);
+                if (cid)
+                    hashu64_insert(cid, (void*)1, zerocids);
+            }
+            strarray_free(ids);
             break;
 
         case 'b':
@@ -991,6 +1001,11 @@ int main(int argc, char **argv)
     }
     else {
         do_user(userid, NULL);
+    }
+
+    if (zerocids) {
+        free_hashu64_table(zerocids, NULL);
+        free(zerocids);
     }
 
     shut_down(0);

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -916,7 +916,7 @@ int main(int argc, char **argv)
             break;
 
         case 'Z':
-            if (mode != UNKNOWN)
+            if (mode != UNKNOWN && mode != ZERO)
                 usage(argv[0]);
             mode = ZERO;
             if (!zerocids) {

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -927,7 +927,7 @@ int main(int argc, char **argv)
             int i;
             for (i = 0; i < strarray_size(ids); i++) {
                 conversation_id_t cid = NULLCONVERSATION;
-                if (!conversation_id_decode(&cid, optarg))
+                if (!conversation_id_decode(&cid, strarray_nth(ids, i)))
                     usage(argv[0]);
                 if (cid)
                     hashu64_insert(cid, (void*)1, zerocids);


### PR DESCRIPTION
This allows us to zero out just a single CID, rather than everything - it's to help fix up the "same email, multiple CIDs" bug that we currently have - we can just nuke each of those cids.

Ideally you'd give a list of CIDs to zero, but that's a bunch more work to build, and this will be fast enough because usually it's just a couple of CIDs for each user.  Zeroing EVERYTHING is much slower and breaks the mailbox for a bit.