### PR TITLE
global.c: change how we set logmask

### DIFF
--- a/imap/global.c
+++ b/imap/global.c
@@ -187,19 +187,19 @@ static void cyrus_modules_done()
     }
 }
 
+static void debug_update_log_suppression() {
+  if (config_debug)
+    setlogmask(LOG_UPTO(LOG_DEBUG));
+  else
+    setlogmask(LOG_UPTO(LOG_INFO));
+}
+
 static void debug_toggled(void)
 {
-    int logmask = setlogmask(0); /* gets the current log mask */
-
-    if (config_debug)
-        logmask |= LOG_MASK(LOG_DEBUG);
-    else
-        logmask &= ~LOG_MASK(LOG_DEBUG);
+    debug_update_log_suppression();
 
     syslog(LOG_INFO, "debug logging turned %s",
                      config_debug ? "on" : "off");
-
-    setlogmask(logmask);
 }
 
 /* Called before a cyrus application starts (but after command line parameters
@@ -262,6 +262,8 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
     /* Load configuration file.  This will set config_dir when it finds it */
     config_read(alt_config, config_need_data);
 
+    debug_update_log_suppression();
+
     /* allow toggleable debug logging */
     config_toggle_debug_cb = &debug_toggled;
 
@@ -287,6 +289,7 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
 
         closelog();
         openlog(ident_buf, syslog_opts, facnum);
+        debug_update_log_suppression();
     }
     /* Do not free ident_buf, syslog needs it for the life of this process! */
 

--- a/master/masterconf.c
+++ b/master/masterconf.c
@@ -121,7 +121,7 @@ int masterconf_init(const char *ident, const char *alt_config)
 
     /* drop debug messages locally */
     if (!config_debug)
-        setlogmask(~LOG_MASK(LOG_DEBUG));
+        setlogmask(LOG_UPTO(LOG_INFO));
 
     return 0;
 }


### PR DESCRIPTION
Even with "debug: no" in config, I was seeing a lot of syslog debugging
getting sent.  The problem seems to have been that the logmask was not
being set reliably.  This fixes that by doing a few things:

1.  The logmask-setting has been hoisted into
    debug_update_log_suppression, which can be called outside the
    config_toggle_debug_cb -- meaning we can call it during initial
    setup.

2.  The logmask-setting now avoids explicit bit flipping in favor of the
    somewhat clearer LOG_UPTO macro.  (syslog priorities are numbered
    backward, so it really means "at least this priority" the way humans
    would understand it.)

3.  We update log suppression immediately after loading config.
    Previously, this wasn't happening, because we loaded config before
    calling debug_toggle.