### PR TITLE
Rename between users

### DIFF
--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -3063,8 +3063,63 @@ sub test_num_folders_delete_delayed
     $self->_check_usages(storage => 0, $res_mailbox => 2);
 }
 
-sub test_storage_convquota
-    :min_version_3_3 :Conversations :ConversationsQuota
+sub test_storage_convquota_immediate
+    :min_version_3_3 :Conversations :ConversationsQuota :ImmediateDelete
+{
+    my ($self) = @_;
+
+    xlog $self, "test increasing usage of the STORAGE quota resource as messages are added";
+    $self->_set_quotaroot('user.cassandane');
+    xlog $self, "set ourselves a basic limit";
+    $self->_set_limits(storage => 100000);
+    $self->_check_usages(storage => 0);
+    my $talk = $self->{store}->get_client();
+
+    my $KEY = "/shared/vendor/cmu/cyrus-imapd/userrawquota";
+
+    $talk->create("INBOX.sub") || die "Failed to create subfolder";
+
+    # append some messages
+    $self->{store}->set_folder("INBOX");
+    my $msg = $self->make_message("Message 1",
+                                  extra_lines => 10 + rand(5000));
+    my $size1 = length($msg->as_string());
+
+    $self->{store}->set_folder("INBOX.sub");
+    my $msg2 = $self->make_message("Message 2",
+                                  extra_lines => 10 + rand(5000));
+    my $size2 = length($msg2->as_string());
+
+    my $data1 = $talk->getmetadata("INBOX", $KEY);
+    my ($rawusage1) = $data1->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
+
+    $self->_check_usages(storage => int(($size1+$size2)/1024));
+    $self->assert_num_equals(int(($size1+$size2)/1024), $rawusage1);
+
+    $talk->select("INBOX");
+    $talk->copy("1", "INBOX.sub");
+
+    my $data2 = $talk->getmetadata("INBOX", $KEY);
+    my ($rawusage2) = $data2->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
+
+    # quota usage hasn't changed, because we don't get double-charged
+    $self->_check_usages(storage => int(($size1+$size2)/1024));
+    # but raw usage has gone up by another copy of message 1
+    $self->assert_num_equals(int(($size1+$size2+$size1)/1024), $rawusage2);
+
+    $talk->delete("INBOX.sub");
+
+    my $data3 = $talk->getmetadata("INBOX", $KEY);
+    my ($rawusage3) = $data3->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
+
+    # we just lost all copies of message2
+    $self->_check_usages(storage => int($size1/1024));
+    # and also the second copy of message1, so just size1 left
+    $self->assert_num_equals(int($size1/1024), $rawusage3);
+}
+
+sub test_storage_convquota_delayed
+    :min_version_3_3 :Conversations :ConversationsQuota :DelayedDelete
 {
     my ($self) = @_;
 

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -142,6 +142,9 @@ static char *conversations_path(mbname_t *mbname)
      * it's hard-coded as the user */
     if (!mbname_userid(mbname))
         return NULL;
+    // deleted mailboxes don't have a conversations database
+    if (mbname_isdeleted(mbname))
+	return NULL;
     if (convdir)
         return strconcat(convdir, "/", mbname_userid(mbname), ".", suff, (char *)NULL);
     return mboxname_conf_getpath(mbname, suff);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6667,15 +6667,6 @@ HIDDEN int mailbox_rename_copy(struct mailbox *oldmailbox,
     assert(mailbox_index_islocked(oldmailbox, 1));
     assert(mailbox_mbtype(oldmailbox) & MBTYPE_LEGACY_DIRS);
 
-    /* we can't rename back from a deleted mailbox, because the conversations
-     * information will be wrong.  Ideally we might re-calculate, but for now
-     * we just throw a big fat error */
-    if (config_getswitch(IMAPOPT_CONVERSATIONS) &&
-        mboxname_isdeletedmailbox(mailbox_name(oldmailbox), NULL)) {
-        syslog(LOG_ERR, "can't rename a deleted mailbox %s", mailbox_name(oldmailbox));
-        return IMAP_MAILBOX_BADNAME;
-    }
-
     /* create uidvalidity if not explicitly requested */
     if (!uidvalidity)
         uidvalidity = mboxname_nextuidvalidity(newname, oldmailbox->i.uidvalidity);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6737,28 +6737,22 @@ HIDDEN int mailbox_rename_copy(struct mailbox *oldmailbox,
      * don't rename the conversations DB - instead we re-create
      * the records in the target user.  Sorry, was too complex
      * otherwise handling all the special cases */
-    if (mailbox_has_conversations(oldmailbox)) {
-        oldcstate = mailbox_get_cstate(oldmailbox);
-        assert(oldcstate);
-    }
-
-    if (mailbox_has_conversations(newmailbox)) {
-        newcstate = mailbox_get_cstate(newmailbox);
-        assert(newcstate);
-    }
+    oldcstate = mailbox_get_cstate(oldmailbox);
+    newcstate = mailbox_get_cstate(newmailbox);
 
     if (oldcstate && newcstate && !strcmp(oldcstate->path, newcstate->path)) {
         /* we can just rename within the same user */
         if (oldcstate->folders_byname) {
             r = conversations_rename_folder(oldcstate, mailbox_name(oldmailbox), newname);
         }
+        /* otherwise it's got the same key, so nothing to do */
     }
     else {
         /* have to handle each one separately */
-        if (newcstate)
-            r = mailbox_add_conversations(newmailbox, /*silent*/0);
         if (oldcstate)
             r = mailbox_delete_conversations(oldmailbox);
+        if (!r && newcstate)
+            r = mailbox_add_conversations(newmailbox, /*silent*/0);
     }
     if (r) goto fail;
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -661,7 +661,7 @@ extern int mailbox_copy_files(struct mailbox *mailbox, const char *newpart,
 extern int mailbox_delete_cleanup(struct mailbox *mailbox, const char *part, const char *name, const char *uniqueid);
 
 extern int mailbox_rename_nocopy(struct mailbox *oldmailbox,
-                                 const char *newname, int silent);
+                                 struct mboxlist_entry *newmbentry, int silent);
 
 extern int mailbox_rename_copy(struct mailbox *oldmailbox,
                                const char *newname, const char *newpart,

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2836,6 +2836,9 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
         /* Rename the mailbox metadata */
         r = mailbox_rename_nocopy(oldmailbox, newmbentry, silent);
         if (r) goto done;
+
+        // foldermodseq gets updated by the rename
+        newmbentry->foldermodseq = oldmailbox->i.highestmodseq;
     }
 
     syslog(LOG_INFO, "Rename: %s -> %s", oldname, newname);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2822,11 +2822,6 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
         newmbentry->foldermodseq = newmailbox->i.highestmodseq;
     }
     else {
-        /* Rename the mailbox metadata */
-        r = mailbox_rename_nocopy(oldmailbox, newname, silent);
-
-        if (r) goto done;
-
         /* rewrite entry with new name */
         newmbentry = mboxlist_entry_create();
         newmbentry->name = xstrdupnull(newname);
@@ -2837,6 +2832,10 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
         newmbentry->uniqueid = xstrdupnull(mailbox_uniqueid(oldmailbox));
         newmbentry->createdmodseq = oldmailbox->i.createdmodseq;
         newmbentry->foldermodseq = oldmailbox->i.highestmodseq;
+
+        /* Rename the mailbox metadata */
+        r = mailbox_rename_nocopy(oldmailbox, newmbentry, silent);
+        if (r) goto done;
     }
 
     syslog(LOG_INFO, "Rename: %s -> %s", oldname, newname);


### PR DESCRIPTION
We found an issue in Fastmail production where a user had done:

1) `rename user.A.foo user.B.foo`

followed by

2) `rename user.B.foo user.A.foo`

Which had caused conversations to be all broken because we weren't correctly detecting this case in the mailbox_rename_nocopy (uuid paths) case.

This PR adds a test for the case, then code to make it work (and yes, I did tdd this!)