### PR TITLE
Fix invalid read for BINARY content-transfer-encoding header

### DIFF
--- a/cassandane/Cassandane/Cyrus/Simple.pm
+++ b/cassandane/Cassandane/Cyrus/Simple.pm
@@ -280,4 +280,26 @@ sub test_toggleable_debug_logging
     }
 }
 
+sub test_append_binary
+{
+    my ($self) = @_;
+    my $imap = $self->{store}->get_client();
+
+    my $mime = <<'EOF' =~ s/\n/\r\n/gr;
+To: to@local
+From: from@local
+Subject: test
+Content-Transfer-Encoding:binary
+
+test
+EOF
+
+    $imap->append("INBOX", { Binary => $mime });
+    $self->assert_str_equals('ok', $imap->get_last_completion_response());
+
+    $imap->select('INBOX');
+    my $res = $imap->fetch('1', '(BINARY[1])');
+    $self->assert_str_equals("test\r\n", $res->{1}{binary});
+}
+
 1;

--- a/imap/message.c
+++ b/imap/message.c
@@ -959,9 +959,12 @@ static int message_parse_headers(struct msg *msg, struct body *body,
                     !strcmpsafe(body->encoding, "BINARY")) {
                     char *p = (char*)
                         stristr(msg->base + body->header_offset +
-                                (next - headers.s) + 27,
+                                (next - headers.s) + 26,
                                 "binary");
-                    memcpy(p, "base64", 6);
+                    if (p)
+                        memcpy(p, "base64", 6);
+                    else
+                        xsyslog(LOG_ERR, "can not patch BINARY CTE header", NULL);
                 }
                 break;
             case RFC822_CONTENT_TYPE:

--- a/lib/stristr.c
+++ b/lib/stristr.c
@@ -27,10 +27,10 @@
  extern "C" {
 #endif
 
-EXPORTED char *stristr(const char *String, const char *Pattern)
+EXPORTED char *strinstr(const char *String, size_t StringLen, const char *Pattern)
 {
       char *pptr, *sptr, *start;
-      size_t slen = strlen(String);
+      size_t slen = StringLen;
       size_t plen = strlen(Pattern);
 
       if (!plen) return (char *)String;
@@ -68,6 +68,11 @@ EXPORTED char *stristr(const char *String, const char *Pattern)
             }
       }
       return(NULL);
+}
+
+EXPORTED char *stristr(const char *String, const char *Pattern)
+{
+      return strinstr(String, strlen(String), Pattern);
 }
 
 #if defined(__cplusplus) && __cplusplus

--- a/lib/stristr.h
+++ b/lib/stristr.h
@@ -4,6 +4,9 @@
 #ifndef INCLUDED_STRISTR_H
 #define INCLUDED_STRISTR_H
 
+#include <stddef.h>
+
 extern char *stristr(const char *haystack, const char *needle);
+extern char *strinstr(const char *haystack, size_t haystack_len, const char *needle);
 
 #endif /* INCLUDED_STRISTR_H */


### PR DESCRIPTION
This fixes an off-by-one read when monkey-patching a `Content-Transfer-Encoding` header value from `BINARY` to `BASE64`.

Once approved, this should get backported this to at least 3.10 but I'm not sure I need to open a new PR for that?