### PR TITLE
Clearmodseq

### DIFF
--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -426,6 +426,46 @@ sub test_reconstruct_splitconv
 }
 
 #
+# test clearing the modseq
+#
+sub test_clearmodseq
+    :min_version_3_1
+{
+    my ($self) = @_;
+
+    my $talk = $self->{store}->get_client();
+
+    # check IMAP server has the XCONVERSATIONS capability
+    $self->assert($talk->capability()->{xconversations});
+
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->setquota('user.cassandane', ['STORAGE', 500000]);
+
+    for (1..20) {
+      $self->make_message("Message A$_");
+    }
+
+    my $precounters = $self->{store}->get_counters();
+    # we've made a bunch of changes, this should be more than 10!
+    $self->assert($precounters->{highestmodseq} > 10, "$precounters->{highestmodseq} > 10");
+
+    # zero out the modseqs
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb', '-M', 'cassandane');
+
+    my $midcounters = $self->{store}->get_counters();
+    # we haven't made any changes, should actually be zero!
+    $self->assert($midcounters->{highestmodseq} < 10, "$midcounters->{highestmodseq} < 10");
+
+    $self->make_message("Message B1");
+    $self->make_message("Message B2");
+
+    my $postcounters = $self->{store}->get_counters();
+    # we've only created two more emails, it shouldn't have bounced higher
+    $self->assert($postcounters->{highestmodseq} < 10, "$postcounters->{highestmodseq} < 10");
+
+}
+
+#
 # Test APPEND of messages to IMAP
 #
 sub _munge_annot_crc

--- a/changes/next/clearmodseq
+++ b/changes/next/clearmodseq
@@ -1,0 +1,19 @@
+Description:
+
+Added --clearmodseq option to ctl_conversationsdb
+
+
+Config changes:
+
+No changes
+
+
+Upgrade instructions:
+
+No upgrade required, however if you have crazy large modseqs in a user for some reason, this
+command can be used to reset them.
+
+
+GitHub issue:
+
+No github issue

--- a/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/ctl_conversationsdb.rst
@@ -93,6 +93,11 @@ Options
     The information can all be recalculated (eventually) from message
     headers, using the **-b** option.
 
