### PR TITLE
Add a 'replicaonly' config option and directory

### DIFF
--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -3104,9 +3104,22 @@ static modseq_t mboxname_domodseq(const char *fname,
     return counters.highestmodseq;
 }
 
+static void mboxname_assert_canadd(mbname_t *mbname)
+{
+    assert(!config_getswitch(IMAPOPT_REPLICAONLY));
+    // add code for suppressing particular users by filename
+    const char *userid = mbname_userid(mbname);
+    if (!userid) return;
+    char *path = strconcat(config_dir, "/replicaonly/", userid, (char *)NULL);
+    struct stat sbuf;
+    assert(stat(path, &sbuf) == -1); // file must not exist
+    free(path);
+}
+
 EXPORTED modseq_t mboxname_nextmodseq(const char *mboxname, modseq_t last, int mbtype, int flags)
 {
     mbname_t *mbname = mbname_from_intname(mboxname);
+    mboxname_assert_canadd(mbname);
     char *fname = mboxname_conf_getpath(mbname, "counters");
 
     modseq_t modseq = mboxname_domodseq(fname, mboxname, last, MBOXMODSEQ, mbtype, flags, 1);
@@ -3152,6 +3165,7 @@ EXPORTED modseq_t mboxname_readquotamodseq(const char *mboxname)
 EXPORTED modseq_t mboxname_nextquotamodseq(const char *mboxname, modseq_t last)
 {
     mbname_t *mbname = mbname_from_intname(mboxname);
+    mboxname_assert_canadd(mbname);
     char *fname = mboxname_conf_getpath(mbname, "counters");
 
     modseq_t modseq = mboxname_domodseq(fname, mboxname, last, QUOTAMODSEQ, 0, 0, 1);
@@ -3200,6 +3214,7 @@ EXPORTED modseq_t mboxname_readraclmodseq(const char *mboxname)
 EXPORTED modseq_t mboxname_nextraclmodseq(const char *mboxname, modseq_t last)
 {
     mbname_t *mbname = mbname_from_intname(mboxname);
+    mboxname_assert_canadd(mbname);
     char *fname = mboxname_conf_getpath(mbname, "counters");
 
     modseq_t modseq = mboxname_domodseq(fname, mboxname, last, RACLMODSEQ, 0, 0, 1);
@@ -3249,6 +3264,7 @@ EXPORTED uint32_t mboxname_nextuidvalidity(const char *mboxname, uint32_t last)
     struct mboxname_counters counters;
     int fd = -1;
     mbname_t *mbname = mbname_from_intname(mboxname);
+    mboxname_assert_canadd(mbname);
     char *fname = mboxname_conf_getpath(mbname, "counters");
 
     /* XXX error handling */

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -606,6 +606,8 @@ int fixquota_finish(int thisquota)
                 localq.scanuseds[res]);
             if (!flag_reportonly)
                 localq.useds[res] = localq.scanuseds[res];
+            // need to bump modseq, we changed something
+            localq.dirty = 1;
         }
     }
 

--- a/imap/quota.h
+++ b/imap/quota.h
@@ -83,6 +83,8 @@ struct quota {
     char *scanmbox;
     quota_t scanuseds[QUOTA_NUMRESOURCES];
 
+    /* inforation for changes */
+    int dirty;
     modseq_t modseq;
 };
 

--- a/imap/quota_db.c
+++ b/imap/quota_db.c
@@ -352,6 +352,8 @@ EXPORTED int quota_check(const struct quota *q,
 EXPORTED void quota_use(struct quota *q,
                enum quota_resource res, quota_t delta)
 {
+    if (delta)
+        q->dirty = 1;
     /* prevent underflow */
     if ((delta < 0) && (-delta > q->useds[res])) {
         syslog(LOG_INFO, "Quota underflow for root %s, resource %s,"
@@ -458,7 +460,7 @@ EXPORTED int quota_write(struct quota *quota, int silent, struct txn **tid)
     qrlen = strlen(quota->root);
     if (!qrlen) return IMAP_QUOTAROOT_NONEXISTENT;
 
-    if (mboxname_isusermailbox(quota->root, /*isinbox*/0)) {
+    if (quota->dirty && mboxname_isusermailbox(quota->root, /*isinbox*/0)) {
         if (silent)
             quota->modseq = mboxname_setquotamodseq(quota->root, quota->modseq);
         else

--- a/imap/user.c
+++ b/imap/user.c
@@ -593,7 +593,7 @@ static int find_cb(void *rockp __attribute__((unused)),
     int r;
 
     root = xstrndup(key, keylen);
-    r = quota_deleteroot(root, 0);
+    r = quota_deleteroot(root, 1);
     free(root);
 
     return r;

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2217,6 +2217,10 @@ If all partitions are over that limit, this feature is not used anymore.
 /* If enabled, all IMAP, POP and JMAP connections are read-only,
  * no writes allowed. */
 
+{ "replicaonly", 0, SWITCH, "3.9.0" }
+/* If enabled, nothing is allowed to increase modseq or uidvalidity,
+ * no writes allowed at all. */
+
 { "reject8bit", 0, SWITCH, "2.3.17" }
 /* If enabled, lmtpd rejects messages with 8-bit characters in the
    headers. */


### PR DESCRIPTION
If the config is set, or there is a file with the username in the directory, then abort if any attempt is made to call `nextmodseq` or `nextuidvalidity`, instead only sync_server writes are allowed.

This branch also fixes two bugs found by this test already.