### PR TITLE
installed headers don't compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ cunit/unit
 debian/
 depcomp
 doc/examples/imapd_conf/imapd.conf.sample
+doc/examples/libcyrus/example_libcyrus_min
 doc/html/
 doc/legacy/murder.png
 doc/legacy/netnews.png

--- a/Makefile.am
+++ b/Makefile.am
@@ -808,6 +808,7 @@ include_HEADERS = \
     lib/vparse.h \
     lib/wildmat.h \
     lib/xmalloc.h \
+    lib/xsha1.h \
     lib/xunlink.h
 
 nodist_include_HEADERS = \
@@ -825,7 +826,6 @@ noinst_HEADERS += \
     lib/ptrarray.h \
     lib/slowio.h \
     lib/util.h \
-    lib/xsha1.h \
     lib/xstrlcat.h \
     lib/xstrlcpy.h \
     lib/xstrnchr.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -764,7 +764,6 @@ include_HEADERS = \
     lib/bitvector.h \
     lib/bloom.h \
     lib/bsearch.h \
-    lib/bufarray.h \
     lib/charset.h \
     lib/chartable.h \
     lib/command.h \
@@ -805,7 +804,6 @@ include_HEADERS = \
     lib/stristr.h \
     lib/times.h \
     lib/tok.h \
-    lib/vparse.h \
     lib/wildmat.h \
     lib/xmalloc.h \
     lib/xsha1.h \
@@ -818,6 +816,7 @@ nobase_include_HEADERS = sieve/sieve_interface.h
 nobase_nodist_include_HEADERS = sieve/sieve_err.h
 
 noinst_HEADERS += \
+    lib/bufarray.h \
     lib/byteorder.h \
     lib/gai.h \
     lib/libconfig.h \
@@ -826,6 +825,7 @@ noinst_HEADERS += \
     lib/ptrarray.h \
     lib/slowio.h \
     lib/util.h \
+    lib/vparse.h \
     lib/xstrlcat.h \
     lib/xstrlcpy.h \
     lib/xstrnchr.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -1549,13 +1549,11 @@ lib_libcyrus_min_la_SOURCES = \
     lib/util.c \
     lib/vparse.c \
     lib/xmalloc.c \
+    lib/xsha1.c \
     lib/xstrlcat.c \
     lib/xstrlcpy.c \
     lib/xstrnchr.c \
     lib/xunlink.c
-if !HAVE_SSL
-lib_libcyrus_min_la_SOURCES += lib/xsha1.c
-endif
 if IPV6_noGETADDRINFO
 lib_libcyrus_min_la_SOURCES += lib/getaddrinfo.c
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -764,7 +764,6 @@ include_HEADERS = \
     lib/bloom.h \
     lib/bsearch.h \
     lib/charset.h \
-    lib/chartable.h \
     lib/command.h \
     lib/crc32.h \
     lib/cyr_lock.h \
@@ -1464,6 +1463,7 @@ lib_libcyrus_la_SOURCES = \
     lib/bloom.c \
     lib/bsearch.c \
     lib/charset.c \
+    lib/chartable.h \
     lib/command.c \
     lib/cyr_qsort_r.c \
     lib/cyrusdb.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -760,7 +760,6 @@ include_HEADERS = \
     lib/arrayu64.h \
     lib/assert.h \
     lib/auth.h \
-    lib/auth_pts.h \
     lib/bitvector.h \
     lib/bloom.h \
     lib/bsearch.h \
@@ -1459,6 +1458,7 @@ lib_libcyrus_la_SOURCES = \
     lib/auth_krb5.c \
     lib/auth_mboxgroups.c \
     lib/auth_pts.c \
+    lib/auth_pts.h \
     lib/auth_unix.c \
     lib/bitvector.c \
     lib/bloom.c \

--- a/cassandane/Cassandane/Cyrus/LibCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/LibCyrus.pm
@@ -173,6 +173,15 @@ sub run_test
 
     my $runerr = $self->{instance}->{basedir} . "/$name.err";
 
