### PR TITLE
jmap_calendar.c: prefix Calendar[Event] state strings with 'J'

### DIFF
--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -1318,8 +1318,19 @@ static char *_state_string(int prefixed_state, modseq_t modseq)
 EXPORTED char *jmap_state_string(jmap_req_t *req, modseq_t modseq,
                                  int mbtype, int flags)
 {
-    int prefixed_state =
-        (mbtype == MBTYPE_EMAIL) && USER_COMPACT_EMAILIDS(req->cstate);
+    int prefixed_state = 0;
+
+    if (USER_COMPACT_EMAILIDS(req->cstate)) {
+        switch (mbtype) {
+        case MBTYPE_EMAIL:
+        case MBTYPE_CALENDAR:
+            prefixed_state = 1;
+            break;
+
+        default:
+            break;
+        }
+    }
 
     // if we were not given a modseq, look it up by mbtype
     if (!modseq) modseq = jmap_modseq(req, mbtype, flags);

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -3636,3 +3636,14 @@ EXPORTED void jmap_report_isdefault(struct jmap_set *set, const char *name,
                             json_pack("{s:b}", "isDefault", isdef));
     }
 }
+
+EXPORTED bool jmap_state_matches(struct conversations_state *cstate,
+                                 const char *if_in_state, modseq_t modseq)
+{
+    if (USER_COMPACT_EMAILIDS(cstate) &&  // check for mandatory prefix
+        *if_in_state++ != JMAP_STATE_STRING_PREFIX) {
+        return false;
+    }
+
+    return (atomodseq_t(if_in_state) == modseq);
+}

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -626,4 +626,7 @@ extern void jmap_add_methods(jmap_method_t methods[], jmap_settings_t *settings)
 extern void jmap_report_isdefault(struct jmap_set *set, const char *name,
                                   const char *id, bool isdef);
 
+extern bool jmap_state_matches(struct conversations_state *cstate,
+                               const char *if_in_state, modseq_t modseq);
+
 #endif /* JMAP_API_H */

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -936,7 +936,7 @@ static int jmap_calendar_get(struct jmap_req *req)
     }
 
     /* Build response */
-    get.state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, 0));
+    get.state = jmap_state_string(req, 0, MBTYPE_CALENDAR, 0);
     jmap_ok(req, jmap_get_reply(&get));
 
 done:
@@ -1013,7 +1013,8 @@ done:
 static int jmap_calendar_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
+    struct jmap_changes changes =
+        { .prefixed_state = USER_COMPACT_EMAILIDS(req->cstate) };
     json_t *err = NULL;
     int r = 0;
 
@@ -2110,16 +2111,14 @@ static int jmap_calendar_set(struct jmap_req *req)
         goto done;
     }
 
-    if (set.if_in_state) {
-        if (atomodseq_t(set.if_in_state) != jmap_modseq(req, MBTYPE_CALENDAR, 0)) {
-            jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
-            goto done;
-        }
-        set.old_state = xstrdup(set.if_in_state);
+    modseq_t old_modseq = jmap_modseq(req, MBTYPE_CALENDAR, 0);
+    if (set.if_in_state &&
+        !jmap_state_matches(req->cstate, set.if_in_state, old_modseq)) {
+        jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
+        goto done;
     }
-    else {
-        set.old_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, 0));
-    }
+
+    set.old_state = jmap_state_string(req, old_modseq, MBTYPE_CALENDAR, 0);
 
     r = caldav_create_defaultcalendars(req->accountid,
                                        &httpd_namespace, req->authstate, NULL);
@@ -2272,7 +2271,8 @@ static int jmap_calendar_set(struct jmap_req *req)
         free(calhome_name);
     }
 
-    set.new_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, JMAP_MODSEQ_RELOAD));
+    set.new_state =
+        jmap_state_string(req, 0, MBTYPE_CALENDAR, JMAP_MODSEQ_RELOAD);
 
     jmap_ok(req, jmap_set_reply(&set));
 
@@ -3802,7 +3802,7 @@ static int jmap_calendarevent_get(struct jmap_req *req)
     }
 
     /* Build response */
-    get.state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, 0));
+    get.state = jmap_state_string(req, 0, MBTYPE_CALENDAR, 0);
     jmap_ok(req, jmap_get_reply(&get));
 
 done:
@@ -5905,16 +5905,14 @@ static int jmap_calendarevent_set(struct jmap_req *req)
         goto done;
     }
 
