### PR TITLE
master-event.testc: Fix -Wclobbered bug with -Og or higher enabled

### DIFF
--- a/cunit/master-event.testc
+++ b/cunit/master-event.testc
@@ -275,7 +275,7 @@ static void test_reschedule_event_bad(void)
     volatile unsigned i;
 
     for (i = 0; i < n_tests; i++) {
-        struct timeval now = TV_INIT(time(NULL), 0);
+        volatile struct timeval now = TV_INIT(time(NULL), 0);
         struct timeval mark = TV_INIT(tests[i].mark, 0);
         struct event *event;
 


### PR DESCRIPTION
With optimisations enabled, gcc 14.2.0 with `make check` complains:

    In file included from cunit/master-event.c:2:
    ./cunit/master-event.testc: In function 'test_reschedule_event_bad':
    ./cunit/master-event.testc:278:24: error: variable 'now' might be clobbered by 'longjmp' or 'vfork' [-Werror=clobbered]
      278 |         struct timeval now = TV_INIT(time(NULL), 0);
          |                        ^~~
      CC       cunit/meta-timeofday.o
      CC       cunit/parseaddr.o

The setjmp man page says:

    The compiler may optimize variables into registers, and  longjmp()  may
    restore  the values of other registers in addition to the stack pointer
    and program counter.  Consequently, the values of  automatic  variables
    are  unspecified after a call to longjmp() if they meet all the follow‐
    ing criteria:

    •  they are local to the function that made the corresponding  setjmp()
       call;

    •  their   values  are  changed  between  the  calls  to  setjmp()  and
       longjmp(); and

    •  they are not declared as volatile.

So we must mark `now` volatile so the setjmp/longjmp play nicely with it.