### PR TITLE
reject unknown "kind" components, cope with bad JSPROP

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_get_unresolvable_jsprop
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_unresolvable_jsprop
@@ -1,0 +1,63 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_get_unresolvable_jsprop
+    :min_version_3_9
+    ($self)
+{
+    my $jmap = $self->{jmap};
+    my $carddav = $self->{carddav};
+
+    # Get the starting JMAP state before we create anything, so we can ask
+    # ContactCard/changes for the id of the card we're about to put.  We need
+    # changes because ContactCard/get is the very thing under test -- if the
+    # bug is present, asking /get to enumerate ids hides the same card we want
+    # to look up by id.
+    my $startState = $jmap->request([['ContactCard/get', { ids => [] } ]])
+                          ->single_sentence->arguments->{state};
+
+    # This vCard has a JSPROP whose JSPTR points into a JSContact
+    # subtree that will not be reconstructed on read: there is no ADR
+    # property, so the converted JSContact has no "addresses" object at
+    # all, and the patch "addresses/a0/components" = [...] cannot be
+    # applied.
+    #
+    # This shape used to be produced by ContactCard/set when a client
+    # sent an AddressComponent with an invalid "kind"; such cards may
+    # still exist on disk from before that bug was fixed.
+    #
+    # ContactCard/get used to silently drop such cards from the result:
+    # jmap_card_from_vcard returned NULL, but getcards_cb did not
+    # notice and bumped its row count anyway, so the caller put the id
+    # in neither "list" nor "notFound" -- a JMAP spec violation.
+    my $uid = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+    my $vcard = <<EOF;
+BEGIN:VCARD
+VERSION:4.0
+UID:$uid
+FN:Broken Contact
+JSPROP;JSPTR=addresses/a0/components:"Main St"
+END:VCARD
+EOF
+    $vcard =~ s/\r?\n/\r\n/gs;
+    $carddav->Request('PUT', 'Default/broken.vcf', $vcard,
+        'Content-Type' => 'text/vcard');
+
+    my $res = $jmap->request([
+        ['ContactCard/changes', { sinceState => $startState } ],
+    ]);
+    my $created = $res->single_sentence->arguments->{created};
+    $self->assert_num_equals(1, scalar $created->@*);
+    my $id = $created->[0];
+
+    $res = $jmap->request([ ['ContactCard/get', { ids => [$id] } ] ]);
+
+    my $got      = $res->single_sentence->arguments->{list};
+    my $notFound = $res->single_sentence->arguments->{notFound};
+
+    $self->assert(
+        ($got->@* == 1 && $got->[0]{id} eq $id)
+         || ($notFound->@* == 1 && $notFound->[0] eq $id),
+        "requested id must appear in either list or notFound"
+    );
+}

--- a/cassandane/tiny-tests/JMAPContacts/card_set_create_addresses_unknown_kind
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_create_addresses_unknown_kind
@@ -1,0 +1,53 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_set_create_addresses_unknown_kind
+    :min_version_3_9
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+    my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
+
+    # "streetAddress" is not a valid AddressComponent.kind per RFC 9553
+    # section 2.5.1.1; the street name kind is "name".  An unknown kind
+    # should be rejected with invalidProperties rather than silently
+    # stored as a JSPROP fallback that no CardDAV client can display.
+    my $res = $jmap->CallMethods([
+        ['ContactCard/set', {
+            create => {
+                "1" => {
+                    '@type' => 'Card',
+                    version => '1.0',
+                    uid => $id,
+                    name => { full => 'John Doe' },
+                    addresses => {
+                        a0 => {
+                            '@type' => 'Address',
+                            components => [
+                                {
+                                    kind => 'streetAddress',
+                                    value => '42 Rue de Rivoli'
+                                },
+                                {
+                                    kind => 'locality',
+                                    value => 'Paris'
+                                }
+                            ],
+                            countryCode => 'FR'
+                        }
+                    }
+                }
+            }
+        }, 'R1']
+    ]);
+
+    $self->assert_null($res->[0][1]{created}{1});
+    $self->assert_not_null($res->[0][1]{notCreated}{1});
+    $self->assert_str_equals("invalidProperties",
+                             $res->[0][1]{notCreated}{1}{type});
+    $self->assert_deep_equals(
+        ["addresses/a0/components[0]/kind"],
+        $res->[0][1]{notCreated}{1}{properties}
+    );
+}