+    my @cmd;
+    my $cassini = Cassandane::Cassini->instance();
+    if ($cassini->bool_val('valgrind', 'enabled')) {
+        push @cmd, $self->{instance}->_valgrind_setup($name);
+    }
+
+    push @cmd, $self->{instance}->{basedir} . "/$name",
+               '-C', $self->{instance}->_imapd_conf();
+
     eval {
         $self->{instance}->run_command({
                 cyrus => 0,
@@ -180,8 +189,7 @@ sub run_test
                     stderr => $runerr,
                 },
             },
-            $self->{instance}->{basedir} . "/$name",
-            '-C', $self->{instance}->_imapd_conf(),
+            @cmd,
         );
     };
     if ($@) {

--- a/cassandane/Cassandane/Cyrus/LibCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/LibCyrus.pm
@@ -80,6 +80,9 @@ sub run_pkgconfig
     my $outfname = $self->{instance}->{basedir} . "/pkg-config.out";
     my $errfname = $self->{instance}->{basedir} . "/pkg-config.err";
 
+    my $cassini = Cassandane::Cassini->instance();
+    my $pkgconfig = $cassini->val('paths', 'pkg-config', '/usr/bin/pkg-config');
+
     $self->{instance}->run_command({
             cyrus => 0,
             redirects => {
@@ -87,7 +90,7 @@ sub run_pkgconfig
                 stderr => $errfname,
             },
         },
-        '/usr/bin/pkg-config', @options, $package
+        $pkgconfig, @options, $package
     );
 
     my $val = slurp_file($outfname);
@@ -130,6 +133,8 @@ sub run_test
 {
     my ($self) = @_;
 
+    my $cassini = Cassandane::Cassini->instance();
+
     my $name = $self->name();
     $name =~ s/^test_//;
 
@@ -150,6 +155,7 @@ sub run_test
     my $ldlibs = $self->run_pkgconfig($lib, '--libs-only-l');
 
     my $makeerr = $self->{instance}->{basedir} . "/make.err";
+    my $make = $cassini->val('paths', 'make', '/usr/bin/make');
 
     eval {
         $self->{instance}->run_command({
@@ -158,7 +164,7 @@ sub run_test
                     stderr => $makeerr,
                 },
             },
-            '/usr/bin/make',
+            $make,
             "CFLAGS=-Wall -Wextra -Werror -g -O0 $cflags",
             "LDFLAGS=$ldflags",
             "LDLIBS=$ldlibs",
@@ -174,7 +180,6 @@ sub run_test
     my $runerr = $self->{instance}->{basedir} . "/$name.err";
 
     my @cmd;
-    my $cassini = Cassandane::Cassini->instance();
     if ($cassini->bool_val('valgrind', 'enabled')) {
         push @cmd, $self->{instance}->_valgrind_setup($name);
     }

--- a/cassandane/Cassandane/Cyrus/LibCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/LibCyrus.pm
@@ -157,6 +157,9 @@ sub run_test
     my $makeerr = $self->{instance}->{basedir} . "/make.err";
     my $make = $cassini->val('paths', 'make', '/usr/bin/make');
 
+    my $warnopts = '-Wall -Wextra -Werror';
+    my $otheropts = '-g -O0 -fdiagnostics-color=always';
+
     eval {
         $self->{instance}->run_command({
                 cyrus => 0,
@@ -165,7 +168,7 @@ sub run_test
                 },
             },
             $make,
-            "CFLAGS=-Wall -Wextra -Werror -g -O0 $cflags",
+            "CFLAGS=$warnopts $otheropts $cflags",
             "LDFLAGS=$ldflags",
             "LDLIBS=$ldlibs",
             '-C', $self->{instance}->{basedir},  # n.b. not cyrus's -C

--- a/cassandane/Cassandane/Cyrus/LibCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/LibCyrus.pm
@@ -1,0 +1,194 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2011-2024 FastMail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Cyrus::LibCyrus;
+use strict;
+use warnings;
+use Cwd qw(abs_path);
+use Data::Dumper;
+use DateTime;
+use File::Copy;
+use File::Find;
+
+use lib '.';
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+use Cassandane::Util::Slurp;
+
+$Data::Dumper::Sortkeys = 1;
+
+my $examples_dir = abs_path('../doc/examples/libcyrus');
+
+sub new
+{
+    my $class = shift;
+    return $class->SUPER::new({}, @_);
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+    $self->SUPER::tear_down();
+}
+
+sub run_pkgconfig
+{
+    my ($self, $package, @options) = @_;
+
+    my $outfname = $self->{instance}->{basedir} . "/pkg-config.out";
+    my $errfname = $self->{instance}->{basedir} . "/pkg-config.err";
+
+    $self->{instance}->run_command({
+            cyrus => 0,
+            redirects => {
+                stdout => $outfname,
+                stderr => $errfname,
+            },
+        },
+        '/usr/bin/pkg-config', @options, $package
+    );
+
+    my $val = slurp_file($outfname);
+    chomp $val;
+
+    return $val;
+}
+
+sub find_tests
+{
+    my ($dir) = @_;
+
+    my @tests;
+
+    find(
+        sub {
+            my $file = $File::Find::name;
+
+            return unless $file =~ s/\.c$//;
+            return unless -f "$file.c";
+            $file =~ s/^$dir\/?//;
+            push @tests, "test_$file";
+        },
+        $dir,
+    );
+
+    return @tests;
+}
+
+sub list_tests
+{
+    my @tests;
+
+    @tests = find_tests($examples_dir);
+
+    return @tests;
+}
+
+sub run_test
+{
+    my ($self) = @_;
+
+    my $name = $self->name();
+    $name =~ s/^test_//;
+
+    my $lib;
+    if ($name =~ m/(libcyrus(?:_\w+)?)/) {
+        $lib = $1;
+    }
+    else {
+        die "couldn't determine libcyrus dependency for test_$name";
+    }
+
+    copy("$examples_dir/$name.c", $self->{instance}->{basedir})
+        or die "copy $examples_dir/$name.c: $!";
+
+    my $cflags = $self->run_pkgconfig($lib, '--cflags');
+    my $ldflags = $self->run_pkgconfig($lib, '--libs-only-L',
+                                             '--libs-only-other');
+    my $ldlibs = $self->run_pkgconfig($lib, '--libs-only-l');
+
+    my $makeerr = $self->{instance}->{basedir} . "/make.err";
+
+    eval {
+        $self->{instance}->run_command({
+                cyrus => 0,
+                redirects => {
+                    stderr => $makeerr,
+                },
+            },
+            '/usr/bin/make',
+            "CFLAGS=-Wall -Wextra -Werror -g -O0 $cflags",
+            "LDFLAGS=$ldflags",
+            "LDLIBS=$ldlibs",
+            '-C', $self->{instance}->{basedir},  # n.b. not cyrus's -C
+            $name,
+        );
+    };
+    if ($@) {
+        xlog "make failed:\n" . slurp_file($makeerr);
+        die $@;
+    }
+
+    my $runerr = $self->{instance}->{basedir} . "/$name.err";
+
+    eval {
+        $self->{instance}->run_command({
+                cyrus => 0,
+                redirects => {
+                    stderr => $runerr,
+                },
+            },
+            $self->{instance}->{basedir} . "/$name",
+            '-C', $self->{instance}->_imapd_conf(),
+        );
+    };
+    if ($@) {
+        xlog "$name failed:\n" . slurp_file($runerr);
+        die $@;
+    }
+
+}
+
+1;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -2003,6 +2003,9 @@ sub _fork_command
         $ENV{CASSANDANE_SYSLOG_FNAME} = abs_path($self->{syslog_fname});
         $ENV{LD_PRELOAD} = abs_path('utils/syslog.so')
     }
+    $ENV{PKG_CONFIG_PATH} = $self->{cyrus_destdir}
+                          . $self->{cyrus_prefix}
+                          . "/lib/pkgconfig";
 
 #     xlog "\$PERL5LIB is"; map { xlog "    $_"; } split(/:/, $ENV{PERL5LIB});
 
@@ -2012,13 +2015,10 @@ sub _fork_command
     # entirely clear how to detect that - we could use readelf -d
     # on an executable to discover what it thinks it's RPATH ought
     # to be, then prepend destdir to that.
-    if ($self->{cyrus_destdir} ne "")
-    {
-        $ENV{LD_LIBRARY_PATH} = join(':', (
-                $self->{cyrus_destdir} . $self->{cyrus_prefix} . "/lib",
-                split(/:/, $ENV{LD_LIBRARY_PATH} || "")
-        ));
-    }
+    $ENV{LD_LIBRARY_PATH} = join(':', (
+            $self->{cyrus_destdir} . $self->{cyrus_prefix} . "/lib",
+            split(/:/, $ENV{LD_LIBRARY_PATH} || "")
+    ));
 #     xlog "\$LD_LIBRARY_PATH is"; map { xlog "    $_"; } split(/:/, $ENV{LD_LIBRARY_PATH});
 
     my $cd = $options->{workingdir};

--- a/cassandane/cassandane.ini.example
+++ b/cassandane/cassandane.ini.example
@@ -216,3 +216,10 @@
 ## basedir =
 # A list of tests which will be suppressed
 ## suppress =
+
+# This section describes where certain system tools are installed.  The
+# defaults are probably usually fine, but here's where to override them
+# if not
+[paths]
+## make = /usr/bin/make
+## pkg-config = /usr/bin/pkg-config

--- a/doc/examples/libcyrus/example_libcyrus.c
+++ b/doc/examples/libcyrus/example_libcyrus.c
@@ -4,12 +4,14 @@
  *
    export LD_LIBRARY_PATH=/path/to/cyrus/lib
    export PKG_CONFIG_PATH=/path/to/cyrus/lib/pkgconfig
-   export CFLAGS=-Wall -Wextra -Werror -g -O0 $(pkg-config --cflags libcyrus_min)
-   export LDFLAGS=$(pkg-config --libs-only-L --libs-only-other libcyrus)
-   export LDLIBS=$(pkg-config --libs-only-l libcyrus)
+   export CFLAGS=-Wall -Wextra -Werror -g -O0 $(pkg-config --cflags libcyrus libcyrus_min)
+   export LDFLAGS=$(pkg-config --libs-only-L --libs-only-other libcyrus libcyrus_min)
+   export LDLIBS=$(pkg-config --libs-only-l libcyrus libcyrus_min)
    make example_libcyrus
    ./example_libcyrus
  */
+
+/* DEPS: libcyrus libcyrus_min */
 
 #define _GNU_SOURCE 1
 
@@ -210,6 +212,9 @@ void test_imclient(void)
     /* XXX though there's already an "example" imclient in the imclient.3 man
      * page, though the API it demonstrates doesn't match the headers, so i
      * guess it's bitrotted
+     */
+    /* XXX might need a separate example_imclient.c, which is possible now that
+     * the file name isn't the dependencies list!
      */
 }
 #endif

--- a/doc/examples/libcyrus/example_libcyrus.c
+++ b/doc/examples/libcyrus/example_libcyrus.c
@@ -1,0 +1,244 @@
+/* example for linking against libcyrus.so
+ *
+ * compile and run something like:
+ *
+   export LD_LIBRARY_PATH=/path/to/cyrus/lib
+   export PKG_CONFIG_PATH=/path/to/cyrus/lib/pkgconfig
+   export CFLAGS=-Wall -Wextra -Werror -g -O0 $(pkg-config --cflags libcyrus_min)
+   export LDFLAGS=$(pkg-config --libs-only-L --libs-only-other libcyrus)
+   export LDLIBS=$(pkg-config --libs-only-l libcyrus)
+   make example_libcyrus
+   ./example_libcyrus
+ */
+
+#define _GNU_SOURCE 1
+
+#include "acl.h"
+#include "auth.h"
+#include "bitvector.h"
+#include "bloom.h"
+#include "bsearch.h"
+/* #include "charset.h" */  /* XXX bogus: needs util.h for struct buf */
+/* #include "command.h" */  /* XXX bogus: needs prot.h for struct protstream */
+#include "cyr_qsort_r.h"
+#include "cyrusdb.h"
+#include "glob.h"
+/* #include "imapurl.h" */  /* XXX bogus: needs util.h for struct buf */
+#include "imclient.h"
+#include "imparse.h"
+#include "iostat.h"
+#include "iptostring.h"
+#include "libcyr_cfg.h"
+#include "lsort.h"
+/* #include "mappedfile.h" */ /* XXX bogus: needs util.h for struct buf */
+#include "murmurhash2.h"
+#include "nonblock.h"
+#include "parseaddr.h"
+#include "procinfo.h"
+/* #include "rfc822tok.h" */ /* XXX bogus: needs util.h for struct buf */
+#include "seqset.h"
+#include "signals.h"
+/* #include "sqldb.h" */ /* XXX bogus: needs ptrarray.h */
+#include "stristr.h"
+#include "times.h"
+#include "wildmat.h"
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sysexits.h>
+#include <time.h>
+
+/* XXX lib/libconfig.h is not installed, have to provide our own prototypes */
+extern void config_read(const char *alt_config, const int config_need_data);
+extern const char *config_dir;
+
+void fatal(const char *s, int code)
+{
+    fputs(s, stderr);
+    exit(code);
+}
+
+void usage(void)
+{
+    fputs("usage", stderr);
+    exit(EX_USAGE);
+}
+
+void test_acl(void)
+{
+    const char str[] = "lrswipckxtedan";
+    char *errstr = NULL;
+    int mask;
+
+    cyrus_acl_checkstr(str, &errstr);
+    free(errstr);
+
+    mask = cyrus_acl_strtomask(str, &mask);
+    (void) mask;
+
+    puts("acl ok");
+}
+
+void test_auth(void)
+{
+    const char id[] = "cassandane";
+    const char *canonid;
+
+    canonid = auth_canonifyid(id, strlen(id));
+    (void) canonid;
+
+    puts("auth ok");
+}
+
+void test_bitvector(void)
+{
+    bitvector_t bv = BV_INITIALIZER;
+    char *str = NULL;
+    unsigned u;
+
+    for (u = 0; u < 20; u++) {
+        if (u % 5 == 0 || u % 3 == 0)
+            bv_set(&bv, u);
+    }
+
+    str = bv_cstring(&bv);
+    free(str);
+
+    bv_fini(&bv);
+    puts("bitvector ok");
+}
+
+void test_bloom(void)
+{
+    struct bloom bloom;
+    unsigned u;
+
+    bloom_init(&bloom, 4000000, 0.01);
+
+    for (u = 0; u < 20; u++) {
+        char buf[128];
+
+        snprintf(buf, sizeof(buf), "%u", u);
+
+        bloom_add(&bloom, buf, strlen(buf));
+    }
+
+    bloom_free(&bloom);
+    puts("bloom ok");
+}
+
+void test_bsearch(void)
+{
+    const char *s1 = "hello", *s2 = "world";
+    int cmp;
+
+    cmp = cmpstringp_raw(&s1, &s2);
+    cmp = cmpstringp_mbox(&s1, &s2);
+    (void) cmp;
+
+    puts("bsearch ok");
+}
+
+static int cmp QSORT_R_COMPAR_ARGS(const void *a, const void *b,
+                                   void *thunk __attribute__((unused)))
+{
+    return *(const int *) a - *(const int *) b;
+}
+
+void test_cyr_qsort_r(void)
+{
+    int array[20];
+    const size_t n_elem = sizeof array / sizeof array[0];
+    unsigned u;
+
+    srand(time(NULL));
+    for (u = 0; u < n_elem; u++) {
+        array[u] = rand();
+    }
+
+    cyr_qsort_r(array, n_elem, sizeof(array[0]), &cmp, NULL);
+
+    puts("cyr_qsort_r ok");
+}
+
+void test_cyrusdb(void)
+{
+    const char *dbname = "twoskip";
+    char fname[1024] = "";
+    struct db *db = NULL;
+    struct txn *tid = NULL;
+    const char key[] = "cassandane";
+    size_t keylen = sizeof(key) - 1;
+    const char *data = NULL;
+    size_t datalen = 0;
+    int r;
+
+    snprintf(fname, sizeof(fname), "%s/%s", config_dir, "foo.db");
+
+    r = cyrusdb_open(dbname, fname, CYRUSDB_CREATE, &db);
+    if (!r) r = cyrusdb_store(db, key, keylen, "foo", strlen("foo"), &tid);
+    if (!r) r = cyrusdb_fetch(db, key, keylen, &data, &datalen, &tid);
+    if (!r) r = cyrusdb_commit(db, tid);
+
+    r = cyrusdb_close(db);
+    (void) r;
+
+    puts("cyrusdb ok");
+}
+
+void test_glob(void)
+{
+    glob *g;
+    int r;
+
+    g = glob_init("fo*", '.');
+
+    r = glob_test(g, "foo");
+    (void) r;
+
+    glob_free(&g);
+    puts("glob ok");
+}
+
+#if 0
+void test_imclient(void)
+{
+    /* XXX need somewhere to connect to...  cass already has an imapd running,
+     * right? could get the host:port for that as commandline args i guess
+     */
+    /* XXX though there's already an "example" imclient in the imclient.3 man
+     * page, though the API it demonstrates doesn't match the headers, so i
+     * guess it's bitrotted
+     */
+}
+#endif
+
+int main(int argc, char **argv)
+{
+    const char *alt_config = NULL;
+    int opt;
+
+    while ((opt = getopt(argc, argv, "C:")) != -1) {
+        switch(opt) {
+        case 'C': /* alt config file */
+            alt_config = optarg;
+            break;
+
+        default:
+            usage();
+            break;
+        }
+    }
+
+    config_read(alt_config, 0);
+
+    test_acl();
+    test_auth();
+    test_bitvector();
+    test_bloom();
+    test_bsearch();
+    test_cyr_qsort_r();
+    test_cyrusdb();
+    test_glob();
+}

--- a/doc/examples/libcyrus/example_libcyrus_min.c
+++ b/doc/examples/libcyrus/example_libcyrus_min.c
@@ -234,6 +234,22 @@ void test_xmalloc(void)
     free(s);
 }
 
+void test_xsha1(void)
+{
+    SHA1_CTX ctx = {0};
+    unsigned char digest[SHA1_DIGEST_LENGTH];
+    const unsigned char data[] = "this is some data";
+
+    SHA1Init(&ctx);
+    SHA1Update(&ctx, data, sizeof(data));
+    SHA1Final(digest, &ctx);
+
+    memset(&ctx, 0, sizeof(ctx));
+    xsha1(data, sizeof(data), digest);
+
+    puts("xsha1 ok");
+}
+
 /* XXX lib/libconfig.h is not installed, have to provide our own prototype */
 extern void config_read(const char *alt_config, const int config_need_data);
 
@@ -269,4 +285,5 @@ int main(int argc, char **argv)
     test_strhash();
     test_tok();
     test_xmalloc();
+    test_xsha1();
 }

