### PR TITLE
config partition sanity checker

### DIFF
--- a/changes/next/cyr-2103-sanity-check-dup-partitions
+++ b/changes/next/cyr-2103-sanity-check-dup-partitions
@@ -1,0 +1,28 @@
+Description:
+
+:cyrusman:`master(8)` now refuses to start when multiple partitions are
+configured with the same directory, or a subdirectory thereof.  This
+prevents potential store corruption when multiple things each think they
+own everything.  :cyrusman:`cyr_info(8)` ``conf-lint`` will report the
+invalid partitions.
+
+
+Documentation:
+
+:cyrusman:`cyr_info(8)`
+
+
+Config changes:
+
+``*partition-*`` entries in :cyrusman:`imapd.conf(5)` are now checked against
+one another.
+
+
+Upgrade instructions:
+
+Nothing required, unless your configuration was already bad.
+
+
+GitHub issue:
+
+#5573

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -1143,7 +1143,7 @@ static void test_partition_sanity_ok(void)
         "t2searchpartition-bar: /srv/search/t2/bar\n"
     );
 
-    r = config_partition_sanity(NULL);
+    r = config_check_partitions(NULL);
     CU_ASSERT_EQUAL(r, 0);
 }
 
@@ -1161,7 +1161,7 @@ static void test_partition_sanity_bad_subdirs(void)
     );
 
     CU_SYSLOG_MATCH("disk path is a prefix of others");
-    r = config_partition_sanity(NULL);
+    r = config_check_partitions(NULL);
     /* there are two subdirs of /srv/foo configured, but since we're doing
      * substring matches rather than a real tree lookup, we only notice the
      * first.
@@ -1183,7 +1183,7 @@ static void test_partition_sanity_bad_dups(void)
     );
 
     CU_SYSLOG_MATCH("disk path used by multiple partitions");
-    r = config_partition_sanity(NULL);
+    r = config_check_partitions(NULL);
     CU_ASSERT_EQUAL(r, -2);
     CU_ASSERT_SYSLOG(/*all*/0, 2);
 }

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -1143,7 +1143,7 @@ static void test_partition_sanity_ok(void)
         "t2searchpartition-bar: /srv/search/t2/bar\n"
     );
 
-    r = config_partition_sanity();
+    r = config_partition_sanity(NULL);
     CU_ASSERT_EQUAL(r, 0);
 }
 
@@ -1161,7 +1161,7 @@ static void test_partition_sanity_bad_subdirs(void)
     );
 
     CU_SYSLOG_MATCH("disk path is a prefix of others");
-    r = config_partition_sanity();
+    r = config_partition_sanity(NULL);
     /* there are two subdirs of /srv/foo configured, but since we're doing
      * substring matches rather than a real tree lookup, we only notice the
      * first.
@@ -1183,7 +1183,7 @@ static void test_partition_sanity_bad_dups(void)
     );
 
     CU_SYSLOG_MATCH("disk path used by multiple partitions");
-    r = config_partition_sanity();
+    r = config_partition_sanity(NULL);
     CU_ASSERT_EQUAL(r, -2);
     CU_ASSERT_SYSLOG(/*all*/0, 2);
 }

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -1125,4 +1125,67 @@ static void test_deprecated_bytesize(void)
     CU_ASSERT_EQUAL(val, 12LL * 1024 * 1024);
 }
 
