### PR TITLE
auth_mboxgroups: a new in-cyrus group mechanism

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1512,6 +1512,7 @@ lib_libcyrus_la_SOURCES = \
 	lib/auth.c \
 	lib/auth_krb.c \
 	lib/auth_krb5.c \
+	lib/auth_mboxgroups.c \
 	lib/auth_pts.c \
 	lib/auth_unix.c \
 	lib/bitvector.c \

--- a/backup/restore.c
+++ b/backup/restore.c
@@ -602,7 +602,7 @@ static struct sync_folder_list *restore_make_reserve_folder_list(
             /* we only care about mboxname here */
             sync_folder_list_add(folder_list, NULL, iter->mboxname,
                                 0, NULL, NULL, 0, 0, 0, 0, synccrcs,
-                                0, 0, 0, 0, NULL, 0, 0, 0, 0);
+                                0, 0, 0, 0, NULL, 0, 0, 0, NULL, 0);
         }
 
         backup_mailbox_list_empty(mailboxes);
@@ -751,7 +751,7 @@ static int restore_add_mailbox(const struct backup_mailbox *mailbox,
         const struct synccrcs synccrcs = {0, 0};
         sync_folder_list_add(reserve_folder_list, NULL, clone->mboxname,
                              0, NULL, NULL, 0, 0, 0, 0, synccrcs,
-                             0, 0, 0, 0, NULL, 0, 0, 0, 0);
+                             0, 0, 0, 0, NULL, 0, 0, 0, NULL, 0);
     }
 
     /* populate mailbox list */
@@ -795,7 +795,7 @@ static int restore_add_message(const struct backup_message *message,
         const struct synccrcs synccrcs = {0, 0};
         sync_folder_list_add(reserve_folder_list, NULL, mailbox->mboxname,
                              0, NULL, NULL, 0, 0, 0, 0, synccrcs,
-                             0, 0, 0, 0, NULL, 0, 0, 0, 0);
+                             0, 0, 0, 0, NULL, 0, 0, 0, NULL, 0);
 
         /* add to mailbox list */
         my_mailbox_list_add(mailbox_list, mailbox);

