### PR TITLE
misc: fix warnings with -O3

### DIFF
--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -177,15 +177,17 @@ sub test_recover_uniqueid_from_header_legacymb
     # ctl_cyrusdb -r should find and fix the missing uniqueid
     $self->{instance}->getsyslog();
     $self->{instance}->start();
-    my $syslog = join(q{}, $self->{instance}->getsyslog());
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my $syslog = join(q{}, $self->{instance}->getsyslog());
 
-    # should have still existed in cyrus.header
-    $self->assert_does_not_match(
-        qr{mailbox header had no uniqueid, creating one}, $syslog);
+        # should have still existed in cyrus.header
+        $self->assert_does_not_match(
+            qr{mailbox header had no uniqueid, creating one}, $syslog);
 
-    # expect to find the log line
-    $self->assert_matches(qr{mbentry had no uniqueid, setting from header},
-                          $syslog);
+        # expect to find the log line
+        $self->assert_matches(qr{mbentry had no uniqueid, setting from header},
+                              $syslog);
+    }
 
     # header should have the same uniqueid as before
     my $cyrus_header = $self->{instance}->folder_to_directory('INBOX')
@@ -274,15 +276,17 @@ sub test_recover_create_missing_uniqueid_legacymb
     # ctl_cyrusdb -r should find and fix the missing uniqueid
     $self->{instance}->getsyslog();
     $self->{instance}->start();
-    my $syslog = join(q{}, $self->{instance}->getsyslog());
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my $syslog = join(q{}, $self->{instance}->getsyslog());
 
-    # expect to find it was missing in the header
-    $self->assert_matches(qr{mailbox header had no uniqueid, creating one},
-                          $syslog);
+        # expect to find it was missing in the header
+        $self->assert_matches(qr{mailbox header had no uniqueid, creating one},
+                              $syslog);
 
-    # expect to find it was missing from mbentry
-    $self->assert_matches(qr{mbentry had no uniqueid, setting from header},
-                          $syslog);
+        # expect to find it was missing from mbentry
+        $self->assert_matches(qr{mbentry had no uniqueid, setting from header},
+                              $syslog);
+    }
 
     # should not be the same uniqueid as before
     $imaptalk = $self->{store}->get_client();

--- a/cassandane/Cassandane/Cyrus/Delivery.pm
+++ b/cassandane/Cassandane/Cyrus/Delivery.pm
@@ -567,13 +567,16 @@ sub test_auditlog_size
     $self->check_messages(\%msgs, check_guid => 0, keyed_on => 'uid');
 
     xlog $self, "Check the correct size was auditlogged";
-    my @appends = $self->{instance}->getsyslog(qr/auditlog: append .* uid=<1>/);
-    $self->assert_num_equals(1, scalar @appends);
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my @appends = $self->{instance}->getsyslog(
+            qr/auditlog: append .* uid=<1>/);
+        $self->assert_num_equals(1, scalar @appends);
 
-    # delivery will add some headers, so it will be larger
-    my $expected_size = $msgs{1}->size();
-    my ($actual_size) = $appends[0] =~ m/ size=<([0-9]+)>/;
-    $self->assert_num_gte($expected_size, $actual_size);
+        # delivery will add some headers, so it will be larger
+        my $expected_size = $msgs{1}->size();
+        my ($actual_size) = $appends[0] =~ m/ size=<([0-9]+)>/;
+        $self->assert_num_gte($expected_size, $actual_size);
+    }
 }
 
 1;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1250,6 +1250,9 @@ sub start
         }
     }
 
