### PR TITLE
GitHub Actions: run a simple build-and-cass run on trixie

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,3 +125,48 @@ jobs:
         echo "debian" $(cat /etc/debian_version)
         /usr/cyrus/libexec/master -V
         /usr/cyrus/sbin/cyr_buildinfo
+
+  build-trixie:
+    name: "Build on trixie"
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+        image: ghcr.io/cyrusimap/cyrus-docker:trixie
+        options: --init
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: setup git safe directory
+      shell: bash
+      run: git config --global --add safe.directory /__w/cyrus-imapd/cyrus-imapd
+    - name: fetch upstream release tags
+      if: ${{ github.repository != 'cyrusimap/cyrus-imapd' }}
+      shell: bash
+      run: |
+        git remote add upstream https://github.com/cyrusimap/cyrus-imapd.git
+        # n.b. --no-tags does not mean "no tags", it means "no automatic tag
+        # following".  we're explicitly fetching the tags we want, we do not
+        # need every other tag that's reachable from them
+        git fetch --no-tags upstream 'refs/tags/cyrus-imapd-*:refs/tags/cyrus-imapd-*'
+    - name: configure and build
+      shell: bash
+      run: cyd build
+    - name: report version information
+      shell: bash
+      run: |
+        echo "debian" $(cat /etc/debian_version)
+        echo "Mail::IMAPTalk" $(cpanm --info Mail::IMAPTalk)
+        /usr/cyrus/libexec/master -V
+        /usr/cyrus/sbin/cyr_buildinfo
+    - name: run cassandane quietly
+      id: cass1
+      continue-on-error: true
+      # We haven't figured out how to make Test::Core work in actions yet.
+      run: cyd test --no-ok --slow "!Test::Core" --format prettier
+    - name: rerun cassandane failures noisily
+      if: ${{ steps.cass1.outcome == 'failure' }}
+      run: cyd test --no-slow --format pretty --rerun
+    - name: collect logs
+      run: cat /tmp/cass/*/conf/log/syslog


### PR DESCRIPTION
It just turns on basic testing of trixie.  Later, I imagine we'll swap the roles of trixie and bookworm.