### PR TITLE
improve cassandane getsyslog

### DIFF
--- a/cassandane/Cassandane/Cyrus/Annotator.pm
+++ b/cassandane/Cassandane/Cyrus/Annotator.pm
@@ -492,10 +492,9 @@ sub test_log_missing_acl
         $self->{store}->set_folder('Other Users.other');
         $self->make_message("Email", body => "set_flag $_->{flag}\r\n",
             store => $self->{store}) or die;
-        my @logs = $self->{instance}->getsyslog();
         my $wantLog = "could not write flag due missing ACL: "
                     . "flag=<\\$_->{flag}> need_rights=<$_->{need_rights}>";
-        $self->assert_matches(qr{$wantLog}, join("\n", @logs));
+        $self->assert_syslog_matches($self->{instance}, qr{$wantLog});
     }
 }
 

--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -977,11 +977,8 @@ sub test_guid_duplicate_same_folder
     $self->assert_null($r3);
     $self->assert_matches(qr/Too many identical emails/, $talk->get_last_error());
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr{IOERROR: conversations GUID limit},
-                              join("\n", @lines));
-    }
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{IOERROR: conversations GUID limit});
 
     $talk->select("INBOX.dest");
     my $data = $talk->fetch("1:*", "(emailid threadid uid)");
@@ -1023,12 +1020,8 @@ sub test_guid_duplicate_total_count
     $self->assert_not_null($r4);
     $self->assert_null($r5);
     $self->assert_matches(qr/Too many identical emails/, $talk->get_last_error());
-
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr{IOERROR: conversations GUID limit},
-                              join("\n", @lines));
-    }
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{IOERROR: conversations GUID limit});
 }
 
 #
@@ -1063,11 +1056,8 @@ sub test_guid_duplicate_expunges
     $self->assert_null($r);
     $self->assert_matches(qr/Too many identical emails/, $talk->get_last_error());
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr{IOERROR: conversations GUID limit},
-                              join("\n", @lines));
-    }
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{IOERROR: conversations GUID limit});
 }
 
 # Test APPEND of two messages, the second of which has a different subject,

--- a/cassandane/Cassandane/Cyrus/Delete.pm
+++ b/cassandane/Cassandane/Cyrus/Delete.pm
@@ -628,11 +628,9 @@ sub test_bz3781
 
     $self->check_folder_not_ondisk($subfolder);
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # We should have generated an IOERROR
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr/IOERROR: bogus filename/, "@lines");
-    }
+    # We should have generated an IOERROR
+    $self->assert_syslog_matches($self->{instance},
+                                 qr/IOERROR: bogus filename/);
 }
 
 sub test_cyr_expire_delete

--- a/cassandane/Cassandane/Cyrus/Delivery.pm
+++ b/cassandane/Cassandane/Cyrus/Delivery.pm
@@ -567,9 +567,7 @@ sub test_auditlog_size
     $self->check_messages(\%msgs, check_guid => 0, keyed_on => 'uid');
 
     xlog $self, "Check the correct size was auditlogged";
-    my @appends = grep {
-        m/auditlog: append .* uid=<1>/
-    } $self->{instance}->getsyslog();
+    my @appends = $self->{instance}->getsyslog(qr/auditlog: append .* uid=<1>/);
     $self->assert_num_equals(1, scalar @appends);
 
     # delivery will add some headers, so it will be larger

--- a/cassandane/Cassandane/Cyrus/Expunge.pm
+++ b/cassandane/Cassandane/Cyrus/Expunge.pm
@@ -142,15 +142,15 @@ sub test_auditlog_size
     $talk->store('1,3,5', '+flags', '(\\Deleted \\Seen)');
     $talk->expunge();
 
-    my @auditlogs = grep {
-        m/auditlog: expunge/
-    } $self->{instance}->getsyslog();
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my @auditlogs = $self->{instance}->getsyslog(qr/auditlog: expunge/);
 
