### PR TITLE
New user namespace locking code

### DIFF
--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -2853,6 +2853,14 @@ sub install_sieve_script
     die "Symlink does not exist: $sieved/defaultbc" if not -l "$sieved/defaultbc";
 
     xlog "Sieve script installed successfully";
+
+    if ($params{upgrade}) {
+        my $srv = $self->get_service('imap');
+        my $adminstore = $srv->create_store(username => 'admin');
+        my $adminclient = $adminstore->get_client();
+        $adminclient->_imap_cmd('UPGRADESIEVE', 0, '', $user);
+        xlog "Sieve upgraded to mailbox version";
+    }
 }
 
 sub install_old_mailbox

--- a/cassandane/tiny-tests/JMAPQuota/quota_get
+++ b/cassandane/tiny-tests/JMAPQuota/quota_get
@@ -12,7 +12,7 @@ sub test_quota_get
     my $script = <<EOF;
 keep;\r
 EOF
-    $self->{instance}->install_sieve_script($script);
+    $self->{instance}->install_sieve_script($script, upgrade => 1);
 
     xlog "Get all Sieve scripts (to create #sieve mailbox) ";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPQuota/quota_query
+++ b/cassandane/tiny-tests/JMAPQuota/quota_query
@@ -12,7 +12,7 @@ sub test_quota_query
     my $script = <<EOF;
 keep;\r
 EOF
-    $self->{instance}->install_sieve_script($script);
+    $self->{instance}->install_sieve_script($script, upgrade => 1);
 
     xlog "Get all Sieve scripts (to create #sieve mailbox) ";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPSieve/sieve_get
+++ b/cassandane/tiny-tests/JMAPSieve/sieve_get
@@ -15,7 +15,7 @@ sub test_sieve_get
 require ["fileinto"];\r
 fileinto "$target";\r
 EOF
-    $self->{instance}->install_sieve_script($script);
+    $self->{instance}->install_sieve_script($script, upgrade => 1);
 
     xlog "get all scripts";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPSieve/sieve_get_duplicate
+++ b/cassandane/tiny-tests/JMAPSieve/sieve_get_duplicate
@@ -15,7 +15,7 @@ sub test_sieve_get_duplicate
 require ["fileinto"];\r
 fileinto "$target";\r
 EOF
