### PR TITLE
shut_down() the service if TLS negotiation fails

### DIFF
--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1311,13 +1311,15 @@ static void starttls(struct http_connection *conn, int timeout)
 
     /* if error */
     if (result == -1) {
-        fatal("Error negotiating TLS", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "Error negotiating TLS");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&saslprops, httpd_saslconn);
     if (result != SASL_OK) {
-        fatal("saslprops_set_tls() failed", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -9349,14 +9349,8 @@ static void cmd_starttls(char *tag, int imaps)
 
     /* if error */
     if (result==-1) {
-        if (imaps == 0) {
-            prot_printf(imapd_out, "%s NO Starttls negotiation failed\r\n", tag);
-            syslog(LOG_NOTICE, "STARTTLS negotiation failed: %s", imapd_clienthost);
-            return;
-        } else {
-            syslog(LOG_NOTICE, "imaps TLS negotiation failed: %s", imapd_clienthost);
-            shut_down(0);
-        }
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", imapd_clienthost);
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell SASL about the negotiated layer */
@@ -9364,11 +9358,7 @@ static void cmd_starttls(char *tag, int imaps)
 
     if (result != SASL_OK) {
         syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
-        if (imaps == 0) {
-            fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
-        } else {
-            shut_down(0);
-        }
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -1463,15 +1463,16 @@ void lmtpmode(struct lmtp_func *func,
 
                 /* if error */
                 if (r==-1) {
-                    prot_printf(pout, "454 4.3.3 STARTTLS failed\r\n");
-                    syslog(LOG_NOTICE, "[lmtpd] STARTTLS failed: %s", cd.clienthost);
-                    continue;
+                    syslog(LOG_NOTICE,
+                           "TLS negotiation failed: %s", cd.clienthost);
+                    func->shutdown(EX_TEMPFAIL);
                 }
 
                 /* tell SASL about the negotiated layer */
                 r = saslprops_set_tls(&saslprops, cd.conn);
                 if (r != SASL_OK) {
-                    fatal("saslprops_set_tls() failed: STARTTLS", EX_TEMPFAIL);
+                    syslog(LOG_NOTICE, "saslprops_set_tls() failed: STARTTLS");
+                    func->shutdown(EX_TEMPFAIL);
                 }
                 if (buf_len(&saslprops.authid)) {
                     cd.authenticated = TLSCERT_AUTHED;

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1997,17 +1997,15 @@ static void cmd_starttls(struct conn *C, const char *tag)
 
     /* if error */
     if (result==-1) {
-        prot_printf(C->pout, "%s NO Starttls negotiation failed\r\n",
-                    tag);
-        syslog(LOG_NOTICE, "STARTTLS negotiation failed: %s",
-               C->clienthost);
-        return;
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", C->clienthost);
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&C->saslprops, C->saslconn);
     if (result != SASL_OK) {
-        fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -4057,25 +4057,15 @@ static void cmd_starttls(int nntps)
 
     /* if error */
     if (result == -1) {
-        if (nntps == 0) {
-            prot_printf(nntp_out, "580 Starttls failed\r\n");
-            syslog(LOG_NOTICE, "[nntpd] STARTTLS failed: %s", nntp_clienthost);
-            return;
-        } else {
-            syslog(LOG_NOTICE, "nntps failed: %s", nntp_clienthost);
-            shut_down(0);
-        }
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", nntp_clienthost);
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&saslprops, nntp_saslconn);
     if (result != SASL_OK) {
         syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
-        if (nntps == 0) {
-            fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
-        } else {
-            shut_down(0);
-        }
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -857,15 +857,15 @@ static void cmd_starttls(void)
 
     /* if error */
     if (result==-1) {
-        prot_printf(sync_out, "NO Starttls failed\r\n");
-        syslog(LOG_NOTICE, "STARTTLS failed: %s", sync_clienthost);
-        return;
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", sync_clienthost);
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&saslprops, sync_saslconn);
     if (result != SASL_OK) {
-        fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -93,6 +93,7 @@ static SSL *tls_conn = NULL;
 extern int sieved_timeout;
 
 /* from elsewhere */
+void shut_down(int code) __attribute__ ((noreturn));
 void fatal(const char *s, int code) __attribute__((noreturn));
 extern int sieved_logfd;
 extern struct backend *backend;
@@ -965,16 +966,16 @@ static int cmd_starttls(struct protstream *sieved_out,
 
     /* if error */
     if (result==-1) {
-        prot_printf(sieved_out, "NO \"Starttls failed\"\r\n");
-        syslog(LOG_NOTICE, "STARTTLS failed: %s", sieved_clienthost);
-        return TIMSIEVE_FAIL;
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", sieved_clienthost);
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(saslprops, sieved_saslconn);
 
     if (result != SASL_OK) {
-        fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */


### PR DESCRIPTION
sending a cleartext response to the client on failure is nonsense