### PR TITLE
Cassandane: Report on all errors, even those in cleanup, and those that are weird

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1100,8 +1100,9 @@ sub tear_down
             xlog "errors found during instance shutdown";
         }
         else {
-            # maybe there's multiple errors, but we can only die once...
-            die $stop_errors[0];
+            # We can't die in here or it'll swallow exceptions from the test if
+            # there were any. Ugh.
+            $self->{stop_errors} = \@stop_errors;
         }
     }
 

--- a/cassandane/Cassandane/Unit/FormatPretty.pm
+++ b/cassandane/Cassandane/Unit/FormatPretty.pm
@@ -157,15 +157,23 @@ sub print_errors
     $self->_print($msg);
 
     my $i = 0;
+
+    my $annotations;
+
     for my $e (@{$result->errors()}) {
         my ($test, $errors) = split(/\n/, $e->to_string(), 2);
         chomp $errors;
         my $prettytest = _prettytest($test);
         $self->_print("\n") if $i++;
         $self->_print($self->ansi([31], "$i) $prettytest") . "\n$errors\n");
-        $self->_print("\nAnnotations:\n", $e->object->annotations())
-          if $e->object->annotations();
+
+        # These will always be the same since they share the same test object
+        # so we just need one of them...
+        $annotations ||= \$e->object->annotations();
     }
+
+    $self->_print("\nAnnotations:\n", $$annotations)
+        if $$annotations;
 
     if ($saved_output_stream) {
         $self->{fh} = $saved_output_stream;

--- a/cassandane/Cassandane/Unit/Formatter.pm
+++ b/cassandane/Cassandane/Unit/Formatter.pm
@@ -150,13 +150,21 @@ sub print_errors
     $self->_print($msg);
 
     my $i = 0;
+
+    my $annotations;
+
     for my $e (@{$result->errors()}) {
         chomp(my $e_to_str = $e);
         $i++;
-        $self->_print("$i) $e_to_str\n");
-        $self->_print("\nAnnotations:\n", $e->object->annotations())
-          if $e->object->annotations();
+        $self->_print("$i) $e_to_str\n\n");
+
+        # These will always be the same since they share the same test object
+        # so we just need one of them...
+        $annotations ||= \$e->object->annotations();
     }
+
+    $self->_print("\nAnnotations:\n", $$annotations)
+        if $$annotations;
 }
 
 sub print_failures

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -457,7 +457,8 @@ sub add_error
     # sorts of stuff we can't thaw.  We have enough information to
     # discover the right TestCase in the parent process.
     $exception->{'-object'} = undef;
-    $witem->{exception} = $exception;
+    $witem->{exceptions} //= [];
+    push @{$witem->{exceptions}}, $exception;
 }
 
 sub add_failure
@@ -984,8 +985,11 @@ sub _finish_workitem
     }
     elsif ($witem->{result} eq 'error')
     {
-        $witem->{exception}->{'-object'} = $test;
-        $result->add_error($test, $witem->{exception});
+        for my $exception (@{$witem->{exceptions}}) {
+            $exception->{'-object'} = $test;
+
+            $result->add_error($test, $exception);
+        }
     }
     $result->end_test($test);
 }

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -487,6 +487,7 @@ use File::Temp qw(tempfile);
 use File::Path qw(mkpath);
 use Data::Dumper;
 use Cassandane::Util::Log;
+use Scalar::Util qw(blessed);
 
 my @test_roots = (
     'Cassandane/Test',
@@ -935,6 +936,9 @@ sub _run_workitem
         my $ex = $@;
         if ($ex)
         {
+            unless ((blessed($ex) // '') eq 'Error::Simple') {
+                $ex = Error::Simple->new($ex);
+            }
             $result->add_error($test,
                                Test::Unit::Error->make_new_from_error($ex));
         }

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -944,6 +944,16 @@ sub _run_workitem
         }
     }
 
+    if ($test->{stop_errors}) {
+        for my $error (@{$test->{stop_errors}}) {
+            unless ((blessed($error) // '') eq 'Error::Simple') {
+                $error = Error::Simple->new($error);
+            }
+            $result->add_error($test,
+                               Test::Unit::Error->make_new_from_error($error));
+        }
+    }
+
     $self->_restore_stdout();
     if ($annotate_flag)
     {


### PR DESCRIPTION
With these fixes:

* `die([])` or `Some::Exception::Class->throw()` will be caught/reported properly
* If syslog errors or other problems are reported in tear_down, they won't overshadow higher up errors
