### PR TITLE
update more JMAP types to destroy before update

### DIFF
--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1025,6 +1025,73 @@ static void _contacts_set(struct jmap_req *req, unsigned kind,
         if (r) goto done;
     }
 
+    /* destroy */
+    size_t index;
+    for (index = 0; index < json_array_size(set.destroy); index++) {
+        const char *id = _json_array_get_string(set.destroy, index);
+        if (!id) {
+            json_t *err = json_pack("{s:s}", "type", "invalidArguments");
+            json_object_set_new(set.not_destroyed, id, err);
+            continue;
+        }
+        mbentry_t *mbentry = NULL;
+        struct carddav_data *cdata = NULL;
+        uint32_t olduid;
+        if (kind == CARDDAV_KIND_ANY && USER_COMPACT_EMAILIDS(req->cstate)) {
+            if (id[0] == JMAP_CONTACTID_PREFIX &&
+                strlen(id) < JMAP_CONTACTID_SIZE) {
+                r = carddav_lookup_jmapid(db, id+1, &cdata);  // strip prefix
+            }
+        }
+        else {
+            r = carddav_lookup_uid(db, NULL, id, &cdata);
+        }
+
+        /* is it a valid contact? */
+        if (r || !cdata || !cdata->dav.imap_uid ||
+            (cdata->kind != kind && kind != CARDDAV_KIND_ANY)) {
+            r = 0;
+            json_t *err = json_pack("{s:s}", "type", "notFound");
+            json_object_set_new(set.not_destroyed, id, err);
+            continue;
+        }
+        olduid = cdata->dav.imap_uid;
+
+        mbentry = jmap_mbentry_from_dav(req, &cdata->dav);
+
+        if (!mbentry || !jmap_hasrights_mbentry(req, mbentry, JACL_REMOVEITEMS)) {
+            int rights = mbentry ? jmap_myrights_mbentry(req, mbentry) : 0;
+            json_t *err = json_pack("{s:s}", "type",
+                                    rights & JACL_READITEMS ?
+                                    "accountReadOnly" : "notFound");
+            json_object_set_new(set.not_destroyed, id, err);
+            mboxlist_entry_free(&mbentry);
+            continue;
+        }
+
+        if (!mailbox || strcmp(mailbox_name(mailbox), mbentry->name)) {
+            mailbox_close(&mailbox);
+            r = mailbox_open_iwl(mbentry->name, &mailbox);
+        }
+        mboxlist_entry_free(&mbentry);
+        if (r) goto done;
+
+        syslog(LOG_NOTICE,
+               "jmap: remove %s %s/%s",
+               kind == CARDDAV_KIND_GROUP ? "group" : "contact",
+               req->accountid, id);
+        r = carddav_remove(mailbox, olduid, /*isreplace*/0, req->userid);
+        if (r) {
+            xsyslog(LOG_ERR, "IOERROR: carddav remove failed",
+                             "kind=<%s> mailbox=<%s> olduid=<%u>",
+                             kind == CARDDAV_KIND_GROUP ? "group" : "contact",
+                             mailbox_name(mailbox), olduid);
+            goto done;
+        }
+
+        json_array_append_new(set.destroyed, json_string(id));
+    }
+
     /* create */
     const char *key;
     json_t *arg;
@@ -1151,73 +1218,6 @@ static void _contacts_set(struct jmap_req *req, unsigned kind,
         json_object_set_new(set.updated, uid, item);
     }
 
