### PR TITLE
deprecate cyrus backups

### DIFF
--- a/changes/next/deprecate-backups
+++ b/changes/next/deprecate-backups
@@ -1,0 +1,25 @@
+Description:
+
+Deprecates the experimental Cyrus Backups feature
+
+Config changes:
+
+backuppartition-name
+backup_compact_minsize
+backup_compact_maxsize
+backup_compact_work_threshold
+backup_staging_path
+backup_retention
+backup_db
+backup_db_path
+backup_keep_previous
+
+Upgrade instructions:
+
+Deployments that rely on the experimental Cyrus Backup feature should
+start planning for an alternative backup solution, as this feature will
+be removed in the future.
+
+GitHub issue:
+
+None

--- a/docsrc/imap/reference/admin/backups.rst
+++ b/docsrc/imap/reference/admin/backups.rst
@@ -4,15 +4,18 @@
 Cyrus Backups
 =============
 
-.. contents::
+.. warning::
+    This experimental feature is no longer under active development.  It
+    is considered deprecated as of 3.10, and will be removed entirely in
+    a future version.
 
+.. contents::
 
 Introduction
 ========================
 
 Cyrus Backups are a replication-based backup service for Cyrus IMAP servers.
-This is currently an experimental feature. If you have the resources to try it
-out alongside your existing backup solutions, feedback would be appreciated.
+This is a deprecated experimental feature.
 
 This document is intended to be a guide to the configuration and
 administration of Cyrus Backups.
@@ -29,7 +32,8 @@ This document assumes a passing familiarity with
 Limitations
 ===========
 
-Cyrus Backups are experimental and incomplete.
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
 
 The following components exist and appear to work:
 
@@ -69,6 +73,9 @@ The following types of information are not currently backed up
 Architecture
 ============
 
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
+
 Cyrus Backups are designed to run on one or more standalone, dedicated backup
 servers, with suitably-sized storage partitions. These servers generally do
 not run an IMAP daemon, nor do they have conventional mailbox storage.
@@ -86,6 +93,9 @@ locations
 
 Installation
 ============
+
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
 
 Requirements
 ------------
@@ -263,6 +273,9 @@ This replicates all users to the channel *backup*.
 Administration
 ==============
 
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
+
 Storage requirements
 --------------------
 
@@ -405,6 +418,9 @@ of interesting configuration possibilities to shake out. Have a rummage in the
 
 Tools
 =====
+
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
 
 ctl\_backups
 ------------

--- a/docsrc/imap/reference/manpages/systemcommands/backupd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/backupd.rst
@@ -19,6 +19,9 @@ Synopsis
 Description
 ===========
 
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
+
 **backupd** is the Cyrus Backups server.  It accepts Cyrus replication protocol
 commands on its standard input and responds on its standard output.  It MUST be
 invoked by :cyrusman:`master(8)` with those descriptors attached to a

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_backups.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_backups.rst
@@ -25,6 +25,9 @@ Synopsis
 Description
 ===========
 
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
+
 **ctl_backups** is a tool for performing administrative operations on Cyrus
 backups.
 

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_backup.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_backup.rst
@@ -29,6 +29,9 @@ Synopsis
 Description
 ===========
 
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
+
 **cyr_backup** is a tool for inspecting the contents of a Cyrus backup.
 
 **cyr_backup** |default-conf-text|

--- a/docsrc/imap/reference/manpages/systemcommands/restore.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/restore.rst
@@ -20,6 +20,9 @@ Synopsis
 Description
 ===========
 
+.. note::
+    Cyrus Backups are experimental, incomplete, and deprecated as of 3.10.
+
 **restore** is a tool for restoring messages and mailboxes from a Cyrus backup
 to a Cyrus IMAP server.  It must be run from the server containing the backup
 storage.


### PR DESCRIPTION
Updates documentation to mark the experimental Cyrus Backups system as deprecated.

This one will need to be backported, so it only contains the documentation changes.  There will be a separate PR later to remove the feature from master.