### PR TITLE
imapoptions: use the {configdirectory} mechanism where feasible

### DIFF
--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -1910,8 +1910,8 @@ static int set_up(void)
     if (!basedir)
         return -1;
 
-    snprintf(buf, sizeof(buf), "configdirectory: %s/conf\n", basedir);
-    config_read_string(buf);
+    snprintf(buf, sizeof(buf), "%s/conf", basedir);
+    config_read_string(buf, NULL);
 
     cyrusdb_init();
 

--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -4,7 +4,6 @@
 #include "imap/global.h"
 #include "retry.h"
 #include "cyrusdb.h"
-#include "libcyr_cfg.h"
 #include "util.h"
 #include "hash.h"
 
@@ -1911,7 +1910,6 @@ static int set_up(void)
     if (!basedir)
         return -1;
 
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, basedir);
     snprintf(buf, sizeof(buf), "configdirectory: %s/conf\n", basedir);
     config_read_string(buf);
 

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -8,7 +8,6 @@
 #include "util.h"
 #include "xunlink.h"
 #include "imap/global.h"
-#include "libcyr_cfg.h"
 #include "imap/annotate.h"
 #include "imap/append.h"
 #include "imap/mboxlist.h"
@@ -2191,7 +2190,6 @@ static int set_up(void)
         }
     }
 
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
         "defaultpartition: "PARTITION"\n"

--- a/cunit/annotate.testc
+++ b/cunit/annotate.testc
@@ -2190,8 +2190,7 @@ static int set_up(void)
         }
     }
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "defaultpartition: "PARTITION"\n"
         "partition-"PARTITION": "DBDIR"/data\n"
     );

--- a/cunit/auditlog.testc
+++ b/cunit/auditlog.testc
@@ -9,7 +9,7 @@
 
 static int set_up(void)
 {
-    config_read_string("configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
                        "auditlog: yes\n");
     return 0;
 }

--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -15,7 +15,6 @@
 #include "imap/backend.h"
 
 #include "lib/libconfig.h"
-#include "lib/libcyr_cfg.h"
 #include "lib/util.h"
 #include "lib/xstrlcpy.h"
 
@@ -1817,7 +1816,6 @@ static int set_up(void)
     }
 
     /* we need config for these tests */
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     buf_printf(&myconfig, "configdirectory: %s/conf\n", DBDIR);
 
     /* certs are in current directory */

--- a/cunit/backend.testc
+++ b/cunit/backend.testc
@@ -1815,18 +1815,16 @@ static int set_up(void)
         return -1;
     }
 
-    /* we need config for these tests */
-    buf_printf(&myconfig, "configdirectory: %s/conf\n", DBDIR);
-
-    /* certs are in current directory */
+    /* we need config for these tests:
+     * -> certs are in current directory
+     * -> disable SSL session caching
+     */
     buf_printf(&myconfig, "tls_server_ca_file: %s/cacert.pem\n", cwd);
     buf_printf(&myconfig, "tls_server_cert: %s/cert.pem\n", cwd);
     buf_printf(&myconfig, "tls_server_key: %s/key.pem\n", cwd);
-
-    /* disable SSL session caching */
     buf_printf(&myconfig, "tls_session_timeout: 0\n");
 
-    config_read_string(buf_cstring(&myconfig));
+    config_read_string(DBDIR"/conf", buf_cstring(&myconfig));
     buf_free(&myconfig);
 
     rend_sock = create_server_socket(&port);

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -1412,8 +1412,7 @@ static int set_up(void)
         return e;
     }
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "conversations_keep_existing: false\n"
     );
 

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -7,7 +7,6 @@
 #include "retry.h"
 #include "strarray.h"
 #include "cyrusdb.h"
-#include "libcyr_cfg.h"
 #include "lib/util.h"       /* for VECTOR_SIZE */
 //#include "message.h"      /* for VECTOR_SIZE */
 #include "xmalloc.h"
@@ -1413,7 +1412,6 @@ static int set_up(void)
         return e;
     }
 
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
         "conversations_keep_existing: false\n"

--- a/cunit/dlist.testc
+++ b/cunit/dlist.testc
@@ -10,9 +10,7 @@
 static int set_up(void)
 {
     /* need basic configuration for getxstring */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     return 0;
 }

--- a/cunit/dlist.testc
+++ b/cunit/dlist.testc
@@ -1,7 +1,6 @@
 #include "config.h"
 #include "cunit/unit.h"
 #include "prot.h"
-#include "lib/libcyr_cfg.h"
 #include "lib/libconfig.h"
 #include "imap/dlist.h"
 #include "util.h"
@@ -11,7 +10,6 @@
 static int set_up(void)
 {
     /* need basic configuration for getxstring */
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
     );

