### PR TITLE
fatal sphinx-build warnings when release checks enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,12 @@ endif # HAVE_LDAP
 
 AM_LDFLAGS = $(COV_LDFLAGS) $(ICU_LIBS)
 
+if ENABLE_RELEASE_CHECKS
+    CFG2HDR_FORBID_UNRELEASED="--forbid-unreleased"
+else
+    CFG2HDR_FORBID_UNRELEASED=
+endif
+
 # have distcheck try to build with all optional components enabled, to aid
 # detection of missing files for these components
 AM_DISTCHECK_CONFIGURE_FLAGS = \
@@ -1587,12 +1593,6 @@ lib/chartable.c: lib/mkchartable.pl lib/charset/unifix.txt \
 	@echo "### Done building chartables."
 
 lib/imapopts.h: lib/imapopts.c
-
-if ENABLE_RELEASE_CHECKS
-    CFG2HDR_FORBID_UNRELEASED="--forbid-unreleased"
-else
-    CFG2HDR_FORBID_UNRELEASED=
-endif
 
 lib/imapopts.c: lib/imapoptions tools/config2header
 	$(AM_V_GEN)$(top_srcdir)/tools/config2header \

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,9 +69,11 @@ endif # HAVE_LDAP
 AM_LDFLAGS = $(COV_LDFLAGS) $(ICU_LIBS)
 
 if ENABLE_RELEASE_CHECKS
-    CFG2HDR_FORBID_UNRELEASED="--forbid-unreleased"
+    CFG2HDR_FORBID_UNRELEASED=--forbid-unreleased
+    SPHINX_FAIL_ON_WARNINGS=-W --keep-going
 else
     CFG2HDR_FORBID_UNRELEASED=
+    SPHINX_FAIL_ON_WARNINGS=
 endif
 
 # have distcheck try to build with all optional components enabled, to aid
@@ -1921,7 +1923,7 @@ clean-sphinx-cache:
 
 if HAVE_SPHINX_BUILD
 
-SPHINX_OPTS = -d $(SPHINX_CACHE) -n -q
+SPHINX_OPTS = -d $(SPHINX_CACHE) -n -q $(SPHINX_FAIL_ON_WARNINGS)
 
 ## detect when source directory is not build directory (i.e. VPATH
 ## build), and clone the docsrc tree into the build directory, so


### PR DESCRIPTION
This makes it so if you've configured with --enable-release-checks, then warnings from sphinx-build will be fatal errors that disrupt the build.

CI already complains about this stuff, so that we don't introduce documentation bugs during normal PRs. But release notes for new releases don't get run through CI until after they've already been pushed, so this gives a similar kind of protection for those.