### PR TITLE
Cassandane: abstract some duplicated code, eliminate much "use lib"

### DIFF
--- a/cassandane/Cassandane/BuildInfo.pm
+++ b/cassandane/Cassandane/BuildInfo.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use JSON;
 
-use lib '.';
 use Cassandane::Cassini;
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cassini.pm
+++ b/cassandane/Cassandane/Cassini.pm
@@ -45,7 +45,6 @@ use warnings;
 use Cwd qw(abs_path);
 use Config::IniFiles;
 
-use lib '.';
 use Cassandane::Util::Log;
 
 my $instance;

--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -41,7 +41,6 @@ package Cassandane::Config;
 use strict;
 use warnings;
 
-use lib '.';
 use Cassandane::Cassini;
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/ACL.pm
+++ b/cassandane/Cassandane/Cyrus/ACL.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Generator;

--- a/cassandane/Cassandane/Cyrus/ALPN.pm
+++ b/cassandane/Cassandane/Cyrus/ALPN.pm
@@ -46,7 +46,6 @@ use HTTP::Tiny;
 use IO::Socket::SSL;
 use XML::Spice;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Admin.pm
+++ b/cassandane/Cassandane/Cyrus/Admin.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/Alpaca.pm
+++ b/cassandane/Cassandane/Cyrus/Alpaca.pm
@@ -43,7 +43,6 @@ use warnings;
 use Cwd qw(abs_path);
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Socket;

--- a/cassandane/Cassandane/Cyrus/Annotator.pm
+++ b/cassandane/Cassandane/Cyrus/Annotator.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Cwd qw(abs_path);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Append.pm
+++ b/cassandane/Cassandane/Cyrus/Append.pm
@@ -49,7 +49,6 @@ use Storable 'dclone';
 use File::Basename;
 use IO::File;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Archive.pm
+++ b/cassandane/Cassandane/Cyrus/Archive.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Words;

--- a/cassandane/Cassandane/Cyrus/Autocreate.pm
+++ b/cassandane/Cassandane/Cyrus/Autocreate.pm
@@ -44,7 +44,6 @@ use Cwd qw(getcwd);
 use Data::Dumper;
 use File::Temp qw(tempdir);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Bug3072.pm
+++ b/cassandane/Cassandane/Cyrus/Bug3072.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use DateTime;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Bug3470.pm
+++ b/cassandane/Cassandane/Cyrus/Bug3470.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 
 sub new

--- a/cassandane/Cassandane/Cyrus/Bug3649.pm
+++ b/cassandane/Cassandane/Cyrus/Bug3649.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::Bug3649;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/Bug3903.pm
+++ b/cassandane/Cassandane/Cyrus/Bug3903.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::Bug3903;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -49,7 +49,6 @@ use Data::Dumper;
 use Text::VCardFast;
 use Cwd qw(abs_path);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
@@ -49,7 +49,6 @@ use Data::Dumper;
 use POSIX;
 use Carp;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Carddav.pm
+++ b/cassandane/Cassandane/Cyrus/Carddav.pm
@@ -49,7 +49,6 @@ use Data::Dumper;
 use XML::Spice;
 use XML::Simple;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/ClamAV.pm
+++ b/cassandane/Cassandane/Cyrus/ClamAV.pm
@@ -43,7 +43,6 @@ use warnings;
 use Cwd qw(abs_path);
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use URI::Escape;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::ThreadedGenerator;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Cyrus/Create.pm
+++ b/cassandane/Cassandane/Cyrus/Create.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/CtlMboxlist.pm
+++ b/cassandane/Cassandane/Cyrus/CtlMboxlist.pm
@@ -43,7 +43,6 @@ use warnings;
 
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/CyrusDB.pm
+++ b/cassandane/Cassandane/Cyrus/CyrusDB.pm
@@ -44,7 +44,6 @@ use Data::Dumper;
 use File::Copy;
 use IO::File;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/DBLookup.pm
+++ b/cassandane/Cassandane/Cyrus/DBLookup.pm
@@ -48,7 +48,6 @@ use Net::CardDAVTalk::VCard;
 use Data::Dumper;
 use XML::Spice;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Delete.pm
+++ b/cassandane/Cassandane/Cyrus/Delete.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::Delete;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use File::Basename;

--- a/cassandane/Cassandane/Cyrus/Delivery.pm
+++ b/cassandane/Cassandane/Cyrus/Delivery.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use IO::File;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Deny.pm
+++ b/cassandane/Cassandane/Cyrus/Deny.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::Deny;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Expunge.pm
+++ b/cassandane/Cassandane/Cyrus/Expunge.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use JSON::XS;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -49,7 +49,6 @@ use Mail::JMAPTalk 0.12;
 use Data::Dumper;
 use Storable 'dclone';
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -49,7 +49,7 @@ use Mail::JMAPTalk 0.12;
 use Data::Dumper;
 use Storable 'dclone';
 
-use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 
 use charnames ':full';

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -50,7 +50,7 @@ use Data::Dumper;
 use Storable 'dclone';
 
 use lib '.';
-use base qw(Cassandane::Cyrus::TestCase);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 
 use charnames ':full';
@@ -232,30 +232,6 @@ sub _fmjmap_err
     my $res = $self->_fmjmap_req($cmd, %args);
     $self->assert_str_equals("error", $res->[0]);
     return $res->[1];
-}
-
-sub _set_quotaroot
-{
-    my ($self, $quotaroot) = @_;
-    $self->{quotaroot} = $quotaroot;
-}
-
-sub _set_quotalimits
-{
-    my ($self, %resources) = @_;
-    my $admintalk = $self->{adminstore}->get_client();
-
-    my $quotaroot = delete $resources{quotaroot} || $self->{quotaroot};
-    my @quotalist;
-    foreach my $resource (keys %resources)
-    {
-        my $limit = $resources{$resource}
-            or die "No limit specified for $resource";
-        push(@quotalist, uc($resource), $limit);
-    }
-    $self->{limits}->{$quotaroot} = { @quotalist };
-    $admintalk->setquota($quotaroot, \@quotalist);
-    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
 }
 
 use Cassandane::Tiny::Loader 'tiny-tests/FastMail';

--- a/cassandane/Cassandane/Cyrus/Fetch.pm
+++ b/cassandane/Cassandane/Cyrus/Fetch.pm
@@ -44,7 +44,6 @@ use Data::Dumper;
 use DateTime;
 use IO::Scalar;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Address;
 use Cassandane::Util::DateTime qw(to_rfc822);

--- a/cassandane/Cassandane/Cyrus/Flags.pm
+++ b/cassandane/Cassandane/Cyrus/Flags.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Words;

--- a/cassandane/Cassandane/Cyrus/HTTPPTS.pm
+++ b/cassandane/Cassandane/Cyrus/HTTPPTS.pm
@@ -44,7 +44,6 @@ use Cwd qw(realpath);
 use JSON;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Cyrus/ID.pm
+++ b/cassandane/Cassandane/Cyrus/ID.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/IMAP4rev2.pm
+++ b/cassandane/Cassandane/Cyrus/IMAP4rev2.pm
@@ -45,7 +45,6 @@ use File::Path qw(mkpath);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::NetString;

--- a/cassandane/Cassandane/Cyrus/IMAPLimits.pm
+++ b/cassandane/Cassandane/Cyrus/IMAPLimits.pm
@@ -43,7 +43,6 @@ use warnings;
 use Mail::JMAPTalk 0.13;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Idle.pm
+++ b/cassandane/Cassandane/Cyrus/Idle.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use DateTime;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/ImapTest.pm
+++ b/cassandane/Cassandane/Cyrus/ImapTest.pm
@@ -44,7 +44,6 @@ use Cwd qw(abs_path);
 use File::Path qw(mkpath);
 use DateTime;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Cassini;

--- a/cassandane/Cassandane/Cyrus/InProgress.pm
+++ b/cassandane/Cassandane/Cyrus/InProgress.pm
@@ -50,7 +50,6 @@ use File::Basename;
 use IO::File;
 use Cwd qw(abs_path getcwd);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Info.pm
+++ b/cassandane/Cassandane/Cyrus/Info.pm
@@ -45,7 +45,6 @@ use Data::Dumper;
 use Date::Format qw(time2str);
 use Time::HiRes qw(usleep);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/JMAPBackup.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPBackup.pm
@@ -50,7 +50,6 @@ use Storable 'dclone';
 use File::Basename;
 use XML::Spice;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/JMAPBlob.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPBlob.pm
@@ -46,7 +46,6 @@ use Mail::JMAPTalk 0.15;
 use Data::Dumper;
 use MIME::Base64 qw(encode_base64);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -54,7 +54,6 @@ use File::Basename;
 use XML::Spice;
 use MIME::Base64 qw(encode_base64url decode_base64url);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/JMAPContacts.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPContacts.pm
@@ -51,7 +51,6 @@ use File::Basename;
 use File::Copy;
 use Cwd qw(abs_path getcwd);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/JMAPContacts.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPContacts.pm
@@ -52,7 +52,7 @@ use File::Copy;
 use Cwd qw(abs_path getcwd);
 
 use lib '.';
-use base qw(Cassandane::Cyrus::TestCase);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;
 
@@ -113,30 +113,6 @@ sub normalize_jscard
     if (not exists $jscard->{'cyrusimap.org:importance'}) {
         $jscard->{'cyrusimap.org:importance'} = '0';
     }
-}
-
-sub _set_quotaroot
-{
-    my ($self, $quotaroot) = @_;
-    $self->{quotaroot} = $quotaroot;
-}
-
-sub _set_quotalimits
-{
-    my ($self, %resources) = @_;
-    my $admintalk = $self->{adminstore}->get_client();
-
-    my $quotaroot = delete $resources{quotaroot} || $self->{quotaroot};
-    my @quotalist;
-    foreach my $resource (keys %resources)
-    {
-        my $limit = $resources{$resource}
-            or die "No limit specified for $resource";
-        push(@quotalist, uc($resource), $limit);
-    }
-    $self->{limits}->{$quotaroot} = { @quotalist };
-    $admintalk->setquota($quotaroot, \@quotalist);
-    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
 }
 
 use Cassandane::Tiny::Loader 'tiny-tests/JMAPContacts';

--- a/cassandane/Cassandane/Cyrus/JMAPContacts.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPContacts.pm
@@ -51,7 +51,7 @@ use File::Basename;
 use File::Copy;
 use Cwd qw(abs_path getcwd);
 
-use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;
 

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -51,7 +51,6 @@ use MIME::Base64 qw(encode_base64);
 use Encode qw(decode_utf8);
 use Cwd qw(abs_path getcwd);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -52,7 +52,7 @@ use Cwd qw(abs_path getcwd);
 use URI;
 use URI::Escape;
 
-use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;
 

--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -52,7 +52,6 @@ use Cwd qw(abs_path getcwd);
 use URI;
 use URI::Escape;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -53,7 +53,7 @@ use URI;
 use URI::Escape;
 
 use lib '.';
-use base qw(Cassandane::Cyrus::TestCase);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;
 
@@ -368,30 +368,6 @@ sub email_query_window_internal
     if ($params{calculateTotal}) {
         $self->assert_num_equals(4, $res->[0][1]->{total});
     }
-}
-
-sub _set_quotaroot
-{
-    my ($self, $quotaroot) = @_;
-    $self->{quotaroot} = $quotaroot;
-}
-
-sub _set_quotalimits
-{
-    my ($self, %resources) = @_;
-    my $admintalk = $self->{adminstore}->get_client();
-
-    my $quotaroot = delete $resources{quotaroot} || $self->{quotaroot};
-    my @quotalist;
-    foreach my $resource (keys %resources)
-    {
-        my $limit = $resources{$resource}
-            or die "No limit specified for $resource";
-        push(@quotalist, uc($resource), $limit);
-    }
-    $self->{limits}->{$quotaroot} = { @quotalist };
-    $admintalk->setquota($quotaroot, \@quotalist);
-    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
 }
 
 use Cassandane::Tiny::Loader 'tiny-tests/JMAPEmail';

--- a/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
@@ -51,7 +51,6 @@ use MIME::Base64 qw(encode_base64);
 use Cwd qw(abs_path getcwd);
 use URI;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -50,7 +50,6 @@ use Storable 'dclone';
 use MIME::Base64 qw(encode_base64);
 use Cwd qw(abs_path getcwd);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/JMAPNote.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPNote.pm
@@ -48,7 +48,6 @@ use Storable 'dclone';
 use MIME::Base64 qw(encode_base64);
 use Cwd qw(abs_path getcwd);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/JMAPQuota.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPQuota.pm
@@ -46,7 +46,7 @@ use Mail::JMAPTalk 0.13;
 use Data::Dumper;
 
 use lib '.';
-use base qw(Cassandane::Cyrus::TestCase);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 
 use charnames ':full';
@@ -82,31 +82,6 @@ sub set_up
         'urn:ietf:params:jmap:calendars',
         'urn:ietf:params:jmap:sieve',
     ]);
-}
-
-sub _set_quotaroot
-{
-    my ($self, $quotaroot) = @_;
-    $self->{quotaroot} = $quotaroot;
-}
-
-# Utility function to set quota limits and check that it stuck
-sub _set_limits
-{
-    my ($self, %resources) = @_;
-    my $admintalk = $self->{adminstore}->get_client();
-
-    my $quotaroot = delete $resources{quotaroot} || $self->{quotaroot};
-    my @quotalist;
-    foreach my $resource (keys %resources)
-    {
-        my $limit = $resources{$resource}
-            or die "No limit specified for $resource";
-        push(@quotalist, uc($resource), $limit);
-    }
-    $self->{limits}->{$quotaroot} = { @quotalist };
-    $admintalk->setquota($quotaroot, \@quotalist);
-    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
 }
 
 sub tear_down

--- a/cassandane/Cassandane/Cyrus/JMAPQuota.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPQuota.pm
@@ -45,7 +45,7 @@ use JSON::XS;
 use Mail::JMAPTalk 0.13;
 use Data::Dumper;
 
-use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 
 use charnames ':full';

--- a/cassandane/Cassandane/Cyrus/JMAPQuota.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPQuota.pm
@@ -45,7 +45,6 @@ use JSON::XS;
 use Mail::JMAPTalk 0.13;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/JMAPSieve.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPSieve.pm
@@ -50,7 +50,6 @@ use File::Basename;
 use IO::File;
 use Cwd qw(abs_path getcwd);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/JMAPTestSuite.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuite.pm
@@ -46,7 +46,6 @@ use DateTime;
 use JSON::XS qw(encode_json);
 use File::Find;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Cassini;

--- a/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPTestSuiteWS.pm
@@ -47,7 +47,6 @@ use JSON::XS qw(encode_json);
 use File::Find;
 use Module::Load::Conditional qw(check_install);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Cassini;

--- a/cassandane/Cassandane/Cyrus/JMAPVacationResponse.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPVacationResponse.pm
@@ -49,7 +49,6 @@ use Storable 'dclone';
 use File::Basename;
 use IO::File;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/LDAP.pm
