### PR TITLE
Twom speedups

### DIFF
--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1505,7 +1505,31 @@ EXPORTED int mboxlist_update_full(const mbentry_t *mbentry, int localonly, int s
 
     r = mboxlist_update_entry_full(mbentry->name, mbentry, &tid, silent);
 
-    /* commit the change to mupdate */
+    /* Commit (or abort) the local change BEFORE talking to mupdate.  We must
+     * not hold the mailboxes.db lock across the mupdate network round-trip:
+     * mupdate may itself need to lock the mailboxes.db (deadlock), and twom
+     * won't yield a write lock.  This means local and mupdate are no longer
+     * atomic - if mupdate fails the local change stays, matching the behaviour
+     * of mboxlist_setacl and friends. */
+    if (tid) {
+        if (r) {
+            r2 = cyrusdb_abort(mbdb, tid);
+            if (r2)
+                xsyslog(LOG_ERR, "DBERROR: error aborting transaction",
+                                 "error=<%s>", cyrusdb_strerror(r2));
+        } else {
+            r2 = cyrusdb_commit(mbdb, tid);
+            if (r2)
+                xsyslog(LOG_ERR, "DBERROR: error committing transaction",
+                                 "error=<%s>", cyrusdb_strerror(r2));
+            if (r2) r = r2;
+            else
+                mboxname_setmodseq(mbentry->name, mbentry->foldermodseq,
+                                   mbentry->mbtype, MBOXMODSEQ_ISFOLDER);
+        }
+    }
+
+    /* commit the change to mupdate (local lock released above) */
     if (!r && !localonly && config_mupdate_server) {
         mupdate_handle *mupdate_h = NULL;
 
@@ -1527,23 +1551,6 @@ EXPORTED int mboxlist_update_full(const mbentry_t *mbentry, int localonly, int s
             }
         }
         mupdate_disconnect(&mupdate_h);
-    }
-
-    if (tid) {
-        if (r) {
-            r2 = cyrusdb_abort(mbdb, tid);
-            if (r2)
-                xsyslog(LOG_ERR, "DBERROR: error aborting transaction",
-                                 "error=<%s>", cyrusdb_strerror(r2));
-        } else {
-            r2 = cyrusdb_commit(mbdb, tid);
-            if (r2)
-                xsyslog(LOG_ERR, "DBERROR: error committing transaction",
-                                 "error=<%s>", cyrusdb_strerror(r2));
-        }
-        if (!r)
-            mboxname_setmodseq(mbentry->name, mbentry->foldermodseq, mbentry->mbtype,
-                               MBOXMODSEQ_ISFOLDER);
     }
 
     return r;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5035,6 +5035,12 @@ static void init_internal()
     }
 }
 
