### PR TITLE
suppress leaked sasl state from backend tests

### DIFF
--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -1342,6 +1342,12 @@ static pid_t server_start(struct server_state *state)
 
         /* Forget the per-connection state */
         server_unaccept(state);
+
+        /* This loops forever until it's killed off by an uncaught SIGTERM.
+         * It MUST NOT exit(0) nor return, otherwise it'll make a mess of the
+         * cunit internal state that's still in memory since we did fork()
+         * but not exec().
+         */
     }
 }
 

--- a/cunit/vg.supp
+++ b/cunit/vg.supp
@@ -87,3 +87,26 @@
     obj:*/libcunit*
     ...
 }
+
+{
+   # shush leaked SASL internal state in toy server process
+   backend_child_process_sasl_state
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:malloc
+   fun:_dlfo_mappings_segment_allocate
+   fun:_dl_find_object_update_1
+   fun:_dl_find_object_update
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:_dlerror_run
+   fun:dlopen_implementation
+   ...
+}


### PR DESCRIPTION
The backend.testc tests are leaking like this:

```
==346751== 4,608 bytes in 2 blocks are possibly lost in loss record 241 of 242
==346751==    at 0x48407B4: malloc (vg_replace_malloc.c:381)
==346751==    by 0x400423B: malloc (rtld-malloc.h:56)
==346751==    by 0x400423B: _dlfo_mappings_segment_allocate (dl-find_object.c:217)
==346751==    by 0x400423B: _dl_find_object_update_1 (dl-find_object.c:671)
==346751==    by 0x400423B: _dl_find_object_update (dl-find_object.c:805)
==346751==    by 0x400BD37: dl_open_worker_begin (dl-open.c:735)
==346751==    by 0x5320FC9: _dl_catch_exception (dl-error-skeleton.c:208)
==346751==    by 0x400B1C5: dl_open_worker (dl-open.c:782)
==346751==    by 0x5320FC9: _dl_catch_exception (dl-error-skeleton.c:208)
==346751==    by 0x400B5B7: _dl_open (dl-open.c:884)
==346751==    by 0x5257437: dlopen_doit (dlopen.c:56)
==346751==    by 0x5320FC9: _dl_catch_exception (dl-error-skeleton.c:208)
==346751==    by 0x532107E: _dl_catch_error (dl-error-skeleton.c:227)
==346751==    by 0x5256F26: _dlerror_run (dlerror.c:138)
==346751==    by 0x52574E8: dlopen_implementation (dlopen.c:71)
==346751==    by 0x52574E8: dlopen@@GLIBC_2.34 (dlopen.c:81)
```

The dlopen in the first frame is odd, suggests that it's probably something to do with libsasl, which dlopens its plugins.  I went down a few rabbit holes here:

* Comment out the `init_sasl()` call from `server_start()`: this makes the leak go away, so it confirms the leak has something to do with sasl, but it also makes the tests that need that fail, so it's not a fix
* Add a call to `sasl_done()` when the server process is finished: I spent quite a bit of time on this, added a SIGTERM handler so it could shut down cleanly and call `sasl_done()` on the way out, figured out a workaround for closing the process without adding noise from cunit still being in memory (due to `fork()` without `exec()`), etc...  only to find that it was still leaking anyway.  Not sure why, perhaps another quirk of the fork without exec
* In the end I reverted everything and just added a suppression instead