### PR TITLE
Fsync mkdir

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -1605,7 +1605,7 @@ EXPORTED int append_copy(struct mailbox *mailbox, struct appendstate *as,
             src_internal_flags & FLAG_INTERNAL_ARCHIVED) {
             struct index_record record;
             r = msgrecord_get_index_record(dst_msgrec, &record);
-            if (!r) r = objectstore_put(as->mailbox, &record, destfname);   // put should just add the refcount.
+            if (!r) r = objectstore_put(as->mailbox, &record, srcfname);   // put should just add the refcount.
         }
 #endif
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6634,6 +6634,7 @@ EXPORTED int mailbox_copy_files(struct mailbox *mailbox, const char *newpart,
     int *fdptr;
     while ((msg = mailbox_iter_step(iter))) {
         const struct index_record *record = msg_record(msg);
+        xstrncpy(oldbuf, mailbox_record_fname(mailbox, record), MAX_MAILBOX_PATH);
 
 #if defined ENABLE_OBJECTSTORE
         if (object_storage_enabled && (record->internal_flags & FLAG_INTERNAL_ARCHIVED)) {
@@ -6641,13 +6642,12 @@ EXPORTED int mailbox_copy_files(struct mailbox *mailbox, const char *newpart,
             memset(&new_mailbox, 0, sizeof(struct mailbox));
             new_mailbox.name = (char*) newname;
             new_mailbox.part = (char*) config_defpartition ;
-            r = objectstore_put(&new_mailbox, record, newbuf);   // put should just add to refcount.
+            r = objectstore_put(&new_mailbox, record, oldbuf);   // put should just add to refcount.
             if (r) break;
             continue;
         }
 #endif
 
-        xstrncpy(oldbuf, mailbox_record_fname(mailbox, record), MAX_MAILBOX_PATH);
         if (record->internal_flags & FLAG_INTERNAL_ARCHIVED) {
             xstrncpy(newbuf, mboxname_archivepath(newpart, newname, newuniqueid, record->uid),
                     MAX_MAILBOX_PATH);

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -683,7 +683,6 @@ extern int mailbox_rename_copy(struct mailbox *oldmailbox,
 extern int mailbox_rename_cleanup(struct mailbox **mailboxptr);
 
 extern int mailbox_copyfile_fdptr(const char *from, const char *to, int nolink, int *dirfdp);
-#define mailbox_copyfile(from, to, nolink) mailbox_copyfile_fdptr(from, to, nolink, NULL)
 
 extern int mailbox_reconstruct(const char *name, int flags, struct mailbox **mailboxp);
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -57,7 +57,6 @@
 #include <sys/wait.h>
 #include <errno.h>
 #include <dirent.h>
-#include <utime.h>
 #include <limits.h>
 
 #include "assert.h"

--- a/imap/unexpunge.c
+++ b/imap/unexpunge.c
@@ -232,7 +232,9 @@ static int restore_expunged(struct mailbox *mailbox, int mode, unsigned long *ui
 
         /* copy the message file */
         fname = mailbox_record_fname(mailbox, &newrecord);
-        r = mailbox_copyfile(oldfname, fname, 0);
+        int *fdptr = (newrecord.internal_flags & FLAG_INTERNAL_ARCHIVED)
+                   ? &mailbox->archive_dirfd : &mailbox->spool_dirfd;
+        r = mailbox_copyfile_fdptr(oldfname, fname, 0, fdptr);
         if (r) break;
 
         /* add the flag if requested */

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1937,7 +1937,8 @@ static int opendb(const char *fname, struct twom_open_data *setup, struct twom_d
 #endif
             free(copy);
             if (dirfd < 0) {
-                r = TWOM_NOTFOUND;
+                if (errno == ENOENT) r = TWOM_NOTFOUND;
+                else r = TWOM_IOERROR;
                 goto done;
             }
             copy = strdup(fname);

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1928,12 +1928,35 @@ static int opendb(const char *fname, struct twom_open_data *setup, struct twom_d
     db->openfile->fd = fd;
     if (fd < 0) {
         if (setup->flags & TWOM_CREATE) {
-            fd = open(db->fname, O_RDWR|O_CREAT, 0644);
+            char *copy = strdup(fname);
+            const char *dir = dirname(copy);
+#if defined(O_DIRECTORY)
+            int dirfd = open(dir, O_RDONLY|O_DIRECTORY, 0600);
+#else
+            int dirfd = open(dir, O_RDONLY, 0600);
+#endif
+            free(copy);
+            if (dirfd < 0) {
+                r = TWOM_NOTFOUND;
+                goto done;
+            }
+            copy = strdup(fname);
+            const char *leaf = basename(copy);
+            fd = openat(dirfd, leaf, O_RDWR|O_CREAT, 0644);
+            free(copy);
             db->openfile->fd = fd;
             if (fd < 0) {
                 if (errno == ENOENT) r = TWOM_NOTFOUND;
+                else r = TWOM_IOERROR;
+                close(dirfd);
                 goto done;
             }
+            if (fsync(dirfd) < 0) {
+                r = TWOM_IOERROR;
+                close(dirfd);
+                goto done;
+            }
+            close(dirfd);
             r = initdb(db, setup->flags);
             if (r) goto done;
         }

--- a/lib/util.c
+++ b/lib/util.c
@@ -529,7 +529,7 @@ EXPORTED void xclosedir(int dirfd)
     errno = saved_errno;
 }
 
-static int xunlink_helper(const char *path, int *dirfdp)
+EXPORTED int cyrus_unlink_fdptr(const char *path, int *dirfdp)
 {
     int local_dirfd = -1;
     if (!dirfdp) dirfdp = &local_dirfd;
@@ -730,7 +730,7 @@ EXPORTED int cyrus_copyfile_fdptr(const char *from, const char *to,
 
     if (!r && (flags & COPYFILE_RENAME)) {
         /* remove the original file if the copy succeeded */
-        xunlink_helper(from, from_dirfdp);
+        cyrus_unlink_fdptr(from, from_dirfdp);
     }
 
     return r;

--- a/lib/util.c
+++ b/lib/util.c
@@ -565,32 +565,9 @@ EXPORTED int cyrus_rename(const char *src, const char *dest)
  */
 EXPORTED int cyrus_mkdir(const char *pathname, mode_t mode __attribute__((unused)))
 {
-    char *path = xstrdupnull(pathname);    /* make a copy to write into */
-    char *p = path;
-    int save_errno;
-    struct stat sbuf;
-
-    if (!p || *p == '\0')
-        return -1;
-
-    while ((p = strchr(p+1, '/'))) {
-        *p = '\0';
-        if (mkdir(path, 0755) == -1 && errno != EEXIST) {
-            save_errno = errno;
-            if (stat(path, &sbuf) == -1) {
-                errno = save_errno;
-                xsyslog(LOG_ERR, "IOERROR: creating directory",
-                                 "path=<%s>", path);
-                free(path);
-                return -1;
-            }
-        }
-        if (errno == EEXIST)
-            errno = 0;
-        *p = '/';
-    }
-
-    free(path);
+    int fd = xopendir(pathname, /*create*/1);
+    if (fd < 0) return -1;
+    close(fd);
     return 0;
 }
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -537,7 +537,10 @@ EXPORTED int cyrus_unlink_fdptr(const char *path, int *dirfdp)
     if (*dirfdp < 0) *dirfdp = xopendir(path, /*create*/0);
     if (*dirfdp < 0) return *dirfdp;
 
-    int r = xunlinkat(*dirfdp, path, /*flags*/0);
+    char *copy = xstrdup(path);
+    const char *leaf = basename(copy);
+    int r = xunlinkat(*dirfdp, leaf, /*flags*/0);
+    free(copy);
 
     if (local_dirfd >= 0) xclosedir(local_dirfd);
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -529,6 +529,28 @@ EXPORTED void xclosedir(int dirfd)
     errno = saved_errno;
 }
 
+EXPORTED int cyrus_settime_fdptr(const char *path, struct timespec *when, int *dirfdp)
+{
+    int local_dirfd = -1;
+    if (!dirfdp) dirfdp = &local_dirfd;
+
+    if (*dirfdp < 0) *dirfdp = xopendir(path, /*create*/0);
+    if (*dirfdp < 0) return *dirfdp;
+
+    struct timespec ts[2];
+    ts[0] = *when;
+    ts[1] = *when;
+
+    char *copy = xstrdup(path);
+    const char *leaf = basename(copy);
+    int r = utimensat(*dirfdp, leaf, ts, 0);
+    free(copy);
+
+    if (local_dirfd >= 0) xclosedir(local_dirfd);
+
+    return r;
+}
+
 EXPORTED int cyrus_unlink_fdptr(const char *path, int *dirfdp)
 {
     int local_dirfd = -1;

--- a/lib/util.h
+++ b/lib/util.h
@@ -223,6 +223,7 @@ extern int removedir(const char *path);
 /* Call rename but fsync the directory before returning success */
 extern int xopendir(const char *dest, int create);
 extern int xrenameat(int dirfd, const char *src, const char *dest);
+extern int cyrus_settime_fdptr(const char *path, struct timespec *when, int *dirfdp);
 extern int cyrus_unlink_fdptr(const char *fname, int *dirfdp);
 extern void xclosedir(int dirfd);
 extern int cyrus_rename(const char *src, const char *dest);

--- a/lib/util.h
+++ b/lib/util.h
@@ -241,14 +241,12 @@ extern int cyrus_mkdir(const char *path, mode_t mode);
 enum {
     COPYFILE_NOLINK = (1<<0),
     COPYFILE_MKDIR  = (1<<1),
-    COPYFILE_RENAME = (1<<2),
-    COPYFILE_KEEPTIME = (1<<3),
-    COPYFILE_NODIRSYNC = (1<<4)
+    COPYFILE_KEEPTIME = (1<<2),
+    COPYFILE_NODIRSYNC = (1<<3)
 };
 
-extern int cyrus_copyfile_fdptr(const char *from, const char *to, int flags,
-                                int *from_dirfdp, int *to_dirfdp);
-#define cyrus_copyfile(from, to, flags) cyrus_copyfile_fdptr(from, to, flags, NULL, NULL)
+extern int cyrus_copyfile_fdptr(const char *from, const char *to, int flags, int *dirfdp);
+#define cyrus_copyfile(from, to, flags) cyrus_copyfile_fdptr(from, to, flags, NULL)
 
 enum {
     BEFORE_SETUID,

--- a/lib/util.h
+++ b/lib/util.h
@@ -223,6 +223,7 @@ extern int removedir(const char *path);
 /* Call rename but fsync the directory before returning success */
 extern int xopendir(const char *dest, int create);
 extern int xrenameat(int dirfd, const char *src, const char *dest);
+extern int cyrus_unlink_fdptr(const char *fname, int *dirfdp);
 extern void xclosedir(int dirfd);
 extern int cyrus_rename(const char *src, const char *dest);
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -221,7 +221,7 @@ extern char *create_tempdir(const char *path, const char *subname);
 extern int removedir(const char *path);
 
 /* Call rename but fsync the directory before returning success */
-extern int xopendir(const char *dest);
+extern int xopendir(const char *dest, int create);
 extern int xrenameat(int dirfd, const char *src, const char *dest);
 extern void xclosedir(int dirfd);
 extern int cyrus_rename(const char *src, const char *dest);


### PR DESCRIPTION
Change cyrus_mkdir to use fsync'd mkdir, and also directly fsync the directories being created when creating a new file for mappedfile.

I didn't go back and patch skiplist, but it gets twoskip via mappedfile, and twom and cyrus.index file creation are explicit