### PR TITLE
Calendars: accept #RRGGBBAA color via CalDAV PROPPATCH, and

### DIFF
--- a/cassandane/tiny-tests/Caldav/calendar_setcolor
+++ b/cassandane/tiny-tests/Caldav/calendar_setcolor
@@ -46,8 +46,21 @@ EOF
     $self->assert_str_equals('HTTP/1.1 200 OK', $propstat->{'{DAV:}status'}{content});
     $self->assert_str_equals('#2952A3', $propstat->{'{DAV:}prop'}{'{http://apple.com/ns/ical/}calendar-color'}{content});
 
+    # Change to hex value with alpha channel.
+    $proppatchXml =~ s/#2952A3/#2952A37F/;
+    $response = $CalDAV->Request('PROPPATCH', "/dav/calendars/user/cassandane/". $CalendarId,
+                                    $proppatchXml, 'Content-Type' => 'text/xml');
+
+    # Assert color is set.
+    $response = $CalDAV->Request('PROPFIND', "/dav/calendars/user/cassandane/". $CalendarId,
+                                 $propfindXml, 'Content-Type' => 'text/xml');
+    $propstat = $response->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0];
+    $self->assert_str_equals('HTTP/1.1 200 OK', $propstat->{'{DAV:}status'}{content});
+    $self->assert_str_equals('#2952A37F', $propstat->{'{DAV:}prop'}{'{http://apple.com/ns/ical/}calendar-color'}{content});
+
+
     # Change to named color.
-    $proppatchXml =~ s/#2952A3/SteelBlue/;
+    $proppatchXml =~ s/#2952A37F/SteelBlue/;
     $response = $CalDAV->Request('PROPPATCH', "/dav/calendars/user/cassandane/". $CalendarId,
                                     $proppatchXml, 'Content-Type' => 'text/xml');
 
@@ -82,8 +95,8 @@ EOF
     $self->assert_str_equals('HTTP/1.1 403 Forbidden', $propstat->{'{DAV:}status'}{content});
     $self->assert(exists $propstat->{'{DAV:}prop'}{'{http://apple.com/ns/ical/}calendar-color'});
 
-    # Attempt to change color to 8-digit hex value.
-    $proppatchXml =~ s/#01a/#01aAfFFa/;
+    # Attempt to change color to 9-digit hex value.
+    $proppatchXml =~ s/#01a/#01aAfFFa0/;
     $response = $CalDAV->Request('PROPPATCH', "/dav/calendars/user/cassandane/". $CalendarId,
                                     $proppatchXml, 'Content-Type' => 'text/xml');
     $propstat = $response->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0];

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_color
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_color
@@ -44,7 +44,7 @@ EOF
     $self->assert_str_equals('SteelBlue',
                              $propstat->{'{DAV:}prop'}{'{http://apple.com/ns/ical/}calendar-color'}{content});
 
-    xlog $self, "update event with hex color value";
+    xlog $self, "update calendar with hex color value";
     $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
@@ -111,4 +111,30 @@ EOF
         }
     }, "R1"]]);
     $self->assert_not_null($res->[0][1]{notUpdated}{$id});
+
+    my $proppatchXml = <<EOF;
+<?xml version="1.0" encoding="UTF-8"?>
+<D:propertyupdate xmlns:D="DAV:" xmlns:A="http://apple.com/ns/ical/">
+  <D:set>
+    <D:prop>
+      <A:calendar-color>#2952A37F</A:calendar-color>
+    </D:prop>
+  </D:set>
+</D:propertyupdate>
+EOF
+
+    xlog $self, "update calendar with hex color + alpha value";
+    $res = $CalDAV->Request('PROPPATCH', "/dav/calendars/user/cassandane/". $id,
+                            $proppatchXml, 'Content-Type' => 'text/xml');
+
+    xlog $self, "assert alpha channel is stripped via JMAP";
+    $res = $jmap->CallMethods([
+        ['Calendar/get', {
+            ids => [ $id ],
+            properties => [ 'color' ]
+         },
+         "R2"],
+    ]);
+    $self->assert_null($res->[0][1]{updated}{$id});
+    $self->assert_str_equals('#2952A3', $res->[0][1]{list}[0]{color});
 }

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -6889,7 +6889,7 @@ static int proppatch_color(xmlNodePtr prop, unsigned set,
             color = (const char *) freeme;
 
             /* Verify we have a valid color name or 6-digit hex value */
-            if (!color || !ical_is_valid_color(color)) {
+            if (!color || !ical_is_valid_color(color, true /*allow_alpha*/)) {
                 xmlFree(freeme);
                 valid = false;
             }

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -3117,7 +3117,7 @@ EXPORTED int ical_categories_is_color(icalproperty *cprop)
 
     if (!categories) return 0;
 
-    return ical_is_valid_color(categories);
+    return ical_is_valid_color(categories, false /*allow_alpha*/);
 }
 
 EXPORTED void icalcomponent_normalize_x(icalcomponent *ical)
@@ -3248,6 +3248,20 @@ EXPORTED icalrecurrencetype_t *icalvalue_get_recurrence(const icalvalue *val)
     if (rt) icalrecurrencetype_ref(rt);
 
     return rt;
+}
+
+EXPORTED bool ical_is_valid_color(const char *val, bool allow_alpha)
+{
+    if (!val) return false;
+
+    if (val[0] == '#') {
+        size_t len = strspn(val+1, "0123456789abcdefABCDEF");
+
+        /* 6- or 8-digit hex */
+        return ((len == 6 || (allow_alpha && len == 8)) && val[len+1] == '\0');
+    }
+
+    return is_css3_color(val);
 }
 
 #endif /* HAVE_ICAL */

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -43,14 +43,6 @@ extern icalrecurrencetype_t *icalvalue_get_recurrence(const icalvalue *val);
 #define icalrecur_byrule_size(rt, rule)      (rt->by[rule].size)
 #define icalrecur_byrule_data(rt, rule)      (rt->by[rule].data)
 
