### PR TITLE
feedback-bugs.rst: Add link to security mailing list

### DIFF
--- a/docsrc/imap/support/feedback-bugs.rst
+++ b/docsrc/imap/support/feedback-bugs.rst
@@ -3,6 +3,10 @@
 Reporting Bugs
 ==============
 
+.. note::
+
+    For **Security Issues** please send your reports to our private `security list <security@cyrus.topicbox.com>`
+
 Bug reports can be sent to us through our :ref:`mailing list <feedback-mailing-lists>` or logged in our `GitHub issue tracker <https://github.com/cyrusimap/cyrus-imapd/issues/>`__. (Registration is required)
 When reporting a bug, please provide the following information;
 


### PR DESCRIPTION
Security reports should go to our private mailing list because of their sensitive nature.