-    $self->{instance}->install_sieve_script($script);
+    $self->{instance}->install_sieve_script($script, upgrade => 1);
 
     xlog "get all scripts";
     my $res = $jmap->CallMethods([

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -12,6 +12,7 @@
 #include "imap/annotate.h"
 #include "imap/append.h"
 #include "imap/mboxlist.h"
+#include "imap/user.h"
 #include "imap/imap_err.h"
 
 #define DBDIR           "test-dbdir"
@@ -2212,7 +2213,7 @@ static int set_up(void)
     mboxlist_init();
     mboxlist_open(NULL);
 
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(MBOXNAME1_INT);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(MBOXNAME1_INT);
 
     /* XXX API abuse? perhaps this should just call mboxlist_create,
      * XXX rather than the low level APIs. */
@@ -2239,9 +2240,9 @@ static int set_up(void)
         return r;
     mailbox_close(&mailbox);
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
-    namespacelock = mboxname_usernamespacelock(MBOXNAME2_INT);
+    user_nslock = user_nslock_lockmb_w(MBOXNAME2_INT);
 
     r = mailbox_create(MBOXNAME2_INT, /*mbtype*/0, /*version*/0, PARTITION, ACL,
                        makeuuid(), /*jmapid*/0,
@@ -2266,9 +2267,9 @@ static int set_up(void)
         return r;
     mailbox_close(&mailbox);
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
-    namespacelock = mboxname_usernamespacelock(MBOXNAME3_INT);
+    user_nslock = user_nslock_lockmb_w(MBOXNAME3_INT);
 
     r = mailbox_create(MBOXNAME3_INT, /*mbtype*/0, /*version*/0, PARTITION, ACL,
                        makeuuid(), /*jmapid*/0,
@@ -2290,7 +2291,7 @@ static int set_up(void)
 
     mailbox_close(&mailbox);
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     old_annotation_definitions =
         imapopts[IMAPOPT_ANNOTATION_DEFINITIONS].val.s;

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -599,6 +599,15 @@ out:
     return r;
 }
 
+EXPORTED int annotate_anydb_islocked()
+{
+    struct annotate_db *d;
+    for (d = all_dbs_head ; d ; d = d->next) {
+        if (d->in_txn) return 1;
+    }
+    return 0;
+}
+
 static int _annotate_getdb(const char *mboxid,
                            const struct mailbox *mailbox,
                            unsigned int uid,

--- a/imap/annotate.h
+++ b/imap/annotate.h
@@ -293,6 +293,10 @@ void annotate_done(void);
 int annotate_getdb(const struct mailbox *mailbox, annotate_db_t **dbp);
 void annotate_putdb(annotate_db_t **dbp);
 
+// An API to check if any annotation database is locked, for consistency
+// and safety checks
+int annotate_anydb_islocked();
+
 /* Maybe this isn't the right place - move later */
 int specialuse_validate(const char *mboxname, const char *userid,
                         const char *src, struct buf *dest, int allow_dups);

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -708,7 +708,8 @@ int autocreate_user(struct namespace *namespace, const char *userid)
     strarray_t *subscribe = NULL;
     int numcrt = 0;
     int numsub = 0;
-    struct mboxlock *namespacelock = user_namespacelock(userid);
+
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 #ifdef USE_SIEVE
     const char *source_script;
 #endif
@@ -884,7 +885,7 @@ int autocreate_user(struct namespace *namespace, const char *userid)
 #endif
 
  done:
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     free(inboxname);
     strarray_free(create);
     strarray_free(subscribe);

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -495,7 +495,7 @@ static void do_pop_mupdate(void)
         struct mb_node *me = wipe_head;
         wipe_head = wipe_head->next;
 
-        struct mboxlock *namespacelock = mboxname_usernamespacelock(me->mailbox);
+        user_nslock_t *user_nslock = user_nslock_lockmb_w(me->mailbox);
 
         if (!mboxlist_delayed_delete_isenabled() ||
             mboxname_isdeletedmailbox(me->mailbox, NULL)) {
@@ -506,7 +506,7 @@ static void do_pop_mupdate(void)
                     MBOXLIST_DELETE_LOCALONLY|MBOXLIST_DELETE_FORCE);
         }
 
-        mboxname_release(&namespacelock);
+        user_nslock_release(&user_nslock);
 
         if (ret) {
             fprintf(stderr, "couldn't delete defunct mailbox %s\n",

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -752,7 +752,7 @@ static int do_expunge(struct cyr_expire_ctx *ctx)
             mbentry_t *mbentry = NULL;
             if (mboxlist_lookup_allow_all(name, &mbentry, NULL))
                 continue;
-            struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+            user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
             if (!mboxname_isdeletedmailbox(mbentry->name, NULL)) {
                 mboxname_setmodseq(mbentry->name, mbentry->foldermodseq,
                                    mbentry->mbtype & ~MBTYPE_DELETED,
@@ -763,7 +763,7 @@ static int do_expunge(struct cyr_expire_ctx *ctx)
                 // clean up again, counters probably got re-created
                 user_deletedata(mbentry, 1);
             }
-            mboxname_release(&namespacelock);
+            user_nslock_release(&user_nslock);
             mboxlist_entry_free(&mbentry);
         }
 

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -495,7 +495,7 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
     dav_getpath_byuserid(&newfname, userid);
     buf_printf(&newfname, ".NEW");
 
-    struct mboxlock *namespacelock = user_namespacelock(userid);
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 
     r = IMAP_IOERROR;
     reconstruct_db = sqldb_open(buf_cstring(&newfname), CMD_CREATE, DB_VERSION, davdb_upgrade,
@@ -541,7 +541,7 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
         }
     }
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     buf_free(&newfname);
     buf_free(&fname);

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -378,7 +378,7 @@ int dav_lookup_notify_collection(const char *userid, mbentry_t **mbentryp)
 static int _create_notify_collection(const char *userid, mbentry_t **mbentryp) 
 {
     /* lock the namespace lock and try again */
-    struct mboxlock *namespacelock = user_namespacelock(userid);
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 
     int r = dav_lookup_notify_collection(userid, mbentryp);
 
@@ -401,7 +401,7 @@ static int _create_notify_collection(const char *userid, mbentry_t **mbentryp)
     }
 
  done:
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     return r;
 }
 
@@ -1994,7 +1994,7 @@ HIDDEN int dav_post_share(struct transaction_t *txn, struct meth_params *pparams
     }
 
     /* Local mailbox */
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(txn->req_tgt.mbentry->name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(txn->req_tgt.mbentry->name);
 
     /* Read body */
     ret = parse_xml_body(txn, &root, DAVSHARING_CONTENT_TYPE);
@@ -2164,7 +2164,7 @@ HIDDEN int dav_post_share(struct transaction_t *txn, struct meth_params *pparams
     if (root) xmlFreeDoc(root->doc);
     if (notify) xmlFreeDoc(notify->doc);
     buf_free(&resource);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     dav_run_notifications();
 
     return ret;

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -890,7 +890,7 @@ static int _create_upload_collection(const char *accountid,
                                      struct mailbox **mailboxp)
 {
     /* upload collection */
-    struct mboxlock *namespacelock = user_namespacelock(accountid);
+    user_nslock_t *user_nslock = user_nslock_lock_w(accountid);
     mbentry_t *mbentry = NULL;
     int r = lookup_upload_collection(accountid, &mbentry);
     int need_setacl = 0;
@@ -967,7 +967,7 @@ static int _create_upload_collection(const char *accountid,
     }
 
  done:
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     mboxlist_entry_free(&mbentry);
     return r;
 }

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -332,12 +332,12 @@ static int my_webdav_auth(const char *userid)
     }
 
     /* Auto-provision toplevel DAV drive collection for 'userid' */
-    struct mboxlock *namespacelock = NULL;
+    user_nslock_t *user_nslock = NULL;
     mbname_t *mbname = mbname_from_userid(userid);
     mbname_push_boxes(mbname, config_getstring(IMAPOPT_DAVDRIVEPREFIX));
     int r = mboxlist_lookup(mbname_intname(mbname), NULL, NULL);
     if (r == IMAP_MAILBOX_NONEXISTENT) {
-        namespacelock = user_namespacelock(userid);
+        user_nslock = user_nslock_lock_w(userid);
         // did we lose the race?  Nothing to do!
         r = mboxlist_lookup(mbname_intname(mbname), NULL, NULL);
         if (r != IMAP_MAILBOX_NONEXISTENT) goto done;
@@ -385,7 +385,7 @@ static int my_webdav_auth(const char *userid)
     }
 
  done:
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     mbname_free(&mbname);
     return r;
 }

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6248,7 +6248,7 @@ static void cmd_search(const char *tag, const char *cmd)
     char mytime[100];
     int usinguid = 0, n = 0;
     int state = GETSEARCH_RETURN;
-    struct mboxlock *namespacelock = NULL;
+    user_nslock_t *user_nslock = NULL;
 
     if (backend_current) {
         /* remote mailbox */
@@ -6336,7 +6336,7 @@ static void cmd_search(const char *tag, const char *cmd)
     // hold a lock across potentially multiple mailboxes
     // NOTE: we have to exclusively lock, because index_check will
     // write RECENT data, *sigh*
-    if (imapd_index) namespacelock = mboxname_usernamespacelock(index_mboxname(imapd_index));
+    if (imapd_index) user_nslock = user_nslock_lockmb_w(index_mboxname(imapd_index));
 
     // this refreshes the index, we may be looking at it in our search
     imapd_check(NULL, 0);
@@ -6487,7 +6487,7 @@ static void cmd_search(const char *tag, const char *cmd)
         condstore_enabled("SEARCH MODSEQ");
 
     // release before responding
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     int r = cmd_cancelled(/*insearch*/1);
     if (!r) {
@@ -6502,7 +6502,7 @@ static void cmd_search(const char *tag, const char *cmd)
 
   done:
     freesearchargs(searchargs);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 }
 
 /*
@@ -6836,21 +6836,7 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
     if (!r) {
         struct progress_rock prock = { &progress_cb, tag, time(0), 0 };
 
-        // make sure we get locks in order!
-        struct mboxlock *oldnamespacelock = NULL;
-        struct mboxlock *newnamespacelock = NULL;
-
-        const char *oldmailboxname = index_mboxname(imapd_index);
-        const char *newmailboxname = intname;
-
-        if (strcmpsafe(oldmailboxname, newmailboxname) < 0) {
-            oldnamespacelock = mboxname_usernamespacelock(oldmailboxname);
-            newnamespacelock = mboxname_usernamespacelock(newmailboxname);
-        }
-        else {
-            newnamespacelock = mboxname_usernamespacelock(newmailboxname);
-            oldnamespacelock = mboxname_usernamespacelock(oldmailboxname);
-        }
+        user_nslock_t *user_nslock = user_nslock_bymboxname(index_mboxname(imapd_index), intname, LOCK_EXCLUSIVE);
 
         r = index_copy(imapd_index, sequence, usinguid, intname,
                        &copyuid, !config_getswitch(IMAPOPT_SINGLEINSTANCESTORE),
@@ -6858,8 +6844,7 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
                        (imapd_userisadmin || imapd_userisproxyadmin), ismove,
                        ignorequota, &prock);
 
-        mboxname_release(&oldnamespacelock);
-        mboxname_release(&newnamespacelock);
+        user_nslock_release(&user_nslock);
     }
 
     if (ismove && copyuid && !r) {
@@ -7001,7 +6986,7 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
     if (mbname_userid(mbname) && !strarray_size(mbname_boxes(mbname)))
         is_inbox = 1;
 
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbname_intname(mbname));
+    user_nslock_t *user_nslock = user_nslock_lock_w(mbname_userid(mbname));
 
     const char *type = NULL;
 
@@ -7136,7 +7121,7 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
                     }
 
                     // don't hold the lock locally, we're proxying
-                    mboxname_release(&namespacelock);
+                    user_nslock_release(&user_nslock);
 
                     struct backend *s_conn = NULL;
 
@@ -7442,7 +7427,7 @@ localcreate:
 
 done:
     mailbox_close(&mailbox);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     mboxlist_entry_free(&parent);
     buf_free(&specialuse);
     mbname_free(&mbname);
@@ -7498,7 +7483,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
     }
 
     mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbname_intname(mbname));
+    user_nslock_t *user_nslock = user_nslock_lock_w(mbname_userid(mbname));
 
     r = mlookup(NULL, NULL, mbname_intname(mbname), &mbentry);
 
@@ -7508,7 +7493,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
         int res;
 
         // don't hold the lock locally, we're proxying
-        mboxname_release(&namespacelock);
+        user_nslock_release(&user_nslock);
 
         if (supports_referrals) {
             imapd_refer(tag, mbentry->server, name);
@@ -7606,7 +7591,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
                            /* add */ 0, /* force */ 1, /* notify? */ 0, /*silent*/1);
     }
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     imapd_check(NULL, 0);
 
@@ -7830,17 +7815,7 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location, 
     olduser = mboxname_to_userid(oldmailboxname);
     newuser = mboxname_to_userid(newmailboxname);
 
-    struct mboxlock *oldnamespacelock = NULL;
-    struct mboxlock *newnamespacelock = NULL;
-
-    if (strcmpsafe(oldmailboxname, newmailboxname) < 0) {
-        oldnamespacelock = mboxname_usernamespacelock(oldmailboxname);
-        newnamespacelock = mboxname_usernamespacelock(newmailboxname);
-    }
-    else {
-        newnamespacelock = mboxname_usernamespacelock(newmailboxname);
-        oldnamespacelock = mboxname_usernamespacelock(oldmailboxname);
-    }
+    user_nslock_t *user_nslock = user_nslock_lockdouble(olduser, newuser, LOCK_EXCLUSIVE);
 
     /* Keep temporary copy: master is trashed */
     strcpy(oldmailboxname2, oldmailboxname);
@@ -7877,8 +7852,7 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location, 
         int res;
 
         // don't hold the locks locally, we're proxying
-        mboxname_release(&oldnamespacelock);
-        mboxname_release(&newnamespacelock);
+        user_nslock_release(&user_nslock);
 
         s = proxy_findserver(mbentry->server, &imap_protocol,
                              proxy_userid, &backend_cached,
@@ -8284,8 +8258,7 @@ respond:
     }
 
 done:
-    mboxname_release(&oldnamespacelock);
-    mboxname_release(&newnamespacelock);
+    user_nslock_release(&user_nslock);
     // rename acls after the lock is dropped
     if (!r && rename_user)
         user_sharee_renameacls(&imapd_namespace, olduser, newuser);
@@ -9025,11 +8998,11 @@ static void cmd_setacl(char *tag, const char *name,
     int r;
     mbentry_t *mbentry = NULL;
 
-    char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(intname);
+    mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
+    user_nslock_t *user_nslock = user_nslock_lock_w(mbname_userid(mbname));
 
     /* is it remote? */
-    r = mlookup(tag, name, intname, &mbentry);
+    r = mlookup(tag, name, mbname_intname(mbname), &mbentry);
     if (r == IMAP_MAILBOX_MOVED) goto done;
 
     if (!config_getswitch(IMAPOPT_ALLOWSETACL))
@@ -9041,7 +9014,7 @@ static void cmd_setacl(char *tag, const char *name,
         int res;
 
         // don't hold the lock locally, we're calling remote
-        mboxname_release(&namespacelock);
+        user_nslock_release(&user_nslock);
 
         s = proxy_findserver(mbentry->server, &imap_protocol,
                              proxy_userid, &backend_cached,
@@ -9106,7 +9079,7 @@ static void cmd_setacl(char *tag, const char *name,
             }
         }
 
-        r = mboxlist_setacl(&imapd_namespace, intname, identifier, rights,
+        r = mboxlist_setacl(&imapd_namespace, mbname_intname(mbname), identifier, rights,
                             imapd_userisadmin || imapd_userisproxyadmin,
                             proxy_userid, imapd_authstate);
     }
@@ -9127,8 +9100,8 @@ static void cmd_setacl(char *tag, const char *name,
     }
 
 done:
-    mboxname_release(&namespacelock);
-    free(intname);
+    user_nslock_release(&user_nslock);
+    mbname_free(&mbname);
     mboxlist_entry_free(&mbentry);
 }
 
@@ -11418,7 +11391,7 @@ static void cmd_undump(char *tag, char *name)
 {
     int r = 0;
     mbname_t *mbname = mbname_from_extname(name, &imapd_namespace, imapd_userid);
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbname_intname(mbname));
+    user_nslock_t *user_nslock = user_nslock_lock_w(mbname_userid(mbname));
 
     /* administrators only please */
     if (!imapd_userisadmin)
@@ -11443,7 +11416,7 @@ static void cmd_undump(char *tag, char *name)
                     error_message(IMAP_OK_COMPLETED));
     }
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     mbname_free(&mbname);
 }
 
