### PR TITLE
deliver_merge_reply(): use icaltimezone_get_location_tzid()

### DIFF
--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -546,7 +546,7 @@ static const char *deliver_merge_reply(icalcomponent *ical,  // current iCalenda
             /* Create a new override from the master component
                and add it to the current object */
             icalproperty *recuridp = icalproperty_new_recurrenceid(recurid);
-            const char *tzid = icaltimezone_get_location(startzone);
+            const char *tzid = icaltimezone_get_location_tzid(startzone);
             if (tzid) {
                 icalproperty_set_parameter(recuridp, icalparameter_new_tzid(tzid));
             }


### PR DESCRIPTION
This fixes a bug where creating an override for an event where the VTIMEZONE doesn't include X-LIC-LOCATION would result in the RECURRENCE-ID missing TZID