### PR TITLE
configurable abort on fatal errors

### DIFF
--- a/backup/backupd.c
+++ b/backup/backupd.c
@@ -173,6 +173,9 @@ EXPORTED void fatal(const char* s, int code)
         prot_flush(backupd_out);
     }
     syslog(LOG_ERR, "Fatal error: %s", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(code);
 }
 

--- a/backup/ctl_backups.c
+++ b/backup/ctl_backups.c
@@ -72,6 +72,9 @@ EXPORTED void fatal(const char *error, int code)
 {
     fprintf(stderr, "fatal error: %s\n", error);
     cyrus_done();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/backup/cyr_backup.c
+++ b/backup/cyr_backup.c
@@ -75,6 +75,9 @@ EXPORTED void fatal(const char *error, int code)
 {
     fprintf(stderr, "fatal error: %s\n", error);
     cyrus_done();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/backup/restore.c
+++ b/backup/restore.c
@@ -68,6 +68,9 @@ EXPORTED void fatal(const char *s, int code)
 {
     fprintf(stderr, "Fatal error: %s\n", s);
     syslog(LOG_ERR, "Fatal error: %s", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/changes/next/fatals-abort
+++ b/changes/next/fatals-abort
@@ -1,0 +1,18 @@
+Description:
+
+Adds an option for fatal errors to abort and produce a core dump.
+
+
+Config changes:
+
+fatals_abort
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None

--- a/imap/calalarmd.c
+++ b/imap/calalarmd.c
@@ -76,6 +76,8 @@ EXPORTED void fatal(const char *msg, int err)
 
     cyrus_done();
 
+    if (err != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(err);
 }
 

--- a/imap/cli_fatal.c
+++ b/imap/cli_fatal.c
@@ -44,6 +44,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <sysexits.h>
 
 #include "global.h"
 #include "xmalloc.h"
@@ -60,5 +61,8 @@ EXPORTED void fatal(const char *message, int code)
     recurse_code = code;
     fprintf(stderr, "fatal error: %s\n", message);
     cyrus_done();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -1038,6 +1038,8 @@ EXPORTED void fatal(const char* s, int code)
 {
     fprintf(stderr, "ctl_conversationsdb: %s\n", s);
     cyrus_done();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
-

--- a/imap/cvt_xlist_specialuse.c
+++ b/imap/cvt_xlist_specialuse.c
@@ -87,6 +87,9 @@ EXPORTED void fatal(const char *s, int code)
 {
     fprintf(stderr, "Fatal error: %s\n", s);
     syslog(LOG_ERR, "Fatal error: %s", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/imap/deliver.c
+++ b/imap/deliver.c
@@ -127,6 +127,9 @@ EXPORTED void fatal(const char* s, int code)
     prot_printf(deliver_out,"421 4.3.0 deliver: %s\r\n", s);
     prot_flush(deliver_out);
     cyrus_done();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/imap/fud.c
+++ b/imap/fud.c
@@ -481,6 +481,7 @@ EXPORTED void fatal(const char* s, int code)
     recurse_code = code;
     syslog(LOG_ERR, "Fatal error: %s", s);
 
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(code);
 }
-

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1235,6 +1235,9 @@ EXPORTED void fatal(const char* s, int code)
     }
 
     syslog(LOG_ERR, "%s%s", fatal, s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(code);
 }
 

--- a/imap/idled.c
+++ b/imap/idled.c
@@ -113,6 +113,8 @@ EXPORTED void fatal(const char *msg, int err)
 
     cyrus_done();
 
+    if (err != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(err);
 }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1443,6 +1443,9 @@ EXPORTED void fatal(const char *s, int code)
     }
 
     syslog(LOG_ERR, "Fatal error: %s", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(code);
 }
 

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -1034,10 +1034,10 @@ EXPORTED void fatal(const char* s, int code)
 
     syslog(LOG_ERR, "FATAL: %s", s);
 
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     /* shouldn't return */
     shut_down(code);
-
-    exit(code);
 }
 
 /*

--- a/imap/message_test.c
+++ b/imap/message_test.c
@@ -311,6 +311,9 @@ EXPORTED void fatal(const char* s, int code)
 {
     fprintf(stderr, "message_test: %s\n", s);
     cyrus_done();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -617,10 +617,10 @@ EXPORTED void fatal(const char *s, int code)
     else recurse_code = code;
 
     syslog(LOG_ERR, "%s", s);
-    shut_down(code);
 
-    /* NOTREACHED */
-    exit(code); /* shut up GCC */
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
+    shut_down(code);
 }
 
 #define CHECKNEWLINE(c, ch) do { if ((ch) == '\r') (ch)=prot_getc((c)->pin); \

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -646,6 +646,9 @@ EXPORTED void fatal(const char* s, int code)
     }
     if (stage) append_removestage(stage);
     syslog(LOG_ERR, "Fatal error: %s", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(code);
 }
 

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -674,6 +674,9 @@ EXPORTED void fatal(const char* s, int code)
         prot_flush(popd_out);
     }
     syslog(LOG_ERR, "Fatal error: %s", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(code);
 }
 

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -87,6 +87,8 @@ EXPORTED void fatal(const char *msg, int err)
     syslog(LOG_CRIT, "%s", msg);
     syslog(LOG_NOTICE, "exiting");
 
