### PR TITLE
smtpclient and others: Fix smtp typos

### DIFF
--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -143,7 +143,7 @@ sub default
             # smtpclient_open should fail by default!
             #
             # If your test fails and writes something like
-            #     smptclient_open: can't connect to host: bogus:0/noauth
+            #     smtpclient_open: can't connect to host: bogus:0/noauth
             # in syslog, then Cyrus is calling smtpclient_open(), and you
             # will need to arrange for fakesmtpd to be listening.  To do
             # this add :want_smtpdaemon to the test attributes, or enable

--- a/cassandane/tiny-tests/Sieve/vacation_multiple
+++ b/cassandane/tiny-tests/Sieve/vacation_multiple
@@ -3,6 +3,7 @@ use Cassandane::Tiny;
 
 sub test_vacation_multiple
     :min_version_3_1
+    :want_smtpdaemon
 {
     my ($self) = @_;
 

--- a/imap/smtpclient.c
+++ b/imap/smtpclient.c
@@ -681,19 +681,19 @@ static int validate_envelope_params(ptrarray_t *params)
         smtp_param_t *param = ptrarray_nth(params, i);
         if (!smtp_is_valid_esmtp_keyword(param->key)) {
             syslog(LOG_ERR,
-                   "smtpclient: sessionid=<%s> invalid estmp keyword: \"%s\"",
+                   "smtpclient: sessionid=<%s> invalid esmtp keyword: \"%s\"",
                    session_id(), param->key);
             return IMAP_PROTOCOL_ERROR;
         }
         if (!strcasecmp(param->key, "AUTH")) {
             syslog(LOG_ERR,
-                   "smptclient: sessionid=<%s> rejecting AUTH parameter in envelope",
+                   "smtpclient: sessionid=<%s> rejecting AUTH parameter in envelope",
                    session_id());
             return IMAP_PERMISSION_DENIED;
         }
         if (param->val && !smtp_is_valid_esmtp_value(param->val)) {
             syslog(LOG_ERR,
-                   "smtpclient: sessionid=<%s> invalid estmp value: \"%s\"",
+                   "smtpclient: sessionid=<%s> invalid esmtp value: \"%s\"",
                    session_id(), param->val);
             return IMAP_PROTOCOL_ERROR;
         }
@@ -923,7 +923,7 @@ EXPORTED int smtpclient_open_host(const char *addr, smtpclient_t **smp)
     if (sasl_cb) free_callbacks(sasl_cb);
     if (!bk) {
         syslog(LOG_ERR,
-               "smptclient_open: sessionid=<%s> can't connect to host: %s",
+               "smtpclient_open: sessionid=<%s> can't connect to host: %s",
                session_id(), host);
         if (logfd != -1) close(logfd);
         r = IMAP_INTERNAL;
@@ -1091,7 +1091,7 @@ EXPORTED int smtpclient_open_sendmail(smtpclient_t **smp)
     bk = backend_connect_pipe(ctx->infd, ctx->outfd, &smtp_protocol, 0, logfd);
     if (!bk) {
         syslog(LOG_ERR,
-               "smptclient_open: sessionid=<%s> can't open sendmail backend",
+               "smtpclient_open: sessionid=<%s> can't open sendmail backend",
                session_id());
         r = IMAP_INTERNAL;
         smtpclient_sendmail_freectx(ctx);


### PR DESCRIPTION
And fix vacation_multiple test which relied on that typo to not fail. Without an smtp daemon running it was logging two messages about smtpclient, but one of them was spelled wrong so the test never picked up on it.