### PR TITLE
add an auditlog api

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -608,6 +608,7 @@ cunit_TESTS = \
     cunit/aaa-db.testc \
     cunit/annotate.testc \
     cunit/arrayu64.testc \
+    cunit/auditlog.testc \
     cunit/backend.testc \
     cunit/binhex.testc \
     cunit/bitvector.testc \
@@ -676,7 +677,7 @@ cunit_TESTS += cunit/ical_support.testc
 endif
 
 cunit_unit_SOURCES = $(cunit_FRAMEWORK) $(cunit_TESTS) \
-    imap/mutex_fake.c imap/spool.c imap/search_expr.c \
+    imap/mutex_fake.c imap/auditlog.c imap/spool.c imap/search_expr.c \
     master/event.c master/cronevent.c
 nodist_cunit_unit_SOURCES = cunit/unit-registry.c
 cunit_unit_LDADD = $(LD_SIEVE_ADD) $(LD_UTILITY_ADD) -lcunit
@@ -980,6 +981,8 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/append.h \
     imap/attachextract.c \
     imap/attachextract.h \
+    imap/auditlog.c \
+    imap/auditlog.h \
     imap/backend.c \
     imap/backend.h \
     imap/conversations.c \

--- a/cassandane/Cassandane/Cyrus/Delivery.pm
+++ b/cassandane/Cassandane/Cyrus/Delivery.pm
@@ -623,7 +623,7 @@ sub test_auditlog_size
     xlog $self, "Check the correct size was auditlogged";
     if ($self->{instance}->{have_syslog_replacement}) {
         my @appends = $self->{instance}->getsyslog(
-            qr/auditlog: append: .* uid=<1>/);
+            qr/auditlog: append .* uid=<1>/);
         $self->assert_num_equals(1, scalar @appends);
 
         # delivery will add some headers, so it will be larger

--- a/cunit/auditlog.testc
+++ b/cunit/auditlog.testc
@@ -65,4 +65,32 @@ static void test_trace_id(void)
     buf_free(&buf);
 }
 
+static void test_auditlog_push(void)
+{
+    static const struct {
+        const char *value;
+        const char *expect;
+    } tests[] = {
+        { "",                           " k=<>" },
+        { NULL,                         " k=<>" },
+        { "no brackets",                " k=<no brackets>" },
+        { "<outer brackets swallowed>", " k=<outer brackets swallowed>" },
+        { "inner <brackets> kept",      " k=<inner <brackets> kept>" },
+        { "<unclosed bracket kept",     " k=<<unclosed bracket kept>" },
+        { "unopened bracket kept>",     " k=<unopened bracket kept>>" },
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    struct buf buf = BUF_INITIALIZER;
+    unsigned i;
+
+    for (i = 0; i < n_tests; i++) {
+        buf_reset(&buf);
+        hidden_auditlog_push(&buf, "k", tests[i].value);
+
+        CU_ASSERT_STRING_EQUAL(buf_cstring(&buf), tests[i].expect);
+    }
+
+    buf_free(&buf);
+}
+
 /* vim: set ft=c: */

--- a/cunit/auditlog.testc
+++ b/cunit/auditlog.testc
@@ -1,9 +1,68 @@
 #include "cunit/unit.h"
 #include "imap/auditlog.h"
 
-static void test_stub(void)
+#include "lib/sessionid.h"
+#include "lib/libconfig.h"
+
+#define DBDIR "test-auditlog-dbdir"
+
+extern void hidden_auditlog_begin(struct buf *buf, const char *action);
+extern void hidden_auditlog_push(struct buf *buf,
+                                 const char *key,
+                                 const char *value);
+extern void hidden_auditlog_finish(struct buf *buf);
+
+static int set_up(void)
 {
-    // XXX test something
+    session_clear_id();
+    trace_set_id(NULL, 0);
+    return 0;
+}
+
+static int tear_down(void)
+{
+    session_clear_id();
+    trace_set_id(NULL, 0);
+    return 0;
+}
+
+static void test_session_id(void)
+{
+    struct buf buf = BUF_INITIALIZER;
+    char match[32 + MAX_SESSIONID_SIZE];
+
+    /* need basic configuration for session_new_id() */
+    config_read_string(
+        "configdirectory: "DBDIR"/conf\n"
+    );
+
+    session_new_id();
+    snprintf(match, sizeof(match), " sessionid=<%s> ", session_id());
+
+    CU_SYSLOG_MATCH_SUBSTR(match);
+    hidden_auditlog_begin(&buf, "session id test");
+    hidden_auditlog_push(&buf, "key", "value");
+    hidden_auditlog_finish(&buf);
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    config_reset();
+    system("rm -rf " DBDIR);
+    buf_free(&buf);
+}
+
+static void test_trace_id(void)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    trace_set_id("sometraceid", 0);
+
+    CU_SYSLOG_MATCH_SUBSTR(" r.tid=<sometraceid> ");
+    hidden_auditlog_begin(&buf, "trace id test");
+    hidden_auditlog_push(&buf, "key", "value");
+    hidden_auditlog_finish(&buf);
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&buf);
 }
 
 /* vim: set ft=c: */

