### PR TITLE
http_cal_abook_admin.js: no new collection URLs with leading `-`

### DIFF
--- a/imap/http_cal_abook_admin.js
+++ b/imap/http_cal_abook_admin.js
@@ -83,7 +83,7 @@ function strHash(str) {
         hash <<= 1;
     }
 
-    return hash;
+    return Math.abs(hash);
 }
 
 


### PR DESCRIPTION
Do not create collection URLs with two `-` in a row, or with a leading `-`.  The former happens for name=atreatreaurdeaurntetdauaiuea, the latter for base address http://127.0.0.1/dav/calendars/user/a@b .