### PR TITLE
configure.ac: do not check for python2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2293,16 +2293,11 @@ AX_PROG_PERL_MODULES([Pod::POM::View::Restructured],
                        have_ppvr=no
                      ])
 
-AX_PYTHON_MODULE([git], [], [python2])
+AX_PYTHON_MODULE([git])
 AS_CASE([$HAVE_PYMOD_GIT],
-        [yes],  [],
-        [*],    [
-    unset PYTHON # work around AX_PYTHON_MODULE not cleaning up
-    AX_PYTHON_MODULE([git], [], [python3])
-    AS_CASE([$HAVE_PYMOD_GIT],
-            [yes],  [],
-            [*],    [
-         AC_MSG_WARN([GitPython not found, won't be able to regenerate docs])])
+	[yes],  [],
+	[*],    [
+     AC_MSG_WARN([GitPython not found, won't be able to regenerate docs])
 ])
 
 AM_CONDITIONAL([HAVE_SPHINX_BUILD],


### PR DESCRIPTION
Python module `git` is used only from docsrc/exts/sphinxlocal/builders/gitstamp.py and sphinx-doc has removed support for Python 2 in version [2.0](https://www.sphinx-doc.org/en/master/changes/2.0.html#incompatible-changes) released April 2019.