--- a/cunit/auditlog.testc
+++ b/cunit/auditlog.testc
@@ -1,0 +1,9 @@
+#include "cunit/unit.h"
+#include "imap/auditlog.h"
+
+static void test_stub(void)
+{
+    // XXX test something
+}
+
+/* vim: set ft=c: */

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -104,6 +104,36 @@ HIDDEN void hidden_auditlog_finish(struct buf *buf)
  * Public API
  */
 
+EXPORTED void auditlog_quota(const char *action,
+                             const char *root,
+                             const quota_t *oldquotas,
+                             const quota_t *newquotas)
+{
+    struct buf buf = BUF_INITIALIZER;
+    int resource;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, action);
+    auditlog_push(&buf, "root", root);
+
+    for (resource = 0; resource < QUOTA_NUMRESOURCES; resource++) {
+        if (oldquotas) {
+            buf_printf(&buf, " old%s=<%lld>",
+                             quota_names[resource],
+                             oldquotas[resource]);
+        }
+
+        if (newquotas) {
+            buf_printf(&buf, " new%s=<%lld>",
+                             quota_names[resource],
+                             newquotas[resource]);
+        }
+    }
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out)
 {
     struct buf buf = BUF_INITIALIZER;

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -134,6 +134,24 @@ EXPORTED void auditlog_client(const char *action,
     auditlog_finish(&buf);
 }
 
+/* n.b. you probably want to call duplicate_log()! */
+HIDDEN void auditlog_duplicate(const char *action,
+                               const duplicate_key_t *dkey)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, "duplicate");
+
+    auditlog_push(&buf, "action", action);
+    auditlog_push(&buf, "message-id", dkey->id);
+    auditlog_push(&buf, "uniqueid-or-scope", dkey->to);
+    auditlog_push(&buf, "date", dkey->date);
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_imip(const char *message_id,
                             const char *outcome,
                             const char *errstr)

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -118,6 +118,22 @@ HIDDEN void hidden_auditlog_finish(struct buf *buf)
  * Public API
  */
 
+EXPORTED void auditlog_client(const char *action,
+                              const char *userid,
+                              const char *client)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, action);
+
+    auditlog_push(&buf, "userid", userid);
+    auditlog_push(&buf, "client", client);
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_imip(const char *message_id,
                             const char *outcome,
                             const char *errstr)

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -252,6 +252,41 @@ EXPORTED void auditlog_quota(const char *action,
     auditlog_finish(&buf);
 }
 
