### PR TITLE
configure.ac: do not print SSL under External dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2415,7 +2415,6 @@ Cyrus Server configured components
 
 External dependencies:
    ldap:               $have_ldap
-   openssl:            $with_ssl
    zlib:               $with_zlib
    jansson:            $with_jansson
    pcre:               $cyrus_cv_pcre_utf8


### PR DESCRIPTION
Variable `$with_ssl` was removed by 47149a13f99c2270a1fc6.