### PR TITLE
http_carddav.c: allow changing v3 UID to v4 UID in PUT

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/carddav_put_v3tov4uid
+++ b/cassandane/tiny-tests/JMAPContacts/carddav_put_v3tov4uid
@@ -1,0 +1,91 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_carddav_put_v3tov4uid
+    :needs_dependency_icalvcard
+    ($self)
+{
+    # This is a regression test that asserts that CardDAV clients
+    # can rewrite the UID of a version 3 vCard by prefixing that
+    # UID value with "urn:uuid" and switching to vCard version 4.
+    # This violates the CardDAV spec and would require Cyrus to
+    # reject the PUT with a no-uid-conflict precondition error.
+    # This test only exists to assert that we support this broken
+    # behavior temporarily.
+    #
+    # Note that the brokeness leaks into the Contact API. The
+    # updated card is reported as updated, even though the *id*
+    # of the Contact object changed. This is bogus in JMAP, but
+    # again, it's here because it was broken that way all the time.
+
+    my $jmap = $self->{jmap};
+    my $carddav = $self->{carddav};
+    $ENV{DEBUGDAV} = 1;
+
+    # Initialize JMAP contact state and DAV sync-token.
+    my $res = $jmap->CallMethods([
+        ['Contact/get', { ids => [] }, 'R1']
+    ]);
+    my $contactState = $res->[0][1]{state};
+    $self->assert_not_null($contactState);
+
+    my ($syncChanged, $syncRemoved, $syncErrors, $syncToken) =
+        $carddav->SyncContactLinks('Default');
+
+    # Create contact with Contact API.
+    $res = $jmap->CallMethods([
+        ['Contact/set', {
+            create => {
+                1 => {
+                    lastName => 'test',
+                }
+            }
+        }, 'R1'],
+        ['Contact/get', {
+            ids => ['#1'],
+            properties => ['x-href', 'uid'],
+        }, 'R2'],
+    ]);
+    my $href = $res->[1][1]{list}[0]{'x-href'};
+    $self->assert_not_null($href);
+    my $v3uid = $res->[1][1]{list}[0]{'uid'};
+    $self->assert_not_null($v3uid);
+
+    # Sync changes with JMAP and CardDAV.
+    $res = $jmap->CallMethods([
+        ['Contact/changes', {
+            sinceState => $contactState,
+        }, 'R1']
+    ]);
+    $self->assert_deep_equals([$v3uid], $res->[0][1]{created});
+    $contactState = $res->[0][1]{newState};
+
+    ($syncChanged, $syncRemoved, $syncErrors, $syncToken) =
+        $carddav->SyncContactLinks('Default', syncToken => $syncToken);
+    $self->assert_deep_equals([$href], [keys %$syncChanged]);
+
+    # Rewrite UID in vCard by prefixing urn:uuid.
+    my $vcard = $carddav->Request('GET', $href)->{content};
+    my $v4uid = "urn:uuid:$v3uid";
+    $self->assert($vcard =~ s/^UID:$v3uid\r/UID:$v4uid/m);
+    $self->assert($vcard =~ s/^VERSION:3.0\r/VERSION:4.0\r/m);
+    $carddav->Request('PUT', $href, $vcard, 'Content-Type' => 'text/vcard');
+
+    # Sync changes with JMAP and CardDAV.
+    $res = $jmap->CallMethods([
+        ['Contact/get', {
+            properties => ['uid'],
+        }, 'R1'],
+        ['Contact/changes', {
+            sinceState => $contactState,
+        }, 'R2']
+    ]);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
+    $self->assert_str_equals($v4uid, $res->[0][1]{list}[0]{uid});
+    $self->assert_deep_equals([$v4uid], $res->[1][1]{updated});
+    $contactState = $res->[0][1]{newState};
+
+    ($syncChanged, $syncRemoved, $syncErrors, $syncToken) =
+        $carddav->SyncContactLinks('Default', syncToken => $syncToken);
+    $self->assert_deep_equals([$href], [keys %$syncChanged]);
+}

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -1299,6 +1299,7 @@ static int carddav_put(struct transaction_t *txn, void *obj,
     char *type = NULL, *subtype = NULL;
     struct param *params = NULL;
     const char *want_ver = NULL;
+    char *card_ver = NULL;
     int error_count = 0;
 
     /* Sanity check Content-Type */
@@ -1393,13 +1394,14 @@ static int carddav_put(struct transaction_t *txn, void *obj,
 
         switch (vcardproperty_isa(prop)) {
         case VCARD_VERSION_PROPERTY:
-            if (strcmp(propval, "3.0") &&
-                strcmp(propval, "4.0")) {
+            card_ver = xstrdup(propval);
+            if (strcmp(card_ver, "3.0") &&
+                strcmp(card_ver, "4.0")) {
                 txn->error.precond = CARDDAV_SUPP_DATA;
                 txn->error.desc = "Unsupported vCard version";
                 goto done;
             }
-            if (want_ver && (want_ver[0] != propval[0])) {
+            if (want_ver && (want_ver[0] != card_ver[0])) {
                 txn->error.precond = CARDDAV_VALID_DATA;
                 txn->error.desc =
                     "Content-Type version= and vCard VERSION mismatch";
@@ -1433,7 +1435,30 @@ static int carddav_put(struct transaction_t *txn, void *obj,
         goto done;
     }
 
-    txn->error.precond = check_uid_conflict(txn, mailbox, resource, uid, db);
+    /* Check for changed UID */
+    struct carddav_data *cdata;
+    carddav_lookup_resource(db, txn->req_tgt.mbentry, resource, &cdata, 0);
+
+    const char *olduid = cdata->vcard_uid;
+    const char *newuid = uid;
+    if (cdata->dav.imap_uid && olduid && newuid
+        && cdata->version == 3 && !strcmpsafe(card_ver, "4.0")
+        && !strncasecmp(newuid, "urn:uuid:", 9)
+        && !strcmp(olduid, newuid + 9))
+    {
+        // XXX quirk
+        // This is a PUT that rewrites a version 3 vCard to version 4
+        // and prefixes the UID value of the former card with the
+        // verbatim string "urn:uuid". Strictly speaking, this is not
+        // allowed and would require us to reject this with a
+        // no-uid-conflict precondition error. But previous versions
+        // of Cyrus did allow to do so and there is at least one client
+        // (eMClient) that does these bogus rewrites, so let's allow
+        // this case until they got a chance to fix their code.
+    }
+    else {
+        txn->error.precond = check_uid_conflict(txn, mailbox, resource, uid, db);
+    }
 
   done:
     param_free(&params);
@@ -1441,6 +1466,7 @@ static int carddav_put(struct transaction_t *txn, void *obj,
     free(fullname);
     free(subtype);
     free(type);
+    free(card_ver);
 
     if (txn->error.precond) return HTTP_FORBIDDEN;
 


### PR DESCRIPTION
This allows CardDAV PUTs that rewrite a version 3 vCard to version 4 and prefix the UID value of the former card with the verbatim string "urn:uuid".

Strictly speaking, this is not allowed and would require us to reject this with a no-uid-conflict precondition error. But previous versions of Cyrus did allow to do so and there is at least one client (eMClient) that does these bogus rewrites, so let's allow this case until they got a chance to fix their code.