### PR TITLE
cyr_expire.c: --prune-userflags does NOT take an argument

### DIFF
--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -857,7 +857,7 @@ static int parse_args(int argc, char *argv[], struct arguments *args)
         { "no-conversations", no_argument, NULL, 'c' },
         { "help", no_argument, NULL, 'h' },
         { "prefix", required_argument, NULL, 'p' },
-        { "prune-userflags", required_argument, NULL, 't' },
+        { "prune-userflags", no_argument, NULL, 't' },
         { "userid", required_argument, NULL, 'u' },
         { "verbose", no_argument, NULL, 'v' },
         { "no-expunge", no_argument, NULL, 'x' },


### PR DESCRIPTION
This PR previously had changes to reconstruct which have since been deemed unnecessary.  I have stripped this down to just the fix to cyr_expire