### PR TITLE
Resolve clang-tidy warnings for Xapian wrapper

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -5363,7 +5363,7 @@ static void stuff_converted_part(search_text_receiver_t *receiver,
 
     receiver->begin_part(receiver, part);
     receiver->append_text(receiver, buf);
-    receiver->end_part(receiver, part);
+    receiver->end_part(receiver);
 }
 
 static void stuff_part(search_text_receiver_t *receiver,
@@ -5428,7 +5428,7 @@ static int extract_icalbuf(struct buf *raw, charset_t charset, int encoding,
             str->receiver->begin_part(str->receiver, SEARCH_PART_BODY);
             charset_extract(extract_cb, str, &buf, utf8, 0, "calendar",
                             str->charset_flags);
-            str->receiver->end_part(str->receiver, SEARCH_PART_BODY);
+            str->receiver->end_part(str->receiver);
             charset_free(&utf8);
             buf_reset(&buf);
         }
@@ -5603,7 +5603,7 @@ static int extract_vcardbuf(struct buf *raw, charset_t charset, int encoding,
         str->receiver->begin_part(str->receiver, SEARCH_PART_BODY);
         charset_extract(extract_cb, str, &buf, utf8, 0, "vcard",
                         str->charset_flags);
-        str->receiver->end_part(str->receiver, SEARCH_PART_BODY);
+        str->receiver->end_part(str->receiver);
         charset_free(&utf8);
         buf_reset(&buf);
     }
@@ -5694,7 +5694,7 @@ static int extract_vcardbuf(struct buf *raw, charset_t charset, int encoding,
         str->receiver->begin_part(str->receiver, SEARCH_PART_BODY);
         charset_extract(extract_cb, str, &buf, utf8, 0, "vcard",
                         str->charset_flags);
-        str->receiver->end_part(str->receiver, SEARCH_PART_BODY);
+        str->receiver->end_part(str->receiver);
         charset_free(&utf8);
         buf_reset(&buf);
     }
@@ -5848,7 +5848,7 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
             str->receiver->begin_part(str->receiver, SEARCH_PART_BODY);
             charset_extract(extract_cb, str, data, charset, encoding, mysubtype,
                            mycharset_flags);
-            str->receiver->end_part(str->receiver, SEARCH_PART_BODY);
+            str->receiver->end_part(str->receiver);
         }
     }
 #ifdef USE_HTTPD
@@ -5892,7 +5892,7 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
                 /* Append extracted text */
                 str->receiver->begin_part(str->receiver, SEARCH_PART_ATTACHMENTBODY);
                 str->receiver->append_text(str->receiver, &text);
