### PR TITLE
fix extra warnings when building with -Wwrite-strings

### DIFF
--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -19,7 +19,7 @@ struct binary_result
     size_t datalen;
 };
 
-static char *backend = CUNIT_PARAM("skiplist,flat,twoskip,zeroskip");
+static const char *backend = CUNIT_PARAM("skiplist,flat,twoskip,zeroskip");
 static char *filename;
 static char *filename2;
 

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -680,11 +680,11 @@ static void test_delete(void)
     CU_ASSERT_EQUAL_FATAL(r, 0);
 
     memset(&mbentry, 0, sizeof(mbentry));
-    mbentry.name = MBOXNAME1_INT;
+    mbentry.name = (char *) MBOXNAME1_INT;
     mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
-    mbentry.partition = PARTITION;
-    mbentry.acl = ACL;
+    mbentry.partition = (char *) PARTITION;
+    mbentry.acl = (char *) ACL;
 
     /* set some values */
 
@@ -2224,11 +2224,11 @@ static int set_up(void)
         return r;
 
     memset(&mbentry, 0, sizeof(mbentry));
-    mbentry.name = MBOXNAME1_INT;
+    mbentry.name = (char *) MBOXNAME1_INT;
     mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
-    mbentry.partition = PARTITION;
-    mbentry.acl = ACL;
+    mbentry.partition = (char *) PARTITION;
+    mbentry.acl = (char *) ACL;
     r = mboxlist_updatelock(&mbentry, /*localonly*/1);
     if (r)
         return r;
@@ -2251,11 +2251,11 @@ static int set_up(void)
         return r;
 
     memset(&mbentry, 0, sizeof(mbentry));
-    mbentry.name = MBOXNAME2_INT;
+    mbentry.name = (char *) MBOXNAME2_INT;
     mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
-    mbentry.partition = PARTITION;
-    mbentry.acl = ACL;
+    mbentry.partition = (char *) PARTITION;
+    mbentry.acl = (char *) ACL;
     r = mboxlist_updatelock(&mbentry, /*localonly*/1);
     if (r)
         return r;
@@ -2278,11 +2278,11 @@ static int set_up(void)
         return r;
 
     memset(&mbentry, 0, sizeof(mbentry));
-    mbentry.name = MBOXNAME3_INT;
+    mbentry.name = (char *) MBOXNAME3_INT;
     mbentry.uniqueid = (char *)mailbox_uniqueid(mailbox);
     mbentry.mbtype = 0;
-    mbentry.partition = PARTITION;
-    mbentry.acl = ACL;
+    mbentry.partition = (char *) PARTITION;
+    mbentry.acl = (char *) ACL;
     r = mboxlist_updatelock(&mbentry, /*localonly*/1);
     if (r)
         return r;

--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -1446,7 +1446,7 @@ static int server_auxprop_init(const sasl_utils_t *utils __attribute__((unused))
     static sasl_auxprop_plug_t plug = {
         .features = 0,
         .auxprop_lookup = server_auxprop_lookup,
-        .name = "testserver-hack"
+        .name = (char *) "testserver-hack"
     };
 
     *out_version = max_version;

--- a/cunit/buf.testc
+++ b/cunit/buf.testc
@@ -1612,8 +1612,8 @@ static void test_appendoverlap(void)
 static void test_tocrlf(void)
 {
     struct testcase {
-        char *input;
-        char *expect;
+        const char *input;
+        const char *expect;
     };
 
     struct testcase testcases[] = {

--- a/cunit/cunit.pl
+++ b/cunit/cunit.pl
@@ -434,7 +434,7 @@ sub suite_found_param
 #
 # Also scan for variable declarations of the form
 #
-# [static] char * foo = CUNIT_PARAM("stringliteral");
+# [static] [const] char * foo = CUNIT_PARAM("stringliteral");
 #
 # and make them a parameter for the containing test suite.
 #
@@ -481,7 +481,7 @@ sub suite_scan_for_tests($)
                 next;
             }
 
-            my ($param) = m/^(?:static\s+)char\s*\*\s*(\w+)\s*=\s*CUNIT_PARAM\s*\(/;
+            my ($param) = m/^(?:static\s+)?(?:const\s+)?char\s*\*\s*(\w+)\s*=\s*CUNIT_PARAM\s*\(/;
             if (defined $param)
             {
                 suite_found_param($suite, $param);

--- a/cunit/cyrunit.h
+++ b/cunit/cyrunit.h
@@ -64,10 +64,13 @@ extern void config_read_string(const char *s);
  * XXX like it currently gets very confused by the layers of macros
  * XXX and produces bogus warnings. :(
  */
-extern CU_BOOL CU_assertFormatImplementation(CU_BOOL bValue, unsigned int uiLine,
-                                             char strFile[], char strFunction[],
+extern CU_BOOL CU_assertFormatImplementation(CU_BOOL bValue,
+                                             unsigned int uiLine,
+                                             const char strFile[],
+                                             const char strFunction[],
                                              CU_BOOL bFatal,
-                                             char strConditionFormat[], ...);
+                                             const char strConditionFormat[],
+                                             ...);
 extern void __cunit_wrap_test(const char *name, void (*fn)(void));
 extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
 
@@ -268,7 +271,7 @@ struct cunit_param
 {
     /* initialisation state */
     const char *name;
-    char **variable;
+    const char **variable;
     /* iteration state */
     int nvalues;
     char **values;

--- a/cunit/mailbox.testc
+++ b/cunit/mailbox.testc
@@ -28,7 +28,7 @@ typedef bit32 XXX_CACHE32_TYPE;
 extern int verbose;
 
 struct offset {
-    char *name;
+    const char *name;
     unsigned pos;
     size_t val;
 };

--- a/cunit/proc.testc
+++ b/cunit/proc.testc
@@ -246,16 +246,19 @@ static int collect_procs_cb(pid_t pid,
 
 static void test_proc_foreach(void)
 {
+#define FIELDS(s, c, u, m, x) \
+    { (char *)(s), (char *)(c), (char *)(u), (char *)(m), (char *)(x) }
+
     struct {
         struct proc_handle *handle;
         struct procdata_fields fields;
     } tests[] = {
-        { NULL, { "sn0", "ch0", "ui0", "mb0", "cm0" } },
-        { NULL, { "sn1", "ch1", "ui1", "mb1", "cm1" } },
-        { NULL, { "sn2", "ch2", "ui2", "mb2", "cm2" } },
-        { NULL, { "sn3", "ch3", "ui3", "mb3", "cm3" } },
-        { NULL, { "sn4", "ch4", "ui4", "mb4", "cm4" } },
-        { NULL, { "sn5", "ch5", "ui5", "mb5", "cm5" } },
+        { NULL, FIELDS("sn0", "ch0", "ui0", "mb0", "cm0") },
+        { NULL, FIELDS("sn1", "ch1", "ui1", "mb1", "cm1") },
+        { NULL, FIELDS("sn2", "ch2", "ui2", "mb2", "cm2") },
+        { NULL, FIELDS("sn3", "ch3", "ui3", "mb3", "cm3") },
+        { NULL, FIELDS("sn4", "ch4", "ui4", "mb4", "cm4") },
+        { NULL, FIELDS("sn5", "ch5", "ui5", "mb5", "cm5") },
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     const pid_t mypid = getpid();

--- a/cunit/procinfo.testc
+++ b/cunit/procinfo.testc
@@ -113,25 +113,25 @@ static void test_sort_procinfo(void)
     pinfo1->vmsize = 1;
     pinfo2->vmsize = 2;
 
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "p") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "s") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "q") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "t") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "v") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "h") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "u") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "r") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "c") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "p") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "s") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "q") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "t") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "v") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "h") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "u") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "r") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "c") > 0));
 
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "P") > 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "S") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "Q") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "T") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "V") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "H") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "U") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "R") < 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "C") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "P") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "S") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "Q") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "T") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "V") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "H") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "U") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "R") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, (void *) "C") < 0));
 
     pinfo3 = piarray.data[2];
     pinfo4 = piarray.data[3];
@@ -143,25 +143,25 @@ static void test_sort_procinfo(void)
     pinfo3->vmsize = 1;
     pinfo4->vmsize = 2;
 
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "p") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "s") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "q") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "t") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "v") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "h") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "u") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "r") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "c") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "p") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "s") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "q") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "t") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "v") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "h") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "u") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "r") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, (void *) "c") == 0));
 
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "P") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "S") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "Q") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "T") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "V") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "H") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "U") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "R") == 0));
-    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "C") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "P") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "S") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "Q") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "T") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "V") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "H") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "U") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "R") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, (void *) "C") == 0));
 
     deinit_piarray(&piarray);
 }

--- a/cunit/procinfo.testc
+++ b/cunit/procinfo.testc
@@ -29,7 +29,7 @@ static void not_test_add_procinfo_generic(void)
     CU_ASSERT_PTR_NOT_NULL(pinfo);
 
     CU_ASSERT_EQUAL(piarray.count, 1);
-    CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
+    CU_ASSERT((piarray.alloc >= piarray.count));
     CU_ASSERT_PTR_NOT_NULL(piarray.data);
 
     CU_ASSERT_EQUAL(pinfo->pid, 2342);
@@ -55,7 +55,7 @@ static void test_add_procinfo(void)
     CU_ASSERT_EQUAL(res, 0);
 
     CU_ASSERT_EQUAL(piarray.count, 1);
-    CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
+    CU_ASSERT((piarray.alloc >= piarray.count));
     CU_ASSERT_PTR_NOT_NULL(piarray.data);
 
     pinfo = piarray.data[0];
@@ -69,8 +69,8 @@ static void test_add_procinfo(void)
     CU_ASSERT_STRING_EQUAL(pinfo->cmdname, "command");
     CU_ASSERT_STRING_NOT_EQUAL(pinfo->state, "");
     CU_ASSERT_NOT_EQUAL(pinfo->start, 0);
