### PR TITLE
PROPPATCH: use right namespace prefix in response

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -113,6 +113,9 @@ static const struct dav_namespace_t {
     { XML_NS_SYSFLAG, "SF" },
 };
 
+#define NUM_KNOWN_NAMESPACES                                    \
+    (sizeof(known_namespaces) / sizeof(struct dav_namespace_t))
+
 static const struct match_type_t dav_match_types[] = {
     { "contains", MATCH_TYPE_CONTAINS },
     { "equals", MATCH_TYPE_EQUALS },
@@ -3739,11 +3742,13 @@ static int do_proppatch(struct proppatch_ctx *pctx, xmlNodePtr instr)
                     }
                     else if (pctx->txn->req_tgt.namespace->id != URL_NS_PRINCIPAL) {
                         /* Write "dead" property */
-                        for (long unsigned int i = 0; i < sizeof(known_namespaces) / sizeof(struct dav_namespace_t); i++)
-                            if (!strcmp((const char*)prop->ns->href, known_namespaces[i].href)) {
+                        for (size_t i = 0; i < NUM_KNOWN_NAMESPACES; i++) {
+                            if (!strcmp((const char *) prop->ns->href,
+                                        known_namespaces[i].href)) {
                                 prop->ns = pctx->ns[i];
                                 break;
                             }
+                        }
                         proppatch_todb_internal(prop, set, pctx, propstat, NULL, 1);
                     }
                 }

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3702,6 +3702,7 @@ static int do_proppatch(struct proppatch_ctx *pctx, xmlNodePtr instr)
                          entry++);
 
                     if (entry->name) {
+                        prop->ns = pctx->ns[entry->ns];
                         int rights = httpd_myrights(httpd_authstate,
                                                     pctx->txn->req_tgt.mbentry);
                         if (!entry->put) {
@@ -3738,7 +3739,12 @@ static int do_proppatch(struct proppatch_ctx *pctx, xmlNodePtr instr)
                     }
                     else if (pctx->txn->req_tgt.namespace->id != URL_NS_PRINCIPAL) {
                         /* Write "dead" property */
-                        proppatch_todb(prop, set, pctx, propstat, NULL);
+                        for (long unsigned int i = 0; i < sizeof(known_namespaces) / sizeof(struct dav_namespace_t); i++)
+                            if (!strcmp((const char*)prop->ns->href, known_namespaces[i].href)) {
+                                prop->ns = pctx->ns[i];
+                                break;
+                            }
+                        proppatch_todb_internal(prop, set, pctx, propstat, NULL, 1);
                     }
                 }
             }


### PR DESCRIPTION
Prior to this change
```
curl -XPROPPATCH -Hcontent-type:application/xml -uggg@mydomain.org:ggg --data-binary @- <<EOF http://server/dav/calendars/user/ggg@mydomain.org/Default/

<propertyupdate xmlns="DAV:" >
  <set>
   <prop>
     <schedule-calendar-transp xmlns="http://cyrusimap.org/ns/"><transparent/></schedule-calendar-transp>
     <schedule-calendar-transp xmlns="urn:ietf:params:xml:ns:caldav"><transparent/></schedule-calendar-transp>
     <schedule-calendar-transp xmlns="http://apple.com/ns/ical/"><transparent/></schedule-calendar-transp>
   </prop>
  </set>
</propertyupdate>
EOF
```
returned
```xml
<?xml version="1.0" encoding="utf-8"?>
<multistatus xmlns="DAV:" xmlns:X9835="http://cyrusimap.org/ns/" xmlns:X27CD="urn:ietf:params:xml:ns:caldav" xmlns:XB875="http://apple.com/ns/ical/">
  <response>
    <href>/dav/calendars/user/ggg@mydomain.org/Default/</href>
    <propstat>
      <prop>
        <schedule-calendar-transp/>
        <schedule-calendar-transp/>
        <XB875:schedule-calendar-transp/>
      </prop>
      <status>HTTP/1.1 200 OK</status>
    </propstat>
  </response>
</multistatus>
```
With this change the response is:
```xml
<?xml version="1.0" encoding="utf-8"?>
<multistatus xmlns="DAV:" xmlns:X9835="http://cyrusimap.org/ns/" xmlns:X27CD="urn:ietf:params:xml:ns:caldav" xmlns:XB875="http://apple.com/ns/ical/">
  <response>
    <href>/dav/calendars/user/ggg@mydomain.org/Default/</href>
    <propstat>
      <prop>
        <X9835:schedule-calendar-transp/>
        <X27CD:schedule-calendar-transp/>
        <XB875:schedule-calendar-transp/>
      </prop>
      <status>HTTP/1.1 200 OK</status>
    </propstat>
  </response>
</multistatus>
```