### PR TITLE
http_dav.c: do not suppress unexpected errors in PROPFIND

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -6165,7 +6165,7 @@ int propfind_by_collection(const mbentry_t *mbentry, void *rock)
     buf_free(&writebuf);
     if (mailbox) mailbox_close(&mailbox);
 
-    return 0;
+    return r;
 }
 
 /* Free an entry list */


### PR DESCRIPTION
propfind_by_collection returned 0 despite any unexpected error making it return early.

Fixes #3258