### PR TITLE
docs: hyperlink SEE ALSOs in web version of imapd.conf.5

### DIFF
--- a/tools/lib/Cyrus/IMAPOptions/App/Command/manrst.pm
+++ b/tools/lib/Cyrus/IMAPOptions/App/Command/manrst.pm
@@ -134,9 +134,17 @@ sub footer
     SEE ALSO
     ========
 
-    **imapd(8)**, **pop3d(8)**, **nntpd(8)**, **lmtpd(8)**,
-    **httpd(8)**, **timsieved(8)**, **idled(8)**, **notifyd(8)**,
-    **deliver(8)**, **master(8)**, **ciphers(1)**
+    :cyrusman:`imapd(8)`,
+    :cyrusman:`pop3d(8)`,
+    :cyrusman:`nntpd(8)`,
+    :cyrusman:`lmtpd(8)`,
+    :cyrusman:`httpd(8)`,
+    :cyrusman:`timsieved(8)`,
+    :cyrusman:`idled(8)`,
+    :cyrusman:`notifyd(8)`,
+    :cyrusman:`deliver(8)`,
+    :cyrusman:`master(8)`,
+    :manpage:`ciphers(1)`
     END_FOOTER
 
     print $rst;


### PR DESCRIPTION
The rst files for the other man pages were already using the correct syntax, but the generated one for imapd.conf.5 was not, for historical reasons that no longer apply.

This fixes manrst to output the correct syntax when generating imapd.conf.rst, so that sphinx in turn adds hyperlinks when generating the html version.