### PR TITLE
jmap_mail.c: fix race condition between queryChanges and squatter

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -82,6 +82,7 @@ sub jmap_default_using {
         'urn:ietf:params:jmap:core',
         'urn:ietf:params:jmap:mail',
         'urn:ietf:params:jmap:submission',
+        'https://cyrusimap.org/ns/jmap/mail',
     ];
 }
 

--- a/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
+++ b/cassandane/Cassandane/Cyrus/SearchFuzzy.pm
@@ -2,6 +2,15 @@
 # See COPYING file at the root of the distribution for more details.
 
 package Cassandane::Cyrus::SearchFuzzy;
+
+=head1 NAME
+
+Cassandane::Cyrus::SearchFuzzy - tests for fuzzy search and indexing
+
+=head1 HELPER METHODS
+
+=cut
+
 use strict;
 use warnings;
 use Cwd qw(abs_path);
@@ -14,6 +23,7 @@ use Encode qw(decode encode);
 
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
+use Cassandane::Util::Wait;
 
 sub new
 {
@@ -179,6 +189,53 @@ sub delve_docs
     return \@gdocs, \@parts;
 }
 
+=head2 start_echo_extractor
+
+    $self->start_echo_extractor(%params);
+
+This starts an attachment extractor server as configured in the imapd.conf
+C<search_attachment_extractor_url> config value.  It answers C<HEAD> requests
+with C<204>, C<GET> requests with C<404>, and echoes the request body back for
+any other method.
+
+Valid parameters are:
+
+=over 4
+
+=item tracedir
+
+A directory in which the extractor touches one empty file per request, named
+C<< req<n>_<method>_<guid> >>, so tests can assert which requests it got.
+
+=item trace_delay_seconds
+
+Seconds to sleep before writing the trace file.
+
+=item response_delay_seconds
+
+Seconds to sleep before sending the response; may be an arrayref of per-request
+delays, where requests beyond the end of the array are not delayed.
+
+=item fail_content
+
+A regex; requests whose body matches it are answered with C<500> instead of
+being extracted. Use C<fail_until_file> to disable this while the extractor
+is running.
+
+=item fail_until_file
+
+A file name; once that file exists, C<fail_content> stops taking effect and
+matching requests are extracted normally.
+
+=item wait_for_file
+
+A file name; the extractor blocks each request (for up to 60 seconds) until
+that file shows up, which also blocks the squatter that made the request.
+
+=back
+
+=cut
+
 sub start_echo_extractor
 {
     my ($self, %params) = @_;
@@ -213,9 +270,35 @@ sub start_echo_extractor
         } elsif ($req->method eq 'GET') {
             $res = HTTP::Response->new(404);
             $res->content("nope");
+        } elsif (defined $params{fail_content} &&
+                 $req->content =~ $params{fail_content} &&
+                 !($params{fail_until_file} && -e $params{fail_until_file})) {
+            # This is the part the caller wants us to not extract, at least
+            # until the file fail_until_file starts to exist.
+            $conn->send_error(500);
+            return;
         } else {
             $res = HTTP::Response->new(200);
             $res->content($req->content);
+        }
+
+        if ($params{wait_for_file}) {
+            # Hold the extraction, and with it the mailbox update, until the
+            # caller is done with whatever it wants to happen meanwhile.
+            # This runs in the forked httpd, so a timeout must not die here:
+            # that would take down the extractor, and run the destructors of
+            # the whole test in the fork. Fail the extraction instead and let
+            # the test fail on its own assertions.
+            eval {
+                timed_wait(sub { -e $params{wait_for_file} },
+                    description => "$params{wait_for_file} to show up",
+                    maxwait => 60);
+            };
+            if ($@) {
+                xlog "extractor: $@";
+                $conn->send_error(500);
+                return;
+            }
         }
 
         if ($params{response_delay_seconds}) {

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -363,6 +363,15 @@ magic(SearchAttachmentExtractor => sub {
     $self->config_set('search_attachment_extractor_request_timeout' => '3s');
     $self->config_set('search_attachment_extractor_idle_timeout' => '3s');
 });
+magic(SearchAttachmentExtractorBlocking => sub {
+    # For tests that hold up the extractor on purpose. With the timeouts that
+    # SearchAttachmentExtractor sets, squatter would give up on the extraction
+    # and carry on, and the test would not exercise what it means to. Apply
+    # this after :SearchAttachmentExtractor.
+    my $self = shift;
+    $self->config_set('search_attachment_extractor_request_timeout' => '60s');
+    $self->config_set('search_attachment_extractor_idle_timeout' => '60s');
+});
 magic(SearchLanguage => sub {
     shift->config_set('search_index_language' => 'yes');
 });

--- a/cassandane/tiny-tests/JMAPEmail/email_legacy_ids
+++ b/cassandane/tiny-tests/JMAPEmail/email_legacy_ids
@@ -136,12 +136,15 @@ EOF
 
     xlog $self, "get email list updates";
     $res = $jmap->CallMethods([['Email/queryChanges', {
+        filter => {
+            from => 'gmail.com',
+        },
         sinceQueryState => $state,
         sort => [{
             property => 'receivedAt',
         }],
     }, "R1"]]);
-    $self->assert_num_equals(5, $res->[0][1]->{total});
+    $self->assert_num_equals(3, $res->[0][1]->{total});
     $self->assert_matches(qr/^[0-9].*/, $res->[0][1]->{oldQueryState});
     $self->assert_matches(qr/^[0-9].*/, $res->[0][1]->{newQueryState});
 

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_squatter_ordering
@@ -1,0 +1,215 @@
+#!perl
+use Cassandane::Tiny;
+
+# If an email query happens in between a message got delivered and squatter
+# runs, we had returned a query state that included the createdmodseq of
+# the new message but the message itself was not in the result.
+#
+# A following Email/queryChanges did not report this message either because
+# of the lower createdmodseq. As a result, clients never were aware of this
+# message in the result set, and positions of any newly reported messages
+# in the queryChanges responses were off by one.
+#
+# This test asserts Cyrus does not do that anymore. We fixed this by keeping
+# track of the highest createdmodseq of all messages in the search index,
+# and encoding that value in the query state to cap search results to messages
+# up to and including that createdmodseq.
+#
+# Each message is in its own thread, so the query results are the same
+# for the collapsed and uncollapsed variants of the test.
+#
+# Also see the SearchFuzzy.squatter_createdmodseq test.
+
+sub assert_email_querychanges_squatter_ordering($self, $collapse_threads)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    my $inbox = $user->mailboxes->inbox;
+
+    my %common_query = (
+        collapseThreads => $collapse_threads ? JSON::true : JSON::false,
+        sort => [
+            {
+                isAscending => JSON::false,
+                mailboxId   => $inbox->id,
+                property    => 'snoozedUntil',
+            }, {
+                isAscending => JSON::false,
+                property    => 'receivedAt'
+            },
+        ],
+        filter => {
+            conditions => [
+                { inMailbox => $inbox->id },
+                { text      => 'Garnet'   },
+            ],
+            operator => 'AND',
+        },
+    );
+
+    xlog $self, "Install script to flag messages in inbox";
+    $self->{instance}->install_sieve_script(<<~EOF
+        require ["imap4flags"];
+        addflag "\\Seen";
+        EOF
+    );
+
+    xlog $self, "Make a bunch of messages that match our query";
+    for (1..10) {
+        my $msg = $self->{gen}->generate(subject => "Garnet");
+        $self->{instance}->deliver($msg);
+    }
+
+    xlog $self, "Run squatter to index them";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    xlog $self, "Get email ids";
+    my $res = $jmap->request([[
+        "Email/query" => {
+            %common_query,
+            calculateTotal => JSON::true,
+        },
+    ]]);
+
+    my $qres = $res->sentence_named("Email/query")->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            ids                 => [ (jstr()) x 10 ],
+            position            => 0,
+            total               => 10,
+        }),
+        $qres,
+    );
+    my $base_email_ids = $qres->{ids};
+
+    xlog $self, "Wait a second so new delivery is later";
+    sleep 1;
+
+    xlog $self, "Deliver a matching message but don't run squatter";
+    my $msg1 = $self->{gen}->generate(subject => "Garnet");
+    $self->{instance}->deliver($msg1);
+
+    xlog $self, "Get our query state";
+    $res = $jmap->request([[
+        "Email/query" => {
+            %common_query,
+            limit => 5,
+            calculateTotal => JSON::true,
+        },
+    ]]);
+
+    $qres = $res->sentence_named("Email/query")->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            canCalculateChanges => JSON::true,
+            ids                 => [ (jstr()) x 5 ],
+            position            => 0,
+            total               => 10,
+            queryState          => jstr,
+        }),
+        $qres,
+    );
+
+    xlog $self, "Assert newly delivered but unindexed message is not in result";
+    $self->assert_cmp_deeply([ @{$base_email_ids}[0..4] ], $qres->{ids});
+
+    my $qstate = $qres->{queryState};
+    $self->assert_not_null($qstate);
+
+    my $upto = $qres->{ids}->[-1];
+    $self->assert_not_null($upto);
+
+    xlog $self, "Our query state is $qstate";
+
+    xlog $self, "Assert queryChanges ignores the message squatter has not seen";
+    $res = $jmap->request([[
+        "Email/queryChanges" => {
+            %common_query,
+            sinceQueryState => $qstate,
+            upToId => $upto,
+        },
+    ]]);
+    $self->assert_cmp_deeply(
+        superhashof({
+            added   => [],
+            removed => [],
+        }),
+        $res->sentence_named("Email/queryChanges")->arguments,
+    );
+
+    xlog $self, "Now squatter runs (incremental, as rolling squatter would)...";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Wait a second so new delivery is later";
+    sleep 1;
+
+    xlog $self, "Deliver a new matching message";
+    my $msg2 = $self->{gen}->generate(subject => "Garnet");
+    $self->{instance}->deliver($msg2);
+
+    xlog $self, "Run squatter (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Check Email/queryChanges";
+    $res = $jmap->request([[
+        "Email/queryChanges" => {
+            %common_query,
+            sinceQueryState => $qstate,
+            upToId => $upto,
+        },
+    ]]);
+
+    my $qcres = $res->sentence_named("Email/queryChanges")->arguments;
+    my $newqstate = $qcres->{newQueryState};
+
+    $self->assert_cmp_deeply(
+        superhashof({
+            added               => [ { id => jstr, index => 0 }, { id => jstr, index => 1 } ],
+            removed             => [ jstr, jstr ],
+        }),
+        $qcres,
+    );
+
+    xlog $self, "Check email/query with position 5. Should start one before $upto since two new messages were delivered from the given query state";
+    $res = $jmap->request([[
+        "Email/query" => {
+          %common_query,
+          position => 5,
+        },
+    ]]);
+
+    $qres = $res->sentence_named("Email/query")->arguments;
+    $self->assert_str_equals($upto, $qres->{ids}[1]);
+    $self->assert_cmp_deeply([ @{$base_email_ids}[3..$#{$base_email_ids}] ], $qres->{ids});
+
+    xlog $self, "Compact the search index with reindexing, changing the index generation";
+    $self->assert_not_null($newqstate);
+    $self->{instance}->run_command({cyrus => 1},
+        'squatter', '-z', 't2', '-t', 't1', '-T', 't1');
+
+    xlog $self, "Assert queryChanges refuses to calculate changes across a reindex";
+    $res = $jmap->request([[
+        "Email/queryChanges" => {
+            %common_query,
+            sinceQueryState => $newqstate,
+            upToId => $upto,
+        },
+    ]]);
+    my $error = $res->sentence(0);
+    $self->assert_str_equals('error', $error->name);
+    $self->assert_str_equals('cannotCalculateChanges', $error->arguments->{type});
+}
+
+sub test_email_querychanges_squatter_ordering_uncollapsed
+    :needs_component_sieve
+    ($self)
+{
+    $self->assert_email_querychanges_squatter_ordering(0);
+}
+
+sub test_email_querychanges_squatter_ordering_collapsed
+    :needs_component_sieve
+    ($self)
+{
+    $self->assert_email_querychanges_squatter_ordering(1);
+}

--- a/cassandane/tiny-tests/SearchFuzzy/audit_unindexed
+++ b/cassandane/tiny-tests/SearchFuzzy/audit_unindexed
@@ -40,6 +40,7 @@ sub test_audit_unindexed
     my ($key, $val);
     my $result = $self->{instance}->run_dbcommand_cb(sub ($k, $v) {
       return if $k =~ m/\*V\*/;
+      return if $k =~ m/\*HIGHEST_CREATEDMODSEQ\*/;
       $self->assert_null($key);
       ($key, $val) = ($k, $v);
     }, "$xapdir/xapian/cyrus.indexed.db", $format, ['SHOW']);

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_failed_part
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_failed_part
@@ -1,0 +1,194 @@
+#!perl
+use Cassandane::Tiny;
+
+# A message whose attachment text can not get extracted must not end up
+# recorded as indexed: the indexed ranges of a mailbox only ever get merged,
+# so it would never get indexed again. Indexing the mailbox stops at that
+# message, a later run indexes it and the messages after it.
+
+sub assert_squatter_attachextract_failed_part($self, %params)
+{
+    my $talk = $self->{store}->get_client();
+    my $instance = $self->{instance};
+
+    xlog $self, "Start an extractor that fails for the bad attachment";
+    $self->{unfail} = $instance->{basedir} . "/tmp/unfail_extractor";
+    $self->start_echo_extractor(fail_content => qr/badattachment/,
+                                fail_until_file => $self->{unfail});
+
+    my %make_message = (
+        failmsg => sub {
+            $self->create_message_in_mailbox("INBOX", {
+                subject => "failmsg",
+                args => {
+                    mime_type => "multipart/related",
+                    mime_boundary => "123456789abcdef",
+                    body => ""
+                    ."\r\n--123456789abcdef\r\n"
+                    ."Content-Type: text/plain\r\n"
+                    ."\r\n"
+                    ."failbody"
+                    ."\r\n--123456789abcdef\r\n"
+                    ."Content-Type: application/pdf\r\n"
+                    ."\r\n"
+                    ."badattachment"
+                    ."\r\n--123456789abcdef--\r\n",
+                },
+            });
+        },
+        plainmsg => sub {
+            $self->create_message_in_mailbox("INBOX",
+                { subject => "plainmsg" });
+        },
+        goodmsg => sub {
+            $self->create_message_in_mailbox("INBOX", {
+                subject => "goodmsg",
+                args => {
+                    mime_type => "multipart/related",
+                    mime_boundary => "123456789abcdef",
+                    body => ""
+                    ."\r\n--123456789abcdef\r\n"
+                    ."Content-Type: text/plain\r\n"
+                    ."\r\n"
+                    ."goodbody"
+                    ."\r\n--123456789abcdef\r\n"
+                    ."Content-Type: application/pdf\r\n"
+                    ."\r\n"
+                    ."goodattachment"
+                    ."\r\n--123456789abcdef--\r\n",
+                },
+            });
+        },
+    );
+
+    # Where the message that fails sits decides which messages this run still
+    # gets to index, and what must keep its uid out of the indexed range, so
+    # the caller picks the order the messages get created in. Returns the uid
+    # each of them ended up with.
+    my @order = @{ $params{order} // [qw(failmsg plainmsg goodmsg)] };
+    my %uid;
+    my $nmessages = 0;
+    foreach my $subject (@order) {
+        xlog $self, "Create $subject";
+        $make_message{$subject}->();
+        $uid{$subject} = ++$nmessages;
+    }
+
+    xlog $self, "Index INBOX";
+    my $failed = 0;
+    $instance->run_command({
+        cyrus => 1,
+        handlers => {
+            exited_abnormally => sub { $failed = 1; return 0; },
+        },
+    }, 'squatter', '-i', @{ $params{squatter_args} // [] });
+
+    xlog $self, "Assert squatter reported the failure";
+    $self->assert_num_equals($params{allow_partials} ? 0 : 1, $failed);
+
+    # Unless partials are allowed, indexing stops at the message that fails,
+    # so only the messages created before it get indexed by this run.
+    my %indexed = map { $_ => 1 } @order;
+    if (!$params{allow_partials}) {
+        my $stopped = 0;
+        foreach my $subject (@order) {
+            $stopped = 1 if $subject eq 'failmsg';
+            delete $indexed{$subject} if $stopped;
+        }
+    }
+
+    xlog $self, "Assert indexing stopped at the message that failed";
+    $talk->select("INBOX");
+    my $uids = $talk->search('fuzzy', 'subject', 'plainmsg');
+    $self->assert_deep_equals($indexed{plainmsg} ? [$uid{plainmsg}] : [], $uids);
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'goodattachment');
+    $self->assert_deep_equals($indexed{goodmsg} ? [$uid{goodmsg}] : [], $uids);
+
+    xlog $self, "Assert the failed attachment text is not indexed";
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'badattachment');
+    $self->assert_deep_equals([], $uids);
+
+    return \%uid;
+}
+
+# Not allowing partials, the message that failed is not indexed at all, so a
+# later run must index it, and the messages after it, again.
+sub assert_failed_part_indexed_by_later_run($self, $uid)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "Assert the failed message is not indexed at all";
+    my $uids = $talk->search('fuzzy', 'body', 'failbody');
+    $self->assert_deep_equals([], $uids);
+
+    xlog $self, "Index again, with the extractor no longer failing";
+    open(my $fh, '>', $self->{unfail}) or die "Can't open: $!";
+    close($fh);
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Assert the failed message got indexed now";
+    $uids = $talk->search('fuzzy', 'body', 'failbody');
+    $self->assert_deep_equals([$uid->{failmsg}], $uids);
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'badattachment');
+    $self->assert_deep_equals([$uid->{failmsg}], $uids);
+
+    xlog $self, "Assert the messages after it got indexed now, too";
+    $uids = $talk->search('fuzzy', 'subject', 'plainmsg');
+    $self->assert_deep_equals([$uid->{plainmsg}], $uids);
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'goodattachment');
+    $self->assert_deep_equals([$uid->{goodmsg}], $uids);
+}
+
+# The message that fails is the first one of the mailbox on purpose. That
+# makes it the lowest unindexed uid, which is the one an indexed range gets
+# extended down to so that it does not become gappy.
+sub test_squatter_attachextract_failed_part_nopartials
+    :SearchAttachmentExtractor :NoCheckSyslog
+    ($self)
+{
+    $self->assert_failed_part_indexed_by_later_run(
+        $self->assert_squatter_attachextract_failed_part());
+}
+
+# The message that fails sits between two messages that index fine. The
+# indexed range must not get merged across its uid either.
+sub test_squatter_attachextract_failed_part_middle
+    :SearchAttachmentExtractor :NoCheckSyslog
+    ($self)
+{
+    $self->assert_failed_part_indexed_by_later_run(
+        $self->assert_squatter_attachextract_failed_part(
+            order => [qw(plainmsg failmsg goodmsg)]));
+}
+
+# Allowing partials, that message gets indexed without its attachment text
+# and marked as partially indexed. Indexing does not stop at it.
+sub test_squatter_attachextract_failed_part_partials
+    :SearchAttachmentExtractor :NoCheckSyslog
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    my $uid = $self->assert_squatter_attachextract_failed_part(
+        squatter_args => ['-p'], allow_partials => 1);
+
+    xlog $self, "Assert the failed message is indexed without its attachment";
+    my $uids = $talk->search('fuzzy', 'body', 'failbody');
+    $self->assert_deep_equals([$uid->{failmsg}], $uids);
+
+    xlog $self, "Index again, with the extractor no longer failing";
+    open(my $fh, '>', $self->{unfail}) or die "Can't open: $!";
+    close($fh);
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Assert a plain index run leaves the partial message alone";
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'badattachment');
+    $self->assert_deep_equals([], $uids);
+
+    xlog $self, "Reindex partial messages";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', '-P');
+
+    xlog $self, "Assert the attachment text got indexed now";
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'badattachment');
+    $self->assert_deep_equals([$uid->{failmsg}], $uids);
+}

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_interrupted
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_interrupted
@@ -1,0 +1,159 @@
+#!perl
+use Cassandane::Tiny;
+
+# This test interrupts squatter while it extracts the attachment text
+# of a mailbox, at the point where it does not hold the mailbox lock.
+# It then deletes the mailbox, or deletes and creates a mailbox with that
+# same name, or removes one of the messages it selected. In each case, the
+# index state must remain sane.
+
+sub assert_squatter_attachextract_interrupted($self, $interrupt, %opts)
+{
+    # $interrupt runs once the extractor got called and does the interrupting.
+    # expect_syslog, if given, must match what squatter logged about it.
+    # expect_reindexed, if given, lists the subjects of the messages that
+    # squatter must have indexed in mailbox A after the interruption.
+
+    my $talk = $self->{store}->get_client();
+    my $instance = $self->{instance};
+
+    my $tracedir = tempdir(DIR => $instance->{basedir} . "/tmp");
+    my $unblock = $instance->{basedir} . "/tmp/unblock_extractor";
+
+    xlog $self, "Index a message in INBOX and one in mailbox A";
+    $self->create_message_in_mailbox("INBOX", { subject => "inboxmsg" });
+    $talk->create("A") || die;
+    $self->create_message_in_mailbox("A", { subject => "indexedmsg" });
+    $instance->run_command({cyrus => 1}, 'squatter', '-i');
+
+    my ($highest_createdmodseq, $index_generation) =
+        $self->get_squatter_createdmodseq;
+    $self->assert_num_not_equals(0, $index_generation);
+
+    xlog $self, "Add a plain message and one with an attachment to A";
+    $self->create_message_in_mailbox("A", { subject => "plainmsg" });
+    $self->create_message_in_mailbox("A", {
+        subject => "attachmsg",
+        args => {
+            mime_type => "multipart/related",
+            mime_boundary => "123456789abcdef",
+            body => ""
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: text/plain\r\n"
+            ."\r\n"
+            ."plaintext"
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: application/pdf\r\n"
+            ."\r\n"
+            ."attachment"
+            ."\r\n--123456789abcdef--\r\n",
+        },
+    });
+
+    xlog $self, "Clear syslog";
+    $instance->getsyslog();
+
+    xlog $self, "Start an extractor that blocks until we interrupted squatter";
+    $self->start_echo_extractor(tracedir => $tracedir,
+                                wait_for_file => $unblock);
+
+    xlog $self, "Index mailbox A in the background";
+    my $pid = $instance->run_command({ cyrus => 1, background => 1 },
+        'squatter', '-i', 'user.cassandane.A');
+
+    xlog $self, "Wait for the extractor to get called";
+    timed_wait(sub { scalar(glob("$tracedir/*")) },
+        description => "attachment extraction to start",
+        maxwait => 60);
+
+    $interrupt->();
+
+    # The interruption may have reconnected the store, e.g. to expunge.
+    $talk = $self->{store}->get_client();
+
+    xlog $self, "Let the extractor respond";
+    open(my $fh, '>', $unblock) or die "Can't open > $unblock: $!";
+    close($fh);
+
+    xlog $self, "Assert squatter terminated normally";
+    $instance->reap_command($pid);
+
+    my ($new_createdmodseq, $new_generation) =
+        $self->get_squatter_createdmodseq;
+    if (!$opts{expect_reindexed}) {
+        xlog $self, "Assert the index state of this user did not change";
+        $self->assert_num_equals($highest_createdmodseq, $new_createdmodseq);
+        $self->assert_num_equals($index_generation, $new_generation);
+    }
+
+    xlog $self, "Assert the message indexed before is still searchable";
+    $talk->select("INBOX");
+    my $uids = $talk->search('fuzzy', 'subject', 'inboxmsg');
+    $self->assert_num_equals(1, scalar @{$uids});
+
+    if ($opts{expect_reindexed}) {
+        xlog $self, "Assert squatter indexed the mailbox that is there now";
+        $talk->select("A");
+        foreach my $subject (@{$opts{expect_reindexed}}) {
+            $uids = $talk->search('fuzzy', 'subject', $subject);
+            $self->assert_num_equals(1, scalar @{$uids});
+        }
+    }
+
+    if ($opts{expect_syslog} && $instance->{have_syslog_replacement}) {
+        xlog $self, "Assert squatter reported the interruption";
+        my @log = $instance->getsyslog($opts{expect_syslog});
+        $self->assert_num_not_equals(0, scalar @log);
+    }
+}
+
+sub test_squatter_attachextract_interrupted_mbox_deleted
+    :SearchAttachmentExtractor :SearchAttachmentExtractorBlocking
+    ($self)
+{
+    $self->assert_squatter_attachextract_interrupted(sub {
+        # The mailbox is gone by the time squatter wants to index into it.
+        xlog $self, "Delete mailbox A";
+        my $talk = $self->{store}->get_client();
+        $talk->delete("A") || die;
+    });
+}
+
+sub test_squatter_attachextract_interrupted_msg_removed
+    :SearchAttachmentExtractor :SearchAttachmentExtractorBlocking
+    ($self)
+{
+    $self->assert_squatter_attachextract_interrupted(sub {
+        # A message that squatter selected is gone from the index by the time
+        # it wants to index it. That message needs no indexing anymore, but
+        # the messages after it still do.
+        xlog $self, "Expunge plainmsg from A, then remove its record";
+        my $talk = $self->{store}->get_client();
+        $talk->select("A") || die;
+        $talk->store('2', '+flags', '(\\Deleted)') || die;
+        $talk->expunge() || die;
+        $self->run_delayed_expunge();
+    }, expect_reindexed => ["attachmsg"],
+       expect_syslog => qr/index record is gone/);
+}
+
+sub test_squatter_attachextract_interrupted_mbox_recreated
+    :SearchAttachmentExtractor :SearchAttachmentExtractorBlocking
+    ($self)
+{
+    $self->assert_squatter_attachextract_interrupted(sub {
+        # A different mailbox goes by that name by the time squatter wants to index
+        # into it, so none of the uids it selected mean anything anymore.
+        xlog $self, "Delete and recreate mailbox A";
+        my $talk = $self->{store}->get_client();
+        $talk->delete("A") || die;
+        $talk->create("A") || die;
+        # Uid 1 is below the lowest uid that squatter selected, so an
+        # indexed range reaching down to the first unindexed uid of this
+        # mailbox would claim it without ever indexing it.
+        $self->create_message_in_mailbox("A", { subject => "recreatedmsg1" });
+        $self->create_message_in_mailbox("A", { subject => "recreatedmsg2" });
+        $self->create_message_in_mailbox("A", { subject => "recreatedmsg3" });
+    }, expect_syslog => qr/mailbox changed while extracting attachments/,
+       expect_reindexed => ["recreatedmsg1", "recreatedmsg2", "recreatedmsg3"]);
+}

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_killed
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_killed
@@ -1,0 +1,71 @@
+#!perl
+use Cassandane::Tiny;
+
+# Kill squatter while it extracts the attachment text of a mailbox. Indexing
+# a mailbox is all or nothing, so none of its messages may be recorded as
+# indexed.
+sub test_squatter_attachextract_killed
+    :SearchAttachmentExtractor :SearchAttachmentExtractorBlocking
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    my $instance = $self->{instance};
+
+    my $tracedir = tempdir(DIR => $instance->{basedir} . "/tmp");
+    my $unblock = $instance->{basedir} . "/tmp/unblock_extractor";
+
+    xlog $self, "Create a plain message and one with an attachment in INBOX";
+    $self->create_message_in_mailbox("INBOX", { subject => "plainmsg" });
+    $self->create_message_in_mailbox("INBOX", {
+        subject => "attachmsg",
+        args => {
+            mime_type => "multipart/related",
+            mime_boundary => "123456789abcdef",
+            body => ""
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: text/plain\r\n"
+            ."\r\n"
+            ."plaintext"
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: application/pdf\r\n"
+            ."\r\n"
+            ."attachment"
+            ."\r\n--123456789abcdef--\r\n",
+        },
+    });
+
+    xlog $self, "Start an extractor that never responds";
+    $self->start_echo_extractor(tracedir => $tracedir,
+                                wait_for_file => $unblock);
+
+    xlog $self, "Index INBOX in the background";
+    my $pid = $instance->run_command({ cyrus => 1, background => 1 },
+        'squatter', '-i', 'user.cassandane');
+
+    xlog $self, "Wait for the extractor to get called";
+    # Assert this positively: squatter must have got as far as extracting,
+    # otherwise this test proves nothing about being killed while it does.
+    timed_wait(sub { scalar(glob("$tracedir/*")) },
+        description => "attachment extraction to start",
+        maxwait => 60);
+
+    xlog $self, "Kill squatter while it waits for the extractor";
+    kill 'KILL', $pid;
+    waitpid($pid, 0);
+
+    xlog $self, "Assert nothing of this mailbox got indexed";
+    $talk->select("INBOX");
+    my $uids = $talk->search('fuzzy', 'subject', 'plainmsg');
+    $self->assert_deep_equals([], $uids);
+
+    xlog $self, "Let the extractor respond, then index again";
+    open(my $fh, '>', $unblock) or die "Can't open > $unblock: $!";
+    close($fh);
+    $instance->run_command({cyrus => 1}, 'squatter', '-i', 'user.cassandane');
+
+    xlog $self, "Assert both messages are indexed now";
+    $uids = $talk->search('fuzzy', 'subject', 'plainmsg');
+    $self->assert_deep_equals([1], $uids);
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'attachment');
+    $self->assert_deep_equals([2], $uids);
+}

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_createdmodseq
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_createdmodseq
@@ -224,6 +224,72 @@ sub test_squatter_createdmodseq_partials
     $self->assert_num_not_equals(0, scalar @{$uids});
 }
 
