### PR TITLE
cyr_expire: batch deletes to 4096 at a time

### DIFF
--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -489,7 +489,7 @@ int scan_me(struct findall_data *data, void *rock)
     srock->i_mbox = i_mbox;
 
     if (verbose) printf("Scanning %s...\n", name);
-    mailbox_expunge(mailbox, NULL, virus_check, srock, NULL, EVENT_MESSAGE_EXPUNGE);
+    mailbox_expunge(mailbox, NULL, virus_check, srock, NULL, EVENT_MESSAGE_EXPUNGE, /*limit*/0);
     if (srock->idx_state) index_close(&srock->idx_state);  /* closes mailbox */
     else mailbox_close(&mailbox);
 

--- a/imap/ipurge.c
+++ b/imap/ipurge.c
@@ -265,7 +265,7 @@ static int purge_one(const mbname_t *mbname)
         return r;
     }
 
-    mailbox_expunge(mailbox, NULL, purge_check, &stats, NULL, EVENT_MESSAGE_EXPUNGE);
+    mailbox_expunge(mailbox, NULL, purge_check, &stats, NULL, EVENT_MESSAGE_EXPUNGE, /*limit*/0);
 
     mailbox_close(&mailbox);
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -652,10 +652,10 @@ extern int mailbox_lock_index(struct mailbox *mailbox, int locktype);
 extern int mailbox_index_islocked(struct mailbox *mailbox, int write);
 
 extern int mailbox_expunge_cleanup(struct mailbox *mailbox, struct mailbox_iter *iter,
-                                   time_t expunge_mark, unsigned *ndeleted);
+                                   time_t expunge_mark, unsigned *ndeleted, int limit);
 extern int mailbox_expunge(struct mailbox *mailbox, struct mailbox_iter *iter,
                            mailbox_decideproc_t *decideproc, void *deciderock,
-                           unsigned *nexpunged, int event_type);
+                           unsigned *nexpunged, int event_type, int limit);
 extern void mailbox_archive(struct mailbox *mailbox, struct mailbox_iter *iter,
                             mailbox_decideproc_t *decideproc, void *deciderock);
 extern void mailbox_remove_files_from_object_storage(struct mailbox *mailbox, unsigned flags);


### PR DESCRIPTION
As promised, here's a batching version of cyr_expire.  It can wind up calling both codepaths multiple times but I think that's OK, it'll be faster without changes each time.  Without that, we'd have to keep a cursor to say where to restart each time, and that's a more complex intervention.