+++ b/cassandane/Cassandane/Cyrus/LDAP.pm
@@ -47,7 +47,6 @@ use warnings;
 use Cwd qw(realpath);
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/LibCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/LibCyrus.pm
@@ -47,7 +47,6 @@ use DateTime;
 use File::Copy;
 use File::Find;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/List.pm
+++ b/cassandane/Cassandane/Cyrus/List.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Generator;

--- a/cassandane/Cassandane/Cyrus/MailboxVersion.pm
+++ b/cassandane/Cassandane/Cyrus/MailboxVersion.pm
@@ -52,7 +52,6 @@ use Encode qw(decode_utf8);
 use Cwd qw(abs_path getcwd);
 use POSIX qw(mktime);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Master.pm
+++ b/cassandane/Cassandane/Cyrus/Master.pm
@@ -44,7 +44,6 @@ use File::stat;
 use POSIX qw(getcwd);
 use DateTime;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Wait;

--- a/cassandane/Cassandane/Cyrus/MaxMessages.pm
+++ b/cassandane/Cassandane/Cyrus/MaxMessages.pm
@@ -46,7 +46,6 @@ use Net::DAVTalk 0.14;
 use Net::CardDAVTalk 0.05;
 use Net::CardDAVTalk::VCard;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Generator;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Cyrus/MboxEvent.pm
+++ b/cassandane/Cassandane/Cyrus/MboxEvent.pm
@@ -43,7 +43,6 @@ use warnings;
 use Data::Dumper;
 use JSON;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Generator;

--- a/cassandane/Cassandane/Cyrus/Mboxgroups.pm
+++ b/cassandane/Cassandane/Cyrus/Mboxgroups.pm
@@ -44,7 +44,6 @@ use Cwd qw(realpath);
 use JSON;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Cyrus/Mbpath.pm
+++ b/cassandane/Cassandane/Cyrus/Mbpath.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::Mbpath;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/Metadata.pm
+++ b/cassandane/Cassandane/Cyrus/Metadata.pm
@@ -44,7 +44,6 @@ use DateTime;
 use File::Temp qw(:POSIX);
 use Config;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Mixin/QuotaHelper.pm
+++ b/cassandane/Cassandane/Cyrus/Mixin/QuotaHelper.pm
@@ -1,0 +1,186 @@
+#!/usr/bin/perl
+#
+#  Copyright (c) 2011-2024 FastMail Pty Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+#  3. The name "Fastmail Pty Ltd" must not be used to
+#     endorse or promote products derived from this software without
+#     prior written permission. For permission or any legal
+#     details, please contact
+#      FastMail Pty Ltd
+#      PO Box 234
+#      Collins St West 8007
+#      Victoria
+#      Australia
+#
+#  4. Redistributions of any form whatsoever must retain the following
+#     acknowledgment:
+#     "This product includes software developed by Fastmail Pty. Ltd."
+#
+#  FASTMAIL PTY LTD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+#  INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY  AND FITNESS, IN NO
+#  EVENT SHALL OPERA SOFTWARE AUSTRALIA BE LIABLE FOR ANY SPECIAL, INDIRECT
+#  OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+#  USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+#  TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+#  OF THIS SOFTWARE.
+#
+
+package Cassandane::Cyrus::Mixin::QuotaHelper;
+use strict;
+use warnings;
+
+use File::Path ();
+
+# Utility function to check that quota's usages
+# and limits are where we expect it to be
+sub _check_usages
+{
+    my ($self, %expecteds) = @_;
+    my $admintalk = $self->{adminstore}->get_client();
+
+    my $quotaroot = delete $expecteds{quotaroot} || $self->{quotaroot};
+    my $limits = $self->{limits}->{$quotaroot};
+
+    my @result = $admintalk->getquota($quotaroot);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # check actual and expected number of resources do match
+    $self->assert_num_equals(scalar(keys %$limits) * 3, scalar(@result));
+
+    # Convert the IMAP result to a conveniently checkable hash.
+    # By checkable, we mean that a failure in assert_deep_equals()
+    # will give a human some idea of what went wrong.
+    my %act;
+    while (scalar(@result)) {
+        my ($res, $used, $limit) = splice(@result, 0, 3);
+        $res = uc($res);
+        die "Resource $res appears twice in result"
+            if defined $act{$res};
+        $act{$res} = {
+            used => $used,
+            limit => $limit,
+        };
+    }
+
+    # Build a conveniently checkable hash from %expecteds
+    # and limits previously by _set_quotalimits().
+    my %exp;
+    foreach my $res (keys %expecteds)
+    {
+        $exp{uc($res)} = {
+            used => $expecteds{$res},
+            limit => $limits->{uc($res)},
+        };
+    }
+
+    # Now actually compare
+    $self->assert_deep_equals(\%exp, \%act);
+}
+
+# Reset the recorded usage in the database.  Used for testing
+# quota -f.  Rather hacky.  Both _set_quotaroot() and _set_quotalimits()
+# can be used to set default values.
+sub _zap_quota
+{
+    my ($self, %params) = @_;
+
+    my $quotaroot = $params{quotaroot} || $self->{quotaroot};
+    my $limits = $params{limits} || $self->{limits}->{$quotaroot};
+    my $useds = $params{useds} || {};
+    $useds = { map { uc($_) => $useds->{$_} } keys %$useds };
+
+    # double check that some other part of Cassandane didn't
+    # accidentally futz with the expected quota db backend
+    my $backend = $self->{instance}->{config}->get('quota_db');
+    $self->assert_str_equals('quotalegacy', $backend)
+        if defined $backend;        # the default value is also ok
+
+    my ($uc) = ($quotaroot =~ m/^user[\.\/](.)/);
+    my ($domain, $dirname);
+    ($quotaroot, $domain) = split '@', $quotaroot;
+    if ($domain) {
+        my ($dc) = ($domain =~ m/^(.)/);
+        $dirname = $self->{instance}->{basedir} . "/conf/domain/$dc/$domain";
+    }
+    else {
+        $dirname = $self->{instance}->{basedir} . "/conf";
+    }
+    $dirname .= "/quota/$uc";
+    my $qfn = $quotaroot;
+    $qfn =~ s/\//\./g;
+    my $filename = "$dirname/$qfn";
+    File::Path::mkpath($dirname);
+
+    open QUOTA,'>',$filename
+        or die "Failed to open $filename for writing: $!";
+
+    # STORAGE is special and always present, but -1 if unlimited
+    my $limit = $limits->{STORAGE} || -1;
+    my $used = $useds->{STORAGE} || 0;
+    print QUOTA "$used\n$limit";
+
+    # other resources have a leading keyword if present
+    my %keywords = ( MESSAGE => 'M', $self->res_annot_storage => 'AS' );
+    foreach my $resource (keys %$limits)
+    {
+        my $kw = $keywords{$resource} or next;
+        $limit = $limits->{$resource};
+        $used = $useds->{$resource} || 0;
+        print QUOTA " $kw $used $limit";
+    }
+
+    print QUOTA "\n";
+    close QUOTA;
+
+    $self->{instance}->_fix_ownership($self->{instance}{basedir} . "/conf/quota");
+}
+
+# Utility function to check that there is no quota
+sub _check_no_quota
+{
+    my ($self) = @_;
+    my $admintalk = $self->{adminstore}->get_client();
+
+    my @res = $admintalk->getquota($self->{quotaroot});
+    $self->assert_str_equals('no', $admintalk->get_last_completion_response());
+}
+
+
+sub _set_quotaroot
+{
+    my ($self, $quotaroot) = @_;
+    $self->{quotaroot} = $quotaroot;
+}
+
+# Utility function to set quota limits and check that it stuck
+sub _set_quotalimits
+{
+    my ($self, %resources) = @_;
+    my $admintalk = $self->{adminstore}->get_client();
+
+    my $quotaroot = delete $resources{quotaroot} || $self->{quotaroot};
+    my @quotalist;
+    foreach my $resource (keys %resources)
+    {
+        my $limit = $resources{$resource}
+            or die "No limit specified for $resource";
+        push(@quotalist, uc($resource), $limit);
+    }
+    $self->{limits}->{$quotaroot} = { @quotalist };
+    $admintalk->setquota($quotaroot, \@quotalist);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+}
+
+1;

--- a/cassandane/Cassandane/Cyrus/Move.pm
+++ b/cassandane/Cassandane/Cyrus/Move.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/MurderDAV.pm
+++ b/cassandane/Cassandane/Cyrus/MurderDAV.pm
@@ -43,7 +43,6 @@ use warnings;
 use URI;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/MurderIMAP.pm
+++ b/cassandane/Cassandane/Cyrus/MurderIMAP.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Words;

--- a/cassandane/Cassandane/Cyrus/MurderJMAP.pm
+++ b/cassandane/Cassandane/Cyrus/MurderJMAP.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/Nntp.pm
+++ b/cassandane/Cassandane/Cyrus/Nntp.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use News::NNTPClient;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Words;

--- a/cassandane/Cassandane/Cyrus/Notify.pm
+++ b/cassandane/Cassandane/Cyrus/Notify.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Objectid.pm
+++ b/cassandane/Cassandane/Cyrus/Objectid.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Generator;

--- a/cassandane/Cassandane/Cyrus/Pop3.pm
+++ b/cassandane/Cassandane/Cyrus/Pop3.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Net::POP3;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -44,7 +44,6 @@ use Data::Dumper;
 use File::Slurp;
 use HTTP::Tiny;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/QResync.pm
+++ b/cassandane/Cassandane/Cyrus/QResync.pm
@@ -45,7 +45,6 @@ use File::Path qw(mkpath);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::NetString;

--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -41,12 +41,11 @@ package Cassandane::Cyrus::Quota;
 use strict;
 use warnings;
 use Cwd qw(abs_path);
-use File::Path qw(mkpath);
 use DateTime;
 use Data::Dumper;
 
 use lib '.';
-use base qw(Cassandane::Cyrus::TestCase);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::NetString;
 use Cassandane::Util::Slurp;
@@ -76,145 +75,6 @@ sub tear_down
 {
     my ($self) = @_;
     $self->SUPER::tear_down();
-}
-
-sub _set_quotaroot
-{
-    my ($self, $quotaroot) = @_;
-    $self->{quotaroot} = $quotaroot;
-}
-
-# Utility function to set quota limits and check that it stuck
-sub _set_limits
-{
-    my ($self, %resources) = @_;
-    my $admintalk = $self->{adminstore}->get_client();
-
-    my $quotaroot = delete $resources{quotaroot} || $self->{quotaroot};
-    my @quotalist;
-    foreach my $resource (keys %resources)
-    {
-        my $limit = $resources{$resource}
-            or die "No limit specified for $resource";
-        push(@quotalist, uc($resource), $limit);
-    }
-    $self->{limits}->{$quotaroot} = { @quotalist };
-    $admintalk->setquota($quotaroot, \@quotalist);
-    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
-}
-
-# Utility function to check that quota's usages
-# and limits are where we expect it to be
-sub _check_usages
-{
-    my ($self, %expecteds) = @_;
-    my $admintalk = $self->{adminstore}->get_client();
-
-    my $quotaroot = delete $expecteds{quotaroot} || $self->{quotaroot};
-    my $limits = $self->{limits}->{$quotaroot};
-
-    my @result = $admintalk->getquota($quotaroot);
-    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
-
-    # check actual and expected number of resources do match
-    $self->assert_num_equals(scalar(keys %$limits) * 3, scalar(@result));
-
-    # Convert the IMAP result to a conveniently checkable hash.
-    # By checkable, we mean that a failure in assert_deep_equals()
-    # will give a human some idea of what went wrong.
-    my %act;
-    while (scalar(@result)) {
-        my ($res, $used, $limit) = splice(@result, 0, 3);
-        $res = uc($res);
-        die "Resource $res appears twice in result"
-            if defined $act{$res};
-        $act{$res} = {
-            used => $used,
-            limit => $limit,
-        };
-    }
-
-    # Build a conveniently checkable hash from %expecteds
-    # and limits previously by _set_limits().
-    my %exp;
-    foreach my $res (keys %expecteds)
-    {
-        $exp{uc($res)} = {
-            used => $expecteds{$res},
-            limit => $limits->{uc($res)},
-        };
-    }
-
-    # Now actually compare
-    $self->assert_deep_equals(\%exp, \%act);
-}
-
-# Reset the recorded usage in the database.  Used for testing
-# quota -f.  Rather hacky.  Both _set_quotaroot() and _set_limits()
-# can be used to set default values.
-sub _zap_quota
-{
-    my ($self, %params) = @_;
-
-    my $quotaroot = $params{quotaroot} || $self->{quotaroot};
-    my $limits = $params{limits} || $self->{limits}->{$quotaroot};
-    my $useds = $params{useds} || {};
-    $useds = { map { uc($_) => $useds->{$_} } keys %$useds };
-
-    # double check that some other part of Cassandane didn't
-    # accidentally futz with the expected quota db backend
-    my $backend = $self->{instance}->{config}->get('quota_db');
-    $self->assert_str_equals('quotalegacy', $backend)
-        if defined $backend;        # the default value is also ok
-
-    my ($uc) = ($quotaroot =~ m/^user[\.\/](.)/);
-    my ($domain, $dirname);
-    ($quotaroot, $domain) = split '@', $quotaroot;
-    if ($domain) {
-        my ($dc) = ($domain =~ m/^(.)/);
-        $dirname = $self->{instance}->{basedir} . "/conf/domain/$dc/$domain";
-    }
-    else {
-        $dirname = $self->{instance}->{basedir} . "/conf";
-    }
-    $dirname .= "/quota/$uc";
-    my $qfn = $quotaroot;
-    $qfn =~ s/\//\./g;
-    my $filename = "$dirname/$qfn";
-    mkpath $dirname;
-
-    open QUOTA,'>',$filename
-        or die "Failed to open $filename for writing: $!";
-
-    # STORAGE is special and always present, but -1 if unlimited
-    my $limit = $limits->{STORAGE} || -1;
-    my $used = $useds->{STORAGE} || 0;
-    print QUOTA "$used\n$limit";
-
-    # other resources have a leading keyword if present
-    my %keywords = ( MESSAGE => 'M', $self->res_annot_storage => 'AS' );
-    foreach my $resource (keys %$limits)
-    {
-        my $kw = $keywords{$resource} or next;
-        $limit = $limits->{$resource};
-        $used = $useds->{$resource} || 0;
-        print QUOTA " $kw $used $limit";
-    }
-
-    print QUOTA "\n";
-    close QUOTA;
-
-    $self->{instance}->_fix_ownership($self->{instance}{basedir} . "/conf/quota");
-}
-
-# Utility function to check that there is no quota
-sub _check_no_quota
-{
-    my ($self) = @_;
-    my $admintalk = $self->{adminstore}->get_client();
-
-    my @res = $admintalk->getquota($self->{quotaroot});
-    $self->assert_str_equals('no', $admintalk->get_last_completion_response());
 }
 
 sub _check_smmap

--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -44,7 +44,6 @@ use Cwd qw(abs_path);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::NetString;

