### PR TITLE
mbname_from_path: Don't crash with '..' at top of tree

### DIFF
--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -903,7 +903,7 @@ EXPORTED mbname_t *mbname_from_path(const char *path)
                 strarray_free(subs);
 
                 /* If we end up at a magic user.foo.INBOX, revert to user.foo */
-                if (mbname_userid(mbname) != NULL &&
+                if (mbname && mbname_userid(mbname) != NULL &&
                     strarray_size(mbname_boxes(mbname)) == 1 &&
                     !strcmp(strarray_nth(mbname_boxes(mbname), 0), "INBOX")) {
                     free(mbname_pop_boxes(mbname));


### PR DESCRIPTION
If we're at the top of the tree and we try to `mbpath -p ..`, we have no mbname pointer anymore, so don't try to call mbname_userid() on it.