### PR TITLE
build deps files for cunit tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -695,7 +695,9 @@ endif
 
 .testc.o:
 	$(AM_V_at)$(CUNIT_PL) --generate-wrapper $<
-	$(AM_V_CC)$(COMPILE) -c -o $@ $<-cunit.c
+	$(AM_V_CC)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
+	$(COMPILE) -MT $@ -MD -MP -MF $$depbase.Tpo -c -o $@ $<-cunit.c &&\
+	$(am__mv) $$depbase.Tpo $$depbase.Po
 	$(AM_V_at)$(CUNIT_RM) $<-cunit.c
 
 $(CUNIT_PROJECT):


### PR DESCRIPTION
This addresses an issue observed in #5499, that we don't build deps files for our cunit tests.  This meant the cunit tests wouldn't necessarily recompile after things they were trying to test had changed.  The change updates the custom rule used for building tests' object files, which had been missing some details, to do the same things as the builtin rule used for normal object files.

It doesn't (yet) address the specific issue of ical_support.testc not recompiling after http_cal_abook_admin.js changes.  I'm still missing a detail somewhere... I've tried a few obvious things, and a few less obvious things, but so far none have made the difference I was looking for.