### PR TITLE
message.c: parse multipart bodies containing bare newlines

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_get_barelf_multipart
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_barelf_multipart
@@ -1,0 +1,66 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_barelf_multipart
+  : RFC2047_UTF8 : NoMunge8Bit
+{
+    my ($self) = @_;
+    my $imap   = $self->{store}->get_client();
+    my $jmap   = $self->{jmap};
+
+    # This is a regression test for handling MIME messages containing
+    # bare newline in Email/get. It assumes that APPEND accepts such
+    # messages as binary literals. This might change in the future in
+    # which case it's OK for this test to fail.
+    # The message cunit tests contain a regression test to ensure that
+    # parsing these MIME messages work even if APPEND rejects them.
+
+    my $mimeBareLF = <<"EOF";
+From: from\@local\r
+To: to\@local\r
+Subject: test\r
+Date: Mon, 13 Apr 2020 15:34:03 +0200\r
+Content-Type: multipart/alternative;\r
+ boundary=xxxxxxxxxxxxxxxxxxxxxx\r
+MIME-Version: 1.0\r
+\r
+--xxxxxxxxxxxxxxxxxxxxxx\r
+Content-Type: text/plain
+X-Foo: bar
+
+textbody
+--xxxxxxxxxxxxxxxxxxxxxx
+Content-Type: text/html
+
+htmlbody
+--xxxxxxxxxxxxxxxxxxxxxx--
+EOF
+    $imap->append('inbox', { Binary => $mimeBareLF });
+
+    my $res = $jmap->CallMethods([
+        [ 'Email/query', {}, 'R1' ],
+        [
+            'Email/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    name     => 'Email/query',
+                    path     => '/ids'
+                },
+                properties         => [ 'bodyStructure', 'bodyValues' ],
+                bodyProperties     => [ 'partId', 'blobId', 'type', 'header:x-foo' ],
+                fetchAllBodyValues => JSON::true,
+            },
+            'R2'
+        ],
+    ]);
+
+    my $bodyStructure = $res->[1][1]{list}[0]{bodyStructure};
+    $self->assert_not_null($bodyStructure);
+    $self->assert_str_equals('multipart/alternative', $bodyStructure->{type});
+    $self->assert_num_equals(2, scalar @{ $bodyStructure->{subParts} });
+    $self->assert_str_equals('text/plain', $bodyStructure->{subParts}[0]{type});
+    $self->assert_str_equals(' bar', $bodyStructure->{subParts}[0]{'header:x-foo'});
+    $self->assert_str_equals('text/html',  $bodyStructure->{subParts}[1]{type});
+    $self->assert_null($bodyStructure->{subParts}[1]{'header:x-foo'});
+}

--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -1419,4 +1419,112 @@ static void test_parse_received_semicolon(void)
    message_free_body(&body);
 
 }
