### PR TITLE
Fix forcesync

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -4577,7 +4577,6 @@ EXPORTED int mailbox_rewrite_index_record(struct mailbox *mailbox,
         record->modseq = mailbox->i.highestmodseq;
         record->last_updated = mailbox->last_updated;
     }
-    assert(record->modseq >= oldrecord.modseq);
 
     if (record->internal_flags & FLAG_INTERNAL_UNLINKED) {
         /* mark required actions */

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2514,8 +2514,10 @@ static int sync_mailbox_compare_update(struct mailbox *mailbox,
             /* higher modseq on the replica is an error */
             if (rrecord->modseq > mrecord.modseq) {
                 if (opt_force) {
-                    syslog(LOG_NOTICE, "forcesync: higher modseq on replica %s %u (" MODSEQ_FMT " > " MODSEQ_FMT ")",
-                           mailbox_name(mailbox), mrecord.uid, rrecord->modseq, mrecord.modseq);
+                    if (doupdate)
+                        syslog(LOG_NOTICE, "forcesync: higher modseq on replica %s %u "
+                               "(" MODSEQ_FMT " > " MODSEQ_FMT ")",
+                               mailbox_name(mailbox), mrecord.uid, rrecord->modseq, mrecord.modseq);
                 }
                 else {
                     xsyslog(LOG_ERR, "SYNCNOTICE: higher modseq on replica",


### PR DESCRIPTION
This fixes a crasher found in Fastmail production with forcesync and a higher modseq on the replica (likely caused by user moves)