### PR TITLE
imapd/httpd:http_allow_noauth_get: don't request authentication depending on the HTTP verb

### DIFF
--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -95,7 +95,7 @@ static int action_conf(struct transaction_t *txn);
 /* Namespace for admin service */
 struct namespace_t namespace_admin = {
     URL_NS_ADMIN, 1, "admin", "/admin", NULL,
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,
     admin_init, NULL, NULL, NULL, NULL,

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -59,7 +59,7 @@ static int meth_post_applepush(struct transaction_t *txn, void *params);
 
 struct namespace_t namespace_applepush = {
     URL_NS_APPLEPUSH, /*enabled*/0, "applepush", "/applepush/subscribe", NULL,
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ|ALLOW_POST,
     &applepush_init, NULL, NULL, NULL, NULL,

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -617,7 +617,7 @@ static struct meth_params caldav_params = {
 /* Namespace for CalDAV collections */
 struct namespace_t namespace_calendar = {
     URL_NS_CALENDAR, 0, "calendar", "/dav/calendars", "/.well-known/caldav",
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     MBTYPE_CALENDAR,
     (ALLOW_READ | ALLOW_POST | ALLOW_WRITE | ALLOW_DELETE |
      ALLOW_PATCH | ALLOW_USERDATA |
@@ -655,7 +655,7 @@ struct namespace_t namespace_calendar = {
 /* Namespace for Freebusy Read URL */
 struct namespace_t namespace_freebusy = {
     URL_NS_FREEBUSY, 0, "freebusy", "/freebusy", NULL,
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     MBTYPE_CALENDAR,
     ALLOW_READ,
     NULL, NULL, NULL, NULL, NULL,

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -392,7 +392,7 @@ static struct meth_params carddav_params = {
 /* Namespace for Carddav collections */
 struct namespace_t namespace_addressbook = {
     URL_NS_ADDRESSBOOK, 0, "addressbook", "/dav/addressbooks", "/.well-known/carddav",
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     MBTYPE_ADDRESSBOOK,
     (ALLOW_READ | ALLOW_POST | ALLOW_WRITE | ALLOW_DELETE |
      ALLOW_DAV | ALLOW_PROPPATCH | ALLOW_MKCOL | ALLOW_ACL | ALLOW_CARD),

--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -72,7 +72,7 @@ static int meth_post(struct transaction_t *txn, void *params);
 /* Namespace for CGI */
 struct namespace_t namespace_cgi = {
     URL_NS_CGI, 0, "cgi", "/cgi-bin", NULL,
-    http_allow_noauth, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ | ALLOW_POST,
     cgi_init, NULL, NULL, NULL, NULL,

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -303,7 +303,7 @@ struct meth_params princ_params = {
 /* Namespace for WebDAV principals */
 struct namespace_t namespace_principal = {
     URL_NS_PRINCIPAL, 0, "principal", "/dav/principals", NULL,
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype */ 0,
     ALLOW_READ | ALLOW_DAV | ALLOW_PROPPATCH,
     &my_dav_init, NULL, NULL, &my_dav_shutdown, &dav_premethod,

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -271,7 +271,7 @@ static struct meth_params notify_params = {
 /* Namespace for WebDAV notification collections */
 struct namespace_t namespace_notify = {
     URL_NS_NOTIFY, 0, "notify", "/dav/notifications", NULL,
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     MBTYPE_COLLECTION,
     (ALLOW_READ | ALLOW_POST | ALLOW_DELETE |
      ALLOW_DAV | ALLOW_PROPPATCH | ALLOW_ACL),

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -58,7 +58,7 @@ static int meth_get_db(struct transaction_t *txn, void *params);
 /* Namespace for DB lookups */
 struct namespace_t namespace_dblookup = {
     URL_NS_DBLOOKUP, /*enabled*/1, "dblookup", "/dblookup", NULL,
-    http_allow_noauth, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,
     NULL, NULL, NULL, NULL, NULL,

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -120,7 +120,7 @@ static struct mime_type_t isched_mime_types[] = {
 
 struct namespace_t namespace_ischedule = {
     URL_NS_ISCHEDULE, 0, "ischedule", "/ischedule", ISCHED_WELLKNOWN_URI,
-    http_allow_noauth, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     (ALLOW_READ | ALLOW_POST | ALLOW_ISCHEDULE),
     isched_init, NULL, NULL, isched_shutdown, NULL,
@@ -152,7 +152,7 @@ struct namespace_t namespace_ischedule = {
 
 struct namespace_t namespace_domainkey = {
     URL_NS_DOMAINKEY, 0, "domainkey", "/domainkeys", "/.well-known/domainkey",
-    http_allow_noauth, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,
     NULL, NULL, NULL, NULL, NULL,

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -83,7 +83,6 @@ static time_t compile_time;
 
 /* Namespace callbacks */
 static void jmap_init(struct buf *serverinfo);
-static int  jmap_need_auth(struct transaction_t *txn);
 static int  jmap_auth(const char *userid);
 static void jmap_reset(void);
 static void jmap_shutdown(void);
@@ -113,7 +112,7 @@ static struct connect_params ws_params = {
 /* Namespace for JMAP */
 struct namespace_t namespace_jmap = {
     URL_NS_JMAP, 0, "jmap", JMAP_ROOT, "/.well-known/jmap",
-    jmap_need_auth, 0,
+    0,
     /*mbtype*/0, 
     (ALLOW_READ | ALLOW_POST | ALLOW_READONLY),
     &jmap_init, &jmap_auth, &jmap_reset, &jmap_shutdown, NULL,
@@ -218,12 +217,6 @@ static int jmap_auth(const char *userid __attribute__((unused)))
     mboxname_init_namespace(&jmap_namespace, options);
 
     return 0;
-}
-
-static int jmap_need_auth(struct transaction_t *txn __attribute__((unused)))
-{
-    /* All endpoints require authentication */
-    return HTTP_UNAUTHORIZED;
 }
 
 static void jmap_reset(void)

--- a/imap/http_prometheus.c
+++ b/imap/http_prometheus.c
@@ -47,7 +47,6 @@
 #include "imap/http_err.h"
 #include "imap/prometheus.h"
 
-static int prom_need_auth(struct transaction_t *txn);
 static void prom_init(struct buf *);
 static int prom_auth(const char *);
 static void prom_reset(void);
@@ -60,7 +59,6 @@ struct namespace_t namespace_prometheus = {
     "prometheus",
     "/metrics",
     /* XXX .well-known url*/ NULL,
-    prom_need_auth,
     /* XXX auth schemes*/ 0,
     /*mboxtype*/ 0,
     (ALLOW_READ),
@@ -94,16 +92,6 @@ struct namespace_t namespace_prometheus = {
         { NULL,                 NULL },                 /* UNLOCK       */
     },
 };
-
-static int prom_need_auth(struct transaction_t *txn __attribute__((unused)))
-{
-    const char *need_auth = config_getstring(IMAPOPT_PROMETHEUS_NEED_AUTH);
-
-    if (!strcmp(need_auth, "none"))
-        return 0;
-
-    return HTTP_UNAUTHORIZED;
-}
 
 static void prom_init(struct buf *serverinfo __attribute__((unused)))
 {

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -109,7 +109,7 @@ static struct body *body_fetch_section(struct body *body, const char *section);
 /* Namespace for RSS feeds of mailboxes */
 struct namespace_t namespace_rss = {
     URL_NS_RSS, 0, "rss", "/rss", NULL,
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,
     rss_init, NULL, NULL, NULL, NULL,

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -132,7 +132,7 @@ static struct mime_type_t tz_mime_types[] = {
 /* Namespace for tzdist service */
 struct namespace_t namespace_tzdist = {
     URL_NS_TZDIST, 0, "tzdist", "/tzdist", TZDIST_WELLKNOWN_URI,
-    http_allow_noauth, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,
     tzdist_init, NULL, NULL, tzdist_shutdown, NULL,

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -259,7 +259,7 @@ struct meth_params webdav_params = {
 /* Namespace for Webdav collections */
 struct namespace_t namespace_drive = {
     URL_NS_DRIVE, 0, "drive", "/dav/drive", NULL,
-    http_allow_noauth_get, /*authschemes*/0,
+    /*authschemes*/0,
     MBTYPE_COLLECTION,
     (ALLOW_READ | ALLOW_POST | ALLOW_WRITE | ALLOW_DELETE |
      ALLOW_DAV | ALLOW_PROPPATCH | ALLOW_MKCOL | ALLOW_ACL),

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -551,7 +551,7 @@ static struct connect_params ws_params = {
 /* Namespace to fetch static content from filesystem */
 static struct namespace_t namespace_default = {
     URL_NS_DEFAULT, 1, "default", "", NULL,
-    http_allow_noauth, /*authschemes*/0,
+    /*authschemes*/0,
     /*mbtype*/0,
     ALLOW_READ,
     NULL, NULL, NULL, NULL, NULL,
@@ -1986,11 +1986,6 @@ EXPORTED int examine_request(struct transaction_t *txn, const char *uri)
     proc_settitle(buf_cstring(&txn->buf), txn->conn->clienthost, httpd_userid,
                   txn->req_tgt.path, txn->req_line.meth);
     buf_reset(&txn->buf);
-
-    /* Request authentication, if necessary */
-    if (!httpd_userid && namespace->need_auth(txn)) {
-        ret = HTTP_UNAUTHORIZED;
-    }
 
     if (ret) return client_need_auth(txn, sasl_result);
 
@@ -5251,27 +5246,6 @@ EXPORTED int httpd_myrights(struct auth_state *authstate, const mbentry_t *mbent
 
     return rights;
 }
-
-/* Allow unauthenticated GET/HEAD, deny all other unauthenticated requests */
-EXPORTED int http_allow_noauth_get(struct transaction_t *txn)
-{
-    /* Inverse logic: True means we *require* authentication */
-    switch (txn->meth) {
-    case METH_GET:
-    case METH_HEAD:
-        /* Let method processing function decide if auth is needed */
-        return 0;
-    default:
-        return 1;
-    }
-}
-
-/* Allow unauthenticated requests */
-EXPORTED int http_allow_noauth(struct transaction_t *txn __attribute__((unused)))
-{
-    return 0;
-}
-
 
 /* Read the body of a request */
 EXPORTED int http_read_req_body(struct transaction_t *txn)

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -507,7 +507,6 @@ struct namespace_t {
     const char *name;           /* Text name of this namespace ([A-Z][a-z][0-9]+) */
     const char *prefix;         /* Prefix of URL path denoting namespace */
     const char *well_known;     /* Any /.well-known/ URI */
-    int (*need_auth)(txn_t *);  /* Function run prior to unauthorized requests */
     unsigned auth_schemes;      /* Bitmask of allowed auth schemes, 0 for any */
     uint32_t mboxtype;          /* What mbtype can be seen in this namespace? */
     unsigned long allow;        /* Bitmask of allowed features/methods */
@@ -628,8 +627,6 @@ extern int process_request(struct transaction_t *txn);
 extern void transaction_free(struct transaction_t *txn);
 
 extern int httpd_myrights(struct auth_state *authstate, const mbentry_t *mbentry);
-extern int http_allow_noauth(struct transaction_t *txn);
-extern int http_allow_noauth_get(struct transaction_t *txn);
 extern int http_read_req_body(struct transaction_t *txn);
 
 extern void zlib_init(struct transaction_t *txn);


### PR DESCRIPTION
Instead always check the ACLs, so that anonymous users can subscribe a CalDAV resource.

This is https://github.com/cyrusimap/cyrus-imapd/issues/2425, 

Let’s what will happen.