### PR TITLE
jmap_mail.c: rewrite CR & LF to CRLF in message/rfc822 attachments

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_encoding
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_encoding
@@ -354,7 +354,17 @@ sub test_email_set_create_encoding
         bodyStructure => {
             type => 'message/rfc822',
         },
-        wantInvalidProperties => ['bodyStructure/type'],
+        wantEncoding => '7bit',
+        wantContentType => 'message/rfc822',
+        wantBlob =>
+            "From: from\@local\r\n" .
+            "To: to\@local\r\n" .
+            "Subject: Test subject\r\n" .
+            "Date: Wed, 27 Apr 2019 13:21:50 -0500\r\n" .
+            "MIME-Version: 1.0\r\n" .
+            "Content-Type: text/html\r\n" .
+            "\r\n" .
+            "a LF\r\n char",
     }, {
         desc => 'message/rfc822 with bare CR',
         blob =>
@@ -369,7 +379,17 @@ sub test_email_set_create_encoding
         bodyStructure => {
             type => 'message/rfc822',
         },
-        wantInvalidProperties => ['bodyStructure/type'],
+        wantEncoding => '7bit',
+        wantContentType => 'message/rfc822',
+        wantBlob =>
+            "From: from\@local\r\n" .
+            "To: to\@local\r\n" .
+            "Subject: Test subject\r\n" .
+            "Date: Wed, 27 Apr 2019 13:21:50 -0500\r\n" .
+            "MIME-Version: 1.0\r\n" .
+            "Content-Type: text/html\r\n" .
+            "\r\n" .
+            "a CR\r\n char",
     }, {
         desc => 'message/rfc822 with long MIME line',
         blob =>


### PR DESCRIPTION
Before, Email/set{create} rejected body parts of type "message/rfc822" if the body value contained a CR or LF octet that is not part of a CRLF sequence. Now, bare CR or LF get rewritten to CRLF when converting the Email object to MIME.

This already is the case for "text/plain" attachments. Typically, CRLF sequences in attachments of these content types got inadvertently rewritten to bare LF during download or in text editors.