### PR TITLE
check for unexpected extra tiny-tests directories

### DIFF
--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -761,6 +761,16 @@ sub check_sanity
         die "$tt directory contains no tests"
             if not $ntests;
     }
+
+    # whinge about 'tiny-tests' directories in unexpected places
+    # start searching in the parent directory so that we're checking the
+    # whole cyrus-imapd repository
+    my @unexpected_tt_dirs = grep {
+        chomp;
+        $_ ne '../cassandane/tiny-tests';
+    } qx{find .. -type d -name tiny-tests};
+    die "unexpected extra tiny-tests directories: @unexpected_tt_dirs"
+        if @unexpected_tt_dirs;
 }
 
 #


### PR DESCRIPTION
Extends the tiny-tests sanity checks from #5011 to complain about extra tiny-tests directories in unexpected places.  This would have prevented the problem that #5030 fixed