-    my %actual_sizes = map {
-        m/ uid=<([0-9]+)>.* size=<([0-9]+)>/
-    } @auditlogs;
+        my %actual_sizes = map {
+            m/ uid=<([0-9]+)>.* size=<([0-9]+)>/
+        } @auditlogs;
 
-    $self->assert_deep_equals(\%expected_sizes, \%actual_sizes);
+        $self->assert_deep_equals(\%expected_sizes, \%actual_sizes);
+    }
 }
 
 sub test_allowdeleted

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -827,8 +827,8 @@ sub test_mailbox_rename_to_inbox_sub
     $self->assert_null($res->{notUpdated});
 
     # make sure we didn't create the deep tree!
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert(not grep { m/INBOX\.INBOX\.INBOX/ } @syslog);
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr/INBOX\.INBOX\.INBOX/);
 }
 
 sub test_mailbox_rename_sub_inbox_both
@@ -869,8 +869,8 @@ sub test_mailbox_rename_sub_inbox_both
     $self->assert_null($res->{notUpdated});
 
     # make sure we didn't create the deep tree!
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert(not grep { m/INBOX\.INBOX\.INBOX/ } @syslog);
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr/INBOX\.INBOX\.INBOX/);
 }
 
 sub test_mailbox_rename_inside_deep
@@ -949,8 +949,8 @@ sub test_mailbox_rename_to_clash_parent_only
     $self->assert_not_null($res->{notUpdated}{$mboxids{B}});
 
     # there were no renames
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert(not grep { m/auditlog: rename/ } @syslog);
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr/auditlog: rename/);
 }
 
 sub test_mailbox_rename_to_clash_name_only_deep
@@ -993,8 +993,8 @@ sub test_mailbox_rename_to_clash_name_only_deep
     $self->assert_not_null($res->{notUpdated}{$mboxids{B}});
 
     # there were no renames
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert(not grep { m/auditlog: rename/ } @syslog);
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr/auditlog: rename/);
 }
 
 sub test_mailbox_rename_to_clash_name_only
@@ -1038,8 +1038,8 @@ sub test_mailbox_rename_to_clash_name_only
     $self->assert_deep_equals(\%mboxids, \%mboxids2);
 
     # there were no renames
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert(not grep { m/auditlog: rename/ } @syslog);
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr/auditlog: rename/);
 }
 
 sub test_mailbox_rename_to_clash_both
@@ -1085,8 +1085,8 @@ sub test_mailbox_rename_to_clash_both
     $self->assert_deep_equals(\%mboxids, \%mboxids2);
 
     # there were no renames
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert(not grep { m/auditlog: rename/ } @syslog);
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr/auditlog: rename/);
 }
 
 sub test_mailbox_case_difference

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -578,9 +578,11 @@ sub test_rename_deepuser_standardfolders
     $self->assert(not $admintalk->get_last_error());
 
     xlog $self, "Make sure we didn't create intermediates in the process!";
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    my $syslog = join "\n", $self->{instance}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     $res = $admintalk->select("user.newuser.bar.sub");
     $self->assert(not $admintalk->get_last_error());
@@ -594,10 +596,12 @@ sub test_rename_deepuser_standardfolders
     # replicate and check the renames
     $self->{replica}->getsyslog();
     $self->run_replication(rolling => 1, inputfile => $synclogfname);
-    @syslog = $self->{replica}->getsyslog();
+    $syslog = join "\n", $self->{replica}->getsyslog();
 
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     # check replication is clean
     $self->check_replication('newuser');
@@ -680,9 +684,11 @@ sub test_rename_deepfolder_intermediates
     $self->assert(not $admintalk->get_last_error());
 
     xlog $self, "Make sure we didn't create intermediates in the process!";
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    my $syslog = join "\n", $self->{instance}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     $data = $self->_fmjmap_ok('Mailbox/get', properties => ['name']);
     my %byname_new = map { $_->{name} => $_->{id} } @{$data->{list}};
@@ -695,10 +701,12 @@ sub test_rename_deepfolder_intermediates
     # replicate and check the renames
     $self->{replica}->getsyslog();
     $self->run_replication(rolling => 1, inputfile => $synclogfname);
