### PR TITLE
Ci unroll matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
             cflags: "-Og"
             cxxflags: "-Og"
             skip-cass: 1
+          - compiler: "--gcc"
+            desc: "Non-UTC timezone"
+            pretest: "ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime && sudo dpkg-reconfigure --frontend noninteractive tzdata"
     runs-on: ubuntu-latest
     container:
         image: ghcr.io/cyrusimap/cyrus-docker:bookworm
@@ -60,6 +63,10 @@ jobs:
         # following".  we're explicitly fetching the tags we want, we do not
         # need every other tag that's reachable from them
         git fetch --no-tags upstream 'refs/tags/cyrus-imapd-*:refs/tags/cyrus-imapd-*'
+    - name: Run pre-test code if any
+      if: ${{ matrix.pretest }}
+      shell: bash
+      run: ${{ matrix.pretest }}
     - name: configure and build
       shell: bash
       run: cyd build "${{ matrix.compiler }}" "${{ matrix.san }}" --cflags "${{ matrix.cflags }}" --cxxflags "${{ matrix.cxxflags }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,20 +18,25 @@ env:
 
 jobs:
   build:
-    name: Cassandane
+    name: "${{ matrix.desc }}"
     strategy:
       fail-fast: false
       matrix:
         include:
           - compiler: "--gcc"
+            desc: "gcc w/cass"
           - compiler: "--clang"
+            desc: "clang w/cass"
           - compiler: "--gcc"
+            desc: "gcc+ubsan w/cass"
             san: "--ubsan"
           - compiler: "--gcc"
+            desc: "gcc+asan w/cass"
             san: "--asan"
             skip: "!Cyrus::Sieve.badscript_timsieved !Cyrus::LibCyrus"
           - compiler: "--gcc"
             # -Og finds more errors at compile time
+            desc: "gcc -Og cunit"
             cflags: "-Og"
             cxxflags: "-Og"
             skip-cass: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,11 @@ jobs:
           - compiler: "--gcc"
             san: "--asan"
             skip: "!Cyrus::Sieve.badscript_timsieved !Cyrus::LibCyrus"
+          - compiler: "--gcc"
+            # -Og finds more errors at compile time
+            cflags: "-Og"
+            cxxflags: "-Og"
+            skip-cass: 1
     runs-on: ubuntu-latest
     container:
         image: ghcr.io/cyrusimap/cyrus-docker:bookworm
@@ -52,7 +57,7 @@ jobs:
         git fetch --no-tags upstream 'refs/tags/cyrus-imapd-*:refs/tags/cyrus-imapd-*'
     - name: configure and build
       shell: bash
-      run: cyd build "${{ matrix.compiler }}" "${{ matrix.san }}"
+      run: cyd build "${{ matrix.compiler }}" "${{ matrix.san }}" --cflags "${{ matrix.cflags }}" --cxxflags "${{ matrix.cxxflags }}"
     - name: report version information
       shell: bash
       run: |
@@ -61,6 +66,7 @@ jobs:
         /usr/cyrus/libexec/master -V
         /usr/cyrus/sbin/cyr_buildinfo
     - name: run cassandane quietly
+      if: ${{ ! matrix.skip-cass }}
       id: cass1
       continue-on-error: true
       # We haven't figured out how to make Test::Core work in actions yet.
@@ -69,7 +75,7 @@ jobs:
       if: ${{ steps.cass1.outcome == 'failure' }}
       run: cyd test --no-slow --format pretty --rerun
     - name: collect logs
-      if: always()
+      if: ${{ ! matrix.skip-cass }}
       run: cat /tmp/cass/*/conf/log/syslog
   valgrind-make-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ "--gcc", "--clang" ]
-        san: [ "" ]
-        skip: [ "" ]
         include:
-          - san: "--ubsan"
-            compiler: "--gcc"
-          - san: "--asan"
-            compiler: "--gcc"
+          - compiler: "--gcc"
+          - compiler: "--clang"
+          - compiler: "--gcc"
+            san: "--ubsan"
+          - compiler: "--gcc"
+            san: "--asan"
             skip: "!Cyrus::Sieve.badscript_timsieved !Cyrus::LibCyrus"
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
This is ready for review.

It makes the ci builds be explicit rather than using the matrix combination strategy with exceptions for different options.

It also names the builds explicitly so the names are clearer/more descriptive 