### PR TITLE
cyr_info: recognise service-prefixed sasl keys in conf-lint

### DIFF
--- a/cassandane/Cassandane/Cyrus/Info.pm
+++ b/cassandane/Cassandane/Cyrus/Info.pm
@@ -212,6 +212,7 @@ sub test_lint_channels
         'banana_sync_host' => 'banana.internal',
         'banana_sync_trust_fund' => 'street art',
         'banana_tcp_keepalive' => 'yes',
+        'banana_sasl_mech_list' => 'PLAIN',
     );
 
     $self->_start_instances();
@@ -225,6 +226,7 @@ sub test_lint_channels
         [ sort(
             "banana_sync_trust_fund: street art\n",
             "banana_tcp_keepalive: yes\n",
+            "banana_sasl_mech_list: PLAIN\n",
         ) ],
         [ sort @output ]
     );
@@ -264,6 +266,35 @@ sub test_lint_partitions
             "backuppartition-bad: /tmp/bbad\n",
             "foosearchpartition-bad: /tmp/sbad\n",
             "metapartition-bad: /tmp/mbad\n",
+        ) ],
+        [ sort @output ]
+    );
+}
+
+sub test_lint_services
+    :want_service_http :needs_component_httpd :NoStartInstances
+{
+    my ($self) = @_;
+
+    $self->config_set(
+        'http_sasl_mech_list' => 'PLAIN',
+        'http_sasl_trust_fund' => 'street art',
+        'http_tcp_keepalive' => 'yes',
+        'http_trust_fund' => 'street art',
+    );
+
+    $self->_start_instances();
+
+    xlog $self, "test 'cyr_info conf-lint' with service-specific config";
+
+    my @output = $self->{instance}->run_cyr_info('conf-lint');
+    @output = grep { !m/_db: / } @output;  # skip database types
+
+    $self->assert_deep_equals(
+        [ sort(
+            "http_trust_fund: street art\n",
+            # XXX we don't verify sasl keys, so this isn't reported
+            #"http_sasl_trust_fund: street art\n",
         ) ],
         [ sort @output ]
     );

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -359,6 +359,10 @@ static void lint_callback(const char *key, const char *val, void *rock)
             /* check if it's a known key */
             if (known_regularkey(key+svc->prefixlen)) return;
             if (known_overflowkey(key+svc->prefixlen)) return;
+
+            if (!strncmp(key+svc->prefixlen, "sasl_", 5)) {
+                if (known_saslkey(key+svc->prefixlen+5)) return;
+            }
         }
     }
 


### PR DESCRIPTION
Makes `cyr_info conf-lint` not complain about e.g. `http_sasl_mech_list: PLAIN`

Fixes #5424 