### PR TITLE
imapd.conf: Deprecate the 'tls_server_dhparam' option.

### DIFF
--- a/changes/next/deprecate-tls-server-dhparam
+++ b/changes/next/deprecate-tls-server-dhparam
@@ -1,0 +1,15 @@
+
+Description:
+
+Deprecate the 'tls_server_dhparam' option.
+This is no longer needed by OpenSSL >= 3.0.
+
+
+Config changes:
+
+The 'tls_server_dhparam' option is no longer used.
+
+
+Upgrade instructions:
+
+The 'tls_server_dhparam' can be removed from imapd.conf.

--- a/lib/imapoptions
+++ b/lib/imapoptions
@@ -3174,9 +3174,8 @@ product version in the capabilities
    Two certificates can be set, e.g RSA and EC, if the filenames are separated with
    comma without spaces. */
 
-{ "tls_server_dhparam", NULL, STRING, "3.1.4" }
-/* File containing the DH parameters belonging to the certificate in
-   tls_server_cert. Used by OpenSSL before version 3.0. */
+{ "tls_server_dhparam", NULL, STRING, "UNRELEASED", "UNRELEASED" }
+/* Deprecated. No longer used. */
 
 { "tls_server_key", NULL, STRING, "3.1.8" }
 /* File containing the private key belonging to the certificate in


### PR DESCRIPTION
This is no longer needed by OpenSSL >= 3.0.

As noted by Dilyan Palauzov