### PR TITLE
caldav_alarm: add explicit path option

### DIFF
--- a/changes/next/caldav-alarm-path
+++ b/changes/next/caldav-alarm-path
@@ -1,0 +1,18 @@
+Description:
+
+Added a config option for caldav_alarm_db_path
+
+
+Config changes:
+
+caldav_alarm_db_path
+
+
+Upgrade instructions:
+
+No change needed, the default path is the same
+
+
+GitHub issue:
+
+none

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -227,7 +227,12 @@ static sqldb_t *caldav_alarm_open()
     }
 
     // XXX - config option?
-    char *dbfilename = strconcat(config_dir, "/caldav_alarm.sqlite3", NULL);
+    char *tempname = NULL;
+    const char *dbfilename = config_getstring(IMAPOPT_CALDAV_ALARM_DB_PATH);
+    if (!dbfilename) {
+        tempname = strconcat(config_dir, "/caldav_alarm.sqlite3", NULL);
+        dbfilename = tempname;
+    }
     my_alarmdb = sqldb_open(dbfilename, CMD_CREATE, DBVERSION, upgrade,
                             config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT, 's') * 1000);
 
@@ -236,7 +241,7 @@ static sqldb_t *caldav_alarm_open()
         mboxname_release(&my_alarmdb_lock);
     }
 
-    free(dbfilename);
+    free(tempname);
     refcount = 1;
     return my_alarmdb;
 }

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -226,7 +226,6 @@ static sqldb_t *caldav_alarm_open()
         return NULL;
     }
 
-    // XXX - config option?
     char *tempname = NULL;
     const char *dbfilename = config_getstring(IMAPOPT_CALDAV_ALARM_DB_PATH);
     if (!dbfilename) {

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -568,6 +568,10 @@ Blank lines and lines beginning with ``#'' are ignored.
 /* Accept invalid RRULEs (e.g. FREQ=WEEKLY;BYMONTHDAY=15)
   rather than rejecting them as errors. */
 
+{ "caldav_alarm_db_path", NULL, STRING, "UNRELEASED" }
+/* Path to the caldav_alarm database file - defaults to
+   $confdir/caldav_alarm.sqlite3 if not set */
+
 { "caldav_alarm_support_components", "VEVENT VTODO", BITFIELD("VEVENT", "VTODO"), "UNRELEASED" }
 /* Space-separated list of iCalendar component types for which
    calalarmd generates alarms. */


### PR DESCRIPTION
I want to make $CONFDIR a tmpfs with a symlink farm for Fastmail, but the default db path is in the top level, so we need a way to specify that the database is elsewhere.