### PR TITLE
Cassandane: try to speed up periodic_event_slow test

### DIFF
--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -881,12 +881,23 @@ sub test_periodic_event_slow
 
     xlog $self, "periodic events run immediately";
 
-    xlog $self, "waiting 5 mins for events to fire, plus some slop";
-    sleep(5*60 + 5);
+    # xlog $self, "waiting 5 mins for events to fire, plus some slop";
+    # sleep(5*60 + 5);
+    my $until = Time::HiRes::time() + (5 * 61);
+
+    my $got;
+    LOOP: while (Time::HiRes::time() <= $until) {
+        $got = $self->lemming_census;
+        my $got_b = $got->{B};
+        last if $got_b && $got_b->{dead} && $got_b->{dead} == 6;
+        use Data::Dumper;
+        warn Dumper($got);
+        sleep(0.25)
+    }
 
     $self->assert_deep_equals({
                                 B => { live => 0, dead => 6 },
-                              }, $self->lemming_census());
+                              }, $got);
 }
 
 sub test_service_bad_name


### PR DESCRIPTION
Before this patch, the test does:

1.  start background work
2.  wait 5m5s
3.  check that it's all good

This patch changes it to:

1.  start background work
2.  every 0.25s, check whether the work is done
3.  give up if not done by 5.5s
4.  check that it's all good

The performance seems moderately better, but not much.  I'm not sure it's worth merging yet, but it's not much more complex.