### PR TITLE
jmap_calendar.c: support compact IDs for JMAP Calendars

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -397,11 +397,10 @@ sub putandget_vevent
     my $jmap = $self->{jmap};
     my $caldav = $self->{caldav};
 
-    xlog $self, "get default calendar id";
-    my $res = $jmap->CallMethods([['Calendar/get', {ids => ["Default"]}, "R1"]]);
-    $self->assert_str_equals("Default", $res->[0][1]{list}[0]{id});
-    my $calid = $res->[0][1]{list}[0]{id};
-    my $xhref = $res->[0][1]{list}[0]{"x-href"};
+    xlog $self, "get default calendar id and href";
+    my $default_calendar = $self->default_user->calendars->default;
+    my $calid = $default_calendar->id;
+    my $xhref = $default_calendar->properties->{'x-href'};
 
     # Create event via CalDAV to test CalDAV/JMAP interop.
     xlog $self, "create event (via CalDAV)";
@@ -410,7 +409,7 @@ sub putandget_vevent
     $caldav->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
 
     xlog $self, "get event $id";
-    $res = $jmap->CallMethods([['CalendarEvent/get', {ids => [$id], properties => $props}, "R1"]]);
+    my $res = $jmap->CallMethods([['CalendarEvent/get', {ids => [$id], properties => $props}, "R1"]]);
 
     my $event = $res->[0][1]{list}[0];
     $self->assert_not_null($event);

--- a/cassandane/Cassandane/TestEntity/DataType/Calendar.pm
+++ b/cassandane/Cassandane/TestEntity/DataType/Calendar.pm
@@ -31,8 +31,26 @@ true C<isDefault> property.
 
     sub default {
         my ($self) = @_;
+        my $dt = $self->datatype;
 
-        return $self->get('Default');
+        my $jmap = $self->user->entity_jmap;
+
+        my $res = $jmap->request([[ "Calendar/get", {} ]]);
+
+        my $get = $res->single_sentence('Calendar/get');
+
+        my @objs = $get->arguments->{list}->@*;
+        @objs > 0 || Carp::confess("user has no Calendars");
+
+        my ($default, @extra) = grep {; $_->{isDefault} } @objs;
+        $default || Carp::confess("user has no default Calendar");
+        @extra && Carp::confess("user has more than one default Calendar");
+
+        $self->instance_class->new({
+            id  => "$objs[0]{id}",
+            factory    => $self,
+            properties => $objs[0],
+        })
     }
 
     use Cassandane::TestEntity::AutoSetup;

--- a/cassandane/tiny-tests/CaldavAlarm/recurring_allday_floating
+++ b/cassandane/tiny-tests/CaldavAlarm/recurring_allday_floating
@@ -23,8 +23,9 @@ END:VTIMEZONE
 END:VCALENDAR
 EOF
 
-    my $CalendarId = $CalDAV->NewCalendar({name => 'foo', timeZone => $UTC});
-    $self->assert_not_null($CalendarId);
+    my $default_calendar = $self->default_user->calendars->default;
+    my $CalendarId = $default_calendar->id;
+    my $CalendarHref = $default_calendar->properties->{'x-href'} . "";
 
     my $now = DateTime->today();
     $now->set_time_zone('Etc/UTC');
@@ -38,7 +39,7 @@ EOF
     my $trigger="-PT5H";
 
     my $uuid = "574E2CD0-2D2A-4554-8B63-C7504481D3A9";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
     my $card = <<EOF;
 BEGIN:VCALENDAR
 VERSION:2.0
@@ -103,7 +104,7 @@ EOF
 EOF
 
     my $res = $CalDAV->Request('PROPPATCH',
-                               "/dav/calendars/user/cassandane/". $CalendarId,
+                               $CalendarHref,
                                $xml, 'Content-Type' => 'text/xml');
 
     $now->add(days => 7);
@@ -148,7 +149,7 @@ EOF
 EOF
 
     $res = $CalDAV->Request('PROPPATCH',
-                            "/dav/calendars/user/cassandane/". $CalendarId,
+                            $CalendarHref,
                             $xml, 'Content-Type' => 'text/xml');
 
     $now->add(days => 7);

--- a/cassandane/tiny-tests/JMAPCalendars/account_get_capabilities
+++ b/cassandane/tiny-tests/JMAPCalendars/account_get_capabilities
@@ -6,7 +6,6 @@ sub test_account_get_capabilities
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $http = $self->{instance}->get_service("http");

--- a/cassandane/tiny-tests/JMAPCalendars/account_get_shareesactas
+++ b/cassandane/tiny-tests/JMAPCalendars/account_get_shareesactas
@@ -6,7 +6,6 @@ sub test_account_get_shareesactas
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $http = $self->{instance}->get_service("http");

--- a/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
@@ -8,7 +8,6 @@ sub test_admin_migrate39_defaultalerts
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $imap = $self->{store}->get_client();
 
@@ -60,15 +59,18 @@ sub assert_calendars ($self, $state)
     my $caldav = $self->{caldav};
     my $imap = $self->{store}->get_client();
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     if (not $state->{did_migrate}) {
         xlog $self, "Create calendars with legacy CalDAV alarms";
         $state->{calendarA} = {
-            id => $self->create_legacy_calendar('A'),
+            name => 'A',
+            id => undef,
+            mbox => $self->create_legacy_calendar('A'),
         };
         $state->{calendarB} = {
-            id => $self->create_legacy_calendar('B'),
+            name => 'B',
+            id => undef,
+            mbox => $self->create_legacy_calendar('B'),
         };
 
         xlog $self, "Set CalDAV alarms on calendar A and calendar home";
@@ -81,7 +83,7 @@ ACTION:AUDIO\r
 X-APPLE-DEFAULT-ALARM:TRUE\r
 END:VALARM\r
 EOF
-        $self->set_caldav_datetime_alarms($state->{calendarA}{id}, $valarms);
+        $self->set_caldav_datetime_alarms($state->{calendarA}{mbox}, $valarms);
         $self->set_caldav_datetime_alarms(undef, $valarms);
         $state->{calendarA}{caldavAlarms} = $valarms;
     }
@@ -91,57 +93,61 @@ EOF
     my $res = $jmap->CallMethods([
         ['Calendar/get', {
             properties => [
+                'name',
                 'defaultAlertsWithTime',
                 'defaultAlertsWithoutTime',
             ],
         }, 'R1'],
     ]);
-    my %calendars = map { $_->{id} => $_ } @{$res->[0][1]{list}};
+    my %calendars = map { $_->{name} => $_ } @{$res->[0][1]{list}};
 
-    $self->assert_null($calendars{$default_cal_id}{defaultAlertsWithTime});
-    $self->assert_null($calendars{$default_cal_id}{defaultAlertsWithoutTime});
+    $self->assert_null($calendars{'personal'}{defaultAlertsWithTime});
+    $self->assert_null($calendars{'personal'}{defaultAlertsWithoutTime});
 
-    my $calendarADefaultAlerts = $calendars{$state->{calendarA}{id}}
+    my $calendarADefaultAlerts = $calendars{$state->{calendarA}{name}}
                                            {defaultAlertsWithTime};
     $self->assert_num_equals(1, scalar keys %$calendarADefaultAlerts);
     $self->assert_null(
-      $calendars{$state->{calendarA}{id}}{defaultAlertsWithoutTime}
+      $calendars{$state->{calendarA}{name}}{defaultAlertsWithoutTime}
     );
 
     $self->assert_null(
-      $calendars{$state->{calendarB}{id}}{defaultAlertsWithTime}
+      $calendars{$state->{calendarB}{name}}{defaultAlertsWithTime}
     );
     $self->assert_null(
-      $calendars{$state->{calendarB}{id}}{defaultAlertsWithoutTime}
+      $calendars{$state->{calendarB}{name}}{defaultAlertsWithoutTime}
     );
 
     if (not $state->{did_migrate}) {
+        $state->{calendarA}{id} = $calendars{$state->{calendarA}{name}}{id};
+        $state->{calendarB}{id} = $calendars{$state->{calendarB}{name}}{id};
+
         $state->{calendarA}{defaultAlert} = (values %$calendarADefaultAlerts)[0];
     } else {
         # Did migrate calendars
         $self->assert_deep_equals({
-            $state->{calendarA}{id} => undef,
-            $state->{calendarB}{id} => undef,
-            $default_cal_id => undef,
+            $state->{calendarA}{mbox} => undef,
+            $state->{calendarB}{mbox} => undef,
+            'Default' => undef,
         }, $state->{migrateResponse}{migrated}{cassandane});
 
         # Migration rewrites default alert UID, if none was set
         $self->assert_matches(qr/UID:[0-9A-Za-z-]+/,
-            $self->get_jmap_defaultalerts_annotation($state->{calendarA}{id}));
+            $self->get_jmap_defaultalerts_annotation($state->{calendarA}{mbox}));
 
         # JMAP annotation is set on both calendars
         $self->assert_not_null($self->get_jmap_defaultalerts_annotation(
-                $state->{calendarA}{id}));
+                $state->{calendarA}{mbox}));
 
         $self->assert_not_null($self->get_jmap_defaultalerts_annotation(
-                $state->{calendarB}{id}));
+                $state->{calendarB}{mbox}));
 
         # CalDAV default alarms annotation got removed
         $self->assert_null($self->get_caldav_datetime_annotation(
-                $state->{calendarA}{id}));
+                $state->{calendarA}{mbox}));
 
         $self->assert_null($self->get_caldav_datetime_annotation(
-                $state->{calendarB}{id}));
+                $state->{calendarB}{mbox}));
 
         # CalDAV default alarms annotation is kept on calendar home
         $self->assert_not_null($self->get_caldav_datetime_annotation(undef));
