### PR TITLE
Remove option auth_mech: krb (Kerberos 4)

### DIFF
--- a/doc/legacy/overview.html
+++ b/doc/legacy/overview.html
@@ -256,8 +256,8 @@ anonymous user.
 <H3><A NAME="aclauth">Kerberos vs. Unix Authorization</A></H3>
 
 The Cyrus IMAP server comes with four authorization mechanisms, one is
-compatible with Unix-style ("<tt>/etc/passwd</tt>") authorization, one for
-use with Kerberos 4, one for use with Kerberos 5, and one for use with
+compatible with Unix-style ("<tt>/etc/passwd</tt>") authorization, one called
+<tt>mboxgroups</tt>, one for use with Kerberos 5, and one for use with
 an external authorization process (ptloader) which can interface with
 other group databases (e.g. AFS PTS groups, LDAP Groups, etc).
 

--- a/docsrc/imap/reference/admin/access-control/identifiers.rst
+++ b/docsrc/imap/reference/admin/access-control/identifiers.rst
@@ -34,8 +34,8 @@ Kerberos vs. Unix Authorization
 -------------------------------
 
 The Cyrus IMAP server comes with four authorization mechanisms, one is
-compatible with Unix-style (``/etc/passwd``) authorization, one for use
-with Kerberos 4, one for use with Kerberos 5, and one for use with an
+compatible with Unix-style (``/etc/passwd``) authorization, one called
+``mboxgroups``, one for use with Kerberos 5, and one for use with an
 external authorization process (ptloader) which can interface with
 other group databases (e.g. AFS PTS groups, LDAP Groups, etc).
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -372,7 +372,7 @@ Blank lines and lines beginning with ``#'' are ignored.
    file or mailboxes list entry?  It's noisy so disabled by default, but
    can be very useful for tracking down what happened if things look strange. */
 
-{ "auth_mech", "unix", STRINGLIST("unix", "pts", "krb", "krb5", "mboxgroups"), "UNRELEASED" }
+{ "auth_mech", "unix", STRINGLIST("unix", "pts", "krb5", "mboxgroups"), "UNRELEASED" }
 /* The authorization mechanism to use. */
 
 { "autocreateinboxfolders", NULL, STRING, "2.5.0", "2.5.0", "autocreate_inbox_folders" }


### PR DESCRIPTION
Adds to https://github.com/cyrusimap/cyrus-imapd/pull/5104.