### PR TITLE
V39/analyzer extra stuff

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2654,6 +2654,8 @@ EXPORTED int conversation_update(struct conversations_state *state,
 {
     conv_folder_t *folder = conversation_get_folder(conv, ecounts->foldernum, /*create*/1);
 
+    assert(folder != NULL); /* should only fire if ecounts->foldernum is negative */
+
     // only count one per instance of the GUID in each folder, and in total
     int delta_num_records = !!ecounts->post.numrecords - !!ecounts->pre.numrecords;
     int delta_exists = !!ecounts->post.exists - !!ecounts->pre.exists;

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5072,8 +5072,13 @@ static struct partial_comp_t *parse_partial_comp(xmlNodePtr node)
         }
         else if (!xmlStrcmp(node->name, BAD_CAST "comp")) {
             struct partial_comp_t *child = parse_partial_comp(node);
-            child->sibling = pcomp->child;
-            pcomp->child = child;
+            if (child) {
+                child->sibling = pcomp->child;
+                pcomp->child = child;
+            }
+            else {
+                /* XXX what does it mean if we get here? */
+            }
         }
     }
 

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -636,6 +636,11 @@ static int carddav_store_resource(struct transaction_t *txn,
         }
     }
 
+    /* XXX better have got those important properties */
+    assert(version != NULL);
+    assert(uid != NULL);
+    assert(fullname != NULL);
+
     /* Check for an existing resource */
     /* XXX  We can't assume that txn->req_tgt.mbentry is our target,
        XXX  because we may have been called as part of a COPY/MOVE */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -1414,6 +1414,8 @@ xmlNodePtr xml_add_error(xmlNodePtr root, struct error_t *err,
     }
     else error = xmlNewChild(root, NULL, BAD_CAST "error", NULL);
 
