### PR TITLE
imapd: track characters used in IMAP tags

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1565,6 +1565,9 @@ static void record_client_tag_behaviour(const char *tag)
         return;
     }
 
+    /* if we haven't returned yet there's some odd stuff in there */
+    xsyslog(LOG_DEBUG, "saw an unusual tag", "tag=<%s>", tag);
+
     /* inclusive checks */
     if ((saw & TAG_SAW_DOT)) {
         client_behavior.did_tag_dot = 1;
@@ -1583,7 +1586,6 @@ static void record_client_tag_behaviour(const char *tag)
     }
 
     if ((saw & TAG_SAW_OTHER)) {
-        xsyslog(LOG_DEBUG, "saw an unusual tag", "tag=<%s>", tag);
         client_behavior.did_tag_other = 1;
     }
 }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1566,7 +1566,7 @@ static void record_client_tag_behaviour(const char *tag)
     }
 
     /* if we haven't returned yet there's some odd stuff in there */
-    xsyslog(LOG_DEBUG, "saw an unusual tag", "tag=<%s>", tag);
+    xsyslog(LOG_INFO, "saw an unusual tag", "tag=<%s>", tag);
 
     /* inclusive checks */
     if ((saw & TAG_SAW_DOT)) {

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -892,7 +892,7 @@ static void imapd_log_client_behavior(void)
                         "%s%s%s%s"
                         "%s%s%s%s"
                         "%s%s"
-                        "%s%s%s%s"
+                        "%s%s%s%s%s"
                         "%s%s%s%s"
                         "%s%s%s%s",
 
@@ -934,6 +934,7 @@ static void imapd_log_client_behavior(void)
                         client_behavior.did_tag_alpha   ? " tag_alpha=<1>"    : "",
                         client_behavior.did_tag_alnum   ? " tag_alnum=<1>"    : "",
                         client_behavior.did_tag_base64  ? " tag_base64=<1>"   : "",
+                        client_behavior.did_tag_onedot  ? " tag_onedot=<1>"   : "",
 
                         client_behavior.did_tag_dot     ? " tag_dot=<1>"      : "",
                         client_behavior.did_tag_sep     ? " tag_sep=<1>"      : "",
@@ -1562,6 +1563,10 @@ static void record_client_tag_behaviour(const char *tag)
     }
     else if (saw && (saw & ~TAG_BASE64) == 0) {
         client_behavior.did_tag_base64 = 1;
+        return;
+    }
+    else if (saw == TAG_SAW_DOT && !tag[1]) {
+        client_behavior.did_tag_onedot = 1;
         return;
     }
 

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -480,6 +480,7 @@ struct client_behavior_registry {
     uint32_t did_tag_alpha    : 1;   /* only letters */
     uint32_t did_tag_alnum    : 1;   /* only numbers and letters */
     uint32_t did_tag_base64   : 1;   /* only base64 characters */
+    uint32_t did_tag_onedot   : 1;   /* single dot */
     uint32_t did_tag_dot      : 1;   /* tags contain dots */
     uint32_t did_tag_sep      : 1;   /* tags contain - or _ */
     uint32_t did_tag_colon    : 1;   /* tags contain : */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -476,15 +476,19 @@ struct client_behavior_registry {
     uint32_t did_xlist        : 1;   /* used XLIST  */
 
     /* what kinds of tags is this client using? */
-    uint32_t did_tag_num      : 1;   /* only numbers */
-    uint32_t did_tag_alpha    : 1;   /* only letters */
-    uint32_t did_tag_alnum    : 1;   /* only numbers and letters */
-    uint32_t did_tag_base64   : 1;   /* only base64 characters */
-    uint32_t did_tag_onedot   : 1;   /* single dot */
+    uint32_t did_tag_only_num      : 1;   /* only numbers */
+    uint32_t did_tag_only_alpha    : 1;   /* only letters */
+    uint32_t did_tag_only_alnum    : 1;   /* only numbers and letters */
+    uint32_t did_tag_only_alnumdot : 1;   /* only numbers, letters, and dots */
+    uint32_t did_tag_only_base64   : 1;   /* only base64 characters */
+    uint32_t did_tag_only_onedot   : 1;   /* single dot */
+    uint32_t did_tag_num      : 1;   /* tags contain numbers */
+    uint32_t did_tag_alpha    : 1;   /* tags contain letters */
     uint32_t did_tag_dot      : 1;   /* tags contain dots */
     uint32_t did_tag_sep      : 1;   /* tags contain - or _ */
     uint32_t did_tag_colon    : 1;   /* tags contain : */
     uint32_t did_tag_angle    : 1;   /* tags contain < or > */
+    uint32_t did_tag_base64   : 1;   /* tags contains base64 punc characters */
     uint32_t did_tag_other    : 1;   /* tags contains other characters */
     uint32_t did_tag_POST     : 1;   /* used string "POST" as a tag */
     uint32_t did_tag_PUT      : 1;   /* used string "PUT" as a tag */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -474,6 +474,20 @@ struct client_behavior_registry {
 
     /* non-standard - track for possible deprecation */
     uint32_t did_xlist        : 1;   /* used XLIST  */
+
+    /* what kinds of tags is this client using? */
+    uint32_t did_tag_num      : 1;   /* only numbers */
+    uint32_t did_tag_alpha    : 1;   /* only letters */
+    uint32_t did_tag_alnum    : 1;   /* only numbers and letters */
+    uint32_t did_tag_base64   : 1;   /* only base64 characters */
+    uint32_t did_tag_dot      : 1;   /* tags contain dots */
+    uint32_t did_tag_sep      : 1;   /* tags contain - or _ */
+    uint32_t did_tag_colon    : 1;   /* tags contain : */
+    uint32_t did_tag_angle    : 1;   /* tags contain < or > */
+    uint32_t did_tag_other    : 1;   /* tags contains other characters */
+    uint32_t did_tag_POST     : 1;   /* used string "POST" as a tag */
+    uint32_t did_tag_PUT      : 1;   /* used string "PUT" as a tag */
+    uint32_t did_tag_inv      : 1;   /* we rejected an invalid tag */
 };
 
 #endif /* INCLUDED_IMAPD_H */


### PR DESCRIPTION
This extends the existing IMAP client behaviour tracking to record categories of characters used in tags

We don't have existing tests for the client behaviour logging, except for a couple of cursory checks in Simple and ID. I might feel more comfortable with some tests that verify the character class mappings detect as expected, but it'd be a whole new test suite, is it worth the effort?  I dunno.