### PR TITLE
httpd/imtest: remove any mention of Digest authentication

### DIFF
--- a/docsrc/imap/rfc-support.rst
+++ b/docsrc/imap/rfc-support.rst
@@ -159,15 +159,6 @@ The following is an inventory of RFCs supported by Cyrus IMAP.
 
     Using TLS with IMAP, POP3 and ACAP
 
-:rfc:`2617`
-
-    HTTP Authentication: Basic and Digest Access Authentication,
-    updated by :rfc:`7616`, :rfc:`7617`, :rfc:`9110`.
-
-    .. NOTE::
-
-        RFC 6331 declares DIGEST-MD5 as Historic.
-
 :rfc:`2817`
 
     HTTP Upgrading to TLS Within HTTP/1.1
@@ -767,11 +758,7 @@ The following is an inventory of RFCs supported by Cyrus IMAP.
 :rfc:`7615`
 
     HTTP Authentication-Info and Proxy-Authentication-Info Response
-    Header Fields, obsoleted by :rfc:`9110`.
-
-:rfc:`7616`
-
-    HTTP Digest Access Authentication
+    Header Fields
 
 :rfc:`7617`
 

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -458,7 +458,7 @@ static int login(struct backend *s, const char *userid,
                         serverin = base64;
                     }
 
-                    /* SASL mech (SCRAM-*, Digest, Negotiate) */
+                    /* SASL mech (SCRAM-*, Negotiate) */
                     r = sasl_client_step(s->saslconn, serverin, serverinlen,
                                          NULL,          /* no prompts */
                                          &clientout, &clientoutlen);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -4300,7 +4300,7 @@ static int http_auth(const char *creds, struct transaction_t *txn)
         httpd_authstate = auth_newstate(user);
     }
     else {
-        /* SASL-based authentication (SCRAM_*, Digest, Negotiate) */
+        /* SASL-based authentication (SCRAM_*, Negotiate) */
         const char *serverout = NULL;
         unsigned int serveroutlen = 0;
         unsigned int auth_params_len = 0;

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -2703,7 +2703,7 @@ static void usage(char *prog, char *prot)
     else if (!strcasecmp(prot, "nntp"))
         printf("             (\"user\" for AUTHINFO USER/PASS\n");
     else if (!strcasecmp(prot, "http"))
-        printf("             (\"basic\", \"digest\", \"negotiate\")\n");
+        printf("             (\"basic\", \"negotiate\")\n");
     printf("  -f file  : pipe file into connection after authentication\n");
     printf("  -r realm : realm\n");
 #ifdef HAVE_SSL


### PR DESCRIPTION
The actual Digest code was removed in #4680 