### PR TITLE
add --enable-release-checks configure option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1587,8 +1587,18 @@ lib/chartable.c: lib/mkchartable.pl lib/charset/unifix.txt \
 
 lib/imapopts.h: lib/imapopts.c
 
+if ENABLE_RELEASE_CHECKS
+    CFG2HDR_FORBID_UNRELEASED="--forbid-unreleased"
+else
+    CFG2HDR_FORBID_UNRELEASED=
+endif
+
 lib/imapopts.c: lib/imapoptions tools/config2header
-	$(AM_V_GEN)$(top_srcdir)/tools/config2header CC="$(CC)" $(top_builddir)/lib/imapopts.c $(top_builddir)/lib/imapopts.h < $(top_srcdir)/lib/imapoptions
+	$(AM_V_GEN)$(top_srcdir)/tools/config2header \
+	    CC="$(CC)" $(CFG2HDR_FORBID_UNRELEASED) \
+	    $(top_builddir)/lib/imapopts.c \
+	    $(top_builddir)/lib/imapopts.h \
+	    < $(top_srcdir)/lib/imapoptions
 
 imap_cvt_xlist_specialuse_SOURCES = imap/mutex_fake.c imap/cvt_xlist_specialuse.c
 imap_cvt_xlist_specialuse_LDADD = $(LD_UTILITY_ADD)

--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,16 @@ AC_SUBST(GCOV_CXXFLAGS)
 AC_SUBST(GCOV_LDFLAGS)
 AC_SUBST(GCOV_LIBS)
 
+dnl enable stricter checks for preparing releases (disabled by default)
+AC_ARG_ENABLE([release-checks],
+              [AS_HELP_STRING([--enable-release-checks],
+                              [enable release checks])],
+              [],
+              [enable_release_checks=no]
+)
+AM_CONDITIONAL([ENABLE_RELEASE_CHECKS],
+               [test "x$enable_release_checks" = "xyes"])
+
 AC_ARG_WITH(login,,AC_MSG_ERROR([--with-login is no longer supported.
 Configure SASL appropriately instead.]))
 
@@ -2602,4 +2612,5 @@ Build info:
    libm:               $LIBM
    unit tests (cunit): $enable_unit_tests
    xxd:                $XXD
+   release checks:     $enable_release_checks
 "

--- a/configure.ac
+++ b/configure.ac
@@ -2284,6 +2284,11 @@ AS_IF(
 )
 
 dnl documentation generation (sphinx, perl2rst, gitpython)
