### PR TITLE
xunlink: clear errno and return 0 on ENOENT

### DIFF
--- a/cunit/command.testc
+++ b/cunit/command.testc
@@ -9,13 +9,12 @@ const char canary[] = "canary.txt";
 
 static void test_run(void)
 {
-    int r;
+    int r = 0;
     struct stat sb;
 
     /* make sure the file isnt there */
-    r = xunlink(canary);
-    if (r < 0) r = errno;
-    if (r == ENOENT) r = 0;
+    if (xunlink(canary))
+        r = errno;
     CU_ASSERT_EQUAL_FATAL(r, 0);
 
     r = run_command("/usr/bin/touch", canary, NULL);
@@ -54,15 +53,14 @@ static void test_popen_r(void)
 static void test_popen_w(void)
 {
 #define WORD0   "semiotics"
-    int r;
+    int r = 0;
     struct command *cmd = NULL;
     FILE *fp;
     char buf[32];
 
     /* make sure the file isnt there */
-    r = xunlink(canary);
-    if (r < 0) r = errno;
-    if (r == ENOENT) r = 0;
+    if (xunlink(canary))
+        r = errno;
     CU_ASSERT_EQUAL_FATAL(r, 0);
 
     snprintf(buf, sizeof(buf), "cat > %s", canary);

--- a/imap/append.c
+++ b/imap/append.c
@@ -1224,10 +1224,7 @@ EXPORTED int append_removestage(struct stagemsg *stage)
 
     while ((p = strarray_pop(&stage->parts))) {
         /* unlink the staging file */
-        if (xunlink(p) != 0) {
-            xsyslog(LOG_ERR, "IOERROR: error unlinking file",
-                             "filename=<%s>", p);
-        }
+        xunlink(p);
         free(p);
     }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5536,9 +5536,7 @@ EXPORTED void mailbox_archive(struct mailbox *mailbox,
                     // didn't manage to store it, so remove the ARCHIVED flag
                     continue;
                 }
-                r = xunlink (srcname);
-                if (r < 0)
-                    syslog(LOG_ERR, "unlink(%s) failed: %m", srcname);
+                xunlink(srcname);
             }
 #endif
             copyrecord.internal_flags |= FLAG_INTERNAL_ARCHIVED | FLAG_INTERNAL_NEEDS_CLEANUP;

--- a/imap/mboxkey.c
+++ b/imap/mboxkey.c
@@ -339,16 +339,8 @@ EXPORTED int mboxkey_delete_user(const char *user)
     }
 
     /* erp! */
-    r = xunlink(fname);
-    if (r < 0 && errno == ENOENT) {
-        syslog(LOG_DEBUG, "cannot unlink %s: %m", fname);
-        /* but maybe the user just never read anything? */
-        r = 0;
-    }
-    else if (r < 0) {
-        syslog(LOG_ERR, "error unlinking %s: %m", fname);
+    if (xunlink(fname))
         r = IMAP_IOERROR;
-    }
     free(fname);
 
     if (lastmboxkey) {

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -225,8 +225,8 @@ static void prometheus_done(void *rock __attribute__((unused)))
     mappedfile_unlock(promhandle->mf);
 
     /* unlink per-process stats file, we don't need it anymore */
-    r = xunlink(mappedfile_fname(promhandle->mf));
-    if (r && errno != ENOENT) goto done;
+    if (xunlink(mappedfile_fname(promhandle->mf)))
+        goto done;
     unlinked = 1;
 
     /* accumulate the statistics */

--- a/imap/seen_db.c
+++ b/imap/seen_db.c
@@ -400,10 +400,8 @@ HIDDEN int seen_delete_user(const char *user)
                user);
     }
 
-    if (xunlink(fname) && errno != ENOENT) {
-        syslog(LOG_ERR, "error unlinking %s: %m", fname);
+    if (xunlink(fname))
         r = IMAP_IOERROR;
-    }
 
     free(fname);
     return r;

--- a/imap/sievedir.c
+++ b/imap/sievedir.c
@@ -259,7 +259,7 @@ EXPORTED int sievedir_deactivate_script(const char *sievedir)
     assert(sievedir);
 
     snprintf(active, sizeof(active), "%s/defaultbc", sievedir);
