### PR TITLE
lmtpd.c: remove redundant check for "anonymous" userid

### DIFF
--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -1134,12 +1134,6 @@ int autocreate_inbox(const mbname_t *mbname)
         return IMAP_MAILBOX_NONEXISTENT;
 
     /*
-     * Exclude anonymous
-     */
-    if (!strcmp(userid, "anonymous"))
-        return IMAP_MAILBOX_NONEXISTENT;
-
-    /*
      * Check for autocreatequota and createonpost
      */
     if (config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K') < 0)


### PR DESCRIPTION
The autocreate_inbox function checks for "anonymous" userid before calling autocreate_user but the latter function also contains a check for "anonymous" userid. Remove the check in autocreate_inbox and leave it to autocreate_user to reject the "anonymous" userid.

Fixes #2539

Thanks to @dilyanpalauzov