### PR TITLE
acl_afs.c:cyrus_acl_myrights() - short circuit

### DIFF
--- a/lib/acl_afs.c
+++ b/lib/acl_afs.c
@@ -26,7 +26,6 @@
  */
 EXPORTED int cyrus_acl_myrights(const struct auth_state *auth_state, const char *origacl)
 {
-    int admin_implies_write = libcyrus_config_getswitch(CYRUSOPT_ACL_ADMIN_IMPLIES_WRITE);
     char *acl = xstrdupsafe(origacl);
     char *thisid, *rights, *nextid;
     long acl_positive = 0, acl_negative = 0;
@@ -61,7 +60,7 @@ EXPORTED int cyrus_acl_myrights(const struct auth_state *auth_state, const char 
 
     free(acl);
 
-    if (admin_implies_write && (acl_positive & ACL_ADMIN)) {
+    if ((acl_positive & ACL_ADMIN) && libcyrus_config_getswitch(CYRUSOPT_ACL_ADMIN_IMPLIES_WRITE)) {
         acl_positive |= ACL_SETSEEN | ACL_WRITE | ACL_INSERT
                      | ACL_DELETEMSG | ACL_EXPUNGE | ACL_ANNOTATEMSG;
     }


### PR DESCRIPTION
Instead of always executing `libcyrus_config_getswitch(…)` with this change `libcyrus_config_getswitch(…)` is invoked only sometimes.