### PR TITLE
Cassandane testrunner.pl: Fix XML formatter

### DIFF
--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -200,7 +200,8 @@ eval
         local *__ANON__ = "runner_xml";
 
         my $runner = Cassandane::Unit::RunnerXML->new($output_dir);
-        my @filters = qw(x skip_version skip_missing_features);
+        my @filters = qw(x skip_version skip_missing_features
+                         enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         push @filters, 'slow_only' if $plan->{slow_only};
         $runner->filter(@filters);


### PR DESCRIPTION
It needs to filter on enable_wanted_properties too, otherwise things like :want_service_http aren't processed, so $self->{caldav} won't be set up leading to this error:

     Perl exception: Can't call method "GetEvents" on an undefined value
     at Cassandane/Cyrus/Sieve.pm line 5560.

... when testrunner.pl is run with -f xml