### PR TITLE
jmap_mail_query.c: don't hardcode user prefix for shared addrbook

### DIFF
--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -148,8 +148,10 @@ static mbentry_t *_get_sharedaddressbook(const char *userid,
 
     strarray_t patterns = STRARRAY_INITIALIZER;
     struct buf pattern = BUF_INITIALIZER;
-    buf_setcstr(&pattern, "user");
-    buf_putc(&pattern, namespace->hier_sep);
+
+    assert(namespace->hier_sep && namespace->prefix[NAMESPACE_USER][0]);
+
+    buf_setcstr(&pattern, namespace->prefix[NAMESPACE_USER]);
     buf_putc(&pattern, '*');
     buf_putc(&pattern, namespace->hier_sep);
     buf_appendcstr(&pattern, config_getstring(IMAPOPT_ADDRESSBOOKPREFIX));


### PR DESCRIPTION
mailbox pattern.  Instead use prefix in the given namespace