+sub test_squatter_createdmodseq_attachments
+    :SearchAttachmentExtractor
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    my $extractor_url = URI->new($self->{instance}->{config}->get('search_attachment_extractor_url'));
+
+    xlog "Start extractor server";
+    my $handler = sub ($conn, $req) {
+        if ($req->method eq 'HEAD') {
+            my $res = HTTP::Response->new(204);
+            $res->content("");
+            $conn->send_response($res);
+        } else {
+            my $res = HTTP::Response->new(200);
+            $res->content("hellofromextractor");
+            $conn->send_response($res);
+        }
+    };
+    $self->{instance}->start_httpd($handler, $extractor_url->port());
+
+    xlog $self, "Create message";
+    my $createdmodseq = $self->create_message_in_mailbox("INBOX");
+
+    xlog $self, "Index all mailboxes (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    my ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseq, $highest_createdmodseq);
+    $self->assert_num_not_equals(0, $index_generation);
+
+    xlog $self, "Create message with attachment, followed by plain message";
+    $self->create_message_in_mailbox("INBOX", {
+        subject => "attachmsg",
+        args => {
+            mime_type => "multipart/related",
+            mime_boundary => "123456789abcdef",
+            body => ""
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: text/plain\r\n"
+            ."\r\n"
+            ."plaintext"
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: application/pdf\r\n"
+            ."\r\n"
+            ."attachment"
+            ."\r\n--123456789abcdef--\r\n"
+        },
+    });
+    $createdmodseq = $self->create_message_in_mailbox("INBOX");
+
+    xlog $self, "Index all mailboxes (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog "Assert attachment is indexed";
+    my $uids = $talk->search('fuzzy', 'xattachmentbody', 'hellofromextractor');
+    $self->assert_num_not_equals(0, scalar @{$uids});
+
+    xlog $self, "Assert index generation did not change";
+    my $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseq, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+}
+
 sub test_squatter_createdmodseq_reindex
     ($self)
 {

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_createdmodseq
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_createdmodseq
@@ -1,0 +1,296 @@
+#!perl
+use Cassandane::Tiny;
+
+# Create a message in mboxname with make_message(params).
+# The return value is the createdmodseq (not the UID!).
+sub create_message_in_mailbox($self, $mboxname, $params = {})
+{
+    my $talk = $self->{store}->get_client();
+
+    $self->{store}->set_folder($mboxname);
+    my $msg = $self->make_message($params->{subject}, %{$params->{args} // {}}) || die;
+    my $uid = $msg->get_attribute('uid');
+
+    $talk->select($mboxname);
+    my $res = $talk->fetch($uid, '(createdmodseq)');
+    my $createdmodseq = $res->{$uid}{createdmodseq}[0];
+
+    return $createdmodseq;
+}
+
+# Read highest createdmodseq and index generation from squatter.
+sub get_squatter_createdmodseq($self)
+{
+    my $basedir = $self->{instance}->{basedir};
+    my $outfile = "$basedir/createdmodseq.tmp";
+    $self->{instance}->run_command(
+        {
+            cyrus => 1,
+            redirects => { stdout => $outfile },
+        },
+        'squatter', '--highest-createdmodseq', '-u', 'cassandane'
+    );
+
+    open(my $fh, '<', $outfile) or die "Cannot open $outfile: $!";
+    my $line = <$fh>;
+    close($fh);
+    chomp $line;
+
+    my (undef, $highest_createdmodseq, $index_generation) = split / /, $line;
+
+    return ($highest_createdmodseq, $index_generation);
+}
+
+sub test_squatter_createdmodseq
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "Create mailboxes";
+    $talk->create("A") || die;
+    $talk->create("B") || die;
+    $talk->create("C") || die;
+
+    xlog $self, "Create message in mailbox A";
+    my $createdmodseqA = $self->create_message_in_mailbox("A");
+
+    xlog $self, "Index all mailboxes (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    my ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqA, $highest_createdmodseq);
+
+    xlog $self, "Create message in mailbox A";
+    $createdmodseqA = $self->create_message_in_mailbox("A");
+
+    xlog $self, "Index all mailboxes (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    my $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqA, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Create message in mailbox B, then C";
+    my $createdmodseqB = $self->create_message_in_mailbox("B");
+    my $createdmodseqC = $self->create_message_in_mailbox("C");
+    $self->assert($createdmodseqB < $createdmodseqC);
+
+    xlog $self, "Index mailbox C (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', 'user.cassandane.C');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqC, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Index mailbox B (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', 'user.cassandane.B');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqC, $highest_createdmodseq);
+    $self->assert_num_not_equals($prev_index_generation, $index_generation);
+
+    xlog "Compact index to t2 tier";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-z', 't2', '-t', 't1');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqC, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Create message in mailbox A";
+    $createdmodseqA = $self->create_message_in_mailbox("A");
+
+    xlog $self, "Index mailbox A (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', 'user.cassandane.A');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqA, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Compact t2 to t3 tier, while t1 stays on top";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-z', 't3', '-t', 't2');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqA, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+}
+
+sub test_squatter_createdmodseq_partials
+    :SearchAttachmentExtractor :NoCheckSyslog
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    my $extractor_url = URI->new($self->{instance}->{config}->get('search_attachment_extractor_url'));
+
+    xlog "Start extractor server";
+    # This extractor server fails for the first index attempt,
+    # then returns "hellofromextractor" for any following requests.
+    my $nrequests = 0;
+    my $handler = sub ($conn, $req) {
+        if ($req->method eq 'HEAD') {
+            my $res = HTTP::Response->new(204);
+            $res->content("");
+            $conn->send_response($res);
+        } else {
+            $nrequests++;
+            if ($nrequests <= 4) {
+                # attach1: squatter sends GET and retries PUT 3 times
+                $conn->send_error(500);
+            } else {
+                my $res = HTTP::Response->new(200);
+                $res->content("hellofromextractor");
+                $conn->send_response($res);
+            }
+        }
+    };
+    $self->{instance}->start_httpd($handler, $extractor_url->port());
+
+    xlog $self, "Create message";
+    my $createdmodseq = $self->create_message_in_mailbox("INBOX");
+
+    xlog $self, "Index all mailboxes (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    my ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseq, $highest_createdmodseq);
+
+    $createdmodseq = $self->create_message_in_mailbox("INBOX", {
+        subject => "partialmsg",
+        args => {
+            mime_type => "multipart/related",
+            mime_boundary => "123456789abcdef",
+            body => ""
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: text/plain\r\n"
+            ."\r\n"
+            ."plaintext"
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: application/pdf\r\n"
+            ."\r\n"
+            ."attachment"
+            ."\r\n--123456789abcdef--\r\n"
+        },
+    });
+
+    xlog $self, "Index all mailboxes (incremental, allow partials)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', '-p');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    my $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseq, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+
+    xlog "Assert attachment is not indexed";
+    my $uids = $talk->search('fuzzy', 'xattachmentbody', 'hellofromextractor');
+    $self->assert_num_equals(0, scalar @{$uids});
+
+    xlog $self, "Create message";
+    $createdmodseq = $self->create_message_in_mailbox("INBOX");
+
+    xlog $self, "Index all mailboxes (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseq, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Reindex partial messages (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', '-P');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseq, $highest_createdmodseq);
+    $self->assert_num_not_equals($prev_index_generation, $index_generation);
+
+    xlog "Assert attachment is indexed";
+    $uids = $talk->search('fuzzy', 'xattachmentbody', 'hellofromextractor');
+    $self->assert_num_not_equals(0, scalar @{$uids});
+}
+
+sub test_squatter_createdmodseq_reindex
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "Create mailboxes";
+    $talk->create("A") || die;
+    $talk->create("B") || die;
+
+    xlog $self, "Create message in mailbox A, then B";
+    my $createdmodseqA = $self->create_message_in_mailbox("A");
+    my $createdmodseqB = $self->create_message_in_mailbox("B");
+    $self->assert($createdmodseqA < $createdmodseqB);
+
+    xlog $self, "Index mailbox B (incremental)";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', 'user.cassandane.B');
+
+    xlog $self, "Assert createdmodseq in squatter";
+    my ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqB, $highest_createdmodseq);
+    $self->assert_num_not_equals(0, $index_generation);
+
+    xlog $self, "Index mailbox A (incremental), which back-dates the index";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i', 'user.cassandane.A');
+
+    xlog $self, "Assert the index generation changed";
+    my $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqB, $highest_createdmodseq);
+    $self->assert_num_not_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Index mailbox A (not incremental), re-adding its messages";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', 'user.cassandane.A');
+
+    xlog $self, "Assert the index generation changed";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqB, $highest_createdmodseq);
+    $self->assert_num_not_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Compact to tier t2 without reindexing";
+    $self->{instance}->run_command({cyrus => 1},
+        'squatter', '-z', 't2', '-t', 't1');
+
+    xlog $self, "Assert highest createdmodseq and index generation are unchanged";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqB, $highest_createdmodseq);
+    $self->assert_num_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Compact back to tier t1 with reindexing";
+    $self->{instance}->run_command({cyrus => 1},
+        'squatter', '-z', 't1', '-t', 't2', '-T', 't2');
+
+    xlog $self, "Assert the index generation changed";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqB, $highest_createdmodseq);
+    $self->assert_num_not_equals($prev_index_generation, $index_generation);
+
+    xlog $self, "Compact to tier t2 with reindexing again";
+    $self->{instance}->run_command({cyrus => 1},
+        'squatter', '-z', 't2', '-t', 't1', '-T', 't1');
+
+    xlog $self, "Assert consecutive reindexes get distinct generations";
+    $prev_index_generation = $index_generation;
+    ($highest_createdmodseq, $index_generation) = $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseqB, $highest_createdmodseq);
+    $self->assert_num_not_equals($prev_index_generation, $index_generation);
+}

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_createdmodseq
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_createdmodseq
@@ -360,3 +360,50 @@ sub test_squatter_createdmodseq_reindex
     $self->assert_num_equals($createdmodseqB, $highest_createdmodseq);
     $self->assert_num_not_equals($prev_index_generation, $index_generation);
 }
+
+sub test_squatter_createdmodseq_failed_msg
+    :SearchAttachmentExtractor :NoCheckSyslog
+    ($self)
+{
+    xlog $self, "Start an extractor that fails for our attachment";
+    $self->start_echo_extractor(fail_content => qr/badattachment/);
+
+    xlog $self, "Create a plain text message, then one with an attachment that fails to index";
+    my $createdmodseq = $self->create_message_in_mailbox("INBOX",
+        { subject => "plainmsg" });
+    my $failed_createdmodseq = $self->create_message_in_mailbox("INBOX", {
+        subject => "failmsg",
+        args => {
+            mime_type => "multipart/related",
+            mime_boundary => "123456789abcdef",
+            body => ""
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: text/plain\r\n"
+            ."\r\n"
+            ."plaintext"
+            ."\r\n--123456789abcdef\r\n"
+            ."Content-Type: application/pdf\r\n"
+            ."\r\n"
+            ."badattachment"
+            ."\r\n--123456789abcdef--\r\n",
+        },
+    });
+    $self->assert_num_lt($failed_createdmodseq, $createdmodseq);
+
+    xlog $self, "Index all mailboxes (incremental)";
+    # Indexing stops at the message that fails, so squatter reports failure.
+    my $failed = 0;
+    $self->{instance}->run_command({
+        cyrus => 1,
+        handlers => {
+            exited_abnormally => sub { $failed = 1; return 0; },
+        },
+    }, 'squatter', '-i');
+    $self->assert_num_equals(1, $failed);
+
+    # A message that fails to index must not advance the highest createdmodseq.
+    xlog $self, "Assert the highest createdmodseq covers the plain text message only";
+    my ($highest_createdmodseq, $index_generation) =
+        $self->get_squatter_createdmodseq;
+    $self->assert_num_equals($createdmodseq, $highest_createdmodseq);
+}

--- a/changes/next/cyr-2833-search-highest-createdmodseq
+++ b/changes/next/cyr-2833-search-highest-createdmodseq
@@ -1,0 +1,28 @@
+Description:
+
+Squatter now stores the highest createdmodseq of all indexed messages
+for Xapian search backends. This is to avoid a race conditions between
+squatter and JMAP Email/queryChanges requests. This does not apply to
+the squat backend.
+
+Documentation:
+
+None
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+Rolling squatters will automatically set the highest createdmodseq for
+newly indexed messages. It does not verify that the createdmodseq for any
+messages that already was indexed indeed is lower than that. Installations
+that once fully built their index and then updated it with rolling squatters
+do not need to take any action. Other installations may consider rebuilding
+their search index if they want to avoid inconsistent Email/queryChanges
+results.
+
+GitHub issue:
+
+None

--- a/docsrc/reference/manpages/systemcommands/squatter.rst
+++ b/docsrc/reference/manpages/systemcommands/squatter.rst
@@ -141,6 +141,22 @@ Options
     Audits the specified mailboxes (or all), reports any unindexed messages.
     |master-new-feature|
 
+.. option:: --attachextract-cache-dir=directory
+
+    Cache the text extracted from attachments in this directory. Before
+    extracting text from an attachment, squatter first looks it up in the
+    cache and only calls the extractor on a cache miss, storing the newly
+    extracted text in the cache.
+    This option is experimental.
+
+.. option:: --attachextract-cache-only
+
+    Only extract attachment text from the cache (see
+    **--attachextract-cache-dir**). Attachments that have no cached text
+    are handled as if text extraction failed for them (also see
+    **--allow-partials**).
+    This option is experimental.
+
 .. option:: -d, --nodaemon
 
     In rolling mode, don't background and do emit log messages on

--- a/docsrc/reference/manpages/systemcommands/squatter.rst
+++ b/docsrc/reference/manpages/systemcommands/squatter.rst
@@ -187,6 +187,13 @@ Options
 
     Display this usage information.
 
+.. option:: --highest-createdmodseq
+
+    For each of the users named in the arguments, print their user id
+    followed by the highest createdmodseq and the generation of their
+    search index. This option requires the **-u** switch.
+    This option is experimental.
+
 .. option:: -i, --incremental
 
     Incremental updates where indexes already exist.

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -408,8 +408,11 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
     }
 
     if (attachextract_cacheonly) {
-        xsyslog(LOG_DEBUG,
-                "cache-only flag is set, will not call extractor", NULL);
+        xsyslog_ev(LOG_DEBUG, "attachment text is not cached",
+                lf_s("guid", guidstr),
+                lf_s("type", axrec->type),
+                lf_s("subtype", axrec->subtype),
+                lf_s("cachefname", cachefname));
         r = IMAP_NOTFOUND;
         goto done;
     }

--- a/imap/index.c
+++ b/imap/index.c
@@ -5343,6 +5343,8 @@ MsgData **index_msgdata_load(struct index_state *state,
 
         /* useful for convupdates */
         cur->modseq = record.modseq;
+        /* required for JMAP Email/queryChanges */
+        cur->createdmodseq = record.createdmodseq;
 
         did_cache = did_env = did_conv = 0;
         tmpenv = NULL;
@@ -6059,9 +6061,6 @@ static int index_sort_compare_arrival(const void *v1, const void *v2)
     ret = md1->internaldate.tv_sec - md2->internaldate.tv_sec;
     if (ret) return ret;
 
-    ret = md1->createdmodseq - md2->createdmodseq;
-    if (ret) return ret;
-
     ret = md1->uid - md2->uid;
     if (ret) return ret;
 
@@ -6079,9 +6078,6 @@ static int index_sort_compare_reverse_arrival(const void *v1, const void *v2)
     int ret;
 
     ret = md2->internaldate.tv_sec - md1->internaldate.tv_sec;
-    if (ret) return ret;
-
-    ret = md2->createdmodseq - md1->createdmodseq;
     if (ret) return ret;
 
     ret = md1->uid - md2->uid;
@@ -6104,9 +6100,6 @@ static int index_sort_compare_reverse_flagged(const void *v1, const void *v2)
     if (ret) return ret;
 
     ret = md2->internaldate.tv_sec - md1->internaldate.tv_sec;
-    if (ret) return ret;
-
-    ret = md2->createdmodseq - md1->createdmodseq;
     if (ret) return ret;
 
     ret = md1->uid - md2->uid;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4039,6 +4039,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     }
 
     search_builder_t *bx = NULL;
+    search_session_t *session = NULL;
     struct mailbox *mbox = NULL;
     mbname_t *mbname = mbname_from_userid(req->accountid);
 
@@ -4050,7 +4051,8 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     }
     if (r) goto done;
 
-    bx = search_begin_search(mbox, 0);
+    session = search_begin_session(mbox, 0);
+    bx = search_begin_search(session);
     if (!bx) {
         syslog(LOG_ERR, "jmap: %s: can't begin search for %s",
                 __func__,  mailbox_name(mbox));
@@ -4209,6 +4211,7 @@ done:
     mailbox_close(&mbox);
     mbname_free(&mbname);
     if (bx) search_end_search(bx);
+    search_end_session(session);
     return r;
 }
 
@@ -6031,19 +6034,26 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
     free(qmboxname);
     if (r) goto done;
 
-    bx = search_begin_search(state->mailbox, SEARCH_MULTIPLE);
+    search_session_t *session =
+        search_begin_session(state->mailbox, SEARCH_MULTIPLE);
+    bx = search_begin_search(session);
     if (!bx) {
         r = IMAP_INTERNAL;
+        search_end_session(session);
         goto done;
     }
 
     search_build_query(bx, searchargs->root);
     if (!bx->get_internalised) {
         r = IMAP_INTERNAL;
+        search_end_search(bx);
+        search_end_session(session);
         goto done;
     }
     intquery = bx->get_internalised(bx);
     search_end_search(bx);
