### PR TITLE
JMAP: require accountId unless specified otherwise

### DIFF
--- a/cassandane/Cassandane/JMAPTester.pm
+++ b/cassandane/Cassandane/JMAPTester.pm
@@ -7,5 +7,12 @@ use MIME::Base64 ();
 
 with 'Cassandane::Role::JMAPTester';
 
+has '+default_arguments' => (
+  lazy    => 1,
+  default => sub ($self) {
+    return { accountId => $self->fallback_account_id };
+  },
+);
+
 no Moo;
 1;

--- a/cassandane/Cassandane/JMAPTesterWS.pm
+++ b/cassandane/Cassandane/JMAPTesterWS.pm
@@ -15,6 +15,13 @@ use MIME::Base64 ();
 
 with 'Cassandane::Role::JMAPTester';
 
+has '+default_arguments' => (
+  lazy    => 1,
+  default => sub ($self) {
+    return { accountId => $self->fallback_account_id };
+  },
+);
+
 around set_scheme_and_host_and_port => sub ($orig, $self, $scheme, $host, $port) {
     $self->$orig($scheme, $host, $port);
 

--- a/cassandane/tiny-tests/FastMail/rename_deepuser_standardfolders
+++ b/cassandane/tiny-tests/FastMail/rename_deepuser_standardfolders
@@ -72,7 +72,9 @@ sub test_rename_deepuser_standardfolders
     $res = $admintalk->select("user.newuser.bar.sub");
     $self->assert(not $admintalk->get_last_error());
 
-    $data = $self->_fmjmap_ok('Mailbox/get', properties => ['name']);
+    $data = $self->_fmjmap_ok('Mailbox/get',
+                              accountId => 'newuser',
+                              properties => ['name']);
     my %byname_new = map { $_->{name} => $_->{id} } @{$data->{list}};
 
     $self->assert_deep_equals(\%byname, \%byname_new);
@@ -91,7 +93,10 @@ sub test_rename_deepuser_standardfolders
     $self->check_replication('newuser');
 
     $rjmap->set_username_and_password('newuser', 'pass');
-    $data = $self->_fmjmap_ok('Mailbox/get', jmap => $rjmap, properties => ['name']);
+    $data = $self->_fmjmap_ok('Mailbox/get',
+                              jmap => $rjmap,
+                              accountId => 'newuser',
+                              properties => ['name']);
     my %byname_newrepl = map { $_->{name} => $_->{id} } @{$data->{list}};
 
     $self->assert_deep_equals(\%byname, \%byname_newrepl);

--- a/cassandane/tiny-tests/FastMail/rename_deepuser_standardfolders_rightnow
+++ b/cassandane/tiny-tests/FastMail/rename_deepuser_standardfolders_rightnow
@@ -71,7 +71,9 @@ sub test_rename_deepuser_standardfolders_rightnow
     $res = $admintalk->select("user.newuser.bar.sub");
     $self->assert(not $admintalk->get_last_error());
 
-    $data = $self->_fmjmap_ok('Mailbox/get', properties => ['name']);
+    $data = $self->_fmjmap_ok('Mailbox/get',
+                              accountId => 'newuser',
+                              properties => ['name']);
     my %byname_new = map { $_->{name} => $_->{id} } @{$data->{list}};
 
     $self->assert_deep_equals(\%byname, \%byname_new);
@@ -87,7 +89,10 @@ sub test_rename_deepuser_standardfolders_rightnow
     $self->check_replication('newuser');
 
     $rjmap->set_username_and_password('newuser', 'pass');
-    $data = $self->_fmjmap_ok('Mailbox/get', jmap => $rjmap, properties => ['name']);
+    $data = $self->_fmjmap_ok('Mailbox/get',
+                              jmap => $rjmap,
+                              accountId => 'newuser',
+                              properties => ['name']);
     my %byname_newrepl = map { $_->{name} => $_->{id} } @{$data->{list}};
 
     $self->assert_deep_equals(\%byname, \%byname_newrepl);

--- a/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
@@ -29,7 +29,9 @@ sub test_admin_migrate39_defaultalerts
 
     xlog $self, "Make sure regular user can't call Admin method";
     my $res = $jmap->CallMethods([
-        ['Admin/migrateCalendarDefaultAlarms', {}, 'R1'],
+        ['Admin/migrateCalendarDefaultAlarms', {
+            accountId => \undef  # suppress auto-add by JMAPTester
+         }, 'R1'],
     ], \@using);
     $self->assert_str_equals('accountNotSupportedByMethod',
         $res->[0][1]{type});
@@ -44,7 +46,9 @@ sub test_admin_migrate39_defaultalerts
 
     xlog $self, "Migrate default alarms";
     $res = $adminJmap->CallMethods([
-        ['Admin/migrateCalendarDefaultAlarms', { }, 'R1'],
+        ['Admin/migrateCalendarDefaultAlarms', {
+            accountId => \undef  # suppress auto-add by JMAPTester
+         }, 'R1'],
     ]);
 
     $state->{did_migrate} = 1;

--- a/cassandane/tiny-tests/JMAPCalendars/admin_rewrite_calendarevent_privacy
+++ b/cassandane/tiny-tests/JMAPCalendars/admin_rewrite_calendarevent_privacy
@@ -21,7 +21,9 @@ sub test_admin_rewrite_calendarevent_privacy
 
     xlog $self, "Make sure regular user can't call Admin method";
     my $res = $jmap->CallMethods([
-        ['Admin/rewriteCalendarEventPrivacy', {}, 'R1'],
+        ['Admin/rewriteCalendarEventPrivacy', {
+            accountId => \undef  # suppress auto-add by JMAPTester
+         }, 'R1'],
     ], \@using);
     $self->assert_str_equals('accountNotSupportedByMethod',
         $res->[0][1]{type});
@@ -129,7 +131,9 @@ sub test_admin_rewrite_calendarevent_privacy
 
     xlog $self, "Rewrite calendar event privacy as admin";
     $res = $adminJmap->CallMethods([
-        ['Admin/rewriteCalendarEventPrivacy', {}, 'R1'],
+        ['Admin/rewriteCalendarEventPrivacy', {
+            accountId => \undef  # suppress auto-add by JMAPTester
+         }, 'R1'],
     ]);
     $self->assert_num_equals(1,
         scalar keys %{$res->[0][1]{rewritten}{cassandane}});

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy
@@ -89,7 +89,7 @@ sub test_calendarevent_copy
             ids => [$copiedEventId],
         }, 'R1'],
         ['CalendarEvent/get', {
-            accountId => undef,
+            accountId => 'cassandane',
             ids => [$eventId],
         }, 'R2'],
     ]);

