### PR TITLE
mboxname.c Don't re-encode already mUTF7-encoded detail part of localpart

### DIFF
--- a/cassandane/tiny-tests/Delivery/plus_address_mutf7
+++ b/cassandane/tiny-tests/Delivery/plus_address_mutf7
@@ -1,0 +1,64 @@
+#!perl
+use Cassandane::Tiny;
+use utf8;
+
+sub test_plus_address_mutf7
+    ($self)
+{
+    xlog $self, "Testing behaviour of plus addressing with mUTF7 mailbox names";
+
+    # IMAPTalk will mUTF7-encode mailbox name in CREATE/SELECT
+    my $imaptalk = $self->{store}->get_client();
+    $self->{store}->set_fetch_attributes('uid');
+
+    xlog $self, "Create folders";
+    $self->setup_mailbox_structure($imaptalk, [
+        [ 'create' => [ "foo", "☃", "a&b" ] ]
+    ]);
+
+    my %msgs;
+    my @testCases = ({
+        uid => 1,
+        plusaddr => "foo",
+        mailbox => "foo",
+    },
+    {
+        uid => 1,
+        plusaddr => "&JgM-", # mUTF7-encoded
+        mailbox => "☃",
+    },
+    {
+        uid => 1,
+        plusaddr => "a&b",
+        mailbox => "a&b",
+    },
+# Can't test UTF-8 plus address until we support SMTPUTF8
+#    {
+#        uid => 2,
+#        plusaddr => "☃",
+#        mailbox => "☃",
+#    },
+    {
+        uid => 2,
+        plusaddr => "a&-b", # mUTF7-encoded
+        mailbox => "a&b",
+    });
+
+    foreach my $tc (@testCases) {
+        my $uid = $tc->{uid};
+
+        if (!$msgs{$uid}) {
+            xlog $self, "Create message $uid";
+            $msgs{$uid} = $self->{gen}->generate(subject => "Message $uid");
+            $msgs{$uid}->set_attribute(uid => $uid);
+        }
+
+        xlog $self, "Deliver message $uid";
+        $self->{instance}->deliver($msgs{$uid},
+                                   user => "cassandane+$tc->{plusaddr}");
+
+        xlog $self, "Check that the message made it";
+        $self->{store}->set_folder($tc->{mailbox});
+        $self->check_messages(\%msgs, check_guid => 0, keyed_on => 'uid');
+    }
+}

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -386,6 +386,9 @@ EXPORTED mbname_t *mbname_from_userid(const char *userid)
     return mbname;
 }
 
+static const char b64mbox[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,";
+
 EXPORTED mbname_t *mbname_from_recipient(const char *recipient, const struct namespace *ns)
 {
     mbname_t *mbname = xzmalloc(sizeof(mbname_t));
@@ -410,20 +413,34 @@ EXPORTED mbname_t *mbname_from_recipient(const char *recipient, const struct nam
 
     char *plus = strchr(mbname->localpart, '+');
     if (plus) {
+        bool is_mutf7 = false;
+        char *encoded = NULL;
         char sep[2];
         sep[0] = ns->hier_sep;
         sep[1] = '\0';
-        *plus = '\0';
+        *plus++ = '\0';
 
-        /* Encode mailbox name in IMAP UTF-7 */
-        charset_t cs = charset_lookupname("utf-8");
-        char *detail =
-            charset_to_imaputf7(plus+1, strlen(plus+1), cs, ENCODING_NONE);
+        /* Is 'detail' already IMAP UTF-7 encoded? */
+        const char *shift = strchr(plus, '&');
+        if (shift) {
+            /* Is this followed by only modified Base64 and unshift? */
+            size_t len = strspn(++shift, b64mbox);
+            if (*(shift+len) == '-') {
+                is_mutf7 = true;
+            }
+        }
 
-        mbname->boxes = strarray_split(detail, sep, /*flags*/0);
+        if (!is_mutf7) {
+            /* Encode mailbox name in IMAP UTF-7 */
+            charset_t cs = charset_lookupname("utf-8");
+            plus = encoded =
+                charset_to_imaputf7(plus, strlen(plus), cs, ENCODING_NONE);
 
-        charset_free(&cs);
-        free(detail);
+            charset_free(&cs);
+        }
+
+        mbname->boxes = strarray_split(plus, sep, /*flags*/0);
+        free(encoded);
     }
     else
         mbname->boxes = strarray_new();


### PR DESCRIPTION
If we received an email for foo+&JgM-@example.com, we were re-encoding the detail as &-JgM-

This fixes #5925