### PR TITLE
EmailSubmission/set: report a dropped submission connection serverFail

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
@@ -29,6 +29,7 @@ sub new
                  conversations_counted_flags => "\\Draft \\Flagged \$IsMailingList \$IsNotification \$HasAttachment",
                  event_groups => 'mailbox message flags calendar applepushservice jmap',
                  jmapsubmission_deleteonsend => 'no',
+                 jmap_nonstandard_extensions => 'yes',
                  httpmodules => 'carddav caldav jmap',
                  httpallowcompress => 'no');
 

--- a/cassandane/Cassandane/Net/SMTPServer.pm
+++ b/cassandane/Cassandane/Net/SMTPServer.pm
@@ -31,8 +31,22 @@ sub override {
     my $stage = shift;
     if ($Self->{server}{control_file} and -e $Self->{server}{control_file}) {
         my $data = decode_json(slurp_file($Self->{server}{control_file}));
-        if ($data->{$stage}) {
-            $Self->send_client_resp(@{$data->{$stage}});
+        if (my $resp = $data->{$stage}) {
+            # A "drop" directive simulates the peer vanishing mid-conversation
+            # (e.g. our sendmail wrapper dying), so the client sees EOF/broken
+            # pipe rather than a reply.
+            if (@$resp && $resp->[0] eq 'drop') {
+                $Self->mylog("SMTP: dropping connection at stage '$stage'");
+                my $client = $Self->{server}{client};
+                $client->close() if $client;
+                close(STDIN);
+                close(STDOUT);
+
+                # Exit this prefork child so the connection is fully torn down;
+                # the parent forks a replacement.
+                exit(0);
+            }
+            $Self->send_client_resp(@$resp);
             return 1;
         }
     }

--- a/cassandane/tiny-tests/JMAPEmailSubmission/emailsubmission_set_smtp_drop
+++ b/cassandane/tiny-tests/JMAPEmailSubmission/emailsubmission_set_smtp_drop
@@ -1,0 +1,43 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_emailsubmission_set_smtp_drop ($self)
+{
+    my $jmap = $self->{jmap};
+
+    my $res = $jmap->CallMethods( [ [ 'Identity/get', {}, "R1" ] ] );
+    my $identityid = $res->[0][1]->{list}[0]->{id};
+    $self->assert_not_null($identityid);
+
+    my $email = $self->default_user->mailboxes->inbox->new_email;
+
+    # The submission server accepts the envelope and the DATA go-ahead (354),
+    # then vanishes before replying.  Cyrus must report this as a transport
+    # failure, not parrot the stale 354 reply text back as a forbiddenToSend
+    # refusal.
+    $self->{instance}->set_smtpd({ end_data => ['drop'] });
+
+    xlog $self, "create email submission against a server that drops mid-DATA";
+    $res = $jmap->CallMethods( [ [ 'EmailSubmission/set', {
+        create => {
+            '1' => {
+                identityId => $identityid,
+                emailId  => $email->id,
+                envelope => {
+                    mailFrom =>  { email => 'from@localhost'   },
+                    rcptTo   => [{ email => 'rcpt1@localhost'  }],
+                },
+            }
+       }
+    }, "R1" ] ] );
+
+    my $err = $res->[0][1]->{notCreated}{1};
+    $self->assert_not_null($err);
+
+    xlog $self, "a dropped connection is a server failure, not a send refusal";
+    $self->assert_str_equals("serverFail", $err->{type});
+
+    xlog $self, "no events were added to the alarmdb";
+    my $alarmdata = $self->{instance}->getalarmdb();
+    $self->assert_num_equals(0, scalar @$alarmdata);
+}

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -859,6 +859,13 @@ static void _emailsubmission_create(jmap_req_t *req,
             break;
         }
 
+        case IMAP_IOERROR:
+            /* Transport failure talking to the submission server (e.g. the
+             * sendmail wrapper died mid-DATA). There is no SMTP reply
+             * describing this, and sm->resp may hold a stale reply.  Fall
+             * through to server error. */
+            break;
+
         default:
             *set_err = json_pack("{s:s s:s}", "type", "forbiddenToSend",
                                  "description", desc ? desc : error_message(r));

--- a/imap/smtpclient.c
+++ b/imap/smtpclient.c
@@ -276,6 +276,11 @@ static int smtpclient_read(smtpclient_t *sm, smtp_readcb_t *cb, void *rock)
     do {
         /* Read next reply line. */
         if (!prot_fgets(buf, 513, sm->backend->in)) {
+            /* No reply was read, so the previously-parsed response (e.g. the
+             * 354 go-ahead to DATA) is not a reply to this command; clear it
+             * so callers don't misreport it as the result. */
+            memset(sm->resp.code, 0, sizeof(sm->resp.code));
+            buf_reset(&sm->resp.text);
             r = IMAP_IOERROR;
             return r;
         }


### PR DESCRIPTION
When the submission server vanished mid-DATA smtpclient returned IMAP_IOERROR.  Then the default error handler in EmailSubmission creation fired, reporting this as forbiddenToSend.  Weirder still, it provided the *previous* command's response as the error, because there was no response to this command, so the response variable was stale.

1. clear the sm->resp.code on failed read
2. on IOERROR, skip the forbiddenToSend default so we end up with a serverError
3. add a test for this

The test uses test entities, which means we need nonstandard JMAP capabilities present in the Cassandane instance.  I think this will be fine.

It also means giving our fake SMTP server the ability to hang up on demand.  Useful here, probably will be useful elsewhere!