### PR TITLE
TestCase: fix warning when no lsan_suppressions

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -599,7 +599,7 @@ sub _create_instances
     my $want = $self->{_want};
     my %instance_params = %{$self->{_instance_params}};
 
-    $instance_params{lsan_suppressions} = "$self->{lsan_suppressions}";
+    $instance_params{lsan_suppressions} = $self->{lsan_suppressions} // "";
 
     my $cassini = Cassandane::Cassini->instance();
 


### PR DESCRIPTION
Fixes:

> Use of uninitialized value in string at Cassandane/Cyrus/TestCase.pm line 602, <GEN2> line 1.