### PR TITLE
Convert everything to urn:ietf:params:jmap:blob

### DIFF
--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -185,7 +185,7 @@ sub default_using {
         urn:ietf:params:jmap:core
         urn:ietf:params:jmap:mail
         urn:ietf:params:jmap:submission
-        https://cyrusimap.org/ns/jmap/blob
+        urn:ietf:params:jmap:blob
         urn:ietf:params:jmap:calendars
         https://cyrusimap.org/ns/jmap/contacts
         https://cyrusimap.org/ns/jmap/calendars

--- a/cassandane/Cassandane/Cyrus/JMAPSieve.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPSieve.pm
@@ -109,7 +109,7 @@ sub set_up
         'urn:ietf:params:jmap:mail',
         'urn:ietf:params:jmap:sieve',
         'https://cyrusimap.org/ns/jmap/sieve',  # for SieveScript/test
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ]);
 }
 

--- a/cassandane/Cassandane/Cyrus/MailboxVersion.pm
+++ b/cassandane/Cassandane/Cyrus/MailboxVersion.pm
@@ -126,7 +126,7 @@ sub set_up
         'urn:ietf:params:jmap:vacationresponse',
         'urn:ietf:params:jmap:contacts',
         'https://cyrusimap.org/ns/jmap/backup',
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
         'https://cyrusimap.org/ns/jmap/contacts',
         'https://cyrusimap.org/ns/jmap/notes',
         'https://cyrusimap.org/ns/jmap/debug',

