### PR TITLE
Gate STARTTLS (and its variants) with allowstarttls option

### DIFF
--- a/cassandane/Cassandane/Cyrus/ALPN.pm
+++ b/cassandane/Cassandane/Cyrus/ALPN.pm
@@ -64,6 +64,7 @@ sub new
     my $config = Cassandane::Config->default()->clone();
     $config->set(tls_server_cert => '@basedir@/conf/certs/cert.pem',
                  tls_server_key => '@basedir@/conf/certs/key.pem',
+                 allowstarttls => 'on',
                  httpmodules => 'caldav');
 
     my $self = $class->SUPER::new({

--- a/cassandane/Cassandane/Cyrus/Alpaca.pm
+++ b/cassandane/Cassandane/Cyrus/Alpaca.pm
@@ -51,7 +51,11 @@ use Cassandane::Util::Socket;
 sub new
 {
     my $class = shift;
-    return $class->SUPER::new({}, @_);
+
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(allowstarttls => 'on');
+
+    return $class->SUPER::new({config => $config}, @_);
 }
 
 sub set_up

--- a/cassandane/Cassandane/Cyrus/StartTLS.pm
+++ b/cassandane/Cassandane/Cyrus/StartTLS.pm
@@ -1,0 +1,276 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2011-2024 FastMail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Cyrus::StartTLS;
+use strict;
+use warnings;
+use JSON::XS;
+use Convert::Base64;
+use Mail::JMAPTalk 0.13;
+use Cwd qw(abs_path);
+use Data::Dumper;
+
+use lib '.';
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+use Cassandane::Util::Socket;
+
+sub new
+{
+    my ($class, @args) = @_;
+
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(conversations => 'yes',
+                 httpmodules => 'jmap',
+                 http_allowplaintext => 'off',
+                 httpallowcompress => 'no');
+
+    my $self = $class->SUPER::new({
+        config => $config,
+        jmap => 1,
+        httpmurder => 1,
+        adminstore => 1,
+        services => [ 'imap', 'http' ]
+    }, @args);
+
+    $self->needs('component', 'jmap');
+    $self->needs('component', 'murder');
+    return $self;
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+    $self->SUPER::tear_down();
+}
+
+sub test_imap_disabled
+    :TLS :needs_dependency_openssl
+{
+    my ($self) = @_;
+
+    # get a pristine connection
+    $self->{store}->disconnect();
+    my $talk = $self->{store}->get_client(NoLogin => 1);
+
+    # STARTTLS should NOT be advertised
+    my $res = $talk->capability();
+    $self->assert_null($res->{starttls});
+
+    # STARTTLS should be unrecognized command
+    $talk->_imap_cmd('starttls', 0, 'starttls');
+    $self->assert_str_equals('bad', $talk->get_last_completion_response());
+}
+
+sub test_imap_enabled
+    :TLS :needs_dependency_openssl :NoStartInstances
+{
+    my ($self) = @_;
+
+    $self->config_set(allowstarttls => 'on');
+
+    $self->_start_instances();
+
+    # get a pristine connection
+    $self->{store}->disconnect();
+    my $talk = $self->{store}->get_client(NoLogin => 1);
+
+    # STARTTLS should be advertised
+    my $res = $talk->capability();
+    $self->assert_not_null($res->{starttls});
+
+    # STARTTLS should succeed
+    $talk->_imap_cmd('starttls', 0, 'starttls');
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+    my $ca_file = abs_path("data/certs/cacert.pem");
+    IO::Socket::SSL->start_SSL($talk->{Socket},
+                               SSL_ca_file => $ca_file,
+                               SSL_verifycn_scheme => 'none',
+    );
+    $self->assert_str_equals('IO::Socket::SSL', ref $talk->{Socket});
+}
+
+sub test_http_disabled
+    :TLS :needs_dependency_openssl
+{
+    my ($self) = @_;
+
+    my $ca_file = abs_path("data/certs/cacert.pem");
+    my $http = HTTP::Tiny->new(
+        max_redirect => 0,
+        SSL_options => {
+            SSL_ca_file => $ca_file,
+            SSL_verifycn_scheme => 'none'
+        }
+    );
+
+    # frontend should NOT offer TLS upgrade and should redirect to https://
+    my $frontend_svc = $self->{frontend}->get_service("http");
+    my $frontend_host = $frontend_svc->host();
+    my $frontend_port = $frontend_svc->port();
+
+    my $scheme = "http";
+    my $host = "$frontend_host:$frontend_port";
+    my $hier_part = "//$host/jmap/";
+    my $url = "$scheme:$hier_part";
+
+    my $req = {
+        method => 'GET',
+        uri => $url,
+        headers => {
+            'Host' => $host,
+            'Connection' => 'Upgrade',
+            'Upgrade' => 'TLS/1.2'
+        },
+        content => '',
+    };
+
+    my $res = $http->request('GET', $url);
+    $self->assert_str_equals('301', $res->{status});
+    $self->assert_matches(qr/https:$hier_part/, $res->{headers}->{location});
+
+    # backend should NOT offer TLS upgrade and should redirect to https://
+    my $backend_svc = $self->{instance}->get_service("http");
+    my $backend_host = $backend_svc->host();
+    my $backend_port = $backend_svc->port();
+
+    $host = "$backend_host:$backend_port";
+    $hier_part = "//$host/jmap/";
+    $url = "$scheme:$hier_part";
+
+    $req = {
+        method => 'GET',
+        uri => $url,
+        headers => {
+            'Host' => $host,
+            'Connection' => 'Upgrade',
+            'Upgrade' => 'TLS/1.2'
+        },
+        content => '',
+    };
+
+    $res = $http->request('GET', $url);
+    $self->assert_str_equals('301', $res->{status});
+    $self->assert_matches(qr/https:$hier_part/, $res->{headers}->{location});
+}
+
+sub test_http_enabled
+    :TLS :needs_dependency_openssl :NoStartInstances
+{
+    my ($self) = @_;
+
+    $self->config_set(allowstarttls => 'on');
+
+    $self->_start_instances();
+    $self->_setup_http_service_objects();
+
+    my $ca_file = abs_path("data/certs/cacert.pem");
+    my $http = HTTP::Tiny->new(
+        max_redirect => 0,
+        SSL_options => {
+            SSL_ca_file => $ca_file,
+            SSL_verifycn_scheme => 'none'
+        }
+    );
+
+    # frontend should NOT offer TLS upgrade and should redirect to https://
+    my $frontend_svc = $self->{frontend}->get_service("http");
+    my $frontend_host = $frontend_svc->host();
+    my $frontend_port = $frontend_svc->port();
+
+    my $scheme = "http";
+    my $host = "$frontend_host:$frontend_port";
+    my $hier_part = "//$host/jmap/";
+    my $url = "$scheme:$hier_part";
+
+    my $req = {
+        method => 'GET',
+        uri => $url,
+        headers => {
+            'Host' => $host,
+            'Connection' => 'Upgrade',
+            'Upgrade' => 'TLS/1.2'
+        },
+        content => '',
+    };
+
+    my $res = $http->request('GET', $url);
+    $self->assert_str_equals('301', $res->{status});
+    $self->assert_matches(qr/https:$hier_part/, $res->{headers}->{location});
+
+    # backend should offer TLS upgrade
+    my $backend_svc = $self->{instance}->get_service("http");
+    my $backend_host = $backend_svc->host();
+    my $backend_port = $backend_svc->port();
+
+    $host = "$backend_host:$backend_port";
+    $hier_part = "//$host/jmap/";
+    $url = "$scheme:$hier_part";
+
+    $req = {
+        method => 'GET',
+        uri => $url,
+        headers => {
+            'Host' => $host,
+            'Connection' => 'Upgrade',
+            'Upgrade' => 'TLS/1.2'
+        },
+        content => '',
+    };
+
+    $res = $http->request('GET', $url);
+    $self->assert_str_equals('426', $res->{status});
+
+    # TLS upgrade should succeed (and request authentication)
+    $http->{handle}->write_request($req);
+    $res = $http->{handle}->read_response_header;
+    $self->assert_str_equals('101', $res->{status});
+
+    $http->{handle}->start_ssl( $backend_host );
+    $res = $http->{handle}->read_response_header;
+    $self->assert_str_equals('401', $res->{status});
+}
+
+1;

--- a/changes/next/cyr-1846-allowstarttls
+++ b/changes/next/cyr-1846-allowstarttls
@@ -1,0 +1,23 @@
+
+Description:
+
+The industry is deprecating STARTTLS in favor of implicit TLS over a
+dedicated port.  This PR disables opportunistic TLS by default.
+
+
+Documentation:
+
+imapd.conf(5)
+
+
+Config changes:
+
+Added the 'allowstarttls' option, which when enabled, allows upgrading a
+plaintext connection to use TLS.
+
+
+Upgrade instructions:
+
+Installations that need to service clients that use opportunistic TLS
+should enable the 'allowstarttls' option, or a protocol specific 'allowstarttls'
+option, E.g. 'imap_allowstarttls'.

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -430,7 +430,7 @@ static struct http_connection http_conn;
 static sasl_ssf_t extprops_ssf = 0;
 int https = 0;
 static int httpd_tls_required = 0;
-static int httpd_tls_enabled = 0;
+static int httpd_starttls_enabled = 0;
 static unsigned avail_auth_schemes = 0; /* bitmask of available auth schemes */
 unsigned long config_httpmodules;
 
@@ -1307,7 +1307,7 @@ static int tls_init(int client_auth, struct buf *serverinfo)
         return HTTP_SERVER_ERROR;
     }
 
-    httpd_tls_enabled = 1;
+    httpd_starttls_enabled = config_getswitch(IMAPOPT_ALLOWSTARTTLS);
 
     return 0;
 }
