### PR TITLE
jmap_mailbox.c: add maxMailboxDepth & maxSizeMailboxName to accountCapabilities

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -68,6 +68,7 @@ sub new
                  httpmodules => 'carddav caldav jmap',
                  jmap_max_size_upload => '1k',
                  jmap_max_size_request => '1k',
+                 jmap_mail_max_size_attachments_per_email => '1m',
                  jmap_nonstandard_extensions => 'yes',
                  httpallowcompress => 'no');
 

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -523,6 +523,27 @@ sub assert_not_file_test
                   "'$path' unexpectedly passed '$test_type' test");
 }
 
+sub assert_cmp_deeply
+{
+    my ($self, $have, $want, $desc) = @_;
+    $desc ||= "deep comparison matched";
+
+    require Test::Deep;
+    my ($ok, $stack) = Test::Deep::cmp_details($want, $have);
+
+    if ($ok) {
+        return $self->assert(1, $desc);
+    }
+
+    my ($package, $filename, $line) = caller;
+
+    my $diag = join qq{\n},
+               "deep comparison failed at $filename, line $line:\n",
+               Test::Deep::deep_diag($stack);
+
+    return $self->assert(0, $diag);
+}
+
 sub new_test_url
 {
     my ($self, $content_or_app) = @_;

--- a/cassandane/tiny-tests/JMAPCore/get_session
+++ b/cassandane/tiny-tests/JMAPCore/get_session
@@ -146,8 +146,27 @@ sub test_get_session
     $self->assert_equals(JSON::true, $primaryAccount->{isPersonal});
     my $accountCapabilities = $primaryAccount->{accountCapabilities};
     $self->assert_not_null($accountCapabilities->{'urn:ietf:params:jmap:blob'});
-    $self->assert_not_null($accountCapabilities->{'urn:ietf:params:jmap:mail'});
-    $self->assert_equals(JSON::true, $accountCapabilities->{'urn:ietf:params:jmap:mail'}{mayCreateTopLevelMailbox});
+
+    {
+        my $ac_mail = $accountCapabilities->{'urn:ietf:params:jmap:mail'};
+
+        use Test::Deep ':v1';
+        $self->assert_cmp_deeply(
+            {
+                # Presented in the same order as found in RFC 8621.
+                maxMailboxesPerEmail => 20,
+                maxMailboxDepth      => JSON::null(),
+                maxSizeMailboxName   => 255,
+                maxSizeAttachmentsPerEmail => 1048576,
+                emailQuerySortOptions => superbagof(),
+                mayCreateTopLevelMailbox => JSON::true(),
+                maxKeywordsPerEmail => 100  # Cyrus-specific
+            },
+            $ac_mail,
+            "mail accountCapabilities look right",
+        );
+    }
+
     $self->assert_not_null($accountCapabilities->{'urn:ietf:params:jmap:submission'});
     if ($buildinfo->get('component', 'sieve')) {
         $self->assert_not_null($accountCapabilities->{'urn:ietf:params:jmap:vacationresponse'});

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_set_name_toolong
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_set_name_toolong
@@ -1,0 +1,29 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_mailbox_set_name_toolong
+    :min_version_3_1
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+
+    xlog $self, "create mailbox";
+    my $name = 'X' x 300;
+    my $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            create => {
+                "1" => { role => undef, name => $name },
+                "2" => { role => undef, name => 'foo' }
+            },
+            update => {
+                "#2" => { name => $name },
+            }
+         }, "R1"]
+    ]);
+    $self->assert_str_equals('Mailbox/set', $res->[0][0]);
+    $self->assert_str_equals('invalidProperties', $res->[0][1]{notCreated}{1}{type});
+    $self->assert_str_equals('name', $res->[0][1]{notCreated}{1}{properties}[0]);
+    $self->assert_str_equals('invalidProperties', $res->[0][1]{notUpdated}{'#2'}{type});
+    $self->assert_str_equals('name', $res->[0][1]{notUpdated}{'#2'}{properties}[0]);
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -347,12 +347,11 @@ HIDDEN void jmap_mail_capabilities(json_t *account_capabilities, int mayCreateTo
         max_size_attachments_per_email = 0;
     }
 
-    json_t *email_capabilities = json_pack("{s:i s:i s:i s:o, s:b}",
+    json_t *email_capabilities = json_pack("{s:i s:i s:i s:o}",
             "maxMailboxesPerEmail", JMAP_MAIL_MAX_MAILBOXES_PER_EMAIL,
             "maxKeywordsPerEmail", JMAP_MAIL_MAX_KEYWORDS_PER_EMAIL,
             "maxSizeAttachmentsPerEmail", max_size_attachments_per_email,
-            "emailsListSortOptions", sortopts,
-            "mayCreateTopLevelMailbox", mayCreateTopLevel);
+            "emailQuerySortOptions", sortopts);
 
     json_object_set_new(account_capabilities, JMAP_URN_MAIL, email_capabilities);
 
@@ -360,7 +359,7 @@ HIDDEN void jmap_mail_capabilities(json_t *account_capabilities, int mayCreateTo
         json_object_set_new(account_capabilities, JMAP_MAIL_EXTENSION, json_object());
     }
 
-    jmap_mailbox_capabilities(account_capabilities);
+    jmap_mailbox_capabilities(account_capabilities, mayCreateTopLevel);
 }
 
 #define JMAP_HAS_ATTACHMENT_FLAG "$HasAttachment"

--- a/imap/jmap_mail.h
+++ b/imap/jmap_mail.h
@@ -62,6 +62,7 @@ extern void jmap_emailsubmission_init(jmap_settings_t *settings);
 extern void jmap_emailsubmission_capabilities(json_t *jcapabilities);
 
 extern void jmap_mailbox_init(jmap_settings_t *settings);
-extern void jmap_mailbox_capabilities(json_t *jcapabilities);
+extern void jmap_mailbox_capabilities(json_t *jcapabilities,
+                                      int mayCreateToplevel);
 
 #endif /* JMAP_MAIL_H */


### PR DESCRIPTION
- Mailbox-specfic limits moved from jmap_mail.c to jmap_mailbox.c
- maxSizeMailboxName enforced in _mboxset_args_parse()
- emailsListSortOptions renamed to emailQuerySortOptions