### PR TITLE
http_caldav.c: prevent creating short C-prefixed calendars

### DIFF
--- a/cassandane/tiny-tests/Caldav/calendar_create_badname
+++ b/cassandane/tiny-tests/Caldav/calendar_create_badname
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_create_badname ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    # Starts with 'C' and <= 12 chars long
+    my $res = $CalDAV->SafeRequest('MKCALENDAR', 'C0123456789A');
+    $self->assert_num_equals(403, $res->{http_response}{status});
+
+    # Starts with 'c' and <= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCOL', 'c01234567890A');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+
+    # Starts with 'C' and >= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCALENDAR', 'C01234567890AB');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+}

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -103,6 +103,7 @@ struct partial_caldata_t {
 static int meth_options_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_fb(struct transaction_t *txn, void *params);
+static int meth_mkcalendar(struct transaction_t *txn, void *params);
 
 static void my_caldav_init(struct buf *serverinfo);
 static int my_caldav_auth(const char *userid);
@@ -612,8 +613,8 @@ struct namespace_t namespace_calendar = {
         { &meth_get_head_cal,   &caldav_params },       /* GET          */
         { &meth_get_head_cal,   &caldav_params },       /* HEAD         */
         { &meth_lock,           &caldav_params },       /* LOCK         */
-        { &meth_mkcol,          &caldav_params },       /* MKCALENDAR   */
-        { &meth_mkcol,          &caldav_params },       /* MKCOL        */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCALENDAR   */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCOL        */
         { &meth_copy_move,      &caldav_params },       /* MOVE         */
         { &meth_options_cal,    &caldav_params },       /* OPTIONS      */
         { &meth_patch,          &caldav_params },       /* PATCH        */
@@ -2677,6 +2678,48 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
 
     /* Unknown action */
     return HTTP_NO_CONTENT;
+}
+
+static int meth_mkcalendar(struct transaction_t *txn, void *params)
+{
+    int r = 0;
+
+    /* Parse the path (use our own entry to suppress lookup) */
+    txn->req_tgt.mbentry = mboxlist_entry_create();
+    r = caldav_parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+
+    /* Make sure method is allowed (only allowed on child of home-set) */
+    if (!txn->req_tgt.collection || txn->req_tgt.resource ||
+        (txn->req_tgt.collection[0] == 'C' &&
+         txn->req_tgt.collen <= CONV_JMAPID_SIZE + 1)) {
+        txn->error.precond = CALDAV_LOCATION_OK;
+        return HTTP_FORBIDDEN;
+    }
+    else if (r) {
+        switch (r) {
+        case IMAP_MAILBOX_EXISTS:
+            txn->error.precond = DAV_RES_EXISTS;
+            break;
+                
+        case IMAP_PERMISSION_DENIED:
+            txn->error.precond = DAV_NEED_PRIVS;
+            txn->error.rights = DACL_BIND;
+            buf_reset(&txn->buf);
+            buf_printf(&txn->buf, "%s/%s/%s",
+                       txn->req_tgt.namespace->prefix, USER_COLLECTION_PREFIX,
+                       txn->req_tgt.userid);
+            txn->error.resource = buf_cstring(&txn->buf);
+            break;
+                
+        default:
+            txn->error.precond = CALDAV_LOCATION_OK;
+            break;
+        }
+
+        return HTTP_FORBIDDEN;
+    }
+
+    return meth_mkcol(txn, params);
 }
 
 /* Perform post-create MKCOL/MKCALENDAR processing */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5702,9 +5702,11 @@ int meth_mkcol(struct transaction_t *txn, void *params)
     /* Response should not be cached */
     txn->flags.cc |= CC_NOCACHE;
 
-    /* Parse the path (use our own entry to suppress lookup) */
-    txn->req_tgt.mbentry = mboxlist_entry_create();
-    r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    if (!txn->req_tgt.mbentry) {
+        /* Parse the path (use our own entry to suppress lookup) */
+        txn->req_tgt.mbentry = mboxlist_entry_create();
+        r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    }
 
     /* Make sure method is allowed (only allowed on child of home-set) */
     if (!txn->req_tgt.collection || txn->req_tgt.resource) {


### PR DESCRIPTION
Require any calendar href that begins with 'C' to be at least 13 chars long so they can be distinguished from new-style compact calendar Ids, which begin with 'C' and are at most 12 chars long.

This is a temp fix until FM middlware is transitioned to new-style Ids only.