### PR TITLE
http_cgi.c:service_main() avoid use after free(environ)

### DIFF
--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -248,13 +248,16 @@ static int meth_get(struct transaction_t *txn,
 
     env = strarray_splitm(NULL, buf_release(&txn->buf), "\t", 0);
     strarray_append(env, NULL);
+    char **const environ_orig = environ;
     environ = env->data;
 
     /* Run script */
     if (command_popen(&cmd, "rw", cwd, script, NULL)) {
         ret = HTTP_SERVER_ERROR;
+        environ = environ_orig;
         goto done;
     }
+    environ = environ_orig;
 
     /* Send request body */
     prot_putbuf(cmd->stdin_prot, &txn->req_body.payload);


### PR DESCRIPTION
environ is freed below and then in the next iteration of `service_main()` → `get_clienthost()` → `getnameinfo()` can call systemd’s nss-resolve:`getenv()`.

Fixes https://github.com/cyrusimap/cyrus-imapd/issues/5072.