### PR TITLE
docsrc/setup-postfix: fix for socketmap

### DIFF
--- a/docsrc/assets/setup-postfix.rst
+++ b/docsrc/assets/setup-postfix.rst
@@ -31,7 +31,7 @@ server and engineer delivery via LMTP.  The following examples show the
     or, if you have enabled smmapd you can automatically track mailboxes with::
 
         postconf -e "virtual_mailbox_domains=hash:/etc/postfix/virtual_recipient_domains"
-        postconf -e "virtual_mailbox_maps=socketmap:unix:/run/cyrus/socket/smmap"
+        postconf -e "virtual_mailbox_maps=socketmap:unix:/run/cyrus/socket/smmap:smmapd"
 
 2.  Optional: Set the concurrency and recipient limits for LMTP delivery to the
     ``virtual`` destination::

--- a/docsrc/imap/reference/manpages/systemcommands/smmapd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/smmapd.rst
@@ -24,7 +24,12 @@ Description
 a Cyrus mailbox exists, that it is postable and it is under quota.  It
 accepts commands on its standard input and responds on its standard
 output.  It MUST be invoked by :cyrusman:`master(8)` with those
-descriptors attached to a remote client connection.
+descriptors attached to a remote client connection.  The service ignores
+the userdeny database.  The received queries contain map name followed by
+mailbox, **smmapd** ignores the map name.  Queries with plus addressing return
+*OK* if the user has a mailbox with the name after plus, otherwise the result
+is *NOTFOUND*.  Match for the mailbox after plus is performed case-sensitive,
+for the address before the plus - case-insensitive.
 
 **smmapd** |default-conf-text|
 


### PR DESCRIPTION
https://www.postfix.org/socketmap_table.5.html says after socketmap:unix:PATH follow colon and a map name.  The map name is sent in the request, as described in the prelude of imap/smmapd.c, but skipped by smmapd.