### PR TITLE
Cassandane: Add test showing NOT:body with findMatchingParts fails

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_not_body_find_matching_parts
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_not_body_find_matching_parts
@@ -1,0 +1,43 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_not_body_find_matching_parts
+    :min_version_3_1 :needs_component_sieve
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+    my $inboxid = $self->getinbox()->{id};
+
+    $self->make_message('uid1', body => "Come to New York we have bagels");
+
+    # findMatchingParts
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+
+    xlog $self, "run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $res = $jmap->CallMethods([[
+        "Email/query" => {
+            "filter" => {
+                "operator" => "AND",
+                "conditions" => [
+                    { "inMailbox" => $inboxid },
+                    { "text" => "\"New York\"" },
+                    {
+                        "operator" => "NOT",
+                        "conditions" => [
+                            { "body" => "bagels" },
+                        ],
+                    },
+                ],
+            },
+            "findMatchingParts" => JSON::true,
+        }, 'a'
+    ]]);
+
+    # Not an error from an invalid query or other...
+    $self->assert_str_equals($res->[0][0], "Email/query");
+
+    # Nothing should match!
+    $self->assert_num_equals(0, scalar @{$res->[0][1]->{ids}});
+}


### PR DESCRIPTION
With an email body containing "Foo Bar Baz" and an Email/query like:

    "filter": {
        "operator": "AND",
        "conditions": [
            { "inMailbox": "<inbox id>" },
            { "text": "\"Foo Bar\"" },
            {
                "operator": "NOT",
                "conditions": [
                    { "body": "Baz" }
                ]
            }
        ]
    }

We find 0 messages as expected.

However, if we use 'https://cyrusimap.org/ns/jmap/mail' and add in:

    "findMatchingParts": true

we incorrectly find a message!