### PR TITLE
cassandane/Makefile: do not run the syntax test by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       id: cass1
       continue-on-error: true
       # We haven't figured out how to make Test::Core work in actions yet.
-      run: cyd test "!Test::Core"
+      run: cyd test --slow "!Test::Core"
     - name: rerun cassandane failures noisily
       if: ${{ steps.cass1.outcome == 'failure' }}
       run: cyd test --no-slow --format pretty --rerun

--- a/cassandane/Makefile
+++ b/cassandane/Makefile
@@ -41,10 +41,8 @@
 SUBDIRS := utils
 PERL := perl
 
-all clean install::
+all clean install:
 	@for dir in $(SUBDIRS) ; do cd $$dir ; $(MAKE) $@ || exit 1 ; done
-
-all:: syntax
 
 # utils/annotator.pl depends on modules installed with Cyrus, which it
 # will only be able to find when invoked by Cyrus::Instance (which sets


### PR DESCRIPTION
We don't actually need to do a syntax test as part of make all.  It can be its own thing, run on demand.  My thinking is that it should be run by the human or robot running the tests, based on whether they think they're likely to *save* or *lose* time by compiling everything up front.  For a two-test run, `make syntax` is probably a waste.  For all the tests, it's just noise.  (On my MacBook Air M2, it takes 7s.)

The next step will be to make `cyd test` run `make syntax` iff there are no positive test specifiers given.  (That is: run it for `cyd test` and `cyd test !Foo` but not `cyd test Bar`.)