### PR TITLE
LibCyrus: don't run compiled examples if not executable

### DIFF
--- a/cassandane/Cassandane/Cyrus/LibCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/LibCyrus.pm
@@ -64,7 +64,8 @@ sub new
 
     my $cassini = Cassandane::Cassini->instance();
     my $rootdir = $cassini->val('cassandane', 'rootdir', '/var/tmp/cass');
-    my $rootdir_mount_opts = qx{findmnt -n -o OPTIONS --target $rootdir};
+    my $findmnt = $cassini->val('paths', 'findmnt', '/usr/bin/findmnt');
+    my $rootdir_mount_opts = qx{$findmnt -n -o OPTIONS --target $rootdir};
 
     $self->{rootdir_is_noexec} = (defined $rootdir_mount_opts
                                   && $rootdir_mount_opts =~ m/\bnoexec\b/);

--- a/cassandane/cassandane.ini.example
+++ b/cassandane/cassandane.ini.example
@@ -223,3 +223,4 @@
 [paths]
 ## make = /usr/bin/make
 ## pkg-config = /usr/bin/pkg-config
+## findmnt = /usr/bin/findmnt


### PR DESCRIPTION
The LibCyrus tests compile and then run some example code, but attempting to run the compiled code will fail when Cassandane's rootdir is on a filesystem that is mounted noexec.

This PR makes these tests skip trying to run the compiled code if it looks like it won't be executable.  Detecting the noexec mount option requires the program `findmnt` -- if it's not installed, the noexec mount option won't be detected, and the tests will expect to be able to execute (and then fail if they can't).

Tested by mounting a new tmpfs partition with the `noexec` option, and then configuring cassandane.ini use a directory on that partition for its `rootdir`