### PR TITLE
smtpclient: add smtp_ehlo_hostname option for EHLO command

### DIFF
--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -729,6 +729,11 @@ sub _generate_imapd_conf
                 smtp_backend => 'host',
                 smtp_host => $self->{smtphost},
             );
+            if (not defined $config->get("servername")) {
+                # smtpclient needs client_bind_name or servername,
+                # falls back to servername if client_bind isn't set.
+                $config->set(servername => "127.0.0.1");
+            }
         }
     }
     else {

--- a/cassandane/Cassandane/Net/SMTPServer.pm
+++ b/cassandane/Cassandane/Net/SMTPServer.pm
@@ -46,8 +46,8 @@ sub new_connection {
 }
 
 sub helo {
-    my ($Self) = @_;
-    $Self->mylog("SMTP: HELO");
+    my ($Self, $Host) = @_;
+    $Self->mylog("SMTP: HELO $Host");
     return if $Self->override('helo');
     $Self->send_client_resp(250, "localhost",
                             "AUTH", "DSN", "SIZE 10000", "ENHANCEDSTATUSCODES");

--- a/changes/next/smtpclient_ehlo_hostname
+++ b/changes/next/smtpclient_ehlo_hostname
@@ -1,0 +1,16 @@
+Description:
+
+Changes the SMTP client EHLO hostname from "localhost" to the `client_bind_name` config option, if set and enabled, or `servername` otherwise.
+
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+None
+
+GitHub issue:
+
+4960


### PR DESCRIPTION
Fixes #4960

Testing this manually is easy, but automated testing in Cassandane requires similar changes to the ones for https://github.com/cyrusimap/cyrus-imapd/pull/4956.