+
+static int foreach_header_cb(const char *name, const char *value, void *rock)
+{
+    strarray_t *headers = rock;
+    strarray_append(headers, name);
+    strarray_append(headers, value);
+    return 0;
+}
+
+static void test_barelf_multipart(void)
+{
+    static const char msg[] =
+"From: from@local\r\n"
+"To: to@local\r\n"
+"Subject: test\r\n"
+"Date: Mon, 13 Apr 2020 15:34:03 +0200\r\n"
+"Content-Type: multipart/alternative;\r\n"
+" boundary=boundary123456789\r\n"
+"Message-ID: <fake800@fastmail.fm>\r\n"
+"MIME-Version: 1.0\r\n"
+"\r\n"
+"--boundary123456789\r\n"
+"Content-Type: text/plain\n" // bare LFs start here
+"X-Foo:bar\n"
+"\n"
+"textbody\n"
+"--boundary123456789\n"
+"Content-Type: text/html\n"
+"\n"
+"htmlbody\n"
+"--boundary123456789--\n";
+
+    struct buf buf = BUF_INITIALIZER;
+    strarray_t headers = STRARRAY_INITIALIZER;
+
+    struct body body;
+    memset(&body, 0x45, sizeof(body));
+    int r = message_parse_mapped(msg, sizeof(msg)-1, &body, NULL);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(strlen(msg), body.filesize);
+
+    // Assert top-level headers and media type.
+    CU_ASSERT_STRING_EQUAL(body.message_id, "<fake800@fastmail.fm>");
+    CU_ASSERT_STRING_EQUAL(body.type, "MULTIPART");
+    CU_ASSERT_STRING_EQUAL(body.subtype, "ALTERNATIVE");
+    CU_ASSERT_EQUAL(2, body.numparts);
+
+    // Assert first body part.
+
+    buf_setmap(&buf, msg + body.subpart[0].header_offset,
+            body.subpart[0].header_size);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf),
+            "Content-Type: text/plain\nX-Foo:bar\n\n");
+
+    message_foreach_header(
+        buf_base(&buf), buf_len(&buf), foreach_header_cb, &headers);
+    CU_ASSERT_EQUAL(4, strarray_size(&headers));
+    CU_ASSERT_STRING_EQUAL("Content-Type", strarray_nth(&headers, 0));
+    CU_ASSERT_STRING_EQUAL(" text/plain", strarray_nth(&headers, 1));
+    CU_ASSERT_STRING_EQUAL("X-Foo", strarray_nth(&headers, 2));
+    CU_ASSERT_STRING_EQUAL("bar", strarray_nth(&headers, 3));
+    strarray_fini(&headers);
+
+    CU_ASSERT_STRING_EQUAL(body.subpart[0].type, "TEXT");
+    CU_ASSERT_STRING_EQUAL(body.subpart[0].subtype, "PLAIN");
+
+    buf_setmap(&buf, msg + body.subpart[0].content_offset,
+            body.subpart[0].content_size);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "textbody");
+
+    buf_setmap(&buf, msg +
+            body.subpart[0].content_offset +
+            body.subpart[0].content_size,
+            body.subpart[0].boundary_size);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "\n--boundary123456789\n");
+
+    // Assert second body part.
+
+    buf_setmap(&buf, msg + body.subpart[1].header_offset,
+            body.subpart[1].header_size);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf),
+            "Content-Type: text/html\n\n");
+
+    message_foreach_header(
+        buf_base(&buf), buf_len(&buf), foreach_header_cb, &headers);
+    CU_ASSERT_EQUAL(2, strarray_size(&headers));
+    CU_ASSERT_STRING_EQUAL("Content-Type", strarray_nth(&headers, 0));
+    CU_ASSERT_STRING_EQUAL(" text/html", strarray_nth(&headers, 1));
+    strarray_fini(&headers);
+
+    CU_ASSERT_STRING_EQUAL(body.subpart[1].type, "TEXT");
+    CU_ASSERT_STRING_EQUAL(body.subpart[1].subtype, "HTML");
+
+    buf_setmap(&buf, msg + body.subpart[1].content_offset,
+            body.subpart[1].content_size);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "htmlbody");
+
+    buf_setmap(&buf, msg +
+            body.subpart[1].content_offset +
+            body.subpart[1].content_size,
+            body.subpart[1].boundary_size);
+    CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), "\n--boundary123456789--\n");
+
+    message_free_body(&body);
+    strarray_fini(&headers);
+    buf_free(&buf);
+}
+
 /* vim: set ft=c: */

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -78,7 +78,7 @@
  * changes to backend_version() in backend.c.
  */
 #define MAILBOX_MINOR_VERSION       (20) /* read comment above! */
-#define MAILBOX_CACHE_MINOR_VERSION (13)
+#define MAILBOX_CACHE_MINOR_VERSION (14)
 
 #define FNAME_HEADER "/cyrus.header"
 #define FNAME_INDEX "/cyrus.index"


### PR DESCRIPTION
Bare newlines are forbidden except for "binary" Content-Transfer encoding but APPEND leniently accepts such messages. This patch is to parse them appropriately, irrespective if APPEND might become more stricter for new messages in the future.