### PR TITLE
jmap_contact.c: always strip urn:uuid: from X-FM-OTHERACCOUNT-MEMBER

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/cardgroup_get_v3
+++ b/cassandane/tiny-tests/JMAPContacts/cardgroup_get_v3
@@ -26,7 +26,7 @@ sub test_cardgroup_get_v3
     my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
     my $member1 = 'urn:uuid:03a0e51f-d1aa-4385-8a53-e29025acd8af';
     my $member2 = 'b8767877-b4a1-4c70-9acc-505d3819e519';
-    my $member3 = 'urn:uuid:26b4eb84-cc7a-4ede-9802-558bb84dcb8f';
+    my $member3 = '26b4eb84-cc7a-4ede-9802-558bb84dcb8f';
     my $href = "Default/$uid.vcf";
     my $card = <<EOF;
 BEGIN:VCARD
@@ -37,7 +37,7 @@ FN:The Doe Family
 N:;;;;
 X-ADDRESSBOOKSERVER-MEMBER:urn:uuid:"$member1"
 X-ADDRESSBOOKSERVER-MEMBER:urn:uuid:$member2
-X-FM-OTHERACCOUNT-MEMBER;USERID=account1:$member3
+X-FM-OTHERACCOUNT-MEMBER;USERID=account1:urn:uuid:$member3
 END:VCARD
 EOF
 

--- a/cassandane/tiny-tests/JMAPContacts/contactgroup_set_cardgroup_get
+++ b/cassandane/tiny-tests/JMAPContacts/contactgroup_set_cardgroup_get
@@ -21,7 +21,11 @@ sub test_contactgroup_set_cardgroup_get
         create => {
             "1" => {
                 name => "group1",
-                contactIds => [$contact1, $contact2]
+                contactIds => [$contact1, $contact2],
+                otherAccountContactIds => {
+                    other1 => ['contact3'],
+                    other2 => ['contact4']
+                }
             }
         }
     }, "R2"]]);
@@ -30,6 +34,10 @@ sub test_contactgroup_set_cardgroup_get
     $res = $jmap->CallMethods([['ContactCard/get', { }, "R3"]]);
     $self->assert_str_equals('group', $res->[0][1]{list}[2]{kind});
     $self->assert_str_equals('group1', $res->[0][1]{list}[2]{name}{full});
-    $self->assert(exists $res->[0][1]{list}[2]{members}{$contact1});
-    $self->assert(exists $res->[0][1]{list}[2]{members}{$contact2});
+    $self->assert_deep_equals({
+        $contact1 => JSON::true,
+        $contact2 => JSON::true,
+        contact3 => JSON::true,
+        contact4 => JSON::true
+    }, $res->[0][1]{list}[2]{members});
 }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -7113,6 +7113,8 @@ static void jsprop_from_vcard(vcardproperty *prop, json_t *obj,
             goto member;
         }
         else if (!strcmp(prop_name, "X-FM-OTHERACCOUNT-MEMBER")) {
+            if (!strncmp(prop_value, "urn:uuid:", 9))
+                prop_value += 9;
             goto member;
         }
         else if (!strcasecmp(prop_name, "X-SOCIALPROFILE") ||


### PR DESCRIPTION
since Cyrus always prepends it on creation