### PR TITLE
vCard: strip any X-LIC-ERR properties

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -5516,7 +5516,7 @@ static int extract_vcardbuf(struct buf *raw, charset_t charset, int encoding,
         vcardbuf = raw;
     }
 
-    vcard = vcardcomponent_new_from_string(buf_cstring(vcardbuf));
+    vcard = vcard_parse_string_x(buf_cstring(vcardbuf));
     if (!vcard) {
         r = IMAP_INTERNAL;
         goto done;

--- a/imap/vcard_support.c
+++ b/imap/vcard_support.c
@@ -452,7 +452,12 @@ EXPORTED void vcard_to_v4(struct vparse_card *vcard)
 
 EXPORTED  vcardcomponent *vcard_parse_string_x(const char *str)
 {
-    return vcardcomponent_new_from_string(str);
+    vcardcomponent *vcard = vcardcomponent_new_from_string(str);
+
+    /* Remove all X-LIC-ERROR properties */
+    if (vcard) vcardcomponent_strip_errors(vcard);
+
+    return vcard;
 }
 
 EXPORTED vcardcomponent *vcard_parse_buf_x(const struct buf *buf)
@@ -476,10 +481,9 @@ EXPORTED vcardcomponent *record_to_vcard_x(struct mailbox *mailbox,
     struct buf buf = BUF_INITIALIZER;
     vcardcomponent *vcard = NULL;
 
-    /* Load message containing the resource and parse vcard data */
+    /* Load message containing the resource and parse vCard data */
     if (!mailbox_map_record(mailbox, record, &buf)) {
-        vcard = vcardcomponent_new_from_string(buf_cstring(&buf) +
-                                               record->header_size);
+        vcard = vcard_parse_string_x(buf_cstring(&buf) + record->header_size);
         buf_free(&buf);
     }
 


### PR DESCRIPTION
Also, don't return ETag on CardDAV PUT if we stripped

This PR is required when compiled against libicalvcard with:
https://github.com/libical/libical/pull/584/commits/771beabb5f28fa72b84b1b5dd6b11b3494fff00a
which now inserts X-LIC-ERR for non-fatal parse errors and continues to parse.

This allows us to parse and accept vCards with bogus properties such as REV:REV even if they already exist on disk.