-    CU_ASSERT_TRUE((pinfo->start <= time(NULL)));
-    CU_ASSERT_TRUE((pinfo->vmsize > 0));
+    CU_ASSERT((pinfo->start <= time(NULL)));
+    CU_ASSERT((pinfo->vmsize > 0));
 
     deinit_piarray(&piarray);
 }
@@ -113,25 +113,25 @@ static void test_sort_procinfo(void)
     pinfo1->vmsize = 1;
     pinfo2->vmsize = 2;
 
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "p") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "s") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "q") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "t") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "v") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "h") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "u") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "r") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "c") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "p") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "s") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "q") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "t") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "v") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "h") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "u") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "r") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "c") > 0));
 
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "P") > 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "S") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "Q") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "T") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "V") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "H") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "U") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "R") < 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "C") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "P") > 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "S") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "Q") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "T") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "V") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "H") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "U") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "R") < 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "C") < 0));
 
     pinfo3 = piarray.data[2];
     pinfo4 = piarray.data[3];
@@ -143,25 +143,25 @@ static void test_sort_procinfo(void)
     pinfo3->vmsize = 1;
     pinfo4->vmsize = 2;
 
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "p") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "s") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "q") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "t") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "v") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "h") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "u") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "r") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "c") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "p") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "s") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "q") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "t") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "v") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "h") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "u") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "r") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "c") == 0));
 
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "P") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "S") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "Q") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "T") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "V") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "H") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "U") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "R") == 0));
-    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "C") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "P") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "S") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "Q") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "T") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "V") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "H") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "U") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "R") == 0));
+    CU_ASSERT((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "C") == 0));
 
     deinit_piarray(&piarray);
 }

--- a/cunit/procinfo.testc
+++ b/cunit/procinfo.testc
@@ -6,162 +6,162 @@
 
 static void test_init_piarray(void)
 {
-	piarray_t piarray;
+    piarray_t piarray;
 
-	init_piarray(&piarray);
+    init_piarray(&piarray);
 
-	CU_ASSERT_EQUAL(piarray.count, 0);
-	CU_ASSERT_EQUAL(piarray.alloc, 0);
-	CU_ASSERT_PTR_NULL(piarray.data);
+    CU_ASSERT_EQUAL(piarray.count, 0);
+    CU_ASSERT_EQUAL(piarray.alloc, 0);
+    CU_ASSERT_PTR_NULL(piarray.data);
 }
 
 #if 0
 static void not_test_add_procinfo_generic(void)
 {
-	piarray_t piarray;
-	struct proc_info *pinfo;
+    piarray_t piarray;
+    struct proc_info *pinfo;
 
-	init_piarray(&piarray);
+    init_piarray(&piarray);
 
-	pinfo = add_procinfo_generic(&piarray, 2342, "service", "host",
-	                             "user", "mailbox", "command");
+    pinfo = add_procinfo_generic(&piarray, 2342, "service", "host",
+                                 "user", "mailbox", "command");
 
-	CU_ASSERT_PTR_NOT_NULL(pinfo);
+    CU_ASSERT_PTR_NOT_NULL(pinfo);
 
-	CU_ASSERT_EQUAL(piarray.count, 1);
-	CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
-	CU_ASSERT_PTR_NOT_NULL(piarray.data);
+    CU_ASSERT_EQUAL(piarray.count, 1);
+    CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
+    CU_ASSERT_PTR_NOT_NULL(piarray.data);
 
-	CU_ASSERT_EQUAL(pinfo->pid, 2342);
-	CU_ASSERT_STRING_EQUAL(pinfo->servicename, "service");
-	CU_ASSERT_STRING_EQUAL(pinfo->user, "user");
-	CU_ASSERT_STRING_EQUAL(pinfo->host, "host");
-	CU_ASSERT_STRING_EQUAL(pinfo->mailbox, "mailbox");
-	CU_ASSERT_STRING_EQUAL(pinfo->cmdname, "command");
+    CU_ASSERT_EQUAL(pinfo->pid, 2342);
+    CU_ASSERT_STRING_EQUAL(pinfo->servicename, "service");
+    CU_ASSERT_STRING_EQUAL(pinfo->user, "user");
+    CU_ASSERT_STRING_EQUAL(pinfo->host, "host");
+    CU_ASSERT_STRING_EQUAL(pinfo->mailbox, "mailbox");
+    CU_ASSERT_STRING_EQUAL(pinfo->cmdname, "command");
 }
 #endif
 
 static void test_add_procinfo(void)
 {
-	piarray_t piarray;
-	struct proc_info *pinfo;
-	int res;
+    piarray_t piarray;
+    struct proc_info *pinfo;
+    int res;
 
-	init_piarray(&piarray);
+    init_piarray(&piarray);
 
-	res = add_procinfo(getpid(), "service", "host", "user",
-	                   "mailbox", "command", &piarray);
+    res = add_procinfo(getpid(), "service", "host", "user",
+                       "mailbox", "command", &piarray);
 
-	CU_ASSERT_EQUAL(res, 0);
+    CU_ASSERT_EQUAL(res, 0);
 
-	CU_ASSERT_EQUAL(piarray.count, 1);
-	CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
-	CU_ASSERT_PTR_NOT_NULL(piarray.data);
+    CU_ASSERT_EQUAL(piarray.count, 1);
+    CU_ASSERT_TRUE((piarray.alloc >= piarray.count));
+    CU_ASSERT_PTR_NOT_NULL(piarray.data);
 
-	pinfo = piarray.data[0];
+    pinfo = piarray.data[0];
 
-	CU_ASSERT_PTR_NOT_NULL(pinfo);
-	CU_ASSERT_EQUAL(pinfo->pid, getpid());
-	CU_ASSERT_STRING_EQUAL(pinfo->servicename, "service");
-	CU_ASSERT_STRING_EQUAL(pinfo->user, "user");
-	CU_ASSERT_STRING_EQUAL(pinfo->host, "host");
-	CU_ASSERT_STRING_EQUAL(pinfo->mailbox, "mailbox");
-	CU_ASSERT_STRING_EQUAL(pinfo->cmdname, "command");
-	CU_ASSERT_STRING_NOT_EQUAL(pinfo->state, "");
-	CU_ASSERT_NOT_EQUAL(pinfo->start, 0);
-	CU_ASSERT_TRUE((pinfo->start <= time(NULL)));
-	CU_ASSERT_TRUE((pinfo->vmsize > 0));
+    CU_ASSERT_PTR_NOT_NULL(pinfo);
+    CU_ASSERT_EQUAL(pinfo->pid, getpid());
+    CU_ASSERT_STRING_EQUAL(pinfo->servicename, "service");
+    CU_ASSERT_STRING_EQUAL(pinfo->user, "user");
+    CU_ASSERT_STRING_EQUAL(pinfo->host, "host");
+    CU_ASSERT_STRING_EQUAL(pinfo->mailbox, "mailbox");
+    CU_ASSERT_STRING_EQUAL(pinfo->cmdname, "command");
+    CU_ASSERT_STRING_NOT_EQUAL(pinfo->state, "");
+    CU_ASSERT_NOT_EQUAL(pinfo->start, 0);
+    CU_ASSERT_TRUE((pinfo->start <= time(NULL)));
+    CU_ASSERT_TRUE((pinfo->vmsize > 0));
 
     deinit_piarray(&piarray);
 }
 
 static void test_sort_procinfo(void)
 {
-	piarray_t piarray;
-	struct proc_info *pinfo1, *pinfo2, *pinfo3, *pinfo4;
-	int res;
+    piarray_t piarray;
+    struct proc_info *pinfo1, *pinfo2, *pinfo3, *pinfo4;
+    int res;
 
-	init_piarray(&piarray);
+    init_piarray(&piarray);
 
-	res = add_procinfo(getpid(), "service1", "host1", "user1",
-	                   "mailbox1", "command1", &piarray);
-	CU_ASSERT_EQUAL(res, 0);
-	CU_ASSERT_EQUAL(piarray.count, 1);
+    res = add_procinfo(getpid(), "service1", "host1", "user1",
+                       "mailbox1", "command1", &piarray);
+    CU_ASSERT_EQUAL(res, 0);
+    CU_ASSERT_EQUAL(piarray.count, 1);
 
-	res = add_procinfo(1, "service2", "host2", "user2",
-	                   "mailbox2", "command2", &piarray);
-	CU_ASSERT_EQUAL(res, 0);
-	CU_ASSERT_EQUAL(piarray.count, 2);
+    res = add_procinfo(1, "service2", "host2", "user2",
+                       "mailbox2", "command2", &piarray);
+    CU_ASSERT_EQUAL(res, 0);
+    CU_ASSERT_EQUAL(piarray.count, 2);
 
-	res = add_procinfo(getpid(), "service1", "host1", "user1",
-	                   "mailbox1", "command1", &piarray);
-	CU_ASSERT_EQUAL(res, 0);
-	CU_ASSERT_EQUAL(piarray.count, 3);
+    res = add_procinfo(getpid(), "service1", "host1", "user1",
+                       "mailbox1", "command1", &piarray);
+    CU_ASSERT_EQUAL(res, 0);
+    CU_ASSERT_EQUAL(piarray.count, 3);
 
-	res = add_procinfo(1, "service2", "host2", "user2",
-	                   "mailbox2", "command2", &piarray);
-	CU_ASSERT_EQUAL(res, 0);
-	CU_ASSERT_EQUAL(piarray.count, 4);
+    res = add_procinfo(1, "service2", "host2", "user2",
+                       "mailbox2", "command2", &piarray);
+    CU_ASSERT_EQUAL(res, 0);
+    CU_ASSERT_EQUAL(piarray.count, 4);
 
-	pinfo1 = piarray.data[0];
-	pinfo2 = piarray.data[1];
+    pinfo1 = piarray.data[0];
+    pinfo2 = piarray.data[1];
 
-	snprintf(pinfo1->state, sizeof(pinfo1->state), "%s", "running1");
-	snprintf(pinfo2->state, sizeof(pinfo2->state), "%s", "running2");
-	pinfo1->start = 1;
-	pinfo2->start = 2;
-	pinfo1->vmsize = 1;
-	pinfo2->vmsize = 2;
+    snprintf(pinfo1->state, sizeof(pinfo1->state), "%s", "running1");
+    snprintf(pinfo2->state, sizeof(pinfo2->state), "%s", "running2");
+    pinfo1->start = 1;
+    pinfo2->start = 2;
+    pinfo1->vmsize = 1;
+    pinfo2->vmsize = 2;
 
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "p") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "s") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "q") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "t") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "v") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "h") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "u") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "r") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "c") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "p") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "s") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "q") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "t") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "v") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "h") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "u") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "r") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "c") > 0));
 
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "P") > 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "S") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "Q") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "T") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "V") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "H") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "U") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "R") < 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "C") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "P") > 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "S") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "Q") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "T") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "V") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "H") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "U") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "R") < 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo2, "C") < 0));
 
