### PR TITLE
jmap_ical.c: fix bug when guessing non-standard timezones and improve caching

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_nonstandard_utcoffset
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_nonstandard_utcoffset
@@ -1,0 +1,85 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_guesstz_nonstandard_utcoffset
+    :needs_dependency_guesstz
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    # This iCalendar object contains two non-standard timezones
+    # for which no equivalent IANA timezone can be found in the
+    # 'guesstz' timezone database. Cyrus falls back to guessing
+    # the nearest UTC offset timezone.
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+PRODID:-//Foo//Bar//EN
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Offset0430
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:-0430
+TZOFFSETTO:-0430
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VTIMEZONE
+TZID:Offset0730
+BEGIN:STANDARD
+DTSTART:16010101T000000
+TZOFFSETFROM:-0730
+TZOFFSETTO:-0730
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:C14C9D9D-D9E0-4008-B995-A1ADEB47E3F9
+DTSTART;TZID=Offset0730:20250130T183000
+DTSTAMP:20250131T231705Z
+DURATION:PT1H
+SEQUENCE:0
+SUMMARY:offset0730
+END:VEVENT
+BEGIN:VEVENT
+UID:1F95E16C-A0EE-4041-8717-F93E175EDBF7
+DTSTART;TZID=Offset0430:20240824T153000
+DTSTAMP:20250131T231705Z
+DURATION:PT1H
+SEQUENCE:0
+SUMMARY:offset0430
+END:VEVENT
+END:VCALENDAR
+EOF
+    $ical =~ s/\r?\n/\r\n/gs;
+
+    my $res = $jmap->CallMethods(
+        [
+            ['Blob/upload', {
+                create => {
+                    ical => {
+                        data => [ {
+                            'data:asText' => $ical,
+                        } ],
+                    },
+                },
+            }, 'R0'],
+            ['CalendarEvent/parse', {
+                blobIds    => ["#ical"],
+                properties =>
+                [ 'start', 'timeZone', 'timeZones', 'title' ],
+            },
+            'R1' ]
+        ],
+        [
+            'urn:ietf:params:jmap:core',
+            'urn:ietf:params:jmap:calendars',
+            'https://cyrusimap.org/ns/jmap/calendars',
+            'https://cyrusimap.org/ns/jmap/blob',
+        ]
+    );
+
+    my %timeZoneByTitle = map { $_->{title} => $_->{timeZone} }
+      @{ $res->[1][1]{parsed}{'#ical'}{entries} };
+
+    $self->assert_str_equals('Etc/GMT+8', $timeZoneByTitle{offset0730});
+    $self->assert_str_equals('Etc/GMT+5', $timeZoneByTitle{offset0430});
+}

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -1094,6 +1094,10 @@ static void jstimezones_add_vtimezones(jstimezones_t *jstzones, icalcomponent *i
     /* Process custom timezones */
     struct buf idbuf = BUF_INITIALIZER;
 
+    // Lookup the first VEVENT, we'll use its DTSTART to determine
+    // the timezone for non-standard UTC offsets later.
+    icalcomponent *realcomp = icalcomponent_get_first_real_component(ical);
+
     for (vtz = icalcomponent_get_first_component(ical, ICAL_VTIMEZONE_COMPONENT);
          vtz;
          vtz = icalcomponent_get_next_component(ical, ICAL_VTIMEZONE_COMPONENT)) {
@@ -1132,13 +1136,12 @@ static void jstimezones_add_vtimezones(jstimezones_t *jstzones, icalcomponent *i
             if (!buf_len(&idbuf)) {
                 /* Could not guess IANA timezone name by comparing timezone
                  * rules. Let's determine the closest "Etc/GMT+X" timezone. */
-                icalcomponent *comp = icalcomponent_get_first_real_component(ical);
-                if (comp) {
+                if (realcomp) {
                     icalcomponent *tmpvtz = icalcomponent_clone(myvtz);
                     icaltimezone *tmptz = icaltimezone_new();
                     icaltimezone_set_component(tmptz, tmpvtz);
 
-                    icaltimetype dtstart = icalcomponent_get_dtstart(comp);
+                    icaltimetype dtstart = icalcomponent_get_dtstart(realcomp);
                     int is_daylight = 0;
                     int offset = icaltimezone_get_utc_offset(tmptz, &dtstart, &is_daylight);
 


### PR DESCRIPTION
This fixes a bug when guessting non-standard timezones which led to some VTIMEZONEs having non-zero minutes in their UTC offset being mapped to floating time. Related to this, this pull request also adds caching of timezones to CalendarEvent/parse, improving latency for that JMAP method.