### PR TITLE
github-actions: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Cyrus IMAP CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
This will supposedly permit us to kick off CI workflow runs manually, without needing a push to a PR or official branch to trigger it.  It might be useful when reviewing ancient PRs that haven't had a CI run before.

Note that the [documentation](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) says that to use this trigger, "your workflow must be in the default branch".  I think this means there's no useful way to test whether this works (or is useful to us) except just merge it to master and see what happens.

There's a bunch of options for further configuring this trigger, but they haven't sounded useful to me just from reading about them.  I figure for now we just turn it on and see what we get by default, and refine it later if we think it'll help.