### PR TITLE
mailbox: fix expunge limit

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5787,7 +5787,7 @@ EXPORTED int mailbox_expunge_cleanup(struct mailbox *mailbox,
             break;
         }
 
-        if (limit && limit >= (int)numdeleted) {
+        if (limit && limit <= (int)numdeleted) {
             r = IMAP_AGAIN;
             break;
         }


### PR DESCRIPTION
Right now we're doing ONE message at time, which is super inefficient