### PR TITLE
spool:parseheader() avoid reassigning zero

### DIFF
--- a/imap/spool.c
+++ b/imap/spool.c
@@ -113,13 +113,11 @@ static int parseheader(struct protstream *fin, FILE *fout,
 
                 if (peek == '\r' || peek == '\n') {
                     /* just reached the end of message */
-                    r = 0;
                     goto ph_error;
                 }
             }
             if (c == '\r' || c == '\n') {
                 /* just reached the end of headers */
-                r = 0;
                 goto ph_error;
             }
             /* field-name      =       1*ftext


### PR DESCRIPTION
`r = 0` is set at the beginning of the function and after each assignment to `r` follows `goto ph_error` and the loop is exited.  So on these places `r` must already be zero.