### PR TITLE
fix shared mailbox subscription bug when one user is prefix of other

### DIFF
--- a/cassandane/Cassandane/Cyrus/Shared.pm
+++ b/cassandane/Cassandane/Cyrus/Shared.pm
@@ -74,4 +74,136 @@ sub tear_down
     $self->SUPER::tear_down();
 }
 
+sub shared_subscribe_common
+{
+    my ($self, $user1, $user2) = @_;
+
+    my $service = $self->{instance}->get_service('imap');
+
+    my @user1_mailboxes = random_words(3);
+    $self->{instance}->create_user($user1,
+                                   subdirs => \@user1_mailboxes);
+
+    my $user1_store = $service->create_store(username => $user1);
+    my $user1_talk = $user1_store->get_client();
+
+    foreach my $mb (@user1_mailboxes) {
+        $user1_talk->subscribe($mb);
+        $user1_talk->setacl($mb, $user2, 'lrs');
+    }
+
+    my @user2_mailboxes = random_words(3);
+    $self->{instance}->create_user($user2,
+                                   subdirs => \@user2_mailboxes);
+
+    my $user2_store = $service->create_store(username => $user2);
+    my $user2_talk = $user2_store->get_client();
+
+    foreach my $mb (@user2_mailboxes) {
+        $user2_talk->subscribe($mb);
+        $user2_talk->setacl($mb, $user1, 'lrs');
+    }
+
+    xlog("subscribe as $user1 to $user2\'s shared mb's");
+    foreach my $mb (@user2_mailboxes) {
+        $user1_talk->subscribe("Other Users.$user2.$mb");
+        $self->assert_equals('ok', $user1_talk->get_last_completion_response());
+    }
+
+    xlog("but not their inbox");
+    $user1_talk->subscribe("Other Users.$user2");
+    $self->assert_equals('no', $user1_talk->get_last_completion_response());
+
+    xlog("make sure $user1 has the right subscriptions");
+    my $user1_subs = $user1_talk->list([qw(SUBSCRIBED)],
+                                       '', '*',
+                                       'RETURN', [qw(CHILDREN)]);
+    $self->assert_mailbox_structure($user1_subs, '.', {
+        (map {(
+            $_ => [ '\\Subscribed', '\\HasNoChildren' ]
+        )} @user1_mailboxes),
+        (map {(
+            "Other Users.$user2.$_" => [
+                '\\Subscribed',
+                '\\HasNoChildren',
+            ]
+        )} @user2_mailboxes),
+    });
+
+    xlog("unsub as $user1 from $user2\'s folders");
+    foreach my $mb (@user2_mailboxes) {
+        $user1_talk->unsubscribe("Other Users.$user2.$mb");
+        $self->assert_equals('ok', $user1_talk->get_last_completion_response());
+    }
+
+    xlog("make sure $user1 has the right subscriptions");
+    $user1_subs = $user1_talk->list([qw(SUBSCRIBED)],
+                                    '', '*',
+                                    'RETURN', [qw(CHILDREN)]);
+    $self->assert_mailbox_structure($user1_subs, '.', {
+        (map {(
+            $_ => [ '\\Subscribed', '\\HasNoChildren' ]
+        )} @user1_mailboxes),
+    });
+
+    xlog("subscribe as $user2 to $user1\'s shared mb's");
+    foreach my $mb (@user1_mailboxes) {
+        $user2_talk->subscribe("Other Users.$user1.$mb");
+        $self->assert_equals('ok',
+                             $user2_talk->get_last_completion_response());
+    }
+
+    xlog("but not their inbox");
+    $user2_talk->subscribe("Other Users.$user1");
+    $self->assert_equals('no', $user2_talk->get_last_completion_response());
+
+    xlog("make sure $user2 has the right subscriptions");
+    my $user2_subs = $user2_talk->list([qw(SUBSCRIBED)],
+                                       '', '*',
+                                       'RETURN', [qw(CHILDREN)]);
+    $self->assert_mailbox_structure($user2_subs, '.', {
+        (map {(
+            $_ => [ '\\Subscribed', '\\HasNoChildren' ]
+        )} @user2_mailboxes),
+        (map {(
+            "Other Users.$user1.$_" => [
+                '\\Subscribed',
+                '\\HasNoChildren',
+            ]
+        )} @user1_mailboxes),
+    });
+
+    xlog("unsub as $user2 from $user1\'s folders");
+    foreach my $mb (@user1_mailboxes) {
+        $user2_talk->unsubscribe("Other Users.$user1.$mb");
+        $self->assert_equals('ok',
+                             $user2_talk->get_last_completion_response());
+    }
+
+    xlog("make sure $user2 has the right subscriptions");
+    $user2_subs = $user2_talk->list([qw(SUBSCRIBED)],
+                                    '', '*',
+                                    'RETURN', [qw(CHILDREN)]);
+    $self->assert_mailbox_structure($user2_subs, '.', {
+        (map {(
+            $_ => [ '\\Subscribed', '\\HasNoChildren' ]
+        )} @user2_mailboxes),
+    });
+}
+
+sub test_subscribe
+{
+    my ($self) = @_;
+
+    $self->shared_subscribe_common('firstuser', 'seconduser');
+}
+
+sub test_subscribe_prefix
+{
+    my ($self) = @_;
+
+    # one user is a prefix of the other!
+    $self->shared_subscribe_common('chris', 'christopher');
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/Shared.pm
+++ b/cassandane/Cassandane/Cyrus/Shared.pm
@@ -219,4 +219,31 @@ sub test_subscribe_prefix
     $self->shared_subscribe_common('chris', 'christopher');
 }
 
