### PR TITLE
http_dav.h: Use 'i' right rather than 'p' for adding a DAV resource

### DIFF
--- a/cassandane/tiny-tests/Caldav/move_across_users
+++ b/cassandane/tiny-tests/Caldav/move_across_users
@@ -31,7 +31,7 @@ sub test_move_across_users
     $self->assert_not_null($CalendarId);
 
     xlog $self, "share to user";
-    $admintalk->setacl("user.manifold.#calendars.$ManCalendarId", "cassandane" => 'lrswipcdn');
+    $admintalk->setacl("user.manifold.#calendars.$ManCalendarId", "cassandane" => 'lrswicdn');
     my $talk = $self->{store}->get_client();
     $talk->subscribe("user.manifold.#calendars.$ManCalendarId");
 
@@ -69,20 +69,44 @@ END:VEVENT
 END:VCALENDAR
 EOF
 
+    xlog $self, "add event to shared calendar";
     $CalDAV->Request('PUT', $href, $card1, 'Content-Type' => 'text/calendar');
 
     my $preman = $CalDAV->GetCalendar($mancal->{id});
     my $precas = $CalDAV->GetCalendar($CalendarId);
 
+    xlog $self, "move event from shared calendar to own calendar";
     $CalDAV->MoveEvent($href, $CalendarId);
 
-    my ($adds, $removes, $errors) = $CalDAV->SyncEvents($mancal->{id}, syncToken => $preman->{syncToken});
+    my ($adds, $removes, $errors, $manToken) =
+        $CalDAV->SyncEvents($mancal->{id}, syncToken => $preman->{syncToken});
     $self->assert_deep_equals([], $adds);
     $self->assert_equals(1, scalar @$removes);
     $self->assert_str_equals($href, $removes->[0]);
     $self->assert_deep_equals([], $errors);
 
-    ($adds, $removes, $errors) = $CalDAV->SyncEvents($CalendarId, syncToken => $precas->{syncToken});
+    ($adds, $removes, $errors, my $casToken) =
+        $CalDAV->SyncEvents($CalendarId, syncToken => $precas->{syncToken});
+
+    $self->assert_equals(1, scalar @$adds);
+    $self->assert_str_equals($adds->[0]{uid}, $uuid1);
+    $self->assert_deep_equals([], $removes);
+    $self->assert_deep_equals([], $errors);
+
+    xlog $self, "move event back to shared calendar";
+    $href = $CalDAV->fullpath("$CalendarId/$uuid1.ics");
+    $CalDAV->MoveEvent($href, $mancal->{id});
+
+    ($adds, $removes, $errors) =
+        $CalDAV->SyncEvents($CalendarId, syncToken => $casToken);
+
+    $self->assert_deep_equals([], $adds);
+    $self->assert_equals(1, scalar @$removes);
+    $self->assert_str_equals($href, $removes->[0]);
+    $self->assert_deep_equals([], $errors);
+
+    ($adds, $removes, $errors) =
+        $CalDAV->SyncEvents($mancal->{id}, syncToken => $manToken);
 
     $self->assert_equals(1, scalar @$adds);
     $self->assert_str_equals($adds->[0]{uid}, $uuid1);

--- a/docsrc/download/installation/http/caldav.rst
+++ b/docsrc/download/installation/http/caldav.rst
@@ -84,129 +84,159 @@ The tables below show how the access controls are used by the CalDAV module.
       <caption>Mapping of IMAP Rights to WebDAV Privileges & HTTP Methods</caption>
       <tr>
         <th>IMAP rights</th>
-        <th colspan=2>WebDAV privileges</th>
+        <th colspan=3>WebDAV privileges</th>
         <th>HTTP methods</th>
       </tr>
       <tr>
-        <td>l - lookup
+        <td style="vertical-align:middle">l - lookup
           <br>r - read</td>
-        <td>DAV:read</td>
-        <td>DAV:read-current-user-privilege-set
-          <br>CALDAV:read-free-busy</td>
+        <td colspan=2 rowspan=2 style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.1">DAV:read</a></td>
+        <td style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.7">DAV:read-current-user-privilege-set</a></td>
         <td>GET/HEAD
