### PR TITLE
carddav_db.c: Strip shared/ prefix from group member queries

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_fromcontactgroupid_when_shared_addrbook_exists
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_fromcontactgroupid_when_shared_addrbook_exists
@@ -122,4 +122,18 @@ sub test_email_query_fromcontactgroupid_when_shared_addrbook_exists
     ], $using);
     $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
     $self->assert_str_equals($emailId1, $res->[0][1]{ids}[0]);
+
+    # Also filter using shared/ prefix
+    $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                fromContactGroupId => "shared/$contactGroupId1"
+            },
+            sort => [
+                { property => "subject" }
+            ],
+        }, 'R1']
+    ], $using);
+    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
+    $self->assert_str_equals($emailId1, $res->[0][1]{ids}[0]);
 }

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -767,6 +767,12 @@ EXPORTED int carddav_getmembers(struct carddav_db *carddavdb,
         (carddavdb->db->version >= DB_MBOXID_VERSION) ?
         mbentry->uniqueid : mbentry->name;
 
+    if (!strncmpsafe(vcard_uid, "shared/", 7)) {
+        /* strip legacy "shared/" prefix -- no longer needed*/
+        vcard_uid += 7;
+        if (!*vcard_uid) return 0; // can't just be "shared/"
+    }
+
     struct sqldb_bindval bval[] = {
         { ":mailbox",      SQLITE_TEXT,    { .s = mailbox            } },
         { ":vcard_uid",    SQLITE_TEXT,    { .s = vcard_uid          } },


### PR DESCRIPTION
We're already stripping it from _getemails, but we failed to strip it when querying groups for a list of members.

This prevented Email/query fromContactGroupId from working when the legacy 'shared/' prefix was used before the group uid.