### PR TITLE
jmap_contact.c: add Card `vCardVersion` property for debugging

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_get_vcardversion
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_vcardversion
@@ -1,0 +1,80 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_get_vcardversion
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $self->{jmap};
+
+    xlog $self, "Create vCards with versions 3.0 and 4.0";
+    my $card = <<~"EOF";
+    BEGIN:VCARD
+    VERSION:3.0
+    UID:574E6CCF-BAE4-4005-B478-222DD257224A
+    N:;;;;
+    FN:version3
+    END:VCARD
+    EOF
+    $card =~ s/\r?\n/\r\n/gs;
+    $user->carddav->Request('PUT', 'Default/testv3.vcf',
+        $card, 'Content-Type' => 'text/vcard');
+
+    $card = <<~"EOF";
+    BEGIN:VCARD
+    VERSION:4.0
+    UID:03191135-EF19-459B-985F-B2E5129BCFCE
+    N:;;;;
+    FN:version4
+    END:VCARD
+    EOF
+    $card =~ s/\r?\n/\r\n/gs;
+    $user->carddav->Request('PUT', 'Default/testv4.vcf',
+        $card, 'Content-Type' => 'text/vcard');
+
+    xlog $self, "Request vCardVersion property without JMAP debug extension";
+    my $using = [
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:contacts',
+    ];
+
+    my $res = $jmap->CallMethods([
+        ['ContactCard/query', { }, 'R1'],
+        ['ContactCard/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'ContactCard/query',
+                path => '/ids',
+            },
+            properties => [ 'cyrusimap.org:vCardVersion', 'name' ],
+        }, 'R2']
+    ], $using);
+
+    $self->assert_cmp_deeply({
+        type => 'invalidArguments',
+        arguments => [ 'properties[0:cyrusimap.org:vCardVersion]' ],
+    }, $res->[1][1]);
+
+    xlog $self, "Request vCardVersion property with JMAP debug extension";
+    push @$using, 'https://cyrusimap.org/ns/jmap/debug';
+    $res = $jmap->CallMethods([
+        ['ContactCard/query', { }, 'R1'],
+        ['ContactCard/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'ContactCard/query',
+                path => '/ids',
+            },
+            properties => [ 'cyrusimap.org:vCardVersion', 'name' ],
+        }, 'R2']
+    ], $using);
+
+    my %cardversion_by_name = map {
+        $_->{name}{full} => $_->{'cyrusimap.org:vCardVersion'}
+    } @{$res->[1][1]{list}};
+
+    $self->assert_cmp_deeply({
+        'version3' => '3.0',
+        'version4' => '4.0',
+    }, \%cardversion_by_name);
+}

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -4935,6 +4935,15 @@ static int getcards_cb(void *rock, struct carddav_data *cdata)
     /* Cache contact */
     hashu64_insert(cdata->dav.rowid, json_dumps(obj, 0), &crock->jmapcache);
 
+    if (jmap_is_using(req, JMAP_DEBUG_EXTENSION)) {
+        /* Set vCard version for debugging. */
+        struct buf buf = BUF_INITIALIZER;
+        buf_printf(&buf, "%d.0", cdata->version);
+        json_object_set_new(obj, "cyrusimap.org:vCardVersion",
+                json_string(buf_cstring(&buf)));
+        buf_free(&buf);
+    }
+
   gotvalue:
 
     jmap_filterprops(obj, crock->get->props);

--- a/imap/jmap_contact_card_props.gperf
+++ b/imap/jmap_contact_card_props.gperf
@@ -69,6 +69,7 @@ jmap_property_t;
 "cyrusimap.org:blobId",     JMAP_CONTACTS_EXTENSION, JMAP_PROP_SERVER_SET
 "cyrusimap.org:size",       JMAP_CONTACTS_EXTENSION, JMAP_PROP_SERVER_SET
 "cyrusimap.org:href",       JMAP_CONTACTS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE
+"cyrusimap.org:vCardVersion",       JMAP_DEBUG_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_IMMUTABLE | JMAP_PROP_SKIP_GET
 #
 # Allow vendor properties (prefix ':' name)
 "*:*", NULL, JMAP_PROP_SKIP_GET


### PR DESCRIPTION
This adds the `cyrusimap.org:vCardVersion` debugging property to ContactCard/get. Its value is the version of the vCard from which the ContactCard got converted from. This property is server-set and immutable.

Requesting this property requires the JMAP request to use the extension `https://cyrusimap.org/ns/jmap/debug`, otherwise the /get method is rejected as requesting an invalid property. A client must explicitly for this property in the `properties` argument.