### PR TITLE
cyrdbbench: use the provided options argument

### DIFF
--- a/bench/cyrdbbench.c
+++ b/bench/cyrdbbench.c
@@ -368,13 +368,14 @@ static size_t do_write(int txnmode, int insmode)
     return bytes;
 }
 
-static int parse_options(int argc, char **argv, const struct option *options __attribute__((unused)))
+static int parse_options(int argc, char **argv, const struct option *options)
 {
     int option;
     int option_index;
 
     while ((option = getopt_long(argc, argv, "d:b:n:t:h?",
-                                 long_options, &option_index)) != -1) {
+                                 options, &option_index)) != -1)
+    {
         switch (option) {
             case 'b':
                 BENCHMARKS = optarg;


### PR DESCRIPTION
The argument was previously marked as unused to shush a compiler warning, but the better fix is to use it.

It came up because 3.12 suffers the same warning, but the commit that shushed the warning on master isn't suitable for backporting.  This PR gets us a better fix, but mostly gets me something I can backport to 3.12.