### PR TITLE
pre-emptive clang-format fixes

### DIFF
--- a/cunit/cyrunit.h
+++ b/cunit/cyrunit.h
@@ -245,6 +245,7 @@ extern int fatal_expected;
 extern char *fatal_string;
 extern int fatal_code;
 
+// clang-format off
 #define CU_EXPECT_CYRFATAL_BEGIN                                \
 do {                                                            \
     fatal_expected = 1;                                         \
@@ -264,6 +265,7 @@ do {                                                            \
         if (fatal_string) free(fatal_string);                   \
         fatal_string = NULL;                                    \
 }   } while (0)
+// clang-format on
 
 
 /* for parametrised tests */

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -214,8 +214,9 @@ static void params_assign(struct cunit_param *params)
 {
     struct cunit_param *p;
 
-    for (p = params ; p->name ; p++)
+    for (p = params ; p->name ; p++) {
         *(p->variable) = p->values[p->idx];
+    }
 
     if (verbose) {
         char buf[1024];
@@ -250,8 +251,9 @@ void __cunit_params_begin(struct cunit_param *params)
             }
         }
     }
-    for (p = params ; p->name ; p++)
+    for (p = params ; p->name ; p++) {
         p->idx = 0;
+    }
     params_assign(params);
     current_params = params;
 }

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -501,10 +501,8 @@ static void init_internal()
 }
 
 /* must be called after cyrus_init */
-EXPORTED void annotate_init(int (*fetch_func)(const char *, const char *,
-                                     const strarray_t *, const strarray_t *),
-                            int (*store_func)(const char *, const char *,
-                                     struct entryattlist *))
+EXPORTED void annotate_init(annotate_fetch_func *fetch_func,
+                            annotate_store_func *store_func)
 {
     if (fetch_func) {
         proxy_fetch_func = fetch_func;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -457,9 +457,11 @@ EXPORTED size_t sizeentryatts(const struct entryattlist *l)
     size_t sz = 0;
     struct attvaluelist *av;
 
-    for ( ; l ; l = l->next)
-        for (av = l->attvalues ; av ; av = av->next)
+    for ( ; l ; l = l->next) {
+        for (av = l->attvalues ; av ; av = av->next) {
             sz += av->value.len;
+        }
+    }
     return sz;
 }
 

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -292,7 +292,7 @@ EXPORTED void appendstrlist(struct strlist **l, char *s)
 
     while (*tail) tail = &(*tail)->next;
 
-    *tail = (struct strlist *)xmalloc(sizeof(struct strlist));
+    *tail = xmalloc(sizeof(struct strlist));
     (*tail)->s = xstrdup(s);
     (*tail)->next = 0;
 }
