### PR TITLE
xml-add_ns: properly handle namespace definition w/o prefix

### DIFF
--- a/cassandane/tiny-tests/Caldav/calendar_setcolor
+++ b/cassandane/tiny-tests/Caldav/calendar_setcolor
@@ -24,11 +24,11 @@ EOF
 
     my $propfindXml = <<EOF;
 <?xml version="1.0" encoding="UTF-8"?>
-<D:propfind xmlns:D="DAV:" xmlns:A="http://apple.com/ns/ical/">
-  <D:prop>
-    <A:calendar-color/>
-  </D:prop>
-</D:propfind>
+<propfind xmlns="DAV:">
+  <prop>
+    <calendar-color xmlns="http://apple.com/ns/ical/"/>
+  </prop>
+</propfind>
 EOF
 
     # Assert that color isn't set.
@@ -42,7 +42,7 @@ EOF
     $response = $CalDAV->Request('PROPPATCH', "/dav/calendars/user/cassandane/". $CalendarId,
                                     $proppatchXml, 'Content-Type' => 'text/xml');
 
-    # Assert color ist set.
+    # Assert color is set.
     $response = $CalDAV->Request('PROPFIND', "/dav/calendars/user/cassandane/". $CalendarId,
                                  $propfindXml, 'Content-Type' => 'text/xml');
     $propstat = $response->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0];

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -1340,8 +1340,16 @@ static int xml_add_ns(xmlNodePtr req, xmlNsPtr *respNs, xmlNodePtr root)
                     ensure_ns(respNs, NS_JMAPCAL, root,
                               (const char *) nsDef->href,
                               (const char *) nsDef->prefix);
-                else
+                else {
+                    if (!nsDef->prefix) {
+                        char myprefix[20];
+                        snprintf(myprefix, sizeof(myprefix), "X%X",
+                                 strhash((const char *) nsDef->href) & 0xffff);
+                        nsDef->prefix = xmlStrdup(BAD_CAST myprefix);
+                    }
+
                     xmlNewNs(root, nsDef->href, nsDef->prefix);
+                }
             }
         }
 


### PR DESCRIPTION
More correct fix for #4489.  Supersedes #5003 