### PR TITLE
typo:(overview_and_concepts.rst) fix typo

### DIFF
--- a/docsrc/imap/concepts/overview_and_concepts.rst
+++ b/docsrc/imap/concepts/overview_and_concepts.rst
@@ -55,7 +55,7 @@ command in :cyrusman:`cyradm(8)`:
 
 .. parsed-literal::
 
-    localhost> **listaclmamilbox tech/%**
+    localhost> **listaclmailbox tech/%**
     tech/Commits:
       group:tech lrswipkxtea
       anyone lrs
@@ -69,7 +69,7 @@ command in :cyrusman:`cyradm(8)`:
       group:tech lrswipkxtecda
       anyone lrsp
 
-    localhost> **listaclmamilbox user/bovik/%**
+    localhost> **listaclmailbox user/bovik/%**
     user/bovik/Drafts:
       bovik lrswipkxtecda
     user/bovik/Sent:


### PR DESCRIPTION
change listaclmamilbox to listaclmailbox which is the correct command in the exemple