### PR TITLE
Master babysit retry

### DIFF
--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -531,6 +531,10 @@ sub test_service_exit_during_start
     $self->assert_null($lemm);
     $self->assert_deep_equals({ A => { live => 0, dead => 5 } },
                               $self->lemming_census());
+
+    xlog $self, "check that the error was syslogged";
+    my @loglines = $self->{instance}->getsyslog();
+    $self->assert(grep { m/too many failures for service/ } @loglines);
 }
 
 sub test_startup

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -532,9 +532,12 @@ sub test_service_exit_during_start
     $self->assert_deep_equals({ A => { live => 0, dead => 5 } },
                               $self->lemming_census());
 
-    xlog $self, "check that the error was syslogged";
-    my @loglines = $self->{instance}->getsyslog();
-    $self->assert(grep { m/too many failures for service/ } @loglines);
+    if ($self->{instance}->{have_syslog_replacement}) {
+        xlog $self, "check that the error was syslogged";
+        my @lines = $self->{instance}->getsyslog(qr/too many failures for service/);
+        $self->assert_num_equals(1, scalar @lines);
+        $self->assert_matches(qr/disabling until next SIGHUP/, $lines[0]);
+    }
 }
 
 sub test_startup

--- a/changes/next/master-babysit-retry
+++ b/changes/next/master-babysit-retry
@@ -1,0 +1,19 @@
+Description:
+
+master: retry all DAEMON block services and services with the 'babysit' flag forever
+
+
+Config changes:
+
+No config changes
+
+
+Upgrade instructions:
+
+Nothing required for upgrade.  You may wish to add 'babysit' to a service,
+which will not only ensure that there's always one forked, but if it dies
+too frequently, it won't stay dead.
+
+
+GitHub issue:
+

--- a/master/master.c
+++ b/master/master.c
@@ -1426,14 +1426,14 @@ static void reap_child(void)
                         s->lastreadyfail = now;
                         if (++s->nreadyfails >= MAX_READY_FAILS && s->exec) {
                             if (s->babysit) {
-                                syslog(LOG_ERR, "too many failures for"
+                                syslog(LOG_ERR, "ERROR: too many failures for"
                                        "service %s/%s, disabling for %d seconds",
                                        SERVICEPARAM(s->name),
                                        SERVICEPARAM(s->familyname),
                                        MAX_READY_FAIL_INTERVAL);
                             }
                             else {
-                                syslog(LOG_ERR, "too many failures for "
+                                syslog(LOG_ERR, "ERROR: too many failures for "
                                        "service %s/%s, disabling until next SIGHUP",
                                        SERVICEPARAM(s->name),
                                        SERVICEPARAM(s->familyname));


### PR DESCRIPTION
I recently moved sync_client to be managed by Cyrus rather than a separate "monitorsync" script.

Likewise, we have other things started under the DAEMON block which are supposed to run forever at Fastmail:

pusher, calalarmd, squatter, idled, bayesrpcd and one day again: promstatd.

This change means that if we hit the restart limit, we retry every 10 seconds forever for anything with the 'babysit' flag - which includes all daemons.  We only try once per 10 seconds unless we get a clean 10 seconds, in which case it resets back to allowing 5 failures with immediate restart.  This should stop it causing a totally crazy amount of restarts.

Finally: I added the string "ERROR" to the messages about hitting the limits, which will help with Fastmail's log tracking.