### PR TITLE
master: tighten up pidfile/etc handling

### DIFF
--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -1341,6 +1341,77 @@ sub test_sighup_reloading_proto
         $self->lemming_census());
 }
 
+sub test_pidfile_symlink
+{
+    my ($self) = @_;
+
+    $self->{instance}->_init_basedir_and_name();
+
+    # XXX it would be nice to put the symlink in the basedir, but anything
+    # XXX we put in there before start will be blown away by _build_skeleton.
+    # XXX instead, set stuff up in /tmp where it won't get trampled before use
+    my $tmp = "/tmp/cassandane-$self->{instance}->{name}";
+    my $symlink_target = "$tmp/rogue_master_pidfile";
+    my $pidfile = "$tmp/master.pid";
+
+    mkdir $tmp or die "mkdir $tmp: $!";
+    symlink $symlink_target, $pidfile
+        or die "symlink $symlink_target $pidfile: $!";
+
+    $self->{instance}->{config}->set('master_pid_file', $pidfile);
+
+    eval {
+        $self->start();
+    };
+    my $e = $@;
+    $self->assert_matches(qr{exited with code 71}, $e->text());
+
+    $self->assert_num_equals(0, $self->{instance}->is_running());
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{can't open pidfile: Too many levels});
+
+    unlink $pidfile;
+    unlink $symlink_target;
+    rmdir $tmp;
+}
+
+sub test_pidfile_lock_symlink
+{
+    my ($self) = @_;
+
+    $self->{instance}->_init_basedir_and_name();
+
+    # XXX it would be nice to put the symlink in the basedir, but anything
+    # XXX we put in there before start will be blown away by _build_skeleton.
+    # XXX instead, set stuff up in /tmp where it won't get trampled before use
+    my $tmp = "/tmp/cassandane-$self->{instance}->{name}";
+    my $symlink_target = "$tmp/rogue_master_pidfile_lock";
+    my $pidfile = "$tmp/master.pid";
+    my $pidfile_lock = "$pidfile.lock";
+
+    mkdir $tmp or die "mkdir $tmp: $!";
+    symlink $symlink_target, $pidfile_lock
+        or die "symlink $symlink_target $pidfile_lock: $!";
+
+    $self->{instance}->{config}->set('master_pid_file', $pidfile);
+
+    eval {
+        $self->start();
+    };
+    my $e = $@;
+    $self->assert_matches(qr{exited with code 71}, $e->text());
+
+    $self->assert_num_equals(0, $self->{instance}->is_running());
+    $self->assert_syslog_matches(
+        $self->{instance},
+        qr{can't open pidfile lock: \S+ \(Too many levels}
+    );
+
+    unlink $pidfile_lock;
+    unlink $symlink_target;
+    rmdir $tmp;
+}
+
 sub test_ready_file
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -942,8 +942,6 @@ sub _read_pid_file
     my $file = $self->_pid_file($name);
     my $pid;
 
-    return undef if ( ! -f $file );
-
     open PID,'<',$file
         or return undef;
     while(<PID>)
@@ -992,7 +990,6 @@ sub _start_master
         xlog "_start_master: logging to $logfile";
         push(@cmd, '-L', $logfile);
     }
-    unlink $self->_pid_file();
     # Start master daemon
     $self->run_command({ cyrus => 1 }, @cmd);
 

--- a/cassandane/utils/fakesaslauthd
+++ b/cassandane/utils/fakesaslauthd
@@ -50,7 +50,6 @@ my $sock = IO::Socket::UNIX->new(
     Listen => SOMAXCONN,
 );
 die "FAILED to create socket $opts{p}: $!" unless $sock;
-system "chmod 777 $opts{p}";
 syslog LOG_INFO, "listening on $opts{p}";
 
 my $shutdown = 0;

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -851,6 +851,19 @@ static void test_magic_configdirectory_default(void)
     CU_ASSERT_STRING_EQUAL(idlesocket, DBDIR"/conf/socket/idle");
 }
 
