### PR TITLE
httpd.c: Add support for HTTP/0.9

### DIFF
--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -674,7 +674,7 @@ static void send_response(struct transaction_t *txn, long code,
         else if ((hdr = spool_getheader(hdrs, "Content-Length"))) {
             txn->resp_body.len = strtoul(hdr[0], NULL, 10);
 
-            if (txn->flags.ver != VER_2) {
+            if (txn->flags.ver < VER_2) {
                 simple_hdr(txn, "Content-Length", "%s", hdr[0]);
             }
         }
@@ -685,7 +685,7 @@ static void send_response(struct transaction_t *txn, long code,
         /* Body is buffered, so send using "identity" TE */
         txn->resp_body.len = len;
 
-        if (txn->flags.ver != VER_2) {
+        if (txn->flags.ver < VER_2) {
             simple_hdr(txn, "Content-Length", "%lu", len);
         }
         txn->conn->end_resp_headers(txn, code);

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -418,9 +418,10 @@ typedef void (*txn_done_t)(struct transaction_t *txn);
 
 /* HTTP version flags */
 enum {
-    VER_1_0 =           0,
-    VER_1_1 =           1,
-    VER_2 =             2
+    VER_0_9 =           0,
+    VER_1_0 =           1,
+    VER_1_1 =           2,
+    VER_2 =             3,
 };
 
 /* Connection token flags */


### PR DESCRIPTION
Mostly just for completeness, and makes doing GET requests via telnet simpler when debugging.

Also, I can leverage this when starting to implement HTTP over QUIC - the ngtcp2 QUIC library has a sample/test HTTP/0.9 over QUIC client