### PR TITLE
http_h2.c: Use nghttp2_ssize APIs if available (requires v.1.60.0+) 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1628,6 +1628,10 @@ dnl                AC_MSG_WARN([Your version of OpenDKIM can not support iSchedu
                 PKG_CHECK_MODULES([NGHTTP2], [libnghttp2 >= 1.34.0], [
                         AC_DEFINE(HAVE_NGHTTP2,[],
                                 [Build HTTP/2 support into httpd?])
+                        AC_CHECK_DECL([nghttp2_submit_data2],
+                                AC_DEFINE(HAVE_NGHTTP2_SSIZE,[],
+                                [Do we have support for nghttp2_ssize?]),
+                                [], [[#include <nghttp2/nghttp2.h>]])
                         with_nghttp2=yes
                 ], [
                         if test "x$with_nghttp2" = "xyes"; then


### PR DESCRIPTION
From Nghttp2 v1.60.0 documentation:

The APIs that use ssize_t, including structs and callback functions, have been deprecated. New APIs that use nghttp2_ssize are introduced as a replacement. The usage of ssize_t is problematic for several reasons. Some platforms do not define ssize_t. The minimum value of ssize_t that POSIX requires is -1 which makes nghttp2 error code out of range. nghttp2_ssize is an alias of ptrdiff_t that is in C standard and covers our error code range.

New code should use new nghttp2_ssize APIs.
The existing applications should consider migrating to new APIs.

The deprecated ssize_t APIs continue to work for backward compatibility.