### PR TITLE
Fix build without libical

### DIFF
--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -55,7 +55,9 @@
 #include <sys/wait.h>
 
 #include "assert.h"
+#ifdef WITH_DAV
 #include "caldav_alarm.h"
+#endif
 #include "cyrusdb.h"
 #include "dav_db.h"
 #include "global.h"

--- a/imap/itip_support.h
+++ b/imap/itip_support.h
@@ -46,7 +46,9 @@
 
 #include <config.h>
 
+#ifdef HAVE_ICAL
 #include <libical/ical.h>
+#endif
 
 #include "acl.h"
 #include "parseaddr.h"
@@ -78,6 +80,7 @@ enum sched_mechanism {
 
 extern const char *sched_mechanisms[];
 
+#ifdef HAVE_ICAL
 struct sched_data {
     enum sched_mechanism mech;
     unsigned flags;
@@ -179,5 +182,7 @@ extern enum sched_deliver_outcome sched_deliver_local(const char *userid,
                                                       struct auth_state *authstate,
                                                       const char **attendeep,
                                                       icalcomponent **icalp);
+
+#endif /* HAVE_ICAL */
 
 #endif /* ITIP_SUPPORT_H */

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -52,12 +52,16 @@
 
 #include "annotate.h"
 #include "append.h"
+#ifdef HAVE_ICAL
 #include "caldav_util.h"
+#endif
 #include "carddav_db.h"
 #include "global.h"
 #include "hash.h"
 #include "index.h"
+#ifdef HAVE_ICAL
 #include "jmap_ical.h"
+#endif
 #include "jmap_util.h"
 #include "json_support.h"
 #include "search_query.h"


### PR DESCRIPTION
Building cyrus-imapd on a system that does not have libical installed (with iCal features accordingly disabled by `configure`) fails with a compiler error `'libical/ical.h' file not found` in various places. Checked on macOS (15.2) and Linux (Ubuntu 20.04).

This appears to have been broken when #3467, #3815, #3845 started including code that was previously exclusive to CalDAV features also when CalDAV is disabled. It was presumably not noticed when testing only on systems that do have libical installed, even with CalDAV explicitly disabled.

I can fix this with the `#ifdefs` added in the attached commit, but am not sure whether these are exactly the right macros to test.