### PR TITLE
logfmt.testc: note NULL vs "~null~" ambiguity

### DIFF
--- a/cunit/logfmt.testc
+++ b/cunit/logfmt.testc
@@ -31,6 +31,7 @@ static void test_logfmt_escape_bytestring1(void)
         const char *expect;
     } tests[] = {
         { NULL,                 "~null~" },
+        { "~null~",             "~null~" }, /* n.b. ambiguity! */
         { "",                   "\"\"" }, /* empty string is quoted */
         { "basic",              "basic" }, /* basic string isn't quoted */
         { "equals=equals",      "\"equals=equals\"" },
@@ -176,6 +177,7 @@ static void test_logfmt_escape_utf8(void)
         const char *expect;
     } tests[] = {
         { NULL,                 "~null~" },
+        { "~null~",             "~null~" }, /* n.b. ambiguity! */
         { "",                   "\"\"" }, /* empty string is quoted */
         { "basic",              "basic" }, /* basic string isn't quoted */
         { "equals=equals",      "\"equals=equals\"" },


### PR DESCRIPTION
Our logfmt convention is that we use the sentinel value `~null~` when logging undefined values, like `foo=~null~`, but this means you can't tell from the logs whether the value being logged was `NULL` or the string `"~null~"`.  We don't use the string `"~null~"` anywhere else, so this doesn't seem like it will be a problem in practice.

This PR just adds a couple of test cases that demonstrate the ambiguity, to document that we're aware of it and not doing anything about it.