### PR TITLE
Idle.pm: pull SESSIONID from procinfo rather than LOGIN response

### DIFF
--- a/cassandane/Cassandane/Cyrus/Idle.pm
+++ b/cassandane/Cassandane/Cyrus/Idle.pm
@@ -428,23 +428,20 @@ sub test_sigterm
     my $store = $svc->create_store(folder => 'INBOX');
     my $talk = $store->get_client();
 
-    # User logged in SESSIONID=<0604061-1337148251-29539-1>
-    my $rem = $talk->get_response_code('remainder');
-    my (undef, $start, $imapd_pid, undef) =
-        ($rem =~ m/SESSIONID=<([^-]+)-(\d+)-(\d+)-(\d+)/);
-    # cyrus switched pid and start at one point - the start will ALWAYS
-    # be larger than the pid, so....
-    ($imapd_pid, $start) = ($start, $imapd_pid) if ($start < $imapd_pid);
-    $self->assert_not_null($imapd_pid);
-    $imapd_pid = 0 + $imapd_pid;
-    $self->assert($imapd_pid > 1);
-    xlog $self, "PID of imapd process is $imapd_pid";
-
     $store->_select();
 
     xlog $self, "Sending the IDLE command";
     $store->idle_begin()
         or die "IDLE failed: $@";
+
+    # procinfo: pid SP servicename SP host [SP user] [SP mailbox] [SP cmdname]
+    my $procinfo = join '', $self->{instance}->run_cyr_info('proc');
+    my ($imapd_pid, undef) =
+        ($procinfo =~ m/^(\d+) imap (.+) cassandane user.cassandane Idle$/);
+    $self->assert_not_null($imapd_pid);
+    $imapd_pid = 0 + $imapd_pid;
+    $self->assert($imapd_pid > 1);
+    xlog $self, "PID of imapd process is $imapd_pid";
 
     xlog $self, "Poll for any unsolicited response - should be none";
     my $r = $store->idle_response({}, 0);

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -2747,4 +2747,36 @@ sub read_mailboxes_db
     return JSON::decode_json(slurp_file($outfile));
 }
 
+sub run_cyr_info
+{
+    my ($self, @args) = @_;
+
+    my $filename = $self->{basedir} . "/cyr_info.out";
+
+    $self->run_command({
+            cyrus => 1,
+            redirects => { stdout => $filename },
+        },
+        'cyr_info',
+        # we get -C for free
+        '-M', $self->_master_conf(),
+        @args
+    );
+
+    open RESULTS, '<', $filename
+        or die "Cannot open $filename for reading: $!";
+    my @res = readline(RESULTS);
+    close RESULTS;
+
+    if ($args[0] eq 'proc') {
+        # if we see any of our fake daemons, no we didn't
+        my @fakedaemons = qw(fakesaslauthd fakeldapd);
+        my $pattern = q{\b(?:} . join(q{|}, @fakedaemons) . q{)\b};
+        my $re = qr{$pattern};
+        @res = grep { $_ !~ m/$re/ } @res;
+    }
+
+    return @res;
+}
+
 1;


### PR DESCRIPTION
IMAPTalk v4.06 now send CAPABILITY command immediately after LOGIN so we lose the LOGIN response