### PR TITLE
Cassandane test entities: load AutoSetup after defining methods

### DIFF
--- a/cassandane/Cassandane/TestEntity/Factory/AddressBook.pm
+++ b/cassandane/Cassandane/TestEntity/Factory/AddressBook.pm
@@ -1,8 +1,6 @@
 package Cassandane::TestEntity::Factory::AddressBook;
 use Moo;
 
-use Cassandane::TestEntity::AutoSetup;
-
 use feature 'state';
 
 sub fill_in_creation_defaults {
@@ -13,6 +11,8 @@ sub fill_in_creation_defaults {
 
     return;
 }
+
+use Cassandane::TestEntity::AutoSetup;
 
 no Moo;
 1;

--- a/cassandane/Cassandane/TestEntity/Factory/ContactCard.pm
+++ b/cassandane/Cassandane/TestEntity/Factory/ContactCard.pm
@@ -1,8 +1,6 @@
 package Cassandane::TestEntity::Factory::ContactCard;
 use Moo;
 
-use Cassandane::TestEntity::AutoSetup;
-
 use Data::GUID ();
 
 sub fill_in_creation_defaults {
@@ -23,6 +21,8 @@ sub fill_in_creation_defaults {
 
     return;
 }
+
+use Cassandane::TestEntity::AutoSetup;
 
 no Moo;
 1;

--- a/cassandane/Cassandane/TestEntity/Factory/Mailbox.pm
+++ b/cassandane/Cassandane/TestEntity/Factory/Mailbox.pm
@@ -1,8 +1,6 @@
 package Cassandane::TestEntity::Factory::Mailbox;
 use Moo;
 
-use Cassandane::TestEntity::AutoSetup;
-
 use feature 'state';
 
 sub fill_in_creation_defaults {
@@ -41,6 +39,8 @@ sub inbox {
         properties => $res->[1][1]{list}[0],
     })
 }
+
+use Cassandane::TestEntity::AutoSetup;
 
 no Moo;
 1;


### PR DESCRIPTION
Before this commit code did this:

    package XYZ::Factory::ContactCard;
    use Cassandane::TestEntity::AutoSetup;
    sub fill_in_creation_defaults {...}

AutoSetup provided sugar for something like this:

    package XYZ::Factory::ContactCard;
    use Moo;
    with 'Cassandane::TestEntity::Role::Factory';
    # other stuff
    sub fill_in_creation_defaults {...}

In the unsugared scenario, `with` comes before `sub ...` in the text, but occurred at runtime, while subroutine definitions are compiled at compile time.  That meant that when `with` was evaluated, the role applicator could determine that the composing class already had a subroutine with that name and decline to install it.  (In-class methods prevent role methods from being installed.)

In the sugared version, the `with` was applied by the implicit call to AutoSetup->import, which occurs at compile time.  Then the fill_in_creation_defaults method gets installed by role application and is then *reinstalled* by the declaration in the class.  AutoSetup can't trivially defer role application, so instead we move it to the end of the class.  Problem solved.