--- a/cassandane/tiny-tests/JMAPContacts/card_copy
+++ b/cassandane/tiny-tests/JMAPContacts/card_copy
@@ -107,7 +107,7 @@ sub test_card_copy
             ids => [$copiedCardId],
         }, 'R1'],
         ['ContactCard/get', {
-            accountId => undef,
+            accountId => 'cassandane',
             ids => [$cardId],
         }, 'R2'],
     ]);
@@ -207,7 +207,7 @@ sub test_card_copy
             ids => [$copiedCardId],
         }, 'R1'],
         ['ContactCard/get', {
-            accountId => undef,
+            accountId => 'cassandane',
             ids => [$cardId],
         }, 'R2'],
     ]);

--- a/cassandane/tiny-tests/JMAPContacts/contact_copy
+++ b/cassandane/tiny-tests/JMAPContacts/contact_copy
@@ -77,7 +77,7 @@ sub test_contact_copy
             ids => [$copiedCardId],
         }, 'R1'],
         ['Contact/get', {
-            accountId => undef,
+            accountId => 'cassandane',
             ids => [$cardId],
         }, 'R2'],
     ]);
@@ -120,7 +120,7 @@ sub test_contact_copy
             ids => [$copiedCardId],
         }, 'R1'],
         ['Contact/get', {
-            accountId => undef,
+            accountId => 'cassandane',
             ids => [$cardId],
         }, 'R2'],
     ]);
@@ -172,7 +172,7 @@ sub test_contact_copy
             ids => [$copiedCardId],
         }, 'R1'],
         ['Contact/get', {
-            accountId => undef,
+            accountId => 'cassandane',
             ids => [$cardId],
         }, 'R2'],
     ]);

--- a/cassandane/tiny-tests/JMAPCore/created_ids
+++ b/cassandane/tiny-tests/JMAPCore/created_ids
@@ -10,7 +10,7 @@ sub test_created_ids
     xlog $self, "send bogus creation ids map";
     my $err = $jmap->request({
         using => ['urn:ietf:params:jmap:mail'],
-        methodCalls => [['Identity/get', {}, 'R1']],
+        methodCalls => [['Identity/get', { accountId => 'cassandane' }, 'R1']],
         createdIds => 'bogus',
     });
 
