### PR TITLE
Sanitizer builds

### DIFF
--- a/cunit/leaksanitizer.suppress
+++ b/cunit/leaksanitizer.suppress
@@ -1,0 +1,5 @@
+leak:__cunit_test_bitfield_invalid
+leak:__cunit_test_enum_invalid
+leak:__cunit_test_duration_invalid
+leak:__cunit_test_bytesize_invalid
+leak:__cunit_test_stringlist_invalid

--- a/cunit/parse.testc
+++ b/cunit/parse.testc
@@ -65,26 +65,30 @@ static void test_parsehex(void)
     CU_ASSERT_EQUAL(r, -1);
 }
 
-#define wrap_int_parser(func, type, s, outp, valp, inp) do          \
-{                                                                   \
-    struct protstream *prot;                                        \
-    char *b;                                                        \
-                                                                    \
-    int *outp__ = (outp);                                           \
-    type *valp__ = (valp);                                          \
-    int *inp__ = (inp);                                             \
-                                                                    \
-    b = xstrdup(s); /* work around bug in prot_ungetc */            \
-    prot = prot_readmap(b, strlen(b));                              \
-                                                                    \
-    *valp__ = (type) CANARY;                                        \
-    *outp__ = func(prot, valp__);                                   \
-    if (inp__) *inp__ = prot_bytes_in(prot);                        \
-                                                                    \
-    prot_free(prot);                                                \
-    free(b);                                                        \
+#define wrap_int_parser_nofree(prot, b, func, type, s, outp, valp, inp); do \
+{                                                                           \
+    int *outp__ = (outp);                                                   \
+    type *valp__ = (valp);                                                  \
+    int *inp__ = (inp);                                                     \
+                                                                            \
+    b = xstrdup(s); /* work around bug in prot_ungetc */                    \
+    prot = prot_readmap(b, strlen(b));                                      \
+                                                                            \
+    *valp__ = (type) CANARY;                                                \
+    *outp__ = func(prot, valp__);                                           \
+    if (inp__) *inp__ = prot_bytes_in(prot);                                \
 } while(0)
 
+#define wrap_int_parser(func, type, s, outp, valp, inp) do           \
+{                                                                    \
+    struct protstream *prot;                                         \
+    char *b;                                                         \
+                                                                     \
+    wrap_int_parser_nofree(prot, b, func, type, s, outp, valp, inp); \
+                                                                     \
+    prot_free(prot);                                                 \
+    free(b);                                                         \
+} while(0)
 
 static void test_getint32(void)
 {
@@ -117,9 +121,17 @@ static void test_getint32(void)
     CU_ASSERT_EQUAL(bytes_in, strlen(STR2));
 
     /* test a string with too many digits */
-    CU_EXPECT_CYRFATAL_BEGIN;
-        wrap_int_parser(getint32, int32_t, STR3, &c, &val, NULL);
-    CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+    {
+        struct protstream *prot = NULL;
+        char *b = NULL;
+
+        CU_EXPECT_CYRFATAL_BEGIN;
+            wrap_int_parser_nofree(prot, b, getint32, int32_t, STR3, &c, &val, NULL);
+        CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+
+        free(prot);
+        free(b);
+    }
 
     /* test a valid value with a different terminator */
     wrap_int_parser(getint32, int32_t, STR4, &c, &val, &bytes_in);
@@ -186,9 +198,17 @@ static void test_getsint32(void)
     CU_ASSERT_EQUAL(bytes_in, strlen(STR2));
 
     /* test a string with too many digits */
-    CU_EXPECT_CYRFATAL_BEGIN;
-        wrap_int_parser(getsint32, int32_t, STR3, &c, &val, NULL);
-    CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+    {
+        struct protstream *prot = NULL;
+        char *b = NULL;
+
+        CU_EXPECT_CYRFATAL_BEGIN;
+            wrap_int_parser_nofree(prot, b, getsint32, int32_t, STR3, &c, &val, NULL);
+        CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+
+        free(prot);
+        free(b);
+    }
 
     /* test a valid value with a different terminator */
     wrap_int_parser(getsint32, int32_t, STR4, &c, &val, &bytes_in);
@@ -253,9 +273,17 @@ static void test_getuint32(void)
     CU_ASSERT_EQUAL(bytes_in, strlen(STR2));
 
     /* test a string with too many digits */
-    CU_EXPECT_CYRFATAL_BEGIN;
-        wrap_int_parser(getuint32, uint32_t, STR3, &c, &val, NULL);
-    CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+    {
+        struct protstream *prot = NULL;
+        char *b = NULL;
+
+        CU_EXPECT_CYRFATAL_BEGIN;
+            wrap_int_parser_nofree(prot, b, getuint32, uint32_t, STR3, &c, &val, NULL);
+        CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+
+        free(prot);
+        free(b);
+    }
 
     /* test a valid value with a different terminator */
     wrap_int_parser(getuint32, uint32_t, STR4, &c, &val, &bytes_in);
@@ -320,9 +348,17 @@ static void test_getint64(void)
     CU_ASSERT_EQUAL(bytes_in, strlen(STR2));
 
     /* test a string with too many digits */
-    CU_EXPECT_CYRFATAL_BEGIN;
-        wrap_int_parser(getint64, int64_t, STR3, &c, &val, NULL);
-    CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+    {
+        struct protstream *prot = NULL;
+        char *b = NULL;
+
+        CU_EXPECT_CYRFATAL_BEGIN;
+            wrap_int_parser_nofree(prot, b, getint64, int64_t, STR3, &c, &val, NULL);
+        CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+
+        free(prot);
+        free(b);
+    }
 
     /* test a valid value with a different terminator */
     wrap_int_parser(getint64, int64_t, STR4, &c, &val, &bytes_in);
@@ -389,9 +425,17 @@ static void test_getsint64(void)
     CU_ASSERT_EQUAL(bytes_in, strlen(STR2));
 
     /* test a string with too many digits */
-    CU_EXPECT_CYRFATAL_BEGIN;
-        wrap_int_parser(getsint64, int64_t, STR3, &c, &val, NULL);
-    CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+    {
+        struct protstream *prot = NULL;
+        char *b = NULL;
+
+        CU_EXPECT_CYRFATAL_BEGIN;
+            wrap_int_parser_nofree(prot, b, getsint64, int64_t, STR3, &c, &val, NULL);
+        CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+
+        free(prot);
+        free(b);
+    }
 
     /* test a valid value with a different terminator */
     wrap_int_parser(getsint64, int64_t, STR4, &c, &val, &bytes_in);
@@ -456,9 +500,17 @@ static void test_getuint64(void)
     CU_ASSERT_EQUAL(bytes_in, strlen(STR2));
 
     /* test a string with too many digits */
-    CU_EXPECT_CYRFATAL_BEGIN;
-        wrap_int_parser(getuint64, uint64_t, STR3, &c, &val, NULL);
-    CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+    {
+        struct protstream *prot = NULL;
+        char *b = NULL;
+
+        CU_EXPECT_CYRFATAL_BEGIN;
+            wrap_int_parser_nofree(prot, b, getuint64, uint64_t, STR3, &c, &val, NULL);
+        CU_EXPECT_CYRFATAL_END(EX_PROTOCOL, "num too big");
+
+        free(prot);
+        free(b);
+    }
 
     /* test a valid value with a different terminator */
     wrap_int_parser(getuint64, uint64_t, STR4, &c, &val, &bytes_in);

--- a/cunit/vg.supp
+++ b/cunit/vg.supp
@@ -73,22 +73,6 @@
     ...
 }
 {
-    # The parse:getint tests each check for fatal parse errors, but when
-    # this occurs the protstream structure is leaked.
-    parse_getint_protstream_leak
-    Memcheck:Leak
-    match-leak-kinds: definite
-    fun:malloc
-    fun:xmalloc
-    fun:xzmalloc
-    fun:prot_readmap
-    fun:test_get*int*
-    ...
-    obj:*/libcunit*
-    ...
-}
-
-{
    # shush leaked SASL internal state in toy server process
    backend_child_process_sasl_state
    Memcheck:Leak

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -72,22 +72,6 @@ static search_expr_t **the_rootp;
 static search_expr_t *the_focus;
 #endif
 
-/* keep this in sync with enum search_op in search_expr.h */
-EXPORTED const char *search_op_name[] = {
-    "SEOP_UNKNOWN",
-    "SEOP_TRUE",
-    "SEOP_FALSE",
-    "SEOP_LT",
-    "SEOP_LE",
-    "SEOP_GT",
-    "SEOP_GE",
-    "SEOP_MATCH",
-    "SEOP_FUZZYMATCH",
-    "SEOP_AND",
-    "SEOP_OR",
-    "SEOP_NOT",
-};
-
 static void split(search_expr_t *e,
                   void (*cb)(const char *, search_expr_t *, search_expr_t *, void *),
                   void *rock);

--- a/imap/search_expr.h
+++ b/imap/search_expr.h
@@ -51,7 +51,6 @@
 struct protstream;
 struct index_state;
 
-/* keep this in sync with search_op_name in search_expr.c */
 enum search_op {
     SEOP_UNKNOWN,
     SEOP_TRUE,
@@ -71,7 +70,6 @@ enum search_op {
     SEOP_OR,
     SEOP_NOT,
 };
-extern const char *search_op_name[];
 
 union search_value {
     time_t t;

--- a/tools/build-with-cyruslibs.sh
+++ b/tools/build-with-cyruslibs.sh
@@ -8,8 +8,8 @@ set -e
 : ${CONFIGOPTS:="--enable-jmap --enable-http --enable-calalarmd --enable-unit-tests --enable-replication --enable-nntp --enable-murder --enable-idled --enable-xapian --enable-autocreate --enable-silent-rules --enable-debug-slowio"}
 export LDFLAGS="-L$LIBSDIR/lib/x86_64-linux-gnu -L$LIBSDIR/lib -Wl,-rpath,$LIBSDIR/lib/x86_64-linux-gnu -Wl,-rpath,$LIBSDIR/lib"
 export PKG_CONFIG_PATH="$LIBSDIR/lib/x86_64-linux-gnu/pkgconfig:$LIBSDIR/lib/pkgconfig:\$PKG_CONFIG_PATH"
-export CFLAGS="-g -fPIC -W -Wall -Wextra -Werror -Wwrite-strings"
-export CXXFLAGS="-g -fPIC -W -Wall -Wextra -Werror"
+export CFLAGS="$CYRUS_SAN_FLAGS -g -fPIC -W -Wall -Wextra -Werror -Wwrite-strings"
+export CXXFLAGS="$CYRUS_SAN_FLAGS -g -fPIC -W -Wall -Wextra -Werror"
 export PATH="$LIBSDIR/bin:$PATH"
 autoreconf -v -i
 echo "./configure --prefix=$TARGET $CONFIGOPTS XAPIAN_CONFIG=$LIBSDIR/bin/xapian-config-1.5"


### PR DESCRIPTION
This is mostly intended to be used in tandem with https://github.com/cyrusimap/cyrus-docker/pull/29/files but can stand on its own.

If you compile cyrus with `-fsanitize=address` and then run `LSAN_OPTIONS=suppressions=leaksanitizer.suppress make check` all tests pass minus those few skipped.

If you compile cyrus with `-fsanitize=undefined`, `make check` will pass but throw some warnings. To get it to fail, compile with `-fsanitize=undefined -fsanitize-undefined-trap-on-error` or use `halt_on_error=1 make check`.

When running cassandane with such a build, LSAN_OPTIONS and UBSAN_OPTIONS will be configured to send log files somewhere cassandane can see them, and cass will detect/report any detected log entries as failures (similar to how testrunner --valgrind works).

There's lots of work to go to get asan/ubsan tests passing, but this gets the infrastructure in place.

With this, we can add asan/ubsan builds to all CI if we want. Draft here: https://github.com/cyrusimap/cyrus-imapd/pull/5273

Note that ubsan will complain until a lot of things are fixed... we could start with just asan builds and work our way up to getting everything passing with both.