### PR TITLE
Refactor the hash code in preparation for dynamic resizing

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -94,7 +94,8 @@ EXPORTED hash_table *construct_hash_table(hash_table *table, size_t size, int us
 */
 EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
 {
-      unsigned val = strhash_seeded(table->seed, key) % table->size;
+      uint32_t hash = strhash_seeded(table->seed, key);
+      unsigned val = hash % table->size;
       bucket *ptr, *newptr;
 
       /*
@@ -104,8 +105,7 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
       for (ptr=(table->table)[val];
            ptr;
            ptr=ptr->next) {
-          int cmpresult = strcmp(key,ptr->key);
-          if (!cmpresult) {
+          if (hash == ptr->hash && !strcmp(key, ptr->key)) {
               /* Match! Replace this value and return the old */
               void *old_data;
 
@@ -125,6 +125,7 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
           newptr=(bucket *)xmalloc(sizeof(bucket));
           newptr->key = xstrdup(key);
       }
+      newptr->hash = hash;
       newptr->data = data;
       newptr->next = (table->table)[val];
       (table->table)[val] = newptr;
@@ -140,21 +141,20 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
 
 EXPORTED void *hash_lookup(const char *key, hash_table *table)
 {
-      unsigned val;
       bucket *ptr;
 
       if (!table->size)
           return NULL;
 
-      val = strhash_seeded(table->seed, key) % table->size;
+      uint32_t hash = strhash_seeded(table->seed, key);
+      unsigned val = hash % table->size;
 
       if (!(table->table)[val])
             return NULL;
 
       for ( ptr = (table->table)[val];NULL != ptr; ptr = ptr->next )
       {
-          int cmpresult = strcmp(key, ptr->key);
-          if (!cmpresult)
+          if (hash == ptr->hash && !strcmp(key, ptr->key))
               return ptr->data;
       }
       return NULL;
@@ -168,7 +168,8 @@ EXPORTED void *hash_lookup(const char *key, hash_table *table)
  * since it will leak memory until you get rid of the entire hash table */
 EXPORTED void *hash_del(const char *key, hash_table *table)
 {
-      unsigned val = strhash_seeded(table->seed, key) % table->size;
+      uint32_t hash = strhash_seeded(table->seed, key);
+      unsigned val = hash % table->size;
       bucket *ptr, *last = NULL;
 
       if (!(table->table)[val])
@@ -186,8 +187,7 @@ EXPORTED void *hash_del(const char *key, hash_table *table)
             NULL != ptr;
             last = ptr, ptr = ptr->next)
       {
-          int cmpresult = strcmp(key, ptr->key);
-          if (!cmpresult)
+          if (hash == ptr->hash && !strcmp(key, ptr->key))
           {
               void *data = ptr->data;
               if (last != NULL )

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -135,28 +135,11 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
               old_data = ptr->data;
               ptr -> data = data;
               return old_data;
-          } else if (cmpresult < 0) {
-              /* The new key is smaller than the current key--
-               * insert a node and return this data */
-              if(table->pool) {
-                  newptr = (bucket *)mpool_malloc(table->pool, sizeof(bucket));
-                  newptr->key = mpool_strdup(table->pool, key);
-              } else {
-                  newptr = (bucket *)xmalloc(sizeof(bucket));
-                  newptr->key = xstrdup(key);
-              }
-              newptr->data = data;
-              newptr->next = ptr;
-              *prev = newptr;
-              table->count++;
-              check_load_factor(table);
-              return data;
           }
       }
 
       /*
-      ** This key is the largest one so far.  Add it to the end
-      ** of the list (*prev should be correct)
+      ** Add it to the end of the list (*prev should be correct)
       */
       if(table->pool) {
           newptr=(bucket *)mpool_malloc(table->pool,sizeof(bucket));
@@ -196,8 +179,6 @@ EXPORTED void *hash_lookup(const char *key, hash_table *table)
           int cmpresult = strcmp(key, ptr->key);
           if (!cmpresult)
               return ptr->data;
-          else if(cmpresult < 0) /* key < ptr->key -- we passed it */
-              return NULL;
       }
       return NULL;
 }
@@ -255,10 +236,6 @@ EXPORTED void *hash_del(const char *key, hash_table *table)
               }
               table->count--;
               return data;
