### PR TITLE
tls_th-lock.c: compile without ssl.h

### DIFF
--- a/imap/tls_th-lock.c
+++ b/imap/tls_th-lock.c
@@ -8,11 +8,9 @@
 #include <pthread.h>
 #include <syslog.h>
 
-#include <openssl/ssl.h>
-
-#include "tls_th-lock.h"
-
 #ifdef HAVE_SSL
+#include <openssl/ssl.h>
+#include "tls_th-lock.h"
 
 /*
  * This entire interface is obsoleted by OpenSSL 1.1.0.


### PR DESCRIPTION
`./configure --without-openssl && make` produces
```
External dependencies:
   openssl:            no
…
  CC       imap/libcyrus_imap_la-tls_th-lock.lo
imap/tls_th-lock.c:11:10: fatal error: openssl/ssl.h: No such file or directory
   11 | #include <openssl/ssl.h>
      |          ^~~~~~~~~~~~~~~
```
This change permits compiling Cyrus IMAP after `./configure --without-openssl && make`, when `ssl.h` is missing.