### PR TITLE
xapian_wrap.cpp: fix phrase search queries for CJK text

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_cjk_phrase
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_cjk_phrase
@@ -1,0 +1,70 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_cjk_phrase
+    :JMAPExtensions
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+use utf8;
+
+    # Create emails with bodies containing CJK text.
+    my %test_emails = (
+        # This contains the terms we'll query in phrase search:
+        match => '【デビットカード】ご利用のお知らせ',
+        # These contain the queried terms, but not in the right
+        # order for phrase search:
+        nomatch1 => '【デビットカード】ご利用不可のお知らせ',
+        nomatch2 => '【デビットカードご利用の方へ】臨時システムメンテナンスのお知らせ',
+    );
+
+    my %create_emails = map {
+        $_ => {
+            mailboxIds => {
+                '$inbox' => JSON::true
+            },
+            from => [{ email => 'foo@local' }],
+            to => [{ email => 'bar@local' }],
+            subject => $_,
+            bodyStructure => {
+                type => 'text/plain',
+                partId => 'part1',
+            },
+            bodyValues => {
+                part1 => {
+                    value => $test_emails{$_},
+                },
+            },
+        }
+    } keys %test_emails;
+
+    my $res = $jmap->CallMethods([
+        ['Email/set', {
+            create => \%create_emails,
+        }, 'R1'],
+    ]);
+
+    my $match_id = $res->[0][1]{created}{'match'}{id};
+    $self->assert_not_null($match_id);
+
+    xlog $self, "run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    # Now query for CJK phrase. Only the expected email must match.
+    $res = $jmap->CallMethods([
+        ['Email/query', {
+            filter => {
+                conditions => [{
+                    body => '"デビットカード"'
+                }, {
+                    body => '"ご利用のお知らせ"',
+                }],
+                operator => 'AND',
+            },
+        }, 'R1'],
+    ]);
+    $self->assert_deep_equals([ $match_id ], $res->[0][1]{ids});
+
+no utf8;
+}

--- a/imap/xapian_wrap.cpp
+++ b/imap/xapian_wrap.cpp
@@ -1986,18 +1986,23 @@ static Xapian::Query *xapian_query_new_match_word_break(const xapian_db_t *db,
                                                         const char *str)
 {
     std::string prefix(get_term_prefix(partnum));
+    unsigned flags = Xapian::QueryParser::FLAG_PHRASE |
+                     Xapian::QueryParser::FLAG_WILDCARD;
 
     Xapian::Query *q = new Xapian::Query {db->parser->parse_query(
             str,
 #if defined(USE_XAPIAN_WORD_BREAKS)
-            Xapian::QueryParser::FLAG_WORD_BREAKS,
+            flags | Xapian::QueryParser::FLAG_WORD_BREAKS,
 #elif defined(USE_XAPIAN_CJK_WORDS)
-            Xapian::QueryParser::FLAG_CJK_WORDS,
+            flags | Xapian::QueryParser::FLAG_CJK_WORDS,
 #else
-            Xapian::QueryParser::FLAG_CJK_NGRAM,
+            flags | Xapian::QueryParser::FLAG_CJK_NGRAM,
 #endif
             prefix)};
 
+    if (xapian_db_has_version_lower_than(db, 17)) {
+    // Before index version 17, fullwidth Latin characters were indexed
+    // capitalized. This requires special-handling.
 #if defined(USE_XAPIAN_WORD_BREAKS) || defined(USE_XAPIAN_CJK_WORDS)
     // There is a bug in Xapian v1.5 and CJK word segmentation, in which
     // a term starting with a fullwidth Latin character such as U+FF21
@@ -2027,6 +2032,7 @@ static Xapian::Query *xapian_query_new_match_word_break(const xapian_db_t *db,
         }
     }
 #endif
+    }
 
     return q;
 }


### PR DESCRIPTION
This fixes a bug where phrase queries for CJK text were queried as loose term search, e.g. the order of terms was irrelevant for a match.

This patch also disables a workaround for CJK text, unless the queried Xapian index has a legacy version. This is because the workaround is not compatible with phrase search queries. Rather than rewriting the workaround to deal with phrase search, the Xapian index should get reindexed in case of false positives.