### PR TITLE
cron-style scheduling of cyrus.conf EVENTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ imap/unexpunge
 imtest/imtest
 install-sh
 lib/chartable.c
+lib/cron-lex.c
+lib/cron-parse.c
+lib/cron-parse.h
 lib/imapopts.c
 lib/imapopts.h
 lib/mkchartable

--- a/Makefile.am
+++ b/Makefile.am
@@ -636,6 +636,7 @@ cunit_TESTS = \
     cunit/imparse.testc \
     cunit/libconfig.testc \
     cunit/mailbox.testc \
+    cunit/master-cronevent.testc \
     cunit/master-event.testc \
     cunit/mboxname.testc \
     cunit/md5.testc \
@@ -678,7 +679,8 @@ cunit_TESTS += cunit/ical_support.testc
 endif
 
 cunit_unit_SOURCES = $(cunit_FRAMEWORK) $(cunit_TESTS) \
-    imap/mutex_fake.c imap/spool.c imap/search_expr.c master/event.c
+    imap/mutex_fake.c imap/spool.c imap/search_expr.c \
+    master/event.c master/cronevent.c
 nodist_cunit_unit_SOURCES = cunit/unit-registry.c
 cunit_unit_LDADD = $(LD_SIEVE_ADD) $(LD_UTILITY_ADD) -lcunit
 
@@ -1706,6 +1708,8 @@ master_master_SOURCES = \
     master/master.h \
     master/masterconf.c \
     master/masterconf.h \
+    master/cronevent.c \
+    master/cronevent.h \
     master/event.c \
     master/event.h \
     master/service.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -779,6 +779,7 @@ include_HEADERS = \
     lib/charset.h \
     lib/command.h \
     lib/crc32.h \
+    lib/cron.h \
     lib/cyr_lock.h \
     lib/cyr_qsort_r.h \
     lib/cyrusdb.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1542,6 +1542,7 @@ lib_libcyrus_min_la_SOURCES = \
     lib/assert.c \
     lib/bufarray.c \
     lib/byteorder.c \
+    lib/cron.c \
     lib/cron-lex.l \
     lib/cron-parse.y \
     lib/dynarray.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -633,6 +633,7 @@ cunit_TESTS = \
     cunit/imparse.testc \
     cunit/libconfig.testc \
     cunit/mailbox.testc \
+    cunit/master-event.testc \
     cunit/mboxname.testc \
     cunit/md5.testc \
     cunit/message.testc \
@@ -674,7 +675,7 @@ cunit_TESTS += cunit/ical_support.testc
 endif
 
 cunit_unit_SOURCES = $(cunit_FRAMEWORK) $(cunit_TESTS) \
-    imap/mutex_fake.c imap/spool.c imap/search_expr.c
+    imap/mutex_fake.c imap/spool.c imap/search_expr.c master/event.c
 nodist_cunit_unit_SOURCES = cunit/unit-registry.c
 cunit_unit_LDADD = $(LD_SIEVE_ADD) $(LD_UTILITY_ADD) -lcunit
 
@@ -1696,6 +1697,8 @@ master_master_SOURCES = \
     master/master.h \
     master/masterconf.c \
     master/masterconf.h \
+    master/event.c \
+    master/event.h \
     master/service.h
 master_master_LDADD = lib/libcyrus_min.la $(LIBS) $(GCOV_LIBS) $(LIBM)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,8 @@ endif # HAVE_LDAP
 
 AM_LDFLAGS = $(COV_LDFLAGS) $(ICU_LIBS)
 
+AM_YFLAGS = -d
+
 if ENABLE_RELEASE_CHECKS
     CFG2HDR_FORBID_UNRELEASED=--forbid-unreleased
     SPHINX_FAIL_ON_WARNINGS=-W --keep-going
@@ -620,6 +622,7 @@ cunit_TESTS = \
     cunit/charset.testc \
     cunit/command.testc \
     cunit/conversations.testc \
+    cunit/cron.testc \
     cunit/cyr_qsort_r.testc \
     cunit/crc32.testc \
     cunit/dlist.testc \
@@ -1531,11 +1534,15 @@ libcrc32_la_CFLAGS = -O3 $(AM_CFLAGS) $(CFLAG_VISIBILITY)
 nodist_lib_libcyrus_min_la_SOURCES = \
     lib/imapopts.c
 
+BUILT_SOURCES += lib/cron-lex.c lib/cron-parse.c lib/cron-parse.h
+
 lib_libcyrus_min_la_SOURCES = \
     lib/arrayu64.c \
     lib/assert.c \
     lib/bufarray.c \
     lib/byteorder.c \
+    lib/cron-lex.l \
+    lib/cron-parse.y \
     lib/dynarray.c \
     lib/hash.c \
     lib/hashset.c \

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -889,6 +889,34 @@ sub test_periodic_event_slow
                               }, $self->lemming_census());
 }
 
+sub test_at_event_bad
+{
+    my ($self) = @_;
+
+    my $srv = $self->lemming_service(tag => 'A');
+
+    # schedule an event with a bad at=hhmm specification
+    $self->lemming_event(tag => 'B',
+                         mode => 'success',
+                         at => '2401');
+    eval {
+        $self->start();
+    };
+    my $e = $@;
+    # The exception thrown depends on how cassandane and master race
+    # against one another.  If master wins, cassandane gets stuck waiting
+    # for the PID file to be valid, and eventually throws a timeout
+    # exception.  If cassandane wins, it correctly detects that master is
+    # no longer running, and throws that.
+    $self->assert_not_null($e);
+#     $self->assert_matches(qr{the master PID file to exist}, $e);
+#     $self->assert_matches(qr{Master no longer running}, $e);
+
+    $self->assert_num_equals(0, $self->{instance}->is_running());
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{invalid at=hhmm specification});
+}
+
 sub test_at_event_slow
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -889,6 +889,38 @@ sub test_periodic_event_slow
                               }, $self->lemming_census());
 }
 
+sub test_at_event_slow
+{
+    my ($self) = @_;
+
+    my $srv = $self->lemming_service(tag => 'A');
+
+    # schedule some events to run a little after the current time, and check
+    # that they do
+    my @offsets = (1, 3, 20);
+
+    my $now = time;
+    my $localtz = DateTime::TimeZone->new(name => 'local');
+    foreach my $offset (@offsets) {
+        my $dt = DateTime->from_epoch(epoch => $now, time_zone => $localtz);
+        $dt->add(minutes => $offset);
+        my $hhmm = $dt->strftime('%H%M');
+        $self->lemming_event(tag => $offset,
+                             mode => 'success',
+                             at => $hhmm);
+    }
+    $self->start();
+
+    xlog $self, "waiting 5 mins for events to fire, plus some slop";
+    sleep(5 * 60 + 5);
+
+    $self->assert_deep_equals({
+        '1'  => { live => 0, dead => 1 },
+        '3'  => { live => 0, dead => 1 },
+        # 20 shouldn't run
+    }, $self->lemming_census());
+}
+
 sub test_service_bad_name
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -921,6 +921,37 @@ sub test_at_event_slow
     }, $self->lemming_census());
 }
 
+sub test_cron_event_slow
+{
+    my ($self) = @_;
+
+    my $srv = $self->lemming_service(tag => 'A');
+
+    # schedule an event to run a few times a little after the current time,
+    # and check that it does
+    my @offsets = (1, 3, 20);
+
+    my $now = time;
+    my $localtz = DateTime::TimeZone->new(name => 'local');
+    my @minutes;
+    foreach my $offset (@offsets) {
+        my $dt = DateTime->from_epoch(epoch => $now, time_zone => $localtz);
+        $dt->add(minutes => $offset);
+        push @minutes, $dt->minute;
+    }
+    $self->lemming_event(tag => 'B',
+                         mode => 'success',
+                         cron => join(',', @minutes) . " * * * *");
+    $self->start();
+
+    xlog $self, "waiting 5 mins for events to fire, plus some slop";
+    sleep(5 * 60 + 5);
+
+    $self->assert_deep_equals({
+        'B'  => { live => 0, dead => 2 },
+    }, $self->lemming_census());
+}
+
 sub test_service_bad_name
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/MasterEvent.pm
+++ b/cassandane/Cassandane/MasterEvent.pm
@@ -52,7 +52,7 @@ sub new
 sub _otherparams
 {
     my ($self) = @_;
-    return ( qw(period at) );
+    return ( qw(period at cron) );
 }
 
 1;

--- a/changes/next/master-cron-events
+++ b/changes/next/master-cron-events
@@ -1,0 +1,24 @@
+Description:
+
+Adds support for cron-style scheduling of cyrus.conf EVENTS
+
+
+Documentation:
+
+cyrus.conf(5)
+doc/examples/cyrus_conf/*
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+Nothing required
+
+
+GitHub issue:
+
+None

--- a/cunit/cron.testc
+++ b/cunit/cron.testc
@@ -1,81 +1,343 @@
 /* Unit test for lib/cron-parse.c */
 #include <config.h>
 #include "cunit/unit.h"
-#include "crc32.h"
 
-#define SENTINEL UINT64_C(0xcafef00dcafef00d)
+#include "lib/cron.h"
 
-/* XXX need to get this from a header */
-extern int cron_parse_datetime(const char *datetime, unsigned max_value,
-                               uint64_t *result);
+#define SENTINEL (struct cron_spec){            \
+    .minutes = UINT64_C(0xcafef00dcafef00d),    \
+    .hours = UINT32_C(0xcafef00d),              \
+    .days_of_month = UINT32_C(0xcafef00d),      \
+    .months = UINT16_C(0xcafe),                 \
+    .days_of_week = UINT8_C(0xcf),              \
+}
 