--- a/cunit/duplicate.testc
+++ b/cunit/duplicate.testc
@@ -278,9 +278,7 @@ static int set_up(void)
         }
     }
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     cyrusdb_init();
     config_duplicate_db = "skiplist";

--- a/cunit/duplicate.testc
+++ b/cunit/duplicate.testc
@@ -8,7 +8,6 @@
 #include "imap/global.h"
 #include "imap/imap_err.h"
 #include "cyrusdb.h"
-#include "libcyr_cfg.h"
 #include "libconfig.h"
 
 #define DBDIR                   "test-duplicate-dbdir"
@@ -279,7 +278,6 @@ static int set_up(void)
         }
     }
 
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
     );

--- a/cunit/getxstring.testc
+++ b/cunit/getxstring.testc
@@ -2,7 +2,6 @@
 #include "config.h"
 #include "cunit/unit.h"
 #include "prot.h"
-#include "lib/libcyr_cfg.h"
 #include "imap/global.h"
 
 #define DBDIR           "test-getxstring-dbdir"
@@ -10,7 +9,6 @@
 static int set_up(void)
 {
     /* need basic configuration for getxstring */
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
     );

--- a/cunit/getxstring.testc
+++ b/cunit/getxstring.testc
@@ -9,9 +9,7 @@
 static int set_up(void)
 {
     /* need basic configuration for getxstring */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     return 0;
 }

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -8,6 +8,7 @@
 
 #include "cunit/unit.h"
 
+#include "lib/buf.h"
 #include "lib/libconfig.h"
 #include "lib/retry.h"
 #include "lib/xmalloc.h"
@@ -36,8 +37,7 @@ static void test_int(void)
     int32_t boundary_limit = -1;
     int32_t conversations_max_thread = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "boundary_limit: 120\n"
         /* conversations_max_thread: 100 (default) */
     );
@@ -57,8 +57,7 @@ static void test_string(void)
     const char *autocreate_sieve_script = NULL;
     const char *addressbookprefix = NULL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "autocreate_sieve_folders: Junk | Trash\n"
         /* autocreate_sieve_script: NULL (default) */
         /* addressbookprefix: #addressbooks (default) */
@@ -85,8 +84,7 @@ static void test_switch(void)
     int allowapop = -1;
     int allownewnews = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "allowanonymouslogin: 1\n"
         /* allowapop: 1 (default) */
         /* allownewnews: 0 (default) */
@@ -109,8 +107,7 @@ static void test_stringlist_value(void)
 {
     const char *annotation_db = NULL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "annotation_db: skiplist\n"
     );
 
@@ -123,8 +120,7 @@ static void test_stringlist_default(void)
 {
     const char *annotation_db = NULL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf", NULL
         /* annotation_db: twoskip (default) */
     );
 
@@ -136,8 +132,7 @@ static void test_stringlist_default(void)
 static void test_stringlist_invalid(void)
 {
     CU_EXPECT_CYRFATAL_BEGIN
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "annotation_db: junk\n"
     );
     CU_EXPECT_CYRFATAL_END(EX_CONFIG, "invalid value 'junk' for annotation_db in line 2");
@@ -147,8 +142,7 @@ static void test_enum_value(void)
 {
     int delete_mode = -1; /* an int, so we can start with a sentinel */
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "delete_mode: immediate\n"
     );
 
@@ -160,8 +154,7 @@ static void test_enum_default(void)
 {
     int delete_mode = -1; /* an int, so we can start with a sentinel */
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf", NULL
         /* delete_mode: delayed (default) */
     );
 
@@ -172,8 +165,7 @@ static void test_enum_default(void)
 static void test_enum_invalid(void)
 {
     CU_EXPECT_CYRFATAL_BEGIN
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "delete_mode: junk\n"
     );
     CU_EXPECT_CYRFATAL_END(EX_CONFIG, "invalid value 'junk' for delete_mode in line 2");
@@ -183,8 +175,7 @@ static void test_bitfield_value(void)
 {
     uint64_t httpmodules = UINT64_MAX;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "httpmodules: carddav freebusy jmap\n"
     );
 
@@ -199,8 +190,7 @@ static void test_bitfield_value_wide(void)
 {
     uint64_t sieve_extensions = UINT64_MAX;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "sieve_extensions: vnd.cyrus.implicit_keep_target\n"
     );
 
@@ -222,8 +212,7 @@ static void test_bitfield_default(void)
 {
     uint64_t httpmodules = UINT64_MAX;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf", NULL
         /* httpmodules: "" (default) */
     );
 
