### PR TITLE
Cassandane: use config for all DB types

### DIFF
--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -119,6 +119,26 @@ sub default
             debug => 'yes',
             httpprettytelemetry => 'yes',
 
+            # from cyr_info conf-default | grep _db:
+            annotation_db => 'twoskip',
+            backup_db => 'twoskip',
+            conversations_db => 'skiplist',
+            duplicate_db => 'twoskip',
+            mboxkey_db => 'twoskip',
+            mboxlist_db => 'twoskip',
+            ptscache_db => 'twoskip',
+            quota_db => 'quotalegacy',
+            search_indexed_db => 'twoskip',
+            seenstate_db => 'twoskip',
+            sortcache_db => 'twoskip',
+            subscription_db => 'flat',
+            statuscache_db => 'twoskip',
+            sync_cache_db => 'twoskip',
+            tlscache_db => 'twoskip',
+            tls_sessions_db => 'twoskip',
+            userdeny_db => 'flat',
+            zoneinfo_db => 'twoskip',
+
             # smtpclient_open should fail by default!
             #
             # If your test fails and writes something like

--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -370,7 +370,8 @@ sub test_upgrade
 
     # nuke the version key
     my $dirs = $self->{instance}->run_mbpath(-u => 'cassandane');
-    $self->{instance}->run_dbcommand($dirs->{user}{conversations}, 'twoskip', ['DELETE', '$VERSION']);
+    my $format = $self->{instance}->{config}->get('conversations_db');
+    $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format, ['DELETE', '$VERSION']);
 
     xlog $self, "Upgrade with deleted VERSION should recalc";
     $outfile = "$basedir/conv-output2.txt";
@@ -1190,8 +1191,9 @@ sub test_rename_between_users
     my $res = $talk->status('INBOX.foo', ['mailboxid']);
     my $fooid = $res->{'mailboxid'}->[0];
 
-    my %data = $self->{instance}->run_dbcommand($dirs->{user}{conversations}, 'twoskip', ['SHOW']);
-    my %mdata = $self->{instance}->run_dbcommand($mdirs->{user}{conversations}, 'twoskip', ['SHOW']);
+    my $format = $self->{instance}->{config}->get('conversations_db');
+    my %data = $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format, ['SHOW']);
+    my %mdata = $self->{instance}->run_dbcommand($mdirs->{user}{conversations}, $format, ['SHOW']);
 
     my $folders = Cyrus::DList->parse_string($data{'$FOLDER_IDS'})->as_perl;
     my $mfolders = Cyrus::DList->parse_string($mdata{'$FOLDER_IDS'})->as_perl;
@@ -1207,8 +1209,8 @@ sub test_rename_between_users
     $self->{store}->set_folder("user.manifold.extra");
     $self->make_message("Extra Msg");
 
-    %data = $self->{instance}->run_dbcommand($dirs->{user}{conversations}, 'twoskip', ['SHOW']);
-    %mdata = $self->{instance}->run_dbcommand($mdirs->{user}{conversations}, 'twoskip', ['SHOW']);
+    %data = $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format, ['SHOW']);
+    %mdata = $self->{instance}->run_dbcommand($mdirs->{user}{conversations}, $format, ['SHOW']);
 
     $folders = Cyrus::DList->parse_string($data{'$FOLDER_IDS'})->as_perl;
     $mfolders = Cyrus::DList->parse_string($mdata{'$FOLDER_IDS'})->as_perl;
@@ -1226,8 +1228,8 @@ sub test_rename_between_users
 
     $talk->rename("user.manifold.foo", "INBOX.foo");
 
-    %data = $self->{instance}->run_dbcommand($dirs->{user}{conversations}, 'twoskip', ['SHOW']);
-    %mdata = $self->{instance}->run_dbcommand($mdirs->{user}{conversations}, 'twoskip', ['SHOW']);
+    %data = $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format, ['SHOW']);
+    %mdata = $self->{instance}->run_dbcommand($mdirs->{user}{conversations}, $format, ['SHOW']);
     $folders = Cyrus::DList->parse_string($data{'$FOLDER_IDS'})->as_perl;
     $mfolders = Cyrus::DList->parse_string($mdata{'$FOLDER_IDS'})->as_perl;
     $self->assert_num_equals(4, scalar @$folders);

