### PR TITLE
Fix testuser

### DIFF
--- a/cassandane/Cassandane/TestUser.pm
+++ b/cassandane/Cassandane/TestUser.pm
@@ -21,7 +21,7 @@ has _common_http_service_args => (
         my $ca_file = Cwd::abs_path("data/certs/cacert.pem");
 
         my %common_args = (
-            user => 'cassandane',
+            user => $self->username,
             password => 'pass',
             host => $service->host(),
             port => $service->port(),


### PR DESCRIPTION
Cassandane test users need the right username for their imap/jmap/etc objects