### PR TITLE
configure/make: Add --enable-asan and --enable-ubsan

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,12 +79,14 @@ if STATIC_ASAN
         AM_CXXFLAGS += -DWITH_STATIC_ASAN
 
 if IS_GCC_COMPILER
-            AM_CFLAGS += -static-libasan
-            AM_CXXFLAGS += -static-libasan
+            AM_CFLAGS += -static-libasan -DWITH_GCC
+            AM_CXXFLAGS += -static-libasan -DWITH_GCC
             AM_LDFLAGS += -static-libasan
 endif # IS_GCC_COMPILER
 else # ! STATIC_ASAN
 if IS_GCC_COMPILER
+            AM_CFLAGS += -DWITH_GCC
+            AM_CXXFLAGS += -DWITH_GCC
 else # ! IS_GCC_COMPILER
             AM_CFLAGS += -shared-libsan
             AM_CXXFLAGS += -shared-libsan
@@ -103,12 +105,14 @@ if STATIC_UBSAN
         AM_CXXFLAGS += -DWITH_STATIC_UBSAN
 
 if IS_GCC_COMPILER
-            AM_CFLAGS += -static-libubsan
-            AM_CXXFLAGS += -static-libubsan
+            AM_CFLAGS += -static-libubsan -DWITH_GCC
+            AM_CXXFLAGS += -static-libubsan -DWITH_GCC
             AM_LDFLAGS += -static-libubsan
 endif # IS_GCC_COMPILER
 else # ! STATIC_UBSAN
 if IS_GCC_COMPILER
+            AM_CFLAGS += -DWITH_GCC
+            AM_CXXFLAGS += -DWITH_GCC
 else # ! IS_GCC_COMPILER
             AM_CFLAGS += -shared-libsan
             AM_CXXFLAGS += -shared-libsan

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,10 +63,59 @@ AM_CPPFLAGS = \
     $(ICU_CFLAGS)
 
 if HAVE_LDAP
-AM_CPPFLAGS += $(LDAP_CPPFLAGS)
+    AM_CPPFLAGS += $(LDAP_CPPFLAGS)
 endif # HAVE_LDAP
 
 AM_LDFLAGS = $(COV_LDFLAGS) $(ICU_LIBS)
+
+if ASAN
+    LSAN_SUPPRESS="env LSAN_OPTIONS=suppressions=leaksanitizer.suppress"
+    AM_CFLAGS += -fsanitize=address -DWITH_ASAN
+    AM_CXXFLAGS += -fsanitize=address -DWITH_ASAN
+    AM_LDFLAGS += -fsanitize=address
+
+if STATIC_ASAN
+        AM_CFLAGS += -DWITH_STATIC_ASAN
+        AM_CXXFLAGS += -DWITH_STATIC_ASAN
+
+if IS_GCC_COMPILER
+            AM_CFLAGS += -static-libasan
+            AM_CXXFLAGS += -static-libasan
+            AM_LDFLAGS += -static-libasan
+endif # IS_GCC_COMPILER
+else # ! STATIC_ASAN
+if IS_GCC_COMPILER
+else # ! IS_GCC_COMPILER
+            AM_CFLAGS += -shared-libsan
+            AM_CXXFLAGS += -shared-libsan
+            AM_LDFLAGS += -shared-libsan
+endif # ! IS_GCC_COMPILER
+endif # STATIC_ASAN
+endif # ASAN
+
+if UBSAN
+    AM_CFLAGS += -fsanitize=undefined -DWITH_UBSAN
+    AM_CXXFLAGS += -fsanitize=undefined -DWITH_UBSAN
+    AM_LDFLAGS += -fsanitize=undefined
+
+if STATIC_UBSAN
+        AM_CFLAGS += -DWITH_STATIC_UBSAN
+        AM_CXXFLAGS += -DWITH_STATIC_UBSAN
+
+if IS_GCC_COMPILER
+            AM_CFLAGS += -static-libubsan
+            AM_CXXFLAGS += -static-libubsan
+            AM_LDFLAGS += -static-libubsan
+endif # IS_GCC_COMPILER
+else # ! STATIC_UBSAN
+if IS_GCC_COMPILER
+else # ! IS_GCC_COMPILER
+            AM_CFLAGS += -shared-libsan
+            AM_CXXFLAGS += -shared-libsan
+            AM_LDFLAGS += -shared-libsan
+endif # ! IS_GCC_COMPILER
+endif # ! STATIC_UBSAN
+endif # UBSAN
 
 # have distcheck try to build with all optional components enabled, to aid
 # detection of missing files for these components
