### PR TITLE
GitHub Actions: Upgrade to upload-pages-artifact v5

### DIFF
--- a/.github/workflows/publish-site.yaml
+++ b/.github/workflows/publish-site.yaml
@@ -70,7 +70,7 @@ jobs:
         run: cyd makesite
       - name: Upload static files as artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: /tmp/CYRUS_DOCS_BUILD_DIR/cyrus-site/
   # Deployment job


### PR DESCRIPTION
v3 was issuing warnings about Node.js 20 actions are deprecated.

(No fault on our part. v4 would also have issued warnings. v5 was only released 5 weeks after GitHub enabled the warning, and 4 weeks after a third party supplied the PR to them to silence the warning that they themselves caused. Dropping the ball...)