### PR TITLE
jmap_calendar.c: ignore cache errors in CalendarEvent/get

### DIFF
--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4092,11 +4092,17 @@ static int jmap_calendarevent_get(struct jmap_req *req)
 
     if (hashu64_count(&rock.cache_jsevents)) {
         r = caldav_begin(db);
-        if (!r) hashu64_enumerate(&rock.cache_jsevents,
+        if (!r) {
+            hashu64_enumerate(&rock.cache_jsevents,
                 cachecalendarevents_cb, &rock);
-        if (r) caldav_abort(db);
-        else r = caldav_commit(db);
-        if (r) goto done;
+            r = caldav_commit(db);
+        }
+        if (r) {
+            xsyslog(LOG_ERR, "failed to cache calendar events, ignoring error",
+                    "userid=<%s> accountid=<%s> err=<%s>",
+                    req->userid, req->accountid, error_message(r));
+            r = 0;
+        }
     }
 
     /* Build response */


### PR DESCRIPTION
Errors during writing the CalendarEvent cache in /get always were meant to be ignored, but an error when starting the write transaction still led to aborting the JMAP request.

This patch updates that to also ignore, but report, such errors.