-	pinfo3 = piarray.data[2];
-	pinfo4 = piarray.data[3];
+    pinfo3 = piarray.data[2];
+    pinfo4 = piarray.data[3];
 
-	snprintf(pinfo3->state, sizeof(pinfo3->state), "%s", "running1");
-	snprintf(pinfo4->state, sizeof(pinfo4->state), "%s", "running2");
-	pinfo3->start = 1;
-	pinfo4->start = 2;
-	pinfo3->vmsize = 1;
-	pinfo4->vmsize = 2;
+    snprintf(pinfo3->state, sizeof(pinfo3->state), "%s", "running1");
+    snprintf(pinfo4->state, sizeof(pinfo4->state), "%s", "running2");
+    pinfo3->start = 1;
+    pinfo4->start = 2;
+    pinfo3->vmsize = 1;
+    pinfo4->vmsize = 2;
 
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "p") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "s") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "q") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "t") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "v") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "h") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "u") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "r") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "c") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "p") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "s") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "q") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "t") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "v") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "h") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "u") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "r") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo1, &pinfo3, "c") == 0));
 
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "P") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "S") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "Q") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "T") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "V") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "H") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "U") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "R") == 0));
-	CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "C") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "P") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "S") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "Q") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "T") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "V") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "H") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "U") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "R") == 0));
+    CU_ASSERT_TRUE((sort_procinfo QSORT_R_COMPAR_ARGS(&pinfo2, &pinfo4, "C") == 0));
 
     deinit_piarray(&piarray);
 }

--- a/cunit/quota.testc
+++ b/cunit/quota.testc
@@ -16,7 +16,7 @@
 #define QUOTAROOT               "user.smurf"
 #define QUOTAROOT_NONEXISTENT   "no-such-quotaroot"
 
-static char *backend = CUNIT_PARAM("quotalegacy,skiplist");
+static const char *backend = CUNIT_PARAM("quotalegacy,skiplist");
 
 static void test_names(void)
 {

--- a/cunit/quota.testc
+++ b/cunit/quota.testc
@@ -59,7 +59,7 @@ static void test_read_no_root(void)
     r = quota_read(&q, NULL, 0);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
 
-    q.root = "";
+    q.root = (char *) "";
     r = quota_read(&q, NULL, 0);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
 
@@ -69,12 +69,12 @@ static void test_read_no_root(void)
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
     CU_ASSERT_PTR_NULL(txn);
 
-    q.root = "";
+    q.root = (char *) "";
     r = quota_read(&q, &txn, 1);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
     CU_ASSERT_PTR_NULL(txn);
 
-    q.root = QUOTAROOT_NONEXISTENT;
+    q.root = (char *) QUOTAROOT_NONEXISTENT;
     r = quota_read(&q, NULL, 0);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
 }
@@ -89,7 +89,7 @@ static void test_write_no_root(void)
     r = quota_write(&q, 0, NULL);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
 
-    q.root = "";
+    q.root = (char *) "";
     r = quota_write(&q, 0, NULL);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
 
@@ -99,7 +99,7 @@ static void test_write_no_root(void)
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
     CU_ASSERT_PTR_NULL(txn);
 
-    q.root = "";
+    q.root = (char *) "";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
     CU_ASSERT_PTR_NULL(txn);
@@ -116,7 +116,7 @@ static void test_read_write(void)
     int r;
 
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
 
     r = quota_read(&q, &txn, 1);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
@@ -138,7 +138,7 @@ static void test_read_write(void)
 
     /* reading in the same txn gets the new values */
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, &txn, 0);
     CU_ASSERT_EQUAL(r, 0);
     for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
@@ -152,7 +152,7 @@ static void test_read_write(void)
 
     /* reading in a new txn gets the new values */
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, &txn, 0);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_PTR_NOT_NULL(txn);
@@ -174,7 +174,7 @@ static void test_abort(void)
     int r;
 
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
 
     r = quota_read(&q, &txn, 1);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
@@ -192,7 +192,7 @@ static void test_abort(void)
 
     /* reading in the same txn gets the new values */
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, &txn, 0);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_EQUAL(q2.useds[QUOTA_STORAGE], q.useds[QUOTA_STORAGE]);
@@ -204,7 +204,7 @@ static void test_abort(void)
 
     /* reading in a new txn gets no result */
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, &txn, 0);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
     CU_ASSERT_PTR_NOT_NULL(txn);
@@ -222,7 +222,7 @@ static void test_abort2(void)
     int r;
 
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
 
     r = quota_read(&q, &txn, 1);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
@@ -249,7 +249,7 @@ static void test_abort2(void)
 
     /* reading in the same txn gets the new values */
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, &txn, 0);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_EQUAL(q2.useds[QUOTA_STORAGE], q.useds[QUOTA_STORAGE]);
@@ -261,7 +261,7 @@ static void test_abort2(void)
 
     /* reading in a new txn gets old values */
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, &txn, 0);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_PTR_NOT_NULL(txn);
@@ -279,7 +279,7 @@ static void test_check_use(void)
     int r;
 
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     q.limits[QUOTA_STORAGE] = 100;
 
     for (i = 1 ; i <= 63 ; i++)
@@ -310,7 +310,7 @@ static void test_check_use(void)
 
     /* test the zero limit */
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     q.limits[QUOTA_STORAGE] = 0;
 
     r = quota_check(&q, QUOTA_STORAGE, 15*1024);
@@ -323,7 +323,7 @@ static void test_check_use(void)
 
     /* test the special limit QUOTA_UNLIMITED */
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     q.limits[QUOTA_STORAGE] = QUOTA_UNLIMITED;
 
     for (i = 1 ; i <= 63 ; i++)
@@ -336,7 +336,7 @@ static void test_check_use(void)
 
     /* test negative diffs in quota_check */
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     q.useds[QUOTA_STORAGE] = 80*1024;   /* used 80 KiB */
     q.limits[QUOTA_STORAGE] = 100;      /* limit 100 KiB */
 
@@ -358,7 +358,7 @@ static void test_check_use(void)
 
     /* test negative diffs in quota_use */
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     q.useds[QUOTA_STORAGE] = 80*1024;   /* used 80 KiB */
     q.limits[QUOTA_STORAGE] = 100;      /* limit 100 KiB */
 
@@ -386,7 +386,7 @@ static void test_check_overquota(void)
     struct quota q;
 
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     q.limits[QUOTA_STORAGE] = 100;
     q.limits[QUOTA_MESSAGE] = 2;
 
@@ -425,7 +425,7 @@ static void test_update_useds(void)
     int r;
 
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     memset(quota_diff, 0, sizeof(quota_diff));
 
     /* updating a NULL or empty or non-existant root returns the error */
@@ -457,7 +457,7 @@ static void test_update_useds(void)
     r = quota_update_useds(QUOTAROOT, diff, NULL, 0); \
     CU_ASSERT_EQUAL(r, 0); \
     memset(&q2, 0, sizeof(q2)); \
-    q2.root = QUOTAROOT; \
+    q2.root = (char *) QUOTAROOT; \
     r = quota_read(&q2, NULL, 0); \
     CU_ASSERT_EQUAL(r, 0); \
     for (res = 0; res < QUOTA_NUMRESOURCES; res++) { \
@@ -525,7 +525,7 @@ static void test_delete(void)
 
     /* add a record to the db and check it's there */
     memset(&q, 0, sizeof(q));
-    q.root = QUOTAROOT;
+    q.root = (char *) QUOTAROOT;
     q.useds[QUOTA_STORAGE] = 12345;
     q.limits[QUOTA_STORAGE] = 678;
 
@@ -537,7 +537,7 @@ static void test_delete(void)
     CU_ASSERT_PTR_NULL(txn);
 
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, NULL, 0);
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_EQUAL(q2.useds[QUOTA_STORAGE], q.useds[QUOTA_STORAGE]);
@@ -558,7 +558,7 @@ static void test_delete(void)
 
     /* record should now be gone */
     memset(&q2, 0, sizeof(q2));
-    q2.root = QUOTAROOT;
+    q2.root = (char *) QUOTAROOT;
     r = quota_read(&q2, NULL, 0);
     CU_ASSERT_EQUAL(r, IMAP_QUOTAROOT_NONEXISTENT);
 }
@@ -781,11 +781,11 @@ static void test_findroot(void)
     TESTCASE("user.farnarkle", NULL);
 
     /* add some db entries, but not the "user." */
-    q.root = "user.foo";
+    q.root = (char *) "user.foo";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, 0);
 
-    q.root = "user.smeg";
+    q.root = (char *) "user.smeg";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, 0);
 
@@ -813,7 +813,7 @@ static void test_findroot(void)
     TESTCASE("user.farnarkle", NULL);
 
     /* add a catch-all "user" record */
-    q.root = "user";
+    q.root = (char *) "user";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, 0);
 
