### PR TITLE
clang-format: disable formatting for JMAP and DAV API struct literals

### DIFF
--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -93,6 +93,7 @@ static int action_conf(struct transaction_t *txn);
 
 
 /* Namespace for admin service */
+// clang-format off
 struct namespace_t namespace_admin = {
     URL_NS_ADMIN, 1, "admin", "/admin", NULL,
     http_allow_noauth_get, /*authschemes*/0,
@@ -124,6 +125,7 @@ struct namespace_t namespace_admin = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 static void admin_init(struct buf *serverinfo __attribute__((unused)))

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -57,6 +57,7 @@ static void applepush_init(struct buf *serverinfo);
 static int meth_get_applepush(struct transaction_t *txn, void *params);
 static int meth_post_applepush(struct transaction_t *txn, void *params);
 
+// clang-format off
 struct namespace_t namespace_applepush = {
     URL_NS_APPLEPUSH, /*enabled*/0, "applepush", "/applepush/subscribe", NULL,
     http_allow_noauth_get, /*authschemes*/0,
@@ -88,6 +89,7 @@ struct namespace_t namespace_applepush = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 static void applepush_init(struct buf *serverinfo __attribute__((unused)))
 {

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -296,6 +296,7 @@ static void end_icalendar(struct buf *buf);
 
 #define ICALENDAR_CONTENT_TYPE "text/calendar; charset=utf-8"
 
+// clang-format off
 static struct mime_type_t caldav_mime_types[] = {
     /* First item MUST be the default type and storage format */
     { ICALENDAR_CONTENT_TYPE, "2.0", "ics",
@@ -322,14 +323,18 @@ static struct mime_type_t caldav_mime_types[] = {
 #endif
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
+// clang-format on
 
+// clang-format off
 static struct patch_doc_t caldav_patch_docs[] = {
     { ICALENDAR_CONTENT_TYPE "; component=VPATCH; optinfo=\"PATCH-VERSION:1\"",
       &caldav_patch },
     { NULL, &caldav_patch }
 };
+// clang-format on
 
 /* Array of supported REPORTs */
+// clang-format off
 static const struct report_type_t caldav_reports[] = {
 
     /* WebDAV Versioning (RFC 3253) REPORTs */
@@ -354,8 +359,10 @@ static const struct report_type_t caldav_reports[] = {
 
     { NULL, 0, NULL, NULL, 0, 0 }
 };
+// clang-format on
 
 /* Array of known "live" properties */
+// clang-format off
 static const struct prop_entry caldav_props[] = {
 
     /* WebDAV (RFC 4918) properties */
@@ -581,8 +588,10 @@ static const struct prop_entry caldav_props[] = {
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };
+// clang-format on
 
 
+// clang-format off
 static struct meth_params caldav_params = {
     caldav_mime_types,
     &caldav_parse_path,
@@ -612,9 +621,11 @@ static struct meth_params caldav_params = {
     { 0, caldav_props },                        /* Allow infinite depth */
     caldav_reports
 };
+// clang-format on
 
 
 /* Namespace for CalDAV collections */
+// clang-format off
 struct namespace_t namespace_calendar = {
     URL_NS_CALENDAR, 0, "calendar", "/dav/calendars", "/.well-known/caldav",
     http_allow_noauth_get, /*authschemes*/0,
@@ -650,9 +661,11 @@ struct namespace_t namespace_calendar = {
         { &meth_unlock,         &caldav_params }        /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 /* Namespace for Freebusy Read URL */
+// clang-format off
 struct namespace_t namespace_freebusy = {
     URL_NS_FREEBUSY, 0, "freebusy", "/freebusy", NULL,
     http_allow_noauth_get, /*authschemes*/0,
@@ -683,6 +696,7 @@ struct namespace_t namespace_freebusy = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 static const struct cal_comp_t {
@@ -8003,6 +8017,7 @@ static int report_fb_query(struct transaction_t *txn,
 }
 
 
+// clang-format off
 static struct mime_type_t freebusy_mime_types[] = {
     /* First item MUST be the default type */
     { ICALENDAR_CONTENT_TYPE, "2.0", "ifb",
@@ -8019,6 +8034,7 @@ static struct mime_type_t freebusy_mime_types[] = {
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
+// clang-format on
 
 
 /* Execute a free/busy query per

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -149,6 +149,7 @@ static int report_card_query(struct transaction_t *txn,
 
 #ifdef HAVE_LIBICALVCARD
 
+// clang-format off
 static struct mime_type_t carddav_mime_types[] = {
     /* First item MUST be the default type and storage format */
     { "text/vcard; charset=utf-8", "3.0", "vcf",
@@ -168,6 +169,7 @@ static struct mime_type_t carddav_mime_types[] = {
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
+// clang-format on
 
 #else /* !HAVE_LIBICALVCARD */
 
@@ -194,6 +196,7 @@ static struct mime_type_t carddav_mime_types[] = {
 #endif /* HAVE_LIBICALVCARD */
 
 /* Array of supported REPORTs */
+// clang-format off
 static const struct report_type_t carddav_reports[] = {
 
     /* WebDAV Versioning (RFC 3253) REPORTs */
@@ -216,8 +219,10 @@ static const struct report_type_t carddav_reports[] = {
 
     { NULL, 0, NULL, NULL, 0, 0 }
 };
+// clang-format on
 
 /* Array of known "live" properties */
+// clang-format off
 static const struct prop_entry carddav_props[] = {
 
     /* WebDAV (RFC 4918) properties */
@@ -357,7 +362,9 @@ static const struct prop_entry carddav_props[] = {
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };
+// clang-format on
 
+// clang-format off
 static struct meth_params carddav_params = {
     carddav_mime_types,
     &carddav_parse_path,
@@ -387,9 +394,11 @@ static struct meth_params carddav_params = {
     { DAV_FINITE_DEPTH, carddav_props },        /* Disable infinite depth */
     carddav_reports
 };
+// clang-format on
 
 
 /* Namespace for Carddav collections */
+// clang-format off
 struct namespace_t namespace_addressbook = {
     URL_NS_ADDRESSBOOK, 0, "addressbook", "/dav/addressbooks", "/.well-known/carddav",
     http_allow_noauth_get, /*authschemes*/0,
@@ -423,6 +432,7 @@ struct namespace_t namespace_addressbook = {
         { &meth_unlock,         &carddav_params }       /* UNLOCK       */
     }
 };
+// clang-format on
 
 static void my_carddav_init(struct buf *serverinfo __attribute__((unused)))
 {

--- a/imap/http_cgi.c
+++ b/imap/http_cgi.c
@@ -70,6 +70,7 @@ static int meth_post(struct transaction_t *txn, void *params);
 
 
 /* Namespace for CGI */
+// clang-format off
 struct namespace_t namespace_cgi = {
     URL_NS_CGI, 0, "cgi", "/cgi-bin", NULL,
     http_allow_noauth, /*authschemes*/0,
@@ -101,6 +102,7 @@ struct namespace_t namespace_cgi = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 static void cgi_init(struct buf *serverinfo __attribute__((unused)))

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -194,6 +194,7 @@ static const struct report_type_t principal_reports[] = {
 };
 
 /* Array of known "live" properties */
+// clang-format off
 static const struct prop_entry principal_props[] = {
 
     /* WebDAV (RFC 4918) properties */
@@ -292,6 +293,7 @@ static const struct prop_entry principal_props[] = {
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };
+// clang-format on
 
 
 struct meth_params princ_params = {
@@ -301,6 +303,7 @@ struct meth_params princ_params = {
 };
 
 /* Namespace for WebDAV principals */
+// clang-format off
 struct namespace_t namespace_principal = {
     URL_NS_PRINCIPAL, 0, "principal", "/dav/principals", NULL,
     http_allow_noauth_get, /*authschemes*/0,
@@ -332,6 +335,7 @@ struct namespace_t namespace_principal = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 /* Linked-list of properties for fetching */
@@ -8030,6 +8034,7 @@ static int principal_search(const char *userid, void *rock)
 }
 
 
+// clang-format off
 static const struct prop_entry prin_search_props[] = {
 
     /* WebDAV (RFC 4918) properties */
@@ -8041,6 +8046,7 @@ static const struct prop_entry prin_search_props[] = {
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };
+// clang-format on
 
 
 /* DAV:principal-property-search REPORT */

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -119,6 +119,7 @@ static xmlDocPtr to_xml(const struct buf *buf)
     return doc;
 }
 
+// clang-format off
 static struct mime_type_t notify_mime_types[] = {
     /* First item MUST be the default type and storage format */
     { DAVNOTIFICATION_CONTENT_TYPE, NULL, "xml",
@@ -128,8 +129,10 @@ static struct mime_type_t notify_mime_types[] = {
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
+// clang-format on
 
 /* Array of supported REPORTs */
+// clang-format off
 static const struct report_type_t notify_reports[] = {
 
     /* WebDAV Versioning (RFC 3253) REPORTs */
@@ -146,8 +149,10 @@ static const struct report_type_t notify_reports[] = {
 
     { NULL, 0, NULL, NULL, 0, 0 }
 };
+// clang-format on
 
 /* Array of known "live" properties */
+// clang-format off
 static const struct prop_entry notify_props[] = {
 
     /* WebDAV (RFC 4918) properties */
@@ -237,7 +242,9 @@ static const struct prop_entry notify_props[] = {
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };
+// clang-format on
 
+// clang-format off
 static struct meth_params notify_params = {
     notify_mime_types,
     &notify_parse_path,
@@ -266,9 +273,11 @@ static struct meth_params notify_params = {
     { DAV_FINITE_DEPTH, notify_props},
     notify_reports
 };
+// clang-format on
 
 
 /* Namespace for WebDAV notification collections */
+// clang-format off
 struct namespace_t namespace_notify = {
     URL_NS_NOTIFY, 0, "notify", "/dav/notifications", NULL,
     http_allow_noauth_get, /*authschemes*/0,
@@ -302,6 +311,7 @@ struct namespace_t namespace_notify = {
         { NULL,                 NULL },                /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 static void my_dav_init(struct buf *serverinfo __attribute__((unused)))

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -56,6 +56,7 @@
 static int meth_get_db(struct transaction_t *txn, void *params);
 
 /* Namespace for DB lookups */
+// clang-format off
 struct namespace_t namespace_dblookup = {
     URL_NS_DBLOOKUP, /*enabled*/1, "dblookup", "/dblookup", NULL,
     http_allow_noauth, /*authschemes*/0,
@@ -87,6 +88,7 @@ struct namespace_t namespace_dblookup = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 static int get_email(struct transaction_t *txn __attribute__((unused)),
                      const char *userid, const char *key)

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -98,6 +98,7 @@ static int dkim_auth(struct transaction_t *txn);
 static int meth_get_domainkey(struct transaction_t *txn, void *params);
 static time_t compile_time;
 
+// clang-format off
 static struct mime_type_t isched_mime_types[] = {
     /* First item MUST be the default type and storage format */
     { "text/calendar; charset=utf-8", "2.0", "ics",
@@ -117,7 +118,9 @@ static struct mime_type_t isched_mime_types[] = {
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
+// clang-format on
 
+// clang-format off
 struct namespace_t namespace_ischedule = {
     URL_NS_ISCHEDULE, 0, "ischedule", "/ischedule", ISCHED_WELLKNOWN_URI,
     http_allow_noauth, /*authschemes*/0,
@@ -149,7 +152,9 @@ struct namespace_t namespace_ischedule = {
         { NULL,                 NULL }  /* UNLOCK       */
     }
 };
+// clang-format on
 
+// clang-format off
 struct namespace_t namespace_domainkey = {
     URL_NS_DOMAINKEY, 0, "domainkey", "/domainkeys", "/.well-known/domainkey",
     http_allow_noauth, /*authschemes*/0,
@@ -179,6 +184,7 @@ struct namespace_t namespace_domainkey = {
         { NULL,                 NULL }  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 void isched_capa_hdr(struct transaction_t *txn, time_t *lastmod, struct stat *sb)

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -111,6 +111,7 @@ static struct connect_params ws_params = {
 
 
 /* Namespace for JMAP */
+// clang-format off
 struct namespace_t namespace_jmap = {
     URL_NS_JMAP, 0, "jmap", JMAP_ROOT, "/.well-known/jmap",
     jmap_need_auth, 0,
@@ -142,6 +143,7 @@ struct namespace_t namespace_jmap = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 /*

--- a/imap/http_prometheus.c
+++ b/imap/http_prometheus.c
@@ -54,6 +54,7 @@ static void prom_reset(void);
 static void prom_shutdown(void);
 static int prom_get(struct transaction_t *txn, void *params);
 
+// clang-format off
 struct namespace_t namespace_prometheus = {
     URL_NS_PROMETHEUS,
     /*enabled*/ 0,
@@ -94,6 +95,7 @@ struct namespace_t namespace_prometheus = {
         { NULL,                 NULL },                 /* UNLOCK       */
     },
 };
+// clang-format on
 
 static int prom_need_auth(struct transaction_t *txn __attribute__((unused)))
 {

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -107,6 +107,7 @@ static struct body *body_fetch_section(struct body *body, const char *section);
 
 
 /* Namespace for RSS feeds of mailboxes */
+// clang-format off
 struct namespace_t namespace_rss = {
     URL_NS_RSS, 0, "rss", "/rss", NULL,
     http_allow_noauth_get, /*authschemes*/0,
@@ -138,6 +139,7 @@ struct namespace_t namespace_rss = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 static void rss_init(struct buf *serverinfo __attribute__((unused)))

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -103,6 +103,7 @@ static struct buf *icaltimezone_as_tzif_leap(icalcomponent* comp);
 static struct buf *_icaltimezone_as_tzif(icalcomponent* ical, bit32 leapcnt,
                                          icaltimetype *startp, icaltimetype *endp);
 
+// clang-format off
 static struct mime_type_t tz_mime_types[] = {
     /* First item MUST be the default type and storage format */
     { "text/calendar; charset=utf-8", "2.0", "ics",
@@ -127,9 +128,11 @@ static struct mime_type_t tz_mime_types[] = {
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
+// clang-format on
 
 
 /* Namespace for tzdist service */
+// clang-format off
 struct namespace_t namespace_tzdist = {
     URL_NS_TZDIST, 0, "tzdist", "/tzdist", TZDIST_WELLKNOWN_URI,
     http_allow_noauth, /*authschemes*/0,
@@ -161,6 +164,7 @@ struct namespace_t namespace_tzdist = {
         { NULL,                 NULL }                  /* UNLOCK       */
     }
 };
+// clang-format on
 
 
 #ifdef HAVE_SHAPELIB

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -98,6 +98,7 @@ static const struct buf *to_buf(const struct buf *buf)
     return buf;
 }
 
+// clang-format off
 static struct mime_type_t webdav_mime_types[] = {
     /* First item MUST be the default type and storage format */
     { "*/*", NULL, NULL,
@@ -107,8 +108,10 @@ static struct mime_type_t webdav_mime_types[] = {
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 };
+// clang-format on
 
 /* Array of supported REPORTs */
+// clang-format off
 static const struct report_type_t webdav_reports[] = {
 
     /* WebDAV Versioning (RFC 3253) REPORTs */
@@ -125,8 +128,10 @@ static const struct report_type_t webdav_reports[] = {
 
     { NULL, 0, NULL, NULL, 0, 0 }
 };
+// clang-format on
 
 /* Array of known "live" properties */
+// clang-format off
 static const struct prop_entry webdav_props[] = {
 
     /* WebDAV (RFC 4918) properties */
@@ -225,7 +230,9 @@ static const struct prop_entry webdav_props[] = {
 
     { NULL, 0, 0, NULL, NULL, NULL }
 };
+// clang-format on
 
+// clang-format off
 struct meth_params webdav_params = {
     webdav_mime_types,
     &webdav_parse_path,
@@ -254,9 +261,11 @@ struct meth_params webdav_params = {
     { DAV_FINITE_DEPTH, webdav_props},
     webdav_reports
 };
+// clang-format on
 
 
 /* Namespace for Webdav collections */
+// clang-format off
 struct namespace_t namespace_drive = {
     URL_NS_DRIVE, 0, "drive", "/dav/drive", NULL,
     http_allow_noauth_get, /*authschemes*/0,
@@ -290,6 +299,7 @@ struct namespace_t namespace_drive = {
         { &meth_unlock,         &webdav_params }       /* UNLOCK       */
     }
 };
+// clang-format on
 
 static void my_webdav_init(struct buf *serverinfo __attribute__((unused)))
 {

--- a/imap/jmap_admin.c
+++ b/imap/jmap_admin.c
@@ -68,6 +68,7 @@
 static int jmap_admin_rewrite_calevent_privacy(jmap_req_t *req);
 static int jmap_admin_migrate_defaultalarms(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_admin_methods_nonstandard[] = {
     {
         "Admin/rewriteCalendarEventPrivacy",
@@ -83,6 +84,7 @@ static jmap_method_t jmap_admin_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_admin_init(jmap_settings_t *settings)
 {

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -77,14 +77,17 @@ static int jmap_backup_restore_mail(jmap_req_t *req);
 
 static char *_prodid = NULL;
 
+// clang-format off
 static jmap_method_t jmap_backup_methods_standard[] = {
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 /* NOTE: we don't set flags to require CSTATE, because that holds
  * a user lock (exclusive if READ_WRITE is requested) for the entire
  * time the method is running.  Backup restores can be quite slow,
  * and we release locks in batches so that the user can keep working */
+// clang-format off
 static jmap_method_t jmap_backup_methods_nonstandard[] = {
     {
         "Backup/restoreContacts",
@@ -112,6 +115,7 @@ static jmap_method_t jmap_backup_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_backup_init(jmap_settings_t *settings)
 {

--- a/imap/jmap_blob.c
+++ b/imap/jmap_blob.c
@@ -64,6 +64,7 @@ static int jmap_blob_get(jmap_req_t *req);
 static int jmap_blob_lookup(jmap_req_t *req);
 static int jmap_blob_upload(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_blob_methods_standard[] = {
     /* RFC 8620 */
     {
@@ -93,7 +94,9 @@ static jmap_method_t jmap_blob_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_core_methods_nonstandard[] = {
     {
         "Blob/get",
@@ -115,6 +118,7 @@ static jmap_method_t jmap_core_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 static json_t *blob_capabilities = NULL;
 
@@ -379,6 +383,7 @@ static int getblob_cb(const conv_guidrec_t* rec, void* vrock)
     return 0;
 }
 
+// clang-format off
 static const jmap_property_t blob_xprops[] = {
     {
         "data",
@@ -419,6 +424,7 @@ static const jmap_property_t blob_xprops[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 struct blob_range {
     size_t offset;
@@ -943,6 +949,7 @@ done:
     return 0;
 }
 
+// clang-format off
 static const jmap_property_t blob_upload_props[] = {
     {
         "id",
@@ -962,6 +969,7 @@ static const jmap_property_t blob_upload_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int _set_arg_to_buf(struct jmap_req *req, struct buf *buf, json_t *arg, int recurse, json_t **errp)
 {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -129,6 +129,7 @@ static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *c
 
 #define JMAPCACHE_CALVERSION 26
 
+// clang-format off
 static jmap_method_t jmap_calendar_methods_standard[] = {
     {
         "Calendar/get",
@@ -318,10 +319,13 @@ static jmap_method_t jmap_calendar_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 jmap_method_t jmap_calendar_methods_nonstandard[] = {
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_calendar_init(jmap_settings_t *settings)
 {
@@ -854,6 +858,7 @@ done:
     return r;
 }
 
+// clang-format off
 static const jmap_property_t calendar_props[] = {
     {
         "id",
@@ -965,6 +970,7 @@ static const jmap_property_t calendar_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int has_calendars_cb(const mbentry_t *mbentry, void *rock)
 {
@@ -3640,6 +3646,7 @@ done:
     return r;
 }
 
+// clang-format off
 static const jmap_property_t event_props[] = {
     {
         "id",
@@ -3911,6 +3918,7 @@ static const jmap_property_t event_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static void cachecalendarevents_cb(uint64_t rowid, void *payload, void *vrock)
 {
@@ -8274,6 +8282,7 @@ done:
     return 0;
 }
 
+// clang-format off
 static const jmap_property_t calendarprincipal_props[] = {
     {
         "id",
@@ -8327,6 +8336,7 @@ static const jmap_property_t calendarprincipal_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 typedef int(*principal_foreach_fn)
     (jmap_req_t* req, const char* accountid, int rights, void* rock);
@@ -10346,7 +10356,7 @@ done:
     mailbox_close(&notifmbox);
 }
 
-
+// clang-format off
 static const jmap_property_t sharenotification_props[] = {
     {
         "id",
@@ -10390,6 +10400,7 @@ static const jmap_property_t sharenotification_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static json_t *sharenotif_tojmap(jmap_req_t *req, message_t *msg, hash_table *props,
                                  void *rock __attribute__((unused)))
@@ -10963,6 +10974,7 @@ done:
     return 0;
 }
 
+// clang-format off
 static const jmap_property_t calendareventnotification_props[] = {
     {
         "id",
@@ -11011,6 +11023,7 @@ static const jmap_property_t calendareventnotification_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 struct eventnotif_tojmap_rock {
     int check_acl;
@@ -11520,6 +11533,7 @@ done:
     return 0;
 }
 
+// clang-format off
 static const jmap_property_t participantidentity_props[] = {
     {
         "id",
@@ -11538,6 +11552,7 @@ static const jmap_property_t participantidentity_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static void encode_participantidentity_id(struct buf *buf, const char *addr)
 {
@@ -11815,6 +11830,7 @@ HIDDEN json_t *jmap_calendar_events_from_msg(jmap_req_t *req,
     return jsevents_by_partid;
 }
 
+// clang-format off
 static const jmap_property_t calendarpreferences_props[] = {
     {
         "id",
@@ -11833,6 +11849,7 @@ static const jmap_property_t calendarpreferences_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_calendarpreferences_get(struct jmap_req *req)
 {

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -126,6 +126,7 @@ static int jmap_contact_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx);
 
 #define JMAPCACHE_CARDVERSION 1
 
+// clang-format off
 static jmap_method_t jmap_contact_methods_standard[] = {
 #ifdef HAVE_LIBICALVCARD
     {
@@ -191,7 +192,9 @@ static jmap_method_t jmap_contact_methods_standard[] = {
 #endif /* HAVE_LIBICALVCARD */
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_contact_methods_nonstandard[] = {
     {
         "ContactGroup/get",
@@ -249,6 +252,7 @@ static jmap_method_t jmap_contact_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 static char *_prodid = NULL;
 
@@ -529,6 +533,7 @@ static int getgroups_cb(void *rock, struct carddav_data *cdata)
     return r;
 }
 
+// clang-format off
 static const jmap_property_t contact_props[] = {
     {
         "id",
@@ -665,7 +670,9 @@ static const jmap_property_t contact_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
+// clang-format off
 static const jmap_property_t group_props[] = {
     {
         "id",
@@ -707,6 +714,7 @@ static const jmap_property_t group_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static void cachecards_cb(uint64_t rowid, void *payload, void *vrock)
 {
@@ -4999,6 +5007,7 @@ static int getaddressbooks_cb(const mbentry_t *mbentry, void *vrock)
     return r;
 }
 
+// clang-format off
 static const jmap_property_t addressbook_props[] = {
     {
         "id",
@@ -5035,6 +5044,7 @@ static const jmap_property_t addressbook_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_addressbook_get(struct jmap_req *req)
 {
@@ -5796,6 +5806,7 @@ done:
  * JMAP ContactCard API
  ****************************************************************************/
 
+// clang-format off
 static const jmap_property_t card_props[] = {
     {
         "id",
@@ -6009,6 +6020,7 @@ static const jmap_property_t card_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 
 /*
@@ -6027,6 +6039,7 @@ struct comp_kind {
 #define FIELD_SKIP (1<<2)  /* Skip this field if extended field exists     */
 
 /* JSContact Name components - ordered per vcard_n_field */
+// clang-format off
 static const struct comp_kind n_comp_kinds[] = {
     { VCARD_N_FAMILY,          "surname",       FIELD_EXT,  VCARD_N_SECONDARY  },
     { VCARD_N_GIVEN,           "given",         0,          0                  },
@@ -6038,8 +6051,10 @@ static const struct comp_kind n_comp_kinds[] = {
     { VCARD_N_GENERATION,      "generation",    FIELD_BWD,  VCARD_N_SUFFIX     },
     { 0,                       NULL,            0,          0                  }
 };
+// clang-format on
 
 /* JSContact Address components - ordered per vcard_adr_field */
+// clang-format off
 static const struct comp_kind adr_comp_kinds[] = {
     { VCARD_ADR_PO_BOX,        "postOfficeBox", 0,          0                  },
     { VCARD_ADR_EXTENDED,      "apartment",     FIELD_SKIP, VCARD_ADR_ROOM     },
@@ -6062,6 +6077,7 @@ static const struct comp_kind adr_comp_kinds[] = {
     { VCARD_ADR_DIRECTION,     "direction",     FIELD_BWD,  VCARD_ADR_STREET   },
     { 0,                       NULL,            0,          0                  }
 };
+// clang-format on
 
 #define ALLOW_CALSCALE_PARAM      (1<<0)
 #define ALLOW_INDEX_PARAM         (1<<1)
@@ -8928,6 +8944,7 @@ struct param_prop_t {
     vcardparameter_kind kind;
 };
 
+// clang-format off
 struct param_prop_t phone_param_props[] = {
     { "features", VCARD_TYPE_PARAMETER  },
     { "label",    VCARD_X_PARAMETER     },
@@ -8935,11 +8952,13 @@ struct param_prop_t phone_param_props[] = {
     { "contexts", VCARD_TYPE_PARAMETER  },
     { NULL,       0                     }
 };
+// clang-format on
 
 #define comm_param_props    (phone_param_props+1)  // label, context & pref
 #define pref_param_props    (phone_param_props+2)  // context & pref
 #define context_param_props (phone_param_props+3)  // context
 
+// clang-format off
 struct param_prop_t directories_param_props[] = {
     { "listAs",    VCARD_INDEX_PARAMETER     },
     { "mediaType", VCARD_MEDIATYPE_PARAMETER },
@@ -8948,6 +8967,7 @@ struct param_prop_t directories_param_props[] = {
     { "contexts",  VCARD_TYPE_PARAMETER      },
     { NULL,       0                          }
 };
+// clang-format on
 
 #define resource_param_props (directories_param_props+1)  // no listAs
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -62,6 +62,7 @@ static int jmap_core_echo(jmap_req_t *req);
 /* JMAP extension methods */
 static int jmap_usercounters_get(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_core_methods_standard[] = {
     {
         "Core/echo",
@@ -71,7 +72,9 @@ static jmap_method_t jmap_core_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_core_methods_nonstandard[] = {
     {
         "UserCounters/get",
@@ -81,6 +84,7 @@ static jmap_method_t jmap_core_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_core_init(jmap_settings_t *settings)
 {
@@ -201,6 +205,7 @@ static int jmap_core_echo(jmap_req_t *req)
 }
 
 /* UserCounters/get method */
+// clang-format off
 static const jmap_property_t usercounters_props[] = {
     {
         "id",
@@ -350,6 +355,7 @@ static const jmap_property_t usercounters_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static void usercounters_get(jmap_req_t *req, struct jmap_get *get)
 {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -123,6 +123,7 @@ static int jmap_emailheader_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx
  * - Identity/set
  */
 
+// clang-format off
 static jmap_method_t jmap_mail_methods_standard[] = {
     {
         "Email/query",
@@ -192,7 +193,9 @@ static jmap_method_t jmap_mail_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_mail_methods_nonstandard[] = {
     {
         "Email/matchMime",
@@ -202,6 +205,7 @@ static jmap_method_t jmap_mail_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 /* NULL terminated list of supported jmap_email_query sort fields */
 struct email_sortfield {
@@ -209,6 +213,7 @@ struct email_sortfield {
     const char *capability;
 };
 
+// clang-format off
 static struct email_sortfield email_sortfields[] = {
     {
         "receivedAt",
@@ -271,6 +276,7 @@ static struct email_sortfield email_sortfields[] = {
         NULL
     }
 };
+// clang-format on
 
 #define jmap_openmbox_by_guidrec(req, rec, mbox, rw)           \
     ((rec->version > CONV_GUIDREC_BYNAME_VERSION) ?            \
@@ -6375,6 +6381,7 @@ static int _thread_get(jmap_req_t *req, json_t *ids,
     return r;
 }
 
+// clang-format off
 static const jmap_property_t thread_props[] = {
     {
         "id",
@@ -6388,6 +6395,7 @@ static const jmap_property_t thread_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_thread_get(jmap_req_t *req)
 {
@@ -7170,6 +7178,7 @@ static json_t * _email_get_header(struct cyrusmsg *msg,
     return conv(json_string_value(jheaderval));
 }
 
+// clang-format off
 static const struct blob_header_t {
     const char *name;
     const char *type;
@@ -7177,6 +7186,7 @@ static const struct blob_header_t {
     { "bimi-indicator", "image/svg+xml" },
     { NULL, NULL }
 };
+// clang-format on
 
 static const char *_encode_emailheader_blobid(const char *emailid,
                                               const char *hdr,
@@ -8420,6 +8430,7 @@ static void jmap_email_get_full(jmap_req_t *req, struct jmap_get *get, struct em
     ptrarray_fini(&rock.mboxes);
 }
 
+// clang-format off
 static const jmap_property_t email_props[] = {
     {
         "id",
@@ -8620,6 +8631,7 @@ static const jmap_property_t email_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_email_get(jmap_req_t *req)
 {

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -81,6 +81,7 @@ static int jmap_emailsubmission_query(jmap_req_t *req);
 static int jmap_emailsubmission_querychanges(jmap_req_t *req);
 static int jmap_identity_get(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_emailsubmission_methods_standard[] = {
     {
         "EmailSubmission/get",
@@ -120,10 +121,13 @@ static jmap_method_t jmap_emailsubmission_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_emailsubmission_methods_nonstandard[] = {
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_emailsubmission_init(jmap_settings_t *settings)
 {
@@ -1230,6 +1234,7 @@ static int getsubmission(jmap_req_t *req, struct jmap_get *get,
     return r;
 }
 
+// clang-format off
 static const jmap_property_t submission_props[] = {
     {
         "id",
@@ -1295,6 +1300,7 @@ static const jmap_property_t submission_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_emailsubmission_get(jmap_req_t *req)
 {
@@ -2281,6 +2287,7 @@ done:
 }
 
 /* Identity/get method */
+// clang-format off
 static const jmap_property_t identity_props[] = {
     {
         "id",
@@ -2397,6 +2404,7 @@ static const jmap_property_t identity_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_identity_get(jmap_req_t *req)
 {

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -101,6 +101,7 @@ static struct rolesort_data ROLESORT[] = {
     { NULL, 10 }  // default
 };
 
+// clang-format off
 static jmap_method_t jmap_mailbox_methods_standard[] = {
     {
         "Mailbox/get",
@@ -134,10 +135,13 @@ static jmap_method_t jmap_mailbox_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_mailbox_methods_nonstandard[] = {
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_mailbox_init(jmap_settings_t *settings)
 {
@@ -764,6 +768,7 @@ static void jmap_mailbox_get_notfound(const char *id, void *data __attribute__((
     json_array_append_new((json_t*) rock, json_string(id));
 }
 
+// clang-format off
 static const jmap_property_t mailbox_props[] = {
     {
         "id",
@@ -899,6 +904,7 @@ static const jmap_property_t mailbox_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_mailbox_get(jmap_req_t *req)
 {

--- a/imap/jmap_mdn.c
+++ b/imap/jmap_mdn.c
@@ -67,6 +67,7 @@
 static int jmap_mdn_send(jmap_req_t *req);
 static int jmap_mdn_parse(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_mdn_methods_standard[] = {
     {
         "MDN/send",
@@ -82,10 +83,13 @@ static jmap_method_t jmap_mdn_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_mdn_methods_nonstandard[] = {
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_mdn_init(jmap_settings_t *settings)
 {

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -75,10 +75,13 @@ static int jmap_note_get(jmap_req_t *req);
 static int jmap_note_set(jmap_req_t *req);
 static int jmap_note_changes(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_notes_methods_standard[] = {
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_notes_methods_nonstandard[] = {
     {
         "Note/get",
@@ -100,6 +103,7 @@ static jmap_method_t jmap_notes_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_notes_init(jmap_settings_t *settings)
 {
@@ -405,6 +409,7 @@ static void not_found_cb(const char *id,
     }
 }
 
+// clang-format off
 static const jmap_property_t notes_props[] = {
     {
         "id",
@@ -438,6 +443,7 @@ static const jmap_property_t notes_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_note_get(jmap_req_t *req)
 {

--- a/imap/jmap_quota.c
+++ b/imap/jmap_quota.c
@@ -61,6 +61,7 @@ static int jmap_quota_get(jmap_req_t *req);
 static int jmap_quota_changes(jmap_req_t *req);
 static int jmap_quota_query(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_quota_methods_standard[] = {
     {
         "Quota/get",
@@ -82,7 +83,9 @@ static jmap_method_t jmap_quota_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_quota_methods_nonstandard[] = {
     {
         "Quota/get",
@@ -92,6 +95,7 @@ static jmap_method_t jmap_quota_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_quota_init(jmap_settings_t *settings)
 {
@@ -119,6 +123,7 @@ HIDDEN void jmap_quota_capabilities(json_t *account_capabilities)
 }
 
 /* Legacy Quota/get method */
+// clang-format off
 static const jmap_property_t legacy_quota_props[] = {
     {
         "id",
@@ -137,6 +142,7 @@ static const jmap_property_t legacy_quota_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int jmap_legacy_quota_get(jmap_req_t *req)
 {
@@ -400,6 +406,7 @@ static int fetch_quotas_cb(struct quota *q, void *rock)
 }
 
 /* Quota/get method */
+// clang-format off
 static const jmap_property_t quota_props[] = {
     {
         "id",
@@ -453,6 +460,7 @@ static const jmap_property_t quota_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static void fetch_quotas(struct qrock_t *qrock)
 {

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -88,6 +88,7 @@ static int jmap_sieve_test(jmap_req_t *req);
 static int maxscripts = 0;
 static json_int_t maxscriptsize = 0;
 
+// clang-format off
 static jmap_method_t jmap_sieve_methods_standard[] = {
     {
         "SieveScript/get",
@@ -115,7 +116,9 @@ static jmap_method_t jmap_sieve_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_sieve_methods_nonstandard[] = {
     {
         "SieveScript/get",
@@ -149,6 +152,7 @@ static jmap_method_t jmap_sieve_methods_nonstandard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 HIDDEN void jmap_sieve_init(jmap_settings_t *settings)
 {
@@ -233,6 +237,7 @@ HIDDEN void jmap_sieve_capabilities(json_t *account_capabilities)
     }
 }
 
+// clang-format off
 static const jmap_property_t sieve_props[] = {
     {
         "id",
@@ -256,6 +261,7 @@ static const jmap_property_t sieve_props[] = {
     },
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 static int getscript(void *rock, struct sieve_data *sdata)
 {

--- a/imap/jmap_vacation.c
+++ b/imap/jmap_vacation.c
@@ -73,6 +73,7 @@
 static int jmap_vacation_get(jmap_req_t *req);
 static int jmap_vacation_set(jmap_req_t *req);
 
+// clang-format off
 static jmap_method_t jmap_vacation_methods_standard[] = {
     {
         "VacationResponse/get",
@@ -88,10 +89,13 @@ static jmap_method_t jmap_vacation_methods_standard[] = {
     },
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
+// clang-format off
 static jmap_method_t jmap_vacation_methods_nonstandard[] = {
     { NULL, NULL, NULL, 0}
 };
+// clang-format on
 
 static int sieve_vacation_enabled = 0;
 
@@ -142,6 +146,7 @@ HIDDEN void jmap_vacation_capabilities(json_t *account_capabilities)
 }
 
 /* VacationResponse/get method */
+// clang-format off
 static const jmap_property_t vacation_props[] = {
     {
         "id",
@@ -181,6 +186,7 @@ static const jmap_property_t vacation_props[] = {
 
     { NULL, NULL, 0 }
 };
+// clang-format on
 
 #define STATUS_ACTIVE    (1<<0)
 #define STATUS_CUSTOM    (1<<1)


### PR DESCRIPTION
https://github.com/cyrusimap/cyrus-imapd/pull/5332 aims to add clang-format formatting rules for the Cyrus codebase. The JMAP and DAV code in Cyrus uses static struct literals to initialize a couple of common data structures. We want to keep these consistently formatted for every entry, but clang-format seems not be able to apply consistent struct literal formatting across nested struct lists.

This patch disables clang-formatting for the code areas that area known to produce inconsistent struct literal formats in the JMAP and DAV code.