### PR TITLE
fix Util::Words::random_word() to not repeat words

### DIFF
--- a/cassandane/Cassandane/Util/Words.pm
+++ b/cassandane/Cassandane/Util/Words.pm
@@ -40,7 +40,7 @@
 package Cassandane::Util::Words;
 use strict;
 use warnings;
-use List::Util qw(uniq);
+use List::Util qw(shuffle uniq);
 
 use Exporter ();
 our @ISA = qw(Exporter);
@@ -82,10 +82,9 @@ sub _read_words
 
 sub random_word
 {
-    _read_words()
-        if (!scalar @words);
-    @remaining = @words unless scalar @remaining;
-    return $remaining[int(rand(scalar @remaining))];
+    _read_words() unless scalar @words;
+    @remaining = shuffle @words unless scalar @remaining;
+    return shift @remaining;
 }
 
 sub random_words

--- a/cassandane/Cassandane/Util/Words.pm
+++ b/cassandane/Cassandane/Util/Words.pm
@@ -40,6 +40,7 @@
 package Cassandane::Util::Words;
 use strict;
 use warnings;
+use List::Util qw(uniq);
 
 use Exporter ();
 our @ISA = qw(Exporter);
@@ -75,6 +76,8 @@ sub _read_words
         last if scalar @words == MAX_WORDS;
     }
     close DICT;
+
+    @words = uniq @words;
 }
 
 sub random_word


### PR DESCRIPTION
Looks like it was always intended to not repeat words (unless it ran out), but there were two bugs in that, causing occasional test failures like this:

```
1) Shared.subscribe_vd_prefix2
 Perl exception: Cannot create user.jim.perl@example.com: IMAP Command : 'create' failed. Response was : no - Mailbox already exists
 at Cassandane/Instance.pm line 1099.
```