@@ -234,8 +223,7 @@ static void test_bitfield_default(void)
 static void test_bitfield_invalid(void)
 {
     CU_EXPECT_CYRFATAL_BEGIN
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "httpmodules: caldav junk\n"
     );
     CU_EXPECT_CYRFATAL_END(EX_CONFIG, "invalid value 'junk' for httpmodules in line 2");
@@ -245,8 +233,7 @@ static void test_duration_value_days(void)
 {
     int32_t timeout = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "timeout: 3d\n"
     );
 
@@ -258,8 +245,7 @@ static void test_duration_value_hours(void)
 {
     int32_t timeout = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "timeout: 3h\n"
     );
 
@@ -271,8 +257,7 @@ static void test_duration_value_minutes(void)
 {
     int32_t timeout = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "timeout: 45m\n"
     );
 
@@ -284,8 +269,7 @@ static void test_duration_value_seconds(void)
 {
     int32_t timeout = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "timeout: 25s\n"
     );
 
@@ -297,8 +281,7 @@ static void test_duration_value_combined(void)
 {
     int32_t timeout = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "timeout: 1h30m\n"
     );
 
@@ -320,8 +303,7 @@ static void test_duration_value_nounits(void)
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "imapidlepoll: 13\n"
         "timeout: 13\n"
         "archive_after: 13\n"
@@ -339,8 +321,7 @@ static void test_duration_value_negative(void)
 {
     int32_t caldav_historical_age = 0xdeadbeef;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "caldav_historical_age: -1\n"
     );
 
@@ -352,8 +333,7 @@ static void test_duration_default(void)
 {
     int32_t timeout = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf", NULL
         /* timeout: 32m (default) */
     );
 
@@ -365,8 +345,7 @@ static void test_duration_nodefault(void)
 {
     int32_t plaintextloginpause = -1;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf", NULL
         /* plaintextloginpause: <none> (default) */
     );
 
@@ -377,8 +356,7 @@ static void test_duration_nodefault(void)
 static void test_duration_invalid(void)
 {
     CU_EXPECT_CYRFATAL_BEGIN
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "timeout: junk\n"
     );
     CU_EXPECT_CYRFATAL_END(EX_CONFIG, "unparsable duration 'junk' for timeout in line 2");
@@ -491,8 +469,7 @@ static void test_bytesize_value_gibibytes(void)
 {
     int64_t archive_maxsize = -1LL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_maxsize: 1G\n"
     );
 
@@ -504,8 +481,7 @@ static void test_bytesize_value_mebibytes(void)
 {
     int64_t archive_maxsize = -1LL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_maxsize: 3M\n"
     );
 
@@ -517,8 +493,7 @@ static void test_bytesize_value_kibibytes(void)
 {
     int64_t archive_maxsize = -1LL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_maxsize: 45K\n"
     );
 
@@ -530,8 +505,7 @@ static void test_bytesize_value_bytes(void)
 {
     int64_t archive_maxsize = -1LL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_maxsize: 25B\n"
     );
 
@@ -552,8 +526,7 @@ static void test_bytesize_value_nounits(void)
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "maxmessagesize: 13\n"
         "archive_maxsize: 13\n"
     );
@@ -579,8 +552,7 @@ static void test_bytesize_value_negative(void)
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     unsigned i;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "maxmessagesize: -1\n"
         "archive_maxsize: -1\n"
     );
@@ -597,8 +569,7 @@ static void test_bytesize_default(void)
 {
     int64_t archive_maxsize = -1LL;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf", NULL
         /* archive_maxsize: 1024 K (default) */
     );
 
@@ -609,8 +580,7 @@ static void test_bytesize_default(void)
 static void test_bytesize_invalid(void)
 {
     CU_EXPECT_CYRFATAL_BEGIN
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_maxsize: junk\n"
     );
     CU_EXPECT_CYRFATAL_END(
@@ -806,36 +776,41 @@ static void test_bytesize_parse(void)
 static void test_magic_configdirectory_value(void)
 {
     const char *idlesocket = NULL;
+    struct buf expect = BUF_INITIALIZER;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "idlesocket: {configdirectory}/some/thing\n"
     );
 
     idlesocket = config_getstring(IMAPOPT_IDLESOCKET);
     CU_ASSERT_PTR_NOT_NULL(idlesocket);
-    CU_ASSERT_STRING_EQUAL(idlesocket, DBDIR"/conf/some/thing");
+
+    buf_printf(&expect, "%s/some/thing", config_dir);
+    CU_ASSERT_STRING_EQUAL(idlesocket, buf_cstring(&expect));
+    buf_free(&expect);
 }
 
 static void test_magic_configdirectory_default(void)
 {
     const char *idlesocket = NULL;
+    struct buf expect = BUF_INITIALIZER;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf", NULL
         /* idlesocket: {configdirectory}/socket/idle (default) */
     );
 
     idlesocket = config_getstring(IMAPOPT_IDLESOCKET);
     CU_ASSERT_PTR_NOT_NULL(idlesocket);