+static void test_partition_sanity_ok(void)
+{
+    int r;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "partition-foo: /srv/foo\n"
+        "archivepartition-foo: /srv/archive/foo\n"
+        "metapartition-foo: /srv/meta/foo\n"
+        "t1searchpartition-foo: /srv/search/t1/foo\n"
+        "t2searchpartition-foo: /srv/search/t2/foo\n"
+        "partition-bar: /srv/bar\n"
+        "archivepartition-bar: /srv/archive/bar\n"
+        "metapartition-bar: /srv/meta/bar\n"
+        "t1searchpartition-bar: /srv/search/t1/bar\n"
+        "t2searchpartition-bar: /srv/search/t2/bar\n"
+    );
+
+    r = config_partition_sanity();
+    CU_ASSERT_EQUAL(r, 0);
+}
+
+static void test_partition_sanity_bad_subdirs(void)
+{
+    int r;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "partition-foo: /srv/foo\n"
+        "archivepartition-foo: /srv/foo/archive\n" /* bad */
+        "metapartition-foo: /srv/foo/meta\n" /* bad */
+        "partition-foobar: /srv/foo-bar\n" /* this better not get in the way */
+        "archivepartition-foobar: /srv/archive/foo-bar\n" /* okay */
+    );
+
+    CU_SYSLOG_MATCH("disk path is a prefix of others");
+    r = config_partition_sanity();
+    /* there are two subdirs of /srv/foo configured, but since we're doing
+     * substring matches rather than a real tree lookup, we only notice the
+     * first.
+     */
+    CU_ASSERT_EQUAL(r, -1); // not -2
+    CU_ASSERT_SYSLOG(/*all*/0, 1); // not 2
+}
+
+static void test_partition_sanity_bad_dups(void)
+{
+    int r;
+
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+        "partition-foo: /srv/foo\n"
+        "t1searchpartition-foo: /srv/foo\n" /* uh oh */
+        "partition-bar: /srv/bar\n"
+        "archivepartition-bar: /srv/bar\n" /* uh oh */
+    );
+
+    CU_SYSLOG_MATCH("disk path used by multiple partitions");
+    r = config_partition_sanity();
+    CU_ASSERT_EQUAL(r, -2);
+    CU_ASSERT_SYSLOG(/*all*/0, 2);
+}
+
 /* vim: set ft=c: */

--- a/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_info.rst
@@ -59,8 +59,8 @@ configuring Cyrus easier.
 
 .. option:: conf-lint
 
-    Print only configuration options which are NOT recognised.  This
-    command should not print anything.  It uses cyrus.conf to find
+    Print configuration options which are NOT recognised, or are invalid.
+    This command should not print anything.  It uses cyrus.conf to find
     the names of configured services to avoid displaying any known
     configuration options for the named service.
 

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -416,7 +416,10 @@ static void do_lint(void)
     /* check all overflow strings */
     config_foreachoverflowstring(lint_callback, &rock);
 
-    /* XXX - check directories and permissions? */
+    /* check partitions */
+    config_partition_sanity(stdout);
+
+    /* XXX - permissions? */
 
     /* clean up */
     struct service_item *ks = rock.known_services;

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -417,7 +417,7 @@ static void do_lint(void)
     config_foreachoverflowstring(lint_callback, &rock);
 
     /* check partitions */
-    config_partition_sanity(stdout);
+    config_check_partitions(stdout);
 
     /* XXX - permissions? */
 

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -343,10 +343,10 @@ EXPORTED void hash_enumerate(hash_table *table, void (*func)(const char *, void 
       }
 }
 
