### PR TITLE
http_admin: fix double-free in action_proc()

### DIFF
--- a/imap/http_admin.c
+++ b/imap/http_admin.c
@@ -537,13 +537,6 @@ static int action_proc(struct transaction_t *txn)
         buf_printf_markup(body, level, "<td>%s</td>", pinfo->mailbox);
         buf_printf_markup(body, level, "<td>%s</td>", pinfo->cmdname);
         buf_printf_markup(body, --level, "</tr>");
-
-        free(pinfo->servicename);
-        free(pinfo->host);
-        free(pinfo->user);
-        free(pinfo->mailbox);
-        free(pinfo->cmdname);
-        free(pinfo);
     }
 
     deinit_piarray(&piarray);


### PR DESCRIPTION
This is all freed a few lines later by the call to deinit_piarray()

Based on a patch by @MASHtm in #5420