### PR TITLE
cyr_dbtool: better handling of transaction AND batch

### DIFF
--- a/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
+++ b/docsrc/imap/reference/manpages/systemcommands/cyr_dbtool.rst
@@ -17,7 +17,7 @@ Synopsis
 
 .. parsed-literal::
 
-    **cyr_dbtool** [ **-C** *config-file* ] [ **-c** ] [ **-N** ] [ **-n** ] [ **-R** ] [ **-S** ] [ **-T** ] [ **-t** ]
+    **cyr_dbtool** [ **-C** *config-file* ] [ **-b** ] [ **-c** ] [ **-N** ] [ **-n** ] [ **-R** ] [ **-S** ] [ **-T** ] [ **-t** ]
             *db-file* *db-backend* *action* [ *key* ] [ *value* ]
 
 Description
@@ -79,6 +79,12 @@ Options
 
     |cli-dash-c-text|
 
+.. option:: -b, --base64
+
+    If specified, all keys and values are provided in base64 format, making
+    automation easier, particularly with batch.  NOTE: the commands in batch
+    mode are still in plain text, just the keys and values are encoded.
+
 .. option:: -c, --convert
 
     Convert the database file if the specified format on the command line
@@ -96,7 +102,12 @@ Options
 .. option:: -R, --readonly
 
     Open the database readonly.  Even if --create is specified, will not
-    create a database if it doesn't exists (since that needs writing)
+    create a database if it doesn't exists (since that needs writing).
+    NOTE: you MUST use '-T' with '-R' as you'll stay in a read-only
+    transaction for the entire time.
+
+    With the twom backend, this will use an MVCC transaction which can
+    run slowly without blocking any other processes.
 
 .. option:: -S, --no-sync
 

--- a/imap/cyr_dbtool.c
+++ b/imap/cyr_dbtool.c
@@ -76,6 +76,12 @@ static int outfd;
 
 static struct db *db = NULL;
 static struct txn **tidp = NULL;