--- a/cassandane/tiny-tests/JMAPContacts/card_set_create_name_unknown_kind
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_create_name_unknown_kind
@@ -7,20 +7,12 @@ sub test_card_set_create_name_unknown_kind
 {
     my $jmap = $self->{jmap};
 
-    my $service = $self->{instance}->get_service("http");
-    $ENV{DEBUGDAV} = 1;
-    my $carddav = Net::CardDAVTalk->new(
-        user => 'cassandane',
-        password => 'pass',
-        host => $service->host(),
-        port => $service->port(),
-        scheme => 'http',
-        url => '/',
-        expandurl => 1,
-    );
-
     my $id = 'ae2640cc-234a-4dd9-95cc-3106258445b9';
 
+    # "middle" is not a valid NameComponent.kind per RFC 9553 section
+    # 2.2.1.1; the value was renamed to "given2".  An unknown kind is
+    # rejected with invalidProperties rather than silently stored as a
+    # JSPROP fallback that no CardDAV client can display.
     my $res = $jmap->CallMethods([
         ['ContactCard/set', {
             create => {
@@ -59,16 +51,12 @@ sub test_card_set_create_name_unknown_kind
         }, 'R1']
     ]);
 
-    $self->assert_not_null($res->[0][1]{created}{1});
-
-    my $href = $res->[0][1]{created}{1}{'cyrusimap.org:href'};
-    $res = $carddav->Request('GET', $href, '',
-                             'Accept' => 'text/vcard; version=4.0');
-
-    my $card = $res->{content};
-    $card =~ s/\r?\n[ \t]+//gs;  # unfold long properties
-
-    $self->assert_matches(qr|JSPROP;JSPTR=name/components:|, $card);
-    $self->assert_matches(qr/FN;DERIVED=TRUE:No Name/, $card);
-    $self->assert_does_not_match(qr/\r\nN;/, $card);
+    $self->assert_null($res->[0][1]{created}{1});
+    $self->assert_not_null($res->[0][1]{notCreated}{1});
+    $self->assert_str_equals("invalidProperties",
+                             $res->[0][1]{notCreated}{1}{type});
+    $self->assert_deep_equals(
+        ["name/components[1]/kind"],
+        $res->[0][1]{notCreated}{1}{properties}
+    );
 }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -7977,8 +7977,22 @@ static json_t *jmap_card_from_vcard(const char *userid,
         json_t *patched = jmap_patchobject_apply(jcard, crock.patch, NULL, 0);
 
         json_decref(crock.patch);
-        json_decref(jcard);
-        jcard = patched;
+        if (patched) {
+            json_decref(jcard);
+            jcard = patched;
+        }
+        else {
+            /* The JSPTR of at least one of the JSPROP properties pointed into
+             * a JSContact subtree that the vCard-to-JSContact conversion did
+             * not reconstruct, so the patch could not be applied. Keep the
+             * unpatched card as defined in RFC 9555, Section 3.2.1.  The
+             * JSPROP contents are preserved in the stored vCard and a client
+             * that requests them directly can still retrieve them. */
+            syslog(LOG_NOTICE,
+                   "jmap_card_from_vcard: patch failed for record %u:%s",
+                   record  ? record->uid : 0,
+                   mailbox ? mailbox_name(mailbox) : "<none>");
+        }
     }
 
     /* Record properties */
@@ -8102,6 +8116,13 @@ static int getcards_cb(void *rock, struct carddav_data *cdata)
     obj = jmap_card_from_vcard(req->userid, vcard, crock->db,
                                crock->mailbox, &record, from_vcard_flags);
     vcardcomponent_free(vcard);
+
+    if (!obj) {
+        syslog(LOG_ERR, "jmap_card_from_vcard returned NULL for %u:%s",
+                cdata->dav.imap_uid, mailbox_name(crock->mailbox));
+        r = IMAP_INTERNAL;
+        goto done;
+    }
 
     if (!crock->args.disable_uri_as_blobid) {
         /* Only cache contacts with media as blobids */

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -9793,9 +9793,8 @@ static vcardproperty *_jscomps_to_vcard(struct jmap_parser *parser, json_t *obj,
             vcardstrarray *field;
 
             if (!ckind) {
-                jmap_parser_pop(parser);
-                _jsunknown_to_vcard(parser, "components", comps, myprops, card);
-                goto fail;
+                jmap_parser_invalid(parser, "kind");
+                break;
             }
 
             /* Add phonetic to proper field */


### PR DESCRIPTION
We're doing two jobs here:

1. stop accepting components with an unknown "kind", so we stop writing JSPROP properties that patch nonexistent patches
2. if we see one of those JSPROP properties, patching something that's null, don't turn the whole card into null, just discard the patch and log it