--- a/cassandane/Cassandane/Cyrus/MaxMessages.pm
+++ b/cassandane/Cassandane/Cyrus/MaxMessages.pm
@@ -174,7 +174,7 @@ sub put_script
         'urn:ietf:params:jmap:core',
         'urn:ietf:params:jmap:mail',
         'https://cyrusimap.org/ns/jmap/sieve',
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ]);
 
     my $res = $self->{jmap}->CallMethods([

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -3303,7 +3303,7 @@ my @DEFAULT_USING = qw(
 
     https://cyrusimap.org/ns/jmap/performance
     https://cyrusimap.org/ns/jmap/backup
-    https://cyrusimap.org/ns/jmap/blob
+    urn:ietf:params:jmap:blob
 );
 
 sub new_jmaptester_ws_for_user ($self, $user, $new_arg = undef) {

--- a/cassandane/tiny-tests/Annotator/no_annotate_sieve
+++ b/cassandane/tiny-tests/Annotator/no_annotate_sieve
@@ -14,7 +14,7 @@ sub test_no_annotate_sieve
         'urn:ietf:params:jmap:mail',
         'urn:ietf:params:jmap:sieve',
         'https://cyrusimap.org/ns/jmap/sieve',  # for SieveScript/test
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ]);
 
     my $flag = '$Artisanal';

--- a/cassandane/tiny-tests/JMAPBlob/blob_get
+++ b/cassandane/tiny-tests/JMAPBlob/blob_get
@@ -35,7 +35,7 @@ sub test_blob_get
 
     xlog "Test without capability";
 
-    my @using = grep {; $_ ne 'https://cyrusimap.org/ns/jmap/blob' }
+    my @using = grep {; $_ ne 'urn:ietf:params:jmap:blob' }
                 $jmap->default_using->@*;
 
     $res = $jmap->CallMethods(

--- a/cassandane/tiny-tests/JMAPBlob/blob_lookup
+++ b/cassandane/tiny-tests/JMAPBlob/blob_lookup
@@ -42,7 +42,7 @@ sub test_blob_lookup
 
     xlog "Test without capability";
 
-    my @using = grep {; $_ ne 'https://cyrusimap.org/ns/jmap/blob' }
+    my @using = grep {; $_ ne 'urn:ietf:params:jmap:blob' }
                 $jmap->default_using->@*;
 
     $res = $jmap->CallMethods(

--- a/cassandane/tiny-tests/JMAPBlob/blob_upload_basic_legacy
+++ b/cassandane/tiny-tests/JMAPBlob/blob_upload_basic_legacy
@@ -19,7 +19,7 @@ sub test_blob_upload_basic_legacy
 
     $self->assert_str_equals($res->[0][0], 'error');
 
-    push @using, 'https://cyrusimap.org/ns/jmap/blob';
+    push @using, 'urn:ietf:params:jmap:blob';
 
     xlog "Regular Blob/upload works and returns a blobId";
     $res = $jmap->CallMethods(

--- a/cassandane/tiny-tests/JMAPBlob/blob_upload_complex
+++ b/cassandane/tiny-tests/JMAPBlob/blob_upload_complex
@@ -9,7 +9,7 @@ sub test_blob_upload_complex
 
     # GET supported digest algorithms from session object
     my $session = $jmap->get_client_session->client_session;
-    my %algs = map { $_ => 1 } @{$session->{capabilities}->{'https://cyrusimap.org/ns/jmap/blob'}->{supportedDigestAlgorithms}};
+    my %algs = map { $_ => 1 } @{$session->{capabilities}->{'urn:ietf:params:jmap:blob'}->{supportedDigestAlgorithms}};
 
     $jmap->default_using([
         'urn:ietf:params:jmap:core',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_blob_lookup
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_blob_lookup
@@ -36,7 +36,7 @@ sub test_calendarevent_blob_lookup
         }, 'R1'],
     ], [
         'urn:ietf:params:jmap:core',
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ]);
     $self->assert_deep_equals([{
         id => $blobId,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_nonstandard_utcoffset
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_nonstandard_utcoffset
@@ -73,7 +73,7 @@ EOF
             'urn:ietf:params:jmap:core',
             'urn:ietf:params:jmap:calendars',
             'https://cyrusimap.org/ns/jmap/calendars',
-            'https://cyrusimap.org/ns/jmap/blob',
+            'urn:ietf:params:jmap:blob',
         ]
     );
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
@@ -184,7 +184,7 @@ EOF
             'urn:ietf:params:jmap:core',
             'urn:ietf:params:jmap:calendars',
             'https://cyrusimap.org/ns/jmap/calendars',
-            'https://cyrusimap.org/ns/jmap/blob',
+            'urn:ietf:params:jmap:blob',
         ]);
         $self->assert_not_null($res->[0][1]{created}{ical});
         if (not grep(/^uid$/, @properties)) {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
@@ -67,7 +67,7 @@ EOF
     my $using = [
         'urn:ietf:params:jmap:core',
         'urn:ietf:params:jmap:calendars',
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ];
 
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/test_calendarevent_parse_multi_icalobj
+++ b/cassandane/tiny-tests/JMAPCalendars/test_calendarevent_parse_multi_icalobj
@@ -59,7 +59,7 @@ EOF
             'urn:ietf:params:jmap:core',
             'urn:ietf:params:jmap:calendars',
             'https://cyrusimap.org/ns/jmap/calendars',
-            'https://cyrusimap.org/ns/jmap/blob',
+            'urn:ietf:params:jmap:blob',
         ]
     );
 

--- a/cassandane/tiny-tests/JMAPContacts/contact_set_avatar_from_deleted_contact
+++ b/cassandane/tiny-tests/JMAPContacts/contact_set_avatar_from_deleted_contact
@@ -21,7 +21,7 @@ sub test_contact_set_avatar_from_deleted_contact
     my $using = [
         'urn:ietf:params:jmap:core',
         'https://cyrusimap.org/ns/jmap/contacts',
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ];
 
     xlog $self, "create initial card";

