### PR TITLE
message.c: decode Subject header before comparing with conversations

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -67,7 +67,7 @@ sub new
     $config->set(caldav_historical_age => -1,
                  caldav_realm => 'Cassandane',
                  conversations => 'yes',
-                 conversations_counted_flags => "\\Draft \\Flagged \$IsMailingList \$IsNotification \$HasAttachment",
+                 conversations_counted_flags => "\\Draft \\Flagged \$IsMailingList \$IsNotification \$HasAttachment \$muted",
                  defaultdomain => 'example.com',
                  httpallowcompress => 'no',
                  httpmodules => 'carddav caldav jmap',

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword_utf8_subject
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword_utf8_subject
@@ -1,0 +1,105 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_sieve_some_in_thread_have_keyword_utf8_subject
+  : needs_component_jmap : needs_component_sieve : NoMunge8Bit : RFC2047_UTF8 {
+    my ($self) = @_;
+    my $jmap   = $self->{jmap};
+    my $imap   = $self->{store}->get_client();
+
+    xlog $self, "Set up Sieve script";
+    $imap->create("matches") or die;
+    my $sieve = <<EOF;
+require ["x-cyrus-jmapquery", "x-cyrus-log", "variables", "fileinto"];
+if
+  allof( not string :is "\${stop}" "Y",
+    jmapquery text:
+    {
+      "someInThreadHaveKeyword": "\$muted"
+    }
+.
+  )
+{
+  fileinto "matches";
+}
+EOF
+    $self->{instance}->install_sieve_script($sieve);
+
+    xlog $self, "Create message with UTF-8 subject";
+    my $mime = <<'EOF';
+From: alice@local
+To: bob@local
+Subject: ¡Hola, señor!
+Message-ID: <1390d09d-60f7-4840-88a2-9f319024b156@local>
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;charset=us-ascii
+Content-Transfer-Encoding: 7bit
+
+hello
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    $imap->append('matches', $mime);
+
+    xlog $self, "Set keyword on message";
+    my $res     = $jmap->CallMethods([ [ 'Email/query', {}, 'R1' ] ]);
+    my $emailId = $res->[0][1]{ids}[0];
+    $self->assert_not_null($emailId);
+    $res = $jmap->CallMethods([ [
+        'Email/set',
+        {
+            update => {
+                $emailId => {
+                    'keywords/$muted' => JSON::true,
+                },
+            }
+        },
+        'R1'
+    ] ]);
+    $self->assert(exists $res->[0][1]{updated}{$emailId});
+
+    xlog $self, "Deliver reply with encoded UTF-8 subject";
+    my $mime = <<'EOF';
+From: bob@local
+To: alic@local
+Subject: =?utf-8?q?Re:_=C2=A1Hola,_se=C3=B1or!?=
+Message-ID: <0d7c0d81-f9b8-41aa-8d05-edd12deda48c@local>
+In-Reply-To: <1390d09d-60f7-4840-88a2-9f319024b156@local>
+Date: Mon, 13 Apr 2020 16:24:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain;charset=us-ascii
+Content-Transfer-Encoding: 7bit
+
+hi there!
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    my $msg = Cassandane::Message->new();
+    $msg->set_lines(split /\n/, $mime);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Assert that threadId and mailboxIds match";
+    $res = $jmap->CallMethods([
+        [ 'Email/query', {}, 'R1' ],
+        [
+            'Email/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    path     => '/ids',
+                    name     => 'Email/query',
+                },
+                properties => [ 'subject', 'mailboxIds', 'keywords', 'threadId' ],
+            },
+            'R2'
+        ],
+    ]);
+    $self->assert_num_equals(2, scalar @{ $res->[0][1]{ids} });
+    $self->assert_str_equals(
+        $res->[1][1]{list}[0]{threadId},
+        $res->[1][1]{list}[1]{threadId}
+    );
+    $self->assert_deep_equals(
+        $res->[1][1]{list}[0]{mailboxIds},
+        $res->[1][1]{list}[1]{mailboxIds}
+    );
+}

--- a/imap/message.c
+++ b/imap/message.c
@@ -3779,25 +3779,18 @@ static int extract_convdata(struct conversations_state *state,
         msubj_oldstyle = buf_release(&msubject);
     }
     else {
-        message_get_field(msg, "rawheaders", MESSAGE_DECODED, &buf);
-        char *c_subj = buf_release(&buf);
-        strarray_set(&want, 0, "subject");
-        message_pruneheader(c_subj, &want, 0);
-        if (!strncasecmp(c_subj, "subject:", 8)) {
-            size_t len = strlen(c_subj);
-            if (c_subj[len-1] == '\n')
-                c_subj[len-1] = '\0';
+        message_get_field(msg, "subject", MESSAGE_SNIPPET, &buf);
+        buf_trim(&buf);
+        if (buf_len(&buf)) {
+            struct buf tmp = BUF_INITIALIZER;
+            buf_copy(&tmp, &buf);
+            conversation_normalise_subject(&tmp);
+            msubj = buf_release(&tmp);
 
-            const char *subj = c_subj + 8;
-            buf_setcstr(&buf, subj);
-            conversation_normalise_subject(&buf);
-            msubj = buf_release(&buf);
-
-            buf_setcstr(&buf, subj);
-            oldstyle_normalise_subject(&buf);
-            msubj_oldstyle = buf_release(&buf);
+            buf_copy(&tmp, &buf);
+            oldstyle_normalise_subject(&tmp);
+            msubj_oldstyle = buf_release(&tmp);
         }
-        free(c_subj);
     }
     *msubjp = msubj;
 


### PR DESCRIPTION
Fixes a bug where the subject of a message without cache record is compared in its word-encoded form to the normalized conversation subject. This primarily impacted Sieve jmapquery filters using one of the thread keyword filter conditions.