### PR TITLE
docsrc/caldav: write down sub-privileges for `DAV:write-properties`

### DIFF
--- a/docsrc/download/installation/http/caldav.rst
+++ b/docsrc/download/installation/http/caldav.rst
@@ -106,7 +106,9 @@ The tables below show how the access controls are used by the CalDAV module.
       <tr>
         <td>w - write
           <br>n - write shared annotation</td>
-        <td colspan=2>DAV:write-properties</td>
+        <td>DAV:write-properties</td>
+        <td>CYRUS:write-properties-collection
+          <br>CYRUS:write-properties-resource</td>
         <td>PROPPATCH
           <br>COPY/MOVE <small>(on destination)</small></td>
       </tr>


### PR DESCRIPTION
This updates the table at https://www.cyrusimap.org/dev/download/installation/http/caldav.html#calendar-access-controls based on https://www.cyrusimap.org/dev/reference/extensions/dav-extensions.html#privileges to spell the sub-privileges of `DAV:write-properties`.

Before:
<img width="748" height="517" alt="image" src="https://github.com/user-attachments/assets/4975495f-de71-42ad-94a1-eaae736b4371" />

After:

<img width="718" height="557" alt="image" src="https://github.com/user-attachments/assets/d1e67be9-e7d7-4ad5-ab91-1baaaf687c03" />