+AC_DEFUN([WARN_DOCDEPS], [
+    AM_COND_IF([ENABLE_RELEASE_CHECKS],
+               [AC_MSG_ERROR([No $1, cannot regenerate docs])],
+               [AC_MSG_WARN([No $1, won't be able to regenerate docs])])
+])
 AC_ARG_VAR(SPHINX_BUILD, [Location of sphinx-build])
 AC_ARG_WITH([sphinx-build],
             AS_HELP_STRING([--with-sphinx-build=(yes|no|PATH)], [Look for sphinx-build in PATH]),
@@ -2294,12 +2299,12 @@ AS_CASE([$with_sphinx_build],
         [no],   [SPHINX_BUILD=''],
         [*],    [AC_PATH_PROG(SPHINX_BUILD, sphinx-build, [], [$with_sphinx_build])])
 AS_IF([test -z "$SPHINX_BUILD"],
-      [AC_MSG_WARN([No sphinx-build, won't be able to regenerate docs])])
+      [WARN_DOCDEPS([sphinx-build])])
 AC_SUBST([SPHINX_BUILD])
 
 AX_PROG_PERL_MODULES([Pod::POM::View::Restructured],
                      [have_ppvr=yes],
-                     [AC_MSG_WARN([No Pod::POM::View::Restructured, won't be able to regenerate docs])
+                     [WARN_DOCDEPS([Pod::POM::View::Restructured])
                        have_ppvr=no
                      ])
 
@@ -2311,8 +2316,7 @@ AS_CASE([$HAVE_PYMOD_GIT],
     AX_PYTHON_MODULE([git], [], [python3])
     AS_CASE([$HAVE_PYMOD_GIT],
             [yes],  [],
-            [*],    [
-         AC_MSG_WARN([GitPython not found, won't be able to regenerate docs])])
+            [*],    [WARN_DOCDEPS([GitPython])])
 ])
 
 AM_CONDITIONAL([HAVE_SPHINX_BUILD],

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,13 @@ AC_ARG_ENABLE([release-checks],
 )
 AM_CONDITIONAL([ENABLE_RELEASE_CHECKS],
                [test "x$enable_release_checks" = "xyes"])
+AM_COND_IF([ENABLE_RELEASE_CHECKS], [
+    AC_MSG_CHECKING([for changes files hanging around])
+    extra_changes_files=$(ls $srcdir/changes/next | grep -cv '0000-TEMPLATE')
+    AC_MSG_RESULT([$extra_changes_files])
+    AS_IF([test $extra_changes_files -ne 0],
+          [AC_MSG_ERROR([found changes files hanging around])])
+])
 
 AC_ARG_WITH(login,,AC_MSG_ERROR([--with-login is no longer supported.
 Configure SASL appropriately instead.]))

--- a/docsrc/imap/developer/releasing.rst
+++ b/docsrc/imap/developer/releasing.rst
@@ -149,7 +149,8 @@ anybody else pushes in the meantime, you will end up with a mess.
 
 4. You will also be prompted to enter the pass phrase for your GPG key, do it.
 5. Generate a configure script: ``autoreconf -i -s``
-6. Generate everything else: ``./configure --enable-maintainer-mode``
+6. Generate everything else, this time with release checks enabled:
+   ``./configure --enable-maintainer-mode --enable-release-checks``
 7. Create the distribution tarball: ``make distcheck`` (yes, again! this time
    will have the correct version, now that you've tagged it.)
 8. If anything goes wrong up to here, delete the tag, fix the issue, and start

--- a/tools/config2header
+++ b/tools/config2header
@@ -44,23 +44,32 @@ require 5;
 use strict;
 use warnings;
 
+# invoked by make like this:
+#./tools/config2header CC="gcc" ./lib/imapopts.c ./lib/imapopts.h < ./lib/imapoptions
+
 my $enum_size = 0;
 my @enum_values = ();
 
-my $CC;
-#
-# Look for CC=xxx "assignments" in the argument list.
-#
-while ($#ARGV >= 0) {
-        last unless ($ARGV[0] =~ m/^(\S+)=(.*)$/);
-        eval "\$$1='$2';";
-        die "$@" if ($@);
+my %vars;
+my %known_vars = map { $_ => 1 } qw(CC);
+
+# process command line arguments
+while (scalar @ARGV) {
+    if ($ARGV[0] =~ m{^(\S+)=(.*)$}) {
+        # var=value
+        die "unrecognised variable $1" if not exists $known_vars{$1};
+        die "missing value for $1" if not defined $2;
+        $vars{$1} = $2;
         shift @ARGV;
+    }
+    else {
+        last;
+    }
 }
 
-my $use_gcc_extension = ($CC and $CC eq 'gcc');
+my $use_gcc_extension = (exists $vars{CC} and $vars{CC} eq 'gcc');
 
-die "wrong number of arguments" if ($#ARGV != 1);
+die "wrong number of arguments" if scalar @ARGV != 2;
 my ($cfile, $hfile) = @ARGV;
 
 open CFILE, ">$cfile";

--- a/tools/config2header
+++ b/tools/config2header
@@ -52,6 +52,8 @@ my @enum_values = ();
 
 my %vars;
 my %known_vars = map { $_ => 1 } qw(CC);
+my %opts;
+my %known_opts = map { $_ => 1 } qw(forbid-unreleased);
 
 # process command line arguments
 while (scalar @ARGV) {
@@ -60,6 +62,12 @@ while (scalar @ARGV) {
         die "unrecognised variable $1" if not exists $known_vars{$1};
         die "missing value for $1" if not defined $2;
         $vars{$1} = $2;
+        shift @ARGV;
+    }
+    elsif ($ARGV[0] =~ m{^--([-\w]+)(?:=(.*))?$}) {
+        # --option or --option=value
+        die "unrecognised option $ARGV[0]" if not exists $known_opts{$1};
+        $opts{$1} = $2 // 1;
         shift @ARGV;
     }
     else {
@@ -158,13 +166,24 @@ sub parse_last_modified
             # "UNRELEASED" strings in lib/imapoptions with the version
             # number that is about to be released.
             # If you're not building a release, ignore it. :)
+            my $prefix;
+
+            if ($opts{'forbid-unreleased'}) {
+                $prefix = -t STDERR ? "\033[31;1merror:\033[0m" : 'error:';
+            }
+            else {
+                $prefix = -t STDERR ? "\033[33;1mwarning:\033[0m" : 'warning:',
+            }
+
             my $w = join q{ },
                     "$0:",
-                    -t STDERR ? "\033[33;1mwarning:\033[0m" : 'warning:',
+                    $prefix,
                     'build contains UNRELEASED config options';
             print STDERR "$w\n";
 
             $__warned_unreleased ++;
+
+            exit 1 if $opts{'forbid-unreleased'};
         }
 
         return "0xFFFFFFFF";


### PR DESCRIPTION
Adds a new option for configure: `--enable-release-checks`

With this option, configure/make will error out for these conditions:

* imapoptions entries that are marked UNRELEASED
* missing dependencies required to build the documentation
* files other than the template in changes/next

Without the option, these conditions are just warnings or ignored as usual.

I expect to use this option only in the final stages of building new public releases, to double check that everything is taken care of.  Between releases, this stuff doesn't matter and/or is the expected state of affairs, so the option isn't useful most of the time.