### PR TITLE
consolidate cassandane 'other' configuration sections

### DIFF
--- a/cassandane/Cassandane/BuildInfo.pm
+++ b/cassandane/Cassandane/BuildInfo.pm
@@ -90,6 +90,8 @@ sub get
 {
     my ($self, $category, $key) = @_;
 
+    return if not exists $self->{data}->{$category};
+    return $self->{data}->{$category} if not defined $key;
     return if not exists $self->{data}->{$category}->{$key};
     return $self->{data}->{$category}->{$key};
 }

--- a/cassandane/Cassandane/BuildInfo.pm
+++ b/cassandane/Cassandane/BuildInfo.pm
@@ -46,19 +46,15 @@ use Cassandane::Cassini;
 use Cassandane::Util::Log;
 
 sub new {
-    my $class = shift;
-    my %params = @_;
+    my ($class, $installation) = @_;
     my $self = {};
+
+    $installation ||= 'default';
 
     my $cassini = Cassandane::Cassini->instance();
 
-    my $prefix = $cassini->val("cyrus default", 'prefix', '/usr/cyrus');
-    $prefix = $params{cyrus_prefix}
-        if defined $params{cyrus_prefix};
-
-    my $destdir = $cassini->val("cyrus default", 'destdir', '');
-    $destdir = $params{cyrus_destdir}
-        if defined $params{cyrus_destdir};
+    my $destdir = $cassini->val("cyrus $installation", 'destdir', '');
+    my $prefix = $cassini->val("cyrus $installation", 'prefix', '/usr/cyrus');
 
     $self->{data} = _read_buildinfo($destdir, $prefix);
 

--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -95,8 +95,6 @@ sub new
 
 sub default
 {
-    my $default_backend = $ENV{CASSANDANE_DEFAULT_DB} // 'twom';
-
     if (!defined($default)) {
         $default = Cassandane::Config->new(
             admins => 'admin mailproxy mupduser repluser',
@@ -120,24 +118,6 @@ sub default
             chatty => 'yes',
             debug => 'yes',
             httpprettytelemetry => 'yes',
-
-            # from cyr_info conf-default | grep _db:
-            annotation_db => $default_backend,
-            conversations_db => $default_backend,
-            duplicate_db => $default_backend,
-            mboxkey_db => $default_backend,
-            mboxlist_db => $default_backend,
-            ptscache_db => $default_backend,
-            quota_db => 'quotalegacy',
-            search_indexed_db => $default_backend,
-            seenstate_db => $default_backend,
-            subscription_db => 'flat',
-            statuscache_db => $default_backend,
-            sync_cache_db => $default_backend,
-            tlscache_db => 'twoskip', # deprecated, does not allow twom
-            tls_sessions_db => $default_backend,
-            userdeny_db => 'flat',
-            zoneinfo_db => $default_backend,
 
             # smtpclient_open should fail by default!
             #

--- a/cassandane/Cassandane/Config.pm
+++ b/cassandane/Cassandane/Config.pm
@@ -197,6 +197,24 @@ sub set
     }
 }
 
+sub set_if_undef
+{
+    my ($self, %nv) = @_;
+
+    while (my ($n, $v) = each %nv) {
+        if (exists $bitfields{$n}) {
+            # XXX bitfield behaviour?
+            die "can't set_if_undef with bitfield '$n'";
+        }
+        elsif (not defined $self->get($n)) {
+            $self->{params}->{$n} = $v;
+        }
+        else {
+            # nothing to do
+        }
+    }
+}
+
 sub set_bits
 {
     my ($self, $name, @bits) = @_;

--- a/cassandane/Cassandane/Cyrus/CassMeta.pm
+++ b/cassandane/Cassandane/Cyrus/CassMeta.pm
@@ -1,0 +1,135 @@
+#!/usr/bin/perl
+# Cassandane::Cyrus::CassMeta: Cassandane meta-tests that need Cyrus
+# (as distinct from Cassandane::Test::*, which don't need Cyrus)
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+package Cassandane::Cyrus::CassMeta;
+use strict;
+use warnings;
+use Data::Dumper;
+
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+
+# See Cassandane::Cyrus::TestCase::_create_instances()
+my @all_instance_names = qw(instance replica frontend backend2);
+
+sub new
+{
+    my $class = shift;
+
+    my $config = Cassandane::Config->default()->clone();
+
+    # override ONE cyrusdb backend to a value that is:
+    #   a) not its usual default
+    #   b) not one that Cassandane::Instance ever prefers
+    #   c) not one that master will reject for that database
+    # so that test_cyrusdb_default_backends can determine whether suite-level
+    # overrides like this are working correctly
+    $config->set('subscription_db' => 'skiplist');
+
+    # turn on murder and replication so we can examine all possible instances
+    my $self = $class->SUPER::new({
+        config => $config,
+        imapmurder => 1,
+        replica => 1,
+    }, @_);
+
+    $self->needs('component', 'murder');
+    $self->needs('component', 'replication');
+
+    return $self;
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+    $self->SUPER::tear_down();
+}
+
+sub test_cyrusdb_default_backends
+{
+    my ($self) = @_;
+
+    my @regular_databases = qw(
+        annotation_db
+        conversations_db
+        duplicate_db
+        mboxkey_db
+        mboxlist_db
+        ptscache_db
+        search_indexed_db
+        seenstate_db
+        statuscache_db
+        sync_cache_db
+        tls_sessions_db
+        zoneinfo_db
+    );
+
+    my @regular_backends = grep { defined }
+                           ($ENV{CASSANDANE_DEFAULT_DB}, 'twom', 'twoskip');
+
+    my %irregular_databases = (
+        quota_db => 'quotalegacy',
+        subscription_db => 'skiplist', # usually 'flat', but we overrode it!
+        tlscache_db => 'twoskip',
+        userdeny_db => 'flat',
+    );
+
+    foreach my $instance_name (@all_instance_names) {
+        my $instance = $self->{$instance_name}
+            || die "instance '$instance_name' not found";
+
+        if ($instance->{buildinfo}->get('cyrusdb', undef)) {
+            # Cassandane sets cyrusdb backends explicitly for Cyrus versions
+            # that report which backends they support
+
+            foreach my $database (@regular_databases) {
+                xlog "checking $database for $instance_name...";
+
+                my $backend = $instance->{config}->get($database);
+
+                # expect it to be set, and to a known backend
+                $self->assert_not_null($backend);
+                # XXX use assert_contains()
+                $self->assert_num_equals(1, scalar grep { $backend eq $_ }
+                                                        @regular_backends);
+            }
+
+            while (my ($database, $expect_backend) = each %irregular_databases) {
+                xlog "checking $database for $instance_name...";
+
+                my $backend = $instance->{config}->get($database);
+
+                $self->assert_not_null($backend);
+                $self->assert_str_equals($expect_backend, $backend);
+            }
+        }
+        else {
+            # other backends should not have been explicitly set
+            foreach my $database (@regular_databases, keys %irregular_databases) {
+                xlog "checking $database for $instance_name...";
+
+                my $backend = $instance->{config}->get($database);
+
+                if ($database eq 'subscription_db') {
+                    # we overrode this one in the constructor
+                    $self->assert_not_null($backend);
+                    $self->assert_str_equals('skiplist', $backend);
+                }
+                else {
+                    $self->assert_null($backend);
+                }
+            }
+        }
+    }
+}
+
+1;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -696,10 +696,10 @@ sub _create_instances
             unless ($self->{no_replicaonly}) {
                 $replica_params{config}->set(replicaonly => 'yes');
             }
-            my $cyrus_replica_prefix = $cassini->val('cyrus replica', 'prefix');
-            if (defined $cyrus_replica_prefix and -d $cyrus_replica_prefix) {
-                xlog $self, "replica instance: using [cyrus replica] configuration";
-                $replica_params{installation} = 'replica';
+            my $cyrus_other_prefix = $cassini->val('cyrus other', 'prefix');
+            if (defined $cyrus_other_prefix and -d $cyrus_other_prefix) {
+                xlog $self, "replica instance: using [cyrus other] configuration";
+                $replica_params{installation} = 'other';
             }
 
             my $class = ref $self;
@@ -744,10 +744,11 @@ sub _create_instances
                 proxy_password => 'mailproxy',
             );
 
-            my $cyrus_murder_prefix = $cassini->val('cyrus murder', 'prefix');
-            if (defined $cyrus_murder_prefix and -d $cyrus_murder_prefix) {
-                xlog $self, "murder instance: using [cyrus murder] configuration";
-                $instance_params{installation} = 'murder';
+            my $cyrus_other_prefix = $cassini->val('cyrus other', 'prefix');
+            if (defined $cyrus_other_prefix and -d $cyrus_other_prefix) {
+                xlog $self, "frontend instance: using [cyrus other] configuration";
+                xlog $self, "backend2 instance: using [cyrus other] configuration";
+                $instance_params{installation} = 'other';
             }
 
             my $class = ref $self;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -726,6 +726,9 @@ sub _create_instances
             $frontend_service_port = Cassandane::PortManager::alloc("localhost");
             $backend2_service_port = Cassandane::PortManager::alloc("localhost");
 
+            my %frontend_params = %instance_params;
+            my %backend2_params = %instance_params;
+
             # set up a front end on which we also run the mupdate master
             my $frontend_conf = $self->{_config}->clone();
             $frontend_conf->set(
@@ -748,14 +751,15 @@ sub _create_instances
             if (defined $cyrus_other_prefix and -d $cyrus_other_prefix) {
                 xlog $self, "frontend instance: using [cyrus other] configuration";
                 xlog $self, "backend2 instance: using [cyrus other] configuration";
-                $instance_params{installation} = 'other';
+                $frontend_params{installation} = 'other';
+                $backend2_params{installation} = 'other';
             }
 
             my $class = ref $self;
             my $name  = $self->{_name} =~ s/^test_//r;
-            $instance_params{description} = "murder frontend for test $class.$name";
-            $instance_params{config} = $frontend_conf;
-            $self->{frontend} = Cassandane::Instance->new(%instance_params,
+            $frontend_params{description} = "murder frontend for test $class.$name";
+            $frontend_params{config} = $frontend_conf;
+            $self->{frontend} = Cassandane::Instance->new(%frontend_params,
                                                           setup_mailbox => 0);
             $self->{frontend}->add_service(name => 'mupdate',
                                            port => $mupdate_port,
@@ -818,9 +822,9 @@ sub _create_instances
                 proxy_password => 'mailproxy',
             );
 
-            $instance_params{description} = "murder backend2 for test $class.$name";
-            $instance_params{config} = $backend2_conf;
-            $self->{backend2} = Cassandane::Instance->new(%instance_params,
+            $backend2_params{description} = "murder backend2 for test $class.$name";
+            $backend2_params{config} = $backend2_conf;
+            $self->{backend2} = Cassandane::Instance->new(%backend2_params,
                                                           setup_mailbox => 0); # XXX ?
             $self->{backend2}->add_services(@{$want->{services}});
 

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1353,8 +1353,7 @@ sub start
         }
     }
 
-    $self->{buildinfo} = Cassandane::BuildInfo->new($self->{cyrus_destdir},
-                                                    $self->{cyrus_prefix});
+    $self->{buildinfo} = Cassandane::BuildInfo->new($self->{installation});
 
     if (!$self->{re_use_dir} || ! -d $self->{basedir})
     {

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -97,7 +97,7 @@ sub new
 
     my $cassini = Cassandane::Cassini->instance();
 
-    my $self = {
+    my $self = bless({
         name => undef,
         buildinfo => undef,
         basedir => undef,
@@ -124,7 +124,7 @@ sub new
         _pid => $$,
         smtpdaemon => 0,
         lsan_suppressions => "",
-    };
+    }, $class);
 
     $self->{name} = $params{name}
         if defined $params{name};
@@ -207,7 +207,7 @@ sub new
 
     # XXX - get testcase name from caller, to apply even finer
     # configuration from cassini ?
-    return bless $self, $class;
+    return $self;
 }
 
 # return an id for use by xlog

--- a/cassandane/cassandane.ini.example
+++ b/cassandane/cassandane.ini.example
@@ -134,20 +134,11 @@
 ##coresizelimit = 100
 
 # This optional section describes the Cyrus installation used for the
-# replica side of replication tests.  You can use this to test
-# replication to a different Cyrus version from your main instance.
-# If this section does not exist, or the prefix it names does not
-# exist, then the replica instance will use the "cyrus default".
-##[cyrus replica]
-##prefix = /usr/cyrus
-##destdir =
-
-# This optional section describes the Cyrus installation used for the
-# murder frontend in murder tests.  You can use this to test a murder
-# with a different Cyrus version from your main instance.
-# If this section does not exist, or the prefix it names does not
-# exist, then the murder tests will use the "cyrus default".
-##[cyrus murder]
+# 'replica' instance in replication tests, and the 'frontend' and 'backend2'
+# instances in murder tests.  You can use this to test cross-version
+# interoperability.  If this section does not exist, or the prefix it names
+# does not exist, then "cyrus default" will be used as usual.
+##[cyrus other]
 ##prefix = /usr/cyrus
 ##destdir =
 

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -91,7 +91,7 @@ static json_t *buildinfo()
 {
     json_t *component = json_object();
     json_t *dependency = json_object();
-    json_t *database = json_object();
+    json_t *cyrusdb = json_object();
     json_t *search = json_object();
     json_t *hardware = json_object();
     json_t *buildconf = json_object();
@@ -100,7 +100,7 @@ static json_t *buildinfo()
 
     json_object_set_new(buildconf, "component", component);
     json_object_set_new(buildconf, "dependency", dependency);
-    json_object_set_new(buildconf, "database", database);
+    json_object_set_new(buildconf, "cyrusdb", cyrusdb);
     json_object_set_new(buildconf, "search", search);
     json_object_set_new(buildconf, "ical", ical);
     json_object_set_new(buildconf, "hardware", hardware);
@@ -265,21 +265,28 @@ static json_t *buildinfo()
     json_object_set_new(dependency, "guesstz", json_false());
 #endif
 
-    /* Enabled databases */
-#ifdef HAVE_MYSQL
-    json_object_set_new(database, "mysql", json_true());
+    /* cyrusdb backends */
+    json_object_set_new(cyrusdb, "flat", json_true());
+    json_object_set_new(cyrusdb, "quotalegacy", json_true());
+    json_object_set_new(cyrusdb, "skiplist", json_true());
+    json_object_set_new(cyrusdb, "twom", json_true());
+    json_object_set_new(cyrusdb, "twoskip", json_true());
+#ifdef USE_CYRUSDB_SQL
+    {
+        json_t *sql_engines = json_array();
+        json_object_set_new(cyrusdb, "sql", sql_engines);
+# ifdef HAVE_MYSQL
+        json_array_append_new(sql_engines, json_string("mysql"));
+# endif
+# ifdef HAVE_PGSQL
+        json_array_append_new(sql_engines, json_string("pgsql"));
+# endif
+# ifdef HAVE_SQLITE
+        json_array_append_new(sql_engines, json_string("sqlite"));
+# endif
+    }
 #else
-    json_object_set_new(database, "mysql", json_false());
-#endif
-#ifdef HAVE_PGSQL
-    json_object_set_new(database, "pgsql", json_true());
-#else
-    json_object_set_new(database, "pgsql", json_false());
-#endif
-#ifdef HAVE_SQLITE
-    json_object_set_new(database, "sqlite", json_true());
-#else
-    json_object_set_new(database, "sqlite", json_false());
+    json_object_set_new(cyrusdb, "sql", json_false());
 #endif
 
     /* Enabled search engines */


### PR DESCRIPTION
This PR:

* consolidates the former `[cyrus replica]` and `[cyrus murder]` cassandane.ini sections into a single `[cyrus other]` section that's used for both.  This makes setting up cross-version testing a bit more ergonomic.
* fixes a few places where Cassandane's cross-version testing support had been broken by changes that didn't take it into account.

With these changes on master, and a subset backported to older branches, it is once again possible to use Cassandane to test replication and murder interactions between Cyrus versions.  (Not all tests pass like this, but the failures are not due to Cassandane bugs.)