### PR TITLE
Twom fixes

### DIFF
--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1811,7 +1811,7 @@ static int read_lock(struct twom_db *db, struct twom_txn **txnp,
         r = unlock(db, file);
         if (r) goto done;
 
-        int newfd = open(db->fname, db->readonly ? O_RDONLY : O_RDWR, 0644);
+        int newfd = open(db->fname, O_RDWR, 0644);
         if (newfd == -1) {
             db->error("read_lock open failed",
                       "filename=<%s>", db->fname);
@@ -1830,9 +1830,8 @@ static int read_lock(struct twom_db *db, struct twom_txn **txnp,
         /* map the new space (note: we map READ|WRITE even for readonly locks,
          * if we might lock for write later and want to reuse the mmap */
         if (file->size) munmap(file->base, file->size);
-        int flags = db->readonly ? PROT_READ : PROT_READ|PROT_WRITE;
         file->size = sbuf.st_size;
-        file->base = (char *)mmap((caddr_t)0, file->size, flags, MAP_SHARED, file->fd, 0L);
+        file->base = (char *)mmap((caddr_t)0, file->size, PROT_READ|PROT_WRITE, MAP_SHARED, file->fd, 0L);
         if (!file->base) {
             db->error("read_lock mmap failed",
                       "filename=<%s> size=<%08llX>", db->fname, (LLU)file->size);
@@ -1932,7 +1931,7 @@ static int opendb(const char *fname, struct twom_open_data *setup, struct twom_d
     db->external_csum = setup->csum;
     db->external_compar = setup->compar;
 
-    int fflags = db->readonly ? O_RDONLY : (create ? O_RDWR|O_CREAT : O_RDWR);
+    int fflags = (create && !db->readonly) ? O_RDWR|O_CREAT : O_RDWR;
     int fd = open(db->fname, fflags, 0644);
     if (fd < 0) {
         r = (errno == ENOENT) ? TWOM_NOTFOUND : TWOM_IOERROR;

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1851,16 +1851,14 @@ static int read_lock(struct twom_db *db, struct twom_txn **txnp,
     /* we can't read an unclean database */
     if (!db_is_clean(db, file)) {
  badfile:
-        /* we have to be able to re-lock safely */
-        if (db->readonly) {
-            r = TWOM_IOERROR;
-            goto done;
-        }
         /* if we take a write lock, that will repair it */
         unlock(db, file);
         // no txn, release the write_lock after repairing if needed
+        int was_readonly = db->readonly;
+        db->readonly = 0;
         r = write_lock(db, NULL, file, flags);
         if (r) return r;
+        db->readonly = was_readonly;
         /* if we want a transaction, we'll need to re-lock with the readlock */
         if (txnp) {
             goto restart;

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -2962,7 +2962,16 @@ static int twom_txn_dump(struct twom_txn *txn, int detail)
             printf("COMMIT start=%08llX\n", (LLU)NEXT0(ptr, 0));
         }
         else if (type == DELETE) {
-            printf("DELETE ancestor=%08llX\n", (LLU)NEXT0(ptr, 0));
+            size_t parent_offset = NEXT0(ptr, 0);
+            const char *key = KEYPTR(loc->file->base + parent_offset);
+            int len = KEYLEN(loc->file->base + parent_offset);
+            if (len > 79) len = 79;
+            if (key) strncpy(scratch, key, len);
+            scratch[len] = 0;
+            for (i = 0; i < len; i++)
+                if (!scratch[i]) scratch[i] = '-';
+            printf("DELETE kl=%llu (%s)\n", (LLU)KEYLEN(loc->file->base + parent_offset), scratch);
+            printf("\t%08llX <-\n", (LLU)parent_offset);
         }
         else {
             const char *key = KEYPTR(ptr);

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -670,17 +670,11 @@ static int read_header(struct twom_db *db, struct tm_file *file, struct tm_heade
 }
 
 /* given an open, mapped, locked db, write the header information */
-static inline int write_header(struct twom_db *db, struct tm_header *header)
+static void pack_header(struct tm_header *header, struct tm_file *file, char *base)
 {
-    int r = tm_ensure(db, HEADER_SIZE);
-    if (r) return r;
-
-    struct tm_file *file = db->openfile;
-
-    char *base = file->base;
     memcpy(base, HEADER_MAGIC, HEADER_MAGIC_SIZE);
     memcpy(base + OFFSET_UUID, header->uuid, 16);
-    *((uint16_t *)(base + OFFSET_VERSION)) = htole32(header->version);
+    *((uint32_t *)(base + OFFSET_VERSION)) = htole32(header->version);
     *((uint32_t *)(base + OFFSET_FLAGS)) = htole32(header->flags);
     *((uint64_t *)(base + OFFSET_GENERATION)) = htole64(header->generation);
     *((uint64_t *)(base + OFFSET_NUM_RECORDS)) = htole64(header->num_records);
@@ -690,17 +684,14 @@ static inline int write_header(struct twom_db *db, struct tm_header *header)
     *((uint64_t *)(base + OFFSET_CURRENT_SIZE)) = htole64(header->current_size);
     *((uint32_t *)(base + OFFSET_MAXLEVEL)) = htole32(header->maxlevel);
     *((uint32_t *)(base + OFFSET_CSUM)) = htole32(file->csum(base, OFFSET_CSUM));
-
-    file->dirty = 1;
-
-    return 0;
 }
 
 /* simple wrapper to write with an fsync */
-static inline int commit_header(struct twom_db *db, struct tm_header *header)
+static int commit_header(struct twom_db *db, struct tm_header *header)
 {
-    int r = write_header(db, header);
-    if (r) return r;
+    struct tm_file *file = db->openfile;
+    pack_header(header, file, file->base);
+    file->dirty = 1;
     return tm_commit(db, HEADER_SIZE);
 }
 
@@ -1651,40 +1642,59 @@ static int write_lock(struct twom_db *db, struct twom_txn **txnp,
 
     // opening a new file, create the header
     if (!sbuf.st_size) {
+        char scratch[512]; // this is big enough, header plus dummy fits in 512
         struct tm_header header;
-        size_t headlen = HLCALC(DUMMY, MAXLEVEL);
-        size_t reclen = headlen + /*crcs*/8;
-        uint32_t csum_flags = set_csum_engine(db, file, flags);
+        size_t filesize = HEADER_SIZE + DUMMY_SIZE;
 
-        // make sure there's space in the file
-        r = tm_ensure(db, HEADER_SIZE + reclen);
-        if (r) goto done;
-
-        // write a blank dummy record
-        char *base = file->base + HEADER_SIZE;
-        memset(base, 0, reclen);
-        *((uint8_t *)(base)) = DUMMY;
-        *((uint8_t *)(base+1)) = MAXLEVEL;
-        *((uint32_t *)(base+headlen)) = htole32(file->csum(base, headlen));
+        // zero out our workspace
+        memset(scratch, 0, 512);
 
         // prepare the header
         uuid_generate(header.uuid);
         header.version = TWOM_VERSION;
         // XXX: other persistent flags?
-        header.flags = csum_flags;
+        header.flags = set_csum_engine(db, file, flags);
         header.generation = 1;
         header.num_records = 0;
         header.num_commits = 0;
         header.dirty_size = 0;
-        header.repack_size = HEADER_SIZE + reclen;
-        header.current_size = HEADER_SIZE + reclen;
+        header.repack_size = filesize;
+        header.current_size = filesize;
         header.maxlevel = 0;
+        pack_header(&header, file, scratch);
 
-        r = commit_header(db, &header);
-        if (r) goto done;
+        // write a blank dummy record
+        size_t headlen = HLCALC(DUMMY, MAXLEVEL);
+        char *base = scratch + DUMMY_OFFSET;
+        *((uint8_t *)(base)) = DUMMY;
+        *((uint8_t *)(base+1)) = MAXLEVEL;
+        *((uint32_t *)(base+headlen)) = htole32(file->csum(base, headlen));
+
+        // ensure that the data is written to the file!
+        size_t written;
+        for (written = 0; written < filesize; ) {
+            ssize_t n = write(file->fd, scratch + written, filesize - written);
+            if (n == -1) {
+                if (errno == EINTR) continue;
+                db->error("db creation failed",
+                          "filename=<%s>", db->fname);
+                if (ftruncate(file->fd, 0))
+                    db->error("truncate in create abort failed",
+                              "filename=<%s>", db->fname);
+                if (unlink(db->fname))
+                    db->error("unlink in create abort failed",
+                              "filename=<%s>", db->fname);
+                r = TWOM_IOERROR;
+                goto done;
+            }
+            written += n;
+        }
+
+        sbuf.st_size = written; // set new size so we'll mmap below
     }
-    // tm_ensure above creates an openmap, so we don't need to check again
-    else if (file->size < (size_t)sbuf.st_size) {
+
+    // if we haven't mapped enough space, do it now
+    if (file->size < (size_t)sbuf.st_size) {
         if (file->size) munmap(file->base, file->size);
         file->size = sbuf.st_size;
         file->base = (char *)mmap((caddr_t)0, file->size, PROT_READ|PROT_WRITE, MAP_SHARED, file->fd, 0L);

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -2912,7 +2912,7 @@ static int twom_txn_dump(struct twom_txn *txn, int detail)
     char scratch[80];
     const char *ptr;
     size_t offset = DUMMY_OFFSET;
-    int i;
+    size_t i;
 
     struct tm_header *header = &txn->file->header;
     struct twom_db *db = txn->db;
@@ -2964,7 +2964,7 @@ static int twom_txn_dump(struct twom_txn *txn, int detail)
         else if (type == DELETE) {
             size_t parent_offset = NEXT0(ptr, 0);
             const char *key = KEYPTR(loc->file->base + parent_offset);
-            int len = KEYLEN(loc->file->base + parent_offset);
+            size_t len = KEYLEN(loc->file->base + parent_offset);
             if (len > 79) len = 79;
             if (key) strncpy(scratch, key, len);
             scratch[len] = 0;
@@ -2975,7 +2975,7 @@ static int twom_txn_dump(struct twom_txn *txn, int detail)
         }
         else {
             const char *key = KEYPTR(ptr);
-            int len = KEYLEN(ptr);
+            size_t len = KEYLEN(ptr);
             if (len > 79) len = 79;
             if (key) strncpy(scratch, key, len);
             scratch[len] = 0;
@@ -2998,7 +2998,7 @@ static int twom_txn_dump(struct twom_txn *txn, int detail)
             printf("\n");
             if (detail > 2) {
                 const char *val = VALPTR(ptr);
-                int len = VALLEN(ptr);
+                size_t len = VALLEN(ptr);
                 if (len > 79) len = 79;
                 if (val) strncpy(scratch, val, len);
                 scratch[len] = 0;


### PR DESCRIPTION
This fixes some issues found with twom in production:
* full disk can cause the mmap to create 16k of blanks then fail to write the headers!  Use write instead for initial header and dummy
* readonly database can read a dirty file after a crash, meaning that it returns errors, always open RDWR and mmap readwrite.

Plus just makes the dump format a bit more regular.