### PR TITLE
caldav_util.c: don't write lock (use a txn) when reading per-user cal data

### DIFF
--- a/cassandane/tiny-tests/Caldav/invite_shared_with_attachment
+++ b/cassandane/tiny-tests/Caldav/invite_shared_with_attachment
@@ -1,0 +1,72 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_invite_shared_with_attachment
+    :Conversations :MailboxLegacyDirs
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->create("user.manifold");
+
+    my $service = $self->{instance}->get_service("http");
+    my $mantalk = Net::CalDAVTalk->new(
+        user => "manifold",
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    xlog $self, "create calendar";
+    my $CalendarId = $mantalk->NewCalendar({name => 'Shared Calendar'});
+    $self->assert_not_null($CalendarId);
+
+    xlog $self, "share to user (without 'k' or 'x')";
+    $admintalk->setacl("user.manifold.#calendars.$CalendarId",
+                       "cassandane" => 'lrspwiten');
+
+    my $CalDAV = Net::CalDAVTalk->new(
+        user => "cassandane",
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+    my $href = "manifold.$CalendarId/$uuid.ics";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:$uuid
+DTEND;TZID=Australia/Melbourne:20160831T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=Australia/Melbourne:20160831T153000
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:cassandane\@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:friend\@example.com
+ORGANIZER;CN=Test User:MAILTO:cassandane\@example.com
+ATTACH;ENCODING=BASE64;VALUE=BINARY:/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////wgALCAABAAEBAREA/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPxA=
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $CalDAV->Request('PUT', $href, $card, 'Content-Type' => 'text/calendar');
+
+    $self->assert_caldav_notified(
+        { recipient => "friend\@example.com", is_update => JSON::false, method => 'REQUEST' },
+    );
+
+    # Update the event (will cause an assert() if we have a lock inversion)
+    $CalDAV->Request('PUT', $href, $card, 'Content-Type' => 'text/calendar');
+}

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -233,21 +233,17 @@ EXPORTED int caldav_is_personalized(struct mailbox *mailbox,
 
     if (cdata->comp_flags.shared) {
         /* Lookup per-user calendar data */
-        int r = mailbox_get_annotate_state(mailbox, cdata->dav.imap_uid, NULL);
+        mbname_t *mbname = NULL;
 
-        if (!r) {
-            mbname_t *mbname = NULL;
-
-            if (mailbox->i.options & OPT_IMAP_SHAREDSEEN) {
-                /* No longer using per-user-data - use owner data */
-                mbname = mbname_from_intname(mailbox_name(mailbox));
-                userid = mbname_userid(mbname);
-            }
-
-            r = mailbox_annotation_lookup(mailbox, cdata->dav.imap_uid,
-                                          PER_USER_CAL_DATA, userid, userdata);
-            mbname_free(&mbname);
+        if (mailbox->i.options & OPT_IMAP_SHAREDSEEN) {
+            /* No longer using per-user-data - use owner data */
+            mbname = mbname_from_intname(mailbox_name(mailbox));
+            userid = mbname_userid(mbname);
         }
+
+        int r = annotatemore_msg_lookup(mailbox, cdata->dav.imap_uid,
+                                        PER_USER_CAL_DATA, userid, userdata);
+        mbname_free(&mbname);
 
         if (!r && buf_len(userdata)) return 1;
         buf_free(userdata);


### PR DESCRIPTION
Otherwise, annotate_anydb_islocked() can fail on an event update