+static void test_configdirectory_missing(void)
+{
+    CU_EXPECT_CYRFATAL_BEGIN
+    config_read_string(
+        /* configdirectory not specified */
+        "annotation_db: twoskip\n"
+    );
+    CU_EXPECT_CYRFATAL_END(
+        EX_CONFIG,
+        "configdirectory option not specified in configuration file"
+    );
+}
+
 static void test_deprecated_int(void)
 {
     /* { "autocreatequotamsg", -1, INT, "2.5.0", "2.5.0", "autocreate_quota_messages" } */

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -311,13 +311,13 @@ CU_BOOL CU_assertFormatImplementation(
 
 EXPORTED void config_read_string(const char *s)
 {
-    char *fname = xstrdup("/tmp/cyrus-cunit-configXXXXXX");
+    char fname[] = "/tmp/cyrus-cunit-configXXXXXX";
     int fd = mkstemp(fname);
+
     retry_write(fd, s, strlen(s));
     config_reset();
     config_read(fname, 0);
     xunlink(fname);
-    free(fname);
     close(fd);
 }
 

--- a/cunit/vg.supp
+++ b/cunit/vg.supp
@@ -43,22 +43,6 @@
     # The libconfig:*_invalid tests all fatal out from in libconfig, which
     # is fine in reality, but under CUnit we're trapping the fatal and not
     # actually exiting.  Which means we detect some leaks that aren't real.
-    config_read_string_fname_leak
-    Memcheck:Leak
-    match-leak-kinds: definite
-    fun:malloc
-    fun:xmalloc
-    fun:xstrdup
-    fun:config_read_string
-    fun:test_*_invalid
-    ...
-    obj:*/libcunit*
-    ...
-}
-{
-    # The libconfig:*_invalid tests all fatal out from in libconfig, which
-    # is fine in reality, but under CUnit we're trapping the fatal and not
-    # actually exiting.  Which means we detect some leaks that aren't real.
     config_read_file_buf_leak
     Memcheck:Leak
     match-leak-kinds: definite

--- a/imap/idlemsg.c
+++ b/imap/idlemsg.c
@@ -138,7 +138,6 @@ EXPORTED int idle_init_sock(const struct sockaddr_un *local)
         return 0;
     }
     umask(oldumask); /* for Linux */
-    chmod(local->sun_path, 0777); /* for DUX */
 
     idle_sock = s;
     idle_local = *local;

--- a/imap/mupdate-slave.c
+++ b/imap/mupdate-slave.c
@@ -95,7 +95,6 @@ static int open_kick_socket(void)
     oldumask = umask((mode_t) 0); /* for Linux */
     r = bind(s, (struct sockaddr *)&srvaddr, len);
     umask(oldumask); /* for Linux */
-    chmod(fnamebuf, 0777); /* for DUX */
     if (r == -1) {
         syslog(LOG_ERR, "bind: %s: %m", fnamebuf);
         fatal("bind failed", EX_OSERR);

--- a/master/master.c
+++ b/master/master.c
@@ -2927,6 +2927,23 @@ static void master_ready(const char *ready_file, int ready)
     }
 }
 
+static void chdir_cores(void)
+{
+    /* Set the current working directory where cores can go to die. */
+    const char *path = config_getstring(IMAPOPT_CONFIGDIRECTORY);
+    /* XXX configdirectory is required, so it should never be NULL... */
+    if (path == NULL) {
+        path = getenv("TMPDIR");
+        if (path == NULL)
+            path = "/tmp";
+    }
+    if (chdir(path))
+        fatalf(2, "couldn't chdir to %s: %m", path);
+    chdir("cores");
+    /* XXX ignoring error when "cores" subdirectory missing */
+    errno = 0;
+}
+
 int main(int argc, char **argv)
 {
     static const char lock_suffix[] = ".lock";
@@ -3069,17 +3086,6 @@ int main(int argc, char **argv)
             exit(EX_OSERR);
         }
 
-        /* Set the current working directory where cores can go to die. */
-        const char *path = config_getstring(IMAPOPT_CONFIGDIRECTORY);
-        if (path == NULL) {
-                path = getenv("TMPDIR");
-                if (path == NULL)
-                        path = "/tmp";
-        }
-        if (chdir(path))
-            fatalf(2, "couldn't chdir to %s: %m", path);
-        r = chdir("cores");
-
         do {
             pid = fork();
 
@@ -3210,6 +3216,7 @@ int main(int argc, char **argv)
         syslog(LOG_ERR, "can't change to the cyrus user: %m");
         exit(1);
     }
