### PR TITLE
conversations: don't update xconvmodseq on replicas

### DIFF
--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -412,7 +412,8 @@ static void test_folder_rename(void)
                         &ecounts1,
                         /*size*/10, /*counts*/NULL,
                         /*modseq*/1,
-                        /*createdmodseq*/1);
+                        /*createdmodseq*/1,
+                        /*silent*/0);
 
     int f2 = conversation_folder_number(state, FOLDER2, 1);
     struct emailcounts ecounts2 = { f2, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
@@ -422,7 +423,8 @@ static void test_folder_rename(void)
                         &ecounts2,
                         /*size*/20, /*counts*/NULL,
                         /*modseq*/8,
-                        /*createdmodseq*/1);
+                        /*createdmodseq*/1,
+                        /*silent*/0);
 
     conv->subject = xstrdup("☃");
 
@@ -526,7 +528,8 @@ static void test_folders(void)
                         &ecounts1,
                         /*size*/0, counts,
                         /*modseq*/4,
-                        /*createdmodseq*/1);
+                        /*createdmodseq*/1,
+                        /*silent*/0);
 
     /* make sure the data we just passed to conversation_update()
      * is present in the structure */
@@ -594,7 +597,8 @@ static void test_folders(void)
                         &ecounts2,
                         /*size*/0, counts,
                         /*modseq*/7,
-                        /*createdmodseq*/1);
+                        /*createdmodseq*/1,
+                        /*silent*/0);
 
     CU_ASSERT_EQUAL((conv->flags & CONV_ISDIRTY), CONV_ISDIRTY);
     CU_ASSERT_EQUAL(conv->num_records, 2);
@@ -630,7 +634,8 @@ static void test_folders(void)
                         &ecounts3,
                         /*size*/0, counts,
                         /*modseq*/55,
-                        /*createdmodseq*/1);
+                        /*createdmodseq*/1,
+                        /*silent*/0);
 
     CU_ASSERT_EQUAL((conv->flags & CONV_ISDIRTY), CONV_ISDIRTY);
     CU_ASSERT_EQUAL(conv->num_records, 3);
@@ -750,7 +755,8 @@ static void test_folders(void)
                         &ecountsneg1,
                         /*size*/0, counts,
                         /*modseq*/56,
-                        /*createdmodseq*/1);
+                        /*createdmodseq*/1,
+                        /*silent*/0);
 
     CU_ASSERT_EQUAL(conv->num_records, 2);
     CU_ASSERT_EQUAL(conv->exists, 1);
@@ -866,7 +872,8 @@ static void test_folder_ordering(void)
                         &ecounts1,
                         /*size*/0, counts,
                         /*modseq*/1,
-                        /*createdmodseq*/0);
+                        /*createdmodseq*/0,
+                        /*silent*/0);
 
     /* add folders out of order */
     struct emailcounts ecounts3 = { f3, 0, -1, { 0, 0, 0, 0, 0, 0 }, { 1, 1, 0, 1, 1, 0 },
@@ -875,7 +882,8 @@ static void test_folder_ordering(void)
                         &ecounts3,
                         /*size*/0, counts,
                         /*modseq*/55,
-                        /*createdmodseq*/0);
+                        /*createdmodseq*/0,
+                        /*silent*/0);
 
     /* save and reload here just to be sure */
     r = conversation_save(state, C_CID, conv);
@@ -892,7 +900,8 @@ static void test_folder_ordering(void)
                         &ecounts2,
                         /*size*/0, counts,
                         /*modseq*/7,
-                        /*createdmodseq*/0);
+                        /*createdmodseq*/0,
+                        /*silent*/0);
 
     CU_ASSERT_EQUAL((conv->flags & CONV_ISDIRTY), CONV_ISDIRTY);
 
@@ -1019,7 +1028,8 @@ static void __test_senders(void)
                         /*exists*/1, /*unseen*/0,
                         /*size*/0, counts,
                         /*modseq*/1,
-                        /*createdmodseq*/0);
+                        /*createdmodseq*/0,
+                        /*silent*/0);
 
     /* there's no function for getting sender data, oh well */
     sender1 = conv->senders;
@@ -1215,7 +1225,8 @@ static void test_dump(void)
                                 &ecounts,
                                 /*size*/0, /*counts*/NULL,
                                 /*modseq*/100,
-                                /*createdmodseq*/0);
+                                /*createdmodseq*/0,
+                                /*silent*/0);
         }
         r = conversation_save(state, cid, conv);
         CU_ASSERT_EQUAL(r, 0);

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -330,13 +330,14 @@ extern int conversations_update_record(struct conversations_state *cstate,
                                        const struct index_record *old,
                                        struct index_record *new_,
                                        int allowrenumber,
-                                       int ignorelimits);
+                                       int ignorelimits,
+				       int silent);
 
 extern int conversation_update(struct conversations_state *state,
                                 conversation_t *conv,
                                 struct emailcounts *ecounts,
                                 ssize_t delta_size, int *delta_counts,
-                                modseq_t modseq, modseq_t createdmodseq);
+                                modseq_t modseq, modseq_t createdmodseq, int silent);
 extern conv_folder_t *conversation_find_folder(struct conversations_state *state,
                                                conversation_t *,
                                                const char *mboxname);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -4345,7 +4345,7 @@ static int mailbox_update_conversations(struct mailbox *mailbox,
 
     int ignorelimits = new ? new->ignorelimits : 1;
     return conversations_update_record(cstate, mailbox, old, new,
-                                       /*allowrenumber*/1, ignorelimits);
+                                       /*allowrenumber*/1, ignorelimits, mailbox->silentchanges);
 }
 
 
@@ -6103,7 +6103,7 @@ EXPORTED int mailbox_add_conversations(struct mailbox *mailbox, int silent)
         struct index_record copyrecord = *record;
         copyrecord.silentupdate = silent;
         r = conversations_update_record(cstate, mailbox, NULL, &copyrecord, 1,
-                                        /*ignorelimits*/1);
+                                        /*ignorelimits*/1, silent);
         if (r) break;
 
         if (copyrecord.cid == record->cid)
@@ -6113,7 +6113,7 @@ EXPORTED int mailbox_add_conversations(struct mailbox *mailbox, int silent)
 
         /* remove this record again */
         r = conversations_update_record(cstate, mailbox, &copyrecord, NULL, 0,
-                                        /*ignorelimits*/1);
+                                        /*ignorelimits*/1, silent);
         if (r) break;
 
         /* we had a cid change, so rewrite will try to correct the counts, so we
@@ -6121,7 +6121,7 @@ EXPORTED int mailbox_add_conversations(struct mailbox *mailbox, int silent)
         struct index_record oldrecord = *record;
         /* add the old record that's going away */
         r = conversations_update_record(cstate, mailbox, NULL, &oldrecord, 0,
-                                        /*ignorelimits*/1);
+                                        /*ignorelimits*/1, silent);
         if (r) break;
 
         /* and finally to the update that will reverse those two actions again */
@@ -6149,7 +6149,8 @@ static int mailbox_delete_conversations(struct mailbox *mailbox)
             continue;
 
         r = conversations_update_record(cstate, mailbox, record, NULL,
-                                        /*allowrenumber*/0, /*ignorelimits*/1);
+                                        /*allowrenumber*/0, /*ignorelimits*/1,
+					mailbox->silentchanges);
         if (r) break;
     }
     mailbox_iter_done(&iter);


### PR DESCRIPTION
It will be synced anyway; we sync_log the affected mailboxes; and this stops it being accidentally bumped by the replica if the message changes are synced out of order.