### PR TITLE
always build/install/distribute manpages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1607,6 +1607,7 @@ imap_cvt_xlist_specialuse_LDADD = $(LD_UTILITY_ADD)
 @SET_MAKE@
 
 dist_man1_MANS = \
+    man/dav_reconstruct.1 \
     man/imtest.1 \
     man/installsieve.1 \
     man/httptest.1 \
@@ -1628,13 +1629,16 @@ dist_man5_MANS = \
 
 dist_man8_MANS = \
     man/arbitron.8 \
+    man/calalarmd.8 \
     man/chk_cyrus.8 \
     man/ctl_conversationsdb.8 \
     man/ctl_cyrusdb.8 \
     man/ctl_deliver.8 \
     man/ctl_mboxlist.8 \
+    man/ctl_zoneinfo.8 \
     man/cvt_cyrusdb.8 \
     man/cvt_xlist_specialuse.8 \
+    man/cyradm.8 \
     man/cyr_buildinfo.8 \
     man/cyr_dbtool.8 \
     man/cyr_deny.8 \
@@ -1648,7 +1652,9 @@ dist_man8_MANS = \
     man/cyr_withlock_run.8 \
     man/cyrdump.8 \
     man/deliver.8 \
+    man/fetchnews.8 \
     man/fud.8 \
+    man/httpd.8 \
     man/idled.8 \
     man/imapd.8 \
     man/ipurge.8 \
@@ -1658,6 +1664,8 @@ dist_man8_MANS = \
     man/mbexamine.8 \
     man/mbpath.8 \
     man/mbtool.8 \
+    man/mupdate.8 \
+    man/nntpd.8 \
     man/notifyd.8 \
     man/pop3d.8 \
     man/pop3proxyd.8 \
@@ -1669,77 +1677,16 @@ dist_man8_MANS = \
     man/quota.8 \
     man/reconstruct.8 \
     man/relocate_by_id.8 \
-    man/smmapd.8 \
-    man/timsieved.8 \
-    man/tls_prune.8 \
-    man/unexpunge.8
-
-if SQUATTER
-dist_man8_MANS += \
-    man/squatter.8
-endif # SQUATTER
-
-if NNTPD
-dist_man8_MANS += \
-    man/fetchnews.8 \
-    man/nntpd.8
-endif # NNTPD
-
-if HTTPD
-dist_man1_MANS += \
-    man/dav_reconstruct.1
-dist_man8_MANS += \
-    man/ctl_zoneinfo.8 \
-    man/httpd.8
-endif # HTTPD
-
-if REPLICATION
-dist_man8_MANS += \
-    man/sync_client.8 \
-    man/sync_reset.8 \
-    man/sync_server.8
-endif # REPLICATION
-
-if MURDER
-dist_man8_MANS += \
-    man/mupdate.8
-endif # MURDER
-
-if PERL
-dist_man8_MANS += \
-    man/cyradm.8
-endif # PERL
-
-if SIEVE
-dist_man8_MANS += \
-    man/sievec.8 \
-    man/sieved.8
-endif
-
-if CALALARMD
-dist_man8_MANS += \
-    man/calalarmd.8
-endif
-
-if MAINTAINER_MODE
-## make sure feature-dependent man pages are included in distribution
-dist_man1_MANS += \
-    man/dav_reconstruct.1
-dist_man8_MANS += \
-    man/calalarmd.8
-    man/ctl_zoneinfo.8 \
-    man/cyradm.8 \
-    man/fetchnews.8 \
-    man/httpd.8 \
-    man/mupdate.8 \
-    man/nntpd.8 \
     man/sievec.8 \
     man/sieved.8 \
+    man/smmapd.8 \
     man/squatter.8 \
     man/sync_client.8 \
     man/sync_reset.8 \
-    man/sync_server.8
-endif # MAINTAINER_MODE
+    man/sync_server.8 \
+    man/timsieved.8 \
+    man/tls_prune.8 \
+    man/unexpunge.8
 
 if BENCH
 check_PROGRAMS += bench/cyrdbbench

--- a/Makefile.am
+++ b/Makefile.am
@@ -1645,6 +1645,7 @@ dist_man8_MANS = \
     man/cyr_synclog.8 \
     man/cyr_userseen.8 \
     man/cyr_virusscan.8 \
+    man/cyr_withlock_run.8 \
     man/cyrdump.8 \
     man/deliver.8 \
     man/fud.8 \
@@ -1715,11 +1716,17 @@ dist_man8_MANS += \
     man/sieved.8
 endif
 
+if CALALARMD
+dist_man8_MANS += \
+    man/calalarmd.8
+endif
+
 if MAINTAINER_MODE
 ## make sure feature-dependent man pages are included in distribution
 dist_man1_MANS += \
     man/dav_reconstruct.1
 dist_man8_MANS += \
+    man/calalarmd.8
     man/ctl_zoneinfo.8 \
     man/cyradm.8 \
     man/fetchnews.8 \


### PR DESCRIPTION
Removes a bunch of brittleness from Makefile.am by not applying feature-conditional logic to man pages.  Closes #4797.

Adds a couple of newer man pages to what's installed/distributed which had been overlooked previously.