### PR TITLE
http_dav: don't hold the user lock if mailbox can't be opened

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -7290,7 +7290,8 @@ int meth_put(struct transaction_t *txn, void *params)
         syslog(LOG_ERR, "http_mailbox_open(%s) failed: %s",
                txn->req_tgt.mbentry->name, error_message(r));
         txn->error.desc = error_message(r);
-        return HTTP_SERVER_ERROR;
+        ret = HTTP_SERVER_ERROR;
+        goto done;
     }
 
     /* Open the DAV DB corresponding to the mailbox */


### PR DESCRIPTION
We hit this in production - mailbox renamed at exactly the wrong time, after the mboxlist entry was looked up but before trying to open the mailbox.