### PR TITLE
backup: fix deleted folder offset and add Cassandane test suite

### DIFF
--- a/cassandane/Cassandane/Cyrus/Backup.pm
+++ b/cassandane/Cassandane/Cyrus/Backup.pm
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+package Cassandane::Cyrus::Backup;
+use strict;
+use warnings;
+use experimental 'signatures';
+use DBI;
+use File::Path;
+
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+
+sub new ($class, @args)
+{
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(servername => 'backuptest');
+
+    return $class->SUPER::new({
+        config => $config,
+    }, @args);
+}
+
+sub set_up ($self)
+{
+    $self->SUPER::set_up();
+}
+
+sub tear_down ($self)
+{
+    $self->SUPER::tear_down();
+}
+
+# Helper: set up backup directories and return ($meta, $data, $service, $servername)
+sub _backup_setup ($self)
+{
+    my $servername = $self->{instance}->get_servername;
+    my $service = $self->{instance}->get_service('backupcyrusd');
+
+    my $data = "$self->{instance}->{basedir}/backupdata";
+    my $meta = "$self->{instance}->{basedir}/backupmeta";
+    mkdir($data);
+    mkdir($meta);
+
+    return ($meta, $data, $service, $servername);
+}
+
+# Helper: run BackupUser and return ($version, $size)
+sub _do_backup ($self, $meta, $data, $service, $servername)
+{
+    local $ENV{DEBUGIO} = 1 if $self->{store}->{verbose};
+
+    return Cyrus::Backup::BackupUser(
+        $service->host, $service->port,
+        $meta, $data, $servername, 'cassandane',
+    );
+}
+
+# Helper: open the backup state database (read-only)
+sub _open_backup_db ($self, $meta)
+{
+    return DBI->connect(
+        "dbi:SQLite:dbname=$meta/backupstate.sqlite3",
+        undef, undef,
+        { RaiseError => 1 },
+    );
+}
+
+use Cassandane::Tiny::Loader;
+
+1;

