### PR TITLE
Tiny group fixes

### DIFF
--- a/lib/auth_pts.c
+++ b/lib/auth_pts.c
@@ -534,7 +534,6 @@ static strarray_t *mygroups(const struct auth_state *auth_state)
         return NULL;
 
     sa = strarray_new();
-    strarray_truncate(sa, auth_state->ngroups);
     for (i = 0; i < auth_state->ngroups; i++) {
         strarray_append(sa, auth_state->groups[i].id);
     }

--- a/lib/auth_unix.c
+++ b/lib/auth_unix.c
@@ -72,19 +72,14 @@ static struct auth_state auth_anonymous = {
  */
 static int mymemberof(const struct auth_state *auth_state, const char *identifier)
 {
-    int i;
-
     if (!auth_state) auth_state = &auth_anonymous;
 
     if (strcmp(identifier, "anyone") == 0) return 1;
 
     if (strcmp(identifier, auth_state->userid) == 0) return 3;
 
-    if (strncmp(identifier, "group:", 6) != 0) return 0;
+    if (!strncmp(identifier, "group:", 6) && strarray_find(&auth_state->groups, identifier+6, 0) >= 0) return 2;
 
-    for (i=0; i<auth_state->groups.count ; i++) {
-        if (strcmp(identifier+6, auth_state->groups.data[i]) == 0) return 2;
-    }
     return 0;
 }
 


### PR DESCRIPTION
Here's the tiny fixes - the pts thing I mentioned, plus a rewrite to stop parsing `group:` as usernames and a use of strarray_find rather than open-coding it in auth_unix.c