### PR TITLE
imapd: treat 'replicaonly' the same as 'readonly'

### DIFF
--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -517,7 +517,7 @@ sub _munge_annot_crc
     $fh->close();
 }
 sub test_replication_reply_200
-    :min_version_3_1 :needs_component_replication :Conversations
+    :min_version_3_1 :needs_component_replication :Conversations :NoReplicaOnly
 {
     my ($self) = @_;
     my %exp;
@@ -583,7 +583,7 @@ sub test_replication_reply_200
 # Test APPEND of messages to IMAP
 #
 sub test_replication_reconstruct
-    :min_version_3_1 :needs_component_replication :Conversations
+    :min_version_3_1 :needs_component_replication :Conversations :NoReplicaOnly
 {
     my ($self) = @_;
     my %exp;

--- a/cassandane/tiny-tests/Metadata/msg_replication_exp_bot
+++ b/cassandane/tiny-tests/Metadata/msg_replication_exp_bot
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_msg_replication_exp_bot
-    :needs_component_replication
+    :needs_component_replication :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Metadata/msg_replication_exp_rep
+++ b/cassandane/tiny-tests/Metadata/msg_replication_exp_rep
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_msg_replication_exp_rep
-    :needs_component_replication
+    :needs_component_replication :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Metadata/msg_replication_mod_bot_msh
+++ b/cassandane/tiny-tests/Metadata/msg_replication_mod_bot_msh
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_msg_replication_mod_bot_msh
-    :needs_component_replication
+    :needs_component_replication :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Metadata/msg_replication_mod_bot_msl
+++ b/cassandane/tiny-tests/Metadata/msg_replication_mod_bot_msl
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_msg_replication_mod_bot_msl
-    :needs_component_replication
+    :needs_component_replication :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Metadata/msg_replication_new_bot_mse_guh
+++ b/cassandane/tiny-tests/Metadata/msg_replication_new_bot_mse_guh
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_msg_replication_new_bot_mse_guh
-    :needs_component_replication
+    :needs_component_replication :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Metadata/msg_replication_new_bot_mse_gul
+++ b/cassandane/tiny-tests/Metadata/msg_replication_new_bot_mse_gul
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_msg_replication_new_bot_mse_gul
-    :needs_component_replication
+    :needs_component_replication :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Metadata/msg_replication_new_rep
+++ b/cassandane/tiny-tests/Metadata/msg_replication_new_rep
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_msg_replication_new_rep
-    :needs_component_replication
+    :needs_component_replication :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Replication/replication_repair_zero_msgs
+++ b/cassandane/tiny-tests/Replication/replication_repair_zero_msgs
@@ -2,6 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_replication_repair_zero_msgs
+    :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Replication/rolling_retry_wait_limit
+++ b/cassandane/tiny-tests/Replication/rolling_retry_wait_limit
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_rolling_retry_wait_limit
-    :CSyncReplication :NoStartInstances :min_version_3_5
+    :CSyncReplication :NoStartInstances :min_version_3_5 :NoReplicaOnly
 {
     my ($self) = @_;
     my $maxwait = 20;

--- a/cassandane/tiny-tests/Replication/splitbrain
+++ b/cassandane/tiny-tests/Replication/splitbrain
@@ -5,6 +5,7 @@ use Cassandane::Tiny;
 # Test replication of messages APPENDed to the master
 #
 sub test_splitbrain
+    :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Replication/splitbrain_bothexpunge
+++ b/cassandane/tiny-tests/Replication/splitbrain_bothexpunge
@@ -5,6 +5,7 @@ use Cassandane::Tiny;
 # Test replication of messages APPENDed to the master
 #
 sub test_splitbrain_bothexpunge
+    :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Replication/splitbrain_masterexpunge
+++ b/cassandane/tiny-tests/Replication/splitbrain_masterexpunge
@@ -5,6 +5,7 @@ use Cassandane::Tiny;
 # Test replication of messages APPENDed to the master
 #
 sub test_splitbrain_masterexpunge
+    :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Replication/splitbrain_replicaexpunge
+++ b/cassandane/tiny-tests/Replication/splitbrain_replicaexpunge
@@ -5,6 +5,7 @@ use Cassandane::Tiny;
 # Test replication of messages APPENDed to the master
 #
 sub test_splitbrain_replicaexpunge
+    :NoReplicaOnly
 {
     my ($self) = @_;
 

--- a/cassandane/tiny-tests/Replication/userflags
+++ b/cassandane/tiny-tests/Replication/userflags
@@ -5,6 +5,7 @@ use Cassandane::Tiny;
 # Test replication of user-defined flags
 #
 sub test_userflags
+    :NoReplicaOnly
 {
     my ($self) = @_;
 


### PR DESCRIPTION
It's never going to be a good idea to run commands that can't be run in readonly when you're on a replica server.