### PR TITLE
jmap_api.c: limit size of client-provided createdIds

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPSieve.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPSieve.pm
@@ -86,6 +86,7 @@ sub new
                  httpallowcompress => 'no',
                  jmap_max_objects_in_get => '3',
                  jmap_max_objects_in_set => '5',
+                 jmap_max_calls_in_request => '5',
                  jmap_nonstandard_extensions => 'yes');
 
     my $self = $class->SUPER::new({

--- a/cassandane/tiny-tests/JMAPSieve/too_many_createdids
+++ b/cassandane/tiny-tests/JMAPSieve/too_many_createdids
@@ -1,0 +1,60 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_too_many_createdids
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+
+    xlog "Test too many createdIds";
+    my $httpReq = {
+        headers => {
+            'Authorization' => $jmap->auth_header(),
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        },
+        content => '{
+            "using" : ["urn:ietf:params:jmap:sieve"],
+            "methodCalls" : [["SieveScript/set", {
+                 "create" : { "1" : { "blobId" : "#A" } }
+            }, "R1"]],
+            "createdIds" : {
+                "A" : "a",
+                "B" : "b",
+                "C" : "c",
+                "D" : "d",
+                "E" : "e",
+                "F" : "f",
+                "G" : "g",
+                "H" : "h",
+                "I" : "i",
+                "J" : "j",
+                "K" : "k",
+                "L" : "l",
+                "M" : "m",
+                "N" : "n",
+                "O" : "o",
+                "P" : "p",
+                "Q" : "q",
+                "R" : "r",
+                "S" : "s",
+                "T" : "t",
+                "U" : "u",
+                "V" : "v",
+                "W" : "w",
+                "X" : "x",
+                "Y" : "y",
+                "Z" : "z"
+            }
+        }'
+    };
+    my $httpRes = $jmap->ua->post($jmap->uri('cassandane'), $httpReq);
+    $self->assert_str_equals("400", $httpRes->{status});
+    my $res = eval { decode_json($httpRes->{content}) };
+    $self->assert_str_equals("400", $res->{status});
+    $self->assert_str_equals("JMAP request exceeds a server limit",
+                             $res->{title});
+    $self->assert_str_equals("urn:ietf:params:jmap:error:limit", $res->{type});
+    $self->assert_str_equals("maxCreatedIdsInRequest", $res->{limit});
+}

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -75,6 +75,7 @@
 #define JMAP_URN_PRINCIPALS "urn:ietf:params:jmap:principals"
 #define JMAP_URN_CALENDAR_PREFERENCES "urn:ietf:params:jmap:calendars:preferences"
 
+#define JMAP_CORE_EXTENSION          "https://cyrusimap.org/ns/jmap/core"
 #define JMAP_BLOB_EXTENSION          "https://cyrusimap.org/ns/jmap/blob"
 #define JMAP_CONTACTS_EXTENSION      "https://cyrusimap.org/ns/jmap/contacts"
 #define JMAP_CALENDARS_EXTENSION     "https://cyrusimap.org/ns/jmap/calendars"
@@ -91,6 +92,7 @@
 enum {
     MAX_SIZE_REQUEST = 0,
     MAX_CALLS_IN_REQUEST,
+    MAX_CREATEDIDS_IN_REQUEST,
     MAX_CONCURRENT_REQUESTS,
     MAX_OBJECTS_IN_GET,
     MAX_OBJECTS_IN_SET,

--- a/imap/jmap_err.et
+++ b/imap/jmap_err.et
@@ -61,4 +61,7 @@ ec JMAP_LIMIT_SIZE,
 ec JMAP_LIMIT_CALLS,
    "urn:ietf:params:jmap:error:limit\0JMAP request exceeds a server limit\0maxCallsInRequest"
 
+ec JMAP_LIMIT_CREATEDIDS,
+   "urn:ietf:params:jmap:error:limit\0JMAP request exceeds a server limit\0maxCreatedIdsInRequest"
+
 end


### PR DESCRIPTION
clientIds hash table sized based on the request arguments