### PR TITLE
Calalarmd replicaonly dryrun

### DIFF
--- a/cassandane/tiny-tests/CaldavAlarm/replication_replicaonly_dryrun
+++ b/cassandane/tiny-tests/CaldavAlarm/replication_replicaonly_dryrun
@@ -1,0 +1,126 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_replication_replicaonly_dryrun
+    :min_version_3_13
+    :needs_component_replication
+    ($self)
+{
+    # The replica is replicaonly (no :NoReplicaOnly magic), so calalarmd must
+    # process records there in dryrun mode: no alarm fired, but the local
+    # nextcheck is still advanced. We use an event 120 days out so its alarm
+    # always lands in the ">60 days, check again in 30 days" push-off path,
+    # which the master advances locally without bumping modseq (so it is not
+    # replicated) -- exactly the case this feature keeps in sync.
+    $self->assert_not_null($self->{replica});
+
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $now = DateTime->now();
+    $now->set_time_zone('Australia/Sydney');
+    # bump everything forward so a slow run doesn't fire anything early
+    $now->add(DateTime::Duration->new(seconds => 300));
+
+    # event starts 120 days out: its alarm is always >60 days from any runtime
+    # used below, so it hits the push-off and never actually fires
+    my $startdt = $now->clone();
+    $startdt->add(DateTime::Duration->new(days => 120));
+    my $start = $startdt->strftime('%Y%m%dT%H%M%S');
+
+    my $enddt = $startdt->clone();
+    $enddt->add(DateTime::Duration->new(seconds => 60));
+    my $end = $enddt->strftime('%Y%m%dT%H%M%S');
+
+    my $uuid = "574E2CD0-2D2A-4554-8B63-C7504481D3A9";
+    my $href = "$CalendarId/$uuid.ics";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.11.1//EN
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Australia/Sydney
+BEGIN:STANDARD
+DTSTART:19700101T000000
+RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4
+TZOFFSETFROM:+1100
+TZOFFSETTO:+1000
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:19700101T000000
+RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=10
+TZOFFSETFROM:+1000
+TZOFFSETTO:+1100
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+TRANSP:OPAQUE
+DTEND;TZID=Australia/Sydney:$end
+UID:$uuid
+DTSTAMP:20160420T141259Z
+SEQUENCE:0
+SUMMARY:main
+DTSTART;TZID=Australia/Sydney:$start
+CREATED:20160420T141217Z
+BEGIN:VALARM
+TRIGGER:PT0S
+ACTION:DISPLAY
+SUMMARY: My alert
+DESCRIPTION:My alarm has triggered
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $CalDAV->Request('PUT', $href, $card, 'Content-Type' => 'text/calendar');
+
+    # process on the master: computes nextcheck via push-off (~now + 30d) and
+    # writes the lastalarm annotation. Nothing fires (event is far away).
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch());
+    $self->assert_alarms();
+
+    # replicate so the replica sees the record + lastalarm annotation; the
+    # replica's sync sets its nextcheck from the replicated lastalarm
+    $self->run_replication();
+
+    # both ends now have exactly one alarm-db entry
+    my $masterdata = $self->{instance}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$masterdata);
+    my $replicadata = $self->{replica}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$replicadata);
+
+    # the replica's nextcheck starts at the master's pushed-off value (~now+30d).
+    # n.b. CaldavAlarm.pm "use POSIX" shadows the assert() method, so the
+    # assert_num_lt/gt helpers (which call $self->assert) can't be used here;
+    # express comparisons via assert_num_equals on a boolean instead.
+    my $oldcheck = $replicadata->[0]{nextcheck};
+    $self->assert_num_equals(1, ($oldcheck < $now->epoch() + 40 * 86400) ? 1 : 0,
+                  "replica nextcheck $oldcheck should start below now+40d");
+
+    # clear notifications on both ends, then run calalarmd on the replicaonly
+    # replica at a time past the stored nextcheck
+    $self->{instance}->getnotify();
+    $self->{replica}->getnotify();
+    my $runtime = $now->epoch() + 40 * 86400;
+    $self->{replica}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $runtime);
+
+    # NO side effects: no alarm fired on the replica (assert_alarms collects
+    # notifications from both the master and the replica)
+    $self->assert_alarms();
+
+    # but the replica advanced its OWN nextcheck (push-off from the new runtime
+    # => ~runtime + 30d). Under the old code calalarmd returned immediately on a
+    # replica and this value would be unchanged at ~now+30d.
+    $replicadata = $self->{replica}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$replicadata);
+    my $newcheck = $replicadata->[0]{nextcheck};
+    # advanced from the old value, and now past the run time (under the old
+    # code calalarmd returned immediately on a replica, leaving it unchanged)
+    $self->assert_num_equals(1, ($newcheck > $oldcheck) ? 1 : 0,
+                  "replica nextcheck should advance ($oldcheck -> $newcheck)");
+    $self->assert_num_equals(1, ($newcheck > $runtime) ? 1 : 0,
+                  "replica nextcheck $newcheck should be past run time $runtime");
+}

