### PR TITLE
Cass: Avoid DST bug in a calalarmd test by jumping ahead a few hours

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_calalarmd
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_calalarmd
@@ -11,6 +11,11 @@ sub test_calendarevent_defaultalerts_calalarmd
     my $now = DateTime->now();
     $now->set_time_zone('Australia/Sydney');
 
+    if ($now->hour >= 1 && $now->hour <= 4) {
+      # Get us away from DST cutover which breaks the test
+      $now->add(DateTime::Duration->new(hours => 4));
+    }
+
     xlog $self, "Create calendar without default alarms";
     my $res = $jmap->CallMethods([
         ['Calendar/set', {


### PR DESCRIPTION
This prevents the test failing around Oct 1st of every year around 12:00 PM US Eastern due to the test using Australia/Sydney and advancing the time into the window of Sydney's DST cutover which throws the error:

    Invalid local time for date in time zone: Australia/Sydney