### PR TITLE
index: init might be NULL

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -365,7 +365,7 @@ EXPORTED int index_open_mailbox(struct mailbox *mailbox, struct index_init *init
     if (init && init->select)
         init->vanishedlist = index_vanished(state, &init->vanished);
 
-    if (!init->stay_locked) index_unlock(state);
+    if (!init || !init->stay_locked) index_unlock(state);
 
     *stateptr = state;
 


### PR DESCRIPTION
Fixes a crash in `cyr_virusscan`, which came in with #5392.  The crash was detected by the ClamAV tests, but they don't currently run in CI.

Looking at callers to `index_open()` and `index_open_mailbox()`, `cyrdump` probably would have crashed here too, since it also passes NULL to the init argument.

(To have the ClamAV tests run locally, install libclamav-dev (or equivalent) and rebuild, the rest is automatic.)