### PR TITLE
cyrusdb_copyfile: sync the directory after copying file

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -1095,18 +1095,6 @@ havefile:
     r = mailbox_copyfile(linkfile ? linkfile : stagefile, fname, nolink);
     if (r) goto out;
 
-    FILE *destfile = fopen(fname, "r");
-    if (destfile) {
-        /* this will hopefully ensure that the link() actually happened
-           and makes sure that the file actually hits disk */
-        fsync(fileno(destfile));
-        fclose(destfile);
-    }
-    else {
-        r = IMAP_IOERROR;
-        goto out;
-    }
-
     if (config_getstring(IMAPOPT_ANNOTATION_CALLOUT) &&
         (mbtype_isa(mailbox_mbtype(mailbox)) == MBTYPE_EMAIL)) {
         if (flags)

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -2196,19 +2196,17 @@ static int tm_rename(struct twom_db *db, struct tm_file *oldfile, const char *ne
     int r = 0;
     int dirfd = -1;
 
-    if (!db->nosync) {
-    #if defined(O_DIRECTORY)
-        dirfd = open(dir, O_RDONLY|O_DIRECTORY, 0600);
+#if defined(O_DIRECTORY)
+    dirfd = open(dir, O_RDONLY|O_DIRECTORY, 0600);
 #else
-        dirfd = open(dir, O_RDONLY, 0600);
+    dirfd = open(dir, O_RDONLY, 0600);
 #endif
-        if (dirfd < 0) {
-            db->error("open directory failed",
-                      "filename=<%s> newname=<%s> directory=<%s>",
-                      db->fname, newname, dir);
-            r = TWOM_IOERROR;
-            goto done;
-        }
+    if (dirfd < 0) {
+        db->error("open directory failed",
+                  "filename=<%s> newname=<%s> directory=<%s>",
+                  db->fname, newname, dir);
+        r = TWOM_IOERROR;
+        goto done;
     }
 
     if (fstat(oldfile->fd, &sbuf) == -1) {
@@ -2232,7 +2230,7 @@ static int tm_rename(struct twom_db *db, struct tm_file *oldfile, const char *ne
         goto done;
     }
 
-    r = rename(newname, db->fname);
+    r = renameat(AT_FDCWD, newname, dirfd, db->fname);
     if (r) goto done;
 
     if (!db->nosync) {

--- a/lib/util.h
+++ b/lib/util.h
@@ -235,7 +235,8 @@ enum {
     COPYFILE_NOLINK = (1<<0),
     COPYFILE_MKDIR  = (1<<1),
     COPYFILE_RENAME = (1<<2),
-    COPYFILE_KEEPTIME = (1<<3)
+    COPYFILE_KEEPTIME = (1<<3),
+    COPYFILE_NODIRSYNC = (1<<4)
 };
 
 extern int cyrus_copyfile(const char *from, const char *to, int flags);


### PR DESCRIPTION
This fixes a bug where append thinks it has copied the file into place, but it was fsyncing the content (which copyfile already did) rather than the directory