### PR TITLE
userdeny: provide detailed error message for clients

### DIFF
--- a/cassandane/tiny-tests/Deny/basic
+++ b/cassandane/tiny-tests/Deny/basic
@@ -5,27 +5,33 @@ sub test_basic ($self)
 {
     xlog $self, "Test the cyr_deny utility with the imap service";
 
+    # Matches userdeny_db.c default_message when cyr_deny omits -m
+    my $default_deny_message = 'Access to this service has been blocked';
+
     # Data thanks to hipsteripsum.me
     my @cases = ({
             # test default options
             user => 'helvetica',
             opts => [ ],
             can_login => 0,
+            expect_deny_message => $default_deny_message,
         },{
             # test the -s option with our service
             user => 'portland',
             opts => [ '-s', 'imap' ],
             can_login => 0,
+            expect_deny_message => $default_deny_message,
         },{
             # test the -s option with another service
             user => 'stumptown',
             opts => [ '-s', 'godard' ],
             can_login => 1,
         },{
-            # test the -m option
+            # test the -m option (client-visible deny text)
             user => 'mustache',
             opts => [ '-m', 'Bugger off, you' ],
             can_login => 0,
+            expect_deny_message => 'Bugger off, you',
         },{
             # control case - no cyr_deny command run
             user => 'vegan',
@@ -65,7 +71,10 @@ sub test_basic ($self)
             xlog $self, "Expecting this to fail";
             eval { $store->get_client(); };
             my $exception = $@;
-            $self->assert_matches(qr/no - login failed: authorization failure/i, $exception);
+            my $expect = $case->{expect_deny_message};
+            $self->assert_not_null($expect);
+            $self->assert_matches(qr/login failed:/i, $exception);
+            $self->assert_matches(qr/\Q$expect\E/i, $exception);
         }
     }
 }

--- a/imap/backend.c
+++ b/imap/backend.c
@@ -760,7 +760,7 @@ static int backend_login(struct backend *ret, const char *userid,
 
         if ((r = backend_authenticate(ret, userid, cb, &my_status))) {
             syslog(LOG_ERR, "couldn't authenticate to backend server: %s",
-                   sasl_errstring(r, NULL, NULL));
+                   cyrus_sasl_errmsg(ret->saslconn, r, /*for_client*/0));
             free(old_mechlist);
             return -1;
         }

--- a/imap/global.c
+++ b/imap/global.c
@@ -663,6 +663,34 @@ static int acl_ok(const char *userid, struct auth_state *authstate)
     return r;
 }
 
