### PR TITLE
jmap: report shareWith invalidProperty with the actual sharee id

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_unknown_calendarright
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_unknown_calendarright
@@ -8,14 +8,14 @@ sub test_calendar_set_unknown_calendarright
     my $jmap = $self->default_user->jmap;
     my $default_cal_id = $self->default_user->calendars->default->id;
 
-    $self->create_user('sharee');
+    $self->create_user('calshare');
 
     my $res = $jmap->CallMethods([
         ['Calendar/set', {
             update => {
                 $default_cal_id => {
                     shareWith => {
-                        sharee => {
+                        calshare => {
                             unknownCalendarRight => JSON::true,
                         },
                     },
@@ -27,6 +27,6 @@ sub test_calendar_set_unknown_calendarright
     $self->assert_str_equals('invalidProperties',
         $res->[0][1]{notUpdated}{$default_cal_id}{type});
 
-    $self->assert_deep_equals(['shareWith/sharee/unknownCalendarRight'],
+    $self->assert_deep_equals(['shareWith/calshare/unknownCalendarRight'],
         $res->[0][1]{notUpdated}{$default_cal_id}{properties});
 }

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_unknown_addressbookright
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_unknown_addressbookright
@@ -16,7 +16,7 @@ sub test_addressbook_set_unknown_addressbookright
             update => {
                 $id => {
                     shareWith => {
-                        sharee => {
+                        abooksharer => {
                             unknownAddressBookRight => JSON::true,
                         },
                     },
@@ -28,6 +28,6 @@ sub test_addressbook_set_unknown_addressbookright
     $self->assert_str_equals('invalidProperties',
         $res->[0][1]{notUpdated}{$id}{type});
 
-    $self->assert_deep_equals(['shareWith/sharee/unknownAddressBookRight'],
+    $self->assert_deep_equals(['shareWith/abooksharer/unknownAddressBookRight'],
         $res->[0][1]{notUpdated}{$id}{properties});
 }

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1477,7 +1477,7 @@ static void setcalendar_parseprops(jmap_req_t *req,
                              strcmp(right, "mayDelete"))) {
 
                         jmap_parser_push(parser, "shareWith");
-                        jmap_parser_push(parser, "sharee");
+                        jmap_parser_push(parser, sharee);
                         jmap_parser_invalid(parser, right);
                         jmap_parser_pop(parser);
                         jmap_parser_pop(parser);

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -2145,7 +2145,7 @@ static void setaddressbook_readprops(jmap_req_t *req,
                              strcmp(right, "mayDelete"))) {
 
                         jmap_parser_push(parser, "shareWith");
-                        jmap_parser_push(parser, "sharee");
+                        jmap_parser_push(parser, sharee);
                         jmap_parser_invalid(parser, right);
                         jmap_parser_pop(parser);
                         jmap_parser_pop(parser);


### PR DESCRIPTION
Calendar/set and AddressBook/set were pushing the literal string "sharee" onto the invalidProperty path when rejecting an unknown right, producing e.g. "shareWith/sharee/mayBogus" regardless of which sharee the client named.  Use the sharee variable, matching what Mailbox/set already does.

Amusingly the tests didn't catch it (if we agree it was a mistake) because the sharing user was named "sharee" -- same as the literal string we were using!