-EXPORTED strarray_t *hash_keys(hash_table *table)
+EXPORTED strarray_t *hash_keys(const hash_table *table)
 {
+    const bucket *temp;
     unsigned i;
-    bucket *temp;
 
     strarray_t *sa = strarray_new();
 

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -87,7 +87,7 @@ void hash_enumerate_sorted(hash_table *table,void (*func)(const char *,void *,vo
                     void *rock, strarray_cmp_fn_t *cmp);
 
 /* gets all the keys from the hashtable */
-strarray_t *hash_keys(hash_table *table);
+strarray_t *hash_keys(const hash_table *table);
 
 /* counts the number of nodes in the hash table */
 

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -1307,3 +1307,165 @@ EXPORTED void config_toggle_debug(void)
     config_debug = !config_debug;
     if (config_toggle_debug_cb) config_toggle_debug_cb();
 }
+
+static const unsigned char cmpstringp_path_lookup[] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,  /* interesting */
+    0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x20,  /* bit is here */
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+    0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
+    0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,
+    0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57,
+    0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,
+    0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,
+    0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f,
+    0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
+    0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+    0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
+    0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e, 0x8f,
+    0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97,
+    0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f,
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+    0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7,
+    0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf,
+    0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7,
+    0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+    0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7,
+    0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf,
+    0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7,
+    0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef,
+    0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+    0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff,
+};
+_Static_assert(256 == sizeof(cmpstringp_path_lookup),
+               "cmpstringp_path_lookup has wrong number of elems");
+
+/* Treats '/' (0x2f) as lower than other printables so that
+ * file paths sort pre-order, depth-first.
+ * XXX This should probably be in lib/bsearch.c, but that's in
+ * XXX libcyrus, which we don't have here.
+ */
+static int cmpstringp_path(const void *aa, const void *bb)
+{
+    const unsigned char *a = *(const unsigned char **) aa;
+    const unsigned char *b = *(const unsigned char **) bb;
+    int cmp = 0;
+
+    #define L(x) (cmpstringp_path_lookup[x])
+    #define CMP(y,z) ((y) > (z)) - ((y) < (z))
+
+    while (*a && *b && 0 == (cmp = CMP(L(*a), L(*b)))) {
+        a++;
+        b++;
+    }
+
+    /* found a mismatch */
+    if (cmp) return cmp;
+
+    /* Walked off the end of one (or both) strings, in which case one
+     * (or both) of these will be zero, and the string with bytes remaining
+     * is the greater.
+     */
+    return CMP(*a, *b);
+
+    #undef CMP
+    #undef L
+}
+
+static void collect_partitions(const char *key, const char *value, void *rock)
+{
+    hash_table *by_value = rock;
+
+    if (strstr(key, "partition-")) {
+        strarray_t *keys;
+
+        keys = hash_lookup(value, by_value);
+        if (!keys) {
+            keys = hash_insert(value, strarray_new(), by_value);
+        }
+
+        strarray_append(keys, key);
+    }
+}
+
+static void check_no_dups(const char *value, void *foo, void *rock)
+{
+    const strarray_t *keys = foo;
+    int *found_bad = rock;
+
+    if (strarray_size(keys) > 1) {
+        char *joined_keys = NULL;
+
+        joined_keys = strarray_join(keys, ",");
+        xsyslog(LOG_ERR, "disk path used by multiple partitions",
+                         "path=<%s> partitions=<%s>",
+                         value, joined_keys);
+        free(joined_keys);
+
+        (*found_bad) ++;
+    }
+}
+
+static int check_no_subdirs(const hash_table *by_value)
+{
+    strarray_t *all_values;
+    const char *prev, *value;
+    int found_bad = 0, i, n;
+
+    all_values = hash_keys(by_value);
+    strarray_sort(all_values, cmpstringp_path);
+    prev = strarray_nth(all_values, 0);
+    for (i = 1, n = strarray_size(all_values); i < n; i++) {
+        size_t prev_len = strlen(prev);
+
+        value = strarray_nth(all_values, i);
+        if (strlen(value) > prev_len
+            && 0 == strncmp(prev, value, prev_len)
+            && value[prev_len] == '/')
+        {
+            xsyslog(LOG_ERR, "disk path is a prefix of others",
+                             "path1=<%s> path2=<%s>",
+                             prev, value);
+            /* XXX only reports first example, and no keys... */
+            found_bad++;
+        }
+
+        prev = value;
+    }
+
+    strarray_free(all_values);
+
+    return found_bad;
+}
+
+/* free_hash_table() needs a function matching free()'s signature */
+static void wrap_strarray_free(void *vp)
+{
+    strarray_free((strarray_t *) vp);
+}
+
+EXPORTED int config_partition_sanity(void)
+{
+    hash_table by_value = HASH_TABLE_INITIALIZER;
+    int found_bad = 0;
+
+    assert(config_loaded);
+
+    /* supposing 2 search tiers, that's possibly 5 disk paths per named
+     * partition.  supposing 5 named partitions, that's possibly 25 paths.
+     */
+    construct_hash_table(&by_value, 25, /* mpool */ 1);
+
+    config_foreachoverflowstring(&collect_partitions, &by_value);
+
+    hash_enumerate(&by_value, &check_no_dups, &found_bad);
+    found_bad += check_no_subdirs(&by_value);
+
+    free_hash_table(&by_value, &wrap_strarray_free);
+    return 0 - found_bad;
+}

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -814,6 +814,10 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
                      config_defpartition ? config_defpartition : "<name>");
             fatal(buf, EX_CONFIG);
         }