-
-    /* destroy */
-    size_t index;
-    for (index = 0; index < json_array_size(set.destroy); index++) {
-        const char *id = _json_array_get_string(set.destroy, index);
-        if (!id) {
-            json_t *err = json_pack("{s:s}", "type", "invalidArguments");
-            json_object_set_new(set.not_destroyed, id, err);
-            continue;
-        }
-        mbentry_t *mbentry = NULL;
-        struct carddav_data *cdata = NULL;
-        uint32_t olduid;
-        if (kind == CARDDAV_KIND_ANY && USER_COMPACT_EMAILIDS(req->cstate)) {
-            if (id[0] == JMAP_CONTACTID_PREFIX &&
-                strlen(id) < JMAP_CONTACTID_SIZE) {
-                r = carddav_lookup_jmapid(db, id+1, &cdata);  // strip prefix
-            }
-        }
-        else {
-            r = carddav_lookup_uid(db, NULL, id, &cdata);
-        }
-
-        /* is it a valid contact? */
-        if (r || !cdata || !cdata->dav.imap_uid ||
-            (cdata->kind != kind && kind != CARDDAV_KIND_ANY)) {
-            r = 0;
-            json_t *err = json_pack("{s:s}", "type", "notFound");
-            json_object_set_new(set.not_destroyed, id, err);
-            continue;
-        }
-        olduid = cdata->dav.imap_uid;
-
-        mbentry = jmap_mbentry_from_dav(req, &cdata->dav);
-
-        if (!mbentry || !jmap_hasrights_mbentry(req, mbentry, JACL_REMOVEITEMS)) {
-            int rights = mbentry ? jmap_myrights_mbentry(req, mbentry) : 0;
-            json_t *err = json_pack("{s:s}", "type",
-                                    rights & JACL_READITEMS ?
-                                    "accountReadOnly" : "notFound");
-            json_object_set_new(set.not_destroyed, id, err);
-            mboxlist_entry_free(&mbentry);
-            continue;
-        }
-
-        if (!mailbox || strcmp(mailbox_name(mailbox), mbentry->name)) {
-            mailbox_close(&mailbox);
-            r = mailbox_open_iwl(mbentry->name, &mailbox);
-        }
-        mboxlist_entry_free(&mbentry);
-        if (r) goto done;
-
-        syslog(LOG_NOTICE,
-               "jmap: remove %s %s/%s",
-               kind == CARDDAV_KIND_GROUP ? "group" : "contact",
-               req->accountid, id);
-        r = carddav_remove(mailbox, olduid, /*isreplace*/0, req->userid);
-        if (r) {
-            xsyslog(LOG_ERR, "IOERROR: carddav remove failed",
-                             "kind=<%s> mailbox=<%s> olduid=<%u>",
-                             kind == CARDDAV_KIND_GROUP ? "group" : "contact",
-                             mailbox_name(mailbox), olduid);
-            goto done;
-        }
-
-        json_array_append_new(set.destroyed, json_string(id));
-    }
 
     /* force modseq to stable */
     if (mailbox) mailbox_unlock_index(mailbox, NULL);
@@ -5825,6 +5825,35 @@ static int jmap_addressbook_set(struct jmap_req *req)
         if (r) goto done;
     }
 
+    /* destroy */
+    size_t index;
+    json_t *jid;
+
+    json_array_foreach(set.destroy, index, jid) {
+        const char *id = json_string_value(jid);
+        if (json_object_get(set.not_destroyed, id)) {
+            continue;
+        }
+        /* Resolve abookid */
+        const char *abookid = id;
+        if (abookid && abookid[0] == '#') {
+            const char *newabookid = jmap_lookup_id(req, abookid + 1);
+            if (!newabookid) {
+                json_t *err = json_pack("{s:s}", "type", "notFound");
+                json_object_set_new(set.not_destroyed, id, err);
+                continue;
+            }
+            abookid = newabookid;
+        }
+        json_t *err = NULL;
+        setaddressbooks_destroy(req, abookid, default_addrbookname,
+                                setargs.on_destroy_remove_contents, &err);
+        if (!err) {
+            json_array_append_new(set.destroyed, json_string(id));
+        }
+        else json_object_set_new(set.not_destroyed, id, err);
+    }
+
     /* create */
     const char *key;
     json_t *arg;
@@ -5870,35 +5899,6 @@ static int jmap_addressbook_set(struct jmap_req *req)
             json_object_set_new(set.updated, id, record);
         }
         else json_object_set_new(set.not_updated, id, err);
