### PR TITLE
xunlink: return +1 when nothing removed because ENONET

### DIFF
--- a/cunit/command.testc
+++ b/cunit/command.testc
@@ -13,7 +13,7 @@ static void test_run(void)
     struct stat sb;
 
     /* make sure the file isnt there */
-    if (xunlink(canary))
+    if (xunlink(canary) == -1)
         r = errno;
     CU_ASSERT_EQUAL_FATAL(r, 0);
 
@@ -59,7 +59,7 @@ static void test_popen_w(void)
     char buf[32];
 
     /* make sure the file isnt there */
-    if (xunlink(canary))
+    if (xunlink(canary) == -1)
         r = errno;
     CU_ASSERT_EQUAL_FATAL(r, 0);
 

--- a/imap/append.c
+++ b/imap/append.c
@@ -1166,8 +1166,8 @@ havefile:
     if (r) goto out;
 
     if (in_object_storage) {  // must delete local file
-        if (xunlink(fname) != 0) // unlink should do it.
-            if (!remove (fname))  // we must insist
+        if (xunlink(fname) == -1) // unlink should do it.
+            if (!remove(fname))  // we must insist
                 syslog(LOG_ERR, "Removing local file <%s> error", fname);
     }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5207,7 +5207,7 @@ HIDDEN int mailbox_repack_commit(struct mailbox_repack **repackptr)
 
     for (i = 0; i < cachefiles.count; i++) {
         const char *fname = strarray_nth(&cachefiles, i);
-        if (!xunlink(fname))
+        if (xunlink(fname) == 0)
             syslog(LOG_NOTICE, "Removed unused cache file %s", fname);
     }
 

--- a/imap/mboxkey.c
+++ b/imap/mboxkey.c
@@ -339,7 +339,7 @@ EXPORTED int mboxkey_delete_user(const char *user)
     }
 
     /* erp! */
-    if (xunlink(fname))
+    if (xunlink(fname) == -1)
         r = IMAP_IOERROR;
     free(fname);
 

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -227,7 +227,7 @@ static void prometheus_done(void *rock __attribute__((unused)))
     mappedfile_unlock(promhandle->mf);
 
     /* unlink per-process stats file, we don't need it anymore */
-    if (xunlink(mappedfile_fname(promhandle->mf)))
+    if (xunlink(mappedfile_fname(promhandle->mf)) == -1)
         goto done;
     unlinked = 1;
 

--- a/imap/seen_db.c
+++ b/imap/seen_db.c
@@ -400,7 +400,7 @@ HIDDEN int seen_delete_user(const char *user)
                user);
     }
 
-    if (xunlink(fname))
+    if (xunlink(fname) == -1)
         r = IMAP_IOERROR;
 
     free(fname);

--- a/imap/sievedir.c
+++ b/imap/sievedir.c
@@ -259,7 +259,7 @@ EXPORTED int sievedir_deactivate_script(const char *sievedir)
     assert(sievedir);
 
     snprintf(active, sizeof(active), "%s/defaultbc", sievedir);
