### PR TITLE
jmap_api.h: do not require JACL_SETSEEN for JACL_WRITEALL

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set
@@ -24,6 +24,16 @@ sub test_calendar_set
     $self->assert_not_null($res->[0][1]{created});
     $self->assert_not_null($res->[0][1]{created}{1}{mailboxUniqueId});
 
+    $self->assert_cmp_deeply(
+      superhashof({
+        mayWriteOwn => jtrue,
+        mayWriteAll => jtrue,
+        mayUpdatePrivate => jtrue,
+      }),
+      $res->[0][1]{created}{1}{myRights},
+      "you may by default write to a calendar you create and own",
+    );
+
     my $id = $res->[0][1]{created}{"1"}{id};
 
     xlog $self, "get calendar $id";

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith
@@ -106,7 +106,7 @@ sub test_calendar_set_sharewith
     my %map = @$acl;
     $self->assert_str_equals('lrswipkxtecdan9', $map{cassandane});
     $self->assert_str_equals('lrw59', $map{manifold});
-    $self->assert_str_equals('lrswitedn79', $map{paraphrase});
+    $self->assert_str_equals('lrwitedn79', $map{paraphrase});
 
     xlog $self, "check Outbox ACL";
     $acl = $admintalk->getacl("user.master.#calendars.Outbox");
@@ -132,7 +132,7 @@ sub test_calendar_set_sharewith
         %map = @$acl;
         $self->assert_str_equals('lrswitedn', $map{cassandane});
         $self->assert_str_equals('lrw', $map{manifold});
-        $self->assert_str_equals('lrswitedn', $map{paraphrase});
+        $self->assert_str_equals('lrwitedn', $map{paraphrase});
     }
 
     xlog $self, "Clear initial syslog";
@@ -158,8 +158,8 @@ sub test_calendar_set_sharewith
         $acl = $admintalk->getacl("user.master.#jmap");
         %map = @$acl;
         $self->assert_str_equals('lrswitedn', $map{cassandane});
-        $self->assert_str_equals('lrswitedn', $map{manifold});
-        $self->assert_str_equals('lrswitedn', $map{paraphrase});
+        $self->assert_str_equals('lrwitedn', $map{manifold});
+        $self->assert_str_equals('lrwitedn', $map{paraphrase});
     }
 
     xlog $self, "Remove the access for paraphrase";
@@ -181,7 +181,7 @@ sub test_calendar_set_sharewith
     $acl = $admintalk->getacl("user.master.#calendars.$CalendarId");
     %map = @$acl;
     $self->assert_str_equals('lrswipkxtecdan9', $map{cassandane});
-    $self->assert_str_equals('lrswitedn579', $map{manifold});
+    $self->assert_str_equals('lrwitedn579', $map{manifold});
     $self->assert_null($map{paraphrase});
 
     xlog $self, "check Outbox ACL";
@@ -208,7 +208,7 @@ sub test_calendar_set_sharewith
         $acl = $admintalk->getacl("user.master.#jmap");
         %map = @$acl;
         $self->assert_str_equals('lrswitedn', $map{cassandane});
-        $self->assert_str_equals('lrswitedn', $map{manifold});
+        $self->assert_str_equals('lrwitedn', $map{manifold});
         $self->assert_null($map{paraphrase});
     }
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith_acl
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith_acl
@@ -112,7 +112,9 @@ sub test_calendar_set_sharewith_acl
         $self->assert_deep_equals(\%mergedrights,
             $res->[1][1]{list}[0]{shareWith}{zztester});
         my %acl = @{$admin->getacl("user.cassandane.#calendars.$calendarId")};
