### PR TITLE
Don't send the "action strings" when notifying

### DIFF
--- a/changes/next/notify_action_string
+++ b/changes/next/notify_action_string
@@ -1,0 +1,20 @@
+Description:
+
+Sieve notifications no longer include the "actions string".
+
+
+Config changes:
+
+None required.
+
+
+Upgrade instructions:
+
+Generally, none required.  In the unlikely event that you required
+notifications sent by Sieve to include the list of exact actions taken so far,
+you may need to update that the expectations of downstream software.
+
+
+GitHub issue:
+
+None.

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -430,7 +430,6 @@ static int build_notify_message(sieve_interp_t *i,
 static int send_notify_callback(sieve_interp_t *interp,
                                 void *message_context,
                                 void *script_context, notify_list_t *notify,
-                                char *actions_string,
                                 const char **errmsg)
 {
     sieve_notify_context_t nc;
@@ -462,7 +461,6 @@ static int send_notify_callback(sieve_interp_t *interp,
     build_notify_message(interp, notify->message, message_context,
                          &out);
     buf_appendcstr(&out, "\n\n");
-    buf_appendcstr(&out, actions_string);
 
     nc.message = buf_cstring(&out);
     nc.fname = NULL;
@@ -677,7 +675,7 @@ static int do_sieve_error(int ret,
                notify_ret = send_notify_callback(interp,
                                                  message_context,
                                                  script_context,n,
-                                                 actions_string, &errmsg);
+                                                 &errmsg);
               ret |= notify_ret;
               }
             n = n->next;


### PR DESCRIPTION
These strings are largely useful for debugging, not end user consumption.

(This commit message was written by Ricardo Signes, replacing the previous internal Fastmail commit message.  The code change is by Bron Gondwana.)