### PR TITLE
fix master crash when DAEMON process exits abnormally

### DIFF
--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -192,6 +192,12 @@ sub lemming_service
     return $self->{instance}->add_service(_lemming_args(%params));
 }
 
+sub lemming_daemon
+{
+    my ($self, %params) = @_;
+    return $self->{instance}->add_daemon(_lemming_args(%params));
+}
+
 sub lemming_start
 {
     my ($self, %params) = @_;
@@ -1356,6 +1362,41 @@ sub test_ready_file
 
     # ready file should be newer than pid file
     $self->assert_num_gte($pid_sb->mtime, $ready_sb->mtime);
+}
+
+sub test_daemon_exits
+{
+    my ($self) = @_;
+
+    my $lemming_delay = 500; #ms
+    my $test_delay = 10; #s
+
+    xlog $self, "Test a program in the DAEMON section which fails";
+    $self->lemming_daemon(tag => 'A', delay => $lemming_delay, mode => 'exit');
+    # This service won't be used
+    my $srv = $self->lemming_service(tag => 'C');
+
+    $self->{instance}->start();
+
+    # make sure it runs long enough for the child janitor to wake up
+    sleep $test_delay;
+
+    # master had better still be running!
+    $self->assert($self->{instance}->is_running(),
+                  "master is no longer running");
+
+    # make sure those lemmings did actually die
+    my $census = $self->lemming_census();
+    # XXX upper limit on this should be MAX_READY_FAILS if we run for less
+    # XXX than MAX_READY_FAIL_INTERVAL seconds, but the delayed restart of
+    # XXX failed daemons doesn't seem to be actually delayed???
+    $self->assert_num_gte(1, $census->{A}->{dead});
+
+    # there'll be syslog errors as long as this is running, so stop it early
+    $self->{instance}->stop(no_check_syslog => 1);
+    # then consume and check them
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{too many failures for});
 }
 
 1;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1032,8 +1032,20 @@ sub tear_down
 
     $self->{cleanup_basedirs} = [@basedirs];
 
-    # maybe there's multiple errors, but we can only die for one of them...
-    die $stop_errors[0] if scalar @stop_errors;
+    if (@stop_errors) {
+        if (exists $self->{'__Error__'}) {
+            # XXX this feels fragile, but there isn't a correct way for
+            # XXX tear_down to see the test's result.
+
+            # looks like we already failed, and dying again here would conceal
+            # the test failure details, which are probably more interesting
+            xlog "errors found during instance shutdown";
+        }
+        else {
+            # maybe there's multiple errors, but we can only die once...
+            die $stop_errors[0];
+        }
+    }
 
     xlog "---------- END $self->{_name} ----------";
 }

--- a/master/master.c
+++ b/master/master.c
@@ -1525,16 +1525,17 @@ static void reap_child(void)
                 }
             }
 
-            if (s && !in_shutdown && failed) {
+            if (c->proc_handle) {
+                proc_cleanup(&c->proc_handle);
+            }
+            else if (s && !in_shutdown && failed) {
                 /* we don't have a proc_handle for service processes because
                  * they manage it themselves, but if one crashed it won't have
                  * cleaned it up
                  */
                 proc_force_cleanup(pid);
             }
-            else {
-                proc_cleanup(&c->proc_handle);
-            }
+
             centry_set_state(c, SERVICE_STATE_DEAD);
         } else {
             /* Are we multithreaded now? we don't know this child */

--- a/master/master.c
+++ b/master/master.c
@@ -1426,7 +1426,7 @@ static void reap_child(void)
                         s->lastreadyfail = now;
                         if (++s->nreadyfails >= MAX_READY_FAILS && s->exec) {
                             if (s->babysit) {
-                                syslog(LOG_ERR, "ERROR: too many failures for"
+                                syslog(LOG_ERR, "ERROR: too many failures for "
                                        "service %s/%s, disabling for %d seconds",
                                        SERVICEPARAM(s->name),
                                        SERVICEPARAM(s->familyname),


### PR DESCRIPTION
Fixes `Internal error: assertion failed (aborting): master/master.c: 340: c->proc_handle == NULL` error when DAEMON process exits abnormally