### PR TITLE
lmtpd.c: don't declare shut_down function twice

### DIFF
--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -124,7 +124,7 @@ static int verify_user(const mbname_t *mbname,
                        struct auth_state *authstate);
 static char *generate_notify(message_data_t *m);
 
-void shut_down(int code);
+static void shut_down(int code) __attribute__((noreturn));
 
 static FILE *spoolfile(message_data_t *msgdata);
 static void removespool(message_data_t *msgdata);
@@ -1068,8 +1068,7 @@ EXPORTED void fatal(const char* s, int code)
 /*
  * Cleanly shut down and exit
  */
-void shut_down(int code) __attribute__((noreturn));
-void shut_down(int code)
+static void shut_down(int code)
 {
     int i;
 

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -216,7 +216,7 @@ static void cmd_starttls(struct conn *C, const char *tag);
 #ifdef HAVE_ZLIB
 static void cmd_compress(struct conn *C, const char *tag, const char *alg);
 #endif
-void shut_down(int code);
+static void shut_down(int code) __attribute__((noreturn));
 static int reset_saslconn(struct conn *c);
 static void database_init(void);
 static void sendupdates(struct conn *C, int flushnow);
@@ -2072,8 +2072,7 @@ void cmd_compress(struct conn *C __attribute__((unused)),
 }
 #endif /* HAVE_ZLIB */
 
-void shut_down(int code) __attribute__((noreturn));
-void shut_down(int code)
+static void shut_down(int code)
 {
     in_shutdown = 1;
 


### PR DESCRIPTION
This broke the clang-14 build with `-Werror` enabled, failing with a `[-Werror,-Winvalid-noreturn]` error.