### PR TITLE
Add xsyslog_ev - a logfmt style logger

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -644,7 +644,8 @@ cunit_TESTS = \
     cunit/search_expr.testc \
     cunit/seqset.testc \
     cunit/slowio.testc \
-    cunit/smallarrayu64.testc
+    cunit/smallarrayu64.testc \
+    cunit/xsyslog_ev.testc
 
 if SIEVE
 cunit_TESTS += cunit/sieve.testc

--- a/cunit/xsyslog_ev.testc
+++ b/cunit/xsyslog_ev.testc
@@ -1,0 +1,236 @@
+#include "config.h"
+#include "cunit/cyrunit.h"
+#include "util.h"
+#include <syslog.h>
+#include <limits.h>
+#include <errno.h>
+
+static void test_lf_c(void)
+{
+    char third = 'c';
+
+    CU_SYSLOG_MATCH("event=\"lf_c test\" first=a second=b third=c");
+    xsyslog_ev(LOG_ERR, "lf_c test",
+        lf_c("first", 'a'), lf_c("second", 'b'), lf_c("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_d(void)
+{
+    int third = -56;
+
+    CU_SYSLOG_MATCH("event=\"lf_d test\" first=12 second=-34 third=-56");
+    xsyslog_ev(LOG_ERR, "lf_d test",
+        lf_d("first", 12), lf_d("second", -34), lf_d("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_ld(void)
+{
+    struct buf want = BUF_INITIALIZER;
+    buf_printf(&want, "event=\"lf_ld test\" first=12 second=-34 third=%ld",
+               LONG_MAX);
+
+    CU_SYSLOG_MATCH(buf_cstring(&want));
+    xsyslog_ev(LOG_ERR, "lf_ld test",
+        lf_ld("first", 12), lf_ld("second", -34), lf_ld("third", LONG_MAX));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&want);
+}
+
+static void test_lf_lld(void)
+{
+    struct buf want = BUF_INITIALIZER;
+    buf_printf(&want, "event=\"lf_lld test\" first=12 second=-34 third=%lld",
+               LLONG_MAX);
+
+    CU_SYSLOG_MATCH(buf_cstring(&want));
+    xsyslog_ev(LOG_ERR, "lf_lld test",
+        lf_lld("first", 12), lf_lld("second", -34), lf_lld("third", LLONG_MAX));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&want);
+}
+
+static void test_lf_u(void)
+{
+    int third = 56;
+
+    CU_SYSLOG_MATCH("event=\"lf_u test\" first=12 second=34 third=56");
+    xsyslog_ev(LOG_ERR, "lf_u test",
+        lf_u("first", 12), lf_u("second", 34), lf_u("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_lu(void)
+{
+    struct buf want = BUF_INITIALIZER;
+    buf_printf(&want, "event=\"lf_lu test\" first=12 second=34 third=%lu",
+               ULONG_MAX);
+
+    CU_SYSLOG_MATCH(buf_cstring(&want));
+    xsyslog_ev(LOG_ERR, "lf_lu test",
+        lf_lu("first", 12), lf_lu("second", 34), lf_lu("third", ULONG_MAX));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&want);
+}
+
+static void test_lf_llu(void)
+{
+    struct buf want = BUF_INITIALIZER;
+    buf_printf(&want, "event=\"lf_llu test\" first=12 second=34 third=%llu",
+               ULLONG_MAX);
+
+    CU_SYSLOG_MATCH(buf_cstring(&want));
+    xsyslog_ev(LOG_ERR, "lf_llu test",
+        lf_llu("first", 12), lf_llu("second", 34), lf_llu("third", ULLONG_MAX));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&want);
+}
+
+static void test_lf_zd(void)
+{
+    ssize_t third = -56;
+
+    CU_SYSLOG_MATCH("event=\"lf_zd test\" first=12 second=34 third=-56");
+    xsyslog_ev(LOG_ERR, "lf_zd test",
+        lf_zd("first", 12), lf_zd("second", 34), lf_zd("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_zu(void)
+{
+    size_t third = 56;
+
+    CU_SYSLOG_MATCH("event=\"lf_zu test\" first=12 second=34 third=56");
+    xsyslog_ev(LOG_ERR, "lf_zu test",
+        lf_zu("first", 12), lf_zu("second", 34), lf_zu("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_llx(void)
+{
+    size_t third = 15;
+
+    CU_SYSLOG_MATCH("event=\"lf_llx test\" first=1 second=A third=F");
+    xsyslog_ev(LOG_ERR, "lf_llx test",
+        lf_llx("first", 1), lf_llx("second", 10), lf_llx("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_f(void)
+{
+    double third = 3.3;
+
+    CU_SYSLOG_MATCH("event=\"lf_f test\" first=1\\.10* second=2\\.20* third=3\\.30*");
+    xsyslog_ev(LOG_ERR, "lf_f test",
+        lf_f("first", 1.1), lf_f("second", 2.2), lf_f("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_m(void)
+{
+    struct buf expect = BUF_INITIALIZER;
+    struct buf errbuf = BUF_INITIALIZER;
+    char *errstr = strerror(1);
+    size_t i;
+    int needs_quotes = 0;
+
+    buf_printf(&expect, "event=\"lf_m test\"");
+
+    // escape error string if necessary...
+    for (i = 0; i < strlen(errstr); i++) {
+        switch (errstr[i]) {
+        case '\\':
+            buf_appendcstr(&errbuf, "\\\\");
+            needs_quotes = 1;
+            break;
+        case '"':
+            buf_appendcstr(&errbuf, "\\\"");
+            needs_quotes = 1;
+            break;
+        case '\r':
+            buf_appendcstr(&errbuf, "\\r");
+            needs_quotes = 1;
+            break;
+        case '\n':
+            buf_appendcstr(&errbuf, "\\n");
+            needs_quotes = 1;
+            break;
+        case ' ':
+            needs_quotes = 1;
+            GCC_FALLTHROUGH
+
+        default:
+            buf_printf(&errbuf, "%c", errstr[i]);
+        }
+    }
+
+    if (needs_quotes || strlen(errstr) == 0) {
+        buf_printf(&expect, " error=\"%s\"", buf_cstring(&errbuf));
+    } else {
+        buf_printf(&expect, " error=%s", buf_cstring(&errbuf));
+    }
+
+    CU_SYSLOG_MATCH(buf_cstring(&expect));
+    errno = 1;
+    xsyslog_ev(LOG_ERR, "lf_m test", lf_m("error"));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&errbuf);
+    buf_free(&expect);
+}
+
+static void test_lf_s(void)
+{
+    const char *third = "three";
+
+    CU_SYSLOG_MATCH("event=\"lf_s test\" first=one second=two third=three");
+    xsyslog_ev(LOG_ERR, "lf_s test",
+        lf_s("first", "one"), lf_s("second", "two"), lf_s("third", third));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    CU_SYSLOG_MATCH("event=\"lf_s test\" first=\"\"");
+    xsyslog_ev(LOG_ERR, "lf_s test", lf_s("first", ""));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    CU_SYSLOG_MATCH("event=\"lf_s test\" first=\"with spaces\"");
+    xsyslog_ev(LOG_ERR, "lf_s test", lf_s("first", "with spaces"));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    CU_SYSLOG_MATCH("event=\"lf_s test\" first=\"with \\\\\"quotes\\\\\"\"");
+    xsyslog_ev(LOG_ERR, "lf_s test", lf_s("first", "with \"quotes\""));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    CU_SYSLOG_MATCH("event=\"lf_s test\" first=\"with \\\\r\\\\n\"");
+    xsyslog_ev(LOG_ERR, "lf_s test", lf_s("first", "with \r\n"));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    CU_SYSLOG_MATCH("event=\"lf_s test\" first=\"with \\\\\\\\\"");
+    xsyslog_ev(LOG_ERR, "lf_s test", lf_s("first", "with \\"));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_raw(void)
+{
+    CU_SYSLOG_MATCH("event=\"lf_raw test\" first=3.14 second=what");
+    xsyslog_ev(LOG_ERR, "lf_raw test",
+        lf_raw("first", "%.02f", 3.14159), lf_raw("second", "%s", "what"));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_mixed(void)
+{
+    CU_SYSLOG_MATCH("event=\"mixed test\" first=1 second=2.1 third=\"hi there\"");
+    xsyslog_ev(LOG_ERR, "mixed test",
+        lf_d("first", 1),
+        lf_raw("second", "%.01f", 2.1),
+        lf_s("third", "hi there")
+    );
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+/* vim: set ft=c: */


### PR DESCRIPTION
This implements roughly the same logging format as https://metacpan.org/dist/Log-Dispatchouli/source/lib/Log/Fmt.pm.

It's structed in a way to maintain compiler time safety checks around variable assignments, type conversions, and printf format strings.

A simple usage looks like:

    int errors = 0;
    ...
    xsyslog_ev(LOG_ERR, "name of event", lf_d("error-count", errors));

which will produce a log entry looking like:

    event="name of event" error-count=3

This provides a number of common printf-style formats used in our existing logs as macros to get the same behaviour. For example, for '%d', you'd use lf_d("key", value), for '%s', lf_s(...), etc...

If you want more control over formatting, there's also lf_raw:

    xsyslog_ev(LOG_ERR, "event", lf_raw("float", "%.02f", 3.14159));

which produces:

    event="event" float=3.14

(lf_raw should probably be used sparingly as it adds more inline code to each place that uses it, increasing binary size...)

You can use as many macros together as necessary. Taking a real example:

    xsyslog(LOG_ERR, "DBERROR: database needs upgrade",
                     "fname=<%s> have=<%d> want=<%d> error=<%s>",
                     open->fname, open->version, version,
                     sqlite3_errmsg(open->db));

becomes:

    xsyslog_ev(LOG_ERR, "DBERROR: database needs upgrade",
        lf_s("fname", open->fname),
        lf_d("have", open->version),
        lf_d("want", version),
        lf_s("error", sqlite3_errmsg(open->db))
    );

_xsyslog_ev_escape() comes from Ken Murchison with modifications by Mark Jason Dominus and myself.

This work is based off of some back and forth conversations with ellie.