### PR TITLE
fix remaining mboxlist usage

### DIFF
--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1155,7 +1155,6 @@ static int addr_compare(const void *a, const void *b)
 static int list_addressbooks(struct transaction_t *txn)
 {
     int ret = 0, precond, rights;
-    char mboxlist[MAX_MAILBOX_PATH+1];
     struct stat sbuf;
     time_t lastmod;
     const char *etag;
@@ -1167,8 +1166,9 @@ static int list_addressbooks(struct transaction_t *txn)
 #include "imap/http_cal_abook_admin_js.h"
 
     /* stat() mailboxes.db for Last-Modified and ETag */
-    snprintf(mboxlist, MAX_MAILBOX_PATH, "%s%s", config_dir, FNAME_MBOXLIST);
+    char *mboxlist = mboxlist_fname();
     stat(mboxlist, &sbuf);
+    free(mboxlist);
     lastmod = MAX(compile_time, sbuf.st_mtime);
     assert(!buf_len(&txn->buf));
     buf_printf(&txn->buf, TIME_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT,

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -554,7 +554,6 @@ static int list_feeds(struct transaction_t *txn)
     int fd = -1;
     struct message_guid guid;
     time_t lastmod = 0;
-    char mboxlist[MAX_MAILBOX_PATH+1];
     struct stat sbuf;
     int ret = 0, precond;
     struct buf *body = &txn->resp_body.payload;
@@ -611,8 +610,9 @@ static int list_feeds(struct transaction_t *txn)
     buf_setcstr(&txn->buf, message_guid_encode(&guid));
 
     /* stat() mailboxes.db for Last-Modified and ETag */
-    snprintf(mboxlist, MAX_MAILBOX_PATH, "%s%s", config_dir, FNAME_MBOXLIST);
+    char *mboxlist = mboxlist_fname();
     stat(mboxlist, &sbuf);
+    free(mboxlist);
     lastmod = MAX(lastmod, sbuf.st_mtime);
     buf_printf(&txn->buf, "-" TIME_T_FMT "-" OFF_T_FMT, sbuf.st_mtime, sbuf.st_size);
 


### PR DESCRIPTION
This fixes items missed in https://github.com/cyrusimap/cyrus-imapd/pull/5267 which fixed the mboxlist pathname detection for caldav but not carddav or rss.