### PR TITLE
cassandane: use twoskip for conversations_db

### DIFF
--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -122,7 +122,7 @@ sub default
             # from cyr_info conf-default | grep _db:
             annotation_db => 'twoskip',
             backup_db => 'twoskip',
-            conversations_db => 'skiplist',
+            conversations_db => 'twoskip',
             duplicate_db => 'twoskip',
             mboxkey_db => 'twoskip',
             mboxlist_db => 'twoskip',


### PR DESCRIPTION
It was (accidentally?) changed from twoskip to skiplist by f75c3e8584f03ca1eb322ae36b5de5787c70cc52

Skiplist doesn't properly support shared access (bug?), so it's a poor choice for conversations_db.

I think we'll probably want to switch most of these defaults to twom soon, but I'll leave that for a separate PR.