### PR TITLE
configure.ac: replication is not 'experimental'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1893,7 +1893,7 @@ dnl
 dnl see if we're compiling replication support programs
 dnl
 AC_ARG_ENABLE(replication,
-        [AS_HELP_STRING([--enable-replication], [enable replication support (experimental)])],,[enable_replication="no";])
+        [AS_HELP_STRING([--enable-replication], [enable replication support])],,[enable_replication="no";])
 AM_CONDITIONAL([REPLICATION], [test "$enable_replication" != no])
 if test "x$enable_replication" = "xyes"; then
         AC_DEFINE(USE_REPLICATION,[],[Build with replication functionality])


### PR DESCRIPTION
Replication was experimental in 2.3, but I don't think that's the case anymore...

For one thing, it's our preferred upgrade path!

This came up here: https://cyrus.topicbox.com/groups/devel/T0f354b019bc535c8-M9ec692e090ac3eda33feea56