### PR TITLE
jmap_ical.c: Don't use stack variable out of scope

### DIFF
--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -818,8 +818,8 @@ static void xjmapid_from_icalm(struct buf *dst, icalproperty *prop)
 {
     buf_reset(dst);
     const char *id = icalproperty_get_xparam_value(prop, JMAPICAL_XPARAM_ID);
+    char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
     if (!id) {
-        char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
         id = sha1hexstr(icalproperty_as_ical_string(prop), keybuf);
     }
     if (id) buf_setcstr(dst, id);


### PR DESCRIPTION
sha1hexstr() returns a pointer to the keybuf arg, so if we want to use id in a higher scope, keybuf must also exist in a higher scope.