### PR TITLE
Status crasher

### DIFF
--- a/cassandane/tiny-tests/List/list_return_uidvalidity
+++ b/cassandane/tiny-tests/List/list_return_uidvalidity
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_list_return_uidvalidity
+    :UnixHierarchySep :AltNamespace
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+
+    $self->setup_mailbox_structure($imaptalk, [
+        [ 'create' => [qw( Fruit Fruit/Apple Fruit/Banana Fruit/Peach)] ],
+    ]);
+
+    $imaptalk->select("Fruit");
+
+    my $data = $imaptalk->list([qw()], "", "*", 'RETURN', ['STATUS', [qw(UIDVALIDITY)]]);
+
+    $self->assert_mailbox_structure($data, '/', {
+        'INBOX'                 => [qw( \\HasNoChildren )],
+        'Fruit'                 => [qw( \\HasChildren )],
+        'Fruit/Apple'           => [qw( \\HasNoChildren )],
+        'Fruit/Banana'          => [qw( \\HasNoChildren )],
+        'Fruit/Peach'           => [qw( \\HasNoChildren )],
+    });
+}

--- a/imap/statuscache_db.c
+++ b/imap/statuscache_db.c
@@ -470,9 +470,6 @@ HIDDEN void status_fill_seen(const char *userid, struct statusdata *sdata,
     assert(userid);
     assert(sdata);
 
-    // we need a matching parent record to exist for these values to be valid
-    assert(sdata->statusitems & STATUS_HIGHESTMODSEQ);
-
     sdata->userid = userid;
     sdata->recent = numrecent;
     sdata->unseen = numunseen;


### PR DESCRIPTION
Fixes an assert when doing a LIST RETURN STATUS over a selected mailbox and not asking for anything which loads the mailbox data.