### PR TITLE
cass: support newer HTTP::Tiny, Net::DAVTalk, Mail::JMAPTalk

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -41,12 +41,14 @@ package Cassandane::Cyrus::TestCase;
 use strict;
 use warnings;
 use attributes;
+use version 0.77;
+use Cwd qw(abs_path);
 use Data::Dumper;
-use Scalar::Util qw(refaddr);
-use List::Util qw(uniq);
 use Digest::file qw(digest_file_hex);
-use File::Temp qw(tempfile);
 use File::Path qw(rmtree);
+use File::Temp qw(tempfile);
+use List::Util qw(uniq);
+use Scalar::Util qw(refaddr);
 
 use lib '.';
 use base qw(Cassandane::Unit::TestCase);
@@ -791,6 +793,47 @@ sub _create_instances
     }
 }
 
+sub _need_http_tiny_env
+{
+    # Net::DAVTalk < 0.23 and Mail::JMAPTalk < 0.17 don't pass through
+    # SSL_options, but HTTP::Tiny >= 0.083 enables SSL certificate
+    # verification, which will fail without our SSL_options.
+    #
+    # For HTTP::Tiny >= 0.086, we can set an environment variable
+    # to turn off SSL certificate verifications.
+    #
+    # For HTTP::Tiny in 0.083 .. 0.085, ¯\_(ツ)_/¯
+    eval {
+        require Net::DAVTalk;
+        require HTTP::Tiny;
+    };
+    return undef if $@;
+
+    my $ndv = version->parse($Net::DAVTalk::VERSION);
+    my $mjv = version->parse($Mail::JMAPTalk::VERSION);
+    my $htv = version->parse($HTTP::Tiny::VERSION);
+
+    # not needed: old HTTP::Tiny doesn't check certificates
+    return undef if $htv < version->parse('0.083');
+
+    # not needed: new Net::DAVTalk and Mail::JMAPTalk pass through SSL_options
+    return undef if $ndv >= version->parse('0.23')
+                    && $mjv >= version->parse('0.17');
+
+    # awkward: HTTP::Tiny 0.083-0.085 are new enough to check certificates
+    # by default, but not new enough for us to override that by the
+    # environment variable.  if you get errors here, you need to either
+    # upgrade HTTP::Tiny to 0.086 (or later), or upgrade Net::DAVTalk to 0.23
+    # and Mail::JMAPTalk to 0.17 (or later).
+    HTTP::Tiny->VERSION('0.086');
+
+    xlog "Have Net::DAVTalk version " . Net::DAVTalk->VERSION();
+    xlog "Have Mail::JMAPTalk version " . Mail::JMAPTalk->VERSION();
+    xlog "Have HTTP::Tiny version " . HTTP::Tiny->VERSION();
+    xlog "Will set PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT=1";
+    return 1;
+}
+
 sub _setup_http_service_objects
 {
     my ($self) = @_;
@@ -800,20 +843,21 @@ sub _setup_http_service_objects
     $service ||= $self->{instance}->get_service("http");
     return if !$service;
 
+    my $ca_file = abs_path("data/certs/cacert.pem");
+
     my %common_args = (
         user => 'cassandane',
         password => 'pass',
         host => $service->host(),
         port => $service->port(),
         scheme => ($service->is_ssl() ? 'https' : 'http'),
+        SSL_options => {
+            SSL_ca_file => $ca_file,
+            SSL_verifycn_scheme => 'none',
+        },
     );
 
-    # XXX HTTP::Tiny 0.8.3 and later have SSL_verify enabled by default, but
-    # XXX Net::DAVTalk doesn't provide any way for us to supply our CA file,
-    # XXX making setup fail with certificate verify errors.
-    # XXX HTTP::Tiny 0.86 and later lets us set this environment variable
-    # XXX to restore the old default
-    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = 1;
+    local $ENV{PERL_HTTP_TINY_SSL_INSECURE_BY_DEFAULT} = _need_http_tiny_env();
 
     if ($self->{instance}->{config}->get_bit('httpmodules', 'carddav')) {
         require Net::CardDAVTalk;
@@ -840,6 +884,9 @@ sub _setup_http_service_objects
             %common_args,
             url => '/jmap/',
         );
+
+        # preload default UA while the HTTP::Tiny env var is still set
+        $self->{jmap}->ua();
     }
 
     xlog $self, "http service objects setup complete!";

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -796,8 +796,8 @@ sub _setup_http_service_objects
     my ($self) = @_;
 
     # nothing to do if no http or https service
-    my $service = $self->{instance}->get_service("http");
-    $service ||= $self->{instance}->get_service("https");
+    my $service = $self->{instance}->get_service("https");
+    $service ||= $self->{instance}->get_service("http");
     return if !$service;
 
     my %common_args = (

--- a/cassandane/tiny-tests/JMAPCore/echo_tls
+++ b/cassandane/tiny-tests/JMAPCore/echo_tls
@@ -1,0 +1,28 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_echo_tls
+    :TLS :want_service_https :needs_component_httpd
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+
+    # better be using https!
+    $self->assert_str_equals('https', $jmap->{scheme});
+
+    my $req = {
+        hello => JSON::true,
+        max => 5,
+        stuff => { foo => "bar", empty => JSON::null }
+    };
+
+    xlog $self, "send ping";
+    my $res = $jmap->CallMethods([['Core/echo', $req, "R1"]]);
+
+    xlog $self, "check pong";
+    $self->assert_not_null($res);
+    $self->assert_str_equals('Core/echo', $res->[0][0]);
+    $self->assert_deep_equals($req, $res->[0][1]);
+    $self->assert_str_equals('R1', $res->[0][2]);
+}


### PR DESCRIPTION
Newer HTTP::Tiny turns on SSL certificate verification by default, which meant tests using HTTPS were failing.  This was previously worked around in #5227.

There have since been updates to Mail::JMAPTalk and Net::DAVTalk to pass through our SSL_options, so if the new versions of those are installed we can skip the workaround and do it properly instead, with certificate verification enabled.

Also added a simple test that exercises JMAP-over-HTTPS, because this was broken just like DAV-over-HTTPS was, just not visibly so because nothing used it.