### PR TITLE
tiny tests: fix propagation of syntax errors

### DIFF
--- a/cassandane/Cassandane/Tiny/Loader.pm
+++ b/cassandane/Cassandane/Tiny/Loader.pm
@@ -26,7 +26,7 @@ sub import {
   for my $test (sort @tests) {
     local $RELOADED;
 
-    unless (eval "package $into; do qq{$test}; 1") {
+    unless (eval "package $into; do qq{$test}; die \$@ if \$@; 1") {
       Carp::confess("tried to load $test but it failed: $@");
     }
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_gmt
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_gmt
@@ -37,6 +37,6 @@ END:VCALENDAR
 EOF
 
     my $event = $self->putandget_vevent($eventId,
-        $ical, ['timeZone');
+        $ical, ['timeZone']);
     $self->assert_str_equals('Etc/GMT+8', $event->{timeZone});
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_recur
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_recur
@@ -44,6 +44,6 @@ END:VCALENDAR
 EOF
 
     my $event = $self->putandget_vevent($eventId,
-        $ical, ['timeZone');
+        $ical, ['timeZone']);
     $self->assert_str_equals('Europe/Berlin', $event->{timeZone});
 }

--- a/cassandane/tiny-tests/JMAPContacts/card_query_shared
+++ b/cassandane/tiny-tests/JMAPContacts/card_query_shared
@@ -103,7 +103,7 @@ sub test_card_query_shared
                         contexts => {
                             private => JSON::true
                         },
-                        isOrdered => JSON::false;
+                        isOrdered => JSON::false,
                         components => [
                             {
                                 kind => "name",


### PR DESCRIPTION
A bug in Cassandane::Tiny::Loader was eating syntax errors.  I have fixed that, then fixed the two tests that were not being run because of that.