### PR TITLE
mailbox: auditlog rename of UUID-mailboxes

### DIFF
--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6506,6 +6506,8 @@ HIDDEN int mailbox_rename_nocopy(struct mailbox *oldmailbox,
     }
     if (r) goto done;
 
+    auditlog_mailbox("rename", oldmailbox, &newmailbox, NULL);
+
     /* unless on a replica, bump the modseq */
     if (!silent) mailbox_modseq_dirty(oldmailbox);
 


### PR DESCRIPTION
We usually auditlog after the mailbox disk changes have succeeded, but there aren't any mailbox disk changes when renaming a UUID mailbox.

But not auditlogging renames at all is confusing, so do it anyway.