### PR TITLE
jmap_push.c: use correct state strings for StateChange object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ imap/imapd
 imap/ipurge
 imap/jmap_*_props.c
 imap/jmap_*_props.h
+imap/jmap_data_types.h
 imap/jmap_err.c
 imap/jmap_err.h
 imap/lmtp_err.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ CLEANFILES = \
     lib/imapopts.c \
     lib/imapopts.h \
     imap/css3_color_array.h \
+    imap/jmap_data_types.h \
     imap/rfc822_header.h \
     imap/mailbox_header_cache.h
 
@@ -360,6 +361,7 @@ EXTRA_DIST = \
     imap/http_err.et \
     imap/imap_err.et \
     imap/jmap_err.et \
+    imap/jmap_data_types.gperf \
     imap/lmtp_err.et \
     imap/mailbox_header_cache.gperf \
     imap/mupdate_err.et \
@@ -1308,6 +1310,7 @@ imap_httpd_LDADD = $(LD_SIEVE_ADD) $(LD_SERVER_ADD)
 
 if JMAP
 BUILT_SOURCES += \
+    imap/jmap_data_types.h \
     imap/jmap_err.c \
     imap/jmap_err.h
 
@@ -1430,6 +1433,7 @@ imap_libcyrus_jmap_props_la_SOURCES += \
 endif
 
 nodist_imap_httpd_SOURCES += \
+    imap/jmap_data_types.h \
     imap/jmap_err.c \
     imap/jmap_err.h
 
@@ -1525,8 +1529,8 @@ imap_unexpunge_LDADD = $(LD_UTILITY_ADD)
 	$(AM_V_GEN)(cd $(@D) && $(COMPILE_ET) $(realpath $<))
 
 # Build specific *.h from *.gperf
-gperf_tables = imap/css3_color_array.h imap/mailbox_header_cache.h \
-	imap/rfc822_header.h lib/htmlchar.h
+gperf_tables = imap/css3_color_array.h imap/jmap_data_types.h \
+	imap/mailbox_header_cache.h imap/rfc822_header.h lib/htmlchar.h
 
 $(gperf_tables): %.h: %.gperf
 	$(AM_V_GEN)gperf $< > $@.NEW && mv $@.NEW $@

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -32,17 +32,39 @@ sub new
                  jmap_max_size_request => '4k',
                  jmap_mail_max_size_attachments_per_email => '1m',
                  jmap_nonstandard_extensions => 'yes',
+                 notesmailbox => 'Notes',
                  httpallowcompress => 'no');
 
     my $self = $class->SUPER::new({
         config => $config,
         jmap => 1,
         adminstore => 1,
-        services => [ 'imap', 'http' ]
+        smtpdaemon => 1,
+        services => [ 'imap', 'http', 'sieve' ]
     }, @args);
 
     $self->needs('component', 'jmap');
+    $self->needs('component', 'sieve');
     return $self;
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+
+    if ($self->{jmap}) {
+        $self->{jmap}->DefaultUsing([
+            'urn:ietf:params:jmap:core',
+            'urn:ietf:params:jmap:mail',
+            'urn:ietf:params:jmap:submission',
+            'urn:ietf:params:jmap:vacationresponse',
+            'urn:ietf:params:jmap:calendars',
+            'urn:ietf:params:jmap:contacts',
+            'urn:ietf:params:jmap:sieve',
+            'https://cyrusimap.org/ns/jmap/notes',
+        ]);
+    }
 }
 
 use Cassandane::Tiny::Loader;

--- a/cassandane/Cassandane/Cyrus/JMAPCore.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCore.pm
@@ -29,7 +29,7 @@ sub new
                  conversations => 'yes',
                  httpmodules => 'carddav caldav jmap',
                  jmap_max_size_upload => '1k',
-                 jmap_max_size_request => '1k',
+                 jmap_max_size_request => '4k',
                  jmap_mail_max_size_attachments_per_email => '1m',
                  jmap_nonstandard_extensions => 'yes',
                  httpallowcompress => 'no');

--- a/cassandane/tiny-tests/JMAPCore/eventsource
+++ b/cassandane/tiny-tests/JMAPCore/eventsource
@@ -2,17 +2,19 @@
 use Cassandane::Tiny;
 
 sub test_eventsource
