### PR TITLE
Fix Email/query snoozedUntil sort criteria to be mutable

### DIFF
--- a/cunit/search_expr.testc
+++ b/cunit/search_expr.testc
@@ -13,6 +13,7 @@
 #include "imap/imapd.h"
 #include "imap/index.h"
 #include "imap/imapparse.h"
+#include "imap/search_query.h"
 
 static struct namespace ns;
 static const char *userid = "fred";
@@ -1395,6 +1396,50 @@ static int set_up(void)
     push_tz(TZ_MELBOURNE);
 
     return 0;
+}
+
+static void test_sort_mutability(void)
+{
+    struct sortcrit sort[2] = { 0 };
+    search_expr_t *e = search_expr_new(NULL, SEOP_TRUE);
+
+#define TESTCASE(is_mutable, sortkey) \
+    { \
+        sort[0].key = (sortkey); \
+        CU_ASSERT_EQUAL((is_mutable), search_is_mutable(sort, e)); \
+    }
+
+    TESTCASE(0, SORT_SEQUENCE);
+    TESTCASE(0, SORT_ARRIVAL);
+    TESTCASE(0, SORT_CC);
+    TESTCASE(0, SORT_DATE);
+    TESTCASE(0, SORT_DISPLAYFROM);
+    TESTCASE(0, SORT_DISPLAYTO);
+    TESTCASE(0, SORT_FROM);
+    TESTCASE(0, SORT_SIZE);
+    TESTCASE(0, SORT_SUBJECT);
+    TESTCASE(0, SORT_TO);
+    TESTCASE(1, SORT_ANNOTATION);
+    TESTCASE(1, SORT_MODSEQ);
+    TESTCASE(0, SORT_UID);
+    TESTCASE(1, SORT_HASFLAG);
+    TESTCASE(1, SORT_CONVMODSEQ);
+    TESTCASE(1, SORT_CONVEXISTS);
+    TESTCASE(1, SORT_CONVSIZE);
+    TESTCASE(1, SORT_HASCONVFLAG);
+    TESTCASE(0, SORT_FOLDER);
+    TESTCASE(0, SORT_RELEVANCY);
+    TESTCASE(0, SORT_SPAMSCORE);
+    TESTCASE(0, SORT_GUID);
+    TESTCASE(0, SORT_EMAILID);
+    TESTCASE(0, SORT_THREADID);
+    TESTCASE(0, SORT_SAVEDATE);
+    TESTCASE(1, SORT_SNOOZEDUNTIL);
+    TESTCASE(0, SORT_CREATEDMODSEQ);
+
+#undef TESTCASE
+
+    search_expr_free(e);
 }
 
 static int tear_down(void)

--- a/imap/index.c
+++ b/imap/index.c
@@ -5947,6 +5947,9 @@ static int index_sort_compare(MsgData *md1, MsgData *md2,
             ret = numcmp(UINT64_MAX - TIMESPEC_TO_NANOSEC(&md1->internaldate),
                          UINT64_MAX - TIMESPEC_TO_NANOSEC(&md2->internaldate));
             break;
+        case SORT_THREADID:
+            ret = numcmp(md1->cid, md2->cid);
+            break;
         }
     } while (!ret && sortcrit[i++].key != SORT_SEQUENCE);
 
@@ -7445,13 +7448,11 @@ EXPORTED char *sortcrit_as_string(const struct sortcrit *sortcrit)
         else
             buf_printf(&b, "UNKNOWN%u", sortcrit->key);
 
-        switch (sortcrit->key) {
-        case SORT_ANNOTATION:
+        if (sortcrit->key == SORT_ANNOTATION) {
             buf_printf(&b, " \"%s\" \"%s\"",
                        sortcrit->args.annot.entry,
                        *sortcrit->args.annot.userid ?
                             "value.priv" : "value.shared");
-            break;
         }
         sortcrit++;
     } while (sortcrit->key);
@@ -7481,6 +7482,8 @@ EXPORTED void freesortcrit(struct sortcrit *s)
         case SORT_SNOOZEDUNTIL:
             free(s[i].args.mailbox.id);
             break;
