### PR TITLE
set SASL-IR parameter per backend

### DIFF
--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -42,10 +42,9 @@ static void proxy_part_filldata(partlist_t *part_list, int idx);
 
 static void imap_postcapability(struct backend *s)
 {
-    if (CAPA(s, CAPA_SASL_IR)) {
-        /* server supports initial response in AUTHENTICATE command */
-        s->prot->u.std.sasl_cmd.maxlen = USHRT_MAX;
-    }
+    /* server supports initial response in AUTHENTICATE command
+       keep this per-backend: avoid leaking SASL-IR capability across hosts. */
+    s->prot->u.std.sasl_cmd.maxlen = CAPA(s, CAPA_SASL_IR) ? USHRT_MAX : 0;
 }
 
 static void imap_postauth(struct backend *s)

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -198,10 +198,9 @@ static char *imap_sasl_parsesuccess(char *str, const char **status)
 
 static void imap_postcapability(struct backend *s)
 {
-    if (CAPA(s, CAPA_SASL_IR)) {
-        /* server supports initial response in AUTHENTICATE command */
-        s->prot->u.std.sasl_cmd.maxlen = USHRT_MAX;
-    }
+    /* server supports initial response in AUTHENTICATE command
+       keep this per-backend: avoid leaking SASL-IR capability across hosts. */
+    s->prot->u.std.sasl_cmd.maxlen = CAPA(s, CAPA_SASL_IR) ? USHRT_MAX : 0;
 }
 
 static const char *_synclock_name(const char *hostname, const char *userid)


### PR DESCRIPTION
This fixes #6004

To fix this I went with the minimal approach of just changing the if to a ternary that will clear the paramater if the capability is no longer present.

I would like to also suggest a more robust fix thats not so minimal:
```
diff --git a/imap/backend.c b/imap/backend.c
index 846ac184d6..a0bcbd0b0e 100644
--- a/imap/backend.c
+++ b/imap/backend.c
@@ -690,6 +690,10 @@ static int backend_authenticate(struct backend *s, const char *userid,
         }
 
         if (mechlist) {
+            /* server supports initial response in AUTHENTICATE command
+               keep this per-backend: avoid leaking SASL-IR capability across hosts. */
+            s->prot->u.std.sasl_cmd.maxlen = CAPA(s, CAPA_SASL_IR) ? USHRT_MAX : 0;
+
             /* we now do the actual SASL exchange */
             saslclient(s->saslconn, &prot->u.std.sasl_cmd, mechlist,
                        s->in, s->out, &r, status);
```
this is executed during the authentication flow right before the SASL exchange and will remove any conventions that require `ask_capability` to be called before an authentication. After this change the postcapability  callback can also be removed from the protocol struct.

If you like the second approach more I'd be happy to change it.