### PR TITLE
cyrus_bylaws.rst: remove Matthew Selsky from core devs

### DIFF
--- a/docsrc/overview/cyrus_bylaws.rst
+++ b/docsrc/overview/cyrus_bylaws.rst
@@ -26,7 +26,6 @@ The members of the Core Developers group are:
 * Bron Gondwana
 * ellie timoney
 * Ken Murchison
-* Matt Selsky
 * Robert Stepanek
 
 III. The Release Engineer


### PR DESCRIPTION
Selsky has not been working on Cyrus in a long time, and says he can be removed from the core dev list.