### PR TITLE
Cyr 2196 abort if conversations open

### DIFF
--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -369,6 +369,11 @@ EXPORTED size_t conversations_estimate_emailcount(struct conversations_state *st
     return count;
 }
 
+EXPORTED int open_conversations_exist(void)
+{
+    return open_conversations ? 1 : 0;
+}
+
 EXPORTED int conversations_open_path_version(const char *fname,
                                              const char *userid, int shared,
                                              struct conversations_state **statep,

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -237,6 +237,8 @@ extern void conversations_set_suffix(const char *suff);
 extern char *conversations_getmboxpath(const char *mboxname);
 extern char *conversations_getuserpath(const char *username);
 
+extern int open_conversations_exist(void);
+
 #define conversations_open_path(p, u, sh, sp) \
     conversations_open_path_version(p, u, sh, sp, 0)
 extern int conversations_open_path_version(const char *path,

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -852,19 +852,19 @@ HIDDEN int jmap_api(struct transaction_t *txn,
         /* Call the message processor. */
         r = mp->proc(&req);
 
-        /* Finalize request context */
-        jmap_finireq(&req);
-
         if (r) {
             conversations_abort(&req.cstate);
             user_nslock_release(&user_nslock);
             txn->error.desc = error_message(r);
             ret = HTTP_SERVER_ERROR;
+            jmap_finireq(&req);
             json_decref(args);
             goto done;
         }
         conversations_commit(&req.cstate);
         user_nslock_release(&user_nslock);
+
+        jmap_finireq(&req);
 
         // run any notification updates after conversations are released
         dav_run_notifications();

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -56,6 +56,7 @@
 #include "msgrecord.h"
 #include "ptrarray.h"
 #include "strarray.h"
+#include <stdbool.h>
 
 #define JMAP_INT_MAX    9007199254740991LL  /*  2^53-1 */
 #define JMAP_INT_MIN    (-JMAP_INT_MAX)     /* -2^53+1 */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -246,7 +246,9 @@ EXPORTED void flags_to_str(const struct index_record *record, char *flagstr)
 
 EXPORTED int open_mailboxes_exist()
 {
-    return open_mailboxes ? 1 : 0;
+    if (open_mailboxes) return 1;
+    if (open_conversations_exist()) return 1;
+    return 0;
 }
 
 EXPORTED int open_mailboxes_namelocked(const char *userid)

--- a/imap/message.c
+++ b/imap/message.c
@@ -1226,7 +1226,7 @@ EXPORTED void message_parse_string(const char *hdr, char **hdrp)
     while ((he = strchr(he, '\n'))!=NULL) {
         if (he > *hdrp && he[-1] == '\r') {
             he--;
-            memmove(he, he+2, strlen(he+2)+1);
+            if (he) memmove(he, he+2, strlen(he+2)+1);
         }
         else {
             memmove(he, he+1, strlen(he+1)+1);


### PR DESCRIPTION
This ensures that we catch the "calalarmd holds conversations open" bug if it happens again!

I have slipstreamed in my two "make it compile on Ubuntu 24.04 on WSL" commits as well.