@@ -708,10 +757,11 @@ check-local:
 	@echo "Running unit tests"
 	@vg= ; \
 		test -z "$$VG" || vg="$(VALGRIND)" ; \
+		test -z "$$SUPPRESS" && suppress=$(LSAN_SUPPRESS) ; \
 		f="-v" ; \
 		test "x$$CUFORMAT" = xjunit && f="-x" ; \
 		cd cunit ; \
-		$$vg ./unit $$f ; \
+		$$vg $$suppress ./unit $$f ; \
 		retval=$$? ; \
 		if [ "x$$CUFORMAT" = xjunit ] ; then \
 			$(RM) -rf reports ; mkdir reports ; ./cunit-to-junit.pl ; \

--- a/configure.ac
+++ b/configure.ac
@@ -2127,6 +2127,47 @@ AC_SUBST(LIB_SASL)
 AC_SUBST(LIB_UUID)
 AC_SUBST(PERL)
 
+AC_ARG_ENABLE([asan],
+[AS_HELP_STRING([--enable-asan], [Build with AddressSanitizer (-fsanitize=address)])],
+[case "${enableval}" in
+  yes) asan=true ;;
+  no)  asan=false ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --enable-asan]) ;;
+esac],[asan=false])
+AM_CONDITIONAL([ASAN], [test "x$asan" = "xtrue"])
+
+AC_ARG_ENABLE([ubsan],
+[AC_HELP_STRING([--enable-ubsan], [Build with UndefinedBehaviorSanitizer (-fsanitize=undefined)])],
+[case "${enableval}" in
+  yes) ubsan=true ;;
+  no)  ubsan=false ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --enable-ubsan]) ;;
+esac],[ubsan=false])
+AM_CONDITIONAL([UBSAN], [test "x$ubsan" = "xtrue"])
+
+if `$CC -v 2>&1 | grep 'gcc version' >/dev/null 2>&1` ; then
+    is_gcc_compiler=true
+fi
+AM_CONDITIONAL([IS_GCC_COMPILER], [test "x$is_gcc_compiler" = "xtrue"])
+
+AC_ARG_ENABLE([static-asan],
+[AS_HELP_STRING([--disable-static-asan], [If --enable-asan is true, do not link asan statically])],
+[case "${enableval}" in
+  yes) static_asan=true ;;
+  no)  static_asan=false ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --disable-static-asan]) ;;
+esac],[static_asan=true])
+AM_CONDITIONAL([STATIC_ASAN], [test "x$static_asan" = "xtrue"])
+
+AC_ARG_ENABLE([static-ubsan],
+[AS_HELP_STRING([--disable-static-ubsan], [If --enable-ubsan is true, do not link ubsan statically])],
+[case "${enableval}" in
+  yes) static_ubsan=true ;;
+  no)  static_ubsan=false ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --disable-static-ubsan]) ;;
+esac],[static_ubsan=true])
+AM_CONDITIONAL([STATIC_UBSAN], [test "x$static_ubsan" = "xtrue"])
+
 dnl
 dnl Enable/disable unit tests.  These are disabled by default, as
 dnl they require an additional library (the CUnit library).
@@ -2589,6 +2630,26 @@ then
         LIBS="$LIBS -lstdc++";
 fi
 
