### PR TITLE
Global lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ imap/cyr_sphinxmgr
 imap/cyr_synclog
 imap/cyr_userseen
 imap/cyr_virusscan
+imap/cyr_withlock_run
 imap/cyrdump
 imap/dav_reconstruct
 imap/deliver

--- a/Makefile.am
+++ b/Makefile.am
@@ -185,6 +185,7 @@ sbin_PROGRAMS += \
 	imap/cyr_df \
 	imap/cyr_ls \
 	imap/cyr_pwd \
+	imap/cyr_withlock_run \
 	imap/cyrdump \
 	imap/cyr_dbtool \
 	imap/cyr_deny \
@@ -924,6 +925,9 @@ imap_cyr_ls_LDADD = $(LD_UTILITY_ADD)
 
 imap_cyr_pwd_SOURCES = imap/cli_fatal.c imap/cyr_pwd.c imap/mutex_fake.c
 imap_cyr_pwd_LDADD = $(LD_UTILITY_ADD)
+
+imap_cyr_withlock_run_SOURCES = imap/cli_fatal.c imap/cyr_withlock_run.c imap/mutex_fake.c
+imap_cyr_withlock_run_LDADD = $(LD_UTILITY_ADD)
 
 imap_cyr_expire_SOURCES = imap/cli_fatal.c imap/cyr_expire.c imap/mutex_fake.c
 imap_cyr_expire_LDADD = $(LD_UTILITY_ADD)

--- a/changes/next/global-lock
+++ b/changes/next/global-lock
@@ -1,0 +1,26 @@
+Description:
+
+Add a way to freeze an entire server temporarily while taking snapshots or
+similar.
+
+
+Config changes:
+
+Adds a new config switch `global_lock` - if true (the default) then a new
+global shared lock is taken before any exclusive lock is taken, and held
+until all global locks are released - meaning that any command which wishes
+to take a consistent snapshot can use the `cyr_withlock_run` command.
+
+Whether or not this setting is enabled, you can also use
+`cyr_withlock_run --user` to run a command with a single user locked.
+
+
+Upgrade instructions:
+
+There are no operational changes required; it just works once you're running
+the new version.
+
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/issues/1763

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_withlock_run.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_withlock_run.rst
@@ -1,0 +1,85 @@
+.. cyrusman:: cyr_withlock_run(8)
+
+.. author: Bron Gondwana
+
+.. _imap-reference-manpages-systemcommands-cyr_withlock_run:
+
+====================
+**cyr_withlock_run**
+====================
+
+is used to run system command with a lock held
+
+..  warning::
+
+    This command runs as the Cyrus user, so if you need to call something
+    as root, the cyrus user may need sudo privileges.
+
+Synopsis
+========
+
+.. parsed-literal::
+
+    **cyr_withlock_run** [ **-C** *config-file* ] [ **-u** *userid* ] cmd args...
+
+Description
+===========
+
+**cyr_withlock_run** will run the command and arguments provided on the
+command line, either locking the entire server, or a particular user, so
+no changes can be made to it while this command is running.
+
+WARNING: since this takes an exclusive lock, it will deadlock if the command tries
+to connect to Cyrus via IMAP/JMAP/etc and run commands that take exclusive locks.
+You can run cyrus commandline tools so long as the environment is passed through.
+
+It is most useful for running an external filesystem snapshot command, which can
+be run safely, knowing that files aren't in a partial state.
+
+
+**cyr_withlock_run** |default-conf-text|
+
+Options
+=======
+
+.. program:: cyr_withlock_run
+
+.. option:: -C config-file
+
+    |cli-dash-c-text|
+
+.. option:: -u, --user <userid>
+
+   Lock just the specified userid rather than the global lock.
+
+   NOTE: if you run for the global lock, then your server must have the
+   `global_lock` config option set, or this command will fail with an
+   error as it can't get a guaranteed lock.
+
+Examples
+========
+
+.. parsed-literal::
+
+    **cyr_withlock_run** sleep 300
+
+..
+
+        Pause all writes on the server for 300 seconds (stops any writes from getting locks)
+
+Files
+=====
+
+/etc/imapd.conf
+
+
+Environment
+===========
+
+Sets the `CYRUS_HAVELOCK_GLOBAL` or `CYRUS_HAVELOCK_USER` environment variables,
+to tell any called cyrus command that this lock is already held.
+
+See Also
+========
+
+:cyrusman:`imapd.conf(5)`

