### PR TITLE
imapparse: accept client LITERAL+ for mupdate

### DIFF
--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1476,6 +1476,38 @@ sub _check_cores
     return "Core files found in $coredir" if scalar $self->find_cores();
 }
 
+sub _check_mupdate
+{
+    my ($self) = @_;
+
+    my $mupdate_server = $self->{config}->get('mupdate_server');
+    return if not $mupdate_server; # not in a murder
+
+    my $serverlist = $self->{config}->get('serverlist');
+    return if $serverlist; # don't sync mboxlist on frontends
+
+    # Run ctl_mboxlist -m to sync backend mailboxes with mupdate.
+    #
+    # You typically run this from START, and we do, but at test start
+    # there's no mailboxes yet, so there's nothing to sync, and if
+    # something is broken it probably won't be detected.
+    my $basedir = $self->{basedir};
+    eval {
+        $self->run_command({
+                redirects => { stdout => "$basedir/ctl_mboxlist.out",
+                               stderr => "$basedir/ctl_mboxlist.err",
+                             },
+                cyrus => 1,
+            }, 'ctl_mboxlist', '-m');
+    };
+    if ($@) {
+        my @err = slurp_file("$basedir/ctl_mboxlist.err");
+        chomp for @err;
+        xlog "ctl_mboxlist -m failed: " . Dumper \@err;
+        return "unable to sync local mailboxes with mupdate";
+    }
+}
+
 sub _check_sanity
 {
     my ($self) = @_;
@@ -1621,6 +1653,7 @@ sub stop
     my @errors;
 
     push @errors, $self->_check_sanity();
+    push @errors, $self->_check_mupdate();
 
     xlog "stop $self->{description}: basedir $self->{basedir}";
 

--- a/imap/imapparse.c
+++ b/imap/imapparse.c
@@ -155,7 +155,10 @@ EXPORTED int getxstring(struct protstream *pin, struct protstream *pout,
         buf_reset(buf);
         c = getuint32(pin, &len);
 
-        if (pin->isclient && c == '+') {
+        /* For IMAP, LITERAL+ is only valid from client->server.  For MUPDATE
+         * it's valid in either direction.
+         */
+        if ((pin->isclient || (flags & GXS_MUPDATE)) && c == '+') {
             /* LITERAL- says maximum size is 4096! */
             if (lminus && len > 4096) {
                 /* Fail per RFC 7888, Section 4, choice 2 */

--- a/imap/imapparse.h
+++ b/imap/imapparse.h
@@ -59,6 +59,7 @@ enum getxstring_flags {
     GXS_LITERAL = (1<<2),   /* result may be {N}literal */
     GXS_NIL     = (1<<3),   /* result may be the special atom NIL */
     GXS_BINARY  = (1<<4),   /* result may contain embedded NULs */
+    GXS_MUPDATE = (1<<5),   /* (non-IMAP) accept LITERAL+ as client */
 
     IMAP_ASTRING = GXS_ATOM|GXS_QUOTED|GXS_LITERAL,
     IMAP_BIN_ASTRING = IMAP_ASTRING|GXS_BINARY,
@@ -70,6 +71,8 @@ enum getxstring_flags {
     /* note: there's some consistency issues here... the special
      * value "NIL" must be quoted to get returned as a string */
     IMAP_NASTRING = GXS_NIL|GXS_ATOM|GXS_QUOTED|GXS_LITERAL,
+
+    MUPDATE_STRING = IMAP_STRING|GXS_MUPDATE,
 };
 
 int getxstring(struct protstream *pin, struct protstream *pout,
@@ -81,6 +84,7 @@ int getxstring(struct protstream *pin, struct protstream *pout,
 #define getqstring(pin, pout, buf) getxstring((pin), (pout), (buf), IMAP_QSTRING)
 #define getstring(pin, pout, buf) getxstring((pin), (pout), (buf), IMAP_STRING)
 #define getnastring(pin, pout, buf) getxstring((pin), (pout), (buf), IMAP_NASTRING)
+#define getmstring(pin, pout, buf) getxstring((pin), (pout), (buf), MUPDATE_STRING)
 #define getcharset(pin, pout, buf) getxstring((pin), (pout), (buf), GXS_ATOM|GXS_QUOTED)
 int getint32(struct protstream *pin, int *num);
 int getint64(struct protstream *pin, int64_t *num);

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -620,7 +620,7 @@ EXPORTED int mupdate_scarf(mupdate_handle *handle,
         switch(handle->cmd.s[0]) {
         case 'B':
             if (!strncmp(handle->cmd.s, "BAD", 3)) {
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg1));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg1));
                 CHECKNEWLINE(handle, ch);
 
                 syslog(LOG_ERR, "mupdate BAD response: %s", handle->arg1.s);
@@ -629,7 +629,7 @@ EXPORTED int mupdate_scarf(mupdate_handle *handle,
                 }
                 goto done;
             } else if (!strncmp(handle->cmd.s, "BYE", 3)) {
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg1));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg1));
                 CHECKNEWLINE(handle, ch);
 
                 syslog(LOG_ERR, "mupdate BYE response: %s", handle->arg1.s);
@@ -642,7 +642,7 @@ EXPORTED int mupdate_scarf(mupdate_handle *handle,
 
         case 'D':
             if (!strncmp(handle->cmd.s, "DELETE", 6)) {
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg1));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg1));
                 CHECKNEWLINE(handle, ch);
 
                 memset(&box, 0, sizeof(box));
@@ -662,21 +662,21 @@ EXPORTED int mupdate_scarf(mupdate_handle *handle,
         case 'M':
             if (!strncmp(handle->cmd.s, "MAILBOX", 7)) {
                 /* Mailbox Name */
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg1));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg1));
                 if (ch != ' ') {
                     r = MUPDATE_PROTOCOL_ERROR;
                     goto done;
                 }
 
                 /* Server */
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg2));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg2));
                 if (ch != ' ') {
                     r = MUPDATE_PROTOCOL_ERROR;
                     goto done;
                 }
 
                 /* ACL */
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg3));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg3));
                 CHECKNEWLINE(handle, ch);
 
                 /* Handle mailbox command */