-    @syslog = $self->{replica}->getsyslog();
+    $syslog = join "\n", $self->{replica}->getsyslog();
 
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     # check replication is clean
     $self->check_replication('cassandane');
@@ -713,9 +721,11 @@ sub test_rename_deepfolder_intermediates
     $admintalk->delete("user.cassandane");
 
     xlog $self, "Make sure we didn't create intermediates in the process!";
-    @syslog = $self->{instance}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $syslog = join "\n", $self->{instance}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     xlog $self, "Make sure there are no files left with cassandane in the name";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{instance}{basedir}/conf/user/c/cassandane.*"));
@@ -724,9 +734,11 @@ sub test_rename_deepfolder_intermediates
 
     # replicate and check the renames
     $self->run_replication(rolling => 1, inputfile => $synclogfname);
-    @syslog = $self->{replica}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $syslog = join "\n", $self->{replica}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     xlog $self, "Make sure there are no files left with cassandane in the name on the replica";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{replica}{basedir}/conf/user/c/cassandane.*"));
@@ -1185,9 +1197,11 @@ sub test_rename_deepuser_standardfolders_rightnow
     $self->assert(not $admintalk->get_last_error());
 
     xlog $self, "Make sure we didn't create intermediates in the process!";
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    my $syslog = join "\n", $self->{instance}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     $res = $admintalk->select("user.newuser.bar.sub");
     $self->assert(not $admintalk->get_last_error());
@@ -1199,9 +1213,11 @@ sub test_rename_deepuser_standardfolders_rightnow
     $self->assert_deep_equals(\%byname, \%byname_new);
 
     # check nothing got logged on the replica
-    @syslog = $self->{replica}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $syslog = join "\n", $self->{replica}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     # check replication is clean
     $self->check_replication('newuser');
@@ -1282,9 +1298,11 @@ sub test_rename_deepfolder_intermediates_rightnow
     $self->assert(not $admintalk->get_last_error());
 
     xlog $self, "Make sure we didn't create intermediates in the process!";
-    my @syslog = $self->{instance}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    my $syslog = join "\n", $self->{instance}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     $data = $self->_fmjmap_ok('Mailbox/get', properties => ['name']);
     my %byname_new = map { $_->{name} => $_->{id} } @{$data->{list}};
@@ -1295,10 +1313,12 @@ sub test_rename_deepfolder_intermediates_rightnow
     $self->assert_deep_equals(\%byname, \%byname_new);
 
     # replicate and check the renames
-    @syslog = $self->{replica}->getsyslog();
+    $syslog = join "\n", $self->{replica}->getsyslog();
 
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     # check replication is clean
     $self->check_replication('cassandane');
@@ -1313,9 +1333,11 @@ sub test_rename_deepfolder_intermediates_rightnow
     $admintalk->delete("user.cassandane");
 
     xlog $self, "Make sure we didn't create intermediates in the process!";
-    @syslog = $self->{instance}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $syslog = join "\n", $self->{instance}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     xlog $self, "Make sure there are no files left with cassandane in the name";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{instance}{basedir}/conf/user/c/cassandane.*"));
@@ -1323,9 +1345,11 @@ sub test_rename_deepfolder_intermediates_rightnow
     $self->assert_not_file_test("$self->{instance}{basedir}/conf/quota/c/user.cassandane", "-d");
 
     # replicate and check the renames
-    @syslog = $self->{replica}->getsyslog();
-    $self->assert_null(grep { m/creating intermediate with children/ } @syslog);
-    $self->assert_null(grep { m/deleting intermediate with no children/ } @syslog);
+    $syslog = join "\n", $self->{replica}->getsyslog();
+    $self->assert_does_not_match(qr/creating intermediate with children/,
+                                 $syslog);
+    $self->assert_does_not_match(qr/deleting intermediate with no children/,
+                                 $syslog);
 
     xlog $self, "Make sure there are no files left with cassandane in the on the replica";
     $self->assert_str_equals(q{}, join(q{ }, glob "$self->{replica}{basedir}/conf/user/c/cassandane.*"));