--- a/cassandane/Cassandane/Cyrus/Backup.pm
+++ b/cassandane/Cassandane/Cyrus/Backup.pm
@@ -48,8 +48,6 @@ sub _backup_setup ($self)
 # Helper: run BackupUser and return ($version, $size)
 sub _do_backup ($self, $meta, $data, $service, $servername)
 {
-    local $ENV{DEBUGIO} = 1 if $self->{store}->{verbose};
-
     return Cyrus::Backup::BackupUser(
         $service->host, $service->port,
         $meta, $data, $servername, 'cassandane',

--- a/cassandane/tiny-tests/Backup/basic
+++ b/cassandane/tiny-tests/Backup/basic
@@ -1,0 +1,38 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+use Cyrus::Backup::Restore;
+
+sub test_basic
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    $self->make_message("Email 1") or die;
+    $self->make_message("Email 2") or die;
+
+    my ($meta, $data, $service, $servername) = $self->_backup_setup();
+
+    my @users = Cyrus::Backup::GetUsers($service->host, $service->port, $servername);
+    $self->assert_str_equals('cassandane', join(',', @users));
+
+    my ($version, $size) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_gt(0, $size);
+
+    # add a subscription and another message
+    my $talk = $self->{store}->get_client();
+    $talk->subscribe("INBOX");
+    $self->make_message("Email 3") or die;
+
+    my ($newversion, $newsize) = $self->_do_backup($meta, $data, $service, $servername);
+
+    $self->assert_num_equals($version, $newversion);
+    $self->assert_num_gt($size, $newsize);
+
+    $self->assert(-f "$meta/backupstate.sqlite3");
+
+    my $restore = Cyrus::Backup::Restore->new($meta);
+    my $file = $restore->TarFileName();
+
+    $self->assert(-f "$data/$file");
+}

--- a/cassandane/tiny-tests/Backup/compress_deleted_folder
+++ b/cassandane/tiny-tests/Backup/compress_deleted_folder
@@ -1,0 +1,94 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+
+# Regression test: deleted folders must stay deleted after compression.
+#
+# Before the fix, the imap row's offset was not updated when a folder was
+# deleted, so CompressBackup's StreamCopy matched the creation entry (keeping
+# it with deleted=0) and dropped the deletion entry.  After compression the
+# folder silently reappeared.
+sub test_compress_deleted_folder
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    # Create two folders with messages
+    $talk->create("INBOX.Keep");
+    $talk->create("INBOX.Disposable");
+
+    $self->{store}->set_folder("INBOX.Keep");
+    $self->make_message("Keep msg 1") or die;
+    $self->make_message("Keep msg 2") or die;
+
+    $self->{store}->set_folder("INBOX.Disposable");
+    $self->make_message("Disposable msg 1") or die;
+
+    my ($meta, $data, $service, $servername) = $self->_backup_setup();
+
+    # First backup
+    my ($version, $size) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_gt(0, $size);
+
+    # Delete Disposable and expire
+    $talk->delete("INBOX.Disposable");
+    $self->{instance}->run_command({ cyrus => 1 },
+        'cyr_expire', '-X' => '0', '-D' => '0');
+
+    # Add another message to Keep
+    $self->{store}->set_folder("INBOX.Keep");
+    $self->make_message("Keep msg 3") or die;
+
+    # Second backup - marks Disposable as deleted
+    my ($version2, $size2) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_gt($size, $size2);
+
+    my $dbh = $self->_open_backup_db($meta);
+    my ($disp_deleted) = $dbh->selectrow_array(
+        "SELECT deleted FROM imap WHERE name = 'INBOX.Disposable' AND deleted != 0",
+    );
+    $self->assert($disp_deleted, 'Disposable marked as deleted before compress');
+
+    my ($tar_before) = $dbh->selectrow_array('SELECT filename FROM status');
+    my ($size_before) = $dbh->selectrow_array('SELECT size FROM status');
+    $dbh->disconnect;
+
+    # Ensure the new tar gets a different timestamp-based filename
+    sleep 1;
+
+    # Compress with -p 101 to force compression regardless of stale percentage
+    my ($cver, $csize, $cpct) = Cyrus::Backup::CompressBackup(
+        $meta, $data, 'cassandane', undef, 101,
+    );
+    $self->assert_num_gt(0, $csize);
+
+    # Verify compression actually ran (new tar file)
+    $dbh = $self->_open_backup_db($meta);
+    my ($tar_after) = $dbh->selectrow_array('SELECT filename FROM status');
+    my ($size_after) = $dbh->selectrow_array('SELECT size FROM status');
+
+    $self->assert_str_not_equals($tar_before, $tar_after,
+        'compression created a new tar file');
+    $self->assert_num_lt($size_before, $size_after,
+        'compressed tar is smaller');
+
+    # THE KEY ASSERTION: Disposable must not reappear after compression
+    my ($disp_after) = $dbh->selectrow_array(
+        "SELECT COUNT(*) FROM imap WHERE name = 'INBOX.Disposable'",
+    );
+    $self->assert_num_equals(0, $disp_after,
+        'Disposable folder removed from imap after compress');
+
+    # Keep folder should still be present with all its messages
+    my ($keep_count) = $dbh->selectrow_array(
+        "SELECT COUNT(*) FROM indexed i "
+        . "JOIN imap im ON (i.folderid = im.folderid) "
+        . "WHERE im.name = 'INBOX.Keep'",
+    );
+    $self->assert_num_equals(3, $keep_count,
+        'Keep folder has all 3 messages after compress');
+
+    $dbh->disconnect;
+}

