### PR TITLE
docsrc: Replace CRAM-MD5 and DIGEST-MD5 with SCRAM

### DIFF
--- a/docsrc/imap/concepts/deployment/authentication_and_authorization.rst
+++ b/docsrc/imap/concepts/deployment/authentication_and_authorization.rst
@@ -32,7 +32,7 @@ The most common set of credentials is a *username* and *password*, but other for
 
 In the case of usernames and passwords though, the exchange and verification of the credentials is at the basis of its security. Sending plain text usernames and passwords over the wire would not allow any application to verify the source of the credentials is actually the user --- who is supposed to be the only party to know the unique combination of username and password.
 
-To obfuscate the login credentials, authentication can be encrypted with CRAM-MD5 or DIGEST-MD5, but this requires the server to have a copy of the original, plain text password. The password in this case becomes the shared secret.
+To obfuscate the login credentials, authentication can be encrypted with SCRAM, but this requires the server to have a copy of the original, plain text password. The password in this case becomes the shared secret.
 
 Another method is to allow the plain text username and password to be transmitted over the wire, but ensure Transport Layer Security (TLS) or the more implicit Secure Socket Layer (SSL). The plain text password can now be used to compare it against a SQL database, bind to an LDAP database, attempt PAM authentication with, etc.
 

--- a/docsrc/imap/concepts/overview_and_concepts.rst
+++ b/docsrc/imap/concepts/overview_and_concepts.rst
@@ -226,7 +226,7 @@ If the ``loginuseacl`` configuration option is turned on, than any Kerberos iden
 Shared Secrets Logins
 =====================
 
-Some mechanisms require the user and the server to share a secret (generally a password) that can be used for comparison without actually passing the password in the clear across the network. For these mechanism (such as CRAM-MD5 and DIGEST-MD5), you will need to supply a source of passwords, such as the sasldb (which is described more fully in the :ref:`Cyrus SASL distribution <cyrussasl:sasl-index>`)
+The SCRAM mechanisms require the user and the server to share a secret (generally a password) that can be used for comparison without actually passing the password in the clear across the network. For these mechanisms, you will need to supply a source of passwords, such as the sasldb (which is described more fully in the :ref:`Cyrus SASL distribution <cyrussasl:sasl-index>`).
 
 Quotas
 ******


### PR DESCRIPTION
… as the former are removed from upstream Cyrus SASL.

https://github.com/cyrusimap/cyrus-sasl/commit/5436909b1d47142ba0961de31bc984bbd544bd80
https://github.com/cyrusimap/cyrus-sasl/commit/2ce03b618ad60338e8f9094f5b7ba7ee0aef40bf

In fact I am not sure if this substitution is correct - if SCRAM or any other current  mechanism requires storing password in clear text - and if the paragraphs are relevant.
