### PR TITLE
JMAP: bump modseq when "updating" externally stored properties

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_extendedprops
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_extendedprops
@@ -1,0 +1,36 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_set_extendedprops
+{
+    my ($self) = @_;
+
+    my $jmap = $self->{jmap};
+
+    # Create calendar
+    my $res = $jmap->CallMethods([
+        ['Calendar/set', {
+            create => {
+                '1' => {
+                    name => 'A',
+                    color => 'blue',
+                }
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{created}{1});
+    my $id = $res->[0][1]{created}{"1"}{id};
+
+    # set externally-stored FM property
+    $res = $jmap->CallMethods([
+        ['Calendar/set',
+            { update => {
+                $id => {
+                    isEventsPublic => JSON::true,
+                }
+            }
+        }, "R1"],
+    ]);
+    $self->assert_null($res->[0][1]{updated}{$id});
+    $self->assert_str_not_equals($res->[0][1]{oldState}, $res->[0][1]{newState});
+}

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_set_extendedprops
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_set_extendedprops
@@ -81,4 +81,17 @@ sub test_mailbox_set_extendedprops
     $self->assert_equals(JSON::false, $res->[0][1]{list}[1]{isSeenShared});
     $self->assert_str_equals('#ABCDEF', $res->[0][1]{list}[1]{color});
     $self->assert_equals(JSON::false, $res->[0][1]{list}[1]{showAsLabel});
+
+    # set externally-stored FM property
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            update => {
+                $mboxIdA => {
+                    hidden => 0,
+                },
+            }
+        }, "R1"]
+    ]);
+    $self->assert_null($res->[0][1]{updated}{$mboxIdA});
+    $self->assert_str_not_equals($res->[0][1]{oldState}, $res->[0][1]{newState});
 }

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -353,7 +353,8 @@ enum {
     JMAP_PROP_SKIP_GET   = (1<<2), // skip in Foo/get if not requested by client
     JMAP_PROP_ALWAYS_GET = (1<<3), // always include in Foo/get
     JMAP_PROP_REJECT_GET = (1<<4), // reject as unknown in Foo/get
-    JMAP_PROP_REJECT_SET = (1<<5)  // reject as unknown in Foo/set
+    JMAP_PROP_REJECT_SET = (1<<5), // reject as unknown in Foo/set
+    JMAP_PROP_EXTERNAL   = (1<<6), // property is stored externally
 };
 
 extern const jmap_property_t *jmap_property_find(const char *name,


### PR DESCRIPTION
This will allow the server to signal to the client via /changes that it needs to sync the resource