### PR TITLE
assert: log message before aborting

### DIFF
--- a/lib/assert.c
+++ b/lib/assert.c
@@ -43,6 +43,7 @@
 #include <config.h>
 #include <stdio.h>
 #include <sysexits.h>
+#include <syslog.h>
 
 #include "xmalloc.h"
 #include "assert.h"
@@ -54,8 +55,16 @@ assertionfailed(const char *file, int line, const char *expr)
 {
     char buf[1024];
 
-    snprintf(buf, sizeof(buf), "Internal error: assertion failed: %s: %d%s%s",
-            file, line, expr ? ": " : "", expr ? expr : "");
-    if (config_fatals_abort) abort();
+    snprintf(buf, sizeof(buf), "Internal error: assertion failed%s: %s: %d%s%s",
+             config_fatals_abort ? " (aborting)" : "",
+             file, line, expr ? ": " : "", expr ? expr : "");
+
+    if (config_fatals_abort) {
+        /* usually the program's fatal function is responsible for handling
+         * the error message, but if we're aborting it won't get called
+         */
+        syslog(LOG_ERR, "%s", buf);
+        abort();
+    }
     fatal(buf, EX_SOFTWARE);
 }


### PR DESCRIPTION
If we're configured to abort on fatal errors, log the assertion failure message before calling abort so that the message doesn't get lost.

Requested by @lerlacher-fm 