### PR TITLE
add attribute noreturn where useful

### DIFF
--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -75,7 +75,7 @@ const int config_need_data = 0;
 static int verbose = 0;
 
 /* forward declarations */
-void usage(void);
+void usage(void) __attribute__((noreturn));
 void free_zoneinfo(void *data);
 void store_zoneinfo(const char *tzid, void *data, void *rock);
 void do_zonedir(const char *prefix, struct hash_table *tzentries,

--- a/imap/ctl_zoneinfo.c
+++ b/imap/ctl_zoneinfo.c
@@ -80,7 +80,7 @@ void free_zoneinfo(void *data);
 void store_zoneinfo(const char *tzid, void *data, void *rock);
 void do_zonedir(const char *prefix, struct hash_table *tzentries,
                 struct zoneinfo *info);
-void shut_down(int code);
+void shut_down(int code) __attribute__((noreturn));
 
 
 int main(int argc, char **argv)
@@ -503,7 +503,6 @@ void store_zoneinfo(const char *tzid, void *data, void *rock)
 /*
  * Cleanly shut down and exit
  */
-void shut_down(int code) __attribute__((noreturn));
 void shut_down(int code)
 {
     in_shutdown = 1;

--- a/imap/cyr_synclog.c
+++ b/imap/cyr_synclog.c
@@ -58,6 +58,7 @@
 #include "util.h"
 #include "xmalloc.h"
 
+__attribute__((noreturn))
 void usage(const char *name) {
     fprintf(stderr, "Usage: %s [-C altconfig] [-{type}] value\n", name);
 

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -249,7 +249,7 @@ static struct scan_engine engine = { "<None Configured>", NULL, NULL, NULL, NULL
 
 
 /* forward declarations */
-int usage(char *name);
+void usage(char *name) __attribute__((noreturn));
 int scan_me(struct findall_data *, void *);
 unsigned virus_check(struct mailbox *mailbox,
                      const struct index_record *record,
@@ -395,7 +395,7 @@ int main (int argc, char *argv[])
     return 0;
 }
 
-int usage(char *name)
+void usage(char *name)
 {
     printf("usage: %s [-C <alt_config>] [-s <imap-search-string>] [ -r [-n] ] [-v]\n"
            "\t[mboxpattern1 ... [mboxpatternN]]\n", name);

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -80,7 +80,7 @@ const int config_need_data = 0;
 
 /* forward declarations */
 void usage(void) __attribute__((noreturn));
-void shut_down(int code);
+void shut_down(int code) __attribute__((noreturn));
 
 static int code = 0;
 

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -79,7 +79,7 @@ static struct namespace recon_namespace;
 const int config_need_data = 0;
 
 /* forward declarations */
-void usage(void);
+void usage(void) __attribute__((noreturn));
 void shut_down(int code);
 
 static int code = 0;

--- a/imap/fud.c
+++ b/imap/fud.c
@@ -74,6 +74,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
+#include "master/service.h"
+
 #define REQ_OK          0
 #define REQ_DENY        1
 #define REQ_UNK         2

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -484,7 +484,7 @@ ptrarray_t backend_cached = PTRARRAY_INITIALIZER;
 static int tls_init(int client_auth, struct buf *serverinfo);
 static void starttls(struct http_connection *conn, int timeout);
 void usage(void) __attribute__((noreturn));
-void shut_down(int code) __attribute__ ((noreturn));
+void shut_down(int code) __attribute__((noreturn));
 
 /* Enable the resetting of a sasl_conn_t */
 static int reset_saslconn(sasl_conn_t **conn);

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -483,7 +483,7 @@ ptrarray_t backend_cached = PTRARRAY_INITIALIZER;
 
 static int tls_init(int client_auth, struct buf *serverinfo);
 static void starttls(struct http_connection *conn, int timeout);
-void usage(void);
+void usage(void) __attribute__((noreturn));
 void shut_down(int code) __attribute__ ((noreturn));
 
 /* Enable the resetting of a sasl_conn_t */

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -106,6 +106,8 @@
 #include "imap/imap_err.h"
 #include "imap/http_err.h"
 
+#include "master/service.h"
+
 #ifdef WITH_DAV
 #include "http_dav.h"
 #endif

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -126,6 +126,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
+#include "master/service.h"
+
 #include "iostat.h"
 
 extern int optind;

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -108,6 +108,8 @@
 #include "imap/imap_err.h"
 #include "imap/lmtp_err.h"
 
+#include "master/service.h"
+
 #include "lmtpd.h"
 #include "lmtpengine.h"
 #ifdef USE_SIEVE

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -92,6 +92,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
+#include "master/service.h"
+
 /* Sent to clients that we can't accept a connection for. */
 static const char SERVER_UNABLE_STRING[] = "* BYE \"Server Unable\"\r\n";
 

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -114,6 +114,8 @@
 #include "imap/imap_err.h"
 #include "imap/nntp_err.h"
 
+#include "master/service.h"
+
 extern int optind;
 extern char *optarg;
 extern int opterr;

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -93,6 +93,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
+#include "master/service.h"
+
 #include "statuscache.h"
 
 #include "iostat.h"

--- a/imap/smmapd.c
+++ b/imap/smmapd.c
@@ -101,6 +101,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
+#include "master/service.h"
+
 static const char *BB;
 static int forcedowncase;
 

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -105,6 +105,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
+#include "master/service.h"
+
 #include "message_guid.h"
 #include "sync_support.h"
 /*#include "cdb.h"*/

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -43,6 +43,7 @@
 #ifndef INCLUDED_ASSERT_H
 #define INCLUDED_ASSERT_H
 
+__attribute__((noreturn))
 void assertionfailed(const char *file, int line, const char *expr);
 
 #define assert(expr)                                                \

--- a/master/service.h
+++ b/master/service.h
@@ -57,7 +57,7 @@ enum {
 extern int service_init(int argc, char **argv, char **envp);
 extern int service_main(int argc, char **argv, char **envp);
 extern int service_main_fd(int fd, int argc, char **argv, char **envp);
-extern void service_abort(int error);
+extern void service_abort(int error) __attribute__((noreturn));
 
 enum {
     MAX_USE = 250,

--- a/notifyd/notifyd.c
+++ b/notifyd/notifyd.c
@@ -67,6 +67,7 @@
 #include "xmalloc.h"
 #include "strarray.h"
 
+#include "master/service.h"
 
 /* global state */
 const int config_need_data = 0;

--- a/perl/sieve/lib/request.c
+++ b/perl/sieve/lib/request.c
@@ -63,6 +63,7 @@
 
 #define BLOCKSIZE 1024
 
+__attribute__((noreturn))
 void parseerror(const char *str)
 {
   printf("Bad protocol from MANAGESIEVE server: %s\n", str);

--- a/ptclient/ptloader.c
+++ b/ptclient/ptloader.c
@@ -65,6 +65,8 @@
 #include "xmalloc.h"
 #include "ptloader.h"
 
+#include "master/service.h"
+
 struct pts_module *pts_modules[] = {
     &pts_http,
 #ifdef HAVE_LDAP

--- a/timsieved/timsieved.c
+++ b/timsieved/timsieved.c
@@ -73,6 +73,7 @@
 #include "imap/proxy.h"
 #include "imap/sync_log.h"
 #include "lib/assert.h"
+#include "master/service.h"
 #include "sieve/sieve_interface.h"
 #include "timsieved/actions.h"
 #include "timsieved/codes.h"


### PR DESCRIPTION
This is a redo of #3737 by @dilyanpalauzov (thanks!)

Adds `__attribute__((noreturn))` to a number of choice places detected by GCC's `-Wsuggest-attribute=noreturn` option.  In particular, it adds it to the places where GCC's suggestion is correct.  Most of these are `usage()`, `shut_down()`, and `service_abort()`, but there's a few others.

The advantage of adding this attribute to functions that intentionally never return is that GCC can now tell us when functions that _should_ return _don't_.  There's a few of those, and this PR does not address them, because they're not critical problems, and they'll need more care than I'm investing right now to deal with properly.  At the time of writing, these are:

* mupdate: `mupdate_client_start()` thread body loops forever (eventually terminated when the process exits)
* fud, notifyd, timsieved: lazy (but safe) `service_main()` implementation whereby the whole process exits after serving one client connection, instead of resetting its state ready for the next one