@@ -19,6 +19,7 @@ sub test_created_ids
     xlog $self, "create a mailbox without any client-supplied creation ids";
     my $res = $jmap->request({
         methodCalls => [['Mailbox/set', {
+            accountId => 'cassandane',
             create => {
                 "1" => {
                     name => "foo",
@@ -36,7 +37,10 @@ sub test_created_ids
     xlog $self, "get mailbox using client-supplied creation id";
     $res = $jmap->request({
         using => ['urn:ietf:params:jmap:mail'],
-        methodCalls => [['Mailbox/get', { ids => ['#1'] }, 'R1']],
+        methodCalls => [['Mailbox/get', {
+            accountId => 'cassandane',
+            ids => ['#1']
+        }, 'R1']],
         createdIds => { 1 => $mboxid1 },
     });
     $self->assert_str_equals($mboxid1, $res->sentence_named('Mailbox/get')->arguments->{list}[0]{id});
@@ -47,6 +51,7 @@ sub test_created_ids
     $res = $jmap->request({
         using => ['urn:ietf:params:jmap:mail'],
         methodCalls => [['Mailbox/set', {
+            accountId => 'cassandane',
             create => {
                 "2" => {
                     name => "bar",
@@ -64,6 +69,7 @@ sub test_created_ids
     $res = $jmap->request({
         using => ['urn:ietf:params:jmap:mail'],
         methodCalls => [['Mailbox/set', {
+            accountId => 'cassandane',
             create => {
                 "3" => {
                     name => "baz",
@@ -85,7 +91,11 @@ sub test_created_ids
     xlog $self, "get mailbox and check parentid";
     $res = $jmap->request({
         using => ['urn:ietf:params:jmap:mail'],
-        methodCalls => [['Mailbox/get', { ids => [$mboxid3], properties => ['parentId'] }, 'R1']],
+        methodCalls => [['Mailbox/get', {
+            accountId => 'cassandane',
+            ids => [$mboxid3],
+            properties => ['parentId']
+        }, 'R1']],
     });
 
     $self->assert_str_equals($mboxid3, $res->sentence_named('Mailbox/get')->arguments->{list}[0]{id});

--- a/cassandane/tiny-tests/JMAPCore/echo
+++ b/cassandane/tiny-tests/JMAPCore/echo
@@ -8,6 +8,7 @@ sub test_echo
     my $jmap = $self->{jmap};
 
     my $req = {
+        accountId => JSON::null,
         hello => JSON::true,
         max => 5,
         stuff => { foo => "bar", empty => JSON::null }

--- a/cassandane/tiny-tests/JMAPCore/echo_tls
+++ b/cassandane/tiny-tests/JMAPCore/echo_tls
@@ -11,6 +11,7 @@ sub test_echo_tls
     $self->assert_matches(qr/^https:/, $jmap->api_uri);
 
     my $req = {
+        accountId => \undef,  # suppress auto-add by JMAPTester
         hello => JSON::true,
         max => 5,
         stuff => { foo => "bar", empty => JSON::null }
@@ -18,6 +19,9 @@ sub test_echo_tls
 
     xlog $self, "send ping";
     my $res = $jmap->CallMethods([['Core/echo', $req, "R1"]]);
+
+    # Delete accountId from request since it won't be in the response
+    delete $req->{accountId};
 
     xlog $self, "check pong";
     $self->assert_not_null($res);

--- a/cassandane/tiny-tests/JMAPCore/identity_get
+++ b/cassandane/tiny-tests/JMAPCore/identity_get
@@ -13,9 +13,11 @@ sub test_identity_get
     ];
 
     my $res = $jmap->CallMethods([
-        ['Identity/get', { }, 'R1'],
-        ['Identity/get', { ids => undef }, 'R2'],
-        ['Identity/get', { ids => [] }, 'R3'],
+        ['Identity/get', { accountId => 'cassandane'               }, 'R1'],
+        ['Identity/get', { accountId => 'cassandane', ids => undef }, 'R2'],
+        ['Identity/get', { accountId => 'cassandane', ids => []    }, 'R3'],
+        ['Identity/get', { accountId => JSON::null                 }, 'R4'],
+        ['Identity/get', {                                         }, 'R5'],
     ], $using);
 
     $self->assert_str_equals('Identity/get', $res->[0][0]);
@@ -30,4 +32,24 @@ sub test_identity_get
 
     $self->assert_deep_equals([], $res->[2][1]{list});
     $self->assert_not_null($res->[2][1]->{state});
+
+    $self->assert_deep_equals([
+        'error',
+        {
+            type => 'invalidArguments',
+            arguments => [ 'accountId' ]
+        },
+        'R4'
+        ], $res->[3]
+    );
+
+    $self->assert_deep_equals([
+        'error',
+        {
+            type => 'invalidArguments',
+            arguments => [ 'accountId' ]
+        },
+        'R5'
+        ], $res->[4]
+    );
 }

--- a/cassandane/tiny-tests/JMAPCore/identity_get
+++ b/cassandane/tiny-tests/JMAPCore/identity_get
@@ -43,13 +43,8 @@ sub test_identity_get
         ], $res->[3]
     );
 
-    $self->assert_deep_equals([
-        'error',
-        {
-            type => 'invalidArguments',
-            arguments => [ 'accountId' ]
-        },
-        'R5'
-        ], $res->[4]
-    );
+    # accountId is auto-added by JMAPTester
+    $self->assert_num_equals(1, scalar @{$res->[4][1]{list}});
+    $self->assert_str_equals('cassandane', $res->[4][1]{list}[0]{id});
+    $self->assert_not_null($res->[4][1]->{state});
 }

--- a/cassandane/tiny-tests/JMAPCore/user_counters
+++ b/cassandane/tiny-tests/JMAPCore/user_counters
@@ -13,7 +13,7 @@ sub test_user_counters
     ];
 
     my $res = $jmap->CallMethods([
-        ['UserCounters/get', {}, "R1"]
+        ['UserCounters/get', { accountId => 'cassandane' }, "R1"]
     ], $using);
 
     my %expect = map {; $_ => 1 } qw(

--- a/cassandane/tiny-tests/JMAPEmail/email_query
+++ b/cassandane/tiny-tests/JMAPEmail/email_query
@@ -7,7 +7,7 @@ sub test_email_query
 {
     my $jmap = $self->{jmap};
 
-    my $account = undef;
+    my $account = 'cassandane';
     my $store = $self->{store};
     my $mboxprefix = "INBOX";
     my $talk = $store->get_client();

--- a/cassandane/tiny-tests/JMAPEmail/email_query_bcc
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_bcc
@@ -7,7 +7,7 @@ sub test_email_query_bcc
 {
     my $jmap = $self->{jmap};
 
-    my $account = undef;
+    my $account = 'cassandane';
     my $store = $self->{store};
     my $mboxprefix = "INBOX";
     my $talk = $store->get_client();

--- a/cassandane/tiny-tests/JMAPEmail/email_query_collapse
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_collapse
@@ -39,11 +39,13 @@ sub test_email_query_collapse
         $exp{C} = $self->make_message("Re: Email A", %params);
         $exp{C}->set_attributes(uid => 3, cid => $exp{A}->get_attribute('cid'));
 
+        my %account_args = $account ? (accountId => $account) : ();
+
         xlog $self, "list uncollapsed threads";
-        $res = $jmap->CallMethods([['Email/query', { accountId => $account }, "R1"]]);
+        $res = $jmap->CallMethods([['Email/query', { %account_args }, "R1"]]);
         $self->assert_num_equals(3, scalar @{$res->[0][1]->{ids}});
 
-        $res = $jmap->CallMethods([['Email/query', { accountId => $account, collapseThreads => JSON::true }, "R1"]]);
+        $res = $jmap->CallMethods([['Email/query', { %account_args, collapseThreads => JSON::true }, "R1"]]);
         $self->assert_num_equals(2, scalar @{$res->[0][1]->{ids}});
     }
 }

--- a/cassandane/tiny-tests/JMAPEmail/email_query_inmailbox_before
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_inmailbox_before
@@ -7,7 +7,7 @@ sub test_email_query_inmailbox_before
 {
     my $jmap = $self->{jmap};
 
-    my $account = undef;
+    my $account = 'cassandane';
     my $store = $self->{store};
     my $mboxprefix = "INBOX";
     my $talk = $store->get_client();

--- a/cassandane/tiny-tests/JMAPEmail/email_query_multiple_to_cross_domain
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_multiple_to_cross_domain
@@ -8,7 +8,7 @@ sub test_email_query_multiple_to_cross_domain
 {
     my $jmap = $self->{jmap};
 
-    my $account = undef;
+    my $account = 'cassandane';
     my $store = $self->{store};
     my $mboxprefix = "INBOX";
     my $talk = $store->get_client();

--- a/cassandane/tiny-tests/JMAPEmail/email_query_shared
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_shared
@@ -18,7 +18,9 @@ sub test_email_query_shared
         my $mboxprefix = defined $account ? "user.$account" : "INBOX";
         my $talk = $store->get_client();
 
-        my $res = $jmap->CallMethods([['Mailbox/get', { accountId => $account }, "R1"]]);
+        my %account_args = $account ? (accountId => $account) : ();
+
+        my $res = $jmap->CallMethods([['Mailbox/get', { %account_args }, "R1"]]);
         my $inboxid = $res->[0][1]{list}[0]{id};
 
         xlog $self, "create mailboxes";
@@ -26,7 +28,7 @@ sub test_email_query_shared
         $talk->create("$mboxprefix.B") || die;
         $talk->create("$mboxprefix.C") || die;
 
-        $res = $jmap->CallMethods([['Mailbox/get', { accountId => $account }, "R1"]]);
+        $res = $jmap->CallMethods([['Mailbox/get', { %account_args }, "R1"]]);
         my %m = map { $_->{name} => $_ } @{$res->[0][1]{list}};
         my $mboxa = $m{"A"}->{id};
         my $mboxb = $m{"B"}->{id};
@@ -97,9 +99,9 @@ sub test_email_query_shared
 
         xlog $self, "fetch emails without filter";
         $res = $jmap->CallMethods([
-                ['Email/query', { accountId => $account }, 'R1'],
+                ['Email/query', { %account_args }, 'R1'],
                 ['Email/get', {
-                        accountId => $account,
+                        %account_args,
                         '#ids' => { resultOf => 'R1', name => 'Email/query', path => '/ids' }
                     }, 'R2'],
             ]);
@@ -114,7 +116,7 @@ sub test_email_query_shared
 
         xlog $self, "filter text";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             text => "foo",
                         },
@@ -124,7 +126,7 @@ sub test_email_query_shared
 
         xlog $self, "filter NOT text";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             operator => "NOT",
                             conditions => [ {text => "foo"} ],
@@ -135,7 +137,7 @@ sub test_email_query_shared
 
         xlog $self, "filter mailbox A";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             inMailbox => $mboxa,
                         },
@@ -145,7 +147,7 @@ sub test_email_query_shared
 
         xlog $self, "filter mailboxes";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             operator => 'OR',
                             conditions => [
@@ -163,7 +165,7 @@ sub test_email_query_shared
 
         xlog $self, "filter mailboxes with not in";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             inMailboxOtherThan => [$mboxb],
                         },
@@ -173,7 +175,7 @@ sub test_email_query_shared
 
         xlog $self, "filter mailboxes with not in";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             inMailboxOtherThan => [$mboxa],
                         },
@@ -182,7 +184,7 @@ sub test_email_query_shared
 
         xlog $self, "filter mailboxes with not in";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             inMailboxOtherThan => [$mboxa, $mboxc],
                         },
@@ -192,7 +194,7 @@ sub test_email_query_shared
 
         xlog $self, "filter mailboxes";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             operator => 'AND',
                             conditions => [
@@ -212,7 +214,7 @@ sub test_email_query_shared
 
         xlog $self, "filter not in mailbox A";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             operator => 'NOT',
                             conditions => [
@@ -228,7 +230,7 @@ sub test_email_query_shared
         xlog $self, "filter by before";
         my $dtbefore = $dtfoo->clone()->subtract(seconds => 1);
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             before => $dtbefore->strftime('%Y-%m-%dT%TZ'),
                         },
@@ -239,7 +241,7 @@ sub test_email_query_shared
         xlog $self, "filter by after",
         my $dtafter = $dtbar->clone()->add(seconds => 1);
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             after => $dtafter->strftime('%Y-%m-%dT%TZ'),
                         },
@@ -249,7 +251,7 @@ sub test_email_query_shared
 
         xlog $self, "filter by after and before",
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             after => $dtafter->strftime('%Y-%m-%dT%TZ'),
                             before => $dtbefore->strftime('%Y-%m-%dT%TZ'),
@@ -259,7 +261,7 @@ sub test_email_query_shared
 
         xlog $self, "filter by minSize";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             minSize => length($bodybar),
                         },
@@ -269,7 +271,7 @@ sub test_email_query_shared
 
         xlog $self, "filter by maxSize";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             maxSize => length($bodybar),
                         },
@@ -279,7 +281,7 @@ sub test_email_query_shared
 
         xlog $self, "filter by header";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             header => [ "x-tra" ],
                         },
@@ -289,7 +291,7 @@ sub test_email_query_shared
 
         xlog $self, "filter by header and value";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         filter => {
                             header => [ "x-tra", "bam" ],
                         },
@@ -298,7 +300,7 @@ sub test_email_query_shared
 
         xlog $self, "sort by ascending receivedAt";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         sort => [{ property => "receivedAt" }],
                     }, "R1"]]);
         $self->assert_num_equals(2, scalar @{$res->[0][1]->{ids}});
@@ -307,7 +309,7 @@ sub test_email_query_shared
 
         xlog $self, "sort by descending receivedAt";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         sort => [{ property => "receivedAt", isAscending => JSON::false, }],
                     }, "R1"]]);
         $self->assert_num_equals(2, scalar @{$res->[0][1]->{ids}});
@@ -316,7 +318,7 @@ sub test_email_query_shared
 
         xlog $self, "sort by ascending size";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         sort => [{ property => "size" }],
                     }, "R1"]]);
         $self->assert_num_equals(2, scalar @{$res->[0][1]->{ids}});
@@ -325,7 +327,7 @@ sub test_email_query_shared
 
         xlog $self, "sort by descending size";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         sort => [{ property => "size", isAscending => JSON::false }],
                     }, "R1"]]);
         $self->assert_num_equals(2, scalar @{$res->[0][1]->{ids}});