--- a/doc/examples/libcyrus/example_libcyrus_min.c
+++ b/doc/examples/libcyrus/example_libcyrus_min.c
@@ -1,0 +1,272 @@
+/* example for linking against libcyrus_min.so
+ *
+ * compile and run something like:
+ *
+   export LD_LIBRARY_PATH=/path/to/cyrus/lib
+   export PKG_CONFIG_PATH=/path/to/cyrus/lib/pkgconfig
+   export CFLAGS=-Wall -Wextra -Werror -g -O0 $(pkg-config --cflags libcyrus_min)
+   export LDFLAGS=$(pkg-config --libs-only-L --libs-only-other libcyrus_min)
+   export LDLIBS=$(pkg-config --libs-only-l libcyrus_min)
+   make example_libcyrus_min
+   ./example_libcyrus_min
+ */
+
+#include "arrayu64.h"
+#include "assert.h"
+#include "dynarray.h"
+#include "hash.h"
+#include "hashset.h"
+#include "hashu64.h"
+#include "imapopts.h"
+#include "mpool.h"
+#include "proc.h"
+#include "retry.h"
+#include "smallarrayu64.h"
+#include "strarray.h"
+#include "strhash.h"
+#include "tok.h"
+#include "xmalloc.h"
+#include "xunlink.h"
+#include "xsha1.h"
+
+#include <getopt.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <sysexits.h>
+#include <time.h>
+#include <unistd.h>
+
+void fatal(const char *s, int code)
+{
+    fputs(s, stderr);
+    exit(code);
+}
+
+void usage(void)
+{
+    fputs("usage", stderr);
+    exit(EX_USAGE);
+}
+
+void test_arrayu64(void)
+{
+    arrayu64_t a = ARRAYU64_INITIALIZER;
+    uint64_t u;
+
+    for (u = 0; u < 20; u++) {
+        arrayu64_append(&a, u);
+    }
+
+    arrayu64_truncate(&a, 0);
+    arrayu64_fini(&a);
+
+    puts("arrayu64 ok");
+}
+
+void test_dynarray(void)
+{
+    uint64_t u;
+    dynarray_t d = DYNARRAY_INITIALIZER(sizeof(u));
+
+    for (u = 0; u < 20; u++) {
+        dynarray_append(&d, &u);
+    }
+
+    dynarray_truncate(&d, 0);
+    dynarray_fini(&d);
+
+    puts("dynarray ok");
+}
+
+void test_hash(void)
+{
+    struct hash_table ht = HASH_TABLE_INITIALIZER;
+    uintptr_t u;
+
+    construct_hash_table(&ht, 20, 0);
+
+    for (u = 0; u < 20; u++) {
+        char key[128] = "";
+        snprintf(key, sizeof key, "%" PRIuPTR, u);
+        hash_insert(key, (void *) u, &ht);
+    }
+
+    free_hash_table(&ht, NULL);
+
+    puts("hash ok");
+}
+
+void test_hashset(void)
+{
+    struct hashset *hs;
+    uint64_t u;
+
+    hs = hashset_new(sizeof(u));
+
+    for (u = 0; u < 20; u++) {
+        hashset_add(hs, &u);
+    }
+
+    hashset_free(&hs);
+
+    puts("hashset ok");
+}
+
+void test_hashu64(void)
+{
+    struct hashu64_table ht = HASHU64_TABLE_INITIALIZER;
+    uint64_t u;
+
+    construct_hashu64_table(&ht, 20, 0);
+
+    for (u = 0; u < 20; u++) {
+        hashu64_insert(u, (void *) u, &ht);
+    }
+
+    free_hashu64_table(&ht, NULL);
+
+    puts("hashu64 ok");
+}
+
+void test_mpool(void)
+{
+    struct mpool *mpool;
+    unsigned u;
+
+    mpool = new_mpool(1024);
+
+    for (u = 0; u < 20; u++) {
+        unsigned *not_lost = mpool_malloc(mpool, sizeof(unsigned));
+
+        *not_lost = u;
+    }
+
+    free_mpool(mpool);
+
+    puts("mpool ok");
+}
+
+void test_proc(void)
+{
+    struct proc_handle *handle = NULL;
+
+    proc_register(&handle,
+                  0,
+                  "servicename",
+                  "clienthost",
+                  "userid",
+                  "mailbox",
+                  "cmd");
+
+    proc_cleanup(&handle);
+
+    puts("proc ok");
+}
+
+void test_retry(void)
+{
+    const char str[] = "retry ok\n";
+
+    fflush(stdout);
+    retry_write(STDOUT_FILENO, str, sizeof(str));
+}
+
+void test_smallarrayu64(void)
+{
+    smallarrayu64_t sa = SMALLARRAYU64_INITIALIZER;
+    uint64_t u;
+
+    for (u = 0; u < 20; u++) {
+        smallarrayu64_append(&sa, u);
+    }
+
+    smallarrayu64_fini(&sa);
+
+    puts("smallarrayu64 ok");
+}
+
+void test_strarray(void)
+{
+    strarray_t sa = STRARRAY_INITIALIZER;
+    unsigned u;
+
+    for (u = 0; u < 20; u++) {
+        char buf[128] = "";
+        snprintf(buf, sizeof(buf), "%u", u);
+        strarray_append(&sa, buf);
+    }
+
+    strarray_fini(&sa);
+
+    puts("strarray ok");
+}
+
+void test_strhash(void)
+{
+    unsigned hash;
+
+    hash = strhash_seeded_djb2(time(NULL), "some string");
+    (void) hash;
+
+    puts("strhash ok");
+}
+
+void test_tok(void)
+{
+    tok_t tok;
+    char *s;
+
+    tok_init(&tok, "tok|ok", "|", 0);
+
+    while ((s = tok_next(&tok))) {
+        printf("%s ", s);
+    }
+    printf("\n");
+
+    tok_fini(&tok);
+}
+
+void test_xmalloc(void)
+{
+    char *s = xstrdup("xmalloc ok");
+
+    puts(s);
+    free(s);
+}
+
+/* XXX lib/libconfig.h is not installed, have to provide our own prototype */
+extern void config_read(const char *alt_config, const int config_need_data);
+
+int main(int argc, char **argv)
+{
+    const char *alt_config = NULL;
+    int opt;
+
+    while ((opt = getopt(argc, argv, "C:")) != -1) {
+        switch(opt) {
+        case 'C': /* alt config file */
+            alt_config = optarg;
+            break;
+
+        default:
+            usage();
+            break;
+        }
+    }
+
+    config_read(alt_config, 0);
+
+    test_arrayu64();
+    test_dynarray();
+    test_hash();
+    test_hashset();
+    test_hashu64();
+    test_mpool();
+    test_proc();
+    test_retry();
+    test_smallarrayu64();
+    test_strarray();
+    test_strhash();
+    test_tok();
+    test_xmalloc();
+}

