### PR TITLE
cyr_expire: silent delete for cleaning up DELETED mailboxes

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3621,7 +3621,8 @@ static int annotation_set_mailboxopt(annotate_state_t *state,
         mailbox_index_dirty(mailbox);
         mailbox_modseq_dirty(mailbox);
         mailbox->i.options = newopts;
-        mboxlist_update_foldermodseq(mailbox_name(mailbox), mailbox->i.highestmodseq);
+        if (!state->silent)
+            mboxlist_update_foldermodseq(mailbox_name(mailbox), mailbox->i.highestmodseq);
     }
 
     return 0;
@@ -3652,7 +3653,8 @@ static int annotation_set_pop3showafter(annotate_state_t *state,
         mailbox_index_dirty(mailbox);
         mailbox_modseq_dirty(mailbox);
         mailbox->i.pop3_show_after = date;
-        mboxlist_update_foldermodseq(mailbox_name(mailbox), mailbox->i.highestmodseq);
+        if (!state->silent)
+            mboxlist_update_foldermodseq(mailbox_name(mailbox), mailbox->i.highestmodseq);
     }
 
     return 0;
@@ -4022,6 +4024,7 @@ static int rename_cb(const char *mboxname __attribute__((unused)),
 {
     struct rename_rock *rrock = (struct rename_rock *) rock;
     int r = 0;
+    int silent = rrock->oldmailbox->silentchanges;
 
     if (rrock->newmailbox &&
         /* snoozed MUST only appear on one copy of a message */
@@ -4036,14 +4039,14 @@ static int rename_cb(const char *mboxname __attribute__((unused)),
             newuserid = rrock->newuserid;
         }
         r = write_entry(rrock->newmailbox, rrock->newuid, entry, newuserid,
-                        value, /*ignorequota*/0, /*silent*/0, NULL, /*maywrite*/1);
+                        value, /*ignorequota*/0, silent, NULL, /*maywrite*/1);
     }
 
     if (!rrock->copy && !r) {
         /* delete existing entry */
         struct buf dattrib = BUF_INITIALIZER;
         r = write_entry(rrock->oldmailbox, uid, entry, userid, &dattrib,
-                        /*ignorequota*/0, /*silent*/0, NULL, /*maywrite*/1);
+                        /*ignorequota*/0, silent, NULL, /*maywrite*/1);
     }
 
     return r;

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -776,8 +776,9 @@ static int do_delete(struct cyr_expire_ctx *ctx)
 
             verbosep("Removing: %s", name);
 
-            ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL,
-                                             MBOXLIST_DELETE_KEEP_INTERMEDIARIES);
+            int flags = MBOXLIST_DELETE_KEEP_INTERMEDIARIES | MBOXLIST_DELETE_SILENT;
+
+            ret = mboxlist_deletemailboxlock(name, 1, NULL, NULL, NULL, flags);
             libcyrus_run_delayed();
             /* XXX: Ignoring the return from mboxlist_deletemailbox() ??? */
             count++;

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -366,7 +366,7 @@ static int fixquota_addroot(struct quota *q, void *rock)
         free(localq.scanmbox);
         localq.scanmbox = NULL;
 
-        r = quota_write(&localq, 0, &tid);
+        r = quota_write(&localq, /*silent*/1, &tid);
         if (r) {
             errmsg(r, "failed writing quota record for '%s'",
                    q->root);
@@ -535,7 +535,7 @@ static int fixquota_dombox(const mbentry_t *mbentry, void *rock)
         free(localq.scanmbox);
         localq.scanmbox = xstrdup(mbentry->name);
 
-        r = quota_write(&localq, 0, &txn);
+        r = quota_write(&localq, /*silent*/1, &txn);
         quota_free(&localq);
 
         if (r) {
@@ -615,7 +615,7 @@ int fixquota_finish(int thisquota)
     free(localq.scanmbox);
     localq.scanmbox = NULL;
 
-    r = quota_write(&localq, 0, &tid);
+    r = quota_write(&localq, /*silent*/1, &tid);
     if (r) {
         errmsg(r, "failed writing quotaroot: '%s'", root);
         goto done;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -4042,7 +4042,7 @@ int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
     mboxlist_usermboxtree(userid, NULL, addmbox_cb, list, 0);
 
     /* delete in reverse so INBOX is last */
-    int delflags = MBOXLIST_DELETE_FORCE;
+    int delflags = MBOXLIST_DELETE_FORCE | MBOXLIST_DELETE_SILENT;
     if (sstate->flags & SYNC_FLAG_LOCALONLY)
         delflags |= MBOXLIST_DELETE_LOCALONLY;
     for (i = list->count; i; i--) {


### PR DESCRIPTION
Found one more missing "silent" codepath!  This is for mailboxes that are already DELETED namespace, so invisible.

Bron.