### PR TITLE
JMAP: add `repairBrokenIcal` argument to CalendarEvent/parse

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
@@ -1,0 +1,186 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_parse_repair_broken_ical
+    :needs_component_jmap
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my @testCases = ({
+        desc => 'Top-level component is VEVENT',
+        wantParsed => {
+            '@type' => 'Event',
+            title => 'test',
+            uid => '2a358cee-6489-4f14-a57f-c104db4dc357',
+        },
+        ical => <<EOF
+BEGIN:VEVENT
+DTSTART:20160928T160000Z
+DURATION:PT1H
+UID:2a358cee-6489-4f14-a57f-c104db4dc357
+SUMMARY:test
+LAST-MODIFIED:20150928T132434Z
+END:VEVENT
+EOF
+    }, {
+        desc => 'iCalendar stream with two iCalendar objects',
+        wantParsed => {
+            '@type' => 'Event',
+            title => 'test1',
+            uid => '1a968fa5-3afd-4736-8fac-21958ef3db90',
+        },
+        ical => <<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ABC Corporation//NONSGML My Product//EN
+BEGIN:VEVENT
+UID:1a968fa5-3afd-4736-8fac-21958ef3db90
+DTSTART:20160928T160000Z
+DURATION:PT1H
+SUMMARY:test1
+END:VEVENT
+END:VCALENDAR
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ABC Corporation//NONSGML My Product//EN
+BEGIN:VEVENT
+UID:b876f7a3-3e71-46e1-a350-84be804aa486
+DTSTART:20160928T160000Z
+DURATION:PT1H
+SUMMARY:test2
+END:VEVENT
+END:VCALENDAR
+EOF
+    }, {
+        desc => 'VEVENT without mandatory UID property',
+        wantParsed => {
+            '@type' => 'Event',
+            title => 'test',
+            # this need not be exactly this uid value
+            uid => 'nouid218e89b7b9041f4b3c1999a93e6dec410b17b903',
+        },
+        ical => <<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ABC Corporation//NONSGML My Product//EN
+BEGIN:VEVENT
+DTSTART:20160928T160000Z
+DURATION:PT1H
+SUMMARY:test
+LAST-MODIFIED:20150928T132434Z
+END:VEVENT
+END:VCALENDAR
+EOF
+    }, {
+        desc => 'METHOD=PUBLISH without ORGANIZER in VEVENT',
+        wantParsed => {
+            '@type' => 'Event',
+            uid => '01b1ee27-32c9-4c45-909b-c4c222666ebe',
+        },
+        # We want to make sure that 'method' is NOT returned.
+        wantAlsoProperties => ['method'],
+        ical => <<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ABC Corporation//NONSGML My Product//EN
+METHOD:PUBLISH
+BEGIN:VEVENT
+DTSTART:20160928T160000Z
+DURATION:PT1H
+SUMMARY:test
+UID:01b1ee27-32c9-4c45-909b-c4c222666ebe
+LAST-MODIFIED:20150928T132434Z
+END:VEVENT
+END:VCALENDAR
+EOF
+    }, {
+        desc => 'Multiple repairs required',
+        wantParsed => {
+            '@type' => 'Event',
+            title => 'summary1',
+            # this need not be exactly this uid value
+            uid => 'nouidacf3612eeeeb579f42176697745fdc984d24aafc',
+        },
+        # We want to make sure that 'method' is NOT returned.
+        wantAlsoProperties => ['method'],
+        ical => <<EOF
+BEGIN:VCALENDAR
+PRODID:-//Microsoft Corporation//Outlook 11.0 MIMEDIR//EN
+VERSION:2.0
+METHOD:PUBLISH
+BEGIN:VEVENT
+DTSTAMP:20231027T170000Z
+DTSTART:20240618T150000
+DTEND:20240618T161800
+SUMMARY;ENCODING=QUOTED-PRINTABLE:summary1
+LOCATION:location1
+PRIORITY:1
+URL:
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-P1D
+ACTION:DISPLAY
+DESCRIPTION:Reminder
+END:VALARM
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+BEGIN:VCALENDAR
+PRODID:-//Microsoft Corporation//Outlook 11.0 MIMEDIR//EN
+VERSION:2.0
+METHOD:PUBLISH
+BEGIN:VEVENT
+DTSTAMP:20231027T170000Z
+DTSTART:20240622T161300
+DTEND:20240622T173400
+SUMMARY;ENCODING=QUOTED-PRINTABLE:summary2
+LOCATION:location2
+PRIORITY:1
+URL:
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-P1D
+ACTION:DISPLAY
+DESCRIPTION:Reminder
+END:VALARM
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR
+EOF
+    });
+
+    for my $tc (@testCases) {
+        $tc->{ical} =~ s/\r?\n/\r\n/gs;
+
+        my @properties = keys %{$tc->{wantParsed}};
+        push(@properties, @{$tc->{wantAlsoProperties}});
+
+        xlog $self, "Running test case: $tc->{desc}";
+
+        my $res = $jmap->CallMethods([
+            ['Blob/upload', {
+                create => {
+                    ical => {
+                        data => [{
+                            'data:asText' => $tc->{ical},
+                        }],
+                    },
+                },
+            }, 'R0'],
+            ['CalendarEvent/parse', {
+                blobIds => [ "#ical" ],
+                repairBrokenIcal => JSON::true,
+                properties => \@properties,
+            }, 'R1']
+        ], [
+            'urn:ietf:params:jmap:core',
+            'urn:ietf:params:jmap:calendars',
+            'https://cyrusimap.org/ns/jmap/calendars',
+            'https://cyrusimap.org/ns/jmap/blob',
+        ]);
+        $self->assert_not_null($res->[0][1]{created}{ical});
+        $self->assert_deep_equals($tc->{wantParsed},
+            $res->[1][1]{parsed}{'#ical'});
+    }
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
@@ -67,7 +67,7 @@ EOF
 
     my $using = [
         'urn:ietf:params:jmap:core',
-        'https://cyrusimap.org/ns/jmap/calendars',
+        'urn:ietf:params:jmap:calendars',
         'https://cyrusimap.org/ns/jmap/blob',
     ];
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
@@ -96,7 +96,7 @@ EOF
     $self->assert_null($res->[1][1]{parsed}{"#ical1"}{recurrenceRule});
     $self->assert_null($res->[1][1]{parsed}{"#ical1"}{recurrenceOverrides});
 
