### PR TITLE
github actions: finesse triggers, update actions/checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: Cyrus IMAP CI
 
 on:
   push:
+    branches:
+      - master
+      - main
+      - 'cyrus-imapd-*'
   pull_request:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,7 @@ on:
     branches:
       - master
       - main
-      - cyrus-imapd-3.10
-      - cyrus-imapd-3.8
-      - cyrus-imapd-3.6
-      - cyrus-imapd-3.4
-      - cyrus-imapd-3.2
-      - cyrus-imapd-3.0
+      - 'cyrus-imapd-*'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         image: cyrusimapdocker/cyrus-buster:latest
         options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --init
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: install missing or frequently-updated deps

--- a/docsrc/imap/developer/major-releasing.rst
+++ b/docsrc/imap/developer/major-releasing.rst
@@ -150,12 +150,7 @@ series will be 3.8 (and then master will become 3.9).
    The generated documentation will be under the `doc/html/` directory --
    examine it in your browser to make sure all your formatting and such makes
    sense.
-9. Tell Github Actions about the new branch: edit `.github/workflows/main.yml`
-   and add the new branch to the list in the obvious spot.  Does anything else
-   need to be done for this step?  Unknown... figure it out and document it!
-   Also currently unknown whether this needs to happen on the master branch,
-   on the branch itself, or both.  So we do it on both just in case.
-10. XXX maybe missing some stuff here still?
+9. XXX maybe missing some stuff here still?
 
 You can double check your work by looking at what changed last time a new
 stable series was forked:
@@ -204,13 +199,8 @@ too.
    that will be reverted from the new branch after forking -- in that case,
    don't delete those changes files from master.  More on this later.
 5. Update `README.md`.
-6. Tell Github Actions about the new branch: edit `.github/workflows/main.yml`
-   and add the new branch to the list in the obvious spot.  Does anything else
-   need to be done for this step?  Unknown... figure it out and document it!
-   Also currently unknown whether this needs to happen on the master branch,
-   on the branch itself, or both.  So we do it on both just in case.
-7. XXX probably steps missing here too
-8. Make sure the RST changes are good: ``make doc-html``, pay attention
+6. XXX probably steps missing here too
+7. Make sure the RST changes are good: ``make doc-html``, pay attention
    to errors and warnings.
 
 You may think you can do this by cherry-picking your commit from the new


### PR DESCRIPTION
Few small things here:
* Upgrade to `actions/checkout@v4`, which should fix a warning about "Node.js 16" being deprecated
* Use a wildcard for specifying the release branches, so we don't need to update the list every new release
* Rationalise the `push` and `pull_request` triggers

The last point should prevent:
* double CI runs when pushing to PR branch on main repo (due to "push" and "pull_request" events both firing)
* CI runs for unpublished branches on forks with actions enabled (Fixes #4922)

But still allow:
* CI runs for PRs against official branches (drafts included)
* CI runs for pushes directly to official branches