### PR TITLE
duplicate.c: when auditlogging, use clearer field name

### DIFF
--- a/imap/duplicate.c
+++ b/imap/duplicate.c
@@ -208,7 +208,7 @@ EXPORTED void duplicate_log(const duplicate_key_t *dkey, const char *action)
     syslog(LOG_INFO, "dupelim: eliminated duplicate message to %s id %s date %s (%s)",
       dkey->to, dkey->id, dkey->date, action);
     if (config_auditlog)
-        syslog(LOG_NOTICE, "auditlog: duplicate sessionid=<%s> action=<%s> message-id=%s user=<%s> date=<%s>",
+        syslog(LOG_NOTICE, "auditlog: duplicate sessionid=<%s> action=<%s> message-id=%s uniqueid-or-scope=<%s> date=<%s>",
                session_id(), action, dkey->id, dkey->to, dkey->date);
 }
 


### PR DESCRIPTION
We were reporting mailbox uniqueid as "user=<X>", which is much more opaque than "uniqueid" which we use elsewhere.  In the future, we'll update auditlog to be logfmt and even clearer, but consistent is a good start.