### PR TITLE
jmap_mail.c: store highest modseq in cyrus.indexed.db for Email/query

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
@@ -1,0 +1,133 @@
+#!perl
+use Cassandane::Tiny;
+
+# If an email query happens before squatter runs, we get the new query state
+# but our results don't have the correct total or list of messages, which
+# messes up further positional Email/query responses
+
+sub test_email_querychanges_snoozed_mail
+    :needs_component_sieve
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    my $inbox = $user->mailboxes->inbox;
+
+    xlog $self, "Install script to flag messages in inbox";
+    $self->{instance}->install_sieve_script(<<~EOF
+        require ["imap4flags"];
+        addflag "\\Seen";
+        EOF
+    );
+
+    xlog $self, "Make a bunch of messages that match our query";
+    for (1..10) {
+        my $msg = $self->{gen}->generate(subject => "Garnet");
+        $self->{instance}->deliver($msg);
+    }
+
+    xlog $self, "Run squatter to index them";  
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    xlog $self, "Wait a second so new delivery is later";
+    sleep 1;
+
+    xlog $self, "Deliver a matching message but don't run squatter";
+    my $msg1 = $self->{gen}->generate(subject => "Garnet");
+    $self->{instance}->deliver($msg1);
+
+    # Uncomment this and things behave
+#    xlog $self, "Run squatter to index them";  
+#    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my %common_query = (
+        sort => [
+            {
+                isAscending => JSON::false,
+                mailboxId   => $inbox->id,
+                property    => 'snoozedUntil',
+            }, {
+                isAscending => JSON::false,
+                property    => 'receivedAt'
+            },
+        ],
+        filter => {
+            conditions => [
+                { inMailbox => $inbox->id },
+                { text      => 'Garnet'   },
+            ],
+            operator => 'AND',
+        },
+    );
+
+    xlog $self, "Get our query state";
+    my $res = $jmap->request([[
+        "Email/query" => {
+            %common_query,
+            limit => 5,
+            calculateTotal => JSON::true,
+        },
+    ]]);
+
+    my $qres = $res->sentence_named("Email/query")->arguments;
+
+    $self->assert_cmp_deeply(
+        superhashof({
+            canCalculateChanges => JSON::true,
+            ids                 => [ (jstr()) x 5 ],
+            position            => 0,
+#           total               => 10, # Or 11 if squatter is run first
+            queryState          => jstr,
+        }),
+        $qres,
+    );
+
+    my $qstate = $qres->{queryState};
+    $self->assert_not_null($qstate);
+
+    xlog $self, "Query state: $qstate";
+
+    my $upto = $qres->{ids}->[-1];
+    $self->assert_not_null($upto);
+
+    xlog $self, "Our query state is $qstate";
+
+    xlog $self, "Now squatter runs...";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    xlog $self, "Wait a second so new delivery is later";
+    sleep 1;
+
+    # Deliver once more
+    xlog $self, "Deliver a new matching message";
+    my $msg2 = $self->{gen}->generate(subject => "Garnet");
+    $self->{instance}->deliver($msg2);
+
+    xlog $self, "Run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    xlog $self, "Email/queryChanges output for informational use...";
+    $res = $jmap->request([[
+        "Email/queryChanges" => {
+            %common_query,
+            sinceQueryState => $qstate,
+            upToId => $upto,
+        },
+    ]]);
+
+    my $qcres = $res->sentence_named("Email/queryChanges")->arguments;
+    my $newqstate = $qcres->{newQueryState};
+
+    xlog $self, "New query state: $newqstate";
+
+    xlog $self, "Check email/query with position 5. Should start at $upto since one new message was delivered at position 0 from the given query state";
+    $res = $jmap->request([[
+        "Email/query" => {
+          %common_query,
+          position => 5,
+        },
+    ]]);
+
+    $qres = $res->sentence_named("Email/query")->arguments;
+    $self->assert_str_equals($upto, $qres->{ids}[0]);
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
@@ -5,7 +5,7 @@ use Cassandane::Tiny;
 # but our results don't have the correct total or list of messages, which
 # messes up further positional Email/query responses
 
