### PR TITLE
install mkimap and rehash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,5 @@ sieve/tests/
 stamp-h1
 timsieved/timsieved
 tools/mkimap
+tools/rehash
 ylwrap

--- a/.gitignore
+++ b/.gitignore
@@ -219,4 +219,5 @@ sieve/test_mailbox
 sieve/tests/
 stamp-h1
 timsieved/timsieved
+tools/mkimap
 ylwrap

--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,7 @@ BUILT_SOURCES = \
 
 CLEANFILES = \
     tools/mkimap \
+    tools/rehash \
     lib/chartable.c \
     lib/imapopts.c \
     lib/imapopts.h
@@ -141,7 +142,7 @@ MAINTAINERCLEANFILES = \
 
 SUBDIRS = . perl/annotator perl/imap
 DIST_SUBDIRS = . perl/annotator perl/imap perl/sieve/managesieve
-sbin_SCRIPTS = tools/mkimap
+sbin_SCRIPTS = tools/mkimap tools/rehash
 dist_sbin_SCRIPTS =
 dist_sysconf_DATA =
 lib_LTLIBRARIES = lib/libcyrus_min.la lib/libcyrus.la
@@ -490,7 +491,8 @@ EXTRA_DIST = \
     sieve/tests/actionExtensions/serverm/ueamail-notify2 \
     sieve/tests/actionExtensions/serverm/ueamail-vacation \
     timsieved/TODO \
-    tools/mkimap.in
+    tools/mkimap.in \
+    tools/rehash.in
 
 TEXINFO_TEX = com_err/et/texinfo.tex
 dist_noinst_SCRIPTS = \
@@ -510,7 +512,6 @@ dist_noinst_SCRIPTS = \
     tools/masssievec \
     tools/mknewsgroups \
     tools/perl2rst \
-    tools/rehash \
     tools/translatesieve
 noinst_MAN = \
     com_err/et/com_err.3 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,7 @@ BUILT_SOURCES = \
     lib/imapopts.h
 
 CLEANFILES = \
+    tools/mkimap \
     lib/chartable.c \
     lib/imapopts.c \
     lib/imapopts.h
@@ -140,6 +141,7 @@ MAINTAINERCLEANFILES = \
 
 SUBDIRS = . perl/annotator perl/imap
 DIST_SUBDIRS = . perl/annotator perl/imap perl/sieve/managesieve
+sbin_SCRIPTS = tools/mkimap
 dist_sbin_SCRIPTS =
 dist_sysconf_DATA =
 lib_LTLIBRARIES = lib/libcyrus_min.la lib/libcyrus.la
@@ -487,7 +489,8 @@ EXTRA_DIST = \
     sieve/tests/actionExtensions/serverm/ueamail-flag5 \
     sieve/tests/actionExtensions/serverm/ueamail-notify2 \
     sieve/tests/actionExtensions/serverm/ueamail-vacation \
-    timsieved/TODO
+    timsieved/TODO \
+    tools/mkimap.in
 
 TEXINFO_TEX = com_err/et/texinfo.tex
 dist_noinst_SCRIPTS = \
@@ -505,7 +508,6 @@ dist_noinst_SCRIPTS = \
     tools/git-version.sh \
     tools/gperf-build-prop-set.pl \
     tools/masssievec \
-    tools/mkimap \
     tools/mknewsgroups \
     tools/perl2rst \
     tools/rehash \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2212,7 +2212,7 @@ cyrus-makemaker-uninstall-workaround:
 
 install-binsymlinks:
 ## Let's symlink everything else
-	for prog in $(sbin_PROGRAMS); do $(LN_S) -f $(sbindir)/`basename $$prog` $(DESTDIR)$(bindir)/; done
+	for prog in $(sbin_PROGRAMS) $(sbin_SCRIPTS) $(dist_sbin_SCRIPTS); do $(LN_S) -f $(sbindir)/`basename $$prog` $(DESTDIR)$(bindir)/; done
 	for prog in $(libexec_PROGRAMS); do $(LN_S) -f $(libexecdir)/`basename $$prog` $(DESTDIR)$(bindir)/; done
 
 SUFFIXES = .fig.png

--- a/changes/next/cyr-2789-install-mkimap
+++ b/changes/next/cyr-2789-install-mkimap
@@ -1,0 +1,25 @@
+Description:
+
+The :cyrusman:`mkimap(8)` and :cyrusman:`rehash(8)` tools are now
+installed to $prefix/sbin by `make install`.
+
+
+Documentation:
+
+(man pages)
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+If your deployment system previously installed these tools manually,
+it no longer needs to.
+
+
+GitHub issue:
+
+If theres a github issue number for this, put it here.

--- a/configure.ac
+++ b/configure.ac
@@ -1869,6 +1869,11 @@ case "${target_os}" in
         AC_MSG_WARN(skipping check for perl cccdlflags on "${target_os}")
 esac
 
