### PR TITLE
UIDonly.pm: account for IMAPTalk +/- v4.06 differences

### DIFF
--- a/cassandane/tiny-tests/UIDonly/fetch
+++ b/cassandane/tiny-tests/UIDonly/fetch
@@ -47,25 +47,12 @@ sub test_fetch
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $imaptalk->get_last_error());
 
-    my %fetched= {};
-    my %handlers =
-    (
-        uidfetch => sub
-        {
-            my (undef, undef, $uid) = @_;
-
-            $fetched{$uid} = $imaptalk->_next_atom();
-        },
-    );
-
     xlog $self, "UID FETCH all FLAGS";
-    $res = $imaptalk->_imap_cmd("UID FETCH", 1, \%handlers,
-                                '1:10', '(FLAGS)');
-    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    my %fetched = $self->uidonly_cmd($imaptalk, 'UID FETCH', '1:10', '(FLAGS)');
     $self->assert(exists $fetched{'2'});
     # make sure UID isn't in the response
-    $self->assert_num_equals(2, scalar @{$fetched{'2'}});
-    $self->assert_str_equals('FLAGS', $fetched{'2'}->[0]);
+    $self->assert(not exists $fetched{'2'}->{uid});
+    $self->assert(exists $fetched{'2'}->{flags});
     $self->assert(exists $fetched{'3'});
     $self->assert(exists $fetched{'4'});
     $self->assert(exists $fetched{'5'});
@@ -75,15 +62,10 @@ sub test_fetch
     $self->assert(exists $fetched{'10'});
 
     xlog $self, "UID FETCH 2 UID";
-    %fetched= {};
-    $res = $imaptalk->_imap_cmd("UID FETCH", 1, \%handlers,
-                                '2', '(UID)');
-    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    %fetched = $self->uidonly_cmd($imaptalk, 'UID FETCH', '2', '(UID)');
     $self->assert(exists $fetched{'2'});
     # make sure UID is in the response
-    $self->assert_num_equals(2, scalar @{$fetched{'2'}});
-    $self->assert_str_equals('UID', $fetched{'2'}->[0]);
-    $self->assert_str_equals('2', $fetched{'2'}->[1]);
+    $self->assert_num_equals(2, $fetched{'2'}->{uid});
 }
 
 1;

--- a/cassandane/tiny-tests/UIDonly/qresync
+++ b/cassandane/tiny-tests/UIDonly/qresync
@@ -33,21 +33,19 @@ sub test_qresync
     $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
     $self->assert_num_equals(1, $res->{uidonly});
 
-    xlog "attenpt to QResync mailbox with message sequence map";
+    xlog "attempt to QResync mailbox with message sequence map";
     $imaptalk->unselect();
     $imaptalk->select("INBOX", "(QRESYNC ($uidvalidity 0 1 (1 1)))" => 1);
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
 
     xlog "QResync mailbox";
-    $imaptalk->unselect();
-    $imaptalk->select("INBOX", "(QRESYNC ($uidvalidity 0 1))" => 1);
-    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
-    $res = $imaptalk->get_response_code('uidfetch');
+    my %fetched = $self->uidonly_cmd($imaptalk, 'SELECT',
+                                     "INBOX", "(QRESYNC ($uidvalidity 0 1))");
+    $self->assert(exists $fetched{'1'});
     # make sure UID isn't in the response
-    $self->assert_not_null($res);
-    $self->assert_num_equals(4, scalar @{$res});
-    $self->assert_str_equals('FLAGS', $res->[0]);
-    $self->assert_str_equals('MODSEQ', $res->[2]);
+    $self->assert(not exists $fetched{'1'}->{uid});
+    $self->assert(exists $fetched{'1'}->{flags});
+    $self->assert(exists $fetched{'1'}->{modseq});
 }
 
 1;

--- a/cassandane/tiny-tests/UIDonly/store
+++ b/cassandane/tiny-tests/UIDonly/store
@@ -30,30 +30,16 @@ sub test_store
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $imaptalk->get_last_error());
 
-    my %fetched= {};
-    my %handlers =
-    (
-        uidfetch => sub
-        {
-            my (undef, undef, $uid) = @_;
-
-            $fetched{$uid} = $imaptalk->_next_atom();
-        },
-    );
-
     xlog $self, "UID STORE";
-    $res = $imaptalk->_imap_cmd("UID STORE", 1, \%handlers,
-                                '1,6', '+FLAGS', '(\\Deleted)');
-    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    my %fetched = $self->uidonly_cmd($imaptalk, 'UID STORE',
+                                     '1,6', '+FLAGS', '(\\Deleted)');
     $self->assert(exists $fetched{'1'});
-    $self->assert_str_equals('FLAGS', $fetched{'1'}->[0]);
-    $self->assert_str_equals('\\Deleted', $fetched{'1'}->[1][0]);
+    $self->assert_str_equals('\\Deleted', $fetched{'1'}->{flags}[0]);
     # make sure that MODSEQ is also in the response
-    $self->assert_str_equals('MODSEQ', $fetched{'1'}->[2]);
+    $self->assert(exists $fetched{'1'}->{modseq});
     $self->assert(exists $fetched{'6'});
-    $self->assert_str_equals('FLAGS', $fetched{'6'}->[0]);
-    $self->assert_str_equals('\\Deleted', $fetched{'6'}->[1][0]);
-    $self->assert_str_equals('MODSEQ', $fetched{'6'}->[2]);
+    $self->assert_str_equals('\\Deleted', $fetched{'6'}->{flags}[0]);
+    $self->assert(exists $fetched{'6'}->{modseq});
 }
 
 1;

--- a/cassandane/tiny-tests/UIDonly/unsolicited
+++ b/cassandane/tiny-tests/UIDonly/unsolicited
@@ -30,25 +30,13 @@ sub test_unsolicited
     xlog $self, "set flag in another session";
     $admintalk->store('1', '+flags', '\\flagged');
 
-    my %fetched= {};
-    my %handlers =
-    (
-        uidfetch => sub
-        {
-            my (undef, undef, $uid) = @_;
-
-            $fetched{$uid} = $imaptalk->_next_atom();
-        },
-    );
-
     xlog $self, "poll for changes";
-    $res = $imaptalk->_imap_cmd('NOOP', 0, \%handlers);
-    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    my %fetched = $self->uidonly_cmd($imaptalk, 'NOOP');
     $self->assert(exists $fetched{'2'});
     # make sure UID isn't in the response
-    $self->assert_num_equals(4, scalar @{$fetched{'2'}});
-    $self->assert_str_equals('FLAGS', $fetched{'2'}->[0]);
-    $self->assert_str_equals('MODSEQ', $fetched{'2'}->[2]);
+    $self->assert(not exists $fetched{'2'}->{uid});
+    $self->assert(exists $fetched{'2'}->{flags});
+    $self->assert(exists $fetched{'2'}->{modseq});
 }
 
 1;


### PR DESCRIPTION
The UIDFETCH data gets returned to the callback as a hash in v4.06 but is an array in v4.04