@@ -334,7 +336,7 @@ sub test_email_query_shared
 
         xlog $self, "sort by ascending id";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         sort => [{ property => "id" }],
                     }, "R1"]]);
         my @ids = sort ($foo, $bar);
@@ -342,7 +344,7 @@ sub test_email_query_shared
 
         xlog $self, "sort by descending id";
         $res = $jmap->CallMethods([['Email/query', {
-                        accountId => $account,
+                        %account_args,
                         sort => [{ property => "id", isAscending => JSON::false }],
                     }, "R1"]]);
         @ids = reverse sort ($foo, $bar);

--- a/imap/jmap_admin.c
+++ b/imap/jmap_admin.c
@@ -34,13 +34,13 @@ static jmap_method_t jmap_admin_methods_nonstandard[] = {
         "Admin/rewriteCalendarEventPrivacy",
         JMAP_ADMIN_EXTENSION,
         &jmap_admin_rewrite_calevent_privacy,
-        JMAP_NO_USERLOCK,
+        JMAP_NO_USERLOCK | JMAP_NO_ACCOUNTID,
     },
     {
         "Admin/migrateCalendarDefaultAlarms",
         JMAP_ADMIN_EXTENSION,
         &jmap_admin_migrate_defaultalarms,
-        JMAP_NO_USERLOCK,
+        JMAP_NO_USERLOCK | JMAP_NO_ACCOUNTID,
     },
     { NULL, NULL, NULL, 0}
 };

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -178,10 +178,12 @@ struct jmap_handler {
 };
 
 enum jmap_method_flags {
-    JMAP_READ_WRITE  = (1 << 0),  /* user can change state with this method */
-    JMAP_NEED_CSTATE = (1 << 1),  /* conv.db is required for this method
-                                     (lock type determined by r/w flag) */
-    JMAP_NO_USERLOCK = (1 << 2)   /* action touches many users, it will do its own locking */
+    JMAP_READ_WRITE   = (1 << 0),  /* user can change state with this method */
+    JMAP_NEED_CSTATE  = (1 << 1),  /* conv.db is required for this method
+                                      (lock type determined by r/w flag) */
+    JMAP_NO_USERLOCK  = (1 << 2),  /* action touches multiple users
+                                      (it will do its own locking) */
+    JMAP_NO_ACCOUNTID = (1 << 3),  /* method DOES NOT accept accountId arg */
 };
 
 typedef struct {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -9391,6 +9391,10 @@ static int jmap_principal_getavailability(struct jmap_req *req)
     /* Parse arguments */
     const char *s;
     json_t *myargs = json_copy(req->args); // shallow copy
+    if ((s = json_string_value(json_object_get(myargs, "accountId")))) {
+        /* already handled in jmap_api() */
+        json_object_del(myargs, "accountId");
+    }
     if ((s = json_string_value(json_object_get(myargs, "id")))) {
         principalid = xstrdup(s);
         json_object_del(myargs, "id");


### PR DESCRIPTION
This is just a start.  A ton of Cass tests will have to be updated unless the underlying perl test code can be made to auto-include accountId.

AND, this should not be merged until we know that the FM UI and middleware do the right thing.