### PR TITLE
remotepurge.c: declare config_fatals_abort

### DIFF
--- a/netnews/remotepurge.c
+++ b/netnews/remotepurge.c
@@ -29,6 +29,7 @@
 #include <pwd.h>
 
 #include "prot.h"
+#include "lib/libconfig.h"
 #include "lib/times.h"
 
 #include "imclient.h"


### PR DESCRIPTION
Otherwise compilation fails:
```
netnews/remotepurge.c: In function ‘fatal’:
netnews/remotepurge.c:111:32: error: ‘config_fatals_abort’ undeclared (first use in this function)
  111 |     if (code != EX_PROTOCOL && config_fatals_abort) abort();
      |                                ^~~~~~~~~~~~~~~~~~~
netnews/remotepurge.c:111:32: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [Makefile:5897: netnews/remotepurge.o] Error 1
```