### PR TITLE
Remove unused #include syslog.h

### DIFF
--- a/imap/calsched_support.c
+++ b/imap/calsched_support.c
@@ -50,7 +50,6 @@
 #include "http_dav.h"
 #include "mailbox.h"
 #include "strarray.h"
-#include "syslog.h"
 #include "util.h"
 
 /* generated headers are not necessarily in current directory */

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -48,7 +48,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
-#include <syslog.h>
 #include <string.h>
 #include <sys/stat.h>
 

--- a/imap/cyrdump.c
+++ b/imap/cyrdump.c
@@ -49,7 +49,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
-#include <syslog.h>
 #include <string.h>
 
 /* cyrus includes */

--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -52,7 +52,6 @@
 #endif
 #include <ctype.h>
 #include <string.h>
-#include <syslog.h>
 #include <assert.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>

--- a/imap/jmap_admin.c
+++ b/imap/jmap_admin.c
@@ -48,7 +48,6 @@
 #endif
 #include <ctype.h>
 #include <string.h>
-#include <syslog.h>
 #include <assert.h>
 #include <errno.h>
 

--- a/imap/jmap_mail_query_parse.c
+++ b/imap/jmap_mail_query_parse.c
@@ -44,7 +44,6 @@
 #include <config.h>
 
 #include <string.h>
-#include <syslog.h>
 
 #include "jmap_api.h"
 #include "jmap_mail_query_parse.h"

--- a/imap/message_test.c
+++ b/imap/message_test.c
@@ -47,7 +47,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
-#include <syslog.h>
 #include <string.h>
 #include <sys/stat.h>
 

--- a/imap/search_test.c
+++ b/imap/search_test.c
@@ -47,7 +47,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sysexits.h>
-#include <syslog.h>
 #include <string.h>
 #include <sys/stat.h>
 

--- a/imap/squat_dump.c
+++ b/imap/squat_dump.c
@@ -59,7 +59,6 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <sysexits.h>
-#include <syslog.h>
 #include <string.h>
 
 #include "assert.h"

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -43,7 +43,6 @@
 #include <config.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h>
 
 #include "auth.h"
 #include "libcyr_cfg.h"


### PR DESCRIPTION
The criteria is that the files do not contain `LOG_` and `[^x]syslog`.