### PR TITLE
backend: don't even try to connect if port == "0"

### DIFF
--- a/imap/backend.c
+++ b/imap/backend.c
@@ -1057,6 +1057,9 @@ EXPORTED struct backend *backend_connect(struct backend *ret_backend, const char
             }
         }
 
+        // don't do lookups if the port number is zero
+        if (!strcmp(service, "0")) goto error;
+
         memset(&hints, 0, sizeof(hints));
         hints.ai_family = PF_UNSPEC;
         hints.ai_socktype = SOCK_STREAM;


### PR DESCRIPTION
This is really annoying me!  On my windows box with WSL, it tries to connect to `bogus:0` and has slow resolution failures for every JMAP test because JMAP will connect to the smtp server in order to fetch capabilities.

This patch just checks for port == "0" which is always bogus, and returns before calling out to `getaddrinfo` so it doesn't wait.