-          <br>COPY/MOVE <small>(on source)</small>
-            <br>PROPFIND
-              <br>REPORT</td>
+          <br>COPY/MOVE
+            <br><small>(on source)</small>
+              <br>PROPFIND
+                <br>REPORT</td>
       </tr>
       <tr>
-        <td><s>s - seen</s></td>
-        <td colspan=2/>
+        <td style="vertical-align:middle">9 - freebusy
+          <br><small>(regular calendar collections ONLY)</small></td>
+        <td style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc4791#section-6.1.1">CALDAV:read-free-busy</a></td>
+        <td>GET/HEAD
+          <br><small>(<a href="#freebusy-url">Freebusy URLs</a> ONLY)</small>
+            <br>REPORT
+              <br><small>(<a href="https://datatracker.ietf.org/doc/html/rfc4791#section-7.10">CALDAV:free-busy-query</a> ONLY)</small></td>
+      </tr>
+      <tr>
+        <td><s>s - seen</s>
+          <br><s>p - post</s></td>
+        <td colspan=4/>
         <td/>
       </tr>
       <tr>
-        <td>w - write
-          <br>n - write shared annotation</td>
-        <td colspan=2>DAV:write-properties</td>
-        <td>PROPPATCH
-          <br>COPY/MOVE <small>(on destination)</small></td>
+        <td style="vertical-align:middle">w - write</td>
+        <td rowspan=6 style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.2">DAV:write</a></td>
+        <td rowspan=2 style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.3">DAV:write-properties</a></td>
+        <td>CY:write-properties-collection</td>
+        <td rowspan=2>PROPPATCH
+          <br>COPY/MOVE
+            <br><small>(on destination)</small></td>
       </tr>
       <tr>
-        <td>i - insert</td>
-        <td colspan=2>DAV:write-content</td>
-        <td>PUT
-          <br>PATCH
-            <br>COPY/MOVE <small>(on destination resource)</small>
-              <br>LOCK
-                <br>UNLOCK <small>(lock owner ONLY)</small></td>
+        <td>n - write shared annotation</td>
+        <td>CY:write-properties-resource</td>
       </tr>
       <tr>
-        <td>p - post</td>
-        <td rowspan=2>DAV:bind</td>
-        <td>CYRUS:add-resource</td>
-        <td>POST</td>
+        <td style="vertical-align:middle">i - insert</td>
+        <td rowspan=2 style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.9">DAV:bind</a></td>
+        <td style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.4">DAV:write-content</a></td>
+        <td>POST
+          <br><small>(<a href="https://datatracker.ietf.org/doc/html/rfc5995#section-3.1">Add Member URI</a>)</small>
+            <br>PUT
+              <br>PATCH
+                <br>COPY/MOVE
+                  <br><small>(on destination resource)</small>
+                    <br>LOCK
+                      <br>UNLOCK
+                        <br><small>(lock owner ONLY)</small></td>
       </tr>
       <tr>
-        <td>k - create mailbox</td>
-        <td>CYRUS:make-collection</td>
+        <td style="vertical-align:middle">k - create mailbox</td>
+        <td style="vertical-align:middle">CY:make-collection</td>
         <td>MKCOL
           <br>MKCALENDAR
-            <br>COPY/MOVE <small>(on destination collection)</small></td>
+            <br>COPY/MOVE
+              <br><small>(on destination collection)</small></td>
       </tr>
       <tr>
-        <td>x - delete mailbox</td>
-        <td rowspan=2>DAV:unbind</td>
-        <td>CYRUS:remove-collection</td>
-        <td>DELETE <small>(collection)</small>
-          <br>MOVE <small>(on source collection)</small></td>
+        <td style="vertical-align:middle">x - delete mailbox</td>
+        <td rowspan=2 style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.10">DAV:unbind</a></td>
+        <td style="vertical-align:middle">CY:remove-collection</td>
+        <td>DELETE
+          <br><small>(collection)</small>
+            <br>MOVE
+              <br><small>(on source collection)</small></td>
       </tr>
       <tr>
