### PR TITLE
mailbox.c: fix a v10 repack bug and plug a memory leak

### DIFF
--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -619,7 +619,18 @@ sub test_downgrade_upgrade
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 
-    for my $version (12, 14, 16, 'max') {
+    for my $version (18, 17, 16, 15, 14, 13, 12, 10, 9, 8, 7, 6) {
+        xlog $self, "Set to version $version";
+        $self->{instance}->run_command({ cyrus => 1 }, 'reconstruct', '-V', $version);
+
+        xlog $self, "Reconnect, \\Seen should still be on message A";
+        $self->{store}->disconnect();
+        $self->{store}->connect();
+        $self->{store}->_select();
+        $self->check_messages(\%msg);
+    }
+
+    for my $version (6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 'max') {
         xlog $self, "Set to version $version";
         $self->{instance}->run_command({ cyrus => 1 }, 'reconstruct', '-V', $version);
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5157,8 +5157,8 @@ HIDDEN int mailbox_repack_commit(struct mailbox_repack **repackptr)
         if (r) goto fail;
     }
 
-    if (repack->newmailbox.i.minor_version >= 10 &&
-            repack->mailbox->i.minor_version >= 10 &&
+    if (repack->newmailbox.i.minor_version > 10 &&
+            repack->mailbox->i.minor_version > 10 &&
             !mailbox_crceq(repack->newmailbox.i.synccrcs, repack->crcs)) {
         xsyslog(LOG_ERR, "IOERROR: CRC mismatch on repack commit",
                          "mailbox=<%s> oldbasic=<%u> newbasic=<%u> "
@@ -5179,6 +5179,7 @@ HIDDEN int mailbox_repack_commit(struct mailbox_repack **repackptr)
         int r = seen_open(repack->userid, SEEN_CREATE, &seendb);
         if (!r) r = seen_lockread(seendb, mailbox_uniqueid(repack->mailbox), &sd);
         if (!r) {
+            seen_freedata(&sd);
             sd.lastuid = repack->newmailbox.i.last_uid;
             sd.seenuids = seqset_cstring(repack->seqset);
             if (!sd.seenuids) sd.seenuids = xstrdup("");

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2071,7 +2071,7 @@ static int mailbox_buf_to_index_record(const char *buf, int version,
 
     if (version < 10) {
         /* modseq was at 72 before the GUID move */
-        record->modseq = ntohll(*((bit64 *)(buf+72)));
+        record->modseq = align_ntohll(buf+72);
         return 0;
     }
 


### PR DESCRIPTION
Found this while rewriting the read/write code on a separate branch.  Figured it made sense to get this fix into master first.