### PR TITLE
standardize on XXX, not FIXME

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: No hard tabs
+name: Content linting
 
 on:
   workflow_dispatch:
@@ -11,7 +11,8 @@ on:
       - master
       - main
 jobs:
-  assert-no-tabs:
+  content-linting:
+    name: Content linting
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -20,3 +21,6 @@ jobs:
     - name: Assert no tabs
       shell: bash
       run: ./tools/hard-tab-tool
+    - name: Assert no FIXME
+      shell: bash
+      run: ./tools/find-fixme-markers

--- a/cassandane/Cassandane/Cyrus/List.pm
+++ b/cassandane/Cassandane/Cyrus/List.pm
@@ -82,37 +82,37 @@ sub tear_down
 #sub test_rfc5258_ex04_remote_children
 #{
 #    my ($self) = @_;
-#    $self->assert(0, 'FIXME test not implemented');
+#    $self->assert(0, 'XXX test not implemented');
 #}
 
 #sub test_rfc5258_ex05_remote_subscribed
 #{
 #    my ($self) = @_;
-#    $self->assert(0, 'FIXME test not implemented');
+#    $self->assert(0, 'XXX test not implemented');
 #}
 
 #sub test_rfc5258_ex06_remote_return_subscribed
 #{
 #    my ($self) = @_;
-#    $self->assert(0, 'FIXME test not implemented');
+#    $self->assert(0, 'XXX test not implemented');
 #}
 
 #sub test_rfc5258_ex09_childinfo
 #{
 #    my ($self) = @_;
-#    $self->assert(0, 'FIXME test not implemented');
+#    $self->assert(0, 'XXX test not implemented');
 #}
 
 #sub test_rfc5258_ex10_multiple_mailbox_patterns_childinfo
 #{
 #    my ($self) = @_;
-#    $self->assert(0, 'FIXME test not implemented');
+#    $self->assert(0, 'XXX test not implemented');
 #}
 
 #sub test_rfc5258_ex11_missing_hierarchy_elements
 #{
 #    my ($self) = @_;
-#    $self->assert(0, 'FIXME test not implemented');
+#    $self->assert(0, 'XXX test not implemented');
 #}
 
 # tests based on rfc 6154 examples:

--- a/cassandane/tiny-tests/CaldavAlarm/reschedule_exception
+++ b/cassandane/tiny-tests/CaldavAlarm/reschedule_exception
@@ -6,7 +6,7 @@ sub test_reschedule_exception
 {
     my ($self) = @_;
 
-    # FIXME disable this test until calalarmd is fixed
+    # XXX disable this test until calalarmd is fixed
     return;
 
     my $CalDAV = $self->{caldav};

--- a/cassandane/tiny-tests/JMAPCalendars/rscale_in_jmap_hidden_in_caldav
+++ b/cassandane/tiny-tests/JMAPCalendars/rscale_in_jmap_hidden_in_caldav
@@ -74,7 +74,7 @@ sub test_rscale_in_jmap_hidden_in_caldav
         $ret->{recurrenceRules},
     );
 
-    # FIXME Net-CalDAV talk needs to update
+    # XXX Net-CalDAV talk needs to update
     # Make sure we have no rscale through caldav, most clients can't
     # handle it
     my $events = $caldav->GetEvents("$calid");

--- a/cassandane/tiny-tests/JMAPEmail/blob_copy
+++ b/cassandane/tiny-tests/JMAPEmail/blob_copy
@@ -10,7 +10,7 @@ sub test_blob_copy
     my $imaptalk = $self->{store}->get_client();
     my $admintalk = $self->{adminstore}->get_client();
 
-    # FIXME how to share just #jmap folder?
+    # XXX how to share just #jmap folder?
     xlog $self, "create user foo and share inbox";
     $self->{instance}->create_user("foo");
     $admintalk->setacl("user.foo", "cassandane", "lrkintex") or die;

--- a/cassandane/tiny-tests/List/rfc5258_ex08_haschildren_childinfo
+++ b/cassandane/tiny-tests/List/rfc5258_ex08_haschildren_childinfo
@@ -21,5 +21,5 @@ sub test_rfc5258_ex08_haschildren_childinfo
     });
 
     # TODO probably break the rest of this test out into 8a, 8b etc
-    xlog('FIXME much more to test here...');
+    xlog('XXX much more to test here...');
 }

--- a/cmulocal/sasl2.m4
+++ b/cmulocal/sasl2.m4
@@ -90,8 +90,8 @@ if test "$gssapi" != no; then
      GSSAPIBASE_LIBS="-L$gssapi_dir"
      GSSAPIBASE_STATIC_LIBS="-L$gssapi_dir"
   else
-     # FIXME: This is only used for building cyrus, and then only as
-     # a real hack.  it needs to be fixed.
+     # XXX: This is only used for building cyrus, and then only as a real hack.
+     # it needs to be fixed.
      gssapi_dir="/usr/local/lib"
   fi
 
