### PR TITLE
caldav_alarm: support suppressing alarms for VEVENT or VTODO

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -479,6 +479,11 @@ magic(Mboxgroups => sub {
     my $self = shift;
     $self->config_set('auth_mech' => 'mboxgroups');
 });
+magic(CaldavAlarmOnlyVevent => sub {
+    my $self = shift;
+    $self->config_set('caldav_alarm_support_components' => 'VEVENT');
+});
+
 
 # Run any magic handlers indicated by the test name or attributes
 sub _run_magic

--- a/cassandane/tiny-tests/CaldavAlarm/supported_components
+++ b/cassandane/tiny-tests/CaldavAlarm/supported_components
@@ -1,0 +1,98 @@
+#!perl
+use Cassandane::Tiny;
+use Data::UUID;
+
+sub initialize_test {
+    my ($self, $now) = @_;
+    my $caldav = $self->{caldav};
+
+    xlog $self, "Create calendars for VEVENT and VTODO";
+    my $eventCalendarId = $caldav->NewCalendar({ name => 'Events' });
+    $self->assert_not_null($eventCalendarId);
+    my $todoCalendarId = $caldav->NewCalendar({ name => 'Todos' });
+    $self->assert_not_null($todoCalendarId);
+
+    xlog $self, "Create VEVENT with alarm triggering in a few seconds";
+    my $start = $now->clone;
+    $start->add(DateTime::Duration->new(seconds => 2));
+    $self->create_component($eventCalendarId, "VEVENT", "event", $start);
+
+    xlog $self, "Create VTODO with alarm triggering in about an hour";
+    $start = $now->clone;
+    $start->add(DateTime::Duration->new(hours => 1, seconds => 2));
+    $self->create_component($todoCalendarId, "VTODO", "todo", $start);
+}
+
+sub test_supported_components
+  : needs_component_calalarmd {
+
+    my ($self) = @_;
+    my $now = DateTime->now();
+
+    $self->initialize_test($now);
+
+    xlog $self, "Assert VEVENT alarm triggers";
+    $self->{instance}->getnotify();
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 60);
+    $self->assert_alarms({ summary => 'event' });
+
+    xlog $self, "Assert VTODO alarm triggers";
+    $self->{instance}->getnotify();
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 3600 + 60);
+    $self->assert_alarms({ summary => 'todo' });
+}
+
+sub test_supported_components_only_vevent
+  : needs_component_calalarmd : CaldavAlarmOnlyVevent {
+
+    my ($self) = @_;
+    my $now = DateTime->now();
+
+    $self->initialize_test($now);
+
+    xlog $self, "Assert VEVENT alarm triggers";
+    $self->{instance}->getnotify();
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 60);
+    $self->assert_alarms({ summary => 'event' });
+
+    xlog $self, "Assert VTODO alarm does not trigger";
+    $self->{instance}->getnotify();
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 3600 + 60);
+    $self->assert_alarms();
+}
+
+sub create_component {
+    my ($self, $calendarId, $compName, $summary, $start) = @_;
+    my $caldav = $self->{caldav};
+
+    my $dtStamp = DateTime->now();
+    $dtStamp->set_time_zone('Etc/UTC');
+    $dtStamp = $dtStamp->strftime('%Y%m%dT%H%M%SZ');
+
+    my $dtStart = $start->strftime('%Y%m%dT%H%M%SZ');
+    my $uid     = (Data::UUID->new)->create_str;
+    $caldav->Request(
+        'PUT', "$calendarId/$uid.ics", <<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:$compName
+UID:$uid
+DTSTART:$dtStart
+DURATION:PT1H
+SUMMARY:$summary
+DTSTAMP:$dtStamp
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:PT0S
+ACTION:DISPLAY
+SUMMARY:alarm
+END:VALARM
+END:$compName
+END:VCALENDAR
+EOF
+        , 'Content-Type' => 'text/calendar'
+    );
+}
+

--- a/changes/next/caldav_alarm_supported_components
+++ b/changes/next/caldav_alarm_supported_components
@@ -1,0 +1,18 @@
+Description:
+
+Adds config option `caldav_alarm_support_components` to suppress alarms for all but select iCalendar component types.
+
+
+Config changes:
+
+caldav_alarm_support_components
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+Replaces pull request https://github.com/cyrusimap/cyrus-imapd/pull/3284

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -598,6 +598,10 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* Accept invalid RRULEs (e.g. FREQ=WEEKLY;BYMONTHDAY=15)
   rather than rejecting them as errors. */
 
+{ "caldav_alarm_support_components", "VEVENT VTODO", BITFIELD("VEVENT", "VTODO"), "UNRELEASED" }
+/* Space-separated list of iCalendar component types for which
+   calalarmd generates alarms. */
+
 { "caldav_alarm_suppress_file", NULL, STRING, "UNRELEASED" }
 /* If this file exists, calalarmd will not process events */
 


### PR DESCRIPTION
This adds the `caldav_alarm_support_components` imapd.conf option to define if alarms should be sent for VEVENT, VTODO, or both. The default is to send alarms for both.

Before this change, VALARMs were processed for any iCalendar component type that libical deems to be a "real" component, that is one of: VEVENT, VTODO, VJOURNAL, VFREEBUSY, VAVAILABILITY, VPOLL, VPATCH, VQUERY, VAGENDA. In practice, RFC 5545 only defines VEVENT and VTODO to contain VALARM components and the temporal semantics for relative alarm triggers would be undefined for the other component types anyway.

Restricting supported components explicitly to VEVENT and VTODO seems to make configuration more clear than some general scheme.