+    bx = NULL;
+    search_end_session(session);
     if (!intquery) {
         r = IMAP_INTERNAL;
         goto done;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6096,11 +6096,13 @@ static int _snippet_tr_end_message(search_text_receiver_t *rx, uint8_t indexleve
         sr->next->end_message(sr->next, indexlevel) : 0;
 }
 
-static int _snippet_tr_end_mailbox(search_text_receiver_t *rx, struct mailbox *mailbox)
+static int _snippet_tr_end_mailbox(search_text_receiver_t *rx,
+                                   struct mailbox *mailbox,
+                                   bool has_more)
 {
     struct snippet_receiver *sr = (struct snippet_receiver*) rx;
     return sr->next->end_mailbox ?
-        sr->next->end_mailbox(sr->next, mailbox) : 0;
+        sr->next->end_mailbox(sr->next, mailbox, has_more) : 0;
 }
 
 static int _snippet_tr_flush(search_text_receiver_t *rx)
@@ -6289,7 +6291,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
             json_array_append_new(*snippets, json_deep_copy(snippet));
             r = 0;
         }
-        int r2 = srx->end_mailbox(srx, mbox);
+        int r2 = srx->end_mailbox(srx, mbox, /*has_more*/false);
         if (!r) r = r2;
 
         json_object_clear(snippet);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3168,6 +3168,8 @@ struct emailquery_result {
     int is_guidsearch;
     int is_imapfoldersearch;
     int never_matches;
+    modseq_t highest_createdmodseq;
+    uint64_t index_generation;
     size_t total_ceiling;
 
     void(*ensure)(struct emailquery *q, struct emailquery_cache *qc, size_t n);
@@ -3207,7 +3209,9 @@ static void jmap_emailquery_fini(struct emailquery *q)
 
 static char *_email_make_querystate(jmap_req_t *req,
                                     modseq_t modseq, uint32_t uid,
-                                    modseq_t addrbook_modseq)
+                                    modseq_t addrbook_modseq,
+                                    modseq_t highest_createdmodseq,
+                                    uint64_t index_generation)
 {
     struct buf buf = BUF_INITIALIZER;
 
@@ -3219,12 +3223,18 @@ static char *_email_make_querystate(jmap_req_t *req,
     if (addrbook_modseq) {
         buf_printf(&buf, ",addrbook:" MODSEQ_FMT, addrbook_modseq);
     }
+    if (highest_createdmodseq) {
+        buf_printf(&buf, ",fts:" MODSEQ_FMT ":" UINT64_FMT,
+                highest_createdmodseq, index_generation);
+    }
     return buf_release(&buf);
 }
 
 static int _email_read_querystate(jmap_req_t *req, const char *s,
                                   modseq_t *modseq, uint32_t *uid,
-                                  modseq_t *addrbook_modseq)
+                                  modseq_t *addrbook_modseq,
+                                  modseq_t *highest_createdmodseq,
+                                  uint64_t *index_generation)
 {
     char sentinel = 0;
 
@@ -3234,15 +3244,29 @@ static int _email_read_querystate(jmap_req_t *req, const char *s,
 
     /* Parse mailbox modseq and uid */
     int n = sscanf(s, MODSEQ_FMT ":%u%c", modseq, uid, &sentinel);
-    if (n <= 2) return n == 2;
-    else if (sentinel != ',') return 0;
+    if (n != 2 && n != 3) return 0;
+    if (n == 3 && sentinel != ',') return 0;
 
-    /* Parse addrbook modseq */
-    s = strchr(s, ',') + 1;
-    if (strncmp(s, "addrbook:", 9)) return 0;
-    s += 9;
-    n = sscanf(s, MODSEQ_FMT "%c", addrbook_modseq, &sentinel);
-    if (n != 1) return 0;
+    /* Parse optional comma-separated suffixes in any order */
+    s = strchr(s, ',');
+    while (s) {
+        s++; /* skip ',' */
+        if (!strncmp(s, "addrbook:", 9)) {
+            s += 9;
+            n = sscanf(s, MODSEQ_FMT "%c", addrbook_modseq, &sentinel);
+            if (n != 1 && n != 2) return 0;
+            if (n == 2 && sentinel != ',') return 0;
+        }
+        else if (!strncmp(s, "fts:", 4)) {
+            s += 4;
+            n = sscanf(s, MODSEQ_FMT ":" UINT64_FMT "%c",
+                    highest_createdmodseq, index_generation, &sentinel);
+            if (n != 2 && n != 3) return 0;
+            if (n == 3 && sentinel != ',') return 0;
+        }
+        else return 0;
+        s = strchr(s, ',');
+    }
 
     /* Parsed successfully */
     return 1;
@@ -3917,6 +3941,8 @@ struct guidsearch_query {
     struct guidsearch_match *matches;
     size_t total;
     size_t collapsed_len;
+    modseq_t highest_createdmodseq;
+    uint64_t index_generation;
 };
 
 static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
@@ -4051,29 +4077,6 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     }
     if (r) goto done;
 
-    session = search_begin_session(mbox, 0);
-    bx = search_begin_search(session);
-    if (!bx) {
-        syslog(LOG_ERR, "jmap: %s: can't begin search for %s",
-                __func__,  mailbox_name(mbox));
-        r = IMAP_INTERNAL;
-        goto done;
-    }
-
-    // Check the required index version.
-    if (need_xapian_index_version > 0) {
-        if (!bx->min_index_version ||
-            bx->min_index_version(bx) < need_xapian_index_version) {
-            xsyslog(LOG_DEBUG,
-                    "xapian index version is less than required minimum"
-                    "for this query - falling back to uidsearch",
-                    "need_xapian_index_version=<%d>",
-                    need_xapian_index_version);
-            r = IMAP_SEARCH_NOT_SUPPORTED;
-            goto done;
-        }
-    }
-
     /* Determine readable folders for userid */
     uint32_t numfolders = conversations_num_folders(req->cstate);
     bv_setsize(&gsq->readable_folders, numfolders);
@@ -4126,7 +4129,8 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         free_hash_table(&foldernum_by_mboxname, NULL);
     }
 
-    // replace cache-backed message-id attributes with Xapian-backed ones
+    // Xapian-backed message-id attributes, swapped into the expression
+    // tree below once we are committed to running guidsearch
     static search_attr_t xapian_messageid_attr = {
         "xapian-messageid",
         SEA_FUZZABLE,
@@ -4181,6 +4185,40 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         NULL
     };
 
+    /* Open search session - this takes a read-lock on the index */
+    session = search_begin_session(mbox, 0);
+
+    /* Read highest createdmodseq and index generation from session */
+    gsq->highest_createdmodseq =
+        search_session_get_highest_createdmodseq(session, &gsq->index_generation);
+
+    /* Prepare query */
+    bx = search_begin_search(session);
+    if (!bx) {
+        syslog(LOG_ERR, "jmap: %s: can't begin search for %s",
+                __func__,  mailbox_name(mbox));
+        r = IMAP_INTERNAL;
+        goto done;
+    }
+
+    // Check the required index version.
+    if (need_xapian_index_version > 0) {
+        if (!bx->min_index_version ||
+            bx->min_index_version(bx) < need_xapian_index_version) {
+            xsyslog(LOG_DEBUG,
+                    "xapian index version is less than required minimum"
+                    "for this query - falling back to uidsearch",
+                    "need_xapian_index_version=<%d>",
+                    need_xapian_index_version);
+            r = IMAP_SEARCH_NOT_SUPPORTED;
+            goto done;
+        }
+    }
+
+    /* Replace the cache-backed message-id attributes in the expression
+     * tree with the Xapian-backed ones declared above. This mutates the
+     * expression in place, so it must only happen once we are sure not
+     * to fall back to uidsearch, which expects the original attributes. */
     ptrarray_t exprs = PTRARRAY_INITIALIZER;
     ptrarray_push(&exprs, search->expr_orig);
     search_expr_t *e;
@@ -4279,11 +4317,16 @@ static int emailquery_guidsearch(jmap_req_t *req,
         NULL,
         0,
         0,
+        0,
+        0,
         0
     };
 
     int r = guidsearch_run(req, search, &gsq);
     if (r) return r;
+
+    qr->highest_createdmodseq = gsq.highest_createdmodseq;
+    qr->index_generation = gsq.index_generation;
 
     guidsearch_sort(req, search->sort, &gsq);
 
@@ -4336,6 +4379,12 @@ static void emailquery_uidsearch_result_ensure(struct emailquery *q, struct emai
         /* Skip expunged or hidden messages */
         if (md->system_flags & FLAG_DELETED ||
             md->internal_flags & FLAG_INTERNAL_EXPUNGED)
+            continue;
+
+        /* For Xapian-based queries, ignore messages having a higher
+         * created modseq than the highest createdmodseq of the index */
+        if (qc->qr.highest_createdmodseq &&
+                md->createdmodseq > qc->qr.highest_createdmodseq)
             continue;
 
         /* Is there another copy of this message with a targeted savedate? */
@@ -4442,6 +4491,10 @@ static int emailquery_uidsearch(jmap_req_t *req,
         return r;
     }
     if (search->never_matches) return 0;
+
+    // Read highest created modseq and index generation for Xapian queries.
+    qr->highest_createdmodseq = search->query->highest_createdmodseq;
+    qr->index_generation = search->query->index_generation;
     if (!search->query->merged_msgdata.count) return 0;
 
     struct emailquery_uidsearch_result_rock *rrock =
@@ -4818,9 +4871,10 @@ static void emailquery_buildresult(struct emailquery *q,
 }
 
 static void emailquery_fingerprint(struct buf *fingerprint,
-                                   const char *accountid,
                                    const char *userid,
-                                   const char *querystate,
+                                   const char *accountid,
+                                   modseq_t modseq,
+                                   modseq_t addrbook_modseq,
                                    struct emailquery *q)
 
 {
@@ -4835,7 +4889,10 @@ static void emailquery_fingerprint(struct buf *fingerprint,
     buf_putc(fingerprint, '>');
 
     buf_putc(fingerprint, '<');
-    buf_appendcstr(fingerprint, querystate);
+    buf_printf(fingerprint, MODSEQ_FMT, modseq);
+    if (addrbook_modseq) {
+        buf_printf(fingerprint, ",addrbook:" MODSEQ_FMT, addrbook_modseq);
+    }
     buf_putc(fingerprint, '>');
 
     if (JNOTNULL(q->super.filter)) {
@@ -4902,10 +4959,11 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
     modseq_t addrbook_modseq = contactgroups->size ?
         jmap_modseq(req, MBTYPE_ADDRESSBOOK, 0) : 0;
-    char *querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
+    char *querystate = NULL;
 
     struct buf fingerprint = BUF_INITIALIZER;
-    emailquery_fingerprint(&fingerprint, req->userid, req->accountid, querystate, q);
+    emailquery_fingerprint(&fingerprint, req->userid, req->accountid,
+                           modseq, addrbook_modseq, q);
 
     /* Try to reuse cached query result */
     int is_cached;
@@ -4933,6 +4991,13 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     emailquery_buildresult(q, &emailquery_cache, errp);
     if (*errp) goto done;
     q->super.can_calculate_changes = emailquery_cache.qr.is_mutable;
+
+    /* Build the querystate. Use the highest createdmodseq and index
+     * generation of the cached result, so we can compare them against
+     * the index state in later queryChanges requests. */
+    querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq,
+            emailquery_cache.qr.highest_createdmodseq,
+            emailquery_cache.qr.index_generation);
     q->super.query_state = xstrdupnull(querystate);
 
     if (jmap_is_using(req, JMAP_PERFORMANCE_EXTENSION)) {
@@ -5081,11 +5146,15 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     uint32_t since_uid;
     uint32_t num_changes = 0;
     modseq_t addrbook_modseq = 0;
+    modseq_t since_highest_createdmodseq = 0;
+    uint64_t since_index_generation = 0;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
                                 &since_modseq, &since_uid,
-                                &addrbook_modseq)) {
+                                &addrbook_modseq,
+                                &since_highest_createdmodseq,
+                                &since_index_generation)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "invalid query state");
         return;
@@ -5114,6 +5183,22 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     /* Run search */
     r = emailsearch_run_uidsearch(req, &search);
     if (r) goto done;
+
+    /* Determine highest createdmodseq for any message to report changes
+     * for. Also match index generation of query state and result. */
+    modseq_t highest_createdmodseq =
+            search.never_matches ? 0 : search.query->highest_createdmodseq;
+    uint64_t index_generation =
+            search.never_matches ? 0 : search.query->index_generation;
+    if (since_highest_createdmodseq || highest_createdmodseq) {
+        if (!since_highest_createdmodseq || !highest_createdmodseq ||
+                since_index_generation != index_generation ||
+                highest_createdmodseq < since_highest_createdmodseq) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search index changed");
+            goto done;
+        }
+    }
 
     /* Prepare result loop */
     const ptrarray_t *msgdata = search.never_matches ? &empty_ptrarray : &search.query->merged_msgdata;
@@ -5148,8 +5233,18 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
 
+        // ignore messages the indexer hasn't caught up with.
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
+
+        // determine if this message only became visible to the
+        // search index after the last query
+        bool is_newly_indexed = since_highest_createdmodseq &&
+                md->createdmodseq > since_highest_createdmodseq;
+
         // for this phase, we only care that it has a change
-        if (md->modseq <= since_modseq) {
+        if (md->modseq <= since_modseq && !is_newly_indexed) {
             if (search.is_mutable) {
                 modseq_t modseq = md->convmodseq;
                 if (!modseq) conversation_get_modseq(req->cstate, md->cid, &modseq);
@@ -5169,6 +5264,11 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     // phase 2: report messages that need it
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
+
+        /* Drop messages the indexer hasn't caught up with. */
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
 
         jmap_set_emailid(req->cstate, &md->guid,
                          0, &md->internaldate, email_id);
@@ -5277,7 +5377,8 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     free_hashu64_table(&touched_cids, NULL);
 
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
+    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq,
+            highest_createdmodseq, index_generation);
 
 done:
     if (r && *err == NULL) {
@@ -5299,11 +5400,15 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     uint32_t since_uid;
     uint32_t num_changes = 0;
     modseq_t addrbook_modseq = 0;
+    modseq_t since_highest_createdmodseq = 0;
+    uint64_t since_index_generation = 0;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
                                 &since_modseq, &since_uid,
-                                &addrbook_modseq)) {
+                                &addrbook_modseq,
+                                &since_highest_createdmodseq,
+                                &since_index_generation)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "invalid query state");
         return;
@@ -5332,6 +5437,22 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     r = emailsearch_run_uidsearch(req, &search);
     if (r) goto done;
 
+    /* Determine highest createdmodseq for any message to report changes
+     * for. Also match index generation of query state and result. */
+    modseq_t highest_createdmodseq =
+            search.never_matches ? 0 : search.query->highest_createdmodseq;
+    uint64_t index_generation =
+            search.never_matches ? 0 : search.query->index_generation;
+    if (since_highest_createdmodseq || highest_createdmodseq) {
+        if (!since_highest_createdmodseq || !highest_createdmodseq ||
+                since_index_generation != index_generation ||
+                highest_createdmodseq < since_highest_createdmodseq) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search index changed");
+            goto done;
+        }
+    }
+
     /* Prepare result loop */
     const ptrarray_t *msgdata = search.never_matches ? &empty_ptrarray : &search.query->merged_msgdata;
     char email_id[JMAP_MAX_EMAILID_SIZE];
@@ -5354,8 +5475,18 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
 
+        // ignore messages the indexer hasn't caught up with.
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
+
+        // determine if this message only became visible to the
+        // search index after the last query
+        bool is_newly_indexed = since_highest_createdmodseq &&
+                md->createdmodseq > since_highest_createdmodseq;
+
         // for this phase, we only care that it has a change
-        if (md->modseq <= since_modseq) continue;
+        if (md->modseq <= since_modseq && !is_newly_indexed) continue;
 
         jmap_set_emailid(req->cstate, &md->guid,
                          0, &md->internaldate, email_id);
@@ -5366,6 +5497,16 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     // phase 2: report messages that need it
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
+
+        // ignore messages the indexer hasn't caught up with.
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
+
+        // determine if this message only became visible to the
+        // search index after the last query
+        bool is_newly_indexed = since_highest_createdmodseq &&
+                md->createdmodseq > since_highest_createdmodseq;
 
         jmap_set_emailid(req->cstate, &md->guid,
                          0, &md->internaldate, email_id);
@@ -5402,7 +5543,8 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
 
         // if it's changed, tell about that
         if ((touched_id & 1)) {
-            if (!search.is_mutable && touched_id == 1 && md->modseq <= since_modseq) {
+            if (!search.is_mutable && touched_id == 1 &&
+                    md->modseq <= since_modseq && !is_newly_indexed) {
                 // this is the exemplar, and it's unchanged,
                 // and we haven't told a removed yet, so we
                 // can just suppress everything
@@ -5442,7 +5584,8 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     free_hash_table(&touched_ids, NULL);
 
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
+    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq,
+            highest_createdmodseq, index_generation);
 
 done:
     if (r && *err == NULL) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5194,6 +5194,13 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
         if (!since_highest_createdmodseq || !highest_createdmodseq ||
                 since_index_generation != index_generation ||
                 highest_createdmodseq < since_highest_createdmodseq) {
+            xsyslog_ev(LOG_INFO, "cannot calculate changes: search index changed",
+                    lf_s("accountid", req->accountid),
+                    lf_llu("since_highest_createdmodseq",
+                        since_highest_createdmodseq),
+                    lf_llu("since_index_generation", since_index_generation),
+                    lf_llu("highest_createdmodseq", highest_createdmodseq),
+                    lf_llu("index_generation", index_generation));
             *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                           "description", "search index changed");
             goto done;
@@ -5447,6 +5454,13 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
         if (!since_highest_createdmodseq || !highest_createdmodseq ||
                 since_index_generation != index_generation ||
                 highest_createdmodseq < since_highest_createdmodseq) {
+            xsyslog_ev(LOG_INFO, "cannot calculate changes: search index changed",
+                    lf_s("accountid", req->accountid),
+                    lf_llu("since_highest_createdmodseq",
+                        since_highest_createdmodseq),
+                    lf_llu("since_index_generation", since_index_generation),
+                    lf_llu("highest_createdmodseq", highest_createdmodseq),
+                    lf_llu("index_generation", index_generation));
             *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                           "description", "search index changed");
             goto done;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6146,12 +6146,11 @@ static int _snippet_tr_end_message(search_text_receiver_t *rx, uint8_t indexleve
 }
 
 static int _snippet_tr_end_mailbox(search_text_receiver_t *rx,
-                                   struct mailbox *mailbox,
-                                   bool has_more)
+                                   struct mailbox *mailbox)
 {
     struct snippet_receiver *sr = (struct snippet_receiver*) rx;
     return sr->next->end_mailbox ?
-        sr->next->end_mailbox(sr->next, mailbox, has_more) : 0;
+        sr->next->end_mailbox(sr->next, mailbox) : 0;
 }
 
 static int _snippet_tr_flush(search_text_receiver_t *rx)
@@ -6340,7 +6339,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
             json_array_append_new(*snippets, json_deep_copy(snippet));
             r = 0;
         }
-        int r2 = srx->end_mailbox(srx, mbox, /*has_more*/false);
+        int r2 = srx->end_mailbox(srx, mbox);
         if (!r) r = r2;
 
         json_object_clear(snippet);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4039,6 +4039,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     }
 
     search_builder_t *bx = NULL;
+    search_session_t *session = NULL;
     struct mailbox *mbox = NULL;
     mbname_t *mbname = mbname_from_userid(req->accountid);
 
@@ -4050,7 +4051,8 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     }
     if (r) goto done;
 
-    bx = search_begin_search(mbox, 0);
+    session = search_begin_session(mbox, 0);
+    bx = search_begin_search(session);
     if (!bx) {
         syslog(LOG_ERR, "jmap: %s: can't begin search for %s",
                 __func__,  mailbox_name(mbox));
@@ -4209,6 +4211,7 @@ done:
     mailbox_close(&mbox);
     mbname_free(&mbname);
     if (bx) search_end_search(bx);
+    search_end_session(session);
     return r;
 }
 
@@ -6080,19 +6083,26 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
     free(qmboxname);
     if (r) goto done;
 
-    bx = search_begin_search(state->mailbox, SEARCH_MULTIPLE);
+    search_session_t *session =
+        search_begin_session(state->mailbox, SEARCH_MULTIPLE);
+    bx = search_begin_search(session);
     if (!bx) {
         r = IMAP_INTERNAL;
+        search_end_session(session);
         goto done;
     }
 
     search_build_query(bx, searchargs->root);
     if (!bx->get_internalised) {
         r = IMAP_INTERNAL;
+        search_end_search(bx);
+        search_end_session(session);
         goto done;
     }
     intquery = bx->get_internalised(bx);
     search_end_search(bx);
+    bx = NULL;
+    search_end_session(session);
     if (!intquery) {
         r = IMAP_INTERNAL;
         goto done;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6097,12 +6097,11 @@ static int _snippet_tr_end_message(search_text_receiver_t *rx, uint8_t indexleve
 }
 
 static int _snippet_tr_end_mailbox(search_text_receiver_t *rx,
-                                   struct mailbox *mailbox,
-                                   bool has_more)
+                                   struct mailbox *mailbox)
 {
     struct snippet_receiver *sr = (struct snippet_receiver*) rx;
     return sr->next->end_mailbox ?
-        sr->next->end_mailbox(sr->next, mailbox, has_more) : 0;
+        sr->next->end_mailbox(sr->next, mailbox) : 0;
 }
 
 static int _snippet_tr_flush(search_text_receiver_t *rx)
@@ -6291,7 +6290,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
             json_array_append_new(*snippets, json_deep_copy(snippet));
             r = 0;
         }
-        int r2 = srx->end_mailbox(srx, mbox, /*has_more*/false);
+        int r2 = srx->end_mailbox(srx, mbox);
         if (!r) r = r2;
 
         json_object_clear(snippet);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5195,6 +5195,13 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
         if (!since_highest_createdmodseq || !highest_createdmodseq ||
                 since_index_generation != index_generation ||
                 highest_createdmodseq < since_highest_createdmodseq) {
+            xsyslog_ev(LOG_INFO, "cannot calculate changes: search index changed",
+                    lf_s("accountid", req->accountid),
+                    lf_llu("since_highest_createdmodseq",
+                        since_highest_createdmodseq),
+                    lf_llu("since_index_generation", since_index_generation),
+                    lf_llu("highest_createdmodseq", highest_createdmodseq),
+                    lf_llu("index_generation", index_generation));
             *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                           "description", "search index changed");
             goto done;
