### PR TITLE
xapian_wrap: return NULL query for empty CJK terms

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_utf8punct_term
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_utf8punct_term
@@ -1,0 +1,87 @@
+#!perl
+use Cassandane::Tiny;
+use Encode qw(decode encode);
+use JSON qw(encode_json);
+
+sub test_email_query_utf8punct_term
+    :needs_component_jmap :needs_component_sieve :JMAPExtensions
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/performance');
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/debug');
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+
+    xlog $self, "Create MIME message containing a non-ASCII punctuation char";
+    my $mime = <<"EOF";
+From: <from\@local>
+To: <to\@local>
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8BIT
+Content-Type: text/plain; charset=utf-8
+
+hello \N{U+2013} world
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    $mime = encode('utf-8', $mime);
+    $imap->append('INBOX', $mime) || die $@;
+
+    xlog $self, "run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $filter = {
+        operator => 'AND',
+        conditions => [{
+            body => 'hello'
+        }, {
+            body => "\N{U+2013}",
+        }, {
+            body => 'world',
+        }],
+    };
+
+    xlog $self, "Assert Email/query ignores punctuation character in filter";
+    my $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => $filter,
+            disableGuidSearch => JSON::true,
+        }, 'R1'],
+        ['Email/query', {
+            filter => $filter,
+        }, 'R2'],
+    ]);
+    $self->assert_equals(JSON::false,
+        $res->[0][1]{performance}{details}{isGuidSearch});
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
+    $self->assert_equals(JSON::true,
+        $res->[1][1]{performance}{details}{isGuidSearch});
+    $self->assert_num_equals(1, scalar @{$res->[1][1]{ids}});
+
+    xlog $self, "Assert JMAP Sieve ignores punctuation character in filter";
+    $imap->create("matches") or die;
+    my $filterAsStr = encode_json($filter);
+    $self->{instance}->install_sieve_script(<<"EOF"
+require ["x-cyrus-jmapquery", "x-cyrus-log", "variables", "fileinto"];
+if
+  allof( not string :is "${stop}" "Y",
+    jmapquery text:
+  $filterAsStr
+.
+  )
+{
+  fileinto "matches";
+}
+EOF
+    );
+
+    my $msg = Cassandane::Message->new();
+    $msg->set_lines(split /\n/, $mime);
+    $self->{instance}->deliver($msg);
+
+    $imap->select('matches');
+    $self->assert_num_equals(1, $imap->get_response_code('exists'));
+    $imap->unselect();
+}

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1918,7 +1918,7 @@ static Xapian::Query* xapian_query_new_match_word_break(const xapian_db_t *db, c
     return q;
 }
 
-EXPORTED Xapian::Query *
+static Xapian::Query *
 xapian_query_new_match_internal(const xapian_db_t *db, int partnum, const char *str)
 {
     const char *prefix = get_term_prefix(XAPIAN_DB_CURRENT_VERSION, partnum);
@@ -1955,12 +1955,7 @@ xapian_query_new_match_internal(const xapian_db_t *db, int partnum, const char *
         Xapian::TermGenerator::stem_strategy stem_strategy =
             get_stem_strategy(XAPIAN_DB_CURRENT_VERSION, partnum);
 
-        Xapian::Query *qq = query_new_textmatch(db, str, prefix, stem_strategy);
-        if (qq->get_type() == Xapian::Query::LEAF_MATCH_NOTHING) {
-            delete qq;
-            qq = NULL;
-        }
-        return qq;
+        return query_new_textmatch(db, str, prefix, stem_strategy);
 
     } catch (const Xapian::Error &err) {
         xsyslog(LOG_ERR, "IOERROR: caught exception",
@@ -2008,6 +2003,12 @@ xapian_query_new_match(const xapian_db_t *db, int partnum, const char *str)
         free(mystr);
         charset_free(&utf8);
     }
+
+    if (q && q->get_type() == Xapian::Query::LEAF_MATCH_NOTHING) {
+        delete q;
+        q = NULL;
+    }
+
     return (xapian_query_t*) q;
 }
 

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1872,7 +1872,7 @@ static Xapian::Query *query_new_type(const xapian_db_t *db __attribute__((unused
     return new Xapian::Query(q);
 }
 
-static Xapian::Query* xapian_query_new_match_cjk(const xapian_db_t *db, const char *str, const char *prefix)
+static Xapian::Query* xapian_query_new_match_word_break(const xapian_db_t *db, const char *str, const char *prefix)
 {
     Xapian::Query *q = new Xapian::Query {db->parser->parse_query(
             str,
@@ -1948,7 +1948,7 @@ xapian_query_new_match_internal(const xapian_db_t *db, int partnum, const char *
         // Don't stem queries for Thaana codepage (0780) or higher.
         for (const unsigned char *p = (const unsigned char *)str; *p; p++) {
             if (*p > 221) //has highbit
-                return xapian_query_new_match_cjk(db, str, prefix);
+                return xapian_query_new_match_word_break(db, str, prefix);
         }
 
         // Stemable codepage.


### PR DESCRIPTION
The Xapian wrapper already returned NULL for ASCII query terms that just consisted of punctuation characters. But a query term containing Unicode punctuation codepoints such as EN DASH (U+2013) was parsed as CJK text, returning an empty, always falsible, query instead of NULL.

This issue just showed up for Email/query using uidsearch, but the new test checks all three codepaths: uidsearch, guidsearch and Sieve.