### PR TITLE
search_squat: Do not search in SEARCH_PART_NONE

### DIFF
--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -1013,7 +1013,7 @@ static int end_update(search_text_receiver_t *rx)
 static int can_match(enum search_op matchop, enum search_part partnum)
 {
     return (matchop == SEOP_MATCH || matchop == SEOP_FUZZYMATCH) &&
-        doctypes_by_part[partnum];
+        partnum != SEARCH_PART_NONE && doctypes_by_part[partnum];
 }
 
 const struct search_engine squat_search_engine = {


### PR DESCRIPTION
When searching for flags, the can_match function from the search engine is called with SEARCH_PART_NONE and squat wrongfully indicates that it can handle it.

As a result, the match function from the search engine then gets called with the char pointer from the search_value union, while the search_value union contains an integer for the search_flags_match handler. The char pointer is invalid and causes a segmentation fault.

Closes: https://github.com/cyrusimap/cyrus-imapd/issues/3562