### PR TITLE
jmap_api.c: ignore rights on \Scheduled when adjusting #jmap

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -5479,4 +5479,65 @@ sub test_mailbox_set_destroy_twice
     $self->assert_str_equals("notFound", $res->[0][1]{notDestroyed}{$id}{type});
 }
 
+sub test_cyr_237
+    :min_version_3_3 :needs_component_jmap :NoAltNameSpace :JMAPExtensions
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+    my $admin = $self->{adminstore}->get_client();
+
+    my $using = [
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:mail',
+        'https://cyrusimap.org/ns/jmap/mail',
+    ];
+
+    xlog $self, "Create \\Scheduled mailbox";
+    my $res = $jmap->CallMethods([
+        [ 'Mailbox/set', {
+            create => {
+                "1" => {
+                    name => "Scheduled",
+                    role => "scheduled"
+                }
+            }
+         }, "R1"],
+    ]);
+
+    xlog $self, "Upload something (to create #jmap)";
+    my $data = $jmap->Upload("some text", "text/plain");
+
+    my $acl = $admin->getacl("user.cassandane.#jmap");
+    my %map = @$acl;
+    $self->assert_str_equals('lrswipkxtecdan', $map{cassandane});
+    $self->assert_null($map{sharee});
+    $self->assert_null($map{'-anyone'});
+
+    my $inboxId = $self->getinbox()->{id};
+    $self->assert_not_null($inboxId);
+
+    xlog $self, "Share INBOX";
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            update => {
+                $inboxId => {
+                    shareWith => {
+                        sharee => {
+                            mayRead => JSON::true,
+                            mayWrite => JSON::true,
+                        },
+                    },
+                },
+            },
+        }, 'R2']
+    ], $using);
+
+    $acl = $admin->getacl("user.cassandane.#jmap");
+    %map = @$acl;
+    $self->assert_str_equals('lrswipkxtecdan', $map{cassandane});
+    $self->assert_str_equals('lrswitedn', $map{sharee});
+    $self->assert_null($map{'-anyone'});
+}
+
 1;

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2868,6 +2868,12 @@ static int sharedrights_cb(const mbentry_t *mbentry, void *vrock)
     /* Skip any special use folders (#jmap, #calendars, #notifications, etc.) */
     switch (mbtype_isa(mbentry->mbtype)) {
     case MBTYPE_EMAIL:
+        if (mboxname_isscheduledmailbox(mbentry->name, MBTYPE_EMAIL)) {
+            /* Skip \Scheduled because it is always read-only,
+               and a sharee would have no need to upload anything */
+            return 0;
+        }
+
     case MBTYPE_CALENDAR:
     case MBTYPE_ADDRESSBOOK:
         break;


### PR DESCRIPTION
\Scheduled has '-anyone' identifier to remove r/w rights which when inherited by #jmap prevents setting \Expunged flag