### PR TITLE
docsrc/conf.py: make the left sidebar expand less

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -193,8 +193,14 @@ html_context = {
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {}
-
+html_theme_options = {
+    # Keep the sidebar from feeling infinitely deep: cap nesting at two levels
+    # and stop pulling in-page section headings into the nav.
+    "navigation_depth": 2,
+    "titles_only": True,
+    "collapse_navigation": True,
+    "sticky_navigation": True,
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ["exts/themes"]


### PR DESCRIPTION
I often feel lost in the doc site, in part because it has *so much* navigation "help".  Rather than give me a deep, deep drilldown to every little subheading -- progressively disclosed so that I can't build up a place memory -- just stick to two levels.  A rebuild made the site feel much, much friendlier.

Lots of information architecture work left to do after this, though.