### PR TITLE
util.h: fix compilation with clang++ for alias("wrap_clock_gettime")

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -466,11 +466,13 @@ enum xsyslog_ev_arg_type {
  * We need this shim because, unlike gettimeofday, clock_gettime itself is
  * not a weak alias, so it can't be overridden directly.
  */
+#ifndef __cplusplus
 static int wrap_clock_gettime(clockid_t id, struct timespec *ts)
 {
     return clock_gettime(id, ts);
 }
 __attribute__((weak, alias("wrap_clock_gettime"), visibility("default")))
 extern int cyrus_gettime(clockid_t, struct timespec *);
+#endif
 
 #endif /* INCLUDED_UTIL_H */


### PR DESCRIPTION
Clang++ 22.1.6 fails compiling:
```
$ make imap/xapian_wrap.o CXX=clang++
  CXX      imap/xapian_wrap.o
In file included from imap/xapian_wrap.cpp:15:
./lib/util.h:468:12: warning: unused function 'wrap_clock_gettime' [-Wunused-function]
  468 | static int wrap_clock_gettime(clockid_t id, struct timespec *ts)
      |            ^~~~~~~~~~~~~~~~~~
./lib/util.h:472:22: error: alias must point to a defined variable or function
  472 | __attribute__((weak, alias("wrap_clock_gettime"), visibility("default")))
      |                      ^
./lib/util.h:472:22: note: the function or variable specified in an alias must refer to its mangled name
./lib/util.h:472:22: note: function by that name is mangled as "_ZL18wrap_clock_gettimeiP8timespec"
  472 | __attribute__((weak, alias("wrap_clock_gettime"), visibility("default")))
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                      alias("_ZL18wrap_clock_gettimeiP8timespec")
1 warning and 1 error generated.
make: *** [Makefile:7776: imap/xapian_wrap.o] Error 1
```
This chaneg included, with g++ 16.1:
```
$ readelf --all -W imap/.libs/libcyrus_imap_la-xapian_wrap.o
Symbol table '.symtab' contains 668 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
    79: 00000000000048c0     5 FUNC    LOCAL  DEFAULT   64 wrap_clock_gettime
   409: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND clock_gettime
   410: 00000000000048c0     5 FUNC    WEAK   DEFAULT   64 cyrus_gettime
```
With clang++:
```
$ readelf --all W imap/.libs/libcyrus_imap_la-xapian_wrap.o
Symbol table '.symtab' contains 787 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     3: 0000000000000000     5 FUNC    LOCAL  DEFAULT    2 _ZL18wrap_clock_gettimeiP8timespec
   388: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND clock_gettime
   784: 0000000000000000     5 FUNC    WEAK   DEFAULT    2 cyrus_gettime
```