### PR TITLE
runtime toggleable debug logging

### DIFF
--- a/cassandane/Cassandane/Cyrus/Simple.pm
+++ b/cassandane/Cassandane/Cyrus/Simple.pm
@@ -213,4 +213,71 @@ sub test_cmdtimer_sessionid
     }
 }
 
+sub test_toggleable_debug_logging
+    :min_version_3_9
+{
+    my ($self) = @_;
+
+    my $config_debug = $self->{instance}->{config}->get_bool('debug', 'no');
+    my $imaptalk = $self->{store}->get_client();
+
+    # can't do anything without captured syslog
+    if (!$self->{instance}->{have_syslog_replacement}) {
+        xlog $self, "can't examine syslog, test is useless";
+        return;
+    }
+
+    # find our imapd pid from syslog
+    my $loginpat = qr{
+        \bimap\[(\d+)\]:\slogin:
+        \s\S+\s\[[\d\.]+\]\scassandane\splaintext
+        \sUser\slogged\sin
+    }x;
+    my @logins = $self->{instance}->getsyslog($loginpat);
+    $self->assert_num_equals(1, scalar @logins);
+    $logins[0] =~ m/$loginpat/;
+    my $imapd_pid = $1;
+
+    for (1..5) {
+        $imaptalk->unselect();
+        my $res = $imaptalk->select('INBOX');
+        $self->assert_str_equals('ok',
+                                 $imaptalk->get_last_completion_response());
+
+        # this is really looking at cassandane's own injected syslog
+        # output, so it depends on the injected syslog doing the right
+        # thing with masking
+        my $selectpat = qr/open: user cassandane opened INBOX/;
+        my @lines = $self->{instance}->getsyslog($selectpat);
+        if ($config_debug) {
+            $self->assert_num_equals(1, scalar @lines);
+            $self->assert_matches(qr/imap\[$imapd_pid\]:/, $lines[0]);
+        }
+        else {
+            $self->assert_num_equals(0, scalar @lines);
+        }
+
+        $config_debug = !$config_debug;
+
+        # toggle debug logging by sending SIGUSR1
+        my $count = kill 'SIGUSR1', $imapd_pid;
+        $self->assert_num_equals(1, $count);
+
+        # we can also look for the message logged by cyrus at the
+        # time it toggles the value
+        my $statuspat = qr/debug logging turned (on|off)/;
+        @lines = $self->{instance}->getsyslog($statuspat);
+        $self->assert_num_equals(1, scalar @lines);
+        $self->assert_matches(qr/imap\[$imapd_pid\]:/, $lines[0]);
+        $lines[0] =~ $statuspat;
+        my $status = $1;
+        if ($config_debug) {
+            $self->assert_str_equals('on', $status);
+        }
+        else {
+            $self->assert_str_equals('off', $status);
+        }
+    }
+}
+
 1;

--- a/cassandane/utils/syslog.c
+++ b/cassandane/utils/syslog.c
@@ -88,14 +88,18 @@ EXPORTED void closelog(void)
     is_opened = 0;
 }
 
-static void fake_vsyslog(int priority __attribute__((unused)),
-                         const char *format, va_list ap)
+static void fake_vsyslog(int priority, const char *format, va_list ap)
 {
     struct timeval now = {0};
     char timestamp[16] = {0};
     int saved_errno = errno;
+    int logmask;
 
     if (!is_opened) return; /* no file to write to */
+
+    logmask = setlogmask(0); /* get the real syslog's current mask */
+    if (!(logmask & LOG_MASK(LOG_PRI(priority))))
+        return; /* do not want messages of this priority logged */
 
     gettimeofday(&now, NULL);
 

--- a/changes/next/toggleable-debug
+++ b/changes/next/toggleable-debug
@@ -1,0 +1,19 @@
+Description:
+
+Running processes can now have debug logging toggled on/off by sending
+them SIGUSR1
+
+
+Config changes:
+
+debug
+
+
+Upgrade instructions:
+
+Nothing required
+
+
+GitHub issue:
+
+None

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4852,6 +4852,9 @@ static void cmd_select(char *tag, char *cmd, char *name)
                 index_hasrights(imapd_index, ACL_READ_WRITE) ?
                 "WRITE" : "ONLY", error_message(IMAP_OK_COMPLETED));
 
+    /* n.b. this debug log line is now load-bearing -- the cassandane test
+     * Simple.toggleable_debug_logging looks for it
+     */
     syslog(LOG_DEBUG, "open: user %s opened %s", imapd_userid, name);
     goto done;
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -804,8 +804,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    For backward compatibility, if no unit is specified, seconds is
    assumed. */
 
-{ "debug", 0, SWITCH, "2.5.0" }
-/* If enabled, allow syslog() to pass LOG_DEBUG messages. */
+{ "debug", 0, SWITCH, "UNRELEASED" }
+/* If enabled, allow syslog() to pass LOG_DEBUG messages.
+.PP
+   This can be toggled for a running process by sending it SIGUSR1.
+   */
 
 { "debug_command", NULL, STRING, "2.3.17" }
 /* Debug command to be used by processes started with -D option.  The string

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -88,6 +88,7 @@ EXPORTED unsigned config_maxword;
 EXPORTED unsigned config_maxquoted;
 EXPORTED int config_qosmarking;
 EXPORTED int config_debug;
+EXPORTED toggle_debug_cb config_toggle_debug_cb = NULL;
 
 static int config_loaded;
 
@@ -657,6 +658,7 @@ EXPORTED void config_reset(void)
     config_maxword = 0;
     config_qosmarking = 0;
     config_debug = 0;
+    config_toggle_debug_cb = NULL;
 
     /* reset all the options */
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
@@ -878,6 +880,7 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
 
     /* allow debug logging */
     config_debug = config_getswitch(IMAPOPT_DEBUG);
+    if (config_toggle_debug_cb) config_toggle_debug_cb();
 }
 
 #define GROWSIZE 4096
@@ -1271,4 +1274,10 @@ static void config_read_file(const char *filename)
 
     fclose(infile);
     free(buf);
+}
+
+EXPORTED void config_toggle_debug(void)
+{
+    config_debug = !config_debug;
+    if (config_toggle_debug_cb) config_toggle_debug_cb();
 }

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -102,6 +102,11 @@ extern unsigned config_maxword;
 extern int config_qosmarking;
 extern int config_debug;
 
+/* for toggling config_debug and its behaviours at runtime */
+typedef void (*toggle_debug_cb)(void);
+extern toggle_debug_cb config_toggle_debug_cb;
+extern void config_toggle_debug(void);
+
 /* config requirement flags */
 #define CONFIG_NEED_PARTITION_DATA (1<<0)
 


### PR DESCRIPTION
This adds an API such that `config_debug` (aka "debug:" in imapd.conf) can be toggled on and off at runtime, and hooks up a signal handler such that SIGUSR1 will toggle it.  The test case tests this with `imapd`, but it should work the same for any Cyrus process (specifically, any process that calls both `cyrus_init()` and `signals_add_handlers()`).

You can already crudely toggle debug logging by changing debug: in imapd.conf and sending master a SIGHUP, but that a) affects all Cyrus process, b) only after they restart and reread the config, and c) also picks up other unrelated config changes.  This PR allows toggling debug logging on or off for a specific process, while that process is already running, and without reloading the config generally.

SIGUSR1 is already used by cunit (for test timeout handling) and Cassandane (as part of hooking a debugger to a running test process), but isn't used by Cyrus itself.  This usage shouldn't clash with the test systems' usages.