### PR TITLE
jmap: make MIME boundaries deterministic for Email/set create

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_deterministic_boundaries
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_deterministic_boundaries
@@ -1,0 +1,113 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_set_create_deterministic_boundaries
+    :min_version_3_1 :needs_component_sieve
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+    xlog $self, "Create a multipart email with text and html bodies";
+    my $res = $jmap->CallMethods([
+        ['Email/set', { create => {
+            "a" => {
+                mailboxIds => { '$inbox' => JSON::true },
+                from => [{ name => "Test", email => 'test@example.com' }],
+                to => [{ name => "Dest", email => 'dest@example.com' }],
+                subject => "Deterministic boundary test",
+                "header:Message-Id" => '<test1234@example.com>',
+                "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
+                bodyStructure => {
+                    type => 'multipart/alternative',
+                    subParts => [{
+                        type => 'text/plain',
+                        partId => 'text',
+                    }, {
+                        type => 'text/html',
+                        partId => 'html',
+                    }],
+                },
+                bodyValues => {
+                    text => { value => "Hello world" },
+                    html => { value => "<p>Hello world</p>" },
+                },
+            },
+        }}, "R1"],
+    ]);
+    my $emailId1 = $res->[0][1]{created}{a}{id};
+    my $blobId1 = $res->[0][1]{created}{a}{blobId};
+    $self->assert_not_null($emailId1);
+    $self->assert_not_null($blobId1);
+
+    xlog $self, "Delete the email";
+    $res = $jmap->CallMethods([
+        ['Email/set', { destroy => [$emailId1] }, "R2"],
+    ]);
+    $self->assert_str_equals($emailId1, $res->[0][1]{destroyed}[0]);
+
+    xlog $self, "Create the exact same email again - must produce same blobId";
+    $res = $jmap->CallMethods([
+        ['Email/set', { create => {
+            "b" => {
+                mailboxIds => { '$inbox' => JSON::true },
+                from => [{ name => "Test", email => 'test@example.com' }],
+                to => [{ name => "Dest", email => 'dest@example.com' }],
+                subject => "Deterministic boundary test",
+                "header:Message-Id" => '<test1234@example.com>',
+                "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
+                bodyStructure => {
+                    type => 'multipart/alternative',
+                    subParts => [{
+                        type => 'text/plain',
+                        partId => 'text',
+                    }, {
+                        type => 'text/html',
+                        partId => 'html',
+                    }],
+                },
+                bodyValues => {
+                    text => { value => "Hello world" },
+                    html => { value => "<p>Hello world</p>" },
+                },
+            },
+        }}, "R3"],
+    ]);
+    my $blobId2 = $res->[0][1]{created}{b}{blobId};
+    $self->assert_not_null($blobId2);
+
+    xlog $self, "Same input must produce same blobId (identical RFC822 output)";
+    $self->assert_str_equals($blobId1, $blobId2);
+
+    xlog $self, "Create email with different body content";
+    $res = $jmap->CallMethods([
+        ['Email/set', { create => {
+            "c" => {
+                mailboxIds => { '$inbox' => JSON::true },
+                from => [{ name => "Test", email => 'test@example.com' }],
+                to => [{ name => "Dest", email => 'dest@example.com' }],
+                subject => "Deterministic boundary test",
+                "header:Message-Id" => '<test1234@example.com>',
+                "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
+                bodyStructure => {
+                    type => 'multipart/alternative',
+                    subParts => [{
+                        type => 'text/plain',
+                        partId => 'text',
+                    }, {
+                        type => 'text/html',
+                        partId => 'html',
+                    }],
+                },
+                bodyValues => {
+                    text => { value => "Hello different world" },
+                    html => { value => "<p>Hello different world</p>" },
+                },
+            },
+        }}, "R4"],
+    ]);
+    my $blobId3 = $res->[0][1]{created}{c}{blobId};
+    $self->assert_not_null($blobId3);
+
+    xlog $self, "Different content must produce different blobId";
+    $self->assert_str_not_equals($blobId1, $blobId3);
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_deterministic_boundaries
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_deterministic_boundaries
@@ -2,44 +2,45 @@
 use Cassandane::Tiny;
 
 sub test_email_set_create_deterministic_boundaries
