### PR TITLE
cassandane: finer granularity cleanup option

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1121,9 +1121,12 @@ sub post_tear_down
 {
     my ($self, $result) = @_;
 
+    my $cassini = Cassandane::Cassini->instance();
+    my $cleanup = $cassini->val('cassandane', 'cleanup', 'no');
+
     if ($result eq 'pass'
         && ref $self->{cleanup_basedirs}
-        && Cassandane::Cassini->instance()->bool_val('cassandane', 'cleanup')
+        && ($cleanup eq 'yes' or $cleanup eq 'post')
     ) {
         foreach my $basedir (@{$self->{cleanup_basedirs}}) {
             xlog $self, "Cleaning up basedir " . $basedir;

--- a/cassandane/cassandane.ini.example
+++ b/cassandane/cassandane.ini.example
@@ -74,9 +74,18 @@
 #    usernames and passwords, but it requires installing the package
 #    containing the saslpasswd2 binary.
 ##pwcheck = alwaystrue
-# Whether to clean up instance directories after their tests have
-# run (also, will remove and old instance directories from earlier
-# runs).  See also the --cleanup option to testrunner.pl.
+# Automatic cleanup of instance directories.  These can take up a lot
+# of disk space!  Value is one of 'yes', 'no', 'pre', or 'post'.
+#
+# pre:  before running tests, removes any instance directories left
+#       behind by previous runs
+# post: after running tests, removes instance directories for tests
+#       that passed (failures are left behind for autopsy)
+# yes:  both pre and post cleanup phases are run
+# no:   (default) neither cleanup phase is run
+#
+# The --cleanup option to testrunner.pl accepts the same values and
+# overrides whatever is set here.
 ##cleanup = no
 # How many worker processes to run.  Overridden by -j argument to
 # testrunner.pl.

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -174,9 +174,11 @@ while (defined(my $a = shift))
     {
         $cassini_filename = shift;
     }
-    elsif ($a eq '-c' || $a eq '--cleanup')
+    elsif ($a eq '-c' || $a =~ m/^--cleanup(?:=(\w*))?$/)
     {
-        push(@cassini_overrides, ['cassandane', 'cleanup', 'yes']);
+        my $v = $1 // 'yes';
+        usage if not grep { $v eq $_ } qw(yes no pre post);
+        push(@cassini_overrides, ['cassandane', 'cleanup', $v]);
     }
     elsif ($a eq '--no-cleanup')
     {
@@ -283,8 +285,11 @@ while (defined(my $a = shift))
 my $cassini = Cassandane::Cassini->new(filename => $cassini_filename);
 map { $cassini->override(@$_); } @cassini_overrides;
 
-Cassandane::Instance::cleanup_leftovers()
-    if ($cassini->bool_val('cassandane', 'cleanup'));
+# pre-run cleanup
+my $cleanup = $cassini->val('cassandane', 'cleanup', 'no');
+if ($cleanup eq 'yes' or $cleanup eq 'pre') {
+    Cassandane::Instance::cleanup_leftovers();
+}
 
 my $rootdir = $cassini->val('cassandane', 'rootdir', '/var/tmp/cass');
 unless (-e $rootdir) {


### PR DESCRIPTION
The actual cleanup code is unchanged; this just makes the pre-run and post-run cleanup phases individually configurable, instead of only both or neither.

See the documentation in cassandane.ini.example for usage.