### PR TITLE
JMAPTestSuite: suppress t:core:jmap-session-resource before 3.13

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPTestSuite.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuite.pm
@@ -66,6 +66,8 @@ my %notbefore = (
     't:Email:get:header-header-field-name' => '3.5',
     't:Email:import:good-imports' => '3.8',
     't:Email:import:one-fails-another-succeeds' => '3.8',
+    't:core:jmap-session-resource' => '3.13',
+    't:core:jmap-session-resource' => '3.13',
 );
 
 # Tests which JMAP-TestSuite will skip anyway when it detects it's

--- a/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
@@ -67,6 +67,8 @@ my %notbefore = (
     't:Email:get:header-header-field-name' => '3.5',
     't:Email:import:good-imports' => '3.8',
     't:Email:import:one-fails-another-succeeds' => '3.8',
+    't:core:jmap-session-resource' => '3.13',
+    't:core:jmap-session-resource' => '3.13',
 );
 
 # Tests which JMAPTestSuite will skip anyway when it detects it's


### PR DESCRIPTION
... and same for JMAPTestSuiteWS.  These tests [have been updated](https://github.com/fastmail/JMAP-TestSuite/pull/40) and no longer pass on 3.12 or earlier