### PR TITLE
misc fixes from building on 32-bit architectures with 64-bit time_t

### DIFF
--- a/backup/lcb_compact.c
+++ b/backup/lcb_compact.c
@@ -143,8 +143,8 @@ static int compact_closerename(struct backup **originalp,
     struct buf ts_index_fname = BUF_INITIALIZER;
     int r;
 
-    buf_printf(&ts_data_fname, "%s.%ld", original->data_fname, now);
-    buf_printf(&ts_index_fname, "%s.%ld", original->index_fname, now);
+    buf_printf(&ts_data_fname, "%s." TIME_T_FMT, original->data_fname, now);
+    buf_printf(&ts_index_fname, "%s." TIME_T_FMT, original->index_fname, now);
 
     /* link original files into timestamped names */
     r = link(original->data_fname, buf_cstring(&ts_data_fname));

--- a/backup/lcb_indexw.c
+++ b/backup/lcb_indexw.c
@@ -609,7 +609,7 @@ static int _index_sub(struct backup *backup, struct dlist *dl,
 
     /* set the unsubscribed time if this is an UNSUB */
     if (!strcmp(dl->name, "UNSUB")) {
-        syslog(LOG_DEBUG, "setting unsubscribed to %ld for %s", ts, mboxname);
+        syslog(LOG_DEBUG, "setting unsubscribed to " TIME_T_FMT " for %s", ts, mboxname);
         struct sqldb_bindval *unsubscribed_bval = &bval[2];
         assert(strcmp(unsubscribed_bval->name, ":unsubscribed") == 0);
         unsubscribed_bval->type = SQLITE_INTEGER;

--- a/cunit/ical_support.testc
+++ b/cunit/ical_support.testc
@@ -122,14 +122,13 @@ static void test_icalrecurrenceset_get_utc_timespan(void)
         "20160928T160000Z",
         "20170228T170000Z",
         1
-    }, {
-        NULL, NULL, NULL, NULL, 0
     }};
+    const size_t n_tcs = sizeof(tcs) / sizeof(tcs[0]);
 
     struct buf buf = BUF_INITIALIZER;
-    struct testcase *tc;
-    for (tc = tcs; tc->icalstr; tc++) {
-        // fprintf(stderr, "%s: %s\n", __func__, tc->desc);
+    unsigned i;
+    for (i = 0; i < n_tcs; i++) {
+        const struct testcase *tc = &tcs[i];
         buf_setcstr(&buf, tc->icalstr);
         icalcomponent *ical = ical_string_as_icalcomponent(&buf);
         CU_ASSERT_PTR_NOT_NULL(ical);
@@ -197,3 +196,5 @@ static void test_icalcomponent_myforeach_duplicate_rrule(void)
     icalcomponent_free(ical);
     buf_free(&buf);
 }
+
+/* vim: set ft=c: */

--- a/cunit/timeofday.c
+++ b/cunit/timeofday.c
@@ -198,8 +198,13 @@ void time_restore(void)
 /* call the real libc function */
 static int real_gettimeofday(struct timeval *tv, ...)
 {
+#if defined(__USE_TIME_BITS64)
+    extern int __gettimeofday64(struct timeval *, ...);
+    return __gettimeofday64(tv, NULL);
+#else
     extern int __gettimeofday(struct timeval *, ...);
     return __gettimeofday(tv, NULL);
+#endif
 }
 
 /* provide a function to hide the libc weak alias */

--- a/imap/cyr_ls.c
+++ b/imap/cyr_ls.c
@@ -181,7 +181,10 @@ static void long_list(struct stat *statp)
 
     strftime(datestr, 13, datefmt, localtime(&(statp->st_ctime)));
 
-    printf("%c%c%c%c%c%c%c%c%c%c %" PRIuMAX " %-8s %-8s % 10ld %s ",
+    /* XXX statp->st_size should use OFF_T_FMT not PRIi64, but our FMT
+     * XXX macros don't allow setting flags
+     */
+    printf("%c%c%c%c%c%c%c%c%c%c %" PRIuMAX " %-8s %-8s % 10" PRIi64 " %s ",
            S_ISDIR(statp->st_mode) ? 'd' : '-',
            (statp->st_mode & S_IRUSR) ? 'r' : '-',
            (statp->st_mode & S_IWUSR) ? 'w' : '-',
@@ -194,7 +197,7 @@ static void long_list(struct stat *statp)
            (statp->st_mode & S_IXOTH) ? 'x' : '-',
            (uintmax_t) statp->st_nlink, // int size differs by platform
            pwd->pw_name, grp->gr_name,
-           statp->st_size, datestr);
+           (int64_t) statp->st_size, datestr);
 }
 
 struct list_opts {

--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -137,7 +137,8 @@ static void req_hdr_to_env(const char *name, const char *contents,
         if (exists) {
             /* Append value to existing value(s) */
             const char *next = strchr(exists + 1, '\t');
-            unsigned offset = next ? next - env_str : (unsigned) strlen(env_str);
+            unsigned offset = next ? (unsigned) (next - env_str)
+                                   : (unsigned) strlen(env_str);
 
             buf_insertcstr(environ, offset, ", ");
             buf_insertcstr(environ, offset + 2, contents);

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -855,7 +855,8 @@ static int dav_store_notification(struct transaction_t *txn,
     }
 
     buf_reset(&txn->buf);
-    buf_printf(&txn->buf, "<%s-%ld@%s>", resource, time(0), config_servername);
+    buf_printf(&txn->buf, "<%s-" TIME_T_FMT "@%s>",
+                          resource, time(0), config_servername);
     spool_replace_header(xstrdup("Message-ID"),
                          buf_release(&txn->buf), txn->req_hdrs);
 

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -1553,7 +1553,8 @@ static struct prot_waitevent *es_push(struct protstream *s __attribute__((unused
     int do_close = 0;
 
     xsyslog(LOG_DEBUG, "JMAP eventSource push",
-            "accountid=<%s>, now=<%ld>, next_poll=<%ld>, next_ping=<%ld>",
+            "accountid=<%s>, now=<" TIME_T_FMT ">,"
+            " next_poll=<" TIME_T_FMT ">, next_ping=<" TIME_T_FMT ">",
             jpush->accountid, now, jpush->next_poll, jpush->next_ping);
 
     buf_reset(buf);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -3053,10 +3053,10 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
     txn->conn->begin_resp_headers(txn, code);
 
 
+    now = time(0);
     switch (code) {
     default:
         /* Final response */
-        now = time(0);
         httpdate_gen(datestr, sizeof(datestr), now);
         simple_hdr(txn, "Date", "%s", datestr);
 

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -1490,7 +1490,7 @@ icalrecurrenceset_get_utc_timespan(icalcomponent *ical,
                     }
                     else if (!recur.count) {
                         /* Recurrence never ends - set end of span to eternity */
-                        span.end =
+                        period.end =
                             icaltime_from_timet_with_zone(caldav_eternity, 0, NULL);
 
                         /* Skip RRULE & RDATE expansion */
@@ -1506,7 +1506,7 @@ icalrecurrenceset_get_utc_timespan(icalcomponent *ical,
                         comp,
                         icaltime_from_timet_with_zone(caldav_epoch, 0, NULL),
                         icaltime_from_timet_with_zone(caldav_eternity, 0, NULL),
-                        utc_timespan_cb, &span);
+                        utc_timespan_cb, &period);
             }
 
             /* Add RRULEs back, if we had removed them before. */

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -385,7 +385,7 @@ static int restore_collection_cb(const mbentry_t *mbentry, void *rock)
     if ((rrock->jrestore->mode & UNDO_ALL) &&
         rrock->jrestore->cutoff < rrock->mailbox->i.changes_epoch) {
         syslog(log_level,
-               "skipping '%s': cutoff (%ld) prior to mailbox history (%ld)",
+               "skipping '%s': cutoff (" TIME_T_FMT ") prior to mailbox history (" TIME_T_FMT")",
                mailbox_name(rrock->mailbox), rrock->jrestore->cutoff,
                rrock->mailbox->i.changes_epoch);
 
@@ -403,7 +403,8 @@ static int restore_collection_cb(const mbentry_t *mbentry, void *rock)
 
         resource = rrock->resource_name_cb(msg, rrock->rock);
         syslog(log_level,
-               "UID %u: expunged: %x, savedate: %ld, updated: %ld, name: %s",
+               "UID %u: expunged: %x, savedate: " TIME_T_FMT ","
+               " updated: " TIME_T_FMT ", name: %s",
                record->uid, (record->internal_flags & FLAG_INTERNAL_EXPUNGED),
                record->savedate, record->last_updated,
                resource ? resource : "NULL");
@@ -903,7 +904,7 @@ static int jmap_backup_restore_contacts(jmap_req_t *req)
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     char *addrhomeset = carddav_mboxname(req->accountid, NULL);
 
-    syslog(restore.log_level, "jmap_backup_restore_contacts(%s, %ld)",
+    syslog(restore.log_level, "jmap_backup_restore_contacts(%s, " TIME_T_FMT ")",
            addrhomeset, restore.cutoff);
 
     struct contact_rock crock =
@@ -1396,7 +1397,7 @@ static int jmap_backup_restore_calendars(jmap_req_t *req)
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     char *calhomeset = caldav_mboxname(req->accountid, NULL);
 
-    syslog(restore.log_level, "jmap_backup_restore_calendars(%s, %ld)",
+    syslog(restore.log_level, "jmap_backup_restore_calendars(%s, " TIME_T_FMT ")",
            calhomeset, restore.cutoff);
 
     struct calendar_rock crock =
@@ -1489,7 +1490,7 @@ static int jmap_backup_restore_notes(jmap_req_t *req)
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     const char *subfolder = config_getstring(IMAPOPT_NOTESMAILBOX);
 
-    syslog(restore.log_level, "jmap_backup_restore_notes(%s, %ld)",
+    syslog(restore.log_level, "jmap_backup_restore_notes(%s, " TIME_T_FMT ")",
            subfolder ? subfolder : "NULL", restore.cutoff);
 
     if (subfolder) {
@@ -1614,7 +1615,7 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
     if (mboxname_isdeletedmailbox(mbentry->name, &timestamp)) {
         if (timestamp <= rrock->jrestore->cutoff) {
             /* Mailbox was destroyed before cutoff - not interested */
-            syslog(log_level, "skipping '%s': destroyed (%ld) before cutoff",
+            syslog(log_level, "skipping '%s': destroyed (" TIME_T_FMT ") before cutoff",
                    mbentry->name, timestamp);
 
             return 0;
@@ -1642,7 +1643,8 @@ static int restore_message_list_cb(const mbentry_t *mbentry, void *rock)
         int ignore_draft = 0;
 
         syslog(log_level,
-               "UID %u: expunged: %x, draft: %x, intdate: %ld, updated: %ld",
+               "UID %u: expunged: %x, draft: %x,"
+               " intdate: " TIME_T_FMT ", updated: " TIME_T_FMT,
                record->uid, (record->internal_flags & FLAG_INTERNAL_EXPUNGED),
                (record->system_flags & FLAG_DRAFT),
                record->internaldate, record->last_updated);
@@ -2142,7 +2144,7 @@ static int jmap_backup_restore_mail(jmap_req_t *req)
     hash_table msgids = HASH_TABLE_INITIALIZER;
     char *inbox = mboxname_user_mbox(req->accountid, NULL);
 
-    syslog(restore.log_level, "jmap_backup_restore_mail(%s, %ld)",
+    syslog(restore.log_level, "jmap_backup_restore_mail(%s, " TIME_T_FMT ")",
            inbox, restore.cutoff);
 
     struct mail_rock mrock = {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3476,7 +3476,7 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                     else {
                         // most likely guidsearch_rank_clause must be
                         // updated to reject this unsupported flag
-                        syslog(LOG_ERR, "%s: ignoring unsupported flag: %0lx",
+                        syslog(LOG_ERR, "%s: ignoring unsupported flag: %0" PRIx64,
                                 __func__, e->value.u);
                     }
                 }

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -418,7 +418,7 @@ static int store_submission(jmap_req_t *req, struct mailbox *mailbox,
             "From: %s\r\n"
             "Subject: JMAP EmailSubmission for %s\r\n"
             "Content-Type: message/rfc822\r\n"
-            "Content-Length: %ld\r\n"
+            "Content-Length: " SIZE_T_FMT "\r\n"
             "%s: ", datestr, from,
             json_string_value(json_object_get(emailsubmission, "emailId")),
             msglen, JMAP_SUBMISSION_HDR);

--- a/imap/jmap_notif.c
+++ b/imap/jmap_notif.c
@@ -226,7 +226,8 @@ static int append_eventnotif(const char *from,
     fputs(date5322, fp);
     fputs("\r\n", fp);
 
-    fprintf(fp, "Message-ID: <%s-%ld@%s>\r\n", makeuuid(), created, config_servername);
+    fprintf(fp, "Message-ID: <%s-" TIME_T_FMT "@%s>\r\n",
+                makeuuid(), created, config_servername);
     fputs("Content-Type: application/json; charset=utf-8\r\n", fp);
     fputs("Content-Transfer-Encoding: 8bit\r\n", fp);
 

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -1827,7 +1827,7 @@ static int snooze(void *ac,
         uint64_t t = arrayu64_nth(sn->times, i);
 
         buf_reset(sd->buf);
-        buf_printf(sd->buf, "%02lu:%02lu:%02lu",
+        buf_printf(sd->buf, "%02" PRIu64 ":%02" PRIu64 ":%02" PRIu64,
                    t / 3600, (t % 3600) / 60, t % 60);
         json_array_append_new(jtimes, json_string(buf_cstring(sd->buf)));
     }

--- a/imap/mbtool.c
+++ b/imap/mbtool.c
@@ -205,7 +205,7 @@ static int do_timestamp(const mbname_t *mbname)
     while ((msg = mailbox_iter_step(iter))) {
         const struct index_record *record = msg_record(msg);
         /* 1 day is close enough */
-        if (labs(record->internaldate - record->gmtime) < 86400)
+        if (llabs(record->internaldate - record->gmtime) < 86400)
             continue;
 
         struct index_record copyrecord = *record;

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -515,12 +515,12 @@ static void get_searchparts(const char *key, const char *val, void *rock)
 
             buf_setcstr(&buf, basedir);
             buf_appendcstr(&buf, XAPIAN_DIRNAME);
-            if (gen) buf_printf(&buf, ".%lu", gen);
+            if (gen) buf_printf(&buf, ".%" PRIu64, gen);
             strarray_append(srock->oldpaths, buf_cstring(&buf));
 
             buf_setcstr(&buf, val);
             buf_printf(&buf, FNAME_USERDIR "%s" XAPIAN_DIRNAME, srock->userpath);
-            if (gen) buf_printf(&buf, ".%lu", gen);
+            if (gen) buf_printf(&buf, ".%" PRIu64, gen);
             strarray_append(srock->newpaths, buf_cstring(&buf));
         }
     }

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -613,7 +613,7 @@ static int store_script(struct mailbox *mailbox, struct sieve_data *sdata,
     fprintf(f, "Message-ID: <%s@%s>\r\n", sdata->contentid, config_servername);
 
     fprintf(f, "Content-Type: application/sieve; charset=utf-8\r\n");
-    fprintf(f, "Content-Length: %lu\r\n", datalen);
+    fprintf(f, "Content-Length: " SIZE_T_FMT "\r\n", datalen);
     fprintf(f, "Content-Disposition: attachment;\r\n\tfilename=\"%s%s\"\r\n",
             sdata->id ? sdata->id : makeuuid(), SIEVE_EXTENSION);
     fputs("MIME-Version: 1.0\r\n", f);

--- a/lib/times.c
+++ b/lib/times.c
@@ -41,6 +41,7 @@
  */
 
 #include <ctype.h>
+#include <inttypes.h>
 #include <memory.h>
 #include <stdio.h>
 #include <string.h>
@@ -551,10 +552,13 @@ static int breakdown_time_to_iso8601(const struct timeval *t, struct tm *tm,
     if (rlen > 0) {
         switch(tv_precision) {
         case timeval_ms:
-            rlen += snprintf(buf+rlen, len-rlen, ".%.3lu", t->tv_usec/1000);
+            /* no portable format conversion for tv_usec, just cast to int64_t */
+            rlen += snprintf(buf+rlen, len-rlen, ".%.3" PRIi64,
+                             (int64_t) t->tv_usec/1000);
             break;
         case timeval_us:
-            rlen += snprintf(buf+rlen, len-rlen, ".%.6lu", t->tv_usec);
+            rlen += snprintf(buf+rlen, len-rlen, ".%.6" PRIi64,
+                             (int64_t) t->tv_usec);
             break;
         case timeval_s:
             break;


### PR DESCRIPTION
I spent some time a few months ago trying to track down a variety of build failures on armel, armhf, and some others platforms affected by Debian's transition to providing a 64-bit time_t on these 32-bit platforms (#4876, #4887), but eventually stalled out on a stack smashing problem that seemed to be coming from within libical.  @rjbs and I decided that it wasn't worth spending more time chasing the problem around since it makes no sense to run an IMAP service on these sort of devices anyway.

This PR is a distillation of the useful changes I made while investigating.