-    CU_ASSERT_STRING_EQUAL(idlesocket, DBDIR"/conf/socket/idle");
+
+    buf_printf(&expect, "%s/socket/idle", config_dir);
+    CU_ASSERT_STRING_EQUAL(idlesocket, buf_cstring(&expect));
+    buf_free(&expect);
 }
 
 static void test_configdirectory_missing(void)
 {
     CU_EXPECT_CYRFATAL_BEGIN
-    config_read_string(
-        /* configdirectory not specified */
+    config_read_string(NULL, /* configdirectory not specified! */
         "annotation_db: twoskip\n"
     );
     CU_EXPECT_CYRFATAL_END(
@@ -851,8 +826,7 @@ static void test_deprecated_int(void)
 
     /* set the deprecated name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "autocreatequotamsg: 12\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 1);
@@ -870,8 +844,7 @@ static void test_deprecated_int(void)
 
     /* set the new name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "autocreate_quota_messages: 12\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 0);
@@ -882,8 +855,7 @@ static void test_deprecated_int(void)
 
     /* set both names to different values */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "autocreatequotamsg: 12\n"
         "autocreate_quota_messages: 15\n"
     );
@@ -901,8 +873,7 @@ static void test_deprecated_string(void)
 
     /* set the deprecated name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "tlscache_db_path: foo\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 1);
@@ -921,8 +892,7 @@ static void test_deprecated_string(void)
 
     /* set the new name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "tls_sessions_db_path: foo\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 0);
@@ -934,8 +904,7 @@ static void test_deprecated_string(void)
 
     /* set both names to different values */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "tlscache_db_path: foo\n"
         "tls_sessions_db_path: bar\n"
     );
@@ -957,8 +926,7 @@ static void test_deprecated_stringlist(void)
 
     /* set the deprecated name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "tlscache_db: sql\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 1);
@@ -977,8 +945,7 @@ static void test_deprecated_stringlist(void)
 
     /* set the new name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "tls_sessions_db: sql\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 0);
@@ -990,8 +957,7 @@ static void test_deprecated_stringlist(void)
 
     /* set both names to different values */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "tlscache_db: sql\n"
         "tls_sessions_db: twoskip\n"
     );
@@ -1011,8 +977,7 @@ static void test_deprecated_duration(void)
 
     /* set the deprecated name only */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_days: 8\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 1);
@@ -1030,8 +995,7 @@ static void test_deprecated_duration(void)
 
     /* set the new name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_after: 12d\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 0);
@@ -1042,8 +1006,7 @@ static void test_deprecated_duration(void)
 
     /* set both names to different values */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "archive_days: 7\n"
         "archive_after: 12d\n"
     );
@@ -1062,8 +1025,7 @@ static void test_deprecated_bytesize(void)
 
     /* set the deprecated name only */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "autocreatequota: 8\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 1);
@@ -1081,8 +1043,7 @@ static void test_deprecated_bytesize(void)
 
     /* set the new name */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "autocreate_quota: 12M\n"
     );
     CU_ASSERT_SYSLOG(/*all*/0, 0);
@@ -1093,8 +1054,7 @@ static void test_deprecated_bytesize(void)
 
     /* set both names to different values */
     CU_SYSLOG_MATCH("Option '.*' is deprecated");
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "autocreatequota: 7\n"
         "autocreate_quota: 12M\n"
     );
