### PR TITLE
imap/index.[ch]: remove unused index_refresh()

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -1754,16 +1754,6 @@ EXPORTED int index_status(struct index_state *state, struct statusdata *sdata)
     return 0;
 }
 
-EXPORTED int index_refresh(struct index_state *state)
-{
-    int r;
-
-    r = index_lock(state, /*readonly*/1);  /* calls index_refresh_locked */
-    if (r) return r;
-    index_unlock(state);
-    return 0;
-}
-
 EXPORTED void index_unlock(struct index_state *state)
 {
     // only update seen if we've got a writelocked mailbox

--- a/imap/index.h
+++ b/imap/index.h
@@ -256,7 +256,6 @@ extern int index_open(const char *name, struct index_init *init,
                       struct index_state **stateptr);
 extern int index_open_mailbox(struct mailbox *mailbox, struct index_init *init,
                               struct index_state **stateptr);
-extern int index_refresh(struct index_state *state);
 extern void index_checkflags(struct index_state *state, int print, int dirty);
 extern void index_select(struct index_state *state, struct index_init *init);
 extern int index_status(struct index_state *state, struct statusdata *sdata);


### PR DESCRIPTION
`index_refresh()` is still mentioned in docsrc/developer/API/index-api.rst.