### PR TITLE
jmap_contact: encode vCard v4.0 blobs as data: URI

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPContacts.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPContacts.pm
@@ -49,10 +49,12 @@ use Data::Dumper;
 use Storable 'dclone';
 use File::Basename;
 use File::Copy;
+use Cwd qw(abs_path getcwd);
 
 use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
+use Cassandane::Util::Slurp;
 
 use charnames ':full';
 

--- a/cassandane/tiny-tests/JMAPContacts/contact_set_avatar_v4
+++ b/cassandane/tiny-tests/JMAPContacts/contact_set_avatar_v4
@@ -1,0 +1,67 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_contact_set_avatar_v4
+    :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $carddav = $self->{carddav};
+
+    xlog $self, "Create a v4 vCard over CardDAV";
+    my $id = '816ad14a-f9ef-43a8-9039-b57bf321de1f';
+    my $href = "Default/$id.vcf";
+    my $card = <<EOF;
+BEGIN:VCARD
+VERSION:4.0
+PRODID:+//IDN bitfire.at//DAVx5/4.2.0.3-gplay ez-vcard/0.11.3
+UID:$id
+FN:Foo
+N:;Foo;;;
+REV:20220504T040120Z
+END:VCARD
+EOF
+    $card =~ s/\r?\n/\r\n/gs;
+
+    $carddav->Request('PUT', $href, $card, 'Content-Type' => 'text/vcard');
+
+    xlog $self, "Get JMAP Contact";
+    my $res = $jmap->CallMethods([
+        ['Contact/get', {
+            properties => ['avatar', 'x-hasPhoto'],
+        }, 'R1']
+    ]);
+    my $contactId = $res->[0][1]{list}[0]{id};
+    $self->assert_not_null($contactId);
+    $self->assert_null($res->[0][1]{list}[0]{avatar});
+
+    xlog $self, "Set avatar on contact";
+    my $binary = slurp_file(abs_path('data/logo.gif'));
+    my $data = $jmap->Upload($binary, "image/gif");
+    $res = $jmap->CallMethods([
+        ['Contact/set', {
+            update => {
+                $contactId => {
+                    avatar => {
+                        blobId => $data->{blobId},
+                        type => "image/gif",
+                    }
+                }
+            }
+        }, 'R1']
+    ]);
+    my $avatarBlobId = $res->[0][1]{updated}{$contactId}{avatar}{blobId};
+    $self->assert_not_null($avatarBlobId);
+
+    xlog $self, "Get vCard over CardDAV as version 4.0";
+    $res = $carddav->Request('GET', $href, undef,
+        "Accept" => "text/vcard; version=4.0");
+    my $vcard = Net::CardDAVTalk::VCard->new_fromstring($res->{content});
+    my $photo = $vcard->{properties}->{photo}->[0] // undef;
+    $self->assert(not $photo->{binary});
+    $self->assert_equals("data:image/gif;base64,", substr($photo->{value}, 0, 22));
+
+    xlog $self, "Assert avatar blob contents";
+    $data = $jmap->Download('cassandane', $avatarBlobId);
+    $self->assert($binary eq $data->{content});
+}

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -1548,7 +1548,7 @@ static void test_encode_mimebody(void)
         size_t wantlen = strlen(want); \
         size_t preflight_outlen = 0xffee; \
         int preflight_outlines = 0x1234; \
