### PR TITLE
mailbox: keep all the change flags

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2274,7 +2274,8 @@ static int _store_change(struct mailbox *mailbox, struct index_record *record, i
 
     /* finally always copy the data into place */
     change->record = *record;
-    change->flags = flags;
+    /* rewrite might set extra flags, keep all of them */
+    change->flags |= flags;
 
     if (mailbox_cacherecord(mailbox, record)) {
         /* failed to load cache record */


### PR DESCRIPTION
We store ISAPPEND during append, but if we then rewrite the record before committing, we were losing that flag.  We need to keep all the flags so we generate all the syslog lines.

This was discovered when trying to track down "missing log lines" in Fastmail production, but it turned out they weren't missing after all, just not logged!