### PR TITLE
imapd.c: split logging of client use of ANNOTATE (message) and GET/SETANNOTATION (mailbox)

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4423,6 +4423,8 @@ static int cmd_append(char *tag, char *name, const char *cur_name, int isreplace
                 }
                 qdiffs[QUOTA_ANNOTSTORAGE] += sizeentryatts(curstage->annotations);
                 c = getword(imapd_in, &arg);
+
+                client_behavior_mask |= CB_ANNOTATE;
             }
             else
                 break;  /* not a known extension keyword */
@@ -4850,7 +4852,7 @@ static void cmd_select(char *tag, char *cmd, char *name)
                  * ANNOTATION responses in this session, but we don't
                  * actually have to do anything with it, so we won't.
                  */
-                ;
+                client_behavior_mask |= CB_ANNOTATE;
             }
             else if (allowdeleted && !strcmp(arg.s, "VENDOR.CMU-INCLUDE-EXPUNGED")) {
                 init.want_expunged = 1;
@@ -6022,6 +6024,8 @@ static void cmd_store(char *tag, char *sequence, int usinguid)
         storeargs.isadmin = imapd_userisadmin;
         storeargs.userid = imapd_userid;
         storeargs.authstate = imapd_authstate;
+
+        client_behavior_mask |= CB_ANNOTATE;
         goto notflagsdammit;
     }
     else {
@@ -6313,14 +6317,7 @@ static void cmd_search(const char *tag, const char *cmd)
         goto done;
     }
 
-    if (searchargs->returnopts & SEARCH_RETURN_SAVE)
-        client_behavior_mask |= CB_SEARCHRES;
-
-    if (searchargs->returnopts & SEARCH_RETURN_PARTIAL)
-        client_behavior_mask |= CB_PARTIAL;
-
-    if (searchargs->did_objectid)
-        client_behavior_mask |= CB_OBJECTID;
+    client_behavior_mask |= searchargs->client_behavior_mask;
 
     // this refreshes the index, we may be looking at it in our search
     imapd_check(NULL, 0);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -880,6 +880,7 @@ static const struct client_behavior {
     const char *name;
 } client_behavior_registry[] = {
     { CB_ANNOTATE,    "annotate"    },
+    { CB_ANNOTATEMBOX,"annotatembox"},
     { CB_BINARY,      "binary"      },
     { CB_CATENATE,    "catenate"    },
     { CB_COMPRESS,    "compress"    },
@@ -10623,7 +10624,7 @@ static void cmd_getannotation(const char *tag, char *mboxpat)
     strarray_t attribs = STRARRAY_INITIALIZER;
     annotate_state_t *astate = NULL;
 
-    client_behavior_mask |= CB_ANNOTATE;
+    client_behavior_mask |= CB_ANNOTATEMBOX;
 
     c = parse_annotate_fetch_data(tag, /*permessage_flag*/0, &entries, &attribs);
     if (c <= EOF) {
@@ -11021,7 +11022,7 @@ static void cmd_setannotation(const char *tag, char *mboxpat)
     struct entryattlist *entryatts = NULL;
     annotate_state_t *astate = NULL;
 
-    client_behavior_mask |= CB_ANNOTATE;
+    client_behavior_mask |= CB_ANNOTATEMBOX;
 
     c = parse_annotate_store_data(tag, 0, &entryatts);
     if (c <= EOF) {

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -239,7 +239,7 @@ struct searchargs {
     /* used only during parsing */
     int fuzzy_depth;
     uint64_t maxargssize_mark;
-    unsigned did_objectid : 1;
+    uint32_t client_behavior_mask;
 
     /* For ESEARCH */
     const char *tag;
@@ -401,7 +401,9 @@ extern struct protstream *imapd_out, *imapd_in;
 
 /* Bitmask for exhibited client behaviors */
 enum {
-    CB_ANNOTATE    =  (1<<21),  /* FETCH ANNOTATION                      */
+    CB_ANNOTATE    =  (1<<21),  /* ANNOTATE on SELECT/EXAMINE,
+                                   ANNOTATION on APPEND, or
+                                   FETCH/STORE/SEARCH/SORT ANNOTATION    */
     CB_BINARY      =  (1<<0),   /* FETCH BINARY or APPEND literal8       */
     CB_CATENATE    =  (1<<1),   /* CATENATE on APPEND                    */
     CB_COMPRESS    =  (1<<2),   /* COMPRESS                              */

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -401,6 +401,7 @@ extern struct protstream *imapd_out, *imapd_in;
 
 /* Bitmask for exhibited client behaviors */
 enum {
+    CB_ANNOTATE    =  (1<<21),  /* FETCH ANNOTATION                      */
     CB_BINARY      =  (1<<0),   /* FETCH BINARY or APPEND literal8       */
     CB_CATENATE    =  (1<<1),   /* CATENATE on APPEND                    */
     CB_COMPRESS    =  (1<<2),   /* COMPRESS                              */
@@ -427,7 +428,7 @@ enum {
     CB_UTF8ACCEPT  =  (1<<19),  /* ENABLE UTF8=ACCEPT                    */
 
     /* non-standard - track for possible deprecation                     */
-    CB_ANNOTATE    =  (1<<30),  /* GET/SETANNOTATION or FETCH ANNOTATION */
+    CB_ANNOTATEMBOX=  (1<<30),  /* GET/SETANNOTATION (old ANNOTATEMORE)  */
     CB_XLIST       =  (1U<<31), /* XLIST                                 */
 };
 

--- a/imap/imapparse.c
+++ b/imap/imapparse.c
@@ -698,6 +698,7 @@ EXPORTED int get_search_return_opts(struct protstream *pin,
         }
         else if (!strcmp(opt.s, "save")) {      /* RFC 5182 */
             searchargs->returnopts |= SEARCH_RETURN_SAVE;
+            searchargs->client_behavior_mask |= CB_SEARCHRES;
         }
         else if (!strcmp(opt.s, "relevancy")) { /* RFC 6203 */
             searchargs->returnopts |= SEARCH_RETURN_RELEVANCY;
@@ -716,6 +717,7 @@ EXPORTED int get_search_return_opts(struct protstream *pin,
             }
 
             searchargs->returnopts |= SEARCH_RETURN_PARTIAL;
+            searchargs->client_behavior_mask |= CB_PARTIAL;
         }
         else {
             prot_printf(pout,
@@ -1135,7 +1137,7 @@ static int get_search_criterion(struct protstream *pin,
             if (c <= EOF) goto missingarg;
             bytestring_match(parent, arg.s, criteria.s, base);
 
-            base->did_objectid = 1;
+            base->client_behavior_mask |= CB_OBJECTID;
         }
         else goto badcri;
         break;
@@ -1424,7 +1426,7 @@ static int get_search_criterion(struct protstream *pin,
             if (c <= EOF) goto missingarg;
             bytestring_match(parent, arg.s, criteria.s, base);
 
-            base->did_objectid = 1;
+            base->client_behavior_mask |= CB_OBJECTID;
         }
         else goto badcri;
         break;


### PR DESCRIPTION
Also, logs ANNOTATE use with APPEND, STORE, SEARCH, SELECT