### PR TITLE
cunit/vg.supp: update for new shape of backend.testc sasl leak

### DIFF
--- a/cunit/vg.supp
+++ b/cunit/vg.supp
@@ -61,3 +61,20 @@
    fun:dlopen_implementation
    ...
 }
+{
+   # probably a duplicate of backend_child_process_sasl_state,
+   # but the shape changed
+   backend_sasl_client_init
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:xmalloc
+   obj:*
+   obj:*
+   fun:sasl_client_add_plugin
+   obj:/usr/lib/x86_64-linux-gnu/libsasl2.so.*
+   fun:sasl_client_init
+   fun:init_sasl
+   fun:set_up
+   ...
+}


### PR DESCRIPTION
The old suppression stopped working for me, I guess Ubuntu build of cyrus-sasl isn't using dlopen anymore.  I've added a new suppression that works for me, but left the existing one there because Debian/CI probably still needs it.