+/*
+ * Return a SASL error message appropriate for the caller.
+ *
+ * For clients: SASL_NOUSER is remapped to SASL_BADAUTH to avoid leaking user
+ * existence. For SASL_DISABLED (userdeny), sasl_errdetail() is returned so the
+ * admin-supplied deny message reaches the client. All other client errors fall
+ * back to sasl_errstring().
+ *
+ * For operators/logging: sasl_errdetail() is preferred (includes plugin and
+ * callback text, e.g. user deny from user_deny.db set via sasl_seterror());
+ * falls back to sasl_errstring() if errdetail is empty.
+ */
+EXPORTED const char *cyrus_sasl_errmsg(sasl_conn_t *conn, int sasl_err_code, int for_client)
+{
+    /* Hide user existence from clients */
+    if (for_client && sasl_err_code == SASL_NOUSER)
+        sasl_err_code = SASL_BADAUTH;
+
+    /* Operators always get detail; clients only for SASL_DISABLED (userdeny) */
+    if (!for_client || sasl_err_code == SASL_DISABLED) {
+        const char *errstr = sasl_errdetail(conn);
+        if (errstr && *errstr) return errstr;
+    }
+
+    /* Otherwise use the generic error string */
+    return sasl_errstring(sasl_err_code, NULL, NULL);
+}
+
 /* should we allow users to proxy?  return SASL_OK if yes,
    SASL_BADAUTH otherwise */
 EXPORTED int mysasl_proxy_policy(sasl_conn_t *conn,
@@ -675,6 +703,7 @@ EXPORTED int mysasl_proxy_policy(sasl_conn_t *conn,
 {
     struct proxy_context *ctx = (struct proxy_context *) context;
     const char *val = config_getstring(IMAPOPT_LOGINREALMS);
+    char denymsg[4096];
     struct auth_state *authstate;
     int userisadmin = 0;
     char *realm;
@@ -718,16 +747,14 @@ EXPORTED int mysasl_proxy_policy(sasl_conn_t *conn,
     }
 
     /* is requested_user denied access?  authenticated admins are exempt */
-    if (!userisadmin && userdeny(requested_user, config_ident, NULL, 0)) {
-        syslog(LOG_ERR, "user '%s' denied access to service '%s'",
-               requested_user, config_ident);
-        sasl_seterror(conn, SASL_NOLOG,
-                      "user '%s' is denied access to service '%s'",
-                      requested_user, config_ident);
+    if (!userisadmin && userdeny(requested_user, config_ident, denymsg, sizeof(denymsg))) {
+        syslog(LOG_ERR, "user '%s' denied access to service '%s': %s",
+               requested_user, config_ident, denymsg);
+        sasl_seterror(conn, SASL_NOLOG, "%s", denymsg);
 
         auth_freestate(authstate);
 
-        return SASL_NOAUTHZ;
+        return SASL_DISABLED;
     }
 
     if (alen != rlen || strncmp(auth_identity, requested_user, alen)) {

--- a/imap/global.h
+++ b/imap/global.h
@@ -73,6 +73,10 @@ extern int mysasl_proxy_policy(sasl_conn_t *conn,
                                unsigned urlen __attribute__((unused)),
                                struct propctx *propctx __attribute__((unused)));
 
+/* Prefer SASL connection detail (includes sasl_seterror text, e.g. user_deny.db
+ * message from mysasl_proxy_policy); else generic catalog string for error code */
+extern const char *cyrus_sasl_errmsg(sasl_conn_t *conn, int sasl_err_code, int for_client);
+
 /* check if `authstate' is a valid member of class */
 extern int global_authisa(struct auth_state *authstate,
                           enum imapopt opt);

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -17,6 +17,7 @@
 
 #include "httpd.h"
 #include "http_proxy.h"
+#include "global.h"
 #include "http_ws.h"
 #include "iptostring.h"
 #include "mupdate-client.h"
@@ -440,7 +441,8 @@ static int login(struct backend *s, const char *userid,
     free(sid);
     if (hdrs) spool_free_hdrcache(hdrs);
 
-    if (r && status && !*status) *status = sasl_errstring(r, NULL, NULL);
+    if (r && status && !*status)
+        *status = cyrus_sasl_errmsg(s->saslconn, r, /*for_client*/1);
 
     return r;
 }

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -1449,9 +1449,11 @@ static int client_need_auth(struct transaction_t *txn, int sasl_result)
         /* Tell client to authenticate */
         if (sasl_result == SASL_CONTINUE)
             txn->error.desc = "Continue authentication exchange";
-        else if (sasl_result) txn->error.desc = "Authentication failed";
-        else txn->error.desc =
-                 "Must authenticate to access the specified target";
+        else if (sasl_result && !txn->error.desc)
+            txn->error.desc = "Authentication failed";
+        else if (!sasl_result && !txn->error.desc)
+            txn->error.desc =
+                "Must authenticate to access the specified target";
 
         return HTTP_UNAUTHORIZED;
     }
@@ -1687,6 +1689,13 @@ static int auth_check_hdrs(struct transaction_t *txn, int *sasl_result)
             r = http_auth(hdr[0], txn);
             if ((r < 0) || !txn->auth_chal.scheme) {
                 /* Auth failed - reinitialize */
+                const char *emsg = cyrus_sasl_errmsg(httpd_saslconn, r, /*for_client*/1);
+
+                if (emsg && *emsg) {
+                    buf_reset(&txn->buf);
+                    buf_appendcstr(&txn->buf, emsg);
+                    txn->error.desc = buf_cstring(&txn->buf);
+                }
                 syslog(LOG_DEBUG, "auth failed - reinit");
                 reset_saslconn(&httpd_saslconn);
                 txn->auth_chal.scheme = NULL;
@@ -1746,6 +1755,13 @@ static int auth_check_hdrs(struct transaction_t *txn, int *sasl_result)
         r = proxy_authz(&authzid, txn);
         if (r) {
             /* Proxy authz failed - reinitialize */
+            const char *emsg = cyrus_sasl_errmsg(httpd_saslconn, r, /*for_client*/1);
+
+            if (emsg && *emsg) {
+                buf_reset(&txn->buf);
+                buf_appendcstr(&txn->buf, emsg);
+                txn->error.desc = buf_cstring(&txn->buf);
+            }
             syslog(LOG_DEBUG, "proxy authz failed - reinit");
             reset_saslconn(&httpd_saslconn);
             txn->auth_chal.scheme = NULL;
@@ -3993,7 +4009,7 @@ static int proxy_authz(const char **authzid, struct transaction_t *txn)
     if (status) {
         loginlog_bad(txn->conn->clienthost, httpd_authid, NULL,
                      txn->auth_chal.scheme->name,
-                     sasl_errdetail(httpd_saslconn));
+                     cyrus_sasl_errmsg(httpd_saslconn, status, /*for_client*/0));
         return status;
     }
 
@@ -4280,7 +4296,7 @@ static int http_auth(const char *creds, struct transaction_t *txn)
             if (*user == '\0')  // TB can send "Authorization: Basic Og=="
                 txn->error.desc = "All-whitespace username.";
             loginlog_bad(txn->conn->clienthost, realuser, NULL, "Basic",
-                         sasl_errdetail(httpd_saslconn));
+                         cyrus_sasl_errmsg(httpd_saslconn, status, /*for_client*/0));
             free(realuser);
 
             /* Don't allow user probing */
@@ -4344,7 +4360,7 @@ static int http_auth(const char *creds, struct transaction_t *txn)
         /* Failure - probably bad client response */
         if ((status != SASL_OK) && (status != SASL_CONTINUE)) {
             syslog(LOG_ERR, "SASL failed: %s",
-                   sasl_errstring(status, NULL, NULL));
+                   cyrus_sasl_errmsg(httpd_saslconn, status, /*for_client*/0));
             return status;
         }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3111,17 +3111,14 @@ static void cmd_login(char *tag, char *user)
                                  passwd,
                                  strlen(passwd))) != SASL_OK) {
         loginlog_bad(imapd_clienthost, canon_user, "plaintext", NULL,
-                     sasl_errdetail(imapd_saslconn));
+                     cyrus_sasl_errmsg(imapd_saslconn, r, /*for_client*/0));
 
         failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
 
