### PR TITLE
changes: start a changes entry for compact ids

### DIFF
--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -1160,8 +1160,8 @@ sub test_rename_between_users
 
     # folder IDs should be "INBOX", "foo", "bar"
 
-    my $res = $talk->status('INBOX.foo', ['mailboxid']);
-    my $fooid = $res->{'mailboxid'}->[0];
+    my $res = $talk->status('INBOX.foo', ['uniqueid']);
+    my $fooid = $res->{'uniqueid'}->[0];
 
     my %data = $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format, ['SHOW']);
     my %mdata = $self->{instance}->run_dbcommand($mdirs->{user}{conversations}, $format, ['SHOW']);
@@ -1194,8 +1194,8 @@ sub test_rename_between_users
     $self->{store}->set_folder("INBOX.again");
     $self->make_message("Again Msg");
 
-    $res = $talk->status('INBOX.again', ['mailboxid']);
-    my $againid = $res->{'mailboxid'}->[0];
+    $res = $talk->status('INBOX.again', ['uniqueid']);
+    my $againid = $res->{'uniqueid'}->[0];
 
     $talk->rename("user.manifold.foo", "INBOX.foo");
 

--- a/cassandane/tiny-tests/FastMail/cyr_expire_delete_findpaths_nolegacy
+++ b/cassandane/tiny-tests/FastMail/cyr_expire_delete_findpaths_nolegacy
@@ -29,10 +29,10 @@ sub test_cyr_expire_delete_findpaths_nolegacy
     $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format,
                                      ['SET', '$VERSION', '1']);
 
-    my $res = $admintalk->status($inbox, ['mailboxid']);
-    my $inboxid = $res->{mailboxid}[0];
-    $res = $admintalk->status($subfolder, ['mailboxid']);
-    my $subid = $res->{mailboxid}[0];
+    my $res = $admintalk->status($inbox, ['uniqueid']);
+    my $inboxid = $res->{uniqueid}[0];
+    $res = $admintalk->status($subfolder, ['uniqueid']);
+    my $subid = $res->{uniqueid}[0];
 
     xlog $self, "Delete $subfolder";
     $admintalk->unselect();

--- a/cassandane/tiny-tests/FastMail/cyr_expire_rename_safe
+++ b/cassandane/tiny-tests/FastMail/cyr_expire_rename_safe
@@ -29,10 +29,10 @@ sub test_cyr_expire_rename_safe
     $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format,
                                      ['SET', '$VERSION', '1']);
 
-    my $res = $admintalk->status($inbox, ['mailboxid']);
-    my $inboxid = $res->{mailboxid}[0];
-    $res = $admintalk->status($subfolder, ['mailboxid']);
-    my $subid = $res->{mailboxid}[0];
+    my $res = $admintalk->status($inbox, ['uniqueid']);
+    my $inboxid = $res->{uniqueid}[0];
+    $res = $admintalk->status($subfolder, ['uniqueid']);
+    my $subid = $res->{uniqueid}[0];
 
     xlog $self, "Run cyr_expire -D now.";
     $self->{instance}->run_command({ cyrus => 1 }, 'cyr_expire', '-D' => '0', '-X' => 0, '-E' => 0 , '-v');

--- a/cassandane/tiny-tests/FastMail/sync_reset_nolegacy
+++ b/cassandane/tiny-tests/FastMail/sync_reset_nolegacy
@@ -30,10 +30,10 @@ sub test_sync_reset_nolegacy
     $self->{instance}->run_dbcommand($dirs->{user}{conversations}, $format,
                                      ['SET', '$VERSION', '1']);
 
-    my $res = $admintalk->status($inbox, ['mailboxid']);
-    my $inboxid = $res->{mailboxid}[0];
-    $res = $admintalk->status($subfolder, ['mailboxid']);
-    my $subid = $res->{mailboxid}[0];
+    my $res = $admintalk->status($inbox, ['uniqueid']);
+    my $inboxid = $res->{uniqueid}[0];
+    $res = $admintalk->status($subfolder, ['uniqueid']);
+    my $subid = $res->{uniqueid}[0];
 
     my $basedir = $self->{instance}{basedir};
     open(FH, "-|", "find", $basedir);

--- a/changes/next/compact-object-ids
+++ b/changes/next/compact-object-ids
@@ -1,0 +1,46 @@
+Description:
+
+New compact object ids for Email, Mailbox, and Thread types
+
+Documentation:
+
+There isn't any.  (Should there be?)
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+This version of Cyrus introduces "compact" object ids for email, mailbox, and
+thread objects.  These forms can be packed into 64-bits for more efficient
+client-side caching.  Their ASCII forms are also much shorter, for reduced
+bandwidth use.
+
+All users created in this version of Cyrus IMAP will have compact ids enabled
+by default.
+
+It is not strictly required to switch all users to compact object ids to
+upgrade to this version of Cyrus, but it will very likely be required before
+the next version.
+
+To switch a user to compact object ids, you must:
+
+* reconstruct each user using `reconstruct -u -T -V max`
+* upgrade the user's conversations database with `ctl_conversationsdb -U -R`
+
+In a replicated environment, these should be performed on the primary first and
+the replicas afterward.  Then, only on the primary:
+
+* switch on compact object ids for the user with `ctl_conversationsdb -I on`
+
+This conversion will change the value of the MAILBOXID, EMAILID, and THREADID
+data (q.v. RFC 8474) for the user's mailboxes and email.  While in theory this
+could be disruptive to aggressively caching IMAP clients, our finding is that
+in practice, no client relies on these.
+
+GitHub issue:
+
+None

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6900,7 +6900,7 @@ static void cmd_create(char *tag, char *name, struct dlist *extargs, int localon
     const char *server = NULL;
     const char *uniqueid = NULL;
     uint32_t minor_version = 0;
-    uint32_t compactids = 0;
+    uint32_t compactids = 1;
     struct buf specialuse = BUF_INITIALIZER;
     struct dlist *use;
     struct mailbox *mailbox = NULL;
@@ -7301,7 +7301,8 @@ localcreate:
 
     /* Close newly created mailbox before writing annotations */
     struct conversations_state *cstate = mailbox_get_cstate(mailbox);
-    if (is_inbox && compactids && (!minor_version || minor_version >= 20)) {
+    if (is_inbox && compactids && (!minor_version || minor_version >= 20)
+        && config_getswitch(IMAPOPT_CONVERSATIONS)) {
         r = conversations_enable_compactids(cstate, 1);
         if (r) {
             syslog(LOG_NOTICE,


### PR DESCRIPTION
This is more free-form text than most changes files, but I think it's probably about right.

It claims that new users will be created compact by default, which we'll want to make true before claiming it.