--- a/cassandane/Cassandane/Cyrus/Flags.pm
+++ b/cassandane/Cassandane/Cyrus/Flags.pm
@@ -626,11 +626,9 @@ sub test_max_userflags
     $self->assert_null($res);
     $self->assert_matches(qr/Too many user flags in mailbox/, $e);
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # We should have generated an IOERROR
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr/IOERROR: out of flags/, "@lines");
-    }
+    # We should have generated an IOERROR
+    $self->assert_syslog_matches($self->{instance},
+                                 qr/IOERROR: out of flags/);
 
     xlog $self, "Can set all the flags at once";
     my @flags = sort { $allflags{$a} <=> $allflags{$b} } (keys %allflags);
@@ -1586,10 +1584,8 @@ sub test_userflags_crash
     $self->assert_str_equals('no', $talk->get_last_completion_response());
 
     # should have got a syslog message about conversations GUID limit
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr/IOERROR: conversations GUID limit/, "@lines");
-    }
+    $self->assert_syslog_matches($self->{instance},
+                                 qr/IOERROR: conversations GUID limit/);
 
     # change some flags on the first message
     $talk->store('1', '-flags', qw(a b c d));
@@ -1603,10 +1599,8 @@ sub test_userflags_crash
     $self->assert_str_equals('no', $talk->get_last_completion_response());
 
     # should have got a syslog message about conversations GUID limit
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr/IOERROR: conversations GUID limit/, "@lines");
-    }
+    $self->assert_syslog_matches($self->{instance},
+                                 qr/IOERROR: conversations GUID limit/);
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/ID.pm
+++ b/cassandane/Cassandane/Cyrus/ID.pm
@@ -88,9 +88,7 @@ sub test_cmd_id
         $imaptalk->logout();
         undef $imaptalk;
 
-        my @lines = $self->{instance}->getsyslog();
-
-        my (@behavior_lines) = grep { /session ended/ } @lines;
+        my @behavior_lines = $self->{instance}->getsyslog(qr/session ended/);
 
         $self->assert_num_gte(1, scalar @behavior_lines);
 

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -595,14 +595,11 @@ sub test_require_conversations
     my ($response, undef) = $jmap->Request($JMAPRequest);
     $self->assert(not $response->{success});
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # httpd should syslog an error
-        my @syslog = $self->{instance}->getsyslog();
-        $self->assert_matches(
-            qr/ERROR: cannot enable \w+ module with conversations disabled/,
-            "@syslog"
-        );
-    }
+    # httpd should syslog an error
+    $self->assert_syslog_matches(
+        $self->{instance},
+        qr/ERROR: cannot enable \w+ module with conversations disabled/,
+    );
 }
 
 sub test_eventsource

--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -2659,9 +2659,10 @@ sub test_mailbox_set_destroy_removemsgs
 
     my ($maj, $min) = Cassandane::Instance->get_version();
     if ($maj > 3 || ($maj == 3 && $min >= 7)) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr{Destroyed mailbox: mboxid=<$mboxId> msgcount=<1>},
-                              join("\n", @lines));
+        $self->assert_syslog_matches(
+            $self->{instance},
+            qr{Destroyed mailbox: mboxid=<$mboxId> msgcount=<1>}
+        );
     }
 }
 

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -673,8 +673,8 @@ sub test_service_dup_port
 
     if ($self->{instance}->{have_syslog_replacement}) {
         # check syslog for the expected error
-        my @lines = grep { m/unable to create (?:A|B) listener socket:/ }
-                        $self->{instance}->getsyslog();
+        my $pat = qr/unable to create (?:A|B) listener socket:/;
+        my @lines = $self->{instance}->getsyslog($pat);
         $self->assert_num_equals(1, scalar @lines);
         $self->assert_matches(qr/Address already in use/, $lines[0]);
     }

