### PR TITLE
use renameat and fsync(dirfd) for ALL renames

### DIFF
--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -4651,7 +4651,7 @@ EXPORTED int annotatemore_upgrade(void)
     buf_appendcstr(&buf, ".OLD");
 
     /* rename db file to backup */
-    r = rename(fname, buf_cstring(&buf));
+    r = cyrus_rename(fname, buf_cstring(&buf));
     free(fname);
     if (r) goto done;
     

--- a/imap/append.c
+++ b/imap/append.c
@@ -1592,7 +1592,7 @@ EXPORTED int append_copy(struct mailbox *mailbox, struct appendstate *as,
         destfname = xstrdup(tmp);
 
         int *fdptr = dst_internal_flags & FLAG_INTERNAL_ARCHIVED
-                   ? &mailbox->archive_dirfd : &mailbox->spool_dirfd;
+                   ? &as->mailbox->archive_dirfd : &as->mailbox->spool_dirfd;
 
         if (!(object_storage_enabled &&
               src_internal_flags & FLAG_INTERNAL_ARCHIVED))   // if object storage do not move file

--- a/imap/append.c
+++ b/imap/append.c
@@ -1075,9 +1075,11 @@ havefile:
     if (r) goto out;
 
     /* should we archive it straight away? */
+    int *fdptr = &mailbox->spool_dirfd;
     if (msgrecord_should_archive(msgrec, NULL)) {
         r = msgrecord_add_internalflags(msgrec, FLAG_INTERNAL_ARCHIVED);
         if (r) goto out;
+        fdptr = &mailbox->archive_dirfd;
     }
 
     /* unlink BOTH potential destination files to clean up any past failure.
@@ -1092,7 +1094,7 @@ havefile:
     r = msgrecord_get_fname(msgrec, &fname);
     if (r) goto out;
 
-    r = mailbox_copyfile(linkfile ? linkfile : stagefile, fname, nolink);
+    r = mailbox_copyfile_fdptr(linkfile ? linkfile : stagefile, fname, nolink, fdptr);
     if (r) goto out;
 
     if (config_getstring(IMAPOPT_ANNOTATION_CALLOUT) &&
@@ -1589,9 +1591,12 @@ EXPORTED int append_copy(struct mailbox *mailbox, struct appendstate *as,
         if (r) goto out;
         destfname = xstrdup(tmp);
 
+        int *fdptr = dst_internal_flags & FLAG_INTERNAL_ARCHIVED
+                   ? &mailbox->archive_dirfd : &mailbox->spool_dirfd;
+
         if (!(object_storage_enabled &&
               src_internal_flags & FLAG_INTERNAL_ARCHIVED))   // if object storage do not move file
-           r = mailbox_copyfile(srcfname, destfname, nolink);
+           r = mailbox_copyfile_fdptr(srcfname, destfname, nolink, fdptr);
 
         if (r) goto out;
 

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -534,7 +534,7 @@ gotdata:
                         "tempfname=<%s>", tempfname);
             }
             else {
-                if (rename(tempfname, cachefname)) {
+                if (cyrus_rename(tempfname, cachefname)) {
                     xsyslog(LOG_WARNING, "failed to rename tempfile to cache file",
                             "tempfname=<%s> cachefname=<%s>",
                             tempfname, cachefname);

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -393,13 +393,13 @@ static int autocreate_sieve(const char *userid, const char *source_script)
 
 
     /* Renaming the necessary stuff */
-    if (rename(script_names.tmpname1, script_names.scriptname)) {
+    if (cyrus_rename(script_names.tmpname1, script_names.scriptname)) {
         syslog(LOG_ERR, "autocreate_sieve: rename %s -> %s failed: %m",
                script_names.tmpname1, script_names.scriptname);
         goto failed3;
     }
 
-    if (rename(script_names.bctmpname, script_names.bcscriptname)) {
+    if (cyrus_rename(script_names.bctmpname, script_names.bcscriptname)) {
         syslog(LOG_ERR, "autocreate_sieve: rename %s -> %s failed: %m",
                script_names.bctmpname, script_names.bcscriptname);
         xunlink(script_names.bcscriptname);
@@ -473,7 +473,7 @@ static int autocreate_sieve(const char *userid, const char *source_script)
         } /* if else if */
 
         /* rename the temporary created sieve script to its final name. */
-        if (rename(script_names.tmpname2, compiled_source_script)) {
+        if (cyrus_rename(script_names.tmpname2, compiled_source_script)) {
             if (errno != EEXIST) {
                 xunlink(script_names.tmpname2);
                 xunlink(compiled_source_script);

--- a/imap/ctl_cyrusdb.c
+++ b/imap/ctl_cyrusdb.c
@@ -407,7 +407,7 @@ int main(int argc, char *argv[])
 
                 /* move db.backup1 to db.backup2 */
                 if (r2 == 0 || errno == ENOENT)
-                    r2 = rename(backup1, backup2);
+                    r2 = cyrus_rename(backup1, backup2);
 
                 /* make a new db.backup1 */
                 if (r2 == 0 || errno == ENOENT)

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -527,7 +527,7 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
             xunlink(buf_cstring(&newfname));
         }
         else {
-            rename(buf_cstring(&newfname), buf_cstring(&fname));
+            cyrus_rename(buf_cstring(&newfname), buf_cstring(&fname));
         }
     }
 

--- a/imap/fetchnews.c
+++ b/imap/fetchnews.c
@@ -410,7 +410,7 @@ int main(int argc, char *argv[])
 
             /* upgrade from the old stamp filename to the new */
             snprintf(oldfile, sizeof(oldfile), "%s/newsstamp", config_dir);
-            rename(oldfile, sfile);
+            cyrus_rename(oldfile, sfile);
         }
 
         if ((fd = open(sfile, O_RDWR | O_CREAT, 0644)) == -1) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6856,14 +6856,15 @@ EXPORTED int mailbox_rename_cleanup(struct mailbox **mailboxptr)
 /*
  * Copy (or link) the file 'from' to the file 'to'
  */
-EXPORTED int mailbox_copyfile(const char *from, const char *to, int nolink)
+EXPORTED int mailbox_copyfile_fdptr(const char *from, const char *to,
+                                    int nolink, int *dest_dirfdp)
 {
     int flags = COPYFILE_MKDIR|COPYFILE_KEEPTIME;
     if (nolink) flags |= COPYFILE_NOLINK;
 
     if (mailbox_wait_cb) mailbox_wait_cb(mailbox_wait_cb_rock);
 
-    if (cyrus_copyfile(from, to, flags))
+    if (cyrus_copyfile_fdptr(from, to, flags, NULL, dest_dirfdp))
         return IMAP_IOERROR;
 
     return 0;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -331,7 +331,7 @@ EXPORTED int mailbox_meta_rename(struct mailbox *mailbox, int metafile)
     const char *fname = mailbox_meta_fname(mailbox, metafile);
     const char *newfname = mailbox_meta_newfname(mailbox, metafile);
 
-    if (rename(newfname, fname))
+    if (cyrus_rename(newfname, fname))
         return IMAP_IOERROR;
 
     return 0;
@@ -7617,7 +7617,7 @@ static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int
 
         oldfname = xstrdup(fname);
         newfname = xstrdup(mailbox_record_fname(mailbox, &record));
-        r = rename(oldfname, newfname);
+        r = cyrus_rename(oldfname, newfname);
         free(oldfname);
         free(newfname);
         if (r) {

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -302,6 +302,8 @@ struct mailbox {
     int header_dirty;
     int quota_dirty;
     int has_changed;
+    int spool_dirfd;
+    int archive_dirfd;
     time_t last_updated; /* for appends*/
     quota_t quota_previously_used[QUOTA_NUMRESOURCES]; /* for quota change */
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -682,8 +682,8 @@ extern int mailbox_rename_copy(struct mailbox *oldmailbox,
                                struct mailbox **newmailboxptr);
 extern int mailbox_rename_cleanup(struct mailbox **mailboxptr);
 
-
-extern int mailbox_copyfile(const char *from, const char *to, int nolink);
+extern int mailbox_copyfile_fdptr(const char *from, const char *to, int nolink, int *dirfdp);
+#define mailbox_copyfile(from, to, nolink) mailbox_copyfile_fdptr(from, to, nolink, NULL)
 
 extern int mailbox_reconstruct(const char *name, int flags, struct mailbox **mailboxp);
 

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5718,7 +5718,7 @@ EXPORTED int mboxlist_upgrade(int *upgraded)
     mboxlist_close();
 
     /* rename new db file */
-    if (!r) r = rename(newfname, fname);
+    if (!r) r = cyrus_rename(newfname, fname);
 
     if (!r && upgraded) *upgraded = 1;
 
@@ -5931,7 +5931,7 @@ static int mboxlist_upgrade_subs_work(const char *userid,
 
     if (!db_r) {
         /* rename new db file */
-        if (rename(newsubsfname, subsfname) < 0) {
+        if (cyrus_rename(newsubsfname, subsfname) < 0) {
             syslog(LOG_ERR, "DBERROR: renaming %s: %m", newsubsfname);
             fatal("can't rename subscriptions file", EX_TEMPFAIL);
         }

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2965,7 +2965,7 @@ static int mboxname_set_fcounters(const char *fname, struct mboxname_counters *v
     close(newfd);
     newfd = -1;
 
-    if (rename(newfname, fname)) {
+    if (cyrus_rename(newfname, fname)) {
         r = IMAP_IOERROR;
         xsyslog(LOG_ERR, "IOERROR: rename failed",
                          "oldfname=<%s> newfname=<%s>",

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -477,10 +477,10 @@ static int relocate(const char *old, const char *new)
     if (!quiet) printf("\tRenaming: %s\t -> %s\n", old, new);
 
     if (!nochanges) {
-        r = rename(old, new);
+        r = cyrus_rename(old, new);
         if (r && errno == ENOENT) {
             cyrus_mkdir(new, 0755);
-            r = rename(old, new);
+            r = cyrus_rename(old, new);
         }
 
         if (r) fprintf(stderr, "\tFailed to rename %s\t -> %s: %m\n", old, new);

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -4125,7 +4125,7 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
             printf("renaming tempdir into place\n");
         }
         removedir(destdir);
-        r = rename(tempdestdir, destdir);
+        r = cyrus_rename(tempdestdir, destdir);
         if (r) {
             printf("ERROR: failed to rename into place %s to %s\n", tempdestdir, destdir);
             goto out;

--- a/imap/seen_db.c
+++ b/imap/seen_db.c
@@ -419,7 +419,7 @@ HIDDEN int seen_rename_user(const char *olduser, const char *newuser)
     }
 
     cyrus_mkdir(newfname, 0755);
-    if (rename(oldfname, newfname) && errno != ENOENT) {
+    if (cyrus_rename(oldfname, newfname) && errno != ENOENT) {
         syslog(LOG_ERR, "error renaming %s to %s: %m", oldfname, newfname);
         r = IMAP_IOERROR;
     }

--- a/imap/sievedir.c
+++ b/imap/sievedir.c
@@ -242,7 +242,7 @@ EXPORTED int sievedir_activate_script(const char *sievedir, const char *name)
         return SIEVEDIR_IOERROR;
     }
 
-    if (rename(tmp, active) < 0) {
+    if (cyrus_rename(tmp, active) < 0) {
         xsyslog(LOG_ERR, "IOERROR: failed to rename active script link",
                 "oldpath=<%s> newpath=<%s>", tmp, active);
         xunlink(tmp);
@@ -298,7 +298,7 @@ EXPORTED int sievedir_rename_script(const char *sievedir,
              "%s/%s%s", sievedir, oldname, BYTECODE_SUFFIX);
     snprintf(newpath, sizeof(newpath),
              "%s/%s%s", sievedir, newname, BYTECODE_SUFFIX);
-    r = rename(oldpath, newpath);
+    r = cyrus_rename(oldpath, newpath);
     if (r) {
         xsyslog(LOG_ERR, "IOERROR: failed to rename bytecode file",
                 "oldpath=<%s> newpath=<%s>", oldpath, newpath);
@@ -375,7 +375,7 @@ EXPORTED int sievedir_put_script(const char *sievedir, const char *name,
     /* rename */
     char path[PATH_MAX];
     snprintf(path, sizeof(path), "%s/%s%s", sievedir, name, BYTECODE_SUFFIX);
-    r = rename(new_bcpath, path);
+    r = cyrus_rename(new_bcpath, path);
     if (r) {
         xsyslog(LOG_ERR, "IOERROR: failed to rename bytecode file",
                 "oldpath=<%s> newpath=<%s>", new_bcpath, path);

--- a/imap/sync_log.c
+++ b/imap/sync_log.c
@@ -553,7 +553,7 @@ EXPORTED int sync_log_reader_begin(sync_log_reader_t *slr)
         }
 
         /* Move sync_log to our work file */
-        if (rename(slr->log_file, slr->work_file) < 0) {
+        if (cyrus_rename(slr->log_file, slr->work_file) < 0) {
             syslog(LOG_ERR, "Rename %s -> %s failed: %m",
                    slr->log_file, slr->work_file);
             return IMAP_IOERROR;

--- a/imap/user.c
+++ b/imap/user.c
@@ -430,7 +430,7 @@ static int user_renamesieve(const char *olduser, const char *newuser)
      *
      * XXX this doesn't rename sieve scripts
      */
-    if (!r) r = rename(oldpath, newpath);
+    if (!r) r = cyrus_rename(oldpath, newpath);
     if (r < 0) {
         if (errno == ENOENT) {
             syslog(LOG_WARNING, "error renaming %s to %s: %m",

--- a/lib/cyrusdb.c
+++ b/lib/cyrusdb.c
@@ -608,7 +608,7 @@ EXPORTED int cyrusdb_convert(const char *fromfname, const char *tofname,
 
     /* created a new filename - so it's a replace-in-place */
     if (newfname) {
-        r = rename(newfname, fromfname);
+        r = cyrus_rename(newfname, fromfname);
         if (r) goto err;
     }
 

--- a/lib/cyrusdb_flat.c
+++ b/lib/cyrusdb_flat.c
@@ -727,7 +727,7 @@ static int mystore(struct dbengine *db,
         /* commit immediately */
         if (fsync(writefd) ||
             fstat(writefd, &sbuf) == -1 ||
-            rename(fnamebuf, db->fname) == -1) {
+            cyrus_rename(fnamebuf, db->fname) == -1) {
             xsyslog(LOG_ERR, "IOERROR: commit failed",
                              "fname=<%s>",
                              fnamebuf);
@@ -807,7 +807,7 @@ static int commit_txn(struct dbengine *db, struct txn *tid)
         writefd = tid->fd;
         if (fsync(writefd) ||
             fstat(writefd, &sbuf) == -1 ||
-            rename(tid->fnamenew, db->fname) == -1) {
+            cyrus_rename(tid->fnamenew, db->fname) == -1) {
             xsyslog(LOG_ERR, "IOERROR: commit failed",
                              "fname=<%s>",
                              tid->fnamenew);

--- a/lib/cyrusdb_quotalegacy.c
+++ b/lib/cyrusdb_quotalegacy.c
@@ -248,7 +248,7 @@ static int commit_subtxn(const char *fname, struct subtxn *tid)
 
         if (fsync(writefd) ||
             fstat(writefd, &sbuf) == -1 ||
-            rename(tid->fnamenew, fname) == -1 ||
+            cyrus_rename(tid->fnamenew, fname) == -1 ||
             lock_unlock(writefd, fname) == -1) {
             xsyslog(LOG_ERR, "IOERROR: commit failed",
                              "fname=<%s>",

--- a/lib/cyrusdb_skiplist.c
+++ b/lib/cyrusdb_skiplist.c
@@ -1862,7 +1862,7 @@ static int mycheckpoint(struct dbengine *db)
     }
 
     /* move new file to original file name */
-    if (!r && (rename(fname, db->fname) < 0)) {
+    if (!r && (cyrus_rename(fname, db->fname) < 0)) {
         xsyslog(LOG_ERR, "DBERROR: rename failed",
                          "source=<%s> destination=<%s>",
                          fname, db->fname);

--- a/lib/mappedfile.c
+++ b/lib/mappedfile.c
@@ -459,7 +459,7 @@ EXPORTED int mappedfile_rename(struct mappedfile *mf, const char *newname)
         goto done;
     }
 
-    r = rename(mf->fname, newname);
+    r = renameat(AT_FDCWD, mf->fname, dirfd, newname);
     if (r < 0) {
         xsyslog(LOG_ERR, "IOERROR: rename failed",
                          "filename=<%s> newname=<%s>",

--- a/lib/mappedfile.c
+++ b/lib/mappedfile.c
@@ -442,44 +442,16 @@ EXPORTED int mappedfile_truncate(struct mappedfile *mf, off_t offset)
 
 EXPORTED int mappedfile_rename(struct mappedfile *mf, const char *newname)
 {
-    char *copy = xstrdup(newname);
-    const char *dir = dirname(copy);
-    int r = 0;
-
-#if defined(O_DIRECTORY)
-    int dirfd = open(dir, O_RDONLY|O_DIRECTORY, 0600);
-#else
-    int dirfd = open(dir, O_RDONLY, 0600);
-#endif
-    if (dirfd < 0) {
-        xsyslog(LOG_ERR, "IOERROR: open directory failed",
-                         "filename=<%s> newname=<%s> directory=<%s>",
-                         mf->fname, newname, dir);
-        r = dirfd;
-        goto done;
-    }
-
-    r = renameat(AT_FDCWD, mf->fname, dirfd, newname);
+    int r = cyrus_rename(mf->fname, newname);
     if (r < 0) {
-        xsyslog(LOG_ERR, "IOERROR: rename failed",
+        xsyslog(LOG_ERR, "IOERROR: mappedfile_rename failed",
                          "filename=<%s> newname=<%s>",
                          mf->fname, newname);
-        goto done;
+        return r;
     }
 
-    r = fsync(dirfd);
-    if (r < 0) {
-        xsyslog(LOG_ERR, "IOERROR: fsync directory failed",
-                         "filename=<%s> newname=<%s> directory=<%s>",
-                         mf->fname, newname, dir);
-        goto done;
-    }
-
+    // rename done
     free(mf->fname);
     mf->fname = xstrdup(newname);
-
- done:
-    if (dirfd >= 0) close(dirfd);
-    free(copy);
-    return r;
+    return 0;
 }

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -187,7 +187,7 @@ EXPORTED int proc_register(struct proc_handle **handlep,
                       servicename, clienthost, userid, mailbox, cmd);
     fclose(procfile);
 
-    if (rename(newfname, handle->fname)) {
+    if (cyrus_rename(newfname, handle->fname)) {
         xsyslog(LOG_ERR, "IOERROR: rename failed",
                          "source=<%s> dest=<%s>",
                          newfname, handle->fname);

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -2191,8 +2191,10 @@ static int replay_cb(void *rock,
 static int tm_rename(struct twom_db *db, struct tm_file *oldfile, const char *newname)
 {
     struct stat sbuf, sbuffile;
-    char *copy = strdup(db->fname);
-    const char *dir = dirname(copy);
+    char *copyd = strdup(db->fname);
+    char *copyb = strdup(db->fname);
+    const char *dir = dirname(copyd);
+    const char *file = dirname(copyb);
     int r = 0;
     int dirfd = -1;
 
@@ -2230,7 +2232,7 @@ static int tm_rename(struct twom_db *db, struct tm_file *oldfile, const char *ne
         goto done;
     }
 
-    r = renameat(AT_FDCWD, newname, dirfd, db->fname);
+    r = renameat(AT_FDCWD, newname, dirfd, file);
     if (r) goto done;
 
     if (!db->nosync) {
@@ -2245,7 +2247,8 @@ static int tm_rename(struct twom_db *db, struct tm_file *oldfile, const char *ne
 
  done:
     if (dirfd >= 0) close(dirfd);
-    free(copy);
+    free(copyd);
+    free(copyb);
     return r;
 }
 

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -2194,7 +2194,7 @@ static int tm_rename(struct twom_db *db, struct tm_file *oldfile, const char *ne
     char *copyd = strdup(db->fname);
     char *copyb = strdup(db->fname);
     const char *dir = dirname(copyd);
-    const char *file = dirname(copyb);
+    const char *file = basename(copyb);
     int r = 0;
     int dirfd = -1;
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -458,6 +458,7 @@ EXPORTED int cyrus_rename(const char *src, const char *dest)
     char *copy = xstrdup(dest);
     const char *dir = dirname(copy);
     int r = 0;
+    int saved_errno = 0;
 
 #if defined(O_DIRECTORY)
     int dirfd = open(dir, O_RDONLY|O_DIRECTORY, 0600);
@@ -472,8 +473,15 @@ EXPORTED int cyrus_rename(const char *src, const char *dest)
     r = renameat(AT_FDCWD, src, dirfd, dest);
     if (!r) r = fsync(dirfd);
 
+    // make sure close doesn't clear errno
+    if (r) {
+        saved_errno = errno;
+    }
+
     close(dirfd);
     free(copy);
+
+    errno = saved_errno;
 
     return r;
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -455,10 +455,9 @@ EXPORTED int removedir(const char *path)
 // destination directory before returning
 EXPORTED int cyrus_rename(const char *src, const char *dest)
 {
-    char *copy = xstrdup(dest);
-    const char *dir = dirname(copy);
+    char *copyd = xstrdup(dest);
+    const char *dir = dirname(copyd);
     int r = 0;
-    int saved_errno = 0;
 
 #if defined(O_DIRECTORY)
     int dirfd = open(dir, O_RDONLY|O_DIRECTORY, 0600);
@@ -466,23 +465,23 @@ EXPORTED int cyrus_rename(const char *src, const char *dest)
     int dirfd = open(dir, O_RDONLY, 0600);
 #endif
     if (dirfd < 0) {
-        free(copy);
+        free(copyd);
         return dirfd;
     }
 
-    r = renameat(AT_FDCWD, src, dirfd, dest);
+    char *copyb = xstrdup(dest);
+    const char *file = basename(copyb);
+
+    r = renameat(AT_FDCWD, src, dirfd, file);
     if (!r) r = fsync(dirfd);
 
     // make sure close doesn't clear errno
-    if (r) {
-        saved_errno = errno;
-    }
-
+    int saved_errno = errno;
     close(dirfd);
-    free(copy);
-
     errno = saved_errno;
 
+    free(copyd);
+    free(copyb);
     return r;
 }
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -220,6 +220,9 @@ extern char *create_tempdir(const char *path, const char *subname);
  * value of remove on error. */
 extern int removedir(const char *path);
 
+/* Call rename but fsync the directory before returning success */
+extern int cyrus_rename(const char *src, const char *dest);
+
 /* Close a network filedescriptor the "safe" way */
 extern int cyrus_close_sock(int fd);
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -221,6 +221,9 @@ extern char *create_tempdir(const char *path, const char *subname);
 extern int removedir(const char *path);
 
 /* Call rename but fsync the directory before returning success */
+extern int xopendir(const char *dest);
+extern int xrenameat(int dirfd, const char *src, const char *dest);
+extern void xclosedir(int dirfd);
 extern int cyrus_rename(const char *src, const char *dest);
 
 /* Close a network filedescriptor the "safe" way */
@@ -242,7 +245,9 @@ enum {
     COPYFILE_NODIRSYNC = (1<<4)
 };
 
-extern int cyrus_copyfile(const char *from, const char *to, int flags);
+extern int cyrus_copyfile_fdptr(const char *from, const char *to, int flags,
+                                int *from_dirfdp, int *to_dirfdp);
+#define cyrus_copyfile(from, to, flags) cyrus_copyfile_fdptr(from, to, flags, NULL, NULL)
 
 enum {
     BEFORE_SETUID,


### PR DESCRIPTION
I was originally planning to just use renameat in mappedfile, but on reflection I built an API wrapper for rename, and used that everywhere (except twom; which tries not to use the rest of cyrus libs for portability)