### PR TITLE
imapd.c: add support for JMAPACCESS capability and response code

### DIFF
--- a/changes/next/imap_jmapaccess
+++ b/changes/next/imap_jmapaccess
@@ -1,0 +1,19 @@
+
+Description:
+
+Adds support for IMAP JMAPACCESS response code (draft-ietf-extra-jmapaccess).
+
+
+Config changes:
+
+Adds jmapaccess_url option.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/docsrc/imap/rfc-support.rst
+++ b/docsrc/imap/rfc-support.rst
@@ -908,6 +908,10 @@ The following is an inventory of RFCs supported by Cyrus IMAP.
 
     IMAP4 Extension: Message Preview Generation
 
+:rfc:`9042`
+
+    Sieve Email Filtering: Delivery by MAILBOXID
+
 :rfc:`9051`
 
     Internet Message Access Protocol (IMAP) - version 4rev2
@@ -931,9 +935,9 @@ draft-ietf-extra-imap-inprogress
 
    IMAP4 Response Code for Command Progress Notifications
 
-draft-ietf-extra-sieve-mailboxid
+draft-ietf-extra-jmapaccess
 
-    Sieve Email Filtering: delivery by mailboxid
+   The JMAPACCESS Extension for IMAP
 
 draft-ietf-extra-sieve-snooze
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -1230,6 +1230,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    the same has to be done (cyr_dbtool) for each subscription database
    See improved_mboxlist_sort.html.*/
 
+{ "jmapaccess_url", NULL, STRING, "UNRELEASED" }
+/* The JMAP Session URL to advertise to sucessfully authenticated IMAP clients,
+   if the same credentials can be used to authenticate via JMAP
+   (see draft-ietf-extra-jmapaccess). */
+
 { "jmap_emailsearch_db_path", NULL, STRING, "3.1.6", "3.6.0" }
 /* The absolute path to the JMAP email search cache file.  If not
    specified, JMAP Email/query and Email/queryChanges will not


### PR DESCRIPTION
Implementation of 
[https://www.ietf.org/archive/id/draft-ietf-extra-jmapaccess-08.html](url)
without a JMAPACCESS capability (as discussed at IETF 119)