@@ -5448,6 +5455,13 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
         if (!since_highest_createdmodseq || !highest_createdmodseq ||
                 since_index_generation != index_generation ||
                 highest_createdmodseq < since_highest_createdmodseq) {
+            xsyslog_ev(LOG_INFO, "cannot calculate changes: search index changed",
+                    lf_s("accountid", req->accountid),
+                    lf_llu("since_highest_createdmodseq",
+                        since_highest_createdmodseq),
+                    lf_llu("since_index_generation", since_index_generation),
+                    lf_llu("highest_createdmodseq", highest_createdmodseq),
+                    lf_llu("index_generation", index_generation));
             *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                           "description", "search index changed");
             goto done;

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3168,6 +3168,8 @@ struct emailquery_result {
     int is_guidsearch;
     int is_imapfoldersearch;
     int never_matches;
+    modseq_t highest_createdmodseq;
+    uint64_t index_generation;
     size_t total_ceiling;
 
     void(*ensure)(struct emailquery *q, struct emailquery_cache *qc, size_t n);
@@ -3207,7 +3209,9 @@ static void jmap_emailquery_fini(struct emailquery *q)
 
 static char *_email_make_querystate(jmap_req_t *req,
                                     modseq_t modseq, uint32_t uid,
-                                    modseq_t addrbook_modseq)
+                                    modseq_t addrbook_modseq,
+                                    modseq_t highest_createdmodseq,
+                                    uint64_t index_generation)
 {
     struct buf buf = BUF_INITIALIZER;
 
@@ -3219,12 +3223,18 @@ static char *_email_make_querystate(jmap_req_t *req,
     if (addrbook_modseq) {
         buf_printf(&buf, ",addrbook:" MODSEQ_FMT, addrbook_modseq);
     }
+    if (highest_createdmodseq) {
+        buf_printf(&buf, ",fts:" MODSEQ_FMT ":" UINT64_FMT,
+                highest_createdmodseq, index_generation);
+    }
     return buf_release(&buf);
 }
 
 static int _email_read_querystate(jmap_req_t *req, const char *s,
                                   modseq_t *modseq, uint32_t *uid,
-                                  modseq_t *addrbook_modseq)
+                                  modseq_t *addrbook_modseq,
+                                  modseq_t *highest_createdmodseq,
+                                  uint64_t *index_generation)
 {
     char sentinel = 0;
 
@@ -3234,15 +3244,29 @@ static int _email_read_querystate(jmap_req_t *req, const char *s,
 
     /* Parse mailbox modseq and uid */
     int n = sscanf(s, MODSEQ_FMT ":%u%c", modseq, uid, &sentinel);
-    if (n <= 2) return n == 2;
-    else if (sentinel != ',') return 0;
+    if (n != 2 && n != 3) return 0;
+    if (n == 3 && sentinel != ',') return 0;
 
-    /* Parse addrbook modseq */
-    s = strchr(s, ',') + 1;
-    if (strncmp(s, "addrbook:", 9)) return 0;
-    s += 9;
-    n = sscanf(s, MODSEQ_FMT "%c", addrbook_modseq, &sentinel);
-    if (n != 1) return 0;
+    /* Parse optional comma-separated suffixes in any order */
+    s = strchr(s, ',');
+    while (s) {
+        s++; /* skip ',' */
+        if (!strncmp(s, "addrbook:", 9)) {
+            s += 9;
+            n = sscanf(s, MODSEQ_FMT "%c", addrbook_modseq, &sentinel);
+            if (n != 1 && n != 2) return 0;
+            if (n == 2 && sentinel != ',') return 0;
+        }
+        else if (!strncmp(s, "fts:", 4)) {
+            s += 4;
+            n = sscanf(s, MODSEQ_FMT ":" UINT64_FMT "%c",
+                    highest_createdmodseq, index_generation, &sentinel);
+            if (n != 2 && n != 3) return 0;
+            if (n == 3 && sentinel != ',') return 0;
+        }
+        else return 0;
+        s = strchr(s, ',');
+    }
 
     /* Parsed successfully */
     return 1;
@@ -3917,6 +3941,8 @@ struct guidsearch_query {
     struct guidsearch_match *matches;
     size_t total;
     size_t collapsed_len;
+    modseq_t highest_createdmodseq;
+    uint64_t index_generation;
 };
 
 static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
@@ -4051,29 +4077,6 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     }
     if (r) goto done;
 
-    session = search_begin_session(mbox, 0);
-    bx = search_begin_search(session);
-    if (!bx) {
-        syslog(LOG_ERR, "jmap: %s: can't begin search for %s",
-                __func__,  mailbox_name(mbox));
-        r = IMAP_INTERNAL;
-        goto done;
-    }
-
-    // Check the required index version.
-    if (need_xapian_index_version > 0) {
-        if (!bx->min_index_version ||
-            bx->min_index_version(bx) < need_xapian_index_version) {
-            xsyslog(LOG_DEBUG,
-                    "xapian index version is less than required minimum"
-                    "for this query - falling back to uidsearch",
-                    "need_xapian_index_version=<%d>",
-                    need_xapian_index_version);
-            r = IMAP_SEARCH_NOT_SUPPORTED;
-            goto done;
-        }
-    }
-
     /* Determine readable folders for userid */
     uint32_t numfolders = conversations_num_folders(req->cstate);
     bv_setsize(&gsq->readable_folders, numfolders);
@@ -4126,7 +4129,8 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         free_hash_table(&foldernum_by_mboxname, NULL);
     }
 
-    // replace cache-backed message-id attributes with Xapian-backed ones
+    // Xapian-backed message-id attributes, swapped into the expression
+    // tree below once we are committed to running guidsearch
     static search_attr_t xapian_messageid_attr = {
         "xapian-messageid",
         SEA_FUZZABLE,
@@ -4181,6 +4185,40 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         NULL
     };
 
+    /* Open search session - this takes a read-lock on the index */
+    session = search_begin_session(mbox, 0);
+
+    /* Read highest createdmodseq and index generation from session */
+    gsq->highest_createdmodseq =
+        search_session_get_highest_createdmodseq(session, &gsq->index_generation);
+
+    /* Prepare query */
+    bx = search_begin_search(session);
+    if (!bx) {
+        syslog(LOG_ERR, "jmap: %s: can't begin search for %s",
+                __func__,  mailbox_name(mbox));
+        r = IMAP_INTERNAL;
+        goto done;
+    }
+
+    // Check the required index version.
+    if (need_xapian_index_version > 0) {
+        if (!bx->min_index_version ||
+            bx->min_index_version(bx) < need_xapian_index_version) {
+            xsyslog(LOG_DEBUG,
+                    "xapian index version is less than required minimum"
+                    "for this query - falling back to uidsearch",
+                    "need_xapian_index_version=<%d>",
+                    need_xapian_index_version);
+            r = IMAP_SEARCH_NOT_SUPPORTED;
+            goto done;
+        }
+    }
+
+    /* Replace the cache-backed message-id attributes in the expression
+     * tree with the Xapian-backed ones declared above. This mutates the
+     * expression in place, so it must only happen once we are sure not
+     * to fall back to uidsearch, which expects the original attributes. */
     ptrarray_t exprs = PTRARRAY_INITIALIZER;
     ptrarray_push(&exprs, search->expr_orig);
     search_expr_t *e;
@@ -4279,11 +4317,16 @@ static int emailquery_guidsearch(jmap_req_t *req,
         NULL,
         0,
         0,
+        0,
+        0,
         0
     };
 
     int r = guidsearch_run(req, search, &gsq);
     if (r) return r;
+
+    qr->highest_createdmodseq = gsq.highest_createdmodseq;
+    qr->index_generation = gsq.index_generation;
 
     guidsearch_sort(req, search->sort, &gsq);
 
@@ -4336,6 +4379,12 @@ static void emailquery_uidsearch_result_ensure(struct emailquery *q, struct emai
         /* Skip expunged or hidden messages */
         if (md->system_flags & FLAG_DELETED ||
             md->internal_flags & FLAG_INTERNAL_EXPUNGED)
+            continue;
+
+        /* For Xapian-based queries, ignore messages having a higher
+         * created modseq than the highest createdmodseq of the index */
+        if (qc->qr.highest_createdmodseq &&
+                md->createdmodseq > qc->qr.highest_createdmodseq)
             continue;
 
         /* Is there another copy of this message with a targeted savedate? */
@@ -4442,6 +4491,10 @@ static int emailquery_uidsearch(jmap_req_t *req,
         return r;
     }
     if (search->never_matches) return 0;
+
+    // Read highest created modseq and index generation for Xapian queries.
+    qr->highest_createdmodseq = search->query->highest_createdmodseq;
+    qr->index_generation = search->query->index_generation;
     if (!search->query->merged_msgdata.count) return 0;
 
     struct emailquery_uidsearch_result_rock *rrock =
@@ -4819,9 +4872,10 @@ static void emailquery_buildresult(struct emailquery *q,
 }
 
 static void emailquery_fingerprint(struct buf *fingerprint,
-                                   const char *accountid,
                                    const char *userid,
-                                   const char *querystate,
+                                   const char *accountid,
+                                   modseq_t modseq,
+                                   modseq_t addrbook_modseq,
                                    struct emailquery *q)
 
 {
@@ -4836,7 +4890,10 @@ static void emailquery_fingerprint(struct buf *fingerprint,
     buf_putc(fingerprint, '>');
 
     buf_putc(fingerprint, '<');
-    buf_appendcstr(fingerprint, querystate);
+    buf_printf(fingerprint, MODSEQ_FMT, modseq);
+    if (addrbook_modseq) {
+        buf_printf(fingerprint, ",addrbook:" MODSEQ_FMT, addrbook_modseq);
+    }
     buf_putc(fingerprint, '>');
 
     if (JNOTNULL(q->super.filter)) {
@@ -4903,10 +4960,11 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
     modseq_t addrbook_modseq = contactgroups->size ?
         jmap_modseq(req, MBTYPE_ADDRESSBOOK, 0) : 0;
-    char *querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
+    char *querystate = NULL;
 
     struct buf fingerprint = BUF_INITIALIZER;
-    emailquery_fingerprint(&fingerprint, req->userid, req->accountid, querystate, q);
+    emailquery_fingerprint(&fingerprint, req->userid, req->accountid,
+                           modseq, addrbook_modseq, q);
 
     /* Try to reuse cached query result */
     int is_cached;
@@ -4934,6 +4992,13 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     emailquery_buildresult(q, &emailquery_cache, errp);
     if (*errp) goto done;
     q->super.can_calculate_changes = emailquery_cache.qr.is_mutable;
+
+    /* Build the querystate. Use the highest createdmodseq and index
+     * generation of the cached result, so we can compare them against
+     * the index state in later queryChanges requests. */
+    querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq,
+            emailquery_cache.qr.highest_createdmodseq,
+            emailquery_cache.qr.index_generation);
     q->super.query_state = xstrdupnull(querystate);
 
     if (jmap_is_using(req, JMAP_PERFORMANCE_EXTENSION)) {
@@ -5082,11 +5147,15 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     uint32_t since_uid;
     uint32_t num_changes = 0;
     modseq_t addrbook_modseq = 0;
+    modseq_t since_highest_createdmodseq = 0;
+    uint64_t since_index_generation = 0;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
                                 &since_modseq, &since_uid,
-                                &addrbook_modseq)) {
+                                &addrbook_modseq,
+                                &since_highest_createdmodseq,
+                                &since_index_generation)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "invalid query state");
         return;
@@ -5115,6 +5184,22 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     /* Run search */
     r = emailsearch_run_uidsearch(req, &search);
     if (r) goto done;
+
+    /* Determine highest createdmodseq for any message to report changes
+     * for. Also match index generation of query state and result. */
+    modseq_t highest_createdmodseq =
+            search.never_matches ? 0 : search.query->highest_createdmodseq;
+    uint64_t index_generation =
+            search.never_matches ? 0 : search.query->index_generation;
+    if (since_highest_createdmodseq || highest_createdmodseq) {
+        if (!since_highest_createdmodseq || !highest_createdmodseq ||
+                since_index_generation != index_generation ||
+                highest_createdmodseq < since_highest_createdmodseq) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search index changed");
+            goto done;
+        }
+    }
 
     /* Prepare result loop */
     const ptrarray_t *msgdata = search.never_matches ? &empty_ptrarray : &search.query->merged_msgdata;
@@ -5149,8 +5234,18 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
 
+        // ignore messages the indexer hasn't caught up with.
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
+
+        // determine if this message only became visible to the
+        // search index after the last query
+        bool is_newly_indexed = since_highest_createdmodseq &&
+                md->createdmodseq > since_highest_createdmodseq;
+
         // for this phase, we only care that it has a change
-        if (md->modseq <= since_modseq) {
+        if (md->modseq <= since_modseq && !is_newly_indexed) {
             if (search.is_mutable) {
                 modseq_t modseq = md->convmodseq;
                 if (!modseq) conversation_get_modseq(req->cstate, md->cid, &modseq);
@@ -5170,6 +5265,11 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     // phase 2: report messages that need it
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
+
+        /* Drop messages the indexer hasn't caught up with. */
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
 
         jmap_set_emailid(req->cstate, &md->guid,
                          0, &md->internaldate, email_id);
@@ -5278,7 +5378,8 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     free_hashu64_table(&touched_cids, NULL);
 
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
+    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq,
+            highest_createdmodseq, index_generation);
 
 done:
     if (r && *err == NULL) {
@@ -5300,11 +5401,15 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     uint32_t since_uid;
     uint32_t num_changes = 0;
     modseq_t addrbook_modseq = 0;
+    modseq_t since_highest_createdmodseq = 0;
+    uint64_t since_index_generation = 0;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
                                 &since_modseq, &since_uid,
-                                &addrbook_modseq)) {
+                                &addrbook_modseq,
+                                &since_highest_createdmodseq,
+                                &since_index_generation)) {
         *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                       "description", "invalid query state");
         return;
@@ -5333,6 +5438,22 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     r = emailsearch_run_uidsearch(req, &search);
     if (r) goto done;
 
+    /* Determine highest createdmodseq for any message to report changes
+     * for. Also match index generation of query state and result. */
+    modseq_t highest_createdmodseq =
+            search.never_matches ? 0 : search.query->highest_createdmodseq;
+    uint64_t index_generation =
+            search.never_matches ? 0 : search.query->index_generation;
+    if (since_highest_createdmodseq || highest_createdmodseq) {
+        if (!since_highest_createdmodseq || !highest_createdmodseq ||
+                since_index_generation != index_generation ||
+                highest_createdmodseq < since_highest_createdmodseq) {
+            *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                                          "description", "search index changed");
+            goto done;
+        }
+    }
+
     /* Prepare result loop */
     const ptrarray_t *msgdata = search.never_matches ? &empty_ptrarray : &search.query->merged_msgdata;
     char email_id[JMAP_MAX_EMAILID_SIZE];
@@ -5355,8 +5476,18 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
 
+        // ignore messages the indexer hasn't caught up with.
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
+
+        // determine if this message only became visible to the
+        // search index after the last query
+        bool is_newly_indexed = since_highest_createdmodseq &&
+                md->createdmodseq > since_highest_createdmodseq;
+
         // for this phase, we only care that it has a change
-        if (md->modseq <= since_modseq) continue;
+        if (md->modseq <= since_modseq && !is_newly_indexed) continue;
 
         jmap_set_emailid(req->cstate, &md->guid,
                          0, &md->internaldate, email_id);
@@ -5367,6 +5498,16 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     // phase 2: report messages that need it
     for (i = 0 ; i < mdcount; i++) {
         MsgData *md = ptrarray_nth(msgdata, i);
+
+        // ignore messages the indexer hasn't caught up with.
+        if (highest_createdmodseq &&
+                md->createdmodseq > highest_createdmodseq)
+            continue;
+
+        // determine if this message only became visible to the
+        // search index after the last query
+        bool is_newly_indexed = since_highest_createdmodseq &&
+                md->createdmodseq > since_highest_createdmodseq;
 
         jmap_set_emailid(req->cstate, &md->guid,
                          0, &md->internaldate, email_id);
@@ -5403,7 +5544,8 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
 
         // if it's changed, tell about that
         if ((touched_id & 1)) {
-            if (!search.is_mutable && touched_id == 1 && md->modseq <= since_modseq) {
+            if (!search.is_mutable && touched_id == 1 &&
+                    md->modseq <= since_modseq && !is_newly_indexed) {
                 // this is the exemplar, and it's unchanged,
                 // and we haven't told a removed yet, so we
                 // can just suppress everything
@@ -5443,7 +5585,8 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     free_hash_table(&touched_ids, NULL);
 
     modseq_t modseq = jmap_modseq(req, MBTYPE_EMAIL, 0);
-    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq);
+    query->new_querystate = _email_make_querystate(req, modseq, 0, addrbook_modseq,
+            highest_createdmodseq, index_generation);
 
 done:
     if (r && *err == NULL) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6145,11 +6145,13 @@ static int _snippet_tr_end_message(search_text_receiver_t *rx, uint8_t indexleve
         sr->next->end_message(sr->next, indexlevel) : 0;
 }
 
-static int _snippet_tr_end_mailbox(search_text_receiver_t *rx, struct mailbox *mailbox)
+static int _snippet_tr_end_mailbox(search_text_receiver_t *rx,
+                                   struct mailbox *mailbox,
+                                   bool has_more)
 {
     struct snippet_receiver *sr = (struct snippet_receiver*) rx;
     return sr->next->end_mailbox ?
-        sr->next->end_mailbox(sr->next, mailbox) : 0;
+        sr->next->end_mailbox(sr->next, mailbox, has_more) : 0;
 }
 
 static int _snippet_tr_flush(search_text_receiver_t *rx)
@@ -6338,7 +6340,7 @@ static int _snippet_get(jmap_req_t *req, json_t *filter,
             json_array_append_new(*snippets, json_deep_copy(snippet));
             r = 0;
         }
-        int r2 = srx->end_mailbox(srx, mbox);
+        int r2 = srx->end_mailbox(srx, mbox, /*has_more*/false);
         if (!r) r = r2;
 
         json_object_clear(snippet);

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -634,7 +634,8 @@ static int _matchmime_tr_end_message(search_text_receiver_t *rx, uint8_t indexle
 }
 
 static int _matchmime_tr_end_mailbox(search_text_receiver_t *rx __attribute__((unused)),
-                                     struct mailbox *mailbox __attribute__((unused)))
+                                     struct mailbox *mailbox __attribute__((unused)),
+                                     bool has_more __attribute__((unused)))
 {
     return 0;
 }

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -634,8 +634,7 @@ static int _matchmime_tr_end_message(search_text_receiver_t *rx, uint8_t indexle
 }
 
 static int _matchmime_tr_end_mailbox(search_text_receiver_t *rx __attribute__((unused)),
-                                     struct mailbox *mailbox __attribute__((unused)),
-                                     bool has_more __attribute__((unused)))
+                                     struct mailbox *mailbox __attribute__((unused)))
 {
     return 0;
 }

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -48,7 +48,9 @@ static const struct search_engine default_search_engine = {
     NULL,
     NULL,
     NULL,
-    NULL
+    NULL,
+    NULL,
+    NULL,
 };
 
 EXPORTED const struct search_engine *search_engine(void)
@@ -144,19 +146,35 @@ EXPORTED int search_part_is_header(enum search_part part)
     return 0;
 }
 
-EXPORTED search_builder_t *search_begin_search(struct mailbox *mailbox, int opts)
+EXPORTED search_builder_t *search_begin_search(search_session_t *session)
 {
-    if (!mailbox) return NULL;
+    if (!session) return NULL;
 
     const struct search_engine *se = search_engine();
-    return (se->begin_search ?
-            se->begin_search(mailbox, opts) : NULL);
+    return (se->begin_search ? se->begin_search(session) : NULL);
 }
 
 EXPORTED void search_end_search(search_builder_t *bx)
 {
     const struct search_engine *se = search_engine();
     if (se->end_search) se->end_search(bx);
+}
+
+EXPORTED search_session_t *search_begin_session(struct mailbox *mailbox,
+                                                int opts)
+{
+    if (!mailbox) return NULL;
+
+    const struct search_engine *se = search_engine();
+    return (se->begin_session ?
+            se->begin_session(mailbox, opts) : NULL);
+}
+
+EXPORTED void search_end_session(search_session_t *session)
+{
+    if (!session) return;
+    const struct search_engine *se = search_engine();
+    if (se->end_session) se->end_session(session);
 }
 
 EXPORTED search_text_receiver_t *search_begin_update(int verbose)

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -533,8 +533,9 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
     if (!dynarray_size(&attachparts))
         goto done;
 
-    // Release mailbox lock
-    r = rx->end_mailbox(rx, mailbox);
+    // Release mailbox lock. Indexing this mailbox is not complete yet,
+    // it resumes after extracting attachments.
+    r = rx->end_mailbox(rx, mailbox, /*has_more*/true);
     if (r) goto done;
     mailbox_close(&mailbox);
 
@@ -592,7 +593,7 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
     free(mycachedir);
     free(mboxname);
     {
-        int r2 = rx->end_mailbox(rx, mailbox);
+        int r2 = rx->end_mailbox(rx, mailbox, /*has_more*/false);
         if (r) return r;
         if (r2) return r2;
     }

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -51,6 +51,7 @@ static const struct search_engine default_search_engine = {
     NULL,
     NULL,
     NULL,
+    NULL,
 };
 
 EXPORTED const struct search_engine *search_engine(void)
@@ -175,6 +176,16 @@ EXPORTED void search_end_session(search_session_t *session)
     if (!session) return;
     const struct search_engine *se = search_engine();
     if (se->end_session) se->end_session(session);
+}
+
+EXPORTED modseq_t search_session_get_highest_createdmodseq(search_session_t *session,
+                                                           uint64_t *index_generation)
+{
+    if (index_generation) *index_generation = 0;
+    if (!session) return 0;
+    const struct search_engine *se = search_engine();
+    return se->session_get_highest_createdmodseq ?
+            se->session_get_highest_createdmodseq(session, index_generation) : 0;
 }
 
 EXPORTED search_text_receiver_t *search_begin_update(int verbose)

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -19,6 +19,7 @@
 #include "global.h"
 #include "ptrarray.h"
 #include "search_engines.h"
+#include "seqset.h"
 #include "attachextract.h"
 
 /* generated headers are not necessarily in current directory */
