### PR TITLE
TestCase: add :min_other_version and :max_other_version magic

### DIFF
--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -157,7 +157,7 @@ sub new
         jmap => 1,
         deliver => 1,
         adminstore => 1,
-        services => [ 'imap', 'http', 'sieve', 'backupcyrusd' ]
+        services => [ 'imap', 'http', 'sieve' ]
     }, @args);
 
     $self->needs('component', 'jmap');

--- a/cassandane/Cassandane/Cyrus/Reconstruct.pm
+++ b/cassandane/Cassandane/Cyrus/Reconstruct.pm
@@ -696,6 +696,7 @@ sub test_downgrade_upgrade
 sub test_upgrade_v19_to_v20
     :MailboxLegacyDirs :NoAltNameSpace :Conversations :Replication
     :NoStartInstances
+    :min_version_3_13 :min_other_version_3_13
 {
     my ($self) = @_;
 

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -566,7 +566,7 @@ sub _run_magic
 
             my $m = lc($a);
             # ignore min/max version attribution here
-            next if $a =~ m/^(?:min|max)_version_/;
+            next if $a =~ m/^(?:min|max)_(?:other_)?version_/;
             # ignore feature test attribution here
             next if $a =~ m/^needs_/;
             # ignore want attribution here

--- a/cassandane/Cassandane/Unit/TestCase.pm
+++ b/cassandane/Cassandane/Unit/TestCase.pm
@@ -74,13 +74,15 @@ sub _skip_version
 {
     my ($str) = @_;
 
-    return if not $str =~ m/^(min|max)_version_([\d_]+)$/;
+    return if not $str =~ m/^(min|max)_(other_)?version_([\d_]+)$/;
     my $minmax = $1;
+    my $installation = ($2 ? 'other' : 'default');
     my ($lim_major, $lim_minor, $lim_revision, $lim_commits)
-        = map { 0 + $_ } split /_/, $2;
+        = map { 0 + $_ } split /_/, $3;
     return if not defined $lim_major;
 
-    my ($major, $minor, $revision, $commits) = Cassandane::Instance->get_version();
+    my ($major, $minor, $revision, $commits)
+        = Cassandane::Instance->get_version($installation);
 
     if ($minmax eq 'min') {
         return 1 if $major < $lim_major; # too old, skip!
@@ -153,7 +155,7 @@ sub filter
             my $sub = $self->can($self->{_name});
             return if not defined $sub;
             foreach my $attr (attributes::get($sub)) {
-                next if $attr !~ m/^(?:min|max)_version_[\d_]+$/;
+                next if $attr !~ m/^(?:min|max)_(?:other_)?version_[\d_]+$/;
                 return 1 if _skip_version($attr);
             }
             return;

--- a/cassandane/tiny-tests/FastMail/backupcyrusd
+++ b/cassandane/tiny-tests/FastMail/backupcyrusd
@@ -6,6 +6,7 @@ use Cyrus::Backup;
 use Cyrus::Backup::Restore;
 
 sub test_backupcyrusd
+    :min_version_3_13 :want_service_backupcyrusd
 {
     my ($self) = @_;
 


### PR DESCRIPTION
This is the same as :min_version and :max_version, except that it asserts that the 'other' instance meets some version criteria for tests that spin up multiple instances.  This is the 'replica' instance in replication tests, and the 'frontend' and 'backend2' instances in murder tests.

This should be used sparingly for preventing false negatives during cross-version testing:

* tests that exercise some new protocol feature that is known to be not understood by older versions can be marked :min_older_version_x_y (where x.y is when the feature was added)
* tests that exercised some protocol feature that has been removed can be annotated :max_other_version_x_y (where x.y was the last version that contained the feature)

Also fixes a couple of cross-version problems of the low-hanging fruit variety.