### PR TITLE
TestCase: override assert_matches with better default fail msg

### DIFF
--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -392,6 +392,7 @@ sub assert_matches
 {
     my ($self, $pattern, $string, @rest) = @_;
     my $message;
+    my $multiline;
 
     die "pattern is not a regular expression"
         if lc ref($pattern) ne 'regexp';
@@ -400,7 +401,7 @@ sub assert_matches
         $message = join('', @rest);
     }
     elsif ($string =~ m/\n./) {
-        xlog "assert_matches: multiline string:\n" . $string;
+        $multiline = 1;
         $message = "pattern /$pattern/ did not match [multiline string]";
     }
     else {
@@ -408,6 +409,9 @@ sub assert_matches
     }
 
     my $matches = $string =~ m/$pattern/;
+    if (!$matches && $multiline) {
+        xlog "assert_matches: multiline string:\n" . $string;
+    }
     $self->assert($matches, $message);
 }
 
@@ -417,6 +421,7 @@ sub assert_does_not_match
 {
     my ($self, $pattern, $string, @rest) = @_;
     my $message;
+    my $multiline;
 
     die "pattern is not a regular expression"
         if lc ref($pattern) ne 'regexp';
@@ -425,7 +430,7 @@ sub assert_does_not_match
         $message = join('', @rest);
     }
     elsif ($string =~ m/\n./) {
-        xlog "assert_does_not_match: multiline string:\n" . $string;
+        $multiline = 1;
         $message = "pattern /$pattern/ unexpectedly matched [multiline string]";
     }
     else {
@@ -433,6 +438,9 @@ sub assert_does_not_match
     }
 
     my $matches = $string =~ m/$pattern/;
+    if ($matches && $multiline) {
+        xlog "assert_does_not_match: multiline string:\n" . $string;
+    }
     $self->assert(!$matches, $message);
 }
 

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -386,6 +386,56 @@ sub assert_num_lt
                   "$actual is not less-than $expected");
 }
 
+# override assert_matches from Test::Unit:Assert, whose default failure
+# message is very hard to read in common cases
+sub assert_matches
+{
+    my ($self, $pattern, $string, @rest) = @_;
+    my $message;
+
+    die "pattern is not a regular expression"
+        if lc ref($pattern) ne 'regexp';
+
+    if (@rest) {
+        $message = join('', @rest);
+    }
+    elsif ($string =~ m/\n./) {
+        xlog "assert_matches: multiline string:\n" . $string;
+        $message = "pattern /$pattern/ did not match [multiline string]";
+    }
+    else {
+        $message = "pattern /$pattern/ did not match string \"$string\"";
+    }
+
+    my $matches = $string =~ m/$pattern/;
+    $self->assert($matches, $message);
+}
+
+# override assert_does_not_match from Test::Unit:Assert, whose default failure
+# message is very hard to read in common cases
+sub assert_does_not_match
+{
+    my ($self, $pattern, $string, @rest) = @_;
+    my $message;
+
+    die "pattern is not a regular expression"
+        if lc ref($pattern) ne 'regexp';
+
+    if (@rest) {
+        $message = join('', @rest);
+    }
+    elsif ($string =~ m/\n./) {
+        xlog "assert_does_not_match: multiline string:\n" . $string;
+        $message = "pattern /$pattern/ unexpectedly matched [multiline string]";
+    }
+    else {
+        $message = "pattern /$pattern/ unexpectedly matched string \"$string\"";
+    }
+
+    my $matches = $string =~ m/$pattern/;
+    $self->assert(!$matches, $message);
+}
+
 sub assert_date_matches
 {
     my ($self, $expected, $actual, $tolerance) = @_;


### PR DESCRIPTION
This overrides Test::Unit::Assert's `assert_matches()` and `assert_does_not_match()` with our own, so we can get less confusing default failure messages.  The "$string did not match $pattern" from Test::Unit::Assert is very hard to read when $string contains multiple lines (such as a response object, caught exception, ical string, chunk of syslog, etc).

For multiline strings (that is, strings containing a newline followed by any non-newline), the new failure message says "[multiline string]" instead of the string.  In particular, this avoids cluttering up the exception stack with a string that might itself be an exception stack!  The actual string is logged, so it's still available if you want it.

For single line strings (including strings whose only newline is at the end), the string is included.

Either way, the failure message starts with "pattern ...", so whatever the runtime text is, there is something constant _first_.