### PR TITLE
Create a strarray_contains API and migrate to using it for contains checks

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_messageid
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_messageid
@@ -8,6 +8,7 @@ sub test_email_query_messageid
     my $imap   = $self->{store}->get_client();
 
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/debug');
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/performance');
 
     my $mime = <<'EOF';

--- a/cassandane/tiny-tests/JMAPEmail/email_query_references_inreplyto
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_references_inreplyto
@@ -8,6 +8,7 @@ sub test_email_query_references_inreplyto
     my $imap   = $self->{store}->get_client();
 
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/debug');
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/performance');
 
     xlog $self, "Assert 'inReplyTo' and 'references' filter conditions";

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3770,7 +3770,7 @@ EXPORTED int specialuse_validate(const char *mboxname, const char *userid,
                 STRARRAY_TRIM
             );
 
-            if (strarray_find(forbidden, strarray_nth(valid, j), 0) != -1
+            if (strarray_contains(forbidden, strarray_nth(valid, j))
                 && mboxlist_haschildren(mboxname))
             {
                 r = IMAP_MAILBOX_HASCHILDREN;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3746,7 +3746,7 @@ EXPORTED int specialuse_validate(const char *mboxname, const char *userid,
         }
 
         if (cur_attribs &&
-            (strarray_find_case(cur_attribs, strarray_nth(valid, j), 0) >= 0)) {
+            (strarray_contains_case(cur_attribs, strarray_nth(valid, j)))) {
             /* The mailbox has this specialuse attribute set already */
             skip_mbcheck = 1;
         }

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -838,7 +838,7 @@ int autocreate_user(struct namespace *namespace, const char *userid)
         }
 
         /* subscribe if requested */
-        if (strarray_find(subscribe, name, 0) >= 0) {
+        if (strarray_contains(subscribe, name)) {
             r = mboxlist_changesub(foldername, userid, auth_state, 1, 1, 1, 1);
             if (!r) {
                 numsub++;

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -538,7 +538,7 @@ static int process_alarm_cb(icalcomponent *comp,
         if (!attendee) continue;
         if (!strncasecmp(attendee, "mailto:", 7)) attendee += 7;
 
-        if (strarray_find_case(&sched_addrs, attendee, 0) >= 0) {
+        if (strarray_contains_case(&sched_addrs, attendee)) {
             const char *partstat =
                 icalproperty_get_parameter_as_string(prop, "PARTSTAT");
 

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -328,7 +328,7 @@ static int validate_mayinvite(icalproperty *prop,
 
     const char *uri = icalproperty_get_attendee(prop);
     if (uri &&!strncasecmp(uri, "mailto:", 7) && sched_addrs &&
-            strarray_find(sched_addrs, uri + 7, 0) >= 0) {
+            strarray_contains(sched_addrs, uri + 7)) {
         /* User adds their own ATTENDEE */
         if (!(allow_propupdates & propupdate_inviteself))
             return HTTP_FORBIDDEN;
@@ -441,7 +441,7 @@ static int validate_propupdates(icalcomponent *ical, icalcomponent *oldical,
                 {
                     const char *uri = icalproperty_get_attendee(prop);
                     if (uri && !strncasecmp(uri, "mailto:", 7) && sched_addrs &&
-                            strarray_find(sched_addrs, uri + 7, 0) >= 0) {
+                            strarray_contains(sched_addrs, uri + 7)) {
                         /* User updates their own ATTENDEE */
                         if (!(allow_propupdates & propupdate_rsvp))
                             return HTTP_FORBIDDEN;
@@ -694,7 +694,7 @@ static int includes_attendee(icalcomponent *ical, const strarray_t *sched_addrs)
 
             const char *uri = icalproperty_get_attendee(prop);
             if (uri && !strncasecmp(uri, "mailto:", 7) &&
-                    strarray_find(sched_addrs, uri + 7, 0) >= 0)
+                    strarray_contains(sched_addrs, uri + 7))
                 return 1;
         }
     }
@@ -766,7 +766,7 @@ static int caldav_store_preprocess(struct transaction_t *txn,
     else if (cdata->dav.imap_uid && (rights & DACL_WRITEOWNRSRC) &&
             (!cdata->organizer ||
              (schedule_addresses &&
-              strarray_find(schedule_addresses, cdata->organizer, 0) >= 0))) {
+              strarray_contains(schedule_addresses, cdata->organizer)))) {
         /* User may update resource whey they are organizer */
         allow_propupdates = propupdate_all;
     }

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -434,7 +434,7 @@ static int _dav_reconstruct_mb(const mbentry_t *mbentry,
             strarray_t *specialuse =
                 strarray_split(buf_cstring(&attrib), NULL, 0);
 
-            if (strarray_find(specialuse, "\\Snoozed", 0) >= 0) {
+            if (strarray_contains(specialuse, "\\Snoozed")) {
                 addproc = &mailbox_add_email_alarms;
             }
             strarray_free(specialuse);

--- a/imap/defaultalarms.c
+++ b/imap/defaultalarms.c
@@ -496,7 +496,7 @@ static void merge_alarms(icalcomponent *comp, icalcomponent *alarms)
                 !!icalcomponent_get_x_property_by_name(old, "X-APPLE-DEFAULT-ALARM");
 
             int is_snoozed = old_uid &&
-                strarray_find(&related_uids, old_uid, 0) >= 0;
+                strarray_contains(&related_uids, old_uid);
 
             int is_acked = !!icalcomponent_get_first_property(old,
                     ICAL_ACKNOWLEDGED_PROPERTY);

--- a/imap/global.c
+++ b/imap/global.c
@@ -947,9 +947,7 @@ EXPORTED void parse_sessionid(const char *str, char *sessionid)
 
 EXPORTED int capa_is_disabled(const char *str)
 {
-    if (!suppressed_capabilities) return 0;
-
-    return (strarray_find_case(suppressed_capabilities, str, 0) >= 0);
+    return strarray_contains_case(suppressed_capabilities, str);
 }
 
 /*

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1079,7 +1079,7 @@ static int caldav_check_precond(struct transaction_t *txn,
                                                   txn->req_tgt.mbentry->name,
                                                   txn->req_tgt.userid,
                                                   &schedule_addresses);
-                    if (strarray_find(&schedule_addresses, cdata->organizer, 0) < 0) {
+                    if (!strarray_contains(&schedule_addresses, cdata->organizer)) {
                         precond = HTTP_FORBIDDEN;
                     }
                     strarray_fini(&schedule_addresses);

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1531,7 +1531,7 @@ static int caldav_delete_cal(struct transaction_t *txn,
         char *cal_ownerid = mboxname_to_userid(txn->req_tgt.mbentry->name);
         char *sched_userid = (txn->req_tgt.flags == TGT_DAV_SHARED) ?
             xstrdup(txn->req_tgt.userid) : NULL;
-        if (strarray_find_case(&schedule_addresses, cdata->organizer, 0) >= 0) {
+        if (strarray_contains_case(&schedule_addresses, cdata->organizer)) {
             /* Organizer scheduling object resource */
             if (_scheduling_enabled(txn, mailbox) && !is_draft)
                 sched_request(cal_ownerid, sched_userid, &schedule_addresses,
@@ -3126,7 +3126,7 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
         char *sched_userid = (txn->req_tgt.flags == TGT_DAV_SHARED) ?
             xstrdup(txn->req_tgt.userid) : NULL;
             
-        if (strarray_find_case(&schedule_addresses, cdata->organizer, 0) >= 0) {
+        if (strarray_contains_case(&schedule_addresses, cdata->organizer)) {
             /* Organizer scheduling object resource */
             if (_scheduling_enabled(txn, calendar))
                 sched_request(cal_ownerid, sched_userid, &schedule_addresses,
@@ -4100,7 +4100,7 @@ static int caldav_put(struct transaction_t *txn, void *obj,
             sched_userid = (txn->req_tgt.flags == TGT_DAV_SHARED) ?
                 xstrdup(txn->req_tgt.userid) : NULL;
 
-            if (strarray_find_case(&schedule_addresses, organizer, 0) >= 0) {
+            if (strarray_contains_case(&schedule_addresses, organizer)) {
                 /* Organizer scheduling object resource */
                 if (ret) {
                     txn->error.precond = CALDAV_ALLOWED_ORG_CHANGE;

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1818,7 +1818,7 @@ static void update_attendee_status(icalcomponent *ical, strarray_t *onrecurids,
                 icalcomponent_get_first_property(comp, ICAL_RECURRENCEID_PROPERTY);
             const char *recurid = "";
             if (prop) recurid = icalproperty_get_value_as_string(prop);
-            if (strarray_find(onrecurids, recurid, 0) < 0) continue;
+            if (!strarray_contains(onrecurids, recurid)) continue;
         }
 
         icalproperty *prop = icalcomponent_get_first_invitee(comp);
@@ -2647,7 +2647,7 @@ static void update_organizer_status(icalcomponent *ical, strarray_t *onrecurids,
                 icalcomponent_get_first_property(comp, ICAL_RECURRENCEID_PROPERTY);
             const char *recurid = "";
             if (prop) recurid = icalproperty_get_value_as_string(prop);
-            if (strarray_find(onrecurids, recurid, 0) < 0) continue;
+            if (!strarray_contains(onrecurids, recurid)) continue;
         }
 
         icalproperty *prop =

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -2162,7 +2162,7 @@ static void prune_properties(vcardcomponent *vcard, strarray_t *partial)
 
         next = vcardcomponent_get_next_property(vcard, VCARD_ANY_PROPERTY);
 
-        if (strarray_find_case(partial, prop_name, 0) < 0) {
+        if (!strarray_contains_case(partial, prop_name)) {
             vcardcomponent_remove_property(vcard, prop);
             vcardproperty_free(prop);
         }
@@ -2269,7 +2269,7 @@ static void prune_properties(struct vparse_card *vcard, strarray_t *partial)
     while (*entryp) {
         struct vparse_entry *entry = *entryp;
 
-        if (strarray_find_case(partial, entry->name, 0) < 0) {
+        if (!strarray_contains_case(partial, entry->name)) {
             *entryp = entry->next;
             entry->next = NULL; /* so free doesn't walk the chain */
             vparse_free_entry(entry);

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -1509,7 +1509,7 @@ static int jmap_ws(struct transaction_t *txn, enum wslay_opcode opcode,
                 const char *val = json_string_value(jval);
 
                 if (val &&
-                    strarray_find_case(httpd_log_headers, hdrname, 0) >= 0) {
+                    strarray_contains_case(httpd_log_headers, hdrname)) {
                     buf_printf(logbuf, "; %s=\"%s\"", hdrname, val);
                 }
             }

--- a/imap/idled.c
+++ b/imap/idled.c
@@ -196,7 +196,7 @@ static int notify_cb(sqlite3_stmt *stmt, void *rock)
         case FILTER_SUBSCRIBED: {
             /* keyval is userid */
             strarray_t *sublist = mboxlist_sublist(keyval);
-            if (strarray_find(sublist, mbentry->name, 0) >= 0)
+            if (strarray_contains(sublist, mbentry->name))
                 notify = 1;
             strarray_free(sublist);
             break;

--- a/imap/index.c
+++ b/imap/index.c
@@ -5750,7 +5750,7 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
     struct buf text = BUF_INITIALIZER;
     int r = 0;
 
-    if (isbody && partid && str->partids && strarray_find(str->partids, partid, 0) < 0) {
+    if (isbody && partid && str->partids && !strarray_contains(str->partids, partid)) {
         /* Skip part */
         return 0;
     }

--- a/imap/index.c
+++ b/imap/index.c
@@ -5837,7 +5837,7 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
             const char *mysubtype = subtype;
 
             if (!strcmpsafe(subtype, "PLAIN") && partid &&
-                    strarray_find(&str->striphtml, partid, 0) >= 0) {
+                    strarray_contains(&str->striphtml, partid)) {
                 /* Strip any HTML tags from plain text before indexing */
                 mycharset_flags &= ~(CHARSET_SKIPHTML|CHARSET_KEEPHTML);
                 /* Keep angle-bracketed URIs in text */
@@ -8402,7 +8402,7 @@ EXPORTED int insert_into_mailbox_allowed(struct mailbox *mailbox)
             strarray_t *specialuse =
                 strarray_split(buf_cstring(&attrib), NULL, 0);
 
-            if (strarray_find(specialuse, "\\Snoozed", 0) >= 0) {
+            if (strarray_contains(specialuse, "\\Snoozed")) {
                 r = IMAP_MAILBOX_NOTSUPPORTED;
             }
             strarray_free(specialuse);

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -163,7 +163,7 @@ static int pick_scheddefault_cb(const mbentry_t *mbentry, void *vrock)
     if (mbtype_isa(mbentry->mbtype) == MBTYPE_CALENDAR) {
         mbname = mbname_from_intname(mbentry->name);
         const char *collname = strarray_nth(mbname_boxes(mbname), -1);
-        if (strarray_find(&rock->ignore, collname, 0) < 0) {
+        if (!strarray_contains(&rock->ignore, collname)) {
             if (mbentry->acl) {
                 // Must be writable by owner
                 const char *ownerid = mbname_userid(mbname);

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -678,7 +678,7 @@ HIDDEN int jmap_api(struct transaction_t *txn,
     }
 
     /* Process call stack */
-    do_perf = strarray_find(&using_capabilities, JMAP_PERFORMANCE_EXTENSION, 0) >= 0;
+    do_perf = strarray_contains(&using_capabilities, JMAP_PERFORMANCE_EXTENSION);
     json_t *mc;
     while ((mc = ptrarray_pop(&method_calls))) {
         /* Send provisional response, if necessary */
@@ -3120,7 +3120,7 @@ HIDDEN void jmap_parse_sharewith_patch(json_t *arg, json_t **shareWith)
 
 HIDDEN int jmap_is_using(jmap_req_t *req, const char *capa)
 {
-    return strarray_find(req->using_capabilities, capa, 0) >= 0;
+    return strarray_contains(req->using_capabilities, capa);
 }
 
 /*
@@ -3279,7 +3279,7 @@ static int _mbox_find_specialuse_cb(const mbentry_t *mbentry, void *rock)
 
     if (attrib.len) {
         strarray_t *uses = strarray_split(buf_cstring(&attrib), " ", STRARRAY_TRIM);
-        if (strarray_find_case(uses, d->use, 0) >= 0) {
+        if (strarray_contains_case(uses, d->use)) {
             d->uniqueid = xstrdup(mbentry->uniqueid);
         }
         strarray_free(uses);

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -699,7 +699,7 @@ HIDDEN int jmap_api(struct transaction_t *txn,
 
         /* Find the message processor */
         mp = find_methodproc(mname, &settings->methods);
-        if (!mp || strarray_find(&using_capabilities, mp->capability, 0) < 0) {
+        if (!mp || !strarray_contains(&using_capabilities, mp->capability)) {
             json_array_append_new(resp, json_pack("[s {s:s} s]",
                         "error", "type", "unknownMethod", tag));
             json_decref(args);

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -991,7 +991,7 @@ static int do_scheduling(jmap_req_t *req,
     caldav_get_schedule_addresses(req->txn->req_hdrs, mboxname,
                                   req->userid, schedule_addresses);
 
-    if (strarray_find_case(schedule_addresses, organizer, 0) >= 0) {
+    if (strarray_contains_case(schedule_addresses, organizer)) {
         /* Organizer scheduling object resource */
         sched_request(req->userid, req->userid, schedule_addresses, organizer,
                       oldical, ical, SCHED_MECH_JMAP_RESTORE);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -5206,7 +5206,7 @@ static void updateevent_bump_sequence(json_t *old_event,
     if (JNOTNULL(jreplyto)) {
         const char *addr = json_string_value(json_object_get(jreplyto, "imip"));
         if (addr && !strncasecmp(addr, "mailto:", 7) &&
-                strarray_find(schedule_addresses, addr + 7, 0) < 0) {
+                !strarray_contains(schedule_addresses, addr + 7)) {
             return;
         }
     }
@@ -5978,7 +5978,7 @@ static int setcalendarevents_destroy(jmap_req_t *req,
     if (!jmap_hasrights_mbentry(req, mbentry, JACL_REMOVEITEMS)) {
         if (!jmap_hasrights_mbentry(req, mbentry, JACL_WRITEOWN) ||
                 (cdata->organizer &&
-                 strarray_find(&schedule_addresses, cdata->organizer, 0) < 0)) {
+                 !strarray_contains(&schedule_addresses, cdata->organizer))) {
             r = IMAP_PERMISSION_DENIED;
             goto done;
         }

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3094,7 +3094,7 @@ static void getcalendarevents_reduce_participants_internal(json_t *jparticipants
                 continue;
             }
 
-            if (strarray_find_case(schedule_addresses, uri + 7, 0) >= 0) {
+            if (strarray_contains_case(schedule_addresses, uri + 7)) {
                 json_object_set_new(keep_ids,
                         participant_id, json_true());
                 continue;
@@ -4161,7 +4161,7 @@ static int setcalendarevents_schedule(const char *sched_userid,
             /* XXX Hack for Outlook */ icalcomponent_get_first_invitee(comp)) {
 
         /* Send scheduling message. */
-        if (strarray_find_case(schedule_addresses, organizer, 0) >= 0) {
+        if (strarray_contains_case(schedule_addresses, organizer)) {
             /* Organizer scheduling object resource */
             sched_request(sched_userid, sched_userid, schedule_addresses, organizer,
                           oldical, newical, SCHED_MECH_JMAP_SET);

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -4556,7 +4556,7 @@ static int _contact_set_update(jmap_req_t *req, unsigned kind,
                    if in the same mailbox and no data change */
                 syslog(LOG_NOTICE, "jmap: touch contact %s/%s",
                        req->accountid, resource);
-                if (strarray_find_case(flags, "\\Flagged", 0) >= 0)
+                if (strarray_contains_case(flags, "\\Flagged"))
                     record.system_flags |= FLAG_FLAGGED;
                 else
                     record.system_flags &= ~FLAG_FLAGGED;

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -3587,7 +3587,7 @@ static json_t *timezones_from_ical(json_t *jsevent, jstimezones_t *jstzones)
         if (!jstz->is_custom) continue;
 
         /* Skip orphaned timezones */
-        if (strarray_find(&want_tzids, jstzid, 0) < 0) {
+        if (!strarray_contains(&want_tzids, jstzid)) {
             continue;
         }
 
@@ -7498,7 +7498,7 @@ static void timezones_to_ical(icalcomponent *ical,
 
         jmap_parser_pop(parser);
 
-        if (strarray_find(&custom_jstzids, jstzid, 0) < 0) {
+        if (!strarray_contains(&custom_jstzids, jstzid)) {
             // this timezone is not referenced by any known property
             if (jmapctx && !jmapctx->to_ical.ignore_orphan_timezones) {
                 jmap_parser_invalid(parser, jstzid);
@@ -7682,7 +7682,7 @@ HIDDEN int jmapical_is_origin(json_t *jsevent, const strarray_t *schedule_addres
                 if (!strncasecmp(orga, "mailto:", 7)) {
                     orga += 7;
                 }
-                if (strarray_find_case(schedule_addresses, orga, 0) < 0) {
+                if (!strarray_contains_case(schedule_addresses, orga)) {
                     return 0;
                 }
             }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2663,7 +2663,7 @@ static int convert_foldermatch(search_expr_t *e,
 
     struct emailsearch_folders_value *val = e->value.v;
     const char *folder = strarray_nth(&val->foldernames, 0);
-    int is_preferred = strarray_find(preferred_folders, folder, 0) >= 0;
+    int is_preferred = strarray_contains(preferred_folders, folder);
     if (!is_preferred && only_preferred) {
         return 0;
     }
@@ -3788,7 +3788,7 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
                 else  {
                     // check if conversation flag is counted
                     if (cstate->counted_flags &&
-                        strarray_find_case(cstate->counted_flags, e->value.s, 0) >= 0) {
+                        strarray_contains_case(cstate->counted_flags, e->value.s)) {
                         if (nonxapian_hash) {
                             guidsearch_hash_expr(e, nonxapian_hash);
                         }
@@ -8134,7 +8134,7 @@ static int _email_get_bodies(jmap_req_t *req,
             if (rawflags) {
                 strarray_t *flags = strarray_split(rawflags, NULL, 0);
                 if (flags &&
-                        strarray_find_case(flags, JMAP_HAS_ATTACHMENT_FLAG, 0) >= 0) {
+                        strarray_contains_case(flags, JMAP_HAS_ATTACHMENT_FLAG)) {
                     check_annotations = 1;
                 }
             }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6049,7 +6049,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
             const char *part_id;
             void *tmp;
             json_object_foreach_safe(jattachments, tmp, part_id, jmatch){
-                if (strarray_find(&partids, part_id, 0) < 0) {
+                if (!strarray_contains(&partids, part_id)) {
                     json_object_del(jattachments, part_id);
                 }
             }
@@ -12792,7 +12792,7 @@ static int _email_bulkupdate_open(jmap_req_t *req, struct email_bulkupdate *bulk
             /* If trying to move a message in/out of $scheduled
                it better be in our scheduled email cache */
             if (!strcmpnull(scheduled_uniqueid, mbox_id) &&
-                strarray_find(req->scheduled_emails, update->email_id, 0) < 0) {
+                !strarray_contains(req->scheduled_emails, update->email_id)) {
                 is_valid = 0;
             }
 

--- a/imap/jmap_mail_query_parse.c
+++ b/imap/jmap_mail_query_parse.c
@@ -54,7 +54,7 @@ HIDDEN void jmap_email_filtercondition_parse(json_t *filter,
                                              jmap_email_filter_parse_ctx_t *ctx)
 {
     const char *field, *s = NULL;
-    int have_mail_extension = strarray_find(ctx->capabilities, JMAP_MAIL_EXTENSION, 0);
+    int have_mail_extension = strarray_contains(ctx->capabilities, JMAP_MAIL_EXTENSION);
     json_t *arg;
 
     json_object_foreach(filter, field, arg) {

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -1967,21 +1967,21 @@ static int submission_filter_match(void *vf, void *rock)
                 json_string_value(json_object_get(sfrock->submission,
                                                   "identityId"));
 
-            if (strarray_find(f->identityIds, identityId, 0) == -1) return 0;
+            if (!strarray_contains(f->identityIds, identityId)) return 0;
         }
         if (f->emailIds) {
             sfrock->emailId =
                 json_string_value(json_object_get(sfrock->submission,
                                                   "emailId"));
 
-            if (strarray_find(f->emailIds, sfrock->emailId, 0) == -1) return 0;
+            if (!strarray_contains(f->emailIds, sfrock->emailId)) return 0;
         }
         if (f->threadIds) {
             sfrock->threadId =
                 json_string_value(json_object_get(sfrock->submission,
                                                   "threadId"));
 
-            if (strarray_find(f->threadIds, sfrock->threadId, 0) == -1) return 0;
+            if (!strarray_contains(f->threadIds, sfrock->threadId)) return 0;
         }
     }
 

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -669,8 +669,7 @@ static json_t *_mbox_get(jmap_req_t *req,
     }
 
     if (jmap_wantprop(props, "isSubscribed")) {
-        int is_subscribed =
-            sublist && strarray_find(sublist, mbentry->name, 0) >= 0;
+        int is_subscribed = strarray_contains(sublist, mbentry->name);
         json_object_set_new(obj, "isSubscribed", json_boolean(is_subscribed));
     }
 
@@ -3605,7 +3604,7 @@ static void _mboxset_state_update_specialuse(struct mboxset_state *state,
             int j;
             for (j = 0; j < strarray_size(specialuses); j++) {
                 const char *specialuse = strarray_nth(specialuses, j);
-                if (strarray_find(protected_uses, specialuse, 0) >= 0) {
+                if (strarray_contains(protected_uses, specialuse)) {
                     strarray_add(&want_protected, specialuse);
                 }
             }
@@ -3669,7 +3668,7 @@ static void _mboxset_state_update_specialuse(struct mboxset_state *state,
             continue;
         }
         const char *specialuse = strarray_nth(specialuses, 0);
-        if (strarray_find(&have_specialuses, specialuse, 0) >= 0) {
+        if (strarray_contains(&have_specialuses, specialuse)) {
             state->has_conflict = 1;
             buf_printf(&conflict_desc, "\nMailbox %s has specialuse %s, but at "
                     "least one other mailbox also has this specialuse.",

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -1140,9 +1140,9 @@ static int _mboxquery_eval_filter(mboxquery_t *query,
         }
         if (JNOTNULL(filter->is_subscribed)) {
             int want_subscribed = json_boolean_value(filter->is_subscribed);
-            int is_subscribed = strarray_find(query->sublist, rec->mboxname, 0);
-            if (want_subscribed && is_subscribed < 0) return 0;
-            if (!want_subscribed && is_subscribed >= 0) return 0;
+            int is_subscribed = strarray_contains(query->sublist, rec->mboxname);
+            if (want_subscribed && !is_subscribed) return 0;
+            if (!want_subscribed && is_subscribed) return 0;
         }
         return 1;
     }

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -3583,7 +3583,7 @@ static void _mboxset_state_update_specialuse(struct mboxset_state *state,
             int j;
             for (j = 0; j < strarray_size(specialuses); j++) {
                 const char *specialuse = strarray_nth(specialuses, j);
-                if (strarray_find(protected_uses, specialuse, 0) < 0) {
+                if (!strarray_contains(protected_uses, specialuse)) {
                     continue;
                 }
                 struct mboxset_entry *entry = hash_lookup(args->mbox_id, state->entry_by_id);
@@ -3681,7 +3681,7 @@ static void _mboxset_state_update_specialuse(struct mboxset_state *state,
     /* Validate: all protected preserved */
     for (i = 0; i < strarray_size(&want_protected); i++) {
         const char *protected = strarray_nth(&want_protected, i);
-        if (strarray_find(&have_specialuses, protected, 0) < 0) {
+        if (!strarray_contains(&have_specialuses, protected)) {
             if (buf_len(&conflict_desc))
                 buf_putc(&conflict_desc, ' ');
             buf_printf(&conflict_desc, "\nA mailbox had protected specialuse %s "

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1417,7 +1417,7 @@ static int getspecialuseexists(void *sc, const char *extname, strarray_t *uses)
             strarray_t *haystack = strarray_split(buf_cstring(&attrib), " ", 0);
 
             for (i = 0; i < strarray_size(uses); i++) {
-                if (strarray_find_case(haystack, strarray_nth(uses, i), 0) < 0) {
+                if (!strarray_contains_case(haystack, strarray_nth(uses, i))) {
                     r = 0;
                     break;
                 }

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -225,7 +225,7 @@ static int getspecialuseexists(void *sc, const char *extname, strarray_t *uses)
             strarray_t *haystack = strarray_split(buf_cstring(&attrib), " ", 0);
 
             for (i = 0; i < strarray_size(uses); i++) {
-                if (strarray_find_case(haystack, strarray_nth(uses, i), 0) < 0) {
+                if (!strarray_contains_case(haystack, strarray_nth(uses, i))) {
                     r = 0;
                     break;
                 }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -1201,7 +1201,7 @@ EXPORTED char *mailbox_visible_users(const struct mailbox *mailbox)
         // not admin or special name
         if (strcmp(name, "anyone")) goto done;
         if (strcmp(name, "anonymous")) goto done;
-        if (strarray_find(admins, name, 0) >= 0) goto done;
+        if (strarray_contains(admins, name)) goto done;
         // OK, this belongs
         if (strncmp(name, "group:", 6)) {
             strarray_appendm(&users, name);
@@ -1628,7 +1628,7 @@ static int _too_many_flags(const char *flag, int num)
     if (val) {
         strarray_t *flags = strarray_split(val, NULL, 0);
         // it's not too many if there's still space and it's an initial flag
-        if (strarray_find_case(flags, flag, 0) >= 0)
+        if (strarray_contains_case(flags, flag))
             too_many = 0;
         strarray_free(flags);
     }

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -246,7 +246,7 @@ EXPORTED int mboxevent_init(void)
     excluded_specialuse = strarray_split(options, NULL, 0);
 
     /* special meaning to disable event notification on all sub folders */
-    if (strarray_find_case(excluded_specialuse, "ALL", 0) >= 0)
+    if (strarray_contains_case(excluded_specialuse, "ALL"))
         enable_subfolder = 0;
 
     /* get event types's extra parameters */
@@ -322,7 +322,7 @@ static int mboxevent_enabled_for_mailbox(struct mailbox *mailbox)
 
         for (i = 0; i < strarray_size(specialuse) ; i++) {
             const char *attribute = strarray_nth(specialuse, i);
-            if (strarray_find(excluded_specialuse, attribute, 0) >= 0) {
+            if (strarray_contains(excluded_specialuse, attribute)) {
                 enabled = 0;
                 goto done;
             }
@@ -704,7 +704,7 @@ EXPORTED void mboxevent_notify(struct mboxevent **mboxevents)
         if (event->type == EVENT_FLAGS_SET &&
             event->next &&
             event->next->type == EVENT_FLAGS_CLEAR &&
-            strarray_find_case(&event->next->flagnames, "\\Seen", 0) >= 0) {
+            strarray_contains_case(&event->next->flagnames, "\\Seen")) {
 
             struct mboxevent *other = event->next;
             // swap the outsides first

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -830,23 +830,23 @@ EXPORTED void mboxevent_add_flags(struct mboxevent *event, char *flagnames[MAX_U
 
     /* add system flags */
     if (system_flags & FLAG_DELETED) {
-        if (strarray_find_case(excluded_flags, "\\Deleted", 0) < 0)
+        if (!strarray_contains_case(excluded_flags, "\\Deleted"))
             strarray_add_case(&event->flagnames, "\\Deleted");
     }
     if (system_flags & FLAG_ANSWERED) {
-        if (strarray_find_case(excluded_flags, "\\Answered", 0) < 0)
+        if (!strarray_contains_case(excluded_flags, "\\Answered"))
             strarray_add_case(&event->flagnames, "\\Answered");
     }
     if (system_flags & FLAG_FLAGGED) {
-        if (strarray_find_case(excluded_flags, "\\Flagged", 0) < 0)
+        if (!strarray_contains_case(excluded_flags, "\\Flagged"))
             strarray_add_case(&event->flagnames, "\\Flagged");
     }
     if (system_flags & FLAG_DRAFT) {
-        if (strarray_find_case(excluded_flags, "\\Draft", 0) < 0)
+        if (!strarray_contains_case(excluded_flags, "\\Draft"))
             strarray_add_case(&event->flagnames, "\\Draft");
     }
     if (system_flags & FLAG_SEEN) {
-        if (strarray_find_case(excluded_flags, "\\Seen", 0) < 0)
+        if (!strarray_contains_case(excluded_flags, "\\Seen"))
             strarray_add_case(&event->flagnames, "\\Seen");
     }
 
@@ -858,7 +858,7 @@ EXPORTED void mboxevent_add_flags(struct mboxevent *event, char *flagnames[MAX_U
         if (!(flagnames[flag] && (flagmask & (1<<(flag & 31)))))
             continue;
 
-        if (strarray_find_case(excluded_flags, flagnames[flag], 0) < 0)
+        if (!strarray_contains_case(excluded_flags, flagnames[flag]))
             strarray_add_case(&event->flagnames, flagnames[flag]);
     }
 }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -825,7 +825,7 @@ static int _find_specialuse(const mbentry_t *mbentry, void *rock)
 
     if (attrib.len) {
         strarray_t *uses = strarray_split(buf_cstring(&attrib), NULL, 0);
-        if (strarray_find_case(uses, d->use, 0) >= 0)
+        if (strarray_contains_case(uses, d->use))
             d->mboxname = xstrdup(mbentry->name);
         strarray_free(uses);
     }
@@ -1034,7 +1034,7 @@ static int mboxlist_update_raclmodseq_wrapper(const char *acluser,
 {
     // not a group, just update it
     if (strncmp(acluser, "group:", 6)) {
-        if (strarray_find(touched_users, acluser, 0) >= 0) return 0;
+        if (strarray_contains(touched_users, acluser)) return 0;
         strarray_append(touched_users, acluser);
         return mboxlist_update_raclmodseq(acluser);
     }
@@ -1048,7 +1048,7 @@ static int mboxlist_update_raclmodseq_wrapper(const char *acluser,
     int i;
     for (i = 0; i < strarray_size(members); i++) {
         const char *member = strarray_nth(members, i);
-        if (strarray_find(touched_users, member, 0) >= 0) continue;
+        if (strarray_contains(touched_users, member)) continue;
         strarray_append(touched_users, member);
         r = mboxlist_update_raclmodseq(member);
         if (r) break;
@@ -1087,7 +1087,7 @@ static int mboxlist_update_racl(const char *dbname, const mbentry_t *oldmbentry,
             const char *acluser = strarray_nth(oldusers, i);
             if (!strpbrk(strarray_nth(oldusers, i+1), "lr")) continue;
             if (!strcmpsafe(userid, acluser)) continue;
-            if (strarray_find(admins, acluser, 0) >= 0) continue;
+            if (strarray_contains(admins, acluser)) continue;
             if (user_can_read(newusers, acluser)) continue;
             mboxlist_racl_key(!!userid, acluser, dbname, &buf);
             r = cyrusdb_delete(mbdb, buf.s, buf.len, txn, /*force*/1);
@@ -1101,7 +1101,7 @@ static int mboxlist_update_racl(const char *dbname, const mbentry_t *oldmbentry,
             const char *acluser = strarray_nth(newusers, i);
             if (!strpbrk(strarray_nth(newusers, i+1), "lr")) continue;
             if (!strcmpsafe(userid, acluser)) continue;
-            if (strarray_find(admins, acluser, 0) >= 0) continue;
+            if (strarray_contains(admins, acluser)) continue;
             if (user_can_read(oldusers, acluser)) continue;
             mboxlist_racl_key(!!userid, acluser, dbname, &buf);
             r = cyrusdb_store(mbdb, buf.s, buf.len, "", 0, txn);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1677,7 +1677,7 @@ static int _mboxname_isspecialuse(const char *name, const char *specialuse)
         strarray_t *uses = strarray_split(buf_cstring(&attrib),
                                           " ", STRARRAY_TRIM);
 
-        if (strarray_find_case(uses, specialuse, 0) >= 0) {
+        if (strarray_contains_case(uses, specialuse)) {
             res = 1;
         }
         strarray_free(uses);

--- a/imap/message.c
+++ b/imap/message.c
@@ -3835,7 +3835,7 @@ static int extract_convdata(struct conversations_state *state,
             msgid = lcase(msgid);
 
             /* already seen this one? */
-            if (strarray_find(msgidlist, msgid, 0) >= 0) {
+            if (strarray_contains(msgidlist, msgid)) {
                 free(msgid);
                 continue;
             }

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1814,7 +1814,7 @@ static int sendupdate(const mbentry_t *mbentry, void *rock)
         /* Either there is not a prefix to test, or we matched it */
 
         if (!C->streaming_hosts ||
-            strarray_find(C->streaming_hosts, mbentry->server, 0) >= 0) {
+            strarray_contains(C->streaming_hosts, mbentry->server)) {
             switch (m->t) {
             case SET_ACTIVE:
                 prot_printf(C->pout,

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
             /* Add data & archive paths */
             for (j = 0; datapath[j]; j++) {
                 path = datapath[j](partition, name, NULL, 0);
-                if (!path || strarray_find(oldpaths, path, 0) >= 0) continue;
+                if (!path || strarray_contains(oldpaths, path)) continue;
 
                 strarray_append(oldpaths, path);
                 strarray_append(newpaths,
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
             /* Add metadata paths */
             for (metafile = 0; metafile <= META_ARCHIVECACHE; metafile++) {
                 path = mboxname_metapath(partition, name, NULL, metafile, 0);
-                if (!path || strarray_find(oldpaths, path, 0) >= 0) continue;
+                if (!path || strarray_contains(oldpaths, path)) continue;
 
                 strarray_append(oldpaths, path);
                 strarray_append(newpaths,

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -1437,8 +1437,7 @@ static int search_list_match(message_t *m,
 
     r = getter(m, &buf);
     if (!r && buf.len) {
-        const char *val = buf_cstring(&buf);
-        r = (strarray_find(internal, val, 0) >= 0) ? 1 : 0;
+        r = strarray_contains(internal, buf_cstring(&buf)) ? 1 : 0;
     }
     else
         r = 0;

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -4020,7 +4020,7 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
             xapian_check_if_needs_reindex(srcdirs, toreindex, flags & SEARCH_COMPACT_ONLYUPGRADE);
             for (i = 0; i < srcdirs->count; i++) {
                 const char *thisdir = strarray_nth(srcdirs, i);
-                if (strarray_find(toreindex, thisdir, 0) < 0)
+                if (!strarray_contains(toreindex, thisdir))
                     strarray_append(tocompact, thisdir);
             }
         }

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -205,8 +205,8 @@ static strarray_t *activefile_filter(const strarray_t *active, const strarray_t 
         struct activeitem *item = activeitem_parse(name);
         /* we want to compress anything which can't possibly exist as well
          * as anything which matches the filter tiers */
-        if (!item || strarray_find(tiers, item->tier, 0) >= 0
-                  || strarray_find(tiers, name, 0) >= 0
+        if (!item || strarray_contains(tiers, item->tier)
+                  || strarray_contains(tiers, name)
                   || !xapian_rootdir(item->tier, partition))
             strarray_append(res, name);
         activeitem_free(item);
@@ -3924,7 +3924,7 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
 
     /* are we going to change the first active?  We need to start indexing to
      * a new location! */
-    if (strarray_find(tochange, strarray_nth(active, 0), 0) >= 0) {
+    if (strarray_contains(tochange, strarray_nth(active, 0))) {
         /* always recalculate the first name once the destination is chosen,
         * because we may be compressing to the default tier for some reason */
         char *newstart = activefile_nextname(active, config_getstring(IMAPOPT_DEFAULTSEARCHTIER));

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -288,13 +288,13 @@ static int should_index(const char *name)
 
     // skip listed domains
     if (mbname_domain(mbname) && skip_domains &&
-        strarray_find(skip_domains, mbname_domain(mbname), 0) >= 0) {
+        strarray_contains(skip_domains, mbname_domain(mbname))) {
         ret = 0;
         goto done;
     }
 
     // skip listed users
-    if (userid && skip_users && strarray_find(skip_users, userid, 0) >= 0) {
+    if (userid && skip_users && strarray_contains(skip_users, userid)) {
         ret = 0;
         goto done;
     }

--- a/imap/sync_log.c
+++ b/imap/sync_log.c
@@ -173,7 +173,7 @@ static int sync_log_enabled(const char *channel)
         return 0;       /* entire mechanism is disabled */
     if (!sync_log_suppressed)
         return 1;       /* _suppress() wasn't called */
-    if (unsuppressable && strarray_find(unsuppressable, channel, 0) >= 0)
+    if (unsuppressable && strarray_contains(unsuppressable, channel))
         return 1;       /* channel is unsuppressable */
     return 0;           /* suppressed */
 }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3098,14 +3098,14 @@ int sync_apply_mailbox(struct dlist *kin,
         // add any new
         for (i = 0; i < strarray_size(usergroups); i++) {
             const char *group = strarray_nth(usergroups, i);
-            if (strarray_find(&mygroups, group, 0) >= 0) continue;
+            if (strarray_contains(&mygroups, group)) continue;
             r = mboxlist_set_usergroup(userid, group, /*add*/1, /*silent*/1);
             if (r) goto done;
         }
         // remove any old
         for (i = 0; i < strarray_size(&mygroups); i++) {
             const char *group = strarray_nth(&mygroups, i);
-            if (strarray_find(usergroups, group, 0) >= 0) continue;
+            if (strarray_contains(usergroups, group)) continue;
             r = mboxlist_set_usergroup(userid, group, /*add*/0, /*silent*/1);
             if (r) goto done;
         }
@@ -3466,7 +3466,7 @@ static int remove_cb(const char *sievedir, const char *fname,
             if (ext && !strcmp(ext, BYTECODE_SUFFIX)) {
                 namelen = ext - fname;
                 snprintf(path, sizeof(path), "%.*s", (int) namelen, fname);
-                if (strarray_find(list, path, 0) >= 0) {
+                if (strarray_contains(list, path)) {
                     /* Bytecode for an existing script - keep it */
                     return SIEVEDIR_OK;
                 }

--- a/lib/acl_afs.c
+++ b/lib/acl_afs.c
@@ -252,8 +252,7 @@ EXPORTED int is_system_user(const char *userid)
 
     if (!strcmp(userid, "anyone")) return 1;
     if (!strcmp(userid, "anonymous")) return 1;
-    if (strarray_find(admins, userid, 0) >= 0)
-        return 1;
+    if (strarray_contains(admins, userid)) return 1;
 
     return 0;
 }

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -78,7 +78,7 @@ static int mymemberof(const struct auth_state *auth_state, const char *identifie
 
     if (strcmp(identifier, auth_state->userid) == 0) return 3;
 
-    if (strarray_find(&auth_state->groups, identifier, 0) >= 0) return 2;
+    if (strarray_contains(&auth_state->groups, identifier)) return 2;
 
     return 0;
 }

--- a/lib/auth_unix.c
+++ b/lib/auth_unix.c
@@ -78,7 +78,7 @@ static int mymemberof(const struct auth_state *auth_state, const char *identifie
 
     if (strcmp(identifier, auth_state->userid) == 0) return 3;
 
-    if (!strncmp(identifier, "group:", 6) && strarray_find(&auth_state->groups, identifier+6, 0) >= 0) return 2;
+    if (!strncmp(identifier, "group:", 6) && strarray_contains(&auth_state->groups, identifier+6)) return 2;
 
     return 0;
 }

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -464,7 +464,7 @@ EXPORTED int strarray_intersect(const strarray_t *sa, const strarray_t *sb)
     /* XXX O(n^2)... but we don't have a proper set type */
     int i;
     for (i = 0; i < sa->count; i++)
-        if (strarray_find(sb, strarray_nth(sa, i), 0) >= 0)
+        if (strarray_contains(sb, strarray_nth(sa, i)))
             return 1;
     return 0;
 }
@@ -474,7 +474,7 @@ EXPORTED int strarray_intersect_case(const strarray_t *sa, const strarray_t *sb)
     /* XXX O(n^2)... but we don't have a proper set type */
     int i;
     for (i = 0; i < sa->count; i++)
-        if (strarray_find_case(sb, strarray_nth(sa, i), 0) >= 0)
+        if (strarray_contains_case(sb, strarray_nth(sa, i)))
             return 1;
     return 0;
 }

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -439,6 +439,8 @@ EXPORTED void strarray_uniq(strarray_t *sa)
 static int strarray_findg(const strarray_t *sa, const char *match, int starting,
                           int (*compare)(const char *, const char *))
 {
+    if (!sa) return -1;
+
     int i;
 
     for (i = starting ; i < sa->count ; i++)

--- a/lib/strarray.h
+++ b/lib/strarray.h
@@ -116,6 +116,8 @@ int strarray_find(const strarray_t *sa, const char *match,
                   int starting);
 int strarray_find_case(const strarray_t *sa, const char *match,
                        int starting);
+#define strarray_contains(sa, match) (strarray_find(sa, match, 0) >= 0)
+#define strarray_contains_case(sa, match) (strarray_find_case(sa, match, 0) >= 0)
 
 int strarray_intersect(const strarray_t *sa, const strarray_t *b);
 int strarray_intersect_case(const strarray_t *sa, const strarray_t *b);

--- a/lib/vparse.c
+++ b/lib/vparse.c
@@ -1268,7 +1268,7 @@ EXPORTED int vparse_restriction_check(struct vparse_card *card)
                 }
 
                 /* Like-properties having the same ALTID only get counted once */
-                if (strarray_find(&altids[i], altid, 0) != -1) continue;
+                if (strarray_contains(&altids[i], altid)) continue;
 
                 strarray_append(&altids[i], altid);
                 counts[i]++;

--- a/lib/vparse.c
+++ b/lib/vparse.c
@@ -188,7 +188,7 @@ repeat:
     r = _parse_param_key(state, &haseq);
     if (r) return r;
 
-    if (state->multiparam && strarray_find_case(state->multiparam, state->param->name, 0) >= 0)
+    if (state->multiparam && strarray_contains_case(state->multiparam, state->param->name))
         multiparam = 1;
 
     /* now get the value */
@@ -423,9 +423,9 @@ out:
 
 static int _parse_entry_value(struct vparse_state *state)
 {
-    if (state->multivalsemi && strarray_find_case(state->multivalsemi, state->entry->name, 0) >= 0)
+    if (state->multivalsemi && strarray_contains_case(state->multivalsemi, state->entry->name))
         return _parse_entry_multivalue(state, ';');
-    if (state->multivalcomma && strarray_find_case(state->multivalcomma, state->entry->name, 0) >= 0)
+    if (state->multivalcomma && strarray_contains_case(state->multivalcomma, state->entry->name))
         return _parse_entry_multivalue(state, ',');
 
     NOTESTART();

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -1536,7 +1536,7 @@ envelope_err:
                 if (p) p[1] = '\0';
             }
 
-            if (strarray_find_case(interp->notifymethods, str, 0) == -1)
+            if (!strarray_contains_case(interp->notifymethods, str))
                 res = 0;
         }
 


### PR DESCRIPTION
We had tons of `>= 0` or `< 0` checks for strarray_find and a few bugs where the zero check wasn't done right, so create a more sensible boolean API for the actual question we want to ask!

I also replaced all the uses of strarray_find that are purely of this kind (not using the index for anything else), and grouped the changes into one commit per style of usage (postive vs negative, and comparision or test for -1) for easy reading.

Finally, I have bugfixes for two of the bugs found, and left one complex bug in jmap_mailbox for later examination.