### PR TITLE
jmap_contact.c: properly handle VALUE=X param on text-valued properties

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_get_prodid
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_prodid
@@ -1,0 +1,53 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_get_prodid
+    :needs_dependency_icalvcard
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my $service = $self->{instance}->get_service("http");
+
+    $ENV{DEBUGDAV} = 1;
+
+    my $carddav = Net::CardDAVTalk->new(
+        user => 'cassandane',
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    my $prodid = '-//CyrusIMAP.org//Cyrus 3.13.0-alpha0-298-g236a396a8b//EN';
+
+    my $card = << "EOF";
+BEGIN:VCARD
+PRODID;VALUE=X:$prodid
+VERSION:3.0
+UID:6928260E-EDF6-11EF-9AB7-AEA159270051
+N:;Some;One;;
+FN:Some One
+ORG:Some Org;
+TITLE:
+EMAIL;TYPE=HOME,PREF:email\@example.com
+NICKNAME:
+NOTE:
+REV:20210915T054744Z
+END:VCARD
+EOF
+
+    $card =~ s/\r?\n/\r\n/gs;
+    $carddav->Request(
+        'PUT', "Default/test.vcf", $card, 'Content-Type' => 'text/vcard'
+    );
+
+    my $res = $jmap->CallMethods([
+        ['ContactCard/get', {
+        }, 'R1']
+    ]);
+
+    $self->assert_str_equals($prodid, $res->[0][1]{list}[0]{prodId});
+}


### PR DESCRIPTION
vcardproperty_get_prodid() will return NULL if the property contains VALUE=X because the value type isn't TEXT and is stored in a different field of struct vcardvalue.

This patch treats VALUE=X as a text string