+EXPORTED int mboxlist_yield(void)
+{
+    if (!mboxlist_dbopen) return 0;
+    return cyrusdb_yield(mbdb);
+}
+
 /* must be called after cyrus_init */
 EXPORTED void mboxlist_init(void)
 {

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -390,6 +390,8 @@ void mboxlist_close(void);
 /* initialize database structures */
 void mboxlist_init(void);
 
+int mboxlist_yield(void);
+
 /* done with database stuff */
 void mboxlist_done(void);
 

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -513,6 +513,11 @@ EXPORTED int mupdate_noop(mupdate_handle *handle, mupdate_callback callback,
         return MUPDATE_BADPARAM;
     }
 
+    if (mboxlist_yield()) {
+        syslog(LOG_ERR, "%s: databases locked", __func__);
+        return MUPDATE_FAIL;
+    }
+
     prot_printf(handle->conn->out,
                 "X%u NOOP\r\n", handle->tagn++);
 

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -173,6 +173,11 @@ EXPORTED int mupdate_activate(mupdate_handle *handle,
         return MUPDATE_BADPARAM;
     }
 
+    if (mboxlist_yield()) {
+        syslog(LOG_ERR, "%s: databases locked", __func__);
+        return MUPDATE_FAIL;
+    }
+
     if (config_mupdate_config == IMAP_ENUM_MUPDATE_CONFIG_REPLICATED) {
         /* we don't care about the server part, everything is local */
         if (p) location = p + 1;
@@ -235,6 +240,11 @@ HIDDEN int mupdate_reserve(mupdate_handle *handle,
         return MUPDATE_BADPARAM;
     }
 
+    if (mboxlist_yield()) {
+        syslog(LOG_ERR, "%s: databases locked", __func__);
+        return MUPDATE_FAIL;
+    }
+
     if (config_mupdate_config == IMAP_ENUM_MUPDATE_CONFIG_REPLICATED) {
         /* we don't care about the location part, everything is local */
         if (p) location = p + 1;
@@ -295,6 +305,11 @@ EXPORTED int mupdate_deactivate(mupdate_handle *handle,
         return MUPDATE_BADPARAM;
     }
 
+    if (mboxlist_yield()) {
+        syslog(LOG_ERR, "%s: databases locked", __func__);
+        return MUPDATE_FAIL;
+    }
+
     if (config_mupdate_config == IMAP_ENUM_MUPDATE_CONFIG_REPLICATED) {
         /* we don't care about the server part, everything is local */
         if (p) location = p + 1;
@@ -336,6 +351,11 @@ EXPORTED int mupdate_delete(mupdate_handle *handle,
     }
 
     if (!handle->saslcompleted) return MUPDATE_NOAUTH;
+
+    if (mboxlist_yield()) {
+        syslog(LOG_ERR, "%s: databases locked", __func__);
+        return MUPDATE_FAIL;
+    }
 
     prot_printf(handle->conn->out,
                 "X%u DELETE {" SIZE_T_FMT "+}\r\n%s\r\n", handle->tagn++,
@@ -406,6 +426,11 @@ EXPORTED int mupdate_find(mupdate_handle *handle, const char *mailbox,
         return MUPDATE_BADPARAM;
     }
 
+    if (mboxlist_yield()) {
+        syslog(LOG_ERR, "%s: databases locked", __func__);
+        return MUPDATE_FAIL;
+    }
+
     prot_printf(handle->conn->out,
                 "X%u FIND {" SIZE_T_FMT "+}\r\n%s\r\n", handle->tagn++,
                 strlen(mailbox), mailbox);
@@ -444,6 +469,11 @@ EXPORTED int mupdate_list(mupdate_handle *handle, mupdate_callback callback,
     if (!callback) {
         syslog(LOG_ERR, "%s: no callback", __func__);
         return MUPDATE_BADPARAM;
+    }
+
+    if (mboxlist_yield()) {
+        syslog(LOG_ERR, "%s: databases locked", __func__);
+        return MUPDATE_FAIL;
     }
 
     if (prefix) {

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1746,6 +1746,9 @@ static int sendupdate(const mbentry_t *mbentry, void *rock)
 
     if (!C) return -1;
 
+    int r = mboxlist_yield();
+    if (r) return r;
+
     m = database_lookup(mbentry->name, mbentry, NULL);
     if (!m) return -1;
 

--- a/lib/cyrusdb.c
+++ b/lib/cyrusdb.c
@@ -650,6 +650,12 @@ EXPORTED int cyrusdb_unlink(const char *backend, const char *fname, int flags)
     return db->unlink(fname, flags);
 }
 
+EXPORTED int cyrusdb_yield(struct db *db)
+{
+    if (!db || !db->backend->yield) return 0;
+    return db->backend->yield(db->engine);
+}
+
 EXPORTED cyrusdb_archiver *cyrusdb_getarchiver(const char *backend)
 {
     struct cyrusdb_backend *db = cyrusdb_fromname(backend);

--- a/lib/cyrusdb.h
+++ b/lib/cyrusdb.h
@@ -72,6 +72,9 @@ struct cyrusdb_backend {
     /* unlinks this specific database, including cleaning up any environment */
     int (*unlink)(const char *fname, int flags);
 
+    /* yield any transactions on the current database */
+    int (*yield)(struct dbengine *db);
+
     /* open the specified database in the global environment */
     int (*open)(const char *fname, int flags, struct dbengine **ret, struct txn **tid);
 
@@ -254,6 +257,7 @@ extern int cyrusdb_abort(struct db *db, struct txn *tid);
 extern int cyrusdb_dump(struct db *db, int detail);
 extern int cyrusdb_consistent(struct db *db);
 extern int cyrusdb_repack(struct db *db);
+extern int cyrusdb_yield(struct db *db);
 extern int cyrusdb_compar(struct db *db,
                           const char *a, size_t alen,
                           const char *b, size_t blen);

--- a/lib/cyrusdb_flat.c
+++ b/lib/cyrusdb_flat.c
@@ -808,6 +808,8 @@ EXPORTED struct cyrusdb_backend cyrusdb_flat =
     &cyrusdb_generic_archive,
     &cyrusdb_generic_unlink,
 
+    NULL, /*yield*/
+
     &myopen,
     &myclose,
 

--- a/lib/cyrusdb_quotalegacy.c
+++ b/lib/cyrusdb_quotalegacy.c
@@ -840,6 +840,8 @@ HIDDEN struct cyrusdb_backend cyrusdb_quotalegacy =
     &cyrusdb_generic_noarchive,
     &cyrusdb_generic_unlink,
 
+    NULL, /*yield*/
+
     &myopen,
     &myclose,
 

--- a/lib/cyrusdb_skiplist.c
+++ b/lib/cyrusdb_skiplist.c
@@ -2449,6 +2449,8 @@ EXPORTED struct cyrusdb_backend cyrusdb_skiplist =
     &cyrusdb_generic_archive,
     &cyrusdb_generic_unlink,
 
+    NULL, /*yield*/
+
     &myopen,
     &myclose,
 

--- a/lib/cyrusdb_sql.c
+++ b/lib/cyrusdb_sql.c
@@ -921,6 +921,9 @@ HIDDEN struct cyrusdb_backend cyrusdb_sql =
     &cyrusdb_generic_noarchive,
     NULL,
 
+    NULL, /*yield*/
+    NULL, /*yieldall*/
+
     &myopen,
     &myclose,
 

--- a/lib/cyrusdb_sql.c
+++ b/lib/cyrusdb_sql.c
@@ -922,7 +922,6 @@ HIDDEN struct cyrusdb_backend cyrusdb_sql =
     NULL,
 
     NULL, /*yield*/
-    NULL, /*yieldall*/
 
     &myopen,
     &myclose,

--- a/lib/cyrusdb_twom.c
+++ b/lib/cyrusdb_twom.c
@@ -231,11 +231,6 @@ static int myforeach(struct dbengine *db,
     int tmflags = 0;
 
     if (!tidptr) {
-        // we call out to the mupdate server within mailbox findall,
-        // which tries to lock the mailboxes.db!  This breaks unless
-        // we release the lock every time sadly, so add ALWAYSYIELD
-        // to match twoskip/skiplist et al behaviour
-        tmflags |= TWOM_ALWAYSYIELD;
         struct twom_db *tmdb = (struct twom_db *)db;
         return _errormap(twom_db_foreach(tmdb, prefix, prefixlen,
                                          goodp, cb, rock, tmflags));

--- a/lib/cyrusdb_twom.c
+++ b/lib/cyrusdb_twom.c
@@ -351,6 +351,13 @@ static int delete(struct dbengine *db,
     return mywrite(db, key, keylen, NULL, 0, tidptr, tmflags);
 }
 
+static int yield(struct dbengine *db)
+{
+    struct twom_db *tmdb = (struct twom_db *)db;
+    int tmr = twom_db_yield(tmdb);
+    return _errormap(tmr);
+}
+
 HIDDEN struct cyrusdb_backend cyrusdb_twom =
 {
     "twom",                  /* name */
@@ -360,7 +367,7 @@ HIDDEN struct cyrusdb_backend cyrusdb_twom =
     &cyrusdb_generic_archive,
     &cyrusdb_generic_unlink,
 
-    NULL, /*yield*/
+    &yield,
 
     &myopen,
     &myclose,

--- a/lib/cyrusdb_twom.c
+++ b/lib/cyrusdb_twom.c
@@ -360,6 +360,8 @@ HIDDEN struct cyrusdb_backend cyrusdb_twom =
     &cyrusdb_generic_archive,
     &cyrusdb_generic_unlink,
 
+    NULL, /*yield*/
+
     &myopen,
     &myclose,
 

--- a/lib/cyrusdb_twoskip.c
+++ b/lib/cyrusdb_twoskip.c
@@ -2563,6 +2563,8 @@ HIDDEN struct cyrusdb_backend cyrusdb_twoskip =
     &cyrusdb_generic_archive,
     &cyrusdb_generic_unlink,
 
+    NULL, /*yield*/
+
     &myopen,
     &myclose,
 

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -46,6 +46,13 @@
 /* release lock in foreach at least every N records */
 #define FOREACH_LOCK_RELEASE 1024
 
+/* When re-locking during a long foreach we normally use TWOM_ONELOCK to skip
+ * the header "gate" lock and save syscalls.  But the gate is what lets a
+ * waiting writer fend off new readers, so if we ALWAYS skipped it a busy set
+ * of overlapping foreaches would starve writers indefinitely.  So every N
+ * re-locks we fall back to the full double-lock, bounding writer starvation. */
+#define FOREACH_GATE_RELOCKS 64
+
 /* type aliases */
 #define LLU long long unsigned int
 #define LU long unsigned int
@@ -133,6 +140,7 @@ struct twom_txn {
     struct tm_file *file;
     size_t end;
     uint64_t counter;
+    uint64_t nlocks;
     unsigned readonly:1;
     unsigned nosync:1;
     unsigned noyield:1;
@@ -2184,7 +2192,10 @@ static int myreplay(struct twom_txn *txn,
         if (txn->counter > db->foreach_lock_release) {
             r = unlock(db, file);
             if (r) return r;
-            r = read_lock(db, &txn, file, /*flags*/TWOM_ONELOCK);
+            /* as in twom_cursor_next: mostly ONELOCK, but periodically take
+             * the full double-lock so we don't starve a waiting writer */
+            int lockflags = (txn->nlocks++ % FOREACH_GATE_RELOCKS) ? TWOM_ONELOCK : 0;
+            r = read_lock(db, &txn, file, lockflags);
             if (r) return r;
             txn->counter = 0;
         }
@@ -2714,7 +2725,11 @@ int twom_cursor_next(struct twom_cursor *cur,
         }
 
         if (!txn->file->has_datalock) {
-            r = read_lock(txn->db, &txn, txn->mvcc ? txn->file : NULL, TWOM_ONELOCK);
+            /* usually re-lock cheaply with ONELOCK (skipping the header gate),
+             * but every FOREACH_GATE_RELOCKS re-locks take the full double-lock
+             * so a writer waiting on the gate isn't starved by this foreach */
+            int lockflags = (txn->nlocks++ % FOREACH_GATE_RELOCKS) ? TWOM_ONELOCK : 0;
+            r = read_lock(txn->db, &txn, txn->mvcc ? txn->file : NULL, lockflags);
             if (r) return r;
             txn->counter = 0;
         }

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -1555,13 +1555,14 @@ static int write_lock(struct twom_db *db, struct twom_txn **txnp,
     struct flock fl;
     int r = 0;
     int cmd = (flags & TWOM_NONBLOCKING) ? F_SETLK : F_SETLKW;
+    int take_headlock = (flags & TWOM_ONELOCK) ? 0 : 1;
     struct tm_file *file = forcefile ? forcefile : db->openfile;
 
     if (file->has_headlock || file->has_datalock) return TWOM_INTERNAL;
 
     for (;;) {
         // lock the head section
-        for (;!file->has_headlock;) {
+        for (;take_headlock && !file->has_headlock;) {
             fl.l_type = F_WRLCK;
             fl.l_whence = SEEK_SET;
             fl.l_start = 0;
@@ -1630,6 +1631,9 @@ static int write_lock(struct twom_db *db, struct twom_txn **txnp,
         }
 
         if (sbuf.st_ino == sbuffile.st_ino) break;
+
+        // go straight to the data lock when retrying
+        take_headlock = 0;
 
         r = unlock(db, file);
         if (r) goto done;
@@ -1705,12 +1709,13 @@ static int read_lock(struct twom_db *db, struct twom_txn **txnp,
     struct flock fl;
     struct tm_file *file = forcefile ? forcefile : db->openfile;
     int cmd = (flags & TWOM_NONBLOCKING) ? F_SETLK : F_SETLKW;
+    int take_headlock = (flags & TWOM_ONELOCK) ? 0 : 1;
 
     if (file->has_headlock || file->has_datalock) return TWOM_INTERNAL;
 
     for (;;) {
         // take the headlock
-        for (;!file->has_headlock;) {
+        for (;take_headlock && !file->has_headlock;) {
             fl.l_type = F_RDLCK;
             fl.l_whence = SEEK_SET;
             fl.l_start = 0;
@@ -1781,6 +1786,9 @@ static int read_lock(struct twom_db *db, struct twom_txn **txnp,
 
         // file is unchanged, we have successfully locked
         if (sbuf.st_ino == sbuffile.st_ino) break;
+
+        // go straight to the data lock when retrying
+        take_headlock = 0;
 
         // unlock the old file
         r = unlock(db, file);
@@ -2176,7 +2184,7 @@ static int myreplay(struct twom_txn *txn,
         if (txn->counter > db->foreach_lock_release) {
             r = unlock(db, file);
             if (r) return r;
-            r = read_lock(db, &txn, file, /*flags*/0);
+            r = read_lock(db, &txn, file, /*flags*/TWOM_ONELOCK);
             if (r) return r;
             txn->counter = 0;
         }
@@ -2706,7 +2714,7 @@ int twom_cursor_next(struct twom_cursor *cur,
         }
 
         if (!txn->file->has_datalock) {
-            r = read_lock(txn->db, &txn, txn->mvcc ? txn->file : NULL, /*flags*/0);
+            r = read_lock(txn->db, &txn, txn->mvcc ? txn->file : NULL, TWOM_ONELOCK);
             if (r) return r;
             txn->counter = 0;
         }
@@ -3287,7 +3295,7 @@ int twom_db_repack(struct twom_db *db)
     /* open fname.NEW */
     snprintf(newfname, sizeof(newfname), "%s.NEW", db->fname);
 
-    int flags = TWOM_NONBLOCKING; // if another file has already locked it, something is broken
+    int flags = TWOM_NONBLOCKING | TWOM_ONELOCK; // if another file has already locked it, something is broken
     if (db->external_csum)
         flags |= TWOM_CSUM_EXTERNAL;
     else if (db->nocsum)

--- a/lib/twom.h
+++ b/lib/twom.h
@@ -46,6 +46,7 @@ enum twom_flagspec {
     TWOM_NOCSUM          = 1<<2,    /* Don't check checksums on read */
     TWOM_NOSYNC          = 1<<3,    /* Don't msync/fsync on write */
     TWOM_NONBLOCKING     = 1<<4,    /* When taking a lock, return immediately if the file is already locked */
+    TWOM_ONELOCK         = 1<<5,    /* When locking, skip the double-lock process */
 
     TWOM_ALWAYSYIELD     = 1<<9,    /* Yield foreach before every callback */
     TWOM_NOYIELD         = 1<<10,   /* Never yield a read transaction lock */


### PR DESCRIPTION
This MR came from some shower thoughts.

1) I always meant to add `yield` support to mupdate and then remove always-yield from our use of twom.  Doing that really reduces the number of locks that are needed for a non-transactional foreach, which is a big win for reducing syscalls in a bunch of our code.  So I did that.

2) I realised that we didn't need to repeat the HEADLOCK every time we get a file change, or re-lock within a foreach.  It's OK to favour currently running clients more, and that ALSO reduces the number of syscalls.

So I did both of those.