-sub test_email_querychanges_snoozed_mail
+sub test_email_querychanges_squatter_ordering
     :needs_component_sieve
     ($self)
 {

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
@@ -13,33 +13,6 @@ sub test_email_querychanges_squatter_ordering
     my $jmap = $user->jmap;
     my $inbox = $user->mailboxes->inbox;
 
-    xlog $self, "Install script to flag messages in inbox";
-    $self->{instance}->install_sieve_script(<<~EOF
-        require ["imap4flags"];
-        addflag "\\Seen";
-        EOF
-    );
-
-    xlog $self, "Make a bunch of messages that match our query";
-    for (1..10) {
-        my $msg = $self->{gen}->generate(subject => "Garnet");
-        $self->{instance}->deliver($msg);
-    }
-
-    xlog $self, "Run squatter to index them";  
-    $self->{instance}->run_command({cyrus => 1}, 'squatter');
-
-    xlog $self, "Wait a second so new delivery is later";
-    sleep 1;
-
-    xlog $self, "Deliver a matching message but don't run squatter";
-    my $msg1 = $self->{gen}->generate(subject => "Garnet");
-    $self->{instance}->deliver($msg1);
-
-    # Uncomment this and things behave
-#    xlog $self, "Run squatter to index them";  
-#    $self->{instance}->run_command({cyrus => 1}, 'squatter');
-
     my %common_query = (
         sort => [
             {
@@ -60,8 +33,50 @@ sub test_email_querychanges_squatter_ordering
         },
     );
 
-    xlog $self, "Get our query state";
+    xlog $self, "Install script to flag messages in inbox";
+    $self->{instance}->install_sieve_script(<<~EOF
+        require ["imap4flags"];
+        addflag "\\Seen";
+        EOF
+    );
+
+    xlog $self, "Make a bunch of messages that match our query";
+    for (1..10) {
+        my $msg = $self->{gen}->generate(subject => "Garnet");
+        $self->{instance}->deliver($msg);
+    }
+
+    xlog $self, "Run squatter to index them";  
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    xlog $self, "Get email ids";
     my $res = $jmap->request([[
+        "Email/query" => {
+            %common_query,
+            calculateTotal => JSON::true,
+        },
+    ]]);
+
+    my $qres = $res->sentence_named("Email/query")->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            ids                 => [ (jstr()) x 10 ],
+            position            => 0,
+            total               => 10,
+        }),
+        $qres,
+    );
+    my $base_email_ids = $qres->{ids};
+
+    xlog $self, "Wait a second so new delivery is later";
+    sleep 1;
+
+    xlog $self, "Deliver a matching message but don't run squatter";
+    my $msg1 = $self->{gen}->generate(subject => "Garnet");
+    $self->{instance}->deliver($msg1);
+
+    xlog $self, "Get our query state";
+    $res = $jmap->request([[
         "Email/query" => {
             %common_query,
             limit => 5,
@@ -69,18 +84,20 @@ sub test_email_querychanges_squatter_ordering
         },
     ]]);
 
-    my $qres = $res->sentence_named("Email/query")->arguments;
-
+    $qres = $res->sentence_named("Email/query")->arguments;
     $self->assert_cmp_deeply(
         superhashof({
             canCalculateChanges => JSON::true,
             ids                 => [ (jstr()) x 5 ],
             position            => 0,
-#           total               => 10, # Or 11 if squatter is run first
+            total               => 10,
             queryState          => jstr,
         }),
         $qres,
     );
+
+    xlog $self, "Assert newly delivered but unindexed message is not in result";
+    $self->assert_cmp_deeply([ @{$base_email_ids}[0..4] ], $qres->{ids});
 
     my $qstate = $qres->{queryState};
     $self->assert_not_null($qstate);
