### PR TITLE
ctl_conversationsdb: ignore limits when rebuilding

### DIFF
--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -259,6 +259,8 @@ static int build_cid_cb(const mbentry_t *mbentry,
             r = mailbox_cacherecord(mailbox, &oldrecord);
             if (r) goto done;
 
+            oldrecord.ignorelimits = 1;
+
             r = message_update_conversations(cstate, mailbox, &oldrecord, NULL);
             if (r) goto done;
 


### PR DESCRIPTION
If we're already over the limits, there's nothing we can do about it short of removing messages, which this tool doesn't do.

When I rebuilt Fastmail users after fixing the CID/THRID mismatch, some failed to complete due to this error.