### PR TITLE
Fix typos in the `doc` and `docsrc` dirs and a few text files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ spell out some of the standards of formatting and construction.  This document
 is, at present, quite out of date.  You are probably best served by just
 copying the style of the surrounding code.
 
-The repostitory contains a `.clang-format` file that reflects our preferred
+The repository contains a `.clang-format` file that reflects our preferred
 style.  This isn't applied automatically, and existing files are not already in
 that style -- so it's not a silver bullet for styling.  But it might help.
 

--- a/cassandane/Cassandane/Test/Cassini.pm
+++ b/cassandane/Cassandane/Test/Cassini.pm
@@ -71,31 +71,31 @@ sub test_basic
 
     my $cassini = $self->new_cassini;
 
-    # Don't find non-existant param in non-existant section
+    # Don't find non-existent param in non-existent section
     $self->assert_null($cassini->val('swag', 'quinoa'));
     # or return the default
     $self->assert_str_equals('whatever',
                              $cassini->val('swag', 'quinoa', 'whatever'));
 
-    # Don't find non-existant param in existant section
+    # Don't find non-existent param in existent section
     $self->assert_null($cassini->val('helvetica', 'quinoa'));
     # or return the default
     $self->assert_str_equals('whatever',
                              $cassini->val('helvetica', 'quinoa', 'whatever'));
 
-    # Don't find param in non-existant section where the
+    # Don't find param in non-existent section where the
     # param does exist in another section
     $self->assert_null($cassini->val('swag', 'blog'));
     # or return the default
     $self->assert_str_equals('whatever',
                              $cassini->val('swag', 'blog', 'whatever'));
 
-    # Don't find case aliases for existant param
+    # Don't find case aliases for existent param
     $self->assert_null($cassini->val('Helvetica', 'blog'));
     $self->assert_null($cassini->val('helvetica', 'Blog'));
     $self->assert_null($cassini->val('HELvEtIca', 'blOG'));
 
-    # Do find exact match for existant param
+    # Do find exact match for existent param
     $self->assert_str_equals('ethical', $cassini->val('helvetica', 'blog'));
 }
 

