### PR TITLE
imapoptions: deprecate unused "postspec" option

### DIFF
--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -2144,7 +2144,8 @@ If all partitions are over that limit, this feature is not used anymore.
 /* Username that is used as the 'From' address in rejection MDNs produced
    by sieve. */
 
-{ "postspec", NULL, STRING, "2.3.17" }
+{ "postspec", NULL, STRING, "UNRELEASED", "UNRELEASED" }
+/* Deprecated. No longer used. */
 
 { "postuser", "", STRING, "2.3.17" }
 /* Userid used to deliver messages to shared folders.  For example, if


### PR DESCRIPTION
This option got introduced for version "2.3.17" but it seemingly never got implemented. The commit ref that introduced it is ced20b69d8064480d05e6f40da4093584b4c4ae9

Fixes #2948