+sub test_subscribe_vd
+    :VirtDomains :CrossDomains
+{
+    my ($self) = @_;
+
+    $self->shared_subscribe_common('firstuser@example.com',
+                                   'seconduser@example.com');
+}
+
+sub test_subscribe_vd_prefix
+    :VirtDomains :CrossDomains
+{
+    my ($self) = @_;
+
+    $self->shared_subscribe_common('matt@example.com',
+                                   'matthew@example.com');
+}
+
+sub test_subscribe_vd_prefix2
+    :VirtDomains :CrossDomains
+{
+    my ($self) = @_;
+
+    $self->shared_subscribe_common('jim@example.com',
+                                   'jim@example.coma.example.com');
+}
+
 1;

--- a/cassandane/Cassandane/Cyrus/Shared.pm
+++ b/cassandane/Cassandane/Cyrus/Shared.pm
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2011-2024 Fastmail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      Fastmail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Cyrus::Shared;
+use strict;
+use warnings;
+use DateTime;
+use Data::Dumper;
+
+use lib '.';
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Instance;
+use Cassandane::Util::Log;
+use Cassandane::Util::Words;
+
+$Data::Dumper::Sortkeys = 1;
+
+sub new
+{
+    my ($class, @args) = @_;
+
+    my $self = $class->SUPER::new({ adminstore => 1 }, @args);
+
+    return $self;
+}
+
+sub set_up
+{
+    my ($self) = @_;
+
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+
+    $self->SUPER::tear_down();
+}
+
+1;

--- a/cassandane/Cassandane/Cyrus/Subscriptions.pm
+++ b/cassandane/Cassandane/Cyrus/Subscriptions.pm
@@ -37,7 +37,7 @@
 #  OF THIS SOFTWARE.
 #
 
-package Cassandane::Cyrus::Lsub;
+package Cassandane::Cyrus::Subscriptions;
 use strict;
 use warnings;
 use DateTime;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1073,8 +1073,15 @@ sub create_user
     my $adminclient = $adminstore->get_client();
 
     my @mboxes = ( $mb->to_external() );