--- a/cassandane/tiny-tests/JMAPEmail/replication_snooze_replica_dryrun
+++ b/cassandane/tiny-tests/JMAPEmail/replication_snooze_replica_dryrun
@@ -1,0 +1,96 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_replication_snooze_replica_dryrun
+    :min_version_3_13 :needs_component_calalarmd
+    :needs_component_sieve :needs_component_replication :JMAPExtensions
+    ($self)
+{
+    # A replicaonly replica processes snoozed emails in dryrun mode. The same
+    # failover invariants as delayed send apply (see the futurerelease test in
+    # JMAPEmailSubmission):
+    #
+    #  1. the replica must NOT unsnooze the message itself -- only the master
+    #     does -- so the alarm-db record must survive a dryrun run.
+    #  2. an overdue record must stay DUE (nextcheck not pushed into the
+    #     future). The unsnooze is replicated, so a healthy replica simply has
+    #     the record deleted; but if replication is behind (the failover case),
+    #     a promoted replica must awaken the message on its very next run rather
+    #     than waiting. The cheap ~10s re-poll until then is the acceptable cost.
+    my $jmap = $self->{jmap};
+
+    # we need 'https://cyrusimap.org/ns/jmap/mail' capability for the
+    # snoozed property
+    my @using = @{ $jmap->DefaultUsing() };
+    push @using, 'https://cyrusimap.org/ns/jmap/mail';
+    $jmap->DefaultUsing(\@using);
+
+    my $inboxId = $self->getinbox()->{id};
+
+    xlog $self, "Generate an email via IMAP";
+    $self->make_message("foo", body => "an email\r\nwithCRLF\r\n") or die;
+
+    my $res = $jmap->CallMethods([['Email/query', {}, "R1"]]);
+    my $emailId = $res->[0][1]->{ids}[0];
+
+    xlog $self, "create snooze mailbox";
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', { create => { "1" => {
+            name => "snoozed", parentId => undef, role => "snoozed"
+        }}}, "R2"]
+    ]);
+    $self->assert_not_null($res->[0][1]{created});
+    my $snoozedId = $res->[0][1]{created}{"1"}{id};
+
+    xlog $self, "snooze the message";
+    my $maildate = DateTime->now();
+    $maildate->add(DateTime::Duration->new(seconds => 30));
+    my $datestr = $maildate->strftime('%Y-%m-%dT%TZ');
+
+    $res = $jmap->CallMethods([
+        ['Email/set', {
+            update => { $emailId => {
+                "mailboxIds/$inboxId" => undef,
+                "mailboxIds/$snoozedId" => $JSON::true,
+                "snoozed" => { "until" => $datestr },
+            }}
+        }, 'R3']
+    ]);
+    $self->assert_not_null($res->[0][1]{updated});
+    $self->assert_null($res->[0][1]{notUpdated});
+
+    xlog $self, "snooze is in the master alarmdb";
+    my $alarmdata = $self->{instance}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$alarmdata);
+
+    $self->run_replication();
+
+    xlog $self, "snooze replicated to the replica alarmdb, due at the wakeup time";
+    my $replicadata = $self->{replica}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$replicadata);
+    my $oldcheck = $replicadata->[0]{nextcheck};
+
+    xlog $self, "run calalarmd on the replicaonly replica well past the wakeup";
+    my $runtime = $maildate->epoch() + 90;
+    # sanity: the record is overdue at our chosen runtime. n.b. POSIX shadows
+    # assert(), so express comparisons via assert_num_equals on a boolean.
+    $self->assert_num_equals(1, ($oldcheck <= $runtime) ? 1 : 0,
+        "wakeup $oldcheck should be at/before run time $runtime");
+    $self->{replica}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $runtime);
+
+    xlog $self, "replica did NOT unsnooze: the alarm-db record still exists";
+    $replicadata = $self->{replica}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$replicadata);
+
+    xlog $self, "replica did NOT unsnooze: message still snoozed on the master";
+    $res = $jmap->CallMethods([['Email/get',
+        { ids => [ $emailId ], properties => [ 'mailboxIds', 'snoozed' ]}, "R4"]]);
+    my $msg = $res->[0][1]->{list}[0];
+    $self->assert_not_null($msg->{mailboxIds}{$snoozedId});
+    $self->assert_equals($datestr, $msg->{snoozed}{'until'});
+
+    xlog $self, "overdue record stays due so a promoted replica awakens it immediately";
+    my $newcheck = $replicadata->[0]{nextcheck};
+    $self->assert_num_equals(1, ($newcheck <= $runtime) ? 1 : 0,
+        "replica nextcheck $newcheck should stay at/before run time $runtime");
+}

