### PR TITLE
sessionid: allow '.' in trace ids

### DIFF
--- a/cassandane/tiny-tests/Delivery/traceid
+++ b/cassandane/tiny-tests/Delivery/traceid
@@ -3,7 +3,7 @@ use Cassandane::Tiny;
 
 sub test_traceid ($self)
 {
-    my $good_traceid = "01234567890abcdefghijklmnopqrstuvwxyz";
+    my $good_traceid = "01234567890.abcdefghijklmnopqrstuvwxyz";
     my $bad_traceid = "spaces and quotes aren't valid";
 
     my %msgs;

--- a/cunit/sessionid.testc
+++ b/cunit/sessionid.testc
@@ -117,6 +117,8 @@ static void test_trace_id(void)
         { "",   17, NULL }, /* (regardless of len) */
         { X64,   0,  X64 }, /* long values okay */
         { X255,  0, X255 }, /* very long values okay */
+        { "fastmta.style.dotted.id", 0,
+          "fastmta.style.dotted.id" }, /* '.' is allowed */
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     const char *actual;

--- a/docsrc/reference/extensions/lmtp.md
+++ b/docsrc/reference/extensions/lmtp.md
@@ -47,8 +47,8 @@ TRACE <traceid>
 ```
 
 `<traceid>` must be at most 255 bytes and consist only of characters from the
-base64url alphabet without padding -- that is, ASCII letters, digits, `-`,
-and `_`.  Other characters or an over-length value yield:
+base64url alphabet without padding, plus `.` -- that is, ASCII letters,
+digits, `-`, `_`, and `.`.  Other characters or an over-length value yield:
 
 ```
 501 5.5.4 Invalid TRACE id.

--- a/lib/sessionid.h
+++ b/lib/sessionid.h
@@ -16,10 +16,11 @@ extern bool session_have_id(void);
 extern void session_clear_id(void);
 extern void parse_sessionid(const char *str, char *sessionid);
 
-/* This is the base64jmap set, which for this purpose is the same as the
- * base64url set without the optional padding character.
+/* The base64jmap set (base64url without the optional padding character),
+ * plus '.' so that dotted identifiers used by some clients (e.g. FastMTA)
+ * are accepted verbatim.
  */
-#define TRACE_ID_GOODCHARS "-0123456789"                    \
+#define TRACE_ID_GOODCHARS ".-0123456789"                   \
                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"     \
                            "_abcdefghijklmnopqrstuvwxyz"
 


### PR DESCRIPTION
Some clients that talk to Cyrus (e.g. FastMTA) use '.' as a value inside their identifiers, and the existing base64url-without-padding alphabet rejected those ids outright. Add '.' to TRACE_ID_GOODCHARS, update the LMTP extension docs, and extend the cunit and cassandane tests to exercise a dotted id.