### PR TITLE
xapian_wrap.cpp: support phrase search for email addresses

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_emailaddress
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_emailaddress
@@ -180,6 +180,21 @@ EOF
     }, {
         to => decode('utf-8', 'Dømi <*@*dømi.fo>'),
         wantIds => [$ids[4]],
+    }, {
+        to => 'foo.bar@xxx.example.com',
+        wantIds => [$ids[0]],
+    }, {
+        to => 'Jon Doe <foo.bar@xxx.example.com>',
+        wantIds => [$ids[0]],
+    }, {
+        to => '"foo.bar@xxx.example.com"',
+        wantIds => [$ids[0]],
+    }, {
+        to => '"Jon Doe <foo.bar@xxx.example.com>"',
+        wantIds => [$ids[0]],
+    }, {
+        to => '"foo*@*example.com"',
+        wantIds => [],
     });
 
     foreach (@tests) {


### PR DESCRIPTION
Quotes signify phrase search in free text queries but were not supported in email queries since we supported querying for sub-parts of an email address. This reintroduces phrase search for email queries.