### PR TITLE
Fix compilation failure due to -Werror flag

### DIFF
--- a/docsrc/imap/concepts/deployment/storage.rst
+++ b/docsrc/imap/concepts/deployment/storage.rst
@@ -969,11 +969,3 @@ chunks, which may not be what you require at that moment.
 .. _Cluster LVM: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Logical_Volume_Manager_Administration/LVM_Cluster_Overview.html
 .. _dm-cache: http://en.wikipedia.org/wiki/Dm-cache
 .. _Kolab Systems AG: https://kolabsys.com
-
-.. glossary::
-        MTBF
-            Mean Time Between Failures
-
-.. glossary::
-        HBA
-            Host Bus Adapter - connects a host system (computer) to other network and storage devices

--- a/docsrc/imap/concepts/features/server-aggregation.rst
+++ b/docsrc/imap/concepts/features/server-aggregation.rst
@@ -387,13 +387,3 @@ Back to :ref:`imap-features`
 
     Including but not limited to ``SELECT``, ``UID MOVE``, ``RENAME``,
     etc.
-
-.. glossary::
-
-    frontend
-	  the user interface
-
-.. glossary::
-
-	backend
-	  the server components

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3816,7 +3816,7 @@ int parse_xml_body(struct transaction_t *txn, xmlNodePtr *root,
         return HTTP_BAD_REQUEST;
     }
     else {
-        xmlErrorPtr err = xmlCtxtGetLastError(txn->conn->xml);
+        const xmlError *err = xmlCtxtGetLastError(txn->conn->xml);
         if (err) {
             xmlFreeDoc(doc);
             txn->error.desc = err->message;


### PR DESCRIPTION
This is an attempt to get this commands working for building the cyrus-imapd:

```bash
autoreconf -i
./configure CFLAGS="-W -Wno-unused-parameter -g -O0 -Wall -Wextra -Werror -fPIC --std=gnu99"   \
    --enable-srs --enable-afs --enable-autocreate --enable-idled --enable-nntp --enable-murder \
    --enable-http --enable-calalarmd --enable-jmap --enable-xapian --enable-replication        \
    --enable-backup --enable-cmulocal --enable-oldsievename --enable-unit-tests                \
    --enable-cyrusdb-benchmarks
make lex-fix
cd perl/annotator; perl Makefile.PL
cd ../imap; perl Makefile.PL
cd ../sieve/managesieve; perl Makefile.PL
cd ../../..
make -j8
make check
```

Without error caused by warning and `-Werror` flag. Also notes that currently I'm working with upstream's latest stable version of toolchains and dependencies. Thus, the fix might not quite relevant on Debian but definitely needed in rolling release distributions like Arch.