-    if (xunlink(active) != 0 && errno != ENOENT) {
+    if (xunlink(active) != 0) {
         xsyslog(LOG_ERR, "IOERROR: failed to delete active script link",
                 "link=<%s>", active);
         return SIEVEDIR_IOERROR;
@@ -276,7 +276,7 @@ EXPORTED int sievedir_delete_script(const char *sievedir, const char *name)
 
     /* delete bytecode */
     snprintf(path, sizeof(path), "%s/%s%s", sievedir, name, BYTECODE_SUFFIX);
-    if (xunlink(path) != 0 && errno != ENOENT) {
+    if (xunlink(path) != 0) {
         xsyslog(LOG_ERR, "IOERROR: failed to delete bytecode file",
                 "path=<%s>", path);
         return SIEVEDIR_IOERROR;

--- a/lib/cyrusdb_quotalegacy.c
+++ b/lib/cyrusdb_quotalegacy.c
@@ -259,13 +259,8 @@ static int commit_subtxn(const char *fname, struct subtxn *tid)
         free(tid->fnamenew);
     } else if (tid->delete) {
         /* delete file */
-        r = xunlink(fname);
-        if (r == -1) {
-            xsyslog(LOG_ERR, "IOERROR: unlink failed",
-                             "fname=<%s>",
-                             fname);
+        if (xunlink(fname))
             r = CYRUSDB_IOERROR;
-        }
     } else {
         /* read-only txn */
     }

--- a/lib/util.c
+++ b/lib/util.c
@@ -571,9 +571,15 @@ static int _copyfile_helper(const char *from, const char *to, int flags)
     if (!nolink) {
         if (link(from, to) == 0) return 0;
         if (errno == EEXIST) {
-            if (xunlink(to) == -1) {
+            /* n.b. unlink rather than xunlink.  at this point we believe
+             * a file definitely exists that we want to remove, so if
+             * unlink tells us ENOENT then that's super weird and we're
+             * probably racing against something
+             */
+            if (unlink(to) == -1) {
                 xsyslog(LOG_ERR, "IOERROR: unlinking to recreate failed",
                                  "filename=<%s>", to);
+                errno = 0;
                 return -1;
             }
             if (link(from, to) == 0) return 0;

--- a/lib/xunlink.c
+++ b/lib/xunlink.c
@@ -54,30 +54,23 @@ EXPORTED int xunlink_fn(const char *sfile, int sline, const char *sfunc,
 {
     int saved_errno, r;
 
-    /* n.b. we don't reset errno before calling unlink, so it might contain
-     * stuff from some earlier syscall.  that's fine, because we only examine
-     * it when unlink's return value indicates an error, in which case its
-     * value is definitely ours.  otherwise we just save and restore it
-     * untouched.
-     */
-
-    r = unlink(pathname);
     saved_errno = errno;
+    r = unlink(pathname);
 
     if (r) {
-        if (saved_errno == ENOENT) {
-            /* we usually ignore this case, so reduce errno pollution
+        if (errno == ENOENT) {
+            /* we usually ignore this case, so treat it as not an error
              *
              * this means you can't use this wrapper function when you do care
              * about this case
              */
-            saved_errno = 0;
             r = 0;
         }
         else {
             /* n.b. not simply using xsyslog, because we want to log our
              * caller's location, but xsyslog would log ours
              */
+            saved_errno = errno;
             syslog(LOG_ERR, "IOERROR: unlink failed:"
                             " pathname=<%s> syserror=<%s>"
                             " file=<%s> line=<%d> func=<%s>",
@@ -97,30 +90,23 @@ EXPORTED int xunlinkat_fn(const char *sfile, int sline, const char *sfunc,
 {
     int saved_errno, r;
 
-    /* n.b. we don't reset errno before calling unlinkat, so it might contain
-     * stuff from some earlier syscall.  that's fine, because we only examine
-     * it when unlinkat's return value indicates an error, in which case its
-     * value is definitely ours.  otherwise we just save and restore it
-     * untouched.
-     */
-
-    r = unlinkat(dirfd, pathname, flags);
     saved_errno = errno;
+    r = unlinkat(dirfd, pathname, flags);
 
     if (r) {
-        if (saved_errno == ENOENT) {
-            /* we usually ignore this case, so reduce errno pollution
+        if (errno == ENOENT) {
+            /* we usually ignore this case, so treat it as not an error
              *
              * this means you can't use this wrapper function when you do care
              * about this case
              */
-            saved_errno = 0;
             r = 0;
         }
         else {
             /* n.b. not simply using xsyslog, because we want to log our
              * caller's location, but xsyslog would log ours
              */
+            saved_errno = errno;
             syslog(LOG_ERR, "IOERROR: unlinkat failed:"
                             " dirfd=<%d> pathname=<%s> flags=<%d> syserror=<%s>"
                             " file=<%s> line=<%d> func=<%s>",

--- a/lib/xunlink.c
+++ b/lib/xunlink.c
@@ -54,19 +54,38 @@ EXPORTED int xunlink_fn(const char *sfile, int sline, const char *sfunc,
 {
     int saved_errno, r;
 
+    /* n.b. we don't reset errno before calling unlink, so it might contain
+     * stuff from some earlier syscall.  that's fine, because we only examine
+     * it when unlink's return value indicates an error, in which case its
+     * value is definitely ours.  otherwise we just save and restore it
+     * untouched.
+     */
+
     r = unlink(pathname);
     saved_errno = errno;
 
-    if (r && saved_errno != ENOENT) {
-        /* n.b. not simply using xsyslog, because we want to log our caller's
-         * location, but xsyslog would log ours
-         */
-        syslog(LOG_ERR, "IOERROR: unlink failed: pathname=<%s> syserror=<%s>"
-                        " file=<%s> line=<%d> func=<%s>",
-                        pathname, strerror(saved_errno),
-                        sfile, sline, sfunc);
+    if (r) {
+        if (saved_errno == ENOENT) {
+            /* we usually ignore this case, so reduce errno pollution
+             *
+             * this means you can't use this wrapper function when you do care
+             * about this case
+             */
+            saved_errno = 0;
+            r = 0;
+        }
+        else {
+            /* n.b. not simply using xsyslog, because we want to log our
+             * caller's location, but xsyslog would log ours
+             */
+            syslog(LOG_ERR, "IOERROR: unlink failed:"
+                            " pathname=<%s> syserror=<%s>"
+                            " file=<%s> line=<%d> func=<%s>",
+                            pathname, strerror(saved_errno),
+                            sfile, sline, sfunc);
 
-        /* if you want to abort() on unlink failure, patch that in here */
+            /* if you want to abort() on unlink failure, patch that in here */
+        }
     }
 
     errno = saved_errno;
@@ -78,20 +97,38 @@ EXPORTED int xunlinkat_fn(const char *sfile, int sline, const char *sfunc,
 {
     int saved_errno, r;
 
+    /* n.b. we don't reset errno before calling unlinkat, so it might contain
+     * stuff from some earlier syscall.  that's fine, because we only examine
+     * it when unlinkat's return value indicates an error, in which case its
+     * value is definitely ours.  otherwise we just save and restore it
+     * untouched.
+     */
+
     r = unlinkat(dirfd, pathname, flags);
     saved_errno = errno;
 
-    if (r && saved_errno != ENOENT) {
-        /* n.b. not simply using xsyslog, because we want to log our caller's
-         * location, but xsyslog would log ours
-         */
-        syslog(LOG_ERR, "IOERROR: unlinkat failed:"
-                        " dirfd=<%d> pathname=<%s> flags=<%d> syserror=<%s>"
-                        " file=<%s> line=<%d> func=<%s>",
-                        dirfd, pathname, flags, strerror(saved_errno),
-                        sfile, sline, sfunc);
+    if (r) {
+        if (saved_errno == ENOENT) {
+            /* we usually ignore this case, so reduce errno pollution
+             *
+             * this means you can't use this wrapper function when you do care
+             * about this case
+             */
+            saved_errno = 0;
+            r = 0;
+        }
+        else {
+            /* n.b. not simply using xsyslog, because we want to log our
+             * caller's location, but xsyslog would log ours
+             */
+            syslog(LOG_ERR, "IOERROR: unlinkat failed:"
+                            " dirfd=<%d> pathname=<%s> flags=<%d> syserror=<%s>"
+                            " file=<%s> line=<%d> func=<%s>",
+                            dirfd, pathname, flags, strerror(saved_errno),
+                            sfile, sline, sfunc);
 
-        /* if you want to abort() on unlinkat failure, patch that in here */
+            /* if you want to abort() on unlinkat failure, patch that in here */
+        }
     }
 
     errno = saved_errno;

--- a/lib/xunlink.h
+++ b/lib/xunlink.h
@@ -49,9 +49,13 @@
  * N.B. These are NOT "error-handling" wrappers; you still must check the
  * return value, errno, etc, and handle errors accordingly!
  *
- * These wrappers present the same interface as the original functions,
- * but will also log an error if the original function did anything
- * other than succeed or fail-due-to-ENOENT
+ * These wrappers present almost the same interface as the original functions,
+ * except that:
+ *  1) errors are logged for you; and
+ *  2) ENOENT is treated as not an error: nothing is logged, errno is cleared,
+ *     and 0 is returned
+ *
+ * You cannot use these wrappers if you need to detect ENOENT failures.
  **/
 
 #define xunlink(pathname)                                                     \

--- a/lib/xunlink.h
+++ b/lib/xunlink.h
@@ -52,7 +52,7 @@
  * These wrappers present almost the same interface as the original functions,
  * except that:
  *  1) errors are logged for you; and
- *  2) ENOENT is treated as not an error: nothing is logged, errno is cleared,
+ *  2) ENOENT is treated as not an error: nothing is logged, errno is not set,
  *     and 0 is returned
  *
  * You cannot use these wrappers if you need to detect ENOENT failures.


### PR DESCRIPTION
We almost always ignore this case anyway. Swallowing it here prevents some `syserror=<No such file or directory>` pollution in unrelated log lines.
    
With this change, if you DO care to differentiate between "file has been unlinked" and "file didn't exist anyway", you need to use unlink directly (and check/log errors yourself!)

Fixes some call sites to not do redundant logging or ENOENT checking