-        char *preflight_retval = charset_encode_mimebody(NULL, inlen, NULL, \
+        char *preflight_retval = charset_b64encode_mimebody(NULL, inlen, NULL, \
             &preflight_outlen, &preflight_outlines, wrap); \
         CU_ASSERT_PTR_NULL(preflight_retval); \
         CU_ASSERT_EQUAL(wantlen, preflight_outlen); \
@@ -1556,7 +1556,7 @@ static void test_encode_mimebody(void)
         char *retval = malloc(preflight_outlen); \
         size_t encode_outlen = 0x1234; \
         int encode_outlines = 0xffee; \
-        char *encode_retval = charset_encode_mimebody(in, inlen, \
+        char *encode_retval = charset_b64encode_mimebody(in, inlen, \
                 retval, &encode_outlen, &encode_outlines, wrap); \
         CU_ASSERT_PTR_EQUAL(retval, encode_retval); \
         CU_ASSERT_EQUAL(wantlen, encode_outlen); \

--- a/cunit/xsha1.testc
+++ b/cunit/xsha1.testc
@@ -26,13 +26,13 @@ static void _checksha(const char *text, size_t len, const char *expect)
 
     // test charset version - encoded
     size_t len64 = 0;
-    charset_encode_mimebody(NULL, len, NULL, &len64, NULL, 1 /* wrap */);
+    charset_b64encode_mimebody(NULL, len, NULL, &len64, NULL, 1 /* wrap */);
     if (len64) {
         char *encbuf = xmalloc(len64);
         size_t outlen = 0;
         memset(dest, 0, sizeof(dest));
         memset(hexstr, 0, sizeof(hexstr));
-        charset_encode_mimebody(text, len, encbuf, &len64, NULL, 1 /* wrap */);
+        charset_b64encode_mimebody(text, len, encbuf, &len64, NULL, 1 /* wrap */);
         charset_decode_sha1(dest, &outlen, encbuf, len64, ENCODING_BASE64);
         bin_to_hex(dest, SHA1_DIGEST_LENGTH, hexstr, BH_LOWER);
         CU_ASSERT_STRING_EQUAL(expect, hexstr);

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -544,10 +544,10 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
     buf_appendcstr(&msgbuf, "Content-Transfer-Encoding: base64\r\n");
     buf_appendcstr(&msgbuf, "\r\n");
 
-    charset_encode_mimebody(NULL, strlen(ical_str), NULL, &outlen,
+    charset_b64encode_mimebody(NULL, strlen(ical_str), NULL, &outlen,
                             NULL, 1 /* wrap */);
     buf_ensure(&tmpbuf, outlen);
-    charset_encode_mimebody(ical_str, strlen(ical_str),
+    charset_b64encode_mimebody(ical_str, strlen(ical_str),
                             (char *) buf_base(&tmpbuf), &outlen,
                             NULL, 1 /* wrap */);
     buf_appendmap(&msgbuf, buf_base(&tmpbuf), outlen);

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -3565,6 +3565,9 @@ static int _blob_to_card(struct jmap_req *req,
         goto done;
     }
 
+    /* (Re)write vCard property */
+    vparse_delete_entries(card, NULL, prop);
+
     base = buf_base(&ctx.blob);
     len = buf_len(&ctx.blob);
 
@@ -3572,23 +3575,38 @@ static int _blob_to_card(struct jmap_req *req,
     size_t len64 = 0;
     charset_b64encode_mimebody(NULL, len, NULL, &len64, NULL, 0 /* no wrap */);
 
-    /* Now encode the blob */
-    encbuf = xzmalloc(len64+1);
-    charset_b64encode_mimebody(base, len, encbuf, &len64, NULL, 0 /* no wrap */);
-    base = encbuf;
-
-    /* (Re)write vCard property */
-    vparse_delete_entries(card, NULL, prop);
-
-    struct vparse_entry *entry = vparse_add_entry(card, NULL, prop, base);
-
-    vparse_add_param(entry, "ENCODING", "b");
-
-    if (buf_len(&ctx.content_type)) {
-        char *subtype = xstrdupnull(strchr(buf_cstring(&ctx.content_type), '/'));
-        vparse_add_param(entry, "TYPE", ucase(subtype+1));
-        free(subtype);
+    /* Now create the property */
+    char *version = vparse_get_value(vparse_get_entry(card, NULL, "VERSION"));
+    if (!strcmpsafe("4.0", version)) {
+        // Create version 4.0 data: URI property
+        buf_setcstr(&buf, "data:");
+        if (buf_len(&ctx.content_type)) {
+            buf_append(&buf, &ctx.content_type);
+        }
+        buf_appendcstr(&buf, ";base64,");
+        encbuf = xzmalloc(buf_len(&buf) + len64 + 1);
+        memcpy(encbuf, buf_base(&buf), buf_len(&buf));
+        charset_b64encode_mimebody(
+            base, len, encbuf + buf_len(&buf), &len64, NULL, 0 /* no wrap */);
+        vparse_add_entry(card, NULL, prop, encbuf);
     }
+    else {
+        // Create version 3.0 binary property
+        encbuf = xzmalloc(len64 + 1);
+        charset_b64encode_mimebody(
+            base, len, encbuf, &len64, NULL, 0 /* no wrap */);
+
+        struct vparse_entry *entry = vparse_add_entry(card, NULL, prop, encbuf);
+        vparse_add_param(entry, "ENCODING", "b");
+
+        if (buf_len(&ctx.content_type)) {
+            char *subtype =
+                xstrdupnull(strchr(buf_cstring(&ctx.content_type), '/'));
+            vparse_add_param(entry, "TYPE", ucase(subtype + 1));
+            free(subtype);
+        }
+    }
+    xzfree(version);
 
     /* Add this blob to our list */
     property_blob_t *blob = property_blob_new(key, prop,

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -3570,11 +3570,11 @@ static int _blob_to_card(struct jmap_req *req,
 
     /* Pre-flight base64 encoder to determine length */
     size_t len64 = 0;
-    charset_encode_mimebody(NULL, len, NULL, &len64, NULL, 0 /* no wrap */);
+    charset_b64encode_mimebody(NULL, len, NULL, &len64, NULL, 0 /* no wrap */);
 
     /* Now encode the blob */
     encbuf = xzmalloc(len64+1);
-    charset_encode_mimebody(base, len, encbuf, &len64, NULL, 0 /* no wrap */);
+    charset_b64encode_mimebody(base, len, encbuf, &len64, NULL, 0 /* no wrap */);
     base = encbuf;
 
     /* (Re)write vCard property */
@@ -9926,12 +9926,12 @@ static vcardproperty *_jsresource_to_vcard(struct jmap_parser *parser, json_t *o
 
             /* Pre-flight base64 encoder to determine length */
             size_t len64 = 0;
-            charset_encode_mimebody(NULL, len, NULL,
+            charset_b64encode_mimebody(NULL, len, NULL,
                                     &len64, NULL, 0 /* no wrap */);
 
             /* Now encode the blob */
             buf_ensure(&buf, len64+1);
-            charset_encode_mimebody(base, len,
+            charset_b64encode_mimebody(base, len,
                                     (char *) buf_base(&buf) + buf_len(&buf),
                                     &len64, NULL, 0 /* no wrap */);
             buf_truncate(&buf, buf_len(&buf) + len64);

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -617,9 +617,9 @@ static int jmap_blob_get(jmap_req_t *req)
             if (want_base64) {
                 if (len) {
                     size_t len64 = 0;
-                    charset_encode_mimebody(NULL, len, NULL, &len64, NULL, 0 /* no wrap */);
+                    charset_b64encode_mimebody(NULL, len, NULL, &len64, NULL, 0 /* no wrap */);
                     char *encbuf = xzmalloc(len64+1);
-                    charset_encode_mimebody(base, len, encbuf, &len64, NULL, 0 /* no wrap */);
+                    charset_b64encode_mimebody(base, len, encbuf, &len64, NULL, 0 /* no wrap */);
                     json_object_set_new(item, "data:asBase64", json_stringn(encbuf, len64));
                     free(encbuf);
                 }
@@ -639,7 +639,7 @@ static int jmap_blob_get(jmap_req_t *req)
                 md5((unsigned char *)base, len, data);
                 size_t len64 = 24;
                 char output[24];
-                charset_encode_mimebody((char *)data, 16, output, &len64, NULL, 0 /* no wrap */);
+                charset_b64encode_mimebody((char *)data, 16, output, &len64, NULL, 0 /* no wrap */);
                 json_object_set_new(item, "digest:md5", json_stringn(output, 24));
             }
 
@@ -649,7 +649,7 @@ static int jmap_blob_get(jmap_req_t *req)
                 xsha1((unsigned char *)base, len, data);
                 size_t len64 = 28;
                 char output[28];
-                charset_encode_mimebody((char *)data, 20, output, &len64, NULL, 0 /* no wrap */);
+                charset_b64encode_mimebody((char *)data, 20, output, &len64, NULL, 0 /* no wrap */);
                 json_object_set_new(item, "digest:sha", json_stringn(output, 28));
             }
 
@@ -660,7 +660,7 @@ static int jmap_blob_get(jmap_req_t *req)
                 xsha256((unsigned char *)base, len, data);
                 size_t len64 = 44;
                 char output[44];
-                charset_encode_mimebody((char *)data, 32, output, &len64, NULL, 0 /* no wrap */);
+                charset_b64encode_mimebody((char *)data, 32, output, &len64, NULL, 0 /* no wrap */);
                 json_object_set_new(item, "digest:sha-256", json_stringn(output, 44));
             }
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -10529,11 +10529,11 @@ static void _emailpart_blob_to_mime(jmap_req_t *req,
             encoding = "BASE64";
             size_t len64 = 0;
             /* Pre-flight encoder to determine length */
-            charset_encode_mimebody(NULL, content_size, NULL, &len64, NULL, 1 /* wrap */);
+            charset_b64encode_mimebody(NULL, content_size, NULL, &len64, NULL, 1 /* wrap */);
             if (len64) {
                 /* Now encode the body */
                 encbuf = xmalloc(len64);
-                charset_encode_mimebody(content, content_size, encbuf, &len64, NULL, 1 /* wrap */);
+                charset_b64encode_mimebody(content, content_size, encbuf, &len64, NULL, 1 /* wrap */);
             }
             content = encbuf;
             content_size = len64;

--- a/imap/message.c
+++ b/imap/message.c
@@ -1955,7 +1955,7 @@ static void message_parse_content(struct msg *msg, struct body *body,
         int b64_lines, delta;
 
         /* Determine encoded size */
-        charset_encode_mimebody(NULL, body->content_size, NULL,
+        charset_b64encode_mimebody(NULL, body->content_size, NULL,
                                 &b64_size, NULL, 1 /* wrap */);
 
         delta = b64_size - body->content_size;
@@ -1968,7 +1968,7 @@ static void message_parse_content(struct msg *msg, struct body *body,
                 msg->len - s_offset);
 
         /* Encode content into buffer at current position */
-        charset_encode_mimebody(msg->base + s_offset + delta,
+        charset_b64encode_mimebody(msg->base + s_offset + delta,
                                 body->content_size,
                                 (char*) msg->base + s_offset,
                                 NULL, &b64_lines, 1 /* wrap */);

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -3782,9 +3782,9 @@ EXPORTED const char *charset_decode_mimebody(const char *msg_base, size_t len, i
 static const char base_64[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-EXPORTED char *charset_encode_mimebody(const char *msg_base, size_t len,
-                                       char *retval, size_t *outlen,
-                                       int *outlines, int wrap)
+EXPORTED char *charset_b64encode_mimebody(const char *msg_base, size_t len,
+                                          char *retval, size_t *outlen,
+                                          int *outlines, int wrap)
 {
     const unsigned char *s;
     unsigned char s0, s1, s2;

--- a/lib/charset.h
+++ b/lib/charset.h
@@ -137,9 +137,9 @@ extern int charset_searchfile(const char *substr, comp_pat *pat,
 extern const char *charset_decode_mimebody(const char *msg_base, size_t len,
                                            int encoding, char **retval,
                                            size_t *outlen);
-extern char *charset_encode_mimebody(const char *msg_base, size_t len,
-                                     char *retval, size_t *outlen,
-                                     int *outlines, int wrap);
+extern char *charset_b64encode_mimebody(const char *msg_base, size_t len,
+                                        char *retval, size_t *outlen,
+                                        int *outlines, int wrap);
 extern char *charset_qpencode_mimebody(const char *msg_base, size_t len,
                                        int force_quote, size_t *outlen);
 extern char *charset_to_utf8cstr(const char *msg_base, size_t len, charset_t charset, int encoding);


### PR DESCRIPTION
This fixes a bug where setting an avatar with JMAP Contact/set on an existing vCard 4.0 card resulted in the vCard having a b-encoded PHOTO value. But PHOTO must have a data: URI value in vCard 4.0