### PR TITLE
caldav_util.c: Limit msg Subject to the first 1k chars of SUMMARY

### DIFF
--- a/cassandane/tiny-tests/Caldav/put_huge_summary
+++ b/cassandane/tiny-tests/Caldav/put_huge_summary
@@ -1,0 +1,36 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_put_huge_summary ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $href = "$CalendarId/huge-summary.ics";
+    my $summary = ('x') x 95000;
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+DTEND:20160831T183000Z
+TRANSP:OPAQUE
+SUMMARY:$summary
+DTSTART:20160831T153000Z
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+UID:xyz
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    # Without the fix in Cyrus this will return a 500 (Internal Server Error)
+    # due to an assert() on a NULL resource URI
+    my $res = $CalDAV->SafeRequest('PUT', $href, $card,
+                                   'Content-Type' => 'text/calendar');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+}

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1137,8 +1137,22 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
     const char *summary = icalcomponent_get_summary(comp);
     if (summary) {
         int force = !!strchr(summary, '\n'); // force encoding if embedded LF
+        size_t limit = 1024, len = strlen(summary);
+        struct buf buf = BUF_INITIALIZER;
 
-        mimehdr = charset_encode_mimeheader(summary, 0, force);
+        /* Limit the subject to the first 1k chars of the SUMMARY.
+         * Otherwise, if the SUMMARY is huge, we could end up with more
+         * than 1000 header lines and we will fail to find the
+         * Content-Disposition header, and therefore have no resource URI.
+         */
+        if (len > limit) {
+            buf_setcstr(&buf, summary);
+            buf_truncate_utf8(&buf, 1024);
+            summary = buf_base(&buf);
+            len = buf_len(&buf);
+        }
+        mimehdr = charset_encode_mimeheader(summary, len, force);
+        buf_free(&buf);
 
         /*  trim trailing WS (LF will break our MIME message header) */
         char *end = mimehdr + strlen(mimehdr) - 1;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -758,56 +758,6 @@ static struct header_prop *_header_parseprop(const char *s)
     return hprop;
 }
 
-/* Generate a preview of text of at most len bytes, excluding the zero
- * byte.
- *
- * Consecutive whitespaces, including newlines, are collapsed to a single
- * blank. If text is longer than len and len is greater than 4, then return
- * a string  ending in '...' and holding as many complete UTF-8 characters,
- * that the total byte count of non-zero characters is at most len.
- *
- * The input string must be properly encoded UTF-8 */
-static char *_email_extract_preview(const char *text, size_t len)
-{
-    unsigned char *dst, *d, *t;
-    size_t n;
-
-    if (!text) {
-        return NULL;
-    }
-
-    /* Replace all whitespace with single blanks. */
-    dst = (unsigned char *) xzmalloc(len+1);
-    for (t = (unsigned char *) text, d = dst; *t && d < (dst+len); ++t, ++d) {
-        *d = isspace(*t) ? ' ' : *t;
-        if (isspace(*t)) {
-            while(isspace(*++t))
-                ;
-            --t;
-        }
-    }
-    n = d - dst;
-
-    /* Anything left to do? */
-    if (n < len || len <= 4) {
-        return (char*) dst;
-    }
-
-    /* Append trailing ellipsis. */
-    dst[--n] = '.';
-    dst[--n] = '.';
-    dst[--n] = '.';
-    while (n && (dst[n] & 0xc0) == 0x80) {
-        dst[n+2] = 0;
-        dst[--n] = '.';
-    }
-    if (dst[n] >= 0x80) {
-        dst[n+2] = 0;
-        dst[--n] = '.';
-    }
-    return (char *) dst;
-}
-
 struct _email_mailboxes_rock {
     jmap_req_t *req;
     json_t *mboxs;
@@ -8299,10 +8249,12 @@ static int _email_get_bodies(jmap_req_t *req,
             if (text) {
                 int64_t len = config_getbytesize(IMAPOPT_JMAP_PREVIEW_LENGTH, 'B');
                 if (len < 0) len = 0;
-                char *preview = _email_extract_preview(text, len);
-                json_object_set_new(email, "preview", json_string(preview));
-                free(preview);
-                free(text);
+                struct buf preview = BUF_INITIALIZER;
+                buf_initmcstr(&preview, text);
+                buf_truncate_utf8(&preview, len);
+                json_object_set_new(email, "preview",
+                                    json_string(buf_cstring(&preview)));
+                buf_free(&preview);
             }
         }
     }

--- a/lib/buf.c
+++ b/lib/buf.c
@@ -702,3 +702,51 @@ EXPORTED void buf_trim(struct buf *buf)
         buf_truncate(buf, i);
     }
 }
+
+/* Truncate a buffer of UTF-8 text to at most len bytes.
+ *
+ * Consecutive whitespaces, including newlines, are collapsed to a single
+ * blank. If text is longer than len and len is greater than 4, then return
+ * a string ending in '...' and holding as many complete UTF-8 characters,
+ * such that the total byte count of non-zero characters is at most len.
+ *
+ * The input string must be properly encoded UTF-8.
+ */
+EXPORTED void buf_truncate_utf8(struct buf *buf, size_t len)
+{
+    unsigned char *dst, *d;
+    size_t i, n;
+
+    dst = (unsigned char *) buf->s;
+
+    /* Replace all whitespace with single blanks. */
+    for (i = 0, d = dst; len && i < buf->len; ++i, ++d, --len) {
+        if (isspace(buf->s[i])) {
+            *d = ' ';
+            while (isspace(buf->s[i+1]) && ++i < buf->len);
+        }
+        else {
+            *d = buf->s[i];
+        }
+    }
+    n = d - dst;
+
+    if (i < buf->len && n > 4) {
+        /* Append trailing ellipsis. */
+        dst[--n] = '.';
+        dst[--n] = '.';
+        dst[--n] = '.';
+        while (n && (dst[n] & 0xc0) == 0x80) {
+            dst[n+2] = 0;
+            dst[--n] = '.';
+        }
+        if (dst[n] >= 0x80) {
+            dst[n+2] = 0;
+            dst[--n] = '.';
+        }
+
+        n += 3;
+    }
+
+    buf->len = n;
+}

--- a/lib/buf.h
+++ b/lib/buf.h
@@ -79,5 +79,6 @@ const char *buf_lcase(struct buf *buf);
 const char *buf_ucase(struct buf *buf);
 const char *buf_tocrlf(struct buf *buf);
 void buf_trim(struct buf *buf);
+void buf_truncate_utf8(struct buf *buf, size_t len);
 
 #endif


### PR DESCRIPTION
Otherwise, if the SUMMARY is huge, we could end up with more than 1000 header lines and we will fail to find the Content-Disposition header, and therefore have no resource URI.