### PR TITLE
charset.c: discard empty escape sequences from ISO-2022-JP text

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_iso2022jp
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_bodyvalues_iso2022jp
@@ -1,0 +1,59 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_bodyvalues_iso2022jp
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $imap = $self->{store}->get_client();
+
+    my $mime = <<'EOF';
+From: <from@local>
+To: <to@local>
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+Subject: msg5
+MIME-Version: 1.0
+Content-Type: text/html; charset="iso-2022-jp"
+Content-Transfer-Encoding: quoted-printable
+
+=1B$B!J=1B(B=1B$BGcJ*=
+=1B(B=1B$B!K=1B(B=
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+
+    my $msg = Cassandane::Message->new();
+    $msg->set_lines(split /\n/, $mime);
+    $self->{instance}->deliver($msg);
+
+    xlog "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-Z');
+
+    my $using = [
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:mail',
+        'urn:ietf:params:jmap:submission',
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/debug',
+        'https://cyrusimap.org/ns/jmap/performance',
+    ];
+
+    my $res = $jmap->CallMethods([
+        ['Email/query', { }, 'R1'],
+        ['Email/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name     => 'Email/query',
+                path     => '/ids'
+            },
+            fetchAllBodyValues => JSON::true,
+            properties => ['bodyValues'],
+        }, 'R2'],
+    ], $using);
+
+use utf8;
+    my $bodyValue = $res->[1][1]{list}[0]{bodyValues}{1};
+    $self->assert_str_equals("（買物）", $bodyValue->{value});
+    $self->assert_equals(JSON::false, $bodyValue->{isEncodingProblem});
+    $self->assert_equals(JSON::false, $bodyValue->{isTruncated});
+no utf8;
+}

--- a/cunit/charset.testc
+++ b/cunit/charset.testc
@@ -156,6 +156,64 @@ static void test_to_utf8(void)
     buf_free(&buf);
 }
 
+static void test_to_utf8_iso2022jp(void)
+{
+    struct test_case {
+        const char *input;
+        const char *want;
+        int encoding;
+    };
+
+    struct test_case test_cases[] = {{
+        .input = "=1B$B!J=1B(B=1B$BGcJ*=\r\n=1B(B=1B$B!K=1B(B",
+        .want = "（買物）",
+        .encoding = ENCODING_QP
+    }, {
+        // ASCII, no text
+        .input = "\x1b$B",
+        .want = "",
+    }, {
+        // ASCII, JIS X 0201-1976, no text
+        .input = "\x1b$B\x1b(B",
+        .want = "",
+    }, {
+        // text, JIS X 0208-1983, ASCII, text
+        .input = "foo\x1b$B\x1b(Bbar",
+        .want = "foobar",
+    }, {
+        // text, ASCII, ASCII, text
+        .input = "foo\x1b(B\x1b(Bbar",
+        .want = "foobar",
+    }, {
+        // text, JIS X 0208-1983, JIS X 0208-1978, ASCII, text
+        .input = "foo\x1b$B\x1b$@\x1b(Bbar",
+        .want = "foobar",
+    }, {
+        // JIS X 0208-1983, JIS X 0201-1976, 2byte-text, JIS X 0201-1976, ASCII
+        .input = "\x1b$B\x1b(J\x5c\x1b(J\x1b(B",
+        .want = "¥",
+    }, {
+        // JIS X 0201-1976, ASCII, JIS X 0208-1983, 2byte-text
+        .input = "\x1b(J\x1b(B\x1b$B\x24\x21",
+        .want = "ぁ",
+    }};
+
+    struct buf buf = BUF_INITIALIZER;
+    charset_t cs = charset_lookupname("iso-2022-jp");
+    CU_ASSERT_PTR_NOT_NULL(cs);
+
+    for (size_t i = 0; i < sizeof(test_cases)/sizeof(test_cases[0]); i++) {
+        struct test_case *tc = &test_cases[i];
+        int r = charset_to_utf8(
+            &buf, tc->input, strlen(tc->input), cs, tc->encoding);
+        CU_ASSERT_EQUAL(r, 0);
+        CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), tc->want);
+    }
+
+    charset_free(&cs);
+    buf_free(&buf);
+}
+
 static void test_to_imaputf7(void)
 {
     charset_t csu8 = charset_lookupname("utf-8");


### PR DESCRIPTION
This preprocesses text encoded in ISO-2022-JP before handing it over to libicu for conversion. The character encoding is defined in RFC 1468 and contains segments of both one-byte and two-byte character sequences. A segment starts with an escape sequence that indicates the encoding of the following text bytes.

Escape sequences must be followed by at least one text character, but some MIME messages violate this and instead concatenate multiple escape sequences. For every such sequence, libicu inserts a REPLACEMENT character. This is bad user experience and other character encoding libraries, such as the one for Java, Go or the iconv utility ignore such empty sequences.

This patch tweaks the charset pipeline by discarding all but the last in a run of escape sequences before passing the bytes to the libicu-based charset converters. As a result, the converted text does not contain REPLACEMENT characters, as if those empty escape sequences never were part of the byte stream.