### PR TITLE
Mailbox locking refcount

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -946,6 +946,15 @@ sub test_mailbox_query_filteroperator
     ]);
     $self->assert(exists $res->[0][1]{updated}{$mboxids{'Ham'}});
 
+    xlog $self, "make sure subscribing changed state";
+    $self->assert_not_equals($res->[0][1]{oldState}, $res->[0][1]{newState});
+
+    my $state = $res->[0][1]{oldState};
+    $res = $jmap->CallMethods([['Mailbox/changes', { sinceState => $state }, "R1"]]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{updated}});
+    $self->assert_equals($res->[0][1]{updated}[0], $mboxids{'Ham'});
+    $self->assert_null($res->[0][1]{updatedProperties});
+
     xlog $self, "list mailboxes filtered by parentId OR role";
     $res = $jmap->CallMethods([['Mailbox/query', {
         filter => {

--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -572,4 +572,55 @@ sub test_reconstruct_uniqueid_from_header_uuidmb
     $self->assert_str_equals("user\x1fcassandane", $hash->{N});
 }
 
+sub test_downgrade_upgrade
+{
+    my ($self) = @_;
+
+    my $talk = $self->{store}->get_client();
+    $self->{store}->_select();
+    $self->assert_num_equals(1, $talk->uid());
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+
+    xlog $self, "Add two messages";
+    my %msg;
+    $msg{A} = $self->make_message('Message A');
+    $msg{A}->set_attributes(id => 1,
+                            uid => 1,
+                            flags => []);
+    $msg{B} = $self->make_message('Message B');
+    $msg{B}->set_attributes(id => 2,
+                            uid => 2,
+                            flags => []);
+    $self->check_messages(\%msg);
+
+    xlog $self, "Set \\Seen on message A";
+    my $res = $talk->store('1', '+flags', '(\\Seen)');
+    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $msg{A}->set_attribute(flags => ['\\Seen']);
+    $self->check_messages(\%msg);
+
+    xlog $self, "Clear \\Seen on message A";
+        $res = $talk->store('1', '-flags', '(\\Seen)');
+    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $msg{A}->set_attribute(flags => []);
+    $self->check_messages(\%msg);
+
+    xlog $self, "Set \\Seen on message A again";
+    $res = $talk->store('1', '+flags', '(\\Seen)');
+    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $msg{A}->set_attribute(flags => ['\\Seen']);
+    $self->check_messages(\%msg);
+
+    for my $version (12, 14, 16, 'max') {
+        xlog $self, "Set to version $version";
+        eval { $self->{instance}->run_command({ cyrus => 1 }, 'reconstruct', '-V', $version) };
+
+        xlog $self, "Reconnect, \\Seen should still be on message A";
+        $self->{store}->disconnect();
+        $self->{store}->connect();
+        $self->{store}->_select();
+        $self->check_messages(\%msg);
+    }
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -613,7 +613,7 @@ sub test_downgrade_upgrade
 
     for my $version (12, 14, 16, 'max') {
         xlog $self, "Set to version $version";
-        eval { $self->{instance}->run_command({ cyrus => 1 }, 'reconstruct', '-V', $version) };
+        $self->{instance}->run_command({ cyrus => 1 }, 'reconstruct', '-V', $version);
 
         xlog $self, "Reconnect, \\Seen should still be on message A";
         $self->{store}->disconnect();

--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -1529,6 +1529,7 @@ sub assert_user_sub_exists
     my ($self, $instance, $user) = @_;
 
     my $subs = $instance->get_conf_user_file($user, 'sub');
+    $self->assert_not_null($subs);
 
     xlog $self, "Looking for subscriptions file $subs";
 
@@ -1540,6 +1541,7 @@ sub assert_user_sub_not_exists
     my ($self, $instance, $user) = @_;
 
     my $subs = $instance->get_conf_user_file($user, 'sub');
+    return unless $subs;  # user might not exist
 
     xlog $self, "Looking for subscriptions file $subs";
 

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1448,7 +1448,11 @@ sub _check_cores
         my $prog = _detect_core_program($core);
 
         xlog "Found core file $core";
-        xlog "   from program $prog" if defined $prog;
+        if (defined $prog) {
+           xlog "   from program $prog";
+           my ($bin) = $prog =~ m/^(\S+)/; # binary only
+           xlog "   debug: sudo gdb $bin $core";
+        }
     }
     closedir CORES;
 

--- a/cassandane/doc/README.deps
+++ b/cassandane/doc/README.deps
@@ -163,7 +163,8 @@ Debian/Ubuntu copypasta:
        libdbd-sqlite3-perl libdigest-crc-perl libxml-simple-perl
 
   sudo cpan Math::Int64 Mail::JMAPTalk Mail::IMAPTalk \
-       Net::CalDAVTalk Net::CardDAVTalk String::CRC32
+       Net::CalDAVTalk Net::CardDAVTalk String::CRC32 \
+       IO::File::Lockable
 
 Fedora copypasta:
    # there's heaps more to add here... needs to be tested

--- a/cassandane/tiny-tests/JMAPCalendars/calendar-set-sharewith-acl
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar-set-sharewith-acl
@@ -8,7 +8,8 @@ sub test_calendar_set_sharewith_acl
     my $jmap = $self->{jmap};
     my $admin = $self->{adminstore}->get_client();
 
-    $admin->create("user.test1");
+    $admin->create("user.aatester");
+    $admin->create("user.zztester");
 
     my $res = $jmap->CallMethods([
         ['Calendar/set', {
@@ -79,7 +80,8 @@ sub test_calendar_set_sharewith_acl
                 update => {
                     $calendarId => {
                         shareWith => {
-                            test1 => $_->{rights},
+                            aatester => $_->{rights},
+                            zztester => $_->{rights},
                         },
                     },
                 },
@@ -104,8 +106,11 @@ sub test_calendar_set_sharewith_acl
         ), %{$_->{wantRights}});
 
         $self->assert_deep_equals(\%mergedrights,
-            $res->[1][1]{list}[0]{shareWith}{test1});
+            $res->[1][1]{list}[0]{shareWith}{aatester});
+        $self->assert_deep_equals(\%mergedrights,
+            $res->[1][1]{list}[0]{shareWith}{zztester});
         my %acl = @{$admin->getacl("user.cassandane.#calendars.$calendarId")};
-        $self->assert_str_equals($_->{acl}, $acl{test1});
+        $self->assert_str_equals($_->{acl}, $acl{aatester});
+        $self->assert_str_equals($_->{acl}, $acl{zztester});
     }
 }

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -529,7 +529,7 @@ static int autochangesub(struct findall_data *data, void *rock)
     /* ignore all user mailboxes, we only want shared */
     if (mboxname_isusermailbox(name, 0)) return 0;
 
-    r = mboxlist_changesub(name, userid, auth_state, 1, 0, 1);
+    r = mboxlist_changesub(name, userid, auth_state, 1, 0, 1, 1);
 
     /* unless this name was explicitly chosen, ignore the failure */
     if (!was_explicit) return 0;
@@ -777,7 +777,7 @@ int autocreate_user(struct namespace *namespace, const char *userid)
                                1/*isadmin*/, userid, auth_state,
                                MBOXLIST_CREATE_NOTIFY, NULL/*mailboxptr*/);
 
-    if (!r) r = mboxlist_changesub(inboxname, userid, auth_state, 1, 1, 1);
+    if (!r) r = mboxlist_changesub(inboxname, userid, auth_state, 1, 1, 1, 1);
     if (r) {
         syslog(LOG_ERR, "autocreateinbox: User %s, INBOX failed. %s",
                userid, error_message(r));
@@ -839,7 +839,7 @@ int autocreate_user(struct namespace *namespace, const char *userid)
 
         /* subscribe if requested */
         if (strarray_find(subscribe, name, 0) >= 0) {
-            r = mboxlist_changesub(foldername, userid, auth_state, 1, 1, 1);
+            r = mboxlist_changesub(foldername, userid, auth_state, 1, 1, 1, 1);
             if (!r) {
                 numsub++;
                 syslog(LOG_NOTICE,"autocreateinbox: User %s, subscription to %s succeeded",

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -1722,3 +1722,13 @@ EXPORTED void dlist_rename(struct dlist *dl, const char *name)
     free(dl->name);
     dl->name = xstrdup(name);
 }
+
+EXPORTED struct dlist *dlist_copy(const struct dlist *dl)
+{
+    struct buf buf = BUF_INITIALIZER;
+    struct dlist *new = NULL;
+    dlist_printbuf(dl, 1, &buf);
+    dlist_parsemap(&new, 1, 0, buf_base(&buf), buf_len(&buf));
+    buf_free(&buf);
+    return new;
+}

--- a/imap/dlist.c
+++ b/imap/dlist.c
@@ -1725,6 +1725,7 @@ EXPORTED void dlist_rename(struct dlist *dl, const char *name)
 
 EXPORTED struct dlist *dlist_copy(const struct dlist *dl)
 {
+    if (!dl) return NULL;
     struct buf buf = BUF_INITIALIZER;
     struct dlist *new = NULL;
     dlist_printbuf(dl, 1, &buf);

--- a/imap/dlist.h
+++ b/imap/dlist.h
@@ -247,6 +247,8 @@ struct dlist *dlist_getkvchild_bykey(struct dlist *dl,
 
 void dlist_rename(struct dlist *dl, const char *name);
 
+struct dlist *dlist_copy(const struct dlist *dl);
+
 const char *dlist_lastkey(void);
 
 /* print a dlist iteratively rather than recursively */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4943,7 +4943,7 @@ static int meth_delete_collection(struct transaction_t *txn,
             /* Unsubscribe */
             r = mboxlist_changesub(txn->req_tgt.mbentry->name,
                                    txn->req_tgt.userid,
-                                   httpd_authstate, 0 /* remove */, 0, 0);
+                                   httpd_authstate, 0 /* remove */, 0, 0, 0);
             if (r) {
                 syslog(LOG_ERR, "mboxlist_changesub(%s, %s) failed: %s",
                        txn->req_tgt.mbentry->name, txn->req_tgt.userid,

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -385,7 +385,7 @@ static int _create_notify_collection(const char *userid, mbentry_t **mbentryp)
                                    1/*isadmin*/, userid, NULL/*authstate*/,
                                    0/*flags*/, NULL);
 
-        if (r) xsyslog(LOG_ERR, "IOERROR: failed to create notify collection"
+        if (r) xsyslog(LOG_ERR, "IOERROR: failed to create notify collection",
                       "mailbox=<%s> error=<%s>",
                       mbentry->name, error_message(r));
     }

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -318,7 +318,7 @@ static void my_dav_init(struct buf *serverinfo __attribute__((unused)))
 }
 
 
-int dav_lookup_notify_collection(const char *userid, mbentry_t **mbentry)
+int dav_lookup_notify_collection(const char *userid, mbentry_t **mbentryp)
 {
     mbname_t *mbname;
     const char *notifyname;
@@ -341,22 +341,22 @@ int dav_lookup_notify_collection(const char *userid, mbentry_t **mbentry)
 
     /* Locate the mailbox */
     notifyname = mbname_intname(mbname);
-    r = proxy_mlookup(notifyname, mbentry, NULL, NULL);
+    r = proxy_mlookup(notifyname, mbentryp, NULL, NULL);
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         /* Find location of INBOX */
         char *inboxname = mboxname_user_mbox(userid, NULL);
 
-        int r1 = proxy_mlookup(inboxname, mbentry, NULL, NULL);
+        int r1 = proxy_mlookup(inboxname, mbentryp, NULL, NULL);
         free(inboxname);
         if (r1 == IMAP_MAILBOX_NONEXISTENT) {
             r = IMAP_INVALID_USER;
             goto done;
         }
 
-        mboxlist_entry_free(mbentry);
-        *mbentry = mboxlist_entry_create();
-        (*mbentry)->name = xstrdup(notifyname);
-        (*mbentry)->mbtype = MBTYPE_COLLECTION;
+        mboxlist_entry_free(mbentryp);
+        *mbentryp = mboxlist_entry_create();
+        (*mbentryp)->name = xstrdup(notifyname);
+        (*mbentryp)->mbtype = MBTYPE_COLLECTION;
     }
 
   done:

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -1090,7 +1090,7 @@ HIDDEN int notify_post(struct transaction_t *txn)
 
     /* [Un]subscribe */
     r = mboxlist_changesub(mboxname, txn->req_tgt.userid,
-                           httpd_authstate, add, 0, 0);
+                           httpd_authstate, add, 0, 0, 0);
     if (r) {
         syslog(LOG_ERR, "mboxlist_changesub(%s, %s) failed: %s",
                mboxname, txn->req_tgt.userid, error_message(r));

--- a/imap/http_dav_sharing.h
+++ b/imap/http_dav_sharing.h
@@ -93,8 +93,9 @@ int dav_create_invite(xmlNodePtr *notify, xmlNsPtr *ns,
                       struct request_target_t *tgt,
                       const struct prop_entry *live_props,
                       const char *sharee, int access, xmlChar *content);
-int dav_send_notification(xmlDocPtr doc, struct dlist *extradata,
+int dav_schedule_notification(xmlDocPtr doc, struct dlist *extradata,
                           const char *userid, const char *resource);
+void dav_run_notifications();
 
 int dav_lookup_notify_collection(const char *userid, mbentry_t **mbentry);
 

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -630,7 +630,7 @@ static int jmap_getblob_default_handler(jmap_req_t *req,
     }
 
  done:
-    if (mbox) jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     if (body) {
         message_free_body(body);
         free(body);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8187,7 +8187,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
 
     if (!r && config_getswitch(IMAPOPT_DELETE_UNSUBSCRIBE)) {
         mboxlist_changesub(mbname_intname(mbname), imapd_userid, imapd_authstate,
-                           /* add */ 0, /* force */ 0, /* notify? */ 1);
+                           /* add */ 0, /* force */ 1, /* notify? */ 0, /*silent*/1);
     }
 
     mboxname_release(&namespacelock);
@@ -8292,7 +8292,7 @@ static int renmbox(const mbentry_t *mbentry, void *rock)
 
     if (!r && config_getswitch(IMAPOPT_DELETE_UNSUBSCRIBE)) {
         mboxlist_changesub(mbentry->name, imapd_userid, imapd_authstate,
-                           /* add */ 0, /* force */ 0, /* notify? */ 0);
+                           /* add */ 0, /* force */ 1, /* notify? */ 0, /*silent*/1);
     }
 
     oldextname =
@@ -8733,7 +8733,7 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location, 
 
         if (!r && config_getswitch(IMAPOPT_DELETE_UNSUBSCRIBE)) {
             mboxlist_changesub(oldmailboxname, imapd_userid, imapd_authstate,
-                               /* add */ 0, /* force */ 0, /* notify? */ 1);
+                               /* add */ 0, /* force */ 1, /* notify? */ 0, /*silent*/1);
         }
     }
 
@@ -9209,7 +9209,7 @@ static void cmd_changesub(char *tag, char *namespace, char *name, int add)
         }
         else {
             char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
-            r = mboxlist_changesub(intname, imapd_userid, imapd_authstate, add, force, 1);
+            r = mboxlist_changesub(intname, imapd_userid, imapd_authstate, add, force, 1, 0);
             free(intname);
         }
     }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8781,7 +8781,6 @@ submboxes:
 
     /* take care of deleting old quotas */
     if (!r && rename_user) {
-        user_sharee_renameacls(&imapd_namespace, olduser, newuser);
         user_deletequotaroots(olduser);
         sync_log_unuser(olduser);
     }
@@ -8826,6 +8825,9 @@ respond:
 done:
     mboxname_release(&oldnamespacelock);
     mboxname_release(&newnamespacelock);
+    // rename acls after the lock is dropped
+    if (!r && rename_user)
+        user_sharee_renameacls(&imapd_namespace, olduser, newuser);
     mboxlist_entry_free(&mbentry);
     if (oldname != orig_oldname) free(oldname);
     if (newname != orig_newname) free(newname);

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2725,7 +2725,7 @@ static void send_dav_invite(const char *userid, void *val, void *rock)
         if (!old || !new) {
             /* Change subscription */
             r = mboxlist_changesub(irock->mboxname, userid, httpd_authstate,
-                                   access != SHARE_NONE, 0, /*notify*/1);
+                                   access != SHARE_NONE, 0, /*notify*/1, /*silent*/0);
         }
 
         if (!r) {

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1053,19 +1053,14 @@ void jmap_add_id(jmap_req_t *req, const char *creation_id, const char *id)
     hash_insert(creation_id, xstrdup(id), req->created_ids);
 }
 
-HIDDEN int jmap_openmbox(jmap_req_t *req __attribute__((unused)), const char *name,
-                         struct mailbox **mboxp, int rw)
-{
-    return rw ? mailbox_open_iwl(name, mboxp) : mailbox_open_irl(name, mboxp);
-}
-
 HIDDEN int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,
                                      struct mailbox **mboxp, int rw)
 {
     const mbentry_t *mbentry = jmap_mbentry_by_uniqueid(req, id);
 
     if (mbentry)
-        return jmap_openmbox(req, mbentry->name, mboxp, rw);
+        return rw ? mailbox_open_iwl(mbentry->name, mboxp)
+                  : mailbox_open_irl(mbentry->name, mboxp);
     else
         return IMAP_MAILBOX_NONEXISTENT;
 }
@@ -1107,7 +1102,7 @@ static int findblob_cb(const conv_guidrec_t *rec, void *rock)
         }
     }
 