-    map { push(@mboxes, $mb->make_child($_)->to_external()); } @{$params{subdirs}}
-        if ($params{subdirs});
+    foreach my $subdir ($params{subdirs} ? @{$params{subdirs}} : ())
+    {
+        if (ref $subdir eq 'Cassandane::Mboxname') {
+            push(@mboxes, $subdir->to_external());
+        }
+        else {
+            push(@mboxes, $mb->make_child($subdir)->to_external());
+        }
+    }
 
     foreach my $mb (@mboxes)
     {

--- a/cassandane/Cassandane/Mboxname.pm
+++ b/cassandane/Cassandane/Mboxname.pm
@@ -132,7 +132,7 @@ sub _external_separator
     my ($self) = @_;
     die "No Config specified"
         unless defined $self->{config};
-    return $self->{config}->get_bool('unixhierarchysep', 'off') ? '/' : '.';
+    return $self->{config}->get_bool('unixhierarchysep', 'on') ? '/' : '.';
 }
 
 sub _external_separator_regexp
@@ -140,7 +140,7 @@ sub _external_separator_regexp
     my ($self) = @_;
     die "No Config specified"
         unless defined $self->{config};
-    return $self->{config}->get_bool('unixhierarchysep', 'off') ? qr/\// : qr/\./;
+    return $self->{config}->get_bool('unixhierarchysep', 'on') ? qr/\// : qr/\./;
 }
 
 

--- a/cassandane/Cassandane/Test/Mboxname.pm
+++ b/cassandane/Cassandane/Test/Mboxname.pm
@@ -87,6 +87,12 @@ sub test_parts_ctor
                              'quinoa.com!user.pickled.fanny.pack');
     $self->assert_str_equals($mb->to_external,
                              'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('admin'),
+                             'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('owner'),
+                             'fanny.pack');
+    $self->assert_str_equals($mb->to_external('other'),
+                             'Other Users.pickled@quinoa^com.fanny.pack');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -105,6 +111,12 @@ sub test_internal_ctor
                              'quinoa.com!user.pickled.fanny.pack');
     $self->assert_str_equals($mb->to_external,
                              'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('admin'),
+                             'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('owner'),
+                             'fanny.pack');
+    $self->assert_str_equals($mb->to_external('other'),
+                             'Other Users.pickled@quinoa^com.fanny.pack');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -123,6 +135,12 @@ sub test_external_ctor
                              'quinoa.com!user.pickled.fanny.pack');
     $self->assert_str_equals($mb->to_external,
                              'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('admin'),
+                             'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('owner'),
+                             'fanny.pack');
+    $self->assert_str_equals($mb->to_external('other'),
+                             'Other Users.pickled@quinoa^com.fanny.pack');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -141,6 +159,12 @@ sub test_username_ctor
                              'quinoa.com!user.pickled');
     $self->assert_str_equals($mb->to_external,
                              'user.pickled@quinoa.com');
+    $self->assert_str_equals($mb->to_external('admin'),
+                             'user.pickled@quinoa.com');
+    $self->assert_str_equals($mb->to_external('owner'),
+                             'INBOX');
+    $self->assert_str_equals($mb->to_external('other'),
+                             'Other Users.pickled@quinoa^com');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -205,6 +229,12 @@ sub test_from_internal
                              'quinoa.com!user.pickled.fanny.pack');
     $self->assert_str_equals($mb->to_external,
                              'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('admin'),
+                             'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('owner'),
+                             'fanny.pack');
+    $self->assert_str_equals($mb->to_external('other'),
+                             'Other Users.pickled@quinoa^com.fanny.pack');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -222,6 +252,12 @@ sub test_from_external
                              'quinoa.com!user.pickled.fanny.pack');
     $self->assert_str_equals($mb->to_external,
                              'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('admin'),
+                             'user.pickled.fanny.pack@quinoa.com');
+    $self->assert_str_equals($mb->to_external('owner'),
+                             'fanny.pack');
+    $self->assert_str_equals($mb->to_external('other'),
+                             'Other Users.pickled@quinoa^com.fanny.pack');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -239,6 +275,12 @@ sub test_from_username
                              'quinoa.com!user.pickled');
     $self->assert_str_equals($mb->to_external,
                              'user.pickled@quinoa.com');
+    $self->assert_str_equals($mb->to_external('admin'),
+                             'user.pickled@quinoa.com');
+    $self->assert_str_equals($mb->to_external('owner'),
+                             'INBOX');
+    $self->assert_str_equals($mb->to_external('other'),
+                             'Other Users.pickled@quinoa^com');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }

--- a/cassandane/Cassandane/Test/Mboxname.pm
+++ b/cassandane/Cassandane/Test/Mboxname.pm
@@ -79,20 +79,20 @@ sub test_parts_ctor
     my $mb = Cassandane::Mboxname->new(
             domain => 'quinoa.com',
             userid => 'pickled',
-            box => 'fanny.pack');
+            box => 'pants.waist^band');
     $self->assert_str_equals($mb->domain, 'quinoa.com');
     $self->assert_str_equals($mb->userid, 'pickled');
-    $self->assert_str_equals($mb->box, 'fanny.pack');
+    $self->assert_str_equals($mb->box, 'pants.waist^band');
     $self->assert_str_equals($mb->to_internal,
-                             'quinoa.com!user.pickled.fanny.pack');
+                             'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->to_external,
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('admin'),
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('owner'),
-                             'fanny.pack');
+                             'pants.waist^band');
     $self->assert_str_equals($mb->to_external('other'),
-                             'Other Users.pickled@quinoa^com.fanny.pack');
+                             'Other Users.pickled@quinoa^com.pants.waist^band');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -103,20 +103,20 @@ sub test_internal_ctor
 
     my $mb = Cassandane::Mboxname->new(
                 config => myconfig(),
-                internal => 'quinoa.com!user.pickled.fanny.pack');
+                internal => 'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->domain, 'quinoa.com');
     $self->assert_str_equals($mb->userid, 'pickled');
-    $self->assert_str_equals($mb->box, 'fanny.pack');
+    $self->assert_str_equals($mb->box, 'pants.waist^band');
     $self->assert_str_equals($mb->to_internal,
-                             'quinoa.com!user.pickled.fanny.pack');
+                             'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->to_external,
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('admin'),
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('owner'),
-                             'fanny.pack');
+                             'pants.waist^band');
     $self->assert_str_equals($mb->to_external('other'),
-                             'Other Users.pickled@quinoa^com.fanny.pack');
+                             'Other Users.pickled@quinoa^com.pants.waist^band');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -127,20 +127,20 @@ sub test_external_ctor
 
     my $mb = Cassandane::Mboxname->new(
                 config => myconfig(),
-                external => 'user.pickled.fanny.pack@quinoa.com');
+                external => 'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->domain, 'quinoa.com');
     $self->assert_str_equals($mb->userid, 'pickled');
-    $self->assert_str_equals($mb->box, 'fanny.pack');
+    $self->assert_str_equals($mb->box, 'pants.waist^band');
     $self->assert_str_equals($mb->to_internal,
-                             'quinoa.com!user.pickled.fanny.pack');
+                             'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->to_external,
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('admin'),
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('owner'),
-                             'fanny.pack');
+                             'pants.waist^band');
     $self->assert_str_equals($mb->to_external('other'),
-                             'Other Users.pickled@quinoa^com.fanny.pack');
+                             'Other Users.pickled@quinoa^com.pants.waist^band');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -179,7 +179,7 @@ sub test_broken_ctor
     {
         $mb = Cassandane::Mboxname->new(
                 config => myconfig(),
-                internal => 'quinoa.com!user.pickled.fanny.pack',
+                internal => 'quinoa.com!user.pickled.pants.waist^band',
                 username => 'pickled@quinoa.com');
     };
     $ex = $@;
@@ -189,7 +189,7 @@ sub test_broken_ctor
     {
         $mb = Cassandane::Mboxname->new(
                 config => myconfig(),
-                external => 'user.pickled.fanny.pack@quinoa.com',
+                external => 'user.pickled.pants.waist^band@quinoa.com',
                 username => 'pickled@quinoa.com');
     };
     $ex = $@;
@@ -199,8 +199,8 @@ sub test_broken_ctor
     {
         $mb = Cassandane::Mboxname->new(
                 config => myconfig(),
-                internal => 'quinoa.com!user.pickled.fanny.pack',
-                external => 'user.pickled.fanny.pack@quinoa.com');
+                internal => 'quinoa.com!user.pickled.pants.waist^band',
+                external => 'user.pickled.pants.waist^band@quinoa.com');
     };
     $ex = $@;
     $self->assert_matches(qr/contradictory initialisers/, $ex);
