### PR TITLE
small mboxgroups doc fixes

### DIFF
--- a/docsrc/imap/concepts/overview_and_concepts.rst
+++ b/docsrc/imap/concepts/overview_and_concepts.rst
@@ -150,6 +150,7 @@ Rights are combined through concatenation.  Please see
 
 .. include:: /imap/reference/admin/access-control/identifiers.rst
     :start-after: _imap-admin-access-control-identifiers:
+    :end-before: _imap-admin-access-control-authorization-mechanisms:
 
 Negative Rights
 ===============

--- a/docsrc/imap/reference/admin/access-control/identifiers.rst
+++ b/docsrc/imap/reference/admin/access-control/identifiers.rst
@@ -82,6 +82,8 @@ a non-/etc/passwd backend. Note that using unix groups in this way
     NSS augmentations, such as ``nss_ldap``, ``pam_ldap`` or ``sssd``
     may be used to provide Cyrus access to group information via NSS.
 
+.. _auth_mech_mboxgroups:
+
 mboxgroups Authorization
 ------------------------
 

--- a/docsrc/imap/reference/admin/access-control/identifiers.rst
+++ b/docsrc/imap/reference/admin/access-control/identifiers.rst
@@ -1,6 +1,5 @@
 .. _imap-admin-access-control-identifiers:
 
-
 Access Control Identifier (ACI)
 ===============================
 
@@ -14,7 +13,9 @@ distinguished by the prefix "group:".  For example, "group:accounting".
           virtdomains, tips and tricks etc.
 
 There are two special identifiers, "anonymous", and "anyone".  The meaning of
-other identifiers usually depends on the authorization mechanism being used.
+other identifiers usually depends on the
+:ref:`authorization mechanism<imap-admin-access-control-authorization-mechanisms>`
+being used.
 
 ``anonymous`` and ``anyone``
 ----------------------------
@@ -27,6 +28,7 @@ anonymous user.
 Both ``anonymous`` and ``anyone`` may commonly be used with the **post**
 right ``p`` to allow message insertion to mailboxes.
 
+.. _imap-admin-access-control-authorization-mechanisms:
 
 Authorization Mechanisms
 ========================


### PR DESCRIPTION
Follows on from #5271 

* Adds a link target to the new `auth_mech: mboxgroups` documentation, so that the 3.12 release notes will be able to link to it
* Makes the "overview and concepts" page not embed the entire "access control identifiers" page, just the first section of it.  This fixes a duplicate link target error that came up once the link target above was added