### PR TITLE
two small changes: libxml NONET and null check in tz parsing

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3794,7 +3794,8 @@ int parse_xml_body(struct transaction_t *txn, xmlNodePtr *root,
     /* Parse the XML request */
     doc = xmlCtxtReadMemory(txn->conn->xml, buf_cstring(&txn->req_body.payload),
                             buf_len(&txn->req_body.payload), NULL, NULL,
-                            XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+                            XML_PARSE_NOERROR | XML_PARSE_NOWARNING |
+                            XML_PARSE_NONET);
     if (!doc) {
         txn->error.desc = "Unable to parse XML body";
         return HTTP_BAD_REQUEST;

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -73,7 +73,7 @@ static xmlDocPtr to_xml(const struct buf *buf)
     ctxt = xmlNewParserCtxt();
     if (ctxt) {
         doc = xmlCtxtReadMemory(ctxt, buf_base(buf), buf_len(buf), NULL, NULL,
-                                XML_PARSE_NOWARNING);
+                                XML_PARSE_NOWARNING | XML_PARSE_NONET);
         xmlFreeParserCtxt(ctxt);
     }
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -10146,7 +10146,7 @@ static json_t *sharenotif_tojmap(jmap_req_t *req, message_t *msg, hash_table *pr
         xmlParserCtxtPtr ctxt = xmlNewParserCtxt();
         if (ctxt) {
             doc = xmlCtxtReadMemory(ctxt, buf_base(&buf), buf_len(&buf),
-                    NULL, NULL, XML_PARSE_NOWARNING);
+                    NULL, NULL, XML_PARSE_NOWARNING | XML_PARSE_NONET);
             xmlFreeParserCtxt(ctxt);
         }
         buf_reset(&buf);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -813,14 +813,24 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
             if (buf_len(&attrib)) {
                 icalcomponent *ical, *vtz;
                 icalproperty *tzid;
+                const char *tzidstr = NULL;
 
                 ical = icalparser_parse_string(buf_cstring(&attrib));
-                vtz = icalcomponent_get_first_component(ical,
-                                                        ICAL_VTIMEZONE_COMPONENT);
-                tzid = icalcomponent_get_first_property(vtz, ICAL_TZID_PROPERTY);
+                /* The annotation is normally validated on PROPPATCH, but it
+                 * can also be written via SETMETADATA, which bypasses that
+                 * check.  Defensively guard each step. */
+                if (ical) {
+                    vtz = icalcomponent_get_first_component(ical,
+                                                            ICAL_VTIMEZONE_COMPONENT);
+                    if (vtz) {
+                        tzid = icalcomponent_get_first_property(vtz,
+                                                                ICAL_TZID_PROPERTY);
+                        if (tzid) tzidstr = icalproperty_get_tzid(tzid);
+                    }
+                }
                 json_object_set_new(obj, "timeZone",
-                                    json_string(icalproperty_get_tzid(tzid)));
-                icalcomponent_free(ical);
+                                    tzidstr ? json_string(tzidstr) : json_null());
+                if (ical) icalcomponent_free(ical);
             }
             else {
                 json_object_set_new(obj, "timeZone", json_null());

--- a/imap/vcard_support.c
+++ b/imap/vcard_support.c
@@ -83,7 +83,8 @@ static size_t _prop_decode_value(const char *data,
         if (!*content_type) {
             xmlDocPtr doc = xmlReadMemory(decbuf, size, NULL, NULL,
                                           XML_PARSE_NOERROR |
-                                          XML_PARSE_NOWARNING);
+                                          XML_PARSE_NOWARNING |
+                                          XML_PARSE_NONET);
             if (doc) {
                 xmlNodePtr root = xmlDocGetRootElement(doc);
                 if (!xmlStrcmp(root->name, BAD_CAST "svg")) {

--- a/imap/xcal.c
+++ b/imap/xcal.c
@@ -1053,7 +1053,7 @@ icalcomponent *xcal_string_as_icalcomponent(const struct buf *buf)
     ctxt = xmlNewParserCtxt();
     if (ctxt) {
         doc = xmlCtxtReadMemory(ctxt, buf_base(buf), buf_len(buf), NULL, NULL,
-                                XML_PARSE_NOWARNING);
+                                XML_PARSE_NOWARNING | XML_PARSE_NONET);
         xmlFreeParserCtxt(ctxt);
     }
     if (!doc) {


### PR DESCRIPTION
This is two small, unrelated changes that came in the same report.  Neither is risky, they both just mitigate some risk if circumstances change elsewhere in the code or world.