### PR TITLE
Further cleanup of the hash code prior to dynamic resizing

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_query
@@ -146,4 +146,35 @@ sub test_calendareventnotification_query
     $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
     $self->assert_str_not_equals($notif1->{id}, $res->[0][1]{ids}[0]);
     $self->assert_str_not_equals($notif2->{id}, $res->[0][1]{ids}[0]);
+    my $notif3_id = $res->[0][1]{ids}[0];
+
+    $res = $manjmap->CallMethods([
+        ['CalendarEventNotification/query', {
+            accountId => 'cassandane',
+            filter => {
+                calendarEventIds => ['entwives'],
+            },
+        }, 'R2'],
+    ]);
+    $self->assert_deep_equals([], $res->[0][1]{ids});
+
+    $res = $manjmap->CallMethods([
+        ['CalendarEventNotification/query', {
+            accountId => 'cassandane',
+            filter => {
+                calendarEventIds => [],
+            },
+        }, 'R3'],
+    ]);
+    $self->assert_deep_equals([], $res->[0][1]{ids});
+
+    $res = $manjmap->CallMethods([
+        ['CalendarEventNotification/query', {
+            accountId => 'cassandane',
+            filter => {
+            },
+        }, 'R4'],
+    ]);
+    $self->assert_cmp_deeply(bag($notif1->{id}, $notif2->{id}, $notif3_id),
+                             $res->[0][1]{ids});
 }

--- a/cassandane/tiny-tests/JMAPEmail/email_query_fromcontactcarduid
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_fromcontactcarduid
@@ -118,9 +118,7 @@ sub test_email_query_fromcontactcarduid
             ],
         }, 'R1']
     ], $using);
-    $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($emailId1, $res->[0][1]{ids}[0]);
-    $self->assert_str_equals($emailId2, $res->[0][1]{ids}[1]);
+    $self->assert_deep_equals([$emailId1, $emailId2], $res->[0][1]{ids});
 
     # Filter by fromAnyContact
     $res = $jmap->CallMethods([
@@ -133,9 +131,7 @@ sub test_email_query_fromcontactcarduid
             ],
         }, 'R1']
     ], $using);
-    $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($emailId1, $res->[0][1]{ids}[0]);
-    $self->assert_str_equals($emailId2, $res->[0][1]{ids}[1]);
+    $self->assert_deep_equals([$emailId1, $emailId2], $res->[0][1]{ids});
 
     # Negate filter by contact group.
     $res = $jmap->CallMethods([
@@ -151,8 +147,7 @@ sub test_email_query_fromcontactcarduid
             ],
         }, 'R1']
     ], $using);
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($emailId3, $res->[0][1]{ids}[0]);
+    $self->assert_deep_equals([$emailId3], $res->[0][1]{ids});
 
     # Unknown contact group should return an empty set.
     $res = $jmap->CallMethods([
@@ -234,12 +229,9 @@ sub test_email_query_fromcontactcarduid
             },
         }, 'R3']
     ], $using);
-    $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($emailId4, $res->[0][1]{ids}[0]);
-    $self->assert_num_equals(1, scalar @{$res->[1][1]{ids}});
-    $self->assert_str_equals($emailId5, $res->[1][1]{ids}[0]);
-    $self->assert_num_equals(1, scalar @{$res->[2][1]{ids}});
-    $self->assert_str_equals($emailId6, $res->[2][1]{ids}[0]);
+    $self->assert_deep_equals([$emailId4], $res->[0][1]{ids});
+    $self->assert_deep_equals([$emailId5], $res->[1][1]{ids});
+    $self->assert_deep_equals([$emailId6], $res->[2][1]{ids});
 
     # Support individual cards
     $res = $jmap->CallMethods([
@@ -287,7 +279,5 @@ sub test_email_query_fromcontactcarduid
             sort => [{ property => "subject" }],
         }, 'R1'],
     ], $using);
-    $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
-    $self->assert_str_equals($emailId7, $res->[0][1]{ids}[0]);
-    $self->assert_str_equals($emailId8, $res->[0][1]{ids}[1]);
+    $self->assert_deep_equals([$emailId7, $emailId8], $res->[0][1]{ids});
 }

--- a/cassandane/tiny-tests/JMAPNote/note_get
+++ b/cassandane/tiny-tests/JMAPNote/note_get
@@ -60,31 +60,24 @@ EOF
     $imap->append('INBOX.Notes', $note3) || die $@;
 
     my $res = $jmap->CallMethods([['Note/get', { }, "R1"]]);
-    $self->assert_cmp_deeply(
+    $self->assert_cmp_deeply([
         superhashof({
             id     => $id1,
             title  => 'snowman',
             body   => "☃\n\n",
             isHTML => JSON::false
         }),
-        $res->[0][1]{list}[0],
-    );
-    $self->assert_cmp_deeply(
         superhashof({
             id     => $id2,
             title  => 'bad charset',
             body   => "foo bar\n",
             isHTML => JSON::false
         }),
-        $res->[0][1]{list}[1],
-    );
-    $self->assert_cmp_deeply(
         superhashof({
             id     => $id3,
             title  => 'bad encoding',
             body   => "foo bar\n",
             isHTML => JSON::false
         }),
-        $res->[0][1]{list}[2],
-    );
+    ], $res->[0][1]{list});
 }

--- a/cassandane/tiny-tests/JMAPNote/note_get
+++ b/cassandane/tiny-tests/JMAPNote/note_get
@@ -80,4 +80,30 @@ EOF
             isHTML => JSON::false
         }),
     ], $res->[0][1]{list});
+
+    my $id4 = $id2 =~ tr/0-9/5-90-4/r;
+    my $id5 = $id3 =~ tr/0-9/5-90-4/r;
+    $res = $jmap->CallMethods([['Note/get',
+                                { ids => [$id4, $id1, $id5] },
+                                "R2"]]);
+    $self->assert_cmp_deeply(
+        bag($id4, $id5),
+        $res->[0][1]{notFound},
+    );
+    $self->assert_cmp_deeply([
+        superhashof({
+            id     => $id1,
+            title  => 'snowman',
+            body   => "☃\n\n",
+            isHTML => JSON::false
+        })],
+        $res->[0][1]{list},
+    );
+
+    $res = $jmap->CallMethods([['Note/get',
+                                { ids => [] },
+                                "R2"]]);
+    $self->assert_cmp_deeply([],
+        $res->[0][1]{list},
+    );
 }

--- a/cassandane/tiny-tests/JMAPNote/note_set
+++ b/cassandane/tiny-tests/JMAPNote/note_set
@@ -64,15 +64,15 @@ sub test_note_set
 
     my $id = $res->[0][1]{created}{"1"}{id};
     $self->assert_not_null($id);
-    $self->assert_cmp_deeply(
+    $self->assert_cmp_deeply([
         superhashof({
             id        => $id,
             title     => 'HTML',
             body      => '<html><head></head><body>Hello World</body></html>',
             isHTML    => JSON::true,
             isFlagged => JSON::false
-        }),
-        $res->[1][1]{list}[0],
+        })],
+        $res->[1][1]{list},
     );
 
     xlog "update note with HTML body";
@@ -88,15 +88,15 @@ sub test_note_set
         ['Note/get', { }, "R2"]
     ]);
     $self->assert_not_null($res->[0][1]{updated}{$id});
-    $self->assert_cmp_deeply(
+    $self->assert_cmp_deeply([
         superhashof({
             id        => $id,
             title     => 'HTML',
             body      => '<html><head></head><body>Hello World 2</body></html>',
             isHTML    => JSON::true,
             isFlagged => JSON::false
-        }),
-        $res->[1][1]{list}[0],
+        })],
+        $res->[1][1]{list},
     );
 
     xlog "update note with plain text body";
@@ -114,15 +114,15 @@ sub test_note_set
         ['Note/get', { }, "R2"]
     ]);
     $self->assert_not_null($res->[0][1]{updated}{$id});
-    $self->assert_cmp_deeply(
+    $self->assert_cmp_deeply([
         superhashof({
             id        => $id,
             title     => 'plain text',
             body      => 'Hello World 3',
             isHTML    => JSON::false,
             isFlagged => JSON::false
-        }),
-        $res->[1][1]{list}[0],
+        })],
+        $res->[1][1]{list},
     );
 
     xlog "set \flagged";
@@ -132,15 +132,15 @@ sub test_note_set
 
     xlog "verify isFlagged";
     $res = $jmap->CallMethods([['Note/get', { }, "R1"]]);
-    $self->assert_cmp_deeply(
+    $self->assert_cmp_deeply([
         superhashof({
             id        => $id,
             title     => 'plain text',
             body      => 'Hello World 3',
             isHTML    => JSON::false,
             isFlagged => JSON::true
-        }),
-        $res->[0][1]{list}[0],
+        })],
+        $res->[0][1]{list},
     );
 
     xlog "destroy note";

