### PR TITLE
acl_afs.c:cyrus_acl_set() remove free(NULL)

### DIFF
--- a/lib/acl_afs.c
+++ b/lib/acl_afs.c
@@ -107,8 +107,7 @@ EXPORTED int cyrus_acl_set(char **acl, const char *identifier,
     }
 
     /* Prevent ACLs for empty identifiers */
-    if (strlen(identifier) == 0) {
-        if (newidentifier) free(newidentifier);
+    if (*identifier == '\0') {
         return -1;
     }
 


### PR DESCRIPTION
Here `newidentifier` is always `NULL`. It would be not `NULL` if in the past `*identifier == '-'`, but then `strlen(identifier)` would not be NULL, so the line will not be executed.