### PR TITLE
cassandane: option to suppress success output (only show errors and failures)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       id: cass1
       continue-on-error: true
       # We haven't figured out how to make Test::Core work in actions yet.
-      run: cyd test --slow "!Test::Core" --format prettier "${{ matrix.skip }}"
+      run: cyd test --no-ok --slow "!Test::Core" --format prettier "${{ matrix.skip }}"
     - name: rerun cassandane failures noisily
       if: ${{ steps.cass1.outcome == 'failure' }}
       run: cyd test --no-slow --format pretty --rerun

--- a/cassandane/Cassandane/Unit/FormatPretty.pm
+++ b/cassandane/Cassandane/Unit/FormatPretty.pm
@@ -233,9 +233,14 @@ sub print_header {
                         ? $self->ansi([31], $result->error_count)
                         : "0";
 
+        my $x = $result->run_count() - ($result->failure_count()
+                                        + $result->error_count());
+        my $success_count = $x ? $self->ansi([32], $x) : "0";
+
         $self->_print("\n", $self->ansi([31], "!!!FAILURES!!!"), "\n",
                       "Test Results:\n",
                       "Run: ", $result->run_count(),
+                      ", Successes: $success_count",
                       ", Failures: $failure_count",
                       ", Errors: $error_count",
                       "\n");

--- a/cassandane/Cassandane/Unit/FormatPretty.pm
+++ b/cassandane/Cassandane/Unit/FormatPretty.pm
@@ -60,6 +60,10 @@ sub new
         $self->{_quiet_report_fh} = IO::File->new($quiet_report_file, 'w');
         # if we can't write there, just don't do it
     }
+    if ($params->{no_ok}) {
+        # don't print success outputs to terminal, only error/failure
+        $self->{_no_ok} = 1;
+    }
     return $self;
 }
 
@@ -81,6 +85,8 @@ sub add_pass
 {
     my $self = shift;
     my $test = shift;
+
+    return if $self->{_no_ok};
 
     my $line = sprintf "%s %s\n",
                        $self->ansi([32], '[  OK  ]'),

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -301,6 +301,12 @@ while (my $a = shift)
     {
         $want_rerun = 2;
     }
+    elsif ($a eq '--no-ok')
+    {
+        # suppress success reports in formatters that support that
+        # (i.e. only report errors and failures)
+        $format_params{no_ok} = 1;
+    }
     elsif ($a =~ m/^-/)
     {
         usage;

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -205,7 +205,7 @@ my $cassini_filename;
 my @cassini_overrides;
 my $want_rerun;
 
-while (my $a = shift)
+while (defined(my $a = shift))
 {
     if ($a eq '--config')
     {

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -62,6 +62,7 @@ $Data::Dumper::Sortkeys = 1;
 $Data::Dumper::Trailingcomma = 1;
 
 my %want_formats = ();
+my %format_params = ();
 my $output_dir = 'reports';
 my $do_list = 0;
 # The default really should be --no-keep-going like make
@@ -144,31 +145,32 @@ my %formatters = (
     tap => {
         writes_to_stdout => 1,
         formatter => sub {
-            my ($fh) = @_;
+            my ($params, $fh) = @_;
             return Cassandane::Unit::FormatTAP->new($fh);
         },
     },
     pretty => {
         writes_to_stdout => 1,
         formatter => sub {
-            my ($fh) = @_;
-            return Cassandane::Unit::FormatPretty->new({}, $fh);
+            my ($params, $fh) = @_;
+            $params->{quiet} = 0;
+            return Cassandane::Unit::FormatPretty->new($params, $fh);
         },
     },
     prettier => {
         writes_to_stdout => 1,
         formatter => sub {
-            my ($fh) = @_;
-            return Cassandane::Unit::FormatPretty->new({quiet=>1}, $fh);
+            my ($params, $fh) = @_;
+            $params->{quiet} = 1;
+            return Cassandane::Unit::FormatPretty->new($params, $fh);
         },
     },
     xml => {
         writes_to_stdout => 0,
         formatter => sub {
-            my ($fh) = @_;
-            return Cassandane::Unit::FormatXML->new({
-                directory => $output_dir
-            });
+            my ($params, $fh) = @_;
+            $params->{directory} = $output_dir;
+            return Cassandane::Unit::FormatXML->new($params);
         },
     },
 );
@@ -384,7 +386,8 @@ else
 
     my $runner = Cassandane::Unit::Runner->new();
     foreach my $f (keys %want_formats) {
-        $runner->add_formatter($formatters{$f}->{formatter}->());
+        my $formatter = $formatters{$f}->{formatter}->({%format_params});
+        $runner->add_formatter($formatter);
     }
     $runner->filter(@filters);
 


### PR DESCRIPTION
When cassandane tests fail in CI, it can be hard to see which ones failed:

* at the "run cassandane quietly" stage, the failing tests are lost in a sea of OKs
* at the "rerun cassandane failures noisily" stage, they're lost in a sea of detailed error logging

This PR adds a "no_ok" formatter parameter for suppressing success results, and implements it for FormatPretty (i.e. `pretty` and `prettier`).  Formatters that don't recognise it (`tap`, `xml`) will ignore it.  Call `testrunner.pl` with `--no-ok` to enable this behaviour.

`cyd test` doesn't yet know about `--no-ok` and will reject it as an invalid argument, so to use the new testrunner option with cyd, for now you'll need to smuggle it through as a non-option argument.  The main.yml workflow has been updated to do this for the "run cassandane quietly" step.

**Deliberately fails CI**, due to the "JUNK force a failure and an error" commit, which I will drop before merging.  View the CI reports and check the "run cassandane quietly" output: it's now very easy to see exactly which tests failed, because there isn't ~2k lines of "[ OK ] Some.other_test" cluttering things up anymore.