### PR TITLE
cyr_info: Don't misinterpret bitfields with flags >= 1<<31 or multipl…

### DIFF
--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -57,7 +57,7 @@ my %bitfields = (
     'httpmodules' => 'admin caldav carddav cgi domainkey freebusy ischedule jmap prometheus rss tzdist webdav',
     'metapartition_files' => 'header index cache expunge squat annotations lock dav archivecache',
     'newsaddheaders' => 'to replyto',
-    'sieve_extensions' => 'fileinto reject vacation vacation-seconds notify include envelope environment body relational regex subaddress copy date index imap4flags imapflags mailbox mboxmetadata servermetadata variables editheader extlists duplicate ihave fcc special-use redirect-dsn redirect-deliverby mailboxid vnd.cyrus.log x-cyrus-log vnd.cyrus.jmapquery x-cyrus-jmapquery vnd.cyrus.imip snooze vnd.cyrus.snooze x-cyrus-snooze vnd.cyrus.implicit_keep_target',
+    'sieve_extensions' => 'fileinto reject vacation vacation-seconds notify include envelope environment body relational regex subaddress copy date index imap4flags imapflags mailbox mboxmetadata servermetadata variables editheader extlists duplicate ihave fcc special-use redirect-dsn redirect-deliverby mailboxid vnd.cyrus.log x-cyrus-log vnd.cyrus.jmapquery x-cyrus-jmapquery processcalendar vnd.cyrus.imip snooze vnd.cyrus.snooze x-cyrus-snooze vnd.cyrus.implicit_keep_target',
 );
 my $bitfields_fixed = 0;
 

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -143,7 +143,10 @@ static void do_conf(int only_changed, int want_since, uint32_t since)
                     highlight(imapopts[i].last_modified);
                 printf("%s:", imapopts[i].optname);
                 for (j = 0; imapopts[i].enum_options[j].name; j++) {
-                    if (imapopts[i].val.x & (1<<j)) {
+                    /* multiple names? Use only the non-legacy (first) one */
+                    if (j && imapopts[i].enum_options[j].val == imapopts[i].enum_options[j-1].val)
+                        continue;
+                    if (imapopts[i].val.x & imapopts[i].enum_options[j].val) {
                         printf(" %s", imapopts[i].enum_options[j].name);
                     }
                 }
@@ -242,7 +245,10 @@ static void do_defconf(int want_since, uint32_t since)
             case OPT_BITFIELD:
                 printf("%s:", imapopts[i].optname);
                 for (j = 0; imapopts[i].enum_options[j].name; j++) {
-                    if (imapopts[i].def.x & (1<<j)) {
+                    /* multiple names? Use only the non-legacy (first) one */
+                    if (j && imapopts[i].enum_options[j].val == imapopts[i].enum_options[j-1].val)
+                        continue;
+                    if (imapopts[i].def.x & imapopts[i].enum_options[j].val) {
                         printf(" %s", imapopts[i].enum_options[j].name);
                     }
                 }


### PR DESCRIPTION
…e names

1<<31 or higher cannot be represented by an integer, so may wrap around or trigger other undefined behaviour. The end result of this was that:

    sieve_extensions: fileinto

reported as:

    sieve_extensions: fileinto vnd.cyrus.jmapquery

Also, some bitfields can have multiple names, and these take up actual slots in the enum_options array. These multi-named options would increment 'j' an extra time, meaning that this:

    sieve_extensions: snooze

would be reported as:

    sieve_extensions: x-cyrus-log

Rather than bit shifting from j, compare directly with the value of the particular flags.