### PR TITLE
fix pcre2 crash when regex_t uninitialised

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -488,6 +488,16 @@ sub badscript_common
         "require [\"fileinto\",\"copy\"];\nfileinto :copy \"foo\";\n");
     $self->assert_str_equals('success', $res);
 
+    my $badregex1 = << 'EOF';
+require ["regex"];
+if header :regex "Subject" "Message (x)?(.*" {
+    stop;
+}
+EOF
+    ($res, $errs) = $self->compile_sieve_script('badregex1', $badregex1);
+    $self->assert_str_equals('failure', $res);
+    $self->assert_matches(qr/unbalanced/, $errs);
+
     # TODO: test UTF-8 verification of the string parameter
 }
 

--- a/cunit/buf.testc
+++ b/cunit/buf.testc
@@ -646,7 +646,7 @@ static void test_replace_all(void)
         CU_ASSERT_STRING_EQUAL(b.s, _in); \
  \
         r = regcomp(&re, _reg, REG_EXTENDED); \
-        CU_ASSERT_EQUAL(r, 0);
+        CU_ASSERT_EQUAL_FATAL(r, 0);
 #define TESTCASE_MIDDLE \
         n = buf_replace_one_re(&b, &re, _rep);
 #define TESTCASE_END \

--- a/lib/glob.c
+++ b/lib/glob.c
@@ -58,6 +58,7 @@
 EXPORTED glob *glob_init(const char *str, char sep)
 {
     struct buf buf = BUF_INITIALIZER;
+    int r;
 
     buf_appendcstr(&buf, "(^");
     while (*str) {
@@ -109,7 +110,9 @@ EXPORTED glob *glob_init(const char *str, char sep)
     buf_appendcstr(&buf, "]|$)");
 
     glob *g = xmalloc(sizeof(glob));
-    regcomp(&g->regex, buf_cstring(&buf), REG_EXTENDED);
+    r = regcomp(&g->regex, buf_cstring(&buf), REG_EXTENDED);
+    /* XXX handle regex compilation failure properly! */
+    assert(r == 0);
     buf_free(&buf);
 
     return g;

--- a/sieve/sieve.y
+++ b/sieve/sieve.y
@@ -2140,7 +2140,6 @@ static int verify_regexlist(sieve_script_t *sscript,
                             const strarray_t *sa, int collation)
 {
     int i, ret = 0;
-    regex_t reg;
     int cflags = REG_EXTENDED | REG_NOSUB;
 
     /* support UTF8 comparisons */
@@ -2156,6 +2155,7 @@ static int verify_regexlist(sieve_script_t *sscript,
 
     for (i = 0 ; !ret && i < strarray_size(sa) ; i++) {
         const char *s = strarray_nth(sa, i);
+        regex_t reg = {0};
 
         /* Don't try to validate a regex that includes variables */
         if (supported(SIEVE_CAPA_VARIABLES) && strstr(s, "${")) continue;


### PR DESCRIPTION
This fixes a crash seen in the wild at Fastmail when Cyrus is built with PCRE2 rather than PCRE.

Looks like the PCRE2 `pcre2_regcomp()` has different behaviour from the POSIX or PCRE1 `regcomp()` when the pattern fails to compile.  In this case the PCRE2 version doesn't touch its regex_t argument.  If it wasn't already initialized otherwise, it will remain uninitialized, and a later call to `pcre2_regfree()` will crash.

That means we need to be sure to initialise regex_t objects, not rely on `regcomp()` to do it.