--- a/cassandane/tiny-tests/JMAPContacts/contact_set_avatar_singlecommand
+++ b/cassandane/tiny-tests/JMAPContacts/contact_set_avatar_singlecommand
@@ -21,7 +21,7 @@ sub test_contact_set_avatar_singlecommand
     my $using = [
         'urn:ietf:params:jmap:core',
         'https://cyrusimap.org/ns/jmap/contacts',
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ];
 
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPEmail/blob_get
+++ b/cassandane/tiny-tests/JMAPEmail/blob_get
@@ -30,11 +30,11 @@ sub test_blob_get
     $jmap->DefaultUsing(\@using);
 
     $res = $jmap->CallMethods([
-        ['Blob/lookup', { ids => [$blobId], types => ['Mailbox', 'Thread', 'Email']}, "R1"],
+        ['Blob/lookup', { ids => [$blobId], typeNames => ['Mailbox', 'Thread', 'Email']}, "R1"],
     ]);
 
     my $blob = $res->[0][1]{list}[0];
-    $self->assert_deep_equals($wantMailboxIds, $blob->{types}{Mailbox});
-    $self->assert_deep_equals($wantEmailIds, $blob->{types}{Email});
-    $self->assert_deep_equals($wantThreadIds, $blob->{types}{Thread});
+    $self->assert_deep_equals($wantMailboxIds, $blob->{matchedIds}{Mailbox});
+    $self->assert_deep_equals($wantEmailIds, $blob->{matchedIds}{Email});
+    $self->assert_deep_equals($wantThreadIds, $blob->{matchedIds}{Thread});
 }

--- a/cassandane/tiny-tests/JMAPEmail/blob_get
+++ b/cassandane/tiny-tests/JMAPEmail/blob_get
@@ -26,7 +26,7 @@ sub test_blob_get
     my $wantThreadIds = [$res->[1][1]{list}[0]{threadId}];
 
     my @using = @{ $jmap->DefaultUsing() };
-    push @using, 'https://cyrusimap.org/ns/jmap/blob';
+    push @using, 'urn:ietf:params:jmap:blob';
     $jmap->DefaultUsing(\@using);
 
     $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPEmail/email_blob_set_singlecommand
+++ b/cassandane/tiny-tests/JMAPEmail/email_blob_set_singlecommand
@@ -38,7 +38,7 @@ EOF
         'https://cyrusimap.org/ns/jmap/performance',
         'urn:ietf:params:jmap:core',
         'urn:ietf:params:jmap:mail',
-        'https://cyrusimap.org/ns/jmap/blob',
+        'urn:ietf:params:jmap:blob',
     ];
 
     xlog $self, "do the lot!";

--- a/cassandane/tiny-tests/JMAPEmail/email_parse_inmemory_blob
+++ b/cassandane/tiny-tests/JMAPEmail/email_parse_inmemory_blob
@@ -8,7 +8,7 @@ sub test_email_parse_inmemory_blob
     my $jmap = $self->{jmap};
 
     # XXX: replace with the upstream one once RFC 9404 is finished
-    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/blob');
+    $jmap->AddUsing('urn:ietf:params:jmap:blob');
 
     my $mimeMsg = <<'EOF';
 From: <from@local>

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_encoding
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_encoding
@@ -9,7 +9,7 @@ use Data::UUID;
 sub test_email_set_create_encoding ($self)
 {
     my $jmap = $self->{jmap};
-    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/blob');
+    $jmap->AddUsing('urn:ietf:params:jmap:blob');
 
     # Optionally persist tests in file.
     my $writeEmail2MimeTests = 0;

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -38,7 +38,6 @@
 #define JMAP_URN_CALENDAR_PREFERENCES "urn:ietf:params:jmap:calendars:preferences"
 
 #define JMAP_CORE_EXTENSION          "https://cyrusimap.org/ns/jmap/core"
-#define JMAP_BLOB_EXTENSION          "https://cyrusimap.org/ns/jmap/blob"
 #define JMAP_CONTACTS_EXTENSION      "https://cyrusimap.org/ns/jmap/contacts"
 #define JMAP_CALENDARS_EXTENSION     "https://cyrusimap.org/ns/jmap/calendars"
 #define JMAP_MAIL_EXTENSION          "https://cyrusimap.org/ns/jmap/mail"


### PR DESCRIPTION
RFC9404 has been out for years, we don't need to support our stale old API any more