--- a/cassandane/tiny-tests/Backup/folder_delete
+++ b/cassandane/tiny-tests/Backup/folder_delete
@@ -1,0 +1,57 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+
+sub test_folder_delete
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    # Create two folders with messages
+    $talk->create("INBOX.Keep");
+    $talk->create("INBOX.Disposable");
+
+    $self->{store}->set_folder("INBOX.Keep");
+    $self->make_message("Keep msg 1") or die;
+
+    $self->{store}->set_folder("INBOX.Disposable");
+    $self->make_message("Disposable msg 1") or die;
+
+    my ($meta, $data, $service, $servername) = $self->_backup_setup();
+
+    # First backup
+    my ($version, $size) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_gt(0, $size);
+
+    # Verify both folders in backup state
+    my $dbh = $self->_open_backup_db($meta);
+    my $rows = $dbh->selectall_hashref('SELECT * FROM imap', 'name');
+    $self->assert(exists $rows->{'INBOX.Keep'}, 'Keep folder in backup');
+    $self->assert(exists $rows->{'INBOX.Disposable'}, 'Disposable folder in backup');
+    $self->assert_num_equals(0, $rows->{'INBOX.Keep'}{deleted});
+    $self->assert_num_equals(0, $rows->{'INBOX.Disposable'}{deleted});
+    $dbh->disconnect;
+
+    # Delete the Disposable folder and expire it
+    $talk->delete("INBOX.Disposable");
+    $self->{instance}->run_command({ cyrus => 1 },
+        'cyr_expire', '-X' => '0', '-D' => '0');
+
+    # Second backup - should mark Disposable as deleted
+    my ($version2, $size2) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_gt($size, $size2);
+
+    $dbh = $self->_open_backup_db($meta);
+    $rows = $dbh->selectall_hashref('SELECT * FROM imap WHERE deleted = 0', 'name');
+    $self->assert(exists $rows->{'INBOX.Keep'}, 'Keep folder still active');
+    $self->assert(!exists $rows->{'INBOX.Disposable'},
+        'Disposable no longer active after deletion');
+
+    my ($deleted_ts) = $dbh->selectrow_array(
+        "SELECT deleted FROM imap WHERE name = 'INBOX.Disposable' AND deleted != 0",
+    );
+    $self->assert($deleted_ts, 'Disposable has a deletion timestamp');
+    $dbh->disconnect;
+}

--- a/cassandane/tiny-tests/Backup/restore_getfile
+++ b/cassandane/tiny-tests/Backup/restore_getfile
@@ -1,0 +1,79 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+use Cyrus::Backup::Restore;
+
+# Test that Cyrus::Backup::Restore can extract message files from a backup
+# by their SHA1 guid, both before and after compression.
+sub test_restore_getfile
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    $talk->create("INBOX.TestFolder");
+    $self->{store}->set_folder("INBOX.TestFolder");
+    $self->make_message("Test message 1") or die;
+    $self->make_message("Test message 2") or die;
+
+    my ($meta, $data, $service, $servername) = $self->_backup_setup();
+
+    # Back up
+    my ($version, $size) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_gt(0, $size);
+
+    # Get the SHA1 guids of backed-up files from the state DB
+    my $dbh = $self->_open_backup_db($meta);
+    my $guids = $dbh->selectcol_arrayref("SELECT guid FROM files");
+    $dbh->disconnect;
+
+    $self->assert(@$guids >= 2, 'at least 2 message files in backup');
+
+    # Use Restore to extract them
+    my $restore = Cyrus::Backup::Restore->new($meta);
+
+    # Verify TarFileName works
+    my $tarfile = $restore->TarFileName();
+    $self->assert($tarfile, 'TarFileName returns a value');
+    $self->assert(-f "$data/$tarfile", 'tar file exists on disk');
+
+    # Extract files
+    my @extracted = $restore->GetFile(@$guids);
+    $self->assert_num_equals(scalar @$guids, scalar @extracted,
+        'all requested files were extracted');
+
+    # Verify extracted files exist and are non-empty
+    for my $path (@extracted) {
+        $self->assert(-f $path, "extracted file exists: $path");
+        $self->assert(-s $path, "extracted file is non-empty: $path");
+    }
+
+    # Clean up before compression test — must release DB lock first
+    undef $restore;
+    unlink @extracted;
+    rmdir "$meta/files";
+
+    # Now compress and verify restore still works
+    sleep 1;
+    my ($cver, $csize, $cpct) = Cyrus::Backup::CompressBackup(
+        $meta, $data, 'cassandane', undef, 101,
+    );
+    $self->assert_num_gt(0, $csize);
+
+    # Re-open restore against compressed backup
+    my $restore2 = Cyrus::Backup::Restore->new($meta);
+    my $tarfile2 = $restore2->TarFileName();
+    $self->assert_str_not_equals($tarfile, $tarfile2,
+        'compressed backup has a new tar file');
+
+    # Extract again from compressed backup
+    my @extracted2 = $restore2->GetFile(@$guids);
+    $self->assert_num_equals(scalar @$guids, scalar @extracted2,
+        'all files extracted from compressed backup');
+
+    for my $path (@extracted2) {
+        $self->assert(-f $path, "extracted file exists after compress: $path");
+        $self->assert(-s $path, "extracted file is non-empty after compress: $path");
+    }
+}