+EXPORTED void auditlog_sieve(const char *action,
+                             const char *userid,
+                             const char *in_msgid,
+                             const char *out_msgid,
+                             const char *target,
+                             const char *from_addr,
+                             const char *to_addr)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, action);
+
+    if (userid)
+        auditlog_push(&buf, "userid", userid);
+
+    /* message-ids have their own <> */
+    buf_printf(&buf, " in.msgid=%s", in_msgid ? in_msgid : "<nomsgid>");
+    if (out_msgid)
+        buf_printf(&buf, " out.msgid=%s", out_msgid);
+
+    if (target)
+        auditlog_push(&buf, "target", target);
+
+    /* from-addr has its own <> */
+    if (from_addr)
+        buf_printf(&buf, " from=%s", from_addr);
+
+    if (to_addr)
+        auditlog_push(&buf, "to", to_addr); // XXX ^
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out)
 {
     struct buf buf = BUF_INITIALIZER;

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -204,6 +204,24 @@ EXPORTED void auditlog_message(const char *action,
     auditlog_finish(&buf);
 }
 
+EXPORTED void auditlog_proxy(const char *userid, const char *status)
+{
+    struct buf buf = BUF_INITIALIZER;
+    char rsessionid[MAX_SESSIONID_SIZE];
+
+    if (!config_auditlog) return;
+
+    parse_sessionid(status, rsessionid);
+
+    auditlog_begin(&buf, "proxy");
+
+    if (userid)
+        auditlog_push(&buf, "userid", userid);
+    auditlog_push(&buf, "remote", rsessionid);
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_quota(const char *action,
                              const char *root,
                              const quota_t *oldquotas,

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -118,6 +118,24 @@ HIDDEN void hidden_auditlog_finish(struct buf *buf)
  * Public API
  */
 
+EXPORTED void auditlog_imip(const char *message_id,
+                            const char *outcome,
+                            const char *errstr)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, "processed iMIP");
+
+    auditlog_push(&buf, "message-id", message_id ? message_id : "nomsgid");
+    auditlog_push(&buf, "outcome", outcome);
+    if (errstr)
+        auditlog_push(&buf, "errstr", errstr);
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_mailbox(const char *action,
                                const struct mailbox *oldmailbox,
                                const struct mailbox *mailbox,

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -104,6 +104,28 @@ HIDDEN void hidden_auditlog_finish(struct buf *buf)
  * Public API
  */
 
+EXPORTED void auditlog_mboxname(const char *action,
+                                const char *userid,
+                                const char *mboxname)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, action);
+
+    if (userid) {
+        auditlog_push(&buf, "userid", userid);
+    }
+
+    if (mboxname) {
+        /* XXX convert to consistent namespace? */
+        auditlog_push(&buf, "mailbox", mboxname);
+    }
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_quota(const char *action,
                              const char *root,
                              const quota_t *oldquotas,

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -118,6 +118,28 @@ HIDDEN void hidden_auditlog_finish(struct buf *buf)
  * Public API
  */
 
+EXPORTED void auditlog_acl(const char *mboxname,
+                           const mbentry_t *oldmbentry,
+                           const mbentry_t *mbentry)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, "acl");
+
+    /* XXX convert mboxname to consistent namespace? */
+    auditlog_push(&buf, "mailbox", mboxname);
+    auditlog_push(&buf, "uniqueid", mbentry->uniqueid);
+    auditlog_push(&buf, "jmapid", mbentry->jmapid);
+    auditlog_push(&buf, "mbtype", mboxlist_mbtype_to_string(mbentry->mbtype));
+    auditlog_push(&buf, "oldacl", oldmbentry ? oldmbentry->acl : "NONE");
+    auditlog_push(&buf, "acl", mbentry->acl);
+    buf_printf(&buf, " foldermodseq=<" MODSEQ_FMT ">", mbentry->foldermodseq);
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_client(const char *action,
                               const char *userid,
                               const char *client)

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -268,6 +268,29 @@ EXPORTED void auditlog_message(const char *action,
     auditlog_finish(&buf);
 }
 
+EXPORTED void auditlog_modseq(const struct mailbox *mailbox)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, "modseq");
+
+    auditlog_push(&buf, "mailbox", mailbox_name(mailbox));
+    auditlog_push(&buf, "uniqueid", mailbox_uniqueid(mailbox));
+    auditlog_push(&buf, "mboxid", mailbox_jmapid(mailbox));
+
+    buf_printf(&buf, " highestmodseq=<" MODSEQ_FMT ">",
+                     mailbox->i.highestmodseq);
+    buf_printf(&buf, " deletedmodseq=<" MODSEQ_FMT ">",
+                     mailbox->i.deletedmodseq);
+    buf_printf(&buf, " crcs=<%u/%u>",
+                     mailbox->i.synccrcs.basic,
+                     mailbox->i.synccrcs.annot);
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_proxy(const char *userid, const char *status)
 {
     struct buf buf = BUF_INITIALIZER;

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -1,0 +1,44 @@
+/* auditlog - audit logging API
+ *
+ * Copyright (c) 1994-2025 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <config.h>
+
+#include "imap/auditlog.h"

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -268,6 +268,26 @@ EXPORTED void auditlog_message(const char *action,
     auditlog_finish(&buf);
 }
 
+EXPORTED void auditlog_message_uid(const char *action,
+                                   const struct mailbox *mailbox,
+                                   uint32_t uid,
+                                   const char *flagstr)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&buf, action);
+
+    auditlog_push(&buf, "mailbox", mailbox_name(mailbox));
+    auditlog_push(&buf, "uniqueid", mailbox_uniqueid(mailbox));
+    auditlog_push(&buf, "mboxid", mailbox_jmapid(mailbox));
+    buf_printf(&buf, " uid=<%" PRIu32 ">", uid);
+    auditlog_push(&buf, "sysflags", flagstr);
+
+    auditlog_finish(&buf);
+}
+
 EXPORTED void auditlog_modseq(const struct mailbox *mailbox)
 {
     struct buf buf = BUF_INITIALIZER;

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -50,6 +50,9 @@
 
 #include <stdint.h>
 
+extern void auditlog_mboxname(const char *action,
+                              const char *userid,
+                              const char *mboxname);
 extern void auditlog_quota(const char *action,
                            const char *root,
                            const quota_t *oldquotas,

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -50,6 +50,9 @@
 
 #include <stdint.h>
 
+extern void auditlog_client(const char *action,
+                            const char *userid,
+                            const char *client);
 extern void auditlog_imip(const char *message_id,
                           const char *outcome,
                           const char *errstr);

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -66,6 +66,13 @@ extern void auditlog_quota(const char *action,
                            const char *root,
                            const quota_t *oldquotas,
                            const quota_t *newquotas);
+extern void auditlog_sieve(const char *action,
+                           const char *userid,
+                           const char *in_msgid,
+                           const char *out_msgid,
+                           const char *target,
+                           const char *from_addr,
+                           const char *to_addr);
 extern void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out);
 
 #endif

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -70,6 +70,10 @@ extern void auditlog_message(const char *action,
                              struct mailbox *mailbox,
                              const struct index_record *record,
                              const char *message_id);
+extern void auditlog_message_uid(const char *action,
+                                 const struct mailbox *mailbox,
+                                 uint32_t uid,
+                                 const char *flagstr);
 extern void auditlog_modseq(const struct mailbox *mailbox);
 extern void auditlog_proxy(const char *userid, const char *status);
 extern void auditlog_quota(const char *action,

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -51,6 +51,9 @@
 
 #include <stdint.h>
 
+extern void auditlog_acl(const char *mboxname,
+                         const mbentry_t *oldmbentry,
+                         const mbentry_t *mbentry);
 extern void auditlog_client(const char *action,
                             const char *userid,
                             const char *client);

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -50,6 +50,10 @@
 
 #include <stdint.h>
 
+extern void auditlog_mailbox(const char *action,
+                             const struct mailbox *oldmailbox,
+                             const struct mailbox *mailbox,
+                             const char *newpartition);
 extern void auditlog_mboxname(const char *action,
                               const char *userid,
                               const char *mboxname);

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -61,6 +61,7 @@ extern void auditlog_message(const char *action,
                              struct mailbox *mailbox,
                              const struct index_record *record,
                              const char *message_id);
+extern void auditlog_proxy(const char *userid, const char *status);
 extern void auditlog_quota(const char *action,
                            const char *root,
                            const quota_t *oldquotas,

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -50,6 +50,9 @@
 
 #include <stdint.h>
 
+extern void auditlog_imip(const char *message_id,
+                          const char *outcome,
+                          const char *errstr);
 extern void auditlog_mailbox(const char *action,
                              const struct mailbox *oldmailbox,
                              const struct mailbox *mailbox,

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -42,4 +42,14 @@
 #ifndef INCLUDED_AUDITLOG_H
 #define INCLUDED_AUDITLOG_H
 
+#include "imap/mailbox.h"
+#include "imap/mboxlist.h"
+#include "imap/quota.h"
+
+#include "lib/libconfig.h"
+
+#include <stdint.h>
+
+extern void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out);
+
 #endif

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -1,0 +1,45 @@
+/* auditlog - audit logging API
+ *
+ * Copyright (c) 1994-2025 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef INCLUDED_AUDITLOG_H
+#define INCLUDED_AUDITLOG_H
+
+#endif

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -42,6 +42,7 @@
 #ifndef INCLUDED_AUDITLOG_H
 #define INCLUDED_AUDITLOG_H
 
+#include "imap/duplicate.h"
 #include "imap/mailbox.h"
 #include "imap/mboxlist.h"
 #include "imap/quota.h"
@@ -53,6 +54,8 @@
 extern void auditlog_client(const char *action,
                             const char *userid,
                             const char *client);
+extern void auditlog_duplicate(const char *action,
+                               const duplicate_key_t *dkey);
 extern void auditlog_imip(const char *message_id,
                           const char *outcome,
                           const char *errstr);

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -50,6 +50,10 @@
 
 #include <stdint.h>
 
+extern void auditlog_quota(const char *action,
+                           const char *root,
+                           const quota_t *oldquotas,
+                           const quota_t *newquotas);
 extern void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out);
 
 #endif

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -70,6 +70,7 @@ extern void auditlog_message(const char *action,
                              struct mailbox *mailbox,
                              const struct index_record *record,
                              const char *message_id);
+extern void auditlog_modseq(const struct mailbox *mailbox);
 extern void auditlog_proxy(const char *userid, const char *status);
 extern void auditlog_quota(const char *action,
                            const char *root,

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -57,6 +57,10 @@ extern void auditlog_mailbox(const char *action,
 extern void auditlog_mboxname(const char *action,
                               const char *userid,
                               const char *mboxname);
+extern void auditlog_message(const char *action,
+                             struct mailbox *mailbox,
+                             const struct index_record *record,
+                             const char *message_id);
 extern void auditlog_quota(const char *action,
                            const char *root,
                            const quota_t *oldquotas,

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -65,6 +65,7 @@
 #include <sasl/sasl.h>
 #include <sasl/saslutil.h>
 
+#include "auditlog.h"
 #include "backend.h"
 #include "global.h"
 #include "iptostring.h"
@@ -851,11 +852,10 @@ static int backend_login(struct backend *ret, const char *userid,
                 post_parse_capability(ret);
             }
 
-            if (!(strcmp(prot->service, "imap") &&
-                 (strcmp(prot->service, "pop3")))) {
-                char rsessionid[MAX_SESSIONID_SIZE];
-                parse_sessionid(my_status, rsessionid);
-                syslog(LOG_NOTICE, "auditlog: proxy %s sessionid=<%s> remote=<%s>", userid, session_id(), rsessionid);
+            if (!(strcmp(prot->service, "imap")
+                && (strcmp(prot->service, "pop3"))))
+            {
+                auditlog_proxy(userid, my_status);
             }
         }
 

--- a/imap/duplicate.c
+++ b/imap/duplicate.c
@@ -69,6 +69,7 @@
 #endif
 
 #include "assert.h"
+#include "auditlog.h"
 #include "xmalloc.h"
 #include "global.h"
 #include "util.h"
@@ -207,9 +208,7 @@ EXPORTED void duplicate_log(const duplicate_key_t *dkey, const char *action)
     assert(dkey->date != NULL);
     syslog(LOG_INFO, "dupelim: eliminated duplicate message to %s id %s date %s (%s)",
       dkey->to, dkey->id, dkey->date, action);
-    if (config_auditlog)
-        syslog(LOG_NOTICE, "auditlog: duplicate sessionid=<%s> action=<%s> message-id=%s uniqueid-or-scope=<%s> date=<%s>",
-               session_id(), action, dkey->id, dkey->to, dkey->date);
+    auditlog_duplicate(action, dkey);
 }
 
 EXPORTED void duplicate_mark(const duplicate_key_t *dkey, time_t mark, unsigned long uid)

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -82,6 +82,7 @@
 #include "tls.h"
 #include "map.h"
 
+#include "auditlog.h"
 #include "imapd.h"
 #include "proc.h"
 #include "version.h"
@@ -726,12 +727,7 @@ static void httpd_reset(struct http_connection *conn)
         prot_free(httpd_out);
     }
 
-    if (config_auditlog) {
-        syslog(LOG_NOTICE,
-               "auditlog: traffic sessionid=<%s>"
-               " bytes_in=<%" PRIu64 "> bytes_out=<%" PRIu64 ">",
-               session_id(), bytes_in, bytes_out);
-    }
+    auditlog_traffic(bytes_in, bytes_out);
 
     httpd_in = httpd_out = NULL;
 
@@ -1196,11 +1192,7 @@ void shut_down(int code)
     prometheus_increment(code ? CYRUS_HTTP_SHUTDOWN_TOTAL_STATUS_ERROR
                               : CYRUS_HTTP_SHUTDOWN_TOTAL_STATUS_OK);
 
-    if (config_auditlog)
-        syslog(LOG_NOTICE,
-               "auditlog: traffic sessionid=<%s>"
-               " bytes_in=<%" PRIu64 "> bytes_out=<%" PRIu64 ">",
-               session_id(), bytes_in, bytes_out);
+    auditlog_traffic(bytes_in, bytes_out);
 
     saslprops_free(&saslprops);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -71,6 +71,7 @@
 #include "acl.h"
 #include "annotate.h"
 #include "append.h"
+#include "auditlog.h"
 #include "auth.h"
 #ifdef USE_AUTOCREATE
 #include "autocreate.h"
@@ -1003,10 +1004,7 @@ static void imapd_reset(void)
         prot_free(imapd_out);
     }
 
-    if (config_auditlog)
-        syslog(LOG_NOTICE, "auditlog: traffic sessionid=<%s>"
-               " bytes_in=<%" PRIu64 "> bytes_out=<%" PRIu64 ">",
-               session_id(), bytes_in, bytes_out);
+    auditlog_traffic(bytes_in, bytes_out);
 
     imapd_in = imapd_out = NULL;
 
@@ -1400,10 +1398,7 @@ void shut_down(int code)
     prometheus_increment(code ? CYRUS_IMAP_SHUTDOWN_TOTAL_STATUS_ERROR
                               : CYRUS_IMAP_SHUTDOWN_TOTAL_STATUS_OK);
 
-    if (config_auditlog)
-        syslog(LOG_NOTICE, "auditlog: traffic sessionid=<%s>"
-               " bytes_in=<%" PRIu64 "> bytes_out=<%" PRIu64 ">",
-               session_id(), bytes_in, bytes_out);
+    auditlog_traffic(bytes_in, bytes_out);
 
     if (protin) protgroup_free(protin);
 

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1309,7 +1309,8 @@ EXPORTED void jmap_set_blobid(const struct message_guid *guid, char *buf)
 
 EXPORTED void jmap_set_emailid(struct conversations_state *cstate,
                                const struct message_guid *guid,
-                               uint64_t nanosec, struct timespec *ts,
+                               uint64_t nanosec,
+                               const struct timespec *ts,
                                char *emailid)
 {
     // initialize a struct buf with char emailid[JMAP_MAX_EMAILID_SIZE]

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -203,7 +203,8 @@ extern void jmap_set_blobid(const struct message_guid *guid, char *buf);
 
 extern void jmap_set_emailid(struct conversations_state *cstate,
                              const struct message_guid *guid,
-                             uint64_t nanosec, struct timespec *ts,
+                             uint64_t nanosec,
+                             const struct timespec *ts,
                              char *emailid);
 
 #define JMAP_MAILBOXID_PREFIX 'P'

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1741,12 +1741,9 @@ static int sieve_processcal(void *ac, void *ic, void *sc, void *mc,
                       m->id ? m->id : "<nomsgid>",
                       buf_cstring(&cal->outcome),
                       buf_cstring(&cal->reason));
-    if (config_auditlog)
-        syslog(LOG_NOTICE,
-               "auditlog: processed iMIP sessionid=<%s> message-id=%s"
-               " outcome=%s errstr='%s'",
-               session_id(), m->id ? m->id : "<nomsgid>",
-               buf_cstring(&cal->outcome), buf_cstring(&cal->reason));
+    auditlog_imip(m->id,
+                  buf_cstring(&cal->outcome),
+                  buf_cstringnull_ifempty(&cal->reason));
 
     strarray_fini(&sched_addresses);
     if (parts) {

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -67,6 +67,7 @@
 #include <sasl/saslutil.h>
 
 #include "assert.h"
+#include "auditlog.h"
 #include "util.h"
 #include "auth.h"
 #include "prot.h"
@@ -1725,7 +1726,7 @@ static void pushmsg(struct protstream *in, struct protstream *out,
 int lmtp_runtxn(struct backend *conn, struct lmtp_txn *txn)
 {
     int j, code, r = 0;
-    char buf[8192], rsessionid[MAX_SESSIONID_SIZE];
+    char buf[8192];
     int onegood;
     const char *traceid = trace_id();
 
@@ -1740,11 +1741,7 @@ int lmtp_runtxn(struct backend *conn, struct lmtp_txn *txn)
     if (!ISGOOD(code)) {
         goto failall;
     }
-
-    if (config_auditlog) {
-        parse_sessionid(buf, rsessionid);
-        syslog(LOG_NOTICE, "auditlog: proxy sessionid=<%s> remote=<%s>", session_id(), rsessionid);
-    }
+    auditlog_proxy(NULL, buf);
 
     /* forward traceid if remote supports it */
     if (traceid && CAPA(conn, CAPA_TRACE)) {

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -77,6 +77,7 @@
 
 #include "annotate.h"
 #include "assert.h"
+#include "auditlog.h"
 #include "bsearch.h"
 #ifdef WITH_DAV
 #include "caldav_db.h"
@@ -6526,13 +6527,7 @@ EXPORTED int mailbox_create(const char *name,
     r = mailbox_commit(mailbox);
     if (r) goto done;
 
-    if (config_auditlog)
-        xsyslog(LOG_NOTICE, "auditlog: create",
-                "sessionid=<%s> mailbox=<%s> uniqueid=<%s>"
-                " mboxid=<%s> uidvalidity=<%u>",
-                session_id(), mailbox_name(mailbox),
-                mailbox_uniqueid(mailbox), mailbox_jmapid(mailbox),
-                mailbox->i.uidvalidity);
+    auditlog_mailbox("create", NULL, mailbox, NULL);
 
 done:
     mbname_free(&mbname);
@@ -6788,11 +6783,7 @@ static int mailbox_delete_internal(struct mailbox **mailboxptr)
 
     syslog(LOG_NOTICE, "Deleted mailbox %s", mailbox_name(mailbox));
 
-    if (config_auditlog)
-        xsyslog(LOG_NOTICE, "auditlog: delete",
-                "sessionid=<%s> mailbox=<%s> uniqueid=<%s> mboxid=<%s>",
-                session_id(), mailbox_name(mailbox),
-                mailbox_uniqueid(mailbox), mailbox_jmapid(mailbox));
+    auditlog_mailbox("delete", NULL, mailbox, NULL);
 
     proc_killmbox(mailbox_name(mailbox));
 
@@ -7303,12 +7294,7 @@ HIDDEN int mailbox_rename_copy(struct mailbox *oldmailbox,
     r = mailbox_commit(newmailbox);
     if (r) goto fail;
 
-    if (config_auditlog)
-        xsyslog(LOG_NOTICE, "auditlog: rename",
-                "sessionid=<%s> oldmailbox=<%s> newmailbox=<%s>"
-                " uniqueid=<%s> mboxid=<%s>",
-                session_id(), mailbox_name(oldmailbox), newname,
-                mailbox_uniqueid(newmailbox), mailbox_jmapid(newmailbox));
+    auditlog_mailbox("rename", oldmailbox, newmailbox, NULL);
 
     if (newmailboxptr) *newmailboxptr = newmailbox;
     else mailbox_close(&newmailbox);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -3296,17 +3296,9 @@ EXPORTED int mailbox_commit(struct mailbox *mailbox)
         return IMAP_IOERROR;
     }
 
-    if (config_auditlog && mailbox->modseq_dirty)
-        xsyslog(LOG_NOTICE, "auditlog: modseq",
-                "sessionid=<%s> mailbox=<%s> uniqueid=<%s> mboxid=<%s>"
-                " highestmodseq=<" MODSEQ_FMT
-                "> deletedmodseq=<" MODSEQ_FMT "> crcs=<%u/%u>",
-                session_id(), mailbox_name(mailbox),
-                mailbox_uniqueid(mailbox), mailbox_jmapid(mailbox),
-                mailbox->i.highestmodseq, mailbox->i.deletedmodseq,
-                mailbox->i.synccrcs.basic, mailbox->i.synccrcs.annot);
-
     if (mailbox->modseq_dirty) {
+        auditlog_modseq(mailbox);
+
         struct mboxevent *mboxevent = mboxevent_new(EVENT_MAILBOX_MODSEQ);
         mboxevent_extract_mailbox(mboxevent, mailbox);
         mboxevent_set_access(mboxevent, NULL, NULL, "", mailbox_name(mailbox), 0);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5041,26 +5041,12 @@ EXPORTED void mailbox_cleanup_uid(struct mailbox *mailbox, uint32_t uid, const c
     const char *archivefname = mailbox_archive_fname(mailbox, uid);
 
     if (cyrus_unlink_fdptr(spoolfname, &mailbox->spool_dirfd) == 0) {
-        if (config_auditlog) {
-            xsyslog(LOG_NOTICE, "auditlog: unlink",
-                    "sessionid=<%s> mailbox=<%s> uniqueid=<%s> mboxid=<%s>"
-                    " uid=<%u> sysflags=<%s>",
-                    session_id(), mailbox_name(mailbox),
-                    mailbox_uniqueid(mailbox), mailbox_jmapid(mailbox),
-                    uid, flagstr);
-        }
+        auditlog_message_uid("remove-spool", mailbox, uid, flagstr);
     }
 
     if (strcmp(spoolfname, archivefname)) {
         if (cyrus_unlink_fdptr(archivefname, &mailbox->archive_dirfd) == 0) {
-            if (config_auditlog) {
-                xsyslog(LOG_NOTICE, "auditlog: unlinkarchive",
-                        "sessionid=<%s> mailbox=<%s> uniqueid=<%s> mboxid=<%s>"
-                        " uid=<%u> sysflags=<%s>",
-                        session_id(), mailbox_name(mailbox),
-                        mailbox_uniqueid(mailbox), mailbox_jmapid(mailbox),
-                        uid, flagstr);
-            }
+            auditlog_message_uid("remove-archive", mailbox, uid, flagstr);
         }
     }
 }

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -180,11 +180,14 @@ static struct MsgFlagMap msgflagmap[] = {
     {"EX", (int)FLAG_INTERNAL_EXPUNGED}
     /* ZZ -> invalid file found on disk */
 };
+_Static_assert(N_MSGFLAGMAP == sizeof(msgflagmap) / sizeof(msgflagmap[0]),
+               "N_MSGFLAGMAP has the wrong value");
 /* The length of the msgflagmap list * 2 +
  * Total number of separators possible
  * = 33 bytes
  */
-#define FLAGMAPSTR_MAXLEN (1 + 3 *(sizeof(msgflagmap) / sizeof(struct MsgFlagMap)))
+_Static_assert(FLAGMAPSTR_MAXLEN == 1 + 3 * N_MSGFLAGMAP,
+               "FLAGMAPSTR_MAXLEN has the wrong value");
 
 static int mailbox_index_unlink(struct mailbox *mailbox);
 static int _mailbox_index_repack(struct mailbox *mailbox,
@@ -234,7 +237,7 @@ static inline void flags_to_str_internal(uint32_t flags, char *flagstr)
     }
 }
 
-static void flags_to_str(struct index_record *record, char *flagstr)
+EXPORTED void flags_to_str(const struct index_record *record, char *flagstr)
 {
     uint32_t flags = record->system_flags | record->internal_flags;
 

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -580,11 +580,15 @@ enum {
 
 /*
  * This structure maintains a list of FLAG_ to the string literal mapping.
+ * The defines are validated at compile time in mailbox.c
  */
 struct MsgFlagMap {
     const char *code;
     MsgFlags flag;
 };
+#define N_MSGFLAGMAP (11)
+#define FLAGMAPSTR_MAXLEN (1 + 3 * N_MSGFLAGMAP)
+extern void flags_to_str(const struct index_record *record, char *flagstr);
 
 unsigned mailbox_cached_header(const char *s);
 unsigned mailbox_cached_header_inline(const char *text);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1475,15 +1475,8 @@ static int mboxlist_update_entry_full(const char *name, const mbentry_t *mbentry
 
         if (r) goto done;
 
-        if (config_auditlog && (!old || strcmpsafe(old->acl, mbentry->acl))) {
-            /* XXX is there a difference between "" and NULL? */
-            xsyslog(LOG_NOTICE, "auditlog: acl",
-                                "mailbox=<%s> uniqueid=<%s> jmapid=<%s> "
-                                "mbtype=<%s> oldacl=<%s> acl=<%s> "
-                                "foldermodseq=<" MODSEQ_FMT ">",
-                    name, mbentry->uniqueid, mbentry->jmapid,
-                    mboxlist_mbtype_to_string(mbentry->mbtype),
-                    old ? old->acl : "NONE", mbentry->acl, mbentry->foldermodseq);
+        if (!old || strcmpsafe(old->acl, mbentry->acl)) {
+            auditlog_acl(name, old, mbentry);
         }
     }
     else if (old) {

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3255,13 +3255,9 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
             char *oldpartition = xstrdupnull(mailbox_partition(oldmailbox));
             char *olduniqueid = (mailbox_mbtype(oldmailbox) & MBTYPE_LEGACY_DIRS) ?
                 NULL : xstrdup(mailbox_uniqueid(oldmailbox));
-            if (config_auditlog)
-                xsyslog(LOG_NOTICE, "auditlog: partitionmove",
-                        "sessionid=<%s> mailbox=<%s> uniqueid=<%s> mboxid=<%s>"
-                        " oldpart=<%s> newpart=<%s>",
-                        session_id(),
-                        mailbox_name(oldmailbox), mailbox_uniqueid(oldmailbox),
-                        mailbox_jmapid(oldmailbox), oldpartition, partition);
+
+            auditlog_mailbox("partitionmove", NULL, oldmailbox, newpartition);
+
             /* this will sync-log the name anyway */
             mailbox_close(&oldmailbox);
             mailbox_delete_cleanup(NULL, oldpartition, oldname, olduniqueid);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5532,16 +5532,7 @@ EXPORTED int mboxlist_changesub(const char *name, const char *userid,
         mboxevent_free(&mboxevent);
     }
 
-    if (add) {
-        xsyslog(LOG_NOTICE, "auditlog: subscribe",
-                            "userid=<%s> mailbox=<%s>",
-                            userid, name);
-    }
-    else {
-        xsyslog(LOG_NOTICE, "auditlog: unsubscribe",
-                            "userid=<%s> mailbox=<%s>",
-                            userid, name);
-    }
+    auditlog_mboxname(add ? "subscribe" : "unsubscribe", userid, name);
 
   done:
     mboxlist_entry_free(&mbentry);

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -74,6 +74,7 @@
 #include "slowio.h"
 #include "tls.h"
 
+#include "auditlog.h"
 #include "imapd.h"
 #include "mailbox.h"
 #include "mboxevent.h"
@@ -355,10 +356,7 @@ static void popd_reset(void)
         prot_free(popd_out);
     }
 
-    if (config_auditlog)
-        syslog(LOG_NOTICE, "auditlog: traffic sessionid=<%s>"
-               " bytes_in=<%" PRIu64 "> bytes_out=<%" PRIu64 ">",
-               session_id(), bytes_in, bytes_out);
+    auditlog_traffic(bytes_in, bytes_out);
 
     popd_in = popd_out = NULL;
 
@@ -656,10 +654,7 @@ void shut_down(int code)
         prometheus_decrement(CYRUS_POP3_READY_LISTENERS);
     }
 
-    if (config_auditlog)
-        syslog(LOG_NOTICE, "auditlog: traffic sessionid=<%s>"
-               " bytes_in=<%" PRIu64 "> bytes_out=<%" PRIu64 ">",
-               session_id(), bytes_in, bytes_out);
+    auditlog_traffic(bytes_in, bytes_out);
 
     tls_shutdown_serverengine();
 


### PR DESCRIPTION
**Reviewers:** I suggest reading this commit-by-commit.

This adds an auditlog API, providing a handful of real (type-checked!) functions for the various patterns we auditlog, and updates all existing audit logging to use it.  I think we will find it is much easier to use and maintain than syslog or xsyslog were.

The output should be mostly unchanged, except that:

* trace-id is now audit logged as `r.tid=<...>` if it was set  (see #5614)
* the `unlink` and `unlinkarchive` lines from `mailbox_cleanup_uid()` are now `remove-spool` and `remove-archive` respectively, so they don't get conflated with the `unlink` lines from `mailbox_commit()`
* some fields may be output in a different order from before
* some extra fields may be output that weren't before
* some inconsistencies have been brought into line

I thought I was going to implement this as macros around xsyslog, but that turned out to be a silly direction.  Instead, the `auditlog_foo()` functions are implemented in terms of a lightweight internal API that will be easy to modify or replace if we want to change the output format in the future.