### PR TITLE
shut_down() the service if TLS negotiation fails

### DIFF
--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -374,7 +374,7 @@ sub test_connection_setup_failure_imapd
             $store->get_client();
         };
         my $error = $@;
-        $self->assert_matches(qr{Connection closed by other end}, $error);
+        $self->assert_not_null($error);
     }
 
     # wait a bit for the prometheus report to refresh
@@ -412,11 +412,10 @@ sub test_connection_setup_failure_imapd
     # should not have had any successful connections to imaps
     $self->assert(not exists $total->{$service_label});
 
-    # should be $badconn shutdowns counted (imapd treats this condition
-    # as an ok shutdown, not an error)
+    # should be $badconns error shutdowns counted
     $self->assert_num_equals(
         $badconns,
-        $shutdown->{"$service_label,status=\"ok\""}->{value}
+        $shutdown->{"$service_label,status=\"error\""}->{value}
     );
 
     # XXX someday: expect to find $badconns setup failures counted

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1311,13 +1311,15 @@ static void starttls(struct http_connection *conn, int timeout)
 
     /* if error */
     if (result == -1) {
-        fatal("Error negotiating TLS", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "Error negotiating TLS");
+        shut_down(EX_PROTOCOL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&saslprops, httpd_saslconn);
     if (result != SASL_OK) {
-        fatal("saslprops_set_tls() failed", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -9349,14 +9349,8 @@ static void cmd_starttls(char *tag, int imaps)
 
     /* if error */
     if (result==-1) {
-        if (imaps == 0) {
-            prot_printf(imapd_out, "%s NO Starttls negotiation failed\r\n", tag);
-            syslog(LOG_NOTICE, "STARTTLS negotiation failed: %s", imapd_clienthost);
-            return;
-        } else {
-            syslog(LOG_NOTICE, "imaps TLS negotiation failed: %s", imapd_clienthost);
-            shut_down(0);
-        }
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", imapd_clienthost);
+        shut_down(EX_PROTOCOL);
     }
 
     /* tell SASL about the negotiated layer */
@@ -9364,11 +9358,7 @@ static void cmd_starttls(char *tag, int imaps)
 
     if (result != SASL_OK) {
         syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
-        if (imaps == 0) {
-            fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
-        } else {
-            shut_down(0);
-        }
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -1463,15 +1463,16 @@ void lmtpmode(struct lmtp_func *func,
 
                 /* if error */
                 if (r==-1) {
-                    prot_printf(pout, "454 4.3.3 STARTTLS failed\r\n");
-                    syslog(LOG_NOTICE, "[lmtpd] STARTTLS failed: %s", cd.clienthost);
-                    continue;
+                    syslog(LOG_NOTICE,
+                           "TLS negotiation failed: %s", cd.clienthost);
+                    func->shutdown(EX_PROTOCOL);
                 }
 
                 /* tell SASL about the negotiated layer */
                 r = saslprops_set_tls(&saslprops, cd.conn);
                 if (r != SASL_OK) {
-                    fatal("saslprops_set_tls() failed: STARTTLS", EX_TEMPFAIL);
+                    syslog(LOG_NOTICE, "saslprops_set_tls() failed: STARTTLS");
+                    func->shutdown(EX_TEMPFAIL);
                 }
                 if (buf_len(&saslprops.authid)) {
                     cd.authenticated = TLSCERT_AUTHED;

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1997,17 +1997,15 @@ static void cmd_starttls(struct conn *C, const char *tag)
 
     /* if error */
     if (result==-1) {
-        prot_printf(C->pout, "%s NO Starttls negotiation failed\r\n",
-                    tag);
-        syslog(LOG_NOTICE, "STARTTLS negotiation failed: %s",
-               C->clienthost);
-        return;
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", C->clienthost);
+        shut_down(EX_PROTOCOL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&C->saslprops, C->saslconn);
     if (result != SASL_OK) {
-        fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -4057,25 +4057,15 @@ static void cmd_starttls(int nntps)
 
     /* if error */
     if (result == -1) {
-        if (nntps == 0) {
-            prot_printf(nntp_out, "580 Starttls failed\r\n");
-            syslog(LOG_NOTICE, "[nntpd] STARTTLS failed: %s", nntp_clienthost);
-            return;
-        } else {
-            syslog(LOG_NOTICE, "nntps failed: %s", nntp_clienthost);
-            shut_down(0);
-        }
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", nntp_clienthost);
+        shut_down(EX_PROTOCOL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&saslprops, nntp_saslconn);
     if (result != SASL_OK) {
         syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
-        if (nntps == 0) {
-            fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
-        } else {
-            shut_down(0);
-        }
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -189,7 +189,7 @@ static void cmd_auth(char *arg);
 static void cmd_capa(void);
 static void cmd_pass(char *pass);
 static void cmd_user(char *user);
-static void cmd_starttls(int pop3s);
+static void cmd_stls(int pop3s);
 static int blat(int msg, int lines);
 static int openinbox(void);
 static void cmdloop(void);
@@ -521,7 +521,7 @@ int service_main(int argc __attribute__((unused)),
 
     /* we were connected on pop3s port so we should do
        TLS negotiation immediatly */
-    if (pop3s == 1) cmd_starttls(1);
+    if (pop3s == 1) cmd_stls(1);
 
     /* Create APOP challenge for banner */
     *popd_apop_chal = 0;
@@ -929,7 +929,7 @@ done:
                     /* XXX  discard any input pipelined after STLS */
                     prot_flush(popd_in);
 
-                    cmd_starttls(0);
+                    cmd_stls(0);
                 }
             }
             else {
@@ -1155,7 +1155,7 @@ static const struct tls_alpn_t pop3_alpn_map[] = {
     { NULL,   NULL, NULL }
 };
 
-static void cmd_starttls(int pop3s)
+static void cmd_stls(int pop3s)
 {
     int result;
     char *localip, *remoteip;
@@ -1216,25 +1216,15 @@ static void cmd_starttls(int pop3s)
 
     /* if error */
     if (result==-1) {
-        if (pop3s == 0) {
-            prot_printf(popd_out, "-ERR [SYS/PERM] Starttls failed\r\n");
-            syslog(LOG_NOTICE, "[pop3d] STARTTLS failed: %s", popd_clienthost);
-        } else {
-            syslog(LOG_NOTICE, "pop3s failed: %s", popd_clienthost);
-            shut_down(0);
-        }
-        return;
+        syslog(LOG_NOTICE, "TLS negiation failed: %s", popd_clienthost);
+        shut_down(EX_PROTOCOL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&saslprops, popd_saslconn);
     if (result != SASL_OK) {
-        syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
-        if (pop3s == 0) {
-            fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
-        } else {
-            shut_down(0);
-        }
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_stls()");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */
@@ -1245,9 +1235,9 @@ static void cmd_starttls(int pop3s)
     popd_tls_required = 0;
 }
 #else
-static void cmd_starttls(int pop3s __attribute__((unused)))
+static void cmd_stls(int pop3s __attribute__((unused)))
 {
-    fatal("cmd_starttls() called, but no OpenSSL", EX_SOFTWARE);
+    fatal("cmd_stls() called, but no OpenSSL", EX_SOFTWARE);
 }
 #endif /* HAVE_SSL */
 

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -857,15 +857,15 @@ static void cmd_starttls(void)
 
     /* if error */
     if (result==-1) {
-        prot_printf(sync_out, "NO Starttls failed\r\n");
-        syslog(LOG_NOTICE, "STARTTLS failed: %s", sync_clienthost);
-        return;
+        syslog(LOG_NOTICE, "TLS negotiation failed: %s", sync_clienthost);
+        shut_down(EX_PROTOCOL);
     }
 
     /* tell SASL about the negotiated layer */
     result = saslprops_set_tls(&saslprops, sync_saslconn);
     if (result != SASL_OK) {
-        fatal("saslprops_set_tls() failed: cmd_starttls()", EX_TEMPFAIL);
+        syslog(LOG_NOTICE, "saslprops_set_tls() failed: cmd_starttls()");
+        shut_down(EX_TEMPFAIL);
     }
 
     /* tell the prot layer about our new layers */


### PR DESCRIPTION
sending a cleartext response to the client on failure is nonsense