### PR TITLE
twom.c: return NOTFOUND when creating a db in an inexistent dir

### DIFF
--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -22,6 +22,7 @@ struct binary_result
 static const char *backend = CUNIT_PARAM("skiplist,flat,twom,twoskip");
 static char *filename;
 static char *filename2;
+static char *basedir;
 
 static int fexists(const char *fname)
 {
@@ -233,6 +234,36 @@ static void test_openclose(void)
     r = cyrusdb_close(db);
     CU_ASSERT_EQUAL(r, CYRUSDB_OK);
     CU_ASSERT_EQUAL(fexists(filename), 0);
+}
+
+static void test_openclose_mkdir(void)
+{
+    struct db *db = NULL;
+    int r;
+
+    char *myfilename = strconcat(basedir, "/inexistent/cyrus.", backend, "-test", (char *)NULL);
+
+    CU_ASSERT_EQUAL(fexists(filename), -ENOENT);
+
+    /* open() without _CREATE fails with NOTFOUND
+     * and doesn't create the db */
+    r = cyrusdb_open(backend, myfilename, 0, &db);
+    CU_ASSERT(r == CYRUSDB_NOTFOUND || r == CYRUSDB_IOERROR);
+    CU_ASSERT_PTR_NULL(db);
+    CU_ASSERT_EQUAL(fexists(myfilename), -ENOENT);
+
+    /* open() with _CREATE succeeds and creates the db */
+    r = cyrusdb_open(backend, myfilename, CYRUSDB_CREATE, &db);
+    CU_ASSERT_EQUAL_FATAL(r, CYRUSDB_OK);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+    CU_ASSERT_EQUAL_FATAL(fexists(myfilename), 0);
+
+    /* closing succeeds and leaves the file in place */
+    r = cyrusdb_close(db);
+    CU_ASSERT_EQUAL(r, CYRUSDB_OK);
+    CU_ASSERT_EQUAL(fexists(myfilename), 0);
+
+    free(myfilename);
 }
 
 static void test_multiopen(void)
@@ -1627,8 +1658,6 @@ static void test_many(void)
     free_hash_table(&exphash, free);
 #undef MAXN
 }
-
-static char *basedir;
 
 static int set_up(void)
 {

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -4047,7 +4047,7 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
             strarray_unshift(newdirs, tempreindexdir);
             r = search_reindex(userid, toreindex, newdirs, newtiers, flags);
             if (r) {
-                printf("ERROR: failed to reindex to %s", tempreindexdir);
+                printf("ERROR: failed to reindex to %s\n", tempreindexdir);
                 removedir(tempreindexdir);
                 goto out;
             }

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1930,7 +1930,10 @@ static int opendb(const char *fname, struct twom_open_data *setup, struct twom_d
         if (setup->flags & TWOM_CREATE) {
             fd = open(db->fname, O_RDWR|O_CREAT, 0644);
             db->openfile->fd = fd;
-            if (fd < 0) goto done;
+            if (fd < 0) {
+                if (errno == ENOENT) r = TWOM_NOTFOUND;
+                goto done;
+            }
             r = initdb(db, setup->flags);
             if (r) goto done;
         }


### PR DESCRIPTION
Fixes a bug that surfaced when trying to reindex a Xapian database during compaction. The root cause is that the twom backend does not create the parent directory of a database file when create-opening a database, but creating that parent directory is expected by the cyrusdb API. In addition to fixing the bug, this PR adds a cunit test that asserts create-opening databases in inexistent directories for all database backend implementations.