+    if (daemon_mode) chdir_cores();
 #endif
 
     masterconf_getsection("START", &add_start, NULL);
@@ -3235,6 +3242,7 @@ int main(int argc, char **argv)
         syslog(LOG_ERR, "can't change to the cyrus user: %m");
         exit(1);
     }
+    if (daemon_mode) chdir_cores();
 #endif
 
     /* init ctable janitor */

--- a/master/master.c
+++ b/master/master.c
@@ -693,12 +693,6 @@ static void service_create(struct service *s, int is_startup)
             continue;
         }
 
-        if (s->listen[0] == '/') { /* unix socket */
-            /* for DUX, where this isn't the default.
-               (harmlessly fails on some systems) */
-            chmod(s->listen, (mode_t) 0777);
-        }
-
         if ((!strcmp(s->proto, "tcp") || !strcmp(s->proto, "tcp4")
              || !strcmp(s->proto, "tcp6"))
             && listen(s->socket, listen_queue_backlog) < 0) {

--- a/master/master.c
+++ b/master/master.c
@@ -2931,12 +2931,10 @@ static void chdir_cores(void)
 {
     /* Set the current working directory where cores can go to die. */
     const char *path = config_getstring(IMAPOPT_CONFIGDIRECTORY);
-    /* XXX configdirectory is required, so it should never be NULL... */
-    if (path == NULL) {
-        path = getenv("TMPDIR");
-        if (path == NULL)
-            path = "/tmp";
-    }
+
+    /* configdirectory is required, so it should never be NULL... */
+    assert(path != NULL);
+
     if (chdir(path))
         fatalf(2, "couldn't chdir to %s: %m", path);
     chdir("cores");

--- a/master/master.c
+++ b/master/master.c
@@ -3020,10 +3020,10 @@ int main(int argc, char **argv)
         for (fd = 0; fd < 3; fd++) {
             const char *file = (error_log && fd > 0 ?
                                 error_log : "/dev/null");
-            int mode = (fd > 0 ? O_WRONLY : O_RDWR) |
-                       (error_log && fd > 0 ? O_CREAT|O_APPEND : 0);
+            int flags = (fd > 0 ? O_WRONLY : O_RDWR)
+                        | (error_log && fd > 0 ? O_CREAT|O_APPEND|O_NOFOLLOW : 0);
             close(fd);
-            if (open(file, mode, 0666) != fd)
+            if (open(file, flags, 0666) != fd)
                 fatalf(2, "couldn't open %s: %m", file);
         }
     }
@@ -3052,7 +3052,7 @@ int main(int argc, char **argv)
 
         pidfile_lock = strconcat(pidfile, lock_suffix, (char *)NULL);
 
-        pidlock_fd = open(pidfile_lock, O_CREAT|O_TRUNC|O_RDWR, 0644);
+        pidlock_fd = open(pidfile_lock, O_CREAT|O_TRUNC|O_RDWR|O_NOFOLLOW, 0644);
         if (pidlock_fd == -1) {
             syslog(LOG_ERR, "can't open pidfile lock: %s (%m)", pidfile_lock);
             exit(EX_OSERR);
@@ -3127,7 +3127,7 @@ int main(int argc, char **argv)
     }
 
     /* Write out the pidfile */
-    pidfd = open(pidfile, O_CREAT|O_RDWR, 0644);
+    pidfd = open(pidfile, O_CREAT|O_RDWR|O_NOFOLLOW, 0644);
     if (pidfd == -1) {
         int exit_result = EX_OSERR;
 


### PR DESCRIPTION
This improves a few aspects of the master binary's file and filesystem handling:

* When opening or creating `pidfile`, `pidfile_lock`, and `error_log` during startup (i.e. probably as root), don't permit symlinks to be followed.
* Don't chdir to the cores directory until after dropping privileges.

And in general:

* No need to chmod unix domain sockets