@@ -98,7 +115,6 @@ sub test_email_querychanges_squatter_ordering
     xlog $self, "Wait a second so new delivery is later";
     sleep 1;
 
-    # Deliver once more
     xlog $self, "Deliver a new matching message";
     my $msg2 = $self->{gen}->generate(subject => "Garnet");
     $self->{instance}->deliver($msg2);
@@ -106,7 +122,7 @@ sub test_email_querychanges_squatter_ordering
     xlog $self, "Run squatter";
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
 
-    xlog $self, "Email/queryChanges output for informational use...";
+    xlog $self, "Check Email/queryChanges";
     $res = $jmap->request([[
         "Email/queryChanges" => {
             %common_query,
@@ -118,9 +134,15 @@ sub test_email_querychanges_squatter_ordering
     my $qcres = $res->sentence_named("Email/queryChanges")->arguments;
     my $newqstate = $qcres->{newQueryState};
 
-    xlog $self, "New query state: $newqstate";
+    $self->assert_cmp_deeply(
+        superhashof({
+            added               => [ { id => jstr, index => 0 }, { id => jstr, index => 1 } ],
+            removed             => [ jstr, jstr ],
+        }),
+        $qcres,
+    );
 
-    xlog $self, "Check email/query with position 5. Should start at $upto since one new message was delivered at position 0 from the given query state";
+    xlog $self, "Check email/query with position 5. Should start one before $upto since two new messages were delivered from the given query state";
     $res = $jmap->request([[
         "Email/query" => {
           %common_query,
@@ -129,5 +151,6 @@ sub test_email_querychanges_squatter_ordering
     ]]);
 
     $qres = $res->sentence_named("Email/query")->arguments;
-    $self->assert_str_equals($upto, $qres->{ids}[0]);
+    $self->assert_str_equals($upto, $qres->{ids}[1]);
+    $self->assert_cmp_deeply([ @{$base_email_ids}[3..$#{$base_email_ids}] ], $qres->{ids});
 }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5155,6 +5155,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     uint32_t since_uid;
     uint32_t num_changes = 0;
     modseq_t addrbook_modseq = 0;
+    modseq_t expunged_modseq = 0;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
@@ -5249,6 +5250,9 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
 
         int is_expunged = (md->system_flags & FLAG_DELETED) ||
                 (md->internal_flags & FLAG_INTERNAL_EXPUNGED);
+
+        if (is_expunged && md->modseq > expunged_modseq)
+            expunged_modseq = md->modseq;
 
         size_t touched_id = (size_t)hash_lookup(email_id, &touched_ids);
         size_t new_touched_id = touched_id;
@@ -5350,9 +5354,15 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     free_hash_table(&touched_ids, NULL);
     free_hashu64_table(&touched_cids, NULL);
 
-    modseq_t modseq = emailsearch_has_fuzzymatch(&search) ?
-        search_get_indexed_modseq(req->accountid) : 0;
+    modseq_t modseq = 0;
+    if (emailsearch_has_fuzzymatch(&search)) {
+        modseq = search_get_indexed_modseq(req->accountid);
+        if (modseq && expunged_modseq > modseq) {
+            modseq = expunged_modseq;
+        }
+    }
     if (!modseq) modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
+
     query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
 
 done:
@@ -5375,6 +5385,7 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     uint32_t since_uid;
     uint32_t num_changes = 0;
     modseq_t addrbook_modseq = 0;
+    modseq_t expunged_modseq = 0;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
@@ -5449,6 +5460,9 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
         int is_expunged = (md->system_flags & FLAG_DELETED) ||
                 (md->internal_flags & FLAG_INTERNAL_EXPUNGED);
 
+        if (is_expunged && md->modseq > expunged_modseq)
+            expunged_modseq = md->modseq;
+
         size_t touched_id = (size_t)hash_lookup(email_id, &touched_ids);
         size_t new_touched_id = touched_id;
 
@@ -5517,9 +5531,15 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
 
     free_hash_table(&touched_ids, NULL);
 
-    modseq_t modseq = emailsearch_has_fuzzymatch(&search) ?
-        search_get_indexed_modseq(req->accountid) : 0;
+    modseq_t modseq = 0;
+    if (emailsearch_has_fuzzymatch(&search)) {
+        modseq = search_get_indexed_modseq(req->accountid);
+        if (modseq && expunged_modseq > modseq) {
+            modseq = expunged_modseq;
+        }
+    }
     if (!modseq) modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
+
     query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
 
 done:

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3218,8 +3218,10 @@ struct emailquery_result {
     int is_mutable;
     int is_guidsearch;
     int is_imapfoldersearch;
+    int has_fuzzymatch;
     int never_matches;
     size_t total_ceiling;
+    char *querystate;
 
     void(*ensure)(struct emailquery *q, struct emailquery_cache *qc, size_t n);
     const char *(*partid)(uint64_t partnum, void *rock);
@@ -3303,6 +3305,19 @@ static int emailsearch_is_mutable(struct emailsearch *search)
 {
     /* can calculate changes for mutable sort, but not mutable search */
     return search->is_mutable > 1 ? 0 : 1;
+}
+
+static int emailsearch_has_fuzzymatch_cb(search_expr_t *e,
+                                         void *rock __attribute__((unused)))
+{
+    return e->op == SEOP_FUZZYMATCH;
+}
+
+static int emailsearch_has_fuzzymatch(struct emailsearch *search)
+{
+    return search->expr_orig &&
+           search_expr_apply(search->expr_orig,
+                             emailsearch_has_fuzzymatch_cb, NULL);
 }
 
 // GUID search
@@ -4566,6 +4581,7 @@ static int emailquery_search(jmap_req_t *req,
     qr->is_mutable = emailsearch_is_mutable(&search);
     qr->is_imapfoldersearch = search.is_imapfolder;
     qr->is_guidsearch = is_guidsearch;
+    qr->has_fuzzymatch = emailsearch_has_fuzzymatch(&search);
     qr->never_matches = search.never_matches;
 
     /* set search cost info */
@@ -4610,6 +4626,7 @@ static void emailquery_cache_reset(struct emailquery_cache *qc)
     free(qc->uncollapsed_matches);
     free(qc->collapsed_matches); // members are shallow copy of uncollapsed
     free(qc->fingerprint);
+    free(qc->qr.querystate);
     if (qc->seen_threads) hashset_free(&qc->seen_threads);
     if (qc->qr.free) {
         qc->qr.free(qc->qr.rock);
@@ -4868,9 +4885,9 @@ static void emailquery_buildresult(struct emailquery *q,
 static void emailquery_fingerprint(struct buf *fingerprint,
                                    const char *accountid,
                                    const char *userid,
-                                   const char *querystate,
+                                   modseq_t modseq,
+                                   modseq_t addrbook_modseq,
                                    struct emailquery *q)
-
 {
     buf_reset(fingerprint);
 
@@ -4882,9 +4899,8 @@ static void emailquery_fingerprint(struct buf *fingerprint,
     buf_appendcstr(fingerprint, accountid);
     buf_putc(fingerprint, '>');
 
-    buf_putc(fingerprint, '<');
-    buf_appendcstr(fingerprint, querystate);
-    buf_putc(fingerprint, '>');
+    buf_printf(fingerprint, "<" MODSEQ_FMT ">", modseq);
+    buf_printf(fingerprint, "<" MODSEQ_FMT ">", addrbook_modseq);
 
     if (JNOTNULL(q->super.filter)) {
         buf_putc(fingerprint, '<');
@@ -4947,13 +4963,14 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     json_t *res = NULL;
     int r = 0;
 
-    modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
     modseq_t addrbook_modseq = contactgroups->size ?
         jmap_modseq(req, MBTYPE_ADDRESSBOOK, 0) : 0;
-    char *querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
+
+    modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
 
     struct buf fingerprint = BUF_INITIALIZER;
-    emailquery_fingerprint(&fingerprint, req->userid, req->accountid, querystate, q);
+    emailquery_fingerprint(&fingerprint, req->userid, req->accountid,
+                           modseq, addrbook_modseq, q);
 
     /* Try to reuse cached query result */
     int is_cached;
@@ -4963,6 +4980,16 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
         is_cached = 0;
         r = emailquery_search(req, q, &emailquery_cache.qr, contactgroups, errp);
         if (r || *errp) goto done;
+
+        /* Use the highest indexed modseq for searches backed by Xapian */
+        modseq_t state_modseq = modseq;
+        if (emailquery_cache.qr.has_fuzzymatch) {
+            modseq_t indexed_modseq = search_get_indexed_modseq(req->accountid);
+            if (indexed_modseq) state_modseq = indexed_modseq;
+        }
+        emailquery_cache.qr.querystate =
+            _email_make_querystate(req, state_modseq, 0, addrbook_modseq);
+
         emailquery_cache.fingerprint = buf_release(&fingerprint);
         emailquery_cache.last_accessed = time(NULL);
     }
@@ -4981,7 +5008,7 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     emailquery_buildresult(q, &emailquery_cache, errp);
     if (*errp) goto done;
     q->super.can_calculate_changes = emailquery_cache.qr.is_mutable;
-    q->super.query_state = xstrdupnull(querystate);
+    q->super.query_state = xstrdupnull(emailquery_cache.qr.querystate);
 
     if (jmap_is_using(req, JMAP_PERFORMANCE_EXTENSION)) {
         json_object_set_new(req->perf_details, "isImapFolderSearch",
@@ -5039,7 +5066,6 @@ done:
         else *errp = jmap_server_error(r);
     }
     buf_free(&fingerprint);
-    free(querystate);
     return res;
 }
 
@@ -5324,7 +5350,9 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     free_hash_table(&touched_ids, NULL);
     free_hashu64_table(&touched_cids, NULL);
 
-    modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
+    modseq_t modseq = emailsearch_has_fuzzymatch(&search) ?
+        search_get_indexed_modseq(req->accountid) : 0;
+    if (!modseq) modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
     query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
 
 done:
@@ -5489,7 +5517,9 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
 
     free_hash_table(&touched_ids, NULL);
 
-    modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
+    modseq_t modseq = emailsearch_has_fuzzymatch(&search) ?
+        search_get_indexed_modseq(req->accountid) : 0;
+    if (!modseq) modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
     query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
 
 done:

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -190,6 +190,7 @@ int search_update_mailbox(search_text_receiver_t *rx,
                           struct mailbox **mailboxptr,
                           int min_indexlevel, int flags);
 int search_end_update(search_text_receiver_t *rx);
+modseq_t search_get_indexed_modseq(const char *userid);
 
 /* Create a search text receiver for snippets. For each non-empty
  * snippet generated from a message search part, callback proc is called.

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -586,6 +586,29 @@ static int cachetier_cb(void *vrock, const char *key, size_t keylen,
     struct indexeddb *idb = rock->idb;
 
     if (idb->version >= 2) {
+        /* Handle highest indexed modseq with max semantics */
+        if (!strcmp(key, "*MAXMODSEQ*")) {
+            bit64 srcmodseq = 0;
+            if (datalen > 0 && parsenum(data, NULL, datalen, &srcmodseq))
+                return 0;
+            const char *olddata = NULL;
+            size_t olddatalen = 0;
+            bit64 oldmodseq = 0;
+            int r = cyrusdb_fetch(idb->db, key, keylen, &olddata, &olddatalen, &idb->txn);
+            if (!r && olddatalen > 0)
+                parsenum(olddata, NULL, olddatalen, &oldmodseq);
+            if (srcmodseq <= oldmodseq) return 0;
+            struct buf val = BUF_INITIALIZER;
+            buf_printf(&val, MODSEQ_FMT, srcmodseq);
+            r = cyrusdb_store(idb->db, key, keylen,
+                              buf_base(&val), buf_len(&val), &idb->txn);
+            buf_free(&val);
+            if (r) {
+                xsyslog(LOG_ERR, "could not save key", "key=<%.*s> dberror=<%s>",
+                        (int)keylen, key, cyrusdb_strerror(r));
+            }
+            return r;
+        }
         /* Ignore all but mailbox entries */
         if (keylen < 3 || strncmp(key, "*M*", 3)) return 0;
     }
@@ -1011,6 +1034,7 @@ static int write_indexed(const char *dir,
                          uint32_t uidvalidity,
                          const char *uniqueid,
                          seqset_t *seq,
+                         modseq_t modseq,
                          int verbose)
 {
     struct buf path = BUF_INITIALIZER;
@@ -1042,6 +1066,27 @@ static int write_indexed(const char *dir,
     }
 
     r = store_indexed(idb, key.s, key.len, seq);
+    if (r) goto out;
+
+    /* Update the highest indexed modseq for this user */
+    if (modseq && idb->version >= 2) {
+        const char *data = NULL;
+        size_t datalen = 0;
+        modseq_t oldmodseq = 0;
+        int r2 = cyrusdb_fetch(idb->db, "*MAXMODSEQ*", 11, &data, &datalen, &idb->txn);
+        if (!r2 && datalen > 0) {
+            bit64 num;
+            if (!parsenum(data, NULL, datalen, &num))
+                oldmodseq = (modseq_t)num;
+        }
+        if (modseq > oldmodseq) {
+            struct buf val = BUF_INITIALIZER;
+            buf_printf(&val, MODSEQ_FMT, modseq);
+            r = cyrusdb_store(idb->db, "*MAXMODSEQ*", 11,
+                              buf_base(&val), buf_len(&val), &idb->txn);
+            buf_free(&val);
+        }
+    }
 
 out:
     if (idb) {
@@ -2130,6 +2175,7 @@ struct xapian_receiver
     struct message_guid guid;
     uint32_t uid;
     time_t internaldate;
+    modseq_t modseq;
     enum search_part part;
     const struct message_guid *part_guid;
     const char *partid;
@@ -2149,6 +2195,7 @@ struct xapian_update_receiver
     unsigned int commits;
     seqset_t *oldindexed;
     seqset_t *indexed;
+    modseq_t highest_modseq;
     strarray_t *activedirs;
     strarray_t *activetiers;
     hash_table cached_seqs;
@@ -2296,7 +2343,8 @@ static int flush(search_text_receiver_t *rx)
     if (tr->indexed) {
         r = write_indexed(strarray_nth(tr->activedirs, 0),
                 mailbox_name(tr->super.mailbox), tr->super.mailbox->i.uidvalidity,
-                mailbox_uniqueid(tr->super.mailbox), tr->indexed, tr->super.verbose);
+                mailbox_uniqueid(tr->super.mailbox), tr->indexed,
+                tr->highest_modseq, tr->super.verbose);
         if (r) goto out;
     }
 
@@ -2368,6 +2416,7 @@ static int begin_message(search_text_receiver_t *rx, message_t *msg)
     int r = message_get_uid(msg, &tr->super.uid);
     if (!r) r = message_get_guid(msg, &guid);
     if (!r) r = message_get_internaldate(msg, &tr->super.internaldate);
+    if (!r) r = message_get_modseq(msg, &tr->super.modseq);
     if (r) return r;
 
     message_guid_copy(&tr->super.guid, guid);
@@ -2594,11 +2643,14 @@ static int end_message_update(search_text_receiver_t *rx, uint8_t indexlevel)
         seqset_add(tr->indexed, seqset_firstnonmember(tr->oldindexed), 1);
     }
     seqset_add(tr->indexed, tr->super.uid, 1);
+    if (tr->super.modseq > tr->highest_modseq)
+        tr->highest_modseq = tr->super.modseq;
 
 out:
     tr->super.uid = 0;
     message_guid_set_null(&tr->super.guid);
     tr->super.internaldate = 0;
+    tr->super.modseq = 0;
     return r;
 }
 
@@ -4273,6 +4325,60 @@ out:
     mailbox_close(&mailbox);
     free(inboxname);
     return r;
+}
+
+EXPORTED modseq_t search_get_indexed_modseq(const char *userid)
+{
+    char *inboxname = mboxname_user_mbox(userid, NULL);
+    struct mailbox *inbox = NULL;
+    struct mappedfile *activefile = NULL;
+    strarray_t *active = NULL;
+    strarray_t *activedirs = NULL;
+    strarray_t *activetiers = NULL;
+    struct indexeddb *idb = NULL;
+    modseq_t modseq = 0;
+    int r = 0;
+
+    r = mailbox_open_irl(inboxname, &inbox);
+    if (r) goto out;
+
+    r = activefile_open(mailbox_name(inbox), mailbox_partition(inbox),
+                        &activefile, AF_LOCK_READ, &active);
+    if (r) goto out;
+
+    activedirs = activefile_resolve(mailbox_name(inbox), mailbox_partition(inbox),
+                                    active, /*dostat*/1, &activetiers);
+    if (!activedirs || !activedirs->count) goto out;
+
+    struct buf path = BUF_INITIALIZER;
+    buf_printf(&path, "%s%s", strarray_nth(activedirs, 0), INDEXEDDB_FNAME);
+    r = indexeddb_open(userid, buf_cstring(&path), 0, &idb);
+    buf_free(&path);
+    if (r) goto out;
+
+    if (idb->version >= 2) {
+        const char *data = NULL;
+        size_t datalen = 0;
+        r = cyrusdb_fetch(idb->db, "*MAXMODSEQ*", 11, &data, &datalen, NULL);
+        if (!r && datalen > 0) {
+            bit64 num;
+            if (!parsenum(data, NULL, datalen, &num))
+                modseq = (modseq_t)num;
+        }
+    }
+
+out:
+    indexeddb_close(&idb, 0);
+    strarray_free(activedirs);
+    strarray_free(activetiers);
+    strarray_free(active);
+    if (activefile) {
+        mappedfile_unlock(activefile);
+        mappedfile_close(&activefile);
+    }
+    mailbox_close(&inbox);
+    free(inboxname);
+    return modseq;
 }
 
 static int can_match(enum search_op matchop, enum search_part partnum)


### PR DESCRIPTION
This changes the query state of Email/query if the query requires
the result be computed from Xapian: up until now, the query state
was the highest modseq of the user email mailboxes. Now, the query
state is the highest modseq of the message that was indexed in Xapian.
This change only applies to queries that require Xapian. Other
queries still use the highest modseq as the query state.

Doing so is required because otherwise Email/query can return a query
state that includes the modseq of a newly arrived message, but
before that message got indexed. As a result, a queryChanges request
using that query state does not report that message, leading to
inconsistencies in the client cache.

To support this, squatter now tracks the highest modseq it processes per
user in cyrus.indexed.db under the "*MAXMODSEQ*" key.  The cache_indexed()
path that merges lower-tier indexed.db files into the top tier propagates
this value using max semantics.  A new exported function
search_get_indexed_modseq() reads this value back by opening the inbox
activefile and looking up the key in the top-tier indexed.db.

The emailquery_fingerprint function now takes modseq and addrbook_modseq
directly instead of the querystate string, separating cache invalidation
from query state representation.  The query state is computed and stored
in emailquery_result on a cache miss, and reused from the cached result
on a cache hit.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>