-        $self->assert_str_equals($_->{acl}, $acl{aatester});
-        $self->assert_str_equals($_->{acl}, $acl{zztester});
+
+        my $shared_acl = $_->{acl} =~ s/s//r;
+        $self->assert_str_equals($shared_acl, $acl{aatester});
+        $self->assert_str_equals($shared_acl, $acl{zztester});
     }
 }

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_sharewith
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_sharewith
@@ -92,7 +92,7 @@ sub test_addressbook_set_sharewith
     my %map = @$acl;
     $self->assert_str_equals('lrswitedn', $map{cassandane});
     $self->assert_str_equals('lrw', $map{manifold});
-    $self->assert_str_equals('lrswitedn', $map{paraphrase});
+    $self->assert_str_equals('lrwitedn', $map{paraphrase});
 
     xlog $self, "Update sharewith just for manifold";
     $jmap->CallMethods([
@@ -107,8 +107,8 @@ sub test_addressbook_set_sharewith
     $acl = $admintalk->getacl("user.master.#jmap");
     %map = @$acl;
     $self->assert_str_equals('lrswitedn', $map{cassandane});
-    $self->assert_str_equals('lrswitedn', $map{manifold});
-    $self->assert_str_equals('lrswitedn', $map{paraphrase});
+    $self->assert_str_equals('lrwitedn', $map{manifold});
+    $self->assert_str_equals('lrwitedn', $map{paraphrase});
 
     xlog $self, "Remove the access for paraphrase";
     $res = $jmap->CallMethods([
@@ -129,13 +129,13 @@ sub test_addressbook_set_sharewith
     $acl = $admintalk->getacl("user.master.#addressbooks.$AddressBookId");
     %map = @$acl;
     $self->assert_str_equals('lrswipkxtecdan', $map{cassandane});
-    $self->assert_str_equals('lrswitedn', $map{manifold});
+    $self->assert_str_equals('lrwitedn', $map{manifold});
     $self->assert_null($map{paraphrase});
 
     xlog $self, "check ACL on JMAP upload folder";
     $acl = $admintalk->getacl("user.master.#jmap");
     %map = @$acl;
     $self->assert_str_equals('lrswitedn', $map{cassandane});
-    $self->assert_str_equals('lrswitedn', $map{manifold});
+    $self->assert_str_equals('lrwitedn', $map{manifold});
     $self->assert_null($map{paraphrase});
 }

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_sharewith_acl
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_sharewith_acl
@@ -37,7 +37,7 @@ sub test_addressbook_set_sharewith_acl
         rights => {
             mayWrite => JSON::true,
         },
-        acl => 'switedn',
+        acl => 'witedn',
         wantRights => {
             mayWrite => JSON::true,
         },

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -136,7 +136,7 @@ void jmap_data_types_foreach(void (*cb)(const jmap_data_type_t *, void *),
 #define JACL_RSVP           ACL_USER7      /* Keep sync'd with DACL_REPLY */
 #define JACL_WRITEOWN       ACL_USER6
 #define JACL_UPDATEPRIVATE  ACL_USER5
-#define JACL_WRITEALL       (JACL_ADDITEMS|JACL_UPDATEITEMS|JACL_SETSEEN|JACL_SETMETADATA|JACL_REMOVEITEMS)
+#define JACL_WRITEALL       (JACL_ADDITEMS|JACL_UPDATEITEMS|JACL_SETMETADATA|JACL_REMOVEITEMS)
 
 /* Cyrus-specific privileges */
 #define JACL_LOOKUP         ACL_LOOKUP


### PR DESCRIPTION
JACL_WRITEALL is only use in DAV-like datatypes, none of which use JACL_SETSEEN for anything.  In a recent commit, we stopped adding ACL_SETSEEN to the calendar homeset of new users, so new calendars didn't inherit it, so they weren't WRITEALL, so we reported that they could not write to the calendar.

We'd *let* them, because they had admin, but clients that took the myRights advice to heart would not offer the option to write.

So:  stop making JACL_SETSEEN part of JACL_WRITEALL, and assert that a new calendar is mayWriteAll (etc) for its owner.  No existing test caught this!