-        /* Don't allow user probing */
-        if (r == SASL_NOUSER) r = SASL_BADAUTH;
-
-        if ((reply = sasl_errstring(r, NULL, NULL)) != NULL) {
+        if ((reply = cyrus_sasl_errmsg(imapd_saslconn, r, /*for_client*/1)) != NULL) {
             prot_printf(imapd_out, "%s NO Login failed: %s\r\n", tag, reply);
         } else {
             prot_printf(imapd_out, "%s NO Login failed: %d\r\n", tag, r);
@@ -3135,7 +3132,7 @@ static void cmd_login(char *tag, char *user)
         r = sasl_getprop(imapd_saslconn, SASL_USERNAME, &val);
 
         if(r != SASL_OK) {
-            if ((reply = sasl_errstring(r, NULL, NULL)) != NULL) {
+            if ((reply = cyrus_sasl_errmsg(imapd_saslconn, r, /*for_client*/1)) != NULL) {
                 prot_printf(imapd_out, "%s NO Login failed: %s\r\n",
                             tag, reply);
             } else {
@@ -3221,7 +3218,7 @@ static void cmd_authenticate(char *tag, char *authtype, char *resp)
                 sasl_getprop(imapd_saslconn, SASL_USERNAME, (const void **) &userid);
 
             loginlog_bad(imapd_clienthost, userid, authtype, NULL,
-                         sasl_errdetail(imapd_saslconn));
+                         cyrus_sasl_errmsg(imapd_saslconn, sasl_result, /*for_client*/0));
 
             prometheus_increment(CYRUS_IMAP_AUTHENTICATE_TOTAL_RESULT_NO);
             failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
@@ -3229,10 +3226,7 @@ static void cmd_authenticate(char *tag, char *authtype, char *resp)
                 sleep(failedloginpause);
             }
 
-            /* Don't allow user probing */
-            if (sasl_result == SASL_NOUSER) sasl_result = SASL_BADAUTH;
-
-            errorstring = sasl_errstring(sasl_result, NULL, NULL);
+            errorstring = cyrus_sasl_errmsg(imapd_saslconn, sasl_result, /*for_client*/1);
             if (errorstring) {
                 prot_printf(imapd_out, "%s NO %s\r\n", tag, errorstring);
             } else {

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -1063,14 +1063,12 @@ void lmtpmode(struct lmtp_func *func,
                           }
 
                           loginlog_bad(cd.clienthost, userid, mech, NULL,
-                                       sasl_errdetail(cd.conn));
+                                       cyrus_sasl_errmsg(cd.conn, r, /*for_client*/0));
 
                           prometheus_increment(CYRUS_IMAP_AUTHENTICATE_TOTAL_RESULT_NO);
 
                           prot_printf(pout, "501 5.5.4 %s\r\n",
-                                      sasl_errstring((r == SASL_NOUSER ?
-                                                      SASL_BADAUTH : r),
-                                                     NULL, NULL));
+                                      cyrus_sasl_errmsg(cd.conn, r, /*for_client*/1));
                       }
                   }
 

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1464,11 +1464,10 @@ static void cmd_authenticate(struct conn *C,
                 sasl_getprop(C->saslconn, SASL_USERNAME, (const void **) &userid);
 
             loginlog_bad(C->clienthost, userid, mech, NULL,
-                         sasl_errdetail(C->saslconn));
+                         cyrus_sasl_errmsg(C->saslconn, r, /*for_client*/0));
 
             prot_printf(C->pout, "%s NO \"%s\"\r\n", tag,
-                        sasl_errstring((r == SASL_NOUSER ? SASL_BADAUTH : r),
-                                       NULL, NULL));
+                        cyrus_sasl_errmsg(C->saslconn, r, /*for_client*/1));
         }
 
         reset_saslconn(C);

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -1934,6 +1934,7 @@ static void cmd_authinfo_pass(char *pass)
 {
     int failedloginpause;
     int r;
+    int auth_rc;
 
     /* Conceal password in telemetry log */
     if (nntp_logfd != -1 && pass) {
@@ -1967,18 +1968,21 @@ static void cmd_authinfo_pass(char *pass)
             return;
         }
     }