@@ -695,7 +695,7 @@ EXPORTED int mupdate_scarf(mupdate_handle *handle,
             goto badcmd;
         case 'N':
             if (!strncmp(handle->cmd.s, "NO", 2)) {
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg1));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg1));
                 CHECKNEWLINE(handle, ch);
 
                 syslog(LOG_DEBUG, "mupdate NO response: %s", handle->arg1.s);
@@ -709,7 +709,7 @@ EXPORTED int mupdate_scarf(mupdate_handle *handle,
         case 'O':
             if (!strncmp(handle->cmd.s, "OK", 2)) {
                 /* It's all good, grab the attached string and move on */
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg1));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg1));
 
                 CHECKNEWLINE(handle, ch);
                 if (wait_for_ok) {
@@ -722,14 +722,14 @@ EXPORTED int mupdate_scarf(mupdate_handle *handle,
         case 'R':
             if (!strncmp(handle->cmd.s, "RESERVE", 7)) {
                 /* Mailbox Name */
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg1));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg1));
                 if (ch != ' ') {
                     r = MUPDATE_PROTOCOL_ERROR;
                     goto done;
                 }
 
                 /* Server */
-                ch = getstring(handle->conn->in, handle->conn->out, &(handle->arg2));
+                ch = getmstring(handle->conn->in, handle->conn->out, &(handle->arg2));
                 CHECKNEWLINE(handle, ch);
 
                 /* Handle reserve command */


### PR DESCRIPTION
The mupdate protocol uses LITERAL+ like syntax in both directions.  This got broken when we made `getxstring()` strict about only accepting it from clients (per RFC 7888: "The non-synchronizing literal form MUST NOT be sent from server to client."), resulting in murder backends being unable to synchronise their mailboxes.db with the mupdate server.  `ctl_mboxlist -m` would fail with an error like "couldn't do LIST command on mupdate server" when parsing the mailboxes from the LIST response.  Our tests didn't detect this because they only run `ctl_mboxlist -m` at startup, when there aren't any mailboxes yet, and the LIST response is empty.

* Adds an additional `ctl_mboxlist -m` run to the post-test shutdown checks for any instances that are configured as a murder backend.
* Adds an mupdate-specific flag to `getxstring()`, and arranges for mupdate-client.c to use it.  When this flag is present, the LITERAL+ syntax is accepted in any direction.