--- a/cassandane/Cassandane/Cyrus/Metadata.pm
+++ b/cassandane/Cassandane/Cyrus/Metadata.pm
@@ -1571,19 +1571,14 @@ sub test_msg_replication_new_bot_mse_gul
     xlog $self, "Check that annotations in the master and replica DB match";
     $self->check_msg_annotation_replication($master_store, $replica_store);
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # We should have generated a SYNCERROR or two
-        my @lines = $self->{instance}->getsyslog();
-
-        my $pattern = qr{
-            \bSYNCERROR:\sguid\smismatch
-            (?: \suser\.cassandane\s1\b
-              | :\smailbox=<user\.cassandane>\suid=<1>
-            )
-        }x;
-
-        $self->assert_matches($pattern, "@lines");
-    }
+    # We should have generated a SYNCERROR or two
+    my $pattern = qr{
+        \bSYNCERROR:\sguid\smismatch
+        (?: \suser\.cassandane\s1\b
+            | :\smailbox=<user\.cassandane>\suid=<1>
+        )
+    }x;
+    $self->assert_syslog_matches($self->{instance}, $pattern);
 }
 
 sub test_msg_replication_new_bot_mse_guh
@@ -1641,19 +1636,14 @@ sub test_msg_replication_new_bot_mse_guh
     xlog $self, "Check that annotations in the master and replica DB match";
     $self->check_msg_annotation_replication($master_store, $replica_store);
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # We should have generated a SYNCERROR or two
-        my @lines = $self->{instance}->getsyslog();
-
-        my $pattern = qr{
-            \bSYNCERROR:\sguid\smismatch
-            (?: \suser\.cassandane\s1\b
-              | :\smailbox=<user\.cassandane>\suid=<1>
-            )
-        }x;
-
-        $self->assert_matches($pattern, "@lines");
-    }
+    # We should have generated a SYNCERROR or two
+    my $pattern = qr{
+        \bSYNCERROR:\sguid\smismatch
+        (?: \suser\.cassandane\s1\b
+            | :\smailbox=<user\.cassandane>\suid=<1>
+        )
+    }x;
+    $self->assert_syslog_matches($self->{instance}, $pattern);
 }
 
 

--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -278,17 +278,13 @@ sub test_message
     $res = $store->idle_response({}, 1);
     $self->assert(!$res, "no unsolicited responses");
 
+    # make sure that the connection is ended so that imapd reset happens
+    $talk->logout();
+    undef $talk;
+
     # we enabled NOTIFY, so we should see it in client behaviors
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # make sure that the connection is ended so that imapd reset happens
-        $talk->logout();
-        undef $talk;
-
-        my (@lines) = grep { /session ended/ && /notify=<1>/ }
-                      $self->{instance}->getsyslog();
-
-        $self->assert_num_gte(1, scalar @lines);
-    }
+    my $pat = qr/session ended.*notify=<1>/;
+    $self->assert_syslog_matches($self->{instance}, $pat);
 }
 
 sub test_mailbox

--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -2672,11 +2672,9 @@ sub test_reconstruct
         $res_annot_storage => int($expected_annotation_storage/1024),
     );
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # We should have generated a SYNCERROR or two
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr/IOERROR: opening index/, "@lines");
-    }
+    # We should have generated a SYNCERROR or two
+    $self->assert_syslog_matches($self->{instance},
+                                 qr/IOERROR: opening index/);
 }
 
 sub test_reconstruct_orphans
