### PR TITLE
jmap_mail.c: properly report 'existingId' when appending identical message

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_import
+++ b/cassandane/tiny-tests/JMAPEmail/email_import
@@ -97,5 +97,6 @@ sub test_email_import
     }, "R1"]]);
     $self->assert_str_equals("Email/import", $res->[0][0]);
     $self->assert_str_equals("alreadyExists", $res->[0][1]->{notCreated}{"1"}{type});
-    $self->assert_not_null($res->[0][1]->{notCreated}{"1"}{existingId});
+    $self->assert_str_equals($msg->{id},
+                             $res->[0][1]->{notCreated}{"1"}{existingId});
 }


### PR DESCRIPTION
This fixes a bug where we were returning an empty string as 'existingId'