### PR TITLE
Sync no whack users

### DIFF
--- a/cassandane/tiny-tests/Replication/rename_create_resync
+++ b/cassandane/tiny-tests/Replication/rename_create_resync
@@ -1,0 +1,85 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Test: user "victim" renamed to "mover" on a second server (simulating a
+# user move), while a new user "victim" is created on the first server and
+# synced to the replica.  Syncing "mover" from the second server with -O
+# (no_copyback) must NOT wipe "victim"'s inbox on the replica.
+#
+# Bug: sync_client -u mover walks the name_history of mover's mailbox
+# (which includes "victim"'s old mailbox name), queries the replica for
+# that name, finds the new victim's inbox there, and since that UUID is
+# unknown on the second server, the NO_COPYBACK path sends UNMAILBOX for
+# victim's name -- wiping victim's inbox on the replica.
+#
+sub test_rename_create_resync
+    :NoAltNameSpace :AllowMoves :Replication :DelayedDelete
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+
+    # OldStore = $self->{instance}, Replica = $self->{replica}
+    # NewStore = a fresh instance that syncs to the same Replica.
+
+    xlog $self, "Create and start NewStore instance pointing at Replica";
+    my $replica_sync_port = $self->{replica}->get_service('sync')->port();
+    my $replica_sync_host = $self->{replica}->get_service('sync')->host();
+
+    my $newstore_conf = $self->{_config}->clone();
+    $newstore_conf->set(
+        sync_host     => $replica_sync_host,
+        sync_port     => $replica_sync_port,
+        sync_authname => 'repluser',
+        sync_password => 'replpass',
+    );
+    my $newstore = Cassandane::Instance->new(
+        config        => $newstore_conf,
+        description   => "newstore for test rename_create_resync",
+        setup_mailbox => 0,
+    );
+    $newstore->add_service(name => 'imap');
+    $newstore->start();
+    $self->{backend2} = $newstore;  # handed to tear_down for cleanup
+
+    xlog $self, "NewStore: create user.victim then rename to user.mover";
+    xlog $self, "(gives mover a name_history containing user.victim)";
+    my $newstore_imap = $newstore->get_service('imap');
+    my $newstore_admin = $newstore_imap->create_store(username => 'admin');
+    my $newstore_admintalk = $newstore_admin->get_client();
+    $newstore_admintalk->create("user.victim");
+    $self->assert_str_equals('ok', $newstore_admintalk->get_last_completion_response());
+    $newstore_admintalk->rename("user.victim", "user.mover");
+    $self->assert_str_equals('ok', $newstore_admintalk->get_last_completion_response());
+    $newstore_admin->disconnect();
+
+    xlog $self, "OldStore: create user.victim and deliver messages";
+    $admintalk->create("user.victim");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    my $mastersvc = $self->{instance}->get_service('imap');
+    my $victim_store = $mastersvc->create_store(username => 'victim');
+    $victim_store->set_fetch_attributes('uid');
+    my %msgs;
+    $msgs{A} = $self->make_message("Message A", store => $victim_store);
+    $msgs{B} = $self->make_message("Message B", store => $victim_store);
+
+    xlog $self, "Sync user.victim from OldStore to Replica";
+    $self->run_replication(user => 'victim');
+
+    xlog $self, "Verify Replica has victim's messages before syncing mover";
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replica_victim = $replicasvc->create_store(username => 'victim');
+    $replica_victim->set_fetch_attributes('uid');
+    $self->check_messages(\%msgs, store => $replica_victim);
+
+    xlog $self, "Sync user.mover from NewStore to Replica with -O (no_copyback)";
+    xlog $self, "This MUST NOT send UNMAILBOX user.victim to the Replica";
+    $self->_disconnect_all();
+    $newstore->run_command({cyrus => 1},
+        'sync_client', '-v', '-v', '-o', '-O', '-u', 'mover');
+
+    xlog $self, "Check victim's replica inbox still has its messages";
+    $replica_victim = $replicasvc->create_store(username => 'victim');
+    $replica_victim->set_fetch_attributes('uid');
+    $self->check_messages(\%msgs, store => $replica_victim);
+}

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -6968,6 +6968,22 @@ static int do_folders(struct sync_client_state *sync_cs,
             }
         }
         else if (sync_cs->flags & SYNC_FLAG_NO_COPYBACK) {
+            /* When syncing user X, name_history can pull in former names from
+             * a different user's namespace (e.g. user Y was once named X).
+             * If rfolder->name belongs to a different user than the one being
+             * synced, it is a foreign mailbox that snuck in via name_history —
+             * do not delete it on the replica. */
+            if (sync_cs->userid) {
+                char *rfolder_userid = mboxname_to_userid(rfolder->name);
+                int foreign = rfolder_userid && strcmp(rfolder_userid, sync_cs->userid) != 0;
+                free(rfolder_userid);
+                if (foreign) {
+                    syslog(LOG_NOTICE, "SYNCNOTICE: skipping delete of %s (foreign user, syncing %s)",
+                           rfolder->name, sync_cs->userid);
+                    r = 0;
+                    continue;
+                }
+            }
             /* we're forcing a delete */
             syslog(LOG_NOTICE, "SYNCNOTICE: forcing delete of remote folder despite no tombstone %s",
                    rfolder->name);
@@ -7096,7 +7112,6 @@ static int do_folders(struct sync_client_state *sync_cs,
 int sync_do_mailboxes(struct sync_client_state *sync_cs,
                       struct sync_name_list *mboxname_list,
                       const char *topart, int flags)
-
 {
     struct sync_name *mbox, *next, *prev = NULL;
     struct sync_folder_list *replica_folders = sync_folder_list_create();
@@ -7354,9 +7369,11 @@ static int do_user_main(struct sync_client_state *sync_cs,
         sync_name_list_add(info.mboxlist, rfolder->name);
     }
 
+    sync_cs->userid = userid;
     int flags = sync_cs->flags;
     if (!r) r = sync_do_mailboxes(sync_cs, info.mboxlist, topart, flags);
     if (!r) r = sync_do_user_quota(sync_cs, info.quotalist, replica_quota);
+    sync_cs->userid = NULL;
 
     sync_name_list_free(&info.mboxlist);
     sync_name_list_free(&info.quotalist);

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -266,8 +266,9 @@ struct sync_client_state {
     struct db *cachedb;
     struct buf tagbuf;
     unsigned flags;
+    const char *userid;  /* set during user-sync operations; NULL otherwise */
 };
-#define SYNC_CLIENT_STATE_INITIALIZER { NULL, NULL, NULL, NULL, NULL, BUF_INITIALIZER, 0 }
+#define SYNC_CLIENT_STATE_INITIALIZER { NULL, NULL, NULL, NULL, NULL, BUF_INITIALIZER, 0, NULL }
 
 /* =====================  server-side sync  ============================= */
 


### PR DESCRIPTION
Right now, `sync_client -O -u` will wipe out new users with the same name as the source folders if a user was renamed, which is BAD.  This fixes that bug.