### PR TITLE
Buf mmap fix length

### DIFF
--- a/lib/map_shared.c
+++ b/lib/map_shared.c
@@ -89,13 +89,11 @@ EXPORTED void map_refresh(int fd, int onceonly, const char **base,
         }
     }
 
-    /* always map one extra byte so there's a trailing NULL to protect
-     * us from overruns.  This does NOT mean that we should treat this
-     * memory as a cstring */
-    if (!onceonly)
-        newlen = (newlen + 2*SLOP) & ~(SLOP-1);
+    if (!onceonly) {
+        newlen = (newlen + 2*SLOP - 1) & ~(SLOP-1);
+    }
 
-    *base = (char *)mmap((caddr_t)0, onceonly ? newlen + 1 : newlen, PROT_READ, MAP_SHARED
+    *base = (char *)mmap((caddr_t)0, newlen, PROT_READ, MAP_SHARED
 #ifdef MAP_FILE
 | MAP_FILE
 #endif

--- a/lib/map_stupidshared.c
+++ b/lib/map_stupidshared.c
@@ -94,10 +94,7 @@ EXPORTED map_refresh(int fd, int onceonly, const char **base,
     flags |= MAP_VARIABLE;
 #endif
 
-    /* always map one extra byte so there's a trailing NULL to protect
-     * us from overruns.  This does NOT mean that we should treat this
-     * memory as a cstring */
-    *base = (char *)mmap((caddr_t)0, newlen+1, PROT_READ, flags, fd, 0L);
+    *base = (char *)mmap((caddr_t)0, newlen, PROT_READ, flags, fd, 0L);
     if (*base == (char *)MAP_FAILED) {
         syslog(LOG_ERR, "IOERROR: mapping %s file%s%s: %m", name,
                mboxname ? " for " : "", mboxname ? mboxname : "");


### PR DESCRIPTION
This reverts the changes from https://github.com/cyrusimap/cyrus-imapd/pull/4840 which turns out to leak mmaps!  You can't just munmap a different length than you passed to mmap.

Instead, we're going to find the actual bugs and fix them as we hit them.