+        default:
+            ;
         }
         i++;
     } while (s[i].key != SORT_SEQUENCE);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3301,8 +3301,8 @@ static int _email_read_querystate(jmap_req_t *req, const char *s,
 
 static int emailsearch_is_mutable(struct emailsearch *search)
 {
-    /* can calculate changes for mutable sort, but not mutable search */
-    return search->is_mutable > 1 ? 0 : 1;
+    // see search_is_mutable(): bit 0 indicates mutability of sort
+    return search->is_mutable > 1 ? 1 : 0;
 }
 
 // GUID search
@@ -4980,7 +4980,7 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     q->cstate = req->cstate;
     emailquery_buildresult(q, &emailquery_cache, errp);
     if (*errp) goto done;
-    q->super.can_calculate_changes = emailquery_cache.qr.is_mutable;
+    q->super.can_calculate_changes = !emailquery_cache.qr.is_mutable;
     q->super.query_state = xstrdupnull(querystate);
 
     if (jmap_is_using(req, JMAP_PERFORMANCE_EXTENSION)) {
@@ -5153,7 +5153,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
                       /*ignore_timer*/0, err);
     if (*err) goto done;
 
-    if (!emailsearch_is_mutable(&search)) {
+    if (emailsearch_is_mutable(&search)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "mutable search");
         goto done;
@@ -5370,7 +5370,7 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
                       /*ignore_timer*/0, err);
     if (*err) goto done;
 
-    if (!emailsearch_is_mutable(&search)) {
+    if (emailsearch_is_mutable(&search)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "mutable search");
         goto done;

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -2063,6 +2063,8 @@ static int sub_sort_compare(const void **vp1, const void **vp2)
             }
             ret = strcmpsafe(m1->threadId, m2->threadId);
             break;
+        default:
+            ;
         }
     }
 

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -1191,9 +1191,28 @@ static int is_mutable_sort(struct sortcrit *sortcrit)
             case SORT_CONVEXISTS:
             case SORT_CONVSIZE:
             case SORT_HASCONVFLAG:
+            case SORT_SNOOZEDUNTIL:
                 return 1;
-            default:
-                break;
+            case SORT_SEQUENCE:
+            case SORT_ARRIVAL:
+            case SORT_CC:
+            case SORT_DATE:
+            case SORT_DISPLAYFROM:
+            case SORT_DISPLAYTO:
+            case SORT_FROM:
+            case SORT_SIZE:
+            case SORT_SUBJECT:
+            case SORT_TO:
+            case SORT_UID:
+            case SORT_FOLDER:
+            case SORT_RELEVANCY:
+            case SORT_SPAMSCORE:
+            case SORT_GUID:
+            case SORT_EMAILID:
+            case SORT_THREADID:
+            case SORT_SAVEDATE:
+            case SORT_CREATEDMODSEQ:
+                return 0;
         }
     }
 

--- a/imap/search_sort.h
+++ b/imap/search_sort.h
@@ -5,26 +5,8 @@
 #ifndef __CYRUS_SEARCH_SORT_H__
 #define __CYRUS_SEARCH_SORT_H__
 
-/* Sort criterion */
-struct sortcrit {
-    unsigned key;               /* sort key */
-    int flags;                  /* key modifiers as defined below */
-    union {                     /* argument(s) to the sort key */
-        struct {
-            char *entry;
-            char *userid;
-        } annot;
-        struct {
-            char *name;
-        } flag;
-        struct {
-            char *id;
-        } mailbox;
-    } args;
-};
-
 /* Values for sort keys */
-enum {
+enum sortkey {
     SORT_SEQUENCE = 0,
     SORT_ARRIVAL,       /* RFC 5256 */
     SORT_CC,            /* RFC 5256 */
@@ -52,7 +34,24 @@ enum {
     SORT_SAVEDATE,      /* nonstandard */
     SORT_SNOOZEDUNTIL,  /* nonstandard */
     SORT_CREATEDMODSEQ, /* nonstandard */
-    /* values > 255 are reserved for internal use */
+};
+
+/* Sort criterion */
+struct sortcrit {
+    enum sortkey key;           /* sort key */
+    int flags;                  /* key modifiers as defined below */
+    union {                     /* argument(s) to the sort key */
+        struct {
+            char *entry;
+            char *userid;
+        } annot;
+        struct {
+            char *name;
+        } flag;
+        struct {
+            char *id;
+        } mailbox;
+    } args;
 };
 
 /* Sort key modifier flag bits */


### PR DESCRIPTION
This fixes the mutability of the `snoozedUntil` Email/query criteria. Cyrus internally distinguishes between between mutable and immutable search queries and sorts. As long as the search query is immutable, Cyrus can calculate query changes even if the sort is mutable.

The `/queryChanges` code then includes a couple of optimizations for immutable sorts, but these optimizations can lead to erroneous results when applied to a mutable sort. Because the `snoozedUntil` criteria wasn't explicitly defined to be mutable, it was handled as immutable and thus error-prone.

This patch sanitizes the implementation of sort criteria such that missing to declare a future sort criteria as mutable/immutable becomes unlikely.