-    else if (sasl_checkpass(nntp_saslconn,
+    else if ((auth_rc = sasl_checkpass(nntp_saslconn,
                             nntp_userid,
                             strlen(nntp_userid),
                             pass,
-                            strlen(pass))!=SASL_OK) {
+                            strlen(pass)))!=SASL_OK) {
+        const char *reply;
+
         loginlog_bad(nntp_clienthost, nntp_userid, "plaintext", NULL,
-                     sasl_errdetail(nntp_saslconn));
+                     cyrus_sasl_errmsg(nntp_saslconn, auth_rc, /*for_client*/0));
         failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
-        prot_printf(nntp_out, "481 Invalid login\r\n");
+        reply = cyrus_sasl_errmsg(nntp_saslconn, auth_rc, /*for_client*/1);
+        prot_printf(nntp_out, "481 %s\r\n", reply ? reply : "Invalid login");
         free(nntp_userid);
         nntp_userid = 0;
 
@@ -2113,17 +2117,14 @@ static void cmd_authinfo_sasl(char *cmd, char *mech, char *resp)
                 sasl_getprop(nntp_saslconn, SASL_USERNAME, (const void **) &userid);
 
             loginlog_bad(nntp_clienthost, userid, mech, NULL,
-                         sasl_errdetail(nntp_saslconn));
+                         cyrus_sasl_errmsg(nntp_saslconn, sasl_result, /*for_client*/0));
 
             failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {
                 sleep(failedloginpause);
             }
 
