### PR TITLE
Revert "slowio: Use CLOCK_PROCESS_CPUTIME_ID instead of CLOCK_MONOTONIC"

### DIFF
--- a/cunit/slowio.testc
+++ b/cunit/slowio.testc
@@ -3,7 +3,6 @@
 #include "lib/util.h"
 
 #include <inttypes.h>
-#include <stdint.h>
 
 #if HAVE_VALGRIND_VALGRIND_H
 #include <valgrind/valgrind.h>
@@ -113,26 +112,6 @@ static void test_limit2(void)
     }
 }
 
-static void busywait_for(double howlong)
-{
-    struct timespec start;
-    int64_t max_tries = INT64_MAX;
-
-    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &start);
-
-    for (int64_t i = 0; i < max_tries; i++) {
-        struct timespec now;
-        clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &now);
-
-        double elapsed = (double)(now.tv_sec - start.tv_sec);
-        elapsed += (double)(now.tv_nsec - start.tv_nsec) / 1000000000.0;
-
-        if (elapsed > howlong) {
-            break;
-        }
-    }
-}
-
 static void test_slower_than_rate_limit(void)
 {
     struct slowio slowio = {0}, saved_slowio;
@@ -144,7 +123,8 @@ static void test_slower_than_rate_limit(void)
 
     /* pretend we're reading/writing slightly slower than the rate limit */
     for (i = 1; i <= 4; i++) {
-        busywait_for(i + .001); /* 1 ms over */
+        struct timespec io_delay = { i, 1000000 }; /* 1 ms over */
+        nanosleep(&io_delay, NULL);
 
         memcpy(&saved_slowio, &slowio, sizeof(slowio));
         start = now_ms();

--- a/lib/slowio.c
+++ b/lib/slowio.c
@@ -76,7 +76,7 @@ EXPORTED void slowio_maybe_delay_impl(struct slowio *slowio, ssize_t n_bytes)
 
     if (n_bytes < 0) return; /* that wasn't a valid I/O op! */
 
-    if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &now)) {
+    if (clock_gettime(CLOCK_MONOTONIC, &now)) {
         xsyslog(LOG_DEBUG, "clock_gettime failed", NULL);
         errno = 0;
         return;
@@ -121,7 +121,7 @@ EXPORTED void slowio_maybe_delay_impl(struct slowio *slowio, ssize_t n_bytes)
             r = nanosleep(&sleeptime, &sleeptime);
         } while (r == -1 && errno == EINTR);
 
-        clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &slowio->last_delay);
+        clock_gettime(CLOCK_MONOTONIC, &slowio->last_delay);
         slowio->bytes_since_last_delay = 0;
     }
 }


### PR DESCRIPTION
This reverts commit e221e564c07379c85214733ce721ab3e35317d99. On NixOS and CentOS (at least) multiple calls to clock_gettime using CLOCK_PROCESS_CPUTIME_ID often return identical values (?!) which breaks the cunit slowio tests.

We'll have to figure out something else to stop this from failing across all platforms...