-    r = jmap_openmbox(req, mbentry->name, &d->mbox, 0);
+    r = mailbox_open_irl(mbentry->name, &d->mbox);
     mboxlist_entry_free(&mbentry);
     if (r) return r;
 

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2740,8 +2740,8 @@ static void send_dav_invite(const char *userid, void *val, void *rock)
             dlist_setatom(extradata, "OLD", rights);
             cyrus_acl_masktostr(change->newrights, rights);
             dlist_setatom(extradata, "NEW", rights);
-            r = dav_send_notification(irock->notify->doc, extradata,
-                    userid, buf_cstring(&irock->resource));
+            r = dav_schedule_notification(irock->notify->doc, extradata,
+                                          userid, buf_cstring(&irock->resource));
         }
     }
 }

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -839,6 +839,9 @@ HIDDEN int jmap_api(struct transaction_t *txn,
         }
         conversations_commit(&req.cstate);
 
+	// run any notification updates after conversations are released
+	dav_run_notifications();
+
         json_decref(args);
     }
 

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1053,21 +1053,10 @@ void jmap_add_id(jmap_req_t *req, const char *creation_id, const char *id)
     hash_insert(creation_id, xstrdup(id), req->created_ids);
 }
 
-HIDDEN int jmap_openmbox(jmap_req_t *req, const char *name,
+HIDDEN int jmap_openmbox(jmap_req_t *req __attribute__((unused)), const char *name,
                          struct mailbox **mboxp, int rw)
 {
-    int r;
-
-    /* Add mailbox to cache */
-    if (req->force_openmbox_rw)
-        rw = 1;
-    r = rw ? mailbox_open_iwl(name, mboxp) : mailbox_open_irl(name, mboxp);
-    if (r) {
-        syslog(LOG_ERR, "jmap_openmbox(%s): %s", name, error_message(r));
-        return r;
-    }
-
-    return 0;
+    return rw ? mailbox_open_iwl(name, mboxp) : mailbox_open_irl(name, mboxp);
 }
 
 HIDDEN int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1081,11 +1081,6 @@ HIDDEN int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,
         return IMAP_MAILBOX_NONEXISTENT;
 }
 
