### PR TITLE
proppatch_caltransp() - reject more invalid input

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -6306,7 +6306,10 @@ static int proppatch_caltransp(xmlNodePtr prop, unsigned set,
                                struct propstat propstat[],
                                void *rock __attribute__((unused)))
 {
-    if (pctx->txn->req_tgt.collection && !pctx->txn->req_tgt.resource) {
+    const char *explanation = NULL;
+    if (pctx->txn->req_tgt.flags & (TGT_MANAGED_ATTACH | TGT_SCHED_INBOX | TGT_SCHED_OUTBOX))
+        explanation = "Cannot be altered on Attachments, Inbox, or Outbox";
+    else if (pctx->txn->req_tgt.collection && !pctx->txn->req_tgt.resource) {
         const xmlChar *value = NULL;
 
         if (set) {
@@ -6317,34 +6320,36 @@ static int proppatch_caltransp(xmlNodePtr prop, unsigned set,
 
                 /* Make sure it is a value we understand */
                 if (cur->type != XML_ELEMENT_NODE) continue;
-                if ((!xmlStrcmp(cur->name, BAD_CAST "opaque") ||
+                if (!value && (!xmlStrcmp(cur->name, BAD_CAST "opaque") ||
                      !xmlStrcmp(cur->name, BAD_CAST "transparent")) &&
                      !xmlStrcmp(cur->ns->href, BAD_CAST XML_NS_CALDAV)) {
                     value = cur->name;
-                    break;
                 }
                 else {
-                    /* Unknown value */
                     xml_add_prop(HTTP_CONFLICT, pctx->ns[NS_DAV],
                                  &propstat[PROPSTAT_CONFLICT],
                                  prop->name, prop->ns, NULL, 0);
+                    xmlNewTextChild(propstat[PROPSTAT_CONFLICT].root, NULL, BAD_CAST "responsedescription",
+                                    value ? BAD_CAST "More than one values set"
+                                    : BAD_CAST "Not recognized value");
 
-                    *pctx->ret = HTTP_FORBIDDEN;
+                    *pctx->ret = HTTP_CONFLICT;
 
                     return 0;
                 }
             }
         }
-
-        proppatch_todb(prop, set, pctx, propstat, (void *) value);
+        if (value || !set)
+            return proppatch_todb(prop, set, pctx, propstat, (void *) value);
+        explanation = "No value set";
     }
-    else {
-        xml_add_prop(HTTP_FORBIDDEN, pctx->ns[NS_DAV],
-                     &propstat[PROPSTAT_FORBID],
-                     prop->name, prop->ns, NULL, 0);
+    xml_add_prop(HTTP_FORBIDDEN, pctx->ns[NS_DAV], &propstat[PROPSTAT_FORBID],
+                 prop->name, prop->ns, NULL, 0);
+    if (explanation)
+        xmlNewTextChild(propstat[PROPSTAT_FORBID].root, NULL,
+                        BAD_CAST "responsedescription", BAD_CAST explanation);
 
-        *pctx->ret = HTTP_FORBIDDEN;
-    }
+    *pctx->ret = HTTP_FORBIDDEN;
 
     return 0;
 }


### PR DESCRIPTION
This prevents accepting some invalid schedule-calendar-transp changes, like on the Scheduling Outbox, or with not exactly one parameter.  For example this was accepted:
```
curl -XPROPPATCH -Hcontent-type:application/xml -ume:pw --data-binary @- <<EOF http://server/dav/calendars/user/me/Default
<propertyupdate xmlns="DAV:">
  <set>
    <prop>
      <schedule-calendar-transp xmlns="urn:ietf:params:xml:ns:caldav"><transparent/><opaque/></schedule-calendar-transp>
    </prop>
  </set>
</propertyupdate>
EOF
```
