### PR TITLE
http_caldav: only lookup annotation on real mailboxes

### DIFF
--- a/cassandane/tiny-tests/Caldav/options
+++ b/cassandane/tiny-tests/Caldav/options
@@ -1,0 +1,28 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_options {
+    my ($self) = @_;
+
+    my $caldav = $self->{caldav};
+
+    sub get_options {
+        my ($url) = shift;
+        my $res = $caldav->ua()->request(
+            'OPTIONS',
+            $caldav->request_url($url),
+            { headers => { Authorization => $caldav->auth_header() } }
+        );
+        return $res->{headers}{dav};
+    }
+
+    $self->assert(grep(/calendar-access/,
+            @{ get_options('/dav/calendars/user/cassandane/Default') }));
+    $self->assert(grep(/calendar-access/,
+            @{ get_options('/dav/calendars/user/cassandane/') }));
+    $self->assert(grep(/calendar-access/,
+            @{ get_options('/dav/calendars/') }));
+
+    $self->assert(not grep(/calendar-access/, @{ get_options('/dav/') }));
+    $self->assert(not grep(/calendar-access/, @{ get_options('/') }));
+}

--- a/cassandane/tiny-tests/Caldav/options
+++ b/cassandane/tiny-tests/Caldav/options
@@ -16,13 +16,38 @@ sub test_options {
         return $res->{headers}{dav};
     }
 
-    $self->assert(grep(/calendar-access/,
-            @{ get_options('/dav/calendars/user/cassandane/Default') }));
-    $self->assert(grep(/calendar-access/,
-            @{ get_options('/dav/calendars/user/cassandane/') }));
-    $self->assert(grep(/calendar-access/,
-            @{ get_options('/dav/calendars/') }));
+    # Non-calendar collections - no scheduling
+    $self->assert_null(@{ get_options('/') });
+    $self->assert(not grep(/calendar-auto-schedule/,
+                           @{ get_options('/dav/') }));
 
-    $self->assert(not grep(/calendar-access/, @{ get_options('/dav/') }));
-    $self->assert(not grep(/calendar-access/, @{ get_options('/') }));
+    # Calendar collections - scheduling enabled by default
+    $self->assert(grep(/calendar-auto-schedule/,
+            @{ get_options('/dav/calendars/') }));
+    $self->assert(grep(/calendar-auto-schedule/,
+            @{ get_options('/dav/calendars/user/') }));
+    $self->assert(grep(/calendar-auto-schedule/,
+            @{ get_options('/dav/calendars/user/cassandane/') }));
+    $self->assert(grep(/calendar-auto-schedule/,
+            @{ get_options('/dav/calendars/user/cassandane/Default') }));
+
+    # Disable scheduling on Default calendar
+    my $xml = <<EOF;
+<?xml version="1.0" encoding="UTF-8"?>
+<D:propertyupdate xmlns:D="DAV:" xmlns:CY="http://cyrusimap.org/ns/">
+  <D:set>
+    <D:prop>
+      <CY:scheduling-enabled>F</CY:scheduling-enabled>
+    </D:prop>
+  </D:set>
+</D:propertyupdate>
+EOF
+    
+    my $res = $caldav->Request('PROPPATCH',
+                               "/dav/calendars/user/cassandane/Default",
+                               $xml, 'Content-Type' => 'text/xml');
+
+    # Scheduling should NOT be advertised
+    $self->assert(not grep(/calendar-auto-schedule/,
+            @{ get_options('/dav/calendars/user/cassandane/Default') }));
 }

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -8220,10 +8220,10 @@ static int meth_options_cal(struct transaction_t *txn, void *params)
                    txn->req_tgt.path);
         strarray_appendm(&txn->resp_body.links, buf_release(&link));
     }
-    if (txn->req_tgt.allow & ALLOW_CAL_SCHED) {
+    if ((txn->req_tgt.allow & ALLOW_CAL_SCHED) && txn->req_tgt.mbentry) {
         struct buf temp = BUF_INITIALIZER;
         if (!annotatemore_lookup_mbe(txn->req_tgt.mbentry, DAV_ANNOT_NS "<" XML_NS_CYRUS ">scheduling-enabled", "", &temp)
-            && (!strcasecmp(buf_cstring(&temp), "F") || !strcasecmp(temp.s, "no")))
+            && (!strcasecmp(buf_cstring(&temp), "F") || !strcasecmp(buf_cstring(&temp), "no")))
                 txn->req_tgt.allow &= ~ALLOW_CAL_SCHED;
         buf_free(&temp);
     };


### PR DESCRIPTION
This fixes a crash for OPTIONS /dav/calendars and adds tests that should've been part of the original PR