### PR TITLE
shush known format-nonliteral warnings

### DIFF
--- a/cunit/cyrunit.h
+++ b/cunit/cyrunit.h
@@ -59,11 +59,7 @@ extern void config_read_string(const char *s);
  * which makes it rather hard to see why an assertion failed.  So we
  * replace the macros with improved ones, keeping the same API.
  */
-/* XXX Would like to add __attribute__((format(printf, 6, 7)))
- * XXX to this so the compiler can warn if it's misused, but it looks
- * XXX like it currently gets very confused by the layers of macros
- * XXX and produces bogus warnings. :(
- */
+__attribute__((format(printf, 6, 7)))
 extern CU_BOOL CU_assertFormatImplementation(CU_BOOL bValue,
                                              unsigned int uiLine,
                                              const char strFile[],

--- a/cunit/cyrunit.h
+++ b/cunit/cyrunit.h
@@ -182,7 +182,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     CU_assertFormatImplementation(!strcmp(_a?_a:"",_e?_e:""), __LINE__, \
         __FILE__, "", CU_FALSE,                                         \
         "CU_ASSERT_STRING_EQUAL(%s=\"%s\",%s=\"%s\")",                  \
-        #actual, _a, #expected, _e);                                    \
+        #actual, _a ? _a : "(null)",                                    \
+        #expected, _e ? _e : "(null)");                                 \
 } while(0)
 
 #undef CU_ASSERT_STRING_EQUAL_FATAL
@@ -191,7 +192,8 @@ extern int __cunit_wrap_fixture(const char *name, int (*fn)(void));
     CU_assertFormatImplementation(!strcmp(_a?_a:"",_e?_e:""), __LINE__, \
         __FILE__, "", CU_TRUE,                                          \
         "CU_ASSERT_STRING_EQUAL_FATAL(%s=\"%s\",%s=\"%s\")",            \
-        #actual, _a, #expected, _e);                                    \
+        #actual, _a ? _a : "(null)",                                    \
+        #expected, _e ? _e : "(null)");                                 \
 } while(0)
 
 #undef CU_ASSERT_STRING_NOT_EQUAL

--- a/imap/cyr_ls.c
+++ b/imap/cyr_ls.c
@@ -177,9 +177,14 @@ static void long_list(struct stat *statp)
     pwd = getpwuid(statp->st_uid);
     grp = getgrgid(statp->st_gid);
 
-    if (now - statp->st_ctime > SECONDS_PER_YEAR) datefmt = "%b %d  %Y";
+    if (now - statp->st_ctime > SECONDS_PER_YEAR)
+        datefmt = "%b %d  %Y";
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string chosen above */
     strftime(datestr, 13, datefmt, localtime(&(statp->st_ctime)));
+#pragma GCC diagnostic pop
 
     /* XXX statp->st_size should use OFF_T_FMT not PRIi64, but our FMT
      * XXX macros don't allow setting flags

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2227,8 +2227,12 @@ static int list_calendars(struct transaction_t *txn)
     buf_printf_markup(body, level, "<title>%s</title>", "Available Calendars");
     buf_printf_markup(body, level++, "<script type=\"text/javascript\">");
     buf_appendcstr(body, "//<![CDATA[\n");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string comes from http_cal_abook_admin_js.h */
     buf_printf(body, http_cal_abook_admin_js,
                CYRUS_VERSION, http_cal_abook_admin_js_len);
+#pragma GCC diagnostic pop
     buf_appendcstr(body, "//]]>\n");
     buf_printf_markup(body, --level, "</script>");
     buf_printf_markup(body, level++, "<noscript>");

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1229,8 +1229,12 @@ static int list_addressbooks(struct transaction_t *txn)
     buf_printf_markup(body, level, "<title>%s</title>", "Available Addressbooks");
     buf_printf_markup(body, level++, "<script type=\"text/javascript\">");
     buf_appendcstr(body, "//<![CDATA[\n");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string comes from http_cal_abook_admin_js.h */
     buf_printf(body, http_cal_abook_admin_js,
                CYRUS_VERSION, http_cal_abook_admin_js_len);
+#pragma GCC diagnostic pop
     buf_appendcstr(body, "//]]>\n");
     buf_printf_markup(body, --level, "</script>");
     buf_printf_markup(body, level++, "<noscript>");

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -1728,7 +1728,11 @@ static int json_error_response(struct transaction_t *txn, long tz_code,
     else fmt = "End date-time <= start date-time";
 
     assert(!buf_len(&txn->buf));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string chosen above */
     buf_printf(&txn->buf, fmt, param_name);
+#pragma GCC diagnostic pop
 
     root = json_pack("{s:s s:s s:i}", "title", buf_cstring(&txn->buf),
                      "type", error_message(tz_code),

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2674,13 +2674,23 @@ static void comma_list_body(struct buf *buf,
     for (i = 0; vals[i]; i++) {
         if (flags & (1 << i)) {
             buf_appendcstr(buf, sep);
-            if (has_args) buf_vprintf(buf, vals[i], args);
-            else buf_appendcstr(buf, vals[i]);
+            if (has_args) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+                buf_vprintf(buf, vals[i], args);
+#pragma GCC diagnostic pop
+            }
+            else {
+                buf_appendcstr(buf, vals[i]);
+            }
             sep = ", ";
         }
         else if (has_args) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
             /* discard any unused args */
             vsnprintf(NULL, 0, vals[i], args);
+#pragma GCC diagnostic pop
         }
     }
 }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3817,8 +3817,11 @@ static void capa_response(int flags)
             do {
                 prot_putc(' ', imapd_out);
                 prot_puts(imapd_out, capa);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+                /* format string and args chosen carefully */
                 prot_printf(imapd_out, valfmt, s, i64);
-
+#pragma GCC diagnostic pop
             } while ((mask & CAPA_MULTI) && (++n < num) && (s = *(++strp)));
         }
     }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4680,12 +4680,22 @@ static void warn_about_quota(const char *quotaroot)
             pc_usage = (int)(((double) q.useds[res] * 100.0) /
                              (double) ((quota_t) q.limits[res] * quota_units[res]));
 
