### PR TITLE
sieve_db.c: support a shared #sieve mailbox for global scripts

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -360,6 +360,7 @@ EOF
 
 sub timsieved_client {
     my $self = shift;
+    my $userid = shift // 'cassandane';
 
     my $srv = $self->{instance}->get_service('sieve');
     my $client = IO::Socket::IP->new(
@@ -375,7 +376,7 @@ sub timsieved_client {
     timsieved_write($client, "AUTHENTICATE \"PLAIN\"\n");
     $self->assert_str_equals("{0}\r\n\r\n", timsieved_read($client));
 
-    my $plain = encode_base64("\0cassandane\0test", "");
+    my $plain = encode_base64("\0" . $userid . "\0test", "");
     my $len = length($plain);
     timsieved_write($client, "{$len+}\r\n");
     timsieved_write($client, "$plain\n");

--- a/cassandane/tiny-tests/Sieve/timsieved_global_script
+++ b/cassandane/tiny-tests/Sieve/timsieved_global_script
@@ -1,0 +1,60 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_timsieved_global_script
+    :MagicPlus
+    ($self)
+{
+    # Create a sieve script as an admin
+    my $client = $self->timsieved_client('admin');
+
+    my $name = 'test-script';
+    my $script = <<~"EOF";
+      require "imap4flags";
+      keep :flags "\\\\flagged";
+      EOF
+    my $slen = length($script);
+
+    timsieved_write($client, <<~"EOF");
+      PUTSCRIPT "$name" {$slen+}\r
+      $script
+      EOF
+    $self->assert_str_equals("OK\r\n", timsieved_read($client));
+
+    timsieved_write($client, "LISTSCRIPTS\n");
+    $self->assert_str_equals("\"$name\"\r\nOK\r\n", timsieved_read($client));
+
+    timsieved_write($client, "GETSCRIPT \"$name\"\n");
+    $self->assert_str_equals("{$slen}\r\n$script\r\nOK\r\n",
+                             timsieved_read($client));
+
+    # Make sure the script is stored in the #sieve mailbox
+    my $admintalk = $self->{adminstore}->get_client(NoLogin => 1);
+    $admintalk->login("admin+dav", "secret");
+
+    $admintalk->examine('#sieve');
+    my $res = $admintalk->fetch('1:*',
+                                '(BODY[HEADER.FIELDS (Subject)] BODY[TEXT])');
+    $self->assert_str_equals($name, $res->{1}{headers}{subject}[0]);
+    $self->assert_str_equals($script, $res->{1}{body});
+
+    # Create a shared mailbox and assign our global sieve script to it
+    my $mboxname = 'shared-mailbox';
+    $admintalk->create($mboxname);
+    $admintalk->setacl($mboxname, anyone => 'lrswp');
+
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/sieve';
+    $admintalk->setmetadata($mboxname, $entry, $name);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # Deliver a message to the shared mailbox
+    my $msg = $self->{gen}->generate(subject => "Test Message");
+    $self->{instance}->deliver($msg, users => [ "" ], folder => $mboxname);
+
+    # Make sure that the script was executed and the message is \Flagged
+    $admintalk->examine($mboxname);
+    $res = $admintalk->fetch('1:*', '(FLAGS)');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $self->assert_deep_equals($res,
+                              { '1' => { 'flags' => [ '\\Recent', '\\Flagged'] }});
+}

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -942,7 +942,7 @@ EXPORTED const char *mbname_intname(const mbname_t *mbname)
         sep = 1;
     }
 
-    if (mbname->localpart) {
+    if (mbname->localpart && *mbname->localpart) {
         if (sep) buf_putc(&buf, '.');
         buf_appendcstr(&buf, "user.");
         _append_intbuf(&buf, mbname->localpart);

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -547,6 +547,7 @@ static int store_script(struct mailbox *mailbox, struct sieve_data *sdata,
 
     /* Create RFC 5322 header for script */
     char *userid = mboxname_to_userid(mailbox_name(mailbox));
+    if  (!userid) userid = xstrdup(strarray_nth(config_admins,0));
     if (strchr(userid, '@')) {
         buf_printf(&buf, "<%s>", userid);
     }
@@ -830,7 +831,8 @@ static int migrate_cb(const char *sievedir,
     return SIEVEDIR_OK;
 }
 
-EXPORTED int sieve_ensure_folder(const char *userid, struct mailbox **mailboxptr, int silent)
+EXPORTED int sieve_ensure_folder(const char *userid,
+                                 struct mailbox **mailboxptr, int silent)
 {
     const char *sievedir = user_sieve_path(userid);
     struct stat sbuf;
@@ -915,6 +917,7 @@ EXPORTED int sieve_script_rebuild(const char *userid,
                                   const char *sievedir, const char *script)
 {
     struct buf namebuf = BUF_INITIALIZER, *content_buf = NULL;
+    struct mailbox *mailbox = NULL;
     struct sieve_data *sdata = NULL;
     struct sieve_db *db = NULL;
     const char *content = NULL;
@@ -922,36 +925,31 @@ EXPORTED int sieve_script_rebuild(const char *userid,
     struct stat bc_stat;
     int r;
 
-    db = sievedb_open_userid(userid);
-    if (!db) {
-        r = IMAP_INTERNAL;
-        goto done;
+    /* Open sieve mailbox and db */
+    r = sieve_ensure_folder(userid, &mailbox, 0/*silent*/);
+    if (r) {
+        syslog(LOG_ERR, "IOERROR: failed to open sieve mailbox for %s (%s)",
+               userid, error_message(r));
     }
+    else {
+        db = sievedb_open_mailbox(mailbox);
+        if (!db) r = IMAP_INTERNAL;
+    }
+
+    if (r) goto done;
 
     /* Lookup script in Sieve DB */
     r = sievedb_lookup_name(db, script, &sdata, 0);
     if (!r) {
-        char *mboxname = sieve_mboxname(userid);
-        struct mailbox *mailbox = NULL;
-
         lastupdated = sdata->lastupdated;
 
         content_buf = buf_new();
 
-        r = mailbox_open_irl(mboxname, &mailbox);
-        if (r) {
-            syslog(LOG_ERR, "IOERROR: failed to open %s (%s)",
-                   mboxname, error_message(r));
-        }
-        else {
-            r = sieve_script_fetch(mailbox, sdata, content_buf);
+        r = sieve_script_fetch(mailbox, sdata, content_buf);
 
-            if (!r) {
-                content = buf_cstring(content_buf);
-            }
+        if (!r) {
+            content = buf_cstring(content_buf);
         }
-        mailbox_close(&mailbox);
-        free(mboxname);
 
         if (r) goto done;
     }
@@ -1029,6 +1027,7 @@ EXPORTED int sieve_script_rebuild(const char *userid,
     buf_destroy(content_buf);
     buf_free(&namebuf);
     sievedb_close(db);
+    mailbox_close(&mailbox);
 
     return r;
 }
@@ -1042,7 +1041,10 @@ EXPORTED char *sieve_mboxname(const char *userid)
 
     buf_setcstr(&boxbuf, config_getstring(IMAPOPT_SIEVE_FOLDER));
 
-    res = mboxname_user_mbox(userid, buf_cstring(&boxbuf));
+    if (userid)
+        res = mboxname_user_mbox(userid, buf_cstring(&boxbuf));
+    else
+        res = buf_release(&boxbuf);
 
     buf_free(&boxbuf);
 

--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -69,18 +69,21 @@ int actions_init(void)
 
 int actions_setuser(const char *userid)
 {
+    mbname_t *mbname = mbname_from_userid(userid);
     struct buf buf = BUF_INITIALIZER;
     int result;
 
-    sieved_userid = xstrdup(userid);
+    sieved_userid = xstrdup(userid); // for logging
 
     if (sieved_userisadmin) {
-        char *domain = NULL;
+        const char *domain = mbname_domain(mbname);
+
+        mbname_set_localpart(mbname, "");
 
         buf_setcstr(&buf, sieve_dir_config);
 
-        if (config_virtdomains && (domain = strrchr(userid, '@'))) {
-            char dhash = (char) dir_hash_c(++domain, config_fulldirhash);
+        if (config_virtdomains && domain) {
+            char dhash = (char) dir_hash_c(domain, config_fulldirhash);
             buf_printf(&buf, "%s%c/%s", FNAME_DOMAINDIR, dhash, domain);
         }
 
@@ -103,17 +106,18 @@ int actions_setuser(const char *userid)
         }
     }
 
-    if (result) return TIMSIEVE_FAIL;
+    if (!result) {
+        result = sieve_ensure_folder(mbname_userid(mbname),
+                                     &sieve_mailbox, /*silent*/0);
+        if (!result) {
+            sievedb = sievedb_open_mailbox(sieve_mailbox);
+            mailbox_unlock_index(sieve_mailbox, NULL);
+        }
+    }
 
-    sievedb = sievedb_open_userid(sieved_userid);
-    if (!sievedb) return TIMSIEVE_FAIL;
+    mbname_free(&mbname);
 
-    result = sieve_ensure_folder(sieved_userid, &sieve_mailbox, /*silent*/0);
-    if (result) return TIMSIEVE_FAIL;
-
-    mailbox_unlock_index(sieve_mailbox, NULL);
-
-    return TIMSIEVE_OK;
+    return (sievedb ? TIMSIEVE_OK : TIMSIEVE_FAIL);
 }
 
 void actions_unsetuser(void)


### PR DESCRIPTION
Sieve scripts created by admins are stored in a shared space rather than in user space.  Prior to this fix, we were trying use a #sieve mailbox under the admins (non-existent) INBOX.
