### PR TITLE
DAV propfind: don't crash if we fail to transform iCal/vCard data

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -1726,9 +1726,6 @@ int propfind_getdata(const xmlChar *name, xmlNsPtr ns,
         struct mime_type_t *mime = *out_type;
         char *freeme = NULL;
 
-        prop = xml_add_prop(HTTP_OK, fctx->ns[NS_DAV],
-                            &propstat[PROPSTAT_OK], name, ns, NULL, 0);
-
         if (mime != mime_types) {
             /* Not the storage format - convert into requested MIME type */
             struct buf inbuf = BUF_INITIALIZER;
@@ -1739,23 +1736,32 @@ int propfind_getdata(const xmlChar *name, xmlNsPtr ns,
                 buf_free(&inbuf);
             }
 
+            if (!fctx->obj) return HTTP_UNPROCESSABLE;
+
             struct buf *outbuf = mime->from_object(fctx->obj);
             datalen = buf_len(outbuf);
-            data = freeme = buf_release(outbuf);
+            data = freeme = buf_releasenull(outbuf);
             buf_destroy(outbuf);
 
-            xmlSetProp(prop,
-                       BAD_CAST "content-type", BAD_CAST mime->content_type);
-            if (mime->version)
-                xmlSetProp(prop, BAD_CAST "version", BAD_CAST mime->version);
+            if (!data) return HTTP_UNPROCESSABLE;
         }
+
+        prop = xml_add_prop(HTTP_OK, fctx->ns[NS_DAV],
+                            &propstat[PROPSTAT_OK], name, ns, NULL, 0);
 
         xmlAddChild(prop,
                     xmlNewCDataBlock(fctx->root->doc, BAD_CAST data, datalen));
 
         fctx->flags.fetcheddata = 1;
 
-        if (freeme) free(freeme);
+        if (freeme) {
+            xmlSetProp(prop,
+                       BAD_CAST "content-type", BAD_CAST mime->content_type);
+            if (mime->version)
+                xmlSetProp(prop, BAD_CAST "version", BAD_CAST mime->version);
+
+            free(freeme);
+        }
     }
 
     return ret;

--- a/imap/http_err.et
+++ b/imap/http_err.et
@@ -191,7 +191,7 @@ ec HTTP_MISDIRECTED,
    "421 Misdirected Request"
 
 ec HTTP_UNPROCESSABLE,
-   "422 Unprocessable Entity"
+   "422 Unprocessable Content"
 
 ec HTTP_LOCKED,
    "423 Locked"                          /* RFC 4918 (WebDAV) */

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -764,7 +764,7 @@ EXPORTED struct buf *my_icalcomponent_as_ical_string(icalcomponent* comp)
     char *str = icalcomponent_as_ical_string_r(comp);
     struct buf *ret = buf_new();
 
-    buf_initm(ret, str, strlen(str));
+    if (str) buf_initm(ret, str, strlen(str));
 
     return ret;
 }

--- a/imap/vcard_support.c
+++ b/imap/vcard_support.c
@@ -464,7 +464,7 @@ EXPORTED struct buf *vcard_as_buf_x(vcardcomponent *vcard)
     char *str = vcardcomponent_as_vcard_string_r(vcard);
     struct buf *ret = buf_new();
 
-    buf_initm(ret, str, strlen(str));
+    if (str) buf_initm(ret, str, strlen(str));
 
     return ret;
 }


### PR DESCRIPTION
respond with 422 (Unprocessable Content)