### PR TITLE
dynarray append improvements

### DIFF
--- a/cunit/dynarray.testc
+++ b/cunit/dynarray.testc
@@ -41,6 +41,37 @@ static void test_basic(void)
     CU_ASSERT_PTR_NULL(da);
 }
 
+static void test_append_empty(void)
+{
+    struct dynarray *da = dynarray_new(sizeof(uint32_t));
+    uint32_t *valp1, *valp2;
+    int index;
+
+    CU_ASSERT_EQUAL(dynarray_size(da), 0);
+    CU_ASSERT_PTR_NULL(dynarray_nth(da, 0));
+    CU_ASSERT_PTR_NULL(dynarray_nth(da, -1));
+
+    index = dynarray_append_empty(da, (void **) &valp1);
+
+    CU_ASSERT_EQUAL(index, 0);
+    CU_ASSERT_EQUAL(dynarray_size(da), 1);
+    CU_ASSERT_EQUAL(*valp1, 0);
+    CU_ASSERT_PTR_EQUAL(dynarray_nth(da, index), valp1);
+    CU_ASSERT_PTR_EQUAL(dynarray_nth(da, -1), valp1);
+
+    index = dynarray_append_empty(da, (void **) &valp2);
+
+    CU_ASSERT_EQUAL(index, 1);
+    CU_ASSERT_EQUAL(dynarray_size(da), 2);
+    CU_ASSERT_EQUAL(*valp2, 0);
+    CU_ASSERT_PTR_EQUAL(dynarray_nth(da, index), valp2);
+    CU_ASSERT_PTR_EQUAL(dynarray_nth(da, -1), valp2);
+
+    CU_ASSERT_PTR_NOT_EQUAL(valp1, valp2);
+
+    dynarray_free(&da);
+    CU_ASSERT_PTR_NULL(da);
+}
 
 static void test_set(void)
 {

--- a/cunit/dynarray.testc
+++ b/cunit/dynarray.testc
@@ -4,29 +4,35 @@
 #include "xmalloc.h"
 #include "dynarray.h"
 
+#define CU_ASSERT_MEMEQUAL(actual, expected, sz) \
+    CU_ASSERT_EQUAL(memcmp(actual, expected, sz), 0)
+
 static void test_basic(void)
 {
     struct dynarray *da = dynarray_new(sizeof(uint32_t));
     uint32_t *valp;
+    int index;
 
     CU_ASSERT_EQUAL(dynarray_size(da), 0);
     CU_ASSERT_PTR_NULL(dynarray_nth(da, 0));
     CU_ASSERT_PTR_NULL(dynarray_nth(da, -1));
 
     uint32_t val1 = 0xbeefc0de;
-    dynarray_append(da, &val1);
+    index = dynarray_append(da, &val1);
 
+    CU_ASSERT_EQUAL(index, 0);
     CU_ASSERT_EQUAL(dynarray_size(da), 1);
-    valp = dynarray_nth(da, 0);
+    valp = dynarray_nth(da, index);
     CU_ASSERT_EQUAL(*valp, val1);
     valp = dynarray_nth(da, -1);
     CU_ASSERT_EQUAL(*valp, val1);
 
     uint32_t val2 = 0x00c0fefe;
-    dynarray_append(da, &val2);
+    index = dynarray_append(da, &val2);
 
+    CU_ASSERT_EQUAL(index, 1);
     CU_ASSERT_EQUAL(dynarray_size(da), 2);
-    valp = dynarray_nth(da, 1);
+    valp = dynarray_nth(da, index);
     CU_ASSERT_EQUAL(*valp, val2);
     valp = dynarray_nth(da, -1);
     CU_ASSERT_EQUAL(*valp, val2);
@@ -35,8 +41,6 @@ static void test_basic(void)
     CU_ASSERT_PTR_NULL(da);
 }
 
-#define CU_ASSERT_MEMEQUAL(actual, expected, sz) \
-    CU_ASSERT_EQUAL(memcmp(actual, expected, sz), 0)
 
 static void test_set(void)
 {

--- a/lib/dynarray.c
+++ b/lib/dynarray.c
@@ -160,6 +160,17 @@ EXPORTED int dynarray_append(struct dynarray *da, void *memb)
     return da->count++;
 }
 
+EXPORTED int dynarray_append_empty(struct dynarray *da, void **out_memb)
+{
+    void *memb;
+
+    ensure_alloc(da, da->count+1);
+    memb = da->data + da->count * da->membsize;
+    memset(memb, 0, da->membsize);
+    if (out_memb) *out_memb = memb;
+    return da->count++;
+}
+
 EXPORTED void dynarray_set(struct dynarray *da, int idx, void *memb)
 {
     if ((idx = adjust_index_rw(da, idx, 0)) < 0)

--- a/lib/dynarray.c
+++ b/lib/dynarray.c
@@ -153,11 +153,11 @@ static char *dump(struct dynarray *da)
     return buf_release(&buf);
 }
 
-EXPORTED void dynarray_append(struct dynarray *da, void *memb)
+EXPORTED int dynarray_append(struct dynarray *da, void *memb)
 {
     ensure_alloc(da, da->count+1);
     memcpy(da->data + da->count * da->membsize, memb, da->membsize);
-    da->count++;
+    return da->count++;
 }
 
 EXPORTED void dynarray_set(struct dynarray *da, int idx, void *memb)

--- a/lib/dynarray.h
+++ b/lib/dynarray.h
@@ -60,6 +60,7 @@ extern struct dynarray *dynarray_new(size_t membsize);
 extern void dynarray_free(struct dynarray **dap);
 
 extern int dynarray_append(struct dynarray *da, void *memb);
+extern int dynarray_append_empty(struct dynarray *da, void **out_memb);
 extern void dynarray_set(struct dynarray *, int idx, void *memb);
 extern void *dynarray_nth(const struct dynarray *da, int idx);
 extern int dynarray_size(struct dynarray *da);

--- a/lib/dynarray.h
+++ b/lib/dynarray.h
@@ -59,7 +59,7 @@ extern void dynarray_fini(struct dynarray *da);
 extern struct dynarray *dynarray_new(size_t membsize);
 extern void dynarray_free(struct dynarray **dap);
 
-extern void dynarray_append(struct dynarray *da, void *memb);
+extern int dynarray_append(struct dynarray *da, void *memb);
 extern void dynarray_set(struct dynarray *, int idx, void *memb);
 extern void *dynarray_nth(const struct dynarray *da, int idx);
 extern int dynarray_size(struct dynarray *da);


### PR DESCRIPTION
To use `dynarray_append()`, you need to already have the object you want to append to the array.  If you don't, you need to construct one in scratch space somewhere, so it can be copied into place by `dynarray_append()`, and then (shallowly) discard the scratch space copy.

This PR adds `dynarray_append_empty()`, which allocates a new, empty, slot in the array, and gives you back a pointer to it so you can construct its value in place.  For trivial objects the difference is academic, but for complex objects it avoids the memcpy and simplifies the memory management.

It also updates `dynarray_append()` to return the index of the new element.  This will let you know where the thing you added is, which will be useful for more complicated data models using dynarrays as backing store.  I've checked the existing callers and none of them benefit from this detail, so they haven't been updated to use it, they just ignore the return value.

The API for `dynarray_append_empty()` is a little funny, because `void **` does not benefit from the same implicit casting behaviours as `void *` does -- see the cunit test for examples of what it's like to call it.  I thought about making it just return the pointer instead of using an out parameter for it, but I also needed the index, and it felt better to return the index like `dynarray_append()` does.

I'll need this for #5317 eventually, but it stands alone, and it's simpler to review it separately.