### PR TITLE
caldav_alarm: suppress duplicate alarms

### DIFF
--- a/cassandane/tiny-tests/CaldavAlarm/suppress_duplicates
+++ b/cassandane/tiny-tests/CaldavAlarm/suppress_duplicates
@@ -1,0 +1,68 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_suppress_duplicates
+    :needs_component_calalarmd
+{
+    my ($self) = @_;
+    my $caldav = $self->{caldav};
+
+    my $now = DateTime->now();
+    $now->set_time_zone('Etc/UTC');
+
+    my $startdt = $now->clone();
+    $startdt->add(DateTime::Duration->new(seconds => 2));
+    my $start = $startdt->strftime('%Y%m%dT%H%M%SZ');
+
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:574E2CD0-2D2A-4554-8B63-C7504481D3A9
+SUMMARY:test
+DTSTART:$start
+SEQUENCE:0
+BEGIN:VALARM
+X-JMAP-ID:displayAlert1
+TRIGGER:PT0S
+ACTION:DISPLAY
+DESCRIPTION:My display alarm
+END:VALARM
+BEGIN:VALARM
+X-JMAP-ID:displayAlert2
+TRIGGER:PT0S
+ACTION:DISPLAY
+DESCRIPTION:My other display alarm
+END:VALARM
+BEGIN:VALARM
+X-JMAP-ID:emailAlert1
+TRIGGER:PT0S
+ACTION:EMAIL
+SUMMARY:My email alarm
+DESCRIPTION:My email alarm description
+ATTENDEE:mailto:emailalarm\@example.com
+END:VALARM
+BEGIN:VALARM
+X-JMAP-ID:emailAlert2
+TRIGGER:PT0S
+ACTION:EMAIL
+SUMMARY:My other email alarm
+DESCRIPTION:My other email alarm description
+ATTENDEE:mailto:other-emailalarm\@example.com
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOF
+    $caldav->Request('PUT', 'Default/test.ics', $ical,
+        'Content-Type' => 'text/calendar');
+
+    $self->{instance}->getnotify();
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch()  + 60);
+
+    $self->assert_alarms(
+        {action => 'display', alarmTime => $start, alertId => 'displayAlert1' },
+        {action => 'email', alarmTime => $start, alertId => 'emailAlert1' },
+    );
+}

--- a/changes/next/calalarmd_suppress_duplicates
+++ b/changes/next/calalarmd_suppress_duplicates
@@ -1,0 +1,13 @@
+Description:
+
+Suppress duplicate calendar alarms in calalarmd.
+
+
+Config changes:
+
+calendar_suppress_duplicate_alarms
+
+
+Upgrade instructions:
+
+This feature is enabled by default.

--- a/cunit/ical_support.testc
+++ b/cunit/ical_support.testc
@@ -145,3 +145,55 @@ static void test_icalrecurrenceset_get_utc_timespan(void)
 
     free(eternitystr);
 }
+
+static int icalcomponent_myforeach_duplicate_rrule_cb(icalcomponent *comp __attribute__((unused)),
+                                                      icaltimetype start __attribute__((unused)),
+                                                      icaltimetype end __attribute__((unused)),
+                                                      icaltimetype recurid,
+                                                      int is_standalone __attribute__((unused)),
+                                                      void *data)
+{
+    strarray_t *recurids = data;
+    strarray_append(recurids, icaltime_as_ical_string(recurid));
+    return 1;
+}
+
+static void test_icalcomponent_myforeach_duplicate_rrule(void)
+{
+    init_caldav();
+
+    struct buf buf = BUF_INITIALIZER;
+    buf_setcstr(&buf,
+            "BEGIN:VCALENDAR\r\n"
+            "VERSION:2.0\r\n"
+            "PRODID:-//Foo//Bar//EN\r\n"
+            "CALSCALE:GREGORIAN\r\n"
+            "BEGIN:VEVENT\r\n"
+            "UID:574E2CD0-2D2A-4554-8B63-C7504481D3A9\r\n"
+            "SUMMARY:test\r\n"
+            "DTSTART:20240101T010203Z\r\n"
+            "SEQUENCE:0\r\n"
+            "RRULE:FREQ=DAILY;COUNT=3\r\n"
+            "RRULE:FREQ=DAILY;COUNT=3\r\n"
+            "RRULE:FREQ=WEEKLY;COUNT=2\r\n"
+            "END:VEVENT\r\n"
+            "END:VCALENDAR");
+
+    icalcomponent *ical = ical_string_as_icalcomponent(&buf);
+    CU_ASSERT_PTR_NOT_NULL(ical);
+
+    strarray_t recurids = STRARRAY_INITIALIZER;
+    struct icalperiodtype range = ICALPERIODTYPE_INITIALIZER;
+    int r = icalcomponent_myforeach(ical, range, NULL,
+        icalcomponent_myforeach_duplicate_rrule_cb, &recurids);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(strarray_size(&recurids), 4);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&recurids, 0), "20240101T010203Z");
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&recurids, 1), "20240102T010203Z");
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&recurids, 2), "20240103T010203Z");
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&recurids, 3), "20240108T010203Z");
+
+    strarray_fini(&recurids);
+    icalcomponent_free(ical);
+    buf_free(&buf);
+}

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -665,6 +665,11 @@ Blank lines and lines beginning with ``#'' are ignored.
    The default is 5 minutes.  The minimum value is 0, which will
    allow all alarms. */
 
+{ "calendar_suppress_duplicate_alarms", 1, SWITCH, "UNRELEASED" }
+/* Suppress duplicate calendar alarms in calalarmd. If this is set,
+   then at most one alarm notification is sent for any given alarm
+   action, point in time and calendar event. */
+
 { "carddav_allowaddmember", 0, SWITCH, "3.1.3" }
 /* Enable support for POST add-member on the CardDAV server. */
 


### PR DESCRIPTION
Suppress duplicate calendar alarms in calalarmd. At most one alarm notification is sent for any given alarm action, point in time and calendar event.

Some broken calendar client implementations seem to append the exact same alarm every time they update the event, resulting in duplicate alarms being triggered.

This feature is optional and enabled by default.

This PR also includes duplicate suppression in recurrence rules. This is an internal fix only.