### PR TITLE
jmap_mail.c: always set mandatory EmailBodyPart.type property

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_get_bodypart_default_type
+++ b/cassandane/tiny-tests/JMAPEmail/email_get_bodypart_default_type
@@ -1,0 +1,96 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_get_bodypart_default_type
+    ($self)
+{
+    my $jmap   = $self->{jmap};
+    my $imap   = $self->{store}->get_client();
+
+    my $mime = <<'EOF';
+From: <from@local>
+To: <to@local>
+Subject: msgTopLevel
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+Message-ID: <message-id-1@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain
+
+msgTopLevel
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $mime) || die $@;
+
+    $mime = <<'EOF';
+From: <from@local>
+To: <to@local>
+Subject: msgMultipart
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+Message-ID: <message-id-2@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/related;
+ boundary=37484ccfd6bb443d87a53fcee72c041d
+
+--37484ccfd6bb443d87a53fcee72c041d
+Content-Transfer-Encoding: 7bit
+
+msgMultiPart
+
+--37484ccfd6bb443d87a53fcee72c041d
+Content-Type: multipart/digest;
+ boundary=7741d241dde04e55ba27092968fec0ba
+
+
+--7741d241dde04e55ba27092968fec0ba
+
+From: <from@local>
+To: <to@local>
+Subject: embeddedMsg
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+Message-ID: <message-id-3@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain
+
+embeddedMsg
+--7741d241dde04e55ba27092968fec0ba--
+
+--37484ccfd6bb443d87a53fcee72c041d--
+EOF
+    $mime =~ s/\r?\n/\r\n/gs;
+    $imap->append('INBOX', $mime) || die $@;
+
+    xlog $self, "Assert all emails belong to the same thread";
+    my $res = $jmap->CallMethods([
+        [ 'Email/query', {}, 'R1' ],
+        [
+            'Email/get',
+            {
+                '#ids' => {
+                    resultOf => 'R1',
+                    name     => 'Email/query',
+                    path     => '/ids'
+                },
+                properties => [ 'subject', 'bodyStructure' ],
+            },
+            'R2'
+        ],
+    ]);
+
+    my %emails = map { $_->{subject} => $_ } @{$res->[1][1]{list}};
+
+    $self->assert_cmp_deeply(superhashof({
+        type => 'text/plain'
+    }), $emails{msgTopLevel}->{bodyStructure});
+
+    $self->assert_cmp_deeply(superhashof({
+        type => 'multipart/related',
+        subParts => [superhashof({
+            type => 'text/plain'
+        }), superhashof({
+            type => 'multipart/digest',
+            subParts => [superhashof({
+                type => 'message/rfc822'
+            })],
+        })],
+    }), $emails{msgMultipart}->{bodyStructure});
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7698,6 +7698,7 @@ static void emailbodypart_read_name(struct buf *buf, const struct body *part)
 static json_t *_email_get_bodypart(jmap_req_t *req,
                                    struct email_getargs *args,
                                    struct cyrusmsg *msg,
+                                   const struct body *parent,
                                    const struct body *part)
 {
     struct buf buf = BUF_INITIALIZER;
@@ -7789,12 +7790,32 @@ static json_t *_email_get_bodypart(jmap_req_t *req,
     }
 
     /* type */
-    if (jmap_wantprop(bodyprops, "type") && part->type) {
-        buf_setcstr(&buf, part->type);
-        if (part->subtype) {
-            buf_appendcstr(&buf, "/");
-            buf_appendcstr(&buf, part->subtype);
+    if (jmap_wantprop(bodyprops, "type")) {
+        if (part->type) {
+            buf_setcstr(&buf, part->type);
+            if (part->subtype) {
+                buf_appendcstr(&buf, "/");
+                buf_appendcstr(&buf, part->subtype);
+            }
         }
+        else {
+            // Set default type, the 'type' property is mandatory.
+            if (part->numparts) {
+                // Non-standard: this indicates an error with the
+                // parsed bodystructure. Deal with it gracefully.
+                buf_setcstr(&buf, "multipart/related");
+            }
+            // Set default types according to RFC 2046.
+            else if (parent &&
+                !strcasecmpsafe(parent->type, "multipart") &&
+                !strcasecmpsafe(parent->subtype, "digest")) {
+                buf_setcstr(&buf, "message/rfc822");
+            }
+            else {
+                buf_setcstr(&buf, "text/plain");
+            }
+        }
+
         json_object_set_new(jbodypart, "type", json_string(buf_lcase(&buf)));
     }
 
@@ -7905,7 +7926,7 @@ static json_t *_email_get_bodypart(jmap_req_t *req,
         for (i = 0; i < part->numparts; i++) {
             struct body *subpart = part->subpart + i;
             json_array_append_new(subparts,
-                    _email_get_bodypart(req, args, msg, subpart));
+                    _email_get_bodypart(req, args, msg, part, subpart));
 
         }
         json_object_set_new(jbodypart, "subParts", subparts);
@@ -8066,7 +8087,7 @@ static int _email_get_bodies(jmap_req_t *req,
     /* bodyStructure */
     if (jmap_wantprop(props, "bodyStructure")) {
         json_object_set_new(email, "bodyStructure",
-                _email_get_bodypart(req, args, msg, part));
+                _email_get_bodypart(req, args, msg, NULL, part));
     }
 
     /* bodyValues */
@@ -8121,7 +8142,7 @@ static int _email_get_bodies(jmap_req_t *req,
         for (i = 0; i < bodies.textlist.count; i++) {
             struct body *part = ptrarray_nth(&bodies.textlist, i);
             json_array_append_new(text_body,
-                    _email_get_bodypart(req, args, msg, part));
+                    _email_get_bodypart(req, args, msg, NULL, part));
         }
         json_object_set_new(email, "textBody", text_body);
     }
@@ -8133,7 +8154,7 @@ static int _email_get_bodies(jmap_req_t *req,
         for (i = 0; i < bodies.htmllist.count; i++) {
             struct body *part = ptrarray_nth(&bodies.htmllist, i);
             json_array_append_new(html_body,
-                    _email_get_bodypart(req, args, msg, part));
+                    _email_get_bodypart(req, args, msg, NULL, part));
         }
         json_object_set_new(email, "htmlBody", html_body);
     }
@@ -8145,7 +8166,7 @@ static int _email_get_bodies(jmap_req_t *req,
         for (i = 0; i < bodies.attslist.count; i++) {
             struct body *part = ptrarray_nth(&bodies.attslist, i);
             json_array_append_new(attachments,
-                    _email_get_bodypart(req, args, msg, part));
+                    _email_get_bodypart(req, args, msg, NULL, part));
         }
         json_object_set_new(email, "attachments", attachments);
     }


### PR DESCRIPTION
This updates Email/get to always set the 'type' property of an EmailBodyPart object, even if the type field is NULL in the Cyrus-internal bodypart structure.