-                str->receiver->end_part(str->receiver, SEARCH_PART_ATTACHMENTBODY);
+                str->receiver->end_part(str->receiver);
             }
             else if (r) {
                 syslog(LOG_ERR, "IOERROR index: can't extract attachment %s (%s/%s): %s",

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5921,7 +5921,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
     json_t *val;
     size_t i;
     char *mboxname = NULL;
-    static search_snippet_markup_t markup = { "<mark>", "</mark>", "..." };
+    static struct search_snippet_markup markup = { "<mark>", "</mark>", "..." };
     strarray_t partids = STRARRAY_INITIALIZER;
 
     ptrarray_t search_attrs = PTRARRAY_INITIALIZER;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5841,11 +5841,11 @@ static int _snippet_tr_append_text(search_text_receiver_t *rx,
         sr->next->append_text(sr->next, text) : 0;
 }
 
-static void _snippet_tr_end_part(search_text_receiver_t *rx, int part)
+static void _snippet_tr_end_part(search_text_receiver_t *rx)
 {
     struct snippet_receiver *sr = (struct snippet_receiver*) rx;
     sr->search_part = -1;
-    if (sr->next->end_part) sr->next->end_part(sr->next, part);
+    if (sr->next->end_part) sr->next->end_part(sr->next);
 }
 
 static void _snippet_tr_end_bodypart(search_text_receiver_t *rx)

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -525,7 +525,7 @@ static int _matchmime_tr_begin_bodypart(search_text_receiver_t *rx __attribute__
 }
 
 static void _matchmime_tr_begin_part(search_text_receiver_t *rx __attribute__((unused)),
-                                     int part __attribute__((unused)))
+                                     enum search_part part __attribute__((unused)))
 {
 }
 
@@ -552,7 +552,7 @@ static int _matchmime_tr_append_text(search_text_receiver_t *rx,
     return 0;
 }
 
-static void _matchmime_tr_end_part(search_text_receiver_t *rx, int part)
+static void _matchmime_tr_end_part(search_text_receiver_t *rx, enum search_part part)
 {
     struct matchmime_receiver *tr = (struct matchmime_receiver *) rx;
     xapian_dbw_doc_part(tr->matchmime->dbw, &tr->buf, part);
@@ -916,6 +916,7 @@ static int _email_matchmime_evaluate(json_t *filter,
         int i;
         for (i = 0 ; i < SEARCH_NUM_PARTS ; i++) {
             switch (i) {
+                case SEARCH_PART_ANY:
                 case SEARCH_PART_LISTID:
                 case SEARCH_PART_TYPE:
                 case SEARCH_PART_LANGUAGE:

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -1309,7 +1309,7 @@ HIDDEN matchmime_t *jmap_email_matchmime_new(const struct buf *mime, json_t **er
     const char *paths[2];
     paths[0] = matchmime->dbpath;
     paths[1] = NULL;
-    r = xapian_dbw_open(paths, &matchmime->dbw, /*mode*/0, /*nosync*/1);
+    r = xapian_dbw_open(paths, &matchmime->dbw, XAPIAN_DBW_NOSYNC);
     if (r) {
         syslog(LOG_ERR, "jmap_matchmime: can't open search backend: %s",
                 error_message(r));

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -105,7 +105,7 @@ EXPORTED const struct search_engine *search_engine(void)
     }
 }
 
-EXPORTED search_snippet_markup_t default_snippet_markup = {
+EXPORTED struct search_snippet_markup default_snippet_markup = {
     "<b>", "</b>", "..."
 };
 
@@ -580,7 +580,7 @@ EXPORTED int search_end_update(search_text_receiver_t *rx)
 
 EXPORTED search_text_receiver_t *search_begin_snippets(void *internalised,
                                                        int verbose,
-                                                       search_snippet_markup_t *markup,
+                                                       struct search_snippet_markup *markup,
                                                        search_snippet_cb_t proc,
                                                        void *rock)
 {

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -91,13 +91,13 @@ struct search_builder {
     unsigned (*min_index_version)(search_builder_t*);
 };
 
-typedef struct search_snippet_markup {
+struct search_snippet_markup {
     const char *hi_start;
     const char *hi_end;
     const char *omit;
-} search_snippet_markup_t;
+};
 
-extern search_snippet_markup_t default_snippet_markup;
+extern struct search_snippet_markup default_snippet_markup;
 
 /* The functions in search_text_receiver_t get called at least once for each part of every message.
    The invocations form a sequence:
@@ -184,7 +184,7 @@ struct search_engine {
     int (*end_update)(search_text_receiver_t *);
     search_text_receiver_t *(*begin_snippets)(void *internalised,
                                               int verbose,
-                                              search_snippet_markup_t *markup,
+                                              struct search_snippet_markup *markup,
                                               search_snippet_cb_t,
                                               void *rock);
     int (*end_snippets)(search_text_receiver_t *);
@@ -240,7 +240,7 @@ int search_end_update(search_text_receiver_t *rx);
  * to receive more snippets for this message. */
 search_text_receiver_t *search_begin_snippets(void *internalised,
                                               int verbose,
-                                              search_snippet_markup_t *markup,
+                                              struct search_snippet_markup *markup,
                                               search_snippet_cb_t proc,
                                               void *rock);
 int search_end_snippets(search_text_receiver_t *rx);

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -112,7 +112,7 @@ extern struct search_snippet_markup default_snippet_markup;
        ...
        receiver->begin_part(<partN>)
        receiver->append_text(<text>)     (1 or more times)
-       receiver->end_part(<partN>)
+       receiver->end_part()
        receiver->begin_bodypart(<bodypart1>)
 
        receiver->end_message()
@@ -137,7 +137,7 @@ struct search_text_receiver {
     void (*begin_part)(search_text_receiver_t *, enum search_part);
     /* Returns IMAP_MESSAGE_TOO_LARGE if no more bytes are accepted */
     int  (*append_text)(search_text_receiver_t *, const struct buf *);
-    void (*end_part)(search_text_receiver_t *, enum search_part);
+    void (*end_part)(search_text_receiver_t *);
     void (*end_bodypart)(search_text_receiver_t *);
 #define SEARCH_INDEXLEVEL_BASIC 1
 #define SEARCH_INDEXLEVEL_ATTACH 3

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -57,7 +57,7 @@
 #define XAPIAN_DIRNAME       "/xapian"
 
 extern int xapian_basedir(const char *tier, const char *mboxname,
-                          const char *part, const char *root, char **basedir);
+                          const char *partition, const char *root, char **basedir);
 
 typedef int (*search_hit_cb_t)(const char *mboxname, uint32_t uidvalidity,
                                uint32_t uid, const char *partid, void *rock);
@@ -66,7 +66,7 @@ typedef int (*search_hitguid_cb_t)(const conv_guidrec_t *rec, size_t nguids,
                                    void *rock);
 
 typedef int (*search_snippet_cb_t)(struct mailbox *, uint32_t uid,
-                                   /* SEARCH_PART_* constants */int part,
+                                   enum search_part part,
                                    const char *bodypartid,
                                    const char *snippet, void *rock);
 
@@ -82,8 +82,8 @@ struct search_builder {
 #define SEARCH_OP_FALSE     105
     void (*begin_boolean)(search_builder_t *, int op);
     void (*end_boolean)(search_builder_t *, int op);
-    void (*match)(search_builder_t *, int part, const char *str);
-    void (*matchlist)(search_builder_t *, int part, const strarray_t *items);
+    void (*match)(search_builder_t *, enum search_part, const char *str);
+    void (*matchlist)(search_builder_t *, enum search_part, const strarray_t *items);
     void *(*get_internalised)(search_builder_t *);
     int (*run)(search_builder_t *, search_hit_cb_t proc, void *rock);
     /* XXX - guidsearch is a hack for speeding up JMAP email queries */
@@ -134,10 +134,10 @@ struct search_text_receiver {
     int (*begin_bodypart)(search_text_receiver_t *, const char *partid,
                           const struct message_guid *content_guid,
                           const char *type, const char *subtype);
-    void (*begin_part)(search_text_receiver_t *, int part);
+    void (*begin_part)(search_text_receiver_t *, enum search_part);
     /* Returns IMAP_MESSAGE_TOO_LARGE if no more bytes are accepted */
     int  (*append_text)(search_text_receiver_t *, const struct buf *);
-    void (*end_part)(search_text_receiver_t *, int part);
+    void (*end_part)(search_text_receiver_t *, enum search_part);
     void (*end_bodypart)(search_text_receiver_t *);
 #define SEARCH_INDEXLEVEL_BASIC 1
 #define SEARCH_INDEXLEVEL_ATTACH 3
@@ -197,7 +197,7 @@ struct search_engine {
     int (*deluser)(const struct mboxlist_entry *mbentry);
     int (*check_config)(char **errstr);
     int (*langstats)(const char *userid, ptrarray_t *lstats, size_t *total_docs);
-    int (*can_match)(enum search_op matchop, int partnum);
+    int (*can_match)(enum search_op matchop, enum search_part);
     int (*upgrade)(const char *userid);
 };
 
@@ -256,13 +256,13 @@ int search_check_config(char **errstr);
 
 int search_upgrade(const char *userid);
 
-int search_can_match(enum search_op matchop, int partnum);
+int search_can_match(enum search_op matchop, enum search_part);
 
 /* for debugging */
 extern const char *search_op_as_string(int op);
 
 /* for mbpath */
-extern int xapian_basedir(const char *tier, const char *mboxname, const char *part,
+extern int xapian_basedir(const char *tier, const char *mboxname, const char *partition,
                           const char *root, char **basedir);
 
 

--- a/imap/search_expr.h
+++ b/imap/search_expr.h
@@ -45,6 +45,7 @@
 
 #include "mailbox.h"
 #include "message.h"
+#include "search_part.h"
 #include "util.h"
 
 struct protstream;
@@ -92,7 +93,7 @@ typedef struct search_attr search_attr_t;
 struct search_attr {
     const char *name;
     int flags;
-    int part;
+    enum search_part part;
     int cost;
     void (*internalise)(struct index_state *, const union search_value *,
                         void *data1, void **internalisedp);

--- a/imap/search_part.h
+++ b/imap/search_part.h
@@ -45,27 +45,29 @@
 
 /* These constants are passed into the search_text_receiver_t.begin_part callback to
    tell it which part of the message is being sent down */
-#define SEARCH_PART_NONE            (-1)
-#define SEARCH_PART_ANY             0
-#define SEARCH_PART_FROM            1
-#define SEARCH_PART_TO              2
-#define SEARCH_PART_CC              3
-#define SEARCH_PART_BCC             4
-#define SEARCH_PART_SUBJECT         5
-#define SEARCH_PART_LISTID          6 /* List-Id or Mailing-List fields */
-#define SEARCH_PART_TYPE            7 /* MIME Content-Type except multipart */
-#define SEARCH_PART_HEADERS         8 /* headers OTHER than the above headers */
-#define SEARCH_PART_BODY            9
-#define SEARCH_PART_LOCATION        10
-#define SEARCH_PART_ATTACHMENTNAME  11
-#define SEARCH_PART_ATTACHMENTBODY  12
-#define SEARCH_PART_DELIVEREDTO     13
-#define SEARCH_PART_LANGUAGE        14 /* ISO 639 two or three letter code */
-#define SEARCH_PART_PRIORITY        15 /* String-encoded decimal integer > 0 */
-#define SEARCH_PART_MESSAGEID       16
-#define SEARCH_PART_REFERENCES      17
-#define SEARCH_PART_INREPLYTO       18
-#define SEARCH_NUM_PARTS            19
+enum search_part {
+    SEARCH_PART_NONE = -1,
+    SEARCH_PART_ANY,
+    SEARCH_PART_FROM,
+    SEARCH_PART_TO,
+    SEARCH_PART_CC,
+    SEARCH_PART_BCC,
+    SEARCH_PART_SUBJECT,
+    SEARCH_PART_LISTID,  /* List-Id or Mailing-List fields */
+    SEARCH_PART_TYPE,    /* MIME Content-Type except multipart */
+    SEARCH_PART_HEADERS, /* headers OTHER than the above headers */
+    SEARCH_PART_BODY,
+    SEARCH_PART_LOCATION,
+    SEARCH_PART_ATTACHMENTNAME,
+    SEARCH_PART_ATTACHMENTBODY,
+    SEARCH_PART_DELIVEREDTO,
+    SEARCH_PART_LANGUAGE, /* ISO 639 two or three letter code */
+    SEARCH_PART_PRIORITY, /* String-encoded decimal integer > 0 */
+    SEARCH_PART_MESSAGEID,
+    SEARCH_PART_REFERENCES,
+    SEARCH_PART_INREPLYTO,
+    SEARCH_NUM_PARTS,
+};
 
 /* Implemented in search_engines.c */
 extern const char *search_part_as_string(int part);

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -703,8 +703,7 @@ static int append_text(search_text_receiver_t *rx,
     return r;
 }
 
-static void end_part(search_text_receiver_t *rx,
-                     enum search_part part __attribute__((unused)))
+static void end_part(search_text_receiver_t *rx)
 {
     SquatReceiverData *d = (SquatReceiverData *) rx;
     int s = 0;      /* SQUAT error */

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -320,7 +320,7 @@ static void end_boolean(search_builder_t *bx, int op __attribute__((unused)))
     opstack_pop(bb);
 }
 
-static void match(search_builder_t *bx, int part, const char *str)
+static void match(search_builder_t *bx, enum search_part part, const char *str)
 {
     SquatBuilderData *bb = (SquatBuilderData *)bx;
     struct opstack *parent = opstack_top(bb);
@@ -620,7 +620,7 @@ static int begin_bodypart(search_text_receiver_t *rx __attribute__((unused)),
     return 0;
 }
 
-static void begin_part(search_text_receiver_t *rx, int part)
+static void begin_part(search_text_receiver_t *rx, enum search_part part)
 {
     SquatReceiverData *d = (SquatReceiverData *) rx;
     char part_char = 0;
@@ -704,7 +704,7 @@ static int append_text(search_text_receiver_t *rx,
 }
 
 static void end_part(search_text_receiver_t *rx,
-                     int part __attribute__((unused)))
+                     enum search_part part __attribute__((unused)))
 {
     SquatReceiverData *d = (SquatReceiverData *) rx;
     int s = 0;      /* SQUAT error */
@@ -1050,7 +1050,7 @@ static int end_update(search_text_receiver_t *rx)
     return 0;
 }
 
-static int can_match(enum search_op matchop, int partnum)
+static int can_match(enum search_op matchop, enum search_part partnum)
 {
     return (matchop == SEOP_MATCH || matchop == SEOP_FUZZYMATCH) &&
         doctypes_by_part[partnum];

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2476,8 +2476,7 @@ static int append_text(search_text_receiver_t *rx,
     return 0;
 }
 
-static void end_part(search_text_receiver_t *rx,
-                     enum search_part part __attribute__((unused)))
+static void end_part(search_text_receiver_t *rx)
 {
     xapian_receiver_t *tr = (xapian_receiver_t *)rx;
     struct segment *seg;
@@ -3127,7 +3126,7 @@ static int flush_snippets(search_text_receiver_t *rx)
             last_part = -1;
         }
 
-        r = xapian_snipgen_doc_part(tr->snipgen, &seg->text, seg->part);
+        r = xapian_snipgen_doc_part(tr->snipgen, &seg->text);
         last_partid = seg->partid;
         last_part = seg->part;
         if (r) break;

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2564,7 +2564,7 @@ static int end_message_update(search_text_receiver_t *rx, uint8_t indexlevel)
     int r = 0;
 
     if (!tr->dbw) {
-        r = xapian_dbw_open((const char **)tr->activedirs->data, &tr->dbw, tr->mode, /*nosync*/0);
+        r = xapian_dbw_open((const char **)tr->activedirs->data, &tr->dbw, tr->mode);
         if (r) goto out;
     }
 
@@ -2768,7 +2768,7 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
 
     if (tr->mode == XAPIAN_DBW_XAPINDEXED) {
         /* open the DB now, we need it to check if messages are indexed */
-        r = xapian_dbw_open((const char **)tr->activedirs->data, &tr->dbw, tr->mode, /*nosync*/0);
+        r = xapian_dbw_open((const char **)tr->activedirs->data, &tr->dbw, tr->mode);
         if (r) goto out;
     }
 
@@ -3571,7 +3571,8 @@ static int reindex_mb(void *rock,
     for (i = 1; i < strarray_size(filter->destpaths); i++)
         strarray_append(&alldirs, strarray_nth(filter->destpaths, i));
 
-    r = xapian_dbw_open((const char **)alldirs.data, &tr->dbw, tr->mode, /*nosync*/1);
+    r = xapian_dbw_open((const char **)alldirs.data, &tr->dbw,
+                        tr->mode | XAPIAN_DBW_NOSYNC);
     if (r) goto done;
 
     /* initialise here so it doesn't add firstunindexed
@@ -3658,7 +3659,9 @@ static int reindex_mb(void *rock,
                 strarray_insert(&alldirs, 1, buf_cstring(&buf));
 
                 // finally, re-open the database on the new empty directory with the extra path added
-                if (!r) r = xapian_dbw_open((const char **)alldirs.data, &tr->dbw, tr->mode, /*nosync*/1);
+                if (!r)
+                    r = xapian_dbw_open((const char **)alldirs.data, &tr->dbw,
+                                        tr->mode | XAPIAN_DBW_NOSYNC);
                 if (r) goto done;
                 filter->numindexed = 0;
             }

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2201,7 +2201,7 @@ struct xapian_snippet_receiver
     search_snippet_cb_t proc;
     void *rock;
     struct xapiandb_lock lock;
-    const search_snippet_markup_t *markup;
+    const struct search_snippet_markup *markup;
 };
 
 struct is_indexed_rock {
@@ -3018,8 +3018,7 @@ static int begin_mailbox_snippets(search_text_receiver_t *rx,
     if (r) goto out;
     if (!tr->lock.activedirs || !tr->lock.activedirs->count) goto out;
 
-    tr->snipgen = xapian_snipgen_new(tr->lock.db, tr->markup->hi_start,
-                                     tr->markup->hi_end, tr->markup->omit);
+    tr->snipgen = xapian_snipgen_new(tr->lock.db, tr->markup);
 
 out:
     return r;
@@ -3170,7 +3169,7 @@ static int end_mailbox_snippets(search_text_receiver_t *rx,
 
 static search_text_receiver_t *begin_snippets(void *internalised,
                                               int verbose,
-                                              search_snippet_markup_t *m,
+                                              struct search_snippet_markup *m,
                                               search_snippet_cb_t proc,
                                               void *rock)
 {

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -91,7 +91,7 @@
 
 struct segment
 {
-    int part;
+    enum search_part part;
     struct message_guid guid;
     char doctype;
     int sequence;       /* forces stable sort order JIC */
@@ -2034,7 +2034,7 @@ static void end_boolean(search_builder_t *bx, int op __attribute__((unused)))
     ptrarray_pop(&bb->stack);
 }
 
-static void matchlist(search_builder_t *bx, int part, const strarray_t *vals)
+static void matchlist(search_builder_t *bx, enum search_part part, const strarray_t *vals)
 {
     xapian_builder_t *bb = (xapian_builder_t *)bx;
     struct opnode *top = ptrarray_tail(&bb->stack);
@@ -2055,7 +2055,7 @@ static void matchlist(search_builder_t *bx, int part, const strarray_t *vals)
         bb->root = on;
 }
 
-static void match(search_builder_t *bx, int part, const char *val)
+static void match(search_builder_t *bx, enum search_part part, const char *val)
 {
     strarray_t items = STRARRAY_INITIALIZER;
     strarray_append(&items, val);
@@ -2166,7 +2166,7 @@ struct xapian_receiver
     struct message_guid guid;
     uint32_t uid;
     time_t internaldate;
-    int part;
+    enum search_part part;
     const struct message_guid *part_guid;
     const char *partid;
     unsigned int part_total;
@@ -2423,7 +2423,7 @@ static int begin_bodypart(search_text_receiver_t *rx,
     return 0;
 }
 
-static void begin_part(search_text_receiver_t *rx, int part)
+static void begin_part(search_text_receiver_t *rx, enum search_part part)
 {
     xapian_receiver_t *tr = (xapian_receiver_t *)rx;
 
@@ -2477,7 +2477,7 @@ static int append_text(search_text_receiver_t *rx,
 }
 
 static void end_part(search_text_receiver_t *rx,
-                     int part __attribute__((unused)))
+                     enum search_part part __attribute__((unused)))
 {
     xapian_receiver_t *tr = (xapian_receiver_t *)rx;
     struct segment *seg;
@@ -3028,7 +3028,7 @@ out:
 /* Find match terms for the given part and add them to the Xapian
  * snippet generator.  */
 static void generate_snippet_terms(xapian_snipgen_t *snipgen,
-                                   int part,
+                                   enum search_part part,
                                    struct opnode *on)
 {
     struct opnode *child;
@@ -4304,7 +4304,7 @@ out:
     return r;
 }
 
-static int can_match(enum search_op matchop, int partnum)
+static int can_match(enum search_op matchop, enum search_part partnum)
 {
     return (matchop == SEOP_FUZZYMATCH && partnum != SEARCH_PART_NONE) ||
            (matchop == SEOP_MATCH && (partnum == SEARCH_PART_MESSAGEID ||

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -1602,6 +1602,7 @@ static xapian_query_t *opnode_to_query(const xapian_db_t *db, struct opnode *on,
           * all of the available prefixes */
         for (i = 0 ; i < SEARCH_NUM_PARTS ; i++) {
             switch (i) {
+                case SEARCH_PART_ANY:
                 case SEARCH_PART_LISTID:
                 case SEARCH_PART_TYPE:
                 case SEARCH_PART_LANGUAGE:

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1003,7 +1003,7 @@ static int add_email_part(xapian_dbw_t *dbw, const struct buf *part, int partnum
             dbw->term_generator->set_stopper(NULL);
             dbw->term_generator->index_text(Xapian::Utf8Iterator(val), 1, prefix);
         }
-        if (addr->domain && strcmp(addr->domain, "unspecified-domain")) {
+        if (addr->domain && strcmp(addr->domain, "unspecified-domain") != 0) {
             char *utf8_domain = charset_idna_to_utf8(addr->domain);
             char *puny_domain = charset_idna_to_ascii(addr->domain);
 
@@ -1522,7 +1522,8 @@ EXPORTED int xapian_db_langstats(xapian_db_t *db, ptrarray_t* lstats,
 
 EXPORTED void xapian_query_add_stemmer(xapian_db_t *db, const char *iso_lang)
 {
-    if (strcmp(iso_lang, "en")) db->stem_languages->insert(iso_lang);
+    if (strcmp(iso_lang, "en") != 0)
+        db->stem_languages->insert(iso_lang);
 }
 
 static Xapian::Query* query_new_textmatch(const xapian_db_t *db,

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -553,7 +553,7 @@ EXPORTED int xapian_compact_dbs(const char *dest, const char **sources)
 
 /* ====================================================================== */
 
-static std::string get_term_prefix(int partnum)
+static std::string get_term_prefix(enum search_part partnum)
 {
     assert(partnum > SEARCH_PART_ANY && partnum < SEARCH_NUM_PARTS);
 
@@ -590,7 +590,7 @@ static std::string get_term_prefix(int partnum)
     return term_prefixes[partnum];
 }
 
-static Xapian::TermGenerator::stem_strategy get_stem_strategy(int partnum)
+static Xapian::TermGenerator::stem_strategy get_stem_strategy(enum search_part partnum)
 {
     static Xapian::TermGenerator::stem_strategy stem_strategy[SEARCH_NUM_PARTS] = {
         // Version 2 and higher
@@ -879,7 +879,7 @@ EXPORTED int xapian_dbw_begin_doc(xapian_dbw_t *dbw,
     return r;
 }
 
-static int add_language_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
+static int add_language_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part partnum)
 {
     std::string prefix(get_term_prefix(partnum));
     std::string val = parse_langcode(buf_cstring(part));
@@ -902,7 +902,7 @@ static std::string parse_priority(const char *str)
     return std::to_string(u);
 }
 
-static int add_priority_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
+static int add_priority_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part partnum)
 {
     std::string prefix(get_term_prefix(partnum));
     if (buf_len(part)) {
@@ -957,7 +957,7 @@ static std::string parse_listid(const char *str)
     return val;
 }
 
-static int add_listid_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
+static int add_listid_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part partnum)
 {
     std::string prefix(get_term_prefix(partnum));
 
@@ -974,7 +974,7 @@ static int add_listid_part(xapian_dbw_t *dbw, const struct buf *part, int partnu
     return 0;
 }
 
-static int add_email_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
+static int add_email_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part partnum)
 {
     std::string prefix(get_term_prefix(partnum));
     struct address_itr itr;
@@ -1085,7 +1085,7 @@ static std::pair<std::string, std::string> parse_content_type(const char *str)
     return ret;
 }
 
-static int add_type_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
+static int add_type_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part partnum)
 {
     std::string prefix(get_term_prefix(partnum));
     std::pair<std::string, std::string> ct = parse_content_type(buf_cstring(part));
@@ -1101,14 +1101,14 @@ static int add_type_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
     return 0;
 }
 
-static int add_msgid_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
+static int add_msgid_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part partnum)
 {
     std::string prefix(get_term_prefix(partnum));
     add_boolean_nterm(*dbw->document, prefix + buf_cstring(part));
     return 0;
 }
 
-static int add_text_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
+static int add_text_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part partnum)
 {
     std::string prefix(get_term_prefix(partnum));
     int r = 0;
@@ -1181,7 +1181,7 @@ static int add_text_part(xapian_dbw_t *dbw, const struct buf *part, int partnum)
 
 EXPORTED int xapian_dbw_doc_part(xapian_dbw_t *dbw,
                                  const struct buf *part,
-                                 int partnum)
+                                 enum search_part partnum)
 {
     int r = 0;
 
@@ -1524,7 +1524,7 @@ EXPORTED void xapian_query_add_stemmer(xapian_db_t *db, const char *iso_lang)
 }
 
 static Xapian::Query* query_new_textmatch(const xapian_db_t *db,
-                                          int partnum,
+                                          enum search_part partnum,
                                           const char *match,
                                           Xapian::TermGenerator::stem_strategy tg_stem_strategy)
 {
@@ -1576,7 +1576,7 @@ static Xapian::Query* query_new_textmatch(const xapian_db_t *db,
 }
 
 static Xapian::Query *query_new_language(const xapian_db_t *db __attribute__((unused)),
-                                         int partnum,
+                                         enum search_part partnum,
                                          const char *str)
 {
     std::string val = parse_langcode(str);
@@ -1588,7 +1588,7 @@ static Xapian::Query *query_new_language(const xapian_db_t *db __attribute__((un
 }
 
 static Xapian::Query *query_new_priority(const xapian_db_t *db __attribute__((unused)),
-                                         int partnum,
+                                         enum search_part partnum,
                                          const char *str)
 {
     std::string val = parse_priority(str);
@@ -1600,7 +1600,7 @@ static Xapian::Query *query_new_priority(const xapian_db_t *db __attribute__((un
 }
 
 static Xapian::Query *query_new_listid(const xapian_db_t *db,
-                                       int partnum,
+                                       enum search_part partnum,
                                        const char *str)
 {
     Xapian::Query *q = NULL;
@@ -1628,14 +1628,14 @@ static Xapian::Query *query_new_listid(const xapian_db_t *db,
 }
 
 static Xapian::Query *query_new_messageid(const xapian_db_t *db __attribute__((unused)),
-                                          int partnum,
+                                          enum search_part partnum,
                                           const char *str)
 {
     return new Xapian::Query(std::string(get_term_prefix(partnum)) + str);
 }
 
 static Xapian::Query *query_new_email(const xapian_db_t *db,
-                                      int partnum,
+                                      enum search_part partnum,
                                       const char *searchstr)
 {
     std::string prefix(get_term_prefix(partnum));
@@ -1861,7 +1861,7 @@ static void append_alnum(struct buf *buf, const char *ss)
 }
 
 static Xapian::Query *query_new_type(const xapian_db_t *db __attribute__((unused)),
-                                     int partnum,
+                                     enum search_part partnum,
                                      const char *str)
 {
 
@@ -1921,7 +1921,7 @@ static Xapian::Query *query_new_type(const xapian_db_t *db __attribute__((unused
 }
 
 static Xapian::Query *xapian_query_new_match_word_break(const xapian_db_t *db,
-                                                        int partnum,
+                                                        enum search_part partnum,
                                                         const char *str)
 {
     std::string prefix(get_term_prefix(partnum));
@@ -1971,7 +1971,7 @@ static Xapian::Query *xapian_query_new_match_word_break(const xapian_db_t *db,
 }
 
 static Xapian::Query *xapian_query_new_match_internal(const xapian_db_t *db,
-                                                      int partnum,
+                                                      enum search_part partnum,
                                                       const char *str,
                                                       int convert_flags)
 {
@@ -2085,7 +2085,7 @@ static bool query_terms_eq(const Xapian::Query *qa, const Xapian::Query *qb)
 }
 
 EXPORTED xapian_query_t *
-xapian_query_new_match(const xapian_db_t *db, int partnum, const char *str)
+xapian_query_new_match(const xapian_db_t *db, enum search_part partnum, const char *str)
 {
     if (db->subdbs->empty()) {
         // no database to query
@@ -2485,7 +2485,7 @@ EXPORTED int xapian_snipgen_make_snippet(xapian_snipgen_t *snipgen,
 
 EXPORTED int xapian_snipgen_doc_part(xapian_snipgen_t *snipgen,
                                      const struct buf *part,
-                                     int partnum __attribute__((unused)))
+                                     enum search_part partnum __attribute__((unused)))
 {
     // Ignore empty queries.
     if (!snipgen->loose_terms && !snipgen->queries) return 0;

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1357,7 +1357,7 @@ static int xapian_db_init(xapian_db_t *db, int is_inmemory)
         if (!is_inmemory) {
             // Determine stemmer languages (in addition to English).
             std::map<const std::string, unsigned> lang_counts;
-            size_t total_doccount = 0;
+            unsigned total_doccount = 0;
             for (const Xapian::Database& subdb : *db->subdbs) {
                 read_language_counts(subdb, lang_counts);
                 total_doccount += subdb.get_doccount();
@@ -2096,7 +2096,7 @@ xapian_query_new_match(const xapian_db_t *db, int partnum, const char *str)
         return NULL;
     }
 
-    int min_version = *db->db_versions->begin();
+    unsigned min_version = *db->db_versions->begin();
     if (min_version < XAPIAN_DB_MIN_SUPPORTED_VERSION) {
         xsyslog(LOG_WARNING,
                 "deprecated database version, reindex required",
@@ -2105,7 +2105,7 @@ xapian_query_new_match(const xapian_db_t *db, int partnum, const char *str)
                 db->paths->c_str());
     }
 
-    int max_version = *db->db_versions->rbegin();
+    unsigned max_version = *db->db_versions->rbegin();
 
     Xapian::Query *q = NULL;
     if (max_version >= 17) {

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -2092,8 +2092,6 @@ xapian_query_new_match(const xapian_db_t *db, enum search_part partnum, const ch
         return NULL;
     }
 
-    std::string(get_term_prefix(partnum));
-
     unsigned min_version = *db->db_versions->begin();
     if (min_version < XAPIAN_DB_MIN_SUPPORTED_VERSION) {
         xsyslog(LOG_WARNING,

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -394,8 +394,11 @@ static std::string detect_language(const struct buf *part)
     bool reliable = false;
 
     buf_cstring(part);
-    CLD2::Language lang =
-        CLD2::DetectLanguage(buf_base(part), buf_len(part), 1, &reliable);
+    CLD2::Language lang = CLD2::DetectLanguage(
+        buf_base(part),
+        buf_len(part) < INT_MAX ? static_cast<int>(buf_len(part)) : INT_MAX,
+        1,
+        &reliable);
 
     if (reliable && lang != CLD2::UNKNOWN_LANGUAGE) {
         std::string code(CLD2::LanguageCode(lang));

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1631,7 +1631,7 @@ static Xapian::Query *query_new_messageid(const xapian_db_t *db __attribute__((u
                                           enum search_part partnum,
                                           const char *str)
 {
-    return new Xapian::Query(std::string(get_term_prefix(partnum)) + str);
+    return new Xapian::Query(get_term_prefix(partnum) + str);
 }
 
 static Xapian::Query *query_new_email(const xapian_db_t *db,

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -2484,8 +2484,7 @@ EXPORTED int xapian_snipgen_make_snippet(xapian_snipgen_t *snipgen,
 }
 
 EXPORTED int xapian_snipgen_doc_part(xapian_snipgen_t *snipgen,
-                                     const struct buf *part,
-                                     enum search_part partnum __attribute__((unused)))
+                                     const struct buf *part)
 {
     // Ignore empty queries.
     if (!snipgen->loose_terms && !snipgen->queries) return 0;

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -694,8 +694,7 @@ static int xapian_dbw_init(xapian_dbw_t *dbw)
     return 0;
 }
 
-EXPORTED int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp,
-                             int mode, int nosync)
+EXPORTED int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp, int mode)
 {
     xapian_dbw_t *dbw = (xapian_dbw_t *)xzmalloc(sizeof(xapian_dbw_t));
     int r = 0;
@@ -704,7 +703,9 @@ EXPORTED int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp,
     std::set<int> db_versions;
     try {
         int flags = Xapian::DB_BACKEND_GLASS|Xapian::DB_RETRY_LOCK;
-        if (nosync) flags |= Xapian::DB_DANGEROUS|Xapian::DB_NO_SYNC;
+        if (mode & XAPIAN_DBW_NOSYNC) {
+            flags |= Xapian::DB_DANGEROUS|Xapian::DB_NO_SYNC;
+        }
         try {
             dbw->database = new Xapian::WritableDatabase{thispath, flags|Xapian::DB_OPEN};
             db_versions = read_db_versions(*dbw->database);
@@ -740,7 +741,7 @@ EXPORTED int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp,
     }
 
     /* open the read-only databases */
-    if (mode == XAPIAN_DBW_XAPINDEXED) {
+    if (mode & XAPIAN_DBW_XAPINDEXED) {
         while (*paths) {
             try {
                 thispath = *paths;

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -2333,19 +2333,16 @@ struct xapian_snipgen
 };
 
 EXPORTED xapian_snipgen_t *
-xapian_snipgen_new(xapian_db_t *db,
-                   const char *hi_start,
-                   const char *hi_end,
-                   const char *omit)
+xapian_snipgen_new(xapian_db_t *db, const struct search_snippet_markup *markup)
 {
     xapian_snipgen_t *snipgen = (xapian_snipgen_t *)xzmalloc(sizeof(xapian_snipgen_t));
     snipgen->default_stemmer = new Xapian::Stem(new CyrusSearchStemmer);
     snipgen->db = db;
     snipgen->memdb = new Xapian::WritableDatabase(std::string(), Xapian::DB_BACKEND_INMEMORY);
     snipgen->buf = buf_new();
-    snipgen->hi_start = hi_start;
-    snipgen->hi_end = hi_end;
-    snipgen->omit = omit;
+    snipgen->hi_start = markup->hi_start;
+    snipgen->hi_end = markup->hi_end;
+    snipgen->omit = markup->omit;
     snipgen->max_len = (size_t) config_getint(IMAPOPT_SEARCH_SNIPPET_LENGTH);
 
     return snipgen;

--- a/imap/xapian_wrap.h
+++ b/imap/xapian_wrap.h
@@ -98,7 +98,7 @@ extern xapian_snipgen_t *xapian_snipgen_new(xapian_db_t *db, const struct search
 extern void xapian_snipgen_free(xapian_snipgen_t *);
 extern int xapian_snipgen_add_match(xapian_snipgen_t *snipgen, const char *match);
 extern int xapian_snipgen_begin_doc(xapian_snipgen_t *snipgen, const struct message_guid *guid, char doctype);
-extern int xapian_snipgen_doc_part(xapian_snipgen_t *snipgen, const struct buf *part, enum search_part);
+extern int xapian_snipgen_doc_part(xapian_snipgen_t *snipgen, const struct buf *part);
 extern int xapian_snipgen_end_doc(xapian_snipgen_t *snipgen, struct buf *);
 
 /* filter interface */

--- a/imap/xapian_wrap.h
+++ b/imap/xapian_wrap.h
@@ -63,9 +63,10 @@ extern int xapian_compact_dbs(const char *dest, const char **sources);
 extern void xapian_check_if_needs_reindex(const strarray_t *sources, strarray_t *toreindex, int always_upgrade);
 
 /* write-side interface */
-#define XAPIAN_DBW_CONVINDEXED 0
-#define XAPIAN_DBW_XAPINDEXED 1
-extern int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp, int mode, int nosync);
+#define XAPIAN_DBW_CONVINDEXED 0x0
+#define XAPIAN_DBW_XAPINDEXED  0x1
+#define XAPIAN_DBW_NOSYNC      0x2
+extern int xapian_dbw_open(const char **paths, xapian_dbw_t **dbwp, int mode);
 extern int xapian_dbw_openmem(xapian_dbw_t **dbwp); // use only for data <1mb
 extern void xapian_dbw_close(xapian_dbw_t *dbw);
 extern int xapian_dbw_begin_txn(xapian_dbw_t *dbw);

--- a/imap/xapian_wrap.h
+++ b/imap/xapian_wrap.h
@@ -93,7 +93,7 @@ extern void xapian_query_free(xapian_query_t *);
 extern int xapian_query_run(const xapian_db_t *, const xapian_query_t *query,
                             int (*cb)(void *base, size_t n, void *rock), void *rock);
 /* snippets interface */
-extern xapian_snipgen_t *xapian_snipgen_new(xapian_db_t *db, const char *hi_start, const char *hi_end, const char *omit);
+extern xapian_snipgen_t *xapian_snipgen_new(xapian_db_t *db, const struct search_snippet_markup *markup);
 extern void xapian_snipgen_free(xapian_snipgen_t *);
 extern int xapian_snipgen_add_match(xapian_snipgen_t *snipgen, const char *match);
 extern int xapian_snipgen_begin_doc(xapian_snipgen_t *snipgen, const struct message_guid *guid, char doctype);

--- a/imap/xapian_wrap.h
+++ b/imap/xapian_wrap.h
@@ -45,6 +45,7 @@
 
 #include "message_guid.h"
 #include "util.h"
+#include "search_part.h"
 #include "strarray.h"
 #include "ptrarray.h"
 
@@ -73,7 +74,7 @@ extern int xapian_dbw_begin_txn(xapian_dbw_t *dbw);
 extern int xapian_dbw_commit_txn(xapian_dbw_t *dbw);
 extern int xapian_dbw_cancel_txn(xapian_dbw_t *dbw);
 extern int xapian_dbw_begin_doc(xapian_dbw_t *dbw, const struct message_guid *guid, char doctype);
-extern int xapian_dbw_doc_part(xapian_dbw_t *dbw, const struct buf *part, int num_part);
+extern int xapian_dbw_doc_part(xapian_dbw_t *dbw, const struct buf *part, enum search_part);
 extern int xapian_dbw_end_doc(xapian_dbw_t *dbw, uint8_t indexlevel);
 extern unsigned long xapian_dbw_total_length(xapian_dbw_t *dbw);
 extern uint8_t xapian_dbw_is_indexed(xapian_dbw_t *dbw, const struct message_guid *guid, char doctype);
@@ -84,7 +85,7 @@ extern int xapian_db_opendbw(struct xapian_dbw *dbw, xapian_db_t **dbp);
 extern unsigned xapian_db_min_index_version(xapian_db_t*);
 extern void xapian_db_close(xapian_db_t *);
 extern void xapian_query_add_stemmer(xapian_db_t *, const char *iso_lang);
-extern xapian_query_t *xapian_query_new_match(const xapian_db_t *, int num_part, const char *term);
+extern xapian_query_t *xapian_query_new_match(const xapian_db_t *, enum search_part, const char *term);
 extern xapian_query_t *xapian_query_new_compound(const xapian_db_t *, int is_or, xapian_query_t **children, int n);
 extern xapian_query_t *xapian_query_new_matchall(const xapian_db_t *);
 extern xapian_query_t *xapian_query_new_not(const xapian_db_t *, xapian_query_t *);
@@ -97,7 +98,7 @@ extern xapian_snipgen_t *xapian_snipgen_new(xapian_db_t *db, const struct search
 extern void xapian_snipgen_free(xapian_snipgen_t *);
 extern int xapian_snipgen_add_match(xapian_snipgen_t *snipgen, const char *match);
 extern int xapian_snipgen_begin_doc(xapian_snipgen_t *snipgen, const struct message_guid *guid, char doctype);
-extern int xapian_snipgen_doc_part(xapian_snipgen_t *snipgen, const struct buf *part, int partnum);
+extern int xapian_snipgen_doc_part(xapian_snipgen_t *snipgen, const struct buf *part, enum search_part);
 extern int xapian_snipgen_end_doc(xapian_snipgen_t *snipgen, struct buf *);
 
 /* filter interface */


### PR DESCRIPTION
The current Xapian wrapper code in `imap/xapian_wrap.cpp` is anything but idiomatic or modern C++ code. https://github.com/cyrusimap/cyrus-imapd/pull/2818 highlights some of that, but we didn't act on it timely and the code now is stale. It also didn't help that the code changes are all in a single commit.

This PR attempts to sanitize the C++ code in smaller steps. As a baseline of what constitutes "sane C++" code, we'll start with the [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) linter with the `bugprone` check category.

I am using this with Debian LLVM version 14.0.6.