--- a/imap/cyr_withlock_run.c
+++ b/imap/cyr_withlock_run.c
@@ -125,16 +125,16 @@ int main(int argc, char **argv)
     for (i = optind; i < argc; i++)
         strarray_append(&args, argv[i]);
     if (userid) {
-        static char env_havelock[100];
-        snprintf(env_havelock, sizeof(env_havelock), "CYRUS_HAVELOCK_GLOBAL=1");
-        putenv(env_havelock);
-        r = mboxname_run_with_lock(runcmd, &args);
-    }
-    else {
         static char env_userlock[MAX_MAILBOX_NAME+30];
         snprintf(env_userlock, sizeof(env_userlock), "CYRUS_HAVELOCK_USER=%s", userid);
         putenv(env_userlock);
         r = user_run_with_lock(userid, runcmd, &args);
+    }
+    else {
+        static char env_havelock[100];
+        snprintf(env_havelock, sizeof(env_havelock), "CYRUS_HAVELOCK_GLOBAL=1");
+        putenv(env_havelock);
+        r = mboxname_run_with_lock(runcmd, &args);
     }
     strarray_fini(&args);
 

--- a/imap/cyr_withlock_run.c
+++ b/imap/cyr_withlock_run.c
@@ -1,0 +1,144 @@
+/* cyr_withlock_run.c -- run a command with the global lock or a user lock held
+ *
+ * Copyright (c) 1994-2023 Carnegie Mellon University.  All rights reserved.
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "global.h"
+#include "mboxname.h"
+#include "command.h"
+#include "strarray.h"
+#include "user.h"
+
+/* generated headers are not necessarily in current directory */
+#include "imap/imap_err.h"
+
+/* current namespace */
+static struct namespace cyr_runlock_namespace;
+
+static int usage(const char *error)
+{
+    fprintf(stderr, "usage: cyr_runlock [-C <alt_config>] cmd args\n");
+    fprintf(stderr, "\n");
+    if (error) {
+        fprintf(stderr, "\n");
+        fprintf(stderr, "ERROR: %s", error);
+    }
+    exit(-1);
+}
+
+int runcmd(void *rock)
+{
+    return run_command_strarray((const strarray_t *)rock);
+}
+
+int main(int argc, char **argv)
+{
+    int r;
+    int opt;
+    char *alt_config = NULL;
+    char *userid = NULL;
+
+    /* keep this in alphabetical order */
+    static const char short_options[] = "C:u:";
+
+    static const struct option long_options[] = {
+        /* n.b. no long option for -C */
+        { "user", required_argument, NULL, 'u' },
+        { 0, 0, 0, 0 },
+    };
+
+    while (-1 != (opt = getopt_long(argc, argv,
+                                    short_options, long_options, NULL)))
+    {
+        switch(opt) {
+        case 'C': /* alt config file */
+            alt_config = optarg;
+            break;
+	
+	case 'u':
+	    userid = optarg;
+	    break;
+
+        default:
+            usage(NULL);
+        }
+    }
+
+    cyrus_init(alt_config, "cyr_runlock", 0, 0);
+
+    r = mboxname_init_namespace(&cyr_runlock_namespace, NAMESPACE_OPTION_ADMIN);
+    if (r) {
+        fatal(error_message(r), -1);
+    }
+
+    strarray_t args = STRARRAY_INITIALIZER;
+    int i;
+    for (i = optind; i < argc; i++)
+        strarray_append(&args, argv[i]);
+    if (userid) {
+        static char env_havelock[100];
+        snprintf(env_havelock, sizeof(env_havelock), "CYRUS_HAVELOCK_GLOBAL=1");
+        putenv(env_havelock);
+        r = mboxname_run_with_lock(runcmd, &args);
+    }
+    else {
+        static char env_userlock[MAX_MAILBOX_NAME+30];
+        snprintf(env_userlock, sizeof(env_userlock), "CYRUS_HAVELOCK_USER=%s", userid);
+        putenv(env_userlock);
+        r = user_run_with_lock(userid, runcmd, &args);
+    }
+    strarray_fini(&args);
+
+    cyrus_done();
+
+    exit(r ? EXIT_FAILURE : EXIT_SUCCESS);
+}

--- a/imap/global.h
+++ b/imap/global.h
@@ -179,6 +179,8 @@ extern const char *config_userdeny_db;
 extern const char *config_zoneinfo_db;
 extern const char *config_conversations_db;
 extern const char *config_backup_db;
