### PR TITLE
configure.ac: require libical 4.0 instead of 3.99.99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1461,7 +1461,7 @@ dnl
                                 [Do we have support for xmlBufferDetach()?]))
                 ])
 
-        PKG_CHECK_MODULES([ICAL], [libical >= 3.99.99], [
+        PKG_CHECK_MODULES([ICAL], [libical >= 4.0], [
                 AC_DEFINE(HAVE_ICAL,[],[Build CalDAV support into httpd?])
                 LIBS="$LIBS ${ICAL_LIBS} -licalvcard"
                 with_ical=yes


### PR DESCRIPTION
Version 3.99.99 is hard to install and hard to define what exactly it means.