--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -52,7 +52,7 @@ my $default;
 # XXX this synchronised...
 my %bitfields = (
     'calendar_component_set' => 'VEVENT VTODO VJOURNAL VFREEBUSY VAVAILABILITY VPOLL',
-    'event_extra_params' => 'bodyStructure clientAddress diskUsed flagNames messageContent messageSize messages modseq service timestamp uidnext vnd.cmu.midset vnd.cmu.unseenMessages vnd.cmu.envelope vnd.cmu.sessionId vnd.cmu.mailboxACL vnd.cmu.mbtype vnd.cmu.davFilename vnd.cmu.davUid vnd.fastmail.clientId vnd.fastmail.sessionId vnd.fastmail.convExists vnd.fastmail.convUnseen vnd.fastmail.cid vnd.fastmail.counters vnd.fastmail.jmapEmail vnd.fastmail.jmapStates vnd.cmu.emailid vnd.cmu.threadid',
+    'event_extra_params' => 'bodyStructure clientAddress diskUsed flagNames messageContent messageSize messages modseq service timestamp uidnext vnd.cmu.midset vnd.cmu.unseenMessages vnd.cmu.envelope vnd.cmu.sessionId vnd.cmu.mailboxACL vnd.cmu.mbtype vnd.cmu.davFilename vnd.cmu.davUid vnd.fastmail.clientId vnd.fastmail.sessionId vnd.fastmail.convExists vnd.fastmail.convUnseen vnd.fastmail.cid vnd.fastmail.counters vnd.fastmail.jmapEmail vnd.fastmail.jmapStates vnd.cmu.emailid vnd.cmu.threadid vnd.cmu.visibleUsers',
     'event_groups' => 'message quota flags access mailbox subscription calendar applepushservice jmap',
     'httpmodules' => 'admin caldav carddav cgi domainkey freebusy ischedule jmap prometheus rss tzdist webdav',
     'metapartition_files' => 'header index cache expunge squat annotations lock dav archivecache',

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -147,7 +147,7 @@ sub new
                  event_content_inclusion_mode => 'standard',
                  event_content_size => '1',
                  event_exclude_specialuse => '\\Junk',
-                 event_extra_params => 'modseq vnd.fastmail.clientId service uidnext vnd.fastmail.sessionId vnd.cmu.envelope vnd.fastmail.convUnseen vnd.fastmail.convExists vnd.fastmail.cid vnd.cmu.mbtype vnd.cmu.davFilename vnd.cmu.davUid vnd.cmu.mailboxACL vnd.fastmail.counters messages vnd.cmu.unseenMessages flagNames vnd.cmu.emailid vnd.cmu.threadid',
+                 event_extra_params => 'modseq vnd.fastmail.clientId service uidnext vnd.fastmail.sessionId vnd.cmu.envelope vnd.fastmail.convUnseen vnd.fastmail.convExists vnd.fastmail.cid vnd.cmu.mbtype vnd.cmu.davFilename vnd.cmu.davUid vnd.cmu.mailboxACL vnd.fastmail.counters messages vnd.cmu.unseenMessages flagNames vnd.cmu.emailid vnd.cmu.threadid vnd.cmu.visibleUsers',
                  event_groups => 'mailbox message flags calendar applepushservice',
                  event_notifier => 'pusher',
                  sync_log => 'yes',

--- a/cassandane/Cassandane/Cyrus/Mboxgroups.pm
+++ b/cassandane/Cassandane/Cyrus/Mboxgroups.pm
@@ -1,0 +1,304 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2024 Fastmail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Cyrus::Mboxgroups;
+use strict;
+use warnings;
+use Cwd qw(realpath);
+use JSON;
+use Data::Dumper;
+
+use lib '.';
+use base qw(Cassandane::Cyrus::TestCase);
+use base qw(Cassandane::Unit::TestCase);
+use Cassandane::Util::Log;
+
+sub new
+{
+    my ($class, @args) = @_;
+
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(
+        auth_mech => 'mboxgroups',
+    );
+
+    my $self = $class->SUPER::new({
+        config => $config,
+        adminstore => 1,
+        services => [qw( imap )],
+        start_instances => 0,
+    }, @args);
+
+    return $self;
+}
+
+sub set_up
+{
+    my ($self) = @_;
+
+    $self->SUPER::set_up();
+
+    $self->_start_instances();
+
+    $self->{instance}->create_user("otheruser");
+
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $admintalk->_imap_cmd('SETUSERGROUP', 0, '', 'cassandane', 'group:group c');
+    $admintalk->_imap_cmd('SETUSERGROUP', 0, '', 'cassandane', 'group:group co');
+    $admintalk->_imap_cmd('SETUSERGROUP', 0, '', 'otheruser', 'group:group co');
+    $admintalk->_imap_cmd('SETUSERGROUP', 0, '', 'otheruser', 'group:group o');
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+
+    # clean this up as soon as we're done with it, cause it's holding a
+    # port open!
+    delete $self->{server};
+
+    $self->SUPER::tear_down();
+}
+
+sub test_setacl_groupid
+    :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $admintalk->create("user.cassandane.groupid");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    $admintalk->setacl("user.cassandane.groupid",
+                       "group:foo",
+                       "lrswipkxtecdan");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+}
+
+sub test_setacl_groupid_spaces
+    :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $admintalk->create("user.cassandane.groupid_spaces");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    $admintalk->setacl("user.cassandane.groupid_spaces",
+                       "group:this group name has spaces",
+                       "lrswipkxtecdan");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    my $data = $admintalk->getacl("user.cassandane.groupid_spaces");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    $self->assert(scalar @{$data} % 2 == 0);
+    my %acl = @{$data};
+    $self->assert_str_equals($acl{"group:this group name has spaces"},
+                             "lrswipkxtecdan");
+
+    $admintalk->select("user.cassandane.groupid_spaces");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+}
+
+sub test_list_groupaccess_noracl
+    :min_version_3_7 :NoAltNamespace
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{adminstore}->get_client();
+    my $imaptalk = $self->{store}->get_client();
+
+    $admintalk->create("user.otheruser.groupaccess");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    $admintalk->setacl("user.otheruser.groupaccess",
+                       "group:group co", "lrswipkxtecdan");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    my $list = $imaptalk->list("", "*");
+    my @boxes = sort map { $_->[2] } @{$list};
+
+    $self->assert_deep_equals(\@boxes,
+                              ['INBOX', 'user.otheruser.groupaccess']);
+}
+
+sub test_list_groupaccess_racl
+    :ReverseACLs :min_version_3_7 :NoAltNamespace
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{adminstore}->get_client();
+    my $imaptalk = $self->{store}->get_client();
+
+    $admintalk->create("user.otheruser.groupaccess");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    $admintalk->setacl("user.otheruser.groupaccess",
+                       "group:group co", "lrswipkxtecdn");
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    if (get_verbose()) {
+        $self->{instance}->run_command(
+            { cyrus => 1, },
+            'cyr_dbtool',
+            "$self->{instance}->{basedir}/conf/mailboxes.db",
+            'twoskip',
+            'show'
+        );
+    }
+
+    my $list = $imaptalk->list("", "*");
+    my @boxes = sort map { $_->[2] } @{$list};
+
+    $self->assert_deep_equals(\@boxes,
+                              ['INBOX', 'user.otheruser.groupaccess']);
+}
+
+sub do_test_list_order
+    :min_version_3_7
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{adminstore}->get_client();
+    my $imaptalk = $self->{store}->get_client();
+
+    $imaptalk->create("INBOX.zzz");
+    $self->assert_str_equals('ok',
+        $imaptalk->get_last_completion_response());
+
+    $imaptalk->create("INBOX.aaa");
+    $self->assert_str_equals('ok',
+        $imaptalk->get_last_completion_response());
+
+    my %adminfolders = (
+        'user.otheruser.order-user' => 'cassandane',
+        'user.otheruser.order-co' => 'group:group co',
+        'user.otheruser.order-c' => 'group:group c',
+        'user.otheruser.order-o' => 'group:group o',
+        'shared.order-co' => 'group:group co',
+        'shared.order-c' => 'group:group c',
+        'shared.order-o' => 'group:group o',
+    );
+
+    while (my ($folder, $identifier) = each %adminfolders) {
+        $admintalk->create($folder);
+        $self->assert_str_equals('ok',
+            $admintalk->get_last_completion_response(),
+            "created folder $folder successfully");
+
+        $admintalk->setacl($folder, $identifier, "lrswipkxtecdn");
+        $self->assert_str_equals('ok',
+            $admintalk->get_last_completion_response(),
+            "setacl folder $folder for $identifier successfully");
+
+        if ($folder =~ m/^shared/) {
+            # subvert default permissions on shared namespace for
+            # purpose of testing ordering
+            $admintalk->setacl($folder, "anyone", "p");
+            $self->assert_str_equals('ok',
+                $admintalk->get_last_completion_response(),
+                "setacl folder $folder for anyone successfully");
+        }
+    }
+
+    if (get_verbose()) {
+        $self->{instance}->run_command(
+            { cyrus => 1, },
+            'cyr_dbtool',
+            "$self->{instance}->{basedir}/conf/mailboxes.db",
+            'twoskip',
+            'show'
+        );
+    }
+
+    my $list = $imaptalk->list("", "*");
+    my @boxes = map { $_->[2] } @{$list};
+
+    # Note: order is
+    # * mine, alphabetically,
+    # * other users', alphabetically,
+    # * shared, alphabetically
+    # ... which is not the order we created them ;)
+    # Also, the "order-o" folders are not returned, because cassandane
+    # is not a member of that group
+    my @expect = qw(
+        INBOX
+        INBOX.aaa
+        INBOX.zzz
+        user.otheruser.order-c
+        user.otheruser.order-co
+        user.otheruser.order-user
+    );
+    my ($maj, $min) = Cassandane::Instance->get_version();
+    if ($maj > 3 || ($maj == 3 && $min > 4)) {
+        push @expect, qw(shared);
+    }
+    push @expect, qw( shared.order-c shared.order-co );
+    $self->assert_deep_equals(\@boxes, \@expect);
+}
+
+sub test_list_order_noracl
+    :min_version_3_7 :NoAltNamespace
+{
+    my $self = shift;
+    return $self->do_test_list_order(@_);
+}
+
+sub test_list_order_racl
+    :ReverseACLs :min_version_3_7 :NoAltNamespace
+{
+    my $self = shift;
+    return $self->do_test_list_order(@_);
+}
+
+1;

