### PR TITLE
jmap_ical.c: fix JSCalendar conversion for DTEND with non-IANA timezones

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_alert_acknowledged_far_future
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_alert_acknowledged_far_future
@@ -1,0 +1,51 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_get_alert_acknowledged_far_future
+  : needs_component_jmap {
+    my ($self) = @_;
+
+    my $jmap   = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+TRANSP:TRANSPARENT
+DTSTART;TZID=Europe/Vienna:20240901T160000
+DURATION:PT1H
+UID:DBDB02AB-4799-45DD-A83D-5B1006C27CE2
+DTSTAMP:20160901T000000Z
+SUMMARY:test
+BEGIN:VALARM
+TRIGGER:-PT30M
+ACTION:DISPLAY
+DESCRIPTION:test
+ACKNOWLEDGED:99991231T235959
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOF
+    $caldav->Request('PUT', 'Default/test.ics', $ical, 'Content-Type' => 'text/calendar');
+
+    $res = $jmap->CallMethods([
+        [ 'CalendarEvent/query', {}, 'R1' ],
+        [
+            'CalendarEvent/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    name     => 'CalendarEvent/query',
+                    path     => '/ids'
+                },
+                properties => ['alerts'],
+            },
+            'R2'
+        ],
+    ]);
+    my @alerts = values %{ $res->[1][1]{list}[0]{alerts} };
+    $self->assert_str_equals('9999-12-31T23:59:59Z', $alerts[0]{acknowledged});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_locations_dtend
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_locations_dtend
@@ -1,0 +1,65 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_get_locations_dtend
+  : needs_component_jmap {
+    my ($self) = @_;
+
+    my $jmap   = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+TRANSP:TRANSPARENT
+DTSTART;TZID=Europe/Vienna:20240901T160000
+RRULE:FREQ=MONTHLY
+DTEND;TZID=America/New_York:20240928T170000
+UID:8D9B581D-6F64-4F9F-89CE-8F9C09D54911
+DTSTAMP:20160901T000000Z
+SUMMARY:test
+END:VEVENT
+BEGIN:VEVENT
+TRANSP:TRANSPARENT
+RECURRENCE-ID;TZID=Europe/Vienna:20241001T170000
+DTSTART;TZID=Europe/Vienna:20240930T170000
+RRULE:FREQ=MONTHLY
+DTEND;TZID=America/New_York:20240930T180000
+UID:8D9B581D-6F64-4F9F-89CE-8F9C09D54911
+DTSTAMP:20160901T000000Z
+SUMMARY:test
+END:VEVENT
+END:VCALENDAR
+EOF
+    $caldav->Request('PUT', 'Default/test.ics', $ical, 'Content-Type' => 'text/calendar');
+
+    $res = $jmap->CallMethods([
+        [ 'CalendarEvent/query', {}, 'R1' ],
+        [
+            'CalendarEvent/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    name     => 'CalendarEvent/query',
+                    path     => '/ids'
+                },
+                properties => [ 'locations', 'recurrenceOverrides' ],
+            },
+            'R2'
+        ],
+    ]);
+    my @locations = values %{ $res->[1][1]{list}[0]{locations} };
+    $self->assert_deep_equals(
+        \@locations,
+        [ { timeZone => 'America/New_York', relativeTo => 'end' } ]
+    );
+
+    my @recurOverrides = values %{ $res->[1][1]{list}[0]{recurrenceOverrides} };
+    $self->assert_deep_equals(
+        \@recurOverrides,
+        [ { start => '2024-09-30T17:00:00', duration => 'PT7H' } ],
+    );
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_locations_dtend
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_locations_dtend
@@ -54,7 +54,7 @@ EOF
     my @locations = values %{ $res->[1][1]{list}[0]{locations} };
     $self->assert_deep_equals(
         \@locations,
-        [ { timeZone => 'America/New_York', relativeTo => 'end' } ]
+        [ { '@type' => 'Location', timeZone => 'America/New_York', relativeTo => 'end' } ]
     );
 
     my @recurOverrides = values %{ $res->[1][1]{list}[0]{recurrenceOverrides} };

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_non_iana_dtend_timezone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_non_iana_dtend_timezone
@@ -1,0 +1,147 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_set_preserve_non_iana_dtend_timezone
+  : needs_component_jmap {
+    my ($self) = @_;
+
+    my $jmap   = $self->{jmap};
+    my $caldav = $self->{caldav};
+
+    xlog $self, "Create event with differing DTSTART and DTEND non-IANA timezones";
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Singapore Standard Time
+X-EM-DISPLAYNAME:(UTC+08:00) Kuala Lumpur\, Singapore
+BEGIN:STANDARD
+TZNAME:Malay Peninsula Standard Time
+DTSTART:00010101T000000
+TZOFFSETFROM:+0800
+TZOFFSETTO:+0800
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VTIMEZONE
+TZID:AUS Eastern Standard Time
+BEGIN:STANDARD
+DTSTART:16010101T030000
+TZOFFSETFROM:+1100
+TZOFFSETTO:+1000
+RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=4
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:16010101T020000
+TZOFFSETFROM:+1000
+TZOFFSETTO:+1100
+RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=10
+END:DAYLIGHT
+END:VTIMEZONE
+VERSION:2.0
+BEGIN:VEVENT
+TRANSP:TRANSPARENT
+DTSTART;TZID=AUS Eastern Standard Time:20240901T160000
+DTEND;TZID=Singapore Standard Time:20240901T170000
+UID:569470DB-7710-4B0B-80EB-3A4A7B528C77
+DTSTAMP:20160901T000000Z
+SUMMARY:test
+END:VEVENT
+END:VCALENDAR
+EOF
+    $caldav->Request('PUT', 'Default/test.ics', $ical, 'Content-Type' => 'text/calendar');
+
+    xlog $self, "Assert timezone ids are mapped to IANA names";
+    $res = $jmap->CallMethods([
+        [ 'CalendarEvent/query', {}, 'R1' ],
+        [
+            'CalendarEvent/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    name     => 'CalendarEvent/query',
+                    path     => '/ids'
+                },
+                properties => [ 'timeZone', 'locations' ],
+            },
+            'R2'
+        ],
+    ]);
+    my $eventId = $res->[1][1]{list}[0]{id};
+    $self->assert_not_null($eventId);
+
+    $self->assert_str_equals('Australia/Sydney', $res->[1][1]{list}[0]{timeZone});
+    my @locations = values %{ $res->[1][1]{list}[0]{locations} };
+    $self->assert_deep_equals(
+        \@locations,
+        [ { '@type' => 'Location', timeZone => 'Asia/Singapore', relativeTo => 'end' } ]
+    );
+
+    xlog $self, "Update event title, keeping timezones untouched";
+    $res = $jmap->CallMethods([
+        [
+            'CalendarEvent/set',
+            {
+                update => {
+                    $eventId => {
+                        title => 'updatedTitle',
+                    },
+                },
+            },
+            'R1'
+        ],
+        [
+            'CalendarEvent/get',
+            {
+                'ids'      => [$eventId],
+                properties => [ 'timeZone', 'locations' ],
+            },
+            'R2'
+        ],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    $self->assert_str_equals('Australia/Sydney', $res->[1][1]{list}[0]{timeZone});
+    my @locations = values %{ $res->[1][1]{list}[0]{locations} };
+    $self->assert_deep_equals(
+        \@locations,
+        [ { '@type' => 'Location', timeZone => 'Asia/Singapore', relativeTo => 'end' } ]
+    );
+
+    $res = $caldav->Request('GET', 'Default/test.ics');
+    my $ical = Data::ICal->new(data => $res->{content});
+
+    xlog "Assert non-IANA VTIMEZONEs are kept";
+    my @timezoneTzIds = sort
+      map  { $_->value }
+      map  { $_->property('TZID')->@* }
+      grep { $_->ical_entry_type eq 'VTIMEZONE' } @{ $ical->entries };
+    $self->assert_deep_equals(
+        [
+            'AUS Eastern Standard Time',
+            'Singapore Standard Time',
+        ],
+        \@timezoneTzIds
+    );
+
+    xlog "Assert non-IANA TZIDs are kept for DTSTART and DTEND";
+    my @dtstartTzIds = map { $_->parameters->{'TZID'} }
+      map  { $_->property('DTSTART')->@* }
+      grep { $_->ical_entry_type eq 'VEVENT' } @{ $ical->entries };
+    $self->assert_deep_equals(
+        [
+            'AUS Eastern Standard Time',
+        ],
+        \@dtstartTzIds
+    );
+
+    my @dtendTzIds = map { $_->parameters->{'TZID'} }
+      map  { $_->property('DTEND')->@* }
+      grep { $_->ical_entry_type eq 'VEVENT' } @{ $ical->entries };
+    $self->assert_deep_equals(
+        [
+            'Singapore Standard Time',
+        ],
+        \@dtendTzIds
+    );
+}

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -1376,11 +1376,13 @@ HIDDEN int jmapical_utcdatetime_from_string(const char *val, struct jmapical_dat
 
 HIDDEN int jmapical_datetime_from_icalprop(icalproperty *prop, struct jmapical_datetime *dt)
 {
-    icaltimetype icaldt = icalvalue_get_datetimedate(icalproperty_get_value(prop));
-    if (!icaltime_is_valid_time(icaldt)) return -1;
+    icalvalue *val = icalproperty_get_value(prop);
+    if (!(icalvalue_isa(val) == ICAL_DATETIME_VALUE) &&
+        !(icalvalue_isa(val) == ICAL_DATE_VALUE)) {
+        return -1;
+    }
 
-    jmapical_datetime_from_icaltime(icaldt, dt);
-
+    jmapical_datetime_from_icaltime(icalvalue_get_datetimedate(val), dt);
     return 0;
 }
 
@@ -1548,8 +1550,8 @@ static const char *tzid_from_icalprop(icalproperty *prop, int guess,
         } else if (tz) return icaltimezone_get_location(tz);
     } else {
         icalvalue *val = icalproperty_get_value(prop);
-        icaltimetype dt = icalvalue_get_datetime(val);
-        if (icaltime_is_valid_time(dt) && icaltime_is_utc(dt)) {
+        if (icalvalue_isa(val) == ICAL_DATETIME_VALUE &&
+            (icaltime_is_utc(icalvalue_get_datetime(val)))) {
             tzid = "Etc/UTC";
         }
     }


### PR DESCRIPTION
This fixes bugs that show when updating CalendarEvent objects where the updated iCalendar data contains a DTEND property having a non-IANA TZID that differs from the DTSTART timezone identifier.
In addition, this patch also replaces use of libical's `icaltime_is_valid_time` with own value checking, as libical arbitrarily restricts the year part of datetimes to be less than 3000.