-            /* Don't allow user probing */
-            if (sasl_result == SASL_NOUSER) sasl_result = SASL_BADAUTH;
-
-            errorstring = sasl_errstring(sasl_result, NULL, NULL);
+            errorstring = cyrus_sasl_errmsg(nntp_saslconn, sasl_result, /*for_client*/1);
             if (errorstring) {
                 prot_printf(nntp_out, "%d %s\r\n", code, errorstring);
             } else {

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -1211,18 +1211,15 @@ static void cmd_apop(char *response)
          * XXX could parse it out, or it might be available from sasl_getprop
          */
         loginlog_bad(popd_clienthost, NULL, NULL, NULL,
-                     sasl_errdetail(popd_saslconn));
+                     cyrus_sasl_errmsg(popd_saslconn, sasl_result, /*for_client*/0));
 
         failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
 
-        /* Don't allow user probing */
-        if (sasl_result == SASL_NOUSER) sasl_result = SASL_BADAUTH;
-
         prot_printf(popd_out, "-ERR [AUTH] authenticating: %s\r\n",
-                    sasl_errstring(sasl_result, NULL, NULL));
+                    cyrus_sasl_errmsg(popd_saslconn, sasl_result, /*for_client*/1));
 
         free(popd_subfolder);
         popd_subfolder = NULL;
@@ -1298,6 +1295,7 @@ static void cmd_user(char *user)
 static void cmd_pass(char *pass)
 {
     int failedloginpause;
+    int pr;
 
     if (!popd_userid) {
         prot_printf(popd_out, "-ERR [AUTH] Must give USER command\r\n");
@@ -1316,20 +1314,24 @@ static void cmd_pass(char *pass)
             return;
         }
     }
-    else if (SASL_OK != sasl_checkpass(popd_saslconn,
+    else if ((pr = sasl_checkpass(popd_saslconn,
                                        popd_userid,
                                        strlen(popd_userid),
                                        pass,
-                                       strlen(pass)))
+                                       strlen(pass))) != SASL_OK)
     {
+        const char *reply;
+
         loginlog_bad(popd_clienthost, popd_userid, "plaintext", NULL,
-                     sasl_errdetail(popd_saslconn));
+                     cyrus_sasl_errmsg(popd_saslconn, pr, /*for_client*/0));
 
         failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
         if (failedloginpause != 0) {
             sleep(failedloginpause);
         }
-        prot_printf(popd_out, "-ERR [AUTH] Invalid login\r\n");
+        reply = cyrus_sasl_errmsg(popd_saslconn, pr, /*for_client*/1);
+        prot_printf(popd_out, "-ERR [AUTH] %s\r\n",
+                    reply ? reply : "Invalid login");
         free(popd_userid);
         popd_userid = NULL;
         free(popd_subfolder);
@@ -1520,18 +1522,15 @@ static void cmd_auth(char *arg)
             }
 
             loginlog_bad(popd_clienthost, userid, authtype, NULL,
-                         sasl_errstring(sasl_result, NULL, NULL));
+                         cyrus_sasl_errmsg(popd_saslconn, sasl_result, /*for_client*/0));
 
             failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {
                 sleep(failedloginpause);
             }
 
