### PR TITLE
Sieve: a STOP action should not be an error (exit the processing loop directly)

### DIFF
--- a/cassandane/tiny-tests/Sieve/implicit-keep-target-stop
+++ b/cassandane/tiny-tests/Sieve/implicit-keep-target-stop
@@ -1,0 +1,32 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_implicit_keep_target_stop
+    :min_version_3_9 :needs_component_sieve :NoAltNameSpace
+{
+    my ($self) = @_;
+
+    my $folder = "INBOX.foo";
+
+    xlog $self, "Create folder";
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create($folder)
+        or die "Cannot create $folder: $@";
+
+    xlog $self, "Install a script";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["vnd.cyrus.implicit_keep_target"];
+implicit_keep_target "$folder";
+stop;
+EOF
+    );
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to $folder";
+    $self->{store}->set_folder($folder);
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+}
+

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -1759,7 +1759,9 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
 
         switch (op) {
         case B_STOP:
-            res = 1;
+            /* Exit the loop directly,
+               as an error will skip filing into a custom implicit keep target */
+            goto done;
             break;
 
 
@@ -2596,7 +2598,7 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
             return SIEVE_FAIL;
         }
 
-        if (res) break;  /* we've either encountered an error or a stop */
+        if (res) break;  /* we've encountered an error */
     }
 
   done:


### PR DESCRIPTION
An error will skip filing into a custom implicit keep target