-    }
-
-    /* destroy */
-    size_t index;
-    json_t *jid;
-
-    json_array_foreach(set.destroy, index, jid) {
-        const char *id = json_string_value(jid);
-        if (json_object_get(set.not_destroyed, id)) {
-            continue;
-        }
-        /* Resolve abookid */
-        const char *abookid = id;
-        if (abookid && abookid[0] == '#') {
-            const char *newabookid = jmap_lookup_id(req, abookid + 1);
-            if (!newabookid) {
-                json_t *err = json_pack("{s:s}", "type", "notFound");
-                json_object_set_new(set.not_destroyed, id, err);
-                continue;
-            }
-            abookid = newabookid;
-        }
-        json_t *err = NULL;
-        setaddressbooks_destroy(req, abookid, default_addrbookname,
-                                setargs.on_destroy_remove_contents, &err);
-        if (!err) {
-            json_array_append_new(set.destroyed, json_string(id));
-        }
-        else json_object_set_new(set.not_destroyed, id, err);
     }
 
     if (setargs.on_success_set_is_default &&

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1036,6 +1036,73 @@ static void _contacts_set(struct jmap_req *req, unsigned kind,
         if (r) goto done;
     }
 
+    /* destroy */
+    size_t index;
+    for (index = 0; index < json_array_size(set.destroy); index++) {
+        const char *id = _json_array_get_string(set.destroy, index);
+        if (!id) {
+            json_t *err = json_pack("{s:s}", "type", "invalidArguments");
+            json_object_set_new(set.not_destroyed, id, err);
+            continue;
+        }
+        mbentry_t *mbentry = NULL;
+        struct carddav_data *cdata = NULL;
+        uint32_t olduid;
+        if (kind == CARDDAV_KIND_ANY && USER_COMPACT_EMAILIDS(req->cstate)) {
+            if (id[0] == JMAP_CONTACTID_PREFIX &&
+                strlen(id) < JMAP_CONTACTID_SIZE) {
+                r = carddav_lookup_jmapid(db, id+1, &cdata);  // strip prefix
+            }
+        }
+        else {
+            r = carddav_lookup_uid(db, NULL, id, &cdata);
+        }
+
+        /* is it a valid contact? */
+        if (r || !cdata || !cdata->dav.imap_uid ||
+            (cdata->kind != kind && kind != CARDDAV_KIND_ANY)) {
+            r = 0;
+            json_t *err = json_pack("{s:s}", "type", "notFound");
+            json_object_set_new(set.not_destroyed, id, err);
+            continue;
+        }
+        olduid = cdata->dav.imap_uid;
+
+        mbentry = jmap_mbentry_from_dav(req, &cdata->dav);
+
+        if (!mbentry || !jmap_hasrights_mbentry(req, mbentry, JACL_REMOVEITEMS)) {
+            int rights = mbentry ? jmap_myrights_mbentry(req, mbentry) : 0;
+            json_t *err = json_pack("{s:s}", "type",
+                                    rights & JACL_READITEMS ?
+                                    "accountReadOnly" : "notFound");
+            json_object_set_new(set.not_destroyed, id, err);
+            mboxlist_entry_free(&mbentry);
+            continue;
+        }
+
+        if (!mailbox || strcmp(mailbox_name(mailbox), mbentry->name)) {
+            mailbox_close(&mailbox);
+            r = mailbox_open_iwl(mbentry->name, &mailbox);
+        }
+        mboxlist_entry_free(&mbentry);
+        if (r) goto done;
+
+        syslog(LOG_NOTICE,
+               "jmap: remove %s %s/%s",
+               kind == CARDDAV_KIND_GROUP ? "group" : "contact",
+               req->accountid, id);
+        r = carddav_remove(mailbox, olduid, /*isreplace*/0, req->userid);
+        if (r) {
+            xsyslog(LOG_ERR, "IOERROR: carddav remove failed",
+                             "kind=<%s> mailbox=<%s> olduid=<%u>",
+                             kind == CARDDAV_KIND_GROUP ? "group" : "contact",
+                             mailbox_name(mailbox), olduid);
+            goto done;
+        }
+
+        json_array_append_new(set.destroyed, json_string(id));
+    }
+
     /* create */
     const char *key;
     json_t *arg;
@@ -1174,73 +1241,6 @@ static void _contacts_set(struct jmap_req *req, unsigned kind,
         json_object_set_new(set.updated, uid, item);
     }
 
-
-    /* destroy */
-    size_t index;
-    for (index = 0; index < json_array_size(set.destroy); index++) {
-        const char *id = _json_array_get_string(set.destroy, index);
-        if (!id) {
-            json_t *err = json_pack("{s:s}", "type", "invalidArguments");
-            json_object_set_new(set.not_destroyed, id, err);
-            continue;
-        }
-        mbentry_t *mbentry = NULL;
-        struct carddav_data *cdata = NULL;
-        uint32_t olduid;
-        if (kind == CARDDAV_KIND_ANY && USER_COMPACT_EMAILIDS(req->cstate)) {
-            if (id[0] == JMAP_CONTACTID_PREFIX &&
-                strlen(id) < JMAP_CONTACTID_SIZE) {
-                r = carddav_lookup_jmapid(db, id+1, &cdata);  // strip prefix
-            }
-        }
-        else {
-            r = carddav_lookup_uid(db, NULL, id, &cdata);
-        }
-
-        /* is it a valid contact? */
-        if (r || !cdata || !cdata->dav.imap_uid ||
-            (cdata->kind != kind && kind != CARDDAV_KIND_ANY)) {
-            r = 0;
-            json_t *err = json_pack("{s:s}", "type", "notFound");
-            json_object_set_new(set.not_destroyed, id, err);
-            continue;
-        }
-        olduid = cdata->dav.imap_uid;
-
-        mbentry = jmap_mbentry_from_dav(req, &cdata->dav);
-
-        if (!mbentry || !jmap_hasrights_mbentry(req, mbentry, JACL_REMOVEITEMS)) {
-            int rights = mbentry ? jmap_myrights_mbentry(req, mbentry) : 0;
-            json_t *err = json_pack("{s:s}", "type",
-                                    rights & JACL_READITEMS ?
-                                    "accountReadOnly" : "notFound");
-            json_object_set_new(set.not_destroyed, id, err);
-            mboxlist_entry_free(&mbentry);
-            continue;
-        }
-
-        if (!mailbox || strcmp(mailbox_name(mailbox), mbentry->name)) {
-            mailbox_close(&mailbox);
-            r = mailbox_open_iwl(mbentry->name, &mailbox);
-        }
-        mboxlist_entry_free(&mbentry);
-        if (r) goto done;
-
-        syslog(LOG_NOTICE,
-               "jmap: remove %s %s/%s",
-               kind == CARDDAV_KIND_GROUP ? "group" : "contact",
-               req->accountid, id);
-        r = carddav_remove(mailbox, olduid, /*isreplace*/0, req->userid);
-        if (r) {
-            xsyslog(LOG_ERR, "IOERROR: carddav remove failed",
-                             "kind=<%s> mailbox=<%s> olduid=<%u>",
-                             kind == CARDDAV_KIND_GROUP ? "group" : "contact",
-                             mailbox_name(mailbox), olduid);
-            goto done;
-        }
-
-        json_array_append_new(set.destroyed, json_string(id));
-    }
 
     /* force modseq to stable */
     if (mailbox) mailbox_unlock_index(mailbox, NULL);
@@ -5848,6 +5848,35 @@ static int jmap_addressbook_set(struct jmap_req *req)
         if (r) goto done;
     }
 
