### PR TITLE
cass: print finished time

### DIFF
--- a/cassandane/Cassandane/Unit/Formatter.pm
+++ b/cassandane/Cassandane/Unit/Formatter.pm
@@ -43,6 +43,7 @@ use warnings;
 
 use base 'Test::Unit::Listener';
 use Benchmark;
+use Date::Format;
 use IO::Handle;
 
 sub new
@@ -112,7 +113,10 @@ sub print_summary
     my ($self, $result, $start_time, $end_time) = @_;
 
     my $run_time = timediff($end_time, $start_time);
-    print "\n", "Time: ", timestr($run_time), "\n";
+
+    print "\n";
+    print "Time: ", timestr($run_time), "\n";
+    print "Finished: ", time2str("%T", $end_time->real()), "\n";
 
     $self->print_header($result);
     $self->print_errors($result);


### PR DESCRIPTION
Adds the finished time to the summary printed at the end of the run.  This will apply to all output formats that use the base class `finished()` and `print_summary()`, which at the moment is "pretty", "prettier", and "tap", but not "xml".

That is, the "Finished:" line has been added, like this:

```
Time:  3 wallclock secs ( 0.02 usr  0.01 sys +  1.44 cusr  1.18 csys =  2.65 CPU)
Finished: 11:25:14

OK (13 tests)
```

If I step away and then come back to finished Cassandane results, it's not always clear to me whether they are the results I wanted, or if I actually forgot to start it and I'm just seeing leftovers from the previous run.  Having the finish time in the output removes that ambiguity.

I could add the start time here too if anyone thinks it would be useful, but I don't want to clutter the output otherwise.