### PR TITLE
Sync rename lock order

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -255,6 +255,9 @@ magic(ReverseACLs => sub {
 magic(RightNow => sub {
     shift->config_set(sync_rightnow_channel => '""');
 });
+magic(SyncCache => sub {
+    shift->config_set('sync_cache_db_path' => '@basedir@/sync_cache.db');
+});
 magic(SyncLog => sub {
     shift->config_set(sync_log => 1);
 });

--- a/cassandane/tiny-tests/Replication/rename_old_synccache
+++ b/cassandane/tiny-tests/Replication/rename_old_synccache
@@ -1,0 +1,82 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Test replication of mailbox only after a rename
+#
+sub test_rename_old_synccache
+    :NoAltNameSpace :AllowMoves :Replication :SyncLog :DelayedDelete :SyncCache
+{
+    my ($self) = @_;
+
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+    my $cachefname = "$self->{instance}->{basedir}/sync_cache.db";
+
+    xlog $self, "SYNC LOG FNAME $synclogfname";
+
+    my $master_store = $self->{master_store};
+    my $replica_store = $self->{replica_store};
+
+    my $mastertalk = $master_store->get_client();
+    my $replicatalk = $replica_store->get_client();
+
+    $mastertalk->create("INBOX.sub");
+    $master_store->set_folder("INBOX.sub");
+
+    xlog $self, "append some messages";
+    my %exp;
+    my $N = 1;
+    for (1..$N)
+    {
+        my $msg = $self->make_message("Message $_", store => $master_store);
+        $exp{$_} = $msg;
+    }
+    xlog $self, "check the messages got there";
+    $self->check_messages(\%exp, $master_store);
+
+    xlog $self, "run initial replication";
+    $self->run_replication();
+    #$self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+    $self->check_replication('cassandane');
+
+    rename($cachefname, "$cachefname.junk");
+
+    xlog $self, "rename user";
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->rename("user.cassandane", "user.dest");
+
+    $self->{instance}->getsyslog();
+    $self->{replica}->getsyslog();
+
+    $self->run_replication(user => 'dest');
+    $self->check_replication('dest');
+
+    xlog $self, "Rename again";
+    $admintalk = $self->{adminstore}->get_client();
+    $admintalk->rename("user.dest", "user.third");
+
+    # replication works again
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+    $self->check_replication('third');
+
+    # rename back sync-cache having missed the renames
+    rename("$cachefname.junk", $cachefname);
+
+    # copy messages to inbox to cause things to need to be synced
+    $admintalk = $self->{adminstore}->get_client();
+    $admintalk->select("user.third.sub");
+    $admintalk->copy('1:*', 'user.third');
+
+    # replication works again
+    # NOTE - first one will fail due to bogus records in sync_cache, but second should work
+    eval { $self->run_replication(rolling => 1, inputfile => $synclogfname) };
+    $self->{instance}->getsyslog(); # clear syslog
+
+    # second run will make everything good again
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+    $self->check_replication('third');
+
+}

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -6926,6 +6926,8 @@ static int do_folders(struct sync_client_state *sync_cs,
         // ok, it's a rename and both source and destination names exist already,
         // is there an intermediate we can rename to?
 
+        sync_uncache(sync_cs, item->oldname);
+
         mbentry_t *mbentry_byid = NULL;
         if (mboxlist_lookup_by_uniqueid(item->uniqueid, &mbentry_byid, NULL)) continue;
         int i;
@@ -6938,6 +6940,7 @@ static int do_folders(struct sync_client_state *sync_cs,
             // and then reuse this item for the rename from temporary to final
             free(item->oldname);
             item->oldname = xstrdup(histitem->name);
+            sync_uncache(sync_cs, item->oldname);
             break;
         }
         mboxlist_entry_free(&mbentry_byid);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -6897,8 +6897,10 @@ static int do_folders(struct sync_client_state *sync_cs,
             else {
                 /* we've found a rename! */
                 const char *part = topart ? topart : tombstone->partition;
-                sync_rename_list_add(rename_folders, tombstone->uniqueid, rfolder->name,
-                                     tombstone->name, part, tombstone->uidvalidity);
+                if (strcmp(tombstone->name, rfolder->name) || (rfolder->part && strcmpsafe(part, rfolder->part))) {
+                    sync_rename_list_add(rename_folders, tombstone->uniqueid, rfolder->name,
+                                         tombstone->name, part, tombstone->uidvalidity);
+                }
                 mboxlist_entry_free(&tombstone);
             }
         }


### PR DESCRIPTION
This fixes a couple issues seen in Fastmail production with renames

One issue is rename A -> C -> B; depending which user is the initiating userid in sync_do_user, it locks that one first; leading to lock inversion issues.

Also, the tombstone check can wind up adding same folder, same partition to the rename list, which the replica will reject!