@@ -1109,8 +1069,7 @@ static void test_partition_sanity_ok(void)
 {
     int r;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "partition-foo: /srv/foo\n"
         "archivepartition-foo: /srv/archive/foo\n"
         "metapartition-foo: /srv/meta/foo\n"
@@ -1131,8 +1090,7 @@ static void test_partition_sanity_bad_subdirs(void)
 {
     int r;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "partition-foo: /srv/foo\n"
         "archivepartition-foo: /srv/foo/archive\n" /* bad */
         "metapartition-foo: /srv/foo/meta\n" /* bad */
@@ -1154,8 +1112,7 @@ static void test_partition_sanity_bad_dups(void)
 {
     int r;
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "partition-foo: /srv/foo\n"
         "t1searchpartition-foo: /srv/foo\n" /* uh oh */
         "partition-bar: /srv/bar\n"

--- a/cunit/logfmt.testc
+++ b/cunit/logfmt.testc
@@ -15,7 +15,7 @@
 
 static int set_up(void)
 {
-    config_read_string("configdirectory: "DBDIR"/conf\n");
+    config_read_string(DBDIR"/conf", NULL);
     session_clear_id();
     trace_set_id(NULL, 0);
     return 0;

--- a/cunit/loginlog.testc
+++ b/cunit/loginlog.testc
@@ -11,9 +11,7 @@
 static int set_up(void)
 {
     /* need basic configuration for session_new_id() */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     session_clear_id();
     trace_set_id(NULL, 0);

--- a/cunit/mboxname.testc
+++ b/cunit/mboxname.testc
@@ -4,7 +4,6 @@
 #include <assert.h>
 #include "cunit/unit.h"
 #include "lib/libconfig.h"
-#include "lib/libcyr_cfg.h"
 #include "lib/xunlink.h"
 #include "imap/mboxname.h"
 #include "imap/mailbox.h"
@@ -1066,7 +1065,6 @@ static const char *old_config_defdomain;
 static int set_up(void)
 {
     /* need basic configuration */
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
     );

--- a/cunit/mboxname.testc
+++ b/cunit/mboxname.testc
@@ -1065,9 +1065,7 @@ static const char *old_config_defdomain;
 static int set_up(void)
 {
     /* need basic configuration */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     /*
      * TODO: this is pretty hacky.  There should be some

--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -5,7 +5,6 @@
 #include "parseaddr.h"
 #include "util.h"
 #include "lib/libconfig.h"
-#include "lib/libcyr_cfg.h"
 #include "imap/mailbox.h"
 #include "imap/message.h"
 
@@ -14,7 +13,6 @@
 static int set_up(void)
 {
     /* need basic configuration for message_parse_headers */
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
     );

--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -13,9 +13,7 @@
 static int set_up(void)
 {
     /* need basic configuration for message_parse_headers */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     return 0;
 }

--- a/cunit/proc.testc
+++ b/cunit/proc.testc
@@ -26,17 +26,14 @@ static int set_up(void)
 {
     char myconfigdir_template[] = "/tmp/cyrus-cunit-proctestc-XXXXXX";
     char *dir;
-    struct buf myconfig = BUF_INITIALIZER;
 
     dir = mkdtemp(myconfigdir_template);
     if (!dir) return errno;
 
     myconfigdir = xstrdup(dir);
-    buf_printf(&myconfig, "configdirectory: %s\n", myconfigdir);
 
-    config_read_string(buf_cstring(&myconfig));
+    config_read_string(myconfigdir, NULL);
 
-    buf_free(&myconfig);
     return 0;
 }
 

--- a/cunit/quota.testc
+++ b/cunit/quota.testc
@@ -8,7 +8,6 @@
 #include "imap/global.h"
 #include "imap/imap_err.h"
 #include "cyrusdb.h"
-#include "libcyr_cfg.h"
 #include "libconfig.h"
 #include "hash.h"
 
@@ -1025,7 +1024,6 @@ static int set_up(void)
         }
     }
 
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
     );

--- a/cunit/quota.testc
+++ b/cunit/quota.testc
@@ -1024,9 +1024,7 @@ static int set_up(void)
         }
     }
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     cyrusdb_init();
     config_quota_db = "skiplist";

--- a/cunit/search_expr.testc
+++ b/cunit/search_expr.testc
@@ -5,7 +5,6 @@
 #include "cunit/unit-timeofday.h"
 
 #include "lib/libconfig.h"
-#include "lib/libcyr_cfg.h"
 #include "lib/prot.h"
 #include "lib/util.h"
 #include "lib/xmalloc.h"
@@ -1383,7 +1382,6 @@ static int set_up(void)
     /* n.b. initalising like this skips the on-shutdown cleanup... */
     search_attr_init();
 
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
         "conversations: yes\n"

--- a/cunit/search_expr.testc
+++ b/cunit/search_expr.testc
@@ -1382,8 +1382,7 @@ static int set_up(void)
     /* n.b. initalising like this skips the on-shutdown cleanup... */
     search_attr_init();
 
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "conversations: yes\n"
     );
 