@@ -2814,11 +2812,9 @@ sub test_reconstruct_orphans
         $res_annot_storage => int($expected_annotation_storage/1024),
     );
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        # We should have generated a SYNCERROR or two
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr/IOERROR: opening index/, "@lines");
-    }
+    # We should have generated a SYNCERROR or two
+    $self->assert_syslog_matches($self->{instance},
+                                 qr/IOERROR: opening index/);
 }
 
 Cassandane::Cyrus::TestCase::magic(Bug3735 => sub {

--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -2241,9 +2241,7 @@ sub test_squatter_attachextract_nolock
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v');
 
     xlog $self, "Inspect syslog and extractor trace files";
-    my @log = grep {
-        /squatter\[\d+\]: (released|reacquired) mailbox lock/
-    } $self->{instance}->getsyslog();
+    my @log = $self->{instance}->getsyslog(qr/squatter\[\d+\]: (released|reacquired) mailbox lock/);
 
     my ($released_timestamp) = ($log[0] =~ /released.+unixepoch=<(\d+)>/);
     $self->assert_not_null($released_timestamp);
@@ -2299,9 +2297,6 @@ sub test_squatter_attachextract_timeout
         ."\r\n"
         ."attachterm"
         ."\r\n--123456789abcdef--\r\n");
-
-    xlog $self, "Clear syslog";
-    $self->{instance}->getsyslog();
 
     xlog $self, "Run squatter (allowing partials)";
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-p');
@@ -2397,9 +2392,6 @@ sub test_squatter_attachextract_unprocessable_content
         ."attachterm"
         ."\r\n--123456789abcdef--\r\n");
 
-    xlog $self, "Clear syslog";
-    $self->{instance}->getsyslog();
-
     xlog $self, "Run squatter (allowing partials)";
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-p');
 
@@ -2434,6 +2426,5 @@ sub test_squatter_attachextract_unprocessable_content
     $self->assert_matches(qr/req1_GET_/, $tracefiles[0]);
     $self->assert_matches(qr/req2_PUT_/, $tracefiles[1]);
 }
-
 
 1;

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -143,8 +143,7 @@ sub test_simple
         my $uids = $imap->search(@{$_->{search}}) || die;
         $self->assert_deep_equals($_->{wantUids}, $uids);
 
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr{Squat run}, join("\n", @lines));
+        $self->assert_syslog_matches($self->{instance}, qr{Squat run});
     }
 }
 
@@ -190,8 +189,7 @@ sub test_one_doc_per_message
         my $uids = $imap->search(@{$_->{search}}) || die;
         $self->assert_deep_equals($_->{wantUids}, $uids);
 
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert(grep /Squat run/, @lines);
+        $self->assert_syslog_matches($self->{instance}, qr/Squat run/);
     }
 
     # make some more messages
@@ -227,8 +225,7 @@ sub test_one_doc_per_message
         my $uids = $imap->search(@{$_->{search}}) || die;
         $self->assert_deep_equals($_->{wantUids}, $uids);
 
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert(grep /Squat run/, @lines);
+        $self->assert_syslog_matches($self->{instance}, qr/Squat run/);
     }
 }
 
@@ -246,14 +243,13 @@ sub test_skip_unmodified
 
     $self->{instance}->getsyslog();
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
-    my @lines = $self->{instance}->getsyslog();
-    $self->assert_does_not_match(qr{Squat skipping mailbox},
-                                 join("\n", @lines));
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr{Squat skipping mailbox});
 
     $self->{instance}->getsyslog();
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-s', '0');
-    @lines = $self->{instance}->getsyslog();
-    $self->assert_matches(qr{Squat skipping mailbox}, join("\n", @lines));
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{Squat skipping mailbox});
 }
 
 sub test_nonincremental

--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -7481,10 +7481,8 @@ EOF
     $self->{instance}->deliver($msg);
 
     # Verify that message was redirected (no RCPT TO error)
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_does_not_match(qr/RCPT TO: code=553 text=5.1.1/, "@lines");
-    }
+    $self->assert_syslog_does_not_match($self->{instance},
+                                        qr/RCPT TO: code=553 text=5.1.1/);
 
     xlog $self, "Make sure that message is NOT in INBOX (due to runtime error)";
     my $talk = $self->{store}->get_client();

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1601,6 +1601,26 @@ sub assert_sieve_matches
                              digest_file_hex($filename, "MD5"));
 }
 