@@ -1642,7 +1642,7 @@ static int preauth_check_hdrs(struct transaction_t *txn)
     else if (txn->flags.ver == VER_1_1 &&
              !(txn->conn->tls_ctx || (txn->flags.conn & CONN_CLOSE))) {
         /* Advertise available upgrade protocols */
-        if (httpd_tls_enabled &&
+        if (httpd_starttls_enabled &&
             config_mupdate_server && config_getstring(IMAPOPT_PROXYSERVERS)) {
             txn->flags.upgrade |= UPGRADE_TLS;
         }
@@ -2415,7 +2415,8 @@ static void parse_upgrade(struct transaction_t *txn)
         char *token;
 
         while ((token = tok_next(&tok))) {
-            if (!txn->conn->tls_ctx && httpd_tls_enabled &&
+            if (!txn->conn->tls_ctx && httpd_starttls_enabled &&
+                config_mupdate_server && config_getstring(IMAPOPT_PROXYSERVERS) &&
                 !strcasecmp(token, TLS_VERSION)) {
                 /* Upgrade to TLS */
                 txn->flags.conn |= CONN_UPGRADE;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -203,7 +203,7 @@ static int imapd_notify_enabled = 0;
 static int imapd_login_disabled = 0;
 static int imapd_compress_allowed = 0;
 static int imapd_utf8_allowed = 0;
-static int imapd_tls_allowed = 0;
+static int imapd_starttls_allowed = 0;
 static int imapd_starttls_done = 0; /* have we done a successful starttls? */
 static int imapd_tls_required = 0; /* is tls required? */
 static void *imapd_tls_comp = NULL; /* TLS compression method, if any */
@@ -470,7 +470,7 @@ static struct capa_struct base_capabilities[] = {
     { "SORT=DISPLAY",          CAPA_POSTAUTH,           { 0 } }, /* RFC 5957 */
     { "SPECIAL-USE",           CAPA_POSTAUTH,           { 0 } }, /* RFC 6154 */
     { "STARTTLS",              CAPA_PREAUTH|CAPA_STATE,          /* RFC 9051 */
-      { .statep = &imapd_tls_allowed }                        },
+      { .statep = &imapd_starttls_allowed }                        },
     { "STATUS=SIZE",           CAPA_POSTAUTH,           { 0 } }, /* RFC 8438 */
     { "THREAD=ORDEREDSUBJECT", CAPA_POSTAUTH,           { 0 } }, /* RFC 5256 */
     { "THREAD=REFERENCES",     CAPA_POSTAUTH,           { 0 } }, /* RFC 5256 */
@@ -1053,7 +1053,7 @@ static void imapd_reset(void)
     imapd_compress_done = 0;
     imapd_tls_comp = NULL;
     imapd_starttls_done = 0;
-    imapd_tls_allowed = tls_enabled();
+    imapd_starttls_allowed = tls_starttls_enabled();
 #ifdef HAVE_ZLIB
     imapd_compress_allowed = 1;
 #endif
@@ -1084,7 +1084,7 @@ int service_init(int argc, char **argv, char **envp)
     /* load the SASL plugins */
     global_sasl_init(1, 1, mysasl_cb);
 
-    imapd_tls_allowed = tls_enabled();
+    imapd_starttls_allowed = tls_starttls_enabled();
 #ifdef HAVE_ZLIB
     imapd_compress_allowed = 1;
 #endif
@@ -2305,7 +2305,7 @@ static void cmdloop(void)
 
         case 'S':
             if (!strcmp(cmd.s, "Starttls")) {
-                if (!tls_enabled()) {
+                if (!imapd_starttls_allowed) {
                     /* we don't support starttls */
                     goto badcmd;
                 }
@@ -9493,7 +9493,7 @@ static void cmd_starttls(char *tag, int imaps)
     prot_settls(imapd_out, tls_conn);
 
     imapd_starttls_done = 1;
-    imapd_login_disabled = imapd_tls_allowed = imapd_tls_required = 0;
+    imapd_login_disabled = imapd_starttls_allowed = imapd_tls_required = 0;
 
     imapd_tls_comp = (void *) SSL_get_current_compression(tls_conn);
     if (imapd_tls_comp) imapd_compress_allowed = 0;

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -1206,7 +1206,7 @@ void lmtpmode(struct lmtp_func *func,
                                 "250-SIZE %" PRIu64 "\r\n",
                           config_servername, max_msgsize);
 
-              if (tls_enabled() && !cd.starttls_done &&
+              if (tls_starttls_enabled() && !cd.starttls_done &&
                   cd.authenticated == NOAUTH) {
                   prot_printf(pout, "250-STARTTLS\r\n");
               }
@@ -1429,7 +1429,7 @@ void lmtpmode(struct lmtp_func *func,
       case 's':
       case 'S':
 #ifdef HAVE_SSL
-            if (!strcasecmp(buf, "starttls") && tls_enabled() &&
+            if (!strcasecmp(buf, "starttls") && tls_starttls_enabled() &&
                 !func->preauth) { /* don't need TLS for preauth'd connect */
 
                 /* XXX  discard any input pipelined after STARTTLS */

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -833,7 +833,7 @@ static mupdate_docmd_result_t docmd(struct conn *c)
         break;
 
     case 'S':
-        if (!strcmp(c->cmd.s, "Starttls")) {
+        if (!strcmp(c->cmd.s, "Starttls") && tls_starttls_enabled()) {
             CHECKNEWLINE(c, ch);
 
             /* XXX  discard any input pipelined after STARTTLS */
@@ -1038,7 +1038,7 @@ static void dobanner(struct conn *c)
     prot_printf(c->pout, "%s\r\n",
                 (ret == SASL_OK && mechcount > 0) ? mechs : "* AUTH");
 
-    if (tls_enabled() && !c->tlsconn) {
+    if (tls_starttls_enabled() && !c->tlsconn) {
         prot_printf(c->pout, "* STARTTLS\r\n");
     }
 

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -1336,7 +1336,8 @@ static void cmdloop(void)
             break;
 
         case 'S':
-            if (!strcmp(cmd.s, "Starttls") && tls_enabled()) {
+            if (!strcmp(cmd.s, "Starttls")) {
+                if (!tls_starttls_enabled()) goto badcmd;
                 if (c == '\r') c = prot_getc(nntp_in);
                 if (c != '\n') goto extraargs;
 
@@ -1770,7 +1771,7 @@ static void cmd_capabilities(char *keyword __attribute__((unused)))
     }
 
     /* add STARTTLS */
-    if (tls_enabled() && !nntp_starttls_done && !nntp_authstate)
+    if (tls_starttls_enabled() && !nntp_starttls_done && !nntp_authstate)
         prot_printf(nntp_out, "STARTTLS\r\n");
 
     if (!nntp_tls_required) {
@@ -2417,7 +2418,7 @@ static void cmd_help(void)
 
     prot_printf(nntp_out, "\tQUIT\r\n"
                 "\t\tTerminate the session.\r\n");
-    if (tls_enabled() && !nntp_starttls_done && !nntp_authstate) {
+    if (tls_starttls_enabled() && !nntp_starttls_done && !nntp_authstate) {
         prot_printf(nntp_out, "\tSTARTTLS\r\n"
                     "\t\tStart a TLS negotiation.\r\n");
     }

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -927,7 +927,7 @@ done:
             else if (!strcmp(inputbuf, "auth")) {
                 cmd_auth(arg);
             }
-            else if (!strcmp(inputbuf, "stls") && tls_enabled()) {
+            else if (!strcmp(inputbuf, "stls") && tls_starttls_enabled()) {
                 if (arg) {
                     prot_printf(popd_out, "-ERR Unexpected extra argument\r\n");
                 } else {
@@ -1458,7 +1458,7 @@ static void cmd_capa(void)
         prot_write(popd_out, mechlist, strlen(mechlist));
     }
 
-    if (tls_enabled() && !popd_starttls_done && !popd_authstate) {
+    if (tls_starttls_enabled() && !popd_starttls_done && !popd_authstate) {
         prot_printf(popd_out, "STLS\r\n");
     }
     if (expire < 0) {

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -291,7 +291,7 @@ static void dobanner(void)
             prot_printf(sync_out, "%s", mechlist);
         }
 
-        if (tls_enabled() && !sync_starttls_done) {
+        if (tls_starttls_enabled() && !sync_starttls_done) {
             prot_printf(sync_out, "* STARTTLS\r\n");
         }
 
@@ -655,7 +655,7 @@ static void cmdloop(void)
             break;
 
         case 'S':
-            if (!strcmp(cmd.s, "Starttls") && tls_enabled()) {
+            if (!strcmp(cmd.s, "Starttls") && tls_starttls_enabled()) {
                 if (c == '\r') c = prot_getc(sync_in);
                 if (c != '\n') goto extraargs;
 

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -1755,3 +1755,9 @@ EXPORTED int tls_enabled(void)
 }
 
 #endif /* HAVE_SSL */
+
+
+EXPORTED int tls_starttls_enabled(void)
+{
+    return config_getswitch(IMAPOPT_ALLOWSTARTTLS) && tls_enabled();
+}

--- a/imap/tls.h
+++ b/imap/tls.h
@@ -50,6 +50,9 @@
 /* is tls enabled? */
 int tls_enabled(void);
 
+/* is starttls enabled? */
+int tls_starttls_enabled(void);
+
 /* name of the SSL/TLS sessions database */
 #define FNAME_TLSSESSIONS "/tls_sessions.db"
 

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -197,6 +197,13 @@ are listed with ``<none>''.
   This was implemented to prevent clients renaming Sent to Trash/Sent, 
   which would confused other clients. */
 
+{ "allowstarttls", 0, SWITCH, "UNRELEASED" }
+/* If enabled, allows upgrading a plaintext connection to use TLS
+   (a.k.a opportunistic TLS) via a protocol specific
+   command/mechanism.  IMAP, LMTP, NNTP, and ManageSieve use the
+   STARTTLS command.  POP3 uses the STLS command.  HTTP uses the
+   Upgrade header field. */
+
 { "allowusermoves", 0, SWITCH, "2.3.17" }
 /* Allow moving user accounts (with associated meta-data) via RENAME
    or XFER.

--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -205,7 +205,7 @@ int capabilities(struct protstream *conn, sasl_conn_t *saslconn,
                     strarray_nth(extensions, i), strarray_nth(extensions, i+1));
     }
 
-    if (tls_enabled() && !starttls_done && !authenticated) {
+    if (tls_starttls_enabled() && !starttls_done && !authenticated) {
         prot_puts(conn, "\"STARTTLS\"\r\n");
     }
 

--- a/timsieved/lex.c
+++ b/timsieved/lex.c
@@ -101,7 +101,7 @@ static int token_lookup(const char *str)
 
     case 's':
         if (strcmp(str, "setactive")==0) return SETACTIVE;
-        if (strcmp(str, "starttls")==0 && tls_enabled())
+        if (strcmp(str, "starttls")==0 && tls_starttls_enabled())
             return STARTTLS;
         break;
 


### PR DESCRIPTION
This also only allows HTTP upgrade to TLS on backends in a Murder