### PR TITLE
JMAP Contacts: preserve x-properties in Contact/copy

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/contact_copy_preserve_xprops
+++ b/cassandane/tiny-tests/JMAPContacts/contact_copy_preserve_xprops
@@ -1,0 +1,101 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_contact_copy_preserve_xprops
+  : needs_component_jmap {
+    my ($self)    = @_;
+    my $jmap      = $self->{jmap};
+    my $carddav   = $self->{carddav};
+    my $admintalk = $self->{adminstore}->get_client();
+    my $service   = $self->{instance}->get_service("http");
+
+    xlog $self, "create shared account";
+    $admintalk->create("user.other");
+
+    my $otherCarddav = Net::CardDAVTalk->new(
+        user      => "other",
+        password  => 'pass',
+        host      => $service->host(),
+        port      => $service->port(),
+        scheme    => 'http',
+        url       => '/',
+        expandurl => 1,
+    );
+
+    my $otherJmap = Mail::JMAPTalk->new(
+        user     => 'other',
+        password => 'pass',
+        host     => $service->host(),
+        port     => $service->port(),
+        scheme   => 'http',
+        url      => '/jmap/',
+    );
+    $otherJmap->DefaultUsing([
+        'urn:ietf:params:jmap:core',
+        'https://cyrusimap.org/ns/jmap/contacts',
+        'https://cyrusimap.org/ns/jmap/debug'
+    ]);
+
+    xlog $self, "share addressbook";
+    $admintalk->setacl(
+        "user.other.#addressbooks.Default",
+        "cassandane" => 'lrswipkxtecdn'
+    ) or die;
+
+    my $card = decode(
+        'utf-8', <<EOF
+BEGIN:VCARD
+VERSION:3.0
+UID:0A8F88DE-1073-4D47-926F-0D535523FD15
+N:Smith;Hank;;
+FN:Hank Smith
+X-FOO;X-BAZ=Bam:Bar
+REV:2008-04-24T19:52:43Z
+END:VCARD
+EOF
+    );
+    $card =~ s/\r?\n/\r\n/gs;
+    $carddav->Request('PUT', 'Default/test.vcf', $card, 'Content-Type' => 'text/vcard');
+
+    my $res = $jmap->CallMethods([
+        [ 'Contact/query', {}, 'R1' ],
+    ]);
+    $self->assert_num_equals(1, scalar @{ $res->[0][1]{ids} });
+    my $contactId = $res->[0][1]{ids}[0];
+    $self->assert_not_null($contactId);
+
+    $res = $jmap->CallMethods([
+        [
+            'Contact/copy',
+            {
+                fromAccountId => 'cassandane',
+                accountId     => 'other',
+                create        => {
+                    contact1 => {
+                        addressbookId => 'Default',
+                        id            => $contactId
+                    }
+                },
+                onSuccessDestroyOriginal => JSON::false,
+            },
+            'R1'
+        ],
+    ]);
+    my $copiedContactId = $res->[0][1]{created}{contact1}{id};
+    $self->assert_not_null($copiedContactId);
+
+    $res = $otherJmap->CallMethods([
+        [
+            'Contact/get',
+            {
+                accountId  => 'other',
+                ids        => [$copiedContactId],
+                properties => [ 'x-href' ],
+            },
+            'R1'
+        ],
+    ]);
+
+    $card = $otherCarddav->Request('GET', $res->[0][1]{list}[0]{'x-href'});
+    $self->assert_matches(qr/^X-FOO;X-BAZ=Bam:Bar\r$/m, $card->{content});
+}

