### PR TITLE
configure.ac: make 'function nesting' check safer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2253,8 +2253,9 @@ int cval(const void *a, const void *b, void *prev)
   return 1;
 }
 ],[
-    char *dest;
-    func("abc", 3, 1, cval, &dest);
+    /* the chaos is a pair of quadrigraphs representing square brackets */
+    char *dest, buf@<:@@:>@ = "abc";
+    func(buf, 3, 1, cval, &dest);
 ],cyrus_cv_function_nesting=yes, cyrus_cv_function_nesting=no))
 AC_MSG_RESULT($cyrus_cv_function_nesting)
 if test "$cyrus_cv_function_nesting" = "yes"; then


### PR DESCRIPTION
The call to `func("abc", ...)`, if run, would have qsorted the bytes of the string literal "abc", which is undefined behaviour.

When building with -Wwrite-strings and -Werror (as we usually do), the attempt to write to a string literal is a compile-time error. The check misinterprets this as function nesting being unavailable.

This fixes it to call func correctly, with a modifiable buffer, preventing the unrelated compiler error.