+    if (!error) fatal("Virtual memory exhausted", EX_TEMPFAIL);
+
     ensure_ns(avail_ns, precond->ns, root, known_namespaces[precond->ns].href,
               known_namespaces[precond->ns].prefix);
     node = xmlNewChild(error, avail_ns[precond->ns],

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -2092,6 +2092,7 @@ HIDDEN int dav_post_share(struct transaction_t *txn, struct meth_params *pparams
                 }
                 else {
                     /* Notify sharee */
+                    assert(notify == NULL);
                     r = dav_create_invite(&notify, ns, &txn->req_tgt,
                                           pparams->propfind.lprops,
                                           userid, access, content);

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -1842,6 +1842,9 @@ static xmlNodePtr get_props(struct request_target_t *req_tgt,
 
     buf_free(&fctx.buf);
 
+    /* XXX better have gotten something */
+    assert(propstat.root != NULL);
+
     node = propstat.root->children;
     xmlUnlinkNode(node);
     xmlFreeNode(propstat.root);

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -131,11 +131,11 @@ static int get_email2uids(struct transaction_t *txn __attribute__((unused)),
 {
     struct carddav_db *db = NULL;
     strarray_t *array = NULL;
-    char *result = NULL;
     json_t *json;
     int ret = HTTP_NO_CONTENT;
     int i;
     char *mboxname = NULL;
+    char *result = NULL;
     const char **mailboxhdrs;
     const char *mailbox = "Default";
     mbentry_t *mbentry = NULL;
@@ -173,8 +173,8 @@ static int get_email2uids(struct transaction_t *txn __attribute__((unused)),
     ret = 0;
 
 done:
-    free(mboxname);
-    free(result);
+    if (mboxname) free(mboxname);
+    if (result) free(result);
     mboxlist_entry_free(&mbentry);
     if (array) strarray_free(array);
     if (db) carddav_close(db);
@@ -231,8 +231,8 @@ static int get_email2details(struct transaction_t *txn __attribute__((unused)),
     ret = 0;
 
 done:
-    free(mboxname);
-    free(result);
+    if (mboxname) free(mboxname);
+    if (result) free(result);
     mboxlist_entry_free(&mbentry);
     if (array) strarray_free(array);
     if (db) carddav_close(db);
@@ -293,8 +293,8 @@ static int get_uid2groups(struct transaction_t *txn,
     ret = 0;
 
 done:
-    free(mboxname);
-    free(result);
+    if (mboxname) free(mboxname);
+    if (result) free(result);
     mboxlist_entry_free(&mbentry);
     if (array) strarray_free(array);
     if (db) carddav_close(db);

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -413,6 +413,11 @@ static int login(struct backend *s, const char *userid,
             if (serverin) {
                 /* Perform the next step in the auth exchange */
 
+                /* XXX if we got here via the 'goto challenge' in 'case 200:',
+                 * XXX then scheme might still be null
+                 */
+                assert(scheme != NULL);
+
                 if (scheme->id == AUTH_BASIC) {
                     /* Don't care about "realm" in server challenge */
                     const char *authid =
@@ -1410,7 +1415,7 @@ EXPORTED int http_proxy_check_input(struct http_connection *conn,
                     if (pin == txn->be->in) break;
                 }
 
-                if (pin != txn->be->in) {
+                if (!txn || pin != txn->be->in) {
                     /* XXX shouldn't get here !!! */
                     fatal("unknown protstream returned"
                           " by prot_select() in http_proxy_check_input()",

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -4206,6 +4206,8 @@ static int http_auth(const char *creds, struct transaction_t *txn)
         }
     }
 
+    assert(scheme != NULL);
+
     /* Parse any auth parameters, if necessary */
     if (clientin && (scheme->flags & AUTH_DATA_PARAM)) {
         const char *sid = NULL;

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -1222,9 +1222,9 @@ icalcomponent_get_utc_timespan(icalcomponent *comp,
                 if (!icaltime_is_null_time(due)) {
                     /* Has DUE (DTEND for VPOLL) */
                     if (icaltime_compare(due, period.start) < 0)
-                        memcpy(&period.start, &due, sizeof(struct icaltimetype));
+                        period.start = due;
                     if (icaltime_compare(due, period.end) > 0)
-                        memcpy(&period.end, &due, sizeof(struct icaltimetype));
+                        period.end = due;
                 }
             }
         }
@@ -1250,9 +1250,9 @@ icalcomponent_get_utc_timespan(icalcomponent *comp,
                     struct icaltimetype created =
                         icaltime_convert_to_utc(icalproperty_get_created(prop), NULL);
                     if (icaltime_compare(created, period.start) < 0)
-                        memcpy(&period.start, &created, sizeof(struct icaltimetype));
+                        period.start = created;
                     if (icaltime_compare(created, period.end) > 0)
-                        memcpy(&period.end, &created, sizeof(struct icaltimetype));
+                        period.end = created;
                 }
             }
             else if ((prop =

--- a/imap/index.c
+++ b/imap/index.c
@@ -7133,6 +7133,7 @@ static void index_thread_orderedsubj(struct index_state *state,
             }
             /* otherwise, add to siblings */
             else {
+                assert(last != NULL);
                 last->next = newnode;
                 last = last->next;
             }
@@ -7141,6 +7142,7 @@ static void index_thread_orderedsubj(struct index_state *state,
         else {
             cur->next = newnode;        /* create and start a new thread */
             parent = cur = cur->next;   /* now work with the new thread */
+            /* XXX reset last ? */
         }
 
         psubj_hash = msg->xsubj_hash;

--- a/imap/index.c
+++ b/imap/index.c
@@ -7092,8 +7092,11 @@ static void index_thread_orderedsubj(struct index_state *state,
     char *psubj;
     Thread *head, *newnode, *cur, *parent, *last;
 
+    if (nmsg == 0) return; /* nothing to do here */
+
     /* Create/load the msgdata array */
     msgdata = index_msgdata_load(state, msgno_list, nmsg, sortcrit, 0, NULL);
+    assert(msgdata != NULL);
 
     /* Sort messages by subject and date */
     index_msgdata_sort(msgdata, nmsg, sortcrit);
@@ -7751,8 +7754,11 @@ static void _index_thread_ref(struct index_state *state, unsigned *msgno_list,
     struct hash_table id_table;
     struct rootset rootset;
 
+    if (nmsg == 0) return; /* nothing to do here */
+
     /* Create/load the msgdata array */
     msgdata = index_msgdata_load(state, msgno_list, nmsg, loadcrit, 0, NULL);
+    assert(msgdata != NULL);
 
     /* calculate the sum of the number of references for all messages */
     for (mi = 0, tref = 0 ; mi < nmsg ; mi++)

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -1801,7 +1801,7 @@ static void restore_mailbox_plan_cb(const char *guid __attribute__((unused)),
     struct message_t *message = (struct message_t *) data;
     ptrarray_t *deleted = &message->deleted;
     hash_table *mailboxes = (hash_table *) rock;
-    time_t last_removed;
+    time_t last_removed = 0;
     int i;
 
     if (!message->ignore) ptrarray_sort(deleted, &rmail_cmp);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -9689,6 +9689,9 @@ static int jmap_principal_getavailability(struct jmap_req *req)
         json_object_del(myargs, "showDetails");
     }
 
+    /* XXX what if these fields were missing? */
+    assert(principalid != NULL);
+
     json_t *jprops = json_object_get(myargs, "eventProperties");
     if (json_is_array(jprops)) {
         props = xzmalloc(sizeof(hash_table));

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -9290,6 +9290,7 @@ static unsigned _jsname_to_vcard(struct jmap_parser *parser, json_t *jval,
                     _jsunknown_to_vcard(parser, key, jsubprop, myprops, card);
                 }
 
+                /* XXX ckind may still be NULL here! */
                 fields[ckind->idx] = json_string_value(jsubprop);
                 last_field = MAX(last_field, ckind->idx);
             }

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1987,6 +1987,9 @@ static int jmap_sieve_test(struct jmap_req *req)
         goto done;
     }
 
+    /* XXX shush analyzer fp */
+    assert(scriptid != NULL);
+
     if (scriptid[0] == 'S') {
         const char *sievedir = user_sieve_path(req->accountid);
         struct sieve_data *sdata = NULL;

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1629,7 +1629,7 @@ static void cmd_set(struct conn *C,
              * deactivation twice. Suppress bailing out on the second one
              * (the replica).
              */
-            if (strcmp(m->location, location)) {
+            if (!m || strcmp(m->location, location)) {
                 /* failed; mailbox not currently active */
                 msg = NOTACTIVE;
                 goto done;
@@ -1640,14 +1640,15 @@ static void cmd_set(struct conn *C,
     }
 
     if (t == SET_DELETE) {
-        if (!m) {
+        if (!m) { // XXX <- m is NULL!
             /* Check if we run in a discrete murder topology */
             if (config_mupdate_config == IMAP_ENUM_MUPDATE_CONFIG_STANDARD) {
                 /* Replicated backends with the same server name issue
                  * deletion twice. Suppress bailing out on the second one
                  * (the replica).
                  */
-                if (strcmp(m->location, location)) {
+                /* XXX makes no sense to examine m->location when m is NULL! */
+                if (m && strcmp(m->location, location)) {
                     /* failed; mailbox doesn't exist */
                     msg = DOESNTEXIST;
                     goto done;
@@ -1746,6 +1747,8 @@ static void cmd_find(struct conn *C, const char *tag, const char *mailbox,
               int send_ok, int send_delete)
 {
     struct mbent *m;
+
+    assert(mailbox != NULL);
 
     syslog(LOG_DEBUG, "cmd_find(fd:%d, %s)", C->fd, mailbox);
 

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -902,8 +902,10 @@ static int subquery_run_one_folder(search_query_t *query,
         folder_add_uid(folder, im->uid);
         folder_add_modseq(folder, im->modseq);
 
-        if (query->sortcrit)
+        if (query->sortcrit) {
+            assert(msgno_list != NULL);
             msgno_list[nmsgs++] = msgno;
+        }
 
         /* track first and last for MIN/MAX queries */
         if (!folder->first_modseq) folder->first_modseq = im->modseq;

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -43,7 +43,8 @@
 #ifndef INCLUDED_ASSERT_H
 #define INCLUDED_ASSERT_H
 
-void assertionfailed(const char *file, int line, const char *expr);
+void assertionfailed(const char *file, int line, const char *expr)
+    __attribute__((noreturn));
 
 #define assert(expr)                                                \
     ((expr)                                                         \

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3160,8 +3160,10 @@ static void mimeheader_cat(struct convert_rock *target, const char *s, int flags
     /* set up the conversion path */
     if (flags & CHARSET_MIME_UTF8) {
         defaultcs = charset_lookupname("utf-8");
+        assert(defaultcs != CHARSET_UNKNOWN_CHARSET);
     } else {
         defaultcs = charset_lookupname("us-ascii");
+        assert(defaultcs != CHARSET_UNKNOWN_CHARSET);
     }
     input = convert_init(defaultcs, 1/*to_uni*/, target);
 


### PR DESCRIPTION
This sits on top of #4724, will need rebasing once that lands.  The real contents here are the commits starting with "WIP".

This contains all the stuff where there's either a real problem that I haven't worked out how to solve properly, or where I needed to add stuff just to shut up a false positive from the static analyzer.

Even with all these commits, a few source files still don't build cleanly with `-fanalyze` yet.  In particular, all the code generated by flex/bison.  Also, jmap_contact.c, httpd.c, and http_jwt.testc are others I remember at the time of writing.  For these files, I had to compile them individually without `-fanalyze` due to things I couldn't fix nor shut up.

With these commits, and a **lot** of CPU time and RAM, you can build all of Cyrus (with exceptions as above) under the analyzer, and successfully run the cunit and cassandane tests.