### PR TITLE
charset.c: split address-specific encoding from encode_mimeheader

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_subject_with_address
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_subject_with_address
@@ -1,0 +1,47 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_set_create_subject_with_address
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    # This is a regression test for encoding of the Subject header: everything
+    # after the comma got chopped off when the first bit of a subject was an
+    # email address.
+    my $subject = 'foo@example.com, some more words here';
+
+    my $res = $jmap->CallMethods([
+        ['Email/set', {
+            create => {
+                email => {
+                    mailboxIds => {
+                        '$inbox' => JSON::true,
+                    },
+                    subject => $subject,
+                    from => [{
+                        email => 'from@local'
+                    }] ,
+                    to => [{
+                        email => 'to@local'
+                    }] ,
+                    bodyStructure => {
+                        type => 'text/plain',
+                        partId => 'part1',
+                    },
+                    bodyValues => {
+                        part1 => {
+                            value => 'email',
+                        }
+                    },
+                },
+            },
+        }, 'R1'],
+        ['Email/get', {
+            ids => ['#email'],
+            properties => ['subject'],
+        }, 'R2'],
+    ]);
+
+    $self->assert_str_equals($subject, $res->[1][1]{list}[0]{subject});
+}

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -374,9 +374,6 @@ static void test_encode_mimeheader(void)
              "=?UTF-8?Q?01234567890123456789012345678901234567890123456789012345?="
              "\r\n ""=?UTF-8?Q?=E2=82=AC?=", 0);
 
-    /* only encode display-name of address */
-    TESTCASE("\"abc\xe2\x88\x97xyz\" <foo@example.com>", "=?UTF-8?Q?=22abc=E2=88=97xyz=22?= <foo@example.com>", 0);
-
     /* fold long lines with whitespace */
     TESTCASE("012345678 " "012345678 " "012345678 " "012345678 "
              "012345678 " "012345678 " "012345678 " "0123456789",
@@ -409,6 +406,59 @@ static void test_encode_mimeheader(void)
              "=?UTF-8?Q?" "0123456789" "0123456789" "0123456789" "0123456789"
              "0123456789" "0123456789" "01?=\r\n "
              "=?UTF-8?Q?" "2345678901" "2345678?=", 79);