--- a/cassandane/Cassandane/Cyrus/Mboxgroups.pm
+++ b/cassandane/Cassandane/Cyrus/Mboxgroups.pm
@@ -98,7 +98,6 @@ sub tear_down
 }
 
 sub test_setacl_groupid
-    :min_version_3_7
 {
     my ($self) = @_;
 
@@ -116,7 +115,6 @@ sub test_setacl_groupid
 }
 
 sub test_setacl_groupid_spaces
-    :min_version_3_7
 {
     my ($self) = @_;
 
@@ -147,7 +145,7 @@ sub test_setacl_groupid_spaces
 }
 
 sub test_list_groupaccess_noracl
-    :min_version_3_7 :NoAltNamespace
+    :NoAltNamespace
 {
     my ($self) = @_;
 
@@ -171,7 +169,7 @@ sub test_list_groupaccess_noracl
 }
 
 sub test_list_groupaccess_racl
-    :ReverseACLs :min_version_3_7 :NoAltNamespace
+    :ReverseACLs :NoAltNamespace
 {
     my ($self) = @_;
 
@@ -205,7 +203,6 @@ sub test_list_groupaccess_racl
 }
 
 sub do_test_list_order
-    :min_version_3_7
 {
     my ($self) = @_;
 
@@ -288,14 +285,14 @@ sub do_test_list_order
 }
 
 sub test_list_order_noracl
-    :min_version_3_7 :NoAltNamespace
+    :NoAltNamespace
 {
     my $self = shift;
     return $self->do_test_list_order(@_);
 }
 
 sub test_list_order_racl
-    :ReverseACLs :min_version_3_7 :NoAltNamespace
+    :ReverseACLs :NoAltNamespace
 {
     my $self = shift;
     return $self->do_test_list_order(@_);

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -475,6 +475,10 @@ magic(SlowIO => sub {
     my $self = shift;
     $self->config_set('debug_slowio' => 'yes');
 });
+magic(Mboxgroups => sub {
+    my $self = shift;
+    $self->config_set('auth_mech' => 'mboxgroups');
+});
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -344,7 +344,7 @@ magic(FastMailEvent => sub {
         event_content_inclusion_mode => 'standard',
         event_content_size => 1,  # just the first byte
         event_exclude_specialuse => '\\Junk',
-        event_extra_params => 'modseq vnd.fastmail.clientId service uidnext vnd.fastmail.sessionId vnd.cmu.envelope vnd.fastmail.convUnseen vnd.fastmail.convExists vnd.fastmail.cid vnd.cmu.mbtype vnd.cmu.davFilename vnd.cmu.davUid vnd.cmu.mailboxACL vnd.fastmail.counters messages vnd.cmu.unseenMessages flagNames',
+        event_extra_params => 'modseq vnd.fastmail.clientId service uidnext vnd.fastmail.sessionId vnd.cmu.envelope vnd.fastmail.convUnseen vnd.fastmail.convExists vnd.fastmail.cid vnd.cmu.mbtype vnd.cmu.davFilename vnd.cmu.davUid vnd.cmu.mailboxACL vnd.fastmail.counters messages vnd.cmu.unseenMessages flagNames vnd.cmu.visibleUsers',
         event_groups => 'mailbox message flags calendar applepushservice',
     );
 });

