### PR TITLE
Cyr 2152 no build jmapsubmission

### DIFF
--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -331,6 +331,9 @@ static int build_cid_cb(const mbentry_t *mbentry, void *rock)
         int count = 0;
         loop = 0;
 
+        // skip mailboxes without conversations (e.g. the submission folder)
+        if (!mailbox_has_conversations(mailbox)) break;
+
         struct mailbox_iter *iter = mailbox_iter_init(mailbox, 0, ITER_SKIP_UNLINKED);
         const message_t *msg;
         while ((msg = mailbox_iter_step(iter))) {


### PR DESCRIPTION
This is a tiny fix so we can add CIDs to anyone missing them without creating tons of extra jmapsubmission auditlog changes and causing whatever bug we're not writing CIDs to those in the first place to avoid!