### PR TITLE
Cassandane: put a "description" file in most instance base dirs

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -668,7 +668,10 @@ sub _create_instances
         $instance_params{old_jmap_ids} = $self->{old_jmap_ids}
             if exists $self->{old_jmap_ids};
 
-        $instance_params{description} = "main instance for test $self->{_name}";
+        my $class = ref $self;
+        my $name  = $self->{_name} =~ s/^test_//r;
+        $instance_params{description} = "main instance for test $class.$name";
+
         $self->{instance} = Cassandane::Instance->new(%instance_params);
         $self->{instance}->add_services(@{$want->{services}});
         $self->{instance}->_setup_for_deliver()
@@ -699,7 +702,9 @@ sub _create_instances
                 $replica_params{installation} = 'replica';
             }
 
-            $replica_params{description} = "replica instance for test $self->{_name}";
+            my $class = ref $self;
+            my $name  = $self->{_name} =~ s/^test_//r;
+            $replica_params{description} = "replica instance for test $class.$name";
             $self->{replica} = Cassandane::Instance->new(%replica_params,
                                                          setup_mailbox => 0);
             my ($v) = Cassandane::Instance->get_version($replica_params{installation});
@@ -745,7 +750,9 @@ sub _create_instances
                 $instance_params{installation} = 'murder';
             }
 
-            $instance_params{description} = "murder frontend for test $self->{_name}";
+            my $class = ref $self;
+            my $name  = $self->{_name} =~ s/^test_//r;
+            $instance_params{description} = "murder frontend for test $class.$name";
             $instance_params{config} = $frontend_conf;
             $self->{frontend} = Cassandane::Instance->new(%instance_params,
                                                           setup_mailbox => 0);
@@ -810,7 +817,9 @@ sub _create_instances
                 proxy_password => 'mailproxy',
             );
 
-            $instance_params{description} = "murder backend2 for test $self->{_name}";
+            my $class = ref $self;
+            my $name  = $self->{_name} =~ s/^test_//r;
+            $instance_params{description} = "murder backend2 for test $class.$name";
             $instance_params{config} = $backend2_conf;
             $self->{backend2} = Cassandane::Instance->new(%instance_params,
                                                           setup_mailbox => 0); # XXX ?

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -692,6 +692,7 @@ sub _list_pid_files
 sub _build_skeleton
 {
     my ($self) = @_;
+    my $basedir = $self->{basedir};
 
     my @subdirs =
     (
@@ -721,9 +722,20 @@ sub _build_skeleton
     );
     foreach my $sd (@subdirs)
     {
-        my $d = $self->{basedir} . '/' . $sd;
+        my $d = "$basedir/$sd";
         mkpath $d
             or die "Cannot make path $d: $!";
+    }
+
+    if ($self->{description}) {
+        open my $desc_fh, '>', "$basedir/description"
+            or die "Can't write to $basedir/description: $!";
+
+        $desc_fh->say($self->{description})
+            or die "Error writing to $basedir/description: $!";
+
+        close $desc_fh
+            or die "Error closing $basedir/description: $!";
     }
 }
 


### PR DESCRIPTION
After a test run, sometimes I want to very quickly find the main instance for the Foo.bar_baz test.  This is a bit of a pain.

This commit should make it a bit less of a pain.  When the test represented by &Cassandane::Cyrus::Foo::test_bar_baz is run, the /tmp/cass/XXXXX directory for its main instance will now have a `description` file that contains "Foo.bar_baz".

We can improve upon this in the future, but this should help to start.