### PR TITLE
imapoptions: automate duration/bytesize unit handling

### DIFF
--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -250,7 +250,7 @@ static void test_duration_value_days(void)
         "timeout: 3d\n"
     );
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_TIMEOUT);
     CU_ASSERT_EQUAL(timeout, 3 * 24 * 60 * 60);
 }
 
@@ -263,7 +263,7 @@ static void test_duration_value_hours(void)
         "timeout: 3h\n"
     );
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_TIMEOUT);
     CU_ASSERT_EQUAL(timeout, 3 * 60 * 60);
 }
 
@@ -276,7 +276,7 @@ static void test_duration_value_minutes(void)
         "timeout: 45m\n"
     );
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_TIMEOUT);
     CU_ASSERT_EQUAL(timeout, 45 * 60);
 }
 
@@ -289,7 +289,7 @@ static void test_duration_value_seconds(void)
         "timeout: 25s\n"
     );
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_TIMEOUT);
     CU_ASSERT_EQUAL(timeout, 25);
 }
 
@@ -302,30 +302,37 @@ static void test_duration_value_combined(void)
         "timeout: 1h30m\n"
     );
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_TIMEOUT);
     CU_ASSERT_EQUAL(timeout, 1.5 * 60 * 60);
 }
 
 static void test_duration_value_nounits(void)
 {
-    int timeout = -1;
+    static const struct {
+        enum imapopt opt;
+        int multiplier;
+    } tests[] = {
+        { IMAPOPT_IMAPIDLEPOLL, 1 }, /* implicitly seconds */
+        { IMAPOPT_TIMEOUT, 60 }, /* Default-Unit: m */
+        /* we don't have a DURATION option with Default-Unit: h */
+        { IMAPOPT_ARCHIVE_AFTER, 60 * 60 * 24 }, /* Default-Unit: d */
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
+        "imapidlepoll: 13\n"
         "timeout: 13\n"
+        "archive_after: 13\n"
     );
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 's');
-    CU_ASSERT_EQUAL(timeout, 13);
+    for (i = 0; i < n_tests; i++) {
+        int duration = -1;
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 'm');
-    CU_ASSERT_EQUAL(timeout, 13 * 60);
-
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 'h');
-    CU_ASSERT_EQUAL(timeout, 13 * 60 * 60);
-
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 'd');
-    CU_ASSERT_EQUAL(timeout, 13 * 60 * 60 * 24);
+        duration = config_getduration(tests[i].opt);
+        CU_ASSERT_EQUAL(duration, 13 * tests[i].multiplier);
+    }
 }
 
 static void test_duration_value_negative(void)
@@ -337,7 +344,7 @@ static void test_duration_value_negative(void)
         "caldav_historical_age: -1\n"
     );
 
-    caldav_historical_age = config_getduration(IMAPOPT_CALDAV_HISTORICAL_AGE, 'd');
+    caldav_historical_age = config_getduration(IMAPOPT_CALDAV_HISTORICAL_AGE);
     CU_ASSERT_EQUAL(caldav_historical_age, -1 * 60 * 60 * 24);
 }
 
@@ -350,7 +357,7 @@ static void test_duration_default(void)
         /* timeout: 32m (default) */
     );
 
-    timeout = config_getduration(IMAPOPT_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_TIMEOUT);
     CU_ASSERT_EQUAL(timeout, 32 * 60);
 }
 
@@ -363,7 +370,7 @@ static void test_duration_nodefault(void)
         /* plaintextloginpause: <none> (default) */
     );
 
-    plaintextloginpause = config_getduration(IMAPOPT_PLAINTEXTLOGINPAUSE, 's');
+    plaintextloginpause = config_getduration(IMAPOPT_PLAINTEXTLOGINPAUSE);
     CU_ASSERT_EQUAL(plaintextloginpause, 0);
 }
 
@@ -1002,13 +1009,13 @@ static void test_deprecated_duration(void)
 
     /* should not be able to read the deprecated name */
     CU_EXPECT_CYRFATAL_BEGIN;
-    val = config_getduration(IMAPOPT_ARCHIVE_DAYS, 'd');
+    val = config_getduration(IMAPOPT_ARCHIVE_DAYS);
     CU_EXPECT_CYRFATAL_END(EX_SOFTWARE,
         "Option 'archive_days' is deprecated in favor of "
         "'archive_after' since version 3.1.8.");
 
     /* should be able to read it at the new name */
-    val = config_getduration(IMAPOPT_ARCHIVE_AFTER, 'd');
+    val = config_getduration(IMAPOPT_ARCHIVE_AFTER);
     CU_ASSERT_EQUAL(val, 8 * 24 * 60 * 60);
 
     /* set the new name */
@@ -1020,7 +1027,7 @@ static void test_deprecated_duration(void)
     CU_ASSERT_SYSLOG(/*all*/0, 0);
 
     /* should be able to read it at the new name */
-    val = config_getduration(IMAPOPT_ARCHIVE_AFTER, 'd');
+    val = config_getduration(IMAPOPT_ARCHIVE_AFTER);
     CU_ASSERT_EQUAL(val, 12 * 24 * 60 * 60);
 
     /* set both names to different values */
@@ -1033,7 +1040,7 @@ static void test_deprecated_duration(void)
     CU_ASSERT_SYSLOG(/*all*/0, 1);
 
     /* should read new value at the new name */
-    val = config_getduration(IMAPOPT_ARCHIVE_AFTER, 'd');
+    val = config_getduration(IMAPOPT_ARCHIVE_AFTER);
     CU_ASSERT_EQUAL(val, 12 * 24 * 60 * 60);
 }
 

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -496,7 +496,7 @@ static void test_bytesize_value_gibibytes(void)
         "archive_maxsize: 1G\n"
     );
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE);
     CU_ASSERT_EQUAL(archive_maxsize, 1LL * 1024 * 1024 * 1024);
 }
 
@@ -509,7 +509,7 @@ static void test_bytesize_value_mebibytes(void)
         "archive_maxsize: 3M\n"
     );
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE);
     CU_ASSERT_EQUAL(archive_maxsize, 3LL * 1024 * 1024);
 }
 
@@ -522,7 +522,7 @@ static void test_bytesize_value_kibibytes(void)
         "archive_maxsize: 45K\n"
     );
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE);
     CU_ASSERT_EQUAL(archive_maxsize, 45LL * 1024);
 }
 
@@ -535,52 +535,62 @@ static void test_bytesize_value_bytes(void)
         "archive_maxsize: 25B\n"
     );
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'B');
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE);
     CU_ASSERT_EQUAL(archive_maxsize, 25LL);
 }
 
 static void test_bytesize_value_nounits(void)
 {
-    int64_t archive_maxsize = -1LL;
+    static const struct {
+        enum imapopt opt;
+        int64_t multiplier;
+    } tests[] = {
+        { IMAPOPT_MAXMESSAGESIZE, 1 }, /* implicitly seconds */
+        { IMAPOPT_ARCHIVE_MAXSIZE, 1024 }, /* Default-Unit: K */
+        /* we don't have BYTESIZE options with Default-Unit: M or G */
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
+        "maxmessagesize: 13\n"
         "archive_maxsize: 13\n"
     );
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'B');
-    CU_ASSERT_EQUAL(archive_maxsize, 13LL);
+    for (i = 0; i < n_tests; i++) {
+        int64_t bytesize = -1;
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
-    CU_ASSERT_EQUAL(archive_maxsize, 13LL * 1024);
-
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'M');
-    CU_ASSERT_EQUAL(archive_maxsize, 13LL * 1024 * 1024);
-
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'G');
-    CU_ASSERT_EQUAL(archive_maxsize, 13LL * 1024 * 1024 * 1024);
+        bytesize = config_getbytesize(tests[i].opt);
+        CU_ASSERT_EQUAL(bytesize, 13 * tests[i].multiplier);
+    }
 }
 
 static void test_bytesize_value_negative(void)
 {
-    int64_t archive_maxsize = 0xdeadbeef;
+    static const struct {
+        enum imapopt opt;
+        int64_t multiplier;
+    } tests[] = {
+        { IMAPOPT_MAXMESSAGESIZE, 1 }, /* implicitly seconds */
+        { IMAPOPT_ARCHIVE_MAXSIZE, 1024 }, /* Default-Unit: K */
+        /* we don't have BYTESIZE options with Default-Unit: M or G */
+    };
+    const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
+    unsigned i;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
+        "maxmessagesize: -1\n"
         "archive_maxsize: -1\n"
     );
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'B');
-    CU_ASSERT_EQUAL(archive_maxsize, -1LL);
+    for (i = 0; i < n_tests; i++) {
+        int64_t bytesize = -1;
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
-    CU_ASSERT_EQUAL(archive_maxsize, -1LL * 1024);
-
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'M');
-    CU_ASSERT_EQUAL(archive_maxsize, -1LL * 1024 * 1024);
-
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'G');
-    CU_ASSERT_EQUAL(archive_maxsize, -1LL * 1024 * 1024 * 1024);
+        bytesize = config_getbytesize(tests[i].opt);
+        CU_ASSERT_EQUAL(bytesize, -1 * tests[i].multiplier);
+    }
 }
 
 static void test_bytesize_default(void)
@@ -592,7 +602,7 @@ static void test_bytesize_default(void)
         /* archive_maxsize: 1024 K (default) */
     );
 
-    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    archive_maxsize = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE);
     CU_ASSERT_EQUAL(archive_maxsize, 1024LL * 1024);
 }
 
@@ -1060,13 +1070,13 @@ static void test_deprecated_bytesize(void)
 
     /* should not be able to read the deprecated name */
     CU_EXPECT_CYRFATAL_BEGIN;
-    val = config_getbytesize(IMAPOPT_AUTOCREATEQUOTA, 'K');
+    val = config_getbytesize(IMAPOPT_AUTOCREATEQUOTA);
     CU_EXPECT_CYRFATAL_END(EX_SOFTWARE,
         "Option 'autocreatequota' is deprecated in favor of "
         "'autocreate_quota' since version 2.5.0.");
 
     /* should be able to read it at the new name */
-    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA);
     CU_ASSERT_EQUAL(val, 8LL * 1024);
 
     /* set the new name */
@@ -1078,7 +1088,7 @@ static void test_deprecated_bytesize(void)
     CU_ASSERT_SYSLOG(/*all*/0, 0);
 
     /* should be able to read it at the new name */
-    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA);
     CU_ASSERT_EQUAL(val, 12LL * 1024 * 1024);
 
     /* set both names to different values */
@@ -1091,7 +1101,7 @@ static void test_deprecated_bytesize(void)
     CU_ASSERT_SYSLOG(/*all*/0, 1);
 
     /* should read new value at the new name */
