### PR TITLE
imapoptions: reword default value for calendar_user_address_set

### DIFF
--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1543,7 +1543,6 @@ static int sieve_processcal(void *ac, void *ic, void *sc, void *mc,
 
         domains = config_getstring(IMAPOPT_CALENDAR_USER_ADDRESS_SET);
         if (!domains) domains = config_defdomain;
-        if (!domains) domains = config_servername;
 
         tok_init(&tok, domains, " \t", TOK_TRIMLEFT|TOK_TRIMRIGHT);
         while ((domain = tok_next(&tok))) {

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -635,7 +635,7 @@ Blank lines and lines beginning with ``#'' are ignored.
 { "calendar_user_address_set", NULL, STRING, "2.5.0" }
 /* Space-separated list of domains corresponding to calendar user
    addresses for which the server is responsible.  If not set (the
-   default), the value of the "servername" option will be used. */
+   default), the value of the "defaultdomain" option will be used. */
 
 { "calendar_component_set", "VEVENT VTODO VJOURNAL VFREEBUSY VAVAILABILITY VPOLL", BITFIELD("VEVENT", "VTODO", "VJOURNAL", "VFREEBUSY", "VAVAILABILITY", "VPOLL"), "3.1.7" }
 /* Space-separated list of iCalendar component types that calendar

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -847,7 +847,6 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
     /* create an array of calendar-user-address-set domains */
     cua_domains = config_getstring(IMAPOPT_CALENDAR_USER_ADDRESS_SET);
     if (!cua_domains) cua_domains = config_defdomain;
-    if (!cua_domains) cua_domains = config_servername;
 
     tok_init(&tok, cua_domains, " \t", TOK_TRIMLEFT|TOK_TRIMRIGHT);
     while ((domain = tok_next(&tok)))


### PR DESCRIPTION
defaultdomain cannot be NULL, it defaults to `internal`. I see no way how can config_defdomain be NULL.  When I set in imapd.conf

> defaultdomain:

master logs “empty option value on line 7 of configuration file”, “exiting”.

Here the documentation is adjusted to the implementation.