-static void test_cron_parse_datetime(void)
+#define DO_CRON_PARSE_SPEC(a, b, c, d) do {                                 \
+    const char *arg_spec = (a);                                             \
+    const int arg_expect_r = (b);                                           \
+    const struct cron_spec *arg_expect_result = (c);                        \
+    const char *arg_expect_err = (d);                                       \
+                                                                            \
+    struct cron_spec actual_result = SENTINEL;                              \
+    const char *actual_err = NULL;                                          \
+    int actual_r;                                                           \
+                                                                            \
+    actual_r = cron_parse_spec(arg_spec, &actual_result, &actual_err);      \
+    CU_ASSERT_EQUAL(actual_r, arg_expect_r);                                \
+                                                                            \
+    if (arg_expect_r) {                                                     \
+        CU_ASSERT_PTR_NOT_NULL(actual_err);                                 \
+        CU_ASSERT_STRING_EQUAL(actual_err, arg_expect_err);                 \
+        CU_ASSERT_EQUAL(actual_result.minutes, SENTINEL.minutes);           \
+        CU_ASSERT_EQUAL(actual_result.hours, SENTINEL.hours);               \
+        CU_ASSERT_EQUAL(actual_result.days_of_month,                        \
+                        SENTINEL.days_of_month);                            \
+        CU_ASSERT_EQUAL(actual_result.months, SENTINEL.months);             \
+        CU_ASSERT_EQUAL(actual_result.days_of_week, SENTINEL.days_of_week); \
+    }                                                                       \
+    else {                                                                  \
+        CU_ASSERT_PTR_NULL(actual_err);                                     \
+        CU_ASSERT_EQUAL(actual_result.hours,                                \
+                        arg_expect_result->hours);                          \
+        CU_ASSERT_EQUAL(actual_result.days_of_month,                        \
+                        arg_expect_result->days_of_month);                  \
+        CU_ASSERT_EQUAL(actual_result.months,                               \
+                        arg_expect_result->months);                         \
+        CU_ASSERT_EQUAL(actual_result.days_of_week,                         \
+                        arg_expect_result->days_of_week);                   \
+    }                                                                       \
+} while (0)
+
+static void test_cron_parse_spec_asterisk(void)
+{
+    const char *spec = "* * * * *";
+    struct cron_spec expect_result = {
+        CRON_ALL_MINUTES,
+        CRON_ALL_HOURS,
+        CRON_ALL_DAYS_OF_MONTH,
+        CRON_ALL_MONTHS,
+        CRON_ALL_DAYS_OF_WEEK,
+    };
+
+    DO_CRON_PARSE_SPEC(spec, 0, &expect_result, NULL);
+}
+
+static void test_cron_parse_spec_minutes(void)
 {
     const struct {
-        const char *datetime;
-        unsigned max_value;
+        const char *minutes_spec;
         int expect_r;
-        uint64_t expect_result;
+        uint64_t expect_minutes;
+        const char *expect_err;
     } tests[] = {
-        { "*", 60 /* 0-59, 60==0 */, 0, UINT64_C(0x0FFFFFFFFFFFFFFF) },
-        { "*", 24 /* 0-23, 24==0 */, 0, UINT64_C(0x0000000000FFFFFF) },
-        { "*", 31 /* 1-31, 31==0 */, 0, UINT64_C(0x000000007FFFFFFF) },
-        { "*", 12 /* 1-12, 12==0 */, 0, UINT64_C(0x0000000000000FFF) },
-        { "*",  7 /* 0-6,   7==0 */, 0, UINT64_C(0x000000000000007F) },
-        { "0",  0, 0, UINT64_C(0b1) },
-        { "1",  0, 0, UINT64_C(0b10) },
-        { "2",  0, 0, UINT64_C(0b100) },
-        { "3",  0, 0, UINT64_C(0b1000) },
-        { "1,3", 0, 0, UINT64_C(0b1010) },
-        { "1-4", 0, 0, UINT64_C(0b11110) },
-        { "2-4,6-7,9", 0, 0, UINT64_C(0b1011011100) },
-        { "*/5", 24, 0, UINT64_C(0b000100001000010000100001) },
-        { "5-15/2", 0, 0, UINT64_C(0b0101010101000000) },
-        { "0-2,5-6,7-23/3", 0, 0, UINT64_C(0b001001001001001001100111) },
+        { "0",       0, UINT64_C(0b1), NULL },
+        { "1",       0, UINT64_C(0b10), NULL },
+        { "2",       0, UINT64_C(0b100), NULL },
+        { "3",       0, UINT64_C(0b1000), NULL },
+        { "03",      0, UINT64_C(0b1000), NULL },
+        { "1,3",     0, UINT64_C(0b1010), NULL },
+        { "2-4,6-7,9",
+                     0, UINT64_C(0b1011011100), NULL },
+        { "4-17",    0, UINT64_C(0b111111111111110000), NULL },
+        { "*/5",     0,
+          UINT64_C(0b0000000010000100001000010000100001000010000100001000010000100001),
+          NULL },
+        { "5-15/2",  0, UINT64_C(0b0101010101000000), NULL },
+        { "0-2,5-6,7-23/3",
+                     0, UINT64_C(0b001001001001001001100111), NULL },
+        { "60",     -1, UINT64_C(0), "minutes out of range" },
+        { "65-70",  -1, UINT64_C(0), "value out of range" },
+        { "0-60",   -1, UINT64_C(0), "minutes out of range" },
+        { "0-60/5", -1, UINT64_C(0), "minutes out of range" },
+        { "15-2",   -1, UINT64_C(0), "range back to front" },
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;
 
-    fputs("\n", stderr);
     for (i = 0; i < n_tests; i++) {
-        uint64_t actual_result;
-        int actual_r;
+        struct cron_spec expect_result = {
+            tests[i].expect_minutes,
+            CRON_ALL_HOURS,
+            CRON_ALL_DAYS_OF_MONTH,
+            CRON_ALL_MONTHS,
+            CRON_ALL_DAYS_OF_WEEK,
+        };
+        char spec[128];
 
-        actual_r = cron_parse_datetime(tests[i].datetime,
-                                       tests[i].max_value,
-                                       &actual_result);
-        fprintf(stderr, "%u %s %u expected %" PRIx64 " got %" PRIx64 "\n",
-                        i, tests[i].datetime, tests[i].max_value,
-                        tests[i].expect_result, actual_result);
-        CU_ASSERT_EQUAL(actual_r, tests[i].expect_r);
-        CU_ASSERT_EQUAL(actual_result, tests[i].expect_result);
+        snprintf(spec, sizeof(spec), "%s * * * *", tests[i].minutes_spec);
+
+        DO_CRON_PARSE_SPEC(spec,
+                           tests[i].expect_r,
+                           &expect_result,
+                           tests[i].expect_err);
     }
 }
 
-static void test_cron_parse_datetime_invalid(void)
+static void test_cron_parse_spec_hours(void)
 {
-    const char *const tests[] = {
-        "",
-        "**",
-        " ",
-        "cat",
-        "1-5/",
-        "1-5/egg",
-        "mon,tue,wed",
+    const struct {
+        const char *hours_spec;
+        int expect_r;
+        uint64_t expect_hours;
+        const char *expect_err;
+    } tests[] = {
+        { "0",       0, UINT32_C(0b1), NULL },
+        { "1",       0, UINT32_C(0b10), NULL },
+        { "2",       0, UINT32_C(0b100), NULL },
+        { "3",       0, UINT32_C(0b1000), NULL },
+        { "03",      0, UINT32_C(0b1000), NULL },
+        { "1,3",     0, UINT32_C(0b1010), NULL },
+        { "2-4,6-7,9",
+                     0, UINT32_C(0b1011011100), NULL },
+        { "4-17",    0, UINT32_C(0b111111111111110000), NULL },
+        { "*/5",     0, UINT32_C(0b000100001000010000100001), NULL },
+        { "5-15/2",  0, UINT32_C(0b0101010101000000), NULL },
+        { "0-2,5-6,7-23/3",
+                     0, UINT32_C(0b001001001001001001100111), NULL },
+        { "24",     -1, UINT32_C(0), "hours out of range" },
+        { "60-70",  -1, UINT32_C(0), "value out of range" },
+        { "0-24",   -1, UINT32_C(0), "hours out of range" },
+        { "0-24/4", -1, UINT32_C(0), "hours out of range" },
+        { "15-2",   -1, UINT32_C(0), "range back to front" },
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;
 
-    fputs("\n", stderr);
     for (i = 0; i < n_tests; i++) {
-        uint64_t actual_result = SENTINEL;
-        int actual_r;
+        struct cron_spec expect_result = {
+            CRON_ALL_MINUTES,
+            tests[i].expect_hours,
+            CRON_ALL_DAYS_OF_MONTH,
+            CRON_ALL_MONTHS,
+            CRON_ALL_DAYS_OF_WEEK,
+        };
+        char spec[128];
 
-        actual_r = cron_parse_datetime(tests[i], 0, &actual_result);
-        fprintf(stderr, "%s: <%s> returned %d\n",
-                __func__, tests[i], actual_r);
-        CU_ASSERT_EQUAL(actual_r, 1);
-        CU_ASSERT_EQUAL(actual_result, SENTINEL);
+        snprintf(spec, sizeof(spec), "* %s * * *", tests[i].hours_spec);
+
+        DO_CRON_PARSE_SPEC(spec,
+                           tests[i].expect_r,
+                           &expect_result,
+                           tests[i].expect_err);
+    }
+}
+
+static void test_cron_parse_spec_days_of_month(void)
+{
+    const struct {
+        const char *doms_spec;
+        int expect_r;
+        uint32_t expect_doms;
+        const char *expect_err;
+    } tests[] = {
+        { "0",       0, UINT32_C(0b1000000000000000000000000000000), NULL },
+        { "1",       0, UINT32_C(0b1), NULL },
+        { "2",       0, UINT32_C(0b10), NULL },
+        { "3",       0, UINT32_C(0b100), NULL },
+        { "03",      0, UINT32_C(0b100), NULL },
+        { "1,3",     0, UINT32_C(0b101), NULL },
+        { "2-4,6-7,9",
+                     0, UINT32_C(0b101101110), NULL },
+        { "4-17",    0, UINT32_C(0b11111111111111000), NULL },
+        { "*/5",     0, UINT32_C(0b00100001000010000100001000010000), NULL },
+        { "5-15/2",  0, UINT32_C(0b00000000000000000010101010100000), NULL },
+        { "1-2,5-6,7-23/3",
+                     0, UINT32_C(0b00000000000100100100100100110011), NULL },
+        { "32",     -1, UINT32_C(0), "days of month out of range" },
+        { "65-70",  -1, UINT32_C(0), "value out of range" },
+        { "0-32",   -1, UINT32_C(0), "days of month out of range" },
+        { "0-40/5", -1, UINT32_C(0), "days of month out of range" },
+        { "15-2",   -1, UINT32_C(0), "range back to front" },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct cron_spec expect_result = {
+            CRON_ALL_MINUTES,
+            CRON_ALL_HOURS,
+            tests[i].expect_doms,
+            CRON_ALL_MONTHS,
+            CRON_ALL_DAYS_OF_WEEK,
+        };
+        char spec[128];
+
+        snprintf(spec, sizeof(spec), "* * %s * *", tests[i].doms_spec);
+
+        DO_CRON_PARSE_SPEC(spec,
+                           tests[i].expect_r,
+                           &expect_result,
+                           tests[i].expect_err);
+    }
+}
+
+static void test_cron_parse_spec_months(void)
+{
+    const struct {
+        const char *months_spec;
+        int expect_r;
+        uint16_t expect_months;
+        const char *expect_err;
+    } tests[] = {
+        { "0",       0, UINT16_C(0b100000000000), NULL },
+        { "1",       0, UINT16_C(0b1), NULL },
+        { "2",       0, UINT16_C(0b10), NULL },
+        { "3",       0, UINT16_C(0b100), NULL },
+        { "03",      0, UINT16_C(0b100), NULL },
+        { "1,3",     0, UINT16_C(0b101), NULL },
+        { "2-4,6-7,9",
+                     0, UINT16_C(0b101101110), NULL },
+        { "*/2",     0, UINT16_C(0b101010101010), NULL },
+        { "*/3",     0, UINT16_C(0b100100100100), NULL },
+        { "*/4",     0, UINT16_C(0b100010001000), NULL },
+        { "*/5",     0, UINT16_C(0b001000010000), NULL },
+        { "*/6",     0, UINT16_C(0b100000100000), NULL },
+        { "*/7",     0, UINT16_C(0b000001000000), NULL },
+        { "5-11/2",  0, UINT16_C(0b001010100000), NULL },
+        { "1-2,5-6,7-12/3",
+                     0, UINT16_C(0b100100110011), NULL },
+        { "jan",     0, UINT16_C(0b1), NULL },
+        { "feb",     0, UINT16_C(0b10), NULL },
+        { "mar",     0, UINT16_C(0b100), NULL },
+        { "apr",     0, UINT16_C(0b1000), NULL },
+        { "may",     0, UINT16_C(0b10000), NULL },
+        { "jun",     0, UINT16_C(0b100000), NULL },
+        { "jul",     0, UINT16_C(0b1000000), NULL },
+        { "aug",     0, UINT16_C(0b10000000), NULL },
+        { "sep",     0, UINT16_C(0b100000000), NULL },
+        { "oct",     0, UINT16_C(0b1000000000), NULL },
+        { "nov",     0, UINT16_C(0b10000000000), NULL },
+        { "dec",     0, UINT16_C(0b100000000000), NULL },
+        { "13",     -1, UINT16_C(0), "months out of range" },
+        { "65-70",  -1, UINT16_C(0), "value out of range" },
+        { "1-13",   -1, UINT16_C(0), "months out of range" },
+        { "1-20/5", -1, UINT16_C(0), "months out of range" },
+        { "7-2",    -1, UINT16_C(0), "range back to front" },
+        { "cat",    -1, UINT16_C(0), "syntax error" },
+        { "jan,feb",-1, UINT16_C(0), "syntax error" },
+        { "sun",    -1, UINT16_C(0), "syntax error" },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct cron_spec expect_result = {
+            CRON_ALL_MINUTES,
+            CRON_ALL_HOURS,
+            CRON_ALL_DAYS_OF_MONTH,
+            tests[i].expect_months,
+            CRON_ALL_DAYS_OF_WEEK,
+        };
+        char spec[128];
+
+        snprintf(spec, sizeof(spec), "* * * %s *", tests[i].months_spec);
+
+        DO_CRON_PARSE_SPEC(spec,
+                           tests[i].expect_r,
+                           &expect_result,
+                           tests[i].expect_err);
+    }
+}
+
+static void test_cron_parse_spec_days_of_week(void)
+{
+    const struct {
+        const char *dows_spec;
+        int expect_r;
+        uint8_t expect_dows;
+        const char *expect_err;
+    } tests[] = {
+        { "0",       0, UINT8_C(0b1), NULL },
+        { "7",       0, UINT8_C(0b1), NULL },
+        { "1",       0, UINT8_C(0b10), NULL },
+        { "2",       0, UINT8_C(0b100), NULL },
+        { "3",       0, UINT8_C(0b1000), NULL },
+        { "03",      0, UINT8_C(0b1000), NULL },
+        { "1,3",     0, UINT8_C(0b1010), NULL },
+        { "2-4,6-7", 0, UINT8_C(0b01011101), NULL },
+        { "*/2",     0, UINT8_C(0b01010101), NULL },
+        { "*/3",     0, UINT8_C(0b01001001), NULL },
+        { "*/4",     0, UINT8_C(0b00010001), NULL },
+        { "*/5",     0, UINT8_C(0b00100001), NULL },
+        { "*/6",     0, UINT8_C(0b01000001), NULL },
+        { "*/7",     0, UINT8_C(0b00000001), NULL },
+        { "2-7/2",   0, UINT8_C(0b01010100), NULL },
+        { "0,2-6/3", 0, UINT8_C(0b01001001), NULL },
+        { "sun",     0, UINT8_C(0b1), NULL },
+        { "mon",     0, UINT8_C(0b10), NULL },
+        { "tue",     0, UINT8_C(0b100), NULL },
+        { "wed",     0, UINT8_C(0b1000), NULL },
+        { "thu",     0, UINT8_C(0b10000), NULL },
+        { "fri",     0, UINT8_C(0b100000), NULL },
+        { "sat",     0, UINT8_C(0b1000000), NULL },
+        { "8",      -1, UINT8_C(0), "days of week out of range" },
+        { "65-70",  -1, UINT8_C(0), "value out of range" },
+        { "1-13",   -1, UINT8_C(0), "days of week out of range" },
+        { "1-20/5", -1, UINT8_C(0), "days of week out of range" },
+        { "7-2",    -1, UINT8_C(0), "range back to front" },
+        { "cat",    -1, UINT8_C(0), "syntax error" },
+        { "sat,sun",-1, UINT8_C(0), "syntax error" },
+        { "jan",    -1, UINT8_C(0), "syntax error" },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct cron_spec expect_result = {
+            CRON_ALL_MINUTES,
+            CRON_ALL_HOURS,
+            CRON_ALL_DAYS_OF_MONTH,
+            CRON_ALL_MONTHS,
+            tests[i].expect_dows,
+        };
+        char spec[128];
+
+        snprintf(spec, sizeof(spec), "* * * * %s", tests[i].dows_spec);
+
+        DO_CRON_PARSE_SPEC(spec,
+                           tests[i].expect_r,
+                           &expect_result,
+                           tests[i].expect_err);
     }
 }
 

--- a/cunit/cron.testc
+++ b/cunit/cron.testc
@@ -1,0 +1,82 @@
+/* Unit test for lib/cron-parse.c */
+#include <config.h>
+#include "cunit/unit.h"
+#include "crc32.h"
+
+#define SENTINEL UINT64_C(0xcafef00dcafef00d)
+
+/* XXX need to get this from a header */
+extern int cron_parse_datetime(const char *datetime, unsigned max_value,
+                               uint64_t *result);
+
+static void test_cron_parse_datetime(void)
+{
+    const struct {
+        const char *datetime;
+        unsigned max_value;
+        int expect_r;
+        uint64_t expect_result;
+    } tests[] = {
+        { "*", 60 /* 0-59, 60==0 */, 0, UINT64_C(0x0FFFFFFFFFFFFFFF) },
+        { "*", 24 /* 0-23, 24==0 */, 0, UINT64_C(0x0000000000FFFFFF) },
+        { "*", 31 /* 1-31, 31==0 */, 0, UINT64_C(0x000000007FFFFFFF) },
+        { "*", 12 /* 1-12, 12==0 */, 0, UINT64_C(0x0000000000000FFF) },
+        { "*",  7 /* 0-6,   7==0 */, 0, UINT64_C(0x000000000000007F) },
+        { "0",  0, 0, UINT64_C(0b1) },
+        { "1",  0, 0, UINT64_C(0b10) },
+        { "2",  0, 0, UINT64_C(0b100) },
+        { "3",  0, 0, UINT64_C(0b1000) },
+        { "1,3", 0, 0, UINT64_C(0b1010) },
+        { "1-4", 0, 0, UINT64_C(0b11110) },
+        { "2-4,6-7,9", 0, 0, UINT64_C(0b1011011100) },
+        { "*/5", 24, 0, UINT64_C(0b000100001000010000100001) },
+        { "5-15/2", 0, 0, UINT64_C(0b0101010101000000) },
+        { "0-2,5-6,7-23/3", 0, 0, UINT64_C(0b001001001001001001100111) },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    fputs("\n", stderr);
+    for (i = 0; i < n_tests; i++) {
+        uint64_t actual_result;
+        int actual_r;
+
+        actual_r = cron_parse_datetime(tests[i].datetime,
+                                       tests[i].max_value,
+                                       &actual_result);
+        fprintf(stderr, "%u %s %u expected %" PRIx64 " got %" PRIx64 "\n",
+                        i, tests[i].datetime, tests[i].max_value,
+                        tests[i].expect_result, actual_result);
+        CU_ASSERT_EQUAL(actual_r, tests[i].expect_r);
+        CU_ASSERT_EQUAL(actual_result, tests[i].expect_result);
+    }
+}
+
+static void test_cron_parse_datetime_invalid(void)
+{
+    const char *const tests[] = {
+        "",
+        "**",
+        " ",
+        "cat",
+        "1-5/",
+        "1-5/egg",
+        "mon,tue,wed",
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    fputs("\n", stderr);
+    for (i = 0; i < n_tests; i++) {
+        uint64_t actual_result = SENTINEL;
+        int actual_r;
+
+        actual_r = cron_parse_datetime(tests[i], 0, &actual_result);
+        fprintf(stderr, "%s: <%s> returned %d\n",
+                __func__, tests[i], actual_r);
+        CU_ASSERT_EQUAL(actual_r, 1);
+        CU_ASSERT_EQUAL(actual_result, SENTINEL);
+    }
+}
+
+/* vim: set ft=c: */

--- a/cunit/cron.testc
+++ b/cunit/cron.testc
@@ -406,4 +406,55 @@ static void test_cron_spec_from_timeval(void)
     }
 }
 
+static void test_cron_spec_matches(void)
+{
+    const struct {
+        const char *spec_str;
+        struct cron_spec current_time;
+        bool expect_matches;
+    } tests[] = {
+        /* any time should match all asterisks */
+        { "* * * * *", CS_MOMENT(27, 11, 4, 8, 1), true },
+        /* 4am on 2nd of any month regardless of day-of-week */
+        { "0 4 2 * *", CS_MOMENT(0, 4, 2, 8, 6), true },
+        { "0 4 2 * *", CS_MOMENT(1, 4, 2, 8, 6), false },
+        { "0 4 2 * *", CS_MOMENT(0, 3, 2, 8, 6), false },
+        { "0 4 2 * *", CS_MOMENT(0, 4, 3, 8, 0), false },
+        { "0 4 2 * *", CS_MOMENT(0, 4, 2, 7, 3), true },
+        /* 4am on any day of august */
+        { "0 4 * 8 *", CS_MOMENT(0, 4, 2, 8, 6), true },
+        { "0 4 * 8 *", CS_MOMENT(0, 4, 3, 8, 0), true },
+        { "0 4 * 8 *", CS_MOMENT(0, 4, 4, 8, 1), true },
+        { "0 4 * 8 *", CS_MOMENT(0, 4, 5, 8, 2), true },
+        { "0 4 * 8 *", CS_MOMENT(0, 4, 5, 7, 1), false },
+        { "0 4 * 8 *", CS_MOMENT(0, 4, 5, 6, 4), false },
+        /* 4am on any friday regardless of day-of-month */
+        { "0 4 * * 5", CS_MOMENT(0, 4,  1, 8, 5), true },
+        { "0 4 * * 5", CS_MOMENT(0, 4,  8, 8, 5), true },
+        { "0 4 * * 5", CS_MOMENT(0, 4, 15, 8, 5), true },
+        { "0 4 * * 5", CS_MOMENT(0, 4, 22, 8, 5), true },
+        { "0 4 * * 5", CS_MOMENT(0, 4, 29, 8, 5), true },
+        { "0 4 * * 5", CS_MOMENT(0, 4, 30, 8, 6), false },
+        /* 4am on any friday OR any 13th day-of-month */
+        { "0 4 13 * 5", CS_MOMENT(0, 4, 17, 6, 2), false },
+        { "0 4 13 * 5", CS_MOMENT(0, 4, 20, 6, 5), true },
+        { "0 4 13 * 5", CS_MOMENT(0, 4, 13, 7, 0), true },
+        { "0 4 13 * 5", CS_MOMENT(0, 4, 13, 6, 5), true },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct cron_spec spec = SENTINEL;
+        bool actual_matches;
+        int r;
+
+        r = cron_parse_spec(tests[i].spec_str, &spec, NULL);
+        CU_ASSERT_EQUAL(r, 0);
+
+        actual_matches = cron_spec_matches(&spec, &tests[i].current_time);
+        CU_ASSERT_EQUAL(actual_matches, tests[i].expect_matches);
+    }
+}
+
 /* vim: set ft=c: */

--- a/cunit/cron.testc
+++ b/cunit/cron.testc
@@ -1,6 +1,7 @@
-/* Unit test for lib/cron-parse.c */
+/* Unit test for lib/cron.c and lib/cron-parse.y */
 #include <config.h>
 #include "cunit/unit.h"
+#include "cunit/unit-timezones.h"
 
 #include "lib/cron.h"
 
@@ -47,6 +48,12 @@
                         arg_expect_result->days_of_week);                   \
     }                                                                       \
 } while (0)
