### PR TITLE
Provide missing messageContent for new messages delivered via LMTP

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -1195,13 +1195,13 @@ out:
     }
 
     /* finish filling the event notification */
-    destfile = fopen(fname, "r");
-    if (!destfile) {
+    FILE *msgfile = fopen(fname, "r");
+    if (!msgfile) {
       syslog(LOG_ERR, "IOERROR: opening message file %s: %m", fname);
     } else {
       /* Extract messageContent for MessageNew notifications */
-      mboxevent_extract_content_msgrec(mboxevent, msgrec, destfile);
-      fclose(destfile);
+      mboxevent_extract_content_msgrec(mboxevent, msgrec, msgfile);
+      fclose(msgfile);
     }
     /* XXX avoid to parse ENVELOPE record since Message-Id is already
      * present in body structure ? */

--- a/imap/append.c
+++ b/imap/append.c
@@ -1195,6 +1195,14 @@ out:
     }
 
     /* finish filling the event notification */
+    destfile = fopen(fname, "r");
+    if (!destfile) {
+      syslog(LOG_ERR, "IOERROR: opening message file %s: %m", fname);
+    } else {
+      /* Extract messageContent for MessageNew notifications */
+      mboxevent_extract_content_msgrec(mboxevent, msgrec, destfile);
+      fclose(destfile);
+    }
     /* XXX avoid to parse ENVELOPE record since Message-Id is already
      * present in body structure ? */
     mboxevent_extract_msgrecord(mboxevent, msgrec);

--- a/imap/append.c
+++ b/imap/append.c
@@ -1197,11 +1197,11 @@ out:
     /* finish filling the event notification */
     FILE *msgfile = fopen(fname, "r");
     if (!msgfile) {
-      syslog(LOG_ERR, "IOERROR: opening message file %s: %m", fname);
+        syslog(LOG_ERR, "IOERROR: opening message file %s: %m", fname);
     } else {
-      /* Extract messageContent for MessageNew notifications */
-      mboxevent_extract_content_msgrec(mboxevent, msgrec, msgfile);
-      fclose(msgfile);
+        /* Extract messageContent for MessageNew notifications */
+        mboxevent_extract_content_msgrec(mboxevent, msgrec, msgfile);
+        fclose(msgfile);
     }
     /* XXX avoid to parse ENVELOPE record since Message-Id is already
      * present in body structure ? */


### PR DESCRIPTION
This PR adresses issue #5490 

## ✅ Summary

This PR ensures that `messageContent` is included in `MessageNew` events emitted during LMTP delivery (`append_fromstage_full()`). Without this, systems configured to send event notifications that include `messageContent` may experience fatal delivery failures.

## 🐛 Problem

Currently, `messageContent` is only extracted in `append_fromstream()`, not in `append_fromstage_full()`, which is used during LMTP delivery. If notifications are enabled and expect `messageContent`, delivery fails with:

```
FATAL: Internal error: assertion failed: imap/mboxevent.c: 743: filled_params(type, event)
```

## 🔧 Fix

This patch opens the newly written message file and calls `mboxevent_extract_content_msgrec()` inside `append_fromstage_full()` to ensure `messageContent` is populated in the event structure, mirroring the behavior in `append_fromstream()`.

## 🧪 Tested

Tested locally with LMTP delivery and notification configuration requiring `messageContent`. Messages are now delivered successfully and the content is included in the emitted event.
