### PR TITLE
Add ubsan `make check` build for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,38 @@ jobs:
         echo "debian" $(cat /etc/debian_version)
         /usr/cyrus/libexec/master -V
         /usr/cyrus/sbin/cyr_buildinfo
+  ubsan-make-check:
+    runs-on: ubuntu-latest
+    container:
+        image: ghcr.io/cyrusimap/cyrus-docker:bookworm
+        options: --init
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: setup git safe directory
+      shell: bash
+      run: git config --global --add safe.directory /__w/cyrus-imapd/cyrus-imapd
+    - name: fetch upstream release tags
+      if: ${{ github.repository != 'cyrusimap/cyrus-imapd' }}
+      shell: bash
+      run: |
+        git remote add upstream https://github.com/cyrusimap/cyrus-imapd.git
+        # n.b. --no-tags does not mean "no tags", it means "no automatic tag
+        # following".  we're explicitly fetching the tags we want, we do not
+        # need every other tag that's reachable from them
+        git fetch --no-tags upstream 'refs/tags/cyrus-imapd-*:refs/tags/cyrus-imapd-*'
+    - name: configure and build
+      shell: bash
+      run: |
+        echo "building cyrus version" $(./tools/git-version.sh)
+        UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 CYRUS_SAN_FLAGS="-fsanitize=undefined" ./tools/build-with-cyruslibs.sh
+    - name: report version information
+      shell: bash
+      run: |
+        echo "debian" $(cat /etc/debian_version)
+        /usr/cyrus/libexec/master -V
+        /usr/cyrus/sbin/cyr_buildinfo
   valgrind-make-check:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
This will run the cunit tests under ubsan to find quick problems in cunit tests.

Later we can get cassandane running an ubsan build as well, but that will take some work to get it clean.