### PR TITLE
message_parse_received_date() avoid calling `message_parse_string(hdr="")`

### DIFF
--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -1391,4 +1391,17 @@ static void test_parse_bogus_charset_params(void)
 #undef TESTCASE
 }
 
+/*
+ * Verifies that message_parse_received_date() does not read
+ * uninitialized data in the second call to message_parse_string()
+ */
+static void test_parse_received_semicolon(void)
+{
+   static const char msg[] = "Received: abc;\r\n\r\nd";
+   struct body body;
+   memset(&body, 0x45, sizeof(body));
+   CU_ASSERT_EQUAL(message_parse_mapped(msg, sizeof(msg)-1, &body, NULL), 0);
+   CU_ASSERT_STRING_EQUAL(body.received_date, "");
+   message_free_body(&body);
+}
 /* vim: set ft=c: */

--- a/imap/message.c
+++ b/imap/message.c
@@ -2010,7 +2010,7 @@ static void message_parse_received_date(const char *hdr, char **hdrp)
     curp--;
 
   /* Didn't find ; - fill in hdrp so we don't look at next received header */
-  if (curp == hdrbuf) {
+  if (curp == hdrbuf || curp[1] == '\0') {
     *hdrp = hdrbuf;
     return;
   }


### PR DESCRIPTION
as the latter does `hdr = strchr(hdr+1, '\n')` and `hdr+1` is not allocated.

Without the change in message.c, calling 

> $ valgrind --trace-children=yes ./cunit/unit cunit/message:parse_received_semicolon

prints
```
==176956== Invalid read of size 1                                   
==176956==    at 0x7F25960: __strchr_avx2 (strchr-avx2.S:53)        
==176956==    by 0x490AA62: message_parse_string (message.c:1180)                                                                       
==176956==    by 0x490CCDE: message_parse_received_date (message.c:2019)         
==176956==    by 0x490A3F1: message_parse_headers (message.c:981)                                                                       
==176956==    by 0x4909BAD: message_parse_body (message.c:779)                                                                          
==176956==    by 0x4908FEF: message_parse_mapped (message.c:525)    
==176956==    by 0x53800A: test_parse_received_semicolon (message.testc:1403)
==176956==    by 0x4112F8: __cunit_wrap_test (unit.c:159)
==176956==    by 0x538C5E: __cunit_test_parse_received_semicolon (message.testc-cunit.c:143)
==176956==    by 0x789266A: run_single_test.constprop.0 (TestRun.c:991)
==176956==    by 0x7894DE7: CU_run_test (TestRun.c:473)
==176956==    by 0x411C25: run_tests (unit.c:389)
==176956==  Address 0x8563245 is 0 bytes after a block of size 5 alloc'd
==176956==    at 0x484278B: malloc (vg_replace_malloc.c:431)
==176956==    by 0x4C4E328: xmalloc (xmalloc.c:56)
==176956==    by 0x4C4E553: xstrndup (xmalloc.c:115)
==176956==    by 0x490AAE3: message_parse_string (message.c:1190)
==176956==    by 0x490CC78: message_parse_received_date (message.c:1999)
==176956==    by 0x490A3F1: message_parse_headers (message.c:981)
==176956==    by 0x4909BAD: message_parse_body (message.c:779)
==176956==    by 0x4908FEF: message_parse_mapped (message.c:525)
==176956==    by 0x53800A: test_parse_received_semicolon (message.testc:1403)
==176956==    by 0x4112F8: __cunit_wrap_test (unit.c:159)
==176956==    by 0x538C5E: __cunit_test_parse_received_semicolon (message.testc-cunit.c:143)
==176956==    by 0x789266A: run_single_test.constprop.0 (TestRun.c:991)
```