@@ -209,7 +209,7 @@ sub test_broken_ctor
     {
         $mb = Cassandane::Mboxname->new(
                 config => myconfig(),
-                internal => 'quinoa.com!user.pickled.fanny.pack',
+                internal => 'quinoa.com!user.pickled.pants.waist^band',
                 selvage => 'sustainble');
     };
     $ex = $@;
@@ -221,20 +221,20 @@ sub test_from_internal
     my ($self) = @_;
 
     my $mb = Cassandane::Mboxname->new(config => myconfig());
-    $mb->from_internal('quinoa.com!user.pickled.fanny.pack');
+    $mb->from_internal('quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->domain, 'quinoa.com');
     $self->assert_str_equals($mb->userid, 'pickled');
-    $self->assert_str_equals($mb->box, 'fanny.pack');
+    $self->assert_str_equals($mb->box, 'pants.waist^band');
     $self->assert_str_equals($mb->to_internal,
-                             'quinoa.com!user.pickled.fanny.pack');
+                             'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->to_external,
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('admin'),
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('owner'),
-                             'fanny.pack');
+                             'pants.waist^band');
     $self->assert_str_equals($mb->to_external('other'),
-                             'Other Users.pickled@quinoa^com.fanny.pack');
+                             'Other Users.pickled@quinoa^com.pants.waist^band');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -244,20 +244,20 @@ sub test_from_external
     my ($self) = @_;
 
     my $mb = Cassandane::Mboxname->new(config => myconfig());
-    $mb->from_external('user.pickled.fanny.pack@quinoa.com');
+    $mb->from_external('user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->domain, 'quinoa.com');
     $self->assert_str_equals($mb->userid, 'pickled');
-    $self->assert_str_equals($mb->box, 'fanny.pack');
+    $self->assert_str_equals($mb->box, 'pants.waist^band');
     $self->assert_str_equals($mb->to_internal,
-                             'quinoa.com!user.pickled.fanny.pack');
+                             'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->to_external,
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('admin'),
-                             'user.pickled.fanny.pack@quinoa.com');
+                             'user.pickled.pants.waist^band@quinoa.com');
     $self->assert_str_equals($mb->to_external('owner'),
-                             'fanny.pack');
+                             'pants.waist^band');
     $self->assert_str_equals($mb->to_external('other'),
-                             'Other Users.pickled@quinoa^com.fanny.pack');
+                             'Other Users.pickled@quinoa^com.pants.waist^band');
     $self->assert_str_equals($mb->to_username,
                              'pickled@quinoa.com');
 }
@@ -295,17 +295,17 @@ sub test_make_child
     $self->assert_str_equals($mb->to_internal,
                              'quinoa.com!user.pickled');
 
-    my $mb2 = $mb->make_child('fanny');
+    my $mb2 = $mb->make_child('pants');
     $self->assert_str_equals($mb2->to_internal,
-                             'quinoa.com!user.pickled.fanny');
+                             'quinoa.com!user.pickled.pants');
     $self->assert_str_equals($mb->to_internal,
                              'quinoa.com!user.pickled');
 
-    my $mb3 = $mb2->make_child('pack');
+    my $mb3 = $mb2->make_child('waist^band');
     $self->assert_str_equals($mb3->to_internal,
-                             'quinoa.com!user.pickled.fanny.pack');
+                             'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb2->to_internal,
-                             'quinoa.com!user.pickled.fanny');
+                             'quinoa.com!user.pickled.pants');
     $self->assert_str_equals($mb->to_internal,
                              'quinoa.com!user.pickled');
 }
