### PR TITLE
docs: update release process documentation

### DIFF
--- a/docsrc/imap/developer/major-releasing.rst
+++ b/docsrc/imap/developer/major-releasing.rst
@@ -264,26 +264,22 @@ Tell the website builder about the new branch
 The website is automatically rebuilt by a script, which needs to be updated
 to know about the new series.
 
-1. Clone ``git@github.com:cyrusimap/cyrusimap.org.git``, or ensure the clone
-   you already have is up to date
-2. Update `run-gp.sh` to know about the new version.  You'll need to add code
-   in several places, but it's pretty self-explanatory once you look at it.
-   For the time being, do NOT change which version `$target` and
-   `$target/stable` are rsync'd from.  We'll change these later, once the real
-   release has been published.  In the meantime, we want the top level and
-   stable sections to continue to be built from the existing stable branch.
+1. Clone ``git@github.com:cyrusimap/cyrusimap.github.io.git``, or ensure the
+   clone you already have is up to date
+2. Update ``build-cyrus-site`` to know about the new version.  You do this by
+   adding a ``cyrus_branch()`` call to the ``%sources`` hash.  Do NOT change
+   the line for current stable at this stage.  We'll change that later, once
+   the real release has been published.  In the meantime, we want the top level
+   and stable sections to continue to be built from the existing stable branch,
+   but we want the website for the new branch to be available at ``/x.y``.
 3. You can check your work by comparing your changes to previous commits
-4. Commit and push your changes.  The system that runs this script fetches
-   changes automatically before running it, so the next run to start will
-   use the updated version.  It starts approximately on the hour, and can
-   take ~15 minutes if there are large changes, such as adding a whole new
-   branch...
+4. Commit and push your changes (or submit a PR).  There is a Github Action
+   on this repository that rebuilds the website once per hour, using the
+   current version of this script, so your changes will take effect at the
+   next run after they are merged to master.
 5. You should now be able to access a version of the website built from the
    new branch at `https://www.cyrusimap.org/<version>/`.  Check that in your
    browser, make sure it reports the correct new versions.
-6. You should also see a new "automatic commit" from "cyrusdocgen" on
-   https://github.com/cyrusimap/cyrusimap.github.io -- that's the result of
-   the run-gp.sh script having run.
 
 First beta
 ==========
@@ -363,11 +359,10 @@ For this one, we've got a little more housekeeping to do.
    numbers in the "rst_prolog" section.  Go through the old branches and
    update each's `docsrc/conf.py` to contain the same lie.  Commit and push
    these as you go.