--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -94,20 +94,20 @@ sub bogus_test_upgrade_v2_4
 
     xlog $self, "test resources usage computing upon upgrading a cyrus v2.4 mailbox";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_limits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
 
     xlog $self, "store annotations";
     my $data = $self->make_random_data(10);
     my $expected_annotation_storage = length($data);
     $talk->setmetadata($self->{store}->{folder}, '/private/comment', { Quote => $data });
     $self->assert_str_equals('ok', $talk->get_last_completion_response());
-    $self->_check_usages($self->res_annot_storage => int($expected_annotation_storage/1024));
+    $self->check_usages($self->res_annot_storage => int($expected_annotation_storage/1024));
 
     xlog $self, "restore cyrus v2.4 mailbox content and quota file";
     $self->{instance}->unpackfile(abs_path('data/cyrus/quota_upgrade_v2_4.user.tar.gz'), 'data/user');
@@ -136,12 +136,12 @@ sub bogus_test_upgrade_v2_4
     # set quota limits on resources which did not exist in previous cyrus versions;
     # when the mailbox was upgraded, new resources quota usage shall have been
     # computed automatically
-    $self->_set_limits(
+    $self->set_limits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 10000,
     );
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),

--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -44,7 +44,7 @@ use Cwd qw(abs_path);
 use DateTime;
 use Data::Dumper;
 
-use base qw(Cassandane::Cyrus::TestCase Cassandane::Cyrus::Mixin::QuotaHelper);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 use Cassandane::Util::NetString;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -46,7 +46,6 @@ use IO::File;
 use JSON;
 use Cwd qw(abs_path);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/RelocateById.pm
+++ b/cassandane/Cassandane/Cyrus/RelocateById.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Rename.pm
+++ b/cassandane/Cassandane/Cyrus/Rename.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/Replace.pm
+++ b/cassandane/Cassandane/Cyrus/Replace.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Generator;

--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -43,7 +43,6 @@ use warnings;
 use Data::Dumper;
 use DateTime;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Search.pm
+++ b/cassandane/Cassandane/Cyrus/Search.pm
@@ -44,7 +44,6 @@ use Cwd qw(abs_path);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -48,7 +48,6 @@ use File::stat;
 use MIME::Base64 qw(encode_base64);
 use Encode qw(decode encode);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/SearchSquat.pm
+++ b/cassandane/Cassandane/Cyrus/SearchSquat.pm
@@ -44,7 +44,6 @@ use Cwd qw(abs_path);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Shared.pm
+++ b/cassandane/Cassandane/Cyrus/Shared.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Instance;
 use Cassandane::Mboxname;

--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -48,7 +48,6 @@ use File::Temp qw/tempfile/;
 use DateTime;
 use Date::Parse;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Encode qw(decode);

--- a/cassandane/Cassandane/Cyrus/Simple.pm
+++ b/cassandane/Cassandane/Cyrus/Simple.pm
@@ -44,7 +44,6 @@ use Cwd qw(getcwd realpath);
 use Data::Dumper;
 use DateTime;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Specialuse.pm
+++ b/cassandane/Cassandane/Cyrus/Specialuse.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::Specialuse;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/StartTLS.pm
+++ b/cassandane/Cassandane/Cyrus/StartTLS.pm
@@ -46,7 +46,6 @@ use Mail::JMAPTalk 0.13;
 use Cwd qw(abs_path);
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Socket;

--- a/cassandane/Cassandane/Cyrus/Subscriptions.pm
+++ b/cassandane/Cassandane/Cyrus/Subscriptions.pm
@@ -46,7 +46,6 @@ use File::Basename;
 use File::Copy;
 use File::Path qw(mkpath);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Mboxname;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Cyrus/SyncProto.pm
+++ b/cassandane/Cassandane/Cyrus/SyncProto.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::SyncProto;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/T116.pm
+++ b/cassandane/Cassandane/Cyrus/T116.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::T116;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Instance;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -50,7 +50,6 @@ use File::Temp qw(tempfile);
 use List::Util qw(uniq);
 use Scalar::Util qw(refaddr);
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::TestUser;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Cyrus/TestEntities.pm
+++ b/cassandane/Cassandane/Cyrus/TestEntities.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::TestEntities;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/TestEntities.pm
+++ b/cassandane/Cassandane/Cyrus/TestEntities.pm
@@ -50,45 +50,16 @@ sub new
     my ($class, @args) = @_;
 
     my $config = Cassandane::Config->default()->clone();
-    $config->set(caldav_historical_age => -1,
-                 caldav_realm => 'Cassandane',
-                 conversations => 'yes',
-                 conversations_counted_flags => "\\Draft \\Flagged \$IsMailingList \$IsNotification \$HasAttachment \$muted",
-                 defaultdomain => 'example.com',
-                 httpallowcompress => 'no',
+    $config->set(conversations => 'yes',
                  httpmodules => 'carddav caldav jmap',
-                 imipnotifier => 'imip',
-                 icalendar_max_size => 100000,
-                 jmap_nonstandard_extensions => 'yes',
-                 jmapsubmission_deleteonsend => 'no',
-                 notesmailbox => 'Notes',
-                 sync_log => 'yes');
-
-    # setup sieve
-    my ($maj, $min) = Cassandane::Instance->get_version();
-    if ($maj == 3 && $min == 0) {
-        # need to explicitly add 'body' to sieve_extensions for 3.0
-        $config->set(sieve_extensions =>
-            "fileinto reject vacation vacation-seconds imap4flags notify " .
-            "envelope relational regex subaddress copy date index " .
-            "imap4flags mailbox mboxmetadata servermetadata variables " .
-            "body");
-    }
-    elsif ($maj < 3) {
-        # also for 2.5 (the earliest Cyrus that Cassandane can test)
-        $config->set(sieve_extensions =>
-            "fileinto reject vacation vacation-seconds imap4flags notify " .
-            "envelope relational regex subaddress copy date index " .
-            "imap4flags body");
-    }
-    $config->set(sievenotifier => 'mailto');
+                 jmap_nonstandard_extensions => 'yes');
 
     my $self = $class->SUPER::new({
         config => $config,
         jmap => 1,
         deliver => 1,
         adminstore => 1,
-        services => [ 'imap', 'http', 'sieve' ]
+        services => [ 'imap', 'http' ]
     }, @args);
 
     $self->needs('component', 'jmap');

--- a/cassandane/Cassandane/Cyrus/TesterCalDAV.pm
+++ b/cassandane/Cassandane/Cyrus/TesterCalDAV.pm
@@ -45,7 +45,6 @@ use File::Path qw(mkpath);
 use DateTime;
 use JSON::XS;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/TesterCardDAV.pm
+++ b/cassandane/Cassandane/Cyrus/TesterCardDAV.pm
@@ -45,7 +45,6 @@ use File::Path qw(mkpath);
 use DateTime;
 use JSON::XS;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/Cyrus/Thread.pm
+++ b/cassandane/Cassandane/Cyrus/Thread.pm
@@ -43,7 +43,6 @@ use warnings;
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/UIDbatches.pm
+++ b/cassandane/Cassandane/Cyrus/UIDbatches.pm
@@ -44,7 +44,6 @@ use Cwd qw(abs_path);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/UIDonly.pm
+++ b/cassandane/Cassandane/Cyrus/UIDonly.pm
@@ -49,7 +49,6 @@ use Storable 'dclone';
 use File::Basename;
 use IO::File;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Cyrus/URLAuth.pm
+++ b/cassandane/Cassandane/Cyrus/URLAuth.pm
@@ -45,7 +45,6 @@ use File::Path qw(mkpath);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::NetString;

--- a/cassandane/Cassandane/Cyrus/UTF8Accept.pm
+++ b/cassandane/Cassandane/Cyrus/UTF8Accept.pm
@@ -45,7 +45,6 @@ use File::Path qw(mkpath);
 use DateTime;
 use Data::Dumper;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::NetString;

--- a/cassandane/Cassandane/Cyrus/Userid.pm
+++ b/cassandane/Cassandane/Cyrus/Userid.pm
@@ -41,7 +41,6 @@ package Cassandane::Cyrus::Userid;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Generator.pm
+++ b/cassandane/Cassandane/Generator.pm
@@ -43,7 +43,6 @@ use warnings;
 use feature qw(state);
 use Digest::MD5 qw(md5_hex);
 
-use lib '.';
 use Cassandane::Util::DateTime qw(to_rfc822 from_iso8601);
 use Cassandane::Address;
 use Cassandane::Message;

--- a/cassandane/Cassandane/GenericListener.pm
+++ b/cassandane/Cassandane/GenericListener.pm
@@ -41,7 +41,6 @@ package Cassandane::GenericListener;
 use strict;
 use warnings;
 
-use lib '.';
 use Cassandane::Util::Log;
 use Cassandane::PortManager;
 

--- a/cassandane/Cassandane/IMAPMessageStore.pm
+++ b/cassandane/Cassandane/IMAPMessageStore.pm
@@ -46,7 +46,6 @@ use Cwd qw(abs_path);
 # runtime dependency of Mail::IMAPTalk. make sure we have it!
 require IO::Socket::SSL;
 
-use lib '.';
 use base qw(Cassandane::MessageStore);
 use Cassandane::Util::Log;
 use Cassandane::Util::DateTime qw(to_rfc822);

--- a/cassandane/Cassandane/IMAPService.pm
+++ b/cassandane/Cassandane/IMAPService.pm
@@ -41,7 +41,6 @@ package Cassandane::IMAPService;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Service);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -64,7 +64,6 @@ use Time::HiRes qw(usleep);
 use List::Util qw(uniqstr);
 use MIME::Base64 qw(decode_base64 encode_base64);
 
-use lib '.';
 use Cassandane::Util::DateTime qw(to_iso8601);
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/MaildirMessageStore.pm
+++ b/cassandane/Cassandane/MaildirMessageStore.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use File::Path qw(mkpath rmtree);
 
-use lib '.';
 use base qw(Cassandane::MessageStore);
 
 sub new

--- a/cassandane/Cassandane/MasterDaemon.pm
+++ b/cassandane/Cassandane/MasterDaemon.pm
@@ -41,7 +41,6 @@ package Cassandane::MasterDaemon;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::MasterEntry);
 
 sub new

--- a/cassandane/Cassandane/MasterEntry.pm
+++ b/cassandane/Cassandane/MasterEntry.pm
@@ -41,7 +41,6 @@ package Cassandane::MasterEntry;
 use strict;
 use warnings;
 
-use lib '.';
 use Cassandane::Util::Log;
 
 my $next_tag = 1;

--- a/cassandane/Cassandane/MasterEvent.pm
+++ b/cassandane/Cassandane/MasterEvent.pm
@@ -41,7 +41,6 @@ package Cassandane::MasterEvent;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::MasterEntry);
 
 sub new

--- a/cassandane/Cassandane/MasterStart.pm
+++ b/cassandane/Cassandane/MasterStart.pm
@@ -41,7 +41,6 @@ package Cassandane::MasterStart;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::MasterEntry);
 
 sub new

--- a/cassandane/Cassandane/MboxMessageStore.pm
+++ b/cassandane/Cassandane/MboxMessageStore.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use POSIX qw(strftime);
 
-use lib '.';
 use base qw(Cassandane::MessageStore);
 use Cassandane::Util::DateTime qw(from_rfc822);
 use Cassandane::Message;

--- a/cassandane/Cassandane/Mboxname.pm
+++ b/cassandane/Cassandane/Mboxname.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use overload qw("") => \&to_internal;
 
-use lib '.';
 use Cassandane::Util::Log;
 
 sub new

--- a/cassandane/Cassandane/Message.pm
+++ b/cassandane/Cassandane/Message.pm
@@ -44,7 +44,6 @@ use base qw(Clone Exporter);
 use overload qw("") => \&as_string;
 use Math::Int64;
 
-use lib '.';
 use Cassandane::Util::Log;
 use Cassandane::Util::DateTime qw(to_rfc3501);
 use Cassandane::Util::SHA;

--- a/cassandane/Cassandane/MessageStore.pm
+++ b/cassandane/Cassandane/MessageStore.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use overload qw("") => \&as_string;
 
-use lib '.';
 use Cassandane::Util::Log;
 
 sub new

--- a/cassandane/Cassandane/MessageStoreFactory.pm
+++ b/cassandane/Cassandane/MessageStoreFactory.pm
@@ -45,7 +45,6 @@ use URI;
 use URI::Escape qw(uri_unescape);
 use Exporter ();
 
-use lib '.';
 use Cassandane::MboxMessageStore;
 use Cassandane::MaildirMessageStore;
 use Cassandane::IMAPMessageStore;

--- a/cassandane/Cassandane/Mixin/QuotaHelper.pm
+++ b/cassandane/Cassandane/Mixin/QuotaHelper.pm
@@ -37,7 +37,7 @@
 #  OF THIS SOFTWARE.
 #
 
-package Cassandane::Cyrus::Mixin::QuotaHelper;
+package Cassandane::Mixin::QuotaHelper;
 use strict;
 use warnings;
 

--- a/cassandane/Cassandane/Mixin/QuotaHelper.pm
+++ b/cassandane/Cassandane/Mixin/QuotaHelper.pm
@@ -45,7 +45,7 @@ use File::Path ();
 
 # Utility function to check that quota's usages
 # and limits are where we expect it to be
-sub _check_usages
+sub check_usages
 {
     my ($self, %expecteds) = @_;
     my $admintalk = $self->{adminstore}->get_client();
@@ -92,7 +92,7 @@ sub _check_usages
 # Reset the recorded usage in the database.  Used for testing
 # quota -f.  Rather hacky.  Both _set_quotaroot() and _set_quotalimits()
 # can be used to set default values.
-sub _zap_quota
+sub zap_quota
 {
     my ($self, %params) = @_;
 
@@ -148,7 +148,7 @@ sub _zap_quota
 }
 
 # Utility function to check that there is no quota
-sub _check_no_quota
+sub check_no_quota
 {
     my ($self) = @_;
     my $admintalk = $self->{adminstore}->get_client();
@@ -158,14 +158,14 @@ sub _check_no_quota
 }
 
 
-sub _set_quotaroot
+sub set_quotaroot
 {
     my ($self, $quotaroot) = @_;
     $self->{quotaroot} = $quotaroot;
 }
 
 # Utility function to set quota limits and check that it stuck
-sub _set_quotalimits
+sub set_quotalimits
 {
     my ($self, %resources) = @_;
     my $admintalk = $self->{adminstore}->get_client();

--- a/cassandane/Cassandane/Net/SMTPServer.pm
+++ b/cassandane/Cassandane/Net/SMTPServer.pm
@@ -7,7 +7,6 @@ use File::Spec::Functions qw(catfile);
 use File::Temp qw(mkstemps);
 use Net::Server::PreFork;
 
-use lib ".";
 use Net::XmtpServer;
 use Cassandane::Util::Log;
 use Cassandane::Util::Slurp;

--- a/cassandane/Cassandane/POP3MessageStore.pm
+++ b/cassandane/Cassandane/POP3MessageStore.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Net::POP3;
 
-use lib '.';
 use base qw(Cassandane::MessageStore);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/PortManager.pm
+++ b/cassandane/Cassandane/PortManager.pm
@@ -41,7 +41,6 @@ package Cassandane::PortManager;
 use strict;
 use warnings;
 
-use lib '.';
 use Cassandane::Cassini;
 use IO::Socket::IP;
 use POSIX qw(EADDRINUSE);

--- a/cassandane/Cassandane/SequenceGenerator.pm
+++ b/cassandane/Cassandane/SequenceGenerator.pm
@@ -41,7 +41,6 @@ package Cassandane::SequenceGenerator;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Generator);
 use Cassandane::Util::DateTime qw(to_iso8601);
 use Cassandane::Address;

--- a/cassandane/Cassandane/Service.pm
+++ b/cassandane/Cassandane/Service.pm
@@ -41,7 +41,6 @@ package Cassandane::Service;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::MasterEntry);
 use Cassandane::GenericListener;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/ServiceFactory.pm
