### PR TITLE
Add libxml/parser.h include (2)

### DIFF
--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -52,6 +52,8 @@
 #include <unistd.h>
 #endif
 
+#include <libxml/parser.h>
+
 #include "acl.h"
 #include "annotate.h"
 #include "append.h"


### PR DESCRIPTION
This is required for libxml2 2.12.0 and above.

Missing piece in PR #4745.


Revealed when compiled with --enable-jmap.