### PR TITLE
smtpclient.c: use config_servername rather than IMAPOPT value

### DIFF
--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -729,11 +729,6 @@ sub _generate_imapd_conf
                 smtp_backend => 'host',
                 smtp_host => $self->{smtphost},
             );
-            if (not defined $config->get("servername")) {
-                # smtpclient needs client_bind_name or servername,
-                # falls back to servername if client_bind isn't set.
-                $config->set(servername => "127.0.0.1");
-            }
         }
     }
     else {

--- a/imap/smtpclient.c
+++ b/imap/smtpclient.c
@@ -152,7 +152,7 @@ EXPORTED int smtpclient_open(smtpclient_t **smp)
                 config_getstring(IMAPOPT_CLIENT_BIND_NAME);
         }
         if (!smtpclient_ehlo_hostname) {
-            smtpclient_ehlo_hostname = config_getstring(IMAPOPT_SERVERNAME);
+            smtpclient_ehlo_hostname = config_servername;
         }
         if (!smtpclient_ehlo_hostname) {
             xsyslog(LOG_ERR,


### PR DESCRIPTION
Follow-up to https://github.com/cyrusimap/cyrus-imapd/pull/4966#pullrequestreview-2173261124