### PR TITLE
replicaonly: add silent RACL updates and batch them to sync

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -75,6 +75,7 @@
 #include "mboxevent.h"
 #include "mboxlist.h"
 #include "conversations.h"
+#include "user.h"
 #include "util.h"
 #include "xmalloc.h"
 #include "strarray.h"
@@ -321,6 +322,11 @@ static int noexpire_mailbox(const mbentry_t *mbentry)
             ret = last_seen.has_noexpire;
             goto done;
         }
+
+	if (user_isreplicaonly(mbname_userid(mbname))) {
+            ret = 1;
+            goto done;
+	}
 
         // Determine user inbox name
         if (mbname_isdeleted(mbname)) {

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1173,7 +1173,8 @@ static int mboxlist_update_entry_full(const char *name, const mbentry_t *mbentry
      * function if renaming */
     assert_namespacelocked(name);
 
-    if (!silent) mboxname_assert_canadd(mbname);
+    if (!silent && !(mbentry && (mbentry->mbtype & MBTYPE_DELETED)))
+        mboxname_assert_canadd(mbname);
 
     /* take a local transaction if there isn't one already - we definitely
      * want all these updates in a single transaction so the mboxlist is

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -182,7 +182,9 @@ int mboxlist_insertremote(mbentry_t *mbentry, struct txn **rettid);
 int mboxlist_deleteremote(const char *name, struct txn **in_tid);
 
 /* Update a mailbox's entry */
-int mboxlist_update(const mbentry_t *mbentry, int localonly);
+#define mboxlist_update(m, l) mboxlist_update_full(m, l, 0)
+int mboxlist_update_full(const mbentry_t *mbentry, int localonly,
+                         int silent);
 /* Update but take the usernamespace lock first */
 int mboxlist_updatelock(const mbentry_t *mbentry, int localonly);
 

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -3154,7 +3154,7 @@ static modseq_t mboxname_domodseq(const char *fname,
     return counters.highestmodseq;
 }
 
-static void mboxname_assert_canadd(mbname_t *mbname)
+EXPORTED void mboxname_assert_canadd(const mbname_t *mbname)
 {
     assert(!config_getswitch(IMAPOPT_REPLICAONLY));
     // add code for suppressing particular users by filename

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -388,6 +388,7 @@ struct mboxname_counters {
 int mboxname_read_counters(const char *mboxname, struct mboxname_counters *vals);
 #define MBOXMODSEQ_ISFOLDER (1<<0)
 #define MBOXMODSEQ_ISDELETE (1<<1)
+void mboxname_assert_canadd(const mbname_t *mbname);
 modseq_t mboxname_nextmodseq(const char *mboxname, modseq_t last, int mbtype, int flags);
 modseq_t mboxname_setmodseq(const char *mboxname, modseq_t val, int mbtype, int flags);
 uint32_t mboxname_readuidvalidity(const char *mboxname);

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -154,8 +154,10 @@ static int reset_single(const char *userid)
 
     for (i = mblist->count; i; i--) {
         const char *name = strarray_nth(mblist, i-1);
-        r = mboxlist_deletemailbox(name, 1, sync_userid, sync_authstate, NULL,
-                MBOXLIST_DELETE_LOCALONLY|MBOXLIST_DELETE_FORCE);
+	int delflags = MBOXLIST_DELETE_FORCE | MBOXLIST_DELETE_SILENT |
+		       MBOXLIST_DELETE_LOCALONLY;
+        r = mboxlist_deletemailbox(name, 1, sync_userid, sync_authstate,
+                                   NULL, delflags);
         if (r == IMAP_MAILBOX_NONEXISTENT) {
             printf("skipping already removed mailbox %s\n", name);
         }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2706,7 +2706,10 @@ int sync_apply_mailbox(struct dlist *kin,
         newmbentry->foldermodseq = highestmodseq;
         newmbentry->createdmodseq = createdmodseq;
 
-        r = mboxlist_updatelock(newmbentry, /*localonly*/1);
+        struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
+        r = mboxlist_update_full(newmbentry, /*localonly*/1, /*silent*/1);
+        mboxname_release(&namespacelock);
+
         mboxlist_entry_free(&newmbentry);
 
         return r;


### PR DESCRIPTION
This fixes the bumping of RACLMODSEQ on replicas when changes are synced in.  Without this, replicaonly breaks on mailbox creation and deletion if there's shared folders.

We do sync the RACLMODSEQ value along with the mailbox when it syncs, so it's correct not to bump it separately in the update_entry code.

Note: this code also includes and assert that it always gets called with `silent` if replicaonly, which is a nice extra protection and helped with debugging.