+if test "X$asan" = "Xtrue";
+then
+    if test "X$static_asan" = "Xtrue";
+    then
+       asan_desc="(statically linked)"
+    else
+       asan_desc="(dynamically linked)"
+    fi
+fi
+
+if test "X$ubsan" = "Xtrue";
+then
+    if test "X$static_ubsan" = "Xtrue";
+    then
+       ubsan_desc="(statically linked)"
+    else
+       ubsan_desc="(dynamically linked)"
+    fi
+fi
+
 dnl make sure that Makefile is the last thing output
 AC_CONFIG_FILES([
     libcyrus_imap.pc
@@ -2681,4 +2742,6 @@ Build info:
    unit tests (cunit): $enable_unit_tests
    xxd:                $XXD
    release checks:     $enable_release_checks
+   asan:               $asan $asan_desc
+   ubsan:              $ubsan $ubsan_desc
 "

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -89,6 +89,7 @@ static void usage(void)
 /* Gather the build configuration parameters as JSON object */
 static json_t *buildinfo()
 {
+    json_t *compilation = json_object();
     json_t *component = json_object();
     json_t *dependency = json_object();
     json_t *database = json_object();
@@ -98,6 +99,7 @@ static json_t *buildinfo()
     json_t *version = json_object();
     json_t *ical = json_object();
 
+    json_object_set_new(buildconf, "compilation", compilation);
     json_object_set_new(buildconf, "component", component);
     json_object_set_new(buildconf, "dependency", dependency);
     json_object_set_new(buildconf, "database", database);
@@ -349,6 +351,38 @@ static json_t *buildinfo()
 #else
     json_object_set_new(version, "FORTIFY_LEVEL",
                                  json_integer(0));
+#endif
+
+#if defined WITH_ASAN
+    json_object_set_new(compilation, "ASAN", json_true());
+#else
+    json_object_set_new(compilation, "ASAN", json_false());
+#endif
+
+#if defined WITH_STATIC_ASAN
+    json_object_set_new(compilation, "STATIC_ASAN", json_true());
+#else
+    json_object_set_new(compilation, "STATIC_ASAN", json_false());
+#endif
+
+#if defined WITH_UBSAN
+    json_object_set_new(compilation, "UBSAN", json_true());
+#else
+    json_object_set_new(compilation, "UBSAN", json_false());
+#endif
+
+#if defined WITH_STATIC_UBSAN
+    json_object_set_new(compilation, "STATIC_UBSAN", json_true());
+#else
+    json_object_set_new(compilation, "STATIC_UBSAN", json_false());
+#endif
+
+/* only detected if ASAN or UBSAN is true, so we won't fill in a WITH_GCC
+   false f it isn't set
+*/
+
+#if defined WITH_GCC
+    json_object_set_new(compilation, "WITH_GCC", json_true());
 #endif
 
     /* Whew ... */

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -528,6 +528,10 @@ int main(int argc, char *argv[])
         printf(" (built with ubsan (dynamically linked))");
 #endif
 
+#if defined WITH_GCC
+        printf(" (built with gcc)");
+#endif
+
         printf("\n");
         return 0;
     }

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -514,7 +514,21 @@ int main(int argc, char *argv[])
 
     /* we don't need to read config to handle this one */
     if (!strcmp(argv[optind], "version")) {
-        printf("%s %s\n", PACKAGE_NAME, CYRUS_VERSION);
+        printf("%s %s", PACKAGE_NAME, CYRUS_VERSION);
+
+#if defined WITH_STATIC_ASAN
+        printf(" (built with asan (statically linked))");
+#elif defined WITH_ASAN
+        printf(" (built with asan (dynamically linked))");
+#endif
+
+#if defined WITH_STATIC_UBSAN
+        printf(" (built with ubsan (statically linked))");
+#elif defined WITH_UBSAN
+        printf(" (built with ubsan (dynamically linked))");
+#endif
+
+        printf("\n");
         return 0;
     }
 


### PR DESCRIPTION
If enabled, by default these will link the sanitizer libraries statically. You can use --disable-static-asan and --disable-static-ubsan if you want them linked dynamically.

Generally, you want static linking, and the other tooling (that will make use of these configure arguments) will expect the libraries to be linked statically.

`cyr_info version` will also now use this info and display whether cyrus was built with one, both, or none of these sanitizers.

`make check` will automatically apply LSAN suppressions if built with asan. You can avoid this by doing:

    make SUPPRESS=0 check