--- a/cassandane/tiny-tests/JMAPContacts/contact_set_preserve_xprops
+++ b/cassandane/tiny-tests/JMAPContacts/contact_set_preserve_xprops
@@ -1,0 +1,74 @@
+#!perl
+use Cassandane::Tiny;
+use Encode qw(decode);
+
+sub test_contact_set_preserve_xprops
+  : needs_component_jmap {
+    my ($self)  = @_;
+    my $jmap    = $self->{jmap};
+    my $carddav = $self->{carddav};
+
+    xlog $self, "Create vCard with x-property";
+    my $card = decode(
+        'utf-8', <<EOF
+BEGIN:VCARD
+VERSION:3.0
+UID:0A8F88DE-1073-4D47-926F-0D535523FD15
+N:Smith;Hank;;
+FN:Hank Smith
+X-FOO;X-BAZ=Bam:Bar
+REV:2008-04-24T19:52:43Z
+END:VCARD
+EOF
+    );
+    $card =~ s/\r?\n/\r\n/gs;
+    $carddav->Request('PUT', 'Default/test.vcf', $card, 'Content-Type' => 'text/vcard');
+
+    xlog $self, "Update some contact property";
+    my $res = $jmap->CallMethods([
+        [ 'Contact/query', {}, 'R1' ],
+        [
+            'Contact/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    path     => '/ids',
+                    name     => 'Contact/query',
+                },
+                properties => ['lastName'],
+            },
+            'R2'
+        ],
+    ]);
+
+    my $contactId = $res->[0][1]{ids}[0];
+    $self->assert_not_null($contactId);
+    $self->assert_str_equals('Smith', $res->[1][1]{list}[0]{lastName});
+
+    $res = $jmap->CallMethods([
+        [
+            'Contact/set',
+            {
+                update => {
+                    $contactId => {
+                        lastName => 'Kraut',
+                    }
+                },
+            },
+            'R1'
+        ],
+        [
+            'Contact/get',
+            {
+                ids        => [$contactId],
+                properties => ['lastName'],
+            },
+            'R2'
+        ],
+    ]);
+    $self->assert_str_equals('Kraut', $res->[1][1]{list}[0]{lastName});
+
+    xlog $self, "Update x-property is preserved in vCard";
+    $res = $carddav->Request('GET', 'Default/test.vcf');
+    $self->assert_matches(qr/^X-FOO;X-BAZ=Bam:Bar\r?$/m, $res->{content});
+}

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1594,7 +1594,7 @@ HIDDEN void jmap_get_parse(jmap_req_t *req,
                             propdef = NULL;
                         }
                     }
-                    if (!propdef) {
+                    if (!propdef || (propdef->flags & JMAP_PROP_REJECT_GET)) {
                         jmap_parser_push_index(parser, "properties", i, name);
                         jmap_parser_invalid(parser, NULL);
                         jmap_parser_pop(parser);
@@ -1704,6 +1704,9 @@ static void jmap_set_validate_props(jmap_req_t *req, const char *id, json_t *job
             json_array_append_new(invalid, json_string(path));
         }
         else if (prop->capability && !jmap_is_using(req, prop->capability)) {
+            json_array_append_new(invalid, json_string(path));
+        }
+        else if (prop->flags & JMAP_PROP_REJECT_SET) {
             json_array_append_new(invalid, json_string(path));
         }
         else if (id) {

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -332,7 +332,9 @@ enum {
     JMAP_PROP_SERVER_SET = (1<<0),
     JMAP_PROP_IMMUTABLE  = (1<<1),
     JMAP_PROP_SKIP_GET   = (1<<2), // skip in Foo/get if not requested by client
-    JMAP_PROP_ALWAYS_GET = (1<<3)  // always include in Foo/get
+    JMAP_PROP_ALWAYS_GET = (1<<3), // always include in Foo/get
+    JMAP_PROP_REJECT_GET = (1<<4), // reject as unknown in Foo/get
+    JMAP_PROP_REJECT_SET = (1<<5)  // reject as unknown in Foo/set
 };
 
 extern const jmap_property_t *jmap_property_find(const char *name,

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -3955,6 +3955,7 @@ static int _json_to_card(struct jmap_req *req,
                 pname = "X-PHONETIC-ORG";
 
             if (json_is_string(jval) && pname) {
+                vparse_delete_entries(card, NULL, pname);
                 buf_setcstr(&buf, json_string_value(jval));
                 buf_trim(&buf);
                 if (buf_len(&buf)) {

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -653,7 +653,7 @@ static const jmap_property_t contact_props[] = {
     {
         "vCardProps",
         NULL,
-        0
+        JMAP_PROP_REJECT_GET | JMAP_PROP_REJECT_SET | JMAP_PROP_SKIP_GET
     },
 
     /* FM extensions */


### PR DESCRIPTION
This updates the `Contact/copy` method of the non-standard Contact object type to preserve arbitrary x-properties in the copied vCard.

It adds the `vCardProps` property as defined in https://www.rfc-editor.org/rfc/rfc9555.html#name-vcardprops to the Contact object type The implementation is for Cyrus-internal use only and `Contact/set` and `Contact/get` reject this property as unknown.

Also contained in this PR is a related, minor fix:  `Contact/set` now replaces rather than adds the non-standard phonetic contact properties.