### PR TITLE
Master: fix babysit syslog check

### DIFF
--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -1504,8 +1504,8 @@ sub test_babysit
     };
 
     # make sure it said it's going to wait
-    my @lines = $self->{instance}->getsyslog(qr/ERROR: too many failures .*disabling/);
-    $self->assert_num_equals(1, scalar @lines);
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{ERROR: too many failures .*disabling});
 
     # master should not have restarted after 5 deaths
     $self->assert_deep_equals({ A => { live => 0, dead => 5 } },

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -2715,6 +2715,10 @@ sub setup_syslog_replacement
 # But if you need to make sure an error WAS logged, first make sure that
 # $instance->{have_syslog_replacement} is true, otherwise you will always
 # fail on systems where the syslog replacement doesn't work.
+#
+# In most cases you probably want assert_syslog_matches from TestCase
+# (or assert_syslog_does_not_match).  If you need something trickier,
+# check those anyway to see how to do so safely.
 sub getsyslog
 {
     my ($self, $pattern) = @_;


### PR DESCRIPTION
Direct unconditional use of getsyslog was causing this test to fail when the syslog replacement was unavailable (e.g. due to having compiled with source fortification enabled).