### PR TITLE
twom.c: don't truncate file->size during recovery

### DIFF
--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1418,12 +1418,6 @@ static int recovery1(struct twom_db *db, struct tm_loc *loc, int *count)
     r = tm_commit(db, loc->end);
     if (r) return r;
 
-    if (ftruncate(file->fd, loc->end)) {
-        db->error("failed to truncate back to committed size",
-                  "fname=<%s> size=<%08llX>", db->fname, (LLU)loc->end);
-        return TWOM_IOERROR;
-    }
-
     /* clear the dirty flag */
     struct tm_header *header = &file->header;
     header->flags &= ~DIRTY;

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1423,8 +1423,6 @@ static int recovery1(struct twom_db *db, struct tm_loc *loc, int *count)
                   "fname=<%s> size=<%08llX>", db->fname, (LLU)loc->end);
         return TWOM_IOERROR;
     }
-    // this will cause tm_ensure to re-mmap even though the map is bigger
-    loc->file->size = loc->end;
 
     /* clear the dirty flag */
     struct tm_header *header = &file->header;


### PR DESCRIPTION
This fixes a bug where aborting a twom transaction followed by closing the database leaves a dangling mmapped region as long as the process still is running.

The bug is the result of truncating the file->size field in the recovery1 function. If the file has previously been mmapped to a larger region than that new size, the munmap following a db_close leaves the remaining region mapped for the process.