### PR TITLE
twoskip: free transaction after repack

### DIFF
--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -2011,6 +2011,7 @@ static int mycheckpoint(struct dbengine *db)
 
     /* OK, we're committed now - clean up */
     unlock(db);
+    free(db->current_txn);
 
     /* gotta clean it all up */
     mappedfile_close(&db->mf);

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -1963,8 +1963,11 @@ static int mycheckpoint(struct dbengine *db)
     clock_t start = sclock();
     struct copy_rock cr;
     int r = 0;
+    struct txn *localtid = NULL;
+    struct txn **tidptr = &db->current_txn;
+    if (!*tidptr) tidptr = &localtid;
 
-    r = myconsistent(db, db->current_txn);
+    r = myconsistent(db, *tidptr);
     if (r) {
         syslog(LOG_ERR, "db %s, inconsistent pre-checkpoint, bailing out",
                FNAME(db));
@@ -1984,7 +1987,7 @@ static int mycheckpoint(struct dbengine *db)
     // set up the pointers so copy_cb logic can work
     relocate(cr.db);
 
-    r = myforeach(db, NULL, 0, NULL, copy_cb, &cr, &db->current_txn);
+    r = myforeach(db, NULL, 0, NULL, copy_cb, &cr, tidptr);
     if (r) goto err;
 
     r = myconsistent(cr.db, cr.tid);
@@ -2011,7 +2014,7 @@ static int mycheckpoint(struct dbengine *db)
 
     /* OK, we're committed now - clean up */
     unlock(db);
-    free(db->current_txn);
+    if (localtid) free(localtid);
 
     /* gotta clean it all up */
     mappedfile_close(&db->mf);


### PR DESCRIPTION
This mirrors the code in commit/abort after unlocking.  We're about to replace *db with data from the new DB, so free up the memory.