### PR TITLE
sieve_eval_bc:B_REDIRECT make the function reentrant

### DIFF
--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -1928,7 +1928,7 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
             const char *bymode = cmd.u.r.bymode;
             const char *dsn_notify = cmd.u.r.dsn_notify;
             const char *dsn_ret = cmd.u.r.dsn_ret;
-            const char *deliverby = NULL;
+            char *deliverby = NULL;
             struct buf *headers = NULL;
 
             if (requires & BFE_VARIABLES) {
@@ -1972,10 +1972,9 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
                   by-mode  = "N" / "R"           ; "Notify" or "Return"
                   by-trace = "T"                 ; "Trace"
                 */
-                static char by_value[14];
-                snprintf(by_value, sizeof(by_value), "%+ld;%c%s",
+                deliverby = xmalloc(14);
+                snprintf(deliverby, 14, "%+ld;%c%s",
                          sec, toupper(bymode[0]), cmd.u.r.bytrace ? "T" : "");
-                deliverby = by_value;
             }
 
             if (i->edited_headers) i->getheadersection(m, &headers);

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -1972,9 +1972,10 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
                   by-mode  = "N" / "R"           ; "Notify" or "Return"
                   by-trace = "T"                 ; "Trace"
                 */
-                deliverby = xmalloc(14);
-                snprintf(deliverby, 14, "%+ld;%c%s",
-                         sec, toupper(bymode[0]), cmd.u.r.bytrace ? "T" : "");
+                struct buf by_value = BUF_INITIALIZER;
+                buf_printf(&by_value, "%+ld;%c%s",
+                           sec, toupper(bymode[0]), cmd.u.r.bytrace ? "T" : "");
+                deliverby = buf_release(&by_value);
             }
 
             if (i->edited_headers) i->getheadersection(m, &headers);

--- a/sieve/message.c
+++ b/sieve/message.c
@@ -243,7 +243,7 @@ int do_fileinto(sieve_interp_t *i, void *sc,
  *
  * incompatible with: [e]reject
  */
-int do_redirect(action_list_t *a, const char *addr, const char *deliverby,
+int do_redirect(action_list_t *a, const char *addr, char *deliverby,
                 const char *dsn_notify, const char *dsn_ret,
                 int is_ext_list, int cancel_keep, struct buf *headers)
 {
@@ -620,6 +620,7 @@ void free_action_list(action_list_t *a)
 
         case ACTION_REDIRECT:
             buf_destroy(a->u.red.headers);
+            free(a->u.red.deliverby);
             break;
 
         default:

--- a/sieve/message.h
+++ b/sieve/message.h
@@ -138,7 +138,7 @@ int do_fileinto(sieve_interp_t *i, void *sc,
                 action_list_t *a, const char *mbox, const char *specialuse,
                 unsigned flags, const char *mailboxid,
                 strarray_t *imapflags, struct buf *headers);
-int do_redirect(action_list_t *a, const char *addr, const char *deliverby,
+int do_redirect(action_list_t *a, const char *addr, char *deliverby,
                 const char *dsn_notify, const char *dsn_ret,
                 int is_ext_list, int cancel_keep, struct buf *headers);
 int do_keep(sieve_interp_t *i, void *sc, unsigned flags,

--- a/sieve/sieve_interface.h
+++ b/sieve/sieve_interface.h
@@ -141,7 +141,7 @@ typedef struct sieve_cal_context {
 typedef struct sieve_redirect_context {
     const char *addr;
     int is_ext_list :1;
-    const char *deliverby;
+    char *deliverby;
     const char *dsn_notify;
     const char *dsn_ret;
     struct buf *headers;


### PR DESCRIPTION
make by_value non-static, so that libcyrus_sieve can be used to interpret bytecode in multi-threaded environment.

I use `sieve_eval_bc()` in a multi-threaded application.