### PR TITLE
xsyslog_fn(): make `struct buf buf` non-static

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -2154,12 +2154,11 @@ EXPORTED void tcp_disable_nagle(int fd)
 EXPORTED void xsyslog_fn(int priority, const char *description,
                          const char *func, const char *extra_fmt, ...)
 {
-    static struct buf buf = BUF_INITIALIZER;
+    struct buf buf = BUF_INITIALIZER;
     int saved_errno = errno;
     int want_diag = (LOG_PRI(priority) != LOG_NOTICE
                      && LOG_PRI(priority) != LOG_INFO);
 
-    buf_reset(&buf);
     buf_appendcstr(&buf, description);
     buf_appendmap(&buf, ": ", 2);
     if (extra_fmt && *extra_fmt) {


### PR DESCRIPTION
so that `message_parse_mapped()` can be called concurrently and each thread can log via `charset_decode_sha1()` “ignoring invalid base64 characters”.

Besides, there is no point to have the variable `buf` static here.