### PR TITLE
sphinxlocal cleanup

### DIFF
--- a/docsrc/exts/sphinxlocal/builders/gitstamp.py
+++ b/docsrc/exts/sphinxlocal/builders/gitstamp.py
@@ -90,3 +90,8 @@ def what_build_am_i(app):
 # know what the build output format is.
 def setup(app):
     app.connect('builder-inited', what_build_am_i)
+    return {
+        # XXX Are we parallel r/w safe? Dunno! Say we're not, just in case.
+        'parallel_read_safe': False,
+        'parallel_write_safe': False,
+    }

--- a/docsrc/exts/sphinxlocal/roles/cyrusman.py
+++ b/docsrc/exts/sphinxlocal/roles/cyrusman.py
@@ -1,35 +1,13 @@
-"""
-    sphinxlocal.roles.cyrusman
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-    Turn :cyrusman: links into manpage references to the cyrus imap doc tree
-
-    :version: 0.1
-    :author: Nicola Nye <nicolan@fastmail.com>
-
-    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
-    :license: BSD, see LICENSE for details.
-"""
-
-from sphinx.errors import SphinxError
-from docutils import nodes, utils
-from docutils.parsers.rst.roles import set_classes
-from string import Template
-import re
-
-try:
-    from sphinx.util import logging
-    logger = logging.getLogger(__name__)
-except:
-    logger = None
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+import docutils
 
 def setup(app):
-    global logger
-    if logger is None:
-        logger = app
-    logger.info('Initializing cyrusman plugin')
-    app.add_crossref_type('cyrusman', 'cyrusman', '%s', nodes.generated)
-    return
-
-class CyrusManExtension(SphinxError):
-        category = ':cyrusman: error'
+    app.add_crossref_type('cyrusman',
+                          'cyrusman',
+                          '%s',
+                          docutils.nodes.generated)
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docsrc/exts/sphinxlocal/roles/imapdconf.py
+++ b/docsrc/exts/sphinxlocal/roles/imapdconf.py
@@ -8,4 +8,7 @@ def setup(app):
                           'imapdconf',
                           'single: %s',
                           docutils.nodes.literal)
-    return
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docsrc/exts/sphinxlocal/sitemap.py
+++ b/docsrc/exts/sphinxlocal/sitemap.py
@@ -69,3 +69,8 @@ def what_build_am_i(app):
 def setup(app):
     app.add_config_value("sitemap_website", None, '')
     app.connect('builder-inited', what_build_am_i)
+    return {
+        # XXX Are we parallel r/w safe? Dunno! Say we're not, just in case.
+        'parallel_read_safe': False,
+        'parallel_write_safe': False,
+    }


### PR DESCRIPTION
Sphinx 7 was complaining that cyrusman.py doesn't indicate whether or not it supports parallel read/write, and was falling back to serial mode.  I've fixed cyrusman.py to indicate that it does, assuming that that is true because the script is very simple.  While in there, I also removed a heap of unneccesary clutter that made it look far more complicated than it actually is.

Once I fixed cyrusman.py, it started complaining about the next one, and so on.  So I have updated all of them, thus:

* cyrusman.py: supports parallel r/w
* imapdconf.py: ditto
* gitstamp:py: does not support parallel r/w (it might, but I don't know that at a glance)
* sitemap.py: ditto

Sphinx still complains, but now it complains that gitstamp.py or sitemap.py (whichever it examines first) _doesn't support_ parallel r/w, instead of complaining that it _doesn't know_.  So I haven't fixed the "sphinx complains" issue but I've at least made things a little better.