### PR TITLE
prometheus: per-report update frequencies

### DIFF
--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -61,6 +61,7 @@ sub new
     $config->set(prometheus_need_auth => "none");
     $config->set(prometheus_service_update_freq => 2);
     $config->set(prometheus_master_update_freq => 2);
+    $config->set(prometheus_usage_update_freq => 2);
 
     return $class->SUPER::new(
         { adminstore => 1,

--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -133,7 +133,7 @@ sub test_aaasetup
     $self->assert(1);
 }
 
-sub test_reportfile_exists
+sub test_service_reportfile_exists
     :min_version_3_1 :needs_component_httpd
 {
     my ($self) = @_;
@@ -144,11 +144,11 @@ sub test_reportfile_exists
     # and wait for a fresh report
     sleep 3;
 
-    my $reportfile_name = "$self->{instance}->{basedir}/conf/stats/report.txt";
+    my $fname = "$self->{instance}->{basedir}/conf/stats/service.txt";
 
-    $self->assert_file_test($reportfile_name, '-f');
+    $self->assert_file_test($fname, '-f');
 
-    my $report = parse_report(scalar read_file $reportfile_name);
+    my $report = parse_report(scalar read_file $fname);
 
     $self->assert(scalar keys %{$report});
     $self->assert(exists $report->{cyrus_imap_connections_total});

--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -59,7 +59,8 @@ sub new
     $config->set(prometheus_enabled => "yes");
     $config->set(httpmodules => "prometheus");
     $config->set(prometheus_need_auth => "none");
-    $config->set(prometheus_update_freq => 2);
+    $config->set(prometheus_service_update_freq => 2);
+    $config->set(prometheus_master_update_freq => 2);
 
     return $class->SUPER::new(
         { adminstore => 1,

--- a/changes/next/prom-usage-stats
+++ b/changes/next/prom-usage-stats
@@ -8,11 +8,14 @@ Config changes:
 prometheus_update_freq
 prometheus_service_update_freq
 prometheus_master_update_freq
+prometheus_usage_update_freq
 
 
 Upgrade instructions:
 
-None yet (FIXME)
+The Prometheus usage report will be turned off by default after upgrade.
+This means that the "cyrus_usage_..." metrics will no longer be reported.
+To turn this back on, set prometheus_usage_update_freq to a suitable duration.
 
 
 GitHub issue:

--- a/changes/next/prom-usage-stats
+++ b/changes/next/prom-usage-stats
@@ -1,0 +1,20 @@
+Description:
+
+Increased granularity of Prometheus report frequency configuration.
+
+
+Config changes:
+
+prometheus_update_freq
+prometheus_service_update_freq
+prometheus_master_update_freq
+
+
+Upgrade instructions:
+
+None yet (FIXME)
+
+
+GitHub issue:
+
+None

--- a/docsrc/imap/reference/admin/monitoring.rst
+++ b/docsrc/imap/reference/admin/monitoring.rst
@@ -16,8 +16,9 @@ Setup
 
     * Set the `prometheus_enabled` setting in :cyrusman:`imapd.conf(5)` to "yes"
     * Add the `prometheus` module to your `httpmodules` in :cyrusman:`imapd.conf(5)`
-    * Set the `prometheus_need_auth`, `prometheus_update_freq` and `prometheus_stats_dir`
-      settings in :cyrusman:`imapd.conf(5)` to taste
+    * Set the `prometheus_need_auth`, `prometheus_service_update_freq`,
+      `prometheus_master_update_freq`, and `prometheus_stats_dir` settings in
+      :cyrusman:`imapd.conf(5)` to taste
     * Add a job to run :cyrusman:`promstatsd(8)` to the DAEMON section of
       :cyrusman:`cyrus.conf(5)` (the actual daemon process)
     * Add a job to run ``promstatsd -c`` to the START section of :cyrusman:`cyrus.conf(5)`
@@ -36,8 +37,12 @@ Configuration options
         :end-before: endblob prometheus_need_auth
 
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst
-        :start-after: startblob prometheus_update_freq
-        :end-before: endblob prometheus_update_freq
+        :start-after: startblob prometheus_service_update_freq
+        :end-before: endblob prometheus_service_update_freq
+
+    .. include:: /imap/reference/manpages/configs/imapd.conf.rst
+        :start-after: startblob prometheus_master_update_freq
+        :end-before: endblob prometheus_master_update_freq
 
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst
         :start-after: startblob prometheus_stats_dir

--- a/docsrc/imap/reference/admin/monitoring.rst
+++ b/docsrc/imap/reference/admin/monitoring.rst
@@ -17,8 +17,8 @@ Setup
     * Set the `prometheus_enabled` setting in :cyrusman:`imapd.conf(5)` to "yes"
     * Add the `prometheus` module to your `httpmodules` in :cyrusman:`imapd.conf(5)`
     * Set the `prometheus_need_auth`, `prometheus_service_update_freq`,
-      `prometheus_master_update_freq`, and `prometheus_stats_dir` settings in
-      :cyrusman:`imapd.conf(5)` to taste
+      `prometheus_master_update_freq`, `prometheus_usage_update_freq`, and
+      `prometheus_stats_dir` settings in :cyrusman:`imapd.conf(5)` to taste
     * Add a job to run :cyrusman:`promstatsd(8)` to the DAEMON section of
       :cyrusman:`cyrus.conf(5)` (the actual daemon process)
     * Add a job to run ``promstatsd -c`` to the START section of :cyrusman:`cyrus.conf(5)`
@@ -43,6 +43,10 @@ Configuration options
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst
         :start-after: startblob prometheus_master_update_freq
         :end-before: endblob prometheus_master_update_freq
+
+    .. include:: /imap/reference/manpages/configs/imapd.conf.rst
+        :start-after: startblob prometheus_usage_update_freq
+        :end-before: endblob prometheus_usage_update_freq
 
     .. include:: /imap/reference/manpages/configs/imapd.conf.rst
         :start-after: startblob prometheus_stats_dir

--- a/docsrc/imap/reference/manpages/systemcommands/promstatsd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/promstatsd.rst
@@ -36,11 +36,13 @@ the "/metrics" URL, if "prometheus" has been set in **httpmodules** in
 **promstatsd** |default-conf-text|
 
 In the first synopsis, **promstatsd** will run as a daemon, updating the
-service report at the specified *service-frequency*.  If the optional
-**-f** *service-frequency* argument is not provided, the
-**prometheus_service_update_freq** from :cyrusman:`imapd.conf(5)` will be used,
-which defaults to 10 seconds.  This invocation should be run from the DAEMON
-section of :cyrusman:`cyrus.conf(5)` (see :ref:`promstatsd-examples` below).
+service and (optionally) usage reports at the frequencies set by the
+**prometheus_service_update_freq** and **prometheus_usage_update_freq**
+:cyrusman:`imapd.conf(5)` options, which default to 10s and disabled,
+respectively.  The optional **-f** *service-frequency* argument can be used to
+override **prometheus_service_update_freq**.  This invocation should be run
+from the DAEMON section of :cyrusman:`cyrus.conf(5)` (see
+:ref:`promstatsd-examples` below).
 
 In the second synopsis, **promstatsd** will clean up all statistics files and
 exit.  The statistics Cyrus maintains are only valid while Cyrus is running,
@@ -48,7 +50,7 @@ so this invocation must be run from the START section of
 :cyrusman:`cyrus.conf(5)` (see :ref:`promstatsd-examples` below) to clean up
 after the previous run, before new service processes are started.
 
-In the third synopsis, **promstatsd** will immediately update the report
+In the third synopsis, **promstatsd** will immediately update the report(s)
 once, and then exit.  This can be safely used while another **promstatsd**
 process runs in daemon form.  It is useful if you need to update the report
 *now* for some reason, rather than waiting for the daemon's next update.
@@ -69,7 +71,7 @@ Options
 
 .. option:: -1
 
-    Update the report once and exit.
+    Update the report(s) once and exit.
 
 .. option:: -c
 

--- a/docsrc/imap/reference/manpages/systemcommands/promstatsd.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/promstatsd.rst
@@ -13,7 +13,7 @@ Synopsis
 
 .. parsed-literal::
 
-    **promstatsd** [ **-C** *config-file* ] [ **-v** ] [ **-f** *frequency* ] [ **-d** ]
+    **promstatsd** [ **-C** *config-file* ] [ **-v** ] [ **-f** *service-frequency* ] [ **-d** ]
 
     **promstatsd** [ **-C** *config-file* ] [ **-v** ] **-c**
 
@@ -36,11 +36,11 @@ the "/metrics" URL, if "prometheus" has been set in **httpmodules** in
 **promstatsd** |default-conf-text|
 
 In the first synopsis, **promstatsd** will run as a daemon, updating the
-report at the specified *frequency*.  If the optional **-f** *frequency*
-argument is not provided, the **prometheus_update_freq** from
-:cyrusman:`imapd.conf(5)` will be used, which defaults to 10 seconds.  This
-invocation should be run from the DAEMON section of :cyrusman:`cyrus.conf(5)`
-(see :ref:`promstatsd-examples` below).
+service report at the specified *service-frequency*.  If the optional
+**-f** *service-frequency* argument is not provided, the
+**prometheus_service_update_freq** from :cyrusman:`imapd.conf(5)` will be used,
+which defaults to 10 seconds.  This invocation should be run from the DAEMON
+section of :cyrusman:`cyrus.conf(5)` (see :ref:`promstatsd-examples` below).
 
 In the second synopsis, **promstatsd** will clean up all statistics files and
 exit.  The statistics Cyrus maintains are only valid while Cyrus is running,
@@ -80,11 +80,11 @@ Options
     Debug mode -- **promstatsd** will not background itself, for aid in
     debugging.
 
-.. option:: -f frequency
+.. option:: -f service-frequency
 
-    Update the report every *frequency* seconds.  If not specified, the
-    **prometheus_update_freq** from :cyrusman:`imapd.conf(5)` will be used,
-    which defaults to 10 seconds.
+    Update the service report every *service-frequency* seconds.  If not
+    specified, the **prometheus_service_update_freq** from
+    :cyrusman:`imapd.conf(5)` will be used, which defaults to 10 seconds.
 
 .. option:: -v
 

--- a/imap/prometheus.h
+++ b/imap/prometheus.h
@@ -52,8 +52,9 @@
 
 #include "imap/promdata.h"
 
-#define FNAME_PROM_REPORT "report.txt"
+#define FNAME_PROM_SERVICE_REPORT "service.txt"
 #define FNAME_PROM_MASTER_REPORT "master.txt"
+#define FNAME_PROM_USAGE_REPORT "usage.txt"
 #define FNAME_PROM_DONEPROCS "doneprocs"
 #define FNAME_PROM_STATS_DIR "/stats"
 

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -741,7 +741,7 @@ int main(int argc, char **argv)
     }
 
     if (frequency <= 0)
-        frequency = config_getduration(IMAPOPT_PROMETHEUS_UPDATE_FREQ, 's');
+        frequency = config_getduration(IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ, 's');
     if (frequency <= 0)
         frequency = 10;
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2156,17 +2156,26 @@ If all partitions are over that limit, this feature is not used anymore.
    used. */
 
 { "prometheus_enabled", 0, SWITCH, "3.1.2" }
-/* Whether tracking of service metrics for Prometheus is enabled. */
+/* Whether tracking of metrics for Prometheus is enabled. */
 
 { "prometheus_need_auth", "admin", STRINGLIST("none", "user", "admin"), "3.1.2" }
 /* Authentication level required to fetch Prometheus metrics. */
 
-{ "prometheus_update_freq", "10s", DURATION, "3.1.8" }
-/* Frequency in at which promstatsd should re-collate its statistics
-   report.  The minimum value is 1 second.
+{ "prometheus_update_freq", "10s", DURATION, "3.1.8", "UNRELEASED", "prometheus_service_update_freq" }
+/* Deprecated in favour of \fIprometheus_service_update_freq\fR
+   and \fIprometheus_master_update_freq\fR */
+
+{ "prometheus_service_update_freq", "10s", DURATION, "UNRELEASED" }
+/* Frequency in at which promstatsd should re-collate its service
+   statistics report.  The minimum value is 1 second.
 .PP
-   For backward compatibility, if no unit is specified, seconds is
-   assumed. */
+   If no unit is specified, seconds is assumed. */
+
+{ "prometheus_master_update_freq", NULL, DURATION, "UNRELEASED" }
+/* Frequency in at which master should re-collate its statistics report.
+   If not set, \fIprometheus_service_update_freq\fR is used.
+.PP
+   If no unit is specified, seconds is assumed. */
 
 { "prometheus_stats_dir", NULL, STRING, "3.1.2" }
 /* Directory to use for gathering prometheus statistics.  If specified,

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2162,8 +2162,9 @@ If all partitions are over that limit, this feature is not used anymore.
 /* Authentication level required to fetch Prometheus metrics. */
 
 { "prometheus_update_freq", "10s", DURATION, "3.1.8", "UNRELEASED", "prometheus_service_update_freq" }
-/* Deprecated in favour of \fIprometheus_service_update_freq\fR
-   and \fIprometheus_master_update_freq\fR */
+/* Deprecated in favour of \fIprometheus_service_update_freq\fR,
+   \fIprometheus_master_update_freq\fR, and
+   \fIprometheus_usage_update_freq\fR. */
 
 { "prometheus_service_update_freq", "10s", DURATION, "UNRELEASED" }
 /* Frequency in at which promstatsd should re-collate its service
@@ -2174,6 +2175,15 @@ If all partitions are over that limit, this feature is not used anymore.
 { "prometheus_master_update_freq", NULL, DURATION, "UNRELEASED" }
 /* Frequency in at which master should re-collate its statistics report.
    If not set, \fIprometheus_service_update_freq\fR is used.
+.PP
+   If no unit is specified, seconds is assumed. */
+
+{ "prometheus_usage_update_freq", NULL, DURATION, "UNRELEASED" }
+/* Frequency in at which promstatsd should re-collate its usage
+   statistics report.  Note that this report is relatively expensive to
+   produce.  If not set, usage statistics are not reported.
+.PP
+   Best to make this a multiple of \fIprometheus_service_update_freq\fR.
 .PP
    If no unit is specified, seconds is assumed. */
 

--- a/master/master.c
+++ b/master/master.c
@@ -2479,7 +2479,9 @@ static void init_prom_report(struct timeval now)
     const char *tmp;
 
     prom_enabled = config_getswitch(IMAPOPT_PROMETHEUS_ENABLED);
-    prom_frequency = config_getduration(IMAPOPT_PROMETHEUS_UPDATE_FREQ, 's');
+    prom_frequency = config_getduration(IMAPOPT_PROMETHEUS_MASTER_UPDATE_FREQ, 's');
+    if (!prom_frequency)
+        prom_frequency = config_getduration(IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ, 's');
 
     if (prom_frequency < 1) prom_enabled = 0;
     if (!prom_enabled) return;


### PR DESCRIPTION
We found that the Prometheus "usage" report (which reports user and mailbox counts, and quota commitments) is relatively expensive to produce, as it needs to iterate the mailboxes and quota databases.  It is not appropriate to run at the default 10s frequency used by the other reports.

This PR splits the `prometheus_update_freq` imapd.conf option into three new ones: `prometheus_service_update_freq`, `prometheus_master_update_freq`, and `prometheus_usage_update_freq`, so that these reports can be updated at different frequencies.

* `prometheus_service_update_freq` defaults to 10s, like `prometheus_update_freq` did
* `prometheus_master_update_freq` defaults to 0, in which case `prometheus_service_update_freq` will be used instead
* `prometheus_usage_update_freq` defaults to 0, in which case the usage report will not be computed
* The usual deprecated option handling deals with imapd.conf files that still contain the old `prometheus_update_freq` setting

The `/metrics.txt` file that is served by the http_prometheus module remains essentially unchanged: it concatenates the latest version of the reports into a single file whenever it's queried.  Metrics are individually timestamped anyway, so changes to update frequencies will be visible on graphs, but the behaviour doesn't change.

It would be nice to set a useful default for `prometheus_usage_update_freq` instead of disabling it, but we'll need timing data from a production deployment to determine a suitable value.