--- a/doc/examples/libcyrus/example_libcyrus_min.c
+++ b/doc/examples/libcyrus/example_libcyrus_min.c
@@ -11,6 +11,8 @@
    ./example_libcyrus_min
  */
 
+/* DEPS: libcyrus_min */
+
 #include "arrayu64.h"
 #include "assert.h"
 #include "dynarray.h"

--- a/lib/auth.h
+++ b/lib/auth.h
@@ -43,7 +43,7 @@
 #ifndef INCLUDED_AUTH_H
 #define INCLUDED_AUTH_H
 
-#include "lib/strarray.h"
+#include "strarray.h"
 
 struct auth_state;
 

--- a/lib/bitvector.h
+++ b/lib/bitvector.h
@@ -43,10 +43,6 @@
 #ifndef __CYRUS_LIB_BITVECTOR_H__
 #define __CYRUS_LIB_BITVECTOR_H__
 
-#include <config.h>
-#include <sys/types.h>
-#include <limits.h>
-
 typedef struct bitvector bitvector_t;
 
 #define BV_NOALLOCSIZE 8

--- a/lib/command.h
+++ b/lib/command.h
@@ -46,9 +46,8 @@
 #ifndef INCLUDED_COMMAND_H
 #define INCLUDED_COMMAND_H
 
