### PR TITLE
CalDAV OPTIONS: do not announce `calendar-auto-schedule` when CY:scheduling-enabled is `F`

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -8202,6 +8202,13 @@ static int meth_options_cal(struct transaction_t *txn, void *params)
                    txn->req_tgt.path);
         strarray_appendm(&txn->resp_body.links, buf_release(&link));
     }
+    if (txn->req_tgt.allow & ALLOW_CAL_SCHED) {
+        struct buf temp = BUF_INITIALIZER;
+        if (!annotatemore_lookup_mbe(txn->req_tgt.mbentry, DAV_ANNOT_NS "<" XML_NS_CYRUS ">scheduling-enabled", "", &temp)
+            && (!strcasecmp(buf_cstring(&temp), "F") || !strcasecmp(temp.s, "no")))
+                txn->req_tgt.allow &= ~ALLOW_CAL_SCHED;
+        buf_free(&temp);
+    };
 
     return meth_options(txn, oparams->parse_path);
 }


### PR DESCRIPTION
This way client software can show to the user when server-side scheduling is disabled.  The client software can then offer to send iMIP messages.

While `_scheduling_enabled()` calls

> annotatemore_lookupmask_mbox(mailbox, DAV_ANNOT_NS "<" XML_NS_CYRUS ">scheduling-enabled", "", &buf);`

this function executes

> annotatemore_lookup_mbe(mbentry, DAV_ANNOT_NS "<" XML_NS_CYRUS ">scheduling-enabled", "", &buf);`

The difference is, that the former also invokes
```c
/* and because of Bron's use of NULL rather than "" at FastMail... */
if (value->len == 0)
    r = _annotate_lookup(mboxname, mboxid, uid, entry, NULL, value);
```
I do not understand how this NULL is supposed to work at FastMail.