### PR TITLE
cassandane: use master_pid_file from config so tests can override it

### DIFF
--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -103,6 +103,7 @@ sub default
             configdirectory => '@basedir@/conf',
             syslog_prefix => '@name@',
             sievedir => '@basedir@/conf/sieve',
+            master_pid_file => '@basedir@/run/master.pid',
             master_ready_file => '@basedir@/master.ready',
             defaultpartition => 'default',
             defaultdomain => 'defdomain',

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -1345,8 +1345,10 @@ sub test_ready_file
 {
     my ($self) = @_;
 
+    # config isn't fully initialised until start() is called, so we can't
+    # just read these the sensible way. instead, predict the defaults.
     my $ready_file = $self->{instance}->get_basedir() . '/master.ready';
-    my $pid_file = $self->{instance}->_pid_file();
+    my $pid_file = $self->{instance}->get_basedir() . '/run/master.pid';
 
     # pid file should not already exist
     my $pid_sb = stat($pid_file);

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -648,6 +648,11 @@ sub _pid_file
 
     $name ||= 'master';
 
+    if ($name eq 'master') {
+        my $pidfile = $self->{config}->get('master_pid_file');
+        return $self->{config}->substitute($pidfile) if $pidfile;
+    }
+
     return $self->{basedir} . "/run/$name.pid";
 }
 
@@ -976,7 +981,6 @@ sub _start_master
         # The following is added automatically by _fork_command:
         # '-C', $self->_imapd_conf(),
         '-l', '255',
-        '-p', $self->_pid_file(),
         '-d',
         '-M', $self->_master_conf(),
     );


### PR DESCRIPTION
The master pid file is configurable in imapd.conf, but Cassandane currently forces it to a hardcoded value via the '-p' argument.  This PR updates Cassandane to set and use the value from imapd.conf.  In practice, nothing really changes here, except that now tests will be able to override it if they need to.

I expect to make use of this soon, but I'd like to get it through CI and landed before that.