### PR TITLE
github actions on forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,12 @@ jobs:
         cpanm Digest::CRC
         cpanm XML::Simple # XXX could be grabbed from apt by docker image
         cpanm Mail::IMAPTalk # in image, but fetch latest!
+    - name: setup git safe directory
+      shell: bash
+      run: git config --global --add safe.directory /__w/cyrus-imapd/cyrus-imapd
     - name: configure and build
       shell: bash
       run: |
-        git config --global --add safe.directory /__w/cyrus-imapd/cyrus-imapd
         echo "building cyrus version" $(./tools/git-version.sh)
         ./tools/build-with-cyruslibs.sh
     - name: report version information

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,15 @@ jobs:
     - name: setup git safe directory
       shell: bash
       run: git config --global --add safe.directory /__w/cyrus-imapd/cyrus-imapd
+    - name: fetch upstream release tags
+      if: ${{ github.repository != 'cyrusimap/cyrus-imapd' }}
+      shell: bash
+      run: |
+        git remote add upstream https://github.com/cyrusimap/cyrus-imapd.git
+        # n.b. --no-tags does not mean "no tags", it means "no automatic tag
+        # following".  we're explicitly fetching the tags we want, we do not
+        # need every other tag that's reachable from them
+        git fetch --no-tags upstream 'refs/tags/cyrus-imapd-*:refs/tags/cyrus-imapd-*'
     - name: configure and build
       shell: bash
       run: |


### PR DESCRIPTION
Updates github actions to fetch the release tags from the upstream repository if the repository the action is running on is not the upstream repository.

This solves Cassandane test failures on forks that have actions enabled but do not have up to date release tags.  It could also be solved on the fork by updating the release tags, but the cause and solution aren't obvious, so just automate it to avoid confusion.