+
+static int tear_down(void)
+{
+    restore_tz();
+    return 0;
+}
 
 static void test_cron_parse_spec_asterisk(void)
 {
@@ -338,6 +345,64 @@ static void test_cron_parse_spec_days_of_week(void)
                            tests[i].expect_r,
                            &expect_result,
                            tests[i].expect_err);
+    }
+}
+
+#define TV_INIT(s, u) (struct timeval){ .tv_sec = (s), .tv_usec = (u) }
+
+#define CS_MOMENT(min, hr, dm, mon, dw) (struct cron_spec) {                \
+    .minutes = UINT64_C(1) << (min),                                        \
+    .hours = UINT32_C(1) << (hr),                                           \
+    .days_of_month = UINT32_C(1) << ((dm) - 1),                             \
+    .months = UINT16_C(1) << ((mon) - 1),                                   \
+    .days_of_week = UINT8_C(1) << (dw),                                     \
+}
+
+#define TIME_T_NOSEC(t) ({ __auto_type t_ = (t); t_ - (t_ % 60); })
+
+static void test_cron_spec_from_timeval(void)
+{
+    const struct {
+        const char *tz;
+        struct timeval tv;
+        struct cron_spec expect_spec;
+        time_t expect_run_time;
+    } tests[] = {
+        { TZ_MELBOURNE,
+          TV_INIT(1753837286, 0),   /* UTC: 2025-07-30 01:01 */
+          /* just a normal time */
+          CS_MOMENT(1, 12, 30, 7, 3),
+          TIME_T_NOSEC(1753837286) },
+        { TZ_NEWYORK,
+          TV_INIT(1754020800, 0),   /* UTC: 2025-08-01 04:00 */
+          /* trying to exercise tm_mday==0 behaviour... */
+          CS_MOMENT(0, 23, 31, 7, 4),
+          TIME_T_NOSEC(1754020800) },
+        { TZ_MELBOURNE,
+          TV_INIT(1709179200, 0),   /* UTC: 2024-02-29 04:00 */
+          /* better try february 29... */
+          CS_MOMENT(0, 15, 29, 2, 4),
+          TIME_T_NOSEC(1709179200) },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct cron_spec actual_spec = SENTINEL;
+        time_t actual_run_time = -1;
+
+        push_tz(tests[i].tz);
+        cron_spec_from_timeval(&actual_spec, &actual_run_time, &tests[i].tv);
+        pop_tz();
+
+        CU_ASSERT_EQUAL(actual_spec.hours, tests[i].expect_spec.hours);
+        CU_ASSERT_EQUAL(actual_spec.days_of_month,
+                        tests[i].expect_spec.days_of_month);
+        CU_ASSERT_EQUAL(actual_spec.months, tests[i].expect_spec.months);
+        CU_ASSERT_EQUAL(actual_spec.days_of_week,
+                        tests[i].expect_spec.days_of_week);
+
+        CU_ASSERT_EQUAL(actual_run_time, tests[i].expect_run_time);
     }
 }
 

