### PR TITLE
configure.ac: check for cyruslibs dependencies also without pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1725,16 +1725,25 @@ dnl                AC_MSG_WARN([Your version of OpenDKIM can not support iSchedu
         AC_ARG_WITH(wslay, [AS_HELP_STRING([--without-wslay], [disable WebSockets support (check)])],,[with_wslay="check"])
         if test "x$with_wslay" = "xyes" -o "x$with_wslay" = "xcheck"; then
                 PKG_CHECK_MODULES([WSLAY], [libwslay >= 1.1.1], [
-                        AC_DEFINE(HAVE_WSLAY,[],
-                                [Build WebSockets support into httpd?])
                         with_wslay=yes
                 ], [
-                        if test "x$with_wslay" = "xyes"; then
-                                AC_MSG_ERROR([WebSockets explicitly requested, but libwslay was not found])
-                        fi
-                        AC_MSG_NOTICE([httpd will not have support for WebSockets.  Consider installing libwslay])
-                        with_wslay=no
+                        AC_SEARCH_LIBS([wslay_event_context_free], [wslay], [
+                            AC_SUBST([WSLAY_LIBS], [-lwslay])
+                            with_wslay=yes
+                        ], [
+                                if test "x$with_wslay" = "xyes"; then
+                                        AC_MSG_ERROR([WebSockets explicitly requested, but libwslay was not found])
+                                fi
+                                with_wslay=no
+                        ])
                 ])
+
+                if test "x$with_wslay" = "xyes"; then
+                        AC_DEFINE(HAVE_WSLAY,[],
+                                [Build WebSockets support into httpd?])
+                else
+                        AC_MSG_NOTICE([httpd will not have support for WebSockets.  Consider installing libwslay])
+                fi
         fi
 
         AC_ARG_WITH(brotli, [AS_HELP_STRING([--without-brotli], [disable brotli compression (check)])])

--- a/configure.ac
+++ b/configure.ac
@@ -1529,16 +1529,45 @@ dnl
 dnl Check for cld2 library
 dnl
 AC_ARG_WITH([cld2],
-	[AS_HELP_STRING([--without-cld2], [ignore presence of cld2 library and disable it])],
+    [
+        AS_HELP_STRING([--without-cld2], [ignore presence of cld2 library and disable it])
+    ],
     [],
     [with_cld2=yes])
 AS_IF([test "x$with_cld2" = "xyes"],
-	[ PKG_CHECK_MODULES([CLD2], [cld2],
-		[ AC_DEFINE(HAVE_CLD2, [], [Build with cld2 library support])
-		  with_cld2=yes ],
-          with_cld2=no)])
-AC_SUBST([CLD2_LIBS])
-AC_SUBST([CLD2_CFLAGS])
+    [ PKG_CHECK_MODULES([CLD2], [cld2],
+        [
+            AC_SUBST([CLD2_LIBS])
+            AC_SUBST([CLD2_CFLAGS])
+            AC_DEFINE([HAVE_CLD2], [], [Use CLD2])
+            with_cld2=yes
+        ],
+        [
+          AC_LANG_PUSH([C++])
+          NOCLD2_LIBS=$LIBS
+          LIBS="-lcld2 $LIBS"
+          AC_LINK_IFELSE([
+            AC_LANG_PROGRAM(
+                [[
+                    #include <cstdio>
+                    #include <cld2/public/compact_lang_det.h>
+                ]],
+                [[ CLD2::isDataDynamic(); ]]
+            )],
+            [
+                AC_SUBST([CLD2_LIBS], [-lcld2])
+                AC_SUBST([CLD2_CFLAGS])
+                AC_DEFINE([HAVE_CLD2], [], [Use CLD2])
+                with_cld2=yes
+            ],
+            [
+                with_cld2=no
+            ]
+          )
+          AC_LANG_POP([C++])
+          LIBS=$NOCLD2_LIBS
+        ])
+    ])
 AM_CONDITIONAL([HAVE_CLD2], [test "x$with_cld2" = xyes])
 
 dnl


### PR DESCRIPTION
This updates configure.ac to fall back checking for the cld2 and wslay dependencies even if pkg-config could not find them. These dependencies have now been removed from the https://github.com/cyrusimap/cyruslibs repository and their upstream version does not support pkg-config. This patch allows detecting them in the standard include and library paths.