+    if (err != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(err);
 }
 

--- a/imap/search_test.c
+++ b/imap/search_test.c
@@ -332,6 +332,9 @@ EXPORTED void fatal(const char* s, int code)
 {
     fprintf(stderr, "search_test: %s\n", s);
     cyrus_done();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/imap/smmapd.c
+++ b/imap/smmapd.c
@@ -166,7 +166,8 @@ EXPORTED void fatal(const char* s, int code)
     }
     recurse_code = code;
     syslog(LOG_ERR, "Fatal error: %s", s);
-    abort();
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
 
     shut_down(code);
 }

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -138,6 +138,9 @@ EXPORTED void fatal(const char *s, int code)
 {
     fprintf(stderr, "Fatal error: %s\n", s);
     syslog(LOG_ERR, "Fatal error: %s", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -116,6 +116,9 @@ static int usage(const char *name)
 EXPORTED void fatal(const char* s, int code)
 {
     fprintf(stderr, "sync_reset: %s\n", s);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -465,6 +465,7 @@ EXPORTED void fatal(const char* s, int code)
         prot_flush(sync_out);
     }
     syslog(LOG_ERR, "Fatal error: %s", s);
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
     shut_down(code);
 }
 

--- a/lib/assert.c
+++ b/lib/assert.c
@@ -47,6 +47,8 @@
 #include "xmalloc.h"
 #include "assert.h"
 
+extern int config_fatals_abort;
+
 EXPORTED void
 assertionfailed(const char *file, int line, const char *expr)
 {
@@ -54,5 +56,6 @@ assertionfailed(const char *file, int line, const char *expr)
 
     snprintf(buf, sizeof(buf), "Internal error: assertion failed: %s: %d%s%s",
             file, line, expr ? ": " : "", expr ? expr : "");
+    if (config_fatals_abort) abort();
     fatal(buf, EX_SOFTWARE);
 }

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -998,6 +998,14 @@ Blank lines and lines beginning with ``#'' are ignored.
    For backward compatibility, if no unit is specified, seconds is
    assumed. */
 
+{ "fatals_abort", 0, SWITCH, "UNRELEASED" }
+/* If enabled, when fatal errors are detected, Cyrus will call abort()
+   to produce a core dump, unless the error was due to a misbehaving
+   client.  This is useful if you have the ability to debug a core dump.
+.PP
+   If not enabled (the default), the process will exit normally with
+   an error code. */
+
 { "flushseenstate", 1, SWITCH, "2.5.0", "2.5.0" }
 /* Deprecated. No longer used. */
 

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -91,6 +91,7 @@ EXPORTED int config_qosmarking;
 EXPORTED int config_debug;
 EXPORTED toggle_debug_cb config_toggle_debug_cb = NULL;
 EXPORTED int config_debug_slowio = 0;
+EXPORTED int config_fatals_abort = 0;
 
 static int config_loaded;
 
@@ -663,6 +664,7 @@ EXPORTED void config_reset(void)
     config_debug = 0;
     config_toggle_debug_cb = NULL;
     config_debug_slowio = 0;
+    config_fatals_abort = 0;
 
     /* reset all the options */
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
@@ -893,6 +895,9 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
 
     /* do we want artificially-slow I/O ops */
     config_debug_slowio = config_getswitch(IMAPOPT_DEBUG_SLOWIO);
+
+    /* do we want to abort() on fatal errors */
+    config_fatals_abort = config_getswitch(IMAPOPT_FATALS_ABORT);
 }
 
 #define GROWSIZE 4096

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -103,6 +103,7 @@ extern unsigned config_maxword;
 extern int config_qosmarking;
 extern int config_debug;
 extern int config_debug_slowio;
+extern int config_fatals_abort;
 
 /* for toggling config_debug and its behaviours at runtime */
 typedef void (*toggle_debug_cb)(void);

--- a/master/master.c
+++ b/master/master.c
@@ -212,6 +212,7 @@ EXPORTED void fatal(const char *msg, int code)
 {
     syslog(LOG_CRIT, "%s", msg);
     syslog(LOG_NOTICE, "exiting");
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
     exit(code);
 }
 

--- a/netnews/remotepurge.c
+++ b/netnews/remotepurge.c
@@ -147,6 +147,9 @@ EXPORTED void fatal(const char *s, int code)
         syslog(LOG_ERR, "fatal error: %s", s);
         fprintf(stderr, "fatal error: %s\n", s);
     }
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(code);
 }
 

--- a/notifyd/notifyd.c
+++ b/notifyd/notifyd.c
@@ -214,6 +214,8 @@ EXPORTED void fatal(const char *s, int code)
 
     syslog(LOG_ERR, "Fatal error: %s", s);
 
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(code);
 }
 

