### PR TITLE
Ctl conversations basecid

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -1815,11 +1815,11 @@ static void conversations_thread_sort(conversation_t *conv)
     ptrarray_fini(&items);
 }
 
-static void conversation_update_thread(conversation_t *conv,
-                                       const struct message_guid *guid,
-                                       time_t internaldate,
-                                       modseq_t createdmodseq,
-                                       int delta_exists)
+EXPORTED void conversation_update_thread(conversation_t *conv,
+                                         const struct message_guid *guid,
+                                         time_t internaldate,
+                                         modseq_t createdmodseq,
+                                         int delta_exists)
 {
     conv_thread_t *thread, **nextp = &conv->thread;
 

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -352,6 +352,11 @@ extern void conversation_update_sender(conversation_t *conv,
                                        const char *domain,
                                        time_t lastseen,
                                        ssize_t delta_exists);
+extern void conversation_update_thread(conversation_t *conv,
+                                       const struct message_guid *guid,
+                                       time_t internaldate,
+                                       modseq_t createdmodseq,
+                                       int delta_exists);
 
 extern int conversations_prune(struct conversations_state *state,
                                time_t thresh, unsigned int *,

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -537,7 +537,7 @@ static unsigned int diff_records(struct conversations_state *a,
             continue;
         }
 
-        /* both exist an are the same key */
+        /* both exist and are the same key */
         delta = blob_compare(ca.data, ca.datalen, cb.data, cb.datalen);
         if (delta) {
             ndiffs++;
@@ -560,6 +560,7 @@ static int fix_modseqs(struct conversations_state *a,
 {
     int ra, rb;
     struct cursor ca, cb;
+    char buf[80];
     int keydelta;
     int r;
 
@@ -700,6 +701,25 @@ static int fix_modseqs(struct conversations_state *a,
                                 (int)cb.keylen, cb.key,
                                 b->path, error_message(r));
                 return r;
+            }
+        }
+        if (ca.key[0] == 'G') {
+            // basecid might be different on the old record, so if they're both v3, then copy the data over
+            if (ca.datalen >= 33 && cb.datalen >= 33 && ca.data[0] == (char)0x83 && cb.data[0] == (char)0x83) {
+                conversation_id_t basea = ntohll(*((bit64*)(ca.data+25)));
+                conversation_id_t baseb = ntohll(*((bit64*)(cb.data+25)));
+                if (basea != baseb && cb.datalen < 80) {
+                    memcpy(buf, cb.data, cb.datalen);
+                    *((uint64_t *)(buf + 25)) = htonll(basea);
+                    r = cyrusdb_store(b->db, cb.key, cb.keylen, buf, cb.datalen, &b->txn);
+                    if (r) {
+                         fprintf(stderr, "Failed to store conversations "
+                                         "record \"%.*s\" to %s: %s, giving up\n",
+                                         (int)cb.keylen, cb.key,
+                                         b->path, error_message(r));
+                         return r;
+                    }
+                }
             }
         }
 

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -677,6 +677,7 @@ static int fix_modseqs(struct conversations_state *a,
             conv_folder_t *foldera;
             conv_folder_t *folderb;
             conv_sender_t *sendera;
+            conv_thread_t *threada;
 
             r = conversation_parse(ca.data, ca.datalen, &conva, CONV_WITHALL);
             if (r) {
@@ -716,6 +717,15 @@ static int fix_modseqs(struct conversations_state *a,
                 conversation_update_sender(&convb, sendera->name, sendera->route,
                                            sendera->mailbox, sendera->domain,
                                            sendera->lastseen, /*delta_count*/0);
+            }
+
+            /* emails have modseqs, and the modseq might be for a deleted message */
+            for (threada = conva.thread; threada; threada = threada->next) {
+                /* always update!  The delta logic will ensure we don't add
+                 * the record if it's not already at least present in the
+                 * other conversation */
+                conversation_update_thread(&convb, &threada->guid, threada->internaldate,
+                        threada->createdmodseq, /*delta_exists*/0);
             }
 
             /* be nice to know if this is needed, but at least twoskip


### PR DESCRIPTION
As discussed this morning, this should do two things:

1) avoid us finding a diff when only the basecid is different in G keys
2) replace binary gunk with human readable output

I did NOT make cyr_dbtool ungunk the binary output because that's not needed for this immediate issue.