--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -147,10 +147,11 @@ sub test_recover_uniqueid_from_header_legacymb
     # lose that uniqueid from mailboxes.db
     my $I = "I$uniqueid";
     my $N = "Nuser\x1fcassandane";
-    $self->{instance}->run_dbcommand($mailboxes_db, "twoskip",
+    my $format = $self->{instance}->{config}->get('mboxlist_db');
+    $self->{instance}->run_dbcommand($mailboxes_db, $format,
                                      [ 'DELETE', $I ]);
     my (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     my $dlist = Cyrus::DList->parse_string($mbentry);
     my $hash = $dlist->as_perl();
@@ -158,11 +159,11 @@ sub test_recover_uniqueid_from_header_legacymb
     $hash->{I} = undef;
     $dlist = Cyrus::DList->new_perl('', $hash);
     $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         [ 'SET', $N, $dlist->as_string() ]);
 
     my %updated = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip", ['SHOW']);
+        $mailboxes_db, $format, ['SHOW']);
     xlog "updated mailboxes.db: " . Dumper \%updated;
 
     # bring service back up
@@ -190,7 +191,7 @@ sub test_recover_uniqueid_from_header_legacymb
 
     # mbentry should have the same uniqueid as before
     (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     $dlist = Cyrus::DList->parse_string($mbentry);
     $hash = $dlist->as_perl();
@@ -198,7 +199,7 @@ sub test_recover_uniqueid_from_header_legacymb
 
     # $I entry should be back
     my ($key, $value) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $I]);
     $self->assert_str_equals($I, $key);
     $dlist = Cyrus::DList->parse_string($value);
@@ -235,10 +236,11 @@ sub test_recover_create_missing_uniqueid_legacymb
     # lose that uniqueid from mailboxes.db
     my $I = "I$uniqueid";
     my $N = "Nuser\x1fcassandane";
-    $self->{instance}->run_dbcommand($mailboxes_db, "twoskip",
+    my $format = $self->{instance}->{config}->get('mboxlist_db');
+    $self->{instance}->run_dbcommand($mailboxes_db, $format,
                                      [ 'DELETE', $I ]);
     my (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     my $dlist = Cyrus::DList->parse_string($mbentry);
     my $hash = $dlist->as_perl();
@@ -246,11 +248,11 @@ sub test_recover_create_missing_uniqueid_legacymb
     $hash->{I} = undef;
     $dlist = Cyrus::DList->new_perl('', $hash);
     $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         [ 'SET', $N, $dlist->as_string() ]);
 
     my %updated = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip", ['SHOW']);
+        $mailboxes_db, $format, ['SHOW']);
     xlog "updated mailboxes.db: " . Dumper \%updated;
 
     # lose it from cyrus.header too
@@ -298,7 +300,7 @@ sub test_recover_create_missing_uniqueid_legacymb
 
     # mbentry should have the new uniqueid
     (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     $dlist = Cyrus::DList->parse_string($mbentry);
     $hash = $dlist->as_perl();
@@ -307,7 +309,7 @@ sub test_recover_create_missing_uniqueid_legacymb
     # new runq entry should exist
     my $newI = "I$newuniqueid";
     my ($key, $value) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $newI]);
     $self->assert_str_equals($newI, $key);
     $dlist = Cyrus::DList->parse_string($value);

--- a/cassandane/Cassandane/Cyrus/HTTPPTS.pm
+++ b/cassandane/Cassandane/Cyrus/HTTPPTS.pm
@@ -263,11 +263,12 @@ sub test_list_groupaccess_racl
     $self->assert_num_not_equals($precounters->{raclmodseq}, $postcounters->{raclmodseq}, "RACL modseq changed");
 
     if (get_verbose()) {
+        my $format = $self->{instance}->{config}->get('mboxlist_db');
         $self->{instance}->run_command(
             { cyrus => 1, },
             'cyr_dbtool',
             "$self->{instance}->{basedir}/conf/mailboxes.db",
-            'twoskip',
+            $format,
             'show'
         );
     }
