### PR TITLE
imapd.c: allow setting mailbox version with CREATE param

### DIFF
--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -2215,7 +2215,7 @@ static int set_up(void)
 
     /* XXX API abuse? perhaps this should just call mboxlist_create,
      * XXX rather than the low level APIs. */
-    r = mailbox_create(MBOXNAME1_INT, /*mbtype*/0, PARTITION, ACL,
+    r = mailbox_create(MBOXNAME1_INT, /*mbtype*/0, /*version*/0, PARTITION, ACL,
                        makeuuid(),
                        /*options*/0, /*uidvalidity*/0,
                        /*createdmodseq*/0,
@@ -2242,7 +2242,7 @@ static int set_up(void)
 
     namespacelock = mboxname_usernamespacelock(MBOXNAME2_INT);
 
-    r = mailbox_create(MBOXNAME2_INT, /*mbtype*/0, PARTITION, ACL,
+    r = mailbox_create(MBOXNAME2_INT, /*mbtype*/0, /*version*/0, PARTITION, ACL,
                        makeuuid(),
                        /*options*/0, /*uidvalidity*/0,
                        /*createdmodseq*/0,
@@ -2269,7 +2269,7 @@ static int set_up(void)
 
     namespacelock = mboxname_usernamespacelock(MBOXNAME3_INT);
 
-    r = mailbox_create(MBOXNAME3_INT, /*mbtype*/0, PARTITION, ACL,
+    r = mailbox_create(MBOXNAME3_INT, /*mbtype*/0, /*version*/0, PARTITION, ACL,
                        makeuuid(),
                        /*options*/0, /*uidvalidity*/0,
                        /*createdmodseq*/0,

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -231,10 +231,17 @@ extern void conversations_set_suffix(const char *suff);
 extern char *conversations_getmboxpath(const char *mboxname);
 extern char *conversations_getuserpath(const char *username);
 
-extern int conversations_open_path(const char *path, const char *userid, int shared,
-                                   struct conversations_state **statep);
-extern int conversations_open_user(const char *username, int shared,
-                                   struct conversations_state **statep);
+#define conversations_open_path(p, u, sh, sp) \
+    conversations_open_path_version(p, u, sh, sp, 0)
+extern int conversations_open_path_version(const char *path,
+                                           const char *userid, int shared,
+                                           struct conversations_state **statep,
+                                           int version);
+#define conversations_open_user(u, sh, sp) \
+    conversations_open_user_version(u, sh, sp, 0)
+extern int conversations_open_user_version(const char *username, int shared,
+                                           struct conversations_state **statep,
+                                           int version);
 extern int conversations_open_mbox(const char *mboxname, int shared,
                                    struct conversations_state **statep);
 extern struct conversations_state *conversations_get_path(const char *path);

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -663,7 +663,8 @@ extern void mailbox_archive(struct mailbox *mailbox, struct mailbox_iter *iter,
 extern void mailbox_remove_files_from_object_storage(struct mailbox *mailbox, unsigned flags);
 extern void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *sd);
 
-extern int mailbox_create(const char *name, uint32_t mbtype, const char *part, const char *acl,
+extern int mailbox_create(const char *name, uint32_t mbtype, int minor_version,
+                          const char *part, const char *acl,
                           const char *uniqueid, int options, unsigned uidvalidity,
                           modseq_t createdmodseq, modseq_t highestmodseq,
                           struct mailbox **mailboxptr);

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -907,7 +907,7 @@ EXPORTED int undump_mailbox(const char *mbname,
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         mbentry_t *mbentry = NULL;
         r = mboxlist_lookup(mbname, &mbentry, NULL);
-        if (!r) r = mailbox_create(mbname, mbentry->mbtype,
+        if (!r) r = mailbox_create(mbname, mbentry->mbtype, /*version*/0,
                                    mbentry->partition, mbentry->acl,
                                    mbentry->uniqueid, 0, 0, 0, 0, &mailbox);
         mboxlist_entry_free(&mbentry);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1857,7 +1857,7 @@ EXPORTED int mboxlist_promote_intermediary(const char *mboxname)
     xzfree(mbentry->acl);
     mbentry->acl = xstrdupnull(parent->acl);
 
-    r = mailbox_create(mboxname, mbentry->mbtype,
+    r = mailbox_create(mboxname, mbentry->mbtype, 0 /* version */,
                        mbentry->partition, mbentry->acl,
                        mbentry->uniqueid, 0 /* options */,
                        mbentry->uidvalidity,
@@ -1897,11 +1897,11 @@ done:
  *
  */
 
-EXPORTED int mboxlist_createmailbox(const mbentry_t *mbentry,
-                                    unsigned options, modseq_t highestmodseq,
-                                    unsigned isadmin, const char *userid,
-                                    const struct auth_state *auth_state,
-                                    unsigned flags, struct mailbox **mboxptr)
+EXPORTED int mboxlist_createmailbox_version(const mbentry_t *mbentry, int minor_version,
+                                            unsigned options, modseq_t highestmodseq,
+                                            unsigned isadmin, const char *userid,
+                                            const struct auth_state *auth_state,
+                                            unsigned flags, struct mailbox **mboxptr)
 {
     const char *mboxname = mbentry->name;
     char *uniqueid = xstrdupnull(mbentry->uniqueid);
@@ -1998,7 +1998,8 @@ EXPORTED int mboxlist_createmailbox(const mbentry_t *mbentry,
         }
 
         /* Filesystem Operations */
-        r = mailbox_create(mboxname, mbtype, newpartition, acl, newmbentry->uniqueid,
+        r = mailbox_create(mboxname, mbtype, minor_version,
+                           newpartition, acl, newmbentry->uniqueid,
                            options, uidvalidity, createdmodseq, highestmodseq, &newmailbox);
         if (!r) r = mailbox_add_conversations(newmailbox, silent);
         if (r) {

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -214,11 +214,13 @@ int mboxlist_createmailboxcheck(const char *name, int mbtype,
 /* create mailbox */
 /* if given a mailbox pointer, return the still-locked mailbox
  * for further manipulation */
-int mboxlist_createmailbox(const mbentry_t *mbentry,
-                           unsigned mboxopts, modseq_t highestmodseq,
-                           unsigned isadmin, const char *userid,
-                           const struct auth_state *auth_state,
-                           unsigned flags, struct mailbox **mboxptr);
+#define mboxlist_createmailbox(m, o, h, a, u, s, f, p) \
+    mboxlist_createmailbox_version(m, 0, o, h, a, u, s, f, p)
+int mboxlist_createmailbox_version(const mbentry_t *mbentry, int minor_version,
+                                   unsigned mboxopts, modseq_t highestmodseq,
+                                   unsigned isadmin, const char *userid,
+                                   const struct auth_state *auth_state,
+                                   unsigned flags, struct mailbox **mboxptr);
 
 /* create mailbox with wrapping namespacelock */
 int mboxlist_createmailboxlock(const mbentry_t *mbentry,


### PR DESCRIPTION
- If creating a v19 (or earlier) INBOX, a v1 conv.db will be created
- CREATEs w/o an explicit version will use the version of the parent

This was cherry-picked (and modified) from 64bit-nanosecond-jmapids-bis branch