-    if (set.if_in_state) {
-        if (atomodseq_t(set.if_in_state) != jmap_modseq(req, MBTYPE_CALENDAR, 0)) {
-            jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
-            goto done;
-        }
-        set.old_state = xstrdup(set.if_in_state);
+    modseq_t old_modseq = jmap_modseq(req, MBTYPE_CALENDAR, 0);
+    if (set.if_in_state &&
+        !jmap_state_matches(req->cstate, set.if_in_state, old_modseq)) {
+        jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
+        goto done;
     }
-    else {
-        set.old_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, 0));
-    }
+
+    set.old_state = jmap_state_string(req, old_modseq, MBTYPE_CALENDAR, 0);
 
     r = caldav_create_defaultcalendars(req->accountid,
                                        &httpd_namespace, req->authstate, NULL);
@@ -6064,7 +6062,8 @@ static int jmap_calendarevent_set(struct jmap_req *req)
     jmap_caleventid_free(&eid);
 
 
-    set.new_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, JMAP_MODSEQ_RELOAD));
+    set.new_state =
+        jmap_state_string(req, 0, MBTYPE_CALENDAR, JMAP_MODSEQ_RELOAD);
 
     jmap_ok(req, jmap_set_reply(&set));
 
@@ -6187,7 +6186,8 @@ done:
 static int jmap_calendarevent_changes(struct jmap_req *req)
 {
     struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
-    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
+    struct jmap_changes changes =
+        { .prefixed_state = USER_COMPACT_EMAILIDS(req->cstate) };
     json_t *err = NULL;
     struct caldav_db *db;
     struct geteventchanges_rock rock = {
@@ -7264,7 +7264,7 @@ static int jmap_calendarevent_query(struct jmap_req *req)
     }
 
     /* Build response */
-    query.query_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, 0));
+    query.query_state = jmap_state_string(req, 0, MBTYPE_CALENDAR, 0);
 
     json_t *res = jmap_query_reply(&query);
     if (debug) {
@@ -7429,6 +7429,7 @@ static int jmap_calendarevent_copy(struct jmap_req *req)
     json_t *destroy_events = json_array();
     struct mailbox *notifmbox = NULL;
     mbentry_t *notifmb = NULL;
+    struct conversations_state *from_cstate = NULL;
 
     /* Parse request */
     jmap_copy_parse(req, &parser, NULL, NULL, &copy, &err);
@@ -7437,27 +7438,36 @@ static int jmap_calendarevent_copy(struct jmap_req *req)
         goto done;
     }
 
+    int r = conversations_open_user(copy.from_account_id, 0, &from_cstate);
+    if (r) {
+        xsyslog(LOG_ERR, "can't open conversations",
+                "fromAccountId=<%s> error=<%s>",
+                copy.from_account_id, error_message(r));
+        jmap_error(req, jmap_server_error(r));
+        goto done;
+    }
+
     if (copy.if_from_in_state) {
         struct mboxname_counters counters;
         char *srcinbox = mboxname_user_mbox(copy.from_account_id, NULL);
         assert (!mboxname_read_counters(srcinbox, &counters));
         free(srcinbox);
-        if (atomodseq_t(copy.if_from_in_state) != counters.caldavmodseq) {
+
+        if (!jmap_state_matches(from_cstate,
+                                copy.if_from_in_state, counters.caldavmodseq)) {
             jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
             goto done;
         }
     }
 
-    if (copy.if_in_state) {
-        if (atomodseq_t(copy.if_in_state) != jmap_modseq(req, MBTYPE_CALENDAR, 0)) {
-            jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
-            goto done;
-        }
-        copy.old_state = xstrdup(copy.if_in_state);
+    modseq_t old_modseq = jmap_modseq(req, MBTYPE_CALENDAR, 0);
+    if (copy.if_in_state &&
+        !jmap_state_matches(req->cstate, copy.if_in_state, old_modseq)) {
+        jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
+        goto done;
     }
-    else {
-        copy.old_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, 0));
-    }
+
+    copy.old_state = jmap_state_string(req, old_modseq, MBTYPE_CALENDAR, 0);
 
     src_db = caldav_open_userid(copy.from_account_id);
     if (!src_db) {
@@ -7471,7 +7481,7 @@ static int jmap_calendarevent_copy(struct jmap_req *req)
     }
 
     /* Open notifications mailbox, but continue even on error. */