+
+#undef TESTCASE
+}
+
+static void test_encode_addrheader(void)
+{
+    /* corner cases in Quoted-Printable */
+#define TESTCASE(in, exp) \
+    { \
+        static const char _in[] = (in); \
+        static const char _exp[] = (exp); \
+        char *s = charset_encode_addrheader(_in, 0, 0); \
+        CU_ASSERT_PTR_NOT_NULL(s); \
+        char *unfolded = charset_unfold(s, strlen(s), CHARSET_UNFOLD_SKIPWS); \
+        CU_ASSERT_STRING_EQUAL(unfolded, _exp); \
+        free(unfolded); \
+        free(s); \
+    }
+
+    // Encode valid address lists as address list header:
+
+    /* multiple addresses */
+    TESTCASE("foo@local, bar@local", "foo@local, bar@local");
+
+    /* one display-name and address */
+    TESTCASE("\"abc\xe2\x88\x97xyz\" <foo@local>",
+             "=?UTF-8?Q?=22abc=E2=88=97xyz=22?= <foo@local>");
+
+    /* multiple display-names and addresses */
+    TESTCASE("\xf0\x9f\x99\x82 <foo@local>, "
+             "bar@local, "
+             "\xf0\x9f\xa4\xa1 <baz@local>",
+            "=?UTF-8?Q?=F0=9F=99=82?= <foo@local>, "
+             "bar@local, "
+            "=?UTF-8?Q?=F0=9F=A4=A1?= <baz@local>");
+
+    // Fall back encoding invalid address lists as regular header:
+
+    /* address and non-address text */
+    TESTCASE("foo@local, some stuff", "foo@local, some stuff");
+    TESTCASE("some stuff, foo@local", "some stuff, foo@local");
+
+    /* address and non-address non-ASCII text */
+    TESTCASE("foo@local, \xf0\x9f\x99\x82",
+             "=?UTF-8?Q?foo@local,_=F0=9F=99=82?=");
+
+    /* address and non-address text, multiple addresses */
+    TESTCASE("foo@local, some stuff, bar@local, other stuff",
+             "foo@local, some stuff, bar@local, other stuff");
+
+    /* display-name and address and trainling non-address text */
+    TESTCASE("\xc2\xa3 <foo@local>, stuff",
+             "=?UTF-8?Q?=C2=A3_<foo@local>,_stuff?=");
 
 #undef TESTCASE
 }

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1168,7 +1168,7 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
         if (organizer) {
             assert(!buf_len(&txn->buf));
             buf_printf(&txn->buf, "<%s>", organizer);
-            mimehdr = charset_encode_mimeheader(buf_cstring(&txn->buf),
+            mimehdr = charset_encode_addrheader(buf_cstring(&txn->buf),
                                                 buf_len(&txn->buf), 0);
             spool_replace_header(xstrdup("From"), mimehdr, txn->req_hdrs);
             buf_reset(&txn->buf);
@@ -1193,7 +1193,7 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
 
     if (strarray_size(schedule_addresses)) {
         char *value = strarray_join(schedule_addresses, ",");
-        mimehdr = charset_encode_mimeheader(value, 0, 0);
+        mimehdr = charset_encode_addrheader(value, 0, 0);
         spool_replace_header(xstrdup("X-Schedule-User-Address"),
                              mimehdr, txn->req_hdrs);
         free(value);

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -1246,7 +1246,7 @@ static int _carddav_store(struct mailbox *mailbox, struct buf *vcard,
     time_to_rfc5322(now, datestr, sizeof(datestr));
 
     /* XXX  This needs to be done via an LDAP/DB lookup */
-    header = charset_encode_mimeheader(mbuserid, 0, 0);
+    header = charset_encode_addrheader(mbuserid, 0, 0);
     fprintf(f, "From: %s <>\r\n", header);
     free(header);
 

--- a/imap/dav_util.c
+++ b/imap/dav_util.c
@@ -152,7 +152,7 @@ EXPORTED int dav_store_resource(struct transaction_t *txn,
             buf_printf(&txn->buf, "<%s@%s>", txn->userid, config_servername);
         }
 
-        mimehdr = charset_encode_mimeheader(buf_cstring(&txn->buf),
+        mimehdr = charset_encode_addrheader(buf_cstring(&txn->buf),
                                             buf_len(&txn->buf), 0);
         fprintf(f, "From: %s\r\n", mimehdr);
         free(mimehdr);

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -1145,7 +1145,7 @@ static int jmap_upload(struct transaction_t *txn)
             buf_printf(&txn->buf, "<%s@%s>", httpd_userid, config_servername);
         }
 
-        mimehdr = charset_encode_mimeheader(buf_cstring(&txn->buf),
+        mimehdr = charset_encode_addrheader(buf_cstring(&txn->buf),
                                             buf_len(&txn->buf), 0);
         fprintf(f, "From: %s\r\n", mimehdr);
         free(mimehdr);

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -406,7 +406,7 @@ static int store_submission(jmap_req_t *req, struct mailbox *mailbox,
         buf_printf(&buf, "<%s@%s>", httpd_userid, config_servername);
     }
 
-    from = charset_encode_mimeheader(buf_cstring(&buf), buf_len(&buf), 0);
+    from = charset_encode_addrheader(buf_cstring(&buf), buf_len(&buf), 0);
 
     fprintf(f, "MIME-Version: 1.0\r\n"
             "Date: %s\r\n"

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -643,7 +643,7 @@ static int _note_create(struct mailbox *mailbox, json_t *note, json_t **new_note
     else {
         buf_printf(&buf, "<%s@%s>", httpd_userid, config_servername);
     }
-    from = charset_encode_mimeheader(buf_cstring(&buf), buf_len(&buf), 0);
+    from = charset_encode_addrheader(buf_cstring(&buf), buf_len(&buf), 0);
 
     fprintf(f, "MIME-Version: 1.0 (Cyrus-JMAP/%s)\r\n"
             "X-Uniform-Type-Identifier: %s\r\n"

--- a/imap/jmap_notif.c
+++ b/imap/jmap_notif.c
@@ -109,7 +109,7 @@ HIDDEN char *jmap_caleventnotif_format_fromheader(const char *userid)
     else {
         buf_printf(&buf, "<%s@%s>", userid, config_servername);
     }
-    char *notfrom = charset_encode_mimeheader(buf_cstring(&buf), buf_len(&buf), 0);
+    char *notfrom = charset_encode_addrheader(buf_cstring(&buf), buf_len(&buf), 0);
     buf_free(&buf);
     return notfrom;
 }

--- a/imap/message.c
+++ b/imap/message.c
@@ -1338,7 +1338,7 @@ EXPORTED void message_parse_type(const char *hdr, char **typep, char **subtypep,
                 }
                 if (!has_highbit) continue;
                 /* Reencode the parameter value */
-                char *encvalue = charset_encode_mimeheader(param->value, strlen(param->value), 0);
+                char *encvalue = charset_encode_addrheader(param->value, strlen(param->value), 0);
                 if (encvalue) {
                     free(param->value);
                     param->value = encvalue;

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -592,7 +592,7 @@ static int store_script(struct mailbox *mailbox, struct sieve_data *sdata,
     else {
         buf_printf(&buf, "<%s@%s>", userid, config_servername);
     }
-    mimehdr = charset_encode_mimeheader(buf_cstring(&buf), buf_len(&buf), 0);
+    mimehdr = charset_encode_addrheader(buf_cstring(&buf), buf_len(&buf), 0);
     fprintf(f, "From: %s\r\n", mimehdr);
     free(mimehdr);
 

--- a/lib/charset.h
+++ b/lib/charset.h
@@ -151,8 +151,29 @@ extern int charset_to_utf8(struct buf *dst, const char *src, size_t len, charset
 
 extern int charset_search_mimeheader(const char *substr, comp_pat *pat, const char *s, int flags);
 
+/* "Q" encode the header field body (per RFC 2047) of 'len' bytes
+ * located at 'header'.
+ * Returns a buffer which the caller must free.
+ */
 extern char *charset_encode_mimeheader(const char *header, size_t len, int force_quote);
-extern char *charset_encode_mimephrase(const char *header);
+
+/* "Q" encode the header field body (per RFC 2047) of 'len' bytes
+ * located at 'header'. The header is assumed to contain a list of
+ * addresses, such as in a From or Cc header. For such addresses,
+ * the display name is encoded but the address part left unencoded.
+ * If the header value is not a valid address-list (per RFC 5322,
+ * 3.4), then this is equivalent to calling charset_encode_mimeheader.
+ * Returns a buffer which the caller must free.
+ */
+extern char *charset_encode_addrheader(const char *header, size_t len, int force_quote);
+
+/* "Q" encode the header phrase (per RFC 2047) of 'len' bytes
+ * located at 'phrase'. Quoting RFC 2047, this acts as a replacement
+ * for a 'word' entity within a 'phrase', for example, one that
+ * precedes an address in a From, To, or Cc header.
+ * Returns a buffer which the caller must free.
+ */
+extern char *charset_encode_mimephrase(const char *phrase);
 
 extern char *charset_unfold(const char *s, size_t len, int flags);
 

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -2402,7 +2402,7 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
                 value = parse_string(value, variables);
             }
 
-            encoded_value = charset_encode_mimeheader(value, strlen(value), 0);
+            encoded_value = charset_encode_addrheader(value, strlen(value), 0);
 
             i->addheader(m, name, encoded_value, index);
             i->edited_headers = 1;


### PR DESCRIPTION
The current charset_encode_mimeheader function encodes its input differently depending on if the header value contains an email address or not.

- If it finds email addresses, it Q-encodes only the display name of the adress and appends the email address as-is. Any *trailing* non-email address content is discarded, but any non-email address content *in-between* valid addresses is kept as-is. For such input, this function currently produces invalid address-list headers.
- If instead if does not find an email address, then it encodes the entire header using Q-encoding.

This patch moves the address-list encoding into its own function, charset_encode_addrheader:

- The charset_encode_mimeheader from now on always encodes its given value in entirety in Q-encoding.
- The charset_encode_addrheader attempts to encode the header value as an address list, but if the result is an invalid address list header it falls back to calling charset_encode_mimeheader.

For backward compatibility, this patch calls charset_encode_addrheader at all those call sites, where it is unknown if the header value is supposed to contain an address list or some other value.