### PR TITLE
Lmtp ratelimit

### DIFF
--- a/changes/next/lmtp-ratelimit
+++ b/changes/next/lmtp-ratelimit
@@ -1,0 +1,27 @@
+Description:
+
+Support user and lmtp rate limits in lmtp
+
+
+Config changes:
+
+This changes the behaviour of the maxlogins_per_user and maxlogins_per_host
+configuration options to limit each item per service, so 5 logins from a
+host for imap won't also limit http logins.
+
+It also limits lmtp connections for delivery to a locked mailbox,
+returning a 4xx code if additional connections are made that try to
+deliver to the same mailbox if there are already N connections waiting.
+
+
+Upgrade instructions:
+
+No config changes required, it's rare that you have more than one LMTP
+connection waiting on a mailbox so it's very unlikely that existing
+limits will affect lmtp - though you may want to double check that your
+limits still make sense given that each service now has a separate count.
+
+
+GitHub issue:
+
+If theres a github issue number for this, put it here.

--- a/imap/imap_err.et
+++ b/imap/imap_err.et
@@ -56,6 +56,12 @@ ec IMAP_SYS_ERROR,
 ec IMAP_NOSPACE,
    "mail system storage has been exceeded"
 
+ec IMAP_LIMIT_USER,
+   "Too many connections from this user"
+
+ec IMAP_LIMIT_HOST,
+   "Too many connections from this host"
+
 ec IMAP_PERMISSION_DENIED,
    "Permission denied"
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -2973,7 +2973,7 @@ static int checklimits(const char *tag)
 {
     struct proc_limits limits;
 
-    limits.procname = "imapd";
+    limits.servicename = config_ident;
     limits.clienthost = imapd_clienthost;
     limits.userid = imapd_userid;
 

--- a/imap/lmtp_err.et
+++ b/imap/lmtp_err.et
@@ -62,6 +62,9 @@ ec LMTP_SERVER_FULL,
 ec LMTP_SERVER_FAILURE,
    "451 4.4.3 %s"
 
+ec LMTP_SERVER_BUSY,
+   "451 4.4.5 %s"
+
 ec LMTP_MAILBOX_FULL,
    "452 4.2.2 %s SESSIONID=<%s>"
 

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -149,6 +149,11 @@ static void send_lmtp_error(struct protstream *pout, int r, strarray_t *resp)
         code = LMTP_OK;
         break;
 
+    case IMAP_LIMIT_HOST:
+    case IMAP_LIMIT_USER:
+        code = LMTP_SERVER_BUSY;
+        break;
+
     case IMAP_SERVER_UNAVAILABLE:
     case MUPDATE_NOCONN:
     case MUPDATE_NOAUTH:

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -2210,7 +2210,7 @@ static void cmd_authinfo_sasl(char *cmd, char *mech, char *resp)
         }
     }
 
-    limits.procname = "nntpd";
+    limits.servicename = config_ident;
     limits.clienthost = nntp_clienthost;
     limits.userid = nntp_userid;
     if (proc_checklimits(&limits)) {

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -1839,7 +1839,7 @@ int openinbox(void)
         mailbox_unlock_index(popd_mailbox, NULL);
     }
 
-    limits.procname = "pop3d";
+    limits.servicename = config_ident;
     limits.clienthost = popd_clienthost;
     limits.userid = popd_userid;
     if (proc_checklimits(&limits)) {

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -330,7 +330,7 @@ EXPORTED int proc_foreach(procdata_t *func, void *rock)
 }
 
 static int procusage_cb(pid_t pid __attribute__((unused)),
-                        const char *servicename __attribute__((unused)),
+                        const char *servicename,
                         const char *clienthost,
                         const char *userid,
                         const char *mboxname __attribute__((unused)),
@@ -341,6 +341,10 @@ static int procusage_cb(pid_t pid __attribute__((unused)),
 
     /* we only count logged in sessions */
     if (!userid) return 0;
+
+    /* only check for logins to the particular protocol */
+    if (limitsp->servicename && strcmp(servicename, limitsp->servicename))
+        return 0;
 
     if (limitsp->clienthost && !strcmp(clienthost, limitsp->clienthost))
         limitsp->host++;

--- a/lib/proc.h
+++ b/lib/proc.h
@@ -60,7 +60,7 @@ typedef int procdata_t(pid_t pid,
 extern int proc_foreach(procdata_t *func, void *rock);
 
 struct proc_limits {
-    const char *procname;
+    const char *servicename;
     const char *clienthost;
     const char *userid;
     int user;


### PR DESCRIPTION
We're running into issues in Fastmail production where a single mailbox locked up for a crazy amount of time can cause starvation by having hundreds of lmtp processes waiting on locks.

We could test for locks, but it's OK to have a few waiting - we should just tell the rest to try again later.  This re-uses the
proc_checklimit in lmtpd to check the limits for each userid before trying to lock their conversations.db, and returns a useful 451 code to the sender saying that there are too many connections for this user.

We'll probably set something like a 10 process limit for our servers, which allows for all the MXes to send one and a few spares still open.