### PR TITLE
jmap_mail: if no rfc822 subpart, use regular part

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7259,11 +7259,11 @@ static int _email_get_headers(jmap_req_t *req __attribute__((unused)),
         jmap_wantprop(props, "bcc") ||
         jmap_wantprop(props, "subject") ||
         jmap_wantprop(props, "sentAt")) {
-        const struct body *part;
+        const struct body *part = NULL;
         if (msg->rfc822part) {
             part = msg->rfc822part->subpart;
         }
-        else {
+        if (!part) {
             r = _cyrusmsg_need_part0(msg);
             if (r) return r;
             part = msg->part0;


### PR DESCRIPTION
This fixes a crasher found in FM production, where subpart was NULL.

I'm not sure if this is correct.  Other options would be "return the msg->rfc822part" or "return an error".  Definitely leaving part as NULL isn't right though.