+    $self->{buildinfo} = Cassandane::BuildInfo->new($self->{cyrus_destdir},
+                                                    $self->{cyrus_prefix});
+
     if (!$self->{re_use_dir} || ! -d $self->{basedir})
     {
         $created = 1;
@@ -1257,8 +1260,6 @@ sub start
         $self->_build_skeleton();
         # TODO: system("echo 1 >/proc/sys/kernel/core_uses_pid");
         # TODO: system("echo 1 >/proc/sys/fs/suid_dumpable");
-        $self->{buildinfo} = Cassandane::BuildInfo->new($self->{cyrus_destdir},
-                                                        $self->{cyrus_prefix});
 
         # the main imapd.conf
         $self->_generate_imapd_conf($self->{config});
@@ -2318,6 +2319,13 @@ sub setup_syslog_replacement
 
     if (not(-e 'utils/syslog.so') || not(-e 'utils/syslog_probe')) {
         xlog "utils/syslog.so not found (do you need to run 'make'?)";
+        xlog "tests will not examine syslog output";
+        $self->{have_syslog_replacement} = 0;
+        return;
+    }
+
+    if ($self->{buildinfo}->get('version', 'FORTIFY_LEVEL')) {
+        xlog "Cyrus was built with -D_FORTIFY_SOURCE";
         xlog "tests will not examine syslog output";
         $self->{have_syslog_replacement} = 0;
         return;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1145,7 +1145,8 @@ sub _start_smtpd
             my $self = shift;
             xlog "killing smtpd $smtppid";
             kill(15, $smtppid);
-            waitpid($smtppid, 0);
+            my $r = waitpid($smtppid, 0);
+            xlog "waitpid $smtppid returned $r";
         };
     }
     else {

--- a/cassandane/tiny-tests/JMAPEmail/searchsnippet_search_maxsize
+++ b/cassandane/tiny-tests/JMAPEmail/searchsnippet_search_maxsize
@@ -30,8 +30,10 @@ EOF
     xlog "Assert indexer only processes maxsize bytes of text";
     $self->{instance}->getsyslog(); # clear syslog
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
-    my @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
-    $self->assert_num_equals(1, scalar @lines);
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
+        $self->assert_num_equals(1, scalar @lines);
+    }
 
     my $res = $jmap->CallMethods([
         ['Email/query', {
@@ -62,8 +64,10 @@ EOF
         }, 'R3'],
     ]);
     $self->assert_not_null($res->[0][1]{list}[0]{preview});
-    @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
-    $self->assert_num_equals(1, scalar @lines);
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
+        $self->assert_num_equals(1, scalar @lines);
+    }
 
     xlog "Assert snippet generator only processes maxsize bytes of text";
     $self->{instance}->getsyslog(); # clear syslog
@@ -76,6 +80,8 @@ EOF
         }, 'R3'],
     ]);
     $self->assert_null($res->[0][1]{list}[0]{preview});
-    @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
-    $self->assert_num_equals(1, scalar @lines);
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my @lines = $self->{instance}->getsyslog(qr/Xapian: truncating/);
+        $self->assert_num_equals(1, scalar @lines);
+    }
 }

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_nolock
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_nolock
@@ -44,22 +44,31 @@ sub test_squatter_attachextract_nolock
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v');
 
     xlog $self, "Inspect syslog and extractor trace files";
-    my @log = $self->{instance}->getsyslog(qr/squatter\[\d+\]: (released|reacquired) mailbox lock/);
+    my $released_timestamp = undef;
+    my $reacquired_timestamp = undef;
+    if ($self->{instance}->{have_syslog_replacement}) {
+        my @log = $self->{instance}->getsyslog(
+            qr/squatter\[\d+\]: (released|reacquired) mailbox lock/);
 
-    my ($released_timestamp) = ($log[0] =~ /released.+unixepoch=<(\d+)>/);
-    $self->assert_not_null($released_timestamp);
+        ($released_timestamp) = ($log[0] =~ /released.+unixepoch=<(\d+)>/);
+        $self->assert_not_null($released_timestamp);
+
+        ($reacquired_timestamp) = ($log[1] =~ /reacquired.+unixepoch=<(\d+)>/);
+        $self->assert_not_null($reacquired_timestamp);
+    }
 
     my @tracefiles = glob($tracedir."/*_PUT_*");
     $self->assert_num_equals(1, scalar @tracefiles);
     my $extractor_timestamp = stat($tracefiles[0])->ctime;
     $self->assert_not_null($extractor_timestamp);
 
-    my ($reacquired_timestamp) = ($log[1] =~ /reacquired.+unixepoch=<(\d+)>/);
-    $self->assert_not_null($reacquired_timestamp);
-
     xlog $self, "Assert extractor got called without mailbox lock";
