### PR TITLE
mboxlist: auditlog subscriptions

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5331,6 +5331,17 @@ EXPORTED int mboxlist_changesub(const char *name, const char *userid,
         mboxevent_free(&mboxevent);
     }
 
+    if (add) {
+        xsyslog(LOG_NOTICE, "auditlog: subscribe",
+                            "sessionid=<%s> userid=<%s> mailbox=<%s>",
+                session_id(), userid, name);
+    }
+    else {
+        xsyslog(LOG_NOTICE, "auditlog: unsubscribe",
+                            "sessionid=<%s> userid=<%s> mailbox=<%s>",
+                session_id(), userid, name);
+    }
+
   done:
     mboxlist_entry_free(&mbentry);
     free(dbname);


### PR DESCRIPTION
This might be closing the barn door after a horse has bolted, but it's useful to know when things were subscribed or unsubscribed!