### PR TITLE
Cross-reference duplicated Sieve documentation

### DIFF
--- a/docsrc/reference/admin/sieve.rst
+++ b/docsrc/reference/admin/sieve.rst
@@ -28,11 +28,11 @@ as a .sieve file.
 Installing Sieve
 ================
 
-This section assumes that you :ref:`compiled Cyrus <compiling>` with sieve
+This section assumes that you :ref:`compiled Cyrus <compiling>` with Sieve
 support. If you specified ``--disable-sieve`` when running ``./configure``,
 you did NOT compile the server with sieve support.
 
-Configure sieve
+Configure Sieve
 ---------------
 
 Depending on what's in your ``/etc/services`` file, sieve will usually be set
@@ -240,6 +240,8 @@ Cyrus supports a subset of these:
 
 Cyrus IMAP Specific Extensions
 ------------------------------
+
+More extensions are described at :doc:`/reference/extensions/sieve`.
 
 .. _vnd.cyrus.log:
 

--- a/docsrc/reference/extensions/sieve.md
+++ b/docsrc/reference/extensions/sieve.md
@@ -1,7 +1,8 @@
 # Sieve extensions
 
 This document lists Cyrus's nonstandard extensions to Cyrus IMAP's
-Sieve implementation, found in the `sieve/` directory.
+Sieve implementation, found in the `sieve/` directory. More extensions are
+described at [Cyrus IMAP Specific Extensions](../admin/sieve.rst#cyrus-imap-specific-extensions).
 
 ## `snooze`
 

--- a/docsrc/reference/extensions/sieve.md
+++ b/docsrc/reference/extensions/sieve.md
@@ -2,7 +2,7 @@
 
 This document lists Cyrus's nonstandard extensions to Cyrus IMAP's
 Sieve implementation, found in the `sieve/` directory. More extensions are
-described at [Cyrus IMAP Specific Extensions](../admin/sieve.rst#cyrus-imap-specific-extensions).
+described at {ref}`Cyrus IMAP Specific Extensions <cyrus-sieve-extensions>`.
 
 ## `snooze`
 


### PR DESCRIPTION
This creates cross-reference between the two places, describing Cyrus Sieve extensions. It prints a warning during build:


> writing output... [100%] reference/manpages/usercommands/sieveshell
> docsrc/reference/extensions/sieve.md:3: WARNING: local id not found in doc 'reference/admin/sieve': 'cyrus-imap-specific-extensions' [myst.xref_missing]
> generating indices... genindex done


which I do not know how to resolve, but it works as expected.