### PR TITLE
search_query.c: min_uid might start at zero

### DIFF
--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -648,7 +648,6 @@ static int _subquery_run_one_folder(search_query_t *query,
             }
 
             memset(&folder->esearch, 0, sizeof(folder->esearch));
-            folder->esearch.min_uid = state->last_uid + 1;
         }
 
         /* we have a new UID that needs to be merged in */
@@ -658,7 +657,7 @@ static int _subquery_run_one_folder(search_query_t *query,
         folder->esearch.all_count++;
 
         /* track first and last for MIN/MAX queries */
-        if (im->uid < folder->esearch.min_uid) {
+        if (!folder->esearch.min_uid || im->uid < folder->esearch.min_uid) {
             folder->esearch.min_uid = im->uid;
             folder->esearch.first_modseq = im->modseq;
         }


### PR DESCRIPTION
_subquery_run_one_folder() can be called with an existing folder so we don't have the chance to set min_uid to last_uid + 1

This bug only appeared with using Xapian for search