### PR TITLE
hash: remove the definitions of hash and hashu64 buckets from the headers

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -14,6 +14,13 @@
 #include "util.h"
 #include "xmalloc.h"
 
+struct bucket {
+    void *data;
+    struct bucket *next;
+    uint32_t hash;
+    char key[];
+};
+
 /*
 ** public domain code by Jerry Coffin, with improvements by HenkJan Wolthuis.
 **

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -16,12 +16,7 @@
 ** if there was one.
 */
 
-typedef struct bucket {
-    void *data;
-    struct bucket *next;
-    uint32_t hash;
-    char key[];
-} bucket;
+typedef struct bucket bucket;
 
 /*
 ** This is what you actually declare an instance of to create a table.

--- a/lib/hashu64.c
+++ b/lib/hashu64.c
@@ -11,6 +11,12 @@
 #include "mpool.h"
 #include "xmalloc.h"
 
+struct bucketu64 {
+    uint64_t key;
+    void *data;
+    struct bucketu64 *next;
+};
+
 /*
 ** public domain code by Jerry Coffin, with improvements by HenkJan Wolthuis.
 **

--- a/lib/hashu64.h
+++ b/lib/hashu64.h
@@ -13,11 +13,7 @@
 ** if there was one.
 */
 
-typedef struct bucketu64 {
-    uint64_t key;
-    void *data;
-    struct bucketu64 *next;
-} bucketu64;
+typedef struct bucketu64 bucketu64;
 
 /*
 ** This is what you actually declare an instance of to create a table.


### PR DESCRIPTION
Move the definitions to the respective C files, and put a declaration in the headers.

The structs contain variable length arrays, which are legal in C but not C++ clang++ and g++ both default to being lax, but warn about this when -pedantic is enabled (not our default). The headers are transitively included into xapian_wrap.cpp, hence why we see this.

The directly included headers need the hash_table definition, hence they need to be included. However, no part of the hash implementation needs the bucket *definition* visible to the headers. Hence replacing the definition with a declaration is viable, moving the actual declaration to the only source file that needs it.

This also has the beneficial side effect of exposing less implementation detail in places that don't need to see it.