+extern int config_take_globallock;
+extern char *config_skip_userlock;
 extern int config_httpprettytelemetry;
 extern int charset_flags;
 extern int charset_snippet_flags;

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -124,6 +124,8 @@ static const char index_mod64[256] = {
 
 #define FNAME_SHAREDPREFIX "shared"
 
+#define GLOBAL_LOCKNAME "$GLOBAL"
+
 EXPORTED int open_mboxlocks_exist(void)
 {
     return open_mboxlocks ? 1 : 0;
@@ -183,8 +185,8 @@ static void remove_lockitem(struct mboxlocklist *remitem)
 
 /* name locking support */
 
-EXPORTED int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
-                  int locktype_and_flags)
+static int mboxname_lock_item(const char *mboxname, struct mboxlock **mboxlockptr,
+                              int locktype_and_flags)
 {
     const char *fname;
     int r = 0;
@@ -242,9 +244,25 @@ done:
                 "name=<%s> error=<%s>", mboxname, error_message(r));
         remove_lockitem(lockitem);
     }
-    else *mboxlockptr = &lockitem->l;
+    else if (mboxlockptr) {
+        *mboxlockptr = &lockitem->l;
+    }
 
     return r;
+}
+
+EXPORTED int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
+                           int locktype_and_flags)
+{
+    if (config_getswitch(IMAPOPT_GLOBAL_LOCK) && locktype_and_flags & LOCK_EXCLUSIVE) {
+        // if we have an exclusive lock, we MUST already be holding
+	// the shared global lock, or we have to open it.
+	if (!mboxname_islocked(GLOBAL_LOCKNAME)) {
+	    int r = mboxname_lock_item(GLOBAL_LOCKNAME, NULL, LOCK_SHARED);
+	    if (r) return r;
+	}
+    }
+    return mboxname_lock_item(mboxname, mboxlockptr, locktype_and_flags);
 }
 
 EXPORTED void mboxname_release(struct mboxlock **mboxlockptr)
@@ -265,6 +283,13 @@ EXPORTED void mboxname_release(struct mboxlock **mboxlockptr)
     }
 
     remove_lockitem(lockitem);
