### PR TITLE
doc/ developer-testing.rst: install more things from CPAN needed by cassandane

### DIFF
--- a/docsrc/imap/developer/developer-testing.rst
+++ b/docsrc/imap/developer/developer-testing.rst
@@ -45,6 +45,7 @@ Install and configure Cassandane
 
    .. code-block:: bash
 
+        sudo cpan -i AnyEvent Config::IniFiles Data::GUID Digest::CRC File::Slurp IO::File::fcntl IO::Socket::INET6 Net::Server::PreForkSimple News::NNTPClient Plack::Loader Types::Standard Unix::Syslog XML::Generator XML::Simple
         sudo cpan -i Tie::DataUUID
         sudo cpan -i XML::Spice
         sudo cpan -i XML::Fast
@@ -58,6 +59,10 @@ Install and configure Cassandane
         sudo cpan -i Net::CalDAVTalk
         sudo cpan -i Mail::JMAPTalk
         sudo cpan -i Math::Int64
+
+   With recent perl versions ``Test::Unit::TestRunner`` cannot be installed with ``cpan``.  Download
+   the package and apply the changes from https://sources.debian.org/patches/libtest-unit-perl/0.25-7/
+   before installing it.
 
 3. Build Cassandane's binary components
 


### PR DESCRIPTION
Otherwise `make -Ccassandane` fails:
```
…
./sprinkle.pl syntax OK
Can't locate Config/IniFiles.pm in @INC (you may need to install the Config::IniFiles module) (@INC entries checked: . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at Cassandane/Cassini.pm line 46.
BEGIN failed--compilation aborted at Cassandane/Cassini.pm line 46.
Compilation failed in require at Cassandane/Config.pm line 45.
BEGIN failed--compilation aborted at Cassandane/Config.pm line 45.
Compilation failed in require at ./start-instance.pl line 48.
BEGIN failed--compilation aborted at ./start-instance.pl line 48.
make: *** [Makefile:74: start-instance.pl_syntax] Error 2

…
./split-by-thread.pl syntax OK
./sprinkle.pl syntax OK
Can't locate AnyEvent.pm in @INC (you may need to install the AnyEvent module) (@INC entries checked: . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at Cassandane/Instance.pm line 56.
BEGIN failed--compilation aborted at Cassandane/Instance.pm line 56.
Compilation failed in require at ./start-instance.pl line 49.
BEGIN failed--compilation aborted at ./start-instance.pl line 49.
make: *** [Makefile:74: start-instance.pl_syntax] Error 2

…
./pop3showafter.pl syntax OK
./split-by-thread.pl syntax OK
./sprinkle.pl syntax OK
Can't locate Net/Server/PreForkSimple.pm in @INC (you may need to install the Net::Server::PreForkSimple module) (@INC entries checked: . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at Cassandane/Net/SMTPServer.pm line 6.
BEGIN failed--compilation aborted at Cassandane/Net/SMTPServer.pm line 6.
Compilation failed in require at Cassandane/Instance.pm line 81.
BEGIN failed--compilation aborted at Cassandane/Instance.pm line 81.
Compilation failed in require at ./start-instance.pl line 49.
BEGIN failed--compilation aborted at ./start-instance.pl line 49.
make: *** [Makefile:74: start-instance.pl_syntax] Error 2

…
./sprinkle.pl syntax OK
./start-instance.pl syntax OK
Can't locate File/Slurp.pm in @INC (you may need to install the File::Slurp module) (@INC entries checked: /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ./testrunner.pl line 44.
BEGIN failed--compilation aborted at ./testrunner.pl line 44.
make: *** [Makefile:74: testrunner.pl_syntax] Error 2

./sprinkle.pl syntax OK
./start-instance.pl syntax OK
Can't locate Plack/Loader.pm in @INC (you may need to install the Plack::Loader module) (@INC entries checked: . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at Cassandane/Util/TestUrl.pm line 3.

./utils/guid2cid.pl syntax OK
./utils/tiny-test-splitter.pl syntax OK
Can't locate Unix/Syslog.pm in @INC (you may need to install the Unix::Syslog module) (@INC entries checked: /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at /usr/local/lib/perl5/site_perl/5.38.2/Cyrus/Annotator/Daemon.pm line 48.
BEGIN failed--compilation aborted at /usr/local/lib/perl5/site_perl/5.38.2/Cyrus/Annotator/Daemon.pm line 48.
Compilation failed in require at /usr/local/lib/perl5/5.38.2/base.pm line 137.
        ...propagated at /usr/local/lib/perl5/5.38.2/base.pm line 159.


./Cassandane/Cyrus/CaldavAlarm.pm syntax OK
Can't locate XML/Simple.pm in @INC (you may need to install the XML::Simple module) (@INC entries checked: /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ./Cassandane/Cyrus/Carddav.pm line 50.
BEGIN failed--compilation aborted at ./Cassandane/Cyrus/Carddav.pm line 50.

./Cassandane/Cyrus/CtlMboxlist.pm syntax OK
Can't locate IO/File/fcntl.pm in @INC (you may need to install the IO::File::fcntl module) (@INC entries checked: ../perl/imap . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ../perl/imap/Cyrus/HeaderFile.pm line 11.
BEGIN failed--compilation aborted at ../perl/imap/Cyrus/HeaderFile.pm line 11.
Compilation failed in require at ./Cassandane/Cyrus/CyrusDB.pm line 54.

./Cassandane/Cyrus/JMAPBackup.pm syntax OK
Can't locate Data/GUID.pm in @INC (you may need to install the Data::GUID module) (@INC entries checked: /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ./Cassandane/Cyrus/JMAPCalendars.pm line 50.
BEGIN failed--compilation aborted at ./Cassandane/Cyrus/JMAPCalendars.pm line 50.

./Cassandane/Cyrus/MurderJMAP.pm syntax OK
Can't locate News/NNTPClient.pm in @INC (you may need to install the News::NNTPClient module) (@INC entries checked: /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ./Cassandane/Cyrus/Nntp.pm line 44.
BEGIN failed--compilation aborted at ./Cassandane/Cyrus/Nntp.pm line 44.

./Cassandane/Cyrus/Specialuse.pm syntax OK
Can't locate Digest/CRC.pm in @INC (you may need to install the Digest::CRC module) (@INC entries checked: ../perl/imap . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ../perl/imap/Cyrus/SyncProto.pm line 50.
BEGIN failed--compilation aborted at ../perl/imap/Cyrus/SyncProto.pm line 50.
Compilation failed in require at ./Cassandane/Cyrus/SyncProto.pm line 49.

./Cassandane/Cyrus/Specialuse.pm syntax OK
Can't locate Types/Standard.pm in @INC (you may need to install the Types::Standard module) (@INC entries checked: ../perl/imap . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ../perl/imap/Cyrus/Mbname.pm line 7.
BEGIN failed--compilation aborted at ../perl/imap/Cyrus/Mbname.pm line 7.
Compilation failed in require at ../perl/imap/Cyrus/AccountSync.pm line 48.

./Cassandane/Unit/RunnerPretty.pm syntax OK
Can't locate XML/Generator.pm in @INC (you may need to install the XML::Generator module) (@INC entries checked: /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at ./Cassandane/Unit/RunnerXML.pm line 42.
BEGIN failed--compilation aborted at ./Cassandane/Unit/RunnerXML.pm line 42.


make[1]: Leaving directory '/git/cyrus/cyrus-imapd/cassandane/utils'
Can't locate IO/Socket/INET6.pm in @INC (you may need to install the IO::Socket::INET6 module) (@INC entries checked: . /usr/local/lib/perl5/site_perl/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/site_perl/5.38.2 /usr/local/lib/perl5/5.38.2/x86_64-linux-thread-multi-ld /usr/local/lib/perl5/5.38.2) at Cassandane/Util/Socket.pm line 45.
BEGIN failed--compilation aborted at Cassandane/Util/Socket.pm line 45.
```