### PR TITLE
haproxy.c: v2sig - fix compiler warning

### DIFF
--- a/imap/haproxy.c
+++ b/imap/haproxy.c
@@ -19,7 +19,7 @@
 /* returns 0 on success, <0 upon error */
 EXPORTED int haproxy_read_hdr(int s, struct sockaddr *to, struct sockaddr *from)
 {
-    const char v2sig[12] = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A";
+    static const char v2sig[] = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A";
 
     union {
         struct {


### PR DESCRIPTION
Fix compiler warning:
```
  CC       imap/libcyrus_imap_la-haproxy.lo
../imap/haproxy.c: In function 'haproxy_read_hdr':
../imap/haproxy.c:22:35: warning: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (13 chars into 12 available) [-Wunterminated-string-initialization]
   22 |     static const char v2sig[12] = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A";
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Well, it now uses 13 bytes to store the data, instead of 12 bytes, which is probably aligned to 16 bytes on 16bit systems, or even 32 bits on 32 bit systems.