### PR TITLE
sync_support: uncache BEFORE freeing memory

### DIFF
--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -6551,11 +6551,11 @@ int sync_do_update_mailbox(struct sync_client_state *sync_cs,
         sync_send_apply(kl, sync_cs->backend->out);
         r = sync_parse_response("MAILBOX", sync_cs->backend->in, NULL);
 
-        dlist_free(&kl);
-        mboxlist_entry_free(&mbentry);
-
         // we never want to cache intermediate records
         sync_uncache(sync_cs, mbentry->name);
+
+        dlist_free(&kl);
+        mboxlist_entry_free(&mbentry);
 
         return r;
     }


### PR DESCRIPTION
I messed this up when creating the MR, uncache is good, but we have to do it before freeing the name.