### PR TITLE
Fix 3.10.0-rc2 build failure when building against ICU 75 caused by AX_CXX_COMPILE_STDCXX_11 update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -633,7 +633,7 @@ if test "x$enable_xapian" != xno ; then
         fi
 
         dnl Xapian requires CXX11
-        AX_CXX_COMPILE_STDCXX_11([noext], [mandatory])
+        AX_CXX_COMPILE_STDCXX_11([], [mandatory])
 
         dnl If AC_PROG_LIBTOOL (or the deprecated older version AM_PROG_LIBTOOL)
         dnl has already been expanded, enable libtool support now, otherwise add


### PR DESCRIPTION
I recently tried building 3.10.0-rc2 but got the following error from icu_wrap.cpp:

<details><summary>Click to expand error message</summary>

```
  CXX      imap/libcyrus_imap_la-icu_wrap.lo
In file included from /usr/include/unicode/uenum.h:25,
                 from /usr/include/unicode/ucnv.h:52,
                 from imap/icu_wrap.cpp:50:
/usr/include/unicode/localpointer.h:561:26: error: parameter declared 'auto'
  561 | template <typename Type, auto closeFunction>
      |                          ^~~~
/usr/include/unicode/localpointer.h:573:76: error: template argument 2 is invalid
  573 |     explicit LocalOpenPointer(std::unique_ptr<Type, decltype(closeFunction)> &&p)
      |                                                                            ^
/usr/include/unicode/localpointer.h:583:78: error: template argument 2 is invalid
  583 |     LocalOpenPointer &operator=(std::unique_ptr<Type, decltype(closeFunction)> &&p) {
      |                                                                              ^
/usr/include/unicode/localpointer.h:599:59: error: template argument 2 is invalid
  599 |     operator std::unique_ptr<Type, decltype(closeFunction)> () && {
      |                                                           ^
/usr/include/unicode/uenum.h:69:1: note: invalid template non-type parameter
   69 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUEnumerationPointer, UEnumeration, uenum_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/ucnv.h:597:1: note: invalid template non-type parameter
  597 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUConverterPointer, UConverter, ucnv_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/unicode/unistr.h:39,
                 from imap/icu_wrap.cpp:51:
/usr/include/unicode/stringpiece.h:133:29: error: 'enable_if_t' in namespace 'std' does not name a template type
  133 |             typename = std::enable_if_t<
      |                             ^~~~~~~~~~~
/usr/include/unicode/stringpiece.h:133:24: note: 'std::enable_if_t' is only available from C++14 onwards
  133 |             typename = std::enable_if_t<
      |                        ^~~
/usr/include/unicode/stringpiece.h:133:40: error: expected '>' before '<' token
  133 |             typename = std::enable_if_t<
      |                                        ^
/usr/include/unicode/ures.h:268:1: note: invalid template non-type parameter
  268 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUResourceBundlePointer, UResourceBundle, ures_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/ucal.h:803:1: note: invalid template non-type parameter
  803 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUCalendarPointer, UCalendar, ucal_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [Makefile:7330: imap/libcyrus_imap_la-icu_wrap.lo] Error 1
make[2]: Leaving directory '/build/cyrus-imapd/src/cyrus-imapd-3.10.0-rc2'
make[1]: *** [Makefile:7676: all-recursive] Error 1
make[1]: Leaving directory '/build/cyrus-imapd/src/cyrus-imapd-3.10.0-rc2'
make: *** [Makefile:3415: all] Error 2
```

</details>

This is because Cyrus adds `-std=c++11` to the compiler flags even though ICU 75 requires C++17. Interestingly, this build failure occurs only in the 3.10 RC but not 3.8.4. After some investigation, I found that this is because 3.10 comes with an updated version of the AX_CXX_COMPILE_STDCXX_11 macro from the autoconf archive (d216133dffb8eb81dec266600f683f226af5dd04), which behaves differently from the version included in 3.8.

In the old version of the macro (in 3.8), if the compiler supports C++11 features, no `-std=c++11` flag would be added, so any compiler that supports C++17 features by default would simply work. In the new version (in 3.10), however, because the `noext` option is passed to the macro in configure.ac, the macro will *always* add the `-std=c++11` flag to ensure that compiler extensions are turned off, and C++17 features will be disabled even if the compiler has them enabled by default. This then results in a build failure when building against ICU 75, which requires C++17.

Because Cyrus doesn’t seem to disable compiler extensions for C, and I also couldn’t find any specific reason for adding the `noext` option using git blame, this PR simply gets rid of the option. With recent compilers, this will make the C++11 check behave the same as it did in 3.8, and with older compilers, it should simply result in `-std=gnu++11` instead of `-std=c++11` (although I haven’t verified it since I don’t currently have such an older compiler lying around).