### PR TITLE
various: fix issues found by running cassandane under valgrind

### DIFF
--- a/cassandane/vg.supp
+++ b/cassandane/vg.supp
@@ -104,3 +104,19 @@
   ...
 }
 
+{
+   # shush leaked SASL internal state
+   # XXX this might be a real leak, but if so a fix is not immediately clear
+   sasl_client_add_plugin
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:xmalloc
+   obj:*
+   obj:*
+   fun:sasl_client_add_plugin
+   obj:/usr/lib/x86_64-linux-gnu/libsasl2.so.*
+   fun:sasl_client_init
+   fun:global_sasl_init
+   ...
+}

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8815,7 +8815,10 @@ static void cmd_getacl(const char *tag, const char *name)
     char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
 
     r = mlookup(tag, name, intname, &mbentry);
-    if (r == IMAP_MAILBOX_MOVED) return;
+    if (r == IMAP_MAILBOX_MOVED) {
+        free(intname);
+        return;
+    }
 
     if (!r) {
         access = cyrus_acl_myrights(imapd_authstate, mbentry->acl);
@@ -8909,7 +8912,10 @@ static void cmd_listrights(char *tag, char *name, char *identifier)
 
     char *intname = mboxname_from_external(name, &imapd_namespace, imapd_userid);
     r = mlookup(tag, name, intname, &mbentry);
-    if (r == IMAP_MAILBOX_MOVED) return;
+    if (r == IMAP_MAILBOX_MOVED) {
+        free(intname);
+        return;
+    }
 
     if (!r) {
         rights = cyrus_acl_myrights(imapd_authstate, mbentry->acl);
@@ -8926,6 +8932,8 @@ static void cmd_listrights(char *tag, char *name, char *identifier)
 
     if (r) {
         prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
+
+        free(intname);
         return;
     }
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -14503,6 +14503,7 @@ static void cmd_genurlauth(char *tag)
         if (c == IMAP_LITERAL_TOO_LARGE) {
             prot_printf(imapd_out, "%s NO %s in Genurlauth\r\n",
                         tag, error_message(c));
+            mboxkey_close(mboxkey_db);
             return;
         }
         if (c != ' ') {
@@ -14510,6 +14511,7 @@ static void cmd_genurlauth(char *tag)
                         "%s BAD Missing required argument to Genurlauth\r\n",
                         tag);
             eatline(imapd_in, c);
+            mboxkey_close(mboxkey_db);
             return;
         }
         c = getword(imapd_in, &arg2);
@@ -14518,6 +14520,7 @@ static void cmd_genurlauth(char *tag)
                         "%s BAD Unknown auth mechanism to Genurlauth %s\r\n",
                         tag, arg2.s);
             eatline(imapd_in, c);
+            mboxkey_close(mboxkey_db);
             return;
         }
 
@@ -14550,6 +14553,7 @@ static void cmd_genurlauth(char *tag)
             eatline(imapd_in, c);
             free(url.freeme);
             free(intname);
+            mboxkey_close(mboxkey_db);
             return;
         }
 
@@ -14590,6 +14594,7 @@ static void cmd_genurlauth(char *tag)
                         r == IMAP_BADURL ? error_message(r) : cyrusdb_strerror(r));
             free(url.freeme);
             free(intname);
+            mboxkey_close(mboxkey_db);
             return;
         }
 

--- a/imap/index.c
+++ b/imap/index.c
@@ -922,6 +922,9 @@ seqset_t *index_vanished(struct index_state *state,
     seqset_t *seq;
 
     /* check uidvalidity match */
+    /* XXX Seems like uidvalidity_is_max never gets set to anything but zero.
+     * XXX What was its purpose?  Can we get rid of it?
+     */
     if (params->uidvalidity_is_max) {
         if (params->uidvalidity < mailbox->i.uidvalidity) return NULL;
     }
@@ -1231,7 +1234,7 @@ EXPORTED int index_fetch(struct index_state *state,
     }
 
     if (fetchargs->vanished) {
-        struct vanished_params v;
+        struct vanished_params v = {0};
         v.sequence = sequence;
         v.uidvalidity = state->mailbox->i.uidvalidity;
         v.modseq = fetchargs->changedsince;

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -152,7 +152,7 @@ static int promdir_foreach(promdir_foreach_cb *proc,
 
     while ((dirent = readdir(dh))) {
         char fname[PATH_MAX];
-        struct prom_stats stats;
+        struct prom_stats stats = PROM_STATS_INITIALIZER;
         struct mappedfile *mf = NULL;
 
         /* skip filenames we don't care about */
@@ -173,6 +173,25 @@ static int promdir_foreach(promdir_foreach_cb *proc,
             mappedfile_close(&mf);
             continue;
         }
+
+        if (mappedfile_size(mf) != sizeof(stats)) {
+            /* we may have snuck our read lock in before the process that
+             * created the file could lock it and write to it, in which case
+             * it'll be empty, and we should ignore it for now
+             */
+            if (mappedfile_size(mf) != 0) {
+                /* if it's not empty, that's a surprise! */
+                xsyslog(LOG_DEBUG, "unexpected file size",
+                                   "filename=<%s> expected=<" SIZE_T_FMT ">"
+                                   " actual=<" SIZE_T_FMT ">",
+                                   fname, sizeof(stats), mappedfile_size(mf));
+            }
+
+            mappedfile_unlock(mf);
+            mappedfile_close(&mf);
+            continue;
+        }
+
         memcpy(&stats, mappedfile_base(mf), mappedfile_size(mf));
         mappedfile_unlock(mf);
         mappedfile_close(&mf);

--- a/ptclient/ldap.c
+++ b/ptclient/ldap.c
@@ -1396,11 +1396,13 @@ static int ptsmodule_make_authstate_group(
             (*newstate)->groups[j].hash = strhash((*newstate)->groups[j].id);
             j++;
         }
+        ldap_value_free(uvals);
     }
 
     rc = PTSM_OK;
 
 done:;
+    ldap_value_free(vals);
 
     if (res)
         ldap_msgfree(res);


### PR DESCRIPTION
Fixes or workarounds for issues found by running cassandane under valgrind (which CI doesn't do).

For whatever it's worth, a full `./testrunner.pl --valgrind` of the master branch takes around 1 hour 40 mins on my current laptop.  Which is still too long to do routinely, but is now at least feasible to run occasionally.

My priority here is to get the tests passing; this is not a comprehensive audit.