### PR TITLE
docs: stop mentioning Travis CI

### DIFF
--- a/docsrc/imap/developer/cyrusworks.rst
+++ b/docsrc/imap/developer/cyrusworks.rst
@@ -5,13 +5,12 @@ Cyrus Works
 About Cyrus Works
 =================
 
-`Cyrus Works <https://cyrus.works>`_ is a domain redirection to the Cyrus
-IMAP project's Travis CI dashboard.
+`Cyrus Works <https://cyrus.works>`_ is a domain redirection to the Cyrus IMAP
+project's GitHub Actions dashboard.
 
-Whenever the Cyrus team push changes to
-`the project repository <https://github.com/cyrusimap/>`_, Travis CI
-(via github integration) automatically builds the new commits.  This also
-applies to pull requests submitted through the GitHub site.
+Whenever the Cyrus team push changes to `the project repository
+<https://github.com/cyrusimap/>`_, GitHub Actions automatically build the new
+commits.  This also applies to pull requests submitted through the GitHub site.
 
 How it works
 ============


### PR DESCRIPTION
We no longer use Travis, we use GitHub Actions.