### PR TITLE
Allow limiting Sieve :regex execution time

### DIFF
--- a/cassandane/tiny-tests/Sieve/regex-timeout
+++ b/cassandane/tiny-tests/Sieve/regex-timeout
@@ -1,0 +1,57 @@
+#!perl
+use Cassandane::Tiny;
+use Cassandane::Util::Slurp;
+use Cwd qw(abs_path);
+
+sub test_regex_timeout
+    :min_version_3_9 :needs_component_sieve :NoAltNameSpace :NoStartInstances
+{
+    my ($self) = @_;
+
+    # The regex below takes ~0.75s to execute on the given input
+    $self->{instance}->{config}->set('sieve_regex_timeout' => '0.5');
+    $self->_start_instances();
+
+    xlog, $self, "Create manifold user and make it readable by cassandane";
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->create("user.manifold");
+    $admintalk->setacl("user.manifold", cassandane => 'lrs');
+
+    xlog $self, "Install a script for cassandane";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["regex", "imap4flags"];
+if header :regex "Subject"
+  "a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaa" {
+    addflag "\\\\Flagged";
+    keep;
+}
+EOF
+    );
+
+    xlog $self, "Install a script for manifold";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["regex", "imap4flags"];
+if header :regex "Subject" "aaaa" {
+    keep :flags "\\\\Flagged";
+}
+EOF
+    , username => 'manifold');
+
+    my $msg = $self->{gen}->generate(subject => 'aaaaaaaaaaaaaaaaaaaaaaaaa');
+    $self->{instance}->deliver($msg, users => [ 'cassandane', 'manifold' ]);
+
+    xlog $self, "Check that the message made it to INBOX due to Sieve failure";
+    $self->{store}->set_folder('INBOX');
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+    $msg->set_attribute(uid => 1);
+    $msg->set_attribute(flags => [ '\\Recent', '$SieveFailed' ]);
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Check that the message made it to manifold INBOX with \Flagged";
+    $self->{store}->set_folder('user.manifold');
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+    $msg->set_attribute(uid => 1);
+    $msg->set_attribute(flags => [ '\\Recent', '\\Flagged' ]);
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+}
+

--- a/changes/next/sieve_regex_timeout
+++ b/changes/next/sieve_regex_timeout
@@ -1,0 +1,14 @@
+
+Description:
+
+Allow limiting Sieve :regex execution time.
+
+
+Config changes:
+
+Adds 'sieve_regex_timeout' option.
+
+
+Upgrade instructions:
+
+None.

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2696,6 +2696,12 @@ product version in the capabilities
 /* Maximum number of sieve scripts any user may have, enforced at
    submission by timsieved(8). */
 
+{ "sieve_regex_timeout", NULL, STRING, "UNRELEASED" }
+/* Time in floating point seconds. Any Sieve :regex match that takes
+   longer than this time is aborted and the script will fail (message
+   will be delivered to INBOX).
+   A NULL value (default) or a value of "0" will disable the timeout */ 
+
 { "sieve_utf8fileinto", 0, SWITCH, "2.3.17" }
 /* If enabled, the sieve engine expects folder names for the
    \fIfileinto\fR action in scripts to use UTF8 encoding.  Otherwise,

--- a/sieve/sieve_err.et
+++ b/sieve/sieve_err.et
@@ -65,6 +65,9 @@ ec SIEVE_DONE,
 ec SIEVE_SCRIPT_RELOADED,
    "Sieve script was loaded in the past"
 
+ec SIEVE_REGEX_TIMEOUT,
+   "Sieve :regex execution too long"
+
 
 # Parse errors
 


### PR DESCRIPTION
This will about from regexec(), and return an error code so that execution of the script will fail (message still delivered to INBOX)
The lmtpd will be terminated after the message has been delivered to all recipients.