### PR TITLE
imapoptions: mark old restore_foo options deprecated

### DIFF
--- a/lib/imapoptions/restore_authname
+++ b/lib/imapoptions/restore_authname
@@ -1,7 +1,5 @@
 Name: restore_authname
 Type: STRING
 Default-Value: NULL
-Last-Modified: 3.0.0
-
-The authentication used by the restore tool when authenticating to an
-IMAP/sync server.
+Deprecated-Since: UNRELEASED
+Last-Modified: UNRELEASED

--- a/lib/imapoptions/restore_password
+++ b/lib/imapoptions/restore_password
@@ -1,7 +1,5 @@
 Name: restore_password
 Type: STRING
 Default-Value: NULL
-Last-Modified: 3.0.0
-
-The password used by the restore tool when authenticating to an IMAP/sync
-server.
+Deprecated-Since: UNRELEASED
+Last-Modified: UNRELEASED

--- a/lib/imapoptions/restore_realm
+++ b/lib/imapoptions/restore_realm
@@ -1,7 +1,5 @@
 Name: restore_realm
 Type: STRING
 Default-Value: NULL
-Last-Modified: 3.0.0
-
-The authentication realm used by the restore tool when authenticating to an
-IMAP/sync server.
+Deprecated-Since: UNRELEASED
+Last-Modified: UNRELEASED


### PR DESCRIPTION
In practice, these options hadn't been used since 2020, and the feature they belonged to was removed altogether in 2024. But they were overlooked both times!