### PR TITLE
Makefile.am: needs to know about xxhash.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1498,7 +1498,9 @@ lib_libcyrus_la_SOURCES = \
     lib/stristr.c \
     lib/times.c \
     lib/twom.c \
-    lib/wildmat.c
+    lib/wildmat.c \
+    lib/xxhash.h
+
 if USE_CYRUSDB_SQL
 lib_libcyrus_la_SOURCES += lib/cyrusdb_sql.c
 endif


### PR DESCRIPTION
otherwise it doesn't get distributed, and Cyrus can't be compiled from a source tarball because files are missing.

Looks like xxhash.h is only used to inline a bunch of stuff straight into twom.c, it's not a general-purpose library header.  So it goes into the same foo_SOURCES section as twom.c, and not one of the foo_HEADERS sections.

---

The way you test this sort of thing from a git tree is:

```
$git clean -xfd
$autoreconf -is
$./configure --enable-maintainer-mode
$ make distcheck
```

(Notice that this bypasses all of your usual build environment scripting and stuff! So you'll probably need to add the cyruslibs "bin" directory to your PATH temporarily, and perhaps some other things, so that the `make distcheck` step can succeed without false negatives.)

Among other things, `make distcheck` makes a distribution tarball, then extracts it, and tries to make a new distribution tarball from only the sources in the first one.  If it succeeds, then we know the distribution contains everything it needs to rebuild itself.  If it fails, then there's files in git that Makefile.am doesn't know about.