### PR TITLE
cass: Add ContactCard test showing adding a member to an empty group …

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_set_add_remove_add
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_set_add_remove_add
@@ -1,0 +1,84 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_cardgroup_set_add_remove_add
+    :min_version_3_9 :needs_dependency_icalvcard
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my $service = $self->{instance}->get_service("http");
+
+    xlog $self, "Make a contact card";
+    my $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            create => {
+                "1" => {
+                    '@type' => 'Card',
+                    version => '1.0',
+                    name => { full => 'John Doe' },
+                },
+            }
+        }, 'R1']
+    ]);
+
+    my $card_id = $res->[0][1]{created}{1}{id};
+    $self->assert_not_null($card_id);
+
+    xlog $self, "Make a contact group";
+    my $name = 'The Doe Family';
+
+    $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            create => {
+                "1" => {
+                    '@type' => 'Card',
+                    version => '1.0',
+                    kind => 'group',
+                    name => { full => $name },
+                }
+            }
+        }, 'R1']
+    ]);
+
+    my $group_id = $res->[0][1]{created}{1}{id};
+    $self->assert_not_null($group_id);
+
+    xlog $self, "Add the member";
+    $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            update => {
+                $group_id => {
+                    "members/$card_id" => JSON::true
+                }
+            }
+         }, "R2"]
+    ]);
+
+    $self->assert_not_null($res->[0][1]{updated}{$group_id});
+
+    xlog $self, "Remove the member";
+    $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            update => {
+                $group_id => {
+                    "members/$card_id" => undef,
+                }
+            }
+         }, "R2"]
+    ]);
+
+    $self->assert_not_null($res->[0][1]{updated}{$group_id});
+
+    xlog $self, "Re-add the member";
+    $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            update => {
+                $group_id => {
+                    "members/$card_id" => JSON::true
+                }
+            }
+         }, "R2"]
+    ]);
+    $self->assert_not_null($res->[0][1]{updated}{$group_id});
+}

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -11748,6 +11748,7 @@ static int _card_set_update(jmap_req_t *req, unsigned kind,
                                            db, *mailbox, &record,
                                            IGNORE_VCARD_VERSION | IGNORE_DERIVED_PROPS);
     vcardcomponent_free(vcard);
+    vcard = NULL;
 
     /* Remove old "updated" */
     json_object_del(old_obj, "updated");


### PR DESCRIPTION
…crashes

I've seen crashes after adding a contact to an empty group after removing all previous contacts, but this test is actually triggering the crash on the *first* add, which surprised me...