### PR TITLE
tls.c: don't leak SSL_SESSIONs when caching

### DIFF
--- a/cassandane/Cassandane/Cyrus/ALPN.pm
+++ b/cassandane/Cassandane/Cyrus/ALPN.pm
@@ -151,7 +151,6 @@ sub assert_alpn_protocol
 }
 
 sub test_imap_none
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -171,7 +170,6 @@ sub test_imap_none
 }
 
 sub test_imap_good
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -209,7 +207,6 @@ sub test_imap_bad
 }
 
 sub test_imaps_none
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -224,7 +221,6 @@ sub test_imaps_none
 }
 
 sub test_imaps_good
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -288,7 +284,6 @@ sub do_https_request
 
 sub test_https_none
     :want_service_https :needs_component_httpd
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -306,7 +301,6 @@ sub test_https_none
 
 sub test_https_http10
     :want_service_https :needs_component_httpd
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -324,7 +318,6 @@ sub test_https_http10
 
 sub test_https_http11
     :want_service_https :needs_component_httpd
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -342,7 +335,6 @@ sub test_https_http11
 
 sub test_https_multi
     :want_service_https :needs_component_httpd
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -360,7 +352,6 @@ sub test_https_multi
 
 sub test_https_h2
     :want_service_https :needs_component_httpd :needs_dependency_nghttp2
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -382,7 +373,6 @@ sub test_https_h2
 
 sub test_https_multi2
     :want_service_https :needs_component_httpd :needs_dependency_nghttp2
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -404,7 +394,6 @@ sub test_https_multi2
 
 sub test_https_bad
     :want_service_https :needs_component_httpd
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/Alpaca.pm
+++ b/cassandane/Cassandane/Cyrus/Alpaca.pm
@@ -316,7 +316,6 @@ sub test_http_post_drop_connection2
 
 sub test_http_post_drop_connection3
     :TLS :needs_dependency_openssl
-    :SuppressLSAN(libcrypto.so)
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/MboxEvent.pm
+++ b/cassandane/Cassandane/Cyrus/MboxEvent.pm
@@ -88,7 +88,6 @@ sub tear_down
 
 sub test_tls_login_event
     :TLS :min_version_3_0
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/StartTLS.pm
+++ b/cassandane/Cassandane/Cyrus/StartTLS.pm
@@ -106,7 +106,6 @@ sub test_imap_disabled
 
 sub test_imap_enabled
     :TLS :needs_dependency_openssl :NoStartInstances
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 
@@ -199,7 +198,6 @@ sub test_http_disabled
 
 sub test_http_enabled
     :TLS :needs_dependency_openssl :NoStartInstances
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/JMAPCore/echo_tls
+++ b/cassandane/tiny-tests/JMAPCore/echo_tls
@@ -3,7 +3,6 @@ use Cassandane::Tiny;
 
 sub test_echo_tls
     :TLS :want_service_https :needs_component_httpd
-    :SuppressLSAN(libcrypto.so libssl.so)
 {
     my ($self) = @_;
 

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -505,7 +505,7 @@ static int new_session_cb(SSL *ssl __attribute__((unused)),
                idstr, ctime(&expire), ret ? "failed" : "ok");
     }
 
-    return (ret == 0);
+    return 0;
 }
 
 /*
@@ -980,7 +980,7 @@ EXPORTED int     tls_init_serverengine(const char *ident,
     SSL_CTX_sess_set_cache_size(s_ctx, 1);  /* 0 is unlimited, so use 1 */
     SSL_CTX_set_session_cache_mode(s_ctx, SSL_SESS_CACHE_SERVER |
                                    SSL_SESS_CACHE_NO_AUTO_CLEAR |
-                                   SSL_SESS_CACHE_NO_INTERNAL_LOOKUP);
+                                   SSL_SESS_CACHE_NO_INTERNAL);
 
     /* Get the session timeout from the config file */
     timeout = config_getduration(IMAPOPT_TLS_SESSION_TIMEOUT, 'm');


### PR DESCRIPTION
Let's get this on future to make sure that it doesn't break anything before we actually merge.