### PR TITLE
imapd.c: remove support for XMOVE

### DIFF
--- a/changes/next/remove_imap_xmove
+++ b/changes/next/remove_imap_xmove
@@ -1,0 +1,14 @@
+
+Description:
+
+Support for the legacy IMAP XMOVE command has been removed.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -505,7 +505,6 @@ static struct capa_struct base_capabilities[] = {
     { "XCONVERSATIONS",        CAPA_POSTAUTH|CAPA_CONFIG,        /* CY */
       { .config = IMAPOPT_CONVERSATIONS }                     },
     { "XLIST",                 CAPA_POSTAUTH,           { 0 } }, /* NS */
-    { "XMOVE",                 CAPA_POSTAUTH,           { 0 } }, /* NS */
     { "XUSERGROUPS",           CAPA_POSTAUTH|CAPA_STATE,
       { .statep = &auth_is_mboxgroups }                       }, /* CY */
 
@@ -897,7 +896,7 @@ static void imapd_log_client_behavior(void)
                         "%s%s%s%s"
                         "%s%s%s%s"
                         "%s%s%s"
-                        "%s%s%s",
+                        "%s%s",
 
                         session_id(),
                         imapd_userid ? imapd_userid : "",
@@ -928,8 +927,7 @@ static void imapd_log_client_behavior(void)
                         client_behavior.did_utf8_accept ? " utf8_accept=<1>"  : "",
 
                         client_behavior.did_scan        ? " scan=<1>"         : "",
-                        client_behavior.did_xlist       ? " xlist=<1>"        : "",
-                        client_behavior.did_xmove       ? " xmove=<1>"        : "");
+                        client_behavior.did_xlist       ? " xlist=<1>"        : "");
 }
 
 static void imapd_reset(void)
@@ -2097,10 +2095,7 @@ static void cmdloop(void)
 
                 cmd_copy(tag.s, arg1.s, arg2.s, usinguid, /*ismove*/1);
 
-                if (cmdname[0] == 'x')
-                    client_behavior.did_xmove = 1;
-                else
-                    client_behavior.did_move = 1;
+                client_behavior.did_move = 1;
 
                 prometheus_increment(CYRUS_IMAP_MOVE_TOTAL);
             } else goto badcmd;
@@ -2539,10 +2534,6 @@ static void cmdloop(void)
                     if (readonly) goto noreadonly;
                     goto move;
                 }
-                else if (!strcmp(arg1.s, "xmove")) {
-                    if (readonly) goto noreadonly;
-                    goto move;
-                }
                 else if (!strcmp(arg1.s, "replace")) {
                     if (readonly) goto noreadonly;
                     goto replace;
@@ -2697,13 +2688,6 @@ static void cmdloop(void)
                 if (listargs.pat.count) cmd_list(tag.s, &listargs);
 
                 prometheus_increment(CYRUS_IMAP_LIST_TOTAL);
-            }
-            else if (!strcmp(cmd.s, "Xmove")) {
-                if (readonly) goto noreadonly;
-                if (!imapd_index && !backend_current) goto nomailbox;
-                usinguid = 0;
-                if (c != ' ') goto missingargs;
-                goto move;
             }
             else if (!strcmp(cmd.s, "Xrunannotator")) {
                 if (readonly) goto noreadonly;

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -471,7 +471,6 @@ struct client_behavior_registry {
     /* non-standard - track for possible deprecation */
     uint32_t did_scan         : 1;   /* used SCAN  */
     uint32_t did_xlist        : 1;   /* used XLIST  */
-    uint32_t did_xmove        : 1;   /* used XMOVE  */
 };
 
 #endif /* INCLUDED_IMAPD_H */


### PR DESCRIPTION
Do not merge until we are certain that no major clients still use XMOVE rather than MOVE (I think we are certain).