### PR TITLE
imapd.c: can't keep conv.db open across commands for NOTIFY SELECTED

### DIFF
--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -142,7 +142,7 @@ sub test_bad
 }
 
 sub test_message
-    :needs_component_idled :min_version_3_9
+    :needs_component_idled :Conversations
 {
     my ($self) = @_;
 
@@ -178,7 +178,7 @@ sub test_message
     xlog $self, "Enable Notify";
     my $res = $talk->_imap_cmd('NOTIFY', 0, 'STATUS', 'SET', 'STATUS',
                                "(SELECTED (MessageNew" .
-                               " (UID BODY.PEEK[HEADER.FIELDS (From Subject)])" .
+                               " (UID EMAILID MAILBOXIDS BODY.PEEK[HEADER.FIELDS (From Subject)])" .
                                " MessageExpunge FlagChange))",
                                "(PERSONAL (MessageNew MessageExpunge))");
 
@@ -242,6 +242,8 @@ sub test_message
     $self->assert_num_equals(3, $fetch->{2}{uid});
     $self->assert_str_equals('Message 3', $fetch->{2}{headers}{subject}[0]);
     $self->assert_not_null($fetch->{2}{headers}{from});
+    $self->assert_not_null($fetch->{2}{emailid}[0]);
+    $self->assert_not_null($fetch->{2}{mailboxids}[0]);
 
     xlog $self, "DELETE message from INBOX in other session";
     $res = $othertalk->store('1', '+flags', '(\\Deleted)');

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -106,7 +106,6 @@ struct fetchargs {
     strarray_t attribs;
     int isadmin;
     struct auth_state *authstate;
-    struct conversations_state *convstate; /* for FETCH_*IDS */
 
     range_t partial;              /* For PARTIAL */
 };

--- a/imap/index.h
+++ b/imap/index.h
@@ -259,11 +259,13 @@ struct progress_rock {
 int index_fetchresponses(struct index_state *state,
                          seqset_t *seq,
                          int usinguid,
+                         struct conversations_state *convstate,
                          const struct fetchargs *fetchargs,
                          int *fetchedsomething);
 extern int index_fetch(struct index_state *state,
                        const char* sequence,
-                       int usinguid,
+                       int usinguid, int readonly,
+                       struct conversations_state *convstate,
                        const struct fetchargs* fetchargs,
                        int* fetchedsomething);
 extern int index_store(struct index_state *state,


### PR DESCRIPTION
so open and close it as needed when pushing FETCH responses.

As a side effect, this commit moves convstate out of fetchargs