### PR TITLE
index_warmup() - used released memory

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -1650,8 +1650,6 @@ EXPORTED int index_warmup(const struct mboxlist_entry *mbentry,
             fname = tofree = conversations_getmboxpath(mbentry->name);
             r = warmup_file(fname, 0, 0);
             if (r) goto out;
-            free(tofree);
-            tofree = NULL;
         }
     }
     if (warmup_flags & WARMUP_SEARCH) {


### PR DESCRIPTION
In index.c:index_warmup() with this flow:
```c
    const char *fname = NULL;
    char *tofree = NULL;
    if (warmup_flags & WARMUP_CONVERSATIONS) {
        if (config_getswitch(IMAPOPT_CONVERSATIONS)) {
            fname = tofree = conversations_getmboxpath(mbentry->name);
            r = warmup_file(fname, 0, 0);
            if (r) goto out;
            free(tofree);
            tofree = NULL;
        }
    }
    if (r)
        syslog(LOG_ERR, "IOERROR: unable to warmup file %s: %s", fname, error_message(r));
```
would log `fname`, but its memory is released.  If the last `if (r)` cannot match, then in this function `tofree` should be made local variable to the snippet `if (warmup_flags & WARMUP_CONVERSATIONS) { … }`.