-    int r = jmap_create_notify_collection(req->accountid, &notifmb);
+    r = jmap_create_notify_collection(req->accountid, &notifmb);
     if (!r) r = mailbox_open_iwl(notifmb->name, &notifmbox);
     if (r) {
         xsyslog(LOG_WARNING, "can not open jmapnotify collection",
@@ -7503,7 +7513,8 @@ static int jmap_calendarevent_copy(struct jmap_req *req)
     }
 
     /* Build response */
-    copy.new_state = modseqtoa(jmap_modseq(req, MBTYPE_CALENDAR, JMAP_MODSEQ_RELOAD));
+    copy.new_state =
+        jmap_state_string(req, 0, MBTYPE_CALENDAR, JMAP_MODSEQ_RELOAD);
     jmap_ok(req, jmap_copy_reply(&copy));
 
     /* Destroy originals, if requested */
@@ -7519,6 +7530,7 @@ static int jmap_calendarevent_copy(struct jmap_req *req)
     }
 
 done:
+    conversations_commit(&from_cstate);
     mailbox_close(&notifmbox);
     mboxlist_entry_free(&notifmb);
     json_decref(destroy_events);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -13627,14 +13627,10 @@ static int jmap_email_set(jmap_req_t *req)
     }
 
     modseq_t old_modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    if (set.if_in_state) {
-        const char *if_in_state = set.if_in_state;
-        if ((USER_COMPACT_EMAILIDS(req->cstate) &&  // check for mandatory prefix
-             *if_in_state++ != JMAP_STATE_STRING_PREFIX) ||
-            atomodseq_t(if_in_state) != old_modseq) {
-            jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
-            goto done;
-        }
+    if (set.if_in_state &&
+        !jmap_state_matches(req->cstate, set.if_in_state, old_modseq)) {
+        jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
+        goto done;
     }
 
     set.old_state = jmap_state_string(req, old_modseq, MBTYPE_EMAIL, 0);
@@ -13980,13 +13976,10 @@ static int jmap_email_import(jmap_req_t *req)
     }
 
     modseq_t old_modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    if (if_in_state) {
-        if ((USER_COMPACT_EMAILIDS(req->cstate) &&  // check for mandatory prefix
-             *if_in_state++ != JMAP_STATE_STRING_PREFIX) ||
-            atomodseq_t(if_in_state) != old_modseq) {
-            jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
-            goto done;
-        }
+    if (if_in_state &&
+        !jmap_state_matches(req->cstate, if_in_state, old_modseq)) {
+        jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
+        goto done;
     }
 
     old_state = jmap_state_string(req, old_modseq, MBTYPE_EMAIL, 0);
@@ -14412,24 +14405,18 @@ static int jmap_email_copy(jmap_req_t *req)
         struct mboxname_counters counters;
         assert (!mboxname_read_counters(srcinbox, &counters));
 
-        const char *if_from_in_state = copy.if_from_in_state;
-        if ((USER_COMPACT_EMAILIDS(from_cstate) &&  // check for mandatory prefix
-             *if_from_in_state++ != JMAP_STATE_STRING_PREFIX) ||
-            atomodseq_t(if_from_in_state) != counters.mailmodseq) {
+        if (!jmap_state_matches(from_cstate,
+                                copy.if_from_in_state, counters.mailmodseq)) {
             jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
             goto done;
         }
     }
 
     modseq_t old_modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    if (copy.if_in_state) {
-        const char *if_in_state = copy.if_in_state;
-        if ((USER_COMPACT_EMAILIDS(req->cstate) &&  // check for mandatory prefix
-             *if_in_state++ != JMAP_STATE_STRING_PREFIX) ||
-            atomodseq_t(if_in_state) != old_modseq) {
-            jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
-            goto done;
-        }
+    if (copy.if_in_state &&
+        !jmap_state_matches(req->cstate, copy.if_in_state, old_modseq)) {
+        jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
+        goto done;
     }
 
     copy.old_state = jmap_state_string(req, old_modseq, MBTYPE_EMAIL, 0);

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4006,14 +4006,10 @@ static int jmap_mailbox_set(jmap_req_t *req)
     }
 
     modseq_t old_modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    if (set.super.if_in_state) {
-        const char *if_in_state = set.super.if_in_state;
-        if ((USER_COMPACT_EMAILIDS(req->cstate) &&  // check for mandatory prefix
-             *if_in_state++ != JMAP_STATE_STRING_PREFIX) ||
-            atomodseq_t(if_in_state) != old_modseq) {
-            jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
-            goto done;
-        }
+    if (set.super.if_in_state &&
+        !jmap_state_matches(req->cstate, set.super.if_in_state, old_modseq)) {
+        jmap_error(req, json_pack("{s:s}", "type", "stateMismatch"));
+        goto done;
     }
 
     set.super.old_state = jmap_state_string(req, old_modseq, MBTYPE_EMAIL, 0);


### PR DESCRIPTION
When deployed (presumably simultaneously with compact Calendar[Event] ids) this will trigger cannotCalculateChanges and force client to resync