### PR TITLE
Cyrus::IndexFile - name the SNOOZED system flag with a hidden name

### DIFF
--- a/perl/imap/lib/Cyrus/IndexFile.pm
+++ b/perl/imap/lib/Cyrus/IndexFile.pm
@@ -1333,13 +1333,13 @@ EOF
   },
 };
 
-my %SystemFlagMap = (
+our %SystemFlagMap = (
    0 => "\\Answered",
    1 => "\\Flagged",
    2 => "\\Deleted",
    3 => "\\Draft",
    4 => "\\Seen",
-  26 => "\\Snoozed",
+  26 => "[SNOOZED]",
   27 => "[SPLITCONVERSATION]",
   28 => "[NEEDS-CLEANUP]",
   29 => "[ARCHIVED]",


### PR DESCRIPTION
We can't just define \\Snoozed, it's not a standard systemflag name. This aligns with the rest of the internal names being [FOO] which can be trivally grepped by supporting code