### PR TITLE
MUPDATE: add MAILBOX-EXTENDED capability and functionalty

### DIFF
--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -113,6 +113,7 @@ struct mb_node
 {
     char mailbox[MAX_MAILBOX_BUFFER];
     char location[MAX_MAILBOX_BUFFER];
+    char jmapid[JMAP_MAX_MAILBOXID_SIZE];
     char *acl;
     struct mb_node *next;
 };
@@ -164,8 +165,11 @@ static int mupdate_list_cb(struct mupdate_mailboxdata *mdata,
         next = xzmalloc(sizeof(struct mb_node));
         strlcpy(next->mailbox, mdata->mailbox, sizeof(next->mailbox));
         strlcpy(next->location, mdata->location, sizeof(next->location));
-        if (!strncmp(cmd, "MAILBOX", 7))
+        if (!strncmp(cmd, "MAILBOX", 7)) {
             next->acl = xstrdup(mdata->acl);
+            if (mdata->jmapid)
+                strlcpy(next->jmapid, mdata->jmapid, sizeof(next->jmapid));
+        }
 
         *act_tail = next;
         act_tail = &(next->next);
@@ -219,7 +223,7 @@ static int pop_mupdate_cb(const mbentry_t *mbentry, void *rockp)
             /* No need to update mupdate NOW, we'll get it when we
              * untag the mailbox */
             skip_flag = 1;
-        } else if (act_head->acl) {
+        } else if (act_head->acl && mbentry->jmapid) {
             if (
                     !strcmp(realpart, act_head->location) &&
                     !strcmp(mbentry->acl, act_head->acl)
@@ -330,7 +334,8 @@ static int pop_mupdate_cb(const mbentry_t *mbentry, void *rockp)
         return 0;
     }
 
-    r = mupdate_activate(rock->h, mbentry->name, realpart, mbentry->acl);
+    r = mupdate_activate(rock->h, mbentry->name, realpart,
+                         mbentry->acl, mbentry->jmapid);
 
     if (r == MUPDATE_NOCONN) {
         fprintf(stderr, "permanent failure storing '%s'\n", mbentry->name);
@@ -463,7 +468,8 @@ static void do_pop_mupdate(void)
 
         /* force a push to mupdate */
         snprintf(buf, sizeof(buf), "%s!%s", config_servername, mbentry->partition);
-        ret = mupdate_activate(popmupdaterock.h, me->mailbox, buf, mbentry->acl);
+        ret = mupdate_activate(popmupdaterock.h, me->mailbox, buf,
+                               mbentry->acl, mbentry->jmapid);
         if (ret) {
             fprintf(stderr,
                     "couldn't perform mupdatepush to un-remote-flag %s\n",

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1566,7 +1566,7 @@ EXPORTED int mboxlist_update_full(const mbentry_t *mbentry, int localonly, int s
             char *location = strconcat(config_servername, "!",
                                        mbentry->partition, (char *)NULL);
             r = mupdate_activate(mupdate_h, mbentry->name,
-                                 location, mbentry->acl);
+                                 location, mbentry->acl, mbentry->jmapid);
             free(location);
             if (r) {
                 syslog(LOG_ERR,
@@ -2204,7 +2204,8 @@ EXPORTED int mboxlist_createmailbox_version(const mbentry_t *mbentry, int minor_
 
         r = mupdate_connect(config_mupdate_server, NULL, &mupdate_h, NULL);
         if (!r) r = mupdate_reserve(mupdate_h, mboxname, loc);
-        if (!r) r = mupdate_activate(mupdate_h, mboxname, loc, acl);
+        if (!r) r = mupdate_activate(mupdate_h, mboxname, loc,
+                                     acl, newmbentry->jmapid);
         if (r) {
             syslog(LOG_ERR, "MUPDATE: can't commit mailbox entry for '%s'",
                    mboxname);
@@ -3157,7 +3158,8 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
             if (!r) r = mupdate_delete(mupdate_h, oldname);
             if (!r) r = mupdate_reserve(mupdate_h, newname, loc);
         }
-        if (!r) r = mupdate_activate(mupdate_h, newname, loc, newmbentry->acl);
+        if (!r) r = mupdate_activate(mupdate_h, newname, loc,
+                                     newmbentry->acl, newmbentry->jmapid);
         if (r) {
             syslog(LOG_ERR,
                    "MUPDATE: can't commit mailbox entry for '%s'",
@@ -3600,7 +3602,7 @@ EXPORTED int mboxlist_setacl(const struct namespace *namespace __attribute__((un
                    name);
         }
         else {
-            r = mupdate_activate(mupdate_h, name, buf, newacl);
+            r = mupdate_activate(mupdate_h, name, buf, newacl, mbentry->jmapid);
             if(r) {
                 syslog(LOG_ERR,
                        "MUPDATE: can't update mailbox entry for '%s'",
@@ -3707,7 +3709,7 @@ mboxlist_setacls(const char *name, const char *newacl, modseq_t foldermodseq, in
                    "cannot connect to mupdate server for syncacl on '%s'",
                    name);
         } else {
-            r = mupdate_activate(mupdate_h, name, buf, newacl);
+            r = mupdate_activate(mupdate_h, name, buf, newacl, mbentry->jmapid);
             if (r) {
                 syslog(LOG_ERR,
                        "MUPDATE: can't update mailbox entry for '%s'",

--- a/imap/mupdate-client.h
+++ b/imap/mupdate-client.h
@@ -45,6 +45,11 @@
 
 #include <sasl/sasl.h>
 
+enum {
+    /* MUPDATE capabilities */
+    CAPA_MAILBOXEXT          = (1 << 3),
+};
+
 #define FNAME_MUPDATE_TARGET_SOCK "/socket/mupdate.target"
 
 typedef struct mupdate_handle_s mupdate_handle;
@@ -59,7 +64,7 @@ void mupdate_disconnect(mupdate_handle **h);
 /* activate a mailbox */
 int mupdate_activate(mupdate_handle *handle,
                      const char *mailbox, const char *location,
-                     const char *acl);
+                     const char *acl, const char *jmapid);
 
 /* reserve a piece of namespace */
 int mupdate_reserve(mupdate_handle *handle,
@@ -82,6 +87,7 @@ struct mupdate_mailboxdata {
     const char *mailbox;
     const char *location;
     const char *acl;
+    const char *jmapid;
     enum mbtype t;
 };
 
@@ -111,5 +117,9 @@ int mupdate_noop(mupdate_handle *handle, mupdate_callback callback,
 
 /* ping a local slave */
 void kick_mupdate(void);
+
+/* parse extended mailbox args in ACTIVATE command and MAILBOX response */
+int mupdate_parse_mailbox_extargs(struct protstream *pin,
+                                  struct dlist **extargs);
 
 #endif

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -127,7 +127,8 @@ struct conn {
 
     SSL *tlsconn;
     void *tls_comp;     /* TLS compression method, if any */
-    int compress_done;  /* have we done a successful compress? */
+
+    uint32_t client_capa;
 
     int idle;
 
@@ -203,7 +204,8 @@ static void cmd_authenticate(struct conn *C,
                       const char *clientstart);
 static void cmd_set(struct conn *C,
              const char *tag, const char *mailbox,
-             const char *location, const char *acl, enum settype t);
+             const char *location, const char *acl,
+             struct dlist *extargs, enum settype t);
 static void cmd_find(struct conn *C, const char *tag, const char *mailbox,
               int send_ok, int send_delete);
 static void cmd_list(struct conn *C, const char *tag, const char *host_prefix);
@@ -213,6 +215,7 @@ static void cmd_starttls(struct conn *C, const char *tag);
 #ifdef HAVE_ZLIB
 static void cmd_compress(struct conn *C, const char *tag, const char *alg);
 #endif
+static void cmd_enable(struct conn *C, const char *tag, strarray_t *args);
 static void shut_down(int code) __attribute__((noreturn));
 static int reset_saslconn(struct conn *c);
 static void database_init(void);
@@ -693,19 +696,35 @@ static mupdate_docmd_result_t docmd(struct conn *c)
         }
         else if (!c->userid) goto nologin;
         else if (!strcmp(c->cmd.s, "Activate")) {
+            struct dlist *extargs = NULL;
+
             if (ch != ' ') goto missingargs;
             ch = getstring(c->pin, c->pout, &(c->arg1));
             if (ch != ' ') goto missingargs;
             ch = getstring(c->pin, c->pout, &(c->arg2));
             if (ch != ' ') goto missingargs;
             ch = getstring(c->pin, c->pout, &(c->arg3));
+            if (ch == ' ') {
+                ch = mupdate_parse_mailbox_extargs(c->pin, &extargs);
+                if (ch == EOF) {
+                    dlist_free(&extargs);
+                    goto badargs;
+                }
+            }
             CHECKNEWLINE(c, ch);
 
-            if (c->streaming) goto notwhenstreaming;
-            if (!masterp) goto masteronly;
+            if (c->streaming) {
+                dlist_free(&extargs);
+                goto notwhenstreaming;
+            }
+            if (!masterp) {
+                dlist_free(&extargs);
+                goto masteronly;
+            }
 
             cmd_set(c, c->tag.s, c->arg1.s, c->arg2.s,
-                    c->arg3.s, SET_ACTIVE);
+                    c->arg3.s, extargs, SET_ACTIVE);
+            dlist_free(&extargs);
         }
         else goto badcmd;
         break;
@@ -736,7 +755,7 @@ static mupdate_docmd_result_t docmd(struct conn *c)
             if (!masterp) goto masteronly;
 
             cmd_set(c, c->tag.s, c->arg1.s, c->arg2.s,
-                    NULL, SET_DEACTIVATE);
+                    NULL, NULL, SET_DEACTIVATE);
         }
         else if (!strcmp(c->cmd.s, "Delete")) {
             if (ch != ' ') goto missingargs;
@@ -746,7 +765,29 @@ static mupdate_docmd_result_t docmd(struct conn *c)
             if (c->streaming) goto notwhenstreaming;
             if (!masterp) goto masteronly;
 
-            cmd_set(c, c->tag.s, c->arg1.s, NULL, NULL, SET_DELETE);
+            cmd_set(c, c->tag.s, c->arg1.s, NULL, NULL, NULL, SET_DELETE);
+        }
+        else goto badcmd;
+        break;
+
+    case 'E':
+        if (!c->userid) goto nologin;
+        else if (!strcmp(c->cmd.s, "Enable")) {
+            strarray_t args = STRARRAY_INITIALIZER;
+
+            if (ch != ' ') goto missingargs;
+            do {
+                ch = getword(c->pin, &(c->arg1));
+                if (!c->arg1.s[0]) {
+                    strarray_fini(&args);
+                    goto missingargs;
+                }
+                strarray_append(&args, c->arg1.s);
+            } while (ch == ' ');
+            CHECKNEWLINE(c, ch);
+
+            cmd_enable(c, c->tag.s, &args);
+            strarray_fini(&args);
         }
         else goto badcmd;
         break;
@@ -821,7 +862,7 @@ static mupdate_docmd_result_t docmd(struct conn *c)
             if (c->streaming) goto notwhenstreaming;
             if (!masterp) goto masteronly;
 
-            cmd_set(c, c->tag.s, c->arg1.s, c->arg2.s, NULL, SET_RESERVE);
+            cmd_set(c, c->tag.s, c->arg1.s, c->arg2.s, NULL, NULL, SET_RESERVE);
         }
         else goto badcmd;
         break;
@@ -847,7 +888,7 @@ static mupdate_docmd_result_t docmd(struct conn *c)
             }
 
             /* if we've already done COMPRESS fail */
-            if (c->compress_done) {
+            if (c->client_capa & CAPA_COMPRESS) {
                 prot_printf(c->pout,
                             "%s BAD Can't Starttls after Compress\r\n",
                             c->tag.s);
@@ -1037,12 +1078,13 @@ static void dobanner(struct conn *c)
     }
 
 #ifdef HAVE_ZLIB
-    if (!c->compress_done && !c->tls_comp) {
+    if (!(c->client_capa & CAPA_COMPRESS) && !c->tls_comp) {
         prot_printf(c->pout, "* COMPRESS \"DEFLATE\"\r\n");
     }
 #endif
 
     prot_printf(c->pout, "* PARTIAL-UPDATE\r\n");
+    prot_printf(c->pout, "* MAILBOX-EXTENDED\r\n");
 
     prot_printf(c->pout,
                 "* OK MUPDATE \"%s\" \"Cyrus IMAP\" \"%s\" \"%s\"\r\n",
@@ -1372,6 +1414,7 @@ static void database_log(const struct mbent *mb, struct txn **mytid)
     mbentry->name = xstrdupnull(mb->mailbox);
 
     mbentry->server = xstrdupnull(mb->location);
+    mbentry->jmapid = xstrdupnull(mb->jmapid);
 
     c = strchr(mbentry->server, '!');
     if (c) {
@@ -1453,10 +1496,12 @@ static struct mbent *database_lookup(const char *name, const mbentry_t *mbentry,
         out->mailbox = mpool_strdup(pool, name);
         out->location = mpool_strdup(pool, location);
         free(location);
+        if (mbentry->jmapid) out->jmapid = mpool_strdup(pool, mbentry->jmapid);
     }
     else {
         out->mailbox = xstrdup(name);
         out->location = location;
+        out->jmapid = xstrdupnull(mbentry->jmapid);
     }
 
     if (my_mbentry) mboxlist_entry_free(&my_mbentry);
@@ -1576,7 +1621,8 @@ static void log_update(const char *mailbox,
 
 static void cmd_set(struct conn *C,
              const char *tag, const char *mailbox,
-             const char *location, const char *acl, enum settype t)
+             const char *location, const char *acl,
+             struct dlist *extargs, enum settype t)
 {
     struct mbent *m;
     char *oldlocation = NULL;
@@ -1679,6 +1725,10 @@ static void cmd_set(struct conn *C,
 
             newm->t = t;
 
+            const char *jmapid = NULL;
+            dlist_getatom(extargs, "JMAPID", &jmapid);
+            newm->jmapid = xstrdupnull(jmapid);
+
             /* re-scope */
             m = newm;
         }
@@ -1748,12 +1798,16 @@ static void cmd_find(struct conn *C, const char *tag, const char *mailbox,
                 "%s MAILBOX "
                 "{" SIZE_T_FMT "+}\r\n%s "
                 "{" SIZE_T_FMT "+}\r\n%s "
-                "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                "{" SIZE_T_FMT "+}\r\n%s",
                 tag,
                 strlen(m->mailbox), m->mailbox,
                 strlen(m->location), m->location,
                 strlen(m->acl), m->acl
             );
+        if (m->jmapid && (C->client_capa & CAPA_MAILBOXEXT)) {
+            prot_printf(C->pout, " (JMAPID %s)", m->jmapid);
+        }
+        prot_puts(C->pout, "\r\n");
 
     } else if (m && m->t == SET_RESERVE) {
         prot_printf(C->pout,
@@ -1805,12 +1859,16 @@ static int sendupdate(const mbentry_t *mbentry, void *rock)
                         "%s MAILBOX "
                         "{" SIZE_T_FMT "+}\r\n%s "
                         "{" SIZE_T_FMT "+}\r\n%s "
-                        "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                        "{" SIZE_T_FMT "+}\r\n%s",
                         C->streaming,
                         strlen(m->mailbox), m->mailbox,
                         strlen(m->location), m->location,
                         strlen(m->acl), m->acl
                     );
+                if (m->jmapid && (C->client_capa & CAPA_MAILBOXEXT)) {
+                    prot_printf(C->pout, " (JMAPID %s)", m->jmapid);
+                }
+                prot_puts(C->pout, "\r\n");
 
                 break;
             case SET_RESERVE:
@@ -2003,7 +2061,7 @@ static void cmd_starttls(struct conn *C, const char *tag)
 #ifdef HAVE_ZLIB
 static void cmd_compress(struct conn *C, const char *tag, const char *alg)
 {
-    if (C->compress_done) {
+    if (C->client_capa & CAPA_COMPRESS) {
         prot_printf(C->pout,
                     "%s BAD DEFLATE active via COMPRESS\r\n", tag);
     }
@@ -2029,7 +2087,7 @@ static void cmd_compress(struct conn *C, const char *tag, const char *alg)
         prot_setcompress(C->pin);
         prot_setcompress(C->pout);
 
-        C->compress_done = 1;
+        C->client_capa |= CAPA_COMPRESS;
     }
 }
 #else
@@ -2041,6 +2099,34 @@ void cmd_compress(struct conn *C __attribute__((unused)),
           EX_SOFTWARE);
 }
 #endif /* HAVE_ZLIB */
+
+static void cmd_enable(struct conn *C, const char *tag, strarray_t *args)
+{
+    uint32_t new_capa = 0;
+    int i, n = strarray_size(args);
+
+    for (i = 0; i < n; i++) {
+        const char *arg = strarray_nth(args, i);
+
+        if (!strcasecmp(arg, "mailbox-extended"))
+            new_capa |= CAPA_MAILBOXEXT;
+    }
+
+    /* filter out already enabled extensions */
+    new_capa ^= C->client_capa;
+
+    if (new_capa) {
+        prot_printf(C->pout, "%s ENABLED", tag);
+        if (new_capa & CAPA_MAILBOXEXT)
+            prot_puts(C->pout, " MAILBOX-EXTENDED");
+        prot_puts(C->pout, "\r\n");
+    }
+
+    /* track the new capabilities */
+    C->client_capa |= new_capa;
+
+    prot_printf(C->pout, "%s OK \"done\"\r\n", tag);
+}
 
 static void shut_down(int code)
 {
@@ -2508,6 +2594,7 @@ void mupdate_unready(void)
 void free_mbent(struct mbent *p)
 {
     if (!p) return;
+    free(p->jmapid);
     free(p->location);
     free(p->mailbox);
     free(p);

--- a/imap/mupdate.h
+++ b/imap/mupdate.h
@@ -92,6 +92,7 @@ enum settype {
 struct mbent {
     char *mailbox;
     char *location;
+    char *jmapid;
     enum settype t;
     struct mbent *next; /* used for queue */
     char acl[1];


### PR DESCRIPTION
This extends the ACTIVATE command to accept " (JMAPID xxx)" as its last argument,
and extends the MAILBOX response to return " (JMAPID xxx)" as its last argument (iff the client has sent ENABLE MAILBOX-EXTENDED)

This also needs a changes file and some documentation once the guts are approved.