### PR TITLE
more cassandane syslog fixes

### DIFF
--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -1268,6 +1268,12 @@ sub test_unmap_failed_appends
     :NoCheckSyslog
 {
     my ($self) = @_;
+
+    if (not $self->{instance}->{have_syslog_replacement}) {
+        xlog "syslog replacement unavailable, can't do anything";
+        return;
+    }
+
     my $imap = $self->{store}->get_client();
 
     my $mime = <<'EOF';

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -1498,9 +1498,9 @@ sub test_babysit
     for (1..20) {
       $killed++ if $self->lemming_cull();
 
-      last if $killed >= 5;
-
       sleep(.5);
+
+      last if $killed >= 5;
     };
 
     # make sure it said it's going to wait

--- a/cassandane/tiny-tests/Sieve/snooze
+++ b/cassandane/tiny-tests/Sieve/snooze
@@ -39,9 +39,8 @@ EOF
     $self->{instance}->deliver($msg1);
 
     xlog $self, "Check for error message in syslog";
-    my @lines =
-        $self->{instance}->getsyslog(qr/Sieve: can't find \\Snoozed mailbox/);
-    $self->assert_num_equals(1, scalar @lines);
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{Sieve: can't find \\Snoozed mailbox});
 
     xlog $self, "Check that the message was delivered to INBOX";
     $self->{store}->set_folder("INBOX");

--- a/cassandane/tiny-tests/Sieve/snooze_bad_tzid
+++ b/cassandane/tiny-tests/Sieve/snooze_bad_tzid
@@ -44,8 +44,8 @@ EOF
     $self->{instance}->deliver($msg1);
 
     xlog $self, "Check for error message in syslog";
-    my @lines = $self->{instance}->getsyslog(qr/Sieve: unknown time zone/);
-    $self->assert_num_equals(1, scalar @lines);
+    $self->assert_syslog_matches($self->{instance},
+                                 qr{Sieve: unknown time zone});
 
     xlog $self, "Check that the message was delivered to INBOX";
     $self->{store}->set_folder("INBOX");


### PR DESCRIPTION
This fixes a few more tests that were failing in various ways when syslog was unavailable.

Found by compiling with -D_FORTIFY_SOURCE=3 (which has the side of effect of making syslog unavailable) then running Cassandane to see what failed, rather than by code audit.