### PR TITLE
sync_sieve_upload() always initialize buffer with script content

### DIFF
--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3583,7 +3583,6 @@ int sync_sieve_upload(const char *userid, const char *fname,
     snprintf(name, sizeof(name), "%.*s", (int) (ext - fname), fname);
     r = sievedb_lookup_name(db, name, &sdata, 0);
     if (r == CYRUSDB_NOTFOUND) {
-        buf_init_ro(&buf, content, len);
         sdata->name = name;
     }
     else if (r) {
@@ -3591,6 +3590,7 @@ int sync_sieve_upload(const char *userid, const char *fname,
         goto done;
     }
 
+    buf_init_ro(&buf, content, len);
     r = sieve_script_store(mailbox, sdata, &buf);
 
   done:


### PR DESCRIPTION
This fixes a bug where updating a script on a pre-sieve mailbox server resulted in an empty script on a sieve-mailbox replica (#4947 ).  

This had to be tested manually with different versions of Cyrus.