### PR TITLE
http_jmap.c: add "urn:ietf:params:jmap:core:backendInfo" capability

### DIFF
--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -58,6 +58,7 @@
 #include "strarray.h"
 
 #define JMAP_URN_CORE       "urn:ietf:params:jmap:core"
+#define JMAP_URN_CORE_INFO  "urn:ietf:params:jmap:core:backendInfo"
 #define JMAP_URN_MAIL       "urn:ietf:params:jmap:mail"
 #define JMAP_URN_SUBMISSION "urn:ietf:params:jmap:submission"
 #define JMAP_URN_VACATION   "urn:ietf:params:jmap:vacationresponse"

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -47,6 +47,7 @@
 
 #include <string.h>
 #include <syslog.h>
+#include <sys/utsname.h>
 
 #include "acl.h"
 #include "append.h"
@@ -182,6 +183,23 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
                 "maxObjectsInSet",
                 settings->limits[MAX_OBJECTS_IN_SET],
                 "collationAlgorithms", json_array()));
+
+    if (config_serverinfo == IMAP_ENUM_SERVERINFO_ON) {
+        struct utsname buf;
+
+        uname(&buf);
+        json_object_set_new(settings->server_capabilities,
+                            JMAP_URN_CORE_INFO,
+                            json_pack("{s:{s:s s:s} s:n s:{s:s s:s} s:n}",
+                                      "product",
+                                      "name", "Cyrus JMAP",
+                                      "version", CYRUS_VERSION,
+                                      "backend",
+                                      "environment",
+                                      "name", buf.sysname,
+                                      "version", buf.release,
+                                      "capabilitiesOverrides"));
+    }
 
     jmap_method_t *mp;
     for (mp = jmap_core_methods_standard; mp->name; mp++) {


### PR DESCRIPTION
Per https://datatracker.ietf.org/doc/draft-ietf-jmap-portability-extensions/