### PR TITLE
Copy to self refcount

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -3022,9 +3022,6 @@ EXPORTED int mailbox_abort(struct mailbox *mailbox)
 {
     int r;
 
-    // we can't abort with additional references, just have to die
-    assert(mailbox->refcount == 1);
-
 #ifdef WITH_DAV
     r = mailbox_abort_dav(mailbox);
     if (r) return r;


### PR DESCRIPTION
This fixes a crasher we have with a user who's copying from their Archive folder to the Archive folder over and over in FM production.