--- a/cassandane/tiny-tests/JMAPSieve/deliver_corrupt_dav_db
+++ b/cassandane/tiny-tests/JMAPSieve/deliver_corrupt_dav_db
@@ -1,0 +1,125 @@
+#!perl
+use Cassandane::Tiny;
+use Path::Tiny;
+
+# This test is based on email_query_fromanycontact_ignore_localpartonly but
+# modified to trigger an error path.
+#
+# Creating the contact creates a dav.db on disk
+# The method install_sieve_script directly calls sievec to compile the sieve
+# script, and stores both the source script and the bytecode version on disk
+#
+# The test then finds and scribbles on dav.db
+#
+# After this, a call to deliver
+# * fails to open dav.db
+# * assumes that what's on disk is good enough
+# * runs with what it has
+# * that bytecode-on-disk needs to load contacts
+# * that fails (fails to open dav.db)
+# * sieve filtering aborted; fallback to default delivery (to INBOX)
+#
+# We might consider the above detailed behaviour a bug - if the dav.db can't be
+# opened to check that the script is current, instead of running with a possibly
+# stale script, should we instead immediately do the "fallback to default
+# delivery"?
+#
+# Or instead, should we aggressively uncache the script from disk when the
+# dav.db is updated - ie move the staleness check into the write path?
+#
+# Either way, the end behaviour of *this* test should be the same - if the
+# dav.db is corrupt then sieve should not run, and delivery should be to INBOX
+# The precise why of how it happens might be wrong. (And we need other tests to
+# validate behaviour for an on-disk cached sieve script that didn't need dav.db)
+
+sub test_deliver_corrupt_dav_db
+    :min_version_3_3 :JMAPExtensions
+    :needs_component_sieve
+    ($self)
+{
+    my $contactId1 = $self->default_user->contacts->create({
+        emails => {
+            personal => {
+                contexts => { private => JSON::true },
+                address => 'email'
+            }
+        },
+    });
+    $self->assert_not_null($contactId1);
+
+    xlog "Assert JMAP sieve ignores localpart-only contacts";
+    $self->{store}->get_client()->create("INBOX.matches") or die;
+    $self->{instance}->install_sieve_script(<<'EOF'
+require ["x-cyrus-jmapquery", "x-cyrus-log", "variables", "fileinto"];
+if
+  allof( not string :is "${stop}" "Y",
+    jmapquery text:
+  {
+    "operator" : "NOT",
+    "conditions" : [
+        {
+           "fromAnyContact" : true
+        }
+    ]
+  }
+.
+  )
+{
+  fileinto "INBOX.matches";
+}
+EOF
+    );
+
+    # This is what is supposed to happen, given the sieve filter above.
+    # We keep this code in to confirm that the correct behaviour of the sieve
+    # filter. This call to ->deliver() isn't needed to create a dav.db on disk.
+    my $msg1 = $self->{gen}->generate(from => Cassandane::Address->new(
+            localpart => 'email', domain => 'local'
+    ), subject => 'Message 1');
+
+    $self->{instance}->deliver($msg1);
+    $self->{store}->set_fetch_attributes('uid');
+    $self->{store}->set_folder('INBOX.matches');
+    $self->check_messages({ 1 => $msg1 }, check_guid => 0);
+
+    my @found;
+    path($self->{instance}->{basedir})->visit(
+        sub ($path, $) {
+          return if $path->is_dir();
+          # We have to "corrupt" the file on disk. If we simply remove it then a
+          # fresh (valid) SQLlite database is created on the next call to
+          # sqlite3_open_v2()
+          # Instead, with a corrupt file sqlite3_open_v2() succeeds but the call
+          # sqlite3_exec(open->db, "PRAGMA user_version;", ...) fais and logs.
+          if($path->basename() eq 'dav.db') {
+            push @found, $path;
+            $path->spew("this space for rent\n");
+          }
+        },
+        { recurse => 1 }
+    );
+    $self->assert_num_equals(1, scalar @found, 'exactly one dav.db found');
+
+    # We repeat the above delivery, and test that the outcome differs:
+    my $msg2 = $self->{gen}->generate(from => Cassandane::Address->new(
+            localpart => 'email', domain => 'local'
+    ), subject => 'Message 2');
+    $msg2->set_attribute(uid => 1);
+
+    $self->{instance}->getsyslog();
+    $self->{instance}->deliver($msg2);
+    my @lines = $self->{instance}->getsyslog();
+    # Exactly what we log might change if we change the implementation. But I
+    # think it better to write a potentially fragile test, because with it we
+    # see whether the expected code paths are still reached.
+    # Cassandane::Instance::_check_syslog() faults these if it sees them:
+    my @dberror = grep /: DBERROR: get user version failed: sessionid=<[^>]+> fname=<\Q$found[0]\E> error=<file is not a database>/, @lines;
+    $self->assert_num_equals(2, scalar @dberror, '2 expected fatal log lines found');
+    # The actual error we're trying to reach doesn't default to a test failure:
+    my @carddav_error = grep /: jmap: carddav_open_userid\(cassandane\) failed$/, @lines;
+    $self->assert_num_equals(1, scalar @carddav_error, 'carddav_open_userid logged failure');
+
+    $self->check_messages({ 1 => $msg1 }, check_guid => 0);
+    $self->{store}->set_folder('INBOX');
+    $self->check_messages({ 1 => $msg2 }, check_guid => 0);
+}

--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -1779,7 +1779,7 @@ static void count_cb(const char *key __attribute__((unused)),
     (*np)++;
 }
 
-static unsigned int hash_count(hash_table *ht)
+static unsigned int hash_count_slow(hash_table *ht)
 {
     unsigned int n = 0;
     hash_enumerate(ht, count_cb, &n);
@@ -1799,12 +1799,12 @@ static unsigned int hash_count(hash_table *ht)
         } \
     } \
     CU_ASSERT_EQUAL(nsubset, expcount); \
-    CU_ASSERT_EQUAL(hash_count(&exphash), nsubset); \
+    CU_ASSERT_EQUAL(hash_count_slow(&exphash), nsubset); \
 }
 
 #define FOREACH_POSTCONDITION() \
     CU_ASSERT_EQUAL(r, CYRUSDB_OK); \
-    CU_ASSERT_EQUAL(hash_count(&exphash), 0);
+    CU_ASSERT_EQUAL(hash_count_slow(&exphash), 0);
 
 #define FOREACH_TEST(prefix, prefixlen, good, condition, expcount) \
     FOREACH_PRECONDITION(condition, expcount); \

--- a/cunit/hash.testc
+++ b/cunit/hash.testc
@@ -120,8 +120,8 @@ static void test_empty(void)
     hash_enumerate(&ht, count_cb, &count);
     CU_ASSERT_EQUAL(0, count);
 
-    /* check hash_numrecords */
-    CU_ASSERT_EQUAL(0, hash_numrecords(&ht));
+    /* check hash_count */
+    CU_ASSERT_EQUAL(0, hash_count(&ht));
 
     /* free the hash table */
     free_hash_table(&ht, NULL);
@@ -152,8 +152,8 @@ static void test_reinsert(void)
     hash_enumerate(&ht, count_cb, &count);
     CU_ASSERT_EQUAL(1, count);
 
-    /* check hash_numrecords */
-    CU_ASSERT_EQUAL(1, hash_numrecords(&ht));
+    /* check hash_count */
+    CU_ASSERT_EQUAL(1, hash_count(&ht));
 
     /* re-insert into the hash table */
     d = hash_insert(KEY0, VALUE1, &ht);
@@ -169,8 +169,8 @@ static void test_reinsert(void)
     hash_enumerate(&ht, count_cb, &count);
     CU_ASSERT_EQUAL(1, count);
 
-    /* check hash_numrecords */
-    CU_ASSERT_EQUAL(1, hash_numrecords(&ht));
+    /* check hash_count */
+    CU_ASSERT_EQUAL(1, hash_count(&ht));
 
     /* delete from the hash table */
     d = hash_del(KEY0, &ht);
@@ -185,8 +185,8 @@ static void test_reinsert(void)
     hash_enumerate(&ht, count_cb, &count);
     CU_ASSERT_EQUAL(0, count);
 
-    /* check hash_numrecords */
-    CU_ASSERT_EQUAL(0, hash_numrecords(&ht));
+    /* check hash_count */
+    CU_ASSERT_EQUAL(0, hash_count(&ht));
 
     /* free the hash table */
     free_hash_table(&ht, NULL);
@@ -254,8 +254,8 @@ static void test_many(void)
     hash_enumerate(&ht, count_cb, &count);
     CU_ASSERT_EQUAL(N, count);
 
-    /* check hash_numrecords */
-    CU_ASSERT_EQUAL(N, hash_numrecords(&ht));
+    /* check hash_count */
+    CU_ASSERT_EQUAL(N, hash_count(&ht));
 
     /* delete from the hash table */
     for (i = 0 ; i < N ; i++) {
@@ -274,8 +274,8 @@ static void test_many(void)
     hash_enumerate(&ht, count_cb, &count);
     CU_ASSERT_EQUAL(0, count);
 
-    /* check hash_numrecords */
-    CU_ASSERT_EQUAL(0, hash_numrecords(&ht));
+    /* check hash_count */
+    CU_ASSERT_EQUAL(0, hash_count(&ht));
 
     /* free the hash table */
     freed_count = 0;
@@ -307,8 +307,8 @@ static void test_freeing_nonempty(void)
     hash_enumerate(&ht, count_cb, &count);
     CU_ASSERT_EQUAL(N, count);
 
-    /* check hash_numrecords */
-    CU_ASSERT_EQUAL(N, hash_numrecords(&ht));
+    /* check hash_count */
+    CU_ASSERT_EQUAL(N, hash_count(&ht));
 
     /* free the hash table */
     freed_count = 0;
@@ -399,7 +399,7 @@ static void test_load_factor_warning(void)
     for (i = 0; i < n_words; i++) {
         hash_insert(words[i], NULL, &ht);
     }
-    CU_ASSERT_EQUAL(n_words, hash_numrecords(&ht));
+    CU_ASSERT_EQUAL(n_words, hash_count(&ht));
     CU_ASSERT_SYSLOG(syslog_index, 2);
 
     free_hash_table(&ht, NULL);

--- a/cunit/master-cronevent.testc
+++ b/cunit/master-cronevent.testc
@@ -334,7 +334,7 @@ static void test_fullday(void)
         hash_del(tests[i].name, &spawn_counts);
     }
 
-    CU_ASSERT_EQUAL(hash_numrecords(&spawn_counts), 0);
+    CU_ASSERT_EQUAL(hash_count(&spawn_counts), 0);
     free_hash_table(&spawn_counts, NULL);
 }
 

--- a/cunit/master-cronevent.testc
+++ b/cunit/master-cronevent.testc
@@ -333,7 +333,7 @@ static void test_fullday(void)
         hash_del(tests[i].name, &spawn_counts);
     }
 
-    CU_ASSERT_EQUAL(hash_numrecords(&spawn_counts), 0);
+    CU_ASSERT_EQUAL(hash_count(&spawn_counts), 0);
     free_hash_table(&spawn_counts, NULL);
 }
 

--- a/cunit/proc.testc
+++ b/cunit/proc.testc
@@ -387,7 +387,7 @@ static void test_proc_foreach(void)
     construct_hash_table(&results, n_tests, 0);
     r = proc_foreach(&collect_procs_cb, &results);
     CU_ASSERT_EQUAL(r, 0);
-    CU_ASSERT_EQUAL(hash_numrecords(&results), 0);
+    CU_ASSERT_EQUAL(hash_count(&results), 0);
 
     /* and we're finished */
     free_hash_table(&results, &free_procdata_fields);

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -89,7 +89,7 @@ EXPORTED void strip_vtimezones(icalcomponent *ical)
         }
     }
 
