### PR TITLE
Fix conversations issues

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2280,7 +2280,7 @@ static int conversations_guid_setitem(struct conversations_state *state,
             buf_appendbit32(&val, system_flags);
             buf_appendbit32(&val, internal_flags);
             buf_appendbit64(&val, (bit64)internaldate);
-            buf_appendbit64(&val, basecid);
+            buf_appendbit64(&val, basecid == cid ? 0 : basecid);
         }
 
         r = cyrusdb_store(state->db, buf_base(&key), buf_len(&key),

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7938,7 +7938,7 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location, 
         rock.newuser = newuser;
         rock.partition = location;
         rock.rename_user = rename_user;
-	rock.noisy = noisy;
+	    rock.noisy = noisy;
 
         /* Check mboxnames to ensure we can write them all BEFORE we start */
         r = mboxlist_allmbox(ombn, checkmboxname, &rock, 0);
@@ -8012,12 +8012,12 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location, 
 
     /* rename all mailboxes matching this */
     if (!r && recursive_rename) {
-	if (noisy) {
+	    if (noisy) {
             prot_printf(imapd_out,
                         "* OK [INPROGRESS (\"%s\" NIL NIL)] rename %s %s\r\n",
                         tag, oldextname, newextname);
             prot_flush(imapd_out);
-	}
+	    }
 
 submboxes:
         strcat(oldmailboxname, ".");

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8065,17 +8065,20 @@ respond:
 
     if (r) {
         prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
+        xsyslog(LOG_NOTICE, "rename failed",
+                "oldmboxname=<%s> newmboxname=<%s> error=<%s>",
+                oldmailboxname, newmailboxname, error_message(r));
         // ensure the mboxlist entry gets fixed up or removed
         if (olddestmbentry) {
             int r2 = mboxlist_update_full(olddestmbentry, /*localonly*/1, /*silent*/1);
             if (r2)
                 xsyslog(LOG_ERR, "IOERROR: replacing old destination tombstone after rename error",
-                        "mboxname=<%s>, error=<%s>", olddestmbentry->name, error_message(r));
+                        "mboxname=<%s> error=<%s>", olddestmbentry->name, error_message(r2));
         } else if (newdestmbentry) {
             int r2 = mboxlist_delete(newdestmbentry);
             if (r2)
                 xsyslog(LOG_ERR, "IOERROR: removing temporary uniqueid tombstone after rename error",
-                        "mboxname=<%s>, error=<%s>", newdestmbentry->name, error_message(r));
+                        "mboxname=<%s> error=<%s>", newdestmbentry->name, error_message(r2));
         }
     } else {
         if (config_mupdate_server)

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3912,17 +3912,20 @@ int sync_apply_rename(struct dlist *kin, struct sync_state *sstate)
 
 done:
     if (r) {
+        xsyslog(LOG_NOTICE, "rename failed",
+                "oldmboxname=<%s> newmboxname=<%s> error=<%s>",
+                oldmboxname, newmboxname, error_message(r));
         // ensure the mboxlist entry gets fixed up or removed
         if (olddestmbentry) {
             int r2 = mboxlist_update_full(olddestmbentry, /*localonly*/1, /*silent*/1);
             if (r2)
                 xsyslog(LOG_ERR, "IOERROR: replacing old destination tombstone after rename error",
-                        "mboxname=<%s>, error=<%s>", olddestmbentry->name, error_message(r));
+                        "mboxname=<%s> error=<%s>", olddestmbentry->name, error_message(r2));
         } else if (newdestmbentry) {
             int r2 = mboxlist_delete(newdestmbentry);
             if (r2)
                 xsyslog(LOG_ERR, "IOERROR: removing temporary uniqueid tombstone after rename error",
-                        "mboxname=<%s>, error=<%s>", newdestmbentry->name, error_message(r));
+                        "mboxname=<%s> error=<%s>", newdestmbentry->name, error_message(r2));
         }
     }
     mboxlist_entry_free(&mbentry);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3853,6 +3853,7 @@ int sync_apply_rename(struct dlist *kin, struct sync_state *sstate)
 
     struct mboxlock *oldlock = NULL;
     struct mboxlock *newlock = NULL;