@@ -211,42 +212,87 @@ static int search_batch_size(void)
  * Returns an IMAP error code or 0 on success.
  */
 static int flush_batch(search_text_receiver_t *rx,
+                       struct mailbox *mailbox,
                        int flags,
-                       ptrarray_t *batch)
+                       seqset_t *uids,
+                       size_t *nindexedptr)
 {
     int i;
     int r = 0;
     int indexflags = 0;
+    ptrarray_t msgs = PTRARRAY_INITIALIZER;
+
+    /* reset the sequence set iterator */
+    seqset_reset(uids);
+    for (uint32_t uid = seqset_getnext(uids); uid; uid = seqset_getnext(uids)) {
+        struct index_record record = {0};
+        r = mailbox_find_index_record(mailbox, uid, &record);
+        if (r == IMAP_NOTFOUND) {
+            /* The record got removed from the index while we did not hold
+             * the mailbox lock. Such a message never needs indexing, so
+             * the indexed uid range may cover it. */
+            xsyslog(LOG_INFO, "index record is gone - ignoring",
+                    "mboxname=<%s> imap_uid=<%d>",
+                    mailbox_name(mailbox), uid);
+            r = 0;
+        }
+        else if (r) {
+            /* We can not tell if this message needs indexing. Indexing
+             * must stop here, or the indexed uid range would get merged
+             * across this uid and never cover it again. */
+            xsyslog(LOG_ERR, "could not read index record",
+                    "mboxname=<%s> imap_uid=<%d> err=<%s>",
+                    mailbox_name(mailbox), uid, error_message(r));
+            goto done;
+        }
+        else if (record.internal_flags & FLAG_INTERNAL_UNLINKED) {
+            /* The message got expunged and its file removed while we did
+             * not hold the mailbox lock. Selecting messages skips unlinked
+             * records, too, and they never need indexing. */
+            xsyslog(LOG_INFO, "message file is gone - ignoring",
+                    "mboxname=<%s> imap_uid=<%d>",
+                    mailbox_name(mailbox), uid);
+        }
+        else {
+            ptrarray_append(&msgs, message_new_from_record(mailbox, &record));
+        }
+    }
 
     /* prefetch files */
-    for (i = 0 ; i < batch->count ; i++) {
-        message_t *msg = ptrarray_nth(batch, i);
+    for (i = 0 ; i < msgs.count ; i++) {
+        message_t *msg = ptrarray_nth(&msgs, i);
 
         const char *fname;
         r = message_get_fname(msg, &fname);
-        if (r) return r;
-        r = warmup_file(fname, 0, 0);
-        if (r) return r; /* means we failed to open a file,
-                            so we'll fail later anyway */
+        if (!r) r = warmup_file(fname, 0, 0);
+        if (r) goto done;
     }
 
     if (flags & SEARCH_UPDATE_ALLOW_PARTIALS)
         indexflags |= INDEX_GETSEARCHTEXT_ALLOW_PARTIALS;
 
-    for (i = 0 ; i < batch->count ; i++) {
-        message_t *msg = ptrarray_nth(batch, i);
-        if (!r) r = index_getsearchtext(msg, NULL, rx, indexflags);
+    for (i = 0 ; i < msgs.count ; i++) {
+        message_t *msg = ptrarray_nth(&msgs, i);
+        r = index_getsearchtext(msg, NULL, rx, indexflags);
+        if (r) goto done;
+        /* release message as soon as we are done */
         message_unref(&msg);
+        ptrarray_set(&msgs, i, NULL);
     }
-    ptrarray_truncate(batch, 0);
-
-    if (r) return r;
 
     if (rx->flush) {
         r = rx->flush(rx);
-        if (r) return r;
+        if (r) goto done;
     }
 
+    if (nindexedptr) *nindexedptr = msgs.count;
+
+done:
+    for (i = 0 ; i < msgs.count ; i++) {
+        message_t *msg = ptrarray_nth(&msgs, i);
+        message_unref(&msg);
+    }
+    ptrarray_fini(&msgs);
     return r;
 }
 
@@ -338,12 +384,13 @@ static void free_attachpart(dynarray_t *attachpart)
     dynarray_fini(attachpart);
 }
 
-static void warmup_attachextract_cache(dynarray_t *attachparts)
+static size_t warmup_attachextract_cache(dynarray_t *attachparts)
 {
     const char *mapped = NULL;
     size_t mapped_len = 0;
     const char *fname = NULL;
     struct buf buf = BUF_INITIALIZER;
+    size_t nfailed = 0;
     int fd = -1;
 
     for (int i = 0; i < dynarray_size(attachparts); i++) {
@@ -359,8 +406,10 @@ static void warmup_attachextract_cache(dynarray_t *attachparts)
             fd = open(ap->fname, O_RDONLY);
             if (fd == -1) {
                 xsyslog(LOG_WARNING, "could not open message file - ignoring",
-                        "file=<%s>", ap->fname);
+                        "file=<%s> guid=<%s>", ap->fname,
+                        message_guid_encode(&ap->axrec.guid));
                 fname = NULL;
+                nfailed++;
                 continue;
             }
 
@@ -371,9 +420,10 @@ static void warmup_attachextract_cache(dynarray_t *attachparts)
 
         if (ap->content_offset + ap->content_size > mapped_len) {
             xsyslog(LOG_ERR, "file size has changed - ignoring",
-                    "file=<%s> expect_size=<%zu> have_size=<%zu>",
-                    ap->fname, ap->content_offset + ap->content_size,
-                    mapped_len);
+                    "file=<%s> guid=<%s> expect_size=<%zu> have_size=<%zu>",
+                    ap->fname, message_guid_encode(&ap->axrec.guid),
+                    ap->content_offset + ap->content_size, mapped_len);
+            nfailed++;
             continue;
         }
 
@@ -387,8 +437,10 @@ static void warmup_attachextract_cache(dynarray_t *attachparts)
         }
         else {
             xsyslog(LOG_ERR, "failed to warmup attachextract cache for body part",
-                    "file=<%s> imap_partid=<%s> err=<%s>",
-                    ap->fname, ap->imap_partid, error_message(r));
+                    "file=<%s> imap_partid=<%s> guid=<%s> err=<%s>",
+                    ap->fname, ap->imap_partid,
+                    message_guid_encode(&ap->axrec.guid), error_message(r));
+            nfailed++;
         }
 
         buf_reset(&buf);
@@ -402,58 +454,20 @@ static void warmup_attachextract_cache(dynarray_t *attachparts)
         close(fd);
 
     buf_free(&buf);
+    return nfailed;
 }
 
-static int flush_attachparts(search_text_receiver_t *rx,
-                             struct mailbox *mailbox,
-                             int flags,
-                             dynarray_t *attachparts)
-{
-    ptrarray_t batch = PTRARRAY_INITIALIZER;
-    int r = 0;
-
-    // Load messages containing the attachment parts.
-    uint32_t prev_uid = 0;
-    for (int i = 0; i < dynarray_size(attachparts); i++) {
-        struct attachpart *ap = dynarray_nth(attachparts, i);
-
-        if (prev_uid == ap->imap_uid)
-            continue;
-
-        prev_uid = ap->imap_uid;
-
-        struct index_record record = {0};
-        r = mailbox_find_index_record(mailbox, ap->imap_uid, &record);
-        if (r) {
-            xsyslog(LOG_WARNING, "could not find index record - ignoring",
-                    "mboxname=<%s> imap_uid=<%d> err=<%s>",
-                    mailbox_name(mailbox), ap->imap_uid,
-                    error_message(r));
-            continue;
-        }
-
-        message_t *msg = message_new_from_record(mailbox, &record);
-        ptrarray_append(&batch, msg);
-    }
-
-    if (batch.count) {
-        // we warmed up the cache - now do not incur network io again
-        r = flush_batch(rx, flags, &batch);
-    }
-
-    ptrarray_fini(&batch);
-    return r;
-}
-
-static void build_batch(search_text_receiver_t *rx,
-                        struct mailbox *mailbox,
-                        int min_indexlevel,
-                        int flags,
-                        ptrarray_t *batch,
-                        int *is_incomplete)
+static void select_messages_to_index(search_text_receiver_t *rx,
+                                     struct mailbox *mailbox,
+                                     int min_indexlevel,
+                                     int flags,
+                                     seqset_t *uids,
+                                     dynarray_t *attachparts,
+                                     int *is_incomplete)
 {
     int reindex_partials = flags & SEARCH_UPDATE_REINDEX_PARTIALS;
     int batch_size = search_batch_size();
+    int nmsgs = 0;
     const message_t *msg;
 
     /* we want to index EXPUNGED messages too, because otherwise when we check the
@@ -465,9 +479,9 @@ static void build_batch(search_text_receiver_t *rx,
 
     while ((msg = mailbox_iter_step(iter))) {
         const struct index_record *record = msg_record(msg);
-        if ((flags & SEARCH_UPDATE_BATCH) && batch->count >= batch_size) {
-            syslog(LOG_INFO, "search_update_mailbox batching %u messages to %s",
-                    batch->count, mailbox_name(mailbox));
+        if ((flags & SEARCH_UPDATE_BATCH) && nmsgs >= batch_size) {
+            syslog(LOG_INFO, "search_update_mailbox batching %d messages to %s",
+                    nmsgs, mailbox_name(mailbox));
             *is_incomplete = 1;
             break;
         }
@@ -481,10 +495,13 @@ static void build_batch(search_text_receiver_t *rx,
             indexlevel = 0;
         }
 
-        if (!indexlevel)
-            ptrarray_append(batch, msg);
-        else
-            message_unref(&msg);
+        if (!indexlevel) {
+            nmsgs++;
+            create_attachpart(mailbox, msg, attachparts);
+            seqset_add(uids, record->uid, 1);
+        }
+
+        message_unref(&msg);
     }
 
     mailbox_iter_done(&iter);
@@ -493,49 +510,42 @@ static void build_batch(search_text_receiver_t *rx,
 EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
                                    struct mailbox **mailboxptr,
                                    int min_indexlevel,
-                                   int flags)
+                                   int flags,
+                                   size_t *nindexedptr)
 {
     int r = 0;                  /* Using IMAP_* not SQUAT_* return codes here */
     int is_incomplete = 0;
-    ptrarray_t batch = PTRARRAY_INITIALIZER;
+    bool in_mailbox = false;
+    size_t nindexed = 0;
+    seqset_t *uids = seqset_init(0, SEQ_SPARSE);
     dynarray_t attachparts = DYNARRAY_INITIALIZER(sizeof(struct attachpart));
     char *mycachedir = NULL;
     struct mailbox *mailbox = *mailboxptr;
     char *mboxname = xstrdup(mailbox_name(mailbox));
+    char *uniqueid = xstrdupnull(mailbox_uniqueid(mailbox));
+    uint32_t uidvalidity = mailbox->i.uidvalidity;
 
     r = rx->begin_mailbox(rx, mailbox, flags);
     if (r) goto done;
+    in_mailbox = true;
 
-    // Build message batch
+    // Determine the messages to index, and the parts to extract text from
 
-    build_batch(rx, mailbox, min_indexlevel, flags, &batch, &is_incomplete);
-    if (!batch.count) goto done;
+    select_messages_to_index(rx, mailbox, min_indexlevel, flags, uids,
+                             &attachparts, &is_incomplete);
 
-    // Split messages with attachments from batch
-    int newlen = 0;
-    for (int i = 0; i < ptrarray_size(&batch); i++) {
-        message_t *msg = ptrarray_nth(&batch, i);
-        if (create_attachpart(mailbox, msg, &attachparts)) {
-            message_unref(&msg);
-        }
-        else ptrarray_set(&batch, newlen++, msg);
-    }
-
-    if (newlen < ptrarray_size(&batch))
-        ptrarray_truncate(&batch, newlen);
-
-    // Index text-only messages
-    if (batch.count) {
-        r = flush_batch(rx, flags, &batch);
-        if (r) goto done;
-    }
-
-    if (!dynarray_size(&attachparts))
+    if (!seqset_first(uids))
         goto done;
 
-    // Release mailbox lock. Indexing this mailbox is not complete yet,
-    // it resumes after extracting attachments.
-    r = rx->end_mailbox(rx, mailbox, /*has_more*/true);
+    if (!dynarray_size(&attachparts)) {
+        // No attachment text to extract, index these messages right away.
+        r = flush_batch(rx, mailbox, flags, uids, &nindexed);
+        goto done;
+    }
+
+    // Release the mailbox lock while extracting attachment text.
+    r = rx->end_mailbox(rx, mailbox);
+    in_mailbox = false;
     if (r) goto done;
     mailbox_close(&mailbox);
 
@@ -553,14 +563,38 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
         attachextract_set_cachedir(mycachedir);
     }
 
-    warmup_attachextract_cache(&attachparts);
+    size_t nfailed = warmup_attachextract_cache(&attachparts);
+    if (nfailed) {
+        // The messages of those parts can not get indexed fully.
+        xsyslog_ev(LOG_WARNING, "could not extract all attachment text",
+                lf_s("mboxname", mboxname),
+                lf_d("parts", dynarray_size(&attachparts)),
+                lf_zu("failed_parts", nfailed));
+    }
 
     // Retake mailbox lock
     r = mailbox_open_irl(mboxname, &mailbox);
     if (r) goto done;
 
+    // A mailbox that got deleted and recreated by this name, or whose uids
+    // got renumbered, has nothing in common with the messages we selected.
+    if (strcmpsafe(uniqueid, mailbox_uniqueid(mailbox)) ||
+            uidvalidity != mailbox->i.uidvalidity) {
+        xsyslog_ev(LOG_NOTICE, "mailbox changed while extracting attachments",
+                lf_s("mboxname", mboxname),
+                lf_s("uniqueid", uniqueid),
+                lf_s("new_uniqueid", mailbox_uniqueid(mailbox)),
+                lf_u("uidvalidity", uidvalidity),
+                lf_u("new_uidvalidity", mailbox->i.uidvalidity));
+        // None of the selected messages got indexed. Have the caller retry
+        // this mailbox, rather than reporting it as indexed.
+        is_incomplete = 1;
+        goto done;
+    }
+
     r = rx->begin_mailbox(rx, mailbox, flags);
     if (r) goto done;
+    in_mailbox = true;
 
     // Log timestamp
     if (flags & SEARCH_UPDATE_VERBOSE) {
@@ -569,34 +603,36 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
                 mboxname, time(NULL));
     }
 
-    // Index cached attachment text
+    // Index all selected messages. Their attachment text is cached now, so
+    // indexing must not call the extractor again while holding the lock.
     int txcacheonly = attachextract_get_cacheonly();
     if (!txcacheonly) {
         attachextract_set_cacheonly(1);
     }
 
-    r = flush_attachparts(rx, mailbox, flags, &attachparts);
+    r = flush_batch(rx, mailbox, flags, uids, &nindexed);
 
     if (!txcacheonly) {
         attachextract_set_cacheonly(0);
     }
 
+ done:
+    if (nindexedptr) *nindexedptr = nindexed;
     if (mycachedir) {
         attachextract_set_cachedir(NULL);
         removedir(mycachedir);
     }
-
- done:
     *mailboxptr = mailbox;
-    ptrarray_fini(&batch);
+    seqset_free(&uids);
     free_attachpart(&attachparts);
     free(mycachedir);
     free(mboxname);