-#include <config.h>
 #include <sys/types.h>
-#include <stdarg.h>
+
 #include "prot.h"
 #include "strarray.h"
 

--- a/lib/cyr_qsort_r.c
+++ b/lib/cyr_qsort_r.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include "cyr_qsort_r.h"
 
 #ifndef cyr_qsort_r

--- a/lib/cyr_qsort_r.h
+++ b/lib/cyr_qsort_r.h
@@ -14,8 +14,6 @@
 #ifndef INCLUDED_CYR_QSORT_R_H
 #define INCLUDED_CYR_QSORT_R_H
 
-#include "config.h"
-
 #include <stdlib.h>
 
 #if defined(_GNU_SOURCE) && defined (__GLIBC__) && \

--- a/lib/glob.c
+++ b/lib/glob.c
@@ -51,6 +51,12 @@
 #include "glob.h"
 #include "xmalloc.h"
 
+/* "compiled" glob structure: may change
+ */
+typedef struct glob {
+    regex_t regex;
+} glob;
+
 /* initialize globbing structure
  *  This makes the following changes to the input string:
  *   1) '*' eats all '*'s and '%'s connected by any wildcard

--- a/lib/glob.h
+++ b/lib/glob.h
@@ -49,13 +49,7 @@
 #ifndef INCLUDED_GLOB_H
 #define INCLUDED_GLOB_H
 
-#include "util.h"
-
-/* "compiled" glob structure: may change
- */
-typedef struct glob {
-    regex_t regex;
-} glob;
+typedef struct glob glob;
 
 /* initialize globbing structure
  *  str      -- globbing string

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -7,7 +7,7 @@
 #include <config.h>
 #endif
 
-#include "lib/assert.h"
+#include "assert.h"
 
 /*
  * This is gnarly, sorry :(  We might have been configured to build

--- a/lib/procinfo.c
+++ b/lib/procinfo.c
@@ -1,3 +1,4 @@
+#include <config.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdlib.h>

--- a/lib/procinfo.h
+++ b/lib/procinfo.h
@@ -1,7 +1,6 @@
 #ifndef INCLUDED_PROCINFO_H
 #define INCLUDED_PROCINFO_H
 
-#include <config.h>
 #include <sys/types.h>
 #include <time.h>
 

--- a/lib/tok.h
+++ b/lib/tok.h
@@ -46,7 +46,6 @@
 #ifndef __CYRUS_TOK_H__
 #define __CYRUS_TOK_H__
 
-#include <config.h>
 #include <sys/types.h>
 #include "xmalloc.h"
 

--- a/lib/xsha1.c
+++ b/lib/xsha1.c
@@ -105,7 +105,7 @@ typedef union _BYTE64QUAD16 {
 } BYTE64QUAD16;
 
 /* Hash a single 512-bit block. This is the core of the algorithm. */
