### PR TITLE
cassandane: Do syntax checks only for changed files

### DIFF
--- a/cassandane/.gitignore
+++ b/cassandane/.gitignore
@@ -3,3 +3,4 @@ reports.old
 cass.errs
 cassandane.ini
 .cassandane.ini
+.cassandane-syntax-check

--- a/cassandane/Makefile
+++ b/cassandane/Makefile
@@ -63,18 +63,11 @@ ifndef NOCYRUS
     CYRUS_PERL_PATHS := $(shell $(PERL) utils/cyrus-perl-paths.pl)
 endif
 
-SYNTAX_rules =
+syntax: .cassandane-syntax-check
 
-define SYNTAX_template
- $(1)_syntax: $(1)
-	@$(PERL) $(CYRUS_PERL_PATHS) -c $(1)
- SYNTAX_rules += $(1)_syntax
-endef
+.cassandane-syntax-check: $(SCRIPTS) $(MODULES)
+	rm -f .cassandane-syntax-check
+	$(foreach path,$?,$(PERL) $(CYRUS_PERL_PATHS) -c $(path) || exit;)
+	touch .cassandane-syntax-check
 
-$(foreach s,$(SCRIPTS),$(eval $(call SYNTAX_template,$(s))))
-
-$(foreach m,$(MODULES),$(eval $(call SYNTAX_template,$(m))))
-
-syntax: $(SYNTAX_rules)
-
-.PHONY: all syntax $(SYNTAX_rules)
+.PHONY: syntax


### PR DESCRIPTION
Instead of `make` inside of cassandane always re-checking syntax, only check syntax if one of the files has actually changed.

This is more in the spirit of make with only rebuilding things on changes, and also makes `cyd test` much faster...