### PR TITLE
mboxname: suppress error if it's just locked and nonblocking

### DIFF
--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -215,8 +215,9 @@ static int mboxname_lock_item(const char *mboxname, struct mboxlock **mboxlockpt
 
 done:
     if (r) {
-        xsyslog(LOG_ERR, "can not lock mailbox",
-                "name=<%s> error=<%s>", mboxname, error_message(r));
+        if (!(nonblock && r == IMAP_MAILBOX_LOCKED))
+            xsyslog(LOG_ERR, "can not lock mailbox",
+                    "name=<%s> error=<%s>", mboxname, error_message(r));
         remove_lockitem(lockitem);
     }
     else if (mboxlockptr) {


### PR DESCRIPTION
This is just a tiny fix!  It turns out we were logging a lot where it was just a quick failure to grab a per-user lock in calalarmd, which uses non-blocking locks to avoid waiting on busy users.