-            /* Don't allow user probing */
-            if (sasl_result == SASL_NOUSER) sasl_result = SASL_BADAUTH;
-
             prot_printf(popd_out, "-ERR [AUTH] authenticating: %s\r\n",
-                        sasl_errstring(sasl_result, NULL, NULL));
+                        cyrus_sasl_errmsg(popd_saslconn, sasl_result, /*for_client*/1));
         }
 
         free(popd_subfolder);

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -701,13 +701,13 @@ static void cmd_authenticate(char *mech, char *resp)
             break;
         default:
             /* failed authentication */
-            errorstring = sasl_errstring(sasl_result, NULL, NULL);
+            errorstring = cyrus_sasl_errmsg(sync_saslconn, sasl_result, /*for_client*/1);
 
             if (r != SASL_NOUSER)
                 sasl_getprop(sync_saslconn, SASL_USERNAME, (const void **) &userid);
 
             loginlog_bad(sync_clienthost, userid, mech, NULL,
-                         sasl_errdetail(sync_saslconn));
+                         cyrus_sasl_errmsg(sync_saslconn, sasl_result, /*for_client*/0));
 
             failedloginpause = config_getduration(IMAPOPT_FAILEDLOGINPAUSE);
             if (failedloginpause != 0) {

--- a/imap/userdeny_db.c
+++ b/imap/userdeny_db.c
@@ -141,7 +141,15 @@ EXPORTED int userdeny(const char *user, const char *service, char *msgbuf, size_
         if (wildmat(service, pat)) {
             /* match ==> we're done */
             ret = !not;
-            if (msgbuf) strlcpy(msgbuf, msg, bufsiz);
+            if (msgbuf) {
+                char *p;
+                strlcpy(msgbuf, msg, bufsiz);
+                /* Replace control characters (incl. CR/LF/TAB) with spaces so
+                   the message is safe to embed in line-based protocol responses */
+                for (p = msgbuf; *p; p++) {
+                    if ((unsigned char)*p < 0x20) *p = ' ';
+                }
+            }
             break;
         }
     }

--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -725,10 +725,7 @@ static int cmd_authenticate(struct protstream *sieved_out,
 
   if (sasl_result!=SASL_OK)
   {
-      /* convert to user error code */
-      if(sasl_result == SASL_NOUSER)
-          sasl_result = SASL_BADAUTH;
-      *errmsg = (const char *) sasl_errstring(sasl_result,NULL,NULL);
+      *errmsg = cyrus_sasl_errmsg(sieved_saslconn, sasl_result, /*for_client*/1);
       loginlog_bad(sieved_clienthost, NULL, mech, NULL, *errmsg);
       goto reset;
   }
@@ -739,7 +736,7 @@ static int cmd_authenticate(struct protstream *sieved_out,
   {
     *errmsg = "Internal SASL error";
     syslog(LOG_ERR, "SASL: sasl_getprop SASL_USERNAME: %s",
-           sasl_errstring(sasl_result, NULL, NULL));
+           cyrus_sasl_errmsg(sieved_saslconn, sasl_result, /*for_client*/0));
     goto reset;
   }
   username = xstrdup((const char *) canon_user);
@@ -777,7 +774,7 @@ static int cmd_authenticate(struct protstream *sieved_out,
                   if (sasl_result!=SASL_OK) {
                       *errmsg = "Internal SASL error";
                       syslog(LOG_ERR, "SASL: sasl_getprop SASL_AUTHUSER: %s",
-                             sasl_errstring(sasl_result, NULL, NULL));
+                             cyrus_sasl_errmsg(sieved_saslconn, sasl_result, /*for_client*/0));
                       goto reset;
                   }
                   authname = xstrdup((const char *) canon_user);


### PR DESCRIPTION
This fixes #6006 

Make the per-user deny message configured via `cyr_deny -m` actually reach the client, as the `cyr_deny(8)` man page already promises. Previously every service threw the message away and emitted a generic SASL error string.

The fix centralises client-facing SASL error formatting in a single helper used by all services, switches userdeny rejections to the semantically correct SASL code, and sanitises the admin-supplied message before it hits the protocol stream.

What has been implemented:

1. New global helper `cyrus_sasl_errmsg()` (imap/global.c, imap/global.h).

   All services previously open-coded the same pattern:

       if (sasl_result == SASL_NOUSER) sasl_result = SASL_BADAUTH;
       errstr = sasl_errstring(sasl_result, NULL, NULL);

   This silently dropped the per-connection detail set via `sasl_seterror()`, which is exactly where the userdeny text lives.
   The new helper:

   * Takes a `sasl_conn_t *`, the SASL result code, and a `for_client` flag.
   * For operator/log output (`for_client == 0`) it prefers `sasl_errdetail()` (plugin + callback text), falling back to `sasl_errstring()`.
   * For client output (`for_client == 1`) it returns the generic `sasl_errstring()` so we do not leak plugin internals or hints about user existence **except** for `SASL_DISABLED`, where it returns `sasl_errdetail()` so the admin-supplied userdeny reason is delivered.
   * Remaps `SASL_NOUSER` to `SASL_BADAUTH` for clients in one place instead of in every caller, preserving the existing anti-user-probing behaviour.

   Every service (imapd, pop3d, nntpd, lmtpd, timsieved, sync_server, mupdate, httpd, the backend proxy login path) now routes its SASL error strings through this helper. The per-service "don't allow user probing" code has been removed since the helper handles it.

2. Return `SASL_DISABLED` from `mysasl_proxy_policy()` on userdeny (imap/global.c).

   The previous return value `SASL_NOAUTHZ` ("authorization failure") misrepresents the situation: the credentials are valid and the identity is authenticated, but the account is administratively disabled. `SASL_DISABLED` ("account disabled") is the correct code per the cyrus-sasl headers, and it is what the new `cyrus_sasl_errmsg()` uses as the trigger to forward the detail string to the client. Operators can also distinguish "wrong proxy authz" from "user is denied" in logs by the error code alone.

   The call to `userdeny()` is updated to pass a real buffer (`char denymsg[4096]`) so the database message is retrieved, logged alongside the syslog line, and then handed to `sasl_seterror()`.

   This also serves as a way to distinguish userdeny error details from any other sasl failure. I've checked the current cyrus-sasl implementation and I don't see any other usage of this error code so the assumption that SASL_DISABLED will have a userdeny message in the error buffer seems appropriate. I don't know if this will be a problem with other third party plugins that store sensitive  information in the error buffer while returning SASL_DISABLED so I'd like your opinion on this.

3. Sanitise the deny message in `userdeny()` (imap/userdeny_db.c).

   The deny string is admin-supplied but is interpolated into line-based protocol responses (IMAP/POP3/NNTP/LMTP/SIEVE/sync_server/mupdate). Embedded CR/LF/TAB or other C0 control bytes would corrupt the protocol stream or, worse, inject responses. `userdeny()` now replaces any byte `< 0x20` with a space before returning, so the value is safe to embed without each caller having to remember to sanitise.

4. httpd special handling (imap/httpd.c, imap/http_proxy.c).

   HTTP doesn't surface SASL errors directly; the helper is wired into `auth_check_hdrs()` and `client_need_auth()` so that a `SASL_DISABLED` result produces the deny message in `txn->error.desc`, which is then emitted in the response body / WWW-Authenticate error description.

Why a single helper? Before this change, eight services each had a  slightly different copy of "map NOUSER, then sasl_errstring()".  Any future tweak to client-facing SASL error handling had to be made in eight places, and the userdeny regression was effectively eight bugs in parallel. With `cyrus_sasl_errmsg()` the policy lives in one function and the call sites collapse to a single line.

Some considerations:
* I did try to put this helper into the most appropriate places but I might have missed a few or misplaced it. Any comments are welcome to fix this.
* Instead of using the sasl error buffer perhaps its more appropriate to add a new buffer in global.c for these specific perpose to isolate the userdeny cases and not rely on the uniqueness of the error code.