+static int base64 = 0;
+
+static struct buf inkeybuf = BUF_INITIALIZER;
+static struct buf invalbuf = BUF_INITIALIZER;
+static struct buf outkeybuf = BUF_INITIALIZER;
+static struct buf outvalbuf = BUF_INITIALIZER;
 
 static int read_key_value(char **keyptr, size_t *keylen, char **valptr, size_t *vallen) {
   int c,res,inkey;
@@ -115,6 +121,16 @@ static int printer_cb(void *rock __attribute__((unused)),
     const char *key, size_t keylen,
     const char *data, size_t datalen)
 {
+    if (base64) {
+        buf_reset(&outkeybuf);
+        buf_reset(&outvalbuf);
+        charset_encode(&outkeybuf, key, keylen, ENCODING_BASE64);
+        charset_encode(&outvalbuf, data, datalen, ENCODING_BASE64);
+        key = buf_base(&outkeybuf);
+        keylen = buf_len(&outkeybuf);
+        data = buf_base(&outvalbuf);
+        datalen = buf_len(&outvalbuf);
+    }
     struct iovec io[4];
     io[0].iov_base = (char *) key;
     io[0].iov_len = keylen;
@@ -133,6 +149,17 @@ static int aprinter_cb(void *rock,
                        const char *key, size_t keylen,
                        const char *data, size_t datalen)
 {
+    if (base64) {
+        buf_reset(&outkeybuf);
+        buf_reset(&outvalbuf);
+        charset_encode(&outkeybuf, key, keylen, ENCODING_BASE64);
+        charset_encode(&outvalbuf, data, datalen, ENCODING_BASE64);
+        key = buf_base(&outkeybuf);
+        keylen = buf_len(&outkeybuf);
+        data = buf_base(&outvalbuf);
+        datalen = buf_len(&outvalbuf);
+    }
+
     struct protstream *out = (struct protstream *)rock;
 
     prot_printamap(out, key, keylen);
@@ -185,21 +212,46 @@ static void batch_commands(struct db *db)
                 tidp = &tid;
             }
             else if (!strcmp(cmd.s, "SHOW")) {
-                r = cyrusdb_foreach(db, key.s, key.len, NULL, aprinter_cb, out, tidp);
+                buf_reset(&inkeybuf);
+                if (base64) {
+                    charset_decode(&inkeybuf, buf_base(&key), buf_len(&key), ENCODING_BASE64);
+                }
+                else {
+                    buf_copy(&inkeybuf, &key);
+                }
+                r = cyrusdb_foreach(db, buf_base(&inkeybuf), buf_len(&inkeybuf), NULL, aprinter_cb, out, tidp);
                 if (r) goto done;
                 prot_flush(out);
             }
             else if (!strcmp(cmd.s, "SET")) {
-                r = cyrusdb_store(db, key.s, key.len, val.s, val.len, tidp);
+                buf_reset(&inkeybuf);
+                buf_reset(&invalbuf);
+                if (base64) {
+                    charset_decode(&inkeybuf, buf_base(&key), buf_len(&key), ENCODING_BASE64);
+                    charset_decode(&invalbuf, buf_base(&val), buf_len(&val), ENCODING_BASE64);
+                }
+                else {
+                    buf_setmap(&inkeybuf, key.s, key.len);
+                    buf_setmap(&invalbuf, val.s, val.len);
+                }
+                r = cyrusdb_store(db, buf_base(&inkeybuf), buf_len(&inkeybuf),
+                                  buf_base(&invalbuf), buf_len(&invalbuf), tidp);
                 if (r) goto done;
             }
             else if (!strcmp(cmd.s, "GET")) {
                 const char *res;
                 size_t reslen;
-                r = cyrusdb_fetch(db, key.s, key.len, &res, &reslen, tidp);
+                buf_reset(&inkeybuf);
+                if (base64) {
+                    charset_decode(&inkeybuf, buf_base(&key), buf_len(&key), ENCODING_BASE64);
+                }
+                else {
+                    buf_copy(&inkeybuf, &key);
+                }
+                r = cyrusdb_fetch(db, buf_base(&inkeybuf), buf_len(&inkeybuf), &res, &reslen, tidp);
                 switch (r) {
                 case 0:
-                    aprinter_cb(out, key.s, key.len, res, reslen);
+                    aprinter_cb(out, buf_base(&inkeybuf), buf_len(&inkeybuf), res, reslen);
                     prot_flush(out);
                     break;
                 case CYRUSDB_NOTFOUND:
@@ -210,7 +262,14 @@ static void batch_commands(struct db *db)
                 }
             }
             else if (!strcmp(cmd.s, "DELETE")) {
-                r = cyrusdb_delete(db, key.s, key.len, tidp, 1);
+                buf_reset(&inkeybuf);
+                if (base64) {
+                    charset_decode(&inkeybuf, buf_base(&key), buf_len(&key), ENCODING_BASE64);
+                }
+                else {
+                    buf_copy(&inkeybuf, &key);
+                }
+                r = cyrusdb_delete(db, buf_base(&inkeybuf), buf_len(&inkeybuf), tidp, 1);
                 if (r) goto done;
             }
             else if (!strcmp(cmd.s, "COMMIT")) {
@@ -274,10 +333,11 @@ int main(int argc, char *argv[])
     struct txn *tid = NULL;
 
     /* keep this in alphabetical order */
-    static const char short_options[] = "C:NRSTcnt";
+    static const char short_options[] = "C:NRSTbcnt";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */
+        { "base64", no_argument, NULL, 'b' },
         { "convert", no_argument, NULL, 'c' },
         { "no-checksum", no_argument, NULL, 'N' },
         { "create", no_argument, NULL, 'n' },
@@ -294,6 +354,9 @@ int main(int argc, char *argv[])
         switch (opt) {
         case 'C': /* alt config file */
             alt_config = optarg;
+            break;
+        case 'b':
+            base64 = 1;
             break;
         case 'c':
             db_flags |= CYRUSDB_CONVERT;
@@ -393,17 +456,35 @@ int main(int argc, char *argv[])
           loop = 1;
         }
         while ( loop ) {
+          buf_reset(&inkeybuf);
+          buf_reset(&invalbuf);
+          if (base64) {
+            charset_decode(&inkeybuf, key, keylen, ENCODING_BASE64);
+            charset_decode(&invalbuf, value, vallen, ENCODING_BASE64);
+          }
+          else {
+            buf_setmap(&inkeybuf, key, keylen);
+            buf_setmap(&invalbuf, value, vallen);
+          }
           if (is_get) {
-            r = cyrusdb_fetch(db, key, keylen, &res, &reslen, tidp);
+            r = cyrusdb_fetch(db, buf_base(&inkeybuf), buf_len(&inkeybuf), &res, &reslen, tidp);
             if (r) break;
-            printf("%.*s\n", (int)reslen, res);
+            if (base64) {
+              buf_reset(&outvalbuf);
+              charset_encode(&outvalbuf, res, reslen, ENCODING_BASE64);
+              printf("%.*s\n", (int)buf_len(&outvalbuf), buf_base(&outvalbuf));
+            } else {
+              printf("%.*s\n", (int)reslen, res);
+            }
           } else if (is_set) {
-            r = cyrusdb_store(db, key, keylen, value, vallen, tidp);
+            r = cyrusdb_store(db, buf_base(&inkeybuf), buf_len(&inkeybuf),
+                              buf_base(&invalbuf), buf_len(&invalbuf), tidp);
             if (r) break;
           } else if (is_delete) {
-            r = cyrusdb_delete(db, key, keylen, tidp, 1);
+            r = cyrusdb_delete(db, buf_base(&inkeybuf), buf_len(&inkeybuf), tidp, 1);
             if (r) break;
           }
+
           loop = 0;
           if ( use_stdin ) {
             loop = read_key_value( &key, &keylen, &value, &vallen );
@@ -455,6 +536,11 @@ int main(int argc, char *argv[])
     cyrusdb_close(db);
 
     cyrus_done();
+
+    buf_free(&inkeybuf);
+    buf_free(&invalbuf);
+    buf_free(&outkeybuf);
+    buf_free(&outvalbuf);
 
     return r ? 1 : 0;
 }


### PR DESCRIPTION
This fixes transaction and batch support.  Right now, '-T' is not compatible with batch; so we can't take a shared lock.