### PR TITLE
logging: log good and bad logins with logfmt

### DIFF
--- a/cassandane/Cassandane/Cyrus/Simple.pm
+++ b/cassandane/Cassandane/Cyrus/Simple.pm
@@ -231,9 +231,9 @@ sub test_toggleable_debug_logging
 
     # find our imapd pid from syslog
     my $loginpat = qr{
-        \bimap\[(\d+)\]:\slogin:
-        \s\S+\s\[[\d\.]+\]\scassandane\splaintext
-        \sUser\slogged\sin
+        \bimap\[(\d+)\]:\sevent=login\.good
+        .+
+        u\.username=cassandane
     }x;
     my @logins = $self->{instance}->getsyslog($loginpat);
     $self->assert_num_equals(1, scalar @logins);

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
@@ -157,7 +157,8 @@ provides more convenient way to manage *user_deny.db*.
 .. only:: html
 
     Subsequent login attempts by this user would result in authentication
-    failures, and log entries like this::
+    failures, and log entries like this (although log formats may change over
+    time)::
 
         # grep baduser /var/log/mail.log
         Sep 19 14:34:57 cyrushost cyrus/imap[635]: fetching user_deny.db entry for 'baduser'

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -1098,8 +1098,11 @@ void lmtpmode(struct lmtp_func *func,
                           if (r != SASL_NOUSER)
                               sasl_getprop(cd.conn, SASL_USERNAME, (const void **) &userid);
 
-                          syslog(LOG_ERR, "badlogin: %s %s (%s) [%s]",
-                                 cd.clienthost, mech, userid, sasl_errdetail(cd.conn));
+                          xsyslog_ev(LOG_NOTICE, "login.bad",
+                                     lf_s("r.clienthost", cd.clienthost),
+                                     lf_s("u.username", userid),
+                                     lf_s("login.mech", mech),
+                                     lf_s("error", sasl_errdetail(cd.conn)));
 
                           prometheus_increment(CYRUS_IMAP_AUTHENTICATE_TOTAL_RESULT_NO);
 
@@ -1135,9 +1138,11 @@ void lmtpmode(struct lmtp_func *func,
               /* authenticated successfully! */
 
               prometheus_increment(CYRUS_IMAP_AUTHENTICATE_TOTAL_RESULT_YES);
-              syslog(LOG_NOTICE, "login: %s %s %s%s %s",
-                     cd.clienthost, user, mech,
-                     cd.starttls_done ? "+TLS" : "", "User logged in");
+              xsyslog_ev(LOG_NOTICE, "login.good",
+                         lf_s("r.clienthost", cd.clienthost),
+                         lf_s("u.username", user),
+                         lf_s("login.mech", mech),
+                         lf_c("login.tls", cd.starttls_done ? 1 : 0));
 
               cd.authenticated = DIDAUTH;
               prot_printf(pout, "235 Authenticated!\r\n");

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1500,9 +1500,11 @@ static void cmd_authenticate(struct conn *C,
             if (r != SASL_NOUSER)
                 sasl_getprop(C->saslconn, SASL_USERNAME, (const void **) &userid);
 
-            syslog(LOG_ERR, "badlogin: %s %s (%s) [%s]",
-                   C->clienthost,
-                   mech, userid, sasl_errdetail(C->saslconn));
+            xsyslog_ev(LOG_NOTICE, "login.bad",
+                       lf_s("r.clienthost", C->clienthost),
+                       lf_s("u.username", userid),
+                       lf_s("login.mech", mech),
+                       lf_s("error", sasl_errdetail(C->saslconn)));
 
             prot_printf(C->pout, "%s NO \"%s\"\r\n", tag,
                         sasl_errstring((r == SASL_NOUSER ? SASL_BADAUTH : r),
@@ -1522,8 +1524,11 @@ static void cmd_authenticate(struct conn *C,
     }
 
     C->userid = (char *) val;
-    syslog(LOG_NOTICE, "login: %s %s %s%s %s", C->clienthost, C->userid,
-           mech, C->tlsconn ? "+TLS" : "", "User logged in");
+    xsyslog_ev(LOG_NOTICE, "login.good",
+               lf_s("r.clienthost", C->clienthost),
+               lf_s("u.username", C->userid),
+               lf_s("login.mech", mech),
+               lf_c("login.tls", C->tlsconn ? 1 : 0));
 
     prot_printf(C->pout, "%s OK \"Authenticated\"\r\n", tag);
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -48,6 +48,7 @@
 
 #include <config.h>
 #include <ctype.h>
+#include <errno.h>
 #include <sys/types.h>
 #include <inttypes.h>
 #include <limits.h>

--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -59,6 +59,7 @@
 
 #include "assert.h"
 #include "libconfig.h"
+#include "util.h"
 #include "xmalloc.h"
 #include "xstrlcpy.h"
 
@@ -688,8 +689,10 @@ static int cmd_authenticate(struct protstream *sieved_out,
       if (sasl_result!=SASL_OK)
       {
         *errmsg="error base64 decoding string";
-        syslog(LOG_NOTICE, "badlogin: %s %s %s",
-               sieved_clienthost, mech, "error base64 decoding string");
+        xsyslog_ev(LOG_NOTICE, "login.bad",
+                   lf_s("r.clienthost", sieved_clienthost),
+                   lf_s("login.mech", mech),
+                   lf_s("error", *errmsg));
         goto reset;
       }
   }
@@ -736,8 +739,10 @@ static int cmd_authenticate(struct protstream *sieved_out,
       if (sasl_result!=SASL_OK)
       {
         *errmsg="error base64 decoding string";
-        syslog(LOG_NOTICE, "badlogin: %s %s %s",
-               sieved_clienthost, mech, "error base64 decoding string");
+        xsyslog_ev(LOG_NOTICE, "login.bad",
+                   lf_s("r.clienthost", sieved_clienthost),
+                   lf_s("login.mech", mech),
+                   lf_s("error", *errmsg));
         goto reset;
       }
 
@@ -757,8 +762,10 @@ static int cmd_authenticate(struct protstream *sieved_out,
                                      &serverout, &serveroutlen);
     } else {
       *errmsg = "expected a STRING followed by an EOL";
-      syslog(LOG_NOTICE, "badlogin: %s %s %s",
-             sieved_clienthost, mech, "expected string");
+      xsyslog_ev(LOG_NOTICE, "login.bad",
+                 lf_s("r.clienthost", sieved_clienthost),
+                 lf_s("login.mech", mech),
+                 lf_s("error", *errmsg));
       goto reset;
     }
 
@@ -770,8 +777,10 @@ static int cmd_authenticate(struct protstream *sieved_out,
       if(sasl_result == SASL_NOUSER)
           sasl_result = SASL_BADAUTH;
       *errmsg = (const char *) sasl_errstring(sasl_result,NULL,NULL);
-      syslog(LOG_NOTICE, "badlogin: %s %s %s",
-             sieved_clienthost, mech, *errmsg);
+      xsyslog_ev(LOG_NOTICE, "login.bad",
+                 lf_s("r.clienthost", sieved_clienthost),
+                 lf_s("login.mech", mech),
+                 lf_s("error", *errmsg));
       goto reset;
   }
 
@@ -882,8 +891,11 @@ static int cmd_authenticate(struct protstream *sieved_out,
       prot_printf(sieved_out, "OK\r\n");
   }
 
-  syslog(LOG_NOTICE, "login: %s %s %s%s %s", sieved_clienthost, username,
-         mech, starttls_done ? "+TLS" : "", "User logged in");
+  xsyslog_ev(LOG_NOTICE, "login.good",
+             lf_s("r.clienthost", sieved_clienthost),
+             lf_s("u.username", username),
+             lf_s("login.mech", mech),
+             lf_c("login.tls", starttls_done ? 1 : 0));
 
   authenticated = 1;
 


### PR DESCRIPTION
This is the first big push toward logfmt-based logging, chosen not because it's the most important thing to convert, but because it was a fairly wide-ranging update with a limited subject matter.

One next step is to write down what a "login.good" and "login.bad" event should look like and stick it in notes.  Even without that, this makes logins easy to machine-parse.

Special note, the loss of `popd_apop_chal` in popd login failure logging.  I think this is acceptable, largely because I don't know what anybody would want to do with the challenge in their logs!