-    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+    val = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA);
     CU_ASSERT_EQUAL(val, 12LL * 1024 * 1024);
 }
 

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -243,7 +243,7 @@ static void test_bitfield_invalid(void)
 
 static void test_duration_value_days(void)
 {
-    int timeout = -1;
+    int32_t timeout = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -256,7 +256,7 @@ static void test_duration_value_days(void)
 
 static void test_duration_value_hours(void)
 {
-    int timeout = -1;
+    int32_t timeout = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -269,7 +269,7 @@ static void test_duration_value_hours(void)
 
 static void test_duration_value_minutes(void)
 {
-    int timeout = -1;
+    int32_t timeout = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -282,7 +282,7 @@ static void test_duration_value_minutes(void)
 
 static void test_duration_value_seconds(void)
 {
-    int timeout = -1;
+    int32_t timeout = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -295,7 +295,7 @@ static void test_duration_value_seconds(void)
 
 static void test_duration_value_combined(void)
 {
-    int timeout = -1;
+    int32_t timeout = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -328,7 +328,7 @@ static void test_duration_value_nounits(void)
     );
 
     for (i = 0; i < n_tests; i++) {
-        int duration = -1;
+        int32_t duration = -1;
 
         duration = config_getduration(tests[i].opt);
         CU_ASSERT_EQUAL(duration, 13 * tests[i].multiplier);
@@ -337,7 +337,7 @@ static void test_duration_value_nounits(void)
 
 static void test_duration_value_negative(void)
 {
-    int caldav_historical_age = 0xdeadbeef;
+    int32_t caldav_historical_age = 0xdeadbeef;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -350,7 +350,7 @@ static void test_duration_value_negative(void)
 
 static void test_duration_default(void)
 {
-    int timeout = -1;
+    int32_t timeout = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -363,7 +363,7 @@ static void test_duration_default(void)
 
 static void test_duration_nodefault(void)
 {
-    int plaintextloginpause = -1;
+    int32_t plaintextloginpause = -1;
 
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
@@ -1007,7 +1007,7 @@ static void test_deprecated_duration(void)
 {
     /* { "archive_days", "7d", DURATION, "3.1.8", "archive_after" } */
     /* { "archive_after", "7d", DURATION } */
-    int val;
+    int32_t val;
 
     /* set the deprecated name only */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -529,10 +529,10 @@ EXPORTED void attachextract_init(struct protstream *clientin)
 
     /* Read config */
     attachextract_idle_timeout =
-        config_getduration(IMAPOPT_SEARCH_ATTACHMENT_EXTRACTOR_IDLE_TIMEOUT, 's');
+        config_getduration(IMAPOPT_SEARCH_ATTACHMENT_EXTRACTOR_IDLE_TIMEOUT);
 
     attachextract_request_timeout =
-        config_getduration(IMAPOPT_SEARCH_ATTACHMENT_EXTRACTOR_REQUEST_TIMEOUT, 's');
+        config_getduration(IMAPOPT_SEARCH_ATTACHMENT_EXTRACTOR_REQUEST_TIMEOUT);
 
     if (attachextract_idle_timeout < attachextract_request_timeout)
         attachextract_idle_timeout = attachextract_request_timeout;

--- a/imap/autocreate.c
+++ b/imap/autocreate.c
@@ -662,7 +662,7 @@ done:
 int autocreate_user(struct namespace *namespace, const char *userid)
 {
     int r = IMAP_MAILBOX_NONEXISTENT; /* default error if we break early */
-    int64_t autocreatequota = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+    int64_t autocreatequota = config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA);
     int autocreatequotamessage = config_getint(IMAPOPT_AUTOCREATE_QUOTA_MESSAGES);
     int n;
     struct auth_state *auth_state = NULL;

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -898,7 +898,7 @@ EXPORTED struct backend *backend_connect_pipe(int infd, int outfd,
     ret->in = prot_new(infd, 0);
     ret->out = prot_new(outfd, 1);
     ret->sock = -1;
-    prot_settimeout(ret->in, config_getduration(IMAPOPT_CLIENT_TIMEOUT, 's'));
+    prot_settimeout(ret->in, config_getduration(IMAPOPT_CLIENT_TIMEOUT));
     prot_setflushonread(ret->in, ret->out);
     ret->prot = prot;
 
@@ -1045,7 +1045,7 @@ EXPORTED struct backend *backend_connect(struct backend *ret_backend, const char
             int n;
             fd_set wfds, rfds;
             time_t now = time(NULL);
-            time_t timeout = now + config_getduration(IMAPOPT_CLIENT_TIMEOUT, 's');
+            time_t timeout = now + config_getduration(IMAPOPT_CLIENT_TIMEOUT);
             struct timeval waitfor;
 
             /* select() socket for writing until we succeed, fail, or timeout */
@@ -1098,7 +1098,7 @@ EXPORTED struct backend *backend_connect(struct backend *ret_backend, const char
     ret->in = prot_new(sock, 0);
     ret->out = prot_new(sock, 1);
     ret->sock = sock;
-    prot_settimeout(ret->in, config_getduration(IMAPOPT_CLIENT_TIMEOUT, 's'));
+    prot_settimeout(ret->in, config_getduration(IMAPOPT_CLIENT_TIMEOUT));
     prot_setflushonread(ret->in, ret->out);
     ret->prot = prot;
 

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -80,7 +80,7 @@ EXPORTED int caldav_alarm_init(void)
     }
 
     min_interval =
-        config_getduration(IMAPOPT_CALENDAR_MINIMUM_ALARM_INTERVAL, 'm');
+        config_getduration(IMAPOPT_CALENDAR_MINIMUM_ALARM_INTERVAL);
     if (min_interval < 0) min_interval = 0;
 
     return sqldb_init();
@@ -194,7 +194,7 @@ static sqldb_t *caldav_alarm_open()
         dbfilename = tempname;
     }
     my_alarmdb = sqldb_open(dbfilename, CMD_CREATE, DBVERSION, upgrade,
-                            config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT, 's') * 1000);
+                            config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000);
 
     if (!my_alarmdb) {
         syslog(LOG_ERR, "DBERROR: failed to open %s", dbfilename);

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1824,7 +1824,7 @@ HIDDEN int caldav_init_jmapcalendar(const char *userid, struct mailbox *mailbox)
 
 EXPORTED icaltimetype caldav_get_historical_cutoff()
 {
-    int age = config_getduration(IMAPOPT_CALDAV_HISTORICAL_AGE, 'd');
+    int age = config_getduration(IMAPOPT_CALDAV_HISTORICAL_AGE);
     icaltimetype cutoff;
 
     if (age < 0) return icaltime_null_time();

--- a/imap/carddav_db.c
+++ b/imap/carddav_db.c
@@ -1141,7 +1141,7 @@ EXPORTED int carddav_store(struct mailbox *mailbox, vcardcomponent *vcard,
     struct buf *buf = vcard_as_buf(vcard);
 
     if (vcard_max_size < 0) {
-        vcard_max_size = config_getbytesize(IMAPOPT_VCARD_MAX_SIZE, 'B');
+        vcard_max_size = config_getbytesize(IMAPOPT_VCARD_MAX_SIZE);
         if (vcard_max_size <= 0) vcard_max_size = BYTESIZE_UNLIMITED;
     }
 

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -758,7 +758,7 @@ static int do_cid_expire(struct cyr_expire_ctx *ctx)
     if (ctx->args.do_cid_expire) {
         int cid_expire_seconds;
 
-        cid_expire_seconds = config_getduration(IMAPOPT_CONVERSATIONS_EXPIRE_AFTER, 'd');
+        cid_expire_seconds = config_getduration(IMAPOPT_CONVERSATIONS_EXPIRE_AFTER);
         ctx->crock.expire_mark = time(0) - cid_expire_seconds + 1;
 
         verbosep("Removing conversation entries older than %0.2f days",

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -116,7 +116,6 @@ static void do_conf(int only_changed, int want_since, uint32_t since)
                 break;
 
             case OPT_BYTESIZE:
-            case OPT_DURATION:
                 if (only_changed) {
                     if (0 == strcmpsafe(imapopts[i].def.s, imapopts[i].val.s))
                         break;
@@ -124,6 +123,24 @@ static void do_conf(int only_changed, int want_since, uint32_t since)
                 if (want_since && since < imapopts[i].last_modified)
                     highlight(imapopts[i].last_modified);
                 printf("%s: %s\n", imapopts[i].name, imapopts[i].val.s);
+                break;
+
+            case OPT_DURATION:
+                if (only_changed) {
+                    int32_t def_duration = 0;
+
+                    if (imapopts[i].def.s != NULL) {
+                        config_parseduration(imapopts[i].def.s,
+                                             imapopts[i].defunit,
+                                             &def_duration);
+                    }
+
+                    if (def_duration == imapopts[i].val.i32)
+                        break;
+                }
+                if (want_since && since < imapopts[i].last_modified)
+                    highlight(imapopts[i].last_modified);
+                printf("%s: %" PRIi32 "\n", imapopts[i].name, imapopts[i].val.i32);
                 break;
 
             case OPT_ENUM:

--- a/imap/cyr_info.c
+++ b/imap/cyr_info.c
@@ -117,12 +117,20 @@ static void do_conf(int only_changed, int want_since, uint32_t since)
 
             case OPT_BYTESIZE:
                 if (only_changed) {
-                    if (0 == strcmpsafe(imapopts[i].def.s, imapopts[i].val.s))
+                    int64_t def_bytesize = 0LL;
+
+                    if (imapopts[i].def.s != NULL) {
+                        config_parsebytesize(imapopts[i].def.s,
+                                             imapopts[i].defunit,
+                                             &def_bytesize);
+                    }
+
+                    if (def_bytesize == imapopts[i].val.i64)
                         break;
                 }
                 if (want_since && since < imapopts[i].last_modified)
                     highlight(imapopts[i].last_modified);
-                printf("%s: %s\n", imapopts[i].name, imapopts[i].val.s);
+                printf("%s: %" PRIi64 "\n", imapopts[i].name, imapopts[i].val.i64);
                 break;
 
             case OPT_DURATION:

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -307,7 +307,7 @@ EXPORTED sqldb_t *dav_open_userid(const char *userid)
     struct buf fname = BUF_INITIALIZER;
     dav_getpath_byuserid(&fname, userid);
     db = sqldb_open(buf_cstring(&fname), CMD_CREATE, DB_VERSION, davdb_upgrade,
-                    config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT, 's') * 1000);
+                    config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000);
     buf_free(&fname);
     return db;
 }
@@ -320,7 +320,7 @@ EXPORTED sqldb_t *dav_open_mailbox(struct mailbox *mailbox)
     struct buf fname = BUF_INITIALIZER;
     dav_getpath(&fname, mailbox);
     db = sqldb_open(buf_cstring(&fname), CMD_CREATE, DB_VERSION, davdb_upgrade,
-                    config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT, 's') * 1000);
+                    config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000);
     buf_free(&fname);
     return db;
 }
@@ -476,7 +476,7 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
 
     r = IMAP_IOERROR;
     reconstruct_db = sqldb_open(buf_cstring(&newfname), CMD_CREATE, DB_VERSION, davdb_upgrade,
-                                config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT, 's') * 1000);
+                                config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000);
     if (reconstruct_db) {
         r = sqldb_begin(reconstruct_db, "reconstruct");
 #ifdef WITH_DAV

--- a/imap/global.c
+++ b/imap/global.c
@@ -308,7 +308,7 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
     /* Configure HTTP */
     config_httpprettytelemetry = config_getswitch(IMAPOPT_HTTPPRETTYTELEMETRY);
 
-    config_search_maxsize = config_getbytesize(IMAPOPT_SEARCH_MAXSIZE, 'K');
+    config_search_maxsize = config_getbytesize(IMAPOPT_SEARCH_MAXSIZE);
 
     if (!cyrus_init_nodb) {
         /* lookup the database backends */

--- a/imap/global.c
+++ b/imap/global.c
@@ -337,7 +337,7 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
         libcyrus_config_setstring(CYRUSOPT_TEMP_PATH,
                                   config_getstring(IMAPOPT_TEMP_PATH));
         libcyrus_config_setint(CYRUSOPT_PTS_CACHE_TIMEOUT, /* <-- n.b. still an int */
-                               config_getduration(IMAPOPT_PTSCACHE_TIMEOUT, 's'));
+                               config_getduration(IMAPOPT_PTSCACHE_TIMEOUT));
         libcyrus_config_setswitch(CYRUSOPT_FULLDIRHASH,
                                   config_getswitch(IMAPOPT_FULLDIRHASH));
         libcyrus_config_setstring(CYRUSOPT_PTSCACHE_DB,

--- a/imap/http_applepush.c
+++ b/imap/http_applepush.c
@@ -132,7 +132,7 @@ static int meth_get_applepush(struct transaction_t *txn,
     struct mboxevent *mboxevent = mboxevent_new(EVENT_APPLEPUSHSERVICE_DAV);
     mboxevent_set_applepushservice_dav(mboxevent, aps_topic, token, httpd_userid,
                                        mailbox_userid, mailbox_uniqueid, mbtype,
-                                       config_getduration(IMAPOPT_APS_EXPIRY, 'd'));
+                                       config_getduration(IMAPOPT_APS_EXPIRY));
     mboxevent_notify(&mboxevent);
     mboxevent_free(&mboxevent);
 

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -738,7 +738,7 @@ static void my_caldav_init(struct buf *serverinfo)
 
     utc_zone = icaltimezone_get_utc_timezone();
 
-    icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE, 'B');
+    icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE);
     if (icalendar_max_size <= 0) icalendar_max_size = BYTESIZE_UNLIMITED;
 }
 

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -2279,7 +2279,7 @@ static void caldav_rewrite_attachprop_to_binary(struct mailbox *attachments,
     if (!buf_len(b64val)) goto done;
 
     int64_t max_size = config_getbytesize(
-        IMAPOPT_WEBDAV_ATTACHMENTS_MAX_BINARY_ATTACH_SIZE, 'K');
+        IMAPOPT_WEBDAV_ATTACHMENTS_MAX_BINARY_ATTACH_SIZE);
     if (max_size > 0 && buf_len(b64val) > (size_t) max_size) goto done;
 
     // Rewrite ATTACH property

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -389,7 +389,7 @@ static void my_carddav_init(struct buf *serverinfo __attribute__((unused)))
 
     compile_time = calc_compile_time(__TIME__, __DATE__);
 
-    vcard_max_size = config_getbytesize(IMAPOPT_VCARD_MAX_SIZE, 'B');
+    vcard_max_size = config_getbytesize(IMAPOPT_VCARD_MAX_SIZE);
     if (vcard_max_size <= 0) vcard_max_size = BYTESIZE_UNLIMITED;
 }
 

--- a/imap/http_client.c
+++ b/imap/http_client.c
@@ -59,7 +59,7 @@ EXPORTED int http_parse_framing(int http2, hdrcache_t hdrs,
     const char **hdr;
 
     if (max_msgsize == 0) {
-        int64_t val = config_getbytesize(IMAPOPT_MAXMESSAGESIZE, 'B');
+        int64_t val = config_getbytesize(IMAPOPT_MAXMESSAGESIZE);
 
         /* 0 means "unlimited", which really means our internally-defined limit */
         if (val <= 0) val = BYTESIZE_UNLIMITED;

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -314,7 +314,7 @@ static int meth_get_isched(struct transaction_t *txn,
             }
         }
 
-        maxlen = config_getbytesize(IMAPOPT_MAXMESSAGESIZE, 'B');
+        maxlen = config_getbytesize(IMAPOPT_MAXMESSAGESIZE);
         if (maxlen <= 0) maxlen = BYTESIZE_UNLIMITED;
         buf_reset(&txn->buf);
         buf_printf(&txn->buf, "%" PRIi64, maxlen);

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -161,7 +161,7 @@ static void jmap_init(struct buf *serverinfo)
 #endif
     jmap_admin_init(&my_jmap_settings);
 
-    jmap_push_poll = config_getduration(IMAPOPT_JMAP_PUSHPOLL, 's');
+    jmap_push_poll = config_getduration(IMAPOPT_JMAP_PUSHPOLL);
     if (jmap_push_poll < 0) jmap_push_poll = 0;
 
     if (ws_enabled) {
@@ -357,7 +357,7 @@ static int meth_get(struct transaction_t *txn,
 
             /* Adjust inactivity timer */
             prot_settimeout(httpd_in,
-                            2 + config_getduration(IMAPOPT_WEBSOCKET_TIMEOUT, 'm'));
+                            2 + config_getduration(IMAPOPT_WEBSOCKET_TIMEOUT));
         }
         return r;
     }

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -807,7 +807,7 @@ static int list_messages(struct transaction_t *txn, struct mailbox *mailbox)
     }
 
     /* Get maximum age of items to display */
-    max_age = config_getduration(IMAPOPT_RSS_MAXAGE, 'd');
+    max_age = config_getduration(IMAPOPT_RSS_MAXAGE);
     if (max_age > 0) age_mark = time(0) - max_age;
 
     /* Get number of items to display */

--- a/imap/http_ws.c
+++ b/imap/http_ws.c
@@ -520,7 +520,7 @@ HIDDEN int ws_init(struct http_connection *conn __attribute__((unused)),
 {
     buf_printf(serverinfo, " Wslay/%s", WSLAY_VERSION);
 
-    ws_timeout = config_getduration(IMAPOPT_WEBSOCKET_TIMEOUT, 'm');
+    ws_timeout = config_getduration(IMAPOPT_WEBSOCKET_TIMEOUT);
 
     return (ws_timeout > 0);
 }

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -876,7 +876,7 @@ int service_init(int argc __attribute__((unused)),
     const char *jwtdir = config_getstring(IMAPOPT_HTTP_JWT_KEY_DIR);
     if (jwtdir) {
         r = http_jwt_init(jwtdir,
-                config_getduration(IMAPOPT_HTTP_JWT_MAX_AGE, 's'));
+                config_getduration(IMAPOPT_HTTP_JWT_MAX_AGE));
     }
 
     return r;
@@ -999,7 +999,7 @@ int service_main(int argc __attribute__((unused)),
     httpd_altsvc = buf_releasenull(&buf);
 
     /* Set inactivity timer */
-    httpd_timeout = config_getduration(IMAPOPT_HTTPTIMEOUT, 'm');
+    httpd_timeout = config_getduration(IMAPOPT_HTTPTIMEOUT);
     if (httpd_timeout < 0) httpd_timeout = 0;
     prot_settimeout(httpd_in, httpd_timeout);
     prot_setflushonread(httpd_in, httpd_out);
@@ -1024,7 +1024,7 @@ int service_main(int argc __attribute__((unused)),
         fatal("Failed initializing HTTP/2 session", EX_TEMPFAIL);
 
     /* Setup the signal handler for keepalive heartbeat */
-    httpd_keepalive = config_getduration(IMAPOPT_HTTPKEEPALIVE, 's');
+    httpd_keepalive = config_getduration(IMAPOPT_HTTPKEEPALIVE);
     if (httpd_keepalive < 0) httpd_keepalive = 0;
     if (httpd_keepalive) {
         struct sigaction action;
@@ -4826,7 +4826,7 @@ HIDDEN int meth_connect(struct transaction_t *txn, void *params)
 
             /* Adjust inactivity timer */
             prot_settimeout(httpd_in,
-                            2 + config_getduration(IMAPOPT_WEBSOCKET_TIMEOUT, 'm'));
+                            2 + config_getduration(IMAPOPT_WEBSOCKET_TIMEOUT));
         }
         return ret;
     }

--- a/imap/idle.c
+++ b/imap/idle.c
@@ -98,7 +98,7 @@ EXPORTED int idle_init(void)
 
 EXPORTED int idle_enabled(void)
 {
-    int idle_period = config_getduration(IMAPOPT_IMAPIDLEPOLL, 's');
+    int idle_period = config_getduration(IMAPOPT_IMAPIDLEPOLL);
 
     /* only enabled if a positive period */
     return (idle_period > 0);
@@ -130,7 +130,7 @@ EXPORTED int idle_start(unsigned long events, time_t timeout,
     json_decref(msg);
 
     if (r) {
-        int idle_timeout = config_getduration(IMAPOPT_IMAPIDLEPOLL, 's');
+        int idle_timeout = config_getduration(IMAPOPT_IMAPIDLEPOLL);
         syslog(LOG_ERR, "IDLE: error sending message "
                         "INIT to idled for pid %d: %s. "
                         "Falling back to polling every %d seconds.",

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1194,7 +1194,7 @@ int service_main(int argc __attribute__((unused)),
     proc_settitle(config_ident, imapd_clienthost, NULL, NULL, NULL);
 
     /* Set inactivity timer */
-    imapd_timeout = config_getduration(IMAPOPT_TIMEOUT, 'm');
+    imapd_timeout = config_getduration(IMAPOPT_TIMEOUT);
     if (imapd_timeout < 30 * 60) imapd_timeout = 30 * 60;
     prot_settimeout(imapd_in, imapd_timeout);
     prot_setflushonread(imapd_in, imapd_out);
@@ -3113,7 +3113,7 @@ static void cmd_login(char *tag, char *user)
         loginlog_bad(imapd_clienthost, canon_user, "plaintext", NULL,
                      sasl_errdetail(imapd_saslconn));
 
-        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
@@ -3157,7 +3157,7 @@ static void cmd_login(char *tag, char *user)
 
         /* Apply penalty only if not under layer */
         if (!imapd_starttls_done) {
-            int plaintextloginpause = config_getduration(IMAPOPT_PLAINTEXTLOGINPAUSE, 's');
+            int plaintextloginpause = config_getduration(IMAPOPT_PLAINTEXTLOGINPAUSE);
             if (plaintextloginpause) {
                 sleep(plaintextloginpause);
             }
@@ -3224,7 +3224,7 @@ static void cmd_authenticate(char *tag, char *authtype, char *resp)
                          sasl_errdetail(imapd_saslconn));
 
             prometheus_increment(CYRUS_IMAP_AUTHENTICATE_TOTAL_RESULT_NO);
-            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {
                 sleep(failedloginpause);
             }
@@ -3606,15 +3606,15 @@ static void cmd_idle(char *tag)
 
     /* get idle timeout */
     if (idle_timeout == -1) {
-        idle_timeout = config_getduration(IMAPOPT_IMAPIDLETIMEOUT, 'm');
+        idle_timeout = config_getduration(IMAPOPT_IMAPIDLETIMEOUT);
         if (idle_timeout <= 0) {
-            idle_timeout = config_getduration(IMAPOPT_TIMEOUT, 'm');
+            idle_timeout = config_getduration(IMAPOPT_TIMEOUT);
         }
     }
 
     /* get polling period */
     if (idle_period == -1) {
-        idle_period = config_getduration(IMAPOPT_IMAPIDLEPOLL, 's');
+        idle_period = config_getduration(IMAPOPT_IMAPIDLEPOLL);
     }
 
     if (CAPA(backend_current, CAPA_IDLE)) {
@@ -6126,7 +6126,7 @@ static void progress_cb(unsigned count, unsigned total, void *rock)
     time_t now;
 
     if (interval == -1) {
-        interval = config_getduration(IMAPOPT_IMAP_INPROGRESS_INTERVAL, 's');
+        interval = config_getduration(IMAPOPT_IMAP_INPROGRESS_INTERVAL);
         if (interval < 0) interval = 0;
     }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1105,10 +1105,10 @@ int service_init(int argc, char **argv, char **envp)
 
     prometheus_increment(CYRUS_IMAP_READY_LISTENERS);
 
-    maxmsgsize = config_getbytesize(IMAPOPT_MAXMESSAGESIZE, 'B');
+    maxmsgsize = config_getbytesize(IMAPOPT_MAXMESSAGESIZE);
     if (maxmsgsize <= 0) maxmsgsize = BYTESIZE_UNLIMITED;
 
-    maxargssize = config_getbytesize(IMAPOPT_MAXARGSSIZE, 'B');
+    maxargssize = config_getbytesize(IMAPOPT_MAXARGSSIZE);
     if (maxargssize <= 0) maxargssize = BYTESIZE_UNLIMITED;
 
     return 0;
@@ -2916,7 +2916,7 @@ static void autocreate_inbox(void)
     if (imapd_userisadmin) return;
     if (imapd_userisproxyadmin) return;
 
-    if (config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K') >= 0) {
+    if (config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA) >= 0) {
         char *inboxname = mboxname_user_mbox(imapd_userid, NULL);
         int r = mboxlist_lookup(inboxname, NULL, NULL);
         free(inboxname);
@@ -4658,9 +4658,9 @@ static void warn_about_quota(const char *quotaroot)
         goto out;           /* failed to read */
 
     memset(thresholds, 0, sizeof(thresholds));
-    thresholds[QUOTA_STORAGE] = config_getbytesize(IMAPOPT_QUOTAWARNSIZE, 'K') / 1024;
+    thresholds[QUOTA_STORAGE] = config_getbytesize(IMAPOPT_QUOTAWARNSIZE) / 1024;
     thresholds[QUOTA_MESSAGE] = config_getint(IMAPOPT_QUOTAWARNMSG);
-    thresholds[QUOTA_ANNOTSTORAGE] = config_getbytesize(IMAPOPT_QUOTAWARNSIZE, 'K') / 1024;
+    thresholds[QUOTA_ANNOTSTORAGE] = config_getbytesize(IMAPOPT_QUOTAWARNSIZE) / 1024;
 
     for (res = 0 ; res < QUOTA_NUMRESOURCES ; res++) {
         if (q.limits[res] < 0)
@@ -7285,7 +7285,7 @@ localcreate:
     if (r == IMAP_PERMISSION_DENIED) {
         if (!strarray_size(mbname_boxes(mbname)) && !strcmpsafe(imapd_userid, mbname_userid(mbname))) {
             int64_t autocreatequotastorage =
-                config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K');
+                config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA);
 
             if (autocreatequotastorage > 0) {
                 mbentry.uniqueid = NULL;

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4320,7 +4320,7 @@ static int createevent_store(jmap_req_t *req,
 
     static int64_t icalendar_max_size = -1;
     if (icalendar_max_size < 0) {
-        icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE, 'B');
+        icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE);
         if (icalendar_max_size <= 0) icalendar_max_size = BYTESIZE_UNLIMITED;
     }
 
@@ -5239,7 +5239,7 @@ static void setcalendarevents_update(jmap_req_t *req,
 
     static int64_t icalendar_max_size = -1;
     if (icalendar_max_size < 0) {
-        icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE, 'B');
+        icalendar_max_size = config_getbytesize(IMAPOPT_ICALENDAR_MAX_SIZE);
         if (icalendar_max_size <= 0) icalendar_max_size = BYTESIZE_UNLIMITED;
     }
 

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -59,8 +59,8 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
     } \
 } while (0)
 
-#define _read_bytesize_opt(val, optkey, defunit) do { \
-    val = config_getbytesize(optkey, defunit); \
+#define _read_bytesize_opt(val, optkey) do { \
+    val = config_getbytesize(optkey); \
     if (val <= 0) { \
         syslog(LOG_ERR, "jmap: invalid property value: %s", \
                imapopts[optkey].name); \
@@ -71,11 +71,11 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
     int64_t *limits = settings->limits;
 
     _read_bytesize_opt(limits[MAX_SIZE_UPLOAD],
-                       IMAPOPT_JMAP_MAX_SIZE_UPLOAD, 'K');
+                       IMAPOPT_JMAP_MAX_SIZE_UPLOAD);
     _read_int_opt(limits[MAX_CONCURRENT_UPLOAD],
                   IMAPOPT_JMAP_MAX_CONCURRENT_UPLOAD);
     _read_bytesize_opt(limits[MAX_SIZE_REQUEST],
-                       IMAPOPT_JMAP_MAX_SIZE_REQUEST, 'K');
+                       IMAPOPT_JMAP_MAX_SIZE_REQUEST);
     _read_int_opt(limits[MAX_CONCURRENT_REQUESTS],
                   IMAPOPT_JMAP_MAX_CONCURRENT_REQUESTS);
     _read_int_opt(limits[MAX_CALLS_IN_REQUEST],
@@ -85,7 +85,7 @@ HIDDEN void jmap_core_init(jmap_settings_t *settings)
     _read_int_opt(limits[MAX_OBJECTS_IN_SET],
                   IMAPOPT_JMAP_MAX_OBJECTS_IN_SET);
     _read_bytesize_opt(limits[MAX_SIZE_BLOB_SET],
-                       IMAPOPT_JMAP_MAX_SIZE_BLOB_SET, 'K');
+                       IMAPOPT_JMAP_MAX_SIZE_BLOB_SET);
     _read_int_opt(limits[MAX_CATENATE_ITEMS],
                   IMAPOPT_JMAP_MAX_CATENATE_ITEMS);
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -312,7 +312,7 @@ HIDDEN void jmap_mail_capabilities(json_t *account_capabilities,
     }
 
     int64_t max_size_attachments_per_email =
-        config_getbytesize(IMAPOPT_JMAP_MAIL_MAX_SIZE_ATTACHMENTS_PER_EMAIL, 'K');
+        config_getbytesize(IMAPOPT_JMAP_MAIL_MAX_SIZE_ATTACHMENTS_PER_EMAIL);
 
     if (max_size_attachments_per_email <= 0) {
         syslog(LOG_ERR, "jmap: invalid property value: %s",
@@ -8247,7 +8247,7 @@ static int _email_get_bodies(jmap_req_t *req,
                 free(html);
             }
             if (text) {
-                int64_t len = config_getbytesize(IMAPOPT_JMAP_PREVIEW_LENGTH, 'B');
+                int64_t len = config_getbytesize(IMAPOPT_JMAP_PREVIEW_LENGTH);
                 if (len < 0) len = 0;
                 struct buf preview = BUF_INITIALIZER;
                 buf_initmcstr(&preview, text);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -281,7 +281,7 @@ HIDDEN void jmap_mail_init(jmap_settings_t *settings)
 
     ptrarray_append(&settings->getblob_handlers, jmap_emailheader_getblob);
 
-    emailquery_cache_max_age = config_getduration(IMAPOPT_JMAP_QUERYCACHE_MAX_AGE, 'm');
+    emailquery_cache_max_age = config_getduration(IMAPOPT_JMAP_QUERYCACHE_MAX_AGE);
     if (emailquery_cache_max_age) {
         struct jmap_handler *h = xzmalloc(sizeof(struct jmap_handler));
         h->eventmask = JMAP_HANDLE_BEFORE_METHOD|

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -116,7 +116,7 @@ HIDDEN void jmap_emailsubmission_capabilities(json_t *account_capabilities)
                                     "DELIVERBY", "MT-PRIORITY", NULL };
         const char **capa;
         struct buf buf = BUF_INITIALIZER;
-        int delay_time = config_getduration(IMAPOPT_JMAP_MAX_DELAYED_SEND, 's');
+        int delay_time = config_getduration(IMAPOPT_JMAP_MAX_DELAYED_SEND);
         if (delay_time < 0) delay_time = 0;
 
         for (capa = smtp_capa; *capa; capa++) {

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -147,7 +147,7 @@ HIDDEN void jmap_sieve_init(jmap_settings_t *settings)
     }
 
     maxscripts = config_getint(IMAPOPT_SIEVE_MAXSCRIPTS);
-    maxscriptsize = config_getbytesize(IMAPOPT_SIEVE_MAXSCRIPTSIZE, 'K');
+    maxscriptsize = config_getbytesize(IMAPOPT_SIEVE_MAXSCRIPTSIZE);
 }
 
 HIDDEN void jmap_sieve_capabilities(json_t *account_capabilities)

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -2338,7 +2338,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     }
 
     duplicate.max_expiration =
-        config_getduration(IMAPOPT_SIEVE_DUPLICATE_MAX_EXPIRATION, 's');
+        config_getduration(IMAPOPT_SIEVE_DUPLICATE_MAX_EXPIRATION);
     res = sieve_register_duplicate(interp, &duplicate);
     if (res != SIEVE_OK) {
         xsyslog(LOG_ERR, "sieve_register_duplicate failed", "return=<%d>", res);

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -694,7 +694,7 @@ static void deliver_remote(message_data_t *msgdata,
         remote = proxy_findserver(d->server, &lmtp_protocol, "",
                                   &backend_cached, NULL, NULL, NULL);
         if (remote) {
-            int txn_timeout = config_getduration(IMAPOPT_LMTPTXN_TIMEOUT, 's');
+            int txn_timeout = config_getduration(IMAPOPT_LMTPTXN_TIMEOUT);
             if (txn_timeout)
                 prot_settimeout(remote->in, txn_timeout);
             lmtp_runtxn(remote, lt);

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -1116,7 +1116,7 @@ int autocreate_inbox(const mbname_t *mbname)
     /*
      * Check for autocreatequota and createonpost
      */
-    if (config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA, 'K') < 0)
+    if (config_getbytesize(IMAPOPT_AUTOCREATE_QUOTA) < 0)
         return IMAP_MAILBOX_NONEXISTENT;
 
     if (!config_getswitch(IMAPOPT_AUTOCREATE_POST))

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -903,7 +903,7 @@ void lmtpmode(struct lmtp_func *func,
     cd.tls_conn = NULL;
     cd.starttls_done = 0;
 
-    max_msgsize = config_getbytesize(IMAPOPT_MAXMESSAGESIZE, 'B');
+    max_msgsize = config_getbytesize(IMAPOPT_MAXMESSAGESIZE);
 
     /* 0 means "unlimited", which really means our internally-defined limit */
     if (max_msgsize <= 0) max_msgsize = BYTESIZE_UNLIMITED;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5223,7 +5223,7 @@ EXPORTED unsigned mailbox_should_archive(struct mailbox *mailbox,
                                          const struct index_record *record,
                                          void *rock)
 {
-    int archive_after = config_getduration(IMAPOPT_ARCHIVE_AFTER, 'd');
+    int archive_after = config_getduration(IMAPOPT_ARCHIVE_AFTER);
     time_t cutoff = time(0) - archive_after;
     if (rock) cutoff = *((time_t *)rock);
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -5227,7 +5227,7 @@ EXPORTED unsigned mailbox_should_archive(struct mailbox *mailbox,
     time_t cutoff = time(0) - archive_after;
     if (rock) cutoff = *((time_t *)rock);
 
-    int64_t archive_size = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE, 'K');
+    int64_t archive_size = config_getbytesize(IMAPOPT_ARCHIVE_MAXSIZE);
     if (archive_size < 0) archive_size = 0;
     size_t maxsize = archive_size;
 

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -1456,7 +1456,7 @@ void mboxevent_extract_content_msgrec(struct mboxevent *event,
         return;
     }
 
-    truncate = config_getbytesize(IMAPOPT_EVENT_CONTENT_SIZE, 'B');
+    truncate = config_getbytesize(IMAPOPT_EVENT_CONTENT_SIZE);
     if (truncate < 0) truncate = 0;
 
     switch (config_getenum(IMAPOPT_EVENT_CONTENT_INCLUSION_MODE)) {
@@ -1521,7 +1521,7 @@ void mboxevent_extract_content(struct mboxevent *event,
     if (!mboxevent_expected_param(event->type, EVENT_MESSAGE_CONTENT))
         return;
 
-    config_truncate = config_getbytesize(IMAPOPT_EVENT_CONTENT_SIZE, 'B');
+    config_truncate = config_getbytesize(IMAPOPT_EVENT_CONTENT_SIZE);
     truncate = (config_truncate < 0) ? 0 : config_truncate;
 
     switch (config_getenum(IMAPOPT_EVENT_CONTENT_INCLUSION_MODE)) {

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1455,7 +1455,7 @@ static void cmd_authenticate(struct conn *C,
                         tag, errorstring ? errorstring : "");
             break;
         default:
-            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {
                 sleep(failedloginpause);
             }

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -487,7 +487,7 @@ int service_main(int argc __attribute__((unused)),
     nntp_tls_required = config_getswitch(IMAPOPT_TLS_REQUIRED);
 
     /* Set inactivity timer */
-    nntp_timeout = config_getduration(IMAPOPT_NNTPTIMEOUT, 'm');
+    nntp_timeout = config_getduration(IMAPOPT_NNTPTIMEOUT);
     if (nntp_timeout < 3 * 60) nntp_timeout = 3 * 60;
     prot_settimeout(nntp_in, nntp_timeout);
     prot_setflushonread(nntp_in, nntp_out);
@@ -1974,7 +1974,7 @@ static void cmd_authinfo_pass(char *pass)
                             strlen(pass))!=SASL_OK) {
         loginlog_bad(nntp_clienthost, nntp_userid, "plaintext", NULL,
                      sasl_errdetail(nntp_saslconn));
-        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
@@ -2115,7 +2115,7 @@ static void cmd_authinfo_sasl(char *cmd, char *mech, char *resp)
             loginlog_bad(nntp_clienthost, userid, mech, NULL,
                          sasl_errdetail(nntp_saslconn));
 
-            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {
                 sleep(failedloginpause);
             }

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -484,7 +484,7 @@ int service_main(int argc __attribute__((unused)),
     popd_tls_required = config_getswitch(IMAPOPT_TLS_REQUIRED);
 
     /* Set inactivity timer */
-    popd_timeout = config_getduration(IMAPOPT_POPTIMEOUT, 'm');
+    popd_timeout = config_getduration(IMAPOPT_POPTIMEOUT);
     if (popd_timeout < 10 * 60) popd_timeout = 10 * 60;
     prot_settimeout(popd_in, popd_timeout);
     prot_setflushonread(popd_in, popd_out);
@@ -804,7 +804,7 @@ static void cmdloop(void)
         if (!strcmp(inputbuf, "quit")) {
             if (!arg) {
                 int pollpadding = config_getint(IMAPOPT_POPPOLLPADDING);
-                int minpollsec = config_getduration(IMAPOPT_POPMINPOLL, 'm');
+                int minpollsec = config_getduration(IMAPOPT_POPMINPOLL);
 
                 /* check preconditions! */
                 if (!popd_mailbox)
@@ -1213,7 +1213,7 @@ static void cmd_apop(char *response)
         loginlog_bad(popd_clienthost, NULL, NULL, NULL,
                      sasl_errdetail(popd_saslconn));
 
-        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
@@ -1325,7 +1325,7 @@ static void cmd_pass(char *pass)
         loginlog_bad(popd_clienthost, popd_userid, "plaintext", NULL,
                      sasl_errdetail(popd_saslconn));
 
-        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+        failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
@@ -1364,7 +1364,7 @@ static void cmd_pass(char *pass)
                           popd_starttls_done, popd_subfolder);
 
         if ((!popd_starttls_done) &&
-            (plaintextloginpause = config_getduration(IMAPOPT_PLAINTEXTLOGINPAUSE, 's'))
+            (plaintextloginpause = config_getduration(IMAPOPT_PLAINTEXTLOGINPAUSE))
              != 0) {
             sleep(plaintextloginpause);
         }
@@ -1384,8 +1384,8 @@ static void cmd_pass(char *pass)
  */
 static void cmd_capa(void)
 {
-    int minpoll = config_getduration(IMAPOPT_POPMINPOLL, 'm');
-    int expire = config_getduration(IMAPOPT_POPEXPIRETIME, 'd');
+    int minpoll = config_getduration(IMAPOPT_POPMINPOLL);
+    int expire = config_getduration(IMAPOPT_POPEXPIRETIME);
     int mechcount;
     const char *mechlist;
 
@@ -1522,7 +1522,7 @@ static void cmd_auth(char *arg)
             loginlog_bad(popd_clienthost, userid, authtype, NULL,
                          sasl_errstring(sasl_result, NULL, NULL));
 
-            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {
                 sleep(failedloginpause);
             }
@@ -1725,7 +1725,7 @@ int openinbox(void)
             goto fail;
         }
 
-        if ((minpoll = config_getduration(IMAPOPT_POPMINPOLL, 'm')) &&
+        if ((minpoll = config_getduration(IMAPOPT_POPMINPOLL)) &&
             popd_mailbox->i.pop3_last_login.tv_sec + minpoll > popd_login_time) {
             syslog(LOG_ERR, "%s: Logins must be at least %d minute%s apart",
                         mbname_intname(mbname),

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -733,7 +733,7 @@ int main(int argc, char **argv)
                                 NULL);
 
         if (reports[i].frequency <= 0)
-            reports[i].frequency = config_getduration(reports[i].freq_opt, 's');
+            reports[i].frequency = config_getduration(reports[i].freq_opt);
         if (reports[i].frequency <= 0)
             reports[i].frequency = reports[i].default_frequency;
 

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -230,7 +230,7 @@ static void replica_connect(void)
     int wait;
 
     if (!maxwait)
-        maxwait = config_getduration(IMAPOPT_SYNC_RECONNECT_MAXWAIT, 's');
+        maxwait = config_getduration(IMAPOPT_SYNC_RECONNECT_MAXWAIT);
 
     for (wait = 15;; wait *= 2) {
         int r = sync_connect(&sync_cs);
@@ -772,7 +772,7 @@ int main(int argc, char **argv)
                 sync_shutdown_file = sync_get_config(channel, IMAPOPT_SYNC_SHUTDOWN_FILE);
 
             if (!min_delta)
-                min_delta = sync_get_durationconfig(channel, IMAPOPT_SYNC_REPEAT_INTERVAL, 's');
+                min_delta = sync_get_durationconfig(channel, IMAPOPT_SYNC_REPEAT_INTERVAL);
 
             flags |= SYNC_FLAG_BATCH;
 

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -613,7 +613,7 @@ int main(int argc, char **argv)
 
     /* get the server name if not specified */
     if (!servername)
-        servername = sync_get_config(channel, "sync_host");
+        servername = sync_get_config(channel, IMAPOPT_SYNC_HOST);
 
     if (!servername)
         fatal("sync_host not defined", EX_SOFTWARE);
@@ -769,10 +769,10 @@ int main(int argc, char **argv)
         else {
             /* rolling replication */
             if (!sync_shutdown_file)
-                sync_shutdown_file = sync_get_config(channel, "sync_shutdown_file");
+                sync_shutdown_file = sync_get_config(channel, IMAPOPT_SYNC_SHUTDOWN_FILE);
 
             if (!min_delta)
-                min_delta = sync_get_durationconfig(channel, "sync_repeat_interval", 's');
+                min_delta = sync_get_durationconfig(channel, IMAPOPT_SYNC_REPEAT_INTERVAL, 's');
 
             flags |= SYNC_FLAG_BATCH;
 

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -327,7 +327,7 @@ int service_main(int argc __attribute__((unused)),
     proc_settitle(config_ident, sync_clienthost, NULL, NULL, NULL);
 
     /* Set inactivity timer */
-    timeout = config_getduration(IMAPOPT_SYNC_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_SYNC_TIMEOUT);
     if (timeout < 3) timeout = 3;
     prot_settimeout(sync_in, timeout);
 
@@ -709,7 +709,7 @@ static void cmd_authenticate(char *mech, char *resp)
             loginlog_bad(sync_clienthost, userid, mech, NULL,
                          sasl_errdetail(sync_saslconn));
 
-            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE, 's');
+            failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {
                 sleep(failedloginpause);
             }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -294,9 +294,9 @@ EXPORTED const char *sync_get_config(const char *channel, enum imapopt opt)
     return response;
 }
 
-EXPORTED int sync_get_durationconfig(const char *channel, enum imapopt opt)
+EXPORTED int32_t sync_get_durationconfig(const char *channel, enum imapopt opt)
 {
-    int response = -1;
+    int32_t response = -1;
 
     assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
     assert(imapopts[opt].type == OPT_DURATION);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -294,7 +294,7 @@ EXPORTED const char *sync_get_config(const char *channel, enum imapopt opt)
     return response;
 }
 
-EXPORTED int sync_get_durationconfig(const char *channel, enum imapopt opt, int defunit)
+EXPORTED int sync_get_durationconfig(const char *channel, enum imapopt opt)
 {
     int response = -1;
 
@@ -308,11 +308,11 @@ EXPORTED int sync_get_durationconfig(const char *channel, enum imapopt opt, int 
                  channel, imapopts[opt].name);
         result = config_getoverflowstring(name, NULL);
         if (result)
-            config_parseduration(result, defunit, &response);
+            config_parseduration(result, imapopts[opt].defunit, &response);
     }
 
     if (response == -1) {
-        response = config_getduration(opt, defunit);
+        response = config_getduration(opt);
     }
 
     return response;
@@ -8493,7 +8493,7 @@ connected:
     }
 
     /* Set inactivity timer */
-    timeout = config_getduration(IMAPOPT_SYNC_TIMEOUT, 's');
+    timeout = config_getduration(IMAPOPT_SYNC_TIMEOUT);
     if (timeout < 3) timeout = 3;
     prot_settimeout(backend->in, timeout);
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -272,75 +272,71 @@ static struct mboxlock *sync_lock(struct sync_client_state *sync_cs,
 
 /* channel-based configuration */
 
-EXPORTED const char *sync_get_config(const char *channel, const char *val)
+EXPORTED const char *sync_get_config(const char *channel, enum imapopt opt)
 {
     const char *response = NULL;
 
+    assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
+    assert((imapopts[opt].type == OPT_STRING) ||
+           (imapopts[opt].type == OPT_STRINGLIST));
+
     if (channel) {
         char name[MAX_MAILBOX_NAME]; /* crazy long, but hey */
-        snprintf(name, MAX_MAILBOX_NAME, "%s_%s", channel, val);
+        snprintf(name, MAX_MAILBOX_NAME, "%s_%s",
+                 channel, imapopts[opt].name);
         response = config_getoverflowstring(name, NULL);
     }
 
     if (!response) {
-        /* get the core value */
-        if (!strcmp(val, "sync_host"))
-            response = config_getstring(IMAPOPT_SYNC_HOST);
-        else if (!strcmp(val, "sync_authname"))
-            response = config_getstring(IMAPOPT_SYNC_AUTHNAME);
-        else if (!strcmp(val, "sync_password"))
-            response = config_getstring(IMAPOPT_SYNC_PASSWORD);
-        else if (!strcmp(val, "sync_realm"))
-            response = config_getstring(IMAPOPT_SYNC_REALM);
-        else if (!strcmp(val, "sync_port"))
-            response = config_getstring(IMAPOPT_SYNC_PORT);
-        else if (!strcmp(val, "sync_shutdown_file"))
-            response = config_getstring(IMAPOPT_SYNC_SHUTDOWN_FILE);
-        else if (!strcmp(val, "sync_cache_db_path"))
-            response = config_getstring(IMAPOPT_SYNC_CACHE_DB_PATH);
-        else
-            fatal("unknown config variable requested", EX_SOFTWARE);
+        response = config_getstring(opt);
     }
 
     return response;
 }
 
-EXPORTED int sync_get_durationconfig(const char *channel, const char *val, int defunit)
+EXPORTED int sync_get_durationconfig(const char *channel, enum imapopt opt, int defunit)
 {
     int response = -1;
+
+    assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
+    assert(imapopts[opt].type == OPT_DURATION);
 
     if (channel) {
         const char *result = NULL;
         char name[MAX_MAILBOX_NAME]; /* crazy long, but hey */
-        snprintf(name, MAX_MAILBOX_NAME, "%s_%s", channel, val);
+        snprintf(name, MAX_MAILBOX_NAME, "%s_%s",
+                 channel, imapopts[opt].name);
         result = config_getoverflowstring(name, NULL);
         if (result)
             config_parseduration(result, defunit, &response);
     }
 
     if (response == -1) {
-        if (!strcmp(val, "sync_repeat_interval"))
-            response = config_getduration(IMAPOPT_SYNC_REPEAT_INTERVAL, defunit);
+        response = config_getduration(opt, defunit);
     }
 
     return response;
 }
 
-static int sync_get_switchconfig(const char *channel, const char *val)
+static int sync_get_switchconfig(const char *channel, enum imapopt opt)
 {
     int response = -1;
+
+    assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
+    assert(imapopts[opt].type == OPT_SWITCH);
 
     if (channel) {
         const char *result = NULL;
         char name[MAX_MAILBOX_NAME]; /* crazy long, but hey */
-        snprintf(name, sizeof(name), "%s_%s", channel, val);
+        snprintf(name, sizeof(name), "%s_%s",
+                 channel, imapopts[opt].name);
         result = config_getoverflowstring(name, NULL);
+        /* XXX switch type, but doesn't handle "yes" etc, only 1/0! */
         if (result) response = atoi(result);
     }
 
     if (response == -1) {
-        if (!strcmp(val, "sync_try_imap"))
-            response = config_getswitch(IMAPOPT_SYNC_TRY_IMAP);
+        response = config_getswitch(opt);
     }
 
     return response;
@@ -5076,7 +5072,7 @@ static struct db *sync_getcachedb(struct sync_client_state *sync_cs)
     const char *dbtype = config_getstring(IMAPOPT_SYNC_CACHE_DB);
     if (!dbtype) return NULL;
 
-    const char *dbpath = sync_get_config(sync_cs->channel, "sync_cache_db_path");
+    const char *dbpath = sync_get_config(sync_cs->channel, IMAPOPT_SYNC_CACHE_DB_PATH);
     if (!dbpath) return NULL;
 
     int flags = CYRUSDB_CREATE;
@@ -8396,18 +8392,18 @@ EXPORTED int sync_connect(struct sync_client_state *sync_cs)
     buf_free(&sync_cs->tagbuf);
 
     cb = mysasl_callbacks(NULL,
-                          sync_get_config(sync_cs->channel, "sync_authname"),
-                          sync_get_config(sync_cs->channel, "sync_realm"),
-                          sync_get_config(sync_cs->channel, "sync_password"));
+                          sync_get_config(sync_cs->channel, IMAPOPT_SYNC_AUTHNAME),
+                          sync_get_config(sync_cs->channel, IMAPOPT_SYNC_REALM),
+                          sync_get_config(sync_cs->channel, IMAPOPT_SYNC_PASSWORD));
 
     /* get the right port */
-    port = sync_get_config(sync_cs->channel, "sync_port");
+    port = sync_get_config(sync_cs->channel, IMAPOPT_SYNC_PORT);
     if (port) {
         imap_csync_protocol.service = port;
         csync_protocol.service = port;
     }
 
-    try_imap = sync_get_switchconfig(sync_cs->channel, "sync_try_imap");
+    try_imap = sync_get_switchconfig(sync_cs->channel, IMAPOPT_SYNC_TRY_IMAP);
 
     if (try_imap) {
         backend = backend_connect(backend, sync_cs->servername,
@@ -8555,7 +8551,8 @@ EXPORTED int sync_checkpoint(struct protstream *clientin)
         const char *conf = config_getstring(IMAPOPT_SYNC_RIGHTNOW_CHANNEL);
         if (conf && strcmp(conf, "\"\""))
             rightnow_sync_cs.channel = conf;
-        rightnow_sync_cs.servername = sync_get_config(rightnow_sync_cs.channel, "sync_host");
+        rightnow_sync_cs.servername = sync_get_config(rightnow_sync_cs.channel,
+                                                      IMAPOPT_SYNC_HOST);
         rightnow_sync_cs.flags = SYNC_FLAG_LOGGING;
         syslog(LOG_DEBUG, "sync_rightnow_connect(%s)", rightnow_sync_cs.servername);
         sync_connect(&rightnow_sync_cs);

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -21,7 +21,7 @@ extern struct protocol_t csync_protocol;
 #define SYNC_MESSAGE_LIST_MAX_OPEN_FILES (64)
 
 const char *sync_get_config(const char *channel, enum imapopt opt);
-int sync_get_durationconfig(const char *channel, enum imapopt opt, int defunit);
+int sync_get_durationconfig(const char *channel, enum imapopt opt);
 
 /* ====================================================================== */
 

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -7,9 +7,10 @@
 
 #include "backend.h"
 #include "dlist.h"
+#include "libconfig.h"
+#include "mailbox.h"
 #include "prot.h"
 #include "seen.h"
-#include "mailbox.h"
 #include "sync_log.h"
 
 extern struct protocol_t imap_csync_protocol;
@@ -19,8 +20,8 @@ extern struct protocol_t csync_protocol;
 #define SYNC_MESSAGE_LIST_HASH_SIZE      (65536)
 #define SYNC_MESSAGE_LIST_MAX_OPEN_FILES (64)
 
-const char *sync_get_config(const char *channel, const char *val);
-int sync_get_durationconfig(const char *channel, const char *val, int defunit);
+const char *sync_get_config(const char *channel, enum imapopt opt);
+int sync_get_durationconfig(const char *channel, enum imapopt opt, int defunit);
 
 /* ====================================================================== */
 

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -21,7 +21,7 @@ extern struct protocol_t csync_protocol;
 #define SYNC_MESSAGE_LIST_MAX_OPEN_FILES (64)
 
 const char *sync_get_config(const char *channel, enum imapopt opt);
-int sync_get_durationconfig(const char *channel, enum imapopt opt);
+int32_t sync_get_durationconfig(const char *channel, enum imapopt opt);
 
 /* ====================================================================== */
 

--- a/imap/tls.c
+++ b/imap/tls.c
@@ -940,7 +940,7 @@ EXPORTED int     tls_init_serverengine(const char *ident,
                                    SSL_SESS_CACHE_NO_INTERNAL);
 
     /* Get the session timeout from the config file */
-    timeout = config_getduration(IMAPOPT_TLS_SESSION_TIMEOUT, 'm');
+    timeout = config_getduration(IMAPOPT_TLS_SESSION_TIMEOUT);
     if (timeout < 0) timeout = 0;
     if (timeout > 24 * 60 * 60) timeout = 24 * 60 * 60; /* 24 hours max */
 

--- a/lib/imapoptions/README.md
+++ b/lib/imapoptions/README.md
@@ -70,6 +70,24 @@ For SWITCH, this must be either 1 (enabled) or 0 (not enabled).
 
 This header is required.
 
+## Default-Unit
+For DURATION and BYTESIZE, this is the unit that Cyrus will assume when
+the configured value has no units.
+
+This header is optional, and should only be set when something other than
+the defaults of 's' (seconds) or 'B' (bytes) are required.  That should
+only happen for the sake of backwards compatibility, and since all such
+backwards-compatible options have already been defined, you should not set
+this header in new options.
+
+For DURATION, valid values are 's' (seconds), 'm' (minutes), 'h' (hours),
+and 'd' (days).
+
+For BYTESIZE, valid values are 'B' (bytes), 'K' (kibibytes), 'M'
+(mebibytes), and 'G' (gibibytes)
+
+For other types, this header is forbidden.
+
 ## Last-Modified
 Set this to UNRELEASED if you add a new option, or change the behaviour of
 an existing one.

--- a/lib/imapoptions/aps_expiry
+++ b/lib/imapoptions/aps_expiry
@@ -1,6 +1,7 @@
 Name: aps_expiry
 Type: DURATION
 Default-Value: 1d
+Default-Unit: d
 Last-Modified: 3.10.0
 
 Time after which a CalDAV/CardDAV push subscription will expire.  A client

--- a/lib/imapoptions/archive_after
+++ b/lib/imapoptions/archive_after
@@ -1,9 +1,8 @@
 Name: archive_after
 Type: DURATION
 Default-Value: 7d
+Default-Unit: d
 Last-Modified: 3.1.8
 
 The duration after which to move messages to the archive partition if
 archiving is enabled.
-
-For backward compatibility, if no unit is specified, days is assumed.

--- a/lib/imapoptions/archive_days
+++ b/lib/imapoptions/archive_days
@@ -1,6 +1,7 @@
 Name: archive_days
 Type: DURATION
 Default-Value: NULL
+Default-Unit: d
 Last-Modified: 3.1.8
 Deprecated-Since: 3.1.8
 Replaced-By: archive_after

--- a/lib/imapoptions/archive_maxsize
+++ b/lib/imapoptions/archive_maxsize
@@ -1,8 +1,7 @@
 Name: archive_maxsize
 Type: BYTESIZE
-Default-Value: 1024 K
+Default-Value: 1024K
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The size of the largest message that won't be archived immediately.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/autocreate_quota
+++ b/lib/imapoptions/autocreate_quota
@@ -1,6 +1,7 @@
 Name: autocreate_quota
 Type: BYTESIZE
 Default-Value: -1
+Default-Unit: K
 Last-Modified: 3.8.0
 
 If set to a value of zero or higher, users have their INBOX folders created
@@ -13,5 +14,3 @@ the user has unlimited quota.
 
 Note that quota has kibibyte granularity.  Values specified here will be
 truncated to the nearest whole kibibyte.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/autocreatequota
+++ b/lib/imapoptions/autocreatequota
@@ -1,6 +1,7 @@
 Name: autocreatequota
 Type: BYTESIZE
 Default-Value: NULL
+Default-Unit: K
 Last-Modified: 3.8.0
 Deprecated-Since: 2.5.0
 Replaced-By: autocreate_quota

--- a/lib/imapoptions/backup_compact_maxsize
+++ b/lib/imapoptions/backup_compact_maxsize
@@ -1,5 +1,6 @@
 Name: backup_compact_maxsize
 Type: BYTESIZE
 Default-Value: 0
+Default-Unit: K
 Last-Modified: 3.12.0
 Deprecated-Since: 3.12.0

--- a/lib/imapoptions/backup_compact_minsize
+++ b/lib/imapoptions/backup_compact_minsize
@@ -1,5 +1,6 @@
 Name: backup_compact_minsize
 Type: BYTESIZE
 Default-Value: 0
+Default-Unit: K
 Last-Modified: 3.12.0
 Deprecated-Since: 3.12.0

--- a/lib/imapoptions/backup_retention
+++ b/lib/imapoptions/backup_retention
@@ -1,5 +1,6 @@
 Name: backup_retention
 Type: DURATION
 Default-Value: 7d
+Default-Unit: d
 Last-Modified: 3.12.0
 Deprecated-Since: 3.12.0

--- a/lib/imapoptions/backup_retention_days
+++ b/lib/imapoptions/backup_retention_days
@@ -1,5 +1,6 @@
 Name: backup_retention_days
 Type: DURATION
 Default-Value: NULL
+Default-Unit: d
 Last-Modified: 3.12.0
 Deprecated-Since: 3.12.0

--- a/lib/imapoptions/caldav_historical_age
+++ b/lib/imapoptions/caldav_historical_age
@@ -1,11 +1,10 @@
 Name: caldav_historical_age
 Type: DURATION
 Default-Value: 7d
+Default-Unit: d
 Last-Modified: 3.1.8
 
 How long after an occurrence of event or task has concluded that it is
 considered 'historical'.  Changes to historical occurrences of events or
 tasks WILL NOT have invite or reply messages sent for them.  A negative
 value means that events and tasks are NEVER considered historical.
-
-For backward compatibility, if no unit is specified, days is assumed.

--- a/lib/imapoptions/calendar_minimum_alarm_interval
+++ b/lib/imapoptions/calendar_minimum_alarm_interval
@@ -1,6 +1,7 @@
 Name: calendar_minimum_alarm_interval
 Type: DURATION
 Default-Value: 5m
+Default-Unit: m
 Last-Modified: 3.8.0
 
 The minimum allowed interval between alarms for a recurring event.

--- a/lib/imapoptions/client_timeout
+++ b/lib/imapoptions/client_timeout
@@ -5,5 +5,3 @@ Last-Modified: 3.1.8
 
 Time to wait before returning a timeout failure when performing a client
 connection (e.g. in a murder environment).
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/conversations_expire_after
+++ b/lib/imapoptions/conversations_expire_after
@@ -1,9 +1,8 @@
 Name: conversations_expire_after
 Type: DURATION
 Default-Value: 90d
+Default-Unit: d
 Last-Modified: 3.1.8
 
 How long the conversations database keeps the message tracking information
 needed for receiving new messages in existing conversations.
-
-For backward compatibility, if no unit is specified, days is assumed.

--- a/lib/imapoptions/conversations_expire_days
+++ b/lib/imapoptions/conversations_expire_days
@@ -1,6 +1,7 @@
 Name: conversations_expire_days
 Type: DURATION
 Default-Value: NULL
+Default-Unit: d
 Last-Modified: 3.1.8
 Deprecated-Since: 3.1.8
 Replaced-By: conversations_expire_after

--- a/lib/imapoptions/dav_lock_timeout
+++ b/lib/imapoptions/dav_lock_timeout
@@ -6,5 +6,3 @@ Last-Modified: 3.1.8
 The maximum time to wait for a write lock on the per-user DAV database
 before timeout. For HTTP requests, the HTTP status code 503 is returned if
 the lock can not be obtained within this time.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/event_content_size
+++ b/lib/imapoptions/event_content_size
@@ -5,5 +5,3 @@ Last-Modified: 3.8.0
 
 Truncate the message content that may be included with MessageAppend and
 MessageNew. Set 0 to include the entire message itself.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/failedloginpause
+++ b/lib/imapoptions/failedloginpause
@@ -4,5 +4,3 @@ Default-Value: 3s
 Last-Modified: 3.1.8
 
 Time to pause after a failed login.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/httpkeepalive
+++ b/lib/imapoptions/httpkeepalive
@@ -8,5 +8,3 @@ seconds.  The minimum value is 0, which will disable the keepalive
 heartbeat.  When enabled, if a request takes longer than *httpkeepalive* to
 process, the server will send the client provisional responses every
 *httpkeepalive* until the final response can be sent.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/httptimeout
+++ b/lib/imapoptions/httptimeout
@@ -1,9 +1,8 @@
 Name: httptimeout
 Type: DURATION
 Default-Value: 5m
+Default-Unit: m
 Last-Modified: 3.1.8
 
 Set the length of the HTTP server's inactivity autologout timer.  The
 minimum value is 0, which will disable persistent connections.
-
-For backwards compatibility, if no unit is specified, minutes is assumed.

--- a/lib/imapoptions/icalendar_max_size
+++ b/lib/imapoptions/icalendar_max_size
@@ -8,5 +8,3 @@ resources whose iCalendar representation is larger than this.
 
 If set to 0 (the default), a large internally-defined limit will be
 applied.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/imapidlepoll
+++ b/lib/imapoptions/imapidlepoll
@@ -6,5 +6,3 @@ Last-Modified: 3.1.8
 The interval for polling for mailbox changes and ALERTs while running the
 IDLE command.  This option is used when idled is not enabled or cannot be
 contacted.  The minimum value is 1 second.  A value of 0 will disable IDLE.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/imapidletimeout
+++ b/lib/imapoptions/imapidletimeout
@@ -1,9 +1,8 @@
 Name: imapidletimeout
 Type: DURATION
 Default-Value: NULL
+Default-Unit: m
 Last-Modified: 3.1.8
 
 Timeout for idling clients (:rfc:`2177`).  If not set (the default), the
 value of :imapdconf:`timeout` will be used instead.
-
-For backward compatibility, if no unit is specified, minutes is assumed.

--- a/lib/imapoptions/jmap_mail_max_size_attachments_per_email
+++ b/lib/imapoptions/jmap_mail_max_size_attachments_per_email
@@ -1,10 +1,9 @@
 Name: jmap_mail_max_size_attachments_per_email
 Type: BYTESIZE
 Default-Value: 10M
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The value to return for the maxSizeAttachmentsPerEmail property of the JMAP
 \"urn:ietf:params:jmap:mail\" capabilities object. The Cyrus JMAP
 implementation does not enforce this size limit.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/jmap_max_delayed_send
+++ b/lib/imapoptions/jmap_max_delayed_send
@@ -6,5 +6,3 @@ Last-Modified: 3.1.8
 The value to return for the maxDelayedSend property of the JMAP
 \"urn:ietf:params:jmap:emailsubmission\" capabilities object.  The Cyrus
 JMAP implementation does not enforce this limit.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/jmap_max_size_blob_set
+++ b/lib/imapoptions/jmap_max_size_blob_set
@@ -1,10 +1,9 @@
 Name: jmap_max_size_blob_set
 Type: BYTESIZE
 Default-Value: 4M
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The maximum size that the JMAP API accepts for Blob/upload. Returned as the
 maxSizeBlobSet property value of the JMAP \"urn:ietf:params:jmap:blob\"
 capabilities object.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/jmap_max_size_request
+++ b/lib/imapoptions/jmap_max_size_request
@@ -1,10 +1,9 @@
 Name: jmap_max_size_request
 Type: BYTESIZE
 Default-Value: 10M
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The maximum size that the JMAP API accepts for requests at the API
 endpoint.  Returned as the maxSizeRequest property value of the JMAP
 \"urn:ietf:params:jmap:core\" capabilities object.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/jmap_max_size_upload
+++ b/lib/imapoptions/jmap_max_size_upload
@@ -1,10 +1,9 @@
 Name: jmap_max_size_upload
 Type: BYTESIZE
 Default-Value: 1G
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The maximum size that the JMAP API accepts for blob uploads. Returned as
 the maxSizeUpload property value of the JMAP \"urn:ietf:params:jmap:core\"
 capabilities object.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/jmap_preview_length
+++ b/lib/imapoptions/jmap_preview_length
@@ -5,5 +5,3 @@ Last-Modified: 3.8.0
 
 The maximum length of dynamically generated message previews. Previews
 stored in :imapdconf:`jmap_preview_annot` take precedence.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/jmap_pushpoll
+++ b/lib/imapoptions/jmap_pushpoll
@@ -6,5 +6,3 @@ Last-Modified: 3.6.0
 The interval for polling for changes on an EventSource connection or when
 push has been ennabled on a WebSocket channel.  The minimum value is 1
 second. A value of 0 will disable push.
-
-If no unit is specified, seconds is assumed.

--- a/lib/imapoptions/jmap_querycache_max_age
+++ b/lib/imapoptions/jmap_querycache_max_age
@@ -1,6 +1,7 @@
 Name: jmap_querycache_max_age
 Type: DURATION
 Default-Value: 0m
+Default-Unit: m
 Last-Modified: 3.6.0
 
 The duration after which unused cached JMAP query results must be evicted
@@ -8,7 +9,5 @@ from process memory. If non-zero, then the full result of the last query
 (before windowing) is stored in-memory. Subsequent queries with the same
 expression and query state can then page through the cached result.  A zero
 value disables query result caching.
-
-If no unit is specified, minutes is assumed.
 
 This feature currently only is enabled for Email/query.

--- a/lib/imapoptions/ldap_time_limit
+++ b/lib/imapoptions/ldap_time_limit
@@ -4,5 +4,3 @@ Default-Value: 5s
 Last-Modified: 3.1.8
 
 How long to wait for a search request to complete.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/ldap_timeout
+++ b/lib/imapoptions/ldap_timeout
@@ -4,5 +4,3 @@ Default-Value: 5s
 Last-Modified: 3.1.8
 
 How long a search can take before timing out.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/lmtptxn_timeout
+++ b/lib/imapoptions/lmtptxn_timeout
@@ -7,5 +7,3 @@ Timeout used during a lmtp transaction to a remote backend (e.g. in a
 murder environment).  Can be used to prevent hung lmtpds on proxy hosts
 when a backend server becomes unresponsive during a lmtp transaction.
 Change to zero for infinite.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/maxargssize
+++ b/lib/imapoptions/maxargssize
@@ -8,5 +8,3 @@ Cyrus.  Commands with arguments that exceed this limit will be rejected.
 
 If set to 0 (the default), a large internally-defined limit will be
 applied.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/maxliteral
+++ b/lib/imapoptions/maxliteral
@@ -7,8 +7,6 @@ Maximum size of a single literal allowed by the IMAP parser.
 
 If set to 0, a large internally-defined limit will be applied.
 
-If no unit is specified, bytes is assumed.
-
 Literals used for message [part] data in APPEND are only limited by the
 :imapdconf:`maxmessagesize` option.
 

--- a/lib/imapoptions/maxmessagesize
+++ b/lib/imapoptions/maxmessagesize
@@ -9,5 +9,3 @@ be rejected.
 
 If set to 0 (the default), a large internally-defined limit will be
 applied.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/maxquoted
+++ b/lib/imapoptions/maxquoted
@@ -6,5 +6,3 @@ Last-Modified: 3.8.0
 Maximum size of a single quoted string allowed by the IMAP parser.
 
 If set to 0, a large internally-defined limit will be applied.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/maxword
+++ b/lib/imapoptions/maxword
@@ -6,5 +6,3 @@ Last-Modified: 3.8.0
 Maximum size of a single word allowed by the IMAP parser.
 
 If set to 0, a large internally-defined limit will be applied.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/nntptimeout
+++ b/lib/imapoptions/nntptimeout
@@ -1,9 +1,8 @@
 Name: nntptimeout
 Type: DURATION
 Default-Value: 3m
+Default-Unit: m
 Last-Modified: 3.1.8
 
 Set the length of the NNTP server's inactivity autologout timer.  The
 minimum value is 3 minutes, also the default.
-
-For backward compatibility, if no unit is specified, minutes is assumed.

--- a/lib/imapoptions/plaintextloginpause
+++ b/lib/imapoptions/plaintextloginpause
@@ -7,5 +7,3 @@ Time to pause after a successful plaintext login.  For systems that support
 strong authentication, this permits users to perceive a cost of using
 plaintext passwords.  (This does not affect the use of PLAIN in SASL
 authentications.)
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/popexpiretime
+++ b/lib/imapoptions/popexpiretime
@@ -1,6 +1,7 @@
 Name: popexpiretime
 Type: DURATION
 Default-Value: -1
+Default-Unit: d
 Last-Modified: 3.1.8
 
 The duration advertised as being the minimum a message may be left on the
@@ -13,5 +14,3 @@ number.
 The Cyrus POP3 server never deletes mail, no matter what the value of this
 parameter is.  However, if a site implements a less liberal policy, it
 needs to change this parameter accordingly.
-
-For backward compatibility, if no unit is specified, days is assumed.

--- a/lib/imapoptions/popminpoll
+++ b/lib/imapoptions/popminpoll
@@ -1,9 +1,8 @@
 Name: popminpoll
 Type: DURATION
 Default-Value: NULL
+Default-Unit: m
 Last-Modified: 3.1.8
 
 Set the minimum amount of time the server forces users to wait between
 successive POP logins.
-
-For backward compatibility, if no unit is specified, minutes is assumed.

--- a/lib/imapoptions/poptimeout
+++ b/lib/imapoptions/poptimeout
@@ -1,9 +1,8 @@
 Name: poptimeout
 Type: DURATION
 Default-Value: 10m
+Default-Unit: m
 Last-Modified: 3.1.8
 
 Set the length of the POP server's inactivity autologout timer.  The
 minimum value is 10 minutes, the default.
-
-For backward compatibility, if no unit is specified, minutes is assumed.

--- a/lib/imapoptions/prometheus_master_update_freq
+++ b/lib/imapoptions/prometheus_master_update_freq
@@ -5,5 +5,3 @@ Last-Modified: 3.12.0
 
 Frequency in at which master should re-collate its statistics report.  If
 not set, :imapdconf:`prometheus_service_update_freq` is used.
-
-If no unit is specified, seconds is assumed.

--- a/lib/imapoptions/prometheus_service_update_freq
+++ b/lib/imapoptions/prometheus_service_update_freq
@@ -5,5 +5,3 @@ Last-Modified: 3.12.0
 
 Frequency in at which promstatsd should re-collate its service statistics
 report.  The minimum value is 1 second.
-
-If no unit is specified, seconds is assumed.

--- a/lib/imapoptions/prometheus_usage_update_freq
+++ b/lib/imapoptions/prometheus_usage_update_freq
@@ -9,5 +9,3 @@ set, usage statistics are not reported.
 
 Best to make this a multiple of
 :imapdconf:`prometheus_service_update_freq`.
-
-If no unit is specified, seconds is assumed.

--- a/lib/imapoptions/ptscache_timeout
+++ b/lib/imapoptions/ptscache_timeout
@@ -5,5 +5,3 @@ Last-Modified: 3.1.8
 
 The timeout for the PTS cache database when using the auth_krb_pts
 authorization method (default: 3 hours).
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/quotawarnkb
+++ b/lib/imapoptions/quotawarnkb
@@ -1,6 +1,7 @@
 Name: quotawarnkb
 Type: BYTESIZE
 Default-Value: NULL
+Default-Unit: K
 Last-Modified: 3.8.0
 Deprecated-Since: 3.8.0
 Replaced-By: quotawarnsize

--- a/lib/imapoptions/quotawarnsize
+++ b/lib/imapoptions/quotawarnsize
@@ -1,6 +1,7 @@
 Name: quotawarnsize
 Type: BYTESIZE
 Default-Value: 0
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The maximum amount of free space at which to give a quota warning (if this
@@ -9,5 +10,3 @@ always given).
 
 Note that quota has kibibyte granularity.  Values specified here will be
 truncated to the nearest whole kibibyte.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/rss_maxage
+++ b/lib/imapoptions/rss_maxage
@@ -1,10 +1,9 @@
 Name: rss_maxage
 Type: DURATION
 Default-Value: NULL
+Default-Unit: d
 Last-Modified: 3.1.8
 
 Maximum age of items to display in an RSS channel.  If non-zero, httpd will
 only display items received within this time period.  If set to 0, all
 available items will be displayed (the default).
-
-For backward compatibility, if no unit is specified, days is assumed.

--- a/lib/imapoptions/search_attachment_extractor_idle_timeout
+++ b/lib/imapoptions/search_attachment_extractor_idle_timeout
@@ -7,5 +7,3 @@ Defines the duration after which to close unused connections to the search
 attachment extractor service. If the idle timeout is less than
 :imapdconf:`search_attachment_extractor_request_timeout`, then it is
 ignored and request timeout used instead.
-
-If no unit is specified, seconds is assumed.

--- a/lib/imapoptions/search_attachment_extractor_request_timeout
+++ b/lib/imapoptions/search_attachment_extractor_request_timeout
@@ -5,5 +5,3 @@ Last-Modified: 3.10.0
 
 Defines the duration after which to cancel non-responding requests to the
 search attachment extractor service.
-
-If no unit is specified, seconds is assumed.

--- a/lib/imapoptions/search_maxsize
+++ b/lib/imapoptions/search_maxsize
@@ -1,10 +1,9 @@
 Name: search_maxsize
 Type: BYTESIZE
 Default-Value: 4M
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The maximum size to index for each message part. Message contents that
 occur after this byte offset will not be indexed nor used to generate
 search snippets. Xapian-only.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/sieve_duplicate_max_expiration
+++ b/lib/imapoptions/sieve_duplicate_max_expiration
@@ -4,5 +4,3 @@ Default-Value: 90d
 Last-Modified: 3.1.8
 
 Maximum expiration time for duplicate message tracking records.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/sieve_maxscriptsize
+++ b/lib/imapoptions/sieve_maxscriptsize
@@ -1,9 +1,8 @@
 Name: sieve_maxscriptsize
 Type: BYTESIZE
 Default-Value: 32K
+Default-Unit: K
 Last-Modified: 3.8.0
 
 Maximum size any sieve script can be, enforced at submission by
 timsieved(8) and JMAP.
-
-For backward compatibility, if no unit is specified, kibibytes is assumed.

--- a/lib/imapoptions/sieve_vacation_max_response
+++ b/lib/imapoptions/sieve_vacation_max_response
@@ -5,5 +5,3 @@ Last-Modified: 3.1.8
 
 Maximum time interval between consecutive vacation responses, per
 :rfc:`6131`.  The default is 90 days.  The minimum is 7 days.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/sieve_vacation_min_response
+++ b/lib/imapoptions/sieve_vacation_min_response
@@ -5,5 +5,3 @@ Last-Modified: 3.1.8
 
 Minimum time interval between consecutive vacation responses, per
 :rfc:`6131`.  The default is 3 days.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/sync_reconnect_maxwait
+++ b/lib/imapoptions/sync_reconnect_maxwait
@@ -11,5 +11,3 @@ between retries.
 
 If this is zero or negative, the backoff duration will be allowed to
 increase indefinitely (not recommended).
-
-If no unit is specified, seconds is assumed.

--- a/lib/imapoptions/sync_repeat_interval
+++ b/lib/imapoptions/sync_repeat_interval
@@ -6,5 +6,3 @@ Last-Modified: 3.1.8
 Minimum interval between replication runs in rolling replication mode. If a
 replication run takes longer than this time, we repeat immediately.  Prefix
 with a channel name to only apply for that channel.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/sync_timeout
+++ b/lib/imapoptions/sync_timeout
@@ -6,5 +6,3 @@ Last-Modified: 3.1.8
 How long to wait for a response before returning a timeout failure when
 talking to a replication peer (client or server).  The minimum duration is
 3 seconds, the default is 30 minutes.
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/tcp_keepalive_idle
+++ b/lib/imapoptions/tcp_keepalive_idle
@@ -5,5 +5,3 @@ Last-Modified: 3.1.8
 
 How long a connection must be idle before keepalive probes are sent (0 ==
 system default).
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/tcp_keepalive_intvl
+++ b/lib/imapoptions/tcp_keepalive_intvl
@@ -4,5 +4,3 @@ Default-Value: 0
 Last-Modified: 3.1.8
 
 Time between keepalive probes (0 == system default).
-
-For backward compatibility, if no unit is specified, seconds is assumed.

--- a/lib/imapoptions/timeout
+++ b/lib/imapoptions/timeout
@@ -1,10 +1,9 @@
 Name: timeout
 Type: DURATION
 Default-Value: 32m
+Default-Unit: m
 Last-Modified: 3.1.8
 
 The length of the IMAP server's inactivity autologout timer.  The minimum
 value is 30 minutes.  The default is 32 minutes, to allow a bit of leeway
 for clients that try to NOOP every 30 minutes.
-
-For backward compatibility, if no unit is specified, minutes is assumed.

--- a/lib/imapoptions/tls_session_timeout
+++ b/lib/imapoptions/tls_session_timeout
@@ -1,10 +1,9 @@
 Name: tls_session_timeout
 Type: DURATION
 Default-Value: 24h
+Default-Unit: m
 Last-Modified: 3.1.8
 
 The length of time that a TLS session will be cached for later reuse.  The
 maximum value is 24 hours, also the default.  A value of 0 will disable
 session caching.
-
-For backward compatibility, if no unit is specified, minutes is assumed.

--- a/lib/imapoptions/vcard_max_size
+++ b/lib/imapoptions/vcard_max_size
@@ -10,5 +10,3 @@ representation is larger than *vcard_max_size*.
 
 If set to 0 (the default), a large internally-defined limit will be
 applied.
-
-If no unit is specified, bytes is assumed.

--- a/lib/imapoptions/webdav_attachments_max_binary_attach_size
+++ b/lib/imapoptions/webdav_attachments_max_binary_attach_size
@@ -1,6 +1,7 @@
 Name: webdav_attachments_max_binary_attach_size
 Type: BYTESIZE
 Default-Value: 1024K
+Default-Unit: K
 Last-Modified: 3.8.0
 
 The maximum byte length of an ATTACH property value when managed attachment

--- a/lib/imapoptions/websocket_timeout
+++ b/lib/imapoptions/websocket_timeout
@@ -1,10 +1,9 @@
 Name: websocket_timeout
 Type: DURATION
 Default-Value: 30m
+Default-Unit: m
 Last-Modified: 3.6.0
 
 Set the length of the HTTP server's inactivity autologout timer when a
 WebSocket channel has been established.  The default is 30 minutes.  The
 minimum value is 0, which will disable WebSockets.
-
-If no unit is specified, minutes is assumed.

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -395,7 +395,7 @@ done:
 }
 
 /* Get a size value, converted to bytes. */
-EXPORTED int64_t config_getbytesize(enum imapopt opt, int defunit)
+EXPORTED int64_t config_getbytesize(enum imapopt opt)
 {
     int64_t bytesize;
 
@@ -403,11 +403,13 @@ EXPORTED int64_t config_getbytesize(enum imapopt opt, int defunit)
     assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
     assert(imapopts[opt].type == OPT_BYTESIZE);
     assert_not_deprecated(opt);
-    assert(strchr("BKMG", defunit) != NULL); /* n.b. also permits \0 */
 
     if (imapopts[opt].val.s == NULL) return 0;
 
-    if (config_parsebytesize(imapopts[opt].val.s, defunit, &bytesize)) {
+    if (config_parsebytesize(imapopts[opt].val.s,
+                             imapopts[opt].defunit,
+                             &bytesize))
+    {
         /* should have been rejected by config_read_file, but just in case */
         char errbuf[1024];
         snprintf(errbuf, sizeof(errbuf),
@@ -811,17 +813,17 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
     tok_fini(&tok);
 
     /* set some limits */
-    i64val = config_getbytesize(IMAPOPT_MAXLITERAL, 'B');
+    i64val = config_getbytesize(IMAPOPT_MAXLITERAL);
     if (i64val <= 0 || i64val > BYTESIZE_UNLIMITED) {
         i64val = BYTESIZE_UNLIMITED;
     }
     config_maxliteral = i64val;
-    i64val = config_getbytesize(IMAPOPT_MAXQUOTED, 'B');
+    i64val = config_getbytesize(IMAPOPT_MAXQUOTED);
     if (i64val <= 0 || i64val > BYTESIZE_UNLIMITED) {
         i64val = BYTESIZE_UNLIMITED;
     }
     config_maxquoted = i64val;
-    i64val = config_getbytesize(IMAPOPT_MAXWORD, 'B');
+    i64val = config_getbytesize(IMAPOPT_MAXWORD);
     if (i64val <= 0 || i64val > BYTESIZE_UNLIMITED) {
         i64val = BYTESIZE_UNLIMITED;
     }

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -136,7 +136,7 @@ EXPORTED uint64_t config_getbitfield(enum imapopt opt)
     return imapopts[opt].val.u64;
 }
 
-static inline int accumulate(int *val, int mult, int nextchar,
+static inline int accumulate(int32_t *val, int mult, int nextchar,
                              struct buf *parse_err)
 {
     int newdigit = 0;
@@ -145,9 +145,9 @@ static inline int accumulate(int *val, int mult, int nextchar,
 
     if (cyrus_isdigit(nextchar)) newdigit = nextchar - '0';
 
-    if (*val > INT_MAX / mult
-        || (*val == INT_MAX / mult
-            && newdigit > INT_MAX % mult))
+    if (*val > INT32_MAX / mult
+        || (*val == INT32_MAX / mult
+            && newdigit > INT32_MAX % mult))
     {
         if (parse_err)
             buf_printf(parse_err, "would overflow at '%c'", nextchar);
@@ -168,13 +168,15 @@ static inline int accumulate(int *val, int mult, int nextchar,
 
  * On error, -1 is returned and out_duration is unchanged.
  */
-EXPORTED int config_parseduration(const char *str, int defunit, int *out_duration)
+EXPORTED int config_parseduration(const char *str, int defunit, int32_t *out_duration)
 {
     assert(strchr("dhms", defunit) != NULL); /* n.b. also permits \0 */
 
     const size_t len = strlen(str);
     const char *p;
-    int accum = 0, duration = 0, neg = 0, sawdigit = 0, r = 0;
+    int32_t accum = 0, duration = 0;
+    bool neg = false, sawdigit = false;
+    int r = 0;
     char *copy = NULL;
     struct buf parse_err = BUF_INITIALIZER;
 
@@ -194,14 +196,14 @@ EXPORTED int config_parseduration(const char *str, int defunit, int *out_duratio
             r = -1;
             goto done;
         }
-        neg = 1;
+        neg = true;
         p++;
     }
     for (; *p; p++) {
         if (cyrus_isdigit(*p)) {
             r = accumulate(&accum, 10, *p, &parse_err);
             if (r) goto done;
-            sawdigit = 1;
+            sawdigit = true;
         }
         else {
             if (!sawdigit) {
@@ -209,7 +211,7 @@ EXPORTED int config_parseduration(const char *str, int defunit, int *out_duratio
                 r = -1;
                 goto done;
             }
-            sawdigit = 0;
+            sawdigit = false;
             switch (*p) {
             case 'd':
                 r = accumulate(&accum, 24, *p, &parse_err);
@@ -224,7 +226,7 @@ EXPORTED int config_parseduration(const char *str, int defunit, int *out_duratio
                 if (r) goto done;
                 /* fall through */
             case 's':
-                if (duration > INT_MAX - accum) {
+                if (duration > INT32_MAX - accum) {
                     buf_printf(&parse_err, "would overflow at '%c'", *p);
                     r = -1;
                     goto done;
@@ -259,29 +261,13 @@ done:
 }
 
 /* Get a duration value, converted to seconds. */
-EXPORTED int config_getduration(enum imapopt opt)
+EXPORTED int32_t config_getduration(enum imapopt opt)
 {
-    int duration;
-
     assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
     assert(imapopts[opt].type == OPT_DURATION);
     assert_not_deprecated(opt);
 
-    if (imapopts[opt].val.s == NULL) return 0;
-
-    if (config_parseduration(imapopts[opt].val.s,
-                             imapopts[opt].defunit,
-                             &duration))
-    {
-        /* should have been rejected by config_read_file, but just in case */
-        char errbuf[1024];
-        snprintf(errbuf, sizeof(errbuf),
-                 "%s: %s: couldn't parse duration '%s'",
-                 __func__, imapopts[opt].name, imapopts[opt].val.s);
-        fatal(errbuf, EX_CONFIG);
-    }
-
-    return duration;
+    return imapopts[opt].val.i32;
 }
 
 /* Parse a size value, converted to bytes.
@@ -538,6 +524,9 @@ static void config_option_deprecate(const int dopt)
 
     imapopts[opt].seen = imapopts[dopt].seen;
 
+    /* belt, suspenders: option and deprecated option better be same type */
+    assert(imapopts[opt].type == imapopts[dopt].type);
+
     switch (imapopts[dopt].type) {
     case OPT_BITFIELD:
         imapopts[opt].val.u64 = imapopts[dopt].val.u64;
@@ -552,12 +541,12 @@ static void config_option_deprecate(const int dopt)
         break;
 
     case OPT_INT:
+    case OPT_DURATION:
         imapopts[opt].val.i32 = imapopts[dopt].val.i32;
         break;
 
     case OPT_STRINGLIST:
     case OPT_STRING:
-    case OPT_DURATION:
     case OPT_BYTESIZE:
         imapopts[opt].val.s = imapopts[dopt].val.s;
         imapopts[dopt].val.s = NULL;
@@ -609,7 +598,6 @@ EXPORTED void config_reset(void)
     /* reset all the options */
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
         if ((imapopts[opt].type == OPT_STRING ||
-             imapopts[opt].type == OPT_DURATION ||
              imapopts[opt].type == OPT_BYTESIZE) &&
             (imapopts[opt].seen ||
              (imapopts[opt].def.s &&
@@ -723,7 +711,34 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
     }
 
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
-        /* See if the option configured is a part of the deprecated hash. */
+        if (imapopts[opt].type == OPT_DURATION && !imapopts[opt].seen) {
+            /* not in config, need to parse default string */
+            int32_t duration;
+
+            if (imapopts[opt].def.s == NULL) {
+                duration = 0;
+            }
+            else if (config_parseduration(imapopts[opt].def.s,
+                                          imapopts[opt].defunit,
+                                          &duration))
+            {
+                /* uh-oh, we've got a bogus Default-Value */
+                char errbuf[1024];
+                snprintf(errbuf, sizeof(errbuf),
+                         "%s: %s: couldn't parse default duration '%s'",
+                         __func__, imapopts[opt].name, imapopts[opt].def.s);
+                fatal(errbuf, EX_SOFTWARE);
+            }
+
+            imapopts[opt].val.i32 = duration;
+        }
+    }
+
+    for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
+        /* See if the option configured is a part of the deprecated hash.
+         * This must only happen after all other option postprocessing,
+         * so we know all values have been properly initialised.
+         */
         if (imapopts[opt].seen && imapopts[opt].deprecated_since) {
             config_option_deprecate(opt);
         }
@@ -1068,7 +1083,6 @@ static void config_read_file(const char *filename)
              * to free the current string if there is one */
             if (imapopts[opt].seen
                 && (imapopts[opt].type == OPT_STRING
-                    || imapopts[opt].type == OPT_DURATION
                     || imapopts[opt].type == OPT_BYTESIZE))
                 free((char *)imapopts[opt].val.s);
 
@@ -1204,8 +1218,10 @@ static void config_read_file(const char *filename)
             }
             case OPT_DURATION:
             {
-                /* make sure it's parseable, though we don't know the default units */
-                if (config_parseduration(p, '\0', NULL)) {
+                int32_t duration = 0;
+
+                if (config_parseduration(p, imapopts[opt].defunit, &duration))
+                {
                     imapopts[opt].seen = 0; /* not seen after all */
                     snprintf(errbuf, sizeof(errbuf),
                              "unparsable duration '%s' for %s in line %d",
@@ -1214,10 +1230,7 @@ static void config_read_file(const char *filename)
                     fatal(errbuf, EX_CONFIG);
                 }
 
-                /* but then store it unparsed, it will be parsed again by
-                 * config_getduration() where the caller knows the appropriate
-                 * default units */
-                imapopts[opt].val.s = xstrdup(p);
+                imapopts[opt].val.i32 = duration;
                 break;
             }
             case OPT_BYTESIZE:

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -383,28 +383,12 @@ done:
 /* Get a size value, converted to bytes. */
 EXPORTED int64_t config_getbytesize(enum imapopt opt)
 {
-    int64_t bytesize;
-
     assert(config_loaded);
     assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
     assert(imapopts[opt].type == OPT_BYTESIZE);
     assert_not_deprecated(opt);
 
-    if (imapopts[opt].val.s == NULL) return 0;
-
-    if (config_parsebytesize(imapopts[opt].val.s,
-                             imapopts[opt].defunit,
-                             &bytesize))
-    {
-        /* should have been rejected by config_read_file, but just in case */
-        char errbuf[1024];
-        snprintf(errbuf, sizeof(errbuf),
-                 "%s: %s: couldn't parse byte size '%s'",
-                 __func__, imapopts[opt].name, imapopts[opt].val.s);
-        fatal(errbuf, EX_CONFIG);
-    }
-
-    return bytesize;
+    return imapopts[opt].val.i64;
 }
 
 EXPORTED const char *config_getoverflowstring(const char *key, const char *def)
@@ -545,9 +529,12 @@ static void config_option_deprecate(const int dopt)
         imapopts[opt].val.i32 = imapopts[dopt].val.i32;
         break;
 
+    case OPT_BYTESIZE:
+        imapopts[opt].val.i64 = imapopts[dopt].val.i64;
+        break;
+
     case OPT_STRINGLIST:
     case OPT_STRING:
-    case OPT_BYTESIZE:
         imapopts[opt].val.s = imapopts[dopt].val.s;
         imapopts[dopt].val.s = NULL;
         break;
@@ -597,8 +584,7 @@ EXPORTED void config_reset(void)
 
     /* reset all the options */
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
-        if ((imapopts[opt].type == OPT_STRING ||
-             imapopts[opt].type == OPT_BYTESIZE) &&
+        if (imapopts[opt].type == OPT_STRING &&
             (imapopts[opt].seen ||
              (imapopts[opt].def.s &&
               imapopts[opt].val.s != imapopts[opt].def.s &&
@@ -711,8 +697,30 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
     }
 
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
-        if (imapopts[opt].type == OPT_DURATION && !imapopts[opt].seen) {
-            /* not in config, need to parse default string */
+        /* type-specific post-processing of defaults */
+        if (imapopts[opt].seen) continue;
+
+        if (imapopts[opt].type == OPT_BYTESIZE) {
+            int64_t bytesize;
+
+            if (imapopts[opt].def.s == NULL) {
+                bytesize = 0;
+            }
+            else if (config_parsebytesize(imapopts[opt].def.s,
+                                         imapopts[opt].defunit,
+                                         &bytesize))
+            {
+                /* uh-oh, we've got a bogus Default-Value */
+                char errbuf[1024];
+                snprintf(errbuf, sizeof(errbuf),
+                         "%s: %s: couldn't parse default bytesize '%s'",
+                         __func__, imapopts[opt].name, imapopts[opt].def.s);
+                fatal(errbuf, EX_SOFTWARE);
+            }
+
+            imapopts[opt].val.i64 = bytesize;
+        }
+        else if (imapopts[opt].type == OPT_DURATION) {
             int32_t duration;
 
             if (imapopts[opt].def.s == NULL) {
@@ -1081,9 +1089,7 @@ static void config_read_file(const char *filename)
 
             /* If we've seen it already, we're replacing it, so we need
              * to free the current string if there is one */
-            if (imapopts[opt].seen
-                && (imapopts[opt].type == OPT_STRING
-                    || imapopts[opt].type == OPT_BYTESIZE))
+            if (imapopts[opt].seen && imapopts[opt].type == OPT_STRING)
                 free((char *)imapopts[opt].val.s);
 
             if (service_specific)
@@ -1235,8 +1241,9 @@ static void config_read_file(const char *filename)
             }
             case OPT_BYTESIZE:
             {
-                /* make sure it's parseable, though we don't know the default units */
-                if (config_parsebytesize(p, '\0', NULL)) {
+                int64_t bytesize = 0;
+
+                if (config_parsebytesize(p, imapopts[opt].defunit, &bytesize)) {
                     imapopts[opt].seen = 0; /* not seen after all */
                     snprintf(errbuf, sizeof(errbuf),
                              "unparsable byte size '%s' for %s in line %d",
@@ -1245,10 +1252,7 @@ static void config_read_file(const char *filename)
                     fatal(errbuf, EX_CONFIG);
                 }
 
-                /* but then store it unparsed, it will be parsed again by
-                 * config_getbytesize() where the caller knows the appropriate
-                 * default units */
-                imapopts[opt].val.s = xstrdup(p);
+                imapopts[opt].val.i64 = bytesize;
                 break;
             }
             case OPT_NOTOPT:

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -258,23 +258,21 @@ done:
     return r;
 }
 
-/* Get a duration value, converted to seconds.
- *
- * defunit is one of 'd', 'h', 'm', 's' and determines how
- * unitless values are parsed.
- */
-EXPORTED int config_getduration(enum imapopt opt, int defunit)
+/* Get a duration value, converted to seconds. */
+EXPORTED int config_getduration(enum imapopt opt)
 {
     int duration;
 
     assert(opt > IMAPOPT_ZERO && opt < IMAPOPT_LAST);
     assert(imapopts[opt].type == OPT_DURATION);
     assert_not_deprecated(opt);
-    assert(strchr("dhms", defunit) != NULL); /* n.b. also permits \0 */
 
     if (imapopts[opt].val.s == NULL) return 0;
 
-    if (config_parseduration(imapopts[opt].val.s, defunit, &duration)) {
+    if (config_parseduration(imapopts[opt].val.s,
+                             imapopts[opt].defunit,
+                             &duration))
+    {
         /* should have been rejected by config_read_file, but just in case */
         char errbuf[1024];
         snprintf(errbuf, sizeof(errbuf),

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -20,7 +20,7 @@ extern bool config_getswitch(enum imapopt opt);
 extern enum enum_value config_getenum(enum imapopt opt);
 extern uint64_t config_getbitfield(enum imapopt opt);
 extern int config_getduration(enum imapopt opt);
-extern int64_t config_getbytesize(enum imapopt opt, int defunit);
+extern int64_t config_getbytesize(enum imapopt opt);
 
 /* these work on additional strings that are not defined in the
  * imapoptions table */

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -19,7 +19,7 @@ extern int32_t config_getint(enum imapopt opt);
 extern bool config_getswitch(enum imapopt opt);
 extern enum enum_value config_getenum(enum imapopt opt);
 extern uint64_t config_getbitfield(enum imapopt opt);
-extern int config_getduration(enum imapopt opt);
+extern int32_t config_getduration(enum imapopt opt);
 extern int64_t config_getbytesize(enum imapopt opt);
 
 /* these work on additional strings that are not defined in the

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -19,7 +19,7 @@ extern int32_t config_getint(enum imapopt opt);
 extern bool config_getswitch(enum imapopt opt);
 extern enum enum_value config_getenum(enum imapopt opt);
 extern uint64_t config_getbitfield(enum imapopt opt);
-extern int config_getduration(enum imapopt opt, int defunit);
+extern int config_getduration(enum imapopt opt);
 extern int64_t config_getbytesize(enum imapopt opt, int defunit);
 
 /* these work on additional strings that are not defined in the

--- a/lib/util.c
+++ b/lib/util.c
@@ -1329,7 +1329,7 @@ EXPORTED void tcp_enable_keepalive(int fd)
         }
 #endif
 #ifdef TCP_KEEPIDLE
-        optval = config_getduration(IMAPOPT_TCP_KEEPALIVE_IDLE, 's');
+        optval = config_getduration(IMAPOPT_TCP_KEEPALIVE_IDLE);
         if (optval) {
             r = setsockopt(fd, proto->p_proto, TCP_KEEPIDLE, &optval, optlen);
             if (r < 0) {
@@ -1338,7 +1338,7 @@ EXPORTED void tcp_enable_keepalive(int fd)
         }
 #endif
 #ifdef TCP_KEEPINTVL
-        optval = config_getduration(IMAPOPT_TCP_KEEPALIVE_INTVL, 's');
+        optval = config_getduration(IMAPOPT_TCP_KEEPALIVE_INTVL);
         if (optval) {
             r = setsockopt(fd, proto->p_proto, TCP_KEEPINTVL, &optval, optlen);
             if (r < 0) {

--- a/master/master.c
+++ b/master/master.c
@@ -2377,9 +2377,9 @@ static void init_prom_report(struct timeval now)
     const char *tmp;
 
     prom_enabled = config_getswitch(IMAPOPT_PROMETHEUS_ENABLED);
-    prom_frequency = config_getduration(IMAPOPT_PROMETHEUS_MASTER_UPDATE_FREQ, 's');
+    prom_frequency = config_getduration(IMAPOPT_PROMETHEUS_MASTER_UPDATE_FREQ);
     if (!prom_frequency)
-        prom_frequency = config_getduration(IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ, 's');
+        prom_frequency = config_getduration(IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ);
 
     if (prom_frequency < 1) prom_enabled = 0;
     if (!prom_enabled) return;

--- a/ptclient/afskrb.c
+++ b/ptclient/afskrb.c
@@ -277,7 +277,7 @@ static struct auth_state *myauthstate(const char *identifier,
        authentication problem, and cache only for a minute.
        Should negative cache time be configurable? */
     if (rc == PRPERM) {
-        int ptscache_timeout = config_getduration(IMAPOPT_PTSCACHE_TIMEOUT, 's');
+        int ptscache_timeout = config_getduration(IMAPOPT_PTSCACHE_TIMEOUT);
         if (ptscache_timeout < 60)
             ptscache_timeout = 60;
         newstate->mark = time(0) + 60 - ptscache_timeout;

--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -316,7 +316,7 @@ static void myinit(void)
     ptsm->uri = config_getstring(IMAPOPT_LDAP_URI);
 
     ptsm->version = (config_getint(IMAPOPT_LDAP_VERSION) == 2 ? LDAP_VERSION2 : LDAP_VERSION3);
-    ptsm->timeout.tv_sec = config_getduration(IMAPOPT_LDAP_TIMEOUT, 's');
+    ptsm->timeout.tv_sec = config_getduration(IMAPOPT_LDAP_TIMEOUT);
     ptsm->timeout.tv_usec = 0;
     ptsm->restart = config_getswitch(IMAPOPT_LDAP_RESTART);
 
@@ -334,7 +334,7 @@ static void myinit(void)
 
     ptsm->referrals = config_getswitch(IMAPOPT_LDAP_REFERRALS);
     ptsm->size_limit = config_getint(IMAPOPT_LDAP_SIZE_LIMIT);
-    ptsm->time_limit = config_getduration(IMAPOPT_LDAP_TIME_LIMIT, 's');
+    ptsm->time_limit = config_getduration(IMAPOPT_LDAP_TIME_LIMIT);
 
     p = config_getstring(IMAPOPT_LDAP_SCOPE);
 

--- a/sieve/interp.c
+++ b/sieve/interp.c
@@ -335,9 +335,9 @@ EXPORTED int sieve_register_vacation(sieve_interp_t *interp, sieve_vacation_t *v
     }
 
     if (v->min_response == 0)
-        v->min_response = config_getduration(IMAPOPT_SIEVE_VACATION_MIN_RESPONSE, 's');
+        v->min_response = config_getduration(IMAPOPT_SIEVE_VACATION_MIN_RESPONSE);
     if (v->max_response == 0)
-        v->max_response = config_getduration(IMAPOPT_SIEVE_VACATION_MAX_RESPONSE, 's');
+        v->max_response = config_getduration(IMAPOPT_SIEVE_VACATION_MAX_RESPONSE);
     if (v->min_response < 0 || v->max_response < 7 * DAY2SEC || !v->autorespond
         || !v->send_response) {
         return SIEVE_FAIL;

--- a/timsieved/lex.c
+++ b/timsieved/lex.c
@@ -96,7 +96,7 @@ void lex_setrecovering(void)
 
 void lex_init(void)
 {
-  maxscriptsize = config_getbytesize(IMAPOPT_SIEVE_MAXSCRIPTSIZE, 'K');
+  maxscriptsize = config_getbytesize(IMAPOPT_SIEVE_MAXSCRIPTSIZE);
 
   buffer = (char *) xmalloc(maxscriptsize);
 }

--- a/timsieved/timsieved.c
+++ b/timsieved/timsieved.c
@@ -201,8 +201,8 @@ EXPORTED void service_abort(int error)
 }
 
 EXPORTED int service_main(int argc __attribute__((unused)),
-                 char **argv __attribute__((unused)),
-                 char **envp __attribute__((unused)))
+                          char **argv __attribute__((unused)),
+                          char **envp __attribute__((unused)))
 {
     const char *remoteip, *localip;
     sasl_security_properties_t *secprops = NULL;
@@ -213,7 +213,7 @@ EXPORTED int service_main(int argc __attribute__((unused)),
     sieved_in = prot_new(0, 0);
     sieved_out = prot_new(1, 1);
 
-    sieved_timeout = config_getduration(IMAPOPT_TIMEOUT, 'm');
+    sieved_timeout = config_getduration(IMAPOPT_TIMEOUT);
     if (sieved_timeout < 10 * 60) sieved_timeout = 10 * 60;
     prot_settimeout(sieved_in, sieved_timeout);
     prot_setflushonread(sieved_in, sieved_out);

--- a/tools/lib/Cyrus/IMAPOptions/App/Command/cheader.pm
+++ b/tools/lib/Cyrus/IMAPOptions/App/Command/cheader.pm
@@ -97,10 +97,11 @@ sub footer
     my $c = <<~"END_FOOTER";
 
     union config_value {
-        const char *s;      /* OPT_STRING, OPT_STRINGLIST, OPT_BYTESIZE */
+        const char *s;      /* OPT_STRING, OPT_STRINGLIST */
         int32_t i32;        /* OPT_INT, OPT_DURATION */
         bool b;             /* OPT_SWITCH */
         enum enum_value e;  /* OPT_ENUM */
+        int64_t i64;        /* OPT_BYTESIZE */
         uint64_t u64;       /* OPT_BITFIELD */
     };
 

--- a/tools/lib/Cyrus/IMAPOptions/App/Command/cheader.pm
+++ b/tools/lib/Cyrus/IMAPOptions/App/Command/cheader.pm
@@ -120,6 +120,7 @@ sub footer
         const enum imapopt replaced_by;
         union config_value val;
         const union config_value def;
+        const int defunit;
         const struct enum_option_s enum_options[MAX_ENUM_OPTS+1];
     };
 

--- a/tools/lib/Cyrus/IMAPOptions/App/Command/cheader.pm
+++ b/tools/lib/Cyrus/IMAPOptions/App/Command/cheader.pm
@@ -97,8 +97,8 @@ sub footer
     my $c = <<~"END_FOOTER";
 
     union config_value {
-        const char *s;      /* OPT_STRING, OPT_STRINGLIST, OPT_DURATION, OPT_BYTESIZE */
-        int32_t i32;        /* OPT_INT */
+        const char *s;      /* OPT_STRING, OPT_STRINGLIST, OPT_BYTESIZE */
+        int32_t i32;        /* OPT_INT, OPT_DURATION */
         bool b;             /* OPT_SWITCH */
         enum enum_value e;  /* OPT_ENUM */
         uint64_t u64;       /* OPT_BITFIELD */

--- a/tools/lib/Cyrus/IMAPOptions/App/Command/csource.pm
+++ b/tools/lib/Cyrus/IMAPOptions/App/Command/csource.pm
@@ -65,6 +65,7 @@ sub header
             .replaced_by = IMAPOPT_ZERO,
             .val.s = NULL,
             .def.s = NULL,
+            .defunit = 0,
             .enum_options = {
                 { NULL, IMAP_ENUM_ZERO },
             },
@@ -88,6 +89,7 @@ sub footer
             .replaced_by = IMAPOPT_ZERO,
             .val.s = NULL,
             .def.s = NULL,
+            .defunit = 0,
             .enum_options = {
                 { NULL, IMAP_ENUM_ZERO },
             },
@@ -128,6 +130,7 @@ sub _print_option
     foreach my $k ('val', 'def') {
         _print_struct_field("$k.$union_field", $default_value);
     }
+    _print_struct_field('defunit', $option->c_default_unit);
 
     print "        .enum_options = {\n";
     foreach my $pair ($option->c_allowed_values) {

--- a/tools/lib/Cyrus/IMAPOptions/App/Command/manrst.pm
+++ b/tools/lib/Cyrus/IMAPOptions/App/Command/manrst.pm
@@ -178,6 +178,17 @@ sub _print_option
         }
 
         print "\n";
+
+        if ($option->can_have_units) {
+            if ($option->has_default_unit) {
+                print "For backward compatibility, if no unit is specified, ";
+            }
+            else {
+                print "If no unit is specified, "
+            }
+            print $option->docs_default_unit;
+            print " is assumed.\n\n";
+        }
     }
 
     if ($option->has_deprecated_since) {

--- a/tools/lib/Cyrus/IMAPOptions/Option.pm
+++ b/tools/lib/Cyrus/IMAPOptions/Option.pm
@@ -11,6 +11,26 @@ use Types::Standard qw(ArrayRef Bool Enum InstanceOf Int Maybe Split Str);
 my @option_types = qw(BITFIELD BYTESIZE DURATION ENUM INT
                       STRING STRINGLIST SWITCH);
 
+my %units = (
+    'DURATION' => {
+        'd' => 'days',
+        'h' => 'hours',
+        'm' => 'minutes',
+        's' => 'seconds',
+    },
+    'BYTESIZE' => {
+        'B' => 'bytes',
+        'K' => 'kibibytes',
+        'M' => 'mebibytes',
+        'G' => 'gibibytes',
+    },
+);
+
+my %default_unit = (
+    'DURATION' => 's',
+    'BYTESIZE' => 'B',
+);
+
 has name => (
     isa => Str,
     is => 'ro',
@@ -33,6 +53,12 @@ has default_value => (
     isa => Maybe[Str] | ArrayRef[Str],
     is => 'ro',
     required => 1,
+);
+
+has default_unit => (
+    isa => Enum[map { keys $_->%* } values %units],
+    is => 'ro',
+    predicate => 1,
 );
 
 has last_modified => (
@@ -186,6 +212,18 @@ sub BUILD
             if $self->has_allowed_values;
     }
 
+    if ($self->has_default_unit) {
+        my $du = $self->default_unit;
+
+        if (exists $units{$type}) {
+            die "default_unit '$du' not allowed for $type"
+                if not $units{$type}->{$du};
+        }
+        else {
+            die "$type can not have default_unit";
+        }
+    }
+
     # Last-Modified must be a version number or UNRELEASED
     _parse_version('last_modified', $self->last_modified);
 
@@ -230,6 +268,13 @@ sub is_unreleased
     return $is_unreleased;
 }
 
+sub can_have_units
+{
+    my ($self) = @_;
+
+    return exists $units{$self->type};
+}
+
 sub _parse_version
 {
     my ($field, $version) = @_;
@@ -271,6 +316,21 @@ sub docs_default_value
     else {
         return $dv;
     }
+}
+
+sub docs_default_unit
+{
+    my ($self) = @_;
+
+    my $type = $self->type;
+
+    die "no default unit for $type" if not $self->can_have_units;
+
+    my $k = $self->has_default_unit
+          ? $self->default_unit
+          : $default_unit{$type};
+
+    return $units{$type}->{$k};
 }
 
 sub _c_name

--- a/tools/lib/Cyrus/IMAPOptions/Option.pm
+++ b/tools/lib/Cyrus/IMAPOptions/Option.pm
@@ -333,6 +333,20 @@ sub docs_default_unit
     return $units{$type}->{$k};
 }
 
+sub c_default_unit
+{
+    my ($self) = @_;
+
+    if ($self->can_have_units) {
+        return $self->has_default_unit
+               ? "'" . $self->default_unit . "'"
+               : "'" . $default_unit{$self->type} . "'";
+    }
+    else {
+        return '0';
+    }
+}
+
 sub _c_name
 {
     my ($name) = @_;


### PR DESCRIPTION
More long overdue improvements that have been enabled by the imapoptions refactor...

This PR resolves a bunch of double-handling that was previously necessary for duration and bytesize options (due to their human-readable units support, and historical options expecting different default units).

* The `defunit` argument to `config_getduration()` and `config_getbytesize()` is now a `Default-Unit:` field in the imapoptions data.  I expect you will almost never need to use this field, because the weird historical options that need it have it set by this PR, and we shouldn't add new weird options.  It is no longer possible to call these functions with the wrong `defunit`.
* The "if no unit is specified, x is assumed" text in the documentation is now generated from the `Default-Unit:` field, or its absence.  It is no longer possible to accidentally document this detail incorrectly.
* Duration and bytesize values are now parsed into numeric values once during initialization, where previously they were re-parsed every time they were accessed (possibly incorrectly, if the caller got `defunit` wrong!).

**Reviewers:** I suggest stepping through this one commit-by-commit.