-        <td>t - delete message
+        <td style="vertical-align:middle">t - delete message
           <br>e - expunge</td>
-        <td>CYRUS:remove-resource</td>
-        <td>DELETE <small>(resource)</small>
-          <br>MOVE <small>(on source resource)</small></td>
+        <td style="vertical-align:middle">CY:remove-resource</td>
+        <td>DELETE
+          <br><small>(resource)</small>
+            <br>MOVE
+              <br><small>(on source resource)</small></td>
       </tr>
       <tr>
-        <td>a - admin</td>
-        <td>CYRUS:admin</td>
-        <td>DAV:read-acl
-          <br>DAV:write-acl
-          <br>DAV:share
-          <br>DAV:unlock</td>
+        <td style="vertical-align:middle">a - administer</td>
+        <td colspan=2 style="vertical-align:middle">CY:admin</td>
+        <td style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.6">DAV:read-acl</a>
+          <br><a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.8">DAV:write-acl</a>
+          <br><a href="https://datatracker.ietf.org/doc/html/draft-pot-webdav-resource-sharing-00#section-7">DAV:share</a>
+          <br><a href="https://datatracker.ietf.org/doc/html/rfc3744#section-3.5">DAV:unlock</a></td>
         <td>ACL
-          <br>PROPFIND <small>(DAV:acl property ONLY)</small>
-          <br>UNLOCK <small>(ANY lock)</small></td>
+          <br>PROPFIND
+            <br><small>(<a href="https://datatracker.ietf.org/doc/html/rfc3744#section-5.5">DAV:acl property</a> ONLY)</small>
+              <br>UNLOCK
+                <br><small>(ANY lock)</small></td>
       </tr>
       <tr>
-        <td colspan=4><i>Regular Calendar Collections ONLY &#151;
-            read freebusy time?</i></td>
+        <td colspan=5 align='center'><b>Scheduling Outbox ONLY &#151;
+            implicitly create/send iTIP message?</b></td>
       </tr>
       <tr>
-        <td>9 - freebusy</td>
-        <td colspan=2>CALDAV:read-free-busy</td>
-        <td>REPORT <small>(CALDAV:free-busy-query ONLY)</small>
-          <br>GET/HEAD <small>(<a href="#freebusy-url">Freebusy URLs</a> ONLY)</small></td>
-      </tr>
-      <tr>
-        <td colspan=4><i>Scheduling Outbox ONLY &#151;
-            implicitly create/send iTIP message?</i></td>
-      </tr>
-      <tr>
-        <td>9 - freebusy</td>
-        <td rowspan=3>CALDAV:schedule-send</td>
-        <td>CALDAV:schedule-send-freebusy</td>
+        <td style="vertical-align:middle">9 - freebusy</td>
+        <td rowspan=3 colspan=2 style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.2.1">CALDAV:schedule-send</a></td>
+        <td style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.2.4">CALDAV:schedule-send-freebusy</a></td>
         <td>POST
           <br><small>(by organizer on scheduling Outbox)</small></td>
       </tr>
       <tr>
-        <td>8 - invite</td>
-        <td>CALDAV:schedule-send-invite</td>
-        <td>PUT/PATCH/DELETE
-          <br><small>(by organizer on calendar resource/collection)</small></td>
+        <td style="vertical-align:middle">8 - invite</td>
+        <td style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.2.2">CALDAV:schedule-send-invite</a></td>
+        <td>PUT
+          <br>PATCH
+            <br>DELETE
+              <br><small>(by organizer on calendar resource/collection)</small></td>
       </tr>
       <tr>
-        <td>7 - reply</td>
-        <td>CALDAV:schedule-send-reply</td>
-        <td>PUT/PATCH/DELETE
-          <br><small>(by attendee on calendar resource/collection)</small></td>
+        <td style="vertical-align:middle">7 - reply</td>
+        <td style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.2.3">CALDAV:schedule-send-reply</a></td>
+        <td>PUT
+          <br>PATCH
+            <br>DELETE
+              <br><small>(by attendee on calendar resource/collection)</small></td>
       </tr>
       <tr>
