### PR TITLE
cassandane.ini.dockerfile: Clean up previous test runs on each run

### DIFF
--- a/cassandane/cassandane.ini.dockertests
+++ b/cassandane/cassandane.ini.dockertests
@@ -42,7 +42,7 @@
 
 [cassandane]
 rootdir = /dev/shm/cass
-cleanup = no
+cleanup = pre
 
 # If we need do, we can put a list of (space-delimited) tests in this setting,
 # and those tests will be skipped.  In the past, we've used it for tests that


### PR DESCRIPTION
With this setting change, running tests will leave all passing/failed dirs in /dev/shm/cass so you can inspect data if you like, but the next test run will remove those, when previously they'd never get cleaned up.

This gives a better default setup for most use cases:

 - For ci, nothing really changes.
 - For users with short lived containers, nothing really changes
 - For users with long lived containers, multiple test runs won't fill up /dev/shm/cass since previous runs' data will be cleaned out before each new run.