--- a/ptclient/ptloader.c
+++ b/ptclient/ptloader.c
@@ -371,6 +371,8 @@ int service_main_fd(int c, int argc __attribute__((unused)),
 EXPORTED void fatal(const char *msg, int exitcode)
 {
     syslog(LOG_ERR, "%s", msg);
+
+    if (exitcode != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(exitcode);
 }
-

--- a/sieve/sievec.c
+++ b/sieve/sievec.c
@@ -47,6 +47,7 @@
 
 #include "sieve_interface.h"
 #include <syslog.h>
+#include <sysexits.h>
 
 #include "libconfig.h"
 #include "xmalloc.h"
@@ -160,5 +161,7 @@ EXPORTED void fatal(const char *s, int code)
 {
     fprintf(stderr, "Fatal error: %s (%d)\r\n", s, code);
 
-    exit(1);
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
+    exit(code);
 }

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -60,6 +60,7 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <inttypes.h>
+#include <sysexits.h>
 
 #include <string.h>
 
@@ -74,6 +75,8 @@ static void generate_script(bytecode_input_t *d, int len);
 EXPORTED void fatal(const char *s, int code)
 {
     fprintf(stderr, "Fatal error: %s (%d)\r\n", s, code);
+
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
 
     exit(code);
 }

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -63,6 +63,7 @@
 
 #include <string.h>
 
+#include "libconfig.h"
 #include "map.h"
 #include "times.h"
 
@@ -74,7 +75,7 @@ EXPORTED void fatal(const char *s, int code)
 {
     fprintf(stderr, "Fatal error: %s (%d)\r\n", s, code);
 
-    exit(1);
+    exit(code);
 }
 
 static int load(int fd, bytecode_input_t ** d)
@@ -104,13 +105,15 @@ int main(int argc, char * argv[])
     bytecode_input_t *bc = NULL;
     int script_fd;
     int opt, usage_error = 0, gen_script = 0;
+    char *alt_config = NULL;
 
     unsigned long len;
 
     /* keep this in alphabetical order */
-    static const char short_options[] = "s";
+    static const char short_options[] = "C:s";
 
     static const struct option long_options[] = {
+        /* n.b. no long option for -C */
         { "as-sieve", no_argument, NULL, 's' },
 
         { 0, 0, 0, 0 },
@@ -120,6 +123,9 @@ int main(int argc, char * argv[])
                                     short_options, long_options, NULL)))
     {
         switch (opt) {
+        case 'C': /* alt config file */
+            alt_config = optarg;
+            break;
         case 's':
             gen_script = 1;
             break;
@@ -142,6 +148,9 @@ int main(int argc, char * argv[])
         fprintf(stderr, "can not open script '%s'\n", argv[1]);
         exit(1);
     }
+
+    /* Load configuration file. */
+    config_read(alt_config, 0);
 
     len=load(script_fd,&bc);
     close(script_fd);

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -58,6 +58,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sysexits.h>
 
 #include "libconfig.h"
 #include "assert.h"
@@ -880,5 +881,8 @@ int main(int argc, char *argv[])
 EXPORTED void fatal(const char* message, int rc)
 {
     fprintf(stderr, "fatal error: %s\n", message);
+
+    if (rc != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(rc);
 }

--- a/sieve/test_mailbox.c
+++ b/sieve/test_mailbox.c
@@ -786,5 +786,8 @@ int main(int argc, char *argv[])
 EXPORTED void fatal(const char* message, int rc)
 {
     fprintf(stderr, "fatal error: %s\n", message);
+
+    if (rc != EX_PROTOCOL && config_fatals_abort) abort();
+
     exit(rc);
 }

--- a/timsieved/timsieved.c
+++ b/timsieved/timsieved.c
@@ -198,6 +198,8 @@ EXPORTED void fatal(const char *s, int code)
     prot_printf(sieved_out, "NO Fatal error: %s\r\n", s);
     prot_flush(sieved_out);
 
+    if (code != EX_PROTOCOL && config_fatals_abort) abort();
+
     shut_down(EX_TEMPFAIL);
 }
 


### PR DESCRIPTION
When a Cyrus process detects a fatal error, it logs an error message and shuts down with a non-zero exit code.  This PR adds a new imapd.conf option `fatals_abort`, which when enabled, will cause Cyrus to call `abort()` instead of exiting non-zero.  Depending on system configuration, this will usually result in a core dump.

**Fastmail:**
This will conflict with the "Fastmail ONLY - make assertion failures and fatal errors into coredumps" commit on our capstone branch.  To deploy this change at Fastmail, I think we need to do something like:
1. Remove that commit from the capstone branch.  New builds will lack the core dump on fatal error behaviour.
2. Label this PR include-in-fastmail. New builds will have the configurable behaviour, but it won't be enabled.
3. Deploy new builds across our environment.
4. Deploy an imapd.conf change to add `fatals_abort: yes`.  We start getting core dumps on fatal errors again.

If we deploy the imapd.conf update before our Cyrus builds include this PR, we might get errors about the unrecognised option.  So I think it's better to get the code deployed first, and then turn it on afterwards, though this leaves a window where we won't get core dumps.

We should not land this PR on the master branch until our own deployment process is finished, so that we can use include-in-fastmail to control the timing.