### PR TITLE
Email/query: Always track collapsed matches so query cache is consistent

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_cache_collapsed_threads
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_cache_collapsed_threads
@@ -1,0 +1,159 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_cache_collapsed_threads
+    :JMAPExtensions :JMAPQueryCacheMaxAge1s
+{
+    my ($self) = @_;
+    my $jmap   = $self->{jmap};
+    my $imap   = $self->{store}->get_client();
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/quota');
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/debug');
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/performance');
+
+    # Create mailboxes A and B.
+    my $res = $jmap->CallMethods([
+        [
+            'Mailbox/set',
+            {
+                create => {
+                    mboxA => {
+                        name => 'A',
+                    },
+                    mboxB => {
+                        name => 'B',
+                    },
+                }
+            },
+            'R1'
+        ],
+    ]);
+    my $mboxA = $res->[0][1]{created}{mboxA}{id};
+    $self->assert_not_null($mboxA);
+    my $mboxB = $res->[0][1]{created}{mboxB}{id};
+    $self->assert_not_null($mboxB);
+
+    # Create messages in mailbox A.
+    $self->{store}->set_folder('A');
+    for (my $i = 0; $i < 10; $i++) {
+        $self->make_message(
+            "msgA$i",
+            to => Cassandane::Address->new(
+                localpart => "recipientA$i",
+                domain    => 'example.com'
+            ),
+        ) || die;
+    }
+
+    # Create messages in mailbox B.
+    $self->{store}->set_folder('B');
+    for (my $i = 0; $i < 10; $i++) {
+        $self->make_message(
+            "msgB$i",
+            to => Cassandane::Address->new(
+                localpart => "recipientB$i",
+                domain    => 'example.com'
+            ),
+        ) || die;
+    }
+
+    xlog $self, "run squatter";
+    $self->{instance}->run_command({ cyrus => 1 }, 'squatter');
+
+    xlog "Mailbox A: seed Email/query cache with collapseThreads=true";
+    $res = $jmap->CallMethods(
+        [ [
+            'Email/query',
+            {
+                filter => {
+                    inMailbox => $mboxA,
+                },
+                collapseThreads => JSON::true,
+            },
+            'R1'
+        ] ]
+    );
+    $self->assert_num_equals(10, scalar @{ $res->[0][1]{ids} });
+    $self->assert_equals(JSON::false, $res->[0][1]{performance}{details}{isCached});
+
+    xlog "Mailbox A: rerun Email/query with collapseThreads=false";
+    $res = $jmap->CallMethods(
+        [ [
+            'Email/query',
+            {
+                filter => {
+                    inMailbox => $mboxA,
+                },
+                collapseThreads => JSON::false,
+            },
+            'R1'
+        ] ]
+    );
+    $self->assert_num_equals(10, scalar @{ $res->[0][1]{ids} });
+    $self->assert_equals(JSON::true, $res->[0][1]{performance}{details}{isCached});
+
+    xlog "Mailbox A: rerun Email/query with collapseThreads=true";
+    $res = $jmap->CallMethods(
+        [ [
+            'Email/query',
+            {
+                filter => {
+                    inMailbox => $mboxA,
+                },
+                collapseThreads => JSON::true,
+            },
+            'R1'
+        ] ]
+    );
+    $self->assert_num_equals(10, scalar @{ $res->[0][1]{ids} });
+    $self->assert_equals(JSON::true, $res->[0][1]{performance}{details}{isCached});
+
+    xlog "Mailbox B: seed Email/query cache with collapseThreads=false";
+    $res = $jmap->CallMethods(
+        [ [
+            'Email/query',
+            {
+                filter => {
+                    inMailbox => $mboxB,
+                },
+                collapseThreads => JSON::false,
+            },
+            'R1'
+        ] ]
+    );
+    $self->assert_num_equals(10, scalar @{ $res->[0][1]{ids} });
+    $self->assert_equals(JSON::false, $res->[0][1]{performance}{details}{isCached});
+
+    xlog "Mailbox B: rerun Email/query with collapseThreads=true";
+    $res = $jmap->CallMethods(
+        [ [
+            'Email/query',
+            {
+                filter => {
+                    inMailbox => $mboxB,
+                },
+                collapseThreads => JSON::true,
+            },
+            'R1'
+        ] ]
+    );
+    $self->assert_num_equals(10, scalar @{ $res->[0][1]{ids} });
+    $self->assert_equals(JSON::true, $res->[0][1]{performance}{details}{isCached});
+
+    xlog "Mailbox B: rerun Email/query with collapseThreads=false";
+    $res = $jmap->CallMethods(
+        [ [
+            'Email/query',
+            {
+                filter => {
+                    inMailbox => $mboxB,
+                },
+                collapseThreads => JSON::false,
+            },
+            'R1'
+        ] ]
+    );
+    $self->assert_num_equals(10, scalar @{ $res->[0][1]{ids} });
+    $self->assert_equals(JSON::true, $res->[0][1]{performance}{details}{isCached});
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4221,7 +4221,7 @@ static void emailquery_guidsearch_result_ensure(struct emailquery *q, struct ema
         message_guid_decode(&match->guid, gsqmatch->guidrep);
         match->cid = gsqmatch->cid;
         smallarrayu64_init(&match->partnums);
-        if (q->collapse_threads && hashset_add(qc->seen_threads, &match->cid))
+        if (hashset_add(qc->seen_threads, &match->cid))
             qc->collapsed_matches[qc->collapsed_len++] = *match;
     }
     qc->have_total = 1;
@@ -4358,7 +4358,7 @@ static void emailquery_uidsearch_result_ensure(struct emailquery *q, struct emai
         }
 
         // calculate the collapsed version too
-        if (q->collapse_threads && hashset_add(qc->seen_threads, &match->cid))
+        if (hashset_add(qc->seen_threads, &match->cid))
             qc->collapsed_matches[qc->collapsed_len++] = *match;
     }
 
@@ -4559,15 +4559,13 @@ static void emailquery_cache_ensure(struct emailquery *q,
             xmalloc(sizeof(struct emailquery_match) * qc->qr.total_ceiling);
         qc->uncollapsed_len = 0;
     }
-    if (q->collapse_threads) {
-        if (!qc->collapsed_matches) {
-            qc->collapsed_matches =
-                xmalloc(sizeof(struct emailquery_match) * qc->qr.total_ceiling);
-            qc->collapsed_len = 0;
-        }
-        if (!qc->seen_threads)
-            qc->seen_threads = hashset_new(sizeof(conversation_id_t));
+    if (!qc->collapsed_matches) {
+        qc->collapsed_matches =
+            xmalloc(sizeof(struct emailquery_match) * qc->qr.total_ceiling);
+        qc->collapsed_len = 0;
     }
+    if (!qc->seen_threads)
+        qc->seen_threads = hashset_new(sizeof(conversation_id_t));
 
     // fill the caches
     qc->qr.ensure(q, qc, n);


### PR DESCRIPTION
When you "Email/query" with collapseThreads = true, we store in the cache info necessary for both collapsed and uncollapsed results.

When you "Email/query" with collapseThreads = false, we were not storing info necessary for collapsed threads results, so subsequent requests that hit the cache but have collapseThreads = true would return 0 items.

Fix that by always computing both