@@ -126,7 +126,7 @@ if test "$gssapi" != no; then
 
     cmu_saved_CPPFLAGS=$CPPFLAGS
     cmu_saved_GSSAPIBASE_LIBS=$GSSAPIBASE_LIBS
-# FIXME - Note that the libraries are in .../lib64 for 64bit kernels
+# XXX - Note that the libraries are in .../lib64 for 64bit kernels
     if test -d "${gssapi}/appsec-rt/lib"; then
       GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -L${gssapi}/appsec-rt/lib"
     fi

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -137,7 +137,7 @@ static void test_prune(void)
     struct conversations_state *state = NULL;
     static const char C_MSGID1[] = "<0003.1288854309@example.com>";
     static const conversation_id_t C_CID1 = 0x1045689abcdef23ULL;
-    time_t stamp1 __attribute__((unused));  /* FIXME did this have a use? it's not being used */
+    time_t stamp1 __attribute__((unused));  /* XXX did this have a use? it's not being used */
     static const char C_MSGID2[] = "<0004.1288854309@example.com>";
     static const conversation_id_t C_CID2 = 0x105689abcdef234ULL;
     time_t stamp2;
@@ -983,7 +983,7 @@ static void test_folder_ordering(void)
 }
 
 #ifdef TEST_SENDERS_COMPILES
