### PR TITLE
jmap_contact.c:_card_set_create() redundant expression

### DIFF
--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -8941,7 +8941,7 @@ static int _card_set_create(jmap_req_t *req,
 
     /* Accept members => NULL by removing it and treating it as not present */
     members = json_object_get(jcard, "members");
-    if (members && json_is_null(members)) {
+    if (json_is_null(members)) {
         json_object_del(jcard, "members");
         members = NULL;
     }


### PR DESCRIPTION
Clang static analyzer says “operator has equivalent nested operands” and jansson.h contains:
```
#define json_is_null(json)    ((json) && json_typeof(json) == JSON_NULL)
```