-    :min_version_3_5 :JMAPExtensions :NoAltNameSpace
+    :JMAPExtensions :NoAltNameSpace
     ($self)
 {
     my $jmap = $self->{jmap};
 
+    xlog $self, "get StateChange object for certain types";
     my $session = $jmap->get_client_session->client_session;
     $self->assert_not_null($session);
     my $event_relative = $session->{eventSourceUrl};
     $self->assert_not_null($event_relative);
 
-    $self->assert_num_equals(1, $event_relative =~ s/\{types\}/Mailbox,Email,Calendar,CalendarEvent,AddressBook,ContactCard/g);
+    my $types = 'Mailbox,Email,Calendar,CalendarEvent,AddressBook,ContactCard';
+    $self->assert_num_equals(1, $event_relative =~ s/\{types\}/$types/g);
     $self->assert_num_equals(1, $event_relative =~ s/\{closeafter\}/state/g);
     $self->assert_num_equals(1, $event_relative =~ s/\{ping\}/0/g);
 
@@ -47,4 +49,115 @@ sub test_eventsource
     $self->assert_not_null($data->{changed}->{cassandane}->{CalendarEvent});
     $self->assert_not_null($data->{changed}->{cassandane}->{AddressBook});
     $self->assert_not_null($data->{changed}->{cassandane}->{ContactCard});
+
+    xlog $self, "create new resources and get states";
+    my $res = $jmap->CallMethods([
+        ['Email/set', {
+            create => {
+                email => {
+                    mailboxIds => {
+                        '$inbox' => JSON::true
+                    },
+                    from => [{ email => q{foo@bar} }],
+                    to => [{ email => q{bar@foo} }],
+                    sentAt => '2019-05-02T03:15:00+07:00',
+                    subject => "test",
+                    bodyStructure => {
+                        partId => '1',
+                    },
+                    bodyValues => {
+                        "1" => {
+                            value => "A text body",
+                        },
+                    },
+                }
+            },
+        }, 'R0'],
+        ['EmailSubmission/set', {
+            create => {
+                submit => {
+                    emailId  => '#email',
+                    envelope => {
+                        mailFrom => {
+                            email => 'from@localhost',
+                        },
+                        rcptTo => [
+                            { email => 'rcpt2@localhost' }
+                        ],
+                    },
+                }
+            }
+        }, 'R1'],
+        ['VacationResponse/set', {
+            update => {
+                "singleton" => {
+                    isEnabled=> JSON::true,
+                    textBody => "Gone fishing"
+                }
+            }
+        }, 'R2'],
+        ['CalendarEvent/set', {
+            create => {
+                event => {
+                    title=> "foo",
+                    start=> "2015-11-07T09:00:00",
+                    duration=> "PT5M",
+                }
+            }
+        }, 'R3'],
+        ['ContactCard/set', {
+            create => {
+                "1" => {
+                    '@type' => 'Card',
+                    version => '1.0',
+                    name => { full => 'foo' }
+                }
+            }
+        }, 'R4'],
+        ['Note/set', {
+            create => {
+                note => {
+                    title  => 'Hello',
+                    body   => 'Hello World',
+                    isHTML => JSON::false,
+                },
+            }
+        }, 'R5'],
+        [ 'Mailbox/get', { }, 'R6' ],
+        [ 'Calendar/get', { }, 'R7' ],
+        [ 'AddressBook/get', { }, 'R8' ],
+        [ 'SieveScript/get', { }, 'R9' ],
+    ]);
+
+    xlog $self, "get StateChange object for ALL types";
+    $event_uri =~ s/\?types=$types/\?types=\*/;
+    $es_request->uri($event_uri);
+    $http_res = $jmap->http_request($es_request);
+    $self->assert_str_equals('200', $http_res->code);
+    $self->assert_str_equals('text/event-stream',
+                             $http_res->header('content-type'));
+    $self->assert_null($http_res->header('content-length'));
+
+    %event = $http_res->decoded_content(charset => undef) =~ /^(\w+): ?(.*)$/mg;
+    $self->assert_not_null($event{id});
+    $self->assert_str_equals('state', $event{event});
+
+    $data = eval { decode_json($event{data}) };
+
+    xlog $self, "verify that states for each object match";
+    $self->assert_cmp_deeply(
+        superhashof({
+            Email => $res->[0][1]->{newState},
+            EmailSubmission => $res->[1][1]->{newState},
+            VacationResponse => $res->[2][1]->{newState},
+            CalendarEvent => $res->[3][1]->{newState},
+            ContactCard => $res->[4][1]->{newState},
+            Note => $res->[5][1]->{newState},
+            Mailbox => $res->[6][1]->{'state'},
+            Calendar => $res->[7][1]->{'state'},
+            AddressBook => $res->[8][1]->{'state'},
+            SieveScript => $res->[9][1]->{'state'},
+        }),
+        $data->{changed}{cassandane}
+    );
 }

--- a/cassandane/tiny-tests/JMAPCore/request_too_large
+++ b/cassandane/tiny-tests/JMAPCore/request_too_large
@@ -12,7 +12,7 @@ sub test_request_too_large ($self)
             'Content-Type' => 'application/json',
             $jmap->_maybe_auth_header,
         ],
-        'X' x 1025,
+        'X' x 4097,
     );
 
     my $http_res = $jmap->http_request($http_req);

