### PR TITLE
DO NOT MERGE: test with cyrus-timezones 2026a

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,13 @@ jobs:
       if: ${{ matrix.pretest }}
       shell: bash
       run: ${{ matrix.pretest }}
+    - name: build custom cyrus-timezones branch
+      shell: bash
+      run: |
+        git clone --depth 1 --shallow-submodules -b cyruslibs-next \
+          https://github.com/cyrusimap/cyruslibs.git
+        cd cyruslibs
+        ./build.sh cyruslibs cyrus-timezones
     - name: configure and build
       shell: bash
       run: cyd build "${{ matrix.compiler }}" "${{ matrix.san }}" --cflags "${{ matrix.cflags }}" --cxxflags "${{ matrix.cxxflags }}"
@@ -117,6 +124,13 @@ jobs:
         # following".  we're explicitly fetching the tags we want, we do not
         # need every other tag that's reachable from them
         git fetch --no-tags upstream 'refs/tags/cyrus-imapd-*:refs/tags/cyrus-imapd-*'
+    - name: build custom cyrus-timezones branch
+      shell: bash
+      run: |
+        git clone --depth 1 --shallow-submodules -b cyruslibs-next \
+          https://github.com/cyrusimap/cyruslibs.git
+        cd cyruslibs
+        ./build.sh cyruslibs cyrus-timezones
     - name: configure and build
       shell: bash
       run: |


### PR DESCRIPTION
This tests the Cyrus build with the new cyruslibs candidate. It upgrades the IANA timezone version to latest version 2026a.