### PR TITLE
auditlog: add and use auditlog_message_touched()

### DIFF
--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -254,6 +254,7 @@ EXPORTED void auditlog_mboxname(const char *action,
 
 EXPORTED void auditlog_message(const char *action,
                                struct mailbox *mailbox,
+                               const struct index_record *oldrecord,
                                const struct index_record *record,
                                const char *message_id)
 {
@@ -278,6 +279,12 @@ EXPORTED void auditlog_message(const char *action,
     buf_printf(&buf, " uid=<%u> modseq=<" MODSEQ_FMT ">",
                      record->uid, record->modseq);
     auditlog_push(&buf, "sysflags", flagstr);
+
+    if (oldrecord) {
+        flags_to_str(oldrecord, flagstr);
+        auditlog_push(&buf, "oldflags", flagstr);
+    }
+
     auditlog_push(&buf, "guid", message_guid_encode(&record->guid));
     auditlog_push(&buf, "emailid", emailid);
     auditlog_push(&buf, "cid", threadid);

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -71,6 +71,7 @@ extern void auditlog_mboxname(const char *action,
                               const char *mboxname);
 extern void auditlog_message(const char *action,
                              struct mailbox *mailbox,
+                             const struct index_record *oldrecord,
                              const struct index_record *record,
                              const char *message_id);
 extern void auditlog_message_uid(const char *action,

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2348,18 +2348,18 @@ static int _commit_one(struct mailbox *mailbox, struct index_change *change)
     }
 
     if (change->flags & CHANGE_ISAPPEND)
-        auditlog_message("append", mailbox, record, change->msgid);
+        auditlog_message("append", mailbox, NULL, record, change->msgid);
 
     if ((record->internal_flags & FLAG_INTERNAL_EXPUNGED)
         && !(change->flags & CHANGE_WASEXPUNGED))
     {
-        auditlog_message("expunge", mailbox, record, NULL);
+        auditlog_message("expunge", mailbox, NULL, record, NULL);
     }
 
     if ((record->internal_flags & FLAG_INTERNAL_UNLINKED)
         && !(change->flags & CHANGE_WASUNLINKED))
     {
-        auditlog_message("unlink", mailbox, record, NULL);
+        auditlog_message("unlink", mailbox, NULL, record, NULL);
     }
 
     return 0;
@@ -4892,7 +4892,7 @@ EXPORTED int mailbox_rewrite_index_record(struct mailbox *mailbox,
     r = _store_change(mailbox, record, changeflags);
     if (r) return r;
 
-    auditlog_message("touched", mailbox, record, NULL);
+    auditlog_message("touched", mailbox, &oldrecord, record, NULL);
 
     /* expunged tracking */
     if (record->internal_flags & FLAG_INTERNAL_EXPUNGED &&
@@ -5958,7 +5958,7 @@ EXPORTED void mailbox_archive(struct mailbox *mailbox,
             continue;
         mailbox->i.options |= OPT_MAILBOX_NEEDS_UNLINK;
 
-        auditlog_message(action, mailbox, &copyrecord, NULL);
+        auditlog_message(action, mailbox, NULL, &copyrecord, NULL);
     }
 
     if (myiter) mailbox_iter_done(&myiter);


### PR DESCRIPTION
This reintroduces "oldflags" in the "touched" log message, which was lost with auditlog_message()