@@ -327,11 +328,12 @@ sub do_test_list_order
     }
 
     if (get_verbose()) {
+        my $format = $self->{instance}->{config}->get('mboxlist_db');
         $self->{instance}->run_command(
             { cyrus => 1, },
             'cyr_dbtool',
             "$self->{instance}->{basedir}/conf/mailboxes.db",
-            'twoskip',
+            $format,
             'show'
         );
     }

--- a/cassandane/Cassandane/Cyrus/Info.pm
+++ b/cassandane/Cassandane/Cyrus/Info.pm
@@ -102,6 +102,10 @@ sub test_conf
         }
     }
 
+    # remove _db: values which are same as default, but coded in
+    # so that we'll have them in the config
+    delete $imapd_conf{$_} for grep { not $cyr_info_conf{$_} } grep { m/_db$/ } keys %imapd_conf;
+
     $self->assert_deep_equals(\%imapd_conf, \%cyr_info_conf);
 }
 
@@ -178,6 +182,7 @@ sub test_lint
     xlog $self, "test 'cyr_info conf-lint' in the simplest case";
 
     my @output = $self->{instance}->run_cyr_info('conf-lint');
+    @output = grep { !m/_db: / } @output;  # skip database types
     $self->assert_deep_equals([], \@output);
 }
 
@@ -193,6 +198,7 @@ sub test_lint_junk
     xlog $self, "test 'cyr_info conf-lint' with junk in the config";
 
     my @output = $self->{instance}->run_cyr_info('conf-lint');
+    @output = grep { !m/_db: / } @output;  # skip database types
     $self->assert_deep_equals(["trust_fund: street art\n"], \@output);
 }
 
@@ -213,6 +219,7 @@ sub test_lint_channels
     xlog $self, "test 'cyr_info conf-lint' with channel-specific sync config";
 
     my @output = $self->{instance}->run_cyr_info('conf-lint');
