### PR TITLE
docsrc/: Typos i → I

### DIFF
--- a/doc/legacy/changes.html
+++ b/doc/legacy/changes.html
@@ -2078,7 +2078,7 @@ correctly in cyrsudb_db3</li>
 names in cyrus.conf. also logs even more verbosely (see bug
 #115.)</li>
 
-<li>libwrap_init() is now inside the loop, since i don't quite
+<li>libwrap_init() is now inside the loop, since I don't quite
 understand the semantics of libwrap calls.</li>
 
 <li>setquota in cyradm now behaves more sanely (and gives correct
@@ -2089,7 +2089,7 @@ work.)</li>
 
 <li>small fixes in timsieved.</li>
 
-<li>added a "make dist" target so i won't dread releases as
+<li>added a "make dist" target so I won't dread releases as
 much.</li>
 </ul>
 

--- a/docsrc/imap/download/release-notes/2.0/2.0.x.rst
+++ b/docsrc/imap/download/release-notes/2.0/2.0.x.rst
@@ -123,11 +123,11 @@ Changes to the Cyrus IMAP Server since 2.0.6
 *   off-by-one bug in seen_db fixed.
 *   starting/committing/aborting transactions now logged more correctly in cyrsudb_db3
 *   master will now accept port numbers instead of just service names in cyrus.conf. also logs even more verbosely (see bug #115.)
-*   libwrap_init() is now inside the loop, since i don't quite understand the semantics of libwrap calls.
+*   libwrap_init() is now inside the loop, since I don't quite understand the semantics of libwrap calls.
 *   setquota in cyradm now behaves more sanely (and gives correct usage message).
 *   bugfixes to the managesieve client perl api. (still needs work.)
 *   small fixes in timsieved.
-*   added a "make dist" target so i won't dread releases as much.
+*   added a "make dist" target so I won't dread releases as much.
 
 Changes to the Cyrus IMAP Server since 2.0.5
 

--- a/docsrc/imap/reference/manpages/systemcommands/mkimap.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/mkimap.rst
@@ -66,9 +66,9 @@ Examples
     ::
 
         reading configure file /etc/imapd.conf...
-        i will configure directory /var/lib/imap.
-        i saw partition /var/spool/cyrus/mail.
-        i saw partition /var/spool/cyrus/news.
+        I will configure directory /var/lib/imap.
+        I saw partition /var/spool/cyrus/mail.
+        I saw partition /var/spool/cyrus/news.
         done
         configuring /var/lib/imap...
         creating /var/spool/cyrus/mail...


### PR DESCRIPTION
See also https://github.com/cyrusimap/cyrus-imapd/pull/3263.