### PR TITLE
configure.ac: Remove AC_C_INLINE, which probes `inline` support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,6 @@ AC_SYS_LONG_FILE_NAMES
 if test $ac_cv_sys_long_file_names = no; then
         AC_MSG_ERROR(The Cyrus IMAPD requires support for long file names)
 fi
-AC_C_INLINE
 
 dnl check for libm -- sets LIBM
 dnl LT_LIB_M breaks under -Werror, so work around that


### PR DESCRIPTION
This autoconf probe is giving the wrong result with clang with our choice of compiler warning and error flags, because the autoconf test code chances to trigger a clang diagnostic we wish to be fatal, and hence autoconf misunderstands this failure to mean "lack of support"

**All** the autoconf probe does is decide whether to create a macro to redefine `inline`, where the choice is "empty string" if no suitable keyword is found. For clang, we got:

    /* Define to `__inline__' or `__inline' if that's what the C compiler
       calls it, or to nothing if 'inline' is not supported under any name.  */
    #ifndef __cplusplus
    #define inline
    #endif

which then **breaks** use of `static inline` functions, because that macro converts the source to read `static`, and clang then (rightly) warns about unused (regular) static functions, which during development we want to be fatal.

The probe was added back in July 2004 as part of commit 7eafcd500ed6f13d:
    use LDAP_LDFLAGS when calling AC_CHECK_LIB for LDAP

Back then, it was reasonable to assume that `inline` might not be supported, as it was only mandated by C99, and many compiler vendors ignored C99 until C11 was ratified. But now, over 20 years later, everyone supports it.