@@ -152,7 +158,6 @@ sub assert_events ($self, $state)
 {
     my $caldav = $self->{caldav};
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     if (not $state->{did_migrate}) {
         # First, create events
@@ -245,17 +250,15 @@ sub assert_shared_calendars ($self, $state)
     my $eventUidB1 = '93c7831d-e246-4dda-ab3f-52acba6b9e3b';
     my $eventUidB2 = '379e7061-d20f-45e4-8366-52d45836a7fd';
 
-    my $default_cal_id = $self->default_user->calendars->default->id;
-
     if (not $state->{did_migrate}) {
         xlog $self, "Create sharee";
         ($self->{shareeJmap}, $self->{shareeCaldav}) = $self->create_user('sharee');
 
         xlog $self, "Share calendars";
         my $admintalk = $self->{adminstore}->get_client();
-        $admintalk->setacl("user.cassandane.#calendars.$state->{calendarA}{id}",
+        $admintalk->setacl("user.cassandane.#calendars.$state->{calendarA}{mbox}",
             sharee => 'lrswipkxtecdn') or die;
-        $admintalk->setacl("user.cassandane.#calendars.$state->{calendarB}{id}",
+        $admintalk->setacl("user.cassandane.#calendars.$state->{calendarB}{mbox}",
             sharee => 'lrswipkxtecdn') or die;
 
         xlog $self, "Create sharee useDefaultAlerts=true in calendar A";
@@ -277,7 +280,7 @@ END:VEVENT
 END:VCALENDAR
 EOF
         $self->{shareeCaldav}->Request('PUT',
-            "cassandane.$state->{calendarA}{id}/$eventUidA1.ics",
+            "cassandane.$state->{calendarA}{mbox}/$eventUidA1.ics",
             $ical,
             'Content-Type' => 'text/calendar',
             'X-Cyrus-rewrite-usedefaultalerts' => 'false',
@@ -301,7 +304,7 @@ END:VEVENT
 END:VCALENDAR
 EOF
         $self->{shareeCaldav}->Request('PUT',
-            "cassandane.$state->{calendarA}{id}/$eventUidA2.ics",
+            "cassandane.$state->{calendarA}{mbox}/$eventUidA2.ics",
             $ical,
             'Content-Type' => 'text/calendar',
             'X-Cyrus-rewrite-usedefaultalerts' => 'false',
@@ -325,7 +328,7 @@ END:VEVENT
 END:VCALENDAR
 EOF
         $self->{shareeCaldav}->Request('PUT',
-            "cassandane.$state->{calendarB}{id}/$eventUidB1.ics",
+            "cassandane.$state->{calendarB}{mbox}/$eventUidB1.ics",
             $ical,
             'Content-Type' => 'text/calendar',
             'X-Cyrus-rewrite-usedefaultalerts' => 'false',
@@ -349,7 +352,7 @@ END:VEVENT
 END:VCALENDAR
 EOF
         $self->{shareeCaldav}->Request('PUT',
-            "cassandane.$state->{calendarB}{id}/$eventUidB2.ics",
+            "cassandane.$state->{calendarB}{mbox}/$eventUidB2.ics",
             $ical,
             'Content-Type' => 'text/calendar',
             'X-Cyrus-rewrite-usedefaultalerts' => 'false',
@@ -392,6 +395,9 @@ EOF
         $self->assert_null($eventB1->{alerts});
     }
     else {
+        my $sharee = $self->{instance}->create_user_without_setup('sharee');
+        my $default_cal_id = $sharee->calendars->default->id;
+
         $self->assert_deep_equals({
             $default_cal_id => undef,
         }, $state->{migrateResponse}{migrated}{sharee});

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_changes
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_changes
@@ -6,7 +6,6 @@ sub test_calendar_changes
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create calendar";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_changes_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_changes_shared
@@ -6,7 +6,6 @@ sub test_calendar_changes_shared
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $admin = $self->{adminstore}->get_client();
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_copy_defaultalerts_mkcalendar
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_copy_defaultalerts_mkcalendar
@@ -13,7 +13,7 @@ sub test_calendar_copy_defaultalerts_mkcalendar
     xlog $self, "No default alerts are set on default calendar";
     my $res = $jmap->CallMethods([
         ['Calendar/get', {
-            ids => ['Default'],
+            ids => [$default_cal_id],
             properties => [
                 'defaultAlertsWithTime',
                 'defaultAlertsWithoutTime',
@@ -26,11 +26,16 @@ sub test_calendar_copy_defaultalerts_mkcalendar
 
     xlog $self, "Create calendar test1 over CalDAV";
     $res = $caldav->Request('MKCALENDAR', "/dav/calendars/user/cassandane/test1");
+    my $admintalk = $self->{adminstore}->get_client();
+    my $stat = $admintalk->status("user.cassandane.#calendars.test1",
+                                  '(mailboxid)');
+    # Replace mailbox prefix with calendar prefix
+    my $calid1 = 'C' . substr($stat->{mailboxid}[0], 1);
 
     xlog $self, "New calendar does not have default alerts";
     $res = $jmap->CallMethods([
         ['Calendar/get', {
-            ids => ['test1'],
+            ids => [$calid1],
             properties => [
                 'defaultAlertsWithTime',
                 'defaultAlertsWithoutTime',
@@ -67,22 +72,26 @@ sub test_calendar_copy_defaultalerts_mkcalendar
     $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
-                test1 => {
+                $calid1 => {
                     defaultAlertsWithTime => $defaultAlertsWithTime1,
                     defaultAlertsWithoutTime => $defaultAlertsWithoutTime1,
                 },
             },
         }, 'R1'],
     ]);
-    $self->assert(exists $res->[0][1]{updated}{test1});
+    $self->assert(exists $res->[0][1]{updated}{$calid1});
 
     xlog $self, "Create calendar test2 over CalDAV";
     $res = $caldav->Request('MKCALENDAR', "/dav/calendars/user/cassandane/test2");
+    $stat = $admintalk->status("user.cassandane.#calendars.test2",
+                                  '(mailboxid)');
+    # Replace mailbox prefix with calendar prefix
+    my $calid2 = 'C' . substr($stat->{mailboxid}[0], 1);
 
     xlog $self, "New calendar inherits default alerts from test1";
     $res = $jmap->CallMethods([
         ['Calendar/get', {
-            ids => ['test2'],
+            ids => [$calid2],
             properties => [
                 'defaultAlertsWithTime',
                 'defaultAlertsWithoutTime',
@@ -119,11 +128,15 @@ sub test_calendar_copy_defaultalerts_mkcalendar
 
     xlog $self, "Create calendar test3 over CalDAV";
     $res = $caldav->Request('MKCALENDAR', "/dav/calendars/user/cassandane/test3");
+    $stat = $admintalk->status("user.cassandane.#calendars.test3",
+                                  '(mailboxid)');
+    # Replace mailbox prefix with calendar prefix
+    my $calid3 = 'C' . substr($stat->{mailboxid}[0], 1);
 
     xlog $self, "New calendar inherits default alerts from Default";
     $res = $jmap->CallMethods([
         ['Calendar/get', {
-            ids => ['test3'],
+            ids => [$calid3],
             properties => [
                 'defaultAlertsWithTime',
                 'defaultAlertsWithoutTime',

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_get
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_get
@@ -6,15 +6,24 @@ sub test_calendar_get
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
-
     my $caldav = $self->{caldav};
 
-    my $id = $caldav->NewCalendar({ name => "calname", color => "aqua"});
+    $caldav->NewCalendar({ name => "calname", color => "aqua"});
     my $unknownId = "foo";
 
+    xlog $self, "get all calendars";
+    my $res = $jmap->CallMethods([['Calendar/get', {ids => undef}, "R1"]]);
+    $self->assert_not_null($res);
+    $self->assert_num_equals(2, scalar(@{$res->[0][1]{list}}));
+    $res = $jmap->CallMethods([['Calendar/get', {}, "R1"]]);
+    $self->assert_not_null($res);
+    $self->assert_num_equals(2, scalar(@{$res->[0][1]{list}}));
+    my %m = map { $_->{name} => $_ } @{$res->[0][1]{list}};
+    my $id = $m{"calname"}{id};
+    $self->assert_matches(qr/^C.*/, $id);
+
     xlog $self, "get existing calendar";
-    my $res = $jmap->CallMethods([['Calendar/get', {ids => [$id]}, "R1"]]);
+    $res = $jmap->CallMethods([['Calendar/get', {ids => [$id]}, "R1"]]);
     $self->assert_not_null($res);
     $self->assert_str_equals('Calendar/get', $res->[0][0]);
     $self->assert_str_equals('R1', $res->[0][2]);
@@ -37,12 +46,4 @@ sub test_calendar_get
     $self->assert_num_equals(0, scalar(@{$res->[0][1]{list}}));
     $self->assert_num_equals(1, scalar(@{$res->[0][1]{notFound}}));
     $self->assert_str_equals($unknownId, $res->[0][1]{notFound}[0]);
-
-    xlog $self, "get all calendars";
-    $res = $jmap->CallMethods([['Calendar/get', {ids => undef}, "R1"]]);
-    $self->assert_not_null($res);
-    $self->assert_num_equals(2, scalar(@{$res->[0][1]{list}}));
-    $res = $jmap->CallMethods([['Calendar/get', {}, "R1"]]);
-    $self->assert_not_null($res);
-    $self->assert_num_equals(2, scalar(@{$res->[0][1]{list}}));
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_get_default
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_get_default
@@ -6,13 +6,13 @@ sub test_calendar_get_default
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     # XXX - A previous CalDAV test might have created the default
     # calendar already. To make this test self-sufficient, we need
     # to create a test user just for this test. How?
     xlog $self, "get default calendar";
-    my $res = $jmap->CallMethods([['Calendar/get', {ids => ["Default"]}, "R1"]]);
-    $self->assert_str_equals("Default", $res->[0][1]{list}[0]{id});
+    my $res = $jmap->CallMethods([['Calendar/get', { }, "R1"]]);
     $self->assert_equals(JSON::true, $res->[0][1]{list}[0]{isDefault});
+    $self->assert_str_equals("/dav/calendars/user/cassandane/Default",
+                             $res->[0][1]{list}[0]{'x-href'});
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_get_freebusy_only
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_get_freebusy_only
@@ -6,7 +6,6 @@ sub test_calendar_get_freebusy_only
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create other user";
     my $admintalk = $self->{adminstore}->get_client();

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_get_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_get_shared
@@ -6,7 +6,6 @@ sub test_calendar_get_shared
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $admintalk = $self->{adminstore}->get_client();

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set
@@ -6,7 +6,6 @@ sub test_calendar_set
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create calendar";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_badname
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_badname
@@ -6,7 +6,6 @@ sub test_calendar_set_badname
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create calendar with excessively long name";
     # Exceed the maximum allowed 256 byte length by 1.

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_color
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_color
@@ -19,12 +19,13 @@ sub test_calendar_set_color
          "R1"],
         ['Calendar/get', {
             ids => [ '#1' ],
-            properties => [ 'color' ]
+            properties => [ 'color', 'x-href' ]
          },
          "R2"],
     ]);
     $self->assert_not_null($res->[0][1]{created});
     my $id = $res->[0][1]{created}{"1"}{id};
+    my $href = $res->[0][1]{created}{"1"}{'x-href'};
     $self->assert_str_equals('SteelBlue', $res->[1][1]{list}[0]{color});
 
     xlog $self, "assert color is visible via CalDAV";
@@ -38,7 +39,7 @@ sub test_calendar_set_color
 EOF
 
     my $CalDAV = $self->{caldav};
-    $res = $CalDAV->Request('PROPFIND', "/dav/calendars/user/cassandane/". $id,
+    $res = $CalDAV->Request('PROPFIND', $href,
                             $propfindXml, 'Content-Type' => 'text/xml');
     my $propstat = $res->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0];
     $self->assert_str_equals('SteelBlue',

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroy_events
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroy_events
@@ -6,7 +6,6 @@ sub test_calendar_set_destroy_events
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $CalDAV = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroyspecials
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroyspecials
@@ -5,24 +5,39 @@ sub test_calendar_set_destroyspecials
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
-    my @specialIds = ["Inbox", "Outbox", "Default", "Attachments"];
+    xlog $self, "Get calendar Ids of specials";
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->list('', 'user.cassandane.#calendars.*',
+                     'RETURN', [ 'STATUS', [ 'MAILBOXID' ] ]);
+    my $res = $admintalk->get_response_code('status') || {};
+
+    # Replace mailbox prefix with calendar prefix
+    my $inId  = 'C' .
+        substr($res->{'user.cassandane.#calendars.Inbox'}{mailboxid}[0], 1);
+    my $outId = 'C' .
+        substr($res->{'user.cassandane.#calendars.Outbox'}{mailboxid}[0], 1);
+    my $defId = 'C' .
+        substr($res->{'user.cassandane.#calendars.Default'}{mailboxid}[0], 1);
+    my $attId = 'C' .
+        substr($res->{'user.cassandane.#calendars.Attachments'}{mailboxid}[0], 1);
+
+    my @specialIds = [ $inId, $outId, $defId, $attId];
 
     xlog $self, "destroy special calendars";
-    my $res = $jmap->CallMethods([
+    $res = $jmap->CallMethods([
             ['Calendar/set', { destroy => @specialIds }, "R1"]
     ]);
     $self->assert_not_null($res);
 
     my $errType;
 
-    $errType = $res->[0][1]{notDestroyed}{"Inbox"}{type};
+    $errType = $res->[0][1]{notDestroyed}{$inId}{type};
     $self->assert_str_equals("notFound", $errType);
-    $errType = $res->[0][1]{notDestroyed}{"Outbox"}{type};
+    $errType = $res->[0][1]{notDestroyed}{$outId}{type};
     $self->assert_str_equals("notFound", $errType);
-    $errType = $res->[0][1]{notDestroyed}{"Default"}{type};
+    $errType = $res->[0][1]{notDestroyed}{$defId}{type};
     $self->assert_str_equals("forbidden", $errType);
-    $errType = $res->[0][1]{notDestroyed}{"Attachments"}{type};
+    $errType = $res->[0][1]{notDestroyed}{$attId}{type};
     $self->assert_str_equals("notFound", $errType);
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_error
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_error
@@ -6,7 +6,6 @@ sub test_calendar_set_error
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create calendar with missing mandatory attributes";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_extendedprops
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_extendedprops
@@ -4,7 +4,6 @@ use Cassandane::Tiny;
 sub test_calendar_set_extendedprops ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     # Create calendar
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_inherit_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_inherit_defaultalerts
@@ -7,7 +7,6 @@ sub test_calendar_set_inherit_defaultalerts
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_issubscribed
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_issubscribed
@@ -6,7 +6,6 @@ sub test_calendar_set_issubscribed
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     # Create calendar
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_issubscribed_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_issubscribed_shared
@@ -6,7 +6,6 @@ sub test_calendar_set_issubscribed_shared
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $admintalk = $self->{adminstore}->get_client();
     my $service = $self->{instance}->get_service("http");

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_shared
@@ -6,7 +6,6 @@ sub test_calendar_set_shared
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $admintalk = $self->{adminstore}->get_client();
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_shared_sort_order
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_shared_sort_order
@@ -6,7 +6,6 @@ sub test_calendar_set_shared_sort_order
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $admintalk = $self->{adminstore}->get_client();

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith
@@ -9,7 +9,6 @@ sub test_calendar_set_sharewith
     my ($maj, $min) = Cassandane::Instance->get_version();
 
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $admintalk = $self->{adminstore}->get_client();
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith_acl
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith_acl
@@ -24,6 +24,9 @@ sub test_calendar_set_sharewith_acl
     ]);
     my $calendarId = $res->[0][1]{created}{1}{id};
     $self->assert_not_null($calendarId);
+    my $href = $res->[0][1]{created}{1}{'x-href'};
+    my $mboxname = basename($href);
+    $self->assert_not_null($mboxname);
 
     my @testCases = ({
         rights => {
@@ -111,7 +114,7 @@ sub test_calendar_set_sharewith_acl
             $res->[1][1]{list}[0]{shareWith}{aatester});
         $self->assert_deep_equals(\%mergedrights,
             $res->[1][1]{list}[0]{shareWith}{zztester});
-        my %acl = @{$admin->getacl("user.cassandane.#calendars.$calendarId")};
+        my %acl = @{$admin->getacl("user.cassandane.#calendars.$mboxname")};
         $self->assert_str_equals($_->{acl}, $acl{aatester});
         $self->assert_str_equals($_->{acl}, $acl{zztester});
     }

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_state
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_state
@@ -6,7 +6,6 @@ sub test_calendar_set_state
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create with invalid state token";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_treat_as_mailbox
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_treat_as_mailbox
@@ -6,7 +6,6 @@ sub test_calendar_treat_as_mailbox
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create calendar";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendaralert_notification
+++ b/cassandane/tiny-tests/JMAPCalendars/calendaralert_notification
@@ -7,7 +7,6 @@ sub test_calendaralert_notification
 {
     my $caldav = $self->{caldav};
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calendarId = $caldav->NewCalendar({name => 'foo'});
     $self->assert_not_null($calendarId);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_blobid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_blobid
@@ -6,7 +6,6 @@ sub test_calendarevent_blobid
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create other user";
 
@@ -16,6 +15,7 @@ sub test_calendarevent_blobid
     $admintalk->setacl("user.other", other => 'lrswipkxtecdn') or die;
 
     my $other_user = $self->{instance}->create_user_without_setup('other');
+    my $default_cal_id = $other_user->calendars->default->id;
     my $otherJmap = $other_user->jmap;
     $otherJmap->DefaultUsing([
         'urn:ietf:params:jmap:core',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_add_override_keep_main_unchanged
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_add_override_keep_main_unchanged
@@ -6,7 +6,6 @@ sub test_calendarevent_changes_add_override_keep_main_unchanged
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $imap = $self->{store}->get_client();
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_ignore_specials
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_ignore_specials
@@ -6,7 +6,6 @@ sub test_calendarevent_changes_ignore_specials
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['CalendarEvent/get', {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_issue2558
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_issue2558
@@ -6,7 +6,6 @@ sub test_calendarevent_changes_issue2558
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "get calendar event updates with bad state";
     my $res = $jmap->CallMethods([['CalendarEvent/changes', { sinceState => 'nonsense' }, "R1"]]);

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_recreate_uid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_recreate_uid
@@ -4,7 +4,6 @@ use Cassandane::Tiny;
 sub test_calendarevent_changes_recreate_uid ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['Calendar/get', {}, 'R1'],

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy
@@ -6,7 +6,6 @@ sub test_calendarevent_copy
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $admintalk = $self->{adminstore}->get_client();
@@ -32,6 +31,11 @@ sub test_calendarevent_copy
     my $srcCalendarId = $caldav->NewCalendar({name => 'Source Calendar'});
     $self->assert_not_null($srcCalendarId);
 
+    my $stat = $admintalk->status("user.cassandane.#calendars.$srcCalendarId",
+                                  '(mailboxid)');
+    # Replace mailbox prefix with calendar prefix
+    my $srcCalendarJmapId = 'C' . substr($stat->{mailboxid}[0], 1);
+
     xlog $self, "create destination calendar";
     my $dstCalendarId = $othercaldav->NewCalendar({name => 'Destination Calendar'});
     $self->assert_not_null($dstCalendarId);
@@ -41,7 +45,7 @@ sub test_calendarevent_copy
 
     my $event =  {
         calendarIds => {
-            $srcCalendarId => JSON::true,
+            $srcCalendarJmapId => JSON::true,
         },
         "uid" => "58ADE31-custom-UID",
         "title"=> "foo",

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy_state
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy_state
@@ -4,7 +4,6 @@ use Cassandane::Tiny;
 sub test_calendarevent_copy_state ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $admintalk = $self->{adminstore}->get_client();
@@ -30,6 +29,11 @@ sub test_calendarevent_copy_state ($self)
     my $srcCalendarId = $caldav->NewCalendar({name => 'Source Calendar'});
     $self->assert_not_null($srcCalendarId);
 
+    my $stat = $admintalk->status("user.cassandane.#calendars.$srcCalendarId",
+                                  '(mailboxid)');
+    # Replace mailbox prefix with calendar prefix
+    my $srcCalendarJmapId = 'C' . substr($stat->{mailboxid}[0], 1);
+
     xlog $self, "create destination calendar";
     my $dstCalendarId = $othercaldav->NewCalendar({name => 'Destination Calendar'});
     $self->assert_not_null($dstCalendarId);
@@ -39,7 +43,7 @@ sub test_calendarevent_copy_state ($self)
 
     my $event =  {
         calendarIds => {
-            $srcCalendarId => JSON::true,
+            $srcCalendarJmapId => JSON::true,
         },
         "uid" => "58ADE31-custom-UID",
         "title"=> "foo",

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_debugblobid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_debugblobid
@@ -6,7 +6,6 @@ sub test_calendarevent_debugblobid
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create other user";
 
@@ -16,6 +15,7 @@ sub test_calendarevent_debugblobid
     $admintalk->setacl("user.other", other => 'lrswipkxtecdn') or die;
 
     my $other_user = $self->{instance}->create_user_without_setup('other');
+    my $default_cal_id = $other_user->calendars->default->id;
     my $otherJmap = $other_user->jmap;
     $otherJmap->DefaultUsing([
         'urn:ietf:params:jmap:core',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_calalarmd
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_calalarmd
@@ -6,7 +6,6 @@ sub test_calendarevent_defaultalerts_calalarmd
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $now = DateTime->now();
@@ -29,6 +28,8 @@ sub test_calendarevent_defaultalerts_calalarmd
     ]);
     my $calendarId = $res->[0][1]{created}{1}{id};
     $self->assert_not_null($calendarId);
+    my $calendarHref = $res->[0][1]{created}{1}{'x-href'};
+    $self->assert_not_null($calendarHref);
 
     xlog $self, "Remove any default alarms";
     $res = $jmap->CallMethods([
@@ -48,7 +49,7 @@ sub test_calendarevent_defaultalerts_calalarmd
     my $start = $startdt->strftime('%Y%m%dT%H%M%S');
 
     my $uuid = "574E2CD0-2D2A-4554-8B63-C7504481D3A9";
-    my $href = "$calendarId/$uuid.ics";
+    my $href = basename($calendarHref) . "/$uuid.ics";
     my $card = <<EOF;
 BEGIN:VCALENDAR
 VERSION:2.0

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_attachbinary
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_attachbinary
@@ -6,7 +6,6 @@ sub test_calendarevent_get_attachbinary
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_duplicate_recurrence_ids
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_duplicate_recurrence_ids
@@ -6,7 +6,6 @@ sub test_calendarevent_get_duplicate_recurrence_ids
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_empty_apple_location
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_empty_apple_location
@@ -6,7 +6,6 @@ sub test_calendarevent_get_empty_apple_location
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_emptyprops
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_emptyprops
@@ -6,7 +6,6 @@ sub test_calendarevent_get_emptyprops
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_expandrecurrences_date
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_expandrecurrences_date
@@ -6,7 +6,6 @@ sub test_calendarevent_get_expandrecurrences_date
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_ignore_dead_standalone_instance
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_ignore_dead_standalone_instance
@@ -6,7 +6,6 @@ sub test_calendarevent_get_ignore_dead_standalone_instance
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_ignore_embedded_ianatz
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_ignore_embedded_ianatz
@@ -6,7 +6,6 @@ sub test_calendarevent_get_ignore_embedded_ianatz
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_privacy_ignore_override
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_privacy_ignore_override
@@ -6,7 +6,6 @@ sub test_calendarevent_get_privacy_ignore_override
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceid
@@ -6,7 +6,6 @@ sub test_calendarevent_get_recurrenceid
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceid_date_start_datetime
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceid_date_start_datetime
@@ -6,7 +6,6 @@ sub test_calendarevent_get_recurrenceid_date_start_datetime
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceinstances
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceinstances
@@ -6,7 +6,6 @@ sub test_calendarevent_get_recurrenceinstances
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_reset_iter
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_reset_iter
@@ -6,7 +6,6 @@ sub test_calendarevent_get_reset_iter
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog "Create events in calendar A and B, both have IMAP uid 1";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_sanitize_geouri
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_sanitize_geouri
@@ -6,7 +6,6 @@ sub test_calendarevent_get_sanitize_geouri
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_sentby_caldav
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_sentby_caldav
@@ -6,7 +6,6 @@ sub test_calendarevent_get_sentby_caldav
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_sentby_imip
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_sentby_imip
@@ -6,7 +6,6 @@ sub test_calendarevent_get_sentby_imip
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_standalone_instances
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_standalone_instances
@@ -6,7 +6,6 @@ sub test_calendarevent_get_standalone_instances
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_standalone_instances_multi
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_standalone_instances_multi
@@ -6,7 +6,6 @@ sub test_calendarevent_get_standalone_instances_multi
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz
@@ -6,7 +6,6 @@ sub test_calendarevent_guesstz
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_etc_gmt
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_etc_gmt
@@ -6,7 +6,6 @@ sub test_calendarevent_guesstz_etc_gmt
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_gmt
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_gmt
@@ -6,7 +6,6 @@ sub test_calendarevent_guesstz_gmt
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_ignore_xjmapid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_ignore_xjmapid
@@ -6,7 +6,6 @@ sub test_calendarevent_guesstz_ignore_xjmapid
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_nonstandard_utcoffset
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_nonstandard_utcoffset
@@ -6,7 +6,6 @@ sub test_calendarevent_guesstz_nonstandard_utcoffset
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     # This iCalendar object contains two non-standard timezones
     # for which no equivalent IANA timezone can be found in the

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_recur
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_guesstz_recur
@@ -6,7 +6,6 @@ sub test_calendarevent_guesstz_recur
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_ignore_orphaned_ical_rows
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_ignore_orphaned_ical_rows
@@ -7,7 +7,6 @@ sub test_calendarevent_ignore_orphaned_ical_rows
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 
@@ -32,6 +31,8 @@ EOF
     ]);
     my $calendarId = $res->[0][1]{created}{1}{id};
     $self->assert_not_null($calendarId);
+    my $calendarHref = $res->[0][1]{created}{1}{'x-href'};
+    $self->assert_not_null($calendarHref);
 
     xlog "Create event via CalDAV";
     my $ical = <<'EOF';
@@ -54,7 +55,7 @@ END:VCALENDAR
 EOF
 
     $res = $caldav->Request('PUT',
-        '/dav/calendars/user/cassandane/' . $calendarId . '/test.ics',
+        $calendarHref . '/test.ics',
         $ical, 'Content-Type' => 'text/calendar');
 
     $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_itip_reply_sequence
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_itip_reply_sequence
@@ -6,7 +6,6 @@ sub test_calendarevent_itip_reply_sequence
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_itip_request_sequence
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_itip_request_sequence
@@ -6,7 +6,6 @@ sub test_calendarevent_itip_request_sequence
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_repair_broken_ical
@@ -4,7 +4,6 @@ use Cassandane::Tiny;
 sub test_calendarevent_parse_repair_broken_ical ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my @testCases = ({
         desc => 'Top-level component is VEVENT',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_parse_singlecommand
@@ -6,7 +6,6 @@ sub test_calendarevent_parse_singlecommand
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $id1 = '97c46ea4-4182-493c-87ef-aee4edc2d38b';
     my $ical1 = <<EOF;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_anchor
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_anchor
@@ -6,7 +6,6 @@ sub test_calendarevent_query_anchor
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_date
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_date
@@ -6,7 +6,6 @@ sub test_calendarevent_query_date
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_datetime
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_datetime
@@ -6,7 +6,6 @@ sub test_calendarevent_query_datetime
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_deleted_calendar
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_deleted_calendar
@@ -6,7 +6,6 @@ sub test_calendarevent_query_deleted_calendar
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 
@@ -25,6 +24,7 @@ sub test_calendarevent_query_deleted_calendar
     my $calidA = $res->[0][1]{created}{"1"}{id};
     my $calidB = $res->[0][1]{created}{"2"}{id};
     my $state = $res->[0][1]{newState};
+    my $hrefA = $res->[0][1]{created}{"1"}{'x-href'};
 
     xlog $self, "create event #1 in calendar $calidA and event #2 in calendar $calidB";
     $res = $jmap->CallMethods([['CalendarEvent/set', {
@@ -68,7 +68,7 @@ sub test_calendarevent_query_deleted_calendar
     $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
 
     xlog $self, "CalDAV delete calendar as cassandane";
-    $caldav->DeleteCalendar("/dav/calendars/user/cassandane/$calidA");
+    $caldav->DeleteCalendar($hrefA);
 
     xlog $self, "get filtered calendar event list";
     $res = $jmap->CallMethods([ ['CalendarEvent/query', {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_expandrecurrences
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_expandrecurrences
@@ -6,7 +6,6 @@ sub test_calendarevent_query_expandrecurrences
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_expandrecurrences_with_exrule
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_expandrecurrences_with_exrule
@@ -6,7 +6,6 @@ sub test_calendarevent_query_expandrecurrences_with_exrule
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_no_sched_inbox
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_no_sched_inbox
@@ -6,7 +6,6 @@ sub test_calendarevent_query_no_sched_inbox
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $imap = $self->{store}->get_client();
     my $caldav = $self->{caldav};

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_shared
@@ -6,7 +6,6 @@ sub test_calendarevent_query_shared
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $admintalk = $self->{adminstore}->get_client();

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_sort
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_sort
@@ -6,7 +6,6 @@ sub test_calendarevent_query_sort
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unixepoch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unixepoch
@@ -6,7 +6,6 @@ sub test_calendarevent_query_unixepoch
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unsupported
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unsupported
@@ -7,7 +7,6 @@ sub test_calendarevent_query_unsupported
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $uuidgen = Data::UUID->new;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts
@@ -6,7 +6,6 @@ sub test_calendarevent_set_alerts
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_owner
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_owner
@@ -13,7 +13,7 @@ sub test_calendarevent_set_alerts_owner
     my $res = $ownerJmap->CallMethods([
         ['Calendar/set', {
             update => {
-                Default => {
+                $default_cal_id => {
                     shareWith => {
                         sharee => {
                             mayReadItems => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_bymonth
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_bymonth
@@ -6,7 +6,6 @@ sub test_calendarevent_set_bymonth
     ($self)
 {
         my $jmap = $self->default_user->jmap;
-        my $default_cal_id = $self->default_user->calendars->default->id;
 
         my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_caldav
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_caldav
@@ -6,7 +6,6 @@ sub test_calendarevent_set_caldav
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 
@@ -18,6 +17,7 @@ sub test_calendarevent_set_caldav
                         }
              }}, "R1"]]);
     my $calid = $res->[0][1]{created}{"1"}{id};
+    my $calhref = $res->[0][1]{created}{"1"}{'x-href'};
 
     xlog $self, "create event in calendar";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
@@ -77,7 +77,7 @@ EOF
     my $eventId2 = encode_eventid($uid2);
 
     xlog $self, "PUT event with UID $uid2";
-    $res = $caldav->Request('PUT', "$calid/$uid2.ics", $ical, 'Content-Type' => 'text/calendar');
+    $res = $caldav->Request('PUT', "$calhref/$uid2.ics", $ical, 'Content-Type' => 'text/calendar');
 
     xlog $self, "get calendar event updates";
     $res = $jmap->CallMethods([['CalendarEvent/changes', { sinceState => $state }, "R1"]]);
@@ -130,7 +130,7 @@ EOF
  <a:prop><a:resourcetype/></a:prop>
 </a:propfind>
 EOF
-    $res = $caldav->Request('PROPFIND', "$calid", $xml,
+    $res = $caldav->Request('PROPFIND', "$calhref", $xml,
         'Content-Type' => 'application/xml',
         'Depth' => '1'
     );

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_created_legacy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_created_legacy
@@ -6,7 +6,6 @@ sub test_calendarevent_set_created_legacy
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_destroy_itip
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_destroy_itip
@@ -6,7 +6,6 @@ sub test_calendarevent_set_destroy_itip
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone
@@ -6,7 +6,6 @@ sub test_calendarevent_set_endtimezone
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone_recurrence
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone_recurrence
@@ -6,7 +6,6 @@ sub test_calendarevent_set_endtimezone_recurrence
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_htmldescription
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_htmldescription
@@ -6,7 +6,6 @@ sub test_calendarevent_set_htmldescription
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_isdraft
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_isdraft
@@ -6,7 +6,6 @@ sub test_calendarevent_set_isdraft
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords
@@ -6,7 +6,6 @@ sub test_calendarevent_set_keywords
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords_patch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords_patch
@@ -6,7 +6,6 @@ sub test_calendarevent_set_keywords_patch
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links
@@ -6,7 +6,6 @@ sub test_calendarevent_set_links
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_linksurl
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_linksurl
@@ -6,7 +6,6 @@ sub test_calendarevent_set_linksurl
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_locations
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_locations
@@ -6,7 +6,6 @@ sub test_calendarevent_set_locations
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move
@@ -6,7 +6,6 @@ sub test_calendarevent_set_move
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_no_preserve_iana_timezone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_no_preserve_iana_timezone
@@ -6,7 +6,6 @@ sub test_calendarevent_set_no_preserve_iana_timezone
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_notitle
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_notitle
@@ -6,7 +6,6 @@ sub test_calendarevent_set_notitle
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participant_links_dir
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participant_links_dir
@@ -6,7 +6,6 @@ sub test_calendarevent_set_participant_links_dir
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participantid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participantid
@@ -6,7 +6,6 @@ sub test_calendarevent_set_participantid
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants
@@ -6,7 +6,6 @@ sub test_calendarevent_set_participants
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_justorga
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_justorga
@@ -6,7 +6,6 @@ sub test_calendarevent_set_participants_justorga
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_organame
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_organame
@@ -6,7 +6,6 @@ sub test_calendarevent_set_participants_organame
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_patch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_patch
@@ -6,7 +6,6 @@ sub test_calendarevent_set_participants_patch
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_patch_empty_xprop
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_patch_empty_xprop
@@ -16,9 +16,9 @@ sub test_calendarevent_set_participants_patch_empty_xprop
         expandurl => 1,
     );
 
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $calHref = $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$calHref/$uuid.ics";
     my $event = <<EOF;
 BEGIN:VCALENDAR
 VERSION:2.0
@@ -44,7 +44,6 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['CalendarEvent/query', {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_recur
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_recur
@@ -6,7 +6,6 @@ sub test_calendarevent_set_participants_recur
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_class
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_class
@@ -6,7 +6,6 @@ sub test_calendarevent_set_preserve_class
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_microsoft_timezone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_preserve_microsoft_timezone
@@ -6,7 +6,6 @@ sub test_calendarevent_set_preserve_microsoft_timezone
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy
@@ -6,12 +6,12 @@ sub test_calendarevent_set_privacy
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
-    my $caldav = $self->{caldav};
+    my $sharer = $self->{instance}->create_user('sharer');
+    my $sharerJmap = $sharer->jmap;
+    my $default_cal_id = $sharer->calendars->default->id;
 
     xlog "share calendar with cassandane user";
-    my ($sharerJmap) = $self->create_user('sharer');
     my $res = $sharerJmap->CallMethods([
         ['Calendar/set', {
             update => {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_prodid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_prodid
@@ -6,7 +6,6 @@ sub test_calendarevent_set_prodid
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_readonly
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_readonly
@@ -6,7 +6,6 @@ sub test_calendarevent_set_readonly
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $admintalk = $self->{adminstore}->get_client();
@@ -26,15 +25,16 @@ sub test_calendarevent_set_readonly
         }, "R1"],
         ['Calendar/get', {
             ids => ['#1'],
-            properties => ['name'],
+            properties => ['x-href'],
         }, "R2"],
     ]);
     my $calendarId = $res->[0][1]{created}{1}{id};
     $self->assert_not_null($calendarId);
-    my $name = $res->[1][1]{list}[0]{'name'};
-    $self->assert_not_null($name);
+    my $href = $res->[1][1]{list}[0]{'x-href'};
+    $self->assert_not_null($href);
 
-    $admintalk->setacl("user.cassandane.#calendars." . $name, "cassandane" => 'lrskxcan9') or die;
+    $admintalk->setacl("user.cassandane.#calendars." . basename($href),
+                       "cassandane" => 'lrskxcan9') or die;
 
     $res = $jmap->CallMethods([
             ['Calendar/get',{

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence
@@ -6,7 +6,6 @@ sub test_calendarevent_set_recurrence
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_bymonthday
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_bymonthday
@@ -6,7 +6,6 @@ sub test_calendarevent_set_recurrence_bymonthday
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_until
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_until
@@ -6,7 +6,6 @@ sub test_calendarevent_set_recurrence_until
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_untilallday
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_untilallday
@@ -6,7 +6,6 @@ sub test_calendarevent_set_recurrence_untilallday
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances
@@ -6,7 +6,6 @@ sub test_calendarevent_set_recurrenceinstances
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances_rdate
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances_rdate
@@ -6,7 +6,6 @@ sub test_calendarevent_set_recurrenceinstances_rdate
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $calid = $self->default_user->calendars->default->id;

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceoverrides
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceoverrides
@@ -6,7 +6,6 @@ sub test_calendarevent_set_recurrenceoverrides
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_relatedto
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_relatedto
@@ -6,7 +6,6 @@ sub test_calendarevent_set_relatedto
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_rsvpsequence
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_rsvpsequence
@@ -6,7 +6,6 @@ sub test_calendarevent_set_rsvpsequence
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my ($id, $ical) = $self->icalfile('rsvpsequence');
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_cancel
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_cancel
@@ -6,7 +6,6 @@ sub test_calendarevent_set_schedule_cancel
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_destroy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_destroy
@@ -6,7 +6,6 @@ sub test_calendarevent_set_schedule_destroy
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_reply_custom_tz
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_reply_custom_tz
@@ -6,7 +6,6 @@ sub test_calendarevent_set_schedule_reply_custom_tz
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_simple
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_simple
@@ -6,7 +6,6 @@ sub test_calendarevent_set_simple
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instance_floatingtz
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instance_floatingtz
@@ -6,7 +6,6 @@ sub test_calendarevent_set_standalone_instance_floatingtz
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_subseconds
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_subseconds
@@ -8,7 +8,6 @@ sub test_calendarevent_set_subseconds
     # subseconds were deprecated in 3.5 but included as experimental in 3.4
 
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_too_large
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_too_large
@@ -6,7 +6,6 @@ sub test_calendarevent_set_too_large
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_type
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_type
@@ -6,7 +6,6 @@ sub test_calendarevent_set_type
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_uid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_uid
@@ -6,7 +6,6 @@ sub test_calendarevent_set_uid
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_aclcheck
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_aclcheck
@@ -6,7 +6,6 @@ sub test_calendareventnotification_aclcheck
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $admin = $self->{adminstore}->get_client();
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_imip
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_imip
@@ -6,7 +6,6 @@ sub test_calendareventnotification_imip
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_querychanges
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_querychanges
@@ -6,7 +6,6 @@ sub test_calendareventnotification_querychanges
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['CalendarEventNotification/queryChanges', {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_query
@@ -6,7 +6,6 @@ sub test_calendarprincipal_query
     ($self)
 {
     my $jmap = $self->{jmap};
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $admintalk = $self->{adminstore}->get_client();
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_querychanges
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_querychanges
@@ -6,7 +6,6 @@ sub test_calendarprincipal_querychanges
     ($self)
 {
     my $jmap = $self->{jmap};
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['Principal/queryChanges', {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_set
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_set
@@ -6,7 +6,6 @@ sub test_calendarprincipal_set
     ($self)
 {
     my $jmap = $self->{jmap};
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['Principal/set', {

--- a/cassandane/tiny-tests/JMAPCalendars/calendarsharenotification_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarsharenotification_query
@@ -6,7 +6,6 @@ sub test_calendarsharenotification_query
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     # Create sharee
     my $admin = $self->{adminstore}->get_client();

--- a/cassandane/tiny-tests/JMAPCalendars/calendarsharenotification_querychanges
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarsharenotification_querychanges
@@ -6,7 +6,6 @@ sub test_calendarsharenotification_querychanges
     ($self)
 {
     my $jmap = $self->{jmap};
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['ShareNotification/queryChanges', {

--- a/cassandane/tiny-tests/JMAPCalendars/crasher20191227
+++ b/cassandane/tiny-tests/JMAPCalendars/crasher20191227
@@ -6,7 +6,6 @@ sub test_crasher20191227
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
 

--- a/cassandane/tiny-tests/JMAPCalendars/itip_ignore_invalid_timezone
+++ b/cassandane/tiny-tests/JMAPCalendars/itip_ignore_invalid_timezone
@@ -7,7 +7,6 @@ sub test_itip_ignore_invalid_timezone
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF

--- a/cassandane/tiny-tests/JMAPCalendars/itip_remove_privacy_property
+++ b/cassandane/tiny-tests/JMAPCalendars/itip_remove_privacy_property
@@ -6,7 +6,6 @@ sub test_itip_remove_privacy_property
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/itip_rsvp_organizer_change
+++ b/cassandane/tiny-tests/JMAPCalendars/itip_rsvp_organizer_change
@@ -6,7 +6,6 @@ sub test_itip_rsvp_organizer_change
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $uid = '7e017102-0caf-490a-bbdf-422141d34e75';
 

--- a/cassandane/tiny-tests/JMAPCalendars/misc_creationids
+++ b/cassandane/tiny-tests/JMAPCalendars/misc_creationids
@@ -6,7 +6,6 @@ sub test_misc_creationids
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create and get calendar and event";
     my $res = $jmap->CallMethods([

--- a/cassandane/tiny-tests/JMAPCalendars/misc_timezone_expansion
+++ b/cassandane/tiny-tests/JMAPCalendars/misc_timezone_expansion
@@ -6,7 +6,6 @@ sub test_misc_timezone_expansion
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {

--- a/cassandane/tiny-tests/JMAPCalendars/no_shared_calendar
+++ b/cassandane/tiny-tests/JMAPCalendars/no_shared_calendar
@@ -6,7 +6,6 @@ sub test_no_shared_calendar
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     xlog $self, "create other user";
     my $admintalk = $self->{adminstore}->get_client();

--- a/cassandane/tiny-tests/JMAPCalendars/participantidentity_changes
+++ b/cassandane/tiny-tests/JMAPCalendars/participantidentity_changes
@@ -6,7 +6,6 @@ sub test_participantidentity_changes
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['ParticipantIdentity/changes', {

--- a/cassandane/tiny-tests/JMAPCalendars/participantidentity_get
+++ b/cassandane/tiny-tests/JMAPCalendars/participantidentity_get
@@ -6,7 +6,6 @@ sub test_participantidentity_get
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
 

--- a/cassandane/tiny-tests/JMAPCalendars/participantidentity_set
+++ b/cassandane/tiny-tests/JMAPCalendars/participantidentity_set
@@ -6,7 +6,6 @@ sub test_participantidentity_set
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $res = $jmap->CallMethods([
         ['ParticipantIdentity/set', {

--- a/cassandane/tiny-tests/JMAPCalendars/rscale_in_jmap_hidden_in_caldav
+++ b/cassandane/tiny-tests/JMAPCalendars/rscale_in_jmap_hidden_in_caldav
@@ -6,12 +6,12 @@ sub test_rscale_in_jmap_hidden_in_caldav
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $caldav = $self->{caldav};
     my $admin = $self->{adminstore}->get_client();
 
     my $calid = $self->default_user->calendars->default->id;
+    my $href = $self->default_user->calendars->default->properties->{'x-href'};
     my $event =  {
         calendarIds => {
             $calid => JSON::true,
@@ -78,7 +78,7 @@ sub test_rscale_in_jmap_hidden_in_caldav
     # XXX Net-CalDAV talk needs to update
     # Make sure we have no rscale through caldav, most clients can't
     # handle it
-    my $events = $caldav->GetEvents("$calid");
+    my $events = $caldav->GetEvents($href);
     $self->assert_deep_equals(
         {
             count => 12,

--- a/cassandane/tiny-tests/JMAPCalendars/session_capability_isrfc
+++ b/cassandane/tiny-tests/JMAPCalendars/session_capability_isrfc
@@ -6,7 +6,6 @@ sub test_session_capability_isrfc
     ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $session = $jmap->get_client_session->client_session;
     $self->assert_not_null($session);

--- a/cassandane/tiny-tests/JMAPCalendars/test_calendarevent_parse_multi_icalobj
+++ b/cassandane/tiny-tests/JMAPCalendars/test_calendarevent_parse_multi_icalobj
@@ -4,7 +4,6 @@ use Cassandane::Tiny;
 sub test_calendarevent_parse_multi_icalobj ($self)
 {
     my $jmap = $self->default_user->jmap;
-    my $default_cal_id = $self->default_user->calendars->default->id;
 
     # Parse iCalendar stream with two iCalendar objects
     my $ical = <<EOF;

--- a/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_only_email_mailboxes
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_only_email_mailboxes
@@ -8,6 +8,7 @@ sub test_email_query_guidsearch_only_email_mailboxes
 {
     my $jmap = $self->{jmap};
     my $imap = $self->{store}->get_client();
+    my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $using = [
         'urn:ietf:params:jmap:core',
@@ -53,7 +54,7 @@ sub test_email_query_guidsearch_only_email_mailboxes
             create => {
                 '2' => {
                     calendarIds => {
-                        Default => JSON::true
+                        $default_cal_id => JSON::true
                     },
                     start => '2020-02-25T11:00:00',
                     timeZone => 'Australia/Melbourne',

--- a/cassandane/tiny-tests/JMAPQuota/quota_query
+++ b/cassandane/tiny-tests/JMAPQuota/quota_query
@@ -30,6 +30,7 @@ EOF
     $self->assert_str_equals('Calendar/get', $res->[0][0]);
     $self->assert_str_equals('R1', $res->[0][2]);
     $self->assert_num_equals(1, scalar @{$res->[0][1]{list}});
+    my $calid = $res->[0][1]{list}[0]{id};
 
     # Right - let's set ourselves some basic usage quota
     $self->set_quotaroot('user.cassandane');
@@ -51,7 +52,7 @@ EOF
         create => {
             "1" => {
                 calendarIds => {
-                    Default => JSON::true,
+                    $calid => JSON::true,
                 },
                 "title" => "foo",
                 "description" => "",

--- a/cassandane/tiny-tests/Sieve/imip_add
+++ b/cassandane/tiny-tests/Sieve/imip_add
@@ -12,7 +12,8 @@ sub test_imip_add
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -69,7 +70,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('An Event', $events->[0]{title});
@@ -111,7 +112,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event was updated on calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_not_null($events->[0]{recurrenceOverrides}{'2021-09-24T15:30:00'});

--- a/cassandane/tiny-tests/Sieve/imip_allow_public
+++ b/cassandane/tiny-tests/Sieve/imip_allow_public
@@ -12,7 +12,8 @@ sub test_imip_allow_public
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -58,7 +59,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_cancel
+++ b/cassandane/tiny-tests/Sieve/imip_cancel
@@ -12,7 +12,8 @@ sub test_imip_cancel
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -70,7 +71,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('tentative', $events->[0]{status});
@@ -110,7 +111,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event was removed from calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('cancelled', $events->[0]{status});

--- a/cassandane/tiny-tests/Sieve/imip_cancel_delete
+++ b/cassandane/tiny-tests/Sieve/imip_cancel_delete
@@ -12,7 +12,8 @@ sub test_imip_cancel_delete
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -68,7 +69,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 
@@ -107,6 +108,6 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event was removed from calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_deep_equals($events, []);
 }

--- a/cassandane/tiny-tests/Sieve/imip_cancel_instance
+++ b/cassandane/tiny-tests/Sieve/imip_cancel_instance
@@ -12,7 +12,8 @@ sub test_imip_cancel_instance
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -70,7 +71,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('An Event', $events->[0]{title});
@@ -112,7 +113,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the updated event made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
 
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});

--- a/cassandane/tiny-tests/Sieve/imip_cancel_to_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_cancel_to_organizer
@@ -12,7 +12,8 @@ sub test_imip_cancel_to_organizer
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -47,11 +48,11 @@ ATTENDEE;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:cassandane\@example.com
 END:VEVENT
 END:VCALENDAR
 EOF
-    my $href = "/dav/calendars/user/cassandane/$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
     $CalDAV->Request('PUT', $href, $ical, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('tentative', $events->[0]{status});
@@ -88,7 +89,7 @@ EOF
     $self->{instance}->deliver($msg);
 
     xlog $self, "Make sure that the event was NOT canceled";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('tentative', $events->[0]{status});

--- a/cassandane/tiny-tests/Sieve/imip_disallow_multiple_vcalendar
+++ b/cassandane/tiny-tests/Sieve/imip_disallow_multiple_vcalendar
@@ -12,7 +12,8 @@ sub test_imip_disallow_multiple_vcalendar
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -72,6 +73,6 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event DID NOT make it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(0, scalar @$events);
 }

--- a/cassandane/tiny-tests/Sieve/imip_disallow_public
+++ b/cassandane/tiny-tests/Sieve/imip_disallow_public
@@ -12,7 +12,8 @@ sub test_imip_disallow_public
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -58,6 +59,6 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event DID NOT make it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(0, scalar @$events);
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite
+++ b/cassandane/tiny-tests/Sieve/imip_invite
@@ -12,7 +12,8 @@ sub test_imip_invite
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -65,7 +66,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_base64
+++ b/cassandane/tiny-tests/Sieve/imip_invite_base64
@@ -12,7 +12,8 @@ sub test_imip_invite_base64
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -72,7 +73,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_calendarid
+++ b/cassandane/tiny-tests/Sieve/imip_invite_calendarid
@@ -17,7 +17,7 @@ sub test_imip_invite_calendarid
 
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
-    xlog $self, "Install a sieve script to process iMIP";
+    xlog $self, "Install a sieve script to process iMIP using legacy calendar id";
     $self->{instance}->install_sieve_script(<<EOF
 require ["body", "variables", "imap4flags", "processcalendar"];
 if body :content "text/calendar" :contains "\nMETHOD:" {
@@ -70,4 +70,49 @@ EOF
     my $events = $CalDAV->GetEvents($CalendarId);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
+
+    my $jmap = $self->{jmap};
+    my $res = $jmap->CallMethods([['Calendar/get', {}, "R1"]]);
+
+    my %calendars = map { $_->{name} => $_ } @{$res->[0][1]{list}};
+    my $jmapid = $calendars{'foo'}{id};
+    $self->assert_not_null($jmapid);
+
+    xlog $self, "Install a sieve script to process iMIP using JMAP calendar id";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "processcalendar"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processcalendar :calendarid "$jmapid" :outcome "outcome";
+    if string "\${outcome}" "added" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    # Change Message-ID
+    $imip =~ s/f8201\@/f8201-1\@/;
+
+    # Update Event
+    $imip =~ s/An Event/An Updated Event/;
+    $imip =~ s/T1830/T1930/;
+    $imip =~ s/SEQUENCE:0/SEQUENCE:1/;
+
+    xlog $self, "Deliver iMIP invite";
+    my $msg2 = Cassandane::Message->new(raw => $imip);
+    $msg2->set_attribute(uid => 2, flags => [ '\\Recent' ]);
+    $self->{instance}->deliver($msg2);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg, 2 => $msg2 },
+                          keyed_on => 'uid', check_guid => 0);
+
+    xlog $self, "Check that the event made it to calendar";
+    $events = $CalDAV->GetEvents($CalendarId);
+
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+    $self->assert_str_equals('PT4H', $events->[0]{duration});
+    $self->assert_str_equals('An Updated Event', $events->[0]{title});
+    $self->assert_num_equals(1, $events->[0]{sequence});
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_funky_uid
+++ b/cassandane/tiny-tests/Sieve/imip_invite_funky_uid
@@ -12,7 +12,8 @@ sub test_imip_invite_funky_uid
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -74,7 +75,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_known_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_invite_known_organizer
@@ -12,7 +12,8 @@ sub test_imip_invite_known_organizer
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Create addressbook user";
@@ -81,7 +82,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_multipart
+++ b/cassandane/tiny-tests/Sieve/imip_invite_multipart
@@ -12,7 +12,8 @@ sub test_imip_invite_multipart
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -78,7 +79,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_single_then_master
+++ b/cassandane/tiny-tests/Sieve/imip_invite_single_then_master
@@ -12,7 +12,8 @@ sub test_imip_invite_single_then_master
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -61,7 +62,7 @@ EOF
     $self->{instance}->deliver($msg);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_null($events->[0]{recurrenceRule});
@@ -109,7 +110,7 @@ EOF
     $self->{instance}->deliver($msg);
 
     xlog $self, "Check that the standalone instance was dropped from the calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
 
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});

--- a/cassandane/tiny-tests/Sieve/imip_invite_unknown_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_invite_unknown_organizer
@@ -12,7 +12,8 @@ sub test_imip_invite_unknown_organizer
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Create addressbook user";
@@ -81,6 +82,6 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event DID NOT make it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(0, scalar @$events);
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_updatesonly
+++ b/cassandane/tiny-tests/Sieve/imip_invite_updatesonly
@@ -12,7 +12,8 @@ sub test_imip_invite_updatesonly
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -65,6 +66,6 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event did NOT make it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_deep_equals([], $events);
 }

--- a/cassandane/tiny-tests/Sieve/imip_invite_wrong_addr
+++ b/cassandane/tiny-tests/Sieve/imip_invite_wrong_addr
@@ -12,7 +12,8 @@ sub test_imip_invite_wrong_addr
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -63,7 +64,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_override
+++ b/cassandane/tiny-tests/Sieve/imip_override
@@ -12,7 +12,8 @@ sub test_imip_override
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -70,7 +71,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('An Event', $events->[0]{title});
@@ -134,7 +135,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the updated event made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
 
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});

--- a/cassandane/tiny-tests/Sieve/imip_preserve_alerts
+++ b/cassandane/tiny-tests/Sieve/imip_preserve_alerts
@@ -12,7 +12,8 @@ sub test_imip_preserve_alerts
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -105,7 +106,7 @@ DESCRIPTION:CYR-140
 END:VALARM
 EOF
 
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     my $href = $events->[0]{href};
     my $response = $CalDAV->Request('GET', $href);
     my $ical = $response->{content};
@@ -164,7 +165,7 @@ EOF
     $self->{instance}->deliver($msg);
 
     xlog $self, "Make sure that alarms remain";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
 
     $response = $CalDAV->Request('GET', $href);
     $ical = Data::ICal->new(data => $response->{content});

--- a/cassandane/tiny-tests/Sieve/imip_publish
+++ b/cassandane/tiny-tests/Sieve/imip_publish
@@ -12,7 +12,8 @@ sub test_imip_publish
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -63,7 +64,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_publish_legacy
+++ b/cassandane/tiny-tests/Sieve/imip_publish_legacy
@@ -12,7 +12,8 @@ sub test_imip_publish_legacy
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -63,7 +64,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_publish_no_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_publish_no_organizer
@@ -12,7 +12,8 @@ sub test_imip_publish_no_organizer
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -61,7 +62,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_publish_no_organizer_legacy
+++ b/cassandane/tiny-tests/Sieve/imip_publish_no_organizer_legacy
@@ -12,7 +12,8 @@ sub test_imip_publish_no_organizer_legacy
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -61,7 +62,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
 }

--- a/cassandane/tiny-tests/Sieve/imip_reply
+++ b/cassandane/tiny-tests/Sieve/imip_reply
@@ -12,9 +12,10 @@ sub test_imip_reply
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -52,7 +53,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -93,7 +94,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Test User',

--- a/cassandane/tiny-tests/Sieve/imip_reply_no_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_reply_no_organizer
@@ -12,9 +12,10 @@ sub test_imip_reply_no_organizer
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -55,7 +56,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -95,7 +96,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Test User',

--- a/cassandane/tiny-tests/Sieve/imip_reply_one_recurrence
+++ b/cassandane/tiny-tests/Sieve/imip_reply_one_recurrence
@@ -12,9 +12,10 @@ sub test_imip_reply_one_recurrence
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "09b59913-30b2-4f90-982a-7ce6e2a56655";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -91,7 +92,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Emerson Leaf',
@@ -167,7 +168,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     # top level is not updated

--- a/cassandane/tiny-tests/Sieve/imip_reply_override
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override
@@ -12,9 +12,10 @@ sub test_imip_reply_override
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -54,7 +55,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -103,7 +104,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Test User',

--- a/cassandane/tiny-tests/Sieve/imip_reply_override_google
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override_google
@@ -12,9 +12,10 @@ sub test_imip_reply_override_google
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -67,7 +68,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -124,7 +125,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Test User',

--- a/cassandane/tiny-tests/Sieve/imip_reply_override_invalid
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override_invalid
@@ -12,9 +12,10 @@ sub test_imip_reply_override_invalid
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -52,7 +53,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -99,7 +100,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the reply was ignored";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('needs-action',
@@ -133,7 +134,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -184,7 +185,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply (master only) made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Test User',

--- a/cassandane/tiny-tests/Sieve/imip_reply_override_rdate
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override_rdate
@@ -12,9 +12,10 @@ sub test_imip_reply_override_rdate
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -53,7 +54,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -101,7 +102,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Test User',

--- a/cassandane/tiny-tests/Sieve/imip_reply_two_recurrences
+++ b/cassandane/tiny-tests/Sieve/imip_reply_two_recurrences
@@ -12,9 +12,10 @@ sub test_imip_reply_two_recurrences
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "09b59913-30b2-4f90-982a-7ce6e2a56655";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -91,7 +92,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Emerson Leaf',
@@ -187,7 +188,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     # top level is not updated

--- a/cassandane/tiny-tests/Sieve/imip_reply_with_alarm
+++ b/cassandane/tiny-tests/Sieve/imip_reply_with_alarm
@@ -12,9 +12,10 @@ sub test_imip_reply_with_alarm
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
-    my $href = "$CalendarId/$uuid.ics";
+    my $href = "$CalendarHref/$uuid.ics";
 
     xlog $self, "Install a sieve script to process iMIP";
     $self->{instance}->install_sieve_script(<<EOF
@@ -52,7 +53,7 @@ EOF
     $CalDAV->Request('PUT', $href, $event, 'Content-Type' => 'text/calendar');
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('',
@@ -99,7 +100,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the reply made it to calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('Test User',

--- a/cassandane/tiny-tests/Sieve/imip_strip_personal_data
+++ b/cassandane/tiny-tests/Sieve/imip_strip_personal_data
@@ -12,7 +12,8 @@ sub test_imip_strip_personal_data
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -71,7 +72,7 @@ EOF
     $self->{instance}->deliver($msg);
 
     xlog $self, "Get the event and verify that personal data has been stripped";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     my $response = $CalDAV->Request('GET', $events->[0]{href});
     my $ical = $response->{content};
     $self->assert_does_not_match(qr/\r\nBEGIN:VALARM/, $ical);

--- a/cassandane/tiny-tests/Sieve/imip_update
+++ b/cassandane/tiny-tests/Sieve/imip_update
@@ -12,7 +12,8 @@ sub test_imip_update
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -69,7 +70,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('An Event', $events->[0]{title});
@@ -114,7 +115,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event was updated on calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('An Updated Event', $events->[0]{title});

--- a/cassandane/tiny-tests/Sieve/imip_update_master_and_add_override
+++ b/cassandane/tiny-tests/Sieve/imip_update_master_and_add_override
@@ -15,7 +15,8 @@ sub test_imip_update_master_and_add_override
 
     xlog $self, "Create calendar user";
     my $CalDAV = $self->{caldav};
-    my $CalendarId = $self->default_user->calendars->default->id;
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
 
     xlog $self, "Install a sieve script to process iMIP";
@@ -72,7 +73,7 @@ EOF
     $IMAP->expunge();
 
     xlog $self, "Check that the event made it to calendar";
-    my $events = $CalDAV->GetEvents($CalendarId);
+    my $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('An Event', $events->[0]{title});
@@ -150,7 +151,7 @@ EOF
     $self->check_messages({ 1 => $msg }, check_guid => 0);
 
     xlog $self, "Check that the event was updated on calendar";
-    $events = $CalDAV->GetEvents($CalendarId);
+    $events = $CalDAV->GetEvents($CalendarHref);
     $self->assert_equals(1, scalar @$events);
     $self->assert_str_equals($uuid, $events->[0]{uid});
     $self->assert_str_equals('An Updated Event', $events->[0]{title});

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -48,6 +48,7 @@
 #include "xapian_wrap.h"
 #include "xmalloc.h"
 #include "xsha1.h"
+#include "xstrlcpy.h"
 #include "zoneinfo_db.h"
 
 /* generated headers are not necessarily in current directory */
@@ -620,8 +621,8 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
 
     json_t *obj = json_object();
 
-    const strarray_t *boxes = mbname_boxes(mbname);
-    const char *id = strarray_nth(boxes, boxes->count-1);
+    char id[JMAP_MAX_CALENDARID_SIZE];
+    jmap_set_calendarid(req->cstate, mbentry, id);
     json_object_set_new(obj, "id", json_string(id));
 
     if (jmap_wantprop(rock->get->props, "x-href")) {
@@ -867,6 +868,43 @@ static int has_calendars(jmap_req_t *req)
     return r == CYRUSDB_DONE;
 }
 
+static void calid_to_mbentry(jmap_req_t *req, const char *id,
+                             mbentry_t **mbentry)
+{
+    int r = IMAP_NOTFOUND;
+
+    if (USER_COMPACT_EMAILIDS(req->cstate)) {
+        if (id[0] == JMAP_CALENDARID_PREFIX) {
+            char jmapid[JMAP_CALENDARID_SIZE];
+            strlcpy(jmapid, id, JMAP_CALENDARID_SIZE);
+            jmapid[0] = JMAP_MAILBOXID_PREFIX;
+            r = mboxlist_lookup_by_jmapid(req->accountid, jmapid, mbentry, NULL);
+        }
+    }
+    else {
+        char *mboxname = caldav_mboxname(req->accountid, id);
+        r = mboxlist_lookup(mboxname, mbentry, NULL);
+        free(mboxname);
+    }
+
+    if (r) {
+        if (r != IMAP_NOTFOUND) {
+            syslog(LOG_ERR,
+                   "Error reading mbentry for addressbook via %s %s: %s",
+                   USER_COMPACT_EMAILIDS(req->cstate) ? "jmapid" : "name",
+                   id, error_message(r));
+        }
+
+        *mbentry = NULL;
+    }
+    else if (((*mbentry)->mbtype & (MBTYPE_RESERVE | MBTYPE_DELETED)) ||
+             mboxname_isdeletedmailbox((*mbentry)->name, NULL)) {
+        /* Ignore "reserved" and "deleted" entries, like they aren't there */
+        mboxlist_entry_free(mbentry);
+        *mbentry = NULL;
+    }
+}
+
 static int jmap_calendar_get(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
@@ -906,11 +944,10 @@ static int jmap_calendar_get(struct jmap_req *req)
         rock.skip_hidden = 0; /* complain about missing ACL rights */
         json_array_foreach(get.ids, i, jval) {
             const char *id = json_string_value(jval);
-            char *mboxname = caldav_mboxname(req->accountid, id);
             mbentry_t *mbentry = NULL;
 
-            r = mboxlist_lookup(mboxname, &mbentry, NULL);
-            if (r == IMAP_NOTFOUND || !mbentry) {
+            calid_to_mbentry(req, id, &mbentry);
+            if (!mbentry) {
                 json_array_append(get.not_found, jval);
                 r = 0;
             }
@@ -923,7 +960,6 @@ static int jmap_calendar_get(struct jmap_req *req)
             }
 
             mboxlist_entry_free(&mbentry);
-            free(mboxname);
             if (r) goto done;
         }
     }
@@ -988,8 +1024,8 @@ static int getcalendarchanges_cb(const mbentry_t *mbentry, void *vrock)
         goto done;
     }
 
-    const strarray_t *boxes = mbname_boxes(mbname);
-    const char *id = strarray_nth(boxes, boxes->count-1);
+    char id[JMAP_MAX_CALENDARID_SIZE];
+    jmap_set_calendarid(rock->req->cstate, mbentry, id);
 
     /* Report this calendar as created, updated or destroyed. */
     if (mbentry->mbtype & MBTYPE_DELETED ||
@@ -1677,38 +1713,6 @@ static int setcalendar_writeprops(jmap_req_t *req,
     return r;
 }
 
-static int set_scheddefault(jmap_req_t *req, annotate_state_t *astate, const char *colname)
-{
-    int r = 0;
-
-    struct buf buf = BUF_INITIALIZER;
-    buf_setcstr(&buf, colname ? colname : "");
-
-    const char *annot =
-        DAV_ANNOT_NS "<" XML_NS_CALDAV ">schedule-default-calendar";
-
-    if (colname) {
-        struct mailbox *mbox = NULL;
-        char *mboxname = caldav_mboxname(req->accountid, colname);
-        // Make sure it exists and is writable
-        r = mailbox_open_iwl(mboxname, &mbox);
-        if (!r) {
-            if (httpd_myrights(req->authstate, mbox->mbentry) & ACL_INSERT)
-                r = annotate_state_writemask(astate, annot, req->accountid, &buf);
-            else
-                r = IMAP_PERMISSION_DENIED;
-        }
-        mailbox_close(&mbox);
-        free(mboxname);
-    }
-    else {
-        r = annotate_state_writemask(astate, annot, req->accountid, &buf);
-    }
-
-    buf_free(&buf);
-    return r;
-}
-
 static int _calendar_hasevents_cb(void *rock __attribute__((unused)),
                                   struct caldav_data *cdata __attribute__((unused)))
 {
@@ -1721,20 +1725,13 @@ static void setcalendars_destroy(jmap_req_t *req, const char *calid,
                                  const char *default_cal_mboxname,
                                  int destroy_events, json_t **err)
 {
-    char *mboxname = caldav_mboxname(req->accountid, calid);
-    mbname_t *mbname = mbname_from_intname(mboxname);
+    mbname_t *mbname = NULL;
     mbentry_t *mbentry = NULL;
     struct buf buf = BUF_INITIALIZER;
     struct caldav_db *db = NULL;
     int r = 0;
 
-    /* Make sure we don't delete special calendars */
-    if (!mbname || jmap_calendar_isspecial(mbname)) {
-        *err = json_pack("{s:s}", "type", "notFound");
-        goto done;
-    }
-
-    jmap_mboxlist_lookup(mboxname, &mbentry, NULL);
+    calid_to_mbentry(req, calid, &mbentry);
 
     /* Check ACL */
     if (!mbentry || !jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
@@ -1746,9 +1743,18 @@ static void setcalendars_destroy(jmap_req_t *req, const char *calid,
         goto done;
     }
 
+    const char *mboxname = mbentry->name;
+
     /* Don't delete default calendar */
     if (!strcmp(mboxname, default_cal_mboxname)) {
         *err = json_pack("{s:s}", "type", "forbidden");
+        goto done;
+    }
+
+    /* Make sure we don't delete special calendars */
+    mbname = mbname_from_intname(mboxname);
+    if (!mbname || jmap_calendar_isspecial(mbname)) {
+        *err = json_pack("{s:s}", "type", "notFound");
         goto done;
     }
 
@@ -1816,7 +1822,6 @@ done:
             *err = jmap_server_error(r);
         }
     }
-    free(mboxname);
     mbname_free(&mbname);
     mboxlist_entry_free(&mbentry);
     buf_free(&buf);
@@ -1957,15 +1962,20 @@ static void setcalendars_create(struct jmap_req *req,
     }
 
     /* Report calendar as created. */
-    *record = json_pack("{s:s s:o}", "id", uid,
+    char id[JMAP_MAX_CALENDARID_SIZE];
+    jmap_set_calendarid(req->cstate, mbentry, id);
+    *record = json_pack("{s:s s:o}", "id", id,
                         "myRights",
                         calendarrights_to_jmap(jmap_myrights_mbentry(req, mbentry),
                                                !strcmp(req->userid, req->accountid)));
     if (jmap_is_using(req, JMAP_CALENDARS_EXTENSION)) {
         json_object_set_new(*record, "mailboxUniqueId",
                         json_string(mbentry->uniqueid));
+        char *xhref = jmap_xhref(mbentry->name, NULL);
+        json_object_set_new(*record, "x-href", json_string(xhref));
+        free(xhref);
     }
-    jmap_add_id(req, creation_id, uid);
+    jmap_add_id(req, creation_id, id);
 
 done:
     if (r && *err == NULL) {
@@ -1988,25 +1998,33 @@ done:
 }
 
 static void setcalendars_update(jmap_req_t *req,
-                                const char *uid,
+                                const char *calid,
                                 json_t *arg,
                                 bool has_ext_props,
                                 json_t **record,
                                 json_t **err)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    char *mboxname = caldav_mboxname(req->accountid, uid);
-    mbname_t *mbname = mbname_from_intname(mboxname);
+    struct setcalendar_props props = { 0 };
+    const char *mboxname = NULL;
+    mbname_t *mbname = NULL;
     struct mailbox *mbox = NULL;
+    mbentry_t *mbentry = NULL;
+
+    calid_to_mbentry(req, calid, &mbentry);
+
+    if (mbentry) {
+        mboxname = mbentry->name;
+        mbname = mbname_from_intname(mboxname);
+    }
 
     /* Make sure we don't mess up special calendars */
-    if (jmap_calendar_isspecial(mbname)) {
+    if (!mbname || jmap_calendar_isspecial(mbname)) {
         *err = json_pack("{s:s}", "type", "notFound");
         goto done;
     }
 
     /* Parse and validate properties. */
-    struct setcalendar_props props;
     setcalendar_parseprops(req, &parser, &props, arg, mboxname);
     props.has_ext_props = has_ext_props;
     if (props.share.With) {
@@ -2060,8 +2078,8 @@ done:
     setcalendar_props_fini(&props);
     mailbox_close(&mbox);
     jmap_parser_fini(&parser);
+    mboxlist_entry_free(&mbentry);
     mbname_free(&mbname);
-    free(mboxname);
 }
 
 struct calendar_set_args {
@@ -2232,44 +2250,43 @@ static int jmap_calendar_set(struct jmap_req *req)
             if (jobj) newid = json_string_value(json_object_get(jobj, "id"));
         }
 
-        char *calhome_name = caldav_mboxname(req->accountid, NULL);
-        annotate_state_t *calhome_astate = NULL;
-        struct mailbox *calhome_mbox = NULL;
+        /* make sure new default calendar exists */
+        mbentry_t *mbentry = NULL;
+        calid_to_mbentry(req, newid, &mbentry);
+        if (mbentry &&
+            jmap_hasrights_mbentry(req, mbentry, JACL_ADMIN_CALENDAR)) {
+            /* set CALDAV:schedule-default-calendar annotation */
+            static const char annot[] =
+                DAV_ANNOT_NS "<" XML_NS_CALDAV ">schedule-default-calendar";
+            char *calhome_mboxname = caldav_mboxname(req->accountid, NULL);
+            mbname_t *mbname = mbname_from_intname(mbentry->name);
+            struct buf buf = BUF_INITIALIZER;
 
-        int r2 = mailbox_open_iwl(calhome_name, &calhome_mbox);
-        if (r2) {
-            xsyslog(LOG_ERR, "can not open calendar home mailbox",
-                    "err=<%s>", error_message(r2));
-        }
-        else {
-            r = mailbox_get_annotate_state(calhome_mbox, 0, &calhome_astate);
-            if (r2) {
-                xsyslog(LOG_ERR, "can not get calendar home annotation state",
-                        "err=<%s>", error_message(r2));
-            }
-            else {
-                r2 = set_scheddefault(req, calhome_astate, newid);
-                if (r2) {
-                    xsyslog(LOG_ERR, "can not set new default calendar",
-                            "name=<%s> err=<%s>", newid, error_message(r2));
+            buf_setcstr(&buf, strarray_nth(mbname_boxes(mbname), -1));
+            r = annotatemore_writemask(calhome_mboxname, annot,
+                                       req->accountid, &buf);
+            buf_free(&buf);
+            mbname_free(&mbname);
+            free(calhome_mboxname);
+
+            if (!r) {
+                /* report that isDefault has been moved to new calendar */
+                jmap_report_isdefault(&set, mbentry->name,
+                                      setargs.on_success_set_is_default, true);
+
+                /* report that isDefault has been removed from old default */
+                mboxlist_entry_free(&mbentry);
+                mboxlist_lookup(default_cal_mboxname, &mbentry, NULL);
+                if (mbentry) {
+                    char oldid[JMAP_MAX_CALENDARID_SIZE];
+
+                    jmap_set_calendarid(req->cstate, mbentry, oldid);
+                    jmap_report_isdefault(&set, mbentry->name, oldid, false);
                 }
-                else {
-                    /* report that isDefault has been moved to new calendar */
-                    char *mboxname = caldav_mboxname(req->accountid, newid);
-                    jmap_report_isdefault(&set, mboxname,
-                                          setargs.on_success_set_is_default,
-                                          true);
-                    free(mboxname);
-
-                    /* report that isDefault has been removed from old default */
-                    jmap_report_isdefault(&set, default_cal_mboxname,
-                                          default_calname, false);
-                }
             }
         }
 
-        mailbox_close(&calhome_mbox);
-        free(calhome_name);
+        mboxlist_entry_free(&mbentry);
     }
 
     set.new_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, JMAP_MODSEQ_RELOAD));
@@ -3474,9 +3491,11 @@ gotevent:
         free(xhref);
     }
     if (jmap_wantprop(props, "calendarIds")) {
-        const strarray_t *boxes = mbname_boxes(rock->mbname);
-        json_object_set_new(jsevent, "calendarIds", json_pack("{s:b}",
-                    strarray_nth(boxes, -1), 1));
+        char id[JMAP_MAX_CALENDARID_SIZE];
+
+        jmap_set_calendarid(rock->req->cstate, rock->mbentry, id);
+        json_object_set_new(jsevent, "calendarIds",
+                            json_pack("{s:b}", id, true));
     }
     if (jmap_wantprop(props, "isOrigin")) {
         json_object_set_new(jsevent, "isOrigin",
@@ -4095,16 +4114,18 @@ static int createevent_lookup_calendar(jmap_req_t *req,
     }
 
     int need_rights = JACL_ADDITEMS|JACL_SETMETADATA;
-    char *mboxname = caldav_mboxname(req->accountid, calendarid);
-    int r = mboxlist_lookup(mboxname, &create->mbentry, NULL);
-    xzfree(mboxname);
-    if (r || !jmap_hasrights_mbentry(req, create->mbentry, need_rights)) {
+    int r = 0;
+
+    calid_to_mbentry(req, calendarid, &create->mbentry);
+
+    if (!create->mbentry ||
+        !jmap_hasrights_mbentry(req, create->mbentry, need_rights)) {
         jmap_parser_invalid(parser, "calendarIds");
-        if (r == IMAP_MAILBOX_NONEXISTENT) r = 0;
+        if (!create->mbentry) r = 0;
     }
     else {
         create->sched_userid = req->accountid;
-        get_schedule_addresses(mboxname, create->sched_userid,
+        get_schedule_addresses(create->mbentry->name, create->sched_userid,
                 &create->schedule_addresses);
     }
     return r;
@@ -5333,20 +5354,17 @@ static void setcalendarevents_update(jmap_req_t *req,
     }
     /* Determine target mailbox */
     if (calendarId) {
-        char *dstmboxname = caldav_mboxname(req->accountid, calendarId);
-        if (strcmp(mbentry->name, dstmboxname)) {
-            r = mboxlist_lookup(dstmboxname, &dstmbentry, NULL);
-        }
-        free(dstmboxname);
-        if (!r && dstmbentry) {
-            r = jmap_openmbox_by_uniqueid(req, dstmbentry->uniqueid, &dstmbox, 1);
-        }
-        if (r == IMAP_MAILBOX_NONEXISTENT) {
+        calid_to_mbentry(req, calendarId, &dstmbentry);
+
+        if (!dstmbentry) {
             jmap_parser_invalid(&parser, "calendarIds");
             r = 0;
             goto done;
         }
-        else if (r) goto done;
+        if (strcmp(mbentry->name, dstmbentry->name)) {
+            r = jmap_openmbox_by_uniqueid(req, dstmbentry->uniqueid, &dstmbox, 1);
+            if (r) goto done;
+        }
     }
 
     const char *sched_userid = req->accountid;
@@ -6503,9 +6521,15 @@ static search_expr_t *eventquery_textsearch_build(jmap_req_t *req,
             e = search_expr_new(this, SEOP_OR);
             json_array_foreach(arg, i, val) {
                 const char *id = json_string_value(val);
-                search_expr_t *m = search_expr_new(e, SEOP_MATCH);
-                m->attr = search_attr_find("folder");
-                m->value.s = caldav_mboxname(req->accountid, id);
+                mbentry_t *mbentry = NULL;
+
+                calid_to_mbentry(req, id, &mbentry);
+                if (mbentry) {
+                    search_expr_t *m = search_expr_new(e, SEOP_MATCH);
+                    m->attr = search_attr_find("folder");
+                    m->value.s = xstrdup(mbentry->name);
+                    mboxlist_entry_free(&mbentry);
+                }
             }
         }
 
@@ -6859,19 +6883,18 @@ static struct caldav_jscal_filter *build_jscal_filter(jmap_req_t *req,
         json_t *jval;
         json_array_foreach(json_object_get(jfilter, "inCalendars"), i, jval) {
             const char *id = json_string_value(jval);
-            char *mboxname = caldav_mboxname(req->accountid, id);
             mbentry_t *mbentry = NULL;
 
-            int r = mboxlist_lookup(mboxname, &mbentry, NULL);
-            if (!r && jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
+            calid_to_mbentry(req, id, &mbentry);
+
+            if (mbentry &&
+                jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
                 caldav_jscal_filter_by_mbentrym(filter, mbentry);
             }
-            else if (r != IMAP_MAILBOX_NONEXISTENT) {
+            else if (!mbentry) {
                 xsyslog(LOG_WARNING, "could not lookup calendar",
-                        "calendarId=<%s> err=<%s>", id, error_message(r));
+                        "calendarId=<%s>", id);
             }
-
-            free(mboxname);
         }
 
         if (!ptrarray_size(&filter->mbentries))

--- a/imap/jmap_calendar_props.gperf
+++ b/imap/jmap_calendar_props.gperf
@@ -51,7 +51,7 @@ jmap_property_t;
 "freeBusyUrl",      JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_EXTERNAL
 "calDavUrl",        JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_EXTERNAL
 "mailboxUniqueId",  JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
-"x-href",           JMAP_DEBUG_EXTENSION,     JMAP_PROP_SERVER_SET
+"x-href",           JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 %%
 
 const jmap_prop_hash_table_t jmap_calendar_props_map = {

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1349,6 +1349,24 @@ EXPORTED void jmap_set_contactid(struct conversations_state *cstate,
     }
 }
 
+EXPORTED void jmap_set_calendarid(struct conversations_state *cstate,
+                                  const mbentry_t *mbentry, char *calid)
+{
+    if (USER_COMPACT_EMAILIDS(cstate)) {
+        strlcpy(calid, mbentry->jmapid, JMAP_MAX_CALENDARID_SIZE);
+        // replace MAILBOXID prefix with CALENDAR prefix
+        calid[0] = JMAP_CALENDARID_PREFIX;
+    }
+    else {
+        // last segment of mailbox name
+        mbname_t *mbname = mbname_from_intname(mbentry->name);
+        const strarray_t *boxes = mbname_boxes(mbname);
+        const char *id = strarray_nth(boxes, -1);
+        strlcpy(calid, id, JMAP_MAX_CALENDARID_SIZE);
+        mbname_free(&mbname);
+    }
+}
+
 EXPORTED char *jmap_role_to_specialuse(const char *role)
 {
     if (!role) return NULL;

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -200,6 +200,14 @@ extern void jmap_set_contactid(struct conversations_state *cstate,
                                const struct carddav_data *cdata,
                                struct buf *cid);
 
+#define JMAP_CALENDARID_PREFIX 'C'
+#define JMAP_CALENDARID_SIZE JMAP_MAILBOXID_SIZE
+
+#define JMAP_MAX_CALENDARID_SIZE MAX(JMAP_CALENDARID_SIZE, MAX_MAILBOX_NAME+1)
+
+extern void jmap_set_calendarid(struct conversations_state *cstate,
+                                const mbentry_t *mbentry, char *calid);
+
 #ifdef HAVE_ICAL
 struct jmap_caleventid {
     const char *raw; /* as requested by client */

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1679,9 +1679,30 @@ static int sieve_processcal(void *ac, void *ic, void *sc, void *mc,
         goto done;
     }
 
+    const char *calendarid = cal->calendarid;
+    char *freeme = NULL;
+    if (calendarid && USER_COMPACT_EMAILIDS(ctx->cstate) &&
+        (calendarid[0] == JMAP_CALENDARID_PREFIX)) {
+        char jmapid[JMAP_CALENDARID_SIZE];
+        mbentry_t *mbentry = NULL;
+
+        // swap mailbox prefix for calendar prefix
+        strlcpy(jmapid, calendarid, JMAP_CALENDARID_SIZE);
+        jmapid[0] = JMAP_MAILBOXID_PREFIX;
+
+        mboxlist_lookup_by_jmapid(ctx->userid, jmapid, &mbentry, NULL);
+        if (mbentry) {
+            mbname_t *mbname = mbname_from_intname(mbentry->name);
+            calendarid = freeme =
+                xstrdup(strarray_nth(mbname_boxes(mbname), -1));
+            mbname_free(&mbname);
+            mboxlist_entry_free(&mbentry);
+        }
+    }
+
     struct sched_data sched_data =
         { SCHED_MECH_SIEVE, sched_flags, itip, NULL, NULL,
-          ICAL_SCHEDULEFORCESEND_NONE, &sched_addresses, cal->calendarid, NULL };
+          ICAL_SCHEDULEFORCESEND_NONE, &sched_addresses, calendarid, NULL };
     struct caldav_sched_param sched_param = {
         (char *) ctx->userid, NULL, 0, 0, 1, NULL
     };
@@ -1691,6 +1712,8 @@ static int sieve_processcal(void *ac, void *ic, void *sc, void *mc,
                                 &sched_param, &sched_data,
                                 (struct auth_state *) sd->authstate,
                                 NULL, NULL);
+    free(freeme);
+
     switch (r) {
     case SCHED_DELIVER_ERROR:
         buf_setcstr(&cal->outcome, "error");


### PR DESCRIPTION
Uses an encoded form of mailbox createdmodseq as the ID