+    int rename_user = 0;
 
     /* make sure we grab these locks in a stable order! */
     if (strcmpsafe(oldmboxname, newmboxname) < 0) {
@@ -3866,17 +3867,47 @@ int sync_apply_rename(struct dlist *kin, struct sync_state *sstate)
     }
 
     r = mboxlist_lookup_allow_all(oldmboxname, &mbentry, 0);
+    if (r) goto done;
 
-    if (!r) r = mboxlist_renamemailbox(mbentry, newmboxname, partition,
-                                       uidvalidity, 1, sstate->userid,
-                                       sstate->authstate, NULL,
-                                       (sstate->flags & SYNC_FLAG_LOCALONLY),
-                                       1/*forceuser*/,
-                                       1/*ignorequota*/,
-                                       1/*keep_intermediaries*/,
-                                       0/*move_subscription*/,
-                                       1/*silent*/);
+    if (mboxname_isusermailbox(oldmboxname, 1) &&
+        mboxname_isusermailbox(newmboxname, 1)) {
+        // we can't rename users if the new inbox already exists!
+        mbentry_t *destmbentry = NULL;
+        r = mboxlist_lookup_allow_all(newmboxname, &destmbentry, NULL);
+        if (r != IMAP_MAILBOX_NONEXISTENT) {
+            mboxlist_entry_free(&destmbentry);
+            r = IMAP_MAILBOX_EXISTS;
+            goto done;
+        }
 
+        rename_user = 1;
+
+        /* we need to create a reference for the uniqueid so we find the right
+         * conversations DB */
+        mbentry_t *newmbentry = mboxlist_entry_copy(mbentry);
+        free(newmbentry->name);
+        newmbentry->name = xstrdup(newmboxname);
+        newmbentry->mbtype |= MBTYPE_DELETED;
+        r = mboxlist_update_full(newmbentry, /*localonly*/1, /*silent*/1);
+        mboxlist_entry_free(&newmbentry);
+        if (r) goto done;
+    }
+
+    r = mboxlist_renamemailbox(mbentry, newmboxname, partition,
+                               uidvalidity, 1, sstate->userid,
+                               sstate->authstate, NULL,
+                               (sstate->flags & SYNC_FLAG_LOCALONLY),
+                               1/*forceuser*/,
+                               1/*ignorequota*/,
+                               1/*keep_intermediaries*/,
+                               0/*move_subscription*/,
+                               1/*silent*/);
+
+    // undo the entry write if doing a user inbox
+    if (r && rename_user)
+        mboxlist_update_full(mbentry, /*localonly*/1, /*silent*/1);
+
+done:
     mboxlist_entry_free(&mbentry);
     mboxname_release(&oldlock);
     mboxname_release(&newlock);

--- a/imap/user.c
+++ b/imap/user.c
@@ -198,7 +198,7 @@ EXPORTED const char *user_sieve_path(const char *inuser)
         char *inboxname = mboxname_user_mbox(user, NULL);
         mbentry_t *mbentry = NULL;
 
-        int r = mboxlist_lookup(inboxname, &mbentry, NULL);
+        int r = mboxlist_lookup_allow_all(inboxname, &mbentry, NULL);
         free(inboxname);
 
         if (r || (mbentry->mbtype & MBTYPE_LEGACY_DIRS)) {
@@ -633,7 +633,7 @@ EXPORTED char *user_hash_xapian(const char *userid, const char *root)
     char *basedir = NULL;
     int r;
 
-    r = mboxlist_lookup(inboxname, &mbentry, NULL);
+    r = mboxlist_lookup_allow_all(inboxname, &mbentry, NULL);
     if (r) goto out;
 
     mbname = mbname_from_intname(mbentry->name);


### PR DESCRIPTION
There's two issues here:

1) basecid inconsistency causing TEMP/REAL mismatch

2) poor inbox detection on user rename causing bigger issues.  The second one is ALSO a known Fastmail issue on user rename, such that we do a full conversations rebuild after renaming.  This will fix that.

The reason these weren't detected earlier is that `ctl_conversationsdb -A` ONLY works on databases which support fetchnext, which skiplist doesn't, so we didn't notice these until switching to make twoskip the default.