### PR TITLE
rename mboxlist_sync_setacls to mboxlist_setacls and add silent flag

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4187,7 +4187,7 @@ int meth_acl(struct transaction_t *txn, void *params)
         }
     }
 
-    r = mboxlist_sync_setacls(txn->req_tgt.mbentry->name, buf_cstring(&acl), mailbox_modseq_dirty(mailbox));
+    r = mboxlist_setacls(txn->req_tgt.mbentry->name, buf_cstring(&acl), mailbox_modseq_dirty(mailbox), /*silent*/0);
     if (!r) {
         mailbox_set_acl(mailbox, buf_cstring(&acl));
         char *userid = mboxname_to_userid(txn->req_tgt.mbentry->name);
@@ -4195,7 +4195,7 @@ int meth_acl(struct transaction_t *txn, void *params)
         free(userid);
     }
     if (r) {
-        syslog(LOG_ERR, "mboxlist_sync_setacls(%s) failed: %s",
+        syslog(LOG_ERR, "mboxlist_setacls(%s) failed: %s",
                txn->req_tgt.mbentry->name, error_message(r));
         txn->error.desc = error_message(r);
         ret = HTTP_SERVER_ERROR;

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -935,8 +935,7 @@ static int _create_upload_collection(const char *accountid,
                 httpd_userid, mailbox_acl(*mailboxp), newacl);
 
         /* ok, change the mailboxes database */
-        r = mboxlist_sync_setacls(mbentry->name, newacl,
-                                  mailbox_modseq_dirty(*mailboxp));
+        r = mboxlist_setacls(mbentry->name, newacl, mailbox_modseq_dirty(*mailboxp), /*silent*/0);
         if (r) {
             syslog(LOG_ERR, "mboxlist_sync_setacls(%s) failed: %s",
                    mbentry->name, error_message(r));

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2856,9 +2856,9 @@ static int set_upload_rights(const char *accountid)
     free_hash_table(&user_access, NULL);
 
     /* ok, change the mailboxes database */
-    r = mboxlist_sync_setacls(mailbox_name(mbox), newacl, mailbox_modseq_dirty(mbox));
+    r = mboxlist_setacls(mailbox_name(mbox), newacl, mailbox_modseq_dirty(mbox), /*silent*/0);
     if (r) {
-        syslog(LOG_ERR, "mboxlist_sync_setacls(%s) failed: %s",
+        syslog(LOG_ERR, "mboxlist_setacls(%s) failed: %s",
                mailbox_name(mbox), error_message(r));
     }
     else {
@@ -2962,9 +2962,9 @@ HIDDEN int jmap_set_sharewith(struct mailbox *mbox,
     hash_enumerate_sorted(&user_access, add_useracls, &newacl, cmpstringp_raw);
 
     /* ok, change the mailboxes database */
-    r = mboxlist_sync_setacls(mailbox_name(mbox), newacl, mailbox_modseq_dirty(mbox));
+    r = mboxlist_setacls(mailbox_name(mbox), newacl, mailbox_modseq_dirty(mbox), /*silent*/0);
     if (r) {
-        syslog(LOG_ERR, "mboxlist_sync_setacls(%s) failed: %s",
+        syslog(LOG_ERR, "mboxlist_setacls(%s) failed: %s",
                mailbox_name(mbox), error_message(r));
     }
     else {

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1316,7 +1316,9 @@ static int mboxlist_update_entry_full(const char *name, const mbentry_t *mbentry
 
 EXPORTED int mboxlist_delete(const mbentry_t *mbentry)
 {
-    return mboxlist_update_entry(mbentry->name, NULL, NULL);
+    // removing an already deleted entry is silent
+    int silent = mbentry->mbtype & MBTYPE_DELETED ? 1 : 0;
+    return mboxlist_update_entry_full(mbentry->name, NULL, NULL, silent);
 }
 
 EXPORTED int mboxlist_deletelock(const mbentry_t *mbentry)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3334,7 +3334,7 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
     }
     mailbox_close(&mailbox);
 
-    if (!r) r = mboxlist_sync_setacls(name, newacl, foldermodseq);
+    if (!r) r = mboxlist_setacls(name, newacl, foldermodseq, /*silent*/0);
 
     mboxname_release(&namespacelock);
     return r;
@@ -3352,7 +3352,7 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
  *
  */
 EXPORTED int
-mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodseq)
+mboxlist_setacls(const char *name, const char *newacl, modseq_t foldermodseq, int silent)
 {
     // the namespacelock will protect us from all races on the local mailboxes.db
     // so we can just read away and know it won't change under us.
@@ -3381,7 +3381,7 @@ mboxlist_sync_setacls(const char *name, const char *newacl, modseq_t foldermodse
     if (mbentry->foldermodseq < foldermodseq)
         mbentry->foldermodseq = foldermodseq;
 
-    r = mboxlist_update_entry_full(name, mbentry, NULL, /*silent*/1);
+    r = mboxlist_update_entry_full(name, mbentry, NULL, silent);
 
     if (r) {
         xsyslog(LOG_ERR, "DBERROR: error updating acl",

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2433,7 +2433,7 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
             newmbentry->createdmodseq = mailbox->i.createdmodseq;
             newmbentry->foldermodseq = mailbox_modseq_dirty(mailbox);
         }
-        r = mboxlist_update(newmbentry, /*localonly*/1);
+        r = mboxlist_update_full(newmbentry, /*localonly*/1, silent);
 
         /* any other updated intermediates get the same modseq */
         if (!r && !keep_intermediaries) {
@@ -2452,7 +2452,7 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
     else {
         /* delete entry (including DELETED.* mailboxes, no need
          * to keep that rubbish around) */
-        r = mboxlist_update_entry(name, NULL, 0);
+        r = mboxlist_update_entry_full(name, NULL, 0, silent);
         if (r) {
             xsyslog(LOG_ERR, "DBERROR: error deleting",
                              "mailbox=<%s> error=<%s>",

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -283,7 +283,7 @@ int mboxlist_setacl(const struct namespace *namespace, const char *name,
 
 /* Change all ACLs on mailbox */
 int mboxlist_updateacl_raw(const char *name, const char *acl);
-int mboxlist_sync_setacls(const char *name, const char *acl, modseq_t foldermodseq);
+int mboxlist_setacls(const char *name, const char *acl, modseq_t foldermodseq, int silent);
 int mboxlist_update_foldermodseq(const char *name, modseq_t foldermodseq);
 
 int mboxlist_set_racls(int enabled);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3048,7 +3048,7 @@ int sync_apply_mailbox(struct dlist *kin,
     mailbox->silentchanges = 1;
 
     /* always take the ACL from the master, it's not versioned */
-    r = mboxlist_sync_setacls(mboxname, acl, foldermodseq ? foldermodseq : highestmodseq);
+    r = mboxlist_setacls(mboxname, acl, foldermodseq ? foldermodseq : highestmodseq, /*silent*/1);
     if (r) goto done;
     mailbox_set_acl(mailbox, acl);
 
@@ -6029,7 +6029,7 @@ static int mailbox_full_update(struct sync_client_state *sync_cs,
     if (foldermodseq) {
         // by writing the same ACL with the updated foldermodseq, this will bounce it
         // if needed
-        r = mboxlist_sync_setacls(mailbox_name(mailbox), mailbox_acl(mailbox), foldermodseq);
+        r = mboxlist_setacls(mailbox_name(mailbox), mailbox_acl(mailbox), foldermodseq, /*silent*/1);
         if (r) goto done;
     }
 
@@ -6271,7 +6271,7 @@ static int update_mailbox_once(struct sync_client_state *sync_cs,
 
     /* bump the foldermodseq if it's higher on the replica */
     if (remote && remote->foldermodseq > mailbox_foldermodseq(mailbox)) {
-        mboxlist_sync_setacls(mailbox_name(mailbox), mailbox_acl(mailbox), remote->foldermodseq);
+        mboxlist_setacls(mailbox_name(mailbox), mailbox_acl(mailbox), remote->foldermodseq, /*silent*/1);
         mailbox->mbentry->foldermodseq = remote->foldermodseq;
     }
 


### PR DESCRIPTION
I couldn't see an easy way to test this, but code reading showed the mistake, and the Fastmail tests will capture it.

We want to NOT be silent for the non-replication cases, so this change plumbs that through, and removes the confusing 'sync' from the function name since it's used outside the replication code now.