+++ b/cassandane/Cassandane/ServiceFactory.pm
@@ -41,7 +41,6 @@ package Cassandane::ServiceFactory;
 use strict;
 use warnings;
 
-use lib '.';
 use Cassandane::Util::Log;
 use Cassandane::Service;
 use Cassandane::IMAPService;

--- a/cassandane/Cassandane/Test/Address.pm
+++ b/cassandane/Cassandane/Test/Address.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::Address;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Address;
 

--- a/cassandane/Cassandane/Test/Base64JMAP.pm
+++ b/cassandane/Cassandane/Test/Base64JMAP.pm
@@ -4,7 +4,6 @@ package Cassandane::Test::Base64JMAP;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 
 use Cassandane::Util::Base64JMAP;

--- a/cassandane/Cassandane/Test/Cassini.pm
+++ b/cassandane/Cassandane/Test/Cassini.pm
@@ -43,7 +43,6 @@ use warnings;
 use File::chdir;
 use File::Temp qw(tempdir);
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Cassini;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Test/Clone.pm
+++ b/cassandane/Cassandane/Test/Clone.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Clone qw(clone);
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 
 sub new

--- a/cassandane/Cassandane/Test/Config.pm
+++ b/cassandane/Cassandane/Test/Config.pm
@@ -43,7 +43,6 @@ use warnings;
 use Data::Dumper;
 use File::Temp qw(tempfile);
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Config;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Test/Core.pm
+++ b/cassandane/Cassandane/Test/Core.pm
@@ -43,7 +43,6 @@ use warnings;
 use Data::Dumper;
 use POSIX qw(getcwd);
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Test/DateTime.pm
+++ b/cassandane/Cassandane/Test/DateTime.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::DateTime;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Util::DateTime;
 

--- a/cassandane/Cassandane/Test/Mboxname.pm
+++ b/cassandane/Cassandane/Test/Mboxname.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::Mboxname;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Mboxname;
 use Cassandane::Config;

--- a/cassandane/Cassandane/Test/Message.pm
+++ b/cassandane/Cassandane/Test/Message.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::Message;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Message;
 use Cassandane::Address;

--- a/cassandane/Cassandane/Test/MessageStoreFactory.pm
+++ b/cassandane/Cassandane/Test/MessageStoreFactory.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::MessageStoreFactory;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::MessageStoreFactory;
 

--- a/cassandane/Cassandane/Test/Metronome.pm
+++ b/cassandane/Cassandane/Test/Metronome.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::Metronome;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Util::Metronome;
 use Cassandane::Util::Sample;

--- a/cassandane/Cassandane/Test/NewTestUrl.pm
+++ b/cassandane/Cassandane/Test/NewTestUrl.pm
@@ -7,7 +7,6 @@ use warnings;
 use JSON;
 use LWP::UserAgent;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 
 sub new

--- a/cassandane/Cassandane/Test/Parameter.pm
+++ b/cassandane/Cassandane/Test/Parameter.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::Parameter;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Util::Log;
 

--- a/cassandane/Cassandane/Test/Sample.pm
+++ b/cassandane/Cassandane/Test/Sample.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::Sample;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::TestCase);
 use Cassandane::Util::Sample;
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Test/Skip.pm
+++ b/cassandane/Cassandane/Test/Skip.pm
@@ -41,7 +41,6 @@ package Cassandane::Test::Skip;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Cyrus::TestCase);
 
 sub new

--- a/cassandane/Cassandane/TestEntity/Factory/AddressBook.pm
+++ b/cassandane/Cassandane/TestEntity/Factory/AddressBook.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Factory::AddressBook;
 use Moo;
 
-use lib '.';
 use Cassandane::TestEntity::AutoSetup;
 
 use feature 'state';

--- a/cassandane/Cassandane/TestEntity/Factory/ContactCard.pm
+++ b/cassandane/Cassandane/TestEntity/Factory/ContactCard.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Factory::ContactCard;
 use Moo;
 
-use lib '.';
 use Cassandane::TestEntity::AutoSetup;
 
 use Data::GUID ();

--- a/cassandane/Cassandane/TestEntity/Factory/Email.pm
+++ b/cassandane/Cassandane/TestEntity/Factory/Email.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Factory::Email;
 use Moo;
 
-use lib '.';
 use Cassandane::TestEntity::AutoSetup;
 
 no Moo;

--- a/cassandane/Cassandane/TestEntity/Factory/Mailbox.pm
+++ b/cassandane/Cassandane/TestEntity/Factory/Mailbox.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Factory::Mailbox;
 use Moo;
 
-use lib '.';
 use Cassandane::TestEntity::AutoSetup;
 
 use feature 'state';

--- a/cassandane/Cassandane/TestEntity/Instance/AddressBook.pm
+++ b/cassandane/Cassandane/TestEntity/Instance/AddressBook.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Instance::AddressBook;
 use Moo;
 
