### PR TITLE
Add compatibility layer to support libical icalrecur by ref and by value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1764,6 +1764,11 @@ dnl
                         [Do we have support for PARTICIPANT-TYPE=VOTER?]),
                 [], [[#include <libical/ical.h>]])
 
+        dnl icalrecurrencetype_new will be new in libical 4.0
+        AC_CHECK_LIB(ical, icalrecurrencetype_new,
+                AC_DEFINE(HAVE_RECUR_BY_REF,[],
+                        [Do we have support for icalrecurrencetype by reference?]))
+
         dnl Check for libicalvcard
         AC_CHECK_LIB(icalvcard, vcardcomponent_new, [
                  AC_DEFINE(HAVE_LIBICALVCARD,[],[Do we have the icalvcard library?])

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -795,7 +795,7 @@ static int check_by_array(const short *byX, short size,
     memcpy(my_byX, byX, size * sizeof(short));
 
     /* convert each value to seconds and determine actual length of data */
-    for (len = 0; len < size && my_byX[len] != ICAL_RECURRENCE_ARRAY_MAX; len++) {
+    for (len = 0; len < size; len++) {
         my_byX[len] *= to_seconds;
     }
 
@@ -896,6 +896,7 @@ static int has_alarms(void *data, struct mailbox *mailbox,
                 int recur_interval = rrule->interval;
                 const char *bypart = "";
                 int disable = 0;
+                short size;
 
                 switch (rrule->freq) {
                 case ICAL_YEARLY_RECURRENCE:
@@ -926,20 +927,20 @@ static int has_alarms(void *data, struct mailbox *mailbox,
                     break;
                 }
 
-                if (rrule->by_second[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+                if ((size = icalrecur_byrule_size(rrule, ICAL_BY_SECOND))) {
                     bypart = "SECOND";
-                    disable = check_by_array(rrule->by_second, ICAL_BY_SECOND_SIZE,
-                                             recur_interval, 1);
+                    disable = check_by_array(icalrecur_byrule_data(rrule, ICAL_BY_SECOND),
+                                             size, recur_interval, 1);
                 }
-                else if (rrule->by_minute[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+                else if ((size = icalrecur_byrule_size(rrule, ICAL_BY_MINUTE))) {
                     bypart = "MINUTE";
-                    disable = check_by_array(rrule->by_minute, ICAL_BY_MINUTE_SIZE,
-                                             recur_interval, 60);
+                    disable = check_by_array(icalrecur_byrule_data(rrule, ICAL_BY_MINUTE),
+                                             size, recur_interval, 60);
                 }
-                else if (rrule->by_hour[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+                else if ((size = icalrecur_byrule_size(rrule, ICAL_BY_HOUR))) {
                     bypart = "HOUR";
-                    disable = check_by_array(rrule->by_hour, ICAL_BY_HOUR_SIZE,
-                                             recur_interval, 3600);
+                    disable = check_by_array(icalrecur_byrule_data(rrule, ICAL_BY_HOUR),
+                                             size, recur_interval, 3600);
                 }
                 else if (recur_interval < min_interval) {
                     disable = 1;

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -1828,16 +1828,18 @@ static unsigned buf_append_rrule_as_posix_string(struct buf *buf,
     at = icalproperty_get_dtstart(prop);
     hour = at.hour;
 
-    if (rrule->by_day[0] == ICAL_RECURRENCE_ARRAY_MAX) {
+    if (icalrecur_byrule_size(rrule, ICAL_BY_DAY) == 0) {
         /* date - Julian yday */
         buf_printf(buf, ",J%u", month_doy_offsets[0][at.month - 1] + at.day);
     }
     else {
         /* BYDAY */
         unsigned month;
-        int week = icalrecurrencetype_day_position(rrule->by_day[0]);
-        int wday = icalrecurrencetype_day_day_of_week(rrule->by_day[0]);
-        int yday = rrule->by_year_day[0];
+        short *by_day = icalrecur_byrule_data(rrule, ICAL_BY_DAY);
+        short *by_year_day = icalrecur_byrule_data(rrule, ICAL_BY_YEAR_DAY);
+        int week = icalrecurrencetype_day_position(by_day[0]);
+        int wday = icalrecurrencetype_day_day_of_week(by_day[0]);
+        int yday = by_year_day[0];
 
         if (yday != ICAL_RECURRENCE_ARRAY_MAX) {
             /* BYYEARDAY */
@@ -1860,9 +1862,11 @@ static unsigned buf_append_rrule_as_posix_string(struct buf *buf,
         }
         else {
             /* BYMONTH */
-            int mday = rrule->by_month_day[0];
+            short *by_month = icalrecur_byrule_data(rrule, ICAL_BY_MONTH);
+            short *by_month_day = icalrecur_byrule_data(rrule, ICAL_BY_MONTH_DAY);
+            int mday = by_month_day[0];
 
-            month = rrule->by_month[0];
+            month = by_month[0];
 
             if (mday != ICAL_RECURRENCE_ARRAY_MAX) {
                 /* MONTHDAY:  wday >= mday */

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -72,11 +72,29 @@ extern icalrecurrencetype_t *icalvalue_get_recurrence(const icalvalue *val);
     icalproperty_set_value(prop, icalvalue_new_recurrence(rt))
 
 #ifdef HAVE_RECUR_BY_REF
+#define ICAL_RECURRENCE_ARRAY_MAX            0x7f7f
 #define icalrecurrence_iterator_new(rt, tt)  icalrecur_iterator_new(rt, tt)
 #define icalvalue_new_recurrence(rt)         icalvalue_new_recur(rt)
 #define icalvalue_set_recurrence(val, rt)    icalvalue_set_recur(val, rt)
+#define icalrecur_byrule_size(rt, rule)      (rt->by[rule].size)
+#define icalrecur_byrule_data(rt, rule)      (rt->by[rule].data)
 
 #else /* !HAVE_RECUR_BY_REF */
+typedef enum icalrecurrencetype_byrule
+{
+    ICAL_BY_MONTH = 0,
+    ICAL_BY_WEEK_NO,
+    ICAL_BY_YEAR_DAY,
+    ICAL_BY_MONTH_DAY,
+    ICAL_BY_DAY,
+    ICAL_BY_HOUR,
+    ICAL_BY_MINUTE,
+    ICAL_BY_SECOND,
+    ICAL_BY_SET_POS,
+
+    ICAL_BY_NUM_PARTS
+} icalrecurrencetype_byrule;
+
 #define icalrecurrence_iterator_new(rt, tt)  icalrecur_iterator_new(*(rt), tt)
 #define icalvalue_new_recurrence(rt)         icalvalue_new_recur(*(rt))
 #define icalvalue_set_recurrence(val, rt)    icalvalue_set_recur(val, *(rt))
@@ -85,6 +103,10 @@ extern icalrecurrencetype_t *icalrecurrencetype_new(void);
 extern icalrecurrencetype_t *icalrecurrencetype_clone(icalrecurrencetype_t *rt);
 extern icalrecurrencetype_t *icalrecurrencetype_new_from_string(const char *str);
 extern void icalrecurrencetype_unref(icalrecurrencetype_t *rt);
+extern short *icalrecur_byrule_data(icalrecurrencetype_t *rt,
+                                    icalrecurrencetype_byrule rule);
+extern short icalrecur_byrule_size(icalrecurrencetype_t *rt,
+                                   icalrecurrencetype_byrule rule);
 #endif /* HAVE_RECUR_BY_REF */
 
 #ifdef HAVE_PARTTYPE_VOTER

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -61,6 +61,32 @@
 #define PER_USER_CAL_DATA                                       \
     DAV_ANNOT_NS "<" XML_NS_CYRUS ">per-user-calendar-data"
 
+typedef struct icalrecurrencetype icalrecurrencetype_t;
+
+extern icalrecurrencetype_t *icalvalue_get_recurrence(const icalvalue *val);
+
+#define icalproperty_get_recurrence(prop)                       \
+    icalvalue_get_recurrence(icalproperty_get_value(prop))
+
+#define icalproperty_set_recurrence(prop, rt)                   \
+    icalproperty_set_value(prop, icalvalue_new_recurrence(rt))
+
+#ifdef HAVE_RECUR_BY_REF
+#define icalrecurrence_iterator_new(rt, tt)  icalrecur_iterator_new(rt, tt)
+#define icalvalue_new_recurrence(rt)         icalvalue_new_recur(rt)
+#define icalvalue_set_recurrence(val, rt)    icalvalue_set_recur(val, rt)
+
+#else /* !HAVE_RECUR_BY_REF */
+#define icalrecurrence_iterator_new(rt, tt)  icalrecur_iterator_new(*(rt), tt)
+#define icalvalue_new_recurrence(rt)         icalvalue_new_recur(*(rt))
+#define icalvalue_set_recurrence(val, rt)    icalvalue_set_recur(val, *(rt))
+
+extern icalrecurrencetype_t *icalrecurrencetype_new(void);
+extern icalrecurrencetype_t *icalrecurrencetype_clone(icalrecurrencetype_t *rt);
+extern icalrecurrencetype_t *icalrecurrencetype_new_from_string(const char *str);
+extern void icalrecurrencetype_unref(icalrecurrencetype_t *rt);
+#endif /* HAVE_RECUR_BY_REF */
+
 #ifdef HAVE_PARTTYPE_VOTER
 #define HAVE_VPOLL_SUPPORT
 #endif

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -461,9 +461,9 @@ static const char *deliver_merge_reply(icalcomponent *ical,  // current iCalenda
                     break;
 
                 case ICAL_RRULE_PROPERTY: {
-                    struct icalrecurrencetype rrule =
-                        icalproperty_get_rrule(prop);
-                    ptrarray_append(&rrules, &rrule);
+                    struct icalrecurrencetype *rrule =
+                        icalproperty_get_recurrence(prop);
+                    ptrarray_append(&rrules, rrule);
                     break;
                 }
 
@@ -526,7 +526,7 @@ static const char *deliver_merge_reply(icalcomponent *ical,  // current iCalenda
                 for (i = 0; !valid && i < size; i++) {
                     struct icalrecurrencetype *rrule = ptrarray_nth(&rrules, i);
                     icalrecur_iterator *ritr =
-                        icalrecur_iterator_new(*rrule, dtstart);
+                        icalrecurrence_iterator_new(rrule, dtstart);
 
                     for (this = icalrecur_iterator_next(ritr);
                          !icaltime_is_null_time(this);
@@ -537,6 +537,7 @@ static const char *deliver_merge_reply(icalcomponent *ical,  // current iCalenda
                         break;
                     }
                     icalrecur_iterator_free(ritr);
+                    icalrecurrencetype_unref(rrule);
                 }
 
                 if (!valid) {

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -1751,25 +1751,27 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
     char *s = NULL;
     struct buf buf = BUF_INITIALIZER;
     size_t i;
+    json_t *recur;
 
-    struct icalrecurrencetype rrule = icalproperty_get_rrule(prop);
-    if (rrule.freq == ICAL_NO_RECURRENCE) {
-        return json_null();
+    struct icalrecurrencetype *rrule = icalproperty_get_recurrence(prop);
+    if (rrule->freq == ICAL_NO_RECURRENCE) {
+        recur = json_null();
+        goto done;
     }
 
-    json_t *recur = json_pack("{s:s}", "@type", "RecurrenceRule");
+    recur = json_pack("{s:s}", "@type", "RecurrenceRule");
 
     /* frequency */
-    s = lcase(xstrdup(icalrecur_freq_to_string(rrule.freq)));
+    s = lcase(xstrdup(icalrecur_freq_to_string(rrule->freq)));
     json_object_set_new(recur, "frequency", json_string(s));
     free(s);
 
-    json_object_set_new(recur, "interval", json_integer(rrule.interval));
+    json_object_set_new(recur, "interval", json_integer(rrule->interval));
 
 #ifdef HAVE_RSCALE
     /* rscale */
-    if (rrule.rscale) {
-        s = xstrdup(rrule.rscale);
+    if (rrule->rscale) {
+        s = xstrdup(rrule->rscale);
         s = lcase(s);
         json_object_set_new(recur, "rscale", json_string(s));
         free(s);
@@ -1777,7 +1779,7 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
 
     /* skip */
     const char *skip = NULL;
-    switch (rrule.skip) {
+    switch (rrule->skip) {
         case ICAL_SKIP_BACKWARD:
             skip = "backward";
             break;
@@ -1793,7 +1795,7 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
 #endif
 
     /* firstDayOfWeek */
-    s = xstrdup(icalrecur_weekday_to_string(rrule.week_start));
+    s = xstrdup(icalrecur_weekday_to_string(rrule->week_start));
     s = lcase(s);
     json_object_set_new(recur, "firstDayOfWeek", json_string(s));
     free(s);
@@ -1805,19 +1807,19 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
         icalrecurrencetype_weekday weekday;
         int pos;
 
-        if (rrule.by_day[i] == ICAL_RECURRENCE_ARRAY_MAX) {
+        if (rrule->by_day[i] == ICAL_RECURRENCE_ARRAY_MAX) {
             break;
         }
 
         jday = json_object();
-        weekday = icalrecurrencetype_day_day_of_week(rrule.by_day[i]);
+        weekday = icalrecurrencetype_day_day_of_week(rrule->by_day[i]);
 
         s = xstrdup(icalrecur_weekday_to_string(weekday));
         s = lcase(s);
         json_object_set_new(jday, "day", json_string(s));
         free(s);
 
-        pos = icalrecurrencetype_day_position(rrule.by_day[i]);
+        pos = icalrecurrencetype_day_position(rrule->by_day[i]);
         if (pos) {
             json_object_set_new(jday, "nthOfPeriod", json_integer(pos));
         }
@@ -1840,11 +1842,11 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
     for (i = 0; i < ICAL_BY_MONTH_SIZE; i++) {
         short bymonth;
 
-        if (rrule.by_month[i] == ICAL_RECURRENCE_ARRAY_MAX) {
+        if (rrule->by_month[i] == ICAL_RECURRENCE_ARRAY_MAX) {
             break;
         }
 
-        bymonth = rrule.by_month[i];
+        bymonth = rrule->by_month[i];
         buf_printf(&buf, "%d", icalrecurrencetype_month_month(bymonth));
         if (icalrecurrencetype_month_is_leap(bymonth)) {
             buf_appendcstr(&buf, "L");
@@ -1859,56 +1861,56 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
         json_decref(jbm);
     }
 
-    if (rrule.by_month_day[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+    if (rrule->by_month_day[0] != ICAL_RECURRENCE_ARRAY_MAX) {
         json_object_set_new(recur, "byMonthDay",
-                recurrence_byX_fromical(rrule.by_month_day,
+                recurrence_byX_fromical(rrule->by_month_day,
                     ICAL_BY_MONTHDAY_SIZE, &identity_int));
     }
-    if (rrule.by_year_day[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+    if (rrule->by_year_day[0] != ICAL_RECURRENCE_ARRAY_MAX) {
         json_object_set_new(recur, "byYearDay",
-                recurrence_byX_fromical(rrule.by_year_day,
+                recurrence_byX_fromical(rrule->by_year_day,
                     ICAL_BY_YEARDAY_SIZE, &identity_int));
     }
-    if (rrule.by_week_no[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+    if (rrule->by_week_no[0] != ICAL_RECURRENCE_ARRAY_MAX) {
         json_object_set_new(recur, "byWeekNo",
-                recurrence_byX_fromical(rrule.by_week_no,
+                recurrence_byX_fromical(rrule->by_week_no,
                     ICAL_BY_WEEKNO_SIZE, &identity_int));
     }
-    if (rrule.by_hour[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+    if (rrule->by_hour[0] != ICAL_RECURRENCE_ARRAY_MAX) {
         json_object_set_new(recur, "byHour",
-                recurrence_byX_fromical(rrule.by_hour,
+                recurrence_byX_fromical(rrule->by_hour,
                     ICAL_BY_HOUR_SIZE, &identity_int));
     }
-    if (rrule.by_minute[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+    if (rrule->by_minute[0] != ICAL_RECURRENCE_ARRAY_MAX) {
         json_object_set_new(recur, "byMinute",
-                recurrence_byX_fromical(rrule.by_minute,
+                recurrence_byX_fromical(rrule->by_minute,
                     ICAL_BY_MINUTE_SIZE, &identity_int));
     }
-    if (rrule.by_second[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+    if (rrule->by_second[0] != ICAL_RECURRENCE_ARRAY_MAX) {
         json_object_set_new(recur, "bySecond",
-                recurrence_byX_fromical(rrule.by_second,
+                recurrence_byX_fromical(rrule->by_second,
                     ICAL_BY_SECOND_SIZE, &identity_int));
     }
-    if (rrule.by_set_pos[0] != ICAL_RECURRENCE_ARRAY_MAX) {
+    if (rrule->by_set_pos[0] != ICAL_RECURRENCE_ARRAY_MAX) {
         json_object_set_new(recur, "bySetPosition",
-                recurrence_byX_fromical(rrule.by_set_pos,
+                recurrence_byX_fromical(rrule->by_set_pos,
                     ICAL_BY_SETPOS_SIZE, &identity_int));
     }
 
-    if (rrule.count != 0) {
+    if (rrule->count != 0) {
         /* Recur count takes precedence over until. */
-        json_object_set_new(recur, "count", json_integer(rrule.count));
-    } else if (!icaltime_is_null_time(rrule.until)) {
+        json_object_set_new(recur, "count", json_integer(rrule->count));
+    } else if (!icaltime_is_null_time(rrule->until)) {
         icaltimetype dtuntil;
-        if (rrule.until.is_date) {
-            dtuntil = rrule.until;
+        if (rrule->until.is_date) {
+            dtuntil = rrule->until;
             dtuntil.hour = 23;
             dtuntil.minute = 59;
             dtuntil.second = 59;
             dtuntil.is_date = 0;
         }
         else {
-            dtuntil = icaltime_convert_to_zone(rrule.until, untiltz);
+            dtuntil = icaltime_convert_to_zone(rrule->until, untiltz);
         }
         struct jmapical_datetime until = JMAPICAL_DATETIME_INITIALIZER;
         jmapical_datetime_from_icaltime(dtuntil, &until);
@@ -1923,6 +1925,8 @@ static json_t* recurrencerule_from_ical(icalproperty *prop, icaltimezone *untilt
         recur = json_null();
     }
 
+  done:
+    icalrecurrencetype_unref(rrule);
     buf_free(&buf);
     return recur;
 }
@@ -6590,27 +6594,19 @@ recurrencerule_to_ical(icalcomponent *comp, struct jmap_parser *parser,
 
     if (!json_array_size(parser->invalid)) {
         /* Add RRULE to component */
-        struct icalrecurrencetype rt =
-            icalrecurrencetype_from_string(buf_ucase(&buf));
-        if (rt.freq != ICAL_NO_RECURRENCE) {
-            icalproperty *prop = NULL;
-            if (kind == ICAL_RRULE_PROPERTY) {
-                prop = icalproperty_new_rrule(rt);
+        struct icalrecurrencetype *rt =
+            icalrecurrencetype_new_from_string(buf_ucase(&buf));
+        if (rt->freq != ICAL_NO_RECURRENCE) {
+            icalproperty *prop = icalproperty_new(kind);
+            if (prop) {
+                icalproperty_set_recurrence(prop, rt);
+                icalcomponent_add_property(comp, prop);
             }
-            else if (kind == ICAL_EXRULE_PROPERTY) {
-                prop = icalproperty_new_exrule(rt);
-            }
-            if (prop) icalcomponent_add_property(comp, prop);
         } else {
             syslog(LOG_ERR, "jmap_ical: generated bogus RRULE: %s", buf_cstring(&buf));
             jmap_parser_invalid(parser, NULL);
         }
-        // XXX this should go to libical
-        if (rt.rscale) {
-            free(rt.rscale);
-            rt.rscale = NULL;
-        }
-        icalrecurrencetype_clear(&rt);
+        icalrecurrencetype_unref(rt);
     }
 
     buf_free(&buf);

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -374,10 +374,11 @@ static void icalproperty_add_value_as_xml_element(xmlNodePtr xprop,
         return;
 
     case ICAL_RECUR_VALUE: {
-        struct icalrecurrencetype recur = icalvalue_get_recur(value);
+        struct icalrecurrencetype *recur = icalvalue_get_recurrence(value);
 
-        icalrecurrencetype_add_as_xxx(&recur, xtype, NULL,
+        icalrecurrencetype_add_as_xxx(recur, xtype, NULL,
                                       &icalrecur_add_string_as_xml_element);
+        icalrecurrencetype_unref(recur);
         return;
     }
 
@@ -724,7 +725,7 @@ static icalvalue *xml_element_to_icalvalue(xmlNodePtr xtype,
     case ICAL_RECUR_VALUE: {
         struct buf rrule = BUF_INITIALIZER;
         struct hash_table byrules;
-        struct icalrecurrencetype rt;
+        struct icalrecurrencetype *rt;
         char *sep = "";
 
         construct_hash_table(&byrules, 10, 1);
@@ -769,10 +770,11 @@ static icalvalue *xml_element_to_icalvalue(xmlNodePtr xtype,
         free_hash_table(&byrules, NULL);
 
         /* parse our iCal RRULE string */
-        rt = icalrecurrencetype_from_string(buf_cstring(&rrule));
+        rt = icalrecurrencetype_new_from_string(buf_cstring(&rrule));
         buf_free(&rrule);
 
-        if (rt.freq != ICAL_NO_RECURRENCE) value = icalvalue_new_recur(rt);
+        if (rt->freq != ICAL_NO_RECURRENCE) value = icalvalue_new_recurrence(rt);
+        icalrecurrencetype_unref(rt);
 
         break;
     }


### PR DESCRIPTION
Also handles the by_* arrays being renamed as part of the icalrecur-by-ref work