### PR TITLE
imparse.h: include <stdint.h>

### DIFF
--- a/lib/imparse.h
+++ b/lib/imparse.h
@@ -43,6 +43,7 @@
 #ifndef INCLUDED_IMPARSE_H
 #define INCLUDED_IMPARSE_H
 
+#include <stdint.h>
 typedef struct {
     uint32_t low;
     uint32_t high;


### PR DESCRIPTION
Apparently the build server (CI) skips netnews.
```    
CC       netnews/readconfig.o
In file included from /git/cyrus/cyrus-imapd/netnews/readconfig.c:77:
/git/cyrus/cyrus-imapd/lib/imparse.h:47:5: error: unknown type name ‘uint32_t’
   47 |     uint32_t low;
      |     ^~~~~~~~
/git/cyrus/cyrus-imapd/lib/imparse.h:48:5: error: unknown type name ‘uint32_t’
   48 |     uint32_t high;
      |     ^~~~~~~~
make[2]: *** [Makefile:5603: netnews/readconfig.o] Error 1
make[2]: Leaving directory '/git/cyrus/cyrus-imapd/build-gcc'
make[1]: *** [Makefile:7698: all-recursive] Error 1
```