+
+    // if the top item is the global lock, remove that now - since
+    // everything it was protected has already closed
+    if (!config_getswitch(IMAPOPT_GLOBAL_LOCK)) return;
+    if (!open_mboxlocks) return;
+    if (strcmpsafe(open_mboxlocks->l.name, GLOBAL_LOCKNAME)) return;
+    remove_lockitem(open_mboxlocks);
 }
 
 EXPORTED int mboxname_islocked(const char *mboxname)

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -254,7 +254,7 @@ done:
 EXPORTED int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
                            int locktype_and_flags)
 {
-    if (config_getswitch(IMAPOPT_GLOBAL_LOCK) && locktype_and_flags & LOCK_EXCLUSIVE) {
+    if (config_take_globallock && locktype_and_flags & LOCK_EXCLUSIVE) {
         // if we have an exclusive lock, we MUST already be holding
 	// the shared global lock, or we have to open it.
 	if (!mboxname_islocked(GLOBAL_LOCKNAME)) {
@@ -267,9 +267,7 @@ EXPORTED int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
 
 EXPORTED int mboxname_run_with_lock(int (*cb)(void *), void *rock)
 {
-    // we could avoid reusing this infrasturcture since this SHOULD be the only lock,
-    // but it's simpler to
-    if (!config_getswitch(IMAPOPT_GLOBAL_LOCK)) return IMAP_MAILBOX_BADNAME;
+    if (!config_take_globallock) return IMAP_MAILBOX_BADNAME;
     if (open_mboxlocks) return IMAP_MAILBOX_LOCKED;
     struct mboxlock *global_lock = NULL;
     int r = mboxname_lock_item(GLOBAL_LOCKNAME, &global_lock, LOCK_EXCLUSIVE);
@@ -299,8 +297,8 @@ EXPORTED void mboxname_release(struct mboxlock **mboxlockptr)
     remove_lockitem(lockitem);
 
     // if the top item is the global lock, remove that now - since
-    // everything it was protected has already closed
-    if (!config_getswitch(IMAPOPT_GLOBAL_LOCK)) return;
+    // everything it was protecting has already closed
+    if (!config_take_globallock) return;
     if (!open_mboxlocks) return;
     if (strcmpsafe(open_mboxlocks->l.name, GLOBAL_LOCKNAME)) return;
     remove_lockitem(open_mboxlocks);

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -137,6 +137,7 @@ int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
 void mboxname_release(struct mboxlock **mboxlockptr);
 int mboxname_islocked(const char *mboxname);
 struct mboxlock *mboxname_usernamespacelock(const char *mboxname);
+int mboxname_run_with_lock(int (*cb)(void *), void *rock);
 
 /* Create namespace based on config options. */
 int mboxname_init_namespace(struct namespace *namespace, unsigned options);

--- a/imap/user.c
+++ b/imap/user.c
@@ -710,6 +710,12 @@ static const char *_namelock_name_from_userid(const char *userid)
         }
     }
 
+    if (config_skip_userlock && !strcmp(config_skip_userlock, userid)) {
+        // add a trailing character to avoid clashing with wrapping lock
+        buf_putc(&buf, '~');
+    }
+
+
     return buf_cstring(&buf);
 }
 

--- a/imap/user.c
+++ b/imap/user.c
@@ -722,6 +722,14 @@ EXPORTED struct mboxlock *user_namespacelock_full(const char *userid, int lockty
     return namelock;
 }
 
+EXPORTED int user_run_with_lock(const char *userid, int (*cb)(void *), void *rock)
+{
+    struct mboxlock *userlock = user_namespacelock(userid);
+    int r = cb(rock);
+    mboxname_release(&userlock);
+    return r;
+}
+
 EXPORTED int user_isnamespacelocked(const char *userid)
 {
     const char *name = _namelock_name_from_userid(userid);

--- a/imap/user.h
+++ b/imap/user.h
@@ -90,6 +90,7 @@ char *user_hash_xapian_byid(const char *mboxid, const char *root);
 struct mboxlock *user_namespacelock_full(const char *userid, int locktype);
 #define user_namespacelock(userid) user_namespacelock_full(userid, LOCK_EXCLUSIVE)
 int user_isnamespacelocked(const char *userid);
+int user_run_with_lock(const char *userid, int (*cb)(void *), void *rock);
 
 int user_sharee_renameacls(const struct namespace *namespace,
                            const char *olduser, const char *newuser);

--- a/lib/command.h
+++ b/lib/command.h
@@ -50,6 +50,7 @@
 #include <sys/types.h>
 #include <stdarg.h>
 #include "prot.h"
+#include "strarray.h"
 
 struct command {
     char *argv0;
@@ -59,6 +60,7 @@ struct command {
 };
 
 extern int run_command(const char *argv0, ...);
+extern int run_command_strarray(const strarray_t *argv);
 extern int command_popen(struct command **cmdp, const char *mode,
                          const char *cwd, const char *argv0, ...);
 extern int command_pclose(struct command **cmdp);

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -999,6 +999,10 @@ Blank lines and lines beginning with ``#'' are ignored.
    the ability to use the <host shortname>_mechs option to set preferred
    mechanisms for a specific host. */
 
+{ "global_lock", 1, SWITCH, "UNRELEASED" }
+/* Use a global shared lock for ALL writes, allowing the global lock
+   wrapper tool to freeze the world */
+
 { "fulldirhash", 0, SWITCH, "2.3.17" }
 /* If enabled, uses an improved directory hashing scheme which hashes
    on the entire username instead of using just the first letter as


### PR DESCRIPTION
This addresses https://github.com/cyrusimap/cyrus-imapd/issues/1763, which has been outstanding for a LONG time, but I'm finally getting to it because I was working on mailbox locking recently, and the user locks and mailbox locks are now consistent enough that it's possible to put this structure into place.

Also, I finally figured out how to make this work sensibly - it's pretty cool - because new locks ALWAYS go on the front of open_mboxlocks, and you can't change a lock from shared to exclusive - it's safe to have shared locks while running this kind of snapshot command - so I could insert the GLOBAL lock before the first exclusive lock of any type, and remove it if it's the front lock, and it guarantees coverage of all writes.  Super simple.  And reads can keep running.

One could also make it so even reads can't run, by just removing the restriction that this only applies to EXCLUSIVE locks.  Or have two locks, one that goes before any reads, and one that only goes before writes.  If we did this, we'd add another flag to cyr_withlock_run to say which one it needed, so you could even lock and run modifying commands!

But that's an enhancement for later, this is good for now!