### PR TITLE
jmap_contact.c: support X-PHONETIC extension properties

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/contact_copy_phonetic
+++ b/cassandane/tiny-tests/JMAPContacts/contact_copy_phonetic
@@ -1,0 +1,104 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_contact_copy_phonetic
+  : needs_component_jmap {
+    my ($self)    = @_;
+    my $jmap      = $self->{jmap};
+    my $carddav   = $self->{carddav};
+    my $admintalk = $self->{adminstore}->get_client();
+    my $service   = $self->{instance}->get_service("http");
+
+    xlog $self, "create shared account";
+    $admintalk->create("user.other");
+
+    my $otherCarddav = Net::CardDAVTalk->new(
+        user      => "other",
+        password  => 'pass',
+        host      => $service->host(),
+        port      => $service->port(),
+        scheme    => 'http',
+        url       => '/',
+        expandurl => 1,
+    );
+
+    my $otherJmap = Mail::JMAPTalk->new(
+        user     => 'other',
+        password => 'pass',
+        host     => $service->host(),
+        port     => $service->port(),
+        scheme   => 'http',
+        url      => '/jmap/',
+    );
+    $otherJmap->DefaultUsing([
+        'urn:ietf:params:jmap:core',
+        'https://cyrusimap.org/ns/jmap/contacts',
+        'https://cyrusimap.org/ns/jmap/debug'
+    ]);
+
+    xlog $self, "share addressbook";
+    $admintalk->setacl(
+        "user.other.#addressbooks.Default",
+        "cassandane" => 'lrswipkxtecdn'
+    ) or die;
+
+    my $card = decode(
+        'utf-8', <<EOF
+BEGIN:VCARD
+VERSION:3.0
+UID:0A8F88DE-1073-4D47-926F-0D535523FD15
+N:Smith;Hank;Frank;
+FN:Hank Smith
+X-PHONETIC-FIRST-NAME:/hæŋk/
+X-PHONETIC-MIDDLE-NAME:/fræŋk/
+X-PHONETIC-LAST-NAME:/smɪθ/
+REV:2008-04-24T19:52:43Z
+END:VCARD
+EOF
+    );
+    $card =~ s/\r?\n/\r\n/gs;
+    $carddav->Request('PUT', 'Default/test.vcf', $card, 'Content-Type' => 'text/vcard');
+
+    my $res = $jmap->CallMethods([
+        [ 'Contact/query', {}, 'R1' ],
+    ]);
+    $self->assert_num_equals(1, scalar @{ $res->[0][1]{ids} });
+    my $contactId = $res->[0][1]{ids}[0];
+    $self->assert_not_null($contactId);
+
+    $res = $jmap->CallMethods([
+        [
+            'Contact/copy',
+            {
+                fromAccountId => 'cassandane',
+                accountId     => 'other',
+                create        => {
+                    contact1 => {
+                        addressbookId => 'Default',
+                        id            => $contactId
+                    }
+                },
+                onSuccessDestroyOriginal => JSON::false,
+            },
+            'R1'
+        ],
+    ]);
+    my $copiedContactId = $res->[0][1]{created}{contact1}{id};
+    $self->assert_not_null($copiedContactId);
+
+    $res = $otherJmap->CallMethods([
+        [
+            'Contact/get',
+            {
+                accountId  => 'other',
+                ids        => [$copiedContactId],
+                properties => [ 'phoneticFirstName', 'phoneticMiddleName', 'phoneticLastName' ],
+            },
+            'R1'
+        ],
+    ]);
+
+    $self->assert_str_equals(decode('utf-8', '/hæŋk/'),  $res->[0][1]{list}[0]{phoneticFirstName});
+    $self->assert_str_equals(decode('utf-8', '/fræŋk/'), $res->[0][1]{list}[0]{phoneticMiddleName});
+    $self->assert_str_equals(decode('utf-8', '/smɪθ/'),  $res->[0][1]{list}[0]{phoneticLastName});
+}

--- a/cassandane/tiny-tests/JMAPContacts/contact_get_phonetic
+++ b/cassandane/tiny-tests/JMAPContacts/contact_get_phonetic
@@ -1,0 +1,50 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_contact_get_phonetic
+  : needs_component_jmap {
+    my ($self)  = @_;
+    my $jmap    = $self->{jmap};
+    my $carddav = $self->{carddav};
+
+    my $card = decode('utf-8', <<EOF
+BEGIN:VCARD
+VERSION:3.0
+UID:E1951B19-80F3-4CA8-BB76-A887843858A3
+FN:鈴木 一朗
+N:鈴木;一朗;;;
+X-PHONETIC-FIRST-NAME:いちろう
+X-PHONETIC-LAST-NAME:すずき
+ORG:日本野球機構
+X-PHONETIC-ORG:にっぽんやきゅうきこう
+END:VCARD
+EOF
+    );
+    $card =~ s/\r?\n/\r\n/gs;
+    $carddav->Request(
+        'PUT', 'Default/test.vcf', $card,
+        'Content-Type' => 'text/vcard; charset=utf-8'
+    );
+
+    my %vcardProps = (
+        firstName         => decode('utf-8', '一朗'),
+        lastName          => decode('utf-8', '鈴木'),
+        company           => decode('utf-8', '日本野球機構'),
+        phoneticFirstName => decode('utf-8', 'いちろう'),
+        phoneticLastName  => decode('utf-8', 'すずき'),
+        phoneticCompany   => decode('utf-8', 'にっぽんやきゅうきこう'),
+    );
+
+    my $res = $jmap->CallMethods([ [
+        'Contact/get',
+        {
+            properties => [ keys %vcardProps ],
+        },
+        'R1'
+    ] ]);
+
+    keys %vcardProps;
+    while (my ($prop, $value) = each %vcardProps) {
+        $self->assert_str_equals($value, $res->[0][1]{list}[0]{$prop});
+    }
+}

