### PR TITLE
mailbox.c: use the correct error code for over message quota

### DIFF
--- a/cassandane/Cassandane/Cyrus/MaxMessages.pm
+++ b/cassandane/Cassandane/Cyrus/MaxMessages.pm
@@ -491,7 +491,7 @@ sub test_maxmsg_email_limited
     };
     my $e = $@;
     $self->assert_not_null($e);
-    $self->assert_matches(qr{over.*quota}, $e);
+    $self->assert_matches(qr{Over quota}, $e);
 
     # should have syslogged about it too
     $self->assert_syslog_matches($self->{instance},

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -4596,7 +4596,7 @@ EXPORTED int mailbox_append_index_record(struct mailbox *mailbox,
                 xsyslog(LOG_ERR, "IOERROR: client hit per-addressbook exists limit",
                                  "mailbox=<%s>",
                                  mailbox_name(mailbox));
-                return IMAP_NO_OVERQUOTA;
+                return IMAP_QUOTA_EXCEEDED;
             }
         }
         else if (mbtype_isa(mailbox_mbtype(mailbox)) == MBTYPE_CALENDAR) {
@@ -4605,7 +4605,7 @@ EXPORTED int mailbox_append_index_record(struct mailbox *mailbox,
                 xsyslog(LOG_ERR, "IOERROR: client hit per-calendar exists limit",
                                  "mailbox=<%s>",
                                  mailbox_name(mailbox));
-                return IMAP_NO_OVERQUOTA;
+                return IMAP_QUOTA_EXCEEDED;
             }
         }
         else if (mbtype_isa(mailbox_mbtype(mailbox)) == MBTYPE_EMAIL) {
@@ -4614,7 +4614,7 @@ EXPORTED int mailbox_append_index_record(struct mailbox *mailbox,
                 xsyslog(LOG_ERR, "IOERROR: client hit per-mailbox exists limit",
                                  "mailbox=<%s>",
                                  mailbox_name(mailbox));
-                return IMAP_NO_OVERQUOTA;
+                return IMAP_QUOTA_EXCEEDED;
             }
         }
         else {


### PR DESCRIPTION
IMAP_NO_OVERQUOTA is used for IMAPOPT_QUOTAWARNPERCENT

This will replace #4915 which will be reverted