### PR TITLE
fix typo in promstatsd error message

### DIFF
--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -690,7 +690,7 @@ int main(int argc, char **argv)
 
     if (!config_getswitch(IMAPOPT_PROMETHEUS_ENABLED)) {
         fatal("Prometheus metrics are not being tracked."
-              "  Set prometheus_enable in imapd.conf",
+              "  Set prometheus_enabled in imapd.conf",
               EX_CONFIG);
     }
 


### PR DESCRIPTION
The message so far read

cyrus/promstatsd[17284]: Prometheus metrics are not being tracked.  Set prometheus_enable in imapd.conf

and I added that setting to my imapd.conf, which didn't solve the problem. Further investigation resulted in detecting that the parameter actually is called "prometheus_enabled" and not "prometheus_enable".

Let's fix the error message to avoid others falling into the same trap.