@@ -316,19 +316,19 @@ sub test_make_parent
 
     my $mb = Cassandane::Mboxname->new(
                 config => myconfig(),
-                internal => 'quinoa.com!user.pickled.fanny.pack');
+                internal => 'quinoa.com!user.pickled.pants.waist^band');
     $self->assert_str_equals($mb->to_internal,
-                             'quinoa.com!user.pickled.fanny.pack');
+                             'quinoa.com!user.pickled.pants.waist^band');
 
     my $mb2 = $mb->make_parent();
     $self->assert_str_equals($mb2->to_internal,
-                             'quinoa.com!user.pickled.fanny');
+                             'quinoa.com!user.pickled.pants');
 
     my $mb3 = $mb2->make_parent();
     $self->assert_str_equals($mb3->to_internal,
                              'quinoa.com!user.pickled');
     $self->assert_str_equals($mb2->to_internal,
-                             'quinoa.com!user.pickled.fanny');
+                             'quinoa.com!user.pickled.pants');
 
     my $mb4 = $mb3->make_parent();
     $self->assert_str_equals($mb4->to_internal,
@@ -336,7 +336,7 @@ sub test_make_parent
     $self->assert_str_equals($mb3->to_internal,
                              'quinoa.com!user.pickled');
     $self->assert_str_equals($mb2->to_internal,
-                             'quinoa.com!user.pickled.fanny');
+                             'quinoa.com!user.pickled.pants');
 }
 
 1;

--- a/cassandane/Cassandane/Util/Words.pm
+++ b/cassandane/Cassandane/Util/Words.pm
@@ -45,7 +45,8 @@ use Exporter ();
 our @ISA = qw(Exporter);
 our @EXPORT = qw(
     &random_word
-    );
+    &random_words
+);
 
 my @words;
 my @remaining;
@@ -82,6 +83,18 @@ sub random_word
         if (!scalar @words);
     @remaining = @words unless scalar @remaining;
     return $remaining[int(rand(scalar @remaining))];
+}
+
+sub random_words
+{
+    my ($count) = @_;
+    my @random_words;
+
+    while ($count-- > 0) {
+        push @random_words, random_word();
+    }
+
+    return wantarray ? @random_words : "@random_words";
 }
 
 1;

