### PR TITLE
Fix compile error on macOS: unknown type name 'ulong'

### DIFF
--- a/imap/http_client.h
+++ b/imap/http_client.h
@@ -57,7 +57,7 @@ struct body_t {
     unsigned char framing;              /* Message framing   */
     unsigned char te;                   /* Transfer-Encoding */
     unsigned max;                       /* Max allowed len   */
-    ulong len;                          /* Content-Length    */
+    unsigned long len;                  /* Content-Length    */
     struct buf payload;                 /* Payload           */
 };
 

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -280,7 +280,7 @@ typedef int (*encode_proc_t)(struct transaction_t *txn,
 
 /* Meta-data for response body (payload & representation headers) */
 struct resp_body_t {
-    ulong len;                          /* Content-Length   */
+    unsigned long len;                  /* Content-Length   */
     struct range *range;                /* Content-Range    */
     struct {
         const char *fname;

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -224,7 +224,7 @@ static int _emailsubmission_address_parse(json_t *addr,
             if (holduntil) {
                 if (!strcasecmp(key, "HOLDFOR")) {
                     char *endptr = (char *) val;
-                    ulong interval = val ? strtoul(val, &endptr, 10) : ULONG_MAX;
+                    unsigned long interval = val ? strtoul(val, &endptr, 10) : ULONG_MAX;
                     time_t now = time(0);
 
                     if (endptr == val || *endptr != '\0' ||


### PR DESCRIPTION
Trying to build cyrus-imapd on macOS (12.5–15.2) fails with a compiler error `unknown type name 'ulong'` in imap/http_client.h and imap/httpd.h (even with no HTTP features enabled). That type does not appear to be defined anywhere in the source code.

Checking on Linux, it appears to be a Linux-specific thing, in my case coming from the following part of /usr/include/x86_64-linux-gnu/sys/types.h:

```c
#ifdef __USE_MISC
/* Old compatibility names for C types.  */
typedef unsigned long int ulong;
```

Using that typedef does not seem to add any value, replace it by the standard type.