### PR TITLE
imap/spool.c: don't needlessly set/free parameters

### DIFF
--- a/imap/spool.c
+++ b/imap/spool.c
@@ -254,8 +254,6 @@ static int parseheader(struct protstream *fin, FILE *fout,
 
     /* and we didn't get a header */
     *headname = NULL;
-    *contents = NULL;
-    *rawvalue = NULL;
 
     return r;
 
@@ -386,27 +384,23 @@ EXPORTED void spool_remove_header_instance(const char *name, int n,
 EXPORTED int spool_fill_hdrcache(struct protstream *fin, FILE *fout,
                                  hdrcache_t cache, const char **skipheaders)
 {
-    int r = 0;
-
     /* let's fill that header cache */
     for (;;) {
-        char *name = NULL, *body = NULL, *raw = NULL;
+        char *name, *body, *raw;
+        int r = parseheader(fin, fout, &name, &body, &raw, skipheaders);
 
-        if ((r = parseheader(fin, fout, &name, &body, &raw, skipheaders)) < 0) {
-            break;
-        }
+        if (r < 0)
+            return r;
         if (!name) {
             /* reached the end of headers */
-            free(body);
-            free(raw);
-            break;
+            return 0;
         }
 
         /* put it in the hash table */
         spool_append_header_raw(name, body, raw, cache);
     }
 
-    return r;
+    return 0;
 }
 
 EXPORTED const char **spool_getheader(hdrcache_t cache, const char *phead)


### PR DESCRIPTION
In `parseheader()` the value of the parameters `headname`, `contents` and `rawvalue` is never read, so there is no need to assign values to the arguments `name`, `body` and `raw` before invoking `parseheader()`.

Before `parseheader()` returns, it either sets newly allocated memory in the parameters `headname`, `contents` and `rawvalue` and the function returns zero, or it assigns `NULL` to `headname`, `contents` and `rawvalue`.  This means, after `parseheader()` returns and the parameter `headname`⇔argument `name` is falsy, then the parameters `contents` and `rawvalue` ⇔ arguments `body` and `raw` would also be `NULL`, so there is no point to call `free()` on them.

The above is shortened even further: when the parameter `headname` / argument `name` is set to `NULL`, there is no point to set `NULL` also to `contents` and `rawvalue`, as in this case after `parseheader()` returns, the values of the parameters `body` and `raw` are not read.

The function `parseheader()` is called from only one place.  Inlining the body of `parseheader()`  in the source code of the relatively short function `spool_fill_hdrcache()` would ease the understanding further.