-        <td colspan=4><i>Scheduling Inbox ONLY &#151;
-            implicitly deliver/process incoming iTIP message?</i></td>
+        <td colspan=5 align='center'><b>Scheduling Inbox ONLY &#151;
+            implicitly deliver/process incoming iTIP message?</b></td>
       </tr>
       <tr>
-        <td>9 - freebusy</td>
-        <td rowspan=3>CALDAV:schedule-deliver</td>
-        <td>CALDAV:schedule-query-freebusy</td>
+        <td style="vertical-align:middle">9 - freebusy</td>
+        <td rowspan=3 colspan=2 style="vertical-align:middle">
+          <a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.1.1">CALDAV:schedule-deliver</a></td>
+        <td><a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.1.4">CALDAV:schedule-query-freebusy</a></td>
         <td rowspan=3/>
       </tr>
       <tr>
-        <td>8 - invite</td>
-        <td>CALDAV:schedule-deliver-invite</td>
+        <td style="vertical-align:middle">8 - invite</td>
+        <td><a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.1.2">CALDAV:schedule-deliver-invite</a></td>
       </tr>
       <tr>
-        <td>7 - reply</td>
-        <td>CALDAV:schedule-deliver-reply</td>
+        <td style="vertical-align:middle">7 - reply</td>
+        <td><a href="https://datatracker.ietf.org/doc/html/rfc6638#section-6.1.3">CALDAV:schedule-deliver-reply</a></td>
       </tr>
     </table>
     <br>
@@ -224,7 +254,7 @@ The tables below show how the access controls are used by the CalDAV module.
         <td rowspan=2>Regular Calendar Collection</td>
         <td>owner</td>
         <td>DAV:all + CALDAV:read-free-busy</td>
-        <td align='right'>lrwipkxtan9</td>
+        <td align='right'>lrwikxtan9</td>
       </tr>
       <tr>
         <td>anyone</td>
@@ -235,7 +265,7 @@ The tables below show how the access controls are used by the CalDAV module.
         <td rowspan=2>Managed Attachments Collection</td>
         <td>owner</td>
         <td>DAV:all</td>
-        <td>lrwipkxtan</td>
+        <td>lrwikxtan</td>
       </tr>
       <tr>
         <td>anyone</td>
@@ -246,7 +276,7 @@ The tables below show how the access controls are used by the CalDAV module.
         <td rowspan=2>Scheduling Inbox</td>
         <td>owner</td>
         <td>DAV:all + CALDAV:schedule-deliver</td>
-        <td>lrwipkxtan789</td>
+        <td>lrwikxtan789</td>
       </tr>
       <tr>
         <td>anyone</td>
@@ -257,7 +287,7 @@ The tables below show how the access controls are used by the CalDAV module.
         <td>Scheduling Outbox</td>
         <td>owner</td>
         <td>DAV:all + CALDAV:schedule-send</td>
-        <td>lrwipkxtan789</td>
+        <td>lrwikxtan789</td>
       </tr>
     </table>
 

--- a/docsrc/reference/extensions/dav-extensions.md
+++ b/docsrc/reference/extensions/dav-extensions.md
@@ -70,7 +70,6 @@ in different IMAP constructs with different ACL bits.
 | Privilege            | Description                        | IMAP ACL bit |
 |----------------------|------------------------------------|--------------|
 | `CY:make-collection` | Create a new sub-collection        | k            |
-| `CY:add-resource`    | Add a new resource to a collection | p            |
 
 ### Under `DAV:unbind`
 

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1435,7 +1435,7 @@ EXPORTED int caldav_create_defaultcalendars(const char *userid,
             }
             else {
                 r = _create_mailbox(userid, mailboxname, MBTYPE_CALENDAR, 0,
-                                    ACL_ALL | DACL_READFB, DACL_READFB, NULL,
+                                    DACL_ALL | DACL_READFB, DACL_READFB, NULL,
                                     namespace, authstate, 0, &user_nslock);
             }
         }