-use lib '.';
 use Cassandane::TestEntity::AutoSetup properties => [ qw(
     id name description sortOrder isDefault isSubscribed
     shareWith myRights

--- a/cassandane/Cassandane/TestEntity/Instance/ContactCard.pm
+++ b/cassandane/Cassandane/TestEntity/Instance/ContactCard.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Instance::ContactCard;
 use Moo;
 
-use lib '.';
 
 # The properties here are from RFC 9553 (plus id and addressBookIds) in order
 # listed in the RFC.

--- a/cassandane/Cassandane/TestEntity/Instance/Email.pm
+++ b/cassandane/Cassandane/TestEntity/Instance/Email.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Instance::Email;
 use Moo;
 
-use lib '.';
 use Cassandane::TestEntity::AutoSetup properties => [ qw(
     id blobId threadId mailboxIds keywords size receivedAt
     messageId inReplyTo references sender from to cc bcc replyTo subject sentAt

--- a/cassandane/Cassandane/TestEntity/Instance/Mailbox.pm
+++ b/cassandane/Cassandane/TestEntity/Instance/Mailbox.pm
@@ -1,7 +1,6 @@
 package Cassandane::TestEntity::Instance::Mailbox;
 use Moo;
 
-use lib '.';
 use Cassandane::TestEntity::AutoSetup properties => [ qw(
     id name parentId role sortOrder
     totalEmails unreadEmails totalThreads unreadThreads

--- a/cassandane/Cassandane/ThreadedGenerator.pm
+++ b/cassandane/Cassandane/ThreadedGenerator.pm
@@ -41,7 +41,6 @@ package Cassandane::ThreadedGenerator;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Generator);
 use Cassandane::Address;
 use Cassandane::Message;

--- a/cassandane/Cassandane/Unit/FormatPretty.pm
+++ b/cassandane/Cassandane/Unit/FormatPretty.pm
@@ -41,7 +41,6 @@ package Cassandane::Unit::FormatPretty;
 use strict;
 use warnings;
 
-use lib '.';
 use base qw(Cassandane::Unit::Formatter);
 
 sub new

--- a/cassandane/Cassandane/Unit/FormatTAP.pm
+++ b/cassandane/Cassandane/Unit/FormatTAP.pm
@@ -43,7 +43,6 @@ use warnings;
 use Data::Dumper;
 use IO::File;
 
-use lib '.';
 use base qw(Cassandane::Unit::Formatter);
 
 sub new

--- a/cassandane/Cassandane/Unit/FormatXML.pm
+++ b/cassandane/Cassandane/Unit/FormatXML.pm
@@ -47,7 +47,6 @@ use Time::HiRes qw(time);
 use Sys::Hostname;
 use POSIX qw(strftime);
 
-use lib '.';
 use base qw(Cassandane::Unit::Formatter);
 
 $VERSION = '0.1';

--- a/cassandane/Cassandane/Unit/Runner.pm
+++ b/cassandane/Cassandane/Unit/Runner.pm
@@ -45,7 +45,6 @@ use Test::Unit::Result;
 use Benchmark;
 use IO::File;
 
-use lib '.';
 use Cassandane::Cassini;
 
 sub new

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -46,7 +46,6 @@ use Data::Dumper;
 use DateTime;
 use DateTime::Format::ISO8601;
 
-use lib '.';
 use Cassandane::Util::Log;
 use Cassandane::Util::TestUrl;
 

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -44,7 +44,6 @@ use IO::Handle;
 use POSIX;
 use Time::HiRes qw(time);
 
-use lib '.';
 use Cassandane::Unit::TestCase;
 
 sub new

--- a/cassandane/Cassandane/Util/Base64JMAP.pm
+++ b/cassandane/Cassandane/Util/Base64JMAP.pm
@@ -43,7 +43,6 @@ use warnings;
 use base qw(Exporter);
 use MIME::Base64 qw(encode_base64url decode_base64url);
 
-use lib '.';
 use Cassandane::Util::Log;
 
 our @EXPORT = qw(&encode_base64jmap &decode_base64jmap);

--- a/cassandane/Cassandane/Util/Metronome.pm
+++ b/cassandane/Cassandane/Util/Metronome.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use Time::HiRes qw(clock_gettime clock_nanosleep CLOCK_MONOTONIC);
 
-use lib '.';
 use Cassandane::Util::Log;
 
 sub new

--- a/cassandane/Cassandane/Util/Setup.pm
+++ b/cassandane/Cassandane/Util/Setup.pm
@@ -45,7 +45,6 @@ use POSIX;
 use User::pwent;
 use Data::Dumper;
 
-use lib '.';
 use Cassandane::Util::Log;
 
 our @EXPORT = qw(&become_cyrus);

--- a/cassandane/Cassandane/Util/Slurp.pm
+++ b/cassandane/Cassandane/Util/Slurp.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 use base qw(Exporter);
 
-use lib '.';
 
 our @EXPORT = qw(&slurp_file);
 

--- a/cassandane/Cassandane/Util/Socket.pm
+++ b/cassandane/Cassandane/Util/Socket.pm
@@ -45,7 +45,6 @@ use IO::Socket::INET;
 use IO::Socket::INET6;
 use IO::Socket::UNIX;
 
-use lib '.';
 use Cassandane::Util::Log;
 
 our @EXPORT = qw(create_client_socket);

--- a/cassandane/Cassandane/Util/TestUrl.pm
+++ b/cassandane/Cassandane/Util/TestUrl.pm
@@ -10,7 +10,6 @@ use Plack::Response;
 use Test::TCP;
 use Carp qw(croak);
 
-use lib '.';
 use Cassandane::PortManager;
 
 sub new

--- a/cassandane/Cassandane/Util/Wait.pm
+++ b/cassandane/Cassandane/Util/Wait.pm
@@ -43,7 +43,6 @@ use warnings;
 use base qw(Exporter);
 use Time::HiRes qw(sleep gettimeofday tv_interval);
 
-use lib '.';
 use Cassandane::Util::Log;
 
 our @EXPORT = qw(&timed_wait);

--- a/cassandane/Makefile
+++ b/cassandane/Makefile
@@ -65,7 +65,7 @@ SYNTAX_rules =
 
 define SYNTAX_template
  $(1)_syntax: $(1)
-	@$(PERL) $(CYRUS_PERL_PATHS) -c $(1)
+	@$(PERL) $(CYRUS_PERL_PATHS) -I . -c $(1)
  SYNTAX_rules += $(1)_syntax
 endef
 

--- a/cassandane/tiny-tests/FastMail/issue_LP52545479
+++ b/cassandane/tiny-tests/FastMail/issue_LP52545479
@@ -68,8 +68,8 @@ sub test_issue_LP52545479
         $res_annot_storage = 'X-ANNOTATION-STORAGE';
     }
 
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(storage => 1,
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 1,
                             $res_annot_storage => 1); # that's 1024 bytes
 
     $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPContacts/contact_copy_overquota
+++ b/cassandane/tiny-tests/JMAPContacts/contact_copy_overquota
@@ -26,8 +26,8 @@ sub test_contact_copy_overquota
     $admintalk->setacl('user.other.#addressbooks.Default',
                        'cassandane' => 'lrswipkxtecdn') or die;
 
-    $self->_set_quotaroot('user.other.#addressbooks');
-    $self->_set_quotalimits(storage => 1);
+    $self->set_quotaroot('user.other.#addressbooks');
+    $self->set_quotalimits(storage => 1);
 
     my $res = $jmap->CallMethods([
         ['Contact/set', {

--- a/cassandane/tiny-tests/JMAPEmail/email_set_getquota
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_getquota
@@ -7,9 +7,9 @@ sub test_email_set_getquota
 {
     my ($self) = @_;
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(storage => 1000); # that's 1000 * 1024 bytes
+    $self->set_quotalimits(storage => 1000); # that's 1000 * 1024 bytes
 
     my $jmap = $self->{jmap};
     my $service = $self->{instance}->get_service("http");

--- a/cassandane/tiny-tests/JMAPQuota/quota_changes
+++ b/cassandane/tiny-tests/JMAPQuota/quota_changes
@@ -10,8 +10,8 @@ sub test_quota_changes
 
     # Right - let's set ourselves some basic usage quota
     xlog "Set a quota limit";
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(
         storage => 100000,
         message => 50000,
         mailbox => 100,
@@ -43,8 +43,8 @@ sub test_quota_changes
     $state = $res->[0][1]{'newState'};
 
     xlog "Update limit";
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(
         storage => 200000,
         message => 50000,
         mailbox => 100,
@@ -73,8 +73,8 @@ sub test_quota_changes
     $self->assert_str_equals('R1', $res->[0][2]);
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
 
-    $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane.#calendars');
+    $self->set_quotalimits(
         storage => 10000,
         message => 5000,
         mailbox => 10,
@@ -94,8 +94,8 @@ sub test_quota_changes
 
     $state = $res->[0][1]{'newState'};
 
-    $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane.#calendars');
+    $self->set_quotalimits(
         storage => 20000,
         message => 5000,
         mailbox => 10,

--- a/cassandane/tiny-tests/JMAPQuota/quota_changes
+++ b/cassandane/tiny-tests/JMAPQuota/quota_changes
@@ -11,7 +11,7 @@ sub test_quota_changes
     # Right - let's set ourselves some basic usage quota
     xlog "Set a quota limit";
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 100000,
         message => 50000,
         mailbox => 100,
@@ -44,7 +44,7 @@ sub test_quota_changes
 
     xlog "Update limit";
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 200000,
         message => 50000,
         mailbox => 100,
@@ -74,7 +74,7 @@ sub test_quota_changes
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
 
     $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 10000,
         message => 5000,
         mailbox => 10,
@@ -95,7 +95,7 @@ sub test_quota_changes
     $state = $res->[0][1]{'newState'};
 
     $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 20000,
         message => 5000,
         mailbox => 10,

--- a/cassandane/tiny-tests/JMAPQuota/quota_get
+++ b/cassandane/tiny-tests/JMAPQuota/quota_get
@@ -33,15 +33,15 @@ EOF
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
 
     # Right - let's set ourselves some basic usage quota
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(
         storage => 100000,
         message => 50000,
         mailbox => 100,
     );
 
-    $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane.#calendars');
+    $self->set_quotalimits(
         storage => 10000,
         message => 5000,
         mailbox => 10,

--- a/cassandane/tiny-tests/JMAPQuota/quota_get
+++ b/cassandane/tiny-tests/JMAPQuota/quota_get
@@ -34,14 +34,14 @@ EOF
 
     # Right - let's set ourselves some basic usage quota
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 100000,
         message => 50000,
         mailbox => 100,
     );
 
     $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 10000,
         message => 5000,
         mailbox => 10,

--- a/cassandane/tiny-tests/JMAPQuota/quota_query
+++ b/cassandane/tiny-tests/JMAPQuota/quota_query
@@ -33,15 +33,15 @@ EOF
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
 
     # Right - let's set ourselves some basic usage quota
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(
         storage => 100000,
         message => 50000,
         mailbox => 100,
     );
 
-    $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane.#calendars');
+    $self->set_quotalimits(
         storage => 10000,
         message => 5000,
         mailbox => 10,

--- a/cassandane/tiny-tests/JMAPQuota/quota_query
+++ b/cassandane/tiny-tests/JMAPQuota/quota_query
@@ -34,14 +34,14 @@ EOF
 
     # Right - let's set ourselves some basic usage quota
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 100000,
         message => 50000,
         mailbox => 100,
     );
 
     $self->_set_quotaroot('user.cassandane.#calendars');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 10000,
         message => 5000,
         mailbox => 10,

--- a/cassandane/tiny-tests/Quota/bug3735
+++ b/cassandane/tiny-tests/Quota/bug3735
@@ -8,9 +8,9 @@ sub test_bug3735
     $self->{instance}->create_user("a");
     $self->{instance}->create_user("ab");
     $self->_set_quotaroot('user.a');
-    $self->_set_limits(storage => 12345);
+    $self->_set_quotalimits(storage => 12345);
     $self->_set_quotaroot('user.ab');
-    $self->_set_limits(storage => 12345);
+    $self->_set_quotalimits(storage => 12345);
 
     my $filename = $self->{instance}->{basedir} . "/bug3735.out";
 

--- a/cassandane/tiny-tests/Quota/bug3735
+++ b/cassandane/tiny-tests/Quota/bug3735
@@ -7,10 +7,10 @@ sub test_bug3735
     my ($self) = @_;
     $self->{instance}->create_user("a");
     $self->{instance}->create_user("ab");
-    $self->_set_quotaroot('user.a');
-    $self->_set_quotalimits(storage => 12345);
-    $self->_set_quotaroot('user.ab');
-    $self->_set_quotalimits(storage => 12345);
+    $self->set_quotaroot('user.a');
+    $self->set_quotalimits(storage => 12345);
+    $self->set_quotaroot('user.ab');
+    $self->set_quotalimits(storage => 12345);
 
     my $filename = $self->{instance}->{basedir} . "/bug3735.out";
 

--- a/cassandane/tiny-tests/Quota/bz3529
+++ b/cassandane/tiny-tests/Quota/bz3529
@@ -18,7 +18,7 @@ sub test_bz3529
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => 0);
 
     xlog $self, "make some messages to hang annotations on";

--- a/cassandane/tiny-tests/Quota/bz3529
+++ b/cassandane/tiny-tests/Quota/bz3529
@@ -14,12 +14,12 @@ sub test_bz3529
     $self->assert_str_equals('quotalegacy', $backend)
         if defined $backend;        # the default value is also ok
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
 
     xlog $self, "make some messages to hang annotations on";
 #       $self->{store}->set_folder($folder);
@@ -37,10 +37,10 @@ sub test_bz3529
     $self->assert_str_equals('ok', $talk->get_last_completion_response());
 
     my $expected = ($uid-1) * length($data);
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     # delete annotations
     $talk->store('1:*', 'annotation', ['/comment', ['value.priv', undef]]);
     $self->assert_str_equals('ok', $talk->get_last_completion_response());
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->check_usages($self->res_annot_storage => 0);
 }

--- a/cassandane/tiny-tests/Quota/deleted_storage
+++ b/cassandane/tiny-tests/Quota/deleted_storage
@@ -6,10 +6,10 @@ sub test_deleted_storage
     my ($self) = @_;
 
     xlog $self, "test DELETED and DELETED-STORAGE STATUS items";
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(storage => 100000);
-    $self->_check_usages(storage => 0);
+    $self->set_quotalimits(storage => 100000);
+    $self->check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 
     # append some messages
@@ -21,7 +21,7 @@ sub test_deleted_storage
         my $len = length($msg->as_string());
         $expected += $len;
         xlog $self, "added $len bytes of message";
-        $self->_check_usages(storage => int($expected/1024));
+        $self->check_usages(storage => int($expected/1024));
     }
 
     # delete messages
@@ -46,5 +46,5 @@ sub test_deleted_storage
     $self->assert_num_equals(0, $res->{'size'});
     $self->assert_num_equals(0, $res->{'deleted-storage'});
 
-    $self->_check_usages(storage => 0);
+    $self->check_usages(storage => 0);
 }

--- a/cassandane/tiny-tests/Quota/deleted_storage
+++ b/cassandane/tiny-tests/Quota/deleted_storage
@@ -8,7 +8,7 @@ sub test_deleted_storage
     xlog $self, "test DELETED and DELETED-STORAGE STATUS items";
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(storage => 100000);
+    $self->_set_quotalimits(storage => 100000);
     $self->_check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/exceeding_message
+++ b/cassandane/tiny-tests/Quota/exceeding_message
@@ -11,7 +11,7 @@ sub test_exceeding_message
 
     xlog $self, "set a low limit";
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(message => 10);
+    $self->_set_quotalimits(message => 10);
     $self->_check_usages(message => 0);
 
     xlog $self, "adding messages to get just below the limit";

--- a/cassandane/tiny-tests/Quota/exceeding_message
+++ b/cassandane/tiny-tests/Quota/exceeding_message
@@ -10,9 +10,9 @@ sub test_exceeding_message
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set a low limit";
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(message => 10);
-    $self->_check_usages(message => 0);
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(message => 10);
+    $self->check_usages(message => 0);
 
     xlog $self, "adding messages to get just below the limit";
     my %msgs;
@@ -23,7 +23,7 @@ sub test_exceeding_message
     xlog $self, "check that the messages are all in the mailbox";
     $self->check_messages(\%msgs);
     xlog $self, "check that the usage is just below the limit";
-    $self->_check_usages(message => 10);
+    $self->check_usages(message => 10);
 
     xlog $self, "add a message that exceeds the limit";
     my $overmsg = eval { $self->make_message("Message 11") };
@@ -41,6 +41,6 @@ sub test_exceeding_message
     }
 
     xlog $self, "check that the exceeding message is not in the mailbox";
-    $self->_check_usages(message => 10);
+    $self->check_usages(message => 10);
     $self->check_messages(\%msgs);
 }

--- a/cassandane/tiny-tests/Quota/exceeding_storage
+++ b/cassandane/tiny-tests/Quota/exceeding_storage
@@ -11,7 +11,7 @@ sub test_exceeding_storage
 
     xlog $self, "set a low limit";
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(storage => 210);
+    $self->_set_quotalimits(storage => 210);
     $self->_check_usages(storage => 0);
 
     xlog $self, "adding messages to get just below the limit";

--- a/cassandane/tiny-tests/Quota/exceeding_storage
+++ b/cassandane/tiny-tests/Quota/exceeding_storage
@@ -10,9 +10,9 @@ sub test_exceeding_storage
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set a low limit";
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(storage => 210);
-    $self->_check_usages(storage => 0);
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 210);
+    $self->check_usages(storage => 0);
 
     xlog $self, "adding messages to get just below the limit";
     my %msgs;
@@ -36,7 +36,7 @@ sub test_exceeding_storage
     xlog $self, "check that the messages are all in the mailbox";
     $self->check_messages(\%msgs);
     xlog $self, "check that the usage is just below the limit";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'OK');
 
     xlog $self, "add a message that exceeds the limit";
@@ -52,6 +52,6 @@ sub test_exceeding_storage
     $self->check_messages(\%msgs);
 
     xlog $self, "check that the quota usage is still the same";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'OK');
 }

--- a/cassandane/tiny-tests/Quota/move_near_limit
+++ b/cassandane/tiny-tests/Quota/move_near_limit
@@ -11,7 +11,7 @@ sub test_move_near_limit
 
     xlog $self, "set a low limit";
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(storage => 210);
+    $self->_set_quotalimits(storage => 210);
     $self->_check_usages(storage => 0);
 
     xlog $self, "adding messages to get just below the limit";

--- a/cassandane/tiny-tests/Quota/move_near_limit
+++ b/cassandane/tiny-tests/Quota/move_near_limit
@@ -10,9 +10,9 @@ sub test_move_near_limit
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set a low limit";
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(storage => 210);
-    $self->_check_usages(storage => 0);
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 210);
+    $self->check_usages(storage => 0);
 
     xlog $self, "adding messages to get just below the limit";
     my %msgs;
@@ -36,7 +36,7 @@ sub test_move_near_limit
     xlog $self, "check that the messages are all in the mailbox";
     $self->check_messages(\%msgs);
     xlog $self, "check that the usage is just below the limit";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'OK');
 
     xlog $self, "add a message that exceeds the limit";

--- a/cassandane/tiny-tests/Quota/num_folders_delete_delayed
+++ b/cassandane/tiny-tests/Quota/num_folders_delete_delayed
@@ -6,7 +6,7 @@ sub test_num_folders_delete_delayed
 {
     my ($self) = @_;
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(storage => 12345, $self->res_mailbox => 500);
+    $self->_set_quotalimits(storage => 12345, $self->res_mailbox => 500);
 
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/num_folders_delete_delayed
+++ b/cassandane/tiny-tests/Quota/num_folders_delete_delayed
@@ -5,20 +5,20 @@ sub test_num_folders_delete_delayed
     :DelayedDelete
 {
     my ($self) = @_;
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(storage => 12345, $self->res_mailbox => 500);
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 12345, $self->res_mailbox => 500);
 
     my $talk = $self->{store}->get_client();
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 2);
+    $self->check_usages(storage => 0, $self->res_mailbox => 2);
 
     $talk->create("INBOX.another");
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 3);
+    $self->check_usages(storage => 0, $self->res_mailbox => 3);
 
     $talk->delete("INBOX.another");
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 2);
+    $self->check_usages(storage => 0, $self->res_mailbox => 2);
 }

--- a/cassandane/tiny-tests/Quota/num_folders_delete_immediate
+++ b/cassandane/tiny-tests/Quota/num_folders_delete_immediate
@@ -4,20 +4,20 @@ use Cassandane::Tiny;
 sub test_num_folders_delete_immediate
 {
     my ($self) = @_;
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(storage => 12345, $self->res_mailbox => 500);
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 12345, $self->res_mailbox => 500);
 
     my $talk = $self->{store}->get_client();
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 2);
+    $self->check_usages(storage => 0, $self->res_mailbox => 2);
 
     $talk->create("INBOX.another");
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 3);
+    $self->check_usages(storage => 0, $self->res_mailbox => 3);
 
     $talk->delete("INBOX.another");
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 2);
+    $self->check_usages(storage => 0, $self->res_mailbox => 2);
 }

--- a/cassandane/tiny-tests/Quota/num_folders_delete_immediate
+++ b/cassandane/tiny-tests/Quota/num_folders_delete_immediate
@@ -5,7 +5,7 @@ sub test_num_folders_delete_immediate
 {
     my ($self) = @_;
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(storage => 12345, $self->res_mailbox => 500);
+    $self->_set_quotalimits(storage => 12345, $self->res_mailbox => 500);
 
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/num_folders_rename
+++ b/cassandane/tiny-tests/Quota/num_folders_rename
@@ -4,20 +4,20 @@ use Cassandane::Tiny;
 sub test_num_folders_rename
 {
     my ($self) = @_;
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(storage => 12345, $self->res_mailbox => 500);
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 12345, $self->res_mailbox => 500);
 
     my $talk = $self->{store}->get_client();
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 2);
+    $self->check_usages(storage => 0, $self->res_mailbox => 2);
 
     $talk->create("INBOX.another");
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 3);
+    $self->check_usages(storage => 0, $self->res_mailbox => 3);
 
     $talk->rename("INBOX.another", "INBOX.out");
 
-    $self->_check_usages(storage => 0, $self->res_mailbox => 3);
+    $self->check_usages(storage => 0, $self->res_mailbox => 3);
 }

--- a/cassandane/tiny-tests/Quota/num_folders_rename
+++ b/cassandane/tiny-tests/Quota/num_folders_rename
@@ -5,7 +5,7 @@ sub test_num_folders_rename
 {
     my ($self) = @_;
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(storage => 12345, $self->res_mailbox => 500);
+    $self->_set_quotalimits(storage => 12345, $self->res_mailbox => 500);
 
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/overquota
+++ b/cassandane/tiny-tests/Quota/overquota
@@ -10,9 +10,9 @@ sub test_overquota
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set a low limit";
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(storage => 210);
-    $self->_check_usages(storage => 0);
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 210);
+    $self->check_usages(storage => 0);
 
     xlog $self, "adding messages to get just below the limit";
     my %msgs;
@@ -36,14 +36,14 @@ sub test_overquota
     xlog $self, "check that the messages are all in the mailbox";
     $self->check_messages(\%msgs);
     xlog $self, "check that the usage is just below the limit";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'OK');
 
     xlog $self, "reduce the quota limit";
-    $self->_set_quotalimits(storage => 100);
+    $self->set_quotalimits(storage => 100);
 
     xlog $self, "check that usage is unchanged";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
     xlog $self, "check that smmap reports over quota";
     $self->_check_smmap('cassandane', 'TEMP');
 
@@ -62,7 +62,7 @@ sub test_overquota
     $self->check_messages(\%msgs);
 
     xlog $self, "check that the quota usage is still unchanged";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'TEMP');
 
     my $delmsg = delete $msgs{1};
@@ -77,7 +77,7 @@ sub test_overquota
 
     xlog $self, "check that the usage has gone down";
     $expected -= $dellen;
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
 
     xlog $self, "check that we are still over quota";
     $self->_check_smmap('cassandane', 'TEMP');

--- a/cassandane/tiny-tests/Quota/overquota
+++ b/cassandane/tiny-tests/Quota/overquota
@@ -11,7 +11,7 @@ sub test_overquota
 
     xlog $self, "set a low limit";
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(storage => 210);
+    $self->_set_quotalimits(storage => 210);
     $self->_check_usages(storage => 0);
 
     xlog $self, "adding messages to get just below the limit";
