### PR TITLE
imap/telemetry: log rusage at LOG_INFO

### DIFF
--- a/imap/telemetry.c
+++ b/imap/telemetry.c
@@ -136,7 +136,7 @@ EXPORTED void telemetry_rusage(char *userid)
          * Some systems provide significantly more data, but POSIX
          * guarantees user & sys CPU time.
          */
-        syslog(LOG_NOTICE, "USAGE %s user: " TIME_T_FMT ".%.6d sys: " TIME_T_FMT ".%.6d", userid,
+        syslog(LOG_INFO, "USAGE %s user: " TIME_T_FMT ".%.6d sys: " TIME_T_FMT ".%.6d", userid,
                user.tv_sec, (int)user.tv_usec,
                sys.tv_sec, (int)sys.tv_usec);
 


### PR DESCRIPTION
The syslog RFC 5424 states that LOG_NOTICE should be used for "normal but significant conditions". USAGE logs aren't significant conditions on the system since they aren't actually conditions at all; they are a way to view numerical metrics on resource usage on a particular action.