--- a/cassandane/tiny-tests/JMAPContacts/contact_set_phonetic
+++ b/cassandane/tiny-tests/JMAPContacts/contact_set_phonetic
@@ -1,0 +1,116 @@
+#!perl
+use Cassandane::Tiny;
+use Encode qw(decode);
+
+sub test_contact_set_phonetic
+  : needs_component_jmap {
+    my ($self)  = @_;
+    my $jmap    = $self->{jmap};
+    my $carddav = $self->{carddav};
+
+    xlog $self, "Create Contact with phonetic properties";
+
+    my %jprops = (
+        firstName         => decode('utf-8', '一朗'),
+        lastName          => decode('utf-8', '鈴木'),
+        company           => decode('utf-8', '日本野球機構'),
+        phoneticFirstName => decode('utf-8', 'いちろう'),
+        phoneticLastName  => decode('utf-8', 'すずき'),
+        phoneticCompany   => decode('utf-8', 'にっぽんやきゅうきこう'),
+    );
+
+    my $res = $jmap->CallMethods([
+        [
+            'Contact/set',
+            {
+                create => {
+                    contact1 => \%jprops,
+                },
+            },
+            'R1'
+        ],
+        [
+            'Contact/get', {
+                ids => ['#contact1'], properties => [ keys %jprops, "x-href" ]
+            }, 'R2'
+        ]
+    ]);
+    my $contactId = $res->[0][1]{created}{contact1}{id};
+    $self->assert_not_null($contactId);
+    my $xhref = $res->[1][1]{list}[0]{'x-href'};
+    $self->assert_not_null($xhref);
+
+    xlog $self, "Assert JMAP and vCard properties";
+
+    keys %jprops;
+    while (my ($prop, $value) = each %jprops) {
+        $self->assert_str_equals($value, $res->[1][1]{list}[0]{$prop});
+    }
+
+    my %vcardProps = (
+        N                       => decode('utf-8', '鈴木;一朗;'),
+        ORG                     => decode('utf-8', '日本野球機構'),
+        'X-PHONETIC-FIRST-NAME' => decode('utf-8', 'いちろう'),
+        'X-PHONETIC-LAST-NAME'  => decode('utf-8', 'すずき'),
+        'X-PHONETIC-ORG'        => decode('utf-8', 'にっぽんやきゅうきこう'),
+    );
+
+    $res = $carddav->Request('GET', $xhref);
+    my $vcard = decode('utf-8', $res->{content});
+    $self->assert_not_null($vcard);
+
+    keys %vcardProps;
+    while (my ($prop, $value) = each %vcardProps) {
+        $self->assert_matches(qr/^$prop:$value\r?$/m, $vcard);
+    }
+
+    xlog $self, "Update phonetic properties";
+
+    $jprops{company}         = 'Acme Corporation';
+    $jprops{phoneticCompany} = decode('utf-8', '/ˈæk.mi/ /ˌkɔːr.pəˈreɪ.ʃən/');
+    delete $jprops{phoneticLastName};
+
+    $vcardProps{ORG}              = $jprops{company};
+    $vcardProps{'X-PHONETIC-ORG'} = $jprops{phoneticCompany};
+    delete $vcardProps{'X-PHONETIC-LAST-NAME'};
+
+    my $res = $jmap->CallMethods([
+        [
+            'Contact/set',
+            {
+                update => {
+                    $contactId => {
+                        company          => $jprops{company},
+                        phoneticCompany  => $jprops{phoneticCompany},
+                        phoneticLastName => undef,
+                    }
+                }
+            },
+            'R1'
+        ],
+        [
+            'Contact/get',
+            {
+                ids => ['#contact1'], properties => [ keys %jprops ],
+            },
+            'R2'
+        ]
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$contactId});
+
+    xlog $self, "Assert JMAP and vCard properties";
+
+    keys %jprops;
+    while (my ($prop, $value) = each %jprops) {
+        $self->assert_str_equals($value, $res->[1][1]{list}[0]{$prop});
+    }
+
+    $res = $carddav->Request('GET', $xhref);
+    my $vcard = decode('utf-8', $res->{content});
+    $self->assert_not_null($vcard);
+
+    keys %vcardProps;
+    while (my ($prop, $value) = each %vcardProps) {
+        $self->assert_matches(qr/^$prop:$value\r?$/m, $vcard);
+    }
+}


### PR DESCRIPTION
Apple macOS Contacts.app allows to store phonetic information for First Name, Middle Name, Last Name and Company. These are stored in the vCard with the X-PHONETIC prefix.

This patch adds the "phoneticFirstName, "phoneticMiddleName", "phoneticLastName" and "phoneticCompany" properties to the Contact type to support these vCard properties in JMAP.