### PR TITLE
configure.ac: require C++17 for Xapian 2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -504,8 +504,8 @@ if test "x$enable_xapian" != xno ; then
             AC_MSG_ERROR([\`$XAPIAN_CONFIG --ltlibs --cxxflags' doesn't work, aborting])
         fi
 
-        dnl Xapian requires CXX11
-        AX_CXX_COMPILE_STDCXX(11)
+        dnl Xapian requires CXX17
+        AX_CXX_COMPILE_STDCXX(17)
 
         dnl If AC_PROG_LIBTOOL (or the deprecated older version AM_PROG_LIBTOOL)
         dnl has already been expanded, enable libtool support now, otherwise add


### PR DESCRIPTION
Cyrus IMAP requires Xapian 2.0. Xapian 2.0 is built using C++17.

xapian_wrap.cpp does `#include <xapian.h>`. xapian.h from Xapian 2.0 does `#include <xapian/cluster.h>`. `xapian/cluster.h` does `#include <string_view>`,  string_view is available in C++17, so xapian_wrap.cpp requires C++17.

The release notes at https://www.cyrusimap.org/dev/download/release-notes/3.13/x/3.13.5.html say Cyrus IMAP requires Xapian 2.0, but configure.ac looks for 1.4 or higher version.