+    /* destroy */
+    size_t index;
+    json_t *jid;
+
+    json_array_foreach(set.destroy, index, jid) {
+        const char *id = json_string_value(jid);
+        if (json_object_get(set.not_destroyed, id)) {
+            continue;
+        }
+        /* Resolve abookid */
+        const char *abookid = id;
+        if (abookid && abookid[0] == '#') {
+            const char *newabookid = jmap_lookup_id(req, abookid + 1);
+            if (!newabookid) {
+                json_t *err = json_pack("{s:s}", "type", "notFound");
+                json_object_set_new(set.not_destroyed, id, err);
+                continue;
+            }
+            abookid = newabookid;
+        }
+        json_t *err = NULL;
+        setaddressbooks_destroy(req, abookid, default_addrbookname,
+                                setargs.on_destroy_remove_contents, &err);
+        if (!err) {
+            json_array_append_new(set.destroyed, json_string(id));
+        }
+        else json_object_set_new(set.not_destroyed, id, err);
+    }
+
     /* create */
     const char *key;
     json_t *arg;
@@ -5893,35 +5922,6 @@ static int jmap_addressbook_set(struct jmap_req *req)
             json_object_set_new(set.updated, id, record);
         }
         else json_object_set_new(set.not_updated, id, err);
-    }
-
-    /* destroy */
-    size_t index;
-    json_t *jid;
-
-    json_array_foreach(set.destroy, index, jid) {
-        const char *id = json_string_value(jid);
-        if (json_object_get(set.not_destroyed, id)) {
-            continue;
-        }
-        /* Resolve abookid */
-        const char *abookid = id;
-        if (abookid && abookid[0] == '#') {
-            const char *newabookid = jmap_lookup_id(req, abookid + 1);
-            if (!newabookid) {
-                json_t *err = json_pack("{s:s}", "type", "notFound");
-                json_object_set_new(set.not_destroyed, id, err);
-                continue;
-            }
-            abookid = newabookid;
-        }
-        json_t *err = NULL;
-        setaddressbooks_destroy(req, abookid, default_addrbookname,
-                                setargs.on_destroy_remove_contents, &err);
-        if (!err) {
-            json_array_append_new(set.destroyed, json_string(id));
-        }
-        else json_object_set_new(set.not_destroyed, id, err);
     }
 
     if (setargs.on_success_set_is_default &&

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -1486,9 +1486,27 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
         set.old_state = modseqtoa(jmap_modseq(req, MBTYPE_JMAPSUBMIT, 0));
     }
 