+
+        if (config_partition_sanity(NULL)) {
+            fatal("invalid partition value detected", EX_CONFIG);
+        }
     }
 
     /* look up mailbox hashing */

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -70,7 +70,7 @@ extern void config_foreachoverflowstring(
 extern const char *config_partitiondir(const char *partition);
 extern const char *config_metapartitiondir(const char *partition);
 extern const char *config_archivepartitiondir(const char *partition);
-extern int config_partition_sanity(FILE *user_output);
+extern int config_check_partitions(FILE *user_output);
 
 /* for parsing duration/bytesize-format strings obtained elsewhere,
  * such as from an overflow string */

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -46,6 +46,8 @@
 #include "imapopts.h"
 #include "strarray.h"
 
+#include <stdio.h>
+
 /* these will assert() if they're called on the wrong type of
    option (imapopts.c) */
 extern void config_reset(void);
@@ -68,7 +70,7 @@ extern void config_foreachoverflowstring(
 extern const char *config_partitiondir(const char *partition);
 extern const char *config_metapartitiondir(const char *partition);
 extern const char *config_archivepartitiondir(const char *partition);
-extern int config_partition_sanity(void);
+extern int config_partition_sanity(FILE *user_output);
 
 /* for parsing duration/bytesize-format strings obtained elsewhere,
  * such as from an overflow string */

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -63,9 +63,12 @@ extern int64_t config_getbytesize(enum imapopt opt, int defunit);
 extern const char *config_getoverflowstring(const char *key, const char *def);
 extern void config_foreachoverflowstring(
     void (*func)(const char *, const char *, void *), void *rock);
+
+/* partition utilities */
 extern const char *config_partitiondir(const char *partition);
 extern const char *config_metapartitiondir(const char *partition);
 extern const char *config_archivepartitiondir(const char *partition);
+extern int config_partition_sanity(void);
 
 /* for parsing duration/bytesize-format strings obtained elsewhere,
  * such as from an overflow string */

--- a/master/master.c
+++ b/master/master.c
@@ -2953,7 +2953,7 @@ int main(int argc, char **argv)
     }
 
     masterconf_init("master", alt_config);
-    if (config_partition_sanity(NULL)) {
+    if (config_check_partitions(NULL)) {
         fatal("invalid partition value detected", EX_CONFIG);
     }
 

--- a/master/master.c
+++ b/master/master.c
@@ -2953,6 +2953,9 @@ int main(int argc, char **argv)
     }
 
     masterconf_init("master", alt_config);
+    if (config_partition_sanity(NULL)) {
+        fatal("invalid partition value detected", EX_CONFIG);
+    }
 
     if (close_std || error_log) {
         /* close stdin/out/err */


### PR DESCRIPTION
#5573 reports that, when Cyrus is configured with mail and search indexes being stored in the same directory, like this:

```
defaultpartition: default
partition-default: /var/spool/imap
defaultsearchtier: default
defaultsearchpartition-default: /var/spool/imap
```

... then compacting the xapian indexes will remove all the mail and metadata files.  Seems like xapian, at least, expects total control over the directories it's configured to use.  Given that, Cyrus shouldn't be allowed to start up in this configuration.

I don't think it makes sense for _any_ of the `*partition-*` settings to share directories with one another.  Even if some combination doesn't currently break, I don't believe we expect these to overlap, so that combination might break in the future.

This PR adds a sanity check to make sure that no partitions are sharing directories, nor are descendants of one another.  If this sort of sharing is detected, `master` and `squatter` will now refuse to start, as will any other cyrus service or tool that requests partition data (via the `CONFIG_NEED_PARTITION_DATA` argument to `cyrus_init()`).  Details of the collisions are logged to syslog.  `cyr_info conf-lint` will detect and report the bad entries in the same way it reports other bad entries.

The sanity checking is based on string comparisons of the configured paths; actual filesystem details are not examined.  So it's probably possible to subvert the checks using symlinks or other trickiness, but I don't think I care -- just don't do that.

For implementation reasons, if multiple partitions are configured as descendants of the same other partition, only the parent and one of the descendants can be reported.  That's enough to prevent starting up with a bad configuration, but a really bad configuration might need several rounds of test/fix to identify and resolve all the issues.

**If people already have configuration like this, what they can do to fix it prior to (or after) upgrading?**  Presumably rearrange their storage, then update their imapd.conf to describe the new layout.  Hopefully they already know how to do this.