### PR TITLE
mailbox.c:mailbox_add_dav() - return no error for already expunged messages

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6107,6 +6107,7 @@ EXPORTED int mailbox_add_dav(struct mailbox *mailbox)
         if (r == IMAP_NO_MSGGONE) {
             if (record->internal_flags & FLAG_INTERNAL_EXPUNGED) {
                 /* Already expunged */
+                r = 0;
                 continue;
             }
 


### PR DESCRIPTION
When I call  dav_reconstuct user  syslog emits

> dav_reconstruct_user: user FAILED Message %d no longer exists

`%d` is literally contained in the log.  dav_db.c:dav_reconstruct_user() calls dav_db.c:_dav_reconstruct_mb():
```c
    case MBTYPE_CALENDAR:
    case MBTYPE_COLLECTION:
    case MBTYPE_ADDRESSBOOK:
        addproc = &mailbox_add_dav;
…
    if (!r) r = addproc(mailbox); //⇔ same as mailbox_add_dav(mailbox)
```
and mailbox.c:mailbox_add_dav() calls
```c
    while ((msg = mailbox_iter_step(iter))) {
        const struct index_record *record = msg_record(msg);
        r = mailbox_update_dav(mailbox, NULL, record);
        if (r == IMAP_NO_MSGGONE) {
            if (record->internal_flags & FLAG_INTERNAL_EXPUNGED) {
                /* Already expunged */
                continue;
            }
         …
         }
     } // while
     return r;
```
So when the last record is “gone”, mailbox_add_dav() and _dav_reconstruct_mb() return IMAP_NO_MSGGONE .  Then dav_reconstruct_user() rolls back the reconstruct transaction.