### PR TITLE
avoid docker ipv6 nonsense

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
         image: cyrusimapdocker/cyrus-bookworm:latest
-        options: --sysctl net.ipv6.conf.all.disable_ipv6=0 --init
+        options: --init
     steps:
     - uses: actions/checkout@v4
       with:

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1213,7 +1213,7 @@ sub start
             Cassandane::Instance->get_version($self->{installation});
 
         if ($maj > 3 || ($maj == 3 && $min >= 1)) {
-            my $host = 'localhost';
+            my $host = '127.0.0.1';
             my $port = Cassandane::PortManager::alloc($host);
 
             $self->{config}->set(

--- a/cassandane/Cassandane/PortManager.pm
+++ b/cassandane/Cassandane/PortManager.pm
@@ -88,6 +88,16 @@ sub port_is_free
         LocalPort => $port,
         Proto     => 'tcp',
         ReuseAddr => 1,
+
+        # There's something odd going on with IO::Socket::IP's use of
+        # getaddrinfo, such that if you provide "::1" as the local address, and
+        # the loopback interface has inet6, but another (say, eth0) interface
+        # does not, the behavior of AI_ADDRCONFIG will be to act as if the
+        # system has no inet6 support, and so inet6 bindings should not be
+        # offered.  Something seems amiss, but I'm not sure where.  Using 0
+        # will allow ports on ::1 to seem available, though.
+        # -- rjbs, 2024-12-14
+        GetAddrInfoFlags => 0,
     );
 
     unless ($socket) {


### PR DESCRIPTION
The key thing here is less that we're making the tests better — which is up for debate — but that it makes it the tests run with less weird Docker fiddling.