### PR TITLE
Add a test showing isDefault JMAP Calendar doesn't persist

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_get_isdefault_persists
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_get_isdefault_persists
@@ -1,0 +1,37 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_get_isdefault_persists
+    :min_version_3_1
+    :CalDAVNoDefaultCalendar
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    $user->calendars->create;
+
+    my $res = $jmap->request([
+      [ 'Calendar/get', { properties => [ 'id', 'isDefault' ] }, ],
+    ]);
+
+    my $cal = $res->sentence_named("Calendar/get")->arguments->{list}[0];
+    $self->assert_equals(JSON::true, $cal->{isDefault});
+
+    my $def_id = $cal->{id};
+    $self->assert($def_id);
+
+    $user->calendars->create;
+
+    $res = $jmap->request([
+      [ 'Calendar/get', { properties => [ 'id', 'isDefault' ] }, ],
+    ]);
+
+    my @def = grep { $_->{isDefault} }
+        $res->sentence_named("Calendar/get")->arguments->{list}->@*;
+
+    $self->assert_cmp_deeply(
+      [ superhashof({ id => $def_id }) ],
+      \@def,
+    );
+}


### PR DESCRIPTION
If the config option `caldav_create_default` is disabled, cyrus will pick different calendar ids in different calls to Calendar/get.

It should pick one and persist it...