@@ -878,11 +878,11 @@ static void test_findroot_virtdomains(void)
 
     /* add some db entries for bloggs.com, but not fnarp.org,
      * not the default domain, and not the "user." */
-    q.root = "bloggs.com!user.foo";
+    q.root = (char *) "bloggs.com!user.foo";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, 0);
 
-    q.root = "bloggs.com!user.smeg";
+    q.root = (char *) "bloggs.com!user.smeg";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, 0);
 
@@ -922,7 +922,7 @@ static void test_findroot_virtdomains(void)
     TESTCASE("user.farnarkle", NULL);
 
     /* add a catch-all "bloggs.com" record */
-    q.root = "bloggs.com!";
+    q.root = (char *) "bloggs.com!";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, 0);
 
@@ -961,7 +961,7 @@ static void test_findroot_virtdomains(void)
     TESTCASE("user.farnarkle", NULL);
 
     /* add a catch-all "fnarp.org!user" record */
-    q.root = "fnarp.org!user";
+    q.root = (char *) "fnarp.org!user";
     r = quota_write(&q, 0, &txn);
     CU_ASSERT_EQUAL(r, 0);
 

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -283,10 +283,10 @@ void __cunit_params_end(void)
 CU_BOOL CU_assertFormatImplementation(
     CU_BOOL bValue,
     unsigned int uiLine,
-    char strFile[],
-    char strFunction[],
+    const char strFile[],
+    const char strFunction[],
     CU_BOOL bFatal,
-    char strConditionFormat[],
+    const char strConditionFormat[],
     ...)
 {
     va_list args;

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -107,7 +107,7 @@ enum SieveFileType {
 };
 static struct sieve_scripts_info {
     enum SieveFileType stype;
-    char *ext;
+    const char *ext;
 } sieve_names[] = {
     {SIEVE_TMP_1, ".script.NEW"},
     {SIEVE_TMP_2, ".NEW"},

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -293,7 +293,7 @@ int main(int argc, char *argv[])
     enum { RECOVER, CHECKPOINT, NONE } op = NONE;
     char *dirname = NULL, *backup1 = NULL, *backup2 = NULL;
     strarray_t files = STRARRAY_INITIALIZER;
-    char *msg = "";
+    const char *msg = "";
     int i, rotated = 0;
 
     /* keep this in alphabetical order */

--- a/imap/cyr_dbtool.c
+++ b/imap/cyr_dbtool.c
@@ -115,13 +115,13 @@ static int printer_cb(void *rock __attribute__((unused)),
     const char *data, size_t datalen)
 {
     struct iovec io[4];
-    io[0].iov_base = (char *)key;
+    io[0].iov_base = (char *) key;
     io[0].iov_len = keylen;
-    io[1].iov_base = "\t";
+    io[1].iov_base = (char *) "\t";
     io[1].iov_len = 1;
-    io[2].iov_base = (char *)data;
+    io[2].iov_base = (char *) data;
     io[2].iov_len = datalen;
-    io[3].iov_base = "\n";
+    io[3].iov_base = (char *) "\n";
     io[3].iov_len = 1;
     retry_writev(outfd, io, 4);
     return 0;

--- a/imap/fetchnews.c
+++ b/imap/fetchnews.c
@@ -125,7 +125,7 @@ static void usage(void)
     exit(-1);
 }
 
-int init_net(const char *host, char *port,
+int init_net(const char *host, const char *port,
              struct protstream **in, struct protstream **out)
 {
     int sock = -1;
@@ -246,7 +246,7 @@ static int fetch(char *msgid, int bymsgid,
 int main(int argc, char *argv[])
 {
     int opt;
-    char *alt_config = NULL, *port = "119";
+    const char *alt_config = NULL, *port = "119";
     const char *peer = NULL, *server = "localhost", *wildmat = "*";
     char *authname = NULL, *password = NULL;
     int psock = -1, ssock = -1;
@@ -277,6 +277,8 @@ int main(int argc, char *argv[])
     while (-1 != (opt = getopt_long(argc, argv,
                                     short_options, long_options, NULL)))
     {
+        char *colon;
+
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
@@ -284,8 +286,10 @@ int main(int argc, char *argv[])
 
         case 's': /* server */
             server = xstrdup(optarg);
-            if ((port = strchr(server, ':')))
-                *port++ = '\0';
+            if ((colon = strchr(server, ':'))) {
+                *colon = '\0';
+                port = colon + 1;
+            }
             else
                 port = "119";
             break;

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -367,13 +367,13 @@ static const struct prop_entry caldav_props[] = {
       propfind_collectionname, proppatch_todb, NULL },
     { "getcontentlanguage", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
-      propfind_fromhdr, NULL, "Content-Language" },
+      propfind_fromhdr, NULL, (void *) "Content-Language" },
     { "getcontentlength", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getlength, NULL, NULL },
     { "getcontenttype", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
-      propfind_getcontenttype, NULL, "Content-Type" },
+      propfind_getcontenttype, NULL, (void *) "Content-Type" },
     { "getetag", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getetag, NULL, NULL },
@@ -385,7 +385,7 @@ static const struct prop_entry caldav_props[] = {
       propfind_lockdisc, NULL, NULL },
     { "resourcetype", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE | PROP_PRESCREEN,
-      propfind_restype, proppatch_restype, "calendar" },
+      propfind_restype, proppatch_restype, (void *) "calendar" },
     { "supportedlock", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
       propfind_suplock, NULL, NULL },
@@ -444,7 +444,7 @@ static const struct prop_entry caldav_props[] = {
     /* WebDAV Sync (RFC 6578) properties */
     { "sync-token", NS_DAV,
       PROP_COLLECTION,
-      propfind_sync_token, NULL, SYNC_TOKEN_URL_SCHEME },
+      propfind_sync_token, NULL, (void *) SYNC_TOKEN_URL_SCHEME },
 
     /* WebDAV Sharing (draft-pot-webdav-resource-sharing) properties */
     { "share-access", NS_DAV,
@@ -460,13 +460,13 @@ static const struct prop_entry caldav_props[] = {
     /* Backwards compatibility with Apple calendar sharing clients */
     { "invite", NS_CS,
       PROP_COLLECTION,
-      propfind_invite, NULL, "calendarserver-sharing" },
+      propfind_invite, NULL, (void *) "calendarserver-sharing" },
     { "allowed-sharing-modes", NS_CS,
       PROP_COLLECTION,
       propfind_sharingmodes, NULL, NULL },
     { "shared-url", NS_CS,
       PROP_COLLECTION,
-      propfind_sharedurl, NULL, "calendarserver-sharing" },
+      propfind_sharedurl, NULL, (void *) "calendarserver-sharing" },
 
     /* CalDAV (RFC 4791) properties */
     { "calendar-data", NS_CALDAV,
@@ -550,7 +550,7 @@ static const struct prop_entry caldav_props[] = {
     /* Apple Calendar Server properties */
     { "getctag", NS_CS,
       PROP_ALLPROP | PROP_COLLECTION,
-      propfind_sync_token, NULL, "" },
+      propfind_sync_token, NULL, (void *) "" },
 
     /* Apple Mobile Me properties */
     { "bulk-requests", NS_MECOM,
@@ -5807,7 +5807,7 @@ static int propfind_scheddefault(const xmlChar *name, xmlNsPtr ns,
     if (fctx->req_tgt->flags != TGT_SCHED_INBOX) return HTTP_NOT_FOUND;
 
     return propfind_calurl(name, ns, fctx,
-                           prop, resp, propstat, SCHED_DEFAULT);
+                           prop, resp, propstat, (void  *) SCHED_DEFAULT);
 }
 
 

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -451,17 +451,19 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
             buf_printf(&plainbuf, "RSVP       : %s\r\n", originator->partstat);
     }
     else {
+        const char *prefix;
+
         if (status) buf_printf(&plainbuf, "Status     : %s\r\n", status);
 
-        for (cp = "Attendees  : ", recip=recipients; recip; recip=recip->next) {
+        for (prefix = "Attendees  : ", recip=recipients; recip; recip=recip->next) {
             if (recip->name && strcasecmp(recip->name, recip->addr))
-                buf_printf(&plainbuf, "%s* %s <%s>", cp, recip->name, recip->addr);
+                buf_printf(&plainbuf, "%s* %s <%s>", prefix, recip->name, recip->addr);
             else
-                buf_printf(&plainbuf, "%s* %s", cp, recip->addr);
+                buf_printf(&plainbuf, "%s* %s", prefix, recip->addr);
             if (recip->role) buf_printf(&plainbuf, "\t(%s)", recip->role);
             buf_appendcstr(&plainbuf, "\r\n");
 
-            cp = TEXT_INDENT;
+            prefix = TEXT_INDENT;
         }
 
         if (descrip) {
@@ -524,10 +526,12 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
             buf_printf(&msgbuf, HTML_ROW, "RSVP", originator->partstat);
     }
     else {
+        const char *prefix;
+
         if (status) buf_printf(&msgbuf, HTML_ROW, "Status", status);
 
         buf_appendcstr(&msgbuf, "<tr><td><b>Attendees</b></td>");
-        for (cp = "<td>", recip = recipients; recip; recip = recip->next) {
+        for (prefix = "<td>", recip = recipients; recip; recip = recip->next) {
             if (recip->name) {
                 HTMLencode(&tmpbuf, recip->name);
                 recip->name = buf_cstring(&tmpbuf);
@@ -535,10 +539,10 @@ static int imip_send_sendmail(const char *userid, icalcomponent *ical, const cha
             else recip->name = recip->addr;
 
             buf_printf(&msgbuf, "%s&#8226; <a href=\"mailto:%s\">%s</a>",
-                    cp, recip->addr, recip->name);
+                       prefix, recip->addr, recip->name);
             if (recip->role) buf_printf(&msgbuf, " <i>(%s)</i>", recip->role);
 
-            cp = "\r\n  <br>";
+            prefix = "\r\n  <br>";
         }
         buf_appendcstr(&msgbuf, "</td></tr>\r\n");
 

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -229,13 +229,13 @@ static const struct prop_entry carddav_props[] = {
       propfind_collectionname, proppatch_todb, NULL },
     { "getcontentlanguage", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
-      propfind_fromhdr, NULL, "Content-Language" },
+      propfind_fromhdr, NULL, (void *) "Content-Language" },
     { "getcontentlength", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getlength, NULL, NULL },
     { "getcontenttype", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
-      propfind_getcontenttype, NULL, "Content-Type" },
+      propfind_getcontenttype, NULL, (void *) "Content-Type" },
     { "getetag", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getetag, NULL, NULL },
@@ -247,7 +247,7 @@ static const struct prop_entry carddav_props[] = {
       propfind_lockdisc, NULL, NULL },
     { "resourcetype", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE | PROP_PRESCREEN,
-      propfind_restype, proppatch_restype, "addressbook" },
+      propfind_restype, proppatch_restype, (void *) "addressbook" },
     { "supportedlock", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
       propfind_suplock, NULL, NULL },
@@ -307,7 +307,7 @@ static const struct prop_entry carddav_props[] = {
     /* WebDAV Sync (RFC 6578) properties */
     { "sync-token", NS_DAV,
       PROP_COLLECTION,
-      propfind_sync_token, NULL, SYNC_TOKEN_URL_SCHEME },
+      propfind_sync_token, NULL, (void *) SYNC_TOKEN_URL_SCHEME },
 
     /* WebDAV Sharing (draft-pot-webdav-resource-sharing) properties */
     { "share-access", NS_DAV,
@@ -340,7 +340,7 @@ static const struct prop_entry carddav_props[] = {
     /* Apple Calendar Server properties */
     { "getctag", NS_CS,
       PROP_ALLPROP | PROP_COLLECTION,
-      propfind_sync_token, NULL, "" },
+      propfind_sync_token, NULL, (void *) "" },
 
     /* Apple Push Notifications Service properties */
     { "push-transports", NS_CS,

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -261,10 +261,10 @@ static const struct prop_entry principal_props[] = {
     /* CalDAV Scheduling (RFC 6638) properties */
     { "schedule-inbox-URL", NS_CALDAV,
       PROP_COLLECTION,
-      propfind_calurl, NULL, SCHED_INBOX },
+      propfind_calurl, NULL, (void *) SCHED_INBOX },
     { "schedule-outbox-URL", NS_CALDAV,
       PROP_COLLECTION,
-      propfind_calurl, NULL, SCHED_OUTBOX },
+      propfind_calurl, NULL, (void *) SCHED_OUTBOX },
     { "calendar-user-address-set", NS_CALDAV,
       PROP_COLLECTION,
       propfind_caluseraddr, proppatch_caluseraddr, NULL },

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -159,13 +159,13 @@ static const struct prop_entry notify_props[] = {
       propfind_fromdb, proppatch_todb, NULL },
     { "getcontentlanguage", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
-      propfind_fromhdr, NULL, "Content-Language" },
+      propfind_fromhdr, NULL, (void *) "Content-Language" },
     { "getcontentlength", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getlength, NULL, NULL },
     { "getcontenttype", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
-      propfind_fromhdr, NULL, "Content-Type" },
+      propfind_fromhdr, NULL, (void *) "Content-Type" },
     { "getetag", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getetag, NULL, NULL },
@@ -218,7 +218,7 @@ static const struct prop_entry notify_props[] = {
     /* WebDAV Sync (RFC 6578) properties */
     { "sync-token", NS_DAV,
       PROP_COLLECTION,
-      propfind_sync_token, NULL, SYNC_TOKEN_URL_SCHEME },
+      propfind_sync_token, NULL, (void *) SYNC_TOKEN_URL_SCHEME },
 
     /* WebDAV Notifications (draft-pot-webdav-notifications) properties */
     { "notificationtype", NS_DAV,
@@ -228,12 +228,12 @@ static const struct prop_entry notify_props[] = {
     /* Backwards compatibility with Apple notifications clients */
     { "notificationtype", NS_CS,
       PROP_RESOURCE,
-      propfind_notifytype, NULL, "calendarserver-sharing" },
+      propfind_notifytype, NULL, (void *) "calendarserver-sharing" },
 
     /* Apple Calendar Server properties */
     { "getctag", NS_CS,
       PROP_ALLPROP | PROP_COLLECTION,
-      propfind_sync_token, NULL, "" },
+      propfind_sync_token, NULL, (void *) "" },
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -1126,7 +1126,7 @@ static void display_part(struct transaction_t *txn,
         /* message/rfc822 */
         struct body *subpart = body->subpart;
         struct address *addr;
-        char *sep;
+        const char *sep;
 
         /* Display enclosed message header as a shaded table */
         buf_printf_markup(buf, level++,

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -1304,7 +1304,7 @@ static void display_message(struct transaction_t *txn,
                             const char *mboxname, const struct index_record *record,
                             struct body *body, const struct buf *msg_buf)
 {
-    struct body toplevel;
+    struct body toplevel = {0};
     struct buf *buf = &txn->resp_body.payload;
     unsigned level = 0;
 
@@ -1341,9 +1341,8 @@ static void display_message(struct transaction_t *txn,
     buf_reset(buf);
 
     /* Encapsulate our body in a message/rfc822 to display toplevel hdrs */
-    memset(&toplevel, 0, sizeof(struct body));
-    toplevel.type = "MESSAGE";
-    toplevel.subtype = "RFC822";
+    toplevel.type = (char *) "MESSAGE";
+    toplevel.subtype = (char *) "RFC822";
     toplevel.subpart = body;
 
     display_part(txn, &toplevel, record, "", msg_buf, level);

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -138,13 +138,13 @@ static const struct prop_entry webdav_props[] = {
       propfind_collectionname, proppatch_todb, NULL },
     { "getcontentlanguage", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
-      propfind_fromhdr, NULL, "Content-Language" },
+      propfind_fromhdr, NULL, (void *) "Content-Language" },
     { "getcontentlength", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getlength, NULL, NULL },
     { "getcontenttype", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
-      propfind_fromhdr, NULL, "Content-Type" },
+      propfind_fromhdr, NULL, (void *) "Content-Type" },
     { "getetag", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
       propfind_getetag, NULL, NULL },
@@ -156,7 +156,7 @@ static const struct prop_entry webdav_props[] = {
       propfind_lockdisc, NULL, NULL },
     { "resourcetype", NS_DAV,
       PROP_ALLPROP | PROP_COLLECTION | PROP_RESOURCE,
-      propfind_restype, proppatch_restype, "addressbook" },
+      propfind_restype, proppatch_restype, (void *) "addressbook" },
     { "supportedlock", NS_DAV,
       PROP_ALLPROP | PROP_RESOURCE,
       propfind_suplock, NULL, NULL },
@@ -216,12 +216,12 @@ static const struct prop_entry webdav_props[] = {
     /* WebDAV Sync (RFC 6578) properties */
     { "sync-token", NS_DAV,
       PROP_COLLECTION,
-      propfind_sync_token, NULL, SYNC_TOKEN_URL_SCHEME },
+      propfind_sync_token, NULL, (void *) SYNC_TOKEN_URL_SCHEME },
 
     /* Apple Calendar Server properties */
     { "getctag", NS_CS,
       PROP_ALLPROP | PROP_COLLECTION,
-      propfind_sync_token, NULL, "" },
+      propfind_sync_token, NULL, (void *) "" },
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };

--- a/imap/idled.c
+++ b/imap/idled.c
@@ -340,7 +340,7 @@ static void process_message(struct sockaddr_un *remote, json_t *msg)
         if (arrayu64_size(&failed_pids)) {
             /* remove clients that have stopped listening to us */
             struct buf buf = BUF_INITIALIZER;
-            char *sep = "";
+            const char *sep = "";
             size_t i;
             
             for (i = 0; i < arrayu64_size(&failed_pids); i++) {

--- a/imap/index.c
+++ b/imap/index.c
@@ -186,7 +186,7 @@ static void index_thread_refs(struct index_state *state,
                               int usinguid);
 
 static seqset_t *_parse_sequence(struct index_state *state,
-                                      const char *sequence, int usinguid);
+                                 const char *sequence, int usinguid);
 static void massage_header(char *hdr);
 
 /* NOTE: Make sure these are listed in CAPABILITY_STRING */
@@ -396,8 +396,8 @@ EXPORTED int index_open(const char *name, struct index_init *init,
     return r;
 }
 
-EXPORTED int index_expunge(struct index_state *state, char *sequence,
-                  int need_deleted)
+EXPORTED int index_expunge(struct index_state *state, const char *sequence,
+                           int need_deleted)
 {
     int r;
     uint32_t msgno;
@@ -1195,10 +1195,10 @@ EXPORTED int index_fetchresponses(struct index_state *state,
  * command.)
  */
 EXPORTED int index_fetch(struct index_state *state,
-                const char *sequence,
-                int usinguid,
-                const struct fetchargs *fetchargs,
-                int *fetchedsomething)
+                         const char *sequence,
+                         int usinguid,
+                         const struct fetchargs *fetchargs,
+                         int *fetchedsomething)
 {
     seqset_t *seq;
     seqset_t *vanishedlist = NULL;
@@ -1289,7 +1289,7 @@ EXPORTED int index_fetch(struct index_state *state,
 /*
  * Perform a STORE command on a sequence
  */
-EXPORTED int index_store(struct index_state *state, char *sequence,
+EXPORTED int index_store(struct index_state *state, const char *sequence,
                          struct storeargs *storeargs)
 {
     struct mailbox *mailbox;
@@ -3103,18 +3103,17 @@ out:
 /*
  * Performs a COPY command
  */
-EXPORTED int
-index_copy(struct index_state *state,
-           char *sequence,
-           int usinguid,
-           char *name,
-           char **copyuidp,
-           int nolink,
-           struct namespace *namespace,
-           int isadmin,
-           int ismove,
-           int ignorequota,
-           struct progress_rock *prock)
+EXPORTED int index_copy(struct index_state *state,
+                        const char *sequence,
+                        int usinguid,
+                        char *name,
+                        char **copyuidp,
+                        int nolink,
+                        struct namespace *namespace,
+                        int isadmin,
+                        int ismove,
+                        int ignorequota,
+                        struct progress_rock *prock)
 {
     struct copyargs copyargs;
     int i;
@@ -3350,8 +3349,8 @@ static int index_appendremote(struct index_state *state, uint32_t msgno,
 /*
  * Performs a COPY command from a local mailbox to a remote mailbox
  */
-EXPORTED int index_copy_remote(struct index_state *state, char *sequence,
-                      int usinguid, struct protstream *pout)
+EXPORTED int index_copy_remote(struct index_state *state, const char *sequence,
+                               int usinguid, struct protstream *pout)
 {
     uint32_t msgno;
     seqset_t *seq;
@@ -8149,8 +8148,8 @@ EXPORTED extern struct nntp_overview *index_overview(struct index_state *state,
     return &over;
 }
 
-EXPORTED extern char *index_getheader(struct index_state *state,
-                                      uint32_t msgno, char *hdr)
+EXPORTED char *index_getheader(struct index_state *state,
+                               uint32_t msgno, const char *hdr)
 {
     static struct buf staticbuf = BUF_INITIALIZER;
     strarray_t headers = STRARRAY_INITIALIZER;
@@ -8246,7 +8245,7 @@ EXPORTED int index_hasrights(const struct index_state *state, int rights)
  * Parse a sequence into an array of sorted & merged ranges.
  */
 static seqset_t *_parse_sequence(struct index_state *state,
-                                      const char *sequence, int usinguid)
+                                 const char *sequence, int usinguid)
 {
     unsigned maxval;
 

--- a/imap/index.h
+++ b/imap/index.h
@@ -264,7 +264,7 @@ extern int index_fetch(struct index_state *state,
                        const struct fetchargs* fetchargs,
                        int* fetchedsomething);
 extern int index_store(struct index_state *state,
-                       char *sequence,
+                       const char *sequence,
                        struct storeargs *storeargs);
 extern int index_run_annotator(struct index_state *state,
                                const char *sequence, int usinguid,
@@ -294,7 +294,7 @@ extern int index_search(struct index_state *state,
                         struct searchargs *searchargs, int usinguid,
                         struct progress_rock *prock);
 extern int index_copy(struct index_state *state,
-                      char *sequence,
+                      const char *sequence,
                       int usinguid,
                       char *name,
                       char **copyuidp,
@@ -338,10 +338,10 @@ extern char *index_get_msgid(struct index_state *state, uint32_t msgno);
 extern struct nntp_overview *index_overview(struct index_state *state,
                                             uint32_t msgno);
 extern char *index_getheader(struct index_state *state, uint32_t msgno,
-                             char *hdr);
+                             const char *hdr);
 extern unsigned long index_getsize(struct index_state *state, uint32_t msgno);
 extern unsigned long index_getlines(struct index_state *state, uint32_t msgno);
-extern int index_copy_remote(struct index_state *state, char *sequence,
+extern int index_copy_remote(struct index_state *state, const char *sequence,
                              int usinguid, struct protstream *pout);
 
 struct searchargs *new_searchargs(const char *tag, int state,
@@ -360,7 +360,7 @@ MsgData **index_msgdata_load(struct index_state *state, unsigned *msgno_list, in
                              unsigned int anchor, int *found_anchor);
 extern int index_search_evaluate(struct index_state *state, const search_expr_t *e, uint32_t msgno);
 
-extern int index_expunge(struct index_state *state, char *uidsequence,
+extern int index_expunge(struct index_state *state, const char *uidsequence,
                          int need_deleted);
 
 /* Extract text for snippets: first look in message bodies, then attachments */

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -11062,19 +11062,22 @@ static void _emailpart_body_to_mime(jmap_req_t *req, struct jmap_parser *parser,
         }
         else if (dst_encoding == ENCODING_BASE64) {
             // Pre-flight encoder to determine length
-            size_t b64_len = 0;
-            char *b64 = "";
+            size_t b64_len;
             charset_b64encode_mimebody(NULL, body_len, NULL, &b64_len, NULL,
                                        /*wrap*/ 1);
             if (b64_len) {
                 // Now encode the body
-                b64 = xmalloc(b64_len);
+                char *b64 = xmalloc(b64_len);
                 charset_b64encode_mimebody(body, body_len, b64, &b64_len, NULL,
                                            /*wrap*/ 1);
                 strarray_appendm(&freeme, b64);
+                dst_body = b64;
+                dst_len = b64_len;
             }
-            dst_body = b64;
-            dst_len = b64_len;
+            else {
+                dst_body = "";
+                dst_len = 0;
+            }
         }
     }
 

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -456,7 +456,7 @@ static int dump_file(int first, int sync,
 
 struct data_file {
     int metaname;
-    char *fname;
+    const char *fname;
 };
 
 /* even though 2.4.x doesn't use cyrus.expunge, we need to be aware
@@ -622,7 +622,8 @@ EXPORTED int dump_mailbox(const char *tag, struct mailbox *mailbox, uint32_t uid
     if (mboxname_isusermailbox(mailbox_name(mailbox), 1)) {
         userid = mboxname_to_userid(mailbox_name(mailbox));
         int sieve_usehomedir = config_getswitch(IMAPOPT_SIEVEUSEHOMEDIR);
-        char *fname = NULL, *ftag = NULL;
+        char *fname = NULL;
+        const char *ftag = NULL;
 
         /* Dump seen and subs files */
         for (i = 0; i< NUM_USER_DATA_FILES; i++) {

--- a/imap/message.c
+++ b/imap/message.c
@@ -2142,10 +2142,10 @@ EXPORTED int message_write_cache(struct index_record *record, const struct body 
     buf_reset(&cacheitem_buffer);
     memset(ib, 0, sizeof(ib));
 
-    toplevel.type = "MESSAGE";
-    toplevel.subtype = "RFC822";
     /* we cast away const because we know that we're only using
-     * toplevel.subpart as const in message_write_section(). */
+     * toplevel as const in message_write_section(). */
+    toplevel.type = (char *) "MESSAGE";
+    toplevel.subtype = (char *) "RFC822";
     toplevel.subpart = (struct body *)body;
 
     subject = charset_parse_mimeheader(body->subject, charset_flags);
@@ -3450,15 +3450,15 @@ static void message_read_binarybody(struct body *body, const char **sect,
  * Read cached envelope, binary bodystructure response and binary bodystructure
  * of the specified record.  Populates 'body' which must be freed by the caller.
  */
-EXPORTED void message_read_bodystructure(const struct index_record *record, struct body **body)
+EXPORTED void message_read_bodystructure(const struct index_record *record,
+                                         struct body **body)
 {
     struct protstream *strm;
-    struct body toplevel;
+    struct body toplevel = {0};
     const char *binbody;
 
-    memset(&toplevel, 0, sizeof(struct body));
-    toplevel.type = "MESSAGE";
-    toplevel.subtype = "RFC822";
+    toplevel.type = (char *) "MESSAGE";
+    toplevel.subtype = (char *) "RFC822";
     toplevel.subpart = *body = xzmalloc(sizeof(struct body));
 
     /* Read envelope response from cache */
@@ -4826,7 +4826,7 @@ static int message_parse_cbodystructure(message_t *m)
     struct protstream *prot = NULL;
     const char *cachestr = cacheitem_base(&m->record, CACHE_SECTION);
     const char *cacheend = cachestr + cacheitem_size(&m->record, CACHE_SECTION);
-    struct body toplevel;
+    struct body toplevel = {0};
     int r;
 
     /* We're reading the cache - double check we have it */
@@ -4848,9 +4848,8 @@ static int message_parse_cbodystructure(message_t *m)
     }
     if (r) goto done;
 
-    memset(&toplevel, 0, sizeof(struct body));
-    toplevel.type = "MESSAGE";
-    toplevel.subtype = "RFC822";
+    toplevel.type = (char *) "MESSAGE";
+    toplevel.subtype = (char *) "RFC822";
     toplevel.subpart = m->body;
 
     r = parse_bodystructure_sections(&cachestr, cacheend, &toplevel,

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -2050,7 +2050,7 @@ static void cmd_authinfo_sasl(char *cmd, char *mech, char *resp)
     int r, sasl_result;
     char *success_data;
     sasl_ssf_t ssf;
-    char *ssfmsg = NULL;
+    const char *ssfmsg = NULL;
     const void *val;
     int failedloginpause;
     struct proc_limits limits;
@@ -2571,7 +2571,7 @@ static int newsgroups_cb(const char *mailbox,
 static void cmd_list(char *arg1, char *arg2)
 {
     if (!arg1)
-        arg1 = "active";
+        arg1 = (char *) "active";
     else
         lcase(arg1);
 
@@ -2579,7 +2579,7 @@ static void cmd_list(char *arg1, char *arg2)
         struct list_rock lrock;
         struct enum_rock erock;
 
-        if (!arg2) arg2 = "*";
+        if (!arg2) arg2 = (char *) "*";
 
         erock.cmd = "ACTIVE";
         erock.wild = xstrdup(arg2); /* make a copy before we munge it */
@@ -2636,7 +2636,7 @@ static void cmd_list(char *arg1, char *arg2)
         struct list_rock lrock;
         struct enum_rock erock;
 
-        if (!arg2) arg2 = "*";
+        if (!arg2) arg2 = (char *) "*";
 
         erock.cmd = "NEWSGROUPS";
         erock.wild = xstrdup(arg2); /* make a copy before we munge it */
@@ -3637,7 +3637,7 @@ static void feedpeer(char *peer, message_data_t *msg)
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = 0;
-    if (!port || !*port) port = "119";
+    if (!port || !*port) port = (char *) "119";
     if (getaddrinfo(host, port, &hints, &res0) != 0) {
         syslog(LOG_ERR, "getaddrinfo(%s, %s) failed: %m", host, port);
         return;

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -321,7 +321,7 @@ EXPORTED int prometheus_text_report(struct buf *buf, const char **mimetype)
 {
     const struct {
         int required;
-        char *fname;
+        const char *fname;
     } reports[] = {
         { 1, FNAME_PROM_SERVICE_REPORT },
         { 0, FNAME_PROM_USAGE_REPORT   },

--- a/imap/protocol.h
+++ b/imap/protocol.h
@@ -71,7 +71,7 @@ enum {
 struct banner_t {
     u_char auto_capa;           /* capability response sent automatically
                                    in banner? */
-    char *resp;                 /* end of banner response */
+    const char *resp;           /* end of banner response */
 };
 
 struct capa_t {

--- a/imap/quota_db.c
+++ b/imap/quota_db.c
@@ -405,7 +405,7 @@ EXPORTED int quota_foreach(const char *prefix, quotaproc_t *proc,
                            void *rock, struct txn **tid, unsigned flags)
 {
     int r;
-    char *search = prefix ? (char *)prefix : "";
+    const char *search = prefix ? prefix : "";
     struct quota_foreach_t foreach_d;
 
     init_internal();
@@ -416,7 +416,7 @@ EXPORTED int quota_foreach(const char *prefix, quotaproc_t *proc,
     foreach_d.use_conv = !!(flags & QUOTA_USE_CONV);
 
     r = cyrusdb_foreach(qdb, search, strlen(search), NULL,
-                     do_onequota, &foreach_d, tid);
+                        do_onequota, &foreach_d, tid);
 
     return r;
 }

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -176,8 +176,8 @@ EXPORTED int tls_enabled(void)
 
 static void apps_ssl_info_callback(const SSL * s, int where, int ret)
 {
-    char   *str;
-    int     w;
+    const char  *str;
+    int         w;
 
     if (var_imapd_tls_loglevel==0) return;
 

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -726,7 +726,7 @@ static icalvalue *xml_element_to_icalvalue(xmlNodePtr xtype,
         struct buf rrule = BUF_INITIALIZER;
         struct hash_table byrules;
         struct icalrecurrencetype *rt;
-        char *sep = "";
+        const char *sep = "";
 
         construct_hash_table(&byrules, 10, 1);
 

--- a/lib/chartable.h
+++ b/lib/chartable.h
@@ -46,13 +46,13 @@ struct charmap {
 };
 
 struct charset {
-    char *name;
+    const char *name;
     const struct charmap (*table)[256];
 };
 
 struct charset_alias {
-    char *name;
-    char *canon_name;
+    const char *name;
+    const char *canon_name;
 };
 
 /* unicode canon translations */

--- a/lib/imclient.c
+++ b/lib/imclient.c
@@ -901,9 +901,9 @@ static void imclient_eof(struct imclient *imclient)
     imclient->readytxt = 0;
 
     for (cmdcb = imclient->cmdcallback; cmdcb; cmdcb = cmdcb->next) {
-        reply.keyword = "EOF";
+        reply.keyword = (char *) "EOF";
         reply.msgno = -1;
-        reply.text = "";
+        reply.text = (char *) "";
         (*cmdcb->proc)(imclient, cmdcb->rock, &reply);
         if (!cmdcb->next) {
             cmdcb->next = cmdcallback_freelist;

--- a/lib/imclient.c
+++ b/lib/imclient.c
@@ -1826,7 +1826,7 @@ static void apps_ssl_info_callback(SSL * s, int where, int ret)
 #endif
 
 EXPORTED int tls_start_clienttls(struct imclient *imclient,
-                        unsigned *layer, char **authid, int fd)
+                        unsigned *layer, const char **authid, int fd)
 {
     int sts;
     SSL_SESSION *session;
@@ -1834,7 +1834,7 @@ EXPORTED int tls_start_clienttls(struct imclient *imclient,
     X509 *peer;
     int tls_cipher_usebits = 0;
     int tls_cipher_algbits = 0;
-    char *tls_peer_CN = "";
+    const char *tls_peer_CN = "";
 
     if (!imclient->tls_conn)
         imclient->tls_conn = (SSL *) SSL_new(imclient->tls_ctx);
@@ -1923,7 +1923,7 @@ EXPORTED int imclient_starttls(struct imclient *imclient,
   int result;
   struct authresult theresult;
   sasl_ssf_t ssf;
-  char *auth_id;
+  const char *auth_id;
 
   imclient_send(imclient, tlsresult, (void *)&theresult,
                 "STARTTLS");

--- a/lib/imparse.c
+++ b/lib/imparse.c
@@ -72,8 +72,8 @@ EXPORTED int imparse_word(char **s, char **retval)
  * by 's'.  On success, places a pointer to the parsed word in the
  * pointer at 'retval', returns the character following the word, and
  * modifies the pointer at 's' to point after the returned character.
- * On failure, returns EOF, modifies the pointer at 'retval' to point
- * at the empty string, and modifies 's' to point around the syntax error.
+ * On failure, returns EOF, sets the pointer at 'retval' to NULL,
+ * and modifies 's' to point around the syntax error.
  * Modifies the input buffer.
  */
 EXPORTED int imparse_astring(char **s, char **retval)
@@ -91,7 +91,7 @@ EXPORTED int imparse_astring(char **s, char **retval)
     case '\r':
     case '\n':
         /* Invalid starting character */
-        *retval = "";
+        *retval = NULL;
         return EOF;
 
     default:
@@ -117,7 +117,7 @@ EXPORTED int imparse_astring(char **s, char **retval)
                 return *(*s)++;
             }
             else if (c == '\0' || c == '\r' || c == '\n') {
-                *retval = "";
+                *retval = NULL;
                 return EOF;
             }
             *d++ = c;
@@ -131,7 +131,7 @@ EXPORTED int imparse_astring(char **s, char **retval)
             len = len*10 + c - '0';
         }
         if (!sawdigit || c != '}' || *(*s)++ != '\r' || *(*s)++ != '\n') {
-            *retval = "";
+            *retval = NULL;
             return EOF;
         }
         *retval = *s;
@@ -221,8 +221,10 @@ EXPORTED int imparse_isnumber(const char *s)
  * and populate the structure in the pointer at 'range'.
  * Returns 0 on success, and non-zero on failure.
  */
-EXPORTED int imparse_range(char *s, range_t *range)
+EXPORTED int imparse_range(const char *s, range_t *range)
 {
+    char *rem;
+
     if (*s == '-') {
         range->is_last = 1;
         s++;
@@ -230,11 +232,12 @@ EXPORTED int imparse_range(char *s, range_t *range)
     if (!Uisdigit(*s)) return -1;
 
     errno = 0;
-    range->low = strtoul(s, &s, 10);
-    if (!range->low || range->low > UINT32_MAX || errno || *s != ':') {
+    range->low = strtoul(s, &rem, 10);
+    if (!range->low || range->low > UINT32_MAX || errno || *rem != ':') {
         errno = 0;
         return -1;
     }
+    s = rem;
 
     if (*++s == '-') {
         if (!range->is_last) return -1;
@@ -242,8 +245,8 @@ EXPORTED int imparse_range(char *s, range_t *range)
     }
     if (!Uisdigit(*s)) return -1;
 
-    range->high = strtoul(s, &s, 10);
-    if (!range->high || range->high > UINT32_MAX  || errno || *s) {
+    range->high = strtoul(s, &rem, 10);
+    if (!range->high || range->high > UINT32_MAX  || errno || *rem) {
         errno = 0;
         return -1;
     }

--- a/lib/imparse.h
+++ b/lib/imparse.h
@@ -56,6 +56,6 @@ extern int imparse_isnatom (const char *s, int len);
 extern int imparse_isatom (const char *s);
 extern int imparse_issequence (const char *s);
 extern int imparse_isnumber (const char *s);
-extern int imparse_range (char *s, range_t *range);
+extern int imparse_range (const char *s, range_t *range);
 
 #endif /* INCLUDED_IMPARSE_H */

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -1160,13 +1160,19 @@ static void config_read_file(const char *filename)
                    as one value unless told otherwise */
 
                 if (imapopts[opt].t == OPT_ENUM) {
-                    /* normalize on/off values */
+                    /* normalize on/off values
+                     * we don't write to p in this section of the parser, so
+                     * this is safe, but if that ever changes it'll crash!
+                     */
                     if (!strcmp(p, "1") || !strcmp(p, "yes") ||
-                        !strcmp(p, "t") || !strcmp(p, "true")) {
-                        p = "on";
-                    } else if (!strcmp(p, "0") || !strcmp(p, "no") ||
-                               !strcmp(p, "f") || !strcmp(p, "false")) {
-                        p = "off";
+                        !strcmp(p, "t") || !strcmp(p, "true"))
+                    {
+                        p = (char *) "on";
+                    }
+                    else if (!strcmp(p, "0") || !strcmp(p, "no") ||
+                             !strcmp(p, "f") || !strcmp(p, "false"))
+                    {
+                        p = (char *) "off";
                     }
                 } else if (imapopts[opt].t == OPT_BITFIELD) {
                     /* split the string into separate values */

--- a/lib/parseaddr.c
+++ b/lib/parseaddr.c
@@ -55,9 +55,14 @@ static const char unspecified_domain[] = "unspecified-domain";
 static void parseaddr_append(struct address ***addrpp, const char *name,
                              const char *route, const char *mailbox,
                              const char *domain, char **freemep, int invalid);
-static int parseaddr_phrase (char **inp, char **phrasep, const char *specials);
-static int parseaddr_domain (char **inp, char **domainp, char **commmentp, int *invalid);
-static int parseaddr_route (char **inp, char **routep);
+static int parseaddr_phrase(char **inp,
+                            const char **phrasep,
+                            const char *specials);
+static int parseaddr_domain(char **inp,
+                            const char **domainp,
+                            const char **commmentp,
+                            int *invalid);
+static int parseaddr_route(char **inp, const char **routep);
 
 /*
  * Parse an address list in 's', appending address structures to
@@ -69,7 +74,7 @@ EXPORTED void parseaddr_list(const char *str, struct address **addrp)
     int ingroup = 0;
     char *freeme;
     int tok = ' ', invalid = 0;
-    char *phrase, *route, *mailbox, *domain, *comment;
+    const char *phrase, *route, *mailbox, *domain, *comment;
 
     /* Skip down to the tail */
     while (*addrp) {
@@ -224,7 +229,9 @@ static void parseaddr_append(struct address ***addrpp, const char *name,
 /*
  * Parse an RFC 822 "phrase", stopping at 'specials'
  */
-static int parseaddr_phrase(char **inp, char **phrasep, const char *specials)
+static int parseaddr_phrase(char **inp,
+                            const char **phrasep,
+                            const char *specials)
 {
     int c;
     char *src = *inp;
@@ -299,7 +306,10 @@ fail:
  * Parse a domain.  If 'commentp' is non-nil, parses any trailing comment.
  * If the domain is invalid, set invalid to non-zero.
  */
-static int parseaddr_domain(char **inp, char **domainp, char **commentp, int *invalid)
+static int parseaddr_domain(char **inp,
+                            const char **domainp,
+                            const char **commentp,
+                            int *invalid)
 {
     u_char c;
     char *src = *inp;
@@ -360,7 +370,7 @@ static int parseaddr_domain(char **inp, char **domainp, char **commentp, int *in
 /*
  * Parse a source route (at-domain-list)
  */
-static int parseaddr_route(char **inp, char **routep)
+static int parseaddr_route(char **inp, const char **routep)
 {
     int c;
     char *src = *inp;

--- a/notifyd/notify_log.c
+++ b/notifyd/notify_log.c
@@ -57,7 +57,7 @@ char* notify_log(const char *class, const char *priority,
                  const char *fname __attribute__((unused)))
 {
     struct buf opt_str = BUF_INITIALIZER;
-    char *sep = "";
+    const char *sep = "";
     int i;
 
     if (nopt) {

--- a/notifyd/notify_zephyr.c
+++ b/notifyd/notify_zephyr.c
@@ -121,13 +121,13 @@ char* notify_zephyr(const char *class, const char *priority,
 
     memset((char *)&notice, 0, sizeof(notice));
     notice.z_kind = UNSAFE;
-    notice.z_class = *class ? (char *) class : MAIL_CLASS;
+    notice.z_class = *class ? (char *) class : (char *) MAIL_CLASS;
     notice.z_class_inst = *priority ? (char *) priority :
-        *mailbox ? (char *) mailbox : "INBOX";
+        *mailbox ? (char *) mailbox : (char *) "INBOX";
 
-    notice.z_opcode = "";
+    notice.z_opcode = (char *) "";
     notice.z_sender = mysender;
-    notice.z_default_format = "From Post Office $1:\n$2";
+    notice.z_default_format = (char *) "From Post Office $1:\n$2";
 
     notice.z_recipient = (char *) user;
 

--- a/notifyd/notifyd.c
+++ b/notifyd/notifyd.c
@@ -229,7 +229,7 @@ static void usage(void)
 EXPORTED int service_init(int argc, char **argv, char **envp __attribute__((unused)))
 {
     int opt;
-    char *method = "null";
+    const char *method = "null";
 
     if (geteuid() == 0) fatal("must run as the Cyrus user", EX_USAGE);
 

--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -761,7 +761,7 @@ static int ptsmodule_get_dn(
     char *base = NULL, *filter = NULL;
     char *domain = NULL;
     char domain_filter[1024];
-    char *attrs[] = {LDAP_NO_ATTRS,NULL}; //do not return all attrs!
+    char *attrs[] = {(char *) LDAP_NO_ATTRS,NULL}; //do not return all attrs!
     char *domain_attrs[] = {(char *)ptsm->domain_name_attribute,(char *)ptsm->domain_result_attribute,NULL};
     LDAPMessage *res = NULL;
     LDAPMessage *entry;
@@ -783,7 +783,7 @@ static int ptsmodule_get_dn(
 
         strcpy(authzid, "u:");
         strcpy(authzid+2, canon_id);
-        c.ldctl_oid = LDAP_CONTROL_PROXY_AUTHZ;
+        c.ldctl_oid = (char *) LDAP_CONTROL_PROXY_AUTHZ;
         c.ldctl_value.bv_val = authzid;
         c.ldctl_value.bv_len = size + 2;
         c.ldctl_iscritical = 1;

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -2119,7 +2119,7 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
                 /* Parse/split the method URI */
                 if (!strncasecmp(method, "mailto:", 7)) {
                     strarray_insertm(cmd.u.n.options, 0, method+7);
-                    method = "mailto";
+                    method = (char *) "mailto";
                 }
                 else if (!strncasecmp(method,
                                       "https://cyrusimap.org/notifiers/", 32)) {

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -341,7 +341,7 @@ EXPORTED void sieve_script_free(sieve_script_t **s)
     }
 }
 
-static void add_header(sieve_interp_t *i, int isenv, char *header,
+static void add_header(sieve_interp_t *i, int isenv, const char *header,
                        void *message_context, struct buf *out)
 {
     const char **h;
@@ -480,7 +480,7 @@ static int send_notify_callback(sieve_interp_t *interp,
     return ret;
 }
 
-static char *action_to_string(action_t action)
+static const char *action_to_string(action_t action)
 {
     switch(action)
         {
@@ -507,7 +507,7 @@ static char *action_to_string(action_t action)
     /* never reached */
 }
 
-static char *sieve_errstr(int code)
+static const char *sieve_errstr(int code)
 {
     switch (code)
         {

--- a/sieve/sieve-lex.l
+++ b/sieve/sieve-lex.l
@@ -62,8 +62,8 @@ extern int encoded_char; /* used to receive encoded-char feedback from parser */
 
 static unsigned long long tonum(const char *str);
 static int decode_string(struct buf *buf);
-extern void sieveerror(sieve_script_t *, char *);
-extern void sieveerror_f(sieve_script_t *, char *fmt, ...);
+extern void sieveerror(sieve_script_t *, const char *);
+extern void sieveerror_f(sieve_script_t *, const char *fmt, ...);
 %}
 
 %option yylineno

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -1770,7 +1770,7 @@ static void generate_script(bytecode_input_t *d, int bc_len)
 
     if (requires) {
         unsigned long long capa;
-        char *sep = "";
+        const char *sep = "";
         int n;
 
         printf("require [");

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -564,7 +564,7 @@ static int send_response(void *ac, void *ic, void *sc,
            src->msg, src->subj, src->addr, m->name, src->fromaddr);
 
     if (src->fcc.mailbox) {
-        message_data_t vmc = { .name = "vacation-autoresponse" };
+        message_data_t vmc = { .name = (char *) "vacation-autoresponse" };
 
         (void) fileinto(&src->fcc, ic, sc, &vmc, errmsg);
     }

--- a/sieve/test_mailbox.c
+++ b/sieve/test_mailbox.c
@@ -487,7 +487,7 @@ static int send_response(void *ac, void *ic, void *sc,
            src->msg, src->subj, src->addr, m->name, src->fromaddr);
 
     if (src->fcc.mailbox) {
-        message_data_t vmc = { .name = "vacation-autoresponse" };
+        message_data_t vmc = { .name = (char *) "vacation-autoresponse" };
 
         (void) fileinto(&src->fcc, ic, sc, &vmc, errmsg);
     }

--- a/tools/build-with-cyruslibs.sh
+++ b/tools/build-with-cyruslibs.sh
@@ -8,7 +8,7 @@ set -e
 : ${CONFIGOPTS:="--enable-jmap --enable-http --enable-calalarmd --enable-unit-tests --enable-replication --enable-nntp --enable-murder --enable-idled --enable-xapian --enable-autocreate --enable-silent-rules --enable-debug-slowio"}
 export LDFLAGS="-L$LIBSDIR/lib/x86_64-linux-gnu -L$LIBSDIR/lib -Wl,-rpath,$LIBSDIR/lib/x86_64-linux-gnu -Wl,-rpath,$LIBSDIR/lib"
 export PKG_CONFIG_PATH="$LIBSDIR/lib/x86_64-linux-gnu/pkgconfig:$LIBSDIR/lib/pkgconfig:\$PKG_CONFIG_PATH"
-export CFLAGS="-g -fPIC -W -Wall -Wextra -Werror"
+export CFLAGS="-g -fPIC -W -Wall -Wextra -Werror -Wwrite-strings"
 export CXXFLAGS="-g -fPIC -W -Wall -Wextra -Werror"
 export PATH="$LIBSDIR/bin:$PATH"
 autoreconf -v -i


### PR DESCRIPTION
This PR fixes all the new warnings that appear when compiling with the `-Wwrite-strings` C dialect option (in which string literals have type `const char[]` rather than `char[]  that will crash if you modify it`).  This option is nice because it means the compiler's usual discarded-qualifiers warnings will now also protect us from doing dodgy stuff with string literals (unless we silence the warning with an explicit cast).

It also adds this option to CFLAGS in tools/build-with-cyruslibs.sh, which means once this is merged, all our Github CI runs will be built with this option, and will yell at us if we do dodgy stuff without at least a cast to shut it up.

There were lots of very similar fixes, which I've grouped up approximately one commit per type of fix.  I suggest reviewing it commit by commit.  You might also want to add -Wwrite-strings to your own local build options after this lands.