@@ -1455,7 +1455,7 @@ EXPORTED int caldav_create_defaultcalendars(const char *userid,
 
         mailboxname = caldav_mboxname(userid, SCHED_DEFAULT);
         r = _create_mailbox(userid, mailboxname, MBTYPE_CALENDAR, comp_types,
-                            ACL_ALL | DACL_READFB, DACL_READFB,
+                            DACL_ALL | DACL_READFB, DACL_READFB,
                             config_getstring(IMAPOPT_CALENDAR_DEFAULT_DISPLAYNAME),
                             namespace, authstate, 1, &user_nslock);
         free(mailboxname);
@@ -1467,7 +1467,7 @@ EXPORTED int caldav_create_defaultcalendars(const char *userid,
         /* Scheduling Inbox */
         mailboxname = caldav_mboxname(userid, SCHED_INBOX);
         r = _create_mailbox(userid, mailboxname, MBTYPE_CALENDAR, 0,
-                            ACL_ALL | DACL_SCHED, DACL_SCHED, NULL,
+                            DACL_ALL | DACL_SCHED, DACL_SCHED, NULL,
                             namespace, authstate, 0, &user_nslock);
         free(mailboxname);
         if (r) goto done;
@@ -1475,7 +1475,7 @@ EXPORTED int caldav_create_defaultcalendars(const char *userid,
         /* Scheduling Outbox */
         mailboxname = caldav_mboxname(userid, SCHED_OUTBOX);
         r = _create_mailbox(userid, mailboxname, MBTYPE_CALENDAR, 0,
-                            ACL_ALL | DACL_SCHED, 0, NULL,
+                            DACL_ALL | DACL_SCHED, 0, NULL,
                             namespace, authstate, 0, &user_nslock);
         free(mailboxname);
         if (r) goto done;
@@ -1486,7 +1486,7 @@ EXPORTED int caldav_create_defaultcalendars(const char *userid,
         /* Managed Attachment Collection */
         mailboxname = caldav_mboxname(userid, MANAGED_ATTACH);
         r = _create_mailbox(userid, mailboxname, MBTYPE_COLLECTION, 0,
-                            ACL_ALL, ACL_READ, NULL,
+                            DACL_ALL, ACL_READ, NULL,
                             namespace, authstate, 0, &user_nslock);
         free(mailboxname);
         if (r) goto done;

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -2426,7 +2426,6 @@ int propfind_supprivset(const xmlChar *name, xmlNsPtr ns,
     }
 
     write = add_suppriv(all, "write", NULL, 0, "Write any object");
-    add_suppriv(write, "write-content", NULL, 0, "Write resource content");
 
     agg = add_suppriv(write, "write-properties", NULL, 0, "Write properties");
     ensure_ns(fctx->ns, NS_CYRUS, resp->parent, XML_NS_CYRUS, "CY");
@@ -2438,8 +2437,7 @@ int propfind_supprivset(const xmlChar *name, xmlNsPtr ns,
     agg = add_suppriv(write, "bind", NULL, 0, "Add new member to collection");
     add_suppriv(agg, "make-collection", fctx->ns[NS_CYRUS], 0,
                 "Make new collection");
-    add_suppriv(agg, "add-resource", fctx->ns[NS_CYRUS], 0,
-                "Add new resource");
+    add_suppriv(agg, "write-content", NULL, 0, "Write resource content");
 
     agg = add_suppriv(write, "unbind", NULL, 0,
                          "Remove member from collection");
@@ -2527,11 +2525,6 @@ static void add_privs(int rights, unsigned flags,
     else do_contained = 1;
 
     if (do_contained) {
-        if (rights & DACL_WRITECONT) {
-            priv = xmlNewChild(parent, NULL, BAD_CAST "privilege", NULL);
-            xmlNewChild(priv, NULL, BAD_CAST "write-content", NULL);
-        }
-
         if (rights & (DACL_WRITEPROPS|DACL_BIND|DACL_UNBIND)) {
             ensure_ns(ns, NS_CYRUS, root, XML_NS_CYRUS, "CY");
 
@@ -2561,7 +2554,7 @@ static void add_privs(int rights, unsigned flags,
 
             /* DAV:bind */
             if ((rights & DACL_BIND) == DACL_BIND ||
-                ((flags & PRIV_NOSUBCOL) && (rights & DACL_ADDRSRC))) {
+                ((flags & PRIV_NOSUBCOL) && (rights & DACL_WRITECONT))) {
                 priv = xmlNewChild(parent, NULL, BAD_CAST "privilege", NULL);
                 xmlNewChild(priv, NULL, BAD_CAST "bind", NULL);
 
@@ -2576,11 +2569,11 @@ static void add_privs(int rights, unsigned flags,
                     xmlNewChild(priv, ns[NS_CYRUS],
                                 BAD_CAST "make-collection", NULL);
                 }
-                if (rights & DACL_ADDRSRC) {
+                if (rights & DACL_WRITECONT) {
                     priv = xmlNewChild(parent, NULL,
                                        BAD_CAST "privilege", NULL);
-                    xmlNewChild(priv, ns[NS_CYRUS],
-                                BAD_CAST "add-resource", NULL);
+                    xmlNewChild(priv, NULL,
+                                BAD_CAST "write-content", NULL);
                 }
             }
 
@@ -4130,9 +4123,6 @@ int meth_acl(struct transaction_t *txn, void *params)
                                        BAD_CAST "remove-collection"))
                             rights |= DACL_RMCOL;
                         else if (!xmlStrcmp(priv->name,
-                                       BAD_CAST "add-resource"))
-                            rights |= DACL_ADDRSRC;
-                        else if (!xmlStrcmp(priv->name,
                                        BAD_CAST "remove-resource"))
                             rights |= DACL_RMRSRC;
                         else if (!xmlStrcmp(priv->name,
@@ -4612,12 +4602,11 @@ int meth_copy_move(struct transaction_t *txn, void *params)
 
     /* Check ACL for current user on destination */
     rights = httpd_myrights(httpd_authstate, dest_tgt.mbentry);
-    if (!(rights & DACL_ADDRSRC) || !(rights & DACL_WRITECONT)) {
+    if (!(rights & DACL_WRITECONT)) {
         /* DAV:need-privileges */
         txn->error.precond = DAV_NEED_PRIVS;
         txn->error.resource = dest_tgt.path;
-        txn->error.rights =
-            !(rights & DACL_ADDRSRC) ? DACL_ADDRSRC : DACL_WRITECONT;
+        txn->error.rights = DACL_WRITECONT;
         ret = HTTP_NO_PRIVS;
         goto done;
     }
@@ -5471,12 +5460,11 @@ int meth_lock(struct transaction_t *txn, void *params)
 
     /* Check ACL for current user */
     rights = httpd_myrights(httpd_authstate, txn->req_tgt.mbentry);
-    if (!(rights & DACL_WRITECONT) || !(rights & DACL_ADDRSRC)) {
+    if (!(rights & DACL_WRITECONT)) {
         /* DAV:need-privileges */
         txn->error.precond = DAV_NEED_PRIVS;
         txn->error.resource = txn->req_tgt.path;
-        txn->error.rights =
-            !(rights & DACL_WRITECONT) ? DACL_WRITECONT : DACL_ADDRSRC;
+        txn->error.rights = DACL_WRITECONT;
         return HTTP_NO_PRIVS;
     }
 
@@ -6686,12 +6674,11 @@ static int dav_post_import(struct transaction_t *txn,
 
     /* Check ACL for current user */
     rights = httpd_myrights(httpd_authstate, txn->req_tgt.mbentry);
-    if (!(rights & DACL_WRITECONT) || !(rights & DACL_ADDRSRC)) {
+    if (!(rights & DACL_WRITECONT)) {
         /* DAV:need-privileges */
         txn->error.precond = DAV_NEED_PRIVS;
         txn->error.resource = txn->req_tgt.path;
-        txn->error.rights =
-            !(rights & DACL_WRITECONT) ? DACL_WRITECONT : DACL_ADDRSRC;
+        txn->error.rights = DACL_WRITECONT;
         return HTTP_NO_PRIVS;
     }
 
@@ -7128,7 +7115,7 @@ int meth_patch(struct transaction_t *txn, void *params)
 int meth_put(struct transaction_t *txn, void *params)
 {
     struct meth_params *pparams = (struct meth_params *) params;
-    int ret, r, precond, rights, reqd_rights;
+    int ret, r, precond, rights, reqd_rights = DACL_WRITECONT;
     const char **hdr, *etag;
     struct mime_type_t *mime = NULL;
     struct mailbox *mailbox = NULL;
@@ -7141,10 +7128,7 @@ int meth_put(struct transaction_t *txn, void *params)
     struct buf msg_buf = BUF_INITIALIZER;
     user_nslock_t *user_nslock = NULL;
 
-    if (txn->meth == METH_POST) {
-        reqd_rights = DACL_ADDRSRC;
-    }
-    else {
+    if (txn->meth != METH_POST) {
         /* Response should not be cached */
         txn->flags.cc |= CC_NOCACHE;
 
@@ -7161,8 +7145,6 @@ int meth_put(struct transaction_t *txn, void *params)
         /* Make sure method is allowed (only allowed on resources) */
         if (!((txn->req_tgt.allow & ALLOW_WRITE) && txn->req_tgt.resource))
             return HTTP_NOT_ALLOWED;
-
-        reqd_rights = DACL_WRITECONT;
 
         if (txn->req_tgt.namespace == &namespace_calendar) {
             /* JMAP introduced the right to update an event

--- a/imap/http_dav.h
+++ b/imap/http_dav.h
@@ -57,7 +57,6 @@ enum {
 #define DACL_PROPCOL    ACL_WRITE       /* CY:write-properties-collection */
 #define DACL_PROPRSRC   ACL_ANNOTATEMSG /* CY:write-properties-resource */
 #define DACL_MKCOL      ACL_CREATE      /* CY:make-collection */
-#define DACL_ADDRSRC    ACL_POST        /* CY:add-resource */
 #define DACL_RMCOL      ACL_DELETEMBOX  /* CY:remove-collection */
 #define DACL_RMRSRC     (ACL_DELETEMSG\
                          |ACL_EXPUNGE)  /* CY:remove-resource */
@@ -77,13 +76,12 @@ enum {
 #define DACL_WRITECONT  ACL_INSERT      /* DAV:write-content */
 #define DACL_WRITEPROPS (DACL_PROPCOL\
                          |DACL_PROPRSRC)/* DAV:write-properties */
-#define DACL_BIND       (DACL_MKCOL\
-                         |DACL_ADDRSRC) /* DAV:bind */
+#define DACL_BIND       (DACL_WRITECONT\
+                         |DACL_MKCOL)   /* DAV:bind */
 #define DACL_UNBIND     (DACL_RMCOL\
                          |DACL_RMRSRC)  /* DAV:unbind */
-#define DACL_WRITE      (DACL_WRITECONT\
+#define DACL_WRITE      (DACL_BIND\
                          |DACL_WRITEPROPS\
-                         |DACL_BIND\
                          |DACL_UNBIND)  /* DAV:write */
 #define DACL_ALL        (DACL_READ\
                          |DACL_WRITE\


### PR DESCRIPTION
This syncs CalDAV behavior with with JMAP.
JMAP only uses the 'i' for adding/updating a resource, but CalDAV used 'p' for add and 'i' for update.
When sharing a calendar as read-write via JMAP, only the 'i' right was granted to the sharee, so a CalDAV MOVE of an event into the shared calendar would fail with
DAV:need-privileges (CY:add-resource).
With this PR, now DAV only requires 'i' for add/update.