### PR TITLE
Cassandane::Cyrus::TestCase: Don't leak fds at the end of tests

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1079,6 +1079,11 @@ sub tear_down
     $self->{backend1_store} = undef;
     $self->{backend1_adminstore} = undef;
 
+    $self->{default_user} = undef;
+    $self->{jmap} = undef;
+    $self->{caldav} = undef;
+    $self->{carddav} = undef;
+
     my @stop_errors;
     my @basedirs;
 


### PR DESCRIPTION
testrunner.pl uses a pool of cassandane workers to run all of the tests.

Before the tests are run, Cassandane loads up all of the tests and creates either a Cassandane::Unit::TestCase or a Cassandane::Cyrus::TestCase object *for each individual test subroutine*.

When each Cassandane::Cyrus::TestCase object runs set_up, they might create a caldav, carddav, and jmaptester object and stash them on the TestCase. Doing this also creates a default_user which itself has an extra jmaptester object for test entity creation/interaction.

When the test is finished, the tear_down method is called, and this is expected to clean up any data that shouldn't be held on to once the test is finished.

Now...

If we hold onto caldav and carddav, one of these two keeps a TIME_WAIT socket fd open from its connection to cyrus' httpd which was shutdown uncleanly.

If we hold onto default_user and jmap, for each one that has made a request we leak another TIME_WAIT socket fd (because it's underlying LWP::UserAgent is using keep_alive), *and* we leak an fd to the logfile cassandane used to communicate between the child / parent testrunner processes per test, because cassandane creates the logfile and dupes the fd into STDOUT/STDERR, then JMAP::Tester captures it due to `$ENV{JMAP_TESTER_LOGGER} = 'HTTP:-2'`!

*Furthermore*, default_user holds onto a Cassandane::Instance, which leaks an fd to the syslog log file for the test through `_syslogfh`!

All of this together I believe fixes a further observed problem where when a Cassandane http process started by `start_httpd()` ends up in an infinite loop trying to read from a non-connected socket. This seems to happen when there are > 1024 fds lying around when it starts up. This is likely because `start_httpd()` is doing:

    POSIX::close( $_ ) for 3 .. 1024; ## Arbitrary upper bound

... which messes up Perl's internal tracking of handles vs file descriptors, breaking things in odd ways when those handles perl is tracking are closed out from under it and then reused by later code!

All of these fd leaks can be seen (without this fix) by doing:

    cyd test --format=pretty -- -vvv JMAPEmail -j 2

And in another window:

    ps auxwww | grep testrunner

And then on one of the two testrunner.pl children:

    lsof -p $thepid

As time goes on, you'll see this list get larger and larger:

    ./testrun 533896 cyrus   13w  FIFO               0,14      0t0 18002939 pipe
    ./testrun 533896 cyrus   14r   REG               0,57    71648  1074956 /tmp/cass/1951510101/conf/log/syslog
    ./testrun 533896 cyrus   15u  IPv4           17999768      0t0      TCP localhost:52294->localhost:29100 (CLOSE_WAIT)
    ./testrun 533896 cyrus   16u   REG               0,57    25018  8338015 /tmp/y53Eh63qoF (deleted)
    ./testrun 533896 cyrus   17r   REG               0,57        0  1076837 /tmp/cass/1951510107/reconstruct.err
    ./testrun 533896 cyrus   18u  IPv4           17999774      0t0      TCP localhost:52300->localhost:29100 (CLOSE_WAIT)
    ./testrun 533896 cyrus   19r   REG               0,57    71368  1075224 /tmp/cass/1951510102/conf/log/syslog
    ./testrun 533896 cyrus   20u  IPv4           18012246      0t0      TCP localhost:35024->localhost:29103 (CLOSE_WAIT)
    ./testrun 533896 cyrus   21u   REG               0,57    15943  8338017 /tmp/J6Nh42MmsH (deleted)
    ./testrun 533896 cyrus   22u  IPv4           17999808      0t0      TCP localhost:35026->localhost:29103 (CLOSE_WAIT)
    ./testrun 533896 cyrus   23r   REG               0,57    70633  1075431 /tmp/cass/1951510103/conf/log/syslog
    ./testrun 533896 cyrus   24u  IPv4           18005725      0t0      TCP localhost:57134->localhost:29106 (CLOSE_WAIT)
    ./testrun 533896 cyrus   25u   REG               0,57    17666  8338018 /tmp/ygiwlQa2Nn (deleted)
    ./testrun 533896 cyrus   26r   REG               0,57    74427  1075744 /tmp/cass/1951510104/conf/log/syslog

With the fix, you'll instead see:

    ./testrun 536900 cyrus   12u   CHR              136,3      0t0        6 /dev/pts/3
    ./testrun 536900 cyrus   13u   CHR              136,3      0t0        6 /dev/pts/3
    ./testrun 536900 cyrus   14u   CHR              136,3      0t0        6 /dev/pts/3
    ./testrun 536900 cyrus   15w  FIFO               0,14      0t0 18050668 pipe
    ./testrun 536900 cyrus   16r   REG               0,57       84  1205588 /tmp/cass/1953080207/conf/log/syslog
    ./testrun 536900 cyrus   19r   REG               0,57        0  1205516 /tmp/cass/1953080206/reconstruct.err

And the final two items will bounce between socket connections, temp files and other things, but will not grow