### PR TITLE
xapian_wrap: ignore punct-only terms only in unstructed search parts

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_punct_no_text
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_punct_no_text
@@ -1,0 +1,56 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_punct_no_text
+    :needs_component_sieve :needs_component_jmap :JMAPExtensions
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+
+    $imap->create("matches") or die;
+
+    # Assert that punctuation-only terms in non-text criteria
+    # match nothing. Also see email_query_utf8punct_term.
+
+    $self->{instance}->install_sieve_script(<<'EOF'
+require ["x-cyrus-jmapquery", "x-cyrus-log", "variables", "fileinto"];
+# Search: "from:\"=\""
+if allof(
+  not string :is "${stop}" "Y",
+  jmapquery text:
+  {
+     "conditions" : [
+        {
+           "from" : "\"=\""
+        }
+     ],
+     "operator" : "OR"
+  }
+.
+) {
+  fileinto "matches";
+  set "stop" "Y";
+}
+EOF
+    );
+
+    my $mime = <<'EOF';
+From: from@local
+To: to@local
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;charset=us-ascii
+Content-Transfer-Encoding: 7bit
+
+hello
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    my $msg = Cassandane::Message->new();
+    $msg->set_lines(split /\n/, $mime);
+    $self->{instance}->deliver($msg);
+
+    xlog "Assert that message did not match";
+    $self->assert_num_equals(0, $imap->message_count('matches'));
+    $self->assert_num_equals(1, $imap->message_count('INBOX'));
+}


### PR DESCRIPTION
This fixes a regression in 0c282379154a776099a83f120311a973c628eb55 Punctuation-only terms only should be ignored in unstructured search parts, such as bodies and subjects.