### PR TITLE
http_caldav_sched.c: fix for organizer getting stomped in sched_request()

### DIFF
--- a/cassandane/tiny-tests/Caldav/invite_lots_of_attendees
+++ b/cassandane/tiny-tests/Caldav/invite_lots_of_attendees
@@ -1,0 +1,89 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_invite_lots_of_attendees
+    :VirtDomains :min_version_3_0
+{
+    my ($self) = @_;
+
+    my $service = $self->{instance}->get_service("http");
+    my $CalDAV = Net::CalDAVTalk->new(
+        user => "cassandane%example.com",
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'hello'});
+    $self->assert_not_null($CalendarId);
+
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+    my $href = "$CalendarId/$uuid.ics";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Australia/Melbourne
+BEGIN:STANDARD
+TZOFFSETFROM:+1100
+RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU
+DTSTART:20080406T030000
+TZNAME:AEST
+TZOFFSETTO:+1000
+END:STANDARD
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+1000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU
+DTSTART:20081005T020000
+TZNAME:AEDT
+TZOFFSETTO:+1100
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:$uuid
+DTEND;TZID=Australia/Melbourne:20160831T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=Australia/Melbourne:20160831T153000
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:cassandane\@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:friend\@example.com
+ORGANIZER;CN=Test User:MAILTO:cassandane\@example.com
+EOF
+
+    my @recipients = ('friend@example.com');
+
+    for my $idx (1..49) {
+        $card .= <<EOF;
+ATTENDEE;X-JMAP-ID=abcdeabcdeabcde${idx};CN=Some One ${idx};
+ EMAIL=attendee${idx}\@example.com;CUTYPE=INDIVIDUAL;X-JMAP-ROLE=attendee;
+ PARTSTAT=NEEDS-ACTION;RSVP=TRUE:mailto:attendee${idx}\@example.com
+EOF
+
+        push @recipients, "attendee${idx}\@example.com";
+    }
+
+    $card .= <<EOF;
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $CalDAV->Request('PUT', $href, $card, 'Content-Type' => 'text/calendar');
+
+    $self->assert_caldav_notified(
+        map {
+            +{
+                recipient => $_,
+                is_update => JSON::false,
+                method    => 'REQUEST'
+            },
+        } @recipients
+    );
+}


### PR DESCRIPTION

When the organizer gets stomped it can result in binary data being used when building the JSON structure which results in an 'Invalid UTF-8 string' error.

The stomping of the organizer value seems consistent if the iTIP request contains a large number of ATTENDEEs, but the JSON failure is random depending on what data the stomped organizer contains.

So, this is a hard problem/fix to write a test for.