### PR TITLE
jmap_ical.c: reject non-integer priority value

### DIFF
--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -7920,7 +7920,7 @@ static void calendarevent_to_ical(icalcomponent *comp,
     }
 
     jprop = json_object_get(event, "priority");
-    if (json_integer_value(jprop) >= 0 || json_integer_value(jprop) <= 9) {
+    if (json_is_integer(jprop)) {
         remove_icalprop(comp, ICAL_PRIORITY_PROPERTY);
         icalproperty *prop = icalproperty_new_priority(json_integer_value(jprop));
         icalcomponent_add_property(comp, prop);


### PR DESCRIPTION
The conditional that validates the priority property value to be in the valid range from 0..9 had an error, effectively accepting any JSON value as a valid priority value. Any non-integer JSON value resulted in priority 0 to be set.

This patch keeps accepting any JSON integer value as priority (contrary to RFC8984 requiring it to be in the 0..9 range), but now rejects any non-integer JSON value.

Fixes #5226