### PR TITLE
Use initializer macros rather than memset() in jmap_*_parse() functions

### DIFF
--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1538,8 +1538,7 @@ HIDDEN void jmap_get_parse(jmap_req_t *req,
     json_t *arg, *val;
     size_t i;
 
-    memset(get, 0, sizeof(struct jmap_get));
-
+    // assume that we are given an initialized jmap_get struct
     get->list = json_array();
     get->not_found = json_array();
 
@@ -1763,7 +1762,8 @@ HIDDEN void jmap_set_parse(jmap_req_t *req, struct jmap_parser *parser,
                            struct jmap_set *set, json_t **err)
 {
     json_t *jargs = req->args;
-    memset(set, 0, sizeof(struct jmap_set));
+
+    // assume that we are given an initialized jmap_set struct
     set->create = json_object();
     set->update = json_object();
     set->destroy = json_array();
@@ -1976,7 +1976,7 @@ HIDDEN void jmap_changes_parse(jmap_req_t *req,
     json_t *arg;
     int have_sincemodseq = 0;
 
-    memset(changes, 0, sizeof(struct jmap_changes));
+    // assume that we are given an initialized jmap_changes struct
     changes->created = json_array();
     changes->updated = json_array();
     changes->destroyed = json_array();
@@ -2056,7 +2056,7 @@ HIDDEN void jmap_copy_parse(jmap_req_t *req, struct jmap_parser *parser,
 {
     json_t *jargs = req->args;
 
-    memset(copy, 0, sizeof(struct jmap_copy));
+    // assume that we are given an initialized jmap_copy struct
     copy->blob_copy = !strcmp(req->method, "Blob/copy");
     copy->create = copy->blob_copy ? json_array() : json_object();
     copy->created = json_object();
@@ -2376,7 +2376,7 @@ HIDDEN void jmap_query_parse(jmap_req_t *req, struct jmap_parser *parser,
     json_t *arg, *val;
     size_t i;
 
-    memset(query, 0, sizeof(struct jmap_query));
+    // assume that we are given an initialized jmap_query struct
     query->ids = json_array();
     query->have_total = 1; /* assume we know the total, we turn it off it not */
 
@@ -2545,7 +2545,7 @@ HIDDEN void jmap_querychanges_parse(jmap_req_t *req,
     json_t *arg, *val;
     size_t i;
 
-    memset(query, 0, sizeof(struct jmap_querychanges));
+    // assume that we are given an initialized jmap_querychanges struct
     query->removed = json_array();
     query->added = json_array();
 
@@ -2693,8 +2693,7 @@ HIDDEN void jmap_parse_parse(jmap_req_t *req,
     const char *key;
     json_t *arg;
 
-    memset(parse, 0, sizeof(struct jmap_parse));
-
+    // assume that we are given an initialized jmap_parse struct
     parse->parsed = json_object();
     parse->not_parsable = json_array();
     parse->not_found = json_array();

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -368,6 +368,8 @@ struct jmap_get {
     json_t *not_found;
 };
 
+#define JMAP_GET_INITIALIZER {0}
+
 typedef int jmap_args_parse_cb(jmap_req_t *, struct jmap_parser *,
                                const char *arg, json_t *val, void *);
 
@@ -401,6 +403,8 @@ struct jmap_set {
     json_t *not_updated;
     json_t *not_destroyed;
 };
+
+#define JMAP_SET_INITIALIZER {0}
 
 extern void jmap_set_parse(jmap_req_t *req, struct jmap_parser *parser,
                            const jmap_property_t valid_props[],
@@ -454,6 +458,8 @@ struct jmap_copy {
     json_t *not_created;
 };
 
+#define JMAP_COPY_INITIALIZER {0}
+
 extern void jmap_copy_parse(jmap_req_t *req, struct jmap_parser *parser,
                             jmap_args_parse_cb args_parse, void *args_rock,
                             struct jmap_copy *copy, json_t **err);
@@ -484,6 +490,8 @@ struct jmap_query {
     int have_total; /* for calculateTotal: false partial */
     json_t *ids;
 };
+
+#define JMAP_QUERY_INITIALIZER {0}
 
 enum jmap_filter_op   {
     JMAP_FILTER_OP_NONE = 0,
@@ -558,6 +566,8 @@ struct jmap_querychanges {
     json_t *added;
 };
 
+#define JMAP_QUERYCHANGES_INITIALIZER {0}
+
 extern void jmap_querychanges_parse(jmap_req_t *req,
                                     struct jmap_parser *parser,
                                     jmap_args_parse_cb args_parse, void *args_rock,
@@ -582,6 +592,8 @@ struct jmap_parse {
     json_t *not_parsable;
     json_t *not_found;
 };
+
+#define JMAP_PARSE_INITIALIZER {0}
 
 extern void jmap_parse_parse(jmap_req_t *req, struct jmap_parser *parser,
                                  jmap_args_parse_cb args_parse, void *args_rock,

--- a/imap/jmap_blob.c
+++ b/imap/jmap_blob.c
@@ -270,7 +270,7 @@ done:
 static int jmap_blob_copy(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_copy copy;
+    struct jmap_copy copy = JMAP_COPY_INITIALIZER;
     json_t *val, *err = NULL;
     size_t i = 0;
     int r = 0;
@@ -465,7 +465,7 @@ static int _parse_range(jmap_req_t *req __attribute__((unused)),
 static int jmap_blob_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     json_t *jval;
     size_t i;
@@ -704,7 +704,7 @@ static int caleventid_cb(void *vrock, struct caldav_jscal *jscal)
 static int jmap_blob_lookup(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     int32_t datatypes = 0;
     json_t *err = NULL;
     struct buf buf = BUF_INITIALIZER;
@@ -1099,7 +1099,7 @@ static int _upload_arg_to_buf(struct jmap_req *req, struct buf *buf, json_t *arg
 static int jmap_blob_upload(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *jerr = NULL;
     int r = 0;
     time_t now = time(NULL);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1005,7 +1005,7 @@ static int has_calendars(jmap_req_t *req)
 static int jmap_calendar_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     int r = 0;
 
@@ -2203,7 +2203,7 @@ static int jmap_calendar_set(struct jmap_req *req)
 {
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     struct jmap_parser argparser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     int on_destroy_remove_events = 0;
     json_t *err = NULL;
     int r = 0;
@@ -3992,7 +3992,7 @@ static int getcalendarevents_parse_args(jmap_req_t *req __attribute__((unused)),
 static int jmap_calendarevent_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     struct caldav_db *db = NULL;
     json_t *err = NULL;
     int r = 0;
@@ -6167,7 +6167,7 @@ static int setcalendarevents_parse_args(jmap_req_t *req __attribute__((unused)),
 static int jmap_calendarevent_set(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
     struct caldav_db *db = NULL;
     struct jmap_caleventid *eid = NULL;
@@ -7514,7 +7514,7 @@ static int calendarevent_validatecomparator(jmap_req_t *req __attribute__((unuse
 static int jmap_calendarevent_query(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     struct eventquery_args args = JMAPICAL_EVENTQUERY_ARGS_INITIALIZER;
 
     /* Parse request */
@@ -7702,7 +7702,7 @@ done:
 static int jmap_calendarevent_copy(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_copy copy;
+    struct jmap_copy copy = JMAP_COPY_INITIALIZER;
     json_t *err = NULL;
     struct caldav_db *src_db = NULL;
     struct caldav_db *dst_db = NULL;
@@ -7884,7 +7884,7 @@ static int _calendareventparse_args_parse(jmap_req_t *req,
 static int jmap_calendarevent_parse(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_parse parse;
+    struct jmap_parse parse = JMAP_QUERYCHANGES_INITIALIZER;
     struct calendareventparse_args args = { 0 };
     json_t *err = NULL;
 
@@ -8622,7 +8622,7 @@ static int principal_get_cb(jmap_req_t *req, const char *accountid,
 static int jmap_principal_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
 
     jmap_get_parse(req, &parser, calendarprincipal_props, 0, NULL, NULL, &get, &err);
@@ -9108,7 +9108,7 @@ done:
 static int jmap_principal_query(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
 
     /* Parse request */
     json_t *err = NULL;
@@ -9165,7 +9165,7 @@ static int jmap_principal_changes(struct jmap_req *req)
 static int jmap_principal_querychanges(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_querychanges query;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
 
     json_t *err = NULL;
     jmap_querychanges_parse(req, &parser, NULL, NULL,
@@ -9187,7 +9187,7 @@ done:
 static int jmap_principal_set(struct jmap_req *req)
 {
     struct jmap_parser argparser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
 
     jmap_set_parse(req, &argparser, calendarprincipal_props, NULL, NULL, &set, &err);
@@ -10610,7 +10610,7 @@ done:
 static int jmap_sharenotification_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     mbentry_t *notifymb = NULL;
 
@@ -10662,7 +10662,7 @@ static int jmap_sharenotification_set(struct jmap_req *req)
 {
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     struct jmap_parser argparser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
     mbentry_t *notifmb = NULL;
 
@@ -10851,7 +10851,7 @@ static int sharenotif_match(message_t *msg, struct notifsearch_entry *entry, voi
 static int jmap_sharenotification_query(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     struct mailbox *notifmbox = NULL;
     mbentry_t *notifmb = NULL;
 
@@ -10969,7 +10969,7 @@ done:
 static int jmap_sharenotification_querychanges(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_querychanges query;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
 
     json_t *err = NULL;
     jmap_querychanges_parse(req, &parser, NULL, NULL,
@@ -11124,7 +11124,7 @@ done:
 static int jmap_calendareventnotification_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     char *notifmboxname = jmap_notifmboxname(req->accountid);
     char *notfrom = jmap_caleventnotif_format_fromheader(req->userid);
@@ -11308,7 +11308,7 @@ static int eventnotif_match(message_t *msg, struct notifsearch_entry *entry, voi
 static int jmap_calendareventnotification_query(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     struct mailbox *notifmbox = NULL;
     hash_table eventids = HASH_TABLE_INITIALIZER;
 
@@ -11440,7 +11440,7 @@ static int jmap_calendareventnotification_set(struct jmap_req *req)
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     char *notifmboxname = jmap_notifmboxname(req->accountid);
     struct jmap_parser argparser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
     mbentry_t *notifmb = NULL;
 
@@ -11528,7 +11528,7 @@ static int jmap_calendareventnotification_changes(struct jmap_req *req)
 static int jmap_calendareventnotification_querychanges(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_querychanges query;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
 
     json_t *err = NULL;
     jmap_querychanges_parse(req, &parser, NULL, NULL,
@@ -11581,7 +11581,7 @@ static void encode_participantidentity_id(struct buf *buf, const char *addr)
 static int jmap_participantidentity_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     int r = 0;
     struct buf buf = BUF_INITIALIZER;
@@ -11676,7 +11676,7 @@ done:
 static int jmap_participantidentity_set(struct jmap_req *req)
 {
     struct jmap_parser argparser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
     int r = 0;
 
@@ -11868,7 +11868,7 @@ static const jmap_property_t calendarpreferences_props[] = {
 static int jmap_calendarpreferences_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     struct buf buf = BUF_INITIALIZER;
     char *calhomename = NULL;
@@ -12119,7 +12119,7 @@ done:
 static int jmap_calendarpreferences_set(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
     int r = 0;
 

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -756,7 +756,7 @@ static int _contacts_get(struct jmap_req *req, carddav_cb_t *cb, int kind,
     }
 
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     struct carddav_db *db = NULL;
     mbentry_t *mbentry = NULL;
@@ -1101,7 +1101,7 @@ static void _contacts_set(struct jmap_req *req, unsigned kind,
                                              jmap_contact_errors_t *errors))
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
     int r = 0;
 
@@ -3021,7 +3021,7 @@ static int _contactsquery(struct jmap_req *req, unsigned kind,
     }
 
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     struct carddav_db *db;
     jmap_filter *parsed_filter = NULL;
     int r = 0;
@@ -4732,7 +4732,7 @@ static int _contacts_copy(struct jmap_req *req,
                                              jmap_contact_errors_t *errors))
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_copy copy;
+    struct jmap_copy copy = JMAP_COPY_INITIALIZER;
     json_t *err = NULL;
     struct carddav_db *src_db = NULL;
     json_t *destroy_cards = json_array();
@@ -5070,7 +5070,7 @@ static const jmap_property_t addressbook_props[] = {
 static int jmap_addressbook_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     int r = 0;
 
@@ -5709,7 +5709,7 @@ static int jmap_addressbook_set(struct jmap_req *req)
 {
     struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     struct jmap_parser argparser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     int on_destroy_remove_contents = 0;
     json_t *err = NULL;
     int r = 0;
@@ -11943,7 +11943,7 @@ static int jmap_card_query(struct jmap_req *req)
 static int jmap_card_querychanges(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_querychanges query;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
 
     json_t *err = NULL;
     jmap_querychanges_parse(req, &parser, NULL, NULL,
@@ -12018,7 +12018,7 @@ static int _card_parseargs_parse(jmap_req_t *req __attribute__((unused)),
 static int jmap_card_parse(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_parse parse;
+    struct jmap_parse parse = JMAP_QUERYCHANGES_INITIALIZER;
     struct card_parseargs args = {0};
     struct carddav_db *db = NULL;
     json_t *err = NULL;

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -462,7 +462,7 @@ static void usercounters_get(jmap_req_t *req, struct jmap_get *get)
 static int jmap_usercounters_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
 
     /* Parse request */

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5011,7 +5011,7 @@ static int emailquery_args_parse(jmap_req_t *req,
 static int jmap_email_query(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct emailquery query;
+    struct emailquery query = JMAP_QUERY_INITIALIZER;
     struct email_contactfilter contactfilter;
     int r = 0;
 
@@ -5437,7 +5437,7 @@ done:
 static int jmap_email_querychanges(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_querychanges query;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
     struct emailquery emailquery;
     struct email_contactfilter contactfilter;
 
@@ -6399,7 +6399,7 @@ static const jmap_property_t thread_props[] = {
 static int jmap_thread_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
 
     /* Parse request */
@@ -8635,7 +8635,7 @@ static const jmap_property_t email_props[] = {
 static int jmap_email_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     struct email_getargs args = _EMAIL_GET_ARGS_INITIALIZER;
     json_t *err = NULL;
 
@@ -8733,7 +8733,7 @@ static int _email_parseargs_parse(jmap_req_t *req,
 static int jmap_email_parse(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_parse parse;
+    struct jmap_parse parse = JMAP_QUERYCHANGES_INITIALIZER;
     struct email_getargs getargs = _EMAIL_GET_ARGS_INITIALIZER;
     struct email_parseargs parseargs = { NULL, &getargs };
     json_t *err = NULL;
@@ -13681,7 +13681,7 @@ static void _email_destroy_bulk(jmap_req_t *req,
 static int jmap_email_set(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
 
     json_t *err = NULL;
     jmap_set_parse(req, &parser, email_props, NULL, NULL, &set, &err);
@@ -14404,7 +14404,7 @@ static void _email_copy_bulk(jmap_req_t *req,
 static int jmap_email_copy(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_copy copy;
+    struct jmap_copy copy = JMAP_COPY_INITIALIZER;
     json_t *err = NULL;
     json_t *destroy_emails = json_array();
     char *srcinbox = NULL;

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -1305,7 +1305,7 @@ static const jmap_property_t submission_props[] = {
 static int jmap_emailsubmission_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     mbentry_t *mbentry = NULL;
     int created = 0;
@@ -1433,7 +1433,7 @@ static int _submission_setargs_parse(jmap_req_t *req,
 static int jmap_emailsubmission_set(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     struct submission_set_args sub_args = { NULL, NULL };
     json_t *err = NULL;
     struct mailbox *submbox = NULL;
@@ -1656,7 +1656,7 @@ done:
 static int jmap_emailsubmission_changes(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     struct mailbox *mbox = NULL;
     mbentry_t *mbentry = NULL;
 
@@ -2111,7 +2111,7 @@ static int sub_sort_compare(const void **vp1, const void **vp2)
 static int jmap_emailsubmission_query(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     struct mailbox *mbox = NULL;
     mbentry_t *mbentry = NULL;
     int created = 0;
@@ -2263,7 +2263,7 @@ done:
 static int jmap_emailsubmission_querychanges(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_querychanges query;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
 
     /* Parse arguments */
     json_t *err = NULL;
@@ -2409,7 +2409,7 @@ static const jmap_property_t identity_props[] = {
 static int jmap_identity_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
 
     /* Parse request */

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -917,7 +917,7 @@ static const jmap_property_t mailbox_props[] = {
 static int jmap_mailbox_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
 
     /* Parse request */
@@ -1611,7 +1611,7 @@ static int _mboxquery_parse_args(jmap_req_t *req __attribute__((unused)),
 static int jmap_mailbox_query(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     mboxquery_args_t args = { 0, 0 };
 
     /* Parse request */
@@ -1659,7 +1659,7 @@ static int _mboxquerychanges_cb(const mbentry_t *mbentry, void *vrock)
 static int jmap_mailbox_querychanges(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_querychanges query;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
     mboxquery_args_t args = { 0, 0 };
     int r = 0;
 
@@ -4109,7 +4109,7 @@ static void _mboxset_fini(struct mboxset *set)
 static int jmap_mailbox_set(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct mboxset set;
+    struct mboxset set = JMAP_SET_INITIALIZER;
 
     /* Parse arguments */
     json_t *arg_err = NULL;

--- a/imap/jmap_mdn.c
+++ b/imap/jmap_mdn.c
@@ -603,7 +603,7 @@ done:
 static int jmap_mdn_parse(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_parse parse;
+    struct jmap_parse parse = JMAP_QUERYCHANGES_INITIALIZER;
     json_t *err = NULL;
 
     /* Parse request */

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -448,7 +448,7 @@ static const jmap_property_t notes_props[] = {
 static int jmap_note_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     mbentry_t *mbentry = NULL;
     struct mailbox *mbox = NULL;
@@ -835,7 +835,7 @@ static void _notes_destroy_cb(const char *id, message_t *msg,
 static int jmap_note_set(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     struct mailbox *mbox = NULL;
     mbentry_t *mbentry = NULL;
     struct buf buf = BUF_INITIALIZER;

--- a/imap/jmap_quota.c
+++ b/imap/jmap_quota.c
@@ -147,7 +147,7 @@ static const jmap_property_t legacy_quota_props[] = {
 static int jmap_legacy_quota_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     char *inboxname = mboxname_user_mbox(req->accountid, NULL);
 
@@ -578,7 +578,7 @@ static void getquota(const char *id, void *val, void *rock)
 static int jmap_quota_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     struct qrock_t qrock = { req, NULL, { 0 }, NULL, HASH_TABLE_INITIALIZER };
 
@@ -649,7 +649,7 @@ static void changes_cb(const char *id, void *val, void *rock)
 static int jmap_quota_changes(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
     struct qrock_t qrock = { req, NULL, { 0 }, NULL, HASH_TABLE_INITIALIZER };
 
     json_t *err = NULL;
@@ -867,7 +867,7 @@ static int quota_cmp QSORT_R_COMPAR_ARGS(const void *va, const void *vb,
 static int jmap_quota_query(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     jmap_filter *parsed_filter = NULL;
     arrayu64_t sortcrit = ARRAYU64_INITIALIZER;
     struct qrock_t qrock = { req, NULL, { 0 }, NULL, HASH_TABLE_INITIALIZER };

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -293,7 +293,7 @@ static int getscript(void *rock, struct sieve_data *sdata)
 static int jmap_sieve_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     struct mailbox *mailbox = NULL;
     struct sieve_db *db = NULL;
@@ -794,7 +794,7 @@ static int _sieve_setargs_parse(jmap_req_t *req __attribute__((unused)),
 static int jmap_sieve_set(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     struct sieve_set_args sub_args = { NULL, 0 };
     json_t *jerr = NULL;
     struct mailbox *mailbox = NULL;
@@ -1113,7 +1113,7 @@ static int sieve_cmp QSORT_R_COMPAR_ARGS(const void *va, const void *vb, void *r
 static int jmap_sieve_query(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_query query;
+    struct jmap_query query = JMAP_QUERY_INITIALIZER;
     jmap_filter *parsed_filter = NULL;
     arrayu64_t sortcrit = ARRAYU64_INITIALIZER;
     struct mailbox *mailbox = NULL;

--- a/imap/jmap_vacation.c
+++ b/imap/jmap_vacation.c
@@ -308,7 +308,7 @@ static void vacation_get(jmap_req_t *req, struct mailbox *mailbox,
 static int jmap_vacation_get(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_get get;
+    struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
     struct sieve_db *db = NULL;
     struct mailbox *mailbox = NULL;
@@ -551,7 +551,7 @@ static void vacation_update(struct jmap_req *req,
 static int jmap_vacation_set(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_set set;
+    struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *jerr = NULL;
     struct sieve_db *db = NULL;
     struct mailbox *mailbox = NULL;


### PR DESCRIPTION
This will allow us to set a field in one of the structs to a non-zero value before calling _parse()