### PR TITLE
Remove support for NTLM

### DIFF
--- a/docsrc/imap/download/installation/manage-dav.rst
+++ b/docsrc/imap/download/installation/manage-dav.rst
@@ -85,8 +85,8 @@ authentication does not depend on a Cyrus SASL plugin.
 
 The advertisement of the other HTTP authentication schemes is controlled by the
 :ref:`SASL mech_list option <cyrussasl:options>` option. For Cyrus httpd
-the GSS-SPNEGO, NTLM, SCRAM-SHA-1, and SCRAM-SHA-256 values enable
-support for the Negotiate (Kerberos only), NTLM, SCRAM-SHA-1, and
+the GSS-SPNEGO, SCRAM-SHA-1, and SCRAM-SHA-256 values enable
+support for the Negotiate (Kerberos only), SCRAM-SHA-1, and
 SCRAM-SHA-256 authentication schemes respectively, provided that the plugins
 are installed on the server.
 

--- a/docsrc/imap/rfc-support.rst
+++ b/docsrc/imap/rfc-support.rst
@@ -959,8 +959,6 @@ draft-murchison-lmtp-ignorequota
 
     LMTP Service Extension for Ignoring Recipient Quotas
 
-[MS-NTHT]   NTLM Over HTTP Protocol Specification
-
 draft-ietf-sieve-regex
 
     Sieve Email Filtering -- Regular Expression Extension

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -458,7 +458,7 @@ static int login(struct backend *s, const char *userid,
                         serverin = base64;
                     }
 
-                    /* SASL mech (SCRAM-*, Digest, Negotiate, NTLM) */
+                    /* SASL mech (SCRAM-*, Digest, Negotiate) */
                     r = sasl_client_step(s->saslconn, serverin, serverinlen,
                                          NULL,          /* no prompts */
                                          &clientout, &clientoutlen);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -451,8 +451,6 @@ struct auth_scheme_t auth_schemes[] = {
     { AUTH_SCRAM_SHA1, "SCRAM-SHA-1", "SCRAM-SHA-1",
       AUTH_NEED_PERSIST | AUTH_SERVER_FIRST | AUTH_BASE64 |
       AUTH_REALM_PARAM | AUTH_DATA_PARAM },
-    { AUTH_NTLM, "NTLM", "NTLM",
-      AUTH_NEED_PERSIST | AUTH_BASE64 },
     { AUTH_BEARER, "Bearer", NULL,
       AUTH_SERVER_FIRST | AUTH_REALM_PARAM },
       AUTH_SCHEME_BASIC,
@@ -4302,7 +4300,7 @@ static int http_auth(const char *creds, struct transaction_t *txn)
         httpd_authstate = auth_newstate(user);
     }
     else {
-        /* SASL-based authentication (SCRAM_*, Digest, Negotiate, NTLM) */
+        /* SASL-based authentication (SCRAM_*, Digest, Negotiate) */
         const char *serverout = NULL;
         unsigned int serveroutlen = 0;
         unsigned int auth_params_len = 0;

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -182,10 +182,9 @@ struct auth_scheme_t {
 enum {
     AUTH_BASIC        = (1<<0),
     AUTH_SPNEGO       = (1<<1),
-    AUTH_NTLM         = (1<<2),
-    AUTH_BEARER       = (1<<3),
-    AUTH_SCRAM_SHA1   = (1<<4),
-    AUTH_SCRAM_SHA256 = (1<<5)
+    AUTH_BEARER       = (1<<2),
+    AUTH_SCRAM_SHA1   = (1<<3),
+    AUTH_SCRAM_SHA256 = (1<<4)
 };
 
 /* Auth scheme flags */

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -2703,7 +2703,7 @@ static void usage(char *prog, char *prot)
     else if (!strcasecmp(prot, "nntp"))
         printf("             (\"user\" for AUTHINFO USER/PASS\n");
     else if (!strcasecmp(prot, "http"))
-        printf("             (\"basic\", \"digest\", \"negotiate\", \"ntlm\")\n");
+        printf("             (\"basic\", \"digest\", \"negotiate\")\n");
     printf("  -f file  : pipe file into connection after authentication\n");
     printf("  -r realm : realm\n");
 #ifdef HAVE_SSL


### PR DESCRIPTION
As it is removed upstream from cyrus-sasl: https://github.com/cyrusimap/cyrus-sasl/commit/60f2b06ca13f8f1390a11139083104e5a52e1ab0.

Looking at the changes, should SCRAM be mentioned at `imtest/imtest.c:2706:printf("             (\"basic\", \"digest\", \"negotiate\")\n");`?