### PR TITLE
proppatch_todb_nomask() - store for user ""

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3379,8 +3379,7 @@ static int proppatch_todb_internal(xmlNodePtr prop, unsigned set,
     if (!r) r = mask ?
         annotate_state_writemask(astate, buf_cstring(&pctx->buf),
                 httpd_userid, &value) :
-        annotate_state_write(astate, buf_cstring(&pctx->buf),
-                httpd_userid, &value);
+        annotate_state_write(astate, buf_cstring(&pctx->buf), "", &value);
 
     if (!r) {
         xml_add_prop(HTTP_OK, pctx->ns[NS_DAV], &propstat[PROPSTAT_OK],


### PR DESCRIPTION
After calling proppatch_todb_nomask() the property should be stored for user `""`, not for httpd_userid.  The latter might or might not be the mailbox owner.