-HIDDEN void jmap_closembox(jmap_req_t *req __attribute__((unused)), struct mailbox **mboxp)
-{
-    mailbox_close(mboxp);
-}
-
 struct findblob_data {
     jmap_req_t *req;
     const char *from_accountid;
@@ -1129,7 +1124,7 @@ static int findblob_cb(const conv_guidrec_t *rec, void *rock)
 
     r = msgrecord_find(d->mbox, rec->uid, &d->mr);
     if (r) {
-        jmap_closembox(req, &d->mbox);
+        mailbox_close(&d->mbox);
         d->mr = NULL;
         return r;
     }
@@ -1247,7 +1242,7 @@ done:
         conversations_commit(&mycstate);
     }
     if (r) {
-        if (data.mbox) jmap_closembox(req, &data.mbox);
+        mailbox_close(&data.mbox);
         if (mybody) {
             message_free_body(mybody);
             free(mybody);

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -165,7 +165,6 @@ typedef struct jmap_req {
     int force_openmbox_rw;
 
     /* Internal state */
-    ptrarray_t *mboxes;
     hash_table *mbstates;
     hash_table *created_ids;
     hash_table *inmemory_blobs;
@@ -278,11 +277,10 @@ extern void jmap_admin_capabilities(json_t *account_capabilities);
 extern void jmap_accounts(json_t *accounts, json_t *primary_accounts);
 
 /* Request-scoped mailbox cache */
-extern int  jmap_openmbox(jmap_req_t *req, const char *name,
-                          struct mailbox **mboxp, int rw);
+extern int jmap_openmbox(jmap_req_t *req, const char *name,
+                         struct mailbox **mboxp, int rw);
 extern int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,
                                      struct mailbox **mboxp, int rw);
-extern int  jmap_isopenmbox(jmap_req_t *req, const char *name);
 extern void jmap_closembox(jmap_req_t *req, struct mailbox **mboxp);
 
 extern int jmap_mboxlist_lookup(const char *name,

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -265,8 +265,6 @@ extern void jmap_admin_capabilities(json_t *account_capabilities);
 extern void jmap_accounts(json_t *accounts, json_t *primary_accounts);
 
 /* Request-scoped mailbox cache */
-extern int jmap_openmbox(jmap_req_t *req, const char *name,
-                         struct mailbox **mboxp, int rw);
 extern int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,
                                      struct mailbox **mboxp, int rw);
 extern int jmap_mboxlist_lookup(const char *name,

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -152,18 +152,6 @@ typedef struct jmap_req {
     double sys_start;
     json_t *perf_details;
 
-    /* The JMAP request keeps its own cache of opened mailboxes,
-     * which can be used by calling jmap_openmbox. If the
-     * force_openmboxrw is set, this causes all following
-     * mailboxes to be opened read-writeable, irrespective if
-     * the caller asked for a read-only lock. This allows to
-     * prevent lock promotion conflicts, in case a cached mailbox
-     * was opened read-only by a helper but it now asked to be
-     * locked exclusively. Since the mailbox lock does not
-     * support lock promition, this would currently abort with
-     * an error. */
-    int force_openmbox_rw;
-
     /* Internal state */
     hash_table *mbstates;
     hash_table *created_ids;

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -281,8 +281,6 @@ extern int jmap_openmbox(jmap_req_t *req, const char *name,
                          struct mailbox **mboxp, int rw);
 extern int jmap_openmbox_by_uniqueid(jmap_req_t *req, const char *id,
                                      struct mailbox **mboxp, int rw);
-extern void jmap_closembox(jmap_req_t *req, struct mailbox **mboxp);
-
 extern int jmap_mboxlist_lookup(const char *name,
                                 mbentry_t **entryptr, struct txn **tid);
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1774,7 +1774,7 @@ static int set_scheddefault(jmap_req_t *req, annotate_state_t *astate, const cha
             else
                 r = IMAP_PERMISSION_DENIED;
         }
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
         free(mboxname);
     }
     else {
@@ -1924,7 +1924,7 @@ done:
             *err = jmap_server_error(r);
         }
     }
-    jmap_closembox(req, &calhome_mbox);
+    mailbox_close(&calhome_mbox);
     free(calhome_name);
     free(mboxname);
     free(defaultname);
@@ -2058,7 +2058,7 @@ static void setcalendars_create(struct jmap_req *req,
                 "mboxname=<%s> err=<%s>",
                 mboxname, error_message(r));
         mailbox_abort(mbox);
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
         int rr = mboxlist_deletemailbox(mboxname, 1, "", NULL, NULL, 0);
         if (rr) {
             syslog(LOG_ERR, "could not delete mailbox %s: %s",
@@ -2140,7 +2140,7 @@ static void setcalendars_update(jmap_req_t *req,
                     "mboxname=<%s> err=<%s>",
                     mboxname, error_message(r));
             mailbox_abort(mbox);
-            jmap_closembox(req, &mbox);
+            mailbox_close(&mbox);
         }
     }
     if (r) {
@@ -2163,7 +2163,7 @@ static void setcalendars_update(jmap_req_t *req,
 
 done:
     setcalendar_props_fini(&props);
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     jmap_parser_fini(&parser);
     mbname_free(&mbname);
     free(mboxname);
@@ -2594,7 +2594,7 @@ done:
         ctx->errstr = desc;
     }
     if (ical) icalcomponent_free(ical);
-    if (mailbox) jmap_closembox(req, &mailbox);
+    mailbox_close(&mailbox);
     mboxlist_entry_free(&freeme);
     free(mboxid);
     free(partid);
@@ -2957,7 +2957,7 @@ static int getcalendarevents_getinstances(json_t *jsevent,
             if (!ical) {
                 /* Open calendar mailbox. */
                 if (!rock->mailbox || strcmp(mailbox_name(rock->mailbox), mbentry->name)) {
-                    jmap_closembox(req, &rock->mailbox);
+                    mailbox_close(&rock->mailbox);
                     r = jmap_openmbox(req, mbentry->name, &rock->mailbox, 0);
                     if (r) goto done;
                 }
@@ -3368,7 +3368,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
 
         /* Open calendar mailbox. */
         if (!rock->mailbox || strcmp(mailbox_uniqueid(rock->mailbox), rock->mbentry->uniqueid)) {
-            jmap_closembox(req, &rock->mailbox);
+            mailbox_close(&rock->mailbox);
             r = jmap_openmbox_by_uniqueid(req, rock->mbentry->uniqueid, &rock->mailbox, 0);
             if (r) goto done;
         }
@@ -4107,7 +4107,7 @@ done:
     jmap_parser_fini(&parser);
     jmap_get_fini(&get);
     if (db) caldav_close(db);
-    if (rock.mailbox) jmap_closembox(req, &rock.mailbox);
+    mailbox_close(&rock.mailbox);
     if (rock.mbentry) mboxlist_entry_free(&rock.mbentry);
     if (rock.mbname) mbname_free(&rock.mbname);
     if (rock.ical) icalcomponent_free(rock.ical);
@@ -4556,7 +4556,7 @@ static int createevent_load_ical(jmap_req_t *req,
                 srcical = NULL;
             }
 
-            jmap_closembox(req, &srcmbox);
+            mailbox_close(&srcmbox);
         }
 
         if (!create->resourcename) {
@@ -4723,7 +4723,7 @@ static int createevent_store(jmap_req_t *req,
 
 done:
     spool_free_hdrcache(txn.req_hdrs);
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     buf_free(&txn.buf);
     buf_free(&buf);
     return r;
@@ -5690,7 +5690,7 @@ static void setcalendarevents_update(jmap_req_t *req,
         if (r) {
             syslog(LOG_ERR, "mailbox_rewrite_index_record (%s) failed: %s",
                     cdata->dav.mailbox, error_message(r));
-            jmap_closembox(req, &mbox);
+            mailbox_close(&mbox);
             goto done;
         }
         mboxevent_extract_record(mboxevent, mbox, &record);
@@ -5702,7 +5702,7 @@ static void setcalendarevents_update(jmap_req_t *req,
         mboxevent_free(&mboxevent);
 
         /* Close the mailbox we moved the event from. */
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
         mbox = dstmbox;
         dstmbox = NULL;
     }
@@ -5820,8 +5820,8 @@ done:
     json_decref(update.event_patch);
     jstimezones_free(&update.jstzones);
 
-    if (mbox) jmap_closembox(req, &mbox);
-    if (dstmbox) jmap_closembox(req, &dstmbox);
+    mailbox_close(&mbox);
+    mailbox_close(&dstmbox);
     jmap_parser_fini(&parser);
     strarray_fini(&del_imapflags);
     strarray_fini(&schedule_addresses);
@@ -6059,7 +6059,7 @@ static int setcalendarevents_destroy(jmap_req_t *req,
         if (r) {
             syslog(LOG_ERR, "mailbox_rewrite_index_record (%s) failed: %s",
                     cdata->dav.mailbox, error_message(r));
-            jmap_closembox(req, &mbox);
+            mailbox_close(&mbox);
             goto done;
         }
     }
@@ -6109,7 +6109,7 @@ static int setcalendarevents_destroy(jmap_req_t *req,
                          is_standalone_instance ? eid->ical_recurid : NULL);
 
 done:
-    if (mbox) jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     if (oldical) icalcomponent_free(oldical);
     if (newical) icalcomponent_free(newical);
     json_decref(old_event);
@@ -6336,8 +6336,8 @@ static int jmap_calendarevent_set(struct jmap_req *req)
     jmap_ok(req, jmap_set_reply(&set));
 
 done:
-    jmap_closembox(req, &schedinbox);
-    jmap_closembox(req, &notifmbox);
+    mailbox_close(&schedinbox);
+    mailbox_close(&notifmbox);
     mboxlist_entry_free(&notifmb);
     jmap_parser_fini(&parser);
     jmap_set_fini(&set);
@@ -6695,9 +6695,7 @@ static int eventquery_cb(void *vrock, struct caldav_jscal *jscal)
     else if (rock->expandrecur) {
         /* Load iCalendar data for main event */
         if (!rock->mailbox || strcmp(mailbox_name(rock->mailbox), mbentry->name)) {
-            if (rock->mailbox) {
-                jmap_closembox(req, &rock->mailbox);
-            }
+            mailbox_close(&rock->mailbox);
             r = jmap_openmbox(req, mbentry->name, &rock->mailbox, 0);
             if (r) goto done;
         }
@@ -6937,7 +6935,7 @@ static int eventquery_textsearch_run(jmap_req_t *req,
 
         if (expandrecur) {
             if (!mailbox || strcmp(mailbox_name(mailbox), mbentry->name)) {
-                if (mailbox) jmap_closembox(req, &mailbox);
+                mailbox_close(&mailbox);
                 r = jmap_openmbox(req, mbentry->name, &mailbox, 0);
                 if (r) goto done;
             }
@@ -6972,7 +6970,7 @@ done:
     if (searchargs) freesearchargs(searchargs);
     if (sortcrit) freesortcrit(sortcrit);
     if (query) search_query_free(query);
-    jmap_closembox(req, &mailbox);
+    mailbox_close(&mailbox);
     free(sched_inboxname);
     free(icalbefore);
     free(icalafter);
@@ -7297,7 +7295,7 @@ static int eventquery_run(jmap_req_t *req,
                                      args.expandrecur ? &mboxsort : sort,
                                      args.expandrecur ? 1 : nsort,
                                      eventquery_cb, &rock);
-        jmap_closembox(req, &rock.mailbox);
+        mailbox_close(&rock.mailbox);
         if (r_db) goto done;
     }
 
@@ -7675,7 +7673,7 @@ done:
         return;
     }
     mboxlist_entry_free(&mbentry);
-    jmap_closembox(req, &src_mbox);
+    mailbox_close(&src_mbox);
     strarray_fini(&schedule_addresses);
     if (src_ical) icalcomponent_free(src_ical);
     json_decref(dst_event);
@@ -7757,7 +7755,7 @@ static int jmap_calendarevent_copy(struct jmap_req *req)
     }
 
 done:
-    jmap_closembox(req, &notifmbox);
+    mailbox_close(&notifmbox);
     mboxlist_entry_free(&notifmb);
     json_decref(destroy_events);
     if (src_db) caldav_close(src_db);
@@ -8040,7 +8038,7 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
         r = IMAP_INTERNAL;
         goto done;
     }
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
 
     /* Find participantId */
     icalcomponent *comp = icalcomponent_get_first_real_component(update.oldical);
@@ -8201,7 +8199,7 @@ done:
     jmap_parser_fini(&parser);
     jmap_caleventid_free(&update.eid);
     if (db) caldav_close(db);
-    if (mbox) jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     if (update.oldical) icalcomponent_free(update.oldical);
     if (update.newical) icalcomponent_free(update.newical);
     jstimezones_free(&update.jstzones);
@@ -8458,7 +8456,7 @@ static int principal_state_init(jmap_req_t *req, SHA1_CTX *sha1)
         SHA1Update(sha1, buf_base(&buf), buf_len(&buf));
         buf_free(&buf);
     }
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     free(calhomename);
     return r;
 }
@@ -9181,7 +9179,7 @@ static int jmap_principal_set(struct jmap_req *req)
                         buf_free(&val);
                     }
                 }
-                jmap_closembox(req, &mbox);
+                mailbox_close(&mbox);
                 free(calhomename);
                 if (!r) {
                     json_object_set_new(set.updated, id, json_object());
@@ -9379,9 +9377,7 @@ static int principal_getavailability_cb(void *vrock, struct caldav_jscal *jscal)
 
     if (!rock->mbox || strcmp(mailbox_uniqueid(rock->mbox), rock->mbentry->uniqueid)) {
         /* reset state for calendar collection */
-        if (rock->mbox) {
-            jmap_closembox(rock->req, &rock->mbox);
-        }
+        mailbox_close(&rock->mbox);
         if (rock->floatingtz) {
             icaltimezone_free(rock->floatingtz, 1);
             rock->floatingtz = NULL;
@@ -9559,9 +9555,7 @@ static void principal_getavailability(jmap_req_t *req,
                                  principal_getavailability_cb, &rock);
     caldav_jscal_filter_fini(&jscal_filter);
     if (r) jmap_error(req, jmap_server_error(r));
-    if (rock.mbox) {
-        jmap_closembox(req, &rock.mbox);
-    }
+    mailbox_close(&rock.mbox);
     if (rock.mbentry) {
         mboxlist_entry_free(&rock.mbentry);
     }
@@ -10083,7 +10077,7 @@ static void notif_get(struct jmap_req *req,
     }
 
 done:
-    jmap_closembox(req, &notifmbox);
+    mailbox_close(&notifmbox);
     seqset_free(&seenuids);
 }
 
@@ -10217,7 +10211,7 @@ static void notif_set(struct jmap_req *req,
 done:
     seqset_free(&seenuids);
     seen_close(&seendb);
-    jmap_closembox(req, &notifmbox);
+    mailbox_close(&notifmbox);
     buf_free(&buf);
 }
 
@@ -10287,7 +10281,7 @@ static void notif_changes(struct jmap_req *req,
 
 done:
     dynarray_free(&entries);
-    jmap_closembox(req, &notifmbox);
+    mailbox_close(&notifmbox);
 }
 
 
@@ -10878,7 +10872,7 @@ static int jmap_sharenotification_query(struct jmap_req *req)
     jmap_ok(req, res);
 
 done:
-    jmap_closembox(req, &notifmbox);
+    mailbox_close(&notifmbox);
     mboxlist_entry_free(&notifmb);
     jmap_query_fini(&query);
     jmap_parser_fini(&parser);
@@ -11346,7 +11340,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
 
 done:
     if (eventids.size) free_hash_table(&eventids, NULL);
-    jmap_closembox(req, &notifmbox);
+    mailbox_close(&notifmbox);
     jmap_query_fini(&query);
     jmap_parser_fini(&parser);
     return 0;
@@ -12023,7 +12017,7 @@ done:
     if (r && *err == NULL) {
         *err = jmap_server_error(r);
     }
-    jmap_closembox(req, &calhomembox);
+    mailbox_close(&calhomembox);
     json_decref(jalertsprefs);
     buf_free(&buf);
 }

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1653,7 +1653,7 @@ static int setcalendar_writeprops(jmap_req_t *req,
     if (!r && props->isSubscribed >= 0) {
         /* Update subscription database */
         r = mboxlist_changesub(mailbox_name(mbox), req->userid, req->authstate,
-                               props->isSubscribed, 0, /*notify*/1);
+                               props->isSubscribed, 0, /*notify*/1, /*silent*/0);
 
         /* Set invite status for CalDAV */
         buf_setcstr(&val, props->isSubscribed ? "invite-accepted" : "invite-declined");
@@ -1858,7 +1858,7 @@ static void setcalendars_destroy(jmap_req_t *req, const char *calid,
     jmap_myrights_delete(req, mboxname);
 
     /* Remove from subscriptions db */
-    mboxlist_changesub(mboxname, req->userid, req->authstate, 0, 1, 0);
+    mboxlist_changesub(mboxname, req->userid, req->authstate, 0, 1, 0, 1);
 
     struct mboxevent *mboxevent = mboxevent_new(EVENT_MAILBOX_DELETE);
     if (mboxlist_delayed_delete_isenabled()) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -2308,6 +2308,7 @@ static int jmap_calendar_set(struct jmap_req *req)
 
 done:
     mboxname_release(&namespacelock);
+    dav_run_notifications(); // after releasing lock
     jmap_parser_fini(&argparser);
     jmap_set_fini(&set);
     return r;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -2308,7 +2308,6 @@ static int jmap_calendar_set(struct jmap_req *req)
 
 done:
     mboxname_release(&namespacelock);
-    dav_run_notifications(); // after releasing lock
     jmap_parser_fini(&argparser);
     jmap_set_fini(&set);
     return r;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1041,7 +1041,7 @@ static int jmap_calendar_get(struct jmap_req *req)
                 }
             }
 
-            if (mbentry) mboxlist_entry_free(&mbentry);
+            mboxlist_entry_free(&mbentry);
             free(mboxname);
             if (r) goto done;
         }
@@ -4108,8 +4108,8 @@ done:
     jmap_get_fini(&get);
     if (db) caldav_close(db);
     mailbox_close(&rock.mailbox);
-    if (rock.mbentry) mboxlist_entry_free(&rock.mbentry);
-    if (rock.mbname) mbname_free(&rock.mbname);
+    mboxlist_entry_free(&rock.mbentry);
+    mbname_free(&rock.mbname);
     if (rock.ical) icalcomponent_free(rock.ical);
     if (rock.ical_instances_by_recurid.size)
         free_hash_table(&rock.ical_instances_by_recurid, _icalcomponent_free_cb);
@@ -9556,9 +9556,7 @@ static void principal_getavailability(jmap_req_t *req,
     caldav_jscal_filter_fini(&jscal_filter);
     if (r) jmap_error(req, jmap_server_error(r));
     mailbox_close(&rock.mbox);
-    if (rock.mbentry) {
-        mboxlist_entry_free(&rock.mbentry);
-    }
+    mboxlist_entry_free(&rock.mbentry);
     if (rock.floatingtz) {
         icaltimezone_free(rock.floatingtz, 1);
         rock.floatingtz = NULL;

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -5111,7 +5111,7 @@ static int setaddressbook_writeprops(jmap_req_t *req,
     if (!r && props->isSubscribed >= 0) {
         /* Update subscription database */
         r = mboxlist_changesub(mboxname, req->userid, req->authstate,
-                               props->isSubscribed, 0, /*notify*/1);
+                               props->isSubscribed, 0, /*notify*/1, /*silent*/0);
 
         /* Set invite status for CalDAV */
         buf_setcstr(&val, props->isSubscribed ? "invite-accepted" : "invite-declined");
@@ -5207,7 +5207,7 @@ static void setaddressbooks_destroy(jmap_req_t *req, const char *abookid,
     jmap_myrights_delete(req, mboxname);
 
     /* Remove from subscriptions db */
-    mboxlist_changesub(mboxname, req->userid, req->authstate, 0, 1, 0);
+    mboxlist_changesub(mboxname, req->userid, req->authstate, 0, 1, 0, 1);
 
     struct mboxevent *mboxevent = mboxevent_new(EVENT_MAILBOX_DELETE);
     if (mboxlist_delayed_delete_isenabled()) {

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -59,6 +59,7 @@
 #include "hash.h"
 #include "http_carddav.h"
 #include "http_dav.h"
+#include "http_dav_sharing.h"
 #include "http_jmap.h"
 #include "json_support.h"
 #include "mailbox.h"
@@ -5546,6 +5547,7 @@ static int jmap_addressbook_set(struct jmap_req *req)
 
 done:
     mboxname_release(&namespacelock);
+    dav_run_notifications();
     jmap_parser_fini(&argparser);
     jmap_set_fini(&set);
     return r;

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -11873,7 +11873,7 @@ static int jmap_contact_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx)
     }
 
     /* Open mailbox, we need it now */
-    r = mailbox_open_iwl(mbentry->name, &mailbox);
+    r = mailbox_open_irl(mbentry->name, &mailbox);
     if (r) {
         ctx->errstr = error_message(r);
         res = HTTP_SERVER_ERROR;

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1281,7 +1281,7 @@ static void _contacts_set(struct jmap_req *req, unsigned kind,
         }
 
         if (!mailbox || strcmp(mailbox_name(mailbox), mbentry->name)) {
-            jmap_closembox(req, &mailbox);
+            mailbox_close(&mailbox);
             r = jmap_openmbox(req, mbentry->name, &mailbox, 1);
         }
         mboxlist_entry_free(&mbentry);
@@ -1315,8 +1315,8 @@ done:
     if (r) jmap_error(req, jmap_server_error(r));
     jmap_parser_fini(&parser);
     jmap_set_fini(&set);
-    jmap_closembox(req, &newmailbox);
-    jmap_closembox(req, &mailbox);
+    mailbox_close(&newmailbox);
+    mailbox_close(&mailbox);
 
     carddav_close(db);
 }
@@ -4045,7 +4045,7 @@ static int _contact_set_create(jmap_req_t *req, unsigned kind, json_t *jcard,
 
     /* we need to create and append a record */
     if (!*mailbox || strcmp(mailbox_name(*mailbox), mboxname)) {
-        jmap_closembox(req, mailbox);
+        mailbox_close(mailbox);
         r = jmap_openmbox(req, mboxname, mailbox, 1);
         if (r == IMAP_MAILBOX_NONEXISTENT) {
             json_array_append_new(invalid, json_string("addressbookId"));
@@ -4202,7 +4202,7 @@ static int _contact_set_update(jmap_req_t *req, unsigned kind,
     }
 
     if (!*mailbox || strcmp(mailbox_name(*mailbox), mbentry->name)) {
-        jmap_closembox(req, mailbox);
+        mailbox_close(mailbox);
         r = jmap_openmbox(req, mbentry->name, mailbox, 1);
     }
     if (r) {
@@ -4371,7 +4371,7 @@ static int _contact_set_update(jmap_req_t *req, unsigned kind,
 
   done:
     mboxlist_entry_free(&mbentry);
-    jmap_closembox(req, &newmailbox);
+    mailbox_close(&newmailbox);
     strarray_free(flags);
     freeentryatts(annots);
     vparse_free_card(vcard);
@@ -4500,8 +4500,8 @@ done:
             *set_err = jmap_server_error(r);
     }
     mboxlist_entry_free(&mbentry);
-    jmap_closembox(req, &dst_mbox);
-    jmap_closembox(req, &src_mbox);
+    mailbox_close(&dst_mbox);
+    mailbox_close(&src_mbox);
     json_decref(dst_card);
     jmap_parser_fini(&myparser);
 }
@@ -5134,7 +5134,7 @@ static int setaddressbook_writeprops(jmap_req_t *req,
     buf_free(&val);
     if (mbox) {
         if (r) mailbox_abort(mbox);
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
     }
     return r;
 }
@@ -11109,7 +11109,7 @@ static int _card_set_create(jmap_req_t *req,
 
     /* we need to create and append a record */
     if (!*mailbox || strcmp(mailbox_name(*mailbox), mboxname)) {
-        jmap_closembox(req, mailbox);
+        mailbox_close(mailbox);
         r = jmap_openmbox(req, mboxname, mailbox, 1);
         if (r == IMAP_MAILBOX_NONEXISTENT) {
             json_array_append_new(invalid, json_string("addressbookId"));
@@ -11289,7 +11289,7 @@ static int _card_set_update(jmap_req_t *req, unsigned kind,
     }
 
     if (!*mailbox || strcmp(mailbox_name(*mailbox), mbentry->name)) {
-        jmap_closembox(req, mailbox);
+        mailbox_close(mailbox);
         r = jmap_openmbox(req, mbentry->name, mailbox, 1);
     }
     if (r) {
@@ -11457,7 +11457,7 @@ static int _card_set_update(jmap_req_t *req, unsigned kind,
 
   done:
     mboxlist_entry_free(&mbentry);
-    jmap_closembox(req, &newmailbox);
+    mailbox_close(&newmailbox);
     freeentryatts(annots);
     vcardcomponent_free(vcard);
     free(resource);
@@ -11662,7 +11662,7 @@ static int jmap_card_parse(jmap_req_t *req)
             json_array_append_new(parse.not_parsable, json_string(blobid));
         }
 
-        if (mailbox) jmap_closembox(req, &mailbox);
+        mailbox_close(&mailbox);
     }
 
     jmap_getblob_ctx_fini(&blob_ctx);
@@ -11823,7 +11823,7 @@ done:
         ctx->errstr = desc;
     }
     if (vcard) vcardcomponent_free(vcard);
-    if (mailbox) jmap_closembox(req, &mailbox);
+    mailbox_close(&mailbox);
     mboxlist_entry_free(&freeme);
     free(mboxid);
     free(propname);
@@ -11955,7 +11955,7 @@ done:
         ctx->errstr = desc;
     }
     if (vcard) vparse_free_card(vcard);
-    if (mailbox) jmap_closembox(req, &mailbox);
+    mailbox_close(&mailbox);
     mboxlist_entry_free(&freeme);
     free(mboxid);
     free(prop);

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -4838,7 +4838,7 @@ static int jmap_addressbook_get(struct jmap_req *req)
                 }
             }
 
-            if (mbentry) mboxlist_entry_free(&mbentry);
+            mboxlist_entry_free(&mbentry);
             free(mboxname);
             if (r) goto done;
         }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -5573,7 +5573,6 @@ static int jmap_addressbook_set(struct jmap_req *req)
 
 done:
     mboxname_release(&namespacelock);
-    dav_run_notifications();
     jmap_parser_fini(&argparser);
     jmap_set_fini(&set);
     return r;

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -77,7 +77,7 @@ static jmap_method_t jmap_core_methods_standard[] = {
         "Blob/copy",
         JMAP_URN_CORE,
         &jmap_blob_copy,
-        JMAP_NEED_CSTATE | JMAP_READ_WRITE
+        JMAP_READ_WRITE // no conversations, we need to get lock ordering first
     },
     {
         "Core/echo",
@@ -357,11 +357,35 @@ static int jmap_blob_copy(jmap_req_t *req)
     size_t i = 0;
     int r = 0;
     struct mailbox *to_mbox = NULL;
+    struct mboxlock *srcnamespacelock = NULL;
+    struct mboxlock *dstnamespacelock = NULL;
 
     /* Parse request */
     jmap_copy_parse(req, &parser, NULL, NULL, &copy, &err);
     if (err) {
         jmap_error(req, err);
+        goto cleanup;
+    }
+
+    char *srcinbox = mboxname_user_mbox(copy.from_account_id, NULL);
+    char *dstinbox = mboxname_user_mbox(req->accountid, NULL);
+    if (strcmp(srcinbox, dstinbox) < 0) {
+        srcnamespacelock = mboxname_usernamespacelock(srcinbox);
+        dstnamespacelock = mboxname_usernamespacelock(dstinbox);
+    }
+    else {
+        dstnamespacelock = mboxname_usernamespacelock(dstinbox);
+        srcnamespacelock = mboxname_usernamespacelock(srcinbox);
+    }
+    free(srcinbox);
+    free(dstinbox);
+
+    // now we can open the cstate
+    r = conversations_open_user(req->accountid, 0, &req->cstate);
+    if (r) {
+        syslog(LOG_ERR, "jmap_email_copy: can't open converstaions: %s",
+                        error_message(r));
+        jmap_error(req, jmap_server_error(r));
         goto cleanup;
     }
 
@@ -397,9 +421,11 @@ done:
     r = 0;
 
 cleanup:
+    mailbox_close(&to_mbox);
+    mboxname_release(&srcnamespacelock);
+    mboxname_release(&dstnamespacelock);
     jmap_parser_fini(&parser);
     jmap_copy_fini(&copy);
-    mailbox_close(&to_mbox);
     return r;
 }
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -832,7 +832,7 @@ static int jmap_blob_lookup(jmap_req_t *req)
             r = IMAP_PERMISSION_DENIED;
         }
         else {
-            r = jmap_openmbox(req, mbentry->name, &mbox, 0);
+            r = mailbox_open_irl(mbentry->name, &mbox);
             if (r) {
                 syslog(LOG_ERR, "jmap_blob_get: can't open mailbox %s: %s",
                        mbentry->name, error_message(r));

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -344,7 +344,7 @@ done:
     message_free_body(body);
     free(body);
     msgrecord_unref(&mr);
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     return r;
 }
 
@@ -946,7 +946,7 @@ static int jmap_blob_lookup(jmap_req_t *req)
         if (caldav_db) caldav_close(caldav_db);
         if (carddav_db) carddav_close(carddav_db);
         mbname_free(&mbname);
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
     }
 
     /* Clean up memory */

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -425,7 +425,7 @@ done:
         message_free_body(body);
         free(body);
     }
-    jmap_closembox(req, &srcmbox);
+    mailbox_close(&srcmbox);
     msgrecord_unref(&mr);
     buf_free(&preamble);
     return r;
@@ -457,7 +457,7 @@ HIDDEN int jmapical_context_open_attachments(struct jmapical_ctx *jmapctx)
         if (!jmapctx->attachments.db) {
             xsyslog(LOG_ERR, "mailbox_open_webdav failed",
                     "attachments=<%s>", mailbox_name(jmapctx->attachments.mbox));
-            jmap_closembox(req, &jmapctx->attachments.mbox);
+            mailbox_close(&jmapctx->attachments.mbox);
             jmapctx->attachments.db = NULL;
             jmapctx->attachments.err = IMAP_INTERNAL;
             return jmapctx->attachments.err;
@@ -558,8 +558,7 @@ HIDDEN void jmapical_context_free(struct jmapical_ctx **jmapctxp)
     if (!jmapctx) return;
 
 #ifndef BUILD_LMTPD
-    if (jmapctx->attachments.mbox)
-        jmap_closembox(jmapctx->req, &jmapctx->attachments.mbox);
+    mailbox_close(&jmapctx->attachments.mbox);
     if (jmapctx->attachments.db)
         webdav_close(jmapctx->attachments.db);
 #endif // BUILD_LMTPD

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -440,8 +440,9 @@ HIDDEN int jmapical_context_open_attachments(struct jmapical_ctx *jmapctx)
 
     if (!jmapctx->attachments.mbox) {
         char *mboxname = caldav_mboxname(req->accountid, MANAGED_ATTACH);
-        int r = jmap_openmbox(req, mboxname, &jmapctx->attachments.mbox,
-                jmapctx->attachments.lock);
+	int rw = jmapctx->attachments.lock;
+        int r = rw ? mailbox_open_iwl(mboxname, &jmapctx->attachments.mbox)
+                   : mailbox_open_irl(mboxname, &jmapctx->attachments.mbox);
         if (r) {
             xsyslog(LOG_ERR, "can't open attachments",
                     "mboxname=<%s> err<%s>", mboxname, error_message(r));

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -13227,9 +13227,6 @@ static void _email_import(jmap_req_t *req,
     int has_attachment = 0;
     const char *sourcefile = NULL;
 
-    /* Force write locks on mailboxes. */
-    req->force_openmbox_rw = 1;
-
     /* Gather keywords */
     strarray_t keywords = STRARRAY_INITIALIZER;
     const json_t *val;
@@ -13361,6 +13358,9 @@ gotrecord:
     }
     if (!internaldate)
         internaldate = time(NULL);
+
+    // mailbox will be readonly, drop the lock so it can be make writable
+    if (mbox) mailbox_unlock_index(mbox, NULL);
 
     /* Write the message to the file system */
     _email_append(req, jmailbox_ids, &keywords, internaldate, snoozed,

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -667,7 +667,7 @@ static void _emailsubmission_create(jmap_req_t *req,
     }
 
     /* Open the mailboxes */
-    r = jmap_openmbox(req, mboxname, &mbox, 1);
+    r = mailbox_open_iwl(mboxname, &mbox);
     if (r) goto done;
 
     /* Load the message */
@@ -1329,7 +1329,7 @@ static int jmap_emailsubmission_get(jmap_req_t *req)
         goto done;
     }
     else {
-        r = jmap_openmbox(req, mbentry->name, &mbox, 0);
+        r = mailbox_open_irl(mbentry->name, &mbox);
     }
     mboxlist_entry_free(&mbentry);
     if (r) goto done;
@@ -1509,7 +1509,7 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
         goto done;
     }
 
-    r = jmap_openmbox(req, mbentry->name, &submbox, 1);
+    r = mailbox_open_iwl(mbentry->name, &submbox);
     assert(submbox);
     mboxlist_entry_free(&mbentry);
     if (r) goto done;
@@ -1682,7 +1682,7 @@ static int jmap_emailsubmission_changes(jmap_req_t *req)
         goto done;
     }
 
-    r = jmap_openmbox(req, mbentry->name, &mbox, 0);
+    r = mailbox_open_irl(mbentry->name, &mbox);
     mboxlist_entry_free(&mbentry);
     if (r) goto done;
 
@@ -2147,7 +2147,7 @@ static int jmap_emailsubmission_query(jmap_req_t *req)
         goto done;
     }
 
-    r = jmap_openmbox(req, mbentry->name, &mbox, 0);
+    r = mailbox_open_irl(mbentry->name, &mbox);
     mboxlist_entry_free(&mbentry);
     if (r) goto done;
 

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -793,7 +793,7 @@ static void _emailsubmission_create(jmap_req_t *req,
      * message open. But we don't want to long-lock the
      * mailbox while sending the mail over to a SMTP host */
     msgrecord_unref(&mr);
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
 
     if (!*sm) {
         /* Open the SMTP connection */
@@ -917,7 +917,7 @@ done:
     if (fd_msg != -1) close(fd_msg);
     if (msg) json_decref(msg);
     if (mr) msgrecord_unref(&mr);
-    if (mbox) jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     if (myenvelope) json_decref(myenvelope);
     free(mboxname);
     buf_free(&buf);
@@ -1370,7 +1370,7 @@ static int jmap_emailsubmission_get(jmap_req_t *req)
         mailbox_iter_done(&iter);
     }
 
-    if (mbox) jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
 
     /* Build response */
     get.state = modseqtoa(jmap_modseq(req, MBTYPE_JMAPSUBMIT,
@@ -1645,7 +1645,7 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
     }
 
 done:
-    jmap_closembox(req, &submbox);
+    mailbox_close(&submbox);
     jmap_parser_fini(&parser);
     jmap_set_fini(&set);
     json_decref(success_emailids);
@@ -1723,7 +1723,7 @@ static int jmap_emailsubmission_changes(jmap_req_t *req)
     }
     mailbox_iter_done(&iter);
 
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
 
     /* Set new state */
     // XXX - this is wrong!  If we want to do this, we need to sort all the changes by
@@ -2206,7 +2206,7 @@ static int jmap_emailsubmission_query(jmap_req_t *req)
     }
     mailbox_iter_done(&iter);
 
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
 
     /* Sort results */
     if (sortcrit) {

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -2335,7 +2335,7 @@ static void _mbox_create(jmap_req_t *req, struct mboxset_args *args,
     /* Write annotations and isSubscribed */
     r = _mbox_set_annots(req, args, mboxname);
     if (!r && args->is_subscribed > 0) {
-        r = mboxlist_changesub(mboxname, req->userid, httpd_authstate, 1, 0, 0);
+        r = mboxlist_changesub(mboxname, req->userid, httpd_authstate, 1, 0, 0, 0);
     }
     if (r) goto done;
 
@@ -2739,7 +2739,7 @@ static void _mbox_update(jmap_req_t *req, struct mboxset_args *args,
 
     if (!r && args->is_subscribed >= 0) {
         r = mboxlist_changesub(mboxname, req->userid, httpd_authstate,
-                               args->is_subscribed, 0, 0);
+                               args->is_subscribed, 0, 0, 0);
     }
     if (!r && (args->shareWith || args->is_seenshared >= 0)) {
         struct mailbox *mbox = NULL;
@@ -3033,7 +3033,7 @@ static void _mbox_destroy(jmap_req_t *req, const char *mboxid,
             mbentry->uniqueid, msgcount);
 
     /* Remove subscription */
-    int r2 = mboxlist_changesub(mbentry->name, req->userid, httpd_authstate, 0, 0, 0);
+    int r2 = mboxlist_changesub(mbentry->name, req->userid, httpd_authstate, 0, 1, 0, 1);
     if (r2) {
         syslog(LOG_ERR, "jmap: mbox_destroy: can't unsubscribe %s:%s",
                 mbentry->name, error_message(r2));

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -2745,7 +2745,7 @@ static void _mbox_update(jmap_req_t *req, struct mboxset_args *args,
         struct mailbox *mbox = NULL;
         uint32_t newopts;
 
-        r = jmap_openmbox(req, mboxname, &mbox, 1);
+        r = mailbox_open_iwl(mboxname, &mbox);
         if (r) goto done;
 
         if (args->shareWith) {
@@ -2824,12 +2824,12 @@ static int _mbox_on_destroy_move(jmap_req_t *req,
         r = IMAP_NOTFOUND;
         goto done;
     }
-    r = jmap_openmbox(req, src_mbentry->name, &src_mbox, 0);
+    r = mailbox_open_irl(src_mbentry->name, &src_mbox);
     if (r) {
         syslog(LOG_ERR, "%s: can't open %s", __func__, src_mbentry->name);
         goto done;
     }
-    r = jmap_openmbox(req, dst_mbentry->name, &dst_mbox, 1);
+    r = mailbox_open_iwl(dst_mbentry->name, &dst_mbox);
     if (r) {
         syslog(LOG_ERR, "%s: can't open %s", __func__, dst_mbentry->name);
         goto done;
@@ -2971,7 +2971,7 @@ static void _mbox_destroy(jmap_req_t *req, const char *mboxid,
             struct mailbox *mbox = NULL;
             struct mailbox_iter *iter = NULL;
 
-            r = jmap_openmbox(req, mbentry->name, &mbox, 0);
+            r = mailbox_open_irl(mbentry->name, &mbox);
             if (r) goto done;
             iter = mailbox_iter_init(mbox, 0, ITER_SKIP_EXPUNGED);
             if (mailbox_iter_step(iter) != NULL) {

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -57,6 +57,8 @@
 #include "bsearch.h"
 #include "cyr_qsort_r.h"
 #include "http_jmap.h"
+#include "http_dav.h"
+#include "http_dav_sharing.h"
 #include "jmap_mail.h"
 #include "json_support.h"
 #include "mailbox.h"
@@ -4122,6 +4124,7 @@ static int jmap_mailbox_set(jmap_req_t *req)
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     _mboxset(req, &set);
     mboxname_release(&namespacelock);
+    dav_run_notifications();
     jmap_ok(req, jmap_set_reply(&set.super));
 
 done:

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -2766,7 +2766,7 @@ static void _mbox_update(jmap_req_t *req, struct mboxset_args *args,
                 mboxlist_update_foldermodseq(mailbox_name(mbox), mbox->i.highestmodseq);
             }
         }
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
     }
     if (r) goto done;
 
@@ -2898,8 +2898,8 @@ done:
     if (r && !result->err) {
         result->err = jmap_server_error(r);
     }
-    jmap_closembox(req, &dst_mbox);
-    jmap_closembox(req, &src_mbox);
+    mailbox_close(&dst_mbox);
+    mailbox_close(&src_mbox);
     ptrarray_fini(&move_msgrecs);
     return r;
 }
@@ -2978,7 +2978,7 @@ static void _mbox_destroy(jmap_req_t *req, const char *mboxid,
                 result->err = json_pack("{s:s}", "type", "mailboxHasEmail");
             }
             mailbox_iter_done(&iter);
-            jmap_closembox(req, &mbox);
+            mailbox_close(&mbox);
             if (result->err) goto done;
         }
     }

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4124,7 +4124,6 @@ static int jmap_mailbox_set(jmap_req_t *req)
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     _mboxset(req, &set);
     mboxname_release(&namespacelock);
-    dav_run_notifications();
     jmap_ok(req, jmap_set_reply(&set.super));
 
 done:

--- a/imap/jmap_mdn.c
+++ b/imap/jmap_mdn.c
@@ -420,7 +420,7 @@ static json_t *generate_mdn(struct jmap_req *req,
   done:
     if (r && err == NULL) err = jmap_server_error(r);
     if (mr) msgrecord_unref(&mr);
-    if (mbox) jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     free(mboxname);
     buf_free(&buf);
 
@@ -644,7 +644,7 @@ static int jmap_mdn_parse(jmap_req_t *req)
             json_array_append_new(parse.not_parsable, json_string(blobid));
         }
         msgrecord_unref(&mr);
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
         message_free_body(body);
         free(body);
         buf_free(&buf);

--- a/imap/jmap_mdn.c
+++ b/imap/jmap_mdn.c
@@ -275,7 +275,7 @@ static json_t *generate_mdn(struct jmap_req *req,
     }
 
     /* Open the mailbox */
-    r = jmap_openmbox(req, mboxname, &mbox, 1);
+    r = mailbox_open_iwl(mboxname, &mbox);
     if (r) goto done;
 
     /* Load the message */

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -472,7 +472,7 @@ static int jmap_note_get(jmap_req_t *req)
 
     rights = jmap_myrights_mbentry(req, mbentry);
 
-    r = jmap_openmbox(req, mbentry->name, &mbox, 0);
+    r = mailbox_open_irl(mbentry->name, &mbox);
     mboxlist_entry_free(&mbentry);
     if (r) goto done;
 
@@ -867,7 +867,7 @@ static int jmap_note_set(jmap_req_t *req)
 
     rights = jmap_myrights_mbentry(req, mbentry);
 
-    r = jmap_openmbox(req, mbentry->name, &mbox, 1);
+    r = mailbox_open_iwl(mbentry->name, &mbox);
     assert(mbox);
     mboxlist_entry_free(&mbentry);
     if (r) goto done;
@@ -999,7 +999,7 @@ static int jmap_note_changes(jmap_req_t *req)
         goto done;
     }
 
-    r = jmap_openmbox(req, mbentry->name, &mbox, 0);
+    r = mailbox_open_irl(mbentry->name, &mbox);
     mboxlist_entry_free(&mbentry);
 
     r = mailbox_user_flag(mbox, DFLAG_UNBIND, &userflag, 0);

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -503,7 +503,7 @@ static int jmap_note_get(jmap_req_t *req)
     get.state = buf_release(&buf);
     jmap_ok(req, jmap_get_reply(&get));
 
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
 
 done:
     jmap_parser_fini(&parser);
@@ -955,7 +955,7 @@ static int jmap_note_set(jmap_req_t *req)
     jmap_ok(req, jmap_set_reply(&set));
 
 done:
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     jmap_parser_fini(&parser);
     jmap_set_fini(&set);
     return 0;
@@ -1057,7 +1057,7 @@ static int jmap_note_changes(jmap_req_t *req)
         }
     }
     mailbox_iter_done(&iter);
-    jmap_closembox(req, &mbox);
+    mailbox_close(&mbox);
     buf_free(&buf);
 
     if (changes.max_changes) {

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -397,7 +397,7 @@ static const char *script_findblob(struct jmap_req *req, const char *id,
             content += record.header_size;
 
             msgrecord_unref(&mr);
-            jmap_closembox(req, &mbox);
+            mailbox_close(&mbox);
         }
     }
 
@@ -2023,7 +2023,7 @@ static int jmap_sieve_test(struct jmap_req *req)
 
         r = sieve_script_parse_string(NULL, content, &errors, &s);
         msgrecord_unref(&mr);
-        jmap_closembox(req, &mbox);
+        mailbox_close(&mbox);
 
         if (r != SIEVE_OK) {
             err = json_pack("{s:s, s:s}", "type", "invalidScript",
@@ -2141,7 +2141,7 @@ static int jmap_sieve_test(struct jmap_req *req)
 
             free_msg(&m);
             msgrecord_unref(&mr);
-            jmap_closembox(req, &mbox);
+            mailbox_close(&mbox);
             if (!envelope) {
                 strarray_fini(&env_from);
                 strarray_fini(&env_to);

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -2477,7 +2477,7 @@ static int autosieve_createfolder(const char *userid, const struct auth_state *a
         goto done;
     }
 
-    mboxlist_changesub(internalname, userid, auth_state, 1, 1, 1);
+    mboxlist_changesub(internalname, userid, auth_state, 1, 1, 1, 1);
     syslog(LOG_DEBUG, "autosievefolder: User %s, folder %s creation succeeded",
            userid, internalname);
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6611,9 +6611,6 @@ HIDDEN int mailbox_rename_nocopy(struct mailbox *oldmailbox,
     return r;
 }
 
-/* if 'userid' is set, we perform the funky RENAME INBOX INBOX.old
-   semantics, regardless of whether or not the name of the mailbox is
-   'user.foo'.*/
 /* requires a write-locked oldmailbox pointer, since we delete it
    immediately afterwards */
 /* This function ONLY WORKS if the type is legacy */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -648,7 +648,8 @@ static struct mappedfile *mailbox_cachefile(struct mailbox *mailbox,
     else
         fname = mailbox_meta_fname(mailbox, META_CACHE);
 
-    return cache_getfile(&mailbox->caches, fname, mailbox->is_readonly, mailbox->i.generation_no);
+    int is_readonly = mailbox->is_readonly || mailbox->index_locktype == LOCK_SHARED;
+    return cache_getfile(&mailbox->caches, fname, is_readonly, mailbox->i.generation_no);
 }
 
 static struct mappedfile *repack_cachefile(struct mailbox_repack *repack,
@@ -4318,7 +4319,8 @@ EXPORTED struct conversations_state *mailbox_get_cstate_full(struct mailbox *mai
     /* open the conversations DB - don't bother checking return code since it'll
      * only be set if it opens successfully, and we can only return NULL or an
      * object */
-    conversations_open_mbox(mailbox_name(mailbox), mailbox->is_readonly, &mailbox->local_cstate);
+    int is_readonly = mailbox->is_readonly || mailbox->index_locktype == LOCK_SHARED;
+    conversations_open_mbox(mailbox_name(mailbox), is_readonly, &mailbox->local_cstate);
     return mailbox->local_cstate;
 }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -3854,7 +3854,7 @@ static int mailbox_update_webdav(struct mailbox *mailbox,
         }
     }
     if (!buf_len(&resource))
-	buf_printf(&resource, "imapuid-%u", new->uid);
+        buf_printf(&resource, "imapuid-%u", new->uid);
 
     webdavdb = mailbox_open_webdav(mailbox);
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2691,9 +2691,10 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
 
     if (mailbox->local_cstate) {
         int r = conversations_commit(&mailbox->local_cstate);
-        if (r)
-            syslog(LOG_ERR, "Error committing to conversations database for mailbox %s: %s",
+        if (r) {
+            syslog(LOG_ERR, "IOERROR: Error committing to conversations database for mailbox %s: %s",
                    mailbox_name(mailbox), error_message(r));
+        }
     }
 
     // release the namespacelock here

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2651,8 +2651,9 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
     if (mailbox->local_cstate) {
         int r = conversations_commit(&mailbox->local_cstate);
         if (r) {
-            syslog(LOG_ERR, "IOERROR: Error committing to conversations database for mailbox %s: %s",
-                   mailbox_name(mailbox), error_message(r));
+            xsyslog(LOG_ERR, "IOERROR: Error committing to conversations database"
+                    "mailbox=<%s> error=<%s>",
+                    mailbox_name(mailbox), error_message(r));
         }
     }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2648,7 +2648,7 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
     if (mailbox->local_cstate) {
         int r = conversations_commit(&mailbox->local_cstate);
         if (r) {
-            xsyslog(LOG_ERR, "IOERROR: Error committing to conversations database"
+            xsyslog(LOG_ERR, "IOERROR: Error committing to conversations database",
                     "mailbox=<%s> error=<%s>",
                     mailbox_name(mailbox), error_message(r));
         }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6644,6 +6644,7 @@ HIDDEN int mailbox_rename_copy(struct mailbox *oldmailbox,
     if (!uidvalidity)
         uidvalidity = mboxname_nextuidvalidity(newname, oldmailbox->i.uidvalidity);
 
+    /* zero means mailbox_create will set it */
     modseq_t highestmodseq = silent ? oldmailbox->i.highestmodseq : 0;
 
     /* Create new mailbox */

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -257,7 +257,7 @@ struct mailbox {
     size_t index_len;   /* mapped size */
 
     int index_locktype; /* 0 = none, 1 = shared, 2 = exclusive */
-    int is_readonly; /* this matches locktype but COULD be true even if locktype == exclusive */
+    int is_readonly; /* tells us whether the index_fd is opened RW or RO */
 
     ino_t header_file_ino;
     bit32 header_file_crc;

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -257,7 +257,7 @@ struct mailbox {
     size_t index_len;   /* mapped size */
 
     int index_locktype; /* 0 = none, 1 = shared, 2 = exclusive */
-    int is_readonly; /* true = open index and cache files readonly */
+    int is_readonly; /* this matches locktype but COULD be true even if locktype == exclusive */
 
     ino_t header_file_ino;
     bit32 header_file_crc;
@@ -310,6 +310,12 @@ struct mailbox {
     struct index_change *index_changes;
     uint32_t index_change_alloc;
     uint32_t index_change_count;
+
+    /* refcounting */
+    int refcount;
+    char *lockname;
+    struct mboxlock *namelock;
+    struct mailbox *next;
 };
 
 #define ITER_SKIP_UNLINKED (1<<0)

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -387,7 +387,7 @@ int mboxlist_checksub(const char *name, const char *userid);
 /* Change 'user's subscription status for mailbox 'name'. */
 int mboxlist_changesub(const char *name, const char *userid,
                        const struct auth_state *auth_state,
-                       int add, int force, int notify);
+                       int add, int force, int notify, int silent);
 
 /* set or create quota root */
 int mboxlist_setquotas(const char *root,

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -131,6 +131,19 @@ EXPORTED int open_mboxlocks_exist(void)
 
 static struct mboxlocklist *create_lockitem(const char *name)
 {
+#if 0
+    // disable this log tracking!
+    if (!strncmp(name, "*U*", 3)) {
+        // LOCK ORDERING!
+        struct mboxlocklist *item;
+        for (item = open_mboxlocks; item; item = item->next) {
+             if (strncmp(item->l.name, "*U*", 3)) continue;
+             if (strcmp(name, item->l.name) < 0) {
+                syslog(LOG_ERR, "IOERROR: namelock ordering wrong %s < %s", name, item->l.name);
+             }
+        }
+    }
+#endif
     struct mboxlocklist *item = xmalloc(sizeof(struct mboxlocklist));
     item->next = open_mboxlocks;
     open_mboxlocks = item;

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -540,6 +540,7 @@ static int do_reconstruct(struct findall_data *data, void *rock)
             }
 	    free(extname);
         }
+        mailbox_close(&mailbox);
         mboxname_release(&namespacelock);
         return 0;
     }

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -140,7 +140,7 @@ static int reset_single(const char *userid)
     /* ignore failures here - the subs file gets deleted soon anyway */
     for (i = sublist->count; i; i--) {
         const char *name = strarray_nth(sublist, i-1);
-        (void)mboxlist_changesub(name, userid, sync_authstate, 0, 0, 0);
+        (void)mboxlist_changesub(name, userid, sync_authstate, 0, 0, 0, /*silent*/1);
     }
 
     mbentry_t *mbentry = NULL;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3729,7 +3729,7 @@ int sync_apply_changesub(struct dlist *kin, struct sync_state *sstate)
     if (!dlist_getatom(kin, "USERID", &userid))
         return IMAP_PROTOCOL_BAD_PARAMETERS;
 
-    return mboxlist_changesub(mboxname, userid, sstate->authstate, add, add, 0);
+    return mboxlist_changesub(mboxname, userid, sstate->authstate, add, add, 0, /*silent*/1);
 }
 
 /* ====================================================================== */
@@ -3974,7 +3974,7 @@ int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
     strarray_t *list = mboxlist_sublist(userid);
     for (i = 0; i < list->count; i++) {
         const char *name = strarray_nth(list, i);
-        mboxlist_changesub(name, userid, sstate->authstate, 0, 0, 0);
+        mboxlist_changesub(name, userid, sstate->authstate, 0, 0, 0, /*silent*/1);
     }
 
     mbentry_t *mbentry = NULL;

--- a/imap/user.c
+++ b/imap/user.c
@@ -379,7 +379,7 @@ static int user_renamesub(const char *name, void* rock)
         name = newname;
     }
 
-    return mboxlist_changesub(name, rrock->newuser, NULL, 1, 1, 1);
+    return mboxlist_changesub(name, rrock->newuser, NULL, 1, 1, 1, /*silent*/1);
 }
 
 static int user_renamesieve(const char *olduser, const char *newuser)

--- a/imap/user.c
+++ b/imap/user.c
@@ -693,21 +693,13 @@ EXPORTED char *user_hash_xapian_byid(const char *mboxid, const char *root)
 
 static const char *_namelock_name_from_userid(const char *userid)
 {
-    const char *p;
     static struct buf buf = BUF_INITIALIZER;
-    if (!userid) userid = ""; // no userid == global lock
 
     buf_setcstr(&buf, "*U*");
-
-    for (p = userid; *p; p++) {
-        switch(*p) {
-            case '.':
-                buf_putc(&buf, '^');
-                break;
-            default:
-                buf_putc(&buf, *p);
-                break;
-        }
+    if (userid) {
+	char *inbox = mboxname_user_mbox(userid, NULL);
+	buf_appendcstr(&buf, inbox);
+	free(inbox);
     }
 
     return buf_cstring(&buf);


### PR DESCRIPTION
This brings back the mboxlist_changesub modseq bump but also rewrites mailbox refcounting so it works, and ALSO replaces the JMAP mailbox cache as part of that change.

There are probably more places we can just open and close rather than having to track the index mailbox too.