-    /* create */
+    /* destroy */
     json_t *jsubmission;
-    const char *creation_id;
+    const char *creation_id, *id;
+    size_t i;
+    json_t *jsubmissionId;
+    json_array_foreach(set.destroy, i, jsubmissionId) {
+        id = json_string_value(jsubmissionId);
+        json_t *set_err = NULL;
+        char *emailid = NULL;
+        _emailsubmission_destroy(req, submbox, id, &set_err, &emailid);
+        if (set_err) {
+            json_object_set_new(set.not_destroyed, id, set_err);
+            free(emailid);
+            continue;
+        }
+        json_array_append_new(set.destroyed, json_string(id));
+        json_object_set_new(success_emailids, id, json_string(emailid));
+        free(emailid);
+    }
+
+    /* create */
     smtpclient_t *sm = NULL;
     json_object_foreach(set.create, creation_id, jsubmission) {
         json_t *set_err = NULL;
@@ -1501,7 +1519,7 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
             free(emailid);
             continue;
         }
-        const char *id = json_string_value(json_object_get(new_submission, "id"));
+        id = json_string_value(json_object_get(new_submission, "id"));
         json_object_set_new(set.created, creation_id, new_submission);
         json_object_set_new(success_emailids, id, json_string(emailid));
         free(emailid);
@@ -1512,7 +1530,6 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
     if (sm) smtpclient_close(&sm);
 
     /* update */
-    const char *id;
     json_object_foreach(set.update, id, jsubmission) {
         json_t *set_err = NULL;
         char *emailid = NULL;
@@ -1524,24 +1541,6 @@ static int jmap_emailsubmission_set(jmap_req_t *req)
             continue;
         }
         json_object_set_new(set.updated, id, json_pack("{s:s}", "id", id));
-        json_object_set_new(success_emailids, id, json_string(emailid));
-        free(emailid);
-    }
-
-    /* destroy */
-    size_t i;
-    json_t *jsubmissionId;
-    json_array_foreach(set.destroy, i, jsubmissionId) {
-        const char *id = json_string_value(jsubmissionId);
-        json_t *set_err = NULL;
-        char *emailid = NULL;
-        _emailsubmission_destroy(req, submbox, id, &set_err, &emailid);
-        if (set_err) {
-            json_object_set_new(set.not_destroyed, id, set_err);
-            free(emailid);
-            continue;
-        }
-        json_array_append_new(set.destroyed, json_string(id));
         json_object_set_new(success_emailids, id, json_string(emailid));
         free(emailid);
     }

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -830,10 +830,28 @@ static int jmap_note_set(jmap_req_t *req)
     }
 
     
