### PR TITLE
TestCase: workaround for HTTP::Tiny behaviour change

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -808,6 +808,13 @@ sub _setup_http_service_objects
         scheme => ($service->is_ssl() ? 'https' : 'http'),
     );
 
+    # XXX HTTP::Tiny 0.8.3 and later have SSL_verify enabled by default, but
+    # XXX Net::DAVTalk doesn't provide any way for us to supply our CA file,
+    # XXX making setup fail with certificate verify errors.
+    # XXX HTTP::Tiny 0.86 and later lets us set this environment variable
+    # XXX to restore the old default
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = 1;
+
     if ($self->{instance}->{config}->get_bit('httpmodules', 'carddav')) {
         require Net::CardDAVTalk;
         $self->{carddav} = Net::CardDAVTalk->new(


### PR DESCRIPTION
HTTP::Tiny 0.83+ defaults to enabling SSL certificate verification.  The Net::DAVTalk modules can't currently configure SSL properly, so tests with a https service configured (ALPN.https_*) fail during setup when HTTP::Tiny is 0.83 or newer.

HTTP::Tiny 0.86+ adds an environment variable for restoring the old default behaviour of not verifying SSL certificates.

This PR sets the environment variable temporarily during setup to stop these tests failing.

Better fix to follow later, once Net::DAVTalk has been updated.