### PR TITLE
github-actions: valgrind 'check-discrete' rather than 'check'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
     - name: make check with valgrind
       shell: bash
       run: |
-        make VG=1 check
+        make VG=1 check-discrete
     - name: report version information
       shell: bash
       run: |


### PR DESCRIPTION
This gives us a valgrind report per test, rather than a single confusing report for the entire run.  It takes longer to run in the usual case, but when something does fail, the error report is easier to understand.

Is the longer run time tolerable?