--- a/changes/next/5146-shared-subs
+++ b/changes/next/5146-shared-subs
@@ -1,0 +1,24 @@
+Description:
+
+* Fixed :issue:`5146`: can't subscribe to shared mailbox when username is a
+  prefix of owner's username
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+No manual intervention required.
+
+Subscriptions databases will be upgraded the next time they're opened, and any
+bad entries due to the bug will be found and fixed.  You can force this for a
+particular user by connecting to IMAP as them and issuing a command like
+``. LSUB "" "*"`` or similar, but this will happen anyway during normal usage.
+
+
+GitHub issue:
+
+#5146

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -378,7 +378,12 @@ static void mboxlist_dbname_to_key(const char *dbname, size_t len,
         char *inbox = mbname_dbname(mbname);
         size_t inboxlen = strlen(inbox);
 
-        if (len >= inboxlen && !strncmp(dbname, inbox, inboxlen)) {
+        if (len >= inboxlen
+            && (len == inboxlen
+                || dbname[inboxlen] == '\0'
+                || dbname[inboxlen] == DB_HIERSEP_CHAR)
+            && !strncmp(dbname, inbox, inboxlen))
+        {
             buf_appendcstr(key, "INBOX");
             dbname += inboxlen;
             len -= inboxlen;
@@ -394,7 +399,13 @@ static void mboxlist_dbname_to_key(const char *dbname, size_t len,
 static void mboxlist_dbname_from_key(const char *key, size_t len,
                                      const char *userid, struct buf *dbname)
 {
-    if (userid && len >= 6 && !strncmp(key+1, "INBOX", 5)) {
+    assert(key[0] == KEY_TYPE_NAME);
+
+    if (userid
+        && len >= 6
+        && (len == 6 || key[6] == '\0' || key[6] == DB_HIERSEP_CHAR)
+        && !strncmp(key+1, "INBOX", 5))
+    {
         mbname_t *mbname = mbname_from_userid(userid);
         char *inbox = mbname_dbname(mbname);
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -102,8 +102,8 @@
 /* n.b. mailboxes.db isn't versioned (yet) */
 
 #define SUBDB_VERSION_KEY      DB_HIERSEP_STR "VER" DB_HIERSEP_STR
-#define SUBDB_VERSION_STR      "2"
-#define SUBDB_VERSION_NUM      (2)
+#define SUBDB_VERSION_STR      "3"
+#define SUBDB_VERSION_NUM      (3)
 
 static mbname_t *mbname_from_dbname(const char *dbname);
 static char *mbname_dbname(const mbname_t *mbname);
@@ -5780,15 +5780,77 @@ static int _upgrade_subs_cb(void *rock, const char *key, size_t keylen,
 {
     struct upgrade_rock *urock = (struct upgrade_rock *) rock;
     struct buf *namebuf = urock->namebuf;
-    char *dbname = NULL;
 
-    /* XXX don't know how to ugprade from anything else yet! */
-    assert(urock->old_version == 0);
+    if (keylen == strlen(SUBDB_VERSION_KEY)
+        && !strncmp(key, SUBDB_VERSION_KEY, keylen))
+    {
+        /* don't try to migrate version record */
+        return 0;
+    }
 
-    buf_setmap(namebuf, key, keylen);
-    dbname = mboxname_to_dbname(buf_cstring(namebuf));
-    mboxlist_dbname_to_key(dbname, strlen(dbname), urock->userid, namebuf);
-    free(dbname);
+    assert(urock->old_version >= 0 && urock->old_version <= SUBDB_VERSION_NUM);
+
+    if (urock->old_version == 0) {
+        char *dbname = NULL;
+
+        /* before versioning we used intnames, need to convert to key */
+        buf_setmap(namebuf, key, keylen);
+        dbname = mboxname_to_dbname(buf_cstring(namebuf));
+        mboxlist_dbname_to_key(dbname, strlen(dbname), urock->userid, namebuf);
+        free(dbname);
+    }
+    /* n.b. there was no version 1 */
+    else if (urock->old_version == 2) {
+        /* version 2 used keys, but handled mailboxes shared between similar
+         * usernames badly (#5146), so we need to clean up that mess
+         */
+        assert(key[0] == KEY_TYPE_NAME);
+
+        if (keylen > 6
+            && !strncmp(key+1, "INBOX", 5)
+            && key[6] != DB_HIERSEP_CHAR)
+        {
+            /* if e.g. user.matt subscribed to mailboxes belonging to
+             * user.matthew, there'll be records like "INBOXhew" to fix
+             */
+            mbname_t *mbname = mbname_from_userid(urock->userid);
+            char *inbox = mbname_dbname(mbname);
+
+            /* n.b. no hiersep char between inbox and the rest; we want to
+             * replace "INBOXhew" with "user.matthew", not with
+             * "user.matt.hew"!
+             */
+            buf_reset(namebuf);
+            buf_putc(namebuf, KEY_TYPE_NAME);
+            buf_appendcstr(namebuf, inbox);
+            buf_appendmap(namebuf, key + 6, keylen - 6);
+
+            xsyslog(LOG_DEBUG, "fixing bad shared mailbox subscription",
+                               "userid=<%s> old_key=<%.*s> new_key=<%s>",
+                               urock->userid,
+                               (int) keylen, key,
+                               buf_cstring(namebuf));
+
+            mbname_free(&mbname);
+            free(inbox);
+        }
+        else {
+            buf_setmap(namebuf, key, keylen);
+        }
+    }
+    else if (urock->old_version == SUBDB_VERSION_NUM) {
+        /* shouldn't get here, but if we do just pass it through */
+        buf_setmap(namebuf, key, keylen);
+    }
+    else {
+        /* XXX uh-oh, don't know how to upgrade from this version */
+        char buf[128];
+
+        snprintf(buf, sizeof(buf),
+                 "don't know how to upgrade sub.db from version %d",
+                 urock->old_version);
+        fatal(buf, EX_SOFTWARE);
+    }
 
     const char *newkey = buf_base(namebuf);
     size_t newkeylen = buf_len(namebuf);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -98,8 +98,10 @@
 #define DB_HIERSEP_CHAR     DB_HIERSEP_STR[0]
 #define DB_USER_PREFIX      "user" DB_HIERSEP_STR
 
-#define DB_VERSION_KEY      DB_HIERSEP_STR "VER" DB_HIERSEP_STR
-#define DB_VERSION_STR      "2"
+/* n.b. mailboxes.db isn't versioned (yet) */
+
+#define SUBDB_VERSION_KEY      DB_HIERSEP_STR "VER" DB_HIERSEP_STR
+#define SUBDB_VERSION_STR      "2"
 
 static mbname_t *mbname_from_dbname(const char *dbname);
 static char *mbname_dbname(const mbname_t *mbname);
@@ -4988,9 +4990,9 @@ mboxlist_opensubs(const char *userid,
         db_r = cyrusdb_open(SUBDB, subsfname, CYRUSDB_CREATE, ret);
         if (db_r == CYRUSDB_OK) {
             // set the version key
-            const char *key = DB_VERSION_KEY;
+            const char *key = SUBDB_VERSION_KEY;
             size_t keylen = strlen(key);
-            const char *data = DB_VERSION_STR;
+            const char *data = SUBDB_VERSION_STR;
             size_t datalen = strlen(data);
             db_r = cyrusdb_store(*ret, key, keylen, data, datalen, NULL);
         }
@@ -5760,9 +5762,9 @@ static int mboxlist_upgrade_subs_work(const char *userid, const char *subsfname,
     db_r = cyrusdb_open(SUBDB, newsubsfname, CYRUSDB_CREATE, &newsubs);
     if (!db_r) {
         /* add version record */
-        const char *key = DB_VERSION_KEY;
+        const char *key = SUBDB_VERSION_KEY;
         size_t keylen = strlen(key);
-        const char *data = DB_VERSION_STR;
+        const char *data = SUBDB_VERSION_STR;
         size_t datalen = strlen(data);
         db_r = cyrusdb_store(newsubs, key, keylen, data, datalen, &newtid);
     }
@@ -5826,8 +5828,8 @@ static int mboxlist_upgrade_subs_work(const char *userid, const char *subsfname,
 static int mboxlist_upgrade_subs(const char *userid, const char *subsfname, struct db **subs)
 {
     // if we have the DB key already in the DB, nothing to do!
-    const char *key = DB_VERSION_KEY;
-    size_t keylen = strlen(DB_VERSION_KEY);
+    const char *key = SUBDB_VERSION_KEY;
+    size_t keylen = strlen(SUBDB_VERSION_KEY);
     const char *data = NULL;
     size_t datalen = 0;
     struct mboxlock *upgradelock = NULL;

--- a/lib/cyrusdb_flat.c
+++ b/lib/cyrusdb_flat.c
@@ -332,6 +332,7 @@ static int myopen(const char *fname, int flags, struct dbengine **ret, struct tx
             free_db(db);
             return CYRUSDB_IOERROR;
         }
+        errno = 0; /* ENOENT has been handled */
         db->fd = open(fname, O_RDWR | O_CREAT, 0644);
     }
 


### PR DESCRIPTION
**Reviewers**: I'd suggest stepping through this one commit by commit

* Fixes #5146 by more strictly checking boundaries when converting between mboxlist dbnames and keys.
* Adds a new Cassandane suite "Shared" with tests for subscribing to shared mailboxes.  I expect we'll accumulate other shared mailbox tests here over time.
* Bumps the subscriptions database version number from 2 to 3, and makes the upgrade-on-open path fix any broken v2 entries it finds.  It fixes the bad subscriptions by string manipulation -- it does _not_ check whether those mailboxes actually exist, nor whether the subscribed user has access to them.  I don't think this is a problem, as I believe you can ordinarily be subscribed to mailboxes that don't exist, or which you cannot see, and you just won't see them, or they'll have the `\Nonexistent` flag if you `LSUB` or `LIST (SUBSCRIBED) ...` them.
* Renames the existing Cassandane "Lsub" test suite to "Subscriptions", and adds tests that create a v2 subscriptions db with good and bad records, and verify that it's correctly upgraded and fixed on first open.
* Extends the old and barely-used Cassandane::Mboxname class to better support non-admin namespace mailboxes, because I needed that functionality for these tests.  These improvements should make this class useful in many other tests too.
* Also improves Cassandane::Util::Words a little, cause I needed lists of random words for the tests.