### PR TITLE
Cassandane::Tiny: Import strict/warnings to consumers

### DIFF
--- a/cassandane/Cassandane/BuildInfo.pm
+++ b/cassandane/Cassandane/BuildInfo.pm
@@ -38,6 +38,8 @@
 #
 
 package Cassandane::BuildInfo;
+use strict;
+use warnings;
 use JSON;
 
 use lib '.';

--- a/cassandane/Cassandane/Tiny.pm
+++ b/cassandane/Cassandane/Tiny.pm
@@ -5,6 +5,11 @@ use warnings;
 sub import {
   no warnings 'once';
   $Cassandane::Tiny::Loader::RELOADED = 1;
+
+  # Everyone gets strict and warnings
+  strict->import();
+  warnings->import();
+
   return;
 }
 

--- a/cassandane/Cassandane/Util/TestUrl.pm
+++ b/cassandane/Cassandane/Util/TestUrl.pm
@@ -1,5 +1,8 @@
 package Cassandane::Util::TestURL;
 
+use strict;
+use warnings;
+
 use Plack::Loader;
 use Plack::Request;
 use Plack::Response;

--- a/cassandane/tiny-tests/Caldav/invite_change_time
+++ b/cassandane/tiny-tests/Caldav/invite_change_time
@@ -53,7 +53,7 @@ EOF
     );
 
     xlog $self, "Change DURATION";
-    my ($href, $ical) = $create_event->();
+    ($href, $ical) = $create_event->();
     $ical =~ s/DURATION:PT1H/DURATION:PT2H/;
     $caldav->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
     $self->assert_caldav_notified(
@@ -61,7 +61,7 @@ EOF
     );
 
     xlog $self, "Change DTSTART TZID to different UTC offset";
-    my ($href, $ical) = $create_event->();
+    ($href, $ical) = $create_event->();
     $ical =~ s/Perth/Melbourne/;
     $caldav->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
     $self->assert_caldav_notified(
@@ -69,7 +69,7 @@ EOF
     );
 
     xlog $self, "Change TZID to same UTC offset using IANA alias";
-    my ($href, $ical) = $create_event->();
+    ($href, $ical) = $create_event->();
     $ical =~ s/Perth/West/;
     $caldav->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
     $self->assert_caldav_notified(
@@ -77,7 +77,7 @@ EOF
     );
 
     xlog $self, "Change DURATION TO DTEND";
-    my ($href, $ical) = $create_event->();
+    ($href, $ical) = $create_event->();
     $ical =~ s/DURATION:PT1H/DTEND;TZID=Australia\/Perth:20240925T020000/;
     $caldav->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
     # Does not trigger an iTIP message, see Caldav.invite_switch_duration_to_dtend

--- a/cassandane/tiny-tests/Caldav/options
+++ b/cassandane/tiny-tests/Caldav/options
@@ -13,7 +13,7 @@ sub test_options {
             $caldav->request_url($url),
             { headers => { Authorization => $caldav->auth_header() } }
         );
-        return $res->{headers}{dav};
+        return $res->{headers}{dav} || [];
     };
 
     # Non-calendar collections - no scheduling

--- a/cassandane/tiny-tests/Caldav/options
+++ b/cassandane/tiny-tests/Caldav/options
@@ -6,7 +6,7 @@ sub test_options {
 
     my $caldav = $self->{caldav};
 
-    sub get_options {
+    my $get_options = sub {
         my ($url) = shift;
         my $res = $caldav->ua()->request(
             'OPTIONS',
@@ -14,22 +14,22 @@ sub test_options {
             { headers => { Authorization => $caldav->auth_header() } }
         );
         return $res->{headers}{dav};
-    }
+    };
 
     # Non-calendar collections - no scheduling
-    $self->assert_null(@{ get_options('/') });
+    $self->assert_null(@{ $get_options->('/') });
     $self->assert(not grep(/calendar-auto-schedule/,
-                           @{ get_options('/dav/') }));
+                           @{ $get_options->('/dav/') }));
 
     # Calendar collections - scheduling enabled by default
     $self->assert(grep(/calendar-auto-schedule/,
-            @{ get_options('/dav/calendars/') }));
+            @{ $get_options->('/dav/calendars/') }));
     $self->assert(grep(/calendar-auto-schedule/,
-            @{ get_options('/dav/calendars/user/') }));
+            @{ $get_options->('/dav/calendars/user/') }));
     $self->assert(grep(/calendar-auto-schedule/,
-            @{ get_options('/dav/calendars/user/cassandane/') }));
+            @{ $get_options->('/dav/calendars/user/cassandane/') }));
     $self->assert(grep(/calendar-auto-schedule/,
-            @{ get_options('/dav/calendars/user/cassandane/Default') }));
+            @{ $get_options->('/dav/calendars/user/cassandane/Default') }));
 
     # Disable scheduling on Default calendar
     my $xml = <<EOF;
@@ -49,5 +49,5 @@ EOF
 
     # Scheduling should NOT be advertised
     $self->assert(not grep(/calendar-auto-schedule/,
-            @{ get_options('/dav/calendars/user/cassandane/Default') }));
+            @{ $get_options->('/dav/calendars/user/cassandane/Default') }));
 }

--- a/cassandane/tiny-tests/Caldav/shared_multiget
+++ b/cassandane/tiny-tests/Caldav/shared_multiget
@@ -62,7 +62,7 @@ sub test_shared_multiget
 EOF
 
     xlog "Run calendar-multiget report";