@@ -40,7 +40,7 @@ sub test_overquota
     $self->_check_smmap('cassandane', 'OK');
 
     xlog $self, "reduce the quota limit";
-    $self->_set_limits(storage => 100);
+    $self->_set_quotalimits(storage => 100);
 
     xlog $self, "check that usage is unchanged";
     $self->_check_usages(storage => int($expected/1024));

--- a/cassandane/tiny-tests/Quota/quota_d
+++ b/cassandane/tiny-tests/Quota/quota_d
@@ -17,7 +17,7 @@ sub test_quota_d
 
     foreach my $user (@users) {
         $admintalk->create("user/$user");
-        $self->_set_limits(
+        $self->_set_quotalimits(
             quotaroot => "user/$user",
             storage => 100000,
             message => 50000,

--- a/cassandane/tiny-tests/Quota/quota_d
+++ b/cassandane/tiny-tests/Quota/quota_d
@@ -17,7 +17,7 @@ sub test_quota_d
 
     foreach my $user (@users) {
         $admintalk->create("user/$user");
-        $self->_set_quotalimits(
+        $self->set_quotalimits(
             quotaroot => "user/$user",
             storage => 100000,
             message => 50000,

--- a/cassandane/tiny-tests/Quota/quota_f
+++ b/cassandane/tiny-tests/Quota/quota_f
@@ -8,13 +8,13 @@ sub test_quota_f
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic usage quota";
-    $self->_set_quotalimits(
+    $self->set_quotalimits(
         quotaroot => 'user.cassandane',
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 10000,
     );
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.cassandane',
         storage => 0,
         message => 0,
@@ -23,7 +23,7 @@ sub test_quota_f
 
     xlog $self, "create some messages to use various quota resources";
     $self->{instance}->create_user("quotafuser");
-    $self->_set_quotalimits(
+    $self->set_quotalimits(
         quotaroot => 'user.quotafuser',
         storage => 100000,
         message => 50000,
@@ -55,13 +55,13 @@ sub test_quota_f
     $admintalk->setmetadata('user.cassandane', '/private/comment', { Quote => $annotation });
 
     xlog $self, "check usages";
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.quotafuser',
         storage => int($quotafuser_expected_storage/1024),
         message => $quotafuser_expected_message,
         $self->res_annot_storage => int($quotafuser_expected_annotation_storage/1024),
     );
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.cassandane',
         storage => int($cassandane_expected_storage/1024),
         message => $cassandane_expected_message,
@@ -69,16 +69,16 @@ sub test_quota_f
     );
 
     xlog $self, "create a bogus quota file";
-    $self->_zap_quota(quotaroot => 'user.quotafuser');
+    $self->zap_quota(quotaroot => 'user.quotafuser');
 
     xlog $self, "check usages";
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.quotafuser',
         storage => 0,
         message => 0,
         $self->res_annot_storage => 0,
     );
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.cassandane',
         storage => int($cassandane_expected_storage/1024),
         message => $cassandane_expected_message,
@@ -89,13 +89,13 @@ sub test_quota_f
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f');
 
     xlog $self, "check usages";
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.quotafuser',
         storage => int($quotafuser_expected_storage/1024),
         message => $quotafuser_expected_message,
         $self->res_annot_storage => int($quotafuser_expected_annotation_storage/1024),
     );
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.cassandane',
         storage => int($cassandane_expected_storage/1024),
         message => $cassandane_expected_message,
@@ -106,13 +106,13 @@ sub test_quota_f
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f');
 
     xlog $self, "check usages";
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.quotafuser',
         storage => int($quotafuser_expected_storage/1024),
         message => $quotafuser_expected_message,
         $self->res_annot_storage => int($quotafuser_expected_annotation_storage/1024),
     );
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user.cassandane',
         storage => int($cassandane_expected_storage/1024),
         message => $cassandane_expected_message,

--- a/cassandane/tiny-tests/Quota/quota_f
+++ b/cassandane/tiny-tests/Quota/quota_f
@@ -8,7 +8,7 @@ sub test_quota_f
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic usage quota";
-    $self->_set_limits(
+    $self->_set_quotalimits(
         quotaroot => 'user.cassandane',
         storage => 100000,
         message => 50000,
@@ -23,7 +23,7 @@ sub test_quota_f
 
     xlog $self, "create some messages to use various quota resources";
     $self->{instance}->create_user("quotafuser");
-    $self->_set_limits(
+    $self->_set_quotalimits(
         quotaroot => 'user.quotafuser',
         storage => 100000,
         message => 50000,

--- a/cassandane/tiny-tests/Quota/quota_f_nested_qr
+++ b/cassandane/tiny-tests/Quota/quota_f_nested_qr
@@ -31,14 +31,14 @@ sub test_quota_f_nested_qr
     }
 
     xlog $self, "set a quota on inbox";
-    $self->_set_limits(quotaroot => $inbox, storage => 100000);
+    $self->_set_quotalimits(quotaroot => $inbox, storage => 100000);
 
     xlog $self, "should have correct STORAGE quota";
     my $ex0 = $exp{$inbox} + $exp{"$inbox.aaa"} + $exp{"$inbox.nnn"} + $exp{"$inbox.zzz"};
     $self->_check_usages(quotaroot => $inbox, storage => int($ex0/1024));
 
     xlog $self, "set a quota on inbox.nnn - a nested quotaroot";
-    $self->_set_limits(quotaroot => "$inbox.nnn", storage => 200000);
+    $self->_set_quotalimits(quotaroot => "$inbox.nnn", storage => 200000);
 
     xlog $self, "should have correct STORAGE quota for both roots";
     my $ex1 = $exp{$inbox} + $exp{"$inbox.aaa"} + $exp{"$inbox.zzz"};

--- a/cassandane/tiny-tests/Quota/quota_f_nested_qr
+++ b/cassandane/tiny-tests/Quota/quota_f_nested_qr
@@ -31,38 +31,38 @@ sub test_quota_f_nested_qr
     }
 
     xlog $self, "set a quota on inbox";
-    $self->_set_quotalimits(quotaroot => $inbox, storage => 100000);
+    $self->set_quotalimits(quotaroot => $inbox, storage => 100000);
 
     xlog $self, "should have correct STORAGE quota";
     my $ex0 = $exp{$inbox} + $exp{"$inbox.aaa"} + $exp{"$inbox.nnn"} + $exp{"$inbox.zzz"};
-    $self->_check_usages(quotaroot => $inbox, storage => int($ex0/1024));
+    $self->check_usages(quotaroot => $inbox, storage => int($ex0/1024));
 
     xlog $self, "set a quota on inbox.nnn - a nested quotaroot";
-    $self->_set_quotalimits(quotaroot => "$inbox.nnn", storage => 200000);
+    $self->set_quotalimits(quotaroot => "$inbox.nnn", storage => 200000);
 
     xlog $self, "should have correct STORAGE quota for both roots";
     my $ex1 = $exp{$inbox} + $exp{"$inbox.aaa"} + $exp{"$inbox.zzz"};
     my $ex2 = $exp{"$inbox.nnn"};
-    $self->_check_usages(quotaroot => $inbox, storage => int($ex1/1024));
-    $self->_check_usages(quotaroot => "$inbox.nnn", storage => int($ex2/1024));
+    $self->check_usages(quotaroot => $inbox, storage => int($ex1/1024));
+    $self->check_usages(quotaroot => "$inbox.nnn", storage => int($ex2/1024));
 
     xlog $self, "create a bogus quota file";
-    $self->_zap_quota(quotaroot => $inbox);
-    $self->_zap_quota(quotaroot => "$inbox.nnn");
-    $self->_check_usages(quotaroot => $inbox, storage => 0);
-    $self->_check_usages(quotaroot => "$inbox.nnn", storage => 0);
+    $self->zap_quota(quotaroot => $inbox);
+    $self->zap_quota(quotaroot => "$inbox.nnn");
+    $self->check_usages(quotaroot => $inbox, storage => 0);
+    $self->check_usages(quotaroot => "$inbox.nnn", storage => 0);
 
     xlog $self, "run quota -f to find and add the quota";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f');
 
     xlog $self, "check that STORAGE quota is restored for both roots";
-    $self->_check_usages(quotaroot => $inbox, storage => int($ex1/1024));
-    $self->_check_usages(quotaroot => "$inbox.nnn", storage => int($ex2/1024));
+    $self->check_usages(quotaroot => $inbox, storage => int($ex1/1024));
+    $self->check_usages(quotaroot => "$inbox.nnn", storage => int($ex2/1024));
 
     xlog $self, "run quota -f again";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f');
 
     xlog $self, "check that STORAGE quota is still correct for both roots";
-    $self->_check_usages(quotaroot => $inbox, storage => int($ex1/1024));
-    $self->_check_usages(quotaroot => "$inbox.nnn", storage => int($ex2/1024));
+    $self->check_usages(quotaroot => $inbox, storage => int($ex1/1024));
+    $self->check_usages(quotaroot => "$inbox.nnn", storage => int($ex2/1024));
 }

--- a/cassandane/tiny-tests/Quota/quota_f_prefix
+++ b/cassandane/tiny-tests/Quota/quota_f_prefix
@@ -18,7 +18,7 @@ sub test_quota_f_prefix
 
     $self->{instance}->create_user("base",
                                    subdirs => [ qw(subdir subdir2) ]);
-    $self->_set_limits(quotaroot => 'user.base', storage => 1000000);
+    $self->_set_quotalimits(quotaroot => 'user.base', storage => 1000000);
     my $exp_base = 0;
 
     xlog $self, "Adding messages to user.base";
@@ -41,7 +41,7 @@ sub test_quota_f_prefix
 
     $self->{instance}->create_user("baseplus",
                                    subdirs => [ qw(subdir) ]);
-    $self->_set_limits(quotaroot => 'user.baseplus', storage => 1000000);
+    $self->_set_quotalimits(quotaroot => 'user.baseplus', storage => 1000000);
     my $exp_baseplus = 0;
 
     xlog $self, "Adding messages to user.baseplus";

--- a/cassandane/tiny-tests/Quota/quota_f_prefix
+++ b/cassandane/tiny-tests/Quota/quota_f_prefix
@@ -18,7 +18,7 @@ sub test_quota_f_prefix
 
     $self->{instance}->create_user("base",
                                    subdirs => [ qw(subdir subdir2) ]);
-    $self->_set_quotalimits(quotaroot => 'user.base', storage => 1000000);
+    $self->set_quotalimits(quotaroot => 'user.base', storage => 1000000);
     my $exp_base = 0;
 
     xlog $self, "Adding messages to user.base";
@@ -41,7 +41,7 @@ sub test_quota_f_prefix
 
     $self->{instance}->create_user("baseplus",
                                    subdirs => [ qw(subdir) ]);
-    $self->_set_quotalimits(quotaroot => 'user.baseplus', storage => 1000000);
+    $self->set_quotalimits(quotaroot => 'user.baseplus', storage => 1000000);
     my $exp_baseplus = 0;
 
     xlog $self, "Adding messages to user.baseplus";
@@ -63,110 +63,110 @@ sub test_quota_f_prefix
     }
 
     xlog $self, "Check that the quotas were updated as expected";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($exp_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($exp_baseplus/1024));
 
     xlog $self, "Run quota -f";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f');
 
     xlog $self, "Check that the quotas were unchanged by quota -f";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($exp_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($exp_baseplus/1024));
 
     my $bogus_base = $exp_base + 20000 + rand(30000);
     my $bogus_baseplus = $exp_baseplus + 50000 + rand(80000);
     xlog $self, "Write incorrect values to the quota db";
-    $self->_zap_quota(quotaroot => 'user.base',
+    $self->zap_quota(quotaroot => 'user.base',
                       useds => { storage => $bogus_base });
-    $self->_zap_quota(quotaroot => 'user.baseplus',
+    $self->zap_quota(quotaroot => 'user.baseplus',
                       useds => { storage => $bogus_baseplus });
 
     xlog $self, "Check that the quotas are now bogus";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($bogus_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($bogus_baseplus/1024));
 
     xlog $self, "Run quota -f with no prefix";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f');
 
     xlog $self, "Check that the quotas were all fixed";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($exp_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($exp_baseplus/1024));
 
     xlog $self, "Write incorrect values to the quota db";
-    $self->_zap_quota(quotaroot => "user.base",
+    $self->zap_quota(quotaroot => "user.base",
                       useds => { storage => $bogus_base });
-    $self->_zap_quota(quotaroot => "user.baseplus",
+    $self->zap_quota(quotaroot => "user.baseplus",
                       useds => { storage => $bogus_baseplus });
 
     xlog $self, "Check that the quotas are now bogus";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($bogus_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($bogus_baseplus/1024));
 
     xlog $self, "Run quota -f on user.base only";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f', 'user.base');
 
     xlog $self, "Check that only the user.base and user.baseplus quotas were fixed";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($exp_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($exp_baseplus/1024));
 
     xlog $self, "Write incorrect values to the quota db";
-    $self->_zap_quota(quotaroot => "user.base",
+    $self->zap_quota(quotaroot => "user.base",
                       useds => { storage => $bogus_base });
-    $self->_zap_quota(quotaroot => "user.baseplus",
+    $self->zap_quota(quotaroot => "user.baseplus",
                       useds => { storage => $bogus_baseplus });
 
     xlog $self, "Check that the quotas are now bogus";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($bogus_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($bogus_baseplus/1024));
 
     xlog $self, "Run quota -f on user.baseplus only";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f', 'user.baseplus');
 
     xlog $self, "Check that only the user.baseplus quotas were fixed";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($bogus_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($exp_baseplus/1024));
 
     xlog $self, "Write incorrect values to the quota db";
-    $self->_zap_quota(quotaroot => "user.base",
+    $self->zap_quota(quotaroot => "user.base",
                       useds => { storage => $bogus_base });
-    $self->_zap_quota(quotaroot => "user.baseplus",
+    $self->zap_quota(quotaroot => "user.baseplus",
                       useds => { storage => $bogus_baseplus });
 
     xlog $self, "Check that the quotas are now bogus";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($bogus_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($bogus_baseplus/1024));
 
     xlog $self, "Run quota -f -u on user base ";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f', '-u', 'base');
 
     xlog $self, "Check that only the user base quotas were fixed";
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($exp_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($bogus_baseplus/1024));
 
     xlog $self, "Run a final quota -f to fix up everything";
     $self->{instance}->run_command({ cyrus => 1 }, 'quota', '-f');
-    $self->_check_usages(quotaroot => 'user.base',
+    $self->check_usages(quotaroot => 'user.base',
                          storage => int($exp_base/1024));
-    $self->_check_usages(quotaroot => 'user.baseplus',
+    $self->check_usages(quotaroot => 'user.baseplus',
                          storage => int($exp_baseplus/1024));
 }

--- a/cassandane/tiny-tests/Quota/quota_f_unixhs
+++ b/cassandane/tiny-tests/Quota/quota_f_unixhs
@@ -9,7 +9,7 @@ sub test_quota_f_unixhs
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic usage quota";
-    $self->_set_limits(
+    $self->_set_quotalimits(
         quotaroot => 'user/cassandane',
         storage => 100000,
         message => 50000,

--- a/cassandane/tiny-tests/Quota/quota_f_unixhs
+++ b/cassandane/tiny-tests/Quota/quota_f_unixhs
@@ -9,13 +9,13 @@ sub test_quota_f_unixhs
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic usage quota";
-    $self->_set_quotalimits(
+    $self->set_quotalimits(
         quotaroot => 'user/cassandane',
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 10000,
     );
-    $self->_check_usages(
+    $self->check_usages(
         quotaroot => 'user/cassandane',
         storage => 0,
         message => 0,

--- a/cassandane/tiny-tests/Quota/quota_f_vs_update
+++ b/cassandane/tiny-tests/Quota/quota_f_vs_update
@@ -13,9 +13,9 @@ sub test_quota_f_vs_update
     my $expected;
 
     xlog $self, "Set up a large but limited quota";
-    $self->_set_quotaroot($basefolder);
-    $self->_set_quotalimits(storage => 1000000);
-    $self->_check_usages(storage => 0);
+    $self->set_quotaroot($basefolder);
+    $self->set_quotalimits(storage => 1000000);
+    $self->check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 
     xlog $self, "Create some sub folders";
@@ -31,7 +31,7 @@ sub test_quota_f_vs_update
     $talk->unselect();
 
     xlog $self, "Check that we have some quota usage";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
 
     xlog $self, "Start a quota -f scan";
     $self->{instance}->quota_Z_go($basefolder);
@@ -67,5 +67,5 @@ sub test_quota_f_vs_update
     $self->{instance}->reap_command(@bits);
 
     xlog $self, "Check that we have the correct quota usage";
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/quota_f_vs_update
+++ b/cassandane/tiny-tests/Quota/quota_f_vs_update
@@ -14,7 +14,7 @@ sub test_quota_f_vs_update
 
     xlog $self, "Set up a large but limited quota";
     $self->_set_quotaroot($basefolder);
-    $self->_set_limits(storage => 1000000);
+    $self->_set_quotalimits(storage => 1000000);
     $self->_check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/quotarename
+++ b/cassandane/tiny-tests/Quota/quotarename
@@ -12,13 +12,13 @@ sub test_quotarename
     my $talk = $self->{store}->get_client();
 
     # Right - let's set ourselves a basic usage quota
-    $self->_set_quotaroot('user.cassandane');
-    $self->_set_quotalimits(
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 10000,
     );
-    $self->_check_usages(
+    $self->check_usages(
         storage => 0,
         message => 0,
         $self->res_annot_storage => 0,
@@ -40,7 +40,7 @@ sub test_quotarename
         $uid++;
     }
 
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),
@@ -69,7 +69,7 @@ sub test_quotarename
     $self->{store}->set_folder("INBOX");
     $talk->select($self->{store}->{folder}) || die;
 
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage_more/1024),
         message => $expected_message_more,
         $self->res_annot_storage => int($expected_annotation_storage_more/1024),
@@ -79,7 +79,7 @@ sub test_quotarename
     $talk->select("INBOX.othersub") || die;
 
     # usage should be the same after a rename
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage_more/1024),
         message => $expected_message_more,
         $self->res_annot_storage => int($expected_annotation_storage_more/1024),
@@ -87,7 +87,7 @@ sub test_quotarename
 
     $talk->delete("INBOX.othersub") || die;
 
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),

--- a/cassandane/tiny-tests/Quota/quotarename
+++ b/cassandane/tiny-tests/Quota/quotarename
@@ -13,7 +13,7 @@ sub test_quotarename
 
     # Right - let's set ourselves a basic usage quota
     $self->_set_quotaroot('user.cassandane');
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 10000,

--- a/cassandane/tiny-tests/Quota/reconstruct
+++ b/cassandane/tiny-tests/Quota/reconstruct
@@ -22,7 +22,7 @@ sub test_reconstruct
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 100000,

--- a/cassandane/tiny-tests/Quota/reconstruct
+++ b/cassandane/tiny-tests/Quota/reconstruct
@@ -7,7 +7,7 @@ sub test_reconstruct
 
     xlog $self, "test resources usage calculated when reconstructing an index";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $folder = 'INBOX';
     my $fentry = '/private/comment';
     my $mentry1 = '/comment';
@@ -22,12 +22,12 @@ sub test_reconstruct
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(
+    $self->set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 100000,
     );
-    $self->_check_usages(
+    $self->check_usages(
         storage => 0,
         message => 0,
         $self->res_annot_storage => 0,
@@ -76,7 +76,7 @@ sub test_reconstruct
     }, $res);
 
     xlog $self, "Check the quota usage is as expected";
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),
@@ -114,7 +114,7 @@ sub test_reconstruct
     }, $res);
 
     xlog $self, "Check the quota usage is still as expected";
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),

--- a/cassandane/tiny-tests/Quota/reconstruct_orphans
+++ b/cassandane/tiny-tests/Quota/reconstruct_orphans
@@ -8,7 +8,7 @@ sub test_reconstruct_orphans
     xlog $self, "test resources usage calculated when reconstructing an index";
     xlog $self, "with messages disappearing, resulting in orphan annotations";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $folder = 'INBOX';
     my $fentry = '/private/comment';
     my $mentry1 = '/comment';
@@ -23,12 +23,12 @@ sub test_reconstruct_orphans
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(
+    $self->set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 100000,
     );
-    $self->_check_usages(
+    $self->check_usages(
         storage => 0,
         message => 0,
         $self->res_annot_storage => 0,
@@ -77,7 +77,7 @@ sub test_reconstruct_orphans
     }, $res);
 
     xlog $self, "Check the quota usage is as expected";
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),
@@ -130,7 +130,7 @@ sub test_reconstruct_orphans
     }, $res);
 
     xlog $self, "Check the quota usage is still as expected";
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),

--- a/cassandane/tiny-tests/Quota/reconstruct_orphans
+++ b/cassandane/tiny-tests/Quota/reconstruct_orphans
@@ -23,7 +23,7 @@ sub test_reconstruct_orphans
     my $admintalk = $self->{adminstore}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 100000,

--- a/cassandane/tiny-tests/Quota/rename_withannot
+++ b/cassandane/tiny-tests/Quota/rename_withannot
@@ -29,7 +29,7 @@ sub test_rename_withannot
     $store->set_folder($src);
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(
+    $self->_set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 100000,

--- a/cassandane/tiny-tests/Quota/rename_withannot
+++ b/cassandane/tiny-tests/Quota/rename_withannot
@@ -8,7 +8,7 @@ sub test_rename_withannot
 
     xlog $self, "test resources usage survives rename";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $src = 'INBOX.src';
     my $dest = 'INBOX.dest';
     my $fentry = '/private/comment';
@@ -29,12 +29,12 @@ sub test_rename_withannot
     $store->set_folder($src);
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(
+    $self->set_quotalimits(
         storage => 100000,
         message => 50000,
         $self->res_annot_storage => 100000,
     );
-    $self->_check_usages(
+    $self->check_usages(
         storage => 0,
         message => 0,
         $self->res_annot_storage => 0,
@@ -101,7 +101,7 @@ sub test_rename_withannot
     }, $res);
 
     xlog $self, "Check the quota usage is as expected";
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),
@@ -142,7 +142,7 @@ sub test_rename_withannot
     }
 
     xlog $self, "Check the quota usage is still as expected";
-    $self->_check_usages(
+    $self->check_usages(
         storage => int($expected_storage/1024),
         message => $expected_message,
         $self->res_annot_storage => int($expected_annotation_storage/1024),

--- a/cassandane/tiny-tests/Quota/storage_convquota_delayed
+++ b/cassandane/tiny-tests/Quota/storage_convquota_delayed
@@ -9,7 +9,7 @@ sub test_storage_convquota_delayed
     xlog $self, "test increasing usage of the STORAGE quota resource as messages are added";
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(storage => 100000);
+    $self->_set_quotalimits(storage => 100000);
     $self->_check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/storage_convquota_delayed
+++ b/cassandane/tiny-tests/Quota/storage_convquota_delayed
@@ -7,10 +7,10 @@ sub test_storage_convquota_delayed
     my ($self) = @_;
 
     xlog $self, "test increasing usage of the STORAGE quota resource as messages are added";
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(storage => 100000);
-    $self->_check_usages(storage => 0);
+    $self->set_quotalimits(storage => 100000);
+    $self->check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 
     my $KEY = "/shared/vendor/cmu/cyrus-imapd/userrawquota";
@@ -31,7 +31,7 @@ sub test_storage_convquota_delayed
     my $data1 = $talk->getmetadata("INBOX", $KEY);
     my ($rawusage1) = $data1->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
 
-    $self->_check_usages(storage => int(($size1+$size2)/1024));
+    $self->check_usages(storage => int(($size1+$size2)/1024));
     $self->assert_num_equals(int(($size1+$size2)/1024), $rawusage1);
 
     $talk->select("INBOX");
@@ -41,7 +41,7 @@ sub test_storage_convquota_delayed
     my ($rawusage2) = $data2->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
 
     # quota usage hasn't changed, because we don't get double-charged
-    $self->_check_usages(storage => int(($size1+$size2)/1024));
+    $self->check_usages(storage => int(($size1+$size2)/1024));
     # but raw usage has gone up by another copy of message 1
     $self->assert_num_equals(int(($size1+$size2+$size1)/1024), $rawusage2);
 
@@ -51,7 +51,7 @@ sub test_storage_convquota_delayed
     my ($rawusage3) = $data3->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
 
     # we just lost all copies of message2
-    $self->_check_usages(storage => int($size1/1024));
+    $self->check_usages(storage => int($size1/1024));
     # and also the second copy of message1, so just size1 left
     $self->assert_num_equals(int($size1/1024), $rawusage3);
 }

--- a/cassandane/tiny-tests/Quota/storage_convquota_immediate
+++ b/cassandane/tiny-tests/Quota/storage_convquota_immediate
@@ -9,7 +9,7 @@ sub test_storage_convquota_immediate
     xlog $self, "test increasing usage of the STORAGE quota resource as messages are added";
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(storage => 100000);
+    $self->_set_quotalimits(storage => 100000);
     $self->_check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/storage_convquota_immediate
+++ b/cassandane/tiny-tests/Quota/storage_convquota_immediate
@@ -7,10 +7,10 @@ sub test_storage_convquota_immediate
     my ($self) = @_;
 
     xlog $self, "test increasing usage of the STORAGE quota resource as messages are added";
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(storage => 100000);
-    $self->_check_usages(storage => 0);
+    $self->set_quotalimits(storage => 100000);
+    $self->check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 
     my $KEY = "/shared/vendor/cmu/cyrus-imapd/userrawquota";
@@ -31,7 +31,7 @@ sub test_storage_convquota_immediate
     my $data1 = $talk->getmetadata("INBOX", $KEY);
     my ($rawusage1) = $data1->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
 
-    $self->_check_usages(storage => int(($size1+$size2)/1024));
+    $self->check_usages(storage => int(($size1+$size2)/1024));
     $self->assert_num_equals(int(($size1+$size2)/1024), $rawusage1);
 
     $talk->select("INBOX");
@@ -41,7 +41,7 @@ sub test_storage_convquota_immediate
     my ($rawusage2) = $data2->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
 
     # quota usage hasn't changed, because we don't get double-charged
-    $self->_check_usages(storage => int(($size1+$size2)/1024));
+    $self->check_usages(storage => int(($size1+$size2)/1024));
     # but raw usage has gone up by another copy of message 1
     $self->assert_num_equals(int(($size1+$size2+$size1)/1024), $rawusage2);
 
@@ -51,7 +51,7 @@ sub test_storage_convquota_immediate
     my ($rawusage3) = $data3->{'INBOX'}{$KEY} =~ m/STORAGE (\d+)/;
 
     # we just lost all copies of message2
-    $self->_check_usages(storage => int($size1/1024));
+    $self->check_usages(storage => int($size1/1024));
     # and also the second copy of message1, so just size1 left
     $self->assert_num_equals(int($size1/1024), $rawusage3);
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_mbox
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_mbox
@@ -12,7 +12,7 @@ sub test_using_annotstorage_mbox
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => 0);
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";

--- a/cassandane/tiny-tests/Quota/using_annotstorage_mbox
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_mbox
@@ -8,12 +8,12 @@ sub test_using_annotstorage_mbox
     xlog $self, "test setting X-ANNOTATION-STORAGE quota resource after";
     xlog $self, "per-mailbox annotations are added";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
 
@@ -34,7 +34,7 @@ sub test_using_annotstorage_mbox
             $expecteds{$folder} += length($moredata);
             $expected += length($moredata);
             xlog $self, "EXPECTING $expected on $folder";
-            $self->_check_usages($self->res_annot_storage => int($expected/1024));
+            $self->check_usages($self->res_annot_storage => int($expected/1024));
         }
     }
 
@@ -42,7 +42,7 @@ sub test_using_annotstorage_mbox
     xlog $self, "Deleting a folder";
     $talk->delete("INBOX.sub") || die "Failed to delete subfolder";
     $expected -= delete($expecteds{"INBOX.sub"});
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     # delete remaining annotations
     $self->{store}->set_folder("INBOX");
@@ -50,5 +50,5 @@ sub test_using_annotstorage_mbox
     $self->assert_str_equals('ok', $talk->get_last_completion_response());
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_mbox_late
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_mbox_late
@@ -8,10 +8,10 @@ sub test_using_annotstorage_mbox_late
     xlog $self, "test increasing usage of the X-ANNOTATION-STORAGE quota";
     xlog $self, "resource as per-mailbox annotations are added";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
 
-    $self->_check_no_quota();
+    $self->check_no_quota();
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
 
@@ -34,13 +34,13 @@ sub test_using_annotstorage_mbox_late
         }
     }
 
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     # delete subfolder
     $talk->delete("INBOX.sub") || die "Failed to delete subfolder";
     $expected -= delete($expecteds{"INBOX.sub"});
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     # delete remaining annotations
     $self->{store}->set_folder("INBOX");
@@ -48,5 +48,5 @@ sub test_using_annotstorage_mbox_late
     $self->assert_str_equals('ok', $talk->get_last_completion_response());
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_mbox_late
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_mbox_late
@@ -34,7 +34,7 @@ sub test_using_annotstorage_mbox_late
         }
     }
 
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => int($expected/1024));
 
     # delete subfolder

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg
@@ -12,7 +12,7 @@ sub test_using_annotstorage_msg
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => 0);
 
     $talk->create("INBOX.sub1") || die "Failed to create subfolder";

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg
@@ -8,12 +8,12 @@ sub test_using_annotstorage_msg
     xlog $self, "test setting X-ANNOTATION-STORAGE quota resource after";
     xlog $self, "per-message annotations are added";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
 
     $talk->create("INBOX.sub1") || die "Failed to create subfolder";
     $talk->create("INBOX.sub2") || die "Failed to create subfolder";
