### PR TITLE
append.c: only call out to annotator on email

### DIFF
--- a/cassandane/utils/annotator.pl
+++ b/cassandane/utils/annotator.pl
@@ -103,6 +103,12 @@ my %commands =
         xlog "clear_flag($flag)";
         $message->clear_flag($flag);
     },
+
+    # These are here so that syntactically valid Sieve scripts can be appended,
+    # and go through the test annotator daemon, and not crash it before hitting
+    # instructions inside the comments.  Weird, right? -- rjbs, 2025-01-29
+    '/*' => sub {},
+    '*/' => sub {},
 );
 
 sub annotate_message

--- a/changes/next/annotate-only-email
+++ b/changes/next/annotate-only-email
@@ -1,0 +1,21 @@
+Description:
+
+The annotator callback is only called on items added to email-type mailboxes.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+In general, no action is required.  In the very unlikely instance that your
+installation was relying on an annotator callout processing non-email appends
+(like Sieve, events, or contacts), you will need to find another solution.  The
+core team does not believe such a configuration is likely to exist.
+
+
+GitHub issue:
+
+None.

--- a/imap/append.c
+++ b/imap/append.c
@@ -1107,10 +1107,8 @@ havefile:
         goto out;
     }
 
-    if (
-        config_getstring(IMAPOPT_ANNOTATION_CALLOUT)
-        && (mbtype_isa(mailbox_mbtype(mailbox)) == MBTYPE_EMAIL)
-    ) {
+    if (config_getstring(IMAPOPT_ANNOTATION_CALLOUT) &&
+        (mbtype_isa(mailbox_mbtype(mailbox)) == MBTYPE_EMAIL)) {
         if (flags)
             newflags = strarray_dup(flags);
         else

--- a/imap/append.c
+++ b/imap/append.c
@@ -1107,7 +1107,10 @@ havefile:
         goto out;
     }
 
-    if (config_getstring(IMAPOPT_ANNOTATION_CALLOUT)) {
+    if (
+        config_getstring(IMAPOPT_ANNOTATION_CALLOUT)
+        && (mbtype_isa(mailbox_mbtype(mailbox)) == MBTYPE_EMAIL)
+    ) {
         if (flags)
             newflags = strarray_dup(flags);
         else
@@ -1345,12 +1348,20 @@ HIDDEN int append_run_annotator(struct appendstate *as,
     strarray_t *flags = NULL;
     struct body *body = NULL;
     int r = 0;
+    struct mailbox *mailbox = NULL;
 
     if (!config_getstring(IMAPOPT_ANNOTATION_CALLOUT))
         return 0;
 
     if (config_getswitch(IMAPOPT_ANNOTATION_CALLOUT_DISABLE_APPEND)) {
         syslog(LOG_DEBUG, "append_run_annotator: Append disabled.");
+        return 0;
+    }
+
+    r = msgrecord_get_mailbox(msgrec, &mailbox);
+    if (r) goto out;
+
+    if (mbtype_isa(mailbox_mbtype(mailbox)) != MBTYPE_EMAIL) {
         return 0;
     }
 

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -624,12 +624,12 @@ static int store_script(struct mailbox *mailbox, struct sieve_data *sdata,
 
     fclose(f);
 
+    /* Treat this as the user taking action, since that's what it is. */
+    authstate = auth_newstate(userid);
+
     if (sdata->isactive) {
         /* Flag script as active */
         strarray_append(&flags, "\\Flagged");
-
-        /* Need authstate in order to set flags */
-        authstate = auth_newstate(userid);
     }
 
     if ((r = append_setup_mbox(&as, mailbox, userid, authstate,


### PR DESCRIPTION
The annotator exists so that installations can update email messages to have extra flags or annotations.  Because "everything" is an email, it was also running on sieve scripts and other non-emails.  This was probably harmless on many installations, but not intended.

This branch updates the annotator to run only on messages being appended to mailboxes of type `e`.

It also fixes a bug in `sieve_db`, wherein we only set the authstate for the `onSuccessActivateScript` side effect, not the rest of script creation.