@@ -356,7 +356,7 @@ EXPORTED void appendentryatt(struct entryattlist **l, const char *entry,
 
     while (*tail) tail = &(*tail)->next;
 
-    *tail = (struct entryattlist *)xmalloc(sizeof(struct entryattlist));
+    *tail = xmalloc(sizeof(struct entryattlist));
     (*tail)->entry = xstrdup(entry);
     (*tail)->attvalues = attvalues;
     (*tail)->next = NULL;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1259,7 +1259,7 @@ EXPORTED int annotatemore_findall_mboxname(const char *mboxname,
     return r;
 }
 
-/***************************  Annotate State Management  ***************************/
+/************************  Annotate State Management  ************************/
 
 EXPORTED annotate_state_t *annotate_state_new(void)
 {

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -2037,6 +2037,7 @@ static void annotation_get_fromdb(annotate_state_t *state,
 }
 
 /* TODO: need to handle /<section-part>/ somehow */
+// clang-format: off
 static const annotate_entrydesc_t message_builtin_entries[] =
 {
     {
@@ -2136,6 +2137,7 @@ static const annotate_entrydesc_t message_builtin_entries[] =
     },
     { NULL, 0, ANNOTATION_PROXY_T_INVALID, 0, 0, NULL, NULL, NULL, NULL }
 };
+// clang-format: on
 
 static const annotate_entrydesc_t message_db_entry =
     {
@@ -2150,6 +2152,7 @@ static const annotate_entrydesc_t message_db_entry =
         NULL
     };
 
+// clang-format: off
 static const annotate_entrydesc_t mailbox_builtin_entries[] =
 {
     {
@@ -2486,6 +2489,7 @@ static const annotate_entrydesc_t mailbox_builtin_entries[] =
         NULL
     },{ NULL, 0, ANNOTATION_PROXY_T_INVALID, 0, 0, NULL, NULL, NULL, NULL }
 };
+// clang-format: on
 
 static const annotate_entrydesc_t mailbox_db_entry =
     {
@@ -2500,6 +2504,7 @@ static const annotate_entrydesc_t mailbox_db_entry =
         NULL
     };
 
+// clang-format: off
 static const annotate_entrydesc_t server_builtin_entries[] =
 {
     {
@@ -2627,6 +2632,7 @@ static const annotate_entrydesc_t server_builtin_entries[] =
     },{ NULL, 0, ANNOTATION_PROXY_T_INVALID,
         0, 0, NULL, NULL, NULL, NULL }
 };
+// clang-format: on
 
 static const annotate_entrydesc_t server_db_entry =
     {

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -3384,12 +3384,12 @@ static int annotate_canon_value(struct buf *value, int type)
         errno = 0;
         buf_cstring(value);
         uwhatever = strtoul(value->s, &p, 10);
-        if ((p == value->s)             /* no value */
-            || (*p != '\0')             /* illegal char */
-            || (unsigned)(p - value->s) != value->len
-                                        /* embedded NUL */
-            || errno                    /* overflow */
-            || strchr(value->s, '-')) { /* negative number */
+        if ((p == value->s)                           /* no value */
+            || (*p != '\0')                           /* illegal char */
+            || (unsigned)(p - value->s) != value->len /* embedded NUL */
+            || errno                                  /* overflow */
+            || strchr(value->s, '-')                  /* negative number */)
+        {
             return IMAP_ANNOTATION_BADVALUE;
         }
         break;
@@ -3399,11 +3399,11 @@ static int annotate_canon_value(struct buf *value, int type)
         errno = 0;
         buf_cstring(value);
         whatever = strtol(value->s, &p, 10);
-        if ((p == value->s)             /* no value */
-            || (*p != '\0')             /* illegal char */
-            || (unsigned)(p - value->s) != value->len
-                                        /* embedded NUL */
-            || errno) {                 /* underflow/overflow */
+        if ((p == value->s)                           /* no value */
+            || (*p != '\0')                           /* illegal char */
+            || (unsigned)(p - value->s) != value->len /* embedded NUL */
+            || errno                                  /* underflow/overflow */)
+        {
             return IMAP_ANNOTATION_BADVALUE;
         }
         break;

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -135,11 +135,12 @@ char *dumpentryatt(const struct entryattlist *l);
 void freeentryatts(struct entryattlist *l);
 
 /* initialize database structures */
-void annotate_init(
-                       int (*fetch_func)(const char *, const char *,
-                                         const strarray_t *, const strarray_t *),
-                       int (*store_func)(const char *, const char *,
-                                         struct entryattlist *));
+typedef int (annotate_fetch_func)(const char *, const char *,
+                                  const strarray_t *, const strarray_t *);
+typedef int (annotate_store_func)(const char *, const char *,
+                                  struct entryattlist *);
+void annotate_init(annotate_fetch_func *fetch_func,
+                   annotate_store_func *store_func);
 
 /* open the annotation db */
 void annotatemore_open(void);

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -109,6 +109,7 @@ static int mymemberof(const struct auth_state *auth_state, const char *identifie
  * Identifiers don't require a digit, really, so that should probably be
  * relaxed, too.
  */
+// clang-format: off
 static const char allowedchars[256] = {
  /* 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 00-0F */
@@ -131,6 +132,7 @@ static const char allowedchars[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
+// clang-format: on
 
 /*
  * Convert 'identifier' into canonical form.

--- a/lib/bsearch.c
+++ b/lib/bsearch.c
@@ -50,6 +50,7 @@
  * Treats \r and \t as end-of-string and treats '.' lower than
  * everything else.
  */
+// clang-format: off
 #define TOCOMPARE(c) (convert_to_compare[(unsigned char)(c)])
 static unsigned char convert_to_compare[256] = {
     0x00, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
@@ -85,6 +86,7 @@ static unsigned char convert_to_compare[256] = {
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff
 };
+// clang-format: on
 
 /*
  * Search for a line starting with 'word'.  The search respects case.

--- a/lib/charset.c
+++ b/lib/charset.c
@@ -85,6 +85,7 @@ EXPORTED void charset_lib_done(void)
 #define unicode_isvalid(c) \
         (!((c >= 0xd800 && c <= 0xdfff) || ((unsigned)c > 0x10ffff)))
 
+// clang-format: off
 static const char QPSAFECHAR[256] = {
 /* control chars are unsafe */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -108,6 +109,7 @@ static const char QPSAFECHAR[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
+// clang-format: on
 
 struct qp_state {
     int isheader;
@@ -284,6 +286,7 @@ static const char *convert_name(struct convert_rock *rock);
 /*
  * Table for decoding hexadecimal in quoted-printable
  */
+// clang-format: off
 static const unsigned char index_hex[256] = {
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
@@ -302,11 +305,13 @@ static const unsigned char index_hex[256] = {
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
 };
+// clang-format: on
 #define HEXCHAR(c)  (index_hex[(unsigned char)(c)])
 
 /*
  * Table for decoding base64
  */
+// clang-format: off
 static const char index_64[256] = {
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XS,XS,XX, XX,XS,XX,XX,
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
@@ -325,10 +330,12 @@ static const char index_64[256] = {
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
 };
+// clang-format: on
 
 /*
  * Table for decoding base64url
  */
+// clang-format: off
 static const char index_64url[256] = {
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XS,XS,XX, XX,XS,XX,XX,
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
@@ -347,6 +354,7 @@ static const char index_64url[256] = {
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
     XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX, XX,XX,XX,XX,
 };
+// clang-format: on
 #define CHAR64(c, index)  (index[(unsigned char)(c)])
 
 EXPORTED int encoding_lookupname(const char *s)
@@ -1061,6 +1069,7 @@ static void uni2utf8(struct convert_rock *rock, uint32_t c)
      * defined last valid codepoint is 0x10ffff so we only handle that
      * range. */
 
+    // clang-format: off
     if (c > 0xffff) {
         convert_putc(rock->next, 0xF0 + ((c >> 18) & 0x07));
         convert_putc(rock->next, 0x80 + ((c >> 12) & 0x3f));
@@ -1079,6 +1088,7 @@ static void uni2utf8(struct convert_rock *rock, uint32_t c)
     else {
         convert_putc(rock->next, c);
     }
+    // clang-format: on
 }
 
 /* Given an octet which is a codepoint in some 7bit or 8bit character
@@ -2555,6 +2565,7 @@ static charset_t lookup_buf(const char *buf, size_t len)
 /* of course = and _ are not included in the set, because they themselves
    need to be quoted it’s just saying they can be present in the Q wordi
    itself, because they’re part of the quoting system */
+// clang-format: off
 static const char QPMIMEPHRASESAFECHAR[256] = {
 /* control chars are unsafe */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2582,6 +2593,7 @@ static const char QPMIMEPHRASESAFECHAR[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
+// clang-format: on
 
 
 /* API */
@@ -4372,6 +4384,7 @@ EXPORTED struct char_counts charset_count_validutf8(const char *data, size_t dat
     return counts;
 }
 
+// clang-format: off
 static const unsigned char hexdigit[256] = {
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -4407,6 +4420,7 @@ static const unsigned char hexdigit[256] = {
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 };
+// clang-format: on
 
 EXPORTED int charset_decode_percent(struct buf *dst, const char *val)
 {
@@ -4432,6 +4446,7 @@ EXPORTED int charset_decode_percent(struct buf *dst, const char *val)
     return r;
 }
 
+// clang-format: off
 const char QSTRINGCHAR[256] = {
 /* control chars 9 (TAB), 10 (LF), 13 (CR) and space (32)
  * are not permitted, all other control characters obsolete */
@@ -4456,6 +4471,7 @@ const char QSTRINGCHAR[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
+// clang-format: on
 
 EXPORTED void charset_append_mime_param(struct buf *buf, unsigned flags,
                                         const char *name, const char *value)

--- a/netnews/readconfig.c
+++ b/netnews/readconfig.c
@@ -154,9 +154,10 @@ STATIC int EXPsplit(char *p, char sep, char **argv, int count)
             for (; *p == sep; p++);
             if (!*p)
                 return i;
-            if (++i == count)
+            if (++i == count) {
                 /* Overflow. */
                 return -1;
+            }
             *argv++ = p;
         }
     return i;

--- a/ptclient/ptloader.c
+++ b/ptclient/ptloader.c
@@ -147,6 +147,7 @@ struct auth_state *ptsmodule_make_authstate(const char *identifier,
  * Identifiers don't require a digit, really, so that should probably be
  * relaxed, too.
  */
+// clang-format: off
 static char allowedchars[256] = {
  /* 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F */
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 00-0F */
@@ -169,6 +170,7 @@ static char allowedchars[256] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
+// clang-format: on
 
 /*
  * Convert 'identifier' into canonical form.

--- a/sieve/bc_emit.c
+++ b/sieve/bc_emit.c
@@ -414,13 +414,16 @@ static int bc_action_emit(int fd, int codep, int stopcodep,
             int testdist, thendist, elsedist;
             int c;
 
-            int jumpFalseLoc = -1;/* this is the location that is being reserved
-                                     for the first jump command
-                                     we jump to the false condition of the test */
+            /* this is the location that is being reserved for the first jump
+             * command.  we jump to the false condition of the test
+             */
+            int jumpFalseLoc = -1;
 
-            int jumpEndLoc = -1; /* this is the location that is being reserved
-                                    for the optional jump command
-                                    it jumps over the else statement to the end */
+            /* this is the location that is being reserved for the optional
+             * jump command.  it jumps over the else statement to the end
+             */
+            int jumpEndLoc = -1;
+
             int jumpto = -1;
             int jumpop = B_JUMP;
 

--- a/sieve/bc_parse.c
+++ b/sieve/bc_parse.c
@@ -467,7 +467,9 @@ EXPORTED int bc_header_parse(bytecode_input_t *bc, int *version, int *requires)
     int pos = 0;
 
     *version = 0;
-    if (requires) *requires = 0;
+    if (requires) {
+        *requires = 0;
+    }
 
     if (memcmp(bc, BYTECODE_MAGIC, BYTECODE_MAGIC_LEN)) return -1;
 
@@ -477,7 +479,9 @@ EXPORTED int bc_header_parse(bytecode_input_t *bc, int *version, int *requires)
     if (*version >= 0x11) {
         int req = ntohl(bc[pos++].value);
 
-        if (requires) *requires = req;
+        if (requires) {
+            *requires = req;
+        }
     }
 
     return pos;

--- a/sieve/bc_parse.c
+++ b/sieve/bc_parse.c
@@ -57,6 +57,7 @@ struct args_t {
     const size_t offsets[MAX_ARGS];
 };
 
+// clang-format: off
 static const struct args_t cmd_args_table[] = {
     { B_STOP,                    "", { 0 } },                            /*  0 */
     { B_KEEP_ORIG,               "", { 0 } },                            /*  1 */
@@ -306,7 +307,9 @@ static const struct args_t cmd_args_table[] = {
         offsetof(struct Commandlist, u.cal.reason_var)
       } },
 };
+// clang-format: on
 
+// clang-format: off
 static const struct args_t test_args_table[] = {
     { BC_FALSE,                  "", { 0 } },                            /*  0 */
     { BC_TRUE,                   "", { 0 } },                            /*  1 */
@@ -454,6 +457,7 @@ static const struct args_t test_args_table[] = {
         offsetof(struct Test, u.dt.kl)
       } },
 };
+// clang-format: on
 
 /* Given a bytecode_input_t at the beginning of a file,
  * return the version, the required extensions,

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -165,6 +165,7 @@ typedef union
  * <match-type: int> <relational-match: int> <collation: int>
  */
 
+// clang-format: off
 enum bytecode {
     B_STOP,
     B_KEEP_ORIG,                /* legacy keep w/o support for :flags          */
@@ -456,7 +457,9 @@ enum bytecode {
     /*****  insert new actions above this line  *****/
     B_ILLEGAL_VALUE             /* any value >= this code is illegal */
 };
+// clang-format: on
 
+// clang-format: off
 enum bytecode_comps {
     BC_FALSE,
     BC_TRUE,
@@ -594,6 +597,7 @@ enum bytecode_comps {
     /*****  insert new tests above this line  *****/
     BC_ILLEGAL_VALUE    /* any value >= this code is illegal */
 };
+// clang-format: on
 
 /* currently one enum so as to help determine where values are being misused.
  * we have left placeholders incase we need to add more later to the middle */


### PR DESCRIPTION
Make a bunch of things a little nicer before clang-format trips over them