-    $self->assert_num_lt($extractor_timestamp, $released_timestamp);
-    $self->assert_num_lt($reacquired_timestamp, $extractor_timestamp);
+    if (defined $released_timestamp) {
+        $self->assert_num_lt($extractor_timestamp, $released_timestamp);
+    }
+    if (defined $reacquired_timestamp) {
+        $self->assert_num_lt($reacquired_timestamp, $extractor_timestamp);
+    }
 
     xlog $self, "Assert terms actually got indexed";
     my $uids = $imap->search('fuzzy', 'body', 'bodyterm');

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -347,6 +347,14 @@ static json_t *buildinfo()
     json_object_set_new(version, "ZONEINFO_VERSION",
                                  json_integer(ZONEINFO_VERSION));
 
+#if defined __USE_FORTIFY_LEVEL && __USE_FORTIFY_LEVEL > 0
+    json_object_set_new(version, "FORTIFY_LEVEL",
+                                 json_integer(__USE_FORTIFY_LEVEL));
+#else
+    json_object_set_new(version, "FORTIFY_LEVEL",
+                                 json_integer(0));
+#endif
+
     /* Whew ... */
     return buildconf;
 }

--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -243,7 +243,7 @@ static int frame_recv_cb(nghttp2_session *session,
 
         buf_reset(logbuf);
         buf_printf(logbuf, "<" TIME_T_FMT "<", time(NULL));   /* timestamp */
-        write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
+        retry_write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
     }
 
     switch (frame->hd.type) {
@@ -257,7 +257,7 @@ static int frame_recv_cb(nghttp2_session *session,
                 spool_enum_hdrcache(txn->req_hdrs,            /* header fields */
                                     &log_cachehdr, logbuf);
                 buf_appendcstr(logbuf, "\r\n");               /* CRLF */
-                write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
+                retry_write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
             }
 
             /* Examine request */
@@ -302,8 +302,8 @@ static int frame_recv_cb(nghttp2_session *session,
 
         if (txn->conn->logfd != -1) {
             /* telemetry log */
-            write(txn->conn->logfd, buf_base(&txn->req_body.payload),
-                  buf_len(&txn->req_body.payload));
+            retry_write(txn->conn->logfd, buf_base(&txn->req_body.payload),
+                        buf_len(&txn->req_body.payload));
         }
 
         if (txn->meth != METH_CONNECT) {
@@ -584,7 +584,7 @@ static void begin_resp_headers(struct transaction_t *txn, long code)
 
         buf_reset(logbuf);
         buf_printf(logbuf, ">" TIME_T_FMT ">", time(NULL));  /* timestamp */
-        write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
+        retry_write(txn->conn->logfd, buf_base(logbuf), buf_len(logbuf));
     }
 
     if (code) simple_hdr(txn, ":status", "%.3s", error_message(code));
@@ -627,7 +627,7 @@ static void add_resp_header(struct transaction_t *txn,
             }
             WRITEV_ADD_TO_IOVEC(iov, niov, nv->value, nv->valuelen);
             WRITEV_ADD_TO_IOVEC(iov, niov, "\r\n", 2);
-            writev(txn->conn->logfd, iov, niov);
+            retry_writev(txn->conn->logfd, iov, niov);
         }
     }
 }
