### PR TITLE
Cassandane: silence TLS session cache leaks detected by valgrind

### DIFF
--- a/cassandane/Cassandane/Cyrus/ALPN.pm
+++ b/cassandane/Cassandane/Cyrus/ALPN.pm
@@ -64,6 +64,7 @@ sub new
     my $config = Cassandane::Config->default()->clone();
     $config->set(tls_server_cert => '@basedir@/conf/certs/cert.pem',
                  tls_server_key => '@basedir@/conf/certs/key.pem',
+                 tls_session_timeout => 0,
                  allowstarttls => 'on',
                  httpmodules => 'caldav');
 

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -424,6 +424,7 @@ magic(TLS => sub {
     my $self = shift;
     $self->config_set(tls_server_cert => '@basedir@/conf/certs/cert.pem');
     $self->config_set(tls_server_key => '@basedir@/conf/certs/key.pem');
+    $self->config_set(tls_session_timeout => 0);
     $self->want('install_certificates');
     $self->want_services('imaps');
 });


### PR DESCRIPTION
With this in place we can remove the :SuppressLSAN() magic from:

ALPN.pm
Alpaca.pm
MboxEvent.pm
StartTLS.pm
JMAPCore/echo_tls