--- a/cunit/sessionid.testc
+++ b/cunit/sessionid.testc
@@ -17,9 +17,7 @@ _Static_assert(sizeof(X256) == 256 + 1, "X266 is wrong length");
 static int set_up(void)
 {
     /* need basic configuration for session_id() */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     /* don't get confused by pollution from other tests */
     session_clear_id();

--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -20,8 +20,8 @@
 #include "map.h"
 #include "util.h"
 #include "cyrusdb.h"
-#include "libcyr_cfg.h"
 #include "libconfig.h"
+#include "libcyr_cfg.h"
 #include "xstrlcat.h"
 #include "xstrlcpy.h"
 #include "xmalloc.h"
@@ -553,7 +553,6 @@ static FILE *fmemopen(const void *buf, size_t len, const char *mode)
 
 static int set_up(void)
 {
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
         "defaultpartition: "PARTITION"\n"

--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -553,8 +553,7 @@ static FILE *fmemopen(const void *buf, size_t len, const char *mode)
 
 static int set_up(void)
 {
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
+    config_read_string(DBDIR"/conf",
         "defaultpartition: "PARTITION"\n"
         "partition-"PARTITION": "DBDIR"/data\n"
         "sievenotifier: mailto\n"

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -28,9 +28,7 @@
 static int set_up(void)
 {
     /* need basic configuration for parseheader */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     return 0;
 }

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -5,7 +5,6 @@
 #include "retry.h"
 #include "xmalloc.h"
 #include "lib/libconfig.h"
-#include "lib/libcyr_cfg.h"
 #include "imap/spool.h"
 #include "xunlink.h"
 
@@ -29,7 +28,6 @@
 static int set_up(void)
 {
     /* need basic configuration for parseheader */
-    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, DBDIR);
     config_read_string(
         "configdirectory: "DBDIR"/conf\n"
     );

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -5,20 +5,24 @@
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <setjmp.h>
 #include <stdarg.h>
 #include <unistd.h>
+
 #include <CUnit/CUnit.h>
 #include <CUnit/Basic.h>
 #include <CUnit/Automated.h>
+
 #if HAVE_VALGRIND_VALGRIND_H
 #include <valgrind/valgrind.h>
 #endif
-#include <setjmp.h>
 
 #include "cunit/unit.h"
 #include "cunit/unit-registry.h"
 #include "cunit/unit-timeout.h"
 
+#include "lib/assert.h"
+#include "lib/buf.h"
 #include "lib/libconfig.h"
 #include "lib/libcyr_cfg.h"
 #include "lib/retry.h"
@@ -279,12 +283,37 @@ CU_BOOL CU_assertFormatImplementation(
     return CU_assertImplementation(bValue, uiLine, buf, strFile, strFunction, bFatal);
 }
 
-EXPORTED void config_read_string(const char *s)
+EXPORTED void config_read_string(const char *confdir, const char *s)
 {
     char fname[] = "/tmp/cyrus-cunit-configXXXXXX";
-    int fd = mkstemp(fname);
+    struct buf opt_confdir = BUF_INITIALIZER;
+    int fd;
 
-    retry_write(fd, s, strlen(s));
+    /* n.b. you should almost always set a confdir, unless you're testing
+     * the fact that cyrus fatals when it's not set!
+     */
+    if (confdir) {
+        if (confdir[0] == '/') {
+            buf_printf(&opt_confdir, "configdirectory: %s\n", confdir);
+        }
+        else {
+            char cwd[PATH_MAX];
+            if (!getcwd(cwd, sizeof(cwd))) {
+                /* if this fails there's not much we can do about it now */
+                perror("getcwd");
+                abort();
+            }
+            buf_printf(&opt_confdir, "configdirectory: %s/%s\n", cwd, confdir);
+        }
+    }
+
+    /* write config to the tmp file and then read it normally */
+    fd = mkstemp(fname);
+    retry_write(fd, buf_cstring(&opt_confdir), buf_len(&opt_confdir));
+    buf_free(&opt_confdir);
+    if (s) {
+        retry_write(fd, s, strlen(s));
+    }
     config_reset();
     config_read(fname, 0);
     xunlink(fname);

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -20,6 +20,7 @@
 #include "cunit/unit-timeout.h"
 
 #include "lib/libconfig.h"
+#include "lib/libcyr_cfg.h"
 #include "lib/retry.h"
 #include "lib/util.h"
 #include "lib/xmalloc.h"
@@ -288,6 +289,9 @@ EXPORTED void config_read_string(const char *s)
     config_read(fname, 0);
     xunlink(fname);
     close(fd);
+
+    /* make sure libcyrus configdirectory is properly initialised */
+    libcyrus_config_setstring(CYRUSOPT_CONFIG_DIR, config_dir);
 }
 
 static void run_tests(void)

--- a/cunit/unit.h
+++ b/cunit/unit.h
@@ -15,7 +15,7 @@
 extern int verbose;
 
 /* initialise libconfig from a string */
-extern void config_read_string(const char *s);
+extern void config_read_string(const char *confdir, const char *s);
 
 /*
  * The standard CUnit assertion *EQUAL* macros have a flaw: they do

--- a/cunit/xsyslog_ev.testc
+++ b/cunit/xsyslog_ev.testc
@@ -331,9 +331,7 @@ static void test_session_id(void)
     char match[32 + MAX_SESSIONID_SIZE];
 
     /* need basic configuration for session_new_id() */
-    config_read_string(
-        "configdirectory: "DBDIR"/conf\n"
-    );
+    config_read_string(DBDIR"/conf", NULL);
 
     session_new_id();
     snprintf(match, sizeof(match), " r.sessionid=%s ", session_id());

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -2360,7 +2360,6 @@ EXPORTED char *mboxname_conf_getpath_legacy(const mbname_t *mbname,
     char c[2], d[2];
 
     const char *root = config_getstring(IMAPOPT_MBOXNAME_USERPATH);
-    if (!root) root = config_dir;
 
     if (mbname->localpart) {
         if (mbname->domain) {
@@ -2439,7 +2438,6 @@ EXPORTED char *mboxid_conf_getpath(const char *mboxid, const char *suffix)
     mboxname_id_hash(path, MAX_MAILBOX_PATH, NULL, mboxid);
 
     const char *root = config_getstring(IMAPOPT_MBOXNAME_USERPATH);
-    if (!root) root = config_dir;
 
     if (suffix) {
         fname = strconcat(root,

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -43,23 +43,21 @@ EXPORTED const char *prometheus_stats_dir(void)
 
     if (buf_len(&statsdir) > 0) return buf_cstring(&statsdir);
 
-    if ((tmp = config_getstring(IMAPOPT_PROMETHEUS_STATS_DIR))) {
-        if (tmp[0] != '/')
-            fatal("prometheus_stats_dir must be fully qualified", EX_CONFIG);
+    tmp = config_getstring(IMAPOPT_PROMETHEUS_STATS_DIR);
 
-        if (strlen(tmp) < 2)
-            fatal("prometheus_stats_dir must not be '/'", EX_CONFIG);
+    /* XXX this is a little weird, we don't validate these requirements
+     * XXX for config_dir...
+     */
+    if (tmp[0] != '/')
+        fatal("prometheus_stats_dir must be fully qualified", EX_CONFIG);
 
-        buf_setcstr(&statsdir, tmp);
+    if (!tmp[1])
+        fatal("prometheus_stats_dir must not be '/'", EX_CONFIG);
 
-        if (statsdir.s[statsdir.len-1] != '/')
-            buf_putc(&statsdir, '/');
-    }
-    else {
-        buf_setcstr(&statsdir, config_dir);
-        buf_appendcstr(&statsdir, FNAME_PROM_STATS_DIR);
+    buf_setcstr(&statsdir, tmp);
+
+    if (statsdir.s[statsdir.len-1] != '/')
         buf_putc(&statsdir, '/');
-    }
 
     return buf_cstring(&statsdir);
 }

--- a/imap/prometheus.h
+++ b/imap/prometheus.h
@@ -18,7 +18,6 @@
 #define FNAME_PROM_MASTER_REPORT "master.txt"
 #define FNAME_PROM_USAGE_REPORT "usage.txt"
 #define FNAME_PROM_DONEPROCS "doneprocs"
-#define FNAME_PROM_STATS_DIR "/stats"
 
 extern const char *prometheus_stats_dir(void);
 

--- a/lib/imapoptions/mboxname_userpath
+++ b/lib/imapoptions/mboxname_userpath
@@ -1,9 +1,9 @@
 Name: mboxname_userpath
 Type: STRING
-Default-Value: NULL
-Last-Modified: 3.13.1
+Default-Value: {configdirectory}
+Last-Modified: UNRELEASED
 
-Path to the parent directory of the user and domain directories.  This
-defaults to 'configdir' if not specified.  This option can be used (along
-with other related options) to place all persistent data outside the
-configdir, allowing it to be on ephemeral storage without using symlinks
+Path to the parent directory of the user and domain directories.  This option
+can be used (along with other related options) to place all persistent data
+outside the configdir, allowing it to be on ephemeral storage without using
+symlinks

--- a/lib/imapoptions/proc_path
+++ b/lib/imapoptions/proc_path
@@ -1,7 +1,6 @@
 Name: proc_path
 Type: STRING
-Default-Value: NULL
-Last-Modified: 2.5.0
+Default-Value: {configdirectory}/proc/
+Last-Modified: UNRELEASED
 
-Path to proc directory.  Default is NULL - must be an absolute path if
-specified.  If not specified, the path $configdirectory/proc/ will be used.
+Path to proc directory.  Must be an absolute path.

--- a/lib/imapoptions/prometheus_stats_dir
+++ b/lib/imapoptions/prometheus_stats_dir
@@ -1,9 +1,7 @@
 Name: prometheus_stats_dir
 Type: STRING
-Default-Value: NULL
-Last-Modified: 3.1.2
+Default-Value: {configdirectory}/stats/
+Last-Modified: UNRELEASED
 
-Directory to use for gathering prometheus statistics.  If specified, must
-be an absolute path.  If not specified, the default path
-$configdirectory/stats/ will be used.  It may be advantageous to locate
-this directory on ephemeral storage.
+Directory to use for gathering prometheus statistics.  Must be an absolute
+path.  It may be advantageous to locate this directory on ephemeral storage.

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -40,9 +40,6 @@
 # endif
 #endif
 
-
-#define FNAME_PROCDIR "/proc"
-
 /* n.b. setproctitle might come from setproctitle.c, or might come from a
  * system library
  */
@@ -52,26 +49,26 @@ extern void setproctitle(const char *fmt, ...)
 static char *proc_getpath(pid_t pid, int isnew)
 {
     struct buf buf = BUF_INITIALIZER;
+    const char *procpath;
 
-    if (config_getstring(IMAPOPT_PROC_PATH)) {
-        const char *procpath = config_getstring(IMAPOPT_PROC_PATH);
+    procpath = config_getstring(IMAPOPT_PROC_PATH);
 
-        if (procpath[0] != '/')
-            fatal("proc path must be fully qualified", EX_CONFIG);
+    /* belt and suspenders: libconfig defaults it if it wasn't set */
+    assert(procpath != NULL);
 
-        if (strlen(procpath) < 2)
-            fatal("proc path must not be '/'", EX_CONFIG);
+    /* XXX this is kinda weird -- we do not have this level of verification
+     * XXX for config_dir, but perhaps we should
+     */
+    if (procpath[0] != '/')
+        fatal("proc_path must be fully qualified", EX_CONFIG);
 
-        buf_setcstr(&buf, procpath);
+    if (!procpath[1])
+        fatal("proc_path must not be '/'", EX_CONFIG);
 
-        if (buf.s[buf.len-1] != '/')
-            buf_putc(&buf, '/');
-    }
-    else {
-        buf_setcstr(&buf, config_dir);
-        buf_appendcstr(&buf, FNAME_PROCDIR);
+    buf_setcstr(&buf, procpath);
+
+    if (buf.s[buf.len-1] != '/')
         buf_putc(&buf, '/');
-    }
 
     if (pid)
         buf_printf(&buf, "%u", pid);

--- a/master/master.c
+++ b/master/master.c
@@ -86,7 +86,6 @@ const char *MASTER_CONFIG_FILENAME = DEFAULT_MASTER_CONFIG_FILENAME;
 #define MAX_READY_FAILS              5
 #define MAX_READY_FAIL_INTERVAL     10  /* 10 seconds */
 
-#define FNAME_PROM_STATS_DIR        "/stats" /* keep in sync with prometheus.h */
 #define FNAME_PROM_MASTER_REPORT    "master.txt"
 
 struct service *Services = NULL;
@@ -2387,18 +2386,11 @@ static void init_prom_report(struct timeval now)
     prom_prev_report.tv_sec = now.tv_sec - prom_frequency; /* next report asap */
     prom_prev_report.tv_usec = 0;
 
-    if ((tmp = config_getstring(IMAPOPT_PROMETHEUS_STATS_DIR))) {
-        if (tmp[0] == '/' && tmp[1] != '\0') {
-            buf_setcstr(&buf, tmp);
-            if (buf.s[buf.len-1] != '/')
-                buf_putc(&buf, '/');
-            buf_appendcstr(&buf, FNAME_PROM_MASTER_REPORT);
-        }
-    }
-    else if ((tmp = config_getstring(IMAPOPT_CONFIGDIRECTORY))) {
+    tmp = config_getstring(IMAPOPT_PROMETHEUS_STATS_DIR);
+    if (tmp[0] == '/' && tmp[1] != '\0') {
         buf_setcstr(&buf, tmp);
-        buf_appendcstr(&buf, FNAME_PROM_STATS_DIR);
-        buf_putc(&buf, '/');
+        if (buf.s[buf.len-1] != '/')
+            buf_putc(&buf, '/');
         buf_appendcstr(&buf, FNAME_PROM_MASTER_REPORT);
     }
 


### PR DESCRIPTION
There's a few imapd.conf options that specify a default value of `NULL` in the imapoptions data, but then compute a non-NULL default value based on `configdirectory` at runtime.  The automated documentation based on the data files doesn't match reality, so these options then need extra verbiage explaining the real behaviour.

We already have a mechanism for deriving config values from the `configdirectory` value, so use it for these options' defaults.  This makes the automatic documentation correct.

I've also fixed some inconsistencies in how cunit handled configdirectory, which made fixing the real problem easier.