### PR TITLE
twom: fix stringop-truncation warning with -O3

### DIFF
--- a/lib/twom.c
+++ b/lib/twom.c
@@ -2988,7 +2988,7 @@ static int twom_txn_dump(struct twom_txn *txn, int detail)
             const char *key = KEYPTR(loc->file->base + parent_offset);
             size_t len = KEYLEN(loc->file->base + parent_offset);
             if (len > 79) len = 79;
-            if (key) strncpy(scratch, key, len);
+            if (key && len) strncpy(scratch, key, len);
             scratch[len] = 0;
             for (i = 0; i < len; i++)
                 if (!scratch[i]) scratch[i] = '-';
@@ -2999,7 +2999,7 @@ static int twom_txn_dump(struct twom_txn *txn, int detail)
             const char *key = KEYPTR(ptr);
             size_t len = KEYLEN(ptr);
             if (len > 79) len = 79;
-            if (key) strncpy(scratch, key, len);
+            if (key && len) strncpy(scratch, key, len);
             scratch[len] = 0;
             for (i = 0; i < len; i++)
                 if (!scratch[i]) scratch[i] = '-';


### PR DESCRIPTION
When x has no key, `KEYLEN(x)` returns 0, but `KEYPTR(x)` returns `""` rather than NULL.  This means the `if (key)` check is always true, and we might call strncpy with len=0. The optimiser notices this and complains.  Shush it by checking len too.

We're just producing (maybe-truncated) human readable output here, so a possibly-empty key isn't concerning.