### PR TITLE
imapd.c: don't send LIST reference arg to backend after pattern canonicalization

### DIFF
--- a/cassandane/Cassandane/Cyrus/MurderIMAP.pm
+++ b/cassandane/Cassandane/Cyrus/MurderIMAP.pm
@@ -218,6 +218,73 @@ sub test_list_specialuse
     $self->assert_deep_equals($bresult, $fresult);
 }
 
+sub test_list_subscribed
+{
+    my ($self) = @_;
+
+    my $frontend = $self->{frontend_store}->get_client();
+    my $backend = $self->{backend1_store}->get_client();
+
+    my %subscribed = map { $_ => 1 } qw( A1 A2 A3 );
+    my %other = map { $_ => 1 } qw( lists personal timesheets );
+
+    # create some subscribed folders
+    foreach my $f (keys %subscribed) {
+        $frontend->create("INBOX.$f");
+        $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+
+        $frontend->subscribe("INBOX.$f");
+        $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    }
+
+    # create some other non special-use folders (control group)
+    foreach my $f (keys %other) {
+        $frontend->create("INBOX.$f");
+        $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+
+        $frontend->subscribe("INBOX.$f");
+        $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    }
+
+    # ask the backend about them
+    my $bresult = $backend->list([qw(SUBSCRIBED)], "", "INBOX.A*");
+    $self->assert_str_equals('ok', $backend->get_last_completion_response());
+    xlog $self, Dumper $bresult;
+
+    # check the responses
+    my %found;
+    foreach my $r (@{$bresult}) {
+        my ($flags, $sep, $name) = @{$r};
+        # carve out the interesting part of the name
+        $self->assert_matches(qr/^INBOX$sep/, $name);
+        $name = substr($name, 6);
+        $found{$name} = 1;
+        # only want subscribed folders
+        $self->assert(exists $subscribed{$name});
+        # must be flagged with \subscribed
+        $self->assert_equals(1, scalar grep { $_ eq '\\Subscribed' } @{$flags});
+    }
+
+    # make sure no expected responses were missing
+    $self->assert_deep_equals(\%subscribed, \%found);
+
+    # ask the frontend about them
+    my $fresult = $frontend->list([qw(SUBSCRIBED)], "", "INBOX.A*");
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    xlog $self, Dumper $fresult;
+
+    # expect the same results as on backend
+    $self->assert_deep_equals($bresult, $fresult);
+
+    # ask the frontend about them with a non-empty reference argument
+    $fresult = $frontend->list([qw(SUBSCRIBED)], "INBOX.A", "*");
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    xlog $self, Dumper $fresult;
+
+    # expect the same results as on backend
+    $self->assert_deep_equals($bresult, $fresult);
+}
+
 sub test_xlist
 {
     my ($self) = @_;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -13830,6 +13830,10 @@ static void list_data(struct listargs *listargs)
 {
     canonical_list_patterns(listargs->ref, &listargs->pat);
 
+    /* The reference argument is now part of the canonical patterns,
+       so send an empty reference to backends */
+    listargs->ref = "";
+
     /* Check to see if we should only list the personal namespace */
     if (!(listargs->cmd == LIST_CMD_EXTENDED)
             && !strcmp(listargs->pat.data[0], "*")


### PR DESCRIPTION
otherwise, a command to a frontend like:

LIST (SUBSCRIBED) "INBOX.A" "*"

gets sent to the backend as:

LIST (SUBSCRIBED) "INBOX.A" "INBOX.A*"

and the backend looks for mailboxes matching "INBOX.AINBOX.A*"

This is a potential fix to #5602 