-/* FIXME this doesn't currently compile, but i can't tell what the broken bit is trying to do */
+/* XXX this doesn't currently compile, but i can't tell what the broken bit is trying to do */
 static void __test_senders(void)
 {
     int r;

--- a/docsrc/imap/reference/admin/access-control/identifiers.rst
+++ b/docsrc/imap/reference/admin/access-control/identifiers.rst
@@ -7,7 +7,7 @@ The Access Control Identifier (ACI) part of an ACL entry specifies the
 user or group for which the entry applies.  Group identifiers are
 distinguished by the prefix "group:".  For example, "group:accounting".
 
-.. todo:: FIXME: Clarify what an ACL entry looks like first. Refer to
+.. TODO:: Clarify what an ACL entry looks like first. Refer to
           how user login names are translated into their identifiers, and (in
           that section) refer to altnamespace, unixhierarchysep, default domain,
           virtdomains, tips and tricks etc.

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -961,7 +961,7 @@ static int split_attribs(const char *data, int datalen,
     /* initialize metadata */
     memset(mdata, 0, sizeof(struct annotate_metadata));
 
-    /* xxx sanity check the data? */
+    /* XXX sanity check the data? */
     if (datalen <= 0)
             return 1;
     /*
@@ -1273,7 +1273,7 @@ EXPORTED annotate_state_t *annotate_state_new(void)
 
 static void annotate_state_start(annotate_state_t *state)
 {
-    /* xxx better way to determine a size for this table? */
+    /* XXX better way to determine a size for this table? */
     construct_hash_table(&state->entry_table, 100, 1);
     construct_hash_table(&state->server_table, 10, 1);
 }
@@ -2835,7 +2835,7 @@ EXPORTED int annotate_state_fetch(annotate_state_t *state,
 
             if (proxy_fetch_func && state->orig_entry && state->mbentry->server &&
                 !hash_lookup(state->mbentry->server, &state->server_table)) {
-                /* xxx ignoring result */
+                /* XXX ignoring result */
                 proxy_fetch_func(state->mbentry->server, state->mbentry->ext_name,
                                  state->orig_entry, state->orig_attribute);
                 hash_insert(state->mbentry->server, (void *)0xDEADBEEF, &state->server_table);

--- a/imap/append.c
+++ b/imap/append.c
@@ -970,7 +970,7 @@ EXPORTED int append_fromstage_full(struct appendstate *as, struct body **body,
         if (r) goto out;
     }
 
-    /* xxx check errors */
+    /* XXX check errors */
     mboxlist_findstage(mailbox_name(mailbox), stagefile, sizeof(stagefile));
     strlcat(stagefile, stage->fname, sizeof(stagefile));
 
@@ -1015,7 +1015,7 @@ EXPORTED int append_fromstage_full(struct appendstate *as, struct body **body,
             /* maybe the directory doesn't exist? */
             char stagedir[MAX_MAILBOX_PATH+1];
 
-            /* xxx check errors */
+            /* XXX check errors */
             mboxlist_findstage(mailbox_name(mailbox), stagedir, sizeof(stagedir));
             if (mkdir(stagedir, 0755) != 0) {
                 syslog(LOG_ERR, "couldn't create stage directory: %s: %m",

--- a/imap/arbitron.c
+++ b/imap/arbitron.c
@@ -76,7 +76,7 @@ extern int optind;
 extern char *optarg;
 
 /* Maintain the mailbox list */
-/* xxx it'd be nice to generate a subscriber list too */
+/* XXX it'd be nice to generate a subscriber list too */
 struct user_list {
     const char *user;
     struct user_list *next;
@@ -381,7 +381,7 @@ static int process_user_p(void *rockp,
     /* remember that 'data' may not be null terminated ! */
     version = strtol(data, &p, 10); data = p;
     if (version < 0) abort();
-    /* xxx not checking version */
+    /* XXX not checking version */
     lastread = strtol(data, &p, 10); data = p;
 
     memcpy(buf, key, keylen);

--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -88,7 +88,7 @@ static int chkmbox(struct findall_data *data, void *rock __attribute__((unused))
     if (r == IMAP_MAILBOX_NONEXISTENT)
        return 0;
 
-    /* xxx reserved mailboxes? */
+    /* XXX reserved mailboxes? */
 
     if (r) {
         fprintf(stderr, "bad mailbox %s in chkmbox: %s\n", name, error_message(r));

--- a/imap/cyrdump.c
+++ b/imap/cyrdump.c
@@ -260,7 +260,7 @@ static int dump_me(struct findall_data *data, void *rock)
     i = 0;
     while (i < numuids && uids[i] < irec->incruid) {
         /* already dumped this message */
-        /* xxx could do binary search to get to the first
+        /* XXX could do binary search to get to the first
            undumped uid */
         i++;
     }

--- a/imap/deliver.c
+++ b/imap/deliver.c
@@ -361,7 +361,7 @@ static int deliver_msg(char *return_path, char *authuser, int ignorequota,
     if (numusers == 0) {
         /* just deliver to mailbox 'mailbox' */
         const char *BB = config_getstring(IMAPOPT_POSTUSER);
-        txn->rcpt[0].addr = (char *) xmalloc(ml + strlen(BB) + 2); /* xxx leaks! */
+        txn->rcpt[0].addr = (char *) xmalloc(ml + strlen(BB) + 2); /* XXX leaks! */
         sprintf(txn->rcpt[0].addr, "%s+%s", BB, mailbox);
         txn->rcpt[0].ignorequota = ignorequota;
     } else {

--- a/imap/fetchnews.c
+++ b/imap/fetchnews.c
@@ -333,7 +333,7 @@ int main(int argc, char *argv[])
     cyrus_init(alt_config, "fetchnews", 0, 0);
 
     /* connect to the peer */
-    /* xxx configurable port number? */
+    /* XXX configurable port number? */
     if ((psock = init_net(peer, "119", &pin, &pout)) < 0) {
         fprintf(stderr, "connection to %s failed\n", peer);
         cyrus_done();

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5310,7 +5310,7 @@ static void prune_properties(icalcomponent *parent,
 
 static int expand_cb(icalcomponent *comp,
                      icaltimetype start, icaltimetype end,
-                     icaltimetype _recurid __attribute__((unused)), // FIXME
+                     icaltimetype _recurid __attribute__((unused)), // XXX
                      int is_standalone __attribute__((unused)),
                      void *rock)
 {

--- a/imap/http_prometheus.c
+++ b/imap/http_prometheus.c
@@ -114,18 +114,18 @@ static void prom_init(struct buf *serverinfo __attribute__((unused)))
 
 static int prom_auth(const char *userid __attribute__((unused)))
 {
-    /* FIXME */
+    /* XXX */
     return 0;
 }
 
 static void prom_reset(void)
 {
-    /* FIXME */
+    /* XXX */
 }
 
 static void prom_shutdown(void)
 {
-    /* FIXME */
+    /* XXX */
 }
 
 static int prom_get(struct transaction_t *txn,

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -816,7 +816,7 @@ out:
     return r;
 }
 
-/* xxx  start of separate proxy-only code
+/* XXX  start of separate proxy-only code
    (remove when we move to a unified environment) */
 static int chomp(struct protstream *p, const char *s)
 {
@@ -1239,7 +1239,7 @@ int proxy_fetch(char *sequence, int usinguid, unsigned items,
 
     return PROXY_OK;
 }
-/* xxx  end of separate proxy-only code */
+/* XXX  end of separate proxy-only code */
 
 int proxy_catenate_url(struct backend *s, struct imapurl *url, FILE *f,
                        size_t maxsize, unsigned long *size, const char **parseerr)

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -5052,7 +5052,7 @@ static void cmd_close(char *tag, char *cmd)
     if (backend_current) {
         /* remote mailbox */
         prot_printf(backend_current->out, "%s %s\r\n", tag, cmd);
-        /* xxx do we want this to say OK if the connection is gone?
+        /* XXX do we want this to say OK if the connection is gone?
          * saying NO is clearly wrong, hense the fatal request. */
         pipe_including_tag(backend_current, tag, 0);
 
@@ -6654,7 +6654,7 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
     if (!r && backend_current) {
         /* remote mailbox -> local or remote mailbox */
 
-        /* xxx  start of separate proxy-only code
+        /* XXX  start of separate proxy-only code
            (remove when we move to a unified environment) */
         struct backend *s = NULL;
 
@@ -6674,7 +6674,7 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
             proxy_copy(tag, sequence, name, myrights, usinguid, s);
             goto cleanup;
         }
-        /* xxx  end of separate proxy-only code */
+        /* XXX  end of separate proxy-only code */
 
         /* simply send the COPY to the backend */
         prot_printf(
@@ -6696,7 +6696,7 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
          *
          * fetch the messages and APPEND them to the backend
          *
-         * xxx  completely untested
+         * XXX  completely untested
          */
         struct backend *s = NULL;
         int res;

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -8191,8 +8191,8 @@ static void calendarevent_to_ical(icalcomponent *comp,
         jmap_parser_invalid(parser, "alerts");
     }
 
-    /* FIXME localizations */
-    /* FIXME categories */
+    /* XXX localizations */
+    /* XXX categories */
 
     /* mayInviteSelf */
     jprop = json_object_get(event, "mayInviteSelf");

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -3769,7 +3769,7 @@ static int _mboxset_state_find_specialuse_cb(const char *mboxname,
     struct mboxset_state *state = rock;
     jmap_req_t *req = state->req;
 
-    if (!strcmpsafe(userid, req->accountid)) { // FIXME userid or accountid?
+    if (!strcmpsafe(userid, req->accountid)) { // XXX userid or accountid?
         const char *mbox_id = hash_lookup(mboxname, state->id_by_imapname);
         if (mbox_id) {
             strarray_t *specialuses = strarray_split(buf_cstring(value), " ", STRARRAY_TRIM);

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -665,7 +665,7 @@ EXPORTED int dump_mailbox(const char *tag, struct mailbox *mailbox, uint32_t uid
 
         /* Dump sieve files
          *
-         * xxx can't use home directories currently
+         * XXX can't use home directories currently
          * (it makes almost no sense in the conext of a murder) */
         if (!sieve_usehomedir) {
             const char *sieve_path = user_sieve_path(userid);
@@ -980,7 +980,7 @@ EXPORTED int undump_mailbox(const char *mbname,
             }
 
             c = getbastring(pin, pout, &content);
-            /* xxx binary */
+            /* XXX binary */
 
             if(c != ' ') {
                 r = IMAP_PROTOCOL_ERROR;
@@ -1122,7 +1122,7 @@ EXPORTED int undump_mailbox(const char *mbname,
             else realname = file.s + 6;
 
             if(sieve_usehomedir) {
-                /* xxx! */
+                /* XXX! */
                 syslog(LOG_ERR,
                        "dropping sieve file %s since this host is " \
                        "configured for sieve_usehomedir",

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -239,7 +239,7 @@ static int do_examine(struct findall_data *data, void *rock)
 
     printf(" Mailbox Header Info:\n");
     printf("  Path to mailbox: %s\n", mailbox_datapath(mailbox, 0));
-    printf("  Mailbox ACL: %s\n", mailbox_acl(mailbox)); /* xxx parse */
+    printf("  Mailbox ACL: %s\n", mailbox_acl(mailbox)); /* XXX parse */
     printf("  Unique ID: %s\n", mailbox_uniqueid(mailbox));
     printf("  User Flags: ");
 

--- a/imap/mboxkey.c
+++ b/imap/mboxkey.c
@@ -449,7 +449,7 @@ HIDDEN int mboxkey_merge(const char *tmpfile, const char *tgtfile)
     struct db *tmp = NULL, *tgt = NULL;
     struct mboxkey_merge_rock rock;
 
-    /* xxx does this need to be CYRUSDB_CREATE? */
+    /* XXX does this need to be CYRUSDB_CREATE? */
     r = cyrusdb_open(DB, tmpfile, CYRUSDB_CREATE, &tmp);
     if(r) goto done;
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -134,7 +134,7 @@ static void init_internal();
 EXPORTED mbentry_t *mboxlist_entry_create(void)
 {
     mbentry_t *ret = xzmalloc(sizeof(mbentry_t));
-    /* xxx - initialiser functions here? */
+    /* XXX - initialiser functions here? */
     return ret;
 }
 

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -397,7 +397,7 @@ static int mupdate_find_cb(struct mupdate_mailboxdata *mdata,
     if (!h || !cmd || !mdata) return 1;
 
     /* coyp the data to the handle storage */
-    /* xxx why can't we just point to the 'mdata' buffers? */
+    /* XXX why can't we just point to the 'mdata' buffers? */
     strlcpy(h->mailbox_buf, mdata->mailbox, sizeof(h->mailbox_buf));
     strlcpy(h->location_buf, mdata->location, sizeof(h->location_buf));
 

--- a/imap/mupdate-client.h
+++ b/imap/mupdate-client.h
@@ -95,7 +95,7 @@ int mupdate_find(mupdate_handle *handle, const char *mailbox,
 /* Callbacks for mupdate_scarf and mupdate_list */
 /* cmd is one of DELETE, MAILBOX, RESERVE */
 /* context is as provided to mupdate_scarf */
-/* FIXME/xxx: "cmd" can probably go away and instead
+/* XXX/xxx: "cmd" can probably go away and instead
  * we just use the t in mdata */
 typedef int (*mupdate_callback)(struct mupdate_mailboxdata *mdata,
                                 const char *cmd, void *context);

--- a/imap/mupdate-client.h
+++ b/imap/mupdate-client.h
@@ -95,7 +95,7 @@ int mupdate_find(mupdate_handle *handle, const char *mailbox,
 /* Callbacks for mupdate_scarf and mupdate_list */
 /* cmd is one of DELETE, MAILBOX, RESERVE */
 /* context is as provided to mupdate_scarf */
-/* XXX/xxx: "cmd" can probably go away and instead
+/* XXX: "cmd" can probably go away and instead
  * we just use the t in mdata */
 typedef int (*mupdate_callback)(struct mupdate_mailboxdata *mdata,
                                 const char *cmd, void *context);

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -2594,7 +2594,7 @@ static void cmd_list(char *arg1, char *arg2)
         /* split the list of wildmats */
         lrock.wild = split_wildmats(arg2, config_getstring(IMAPOPT_NEWSPREFIX));
 
-        /* xxx better way to determine a size for this table? */
+        /* XXX better way to determine a size for this table? */
         construct_hash_table(&lrock.server_table, 10, 1);
 
         prot_printf(nntp_out, "215 List of newsgroups follows:\r\n");
@@ -2651,7 +2651,7 @@ static void cmd_list(char *arg1, char *arg2)
         /* split the list of wildmats */
         lrock.wild = split_wildmats(arg2, config_getstring(IMAPOPT_NEWSPREFIX));
 
-        /* xxx better way to determine a size for this table? */
+        /* XXX better way to determine a size for this table? */
         construct_hash_table(&lrock.server_table, 10, 1);
 
         prot_printf(nntp_out, "215 List of newsgroups follows:\r\n");

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -99,7 +99,7 @@
 #include "sync_support.h"
 #include "sync_log.h"
 
-static int opt_force = 0; // FIXME
+static int opt_force = 0; // XXX
 
 static struct sync_client_state rightnow_sync_cs;
 
@@ -121,9 +121,9 @@ struct protocol_t imap_csync_protocol =
         CAPAF_MANY_PER_LINE,
         { { "AUTH", CAPA_AUTH },
           { "STARTTLS", CAPA_STARTTLS },
-// FIXME doesn't work with compress at the moment for some reason
+// XXX doesn't work with compress at the moment for some reason
 //        { "COMPRESS=DEFLATE", CAPA_COMPRESS },
-// FIXME do we need these ones?
+// XXX do we need these ones?
 //        { "IDLE", CAPA_IDLE },
 //        { "MUPDATE", CAPA_MUPDATE },
 //        { "MULTIAPPEND", CAPA_MULTIAPPEND },
@@ -189,7 +189,7 @@ static char *imap_sasl_parsesuccess(char *str, const char **status)
     syslog(LOG_DEBUG, "imap_sasl_parsesuccess(): input is: %s", str);
     if (NULL == status)  return NULL; /* nothing useful we can do */
 
-    const char *prelude = "A01 OK "; // FIXME don't hardcode this, get it from sasl_cmd->ok
+    const char *prelude = "A01 OK "; // XXX don't hardcode this, get it from sasl_cmd->ok
     const size_t prelude_len = strlen(prelude);
 
     const char *capability = "[CAPABILITY ";

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -84,7 +84,7 @@
 *       The last two values may be different when talking to a crippled
 *       - ahem - export controled peer (e.g. 40/128).
 *
-* xxx we need to offer a callback to do peer issuer certification.
+* XXX we need to offer a callback to do peer issuer certification.
 *     data that should be available for inspection:
 *       If the peer offered a certificate _and_ the certificate could be
 *       verified successfully, part of the certificate data are available as:
@@ -1379,7 +1379,7 @@ EXPORTED int tls_start_servertls(int readfd, int writefd, int timeout,
             syslog(LOG_DEBUG, "subject_CN=%s, issuer_CN=%s",
                    peer_CN, issuer_CN);
 
-        /* xxx verify that we like the peer_issuer/issuer_CN */
+        /* XXX verify that we like the peer_issuer/issuer_CN */
 
         if (peer_CN[0]) {
             /* save the peer id for our caller */
@@ -1862,7 +1862,7 @@ HIDDEN int tls_start_clienttls(int readfd, int writefd,
             syslog(LOG_DEBUG, "subject_CN=%s, issuer_CN=%s",
                    peer_CN, issuer_CN);
 
-        /* xxx verify that we like the peer_issuer/issuer_CN */
+        /* XXX verify that we like the peer_issuer/issuer_CN */
 
         if (authid != NULL) {
             /* save the peer id for our caller */

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -1324,7 +1324,7 @@ static void interactive(struct protocol_t *protocol, char *filename)
             rock = NULL;
         }
 
-        tv.tv_sec = 600; /* 10 minute timeout - xxx protocol specific? */
+        tv.tv_sec = 600; /* 10 minute timeout - XXX protocol specific? */
         tv.tv_usec = 0;
 
         aset = accept_set;

--- a/lib/auth_pts.c
+++ b/lib/auth_pts.c
@@ -347,7 +347,7 @@ static int ptload(const char *identifier, struct auth_state **state)
     const char *config_dir =
         libcyrus_config_getstring(CYRUSOPT_CONFIG_DIR);
 
-    /* xxx this sucks, but it seems to be the only way to satisfy the linker */
+    /* XXX this sucks, but it seems to be the only way to satisfy the linker */
     if(the_ptscache_db == NULL) {
         the_ptscache_db = libcyrus_config_getstring(CYRUSOPT_PTSCACHE_DB);
     }

--- a/lib/cyrusdb_flat.c
+++ b/lib/cyrusdb_flat.c
@@ -713,7 +713,7 @@ static int mystore(struct dbengine *db,
     if (mytid) {
         /* setup so further accesses will be against fname.NEW */
         if (fstat(writefd, &sbuf) == -1) {
-            /* xxx ? */
+            /* XXX ? */
         }
 
         if (!(*mytid)->fnamenew) (*mytid)->fnamenew = xstrdup(fnamebuf);

--- a/lib/cyrusdb_skiplist.c
+++ b/lib/cyrusdb_skiplist.c
@@ -40,9 +40,9 @@
  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-/* xxx check retry_xxx for failure */
+/* XXX check retry_xxx for failure */
 
-/* xxx all offsets should be uint32_ts i think */
+/* XXX all offsets should be uint32_ts i think */
 
 #include <config.h>
 
@@ -201,7 +201,7 @@ static void getsyncfd(struct dbengine *db, struct txn *t)
         t->syncfd = db->fd;
     } else if (t->syncfd == -1) {
         t->syncfd = open(db->fname, O_RDWR | O_DSYNC, 0666);
-        assert(t->syncfd != -1); /* xxx do better error recovery */
+        assert(t->syncfd != -1); /* XXX do better error recovery */
     }
 }
 
@@ -1339,7 +1339,7 @@ static int mystore(struct dbengine *db,
             db->curlevel = lvl;
 
             /* write out that change */
-            write_header(db); /* xxx errors? */
+            write_header(db); /* XXX errors? */
         }
 
         /* we point to what we're updating used to point to */
@@ -1535,7 +1535,7 @@ static int mycommit(struct dbengine *db, struct txn *tid)
         goto done;
     }
 
-    /* xxx consider unlocking the database here: the transaction isn't
+    /* XXX consider unlocking the database here: the transaction isn't
        yet durable but the file is in a form that is consistent for
        other transactions to use. releasing the lock here would give
        ACI properties. */
@@ -2125,9 +2125,9 @@ static int recovery(struct dbengine *db, int flags)
 
         db->listsize++;
 
-        /* xxx check \0 fill on key */
+        /* XXX check \0 fill on key */
 
-        /* xxx check \0 fill on data */
+        /* XXX check \0 fill on data */
 
         /* update previous pointers, record these for updating */
         for (i = 0; !r && i < LEVEL_safe(db, ptr); i++) {

--- a/lib/imclient.c
+++ b/lib/imclient.c
@@ -269,7 +269,7 @@ EXPORTED int imclient_connect(struct imclient **imclient,
     }
 
   /* client new connection */
-  saslresult=sasl_client_new("imap", /* xxx ideally this should be configurable */
+  saslresult=sasl_client_new("imap", /* XXX ideally this should be configurable */
                              (*imclient)->servername,
                              NULL, NULL,
                              cbs ? cbs : callbacks,
@@ -1291,7 +1291,7 @@ static int imclient_authenticate_sub(struct imclient *imclient,
   return (result.replytype != replytype_ok);
 }
 
-/* xxx service is not needed here */
+/* XXX service is not needed here */
 EXPORTED int imclient_authenticate(struct imclient *imclient,
                           char *mechlist,
                           char *service __attribute__((unused)),
@@ -1866,7 +1866,7 @@ EXPORTED int tls_start_clienttls(struct imclient *imclient,
 
     sts = SSL_connect(imclient->tls_conn);
     if (sts <= 0) {
-        printf("[ SSL_connect error %d ]\n", sts); /* xxx get string error? */
+        printf("[ SSL_connect error %d ]\n", sts); /* XXX get string error? */
         session = SSL_get_session(imclient->tls_conn);
         if (session) {
             SSL_CTX_remove_session(imclient->tls_ctx, session);
@@ -1955,7 +1955,7 @@ EXPORTED int imclient_starttls(struct imclient *imclient,
 
   imclient->tls_on = 1;
 
-  auth_id=""; /* xxx this really should be peer_CN or
+  auth_id=""; /* XXX this really should be peer_CN or
                  issuer_CN but I can't figure out which is
                  which at the moment */
 

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -704,7 +704,7 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
 
     config_loaded = 1;
 
-    /* xxx this is leaked, this may be able to be better in 2.2 (cyrus_done) */
+    /* XXX this is leaked, this may be able to be better in 2.2 (cyrus_done) */
     if (alt_config) config_filename = xstrdup(alt_config);
     else config_filename = xstrdup(CONFIG_FILENAME);
 
@@ -728,7 +728,7 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
 
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
         /* Scan options to see if we need to replace {configdirectory} */
-        /* xxx need to scan overflow options as well! */
+        /* XXX need to scan overflow options as well! */
 
         /* Skip options that have a NULL value, aren't strings, or
          * are the configdirectory option */
@@ -1262,7 +1262,7 @@ static void config_read_file(const char *filename)
             /* that is, partition names and anything that might be
              * used by SASL */
 /*
-  xxx this would be nice if it wasn't for other services who might be
+  XXX this would be nice if it wasn't for other services who might be
       sharing this config file and whose names we cannot predict
 
             if (strncasecmp(key,"sasl_",5)

--- a/lib/lock_fcntl.c
+++ b/lib/lock_fcntl.c
@@ -189,7 +189,7 @@ EXPORTED int lock_unlock(int fd, const char *filename __attribute__((unused)))
         r = fcntl(fd, F_SETLKW, &fl);
         if (r != -1) return 0;
         if (errno == EINTR) continue;
-        /* xxx help! */
+        /* XXX help! */
         return -1;
     }
 }

--- a/lib/lock_flock.c
+++ b/lib/lock_flock.c
@@ -145,7 +145,7 @@ EXPORTED int lock_unlock(int fd, const char *filename __attribute__((unused)))
         r = flock(fd, LOCK_UN);
         if (r != -1) return 0;
         if (errno == EINTR) continue;
-        /* xxx help! */
+        /* XXX help! */
         return -1;
     }
 }

--- a/lib/prot.c
+++ b/lib/prot.c
@@ -1561,7 +1561,7 @@ EXPORTED int prot_select(struct protgroup *readstreams, int extra_read_fd,
 #endif
     }
 
-    /* xxx we should probably do a nonblocking select on the remaining
+    /* XXX we should probably do a nonblocking select on the remaining
      * protstreams instead of skipping this part entirely */
     if(!retval) {
         time_t sleepfor;

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -2404,7 +2404,7 @@ int twom_db_open(const char *fname, struct twom_open_data *setup,
             r = twom_db_begin_txn(mydb, setup->flags, txnp);
             if (r) return r;
         }
-        // FIXME: we should check that setup->flags are compatible with the
+        // XXX: we should check that setup->flags are compatible with the
         // flags that the DB was originally opened with and reject if they
         // aren't, e.g. NOSYNC
         mydb->refcount++;

--- a/lib/xxhash.h
+++ b/lib/xxhash.h
@@ -4665,7 +4665,7 @@ XXH_FORCE_INLINE xxh_u64 XXH3_mix16B(const xxh_u8* XXH_RESTRICT input,
      * By forcing seed64 into a register, we disrupt the cost model and
      * cause it to scalarize. See `XXH32_round()`
      *
-     * FIXME: Clang's output is still _much_ faster -- On an AMD Ryzen 3600,
+     * XXX: Clang's output is still _much_ faster -- On an AMD Ryzen 3600,
      * XXH3_64bits @ len=240 runs at 4.6 GB/s with Clang 9, but 3.3 GB/s on
      * GCC 9.2, despite both emitting scalar code.
      *

--- a/master/master.c
+++ b/master/master.c
@@ -1542,7 +1542,7 @@ static void reap_child(void)
             syslog(LOG_ERR,
                    "received SIGCHLD from unknown child pid %d, ignoring",
                    pid);
-            /* FIXME: is this something we should take lightly? */
+            /* XXX: is this something we should take lightly? */
         }
         if (verbose && c) {
             if (c->si != SERVICE_NONE) {

--- a/perl/sieve/lib/isieve.c
+++ b/perl/sieve/lib/isieve.c
@@ -346,7 +346,7 @@ static int getauthline(isieve_t *obj, char **line, unsigned int *linelen,
           }
           return STAT_OK;
       } else { /* server said no or bye*/
-          /* xxx handle referrals */
+          /* XXX handle referrals */
           *errstrp = errstr;
           return STAT_NO;
       }
@@ -646,7 +646,7 @@ static int do_referral(isieve_t *obj, char *refer_to)
         }
     } while(ret && mtried);
 
-    /* xxx leak? */
+    /* XXX leak? */
     if(ret) return STAT_NO;
 
     if (ssf) {

--- a/ptclient/ptexpire.c
+++ b/ptclient/ptexpire.c
@@ -95,7 +95,7 @@ static int expire_cb(void *rockp,
     /* We only get called when we want to delete it */
     syslog(LOG_DEBUG, "deleting entry for %s", key);
 
-    /* xxx maybe we should use transactions for this */
+    /* XXX maybe we should use transactions for this */
     cyrusdb_delete((struct db *)rockp, key, keylen, NULL, 0);
     return 0;
 }

--- a/ptclient/ptloader.c
+++ b/ptclient/ptloader.c
@@ -118,7 +118,7 @@ struct auth_state *ptsmodule_make_authstate(const char *identifier,
     return pts->make_authstate(identifier, size, reply, dsize);
 }
 
-/* xxx this just uses the UNIX canonicalization semantics, which is
+/* XXX this just uses the UNIX canonicalization semantics, which is
  * most likely wrong */
 
 /* Map of which characters are allowed by auth_canonifyid.

--- a/sieve/message.c
+++ b/sieve/message.c
@@ -252,7 +252,7 @@ int do_redirect(action_list_t *a, const char *addr, char *deliverby,
 
     assert(a != NULL);
 
-    /* xxx we should validate addr */
+    /* XXX we should validate addr */
 
     /* see if this conflicts with any previous actions taken on this message */
     while (a != NULL) {

--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -77,7 +77,7 @@ extern const char *sieved_clienthost;
 extern int sieved_domainfromip;
 extern int sieved_userisadmin;
 
-/* xxx these are both leaked, but we only handle one connection at a
+/* XXX these are both leaked, but we only handle one connection at a
  * time... */
 extern sasl_conn_t *sieved_saslconn; /* the sasl connection context */
 static const char *referral_host = NULL;

--- a/tools/find-fixme-markers
+++ b/tools/find-fixme-markers
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+use v5.12.0;
+use warnings;
+
+use utf8;
+
+binmode *STDOUT, ':encoding(utf-8)';
+binmode *STDERR, ':encoding(utf-8)';
+
+use Getopt::Long;
+use IO::File;
+use IO::Dir;
+
+my $getopt_ok = GetOptions(
+  "help"   => \my $help,
+);
+
+if (!$getopt_ok || $help) {
+  die "usage: tab-tool [--really] PATH...";
+}
+
+my @errors = scan([@ARGV]);
+
+say for @errors;
+exit 1 if @errors;
+
+sub scan {
+  my ($paths) = @_;
+
+  my @lines = `git ls-files -- @$paths`;
+
+  die "problem running git ls-files\n" if $?;
+
+  chomp @lines;
+
+  my @found;
+  for my $filename (@lines) {
+    my @bad_line_numbers = scan_file($filename);
+    push @found, map {; "$filename;$_" } @bad_line_numbers;
+  }
+
+  return @found;
+}
+
+sub peek_magic {
+  my ($fh) = @_;
+
+  sysread $fh, my $magic, 2;
+
+  seek $fh, 0, 0;
+
+  return $magic;
+}
+
+sub scan_file {
+  my ($filename) = @_;
+
+  # We need to have the string in the source to find it, basically!
+  return if $filename eq 'tools/find-fixme-markers';
+
+  open my $ih, '<', $filename or die "can't read $filename: $!";
+
+  unless (
+    file_is_interesting($filename)
+    ||
+    -x $filename && peek_magic($ih) eq '#!'
+  ) {
+    return;
+  }
+
+  my @bad_line_numbers;
+  while (<$ih>) {
+    /FIXME/ && push @bad_line_numbers, $.;
+  }
+
+  close $ih or die "error reading from $filename: $!";
+
+  return @bad_line_numbers;
+}
+
+sub file_is_interesting {
+  (local $_) = @_;
+
+  return if -l $_;
+
+  return 1 if m{\.rst\z}
+           || m{\.pl\z}
+           || m{\.c\z}
+           || m{\.h\z}
+           || m{\.pm\z}
+           || m{\Acassandane/tiny-tests/}
+           || m{\Atools/}
+           || $_ eq 'configure.ac';
+
+  return;
+}


### PR DESCRIPTION
As discussed on the call, this removes all FIXME in favor of XXX, and bans future FIXME.

I started in on TODO, but it's a bit more complicated.  Easy to find/fix, but `:: TODO` is a thing in RST, and we have a bunch of "TODO" lists at the top of some files.  That may be a future pass.