-    :min_version_3_1 :needs_component_sieve
+    :needs_component_sieve
     ($self)
 {
     my $jmap = $self->{jmap};
 
+    # Fixed messageId and sentAt ensure the server doesn't generate
+    # random values, keeping the RFC822 output fully deterministic.
+    my %emailProps = (
+        mailboxIds => { '$inbox' => JSON::true },
+        from => [{ name => "Test", email => 'test@example.com' }],
+        to => [{ name => "Dest", email => 'dest@example.com' }],
+        subject => "Deterministic boundary test",
+        messageId => ['test1234@example.com'],
+        sentAt => '2024-01-01T00:00:00Z',
+        bodyStructure => {
+            type => 'multipart/alternative',
+            subParts => [{
+                type => 'text/plain',
+                partId => 'text',
+            }, {
+                type => 'text/html',
+                partId => 'html',
+            }],
+        },
+        bodyValues => {
+            text => { value => "Hello world" },
+            html => { value => "<p>Hello world</p>" },
+        },
+    );
+
     xlog $self, "Create a multipart email with text and html bodies";
     my $res = $jmap->CallMethods([
-        ['Email/set', { create => {
-            "a" => {
-                mailboxIds => { '$inbox' => JSON::true },
-                from => [{ name => "Test", email => 'test@example.com' }],
-                to => [{ name => "Dest", email => 'dest@example.com' }],
-                subject => "Deterministic boundary test",
-                "header:Message-Id" => '<test1234@example.com>',
-                "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
-                bodyStructure => {
-                    type => 'multipart/alternative',
-                    subParts => [{
-                        type => 'text/plain',
-                        partId => 'text',
-                    }, {
-                        type => 'text/html',
-                        partId => 'html',
-                    }],
-                },
-                bodyValues => {
-                    text => { value => "Hello world" },
-                    html => { value => "<p>Hello world</p>" },
-                },
-            },
-        }}, "R1"],
+        ['Email/set', { create => { "a" => {%emailProps} } }, "R1"],
     ]);
-    my $emailId1 = $res->[0][1]{created}{a}{id};
     my $blobId1 = $res->[0][1]{created}{a}{blobId};
-    $self->assert_not_null($emailId1);
     $self->assert_not_null($blobId1);
 
     xlog $self, "Delete the email";
+    my $emailId1 = $res->[0][1]{created}{a}{id};
     $res = $jmap->CallMethods([
         ['Email/set', { destroy => [$emailId1] }, "R2"],
     ]);
@@ -47,30 +48,7 @@ sub test_email_set_create_deterministic_boundaries
 
     xlog $self, "Create the exact same email again - must produce same blobId";
     $res = $jmap->CallMethods([
-        ['Email/set', { create => {
-            "b" => {
-                mailboxIds => { '$inbox' => JSON::true },
-                from => [{ name => "Test", email => 'test@example.com' }],
-                to => [{ name => "Dest", email => 'dest@example.com' }],
-                subject => "Deterministic boundary test",
-                "header:Message-Id" => '<test1234@example.com>',
-                "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
-                bodyStructure => {
-                    type => 'multipart/alternative',
-                    subParts => [{
-                        type => 'text/plain',
-                        partId => 'text',
-                    }, {
-                        type => 'text/html',
-                        partId => 'html',
-                    }],
-                },
-                bodyValues => {
-                    text => { value => "Hello world" },
-                    html => { value => "<p>Hello world</p>" },
-                },
-            },
-        }}, "R3"],
+        ['Email/set', { create => { "b" => {%emailProps} } }, "R3"],
     ]);
     my $blobId2 = $res->[0][1]{created}{b}{blobId};
     $self->assert_not_null($blobId2);
@@ -79,31 +57,13 @@ sub test_email_set_create_deterministic_boundaries
     $self->assert_str_equals($blobId1, $blobId2);
 
     xlog $self, "Create email with different body content";
+    my %differentProps = %emailProps;
+    $differentProps{bodyValues} = {
+        text => { value => "Hello different world" },
+        html => { value => "<p>Hello different world</p>" },
+    };
     $res = $jmap->CallMethods([
-        ['Email/set', { create => {
-            "c" => {
-                mailboxIds => { '$inbox' => JSON::true },
-                from => [{ name => "Test", email => 'test@example.com' }],
-                to => [{ name => "Dest", email => 'dest@example.com' }],
-                subject => "Deterministic boundary test",
-                "header:Message-Id" => '<test1234@example.com>',
-                "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
-                bodyStructure => {
-                    type => 'multipart/alternative',
-                    subParts => [{
-                        type => 'text/plain',
-                        partId => 'text',
-                    }, {
-                        type => 'text/html',
-                        partId => 'html',
-                    }],
-                },
-                bodyValues => {
-                    text => { value => "Hello different world" },
-                    html => { value => "<p>Hello different world</p>" },
-                },
-            },
-        }}, "R4"],
+        ['Email/set', { create => { "c" => {%differentProps} } }, "R4"],
     ]);
     my $blobId3 = $res->[0][1]{created}{c}{blobId};
     $self->assert_not_null($blobId3);

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_duplicate_retry
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_duplicate_retry
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_email_set_create_duplicate_retry
-    :min_version_3_1 :needs_component_sieve
+    :needs_component_sieve
     ($self)
 {
     my $jmap = $self->{jmap};
@@ -12,8 +12,8 @@ sub test_email_set_create_duplicate_retry
         from => [{ name => "Test", email => 'test@example.com' }],
         to => [{ name => "Dest", email => 'dest@example.com' }],
         subject => "Duplicate retry test",
-        "header:Message-Id" => '<retry-test@example.com>',
-        "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
+        messageId => ['retry-test@example.com'],
+        sentAt => '2024-01-01T00:00:00Z',
         bodyStructure => {
             type => 'multipart/alternative',
             subParts => [{

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_duplicate_retry
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_duplicate_retry
@@ -43,9 +43,11 @@ sub test_email_set_create_duplicate_retry
     ]);
 
     xlog $self, "Must get alreadyExists with the existing id";
-    $self->assert_null($res->[0][1]{created}{b});
-    my $err = $res->[0][1]{notCreated}{b};
-    $self->assert_not_null($err);
-    $self->assert_str_equals("alreadyExists", $err->{type});
-    $self->assert_str_equals($emailId, $err->{existingId});
+    $self->assert_cmp_deeply(
+        superhashof({
+            type => "alreadyExists",
+            existingId => $emailId,
+        }),
+        $res->[0][1]{notCreated}{b},
+    );
 }

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_duplicate_retry
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_duplicate_retry
@@ -1,0 +1,51 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_set_create_duplicate_retry
+    :min_version_3_1 :needs_component_sieve
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+    my %emailProps = (
+        mailboxIds => { '$inbox' => JSON::true },
+        from => [{ name => "Test", email => 'test@example.com' }],
+        to => [{ name => "Dest", email => 'dest@example.com' }],
+        subject => "Duplicate retry test",
+        "header:Message-Id" => '<retry-test@example.com>',
+        "header:Date" => 'Mon, 01 Jan 2024 00:00:00 +0000',
+        bodyStructure => {
+            type => 'multipart/alternative',
+            subParts => [{
+                type => 'text/plain',
+                partId => 'text',
+            }, {
+                type => 'text/html',
+                partId => 'html',
+            }],
+        },
+        bodyValues => {
+            text => { value => "Hello world" },
+            html => { value => "<p>Hello world</p>" },
+        },
+    );
+
+    xlog $self, "Create the email";
+    my $res = $jmap->CallMethods([
+        ['Email/set', { create => { "a" => {%emailProps} } }, "R1"],
+    ]);
+    my $emailId = $res->[0][1]{created}{a}{id};
+    $self->assert_not_null($emailId);
+
+    xlog $self, "Retry the same create (simulating network retry)";
+    $res = $jmap->CallMethods([
+        ['Email/set', { create => { "b" => {%emailProps} } }, "R2"],
+    ]);
+
+    xlog $self, "Must get alreadyExists with the existing id";
+    $self->assert_null($res->[0][1]{created}{b});
+    my $err = $res->[0][1]{notCreated}{b};
+    $self->assert_not_null($err);
+    $self->assert_str_equals("alreadyExists", $err->{type});
+    $self->assert_str_equals($emailId, $err->{existingId});
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8736,30 +8736,39 @@ done:
 }
 
 struct boundary_gen {
-    char *base;            /* hash of Email/set properties, or NULL for random */
+    char *base;            /* hash of Email/set properties */
     unsigned counter;      /* incremented for each boundary */
     struct buf buf;        /* reusable buffer for boundary generation */
 };
 
+/* Compute deterministic MIME boundary base from a hash of the
+ * input JSON properties.  This ensures identical Email/set creates
+ * produce identical RFC 822 output (same blobId), enabling
+ * duplicate detection on network retry. */
+static void _boundary_gen_init(struct boundary_gen *gen, json_t *jemail)
+{
+    memset(gen, 0, sizeof(struct boundary_gen));
+
+    char *json = json_dumps(jemail, JSON_COMPACT|JSON_SORT_KEYS);
+    struct message_guid guid;
+    message_guid_generate(&guid, json, strlen(json));
+    gen->base = xstrdup(message_guid_encode(&guid));
+    free(json);
+}
+
+static void _boundary_gen_fini(struct boundary_gen *gen)
+{
+    free(gen->base);
+    buf_free(&gen->buf);
+}
+
 static char *_mime_make_boundary(struct boundary_gen *gen)
 {
-    if (gen && gen->base) {
-        /* deterministic boundary from hash of Email/set properties */
-        struct message_guid guid;
-        buf_reset(&gen->buf);
-        buf_printf(&gen->buf, "%s-%u", gen->base, gen->counter++);
-        message_guid_generate(&guid, buf_base(&gen->buf), buf_len(&gen->buf));
-        return xstrdup(message_guid_encode(&guid));
-    }
-
-    /* fallback: random boundary */
-    char *boundary, *p, *q;
-    boundary = xstrdup(makeuuid());
-    for (p = boundary, q = boundary; *p; p++) {
-        if (*p != '-') *q++ = *p;
-    }
-    *q = 0;
-    return boundary;
+    struct message_guid guid;
+    buf_reset(&gen->buf);
+    buf_printf(&gen->buf, "%s-%u", gen->base, gen->counter++);
+    message_guid_generate(&guid, buf_base(&gen->buf), buf_len(&gen->buf));
+    return xstrdup(message_guid_encode(&guid));
 }
 
 static int _copy_msgrecords(struct auth_state *authstate,
@@ -9284,8 +9293,7 @@ static void _email_fini(struct email *email)
     json_decref(email->jemail);
     _emailpart_fini(email->body);
     free(email->body);
-    free(email->boundary_gen.base);
-    buf_free(&email->boundary_gen.buf);
+    _boundary_gen_fini(&email->boundary_gen);
 }
 
 static json_t *_header_make(const char *header_name,
@@ -11275,20 +11283,12 @@ static void _email_create(jmap_req_t *req,
     struct email_append_detail detail;
     memset(&detail, 0, sizeof(struct email_append_detail));
 
-    /* Compute deterministic MIME boundary base from a hash of the
-     * input JSON properties.  This ensures identical Email/set creates
-     * produce identical RFC 822 output (same blobId), enabling
-     * duplicate detection on network retry. */
-    char *json = json_dumps(jemail, JSON_COMPACT|JSON_SORT_KEYS);
-    struct message_guid boundary_guid;
-    message_guid_generate(&boundary_guid, json, strlen(json));
-    free(json);
-
     /* Parse Email object into internal representation */
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct email email = { HEADERS_INITIALIZER, NULL, NULL, { 0 }, 0, NULL,
-                           { xstrdup(message_guid_encode(&boundary_guid)),
-                             0, BUF_INITIALIZER } };
+    struct email email = { HEADERS_INITIALIZER, NULL, NULL, { 0 }, 0, NULL, {0} };
+
+    _boundary_gen_init(&email.boundary_gen, jemail);
+
     _parse_email(req, jemail, &parser, &email);
 
     /* Validate mailboxIds */

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8736,8 +8736,9 @@ done:
 }
 
 struct boundary_gen {
-    const char *base;  /* hash of Email/set properties, or NULL for random */
-    int counter;       /* incremented for each boundary */
+    char *base;            /* hash of Email/set properties, or NULL for random */
+    unsigned counter;      /* incremented for each boundary */
+    struct buf buf;        /* reusable buffer for boundary generation */
 };
 
 static char *_mime_make_boundary(struct boundary_gen *gen)
@@ -8745,10 +8746,9 @@ static char *_mime_make_boundary(struct boundary_gen *gen)
     if (gen && gen->base) {
         /* deterministic boundary from hash of Email/set properties */
         struct message_guid guid;
-        struct buf buf = BUF_INITIALIZER;
-        buf_printf(&buf, "%s-%d", gen->base, gen->counter++);
-        message_guid_generate(&guid, buf_base(&buf), buf_len(&buf));
-        buf_free(&buf);
+        buf_reset(&gen->buf);
+        buf_printf(&gen->buf, "%s-%u", gen->base, gen->counter++);
+        message_guid_generate(&guid, buf_base(&gen->buf), buf_len(&gen->buf));
         return xstrdup(message_guid_encode(&guid));
     }
 
@@ -9284,6 +9284,8 @@ static void _email_fini(struct email *email)
     json_decref(email->jemail);
     _emailpart_fini(email->body);
     free(email->body);
+    free(email->boundary_gen.base);
+    buf_free(&email->boundary_gen.buf);
 }
 
 static json_t *_header_make(const char *header_name,
@@ -11284,9 +11286,9 @@ static void _email_create(jmap_req_t *req,
 
     /* Parse Email object into internal representation */
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    char *boundary_base = xstrdup(message_guid_encode(&boundary_guid));
     struct email email = { HEADERS_INITIALIZER, NULL, NULL, { 0 }, 0, NULL,
-                           { boundary_base, 0 } };
+                           { xstrdup(message_guid_encode(&boundary_guid)),
+                             0, BUF_INITIALIZER } };
     _parse_email(req, jemail, &parser, &email);
 
     /* Validate mailboxIds */
@@ -11349,7 +11351,6 @@ done:
     strarray_fini(&keywords);
     jmap_parser_fini(&parser);
     _email_fini(&email);
-    free(boundary_base);
 }
 
 static int _email_uidrec_compareuid_cb(const void **pa, const void **pb)

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8735,16 +8735,30 @@ done:
     return 0;
 }
 