+.. option:: -M, --clearmodseq
+
+    Reset the modseqs for all messages and conversation highwatermarks
+    for user *userid*, and from the user's counters file.
+
 .. option:: -b, --rebuild
 
     Rebuild all conversation information in the conversations database

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -3258,7 +3258,7 @@ static int zeromodseq_b_cb(void *rock,
     conversation_t *conv = conversation_new();
     int r;
 
-    r = conversation_parse(val, vallen, conv, /*flags*/0);
+    r = conversation_parse(val, vallen, conv, CONV_WITHALL);
     if (r) goto done;
 
     /* lower the modseqs */

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2450,12 +2450,14 @@ EXPORTED int conversations_update_record(struct conversations_state *cstate,
 
     if (old && new) {
         /* we're always moving forwards */
-        assert(old->uid == new->uid);
-        assert(old->modseq <= new->modseq);
+        if (imaply_strict) {
+            assert(old->uid == new->uid);
+            assert(old->modseq <= new->modseq);
 
-        /* this flag cannot go away */
-        if (old->internal_flags & FLAG_INTERNAL_EXPUNGED)
+            /* this flag cannot go away */
+            if (old->internal_flags & FLAG_INTERNAL_EXPUNGED)
                 assert(new->internal_flags & FLAG_INTERNAL_EXPUNGED);
+        }
 
         /* we're changing the CID for any reason at all, treat as
          * a removal and re-add, so cache gets parsed and msgids

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -367,6 +367,7 @@ extern int conversation_id_decode(conversation_id_t *cid, const char *text);
 
 extern int conversations_zero_counts(struct conversations_state *state, int wipe);
 extern int conversations_cleanup_zero(struct conversations_state *state);
+extern int conversations_zero_modseq(struct conversations_state *state);
 
 extern int conversations_rename_folder(struct conversations_state *state,
                                        const char *from_name,

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -302,6 +302,7 @@ static int do_zeromodseq(const char *userid)
     }
     quota_free(&q);
     if (r) goto done;
+    quota_commit(&txn);
 
     mboxname_zero_counters(inboxname);
 

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -278,6 +278,7 @@ static int zero_modseq_cb(const mbentry_t *mbentry,
 
 static int do_zeromodseq(const char *userid)
 {
+    imaply_strict = 0;
     char *inboxname = mboxname_user_mbox(userid, NULL);
     struct conversations_state *state = NULL;
     int r = 0;

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -949,7 +949,7 @@ int main(int argc, char **argv)
     int recursive = 0;
 
     /* keep in alphabetical order */
-    static const char short_options[] = "AC:FRST:bdruvzZ:";
+    static const char short_options[] = "AC:FMRST:bdruvzZ:";
 
     static const struct option long_options[] = {
         { "audit", no_argument, NULL, 'A' },

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -967,6 +967,7 @@ int main(int argc, char **argv)
         { "audit", no_argument, NULL, 'A' },
         /* n.b. no long option for -C */
         { "check-folders", no_argument, NULL, 'F' },
+        { "clearmodseq", no_argument, NULL, 'M' },
         { "update-counts", no_argument, NULL, 'R' },
         { "split", no_argument, NULL, 'S' },
         { "audit-temp-directory", required_argument, NULL, 'T' },
@@ -977,7 +978,6 @@ int main(int argc, char **argv)
         { "verbose", no_argument, NULL, 'v' },
         { "clear", no_argument, NULL, 'z' },
         { "clearcid", required_argument, NULL, 'Z' },
-        { "clearmodseq", required_argument, NULL, 'M' },
         { 0, 0, 0, 0 },
     };
 

--- a/imap/global.c
+++ b/imap/global.c
@@ -120,6 +120,7 @@ EXPORTED int config_httpprettytelemetry;
 EXPORTED int config_take_globallock;
 EXPORTED char *config_skip_userlock;
 EXPORTED int haproxy_protocol = 0;
+EXPORTED int imaply_strict = 1;
 
 static char session_id_buf[MAX_SESSIONID_SIZE];
 static int session_id_time = 0;

--- a/imap/global.h
+++ b/imap/global.h
@@ -184,6 +184,7 @@ extern int charset_flags;
 extern int charset_snippet_flags;
 extern size_t config_search_maxsize;
 extern int haproxy_protocol;
+extern int imaply_strict;
 
 /* Session ID */
 extern void session_new_id(void);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -3368,6 +3368,31 @@ EXPORTED uint32_t mboxname_setuidvalidity(const char *mboxname, uint32_t val)
     return val;
 }
 
+EXPORTED void mboxname_zero_counters(const char *mboxname)
+{
+    if (!config_getswitch(IMAPOPT_CONVERSATIONS))
+        return;
+
+    struct mboxname_counters counters;
+    int fd = -1;
+    mbname_t *mbname = mbname_from_intname(mboxname);
+    mboxname_assert_canadd(mbname);
+    char *fname = mboxname_conf_getpath(mbname, "counters");
+
+    /* XXX error handling */
+    if (mboxname_load_fcounters(fname, &counters, &fd))
+        goto done;
+
+    memset(&counters, 0, sizeof(struct mboxname_counters));
+
+    /* all zeroed out! */
+    mboxname_set_fcounters(fname, &counters, fd);
+
+ done:
+    free(fname);
+    mbname_free(&mbname);
+}
+
 EXPORTED char *mboxname_common_ancestor(const char *mboxname1, const char *mboxname2)
 {
     mbname_t *mbname1 = mbname_from_intname(mboxname1);

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -400,5 +400,6 @@ modseq_t mboxname_setquotamodseq(const char *mboxname, modseq_t val);
 modseq_t mboxname_readraclmodseq(const char *mboxname);
 modseq_t mboxname_nextraclmodseq(const char *mboxname, modseq_t last);
 modseq_t mboxname_setraclmodseq(const char *mboxname, modseq_t val);
+void mboxname_zero_counters(const char *mboxname);
 
 #endif


### PR DESCRIPTION
This adds a --clearmodseq command to ctl_conversationsdb to allow cleaning up giant modseqs that are messing with Apple.

Due to the way replication works with this, we'll have to run it on all replicas, and since it writes, we're going to have to take down the replicas to run it too :(  Otherwise we'll just copy the new highestmodseq back!