+    @output = grep { !m/_db: / } @output;  # skip database types
 
     $self->assert_deep_equals(
         [ sort(
@@ -249,6 +256,7 @@ sub test_lint_partitions
     xlog $self, "test 'cyr_info conf-lint' with partitions configured";
 
     my @output = $self->{instance}->run_cyr_info('conf-lint');
+    @output = grep { !m/_db: / } @output;  # skip database types
 
     $self->assert_deep_equals(
         [ sort(

--- a/cassandane/Cassandane/Cyrus/LDAP.pm
+++ b/cassandane/Cassandane/Cyrus/LDAP.pm
@@ -240,11 +240,12 @@ sub test_list_groupaccess_racl
     $self->assert_num_not_equals($precounters->{raclmodseq}, $postcounters->{raclmodseq}, "RACL modseq changed");
 
     if (get_verbose()) {
+        my $format = $self->{instance}->{config}->get('mboxlist_db');
         $self->{instance}->run_command(
             { cyrus => 1, },
             'cyr_dbtool',
             "$self->{instance}->{basedir}/conf/mailboxes.db",
-            'twoskip',
+            $format,
             'show'
         );
     }
@@ -303,11 +304,12 @@ sub do_test_list_order
     }
 
     if (get_verbose()) {
+        my $format = $self->{instance}->{config}->get('mboxlist_db');
         $self->{instance}->run_command(
             { cyrus => 1, },
             'cyr_dbtool',
             "$self->{instance}->{basedir}/conf/mailboxes.db",
-            'twoskip',
+            $format,
             'show'
         );
     }

--- a/cassandane/Cassandane/Cyrus/Mboxgroups.pm
+++ b/cassandane/Cassandane/Cyrus/Mboxgroups.pm
@@ -208,11 +208,12 @@ sub test_list_groupaccess_racl
         $admintalk->get_last_completion_response());
 
     if (get_verbose()) {
+        my $format = $self->{instance}->{config}->get('mboxlist_db');
         $self->{instance}->run_command(
             { cyrus => 1, },
             'cyr_dbtool',
             "$self->{instance}->{basedir}/conf/mailboxes.db",
-            'twoskip',
+            $format,
             'show'
         );
     }
@@ -271,11 +272,12 @@ sub do_test_list_order
     }
 
     if (get_verbose()) {
+        my $format = $self->{instance}->{config}->get('mboxlist_db');
         $self->{instance}->run_command(
             { cyrus => 1, },
             'cyr_dbtool',
             "$self->{instance}->{basedir}/conf/mailboxes.db",
-            'twoskip',
+            $format,
             'show'
         );
     }

--- a/cassandane/Cassandane/Cyrus/Metadata.pm
+++ b/cassandane/Cassandane/Cyrus/Metadata.pm
@@ -140,7 +140,6 @@ sub list_annotations
     }
 
     my $format = $instance->{config}->get('annotation_db');
-    $format = $format // 'twoskip';
 
     my @annots;
 

--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -417,10 +417,11 @@ sub test_reconstruct_uniqueid_from_header_path_uuidmb
     # lose that uniqueid from mailboxes.db
     my $I = "I$uniqueid";
     my $N = "Nuser\x1fcassandane";
-    $self->{instance}->run_dbcommand($mailboxes_db, "twoskip",
+    my $format = $self->{instance}->{config}->get('mboxlist_db');
+    $self->{instance}->run_dbcommand($mailboxes_db, $format,
                                      [ 'DELETE', $I ]);
     my (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     my $dlist = Cyrus::DList->parse_string($mbentry);
     my $hash = $dlist->as_perl();
@@ -428,11 +429,11 @@ sub test_reconstruct_uniqueid_from_header_path_uuidmb
     $hash->{I} = undef;
     $dlist = Cyrus::DList->new_perl('', $hash);
     $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         [ 'SET', $N, $dlist->as_string() ]);
 
     my %updated = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip", ['SHOW']);
+        $mailboxes_db, $format, ['SHOW']);
     xlog "updated mailboxes.db: " . Dumper \%updated;
 
     # lose it from cyrus.header too
@@ -468,7 +469,7 @@ sub test_reconstruct_uniqueid_from_header_path_uuidmb
 
     # mbentry should have the same uniqueid as before
     (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     $dlist = Cyrus::DList->parse_string($mbentry);
     $hash = $dlist->as_perl();
@@ -476,7 +477,7 @@ sub test_reconstruct_uniqueid_from_header_path_uuidmb
 
     # $I entry should be back
     my ($key, $value) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $I]);
     $self->assert_str_equals($I, $key);
     $dlist = Cyrus::DList->parse_string($value);
@@ -518,10 +519,11 @@ sub test_reconstruct_uniqueid_from_header_uuidmb
     # lose that uniqueid from mailboxes.db
     my $I = "I$uniqueid";
     my $N = "Nuser\x1fcassandane";
-    $self->{instance}->run_dbcommand($mailboxes_db, "twoskip",
+    my $format = $self->{instance}->{config}->get('mboxlist_db');
+    $self->{instance}->run_dbcommand($mailboxes_db, $format,
                                      [ 'DELETE', $I ]);
     my (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     my $dlist = Cyrus::DList->parse_string($mbentry);
     my $hash = $dlist->as_perl();
@@ -529,11 +531,11 @@ sub test_reconstruct_uniqueid_from_header_uuidmb
     $hash->{I} = undef;
     $dlist = Cyrus::DList->new_perl('', $hash);
     $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         [ 'SET', $N, $dlist->as_string() ]);
 
     my %updated = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip", ['SHOW']);
+        $mailboxes_db, $format, ['SHOW']);
     xlog "updated mailboxes.db: " . Dumper \%updated;
 
     # reconstruct -P should find and fix the missing uniqueid
@@ -562,7 +564,7 @@ sub test_reconstruct_uniqueid_from_header_uuidmb
 
     # mbentry should have the same uniqueid as before
     (undef, $mbentry) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $N]);
     $dlist = Cyrus::DList->parse_string($mbentry);
     $hash = $dlist->as_perl();
@@ -570,7 +572,7 @@ sub test_reconstruct_uniqueid_from_header_uuidmb
 
     # $I entry should be back
     my ($key, $value) = $self->{instance}->run_dbcommand(
-        $mailboxes_db, "twoskip",
+        $mailboxes_db, $format,
         ['SHOW', $I]);
     $self->assert_str_equals($I, $key);
     $dlist = Cyrus::DList->parse_string($value);

