### PR TITLE
more small dynarray tweaks

### DIFF
--- a/lib/dynarray.c
+++ b/lib/dynarray.c
@@ -95,6 +95,7 @@ static inline int grow(int have, int want)
 static void ensure_alloc(struct dynarray *da, int newalloc)
 {
     assert(newalloc >= 0);
+    assert(da->membsize > 0);
     if (newalloc < da->alloc)
         return;
     newalloc = grow(da->alloc, newalloc + 1);

--- a/lib/dynarray.c
+++ b/lib/dynarray.c
@@ -57,8 +57,10 @@ EXPORTED void dynarray_init(struct dynarray *da, size_t membsize)
 
 EXPORTED void dynarray_fini(struct dynarray *da)
 {
+    size_t membsize = da->membsize;
     free(da->data);
     memset(da, 0, sizeof(struct dynarray));
+    da->membsize = membsize;
 }
 
 EXPORTED struct dynarray *dynarray_new(size_t membsize)


### PR DESCRIPTION
Spent ages chasing a weird bug in a thing I'm working on, only for it to turn out that my statically initialised dynarray now had membsize==0, because it had been dynarray_fini'd on cleanup at the end of the previous unit test, and all accesses to it in the next unit test were calculating bogus offsets.  Ouch!

* ensure_alloc now asserts that membsize > 0.  Pretty much everything that needs membsize comes through here on the way in, so I didn't add assertions everywhere, just in ensure_alloc.
* dynarray_fini now preserves the membsize field.   This leaves the dynarray in the same state as dynarray_init: member size is known, but nothing is allocated.  It's now safe to re-use a dynarray after dynarray_fini, though I think the only time you'd expect to do so is in unit tests for modules that use them for internal state.