### PR TITLE
document mboxgroups

### DIFF
--- a/docsrc/imap/reference/admin/access-control/identifiers.rst
+++ b/docsrc/imap/reference/admin/access-control/identifiers.rst
@@ -82,6 +82,52 @@ a non-/etc/passwd backend. Note that using unix groups in this way
     NSS augmentations, such as ``nss_ldap``, ``pam_ldap`` or ``sssd``
     may be used to provide Cyrus access to group information via NSS.
 
+mboxgroups Authorization
+------------------------
+
+::
+
+    auth_mech: mboxgroups
+
+The mboxgroups authorization mechanism is like the Unix mechanism, but it
+looks for groups stored in the mailboxes.db instead of the system groups file.
+
+When this authorization mechanism is in use, imapd will report the capability
+``XUSERGROUPS``, and admins can use the IMAP commands ``GETUSERGROUP``,
+``SETUSERGROUP``, and ``UNSETUSERGROUP`` for group management.
+
+    **GETUSERGROUP** *item*
+
+        If *item* is a userid, returns the groups the user belongs to.  If
+        *item* is a group identifier, returns its members.
+
+        ::
+
+            C: 8 GETUSERGROUP cassandane
+            S: * USERGROUP cassandane ("group:group c" "group:group co")
+            S: 8 OK Completed
+            C: 9 GETUSERGROUP "group:group co"
+            S: * USERGROUP "group:group co" (cassandane otheruser)
+            S: 9 OK Completed
+
+    **SETUSERGROUP** *userid* *group*
+
+        Adds *userid* as a member of *group*
+
+        ::
+
+            C: 9 SETUSERGROUP cassandane "group:new group"
+            S: 9 OK Completed
+
+    **UNSETUSERGROUP** *userid* *group*
+
+        Removes *userid* from *group*
+
+        ::
+
+            C: 9 UNSETUSERGROUP cassandane "group:group c"
+            S: 9 OK Completed
+
 Kerberos Authorization
 ----------------------
 

--- a/docsrc/imap/reference/admin/access-control/identifiers.rst
+++ b/docsrc/imap/reference/admin/access-control/identifiers.rst
@@ -6,17 +6,15 @@ Access Control Identifier (ACI)
 
 The Access Control Identifier (ACI) part of an ACL entry specifies the
 user or group for which the entry applies.  Group identifiers are
-distinguished be the prefix "group:".  For example, "group:accounting".
+distinguished by the prefix "group:".  For example, "group:accounting".
 
 .. todo:: FIXME: Clarify what an ACL entry looks like first. Refer to
           how user login names are translated into their identifiers, and (in
           that section) refer to altnamespace, unixhierarchysep, default domain,
-          virtdomains, sasl_auth_mech tips and tricks etc.
+          virtdomains, tips and tricks etc.
 
-There are two special identifiers, "anonymous", and "anyone", which are
-explained below. The meaning of other identifiers usually depends on
-the authorization mechanism being used (selected by ``--with-auth`` at
-compile time, defaulting to Unix).
+There are two special identifiers, "anonymous", and "anyone".  The meaning of
+other identifiers usually depends on the authorization mechanism being used.
 
 ``anonymous`` and ``anyone``
 ----------------------------
@@ -30,8 +28,8 @@ Both ``anonymous`` and ``anyone`` may commonly be used with the **post**
 right ``p`` to allow message insertion to mailboxes.
 
 
-Kerberos vs. Unix Authorization
--------------------------------
+Authorization Mechanisms
+========================
 
 The Cyrus IMAP server comes with four authorization mechanisms, one is
 compatible with Unix-style (``/etc/passwd``) authorization, one called
@@ -48,8 +46,20 @@ other group databases (e.g. AFS PTS groups, LDAP Groups, etc).
     discussed in the :ref:`imap-concepts-login-authentication` part of
     this document.
 
+The authorization mechanism in use is determined by the ``auth_mech``
+:cyrusman:`imapd.conf(5)` option:
+
+    .. include:: /imap/reference/manpages/configs/imapd.conf.rst
+        :start-after: startblob auth_mech
+        :end-before: endblob auth_mech
+
+
 Unix Authorization
-^^^^^^^^^^^^^^^^^^
+------------------
+
+::
+
+    auth_mech: unix
 
 In the Unix authorization mechanism, ACIs are either a valid userid or
 the string ``group:`` followed by a group listed in ``/etc/group``.
@@ -59,7 +69,6 @@ Thus:
 
     root                Refers to the user root
     group:staff         Refers to the group staff
-
 
 It is also possible to use unix groups with users authenticated through
 a non-/etc/passwd backend. Note that using unix groups in this way
@@ -74,7 +83,11 @@ a non-/etc/passwd backend. Note that using unix groups in this way
     may be used to provide Cyrus access to group information via NSS.
 
 Kerberos Authorization
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
+
+::
+
+    auth_mech: krb5
 
 Using the Kerberos authorization mechanism, ACIs are of the form:
 
@@ -83,11 +96,61 @@ Using the Kerberos authorization mechanism, ACIs are of the form:
 If ``$instance`` is omitted, it defaults to the null string. If
 ``$realm`` is omitted, it defaults to the local realm.
 
+PTS Authorization
+-----------------
 
-Alternative Authorization
-^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+    auth_mech: pts
+
+The PTS authorization mechanism is modular, with the module selected by the
+``pts_module`` :cyrusman:`imapd.conf(5)` option:
+
+    .. include:: /imap/reference/manpages/configs/imapd.conf.rst
+        :start-after: startblob pts_module
+        :end-before: endblob pts_module
+
+The meaning of identifiers depends on the PTS module being used.
+
+AFSKRB Authorization using PTS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    auth_mech: pts
+    pts_module: afskrb
+
+Document this!  Probably by linking to a separate document.
+
+HTTP Authorization using PTS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    auth_mech: pts
+    pts_module: http
+
+Document this!  Probably by linking to a separate document.
+
+LDAP Authorization using PTS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    auth_mech: pts
+    pts_module: ldap
+
+Document this!  Probably by linking to a separate document.
+
+Alternative Authorization using PTS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    auth_mech: pts
+    pts_module: ???
 
 A site may wish to write their own authorization mechanism, perhaps to
-implement a local group mechanism. If it does so (by implementing an
-``auth_[whatever]`` PTS module), it will dictate its own form and
-meaning of identifiers.
+implement a local group mechanism.  You do this by implementing a custom
+PTS module.  The form and meaning of identifiers will be up to the
+implementation.

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1936,6 +1936,7 @@ static void cmdloop(void)
                 prometheus_increment(CYRUS_IMAP_GETQUOTA_TOTAL);
             }
             else if (!strcmp(cmd.s, "Getusergroup")) {
+                if (!imapd_userisadmin) goto adminsonly;
                 if (c != ' ') goto missingargs;
                 c = getastring(imapd_in, imapd_out, &arg1);
                 if (c == EOF) goto missingargs;


### PR DESCRIPTION
**Reviewers: suggest reading this commit by commit**

* Adds basic documentation for the new `auth_mech: mboxgroups` authorization mechanism.

  This was the only place any authorization mechanisms were documented, so I've added it here.  I'm not convinced this is the _best_ place to document authorization mechanisms generally, but I also don't want to undergo a major restructure of the documentation, so this'll do.  I tidied up the existing stuff a little while I was in there.
* Makes IMAP GETUSERGROUP command admin-only.  With this, a normal user could see any other user's groups, or any group's membership.  That felt wrong so I fixed it.
* Adds tests for the group management commands, cause I needed to figure out how they worked anyway

Closes #5252 