### PR TITLE
tls.c: support TLS ALPN unconditionally

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1289,11 +1289,6 @@ dnl call AC_SUBST macro to support pkg-config version older than 0.24
 AC_SUBST([SSL_LIBS])
 AC_SUBST([SSL_CFLAGS])
 
-dnl Check whether OpenSSL supports TLS ALPN extension
-AC_CHECK_LIB(ssl, SSL_CTX_set_alpn_select_cb,
-             [ AC_DEFINE(HAVE_TLS_ALPN, [],
-                         [Do we have support for TLS ALPN extension?])])
-
 dnl
 dnl Allow for setting EGD socket file on systems without /dev/*random.
 dnl

--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -815,7 +815,6 @@ static void alpn_common(const struct tls_alpn_t *client_alpn_map,
 
 static void test_alpn_match_single(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "foo", NULL, NULL },
         { "",    NULL, NULL },
@@ -831,12 +830,10 @@ static void test_alpn_match_single(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_SUCCESS,
                 "foo");
-#endif
 }
 
 static void test_alpn_match_client_only(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "foo", NULL, NULL },
         { "",    NULL, NULL },
@@ -848,12 +845,10 @@ static void test_alpn_match_client_only(void)
                 0,
                 ALPN_COMMON_EXPECT_SUCCESS,
                 NULL);
-#endif
 }
 
 static void test_alpn_match_server_only(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t server_map[] = {
         { "foo", NULL, NULL },
         { "",    NULL, NULL },
@@ -865,12 +860,10 @@ static void test_alpn_match_server_only(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_SUCCESS,
                 NULL);
-#endif
 }
 
 static void test_alpn_match_client_multi(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "foo", NULL, NULL },
         { "bar", NULL, NULL },
@@ -887,12 +880,10 @@ static void test_alpn_match_client_multi(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_SUCCESS,
                 "foo");
-#endif
 }
 
 static void test_alpn_match_server_multi(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "foo", NULL, NULL },
         { "",    NULL, NULL },
@@ -909,12 +900,10 @@ static void test_alpn_match_server_multi(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_SUCCESS,
                 "foo");
-#endif
 }
 
 static void test_alpn_match_multi(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "foo", NULL, NULL },
         { "bar", NULL, NULL },
@@ -932,12 +921,10 @@ static void test_alpn_match_multi(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_SUCCESS,
                 "bar");
-#endif
 }
 
 static void test_alpn_nomatch_single(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "foo", NULL, NULL },
         { "",    NULL, NULL },
@@ -953,12 +940,10 @@ static void test_alpn_nomatch_single(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_FAIL,
                 NULL);
-#endif
 }
 
 static void test_alpn_nomatch_client_multi(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "foo", NULL, NULL },
         { "bar", NULL, NULL },
@@ -975,12 +960,10 @@ static void test_alpn_nomatch_client_multi(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_FAIL,
                 NULL);
-#endif
 }
 
 static void test_alpn_nomatch_server_multi(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "qux", NULL, NULL },
         { "",    NULL, NULL },
@@ -997,12 +980,10 @@ static void test_alpn_nomatch_server_multi(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_FAIL,
                 NULL);
-#endif
 }
 
 static void test_alpn_nomatch_multi(void)
 {
-#if defined(HAVE_TLS_ALPN)
     struct tls_alpn_t client_map[] = {
         { "baz", NULL, NULL },
         { "qux", NULL, NULL },
@@ -1020,7 +1001,6 @@ static void test_alpn_nomatch_multi(void)
                 sizeof(server_map) / sizeof(server_map[0]),
                 ALPN_COMMON_EXPECT_FAIL,
                 NULL);
-#endif
 }
 
 /* TODO: test UNIX socket comms too */

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -173,15 +173,11 @@ static json_t *buildinfo()
 
     /* Build dependencies */
     json_object_set_new(dependency, "openssl", json_true());
+    json_object_set_new(dependency, "openssl_alpn", json_true());
 #ifdef HAVE_LDAP
     json_object_set_new(dependency, "ldap", json_true());
 #else
     json_object_set_new(dependency, "ldap", json_false());
-#endif
-#ifdef HAVE_TLS_ALPN
-    json_object_set_new(dependency, "openssl_alpn", json_true());
-#else
-    json_object_set_new(dependency, "openssl_alpn", json_false());
 #endif
 #ifdef HAVE_ZLIB
     json_object_set_new(dependency, "zlib", json_true());

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -1092,12 +1092,10 @@ EXPORTED int tls_start_servertls(int readfd, int writefd, int timeout,
 
     saslprops_reset(saslprops);
 
-#ifdef HAVE_TLS_ALPN
     if (alpn_map && alpn_map->id[0])
         SSL_CTX_set_alpn_select_cb(s_ctx, alpn_select_cb, (void *) alpn_map);
     else
         SSL_CTX_set_alpn_select_cb(s_ctx, NULL, NULL);
-#endif
 
     tls_conn = (SSL *) SSL_new(s_ctx);
     if (tls_conn == NULL) {
@@ -1318,14 +1316,12 @@ EXPORTED char *tls_get_alpn_protocol(const SSL *conn)
 {
     char *proto = NULL;
 
-#ifdef HAVE_TLS_ALPN
     const unsigned char *data = NULL;
     unsigned int len = 0;
 
     SSL_get0_alpn_selected(conn, &data, &len);
     if (data && len)
         proto = xstrndup((const char *) data, len);
-#endif
 
     return proto;
 }
@@ -1614,7 +1610,6 @@ HIDDEN int tls_start_clienttls(int readfd, int writefd,
 
     if (authid) *authid = NULL;
 
-#ifdef HAVE_TLS_ALPN
     if (alpn_map && alpn_map->id[0]) {
         unsigned char *protos = NULL;
         unsigned int protos_len;
@@ -1630,7 +1625,6 @@ HIDDEN int tls_start_clienttls(int readfd, int writefd,
     else {
         SSL_CTX_set_alpn_protos(c_ctx, NULL, 0);
     }
-#endif
 
     tls_conn = (SSL *) SSL_new(c_ctx);
     if (tls_conn == NULL) {


### PR DESCRIPTION
OpenSSL 3.0+ includes support for ALPN
and we no longer support anything earlier than 3.0