### PR TITLE
cassandane: general-purpose runtime skip hook

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
@@ -89,6 +89,21 @@ sub set_up
     ]);
 }
 
+sub skip_check
+{
+    my ($self) = @_;
+
+    # XXX skip tests that would hang in verbose mode for now -- see
+    # XXX detailed comment at MaxMessages::put_submission
+    if (get_verbose()
+        && $self->{_name} eq 'test_emailsubmission_set_futurerelease')
+    {
+        return 'test would hang in verbose mode';
+    }
+
+    return undef;
+}
+
 sub getinbox
 {
     my ($self, $args) = @_;

--- a/cassandane/Cassandane/Cyrus/MaxMessages.pm
+++ b/cassandane/Cassandane/Cyrus/MaxMessages.pm
@@ -93,6 +93,16 @@ sub tear_down
     $self->SUPER::tear_down();
 }
 
+sub skip_check
+{
+    my ($self) = @_;
+
+    # XXX skip all tests from this suite in verbose mode for now -- see
+    # XXX detailed comment on put_submission below
+    my $reason = "test would hang in verbose mode";
+    return get_verbose() ? $reason : undef;
+}
+
 sub _random_vevent
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -172,6 +172,22 @@ sub filter
             return 1 if $method !~ m/_slow$/;
             return;
         },
+        skip_runtime_check => sub
+        {
+            # To use: add a skip_check method to your test suite that
+            # implements logic to determine whether some test should run or
+            # not (perhaps by examining $self->{_name}).  Return undef if
+            # the test should run, or a message explaining why the test is
+            # being skipped
+            return if not $self->can('skip_check');
+            my $reason = $self->skip_check();
+            if ($reason) {
+                xlog "$self->{_name} will be skipped:",
+                     "skip_check said '$reason'";
+                return 1;
+            }
+            return;
+        },
     };
 }
 

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -145,6 +145,7 @@ my %runners =
         local *__ANON__ = "runner_tap";
         my $runner = Cassandane::Unit::Runner->new($fh);
         my @filters = qw(x skip_version skip_missing_features
+                         skip_runtime_check
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         push @filters, 'slow_only' if $plan->{slow_only};
@@ -157,6 +158,7 @@ my %runners =
         local *__ANON__ = "runner_pretty";
         my $runner = Cassandane::Unit::RunnerPretty->new({}, $fh);
         my @filters = qw(x skip_version skip_missing_features
+                         skip_runtime_check
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         push @filters, 'slow_only' if $plan->{slow_only};
@@ -169,6 +171,7 @@ my %runners =
         local *__ANON__ = "runner_prettier";
         my $runner = Cassandane::Unit::RunnerPretty->new({quiet=>1}, $fh);
         my @filters = qw(x skip_version skip_missing_features
+                         skip_runtime_check
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         push @filters, 'slow_only' if $plan->{slow_only};
@@ -201,6 +204,7 @@ eval
 
         my $runner = Cassandane::Unit::RunnerXML->new($output_dir);
         my @filters = qw(x skip_version skip_missing_features
+                         skip_runtime_check
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         push @filters, 'slow_only' if $plan->{slow_only};


### PR DESCRIPTION
* Adds a hook to Cassandane such that test suites can decide at runtime whether some test should run or not
* Adds such checks to MaxMessages and JMAPEmailSubmission to skip tests that are known to hang in verbose mode when running in verbose mode