--- a/cassandane/tiny-tests/Replication/mboxgroups
+++ b/cassandane/tiny-tests/Replication/mboxgroups
@@ -1,0 +1,116 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_mboxgroups
+    :needs_component_replication :Mboxgroups :ReverseACLs
+{
+    my ($self) = @_;
+
+    my $user = 'brandnew';
+    $self->{instance}->create_user($user);
+
+    my $mastersvc = $self->{instance}->get_service('imap');
+    my $masterstore = $mastersvc->create_store(username => $user);
+    my $mastertalk = $masterstore->get_client();
+
+    my $adminstore = $mastersvc->create_store(username => 'admin');
+    my $admintalk = $adminstore->get_client();
+
+    $admintalk->_imap_cmd('SETUSERGROUP', 0, '', 'cassandane', 'group:shared');
+    $admintalk->_imap_cmd('SETUSERGROUP', 0, '', 'brandnew', 'group:shared');
+
+    $admintalk->setacl("user.cassandane", "group:shared", "lrs");
+
+    $mastertalk->create("INBOX.Test") || die;
+    $mastertalk->create("INBOX.Test.Sub") || die;
+    $mastertalk->create("INBOX.Test Foo") || die;
+
+    my $ldata = $mastertalk->list("", "*");
+    $self->assert_deep_equals($ldata, [
+          [
+            [
+              '\\HasChildren'
+            ],
+            '.',
+            'INBOX'
+          ],
+          [
+            [
+              '\\HasChildren'
+            ],
+            '.',
+            'INBOX.Test'
+          ],
+          [
+            [
+              '\\HasNoChildren'
+            ],
+            '.',
+            'INBOX.Test.Sub'
+          ],
+          [
+            [
+              '\\HasNoChildren'
+            ],
+            '.',
+            'INBOX.Test Foo'
+          ],
+          [
+            [
+              '\\HasNoChildren'
+            ],
+            '.',
+            'Other Users.cassandane'
+          ],
+    ]);
+
+    # run replication
+    $self->run_replication(user => $user);
+    $self->run_replication(user => 'cassandane');
+    $self->check_replication($user);
+    $self->check_replication('cassandane');
+
+    # verify replica store can see folder
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replicastore = $replicasvc->create_store(username => $user);
+    my $replicatalk = $replicastore->get_client();
+
+    my $rdata = $replicatalk->list("", "*");
+    $self->assert_deep_equals($rdata, [
+          [
+            [
+              '\\HasChildren'
+            ],
+            '.',
+            'INBOX'
+          ],
+          [
+            [
+              '\\HasChildren'
+            ],
+            '.',
+            'INBOX.Test'
+          ],
+          [
+            [
+              '\\HasNoChildren'
+            ],
+            '.',
+            'INBOX.Test.Sub'
+          ],
+          [
+            [
+              '\\HasNoChildren'
+            ],
+            '.',
+            'INBOX.Test Foo'
+          ],
+          [
+            [
+              '\\HasNoChildren'
+            ],
+            '.',
+            'Other Users.cassandane'
+          ],
+    ]);
+}

--- a/cassandane/tiny-tests/Replication/shared_folder
+++ b/cassandane/tiny-tests/Replication/shared_folder
@@ -1,0 +1,51 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Test replication of messages APPENDed to the master
+#
+sub test_shared_folder
+    :Replication :SyncLog :needs_component_replication :NoAltNamespace
+{
+    my ($self) = @_;
+
+    my $master_store = $self->{master_store};
+    my $replica_store = $self->{replica_store};
+
+    my $mastersvc = $self->{instance}->get_service('imap');
+    my $adminstore = $mastersvc->create_store(username => 'admin');
+    my $admintalk = $adminstore->get_client();
+
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+
+    xlog $self, "creating shared folder";
+
+    $admintalk->create('shared.folder');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $admintalk->setacl('shared.folder', 'cassandane' => 'lrswipkxtecdn');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+
+    $master_store->set_folder('shared.folder');
+    $replica_store->set_folder('shared.folder');
+
+    xlog $self, "generating messages A..D";
+    my %exp;
+    $exp{A} = $self->make_message("Message A", store => $master_store);
+    $exp{B} = $self->make_message("Message B", store => $master_store);
+    $exp{C} = $self->make_message("Message C", store => $master_store);
+    $exp{D} = $self->make_message("Message D", store => $master_store);
+
+    xlog $self, "Before replication, the master should have all four messages";
+    $self->check_messages(\%exp, store => $master_store);
+    xlog $self, "Before replication, the replica should have no messages";
+    $self->check_messages({}, store => $replica_store);
+
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+
+    xlog $self, "After replication, the master should still have all four messages";
+    $self->check_messages(\%exp, store => $master_store);
+    xlog $self, "After replication, the replica should now have all four messages";
+    $self->check_messages(\%exp, store => $replica_store);
+}

--- a/changes/next/mboxgroups
+++ b/changes/next/mboxgroups
@@ -1,0 +1,22 @@
+Description:
+
+A new authentication backend which is like auth_unix but stores groups in
+the mailboxes.db
+
+
+Config changes:
+
+adds 'mboxgroups' as a possible value for the auth_mech config option
+
+
+Upgrade instructions:
+
+No changed needed - but you can use the mboxgroups backend if you want.
+
+The new capability 'XUSERGROUPS' will appear in imapd, and admins will
+get the new commands GETUSERGROUP, SETUSERGROUP, and UNSETUSERGROUP.
+
+
+GitHub issue:
+
+If theres a github issue number for this, put it here.

--- a/changes/next/mboxgroups
+++ b/changes/next/mboxgroups
@@ -7,6 +7,7 @@ the mailboxes.db
 Config changes:
 
 adds 'mboxgroups' as a possible value for the auth_mech config option
+adds 'vnd.cmu.visibleUsers' to event_extra_params
 
 
 Upgrade instructions:

--- a/imap/global.c
+++ b/imap/global.c
@@ -435,6 +435,8 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
     ical_support_init();
 #endif
 
+    register_mboxgroups_cb(mboxlist_lookup_usergroups);
+
     return 0;
 }
 

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2204,7 +2204,9 @@ static void cmdloop(struct http_connection *conn)
         } while (!http_proxy_check_input(conn, &httpd_pipes,
                                          0 /* timeout */));
 
-        
+        /* ensure group information is up to date */
+        auth_refresh(httpd_authstate);
+
         /* Start command timer */
         cmdtime_starttimer();
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -12716,6 +12716,7 @@ static int sync_mailbox(struct xfer_header *xfer,
                          xconvmodseq,
                          raclmodseq,
                          mailbox_foldermodseq(mailbox),
+                         /* groups */ NULL,
                          /* ispartial */0);
     annots = NULL; /* list took ownership */
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1553,6 +1553,9 @@ static void cmdloop(void)
             shut_down(0);
         }
 
