### PR TITLE
Revert "message.c: reject to parse MIME headers with NUL byte"

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_import_zerobyte
+++ b/cassandane/tiny-tests/JMAPEmail/email_import_zerobyte
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_email_import_zerobyte
-  :needs_component_sieve
+  :needs_component_sieve :NoCheckSyslog
 {
     my ($self) = @_;
     my $jmap = $self->{jmap};

--- a/imap/message.c
+++ b/imap/message.c
@@ -537,18 +537,19 @@ EXPORTED int message_parse_mapped(const char *msg_base, unsigned long msg_len,
 
     if (body->filesize != body->header_size + body->content_size) {
         if (efname)
-            xsyslog(LOG_ERR, "IOERROR: size mismatch on parse",
-                             "guid=<%s> filename=<%s>"
-                             " filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
-                             message_guid_encode(&body->guid), efname,
-                             body->filesize,
-                             body->header_size + body->content_size);
+            /* XXX IOERROR but only LOG_NOTICE?? */
+            xsyslog(LOG_NOTICE, "IOERROR: size mismatch on parse",
+                                "guid=<%s> filename=<%s> "
+                                "filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
+                                message_guid_encode(&body->guid), efname,
+                                body->filesize,
+                                body->header_size + body->content_size);
         else
-            xsyslog(LOG_ERR, "IOERROR: size mismatch on parse",
-                             "guid=<%s>"
-                             " filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
-                             message_guid_encode(&body->guid), body->filesize,
-                             body->header_size + body->content_size);
+            xsyslog(LOG_NOTICE, "IOERROR: size mismatch on parse",
+                                "guid=<%s> "
+                                "filesize=<%" PRIu32 "> bodysize=<%" PRIu32 ">",
+                                message_guid_encode(&body->guid), body->filesize,
+                                body->header_size + body->content_size);
     }
 
     return 0;


### PR DESCRIPTION
This reverts commits f56c25f7fa5eb77668e8d3ba706ca87d0c93ad56 and 0f137e7ab8dfbfaa14b0113cc8def0cc9eb2d94d to avoid reconstruct failing for messages that contain NUL bytes. We'll come up with a proper fix in https://github.com/cyrusimap/cyrus-imapd/pull/5253