### PR TITLE
index.c: use "utf-8" as default charset for vCard data

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_vcard_with_utf8_default
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_vcard_with_utf8_default
@@ -1,0 +1,61 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_vcard_with_utf8_default
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    # Asserts that a text/vcard MIME body part gets indexed
+    # as UTF-8 text, even if the Content-Type header of the
+    # body part does not have an according charset parameter.
+    my $mime = <<'EOF';
+From: alice@local
+To: bob@local
+Subject: test
+Message-ID: <1390d09d-60f7-4840-88a2-9f319024b156@local>
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary=ffd749e987fd42b3991e74bf3424e347
+
+--ffd749e987fd42b3991e74bf3424e347
+Content-Type: text/plain
+
+hello
+--ffd749e987fd42b3991e74bf3424e347
+Content-Type: text/vcard
+
+BEGIN:VCARD
+VERSION:3.0
+FN:adoxography
+END:VCARD
+
+--ffd749e987fd42b3991e74bf3424e347
+Content-Type: text/vcard
+Content-Transfer-Encoding: base64
+
+QkVHSU46VkNBUkQNClZFUlNJT046My4wDQpGTjpSw7ZocmljaA0KRU5EOlZDQVJEDQo=
+--ffd749e987fd42b3991e74bf3424e347--
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $mime);
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+use utf8;
+    my $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                body => "adoxography",
+            },
+        }, 'R1'],
+        ['Email/query', {
+            filter => {
+                body => "Röhrich",
+            },
+        }, 'R2'],
+    ]);
+no utf8;
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
+    $self->assert_num_equals(1, scalar @{$res->[1][1]{ids}});
+}

--- a/imap/index.c
+++ b/imap/index.c
@@ -5493,6 +5493,12 @@ static int extract_vcardbuf(struct buf *raw, charset_t charset, int encoding,
     vcardproperty *prop;
     int r = 0;
     struct buf buf = BUF_INITIALIZER;
+    charset_t mycharset = CHARSET_UNKNOWN_CHARSET;
+
+    if (!charset || !strcasecmp(charset_canon_name(charset), "us-ascii")) {
+        mycharset = charset_lookupname("utf-8");
+        charset = mycharset;
+    }
 
     /* Parse the message into a vcard object */
     const struct buf *vcardbuf = NULL;
@@ -5595,6 +5601,7 @@ static int extract_vcardbuf(struct buf *raw, charset_t charset, int encoding,
 
 done:
     if (vcard) vcardcomponent_free(vcard);
+    charset_free(&mycharset);
     buf_free(&buf);
     return r;
 }


### PR DESCRIPTION
A MIME body part having Content-Type: text/vcard without the charset parameter would otherwise be decoded as US-ASCII, leading to any non-ASCII UTF-8 octets being replaced with the UTF-8 replacement character.