### PR TITLE
itip_support.c: select calendar with lowest cmodseq as default

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_get_isdefault_persists
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_get_isdefault_persists
@@ -1,0 +1,37 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_get_isdefault_persists
+    :min_version_3_1
+    :CalDAVNoDefaultCalendar
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    $user->calendars->create;
+
+    my $res = $jmap->request([
+      [ 'Calendar/get', { properties => [ 'id', 'isDefault' ] }, ],
+    ]);
+
+    my $cal = $res->sentence_named("Calendar/get")->arguments->{list}[0];
+    $self->assert_equals(JSON::true, $cal->{isDefault});
+
+    my $def_id = $cal->{id};
+    $self->assert($def_id);
+
+    $user->calendars->create;
+
+    $res = $jmap->request([
+      [ 'Calendar/get', { properties => [ 'id', 'isDefault' ] }, ],
+    ]);
+
+    my @def = grep { $_->{isDefault} }
+        $res->sentence_named("Calendar/get")->arguments->{list}->@*;
+
+    $self->assert_cmp_deeply(
+      [ superhashof({ id => $def_id }) ],
+      \@def,
+    );
+}

--- a/imap/itip_support.c
+++ b/imap/itip_support.c
@@ -110,6 +110,7 @@ HIDDEN int organizer_changed(icalcomponent *oldcomp, icalcomponent *newcomp)
 
 struct pick_scheddefault_rock {
     strarray_t ignore;
+    modseq_t createdmodseq;
     char *collname;
 };
 
@@ -132,9 +133,11 @@ static int pick_scheddefault_cb(const mbentry_t *mbentry, void *vrock)
                     if (!strcmp(userid, ownerid) || !strcmp(userid, "anyone")) {
                         int rights = 0;
                         cyrus_acl_strtomask(strarray_nth(acl, i+1), &rights);
-                        if (rights & ACL_INSERT) {
+                        if ((rights & ACL_INSERT) &&
+                            mbentry->createdmodseq < rock->createdmodseq) {
+                            rock->createdmodseq = mbentry->createdmodseq;
+                            free(rock->collname);
                             rock->collname = xstrdup(collname);
-                            r = CYRUSDB_DONE;
                         }
                     }
                 }
@@ -168,7 +171,7 @@ HIDDEN char *caldav_scheddefault(const char *userid, int fallback)
         if (mboxlist_lookup(mboxname, &mbentry, NULL)) {
             // attempt to pick any other calendar
             xzfree(collname);
-            struct pick_scheddefault_rock rock = { 0 };
+            struct pick_scheddefault_rock rock = { .createdmodseq = UINT64_MAX };
 
             buf_setcstr(&buf, SCHED_INBOX);
             if (buf.len && buf.s[buf.len-1] == '/')


### PR DESCRIPTION
    When a user had no calendar marked as CALDAV:schedule-default-calendar,
    we used to simply select the first calendar writable by the user as isDefault.
    However, if a new calendar was created with a name that appeared earlier
    in the ASCII sort order, isDefault would migrate to the new calendar.
    
    This PR searches all writable calendars for the one with the lowest
    createdmodseq, which will always yield consistent results.