-    $self->assert_str_equals("jsgroup", $res->[1][1]{parsed}{"#ical2"}{"\@type"});
+    $self->assert_str_equals("Group", $res->[1][1]{parsed}{"#ical2"}{"\@type"});
     $self->assert_num_equals(2, scalar @{$res->[1][1]{parsed}{"#ical2"}{entries}});
     $self->assert_str_equals($id2, $res->[1][1]{parsed}{"#ical2"}{entries}[1]{uid});
     $self->assert_str_equals("Event #2", $res->[1][1]{parsed}{"#ical2"}{entries}[1]{title});

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -11790,6 +11790,7 @@ HIDDEN json_t *jmap_calendar_events_from_msg(jmap_req_t *req,
         jmapctx->from_ical.cyrus_msg.mboxid = mboxid;
         jmapctx->from_ical.cyrus_msg.uid = uid;
         jmapctx->from_ical.cyrus_msg.partid = partid;
+        jmapctx->from_ical.repair_broken_ical = 1;
         json_t *jsevents = jmapical_tojmap_all(ical, NULL, jmapctx);
         if (json_array_size(jsevents)) {
             json_object_set_new(jsevents_by_partid, part->part_id, jsevents);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -180,7 +180,7 @@ static jmap_method_t jmap_calendar_methods_standard[] = {
     },
     {
         "CalendarEvent/parse",
-        JMAP_CALENDARS_EXTENSION,
+        JMAP_URN_CALENDARS,
         &jmap_calendarevent_parse,
         JMAP_NEED_CSTATE
     },

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -7813,21 +7813,26 @@ done:
     return 0;
 }
 
-static int _calendarevent_parseargs_parse(jmap_req_t *req __attribute__((unused)),
+struct calendareventparse_args {
+    hash_table *props;
+    int repair_broken_ical;
+};
+
+static int _calendareventparse_args_parse(jmap_req_t *req,
                                           struct jmap_parser *parser,
                                           const char *key,
                                           json_t *arg,
                                           void *rock)
 {
-    hash_table **props = (hash_table **) rock;
+    struct calendareventparse_args *parseargs = rock;
 
     if (!strcmp(key, "properties")) {
         if (json_is_array(arg)) {
             size_t i;
             json_t *val;
 
-            *props = xzmalloc(sizeof(hash_table));
-            construct_hash_table(*props, json_array_size(arg) + 1, 0);
+            parseargs->props = xzmalloc(sizeof(hash_table));
+            construct_hash_table(parseargs->props, json_array_size(arg) + 1, 0);
             json_array_foreach(arg, i, val) {
                 const char *s = json_string_value(val);
                 if (!s) {
@@ -7836,14 +7841,19 @@ static int _calendarevent_parseargs_parse(jmap_req_t *req __attribute__((unused)
                     jmap_parser_pop(parser);
                     continue;
                 }
-                hash_insert(s, (void*)1, *props);
+                hash_insert(s, (void*)1, parseargs->props);
+            }
+
+            return 1;
+        }
+    }
+    else if (jmap_is_using(req, JMAP_CALENDARS_EXTENSION)) {
+        if (!strcmp(key, "repairBrokenIcal")) {
+            if (json_is_boolean(arg)) {
+                parseargs->repair_broken_ical = json_boolean_value(arg);
+                return 1;
             }
         }
-        else if (JNOTNULL(arg)) {
-            return 0;
-        }
-
-        return 1;
     }
 
     return 0;
@@ -7853,12 +7863,12 @@ static int jmap_calendarevent_parse(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
     struct jmap_parse parse;
-    hash_table *props = NULL;
+    struct calendareventparse_args args = { 0 };
     json_t *err = NULL;
 
     /* Parse request */
     jmap_parse_parse(req, &parser,
-                     &_calendarevent_parseargs_parse, &props, &parse, &err);
+                     &_calendareventparse_args_parse, &args, &parse, &err);
     if (err) {
         jmap_error(req, err);
         goto done;
@@ -7867,6 +7877,9 @@ static int jmap_calendarevent_parse(jmap_req_t *req)
     /* Process request */
     jmap_getblob_context_t blob_ctx;
     jmap_getblob_ctx_init(&blob_ctx, NULL, NULL, "text/calendar", 1);
+
+    struct jmapical_ctx *jmapctx = jmapical_context_new(req, NULL);
+    jmapctx->from_ical.repair_broken_ical = args.repair_broken_ical;
 
     json_t *jval;
     size_t i;
@@ -7897,27 +7910,26 @@ static int jmap_calendarevent_parse(jmap_req_t *req)
 
         ical = icalparser_parse_string(buf_cstring(&blob_ctx.blob));
         if (ical) {
-            events = jmapical_tojmap_all(ical, props, NULL);
+            events = jmapical_tojmap_all(ical, args.props, jmapctx);
             icalcomponent_free(ical);
         }
 
-        if (events) {
-            if (json_array_size(events) > 1) {
-                json_object_set_new(parse.parsed, blobid,
-                                    json_pack("{ s:s s:o }",
-                                              "@type", "Group",
-                                              "entries", events));
-            }
-            else {
-                json_object_set(parse.parsed, blobid, json_array_get(events, 0));
-                json_decref(events);
-            }
-        }
-        else {
+        switch (json_array_size(events)) {
+        case 0:
             json_array_append_new(parse.not_parsable, json_string(blobid));
+            json_decref(events);
+            break;
+        case 1:
+            json_object_set(parse.parsed, blobid, json_array_get(events, 0));
+            json_decref(events);
+            break;
+        default:
+            json_object_set_new(parse.parsed, blobid,
+                json_pack("{ s:s s:o }", "@type", "Group", "entries", events));
         }
     }
 
+    jmapical_context_free(&jmapctx);
     jmap_getblob_ctx_fini(&blob_ctx);
 
     /* Build response */
@@ -7926,8 +7938,10 @@ static int jmap_calendarevent_parse(jmap_req_t *req)
 done:
     jmap_parser_fini(&parser);
     jmap_parse_fini(&parse);
-    free_hash_table(props, NULL);
-    free(props);
+    if (args.props) {
+        free_hash_table(args.props, NULL);
+        free(args.props);
+    }
     return 0;
 }
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -7903,7 +7903,7 @@ static int jmap_calendarevent_parse(jmap_req_t *req)
             if (json_array_size(events) > 1) {
                 json_object_set_new(parse.parsed, blobid,
                                     json_pack("{ s:s s:o }",
-                                              "@type", "jsgroup",
+                                              "@type", "Group",
                                               "entries", events));
             }
             else {

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -4212,13 +4212,8 @@ jmapical_tojmap_all(icalcomponent *ical, hash_table *props,
         repair_broken_ical(&myical);
     }
 
-    // Count the total number of components
-    size_t ncomps = 0;
-    for (comp = icalcomponent_get_first_component(myical, ICAL_VEVENT_COMPONENT);
-         comp;
-         comp = icalcomponent_get_next_component(myical, ICAL_VEVENT_COMPONENT)) {
-             ncomps++;
-    }
+    size_t ncomps =
+        icalcomponent_count_components(myical, ICAL_VEVENT_COMPONENT);
 
     if (ncomps < 2) {
         // Fast-path: There's at most one component in the VCALENDAR

--- a/imap/jmap_ical.h
+++ b/imap/jmap_ical.h
@@ -106,11 +106,6 @@ struct jmapical_ctx {
     jmap_req_t *req;
     struct buf buf;
     struct {
-        const char *mboxid;
-        uint32_t uid;
-        const char *partid;
-    } icalsrc;
-    struct {
         struct buf url;
         const char *baseurl;
         struct webdav_db *db;
@@ -119,21 +114,22 @@ struct jmapical_ctx {
         int err;
     } attachments;
     struct {
-        char *emailrecipient;
-    } alert;
-    struct {
         json_t *serverset;
-        int no_sanitize_timestamps;
-        int allow_method;
         json_t *replyto;
+        char *emailalert_recipient;
+        int ignore_orphan_timezones : 1;
+        int no_sanitize_timestamps : 1;
+        int allow_method : 1;
     } to_ical;
     struct {
-        int want_icalprops;
+        struct {
+            const char *mboxid;
+            uint32_t uid;
+            const char *partid;
+        } cyrus_msg;
+        int want_icalprops : 1;
+        int dont_guess_timezones : 1;
     } from_ical;
-    struct {
-        int no_guess;
-        int ignore_orphans;
-    } timezones;
     const strarray_t *schedule_addresses;
 };
 

--- a/imap/jmap_ical.h
+++ b/imap/jmap_ical.h
@@ -129,6 +129,7 @@ struct jmapical_ctx {
         } cyrus_msg;
         int want_icalprops : 1;
         int dont_guess_timezones : 1;
+        int repair_broken_ical : 1;
     } from_ical;
     const strarray_t *schedule_addresses;
 };


### PR DESCRIPTION
This updates CalendarEvent/parse to optionally parse iCalendar data even if it violates some iCalendar requirements. All these violations were seen in real iCalendar data. This patch only allows parsing such data and converting it to JSCalendar. It does not allow adding such broken iCalendar data via CalDAV or iMIP.