--- a/cassandane/tiny-tests/Delivery/duplicate_suppression_on_badmbox
+++ b/cassandane/tiny-tests/Delivery/duplicate_suppression_on_badmbox
@@ -7,7 +7,7 @@ sub test_duplicate_suppression_on_badmbox
 {
     xlog $self, "Testing behaviour with duplicate suppression on";
     xlog $self, "interaction with attempted delivery to a";
-    xlog $self, "non-existant mailbox";
+    xlog $self, "non-existent mailbox";
 
     my $folder = "INBOX.nonesuch";
     # DO NOT create the target folder

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_move_to_deleted_parent
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_move_to_deleted_parent
@@ -30,7 +30,7 @@ sub test_mailbox_move_to_deleted_parent
     $self->assert_num_equals(1, scalar @{$res->[0][1]{destroyed}});
     $self->assert_null($res->[0][1]{notDestroyed});
 
-    # Try to move "B" under a non-existant mailbox
+    # Try to move "B" under a non-existent mailbox
     $res = $jmap->CallMethods([['Mailbox/set', {
         update => {
             $idB => { parentId => "nosuchid" },

--- a/cassandane/tiny-tests/Master/service_noexe
+++ b/cassandane/tiny-tests/Master/service_noexe
@@ -3,7 +3,7 @@ use Cassandane::Tiny;
 
 sub test_service_noexe ($self)
 {
-    xlog $self, "single service with a non-existant executable";
+    xlog $self, "single service with a non-existent executable";
     my $srvA = $self->lemming_service(tag => 'A');
     my $srvB = $self->{instance}->add_service(
                     name => 'B',

--- a/cassandane/tiny-tests/Metadata/nonexistant_mailbox
+++ b/cassandane/tiny-tests/Metadata/nonexistant_mailbox
@@ -1,7 +1,7 @@
 #!perl
 use Cassandane::Tiny;
 
-sub test_nonexistant_mailbox ($self)
+sub test_nonexistent_mailbox ($self)
 {
     my $imaptalk = $self->{store}->get_client();
     my $entry = '/shared/comment';

--- a/cassandane/tiny-tests/Sieve/deliver
+++ b/cassandane/tiny-tests/Sieve/deliver
@@ -5,7 +5,7 @@ sub test_deliver ($self)
 {
     my $target = "INBOX.target";
 
-    xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
+    xlog $self, "Install a sieve script filing all mail into a nonexistent folder";
     $self->{instance}->install_sieve_script(<<EOF
 require ["fileinto"];
 fileinto "$target";

--- a/cassandane/tiny-tests/Sieve/double_require
+++ b/cassandane/tiny-tests/Sieve/double_require
@@ -5,7 +5,7 @@ sub test_double_require ($self)
 {
     my $target = "INBOX.target";
 
-    xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
+    xlog $self, "Install a sieve script filing all mail into a nonexistent folder";
     $self->{instance}->install_sieve_script(<<EOF
 require ["fileinto"];
 require ["imap4flags"];

--- a/cassandane/tiny-tests/Sieve/error_flag
+++ b/cassandane/tiny-tests/Sieve/error_flag
@@ -5,7 +5,7 @@ sub test_error_flag
     :min_version_3_3
     ($self)
 {
-    xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
+    xlog $self, "Install a sieve script filing all mail into a nonexistent folder";
     $self->{instance}->install_sieve_script(<<EOF);
 require ["ihave", "fileinto"];
 

--- a/cassandane/tiny-tests/Sieve/sieve_setflag
+++ b/cassandane/tiny-tests/Sieve/sieve_setflag
@@ -8,7 +8,7 @@ sub test_sieve_setflag
     xlog $self, "Actually create the target folder";
     my $imaptalk = $self->{store}->get_client();
 
-    xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
+    xlog $self, "Install a sieve script filing all mail into a nonexistent folder";
     $self->{instance}->install_sieve_script(<<EOF
 require ["fileinto", "imap4flags"];
 if header :matches "Subject" "Message 2" {

--- a/cassandane/tiny-tests/Sieve/vacation_with_following_rules
+++ b/cassandane/tiny-tests/Sieve/vacation_with_following_rules
@@ -7,7 +7,7 @@ sub test_vacation_with_following_rules
 {
     my $target = "INBOX.target";
 
-    xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
+    xlog $self, "Install a sieve script filing all mail into a nonexistent folder";
     $self->{instance}->install_sieve_script(<<'EOF'
 
 require ["fileinto", "reject", "vacation", "imap4flags", "envelope", "relational", "regex", "subaddress", "copy", "mailbox", "mboxmetadata", "servermetadata", "date", "index", "comparator-i;ascii-numeric", "variables"];

--- a/cassandane/tiny-tests/Sieve/variables_basic
+++ b/cassandane/tiny-tests/Sieve/variables_basic
@@ -12,7 +12,7 @@ sub test_variables_basic
     $imaptalk->create("INBOX.target.Folder1");
     $imaptalk->create("INBOX.target.Folder2");
 
-    xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
+    xlog $self, "Install a sieve script filing all mail into a nonexistent folder";
     $self->{instance}->install_sieve_script(<<EOF
 require ["fileinto", "variables"];
 set "folder" "target";

--- a/cassandane/tiny-tests/Sieve/variables_regex
+++ b/cassandane/tiny-tests/Sieve/variables_regex
@@ -12,7 +12,7 @@ sub test_variables_regex
     $imaptalk->create("INBOX.target.Folder1");
     $imaptalk->create("INBOX.target.Folder2");
 
-    xlog $self, "Install a sieve script filing all mail into a nonexistant folder";
+    xlog $self, "Install a sieve script filing all mail into a nonexistent folder";
     $self->{instance}->install_sieve_script(<<EOF
 require ["fileinto", "variables", "regex"];
 set "folder" "target";

--- a/cunit/quota.testc
+++ b/cunit/quota.testc
@@ -428,7 +428,7 @@ static void test_update_useds(void)
     q.root = (char *) QUOTAROOT;
     memset(quota_diff, 0, sizeof(quota_diff));
 
-    /* updating a NULL or empty or non-existant root returns the error */
+    /* updating a NULL or empty or non-existent root returns the error */
     quota_diff[QUOTA_STORAGE] = 10*1024;
     quota_diff[QUOTA_MESSAGE] = 2;
     quota_diff[QUOTA_ANNOTSTORAGE] = 1*1024;

--- a/doc/README.twom.md
+++ b/doc/README.twom.md
@@ -6,7 +6,7 @@ skip over multiple records, approximating a binary search.  The lowest "level"
 linked list always visits every record in the database's sort order.
 
 The twom database format is a serialised representation of a skiplist data
-structure, repesenting an ordered list of key/value pairs in a single mmaped
+structure, representing an ordered list of key/value pairs in a single mmaped
 file.  Links between records are stored as offsets within the file.  When new
 records are added, the offsets on the previous records in the link are updated
 by overwriting their location in the file.
@@ -63,7 +63,7 @@ The header is packed directly into the first 96 bytes of the file.  All numbers 
 * Repack Size: 8 bytes - a 64 bit number which is the offset at which all the records were repacked in exactly the correct order.  After this point there may be replaces or deletes.
 * Current Size: 8 bytes - a 64 bit number which is the offset of the end of last commit which is persisted to disk.
 * Max Level: 4 bytes - a 32 bit number (though maximum value is 31) of the highest level of any record in the file other than the DUMMY record.
-* Checksum: 4 bytes - a 32 bit checksum over the preceeding 92 bytes.
+* Checksum: 4 bytes - a 32 bit checksum over the preceding 92 bytes.
 
 ### The Dummy Record
 
@@ -97,7 +97,7 @@ Structures named `twom_` are public, `tm_` are entirely internal.
     - If this is an exclusive transaction (not TWOM_SHARED) then you can write to the file and either abort or commit.  A transaction dirties the file on first write.  An exclusive transaction forces the file to remain locked exclusively for the duration of the transaction.
     - If this is read-only transaction, it can be either MVCC or not.  If it is MVCC, then it never changes file, it always reads from the same file, though it may still need to refresh the length if the lock has been released.  Read-only transactions can release the lock, either explicitly using `twom_db_yield` or implicitly every N transactions to avoid starving other database users.
     - Has a reference counted on the file into which it points, to ensure it isn’t released if this is an MVCC transaction.
-- `struct tm_loc` - a location in the database.  This contains an offset for the current record, the locations of the immediately preceeding record at every level, and the length of the file when it was calculated (a change in file length means that back pointers may have been changed and the location is no longer valid).  If the current record has a DELETE before it, will also contain a `deleted_offset` value.
+- `struct tm_loc` - a location in the database.  This contains an offset for the current record, the locations of the immediately preceding record at every level, and the length of the file when it was calculated (a change in file length means that back pointers may have been changed and the location is no longer valid).  If the current record has a DELETE before it, will also contain a `deleted_offset` value.
     - Has a reference counted on the file into which it points, which is required to allow relocation without having to copy the key content.
 - `struct tm_file` an mmaped file.  Has the file handle and tracks the lock on it.  Also has a parsed version of the header of the file, which is updated every time it’s locked.  (strictly this isn’t necessary, we could do it all with MMAP reads directly from the file).
     - Also contains pointers to the checksum and comparison functions for this file.  These CANNOT BE CHANGED after file creation, but can either use the ones built into twom, or you can pass external functions at file creation time.
@@ -111,7 +111,7 @@ Twom uses fcntl for locking, specifically a two-phase locking system, as describ
 Copying the key parts here:
 
 <blockquote>
-Assume that two arbitraty lock-files are already opened into descriptors fd_sh and fd_ex. Then to gain shared access:
+Assume that two arbitrary lock-files are already opened into descriptors fd_sh and fd_ex. Then to gain shared access:
 
     flock(fd_ex, LOCK_SH) - allow multiple readers to pass through this lock but block writers
     flock(fd_sh, LOCK_SH) - used to block activated writer while readers are working
@@ -143,7 +143,7 @@ We also have a third range lock which is held by any process doing a repack.  Ow
 
 ## Navigating the code - functions
 
-I’ll just describe the key functions, all the basic refcounting and low level pointer checking is pretty self explanitory, but:
+I’ll just describe the key functions, all the basic refcounting and low level pointer checking is pretty self explanatory, but:
 
 `_setloc`
 
@@ -161,7 +161,7 @@ It starts at the DUMMY record, and for every level from the highest down, walks 
 
 If it matches exactly, `offset` will be set to the record and `is_exactmatch` will be 1, otherwise `offset`  will be the record before the gap where it should be, and `is_exactmatch` will be zero.
 
-At the lowest level, it also tracks whether the current item was preceeded by a DELETE record and ancestor pair, and in that case also sets `deleted_offset` to the prior delete record.  This is only useful when `is_exactmatch` is true,
+At the lowest level, it also tracks whether the current item was preceded by a DELETE record and ancestor pair, and in that case also sets `deleted_offset` to the prior delete record.  This is only useful when `is_exactmatch` is true,
 which is suppresses returning the value and is used for some other checks.
 
 `relocate()`
@@ -202,7 +202,7 @@ Will run recovery if the file is DIRTY.
 
 The wimpier cousin of write_lock.  If the file is empty or dirty, it will try for a `write_lock` to fix it, or just error if the database is readonly.
 
-Still takes a writeable mmap unless the database was opened readonly, since that avoids having to unmap and remap later if the caller then takes a write_lock later.
+Still takes a writable mmap unless the database was opened readonly, since that avoids having to unmap and remap later if the caller then takes a write_lock later.
 
 `opendb()` 
 

--- a/doc/examples/cyrus_conf/normal-master.conf
+++ b/doc/examples/cyrus_conf/normal-master.conf
@@ -31,7 +31,7 @@ SERVICES {
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
   lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
-  # this is requied if using socketmap
+  # this is required if using socketmap
 #  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=0
 
   # this is required if using notifications

--- a/doc/examples/cyrus_conf/normal-replica.conf
+++ b/doc/examples/cyrus_conf/normal-replica.conf
@@ -26,7 +26,7 @@ SERVICES {
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
   lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
-  # this is requied if using socketmap
+  # this is required if using socketmap
 #  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=0
 
 	# Synchronization for remote replication.

--- a/doc/examples/cyrus_conf/normal.conf
+++ b/doc/examples/cyrus_conf/normal.conf
@@ -26,7 +26,7 @@ SERVICES {
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
   lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=0
 
-  # this is requied if using socketmap
+  # this is required if using socketmap
 #  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=0
 
   # this is required if using notifications

--- a/doc/examples/cyrus_conf/prefork.conf
+++ b/doc/examples/cyrus_conf/prefork.conf
@@ -26,7 +26,7 @@ SERVICES {
 #  lmtp          cmd="lmtpd" listen="lmtp" prefork=0
   lmtpunix      cmd="lmtpd" listen="/run/cyrus/socket/lmtp" prefork=1
 
-  # this is requied if using socketmap
+  # this is required if using socketmap
 #  smmap         cmd="smmapd" listen="/run/cyrus/socket/smmap" prefork=1
 
   # this is only necessary if using notifications

--- a/doc/legacy/ag.html
+++ b/doc/legacy/ag.html
@@ -194,7 +194,7 @@ correctly is (provided there is no interleaved DELETE in another session):
      A002 SELECT INBOX.new
 </pre></li>
 
-<li>Accesses to non-existant mailboxes are rare.</li>
+<li>Accesses to non-existent mailboxes are rare.</li>
 </ul>
 
 <h3>3.2 Authentication</h3>
@@ -353,7 +353,7 @@ recovery can activate the mailbox in mupdate instead)
 <p> Failure modes: Above, all back end inconsistencies result in the
 next CREATE attempt failing.  The earlier MUPDATE inconsistency results
 in any attempts to CREATE the mailbox on another back end failing.  The
-latter one makes the mailbox unreachable and un-createable.  Though, this
+latter one makes the mailbox unreachable and un-creatable.  Though, this
 is safer than potentially having the mailbox appear in two places when
 the failed backend comes back up.</p>
 

--- a/doc/legacy/install-murder.html
+++ b/doc/legacy/install-murder.html
@@ -210,7 +210,7 @@ authname as the configured in the <tt>proxyservers</tt> line in the backend's
 When you start master on the frontend, a local mailboxes database should
 automatically synchronize itself with the contents of the mupdate master,
 and you should be ready to go.  Your clients should connect to the frontends,
-and the frontends will proxy or refer as applicable to the blackend servers.<p>
+and the frontends will proxy or refer as applicable to the backend servers.<p>
 
 <h3>Additional backend configuration</h3>
 

--- a/doc/legacy/install-snmpmon.html
+++ b/doc/legacy/install-snmpmon.html
@@ -13,7 +13,7 @@
 get moved to the external CySNIIP docs and this will be stuff specific
         to the imapd.
 
-<p>Cyrus uses an auxillary process called "<tt>tugowar</tt>", so named
+<p>Cyrus uses an auxiliary process called "<tt>tugowar</tt>", so named
 because there's a push-pull model.  Various components of the Cyrus
 mail system push data to <tt>tugowar</tt>, and <tt>tugowar</tt>
 listens for SNMP queries (remote clients pull the data from

--- a/doc/legacy/overview.html
+++ b/doc/legacy/overview.html
@@ -761,7 +761,7 @@ server reboot.
 <p>Mail transport agents such as Sendmail, Postfix, or Exim communicate
 with the Cyrus server via LMTP (the Local Mail Transport Protocol)
 implemented by the LMTP daemon.  This can be done either directly by the
-MTA (prefered, for performance reasons) or via the <tt>deliver</tt> LMTP
+MTA (preferred, for performance reasons) or via the <tt>deliver</tt> LMTP
 client.
 
 <h3>Local Mail Transfer Protocol</h3><a name="lmtp"></a>

--- a/docsrc/concepts/overview_and_concepts.rst
+++ b/docsrc/concepts/overview_and_concepts.rst
@@ -565,7 +565,7 @@ Message Delivery
 Mail transport agents such as Sendmail, Postfix, or Exim communicate
 with the Cyrus server via LMTP (the Local Mail Transport Protocol)
 implemented by the LMTP daemon.  This can be done either directly by the
-MTA (prefered, for performance reasons) or via the ``deliver`` LMTP
+MTA (preferred, for performance reasons) or via the ``deliver`` LMTP
 client.
 
 Local Mail Transfer Protocol (lmtp)

--- a/docsrc/developer/API/index-api.rst
+++ b/docsrc/developer/API/index-api.rst
@@ -54,7 +54,7 @@ re-written.
 Also, memory is now cheap. Rather than using locks to ensure
 consistency, we just keep a copy of the ``struct index_record`` for even
 message in the index, stored in memory. Since these are about 100 bytes
-each, a 1 million email mailbox will take rougly 100Mb of memory. That's
+each, a 1 million email mailbox will take roughly 100Mb of memory. That's
 not too bad on a modern server, and that's a **huge** mailbox.
 
 So - the model works like this:

--- a/docsrc/developer/API/mailbox-api.rst
+++ b/docsrc/developer/API/mailbox-api.rst
@@ -13,7 +13,7 @@ Intro
 The Mailbox API is implemented in ``imap/mailbox.h`` and
 ``imap/mailbox.c``. It wraps the data structures of the
 ``cyrus.header``, ``cyrus.index`` and ``cyrus.cache`` files in a
-psuedo-object-oriented way, allowing easy changes to the mailbox while
+pseudo-object-oriented way, allowing easy changes to the mailbox while
 keeping the internal cached data structures consistent.
 
 Opening and closing
@@ -254,7 +254,7 @@ Committing
 ~~~~~~~~~~
 
 When you have finished making any changes, you need to "commit". This
-will write the updated values for any index header fields, rewite the
+will write the updated values for any index header fields, rewrite the
 ``cyrus.header`` file if needed and fsync all changes to disk.
 
 It is a fatal error to unlock (or close) a mailbox that has had changes

--- a/docsrc/developer/guidance/hacking.rst
+++ b/docsrc/developer/guidance/hacking.rst
@@ -367,7 +367,7 @@ out on the cyrus-devel list in June 2010.
 
 ..
 
-    Very occasionally, it may be permissable to use 'goto' from within
+    Very occasionally, it may be permissible to use 'goto' from within
     a complicated or multiply-nested loop, to the top of a loop, but
     only if using another control structure is *less* clear.
 

--- a/docsrc/developer/guidance/mailbox-format.rst
+++ b/docsrc/developer/guidance/mailbox-format.rst
@@ -259,7 +259,7 @@ The overall format looks sort of like this:
 The basic idea being that there is one header, and then all the message
 records are evenly spaced throughout the file. All of the message
 records are at well-known offsets, making any part of the file
-accessable at roughly equal speed.
+accessible at roughly equal speed.
 
 Locking Considerations
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -316,7 +316,7 @@ POP3 Last Login (4 bytes)
     (time\_t) of the last pop3 login to this INBOX, used to enforce the
     "poptimeout" ``imapd.conf`` option.
 UIDvalidity (4 bytes)
-    The UID validitiy of this mailbox. Cyrus currently uses the
+    The UID validity of this mailbox. Cyrus currently uses the
     ``time()`` when this mailbox was created.
 Deleted, Answered, and Flagged (4 bytes each)
     Counts of how many messages have each flag.
@@ -490,7 +490,7 @@ Future considerations
 -  Reformat cache file to use a
    (size)(size)(size)(size)(data)(data)(data) format. This makes
    accesses anywhere in the cache file equally fast, as opposed to
-   having to iterate through all the entires for a given message to get
+   having to iterate through all the entries for a given message to get
    to the last one. Note that either way is still O(1) so maybe it
    doesn't matter much.
 -  It would be useful to store a uniqueid -> mailbox name index, so that

--- a/docsrc/developer/releasing.rst
+++ b/docsrc/developer/releasing.rst
@@ -38,7 +38,7 @@ Release notes
 Write up the release notes, and add them to the appropriate location under
 ``docsrc/download/release-notes/``.  They will not yet be linked up.
 Build the documentation locally with ``make doc-html``, then check the new
-release notes file in your brower to make sure it's correct and complete.
+release notes file in your browser to make sure it's correct and complete.
 It will be in ``doc/html/download/release-notes/...``.
 
 Commit the new release notes with a message like ``docs: release notes for

--- a/docsrc/download/getcyrus.rst
+++ b/docsrc/download/getcyrus.rst
@@ -9,7 +9,7 @@ Where and how do you want to get Cyrus?
 Distribution Package
 ====================
 
-Cyrus IMAP packages are packaged by several Linux distrbution.
+Cyrus IMAP packages are packaged by several Linux distribution.
 
 * Debian provides a "cyrus-imapd" package
 * Fedora provides a "cyrus-imapd" package

--- a/docsrc/download/installation/http/caldav.rst
+++ b/docsrc/download/installation/http/caldav.rst
@@ -358,7 +358,7 @@ The TZID property can have a vendor prefix, that is fixed when compiling vzic by
 IMAP requires that the vendor prefix is the empty string.
 
 The `cyrus-timezones package <https://github.com/cyrusimap/cyrus-timezones>`_ provides
-a vzic, which sets TZID_PREFIX to the emtpy string.
+a vzic, which sets TZID_PREFIX to the empty string.
 
 The steps to populate the :imapdconf:`zoneinfo_dir` directory are:
 

--- a/docsrc/download/release-notes/1/1.x.x.rst
+++ b/docsrc/download/release-notes/1/1.x.x.rst
@@ -107,7 +107,7 @@ Changes to the Cyrus IMAP Server Since Version 1.5.19
 *   Fix brain fart in auth_krb_pts.c where a CLOSE() was done to a DB handle BEFORE we access the data read from the DB database. This means we were copying free'd memory into the groups list. Note this only affects people using DB, AFS and ptloader.
 *   Committed minor syslog log level changes in ptloader and deliver.
 *   make distclean now does what it's supposed to.
-*   Possibly misnamed experimental --enable-static-libraries switch that tries to do a good job of building binaries with whatever static libraries are availible. If you use this, you do so at your own risk, and if it fails, we will disavow all knowledge of you and your team. Good luck, Jim.
+*   Possibly misnamed experimental --enable-static-libraries switch that tries to do a good job of building binaries with whatever static libraries are available. If you use this, you do so at your own risk, and if it fails, we will disavow all knowledge of you and your team. Good luck, Jim.
 *   Add optional third argument to imtest for it to take input from a file. This is a gross hack.
 
 Changes to the Cyrus IMAP Server Since Version 1.5.14
@@ -127,12 +127,12 @@ Changes to the Cyrus IMAP Server Since Version 1.5.14
 *       Split out duplicate delivery elimination to multiple files. This should help reduce the lock contention that normally occurs with this file. To not clutter config_dir, the files will be located in a subdirectory named deliverdb, for example /var/imap/deliverdb. If you don't make this directory, nothing bad will happen (other than duplicate delivery elimination will not work).
 *       The time value is now stored as an integer in native byte order as opposed to converting it to a string before it is stored in the database.
 *       checkdelivered() now obtains a read lock instead of a write lock when trying to check for duplicates. Only markdelivered() grabs a write lock.
-*   Added logic to cause cyradm to abort more cleanly if not given command line arguments in an interactive session. This gets rid of the dreaded application-specific intialization failed messages.
+*   Added logic to cause cyradm to abort more cleanly if not given command line arguments in an interactive session. This gets rid of the dreaded application-specific initialization failed messages.
 
 Changes to the Cyrus IMAP Server Since Version 1.5.11
 
 *   The CREATE command now ignores a trailing hierarchy delimiter instead of ignoring the CREATE command.
-*   UIDPLUS is now always advertised in CAPABILITY and is always availible. The UIDPLUS extension is a set of optimizations using UID values instead of sequence numbers and is described in RFC 2359.
+*   UIDPLUS is now always advertised in CAPABILITY and is always available. The UIDPLUS extension is a set of optimizations using UID values instead of sequence numbers and is described in RFC 2359.
 *   Cyrus no longer rejects messages with 8-bit characters in the headers. Rather than reject the message, characters with the 8th bit set are changed to 'X'. Internationalization in headers is supported by the mechanism specified in RFC 2047 (and RFC 1342).
 
 Changes to the Cyrus IMAP Server Since Version 1.5.10
@@ -142,7 +142,7 @@ Changes to the Cyrus IMAP Server Since Version 1.5.10
 *   The checks for com_err in configure are a little smarter and look to see if all the pieces are there before trying to use them.
 *   Added support for the NAMESPACE extension (if --enable-experiment is supplied).
 *   Added a "reject8bit" switch to imapd.conf. If set to "true", messages containing 8-bit-set characters in the headers are rejected (the previous behavior); if set to "false" or left to the default value, messages containing 8-bit-set characters have these characters changed to a constant character ('X').
-*   Added the "fud" program. This is an interm hack designed to allow allow finger information to be retrieved for cyrus users. This is experimental and it is not recommend that services be built arround this feature, since it is likely to be removed in a future release of the IMAP server.
+*   Added the "fud" program. This is an interim hack designed to allow finger information to be retrieved for cyrus users. This is experimental and it is not recommend that services be built around this feature, since it is likely to be removed in a future release of the IMAP server.
 *   Bug fix: User defined flags now work properly.
 
 Changes to the Cyrus IMAP Server Since Version 1.5.2
@@ -180,7 +180,7 @@ Changes to the Cyrus IMAP Server Since Version 1.5
 *   Bug fix: imclient_authenticate now does resolution on the hostname before authenticating to it. This caused problems when authenticating to an address that was a CNAME.
 *   Bug fix: LIST %.% (and other multiple hierarchy delimiter matches) works properly. Several other glob.c fixes are included as well.
 *   Bug fix: a fetch of exclusively BODY[HEADER.FIELDS...] should now work properly.
-*   Bug fix: reconstruct now considers a nonexistant INN news directory to be empty; this makes reconstruct fix the cyrus.* files in the imap news partition.
+*   Bug fix: reconstruct now considers a nonexistent INN news directory to be empty; this makes reconstruct fix the cyrus.* files in the imap news partition.
 *   Added a manpage for imclient.
 *   Fixed a few other minor bugs.
 
@@ -255,7 +255,7 @@ Changes to the Cyrus IMAP Server Since Version 1.3
 *   Had to remove the declaration of tcl_RcFileName for the latest version of Tcl.
 *   Make much more extensive use of memory mapping. Replace the binary search module with one that searches a memory mapped area.
 *   Replaced the yacc-based RFC822 address parser with a hand-coded one.
-*   Replaced the et (error table) libary with a version that doesn't require lex or yacc. Remove the lex/yacc checking from Configure.
+*   Replaced the et (error table) library with a version that doesn't require lex or yacc. Remove the lex/yacc checking from Configure.
 *   Safety feature: most programs now refuse to run as root.
 *   Bug fix: Issue [TRYCREATE] tag on COPY command when appropriate.
 *   Bug fix: The quoted-printable decoder wasn't ignoring trailing whitespace, as required by MIME.

--- a/docsrc/download/release-notes/2.1/2.1.x.rst
+++ b/docsrc/download/release-notes/2.1/2.1.x.rst
@@ -65,7 +65,7 @@ Changes to the Cyrus IMAP Server since 2.1.10
 
 Changes to the Cyrus IMAP Server since 2.1.9
 
-*   support Berkley DB 4.1
+*   support Berkeley DB 4.1
 *   more portable use of errno throughout
 *   timsieved now does telemetry logging
 *   libcyrus.a no longer supplies fs_get() and fs_give()
@@ -112,7 +112,7 @@ Changes to the Cyrus IMAP Server since 2.1.4
 *   The RENAME command has been almost entirely rewritten. Now we rely on mailbox-level locking instead of locking the entire mailboxes file for the duration of the rename. ctl_cyrusdb -r now also cleans up "reserved" mailboxes that may appear in the event of a crash.
 *   ctl_mboxlist can now dump only a particular partition
 *   The configuration subsystem now uses a hash table to speed up lookups of options. Additionally, the hash table implementation has been updated to possibly take advantage of memory pools.
-*   Many bugfixes related to the Cyrus Murder. Includes improvments to subscription handling as well as correct merging of seen state on mailbox moves.
+*   Many bugfixes related to the Cyrus Murder. Includes improvements to subscription handling as well as correct merging of seen state on mailbox moves.
 *   Can now configure an external debugger (debug_command option in imapd.conf.
 *   Misc. autoconf-related fixes (most notably those related to sasl_checkapop and O_DSYNC).
 *   Misc. locking-related fixes.
@@ -125,7 +125,7 @@ Changes to the Cyrus IMAP Server since 2.1.3
 *   Some warning fixes.
 *   fdatasync() is no longer required.
 *   Fixed a bug in imap/append.c that would show itself if a message was being delivered to five or more different partitions.
-*   Deliveries now don't create a redudant temporary file using tmpfile(); the staging directory is used instead. (Ken Murchison)
+*   Deliveries now don't create a redundant temporary file using tmpfile(); the staging directory is used instead. (Ken Murchison)
 *   Fix a possible crashing bug in squatter. (Ken Murchison)
 *   Deleting a user now also removes their Sieve scripts.
 *   cyrusdb_skiplist: release locks during iteration. Should prevent denial of service attacks and possibly increase performance.

--- a/docsrc/download/release-notes/2.2/2.2.x.rst
+++ b/docsrc/download/release-notes/2.2/2.2.x.rst
@@ -5,7 +5,7 @@ Cyrus IMAP 2.2 Releases
 Changes to the Cyrus IMAP Server since 2.2.13
 
 *   ctl_mboxlist now dumps/undumps the mailbox type flags, making it useful for remote mailboxes.
-*   Added sieve_allowreferrals option to control whether timsieved issues referrals or proxys traffic to backends.
+*   Added sieve_allowreferrals option to control whether timsieved issues referrals or proxies traffic to backends.
 
 Changes to the Cyrus IMAP Server since 2.2.12
 
@@ -74,7 +74,7 @@ Changes to the Cyrus IMAP Server since 2.2.5
 *   Fix segfault in APPEND code
 *   Fix a bug with an interaction between sieve and unixhierarchysep
 *   Fix a file descriptor leak in the quotadb code
-*   Fix a triggered assertation in service-thread services
+*   Fix a triggered assertion in service-thread services
 *   Add a number of internal consistency checks to the skiplist code
 *   Allow mbpath to handle virtual domains
 *   Fix various MANAGESIEVE client authentication issues
@@ -102,7 +102,7 @@ Changes to the Cyrus IMAP Server since 2.2.3
 
 Changes to the Cyrus IMAP Server since 2.2.2
 
-*   Berkeley DB 4.2 Support - note that the Cyrus Berkeley enviroment needs to be reset (db_recover) before a Berkeley DB version upgrade or you need to remove all berkeley dbs. Special care needs to be taken when berkley db is used for mboxlist.
+*   Berkeley DB 4.2 Support - note that the Cyrus Berkeley environment needs to be reset (db_recover) before a Berkeley DB version upgrade or you need to remove all berkeley dbs. Special care needs to be taken when berkeley db is used for mboxlist.
 *   Runtime configuration of the Cyrus databases. The cyrudb backend used for each database can be specified with an imapd.conf option. NOTE: You MUST convert the database using cvt_cyrusdb BEFORE changing the backend in imapd.conf.
 *   Sendmail socket map support (smmapd) for verifying that mailboxes exist and are deliverable before accepting the message and sending it to Cyrus.
 *   New userid mode for virtual domains, which does NOT do reverse lookups of the IP address.
@@ -143,11 +143,11 @@ Changes to the Cyrus IMAP Server since 2.2.0
 
 Changes to the Cyrus IMAP Server since 2.1.x
 
-*   There have been extensive performance and consistency changes to the configuration subsystem. This will both ensure greater consistency between the documentation and the code, as well as a more standard format for specifing service-specific configuration options in imapd.conf. Important changes are detailed here:
+*   There have been extensive performance and consistency changes to the configuration subsystem. This will both ensure greater consistency between the documentation and the code, as well as a more standard format for specifying service-specific configuration options in imapd.conf. Important changes are detailed here:
 *       The tls_[service]_* configuration options have been removed. Now use [servicename]_tls_*, where servicename is the service identifier from cyrus.conf for that particular process.
 *       Administrative groups (e.g. admins and lmtp_admins) no longer union, service groups completely override the generic group.
 *       lmtp_allowplaintext is no longer a defined parameter and must be specified using the service name of your lmtp process if you require a specific value
-*   libcyrus has been split into libcyrus_min and libcyrus, so as to allow sensative applications (such as master) include the least amount of code necessary for operation
+*   libcyrus has been split into libcyrus_min and libcyrus, so as to allow sensitive applications (such as master) include the least amount of code necessary for operation
 *   Virtual domain support. See the virtual domains document for details.
 *   Users can now be renamed (even across domains). Note that this is not atomic and weirdness may occur if the user is logged in during the rename. See the allowusermoves option in imapd.conf(5) for details.
 *   The db3 and db3-nosync database backends have been renamed to berkeley and berkeley-nosync respectively (to avoid confusion over whether or not db4 is supported).

--- a/docsrc/download/release-notes/2.3/x/2.3.15.rst
+++ b/docsrc/download/release-notes/2.3/x/2.3.15.rst
@@ -7,7 +7,7 @@ Changes to the Cyrus IMAP Server since 2.3.14
 *   Fixed CERT VU#336053 - Potential buffer overflow in Sieve.
 *   Added new cyr_df tool for reporting Cyrus spool partition disk space usage.
 *   Fixed a crash when selecting a folder after using the SCAN command
-*   Split mupdate_synchronize() into network scarfing and mailbox comparision pieces. This allows us to not lock out the mailboxes.db and mupdate clients while scarfing the UPDATE response, which can be quite time consuming over slow links.
+*   Split mupdate_synchronize() into network scarfing and mailbox comparison pieces. This allows us to not lock out the mailboxes.db and mupdate clients while scarfing the UPDATE response, which can be quite time consuming over slow links.
 *   Added support for MUPDATE COMPRESS and IMAP COMPRESS commands which help speed up bulk data commands over slow links. Inspired by work of Dave Cridland <dave@cridland.net>
 *   Allow frontend servers in a Murder to proxy the CREATE, DELETE, SETACL, SETQUOTA, and GETQUOTA commands for toplevel mailboxes. In order for a frontend to know where to CREATE a toplevel mailbox, either the defaultserver option must be set (ALL new toplevel mailboxes are created on this particular server), or the serverlist option must be set (new toplevel mailboxes are created on whichever server has the most available spool space).
 *   Use delayed expunge in ipurge to avoid corrupting cache file and as a bonus make it unexpungable.

--- a/docsrc/download/release-notes/2.3/x/2.3.7.rst
+++ b/docsrc/download/release-notes/2.3/x/2.3.7.rst
@@ -8,7 +8,7 @@ Changes to the Cyrus IMAP Server since 2.3.6
 *   Fixed problems with newer cyrus.index files on 64-bit machines.
 *   Added '-p <ssf>' option to services so that PLAIN authentication can be used without TLS in secure environments.
 *   Added munge8bit to control whether unencoded 8-bit characters in headers are changed to 'X' or are left alone.
-*   Added sieve_allowreferrals option to control whether timsieved issues referrals or proxys traffic to backends.
+*   Added sieve_allowreferrals option to control whether timsieved issues referrals or proxies traffic to backends.
 *   Fixed miscellaneous bugs and build issues.
 
 :ref:`imap-release-notes-2.3`

--- a/docsrc/download/release-notes/2.4/x/2.4.3.rst
+++ b/docsrc/download/release-notes/2.4/x/2.4.3.rst
@@ -14,7 +14,7 @@ Changes to the Cyrus IMAP Server since 2.4.2
 *       allowing XFER back all the way to Cyrus 2.2.12. This was accomplished by adding logic that can generate backwards-compatible older version indexes, and version detection from the imapd banner.
 *       correctly fixing seen information for sub-mailboxes on XFER in
 *   Multi-target replication. Strictly this is a new feature - there was a broken implementation in 2.4.0, which is how this snuck in to the bugfix release. It's not super-well documented yet, but it works by creating a separate log file for each destination "channel", and then running one sync_client process per channel, so replication can fall behind on one without affecting replication to the other.
-*   Fixed some crashes and errors which occured when upgrading and opening corrupted mailboxes
+*   Fixed some crashes and errors which occurred when upgrading and opening corrupted mailboxes
 *   Modified AFS ptloader configure options to allow building on more modern systems
 
 :ref:`imap-release-notes-2.4`

--- a/docsrc/download/release-notes/2.4/x/2.4.4.rst
+++ b/docsrc/download/release-notes/2.4/x/2.4.4.rst
@@ -4,7 +4,7 @@ Cyrus IMAP 2.4.4 Release Notes
 
 Changes to the Cyrus IMAP Server since 2.4.3
 
-*   Rewrite index_upgrade to always parse the message files and re-create cyrus.cache, to avoid upgrade upgrade failures where cache errors occured.
+*   Rewrite index_upgrade to always parse the message files and re-create cyrus.cache, to avoid upgrade upgrade failures where cache errors occurred.
 *   Fixed sync_reset handling of user deletions
 *   Fixed proc file handling of LOGIN and folder unselect
 *   use cyrus.expunge file (if still present) to delete bogus records from a failed index upgrade (cause by bugs in earlier version)

--- a/docsrc/download/release-notes/2.4/x/2.4.7.rst
+++ b/docsrc/download/release-notes/2.4/x/2.4.7.rst
@@ -8,13 +8,13 @@ Changes to the Cyrus IMAP Server since 2.4.6
 *   Fixed Bug #3392 - allowing INBOX.INBOX to be created if the case didn't match
 *   Fixed Bug #3404 - incorrect LIST "" "user" response
 *   Fixed Bug #3417 - crash on zero-byte quota file
-*   Fixed numberous bugs with mailbox upgrades
+*   Fixed numerous bugs with mailbox upgrades
 *   Fixed replication errors, which have been reported many times on the mailing list, but don't have bug numbers.
-*   Increated "paranoia" about record ordering in mailbox, which would have detected some bad bugs in replication that caused the infinite runaway mailbox filling reported in 2.4.6 and below
+*   Increased "paranoia" about record ordering in mailbox, which would have detected some bad bugs in replication that caused the infinite runaway mailbox filling reported in 2.4.6 and below
 *   Increased syslogging detail about replication issues
 *   Fixed reconstruct crash with zero-byte index file
 *   Fixed cyradm perl library path finding
-*   Fixed incorrect use of LITERAL+ formats in our responses to clients. Unreported, but could be causing wierd hard-to-track-down bugs out there
+*   Fixed incorrect use of LITERAL+ formats in our responses to clients. Unreported, but could be causing weird hard-to-track-down bugs out there
 *   Fixed append immediately on create
 *   Upgraded Unicode database to version 6.0
 *   Fixed reconstruct crash on folder names with many digits (i.e. ebay auction numbers)

--- a/docsrc/download/release-notes/2.5/x/2.5.0.rst
+++ b/docsrc/download/release-notes/2.5/x/2.5.0.rst
@@ -176,7 +176,7 @@ to set message annotations.
 Event Notifications
 -------------------
 
-Various events occuring in Cyrus IMAP, among which mailbox, message and
+Various events occurring in Cyrus IMAP, among which mailbox, message and
 access events, can now be pushed out through a side-channel and notify
 client applications or provide other infrastructure with detailed
 information.
@@ -247,7 +247,7 @@ Catchall Mailbox for LMTP
 
 Thanks to the work by Carsten Hoeger and Ralf Haferkamp, this new
 feature enables administrators to configure a target mailbox for mail
-delivered through LMTP to targetted mailboxes that do not exist.
+delivered through LMTP to targeted mailboxes that do not exist.
 
 For example, a mail that LMTP would deliver to ``user/bovik``, which
 for the sake of argument does not exist in this example, setting
@@ -265,7 +265,7 @@ Does this impact lmtp_fuzzy_mailbox_match?
 ++++++++++++++++++++++++++++++++++++++++++
 
 Environments that have ``lmtp_fuzzy_mailbox_match`` enabled, in order
-to have LMTP seek from the targetted, non-existent mailbox sub-folder
+to have LMTP seek from the targeted, non-existent mailbox sub-folder
 (example: ``user/bovik/spam/probably``) all the way to the toplevel
 mailbox folder (i.e. ``user/bovik``) until it finds a mailbox
 (sub-)folder that does exist (example: ``user/bovik/spam``), are not
@@ -397,7 +397,7 @@ The default for the :cyrusman:`imapd.conf(5)` configuration option
 ``delete_mode`` has changed from ``immediate`` to ``delayed``.
 
 This causes mail folders that are deleted by a client to not
-immediately dissappear from the filesystem. Instead, they are renamed
+immediately disappear from the filesystem. Instead, they are renamed
 to a deleted namespace that is visible only to administrators.
 
 A separate job ``cyr_expire -D $x`` is to be included in the master

--- a/docsrc/download/release-notes/3.13/x/3.13.1.rst
+++ b/docsrc/download/release-notes/3.13/x/3.13.1.rst
@@ -24,7 +24,7 @@ Major changes since the 3.12 series
 * The annotator is now called only on items added to email-type mailboxes.
 * ``ctl_conversationsdb`` now has ``-U`` for version upgrades.
 * ``lmtpd`` now provides a capability called ``TRACE`` and a new ``TRACE``
-  command for setting an interal trace-id, which will be logged.
+  command for setting an internal trace-id, which will be logged.
 * The ``admins_get_internal_seen`` :cyrusman:`imapd.conf(5)` option has been
   added.  If set, the admin users will always get and set the same ``\Seen``
   flags as the mailbox owner.

--- a/docsrc/download/release-notes/3.13/x/3.13.2.rst
+++ b/docsrc/download/release-notes/3.13/x/3.13.2.rst
@@ -24,7 +24,7 @@ Major changes since the 3.12 series
 * The annotator is now called only on items added to email-type mailboxes.
 * ``ctl_conversationsdb`` now has ``-U`` for version upgrades.
 * ``lmtpd`` now provides a capability called ``TRACE`` and a new ``TRACE``
-  command for setting an interal trace-id, which will be logged.
+  command for setting an internal trace-id, which will be logged.
 * The ``admins_get_internal_seen`` :cyrusman:`imapd.conf(5)` option has been
   added.  If set, the admin users will always get and set the same ``\Seen``
   flags as the mailbox owner.

--- a/docsrc/download/release-notes/3.13/x/3.13.3.rst
+++ b/docsrc/download/release-notes/3.13/x/3.13.3.rst
@@ -24,7 +24,7 @@ Major changes since the 3.12 series
 * The annotator is now called only on items added to email-type mailboxes.
 * ``ctl_conversationsdb`` now has ``-U`` for version upgrades.
 * ``lmtpd`` now provides a capability called ``TRACE`` and a new ``TRACE``
-  command for setting an interal trace-id, which will be logged.
+  command for setting an internal trace-id, which will be logged.
 * The ``admins_get_internal_seen`` :cyrusman:`imapd.conf(5)` option has been
   added.  If set, the admin users will always get and set the same ``\Seen``
   flags as the mailbox owner.

--- a/docsrc/download/release-notes/3.13/x/3.13.4.rst
+++ b/docsrc/download/release-notes/3.13/x/3.13.4.rst
@@ -24,7 +24,7 @@ Major changes since the 3.12 series
 * The annotator is now called only on items added to email-type mailboxes.
 * :cyrusman:`ctl_conversationsdb(8)` now has ``-U`` for version upgrades.
 * :cyrusman:`lmtpd(8)` now provides a capability called ``TRACE`` and a new
-  ``TRACE`` command for setting an interal trace-id, which will be logged.
+  ``TRACE`` command for setting an internal trace-id, which will be logged.
 * The :imapdconf:`admins_get_internal_seen` option has been added.  If set, the
   admin users will always get and set the same ``\Seen`` flags as the mailbox
   owner.

--- a/docsrc/download/release-notes/3.6/x/3.6.0-beta1.rst
+++ b/docsrc/download/release-notes/3.6/x/3.6.0-beta1.rst
@@ -18,7 +18,7 @@ Major changes since the 3.4 series
   mailboxes.  In other words, when creating mailbox user.foo.A.B.C, both
   user.foo.A and user.foo.A.B will also be created as real mailboxes.
 * XFER will no longer move individual mailboxes that would leave unselectable
-  mailboxes behind in the user heirarchy.
+  mailboxes behind in the user hierarchy.
 * Update IMAP PREVIEW extension from
   :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`

--- a/docsrc/download/release-notes/3.6/x/3.6.0-beta2.rst
+++ b/docsrc/download/release-notes/3.6/x/3.6.0-beta2.rst
@@ -18,7 +18,7 @@ Major changes since the 3.4 series
   mailboxes.  In other words, when creating mailbox user.foo.A.B.C, both
   user.foo.A and user.foo.A.B will also be created as real mailboxes.
 * XFER will no longer move individual mailboxes that would leave unselectable
-  mailboxes behind in the user heirarchy.
+  mailboxes behind in the user hierarchy.
 * Update IMAP PREVIEW extension from
   :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`

--- a/docsrc/download/release-notes/3.6/x/3.6.0-beta3.rst
+++ b/docsrc/download/release-notes/3.6/x/3.6.0-beta3.rst
@@ -18,7 +18,7 @@ Major changes since the 3.4 series
   mailboxes.  In other words, when creating mailbox user.foo.A.B.C, both
   user.foo.A and user.foo.A.B will also be created as real mailboxes.
 * XFER will no longer move individual mailboxes that would leave unselectable
-  mailboxes behind in the user heirarchy.
+  mailboxes behind in the user hierarchy.
 * Update IMAP PREVIEW extension from
   :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`

--- a/docsrc/download/release-notes/3.6/x/3.6.0-rc1.rst
+++ b/docsrc/download/release-notes/3.6/x/3.6.0-rc1.rst
@@ -18,7 +18,7 @@ Major changes since the 3.4 series
   mailboxes.  In other words, when creating mailbox user.foo.A.B.C, both
   user.foo.A and user.foo.A.B will also be created as real mailboxes.
 * XFER will no longer move individual mailboxes that would leave unselectable
-  mailboxes behind in the user heirarchy.
+  mailboxes behind in the user hierarchy.
 * Update IMAP PREVIEW extension from
   :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`

--- a/docsrc/download/release-notes/3.6/x/3.6.0-rc2.rst
+++ b/docsrc/download/release-notes/3.6/x/3.6.0-rc2.rst
@@ -18,7 +18,7 @@ Major changes since the 3.4 series
   mailboxes.  In other words, when creating mailbox user.foo.A.B.C, both
   user.foo.A and user.foo.A.B will also be created as real mailboxes.
 * XFER will no longer move individual mailboxes that would leave unselectable
-  mailboxes behind in the user heirarchy.
+  mailboxes behind in the user hierarchy.
 * Update IMAP PREVIEW extension from
   :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * JMAP Blob handling updated to :draft:`draft-ietf-jmap-blob-04`

--- a/docsrc/download/release-notes/3.6/x/3.6.0.rst
+++ b/docsrc/download/release-notes/3.6/x/3.6.0.rst
@@ -18,7 +18,7 @@ Major changes since the 3.4 series
   mailboxes.  In other words, when creating mailbox user.foo.A.B.C, both
   user.foo.A and user.foo.A.B will also be created as real mailboxes.
 * XFER will no longer move individual mailboxes that would leave unselectable
-  mailboxes behind in the user heirarchy.
+  mailboxes behind in the user hierarchy.
 * Update IMAP PREVIEW extension from
   :draft:`draft-ietf-extra-imap-fetch-preview-07` to :rfc:`8970`.
 * Update IMAP SAVEDATE extension from

--- a/docsrc/download/release-notes/index.rst
+++ b/docsrc/download/release-notes/index.rst
@@ -34,7 +34,7 @@ Series 3.14
 
     3.13/index
 
-Supported Verions
+Supported Versions
 -----------------
 
 The latest stable version is |imap_stable_release_notes|.  Its documentation

--- a/docsrc/download/release-notes/index.rst
+++ b/docsrc/download/release-notes/index.rst
@@ -35,7 +35,7 @@ Series 3.14
     3.13/index
 
 Supported Versions
------------------
+------------------
 
 The latest stable version is |imap_stable_release_notes|.  Its documentation
 can be found at :cyrus-stable:`/`.

--- a/docsrc/reference/admin/locations.rst
+++ b/docsrc/reference/admin/locations.rst
@@ -102,7 +102,7 @@ Metadata Partitions
 -------------------
 
 Metadata is information used to process the mailbox data, rather than
-the contents of the messages withing the mailbox.  Examples include
+the contents of the messages within the mailbox.  Examples include
 headers, caches, indexes, etc.
 
     * :imapdconf:`metapartition-name`

--- a/docsrc/reference/admin/murder/murder-concepts.rst
+++ b/docsrc/reference/admin/murder/murder-concepts.rst
@@ -344,7 +344,7 @@ Operations on the Mailbox List
     next CREATE attempt failing. The earlier MUPDATE inconsistency
     results in any attempts to CREATE the mailbox on another backend
     failing. The latter one makes the mailbox unreachable and
-    un-createable. Though, this is safer than potentially having the
+    un-creatable. Though, this is safer than potentially having the
     mailbox appear in two places when the failed backend comes back
     up.
 

--- a/docsrc/reference/admin/murder/murder-mupdate-details.rst
+++ b/docsrc/reference/admin/murder/murder-mupdate-details.rst
@@ -88,7 +88,7 @@ The second line of the initial response begins with ``* AUTH`` and is followed b
 Commands
 ========
 
-The following are the valid commands that a client may send to the MUPDATE server: AUTHENTICATE, ACTIVATE, DELETE, FIND, LIST, LOGOUT, NOOP, RESERVE, and UPDATE. Only AUTHENTICATE and LOGOUT may be issued before a successful authentication has occured. Only LOGOUT and NOOP may be issued after UPDATE has been successfully issued. Only one successful AUTHENTICATE command may be issued per session.
+The following are the valid commands that a client may send to the MUPDATE server: AUTHENTICATE, ACTIVATE, DELETE, FIND, LIST, LOGOUT, NOOP, RESERVE, and UPDATE. Only AUTHENTICATE and LOGOUT may be issued before a successful authentication has occurred. Only LOGOUT and NOOP may be issued after UPDATE has been successfully issued. Only one successful AUTHENTICATE command may be issued per session.
 
 AUTHENTICATE
 ------------
@@ -109,7 +109,7 @@ The ACTIVATE command takes three parameters:
     2. a location in ``server!partition`` format, 
     3. and an ACL for the mailbox.
 
-It will tell the server to insert into its database the given mailbox in the given location with the given ACL. An OK response indicates success, a NO response indicates some sort of failure occured. This is not a valid command to issue to a slave.
+It will tell the server to insert into its database the given mailbox in the given location with the given ACL. An OK response indicates success, a NO response indicates some sort of failure occurred. This is not a valid command to issue to a slave.
 
 DELETE
 ------

--- a/docsrc/reference/admin/sop/replication.rst
+++ b/docsrc/reference/admin/sop/replication.rst
@@ -281,7 +281,7 @@ Terminating Rolling Replication
 
 To be able to stop rolling replication at any time, configure the
 ``sync_shutdown_file`` option in :cyrusman:`imapd.conf(5)` to point to
-a non-existant file, the appearance of this file will trigger a
+a nonexistent file, the appearance of this file will trigger a
 shutdown of a :cyrusman:`sync_client(8)` instance::
 
     sync_shutdown_file: /var/lib/imap/syncstop

--- a/docsrc/reference/faqs/o-unable-join-environment.rst
+++ b/docsrc/reference/faqs/o-unable-join-environment.rst
@@ -1,7 +1,7 @@
 "unable to join environment" error
 ----------------------------------
 
-This error is caused if you build Berkley DB 4 with threading support, 
+This error is caused if you build Berkeley DB 4 with threading support,
 but do not then link the pthreads library to Cyrus. This is commonly 
 caused by a Linux distribution which supplies the pre-threaded library 
 version. 

--- a/docsrc/reference/manpages/systemcommands/reconstruct.rst
+++ b/docsrc/reference/manpages/systemcommands/reconstruct.rst
@@ -71,7 +71,7 @@ Options
 
 .. option:: -p partition, --partition=partition
 
-    Search for the listed (non-existant) mailboxes on the indicated
+    Search for the listed (nonexistent) mailboxes on the indicated
     *partition*. Create the mailboxes in the database in addition to
     reconstructing them. (not compatible with the use of wildcards)
 

--- a/imap/userdeny_db.c
+++ b/imap/userdeny_db.c
@@ -221,7 +221,7 @@ out:
 /*
  * Remove a deny DB record; this has the effect of allowing the given
  * user access to all services.  Returns an IMAP error code or 0 on
- * success.  It is not an error to remove a non-existant record.
+ * success.  It is not an error to remove a non-existent record.
  */
 EXPORTED int denydb_delete(const char *user)
 {

--- a/lib/cyrusdb.h
+++ b/lib/cyrusdb.h
@@ -31,7 +31,7 @@ enum cyrusdb_initflags {
 };
 
 enum cyrusdb_openflags {
-    CYRUSDB_CREATE    = 0x01,    /* Create the database if not existant */
+    CYRUSDB_CREATE    = 0x01,    /* Create the database if not existent */
     CYRUSDB_NOSYNC    = 0x02,    /* durability not a concern */
     CYRUSDB_CONVERT   = 0x04,    /* Convert to the named format if not already */
     CYRUSDB_NOCOMPACT = 0x08,    /* Don't run any database compaction routines */

--- a/lib/twom.h
+++ b/lib/twom.h
@@ -41,7 +41,7 @@ enum twom_ret {
 // we don't reuse flags for different operations (e.g. open, fetch, foreach), as
 // there's 32 bits of space available - though not all flags have meaning in all contexts.
 enum twom_flagspec {
-    TWOM_CREATE          = 1<<0,    /* Create the database if not existant */
+    TWOM_CREATE          = 1<<0,    /* Create the database if not existent */
     TWOM_SHARED          = 1<<1,    /* Open in shared lock mode */
     TWOM_NOCSUM          = 1<<2,    /* Don't check checksums on read */
     TWOM_NOSYNC          = 1<<3,    /* Don't msync/fsync on write */

--- a/master/README
+++ b/master/README
@@ -17,7 +17,7 @@ SERVICES {
   lmtp          cmd="lmtpd" listen="lmtp" prefork=0
 #  lmtpunix     cmd="lmtpd" listen="/lmtp" prefork=0
 
-  # this is requied if using socketmap
+  # this is required if using socketmap
 #  smmap        cmd="smmapd" listen="/smmap" prefork=0
 
   # this is only necessary if using notifications


### PR DESCRIPTION
The typos were identified using the `typos` CLI tool and were reviewed individually.