### PR TITLE
itip_support.c: fix pick_scheddefault_cb()

### DIFF
--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -160,7 +160,7 @@ static int pick_scheddefault_cb(const mbentry_t *mbentry, void *vrock)
     mbname_t *mbname = NULL;
     int r = 0;
 
-    if (mbentry->mbtype & MBTYPE_CALENDAR) {
+    if (mbtype_isa(mbentry->mbtype) == MBTYPE_CALENDAR) {
         mbname = mbname_from_intname(mbentry->name);
         const char *collname = strarray_nth(mbname_boxes(mbname), -1);
         if (strarray_find(&rock->ignore, collname, 0) < 0) {


### PR DESCRIPTION
mbtype isn't a simple bitfield!