### PR TITLE
message.c: reject to parse MIME headers with NUL byte

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_import_zerobyte
+++ b/cassandane/tiny-tests/JMAPEmail/email_import_zerobyte
@@ -2,13 +2,14 @@
 use Cassandane::Tiny;
 
 sub test_email_import_zerobyte
-    :min_version_3_1 :needs_component_sieve
+  :needs_component_sieve
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};
 
-    # A bogus email with an unencoded zero byte
-    my $email = <<"EOF";
+    my @testCases = ({
+        desc => "unencoded zero byte in MIME body",
+        mime => <<"EOF",
 From: \"Some Example Sender\" <example\@local>\r\n
 To: baseball\@local\r\n
 Subject: test email\r\n
@@ -18,32 +19,38 @@ Content-Type: text/plain; charset="UTF-8"\r\n
 \r\n
 This is a test email with a \x{0}-byte.\r\n
 EOF
+    }, {
+        desc => "unencoded zero byte in MIME headers",
+        mime => <<"EOF",
+From: from\@local\r\n
+To: to\@local\r\n
+Subject: subject with \x{0}-byte\r\n
+Date: Wed, 7 Dec 2016 22:11:11 +1100\r\n
+MIME-Version: 1.0\r\n
+Content-Type: text/plain; charset="UTF-8"\r\n
+\r\n
+This is a test email.\r\n
+EOF
+    });
 
-    my $data = $jmap->Upload($email, "message/rfc822");
-    my $blobid = $data->{blobId};
+    foreach (@testCases) {
+        xlog $self, "Upload MIME blob for test '$_->{desc}'";
+        my $blobId = $jmap->Upload($_->{mime}, "message/rfc822")->{blobId};
 
-    xlog $self, "create drafts mailbox";
-    my $res = $jmap->CallMethods([
-            ['Mailbox/set', { create => { "1" => {
-                            name => "drafts",
-                            parentId => undef,
-                            role => "drafts"
-             }}}, "R1"]
-    ]);
-    my $draftsmbox = $res->[0][1]{created}{"1"}{id};
-    $self->assert_not_null($draftsmbox);
-
-    xlog $self, "import email from blob $blobid";
-    $res = $jmap->CallMethods([['Email/import', {
-            emails => {
-                "1" => {
-                    blobId => $blobid,
-                    mailboxIds => {$draftsmbox =>  JSON::true},
-                    keywords => {
-                        '$draft' => JSON::true,
+        xlog $self, "Import email from blob $blobId";
+        my $res = $jmap->CallMethods([ [
+            'Email/import',
+            {
+                emails => {
+                    "1" => {
+                        blobId     => $blobId,
+                        mailboxIds => { '$inbox' => JSON::true },
                     },
                 },
             },
-        }, "R1"]]);
-    $self->assert_str_equals("invalidEmail", $res->[0][1]{notCreated}{1}{type});
+            "R1"
+        ] ]);
+        $self->assert_str_equals("invalidEmail",
+            $res->[0][1]{notCreated}{1}{type});
+    }
 }

--- a/imap/message.c
+++ b/imap/message.c
@@ -539,19 +539,18 @@ EXPORTED int message_parse_mapped(const char *msg_base, unsigned long msg_len,
 
     if (body->filesize != body->header_size + body->content_size) {
         if (efname)
-            /* XXX IOERROR but only LOG_NOTICE?? */
-            xsyslog(LOG_NOTICE, "IOERROR: size mismatch on parse",
-                                "guid=<%s> filename=<%s> "
-                                "filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
-                                message_guid_encode(&body->guid), efname,
-                                body->filesize,
-                                body->header_size + body->content_size);
+            xsyslog(LOG_ERR, "IOERROR: size mismatch on parse",
+                             "guid=<%s> filename=<%s>"
+                             " filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
+                             message_guid_encode(&body->guid), efname,
+                             body->filesize,
+                             body->header_size + body->content_size);
         else
-            xsyslog(LOG_NOTICE, "IOERROR: size mismatch on parse",
-                                "guid=<%s> "
-                                "filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
-                                message_guid_encode(&body->guid), body->filesize,
-                                body->header_size + body->content_size);
+            xsyslog(LOG_ERR, "IOERROR: size mismatch on parse",
+                             "guid=<%s>"
+                             " filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
+                             message_guid_encode(&body->guid), body->filesize,
+                             body->header_size + body->content_size);
     }
 
 done:


### PR DESCRIPTION
Before, the parse continued but set incorrect header and body offsets for the body part. This resulted in log spam noting the discrepancy between the file size and header+body offsets, as well as a bogus in-memory MIME body structure.