-#define ical_is_valid_color(val)                                        \
-    (val &&                                                             \
-     (is_css3_color(val) ||                                             \
-      /* 6-digit hex */                                                 \
-      (val[0] == '#' &&                                                 \
-       strspn(val+1, "0123456789abcdefABCDEF") == 6 &&                  \
-       val[7] == '\0')))
-
 
 #ifdef HAVE_PARTTYPE_VOTER
 #define HAVE_VPOLL_SUPPORT
@@ -254,6 +246,8 @@ extern void icalcomponent_set_jmapid(icalcomponent *comp, const char *id);
 
 #define icalproperty_get_schedulestatus_parameter(prop) \
     icalproperty_get_first_parameter(prop, ICAL_SCHEDULESTATUS_PARAMETER)
+
+extern bool ical_is_valid_color(const char *val, bool allow_alpha);
 
 #endif /* HAVE_ICAL */
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -661,9 +661,20 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
             DAV_ANNOT_NS "<" XML_NS_APPLE ">calendar-color";
         r = annotatemore_lookupmask_mbe(mbentry, color_annot,
                                         req->userid, &attrib);
-        /* Verify we have a valid color name or 6-digit hex value */
-        if (!r && ical_is_valid_color(buf_cstring(&attrib)))
-            json_object_set_new(obj, "color", json_string(buf_cstring(&attrib)));
+        if (!r) {
+            /* Verify we have a valid color name, or 6- or 8-digit hex value */
+            const char *color = buf_base(&attrib);
+
+            if (ical_is_valid_color(color, true /*allow_alpha*/)) {
+                if (*color == '#' && buf_len(&attrib) == 9) {
+                    /* Trim the alpha channel off of 8-digit hex */
+                    buf_truncate(&attrib, 7);
+                    color = buf_cstring(&attrib);
+                }
+
+                json_object_set_new(obj, "color", json_string(color));
+            }
+        }
         buf_free(&attrib);
     }
 
@@ -1171,7 +1182,7 @@ static void setcalendar_parseprops(jmap_req_t *req,
     if (json_is_string(jprop)) {
         props->color = json_string_value(jprop);
         /* Verify we have a valid color name or 6-digit hex value */
-        if (!ical_is_valid_color(props->color)) {
+        if (!ical_is_valid_color(props->color, false /*allow_alpha*/)) {
             jmap_parser_invalid(parser, "color");
         }
     }

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -3911,7 +3911,7 @@ calendarevent_from_ical(icalcomponent *comp,
         if (prop) {
             /* Verify we have a valid color name or 6-digit hex value */
             const char *color = icalproperty_get_color(prop);
-            if (ical_is_valid_color(color)) {
+            if (ical_is_valid_color(color, false /*allow_alpha*/)) {
                 json_object_set_new(event, "color", json_string(color));
             }
         }
@@ -7971,7 +7971,7 @@ static void calendarevent_to_ical(icalcomponent *comp,
     if (json_is_string(jprop)) {
         const char *val = json_string_value(jprop);
         /* Verify we have a valid color name or 6-digit hex value */
-        if (!ical_is_valid_color(val)) {
+        if (!ical_is_valid_color(val, false /*allow_alpha*/)) {
             jmap_parser_invalid(parser, "color");
         }
         else {


### PR DESCRIPTION
strip the alpha channel on Calendar/get

Some CalDAV clients seem to send #RRGGBBAA, but JMAP for Calendars specifies #RRGGBB only, so this allows us to be compatible with both.