### PR TITLE
userdeny_db.c: add defensive check for resolved userid in userdeny function

### DIFF
--- a/imap/userdeny_db.c
+++ b/imap/userdeny_db.c
@@ -88,6 +88,8 @@ EXPORTED int userdeny(const char *user, const char *service, char *msgbuf, size_
 
     init_internal();
 
+    if (!user || !*user) return 0;
+
     if (!denydb) denydb_open(/*create*/0);
     if (!denydb) return 0;
 


### PR DESCRIPTION
This PR is a fix for #5930

I fixed this defensively in userdeny() by returning "not denied" early when user is null or empty, which preserves existing default-allow behavior and prevents unsafe DB fetch/logging calls. This makes the API robust for all callers, including smmapd, and avoids crashes without changing deny behavior for normal valid userids