### PR TITLE
libconfig: use explicit uint64_t for bitfields

### DIFF
--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -218,7 +218,7 @@ static void test_enum_invalid(void)
 
 static void test_bitfield_value(void)
 {
-    unsigned long httpmodules = (unsigned long) -1;
+    uint64_t httpmodules = UINT64_MAX;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -234,7 +234,7 @@ static void test_bitfield_value(void)
 
 static void test_bitfield_value_wide(void)
 {
-    unsigned long sieve_extensions = (unsigned long) -1;
+    uint64_t sieve_extensions = UINT64_MAX;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -257,7 +257,7 @@ static void test_bitfield_value_wide(void)
 
 static void test_bitfield_default(void)
 {
-    unsigned long httpmodules = (unsigned long) -1;
+    uint64_t httpmodules = UINT64_MAX;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -828,7 +828,7 @@ static int is_supported_component(icalcomponent *ical)
 {
     icalcomponent *comp = icalcomponent_get_first_real_component(ical);
     icalcomponent_kind kind = icalcomponent_isa(comp);
-    int is_supported = 0;
+    uint64_t is_supported = 0;
 
     switch (kind) {
     case ICAL_VEVENT_COMPONENT:

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1409,7 +1409,7 @@ static int _create_mailbox(const char *userid, const char *mailboxname,
 
 EXPORTED unsigned long config_types_to_caldav_types(void)
 {
-    unsigned long config_types =
+    uint64_t config_types =
         config_getbitfield(IMAPOPT_CALENDAR_COMPONENT_SET);
     unsigned long types = 0;
 

--- a/imap/global.c
+++ b/imap/global.c
@@ -99,7 +99,7 @@ EXPORTED volatile sig_atomic_t in_shutdown = 0;
 
 EXPORTED int config_fulldirhash;                                /* 0 */
 EXPORTED int config_implicitrights;                     /* "lkxa" */
-EXPORTED unsigned long config_metapartition_files;      /* 0 */
+EXPORTED uint64_t config_metapartition_files;      /* 0 */
 EXPORTED const char *config_mboxlist_db;
 EXPORTED const char *config_quota_db;
 EXPORTED const char *config_subscription_db;

--- a/imap/global.h
+++ b/imap/global.h
@@ -159,7 +159,7 @@ extern int saslprops_set_tls(struct saslprops_t *saslprops,
 extern volatile sig_atomic_t in_shutdown;
 extern int config_fulldirhash;
 extern int config_implicitrights;
-extern unsigned long config_metapartition_files;
+extern uint64_t config_metapartition_files;
 extern const char *config_mboxlist_db;
 extern const char *config_quota_db;
 extern const char *config_subscription_db;

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -432,7 +432,7 @@ int https = 0;
 static int httpd_tls_required = 0;
 static int httpd_starttls_enabled = 0;
 static unsigned avail_auth_schemes = 0; /* bitmask of available auth schemes */
-unsigned long config_httpmodules;
+uint64_t config_httpmodules;
 
 static time_t compile_time;
 struct buf serverinfo = BUF_INITIALIZER;

--- a/imap/httpd.h
+++ b/imap/httpd.h
@@ -568,7 +568,7 @@ extern char *httpd_extradomain;
 extern struct auth_state *httpd_authstate;
 extern struct namespace httpd_namespace;
 extern const char *httpd_localip, *httpd_remoteip;
-extern unsigned long config_httpmodules;
+extern uint64_t config_httpmodules;
 extern strarray_t *httpd_log_headers;
 extern char *httpd_altsvc;
 

--- a/imap/jmap_vacation.c
+++ b/imap/jmap_vacation.c
@@ -117,8 +117,8 @@ HIDDEN void jmap_vacation_init(jmap_settings_t *settings)
     }
 
 #ifdef USE_SIEVE
-    unsigned long config_ext = config_getbitfield(IMAPOPT_SIEVE_EXTENSIONS);
-    unsigned long required =
+    uint64_t config_ext = config_getbitfield(IMAPOPT_SIEVE_EXTENSIONS);
+    uint64_t required =
         IMAP_ENUM_SIEVE_EXTENSIONS_VACATION   |
         IMAP_ENUM_SIEVE_EXTENSIONS_RELATIONAL |
         IMAP_ENUM_SIEVE_EXTENSIONS_DATE;

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -102,7 +102,7 @@ static strarray_t *excluded_specialuse;
 static int enable_subfolder = 1;
 
 static int enabled_events = 0;
-static unsigned long extra_params;
+static uint64_t extra_params;
 
 static struct mboxevent event_template =
 { 0,
@@ -231,7 +231,7 @@ static void init_internal() {
 EXPORTED int mboxevent_init(void)
 {
     const char *options;
-    int groups;
+    uint64_t groups;
 
     if (!(notifier = config_getstring(IMAPOPT_EVENT_NOTIFIER)) && !idle_notifier)
         return 0;

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -3098,7 +3098,7 @@ static int savemsg(message_data_t *m, FILE *f)
             }
             if (!r) {
                 const char *newspostuser = config_getstring(IMAPOPT_NEWSPOSTUSER);
-                unsigned long newsaddheaders =
+                uint64_t newsaddheaders =
                     config_getbitfield(IMAPOPT_NEWSADDHEADERS);
                 const char **to = NULL, **replyto = NULL;
 

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -174,7 +174,7 @@ EXPORTED enum enum_value config_getenum(enum imapopt opt)
     return imapopts[opt].val.e;
 }
 
-EXPORTED unsigned long config_getbitfield(enum imapopt opt)
+EXPORTED uint64_t config_getbitfield(enum imapopt opt)
 {
     assert(config_loaded);
     assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -54,7 +54,7 @@ extern const char *config_getstring(enum imapopt opt);
 extern int config_getint(enum imapopt opt);
 extern int config_getswitch(enum imapopt opt);
 extern enum enum_value config_getenum(enum imapopt opt);
-extern unsigned long config_getbitfield(enum imapopt opt);
+extern uint64_t config_getbitfield(enum imapopt opt);
 extern int config_getduration(enum imapopt opt, int defunit);
 extern int64_t config_getbytesize(enum imapopt opt, int defunit);
 

--- a/sieve/interp.c
+++ b/sieve/interp.c
@@ -81,7 +81,7 @@ EXPORTED sieve_interp_t *sieve_interp_alloc(void *interp_context)
 EXPORTED const strarray_t *sieve_listextensions(sieve_interp_t *i)
 {
     if (i->extensions == NULL) {
-        unsigned long config_sieve_extensions =
+        uint64_t config_sieve_extensions =
             config_getbitfield(IMAPOPT_SIEVE_EXTENSIONS);
         struct buf buf = BUF_INITIALIZER;
         int ext_pos;
@@ -594,7 +594,7 @@ unsigned long long lookup_capability(const char *str)
 
 unsigned long long extension_isactive(sieve_interp_t *interp, const char *str)
 {
-    unsigned long config_ext = config_getbitfield(IMAPOPT_SIEVE_EXTENSIONS);
+    uint64_t config_ext = config_getbitfield(IMAPOPT_SIEVE_EXTENSIONS);
     unsigned long long capa = lookup_capability(str);
 
     switch (capa) {

--- a/tools/config2header
+++ b/tools/config2header
@@ -302,7 +302,7 @@ while (<STDIN>) {
             }
             $e .= "0";
             $def = $use_gcc_extension
-                        ? "U_CFG_V((unsigned long long) $e)"
+                        ? "U_CFG_V((uint64_t) $e)"
                         : "{(void *)($e)}";
 
             # output the enum_options
@@ -324,7 +324,7 @@ while (<STDIN>) {
                 }
 
                 # add the corresponding bit value
-                $e .= " = (1LL<<$bit)";
+                $e .= " = (UINT64_C(1)<<$bit)";
 
                 # add this enum to enum_values
                 push(@enum_values, $e);
@@ -408,7 +408,7 @@ union config_value {
     long i;             /* OPT_INT */
     long b;             /* OPT_SWITCH */
     enum enum_value e;  /* OPT_ENUM */
-    unsigned long long x; /* OPT_BITFIELD */
+    uint64_t x;         /* OPT_BITFIELD */
 };
 
 struct enum_option_s {


### PR DESCRIPTION
This was a mess of `unsigned long` and `unsigned long long`, which we've been getting away with on amd64 where both types are 64 bits wide, but it's not portable: `unsigned long` may be only 32 bits, which breaks sieve_extensions.
    
We expect bitfields to be 64 bits wide, so be explicit.
