### PR TITLE
util.c: do not segv on null string

### DIFF
--- a/cunit/xsyslog_ev.testc
+++ b/cunit/xsyslog_ev.testc
@@ -270,6 +270,11 @@ static void test_lf_s(void)
     xsyslog_ev(LOG_ERR, "lf_s test", lf_s("first", "\\"));
     CU_ASSERT_SYSLOG(/*all*/0, 1);
 
+    // null
+    CU_SYSLOG_MATCH("event=\"lf_s test\" first=~null~");
+    xsyslog_ev(LOG_ERR, "lf_s test", lf_s("first", NULL));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
     // no quoting or escaping
     struct buf str = BUF_INITIALIZER;
     int iter;

--- a/lib/util.c
+++ b/lib/util.c
@@ -2257,6 +2257,11 @@ static char *_xsyslog_ev_escape(const char *val)
     size_t orig_len, escaped_len;
     const char *p;
 
+    if (val == NULL) {
+        buf_setcstr(&buf, "~null~");
+        return buf_release(&buf);
+    }
+
     buf_setcstr(&buf, val);
 
     escaped_len = orig_len = buf_len(&buf);


### PR DESCRIPTION
Before this commit:

    xsyslog_ev(...,
               LF_S("key", null_string));

would produce a segmentation violation.  This commit changes it to format the string as "~null~", mirroring our Perl implementation's "~missing~".  We can refine this later, but this is better than a segv.