-static void SHA1_Transform(sha1_quadbyte state[5], const sha1_byte buffer[64]) {
+static void xSHA1_Transform(sha1_quadbyte state[5], const sha1_byte buffer[64]) {
     sha1_quadbyte   a, b, c, d, e;
     BYTE64QUAD16    *block;
     BYTE64QUAD16    copy;
@@ -153,7 +153,7 @@ static void SHA1_Transform(sha1_quadbyte state[5], const sha1_byte buffer[64]) {
 
 
 /* SHA1_Init - Initialize new context */
-EXPORTED int SHA1Init(SHA1_CTX* context) {
+EXPORTED int xSHA1Init(xSHA1_CTX* context) {
     /* SHA1 initialization constants */
     context->state[0] = 0x67452301;
     context->state[1] = 0xEFCDAB89;
@@ -166,7 +166,7 @@ EXPORTED int SHA1Init(SHA1_CTX* context) {
 }
 
 /* Run your data through this. */
-EXPORTED int SHA1Update(SHA1_CTX *context, const void *vdata, unsigned int len) {
+EXPORTED int xSHA1Update(xSHA1_CTX *context, const void *vdata, unsigned int len) {
     const sha1_byte *data = vdata;
     unsigned int    i, j;
 
@@ -175,9 +175,9 @@ EXPORTED int SHA1Update(SHA1_CTX *context, const void *vdata, unsigned int len) 
     context->count[1] += (len >> 29);
     if ((j + len) > 63) {
         memcpy(&context->buffer[j], data, (i = 64-j));
-        SHA1_Transform(context->state, context->buffer);
+        xSHA1_Transform(context->state, context->buffer);
         for ( ; i + 63 < len; i += 64) {
-            SHA1_Transform(context->state, &data[i]);
+            xSHA1_Transform(context->state, &data[i]);
         }
         j = 0;
     }
@@ -189,7 +189,7 @@ EXPORTED int SHA1Update(SHA1_CTX *context, const void *vdata, unsigned int len) 
 
 
 /* Add padding and return the message digest. */
-EXPORTED int SHA1Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA1_CTX *context) {
+EXPORTED int xSHA1Final(sha1_byte digest[xSHA1_DIGEST_LENGTH], xSHA1_CTX *context) {
     sha1_quadbyte   i, j;
     sha1_byte   finalcount[8];
 
@@ -197,20 +197,20 @@ EXPORTED int SHA1Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA1_CTX *context) 
         finalcount[i] = (sha1_byte)((context->count[(i >= 4 ? 0 : 1)]
          >> ((3-(i & 3)) * 8) ) & 255);  /* Endian independent */
     }
-    SHA1Update(context, (sha1_byte *)"\200", 1);
+    xSHA1Update(context, (sha1_byte *)"\200", 1);
     while ((context->count[0] & 504) != 448) {
-        SHA1Update(context, (sha1_byte *)"\0", 1);
+        xSHA1Update(context, (sha1_byte *)"\0", 1);
     }
     /* Should cause a SHA1_Transform() */
-    SHA1Update(context, finalcount, 8);
-    for (i = 0; i < SHA1_DIGEST_LENGTH; i++) {
+    xSHA1Update(context, finalcount, 8);
+    for (i = 0; i < xSHA1_DIGEST_LENGTH; i++) {
         digest[i] = (sha1_byte)
          ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
     }
     /* Wipe variables */
     i = j = 0;
-    memset(context->buffer, 0, SHA1_BLOCK_LENGTH);
-    memset(context->state, 0, SHA1_DIGEST_LENGTH);
+    memset(context->buffer, 0, xSHA1_BLOCK_LENGTH);
+    memset(context->state, 0, xSHA1_DIGEST_LENGTH);
     memset(context->count, 0, 8);
     memset(&finalcount, 0, 8);
 
@@ -221,16 +221,16 @@ EXPORTED int SHA1Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA1_CTX *context) 
  * End of sha1.c
  */
 
-EXPORTED unsigned char *xsha1(const unsigned char *buf, unsigned long len,
-                              sha1_byte dest[SHA1_DIGEST_LENGTH])
+EXPORTED unsigned char *xsha1_impl(const unsigned char *buf, unsigned long len,
+                                   sha1_byte dest[xSHA1_DIGEST_LENGTH])
 {
-    SHA1_CTX ctx;
+    xSHA1_CTX ctx;
 
-    memset(&ctx, 0, sizeof(SHA1_CTX));
+    memset(&ctx, 0, sizeof(ctx));
 
-    SHA1Init(&ctx);
-    SHA1Update(&ctx, buf, len);
-    SHA1Final(dest, &ctx);
+    xSHA1Init(&ctx);
+    xSHA1Update(&ctx, buf, len);
+    xSHA1Final(dest, &ctx);
 
     return dest;
 }

--- a/lib/xsha1.h
+++ b/lib/xsha1.h
@@ -47,12 +47,35 @@
 #include <config.h>
 #endif
 
-#include "assert.h"
+#include <stdint.h>
+
+/* definitions and types needed by the internal libcyrus_min implementation */
+#define xSHA1_BLOCK_LENGTH   64
+#define xSHA1_DIGEST_LENGTH  20
+#define xSHA_DIGEST_LENGTH   (xSHA1_DIGEST_LENGTH)
+
+typedef uint32_t sha1_quadbyte; /* 4 byte type */
+typedef uint8_t sha1_byte;    /* single byte type */
+typedef struct _xSHA1_CTX {
+    sha1_quadbyte   state[5];
+    sha1_quadbyte   count[2];
+    sha1_byte       buffer[xSHA1_BLOCK_LENGTH];
+} xSHA1_CTX;
+
+int xSHA1Init(xSHA1_CTX* context);
+int xSHA1Update(xSHA1_CTX *context, const void *data, unsigned int len);
+int xSHA1Final(sha1_byte digest[xSHA1_DIGEST_LENGTH], xSHA1_CTX *context);
+
+unsigned char *xsha1_impl(const unsigned char *buf, unsigned long len,
+                          sha1_byte dest[xSHA1_DIGEST_LENGTH]);
 
 #ifdef HAVE_SSL
+/* if an SSL library is available, actually use its implementation instead */
 
 #include <openssl/sha.h>
 #include <openssl/evp.h>
+
+#include "assert.h"
 
 #ifndef SHA1_DIGEST_LENGTH
 #define SHA1_DIGEST_LENGTH (SHA_DIGEST_LENGTH)
@@ -74,29 +97,17 @@
     } while(0);
 
 #else /* HAVE_SSL */
+/* otherwise, use libcyrus_min internal implementation */
 
-#include <stdint.h>
+#define SHA1_BLOCK_LENGTH   xSHA1_BLOCK_LENGTH
+#define SHA1_DIGEST_LENGTH  xSHA1_DIGEST_LENGTH
+#define SHA_DIGEST_LENGTH   xSHA_DIGEST_LENGTH
 
-typedef uint32_t sha1_quadbyte; /* 4 byte type */
-typedef uint8_t sha1_byte;    /* single byte type */
-
-#define SHA1_BLOCK_LENGTH   64
-#define SHA1_DIGEST_LENGTH  20
-#define SHA_DIGEST_LENGTH (SHA1_DIGEST_LENGTH)
-
-/* The SHA1 structure: */
-typedef struct _SHA1_CTX {
-    sha1_quadbyte   state[5];
-    sha1_quadbyte   count[2];
-    sha1_byte   buffer[SHA1_BLOCK_LENGTH];
-} SHA1_CTX;
-
-int SHA1Init(SHA1_CTX* context);
-int SHA1Update(SHA1_CTX *context, const void *data, unsigned int len);
-int SHA1Final(sha1_byte digest[SHA1_DIGEST_LENGTH], SHA1_CTX *context);
-
-unsigned char *xsha1(const unsigned char *buf, unsigned long len,
-              sha1_byte dest[SHA1_DIGEST_LENGTH]);
+#define SHA1_CTX            xSHA1_CTX
+#define SHA1Init(c)         xSHA1Init(c)
+#define SHA1Update(c, d, l) xSHA1Update(c, d, l)
+#define SHA1Final(h, c)     xSHA1Final(h, c)
+#define xsha1(d, l, h)      xsha1_impl(d, l, h)
 
 #endif /* HAVE_SSL */
 

--- a/lib/xsha1.h
+++ b/lib/xsha1.h
@@ -45,7 +45,7 @@
 
 #include <config.h>
 
-#include "lib/assert.h"
+#include "assert.h"
 
 #ifdef HAVE_SSL
 

--- a/lib/xsha1.h
+++ b/lib/xsha1.h
@@ -43,7 +43,9 @@
 #ifndef LIB_XSHA1_H
 #define LIB_XSHA1_H
 
+#if HAVE_CONFIG_H
 #include <config.h>
+#endif
 
 #include "assert.h"
 

--- a/libcyrus.pc.in
+++ b/libcyrus.pc.in
@@ -1,8 +1,13 @@
+prefix = @prefix@
+exec_prefix = @exec_prefix@
+includedir = ${prefix}/include
+libdir = @libdir@
+
 Name: Cyrus Imapd libcyrus
 Description: libcyrus library of Cyrus Imapd
 URL: http://www.cyrusimap.org/
-Cflags: @SSL_CPPFLAGS@ @SASLFLAGS@
+Cflags: -I${includedir}/cyrus @SSL_CPPFLAGS@ @SASLFLAGS@
 Version: @PACKAGE_VERSION@
 Requires.private: libcyrus_min = @PACKAGE_VERSION@
-Libs: -lcyrus
+Libs: -L${libdir} -lcyrus -lcyrus_min
 Libs.private: @LIB_SASL@ @SSL_LIBS@

--- a/libcyrus_imap.pc.in
+++ b/libcyrus_imap.pc.in
@@ -9,5 +9,5 @@ URL: http://www.cyrusimap.org/
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}/cyrus
 Requires.private: libcyrus_min = @PACKAGE_VERSION@, libcyrus = @PACKAGE_VERSION@
-Libs: -L${libdir} -lcyrus_imap
-Libs.private: @PKG_CONFIG_COM_ERR_LIB@ -lcyrus -lcyrus_min
+Libs: -L${libdir} -lcyrus_imap -lcyrus -lcyrus_min
+Libs.private: @PKG_CONFIG_COM_ERR_LIB@


### PR DESCRIPTION
Cyrus installs a bunch of its headers so that other software can compile against the various libcyrus* libraries.  But if you try that it doesn't work, because of various problems in the headers that come of us assuming our code is always compiled from within the cyrus-imapd source tree.

This PR fixes some, but not all, of those issues.  It also adds example source files for calling the working parts of the Cyrus libraries, and adds a LibCyrus test suite to Cassandane to make sure they do actually compile and link correctly.

There's a lot more to fix in this space, but nobody's really asking for it anymore, and I ran out of steam months ago.  Here's a cleaned-up version of the former work in progress so we at least get some benefit from it, and future efforts to fix this stuff will already have test infrastructure ready to go.

Original description:
The Debian package maintainer privately reported a problem from the abi-compatibility-checker not being able to run due to the installed headers not compiling.  This is part of Debian's work to switch to 64-bit time_t on some 32-bit platforms.  Further details in https://cyrus.topicbox.com/groups/devel/T7b15dfc105949d4e-Meae606200efd965cc932318f

I'm using this PR to accumulate the fixes that we need to get the abi-compatibility-checker to actually run.