### PR TITLE
jmap_contact.c: Unescape value of unknown property types

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_set_escaping
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_escaping
@@ -1,0 +1,77 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_set_escaping
+    :needs_dependency_icalvcard
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    my $service = $self->{instance}->get_service("http");
+    $ENV{DEBUGDAV} = 1;
+    my $carddav = Net::CardDAVTalk->new(
+        user => 'cassandane',
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    my $prodid = '-//Example Corp.//CardDAV Client//EN';
+    my $name = 'Mr. John Q. Public, Esq.';
+
+    xlog $self, "Create card with vCard X- property that needs escaping";
+    my $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            create => {
+                "1" => {
+                    '@type' => 'Card',
+                    version => '1.0',
+                    prodId => $prodid,
+                    kind => 'individual',
+                    name => { full => $name },
+                    vCardProps => [
+                        [
+                            'x-activity-alert',
+                            {},
+                            'text',
+                            'type=text,snd=texttone:Droplet',
+                        ],
+                    ]    
+                }
+            }
+        }, 'R1']
+    ]);
+
+    my $id = $res->[0][1]{created}{1}{id};
+    my $href = $res->[0][1]{created}{1}{'cyrusimap.org:href'};
+
+    xlog $self, "Verify that X- property is escaped";
+    $res = $carddav->Request('GET', $href, '',
+                             'Accept' => 'text/vcard; version=4.0');
+    my $card = $res->{content};
+    $card =~ s/\r?\n[ \t]+//gs;  # unfold long properties
+    $self->assert_matches(qr/X-ACTIVITY-ALERT:type=text\\,snd=texttone:Droplet/,
+                          $card);
+
+    xlog $self, "Update the contact";
+    $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            update => {
+                $id => {
+                    prodId => 'foo'
+                }
+            }
+        }, 'R1']
+    ]);
+
+    xlog $self, "Verify that X- property is escaped ONCE";
+    $res = $carddav->Request('GET', $href, '',
+                             'Accept' => 'text/vcard; version=4.0');
+    $card = $res->{content};
+    $card =~ s/\r?\n[ \t]+//gs;  # unfold long properties
+    $self->assert_matches(qr/X-ACTIVITY-ALERT:type=text\\,snd=texttone:Droplet/,
+                          $card);
+}

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -7450,10 +7450,13 @@ static void jsprop_from_vcard(vcardproperty *prop, json_t *obj,
         }
 
         buf_setcstr(crock->buf, vcardproperty_get_property_name(prop));
+        char *dequoted = vcardvalue_strdup_and_dequote_text(&prop_value, NULL);
+
         json_array_append_new(props,
                               json_pack("[s o o o]",
                                         buf_lcase(crock->buf), jparams, jtype,
-                                        jmap_utf8string(prop_value)));
+                                        jmap_utf8string(dequoted)));
+        free(dequoted);
         return;
     }
     }


### PR DESCRIPTION
This prevents exponentially increasing backslashes when cards are updated