### PR TITLE
sync: add support for a skipuser touchfile

### DIFF
--- a/changes/next/skipuser
+++ b/changes/next/skipuser
@@ -1,0 +1,20 @@
+Description:
+
+Add a `skipuser-$userid` touchfile to sync directories
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+Nothing required.  Once you've upgraded, you can touch a file in the sync/
+or sync/channel/ folder called 'skipuser-foo@example.com' which will skip any
+replication for that named user.
+
+
+GitHub issue:
+
+No github issue


### PR DESCRIPTION
This allows skipping replication on one particular user, both rolling and by hand (while using the channel name - you can bypass it by syncing with the IP instead)

This came up after a server failure at Fastmail - it would have been very handy to keep rolling replication going without futzing with the one broken user.  This gives us a tool for this.