### PR TITLE
sync_support.c: validate Sieve in first mailbox_compare_update() pass

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -703,8 +703,8 @@ EXPORTED void message_fetch_part(struct message_content *msg,
  * and fills in appropriate information in the index record pointed to
  * by 'record'.
  */
-HIDDEN int message_create_record(struct index_record *record,
-                          const struct body *body)
+EXPORTED int message_create_record(struct index_record *record,
+                                   const struct body *body)
 {
     /* used for sent time searching, truncated to day with no TZ */
     if (time_from_rfc5322(body->date, &record->sentdate, DATETIME_DATE_ONLY) < 0)

--- a/imap/message.h
+++ b/imap/message.h
@@ -141,6 +141,8 @@ extern int message_copy_strict(struct protstream *from, FILE *to,
                                unsigned size, int allow_null);
 
 extern int message_parse(const char *fname, struct index_record *record);
+extern int message_create_record(struct index_record *record,
+                                 const struct body *body);
 
 struct message_content {
     struct buf map;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -1007,6 +1007,43 @@ int sync_sieve_delete(const char *userid, const char *fname)
 
     return r;
 }
+
+static int sync_sieve_validate(struct index_record *record,
+                               struct sync_msgid_list *part_list)
+{
+    struct sync_msgid *item = sync_msgid_lookup(part_list, &record->guid);
+    FILE *f = NULL;
+    struct body *body = NULL;
+    const char *msg_base = NULL;
+    size_t msg_len;
+    int r = SIEVE_OK;
+    
+    if (!(item && item->fname && (f = fopen(item->fname, "r")))) return r;
+
+    if (!message_parse_file(f, &msg_base, &msg_len, &body, item->fname)) {
+        sieve_script_t *s = NULL;
+        char *err = NULL;
+
+        r = sieve_script_parse_string(NULL,
+                                      msg_base + body->header_size, &err, &s);
+        sieve_script_free(&s);
+
+        if (r == SIEVE_OK) {
+            // create the record now to avoid a re-parse in sync_append_copyfile
+            message_create_record(record, body);
+        }
+    }
+
+    if (body) {
+        message_free_body(body);
+        free(body);
+    }
+
+    map_free(&msg_base, &msg_len);
+    fclose(f);
+
+    return r;
+}
 #else  /* !USE_SIEVE */
 int sync_sieve_activate(const char *userid __attribute__((unused)),
                         const char *bcname __attribute__((unused)))
@@ -1019,6 +1056,12 @@ int sync_sieve_delete(const char *userid __attribute__((unused)),
 {
     return 0;
 }
+
+static int sync_sieve_validate(struct index_record *record,
+                               struct sync_msgid_list *part_list)
+{
+    return 0;
+}    
 #endif  /* USE_SIEVE */
 
 /* ====================================================================== */
@@ -2162,7 +2205,7 @@ int sync_append_copyfile(struct mailbox *mailbox,
 
     if (!item || !item->fname)
         r = IMAP_IOERROR;
-    else
+    else if (!record->cache_version)
         r = message_parse(item->fname, record);
 
     if (r) {
@@ -2604,7 +2647,17 @@ static int sync_mailbox_compare_update(struct mailbox *mailbox,
         /* after LAST_UID, it's an append, that's OK */
         else {
             /* skip out on the first pass */
-            if (!doupdate) continue;
+            if (!doupdate) {
+#ifdef USE_SIEVE
+                /* do we have valid Sieve (e.g. no deprecated extensions)? */
+                if ((mbtype_isa(mailbox->h.mbtype) == MBTYPE_SIEVE) &&
+                    sync_sieve_validate(&mrecord, part_list) != SIEVE_OK) {
+                    r = IMAP_SYNC_BADSIEVE;
+                    goto out;
+                }
+#endif
+                continue;
+            }
 
             mrecord.silentupdate = 1;
             r = sync_append_copyfile(mailbox, &mrecord, mannots, part_list);


### PR DESCRIPTION
Avoid an abort() in sync_server if we have Sieve with deprecated extensions on the master