-    $mgRes = $CalDAV->Request('REPORT', 'Default', $xmlMultiget,
+    my $mgRes = $CalDAV->Request('REPORT', 'Default', $xmlMultiget,
         'Content-Type' => 'application/xml',
     );
 

--- a/cassandane/tiny-tests/JMAPBackup/restore_contacts_all_dryrun
+++ b/cassandane/tiny-tests/JMAPBackup/restore_contacts_all_dryrun
@@ -63,8 +63,8 @@ sub test_restore_contacts_all_dryrun
     my $contactE = $res->[0][1]{created}{"e"}{id};
     my $state = $res->[0][1]{newState};
 
-    $diff = time() - $mark;
-    $period = "PT" . $diff . "S";
+    my $diff = time() - $mark;
+    my $period = "PT" . $diff . "S";
 
     xlog "restore contacts prior to most recent changes";
     $res = $jmap->CallMethods([['Backup/restoreContacts', {

--- a/cassandane/tiny-tests/JMAPBackup/restore_mail_twice
+++ b/cassandane/tiny-tests/JMAPBackup/restore_mail_twice
@@ -110,7 +110,7 @@ sub test_restore_mail_twice
     $self->assert_null($res->[1][1]{list}[0]{mailboxIds}->{$inbox->{id}});
 
     # need a gap between destroys otherwise we will restore both copies
-    my $mark = time();
+    $mark = time();
     sleep 2;
 
     xlog "destroy email1 again";

--- a/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
@@ -92,7 +92,7 @@ EOF
 
     xlog $self, "Assert calendar default alerts";
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Calendar/get', {
             properties => [
                 'defaultAlertsWithTime',
@@ -102,21 +102,22 @@ EOF
     ]);
     my %calendars = map { $_->{id} => $_ } @{$res->[0][1]{list}};
 
-    $self->assert_null($calendars{
-        Default}{defaultAlertsWithTime});
-    $self->assert_null($calendars{
-        Default}{defaultAlertsWithoutTime});
+    $self->assert_null($calendars{Default}{defaultAlertsWithTime});
+    $self->assert_null($calendars{Default}{defaultAlertsWithoutTime});
 
-    my $calendarADefaultAlerts = $calendars{$state->{
-        calendarA}{id}}{defaultAlertsWithTime};
+    my $calendarADefaultAlerts = $calendars{$state->{calendarA}{id}}
+                                           {defaultAlertsWithTime};
     $self->assert_num_equals(1, scalar keys %$calendarADefaultAlerts);
-    $self->assert_null($calendars{$state->{
-        calendarA}{id}}{defaultAlertsWithoutTime});
+    $self->assert_null(
+      $calendars{$state->{calendarA}{id}}{defaultAlertsWithoutTime}
+    );
 
-    $self->assert_null($calendars{$state->{
-        calendarB}{id}}{defaultAlertsWithTime});
-    $self->assert_null($calendars{$state->{
-        calendarB}{id}}{defaultAlertsWithoutTime});
+    $self->assert_null(
+      $calendars{$state->{calendarB}{id}}{defaultAlertsWithTime}
+    );
+    $self->assert_null(
+      $calendars{$state->{calendarB}{id}}{defaultAlertsWithoutTime}
+    );
 
     if (not $state->{did_migrate}) {
         $state->{calendarA}{defaultAlert} = (values %$calendarADefaultAlerts)[0];
@@ -287,7 +288,7 @@ EOF
         );
 
         xlog $self, "Create sharee per-user prop in calendar A";
-        my $ical = <<EOF;
+        $ical = <<EOF;
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Apple Inc.//Mac OS X 10.9.5//EN

--- a/cassandane/tiny-tests/JMAPCalendars/admin_rewrite_calendarevent_privacy
+++ b/cassandane/tiny-tests/JMAPCalendars/admin_rewrite_calendarevent_privacy
@@ -19,7 +19,7 @@ sub test_admin_rewrite_calendarevent_privacy
 );
 
     xlog $self, "Make sure regular user can't call Admin method";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Admin/rewriteCalendarEventPrivacy', {}, 'R1'],
     ], \@using);
     $self->assert_str_equals('accountNotSupportedByMethod',
@@ -28,7 +28,7 @@ sub test_admin_rewrite_calendarevent_privacy
     my $event1Uid = '40d11f36-245b-4a03-8034-df25f38f9f61';
 
     xlog $self, "create two calendar events";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['CalendarEvent/set', {
             create => {
                 event1 => {

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
@@ -140,7 +140,7 @@ sub test_calendar_set_defaultalerts_shared
     $self->assert_shared_defaultalerts($t, 'no alarm!', 'no alarm!');
 }
 
-sub _can_match {
+sub _can_match_b {
     my $event = shift;
     my $want = shift;
 
@@ -177,7 +177,7 @@ sub assert_alarm_notifs {
         my $found = 0;
         my @newwant;
         foreach my $data (@want) {
-            if (not $found and _can_match($event, $data)) {
+            if (not $found and _can_match_b($event, $data)) {
                 $found = 1;
             }
             else {

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
@@ -335,7 +335,7 @@ sub create_test
     $self->assert(exists $res->[1][1]{updated}{Default});
 
     xlog $self, 'Sharee sets useDefaultAlerts=true';
-    my $res = $shareeJmap->CallMethods([
+    $res = $shareeJmap->CallMethods([
         ['CalendarEvent/set', {
             accountId => 'owner',
             update => {

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
@@ -12,11 +12,14 @@ sub test_calendar_set_defaultalerts_shared
     my $ownerJmap = $t->{owner}{jmap};
     my $shareeJmap = $t->{sharee}{jmap};
 
-    $self->assert_shared_defaultalerts($t);
+    # Using a string here will fail matching if we were to attempt to match,
+    # which we shouldn't, since there's no default alarms yet!
+    $self->assert_shared_defaultalerts($t, 'no alarm!', 'no alarm!');
 
     xlog $self, "Owner sets default alarms";
 
     my $alertWithTimeOwnerId = '4c08cb1d-60e0-46e0-9cc1-9622b7a820ed';
+
     $t->{owner}->{defaultAlertsWithTime} = {
         $alertWithTimeOwnerId => {
             '@type' => 'Alert',
@@ -55,7 +58,7 @@ sub test_calendar_set_defaultalerts_shared
         }, 'R1'],
     ]);
 
-    $self->assert_shared_defaultalerts($t);
+    $self->assert_shared_defaultalerts($t, $alertWithTimeOwnerId, 'no alarm!');
 
     xlog $self, 'Sharee sets default alarms';
     my $alertWithTimeShareeId = 'b61e5b53-8ea2-46f4-949d-7b49734ba4d3';
@@ -96,7 +99,7 @@ sub test_calendar_set_defaultalerts_shared
         }, 'R1'],
     ]);
 
-    $self->assert_shared_defaultalerts($t);
+    $self->assert_shared_defaultalerts($t, $alertWithTimeOwnerId, $alertWithTimeShareeId);
 
     xlog $self, 'Owner removes default alarms';
     $t->{owner}->{defaultAlertsWithTime} = undef;
@@ -115,7 +118,7 @@ sub test_calendar_set_defaultalerts_shared
         }, 'R1'],
     ]);
 
-    $self->assert_shared_defaultalerts($t);
+    $self->assert_shared_defaultalerts($t, 'no alarm!', $alertWithTimeShareeId);
 
     xlog $self, 'Sharee removes default alarms';
     $t->{sharee}->{defaultAlertsWithTime} = undef;
@@ -134,7 +137,7 @@ sub test_calendar_set_defaultalerts_shared
         }, 'R1'],
     ]);
 
-    $self->assert_shared_defaultalerts($t);
+    $self->assert_shared_defaultalerts($t, 'no alarm!', 'no alarm!');
 }
 
 sub _can_match {
@@ -198,10 +201,12 @@ sub assert_alarm_notifs {
 
 sub assert_shared_defaultalerts
 {
-    my ($self, $t) = @_;
+    my ($self, $t, $owneralarmid, $shareealarmid) = @_;
 
     for my $who (qw/owner sharee/) {
         my $jmap = $t->{$who}->{jmap};
+
+        my $alarmid = $who eq 'owner' ? $owneralarmid : $shareealarmid;
 
         xlog $self, "Assert alarms for $who";
         my $res = $jmap->CallMethods([
@@ -242,8 +247,7 @@ sub assert_shared_defaultalerts
         $res = $caldav->Request('GET', $xhref);
         if ($defaultAlertsWithTime) {
             $self->assert_matches(qr/BEGIN:VALARM/, $res->{content});
-            my $uid = (values %{$defaultAlertsWithTime})->{uid};
-            $self->assert_matches(qr/UID:$uid/, $res->{content});
+            $self->assert_matches(qr/UID:$alarmid/, $res->{content});
         } else {
             $self->assert(not $res->{content} =~ qr/BEGIN:VALARM/);
         }

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_shared_sort_order
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_shared_sort_order
@@ -50,7 +50,7 @@ sub test_calendar_set_shared_sort_order
     $self->assert_equals(JSON::false, $session->{accounts}{manifold}{isReadOnly});
 
     xlog $self, "Set sortOrder on a calendar";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
             ['Calendar/set', {
                     accountId => 'manifold',
                     update => {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_calalarmd
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_calalarmd
@@ -222,7 +222,7 @@ EOF
     $self->assert_alarms();
 }
 
-sub _can_match {
+sub _can_match_a {
     my $event = shift;
     my $want = shift;
 
@@ -260,7 +260,7 @@ sub assert_alarms {
         my $found = 0;
         my @newwant;
         foreach my $data (@want) {
-            if (not $found and _can_match($event, $data)) {
+            if (not $found and _can_match_a($event, $data)) {
                 $found = 1;
             }
             else {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_etag_preserved_after_alarm
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_etag_preserved_after_alarm
@@ -87,7 +87,7 @@ sub test_calendarevent_defaultalerts_etag_preserved_after_alarm
     $self->assert_num_equals(1, scalar @notifs);
 
     xlog $self, "Get event ETag after alarm fired";
-    my %Headers;
+    %Headers = ();
     if ($caldav->{user}) {
         $Headers{'Authorization'} = $caldav->auth_header();
     }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_updated_by_caldav_put
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_updated_by_caldav_put
@@ -14,7 +14,7 @@ sub test_calendarevent_defaultalerts_updated_by_caldav_put
         '73aac5e1-e736-4c81-8b30-fb6ad5781f95',
         'a7ce891b-ae41-4fdb-a3d1-346d3889c90b'
     ];
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
                 Default => {
@@ -63,7 +63,7 @@ sub assert_valarms
     if ($args{useDefaultAlerts}) {
         $self->assert_not_null($props[0]);
         $self->assert_str_equals('TRUE', $props[0]->value);
-    } elsif ($props) {
+    } elsif (@props) {
         $self->assert_str_equals('FALSE', $props[0]->value);
     }
 
@@ -126,7 +126,7 @@ sub create_jevent
     my $ug = Data::UUID->new;
     my $eventUid = $ug->create_str;
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['CalendarEvent/set', {
             create => {
                 $eventUid => {
@@ -182,6 +182,7 @@ sub assert_preserved_when_unchanged
     $self->assert_null($putetag);
 
     xlog $self, "Assert alarms via CalDAV";
+    my $getetag2;
     ($vcalendar, $vevent, $getetag2) = $self->caldav_get($eventHref);
     $self->assert_str_equals($getetag1, $getetag2);
     $self->assert_valarms($vevent,
@@ -224,6 +225,7 @@ sub assert_preserved_by_snooze_alarm
     $self->assert_null($putetag);
 
     xlog $self, "Assert alarms via CalDAV";
+    my $getetag2;
     ($vcalendar, $vevent, $getetag2) = $self->caldav_get($eventHref);
     my @wantUids = (($alarmUid), @{$self->{defaultAlertIds}});
     $self->assert_valarms($vevent,
@@ -263,6 +265,7 @@ sub assert_disabled_by_user_alarm
     $self->assert_null($putetag);
 
     xlog $self, "Assert alarms via CalDAV";
+    my $getetag2;
     ($vcalendar, $vevent, $getetag2) = $self->caldav_get($eventHref);
     my @wantUids = (($alarmUid), @{$self->{defaultAlertIds}});
     $self->assert_valarms($vevent,
@@ -303,6 +306,7 @@ sub assert_preserved_by_apple_alarm
     $self->assert_null($putetag);
 
     xlog $self, "Assert alarms via CalDAV";
+    my $getetag2;
     ($vcalendar, $vevent, $getetag2) = $self->caldav_get($eventHref);
     my @wantUids = (($alarmUid), @{$self->{defaultAlertIds}});
     $self->assert_valarms($vevent,
@@ -335,6 +339,7 @@ sub assert_disabled_by_removed_default_alarm
     $self->assert_null($putetag);
 
     xlog $self, "Assert alarms via CalDAV";
+    my $getetag2;
     ($vcalendar, $vevent, $getetag2) = $self->caldav_get($eventHref);
     $self->assert_valarms($vevent,
         useDefaultAlerts => 0, uids => [ $keptAlarmUid ],
@@ -366,6 +371,7 @@ sub assert_disabled_by_no_alarms
     $self->assert_null($putetag);
 
     xlog $self, "Assert alarms via CalDAV";
+    my $getetag2;
     ($vcalendar, $vevent, $getetag2) = $self->caldav_get($eventHref);
     $self->assert_valarms($vevent,
         useDefaultAlerts => 0,
@@ -413,6 +419,7 @@ sub assert_not_disabled_if_xheader_set
     $self->assert_null($putetag);
 
     xlog $self, "Assert alarms via CalDAV";
+    my $getetag2;
     ($vcalendar, $vevent, $getetag2) = $self->caldav_get($eventHref);
     $self->assert_valarms($vevent,
         useDefaultAlerts => 1,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_alert_acknowledged_far_future
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_alert_acknowledged_far_future
@@ -31,7 +31,7 @@ END:VCALENDAR
 EOF
     $caldav->Request('PUT', 'Default/test.ics', $ical, 'Content-Type' => 'text/calendar');
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         [ 'CalendarEvent/query', {}, 'R1' ],
         [
             'CalendarEvent/get',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_locations_dtend
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_locations_dtend
@@ -36,7 +36,7 @@ END:VCALENDAR
 EOF
     $caldav->Request('PUT', 'Default/test.ics', $ical, 'Content-Type' => 'text/calendar');
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         [ 'CalendarEvent/query', {}, 'R1' ],
         [
             'CalendarEvent/get',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_ignore_orphaned_ical_rows
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_ignore_orphaned_ical_rows
@@ -87,7 +87,7 @@ EOF
     });
 
     while (my ($rowid, $row) = each %{$ical_rows}) {
-        my @cols = (), @vals = ();
+        my (@cols, @vals);
         while (my($k, $v) = each %{$row}) {
             # make sure we insert in same order
             push(@cols, $k);
@@ -99,7 +99,7 @@ EOF
     }
 
     while (my ($rowid, $row) = each %{$jscal_rows}) {
-        my @cols = (), @vals = ();
+        my (@cols, @vals);
         while (my($k, $v) = each %{$row}) {
             # make sure we insert in same order
             push(@cols, $k);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_multiget_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_multiget_defaultalerts
@@ -28,7 +28,7 @@ sub test_calendarevent_multiget_defaultalerts
     $self->assert(exists $res->[0][1]{updated}{Default});
 
     xlog "Set default alert on calendar and personalized event";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
                 Default => {
@@ -96,7 +96,7 @@ sub test_calendarevent_multiget_defaultalerts
 EOF
 
     xlog "Run multiget";
-    $mgRes = $caldav->Request('REPORT', 'Default', $xmlMultiget,
+    my $mgRes = $caldav->Request('REPORT', 'Default', $xmlMultiget,
         'Content-Type' => 'application/xml',
     );
     my $icaldata = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{urn:ietf:params:xml:ns:caldav}calendar-data'}{content};
@@ -115,7 +115,7 @@ EOF
 EOF
 
     xlog "Run calendar query";
-    $qrRes = $caldav->Request('REPORT', 'Default', $xmlCalQuery,
+    my $qrRes = $caldav->Request('REPORT', 'Default', $xmlCalQuery,
         'Content-Type' => 'application/xml',
     );
     my $qrEtag = $qrRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{DAV:}getetag'}{content};
@@ -149,7 +149,7 @@ EOF
     $mgRes = $caldav->Request('REPORT', 'Default', $xmlMultiget,
         'Content-Type' => 'application/xml',
     );
-    my $icaldata = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{urn:ietf:params:xml:ns:caldav}calendar-data'}{content};
+    $icaldata = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{urn:ietf:params:xml:ns:caldav}calendar-data'}{content};
     $self->assert_matches(qr/TRIGGER:-PT15M/, $icaldata);
     my $newMgEtag = $mgRes->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]{'{DAV:}prop'}{'{DAV:}getetag'}{content};
     $self->assert_str_not_equals($mgEtag, $newMgEtag);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
@@ -186,9 +186,8 @@ EOF
 
     for my $tc (@testCases) {
         $tc->{ical} =~ s/\r?\n/\r\n/gs;
-
         my @properties = keys %{$tc->{wantParsed}};
-        push(@properties, @{$tc->{wantAlsoProperties}});
+        push(@properties, @{$tc->{wantAlsoProperties} || []});
 
         xlog $self, "Running test case: $tc->{desc}";
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_plusaddr
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_plusaddr
@@ -92,7 +92,7 @@ sub test_calendarevent_participantreply_plusaddr
 
     xlog $self, "verify reply sent from attendee to organizer";
     $data = $self->{instance}->getnotify();
-    @imips = grep { $_->{METHOD} eq 'imip' } @$data;
+    my @imips = grep { $_->{METHOD} eq 'imip' } @$data;
     $imip = $imips[0];
     $self->assert_not_null($imip);
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_simple
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_simple
@@ -186,7 +186,7 @@ sub test_calendarevent_participantreply_simple
         xlog $self, "verify that NO iMIP messages are sent to organizer/attendee";
         $data = $self->{instance}->getnotify();
         @imips = grep { $_->{METHOD} eq 'imip' } @$data;
-        $self->assert_null($imips);
+        $self->assert_null($imips[0]);
     }
 
     xlog $self, "set attendee status on override";
@@ -258,6 +258,6 @@ sub test_calendarevent_participantreply_simple
         xlog $self, "verify that NO iMIP messages are sent to organizer/attendee";
         $data = $self->{instance}->getnotify();
         @imips = grep { $_->{METHOD} eq 'imip' } @$data;
-        $self->assert_null($imips);
+        $self->assert_null($imips[0]);
     }
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_standalone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_standalone
@@ -145,6 +145,6 @@ sub test_calendarevent_participantreply_standalone
         xlog $self, "verify that NO iMIP messages are sent to organizer/attendee";
         $data = $self->{instance}->getnotify();
         @imips = grep { $_->{METHOD} eq 'imip' } @$data;
-        $self->assert_null($imips);
+        $self->assert_null($imips[0]);
     }
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
@@ -39,7 +39,7 @@ sub test_calendarevent_query
     );
 
     xlog $self, "create events";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['CalendarEvent/set', {
             create => {
                 eventA1 => {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_owner
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_owner
@@ -106,8 +106,8 @@ sub test_calendarevent_set_alerts_owner
         'calalarmd', '-t' => $now->epoch() + 60);
 
     xlog $self, "assert alarm is fired";
-    my $data = $self->{instance}->getnotify();
-    my @events;
+    $data = $self->{instance}->getnotify();
+    @events = ();
     foreach (@$data) {
         if ($_->{CLASS} eq 'EVENT') {
             my $e = decode_json($_->{MESSAGE});

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_etag
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_etag
@@ -10,7 +10,7 @@ sub test_calendarevent_set_defaultalerts_caldav_etag
     my $caldav = $self->{caldav};
 
     xlog "Update default alerts on calendar";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
                 Default => {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_xapple
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_xapple
@@ -10,7 +10,7 @@ sub test_calendarevent_set_defaultalerts_caldav_xapple
     my $caldav = $self->{caldav};
 
     xlog "Update default alerts on calendar";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
                 Default => {
@@ -56,7 +56,7 @@ sub test_calendarevent_set_defaultalerts_caldav_xapple
     xlog "Get event via CalDAV";
     $res = $caldav->Request('GET', $event1Href);
 
-    $ical = Data::ICal->new(data => $res->{content});
+    my $ical = Data::ICal->new(data => $res->{content});
     my $vevent = (grep { $_->ical_entry_type() eq 'VEVENT' } @{$ical->entries()})[0];
     $self->assert_not_null($vevent);
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_class
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_class
@@ -31,10 +31,10 @@ EOF
     $caldav->Request('PUT', '/dav/calendars/user/cassandane/Default/test.ics',
         $ical, 'Content-Type' => 'text/calendar');
 
-    $res = $caldav->Request('GET', '/dav/calendars/user/cassandane/Default/test.ics');
+    my $res = $caldav->Request('GET', '/dav/calendars/user/cassandane/Default/test.ics');
     $self->assert_matches(qr/CLASS:PRIVATE/, $res->{content});
 
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['CalendarEvent/query', {
         }, 'R1'],
     ]);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_icalxprops
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_icalxprops
@@ -64,8 +64,8 @@ EOF
     $self->assert_str_equals('x-mainevent-prop',
         $res->[0][1]{list}[0]{'cyrusimap.org:iCalProps'}[0][0]);
 
-    my @alarmIcalProps = sort { $_->[0] cmp $_->[1] } @{
-        $res->[0][1]{list}[0]{alerts
+    my @alarmIcalProps = sort { $a->[0] cmp $b->[0] } @{
+        $res->[0][1]{list}[0]{'alerts'
             }{'E576FA39-51B6-45FA-AAF3-7CCE1F21802E'
             }{'cyrusimap.org:iCalProps'}};
     $self->assert_num_equals(2, scalar @alarmIcalProps);
@@ -100,8 +100,8 @@ EOF
     $self->assert_str_equals('x-mainevent-prop',
         $res->[1][1]{list}[0]{'cyrusimap.org:iCalProps'}[0][0]);
 
-    my @alarmIcalProps = sort { $_->[0] cmp $_->[1] } @{
-        $res->[1][1]{list}[0]{alerts
+    @alarmIcalProps = sort { $a->[0] cmp $b->[0] } @{
+        $res->[1][1]{list}[0]{'alerts'
             }{'E576FA39-51B6-45FA-AAF3-7CCE1F21802E'
             }{'cyrusimap.org:iCalProps'}};
     $self->assert_num_equals(2, scalar @alarmIcalProps);
@@ -143,8 +143,8 @@ EOF
     $self->assert_str_equals('x-mainevent-prop',
         $res->[1][1]{list}[0]{'cyrusimap.org:iCalProps'}[0][0]);
 
-    my @alarmIcalProps = sort { $_->[0] cmp $_->[1] } @{
-        $res->[1][1]{list}[0]{alerts
+    @alarmIcalProps = sort { $a->[0] cmp $b->[0] } @{
+        $res->[1][1]{list}[0]{'alerts'
             }{'E576FA39-51B6-45FA-AAF3-7CCE1F21802E'
             }{'cyrusimap.org:iCalProps'}};
     $self->assert_num_equals(2, scalar @alarmIcalProps);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_non_iana_dtend_timezone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_non_iana_dtend_timezone
@@ -52,7 +52,7 @@ EOF
     $caldav->Request('PUT', 'Default/test.ics', $ical, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Assert timezone ids are mapped to IANA names";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         [ 'CalendarEvent/query', {}, 'R1' ],
         [
             'CalendarEvent/get',
@@ -102,14 +102,14 @@ EOF
     $self->assert(exists $res->[0][1]{updated}{$eventId});
 
     $self->assert_str_equals('Australia/Sydney', $res->[1][1]{list}[0]{timeZone});
-    my @locations = values %{ $res->[1][1]{list}[0]{locations} };
+    @locations = values %{ $res->[1][1]{list}[0]{locations} };
     $self->assert_deep_equals(
         \@locations,
         [ { '@type' => 'Location', timeZone => 'Asia/Singapore', relativeTo => 'end' } ]
     );
 
     $res = $caldav->Request('GET', 'Default/test.ics');
-    my $ical = Data::ICal->new(data => $res->{content});
+    $ical = Data::ICal->new(data => $res->{content});
 
     xlog "Assert non-IANA VTIMEZONEs are kept";
     my @timezoneTzIds = sort

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_request_add_participant
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_request_add_participant
@@ -68,7 +68,7 @@ sub test_calendarevent_set_schedule_request_add_participant
         $id => {
             'participants/att2' => {
                 '@type' => "Participant",
-                email => "rr@looneytunes.com",
+                email => 'rr@looneytunes.com',
                 expectReply => JSON::true,
                 kind => "individual",
                 participationStatus => "needs-action",

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_prune
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_prune
@@ -7,8 +7,8 @@ sub test_calendareventnotification_prune
     my ($self) = @_;
     my $jmap = $self->{jmap};
 
-    my $jmap_max_calendareventnotifs = $self->{instance}->{
-            config}->get('jmap_max_calendareventnotifs');
+    my $jmap_max_calendareventnotifs = $self->{instance}->{config}
+                                         ->get('jmap_max_calendareventnotifs');
     $self->assert_not_null($jmap_max_calendareventnotifs);
 
     my ($manJmap) = $self->create_user('manifold');
@@ -40,7 +40,7 @@ sub test_calendareventnotification_prune
     $self->assert(exists $res->[0][1]{updated}{Default});
 
     xlog $self, "Create event notification";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['CalendarEvent/set', {
             create => {
                 event1 => {
@@ -98,7 +98,7 @@ sub test_calendareventnotification_prune
     $self->assert_equals(1, scalar grep { $_->{id} eq $notif1Id } @{$res->[0][1]{list}});
 
     xlog $self, "Create one more event notification";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['CalendarEvent/set', {
             create => {
                 eventX => {

--- a/cassandane/tiny-tests/JMAPCalendars/itip_remove_privacy_property
+++ b/cassandane/tiny-tests/JMAPCalendars/itip_remove_privacy_property
@@ -82,7 +82,7 @@ EOF
 
     xlog $self, "Assert that iMIP message is sent";
     my $data = $self->{instance}->getnotify();
-    my ($imip) = grep { $_->{METHOD} eq 'imip' } @$data;
+    ($imip) = grep { $_->{METHOD} eq 'imip' } @$data;
     $self->assert_not_null($imip);
 
     xlog $self, "Assert privacy property is not present in iTIP REPLY";
@@ -91,7 +91,7 @@ EOF
 
     xlog $self, "Organizer updates invite with recurrence override";
 
-    my $imip = <<'EOF';
+    $imip = <<'EOF';
 Date: Thu, 23 Sep 2021 09:06:18 -0400
 From: Sally Sender <sender@example.net>
 To: Cassandane <cassandane@example.com>
@@ -137,7 +137,7 @@ EOF
     $self->{instance}->deliver(Cassandane::Message->new(raw => $imip));
 
     xlog $self, "Assert user-set privacy property is preserved";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['CalendarEvent/get', {
             ids => [$eventId],
             properties => ['id', 'privacy', 'recurrenceOverrides'],
@@ -146,6 +146,7 @@ EOF
     $self->assert_str_equals('secret', $res->[0][1]{list}[0]->{privacy});
 
     xlog $self, "Assert privacy property on override matches main event";
-    $self->assert_null($res->[0][1]{list}[0]->{
-        recurrenceOverrides}{'2021-09-24T15:30:00'}{privacy});
+    $self->assert_null(
+      $res->[0][1]{list}[0]->{recurrenceOverrides}{'2021-09-24T15:30:00'}{privacy}
+    );
 }

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_destroy_contents
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_destroy_contents
@@ -28,7 +28,7 @@ EOF
     my $cardId = basename($carddav->NewContact($abookId, $VCard), '.vcf');
 
     xlog "Destroy addressbook (with and without onDestroyRemoveContents)";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['AddressBook/set', {
             destroy => [$abookId],
         }, 'R1'],

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_sharewith
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_sharewith
@@ -69,7 +69,7 @@ sub test_addressbook_set_sharewith
     );
 
     xlog $self, "sharee gives third user access to shared addressbook";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
             ['AddressBook/set', {
                     accountId => 'master',
                     update => { "$AddressBookId" => {
@@ -89,8 +89,8 @@ sub test_addressbook_set_sharewith
     $self->assert_not_null($res->[0][1]{updated});
 
     xlog $self, "check ACL on JMAP upload folder";
-    $acl = $admintalk->getacl("user.master.#jmap");
-    %map = @$acl;
+    my $acl = $admintalk->getacl("user.master.#jmap");
+    my %map = @$acl;
     $self->assert_str_equals('lrswitedn', $map{cassandane});
     $self->assert_str_equals('lrw', $map{manifold});
     $self->assert_str_equals('lrswitedn', $map{paraphrase});

--- a/cassandane/tiny-tests/JMAPContacts/card_copy
+++ b/cassandane/tiny-tests/JMAPContacts/card_copy
@@ -218,7 +218,7 @@ return;
         }, 'R2'],
     ]);
     $self->assert_str_equals('foo', $res->[0][1]{list}[0]{firstName});
-    $blob = $jmap->Download({ accept => 'image/jpeg' },
+    my $blob = $jmap->Download({ accept => 'image/jpeg' },
                                'other3', $res->[0][1]{list}[0]{avatar}{blobId});
     $self->assert_str_equals('image/jpeg',
                              $blob->{headers}->{'content-type'});

--- a/cassandane/tiny-tests/JMAPContacts/card_copy_state
+++ b/cassandane/tiny-tests/JMAPContacts/card_copy_state
@@ -33,7 +33,7 @@ sub test_card_copy_state
     };
 
     xlog $self, "create card";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['ContactCard/set', {
             create => {"1" => $card}
          }, "R1"],

--- a/cassandane/tiny-tests/JMAPContacts/card_parse
+++ b/cassandane/tiny-tests/JMAPContacts/card_parse
@@ -41,7 +41,7 @@ EOF
     my $res = $jmap->Upload($card, "text/vcard");
     my $blobId = $res->{blobId};
 
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['ContactCard/parse', {
             blobIds => [ $blobId ],
             properties => [ "\@type", "uid", "name", "media", "vCardProps" ]

--- a/cassandane/tiny-tests/JMAPContacts/card_parse_disable_uri_as_blobid
+++ b/cassandane/tiny-tests/JMAPContacts/card_parse_disable_uri_as_blobid
@@ -23,7 +23,7 @@ EOF
     my $blobId = $data->{blobId};
     $self->assert_not_null($blobId);
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['ContactCard/parse', {
             blobIds => [$blobId],
         }, 'R1'],
@@ -33,13 +33,17 @@ EOF
         }, 'R2'],
     ]);
 
-    $self->assert_not_null($res->[0][1]{parsed}{$blobId}{
-        media}{photo1}{blobId});
-    $self->assert_null($res->[0][1]{parsed}{$blobId}{
-        media}{photo1}{uri});
+    $self->assert_not_null(
+      $res->[0][1]{parsed}{$blobId}{media}{photo1}{blobId}
+    );
+    $self->assert_null(
+      $res->[0][1]{parsed}{$blobId}{media}{photo1}{uri}
+    );
 
-    $self->assert_null($res->[1][1]{parsed}{$blobId}{
-        media}{photo1}{blobId});
-    $self->assert_not_null($res->[1][1]{parsed}{$blobId}{
-        media}{photo1}{uri});
+    $self->assert_null(
+      $res->[1][1]{parsed}{$blobId}{media}{photo1}{blobId}
+    );
+    $self->assert_not_null(
+      $res->[1][1]{parsed}{$blobId}{media}{photo1}{uri}
+    );
 }

--- a/cassandane/tiny-tests/JMAPContacts/card_set_create_basic
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_create_basic
@@ -34,7 +34,7 @@ sub test_card_set_create_basic
     my $name = 'Mr. John Q. Public, Esq.';
     my $id = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
 
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['ContactCard/set', {
             create => {
                 "1" => {

--- a/cassandane/tiny-tests/JMAPContacts/card_set_create_name_unknown_prop
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_create_name_unknown_prop
@@ -34,7 +34,7 @@ sub test_card_set_create_name_unknown_prop
                             {
                                 kind => 'given',
                                 value => 'Robert',
-                                foo => bar
+                                foo => 'bar',
                             },
                             {
                                 kind => 'given2',

--- a/cassandane/tiny-tests/JMAPContacts/card_set_state
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_state
@@ -27,7 +27,7 @@ sub test_card_set_state
     $self->assert_not_null($res);
     $self->assert_str_equals('ContactCard/set', $res->[0][0]);
     $self->assert_str_equals('R1', $res->[0][2]);
-    my $id = $res->[0][1]{created}{"1"}{id};
+    $id = $res->[0][1]{created}{"1"}{id};
     my $state = $res->[0][1]{newState};
 
     xlog $self, "get contact $id";

--- a/cassandane/tiny-tests/JMAPContacts/card_set_uid_text
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_uid_text
@@ -18,7 +18,7 @@ sub test_card_set_uid_text
 
     my $id = 'e2640cc234ad93b9@example.com';
 
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['ContactCard/set', {
             create => {
                 "1" => {

--- a/cassandane/tiny-tests/JMAPContacts/card_set_update
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_update
@@ -134,7 +134,7 @@ sub test_card_set_update
     ]);
 
     my $abookid = $res->[0][1]{created}{"1"}{id};
-    my $href = "$abookid/$id.vcf";
+    $href = "$abookid/$id.vcf";
 
     $res = $jmap->CallMethods([
         ['ContactCard/set', {

--- a/cassandane/tiny-tests/JMAPContacts/card_set_update_media_blob
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_update_media_blob
@@ -54,7 +54,7 @@ sub test_card_set_update_media_blob
     $self->assert_does_not_match(qr|JSPROP|, $card);
 
     xlog $self, "upload photo";
-    my $res = $jmap->Upload("some photo", "image/jpeg");
+    $res = $jmap->Upload("some photo", "image/jpeg");
     my $blobId = $res->{blobId};
 
     $res = $jmap->CallMethods([
@@ -74,7 +74,7 @@ sub test_card_set_update_media_blob
     $res = $carddav->Request('GET', $href, '',
                              'Accept' => 'text/vcard; version=4.0');
 
-    my $card = $res->{content};
+    $card = $res->{content};
     $card =~ s/\r?\n[ \t]+//gs;  # unfold long properties
 
     $self->assert_matches(qr|PHOTO;PROP-ID=res1:data:image/jpeg;base64,c29tZSBwaG90bw==|, $card);

--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_set_update
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_set_update
@@ -67,7 +67,7 @@ sub test_cardgroup_set_update
     $res = $carddav->Request('GET', $href, '',
                              'Accept' => 'text/vcard; version=4.0');
 
-    my $card = $res->{content};
+    $card = $res->{content};
     $card =~ s/\r?\n[ \t]+//gs;  # unfold long properties
 
     $self->assert_matches(qr/MEMBER:$member2/, $card);

--- a/cassandane/tiny-tests/JMAPContacts/contact_copy_state
+++ b/cassandane/tiny-tests/JMAPContacts/contact_copy_state
@@ -33,7 +33,7 @@ sub test_contact_copy_state
     };
 
     xlog $self, "create card";
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Contact/set', {
             create => {"1" => $card}
          }, "R1"],

--- a/cassandane/tiny-tests/JMAPEmail/email_copy
+++ b/cassandane/tiny-tests/JMAPEmail/email_copy
@@ -154,7 +154,7 @@ sub test_email_copy
         }, 'R1']
     ]);
 
-    my $wantKeywords = { 'bar' => JSON::true };
+    $wantKeywords = { 'bar' => JSON::true };
     $self->assert_deep_equals($wantKeywords, $res->[0][1]{list}[0]{keywords});
     $self->assert_str_equals($receivedAt, $res->[0][1]{list}[0]{receivedAt});
 

--- a/cassandane/tiny-tests/JMAPEmail/email_copy_snoozed
+++ b/cassandane/tiny-tests/JMAPEmail/email_copy_snoozed
@@ -43,7 +43,7 @@ sub test_email_copy_snoozed
     my $datestr = $maildate->strftime('%Y-%m-%dT%TZ');
 
     xlog $self, "create snoozed email";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Email/set', {
             create => {
                 1 => {

--- a/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_crlf
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_crlf
@@ -26,7 +26,7 @@ EOF
     $mimeMsg =~ s/\r\n$//;
     $imap->append('INBOX', $mimeMsg) || die $@;
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Email/query', { }, 'R1'],
         ['Email/get', {
             '#ids' => {

--- a/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_nulbyte
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_nulbyte
@@ -24,7 +24,7 @@ EOF
     $mimeMsg =~ s/\r\n$//;
     $imap->append('INBOX', $mimeMsg) || die $@;
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Email/query', { }, 'R1'],
         ['Email/get', {
             '#ids' => {

--- a/cassandane/tiny-tests/JMAPEmail/email_get_createdmodseq
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_createdmodseq
@@ -10,7 +10,7 @@ sub test_email_get_createdmodseq
     $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
 
     xlog $self, "Append duplicate messages";
-    $mimeMessage = <<'EOF';
+    my $mimeMessage = <<'EOF';
 From: <from@local>
 To: to@local
 Subject: test
@@ -25,7 +25,7 @@ EOF
     $imap->append('INBOX', '17-Aug-2023 15:13:54 +0200', $mimeMessage) || die $@;
 
     $imap->select('INBOX');
-    $fetch = $imap->fetch('1:2', ['INTERNALDATE', 'CREATEDMODSEQ']);
+    my $fetch = $imap->fetch('1:2', ['INTERNALDATE', 'CREATEDMODSEQ']);
     $self->assert_str_equals(
         $fetch->{1}{internaldate}, $fetch->{2}{internaldate}
     );
@@ -34,7 +34,7 @@ EOF
     );
 
     # The createdModseq must be the lower modseq.
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Email/query', { }, "R1"],
         ['Email/get', {
             '#ids' => {

--- a/cassandane/tiny-tests/JMAPEmail/email_get_header_nfc
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_header_nfc
@@ -41,7 +41,7 @@ EOF
     $msg->set_lines(split /\n/, $mime);
     $self->{instance}->deliver($msg);
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Email/query', { }, 'R1'],
         ['Email/get', {
             '#ids' => {

--- a/cassandane/tiny-tests/JMAPEmail/email_import_received_at
+++ b/cassandane/tiny-tests/JMAPEmail/email_import_received_at
@@ -27,7 +27,7 @@ sub test_email_import_received_at
                    "Received: from foo ([192.168.0.1]) by bar (Baz); Mon, 15 Aug 2022 07:49:01 -0400\r\n",
         wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-08-15T11:49:01Z',
-        skipVersionBefore => qw(3,7),
+        skipVersionBefore => [3,7],
     }, {
         desc => 'receivedAt from first Received header',
         headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n" .
@@ -36,13 +36,13 @@ sub test_email_import_received_at
                    "Received: from rcv3 ([192.168.0.3]) by baz (Hkl); Tue, 16 Aug 2022 13:01:10 -0200\r\n",
         wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-08-15T11:49:01Z',
-        skipVersionBefore => qw(3,7),
+        skipVersionBefore => [3,7],
     }, {
         desc => 'receivedAt from Date header',
         headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n",
         wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2021-12-31T14:00:00Z',
-        skipVersionBefore => qw(3,7),
+        skipVersionBefore => [3,7],
     }, {
         desc => 'not set',
         wantSentAt => undef,
@@ -55,7 +55,7 @@ sub test_email_import_received_at
                    "Received: from rcv3 ([192.168.0.3]) by baz (Hkl); Sat, 13 Aug 2022 12:00:45 -0200\r\n",
         wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-08-13T14:01:10Z',
-        skipVersionBefore => qw(3,9),
+        skipVersionBefore => [3,9],
     }, {
         desc => 'receivedAt from X-DeliveredInternalDate header',
         headers => "Date: Sat, 1 Jan 2022 01:00:00 +1100\r\n" .
@@ -65,12 +65,13 @@ sub test_email_import_received_at
                    ,
         wantSentAt => '2022-01-01T01:00:00+11:00',
         wantReceivedAt => '2022-08-15T15:00:45Z',
-        skipVersionBefore => qw(3,9),
+        skipVersionBefore => [3,9],
     });
 
     while (my ($i, $tc) = each @testCases) {
 
-        my ($needMaj, $needMin) = $tc->{skipVersionBefore} || qw(0,0);
+        my $skipVersionBefore = $tc->{skipVersionBefore} || [0,0];
+        my ($needMaj, $needMin) = @{$skipVersionBefore};
         if ($maj < $needMaj || ($maj == $needMaj && $min < $needMin)) {
             xlog "maj=$maj needMaj=$needMaj min=$min needMin=$needMin";
             xlog $self, "Skipping test $tc->{creationId}";

--- a/cassandane/tiny-tests/JMAPEmail/email_parse_inmemory_blob
+++ b/cassandane/tiny-tests/JMAPEmail/email_parse_inmemory_blob
@@ -26,7 +26,7 @@ EOF
     # XXX: can't use a result reference in array
     my $blobId = 'G67501cd2e1eaaf65d25e6f3b49554d2193f06ee8';
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Blob/upload', {
             create => {
                 b1 => {

--- a/cassandane/tiny-tests/JMAPEmail/email_query_cjk_fullwidth
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_cjk_fullwidth
@@ -17,7 +17,7 @@ use utf8;
                     },
                     from => [{ email => 'foo@local' }],
                     to => [{ email => 'bar@local' }],
-                    subject => $_->{id},
+                    subject => "some subject",
                     bodyStructure => {
                         type => 'text/plain',
                         partId => 'part1',

--- a/cassandane/tiny-tests/JMAPEmail/email_query_cjk_fullwidth
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_cjk_fullwidth
@@ -39,7 +39,7 @@ EOF
     xlog $self, "run squatter";
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
 
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Email/query', {
             filter => {
                 body => "ＵＦＪ",

--- a/cassandane/tiny-tests/JMAPEmail/email_query_empty_filter_conds
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_empty_filter_conds
@@ -38,7 +38,7 @@ sub test_email_query_empty_filter_conds
                 conditions => [],
             },
         }, 'R3'],
-    ], $using);
+    ]);
 
     $self->assert_num_equals(0, scalar @{$res->[0][1]{ids}});
     $self->assert_num_equals(1, scalar @{$res->[1][1]{ids}});

--- a/cassandane/tiny-tests/JMAPEmail/email_query_messageid
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_messageid
@@ -36,7 +36,7 @@ EOF
     my $emailId = $res->[0][1]{ids}[0];
     $self->assert_not_null($emailId);
 
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         [
             'Email/query',
             {

--- a/cassandane/tiny-tests/JMAPEmail/email_query_no_guidsearch_ignore_jmapuploads
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_no_guidsearch_ignore_jmapuploads
@@ -21,7 +21,7 @@ sub test_email_query_no_guidsearch_ignore_jmapuploads
     xlog $self, "Create Trash mailbox";
     $imap->create("Trash", "(USE (\\Trash))") || die;
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Mailbox/query', {
             sort => [{
                 property => 'name',

--- a/cassandane/tiny-tests/JMAPEmail/email_query_references_inreplyto
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_references_inreplyto
@@ -61,7 +61,7 @@ sub test_email_query_references_inreplyto
     xlog $self, "run squatter";
     $self->{instance}->run_command({ cyrus => 1 }, 'squatter');
 
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         [
             'Email/query',
             {
@@ -140,7 +140,7 @@ if
 EOF
     );
 
-    $mime = <<'EOF';
+    my $mime = <<'EOF';
 From: foo@local
 To: bar@local
 Message-Id: <091e0683cc1a@example.com>

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword
@@ -65,7 +65,7 @@ EOF
     $self->assert_num_equals(0, $imap->message_count('matches'));
 
     xlog $self, "Set flag on message in second conversation split";
-    my $res = $imap->store($convMaxthread + 1, '+flags', '($IsMailingList)');
+    $res = $imap->store($convMaxthread + 1, '+flags', '($IsMailingList)');
 
     xlog $self, "Deliver message for conversation";
     $msg->remove_headers('Message-Id');

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword_utf8_subject
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sieve_some_in_thread_have_keyword_utf8_subject
@@ -59,7 +59,7 @@ EOF
     $self->assert(exists $res->[0][1]{updated}{$emailId});
 
     xlog $self, "Deliver reply with encoded UTF-8 subject";
-    my $mime = <<'EOF';
+    $mime = <<'EOF';
 From: bob@local
 To: alic@local
 Subject: =?utf-8?q?Re:_=C2=A1Hola,_se=C3=B1or!?=

--- a/cassandane/tiny-tests/JMAPEmail/email_query_utf8punct_term
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_utf8punct_term
@@ -66,7 +66,7 @@ EOF
     $self->{instance}->install_sieve_script(<<"EOF"
 require ["x-cyrus-jmapquery", "x-cyrus-log", "variables", "fileinto"];
 if
-  allof( not string :is "${stop}" "Y",
+  allof( not string :is "\${stop}" "Y",
     jmapquery text:
   $filterAsStr
 .

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_encoding
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_encoding
@@ -146,14 +146,14 @@ sub test_email_set_create_encoding
         wantContentType => 'text/plain; charset=utf-8',
     }, {
         desc => 'text/plain with multi-byte UTF-8 and no charset',
-        blob => "$ to \xc2\xa3",
+        blob => "\$ to \xc2\xa3",
         bodyStructure => {
             type => 'text/plain',
         },
         wantInvalidProperties => ['bodyStructure/charset'],
     }, {
         desc => 'text/plain with multi-byte UTF-8 and us-ascii charset',
-        blob => "$ to \xc2\xa3",
+        blob => "\$ to \xc2\xa3",
         bodyStructure => {
             type => 'text/plain',
             charset => 'us-ascii',
@@ -161,7 +161,7 @@ sub test_email_set_create_encoding
         wantInvalidProperties => ['bodyStructure/charset'],
     }, {
         desc => 'text/plain with multi-byte UTF-8 as attachment',
-        blob => "$ to \xc2\xa3",
+        blob => "\$ to \xc2\xa3",
         bodyStructure => {
             type => 'text/plain',
             disposition => 'attachment',
@@ -170,7 +170,7 @@ sub test_email_set_create_encoding
         wantContentType => 'text/plain',
     }, {
         desc => 'text/plain with multi-byte UTF-8 and utf-8 charset',
-        blob => "$ to \xc2\xa3",
+        blob => "\$ to \xc2\xa3",
         bodyStructure => {
             type => 'text/plain',
             charset => 'utf-8',
@@ -689,8 +689,9 @@ sub test_email_set_create_encoding
                 }, $jmapResponses{createEmail}{notCreated}{$emailCreationId});
         } else {
             my $jres = $jmapResponses{createEmail};
-            $self->assert_not_null($jmapResponses{createEmail}{
-                created}{$emailCreationId});
+            $self->assert_not_null(
+              $jmapResponses{createEmail}{created}{$emailCreationId}
+            );
 
             xlog $self, "Assert expected encoding and content type";
             my $gotBodyPart = $jmapResponses{getEmail}{list}[0]{bodyStructure};
@@ -731,8 +732,8 @@ sub test_email_set_create_encoding
                     invalidProperties => clone($tc->{wantInvalidProperties}),
                 };
             } else {
-                my $emailBlobId = $jmapResponses{createEmail}{
-                    created}{$emailCreationId}{blobId};
+                my $emailBlobId = $jmapResponses{createEmail}
+                                   {created}{$emailCreationId}{blobId};
                 my $res = $jmap->Download('cassandane', $emailBlobId);
                 $mimeTest->{want} = {
                     mimeMessage => encode_base64($res->{content}, "")

--- a/cassandane/tiny-tests/JMAPEmail/email_set_header_nfc
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_header_nfc
@@ -24,7 +24,7 @@ sub test_email_set_header_nfc
     my $nonNfcXHeaderValue =       "0.5\N{U+212B}";
     my $normalizedXHeaderValue =   "0.5\N{U+00C5}";
 
-    $res = $jmap->CallMethods([
+    my $res = $jmap->CallMethods([
         ['Email/set', {
             create => {
                 email => {

--- a/cassandane/tiny-tests/JMAPQuota/quota-changes
+++ b/cassandane/tiny-tests/JMAPQuota/quota-changes
@@ -65,7 +65,7 @@ sub test_quota_changes
     $state = $res->[0][1]{'newState'};
 
     xlog "Get all calendars (to create #calendars mailbox) ";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Calendar/get', {
          }, "R1"]]);
     $self->assert_not_null($res);

--- a/cassandane/tiny-tests/JMAPQuota/quota-get
+++ b/cassandane/tiny-tests/JMAPQuota/quota-get
@@ -24,7 +24,7 @@ EOF
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
 
     xlog "Get all calendars (to create #calendars mailbox) ";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Calendar/get', {
          }, "R1"]]);
     $self->assert_not_null($res);
@@ -48,7 +48,7 @@ EOF
     );
 
     xlog "Get all quotas";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Quota/get', {
          }, "R1"]]);
     $self->assert_not_null($res);

--- a/cassandane/tiny-tests/JMAPQuota/quota-query
+++ b/cassandane/tiny-tests/JMAPQuota/quota-query
@@ -24,7 +24,7 @@ EOF
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
 
     xlog "Get all calendars (to create #calendars mailbox) ";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Calendar/get', {
          }, "R1"]]);
     $self->assert_not_null($res);
@@ -65,7 +65,7 @@ EOF
         }}, "R1"]]);
 
     xlog "Get all quotas";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['Quota/get', {
          }, "R1"]]);
     $self->assert_not_null($res);

--- a/cassandane/tiny-tests/Sieve/implicit_keep_target_none
+++ b/cassandane/tiny-tests/Sieve/implicit_keep_target_none
@@ -15,7 +15,7 @@ sub test_implicit_keep_target_none
 
     xlog $self, "Allow plus address delivery";
     $imaptalk->setacl($folder, 'anyone' => 'p');
-    my $imaptalk = $self->{store}->get_client();
+    $imaptalk = $self->{store}->get_client();
 
     xlog $self, "Install a script";
     $self->{instance}->install_sieve_script(<<EOF

--- a/cassandane/tiny-tests/Sieve/unicode_casemap
+++ b/cassandane/tiny-tests/Sieve/unicode_casemap
@@ -22,7 +22,7 @@ sub test_unicode_casemap
     $imaptalk->create($contains)
          or die "Cannot create $contains: $@";
     $imaptalk->create($matches)
-         or die "Cannot create $match: $@";
+         or die "Cannot create $matches: $@";
     $imaptalk->create($regex)
          or die "Cannot create $regex: $@";
 

--- a/cassandane/tiny-tests/UIDonly/expunge
+++ b/cassandane/tiny-tests/UIDonly/expunge
@@ -24,7 +24,7 @@ sub test_expunge
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
     xlog $self, "ENABLE UIDONLY";
-    $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
+    my $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
     $self->assert_num_equals(1, $res->{uidonly});
 
     xlog $self, "EXPUNGE";

--- a/cassandane/tiny-tests/UIDonly/search
+++ b/cassandane/tiny-tests/UIDonly/search
@@ -24,7 +24,7 @@ sub test_search
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
     xlog $self, "SEARCH";
-    $res = $imaptalk->search('not', 'deleted');
+    my $res = $imaptalk->search('not', 'deleted');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $self->assert_num_equals(8, scalar @{$res});
     $self->assert_num_equals(2, $res->[0]);

--- a/cassandane/tiny-tests/UIDonly/store
+++ b/cassandane/tiny-tests/UIDonly/store
@@ -20,7 +20,7 @@ sub test_store
     $self->check_messages(\%exp);
 
     xlog $self, "ENABLE UIDONLY & CONDSTORE";
-    $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY', 'CONDSTORE');
+    my $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY', 'CONDSTORE');
     $self->assert_num_equals(1, $res->{uidonly});
     $self->assert_num_equals(1, $res->{condstore});
 


### PR DESCRIPTION
This way any tiny test gets them by default, avoiding mistakes like forgetting to declare variables, etc...