@@ -36,7 +36,7 @@ sub test_using_annotstorage_msg
             $uid++;
             $expecteds{$folder} += length($data);
             $expected += length($data);
-            $self->_check_usages($self->res_annot_storage => int($expected/1024));
+            $self->check_usages($self->res_annot_storage => int($expected/1024));
         }
     }
 
@@ -44,7 +44,7 @@ sub test_using_annotstorage_msg
     $talk->delete("INBOX.sub1") || die "Failed to delete subfolder";
     $expected -= delete($expecteds{"INBOX.sub1"});
 
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "delete messages in sub2";
     $talk->select("INBOX.sub2");
@@ -55,13 +55,13 @@ sub test_using_annotstorage_msg
     $expected -= delete($expecteds{"INBOX.sub2"});
 
     xlog $self, "Unlike STORAGE, X-ANNOTATION-STORAGE quota is reduced immediately";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     $self->run_delayed_expunge();
     $talk = $self->{store}->get_client();
 
     xlog $self, "X-ANNOTATION-STORAGE quota should not have changed during delayed expunge";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "delete annotations on INBOX";
     $talk->select("INBOX");
@@ -70,5 +70,5 @@ sub test_using_annotstorage_msg
     $talk->close();
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_dedel
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_dedel
@@ -19,10 +19,10 @@ sub test_using_annotstorage_msg_copy_dedel
     my $delete_mode = $self->{instance}->{config}->get('delete_mode');
     $self->assert_str_equals('delayed', $delete_mode);
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 
     my $store = $self->{store};