-    {
-        int r2 = rx->end_mailbox(rx, mailbox, /*has_more*/false);
-        if (r) return r;
-        if (r2) return r2;
+    free(uniqueid);
+    if (in_mailbox) {
+        int r2 = rx->end_mailbox(rx, mailbox);
+        if (!r) r = r2;
     }
+    if (r) return r;
     return is_incomplete ? IMAP_AGAIN : 0;
 }
 

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -152,6 +152,8 @@ struct search_engine {
     void (*end_session)(search_session_t *);
     search_builder_t *(*begin_search)(search_session_t *session);
     void (*end_search)(search_builder_t *);
+    modseq_t (*session_get_highest_createdmodseq)(search_session_t *,
+                                                  uint64_t *index_generation);
     search_text_receiver_t *(*begin_update)(int verbose);
     int (*end_update)(search_text_receiver_t *);
     search_text_receiver_t *(*begin_snippets)(void *internalised,
@@ -191,6 +193,22 @@ extern void search_end_session(search_session_t *);
  */
 extern search_builder_t *search_begin_search(search_session_t *);
 extern void search_end_search(search_builder_t *);
+
+/*
+ * Return the highest createdmodseq of all messages indexed in the search
+ * database, or 0 if unknown.
+ *
+ * The optional index_generation argument is set to a generation marker of
+ * the index. The generation stays the same as long as the index only gets
+ * updated with messages having a higher createdmodseq than any in the index.
+ * It changes whenever the index adds or reindexes messages at or below the
+ * highest createdmodseq, or when the index is fully rebuilt.
+ *
+ * The generation is an opaque value, callers must not assume it to strictly
+ * increase.
+ */
+extern modseq_t search_session_get_highest_createdmodseq(search_session_t *,
+                                                         uint64_t *index_generation);
 
 #define SEARCH_UPDATE_INCREMENTAL (1<<0)
 #define SEARCH_UPDATE_NONBLOCKING (1<<1)

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -5,6 +5,8 @@
 #ifndef INCLUDED_SEARCH_ENGINES_H
 #define INCLUDED_SEARCH_ENGINES_H
 
+#include <stdbool.h>
+
 #include "mailbox.h"
 #include "message_guid.h"
 #include "util.h"
@@ -115,7 +117,12 @@ struct search_text_receiver {
 #define SEARCH_INDEXLEVEL_BEST SEARCH_INDEXLEVEL_ATTACH
 #define SEARCH_INDEXLEVEL_MAX (SEARCH_INDEXLEVEL_PARTIAL - 1)
     int (*end_message)(search_text_receiver_t *, uint8_t indexlevel);
-    int (*end_mailbox)(search_text_receiver_t *, struct mailbox *);
+    /* Finish indexing a mailbox. If has_more is true, this indicates that the
+     * same mailbox will get reopened with more messages, so search engines
+     * may defer updating the index state until the. This mostly is relevant
+     * for two-phased attachment extraction and indexing. */
+    int (*end_mailbox)(search_text_receiver_t *, struct mailbox *,
+                       bool has_more);
     int (*flush)(search_text_receiver_t *);
     int (*audit_mailbox)(search_text_receiver_t *, bitvector_t *unindexed);
     int (*index_charset_flags)(int base_flags);

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -32,6 +32,14 @@ typedef int (*search_snippet_cb_t)(struct mailbox *, uint32_t uid,
                                    const char *bodypartid,
                                    const char *snippet, void *rock);
 
+/*
+ * A search session provides the context for search queries. Every query
+ * within a search session is guaranteed to run on the same index revision.
+ * Obtaining a search session may take a shared lock on the search index,
+ * so sessions should only be held temporarily.
+ */
+typedef struct search_session search_session_t;
+
 typedef struct search_builder search_builder_t;
 struct search_builder {
 /* These values are carefully chosen a) not to clash with the
@@ -140,7 +148,9 @@ struct search_engine {
 #define SEARCH_ATTACHMENTS_IN_ANY (1<<10) /* search attachments in ANY part */
 #define SEARCH_COMPACT_ALLOW_PARTIALS (1<<11) /* allow partially indexed messages */
 #define SEARCH_COMPACT_NONBLOCKING (1<<12) /* skip if locked */
-    search_builder_t *(*begin_search)(struct mailbox *, int opts);
+    search_session_t *(*begin_session)(struct mailbox *, int opts);
+    void (*end_session)(search_session_t *);
+    search_builder_t *(*begin_search)(search_session_t *session);
     void (*end_search)(search_builder_t *);
     search_text_receiver_t *(*begin_update)(int verbose);
     int (*end_update)(search_text_receiver_t *);
@@ -167,13 +177,19 @@ struct search_engine {
 extern const struct search_engine *search_engine();
 
 /*
- * Search for messages which could match the query built with the
- * search_builder_t.  Calls 'proc' once for each hit found.  If 'single'
- * is true, only hits in 'mailbox' are reported; otherwise hits in any
- * folder in the same conversation scope (i.e. the same user) as
- * reported.
+ * Open a search session for the given mailbox and opts. All
+ * search_begin_search() calls made with this session observe the same
+ * index revision. Returns NULL if no engine is configured or on error.
+ * Close the session with search_end_session().
  */
-extern search_builder_t *search_begin_search(struct mailbox *, int opts);
+extern search_session_t *search_begin_session(struct mailbox *, int opts);
+extern void search_end_session(search_session_t *);
+
+/*
+ * Create a search_builder for a query in the given session.
+ * Close the builder with search_end_search().
+ */
+extern search_builder_t *search_begin_search(search_session_t *);
 extern void search_end_search(search_builder_t *);
 
 #define SEARCH_UPDATE_INCREMENTAL (1<<0)

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -117,12 +117,7 @@ struct search_text_receiver {
 #define SEARCH_INDEXLEVEL_BEST SEARCH_INDEXLEVEL_ATTACH
 #define SEARCH_INDEXLEVEL_MAX (SEARCH_INDEXLEVEL_PARTIAL - 1)
     int (*end_message)(search_text_receiver_t *, uint8_t indexlevel);
-    /* Finish indexing a mailbox. If has_more is true, this indicates that the
-     * same mailbox will get reopened with more messages, so search engines
-     * may defer updating the index state until the. This mostly is relevant
-     * for two-phased attachment extraction and indexing. */
-    int (*end_mailbox)(search_text_receiver_t *, struct mailbox *,
-                       bool has_more);
+    int (*end_mailbox)(search_text_receiver_t *, struct mailbox *);
     int (*flush)(search_text_receiver_t *);
     int (*audit_mailbox)(search_text_receiver_t *, bitvector_t *unindexed);
     int (*index_charset_flags)(int base_flags);
@@ -227,9 +222,18 @@ extern modseq_t search_session_get_highest_createdmodseq(search_session_t *,
 #define SEARCH_UPDATE_ALLOW_DUPPARTS (1<<7)
 #define SEARCH_UPDATE_VERBOSE (1<<8)
 search_text_receiver_t *search_begin_update(int verbose);
+/* Index the messages of mailbox *mailboxptr that are not indexed at
+ * min_indexlevel yet. Returns IMAP_AGAIN if the mailbox needs another
+ * update to complete, an IMAP error code on error, or 0.
+ *
+ * If nindexedptr is not NULL, it is set to the number of messages this
+ * update indexed. A caller that repeats an update returning IMAP_AGAIN
+ * must use it to tell an update that made progress from one that did not,
+ * so that it does not repeat forever. */
 int search_update_mailbox(search_text_receiver_t *rx,
                           struct mailbox **mailboxptr,
-                          int min_indexlevel, int flags);
+                          int min_indexlevel, int flags,
+                          size_t *nindexedptr);
 int search_end_update(search_text_receiver_t *rx);
 
 /* Create a search text receiver for snippets. For each non-empty

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -1134,6 +1134,11 @@ EXPORTED int search_query_run(search_query_t *query)
             .session = search_begin_session(query->state->mailbox, opts),
         };
 
+        /* Cache highest createdmodseq and index generation from session */
+        query->highest_createdmodseq =
+            search_session_get_highest_createdmodseq(ctx.session,
+                    &query->index_generation);
+
         hash_enumerate(&query->subs_by_indexed, subquery_run_indexed, &ctx);
 
         search_end_session(ctx.session);

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -828,12 +828,17 @@ static int add_found_uid(const char *mboxname, uint32_t uidvalidity,
     return 0;
 }
 
-static void subquery_run_indexed(const char *key __attribute__((unused)),
+struct subquery_run_indexed_ctx {
+    search_query_t *query;
+    search_session_t *session;
+};
+
+static void subquery_run_indexed(const char *serialised_sub __attribute__((unused)),
                                  void *data, void *rock)
 {
-//     const char *mboxname = key;
     search_subquery_t *sub = data;
-    search_query_t *query = rock;
+    struct subquery_run_indexed_ctx *ctx = rock;
+    search_query_t *query = ctx->query;
     search_expr_t *excluded = NULL;
     search_builder_t *bx;
     struct subquery_rock qr = { 0 };
@@ -846,10 +851,6 @@ static void subquery_run_indexed(const char *key __attribute__((unused)),
         syslog(LOG_INFO, "Running indexed subquery: %s", s);
         free(s);
     }
-
-    int opts = SEARCH_VERBOSE(query->verbose);
-    if (query->multiple) opts |= SEARCH_MULTIPLE;
-    if (query->attachments_in_any) opts |= SEARCH_ATTACHMENTS_IN_ANY;
 
     /* If the subquery is NOT(x) or AND(NOT(x)..(NOT(y))) then
      * it's likely that we will get lots of results to look up
@@ -878,7 +879,7 @@ static void subquery_run_indexed(const char *key __attribute__((unused)),
         excluded = search_expr_duplicate(sub->indexed->children);
     }
 
-    bx = search_begin_search(query->state->mailbox, opts);
+    bx = search_begin_search(ctx->session);
     if (!bx) {
         if (config_getenum(IMAPOPT_SEARCH_ENGINE) == IMAP_ENUM_SEARCH_ENGINE_SQUAT) {
             r = subquery_run_one_folder(query, index_mboxname(query->state), sub->indexed);
@@ -1121,8 +1122,22 @@ EXPORTED int search_query_run(search_query_t *query)
          * all the search engine queries, and builds a set of matched
          * uids per folder.  The second runs per folder and applies
          * any scan expression.
+         * Both phases execute within a query session, which guarantees
+         * a stable index revision.
          */
-        hash_enumerate(&query->subs_by_indexed, subquery_run_indexed, query);
+        int opts = SEARCH_VERBOSE(query->verbose);
+        if (query->multiple) opts |= SEARCH_MULTIPLE;
+        if (query->attachments_in_any) opts |= SEARCH_ATTACHMENTS_IN_ANY;
+
+        struct subquery_run_indexed_ctx ctx = {
+            .query = query,
+            .session = search_begin_session(query->state->mailbox, opts),
+        };
+
+        hash_enumerate(&query->subs_by_indexed, subquery_run_indexed, &ctx);
+
+        search_end_session(ctx.session);
+
         r = query->error;
         if (r) goto out;
     }

--- a/imap/search_query.h
+++ b/imap/search_query.h
@@ -148,6 +148,10 @@ struct search_query {
 
     /* For INPROGRESS responses during IMAP SEARCH */
     struct progress_rock *prock;
+
+    /* Highest createdmodseq and generation of the search index */
+    modseq_t highest_createdmodseq;
+    uint64_t index_generation;
 };
 
 extern search_query_t *search_query_new(struct index_state *state,

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -1046,6 +1046,7 @@ const struct search_engine squat_search_engine = {
     end_session,
     begin_search,
     end_search,
+    /* session_get_highest_createdmodseq */NULL,
     begin_update,
     end_update,
     /* begin_snippets */NULL,

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -335,14 +335,37 @@ static void *get_internalised(search_builder_t *bx
 
 static int run(search_builder_t *bx, search_hit_cb_t proc, void *rock);
 
-static search_builder_t *begin_search(struct mailbox *mailbox, int opts)
+/* SQUAT has no shared index lock to hold across builders, so the
+ * session just carries the parameters begin_search() needs. */
+struct search_session {
+    struct mailbox *mailbox;
+    int opts;
+};
+
+static search_session_t *begin_session(struct mailbox *mailbox, int opts)
+{
+    if (!mailbox) return NULL;
+    search_session_t *session = xzmalloc(sizeof(*session));
+    session->mailbox = mailbox;
+    session->opts = opts;
+    return session;
+}
+
+static void end_session(search_session_t *session)
+{
+    free(session);
+}
+
+static search_builder_t *begin_search(search_session_t *session)
 {
     SquatBuilderData *bb;
     SquatSearchIndex* index;
     const char *fname;
     int fd;
 
-    if (!mailbox) return NULL;
+    if (!session) return NULL;
+    struct mailbox *mailbox = session->mailbox;
+    int opts = session->opts;
 
     if ((opts & SEARCH_MULTIPLE)) {
         syslog(LOG_ERR, "Squat does not support multiple-folder searches, sorry");
@@ -1019,6 +1042,8 @@ static int can_match(enum search_op matchop, enum search_part partnum)
 const struct search_engine squat_search_engine = {
     "SQUAT",
     0,
+    begin_session,
+    end_session,
     begin_search,
     end_search,
     begin_update,

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -924,7 +924,8 @@ static uint8_t is_indexed(search_text_receiver_t *rx, message_t *msg)
 
 static int end_mailbox(search_text_receiver_t *rx,
                        struct mailbox *mailbox
-                            __attribute__((unused)))
+                            __attribute__((unused)),
+                       bool has_more __attribute__((unused)))
 {
     SquatReceiverData *d = (SquatReceiverData *)rx;
     struct stat sb;

--- a/imap/search_squat.c
+++ b/imap/search_squat.c
@@ -924,8 +924,7 @@ static uint8_t is_indexed(search_text_receiver_t *rx, message_t *msg)
 
 static int end_mailbox(search_text_receiver_t *rx,
                        struct mailbox *mailbox
-                            __attribute__((unused)),
-                       bool has_more __attribute__((unused)))
+                            __attribute__((unused)))
 {
     SquatReceiverData *d = (SquatReceiverData *)rx;
     struct stat sb;

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -792,6 +792,32 @@ static void read_highest_createdmodseq_at_dir(const char *userid,
     free(fname);
 }
 
+/* Store the highest createdmodseq and index generation in the indexed.db
+ * located in the xapian database directory dir. */
+static int store_highest_createdmodseq_at_dir(const char *userid,
+                                              const char *dir,
+                                              modseq_t highest_createdmodseq,
+                                              uint64_t index_generation)
+{
+    char *fname = indexeddb_fname(dir);
+    struct indexeddb *idb = NULL;
+
+    int r = indexeddb_open(userid, fname, CYRUSDB_CREATE, &idb);
+    if (!r && (idb->highest_createdmodseq != highest_createdmodseq ||
+                idb->index_generation != index_generation)) {
+        idb->highest_createdmodseq = highest_createdmodseq;
+        idb->index_generation = index_generation;
+        r = store_indexeddb_highest_createdmodseq(idb);
+    }
+    if (idb) {
+        int r2 = indexeddb_close(&idb, r);
+        if (!r) r = r2;
+    }
+
+    free(fname);
+    return r;
+}
+
 /*
  * Merge the indexed.db of all search tiers activetiers[1..n] into the
  * indexed.db of the top tier.
@@ -2419,7 +2445,7 @@ out:
     return r;
 }
 
-static int flush(search_text_receiver_t *rx)
+static int flush_internal(search_text_receiver_t *rx, bool has_more)
 {
     xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
     int r = 0;
@@ -2440,14 +2466,15 @@ static int flush(search_text_receiver_t *rx)
         tr->commits++;
     }
 
-    /* We write out the indexed list for the mailbox only after successfully
-     * updating the index, to avoid a future instance not realising that
-     * there are unindexed messages should we fail to index. We also write
-     * the highest createdmodseq and bump the index generation, if required */
-    if (tr->indexed) {
-        if (tr->batch_lowest_createdmodseq &&
-                tr->batch_lowest_createdmodseq <= tr->highest_createdmodseq) {
-            /* This batch indexed a message that has a lower createdmodseq
+    /* Update the highest createdmodseq and bump the index generation to
+     * cover all batches indexed since begin_mailbox. This must only happen
+     * once the mailbox update is complete (has_more is false): a message
+     * indexed by a later batch of the same update may have a lower
+     * createdmodseq than the highest createdmodseq of an earlier batch,
+     * which would spuriously invalidate the index generation. */
+    if (!has_more && tr->batch_highest_createdmodseq) {
+        if (tr->batch_lowest_createdmodseq <= tr->highest_createdmodseq) {
+            /* This update indexed a message that has a lower createdmodseq
              * than the highest createdmodseq in the index. This means we
              * either reindexed a message, fully or partially, or a message got
              * added to the index that wasn't indexed before but the highest
@@ -2467,20 +2494,45 @@ static int flush(search_text_receiver_t *rx)
         /* Update the highest createdmodseq */
         if (tr->batch_highest_createdmodseq > tr->highest_createdmodseq)
             tr->highest_createdmodseq = tr->batch_highest_createdmodseq;
+    }
 
-        /* Write to the database */
+    /* We write out the indexed list for the mailbox only after successfully
+     * updating the index, to avoid a future instance not realising that
+     * there are unindexed messages should we fail to index. This also
+     * persists the highest createdmodseq and index generation. */
+    if (tr->indexed) {
         r = write_indexed(strarray_nth(tr->activedirs, 0),
                 mailbox_name(tr->super.mailbox), tr->super.mailbox->i.uidvalidity,
                 mailbox_uniqueid(tr->super.mailbox), tr->indexed,
                 tr->highest_createdmodseq, tr->index_generation,
                 tr->super.verbose);
         if (r) goto out;
+    }
+    else if (!has_more && tr->batch_highest_createdmodseq && tr->activedirs) {
+        /* There is no indexed list to write, but an earlier batch of this
+         * update still indexed messages whose highest createdmodseq and
+         * index generation we must persist. */
+        r = store_highest_createdmodseq_at_dir(mbname_userid(tr->super.mbname),
+                strarray_nth(tr->activedirs, 0),
+                tr->highest_createdmodseq, tr->index_generation);
+        if (r) goto out;
+    }
+
+    if (!has_more) {
         tr->batch_highest_createdmodseq = 0;
         tr->batch_lowest_createdmodseq = 0;
     }
 
 out:
     return r;
+}
+
+static int flush(search_text_receiver_t *rx)
+{
+    /* A flush via the receiver API is always intermediate: more batches may
+     * follow, and the mailbox update is only complete once end_mailbox is
+     * called. The highest createdmodseq is committed from end_mailbox_update. */
+    return flush_internal(rx, /*has_more*/true);
 }
 
 static int audit_mailbox(search_text_receiver_t *rx, bitvector_t *unindexed)
@@ -3083,12 +3135,15 @@ static uint8_t is_indexed(search_text_receiver_t *rx, message_t *msg)
 
 static int end_mailbox_update(search_text_receiver_t *rx,
                               struct mailbox *mailbox
-                            __attribute__((unused)))
+                            __attribute__((unused)),
+                              bool has_more)
 {
     xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
     int r = 0;
 
-    r = flush(rx);
+    /* flush_internal handles updating the highest createdmodseq and index
+     * generation once the mailbox update is complete, see has_more. */
+    r = flush_internal(rx, has_more);
 
     /* flush before cleaning up, since indexed data is written by flush */
     seqset_free(&tr->indexed);
@@ -3337,7 +3392,8 @@ static int end_message_snippets(search_text_receiver_t *rx,
 
 static int end_mailbox_snippets(search_text_receiver_t *rx,
                                 struct mailbox *mailbox
-                                    __attribute__((unused)))
+                                    __attribute__((unused)),
+                                bool has_more __attribute__((unused)))
 {
     xapian_snippet_receiver_t *tr = (xapian_snippet_receiver_t *)rx;
 

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -1361,13 +1361,21 @@ struct opnode
     struct opnode *children;
 };
 
+/*
+ * A search session takes a shared lock on the activefile. Within
+ * a session, all Xapian and indexeddb databases for tiers of that
+ * activefile are guaranteed to not change.
+ */
+struct search_session {
+    struct xapiandb_lock lock;
+    struct mailbox *mailbox;
+    int opts;
+};
+
 typedef struct xapian_builder xapian_builder_t;
 struct xapian_builder {
     search_builder_t super;
-    struct xapiandb_lock lock;
-    seqset_t *indexed;
-    struct mailbox *mailbox;
-    int opts;
+    search_session_t *session;
     struct opnode *root;
     ptrarray_t stack;       /* points to opnode* */
     int (*proc)(const char *, uint32_t, uint32_t, const char *, void *);
@@ -1749,8 +1757,8 @@ static int xapian_run_guid_cb(const conv_guidrec_t *rec, void *vrock)
     struct xapian_run_guid_rock *rock = vrock;
     xapian_builder_t *bb = rock->bb;
 
-    if (!(bb->opts & SEARCH_MULTIPLE)) {
-        if (conv_guidrec_mboxcmp(rec, bb->mailbox))
+    if (!(bb->session->opts & SEARCH_MULTIPLE)) {
+        if (conv_guidrec_mboxcmp(rec, bb->session->mailbox))
             return 0;
     }
 
@@ -1774,10 +1782,10 @@ static int xapian_run_cb(void *data, size_t nmemb, void *rock)
     int r = cmd_cancelled(/*insearch*/1);
     if (r) return r;
 
-    struct conversations_state *cstate = mailbox_get_cstate(bb->mailbox);
+    struct conversations_state *cstate = mailbox_get_cstate(bb->session->mailbox);
     if (!cstate) {
         syslog(LOG_INFO, "search_xapian: can't open conversations for %s",
-               mailbox_name(bb->mailbox));
+               mailbox_name(bb->session->mailbox));
         return IMAP_NOTFOUND;
     }
 
@@ -1812,7 +1820,7 @@ static int xapian_run_guidsearch_cb(void *data, size_t nmemb, void *rock)
     int r = cmd_cancelled(/*insearch*/1);
     if (r) return r;
 
-    struct conversations_state *cstate = mailbox_get_cstate(bb->mailbox);
+    struct conversations_state *cstate = mailbox_get_cstate(bb->session->mailbox);
     if (!cstate) return IMAP_NOTFOUND;
 
     qsort(data, nmemb, 41, memcmp40); // byte 41 is always zero
@@ -1841,14 +1849,14 @@ static int run_query(xapian_builder_t *bb)
     int r = 0;
 
     /* Validate query for this db */
-    r = validate_query(bb->lock.db, bb->root);
+    r = validate_query(bb->session->lock.db, bb->root);
     if (r) return r;
 
     if (bb->proc_guidsearch) {
-        xq = opnode_to_query(bb->lock.db, bb->root, bb->opts);
+        xq = opnode_to_query(bb->session->lock.db, bb->root, bb->session->opts);
         if (!xq) goto out;
 
-        r = xapian_query_run(bb->lock.db, xq, xapian_run_guidsearch_cb, bb);
+        r = xapian_query_run(bb->session->lock.db, xq, xapian_run_guidsearch_cb, bb);
         goto out;
     }
 
@@ -1903,18 +1911,18 @@ static int run_query(xapian_builder_t *bb)
         goto out;
     }
 
-    xq = opnode_to_query(bb->lock.db, root, bb->opts);
+    xq = opnode_to_query(bb->session->lock.db, root, bb->session->opts);
     if (!xq) goto out;
 
-    struct conversations_state *cstate = mailbox_get_cstate(bb->mailbox);
+    struct conversations_state *cstate = mailbox_get_cstate(bb->session->mailbox);
     if (!cstate) {
         syslog(LOG_INFO, "search_xapian: can't open conversations for %s",
-                mailbox_name(bb->mailbox));
+                mailbox_name(bb->session->mailbox));
         r = IMAP_NOTFOUND;
         goto out;
     }
     // sort the response by GUID for more efficient later handling
-    r = xapian_query_run(bb->lock.db, xq, xapian_run_cb, bb);
+    r = xapian_query_run(bb->session->lock.db, xq, xapian_run_cb, bb);
 
 out:
     if (root && root != bb->root) opnode_delete(root);
@@ -1945,7 +1953,7 @@ static int run_internal(xapian_builder_t *bb)
     /* Sanity check builder */
     assert((bb->proc == NULL) != (bb->proc_guidsearch == NULL));
 
-    if (!bb->lock.db) return 0; // no index for this user
+    if (!bb->session->lock.db) return 0; // no index for this user
 
     /* Validate config */
     r = check_config(NULL);
@@ -1954,7 +1962,7 @@ static int run_internal(xapian_builder_t *bb)
     if (bb->root) optimise_nodes(NULL, bb->root);
 
     /* Stem using any languages explicitly requested by the user. */
-    add_stemmers(bb->lock.db, bb->root);
+    add_stemmers(bb->session->lock.db, bb->root);
 
     return run_query(bb);
 }
@@ -1972,7 +1980,7 @@ static int run_guidsearch(search_builder_t *bx, search_hitguid_cb_t proc, void *
     xapian_builder_t *bb = (xapian_builder_t *)bx;
     bb->proc_guidsearch = proc;
     bb->rock = rock;
-    if (!bb->lock.db) return IMAP_SEARCH_NOT_SUPPORTED;
+    if (!bb->session->lock.db) return IMAP_SEARCH_NOT_SUPPORTED;
     return run_internal(bb);
 }
 
@@ -1986,14 +1994,14 @@ static void begin_boolean(search_builder_t *bx, int op)
     else
         bb->root = on;
     ptrarray_push(&bb->stack, on);
-    if (SEARCH_VERBOSE(bb->opts))
+    if (SEARCH_VERBOSE(bb->session->opts))
         syslog(LOG_INFO, "begin_boolean(op=%s)", search_op_as_string(op));
 }
 
 static void end_boolean(search_builder_t *bx, int op __attribute__((unused)))
 {
     xapian_builder_t *bb = (xapian_builder_t *)bx;
-    if (SEARCH_VERBOSE(bb->opts))
+    if (SEARCH_VERBOSE(bb->session->opts))
         syslog(LOG_INFO, "end_boolean");
     ptrarray_pop(&bb->stack);
 }
@@ -2005,7 +2013,7 @@ static void matchlist(search_builder_t *bx, enum search_part part, const strarra
     struct opnode *on;
 
     if (!vals) return;
-    if (SEARCH_VERBOSE(bb->opts)) {
+    if (SEARCH_VERBOSE(bb->session->opts)) {
         char *item = strarray_join(vals, ",");
         syslog(LOG_INFO, "match(part=%s, str=\"%s\")",
                search_part_as_string(part), item);
@@ -2050,16 +2058,50 @@ static void free_internalised(void *internalised)
 static unsigned min_index_version(search_builder_t *bx)
 {
     xapian_builder_t *bb = (xapian_builder_t *)bx;
-    if (!bb->lock.db) return 0;
-    return xapian_db_min_index_version(bb->lock.db);
+    if (!bb->session->lock.db) return 0;
+    return xapian_db_min_index_version(bb->session->lock.db);
 }
 
-static search_builder_t *begin_search(struct mailbox *mailbox, int opts)
+static search_session_t *begin_session(struct mailbox *mailbox, int opts)
 {
     int r = check_config(NULL);
     if (r) return NULL;
 
     if (!mailbox) return NULL;
+
+    /* make sure conversations.db is open before we take any xapiandb
+     * locks, to avoid deadlocking */
+    struct conversations_state *cstate = mailbox_get_cstate(mailbox);
+    if (!cstate) {
+        xsyslog(LOG_ERR, "can't open conversations", "mailbox=<%s>",
+                mailbox_name(mailbox));
+        return NULL;
+    }
+
+    search_session_t *session = xzmalloc(sizeof(*session));
+    session->mailbox = mailbox;
+    session->opts = opts;
+
+    r = xapiandb_lock_open(mailbox, &session->lock);
+    if (r) {
+        xapiandb_lock_release(&session->lock);
+        free(session);
+        return NULL;
+    }
+
+    return session;
+}
+
+static void end_session(search_session_t *session)
+{
+    if (!session) return;
+    xapiandb_lock_release(&session->lock);
+    free(session);
+}
+
+static search_builder_t *begin_search(search_session_t *session)
+{
+    if (!session) return NULL;
 
     xapian_builder_t *bb = xzmalloc(sizeof(xapian_builder_t));
     bb->super.begin_boolean = begin_boolean;
@@ -2070,37 +2112,8 @@ static search_builder_t *begin_search(struct mailbox *mailbox, int opts)
     bb->super.run = run;
     bb->super.run_guidsearch = run_guidsearch;
     bb->super.min_index_version = min_index_version;
+    bb->session = session;
 
-    bb->mailbox = mailbox;
-    bb->opts = opts;
-
-    /* make sure the conversations are open before we start indexing
-     * to avoid deadlocking against the search state */
-    struct conversations_state *cstate = mailbox_get_cstate(mailbox);
-    if (!cstate) {
-        xsyslog(LOG_ERR, "can't open conversations", "mailbox=<%s>",
-                mailbox_name(mailbox));
-        r = IMAP_MAILBOX_NOTSUPPORTED;
-        goto out;
-    }
-
-    r = xapiandb_lock_open(mailbox, &bb->lock);
-    if (r) goto out;
-    if (!bb->lock.activedirs || !bb->lock.activedirs->count) goto out;
-
-    /* read the list of all indexed messages to allow (optional) false positives
-     * for unindexed messages */
-    // TODO also handle for guidsearch
-    bb->indexed = seqset_init(0, SEQ_MERGE);
-    mbname_t *mbname = mbname_from_intname(mailbox_name(mailbox));
-    r = read_indexed(mbname_userid(mbname),
-            bb->lock.activedirs, bb->lock.activetiers,
-            mailbox_uniqueid(mailbox), bb->indexed, /*do_cache*/0, /*verbose*/0);
-    mbname_free(&mbname);
-    if (r) goto out;
-
-out:
-    /* XXX - error return? */
     return &bb->super;
 }
 
@@ -2108,12 +2121,8 @@ static void end_search(search_builder_t *bx)
 {
     xapian_builder_t *bb = (xapian_builder_t *)bx;
 
-    seqset_free(&bb->indexed);
     ptrarray_fini(&bb->stack);
     if (bb->root) opnode_delete(bb->root);
-
-    xapiandb_lock_release(&bb->lock);
-
     free(bx);
 }
 
@@ -4286,6 +4295,8 @@ static int can_match(enum search_op matchop, enum search_part partnum)
 const struct search_engine xapian_search_engine = {
     "Xapian",
     SEARCH_FLAG_CAN_BATCH | SEARCH_FLAG_CAN_GUIDSEARCH,
+    begin_session,
+    end_session,
     begin_search,
     end_search,
     begin_update,

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -10,7 +10,9 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <syslog.h>
+#include <stdbool.h>
 #include <string.h>
+#include <time.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -41,6 +43,7 @@
 #define INDEXEDDB_VAL_VERSION   2 /* current version for entry value */
 #define INDEXEDDB_VERSION       2 /* current database version */
 #define INDEXEDDB_FNAME         "/cyrus.indexed.db"
+#define INDEXEDDB_KEY_HIGHEST_CREATEDMODSEQ "*HIGHEST_CREATEDMODSEQ*"
 #define XAPIAN_NAME_LOCK_PREFIX "$XAPIAN$"
 
 // this seems to translate for 4Gb-ish  - units are 10 bytes?
@@ -508,6 +511,8 @@ struct indexeddb {
     struct db *db;
     struct txn *txn;
     int version;
+    modseq_t highest_createdmodseq;
+    uint64_t index_generation;
 };
 
 static int indexeddb_close(struct indexeddb **idbptr, int abort)
@@ -608,6 +613,75 @@ static int cachetier_cb(void *vrock, const char *key, size_t keylen,
     return r;
 }
 
+static int read_indexeddb_highest_createdmodseq(struct indexeddb *idb)
+{
+    const char *data = NULL;
+    size_t datalen = 0;
+    int r = cyrusdb_fetch(idb->db,
+            INDEXEDDB_KEY_HIGHEST_CREATEDMODSEQ,
+            strlen(INDEXEDDB_KEY_HIGHEST_CREATEDMODSEQ),
+            &data, &datalen, NULL);
+    if (r == CYRUSDB_NOTFOUND) return 0;
+    if (r) return r;
+
+    // Parse value as: <highest_createdmodseq>":"<index_generation>
+    bit64 modseq = 0;
+    bit64 generation = 0;
+    const char *end = data + datalen;
+    const char *rest = NULL;
+
+    bool parsed = parsenum(data, &rest, datalen, &modseq) == 0;
+    if (parsed)
+        parsed = rest < end && *rest == ':';
+    if (parsed) {
+        rest++; // skip ':'
+        parsed = rest < end;
+    }
+    if (parsed)
+        parsed = parsenum(rest, &rest, end - rest, &generation) == 0;
+    if (parsed)
+        parsed = rest == end; // generation must consume the remaining bytes
+    if (!parsed) {
+        xsyslog(LOG_ERR, "bogus highest_createdmodseq entry",
+                "entry=<%.*s>", (int) datalen, data);
+        return CYRUSDB_INTERNAL;
+    }
+
+    idb->highest_createdmodseq = modseq;
+    idb->index_generation = generation;
+    return 0;
+}
+
+static int store_indexeddb_highest_createdmodseq(struct indexeddb *idb)
+{
+    struct buf buf = BUF_INITIALIZER;
+    buf_printf(&buf, MODSEQ_FMT ":" UINT64_FMT,
+            idb->highest_createdmodseq, idb->index_generation);
+    int r = cyrusdb_store(idb->db,
+            INDEXEDDB_KEY_HIGHEST_CREATEDMODSEQ,
+            strlen(INDEXEDDB_KEY_HIGHEST_CREATEDMODSEQ),
+            buf_base(&buf), buf_len(&buf), &idb->txn);
+    buf_free(&buf);
+    return r;
+}
+
+/* Return a newly allocated path to the cyrus.indexed.db located in the given
+ * xapian directory. Caller frees. */
+static char *indexeddb_fname(const char *dir)
+{
+    struct buf buf = BUF_INITIALIZER;
+    buf_setcstr(&buf, dir);
+
+    // INDEXEDDB_FNAME macro starts with '/'.
+    size_t len = buf_len(&buf);
+    if (len && buf_base(&buf)[len-1] == '/') {
+        buf_truncate(&buf, len - 1);
+    }
+
+    buf_appendcstr(&buf, INDEXEDDB_FNAME);
+    return buf_release(&buf);
+}
+
 /* Open the cyrus.indexed.db located at fname, passing flags to cyrusdb. */
 static int indexeddb_open(const char *userid, const char *fname,
                          int flags, struct indexeddb **idbptr)
@@ -635,6 +709,10 @@ static int indexeddb_open(const char *userid, const char *fname,
             }
         }
         else if (r == CYRUSDB_NOTFOUND) r = 0;
+
+        if (!r) {
+            r = read_indexeddb_highest_createdmodseq(idb);
+        }
     }
     else if (r == CYRUSDB_NOTFOUND && (flags & CYRUSDB_CREATE)) {
         /* Create database */
@@ -653,9 +731,9 @@ static int indexeddb_open(const char *userid, const char *fname,
                 r = cyrusdb_store(idb->db, "*V*", 3,
                         buf_base(&buf), buf_len(&buf), &idb->txn);
                 buf_reset(&buf);
+
                 if (!r) {
-                    r = r ? cyrusdb_abort(idb->db, idb->txn) :
-                        cyrusdb_commit(idb->db, idb->txn);
+                    r = cyrusdb_commit(idb->db, idb->txn);
                     idb->txn = NULL;
                 }
                 if (!r) {
@@ -687,6 +765,31 @@ static int indexeddb_open(const char *userid, const char *fname,
         *idbptr = idb;
     }
     return r;
+}
+
+/* Read the highest createdmodseq and index generation from the indexed.db
+ * located in the xapian database directory dir. Sets both values to zero
+ * if the database or its entry does not exist, or an error occurred. */
+static void read_highest_createdmodseq_at_dir(const char *userid,
+                                              const char *dir,
+                                              modseq_t *highest_createdmodseq,
+                                              uint64_t *index_generation)
+{
+    char *fname = indexeddb_fname(dir);
+    struct indexeddb *idb = NULL;
+
+    if (highest_createdmodseq) *highest_createdmodseq = 0;
+    if (index_generation) *index_generation = 0;
+
+    if (!indexeddb_open(userid, fname, 0, &idb) && idb) {
+        if (highest_createdmodseq)
+            *highest_createdmodseq = idb->highest_createdmodseq;
+        if (index_generation)
+            *index_generation = idb->index_generation;
+    }
+    if (idb) indexeddb_close(&idb, 0);
+
+    free(fname);
 }
 
 /*
@@ -1011,27 +1114,25 @@ static int write_indexed(const char *dir,
                          uint32_t uidvalidity,
                          const char *uniqueid,
                          seqset_t *seq,
+                         modseq_t highest_createdmodseq,
+                         uint64_t index_generation,
                          int verbose)
 {
-    struct buf path = BUF_INITIALIZER;
     struct buf key = BUF_INITIALIZER;
     struct indexeddb *idb = NULL;
     mbname_t *mbname = mbname_from_intname(mboxname);
     const char *userid = mbname_userid(mbname);
+    char *fname = indexeddb_fname(dir);
     int r = 0;
-
-    buf_reset(&path);
-    buf_printf(&path, "%s%s", dir, INDEXEDDB_FNAME);
 
     if (verbose) {
         char *str = seqset_cstring(seq);
         syslog(LOG_INFO, "write_indexed db=%s uniqueid=%s uids=%s",
-               buf_cstring(&path), uniqueid, str);
+               fname, uniqueid, str);
         free(str);
     }
 
-
-    r = indexeddb_open(userid, buf_cstring(&path), CYRUSDB_CREATE, &idb);
+    r = indexeddb_open(userid, fname, CYRUSDB_CREATE, &idb);
     if (r) goto out;
 
     if (idb->version >= 2) {
@@ -1042,6 +1143,15 @@ static int write_indexed(const char *dir,
     }
 
     r = store_indexed(idb, key.s, key.len, seq);
+    if (r) goto out;
+
+    /* Update highest createdmodseq and index generation, if required. */
+    if (highest_createdmodseq != idb->highest_createdmodseq ||
+            index_generation != idb->index_generation) {
+        idb->highest_createdmodseq = highest_createdmodseq;
+        idb->index_generation = index_generation;
+        r = store_indexeddb_highest_createdmodseq(idb);
+    }
 
 out:
     if (idb) {
@@ -1049,7 +1159,7 @@ out:
         if (!r) r = r2;
     }
     mbname_free(&mbname);
-    buf_free(&path);
+    xzfree(fname);
     buf_free(&key);
     return r;
 }
@@ -1171,10 +1281,7 @@ static int upgrade(const char *userid)
 
     int i;
     for (i = 0; i < strarray_size(activedirs); i++) {
-        buf_setcstr(&buf, strarray_nth(activedirs, i));
-        buf_appendcstr(&buf, INDEXEDDB_FNAME);
-
-        char *fname = xstrdup(buf_cstring(&buf));
+        char *fname = indexeddb_fname(strarray_nth(activedirs, i));
         struct indexeddb *idb = NULL;
 
         r = indexeddb_open(userid, fname, CYRUSDB_CREATE, &idb);
@@ -2092,6 +2199,32 @@ static search_session_t *begin_session(struct mailbox *mailbox, int opts)
     return session;
 }
 
+static modseq_t session_get_highest_createdmodseq(search_session_t *session,
+                                                  uint64_t *index_generation)
+{
+    if (index_generation) *index_generation = 0;
+    if (!session || !session->lock.activedirs || !session->lock.activedirs->count)
+        return 0;
+
+    /* Read the highest createdmodseq and index generation from indexeddb
+     * of the top tier. We hold a read lock on the activefile, so multiple
+     * calls to this function in the same session are guaranteed to return
+     * the same values. */
+
+    modseq_t highest_createdmodseq = 0;
+    char *userid = mboxname_to_userid(mailbox_name(session->mailbox));
+
+    // XXX This opens indexeddb on every call. This is fine with the current
+    // callers, but we might cache the highest modseq and index generation
+    // in the session if this gets called multiple times for a session.
+    read_highest_createdmodseq_at_dir(userid,
+            strarray_nth(session->lock.activedirs, 0),
+            &highest_createdmodseq, index_generation);
+
+    free(userid);
+    return highest_createdmodseq;
+}
+
 static void end_session(search_session_t *session)
 {
     if (!session) return;
@@ -2163,6 +2296,14 @@ struct xapian_update_receiver
     hash_table cached_seqs;
     int mode;
     int flags;
+    /* Highest and lowest createdmodseq seen across messages indexed in the
+     * current batch (0 if none seen yet). */
+    modseq_t batch_highest_createdmodseq;
+    modseq_t batch_lowest_createdmodseq;
+    /* The top tier's highest createdmodseq and index generation, read from
+     * indexeddb */
+    modseq_t highest_createdmodseq;
+    uint64_t index_generation;
 };
 
 /* receiver used for extracting snippets after a search */
@@ -2301,12 +2442,33 @@ static int flush(search_text_receiver_t *rx)
 
     /* We write out the indexed list for the mailbox only after successfully
      * updating the index, to avoid a future instance not realising that
-     * there are unindexed messages should we fail to index */
+     * there are unindexed messages should we fail to index. We also write
+     * the highest createdmodseq and bump the index generation, if required */
     if (tr->indexed) {
+        if (tr->batch_lowest_createdmodseq &&
+                tr->batch_lowest_createdmodseq <= tr->highest_createdmodseq) {
+            /* This batch indexed a message that has a lower createdmodseq
+             * than the highest createdmodseq in the index. This means we
+             * either reindexed a message, fully or partially, or a message got
+             * added to the index that wasn't indexed before but the highest
+             * createdmodseq suggested we had. We need to invalidate the
+             * index generation. */
+            tr->index_generation++;
+        }
+
+        /* Update the highest createdmodseq */
+        if (tr->batch_highest_createdmodseq > tr->highest_createdmodseq)
+            tr->highest_createdmodseq = tr->batch_highest_createdmodseq;
+
+        /* Write to the database */
         r = write_indexed(strarray_nth(tr->activedirs, 0),
                 mailbox_name(tr->super.mailbox), tr->super.mailbox->i.uidvalidity,
-                mailbox_uniqueid(tr->super.mailbox), tr->indexed, tr->super.verbose);
+                mailbox_uniqueid(tr->super.mailbox), tr->indexed,
+                tr->highest_createdmodseq, tr->index_generation,
+                tr->super.verbose);
         if (r) goto out;
+        tr->batch_highest_createdmodseq = 0;
+        tr->batch_lowest_createdmodseq = 0;
     }
 
 out:
@@ -2371,16 +2533,34 @@ static void free_segments(xapian_receiver_t *tr)
 
 static int begin_message(search_text_receiver_t *rx, message_t *msg)
 {
-    xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
+    /* Common code to the update and snippet receivers */
+    xapian_receiver_t *tr = (xapian_receiver_t *)rx;
     const struct message_guid *guid = NULL;
 
-    int r = message_get_uid(msg, &tr->super.uid);
+    int r = message_get_uid(msg, &tr->uid);
     if (!r) r = message_get_guid(msg, &guid);
-    if (!r) r = message_get_internaldate(msg, &tr->super.internaldate);
+    if (!r) r = message_get_internaldate(msg, &tr->internaldate);
     if (r) return r;
 
-    message_guid_copy(&tr->super.guid, guid);
-    free_segments((xapian_receiver_t *)tr);
+    message_guid_copy(&tr->guid, guid);
+    free_segments(tr);
+    return 0;
+}
+
+static int begin_message_update(search_text_receiver_t *rx, message_t *msg)
+{
+    int r = begin_message(rx, msg);
+    if (r) return r;
+
+    xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
+    modseq_t createdmodseq = 0;
+    if (!message_get_createdmodseq(msg, &createdmodseq) && createdmodseq) {
+        if (createdmodseq > tr->batch_highest_createdmodseq)
+            tr->batch_highest_createdmodseq = createdmodseq;
+        if (!tr->batch_lowest_createdmodseq ||
+                createdmodseq < tr->batch_lowest_createdmodseq)
+            tr->batch_lowest_createdmodseq = createdmodseq;
+    }
     return 0;
 }
 
@@ -2739,6 +2919,28 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
     r = check_directory(strarray_nth(tr->activedirs, 0), tr->super.verbose, /*create*/1);
     if (r) goto out;
 
+    /* Read highest createdmodseq and index generation of the top tier.
+     * If this is a new tier, read them from the newest former tier that
+     * has them set. */
+    tr->highest_createdmodseq = 0;
+    tr->index_generation = 0;
+    for (int i = 0; i < strarray_size(tr->activedirs); i++) {
+        read_highest_createdmodseq_at_dir(userid,
+                strarray_nth(tr->activedirs, i),
+                &tr->highest_createdmodseq, &tr->index_generation);
+        if (tr->highest_createdmodseq || tr->index_generation)
+            break;
+    }
+    if (!tr->highest_createdmodseq && !tr->index_generation) {
+        /* Could not read from any tier. This must be
+         * a brand-new index. Initialize the index generation to the current
+         * Unix epoch seconds, so a fully rebuilt index does not restart at a
+         * generation a reader may still hold cached from the old index.
+         * Later revisions only bump the generation by one, so within one
+         * index the generation increases regardless of the clock. */
+        tr->index_generation = (uint64_t) time(NULL);
+    }
+
     if (tr->mode == XAPIAN_DBW_XAPINDEXED) {
         /* open the DB now, we need it to check if messages are indexed */
         r = xapian_dbw_open((const char **)tr->activedirs->data, &tr->dbw, tr->mode);
@@ -2935,7 +3137,7 @@ static search_text_receiver_t *begin_update(int verbose)
     tr->super.super.begin_mailbox = begin_mailbox_update;
     tr->super.super.first_unindexed_uid = first_unindexed_uid;
     tr->super.super.is_indexed = is_indexed;
-    tr->super.super.begin_message = begin_message;
+    tr->super.super.begin_message = begin_message_update;
     tr->super.super.begin_bodypart = begin_bodypart;
     tr->super.super.begin_part = begin_part;
     tr->super.super.append_text = append_text;
@@ -3360,10 +3562,10 @@ static int create_filter(const strarray_t *srcpaths, const strarray_t *destpaths
                          const char *userid, int flags, struct mbfilter *filter,
                          int bloom)
 {
-    struct buf buf = BUF_INITIALIZER;
     int r = 0;
     int i;
     struct conversations_state *cstate = NULL;
+    char *destfname = NULL;
 
     memset(filter, 0, sizeof(struct mbfilter));
     filter->destpaths = destpaths;
@@ -3372,28 +3574,51 @@ static int create_filter(const strarray_t *srcpaths, const strarray_t *destpaths
     filter->flags = flags;
 
     /* build the cyrus.indexed.db from the contents of the source dirs */
-
-    buf_reset(&buf);
-    buf_printf(&buf, "%s%s", strarray_nth(destpaths, 0), INDEXEDDB_FNAME);
-
-    r = indexeddb_open(userid, buf_cstring(&buf), CYRUSDB_CREATE, &filter->idb);
+    destfname = indexeddb_fname(strarray_nth(destpaths, 0));
+    r = indexeddb_open(userid, destfname, CYRUSDB_CREATE, &filter->idb);
     if (r) {
-        printf("ERROR: failed to open indexed %s\n", buf_cstring(&buf));
+        printf("ERROR: failed to open indexed %s\n", destfname);
         goto done;
     }
+
+    /* Carry over the highest createdmodseq and index generation of the source
+     * tiers to the destination tier. If the compaction does not reindex, the
+     * index generation is copied as-is. For compaction with reindex, compact_dbs
+     * takes care of updating the generation. */
+    modseq_t highest_createdmodseq = 0;
+    uint64_t index_generation = 0;
     for (i = 0; i < srcpaths->count; i++) {
         struct indexeddb *srcdb = NULL;
-        buf_reset(&buf);
-        buf_printf(&buf, "%s%s", strarray_nth(srcpaths, i), INDEXEDDB_FNAME);
-        r = indexeddb_open(userid, buf_cstring(&buf), 0, &srcdb);
+        char *srcfname = indexeddb_fname(strarray_nth(srcpaths, i));
+        r = indexeddb_open(userid, srcfname, 0, &srcdb);
+        xzfree(srcfname);
         if (r) {
             r = 0;
             continue;
         }
+
+        if (srcdb->highest_createdmodseq > highest_createdmodseq)
+            highest_createdmodseq = srcdb->highest_createdmodseq;
+        if (srcdb->index_generation > index_generation)
+            index_generation = srcdb->index_generation;
+
         r = cyrusdb_foreach(srcdb->db, "", 0, NULL, copyindexed_cb, filter, NULL);
         indexeddb_close(&srcdb, r);
         if (r) {
             printf("ERROR: failed to process indexed db %s\n", strarray_nth(srcpaths, i));
+            goto done;
+        }
+    }
+    if (highest_createdmodseq > filter->idb->highest_createdmodseq ||
+            index_generation > filter->idb->index_generation) {
+        if (highest_createdmodseq > filter->idb->highest_createdmodseq)
+            filter->idb->highest_createdmodseq = highest_createdmodseq;
+        if (index_generation > filter->idb->index_generation)
+            filter->idb->index_generation = index_generation;
+        r = store_indexeddb_highest_createdmodseq(filter->idb);
+        if (r) {
+            printf("ERROR: failed to store highest createdmodseq and index generation in %s\n",
+                   strarray_nth(destpaths, 0));
             goto done;
         }
     }
@@ -3421,8 +3646,7 @@ static int create_filter(const strarray_t *srcpaths, const strarray_t *destpaths
 
 done:
     conversations_commit(&cstate);
-    buf_free(&buf);
-
+    free(destfname);
     return r;
 }
 
@@ -3784,6 +4008,68 @@ static void cleanup_xapiandirs(const char *mboxname, const char *partition, stra
     strarray_fini(&bogus);
 }
 
+static int compact_set_highest_createdmodseq(const char *userid,
+                                             const char *topdir,
+                                             const char *srcdir,
+                                             bool did_reindex)
+{
+    modseq_t highest_createdmodseq = 0;
+    uint64_t index_generation = 0;
+    struct indexeddb *idb = NULL;
+    char *fname = NULL;
+    int r = 0;
+
+    /* Read highest_createdmodseq from source tier. */
+    if (srcdir && strcmp(topdir, srcdir)) {
+        char *src_fname = indexeddb_fname(srcdir);
+        struct indexeddb *src_idb = NULL;
+
+        r = indexeddb_open(userid, src_fname, 0, &src_idb);
+        if (!r) {
+            highest_createdmodseq = src_idb->highest_createdmodseq;
+            index_generation = src_idb->index_generation;
+            r = indexeddb_close(&src_idb, r);
+        }
+        else if (r == CYRUSDB_NOTFOUND) {
+            r = 0;
+        }
+
+        free(src_fname);
+        if (r) goto done;
+    }
+
+    /* Write highest_createmodseq to top tier. */
+    fname = indexeddb_fname(topdir);
+    r = indexeddb_open(userid, fname, CYRUSDB_CREATE, &idb);
+    if (r) goto done;
+
+    if (idb->highest_createdmodseq > highest_createdmodseq)
+        highest_createdmodseq = idb->highest_createdmodseq;
+    if (idb->index_generation > index_generation)
+        index_generation = idb->index_generation;
+
+    if (did_reindex) {
+        /* Reset the index generation. This typically becomes the Unix epoch
+         * seconds. But if the index generation of the former tier had gone
+         * *past* the current epoch seconds, we'll keep bumping it by one. */
+        uint64_t now = (uint64_t) time(NULL);
+        index_generation = index_generation + 1 > now ?
+            index_generation + 1 : now;
+    }
+
+    if (highest_createdmodseq != idb->highest_createdmodseq ||
+            index_generation != idb->index_generation) {
+        idb->highest_createdmodseq = highest_createdmodseq;
+        idb->index_generation = index_generation;
+        r = store_indexeddb_highest_createdmodseq(idb);
+    }
+
+done:
+    free(fname);
+    int r2 = indexeddb_close(&idb, r);
+    return r ? r : r2;
+}
+
 static int compact_dbs(const char *userid, const strarray_t *reindextiers,
                        const strarray_t *srctiers, const char *desttier,
                        int flags)
@@ -4094,6 +4380,44 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
         strarray_free(newactive);
     }
 
+    if (!created_something) {
+        if (verbose) {
+            printf("nothing compacted, cleaning up %s\n", newdest);
+        }
+        strarray_append(tochange, newdest);
+    }
+
+    for (i = 0; i < tochange->count; i++)
+        strarray_remove_all(active, strarray_nth(tochange, i));
+
+    /* Write the highest createdmodseq and index generation of the
+     * destination tier to the new top tier. */
+    {
+        char *topdir = NULL;
+        for (i = 0; i < active->count; i++) {
+            const char *item = strarray_nth(active, i);
+            if (!strcmp(item, newdest)) {
+                if (created_something) topdir = xstrdup(tempdestdir);
+            }
+            else {
+                topdir = activefile_path(mboxname, mbentry->partition, item,
+                                         /*dostat*/1);
+            }
+            if (topdir) break;
+        }
+        if (topdir) {
+            r = compact_set_highest_createdmodseq(userid, topdir,
+                    created_something ? tempdestdir : NULL,
+                    toreindex && toreindex->count);
+            free(topdir);
+            if (r) {
+                printf("ERROR: failed to carry highest createdmodseq for %s\n",
+                       mboxname);
+                goto out;
+            }
+        }
+    }
+
     if (created_something) {
         /* rename the destination data into place */
         if (verbose) {
@@ -4106,15 +4430,6 @@ static int compact_dbs(const char *userid, const strarray_t *reindextiers,
             goto out;
         }
     }
-    else {
-        if (verbose) {
-            printf("nothing compacted, cleaning up %s\n", newdest);
-        }
-        strarray_append(tochange, newdest);
-    }
-
-    for (i = 0; i < tochange->count; i++)
-        strarray_remove_all(active, strarray_nth(tochange, i));
 
     /* Get an exclusive lock on the activefile */
     mappedfile_writelock(activefile);
@@ -4299,6 +4614,7 @@ const struct search_engine xapian_search_engine = {
     end_session,
     begin_search,
     end_search,
+    session_get_highest_createdmodseq,
     begin_update,
     end_update,
     begin_snippets,

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2454,6 +2454,14 @@ static int flush(search_text_receiver_t *rx)
              * createdmodseq suggested we had. We need to invalidate the
              * index generation. */
             tr->index_generation++;
+            xsyslog_ev(LOG_INFO, "bumping index generation",
+                    lf_s("mailbox", mailbox_name(tr->super.mailbox)),
+                    lf_llu("batch_lowest_createdmodseq",
+                        tr->batch_lowest_createdmodseq),
+                    lf_llu("batch_highest_createdmodseq",
+                        tr->batch_highest_createdmodseq),
+                    lf_llu("highest_createdmodseq", tr->highest_createdmodseq),
+                    lf_llu("index_generation", tr->index_generation));
         }
 
         /* Update the highest createdmodseq */

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -792,32 +792,6 @@ static void read_highest_createdmodseq_at_dir(const char *userid,
     free(fname);
 }
 
-/* Store the highest createdmodseq and index generation in the indexed.db
- * located in the xapian database directory dir. */
-static int store_highest_createdmodseq_at_dir(const char *userid,
-                                              const char *dir,
-                                              modseq_t highest_createdmodseq,
-                                              uint64_t index_generation)
-{
-    char *fname = indexeddb_fname(dir);
-    struct indexeddb *idb = NULL;
-
-    int r = indexeddb_open(userid, fname, CYRUSDB_CREATE, &idb);
-    if (!r && (idb->highest_createdmodseq != highest_createdmodseq ||
-                idb->index_generation != index_generation)) {
-        idb->highest_createdmodseq = highest_createdmodseq;
-        idb->index_generation = index_generation;
-        r = store_indexeddb_highest_createdmodseq(idb);
-    }
-    if (idb) {
-        int r2 = indexeddb_close(&idb, r);
-        if (!r) r = r2;
-    }
-
-    free(fname);
-    return r;
-}
-
 /*
  * Merge the indexed.db of all search tiers activetiers[1..n] into the
  * indexed.db of the top tier.
@@ -2315,6 +2289,8 @@ struct xapian_update_receiver
     struct mboxlock *xapiandb_namelock;
     unsigned int uncommitted;
     unsigned int commits;
+    /* True if any commit failed during the current mailbox update. */
+    bool commit_failed;
     seqset_t *oldindexed;
     seqset_t *indexed;
     strarray_t *activedirs;
@@ -2322,10 +2298,13 @@ struct xapian_update_receiver
     hash_table cached_seqs;
     int mode;
     int flags;
-    /* Highest and lowest createdmodseq seen across messages indexed in the
-     * current batch (0 if none seen yet). */
+    /* Highest and lowest createdmodseq across the messages indexed by the
+     * current mailbox update (0 if none got indexed yet). */
     modseq_t batch_highest_createdmodseq;
     modseq_t batch_lowest_createdmodseq;
+    /* The createdmodseq of the message currently being indexed. It only
+     * counts towards the batch createdmodseqs once that message is indexed. */
+    modseq_t msg_createdmodseq;
     /* The top tier's highest createdmodseq and index generation, read from
      * indexeddb */
     modseq_t highest_createdmodseq;
@@ -2445,34 +2424,59 @@ out:
     return r;
 }
 
-static int flush_internal(search_text_receiver_t *rx, bool has_more)
+/* Commit the messages indexed so far, if any. */
+static int commit_transaction(xapian_update_receiver_t *tr)
 {
-    xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
-    int r = 0;
     struct timeval start, end;
 
-    if (tr->uncommitted) {
-        assert(tr->dbw);
+    if (!tr->uncommitted) return 0;
 
-        gettimeofday(&start, NULL);
-        r = xapian_dbw_commit_txn(tr->dbw);
-        if (r) goto out;
-        gettimeofday(&end, NULL);
+    assert(tr->dbw);
 
-        syslog(LOG_INFO, "Xapian committed %u updates in %.6f sec",
-                    tr->uncommitted, timesub(&start, &end));
+    // Reset uncommitted in the receiver regardless of whether the commit
+    // succeeds or fails. We can't recover from failed commits.
+    unsigned int uncommitted = tr->uncommitted;
+    tr->uncommitted = 0;
 
-        tr->uncommitted = 0;
-        tr->commits++;
+    gettimeofday(&start, NULL);
+    int r = xapian_dbw_commit_txn(tr->dbw);
+    gettimeofday(&end, NULL);
+    if (r) {
+        tr->commit_failed = true; // keep track of failed commit
+        xsyslog_ev(LOG_ERR, "failed to commit transaction",
+                lf_s("mailbox", mailbox_name(tr->super.mailbox)),
+                lf_u("uncommitted", uncommitted),
+                lf_f("seconds", timesub(&start, &end)),
+                lf_s("error", error_message(r)));
+        return r;
     }
 
-    /* Update the highest createdmodseq and bump the index generation to
-     * cover all batches indexed since begin_mailbox. This must only happen
-     * once the mailbox update is complete (has_more is false): a message
-     * indexed by a later batch of the same update may have a lower
-     * createdmodseq than the highest createdmodseq of an earlier batch,
-     * which would spuriously invalidate the index generation. */
-    if (!has_more && tr->batch_highest_createdmodseq) {
+    xsyslog_ev(LOG_INFO, "committed Xapian transaction",
+                lf_u("committed", uncommitted),
+                lf_f("seconds", timesub(&start, &end)));
+
+    tr->commits++;
+    return 0;
+}
+
+/* Write the index state of this mailbox: the list of the messages that got
+ * indexed, the highest createdmodseq they cover and the index generation.
+ * These must get written together and exactly once for a mailbox update,
+ * a reader seeing a message as indexed but the generation not bumped for
+ * it would miss that its cached query results went stale. */
+static int update_indexeddb(xapian_update_receiver_t *tr)
+{
+    if (tr->commit_failed) {
+        xsyslog_ev(LOG_ERR, "not updating indexed.db after failed commit",
+                lf_s("mailbox", mailbox_name(tr->super.mailbox)));
+        return IMAP_IOERROR;
+    }
+
+    /* Nothing got indexed, so there is no state to write. Only a message
+     * that got indexed contributes a batch createdmodseq. */
+    if (!tr->indexed) return 0;
+
+    if (tr->batch_highest_createdmodseq) {
         if (tr->batch_lowest_createdmodseq <= tr->highest_createdmodseq) {
             /* This update indexed a message that has a lower createdmodseq
              * than the highest createdmodseq in the index. This means we
@@ -2498,41 +2502,20 @@ static int flush_internal(search_text_receiver_t *rx, bool has_more)
 
     /* We write out the indexed list for the mailbox only after successfully
      * updating the index, to avoid a future instance not realising that
-     * there are unindexed messages should we fail to index. This also
-     * persists the highest createdmodseq and index generation. */
-    if (tr->indexed) {
-        r = write_indexed(strarray_nth(tr->activedirs, 0),
-                mailbox_name(tr->super.mailbox), tr->super.mailbox->i.uidvalidity,
-                mailbox_uniqueid(tr->super.mailbox), tr->indexed,
-                tr->highest_createdmodseq, tr->index_generation,
-                tr->super.verbose);
-        if (r) goto out;
-    }
-    else if (!has_more && tr->batch_highest_createdmodseq && tr->activedirs) {
-        /* There is no indexed list to write, but an earlier batch of this
-         * update still indexed messages whose highest createdmodseq and
-         * index generation we must persist. */
-        r = store_highest_createdmodseq_at_dir(mbname_userid(tr->super.mbname),
-                strarray_nth(tr->activedirs, 0),
-                tr->highest_createdmodseq, tr->index_generation);
-        if (r) goto out;
-    }
-
-    if (!has_more) {
-        tr->batch_highest_createdmodseq = 0;
-        tr->batch_lowest_createdmodseq = 0;
-    }
-
-out:
-    return r;
+     * there are unindexed messages should we fail to index. */
+    return write_indexed(strarray_nth(tr->activedirs, 0),
+            mailbox_name(tr->super.mailbox), tr->super.mailbox->i.uidvalidity,
+            mailbox_uniqueid(tr->super.mailbox), tr->indexed,
+            tr->highest_createdmodseq, tr->index_generation,
+            tr->super.verbose);
 }
 
 static int flush(search_text_receiver_t *rx)
 {
-    /* A flush via the receiver API is always intermediate: more batches may
-     * follow, and the mailbox update is only complete once end_mailbox is
-     * called. The highest createdmodseq is committed from end_mailbox_update. */
-    return flush_internal(rx, /*has_more*/true);
+    xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
+    /* Only commit the messages in Xapian. We'll update indexed.db
+     * in end_mailbox_update. */
+    return tr->super.mailbox ? commit_transaction(tr) : 0;
 }
 
 static int audit_mailbox(search_text_receiver_t *rx, bitvector_t *unindexed)
@@ -2613,14 +2596,8 @@ static int begin_message_update(search_text_receiver_t *rx, message_t *msg)
     if (r) return r;
 
     xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
-    modseq_t createdmodseq = 0;
-    if (!message_get_createdmodseq(msg, &createdmodseq) && createdmodseq) {
-        if (createdmodseq > tr->batch_highest_createdmodseq)
-            tr->batch_highest_createdmodseq = createdmodseq;
-        if (!tr->batch_lowest_createdmodseq ||
-                createdmodseq < tr->batch_lowest_createdmodseq)
-            tr->batch_lowest_createdmodseq = createdmodseq;
-    }
+    tr->msg_createdmodseq = 0;
+    message_get_createdmodseq(msg, &tr->msg_createdmodseq);
     return 0;
 }
 
@@ -2844,10 +2821,20 @@ static int end_message_update(search_text_receiver_t *rx, uint8_t indexlevel)
     }
     seqset_add(tr->indexed, tr->super.uid, 1);
 
+    /* This message is indexed, so it counts towards the createdmodseqs */
+    if (tr->msg_createdmodseq) {
+        if (tr->msg_createdmodseq > tr->batch_highest_createdmodseq)
+            tr->batch_highest_createdmodseq = tr->msg_createdmodseq;
+        if (!tr->batch_lowest_createdmodseq ||
+                tr->msg_createdmodseq < tr->batch_lowest_createdmodseq)
+            tr->batch_lowest_createdmodseq = tr->msg_createdmodseq;
+    }
+
 out:
     tr->super.uid = 0;
     message_guid_set_null(&tr->super.guid);
     tr->super.internaldate = 0;
+    tr->msg_createdmodseq = 0;
     return r;
 }
 
@@ -2860,6 +2847,42 @@ static int _starts_with_tier(const strarray_t *active, const char *tier)
     int res = !strcmp(item->tier, tier);
     activeitem_free(item);
     return res;
+}
+
+static void cleanup_mailbox_update(xapian_update_receiver_t *tr)
+{
+    seqset_free(&tr->indexed);
+    seqset_free(&tr->oldindexed);
+
+    tr->super.mailbox = NULL;
+    mbname_free(&tr->super.mbname);
+
+    if (tr->dbw) {
+        xapian_dbw_close(tr->dbw);
+        tr->dbw = NULL;
+    }
+
+    if (tr->activefile) {
+        mappedfile_unlock(tr->activefile);
+        mappedfile_close(&tr->activefile);
+        tr->activefile = NULL;
+    }
+
+    if (tr->xapiandb_namelock) {
+        mboxname_release(&tr->xapiandb_namelock);
+        tr->xapiandb_namelock = NULL;
+    }
+
+    if (tr->activedirs) {
+        strarray_free(tr->activedirs);
+        tr->activedirs = NULL;
+    }
+    if (tr->activetiers) {
+        strarray_free(tr->activetiers);
+        tr->activetiers = NULL;
+    }
+
+    tr->flags = 0;
 }
 
 static int begin_mailbox_update(search_text_receiver_t *rx,
@@ -2876,6 +2899,9 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
     tr->flags = flags;
     tr->mode = (flags & (SEARCH_UPDATE_XAPINDEXED|SEARCH_UPDATE_AUDIT)) ?
         XAPIAN_DBW_XAPINDEXED : XAPIAN_DBW_CONVINDEXED;
+    tr->commit_failed = false;
+    tr->batch_highest_createdmodseq = 0;
+    tr->batch_lowest_createdmodseq = 0;
 
     /* not an indexable mailbox, fine - return a code to avoid
      * trying to index each message as well */
@@ -3026,6 +3052,7 @@ static int begin_mailbox_update(search_text_receiver_t *rx,
     tr->super.mbname = mbname_from_intname(mailbox_name(mailbox));
 
 out:
+    if (r) cleanup_mailbox_update(tr);
     free(fname);
     free(userid);
     free(namelock_fname);
@@ -3135,51 +3162,19 @@ static uint8_t is_indexed(search_text_receiver_t *rx, message_t *msg)
 
 static int end_mailbox_update(search_text_receiver_t *rx,
                               struct mailbox *mailbox
-                            __attribute__((unused)),
-                              bool has_more)
+                            __attribute__((unused)))
 {
     xapian_update_receiver_t *tr = (xapian_update_receiver_t *)rx;
     int r = 0;
 
-    /* flush_internal handles updating the highest createdmodseq and index
-     * generation once the mailbox update is complete, see has_more. */
-    r = flush_internal(rx, has_more);
-
-    /* flush before cleaning up, since indexed data is written by flush */
-    seqset_free(&tr->indexed);
-    seqset_free(&tr->oldindexed);
-
-    tr->super.mailbox = NULL;
-    mbname_free(&tr->super.mbname);
-
-    if (tr->dbw) {
-        xapian_dbw_close(tr->dbw);
-        tr->dbw = NULL;
+    if (tr->super.mailbox) {
+        /* Commit whatever is left, then write the index state of this
+         * mailbox. Nothing is indexed for it after this point. */
+        r = commit_transaction(tr);
+        if (!r) r = update_indexeddb(tr);
     }
 
-    /* don't unlock until DB is committed */
-    if (tr->activefile) {
-        mappedfile_unlock(tr->activefile);
-        mappedfile_close(&tr->activefile);
-        tr->activefile = NULL;
-    }
-
-    /* Release xapian db named lock */
-    if (tr->xapiandb_namelock) {
-        mboxname_release(&tr->xapiandb_namelock);
-        tr->xapiandb_namelock = NULL;
-    }
-
-    if (tr->activedirs) {
-        strarray_free(tr->activedirs);
-        tr->activedirs = NULL;
-    }
-    if (tr->activetiers) {
-        strarray_free(tr->activetiers);
-        tr->activetiers = NULL;
-    }
-
-    tr->flags = 0;
+    cleanup_mailbox_update(tr);
 
     return r;
 }
@@ -3392,8 +3387,7 @@ static int end_message_snippets(search_text_receiver_t *rx,
 
 static int end_mailbox_snippets(search_text_receiver_t *rx,
                                 struct mailbox *mailbox
-                                    __attribute__((unused)),
-                                bool has_more __attribute__((unused)))
+                                    __attribute__((unused)))
 {
     xapian_snippet_receiver_t *tr = (xapian_snippet_receiver_t *)rx;
 

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -657,12 +657,16 @@ static int do_search(const char *query, int single, const strarray_t *mboxnames)
         if (single)
             printf("mailbox %s\n", mboxname);
 
-        bx = search_begin_search(mailbox, opts);
-        if (bx) {
-            r = squatter_build_query(bx, query);
-            if (!r)
-                bx->run(bx, print_search_hit, &single);
-            search_end_search(bx);
+        search_session_t *session = search_begin_session(mailbox, opts);
+        if (session) {
+            bx = search_begin_search(session);
+            if (bx) {
+                r = squatter_build_query(bx, query);
+                if (!r)
+                    bx->run(bx, print_search_hit, &single);
+                search_end_search(bx);
+            }
+            search_end_session(session);
         }
 
         mailbox_close(&mailbox);

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -127,6 +127,7 @@ __attribute__((noreturn)) static int usage(const char *name)
             "Experimental options:\n"
             "  --attachextract-cache-dir=DIR  cache extracted attachment text in DIR\n"
             "  --attachextract-cache-only     only extract attachment text from the cache\n"
+            "  --highest-createdmodseq        print index highest createdmodseq and generation (requires -u)\n"
             "\n"
 
             "General options:\n"
@@ -675,6 +676,40 @@ static int do_search(const char *query, int single, const strarray_t *mboxnames)
     return 0;
 }
 
+static int do_highest_createdmodseq(int nuserids, const char **userids)
+{
+    int opts = SEARCH_VERBOSE(verbose);
+
+    /* For each user, open a session on their inbox and report the
+     * highest createdmodseq and index generation of their index. */
+    for (int i = 0 ; i < nuserids ; i++) {
+        const char *userid = userids[i];
+        char *inboxname = mboxname_user_mbox(userid, NULL);
+
+        struct mailbox *mailbox = NULL;
+        int r = mailbox_open_irl(inboxname, &mailbox);
+        if (r) {
+            fprintf(stderr, "Cannot open inbox for user %s: %s\n",
+                    userid, error_message(r));
+            free(inboxname);
+            continue;
+        }
+
+        search_session_t *session = search_begin_session(mailbox, opts);
+        uint64_t index_generation = 0;
+        modseq_t highest_createdmodseq =
+            search_session_get_highest_createdmodseq(session, &index_generation);
+        printf("%s " MODSEQ_FMT " " UINT64_FMT "\n", userid,
+               highest_createdmodseq, index_generation);
+        search_end_session(session);
+
+        mailbox_close(&mailbox);
+        free(inboxname);
+    }
+
+    return 0;
+}
+
 static strarray_t *read_sync_log_items(sync_log_reader_t *slr)
 {
     const char *args[3];
@@ -934,7 +969,7 @@ int main(int argc, char **argv)
     const char *desttier = NULL;
     char *errstr = NULL;
     enum { UNKNOWN, INDEXER, SEARCH, ROLLING, SYNCLOG,
-           COMPACT, AUDIT, LIST } mode = UNKNOWN;
+           COMPACT, AUDIT, LIST, HIGHEST_CREATEDMODSEQ } mode = UNKNOWN;
     const char *axcachedir = NULL;
     int axcacheonly = 0;
     FILE *waitdaemon_status = NULL;
@@ -947,6 +982,7 @@ int main(int argc, char **argv)
     enum squatter_long_options {
         SQUATTER_ATTACHEXTRACT_CACHE_DIR = 1024,
         SQUATTER_ATTACHEXTRACT_CACHE_ONLY,
+        SQUATTER_HIGHEST_CREATEDMODSEQ,
     };
 
     /* Keep these ordered by mode */
@@ -1001,6 +1037,8 @@ int main(int argc, char **argv)
             SQUATTER_ATTACHEXTRACT_CACHE_DIR },
         {"attachextract-cache-only", no_argument, 0,
             SQUATTER_ATTACHEXTRACT_CACHE_ONLY },
+        {"highest-createdmodseq", no_argument, 0,
+            SQUATTER_HIGHEST_CREATEDMODSEQ },
 
         /* misc */
         {"help", no_argument, 0, 'h' },
@@ -1178,6 +1216,11 @@ int main(int argc, char **argv)
             axcacheonly = 1;
             break;
 
+        case SQUATTER_HIGHEST_CREATEDMODSEQ:
+            if (mode != UNKNOWN) usage(argv[0]);
+            mode = HIGHEST_CREATEDMODSEQ;
+            break;
+
         case 'h':
         default:
             usage("squatter");
@@ -1291,6 +1334,11 @@ int main(int argc, char **argv)
         if (recursive_flag && optind == argc) usage(argv[0]);
         expand_mboxnames(&mboxnames, argc-optind, (const char **)argv+optind, user_mode);
         r = do_list(&mboxnames);
+        break;
+    case HIGHEST_CREATEDMODSEQ:
+        /* require -u and at least one user */
+        if (!user_mode || optind == argc) usage(argv[0]);
+        r = do_highest_createdmodseq(argc-optind, (const char **)argv+optind);
         break;
     }
 

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -886,7 +886,7 @@ static int audit_one(const char *mboxname, bitvector_t *unindexed)
     if (r) goto done;
 
 done:
-    r2 = rx->end_mailbox(rx, mailbox);
+    r2 = rx->end_mailbox(rx, mailbox, /*has_more*/false);
     mailbox_close(&mailbox);
     if (!r) r = r2;
     return r;

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -270,10 +270,16 @@ done:
 
 /* ====================================================================== */
 
+/* How many times to repeat an update of the same mailbox that indexed no
+ * message at all. Such an update can only complete if whatever kept it from
+ * indexing goes away, so give up rather than block this run on it. */
+#define MAX_UNPRODUCTIVE_UPDATES 3
+
 /* This is called once for each mailbox we're told to index. */
 static int index_one(const char *name, int blocking)
 {
     struct mailbox *mailbox = NULL;
+    int nunproductive = 0;
     int r;
     int flags = SEARCH_UPDATE_BATCH;
 
@@ -376,14 +382,28 @@ again:
         }
     }
 
-    r = search_update_mailbox(rx, &mailbox, reindex_minlevel, flags);
+    size_t nindexed = 0;
+    r = search_update_mailbox(rx, &mailbox, reindex_minlevel, flags, &nindexed);
 
     mailbox_close(&mailbox);
 
     /* in non-blocking (rolling) mode, only do one batch per mailbox at
      * a time for fairness [IRIS-2471].  The squatter will re-insert the
      * mailbox in the queue */
-    if (blocking && r == IMAP_AGAIN) goto again;
+    if (blocking && r == IMAP_AGAIN) {
+        /* Batching an update indexes messages, so keep going. An update
+         * that indexed nothing, e.g. because the mailbox got recreated
+         * while we extracted its attachment text, may never complete. */
+        if (nindexed) {
+            nunproductive = 0;
+            goto again;
+        }
+        if (++nunproductive <= MAX_UNPRODUCTIVE_UPDATES) goto again;
+
+        xsyslog_ev(LOG_ERR, "giving up on mailbox that indexes no message",
+                lf_s("mboxname", name),
+                lf_d("updates", nunproductive));
+    }
     free(extname);
 
     return r;
@@ -433,6 +453,7 @@ static void expand_mboxnames(strarray_t *sa, int nmboxnames,
 static int do_indexer(const strarray_t *mboxnames)
 {
     int r = 0;
+    int rincomplete = 0;
     int i;
 
     rx = search_begin_update(verbose);
@@ -447,6 +468,12 @@ static int do_indexer(const strarray_t *mboxnames)
             r = 0;
         if (r == IMAP_MAILBOX_LOCKED)
             r = 0; /* XXX - try again? */
+        if (r == IMAP_AGAIN) {
+            /* index_one gave up on this mailbox. Keep indexing the others,
+             * but report the incomplete index for this run. */
+            rincomplete = r;
+            r = 0;
+        }
         if (r) break;
         if (sleepmicroseconds)
             usleep(sleepmicroseconds);
@@ -454,7 +481,7 @@ static int do_indexer(const strarray_t *mboxnames)
 
     search_end_update(rx);
 
-    return r;
+    return r ? r : rincomplete;
 }
 
 static int squatter_build_query(search_builder_t *bx, const char *query)
@@ -873,22 +900,21 @@ static void do_rolling(const char *channel)
 
 static int audit_one(const char *mboxname, bitvector_t *unindexed)
 {
-    int r2, r = 0;
     struct mailbox *mailbox = NULL;
 
-    r = mailbox_open_irl(mboxname, &mailbox);
-    if (r) goto done;
+    int r = mailbox_open_irl(mboxname, &mailbox);
+    if (r) return r;
 
+    /* only end a mailbox that we did begin */
     r = rx->begin_mailbox(rx, mailbox, SEARCH_UPDATE_AUDIT);
-    if (r) goto done;
+    if (!r) {
+        r = rx->audit_mailbox(rx, unindexed);
 
-    r = rx->audit_mailbox(rx, unindexed);
-    if (r) goto done;
+        int r2 = rx->end_mailbox(rx, mailbox);
+        if (!r) r = r2;
+    }
 
-done:
-    r2 = rx->end_mailbox(rx, mailbox, /*has_more*/false);
     mailbox_close(&mailbox);
-    if (!r) r = r2;
     return r;
 }
 


### PR DESCRIPTION
This fixes a race condition between `Email/query[Changes]` and squatter for queries that require full text search. To do so, it adds a new entry in cyrus.indexed.db in the Xapian backend which tracks the highest createdmodseq of all messages in the search index. This allows to limit messages in `Email/query[Changes]` results to those messages that also already are indexed.

Without this change, a message that arrives before `Email/query` finishes but before squatter indexes it can produce a query state that encodes that message's createdmodseq. Following `queryChanges` request then skip past that message, producing invalid queryChanges results.

This change is backwards compatible: as long as the index didn't get written with a new message, `Email/query[Changes]` will execute as before (including the race condition bug). As soon as a new message got indexed, the `Email/query` responses will include the new query state and queryChanges requests with a stale query state will get rejected with `cannotCalculateChanges`.

This change is done in multiple steps, each step is a commit:

1. `search_engines.h: require a read-locked session for queries` refactors the existing query code so that multiple queries can share the same read-lock on the Xapian backend. This is required so that no squatter can run in between two subqueries of a query and invalidate the createdmodseq that's kept now in cyrus.indexed.db.
2. `search_xapian.c: store highest createdmodseq in indexed.db` updates the Xapian backend code to store the highest createdmodseq (and an index generation marker) in cyrus.indexed.db. This covers all usage scenarios of squatter, including compaction with and without reindexing.
3. `jmap_mail.c: fix race condition between queryChanges and squatter` then plumbs that newly introduced createdmodseq of the search index in the JMAP `Email/query[Changes]` code.

An additional tiny commit updates the documentation for squatter for the attachextract feature. This is not related to this change, but it naturally fit in when I updated the squatter docs.

Looking at the commit messages, you might be tempted to think that they are unnecessarily verbose LLM output. They are not, I wrote them as succinctly as possible to still cover the design. If you miss something there or in the source documentation, please let me know.

Thanks to @wolfsage for providing the initial Cassandane test that reproduced the race condition.