--- a/cassandane/tiny-tests/JMAPEmailSubmission/replication_futurerelease_replica_dryrun
+++ b/cassandane/tiny-tests/JMAPEmailSubmission/replication_futurerelease_replica_dryrun
@@ -1,0 +1,86 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_replication_futurerelease_replica_dryrun
+    :min_version_3_13 :needs_component_calalarmd :needs_component_replication
+    ($self)
+{
+    # A replicaonly replica processes delayed-send (futurerelease) submissions
+    # in dryrun mode. The failover invariants (master dies at an inopportune
+    # time, e.g. right at the send time):
+    #
+    #  1. the replica must NOT send the message itself -- only the master does
+    #     -- so the alarm-db record must survive a dryrun run.
+    #  2. an overdue record must stay DUE (nextcheck not pushed into the
+    #     future). The master's "sent" flag is replicated, so if replication is
+    #     healthy the record is simply deleted; if it is NOT (the case that
+    #     leads to a failover), a promoted replica must fire the send on its
+    #     very next run rather than waiting -- users want fast delivery. The
+    #     cheap ~10s re-poll until the flag replicates is the acceptable cost.
+    my $jmap = $self->{jmap};
+
+    my $res = $jmap->CallMethods([['Identity/get', {}, "R1"]]);
+    my $identityid = $res->[0][1]->{list}[0]->{id};
+    $self->assert_not_null($identityid);
+
+    xlog $self, "Generate an email via IMAP";
+    $self->make_message("foo", body => "an email\r\nwithCRLF\r\n") or die;
+
+    $res = $jmap->CallMethods([['Email/query', {}, "R1"]]);
+    my $emailid = $res->[0][1]->{ids}[0];
+
+    my $now = DateTime->now();
+
+    xlog $self, "create a delayed (held) email submission";
+    $res = $jmap->CallMethods([['EmailSubmission/set', {
+        create => {
+            '1' => {
+                identityId => $identityid,
+                emailId  => $emailid,
+                envelope => {
+                    mailFrom => {
+                        email => 'from@localhost',
+                        parameters => { "holdfor" => "30" },
+                    },
+                    rcptTo => [{ email => 'rcpt1@localhost' }],
+                },
+            },
+        }
+    }, "R1"]]);
+    my $msgsubid = $res->[0][1]->{created}{1}{id};
+    $self->assert_not_null($msgsubid);
+
+    xlog $self, "submission is in the master alarmdb";
+    my $alarmdata = $self->{instance}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$alarmdata);
+
+    $self->run_replication();
+
+    xlog $self, "submission replicated to the replica alarmdb, due at the send time";
+    my $replicadata = $self->{replica}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$replicadata);
+    my $oldcheck = $replicadata->[0]{nextcheck};
+
+    xlog $self, "run calalarmd on the replicaonly replica well past the send time";
+    my $runtime = $now->epoch() + 120;
+    # sanity: our chosen runtime is past the stored send time, so the record is
+    # overdue when the replica processes it. n.b. JMAPEmailSubmission.pm
+    # "use POSIX" shadows the assert() method, so the assert_num_lt/gt helpers
+    # can't be used here; express comparisons via assert_num_equals on a boolean.
+    $self->assert_num_equals(1, ($oldcheck <= $runtime) ? 1 : 0,
+        "send time $oldcheck should be at/before run time $runtime");
+    $self->{replica}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $runtime);
+
+    xlog $self, "replica did NOT send: the alarm-db record still exists";
+    $replicadata = $self->{replica}->getalarmdb();
+    $self->assert_num_equals(1, scalar @$replicadata);
+
+    xlog $self, "replica did NOT send: master submission is still pending";
+    $res = $jmap->CallMethods([['EmailSubmission/get', { ids => [ $msgsubid ] }, "R2"]]);
+    $self->assert_str_equals('pending', $res->[0][1]->{list}[0]->{undoStatus});
+
+    xlog $self, "overdue record stays due so a promoted replica sends immediately";
+    my $newcheck = $replicadata->[0]{nextcheck};
+    $self->assert_num_equals(1, ($newcheck <= $runtime) ? 1 : 0,
+        "replica nextcheck $newcheck should stay at/before run time $runtime");
+}

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -2011,7 +2011,11 @@ static void process_one_record(struct caldav_alarm_data *data, time_t runtime, i
            data->mboxname, data->imap_uid, data->type, data->num_retries);
 
     if (data->type == ALARM_UNSCHEDULED) {
-        process_unscheduled(data);
+        // process_unscheduled() emits a notification, which is a side-effect;
+        // on a replica (dryrun) we must not. These records are only created by
+        // the master's local futurerelease-cancel path, so they won't normally
+        // exist on a pure replica.
+        if (!dryrun) process_unscheduled(data);
         return;
     }
 
