### PR TITLE
jmap_calendar:eventquery_cb() memory leak

### DIFF
--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -6693,9 +6693,9 @@ static int eventquery_cb(void *vrock, struct caldav_jscal *jscal)
             mailbox_close(&rock->mailbox);
             r = mailbox_open_irl(mbentry->name, &rock->mailbox);
             if (r) {
-                free(match->ical_uid);
-                free(match->utcstart);
-                free(match);
+                syslog(LOG_ERR, "%s: can't open mailbox %s",
+                       __func__, mbentry->name);
+                eventquery_match_free(&match);
                 goto done;
             }
         }

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -6692,7 +6692,12 @@ static int eventquery_cb(void *vrock, struct caldav_jscal *jscal)
         if (!rock->mailbox || strcmp(mailbox_name(rock->mailbox), mbentry->name)) {
             mailbox_close(&rock->mailbox);
             r = mailbox_open_irl(mbentry->name, &rock->mailbox);
-            if (r) goto done;
+            if (r) {
+                free(match->ical_uid);
+                free(match->utcstart);
+                free(match);
+                goto done;
+            }
         }
         match->ical = caldav_record_to_ical(rock->mailbox, &jscal->cdata, req->userid, NULL);
         if (!match->ical) {


### PR DESCRIPTION
If the lines
```c
match->ical_uid = xstrdup(jscal->cdata.ical_uid);
match->utcstart = xstrdup(jscal->dtstart);
```
are moved just before `ptrarray_append(rock->matches, match);`, then two `free()` here can be skipped.