### PR TITLE
Cassandane: structured vCard testing

### DIFF
--- a/cassandane/Cassandane/TestEntity/DataType/ContactCard.pm
+++ b/cassandane/Cassandane/TestEntity/DataType/ContactCard.pm
@@ -82,6 +82,31 @@ package Cassandane::TestEntity::Instance::ContactCard {
         $self->_as_vcard('4.0');
     }
 
+    sub _as_vcard_struct {
+        my ($self, $version) = @_;
+        my $vcard = $self->_as_vcard($version);
+
+        require Text::VCardFast;
+        my $struct = Text::VCardFast::vcard2hash($vcard);
+
+        $struct || Carp::confess("can't parse $vcard");
+
+        $struct->{objects}->@* == 1
+          || Carp::confess("didn't get exactly one object when parsing vcard");
+
+        return $struct->{objects}[0];
+    }
+
+    sub as_vcard3_struct {
+        my ($self) = @_;
+        $self->_as_vcard_struct('3.0');
+    }
+
+    sub as_vcard4_struct {
+        my ($self) = @_;
+        $self->_as_vcard_struct('4.0');
+    }
+
     sub add_member {
         my ($self, $card_or_uid) = @_;
 

--- a/cassandane/tiny-tests/JMAPContacts/card_set_create_basic
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_create_basic
@@ -26,18 +26,31 @@ sub test_card_set_create_basic
 
     $self->assert_not_null($card->id);
 
-    my $vcard = $card->as_vcard4;
-
-    $vcard =~ s/\r?\n[ \t]+//gs;  # unfold long properties
-    $name =~ s/,/\\\\,/gs;        # escape commas
+    my $vcard = $card->as_vcard4_struct;
 
     $created = $now->strftime('%Y%m%dT%H%M%SZ'); # vCard doesn't use separators
 
-    $self->assert_matches(qr/VERSION:4.0/, $vcard);
-    $self->assert_matches(qr/KIND:INDIVIDUAL/, $vcard);
-    $self->assert_matches(qr/UID;VALUE=TEXT:$uid/, $vcard);
-    $self->assert_matches(qr/PRODID:$prodid/, $vcard);
-    $self->assert_matches(qr/CREATED:$created/, $vcard);
-    $self->assert_matches(qr/FN:$name/, $vcard);
-    $self->assert_does_not_match(qr|JSPROP|, $vcard);
+    my sub prop {
+        my ($v, $p) = @_;
+        return [
+            superhashof({
+                value => $v,
+                ($p ? (params => superhashof($p)) : ())
+            }),
+        ];
+    }
+
+    $self->assert_cmp_deeply(
+        superhashof({
+            properties => superhashof({
+                created => prop($created),
+                fn      => prop($name),
+                kind    => prop('INDIVIDUAL'),
+                prodid  => prop($prodid),
+                uid     => prop($uid, { value => [ 'TEXT' ] }),
+                version => prop('4.0'),
+            })
+        }),
+        $vcard,
+    );
 }


### PR DESCRIPTION
This commit isn't quite done yet, but gets the point across.

First, it adds ->as_vcardX_struct methods to ContactCard instances, which return single-vcard-object result of calling Test::VCardFast::vcard2hash on a vcard blob.  Then one test is tweaked to use the resulting structure as the basis for testing card content.

Probably we should improve the "value" subroutine that's used to generate simple property value tests so that we can use it everywhere. As is, it's okay, but isn't not quite exensible enough for general use.

If we like this general idea, I'll rework this more.