### PR TITLE
jmap_contact.c: handle VALUE=X for media properties

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_get_v3
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_v3
@@ -32,6 +32,8 @@ FN:Forrest Gump
 ORG;PROP-ID=O1:Bubba Gump Shrimp Co.;foo
 TITLE;PROP-ID=T1:Shrimp Man
 PHOTO;PROP-ID=P1;ENCODING=b;TYPE=JPEG:c29tZSBwaG90bw==
+PHOTO;PROP-ID=P2;VALUE=X:
+ https://example.com/contacts/foo/bar
 foo.ADR;PROP-ID=A1;JSCOMPS="s, ;2;3;4;5;6":;;1501 Broadway;New York;NY;10036;USA
 foo.GEO:40.7571383482188;-73.98695548990568
 foo.TZ:-05:00
@@ -121,6 +123,10 @@ EOF
             P1 => {
                 kind => 'photo',
                 mediaType => 'image/jpeg'
+            },
+            P2 => {
+                kind => 'photo',
+                uri => 'https://example.com/contacts/foo/bar'
             }
         }
     };

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -6117,9 +6117,12 @@ static char *_value_to_uri_blobid(vcardproperty *prop,
                                   vcardproperty_version version,
                                   char **type, char **blobid)
 {
+    const char *val;
+
+    val = vcardvalue_as_vcard_string(vcardproperty_get_value(prop));
+
     if (!blobid && version == VCARD_VERSION_40) {
-        const char *uri = vcardvalue_get_uri(vcardproperty_get_value(prop));
-        if (uri) return xstrdup(uri);
+        return xstrdup(val);
     }
 
     struct message_guid guid;
@@ -6154,7 +6157,7 @@ static char *_value_to_uri_blobid(vcardproperty *prop,
         }
     }
 
-    return xstrdup(vcardvalue_get_uri(vcardproperty_get_value(prop)));
+    return xstrdup(val);
 }
 
 static json_t *vcardtime_to_jmap_utcdate(vcardtimetype t)


### PR DESCRIPTION
This fixes a crasher where it was assumed that the value would be a URI and we would fetch the data from the wrong field in the vcardvalue, resulting in strdup()'ing a NULL string