--- a/cassandane/tiny-tests/Backup/restore_tar_contents
+++ b/cassandane/tiny-tests/Backup/restore_tar_contents
@@ -1,0 +1,78 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+use Cyrus::Backup::Restore;
+
+# Test that Cyrus::Backup::Restore::GetTar can stream through a backup
+# and that the tar contains the expected entry types.
+sub test_restore_tar_contents
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    $talk->create("INBOX.Alpha");
+    $talk->subscribe("INBOX");
+
+    $self->{store}->set_folder("INBOX.Alpha");
+    $self->make_message("Alpha msg") or die;
+
+    my ($meta, $data, $service, $servername) = $self->_backup_setup();
+
+    my ($version, $size) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_gt(0, $size);
+
+    # Stream through the tar and catalogue what's in it
+    my $restore = Cyrus::Backup::Restore->new($meta);
+    my $ts = $restore->GetTar();
+
+    my %entries;
+    $ts->StreamCopy(sub {
+        my $header = shift;
+        my $outpos = shift;
+        my $fh = shift;
+
+        my $name = $header->{name};
+        return 'SKIP' unless $name;
+
+        # Categorise by prefix
+        if ($name =~ m{^files/}) {
+            push @{$entries{files}}, $name;
+        }
+        elsif ($name =~ m{^folders/}) {
+            push @{$entries{folders}}, $name;
+        }
+        elsif ($name =~ m{^imap/}) {
+            push @{$entries{imap}}, $name;
+        }
+        elsif ($name =~ m{^meta/}) {
+            push @{$entries{meta}}, $name;
+        }
+        else {
+            push @{$entries{other}}, $name;
+        }
+
+        return 'SKIP';
+    });
+
+    # We should have at least one file (the message)
+    $self->assert(exists $entries{files}, 'tar contains file entries');
+    $self->assert(@{$entries{files}} >= 1,
+        'at least one message file');
+
+    # We should have folder metadata (cyrus.index, cyrus.header at minimum)
+    $self->assert(exists $entries{folders}, 'tar contains folder entries');
+    my @index = grep { m/cyrus\.index$/ } @{$entries{folders}};
+    my @header = grep { m/cyrus\.header$/ } @{$entries{folders}};
+    $self->assert(@index >= 1, 'at least one cyrus.index');
+    $self->assert(@header >= 1, 'at least one cyrus.header');
+
+    # We should have imap links (folder name -> uniqueid mappings)
+    $self->assert(exists $entries{imap}, 'tar contains imap entries');
+
+    # We should have meta entries (subscriptions at minimum since we subscribed)
+    $self->assert(exists $entries{meta}, 'tar contains meta entries');
+    my @subs = grep { m{^meta/sub} } @{$entries{meta}};
+    $self->assert(@subs >= 1, 'at least one subscription meta entry');
+}

--- a/perl/imap/lib/Cyrus/Backup.pm
+++ b/perl/imap/lib/Cyrus/Backup.pm
@@ -20,6 +20,17 @@ use Cyrus::IndexFile;
 use Digest::SHA;
 use Date::Format;
 
+package Cyrus::NullLogger {
+  sub log {}
+  sub log_debug {}
+  sub log_event {}
+  sub log_debug_event {}
+}
+
+our $LOGGER_CB = sub { 'Cyrus::NullLogger' };
+
+sub logger { $LOGGER_CB->() }
+
 our $BackupVersion = 5;
 # UPDATE THIS WHENEVER A NEW CYRUS INDEX MINOR_VERSION IS CREATED
 our $MAX_INDEXVERSION = 20;
