### PR TITLE
iTIP: convert \n from iCalendar to “\r\n  <br>” to the MSA

### DIFF
--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -264,7 +264,7 @@ static void HTMLencode(struct buf *output, const char *input)
     htmlEncodeEntities((unsigned char *) buf_base(output), &outlen,
                        (unsigned char *) input, &inlen, 0);
     buf_truncate(output, outlen);
-    buf_replace_all(output, "\n", "\n  <br>");
+    buf_replace_all(output, "\n", "\r\n  <br>");
 }
 
 #define TEXT_INDENT     "             "


### PR DESCRIPTION
When an `\n` from an iCalendar property value is converted in http_caldav_sched.c:imip_send_sendmail() to HTML, the function used to send to the MSA `\n  <br>`.  That is: a single LF without CR.  This does not work any more, the MSA replies:
```
smtpclient: unexpected response to EOT: code=421 text=4.5.0 Bare linefeed (LF) not allowed
smtpclient: Bad protocol during DATA
```

This change sends in such cases `\r\n` instead of `\n`.