### PR TITLE
compiling.rst: remove RPM packages for SASL DIGEST-MD5

### DIFF
--- a/docsrc/imap/developer/compiling.rst
+++ b/docsrc/imap/developer/compiling.rst
@@ -115,8 +115,6 @@ SASL Authentication
 
     `Cyrus SASL Plain`_, libsasl2-modules, cyrus-sasl-plain, "yes/no", "Required
     to pass Cyrus IMAP's PLAIN authentication unit tests."
-    `Cyrus SASL MD5`_, libsasl2-modules, cyrus-sasl-md5, "yes/no", "Required to
-    pass Cyrus IMAP's DIGEST-MD5 authentication unit tests."
     `sasl binaries`_, sasl2-bin, sasl2-bin, "no", "Administration tools for
     managing SASL."
     `Kerberos`_, libsasl2-modules-gssapi-mit, krb5-devel, "yes/no", "Development


### PR DESCRIPTION
As DIGEST-MD5 is gone, installing its libsasl2 plugin, sasl2/libdigestmd5.so, should not be necessary any more.

On Debian libsasl2-modules installs apart from libdigestmd5.so and libcrammd5.so also liblogin.so.  However libsasl2-modules is still required in the documentation on the line before the deleted herein line.

On Fedora cyrus-sasl-md5 does include only libcrammd5.so and libdigestmd5.so.

If there are no github-side RPM-based tests, this change cannot be tried out.