@@ -245,7 +256,7 @@ sub BackupUser {
       next if $item eq $NewName;
       next if $item eq '..';
       next if $item eq '.';
-      warn "REMOVING STALE FILE $DataDir/$item\n";
+      logger->log("REMOVING STALE FILE $DataDir/$item");
       unlink("$DataDir/$item");
     }
     closedir(DH);
@@ -262,7 +273,7 @@ sub BackupUser {
       next if $item eq '.lock';
       next if $item eq '..';
       next if $item eq '.';
-      warn "REMOVING STALE FILE $MetaDir/$item\n";
+      logger->log("REMOVING STALE FILE $MetaDir/$item");
       unlink("$MetaDir/$item");
     }
     closedir(DH);
@@ -719,12 +730,12 @@ sub iocmd {
 
   my $old = alarm(12000);
 
-  warn "IOCMD: $cmd\n" if $ENV{DEBUGIO};
+  logger->log_debug("IOCMD: $cmd");
 
   $IO->print("$cmd\n");
   my $res = $IO->getline();
   chomp($res);
-  warn "    => $res\n" if $ENV{DEBUGIO};
+  logger->log_debug("    => $res");
   unless ($res =~ m/^OK/) {
     die "IO $cmd failed $res\n";
   }
@@ -742,9 +753,9 @@ sub iolist {
     chomp($line);
     push @res, [map { deuri($_) } split / /, $line];
     last if $line =~ m/^DONE/;
-    warn " * $line\n" if $ENV{DEBUGIO};
+    logger->log_debug(" * $line");
   }
-  warn "DONE\n" if $ENV{DEBUGIO};
+  logger->log_debug("DONE");
 
   return @res;
 }
@@ -789,14 +800,14 @@ sub iofiles {
 
     # check sha1 locally
     my $sha1 = $1;
-    warn " * $sha1 $file $size $mtime $inode\n" if $ENV{DEBUGIO};
+    logger->log_debug(" * $sha1 $file $size $mtime $inode");
     unless ($checksha eq $sha1) {
       die "SHA1 mismatch for fetched file $file: $sha1 => $checksha\n";
     }
 
     $callback->($file, $tempfile, $size, $mtime, $inode, $sha1);
   }
-  warn "DONE\n" if $ENV{DEBUGIO};
+  logger->log_debug("DONE");
 
   return [map { deuri($_) } split / /, $res]; # split the DONE line
 }

--- a/perl/imap/lib/Cyrus/Backup/Restore.pm
+++ b/perl/imap/lib/Cyrus/Backup/Restore.pm
@@ -58,7 +58,7 @@ sub GetFile {
     return 'SKIP' unless $wanted{$header->{name}};
     return 'SKIP' if -f $wanted{$header->{name}};
     return 'EDIT' unless $fh;
-    my $check = ME::CyrusBackup::GetSHA1($fh);
+    my $check = Cyrus::Backup::GetSHA1($fh);
     if ("files/$check" eq $header->{name}) {
       my ($login, $pass, $uid, $gid) = getpwnam('cyrus');
       seek($fh, 0, 0);

--- a/perl/imap/lib/Cyrus/Backup/State.pm
+++ b/perl/imap/lib/Cyrus/Backup/State.pm
@@ -226,7 +226,7 @@ sub addheader {
     my $name = $1;
     my $item = $Self->get($filename);
     if ($item and not $item->{deleted}) {
-      $dbh->do("UPDATE imap SET deleted = ? WHERE name = ? AND deleted = 0", {}, $mtime, $name);
+      $dbh->do("UPDATE imap SET deleted = ?, offset = ? WHERE name = ? AND deleted = 0", {}, $mtime, $offset, $name);
     }
     my $folderid = $Self->folderid($target);
     # if no folderid (symlink to nowhere) we just have the deleted record left


### PR DESCRIPTION
While working on converting Fastmail's backups over to the modules in Cyrus, I was building out the test suite and ran into an issue.  Getting Claude to copy over the tests and build them out into Cassandane surfaced another bug.  This fixes both and adds the related tests.