### PR TITLE
Add custom includeCADs argument to Email/changes

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_changes_cads
+++ b/cassandane/tiny-tests/JMAPEmail/email_changes_cads
@@ -1,0 +1,49 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_changes_cads
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    xlog $self, "get email state";
+    my $res = $jmap->CallMethods([['Email/get', { ids => []}, "R1"]]);
+    my $state = $res->[0][1]->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Generate an email in INBOX via IMAP";
+    $self->make_message("Email A") || die;
+
+    xlog $self, "Get email id";
+    $res = $jmap->CallMethods([['Email/query', {}, "R1"]]);
+    my $ida = $res->[0][1]->{ids}[0];
+    $self->assert_not_null($ida);
+
+    xlog $self, "delete email $ida";
+    $res = $jmap->CallMethods([['Email/set', {destroy => [ $ida ] }, "R1"]]);
+    $self->assert_str_equals($ida, $res->[0][1]->{destroyed}[0]);
+
+    xlog $self, "get email updates";
+    $res = $jmap->CallMethods([['Email/changes', {
+        sinceState => $state
+    }, "R1"]]);
+    $self->assert_str_equals($state, $res->[0][1]->{oldState});
+    $self->assert_str_not_equals($state, $res->[0][1]->{newState});
+    $self->assert_equals(JSON::false, $res->[0][1]->{hasMoreChanges});
+    $self->assert_deep_equals([], $res->[0][1]{created});
+    $self->assert_deep_equals([], $res->[0][1]{updated});
+    $self->assert_deep_equals([], $res->[0][1]{destroyed});
+
+    xlog $self, "get email updates";
+    $res = $jmap->CallMethods([['Email/changes', {
+        includeCADs => JSON::true,
+        sinceState => $state
+    }, "R1"]]);
+    $self->assert_str_equals($state, $res->[0][1]->{oldState});
+    $self->assert_str_not_equals($state, $res->[0][1]->{newState});
+    $self->assert_equals(JSON::false, $res->[0][1]->{hasMoreChanges});
+    $self->assert_deep_equals([], $res->[0][1]{created});
+    $self->assert_deep_equals([], $res->[0][1]{updated});
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{destroyed}});
+    $self->assert_str_equals($ida, $res->[0][1]{destroyed}[0]);
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5614,7 +5614,8 @@ done:
     return 0;
 }
 
-static void _email_changes(jmap_req_t *req, struct jmap_changes *changes, json_t **err)
+static void _email_changes(jmap_req_t *req, struct jmap_changes *changes,
+                           bool include_cads, json_t **err)
 {
     int r = 0;
 
@@ -5686,7 +5687,11 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes, json_t
          */
         switch (rock.status) {
         default:
-            break; /* all messages were created AND deleted since previous state! */
+            /* all messages were created AND deleted since previous state! */
+            if (!include_cads) break;
+
+            GCC_FALLTHROUGH
+
         case 1:
             /* only expunged messages exist */
             json_array_append_new(changes->destroyed, json_string(email_id));
@@ -5720,23 +5725,41 @@ done:
     emailsearch_fini(&search);
 }
 
+static int _changes_args_parse(jmap_req_t *req __attribute__((unused)),
+                               struct jmap_parser *parser __attribute__((unused)),
+                               const char *key,
+                               json_t *arg,
+                               void *rock)
+{
+    bool *include_cads = rock;
+    int r = 0;
+
+    if (!strcmp(key, "includeCADs") && json_is_boolean(arg)) {
+        *include_cads = !!json_boolean_value(arg);
+        r = 1;
+    }
+
+    return r;
+}
+
 static int jmap_email_changes(jmap_req_t *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
     struct jmap_changes changes =
         { .prefixed_state = USER_COMPACT_EMAILIDS(req->cstate) };
+    bool include_cads = 0;
 
     /* Parse request */
     json_t *err = NULL;
     jmap_changes_parse(req, &parser, req->counters.maildeletedmodseq,
-                       NULL, NULL, &changes, &err);
+                       &_changes_args_parse, &include_cads, &changes, &err);
     if (err) {
         jmap_error(req, err);
         goto done;
     }
 
     /* Search for updates */
-    _email_changes(req, &changes, &err);
+    _email_changes(req, &changes, include_cads, &err);
     if (err) {
         jmap_error(req, err);
         goto done;


### PR DESCRIPTION
Normally, if a record has been both created AND destroyed since the oldState of the client it is omitted entirely from the /changes results.

Extra argument to Email/changes — includeCADs: Boolean (default: false).

If true, then any Email that was both created AND destroyed since oldState is included in the destroyed array.