### PR TITLE
docs: add and use :cve: extlink

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -572,6 +572,7 @@ rst_prolog += """
 # XXX handlers here, except that these urls require expanding the version string
 # XXX twice, and the sphinx extlinks thingy currently only supports a single %s
 extlinks = {
+    "cve": ("https://www.cve.org/CVERecord?id=%s", "%s"),
     "draft": ("https://tools.ietf.org/html/%s", "%s"),
     "issue": ("https://github.com/cyrusimap/cyrus-imapd/issues/%s", "Issue #%s"),
     "cyrus-2.5": ("https://www.cyrusimap.org/2.5%s", None),

--- a/docsrc/download/release-notes/2.3/x/2.3.17.rst
+++ b/docsrc/download/release-notes/2.3/x/2.3.17.rst
@@ -4,6 +4,6 @@ Cyrus IMAP 2.3.17 Release Notes
 
 Changes to the Cyrus IMAP Server since 2.3.16
 
-*   Fix for CVE-2011-3208, a remotely exploitable buffer overflow in nntpd
+*   Fix for :cve:`CVE-2011-3208`, a remotely exploitable buffer overflow in nntpd
 
 :ref:`imap-release-notes-2.3`

--- a/docsrc/download/release-notes/2.4/x/2.4.11.rst
+++ b/docsrc/download/release-notes/2.4/x/2.4.11.rst
@@ -22,6 +22,6 @@ Changes to the Cyrus IMAP Server since 2.4.10
 *   Bug #3499 - options to disable namespaces to reduce load on big servers with no shared folders. Thanks Olivier ROLAND
 *   Changed skiplist to truncate old files after checkpoint, which can save disk space on tmpfs or small ssds when old copies were held open by other processes
 *   Made Cyrus more robust against corruption in mailboxes.db data, so it will return an error rather than crashing on invalid entries
-*   Fix for CVE-2011-3208, a remotely exploitable buffer overflow in nntpd - thanks Coverity
+*   Fix for :cve:`CVE-2011-3208`, a remotely exploitable buffer overflow in nntpd - thanks Coverity
 
 :ref:`imap-release-notes-2.4`

--- a/docsrc/download/release-notes/2.5/x/2.5.13.rst
+++ b/docsrc/download/release-notes/2.5/x/2.5.13.rst
@@ -30,7 +30,7 @@ downloading this release, please report this to the mailing lists. Thanks!
 Security fixes
 --------------
 
-* Fixed CVE-2019-11356: buffer overrun in httpd
+* Fixed :cve:`CVE-2019-11356`: buffer overrun in httpd
 
 Bug fixes
 ---------

--- a/docsrc/download/release-notes/2.5/x/2.5.15.rst
+++ b/docsrc/download/release-notes/2.5/x/2.5.15.rst
@@ -30,7 +30,7 @@ downloading this release, please report this to the mailing lists. Thanks!
 Security fixes
 --------------
 
-* Fixed CVE-2019-19783_: When creating a missing mailbox as part of a sieve
+* Fixed :cve:`CVE-2019-19783`: When creating a missing mailbox as part of a sieve
   'fileinto' directive, lmtpd would create it as administrator, bypassing ACL
   checks.
 
@@ -49,8 +49,6 @@ Security fixes
   lmtpd no longer creates these mailboxes as administrator, so users may no
   longer use a 'fileinto' directive to create a mailbox they couldn't create
   otherwise.
-
-.. _CVE-2019-19783: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19783
 
 Bug fixes
 ---------

--- a/docsrc/download/release-notes/2.5/x/2.5.7.rst
+++ b/docsrc/download/release-notes/2.5/x/2.5.7.rst
@@ -24,7 +24,7 @@ Changes Since 2.5.6
 Security fixes
 --------------
 
-* CVE-2015-8077, CVE-2015-8078: protect against integer overflow in urlfetch
+* :cve:`CVE-2015-8077`, :cve:`CVE-2015-8078`: protect against integer overflow in urlfetch
   range checks
 
 SSL changes

--- a/docsrc/download/release-notes/3.0/x/3.0.10.rst
+++ b/docsrc/download/release-notes/3.0/x/3.0.10.rst
@@ -31,7 +31,7 @@ this release, please report this to the mailing lists.  Thanks!
 Security fixes
 --------------
 
-* Fixed CVE-2019-11356: buffer overrun in httpd
+* Fixed :cve:`CVE-2019-11356`: buffer overrun in httpd
 
 Bug fixes
 ---------

--- a/docsrc/download/release-notes/3.0/x/3.0.12.rst
+++ b/docsrc/download/release-notes/3.0/x/3.0.12.rst
@@ -31,7 +31,7 @@ this release, please report this to the mailing lists.  Thanks!
 Security fixes
 --------------
 
-* Fixed CVE-2019-18928: unauthenticated HTTP requests no longer inherit
+* Fixed :cve:`CVE-2019-18928`: unauthenticated HTTP requests no longer inherit
   authentication from the previous request on the same connection
 
 Build changes

--- a/docsrc/download/release-notes/3.0/x/3.0.13.rst
+++ b/docsrc/download/release-notes/3.0/x/3.0.13.rst
@@ -31,7 +31,7 @@ this release, please report this to the mailing lists.  Thanks!
 Security fixes
 --------------
 
-* Fixed CVE-2019-19783_: When creating a missing mailbox as part of a sieve
+* Fixed :cve:`CVE-2019-19783`: When creating a missing mailbox as part of a sieve
   'fileinto' directive, lmtpd would create it as administrator, bypassing ACL
   checks.
 
@@ -50,8 +50,6 @@ Security fixes
   lmtpd no longer creates these mailboxes as administrator, so users may no
   longer use a 'fileinto' directive to create a mailbox they couldn't create
   otherwise.
-
-.. _CVE-2019-19783: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19783
 
 Build changes
 -------------

--- a/docsrc/download/release-notes/3.0/x/3.0.16.rst
+++ b/docsrc/download/release-notes/3.0/x/3.0.16.rst
@@ -25,7 +25,7 @@ Changes Since 3.0.15
 Security fixes:
 ---------------
 
-* Fixed CVE-2021-33582_: Certain user inputs are used as hash table keys during
+* Fixed :cve:`CVE-2021-33582`: Certain user inputs are used as hash table keys during
   processing.  A poorly chosen string hashing algorithm meant that the user
   could control which bucket their data was stored in, allowing a malicious
   user to direct many inputs to a single bucket.  Each subsequent insertion to
@@ -38,8 +38,6 @@ Security fixes:
   precomputed.
 
   Discovered by Matthew Horsfall, Fastmail
-
-.. _CVE-2021-33582: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33582
 
 Build fixes
 -----------

--- a/docsrc/download/release-notes/3.1/x/3.1.2.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.2.rst
@@ -40,8 +40,8 @@ Updates to default configuration
 
 Security fixes
 ==============
-* Contains fix for CVE-2017-14230.
-  [ http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230 ]
+
+* Contains fix for :cve:`CVE-2017-14230`.
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.1/x/3.1.3.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.3.rst
@@ -40,8 +40,8 @@ Updates to default configuration
 
 Security fixes
 ==============
-* Contains fix for CVE-2017-14230.
-  [ http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230 ]
+
+* Contains fix for :cve:`CVE-2017-14230`.
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.1/x/3.1.4.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.4.rst
@@ -42,8 +42,8 @@ Updates to default configuration
 
 Security fixes
 ==============
-* Contains fix for CVE-2017-14230.
-  [ http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230 ]
+
+* Contains fix for :cve:`CVE-2017-14230`.
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.1/x/3.1.5.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.5.rst
@@ -42,8 +42,8 @@ Updates to default configuration
 
 Security fixes
 ==============
-* Contains fix for CVE-2017-14230.
-  [ http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230 ]
+
+* Contains fix for :cve:`CVE-2017-14230`.
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.1/x/3.1.6.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.6.rst
@@ -53,8 +53,8 @@ Updates to default configuration
 
 Security fixes
 ==============
-* Contains fix for CVE-2017-14230.
-  [ http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230 ]
+
+* Contains fix for :cve:`CVE-2017-14230`.
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.1/x/3.1.7.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.7.rst
@@ -62,7 +62,8 @@ Updates to default configuration
 
 Security fixes
 ==============
-* Contains fix for `CVE-2017-14230 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230>`_
+
+* Contains fix for :cve:`CVE-2017-14230`
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.1/x/3.1.8.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.8.rst
@@ -77,8 +77,8 @@ Updates to default configuration
 Security fixes
 ==============
 
-* Contains fix for `CVE-2017-14230 <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230>`_
-* Contains fix for `CVE-2019-18928 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18928>`_
+* Contains fix for :cve:`CVE-2017-14230`
+* Contains fix for :cve:`CVE-2019-18928`
 
 
 Significant bugfixes

--- a/docsrc/download/release-notes/3.1/x/3.1.9.rst
+++ b/docsrc/download/release-notes/3.1/x/3.1.9.rst
@@ -81,9 +81,9 @@ Updates to default configuration
 Security fixes
 ==============
 
-* Contains fix for `CVE-2017-14230 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230>`_
-* Contains fix for `CVE-2019-18928 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18928>`_
-* Contains fix for `CVE-2019-19783 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19783>`_
+* Contains fix for :cve:`CVE-2017-14230`
+* Contains fix for :cve:`CVE-2019-18928`
+* Contains fix for :cve:`CVE-2019-19783`
 
 
 Significant bugfixes

--- a/docsrc/download/release-notes/3.10/x/3.10.0-rc1.rst
+++ b/docsrc/download/release-notes/3.10/x/3.10.0-rc1.rst
@@ -103,7 +103,7 @@ change during the process.
 Security fixes
 ==============
 
-* Fixed CVE-2024-34055_:
+* Fixed :cve:`CVE-2024-34055`:
   Cyrus-IMAP through 3.8.2 and 3.10.0-beta2 allow authenticated attackers
   to cause unbounded memory allocation by sending many LITERALs in a
   single command.
@@ -139,8 +139,6 @@ Security fixes
   These limits may be set small without affecting message uploads, as the
   APPEND command's message literal is limited by ``maxmessagesize``, not by
   these new options.
-
-.. _CVE-2024-34055: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34055
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.10/x/3.10.0-rc2.rst
+++ b/docsrc/download/release-notes/3.10/x/3.10.0-rc2.rst
@@ -106,7 +106,7 @@ change during the process.
 Security fixes
 ==============
 
-* Fixed CVE-2024-34055_:
+* Fixed :cve:`CVE-2024-34055`:
   Cyrus-IMAP through 3.8.2 and 3.10.0-beta2 allow authenticated attackers
   to cause unbounded memory allocation by sending many LITERALs in a
   single command.
@@ -142,8 +142,6 @@ Security fixes
   These limits may be set small without affecting message uploads, as the
   APPEND command's message literal is limited by ``maxmessagesize``, not by
   these new options.
-
-.. _CVE-2024-34055: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34055
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.10/x/3.10.0.rst
+++ b/docsrc/download/release-notes/3.10/x/3.10.0.rst
@@ -106,7 +106,7 @@ change during the process.
 Security fixes
 ==============
 
-* Fixed CVE-2024-34055_:
+* Fixed :cve:`CVE-2024-34055`:
   Cyrus-IMAP through 3.8.2 and 3.10.0-beta2 allow authenticated attackers
   to cause unbounded memory allocation by sending many LITERALs in a
   single command.
@@ -142,8 +142,6 @@ Security fixes
   These limits may be set small without affecting message uploads, as the
   APPEND command's message literal is limited by ``maxmessagesize``, not by
   these new options.
-
-.. _CVE-2024-34055: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34055
 
 Significant bugfixes
 ====================

--- a/docsrc/download/release-notes/3.2/x/3.2.0-beta3.rst
+++ b/docsrc/download/release-notes/3.2/x/3.2.0-beta3.rst
@@ -107,9 +107,9 @@ during the process.
 Security fixes
 ==============
 
-* Contains fix for `CVE-2017-14230 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230>`_
-* Contains fix for `CVE-2019-18928 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18928>`_
-* Contains fix for `CVE-2019-19783 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19783>`_
+* Contains fix for :cve:`CVE-2017-14230`
+* Contains fix for :cve:`CVE-2019-18928`
+* Contains fix for :cve:`CVE-2019-19783`
 
 
 Significant bugfixes

--- a/docsrc/download/release-notes/3.2/x/3.2.0-beta4.rst
+++ b/docsrc/download/release-notes/3.2/x/3.2.0-beta4.rst
@@ -110,9 +110,9 @@ during the process.
 Security fixes
 ==============
 
-* Contains fix for `CVE-2017-14230 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230>`_
-* Contains fix for `CVE-2019-18928 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18928>`_
-* Contains fix for `CVE-2019-19783 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19783>`_
+* Contains fix for :cve:`CVE-2017-14230`
+* Contains fix for :cve:`CVE-2019-18928`
+* Contains fix for :cve:`CVE-2019-19783`
 
 
 Significant bugfixes

--- a/docsrc/download/release-notes/3.2/x/3.2.0-rc1.rst
+++ b/docsrc/download/release-notes/3.2/x/3.2.0-rc1.rst
@@ -110,9 +110,9 @@ during the process.
 Security fixes
 ==============
 
-* Contains fix for `CVE-2017-14230 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230>`_
-* Contains fix for `CVE-2019-18928 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18928>`_
-* Contains fix for `CVE-2019-19783 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19783>`_
+* Contains fix for :cve:`CVE-2017-14230`
+* Contains fix for :cve:`CVE-2019-18928`
+* Contains fix for :cve:`CVE-2019-19783`
 
 
 Significant bugfixes

--- a/docsrc/download/release-notes/3.2/x/3.2.0.rst
+++ b/docsrc/download/release-notes/3.2/x/3.2.0.rst
@@ -106,9 +106,9 @@ during the process.
 Security fixes
 ==============
 
-* Contains fix for `CVE-2017-14230 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14230>`_
-* Contains fix for `CVE-2019-18928 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18928>`_
-* Contains fix for `CVE-2019-19783 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19783>`_
+* Contains fix for :cve:`CVE-2017-14230`
+* Contains fix for :cve:`CVE-2019-18928`
+* Contains fix for :cve:`CVE-2019-19783`
 
 
 Significant bugfixes

--- a/docsrc/download/release-notes/3.2/x/3.2.7.rst
+++ b/docsrc/download/release-notes/3.2/x/3.2.7.rst
@@ -17,13 +17,11 @@ Changes since 3.2.6
 Security fixes:
 ---------------
 
-* Fixed CVE-2021-32056_: Remote authenticated users could bypass intended
+* Fixed :cve:`CVE-2021-32056`: Remote authenticated users could bypass intended
   access restrictions on certain server annotations.  Additionally, a
   long-standing bug in replication did not allow server annotations to be
   replicated.  Combining these two bugs, a remote authenticated user could
   stall replication, requiring administrator intervention.
-
-.. _CVE-2021-32056: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32056
 
 Build changes
 -------------

--- a/docsrc/download/release-notes/3.2/x/3.2.8.rst
+++ b/docsrc/download/release-notes/3.2/x/3.2.8.rst
@@ -17,7 +17,7 @@ Changes since 3.2.7
 Security fixes:
 ---------------
 
-* Fixed CVE-2021-33582_: Certain user inputs are used as hash table keys during
+* Fixed :cve:`CVE-2021-33582`: Certain user inputs are used as hash table keys during
   processing.  A poorly chosen string hashing algorithm meant that the user
   could control which bucket their data was stored in, allowing a malicious
   user to direct many inputs to a single bucket.  Each subsequent insertion to
@@ -30,8 +30,6 @@ Security fixes:
   precomputed.
 
   Discovered by Matthew Horsfall, Fastmail
-
-.. _CVE-2021-33582: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33582
 
 Bug fixes
 ---------

--- a/docsrc/download/release-notes/3.4/x/3.4.1.rst
+++ b/docsrc/download/release-notes/3.4/x/3.4.1.rst
@@ -17,13 +17,11 @@ Changes since 3.4.0
 Security fixes:
 ---------------
 
-* Fixed CVE-2021-32056_: Remote authenticated users could bypass intended
+* Fixed :cve:`CVE-2021-32056`: Remote authenticated users could bypass intended
   access restrictions on certain server annotations.  Additionally, a
   long-standing bug in replication did not allow server annotations to be
   replicated.  Combining these two bugs, a remote authenticated user could
   stall replication, requiring administrator intervention.
-
-.. _CVE-2021-32056: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32056
 
 Build changes
 -------------

--- a/docsrc/download/release-notes/3.4/x/3.4.2.rst
+++ b/docsrc/download/release-notes/3.4/x/3.4.2.rst
@@ -17,7 +17,7 @@ Changes since 3.4.1
 Security fixes:
 ---------------
 
-* Fixed CVE-2021-33582_: Certain user inputs are used as hash table keys during
+* Fixed :cve:`CVE-2021-33582`: Certain user inputs are used as hash table keys during
   processing.  A poorly chosen string hashing algorithm meant that the user
   could control which bucket their data was stored in, allowing a malicious
   user to direct many inputs to a single bucket.  Each subsequent insertion to
@@ -30,8 +30,6 @@ Security fixes:
   precomputed.
 
   Discovered by Matthew Horsfall, Fastmail
-
-.. _CVE-2021-33582: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33582
 
 Build changes
 -------------

--- a/docsrc/download/release-notes/3.4/x/3.4.8.rst
+++ b/docsrc/download/release-notes/3.4/x/3.4.8.rst
@@ -17,7 +17,7 @@ Changes since 3.4.7
 Security fixes
 --------------
 
-* Fixed CVE-2024-34055_:
+* Fixed :cve:`CVE-2024-34055`:
   Cyrus-IMAP through 3.8.2 and 3.10.0-beta2 allow authenticated attackers
   to cause unbounded memory allocation by sending many LITERALs in a
   single command.
@@ -53,5 +53,3 @@ Security fixes
   These limits may be set small without affecting message uploads, as the
   APPEND command's message literal is limited by ``maxmessagesize``, not by
   these new options.
-
-.. _CVE-2024-34055: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34055

--- a/docsrc/download/release-notes/3.6/x/3.6.5.rst
+++ b/docsrc/download/release-notes/3.6/x/3.6.5.rst
@@ -17,7 +17,7 @@ Changes since 3.6.4
 Security fixes
 --------------
 
-* Fixed CVE-2024-34055_:
+* Fixed :cve:`CVE-2024-34055`:
   Cyrus-IMAP through 3.8.2 and 3.10.0-beta2 allow authenticated attackers
   to cause unbounded memory allocation by sending many LITERALs in a
   single command.
@@ -53,5 +53,3 @@ Security fixes
   These limits may be set small without affecting message uploads, as the
   APPEND command's message literal is limited by ``maxmessagesize``, not by
   these new options.
-
-.. _CVE-2024-34055: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34055

--- a/docsrc/download/release-notes/3.8/x/3.8.3.rst
+++ b/docsrc/download/release-notes/3.8/x/3.8.3.rst
@@ -17,7 +17,7 @@ Changes since 3.8.2
 Security fixes
 --------------
 
-* Fixed CVE-2024-34055_:
+* Fixed :cve:`CVE-2024-34055`:
   Cyrus-IMAP through 3.8.2 and 3.10.0-beta2 allow authenticated attackers
   to cause unbounded memory allocation by sending many LITERALs in a
   single command.
@@ -53,5 +53,3 @@ Security fixes
   These limits may be set small without affecting message uploads, as the
   APPEND command's message literal is limited by ``maxmessagesize``, not by
   these new options.
-
-.. _CVE-2024-34055: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34055


### PR DESCRIPTION
This adds a `:cve:` extlink to sphinx for ergonomically linking to CVE records, and updates all the places where we already refer to these to use it.