@@ -646,7 +646,7 @@ static int end_resp_headers(struct transaction_t *txn, long code)
 
     if (txn->conn->logfd != -1) {
         /* telemetry log */
-        write(txn->conn->logfd, "\r\n", 2);
+        retry_write(txn->conn->logfd, "\r\n", 2);
     }
 
     switch (code) {
@@ -744,7 +744,7 @@ static int resp_body_chunk(struct transaction_t *txn,
         WRITEV_ADD_TO_IOVEC(iov, niov,
                             buf_base(logbuf), buf_len(logbuf));
         WRITEV_ADD_TO_IOVEC(iov, niov, data, datalen);
-        writev(txn->conn->logfd, iov, niov);
+        retry_writev(txn->conn->logfd, iov, niov);
     }
 
     /* NOTE: The protstream that we use as the data source MUST remain

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -3035,7 +3035,7 @@ HIDDEN void log_request(long code, struct transaction_t *txn)
 EXPORTED void response_header(long code, struct transaction_t *txn)
 {
     int i, size;
-    time_t now;
+    time_t now = 0;
     char datestr[30];
     const char **hdr;
     struct auth_challenge_t *auth_chal = &txn->auth_chal;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -398,7 +398,7 @@ static struct capa_struct base_capabilities[] = {
     { "ACL",                   CAPA_POSTAUTH,           { 0 } }, /* RFC 4314 */
     { "ANNOTATE-EXPERIMENT-1", CAPA_POSTAUTH,           { 0 } }, /* RFC 5257 */
     { "APPENDLIMIT=",          CAPA_POSTAUTH|CAPA_VALUE,         /* RFC 7889 */
-      { .value = { "%2$" PRIi64, .i64p = &maxmsgsize } }      },
+      { .value = { "%1$s%2$" PRIi64, .i64p = &maxmsgsize } }  },
     { "AUTH=",                 CAPA_OMNIAUTH|CAPA_COMPLEX,       /* RFC 9051 */
       { .complex = &capa_auth }                               },
     { "BINARY",                CAPA_POSTAUTH,           { 0 } }, /* RFC 3516 */

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -795,7 +795,7 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
     if (jmap_wantprop(rock->get->props, "defaultAlertsWithTime") ||
         jmap_wantprop(rock->get->props, "defaultAlertsWithoutTime")) {
 
-        json_t *with_time, *without_time;
+        json_t *with_time = NULL, *without_time = NULL;
         getcalendar_defaultalerts(mbentry->name, req->userid,
                 &with_time, &without_time);
 

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -598,20 +598,24 @@ static int do_compare(struct findall_data *data, void *rock)
             r = record ? mailbox_cacherecord(mailbox, record) : -1;
 
             citem = r ? &empty_buf : cacheitem_buf(record, CACHE_FROM);
-            printf("   From: %-50.*s", (int) MIN(citem->len, 50), citem->s);
+            printf("   From: %-50.*s",
+                   (int) MIN(buf_len(citem), 50), buf_cstring(citem));
 
             if (fs_record.uid && !message_guid_isnull(&fs_record.guid)) {
                 citem = cacheitem_buf(&fs_record, CACHE_FROM);
-                printf("\t%-50.*s", (int) MIN(citem->len, 50), citem->s);
+                printf("\t%-50.*s",
+                       (int) MIN(buf_len(citem), 50), buf_cstring(citem));
             }
             printf("\n");
 
             citem = r ? &empty_buf : cacheitem_buf(record, CACHE_SUBJECT);
-            printf("   Subj: %-50.*s", (int) MIN(citem->len, 50), citem->s);
+            printf("   Subj: %-50.*s",
+                   (int) MIN(buf_len(citem), 50), buf_cstring(citem));
 
             if (fs_record.uid && !message_guid_isnull(&fs_record.guid)) {
                 citem = cacheitem_buf(&fs_record, CACHE_SUBJECT);
-                printf("\t%-50.*s", (int) MIN(citem->len, 50), citem->s);
+                printf("\t%-50.*s",
+                       (int) MIN(buf_len(citem), 50), buf_cstring(citem));
             }
             printf("\n");
             printf("\n");

--- a/imap/vcard_support.c
+++ b/imap/vcard_support.c
@@ -184,7 +184,7 @@ static size_t _prop_decode_value(const char *data,
 
         for (sig = image_signatures; sig->mediatype; sig++) {
             int i;
-            for (i = 0; sig->magic[i].len && i < 2; i++) {
+            for (i = 0; i < 2 && sig->magic[i].len; i++) {
                 if (size - sig->magic[i].offset <= sig->magic[i].len ||
                     memcmp(decbuf + sig->magic[i].offset,
                            sig->magic[i].data, sig->magic[i].len)) {


### PR DESCRIPTION
There's a bunch of compiler warnings that aren't detected unless certain optimisations are being performed.  This PR fixes the warnings that turn up for me using GCC 12.2.0-14 on Debian Bookworm when compiling with `-O3` in CFLAGS and CXXFLAGS.  If you have a newer compiler to try with, it might find more.