-static char *_mime_make_boundary()
-{
-    char *boundary, *p, *q;
+struct boundary_gen {
+    const char *base;  /* hash of Email/set properties, or NULL for random */
+    int counter;       /* incremented for each boundary */
+};
 
+static char *_mime_make_boundary(struct boundary_gen *gen)
+{
+    if (gen && gen->base) {
+        /* deterministic boundary from hash of Email/set properties */
+        struct message_guid guid;
+        struct buf buf = BUF_INITIALIZER;
+        buf_printf(&buf, "%s-%d", gen->base, gen->counter++);
+        message_guid_generate(&guid, buf_base(&buf), buf_len(&buf));
+        buf_free(&buf);
+        return xstrdup(message_guid_encode(&guid));
+    }
+
+    /* fallback: random boundary */
+    char *boundary, *p, *q;
     boundary = xstrdup(makeuuid());
     for (p = boundary, q = boundary; *p; p++) {
         if (*p != '-') *q++ = *p;
     }
     *q = 0;
-
     return boundary;
 }
 
@@ -9260,6 +9274,7 @@ struct email {
     struct timespec internaldate; /* RFC 3501 internaldate aka receivedAt */
     int has_attachment;           /* set the HasAttachment flag */
     json_t *snoozed;              /* set snoozed annotation */
+    struct boundary_gen boundary_gen; /* deterministic MIME boundary generator */
 };
 
 static void _email_fini(struct email *email)
@@ -10032,14 +10047,15 @@ static struct emailpart *_emailpart_parse(jmap_req_t *req,
 }
 
 static struct emailpart *_emailpart_new_multi(const char *subtype,
-                                               ptrarray_t *subparts)
+                                               ptrarray_t *subparts,
+                                               struct boundary_gen *gen)
 {
     struct emailpart *part = xzmalloc(sizeof(struct emailpart));
     int i;
 
     part->type = xstrdup("multipart");
     part->subtype = xstrdup(subtype);
-    part->boundary = _mime_make_boundary();
+    part->boundary = _mime_make_boundary(gen);
     struct buf val = BUF_INITIALIZER;
     buf_printf(&val, "%s/%s;boundary=%s",
             part->type, part->subtype, part->boundary);
@@ -10053,7 +10069,8 @@ static struct emailpart *_emailpart_new_multi(const char *subtype,
 
 static struct emailpart *_email_buildbody(struct emailpart *text_body,
                                           struct emailpart *html_body,
-                                          ptrarray_t *attachments)
+                                          ptrarray_t *attachments,
+                                          struct boundary_gen *gen)
 {
     struct emailpart *root = NULL;
 
@@ -10079,7 +10096,7 @@ static struct emailpart *_email_buildbody(struct emailpart *text_body,
     /* Make MIME part for embedded emails. */
     struct emailpart *emails = NULL;
     if (attached_emails.count >= 2)
-        emails = _emailpart_new_multi("digest", &attached_emails);
+        emails = _emailpart_new_multi("digest", &attached_emails, gen);
     else if (attached_emails.count == 1)
         emails = ptrarray_nth(&attached_emails, 0);
 
@@ -10089,7 +10106,7 @@ static struct emailpart *_email_buildbody(struct emailpart *text_body,
         ptrarray_t alternatives = PTRARRAY_INITIALIZER;
         ptrarray_append(&alternatives, text_body);
         ptrarray_append(&alternatives, html_body);
-        text = _emailpart_new_multi("alternative", &alternatives);
+        text = _emailpart_new_multi("alternative", &alternatives, gen);
         ptrarray_fini(&alternatives);
     }
     else if (text_body)
@@ -10099,14 +10116,14 @@ static struct emailpart *_email_buildbody(struct emailpart *text_body,
 
     /* Make MIME part for inlined attachments, if any. */
     if (text && inlined_files.count) {
-        struct emailpart *related = _emailpart_new_multi("related", &inlined_files);
+        struct emailpart *related = _emailpart_new_multi("related", &inlined_files, gen);
         ptrarray_insert(&related->subparts, 0, text);
         text = related;
     }
 
     /* Choose top-level MIME part. */
     if (attached_files.count) {
-        struct emailpart *mixed = _emailpart_new_multi("mixed", &attached_files);
+        struct emailpart *mixed = _emailpart_new_multi("mixed", &attached_files, gen);
         if (emails) ptrarray_insert(&mixed->subparts, 0, emails);
         if (text) ptrarray_insert(&mixed->subparts, 0, text);
         root = mixed;
@@ -10115,7 +10132,7 @@ static struct emailpart *_email_buildbody(struct emailpart *text_body,
         ptrarray_t wrapped = PTRARRAY_INITIALIZER;
         ptrarray_append(&wrapped, text);
         ptrarray_append(&wrapped, emails);
-        root = _emailpart_new_multi("mixed", &wrapped);
+        root = _emailpart_new_multi("mixed", &wrapped, gen);
         ptrarray_fini(&wrapped);
     }
     else if (text)
@@ -10307,7 +10324,8 @@ static void _email_parse_bodies(jmap_req_t *req,
 
     if (!email->body) {
         /* Build email body from convenience body properties */
-        email->body = _email_buildbody(text_body, html_body, &attachments);
+        email->body = _email_buildbody(text_body, html_body, &attachments,
+                                       &email->boundary_gen);
     }
 
     ptrarray_fini(&attachments);
@@ -10687,7 +10705,8 @@ static void expand_bare_cr_lf(const char **bodyp, size_t *body_lenp,
     *bodyp = new_body;
 }
 
-static void _emailpart_write_headers(struct emailpart *part, FILE *fp)
+static void _emailpart_write_headers(struct emailpart *part, FILE *fp,
+                                     struct boundary_gen *gen)
 {
     _headers_write_mime(&part->headers, fp);
 
@@ -10740,7 +10759,7 @@ static void _emailpart_write_headers(struct emailpart *part, FILE *fp)
     if (part->type && part->subtype &&
         !_headers_have(&part->headers, "Content-Type")) {
         if (!strcasecmpsafe(part->type, "MULTIPART") && !part->boundary)
-            part->boundary = _mime_make_boundary();
+            part->boundary = _mime_make_boundary(gen);
 
         buf_setcstr(&buf, "Content-Type: ");
         buf_appendcstr(&buf, lcase(part->type));
@@ -10790,7 +10809,8 @@ static void _emailpart_write_headers(struct emailpart *part, FILE *fp)
 static void _emailpart_body_to_mime(jmap_req_t *req, struct jmap_parser *parser,
                                     FILE *fp, struct emailpart *part,
                                     struct emailpart *parent_part,
-                                    json_t *missing_blobs)
+                                    json_t *missing_blobs,
+                                    struct boundary_gen *gen)
 {
     jmap_getblob_context_t blob = {0};
     const char *src_body = NULL;
@@ -11045,7 +11065,7 @@ static void _emailpart_body_to_mime(jmap_req_t *req, struct jmap_parser *parser,
     }
 
     // Write MIME headers and content
-    _emailpart_write_headers(part, fp);
+    _emailpart_write_headers(part, fp, gen);
     fputs("Content-Transfer-Encoding: ", fp);
     fputs(content_transfer_encoding, fp);
     fputs("\r\n", fp);
@@ -11062,7 +11082,8 @@ done:
 static void _emailpart_to_mime(jmap_req_t *req, struct jmap_parser *parser,
                                FILE *fp, struct emailpart *part,
                                struct emailpart *parent_part,
-                               json_t *missing_blobs)
+                               json_t *missing_blobs,
+                               struct boundary_gen *gen)
 {
     if (ptrarray_size(&part->subparts)) {
         if (!part->type) {
@@ -11070,23 +11091,24 @@ static void _emailpart_to_mime(jmap_req_t *req, struct jmap_parser *parser,
             part->subtype = xstrdup("mixed");
 
             if (!part->boundary)
-                part->boundary = _mime_make_boundary();
+                part->boundary = _mime_make_boundary(gen);
         }
 
-        _emailpart_write_headers(part, fp);
+        _emailpart_write_headers(part, fp, gen);
 
         for (int i = 0; i < ptrarray_size(&part->subparts); i++) {
             struct emailpart *subpart = ptrarray_nth(&part->subparts, i);
             fprintf(fp, "\r\n--%s\r\n", part->boundary);
             jmap_parser_push_index(parser, "subParts", i, NULL);
-            _emailpart_to_mime(req, parser, fp, subpart, part, missing_blobs);
+            _emailpart_to_mime(req, parser, fp, subpart, part,
+                               missing_blobs, gen);
             jmap_parser_pop(parser);
         }
         fprintf(fp, "\r\n--%s--\r\n", part->boundary);
     }
     else {
         _emailpart_body_to_mime(req, parser, fp, part, parent_part,
-                                missing_blobs);
+                                missing_blobs, gen);
     }
 }
 
@@ -11136,7 +11158,8 @@ static int _email_to_mime(jmap_req_t *req, FILE *fp, void *rock, json_t **err)
         struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
         json_t *missing_blobs = json_array();
         jmap_parser_push(&parser, "bodyStructure");
-        _emailpart_to_mime(req, &parser, fp, email->body, NULL, missing_blobs);
+        _emailpart_to_mime(req, &parser, fp, email->body, NULL, missing_blobs,
+                           &email->boundary_gen);
         jmap_parser_pop(&parser);
         if (json_array_size(missing_blobs)) {
             *err = json_pack(
@@ -11250,9 +11273,20 @@ static void _email_create(jmap_req_t *req,
     struct email_append_detail detail;
     memset(&detail, 0, sizeof(struct email_append_detail));
 
+    /* Compute deterministic MIME boundary base from a hash of the
+     * input JSON properties.  This ensures identical Email/set creates
+     * produce identical RFC 822 output (same blobId), enabling
+     * duplicate detection on network retry. */
+    char *json = json_dumps(jemail, JSON_COMPACT|JSON_SORT_KEYS);
+    struct message_guid boundary_guid;
+    message_guid_generate(&boundary_guid, json, strlen(json));
+    free(json);
+
     /* Parse Email object into internal representation */
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct email email = { HEADERS_INITIALIZER, NULL, NULL, { 0 }, 0, NULL };
+    char *boundary_base = xstrdup(message_guid_encode(&boundary_guid));
+    struct email email = { HEADERS_INITIALIZER, NULL, NULL, { 0 }, 0, NULL,
+                           { boundary_base, 0 } };
     _parse_email(req, jemail, &parser, &email);
 
     /* Validate mailboxIds */
@@ -11315,6 +11349,7 @@ done:
     strarray_fini(&keywords);
     jmap_parser_fini(&parser);
     _email_fini(&email);
+    free(boundary_base);
 }
 
 static int _email_uidrec_compareuid_cb(const void **pa, const void **pb)


### PR DESCRIPTION
Replace random UUID-based MIME boundaries with deterministic ones derived from a SHA1 hash of the canonicalized input JSON properties. This ensures that creating the same Email twice via Email/set produces byte-identical RFC 822 output with the same blobId.

This is important for idempotent retries: if a client retries an Email/set create after a network failure, and the first attempt actually succeeded, the second attempt will produce the same blob and return alreadyExists with the existing id, rather than creating a duplicate message with different MIME boundaries.

The boundary generation uses a struct boundary_gen containing a hash base string and a counter, threaded through all functions that create multipart MIME structures:
- _emailpart_new_multi (body structure building)
- _emailpart_write_headers (header generation)
- _emailpart_to_mime (MIME output)
- _emailpart_body_to_mime (leaf part output)

The hash base is computed once in _email_create from json_dumps(jemail, JSON_COMPACT|JSON_SORT_KEYS), ensuring canonical key ordering. Each boundary is then SHA1(base + counter) encoded as hex, which is safe against an attacker trying to craft content that matches the boundary (SHA1 second preimage resistance).

The base string is xstrdup'd to avoid the static buffer issue with message_guid_encode (which returns a pointer to a single static buffer that would be overwritten by subsequent calls).

The random boundary fallback is preserved for code paths that don't have a boundary_gen (e.g. if the struct is zero-initialized).