### PR TITLE
report_sync_col: handle empty <sync-token/>

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -7635,7 +7635,9 @@ int report_sync_col(struct transaction_t *txn, struct meth_params *rparams,
                 syslog(LOG_DEBUG, "scanned token %s to %d %u %llu %llu",
                        str, r, uidvalidity, syncmodseq, basemodseq);
                 /* Sanity check the token components */
-                if (r < 2 || r > 3 ||
+                if (*str == 0) {
+                    /* Initial sync - empty sync-token */
+                } else if (r < 2 || r > 3 ||
                     (uidvalidity != mailbox->i.uidvalidity) ||
                     (syncmodseq > highestmodseq)) {
                     fctx->txn->error.desc = "Invalid sync-token";


### PR DESCRIPTION
I do not why, but this fixes: https://github.com/cyrusimap/cyrus-imapd/issues/4985.

https://www.rfc-editor.org/rfc/rfc6578#section-3.4:

>  When the DAV:sync-collection request contains an empty DAV:sync-token element, the server MUST return all member URLs of the collection (taking account of the DAV:sync-level XML element value as per Section 3.3, and optional truncation of the result set as per Section 3.6) and it MUST NOT return any removed member URLs. All types of member (collection or non-collection) MUST be reported.