### PR TITLE
Enforce geteuid()≠0 in some user-space tools

### DIFF
--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -1212,6 +1212,8 @@ int main(int argc, char **argv)
         }
     }
 
+    if (geteuid() == 0) fatal("must run as the Cyrus user", EX_USAGE);
+
     if (mode == UNKNOWN)
         usage(argv[0]);
 

--- a/imap/dav_reconstruct.c
+++ b/imap/dav_reconstruct.c
@@ -90,6 +90,8 @@ int main(int argc, char **argv)
         }
     }
 
+    if (geteuid() == 0) fatal("must run as the Cyrus user", EX_USAGE);
+
     cyrus_init(alt_config, "dav_reconstruct", 0, 0);
     global_sasl_init(1,0,NULL);
 

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -153,6 +153,7 @@ int main(int argc,char **argv)
     /* always report if not fixing, otherwise we do nothing */
     if (!fflag)
         do_report = 1;
+    if (geteuid() == 0) fatal("must run as the Cyrus user", EX_USAGE);
 
     cyrus_init(alt_config, "quota", 0, CONFIG_NEED_PARTITION_DATA);
 

--- a/imap/reconstruct.c
+++ b/imap/reconstruct.c
@@ -254,6 +254,8 @@ int main(int argc, char **argv)
         }
     }
 
+    if (geteuid() == 0) fatal("must run as the Cyrus user", EX_USAGE);
+
     cyrus_init(alt_config, "reconstruct", 0, CONFIG_NEED_PARTITION_DATA);
     global_sasl_init(1,0,NULL);
 


### PR DESCRIPTION
The changed files are supposed to be run after version upgrade. Staying as the cyrus-user is error-prone, so these additions enforce changing the user.