### PR TITLE
JMAP Email: update Email/import logic for receivedAt property

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_import_received_at
+++ b/cassandane/tiny-tests/JMAPEmail/email_import_received_at
@@ -2,55 +2,55 @@
 use Cassandane::Tiny;
 
 sub test_email_import_received_at
-    :min_version_3_1 :needs_component_sieve :needs_component_jmap
+    :needs_component_jmap
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
     my ($maj, $min) = Cassandane::Instance->get_version();
 
     my @testCases = ({
-        creationId => 'clientSet1',
-        dateHeader => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
-        receivedHeader => undef,
+        desc => 'receivedAt set by client',
+        headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
         receivedAt => '2022-02-01T12:00:00Z',
+        wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-02-01T12:00:00Z',
     }, {
-        creationId => 'clientSet2',
-        dateHeader => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
-        receivedHeader => "Received: from foo ([192.168.0.1]) by bar (Baz); Mon, 15 Aug 2022 07:49:01 -0400\r\n",
+        desc => 'receivedAt set by client',
+        headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n" .
+                   "Received: from foo ([192.168.0.1]) by bar (Baz); Mon, 15 Aug 2022 07:49:01 -0400\r\n",
         receivedAt => '2022-02-01T12:00:00Z',
+        wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-02-01T12:00:00Z',
     }, {
+        desc => 'receivedAt from Received header',
         creationId => 'receivedAtFromReceivedHeader',
-        dateHeader => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
-        receivedHeader => "Received: from foo ([192.168.0.1]) by bar (Baz); Mon, 15 Aug 2022 07:49:01 -0400\r\n",
-        receivedAt => undef,
+        headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n" .
+                   "Received: from foo ([192.168.0.1]) by bar (Baz); Mon, 15 Aug 2022 07:49:01 -0400\r\n",
+        wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-08-15T11:49:01Z',
         skipVersionBefore => qw(3,7),
     }, {
-        creationId => 'receivedAtFromFirstReceivedHeader',
-        dateHeader => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
-        receivedHeader => "Received: from rcv1 ([192.168.0.1]) by bar (Baz); Mon, 15 Aug 2022 07:49:01 -0400\r\n" .
-                          "Received: from rcv2 ([192.168.0.2]) by tux (Qux); Mon, 13 Aug 2022 12:01:10 -0200\r\n" .
-                          "Received: from rcv3 ([192.168.0.3]) by baz (Hkl); Mon, 16 Aug 2022 13:01:10 -0200\r\n",
-        receivedAt => undef,
+        desc => 'receivedAt from first Received header',
+        headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n" .
+                   "Received: from rcv1 ([192.168.0.1]) by bar (Baz); Mon, 15 Aug 2022 07:49:01 -0400\r\n" .
+                   "Received: from rcv2 ([192.168.0.2]) by tux (Qux); Sat, 13 Aug 2022 12:01:10 -0200\r\n" .
+                   "Received: from rcv3 ([192.168.0.3]) by baz (Hkl); Tue, 16 Aug 2022 13:01:10 -0200\r\n",
+        wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-08-15T11:49:01Z',
         skipVersionBefore => qw(3,7),
     }, {
-        creationId => 'receivedAtFromDateHeader',
-        dateHeader => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
-        receivedHeader => undef,
-        receivedAt => undef,
+        desc => 'receivedAt from Date header',
+        headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
+        wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2021-12-31T14:00:00Z',
         skipVersionBefore => qw(3,7),
     }, {
-        creationId => 'serverSetNoHeader',
-        receivedHeader => undef,
-        receivedAt => undef,
+        desc => 'not set',
+        wantSentAt => undef,
         wantReceivedAt => undef,
     });
 
