### PR TITLE
Revert "tls.c: need to free SSL_SESSION when removing it from cache"

### DIFF
--- a/imap/tls.c
+++ b/imap/tls.c
@@ -637,7 +637,6 @@ static void remove_session_cb(SSL_CTX *ctx __attribute__((unused)),
     session_id = SSL_SESSION_get_id(sess, &session_id_length);
 
     remove_session(session_id, session_id_length);
-    SSL_SESSION_free(sess);
 }
 
 /*


### PR DESCRIPTION
This reverts commit a3523d4067c502a52cb7ee859c1493d1a980b7e0.

imapd does crash sometimes, when it handles the TLS connection.  https://github.com/cyrusimap/cyrus-imapd/issues/4785 describes such reports from different users.

In such cases Cyrus can log “no shared cipher in SSL_accept() -> fail” or “unexpected eof while reading in SSL_accept() -> fail”.

The recommendation at https://github.com/openssl/openssl/issues/23031#issuecomment-1879632721 also states, than doing `SSL_SESSION_free()` during remove_session_cb() is wrong.  If there were leaks, there is probably another case where there is a missing SSL_SESSION_free() call but this place is not right.

• backport to 3.10 and 3.8