-            if (q.useds[res] > (quota_t) q.limits[res] * quota_units[res])
+            if (q.useds[res] > (quota_t) q.limits[res] * quota_units[res]) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+                /* format string from imap_err.et */
                 buf_printf(&msg, error_message(IMAP_NO_OVERQUOTA),
                            quota_names[res]);
-            else if (pc_usage > pc_threshold)
+#pragma GCC diagnostic pop
+            }
+            else if (pc_usage > pc_threshold) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+                /* format string from imap_err.et */
                 buf_printf(&msg, error_message(IMAP_NO_CLOSEQUOTA),
                            pc_usage, quota_names[res]);
+#pragma GCC diagnostic pop
+            }
         }
 
         if (msg.len)

--- a/imap/index.c
+++ b/imap/index.c
@@ -3586,7 +3586,11 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
     r = index_reload_record(state, msgno, &record);
     if (r) {
         prot_printf(state->out, "* OK ");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+        /* format string comes from imap_err.et */
         prot_printf(state->out, error_message(IMAP_NO_MSGGONE), msgno);
+#pragma GCC diagnostic pop
         prot_printf(state->out, "\r\n");
         return 0;
     }
@@ -3598,7 +3602,11 @@ static int index_fetchreply(struct index_state *state, uint32_t msgno,
         fetchargs->bodysections) {
         if (mailbox_map_record(mailbox, &record, &buf)) {
             prot_printf(state->out, "* OK ");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+            /* format string comes from imap_err.et */
             prot_printf(state->out, error_message(IMAP_NO_MSGGONE), msgno);
+#pragma GCC diagnostic pop
             prot_printf(state->out, "\r\n");
             return 0;
         }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -4298,7 +4298,12 @@ static int _contact_set_create(jmap_req_t *req, unsigned kind, json_t *jcard,
         goto done;
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string chosen above */
     syslog(LOG_NOTICE, logfmt, req->accountid, mboxname, uid, name);
+#pragma GCC diagnostic pop
+
     r = carddav_store(*mailbox, card, resourcename, 0, flags, &annots,
                       req->userid, req->authstate, ignorequota, /*oldsize*/ 0);
     if (r && r != HTTP_CREATED && r != HTTP_NO_CONTENT) {

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -171,8 +171,12 @@ static void send_lmtp_error(struct protstream *pout, int r, strarray_t *resp)
 
     case IMAP_PERMISSION_DENIED:
         if (LMTP_LONG_ERROR_MSGS) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+            /* format string comes from lmtp_err.et */
             prot_printf(pout, error_message(LMTP_NOT_AUTHORIZED_LONG),
                         config_getstring(IMAPOPT_POSTMASTER));
+#pragma GCC diagnostic pop
         }
         code = LMTP_NOT_AUTHORIZED;
         break;
@@ -227,7 +231,11 @@ static void send_lmtp_error(struct protstream *pout, int r, strarray_t *resp)
         break;
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string comes from lmtp_err.et */
     prot_printf(pout, error_message(code), text, session_id());
+#pragma GCC diagnostic pop
     prot_puts(pout, "\r\n");
 }
 

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -748,8 +748,17 @@ int main(int argc, char **argv)
         int ret;
         const char *debugger = config_getstring(IMAPOPT_DEBUG_COMMAND);
         if (debugger) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+            /* This is exactly the kind of usage that -Wformat is designed to
+             * complain about (using user-supplied string as format argument),
+             * but in this case the "user" is the server administrator, and
+             * they're about to attach a debugger, so worrying about leaking
+             * contents of memory here is a little silly! :)
+             */
             snprintf(debugbuf, sizeof(debugbuf), debugger,
                      argv[0], getpid(), "promstatsd");
+#pragma GCC diagnostic pop
             syslog(LOG_DEBUG, "running external debugger: %s", debugbuf);
             ret = system(debugbuf); /* run debugger */
             syslog(LOG_DEBUG, "debugger returned exit status: %d", ret);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2678,7 +2678,7 @@ static int sync_mailbox_compare_update(struct mailbox *mailbox,
             int hadsnoozed = 0;
             r = apply_annotations(mailbox, &copy, rannots, mannots, 0, &hadsnoozed);
             if (r) {
-                xsyslog(LOG_ERR, "SYNCERROR: failed to write merged annotations"
+                xsyslog(LOG_ERR, "SYNCERROR: failed to write merged annotations",
                                  "mailbox=<%s> recno=<%u> error=<%s>",
                                  mailbox_name(mailbox),
                                  rrecord->recno,

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -121,8 +121,12 @@ const char *icaltime_as_iso_string(const struct icaltimetype tt)
     else if (icaltime_is_utc(tt)) fmt = "%04d-%02d-%02dT%02d:%02d:%02dZ";
     else fmt = "%04d-%02d-%02dT%02d:%02d:%02d";
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string decided above */
     snprintf(str, sizeof(str), fmt, tt.year, tt.month, tt.day,
              tt.hour, tt.minute, tt.second);
+#pragma GCC diagnostic pop
 
     return str;
 }
@@ -150,7 +154,11 @@ const char *icalvalue_utcoffset_as_iso_string(const icalvalue* value)
     if (s > 0) fmt = "%c%02d:%02d:%02d";
     else fmt = "%c%02d:%02d";
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string decided above */
     snprintf(str, sizeof(str), fmt, sign, abs(h), abs(m), abs(s));
+#pragma GCC diagnostic pop
 
     return str;
 }

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -1554,7 +1554,11 @@ static void print_command(const char *cmd, const char *arg)
     static struct buf buf = BUF_INITIALIZER;
 
     buf_reset(&buf);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* Format string comes from struct protocol_t protocols[] */
     buf_printf(&buf, cmd, arg);
+#pragma GCC diagnostic pop
     buf_replace_all(&buf, "\r\n", "\r\nC: ");
 
     printf("C: %s", buf_cstring(&buf));
@@ -1584,7 +1588,11 @@ static struct buf *ask_capability(struct protocol_t *prot,
         print_command(prot->capa_cmd.cmd, servername);
         printf("\r\n");
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+        /* Format string comes from struct protocol_t protocols[] */
         prot_printf(pout, prot->capa_cmd.cmd, servername);
+#pragma GCC diagnostic pop
         prot_puts(pout, "\r\n");
         prot_flush(pout);
     }
@@ -3229,7 +3237,11 @@ int main(int argc, char **argv)
             print_command(protocol->tls_cmd.cmd, servername);
             printf("\r\n");
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+            /* Format string comes from struct protocol_t protocols[] */
             prot_printf(pout, protocol->tls_cmd.cmd, servername);
+#pragma GCC diagnostic pop
             prot_puts(pout, "\r\n");
             prot_flush(pout);
 

--- a/lib/times.c
+++ b/lib/times.c
@@ -537,7 +537,6 @@ static int breakdown_time_to_iso8601(const struct timeval *t, struct tm *tm,
 {
     int gmtnegative = 0;
     size_t rlen;
-    const char *datefmt = withsep ? "%Y-%m-%dT%H:%M:%S" : "%Y%m%dT%H%M%S";
 
     /*assert(date > 0); - it turns out these can happen, annoyingly enough */
     /*assert(tm->tm_year >= 69);*/
@@ -548,7 +547,9 @@ static int breakdown_time_to_iso8601(const struct timeval *t, struct tm *tm,
     }
     gmtoff /= 60;
 
-    rlen = strftime(buf, len, datefmt, tm);
+    rlen = strftime(buf, len,
+                    withsep ? "%Y-%m-%dT%H:%M:%S" : "%Y%m%dT%H%M%S",
+                    tm);
     if (rlen > 0) {
         switch(tv_precision) {
         case timeval_ms:

--- a/master/service.c
+++ b/master/service.c
@@ -405,7 +405,6 @@ int main(int argc, char **argv, char **envp)
         if (debugger) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-#pragma GCC diagnostic ignored "-Wformat-security"
             /* This is exactly the kind of usage that -Wformat is designed to
              * complain about (using user-supplied string as format argument),
              * but in this case the "user" is the server administrator, and

--- a/sieve/sieve.y
+++ b/sieve/sieve.y
@@ -2063,7 +2063,11 @@ void sieveerror_c(sieve_script_t *sscript, int code, ...)
     va_list args;
 
     va_start(args, code);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    /* format string comes from sieve_err.et */
     vsieveerror_f(sscript, error_message(code), args);
+#pragma GCC diagnostic pop
     va_end(args);
 }
 


### PR DESCRIPTION
This PR shushes individual `-Wformat-nonliteral` warnings in places where we have no choice but to use a non-literal format string.  The intent is that we'll be able to compile with `-Wformat=2` to more aggressively detect misused printf-style functions, and only get errors from actual (new) problems.  I was also able to fix a couple of things that were detected with the higher warning level, so it's already doing its job.

In one location (master), it removes a previous suppression of `-Wformat-security`.  This line isn't actually generating a `-Wformat-security` warning, so I removed the suppression to avoid masking future problems.  promstatsd has a similar piece of code without the suppression, so I have given it the same suppressions and comment.

I have temporarily added `-Wformat=2` to Makefile.am to force the stricter warnings for all builds; **I intend to drop that commit before this PR is merged**.  It's useful in the meantime for having CI for this PR run with the extra warnings, which allowed me to detect and shush a lot of things that clang warned about but GCC didn't.  If we want `-Wformat=2` routinely enabled long term, the right place to add it is probably cyd build.

**Reviewers:** please pull this branch and build/test it locally.  If there's any build errors in your dev environment, let me know and I'll sort those out too.