### PR TITLE
re-fix filtering unindexed messages in squat backend

### DIFF
--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -500,6 +500,9 @@ sub test_unindexed_since
     my $uids = $imap->search('text', 'needle', 'since', '1-Feb-2024');
     $self->assert_deep_equals([1], $uids);
 
+    $uids = $imap->search('text', 'needle', 'not', 'since', '1-Feb-2024');
+    $self->assert_deep_equals([3], $uids);
+
     $self->make_message("needle 4", body => "needle") || die;
     $self->make_message("xxxxxx 5", body => "xxxxxx") || die;
     $self->make_message("old 6", date => $past_dt, body => "needle") || die;
@@ -509,6 +512,9 @@ sub test_unindexed_since
 
     $uids = $imap->search('text', 'needle', 'since', '1-Feb-2024');
     $self->assert_deep_equals([1,4], $uids);
+
+    $uids = $imap->search('text', 'needle', 'not', 'since', '1-Feb-2024');
+    $self->assert_deep_equals([3, 6], $uids);
 }
 
 sub test_since
@@ -528,6 +534,9 @@ sub test_since
     my $uids = $imap->search('since', '1-Feb-2024');
     $self->assert_deep_equals([1,2], $uids);
 
+    $uids = $imap->search('not', 'since', '1-Feb-2024');
+    $self->assert_deep_equals([3], $uids);
+
     $self->make_message("needle 4", body => "needle") || die;
     $self->make_message("xxxxxx 5", body => "xxxxxx") || die;
     $self->make_message("old 6", date => $past_dt, body => "needle") || die;
@@ -537,6 +546,9 @@ sub test_since
 
     $uids = $imap->search('since', '1-Feb-2024');
     $self->assert_deep_equals([1,2,4,5], $uids);
+
+    $uids = $imap->search('not', 'since', '1-Feb-2024');
+    $self->assert_deep_equals([3,6], $uids);
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -446,7 +446,7 @@ sub test_unindexed
 
     $self->run_squatter;
 
-    my $uids = $imap->search('fuzzy', 'body', 'needle') || die;
+    my $uids = $imap->search('text', 'needle');
     $self->assert_deep_equals([1], $uids);
 
     $self->make_message("needle 3", body => "needle") || die;
@@ -455,7 +455,31 @@ sub test_unindexed
     # Do not rerun squatter. Make sure search only returns
     # a matching unindexed message.
 
-    $uids = $imap->search('fuzzy', 'body', 'needle') || die;
+    $uids = $imap->search('text', 'needle');
+    $self->assert_deep_equals([1,3], $uids);
+}
+
+sub test_unindexed_fuzzy
+    :SearchEngineSquat :min_version_3_4
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+
+    $self->make_message("needle 1", body => "needle") || die;
+    $self->make_message("xxxxxx 2", body => "xxxxxx") || die;
+
+    $self->run_squatter;
+
+    my $uids = $imap->search('fuzzy', 'body', 'needle');
+    $self->assert_deep_equals([1], $uids);
+
+    $self->make_message("needle 3", body => "needle") || die;
+    $self->make_message("xxxxxx 4", body => "xxxxxx") || die;
+
+    # Do not rerun squatter. Make sure search only returns
+    # a matching unindexed message.
+
+    $uids = $imap->search('fuzzy', 'body', 'needle');
     $self->assert_deep_equals([1,3], $uids);
 }
 

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -511,4 +511,32 @@ sub test_unindexed_since
     $self->assert_deep_equals([1,4], $uids);
 }
 
