### PR TITLE
Warmup mailbox

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -1631,7 +1631,7 @@ out:
     return r;
 }
 
-EXPORTED int index_warmup(struct mboxlist_entry *mbentry,
+EXPORTED int index_warmup(const struct mboxlist_entry *mbentry,
                           unsigned int warmup_flags,
                           seqset_t *uids)
 {

--- a/imap/index.c
+++ b/imap/index.c
@@ -1637,8 +1637,7 @@ EXPORTED int index_warmup(const struct mboxlist_entry *mbentry,
 {
     const char *fname = NULL;
     char *userid = NULL;
-    char *tofree1 = NULL;
-    char *tofree2 = NULL;
+    char *tofree = NULL;
     unsigned int uid;
     strarray_t files = STRARRAY_INITIALIZER;
     int i;
@@ -1649,17 +1648,24 @@ EXPORTED int index_warmup(const struct mboxlist_entry *mbentry,
         r = warmup_file(fname, 0, 0);
         if (r) goto out;
     }
-    if (warmup_flags & WARMUP_CONVERSATIONS) {
-        if (config_getswitch(IMAPOPT_CONVERSATIONS)) {
-            fname = tofree1 = conversations_getmboxpath(mbentry->name);
-            r = warmup_file(fname, 0, 0);
-            if (r) goto out;
-        }
+    if (warmup_flags & WARMUP_CACHE) {
+        fname = mbentry_metapath(mbentry, META_CACHE, 0);
+        r = warmup_file(fname, 0, 0);
+        if (r) goto out;
     }
     if (warmup_flags & WARMUP_ANNOTATIONS) {
         fname = mbentry_metapath(mbentry, META_ANNOTATIONS, 0);
         r = warmup_file(fname, 0, 0);
         if (r) goto out;
+    }
+    if (warmup_flags & WARMUP_CONVERSATIONS) {
+        if (config_getswitch(IMAPOPT_CONVERSATIONS)) {
+            fname = tofree = conversations_getmboxpath(mbentry->name);
+            r = warmup_file(fname, 0, 0);
+            if (r) goto out;
+            free(tofree);
+            tofree = NULL;
+        }
     }
     if (warmup_flags & WARMUP_SEARCH) {
         userid = mboxname_to_userid(mbentry->name);
@@ -1684,8 +1690,7 @@ out:
         syslog(LOG_ERR, "IOERROR: unable to warmup file %s: %s",
                 fname, error_message(r));
     free(userid);
-    free(tofree1);
-    free(tofree2);
+    free(tofree);
     strarray_fini(&files);
     return r;
 }

--- a/imap/index.h
+++ b/imap/index.h
@@ -230,9 +230,10 @@ struct nntp_overview {
 enum index_warmup_flags
 {
     WARMUP_INDEX            = (1<<0),
-    WARMUP_CONVERSATIONS    = (1<<1),
+    WARMUP_CACHE            = (1<<1),
     WARMUP_ANNOTATIONS      = (1<<2),
-    WARMUP_SEARCH           = (1<<3),
+    WARMUP_CONVERSATIONS    = (1<<3),
+    WARMUP_SEARCH           = (1<<4),
     WARMUP_ALL              = (~WARMUP_SEARCH)
 };
 

--- a/imap/index.h
+++ b/imap/index.h
@@ -269,7 +269,7 @@ extern int index_store(struct index_state *state,
 extern int index_run_annotator(struct index_state *state,
                                const char *sequence, int usinguid,
                                struct namespace *namespace, int isadmin);
-extern int index_warmup(struct mboxlist_entry *, unsigned int warmup_flags,
+extern int index_warmup(const struct mboxlist_entry *, unsigned int warmup_flags,
                         seqset_t *uids);
 extern int index_sort(struct index_state *state, const struct sortcrit *sortcrit,
                       struct searchargs *searchargs, int usinguid,

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -505,6 +505,9 @@ static int do_reconstruct(struct findall_data *data, void *rock)
     /* don't repeat */
     if (hash_lookup(name, &rrock->visited)) return 0;
 
+    /* make sure data is loaded in memory to limit lock time */
+    index_warmup(data->mbentry, WARMUP_ALL, /*uids*/NULL);
+
     struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
 
     if (setversion) {

--- a/lib/util.c
+++ b/lib/util.c
@@ -2058,8 +2058,10 @@ EXPORTED int warmup_file(const char *filename,
     int fd;
     int r;
 
+    if (!filename) return 0;
+
     fd = open(filename, O_RDONLY, 0);
-    if (fd < 0) return errno;
+    if (fd < 0) return 0;
 
     /* Note, posix_fadvise() returns its error code rather than
      * setting errno.  Unlike every other system call including


### PR DESCRIPTION
This adds a index_warmup before we take the lock on each mailbox, ensuring that the user's files are freshly cached and won't cause page faults!

(It also means that cyrus.cache will be loaded by the IMAP XWARMUP command)