-    if (xunlink(active) != 0) {
+    if (xunlink(active) == -1) {
         xsyslog(LOG_ERR, "IOERROR: failed to delete active script link",
                 "link=<%s>", active);
         return SIEVEDIR_IOERROR;
@@ -276,7 +276,7 @@ EXPORTED int sievedir_delete_script(const char *sievedir, const char *name)
 
     /* delete bytecode */
     snprintf(path, sizeof(path), "%s/%s%s", sievedir, name, BYTECODE_SUFFIX);
-    if (xunlink(path) != 0) {
+    if (xunlink(path) == -1) {
         xsyslog(LOG_ERR, "IOERROR: failed to delete bytecode file",
                 "path=<%s>", path);
         return SIEVEDIR_IOERROR;

--- a/imap/squat_build.c
+++ b/imap/squat_build.c
@@ -565,7 +565,7 @@ static int init_write_buffer_to_temp(SquatIndex *index,
         return SQUAT_ERR;
     }
 
-    if (xunlink(tmp_path) < 0) {
+    if (xunlink(tmp_path) == -1) {
         squat_set_last_error(SQUAT_ERR_SYSERR);
         goto cleanup_fd;
     }

--- a/imap/sync_log.c
+++ b/imap/sync_log.c
@@ -619,7 +619,7 @@ EXPORTED int sync_log_reader_end(sync_log_reader_t *slr)
          * log file we rename()d to the work file.  Now that
          * we've done with the work file we can unlink it.
          * Further checks at this point are just paranoia. */
-        if (slr->work_file && xunlink(slr->work_file) < 0) {
+        if (slr->work_file && xunlink(slr->work_file) == -1) {
             syslog(LOG_ERR, "Unlink %s failed: %m", slr->work_file);
             return IMAP_IOERROR;
         }

--- a/lib/cyrusdb_quotalegacy.c
+++ b/lib/cyrusdb_quotalegacy.c
@@ -259,7 +259,7 @@ static int commit_subtxn(const char *fname, struct subtxn *tid)
         free(tid->fnamenew);
     } else if (tid->delete) {
         /* delete file */
-        if (xunlink(fname))
+        if (xunlink(fname) == -1)
             r = CYRUSDB_IOERROR;
     } else {
         /* read-only txn */

--- a/lib/xunlink.c
+++ b/lib/xunlink.c
@@ -59,12 +59,10 @@ EXPORTED int xunlink_fn(const char *sfile, int sline, const char *sfunc,
 
     if (r) {
         if (errno == ENOENT) {
-            /* we usually ignore this case, so treat it as not an error
-             *
-             * this means you can't use this wrapper function when you do care
-             * about this case
+            /* we usually ignore this case, so signal it differently, don't log
+             * it as an error, and leave errno intact
              */
-            r = 0;
+            r = 1;
         }
         else {
             /* n.b. not simply using xsyslog, because we want to log our
@@ -95,12 +93,10 @@ EXPORTED int xunlinkat_fn(const char *sfile, int sline, const char *sfunc,
 
     if (r) {
         if (errno == ENOENT) {
-            /* we usually ignore this case, so treat it as not an error
-             *
-             * this means you can't use this wrapper function when you do care
-             * about this case
+            /* we usually ignore this case, so signal it differently, don't log
+             * it as an error, and leave errno intact
              */
-            r = 0;
+            r = 1;
         }
         else {
             /* n.b. not simply using xsyslog, because we want to log our

--- a/lib/xunlink.h
+++ b/lib/xunlink.h
@@ -53,9 +53,13 @@
  * except that:
  *  1) errors are logged for you; and
  *  2) ENOENT is treated as not an error: nothing is logged, errno is not set,
- *     and 0 is returned
+ *     and 1 is returned
  *
- * You cannot use these wrappers if you need to detect ENOENT failures.
+ *  Almost all callers of xunlink ignore the return value, but if you're going
+ *  to check it, remember:
+ *  *  0 means a successful unlink
+ *  *  1 means there was no file to unlink
+ *  * <0 means another error, which will be syslogged
  **/
 
 #define xunlink(pathname)                                                     \


### PR DESCRIPTION
(This also makes a related change in imap/append.c.)

Recently, xunlink was changed to restore errno after a call if the result was ENOENT, on the theory that we use xunlink when we know the file might not exist, and that we should treat ENOENT like success.  "If we care about the result, we should use unlink, not xunlink!" we said, at the time.

Unsurprisingly, we've now found a case where we care.  During append, we try to remove any file that might be in our way.  If this works, it means there *was* a file, and we report an error.  Unfortunately, when xunlink changed, it seemed like there was *always* a file, because we started to get 0 instead of ENOENT.

This is not a perfect fix, since it will now treat (say) EACCES as "there was nothing to delete".

This just addresses one or two instances.  Next, we should look for any construct in the form "if (xunlink(...) == ...)" and similar ones.