+# tools/mkimap needs its perl path set.  It doesn't use any Cyrus modules,
+# so it does't need a full fixsearchpath.pl run; it's enough to just let
+# configure substitute the shebang and set the mode.
+AC_CONFIG_FILES([tools/mkimap], [chmod +x tools/mkimap])
+
 CMU_LIBWRAP
 
 # Figure out what directories we're linking against.

--- a/configure.ac
+++ b/configure.ac
@@ -1869,10 +1869,11 @@ case "${target_os}" in
         AC_MSG_WARN(skipping check for perl cccdlflags on "${target_os}")
 esac
 
-# tools/mkimap needs its perl path set.  It doesn't use any Cyrus modules,
-# so it does't need a full fixsearchpath.pl run; it's enough to just let
-# configure substitute the shebang and set the mode.
+# These scripts need their perl shebang set.  They don't use any Cyrus modules,
+# so they don't need a full fixsearchpath.pl run; it's enough to just let
+# configure substitute the shebangs and set the mode.
 AC_CONFIG_FILES([tools/mkimap], [chmod +x tools/mkimap])
+AC_CONFIG_FILES([tools/rehash], [chmod +x tools/rehash])
 
 CMU_LIBWRAP
 

--- a/tools/mkimap
+++ b/tools/mkimap
@@ -4,8 +4,12 @@
 
 require 5;
 
-#use strict; # XXX does not compile with strict :(
+use strict;
 use warnings;
+
+my @configs;
+my @parts;
+my $confdir;
 
 sub read_conf {
     my $file = shift;
@@ -36,18 +40,18 @@ sub read_conf {
     close CONF;
 }
 
-$imapdconf = shift || "/etc/imapd.conf";
+my $imapdconf = shift || "/etc/imapd.conf";
 
 push @configs, $imapdconf;
 
-while ($conf = shift @configs) {
+while (my $conf = shift @configs) {
     read_conf($conf);
 }
 
 defined $confdir or die "'configdirectory:' in $imapdconf is missing";
 @parts or die "No partition defined in $imapdconf";
-$d = $confdir;
 
+my $d = $confdir;
 print "configuring $d...\n";
 
 chdir $d or die "couldn't change to $d";
@@ -60,7 +64,7 @@ mkdir "msg", 0755 || warn "can't create $d/msg: $!";
 mkdir "ptclient", 0755 || warn "can't create $d/ptclient: $!";
 mkdir "sync", 0755 || warn "can't create $d/sync: $!";
 
-while ($part = shift @parts) {
+while (my $part = shift @parts) {
     print "creating $part...\n";
     mkdir $part, 0755 || warn "can't create $part: $!";
     chdir $part or die "couldn't change to partition $part";

--- a/tools/mkimap.in
+++ b/tools/mkimap.in
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!@PERL@
 # SPDX-License-Identifier: BSD-3-Clause-CMU
 # See COPYING file at the root of the distribution for more details.
 
@@ -73,3 +73,5 @@ while (my $part = shift @parts) {
 }
 
 print "done\n";
+
+# vim: set ft=perl :

--- a/tools/rehash.in
+++ b/tools/rehash.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 # SPDX-License-Identifier: BSD-3-Clause-CMU
 # See COPYING file at the root of the distribution for more details.
 
@@ -464,3 +464,5 @@ sub tidy_up {
         tidydir("$path/$_", $onemore) for @fdirs;
     }
 }
+
+# vim: set ft=perl :


### PR DESCRIPTION
Fastmail build scripts and cyrus-docker expect `tools/mkimap` to be installed to `$prefix/bin`, but they achieve this by naively copying it into place, which fails to accommodate whatever `$PERL` had been configured.  Fastmail build scripts additionally do the same for `tools/rehash`.

This PR adds `tools/mkimap` and `tools/rehash` to the set of things that are installed, properly, by `make install`.  They are installed to `$prefix/sbin`, which is the correct place for them, and which matches the existing documentation.

The `install-binsymlinks` make target has been updated to include scripts, so if you had a workflow like:

```
make install
make install-binsymlinks
cp tools/mkimap /path/to/cyrus/bin/mkimap
cp tools/rehash /path/to/cyrus/bin/rehash
```

then this should still work, except: depending on the details, the `cp` steps may fail, since the target now already exists as a symlink to the source.  If the `cp` succeeds and replaces the symlinks with the files, it will at least be the correct files.  It works fine in cyrus-docker without any changes, not sure about FM build scripts.

As a side effect of updating the `install-binsymlinks` target, the `cyr_cd.sh` script is now also symlinked into bin.  It had previously been overlooked, as only compiled programs were considered.

**Fastmail:** This might require changes to `infrastructure/packages/cyrus-mkdebian.pl`, particularly around lines 128-9 where mkimap and rehash are manually installed.  Even if changes aren't _required_, the manual installs will be redundant and could be removed.