-3. Remember the `run-gp.sh` script from the cyrusimap.org repository?  Go and
-   move the ``rsync ... $target`` and ``rsync ... $target/stable`` lines from
-   the block for what is now the previous stable release, into the block for
-   the new version (don't forget to update the numbers embedded in these lines
-   too).  Once this is pushed, the next website rebuild will make it all true.
+3. Remember the `build-cyrus-site` script from the cyrusimap.github.io
+   repository?  Go and remove the ``[ '/<version>', '/', '/stable ]`` slug from
+   the previous stable version and add it (changing the version!) to the new
+   one.  Once this is pushed, the next website rebuild will make it all true.
 4. Once the website is fully updated, send that announcement email.
 
 Post-release

--- a/docsrc/imap/developer/releasing.rst
+++ b/docsrc/imap/developer/releasing.rst
@@ -37,14 +37,14 @@ Release notes
 
 Write up the release notes, and add them to the appropriate location under
 ``docsrc/imap/download/release-notes/``.  They will not yet be linked up.
+Build the documentation locally with ``make doc-html``, then check the new
+release notes file in your brower to make sure it's correct and complete.
+It will be in ``doc/html/imap/download/release-notes/...``.
 
-Commit and push your changes, and then wait for cyrusimap.org to rebuild
-(happens each hour, and takes a few mins, so check at about 5 past).  The
-new release notes will be available at their direct URL -- easiest way to
-find it is to browse to some earlier version's release notes, then change
-version in the address bar to load up the new one.  Confirm that they are
-correct and complete.
-
+Commit the new release notes with a message like ``docs: release notes for
+cyrus-imapd <version>``, but don't push it yet.  You might want to keep these
+release commits on a separate branch for now, so you can rebase it if the real
+branch changes along the way.
 
 Pre-release testing
 ===================
@@ -73,8 +73,8 @@ Pre-release testing
    vi.   Run the unit tests: ``make -j4 check`` -- they should pass.
    vii.  Install it to your Cassandane prefix: ``make install``
    viii. Then run Cassandane normally -- it should pass.
-   ix.   If any of this fails, fix it, commit it, then restart the pre-release
-         testing.
+   ix.   If any of this fails, fix it, commit it, land it upstream, then
+         restart the pre-release testing.
 
 Linking up release notes
 ========================
@@ -85,19 +85,17 @@ point, but for now the easiest thing to do is look for lines containing the
 previous version and, if it makes sense to do so, update them to contain the
 new version.
 
-After this change is committed and pushed upstream, the cyrusimap.org website
-will start showing the new version as the "current" version at the next hourly
-update.  So ellie likes to do this step at about 5-10 past the hour, which then
-gives her 50 minutes to finish the rest of the release process without the
-website updating before the downloads are available.
+Commit this on your WIP branch with a message like ``docs: cyrus-imapd
+<version> released``.  This is usually the commit you'll end up tagging as the
+release.
 
 
 Version tagging
 ===============
 
-Note: it is absolutely critical that your repository is clean and your local
-commits have been pushed upstream at this point.  If they are not, and if
-anybody else pushes in the meantime, you will end up with a mess.
+Note: it is critical that your local copy of the branch you'll be releasing to
+is clean and up to date, and that your WIP branch (if any) is a direct
+descendant of it, otherwise you may end up with a mess later.
 
 1. Ensure your repository is clean again: ``git clean -dfx``
 2. Create a signed, annotated tag for the new version: ``git tag -s cyrus-imapd-<version>``
@@ -121,7 +119,10 @@ anybody else pushes in the meantime, you will end up with a mess.
 9. Sign the distribution tarball: ``gpg --sign -b cyrus-imapd-<version>.tar.gz``
 10. Ellie also likes to copy the tarball and signature file somewhere safe,
     just in case something happens between now and uploading.
-11. Push the tag upstream: ``git push ci cyrus-imapd-<version>`` (assuming your
+11. If you've been using a WIP branch for the release notes and docsrc/conf.py
+    changes, fast forward your commits onto the real branch and push it
+    upstream.
+12. Push the tag upstream: ``git push ci cyrus-imapd-<version>`` (assuming your
     remote is named "ci").
 
 
@@ -132,20 +133,25 @@ The website is built from an amalgamation of documentation from:
 
 * The current stable cyrus-imapd branch (top level)
 * The current master cyrus-imapd branch (``/dev`` hierarchy)
-* Each of the following cyrus-imapd branches (``/x.y`` hierarchies)
-
-    - cyrus-imapd-2.5
-    - cyrus-imapd-3.0
-    - cyrus-imapd-3.2
-
+* The release-numbered cyrus-imapd branches (``/x.y`` hierarchies)
 * The current master cyrus-sasl branch (``/sasl`` hierarchy)
 
 When making a cyrus-imapd release, you need to add the new release notes
-file to each relevant cyrus-imapd branch.  You also need to check and
-update the contents of ``docsrc/conf.py`` on each branch AND the cyrus-sasl
-repository.
+file to each relevant cyrus-imapd branch, including master and the current
+stable branch.  You also need to check and update the contents of
+``docsrc/conf.py`` on each branch AND the cyrus-sasl repository.
 
-This step often gets forgotten, so if you actually follow it, and notice
+For the cyrus-imapd branches, you can mostly just cherry-pick the two release
+commits around.  The docsrc/conf.py changes may not pick cleanly to the master
+branch but it's not hard to figure out how to massage it.
+
+For cyrus-sasl, manually update its docsrc/conf.py with the correct cyrus-imapd
+version numbers, commit it with a similar message, and push it.  If in doubt,
+have a look at previous commits that modified this file for inspiration.  If
+you don't have push access to the cyrus-sasl repository, check with someone who
+does.
+
+This step sometimes gets forgotten, so if you actually follow it, and notice
 some missing versions, just go ahead and add them while you're there.
 
 Uploading


### PR DESCRIPTION
The way we update the website has changed as of earlier this year, so I've updated the documentation to describe the new process.  I've also updated a handful of other details while I was at it, so the documented process more closely reflects what I actually do.