-          }
-          if (cmpresult < 0) {
-              /* its not here! */
-              return NULL;
           }
       }
 

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -96,7 +96,6 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
 {
       unsigned val = strhash_seeded(table->seed, key) % table->size;
       bucket *ptr, *newptr;
-      bucket **prev;
 
       /*
       ** NULL means this bucket hasn't been used yet.  We'll simply
@@ -124,9 +123,9 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
       ** This spot in the table is already in use.  See if the current string
       ** has already been inserted, and if so, replace its data
       */
-      for (prev = &((table->table)[val]), ptr=(table->table)[val];
+      for (ptr=(table->table)[val];
            ptr;
-           prev=&(ptr->next),ptr=ptr->next) {
+           ptr=ptr->next) {
           int cmpresult = strcmp(key,ptr->key);
           if (!cmpresult) {
               /* Match! Replace this value and return the old */
@@ -139,7 +138,7 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
       }
 
       /*
-      ** Add it to the end of the list (*prev should be correct)
+      ** Add new keys to the start of the list
       */
       if(table->pool) {
           newptr=(bucket *)mpool_malloc(table->pool,sizeof(bucket));
@@ -149,8 +148,8 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
           newptr->key = xstrdup(key);
       }
       newptr->data = data;
-      newptr->next = NULL;
-      *prev = newptr;
+      newptr->next = (table->table)[val];
+      (table->table)[val] = newptr;
       table->count++;
       check_load_factor(table);
       return data;

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -98,30 +98,8 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
       bucket *ptr, *newptr;
 
       /*
-      ** NULL means this bucket hasn't been used yet.  We'll simply
-      ** allocate space for our new bucket and put our data there, with
-      ** the table pointing at it.
-      */
-      if (!((table->table)[val]))
-      {
-          if(table->pool) {
-              (table->table)[val] =
-                  (bucket *)mpool_malloc(table->pool, sizeof(bucket));
-              (table->table)[val] -> key = mpool_strdup(table->pool, key);
-          } else {
-              (table->table)[val] = (bucket *)xmalloc(sizeof(bucket));
-              (table->table)[val] -> key = xstrdup(key);
-          }
-          (table->table)[val] -> next = NULL;
-          (table->table)[val] -> data = data;
-          table->count++;
-          check_load_factor(table);
-          return (table->table)[val] -> data;
-      }
-
-      /*
-      ** This spot in the table is already in use.  See if the current string
-      ** has already been inserted, and if so, replace its data
+      ** See if the current string has already been inserted, and if so,
+      ** replace its data
       */
       for (ptr=(table->table)[val];
            ptr;
@@ -138,7 +116,7 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
       }
 
       /*
-      ** Add new keys to the start of the list
+      ** Add new keys to the start of the list (which might be empty)
       */
       if(table->pool) {
           newptr=(bucket *)mpool_malloc(table->pool,sizeof(bucket));

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -118,13 +118,28 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
       /*
       ** Add new keys to the start of the list (which might be empty)
       */
+
+      /*
+      ** sizeof(bucket) is 24 on 64 bit systems, as it has to allow for padding.
+      ** whereas offsetof(...) is 20. So using it saves 4 bytes on average
+      */
+      size_t key_len = strlen(key) + 1; /* including the trailing NUL byte */
+      size_t wanted = offsetof(bucket, key) + key_len;
+
+      /* Code reviewers observed that for short keys the above calculation
+         might result in an allocation smaller than the (fully padded) struct.
+         We believe that this is all fine by the C standard, but compilers are
+         software too, and this sort of thing might trigger bugs (or false
+         positive warnings from UBSAN etc). So we play it safe: */
+      if(wanted < sizeof(bucket))
+          wanted = sizeof(bucket);
+
       if(table->pool) {
-          newptr=(bucket *)mpool_malloc(table->pool,sizeof(bucket));
-          newptr->key = mpool_strdup(table->pool,key);
+          newptr=(bucket *)mpool_malloc(table->pool,wanted);
       } else {
-          newptr=(bucket *)xmalloc(sizeof(bucket));
-          newptr->key = xstrdup(key);
+          newptr=(bucket *)xmalloc(wanted);
       }
+      memcpy(newptr->key,key,key_len);
       newptr->hash = hash;
       newptr->data = data;
       newptr->next = (table->table)[val];
@@ -208,7 +223,6 @@ EXPORTED void *hash_del(const char *key, hash_table *table)
                   (table->table)[val] = ptr->next;
               }
               if(!table->pool) {
-                  free(ptr->key);
                   free(ptr);
               }
               table->count--;
@@ -252,7 +266,6 @@ EXPORTED void free_hash_table(hash_table *table, void (*func)(void *))
                   if (func)
                       func(temp->data);
                   if(!table->pool) {
-                      free(temp->key);
                       free(temp);
                   }
               }

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -20,6 +20,7 @@ typedef struct bucket {
     char *key;
     void *data;
     struct bucket *next;
+    uint32_t hash;
 } bucket;
 
 /*

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -17,10 +17,10 @@
 */
 
 typedef struct bucket {
-    char *key;
     void *data;
     struct bucket *next;
     uint32_t hash;
+    char key[];
 } bucket;
 
 /*

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -75,28 +75,8 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
       bucketu64 *ptr, *newptr;
 
       /*
-      ** NULL means this bucket hasn't been used yet.  We'll simply
-      ** allocate space for our new bucket and put our data there, with
-      ** the table pointing at it.
-      */
-      if (!((table->table)[val]))
-      {
-          if(table->pool) {
-              (table->table)[val] =
-                  (bucketu64 *)mpool_malloc(table->pool, sizeof(bucketu64));
-              (table->table)[val] -> key = key;
-          } else {
-              (table->table)[val] = (bucketu64 *)xmalloc(sizeof(bucketu64));
-              (table->table)[val] -> key = key;
-          }
-          (table->table)[val] -> next = NULL;
-          (table->table)[val] -> data = data;
-          return (table->table)[val] -> data;
-      }
-
-      /*
-      ** This spot in the table is already in use.  See if the current string
-      ** has already been inserted, and if so, increment its count.
+      ** See if the current string has already been inserted, and if so,
+      ** increment its count.
       */
       for (ptr=(table->table)[val];
            ptr;
@@ -112,7 +92,7 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
       }
 
       /*
-      ** Add new keys to the start of the list
+      ** Add new keys to the start of the list (which might be empty)
       */
       if(table->pool) {
           newptr=(bucketu64 *)mpool_malloc(table->pool,sizeof(bucketu64));

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -73,7 +73,6 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
 {
       unsigned val = key % table->size;
       bucketu64 *ptr, *newptr;
-      bucketu64 **prev;
 
       /*
       ** NULL means this bucket hasn't been used yet.  We'll simply
@@ -99,9 +98,9 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
       ** This spot in the table is already in use.  See if the current string
       ** has already been inserted, and if so, increment its count.
       */
-      for (prev = &((table->table)[val]), ptr=(table->table)[val];
+      for (ptr=(table->table)[val];
            ptr;
-           prev=&(ptr->next),ptr=ptr->next) {
+           ptr=ptr->next) {
           if (key == ptr->key) {
               /* Match! Replace this value and return the old */
               void *old_data;
@@ -113,7 +112,7 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
       }
 
       /*
-      ** Add it to the end of the list (*prev should be correct)
+      ** Add new keys to the start of the list
       */
       if(table->pool) {
           newptr=(bucketu64 *)mpool_malloc(table->pool,sizeof(bucketu64));
@@ -123,8 +122,8 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
           newptr->key = key;
       }
       newptr->data = data;
-      newptr->next = NULL;
-      *prev = newptr;
+      newptr->next = (table->table)[val];
+      (table->table)[val] = newptr;
       return data;
 }
 

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -37,11 +37,6 @@
 ** of the table to 0.
 */
 
-static inline int u64cmp(uint64_t a, uint64_t b)
-{
-    return (a < b ? -1 : (a > b ? 1 : 0));
-}
-
 EXPORTED hashu64_table *construct_hashu64_table(hashu64_table *table, size_t size, int use_mpool)
 {
       assert(table);
@@ -107,34 +102,18 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
       for (prev = &((table->table)[val]), ptr=(table->table)[val];
            ptr;
            prev=&(ptr->next),ptr=ptr->next) {
-          int cmpresult = u64cmp(key, ptr->key);
-          if (!cmpresult) {
+          if (key == ptr->key) {
               /* Match! Replace this value and return the old */
               void *old_data;
 
               old_data = ptr->data;
               ptr -> data = data;
               return old_data;
-          } else if (cmpresult < 0) {
-              /* The new key is smaller than the current key--
-               * insert a node and return this data */
-              if(table->pool) {
-                  newptr = (bucketu64 *)mpool_malloc(table->pool, sizeof(bucketu64));
-                  newptr->key = key;
-              } else {
-                  newptr = (bucketu64 *)xmalloc(sizeof(bucketu64));
-                  newptr->key = key;
-              }
-              newptr->data = data;
-              newptr->next = ptr;
-              *prev = newptr;
-              return data;
           }
       }
 
       /*
-      ** This key is the largest one so far.  Add it to the end
-      ** of the list (*prev should be correct)
+      ** Add it to the end of the list (*prev should be correct)
       */
       if(table->pool) {
           newptr=(bucketu64 *)mpool_malloc(table->pool,sizeof(bucketu64));
@@ -168,11 +147,8 @@ EXPORTED void *hashu64_lookup(uint64_t key, hashu64_table *table)
 
       for ( ptr = (table->table)[val];NULL != ptr; ptr = ptr->next )
       {
-          int cmpresult = u64cmp(key, ptr->key);
-          if (!cmpresult)
+          if (key == ptr->key)
               return ptr->data;
-          else if(cmpresult < 0) /* key < ptr->key -- we passed it */
-              return NULL;
       }
       return NULL;
 }
@@ -204,8 +180,7 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
             NULL != ptr;
             last = ptr, ptr = ptr->next)
       {
-          int cmpresult = u64cmp(key, ptr->key);
-          if (!cmpresult)
+          if (key == ptr->key)
           {
               if (last != NULL)
               {
@@ -234,9 +209,6 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
                   }
                   return data;
               }
-          } else if (cmpresult < 0) {
-              /* its not here! */
-              return NULL;
           }
       }
 

--- a/lib/strhash.c
+++ b/lib/strhash.c
@@ -8,19 +8,16 @@
 
 /* The well-known djb2 algorithm (e.g. http://www.cse.yorku.ca/~oz/hash.html),
  * with the addition of an optional seed to limit predictability.
- *
- * XXX return type 'unsigned' for back-compat to previous version, but
- * XXX ought to be 'uint32_t'
  */
-EXPORTED unsigned strhash_seeded_djb2(uint32_t seed, const char *string)
+EXPORTED uint32_t strhash_seeded_djb2(uint32_t seed, const char *string)
 {
     const unsigned char *ustr = (const unsigned char *) string;
-    unsigned hash = 5381;
+    uint32_t hash = 5381;
     int c;
 
     if (seed) {
         /* treat the bytes of the seed as a prefix to the string */
-        unsigned i;
+        uint32_t i;
         for (i = 0; i < sizeof seed; i++) {
             c = seed & 0xff;
             hash = ((hash << 5) + hash) ^ c;
@@ -34,9 +31,9 @@ EXPORTED unsigned strhash_seeded_djb2(uint32_t seed, const char *string)
     return hash;
 }
 
-EXPORTED unsigned strhash_legacy(const char *string)
+EXPORTED uint32_t strhash_legacy(const char *string)
 {
-    unsigned ret_val = 0;
+    uint32_t ret_val = 0;
     int i;
 
     while (*string)

--- a/lib/strhash.h
+++ b/lib/strhash.h
@@ -5,8 +5,8 @@
 #ifndef _STRHASH_H_
 #include <stdint.h>
 
-unsigned strhash_seeded_djb2(uint32_t seed, const char *string);
-unsigned strhash_legacy(const char *string);
+uint32_t strhash_seeded_djb2(uint32_t seed, const char *string);
+uint32_t strhash_legacy(const char *string);
 
 #define strhash(in)             strhash_seeded_djb2((0),  (in))
 #define strhash_seeded(sd, in)  strhash_seeded_djb2((sd), (in))


### PR DESCRIPTION
* don't store the chained buckets in sorted key order
* store newly inserted hash entries at the head of the linked list
* merge the "insert a key into an existing list" and "insert a key into an empty list" code paths
* store the 32 bit hash with the key, and check it before calling `strcmp`
* store hash keys using a flexible array in the bucket struct