### PR TITLE
master pselect timing stats

### DIFF
--- a/master/master.c
+++ b/master/master.c
@@ -269,7 +269,7 @@ static void sample_stats(double *samples, size_t n_samples,
     }
 }
 
-#define MAX_SAMPLES (1000u)
+#define MAX_SAMPLES (10000u)
 static struct {
     unsigned n_samples;
     unsigned n_timed_out;


### PR DESCRIPTION
Temporary PR for Fastmail...

This adds some statistics collection so we can find out how the pselect in master's main loop behaves in practice.  It'll log a line like this (wrapped for web reading) after every 10,000 pselect calls, or at master process exit:

```
2025-04-04T11:24:47.489761+11:00 debian 002441030B/master[1078003]: pselect stats:
samples=<10> timeout=<0|9.9997150000000001|9.8705120000000015|6.9219662999999994|4.7767802569057851>
n_timed_out=<3> timed_out=<1.9999999999999999e-06|1.9999999999999999e-06|1.9999999999999999e-06|1.9999999999999999e-06|0>
n_interrupted=<3> interrupted=<0.00093400000000000004|0.055022000000000001|0.011181|0.022379|0.028730199076929488>
n_ready=<4> ready=<0.00073700000000000002|0.124815|0.0012049999999999999|0.031990499999999998|0.061883393262382333> 
```

The numbers are `<min|max|median|mean|stddev>`.  `timeout` is the timeout parameter we passed to pselect (i.e. how long pselect should wait for anything to happen before returning).  `n_timed_out` and `timed_out` are how many times pselect returned due to timing out, and how long it ran for in those cases.  `n_interrupted` and `interrupted` are how many times pselect returned due to being interrupted by a signal, and how long it ran for in those cases; and `n_ready` and `ready` are how many times pselect returned due to a file descriptor becoming ready, and how long it ran in those cases.