### PR TITLE
message: return newcid annotation values in message_extract_cids

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -467,6 +467,10 @@ magic(NoReplicaonly => sub {
     my $self = shift;
     $self->{no_replicaonly} = 1;
 });
+magic(ConversationMaxThread10 => sub {
+    my $self = shift;
+    $self->config_set('conversation_max_thread' => 10);
+});
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword
@@ -1,0 +1,77 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_sieve_some_in_thread_have_keyword
+    :needs_component_jmap :needs_component_sieve :ConversationMaxThread10
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    xlog $self, "Set up Sieve script";
+    $imap->create("matches") or die;
+    my $sieve = <<EOF;
+require ["x-cyrus-jmapquery", "x-cyrus-log", "variables", "fileinto"];
+if
+  allof( not string :is "\${stop}" "Y",
+    jmapquery text:
+    {
+      "someInThreadHaveKeyword": "\$IsMailingList"
+    }
+.
+  )
+{
+  fileinto "matches";
+}
+EOF
+    $self->{instance}->install_sieve_script($sieve);
+
+    xlog $self, "Create split conversation";
+    my $messageId = 'messageid1@example.com';
+    $self->make_message('Email A', messageid => $messageId);
+    my $convMaxthread = $self->{instance}->{config}->get('conversations_max_thread');
+    foreach (1 .. 2 * $convMaxthread - 1) {
+        $self->make_message("Re: Email A",
+            references => [ "<$messageId>" ],
+        );
+    }
+
+    xlog $self, "Set flag on message in first conversation split";
+    my $res = $imap->store($convMaxthread - 1, '+flags', '($IsMailingList)');
+
+    my $mime = <<EOF;
+From: helloworld\@local
+To: to\@local
+Subject: Re: Email A
+References: <$messageId>
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;charset=us-ascii
+Content-Transfer-Encoding: 7bit
+
+hello
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    my $msg = Cassandane::Message->new();
+    $msg->set_lines(split /\n/, $mime);
+
+    xlog $self, "Deliver message for conversation";
+    $msg->remove_headers('Message-Id');
+    $msg->set_headers('Message-Id', '<4bb20c19-3a9d-483f@local>');
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Assert that someInThreadHaveKeyword did not match";
+    # XXX Might be OK to match here. But that's not how it is implemented.
+    $self->assert_num_equals(0, $imap->message_count('matches'));
+
+    xlog $self, "Set flag on message in second conversation split";
+    my $res = $imap->store($convMaxthread + 1, '+flags', '($IsMailingList)');
+
+    xlog $self, "Deliver message for conversation";
+    $msg->remove_headers('Message-Id');
+    $msg->set_headers('Message-Id', '<ccda7f93-0328-47b8@local>');
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Assert that someInThreadHaveKeyword did match";
+    $self->assert_num_equals(1, $imap->message_count('matches'));
+}

--- a/imap/message.c
+++ b/imap/message.c
@@ -5633,5 +5633,19 @@ EXPORTED int message_extract_cids(message_t *msg,
     int r = extract_convdata(cstate, msg, &msgidlist, cids, &msubj);
     strarray_fini(&msgidlist);
     free(msubj);
+    size_t i;
+    for (i = 0; i < arrayu64_size(cids); i++) {
+        conversation_id_t newcid = 0;
+        struct buf annotkey = BUF_INITIALIZER;
+        struct buf annotval = BUF_INITIALIZER;
+        buf_printf(&annotkey, "%snewcid/%016llx", IMAP_ANNOT_NS, (conversation_id_t) arrayu64_nth(cids, i));
+        annotatemore_lookup(cstate->annotmboxname, buf_cstring(&annotkey), "", &annotval);
+        if (annotval.len == 16) {
+            const char *p = buf_cstring(&annotval);
+            /* we have a new canonical CID */
+            parsehex(p, &p, 16, &newcid);
+        }
+        if (newcid) arrayu64_set(cids, i, newcid);
+    }
     return r;
 }


### PR DESCRIPTION
This fixes a bug that has shown up when evaluating JMAP Email queries in Sieve for split conversations.

The some/all/noneInThreadHaveKeyword filter criteria failed, because message_extract_cids returned the conversation id of the first split of all splits in the conversation. This patch changes it to return the very last split which is going to be the one that this message will end up in (unless the message starts a new split).