### PR TITLE
jmap_contact.c: base64url encode vCard UIDs as JMAP ids

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_destroy_contents
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_destroy_contents
@@ -25,15 +25,17 @@ END:VCARD
 EOF
 
     my $VCard = Net::CardDAVTalk::VCard->new_fromstring($card);
-    my $cardId = basename($carddav->NewContact($abookId, $VCard), '.vcf');
+    $carddav->NewContact($abookId, $VCard);
+
+    my $res = $jmap->CallMethods([['Contact/get', {}, "R1"]]);
+    my $cardId = $res->[0][1]{list}[0]{id};
 
     xlog "Destroy addressbook (with and without onDestroyRemoveContents)";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
         ['AddressBook/set', {
             destroy => [$abookId],
         }, 'R1'],
-# XXX  Change to ContactCard/get once implemented
-        ['Contact/get', {
+        ['ContactCard/get', {
             ids => [$cardId],
             properties => ['id'],
         }, 'R2'],
@@ -41,7 +43,7 @@ EOF
             destroy => [$abookId],
             onDestroyRemoveContents => JSON::true,
         }, 'R3'],
-        ['Contact/get', {
+        ['ContactCard/get', {
             ids => [$cardId],
             properties => ['id'],
         }, 'R2'],

--- a/cassandane/tiny-tests/JMAPContacts/card_get_localizations
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_localizations
@@ -23,12 +23,12 @@ sub test_card_get_localizations
     # Sample card from RFC 6350
     # Second N suffix removed due to vparse bug
     # PROP-IDs added so we can easily compare the results
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $href = "Default/test.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:4.0
-UID:$id
+UID:$uid
 LANGUAGE:es
 FN:Gabriel García Márquez
 FN;LANGUAGE=jp:ガブリエル・ガルシア・マルケス
@@ -62,8 +62,7 @@ EOF
         version => '1.0',
         addressBookId => 'Default',
         'cyrusimap.org:href' => $carddav->fullpath() . $href,
-        id => $id,
-        uid => $id,
+        uid => $uid,
         kind => 'individual',
         language => 'es',    
         vCardProps => [
@@ -127,6 +126,7 @@ EOF
     my $have_jscard = $res->[0][1]{list}[0];
 
     # Delete generated fields
+    delete $have_jscard->{id};
     delete $have_jscard->{blobId};
     delete $have_jscard->{'cyrusimap.org:blobId'};
     delete $have_jscard->{'cyrusimap.org:size'};

--- a/cassandane/tiny-tests/JMAPContacts/card_get_ordered_phonetics
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_ordered_phonetics
@@ -20,12 +20,12 @@ sub test_card_get_ordered_phonetics
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $href = "Default/test.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:4.0
-UID:$id
+UID:$uid
 N;ALTID=n1;PHONETIC=IPA:/smɪθ/;/d͡ʒɑn/;;;;;
 N;JSCOMPS=";1;0";ALTID=n1:Smith;John;;;;;
 FN;DERIVED=TRUE:John Smith
@@ -46,8 +46,7 @@ EOF
         version => '1.0',
         addressBookId => 'Default',
         'cyrusimap.org:href' => $carddav->fullpath() . $href,
-        id => $id,
-        uid => $id,
+        uid => $uid,
         created => '2023-08-24T14:36:19Z',
         vCardProps => [
             [ 'version', {}, 'text', '4.0' ]
@@ -65,6 +64,7 @@ EOF
     my $have_jscard = $res->[0][1]{list}[0];
 
     # Delete generated fields
+    delete $have_jscard->{id};
     delete $have_jscard->{blobId};
     delete $have_jscard->{'cyrusimap.org:blobId'};
     delete $have_jscard->{'cyrusimap.org:size'};
@@ -73,7 +73,5 @@ EOF
     normalize_jscard($want_jscard);
     normalize_jscard($have_jscard);
 
-warn Dumper($want_jscard);
-warn Dumper($have_jscard);
     $self->assert_deep_equals($want_jscard, $have_jscard);
 }

--- a/cassandane/tiny-tests/JMAPContacts/card_get_phonetics
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_phonetics
@@ -20,12 +20,12 @@ sub test_card_get_phonetics
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $href = "Default/test.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:4.0
-UID:$id
+UID:$uid
 LANGUAGE:zho-Hant
 FN:孫中山文逸仙
 N;ALTID=1;LANGUAGE=zho-Hant:孫;中山;文,逸仙;;
@@ -47,8 +47,7 @@ EOF
         version => '1.0',
         addressBookId => 'Default',
         'cyrusimap.org:href' => $carddav->fullpath() . $href,
-        id => $id,
-        uid => $id,
+        uid => $uid,
         language => 'zho-Hant',    
         vCardProps => [
             [ 'version', {}, 'text', '4.0' ]
@@ -77,6 +76,7 @@ EOF
     my $have_jscard = $res->[0][1]{list}[0];
 
     # Delete generated fields
+    delete $have_jscard->{id};
     delete $have_jscard->{blobId};
     delete $have_jscard->{'cyrusimap.org:blobId'};
     delete $have_jscard->{'cyrusimap.org:size'};

--- a/cassandane/tiny-tests/JMAPContacts/card_get_v3
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_v3
@@ -20,12 +20,12 @@ sub test_card_get_v3
     );
 
     # PROP-IDs added so we can easily compare the results
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $href = "Default/test.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:3.0
-UID:$id
+UID:$uid
 BDAY;PROP-ID=A1:1944-06-07
 N:Gump;Forrest;;Mr.
 FN:Forrest Gump
@@ -52,8 +52,7 @@ EOF
         version => '1.0',
         addressBookId => 'Default',
         'cyrusimap.org:href' => $carddav->fullpath() . $href,
-        id => $id,
-        uid => $id,
+        uid => $uid,
         updated => '2008-04-24T19:52:43Z',
         vCardProps => [
             [ 'version', {}, 'text', '3.0' ]
@@ -115,6 +114,7 @@ EOF
     $self->assert_not_null($blobid);
 
     # Delete generated fields
+    delete $have_jscard->{id};
     delete $have_jscard->{blobId};
     delete $have_jscard->{media}{P1}{blobId};
     delete $have_jscard->{'cyrusimap.org:blobId'};

--- a/cassandane/tiny-tests/JMAPContacts/card_get_v4
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_v4
@@ -22,12 +22,12 @@ sub test_card_get_v4
     # Sample card from RFC 6350
     # Second N suffix removed due to vparse bug
     # PROP-IDs added so we can easily compare the results
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $href = "Default/test.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:4.0
-UID;VALUE=TEXT:$id
+UID;VALUE=TEXT:$uid
 KIND:individual
 FN:Simon Perreault
 N:Perreault;Simon;;;ing. jr
@@ -74,8 +74,7 @@ EOF
         version => '1.0',
         addressBookId => 'Default',
         'cyrusimap.org:href' => $carddav->fullpath() . $href,
-        id => $id,
-        uid => $id,
+        uid => $uid,
         kind => 'individual',
         updated => '2023-04-22T19:46:39Z',
         vCardProps => [
@@ -214,6 +213,7 @@ EOF
     $self->assert_not_null($s_blobid);
 
     # Delete generated fields
+    delete $have_jscard->{id};
     delete $have_jscard->{blobId};
     delete $have_jscard->{media}{P1}{blobId};
     delete $have_jscard->{media}{S1}{blobId};

--- a/cassandane/tiny-tests/JMAPContacts/card_query
+++ b/cassandane/tiny-tests/JMAPContacts/card_query
@@ -203,20 +203,24 @@ sub test_card_query
     my $id2 = $res->[0][1]{created}{"2"}{id};
     my $id3 = $res->[0][1]{created}{"3"}{id};
     my $id4 = $res->[0][1]{created}{"4"}{id};
+    my $uid1 = $res->[0][1]{created}{"1"}{uid};
+    my $uid2 = $res->[0][1]{created}{"2"}{uid};
+    my $uid3 = $res->[0][1]{created}{"3"}{uid};
+    my $uid4 = $res->[0][1]{created}{"4"}{uid};
 
     xlog $self, "create card groups";
     $res = $jmap->CallMethods([['ContactCard/set', {create => {
         "1" => { kind => 'group',
                  name => { full => "group1" },
-                 members => { $id1 => JSON::true, $id2 => JSON::true }
+                 members => { $uid1 => JSON::true, $uid2 => JSON::true }
                },
         "2" => { kind => 'group',
                  name => { full => "group2" },
-                 members => { $id3 => JSON::true }
+                 members => { $uid3 => JSON::true }
                },
         "3" => { kind => 'group',
                  name => { full => "group3" },
-                 members => { $id4 => JSON::true }
+                 members => { $uid4 => JSON::true }
                }
     }}, "R1"]]);
 

--- a/cassandane/tiny-tests/JMAPContacts/card_query_shared
+++ b/cassandane/tiny-tests/JMAPContacts/card_query_shared
@@ -199,6 +199,10 @@ sub test_card_query_shared
     my $id2 = $res->[0][1]{created}{"card2"}{id};
     my $id3 = $res->[0][1]{created}{"card3"}{id};
     my $id4 = $res->[0][1]{created}{"card4"}{id};
+    my $uid1 = $res->[0][1]{created}{"card1"}{uid};
+    my $uid2 = $res->[0][1]{created}{"card2"}{uid};
+    my $uid3 = $res->[0][1]{created}{"card3"}{uid};
+    my $uid4 = $res->[0][1]{created}{"card4"}{uid};
 
     xlog $self, "create card groups";
     $res = $jmap->CallMethods([ [
@@ -209,17 +213,17 @@ sub test_card_query_shared
                 group1 => {
                     kind    => 'group',
                     name    => { full => "group1" },
-                    members => { $id1 => JSON::true, $id2 => JSON::true }
+                    members => { $uid1 => JSON::true, $uid2 => JSON::true }
                 },
                 group2 => {
                     kind    => 'group',
                     name    => { full => "group2" },
-                    members => { $id3 => JSON::true }
+                    members => { $uid3 => JSON::true }
                 },
                 group3 => {
                     kind    => 'group',
                     name    => { full => "group3" },
-                    members => { $id4 => JSON::true }
+                    members => { $uid4 => JSON::true }
                 }
             }
         },

--- a/cassandane/tiny-tests/JMAPContacts/card_set_state
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_state
@@ -10,7 +10,7 @@ sub test_card_set_state
 
     xlog $self, "create contact";
     my $name = 'Mr. John Q. Public, Esq.';
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
 
     my $res = $jmap->CallMethods([
         ['ContactCard/set', {
@@ -18,7 +18,7 @@ sub test_card_set_state
                 "1" => {
                     '@type' => 'Card',
                     version => '1.0',
-                    uid => $id,
+                    uid => $uid,
                     name => { full => $name }
                 }
             }
@@ -27,7 +27,7 @@ sub test_card_set_state
     $self->assert_not_null($res);
     $self->assert_str_equals('ContactCard/set', $res->[0][0]);
     $self->assert_str_equals('R1', $res->[0][2]);
-    $id = $res->[0][1]{created}{"1"}{id};
+    my $id = $res->[0][1]{created}{"1"}{id};
     my $state = $res->[0][1]{newState};
 
     xlog $self, "get contact $id";

--- a/cassandane/tiny-tests/JMAPContacts/card_set_update
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_update
@@ -19,7 +19,7 @@ sub test_card_set_update
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
 
     my $res = $jmap->CallMethods([
         ['ContactCard/set', {
@@ -27,7 +27,7 @@ sub test_card_set_update
                 "1" => {
                     '@type' => 'Card',
                     version => '1.0',
-                    uid => $id,
+                    uid => $uid,
                     name => { full => 'John Doe' },
                     nicknames => {
                         k391 => {
@@ -41,6 +41,7 @@ sub test_card_set_update
     ]);
 
     $self->assert_not_null($res->[0][1]{created}{1});
+    my $id = $res->[0][1]{created}{1}{id};
     my $href = $res->[0][1]{created}{1}{'cyrusimap.org:href'};
 
     $res = $jmap->CallMethods([
@@ -134,7 +135,7 @@ sub test_card_set_update
     ]);
 
     my $abookid = $res->[0][1]{created}{"1"}{id};
-    $href = "$abookid/$id.vcf";
+    $href = "$abookid/$uid.vcf";
 
     $res = $jmap->CallMethods([
         ['ContactCard/set', {
@@ -155,7 +156,7 @@ sub test_card_set_update
     $card = $res->{content};
     $card =~ s/\r?\n[ \t]+//gs;  # unfold long properties
 
-    $self->assert_matches(qr/UID:$id/, $card);
+    $self->assert_matches(qr/UID:$uid/, $card);
     $self->assert_matches(qr/NICKNAME;PROP-ID=foo:Doey/, $card);
     $self->assert_matches(qr/CATEGORIES:foo/, $card);
     $self->assert_matches(qr/REV:/, $card);

--- a/cassandane/tiny-tests/JMAPContacts/card_set_update_media_blob
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_update_media_blob
@@ -19,7 +19,7 @@ sub test_card_set_update_media_blob
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
 
     my $res = $jmap->CallMethods([
         ['ContactCard/set', {
@@ -27,7 +27,7 @@ sub test_card_set_update_media_blob
                 "1" => {
                     '@type' => 'Card',
                     version => '1.0',
-                    uid => $id,
+                    uid => $uid,
                     name => { full => 'Jane Doe' },
                     media => {
                         res1 => {
@@ -42,6 +42,7 @@ sub test_card_set_update_media_blob
     ]);
 
     $self->assert_not_null($res->[0][1]{created}{1});
+    my $id = $res->[0][1]{created}{1}{id};
     my $href = $res->[0][1]{created}{1}{'cyrusimap.org:href'};
 
     $res = $carddav->Request('GET', $href, '',

--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_get_v3
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_get_v3
@@ -19,15 +19,15 @@ sub test_cardgroup_get_v3
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $member1 = 'urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af';
     my $member2 = 'urn:uuid:b8767877-b4a1-4c70-9acc-505d3819e519';
-    my $href = "Default/$id.vcf";
+    my $href = "Default/$uid.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:3.0
 X-ADDRESSBOOKSERVER-KIND:group
-UID:$id
+UID:$uid
 FN:The Doe Family
 N:;;;;
 X-ADDRESSBOOKSERVER-MEMBER:$member1
@@ -48,8 +48,7 @@ EOF
         version => '1.0',
         addressBookId => 'Default',
         'cyrusimap.org:href' => $carddav->fullpath() . $href,
-        id => $id,
-        uid => $id,
+        uid => $uid,
         kind => 'group',
         vCardProps => [
             [ 'version', {}, 'text', '3.0' ]
@@ -67,6 +66,7 @@ EOF
     my $have_jscard = $res->[0][1]{list}[0];
 
     # Delete generated fields
+    delete $have_jscard->{id};
     delete $have_jscard->{blobId};
     delete $have_jscard->{'cyrusimap.org:blobId'};
     delete $have_jscard->{'cyrusimap.org:size'};

--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_get_v4
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_get_v4
@@ -19,15 +19,15 @@ sub test_cardgroup_get_v4
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $member1 = 'urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af';
     my $member2 = 'urn:uuid:b8767877-b4a1-4c70-9acc-505d3819e519';
-    my $href = "Default/$id.vcf";
+    my $href = "Default/$uid.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:4.0
 KIND:group
-UID:$id
+UID:$uid
 FN:The Doe Family
 MEMBER:$member1
 MEMBER:$member2
@@ -47,8 +47,7 @@ EOF
         version => '1.0',
         addressBookId => 'Default',
         'cyrusimap.org:href' => $carddav->fullpath() . $href,
-        id => $id,
-        uid => $id,
+        uid => $uid,
         kind => 'group',
         vCardProps => [
             [ 'version', {}, 'text', '4.0' ]
@@ -66,6 +65,7 @@ EOF
     my $have_jscard = $res->[0][1]{list}[0];
 
     # Delete generated fields
+    delete $have_jscard->{id};
     delete $have_jscard->{blobId};
     delete $have_jscard->{'cyrusimap.org:blobId'};
     delete $have_jscard->{'cyrusimap.org:size'};

--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_query
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_query
@@ -187,20 +187,24 @@ sub test_cardgroup_query
     my $id2 = $res->[0][1]{created}{"2"}{id};
     my $id3 = $res->[0][1]{created}{"3"}{id};
     my $id4 = $res->[0][1]{created}{"4"}{id};
+    my $uid1 = $res->[0][1]{created}{"1"}{uid};
+    my $uid2 = $res->[0][1]{created}{"2"}{uid};
+    my $uid3 = $res->[0][1]{created}{"3"}{uid};
+    my $uid4 = $res->[0][1]{created}{"4"}{uid};
 
     xlog $self, "create card groups";
     $res = $jmap->CallMethods([['ContactCard/set', {create => {
         "1" => { kind => 'group',
                  name => { full => "group1" },
-                 members => { $id1 => JSON::true, $id2 => JSON::true }
+                 members => { $uid1 => JSON::true, $uid2 => JSON::true }
                },
         "2" => { kind => 'group',
                  name => { full => "group2" },
-                 members => { $id3 => JSON::true }
+                 members => { $uid3 => JSON::true }
                },
         "3" => { kind => 'group',
                  name => { full => "group3" },
-                 members => { $id4 => JSON::true }
+                 members => { $uid4 => JSON::true }
                }
     }}, "R1"]]);
 
@@ -236,7 +240,7 @@ sub test_cardgroup_query
 
     xlog $self, "filter by member";
     $res = $jmap->CallMethods([ ['ContactCard/query', {
-                    filter => { kind => "group", hasMember => $id3 }
+                    filter => { kind => "group", hasMember => $uid3 }
                 }, "R1"] ]);
     $self->assert_num_equals(1, $res->[0][1]{total});
     $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});

--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_set_create
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_set_create
@@ -22,7 +22,7 @@ sub test_cardgroup_set_create
     my $name = 'The Doe Family';
     my $member1 = "urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af";
     my $member2 = "urn:uuid:b8767877-b4a1-4c70-9acc-505d3819e519";
-    my $id = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $uid = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
 
     my $res = $jmap->CallMethods([
         ['ContactCard/set', {
@@ -30,7 +30,7 @@ sub test_cardgroup_set_create
                 "1" => {
                     '@type' => 'Card',
                     version => '1.0',
-                    uid => $id,
+                    uid => $uid,
                     kind => 'group',
                     name => { full => $name },
                     members => {
@@ -53,7 +53,7 @@ sub test_cardgroup_set_create
 
     $self->assert_matches(qr/VERSION:4.0/, $card);
     $self->assert_matches(qr/KIND:GROUP/, $card);
-    $self->assert_matches(qr/UID:$id/, $card);
+    $self->assert_matches(qr/UID:$uid/, $card);
     $self->assert_matches(qr/FN:$name/, $card);
     $self->assert_matches(qr/MEMBER:$member1/, $card);
     $self->assert_matches(qr/MEMBER:$member2/, $card);

--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_set_update
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_set_update
@@ -22,8 +22,7 @@ sub test_cardgroup_set_update
     my $name = 'The Doe Family';
     my $member1 = "urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af";
     my $member2 = "urn:uuid:b8767877-b4a1-4c70-9acc-505d3819e519";
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
-    my $href = "Default/$id.vcf";
+    my $uid = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
 
     my $res = $jmap->CallMethods([
         ['ContactCard/set', {
@@ -31,7 +30,7 @@ sub test_cardgroup_set_update
                 "1" => {
                     '@type' => 'Card',
                     version => '1.0',
-                    uid => $id,
+                    uid => $uid,
                     kind => 'group',
                     name => { full => $name },
                     members => {
@@ -43,7 +42,9 @@ sub test_cardgroup_set_update
     ]);
 
     $self->assert_not_null($res->[0][1]{created}{1});
+    my $id = $res->[0][1]{created}{1}{id};
 
+    my $href = $res->[0][1]{created}{1}{'cyrusimap.org:href'};
     $res = $carddav->Request('GET', $href, '',
                              'Accept' => 'text/vcard; version=4.0');
 

--- a/cassandane/tiny-tests/JMAPContacts/contact_query_uid
+++ b/cassandane/tiny-tests/JMAPContacts/contact_query_uid
@@ -76,5 +76,5 @@ sub test_contact_query_uid
     ]);
     $self->assert_str_equals("Contact/query", $res->[0][0]);
     my %gotIds =  map { $_ => 1 } @{$res->[0][1]{ids}};
-    $self->assert_deep_equals({ $contactUid1 => 1, $contactUid3 => 1, }, \%gotIds);
+    $self->assert_deep_equals({ $contactId1 => 1, $contactId3 => 1, }, \%gotIds);
 }

--- a/cassandane/tiny-tests/JMAPContacts/contact_set
+++ b/cassandane/tiny-tests/JMAPContacts/contact_set
@@ -22,7 +22,7 @@ sub test_contact_set
 
     # get expands default values, so do the same manually
     $contact->{id} = $id;
-    $contact->{uid} = $id;
+    $contact->{uid} = $res->[0][1]{created}{"1"}{uid};
     $contact->{isFlagged} = JSON::false;
     $contact->{prefix} = '';
     $contact->{suffix} = '';

--- a/cassandane/tiny-tests/JMAPContacts/contact_set_uid
+++ b/cassandane/tiny-tests/JMAPContacts/contact_set_uid
@@ -39,8 +39,8 @@ sub test_contact_set_uid
     $self->assert_not_null($res->[1][1]{list}[0]{uid});
     my($filename, $dirs, $suffix) = fileparse($res->[1][1]{list}[0]{"x-href"}, ".vcf");
     $self->assert_not_null($res->[1][1]{list}[0]->{id});
-    $self->assert_str_equals($res->[1][1]{list}[0]->{uid}, $res->[1][1]{list}[0]->{id});
-    $self->assert_str_equals($filename, $res->[1][1]{list}[0]->{id});
+    $self->assert_str_not_equals($res->[1][1]{list}[0]->{uid}, $res->[1][1]{list}[0]->{id});
+    $self->assert_str_equals($filename, $res->[1][1]{list}[0]->{uid});
     $jmap->{CreatedIds} = {};
 
     # A non-pathsafe UID maps to uid but not the DAV resource.
@@ -59,7 +59,7 @@ sub test_contact_set_uid
     $self->assert_not_null($res->[1][1]{list}[0]{uid});
     ($filename, $dirs, $suffix) = fileparse($res->[1][1]{list}[0]{"x-href"}, ".vcf");
     $self->assert_not_null($res->[1][1]{list}[0]->{id});
-    $self->assert_str_equals($res->[1][1]{list}[0]->{id}, $res->[1][1]{list}[0]->{uid});
+    $self->assert_str_not_equals($res->[1][1]{list}[0]->{id}, $res->[1][1]{list}[0]->{uid});
     $self->assert_str_not_equals('path#uid', $filename);
     $jmap->{CreatedIds} = {};
 

--- a/cassandane/tiny-tests/JMAPContacts/contact_update_grouped_property
+++ b/cassandane/tiny-tests/JMAPContacts/contact_update_grouped_property
@@ -19,12 +19,12 @@ sub test_contact_update_grouped_property
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
-    my $href = "Default/$id.vcf";
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $href = "Default/$uid.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:3.0
-UID:$id
+UID:$uid
 N:Gump;Forrest;;Mr.
 FN:Forrest Gump
 ITEM1.ORG:Bubba Gump Shrimp Co.
@@ -43,6 +43,7 @@ EOF
         }, 'R1']
     ]);
 
+    my $id = $res->[0][1]{list}[0]{id};
     $self->assert_equals("Bubba Gump Shrimp Co.",
                          $res->[0][1]{list}[0]{company});
 

--- a/cassandane/tiny-tests/JMAPContacts/contactgroup_get_deduplicate_contactids
+++ b/cassandane/tiny-tests/JMAPContacts/contactgroup_get_deduplicate_contactids
@@ -50,13 +50,15 @@ EOF
             properties => ['contactIds', 'otherAccountContactIds' ],
         }, 'R1']
     ]);
-    my @gotids = sort @{$res->[0][1]{list}[0]{contactIds}};
 
     xlog "Assert contactIds in group got deduplicated";
-    $self->assert_deep_equals(\@wantids, \@gotids);
+    $self->assert_num_equals(3, scalar @{$res->[0][1]{list}[0]{contactIds}});
+    $self->assert_str_not_equals($res->[0][1]{list}[0]{contactIds}[0],
+                                 $res->[0][1]{list}[0]{contactIds}[1]);
+    $self->assert_str_not_equals($res->[0][1]{list}[0]{contactIds}[0],
+                                 $res->[0][1]{list}[0]{contactIds}[2]);
 
     xlog "Assert otherAccountContactIds got deduplicated";
-    $self->assert_deep_equals({ foo => \@wantOtherAccountIds },
-        $res->[0][1]{list}[0]{otherAccountContactIds});
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}[0]{otherAccountContactIds}{foo}});
 
 }

--- a/cassandane/tiny-tests/JMAPContacts/contactgroup_get_v4
+++ b/cassandane/tiny-tests/JMAPContacts/contactgroup_get_v4
@@ -19,12 +19,12 @@ sub test_contactgroup_get_v4
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
-    my $href = "Default/$id.vcf";
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $href = "Default/$uid.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:4.0
-UID:$id
+UID:$uid
 KIND:group
 MEMBER:urn:uuid:60f60d95-1f33-480c-bfd6-02b93a07aefc
 MEMBER:urn:uuid:3e7cfbaf-3199-41bd-8749-38b8d1c89605
@@ -41,7 +41,7 @@ EOF
         ['ContactGroup/get', {
         }, 'R1']
     ]);
-    $self->assert_str_equals($id, $res->[0][1]{list}[0]{id});
+    $self->assert_str_equals($uid, $res->[0][1]{list}[0]{uid});
     $self->assert_str_equals('Test', $res->[0][1]{list}[0]{name});
     $self->assert_num_equals(2, scalar @{$res->[0][1]{list}[0]{contactIds}});
 }

--- a/cassandane/tiny-tests/JMAPContacts/contactgroup_query
+++ b/cassandane/tiny-tests/JMAPContacts/contactgroup_query
@@ -76,5 +76,5 @@ sub test_contactgroup_query
     ]);
     $self->assert_str_equals("ContactGroup/query", $res->[0][0]);
     my %gotIds =  map { $_ => 1 } @{$res->[0][1]{ids}};
-    $self->assert_deep_equals({ $contactGroupUid2 => 1, $contactGroupUid3 => 1, }, \%gotIds);
+    $self->assert_deep_equals({ $contactGroupId2 => 1, $contactGroupId3 => 1, }, \%gotIds);
 }

--- a/cassandane/tiny-tests/JMAPContacts/contactgroup_query_uid
+++ b/cassandane/tiny-tests/JMAPContacts/contactgroup_query_uid
@@ -76,5 +76,5 @@ sub test_contactgroup_query_uid
     ]);
     $self->assert_str_equals("ContactGroup/query", $res->[0][0]);
     my %gotIds =  map { $_ => 1 } @{$res->[0][1]{ids}};
-    $self->assert_deep_equals({ $contactGroupUid1 => 1, $contactGroupUid3 => 1, }, \%gotIds);
+    $self->assert_deep_equals({ $contactGroupId1 => 1, $contactGroupId3 => 1, }, \%gotIds);
 }

--- a/cassandane/tiny-tests/JMAPContacts/contactgroup_set_uid
+++ b/cassandane/tiny-tests/JMAPContacts/contactgroup_set_uid
@@ -37,8 +37,8 @@ sub test_contactgroup_set_uid
     $self->assert_not_null($res->[1][1]{list}[0]{uid});
     my($filename, $dirs, $suffix) = fileparse($res->[1][1]{list}[0]{"x-href"}, ".vcf");
     $self->assert_not_null($res->[1][1]{list}[0]->{id});
-    $self->assert_str_equals($res->[1][1]{list}[0]->{uid}, $res->[1][1]{list}[0]->{id});
-    $self->assert_str_equals($filename, $res->[1][1]{list}[0]->{id});
+    $self->assert_str_not_equals($res->[1][1]{list}[0]->{uid}, $res->[1][1]{list}[0]->{id});
+    $self->assert_str_equals($filename, $res->[1][1]{list}[0]->{uid});
     $jmap->{CreatedIds} = {};
 
     # A non-pathsafe UID maps to uid but not the DAV resource.
@@ -56,7 +56,7 @@ sub test_contactgroup_set_uid
     $self->assert_not_null($res->[1][1]{list}[0]{uid});
     ($filename, $dirs, $suffix) = fileparse($res->[1][1]{list}[0]{"x-href"}, ".vcf");
     $self->assert_not_null($res->[1][1]{list}[0]->{id});
-    $self->assert_str_equals($res->[1][1]{list}[0]->{id}, $res->[1][1]{list}[0]->{uid});
+    $self->assert_str_not_equals($res->[1][1]{list}[0]->{id}, $res->[1][1]{list}[0]->{uid});
     $self->assert_str_not_equals('path#uid', $filename);
     $jmap->{CreatedIds} = {};
 

--- a/cassandane/tiny-tests/JMAPContacts/contactgroup_set_update_v4
+++ b/cassandane/tiny-tests/JMAPContacts/contactgroup_set_update_v4
@@ -21,19 +21,16 @@ sub test_contactgroup_set_update_v4
         expandurl => 1,
     );
 
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
-    my $contact1 = '60f60d95-1f33-480c-bfd6-02b93a07aefc';
-    my $contact2 = '3e7cfbaf-3199-41bd-8749-38b8d1c89605';
-    my $contact3 = '5b3b9ce1-0b5e-4cbd-8add-018321cad51b';
-    my $href = "Default/$id.vcf";
+    my $uid = 'urn:uuid:ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $href = "Default/group.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:4.0
-UID:$id
+UID:$uid
 KIND:group
-MEMBER:urn:uuid:$contact1
-MEMBER:urn:uuid:$contact2
-MEMBER:urn:uuid:$contact3
+MEMBER:urn:uuid:60f60d95-1f33-480c-bfd6-02b93a07aefc
+MEMBER:urn:uuid:3e7cfbaf-3199-41bd-8749-38b8d1c89605
+MEMBER:urn:uuid:5b3b9ce1-0b5e-4cbd-8add-018321cad51b
 FN:Test
 REV:20220217T152253Z
 N:Test
@@ -47,12 +44,13 @@ EOF
         ['ContactGroup/get', {
         }, 'R1']
     ]);
-    $self->assert_str_equals($id, $res->[0][1]{list}[0]{id});
+    my $id = $res->[0][1]{list}[0]{id};
+    $self->assert_str_equals($uid, $res->[0][1]{list}[0]{uid});
     $self->assert_str_equals('Test', $res->[0][1]{list}[0]{name});
     $self->assert_num_equals(3, scalar @{$res->[0][1]{list}[0]{contactIds}});
-    $self->assert_str_equals($contact1, $res->[0][1]{list}[0]{contactIds}[0]);
-    $self->assert_str_equals($contact2, $res->[0][1]{list}[0]{contactIds}[1]);
-    $self->assert_str_equals($contact3, $res->[0][1]{list}[0]{contactIds}[2]);
+    my $contact1 = $res->[0][1]{list}[0]{contactIds}[0];
+    my $contact2 = $res->[0][1]{list}[0]{contactIds}[1];
+    my $contact3 = $res->[0][1]{list}[0]{contactIds}[2];
 
     xlog $self, "update contact group by removing a member and reordering";
     $res = $jmap->CallMethods([['ContactGroup/set', {update => {

--- a/cassandane/tiny-tests/JMAPContacts/misc_categories
+++ b/cassandane/tiny-tests/JMAPContacts/misc_categories
@@ -22,12 +22,12 @@ sub test_misc_categories
 
 
     xlog $self, "create a contact with two categories";
-    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
-    my $href = "Default/$id.vcf";
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $href = "Default/$uid.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
 VERSION:3.0
-UID:$id
+UID:$uid
 N:Gump;Forrest;;Mr.
 FN:Forrest Gump
 ORG:Bubba Gump Shrimp Co.
@@ -42,12 +42,13 @@ EOF
     my $data = $carddav->Request('GET', $href);
     $self->assert_matches(qr/cat1,cat2/, $data->{content});
 
-    my $fetch = $jmap->CallMethods([['Contact/get', {ids => [$id]}, "R2"]]);
+    my $fetch = $jmap->CallMethods([['Contact/get', {}, "R2"]]);
     $self->assert_not_null($fetch);
     $self->assert_str_equals('Contact/get', $fetch->[0][0]);
     $self->assert_str_equals('R2', $fetch->[0][2]);
     $self->assert_str_equals('Forrest', $fetch->[0][1]{list}[0]{firstName});
 
+    my $id = $fetch->[0][1]{list}[0]{id};
     my $res = $jmap->CallMethods([['Contact/set', {
                     update => {$id => {firstName => "foo"}}
                 }, "R1"]]);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1916,6 +1916,8 @@ static void _email_search_contactgroup(search_expr_t *parent,
 {
     if (!contactgroups || !contactgroups->size) return;
 
+    if (*groupid) groupid = contactid_to_uid(groupid);
+
     strarray_t *members = hash_lookup(groupid, contactgroups);
     if (!members || !strarray_size(members)) {
         search_expr_new(parent, SEOP_FALSE);

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -229,7 +229,8 @@ HIDDEN int jmap_email_contactfilter_from_filtercondition(struct jmap_parser *par
     for (c = contactfilters; c->field; c++) {
         json_t *arg = json_object_get(filter, c->field);
         if (!arg) continue;
-        const char *groupid = c->isany ? (json_is_true(arg) ? "" : NULL) : json_string_value(arg);
+        const char *groupid = c->isany ? (json_is_true(arg) ? "" : NULL) :
+            contactid_to_uid(json_string_value(arg));
         if (!groupid) continue;
         if (hash_lookup(groupid, &cfilter->contactgroups)) continue;
 

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1491,3 +1491,24 @@ EXPORTED int jmap_is_valid_id(const char *id)
     return 1;
 }
 
+EXPORTED const char *contactid_to_uid(const char *id)
+{
+    static struct buf buf = BUF_INITIALIZER;
+
+    if (!id) return NULL;
+
+    buf_reset(&buf);
+    charset_decode(&buf, id, strlen(id), ENCODING_BASE64URL);
+    return buf_cstring(&buf);
+}
+
+EXPORTED const char *contactid_from_uid(const char *uid)
+{
+    static struct buf buf = BUF_INITIALIZER;
+
+    if (!uid) return NULL;
+
+    buf_reset(&buf);
+    charset_encode(&buf, uid, strlen(uid), ENCODING_BASE64URL);
+    return buf_cstring(&buf);
+}

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -216,4 +216,7 @@ extern void jmap_caleventid_free(struct jmap_caleventid **eidptr);
 extern void jmap_alertid_encode(icalcomponent *valarm, struct buf *buf);
 #endif /* HAVE_ICAL */
 
+extern const char *contactid_to_uid(const char *id);
+extern const char *contactid_from_uid(const char *uid);
+
 #endif /* JMAP_UTIL_H */


### PR DESCRIPTION
This prevents us from return "urn:uuid:xxx" as an object id, but also allows us to derive the vCard UID from the object id to avoid any changes to dav.db