### PR TITLE
Calalarmd replicaonly

### DIFF
--- a/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
@@ -1378,7 +1378,7 @@ EOF
 }
 
 sub test_replication_at1
-    :min_version_3_0 :needs_component_calalarmd
+    :min_version_3_0 :needs_component_calalarmd :NoReplicaOnly
 {
     my ($self) = @_;
 
@@ -1792,7 +1792,7 @@ EOF
 }
 
 sub test_replication_withalarms_in_tz_with_dst
-    :min_version_3_0 :needs_component_calalarmd
+    :min_version_3_0 :needs_component_calalarmd :NoReplicaOnly
 {
     my ($self) = @_;
 
@@ -1901,7 +1901,7 @@ EOF
 }
 
 sub test_replication_withalarms_in_tz_without_dst
-    :min_version_3_0 :needs_component_calalarmd
+    :min_version_3_0 :needs_component_calalarmd :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -2122,7 +2122,7 @@ sub test_connect_once
 # Test empty mailbox gets overwritten
 #
 sub test_splitbrain_different_uniqueid_unused
-    :min_version_3_5 :needs_component_replication
+    :min_version_3_5 :needs_component_replication :NoReplicaonly
 {
     my ($self) = @_;
 
@@ -2161,7 +2161,7 @@ sub test_splitbrain_different_uniqueid_unused
 # Test non-empty mailbox causes replication to abort
 #
 sub test_splitbrain_different_uniqueid_nonempty
-    :min_version_3_5 :needs_component_replication
+    :min_version_3_5 :needs_component_replication :NoReplicaonly
 {
     my ($self) = @_;
 
@@ -2218,7 +2218,7 @@ sub test_splitbrain_different_uniqueid_nonempty
 # Test mailbox that's had email but is now empty again
 #
 sub test_splitbrain_different_uniqueid_used
-    :min_version_3_5 :needs_component_replication
+    :min_version_3_5 :needs_component_replication :NoReplicaonly
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -463,6 +463,10 @@ magic(JmapMaxCalendarEventNotifs => sub {
     # set to some small number
     $conf->config_set('jmap_max_calendareventnotifs' => 10);
 });
+magic(NoReplicaonly => sub {
+    my $self = shift;
+    $self->{no_replicaonly} = 1;
+});
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic
@@ -616,6 +620,9 @@ sub _create_instances
             my %replica_params = %instance_params;
             $replica_params{config} = $conf->clone();
             $replica_params{config}->set(sync_rightnow_channel => undef);
+	    unless ($self->{no_replicaonly}) {
+                $replica_params{config}->set(replicaonly => 'yes');
+            }
             my $cyrus_replica_prefix = $cassini->val('cyrus replica', 'prefix');
             if (defined $cyrus_replica_prefix and -d $cyrus_replica_prefix) {
                 xlog $self, "replica instance: using [cyrus replica] configuration";

--- a/changes/next/replicaonly
+++ b/changes/next/replicaonly
@@ -1,0 +1,24 @@
+Description:
+
+add 'replicaonly' config option that blocks all non-silent writes
+
+(Silent writes are those where the modseq is specified in the write,
+so the highestmodseq doesn't get increased - these are the sort done
+by sync_server)
+
+Config changes:
+
+the boolean config option `replicaonly` (default: false) can be set
+to mark a server as only being a replica.  This will stop calalarmd
+from doing anything, and also deny any non-silent writes.
+
+
+Upgrade instructions:
+
+No change required - you can keep running without setting this config
+option on replicas, and they will behave as before (in particular,
+you will still have to make sure not to run calalarmd on replicas).
+
+GitHub issue:
+
+none

--- a/imap/calalarmd.c
+++ b/imap/calalarmd.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
         struct timeval start, end;
         double totaltime;
         int tosleep;
-        time_t interval = 1;
+        time_t interval = 10;
 
         signals_poll();
 

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -3110,10 +3110,7 @@ static void mboxname_assert_canadd(mbname_t *mbname)
     // add code for suppressing particular users by filename
     const char *userid = mbname_userid(mbname);
     if (!userid) return;
-    char *path = strconcat(config_dir, "/replicaonly/", userid, (char *)NULL);
-    struct stat sbuf;
-    assert(stat(path, &sbuf) == -1); // file must not exist
-    free(path);
+    assert(!user_isreplicaonly(userid));
 }
 
 EXPORTED modseq_t mboxname_nextmodseq(const char *mboxname, modseq_t last, int mbtype, int flags)

--- a/imap/user.c
+++ b/imap/user.c
@@ -727,3 +727,13 @@ EXPORTED int user_isnamespacelocked(const char *userid)
     const char *name = _namelock_name_from_userid(userid);
     return mboxname_islocked(name);
 }
+
+EXPORTED int user_isreplicaonly(const char *userid)
+{
+    int file_exists = 0;
+    char *path = strconcat(config_dir, "/replicaonly/", userid, (char *)NULL);
+    struct stat sbuf;
+    file_exists = !stat(path, &sbuf);
+    free(path);
+    return file_exists;
+}

--- a/imap/user.h
+++ b/imap/user.h
@@ -50,6 +50,10 @@
 #define FNAME_SUBSSUFFIX     "sub"
 #define FNAME_COUNTERSSUFFIX "counters"
 
+/* check if this user should be treated as being on a replica (for user moves,
+ * or for actual replicas */
+int user_isreplicaonly(const char *userid);
+
 /* path to user's sieve directory */
 const char *user_sieve_path(const char *user);
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2242,7 +2242,7 @@ If all partitions are over that limit, this feature is not used anymore.
 /* If enabled, all IMAP, POP and JMAP connections are read-only,
  * no writes allowed. */
 
-{ "replicaonly", 0, SWITCH, "3.9.0" }
+{ "replicaonly", 0, SWITCH, "UNRELEASED" }
 /* If enabled, nothing is allowed to increase modseq or uidvalidity,
  * no writes allowed at all. */
 


### PR DESCRIPTION
This adds both tests for replicaonly mode (disabled for the tests which MUST actually screw with the replica to test splitbrain recovery!), and support to calalarmd to skip processing for users who are in replicaonly mode.