--- a/cassandane/Cassandane/Cyrus/Rename.pm
+++ b/cassandane/Cassandane/Cyrus/Rename.pm
@@ -857,10 +857,11 @@ sub _match_intermediates
 sub _dbset
 {
     my ($self, $key, $value) = @_;
+    my $format = $self->{instance}->{config}->get('mboxlist_db');
     $self->assert_str_equals('ok', $self->{instance}->run_dbcommand_cb(
         sub { die "got a response!" },
         "$self->{instance}->{basedir}/conf/mailboxes.db",
-        'twoskip',
+        $format,
         defined($value)
           ? ['SET', $key => $value]
           : ['DELETE', $key],

--- a/cassandane/tiny-tests/Metadata/cvt_cyrusdb
+++ b/cassandane/tiny-tests/Metadata/cvt_cyrusdb
@@ -62,7 +62,6 @@ sub test_cvt_cyrusdb
     my $global_db = "$basedir/conf/annotations.db";
     my $global_flat = "$basedir/xann.txt";
     my $format = $self->{instance}->{config}->get('annotation_db');
-    $format = $format // 'twoskip';
 
     $self->assert_not_file_test($global_flat, '-f');
     $self->{instance}->run_command({ cyrus => 1 },

--- a/cassandane/tiny-tests/SearchFuzzy/audit_unindexed
+++ b/cassandane/tiny-tests/SearchFuzzy/audit_unindexed
@@ -34,6 +34,8 @@ sub test_audit_unindexed
     my $data = $self->{instance}->run_mbpath(-u => 'cassandane');
     my $xapdir = $data->{xapian}{t1};
 
+    my $format = $self->{instance}->{config}->get('search_indexed_db');
+
     xlog $self, "Read current cyrus.indexed.db.";
     my ($key, $val);
     my $result = $self->{instance}->run_dbcommand_cb(sub {
@@ -41,13 +43,13 @@ sub test_audit_unindexed
       return if $k =~ m/\*V\*/;
       $self->assert_null($key);
       ($key, $val) = ($k, $v);
-    }, "$xapdir/xapian/cyrus.indexed.db", "twoskip", ['SHOW']);
+    }, "$xapdir/xapian/cyrus.indexed.db", $format, ['SHOW']);
     $self->assert_str_equals('ok', $result);
     $self->assert_not_null($key);
     $self->assert_not_null($val);
 
     xlog $self, "Add UID 2 to sequence set in cyrus.indexed.db";
-    $self->{instance}->run_dbcommand("$xapdir/xapian/cyrus.indexed.db", "twoskip", ['SET', $key, $val . ':2']);
+    $self->{instance}->run_dbcommand("$xapdir/xapian/cyrus.indexed.db", $format, ['SET', $key, $val . ':2']);
 
     xlog $self, "Run squatter audit";
     $result = $self->{instance}->run_command(

--- a/cassandane/tiny-tests/SearchFuzzy/reindex_mb_uniqueid
+++ b/cassandane/tiny-tests/SearchFuzzy/reindex_mb_uniqueid
@@ -17,10 +17,11 @@ sub test_reindex_mb_uniqueid
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-v', '-z', 't2', '-t', 't1', '-T', 't1:0');
 
     xlog "dump t2:cyrus.indexed.db";
-    # assumes twoskip backend and version 2 format keys
+    # assumes version 2 format keys
+    my $format = $self->{instance}->{config}->get('search_indexed_db');
     my $srcfile = $xapdirs->{t2} . '/xapian/cyrus.indexed.db';
     my $dstfile = $basedir . '/tmp/cyrus.indexed.db.flat';
-    $self->{instance}->run_command({cyrus => 1}, 'cvt_cyrusdb', $srcfile, 'twoskip', $dstfile, 'flat');
+    $self->{instance}->run_command({cyrus => 1}, 'cvt_cyrusdb', $srcfile, $format, $dstfile, 'flat');
 
     xlog "assert reindexed tier contains a mailbox key";
     open(FH, "<$dstfile") || die;


### PR DESCRIPTION
Remove all the 'twoskip' hard-coded values (this should basically be a NOOP since it sets the same defaults; but you can more easily change them in cassandane.ini without having the affected tests behave badly.