### PR TITLE
imapd: fix typo in SASL-IR capability

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -461,7 +461,7 @@ static struct capa_struct base_capabilities[] = {
     { "QUOTASET",              CAPA_POSTAUTH,           { 0 } }, /* RFC 9208 */
     { "REPLACE",               CAPA_POSTAUTH,           { 0 } }, /* RFC 8508 */
     { "RIGHTS=kxten",          CAPA_POSTAUTH,           { 0 } }, /* RFC 4314 */
-    { "SASL_IR",               CAPA_PREAUTH,            { 0 } }, /* RFC 4959 */
+    { "SASL-IR",               CAPA_PREAUTH,            { 0 } }, /* RFC 4959 */
     { "SAVEDATE",              CAPA_POSTAUTH,           { 0 } }, /* RFC 8514 */
     { "SAVELIMIT=",            0, /* not implemented */ { 0 } }, /* RFC 9738 */
     { "SEARCH=FUZZY",          CAPA_POSTAUTH,           { 0 } }, /* RFC 6203 */


### PR DESCRIPTION
Fixes #5481

I don't see a good way to test this.  It is possible to coerce Cassandane and Mail::IMAPTalk into using AUTHENTICATE instead of LOGIN, but then Mail::IMAPTalk doesn't expose the details of the SASL transaction, so I can't interrogate whether the initial response was actually used or not.