### PR TITLE
cassandane: support multiple output formats per run

### DIFF
--- a/cassandane/Cassandane/Unit/FormatPretty.pm
+++ b/cassandane/Cassandane/Unit/FormatPretty.pm
@@ -37,12 +37,12 @@
 #  OF THIS SOFTWARE.
 #
 
-package Cassandane::Unit::RunnerPretty;
+package Cassandane::Unit::FormatPretty;
 use strict;
 use warnings;
 
 use lib '.';
-use base qw(Cassandane::Unit::Runner);
+use base qw(Cassandane::Unit::Formatter);
 
 sub new
 {
@@ -66,7 +66,7 @@ sub new
 sub ansi
 {
     my ($self, $codes, @args) = @_;
-    my $isatty = -t $self->print_stream;
+    my $isatty = -t $self->{fh};
 
     my $ansi;
 
@@ -75,13 +75,6 @@ sub ansi
     $ansi .= "\e[0m" if $isatty;
 
     return $ansi;
-}
-
-sub start_test
-{
-    my $self = shift;
-    my $test = shift;
-    # prevent the default action which is to print "."
 }
 
 sub add_pass
@@ -100,8 +93,6 @@ sub add_error
     my $self = shift;
     my $test = shift;
 
-    $self->record_failed($test);
-
     my $line = sprintf "%s %s\n",
                        $self->ansi([31], '[ERROR ]'),
                        _getname($test);
@@ -113,7 +104,6 @@ sub add_failure
     my $self = shift;
     my $test = shift;
 
-    $self->record_failed($test);
     my $line = sprintf "%s %s\n",
                        $self->ansi([33], '[FAILED]'),
                        _getname($test);
@@ -149,8 +139,8 @@ sub print_errors
     my $saved_output_stream;
     if ($self->{_quiet}) {
         if ($self->{_quiet_report_fh}) {
-            $saved_output_stream = $self->{_Print_stream};
-            $self->{_Print_stream} = $self->{_quiet_report_fh};
+            $saved_output_stream = $self->{fh};
+            $self->{fh} = $self->{_quiet_report_fh};
         }
         else {
             return;
@@ -178,7 +168,7 @@ sub print_errors
     }
 
     if ($saved_output_stream) {
-        $self->{_Print_stream} = $saved_output_stream;
+        $self->{fh} = $saved_output_stream;
     }
 }
 
@@ -189,8 +179,8 @@ sub print_failures
     my $saved_output_stream;
     if ($self->{_quiet}) {
         if ($self->{_quiet_report_fh}) {
-            $saved_output_stream = $self->{_Print_stream};
-            $self->{_Print_stream} = $self->{_quiet_report_fh};
+            $saved_output_stream = $self->{fh};
+            $self->{fh} = $self->{_quiet_report_fh};
         }
         else {
             return;
@@ -218,7 +208,7 @@ sub print_failures
     }
 
     if ($saved_output_stream) {
-        $self->{_Print_stream} = $saved_output_stream;
+        $self->{fh} = $saved_output_stream;
     }
 }
 

--- a/cassandane/Cassandane/Unit/FormatXML.pm
+++ b/cassandane/Cassandane/Unit/FormatXML.pm
@@ -37,7 +37,7 @@
 #  OF THIS SOFTWARE.
 #
 
-package Cassandane::Unit::RunnerXML;
+package Cassandane::Unit::FormatXML;
 use strict;
 use warnings;
 use vars qw($VERSION);
@@ -48,9 +48,8 @@ use Sys::Hostname;
 use POSIX qw(strftime);
 
 use lib '.';
-use base qw(Cassandane::Unit::Runner);
+use base qw(Cassandane::Unit::Formatter);
 
-# $Id: XML.pm 27 2004-08-24 11:22:24Z andrew $
 $VERSION = '0.1';
 
 sub new {
@@ -66,17 +65,6 @@ sub new {
     $self->{classrecs} = {};
 
     return $self;
-}
-
-sub do_run {
-    my ($self, $suite) = @_;
-
-    my $result = $self->create_test_result();
-    $result->add_listener($self);
-    my $start_time = time();
-    $suite->run($result, $self);
-    $self->_emit_xml();
-    return $result->was_successful;
 }
 
 sub _classrec {
@@ -96,8 +84,6 @@ sub _testrec {
     return $cr->{testrecs}->{$test->name()} ||=
                 { start_time => 0, node => undef, child_nodes => [] };
 }
-
-sub add_pass {}
 
 sub _extype
 {
@@ -194,6 +180,16 @@ sub _emit_xml {
     }
 }
 
+sub finished
+{
+    my ($self, $result, $start_time, $end_time) = @_;
+
+    # XXX This class does all its own accounting, which is probably
+    # XXX redundant since it doesn't report anything that it couldn't
+    # XXX just get from the usual $result/$start_time/$end_time args.
+    $self->_emit_xml();
+}
+
 sub _xml_filename {
     my ($self, $class) = @_;
 
@@ -202,72 +198,3 @@ sub _xml_filename {
 }
 
 1;
-
-__END__
-
-
-=head1 NAME
-
-Test::Unit::Runner::XML - Generate XML reports from unit test results
-
-=head1 SYNOPSIS
-
-    use Test::Unit::Runner::XML;
-
-    mkdir("test_reports");
-    my $runner = Test::Unit::Runner::XML->new("test-reports");
-    $runner->start($test);
-    exit(!$runner->all_tests_passed());
-
-=head1 DESCRIPTION
-
-Test::Unit::Runner::XML generates XML reports from unit test results. The
-reports are in the same format as those produced by Ant's JUnit task,
-allowing them to be used with Java continuous integration and reporting tools.
-
-=head1 CONSTRUCTOR
-
-    Test::Unit::Runner::XML->new($directory)
-
-Construct a new runner that will write XML reports into $directory
-
-=head1 METHODS
-
-=head2 start
-
-    $runner->start($test);
-
-Run the L<Test::Unit::Test> $test and generate XML reports from the results.
-
-=head2 all_tests_passed
-
-    exit(!$runner->all_tests_passed());
-
-Return true if all tests executed by $runner since it was constructed passed.
-
-=head1 AUTHOR
-
-Copyright (c) 2004 Andrew Eland, E<lt>andrew@andreweland.orgE<gt>.
-
-All rights reserved. This program is free software; you can
-redistribute it and/or modify it under the same terms as Perl itself.
-
-=head1 SEE ALSO
-
-=over 4
-
-=item *
-
-L<Test::Unit>
-
-=item *
-
-L<Test::Unit::TestRunner>
-
-=item *
-
-The Ant JUnit task, http://ant.apache.org/
-
-=cut
-
-

--- a/cassandane/Cassandane/Unit/Formatter.pm
+++ b/cassandane/Cassandane/Unit/Formatter.pm
@@ -1,0 +1,185 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2011-2017 FastMail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Unit::Formatter;
+use strict;
+use warnings;
+
+use base 'Test::Unit::Listener';
+use Benchmark;
+use IO::Handle;
+
+sub new
+{
+    my ($class, $fh) = @_;
+
+    $fh //= \*STDOUT;
+    $fh->autoflush(1);
+
+    return bless {
+        remove_me_in_cassandane_child => 1,
+        fh => $fh,
+    }, $class;
+}
+
+sub _print
+{
+    my ($self, @args) = @_;
+    $self->{fh}->print(@args);
+}
+
+# No-op implementations of Listener interface.  To create a new output
+# format, subclass from this and override the appropriate event handlers
+
+sub start_suite
+{
+    my ($self, $suite) = @_;
+}
+
+sub start_test
+{
+    my ($self, $test) = @_;
+}
+
+sub add_pass
+{
+    my ($self, $test) = @_;
+}
+
+sub add_error
+{
+    my ($self, $test, $exception) = @_;
+}
+
+sub add_failure
+{
+    my ($self, $test, $exception) = @_;
+}
+
+sub end_test
+{
+    my ($self, $test) = @_;
+}
+
+# Override this with your output format's end-of-tests handling.  The
+# default is to print a summary.
+sub finished
+{
+    my ($self, $result, $start_time, $end_time) = @_;
+    $self->print_summary($result, $start_time, $end_time);
+}
+
+# Override this, and/or subs print_header, print_errors, print_failures
+# to change how the summary is presented.
+sub print_summary
+{
+    my ($self, $result, $start_time, $end_time) = @_;
+
+    my $run_time = timediff($end_time, $start_time);
+    print "\n", "Time: ", timestr($run_time), "\n";
+
+    $self->print_header($result);
+    $self->print_errors($result);
+    $self->print_failures($result);
+}
+
+sub print_header
+{
+    my ($self, $result) = @_;
+
+    if ($result->was_successful()) {
+        $self->_print("\n", "OK", " (", $result->run_count(), " tests)\n");
+    }
+    else {
+        $self->_print("\n", "!!!FAILURES!!!", "\n",
+                      "Test Results:\n",
+                      "Run: ", $result->run_count(),
+                      ", Failures: ", $result->failure_count(),
+                      ", Errors: ", $result->error_count(),
+                      "\n");
+    }
+}
+
+sub print_errors
+{
+    my ($self, $result) = @_;
+
+    return unless my $error_count = $result->error_count();
+
+    my $msg = "\nThere " .
+              ($error_count == 1 ?
+                "was 1 error"
+              : "were $error_count errors") .
+              ":\n";
+    $self->_print($msg);
+
+    my $i = 0;
+    for my $e (@{$result->errors()}) {
+        chomp(my $e_to_str = $e);
+        $i++;
+        $self->_print("$i) $e_to_str\n");
+        $self->_print("\nAnnotations:\n", $e->object->annotations())
+          if $e->object->annotations();
+    }
+}
+
+sub print_failures
+{
+    my ($self, $result) = @_;
+
+    return unless my $failure_count = $result->failure_count;
+
+    my $msg = "\nThere " .
+              ($failure_count == 1 ?
+                "was 1 failure"
+              : "were $failure_count failures") .
+              ":\n";
+    $self->_print($msg);
+
+    my $i = 0;
+    for my $f (@{$result->failures()}) {
+        chomp(my $f_to_str = $f);
+        $self->_print("\n") if $i++;
+        $self->_print("$i) $f_to_str\n");
+        $self->_print("\nAnnotations:\n", $f->object->annotations())
+          if $f->object->annotations();
+    }
+}
+
+1;

--- a/cassandane/Cassandane/Unit/Runner.pm
+++ b/cassandane/Cassandane/Unit/Runner.pm
@@ -78,6 +78,19 @@ sub add_formatter
     push @{$self->{formatters}}, $formatter;
 }
 
+# this is very similar to Test::Unit::Result's tell_listeners(), except
+# without the annoying crash when the listener doesn't care about the event
+sub tell_formatters
+{
+    my ($self, $method, @args) = @_;
+
+    foreach my $formatter (@{$self->{formatters}}) {
+        if ($formatter->can($method)) {
+            $formatter->$method(@args);
+        }
+    }
+}
+
 sub do_run
 {
     my ($self, $suite) = @_;

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -202,15 +202,16 @@ eval
         my ($plan, $fh) = @_;
         local *__ANON__ = "runner_xml";
 
-        my $runner = Cassandane::Unit::RunnerXML->new($output_dir);
+        my $runner = Cassandane::Unit::RunnerXML->new({
+            directory => $output_dir
+        });
         my @filters = qw(x skip_version skip_missing_features
                          skip_runtime_check
                          enable_wanted_properties);
         push @filters, 'skip_slow' if $plan->{skip_slow};
         push @filters, 'slow_only' if $plan->{slow_only};
         $runner->filter(@filters);
-        $runner->start($plan);
-        return $runner->all_tests_passed();
+        return $runner->do_run($plan, 0);
     };
 };
 if ($@) {


### PR DESCRIPTION
This adds support to Cassandane for producing multiple formats of output from a single run, as long as they won't be fighting over stdout.  In practice, this means "tap", "pretty", and "prettier" still cannot be used together, but "xml" can be used alongside any of them.  This will become more useful if we add more non-stdout formats in the future (perhaps "json"), but this PR doesn't do that.

There's a bunch of internal architectural changes here, but the main outwardly-visible one should be that you can now specify the `-f <format>` argument to testrunner.pl multiple times.  The other is that the `--rerun` behaviour after test failures now works independently of output format(s).

**Reviewers**: Please pull this branch and run Cassandane in any of the ways you usually would.  If you can test this in an FM inabox or build system setup, even better.  I'm confident that I haven't broken any of my own use cases, but less confident about use cases I don't use myself.  The diff probably makes the most sense when read commit-by-commit.