@@ -56,7 +56,7 @@ sub test_using_annotstorage_msg_copy_dedel
     xlog $self, "Check the annotations are there";
     $self->check_messages(\%exp);
     xlog $self, "Check the quota usage is correct";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "COPY the messages";
     $talk = $store->get_client();
@@ -69,7 +69,7 @@ sub test_using_annotstorage_msg_copy_dedel
     $self->check_messages(\%exp);
 
     xlog $self, "Check the quota usage is now doubled";
-    $self->_check_usages($self->res_annot_storage => int(2*$expected/1024));
+    $self->check_usages($self->res_annot_storage => int(2*$expected/1024));
 
     xlog $self, "Messages are still in the origin folder";
     $store->set_folder($from_folder);
@@ -93,10 +93,10 @@ sub test_using_annotstorage_msg_copy_dedel
     # different question.
 
     xlog $self, "Check the quota usage is back to single";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     $self->run_delayed_expunge();
 
     xlog $self, "Check the quota usage is still back to single";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_dedel
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_dedel
@@ -21,7 +21,7 @@ sub test_using_annotstorage_msg_copy_dedel
 
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_deimm
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_deimm
@@ -19,10 +19,10 @@ sub test_using_annotstorage_msg_copy_deimm
     my $delete_mode = $self->{instance}->{config}->get('delete_mode');
     $self->assert_str_equals('immediate', $delete_mode);
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 
     my $store = $self->{store};
@@ -56,7 +56,7 @@ sub test_using_annotstorage_msg_copy_deimm
     xlog $self, "Check the annotations are there";
     $self->check_messages(\%exp);
     xlog $self, "Check the quota usage is correct";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "COPY the messages";
     $talk = $store->get_client();
@@ -69,7 +69,7 @@ sub test_using_annotstorage_msg_copy_deimm
     $self->check_messages(\%exp);
 
     xlog $self, "Check the quota usage is now doubled";
-    $self->_check_usages($self->res_annot_storage => int(2*$expected/1024));
+    $self->check_usages($self->res_annot_storage => int(2*$expected/1024));
 
     xlog $self, "Messages are still in the origin folder";
     $store->set_folder($from_folder);
@@ -88,5 +88,5 @@ sub test_using_annotstorage_msg_copy_deimm
     $self->check_messages(\%exp);
 
     xlog $self, "Check the quota usage is back to single";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_deimm
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_deimm
@@ -21,7 +21,7 @@ sub test_using_annotstorage_msg_copy_deimm
 
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_exdel
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_exdel
@@ -21,7 +21,7 @@ sub test_using_annotstorage_msg_copy_exdel
 
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_exdel
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_exdel
@@ -19,10 +19,10 @@ sub test_using_annotstorage_msg_copy_exdel
     my $expunge_mode = $self->{instance}->{config}->get('expunge_mode');
     $self->assert_str_equals('delayed', $expunge_mode);
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 
     my $store = $self->{store};
@@ -56,7 +56,7 @@ sub test_using_annotstorage_msg_copy_exdel
     xlog $self, "Check the annotations are there";
     $self->check_messages(\%exp);
     xlog $self, "Check the quota usage is correct";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "COPY the messages";
     $talk = $store->get_client();
@@ -69,7 +69,7 @@ sub test_using_annotstorage_msg_copy_exdel
     $self->check_messages(\%exp);
 
     xlog $self, "Check the quota usage is now doubled";
-    $self->_check_usages($self->res_annot_storage => int(2*$expected/1024));
+    $self->check_usages($self->res_annot_storage => int(2*$expected/1024));
 
     xlog $self, "Messages are still in the origin folder";
     $store->set_folder($from_folder);
@@ -94,10 +94,10 @@ sub test_using_annotstorage_msg_copy_exdel
     $self->check_messages(\%exp);
 
     xlog $self, "Check the quota usage has reduced again";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     $self->run_delayed_expunge();
 
     xlog $self, "Check the quota usage is still the same";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_eximm
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_eximm
@@ -21,7 +21,7 @@ sub test_using_annotstorage_msg_copy_eximm
 
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_eximm
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_copy_eximm
@@ -19,10 +19,10 @@ sub test_using_annotstorage_msg_copy_eximm
     my $expunge_mode = $self->{instance}->{config}->get('expunge_mode');
     $self->assert_str_equals('immediate', $expunge_mode);
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => 0);
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => 0);
     my $talk = $self->{store}->get_client();
 
     my $store = $self->{store};
@@ -56,7 +56,7 @@ sub test_using_annotstorage_msg_copy_eximm
     xlog $self, "Check the annotations are there";
     $self->check_messages(\%exp);
     xlog $self, "Check the quota usage is correct";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "COPY the messages";
     $talk = $store->get_client();
@@ -69,7 +69,7 @@ sub test_using_annotstorage_msg_copy_eximm
     $self->check_messages(\%exp);
 
     xlog $self, "Check the quota usage is now doubled";
-    $self->_check_usages($self->res_annot_storage => int(2*$expected/1024));
+    $self->check_usages($self->res_annot_storage => int(2*$expected/1024));
 
     xlog $self, "Messages are still in the origin folder";
     $store->set_folder($from_folder);
@@ -94,5 +94,5 @@ sub test_using_annotstorage_msg_copy_eximm
     $self->check_messages(\%exp);
 
     xlog $self, "Check the quota usage is back to single";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_late
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_late
@@ -37,7 +37,7 @@ sub test_using_annotstorage_msg_late
         }
     }
 
-    $self->_set_limits($self->res_annot_storage => 100000);
+    $self->_set_quotalimits($self->res_annot_storage => 100000);
     $self->_check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "delete subfolder sub1";

--- a/cassandane/tiny-tests/Quota/using_annotstorage_msg_late
+++ b/cassandane/tiny-tests/Quota/using_annotstorage_msg_late
@@ -8,10 +8,10 @@ sub test_using_annotstorage_msg_late
     xlog $self, "test increasing usage of the X-ANNOTATION-STORAGE quota";
     xlog $self, "resource as per-message annotations are added";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
 
-    $self->_check_no_quota();
+    $self->check_no_quota();
 
     $talk->create("INBOX.sub1") || die "Failed to create subfolder";
     $talk->create("INBOX.sub2") || die "Failed to create subfolder";
@@ -37,13 +37,13 @@ sub test_using_annotstorage_msg_late
         }
     }
 
-    $self->_set_quotalimits($self->res_annot_storage => 100000);
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->set_quotalimits($self->res_annot_storage => 100000);
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "delete subfolder sub1";
     $talk->delete("INBOX.sub1") || die "Failed to delete subfolder";
     $expected -= delete($expecteds{"INBOX.sub1"});
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "delete messages in sub2";
     $talk->select("INBOX.sub2");
@@ -53,13 +53,13 @@ sub test_using_annotstorage_msg_late
 
     xlog $self, "X-ANNOTATION-STORAGE quota goes down immediately";
     $expected -= delete($expecteds{"INBOX.sub2"});
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     $self->run_delayed_expunge();
     $talk = $self->{store}->get_client();
 
     xlog $self, "X-ANNOTATION-STORAGE quota should have been unchanged by expunge";
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 
     xlog $self, "delete annotations on INBOX";
     $talk->select("INBOX");
@@ -67,5 +67,5 @@ sub test_using_annotstorage_msg_late
     $self->assert_str_equals('ok', $talk->get_last_completion_response());
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages($self->res_annot_storage => int($expected/1024));
+    $self->check_usages($self->res_annot_storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_message
+++ b/cassandane/tiny-tests/Quota/using_message
@@ -11,7 +11,7 @@ sub test_using_message
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(message => 50000);
+    $self->_set_quotalimits(message => 50000);
     $self->_check_usages(message => 0);
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";

--- a/cassandane/tiny-tests/Quota/using_message
+++ b/cassandane/tiny-tests/Quota/using_message
@@ -7,12 +7,12 @@ sub test_using_message
 
     xlog $self, "test increasing usage of the MESSAGE quota resource as messages are added";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
 
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(message => 50000);
-    $self->_check_usages(message => 0);
+    $self->set_quotalimits(message => 50000);
+    $self->check_usages(message => 0);
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
 
@@ -29,14 +29,14 @@ sub test_using_message
             my $msg = $self->make_message("Message $_");
             $expecteds{$folder}++;
             $expected++;
-            $self->_check_usages(message => $expected);
+            $self->check_usages(message => $expected);
         }
     }
 
     # delete subfolder
     $talk->delete("INBOX.sub") || die "Failed to delete subfolder";
     $expected -= $expecteds{"INBOX.sub"};
-    $self->_check_usages(message => $expected);
+    $self->check_usages(message => $expected);
 
     # delete messages
     $talk->select("INBOX");
@@ -44,5 +44,5 @@ sub test_using_message
     $talk->close();
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages(message => $expected);
+    $self->check_usages(message => $expected);
 }

--- a/cassandane/tiny-tests/Quota/using_message_late
+++ b/cassandane/tiny-tests/Quota/using_message_late
@@ -29,7 +29,7 @@ sub test_using_message_late
         }
     }
 
-    $self->_set_limits(message => 50000);
+    $self->_set_quotalimits(message => 50000);
     $self->_check_usages(message => $expected);
 
     # delete subfolder

--- a/cassandane/tiny-tests/Quota/using_message_late
+++ b/cassandane/tiny-tests/Quota/using_message_late
@@ -7,9 +7,9 @@ sub test_using_message_late
 
     xlog $self, "test setting MESSAGE quota resource after messages are added";
 
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     my $talk = $self->{store}->get_client();
-    $self->_check_no_quota();
+    $self->check_no_quota();
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
 
@@ -29,13 +29,13 @@ sub test_using_message_late
         }
     }
 
-    $self->_set_quotalimits(message => 50000);
-    $self->_check_usages(message => $expected);
+    $self->set_quotalimits(message => 50000);
+    $self->check_usages(message => $expected);
 
     # delete subfolder
     $talk->delete("INBOX.sub") || die "Failed to delete subfolder";
     $expected -= $expecteds{"INBOX.sub"};
-    $self->_check_usages(message => $expected);
+    $self->check_usages(message => $expected);
 
     # delete messages
     $talk->select("INBOX");
@@ -43,5 +43,5 @@ sub test_using_message_late
     $talk->close();
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages(message => $expected);
+    $self->check_usages(message => $expected);
 }

--- a/cassandane/tiny-tests/Quota/using_storage
+++ b/cassandane/tiny-tests/Quota/using_storage
@@ -8,7 +8,7 @@ sub test_using_storage
     xlog $self, "test increasing usage of the STORAGE quota resource as messages are added";
     $self->_set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_limits(storage => 100000);
+    $self->_set_quotalimits(storage => 100000);
     $self->_check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/Quota/using_storage
+++ b/cassandane/tiny-tests/Quota/using_storage
@@ -6,10 +6,10 @@ sub test_using_storage
     my ($self) = @_;
 
     xlog $self, "test increasing usage of the STORAGE quota resource as messages are added";
-    $self->_set_quotaroot('user.cassandane');
+    $self->set_quotaroot('user.cassandane');
     xlog $self, "set ourselves a basic limit";
-    $self->_set_quotalimits(storage => 100000);
-    $self->_check_usages(storage => 0);
+    $self->set_quotalimits(storage => 100000);
+    $self->check_usages(storage => 0);
     my $talk = $self->{store}->get_client();
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
@@ -30,14 +30,14 @@ sub test_using_storage
             $expecteds{$folder} += $len;
             $expected += $len;
             xlog $self, "added $len bytes of message";
-            $self->_check_usages(storage => int($expected/1024));
+            $self->check_usages(storage => int($expected/1024));
         }
     }
 
     # delete subfolder
     $talk->delete("INBOX.sub") || die "Failed to delete subfolder";
     $expected -= delete($expecteds{"INBOX.sub"});
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'OK');
 
     # delete messages
@@ -46,5 +46,5 @@ sub test_using_storage
     $talk->close();
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_storage_late
+++ b/cassandane/tiny-tests/Quota/using_storage_late
@@ -7,8 +7,8 @@ sub test_using_storage_late
 
     xlog $self, "test setting STORAGE quota resource after messages are added";
 
-    $self->_set_quotaroot('user.cassandane');
-    $self->_check_no_quota();
+    $self->set_quotaroot('user.cassandane');
+    $self->check_no_quota();
     my $talk = $self->{store}->get_client();
 
     $talk->create("INBOX.sub") || die "Failed to create subfolder";
@@ -32,14 +32,14 @@ sub test_using_storage_late
         }
     }
 
-    $self->_set_quotalimits(storage => 100000);
-    $self->_check_usages(storage => int($expected/1024));
+    $self->set_quotalimits(storage => 100000);
+    $self->check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'OK');
 
     # delete subfolder
     $talk->delete("INBOX.sub") || die "Failed to delete subfolder";
     $expected -= delete($expecteds{"INBOX.sub"});
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
 
     # delete messages
     $talk->select("INBOX");
@@ -47,5 +47,5 @@ sub test_using_storage_late
     $talk->close();
     $expected -= delete($expecteds{"INBOX"});
     $self->assert_num_equals(0, $expected);
-    $self->_check_usages(storage => int($expected/1024));
+    $self->check_usages(storage => int($expected/1024));
 }

--- a/cassandane/tiny-tests/Quota/using_storage_late
+++ b/cassandane/tiny-tests/Quota/using_storage_late
@@ -32,7 +32,7 @@ sub test_using_storage_late
         }
     }
 
-    $self->_set_limits(storage => 100000);
+    $self->_set_quotalimits(storage => 100000);
     $self->_check_usages(storage => int($expected/1024));
     $self->_check_smmap('cassandane', 'OK');
 


### PR DESCRIPTION
This is two unrelated changes that I performed together.

1. Some quota-related methods that were _mostly_ duplicated between a few tests are unified into a mixin.
2. the need to `use lib "."` in almost every Cassandane perl module is eliminated