### PR TITLE
Created mailbox check

### DIFF
--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_create_delete
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_create_delete
@@ -1,0 +1,51 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_mailbox_changes_create_delete
+    :min_version_3_5 :NoAltNameSpace
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+
+    $imap->create('INBOX.foo');
+
+    my $res = $jmap->CallMethods([
+        ['Mailbox/get', { }, 'R1'],
+    ]);
+    my $fooId;
+    if ($res->[0][1]{list}[0]{name} eq 'foo') {
+        $fooId = $res->[0][1]{list}[0]{id};
+    }
+    else {
+        $fooId = $res->[0][1]{list}[1]{id};
+    }
+    $self->assert_not_null($fooId);
+    my $state = $res->[0][1]{state};
+    $self->assert_not_null($state);
+
+    $imap->create('INBOX.bar');
+
+    $res = $jmap->CallMethods([
+        ['Mailbox/changes', {
+            sinceState => $state,
+        }, 'R1'],
+    ]);
+    my $barId = $res->[0][1]{created}[0];
+    $self->assert_not_null($barId);
+    $state = $res->[0][1]{newState};
+    $self->assert_not_null($state);
+
+    $imap->create("INBOX.fuzz");
+    $imap->delete("INBOX.fuzz");
+
+    $res = $jmap->CallMethods([
+        ['Mailbox/changes', {
+            sinceState => $state,
+        }, 'R1'],
+    ]);
+    $self->assert_deep_equals([], $res->[0][1]{created});
+    $self->assert_deep_equals([], $res->[0][1]{updated});
+    $self->assert_deep_equals([], $res->[0][1]{destroyed});
+}


### PR DESCRIPTION
Bug reported by Neil in Fastmail tracker - if a folder was created and deleted between synces, it was being returned as "created" still.