### PR TITLE
prot_printf - don't malloc memory

### DIFF
--- a/lib/prot.c
+++ b/lib/prot.c
@@ -195,6 +195,8 @@ EXPORTED int prot_free(struct protstream *s)
     if (s->zbuf) free(s->zbuf);
 #endif
 
+    buf_free(&s->vbuf);
+
     free(s);
 
     return 0;
@@ -1281,13 +1283,11 @@ EXPORTED int prot_printf(struct protstream *s, const char *fmt, ...)
 
 EXPORTED int prot_vprintf(struct protstream *s, const char *fmt, va_list pvar)
 {
-    struct buf buf = BUF_INITIALIZER;
-
     assert(s->write);
 
-    buf_vprintf(&buf, fmt, pvar);
-    prot_puts(s, buf_cstring(&buf));
-    buf_free(&buf);
+    buf_vprintf(&s->vbuf, fmt, pvar);
+    prot_write(s, buf_base(&s->vbuf), buf_len(&s->vbuf));
+    buf_reset(&s->vbuf);
 
     if (s->error || s->eof) return EOF;
     return 0;

--- a/lib/prot.h
+++ b/lib/prot.h
@@ -124,6 +124,8 @@ struct protstream {
     struct protstream *flushonread;
     /* hack to write to an in-memory-string */
     struct buf *writetobuf;
+    /* for printf */
+    struct buf vbuf;
 
     int can_unget;
     uint64_t bytes_in;


### PR DESCRIPTION
We were mallocing on EVERY prot_printf, which is bogus.  Just keep a printf buffer in each protstream.

(a basic FETCH 1:* FLAGS on a 20k message mailbox led to 100k mallocs.  This will remove most of them!)