+sub test_since
+    :SearchEngineSquat :min_version_3_4
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+
+    my $past_dt = DateTime->last_day_of_month(year => 2023, month => 12);
+
+    $self->make_message("needle 1", body => "needle") || die;
+    $self->make_message("xxxxxx 2", body => "xxxxxx") || die;
+    $self->make_message("old 3", date => $past_dt, body => "needle") || die;
+
+    $self->run_squatter;
+
+    my $uids = $imap->search('since', '1-Feb-2024');
+    $self->assert_deep_equals([1,2], $uids);
+
+    $self->make_message("needle 4", body => "needle") || die;
+    $self->make_message("xxxxxx 5", body => "xxxxxx") || die;
+    $self->make_message("old 6", date => $past_dt, body => "needle") || die;
+
+    # Do not rerun squatter. Make sure search only returns
+    # a matching unindexed message.
+
+    $uids = $imap->search('since', '1-Feb-2024');
+    $self->assert_deep_equals([1,2,4,5], $uids);
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -483,4 +483,32 @@ sub test_unindexed_fuzzy
     $self->assert_deep_equals([1,3], $uids);
 }
 
+sub test_unindexed_since
+    :SearchEngineSquat :min_version_3_4
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+
+    my $past_dt = DateTime->last_day_of_month(year => 2023, month => 12);
+
+    $self->make_message("needle 1", body => "needle") || die;
+    $self->make_message("xxxxxx 2", body => "xxxxxx") || die;
+    $self->make_message("old 3", date => $past_dt, body => "needle") || die;
+
+    $self->run_squatter;
+
+    my $uids = $imap->search('text', 'needle', 'since', '1-Feb-2024');
+    $self->assert_deep_equals([1], $uids);
+
+    $self->make_message("needle 4", body => "needle") || die;
+    $self->make_message("xxxxxx 5", body => "xxxxxx") || die;
+    $self->make_message("old 6", date => $past_dt, body => "needle") || die;
+
+    # Do not rerun squatter. Make sure search only returns
+    # a matching unindexed message.
+
+    $uids = $imap->search('text', 'needle', 'since', '1-Feb-2024');
+    $self->assert_deep_equals([1,4], $uids);
+}
+
 1;

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -72,6 +72,22 @@ static search_expr_t **the_rootp;
 static search_expr_t *the_focus;
 #endif
 
+/* keep this in sync with enum search_op in search_expr.h */
+EXPORTED const char *search_op_name[] = {
+    "SEOP_UNKNOWN",
+    "SEOP_TRUE",
+    "SEOP_FALSE",
+    "SEOP_LT",
+    "SEOP_LE",
+    "SEOP_GT",
+    "SEOP_GE",
+    "SEOP_MATCH",
+    "SEOP_FUZZYMATCH",
+    "SEOP_AND",
+    "SEOP_OR",
+    "SEOP_NOT",
+};
+
 static void split(search_expr_t *e,
                   void (*cb)(const char *, search_expr_t *, search_expr_t *, void *),
                   void *rock);

--- a/imap/search_expr.h
+++ b/imap/search_expr.h
@@ -50,6 +50,7 @@
 struct protstream;
 struct index_state;
 
+/* keep this in sync with search_op_name in search_expr.c */
 enum search_op {
     SEOP_UNKNOWN,
     SEOP_TRUE,
@@ -69,6 +70,7 @@ enum search_op {
     SEOP_OR,
     SEOP_NOT,
 };
+extern const char *search_op_name[];
 
 union search_value {
     time_t t;


### PR DESCRIPTION
This was originally fixed in #4698, except it turns out there was additional complexity required that was missed because our tests were inadequate.

The search is split into indexed and unindexed subexpressions.  The indexed subexpression is run through the search engine backend, and the unindexed subexpression is then applied as a filter over the returned results.

The squat engine returns all unindexed messages in its matched set, expecting the post-processing phase to filter them further.  This has been broken (#4692) for a while, because nowadays the post-processing phase doesn't apply the indexed subexpression that squat expects it to, only the unindexed subexpression.

The original fix in #4698 failed to recognise the search having previously been split into separate subexpressions.  It copied the indexed subexpression over the unindexed subexpression and used that for filtering, which had the desired effect when the whole search could be completed from the search index, but broke if there were also unindexed terms (e.g. `SINCE date`) to filter on which had now been lost.

This new attempt at a fix is similar, but recombines the indexed and unindexed subexpressions instead of replacing one with the other.  It also adds a bunch of tests!

Fixes #4692 