### PR TITLE
Make Cyrus build with clang `-Werror`

### DIFF
--- a/com_err/et/com_err.c
+++ b/com_err/et/com_err.c
@@ -133,11 +133,10 @@ errf com_err_hook = default_com_err_proc;
 
 void
 __attribute__((format(printf, 3, 0)))
-com_err_va (whoami, code, fmt, args)
-    const char *whoami;
-    long code;
-    const char *fmt;
-    va_list args;
+com_err_va (const char *whoami,
+            long code,
+            const char *fmt,
+            va_list args)
 {
     (*com_err_hook) (whoami, code, fmt, args);
 }
@@ -172,8 +171,7 @@ EXPORTED void INTERFACE_C com_err (va_alist)
     va_end(pvar);
 }
 
-errf set_com_err_hook (new_proc)
-    errf new_proc;
+errf set_com_err_hook (errf new_proc)
 {
     errf x = com_err_hook;
 

--- a/com_err/et/error_message.c
+++ b/com_err/et/error_message.c
@@ -62,8 +62,7 @@ static char buffer[25];
 
 extern struct et_list * _et_list;
 
-EXPORTED const char * INTERFACE error_message (code)
-long code;
+EXPORTED const char * INTERFACE error_message (long code)
 {
     int offset;
     long l_offset;

--- a/com_err/et/et_name.c
+++ b/com_err/et/et_name.c
@@ -57,8 +57,7 @@ static const char char_set[] =
 
 static char buf[6];
 
-const char * error_table_name (num)
-    long num;
+const char * error_table_name (long num)
 {
     long ch;
     int i;

--- a/com_err/et/init_et.c
+++ b/com_err/et/init_et.c
@@ -52,10 +52,9 @@
 
 extern struct et_list * _et_list;
 
-int init_error_table(msgs, base, count)
-    const char * const * msgs;
-    int base;
-    int count;
+int init_error_table(const char * const * msgs,
+                     int base,
+                     int count)
 {
     struct et_list *etl;
     struct error_table *et;

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2267,7 +2267,7 @@ static int conversations_guid_setitem(struct conversations_state *state,
     if (add) {
         struct buf val = BUF_INITIALIZER;
         if (state->folders_byname) {
-            buf_putc(&val, 0x80 | CONV_GUIDREC_BYNAME_VERSION);
+            buf_putc(&val, (char) (0x80 | CONV_GUIDREC_BYNAME_VERSION));
             buf_appendbit64(&val, cid);
             buf_appendbit32(&val, system_flags);
             buf_appendbit32(&val, internal_flags);
@@ -2275,7 +2275,7 @@ static int conversations_guid_setitem(struct conversations_state *state,
         }
         /* When bumping the G value version, make sure to update _guid_cb */
         else {
-            buf_putc(&val, 0x80 | CONV_GUIDREC_VERSION);
+            buf_putc(&val, (char) (0x80 | CONV_GUIDREC_VERSION));
             buf_appendbit64(&val, cid);
             buf_appendbit32(&val, system_flags);
             buf_appendbit32(&val, internal_flags);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -659,6 +659,8 @@ extern int saslserver(sasl_conn_t *conn, const char *mech,
 /* Enable the resetting of a sasl_conn_t */
 static int reset_saslconn(sasl_conn_t **conn);
 
+void shut_down(int code) __attribute__((noreturn));
+
 static int imapd_canon_user(sasl_conn_t *conn, void *context,
                             const char *user, unsigned ulen,
                             unsigned flags, const char *user_realm,
@@ -1314,7 +1316,6 @@ out:
 /*
  * Cleanly shut down and exit
  */
-void shut_down(int code) __attribute__((noreturn));
 void shut_down(int code)
 {
     int i;


### PR DESCRIPTION
This fixes a few build issues that compiling with clang-14 and clang-18 with `-Wall -Werror` were found by me and @rjbs . Known to build on x86-64 and aarch64.