### PR TITLE
jmap_blob.c: look up ContactCard ids, not the removed Contact type

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_blob_lookup
+++ b/cassandane/tiny-tests/JMAPContacts/card_blob_lookup
@@ -1,0 +1,58 @@
+#!perl
+use Cassandane::Tiny;
+
+# Blob/lookup must map a contact card's blob to a ContactCard id that
+# ContactCard/get can resolve.
+sub test_card_blob_lookup ($self)
+{
+    my $jmap = $self->{jmap};
+
+    my $using = [
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:contacts',
+        'https://cyrusimap.org/ns/jmap/contacts',
+    ];
+
+    xlog $self, "create a contact card";
+    my $res = $jmap->request({
+        using => $using,
+        methodCalls => [['ContactCard/set', { create => {
+            card1 => {
+                '@type' => 'Card',
+                version => '1.0',
+                uid => 'card1uid',
+                name => { full => 'Jane Doe' },
+            },
+        }}, 'R1']],
+    });
+    my $cardId = $res->sentence_named('ContactCard/set')
+                     ->arguments->{created}{card1}{id};
+    $self->assert_not_null($cardId);
+
+    xlog $self, "fetch the card's blobId";
+    $res = $jmap->request({
+        using => $using,
+        methodCalls => [['ContactCard/get', {
+            ids => [$cardId],
+            properties => ['cyrusimap.org:blobId'],
+        }, 'R1']],
+    });
+    my $blobId = $res->sentence_named('ContactCard/get')
+                     ->arguments->{list}[0]{'cyrusimap.org:blobId'};
+    $self->assert_not_null($blobId);
+
+    xlog $self, "Blob/lookup must return the id ContactCard/get uses";
+    $res = $jmap->request({
+        using => [
+            'urn:ietf:params:jmap:core',
+            'urn:ietf:params:jmap:blob',
+        ],
+        methodCalls => [['Blob/lookup', {
+            typeNames => ['ContactCard'],
+            ids => [$blobId],
+        }, 'R1']],
+    });
+    $self->assert_deep_equals([$cardId],
+        $res->sentence_named('Blob/lookup')
+            ->arguments->{list}[0]{matchedIds}{ContactCard});
+}

--- a/imap/jmap_blob.c
+++ b/imap/jmap_blob.c
@@ -445,7 +445,7 @@ done:
 #define DATATYPE_THREAD          (1<<1)
 #define DATATYPE_EMAIL           (1<<2)
 #define DATATYPE_ADDRESSBOOK     (1<<3)
-#define DATATYPE_CONTACT         (1<<4)
+#define DATATYPE_CONTACTCARD     (1<<4)
 #define DATATYPE_CALENDAR        (1<<5)
 #define DATATYPE_CALENDAREVENT   (1<<6)
 
@@ -462,7 +462,7 @@ struct datatype_name known_datatypes[] = {
     { "Thread", DATATYPE_THREAD, MBTYPE_EMAIL },
     { "Email", DATATYPE_EMAIL, MBTYPE_EMAIL },
     { "Addressbook", DATATYPE_ADDRESSBOOK, MBTYPE_ADDRESSBOOK },
-    { "Contact", DATATYPE_CONTACT, MBTYPE_ADDRESSBOOK },
+    { "ContactCard", DATATYPE_CONTACTCARD, MBTYPE_ADDRESSBOOK },
     { "Calendar", DATATYPE_CALENDAR, MBTYPE_CALENDAR },
     { "CalendarEvent", DATATYPE_CALENDAREVENT, MBTYPE_CALENDAR },
     { NULL, 0, 0 }
@@ -642,7 +642,7 @@ static int jmap_blob_lookup(jmap_req_t *req)
             caldav_db = caldav_open_mailbox(mbox);
 
         struct carddav_db *carddav_db = NULL;
-        if (datatypes & DATATYPE_CONTACT)
+        if (datatypes & DATATYPE_CONTACTCARD)
             carddav_db = carddav_open_mailbox(mbox);
 
         int j;
@@ -710,10 +710,15 @@ static int jmap_blob_lookup(jmap_req_t *req)
                     strarray_add(ids, strarray_nth(boxes, -1));
                     break;
 
-                case DATATYPE_CONTACT: {
+                case DATATYPE_CONTACTCARD: {
                     struct carddav_data *cdata = NULL;
                     carddav_lookup_imapuid(carddav_db, mbentry, getblob->uid, &cdata, 0);
-                    if (cdata) strarray_add(ids, cdata->vcard_uid);
+                    if (cdata) {
+                        struct buf cardid = BUF_INITIALIZER;
+                        jmap_set_contactid(req->cstate, cdata, &cardid);
+                        strarray_add(ids, buf_cstring(&cardid));
+                        buf_free(&cardid);
+                    }
                     break;
                     }
 


### PR DESCRIPTION
Blob/lookup still implemented the (otherwise totally deleted) Contact datatype, and never got ContactCard.  Rip out Contact id resolution, bring in ContactCard resolution.