### PR TITLE
jmap_ical: fix inverse sign when guessing Etc/GMT+X timezone

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_etc_gmt
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_etc_gmt
@@ -51,5 +51,5 @@ EOF
             properties => ['timeZone'],
         }, 'R1']
     ]);
-    $self->assert_str_equals('Etc/GMT-10', $res->[0][1]{list}[0]{timeZone});
+    $self->assert_str_equals('Etc/GMT+10', $res->[0][1]{list}[0]{timeZone});
 }

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -1146,7 +1146,7 @@ static void jstimezones_add_vtimezones(jstimezones_t *jstzones, icalcomponent *i
                             h--;
 
                         // Lookup "Etc/GMT+X" timezone
-                        buf_printf(&idbuf, "Etc/GMT%+d", h);
+                        buf_printf(&idbuf, "Etc/GMT%+d", -h);
                         if (!get_cyrus_timezone_from_tzid(buf_cstring(&idbuf), 0))
                             buf_reset(&idbuf);
                     }


### PR DESCRIPTION
A negative UTC offset converts to an Etc/GMT timezone with positive offset. The code and its test got it the other way round.