### PR TITLE
Mmap null

### DIFF
--- a/lib/map_shared.c
+++ b/lib/map_shared.c
@@ -88,11 +88,13 @@ EXPORTED void map_refresh(int fd, int onceonly, const char **base,
         }
     }
 
-    if (!onceonly) {
-        newlen = (newlen + 2*SLOP - 1) & ~(SLOP-1);
-    }
+    /* always map one extra byte so there's a trailing NULL to protect
+     * us from overruns.  This does NOT mean that we should treat this
+     * memory as a cstring */
+    if (!onceonly)
+        newlen = (newlen + 2*SLOP) & ~(SLOP-1);
 
-    *base = (char *)mmap((caddr_t)0, newlen, PROT_READ, MAP_SHARED
+    *base = (char *)mmap((caddr_t)0, onceonly ? newlen + 1 : newlen, PROT_READ, MAP_SHARED
 #ifdef MAP_FILE
 | MAP_FILE
 #endif

--- a/lib/map_stupidshared.c
+++ b/lib/map_stupidshared.c
@@ -93,7 +93,10 @@ EXPORTED map_refresh(int fd, int onceonly, const char **base,
     flags |= MAP_VARIABLE;
 #endif
 
-    *base = (char *)mmap((caddr_t)0, newlen, PROT_READ, flags, fd, 0L);
+    /* always map one extra byte so there's a trailing NULL to protect
+     * us from overruns.  This does NOT mean that we should treat this
+     * memory as a cstring */
+    *base = (char *)mmap((caddr_t)0, newlen+1, PROT_READ, flags, fd, 0L);
     if (*base == (char *)MAP_FAILED) {
         syslog(LOG_ERR, "IOERROR: mapping %s file%s%s: %m", name,
                mboxname ? " for " : "", mboxname ? mboxname : "");


### PR DESCRIPTION
This makes sure we always have NULL at the end of any mmap.