### PR TITLE
Sync no whack users

### DIFF
--- a/cassandane/tiny-tests/Replication/rename_move_resync
+++ b/cassandane/tiny-tests/Replication/rename_move_resync
@@ -1,0 +1,85 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Invariant: syncing one user must never delete another user's mailboxes,
+# even when that user's name_history references the other user's namespace
+# (e.g. mover was once renamed from/to victim) and the sync runs with -O
+# (no_copyback).
+#
+sub test_rename_move_resync
+    :NoAltNameSpace :AllowMoves :Replication :DelayedDelete :Conversations
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+    my $mastersvc = $self->{instance}->get_service('imap');
+    my $replicasvc = $self->{replica}->get_service('imap');
+
+    my $mover_store = $mastersvc->create_store(username => 'mover');
+    $mover_store->set_fetch_attributes('uid');
+
+    xlog $self, "OldStore: create user.mover and give it some data";
+    $admintalk->create("user.mover");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $admintalk->setacl("user.mover", "admin", "lrswipkxteacdn");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $admintalk->create("user.mover.SeparateFolder");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $admintalk->create("user.mover.Trash");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $self->make_message("Message A", store => $mover_store);
+    $self->make_message("Message B", store => $mover_store);
+
+    xlog $self, "rename user.mover to user.victim and back again";
+    $admintalk->rename("user.mover", "user.victim");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $admintalk->rename("user.victim", "user.mover");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    xlog $self, "OldStore: create fresh user.victim and deliver messages";
+    $admintalk->create("user.victim");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $admintalk->setacl("user.victim", "admin", "lrswipkxteacdn");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $admintalk->create("user.victim.Trash");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $admintalk->create("user.victim.OwnFolder");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    my $victim_store = $mastersvc->create_store(username => 'victim');
+    $victim_store->set_fetch_attributes('uid');
+    my %msgs;
+    $msgs{A} = $self->make_message("Message A", store => $victim_store);
+    $msgs{B} = $self->make_message("Message B", store => $victim_store);
+
+    xlog $self, "Sync user.victim from OldStore to Replica (simulating victim's move)";
+    $self->{instance}->run_command({cyrus => 1},
+        'sync_client', '-v', '-v', '-o', '-u', 'victim');
+
+    xlog $self, "Verify Replica has victim's messages";
+    my $replica_victim = $replicasvc->create_store(username => 'victim');
+    $replica_victim->set_fetch_attributes('uid');
+    $self->check_messages(\%msgs, store => $replica_victim);
+
+    xlog $self, "Delete user.victim from OldStore (completing victim's move)";
+    $self->{instance}->run_command({cyrus => 1}, 'sync_reset', '-f', 'victim');
+
+    xlog $self, "Sync user.mover from OldStore to Replica with -O (no_copyback)";
+    xlog $self, "This MUST NOT send UNMAILBOX user.victim to the Replica";
+    $self->_disconnect_all();
+    $self->{instance}->run_command({cyrus => 1},
+        'sync_client', '-v', '-v', '-o', '-O', '-u', 'mover');
+
+    xlog $self, "Verify victim's messages still exist on Replica";
+    $replica_victim = $replicasvc->create_store(username => 'victim');
+    $replica_victim->set_fetch_attributes('uid');
+    $self->check_messages(\%msgs, store => $replica_victim);
+}

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -6946,6 +6946,17 @@ static int do_folders(struct sync_client_state *sync_cs,
         if (r == 0) {
             if (tombstone->mbtype & MBTYPE_DELETED) {
                 mboxlist_entry_free(&tombstone);
+                if (sync_cs->userid) {
+                    char *rfolder_userid = mboxname_to_userid(rfolder->name);
+                    int foreign = rfolder_userid && strcmp(rfolder_userid, sync_cs->userid) != 0;
+                    free(rfolder_userid);
+                    if (foreign) {
+                        syslog(LOG_NOTICE, "SYNCNOTICE: skipping delete of %s (foreign user, syncing %s)",
+                               rfolder->name, sync_cs->userid);
+                        r = 0;
+                        continue;
+                    }
+                }
                 r = sync_do_folder_delete(sync_cs, rfolder->name);
                 if (r) {
                     syslog(LOG_ERR, "SYNCERROR: sync_do_folder_delete(): failed: %s (%s)",
@@ -7024,6 +7035,15 @@ static int do_folders(struct sync_client_state *sync_cs,
         for (i = 0; i < ptrarray_size(&mbentry_byid->name_history); i++) {
             const former_name_t *histitem = ptrarray_nth(&mbentry_byid->name_history, i);
             if (sync_folder_lookup_byname(replica_folders, histitem->name)) continue;
+            /* Skip history entries from a different user's namespace — a cross-user
+             * rename leaves former names in other users' namespaces, which must not
+             * be used as intermediate rename targets on the replica. */
+            char *hist_userid = mboxname_to_userid(histitem->name);
+            char *cur_userid = mboxname_to_userid(mbentry_byid->name);
+            int same_user = !strcmpsafe(hist_userid, cur_userid);
+            free(hist_userid);
+            free(cur_userid);
+            if (!same_user) continue;
             // add a rename from old name to the temporary name
             sync_rename_list_add(rename_folders, item->uniqueid, item->oldname,
                                  histitem->name, item->part, histitem->uidvalidity);
@@ -7268,6 +7288,13 @@ static int do_mailbox_info(const mbentry_t *mbentry, void *rock)
     struct mailbox *mailbox = NULL;
     struct mboxinfo *info = (struct mboxinfo *)rock;
     int r = 0;
+
+    if (mbentry->mbtype & MBTYPE_DELETED) {
+        /* Tombstone: deletion is signalled via the UUID lookup in do_folders;
+         * processing name_history here would pollute mboxname_list with names
+         * from other users' namespaces. */
+        return 0;
+    }
 
     if (mbtype_isa(mbentry->mbtype) == MBTYPE_SIEVE &&
         !(info->flags & SYNC_FLAG_SIEVE_MAILBOX)) {


### PR DESCRIPTION
Here's some more username protections - since one user got hit AGAIN after the first fix.  I wasn't able to recreate the exact cause with tests, however I'm happy that these changes are safe and better than before, particularly the "avoid renaming into the other user" part of the intermediate discovery logic.