### PR TITLE
don't add timezone data in http_caldav_sched.c

### DIFF
--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1147,8 +1147,6 @@ static void sched_deliver_remote(const char *cal_ownerid, const char *sched_user
 
     syslog(LOG_DEBUG, "sched_deliver_remote(%s, %X)", recipient, sparam->flags);
 
-    icalcomponent_add_required_timezones(sched_data->itip);
-
     if (sparam->flags & SCHEDTYPE_ISCHEDULE) {
         /* Use iSchedule */
         xmlNodePtr xml;


### PR DESCRIPTION
We removed this line quite some time ago in Fastmail builds, because we sometimes saw downstream problems with Exchange.

Ken Murchison's advice was that in general clients should not (or no longer) be looking at TZ data included in events, anyway.  Adding it could cause problems, but probably helps no one.  Instead, we'll just leave it be.

(This commit message was written by Ricardo Signes, replacing the previous internal Fastmail commit message.  The code change is by Bron Gondwana.)