### PR TITLE
Email/set: destroy before creating

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_identical_draft_replace
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_identical_draft_replace
@@ -1,0 +1,67 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_set_create_identical_draft_replace ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "create drafts mailbox";
+    my $drafts_mbox = $user->mailboxes->create({ role => 'drafts' });
+
+    # Fixed messageId and sentAt ensure deterministic RFC822 output,
+    # so two creates with the same properties produce the same blob.
+    my %draftProps = (
+        from        => [ { name => "Test", email => 'test@example.com' } ],
+        keywords    => { '$draft' => JSON::true },
+        mailboxIds  => { $drafts_mbox->id => JSON::true },
+        messageId   => ['identical-draft-replace@example.com'],
+        sentAt      => '2024-06-15T12:00:00Z',
+        subject     => "Identical draft replace test",
+        to          => [ { name => "Dest", email => 'dest@example.com' } ],
+        bodyStructure => {
+            type     => 'multipart/alternative',
+            subParts => [
+                { type   => 'text/plain', partId => 'text' },
+                { type   => 'text/html',  partId => 'html' },
+            ],
+        },
+        bodyValues => {
+            text => { value => "Hello world" },
+            html => { value => "<p>Hello world</p>" },
+        },
+    );
+
+    xlog $self, "create the initial draft";
+    my $email_set_res = $jmap->request([[
+        'Email/set' => { create => { "a" => \%draftProps } },
+    ]]);
+
+    my $got = $email_set_res->single_sentence('Email/set')->arguments;
+    my $emailId1 = $got->{created}{a}{id};
+    my $blobId1 = $got->{created}{a}{blobId};
+    $self->assert_not_null($emailId1);
+    $self->assert_not_null($blobId1);
+
+    xlog $self, "replace draft with identical content in a single Email/set";
+    $email_set_res = $jmap->request([[
+        'Email/set' => {
+            create  => { "b" => \%draftProps },
+            destroy => [ $emailId1 ],
+        },
+    ]]);
+    $got = $email_set_res->single_sentence('Email/set')->arguments;
+
+    xlog $self, "create must succeed (not alreadyExists)";
+    my $emailId2 = $got->{created}{b}{id};
+    my $blobId2 = $got->{created}{b}{blobId};
+    $self->assert_not_null($emailId2);
+    $self->assert_not_null($blobId2);
+
+    xlog $self, "destroy must succeed";
+    $self->assert_str_equals($emailId1, $got->{destroyed}[0]);
+
+    xlog $self, "new email has different id but same blob (identical content)";
+    $self->assert_str_not_equals($emailId1, $emailId2);
+    $self->assert_str_equals($blobId1, $blobId2);
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -13666,6 +13666,8 @@ static int jmap_email_set(jmap_req_t *req)
 
     set.old_state = jmap_state_string(req, old_modseq, MBTYPE_EMAIL, 0);
 
+    _email_destroy_bulk(req, set.destroy, set.destroyed, set.not_destroyed);
+
     json_t *email;
     const char *creation_id;
     json_object_foreach(set.create, creation_id, email) {
@@ -13688,8 +13690,6 @@ static int jmap_email_set(jmap_req_t *req)
         debug_bulkupdate = json_object();
     }
     _email_update_bulk(req, set.update, set.updated, set.not_updated, debug_bulkupdate);
-
-    _email_destroy_bulk(req, set.destroy, set.destroyed, set.not_destroyed);
 
     set.new_state = jmap_state_string(req, 0, MBTYPE_EMAIL, JMAP_MODSEQ_RELOAD);
 


### PR DESCRIPTION
With deterministic email creation, you can end up trying to create a new draft identical to the old one.  (Weird, but true.)  Create fails, but if you did a destroy of the old in the same request, destroy succeeds.  Oops!

Destroy first.