-    /* create */
+    /* destroy */
     const char *creation_id, *id;
     json_t *val;
+    size_t i;
+    hash_table ids = HASH_TABLE_INITIALIZER;
+    struct set_rock srock = { &set, &buf, rights };
 
+    construct_hash_table(&ids, 32, 0);
+
+    /* Build hash of ids */
+    json_array_foreach(set.destroy, i, val) {
+        hash_insert(json_string_value(val), (void *) 1, &ids);
+    }
+
+    /* Iterate through each message and destroy matching ids */
+    foreach_note(mbox, &ids, &_notes_destroy_cb, &srock);
+
+    /* Any remaining ids are not destroyed */
+    hash_enumerate(&ids, &not_found_cb, set.not_destroyed);
+    free_hash_table(&ids, NULL);
+
+    /* create */
     json_object_foreach(set.create, creation_id, val) {
         json_t *new_note = NULL;
 
@@ -857,11 +875,7 @@ static int jmap_note_set(jmap_req_t *req)
         }
     }
 
-
     /* update */
-    hash_table ids = HASH_TABLE_INITIALIZER;
-    struct set_rock srock = { &set, &buf, rights };
-
     construct_hash_table(&ids, 32, 0);
 
     /* Build hash of ids */
@@ -874,23 +888,6 @@ static int jmap_note_set(jmap_req_t *req)
 
     /* Any remaining ids are not updated */
     hash_enumerate(&ids, &not_found_cb, set.not_updated);
-    free_hash_table(&ids, NULL);
-
-    
-    /* destroy */
-    construct_hash_table(&ids, 32, 0);
-
-    /* Build hash of ids */
-    size_t i;
-    json_array_foreach(set.destroy, i, val) {
-        hash_insert(json_string_value(val), (void *) 1, &ids);
-    }
-
-    /* Iterate through each message and destroy matching ids */
-    foreach_note(mbox, &ids, &_notes_destroy_cb, &srock);
-
-    /* Any remaining ids are not destroyed */
-    hash_enumerate(&ids, &not_found_cb, set.not_destroyed);
     free_hash_table(&ids, NULL);
 
 

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -797,9 +797,19 @@ static int jmap_sieve_set(struct jmap_req *req)
     }
 
 
-    /* create */
-    const char *creation_id, *script_id;
+    /* destroy */
+    const char *creation_id, *script_id, *id;
     json_t *val;
+    size_t i;
+    json_array_foreach(set.destroy, i, val) {
+        id = json_string_value(val);
+        script_id = (id && id[0] == '#') ? jmap_lookup_id(req, id + 1) : id;
+        if (!script_id) continue;
+
+        set_destroy(script_id, mailbox, db, &set);
+    }
+
+    /* create */
     if (json_object_size(set.create)) {
         /* Count existing scripts */
         int num_scripts;
@@ -827,25 +837,12 @@ static int jmap_sieve_set(struct jmap_req *req)
         }
     }
 
-
     /* update */
-    const char *id;
     json_object_foreach(set.update, id, val) {
         script_id = (id && id[0] == '#') ? jmap_lookup_id(req, id + 1) : id;
         if (!script_id) continue;
 
         set_update(req, script_id, val, mailbox, db, &set);
-    }
-
-
-    /* destroy */
-    size_t i;
-    json_array_foreach(set.destroy, i, val) {
-        id = json_string_value(val);
-        script_id = (id && id[0] == '#') ? jmap_lookup_id(req, id + 1) : id;
-        if (!script_id) continue;
-
-        set_destroy(script_id, mailbox, db, &set);
     }
 
     if (!json_object_size(set.not_created) &&


### PR DESCRIPTION
This looks like a bunch of C code changing — and it is — but `git diff --color-moved` will make clear that 95% of this is shifting code up and down.  Ignore until #5906 shipped, I think.