### PR TITLE
acl.h: remove invalid text about cyrus_acl_myrights()

### DIFF
--- a/lib/acl.h
+++ b/lib/acl.h
@@ -71,7 +71,6 @@ extern char *cyrus_acl_masktostr(int acl, char *str);
 
 /*  cyrus_acl_myrights(acl)
  * Calculate the set of rights the user in 'auth_state' has in the ACL 'acl'.
- * 'acl' must be writable, but is restored to its original condition.
  */
 extern int cyrus_acl_myrights(const struct auth_state *auth_state, const char *acl);
 


### PR DESCRIPTION
```c
EXPORTED int cyrus_acl_myrights(const struct auth_state *auth_state, const char *origacl)
{
    int admin_implies_write = libcyrus_config_getswitch(CYRUSOPT_ACL_ADMIN_IMPLIES_WRITE);
    char *acl = xstrdupsafe(origacl);
```
and afterwards `origacl` is not touched.  So `origacl` must not be writeable.