-    foreach my $tc (@testCases) {
+    while (my ($i, $tc) = each @testCases) {
 
         my ($needMaj, $needMin) = $tc->{skipVersionBefore} || qw(0,0);
         if ($maj < $needMaj || ($maj == $needMaj && $min < $needMin)) {
@@ -61,8 +61,7 @@ sub test_email_import_received_at
 
         xlog $self, "Running test $tc->{creationId}";
 
-        my $mime = $tc->{receivedHeader} || '';
-        $mime .= $tc->{dateHeader} || '';
+        my $mime = $tc->{headers} || '';
         $mime .= <<'EOF';
 From: sender@local
 To: receiver@local
@@ -73,17 +72,19 @@ Content-Transfer-Encoding: quoted-printable
 EOF
         $mime =~ s/\r?\n/\r\n/gs;
         $mime .= "\r\n";
-        $mime .= $tc->{creationId};
+        $mime .= $tc->{desc} || 'foo';
 
         xlog $self, "Upload blob";
         my $blobId = ($jmap->Upload($mime, 'message/rfc822'))->{blobId};
         $self->assert_not_null($blobId);
 
-        xlog $tc->{creationId}, "Import mail";
+        my $creationId = "email" . ($i + 1);
+
+        xlog $self, "Import $creationId" . (": $tc->{desc}" || '');
         my $res = $jmap->CallMethods([
             ['Email/import', {
                 emails => {
-                    $tc->{creationId} => {
+                    $creationId => {
                         blobId => $blobId,
                         mailboxIds => {
                             '$inbox' => JSON::true
@@ -94,17 +95,17 @@ EOF
             }, 'R1'],
             ['Email/get', {
                 ids => [
-                    '#' . $tc->{creationId},
+                    "#$creationId",
                 ],
                 properties => ['receivedAt', 'sentAt'],
             }, 'R2']
         ]);
 
-        $self->assert_not_null($res->[0][1]{created}{$tc->{creationId}});
+        $self->assert_not_null($res->[0][1]{created}{$creationId});
 
         xlog $self, "Assert sentAt";
-        if ($tc->{dateHeader}) {
-            $self->assert_str_equals('2022-01-01T01:00:00+11:00',
+        if ($tc->{wantSentAt}) {
+            $self->assert_str_equals($tc->{wantSentAt},
                 $res->[1][1]{list}[0]{sentAt});
         } else {
             $self->assert_null($res->[1][1]{list}[0]{sentAt});

--- a/cassandane/tiny-tests/JMAPEmail/email_import_received_at
+++ b/cassandane/tiny-tests/JMAPEmail/email_import_received_at
@@ -48,6 +48,25 @@ sub test_email_import_received_at
         desc => 'not set',
         wantSentAt => undef,
         wantReceivedAt => undef,
+    }, {
+        desc => 'receivedAt from first valid Received header',
+        headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n" .
+                   "Received: from rcv1 ([192.168.0.1]) by bar (Baz); invalid datetime\r\n" .
+                   "Received: from rcv2 ([192.168.0.2]) by tux (Qux); Sat, 13 Aug 2022 12:01:10 -0200\r\n" .
+                   "Received: from rcv3 ([192.168.0.3]) by baz (Hkl); Sat, 13 Aug 2022 12:00:45 -0200\r\n",
+        wantSentAt => '2022-01-01T01:00:00+11:00',
+        wantReceivedAt => '2022-08-13T14:01:10Z',
+        skipVersionBefore => qw(3,9),
+    }, {
+        desc => 'receivedAt from X-DeliveredInternalDate header',
+        headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n" .
+                   "Received: from rcv1 ([192.168.0.2]) by tux (Qux); Sat, 13 Aug 2022 12:01:10 -0200\r\n" .
+                   "Received: from rcv2 ([192.168.0.3]) by baz (Hkl); Sat, 13 Aug 2022 12:00:45 -0200\r\n" .
+                   "X-DeliveredInternalDate: Mon, 15 Aug 2022 13:00:45 -0200\r\n",
+                   ,
+        wantSentAt => '2022-01-01T01:00:00+11:00',
+        wantReceivedAt => '2022-08-15T15:00:45Z',
+        skipVersionBefore => qw(3,9),
     });
 
     while (my ($i, $tc) = each @testCases) {

--- a/imap/message.c
+++ b/imap/message.c
@@ -128,7 +128,6 @@ static void message_parse_params(const char *hdr, struct param **paramp);
 static void message_fold_params(struct param **paramp);
 static void message_parse_language(const char *hdr, struct param **paramp);
 static void message_parse_rfc822space(const char **s);
-static void message_parse_received_date(const char *hdr, char **hdrp);
 
 static void message_parse_multipart(struct msg *msg,
                                     struct body *body,
@@ -1987,7 +1986,7 @@ static void message_parse_content(struct msg *msg, struct body *body,
     body_add_content_guid(msg->base + s_offset, body);
 }
 
-static void message_parse_received_date(const char *hdr, char **hdrp)
+EXPORTED void message_parse_received_date(const char *hdr, char **hdrp)
 {
   char *curp, *hdrbuf = 0;
 

--- a/imap/message.h
+++ b/imap/message.h
@@ -201,6 +201,8 @@ extern void message_parse_disposition(const char *hdr, char **hdpr, struct param
 
 extern void message_parse_charset_params(const struct param *params, charset_t *c_ptr);
 
+extern void message_parse_received_date(const char *hdr, char **hdrp);
+
 /* NOTE - scribbles on its input */
 extern void message_parse_env_address(char *str, struct address *addr);
 


### PR DESCRIPTION
This updates Email/import to set the receivedAt property to:

- the Email/import receivedAt argument, if present
- the value of the X-Deliveredinternaldate header, if present
- the value of the first valid Received header
- the value of the Date header, if present
- the current time, if none of the above are present or valid