@@ -2099,9 +2103,11 @@ EXPORTED int caldav_alarm_process(time_t runtime, time_t *intervalp, int dryrun)
 {
     int i;
 
-    // we don't process alarms on replicas
+    // On a replica we still process records, but in dryrun mode — no
+    // side-effects. We notice lastalarm changes replicated from the master
+    // and keep our local nextcheck advanced (e.g. the 30-day push-off).
     if (config_getswitch(IMAPOPT_REPLICAONLY))
-        return 0;
+        dryrun = 1;
 
     // temporarily disable alarms
     const char *suppress_file = config_getstring(IMAPOPT_CALDAV_ALARM_SUPPRESS_FILE);
@@ -2143,7 +2149,7 @@ EXPORTED int caldav_alarm_process(time_t runtime, time_t *intervalp, int dryrun)
         int skipped_some = 0;
         int did_some = 0;
         int num_user_records = 0;
-        int skip_user = 0;
+        int user_dryrun = dryrun;
         char *userid = NULL;
         user_nslock_t *user_nslock = NULL;
         for (i = 0; i < rock.list.count; i++) {
@@ -2160,19 +2166,16 @@ EXPORTED int caldav_alarm_process(time_t runtime, time_t *intervalp, int dryrun)
             // userid will be next to each other
             if (strcmpsafe(userid, mbname_userid(mbname))) {
                 num_user_records = 0;
-                skip_user = 0;
                 free(userid);
                 user_nslock_release(&user_nslock);
                 userid = xstrdup(mbname_userid(mbname));
-                if (user_isreplicaonly(userid)) {
-                    skip_user = 1;
-                    continue;
-                }
+                // replicaonly users are processed without side-effects, just
+                // like a fully replicaonly server: dryrun keeps their local
+                // nextcheck maintained instead of skipping them entirely.
+                user_dryrun = dryrun || user_isreplicaonly(userid);
                 user_nslock = user_nslock_lock(userid, LOCK_NONBLOCKING);
             }
             mbname_free(&mbname);
-
-            if (skip_user) continue;
 
             // if we failed to lock the user, or have done too many for this user, skip
             if (!user_nslock || ++num_user_records > MAX_CONSECUTIVE_ALARMS_PER_USER) {
@@ -2183,7 +2186,7 @@ EXPORTED int caldav_alarm_process(time_t runtime, time_t *intervalp, int dryrun)
             }
 
             did_some++;
-            process_one_record(data, runtime, dryrun);
+            process_one_record(data, runtime, user_dryrun);
             caldav_alarm_fini(data);
             free(data);
         }

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -1138,6 +1138,15 @@ static int caldav_alarm_bump_nextcheck(struct caldav_alarm_data *data,
 
     if (!last_run) last_run = data->last_run;
 
+    /* nothing to do if the row already holds these values (e.g. a replica
+     * re-checking an overdue futurerelease/snooze record whose time never
+     * changes) -- avoid a pointless INSERT OR REPLACE every run */
+    if (nextcheck == data->nextcheck &&
+        num_retries == data->num_retries &&
+        last_run == data->last_run &&
+        !strcmpsafe(last_err, data->last_err))
+        return 0;
+
     return update_alarmdb(data->mboxname, data->imap_uid, nextcheck, data->type,
                           data->num_rcpts, num_retries, last_run, last_err);
 }


### PR DESCRIPTION
This means that a replica which has been running for years doesn't have a really stale database, causing a thundering herd of updates on a failover.