### PR TITLE
reconstruct.c: implement use of --dry-run (-n) with --set-version (-V)

### DIFF
--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -580,6 +580,57 @@ sub test_reconstruct_uniqueid_from_header_uuidmb
     $self->assert_str_equals("user\x1fcassandane", $hash->{N});
 }
 
+sub test_downgrade_dryrun
+{
+    my ($self) = @_;
+
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "Add two messages";
+    $self->make_message('Message A');
+    $self->make_message('Message B');
+
+    my $dir = $self->{instance}->folder_to_directory('user.cassandane');
+    my $file = "$dir/cyrus.index";
+    my $fh = IO::File->new($file, "+<");
+    die "NO SUCH FILE $file" unless $fh;
+    my $index = Cyrus::IndexFile->new($fh);
+    $fh->close();
+
+    my $version = $index->header('MinorVersion');
+    my $hdr_size = $index->header('StartOffset');
+    my $rec_size = $index->header('RecordSize');
+    $self->assert_num_equals(2, $index->header('Exists'));
+
+    xlog $self, "Test setting to version 13";
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'reconstruct', '-n', '-V', '13');
+
+    $fh = IO::File->new($file, "+<");
+    die "NO SUCH FILE $file" unless $fh;
+    $index = Cyrus::IndexFile->new($fh);
+    $fh->close();
+
+    $self->assert_num_equals($version, $index->header('MinorVersion'));
+    $self->assert_num_equals($hdr_size, $index->header('StartOffset'));
+    $self->assert_num_equals($rec_size, $index->header('RecordSize'));
+    $self->assert_num_equals(2, $index->header('Exists'));
+
+    xlog $self, "Actually set to version 13";
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'reconstruct', '-V', '13');
+
+    $fh = IO::File->new($file, "+<");
+    die "NO SUCH FILE $file" unless $fh;
+    $index = Cyrus::IndexFile->new($fh);
+    $fh->close();
+
+    $self->assert_num_equals(13, $index->header('MinorVersion'));
+    $self->assert_num_equals(128, $index->header('StartOffset'));
+    $self->assert_num_equals(104, $index->header('RecordSize'));
+    $self->assert_num_equals(2, $index->header('Exists'));
+}
+
 sub test_downgrade_upgrade
 {
     my ($self) = @_;

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -697,7 +697,7 @@ extern int mailbox_reconstruct(const char *name, int flags, struct mailbox **mai
 extern void mailbox_set_uniqueid(struct mailbox *mailbox, const char *uniqueid);
 extern void mailbox_set_mbtype(struct mailbox *mailbox, uint32_t mbtype);
 
-extern int mailbox_setversion(struct mailbox *mailbox, int version);
+extern int mailbox_setversion(struct mailbox *mailbox, int version, int dryrun);
 
 extern int mailbox_index_recalc(struct mailbox *mailbox);
 

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -517,10 +517,14 @@ static int do_reconstruct(struct findall_data *data, void *rock)
         if (setversion != mailbox->i.minor_version) {
             int oldversion = mailbox->i.minor_version;
             /* need to re-set the version! */
-            int r = mailbox_setversion(mailbox, setversion);
+            int r = mailbox_setversion(mailbox, setversion, !make_changes);
             char *extname = mboxname_to_external(name, &recon_namespace, NULL);
             if (r) {
                 printf("FAILED TO REPACK %s with new version %s\n", extname, error_message(r));
+            }
+            else if (!make_changes){
+                printf("Test conversion %s version %d to %d succeeded\n",
+                       extname, oldversion, setversion);
             }
             else {
                 printf("Converted %s version %d to %d\n", extname, oldversion, setversion);


### PR DESCRIPTION
reconstruct will still report repack errors,
but the new cyrus.index will not be written to disk