@@ -12635,13 +12608,13 @@ static void cmd_xfer(const char *tag, const char *name,
             }
             if (r) goto next;
 
-            struct mboxlock *namespacelock = user_namespacelock(xfer->userid);
+            user_nslock_t *user_nslock = user_nslock_lock_w(xfer->userid);
 
             if (!xfer->use_replication) {
                 /* set the quotaroot if needed */
                 r = xfer_setquotaroot(xfer, mbentry->name);
                 if (r) {
-                    mboxname_release(&namespacelock);
+                    user_nslock_release(&user_nslock);
                     goto next;
                 }
 
@@ -12649,7 +12622,7 @@ static void cmd_xfer(const char *tag, const char *name,
                 if (xfer->remoteversion < 12) {
                     r = seen_open(xfer->userid, SEEN_CREATE, &xfer->seendb);
                     if (r) {
-                        mboxname_release(&namespacelock);
+                        user_nslock_release(&user_nslock);
                         goto next;
                     }
                 }
@@ -12659,7 +12632,7 @@ static void cmd_xfer(const char *tag, const char *name,
             r = mboxlist_lookup_allow_all(inbox, &inbox_mbentry, NULL);
             free(inbox);
             if (r) {
-                mboxname_release(&namespacelock);
+                user_nslock_release(&user_nslock);
                 mboxlist_entry_free(&inbox_mbentry);
                 goto next;
             }
@@ -12677,7 +12650,7 @@ static void cmd_xfer(const char *tag, const char *name,
                 syslog(LOG_INFO, "XFER: deleting user metadata");
                 user_deletedata(inbox_mbentry, 0);
             }
-            mboxname_release(&namespacelock);
+            user_nslock_release(&user_nslock);
             mboxlist_entry_free(&inbox_mbentry);
         }
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -1271,6 +1271,9 @@ EXPORTED int index_fetch(struct index_state *state,
 
     index_unlock(state);
 
+    // we better not leak the annotationsdb across this change
+    assert(!annotate_anydb_islocked());
+
     index_checkflags(state, 1, 0);
 
     if (seqset_first(vanishedlist)) {

--- a/imap/jmap_admin.c
+++ b/imap/jmap_admin.c
@@ -170,7 +170,6 @@ static int rewrite_calevent_privacy(const char *userid, void *vrock)
     char *calhomename = caldav_mboxname(userid, NULL);
     struct caldav_db *caldavdb = NULL;
     struct conversations_state *cstate = NULL;
-    struct mboxlock *namespacelock = NULL;
     strarray_t sched_addrs = STRARRAY_INITIALIZER;
 
     int r = conversations_open_user(userid, 0, &cstate);
@@ -181,15 +180,6 @@ static int rewrite_calevent_privacy(const char *userid, void *vrock)
                 error_message(r));
         json_object_set_new(err, "description",
                 json_string(buf_cstring(&rock->buf)));
-        json_object_set_new(rock->not_rewritten, userid, err);
-        goto done;
-    }
-
-    namespacelock = user_namespacelock(userid);
-    if (!namespacelock) {
-        json_t *err = jmap_server_error(IMAP_INTERNAL);
-        json_object_set_new(err, "description",
-                json_string("can not lock namespace"));
         json_object_set_new(rock->not_rewritten, userid, err);
         goto done;
     }
@@ -323,7 +313,6 @@ done:
     buf_free(&rock->buf);
 
     if (caldavdb) caldav_close(caldavdb);
-    mboxname_release(&namespacelock);
     conversations_commit(&cstate);
     strarray_fini(&sched_addrs);
     free(calhomename);

--- a/imap/jmap_admin.c
+++ b/imap/jmap_admin.c
@@ -73,13 +73,13 @@ static jmap_method_t jmap_admin_methods_nonstandard[] = {
         "Admin/rewriteCalendarEventPrivacy",
         JMAP_ADMIN_EXTENSION,
         &jmap_admin_rewrite_calevent_privacy,
-        /*flags*/0
+        JMAP_NO_USERLOCK,
     },
     {
         "Admin/migrateCalendarDefaultAlarms",
         JMAP_ADMIN_EXTENSION,
         &jmap_admin_migrate_defaultalarms,
-        /*flags*/0
+        JMAP_NO_USERLOCK,
     },
     { NULL, NULL, NULL, 0}
 };

--- a/imap/jmap_admin.c
+++ b/imap/jmap_admin.c
@@ -530,14 +530,7 @@ static int jmap_admin_migrate_defaultalarms(jmap_req_t *req)
     for (int i = 0; i < strarray_size(&userids); i++) {
         const char *userid = strarray_nth(&userids, i);
 
-        struct mboxlock *namespacelock = user_namespacelock(userid);
-        if (!namespacelock) {
-            json_t *err = jmap_server_error(IMAP_INTERNAL);
-            json_object_set_new(err, "description",
-                    json_string("can not lock namespace"));
-            json_object_set_new(not_migrated_userids, userid, err);
-            continue;
-        }
+        user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 
         struct migrate_defaultalarms_rock rock = {
             .userid = userid,
@@ -556,7 +549,7 @@ static int jmap_admin_migrate_defaultalarms(jmap_req_t *req)
 
         json_decref(rock.migrated);
 
-        mboxname_release(&namespacelock);
+        user_nslock_release(&user_nslock);
     }
 
     // Create response

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -772,12 +772,14 @@ HIDDEN int jmap_api(struct transaction_t *txn,
         int readonly = !(mp->flags & JMAP_READ_WRITE);
         int locktype = readonly ? LOCK_SHARED : LOCK_EXCLUSIVE;
         user_nslock_t *user_nslock = NULL;
-        arg = json_object_get(args, "fromAccountId");
-        if (arg && arg != json_null()) {
-            user_nslock = user_nslock_lockdouble(accountid, json_string_value(arg), locktype);
-        }
-        else {
-            user_nslock = user_nslock_lock(accountid, locktype);
+        if (!(mp->flags & JMAP_NO_USERLOCK)) {
+            arg = json_object_get(args, "fromAccountId");
+            if (arg && arg != json_null()) {
+                user_nslock = user_nslock_lockdouble(accountid, json_string_value(arg), locktype);
+            }
+            else {
+                user_nslock = user_nslock_lock(accountid, locktype);
+            }
         }
 
         struct conversations_state *cstate = NULL;

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -220,6 +220,7 @@ enum jmap_method_flags {
     JMAP_READ_WRITE  = (1 << 0),  /* user can change state with this method */
     JMAP_NEED_CSTATE = (1 << 1),  /* conv.db is required for this method
                                      (lock type determined by r/w flag) */
+    JMAP_NO_USERLOCK = (1 << 2)   /* action touches many users, it will do its own locking */
 };
 
 typedef struct {

--- a/imap/jmap_backup.c
+++ b/imap/jmap_backup.c
@@ -93,25 +93,25 @@ static jmap_method_t jmap_backup_methods_nonstandard[] = {
         "Backup/restoreContacts",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_contacts,
-        /*flags*/0
+        JMAP_NEED_CSTATE | JMAP_READ_WRITE,
     },
     {
         "Backup/restoreCalendars",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_calendars,
-        /*flags*/0
+        JMAP_NEED_CSTATE | JMAP_READ_WRITE,
     },
     {
         "Backup/restoreNotes",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_notes,
-        /*flags*/0
+        JMAP_NEED_CSTATE | JMAP_READ_WRITE,
     },
     {
         "Backup/restoreMail",
         JMAP_BACKUP_EXTENSION,
         &jmap_backup_restore_mail,
-        /*flags*/0
+        JMAP_NEED_CSTATE | JMAP_READ_WRITE,
     },
     { NULL, NULL, NULL, 0}
 };
@@ -901,7 +901,6 @@ static int jmap_backup_restore_contacts(jmap_req_t *req)
         goto done;
     }
 
-    struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     char *addrhomeset = carddav_mboxname(req->accountid, NULL);
 
     syslog(restore.log_level, "jmap_backup_restore_contacts(%s, " TIME_T_FMT ")",
@@ -927,7 +926,6 @@ static int jmap_backup_restore_contacts(jmap_req_t *req)
     free(addrhomeset);
     carddav_close(crock.carddavdb);
     buf_free(&crock.buf);
-    mboxname_release(&namespacelock);
 
     /* Build response */
     if (r) {
@@ -1394,7 +1392,6 @@ static int jmap_backup_restore_calendars(jmap_req_t *req)
         goto done;
     }
 
-    struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     char *calhomeset = caldav_mboxname(req->accountid, NULL);
 
     syslog(restore.log_level, "jmap_backup_restore_calendars(%s, " TIME_T_FMT ")",
@@ -1418,7 +1415,6 @@ static int jmap_backup_restore_calendars(jmap_req_t *req)
     free(crock.inboxname);
     free(crock.outboxname);
     caldav_close(crock.caldavdb);
-    mboxname_release(&namespacelock);
 
     /* Build response */
     if (r) {
@@ -1487,7 +1483,6 @@ static int jmap_backup_restore_notes(jmap_req_t *req)
         goto done;
     }
 
-    struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     const char *subfolder = config_getstring(IMAPOPT_NOTESMAILBOX);
 
     syslog(restore.log_level, "jmap_backup_restore_notes(%s, " TIME_T_FMT ")",
@@ -1507,8 +1502,6 @@ static int jmap_backup_restore_notes(jmap_req_t *req)
         }
         free(notes);
     }
-
-    mboxname_release(&namespacelock);
 
     /* Build response */
     if (r) {
@@ -2138,7 +2131,6 @@ static int jmap_backup_restore_mail(jmap_req_t *req)
         goto done;
     }
 
-    struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     hash_table mailboxes = HASH_TABLE_INITIALIZER;
     hash_table emailids = HASH_TABLE_INITIALIZER;
     hash_table msgids = HASH_TABLE_INITIALIZER;
@@ -2186,7 +2178,6 @@ static int jmap_backup_restore_mail(jmap_req_t *req)
     free_hash_table(&emailids, &message_t_free);
     free_hash_table(&msgids, &message_t_free);
     free(inbox);
-    mboxname_release(&namespacelock);
 
     /* Build response */
     if (r) {

--- a/imap/jmap_blob.c
+++ b/imap/jmap_blob.c
@@ -283,7 +283,7 @@ static int jmap_blob_copy(jmap_req_t *req)
         goto cleanup;
     }
 
-    /* Check if we can upload to toAccountId */
+    /* Check if we are allowed to write */
     r = jmap_open_upload_collection(req->accountid, &to_mbox);
     if (r == IMAP_PERMISSION_DENIED) {
         json_array_foreach(copy.create, i, val) {

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -326,14 +326,6 @@ static int ensure_submission_collection(const char *accountid,
         return 0;
     }
 
-    // otherwise, clean up ready for next attempt
-    mboxlist_entry_free(&mbentry);
-
-    struct mboxlock *namespacelock = user_namespacelock(accountid);
-
-    // did we lose the race?
-    r = lookup_submission_collection(accountid, &mbentry);
-
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         if (created) *created = 1;
 
@@ -356,7 +348,6 @@ static int ensure_submission_collection(const char *accountid,
     }
 
  done:
-    mboxname_release(&namespacelock);
     if (mbentryp && !r) *mbentryp = mbentry;
     else mboxlist_entry_free(&mbentry);
     return r;

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4180,9 +4180,7 @@ static int jmap_mailbox_set(jmap_req_t *req)
 
     set.super.old_state = jmap_state_string(req, old_modseq, MBTYPE_EMAIL, 0);
 
-    struct mboxlock *namespacelock = user_namespacelock(req->accountid);
     _mboxset(req, &set);
-    mboxname_release(&namespacelock);
     jmap_ok(req, jmap_set_reply(&set.super));
 
 done:

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -87,19 +87,19 @@ static jmap_method_t jmap_notes_methods_nonstandard[] = {
         "Note/get",
         JMAP_NOTES_EXTENSION,
         &jmap_note_get,
-        /*flags*/0
+        JMAP_NEED_CSTATE,
     },
     {
         "Note/set",
         JMAP_NOTES_EXTENSION,
         &jmap_note_set,
-        JMAP_READ_WRITE
+        JMAP_NEED_CSTATE|JMAP_READ_WRITE
     },
     {
         "Note/changes",
         JMAP_NOTES_EXTENSION,
         &jmap_note_changes,
-        /*flags*/0
+        JMAP_NEED_CSTATE,
     },
     { NULL, NULL, NULL, 0}
 };
@@ -201,14 +201,6 @@ static int ensure_notes_collection(const char *accountid, mbentry_t **mbentryp)
         return 0;
     }
 
-    // otherwise, clean up ready for next attempt
-    mboxlist_entry_free(&mbentry);
-
-    struct mboxlock *namespacelock = user_namespacelock(accountid);
-
-    // did we lose the race?
-    r = lookup_notes_collection(accountid, &mbentry);
-
     if (r == IMAP_MAILBOX_NONEXISTENT) {
         if (!mbentry) goto done;
         else if (mbentry->server) {
@@ -242,7 +234,6 @@ static int ensure_notes_collection(const char *accountid, mbentry_t **mbentryp)
     }
 
  done:
-    mboxname_release(&namespacelock);
     if (mbentryp && !r) *mbentryp = mbentry;
     else mboxlist_entry_free(&mbentry);
     return r;

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -2520,7 +2520,7 @@ static int autosieve_createfolder(const char *userid, const struct auth_state *a
     if (!createsievefolder) return IMAP_MAILBOX_NONEXISTENT;
 
     // lock the namespace and check again before trying to create
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(internalname);
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 
     // did we lose the race?
     r = mboxlist_lookup(internalname, 0, 0);
@@ -2567,7 +2567,7 @@ static int autosieve_createfolder(const char *userid, const struct auth_state *a
     free(parent);
 
 done:
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     return r;
 }
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -62,7 +62,6 @@
 #define MAX_MAILBOX_NAME 510
 #define MAX_MAILBOX_BUFFER 1024
 #define MAX_MAILBOX_PATH 4096
-
 #define MAX_USER_FLAGS (16*8)
 
 #define MAILBOX_HEADER_MAGIC ("\241\002\213\015Cyrus mailbox header\n" \
@@ -294,7 +293,7 @@ struct mailbox {
     struct conversations_state *cstate_value;
 
     /* namespace lock */
-    struct mboxlock *local_namespacelock;
+    struct usernamespacelocks *user_nslock;
 
 #ifdef WITH_DAV
     struct caldav_db *local_caldav;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1270,7 +1270,7 @@ static int mboxlist_update_racl(const char *dbname, const mbentry_t *oldmbentry,
 static void assert_namespacelocked(const char *mboxname)
 {
     char *userid = mboxname_to_userid(mboxname);
-    assert(user_isnamespacelocked(userid));
+    assert(user_nslock_islocked(userid));
     free(userid);
 }
 
@@ -1537,9 +1537,9 @@ EXPORTED int mboxlist_delete(const mbentry_t *mbentry)
 
 EXPORTED int mboxlist_deletelock(const mbentry_t *mbentry)
 {
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
     int r = mboxlist_delete(mbentry);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     return r;
 }
 
@@ -1598,9 +1598,9 @@ EXPORTED int mboxlist_update_full(const mbentry_t *mbentry, int localonly, int s
 
 EXPORTED int mboxlist_updatelock(const mbentry_t *mbentry, int localonly)
 {
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
     int r = mboxlist_update(mbentry, localonly);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     return r;
 }
 
@@ -2245,13 +2245,11 @@ EXPORTED int mboxlist_createmailboxlock(const mbentry_t *mbentry,
                                         const struct auth_state *auth_state,
                                         unsigned flags, struct mailbox **mboxptr)
 {
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
-
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
     int r = mboxlist_createmailbox(mbentry, options, highestmodseq,
                                    isadmin, userid, auth_state,
                                    flags, mboxptr);
-
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     return r;
 }
 
@@ -2276,9 +2274,9 @@ EXPORTED int mboxlist_insertremote(mbentry_t *mbentry,
     }
 
     /* database put */
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
     r = mboxlist_update_entry(mbentry->name, mbentry, txn);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     switch (r) {
     case CYRUSDB_OK:
@@ -2307,7 +2305,7 @@ EXPORTED int mboxlist_deleteremote(const char *name, struct txn **in_tid)
     struct txn *lcl_tid = NULL;
     mbentry_t *mbentry = NULL;
     char *dbname = mboxname_to_dbname(name);
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(name);
 
     if(in_tid) {
         tid = in_tid;
@@ -2367,7 +2365,7 @@ EXPORTED int mboxlist_deleteremote(const char *name, struct txn **in_tid)
         cyrusdb_abort(mbdb, *tid);
     }
     mboxlist_entry_free(&mbentry);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
@@ -2719,11 +2717,9 @@ EXPORTED int mboxlist_deletemailboxlock(const char *name, int isadmin,
                                     struct mboxevent *mboxevent,
                                     int flags)
 {
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
-
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(name);
     int r = mboxlist_deletemailbox(name, isadmin, userid, auth_state, mboxevent, flags);
-
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     return r;
 }
 
@@ -3449,7 +3445,7 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
 
     // the namespacelock will protect us from all races on the local mailboxes.db
     // so we can just read away and know it won't change under us.
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(name);
 
     // not "anyone" or a group - do some username normalisation
     if (!isanyone && strncmp(identifier, "group:", 6)) {
@@ -3621,7 +3617,7 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
     free(newacl);
     mboxlist_entry_free(&mbentry);
     mbname_free(&idname);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
@@ -3631,7 +3627,7 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
 {
     // the namespacelock will protect us from all races on the local mailboxes.db
     // so we can just read away and know it won't change under us.
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(name);
 
     struct mailbox *mailbox = NULL;
     modseq_t foldermodseq = 0;
@@ -3646,7 +3642,7 @@ EXPORTED int mboxlist_updateacl_raw(const char *name, const char *newacl)
 
     if (!r) r = mboxlist_setacls(name, newacl, foldermodseq, /*silent*/0);
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     return r;
 }
 
@@ -3666,7 +3662,7 @@ mboxlist_setacls(const char *name, const char *newacl, modseq_t foldermodseq, in
 {
     // the namespacelock will protect us from all races on the local mailboxes.db
     // so we can just read away and know it won't change under us.
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(name);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(name);
     mbentry_t *mbentry = NULL;
     int r;
 
@@ -3726,7 +3722,7 @@ mboxlist_setacls(const char *name, const char *newacl, modseq_t foldermodseq, in
 
 done:
     mboxlist_entry_free(&mbentry);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
@@ -5855,9 +5851,9 @@ static void _upgrade_cb(const char *key __attribute__((unused)),
         mbentry_t *mbentry = (mbentry_t *) ptrarray_nth(pa, idx);
 
         if (!*urock->r) {
-            struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+            user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
             *urock->r = mboxlist_update_entry(mbentry->name, mbentry, urock->tid);
-            mboxname_release(&namespacelock);
+            user_nslock_release(&user_nslock);
         }
 
         mboxlist_entry_free(&mbentry);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -324,14 +324,6 @@ EXPORTED int mboxname_islocked(const char *mboxname)
     return lockitem->l.locktype;
 }
 
-EXPORTED struct mboxlock *mboxname_usernamespacelock_full(const char *mboxname, int locktype)
-{
-    mbname_t *mbname = mbname_from_intname(mboxname);
-    struct mboxlock *lock = user_namespacelock_full(mbname_userid(mbname), locktype);
-    mbname_free(&mbname);
-    return lock;
-}
-
 /******************** mbname stuff **********************/
 
 static void _mbdirty(mbname_t *mbname)

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -136,8 +136,6 @@ int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
                   int locktype);
 void mboxname_release(struct mboxlock **mboxlockptr);
 int mboxname_islocked(const char *mboxname);
-#define mboxname_usernamespacelock(m) mboxname_usernamespacelock_full(m, LOCK_EXCLUSIVE)
-struct mboxlock *mboxname_usernamespacelock_full(const char *mboxname, int locktype);
 int mboxname_run_with_lock(int (*cb)(void *), void *rock);
 
 /* Create namespace based on config options. */

--- a/imap/message.c
+++ b/imap/message.c
@@ -3574,7 +3574,7 @@ static int getconvmailbox(const char *mboxname, struct mailbox **mailboxptr)
     int r = mailbox_open_iwl(mboxname, mailboxptr);
     if (r != IMAP_MAILBOX_NONEXISTENT) return r;
 
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(mboxname);
 
     // try again - maybe we lost the race!
     r = mailbox_open_iwl(mboxname, mailboxptr);
@@ -3590,7 +3590,7 @@ static int getconvmailbox(const char *mboxname, struct mailbox **mailboxptr)
                                    0/*flags*/, mailboxptr);
     }
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     return r;
 }

--- a/imap/relocate_by_id.c
+++ b/imap/relocate_by_id.c
@@ -227,14 +227,7 @@ int main(int argc, char **argv)
 
             if (!quiet) printf("\nRelocating: %s\n", extname);
 
-            struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
-            if (!namespacelock) {
-                fprintf(stderr,
-                        "Failed to create namespacelock for %s: %s\n",
-                        extname, error_message(r));
-                mboxlist_entry_free(&mbentry);
-                goto cleanup;
-            }
+            user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
 
             /* If we're missing a partition, use the partition of child */
             if (!partition || !*partition) partition = buf_cstring(&part_buf);
@@ -370,7 +363,7 @@ int main(int argc, char **argv)
             }
 
           cleanup:
-            if (namespacelock) mboxname_release(&namespacelock);
+            user_nslock_release(&user_nslock);
             mboxlist_entry_free(&mbentry);
             strarray_free(oldpaths);
             strarray_free(newpaths);
@@ -431,9 +424,9 @@ static int find_p(const mbentry_t *mbentry, void *rock)
             if (!quiet) printf("\nPromoting intermediary: %s\n", extname);
 
             if (!nochanges) {
-                struct mboxlock *namespacelock = mboxname_usernamespacelock(mbentry->name);
+                user_nslock_t *user_nslock = user_nslock_lockmb_w(mbentry->name);
                 r = mboxlist_promote_intermediary(mbentry->name);
-                mboxname_release(&namespacelock);
+                user_nslock_release(&user_nslock);
                 if (r) {
                     fprintf(stderr,
                             "\tFailed to promote intermediary %s: %s\n",

--- a/imap/sync_reset.c
+++ b/imap/sync_reset.c
@@ -128,7 +128,7 @@ static int reset_single(const char *userid)
 {
     int r = 0;
     int i;
-    struct mboxlock *namespacelock = user_namespacelock(userid);
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 
     /* XXX: adding an entry to userdeny_db here would avoid the need to
      * protect against new logins with external proxy rules - Cyrus could
@@ -171,7 +171,7 @@ static int reset_single(const char *userid)
     if (mbentry) r = user_deletedata(mbentry, 1);
 
  fail:
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     mboxlist_entry_free(&mbentry);
     strarray_free(mblist);
     strarray_free(sublist);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2915,9 +2915,9 @@ static int sync_apply_mailbox(struct dlist *kin,
         newmbentry->foldermodseq = highestmodseq;
         newmbentry->createdmodseq = createdmodseq;
 
-        struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
+        user_nslock_t *user_nslock = user_nslock_lockmb_w(mboxname);
         r = mboxlist_update_full(newmbentry, /*localonly*/1, /*silent*/1);
-        mboxname_release(&namespacelock);
+        user_nslock_release(&user_nslock);
 
         mboxlist_entry_free(&newmbentry);
 
@@ -2968,14 +2968,7 @@ static int sync_apply_mailbox(struct dlist *kin,
 
     options = sync_parse_options(options_str);
 
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
-    if (!namespacelock) {
-        r = IMAP_MAILBOX_LOCKED;
-        xsyslog(LOG_ERR, "IOERROR: failed to usernamespacelock",
-                         "mailbox=<%s> uniqueid=<%s>",
-                         mboxname, uniqueid);
-        goto done;
-    }
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(mboxname);
 
     r = mailbox_open_iwl(mboxname, &mailbox);
     if (!r) r = sync_mailbox_version_check(&mailbox);
@@ -3365,7 +3358,7 @@ done:
     if (!r) mailbox_commit(mailbox);
 
     mailbox_close(&mailbox);
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
@@ -3943,7 +3936,7 @@ static int sync_apply_unmailbox(struct dlist *kin, struct sync_state *sstate)
 {
     const char *mboxname = kin->sval;
 
-    struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(mboxname);
 
     /* Delete with admin privileges */
     int delflags = MBOXLIST_DELETE_FORCE | MBOXLIST_DELETE_SILENT;
@@ -3953,7 +3946,7 @@ static int sync_apply_unmailbox(struct dlist *kin, struct sync_state *sstate)
                                    sstate->userid, sstate->authstate,
                                    NULL, delflags);
 
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
@@ -3977,21 +3970,10 @@ static int sync_apply_rename(struct dlist *kin, struct sync_state *sstate)
     /* optional */
     dlist_getnum32(kin, "UIDVALIDITY", &uidvalidity);
 
-    struct mboxlock *oldlock = NULL;
-    struct mboxlock *newlock = NULL;
+    user_nslock_t *user_nslock = user_nslock_bymboxname(oldmboxname, newmboxname, LOCK_EXCLUSIVE);
+
     mbentry_t *olddestmbentry = NULL;
     mbentry_t *newdestmbentry = NULL;
-
-    /* make sure we grab these locks in a stable order! */
-    if (strcmpsafe(oldmboxname, newmboxname) < 0) {
-        oldlock = mboxname_usernamespacelock(oldmboxname);
-        newlock = mboxname_usernamespacelock(newmboxname);
-    }
-    else {
-        // doesn't hurt to double lock, it's refcounted
-        newlock = mboxname_usernamespacelock(newmboxname);
-        oldlock = mboxname_usernamespacelock(oldmboxname);
-    }
 
     r = mboxlist_lookup_allow_all(oldmboxname, &mbentry, 0);
     if (r) goto done;
@@ -4057,8 +4039,7 @@ done:
     mboxlist_entry_free(&mbentry);
     mboxlist_entry_free(&olddestmbentry);
     mboxlist_entry_free(&newdestmbentry);
-    mboxname_release(&oldlock);
-    mboxname_release(&newlock);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
@@ -4317,7 +4298,7 @@ static int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
         return 0;
     }
 
-    struct mboxlock *namespacelock = user_namespacelock(userid);
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 
     /* Nuke subscriptions */
     /* ignore failures here - the subs file gets deleted soon anyway */
@@ -4357,7 +4338,7 @@ static int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
     }
 
  done:
-    mboxname_release(&namespacelock);
+    user_nslock_release(&user_nslock);
     mboxlist_entry_free(&mbentry);
     strarray_free(list);
 
@@ -4657,7 +4638,7 @@ static int sync_restore_mailbox(struct dlist *kin,
             uidvalidity = 0;
         }
 
-        struct mboxlock *namespacelock = mboxname_usernamespacelock(mboxname);
+        user_nslock_t *user_nslock = user_nslock_lockmb_w(mboxname);
         // try again under lock
         r = mailbox_open_iwl(mboxname, &mailbox);
         if (!r) r = sync_mailbox_version_check(&mailbox);
@@ -4686,7 +4667,7 @@ static int sync_restore_mailbox(struct dlist *kin,
                 __func__, mboxname, error_message(r));
             is_new_mailbox = 1;
         }
-        mboxname_release(&namespacelock);
+        user_nslock_release(&user_nslock);
     }
     if (r) {
         syslog(LOG_ERR, "Failed to open mailbox %s to restore: %s",


### PR DESCRIPTION
This does a bunch of things:

- check that we never have a global annotations db lock while we're locking any user, or when we're dropping to read-only long mailbox actions
- adds a dual-user locking version of namespace locks, which always takes them in the right order (and checks that they're not already locked incorrectly!)
- updates JMAP callers to double-lock whenever fromAccountId is set, removing a bunch of special-case code for /copy operations
- makes more /get operations reliably read-only so they can only take SHARED locks