### PR TITLE
jmap_api.c: Fix reporting of isDefault (Calendar/Addressbook)

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_isdefault
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_isdefault
@@ -167,4 +167,69 @@ sub test_calendar_set_isdefault
     ]])->single_sentence("Calendar/set")->arguments;
 
     $self->assert_equals(JSON::null, $res->{updated});
+    $state = $res->{newState};
+
+    xlog $self, "change the default along with a name change";
+    $res = $jmap->request([[
+        'Calendar/set', {
+            update => {
+                $id2 => { name => 'foo2' },
+            },
+            onSuccessSetIsDefault => $id2
+        }
+    ]])->single_sentence("Calendar/set")->arguments;
+
+    $self->assert_cmp_deeply(
+        superhashof({
+            updated => {                   
+                $id2 => {isDefault => JSON::true},
+                $id3 => {isDefault => JSON::false},
+            },
+        }),
+        $res
+    );
+
+    $res = $jmap->request([[
+        'Calendar/changes' => {
+            sinceState => $state
+        },
+    ]])->single_sentence("Calendar/changes")->arguments;
+
+    $self->assert_cmp_deeply(
+        bag($id2, $id3),
+        $res->{updated}
+    );
+    $state = $res->{newState};
+
+    xlog $self, "change the default along with empty updates";
+    $res = $jmap->request([[
+        'Calendar/set', {
+            update => {
+                $id2 => { },
+                $id3 => { },
+            },
+            onSuccessSetIsDefault => $id3
+        }
+    ]])->single_sentence("Calendar/set")->arguments;
+
+    $self->assert_cmp_deeply(
+        superhashof({
+            updated => {                   
+                $id2 => {isDefault => JSON::false},
+                $id3 => {isDefault => JSON::true},
+            },
+        }),
+        $res
+    );
+
+    $res = $jmap->request([[
+        'Calendar/changes' => {
+            sinceState => $state
+        },
+    ]])->single_sentence("Calendar/changes")->arguments;
+
+    $self->assert_cmp_deeply(
+        bag($id2, $id3),
+        $res->{updated}
+    );
 }

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -3618,18 +3618,21 @@ EXPORTED void jmap_report_isdefault(struct jmap_set *set, const char *name,
     else
         obj = json_object_get(set->updated, id);
 
-    if (obj) {
+    if (json_is_object(obj)) {
         json_object_set_new(obj, "isDefault", json_boolean(isdef));
     }
     else {
-        /* Bump modseq so the mailbox shows up in /changes */
-        struct mailbox *mailbox = NULL;
+        /* Did we make any other updates to the mailbox? */
+        if (!json_object_size(json_object_get(set->update, id))) {
+            /* Bump modseq so the mailbox shows up in /changes */
+            struct mailbox *mailbox = NULL;
 
-        mailbox_open_iwl(name, &mailbox);
-        if (mailbox) {
-            mboxlist_update_foldermodseq(name,
-                                         mailbox_modseq_dirty(mailbox));
-            mailbox_close(&mailbox);
+            mailbox_open_iwl(name, &mailbox);
+            if (mailbox) {
+                mboxlist_update_foldermodseq(name,
+                                             mailbox_modseq_dirty(mailbox));
+                mailbox_close(&mailbox);
+            }
         }
 
         json_object_set_new(set->updated, id,


### PR DESCRIPTION
If a calendar/addressbook was updated and didn't have to report any changes to the client, then its id would appear in 'updated' but as a JSON NULL rather than as a JSON object.
We were mistakenly trying to add 'isDefault' to a JSON NULL rather than creating a JSON object containing 'isDefault'.

This commit also now only bumps the modseq of a mailbox if it hasn't already been updated (its only update will be the side-effect of 'on_success_set_is_default')