### PR TITLE
Add ALPN support for all IANA registered protocols

### DIFF
--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1254,6 +1254,7 @@ static unsigned h2_is_available(void *http_conn)
 static const struct tls_alpn_t http_alpn_map[] = {
     { "h2",       &h2_is_available, &http_conn },
     { "http/1.1", NULL,             NULL },
+    { "http/1.0", NULL,             NULL },
     { NULL,       NULL,             NULL }
 };
 

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3999,6 +3999,11 @@ static void cmd_post(char *msgid, int mode)
 }
 
 #ifdef HAVE_SSL
+static const struct tls_alpn_t nntp_alpn_map[] = {
+    { "nntp", NULL, NULL },
+    { NULL,   NULL, NULL }
+};
+
 static void cmd_starttls(int nntps)
 {
     int result;
@@ -4014,10 +4019,11 @@ static void cmd_starttls(int nntps)
         return;
     }
 
+    SSL_CTX *ctx = NULL;
     result=tls_init_serverengine("nntp",
                                  5,        /* depth to verify */
                                  !nntps,   /* can client auth? */
-                                 NULL);
+                                 &ctx);
 
     if (result == -1) {
 
@@ -4030,6 +4036,11 @@ static void cmd_starttls(int nntps)
 
         return;
     }
+
+#ifdef HAVE_TLS_ALPN
+    /* enable TLS ALPN extension */
+    SSL_CTX_set_alpn_select_cb(ctx, tls_alpn_select, (void *) nntp_alpn_map);
+#endif
 
     if (nntps == 0)
     {

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -1150,6 +1150,11 @@ void uidl_msg(uint32_t msgno)
 }
 
 #ifdef HAVE_SSL
+static const struct tls_alpn_t pop3_alpn_map[] = {
+    { "pop3", NULL, NULL },
+    { NULL,   NULL, NULL }
+};
+
 static void cmd_starttls(int pop3s)
 {
     int result;
@@ -1162,10 +1167,11 @@ static void cmd_starttls(int pop3s)
         return;
     }
 
+    SSL_CTX *ctx = NULL;
     result=tls_init_serverengine("pop3",
                                  5,        /* depth to verify */
                                  !pop3s,   /* can client auth? */
-                                 NULL);
+                                 &ctx);
 
     if (result == -1) {
 
@@ -1178,6 +1184,11 @@ static void cmd_starttls(int pop3s)
 
         return;
     }
+
+#ifdef HAVE_TLS_ALPN
+    /* enable TLS ALPN extension */
+    SSL_CTX_set_alpn_select_cb(ctx, tls_alpn_select, (void *) pop3_alpn_map);
+#endif
 
     if (pop3s == 0)
     {


### PR DESCRIPTION
Tested with openssl s_client.  Properly fails if the client tries to use an unknown/incorrect ALPN string.  Continues to accept connections that don't use ALPN