### PR TITLE
master: unlink ready file on shutdown

### DIFF
--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -103,6 +103,7 @@ sub default
             configdirectory => '@basedir@/conf',
             syslog_prefix => '@name@',
             sievedir => '@basedir@/conf/sieve',
+            master_ready_file => '@basedir@/master.ready',
             defaultpartition => 'default',
             defaultdomain => 'defdomain',
             'partition-default' => '@basedir@/data',

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -1328,11 +1328,11 @@ sub test_sighup_reloading_proto
         $self->lemming_census());
 }
 
-sub test_ready_file_new
+sub test_ready_file
 {
     my ($self) = @_;
 
-    my $ready_file = $self->{instance}->get_basedir() . '/conf/master.ready';
+    my $ready_file = $self->{instance}->get_basedir() . '/master.ready';
     my $pid_file = $self->{instance}->_pid_file();
 
     # pid file should not already exist
@@ -1351,62 +1351,11 @@ sub test_ready_file_new
     $self->assert_not_null($pid_sb);
 
     # ready file should exist soon...
-    timed_wait(sub { $ready_sb = stat($ready_file) },
-               description => "$ready_file to exist");
+    $ready_sb = stat($ready_file);
     $self->assert_not_null($ready_sb);
 
     # ready file should be newer than pid file
     $self->assert_num_gte($pid_sb->mtime, $ready_sb->mtime);
-}
-
-sub test_ready_file_exists
-{
-    my ($self) = @_;
-
-    # force basedir to be computed
-    $self->{instance}->get_basedir();
-
-    # cannot be under basedir because it'll be blown away at startup
-    my $ready_file = "/tmp/cassandane-$$-master.ready";
-    $self->{instance}->{config}->set('master_ready_file', $ready_file);
-
-    # must be after the get_basedir() call above
-    my $pid_file = $self->{instance}->_pid_file();
-
-    system("touch", $ready_file) == 0 or die "touch $ready_file: $?";
-    sleep 3;
-
-    # pid file should not already exist
-    my $pid_sb = stat($pid_file);
-    $self->assert_null($pid_sb);
-
-    # ready file should already exist
-    my $ready_sb = stat($ready_file);
-    $self->assert_not_null($ready_sb);
-    my $orig_mtime = $ready_sb->mtime;
-
-    # start cyrus
-    $self->start();
-
-    # pid file should exist now
-    $pid_sb = stat($pid_file);
-    $self->assert_not_null($pid_sb);
-
-    # ready file should be touched soon
-    timed_wait(sub {
-                    $ready_sb = stat($ready_file);
-                    return 1 if $ready_sb->mtime >= $pid_sb->mtime;
-                    return undef;
-               },
-               description => "$ready_file to be newer than $pid_file");
-    $self->assert_not_null($ready_sb);
-
-    # ready file should be newer than pid file
-    $self->assert_num_gte($pid_sb->mtime, $ready_sb->mtime);
-    $self->assert_num_gt($orig_mtime, $ready_sb->mtime);
-
-    # don't pollute /tmp
-    unlink $ready_file;
 }
 
 1;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1011,6 +1011,9 @@ sub _start_master
                 },
                 description => $srv->address() . " to be in LISTEN state");
     }
+    timed_wait(sub { -e "$self->{basedir}/master.ready" },
+               description => "master.ready file exists"
+    );
     xlog "_start_master: all services listening";
 }
 
@@ -1691,6 +1694,7 @@ sub stop
     push @errors, $self->_check_valgrind_logs();
     push @errors, $self->_check_cores();
     push @errors, $self->_check_syslog() unless $params{no_check_syslog};
+    push @errors, "master ready file still exists" if -e "$self->{basedir}/master.ready";
 
     # filter out empty errors (shouldn't be any, but just in case)
     @errors = grep { $_ } @errors;

--- a/master/master.c
+++ b/master/master.c
@@ -2898,7 +2898,7 @@ static void master_ready(const char *ready_file, int ready)
 
     if (!ready) {
         /* remove file to say we're no longer ready! */
-        unlink(ready_file);
+        xunlink(ready_file);
         return;
     }
 

--- a/master/master.c
+++ b/master/master.c
@@ -2887,7 +2887,7 @@ static void check_undermanned(struct service *s, int si, int wdi)
     }
 }
 
-static void master_ready(const char *ready_file)
+static void master_ready(const char *ready_file, int ready)
 {
     int fd;
 
@@ -2895,6 +2895,12 @@ static void master_ready(const char *ready_file)
 
     if (!ready_file) ready_file = config_getstring(IMAPOPT_MASTER_READY_FILE);
     if (!ready_file) return;
+
+    if (!ready) {
+        /* remove file to say we're no longer ready! */
+        unlink(ready_file);
+        return;
+    }
 
     if (cyrus_mkdir(ready_file, 0755 /* ignored */)) return;
 
@@ -3236,7 +3242,7 @@ int main(int argc, char **argv)
     }
 
     /* ok, we're going to start spawning like mad now */
-    master_ready(ready_file); /* ready for work */
+    master_ready(ready_file, 1); /* ready for work */
 
     for (;;) {
         int i, maxfd, ready_fds, total_children = 0;
@@ -3465,6 +3471,9 @@ finished:
             }
         }
     }
+
+    /* tell caller we're done */
+    master_ready(ready_file, 0);
 
     /* XXX paranoia: burn through child table, complain if anything there? */
 

--- a/master/master.c
+++ b/master/master.c
@@ -2913,10 +2913,8 @@ static void master_ready(const char *ready_file, int ready)
         xsyslog(LOG_ERR, "unable to create ready file",
                          "fname=<%s>",
                          ready_file);
+        exit(EX_OSERR);
     }
-
-    /* we did our best */
-    errno = 0;
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This means we can wrap a "is shutdown finished" check on the ready file as well