### PR TITLE
jmap_mail: convert Unicode email domains to ASCII in Email/get

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_get_utf8_domain
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_utf8_domain
@@ -27,7 +27,7 @@ sub test_email_get_utf8_domain
 use utf8;
     $self->assert_deep_equals([{
         name =>  'J. Besteiro',
-        email => 'jb@julián.example.com',
+        email => 'jb@xn--julin-0qa.example.com',
     }], $res->[1][1]{list}[0]{from});
 no utf8;
 

--- a/lib/charset.h
+++ b/lib/charset.h
@@ -212,4 +212,15 @@ extern void charset_write_mime_param(struct buf *buf, int extended, size_t cur_l
  */
 extern char *unicode_casemap(const char *s, ssize_t len);
 
+/*
+ * Convert the string contained in domain using the ToASCII operation
+ * for Internationalized Domain Names (RFC 5890).
+ * Replaces the contents in 'ascii' buffer with the conversion result, or
+ * with the empty string if the domain is not a valid domain name.
+ *
+ * Returns the zero-terminated conversion result contained in 'ascii', or
+ * NULL on error.
+ */
+extern const char *charset_idna_to_ascii(struct buf *ascii, const char *domain);
+
 #endif /* INCLUDED_CHARSET_H */


### PR DESCRIPTION
26a11165390c9cb25c6c72dd08bea24d2c9d2c1d fixed the Cyrus email address parser to accept non-ASCII characters in email address domain names, as required by RFC 6532.

However, until it is clear how to present Internationalized Domain Names (RFC 5890) to JMAP clients, Cyrus will stick to only returning their ASCII representation in the EmailAddress object. JMAP clients still can obtain the Unicode representation by fetching the raw headers of the Email.