### PR TITLE
regression tests for username vs username@somedomain access controls

### DIFF
--- a/cassandane/Cassandane/Cyrus/ACL.pm
+++ b/cassandane/Cassandane/Cyrus/ACL.pm
@@ -270,6 +270,100 @@ sub test_setacl_badrights
     $self->assert_deep_equals($origacl, $newacl);
 }
 
+#Magic word virtdomains in name sets config virtdomains = userid
+sub test_virtdomains_noinherit1
+    :NoAltNamespace :CrossDomains
+{
+    my ($self) = @_;
+
+    my $defaultdomain = $self->{instance}->{config}->get('defaultdomain')
+                        // 'internal';
+    my $cass_defdom = "cassandane\@$defaultdomain";
+    my $cass_dom = 'cassandane@uhoh.org';
+
+    # get stores that authenticate as each username
+    $self->{instance}->create_user($cass_dom);
+    my $imap = $self->{instance}->get_service('imap');
+    my $defdom_store = $imap->create_store(username => $cass_defdom);
+    my $dom_store = $imap->create_store(username => $cass_dom);
+
+    # set up a target folder and some permissions
+    $self->{instance}->create_user('banana');
+    my $folder = 'user.banana';
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->setacl($folder, cassandane => 'lrswip');
+    $admintalk->setacl($folder, $cass_dom => 'lrs');
+    $admintalk->getacl($folder);
+
+    # make the stores all look at the same folder
+    $self->{store}->set_folder($folder);
+    $defdom_store->set_folder($folder);
+    $dom_store->set_folder($folder);
+
+    # 'cassandane' should be able to make a message
+    $self->make_message("message from cassandane", store => $self->{store});
+
+    # 'cassandane@{defaultdomain}' should be able to make a message
+    $self->make_message("message from $cass_defdom", store => $defdom_store);
+
+    # 'cassandane@somedomain' should NOT be able to make a message
+    eval {
+        $self->make_message("message from $cass_dom", store => $dom_store);
+    };
+    my $err = q{} . $@;
+    $self->assert_matches(qr/permission denied/i, $err);
+}
+
+#Magic word virtdomains in name sets config virtdomains = userid
+sub test_virtdomains_noinherit2
+    :NoAltNamespace :CrossDomains
+{
+    my ($self) = @_;
+
+    my $defaultdomain = $self->{instance}->{config}->get('defaultdomain')
+                        // 'internal';
+    my $cass_defdom = "cassandane\@$defaultdomain";
+    my $cass_dom = 'cassandane@uhoh.org';
+
+    # get stores that authenticate as each username
+    $self->{instance}->create_user($cass_dom);
+    my $imap = $self->{instance}->get_service('imap');
+    my $defdom_store = $imap->create_store(username => $cass_defdom);
+    my $dom_store = $imap->create_store(username => $cass_dom);
+
+    # set up a target folder and some permissions
+    $self->{instance}->create_user('banana');
+    my $folder = 'user.banana';
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->setacl($folder, cassandane => 'lrs');
+    $admintalk->setacl($folder, $cass_dom => 'lrswip');
+    $admintalk->getacl($folder);
+
+    # make the stores all look at the same folder
+    $self->{store}->set_folder($folder);
+    $defdom_store->set_folder($folder);
+    $dom_store->set_folder($folder);
+
+    # 'cassandane' should NOT be able to make a message
+    eval {
+        $self->make_message("message from cassandane",
+                            store => $self->{store});
+    };
+    my $err = q{} . $@;
+    $self->assert_matches(qr/permission denied/i, $err);
+
+    # 'cassandane@{defaultdomain}' should NOT be able to make a message
+    eval {
+        $self->make_message("message from $cass_defdom",
+                            store => $defdom_store);
+    };
+    $err = q{} . $@;
+    $self->assert_matches(qr/permission denied/i, $err);
+
+    # 'cassandane@somedomain' should be able to make a message
+    $self->make_message("message from $cass_dom", store => $dom_store);
+}
+
 # see also LDAP.pm for groupid tests
 
 1;

--- a/cassandane/Cassandane/Cyrus/Admin.pm
+++ b/cassandane/Cassandane/Cyrus/Admin.pm
@@ -93,12 +93,56 @@ sub test_imap_admins
     # reconstruct is an admin-only command
     $res = $talk->_imap_cmd("reconstruct", 0, {}, "user.cassandane");
     $self->assert_str_equals('no', $talk->get_last_completion_response());
-    $self->assert($talk->get_last_error() =~ m/permission denied/i);
+    $self->assert_matches(qr/permission denied/i, $talk->get_last_error());
 
     # we should be able to reconstruct as 'imapadmin', because this user
     # is in imap_admins
     $res = $imapadmintalk->_imap_cmd("reconstruct", 0, {}, "user.cassandane");
     $self->assert_str_equals('ok', $imapadmintalk->get_last_completion_response());
+}
+
+#Magic word virtdomains in name sets config virtdomains = userid
+sub test_imap_admins_virtdomains
+{
+    # test whether the imap_admins setting works correctly under virtdomains
+    my ($self) = @_;
+
+    my $domainadmin = 'admin@uhoh.org';
+
+    $self->{instance}->create_user($domainadmin);
+    my $imap = $self->{instance}->get_service('imap');
+    my $domainadminstore = $imap->create_store(username => $domainadmin);
+
+    my $admintalk = $self->{adminstore}->get_client();
+    my $imapadmintalk = $self->{imapadminstore}->get_client();
+    my $domainadmintalk = $domainadminstore->get_client();
+    my $talk = $self->{store}->get_client();
+
+    # we should be able to reconstruct as 'admin', because although
+    # imap_admins overrides admins, we have 'admin' in imap_admins too
+    # (it MUST be there for Cassandane itself to work)
+    my $res = $admintalk->_imap_cmd("reconstruct" , 0, {}, "user.cassandane");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # we should not be able to reconstruct as 'cassandane', because
+    # reconstruct is an admin-only command
+    $res = $talk->_imap_cmd("reconstruct", 0, {}, "user.cassandane");
+    $self->assert_str_equals('no', $talk->get_last_completion_response());
+    $self->assert_matches(qr/permission denied/i, $talk->get_last_error());
+
+    # we should be able to reconstruct as 'imapadmin', because this user
+    # is in imap_admins
+    $res = $imapadmintalk->_imap_cmd("reconstruct", 0, {}, "user.cassandane");
+    $self->assert_str_equals('ok',
+                             $imapadmintalk->get_last_completion_response());
+
+    # we MUST NOT be able to reconstruct as 'admin@uhoh.org', because
+    # this user is not in imap_admins, even though bare 'admin' is
+    $res = $domainadmintalk->_imap_cmd("reconstruct", 0, {}, "user.cassandane");
+    $self->assert_str_equals('no',
+                             $domainadmintalk->get_last_completion_response());
+    $self->assert_matches(qr/permission denied/i,
+                          $domainadmintalk->get_last_error());
 }
 
 1;


### PR DESCRIPTION
Adds some regression tests to ensure `username` and `username@somedomain` are always properly differentiated with respect to `admins:` and mailbox ACL access rights, because we don't seem to have any existing tests for this