--- a/cunit/master-cronevent.testc
+++ b/cunit/master-cronevent.testc
@@ -1,0 +1,251 @@
+#include "cunit/unit.h"
+#include "cunit/unit-timezones.h"
+#include "master/cronevent.h"
+
+#include "lib/cron.h"
+#include "lib/dynarray.h"
+#include "lib/hash.h"
+
+#include <stdlib.h>
+#include <sysexits.h>
+
+#define TV_INIT(s, u) (struct timeval){ .tv_sec = (s), .tv_usec = (u) }
+#define TIME_T_NOSEC(t) ({ __auto_type t_ = (t); t_ - (t_ % 60); })
+
+extern void cronevent_get_schedule(dynarray_t **schedule,
+                                   dynarray_t **details);
+extern time_t cronevent_get_last_run_time(void);
+extern void cronevent_set_last_run_time(time_t run_time);
+
+static int tear_down(void)
+{
+    cronevent_clear();
+    return 0;
+}
+
+static void assert_event_invariants(const struct cron_spec *spec,
+                                    const struct cronevent_details *details)
+{
+    /* no invalid bits set in the spec */
+    CU_ASSERT_EQUAL((spec->minutes & ~CRON_ALL_MINUTES), 0);
+    CU_ASSERT_EQUAL((spec->hours & ~CRON_ALL_HOURS), 0);
+    CU_ASSERT_EQUAL((spec->days_of_month & ~CRON_ALL_DAYS_OF_MONTH), 0);
+    CU_ASSERT_EQUAL((spec->months & ~CRON_ALL_MONTHS), 0);
+    CU_ASSERT_EQUAL((spec->days_of_week & ~CRON_ALL_DAYS_OF_WEEK), 0);
+
+    /* better have a name */
+    CU_ASSERT_PTR_NOT_NULL(details->name);
+    CU_ASSERT_STRING_NOT_EQUAL(details->name, "");
+
+    /* better have something to execute */
+    CU_ASSERT_NOT_EQUAL(strarray_size(&details->exec), 0);
+}
+
+static void assert_schedule_invariants(void)
+{
+    dynarray_t *schedule, *details;
+    int sched_count, det_count;
+    int i;
+
+    cronevent_get_schedule(&schedule, &details);
+
+    sched_count = dynarray_size(schedule);
+    CU_ASSERT(sched_count >= 0);
+
+    det_count = dynarray_size(details);
+    CU_ASSERT(det_count >= 0);
+    CU_ASSERT_EQUAL(sched_count, det_count);
+
+    for (i = 0; i < sched_count; i++) {
+        assert_event_invariants(dynarray_nth(schedule, i),
+                                dynarray_nth(details, i));
+    }
+}
+
+static void test_cronevent_add_bad(void)
+{
+    const struct {
+        const char *name;
+        const char *cmd;
+        const char *spec;
+        const char *expect_fatal;
+    } tests[] = {
+        { NULL,   NULL,  NULL,    "event missing name" },
+        { "",     NULL,  NULL,    "event missing name" },
+        { "name", NULL,  NULL,    "event missing cmd" },
+        { "name", "",    NULL,    "event missing cmd" },
+        { "name", "cmd", NULL,    "unable to parse cron spec" },
+        { "name", "cmd", "",      "unable to parse cron spec" },
+        { "name", "cmd", "bogus", "unable to parse cron spec" },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    volatile unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        CU_EXPECT_CYRFATAL_BEGIN
+        cronevent_add(tests[i].name, tests[i].spec, tests[i].cmd);
+        CU_EXPECT_CYRFATAL_END(EX_CONFIG, tests[i].expect_fatal);
+    }
+}
+
+static void test_cronevent_add(void)
+{
+    const struct {
+        const char *name;
+        const char *cmd;
+        const char *spec;
+        int expect_exec_words;
+    } tests[] = {
+        /* examples from doc/examples/cyrus_conf/normal-master.conf */
+        { "delprune",       "cyr_expire -E 3",          "0 4 * * *",    3 },
+        { "deleteprune",    "cyr_expire -E 4 -D 28",    "30 4 * * *",   5 },
+        { "expungeprune",   "cyr_expire -E 4 -X 28",    "45 4 * * *",   5 },
+        { "tlsprune",       "tls_prune",                "0 4 * * *",    1 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    dynarray_t *schedule, *details;
+    int i;
+
+    cronevent_get_schedule(&schedule, &details);
+
+    for (i = 0; i < (int) n_tests; i++) {
+        struct cronevent_details *event_details;
+        struct cron_spec *event_spec, expect_spec = {0};
+        int r;
+
+        r = cron_parse_spec(tests[i].spec, &expect_spec, NULL);
+        CU_ASSERT_EQUAL(r, 0);
+
+        cronevent_add(tests[i].name, tests[i].spec, tests[i].cmd);
+        assert_schedule_invariants();
+
+        CU_ASSERT_EQUAL(dynarray_size(schedule), i + 1);
+        event_spec = dynarray_nth(schedule, i);
+        CU_ASSERT_PTR_NOT_NULL(event_spec);
+        CU_ASSERT_EQUAL(expect_spec.minutes, event_spec->minutes);
+        CU_ASSERT_EQUAL(expect_spec.hours, event_spec->hours);
+        CU_ASSERT_EQUAL(expect_spec.days_of_month, event_spec->days_of_month);
+        CU_ASSERT_EQUAL(expect_spec.months, event_spec->months);
+        CU_ASSERT_EQUAL(expect_spec.days_of_week, event_spec->days_of_week);
+
+        CU_ASSERT_EQUAL(dynarray_size(details), i + 1);
+        event_details = dynarray_nth(details, i);
+        CU_ASSERT_PTR_NOT_NULL(event_details);
+        CU_ASSERT_STRING_EQUAL(event_details->name, tests[i].name);
+        CU_ASSERT_EQUAL(strarray_size(&event_details->exec),
+                        tests[i].expect_exec_words);
+    }
+
+    cronevent_clear();
+    CU_ASSERT_EQUAL(dynarray_size(schedule), 0);
+    CU_ASSERT_EQUAL(dynarray_size(details), 0);
+}
+
+static void spawn_counter(const char *name,
+                          const strarray_t *exec __attribute__((unused)),
+                          void *rock)
+{
+    hash_table *ht = rock;
+    uintptr_t count;
+
+    count = (uintptr_t) hash_lookup(name, ht);
+    count++;
+    hash_insert(name, (void *) count, ht);
+}
+
+static void test_only_once_per_minute(void)
+{
+    const size_t n_tests = 100;
+    const time_t start_time = 1337; /* anything positive and non-zero */
+    hash_table spawn_counts = HASH_TABLE_INITIALIZER;
+    uintptr_t expect_spawned = 1;
+    time_t expect_last_run_time;
+    uintptr_t i;
+
+    construct_hash_table(&spawn_counts, 5, 1);
+
+    cronevent_add("my event", "* * * * *", "echo hello");
+    assert_schedule_invariants();
+
+    for (i = 0; i < n_tests; i++) {
+        uintptr_t actual_spawned;
+
+        expect_last_run_time = TIME_T_NOSEC(start_time + i);
+
+        if (i && (start_time + i) % 60 == 0)
+            expect_spawned ++;
+
+        cronevent_poll_due(TV_INIT(start_time + i, 0),
+                           &spawn_counter,
+                           &spawn_counts);
+
+        actual_spawned = (uintptr_t) hash_lookup("my event", &spawn_counts);
+        CU_ASSERT_EQUAL(actual_spawned, expect_spawned);
+        CU_ASSERT_EQUAL(cronevent_get_last_run_time(), expect_last_run_time);
+    }
+
+    free_hash_table(&spawn_counts, NULL);
+}
+
+static void test_fullday(void)
+{
+    const struct {
+        const char *name;
+        const char *spec_str;
+        uintptr_t expect_spawned;
+    } tests[] = {
+        { "5 past every hour",
+          "5 * * * *",
+          24 },
+        { "2pm every day",
+          "0 14 * * *",
+          1 },
+        { "2pm every wednesday",
+          "0 14 * * 3",
+          0 },
+        { "daily in july",
+          "0 3 * 7 *",
+          0 },
+        { "every three hours",
+          "0 */3 * * *",
+          8 },
+        { "midnight on tuesdays",
+          "0 0 * * 2",
+          0 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    const time_t start_time = 1754265600; /* UTC: 2025-08-04 00:00:00 (Mon) */
+    const time_t run_for = 24 * 60 * 60;
+    hash_table spawn_counts = HASH_TABLE_INITIALIZER;
+    unsigned i;
+    time_t t;
+
+    construct_hash_table(&spawn_counts, n_tests, 1);
+
+    for (i = 0; i < n_tests; i++) {
+        cronevent_add(tests[i].name, tests[i].spec_str, "echo hello");
+    }
+    assert_schedule_invariants();
+
+    push_tz(TZ_UTC);
+    for (t = 0; t < run_for; t++) {
+        cronevent_poll_due(TV_INIT(start_time + t, 0),
+                           &spawn_counter,
+                           &spawn_counts);
+    }
+    pop_tz();
+
+    for (i = 0; i < n_tests; i++) {
+        uintptr_t actual_spawned;
+
+        actual_spawned = (uintptr_t) hash_lookup(tests[i].name, &spawn_counts);
+        CU_ASSERT_EQUAL(actual_spawned, tests[i].expect_spawned);
+
+        hash_del(tests[i].name, &spawn_counts);
+    }
+
+    CU_ASSERT_EQUAL(hash_numrecords(&spawn_counts), 0);
+    free_hash_table(&spawn_counts, NULL);
+}
+
+/* vim: set ft=c: */

--- a/cunit/master-cronevent.testc
+++ b/cunit/master-cronevent.testc
@@ -82,9 +82,44 @@ static void test_cronevent_add_bad(void)
     volatile unsigned i;
 
     for (i = 0; i < n_tests; i++) {
+        CU_SYSLOG_MATCH(tests[i].expect_fatal);
         CU_EXPECT_CYRFATAL_BEGIN
-        cronevent_add(tests[i].name, tests[i].spec, tests[i].cmd);
+        cronevent_add(tests[i].name, tests[i].spec, tests[i].cmd, false);
         CU_EXPECT_CYRFATAL_END(EX_CONFIG, tests[i].expect_fatal);
+        CU_ASSERT_SYSLOG(/*all*/ 0, 1);
+    }
+}
+
+static void test_cronevent_add_bad_nonfatal(void)
+{
+    const struct {
+        const char *name;
+        const char *cmd;
+        const char *spec;
+        const char *expect_err;
+    } tests[] = {
+        { NULL,   NULL,  NULL,    "event missing name" },
+        { "",     NULL,  NULL,    "event missing name" },
+        { "name", NULL,  NULL,    "event missing cmd" },
+        { "name", "",    NULL,    "event missing cmd" },
+        { "name", "cmd", NULL,    "unable to parse cron spec" },
+        { "name", "cmd", "",      "unable to parse cron spec" },
+        { "name", "cmd", "bogus", "unable to parse cron spec" },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    dynarray_t *schedule, *details;
+    volatile unsigned i;
+
+    cronevent_get_schedule(&schedule, &details);
+
+    for (i = 0; i < n_tests; i++) {
+        CU_SYSLOG_MATCH(tests[i].expect_err);
+        cronevent_add(tests[i].name, tests[i].spec, tests[i].cmd, true);
+        CU_ASSERT_SYSLOG(/*all*/ 0, 1);
+
+        assert_schedule_invariants();
+        CU_ASSERT_EQUAL(dynarray_size(schedule), 0);
+        CU_ASSERT_EQUAL(dynarray_size(details), 0);
     }
 }
 
@@ -116,7 +151,7 @@ static void test_cronevent_add(void)
         r = cron_parse_spec(tests[i].spec, &expect_spec, NULL);
         CU_ASSERT_EQUAL(r, 0);
 
-        cronevent_add(tests[i].name, tests[i].spec, tests[i].cmd);
+        cronevent_add(tests[i].name, tests[i].spec, tests[i].cmd, false);
         assert_schedule_invariants();
 
         CU_ASSERT_EQUAL(dynarray_size(schedule), i + 1);
@@ -164,7 +199,7 @@ static void test_only_once_per_minute(void)
 
     construct_hash_table(&spawn_counts, 5, 1);
 
-    cronevent_add("my event", "* * * * *", "echo hello");
+    cronevent_add("my event", "* * * * *", "echo hello", false);
     assert_schedule_invariants();
 
     for (i = 0; i < n_tests; i++) {
@@ -223,7 +258,7 @@ static void test_fullday(void)
     construct_hash_table(&spawn_counts, n_tests, 1);
 
     for (i = 0; i < n_tests; i++) {
-        cronevent_add(tests[i].name, tests[i].spec_str, "echo hello");
+        cronevent_add(tests[i].name, tests[i].spec_str, "echo hello", false);
     }
     assert_schedule_invariants();
 

--- a/cunit/master-cronevent.testc
+++ b/cunit/master-cronevent.testc
@@ -176,6 +176,61 @@ static void test_cronevent_add(void)
     CU_ASSERT_EQUAL(dynarray_size(details), 0);
 }
 
+/* This test proves some current bad behaviour in cmd=".." parsing.
+ * If we fix the parser, we should move sane versions of these tests
+ * to test_cronevent_add above
+ */
+static void test_cronevent_add_broken_command(void)
+{
+    const struct {
+        const char *cmd;
+        unsigned expect_n_tokens;
+        const char *expect_tokens[10];
+    } tests[] = {
+        { "echo 'hello world'",
+          /* OOPS: breaks up quoted argument */
+          3, { "echo", "'hello", "world'" } },
+        { "echo \"hello world\"",
+          /* OOPS: breaks up quoted argument */
+          3, { "echo", "\"hello", "world\"" } },
+        { "sh -c 'echo \"hello world\"'",
+          /* OOPS: breaks up quoted argument */
+          5, { "sh", "-c", "'echo", "\"hello", "world\"'" } },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    dynarray_t *schedule, *details;
+    int i;
+
+    cronevent_get_schedule(&schedule, &details);
+
+    for (i = 0; i < (int) n_tests; i++) {
+        char name[16];
+        const char *spec = "* * * * *";
+        struct cronevent_details *event_details;
+        unsigned j;
+
+        snprintf(name, sizeof(name), "event %d", i);
+
+        cronevent_add(name, spec, tests[i].cmd, false);
+        assert_schedule_invariants();
+
+        event_details = dynarray_nth(details, i);
+        CU_ASSERT_PTR_NOT_NULL(event_details);
+        CU_ASSERT_STRING_EQUAL(event_details->name, name);
+        CU_ASSERT_EQUAL(strarray_size(&event_details->exec),
+                        tests[i].expect_n_tokens);
+
+        for (j = 0; j < tests[i].expect_n_tokens; j++) {
+            CU_ASSERT_STRING_EQUAL(strarray_nth(&event_details->exec, j),
+                                   tests[i].expect_tokens[j]);
+        }
+    }
+
+    cronevent_clear();
+    CU_ASSERT_EQUAL(dynarray_size(schedule), 0);
+    CU_ASSERT_EQUAL(dynarray_size(details), 0);
+}
+
 static void spawn_counter(const char *name,
                           const strarray_t *exec __attribute__((unused)),
                           void *rock)

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -28,9 +28,13 @@ static void assert_event_invariants(const struct event *evt,
     CU_ASSERT_PTR_NOT_NULL(evt->name);
     CU_ASSERT_STRING_NOT_EQUAL(evt->name, "");
 
-    /* if in a schedule, must have a mark */
     if (in_schedule) {
+        /* if in a schedule, must have a mark */
         CU_ASSERT_NOT_EQUAL(evt->mark.tv_sec, 0);
+    }
+    else {
+        /* otherwise, must not have a next pointer */
+        CU_ASSERT_PTR_NULL(evt->next);
     }
 
     /* if there's an exec it must have a command */
@@ -63,12 +67,13 @@ static void assert_schedule_invariants(const struct event *schedule)
     }
 }
 
-static void test_event_new(void)
+static void test_event_new_oneshot(void)
 {
     const struct {
         const char *name;
+        struct timeval mark;
     } tests[] = {
-        { "hello" },
+        { "hello", { 123, 456 } },
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;
@@ -76,20 +81,120 @@ static void test_event_new(void)
     for (i = 0; i < n_tests; i++) {
         struct event *evt;
 
-        evt = event_new(tests[i].name);
+        evt = event_new_oneshot(tests[i].name, tests[i].mark);
         CU_ASSERT_PTR_NOT_NULL(evt);
 
         /* expect the name to have been set */
         CU_ASSERT_PTR_NOT_NULL(evt->name);
         CU_ASSERT_STRING_EQUAL(evt->name, tests[i].name);
 
+        /* expect the mark to have been set */
+        CU_ASSERT_EQUAL(evt->mark.tv_sec, tests[i].mark.tv_sec);
+        CU_ASSERT_EQUAL(evt->mark.tv_usec, tests[i].mark.tv_usec);
+
         /* expect other fields to be zeroed */
-        CU_ASSERT_EQUAL(evt->mark.tv_sec, 0);
-        CU_ASSERT_EQUAL(evt->mark.tv_usec, 0);
         CU_ASSERT_EQUAL(evt->period, 0);
         CU_ASSERT_EQUAL(evt->hour, 0);
         CU_ASSERT_EQUAL(evt->min, 0);
         CU_ASSERT_EQUAL(evt->periodic, 0);
+        CU_ASSERT_PTR_NULL(evt->exec);
+        CU_ASSERT_PTR_NULL(evt->next);
+
+        /* belt and suspenders, check the invariants */
+        assert_event_invariants(evt, false);
+
+        event_free(evt);
+    }
+}
+
+static void test_event_new_periodic(void)
+{
+    const struct {
+        const char *name;
+        struct timeval mark;
+        time_t period;
+    } tests[] = {
+        { "hello", { 123, 456 }, 10 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct event *evt;
+
+        evt = event_new_periodic(tests[i].name, tests[i].mark, tests[i].period);
+        CU_ASSERT_PTR_NOT_NULL(evt);
+
+        /* expect the name to have been set */
+        CU_ASSERT_PTR_NOT_NULL(evt->name);
+        CU_ASSERT_STRING_EQUAL(evt->name, tests[i].name);
+
+        /* expect the mark to have been set */
+        CU_ASSERT_EQUAL(evt->mark.tv_sec, tests[i].mark.tv_sec);
+        CU_ASSERT_EQUAL(evt->mark.tv_usec, tests[i].mark.tv_usec);
+
+        /* expect the period to have been set */
+        CU_ASSERT_EQUAL(evt->periodic, 1);
+        CU_ASSERT_EQUAL(evt->period, tests[i].period);
+
+        /* expect other fields to be zeroed */
+        CU_ASSERT_EQUAL(evt->hour, 0);
+        CU_ASSERT_EQUAL(evt->min, 0);
+        CU_ASSERT_PTR_NULL(evt->exec);
+        CU_ASSERT_PTR_NULL(evt->next);
+
+        /* belt and suspenders, check the invariants */
+        assert_event_invariants(evt, false);
+
+        event_free(evt);
+    }
+}
+
+static void test_event_new_hourmin(void)
+{
+    const struct {
+        const char *name;
+        int hour;
+        int min;
+    } tests[] = {
+        { "good morning", 7, 30 },
+        { "good night",  22, 30 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct event *evt;
+        struct tm *tm;
+        struct timeval now;
+        double diff;
+
+        evt = event_new_hourmin(tests[i].name, tests[i].hour, tests[i].min);
+        CU_ASSERT_PTR_NOT_NULL(evt);
+
+        /* expect the name to have been set */
+        CU_ASSERT_PTR_NOT_NULL(evt->name);
+        CU_ASSERT_STRING_EQUAL(evt->name, tests[i].name);
+
+        /* expect the mark to have been set */
+        tm = localtime(&evt->mark.tv_sec);
+        CU_ASSERT_EQUAL(tm->tm_hour, tests[i].hour);
+        CU_ASSERT_EQUAL(tm->tm_min, tests[i].min);
+
+        /* expect the mark to be in the future */
+        gettimeofday(&now, NULL);
+        diff = timesub(&now, &evt->mark);
+        CU_ASSERT(diff >= 0.0);
+
+        /* expect the period to have been set */
+        CU_ASSERT_EQUAL(evt->periodic, 0);
+        CU_ASSERT_EQUAL(evt->period, 24 * 60 * 60);
+
+        /* expect the hour and minute to have been set */
+        CU_ASSERT_EQUAL(evt->hour, tests[i].hour);
+        CU_ASSERT_EQUAL(evt->min, tests[i].min);
+
+        /* expect other fields to be zeroed */
         CU_ASSERT_PTR_NULL(evt->exec);
         CU_ASSERT_PTR_NULL(evt->next);
 
@@ -135,14 +240,13 @@ static void test_schedule_event(void)
     unsigned i;
 
     for (i = 0; i < n_tests; i++) {
-        struct event *event;
         char name[64] = {0};
+        struct event *event;
 
         snprintf(name, sizeof(name), "event %u (" TIME_T_FMT ")",
                                      i, tests[i].mark_offset);
 
-        event = event_new(name);
-        event->mark.tv_sec = now + tests[i].mark_offset;
+        event = event_new_oneshot(name, TV_INIT(now + tests[i].mark_offset, 0));
 
         schedule_event(event);
     }
@@ -172,8 +276,7 @@ static void test_reschedule_event_bad(void)
         struct timeval mark = TV_INIT(tests[i].mark, 0);
         struct event *event;
 
-        event = event_new(tests[i].name);
-        event->mark = mark;
+        event = event_new_oneshot(tests[i].name, mark);
 
         CU_EXPECT_CYRFATAL_BEGIN
         reschedule_event(event, now);
@@ -208,10 +311,9 @@ static void test_reschedule_event(void)
         snprintf(name, sizeof(name), "event %u", i);
 
         /* XXX not testing at=hhmm events: they'll go away soon anyway */
-        event = event_new(name);
-        event->mark = TV_INIT(tests[i].mark, 0);
-        event->period = tests[i].period;
-        event->periodic = 1;
+        event = event_new_periodic(name,
+                                   TV_INIT(tests[i].mark, 0),
+                                   tests[i].period);
 
         reschedule_event(event, TV_INIT(tests[i].reschedule_at, 0));
         CU_ASSERT_PTR_NOT_NULL(schedule_peek());
@@ -230,19 +332,18 @@ static void test_schedule_splice_due(void)
     unsigned i;
 
     for (i = 0; i < n_events; i++) {
-        struct event *event;
         char name[64] = {0};
+        struct event *event;
 
         snprintf(name, sizeof(name), "event %u", i);
 
-        event = event_new(name);
-        event->mark.tv_sec = gap * i + now;
+        event = event_new_oneshot(name, TV_INIT(now + gap * i, 0));
         schedule_event(event);
     }
     assert_schedule_invariants(schedule_peek());
 
     mid = gap * i / 2 + now;
-    due = schedule_splice_due((struct timeval){ mid, 0 });
+    due = schedule_splice_due(TV_INIT(mid, 0));
 
     /* check that the spliced events are cogent */
 //     assert_schedule_invariants(due);

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -37,11 +37,6 @@ static void assert_event_invariants(const struct event *evt,
         CU_ASSERT_PTR_NULL(evt->next);
     }
 
-    /* if there's an exec it must have a command */
-    if (evt->exec) {
-        CU_ASSERT_NOT_EQUAL(strarray_size(evt->exec), 0);
-    }
-
     /* periodic events must have a period */
     if (evt->periodic) {
         CU_ASSERT_NOT_EQUAL(evt->period, 0);
@@ -97,7 +92,7 @@ static void test_event_new_oneshot(void)
         CU_ASSERT_EQUAL(evt->hour, 0);
         CU_ASSERT_EQUAL(evt->min, 0);
         CU_ASSERT_EQUAL(evt->periodic, 0);
-        CU_ASSERT_PTR_NULL(evt->exec);
+        CU_ASSERT_EQUAL(strarray_size(&evt->exec), 0);
         CU_ASSERT_PTR_NULL(evt->next);
 
         /* belt and suspenders, check the invariants */
@@ -140,7 +135,7 @@ static void test_event_new_periodic(void)
         /* expect other fields to be zeroed */
         CU_ASSERT_EQUAL(evt->hour, 0);
         CU_ASSERT_EQUAL(evt->min, 0);
-        CU_ASSERT_PTR_NULL(evt->exec);
+        CU_ASSERT_EQUAL(strarray_size(&evt->exec), 0);
         CU_ASSERT_PTR_NULL(evt->next);
 
         /* belt and suspenders, check the invariants */
@@ -195,7 +190,7 @@ static void test_event_new_hourmin(void)
         CU_ASSERT_EQUAL(evt->min, tests[i].min);
 
         /* expect other fields to be zeroed */
-        CU_ASSERT_PTR_NULL(evt->exec);
+        CU_ASSERT_EQUAL(strarray_size(&evt->exec), 0);
         CU_ASSERT_PTR_NULL(evt->next);
 
         /* belt and suspenders, check the invariants */
@@ -203,6 +198,34 @@ static void test_event_new_hourmin(void)
 
         event_free(evt);
     }
+}
+
+static void test_event_set_exec(void)
+{
+    const struct {
+        const char *cmd;
+        int expect_exec_count;
+    } tests[] = {
+        { NULL, 0 },
+        { "", 0 },
+        { "ctl_cyrusdb -c", 2 },
+        { "cyr_expire -E 3", 3 },
+        { "cyr_expire -E 4 -D 28", 5 },
+        { "cyr_expire -E 4 -X 28", 5 },
+        { "tls_prune", 1 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    struct event *event;
+    unsigned i;
+
+    event = event_new_oneshot("test event", TV_INIT(time(NULL) + 10, 0));
+
+    for (i = 0; i < n_tests; i++) {
+        event_set_exec(event, tests[i].cmd);
+        CU_ASSERT_EQUAL(tests[i].expect_exec_count, strarray_size(&event->exec));
+    }
+
+    event_free(event);
 }
 
 static void test_schedule_event_bad(void)

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -346,50 +346,104 @@ static void test_reschedule_event(void)
     }
 }
 
+static size_t count_events(const struct event *list)
+{
+    size_t counter = 0;
+
+    for (; list; list = list->next)
+        counter++;
+
+    return counter;
+}
+
 static void test_schedule_splice_due(void)
 {
-    const size_t n_events = 10;
-    const unsigned gap = 10; /* seconds */
-    time_t now = time(NULL), mid;
-    struct event *due, *schedule;
-    unsigned i;
+    const struct {
+        unsigned n_events;
+        unsigned event_times[10];
+        time_t splice_time;
+        unsigned expect_due;
+        unsigned expect_remainder;
+    } tests[] = {
+        { 10, { 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 },
+          50, 6, 4 },
+        { 10, { 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 },
+          45, 5, 5 },
+        { 10, { 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 },
+          90, 10, 0 },
+        { 10, { 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 },
+          100, 10, 0 },
+        { 1, { 10 },
+          0, 0, 1 },
+        { 1, { 10 },
+          5, 0, 1 },
+        { 1, { 10 },
+          10, 1, 0 },
+        { 1, { 10 },
+          20, 1, 0 },
+        { 0, { 0 },
+          50, 0, 0 },
+        { 0, { 0 },
+          0, 0, 0 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned t;
 
-    for (i = 0; i < n_events; i++) {
-        char name[64] = {0};
-        struct event *event;
+    for (t = 0; t < n_tests; t++) {
+        const time_t now = time(NULL);
+        const time_t splice_time = now + tests[t].splice_time;
+        struct event *due;
+        unsigned e;
 
-        snprintf(name, sizeof(name), "event %u", i);
+        for (e = 0; e < tests[t].n_events; e++) {
+            char name[64] = {0};
+            struct event *event;
+            time_t event_time = now + tests[t].event_times[e];
 
-        event = event_new_oneshot(name, TV_INIT(now + gap * i, 0));
-        schedule_event(event);
+            snprintf(name, sizeof(name), "event %u", e);
+
+            event = event_new_oneshot(name, TV_INIT(event_time, 0));
+            schedule_event(event);
+        }
+        assert_schedule_invariants(schedule_peek());
+
+        due = schedule_splice_due(TV_INIT(splice_time, 0));
+
+        /* check that the spliced events are cogent */
+        if (tests[t].expect_due) {
+            CU_ASSERT_PTR_NOT_NULL(due);
+            assert_schedule_invariants(due);
+            CU_ASSERT_EQUAL(count_events(due), tests[t].expect_due);
+
+            /* don't forget to free the due list! */
+            while (due) {
+                struct event *next;
+
+                CU_ASSERT(due->mark.tv_sec <= splice_time);
+
+                next = due->next;
+                event_free(due);
+                due = next;
+            }
+        }
+        else {
+            CU_ASSERT_PTR_NULL(due);
+        }
+
+        /* check that the remaining schedule is still cogent */
+        if (tests[t].expect_remainder) {
+            struct event *schedule = schedule_peek();
+            CU_ASSERT_PTR_NOT_NULL(schedule);
+            assert_schedule_invariants(schedule);
+            CU_ASSERT_EQUAL(count_events(schedule), tests[t].expect_remainder);
+            CU_ASSERT(schedule->mark.tv_sec > splice_time);
+        }
+        else {
+            CU_ASSERT_PTR_NULL(schedule_peek());
+        }
+
+        schedule_clear();
     }
-    assert_schedule_invariants(schedule_peek());
-
-    mid = gap * i / 2 + now;
-    due = schedule_splice_due(TV_INIT(mid, 0));
-
-    /* check that the spliced events are cogent */
-//     assert_schedule_invariants(due);
-    CU_ASSERT_PTR_NOT_NULL(due);
-    while (due) {
-        struct event *next;
-
-        /* XXX spliced events currently have their order reversed,
-         * XXX so we can't just use assert_schedule_invariants here
-         */
-        assert_event_invariants(due, true);
-        CU_ASSERT(due->mark.tv_sec <= mid);
-
-        next = due->next;
-        event_free(due);
-        due = next;
-    }
-
-    /* check that the remaining schedule is still cogent */
-    schedule = schedule_peek();
-    assert_schedule_invariants(schedule);
-    CU_ASSERT_PTR_NOT_NULL(schedule);
-    CU_ASSERT(schedule->mark.tv_sec > mid);
 }
 
 /* vim: set ft=c: */

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -164,6 +164,49 @@ static void test_event_set_exec(void)
     event_free(event);
 }
 
+/* This test proves some current bad behaviour in cmd=".." parsing.
+ * If we fix the parser, we should move sane versions of these tests
+ * to test_event_set_exec above
+ */
+static void test_event_set_exec_broken_cmd(void)
+{
+    const struct {
+        const char *cmd;
+        unsigned expect_n_tokens;
+        const char *expect_tokens[10];
+    } tests[] = {
+        { "echo 'hello world'",
+          /* OOPS: breaks up quoted argument */
+          3, { "echo", "'hello", "world'" } },
+        { "echo \"hello world\"",
+          /* OOPS: breaks up quoted argument */
+          3, { "echo", "\"hello", "world\"" } },
+        { "sh -c 'echo \"hello world\"'",
+          /* OOPS: breaks up quoted argument */
+          5, { "sh", "-c", "'echo", "\"hello", "world\"'" } },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    struct event *event;
+    unsigned i;
+
+    event = event_new_oneshot("test event", TV_INIT(time(NULL) + 10, 0));
+
+    for (i = 0; i < n_tests; i++) {
+        unsigned j;
+
+        event_set_exec(event, tests[i].cmd);
+        CU_ASSERT_EQUAL(tests[i].expect_n_tokens,
+                        (unsigned) strarray_size(&event->exec));
+
+        for (j = 0; j < tests[i].expect_n_tokens; j++) {
+            CU_ASSERT_STRING_EQUAL(tests[i].expect_tokens[j],
+                                   strarray_nth(&event->exec, j));
+        }
+    }
+
+    event_free(event);
+}
+
 static void test_schedule_event_bad(void)
 {
     struct event evt = { 0 }; /* no name */

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -319,10 +319,14 @@ static void test_reschedule_event(void)
         time_t reschedule_at;
         time_t expect_mark;
     } tests[] = {
+        { 1000, 10,  905,  915 }, /* shouldn't happen, but don't break! */
         { 1000, 10, 1000, 1010 },
-        { 1000, 10, 1001, 1011 },
-        { 1000, 10, 1002, 1012 },
-        { 1000, 10, 1003, 1013 },
+        { 1000, 10, 1001, 1010 },
+        { 1000, 10, 1002, 1010 },
+        { 1000, 10, 1003, 1010 },
+        { 1000, 10, 1009, 1010 },
+        { 1000, 10, 1010, 1020 },
+        { 1000, 10, 1011, 1020 },
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -1,0 +1,271 @@
+#include "cunit/unit.h"
+#include "master/event.h"
+
+#include "lib/strarray.h"
+#include "lib/util.h"
+
+#include <stdbool.h>
+#include <sysexits.h>
+#include <time.h>
+
+#define TV_INIT(s, u) (struct timeval){ .tv_sec = (s), .tv_usec = (u) }
+
+static int set_up(void)
+{
+    return 0;
+}
+
+static int tear_down(void)
+{
+    schedule_clear();
+    return 0;
+}
+
+static void assert_event_invariants(const struct event *evt,
+                                    bool in_schedule)
+{
+    /* must have a name */
+    CU_ASSERT_PTR_NOT_NULL(evt->name);
+    CU_ASSERT_STRING_NOT_EQUAL(evt->name, "");
+
+    /* if in a schedule, must have a mark */
+    if (in_schedule) {
+        CU_ASSERT_NOT_EQUAL(evt->mark.tv_sec, 0);
+    }
+
+    /* if there's an exec it must have a command */
+    if (evt->exec) {
+        CU_ASSERT_NOT_EQUAL(strarray_size(evt->exec), 0);
+    }
+
+    /* periodic events must have a period */
+    if (evt->periodic) {
+        CU_ASSERT_NOT_EQUAL(evt->period, 0);
+    }
+
+    /* "at hh:mm" times must be within range */
+    CU_ASSERT(evt->hour >= 0 && evt->hour <= 23);
+    CU_ASSERT(evt->min >= 0 && evt->min <= 59);
+}
+
+static void assert_schedule_invariants(const struct event *schedule)
+{
+    while (schedule) {
+        assert_event_invariants(schedule, true);
+
+        if (schedule->next) {
+            /* not later than next event */
+            double diff = timesub(&schedule->mark, &schedule->next->mark);
+            CU_ASSERT(diff >= 0.0);
+        }
+
+        schedule = schedule->next;
+    }
+}
+
+static void test_event_new(void)
+{
+    const struct {
+        const char *name;
+    } tests[] = {
+        { "hello" },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct event *evt;
+
+        evt = event_new(tests[i].name);
+        CU_ASSERT_PTR_NOT_NULL(evt);
+
+        /* expect the name to have been set */
+        CU_ASSERT_PTR_NOT_NULL(evt->name);
+        CU_ASSERT_STRING_EQUAL(evt->name, tests[i].name);
+
+        /* expect other fields to be zeroed */
+        CU_ASSERT_EQUAL(evt->mark.tv_sec, 0);
+        CU_ASSERT_EQUAL(evt->mark.tv_usec, 0);
+        CU_ASSERT_EQUAL(evt->period, 0);
+        CU_ASSERT_EQUAL(evt->hour, 0);
+        CU_ASSERT_EQUAL(evt->min, 0);
+        CU_ASSERT_EQUAL(evt->periodic, 0);
+        CU_ASSERT_PTR_NULL(evt->exec);
+        CU_ASSERT_PTR_NULL(evt->next);
+
+        /* belt and suspenders, check the invariants */
+        assert_event_invariants(evt, false);
+
+        event_free(evt);
+    }
+}
+
+static void test_schedule_event_bad(void)
+{
+    struct event evt = { 0 }; /* no name */
+
+    CU_EXPECT_CYRFATAL_BEGIN
+    schedule_event(&evt);
+    CU_EXPECT_CYRFATAL_END(EX_SOFTWARE,
+                           "Serious software bug found: schedule_event()"
+                           " called on unnamed event!");
+
+    CU_ASSERT_PTR_NULL(schedule_peek());
+}
+
+static void test_schedule_event(void)
+{
+    const struct {
+        time_t mark_offset;
+    } tests[] = {
+        /* out of order! */
+        { 59 },
+        { 54 },
+        { 27 },
+        { 36 },
+        { 33 },
+        { 96 },
+        { 66 },
+        { 18 },
+        { 60 },
+        { 26 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    time_t now = time(NULL);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct event *event;
+        char name[64] = {0};
+
+        snprintf(name, sizeof(name), "event %u (" TIME_T_FMT ")",
+                                     i, tests[i].mark_offset);
+
+        event = event_new(name);
+        event->mark.tv_sec = now + tests[i].mark_offset;
+
+        schedule_event(event);
+    }
+
+    CU_ASSERT_PTR_NOT_NULL(schedule_peek());
+    assert_schedule_invariants(schedule_peek());
+}
+
+static void test_reschedule_event_bad(void)
+{
+    const struct {
+        const char *name;
+        time_t mark;
+        int expect_code;
+        const char *expect_msg;
+    } tests[] = {
+        { "no period",
+          time(NULL) + 10,
+          EX_SOFTWARE,
+          NULL },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    volatile unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        struct timeval now = TV_INIT(time(NULL), 0);
+        struct timeval mark = TV_INIT(tests[i].mark, 0);
+        struct event *event;
+
+        event = event_new(tests[i].name);
+        event->mark = mark;
+
+        CU_EXPECT_CYRFATAL_BEGIN
+        reschedule_event(event, now);
+        CU_EXPECT_CYRFATAL_END(tests[i].expect_code, tests[i].expect_msg);
+
+        event_free(event);
+    }
+
+    CU_ASSERT_PTR_NULL(schedule_peek());
+}
+
+static void test_reschedule_event(void)
+{
+    const struct {
+        time_t mark;
+        time_t period;
+        time_t reschedule_at;
+        time_t expect_mark;
+    } tests[] = {
+        { 1000, 10, 1000, 1010 },
+        { 1000, 10, 1001, 1011 },
+        { 1000, 10, 1002, 1012 },
+        { 1000, 10, 1003, 1013 },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        char name[64];
+        struct event *event;
+
+        snprintf(name, sizeof(name), "event %u", i);
+
+        /* XXX not testing at=hhmm events: they'll go away soon anyway */
+        event = event_new(name);
+        event->mark = TV_INIT(tests[i].mark, 0);
+        event->period = tests[i].period;
+        event->periodic = 1;
+
+        reschedule_event(event, TV_INIT(tests[i].reschedule_at, 0));
+        CU_ASSERT_PTR_NOT_NULL(schedule_peek());
+        assert_schedule_invariants(schedule_peek());
+
+        CU_ASSERT_EQUAL(event->mark.tv_sec, tests[i].expect_mark);
+    }
+}
+
+static void test_schedule_splice_due(void)
+{
+    const size_t n_events = 10;
+    const unsigned gap = 10; /* seconds */
+    time_t now = time(NULL), mid;
+    struct event *due, *schedule;
+    unsigned i;
+
+    for (i = 0; i < n_events; i++) {
+        struct event *event;
+        char name[64] = {0};
+
+        snprintf(name, sizeof(name), "event %u", i);
+
+        event = event_new(name);
+        event->mark.tv_sec = gap * i + now;
+        schedule_event(event);
+    }
+    assert_schedule_invariants(schedule_peek());
+
+    mid = gap * i / 2 + now;
+    due = schedule_splice_due((struct timeval){ mid, 0 });
+
+    /* check that the spliced events are cogent */
+//     assert_schedule_invariants(due);
+    CU_ASSERT_PTR_NOT_NULL(due);
+    while (due) {
+        struct event *next;
+
+        /* XXX spliced events currently have their order reversed,
+         * XXX so we can't just use assert_schedule_invariants here
+         */
+        assert_event_invariants(due, true);
+        CU_ASSERT(due->mark.tv_sec <= mid);
+
+        next = due->next;
+        event_free(due);
+        due = next;
+    }
+
+    /* check that the remaining schedule is still cogent */
+    schedule = schedule_peek();
+    assert_schedule_invariants(schedule);
+    CU_ASSERT_PTR_NOT_NULL(schedule);
+    CU_ASSERT(schedule->mark.tv_sec > mid);
+}
+
+/* vim: set ft=c: */

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -37,14 +37,10 @@ static void assert_event_invariants(const struct event *evt,
         CU_ASSERT_PTR_NULL(evt->next);
     }
 
-    /* periodic events must have a period */
-    if (evt->periodic) {
-        CU_ASSERT_NOT_EQUAL(evt->period, 0);
+    /* period must be zero or positive */
+    if (evt->period) {
+        CU_ASSERT(evt->period > 0);
     }
-
-    /* "at hh:mm" times must be within range */
-    CU_ASSERT(evt->hour >= 0 && evt->hour <= 23);
-    CU_ASSERT(evt->min >= 0 && evt->min <= 59);
 }
 
 static void assert_schedule_invariants(const struct event *schedule)
@@ -89,9 +85,6 @@ static void test_event_new_oneshot(void)
 
         /* expect other fields to be zeroed */
         CU_ASSERT_EQUAL(evt->period, 0);
-        CU_ASSERT_EQUAL(evt->hour, 0);
-        CU_ASSERT_EQUAL(evt->min, 0);
-        CU_ASSERT_EQUAL(evt->periodic, 0);
         CU_ASSERT_EQUAL(strarray_size(&evt->exec), 0);
         CU_ASSERT_PTR_NULL(evt->next);
 
@@ -129,65 +122,7 @@ static void test_event_new_periodic(void)
         CU_ASSERT_EQUAL(evt->mark.tv_usec, tests[i].mark.tv_usec);
 
         /* expect the period to have been set */
-        CU_ASSERT_EQUAL(evt->periodic, 1);
         CU_ASSERT_EQUAL(evt->period, tests[i].period);
-
-        /* expect other fields to be zeroed */
-        CU_ASSERT_EQUAL(evt->hour, 0);
-        CU_ASSERT_EQUAL(evt->min, 0);
-        CU_ASSERT_EQUAL(strarray_size(&evt->exec), 0);
-        CU_ASSERT_PTR_NULL(evt->next);
-
-        /* belt and suspenders, check the invariants */
-        assert_event_invariants(evt, false);
-
-        event_free(evt);
-    }
-}
-
-static void test_event_new_hourmin(void)
-{
-    const struct {
-        const char *name;
-        int hour;
-        int min;
-    } tests[] = {
-        { "good morning", 7, 30 },
-        { "good night",  22, 30 },
-    };
-    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
-    unsigned i;
-
-    for (i = 0; i < n_tests; i++) {
-        struct event *evt;
-        struct tm *tm;
-        struct timeval now;
-        double diff;
-
-        evt = event_new_hourmin(tests[i].name, tests[i].hour, tests[i].min);
-        CU_ASSERT_PTR_NOT_NULL(evt);
-
-        /* expect the name to have been set */
-        CU_ASSERT_PTR_NOT_NULL(evt->name);
-        CU_ASSERT_STRING_EQUAL(evt->name, tests[i].name);
-
-        /* expect the mark to have been set */
-        tm = localtime(&evt->mark.tv_sec);
-        CU_ASSERT_EQUAL(tm->tm_hour, tests[i].hour);
-        CU_ASSERT_EQUAL(tm->tm_min, tests[i].min);
-
-        /* expect the mark to be in the future */
-        gettimeofday(&now, NULL);
-        diff = timesub(&now, &evt->mark);
-        CU_ASSERT(diff >= 0.0);
-
-        /* expect the period to have been set */
-        CU_ASSERT_EQUAL(evt->periodic, 0);
-        CU_ASSERT_EQUAL(evt->period, 24 * 60 * 60);
-
-        /* expect the hour and minute to have been set */
-        CU_ASSERT_EQUAL(evt->hour, tests[i].hour);
-        CU_ASSERT_EQUAL(evt->min, tests[i].min);
 
         /* expect other fields to be zeroed */
         CU_ASSERT_EQUAL(strarray_size(&evt->exec), 0);
@@ -222,7 +157,8 @@ static void test_event_set_exec(void)
 
     for (i = 0; i < n_tests; i++) {
         event_set_exec(event, tests[i].cmd);
-        CU_ASSERT_EQUAL(tests[i].expect_exec_count, strarray_size(&event->exec));
+        CU_ASSERT_EQUAL(tests[i].expect_exec_count,
+                        strarray_size(&event->exec));
     }
 
     event_free(event);
@@ -269,7 +205,8 @@ static void test_schedule_event(void)
         snprintf(name, sizeof(name), "event %u (" TIME_T_FMT ")",
                                      i, tests[i].mark_offset);
 
-        event = event_new_oneshot(name, TV_INIT(now + tests[i].mark_offset, 0));
+        event = event_new_oneshot(name,
+                                  TV_INIT(now + tests[i].mark_offset, 0));
 
         schedule_event(event);
     }
@@ -337,7 +274,6 @@ static void test_reschedule_event(void)
 
         snprintf(name, sizeof(name), "event %u", i);
 
-        /* XXX not testing at=hhmm events: they'll go away soon anyway */
         event = event_new_periodic(name,
                                    TV_INIT(tests[i].mark, 0),
                                    tests[i].period);

--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -298,24 +298,32 @@ static void test_reschedule_event(void)
         time_t period;
         time_t reschedule_at;
         time_t expect_mark;
+        unsigned expect_skipped;
     } tests[] = {
-        { 1000, 10,  905,  915 }, /* shouldn't happen, but don't break! */
-        { 1000, 10, 1000, 1010 },
-        { 1000, 10, 1001, 1010 },
-        { 1000, 10, 1002, 1010 },
-        { 1000, 10, 1003, 1010 },
-        { 1000, 10, 1009, 1010 },
-        { 1000, 10, 1010, 1020 },
-        { 1000, 10, 1011, 1020 },
+        { 1000, 10,  905,  915, 0 }, /* shouldn't happen, but don't break! */
+        { 1000, 10, 1000, 1010, 0 },
+        { 1000, 10, 1001, 1010, 0 },
+        { 1000, 10, 1002, 1010, 0 },
+        { 1000, 10, 1003, 1010, 0 },
+        { 1000, 10, 1009, 1010, 0 },
+        { 1000, 10, 1010, 1020, 1 },
+        { 1000, 10, 1011, 1020, 1 },
+        { 1000, 10, 1028, 1030, 2 },
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;
 
     for (i = 0; i < n_tests; i++) {
-        char name[64];
+        char name[32];
+        char skipped[32];
         struct event *event;
 
         snprintf(name, sizeof(name), "event %u", i);
+
+        snprintf(skipped, sizeof(skipped),
+                 "skipped=<%u>",
+                 tests[i].expect_skipped);
+        CU_SYSLOG_MATCH(skipped);
 
         event = event_new_periodic(name,
                                    TV_INIT(tests[i].mark, 0),
@@ -326,6 +334,7 @@ static void test_reschedule_event(void)
         assert_schedule_invariants(schedule_peek());
 
         CU_ASSERT_EQUAL(event->mark.tv_sec, tests[i].expect_mark);
+        CU_ASSERT_SYSLOG(/* all */ 0, !!tests[i].expect_skipped);
     }
 }
 

--- a/cunit/unit-timezones.h
+++ b/cunit/unit-timezones.h
@@ -48,7 +48,7 @@
 
 #define TZ_UTC          "UTC+00"
 #define TZ_NEWYORK      "EST+05"
-#define TZ_MELBOURNE    "AEST-11"
+#define TZ_MELBOURNE    "AEST-11" /* XXX 11 is AEDT not AEST... */
 
 extern void push_tz(const char *tz);
 extern void pop_tz(void);

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -95,7 +95,7 @@ int fatal_code;
 EXPORTED void fatal(const char *s, int code)
 {
     if (fatal_expected) {
-        if (verbose) {
+        if (verbose > 1) {
             log1("fatal(%s)", s);
         }
         fatal_expected = 0;

--- a/cunit/unit.h
+++ b/cunit/unit.h
@@ -203,7 +203,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     CU_assertFormatImplementation(!!strcmp(_a?_a:"",_e?_e:""),          \
         __LINE__, __FILE__, "", CU_FALSE,                               \
         "CU_ASSERT_STRING_NOT_EQUAL(%s=\"%s\",%s=\"%s\")",              \
-        #actual, _a, #expected, _e);                                    \
+        #actual, _a ? _a : "(null)",                                    \
+        #expected, _e ? _e : "(null)");                                 \
 } while(0)
 
 #undef CU_ASSERT_STRING_NOT_EQUAL_FATAL
@@ -212,7 +213,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     CU_assertFormatImplementation(!!strcmp(_a?_a:"",_e?_e:""),          \
         __LINE__, __FILE__, "", CU_TRUE,                                \
         "CU_ASSERT_STRING_NOT_EQUAL_FATAL(%s=\"%s\",%s=\"%s\")",        \
-        #actual, _a, #expected, _e);                                    \
+        #actual, _a ? _a : "(null)",                                    \
+        #expected, _e ? _e : "(null)");                                 \
 } while(0)
 
 #define CU_SYSLOG_MATCH(re) \

--- a/doc/examples/cyrus_conf/cmu-backend.conf
+++ b/doc/examples/cyrus_conf/cmu-backend.conf
@@ -34,14 +34,14 @@ EVENTS {
   checkpoint    cmd="ctl_cyrusdb -c" period=5
 
   # this is only necessary if using duplicate delivery suppression
-  delprune      cmd="ctl_deliver -E 3" at=0400
+  delprune      cmd="ctl_deliver -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 
   reauth        cmd="/usr/local/bin/ksrvtgt -l 3600 imap @SHORTHOST@ ANDREW.CMU.EDU /imap/conf/srvtab"  period=30
 }

--- a/doc/examples/cyrus_conf/murder-backend.conf
+++ b/doc/examples/cyrus_conf/murder-backend.conf
@@ -41,14 +41,14 @@ EVENTS {
 
   # this is only necessary if using duplicate delivery suppression,
   # Sieve or NNTP
-  delprune      cmd="cyr_expire -E 3" at=0400
+  delprune      cmd="cyr_expire -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune   cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune  cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/murder-frontend.conf
+++ b/doc/examples/cyrus_conf/murder-frontend.conf
@@ -41,14 +41,14 @@ EVENTS {
 
   # this is only necessary if using duplicate delivery suppression,
   # Sieve or NNTP
-  delprune      cmd="cyr_expire -E 3" at=0400
+  delprune      cmd="cyr_expire -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune   cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune  cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/normal-master.conf
+++ b/doc/examples/cyrus_conf/normal-master.conf
@@ -44,14 +44,14 @@ EVENTS {
 
   # this is only necessary if using duplicate delivery suppression,
   # Sieve or NNTP
-  delprune      cmd="cyr_expire -E 3" at=0400
+  delprune      cmd="cyr_expire -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune   cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune  cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/normal-replica.conf
+++ b/doc/examples/cyrus_conf/normal-replica.conf
@@ -44,14 +44,14 @@ EVENTS {
 
   # this is only necessary if using duplicate delivery suppression,
   # Sieve or NNTP
-  delprune      cmd="cyr_expire -E 3" at=0400
+  delprune      cmd="cyr_expire -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune   cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune  cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/normal.conf
+++ b/doc/examples/cyrus_conf/normal.conf
@@ -36,17 +36,25 @@ SERVICES {
 EVENTS {
   # this is required
   checkpoint    cmd="ctl_cyrusdb -c" period=30
+  # which could also be written like this:
+#   checkpoint    cmd="ctl_cyrusdb -c" cron="0,30 * * * *"
+  # or this:
+#   checkpoint    cmd="ctl_cyrusdb -c" cron="*/30 * * * *"
+  # the difference being that with a cron specification, it will run at exactly
+  # those minutes, regardless of when master started, whereas with a period
+  # specification it will run every 30 minutes from when master started,
+  # regardless of the clock time
 
   # this is only necessary if using duplicate delivery suppression,
   # Sieve or NNTP
-  delprune      cmd="cyr_expire -E 3" at=0400
+  delprune      cmd="cyr_expire -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune   cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune  cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/prefork.conf
+++ b/doc/examples/cyrus_conf/prefork.conf
@@ -39,14 +39,14 @@ EVENTS {
 
   # this is only necessary if using duplicate delivery suppression,
   # Sieve or NNTP
-  delprune      cmd="cyr_expire -E 3" at=0400
+  delprune      cmd="cyr_expire -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune   cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune  cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 }
 
 DAEMON {

--- a/doc/examples/cyrus_conf/small.conf
+++ b/doc/examples/cyrus_conf/small.conf
@@ -23,14 +23,14 @@ EVENTS {
   checkpoint    cmd="ctl_cyrusdb -c" period=30
 
   # this is only necessary if using duplicate delivery suppression
-  delprune      cmd="cyr_expire -E 3" at=0400
+  delprune      cmd="cyr_expire -E 3" cron="00 04 * * *"
 
   # Expire data older than 28 days.
-  deleteprune   cmd="cyr_expire -E 4 -D 28" at=0430
-  expungeprune  cmd="cyr_expire -E 4 -X 28" at=0445
+  deleteprune   cmd="cyr_expire -E 4 -D 28" cron="30 04 * * *"
+  expungeprune  cmd="cyr_expire -E 4 -X 28" cron="45 04 * * *"
 
   # this is only necessary if caching TLS sessions
-  tlsprune      cmd="tls_prune" at=0400
+  tlsprune      cmd="tls_prune" cron="00 04 * * *"
 }
 
 DAEMON {

--- a/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
+++ b/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
@@ -225,19 +225,35 @@ scheduled cleanup/maintenance.
 
 ..
 
-        The interval (in minutes) at which to run the command.  This
-        integer value is optional, but SHOULD be a positive integer >
-        10.
+        The integer interval (in minutes) at which to run the command.
+
+        Intervals are counted starting from when :cyrusman:`master(8)` was
+        started, they are not aligned to any particular clock time.
+
+        This is optional, but one of **period** or **cron** must be specified.
 
 .. parsed-literal::
 
-    **at=**\ <hhmm>
+    **cron=**\ "min hr dom mon dow"
+
+..
+
+        A string containing five space-delimited fields describing the minutes,
+        hours, days-of-month, months, and days-of-week that this command should
+        run, just like :manpage:`crontab(5)`.  The usual cron features are
+        supported: asterisks, ranges, lists, step values, named months
+        (jan-dec), and named days of the week (sun-sat).
+
+        This is optional, but one of **period** or **cron** must be specified.
+
+.. parsed-literal::
+
+    **at=**\ hhmm
 
 ..
 
         The time (24-hour format) at which to run the command each day.
-        If set to a valid time (0000-2359), period is automatically
-        set to 1440. This string argument is optional.
+        This is an alias for ``cron="mm hh * * *"``.
 
 DAEMON
 ------
@@ -320,8 +336,8 @@ Examples
 
     EVENTS {
         checkpoint    cmd="ctl_cyrusdb -c" period=30
-        delprune      cmd="cyr_expire -E 3" at=0400
-        tlsprune      cmd="tls_prune" at=0400
+        delprune      cmd="cyr_expire -E 3" cron="0 4 * * *"
+        tlsprune      cmd="tls_prune" cron="0 4 * * *"
     }
 
     DAEMON {
@@ -353,4 +369,5 @@ See Also
 :cyrusman:`ctl_cyrusdb(8)`,
 :cyrusman:`ctl_deliver(8)`,
 :cyrusman:`tls_prune(8)`,
+:manpage:`crontab(5)`,
 :manpage:`hosts_access(5)`

--- a/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
+++ b/docsrc/imap/reference/manpages/configs/cyrus.conf.rst
@@ -219,6 +219,11 @@ scheduled cleanup/maintenance.
         The command (with options) to spawn as a child process.  This
         string argument is required.
 
+        Note that this argument is parsed quite naively: arguments are
+        split on whitespace, quoting is not supported.  If you need to run
+        a complex command, make a shell script that calls the real command,
+        and set the event to run the script.
+
 .. parsed-literal::
 
     **period=**\ 0

--- a/lib/cron-lex.l
+++ b/lib/cron-lex.l
@@ -1,0 +1,29 @@
+%option prefix="cron" outfile="lex.yy.c"
+%option noinput nounput noyywrap
+
+%{
+#include "lib/cron-parse.h"
+
+#include <errno.h>
+#include <stdint.h>
+%}
+
+%%
+
+ /* XXX named months/days of week */
+
+[[:digit:]]+ {
+    unsigned long u;
+
+    errno = 0;
+    u = strtoul(yytext, NULL, 10);
+
+    if (errno) {
+        /* XXX ?? */
+    }
+
+    cronlval = u;
+    return NUM;
+}
+
+. { return *yytext; }

--- a/lib/cron-lex.l
+++ b/lib/cron-lex.l
@@ -1,7 +1,9 @@
 %option prefix="cron" outfile="lex.yy.c"
 %option noinput nounput noyywrap
+%option case-insensitive
 
 %{
+#include "lib/cron.h"
 #include "lib/cron-parse.h"
 
 #include <errno.h>
@@ -9,8 +11,6 @@
 %}
 
 %%
-
- /* XXX named months/days of week */
 
 [[:digit:]]+ {
     unsigned long u;
@@ -25,5 +25,28 @@
     cronlval = u;
     return NUM;
 }
+
+[[:blank:]]+ { return SP; }
+
+sun { cronlval = UINT64_C(1) << 0; return NAMED_WEEKDAY; }
+mon { cronlval = UINT64_C(1) << 1; return NAMED_WEEKDAY; }
+tue { cronlval = UINT64_C(1) << 2; return NAMED_WEEKDAY; }
+wed { cronlval = UINT64_C(1) << 3; return NAMED_WEEKDAY; }
+thu { cronlval = UINT64_C(1) << 4; return NAMED_WEEKDAY; }
+fri { cronlval = UINT64_C(1) << 5; return NAMED_WEEKDAY; }
+sat { cronlval = UINT64_C(1) << 6; return NAMED_WEEKDAY; }
+
+jan { cronlval = UINT64_C(1) <<  1; return NAMED_MONTH; }
+feb { cronlval = UINT64_C(1) <<  2; return NAMED_MONTH; }
+mar { cronlval = UINT64_C(1) <<  3; return NAMED_MONTH; }
+apr { cronlval = UINT64_C(1) <<  4; return NAMED_MONTH; }
+may { cronlval = UINT64_C(1) <<  5; return NAMED_MONTH; }
+jun { cronlval = UINT64_C(1) <<  6; return NAMED_MONTH; }
+jul { cronlval = UINT64_C(1) <<  7; return NAMED_MONTH; }
+aug { cronlval = UINT64_C(1) <<  8; return NAMED_MONTH; }
+sep { cronlval = UINT64_C(1) <<  9; return NAMED_MONTH; }
+oct { cronlval = UINT64_C(1) << 10; return NAMED_MONTH; }
+nov { cronlval = UINT64_C(1) << 11; return NAMED_MONTH; }
+dec { cronlval = UINT64_C(1) << 12; return NAMED_MONTH; }
 
 . { return *yytext; }

--- a/lib/cron-parse.y
+++ b/lib/cron-parse.y
@@ -1,0 +1,97 @@
+%{
+#include <config.h>
+
+#include "lib/xmalloc.h" /* XXX only for fatal */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <string.h>
+#include <sysexits.h>
+
+#define BIT(n) (UINT64_C(1) << (n))
+
+#define CRONSTYPE uint64_t
+
+static void yyerror(uint64_t *, const char *);
+
+extern int yylex(void);
+extern struct yy_buffer_state *cron_scan_bytes(const char *bytes, int len);
+extern void cron_delete_buffer(struct yy_buffer_state *b);
+%}
+
+%define api.prefix {cron}
+%parse-param { uint64_t *result }
+%token NUM
+
+%%
+
+start : datetime YYEOF {
+    *result = $$ = $1;
+};
+
+datetime : list; /* XXX also accept month, weekday names here */
+
+list : range;
+
+list : list ',' range {
+    $$ = $1 | $3;
+};
+
+range : '*' {
+    $$ = UINT64_MAX;
+};
+
+range : NUM '-' NUM {
+    $$ = 0;
+    unsigned i;
+    assert($1 <= $3);
+    assert($1 < 64);
+    assert($3 < 64);
+    for (i = $1; i <= $3; i++) {
+        $$ |= BIT(i);
+    }
+};
+
+range : NUM { $$ = BIT($1); };
+
+range : range '/' NUM {
+    unsigned i;
+
+    for (i = 0; i < 64; i++) {
+        if ((i % $3) == 0) continue;
+        $$ &= ~BIT(i);
+    }
+}
+
+%%
+
+static void yyerror(uint64_t *result, const char *err)
+{
+    fprintf(stderr, "%s: result=<%" PRIu64 "> err=<%s>\n",
+                    __func__, *result, err);
+}
+
+EXPORTED int cron_parse_datetime(const char *datetime, unsigned max_value,
+                                 uint64_t *presult)
+{
+    struct yy_buffer_state *state;
+    uint64_t mask, result;
+    int r;
+
+    state = cron_scan_bytes(datetime, strlen(datetime));
+    r = cronparse(&result);
+    cron_delete_buffer(state);
+
+    if (max_value) {
+        /* XXX 64? 63? */
+        assert(max_value < 64);
+        mask = BIT(max_value) - 1;
+        result &= mask;
+    }
+
+    if (!r && presult)
+        *presult = result;
+
+    return r;
+}

--- a/lib/cron-parse.y
+++ b/lib/cron-parse.y
@@ -1,36 +1,112 @@
 %{
 #include <config.h>
 
-#include "lib/xmalloc.h" /* XXX only for fatal */
+#include "lib/cron.h"
 
-#include <assert.h>
-#include <inttypes.h>
-#include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
-#include <sysexits.h>
 
 #define BIT(n) (UINT64_C(1) << (n))
-
-#define CRONSTYPE uint64_t
-
-static void yyerror(uint64_t *, const char *);
 
 extern int yylex(void);
 extern struct yy_buffer_state *cron_scan_bytes(const char *bytes, int len);
 extern void cron_delete_buffer(struct yy_buffer_state *b);
+
+static bool range_saw_asterisk = false;
+static bool range_saw_step = false;
+
+static void yyerror(struct cron_spec *result, const char **, const char *);
 %}
 
 %define api.prefix {cron}
-%parse-param { uint64_t *result }
+%define api.value.type {uint64_t}
+
+%parse-param { struct cron_spec *result } { const char **err }
+
 %token NUM
+%token SP
+%token NAMED_MONTH
+%token NAMED_WEEKDAY
 
 %%
 
-start : datetime YYEOF {
-    *result = $$ = $1;
+spec : minutes SP hours SP doms SP months SP dows YYEOF {
+    result->minutes = $1;
+    result->hours = $3;
+    result->days_of_month = $5;
+    result->months = $7;
+    result->days_of_week = $9;
+    *err = NULL;
+    YYACCEPT;
 };
 
-datetime : list; /* XXX also accept month, weekday names here */
+minutes : list {
+    if (!range_saw_asterisk && ($1 & ~CRON_ALL_MINUTES)) {
+        *err = "minutes out of range";
+        YYERROR;
+    }
+    $$ = $1 & CRON_ALL_MINUTES;
+};
+
+hours : list {
+    if (!range_saw_asterisk && ($1 & ~CRON_ALL_HOURS)) {
+        *err = "hours out of range";
+        YYERROR;
+    }
+    $$ = $1 & CRON_ALL_HOURS;
+};
+
+doms : list {
+    /* accept values 1-31, but set bits 0-30.
+     * interpret 0 as 31, except for stepped range
+     */
+    if (!range_saw_step && ($1 & BIT(0)))
+        $1 |= BIT(31);
+    $1 >>= 1;
+
+    if (!range_saw_asterisk && ($1 & ~CRON_ALL_DAYS_OF_MONTH)) {
+        *err = "days of month out of range";
+        YYERROR;
+    }
+    $$ = $1 & CRON_ALL_DAYS_OF_MONTH;
+};
+
+months : months_check {
+    /* accept values 1-12, but set bits 0-11.
+     * interpret 0 as 12, except for stepped range
+     */
+    if (!range_saw_step && ($1 & BIT(0)))
+        $1 |= BIT(12);
+    $1 >>= 1;
+
+    if (!range_saw_asterisk && ($1 & ~CRON_ALL_MONTHS)) {
+        *err = "months out of range";
+        YYERROR;
+    }
+    $$ = $1 & CRON_ALL_MONTHS;
+};
+
+months_check : list
+             | NAMED_MONTH
+             ;
+
+dows : dows_check {
+    /* accept values 0-6 for sun-sat, and treat 7 as sunday too */
+    if (($1 & BIT(7))) {
+        $1 &= ~BIT(7);
+        $1 |= BIT(0);
+    }
+
+    if (!range_saw_asterisk && ($1 & ~CRON_ALL_DAYS_OF_WEEK)) {
+        *err = "days of week out of range";
+        YYERROR;
+    }
+    $$ = $1 & CRON_ALL_DAYS_OF_WEEK;
+};
+
+dows_check : list
+           | NAMED_WEEKDAY
+           ;
 
 list : range;
 
@@ -39,25 +115,43 @@ list : list ',' range {
 };
 
 range : '*' {
+    range_saw_asterisk = true;
+    range_saw_step = false;
     $$ = UINT64_MAX;
 };
 
 range : NUM '-' NUM {
-    $$ = 0;
     unsigned i;
-    assert($1 <= $3);
-    assert($1 < 64);
-    assert($3 < 64);
+
+    if ($1 > 63 || $3 > 63) {
+        *err = "value out of range";
+        YYERROR;
+    }
+
+    if ($1 > $3) {
+        *err = "range back to front";
+        YYERROR;
+    }
+
+    range_saw_asterisk = false;
+    range_saw_step = false;
+
+    $$ = 0;
     for (i = $1; i <= $3; i++) {
         $$ |= BIT(i);
     }
 };
 
-range : NUM { $$ = BIT($1); };
+range : NUM {
+    range_saw_asterisk = false;
+    range_saw_step = false;
+    $$ = BIT($1);
+};
 
 range : range '/' NUM {
     unsigned i;
 
+    range_saw_step = true;
     for (i = 0; i < 64; i++) {
         if ((i % $3) == 0) continue;
         $$ &= ~BIT(i);
@@ -66,32 +160,31 @@ range : range '/' NUM {
 
 %%
 
-static void yyerror(uint64_t *result, const char *err)
+static void yyerror(struct cron_spec *result __attribute__((unused)),
+                    const char **perr,
+                    const char *err)
 {
-    fprintf(stderr, "%s: result=<%" PRIu64 "> err=<%s>\n",
-                    __func__, *result, err);
+    if (perr) *perr = err;
 }
 
-EXPORTED int cron_parse_datetime(const char *datetime, unsigned max_value,
-                                 uint64_t *presult)
+EXPORTED int cron_parse_spec(const char *spec,
+                             struct cron_spec *presult,
+                             const char **perr)
 {
     struct yy_buffer_state *state;
-    uint64_t mask, result;
+    struct cron_spec result = {0};
+    const char *err = NULL;
     int r;
 
-    state = cron_scan_bytes(datetime, strlen(datetime));
-    r = cronparse(&result);
+    state = cron_scan_bytes(spec, strlen(spec));
+    r = cronparse(&result, &err);
     cron_delete_buffer(state);
-
-    if (max_value) {
-        /* XXX 64? 63? */
-        assert(max_value < 64);
-        mask = BIT(max_value) - 1;
-        result &= mask;
-    }
 
     if (!r && presult)
         *presult = result;
 
-    return r;
+    if (r && perr)
+        *perr = err;
+
+    return r ? -1 : 0;
 }

--- a/lib/cron.c
+++ b/lib/cron.c
@@ -91,3 +91,42 @@ EXPORTED void cron_spec_from_timeval(struct cron_spec *result,
         *run_time = mktime(tm);
     }
 }
+
+#define BIT(n) (UINT64_C(1) << (n))
+static void dump_one(struct buf *buf,
+                     const char *desc,
+                     unsigned n_bits,
+                     uint64_t all_bits,
+                     uint64_t value)
+{
+    if (value == all_bits) {
+        buf_printf(buf, "%s: all\n", desc);
+    }
+    else if (value == 0) {
+        buf_printf(buf, "%s: none\n", desc);
+    }
+    else {
+        const char *sep = "";
+        unsigned i;
+
+        buf_printf(buf, "%s: ", desc);
+        for (i = 0; i < n_bits; i++) {
+            if ((value & BIT(i))) {
+                buf_printf(buf, "%s%u", sep, i);
+                sep = ", ";
+            }
+        }
+        buf_appendcstr(buf, "\n");
+    }
+}
+
+EXPORTED void cron_spec_dump(struct buf *buf, const struct cron_spec *spec)
+{
+    dump_one(buf, "minutes", 60, CRON_ALL_MINUTES, spec->minutes);
+    dump_one(buf, "hours", 24, CRON_ALL_HOURS, spec->hours);
+    dump_one(buf, "days of month", 31,
+             CRON_ALL_DAYS_OF_MONTH, spec->days_of_month);
+    dump_one(buf, "months", 12, CRON_ALL_MONTHS, spec->months);
+    dump_one(buf, "days of week", 7,
+             CRON_ALL_DAYS_OF_WEEK, spec->days_of_week);
+}

--- a/lib/cron.h
+++ b/lib/cron.h
@@ -1,0 +1,65 @@
+/* cron.h -- parsing Cron-style date-time specifications
+ *
+ * Copyright (c) 1994-2025 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef INCLUDED_CRON_H
+#define INCLUDED_CRON_H
+#include <config.h>
+
+#include <stdint.h>
+
+#define CRON_ALL_MINUTES       UINT64_C(0x0FFFFFFFFFFFFFFF)
+#define CRON_ALL_HOURS         UINT64_C(0x00FFFFFF)
+#define CRON_ALL_DAYS_OF_MONTH UINT64_C(0x7FFFFFFF)
+#define CRON_ALL_MONTHS        UINT64_C(0x0FFF)
+#define CRON_ALL_DAYS_OF_WEEK  UINT64_C(0x7F)
+
+struct cron_spec {
+    uint64_t minutes;       /* bits 0-59 represent minutes */
+    uint32_t hours;         /* bits 0-23 represent hours */
+    uint32_t days_of_month; /* bits 0-30 represent days 1-31 */
+    uint16_t months;        /* bits 0-11 represent months 1-12 */
+    uint8_t  days_of_week;  /* bits 0-6 represent days sun-sat */
+};
+
+extern int cron_parse_spec(const char *spec,
+                           struct cron_spec *result,
+                           const char **err);
+#endif

--- a/lib/cron.h
+++ b/lib/cron.h
@@ -43,6 +43,8 @@
 #define INCLUDED_CRON_H
 #include <config.h>
 
+#include "lib/util.h"
+
 #include <stdint.h>
 
 #define CRON_ALL_MINUTES       UINT64_C(0x0FFFFFFFFFFFFFFF)
@@ -65,4 +67,5 @@ extern int cron_parse_spec(const char *spec,
 extern void cron_spec_from_timeval(struct cron_spec *result,
                                    time_t *run_time,
                                    const struct timeval *timeval);
+extern void cron_spec_dump(struct buf *buf, const struct cron_spec *spec);
 #endif

--- a/lib/cron.h
+++ b/lib/cron.h
@@ -45,6 +45,7 @@
 
 #include "lib/util.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #define CRON_ALL_MINUTES       UINT64_C(0x0FFFFFFFFFFFFFFF)
@@ -67,5 +68,7 @@ extern int cron_parse_spec(const char *spec,
 extern void cron_spec_from_timeval(struct cron_spec *result,
                                    time_t *run_time,
                                    const struct timeval *timeval);
+extern bool cron_spec_matches(const struct cron_spec *spec,
+                              const struct cron_spec *current_time);
 extern void cron_spec_dump(struct buf *buf, const struct cron_spec *spec);
 #endif

--- a/master/cronevent.c
+++ b/master/cronevent.c
@@ -63,7 +63,10 @@ static dynarray_t cronevent_details
 
 static time_t cronevent_last_run_time = 0;
 
-EXPORTED void cronevent_add(const char *name, const char *spec, const char *cmd)
+EXPORTED void cronevent_add(const char *name,
+                            const char *spec,
+                            const char *cmd,
+                            bool ignore_err)
 {
     struct cron_spec cron_spec = {0};
     struct cronevent_details *details = NULL;
@@ -74,12 +77,14 @@ EXPORTED void cronevent_add(const char *name, const char *spec, const char *cmd)
         xsyslog(LOG_ERR, "event missing name",
                          "spec=<%s> cmd=<%s>",
                          spec, cmd);
+        if (ignore_err) return;
         fatal("event missing name", EX_CONFIG);
     }
 
     if (!cmd || !*cmd) {
         xsyslog(LOG_ERR, "event missing cmd",
                          "name=<%s>", name);
+        if (ignore_err) return;
         fatal("event missing cmd", EX_CONFIG);
     }
 
@@ -87,6 +92,7 @@ EXPORTED void cronevent_add(const char *name, const char *spec, const char *cmd)
         xsyslog(LOG_ERR, "unable to parse cron spec",
                          "name=<%s> spec=<%s> parse_err=<%s>",
                          name, spec, parse_err);
+        if (ignore_err) return;
         fatal("unable to parse cron spec", EX_CONFIG);
     }
 

--- a/master/cronevent.c
+++ b/master/cronevent.c
@@ -1,0 +1,168 @@
+/* master/cronevent.c -- master process cronevent subsystem
+ *
+ * Copyright (c) 1994-2025 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <config.h>
+
+#include "master/cronevent.h"
+
+#include "lib/assert.h"
+#include "lib/cron.h"
+#include "lib/dynarray.h"
+#include "lib/strarray.h"
+#include "lib/util.h"
+#include "lib/xmalloc.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <sysexits.h>
+#include <syslog.h>
+#include <time.h>
+
+static dynarray_t cronevent_schedule
+    = DYNARRAY_INITIALIZER(sizeof(struct cron_spec));
+static dynarray_t cronevent_details
+    = DYNARRAY_INITIALIZER(sizeof(struct cronevent_details));
+
+static time_t cronevent_last_run_time = 0;
+
+EXPORTED void cronevent_add(const char *name, const char *spec, const char *cmd)
+{
+    struct cron_spec cron_spec = {0};
+    struct cronevent_details *details = NULL;
+    const char *parse_err = NULL;
+    int spec_idx, det_idx;
+
+    if (!name || !*name) {
+        xsyslog(LOG_ERR, "event missing name",
+                         "spec=<%s> cmd=<%s>",
+                         spec, cmd);
+        fatal("event missing name", EX_CONFIG);
+    }
+
+    if (!cmd || !*cmd) {
+        xsyslog(LOG_ERR, "event missing cmd",
+                         "name=<%s>", name);
+        fatal("event missing cmd", EX_CONFIG);
+    }
+
+    if (!spec || cron_parse_spec(spec, &cron_spec, &parse_err)) {
+        xsyslog(LOG_ERR, "unable to parse cron spec",
+                         "name=<%s> spec=<%s> parse_err=<%s>",
+                         name, spec, parse_err);
+        fatal("unable to parse cron spec", EX_CONFIG);
+    }
+
+    spec_idx = dynarray_append(&cronevent_schedule, &cron_spec);
+
+    det_idx = dynarray_append_empty(&cronevent_details, (void **) &details);
+    assert(spec_idx == det_idx);
+
+    details->name = xstrdup(name);
+    /* The xstrdup here looks weird, but strarray_splitm specifically wants
+     * a heap-allocated string it can take ownership of.  It's not leaked.
+     */
+    strarray_splitm(&details->exec, xstrdup(cmd), NULL, 0);
+}
+
+EXPORTED void cronevent_clear(void)
+{
+    struct cronevent_details *details;
+    int i, n;
+
+    dynarray_fini(&cronevent_schedule);
+
+    for (i = 0, n = dynarray_size(&cronevent_details); i < n; i++) {
+        details = dynarray_nth(&cronevent_details, i);
+        free(details->name);
+        strarray_fini(&details->exec);
+    }
+    dynarray_fini(&cronevent_details);
+
+    cronevent_last_run_time = 0;
+}
+
+EXPORTED void cronevent_poll_due(struct timeval now,
+                                 cronevent_spawn_fn *spawner,
+                                 void *rock)
+{
+    struct cron_spec current_time;
+    time_t run_time;
+    int i;
+
+    cron_spec_from_timeval(&current_time, &run_time, &now);
+
+    /* only do anything once per minute */
+    if (cronevent_last_run_time && run_time <= cronevent_last_run_time)
+        return;
+
+    const int n_events = dynarray_size(&cronevent_schedule);
+    assert(n_events == dynarray_size(&cronevent_details));
+
+    for (i = 0; i < n_events; i++) {
+        struct cron_spec *spec = dynarray_nth(&cronevent_schedule, i);
+        struct cronevent_details *details;
+
+        if (cron_spec_matches(spec, &current_time)) {
+            details = dynarray_nth(&cronevent_details, i);
+            spawner(details->name, &details->exec, rock);
+        }
+    }
+
+    cronevent_last_run_time = run_time;
+}
+
+/* hidden accessors for unit tests */
+HIDDEN void cronevent_get_schedule(dynarray_t **schedule,
+                                   dynarray_t **details)
+{
+    *schedule = &cronevent_schedule;
+    *details = &cronevent_details;
+}
+
+HIDDEN time_t cronevent_get_last_run_time(void)
+{
+    return cronevent_last_run_time;
+}
+
+HIDDEN void cronevent_set_last_run_time(time_t run_time)
+{
+    cronevent_last_run_time = run_time;
+}

--- a/master/cronevent.h
+++ b/master/cronevent.h
@@ -44,13 +44,18 @@
 
 #include "lib/strarray.h"
 
+#include <stdbool.h>
+
 /* unit tests need to know this struct */
 struct cronevent_details {
     char *name;
     strarray_t exec;
 };
 
-extern void cronevent_add(const char *name, const char *spec, const char *cmd);
+extern void cronevent_add(const char *name,
+                          const char *spec,
+                          const char *cmd,
+                          bool ignore_err);
 extern void cronevent_clear(void);
 
 typedef void (cronevent_spawn_fn)(const char *name,

--- a/master/cronevent.h
+++ b/master/cronevent.h
@@ -1,0 +1,63 @@
+/* master/cronevent.h -- master process cronevent subsystem
+ *
+ * Copyright (c) 1994-2025 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef MASTER_CRONEVENT_H
+#define MASTER_CRONEVENT_H
+
+#include "lib/strarray.h"
+
+/* unit tests need to know this struct */
+struct cronevent_details {
+    char *name;
+    strarray_t exec;
+};
+
+extern void cronevent_add(const char *name, const char *spec, const char *cmd);
+extern void cronevent_clear(void);
+
+typedef void (cronevent_spawn_fn)(const char *name,
+                                  const strarray_t *exec,
+                                  void *rock);
+extern void cronevent_poll_due(struct timeval now,
+                               cronevent_spawn_fn *spawner,
+                               void *rock);
+
+#endif

--- a/master/event.c
+++ b/master/event.c
@@ -1,0 +1,168 @@
+/* master/event.c -- master process event subsystem
+ *
+ * Copyright (c) 1994-2025 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <config.h>
+
+#include "master/event.h"
+
+#include "lib/assert.h"
+#include "lib/util.h"
+
+#include <sysexits.h>
+#include <syslog.h>
+
+static struct event *schedule = NULL;
+
+EXPORTED struct event *event_new(const char *name)
+{
+    struct event *evt = xzmalloc(sizeof(*evt));
+
+    evt->name = xstrdup(name);
+    return evt;
+}
+
+EXPORTED void event_free(struct event *evt)
+{
+    if (evt->exec) {
+        strarray_free(evt->exec);
+        evt->exec = NULL;
+    }
+    free(evt->name);
+    free(evt);
+}
+
+EXPORTED void schedule_event(struct event *evt)
+{
+    struct event *ptr;
+
+    if (!evt->name)
+        fatal("Serious software bug found: schedule_event() called on unnamed event!",
+              EX_SOFTWARE);
+
+    if (!schedule || timesub(&schedule->mark, &evt->mark) < 0.0) {
+        evt->next = schedule;
+        schedule = evt;
+
+        return;
+    }
+    for (ptr = schedule;
+         ptr->next && timesub(&evt->mark, &ptr->next->mark) <= 0.0;
+         ptr = ptr->next) ;
+
+    /* insert evt */
+    evt->next = ptr->next;
+    ptr->next = evt;
+}
+
+EXPORTED void reschedule_event(struct event *evt, struct timeval now)
+{
+    assert(evt->period);
+
+    if (evt->periodic) {
+        evt->mark = now;
+        evt->mark.tv_sec += evt->period;
+    }
+    else {
+        struct tm *tm;
+        int delta;
+
+        /* Daily Event */
+        while (timesub(&now, &evt->mark) <= 0.0)
+            evt->mark.tv_sec += evt->period;
+
+        /* check for daylight savings fuzz... */
+        tm = localtime(&evt->mark.tv_sec);
+        if (tm->tm_hour != evt->hour || tm->tm_min != evt->min) {
+            /* calculate the same time on the new day */
+            tm->tm_hour = evt->hour;
+            tm->tm_min = evt->min;
+            delta = mktime(tm) - evt->mark.tv_sec;
+            /* bring it within half a period either way */
+            while (delta > (evt->period/2)) delta -= evt->period;
+            while (delta < -(evt->period/2)) delta += evt->period;
+            /* update the time */
+            evt->mark.tv_sec += delta;
+            /* and let us know about the change */
+            syslog(LOG_NOTICE,
+                   "timezone shift for %s - altering schedule by %d seconds",
+                   evt->name, delta);
+        }
+    }
+
+    schedule_event(evt);
+}
+
+EXPORTED struct event *schedule_peek(void)
+{
+    return schedule;
+}
+
+EXPORTED struct event *schedule_splice_due(struct timeval now)
+{
+    struct event *due = NULL, *next;
+
+    /* XXX same algorithm as original, including the bug where it
+     * XXX reverses the order of the events, which becomes very
+     * XXX clear as soon as you use good variable names instead
+     * XXX of "a" and "ptr" :/
+     */
+    while (schedule && timesub(&now, &schedule->mark) <= 0.0) {
+        next = schedule;
+
+        /* delete */
+        schedule = schedule->next;
+
+        /* insert */
+        next->next = due;
+        due = next;
+    }
+
+    return due;
+}
+
+EXPORTED void schedule_clear(void)
+{
+    while (schedule) {
+        struct event *evt = schedule;
+        schedule = schedule->next;
+        event_free(evt);
+    }
+}

--- a/master/event.c
+++ b/master/event.c
@@ -133,8 +133,17 @@ EXPORTED void reschedule_event(struct event *evt, struct timeval now)
     assert(period > 0);
 
     /* don't fall behind schedule if we're running slow for some reason */
-    while (mark <= now_s)
-        mark += period;
+    mark += period;
+    if (mark <= now_s) {
+        unsigned skipped = 0;
+        do {
+            mark += period;
+            skipped ++;
+        } while (mark <= now_s);
+        xsyslog(LOG_WARNING, "periodic event behind schedule",
+                             "name=<%s> period=<" TIME_T_FMT "> skipped=<%u>",
+                             evt->name, evt->period, skipped);
+    }
 
     evt->mark.tv_sec = mark;
 

--- a/master/event.c
+++ b/master/event.c
@@ -199,25 +199,23 @@ EXPORTED struct event *schedule_peek(void)
 
 EXPORTED struct event *schedule_splice_due(struct timeval now)
 {
-    struct event *due = NULL, *next;
+    struct event *due, *last_due = NULL;
 
-    /* XXX same algorithm as original, including the bug where it
-     * XXX reverses the order of the events, which becomes very
-     * XXX clear as soon as you use good variable names instead
-     * XXX of "a" and "ptr" :/
-     */
-    while (schedule && timesub(&now, &schedule->mark) <= 0.0) {
-        next = schedule;
-
-        /* delete */
-        schedule = schedule->next;
-
-        /* insert */
-        next->next = due;
-        due = next;
+    due = schedule;
+    while (due && timesub(&now, &due->mark) <= 0.0) {
+        last_due = due;
+        due = due->next;
     }
 
-    return due;
+    if (last_due) {
+        due = schedule;
+        schedule = last_due->next;
+        last_due->next = NULL;
+        return due;
+    }
+    else {
+        return NULL;
+    }
 }
 
 EXPORTED void schedule_clear(void)

--- a/master/event.c
+++ b/master/event.c
@@ -112,12 +112,21 @@ EXPORTED struct event *event_new_hourmin(const char *name, int hour, int min)
     return evt;
 }
 
+EXPORTED void event_set_exec(struct event *evt, const char *cmd)
+{
+    strarray_truncate(&evt->exec, 0);
+
+    if (cmd) {
+        /* The xstrdup here looks weird, but strarray_splitm specifically wants
+         * a heap-allocated string it can take ownership of.  It's not leaked.
+         */
+        strarray_splitm(&evt->exec, xstrdup(cmd), NULL, 0);
+    }
+}
+
 EXPORTED void event_free(struct event *evt)
 {
-    if (evt->exec) {
-        strarray_free(evt->exec);
-        evt->exec = NULL;
-    }
+    strarray_fini(&evt->exec);
     free(evt->name);
     free(evt);
 }

--- a/master/event.c
+++ b/master/event.c
@@ -159,8 +159,15 @@ EXPORTED void reschedule_event(struct event *evt, struct timeval now)
     assert(evt->period);
 
     if (evt->periodic) {
-        evt->mark = now;
-        evt->mark.tv_sec += evt->period;
+        time_t now_s = now.tv_sec;
+        time_t period = evt->period;
+        time_t mark = MIN(now_s, evt->mark.tv_sec);
+
+        /* don't fall behind schedule if we're running slow for some reason */
+        while (mark <= now_s)
+            mark += period;
+
+        evt->mark.tv_sec = mark;
     }
     else {
         struct tm *tm;

--- a/master/event.h
+++ b/master/event.h
@@ -57,7 +57,11 @@ struct event {
     struct event *next;
 };
 
-extern struct event *event_new(const char *name);
+extern struct event *event_new_oneshot(const char *name, struct timeval mark);
+extern struct event *event_new_periodic(const char *name,
+                                        struct timeval mark,
+                                        time_t period);
+extern struct event *event_new_hourmin(const char *name, int hour, int min);
 extern void event_free(struct event *evt);
 
 extern void schedule_event(struct event *evt);

--- a/master/event.h
+++ b/master/event.h
@@ -53,7 +53,7 @@ struct event {
     int hour;
     int min;
     int periodic;
-    strarray_t *exec;
+    strarray_t exec;
     struct event *next;
 };
 
@@ -63,6 +63,8 @@ extern struct event *event_new_periodic(const char *name,
                                         time_t period);
 extern struct event *event_new_hourmin(const char *name, int hour, int min);
 extern void event_free(struct event *evt);
+
+extern void event_set_exec(struct event *evt, const char *cmd);
 
 extern void schedule_event(struct event *evt);
 extern void reschedule_event(struct event *evt, struct timeval now);

--- a/master/event.h
+++ b/master/event.h
@@ -1,0 +1,71 @@
+/* master/event.h -- master process event subsystem
+ *
+ * Copyright (c) 1994-2025 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef MASTER_EVENT_H
+#define MASTER_EVENT_H
+
+#include <sys/time.h>
+
+#include "lib/strarray.h"
+
+struct event {
+    char *name;
+    struct timeval mark;
+    time_t period;
+    int hour;
+    int min;
+    int periodic;
+    strarray_t *exec;
+    struct event *next;
+};
+
+extern struct event *event_new(const char *name);
+extern void event_free(struct event *evt);
+
+extern void schedule_event(struct event *evt);
+extern void reschedule_event(struct event *evt, struct timeval now);
+
+extern struct event *schedule_splice_due(struct timeval now);
+extern struct event *schedule_peek(void);
+
+extern void schedule_clear(void);
+
+#endif

--- a/master/event.h
+++ b/master/event.h
@@ -50,9 +50,6 @@ struct event {
     char *name;
     struct timeval mark;
     time_t period;
-    int hour;
-    int min;
-    int periodic;
     strarray_t exec;
     struct event *next;
 };
@@ -61,7 +58,6 @@ extern struct event *event_new_oneshot(const char *name, struct timeval mark);
 extern struct event *event_new_periodic(const char *name,
                                         struct timeval mark,
                                         time_t period);
-extern struct event *event_new_hourmin(const char *name, int hour, int min);
 extern void event_free(struct event *evt);
 
 extern void event_set_exec(struct event *evt, const char *cmd);

--- a/master/master.c
+++ b/master/master.c
@@ -1211,10 +1211,10 @@ static void spawn_schedule(struct timeval now)
 
     /* run all events */
     while (due) {
-        /* if a->exec is NULL, we just used the event to wake up,
+        /* if due->exec is empty, we just used the event to wake up,
          * so we actually don't need to exec anything at the moment */
-        if (due->exec) {
-            get_executable(path, sizeof(path), due->exec);
+        if (strarray_size(&due->exec)) {
+            get_executable(path, sizeof(path), &due->exec);
             switch (p = fork()) {
             case -1:
                 syslog(LOG_CRIT,
@@ -1240,7 +1240,7 @@ static void spawn_schedule(struct timeval now)
                 }
 
                 syslog(LOG_DEBUG, "about to exec %s", path);
-                execv(path, due->exec->data);
+                execv(path, due->exec.data);
                 syslog(LOG_ERR, "can't exec %s on schedule: %m", path);
                 exit(EX_OSERR);
                 break;
@@ -2344,7 +2344,7 @@ static void add_event(const char *name, struct entry *e, void *rock)
         evt = event_new_periodic(name, now, period);
     }
 
-    evt->exec = strarray_splitm(NULL, cmd, NULL, 0);
+    event_set_exec(evt, cmd);
 
     schedule_event(evt);
 }

--- a/master/master.c
+++ b/master/master.c
@@ -2313,9 +2313,7 @@ done:
 static void add_event(const char *name, struct entry *e, void *rock)
 {
     int ignore_err = rock ? 1 : 0;
-    /* Note: masterconf_getstring() shares a static buffer with
-     * masterconf_getint() so we *must* strdup here */
-    char *cmd = xstrdup(masterconf_getstring(e, "cmd", ""));
+    const char *cmd = masterconf_getstring(e, "cmd", "");
     int period = 60 * masterconf_getint(e, "period", 0);
     int at = masterconf_getint(e, "at", -1), hour, min;
     struct timeval now;
@@ -2324,13 +2322,12 @@ static void add_event(const char *name, struct entry *e, void *rock)
     gettimeofday(&now, 0);
 
     if (!strcmp(cmd,"")) {
-        char buf[256];
+        char buf[4096];
         snprintf(buf, sizeof(buf),
                  "unable to find command or port for event '%s'", name);
 
         if (ignore_err) {
             syslog(LOG_WARNING, "WARNING: %s -- ignored", buf);
-            free(cmd);
             return;
         }
 


### PR DESCRIPTION
**Reviewers:** The diffs will make more sense when read commit-by-commit.

This PR adds cron-style scheduling of cyrus.conf EVENTS.  It takes a bit of a walk on the way there, the highlights are:

* rips all the existing event handling out of master.c and into a testable module (with minimal changes), and adds tests for it
* updates the new module to have a saner interface, and fixes some old bugs
* adds a parser for cron-style date/time specifications
* adds a new cronevent module based around the new parser
* updates master to support cronevents alongside the existing events
* changes the at=hhmm event handling to use the cronevent stuff under the hood (the at=hhmm cyrus.conf syntax is still supported, so no action is needed during upgrade)

The cron parser is based on the syntax described by `crontab(5)` on my laptop.  I believe this is pretty standard.

Cron events consist of a set of bitfields describing the times the event wants to run (`struct cron_spec`), plus the name of the event and the command to execute (`struct cronevent_details`).  These two structs are maintained in separate, parallel arrays.  Once per minute, the cron_specs for all events are examined in a hot loop to see which (if any) match the current time.  Most minutes, no events will match, so we won't even look at the cronevent_details.  When an event does match, its corresponding cronevent_details are fetched and the command executed.

If Fastmail converted our existing cron jobs into cron-style cyrus.conf EVENTS, there would be about 16 such events (based on role_imaprepl.tt2).  Given the small number, I chose the hot loop check-everything approach, relying on CPU cache prefetching of sequentially-accessed memory to keep it fast, rather than devising some more complicated lookup scheme.  The cron_spec data being isolated in its own array, separate from the cronevent_details, means prefetches in the hot loop aren't wasted on data that probably won't be used.

When initialised, the cronevent subsystem registers a periodic wakeup call timed to the start of the minute, using the existing event system.  This means cronevents will typically run as close to the start of their chosen minute as possible.  The wakeup call setup is similar to what's already used by the janitor and prom_report subsystems, which want to run every ten seconds, though the alignment to the top of the minute is novel.