+sub assert_syslog_matches
+{
+    my ($self, $instance, $pattern) = @_;
+
+    if ($instance->{have_syslog_replacement}) {
+        $self->assert((scalar $instance->getsyslog($pattern) >= 1),
+                      "syslog does not match pattern $pattern");
+    }
+}
+
+sub assert_syslog_does_not_match
+{
+    my ($self, $instance, $pattern) = @_;
+
+    if ($instance->{have_syslog_replacement}) {
+        $self->assert((scalar $instance->getsyslog($pattern) == 0),
+                      "syslog matches pattern $pattern");
+    }
+}
+
 # create a bunch of mailboxes and messages with various flags and annots,
 # returning a hash of what to expect to find there later
 sub populate_user

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent-ignore-orphaned-ical-rows
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent-ignore-orphaned-ical-rows
@@ -172,9 +172,8 @@ EOF
     xlog $self, "Deliver iMIP invite";
     $self->{instance}->deliver(Cassandane::Message->new(raw => $imip));
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert(not grep { /mailbox=<DELETED\.user\.cassandane\.#calendars/ } @lines);
-    }
-
+    $self->assert_syslog_does_not_match(
+        $self->{instance},
+        qr/mailbox=<DELETED\.user\.cassandane\.#calendars/
+    );
 }

--- a/cassandane/tiny-tests/JMAPEmail/email-set-update-too-many-mailboxes-lowlimit
+++ b/cassandane/tiny-tests/JMAPEmail/email-set-update-too-many-mailboxes-lowlimit
@@ -45,9 +45,6 @@ sub test_email_set_update_too_many_mailboxes_lowlimit
     }, 'R1']]);
     $self->assert_str_equals('tooManyMailboxes', $res->[0][1]{notUpdated}{$emailId}{type});
 
-    if ($self->{instance}->{have_syslog_replacement}) {
-        my @lines = $self->{instance}->getsyslog();
-        $self->assert_matches(qr{IOERROR: conversations GUID limit},
-                              join("\n", @lines));
-    }
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{IOERROR: conversations GUID limit});
 }

--- a/cassandane/tiny-tests/JMAPEmail/searchsnippet-search-maxsize
+++ b/cassandane/tiny-tests/JMAPEmail/searchsnippet-search-maxsize
@@ -30,8 +30,8 @@ EOF
     xlog "Assert indexer only processes maxsize bytes of text";
     $self->{instance}->getsyslog(); # clear syslog
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
-    my @lines = $self->{instance}->getsyslog();
-    $self->assert_num_equals(1, scalar grep { m/Xapian: truncating/ } @lines);
+    my @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
+    $self->assert_num_equals(1, scalar @lines);
 
     my $res = $jmap->CallMethods([
         ['Email/query', {
@@ -62,8 +62,8 @@ EOF
         }, 'R3'],
     ]);
     $self->assert_not_null($res->[0][1]{list}[0]{preview});
-    @lines = $self->{instance}->getsyslog();
-    $self->assert_num_equals(1, scalar grep { m/Xapian: truncating/ } @lines);
+    @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
+    $self->assert_num_equals(1, scalar @lines);
 
     xlog "Assert snippet generator only processes maxsize bytes of text";
     $self->{instance}->getsyslog(); # clear syslog
@@ -76,6 +76,6 @@ EOF
         }, 'R3'],
     ]);
     $self->assert_null($res->[0][1]{list}[0]{preview});
-    @lines = $self->{instance}->getsyslog();
-    $self->assert_num_equals(1, scalar grep { m/Xapian: truncating/ } @lines);
+    @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
+    $self->assert_num_equals(1, scalar @lines);
 }


### PR DESCRIPTION
This reduces the amount of boilerplate needed to check for syslog messages from Cassandane tests.

* Adds an optional pattern parameter to `getsyslog()`, so you can filter the lines without an extra step
* Adds `assert_syslog_matches()` and `assert_syslog_does_not_match()` for the common case where you just want to check whether syslog does or does not contain any lines matching some pattern.
* Updates existing tests to use the new features where it makes sense to

Note that the new assertions call `getsyslog()` themselves, so they're _not_ useful if you want to check for multiple patterns at once, because the first call will read all the available lines, and the subsequent calls won't find any.  For that sort of thing you should still use `getsyslog()` directly to read the lines, then match those lines in whatever way seems appropriate.

**Reviewers:** lots of repetitive small changes in here.  Probably easiest to review commit by commit.