### PR TITLE
chk_cyrus: Fix fatal error on nonexistent mailboxes

### DIFF
--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -63,6 +63,7 @@
 #include "mailbox.h"
 #include "map.h"
 #include "xmalloc.h"
+#include "imap_err.h"
 
 static void usage(void)
 {
@@ -81,6 +82,9 @@ static int chkmbox(struct findall_data *data, void *rock __attribute__((unused))
     const char *name = mbname_intname(data->mbname);
 
     r = mboxlist_lookup(name, &mbentry, NULL);
+
+    if (r == IMAP_MAILBOX_NONEXISTENT)
+       return 0;
 
     /* xxx reserved mailboxes? */
 

--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -89,7 +89,7 @@ static int chkmbox(struct findall_data *data, void *rock __attribute__((unused))
     /* xxx reserved mailboxes? */
 
     if (r) {
-        fprintf(stderr, "bad mailbox %s in chkmbox\n", name);
+        fprintf(stderr, "bad mailbox %s in chkmbox: %s\n", name, error_message(r));
         fatal("fatal error",EX_TEMPFAIL);
     }
 


### PR DESCRIPTION
I have these mailboxes on my system:
```
user.me.Junk (\HasChildren)
user.me.Junk.Learn (\NonExistent \HasChildren)
user.me.Junk.Learn.Ham (\HasNoChildren)
user.me.Junk.Learn.Spam (\HasNoChildren)
```
As far as I understand it's perfectly valid to have a nonexistent parent in imap.

However, when I run `chk_cyrus` it gets a fatal error on `user.me.Junk.Learn`:

```
$ chk_cyrus -M user.me.Junk.Learn
Examining mailbox: user.me.Junk.Learn
bad mailbox user.me.Junk.Learn in chkmbox
fatal error: fatal error
```

I investigated and found that the fatal error was `IMAP_MAILBOX_NONEXISTENT`. It seems to me that shouldn't be a fatal error in `chk_cyrus`.

This PR has 2 small commits:

1. One of them prints the error out. With just this commit the output of `chk_cyrus` becomes:
   ```
   $ chk_cyrus -M user.me.Junk.Learn
   Examining mailbox: user.me.Junk.Learn
   bad mailbox user.me.Junk.Learn in chkmbox: Mailbox does not exist
   fatal error: fatal error
   ```
2. One them changes `chk_cyrus` to just skip over nonexistent mailboxes:
   ```
   $  chk_cyrus -M user.me.Junk.Learn
   Examining mailbox: user.me.Junk.Learn
   $
   ```

Does this seem reasonable?