### PR TITLE
fix userflags corruption crash

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1392,7 +1392,8 @@ static int parseentry_cb(int type, struct dlistsax_data *d)
 
             /* zero out the rest */
             while (rock->nflags < MAX_USER_FLAGS) {
-                xzfree(rock->h->flagname[rock->nflags++]);
+                xzfree(rock->h->flagname[rock->nflags]);
+                rock->nflags++;
             }
         }
         break;

--- a/lib/xmalloc.h
+++ b/lib/xmalloc.h
@@ -48,6 +48,8 @@
 /* for free() */
 #include <stdlib.h>
 
+#include "assert.h"
+
 extern void *xmalloc(size_t size);
 extern void *xzmalloc(size_t size);
 extern void *xcalloc(size_t nmemb, size_t size);
@@ -59,9 +61,14 @@ extern char *xstrdupsafe(const char *str);
 extern char *xstrndup(const char *str, size_t len);
 extern void *xmemdup(const void *ptr, size_t size);
 
-// free a pointer and also zero it
-#define xzfree(ptr) do { \
-  if (ptr) { free(ptr); ptr = NULL; } \
+/* free a pointer and also zero it
+ *
+ * CAUTION: ptr argument is evaluated multiple times, beware side effects!
+ */
+#define xzfree(ptr) do {    \
+    assert((ptr) == (ptr)); \
+    free(ptr);              \
+    (ptr) = NULL;           \
 } while (0)
 
 /* Functions using xmalloc.h must provide a function called fatal() conforming


### PR DESCRIPTION
This fixes a crash that can occur during cleanup up after copy/append failures when the mailbox on which the copy/append failed happened to have custom userflags.  Seen in the wild a couple of times at Fastmail.  @wolfsage found a way to reproduce it, which the Cassandane test is based on.  The cause of the crash turned out to be memory corruption resulting from calling the `xzfree()` macro -- which evaluates its `ptr` argument multiple times -- with an argument containing side effects.

It also hardens up the `xzfree()` macro somewhat to hopefully prevent this sort of thing in the future.  With the compiler options I use, the original misuse is now detected at compile time as a `sequence-point` warning, due to the comparison in the assert expression having an undefined evaluation order.  If the compiler misses it, it would still be caught at runtime due to the two evaluations not matching and the assertion failing, and hopefully the developer making the mistake would notice some test failing.

The new test reproduces the crash if run without the other fixes, and succeeds with them.