### PR TITLE
conversations.c: NFC-normalize conversion subjects

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/thread_get_unorm_subject
+++ b/cassandane/tiny-tests/JMAPEmail/thread_get_unorm_subject
@@ -1,0 +1,52 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_thread_get_unorm_subject {
+    my ($self) = @_;
+    my $jmap   = $self->{jmap};
+    my $imap   = $self->{store}->get_client();
+
+    # Unicode Character 'LATIN SMALL LETTER E WITH CIRCUMFLEX' (U+00EA)
+    my $subject1 = "por que =?utf-8?q?voc=C3=AA?= existe?";
+
+    # Unicode Character 'LATIN SMALL LETTER E' (U+0065) plus
+    # Unicode Character 'COMBINING CIRCUMFLEX ACCENT' (U+0302)
+    my $subject2 = "por que =?utf-8?q?voce=CC=82?= existe?";
+
+    $self->make_message(
+        $subject1,
+        messageid => 'msg1@example.com'
+    );
+
+    $self->make_message(
+        $subject2,
+        messageid => 'msg2@example.com',
+        extra_headers => [
+            [ "in-reply-to", '<msg1@example.com>' ],
+        ],
+    );
+
+    my $res = $jmap->CallMethods([
+        [
+            'Email/query', { }, 'R1'
+        ],
+        [
+            'Email/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    name     => 'Email/query',
+                    path     => '/ids'
+                },
+                properties => ['threadId'],
+            },
+            'R2'
+        ],
+    ]);
+
+    $self->assert_num_equals(2, scalar @{$res->[1][1]{list}});
+    $self->assert_str_equals(
+        $res->[1][1]{list}[0]{threadId},
+        $res->[1][1]{list}[1]{threadId}
+    );
+}

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -75,7 +75,11 @@ struct mailbox;
 #define CONVERSATIONS_VERSION 1
 #define CONVERSATIONS_KEY_VERSION 0
 #define CONVERSATIONS_STATUS_VERSION 0
-#define CONVERSATIONS_RECORD_VERSION 1
+// RECORD_VERSION history:
+// 0: original version - no version field in record
+// 1: counts messages per folder and GUID, not UID
+// 2: NFC-normalizes conversation subject
+#define CONVERSATIONS_RECORD_VERSION 2
 
 #define CONV_ISDIRTY     (1<<0)
 #define CONV_WITHFOLDERS (1<<1)


### PR DESCRIPTION
This changes conversion subject normalization to use Unicode NFC normalization. Before, it left non-ASCII bytes in the subject as-is. This led to replies to emails with non-ASCII subjects sometimes not getting assigned to their threads.

This patch bumps the version of B records to 2. It preserves the former subject normalization code for backwards compatibility with existing on-disk conversation records of version 0 or 1.