### PR TITLE
jmap_api: reject non-array query filter conditions

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
@@ -206,6 +206,48 @@ sub test_calendarevent_query
         wantTotal => 3,
         wantIds => [$eventB1{id}],
         wantFastPath => JSON::false,
+    }, {
+        filter => {
+            operator => 'NOT',
+            conditions => [{
+                blarg => 'foo', # invalid - blarg is not a calevent property
+            }],
+        },
+        wantErr => {
+            type => 'invalidArguments',
+            arguments => [ 'filter/conditions[0]/blarg' ],
+        },
+    }, {
+        filter => {
+            operator => 'NOT',
+            conditions => {  # invalid - object rather than array
+                blarg => 'foo',
+            },
+        },
+        wantErr => {
+            type => 'invalidArguments',
+            arguments => [ 'filter/conditions' ],
+        },
+    }, {
+        filter => {
+            operator => 'NOT',
+            # invalid - no conditions
+        },
+        wantErr => {
+            type => 'invalidArguments',
+            arguments => [ 'filter/conditions' ],
+        },
+    }, {
+        filter => {
+            operator => 'BLARG', # invalid operator
+            conditions => [{
+                after => '2023-01-01T02:00:00',
+            }],
+        },
+        wantErr => {
+            type => 'invalidArguments',
+            arguments => [ 'filter/operator' ],
+        },
     });
 
     for my $tc (@testCases) {
@@ -227,14 +269,19 @@ sub test_calendarevent_query
         $res = $jmap->CallMethods([
             ['CalendarEvent/query', $q, 'R1'],
         ]);
-        my $wantTotal = defined $tc->{wantTotal} ?
-            $tc->{wantTotal} : scalar @{$tc->{wantIds}};
-        $self->assert_num_equals($wantTotal, $res->[0][1]{total});
-        $self->assert_deep_equals($tc->{wantIds}, $res->[0][1]{ids});
+        if ($tc->{wantErr}) {
+            $self->assert_str_equals('error', $res->[0][0]);
+            $self->assert_deep_equals($tc->{wantErr}, $res->[0][1]);
+        } else {
+            my $wantTotal = defined $tc->{wantTotal} ?
+                $tc->{wantTotal} : scalar @{$tc->{wantIds}};
+            $self->assert_num_equals($wantTotal, $res->[0][1]{total});
+            $self->assert_deep_equals($tc->{wantIds}, $res->[0][1]{ids});
 
-        if ($maj > 3 || ($maj == 3 && $min > 8)) {
-            $self->assert_equals($tc->{wantFastPath},
-                $res->[0][1]{debug}{isFastPath});
+            if ($maj > 3 || ($maj == 3 && $min > 8)) {
+                $self->assert_equals($tc->{wantFastPath},
+                    $res->[0][1]{debug}{isFastPath});
+            }
         }
     }
 }

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2231,10 +2231,17 @@ HIDDEN void jmap_filter_parse(jmap_req_t *req, struct jmap_parser *parser,
             jmap_parser_invalid(parser, "operator");
         }
         arg = json_object_get(filter, "conditions");
-        json_array_foreach(arg, i, val) {
-            jmap_parser_push_index(parser, "conditions", i, NULL);
-            jmap_filter_parse(req, parser, val, unsupported, parse_condition, cond_rock, err);
-            jmap_parser_pop(parser);
+        if (json_is_array(arg)) {
+            json_array_foreach(arg, i, val) {
+                jmap_parser_push_index(parser, "conditions", i, NULL);
+                jmap_filter_parse(req, parser, val, unsupported,
+                                  parse_condition, cond_rock, err);
+                jmap_parser_pop(parser);
+            }
+        }
+        else {
+            /* conditions missing or not an array. same error either way */
+            jmap_parser_invalid(parser, "conditions");
         }
     } else if (arg) {
         jmap_parser_invalid(parser, "operator");


### PR DESCRIPTION
This fixes `jmap_filter_parse()` to reject filters whose "conditions" is not an array.