### PR TITLE
cass: annotate some tests with dependencies

### DIFF
--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -163,6 +163,7 @@ sub new
 
     $self->needs('component', 'jmap');
     $self->needs('component', 'sieve');
+    $self->needs('dependency', 'cld2');
     return $self;
 }
 

--- a/cassandane/tiny-tests/JMAPEmail/email_query_unicodefdfx
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_unicodefdfx
@@ -3,7 +3,7 @@ use Cassandane::Tiny;
 
 sub test_email_query_unicodefdfx
     :min_version_3_3 :needs_component_sieve
-    :SearchLanguage
+    :SearchLanguage :needs_dependency_cld2
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};


### PR DESCRIPTION
Skip some tests that can't succeed if Cyrus was built without CLD2 and/or wslay

Though I'm not certain that JMAPCore.eventsource failing without wslay isn't showing us a bug.  What do we think?  It sets `Last-Event-Id => 0` and then explicitly expects a 200 response, but instead gets a 204 No content