--- a/imap/http_jmap.c
+++ b/imap/http_jmap.c
@@ -1353,7 +1353,7 @@ static struct prot_waitevent *ws_push(struct protstream *s __attribute__((unused
     if (jstate) {
         /* Add pushState */
         buf_reset(buf);
-        buf_printf(buf, MODSEQ_FMT, jpush->counters.highestmodseq);
+        buf_printf(buf, MODSEQ_FMT, jpush->highestmodseq);
 
         json_object_set_new(jstate, "pushState", json_string(buf_cstring(buf)));
 
@@ -1568,7 +1568,7 @@ static struct prot_waitevent *es_push(struct protstream *s __attribute__((unused
             /* 'state' event */
             event = "state";
             buf_reset(buf);
-            buf_printf(buf, "id: " MODSEQ_FMT "\n", jpush->counters.highestmodseq);
+            buf_printf(buf, "id: " MODSEQ_FMT "\n", jpush->highestmodseq);
 
             if (jpush->closeafter) {
                 do_close = 1;

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -17,6 +17,7 @@
 #include "http_dav.h"
 #include "http_dav_sharing.h"
 #include "http_jmap.h"
+#include "jmap_data_types.h"
 #include "imparse.h"
 #include "mboxname.h"
 #include "msgrecord.h"

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -101,6 +101,7 @@ enum {
 typedef struct {
     const char *name;
     uint32_t kind;
+    bool has_quota;
 } jmap_data_type_t;
 
 const jmap_data_type_t *jmap_data_types_lookup(register const char *str,

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -95,6 +95,8 @@ enum {
     JMAP_TYPE_CALENDAREVENT,
     JMAP_TYPE_CALENDAREVENTNOTIFICATION,
     JMAP_TYPE_PARTICIPANTIDENTITY,
+    JMAP_TYPE_NOTE,
+    /* Non-standard */
     JMAP_NUM_TYPES  /* MUST always be last */
 };
 
@@ -102,6 +104,8 @@ typedef struct {
     const char *name;
     uint32_t kind;
     bool has_quota;
+    uint32_t mbtype;
+    off_t modseq_offset;
 } jmap_data_type_t;
 
 const jmap_data_type_t *jmap_data_types_lookup(register const char *str,

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -64,6 +64,50 @@ enum {
     JMAP_NUM_LIMITS  /* MUST be last */
 };
 
+/* JMAP Data Types */
+enum {
+    /* RFC 8620 */
+    JMAP_TYPE_CORE = 0,
+    JMAP_TYPE_PUSHSUBSCRIPTION,
+    /* RFC 8621 */
+    JMAP_TYPE_MAILBOX,
+    JMAP_TYPE_THREAD,
+    JMAP_TYPE_EMAIL,
+    JMAP_TYPE_EMAILDELIVERY,
+    JMAP_TYPE_SEARCHSNIPPET,
+    JMAP_TYPE_IDENTITY,
+    JMAP_TYPE_EMAILSUBMISSION,
+    JMAP_TYPE_VACATIONRESPONSE,
+    /* RFC 9007 */
+    JMAP_TYPE_MDN,
+    /* RFC 9425 */
+    JMAP_TYPE_QUOTA,
+    /* RFC 9661 */
+    JMAP_TYPE_SIEVESCRIPT,
+    /* RFC 9670 */
+    JMAP_TYPE_PRINCIPAL,
+    JMAP_TYPE_SHARENOTIFICATION,
+    /* RFC 9610 */
+    JMAP_TYPE_ADDRESSBOOK,
+    JMAP_TYPE_CONTACTCARD,
+    /* draft-ietf-jmap-calendars */
+    JMAP_TYPE_CALENDAR,
+    JMAP_TYPE_CALENDAREVENT,
+    JMAP_TYPE_CALENDAREVENTNOTIFICATION,
+    JMAP_TYPE_PARTICIPANTIDENTITY,
+    JMAP_NUM_TYPES  /* MUST always be last */
+};
+
+typedef struct {
+    const char *name;
+    uint32_t kind;
+} jmap_data_type_t;
+
+const jmap_data_type_t *jmap_data_types_lookup(register const char *str,
+                                               register size_t len);
+void jmap_data_types_foreach(void (*cb)(const jmap_data_type_t *, void *),
+                             void *rock);
+
 /* JMAP Mail (RFC 8621) privileges */
 #define JACL_READITEMS      (ACL_READ|ACL_LOOKUP)
 #define JACL_ADDITEMS       ACL_INSERT

--- a/imap/jmap_data_types.gperf
+++ b/imap/jmap_data_types.gperf
@@ -1,0 +1,66 @@
+%{
+/* jmap_data_types.h -- Lookup function for JMAP Data Types */
+/* SPDX-License-Identifier: BSD-3-Clause-CMU */
+/* See COPYING file at the root of the distribution for more details. */
+
+#include "imap/jmap_api.h"
+
+%}
+
+%enum
+%null-strings
+%global-table
+%readonly-tables
+%compare-lengths
+%struct-type
+%omit-struct-type
+
+%define slot-name             name
+%define initializer-suffix    ,UINT32_MAX
+%define word-array-name       jmap_data_types
+%define lookup-function-name  jmap_data_types_lookup
+
+jmap_data_type_t;
+
+%%
+# RFC 8620
+"Core",                      JMAP_TYPE_CORE
+"PushSubscription",          JMAP_TYPE_PUSHSUBSCRIPTION
+# RFC 8621
+"Mailbox",                   JMAP_TYPE_MAILBOX
+"Thread",                    JMAP_TYPE_THREAD
+"Email",                     JMAP_TYPE_EMAIL
+"EmailDelivery",             JMAP_TYPE_EMAILDELIVERY
+"SearchSnippet",             JMAP_TYPE_SEARCHSNIPPET
+"Identity",                  JMAP_TYPE_IDENTITY
+"EmailSubmission",           JMAP_TYPE_EMAILSUBMISSION
+"VacationResponse",          JMAP_TYPE_VACATIONRESPONSE
+# RFC 9007
+"MDN",                       JMAP_TYPE_MDN
+# RFC 9425
+"Quota",                     JMAP_TYPE_QUOTA
+# RFC 9661
+"SieveScript",               JMAP_TYPE_SIEVESCRIPT
+# RFC 9670
+"Principal",                 JMAP_TYPE_PRINCIPAL
+"ShareNotification",         JMAP_TYPE_SHARENOTIFICATION
+# RFC 9610
+"AddressBook",               JMAP_TYPE_ADDRESSBOOK
+"ContactCard",               JMAP_TYPE_CONTACTCARD
+# draft-ietf-jmap-calendars
+"Calendar",                  JMAP_TYPE_CALENDAR
+"CalendarEvent",             JMAP_TYPE_CALENDAREVENT
+"CalendarEventNotification", JMAP_TYPE_CALENDAREVENTNOTIFICATION
+"ParticipantIdentity",       JMAP_TYPE_PARTICIPANTIDENTITY
+%%
+
+
+void jmap_data_types_foreach(void (*cb)(const jmap_data_type_t *, void *),
+                             void *rock)
+{
+    for (unsigned i = MIN_HASH_VALUE; i <= MAX_HASH_VALUE; i++) {
+        const jmap_data_type_t *jtype = &jmap_data_types[i];
+
+        if (jtype->name) cb(jtype, rock);
+    }
+}

--- a/imap/jmap_data_types.gperf
+++ b/imap/jmap_data_types.gperf
@@ -16,7 +16,7 @@
 %omit-struct-type
 
 %define slot-name             name
-%define initializer-suffix    ,UINT32_MAX,false
+%define initializer-suffix    ,UINT32_MAX,false,MBTYPE_UNKNOWN,-1
 %define word-array-name       jmap_data_types
 %define lookup-function-name  jmap_data_types_lookup
 
@@ -24,34 +24,36 @@ jmap_data_type_t;
 
 %%
 # RFC 8620
-"Core",                      JMAP_TYPE_CORE,                      false
-"PushSubscription",          JMAP_TYPE_PUSHSUBSCRIPTION,          false
+"Core",                      JMAP_TYPE_CORE,                      false, MBTYPE_UNKNOWN,     -1
+"PushSubscription",          JMAP_TYPE_PUSHSUBSCRIPTION,          false, MBTYPE_UNKNOWN,     -1
 # RFC 8621
-"Mailbox",                   JMAP_TYPE_MAILBOX,                   true
-"Thread",                    JMAP_TYPE_THREAD,                    false
-"Email",                     JMAP_TYPE_EMAIL,                     true
-"EmailDelivery",             JMAP_TYPE_EMAILDELIVERY,             false
-"SearchSnippet",             JMAP_TYPE_SEARCHSNIPPET,             false
-"Identity",                  JMAP_TYPE_IDENTITY,                  false
-"EmailSubmission",           JMAP_TYPE_EMAILSUBMISSION,           true
-"VacationResponse",          JMAP_TYPE_VACATIONRESPONSE,          true
+"Mailbox",                   JMAP_TYPE_MAILBOX,                   true,  MBTYPE_EMAIL,       offsetof(struct mboxname_counters, mailmodseq)
+"Thread",                    JMAP_TYPE_THREAD,                    false, MBTYPE_UNKNOWN,     -1
+"Email",                     JMAP_TYPE_EMAIL,                     true,  MBTYPE_EMAIL,       offsetof(struct mboxname_counters, mailmodseq)
+"EmailDelivery",             JMAP_TYPE_EMAILDELIVERY,             false, MBTYPE_UNKNOWN,     -1
+"SearchSnippet",             JMAP_TYPE_SEARCHSNIPPET,             false, MBTYPE_UNKNOWN,     -1
+"Identity",                  JMAP_TYPE_IDENTITY,                  false, MBTYPE_UNKNOWN,     -1
+"EmailSubmission",           JMAP_TYPE_EMAILSUBMISSION,           true,  MBTYPE_JMAPSUBMIT,  offsetof(struct mboxname_counters, submissionmodseq)
+"VacationResponse",          JMAP_TYPE_VACATIONRESPONSE,          true,  MBTYPE_SIEVE,       offsetof(struct mboxname_counters, sievemodseq)
 # RFC 9007
-"MDN",                       JMAP_TYPE_MDN,                       false
+"MDN",                       JMAP_TYPE_MDN,                       false, MBTYPE_UNKNOWN,     -1
 # RFC 9425
-"Quota",                     JMAP_TYPE_QUOTA,                     false
+"Quota",                     JMAP_TYPE_QUOTA,                     false, MBTYPE_UNKNOWN,     -1
 # RFC 9661
-"SieveScript",               JMAP_TYPE_SIEVESCRIPT,               true
+"SieveScript",               JMAP_TYPE_SIEVESCRIPT,               true,  MBTYPE_SIEVE,       offsetof(struct mboxname_counters, sievemodseq)
 # RFC 9670
-"Principal",                 JMAP_TYPE_PRINCIPAL,                 false
-"ShareNotification",         JMAP_TYPE_SHARENOTIFICATION,         false
+"Principal",                 JMAP_TYPE_PRINCIPAL,                 false, MBTYPE_UNKNOWN,     -1
+"ShareNotification",         JMAP_TYPE_SHARENOTIFICATION,         false, MBTYPE_UNKNOWN,     -1
 # RFC 9610
-"AddressBook",               JMAP_TYPE_ADDRESSBOOK,               true
-"ContactCard",               JMAP_TYPE_CONTACTCARD,               true
+"AddressBook",               JMAP_TYPE_ADDRESSBOOK,               true,  MBTYPE_ADDRESSBOOK, offsetof(struct mboxname_counters, carddavmodseq)
+"ContactCard",               JMAP_TYPE_CONTACTCARD,               true,  MBTYPE_ADDRESSBOOK, offsetof(struct mboxname_counters, carddavmodseq)
 # draft-ietf-jmap-calendars
-"Calendar",                  JMAP_TYPE_CALENDAR,                  true
-"CalendarEvent",             JMAP_TYPE_CALENDAREVENT,             true
-"CalendarEventNotification", JMAP_TYPE_CALENDAREVENTNOTIFICATION, false
-"ParticipantIdentity",       JMAP_TYPE_PARTICIPANTIDENTITY,       false
+"Calendar",                  JMAP_TYPE_CALENDAR,                  true,  MBTYPE_CALENDAR,    offsetof(struct mboxname_counters, caldavmodseq)
+"CalendarEvent",             JMAP_TYPE_CALENDAREVENT,             true,  MBTYPE_CALENDAR,    offsetof(struct mboxname_counters, caldavmodseq)
+"CalendarEventNotification", JMAP_TYPE_CALENDAREVENTNOTIFICATION, false, MBTYPE_UNKNOWN,     -1
+"ParticipantIdentity",       JMAP_TYPE_PARTICIPANTIDENTITY,       false, MBTYPE_UNKNOWN,     -1
+# Non-standard
+"Note",                      JMAP_TYPE_NOTE,                      false, MBTYPE_COLLECTION,  offsetof(struct mboxname_counters, notesmodseq)
 %%
 
 

--- a/imap/jmap_data_types.gperf
+++ b/imap/jmap_data_types.gperf
@@ -16,7 +16,7 @@
 %omit-struct-type
 
 %define slot-name             name
-%define initializer-suffix    ,UINT32_MAX
+%define initializer-suffix    ,UINT32_MAX,false
 %define word-array-name       jmap_data_types
 %define lookup-function-name  jmap_data_types_lookup
 
@@ -24,34 +24,34 @@ jmap_data_type_t;
 
 %%
 # RFC 8620
-"Core",                      JMAP_TYPE_CORE
-"PushSubscription",          JMAP_TYPE_PUSHSUBSCRIPTION
+"Core",                      JMAP_TYPE_CORE,                      false
+"PushSubscription",          JMAP_TYPE_PUSHSUBSCRIPTION,          false
 # RFC 8621
-"Mailbox",                   JMAP_TYPE_MAILBOX
-"Thread",                    JMAP_TYPE_THREAD
-"Email",                     JMAP_TYPE_EMAIL
-"EmailDelivery",             JMAP_TYPE_EMAILDELIVERY
-"SearchSnippet",             JMAP_TYPE_SEARCHSNIPPET
-"Identity",                  JMAP_TYPE_IDENTITY
-"EmailSubmission",           JMAP_TYPE_EMAILSUBMISSION
-"VacationResponse",          JMAP_TYPE_VACATIONRESPONSE
+"Mailbox",                   JMAP_TYPE_MAILBOX,                   true
+"Thread",                    JMAP_TYPE_THREAD,                    false
+"Email",                     JMAP_TYPE_EMAIL,                     true
+"EmailDelivery",             JMAP_TYPE_EMAILDELIVERY,             false
+"SearchSnippet",             JMAP_TYPE_SEARCHSNIPPET,             false
+"Identity",                  JMAP_TYPE_IDENTITY,                  false
+"EmailSubmission",           JMAP_TYPE_EMAILSUBMISSION,           true
+"VacationResponse",          JMAP_TYPE_VACATIONRESPONSE,          true
 # RFC 9007
-"MDN",                       JMAP_TYPE_MDN
+"MDN",                       JMAP_TYPE_MDN,                       false
 # RFC 9425
-"Quota",                     JMAP_TYPE_QUOTA
+"Quota",                     JMAP_TYPE_QUOTA,                     false
 # RFC 9661
-"SieveScript",               JMAP_TYPE_SIEVESCRIPT
+"SieveScript",               JMAP_TYPE_SIEVESCRIPT,               true
 # RFC 9670
-"Principal",                 JMAP_TYPE_PRINCIPAL
-"ShareNotification",         JMAP_TYPE_SHARENOTIFICATION
+"Principal",                 JMAP_TYPE_PRINCIPAL,                 false
+"ShareNotification",         JMAP_TYPE_SHARENOTIFICATION,         false
 # RFC 9610
-"AddressBook",               JMAP_TYPE_ADDRESSBOOK
-"ContactCard",               JMAP_TYPE_CONTACTCARD
+"AddressBook",               JMAP_TYPE_ADDRESSBOOK,               true
+"ContactCard",               JMAP_TYPE_CONTACTCARD,               true
 # draft-ietf-jmap-calendars
-"Calendar",                  JMAP_TYPE_CALENDAR
-"CalendarEvent",             JMAP_TYPE_CALENDAREVENT
-"CalendarEventNotification", JMAP_TYPE_CALENDAREVENTNOTIFICATION
-"ParticipantIdentity",       JMAP_TYPE_PARTICIPANTIDENTITY
+"Calendar",                  JMAP_TYPE_CALENDAR,                  true
+"CalendarEvent",             JMAP_TYPE_CALENDAREVENT,             true
+"CalendarEventNotification", JMAP_TYPE_CALENDAREVENTNOTIFICATION, false
+"ParticipantIdentity",       JMAP_TYPE_PARTICIPANTIDENTITY,       false
 %%
 
 

--- a/imap/jmap_push.c
+++ b/imap/jmap_push.c
@@ -8,29 +8,44 @@
 #include <syslog.h>
 #include <time.h>
 
+#include "jmap_api.h"
 #include "jmap_push.h"
 
 
 int jmap_push_poll = 0;
 
 
-static const struct datatype_t {
-    const char *name;
-    size_t offset;
-} dataTypes[] = {
-    { "Mailbox",         offsetof(struct mboxname_counters, mailfoldersmodseq)   },
-    { "Email",           offsetof(struct mboxname_counters, mailmodseq)          },
-    { "EmailSubmission", offsetof(struct mboxname_counters, submissionmodseq)    },
-    { "Calendar",        offsetof(struct mboxname_counters, caldavfoldersmodseq) },
-    { "CalendarEvent",   offsetof(struct mboxname_counters, caldavmodseq)        },
-    { "AddressBook",     offsetof(struct mboxname_counters, carddavfoldersmodseq)},
-    { "ContactCard",     offsetof(struct mboxname_counters, carddavmodseq)       },
-    { "SieveScript",     offsetof(struct mboxname_counters, sievemodseq)         },
-    /* legacy/non-standard types */
-    { "Contact",         offsetof(struct mboxname_counters, carddavmodseq)       },
-    { "Note",            offsetof(struct mboxname_counters, notesmodseq)         },
-    { NULL,              0 }
+typedef struct {
+    const jmap_data_type_t *data_type;
+    modseq_t lastmodseq;
+} jmap_type_state_t;
+
+struct add_type_rock {
+    ptrarray_t *type_states;
+    struct mboxname_counters *cur_counters;
+    modseq_t lastmodseq;
 };
+
+static void add_type_cb(const jmap_data_type_t *dtype, void *rock)
+{
+    if (dtype->modseq_offset >= 0) {
+        jmap_type_state_t *state = xmalloc(sizeof(jmap_type_state_t));
+        struct add_type_rock *arock = rock;
+
+        state->data_type = dtype;
+
+        if (arock->lastmodseq == ULLONG_MAX) {
+            modseq_t *cur_modseq =
+                (modseq_t *)((off_t) arock->cur_counters + dtype->modseq_offset);
+            state->lastmodseq = *cur_modseq;
+        }
+        else {
+            state->lastmodseq = arock->lastmodseq;
+        }
+
+        ptrarray_append(arock->type_states, state);
+    }
+}
 
 EXPORTED jmap_push_ctx_t *jmap_push_init(struct transaction_t *txn,
                                          const char *accountid,
@@ -39,13 +54,23 @@ EXPORTED jmap_push_ctx_t *jmap_push_init(struct transaction_t *txn,
 {
     jmap_push_ctx_t *jpush = (jmap_push_ctx_t *) txn->push_ctx;
     struct mboxname_counters cur_counters;
-    const struct datatype_t *dtype;
 
     if (!jpush) {
+        struct conversations_state *cstate = NULL;
+
+        /* Need cstate for state string generation */
+        if (conversations_open_user(accountid, 1/*shared*/, &cstate)) {
+            /* Something went wrong */
+            jmap_push_done(txn);
+            return NULL;
+        }
+
         jpush = xzmalloc(sizeof(jmap_push_ctx_t));
 
         jpush->accountid = xstrdup(accountid);
         jpush->inboxname = mboxname_user_mbox(jpush->accountid, NULL);
+        jpush->req.userid = jpush->req.accountid = jpush->accountid;
+        jpush->req.cstate = cstate;
     }
 
     if (lastmodseq == ULLONG_MAX) {
@@ -56,34 +81,19 @@ EXPORTED jmap_push_ctx_t *jmap_push_init(struct transaction_t *txn,
         }
     }
 
-    /* Initialize our tracking modseqs to the maximum value */
-    for (dtype = dataTypes; dtype->name; dtype++) {
-        modseq_t *modseq =
-            (modseq_t *)((size_t) &jpush->counters + dtype->offset);
-        *modseq = ULLONG_MAX;
+    /* Build an array of states (with start modseq) for the specified types */
+    struct add_type_rock arock =
+        { &jpush->type_states, &cur_counters, lastmodseq };
+    if (strarray_find(types, "*", 0) >= 0) {
+        jmap_data_types_foreach(&add_type_cb, &arock);
     }
+    else {
+        for (int i = 0; i < strarray_size(types); i++) {
+            const char *type = strarray_nth(types, i);
+            const jmap_data_type_t *dtype =
+                jmap_data_types_lookup(type, strlen(type));
 
-    /* Set the start modseq for the specified types */
-    int i;
-    for (i = 0; i < strarray_size(types); i++) {
-        const char *type = strarray_nth(types, i);
-
-        for (dtype = dataTypes; dtype->name; dtype++) {
-            if (!strcmpsafe(type, dtype->name) || !strcmpsafe(type, "*")) {
-                modseq_t *modseq =
-                    (modseq_t *)((size_t) &jpush->counters + dtype->offset);
-
-                if (lastmodseq == ULLONG_MAX) {
-                    modseq_t *cur_modseq =
-                        (modseq_t *)((size_t) &cur_counters + dtype->offset);
-                    *modseq = *cur_modseq;
-                }
-                else {
-                    *modseq = lastmodseq;
-                }
-
-                if (*type != '*') break;
-            }
+            if (dtype) add_type_cb(dtype, &arock);
         }
     }
 
@@ -105,6 +115,16 @@ EXPORTED void jmap_push_done(struct transaction_t *txn)
 
     if (!jpush) return;
 
+    /* Free the array of type states */
+    ptrarray_t *states = &jpush->type_states;
+    for (int i = 0; i < ptrarray_size(states); i++) {
+        free(ptrarray_nth(states, i));
+    }
+    ptrarray_fini(states);
+
+    /* Close cstate */
+    conversations_abort(&jpush->req.cstate);
+
     if (jpush->wait) prot_removewaitevent(txn->conn->pin, jpush->wait);
     free(jpush->accountid);
     free(jpush->inboxname);
@@ -117,7 +137,6 @@ EXPORTED void jmap_push_done(struct transaction_t *txn)
 EXPORTED json_t *jmap_push_get_state(jmap_push_ctx_t *jpush)
 {
     struct mboxname_counters cur_counters;
-    struct buf *buf = &jpush->buf;
     json_t *jstate = NULL;
 
     if (mboxname_read_counters(jpush->inboxname, &cur_counters)) {
@@ -129,23 +148,24 @@ EXPORTED json_t *jmap_push_get_state(jmap_push_ctx_t *jpush)
 
     /* See if anything has changed */
     json_t *changed = json_object();
-    const struct datatype_t *dtype;
-    for (dtype = dataTypes; dtype->name; dtype++) {
-        modseq_t *modseq =
-            (modseq_t *)((size_t) &jpush->counters + dtype->offset);
+    ptrarray_t *states = &jpush->type_states;
+    for (int i = 0; i < ptrarray_size(states); i++) {
+        jmap_type_state_t *tstate = ptrarray_nth(states, i);;
         modseq_t *cur_modseq =
-            (modseq_t *)((size_t) &cur_counters + dtype->offset);
+            (modseq_t *)((off_t) &cur_counters + tstate->data_type->modseq_offset);
 
-        if (*modseq < *cur_modseq) {
-            *modseq = *cur_modseq;
+        if (tstate->lastmodseq < *cur_modseq) {
+            tstate->lastmodseq = *cur_modseq;
 
-            buf_reset(buf);
-            buf_printf(buf, MODSEQ_FMT, *modseq);
-            json_object_set_new(changed, dtype->name, json_string(buf_cstring(buf)));
+            char *newstate = jmap_state_string(&jpush->req, *cur_modseq,
+                                               tstate->data_type->mbtype, 0);
+            json_object_set_new(changed, tstate->data_type->name,
+                                json_string(newstate));
+            free(newstate);
         }
     }
 
-    jpush->counters.highestmodseq = cur_counters.highestmodseq;
+    jpush->highestmodseq = cur_counters.highestmodseq;
 
     if (json_object_size(changed)) {
         jstate = json_pack("{ s:s s:{ s:o } }",

--- a/imap/jmap_push.h
+++ b/imap/jmap_push.h
@@ -15,6 +15,7 @@
 extern int jmap_push_poll;
 
 typedef struct jmap_push_ctx {
+    jmap_req_t req;
     char *accountid;
     char *inboxname;
     int ping;
@@ -22,7 +23,8 @@ typedef struct jmap_push_ctx {
     time_t next_poll;
     unsigned closeafter : 1;
     struct prot_waitevent *wait;
-    struct mboxname_counters counters;
+    modseq_t highestmodseq;
+    ptrarray_t type_states;
     struct buf buf;
 } jmap_push_ctx_t;
 

--- a/imap/jmap_quota.c
+++ b/imap/jmap_quota.c
@@ -148,38 +148,6 @@ done:
     return 0;
 }
 
-/*
- * RFC 9425 methods
- */
-#define JMAP_TYPE_EMAIL            (1<<0)
-#define JMAP_TYPE_MAILBOX          (1<<1)
-#define JMAP_TYPE_EMAILSUBMISSION  (1<<2)
-#define JMAP_TYPE_VACATIONRESPONSE (1<<3)
-#define JMAP_TYPE_SIEVESCRIPT      (1<<4)
-#define JMAP_TYPE_CALENDAR         (1<<5)
-#define JMAP_TYPE_CALENDAREVENT    (1<<6)
-#define JMAP_TYPE_ADDRESSBOOK      (1<<7)
-#define JMAP_TYPE_CONTACT          (1<<8)
-#define JMAP_TYPE_CONTACTGROUP     (1<<9)
-
-static const struct jtype_t {
-    unsigned long bit;
-    const char *name;
-
-} jtypes[] = {
-    { JMAP_TYPE_EMAIL,            "Email"            },
-    { JMAP_TYPE_MAILBOX,          "Mailbox"          },
-    { JMAP_TYPE_EMAILSUBMISSION,  "EmailSubmission"  },
-    { JMAP_TYPE_VACATIONRESPONSE, "VacationResponse" },
-    { JMAP_TYPE_SIEVESCRIPT,      "SieveScript"      },
-    { JMAP_TYPE_CALENDAR,         "Calendar"         },
-    { JMAP_TYPE_CALENDAREVENT,    "CalendarEvent"    },
-    { JMAP_TYPE_ADDRESSBOOK,      "AddressBook"      },
-    { JMAP_TYPE_CONTACT,          "Contact"          },
-    { JMAP_TYPE_CONTACTGROUP,     "ContactGroup"     },
-    { 0,                          NULL               }
-};
-
 static const struct jquota_type_t {
     const char idkey;
     const char *junits;
@@ -198,8 +166,10 @@ struct jquota_root_t {
     quota_t used;
     quota_t limit;
     modseq_t modseq;
-    unsigned long type_mask;
+    uint32_t type_mask;
 };
+
+#define QMASK_BIT(kind) (1 << kind)
 
 struct qrock_t {
     jmap_req_t *req;
@@ -212,7 +182,7 @@ struct qrock_t {
 static int fetch_quotas_cb(struct quota *q, void *rock)
 {
     struct qrock_t *qrock = rock;
-    unsigned long type_masks[QUOTA_NUMRESOURCES] = { 0 };
+    uint32_t type_masks[QUOTA_NUMRESOURCES] = { 0 };
     enum quota_resource qres;
     struct buf buf = BUF_INITIALIZER;
     mbentry_t *mbentry = NULL;
@@ -231,33 +201,31 @@ static int fetch_quotas_cb(struct quota *q, void *rock)
         if (strcmp(mbentry->name, qrock->inboxname)) goto done;
 
         name = "root";
-        type_masks[QUOTA_STORAGE]    |= JMAP_TYPE_EMAIL;
-        type_masks[QUOTA_MESSAGE]    |= JMAP_TYPE_EMAIL;
-        type_masks[QUOTA_NUMFOLDERS] |= JMAP_TYPE_MAILBOX;
+        type_masks[QUOTA_STORAGE]    |= QMASK_BIT(JMAP_TYPE_EMAIL);
+        type_masks[QUOTA_MESSAGE]    |= QMASK_BIT(JMAP_TYPE_EMAIL);
+        type_masks[QUOTA_NUMFOLDERS] |= QMASK_BIT(JMAP_TYPE_MAILBOX);
 
         /* Add all other requests types
            and remove them if we find a type-specific quotaroot */
         if (jmap_is_using(qrock->req, JMAP_URN_SUBMISSION)) {
-            type_masks[QUOTA_STORAGE] |= JMAP_TYPE_EMAILSUBMISSION;
-            type_masks[QUOTA_MESSAGE] |= JMAP_TYPE_EMAILSUBMISSION;
+            type_masks[QUOTA_STORAGE] |= QMASK_BIT(JMAP_TYPE_EMAILSUBMISSION);
+            type_masks[QUOTA_MESSAGE] |= QMASK_BIT(JMAP_TYPE_EMAILSUBMISSION);
         }
         if (jmap_is_using(qrock->req, JMAP_URN_VACATION)) {
-            type_masks[QUOTA_STORAGE] |= JMAP_TYPE_VACATIONRESPONSE;
+            type_masks[QUOTA_STORAGE] |= QMASK_BIT(JMAP_TYPE_VACATIONRESPONSE);
         }
         if (jmap_is_using(qrock->req, JMAP_URN_SIEVE)) {
-            type_masks[QUOTA_STORAGE] |= JMAP_TYPE_SIEVESCRIPT;
+            type_masks[QUOTA_STORAGE] |= QMASK_BIT(JMAP_TYPE_SIEVESCRIPT);
         }
         if (jmap_is_using(qrock->req, JMAP_URN_CALENDARS)) {
-            type_masks[QUOTA_STORAGE]    |= JMAP_TYPE_CALENDAREVENT;
-            type_masks[QUOTA_MESSAGE]    |= JMAP_TYPE_CALENDAREVENT;
-            type_masks[QUOTA_NUMFOLDERS] |= JMAP_TYPE_CALENDAR;
+            type_masks[QUOTA_STORAGE]    |= QMASK_BIT(JMAP_TYPE_CALENDAREVENT);
+            type_masks[QUOTA_MESSAGE]    |= QMASK_BIT(JMAP_TYPE_CALENDAREVENT);
+            type_masks[QUOTA_NUMFOLDERS] |= QMASK_BIT(JMAP_TYPE_CALENDAR);
         }
         if (jmap_is_using(qrock->req, JMAP_CONTACTS_EXTENSION)) {
-            type_masks[QUOTA_STORAGE] |=
-                JMAP_TYPE_CONTACT | JMAP_TYPE_CONTACTGROUP;
-            type_masks[QUOTA_MESSAGE] |=
-                JMAP_TYPE_CONTACT | JMAP_TYPE_CONTACTGROUP;
-            type_masks[QUOTA_NUMFOLDERS] |= JMAP_TYPE_ADDRESSBOOK;
+            type_masks[QUOTA_STORAGE]    |= QMASK_BIT(JMAP_TYPE_CONTACTCARD);
+            type_masks[QUOTA_MESSAGE]    |= QMASK_BIT(JMAP_TYPE_CONTACTCARD);
+            type_masks[QUOTA_NUMFOLDERS] |= QMASK_BIT(JMAP_TYPE_ADDRESSBOOK);
         }
         break;
 
@@ -265,8 +233,8 @@ static int fetch_quotas_cb(struct quota *q, void *rock)
         if (!jmap_is_using(qrock->req, JMAP_URN_MAIL)) goto done;
 
         name = "submission";
-        type_masks[QUOTA_STORAGE] |= JMAP_TYPE_EMAILSUBMISSION;
-        type_masks[QUOTA_MESSAGE] |= JMAP_TYPE_EMAILSUBMISSION;
+        type_masks[QUOTA_STORAGE] |= QMASK_BIT(JMAP_TYPE_EMAILSUBMISSION);
+        type_masks[QUOTA_MESSAGE] |= QMASK_BIT(JMAP_TYPE_EMAILSUBMISSION);
         break;
 
     case MBTYPE_SIEVE:
@@ -275,11 +243,11 @@ static int fetch_quotas_cb(struct quota *q, void *rock)
 
         name = "sieve";
         if (jmap_is_using(qrock->req, JMAP_URN_VACATION)) {
-            type_masks[QUOTA_STORAGE] |= JMAP_TYPE_VACATIONRESPONSE;
+            type_masks[QUOTA_STORAGE] |= QMASK_BIT(JMAP_TYPE_VACATIONRESPONSE);
         }
         if (jmap_is_using(qrock->req, JMAP_URN_SIEVE)) {
-            type_masks[QUOTA_STORAGE] |= JMAP_TYPE_SIEVESCRIPT;
-            type_masks[QUOTA_MESSAGE] |= JMAP_TYPE_SIEVESCRIPT;
+            type_masks[QUOTA_STORAGE] |= QMASK_BIT(JMAP_TYPE_SIEVESCRIPT);
+            type_masks[QUOTA_MESSAGE] |= QMASK_BIT(JMAP_TYPE_SIEVESCRIPT);
         }
         break;
 
@@ -288,9 +256,9 @@ static int fetch_quotas_cb(struct quota *q, void *rock)
         if (!jmap_is_using(qrock->req, JMAP_URN_CALENDARS)) goto done;
 
         name = "calendars";
-        type_masks[QUOTA_STORAGE]    |= JMAP_TYPE_CALENDAREVENT;
-        type_masks[QUOTA_MESSAGE]    |= JMAP_TYPE_CALENDAREVENT;
-        type_masks[QUOTA_NUMFOLDERS] |= JMAP_TYPE_CALENDAR;
+        type_masks[QUOTA_STORAGE]    |= QMASK_BIT(JMAP_TYPE_CALENDAREVENT);
+        type_masks[QUOTA_MESSAGE]    |= QMASK_BIT(JMAP_TYPE_CALENDAREVENT);
+        type_masks[QUOTA_NUMFOLDERS] |= QMASK_BIT(JMAP_TYPE_CALENDAR);
         break;
 
     case MBTYPE_ADDRESSBOOK:
@@ -298,9 +266,9 @@ static int fetch_quotas_cb(struct quota *q, void *rock)
         if (!jmap_is_using(qrock->req, JMAP_CONTACTS_EXTENSION)) goto done;
 
         name = "addressbooks";
-        type_masks[QUOTA_STORAGE] |= JMAP_TYPE_CONTACT | JMAP_TYPE_CONTACTGROUP;
-        type_masks[QUOTA_MESSAGE] |= JMAP_TYPE_CONTACT | JMAP_TYPE_CONTACTGROUP;
-        type_masks[QUOTA_NUMFOLDERS] |= JMAP_TYPE_ADDRESSBOOK;
+        type_masks[QUOTA_STORAGE]    |= QMASK_BIT(JMAP_TYPE_CONTACTCARD);
+        type_masks[QUOTA_MESSAGE]    |= QMASK_BIT(JMAP_TYPE_CONTACTCARD);
+        type_masks[QUOTA_NUMFOLDERS] |= QMASK_BIT(JMAP_TYPE_ADDRESSBOOK);
         break;
     }
 
@@ -378,7 +346,7 @@ static void fetch_quotas(struct qrock_t *qrock)
                             qrock->sieve_count, &qrock->quotas);
 
                 qrock->sieve_count->name = "sieve";
-                qrock->sieve_count->type_mask = JMAP_TYPE_SIEVESCRIPT;
+                qrock->sieve_count->type_mask = QMASK_BIT(JMAP_TYPE_SIEVESCRIPT);
                 qrock->sieve_count->junits = jquota_types[QUOTA_MESSAGE].junits;
 
                 mboxlist_entry_free(&mbentry);
@@ -401,6 +369,21 @@ static void fetch_quotas(struct qrock_t *qrock)
             /* Set limit */
             qrock->sieve_count->limit = maxscripts;
         }
+    }
+}
+
+struct list_types_rock {
+    uint32_t type_mask;
+    json_t *jtypes;
+};
+
+static void list_types_cb(const jmap_data_type_t *dtype, void *rock)
+{
+    struct list_types_rock *trock = rock;
+
+    if (dtype->has_quota &&
+        (trock->type_mask & QMASK_BIT(dtype->kind))) {
+        json_array_append_new(trock->jtypes, json_string(dtype->name));
     }
 }
 
@@ -449,13 +432,9 @@ static void getquota(const char *id, void *val, void *rock)
 
     if (jmap_wantprop(get->props, "types")) {
         json_t *types = json_array();
-        const struct jtype_t *jtype;
+        struct list_types_rock trock = { jroot->type_mask, types };
 
-        for (jtype = jtypes; jtype->name; jtype++) {
-            if (jroot->type_mask & jtype->bit) {
-                json_array_append_new(types, json_string(jtype->name));
-            }
-        }
+        jmap_data_types_foreach(&list_types_cb, &trock);
 
         json_object_set_new(jquota, "types", types);
     }
@@ -669,18 +648,17 @@ static int filter_match(void *vf, void *rock)
     if (f->scope && !strstr("account", f->scope)) return 0;
 
     /* resourceType */
-    if (f->resourceType && !strstr(jroot->junits, f->resourceType)) return 0;
+    if (f->resourceType && strcmp(f->resourceType, jroot->junits)) return 0;
 
     /* type */
     if (f->type) {
-        const struct jtype_t *jtype;
+        const jmap_data_type_t *dtype =
+            jmap_data_types_lookup(f->type, strlen(f->type));
 
-        for (jtype = jtypes; jtype->name; jtype++) {
-            if ((jroot->type_mask & jtype->bit) && strstr(jtype->name, f->type)) {
-                break;
-            }
+        if (!(dtype && dtype->has_quota &&
+              (jroot->type_mask & QMASK_BIT(dtype->kind)))) {
+            return 0;
         }
-        if (!jtype->name) return 0;
     }
 
     /* All matched. */


### PR DESCRIPTION
- Mailbox, Calendar, and AddressBook states need to use the email, caldav, and carddav modseqs respectively rather than *foldersmodseq to match what a client receives in JMAP responses
- Email/Mailbox states need to have a "J" prefix
- Uses gperf array of JMAP Data Types

Should be reviewed commit-by-commit