### PR TITLE
github actions: fetch Mail::IMAPTalk each time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
         cpanm IO::File::fcntl
         cpanm Digest::CRC
         cpanm XML::Simple # XXX could be grabbed from apt by docker image
+        cpanm Mail::IMAPTalk # in image, but fetch latest!
     - name: configure and build
       shell: bash
       run: |
@@ -38,6 +39,7 @@ jobs:
       shell: bash
       run: |
         echo "debian" $(cat /etc/debian_version)
+        echo "Mail::IMAPTalk" $(cpanm --info Mail::IMAPTalk)
         /usr/cyrus/libexec/master -V
         /usr/cyrus/sbin/cyr_buildinfo
     - name: update jmap test suite

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: install missing or frequently-updated deps
+      shell: bash
+      run: |
+        cpanm IO::File::fcntl
+        cpanm Digest::CRC
+        cpanm XML::Simple # XXX could be grabbed from apt by docker image
     - name: configure and build
       shell: bash
       run: |
@@ -42,12 +48,6 @@ jobs:
         git checkout origin/master
         git clean -f -x -d
         cpanm --installdeps .
-    - name: install missing deps
-      shell: bash
-      run: |
-        cpanm IO::File::fcntl
-        cpanm Digest::CRC
-        cpanm XML::Simple # XXX could be grabbed from apt by docker image
     - name: set up cassandane
       working-directory: cassandane
       shell: bash


### PR DESCRIPTION
This updates our CI workflow to fetch the latest copy of Mail::IMAPTalk each time it runs, instead of relying on the version embedded in the docker image.

It also reports the Mail::IMAPTalk version in the "report version information" step (which now occurs after the module has been updated)