### PR TITLE
Subscriptions bump folderstate

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -946,6 +946,15 @@ sub test_mailbox_query_filteroperator
     ]);
     $self->assert(exists $res->[0][1]{updated}{$mboxids{'Ham'}});
 
+    xlog $self, "make sure subscribing changed state";
+    $self->assert_not_equals($res->[0][1]{oldState}, $res->[0][1]{newState});
+
+    my $state = $res->[0][1]{oldState};
+    $res = $jmap->CallMethods([['Mailbox/changes', { sinceState => $state }, "R1"]]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{updated}});
+    $self->assert_equals($res->[0][1]{updated}[0], $mboxids{'Ham'});
+    $self->assert_null($res->[0][1]{updatedProperties});
+
     xlog $self, "list mailboxes filtered by parentId OR role";
     $res = $jmap->CallMethods([['Mailbox/query', {
         filter => {

--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -915,10 +915,9 @@ sub test_mailbox_query_name
 }
 
 sub test_mailbox_query_filteroperator
-    :min_version_3_1 :needs_component_jmap
+    :min_version_3_1 :needs_component_jmap :NoAltNameSpace
 {
     my ($self) = @_;
-    return;
 
     my $jmap = $self->{jmap};
     my $imaptalk = $self->{store}->get_client();
@@ -959,10 +958,11 @@ sub test_mailbox_query_filteroperator
         },
         sort => [{ property => "name" }],
     }, "R1"]]);
-    $self->assert_num_equals(3, scalar @{$res->[0][1]->{ids}});
+    $self->assert_num_equals(4, scalar @{$res->[0][1]->{ids}});
     $self->assert_str_equals($mboxids{'Bonk'}, $res->[0][1]{ids}[0]);
-    $self->assert_str_equals($mboxids{'Spam'}, $res->[0][1]{ids}[1]);
-    $self->assert_str_equals($mboxids{'Zonk'}, $res->[0][1]{ids}[2]);
+    $self->assert_str_equals($mboxids{'Inbox'}, $res->[0][1]{ids}[1]);
+    $self->assert_str_equals($mboxids{'Spam'}, $res->[0][1]{ids}[2]);
+    $self->assert_str_equals($mboxids{'Zonk'}, $res->[0][1]{ids}[3]);
 
     xlog $self, "list mailboxes filtered by name";
     $res = $jmap->CallMethods([['Mailbox/query', {
@@ -978,9 +978,10 @@ sub test_mailbox_query_filteroperator
         filter => {
             isSubscribed => JSON::true,
         },
+        sort => [{ property => "name" }],
     }, "R1"]]);
     $self->assert_num_equals(1, scalar @{$res->[0][1]->{ids}});
-    $self->assert_str_equals($mboxids{'Zonk'}, $res->[0][1]{ids}[0]);
+    $self->assert_str_equals($mboxids{'Ham'}, $res->[0][1]{ids}[0]);
 
     xlog $self, "list mailboxes filtered by isSubscribed is false";
     $res = $jmap->CallMethods([['Mailbox/query', {
@@ -1000,7 +1001,7 @@ sub test_mailbox_query_filteroperator
         filter => {
             operator => "AND",
             conditions => [{
-                parentId => $mboxids{'Inbox'},
+                parentId => JSON::null,
             }, {
                 hasAnyRole => JSON::false,
             }],
@@ -1014,22 +1015,21 @@ sub test_mailbox_query_filteroperator
     $res = $jmap->CallMethods([['Mailbox/query', {
         filter => {
             operator => "NOT",
-            conditions => [
+            conditions => [{
                 operator => "AND",
                 conditions => [{
-                    parentId => $mboxids{'Inbox'},
+                    parentId => JSON::null,
                 }, {
                     hasAnyRole => JSON::true,
                 }],
-            ],
+            }],
         },
         sort => [{ property => "name" }],
     }, "R1"]]);
-    $self->assert_num_equals(4, scalar @{$res->[0][1]->{ids}});
+    $self->assert_num_equals(3, scalar @{$res->[0][1]->{ids}});
     $self->assert_str_equals($mboxids{'Bonk'}, $res->[0][1]{ids}[0]);
-    $self->assert_str_equals($mboxids{'Inbox'}, $res->[0][1]{ids}[1]);
-    $self->assert_str_equals($mboxids{'Spam'}, $res->[0][1]{ids}[2]);
-    $self->assert_str_equals($mboxids{'Zonk'}, $res->[0][1]{ids}[3]);
+    $self->assert_str_equals($mboxids{'Ham'}, $res->[0][1]{ids}[1]);
+    $self->assert_str_equals($mboxids{'Zonk'}, $res->[0][1]{ids}[2]);
 }
 
 sub test_mailbox_query_issue2286

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -1141,6 +1141,7 @@ static int _mboxquery_eval_filter(mboxquery_t *query,
             int want_subscribed = json_boolean_value(filter->is_subscribed);
             int is_subscribed = strarray_find(query->sublist, rec->mboxname, 0);
             if (want_subscribed && is_subscribed < 0) return 0;
+            if (!want_subscribed && is_subscribed >= 0) return 0;
         }
         return 1;
     }


### PR DESCRIPTION
This is actually two fixes!

First, I discovered that an entire important test was being killed with a `return;` at the top!  Ouch.  I discovered this when trying to add to it.

I had to fix that test, during which I discovered a bug with isSubscribed == false, so there's a fix for that.

Then the actual fix, which was discovered when testing with the TMail client - our server wasn't bumping the state string for the mailbox when changing the isSubscribed value.