-    if (hash_numrecords(&tzid_table)) {
+    if (hash_count(&tzid_table)) {
         /* Replace all TZID aliases with actual TZIDs.
            Note: This NEEDS to be done, otherwise looking up the
            builtin timezone will fail on a TZID mismatch. */

--- a/imap/cvt_xlist_specialuse.c
+++ b/imap/cvt_xlist_specialuse.c
@@ -159,7 +159,7 @@ int main (int argc, char **argv)
     construct_hash_table(&xlist, 10, 0);
     config_foreachoverflowstring(xlist_lookup_cb, &xlist);
 
-    if (hash_numrecords(&xlist) < 1) {
+    if (hash_count(&xlist) < 1) {
         /* nothing to do */
         fprintf(stderr, "no xlist- settings in %s, nothing to do\n",
                         alt_config ? alt_config : CONFIG_FILENAME);

--- a/imap/defaultalarms.c
+++ b/imap/defaultalarms.c
@@ -830,7 +830,7 @@ HIDDEN void defaultalarms_migrate39(const mbentry_t *mbentry,
         annotatemore_findall_mailbox(mbox, record->uid, PER_USER_CAL_DATA,
                 0, migrate39_find_peruser_cb, &peruser, ANNOTATE_TOMBSTONES);
 
-        if (!hash_numrecords(&peruser)) {
+        if (!hash_count(&peruser)) {
             free_hash_table(&peruser, free);
             continue;
         }

--- a/imap/duplicate.h
+++ b/imap/duplicate.h
@@ -5,6 +5,8 @@
 #ifndef DUPLICATE_H
 #define DUPLICATE_H
 
+#include <config.h>
+
 #include "hash.h"
 
 /* name of the duplicate delivery database */

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1407,7 +1407,7 @@ HIDDEN int caldav_manage_attachments(const char *userid,
         }
     }
 
-    if (hash_numrecords(&mattach_table)) {
+    if (hash_count(&mattach_table)) {
         if (!attachments) {
             /* Open attachments collection and its DAV DB for writing */
             ret = open_attachments(userid, &attachments, &webdavdb);

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1412,7 +1412,7 @@ HIDDEN int caldav_manage_attachments(const char *userid,
         }
     }
 
-    if (hash_numrecords(&mattach_table)) {
+    if (hash_count(&mattach_table)) {
         if (!attachments) {
             /* Open attachments collection and its DAV DB for writing */
             ret = open_attachments(userid, &attachments, &webdavdb);

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3505,7 +3505,7 @@ HIDDEN int preload_proplist(xmlNodePtr proplist, struct propfind_ctx *fctx)
 
     case PROPFIND_EXPAND:
         /* Add all namespaces attached to the response to our hash table */
-        if (!fctx->ns_table->size) {
+        if (!hash_constructed(fctx->ns_table)) {
             xmlNsPtr nsDef;
 
             construct_hash_table(fctx->ns_table, 10, 1);

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3525,7 +3525,7 @@ HIDDEN int preload_proplist(xmlNodePtr proplist, struct propfind_ctx *fctx)
 
     case PROPFIND_EXPAND:
         /* Add all namespaces attached to the response to our hash table */
-        if (!fctx->ns_table->size) {
+        if (!hash_constructed(fctx->ns_table)) {
             xmlNsPtr nsDef;
 
             construct_hash_table(fctx->ns_table, 10, 1);

--- a/imap/http_tzdist.c
+++ b/imap/http_tzdist.c
@@ -1098,7 +1098,7 @@ static int action_list(struct transaction_t *txn)
             changedsince = 0;
         }
     }
-    else if (hash_numrecords(&txn->req_qparams)) {
+    else if (hash_count(&txn->req_qparams)) {
         return json_error_response(txn, TZ_INVALID_ACTION, NULL, NULL);
     }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -13962,7 +13962,7 @@ static void list_data(struct listargs *listargs)
                                   imapd_authstate, list_cb, &rock);
 
             if (rock.subs) strarray_free(rock.subs);
-            if (rock.server_table.size)
+            if (config_mupdate_server)
                 free_hash_table(&rock.server_table, NULL);
         }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -13948,7 +13948,7 @@ static void list_data(struct listargs *listargs)
                                   imapd_authstate, list_cb, &rock);
 
             if (rock.subs) strarray_free(rock.subs);
-            if (rock.server_table.size)
+            if (config_mupdate_server)
                 free_hash_table(&rock.server_table, NULL);
         }
 

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -876,7 +876,7 @@ static int deliver_merge_cancel(icalcomponent *ical,    // current iCalendar
     icalcomponent_kind kind = ICAL_NO_COMPONENT;
     icalproperty *prop;
     const char *recurid;
-    int num_canceled = 0;
+    size_t num_canceled = 0;
 
     /* Add each override component of current object to hash table */
     construct_hash_table(&override_table, 10, 1);
@@ -941,7 +941,7 @@ static int deliver_merge_cancel(icalcomponent *ical,    // current iCalendar
     }
 
     /* Did we cancel all instances? */
-    int ret = (num_canceled >= hash_numrecords(&override_table));
+    int ret = (num_canceled >= hash_count(&override_table));
 
     free_hash_table(&override_table, NULL);
 

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -868,7 +868,7 @@ static int deliver_merge_cancel(icalcomponent *ical,    // current iCalendar
     icalcomponent_kind kind = ICAL_NO_COMPONENT;
     icalproperty *prop;
     const char *recurid;
-    int num_canceled = 0;
+    size_t num_canceled = 0;
 
     /* Add each override component of current object to hash table */
     construct_hash_table(&override_table, 10, 1);
@@ -933,7 +933,7 @@ static int deliver_merge_cancel(icalcomponent *ical,    // current iCalendar
     }
 
     /* Did we cancel all instances? */
-    int ret = (num_canceled >= hash_numrecords(&override_table));
+    int ret = (num_canceled >= hash_count(&override_table));
 
     free_hash_table(&override_table, NULL);
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -12146,7 +12146,7 @@ static int jmap_participantidentity_changes(struct jmap_req *req)
 }
 
 HIDDEN json_t *jmap_calendar_events_from_msg(hash_table *icsbody_by_partid,
-                                             unsigned allow_max_uids,
+                                             size_t allow_max_uids,
                                              const struct buf *mime)
 {
     json_t *jsevents_by_partid = json_object();
@@ -12175,7 +12175,7 @@ HIDDEN json_t *jmap_calendar_events_from_msg(hash_table *icsbody_by_partid,
             construct_hash_table(&seen_uids, allow_max_uids + 1, 0);
 
             icalcomponent *comp = icalcomponent_get_first_real_component(ical);
-            while (comp && (unsigned)hash_numrecords(&seen_uids) <= allow_max_uids) {
+            while (comp && hash_count(&seen_uids) <= allow_max_uids) {
                 icalcomponent_kind kind = icalcomponent_isa(comp);
 
                 const char *uid = icalcomponent_get_uid(comp);
@@ -12185,7 +12185,7 @@ HIDDEN json_t *jmap_calendar_events_from_msg(hash_table *icsbody_by_partid,
                 comp = icalcomponent_get_next_component(ical, kind);
             }
 
-            unsigned nseen_uids = hash_numrecords(&seen_uids);
+            size_t nseen_uids = hash_count(&seen_uids);
             free_hash_table(&seen_uids, NULL);
 
             if (nseen_uids > allow_max_uids) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3767,8 +3767,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
         rock->imap_uid = cdata->dav.imap_uid;
         rock->is_draft = 0;
         message_guid_set_null(&rock->guid);
-        if (rock->ical_instances_by_recurid.size)
-            free_hash_table(&rock->ical_instances_by_recurid, _icalcomponent_free_cb);
+        free_hash_table(&rock->ical_instances_by_recurid, _icalcomponent_free_cb);
 
         /* Open calendar mailbox. */
         if (!rock->mailbox || strcmp(mailbox_uniqueid(rock->mailbox), rock->mbentry->uniqueid)) {
@@ -4257,8 +4256,7 @@ done:
     mboxlist_entry_free(&rock.mbentry);
     mbname_free(&rock.mbname);
     if (rock.ical) icalcomponent_free(rock.ical);
-    if (rock.ical_instances_by_recurid.size)
-        free_hash_table(&rock.ical_instances_by_recurid, _icalcomponent_free_cb);
+    free_hash_table(&rock.ical_instances_by_recurid, _icalcomponent_free_cb);
     free_hashu64_table(&rock.cache_jsevents, (void(*)(void*))json_decref);
     free_hash_table(&rock.floatingtz_by_mboxid, NULL); /* values owned by libical */
     if (ptrarray_size(&rock.malloced_fallbacktzs)) {
@@ -9221,8 +9219,7 @@ static void principalfilter_finiexpr(struct principalfilter_expr *expr)
 
 static void principalfilter_fini(struct principalfilter *filter)
 {
-    if (filter->props.size)
-        free_hash_table(&filter->props, NULL);
+    free_hash_table(&filter->props, NULL);
     if (filter->db)
         xapian_db_close(filter->db);
     if (filter->dbw)
@@ -11684,7 +11681,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
     jmap_ok(req, res);
 
 done:
-    if (eventids.size) free_hash_table(&eventids, NULL);
+    free_hash_table(&eventids, NULL);
     mailbox_close(&notifmbox);
     jmap_query_fini(&query);
     jmap_parser_fini(&parser);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3931,9 +3931,7 @@ static void getcalendarevents_reset_ical(struct getcalendarevents_rock *rock)
     rock->imap_uid = 0;
     rock->is_draft = 0;
     message_guid_set_null(&rock->guid);
-    if (rock->ical_instances_by_recurid.size)
-        free_hash_table(&rock->ical_instances_by_recurid,
-                        _icalcomponent_free_cb);
+    free_hash_table(&rock->ical_instances_by_recurid, _icalcomponent_free_cb);
 }
 
 static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
@@ -4507,8 +4505,7 @@ done:
     mboxlist_entry_free(&rock.mbentry);
     mbname_free(&rock.mbname);
     if (rock.ical) icalcomponent_free(rock.ical);
-    if (rock.ical_instances_by_recurid.size)
-        free_hash_table(&rock.ical_instances_by_recurid, _icalcomponent_free_cb);
+    free_hash_table(&rock.ical_instances_by_recurid, _icalcomponent_free_cb);
     free_hashu64_table(&rock.cache_jsevents, (void(*)(void*))json_decref);
     free_hash_table(&rock.floatingtz_by_mboxid, NULL); /* values owned by libical */
     if (ptrarray_size(&rock.malloced_fallbacktzs)) {
@@ -9403,8 +9400,7 @@ static void principalfilter_finiexpr(struct principalfilter_expr *expr)
 
 static void principalfilter_fini(struct principalfilter *filter)
 {
-    if (filter->props.size)
-        free_hash_table(&filter->props, NULL);
+    free_hash_table(&filter->props, NULL);
     if (filter->db)
         xapian_db_close(filter->db);
     if (filter->dbw)
@@ -11858,7 +11854,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
     jmap_ok(req, res);
 
 done:
-    if (eventids.size) free_hash_table(&eventids, NULL);
+    free_hash_table(&eventids, NULL);
     mailbox_close(&notifmbox);
     jmap_query_fini(&query);
     jmap_parser_fini(&parser);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4074,7 +4074,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
     }
 
     if (jscal->ical_recurid[0]) {
-        if (!rock->ical_instances_by_recurid.size) {
+        if (!hash_constructed(&rock->ical_instances_by_recurid)) {
             // first time we see a recurrence instance for this ical data.
             // prepare for any further callback calls for the same UID
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3815,7 +3815,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
     }
 
     if (jscal->ical_recurid[0]) {
-        if (!rock->ical_instances_by_recurid.size) {
+        if (!hash_constructed(&rock->ical_instances_by_recurid)) {
             // first time we see a recurrence instance for this ical data.
             // prepare for any further callback calls for the same UID
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -11564,6 +11564,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
     struct jmap_query query = JMAP_QUERY_INITIALIZER;
     struct mailbox *notifmbox = NULL;
     hash_table eventids = HASH_TABLE_INITIALIZER;
+    bool has_eventids = false;
 
     /* Parse request */
     json_t *err = NULL;
@@ -11611,6 +11612,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
     }
     jval = json_object_get(query.filter, "calendarEventIds");
     if (json_is_array(jval)) {
+        has_eventids = true;
         construct_hash_table(&eventids, json_array_size(jval)+1, 0);
         json_t *jid;
         size_t i;
@@ -11652,7 +11654,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
             before,
             after,
             type,
-            eventids.size ? &eventids : NULL
+            has_eventids ? &eventids : NULL
         };
         struct notifsearch search = {
             JMAP_NOTIF_CALENDAREVENT,

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -11737,6 +11737,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
     struct jmap_query query = JMAP_QUERY_INITIALIZER;
     struct mailbox *notifmbox = NULL;
     hash_table eventids = HASH_TABLE_INITIALIZER;
+    bool has_eventids = false;
 
     /* Parse request */
     json_t *err = NULL;
@@ -11784,6 +11785,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
     }
     jval = json_object_get(query.filter, "calendarEventIds");
     if (json_is_array(jval)) {
+        has_eventids = true;
         construct_hash_table(&eventids, json_array_size(jval)+1, 0);
         json_t *jid;
         size_t i;
@@ -11825,7 +11827,7 @@ static int jmap_calendareventnotification_query(struct jmap_req *req)
             before,
             after,
             type,
-            eventids.size ? &eventids : NULL
+            has_eventids ? &eventids : NULL
         };
         struct notifsearch search = {
             JMAP_NOTIF_CALENDAREVENT,

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -11981,7 +11981,7 @@ HIDDEN json_t *jmap_calendar_events_from_msg(jmap_req_t *req,
                                              const char *mboxid,
                                              uint32_t uid,
                                              hash_table *icsbody_by_partid,
-                                             unsigned allow_max_uids,
+                                             size_t allow_max_uids,
                                              const struct buf *mime)
 {
     json_t *jsevents_by_partid = json_object();
@@ -12014,7 +12014,7 @@ HIDDEN json_t *jmap_calendar_events_from_msg(jmap_req_t *req,
             construct_hash_table(&seen_uids, allow_max_uids + 1, 0);
 
             icalcomponent *comp = icalcomponent_get_first_real_component(ical);
-            while (comp && (unsigned)hash_numrecords(&seen_uids) <= allow_max_uids) {
+            while (comp && hash_count(&seen_uids) <= allow_max_uids) {
                 icalcomponent_kind kind = icalcomponent_isa(comp);
 
                 const char *uid = icalcomponent_get_uid(comp);
@@ -12024,7 +12024,7 @@ HIDDEN json_t *jmap_calendar_events_from_msg(jmap_req_t *req,
                 comp = icalcomponent_get_next_component(ical, kind);
             }
 
-            unsigned nseen_uids = hash_numrecords(&seen_uids);
+            size_t nseen_uids = hash_count(&seen_uids);
             free_hash_table(&seen_uids, NULL);
 
             if (nseen_uids > allow_max_uids) {

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -4846,7 +4846,7 @@ static json_t *jmap_card_from_vcard(const char *userid,
         goto done;
 
     /* Don't combine geographical props unless at least one ADR has GROUP set */
-    if (hash_numrecords(&adrs) == 1 && hash_lookup("", &adrs)) {
+    if (hash_count(&adrs) == 1 && hash_lookup("", &adrs)) {
         strarray_free(hash_del("", &adrs));
     }
 

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1089,7 +1089,7 @@ static int contact_textfilter_match(struct contact_textfilter *f, const char *te
     }
 
     /* Validate loose term search */
-    if (!termset->size) {
+    if (!hash_constructed(termset)) {
         /* Extract terms from text and store result in termset */
         xapian_doc_t *doc = xapian_doc_new();
         xapian_doc_index_text(doc, text, strlen(text));

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1005,7 +1005,7 @@ static int contact_textfilter_match(struct contact_textfilter *f, const char *te
     }
 
     /* Validate loose term search */
-    if (!termset->size) {
+    if (!hash_constructed(termset)) {
         /* Extract terms from text and store result in termset */
         xapian_doc_t *doc = xapian_doc_new();
         xapian_doc_index_text(doc, text, strlen(text));

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -168,7 +168,7 @@ static icalcomponent *icalcomps_by_uidrecurid(struct icalcomps *comps,
 
 static ptrarray_t *icalcomps_by_uid(struct icalcomps *comps, const char *uid)
 {
-    if (!comps || !comps->by_uid.size) {
+    if (!comps) {
         return NULL;
     }
     return hash_lookup(uid, &comps->by_uid);

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -147,13 +147,7 @@ static void icalcomps_init(struct icalcomps *comps, icalcomponent *ical)
 static void icalcomps_fini(struct icalcomps *comps)
 {
     if (comps->by_uid.size) {
-        hash_iter *hit = hash_table_iter(&comps->by_uid);
-        while (hash_iter_next(hit)) {
-            ptrarray_t *complist = hash_iter_val(hit);
-            ptrarray_free(complist);
-        }
-        hash_iter_free(&hit);
-        free_hash_table(&comps->by_uid, NULL);
+        free_hash_table(&comps->by_uid, (void (*)(void *)) &ptrarray_free);
     }
     if (comps->by_uidrecurid.size) {
         free_hash_table(&comps->by_uidrecurid, NULL);

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -154,7 +154,7 @@ static void icalcomps_fini(struct icalcomps *comps)
 static icalcomponent *icalcomps_by_uidrecurid(struct icalcomps *comps,
                                               icalcomponent *ofcomp)
 {
-    if (!comps || !comps->by_uidrecurid.size) {
+    if (!comps || !hash_count(&comps->by_uidrecurid)) {
         return NULL;
     }
 

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -146,12 +146,8 @@ static void icalcomps_init(struct icalcomps *comps, icalcomponent *ical)
 
 static void icalcomps_fini(struct icalcomps *comps)
 {
-    if (comps->by_uid.size) {
-        free_hash_table(&comps->by_uid, (void (*)(void *)) &ptrarray_free);
-    }
-    if (comps->by_uidrecurid.size) {
-        free_hash_table(&comps->by_uidrecurid, NULL);
-    }
+    free_hash_table(&comps->by_uid, (void (*)(void *)) &ptrarray_free);
+    free_hash_table(&comps->by_uidrecurid, NULL);
     buf_free(&comps->buf);
 }
 
@@ -1160,12 +1156,8 @@ static void jstimezones_add_vtimezones(jstimezones_t *jstzones, icalcomponent *i
 
 static void jstimezones_fini(jstimezones_t *jstzones)
 {
-    if (jstzones->byjstzid.size) {
-        free_hash_table(&jstzones->byjstzid, NULL);
-    }
-    if (jstzones->bytzid.size) {
-        free_hash_table(&jstzones->bytzid, NULL);
-    }
+    free_hash_table(&jstzones->byjstzid, NULL);
+    free_hash_table(&jstzones->bytzid, NULL);
 
     jstimezones_entry_t *jstz;
     while ((jstz = ptrarray_pop(&jstzones->entries))) {

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -5632,7 +5632,7 @@ participant_to_ical(icalcomponent *comp,
          * original data already only contained an ORGANIZER. */
         json_t *jorga = participant_from_ical(orga, NULL, orga, NULL);
         if (participant_equals(jorga, jpart) &&
-                (hash_numrecords(caladdress_by_participant_id) > 1 ||
+                (hash_count(caladdress_by_participant_id) > 1 ||
                  allow_organizer_attendee_only)) {
             icalproperty_free(prop);
             prop = NULL;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4406,10 +4406,8 @@ static void emailquery_uidsearch_result_free(void *rock)
         hashset_free(&rrock->savedates);
     if (rrock->seen_emails)
         hashset_free(&rrock->seen_emails);
-    if (rrock->partid_bynum.size)
-        free_hashu64_table(&rrock->partid_bynum, free);
-    if (rrock->partnum_byid.size)
-        free_hash_table(&rrock->partnum_byid, NULL);
+    free_hashu64_table(&rrock->partid_bynum, free);
+    free_hash_table(&rrock->partnum_byid, NULL);
 
     free(rrock);
 }
@@ -4564,9 +4562,7 @@ static void emailquery_cache_reset(struct emailquery_cache *qc)
         qc->qr.free(qc->qr.rock);
     }
     free(qc->nextinthread);
-    if (qc->firstinthread.size) {
-        free_hashu64_table(&qc->firstinthread, NULL);
-    }
+    free_hashu64_table(&qc->firstinthread, NULL);
     memset(qc, 0, sizeof(struct emailquery_cache));
 }
 
@@ -8197,7 +8193,7 @@ static int _email_get_bodies(jmap_req_t *req,
         }
         json_object_set_new(email, "calendarEvents", events);
 
-        if (icsbody_by_partid.size) free_hash_table(&icsbody_by_partid, NULL);
+        free_hash_table(&icsbody_by_partid, NULL);
         hashset_free(&icsguids);
     }
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -601,7 +601,7 @@ static struct header_prop *_header_parseprop(const char *s)
      * Any header not found in this map is allowed to be requested
      * in any form. */
     static hash_table allowed_header_forms = HASH_TABLE_INITIALIZER;
-    if (allowed_header_forms.size == 0) {
+    if (!hash_constructed(&allowed_header_forms)) {
         /* TODO initialize with all headers in RFC 5322 and RFC 2369 */
         construct_hash_table(&allowed_header_forms, 32, 0);
         hash_insert("bcc",
@@ -6939,7 +6939,7 @@ static int _email_get_keywords(jmap_req_t *req,
         int r = seen_open(req->userid, SEEN_CREATE, &ctx->seendb);
         if (r) return r;
     }
-    if (ctx->seenseq_by_mbox_id.size == 0) {
+    if (!hash_constructed(&ctx->seenseq_by_mbox_id)) {
         construct_hash_table(&ctx->seenseq_by_mbox_id, 128, 0);
     }
     /* Gather keywords for all message records */
@@ -8361,7 +8361,7 @@ static int _email_get_bodies(jmap_req_t *req,
             }
 
             if (is_icsbody && hashset_add(icsguids, &part->content_guid)) {
-                if (!icsbody_by_partid.size) {
+                if (!hash_constructed(&icsbody_by_partid)) {
                     construct_hash_table(&icsbody_by_partid, 32, 0);
                 }
                 hash_insert(part->part_id, part, &icsbody_by_partid);
@@ -8736,7 +8736,7 @@ static int jmap_email_get(jmap_req_t *req)
     if (args.bodyprops == NULL) {
         args.bodyprops = &_email_get_default_bodyprops;
 
-        if (args.bodyprops->size == 0) {
+        if (!hash_constructed(args.bodyprops)) {
             _email_init_default_props(args.bodyprops);
         }
     }
@@ -8819,7 +8819,7 @@ static int jmap_email_parse(jmap_req_t *req)
     if (getargs.props == NULL) {
         getargs.props = &_email_parse_default_props;
 
-        if (getargs.props->size == 0) {
+        if (!hash_constructed(getargs.props)) {
             _email_init_default_props(getargs.props);
         }
     }
@@ -8828,7 +8828,7 @@ static int jmap_email_parse(jmap_req_t *req)
     if (getargs.bodyprops == NULL) {
         getargs.bodyprops = &_email_get_default_bodyprops;
 
-        if (getargs.bodyprops->size == 0) {
+        if (!getargs.bodyprops->table) {
             _email_init_default_props(getargs.bodyprops);
         }
     }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4458,10 +4458,8 @@ static void emailquery_uidsearch_result_free(void *rock)
         hashset_free(&rrock->savedates);
     if (rrock->seen_emails)
         hashset_free(&rrock->seen_emails);
-    if (rrock->partid_bynum.size)
-        free_hashu64_table(&rrock->partid_bynum, free);
-    if (rrock->partnum_byid.size)
-        free_hash_table(&rrock->partnum_byid, NULL);
+    free_hashu64_table(&rrock->partid_bynum, free);
+    free_hash_table(&rrock->partnum_byid, NULL);
 
     free(rrock);
 }
@@ -4620,9 +4618,7 @@ static void emailquery_cache_reset(struct emailquery_cache *qc)
         qc->qr.free(qc->qr.rock);
     }
     free(qc->nextinthread);
-    if (qc->firstinthread.size) {
-        free_hashu64_table(&qc->firstinthread, NULL);
-    }
+    free_hashu64_table(&qc->firstinthread, NULL);
     memset(qc, 0, sizeof(struct emailquery_cache));
 }
 
@@ -8381,7 +8377,7 @@ static int _email_get_bodies(jmap_req_t *req,
         }
         json_object_set_new(email, "calendarEvents", events);
 
-        if (icsbody_by_partid.size) free_hash_table(&icsbody_by_partid, NULL);
+        free_hash_table(&icsbody_by_partid, NULL);
         hashset_free(&icsguids);
     }
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8182,7 +8182,7 @@ static int _email_get_bodies(jmap_req_t *req,
         }
 
         json_t *events = json_null();
-        if (hash_numrecords(&icsbody_by_partid)) {
+        if (hash_count(&icsbody_by_partid)) {
             r = _cyrusmsg_need_mime(msg);
             if (r) goto done;
             struct mailbox *mbox = NULL;
@@ -12153,7 +12153,7 @@ static void _email_bulkupdate_checklimits(struct email_bulkupdate *bulk)
 {
     /* Validate mailbox counts per email */
     hash_table mbox_ids_by_email_id = HASH_TABLE_INITIALIZER;
-    construct_hash_table(&mbox_ids_by_email_id, hash_numrecords(&bulk->uidrecs_by_email_id)+1, 0);
+    construct_hash_table(&mbox_ids_by_email_id, hash_count(&bulk->uidrecs_by_email_id)+1, 0);
 
     /* Collect current mailboxes per email */
     hash_iter *iter = hash_table_iter(&bulk->uidrecs_by_email_id);
@@ -12342,7 +12342,7 @@ static int _email_bulkupdate_plan_keywords(struct email_bulkupdate *bulk, ptrarr
     }
 
     hash_table seenseq_by_mbox_id = HASH_TABLE_INITIALIZER;
-    construct_hash_table(&seenseq_by_mbox_id, hash_numrecords(&bulk->plans_by_mbox_id)+1, 0);
+    construct_hash_table(&seenseq_by_mbox_id, hash_count(&bulk->plans_by_mbox_id)+1, 0);
 
     /* Plan keyword updates per mailbox */
     hash_iter *iter = hash_table_iter(&bulk->plans_by_mbox_id);
@@ -12658,7 +12658,7 @@ static int _email_bulkupdate_plan(struct email_bulkupdate *bulk, ptrarray_t *upd
     /* Validate plans */
     hash_table erroneous_plans = HASH_TABLE_INITIALIZER;
     construct_hash_table(&erroneous_plans,
-            hash_numrecords(&bulk->plans_by_mbox_id) + 1, 0);
+            hash_count(&bulk->plans_by_mbox_id) + 1, 0);
 
     /* Check permissions and quota */
     int check_quota = !ignorequota && !config_getswitch(IMAPOPT_QUOTA_USE_CONVERSATIONS);
@@ -12686,7 +12686,7 @@ static int _email_bulkupdate_plan(struct email_bulkupdate *bulk, ptrarray_t *upd
             }
         }
     }
-    if (hash_numrecords(&erroneous_plans)) {
+    if (hash_count(&erroneous_plans)) {
         /* Fail any update where the email is an erroneous mailbox plan */
         hash_iter_reset(plan_iter);
         while (hash_iter_next(plan_iter)) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -601,7 +601,7 @@ static struct header_prop *_header_parseprop(const char *s)
      * Any header not found in this map is allowed to be requested
      * in any form. */
     static hash_table allowed_header_forms = HASH_TABLE_INITIALIZER;
-    if (allowed_header_forms.size == 0) {
+    if (!hash_constructed(&allowed_header_forms)) {
         /* TODO initialize with all headers in RFC 5322 and RFC 2369 */
         construct_hash_table(&allowed_header_forms, 32, 0);
         hash_insert("bcc",
@@ -6748,7 +6748,7 @@ static int _email_get_keywords(jmap_req_t *req,
         int r = seen_open(req->userid, SEEN_CREATE, &ctx->seendb);
         if (r) return r;
     }
-    if (ctx->seenseq_by_mbox_id.size == 0) {
+    if (!hash_constructed(&ctx->seenseq_by_mbox_id)) {
         construct_hash_table(&ctx->seenseq_by_mbox_id, 128, 0);
     }
     /* Gather keywords for all message records */
@@ -8170,7 +8170,7 @@ static int _email_get_bodies(jmap_req_t *req,
             }
 
             if (is_icsbody && hashset_add(icsguids, &part->content_guid)) {
-                if (!icsbody_by_partid.size) {
+                if (!hash_constructed(&icsbody_by_partid)) {
                     construct_hash_table(&icsbody_by_partid, 32, 0);
                 }
                 hash_insert(part->part_id, part, &icsbody_by_partid);
@@ -8552,7 +8552,7 @@ static int jmap_email_get(jmap_req_t *req)
     if (args.bodyprops == NULL) {
         args.bodyprops = &_email_get_default_bodyprops;
 
-        if (args.bodyprops->size == 0) {
+        if (!hash_constructed(args.bodyprops)) {
             _email_init_default_props(args.bodyprops);
         }
     }
@@ -8635,7 +8635,7 @@ static int jmap_email_parse(jmap_req_t *req)
     if (getargs.props == NULL) {
         getargs.props = &_email_parse_default_props;
 
-        if (getargs.props->size == 0) {
+        if (!hash_constructed(getargs.props)) {
             _email_init_default_props(getargs.props);
         }
     }
@@ -8644,7 +8644,7 @@ static int jmap_email_parse(jmap_req_t *req)
     if (getargs.bodyprops == NULL) {
         getargs.bodyprops = &_email_get_default_bodyprops;
 
-        if (getargs.bodyprops->size == 0) {
+        if (!getargs.bodyprops->table) {
             _email_init_default_props(getargs.bodyprops);
         }
     }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1918,7 +1918,38 @@ static void _email_search_contactgroup(search_expr_t *parent,
                                        const char *attrname,
                                        hash_table *contactgroups)
 {
-    if (!contactgroups || !contactgroups->size) return;
+    if (!contactgroups) return;
+
+    /* At this point contactgroups must have entries - we can only get here if
+     * jmap_email_contactfilter_from_filtercondition() has been called,
+     * it called construct_hash_table(), and made one or more calls to
+     * hash_insert()
+     * The previous code assumed that it was possible for contactgroups to be
+     * non-NULL but point to an uninitialised hash table, and returned early
+     * in that case. That choice seemed conceptually buggy, because it's not
+     * consistent with the "hard false" SEOP_FALSE return just below - if the
+     * user is asking to filter on a groupid, and there are *no* group IDs, then
+     * the filter should return zero results, not return all results.
+     *
+     * It's actually already handled this way (failure) -
+     * _email_parse_filter_cb() correctly checks and propagates the error
+     * returned from jmap_email_contactfilter_from_filtercondition() and the
+     * search fails. In that function, for carddav_open_userid() to return NULL
+     * dav_open_userid() must fail - the user's SQLite DB on disk must be
+     * present AND corrupt. However, before we even reach that code path Cyrus
+     * has called my_dav_auth() in http_dav_sharing.c
+     * That calls webdav_open_userid(userid), which also calls
+     * dav_open_userid(userid). The failure path there is:
+     * if (!auth_webdavdb) {
+     *     syslog(LOG_ERR, "Unable to open WebDAV DB for userid: %s", userid);
+     *     return HTTP_UNAVAILABLE;
+     * }
+     * Hence that failure isn't even possible via the functions this source file
+     * - the only path that might cause contactgroups not be initialised is
+     * unreachable, because Cyrus will have already returned a 503 status
+     * response if the dav.db exists but can't be read.
+     * (Hence I can't write a test for it)
+     */
 
     strarray_t *members = hash_lookup(groupid, contactgroups);
     if (!members || !strarray_size(members)) {
@@ -4893,7 +4924,11 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     int r = 0;
 
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    modseq_t addrbook_modseq = contactgroups->size ?
+    /* This ternary tests whether the hash initialisation code in
+     * jmap_email_contactfilter_from_filtercondition() was called
+     * "ensure we have preconditions for lookups"
+     */
+    modseq_t addrbook_modseq = hash_constructed(contactgroups) ?
         jmap_modseq(req, MBTYPE_ADDRESSBOOK, 0) : 0;
     char *querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1918,7 +1918,38 @@ static void _email_search_contactgroup(search_expr_t *parent,
                                        const char *attrname,
                                        hash_table *contactgroups)
 {
-    if (!contactgroups || !contactgroups->size) return;
+    if (!contactgroups) return;
+
+    /* At this point contactgroups must have entries - we can only get here if
+     * jmap_email_contactfilter_from_filtercondition() has been called,
+     * it called construct_hash_table(), and made one or more calls to
+     * hash_insert()
+     * The previous code assumed that it was possible for contactgroups to be
+     * non-NULL but point to an uninitialised hash table, and returned early
+     * in that case. That choice seemed conceptually buggy, because it's not
+     * consistent with the "hard false" SEOP_FALSE return just below - if the
+     * user is asking to filter on a groupid, and there are *no* group IDs, then
+     * the filter should return zero results, not return all results.
+     *
+     * It's actually already handled this way (failure) -
+     * _email_parse_filter_cb() correctly checks and propagates the error
+     * returned from jmap_email_contactfilter_from_filtercondition() and the
+     * search fails. In that function, for carddav_open_userid() to return NULL
+     * dav_open_userid() must fail - the user's SQLite DB on disk must be
+     * present AND corrupt. However, before we even reach that code path Cyrus
+     * has called my_dav_auth() in http_dav_sharing.c
+     * That calls webdav_open_userid(userid), which also calls
+     * dav_open_userid(userid). The failure path there is:
+     * if (!auth_webdavdb) {
+     *     syslog(LOG_ERR, "Unable to open WebDAV DB for userid: %s", userid);
+     *     return HTTP_UNAVAILABLE;
+     * }
+     * Hence that failure isn't even possible via the functions this source file
+     * - the only path that might cause contactgroups not be initialised is
+     * unreachable, because Cyrus will have already returned a 503 status
+     * response if the dav.db exists but can't be read.
+     * (Hence I can't write a test for it)
+     */
 
     strarray_t *members = hash_lookup(groupid, contactgroups);
     if (!members || !strarray_size(members)) {
@@ -4954,7 +4985,11 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     int r = 0;
 
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    modseq_t addrbook_modseq = contactgroups->size ?
+    /* This ternary tests whether the hash initialisation code in
+     * jmap_email_contactfilter_from_filtercondition() was called
+     * "ensure we have preconditions for lookups"
+     */
+    modseq_t addrbook_modseq = hash_constructed(contactgroups) ?
         jmap_modseq(req, MBTYPE_ADDRESSBOOK, 0) : 0;
     char *querystate = NULL;
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8373,7 +8373,7 @@ static int _email_get_bodies(jmap_req_t *req,
         }
 
         json_t *events = json_null();
-        if (hash_numrecords(&icsbody_by_partid)) {
+        if (hash_count(&icsbody_by_partid)) {
             r = _cyrusmsg_need_mime(msg);
             if (r) goto done;
             events = jmap_calendar_events_from_msg(&icsbody_by_partid,
@@ -12363,7 +12363,7 @@ static void _email_bulkupdate_checklimits(struct email_bulkupdate *bulk)
 {
     /* Validate mailbox counts per email */
     hash_table mbox_ids_by_email_id = HASH_TABLE_INITIALIZER;
-    construct_hash_table(&mbox_ids_by_email_id, hash_numrecords(&bulk->uidrecs_by_email_id)+1, 0);
+    construct_hash_table(&mbox_ids_by_email_id, hash_count(&bulk->uidrecs_by_email_id)+1, 0);
 
     /* Collect current mailboxes per email */
     hash_iter *iter = hash_table_iter(&bulk->uidrecs_by_email_id);
@@ -12552,7 +12552,7 @@ static int _email_bulkupdate_plan_keywords(struct email_bulkupdate *bulk, ptrarr
     }
 
     hash_table seenseq_by_mbox_id = HASH_TABLE_INITIALIZER;
-    construct_hash_table(&seenseq_by_mbox_id, hash_numrecords(&bulk->plans_by_mbox_id)+1, 0);
+    construct_hash_table(&seenseq_by_mbox_id, hash_count(&bulk->plans_by_mbox_id)+1, 0);
 
     /* Plan keyword updates per mailbox */
     hash_iter *iter = hash_table_iter(&bulk->plans_by_mbox_id);
@@ -12868,7 +12868,7 @@ static int _email_bulkupdate_plan(struct email_bulkupdate *bulk, ptrarray_t *upd
     /* Validate plans */
     hash_table erroneous_plans = HASH_TABLE_INITIALIZER;
     construct_hash_table(&erroneous_plans,
-            hash_numrecords(&bulk->plans_by_mbox_id) + 1, 0);
+            hash_count(&bulk->plans_by_mbox_id) + 1, 0);
 
     /* Check permissions and quota */
     int check_quota = !ignorequota && !config_getswitch(IMAPOPT_QUOTA_USE_CONVERSATIONS);
@@ -12896,7 +12896,7 @@ static int _email_bulkupdate_plan(struct email_bulkupdate *bulk, ptrarray_t *upd
             }
         }
     }
-    if (hash_numrecords(&erroneous_plans)) {
+    if (hash_count(&erroneous_plans)) {
         /* Fail any update where the email is an erroneous mailbox plan */
         hash_iter_reset(plan_iter);
         while (hash_iter_next(plan_iter)) {

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -78,6 +78,10 @@ HIDDEN void jmap_email_contactfilter_init(const char *accountid,
                                           const struct namespace *namespace,
                                           struct email_contactfilter *cfilter)
 {
+    /* This memset() effectively assigns HASH_TABLE_INITIALIZER to the member
+     * .contactgroups. The later lazy initialisation of this hash table works
+     * because that macro expands to all zeros, identical to this memset().
+     */
     memset(cfilter, 0, sizeof(struct email_contactfilter));
     cfilter->accountid = accountid;
     cfilter->authstate = authstate;
@@ -248,6 +252,10 @@ HIDDEN int jmap_email_contactfilter_from_filtercondition(json_t *filter,
         havefield = 1;
         break;
     }
+
+    /* (Observe that the loop above has the same json_*() API calls as the
+     * loop below - the test above is "will the loop below find anything")
+     */
     if (!havefield) goto done;
 
     /* ensure we have preconditions for lookups */
@@ -259,6 +267,8 @@ HIDDEN int jmap_email_contactfilter_from_filtercondition(json_t *filter,
     /* Open CardDAV db for accountid */
     struct carddav_db *carddavdb = carddav_open_userid(cfilter->accountid);
     if (!carddavdb) {
+        /* This code is reachable by lmtpd, tested by deliver_corrupt_dav_db */
+
         syslog(LOG_ERR, "jmap: carddav_open_userid(%s) failed",
                cfilter->accountid);
         r = CYRUSDB_INTERNAL;
@@ -678,23 +688,27 @@ static xapian_query_t *_matchmime_query_new_contactgroup(const char *groupid,
 {
     xapian_query_t *xq = NULL;
 
-    if (cfilter->contactgroups.size) {
-        strarray_t *members = hash_lookup(groupid, &cfilter->contactgroups);
-        if (members && strarray_size(members)) {
-            ptrarray_t xsubqs = PTRARRAY_INITIALIZER;
-            int i;
-            for (i = 0; i < strarray_size(members); i++) {
-                const char *member = strarray_nth(members, i);
-                if (!strchr(member, '@')) continue;
-                xapian_query_t *xsubq = xapian_query_new_match(db, part, member);
-                if (xsubq) ptrarray_append(&xsubqs, xsubq);
-            }
-            if (ptrarray_size(&xsubqs)) {
-                xq = xapian_query_new_compound(db, /*is_or*/1,
-                        (xapian_query_t **) xsubqs.data, xsubqs.count);
-            }
-            ptrarray_fini(&xsubqs);
+    /* If this code is reached, then cfilter->contactgroups has always been
+     * initialised. If jmap_email_contactfilter_from_filtercondition() above
+     * fails to open dav.db then its error return is correctly handled by
+     * jmap_email_matchmime(), meaning that the latter does not call
+     * _matchmime_buildquery() and in turn that does not call this function.
+     */
+    strarray_t *members = hash_lookup(groupid, &cfilter->contactgroups);
+    if (members && strarray_size(members)) {
+        ptrarray_t xsubqs = PTRARRAY_INITIALIZER;
+        int i;
+        for (i = 0; i < strarray_size(members); i++) {
+            const char *member = strarray_nth(members, i);
+            if (!strchr(member, '@')) continue;
+            xapian_query_t *xsubq = xapian_query_new_match(db, part, member);
+            if (xsubq) ptrarray_append(&xsubqs, xsubq);
         }
+        if (ptrarray_size(&xsubqs)) {
+            xq = xapian_query_new_compound(db, /*is_or*/1,
+                    (xapian_query_t **) xsubqs.data, xsubqs.count);
+        }
+        ptrarray_fini(&xsubqs);
     }
     if (!xq) {
         xq = xapian_query_new_not(db, xapian_query_new_matchall(db));

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -251,7 +251,7 @@ HIDDEN int jmap_email_contactfilter_from_filtercondition(json_t *filter,
     if (!havefield) goto done;
 
     /* ensure we have preconditions for lookups */
-    if (!cfilter->contactgroups.size) {
+    if (!hash_constructed(&cfilter->contactgroups)) {
         /* Initialize groups lookup table */
         construct_hash_table(&cfilter->contactgroups, 32, 0);
     }

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -746,7 +746,7 @@ static int jmap_mailbox_get_cb(const mbentry_t *mbentry, void *_rock)
     if (rock->want) {
         hash_del(id, rock->want);
         // are we done looking?
-        if (!hash_numrecords(rock->want))
+        if (!hash_count(rock->want))
             return IMAP_OK_COMPLETED;
     }
 
@@ -2995,7 +2995,7 @@ static void _toposort_cb(const char *id, void *data, void *rock)
 static int _toposort(hash_table *parent_id_by_id, strarray_t *dst)
 {
     struct toposort topo = { parent_id_by_id, dst, HASH_TABLE_INITIALIZER, 0 };
-    construct_hash_table(&topo.visited, hash_numrecords(parent_id_by_id) + 1, 0);
+    construct_hash_table(&topo.visited, hash_count(parent_id_by_id) + 1, 0);
     hash_enumerate(topo.parent_id_by_id, _toposort_cb, &topo);
     free_hash_table(&topo.visited, NULL);
     free_hash_table(&topo.visited, NULL);

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -746,7 +746,7 @@ static int jmap_mailbox_get_cb(const mbentry_t *mbentry, void *_rock)
     if (rock->want) {
         hash_del(id, rock->want);
         // are we done looking?
-        if (!hash_numrecords(rock->want))
+        if (!hash_count(rock->want))
             return IMAP_OK_COMPLETED;
     }
 
@@ -3009,7 +3009,7 @@ static void _toposort_cb(const char *id, void *data, void *rock)
 static int _toposort(hash_table *parent_id_by_id, strarray_t *dst)
 {
     struct toposort topo = { parent_id_by_id, dst, HASH_TABLE_INITIALIZER, 0 };
-    construct_hash_table(&topo.visited, hash_numrecords(parent_id_by_id) + 1, 0);
+    construct_hash_table(&topo.visited, hash_count(parent_id_by_id) + 1, 0);
     hash_enumerate(topo.parent_id_by_id, _toposort_cb, &topo);
     free_hash_table(&topo.visited, NULL);
     free_hash_table(&topo.visited, NULL);

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -347,7 +347,7 @@ static void foreach_note(struct mailbox *mbox, hash_table *ids,
 
         void *data = NULL;
         const char *id = buf_cstring(&buf);
-        if (ids->size) {
+        if (ids) {
             /* Do we have this id? */
             data = hash_lookup(id, ids);
             if (!data) {
@@ -356,6 +356,9 @@ static void foreach_note(struct mailbox *mbox, hash_table *ids,
             }
 
             hash_del(id, ids);
+        }
+        else {
+            /* We have no list - act on everything */
         }
 
         proc(id, msg, data, rock);
@@ -389,6 +392,7 @@ static int jmap_note_get(jmap_req_t *req)
     hash_table ids = HASH_TABLE_INITIALIZER;
     struct buf buf = BUF_INITIALIZER;
     int rights;
+    bool specific_ids = false;
 
     jmap_get_parse(req, &parser, &notes_props, /*allow_null_ids*/1,
                    NULL, NULL, &get, &err);
@@ -423,6 +427,7 @@ static int jmap_note_get(jmap_req_t *req)
         size_t i;
         json_t *val;
 
+        specific_ids = true;
         construct_hash_table(&ids, 32, 0);
         
         json_array_foreach(get.ids, i, val) {
@@ -432,12 +437,14 @@ static int jmap_note_get(jmap_req_t *req)
 
     if ((rights & JACL_READITEMS) == JACL_READITEMS) {
         struct get_rock grock = { &get, &buf };
-        foreach_note(mbox, &ids, &_notes_get_cb, &grock);
+        foreach_note(mbox, specific_ids ? &ids : NULL, &_notes_get_cb, &grock);
     }
 
-    /* Any remaining ids are not found */
-    hash_enumerate(&ids, &not_found_cb, get.not_found);
-    free_hash_table(&ids, NULL);
+    if (specific_ids) {
+        /* Any remaining ids are not found */
+        hash_enumerate(&ids, &not_found_cb, get.not_found);
+        free_hash_table(&ids, NULL);
+    }
 
     /* Build response */
     buf_reset(&buf);

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -290,7 +290,7 @@ static icaltimezone *get_icaltimezone_for_tzid(jscal_ctx_t *ctx, const char *tzi
     if (!tzid) return NULL;
 
     icaltimezone *tz = icaltimezone_get_cyrus_timezone_from_tzid(tzid);
-    if (!tz && ctx->iana_tzid_by_custom_tzid.size) {
+    if (!tz) {
         const char *iana_tzid =
             hash_lookup(tzid, &ctx->iana_tzid_by_custom_tzid);
         if (iana_tzid) {

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -298,7 +298,7 @@ static icaltimezone *get_icaltimezone_for_tzid(jscal_ctx_t *ctx, const char *tzi
     if (!tzid) return NULL;
 
     icaltimezone *tz = icaltimezone_get_cyrus_timezone_from_tzid(tzid);
-    if (!tz && ctx->iana_tzid_by_custom_tzid.size) {
+    if (!tz) {
         const char *iana_tzid =
             hash_lookup(tzid, &ctx->iana_tzid_by_custom_tzid);
         if (iana_tzid) {

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -285,9 +285,7 @@ static void jscal_ctx_fini(jscal_ctx_t *ctx)
     guesstz_close(&ctx->gtz);
 #endif
 
-    if (ctx->iana_tzid_by_custom_tzid.size) {
-        free_hash_table(&ctx->iana_tzid_by_custom_tzid, free);
-    }
+    free_hash_table(&ctx->iana_tzid_by_custom_tzid, free);
 
     // VTIMEZONE pointers are owned by iCalendar object.
     ptrarray_fini(&ctx->unguessable_vtimezones);

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -349,7 +349,7 @@ static void guess_timezones(jscal_ctx_t *ctx, icalcomponent *ical)
         }
     }
 
-    if (!ctx->iana_tzid_by_custom_tzid.size) {
+    if (!hash_constructed(&ctx->iana_tzid_by_custom_tzid)) {
         construct_hash_table(&ctx->iana_tzid_by_custom_tzid,
                 ptrarray_size(&custom_vtzs), 0);
     }

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -357,7 +357,7 @@ static void guess_timezones(jscal_ctx_t *ctx, icalcomponent *ical)
         }
     }
 
-    if (!ctx->iana_tzid_by_custom_tzid.size) {
+    if (!hash_constructed(&ctx->iana_tzid_by_custom_tzid)) {
         construct_hash_table(&ctx->iana_tzid_by_custom_tzid,
                 ptrarray_size(&custom_vtzs), 0);
     }

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -277,9 +277,7 @@ static void jscal_ctx_fini(jscal_ctx_t *ctx)
     guesstz_close(&ctx->gtz);
 #endif
 
-    if (ctx->iana_tzid_by_custom_tzid.size) {
-        free_hash_table(&ctx->iana_tzid_by_custom_tzid, free);
-    }
+    free_hash_table(&ctx->iana_tzid_by_custom_tzid, free);
 
     // VTIMEZONE pointers are owned by iCalendar object.
     ptrarray_fini(&ctx->unguessable_vtimezones);

--- a/imap/jscontact.c
+++ b/imap/jscontact.c
@@ -2119,7 +2119,7 @@ static json_t *jscard_from_vcard(jscontact_ctx_t *ctx, vcardcomponent *vcard)
         goto done;
 
     /* Don't combine geographical props unless at least one ADR has GROUP set */
-    if (hash_numrecords(&adrs) == 1 && hash_lookup("", &adrs)) {
+    if (hash_count(&adrs) == 1 && hash_lookup("", &adrs)) {
         strarray_free(hash_del("", &adrs));
     }
 

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -290,8 +290,8 @@ static void do_collate_service_report(struct buf *buf)
     promdir_foreach(&accum_stats, PROMDIR_FOREACH_PIDS, &all_stats);
 
     report_time = now_ms();
-    syslog(LOG_DEBUG, "updating prometheus report for %d services",
-                      hash_numrecords(&all_stats));
+    syslog(LOG_DEBUG, "updating prometheus report for %zu services",
+                      hash_count(&all_stats));
 
     /* release .doneprocs.lock */
     xunlink(doneprocs_lock_fname);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -8640,7 +8640,7 @@ int sync_do_reader(struct sync_client_state *sync_cs, sync_log_reader_t *slr)
 
     /* And then run tasks. */
 
-    if (hash_numrecords(&user_mailboxes)) {
+    if (hash_count(&user_mailboxes)) {
         struct split_user_mailboxes_rock smrock;
         smrock.sync_cs = sync_cs;
         smrock.user_list = user_list;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -8679,7 +8679,7 @@ int sync_do_reader(struct sync_client_state *sync_cs, sync_log_reader_t *slr)
 
     /* And then run tasks. */
 
-    if (hash_numrecords(&user_mailboxes)) {
+    if (hash_count(&user_mailboxes)) {
         struct split_user_mailboxes_rock smrock;
         smrock.sync_cs = sync_cs;
         smrock.user_list = user_list;

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -1,4 +1,3 @@
-/* +++Date last modified: 05-Jul-1997 */
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -43,8 +42,8 @@ struct bucket {
 
 /* Initialize the hash_table to the size asked for.  Allocates space
 ** for the correct number of pointers and sets them to NULL.  If it
-** can't allocate sufficient memory, signals error by setting the size
-** of the table to 0.
+** can't allocate sufficient memory it will terminate the program with the
+** diagnostic "Virtual memory exhausted"
 */
 
 EXPORTED hash_table *construct_hash_table(hash_table *table, size_t size, int use_mpool)

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -13,6 +13,13 @@
 #include "util.h"
 #include "xmalloc.h"
 
+/* Ideally having this declaration with EXPORTED would be sufficient, and we
+ * could remove it from the definition in the header. gcc is fine with this,
+ * but clang treats it as an error.
+ * See the commit message for attempted approaches that failed. */
+
+EXPORTED extern inline size_t hash_count(const hash_table *table);
+
 struct bucket {
     void *data;
     struct bucket *next;
@@ -164,7 +171,7 @@ EXPORTED void *hash_lookup(const char *key, hash_table *table)
 {
       bucket *ptr;
 
-      if (!table->size)
+      if (!table->size || !table->count)
           return NULL;
 
       uint32_t hash = strhash_seeded(table->seed, key);
@@ -332,12 +339,6 @@ EXPORTED strarray_t *hash_keys(const hash_table *table)
     }
 
     return sa;
-}
-
-EXPORTED int hash_numrecords(hash_table *table)
-{
-    /* XXX macro or inline this if we keep the count field long term */
-    return table->count;
 }
 
 EXPORTED void hash_enumerate_sorted(hash_table *table, void (*func)(const char *, void *, void *),

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <syslog.h>
+#include <stdbool.h>
 
 #include "assert.h"
 #include "hash.h"
@@ -19,6 +20,7 @@
  * See the commit message for attempted approaches that failed. */
 
 EXPORTED extern inline size_t hash_count(const hash_table *table);
+EXPORTED extern inline bool hash_constructed(const hash_table *table);
 
 struct bucket {
     void *data;

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -13,6 +13,13 @@
 #include "util.h"
 #include "xmalloc.h"
 
+/* Ideally having this declaration with EXPORTED would be sufficient, and we
+ * could remove it from the definition in the header. gcc is fine with this,
+ * but clang treats it as an error.
+ * See the commit message for attempted approaches that failed. */
+
+EXPORTED extern inline size_t hash_count(const hash_table *table);
+
 struct bucket {
     void *data;
     struct bucket *next;
@@ -177,7 +184,7 @@ EXPORTED void *hash_lookup(const char *key, hash_table *table)
 {
       bucket *ptr;
 
-      if (!table->size)
+      if (!table->size || !table->count)
           return NULL;
 
       uint32_t hash = strhash_seeded(table->seed, key);
@@ -345,12 +352,6 @@ EXPORTED strarray_t *hash_keys(const hash_table *table)
     }
 
     return sa;
-}
-
-EXPORTED int hash_numrecords(hash_table *table)
-{
-    /* XXX macro or inline this if we keep the count field long term */
-    return table->count;
 }
 
 EXPORTED void hash_enumerate_sorted(hash_table *table, void (*func)(const char *, void *, void *),

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -1,4 +1,3 @@
-/* +++Date last modified: 05-Jul-1997 */
 #ifndef HASH__H
 #define HASH__H
 
@@ -20,7 +19,7 @@ typedef struct bucket bucket;
 
 /*
 ** This is what you actually declare an instance of to create a table.
-** You then call 'construct_table' with the address of this structure,
+** You then call 'construct_hash_table' with the address of this structure,
 ** and a guess at the size of the table.  Note that more nodes than this
 ** can be inserted in the table, but performance degrades as this
 ** happens.  Performance should still be quite adequate until 2 or 3
@@ -37,8 +36,8 @@ typedef struct hash_table {
 } hash_table;
 
 /*
-** This is used to construct the table.  If it doesn't succeed, it sets
-** the table's size to 0, and the pointer to the table to NULL.
+** This is used to construct the table.  If it can't allocate sufficient memory
+** it will terminate the program with the diagnostic "Virtual memory exhausted".
 */
 
 hash_table *construct_hash_table(hash_table *table, size_t size,
@@ -94,9 +93,9 @@ int hash_numrecords(hash_table *table);
 ** it calls the function whose address it was passed, with a pointer
 ** to the data that was in the table.  The function is expected to
 ** free the data.  Typical usage would be:
-** free_table(&table, free);
+** free_hash_table(&table, free);
 ** if the data placed in the table was dynamically allocated, or:
-** free_table(&table, NULL);
+** free_hash_table(&table, NULL);
 ** if not.  ( If the parameter passed is NULL, it knows not to call
 ** any function with the data. )
 */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>           /* For size_t     */
 #include <stdint.h>
+#include <stdbool.h>
 #include "mpool.h"
 #include "strarray.h"
 
@@ -103,6 +104,29 @@ strarray_t *hash_keys(const hash_table *table);
 EXPORTED inline size_t hash_count(const hash_table *table)
 {
     return table->count;
+}
+
+/* true if construct_hash_table() has been called on this hash table
+ * false if the memory has only been initialized with HASH_TABLE_INITIALIZER
+ * undefined if neither HASH_TABLE_INITIALIZER was used nor
+ * construct_hash_table() called.
+ *
+ * As free_hash_table() resets the memory to that same state, will be true after
+ * it has been called
+ * Encapsulates an idiom used by lots of Cyrus code to defer expensive
+ * initialization of hash tables until the first time they are actually needed
+ */
+
+EXPORTED inline bool hash_constructed(const hash_table *table)
+{
+    /* Currently this tests whether .table is non-NULL, but in future we might
+     * change the implementation further such that table isn't even allocated
+     * until the first hash_insert(), so we hide this lookup in a trivial named
+     * function, instead of exposing implementation details that might change
+     * everywhere in the main codebase.
+     */
+
+    return table->table;
 }
 
 /*

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -8,6 +8,13 @@
 
 #define HASH_TABLE_INITIALIZER {0, 0, 0, 0, NULL, NULL}
 
+/* This is an installed header, so it can't assume that EXPORTED is already
+ * defined. */
+
+#ifndef EXPORTED
+#define EXPORTED __attribute__((visibility("default")))
+#endif
+
 /*
 ** A hash table consists of an array of these buckets.  Each bucket
 ** holds a copy of the key, a pointer to the data associated with the
@@ -86,7 +93,10 @@ strarray_t *hash_keys(const hash_table *table);
 
 /* counts the number of nodes in the hash table */
 
-int hash_numrecords(hash_table *table);
+EXPORTED inline size_t hash_count(const hash_table *table)
+{
+    return table->count;
+}
 
 /*
 ** Frees a hash table.  For each node that was inserted in the table,

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>           /* For size_t     */
 #include <stdint.h>
+#include <stdbool.h>
 #include "mpool.h"
 #include "strarray.h"
 
@@ -96,6 +97,29 @@ strarray_t *hash_keys(const hash_table *table);
 EXPORTED inline size_t hash_count(const hash_table *table)
 {
     return table->count;
+}
+
+/* true if construct_hash_table() has been called on this hash table
+ * false if the memory has only been initialized with HASH_TABLE_INITIALIZER
+ * undefined if neither HASH_TABLE_INITIALIZER was used nor
+ * construct_hash_table() called.
+ *
+ * As free_hash_table() resets the memory to that same state, will be true after
+ * it has been called
+ * Encapsulates an idiom used by lots of Cyrus code to defer expensive
+ * initialization of hash tables until the first time they are actually needed
+ */
+
+EXPORTED inline bool hash_constructed(const hash_table *table)
+{
+    /* Currently this tests whether .table is non-NULL, but in future we might
+     * change the implementation further such that table isn't even allocated
+     * until the first hash_insert(), so we hide this lookup in a trivial named
+     * function, instead of exposing implementation details that might change
+     * everywhere in the main codebase.
+     */
+
+    return table->table;
 }
 
 /*

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -1,4 +1,3 @@
-/* +++Date last modified: 05-Jul-1997 */
 #ifndef HASH__H
 #define HASH__H
 
@@ -20,7 +19,7 @@ typedef struct bucket bucket;
 
 /*
 ** This is what you actually declare an instance of to create a table.
-** You then call 'construct_table' with the address of this structure,
+** You then call 'construct_hash_table' with the address of this structure,
 ** and a guess at the size of the table.  Note that more nodes than this
 ** can be inserted in the table, but performance degrades as this
 ** happens.  Performance should still be quite adequate until 2 or 3
@@ -37,8 +36,8 @@ typedef struct hash_table {
 } hash_table;
 
 /*
-** This is used to construct the table.  If it doesn't succeed, it sets
-** the table's size to 0, and the pointer to the table to NULL.
+** This is used to construct the table.  If it can't allocate sufficient memory
+** it will terminate the program with the diagnostic "Virtual memory exhausted".
 */
 
 hash_table *construct_hash_table(hash_table *table, size_t size,
@@ -101,9 +100,9 @@ int hash_numrecords(hash_table *table);
 ** it calls the function whose address it was passed, with a pointer
 ** to the data that was in the table.  The function is expected to
 ** free the data.  Typical usage would be:
-** free_table(&table, free);
+** free_hash_table(&table, free);
 ** if the data placed in the table was dynamically allocated, or:
-** free_table(&table, NULL);
+** free_hash_table(&table, NULL);
 ** if not.  ( If the parameter passed is NULL, it knows not to call
 ** any function with the data. )
 */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -8,6 +8,13 @@
 
 #define HASH_TABLE_INITIALIZER {0, 0, 0, 0, NULL, NULL}
 
+/* This is an installed header, so it can't assume that EXPORTED is already
+ * defined. */
+
+#ifndef EXPORTED
+#define EXPORTED __attribute__((visibility("default")))
+#endif
+
 /*
 ** A hash table consists of an array of these buckets.  Each bucket
 ** holds a copy of the key, a pointer to the data associated with the
@@ -93,7 +100,10 @@ strarray_t *hash_keys(const hash_table *table);
 
 /* counts the number of nodes in the hash table */
 
-int hash_numrecords(hash_table *table);
+EXPORTED inline size_t hash_count(const hash_table *table)
+{
+    return table->count;
+}
 
 /*
 ** Frees a hash table.  For each node that was inserted in the table,

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -1,4 +1,3 @@
-/* +++Date last modified: 05-Jul-1997 */
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -39,8 +38,8 @@ struct bucketu64 {
 
 /* Initialize the hashu64_table to the size asked for.  Allocates space
 ** for the correct number of pointers and sets them to NULL.  If it
-** can't allocate sufficient memory, signals error by setting the size
-** of the table to 0.
+** can't allocate sufficient memory it will terminate the program with the
+** diagnostic "Virtual memory exhausted"
 */
 
 EXPORTED hashu64_table *construct_hashu64_table(hashu64_table *table, size_t size, int use_mpool)

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -150,7 +150,6 @@ EXPORTED void *hashu64_lookup(uint64_t key, hashu64_table *table)
 EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
 {
       unsigned val = key % table->size;
-      void *data;
       bucketu64 *ptr, *last = NULL;
 
       if (!(table->table)[val])
@@ -170,15 +169,10 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
       {
           if (key == ptr->key)
           {
+              void *data = ptr->data;
               if (last != NULL)
               {
-                  data = ptr->data;
                   last->next = ptr->next;
-                  if(!table->pool) {
-                      free(ptr);
-                  }
-                  table->count--;
-                  return data;
               }
 
               /*
@@ -191,14 +185,13 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
 
               else
               {
-                  data = ptr->data;
                   (table->table)[val] = ptr->next;
-                  if(!table->pool) {
-                      free(ptr);
-                  }
-                  table->count--;
-                  return data;
               }
+              if(!table->pool) {
+                  free(ptr);
+              }
+              table->count--;
+              return data;
           }
       }
 

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -10,6 +10,8 @@
 #include "mpool.h"
 #include "xmalloc.h"
 
+EXPORTED extern inline size_t hashu64_count(const hashu64_table *table);
+
 struct bucketu64 {
     uint64_t key;
     void *data;
@@ -48,6 +50,7 @@ EXPORTED hashu64_table *construct_hashu64_table(hashu64_table *table, size_t siz
       assert(size);
 
       table->size  = size;
+      table->count = 0;
 
       /* Allocate the table -- different for using memory pools and not */
       if(use_mpool) {
@@ -109,6 +112,7 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
       newptr->data = data;
       newptr->next = (table->table)[val];
       (table->table)[val] = newptr;
+      table->count++;
       return data;
 }
 
@@ -120,7 +124,7 @@ EXPORTED void *hashu64_insert(uint64_t key, void *data, hashu64_table *table)
 
 EXPORTED void *hashu64_lookup(uint64_t key, hashu64_table *table)
 {
-      if (!table->size)
+      if (!table->size || !table->count)
           return NULL;
 
       unsigned val = key % table->size;
@@ -173,6 +177,7 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
                   if(!table->pool) {
                       free(ptr);
                   }
+                  table->count--;
                   return data;
               }
 
@@ -191,6 +196,7 @@ EXPORTED void *hashu64_del(uint64_t key, hashu64_table *table)
                   if(!table->pool) {
                       free(ptr);
                   }
+                  table->count--;
                   return data;
               }
           }
@@ -245,6 +251,7 @@ EXPORTED void free_hashu64_table(hashu64_table *table, void (*func)(void *))
       }
       table->table = NULL;
       table->size = 0;
+      table->count = 0;
 }
 
 /*
@@ -273,18 +280,3 @@ EXPORTED void hashu64_enumerate(hashu64_table *table,
             }
       }
 }
-
-EXPORTED size_t hashu64_count(hashu64_table *table)
-{
-    size_t count = 0;
-    unsigned i;
-
-    for (i = 0; i < table->size; i++) {
-        bucketu64 *temp;
-        for (temp = (table->table)[i]; temp; temp = temp->next)
-             count++;
-    }
-
-    return count;
-}
-

--- a/lib/hashu64.h
+++ b/lib/hashu64.h
@@ -1,4 +1,3 @@
-/* +++Date last modified: 05-Jul-1997 */
 #ifndef __CYRUS_HASHU64_H__
 #define __CYRUS_HASHU64_H__
 
@@ -17,7 +16,7 @@ typedef struct bucketu64 bucketu64;
 
 /*
 ** This is what you actually declare an instance of to create a table.
-** You then call 'construct_table' with the address of this structure,
+** You then call 'construct_hashu64_table' with the address of this structure,
 ** and a guess at the size of the table.  Note that more nodes than this
 ** can be inserted in the table, but performance degrades as this
 ** happens.  Performance should still be quite adequate until 2 or 3
@@ -31,8 +30,8 @@ typedef struct hashu64_table {
 } hashu64_table;
 
 /*
-** This is used to construct the table.  If it doesn't succeed, it sets
-** the table's size to 0, and the pointer to the table to NULL.
+** This is used to construct the table.  If it can't allocate sufficient memory
+** it will terminate the program with the diagnostic "Virtual memory exhausted".
 */
 
 hashu64_table *construct_hashu64_table(hashu64_table *table, size_t size,
@@ -81,9 +80,9 @@ size_t hashu64_count(hashu64_table *table);
 ** it calls the function whose address it was passed, with a pointer
 ** to the data that was in the table.  The function is expected to
 ** free the data.  Typical usage would be:
-** free_table(&table, free);
+** free_hashu64_table(&table, free);
 ** if the data placed in the table was dynamically allocated, or:
-** free_table(&table, NULL);
+** free_hashu64_table(&table, NULL);
 ** if not.  ( If the parameter passed is NULL, it knows not to call
 ** any function with the data. )
 */

--- a/lib/hashu64.h
+++ b/lib/hashu64.h
@@ -3,7 +3,11 @@
 
 #include <stddef.h>           /* For size_t     */
 
-#define HASHU64_TABLE_INITIALIZER {0, NULL, NULL}
+#define HASHU64_TABLE_INITIALIZER {0, 0, NULL, NULL}
+
+#ifndef EXPORTED
+#define EXPORTED __attribute__((visibility("default")))
+#endif
 
 /*
 ** A hash table consists of an array of these buckets.  Each bucket
@@ -25,6 +29,7 @@ typedef struct bucketu64 bucketu64;
 
 typedef struct hashu64_table {
     size_t size;
+    size_t count;
     bucketu64 **table;
     struct mpool *pool;
 } hashu64_table;
@@ -71,9 +76,12 @@ void *hashu64_del(uint64_t key,hashu64_table *table);
 void hashu64_enumerate(hashu64_table *table,void (*func)(uint64_t ,void *,void *),
                     void *rock);
 
+/* counts the number of nodes in the hash table */
 
-/* just count how many items are in the table */
-size_t hashu64_count(hashu64_table *table);
+EXPORTED inline size_t hashu64_count(const hashu64_table *table)
+{
+    return table->count;
+}
 
 /*
 ** Frees a hash table.  For each node that was inserted in the table,

--- a/lib/stristr.c
+++ b/lib/stristr.c
@@ -1,4 +1,3 @@
-/* +++Date last modified: 05-Jul-1997 */
 /*
 ** Designation:  StriStr
 **

--- a/sieve/sieve_interface.h
+++ b/sieve/sieve_interface.h
@@ -6,6 +6,7 @@
 #define SIEVE_H
 
 #include <stdio.h>
+#include <config.h>
 
 #define SIEVE_VERSION "CMU Sieve 3.0"
 


### PR DESCRIPTION
A common idiom in the Cyrus code is to look directly at the `.size` member of the hash table struct. This is problematic because

1. it breaks encapsulation
2. it's not always clear **why** the code is doing this
3. that member will be removed soon

hence this MR addresses that, and some other problems found

* fix errors in documentation
* rename `hash_numrecords` to `hash_count` and make it `static inline`
* jump through hoops to keep `clang` and `clang++` happy with the above
* improve test coverage of C code that is refactored
* remove code which inspected `.size` before calling `free_hash_table`
* change code implementing lazy hash initialisation to check `.table` instead of `.size`
* change code to use `hash_count` instead of reading `.size` for avoiding expensive key computation logic where there were no keys
* remove code which inspected `.size` simply to avoid calling into `hash_lookup`
* use booleans or NULL pointers to signal "no hash lookup needed" instead of looking at `.size`
* document the initialisation of `contactgroups->table`
* other minor cleanups