+        /* ensure group information is fresh */
+        auth_refresh(imapd_authstate);
+
         signals_poll();
 
         if (!prot_error(imapd_in)) {

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -597,6 +597,9 @@ extern uint32_t mailbox_mbtype(const struct mailbox *mailbox);
 extern modseq_t mailbox_foldermodseq(const struct mailbox *mailbox);
 extern uint32_t mailbox_uidvalidity(const struct mailbox *mailbox);
 
+/* caller must free - tab separated lists of userids */
+extern char *mailbox_visible_users(const struct mailbox *mailbox);
+
 struct caldav_db *mailbox_open_caldav(struct mailbox *mailbox);
 struct carddav_db *mailbox_open_carddav(struct mailbox *mailbox);
 struct webdav_db *mailbox_open_webdav(struct mailbox *mailbox);

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -134,6 +134,7 @@ static struct mboxevent event_template =
     /* 23 */ { EVENT_MBTYPE, "vnd.cmu.mbtype", EVENT_PARAM_STRING, { 0 }, 0 },
     { EVENT_SERVERFQDN, "serverFQDN", EVENT_PARAM_STRING, { 0 }, 0 },
     { EVENT_MAILBOX_ACL, "vnd.cmu.mailboxACL", EVENT_PARAM_STRING, { 0 }, 0 },
+    { EVENT_VISIBLE_USERS, "vnd.cmu.visibleUsers", EVENT_PARAM_STRING, { 0 }, 0 },
     /* 24 */ { EVENT_DAV_FILENAME, "vnd.cmu.davFilename", EVENT_PARAM_STRING, { 0 }, 0 },
     /* 25 */ { EVENT_DAV_UID, "vnd.cmu.davUid", EVENT_PARAM_STRING, { 0 }, 0 },
     /* 26 */ { EVENT_ENVELOPE, "vnd.cmu.envelope", EVENT_PARAM_STRING, { 0 }, 0 },
@@ -576,6 +577,8 @@ static int mboxevent_expected_param(enum event_type type, enum event_param param
     case EVENT_MBTYPE:
         return (type & MAILBOX_EVENTS);
     case EVENT_MAILBOX_ACL:
+        return (type & MAILBOX_EVENTS);
+    case EVENT_VISIBLE_USERS:
         return (type & MAILBOX_EVENTS);
     case EVENT_QUOTA_MESSAGES:
         return type & QUOTA_EVENTS;
@@ -1707,6 +1710,7 @@ EXPORTED void mboxevent_extract_mailbox(struct mboxevent *event,
         xstrdup(mboxlist_mbtype_to_string(mailbox_mbtype(mailbox))));
 
     FILL_STRING_PARAM(event, EVENT_MAILBOX_ACL, xstrdup(mailbox_acl(mailbox)));
+    FILL_STRING_PARAM(event, EVENT_VISIBLE_USERS, mailbox_visible_users(mailbox));
 
     /* mailbox related events also require mailboxID */
     if (event->type & MAILBOX_EVENTS) {

--- a/imap/mboxevent.h
+++ b/imap/mboxevent.h
@@ -129,6 +129,7 @@ enum event_param {
     /* 23 */ EVENT_MBTYPE,
     EVENT_SERVERFQDN,
     EVENT_MAILBOX_ACL,
+    EVENT_VISIBLE_USERS,
     /* 24 */ EVENT_DAV_FILENAME,
     /* 25 */ EVENT_DAV_UID,
     /* 26 */ EVENT_ENVELOPE,

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3167,6 +3167,7 @@ static int _usergroup_add(void *rock,
 
 EXPORTED int mboxlist_lookup_usergroups(const char *item, strarray_t *dest)
 {
+    if (!item) return 0; // if no userid, no groups can possibly match
     init_internal();
     struct buf prefix = BUF_INITIALIZER;
     buf_setcstr(&prefix, "UG");

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -290,6 +290,11 @@ int mboxlist_update_foldermodseq(const char *name, modseq_t foldermodseq);
 
 int mboxlist_set_racls(int enabled);
 
+/* user groups */
+int mboxlist_set_usergroup(const char *userid, const char *group, int val, int silent);
+int mboxlist_lookup_usergroups(const char *userid, strarray_t *dest);
+
+
 int mboxlist_cleanup_deletedentries(const mbentry_t *mbentry, time_t mark);
 
 struct findall_data {

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -1988,20 +1988,18 @@ static int sync_prepare_dlists(struct mailbox *mailbox,
                 dlist_setnum64(kl, "XCONVMODSEQ", xconvmodseq);
         }
         modseq_t raclmodseq = mboxname_readraclmodseq(mailbox_name(mailbox));
-        if (raclmodseq && (!remote || remote->raclmodseq != raclmodseq)) {
-            // only send if different
+        if (raclmodseq)
             dlist_setnum64(kl, "RACLMODSEQ", raclmodseq);
-            char *userid = mboxname_to_userid(mailbox_name(mailbox));
-            strarray_t groups = STRARRAY_INITIALIZER;
-            int r = mboxlist_lookup_usergroups(userid, &groups);
-            if (!r && strarray_size(&groups)) {
-                char *groupstxt = strarray_join(&groups, "\t");
-                dlist_setatom(kl, "USERGROUPS", groupstxt);
-                free(groupstxt);
-            }
-            strarray_fini(&groups);
-            free(userid);
+        char *userid = mboxname_to_userid(mailbox_name(mailbox));
+        strarray_t groups = STRARRAY_INITIALIZER;
+        int r = mboxlist_lookup_usergroups(userid, &groups);
+        if (!r && strarray_size(&groups)) {
+            char *groupstxt = strarray_join(&groups, "\t");
+            dlist_setatom(kl, "USERGROUPS", groupstxt);
+            free(groupstxt);
         }
+        strarray_fini(&groups);
+        free(userid);
     }
     dlist_setnum32(kl, "UIDVALIDITY", mailbox->i.uidvalidity);
     dlist_setatom(kl, "PARTITION", topart);

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -149,6 +149,7 @@ struct sync_folder {
     modseq_t xconvmodseq;
     modseq_t raclmodseq;
     modseq_t foldermodseq;
+    char *groups;
     int ispartial;
     struct quota quota;
     int   mark;
@@ -179,6 +180,7 @@ struct sync_folder *sync_folder_list_add(struct sync_folder_list *l,
                                          modseq_t xconvmodseq,
                                          modseq_t raclmodseq,
                                          modseq_t foldermodseq,
+                                         const char *groups,
                                          int ispartial);
 
 struct sync_folder *sync_folder_lookup(struct sync_folder_list *l,

--- a/lib/auth.c
+++ b/lib/auth.c
@@ -51,6 +51,7 @@
 struct auth_mech *auth_mechs[] = {
     &auth_unix,
     &auth_pts,
+    &auth_mboxgroups,
 #ifdef HAVE_KRB
     &auth_krb,
 #endif

--- a/lib/auth.c
+++ b/lib/auth.c
@@ -115,3 +115,10 @@ EXPORTED strarray_t *auth_groups(const struct auth_state *auth_state)
 
     return auth->groups(auth_state);
 }
+
+EXPORTED void auth_refresh(struct auth_state *auth_state)
+{
+    struct auth_mech *auth = auth_fromname();
+
+    if (auth->refresh) auth->refresh(auth_state);
+}

--- a/lib/auth.h
+++ b/lib/auth.h
@@ -56,6 +56,7 @@ struct auth_mech {
     struct auth_state *(*newstate)(const char *identifier);
     void (*freestate)(struct auth_state *auth_state);
     strarray_t *(*groups)(const struct auth_state *auth_state);
+    void (*refresh)(struct auth_state *auth_state);
 };
 
 extern struct auth_mech *auth_mechs[];
@@ -82,5 +83,6 @@ int auth_memberof(const struct auth_state *auth_state,
 struct auth_state *auth_newstate(const char *identifier);
 void auth_freestate(struct auth_state *auth_state);
 strarray_t *auth_groups(const struct auth_state *auth_state);
+void auth_refresh(struct auth_state *auth_state);
 
 #endif /* INCLUDED_AUTH_H */

--- a/lib/auth.h
+++ b/lib/auth.h
@@ -66,6 +66,9 @@ extern struct auth_mech auth_unix;
 extern struct auth_mech auth_pts;
 extern struct auth_mech auth_krb;
 extern struct auth_mech auth_krb5;
+extern struct auth_mech auth_mboxgroups;
+
+extern void register_mboxgroups_cb(int (*l)(const char *, strarray_t *));
 
 /* auth_canonifyid: canonify the given identifier and return a pointer
  *                  to a static buffer with the canonified ID, or NULL on

--- a/lib/auth_krb.c
+++ b/lib/auth_krb.c
@@ -429,4 +429,5 @@ HIDDEN struct auth_mech auth_krb =
     &mynewstate,
     &myfreestate,
     &mygroups,
+    NULL, /* refresh*/
 };

--- a/lib/auth_krb5.c
+++ b/lib/auth_krb5.c
@@ -251,4 +251,5 @@ HIDDEN struct auth_mech auth_krb5 =
     &mynewstate,
     &myfreestate,
     &mygroups,
+    NULL, /* refresh */
 };

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -196,7 +196,7 @@ static struct auth_state *mynewstate(const char *identifier)
     struct auth_state *newstate;
 
     identifier = mycanonifyid(identifier, 0);
-    if (!identifier) return 0;
+    if (!identifier) return NULL;
 
     newstate = (struct auth_state *)xzmalloc(sizeof(struct auth_state));
 

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -1,0 +1,236 @@
+/* auth_mboxgroups.c -- Mailboxes.db groups authentication
+ *
+ * Copyright (c) 2024 Fastmail Pty Ltd.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#include "auth.h"
+#include "libcyr_cfg.h"
+#include "xmalloc.h"
+#include "strarray.h"
+#include "util.h"
+
+static int (*our_mboxlookup)(const char *userid, strarray_t *sa);
+
+struct auth_state {
+    char userid[81];
+    strarray_t groups;
+};
+
+static struct auth_state auth_anonymous = {
+    "anonymous", STRARRAY_INITIALIZER
+};
+
+/*
+ * Determine if the user is a member of 'identifier'
+ * Returns one of:
+ *      0       User does not match identifier
+ *      1       identifier matches everybody
+ *      2       User is in the group that is identifier
+ *      3       User is identifer
+ */
+static int mymemberof(const struct auth_state *auth_state, const char *identifier)
+{
+    if (!auth_state) auth_state = &auth_anonymous;
+
+    if (strcmp(identifier, "anyone") == 0) return 1;
+
+    if (strcmp(identifier, auth_state->userid) == 0) return 3;
+
+    if (strarray_find(&auth_state->groups, identifier, 0) >= 0) return 2;
+
+    return 0;
+}
+
+/* Map of which characters are allowed by auth_canonifyid.
+ * Key: 0 -> not allowed (special, ctrl, or would confuse Unix or imapd)
+ *      1 -> allowed, but requires an alpha somewhere else in the string
+ *      2 -> allowed, and is an alpha
+ *
+ * At least one character must be an alpha.
+ *
+ * This may not be restrictive enough.
+ * Here are the reasons for the restrictions:
+ *
+ * &    forbidden because of MUTF-7.  (This could be fixed.)
+ * :    forbidden because it's special in /etc/passwd
+ * /    forbidden because it can't be used in a mailbox name
+ * * %  forbidden because they're IMAP magic in the LIST/LSUB commands
+ * ?    it just scares me
+ * ctrl chars, DEL
+ *      can't send them as IMAP characters in plain folder names, I think
+ * 80-FF forbidden because you can't send them in IMAP anyway
+ *       (and they're forbidden as folder names). (This could be fixed.)
+ *
+ * + and - are *allowed* although '+' is probably used for userid+detail
+ * subaddressing and qmail users use '-' for subaddressing.
+ *
+ * Identifiers don't require a digit, really, so that should probably be
+ * relaxed, too.
+ */
+static const char allowedchars[256] = {
+ /* 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 00-0F */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 10-1F */
+    1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, /* 20-2F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, /* 30-3F */
+
+    1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 40-4F */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, /* 50-5F */
+    1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 60-6F */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 0, /* 70-7F */
+
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/*
+ * Convert 'identifier' into canonical form.
+ * Returns a pointer to a static buffer containing the canonical form
+ * or NULL if 'identifier' is invalid.
+ *
+ * XXX If any of the characters marked with 0 are valid and are cropping up,
+ * the right thing to do is probably to canonicalize the identifier to two
+ * representations: one for getpwent calls and one for folder names.  The
+ * latter canonicalizes to a MUTF7 representation.
+ */
+static const char *mycanonifyid(const char *identifier, size_t len)
+{
+    static char retbuf[81];
+    char *p;
+    int username_tolower = 0;
+
+    if (!len) len = strlen(identifier);
+    if (len >= sizeof(retbuf)) return NULL;
+
+    memmove(retbuf, identifier, len);
+    retbuf[len] = '\0';
+
+    /* This used to be far more restrictive, but many sites seem to ignore the
+     * ye olde Unix conventions of username.  Specifically, we used to
+     * - drop case on the buffer
+     * - disallow lots of non-alpha characters ('-', '_', others)
+     * Now we do neither of these, but impose a very different policy based on
+     * the character map above.
+     */
+
+    if (!strncmp(retbuf, "group:", 6)) {
+        return retbuf;
+    }
+
+    /* Copy the string and look up values in the allowedchars array above.
+     * If we see any we don't like, reject the string.
+     * Lowercase usernames if requested.
+     */
+    username_tolower = libcyrus_config_getswitch(CYRUSOPT_USERNAME_TOLOWER);
+    for (p = retbuf; *p; p++) {
+        if (username_tolower && Uisupper(*p))
+            *p = tolower((unsigned char)*p);
+
+        switch (allowedchars[*(unsigned char*) p]) {
+        case 0:
+            return NULL;
+        default:
+            break;
+        }
+    }
+
+    return retbuf;
+}
+
+/*
+ * Set the current user to 'identifier'.  'cacheid', if non-null,
+ * points to a 16-byte binary key to cache identifier's information
+ * with.
+ */
+static struct auth_state *mynewstate(const char *identifier)
+{
+    struct auth_state *newstate;
+
+    identifier = mycanonifyid(identifier, 0);
+    if (!identifier) return 0;
+
+    newstate = (struct auth_state *)xzmalloc(sizeof(struct auth_state));
+
+    strcpy(newstate->userid, identifier);
+    strarray_init(&newstate->groups);
+
+    if (our_mboxlookup) our_mboxlookup(identifier, &newstate->groups);
+
+    return newstate;
+}
+
+static void myfreestate(struct auth_state *auth_state)
+{
+    strarray_fini(&auth_state->groups);
+    free(auth_state);
+}
+
+static strarray_t *mygroups(const struct auth_state *auth_state)
+{
+    return strarray_dup(&auth_state->groups);
+}
+
+EXPORTED void register_mboxgroups_cb(int (*l)(const char *, strarray_t *))
+{
+    our_mboxlookup = l;
+}
+
+HIDDEN struct auth_mech auth_mboxgroups =
+{
+    "mboxgroups",             /* name */
+
+    &mycanonifyid,
+    &mymemberof,
+    &mynewstate,
+    &myfreestate,
+    &mygroups,
+};

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -187,9 +187,7 @@ static const char *mycanonifyid(const char *identifier, size_t len)
 }
 
 /*
- * Set the current user to 'identifier'.  'cacheid', if non-null,
- * points to a 16-byte binary key to cache identifier's information
- * with.
+ * Set the current user to 'identifier' and loads any related groups.
  */
 static struct auth_state *mynewstate(const char *identifier)
 {
@@ -219,6 +217,7 @@ static strarray_t *mygroups(const struct auth_state *auth_state)
     return strarray_dup(&auth_state->groups);
 }
 
+/* reloads groups */
 static void myrefresh(struct auth_state *auth_state)
 {
     if (!auth_state) return;

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -219,6 +219,13 @@ static strarray_t *mygroups(const struct auth_state *auth_state)
     return strarray_dup(&auth_state->groups);
 }
 
+static void myrefresh(struct auth_state *auth_state)
+{
+    if (!auth_state) return;
+    strarray_truncate(&auth_state->groups, 0);
+    if (our_mboxlookup) our_mboxlookup(auth_state->userid, &auth_state->groups);
+}
+
 EXPORTED void register_mboxgroups_cb(int (*l)(const char *, strarray_t *))
 {
     our_mboxlookup = l;
@@ -233,4 +240,5 @@ HIDDEN struct auth_mech auth_mboxgroups =
     &mynewstate,
     &myfreestate,
     &mygroups,
+    &myrefresh,
 };

--- a/lib/auth_pts.c
+++ b/lib/auth_pts.c
@@ -550,4 +550,5 @@ HIDDEN struct auth_mech auth_pts =
     &mynewstate,
     &myfreestate,
     &mygroups,
+    NULL, /* refresh */
 };

--- a/lib/auth_unix.c
+++ b/lib/auth_unix.c
@@ -289,4 +289,5 @@ HIDDEN struct auth_mech auth_unix =
     &mynewstate,
     &myfreestate,
     &mygroups,
+    NULL, /* refresh */
 };

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -964,7 +964,7 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* Don't send event notification for folder with given special-use attributes.
    Set ALL for any folder. */
 
-{ "event_extra_params", "timestamp", BITFIELD("bodyStructure", "clientAddress", "diskUsed", "flagNames", "messageContent", "messageSize", "messages", "modseq", "service", "timestamp", "uidnext", "vnd.cmu.midset", "vnd.cmu.unseenMessages", "vnd.cmu.envelope", "vnd.cmu.sessionId", "vnd.cmu.mailboxACL", "vnd.cmu.mbtype", "vnd.cmu.davFilename", "vnd.cmu.davUid", "vnd.fastmail.clientId", "vnd.fastmail.sessionId", "vnd.fastmail.convExists", "vnd.fastmail.convUnseen", "vnd.fastmail.cid", "vnd.fastmail.counters", "vnd.fastmail.jmapEmail", "vnd.fastmail.jmapStates", "vnd.cmu.emailid", "vnd.cmu.threadid"), "3.6.0" }
+{ "event_extra_params", "timestamp", BITFIELD("bodyStructure", "clientAddress", "diskUsed", "flagNames", "messageContent", "messageSize", "messages", "modseq", "service", "timestamp", "uidnext", "vnd.cmu.midset", "vnd.cmu.unseenMessages", "vnd.cmu.envelope", "vnd.cmu.sessionId", "vnd.cmu.mailboxACL", "vnd.cmu.mbtype", "vnd.cmu.davFilename", "vnd.cmu.davUid", "vnd.fastmail.clientId", "vnd.fastmail.sessionId", "vnd.fastmail.convExists", "vnd.fastmail.convUnseen", "vnd.fastmail.cid", "vnd.fastmail.counters", "vnd.fastmail.jmapEmail", "vnd.fastmail.jmapStates", "vnd.cmu.emailid", "vnd.cmu.threadid", "vnd.cmu.visibleUsers"), "3.6.0" }
 /* Space-separated list of extra parameters to add to any appropriated event. */
 
 { "event_groups", "message mailbox", BITFIELD("message", "quota", "flags", "access", "mailbox", "subscription", "calendar", "applepushservice", "jmap" ), "3.8.0" }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -364,7 +364,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    file or mailboxes list entry?  It's noisy so disabled by default, but
    can be very useful for tracking down what happened if things look strange. */
 
-{ "auth_mech", "unix", STRINGLIST("unix", "pts", "krb", "krb5"), "2.3.17" }
+{ "auth_mech", "unix", STRINGLIST("unix", "pts", "krb", "krb5", "mboxgroups"), "2.3.17" }
 /* The authorization mechanism to use. */
 
 { "autocreateinboxfolders", NULL, STRING, "2.5.0", "2.5.0", "autocreate_inbox_folders" }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -364,7 +364,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    file or mailboxes list entry?  It's noisy so disabled by default, but
    can be very useful for tracking down what happened if things look strange. */
 
-{ "auth_mech", "unix", STRINGLIST("unix", "pts", "krb", "krb5", "mboxgroups"), "2.3.17" }
+{ "auth_mech", "unix", STRINGLIST("unix", "pts", "krb", "krb5", "mboxgroups"), "UNRELEASED" }
 /* The authorization mechanism to use. */
 
 { "autocreateinboxfolders", NULL, STRING, "2.5.0", "2.5.0", "autocreate_inbox_folders" }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -964,7 +964,7 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* Don't send event notification for folder with given special-use attributes.
    Set ALL for any folder. */
 
-{ "event_extra_params", "timestamp", BITFIELD("bodyStructure", "clientAddress", "diskUsed", "flagNames", "messageContent", "messageSize", "messages", "modseq", "service", "timestamp", "uidnext", "vnd.cmu.midset", "vnd.cmu.unseenMessages", "vnd.cmu.envelope", "vnd.cmu.sessionId", "vnd.cmu.mailboxACL", "vnd.cmu.mbtype", "vnd.cmu.davFilename", "vnd.cmu.davUid", "vnd.fastmail.clientId", "vnd.fastmail.sessionId", "vnd.fastmail.convExists", "vnd.fastmail.convUnseen", "vnd.fastmail.cid", "vnd.fastmail.counters", "vnd.fastmail.jmapEmail", "vnd.fastmail.jmapStates", "vnd.cmu.emailid", "vnd.cmu.threadid", "vnd.cmu.visibleUsers"), "3.6.0" }
+{ "event_extra_params", "timestamp", BITFIELD("bodyStructure", "clientAddress", "diskUsed", "flagNames", "messageContent", "messageSize", "messages", "modseq", "service", "timestamp", "uidnext", "vnd.cmu.midset", "vnd.cmu.unseenMessages", "vnd.cmu.envelope", "vnd.cmu.sessionId", "vnd.cmu.mailboxACL", "vnd.cmu.mbtype", "vnd.cmu.davFilename", "vnd.cmu.davUid", "vnd.fastmail.clientId", "vnd.fastmail.sessionId", "vnd.fastmail.convExists", "vnd.fastmail.convUnseen", "vnd.fastmail.cid", "vnd.fastmail.counters", "vnd.fastmail.jmapEmail", "vnd.fastmail.jmapStates", "vnd.cmu.emailid", "vnd.cmu.threadid", "vnd.cmu.visibleUsers"), "UNRELEASED" }
 /* Space-separated list of extra parameters to add to any appropriated event. */
 
 { "event_groups", "message mailbox", BITFIELD("message", "quota", "flags", "access", "mailbox", "subscription", "calendar", "applepushservice", "jmap" ), "3.8.0" }


### PR DESCRIPTION
This takes groups into Cyrus.  I want to add a JMAP-style management interface as well, but that's for v2.

It also adds additional pusher info to push a list of all users who can see the change, for handy pusher/notify extensions.