### PR TITLE
Sieve addannotation

### DIFF
--- a/cassandane/tiny-tests/Info/bitfield_defaults
+++ b/cassandane/tiny-tests/Info/bitfield_defaults
@@ -5,7 +5,7 @@ sub test_bitfield_defaults
     :min_version_3_2 :NoStartInstances
     ($self)
 {
-    my $defaults = "fileinto reject vacation vacation-seconds notify include envelope environment body relational regex subaddress copy date index imap4flags mailbox mboxmetadata servermetadata variables editheader extlists duplicate ihave fcc special-use redirect-dsn redirect-deliverby mailboxid vnd.cyrus.log vnd.cyrus.jmapquery processcalendar snooze vnd.cyrus.implicit_keep_target vnd.cyrus.redirect-multiple";
+    my $defaults = "fileinto reject vacation vacation-seconds notify include envelope environment body relational regex subaddress copy date index imap4flags mailbox mboxmetadata servermetadata variables editheader extlists duplicate ihave fcc special-use redirect-dsn redirect-deliverby mailboxid vnd.cyrus.log vnd.cyrus.jmapquery processcalendar snooze vnd.cyrus.implicit_keep_target vnd.cyrus.redirect-multiple vnd.cyrus.addannotation";
 
     $self->_set_and_get_fields(
         { sieve_extensions => $defaults },

--- a/cassandane/tiny-tests/Sieve/addannotation_basic
+++ b/cassandane/tiny-tests/Sieve/addannotation_basic
@@ -1,0 +1,25 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_addannotation_basic
+    :min_version_3_13
+    ($self)
+{
+    xlog $self, "Install a sieve script with an addannotation action";
+    $self->{instance}->install_sieve_script(<<'EOF'
+require ["vnd.cyrus.addannotation"];
+addannotation "/comment" "hello world";
+EOF
+    );
+
+    xlog $self, "Deliver a message";
+    my $msg1 = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg1);
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->select("INBOX");
+
+    my $res = $imaptalk->fetch(1, '(annotation (/comment (value.shared)))');
+    $self->assert_str_equals('hello world',
+        $res->{1}{annotation}{'/comment'}{'value.shared'});
+}

--- a/cassandane/tiny-tests/Sieve/addannotation_basic
+++ b/cassandane/tiny-tests/Sieve/addannotation_basic
@@ -1,0 +1,24 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_addannotation_basic
+    ($self)
+{
+    xlog $self, "Install a sieve script with an addannotation action";
+    $self->{instance}->install_sieve_script(<<'EOF'
+require ["vnd.cyrus.addannotation"];
+addannotation "/comment" "hello world";
+EOF
+    );
+
+    xlog $self, "Deliver a message";
+    my $msg1 = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg1);
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->select("INBOX");
+
+    my $res = $imaptalk->fetch(1, '(annotation (/comment (value.shared)))');
+    $self->assert_str_equals('hello world',
+        $res->{1}{annotation}{'/comment'}{'value.shared'});
+}

--- a/cassandane/tiny-tests/Sieve/addannotation_denied
+++ b/cassandane/tiny-tests/Sieve/addannotation_denied
@@ -1,0 +1,31 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_addannotation_denied
+    :min_version_3_13
+    ($self)
+{
+    xlog $self, "Restrict the allowlist so /comment is NOT permitted";
+    $self->{instance}->{config}->set(sieve_allowed_annotations => '/vendor/*');
+    $self->{instance}->start();
+
+    xlog $self, "Install a script that sets a non-permitted entry";
+    $self->{instance}->install_sieve_script(<<'EOF'
+require ["vnd.cyrus.addannotation"];
+addannotation "/comment" "should be rejected";
+EOF
+    );
+
+    $self->{instance}->getsyslog();
+
+    xlog $self, "Deliver a message";
+    my $msg1 = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg1);
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->select("INBOX");
+
+    xlog $self, "Message delivered, but annotation absent";
+    my $res = $imaptalk->fetch(1, '(annotation (/comment (value.shared)))');
+    $self->assert_null($res->{1}{annotation}{'/comment'}{'value.shared'});
+}

--- a/cassandane/tiny-tests/Sieve/addannotation_denied
+++ b/cassandane/tiny-tests/Sieve/addannotation_denied
@@ -2,12 +2,12 @@
 use Cassandane::Tiny;
 
 sub test_addannotation_denied
-    :min_version_3_13
+    :min_version_3_13 :NoStartInstances
     ($self)
 {
     xlog $self, "Restrict the allowlist so /comment is NOT permitted";
     $self->{instance}->{config}->set(sieve_allowed_annotations => '/vendor/*');
-    $self->{instance}->start();
+    $self->_start_instances();
 
     xlog $self, "Install a script that sets a non-permitted entry";
     $self->{instance}->install_sieve_script(<<'EOF'
@@ -15,8 +15,6 @@ require ["vnd.cyrus.addannotation"];
 addannotation "/comment" "should be rejected";
 EOF
     );
-
-    $self->{instance}->getsyslog();
 
     xlog $self, "Deliver a message";
     my $msg1 = $self->{gen}->generate(subject => "Message 1");

--- a/cassandane/tiny-tests/Sieve/addannotation_denied
+++ b/cassandane/tiny-tests/Sieve/addannotation_denied
@@ -1,0 +1,29 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_addannotation_denied
+    :NoStartInstances
+    ($self)
+{
+    xlog $self, "Restrict the allowlist so /comment is NOT permitted";
+    $self->{instance}->{config}->set(sieve_allowed_annotations => '/vendor/*');
+    $self->_start_instances();
+
+    xlog $self, "Install a script that sets a non-permitted entry";
+    $self->{instance}->install_sieve_script(<<'EOF'
+require ["vnd.cyrus.addannotation"];
+addannotation "/comment" "should be rejected";
+EOF
+    );
+
+    xlog $self, "Deliver a message";
+    my $msg1 = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg1);
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->select("INBOX");
+
+    xlog $self, "Message delivered, but annotation absent";
+    my $res = $imaptalk->fetch(1, '(annotation (/comment (value.shared)))');
+    $self->assert_null($res->{1}{annotation}{'/comment'}{'value.shared'});
+}

--- a/cassandane/tiny-tests/Sieve/addannotation_same_emailid
+++ b/cassandane/tiny-tests/Sieve/addannotation_same_emailid
@@ -10,7 +10,7 @@ sub test_addannotation_same_emailid
     xlog $self, "Install script that files into two folders with an annotation";
     $self->{instance}->install_sieve_script(<<"EOF"
 require ["vnd.cyrus.addannotation", "fileinto", "copy"];
-addannotation "/vendor/cmu/cyrus-imapd/sieve-matched" "rule-a rule-b";
+addannotation "/comment" "rule-a rule-b";
 fileinto :copy "$target";
 keep;
 EOF
@@ -26,18 +26,18 @@ EOF
     xlog $self, "Fetch emailid + annotation from INBOX";
     $imaptalk->select("INBOX");
     my $inbox = $imaptalk->fetch(1,
-        '(emailid annotation (/vendor/cmu/cyrus-imapd/sieve-matched (value.shared)))');
+        '(emailid annotation (/comment (value.shared)))');
 
     xlog $self, "Fetch emailid + annotation from target";
     $imaptalk->select($target);
     my $tgt = $imaptalk->fetch(1,
-        '(emailid annotation (/vendor/cmu/cyrus-imapd/sieve-matched (value.shared)))');
+        '(emailid annotation (/comment (value.shared)))');
 
     xlog $self, "Both copies carry the annotation";
     $self->assert_str_equals('rule-a rule-b',
-        $inbox->{1}{annotation}{'/vendor/cmu/cyrus-imapd/sieve-matched'}{'value.shared'});
+        $inbox->{1}{annotation}{'/comment'}{'value.shared'});
     $self->assert_str_equals('rule-a rule-b',
-        $tgt->{1}{annotation}{'/vendor/cmu/cyrus-imapd/sieve-matched'}{'value.shared'});
+        $tgt->{1}{annotation}{'/comment'}{'value.shared'});
 
     xlog $self, "Both copies share the SAME emailid (annotation is not part of GUID)";
     $self->assert_str_equals($inbox->{1}{emailid}[0], $tgt->{1}{emailid}[0]);

--- a/cassandane/tiny-tests/Sieve/addannotation_same_emailid
+++ b/cassandane/tiny-tests/Sieve/addannotation_same_emailid
@@ -1,0 +1,44 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_addannotation_same_emailid
+    :min_version_3_13
+    ($self)
+{
+    my $target = "INBOX.target";
+
+    xlog $self, "Install script that files into two folders with an annotation";
+    $self->{instance}->install_sieve_script(<<"EOF"
+require ["vnd.cyrus.addannotation", "fileinto", "copy"];
+addannotation "/vendor/cmu/cyrus-imapd/sieve-matched" "rule-a rule-b";
+fileinto :copy "$target";
+keep;
+EOF
+    );
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create($target) or die "Cannot create $target: $@";
+
+    xlog $self, "Deliver a message";
+    my $msg1 = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg1);
+
+    xlog $self, "Fetch emailid + annotation from INBOX";
+    $imaptalk->select("INBOX");
+    my $inbox = $imaptalk->fetch(1,
+        '(emailid annotation (/vendor/cmu/cyrus-imapd/sieve-matched (value.shared)))');
+
+    xlog $self, "Fetch emailid + annotation from target";
+    $imaptalk->select($target);
+    my $tgt = $imaptalk->fetch(1,
+        '(emailid annotation (/vendor/cmu/cyrus-imapd/sieve-matched (value.shared)))');
+
+    xlog $self, "Both copies carry the annotation";
+    $self->assert_str_equals('rule-a rule-b',
+        $inbox->{1}{annotation}{'/vendor/cmu/cyrus-imapd/sieve-matched'}{'value.shared'});
+    $self->assert_str_equals('rule-a rule-b',
+        $tgt->{1}{annotation}{'/vendor/cmu/cyrus-imapd/sieve-matched'}{'value.shared'});
+
+    xlog $self, "Both copies share the SAME emailid (annotation is not part of GUID)";
+    $self->assert_str_equals($inbox->{1}{emailid}[0], $tgt->{1}{emailid}[0]);
+}

--- a/cassandane/tiny-tests/Sieve/addannotation_same_emailid
+++ b/cassandane/tiny-tests/Sieve/addannotation_same_emailid
@@ -1,0 +1,43 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_addannotation_same_emailid
+    ($self)
+{
+    my $target = "INBOX.target";
+
+    xlog $self, "Install script that files into two folders with an annotation";
+    $self->{instance}->install_sieve_script(<<"EOF"
+require ["vnd.cyrus.addannotation", "fileinto", "copy"];
+addannotation "/comment" "rule-a rule-b";
+fileinto :copy "$target";
+keep;
+EOF
+    );
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create($target) or die "Cannot create $target: $@";
+
+    xlog $self, "Deliver a message";
+    my $msg1 = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg1);
+
+    xlog $self, "Fetch emailid + annotation from INBOX";
+    $imaptalk->select("INBOX");
+    my $inbox = $imaptalk->fetch(1,
+        '(emailid annotation (/comment (value.shared)))');
+
+    xlog $self, "Fetch emailid + annotation from target";
+    $imaptalk->select($target);
+    my $tgt = $imaptalk->fetch(1,
+        '(emailid annotation (/comment (value.shared)))');
+
+    xlog $self, "Both copies carry the annotation";
+    $self->assert_str_equals('rule-a rule-b',
+        $inbox->{1}{annotation}{'/comment'}{'value.shared'});
+    $self->assert_str_equals('rule-a rule-b',
+        $tgt->{1}{annotation}{'/comment'}{'value.shared'});
+
+    xlog $self, "Both copies share the SAME emailid (annotation is not part of GUID)";
+    $self->assert_str_equals($inbox->{1}{emailid}[0], $tgt->{1}{emailid}[0]);
+}

--- a/changes/next/sieve-addannotation
+++ b/changes/next/sieve-addannotation
@@ -1,0 +1,42 @@
+Description:
+
+New "addannotation" Sieve action (capability "vnd.cyrus.addannotation") that
+records an IMAP message annotation on the delivered message.  Unlike
+"addheader", it does not change the message content, so a message filed into
+multiple folders keeps an identical emailid/GUID across every copy.
+
+
+Documentation:
+
+The vnd.cyrus.addannotation capability and the addannotation action.  The
+sieve_allowed_annotations option is documented in lib/imapoptions.
+
+Syntax: addannotation [:priv / :shared] <entry: string> <value: string>;
+(:shared is the default scope.)
+
+
+Config changes:
+
+- sieve_extensions: added "vnd.cyrus.addannotation" to the allowed/default set.
+- sieve_allowed_annotations: new option (default "/vendor/* /comment"); a
+  space-separated list of glob patterns for annotation entry names the
+  addannotation action is permitted to set.
+
+
+Upgrade instructions:
+
+No mailbox/db changes required.  To use the action, "vnd.cyrus.addannotation"
+must be enabled in sieve_extensions (it is by default) and the target entry
+must match a sieve_allowed_annotations glob.  The annotation must also be
+storable by the standard annotation store: "/comment" works out of the box;
+setting a custom entry additionally requires annotation_allow_undefined to be
+enabled and the entry must not be in the reserved /vendor/cmu/cyrus-imapd/
+namespace.
+
+Note: this bumps the Sieve bytecode version to 0x23.  Scripts are recompiled
+to bytecode automatically; no manual action is required.
+
+
+GitHub issue:
+
+(none)

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -24,6 +24,7 @@
 #include "auth.h"
 #include "duplicate.h"
 #include "global.h"
+#include "glob.h"
 #include "imapurl.h"
 #include "lmtpd.h"
 #include "lmtp_sieve.h"
@@ -136,6 +137,51 @@ static int deleteheader(void *mc, const char *head, int index)
 
     if (!index) spool_remove_header(head, m->hdrcache);
     else spool_remove_header_instance(head, index, m->hdrcache);
+
+    return SIEVE_OK;
+}
+
+/* is "entry" permitted by the sieve_allowed_annotations glob list? */
+static int addannotation_allowed(const char *entry)
+{
+    const char *globs = config_getstring(IMAPOPT_SIEVE_ALLOWED_ANNOTATIONS);
+    strarray_t *pats;
+    int i, allowed = 0;
+
+    if (!globs || !*globs) return 0;
+
+    pats = strarray_split(globs, " ", STRARRAY_TRIM);
+    for (i = 0; i < strarray_size(pats); i++) {
+        glob *g = glob_init(strarray_nth(pats, i), '/');
+        if (GLOB_MATCH(g, entry)) allowed = 1;
+        glob_free(&g);
+        if (allowed) break;
+    }
+    strarray_free(pats);
+
+    return allowed;
+}
+
+/* accumulates the annotation "entry" with value "value" on msg.
+   The owner-write permission is enforced downstream when the annotation
+   is stored via the append path under the recipient's auth context. */
+static int addannotation(void *mc, const char *entry,
+                         const char *attrib, const char *value)
+{
+    message_data_t *m = ((deliver_data_t *) mc)->m;
+    struct buf buf = BUF_INITIALIZER;
+
+    if (entry == NULL || value == NULL) return SIEVE_FAIL;
+
+    if (!addannotation_allowed(entry)) {
+        syslog(LOG_NOTICE, "sieve: addannotation entry %s not permitted "
+               "by sieve_allowed_annotations", entry);
+        return SIEVE_FAIL;
+    }
+
+    buf_setcstr(&buf, value);
+    setentryatt(&m->annotations, entry, attrib, &buf);
+    buf_free(&buf);
 
     return SIEVE_OK;
 }
@@ -1130,7 +1176,7 @@ static int sieve_fileinto(void *ac,
     }
 
     ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
-                          &imap4flags, NULL, userid, sd->authstate, md->id,
+                          &imap4flags, md->annotations, userid, sd->authstate, md->id,
                           userid, mdata->notifyheader, mode,
                           intname, md->date, 0 /*savedate*/, quotaoverride, 0);
 
@@ -1154,7 +1200,7 @@ static int sieve_fileinto(void *ac,
             }
 
             ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
-                                  &imap4flags, NULL, userid, sd->authstate, md->id,
+                                  &imap4flags, md->annotations, userid, sd->authstate, md->id,
                                   userid, mdata->notifyheader, mode,
                                   intname, md->date, 0 /*savedate*/, quotaoverride, 0);
         }
@@ -1819,7 +1865,7 @@ static int sieve_keep(void *ac,
     }
 
     ret = deliver_mailbox(md->f, mydata->content, mydata->stage, md->size,
-                          &imap4flags, NULL, authuser, authstate, md->id,
+                          &imap4flags, md->annotations, authuser, authstate, md->id,
                           userid, mydata->notifyheader, mode, intname, md->date,
                           0 /*savedate*/, quotaoverride, acloverride);
 
@@ -2322,6 +2368,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     sieve_register_headersection(interp, &getheadersection);
     sieve_register_addheader(interp, &addheader);
     sieve_register_deleteheader(interp, &deleteheader);
+    sieve_register_addannotation(interp, &addannotation);
     sieve_register_fname(interp, &getfname);
 
     sieve_register_envelope(interp, &getenvelope);

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -24,6 +24,7 @@
 #include "auth.h"
 #include "duplicate.h"
 #include "global.h"
+#include "glob.h"
 #include "imapurl.h"
 #include "lmtpd.h"
 #include "lmtp_sieve.h"
@@ -136,6 +137,50 @@ static int deleteheader(void *mc, const char *head, int index)
 
     if (!index) spool_remove_header(head, m->hdrcache);
     else spool_remove_header_instance(head, index, m->hdrcache);
+
+    return SIEVE_OK;
+}
+
+/* is "entry" permitted by the sieve_allowed_annotations glob list? */
+static int addannotation_allowed(const char *entry)
+{
+    const char *globs = config_getstring(IMAPOPT_SIEVE_ALLOWED_ANNOTATIONS);
+    strarray_t *pats;
+    int i, allowed = 0;
+
+    if (!globs || !*globs) return 0;
+
+    pats = strarray_split(globs, " ", STRARRAY_TRIM);
+    for (i = 0; i < strarray_size(pats); i++) {
+        glob *g = glob_init(strarray_nth(pats, i), '/');
+        if (GLOB_MATCH(g, entry)) allowed = 1;
+        glob_free(&g);
+        if (allowed) break;
+    }
+    strarray_free(pats);
+
+    return allowed;
+}
+
+/* the owner-write permission is enforced downstream, when the append path
+   stores the annotation under the recipient's auth context */
+static int addannotation(void *mc, const char *entry,
+                         const char *attrib, const char *value)
+{
+    message_data_t *m = ((deliver_data_t *) mc)->m;
+    struct buf buf = BUF_INITIALIZER;
+
+    if (entry == NULL || value == NULL) return SIEVE_FAIL;
+
+    if (!addannotation_allowed(entry)) {
+        syslog(LOG_NOTICE, "sieve: addannotation entry %s not permitted "
+               "by sieve_allowed_annotations", entry);
+        return SIEVE_FAIL;
+    }
+
+    buf_setcstr(&buf, value);
+    setentryatt(&m->annotations, entry, attrib, &buf);
+    buf_free(&buf);
 
     return SIEVE_OK;
 }
@@ -1109,7 +1154,7 @@ static int sieve_fileinto(void *ac,
     }
 
     ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
-                          &imap4flags, NULL, userid, sd->authstate, md->id,
+                          &imap4flags, md->annotations, userid, sd->authstate, md->id,
                           userid, mdata->notifyheader, mode,
                           intname, md->date, 0 /*savedate*/, quotaoverride, 0);
 
@@ -1133,7 +1178,7 @@ static int sieve_fileinto(void *ac,
             }
 
             ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
-                                  &imap4flags, NULL, userid, sd->authstate, md->id,
+                                  &imap4flags, md->annotations, userid, sd->authstate, md->id,
                                   userid, mdata->notifyheader, mode,
                                   intname, md->date, 0 /*savedate*/, quotaoverride, 0);
         }
@@ -1811,7 +1856,7 @@ static int sieve_keep(void *ac,
     }
 
     ret = deliver_mailbox(md->f, mydata->content, mydata->stage, md->size,
-                          &imap4flags, NULL, authuser, authstate, md->id,
+                          &imap4flags, md->annotations, authuser, authstate, md->id,
                           userid, mydata->notifyheader, mode, intname, md->date,
                           0 /*savedate*/, quotaoverride, acloverride);
 
@@ -2310,6 +2355,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     sieve_register_headersection(interp, &getheadersection);
     sieve_register_addheader(interp, &addheader);
     sieve_register_deleteheader(interp, &deleteheader);
+    sieve_register_addannotation(interp, &addannotation);
     sieve_register_fname(interp, &getfname);
 
     sieve_register_envelope(interp, &getenvelope);

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -35,6 +35,7 @@
 #include "auth.h"
 #include "prot.h"
 #include "times.h"
+#include "annotate.h"
 #include "global.h"
 #include "prometheus.h"
 #include "xmalloc.h"
@@ -225,6 +226,8 @@ static int msg_new(message_data_t **m, const struct namespace *ns)
 
     ret->hdrcache = spool_new_hdrcache();
 
+    ret->annotations = NULL;
+
     ret->ns = ns;
 
     *m = ret;
@@ -266,6 +269,8 @@ static void msg_free(message_data_t *m)
     }
 
     spool_free_hdrcache(m->hdrcache);
+
+    if (m->annotations) freeentryatts(m->annotations);
 
     free(m);
 }

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -35,6 +35,7 @@
 #include "auth.h"
 #include "prot.h"
 #include "times.h"
+#include "annotate.h"
 #include "global.h"
 #include "mboxevent.h"
 #include "prometheus.h"
@@ -227,6 +228,8 @@ static int msg_new(message_data_t **m, const struct namespace *ns)
 
     ret->hdrcache = spool_new_hdrcache();
 
+    ret->annotations = NULL;
+
     ret->ns = ns;
 
     *m = ret;
@@ -268,6 +271,8 @@ static void msg_free(message_data_t *m)
     }
 
     spool_free_hdrcache(m->hdrcache);
+
+    if (m->annotations) freeentryatts(m->annotations);
 
     free(m);
 }

--- a/imap/lmtpengine.h
+++ b/imap/lmtpengine.h
@@ -38,6 +38,8 @@ struct message_data {
     void *rock;
 
     hdrcache_t hdrcache;
+
+    struct entryattlist *annotations;   /* set by sieve addannotation */
 };
 
 /* return the corresponding header */

--- a/lib/imapoptions/sieve_allowed_annotations
+++ b/lib/imapoptions/sieve_allowed_annotations
@@ -1,0 +1,8 @@
+Name: sieve_allowed_annotations
+Type: STRING
+Default-Value: /vendor/* /comment
+Last-Modified: UNRELEASED
+
+Space-separated list of glob patterns for annotation entry names that the
+Sieve "addannotation" command (vnd.cyrus.addannotation) is permitted to set
+on delivered messages.

--- a/lib/imapoptions/sieve_extensions
+++ b/lib/imapoptions/sieve_extensions
@@ -7,14 +7,15 @@ Allowed-Values: fileinto reject vacation vacation-seconds notify include
  redirect-deliverby mailboxid vnd.cyrus.log=x-cyrus-log
  vnd.cyrus.jmapquery=x-cyrus-jmapquery processcalendar=vnd.cyrus.imip
  snooze=vnd.cyrus.snooze=x-cyrus-snooze vnd.cyrus.implicit_keep_target
- vnd.cyrus.redirect-multiple
+ vnd.cyrus.redirect-multiple vnd.cyrus.addannotation
 Default-Value: fileinto reject vacation vacation-seconds notify include
  envelope environment body relational regex subaddress copy date index
  imap4flags mailbox mboxmetadata servermetadata variables editheader
  extlists duplicate ihave fcc special-use redirect-dsn redirect-deliverby
  mailboxid vnd.cyrus.log vnd.cyrus.jmapquery processcalendar snooze
  vnd.cyrus.implicit_keep_target vnd.cyrus.redirect-multiple
-Last-Modified: 3.13.3
+ vnd.cyrus.addannotation
+Last-Modified: UNRELEASED
 
 Space-separated list of Sieve extensions allowed to be used in sieve
 scripts.  This option has no effect on options that are disabled at compile

--- a/sieve/bc_emit.c
+++ b/sieve/bc_emit.c
@@ -479,6 +479,7 @@ static int bc_action_emit(int fd, int codep, int stopcodep,
         case B_SET:
         case B_ADDHEADER:
         case B_DELETEHEADER:
+        case B_ADDANNOTATION:
         case B_LOG:
         case B_NULL:
         case B_STOP:

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -2373,6 +2373,22 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
             break;
         }
 
+        case B_ADDANNOTATION:
+        {
+            const char *entry = cmd.u.aan.entry;
+            const char *value = cmd.u.aan.value;
+            int scope = cmd.u.aan.scope;
+
+            if (requires & BFE_VARIABLES) {
+                entry = parse_string(entry, variables);
+                value = parse_string(value, variables);
+            }
+
+            i->addannotation(m, entry,
+                             scope ? "value.priv" : "value.shared", value);
+            break;
+        }
+
         case B_DELETEHEADER:
         {
             const char *name = cmd.u.dh.name;

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -2368,6 +2368,22 @@ int sieve_eval_bc(sieve_execute_t *exe, int *impl_keep_p, sieve_interp_t *i,
             break;
         }
 
+        case B_ADDANNOTATION:
+        {
+            const char *entry = cmd.u.aan.entry;
+            const char *value = cmd.u.aan.value;
+            int scope = cmd.u.aan.scope;
+
+            if (requires & BFE_VARIABLES) {
+                entry = parse_string(entry, variables);
+                value = parse_string(value, variables);
+            }
+
+            i->addannotation(m, entry,
+                             scope ? "value.priv" : "value.shared", value);
+            break;
+        }
+
         case B_DELETEHEADER:
         {
             const char *name = cmd.u.dh.name;

--- a/sieve/bc_parse.c
+++ b/sieve/bc_parse.c
@@ -269,6 +269,11 @@ static const struct args_t cmd_args_table[] = {
         offsetof(struct Commandlist, u.cal.outcome_var),
         offsetof(struct Commandlist, u.cal.reason_var)
       } },
+    { B_ADDANNOTATION,           "iss",                                  /* 49 */
+      { offsetof(struct Commandlist, u.aan.scope),
+        offsetof(struct Commandlist, u.aan.entry),
+        offsetof(struct Commandlist, u.aan.value)
+      } },
 };
 // clang-format: on
 

--- a/sieve/bc_parse.c
+++ b/sieve/bc_parse.c
@@ -267,6 +267,11 @@ static const struct args_t cmd_args_table[] = {
         offsetof(struct Commandlist, u.cal.outcome_var),
         offsetof(struct Commandlist, u.cal.reason_var)
       } },
+    { B_ADDANNOTATION,           "iss",                                  /* 49 */
+      { offsetof(struct Commandlist, u.aan.scope),
+        offsetof(struct Commandlist, u.aan.entry),
+        offsetof(struct Commandlist, u.aan.value)
+      } },
 };
 // clang-format: on
 

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -110,7 +110,7 @@ typedef union
  * version 0x21 scripts implemented comparator-i;unicode-casemap (RFC 5051)
  * version 0x22 scripts implemented processcalendar per RFC 9671
 */
-#define BYTECODE_VERSION 0x22
+#define BYTECODE_VERSION 0x23   /* 0x23: addannotation (vnd.cyrus.addannotation) */
 #define BYTECODE_MIN_VERSION 0x03 /* minimum supported version */
 #define BYTECODE_MAGIC "CyrSBytecode"
 #define BYTECODE_MAGIC_LEN 12 /* Should be multiple of 4 */
@@ -415,6 +415,10 @@ enum bytecode {
                                    <calendar-id: string>
                                    <outcome-var: string>
                                    <reason-var: string>                        */
+
+    B_ADDANNOTATION,            /* require "vnd.cyrus.addannotation"
+
+                                   <scope: int> <entry: string> <value: string> */
 
     /*****  insert new actions above this line  *****/
     B_ILLEGAL_VALUE             /* any value >= this code is illegal */

--- a/sieve/bytecode.h
+++ b/sieve/bytecode.h
@@ -109,8 +109,9 @@ typedef union
  * version 0x20 scripts implemented vnd.cyrus.implicit_keep_target
  * version 0x21 scripts implemented comparator-i;unicode-casemap (RFC 5051)
  * version 0x22 scripts implemented processcalendar per RFC 9671
+ * version 0x23 scripts implemented vnd.cyrus.addannotation
 */
-#define BYTECODE_VERSION 0x22
+#define BYTECODE_VERSION 0x23
 #define BYTECODE_MIN_VERSION 0x03 /* minimum supported version */
 #define BYTECODE_MAGIC "CyrSBytecode"
 #define BYTECODE_MAGIC_LEN 12 /* Should be multiple of 4 */
@@ -415,6 +416,10 @@ enum bytecode {
                                    <calendar-id: string>
                                    <outcome-var: string>
                                    <reason-var: string>                        */
+
+    B_ADDANNOTATION,            /* require "vnd.cyrus.addannotation"
+
+                                   <scope: int> <entry: string> <value: string> */
 
     /*****  insert new actions above this line  *****/
     B_ILLEGAL_VALUE             /* any value >= this code is illegal */

--- a/sieve/interp.c
+++ b/sieve/interp.c
@@ -90,6 +90,9 @@ EXPORTED const strarray_t *sieve_listextensions(sieve_interp_t *i)
         if (i->addheader &&
             (config_sieve_extensions & IMAP_ENUM_SIEVE_EXTENSIONS_EDITHEADER))
             buf_appendcstr(&buf, " editheader");
+        if (i->addannotation &&
+            (config_sieve_extensions & IMAP_ENUM_SIEVE_EXTENSIONS_VND_CYRUS_ADDANNOTATION))
+            buf_appendcstr(&buf, " vnd.cyrus.addannotation");
 #if 0  /* Don't advertise this to ManageSieve clients -
           We probably don't want end users adding this action themselves */
         if (config_sieve_extensions & IMAP_ENUM_SIEVE_EXTENSIONS_VND_CYRUS_LOG)
@@ -287,6 +290,13 @@ EXPORTED int sieve_register_addheader(sieve_interp_t *interp, sieve_add_header *
     return SIEVE_OK;
 }
 
+EXPORTED int sieve_register_addannotation(sieve_interp_t *interp,
+                                          sieve_add_annotation *f)
+{
+    interp->addannotation = f;
+    return SIEVE_OK;
+}
+
 EXPORTED int sieve_register_deleteheader(sieve_interp_t *interp, sieve_delete_header *f)
 {
     if (!interp->getheadersection) {
@@ -449,6 +459,7 @@ static const struct sieve_capa_t {
 
     /* Editheader - RFC 5293 */
     { "editheader", SIEVE_CAPA_EDITHEADER },
+    { "vnd.cyrus.addannotation", SIEVE_CAPA_ADDANNOTATION },
 
     /* [Extended] Reject - RFC 5429 */
     { "ereject", SIEVE_CAPA_EREJECT },
@@ -633,6 +644,11 @@ unsigned long long extension_isactive(sieve_interp_t *interp, const char *str)
     case SIEVE_CAPA_EDITHEADER:
         if (!(interp->addheader && interp->deleteheader &&
               (config_ext & IMAP_ENUM_SIEVE_EXTENSIONS_EDITHEADER))) capa = 0;
+        break;
+
+    case SIEVE_CAPA_ADDANNOTATION:
+        if (!(interp->addannotation &&
+              (config_ext & IMAP_ENUM_SIEVE_EXTENSIONS_VND_CYRUS_ADDANNOTATION))) capa = 0;
         break;
 
     case SIEVE_CAPA_EREJECT:

--- a/sieve/interp.h
+++ b/sieve/interp.h
@@ -18,6 +18,7 @@ struct sieve_interp {
     sieve_get_headersection *getheadersection;
     sieve_add_header *addheader;
     sieve_delete_header *deleteheader;
+    sieve_add_annotation *addannotation;
     sieve_get_envelope *getenvelope;
     sieve_get_environment *getenvironment;
     sieve_get_body *getbody;
@@ -195,6 +196,9 @@ enum sieve_capa_flag {
 
     /* vnd.cyrus.redirect-multiple */
     SIEVE_CAPA_REDIR_MULTI  = 1LL<<53,
+
+    /* vnd.cyrus.addannotation */
+    SIEVE_CAPA_ADDANNOTATION = 1LL<<54,
 };
 
 #define SIEVE_CAPA_ALL (SIEVE_CAPA_BASE           \
@@ -250,6 +254,7 @@ enum sieve_capa_flag {
                         | SIEVE_CAPA_IKEEP_TARGET \
                         | SIEVE_CAPA_COMP_UCASEMAP \
                         | SIEVE_CAPA_REDIR_MULTI  \
+                        | SIEVE_CAPA_ADDANNOTATION \
                         )
 
 #define SIEVE_CAPA_IHAVE_INCOMPAT (SIEVE_CAPA_ENCODED_CHAR | SIEVE_CAPA_VARIABLES)

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -175,6 +175,8 @@ EXPORTED sieve_interp_t *sieve_build_nonexec_interp()
     sieve_register_addheader(interpreter, (sieve_add_header *) &stub_generic);
     sieve_register_deleteheader(interpreter,
                                 (sieve_delete_header *) &stub_generic);
+    sieve_register_addannotation(interpreter,
+                                 (sieve_add_annotation *) &stub_generic);
     sieve_register_fname(interpreter, (sieve_get_fname *) &stub_generic);
     sieve_register_envelope(interpreter, (sieve_get_envelope *) &stub_generic);
     sieve_register_environment(interpreter,

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -173,6 +173,8 @@ EXPORTED sieve_interp_t *sieve_build_nonexec_interp()
     sieve_register_addheader(interpreter, (sieve_add_header *) &stub_generic);
     sieve_register_deleteheader(interpreter,
                                 (sieve_delete_header *) &stub_generic);
+    sieve_register_addannotation(interpreter,
+                                 (sieve_add_annotation *) &stub_generic);
     sieve_register_fname(interpreter, (sieve_get_fname *) &stub_generic);
     sieve_register_envelope(interpreter, (sieve_get_envelope *) &stub_generic);
     sieve_register_environment(interpreter,

--- a/sieve/sieve-lex.l
+++ b/sieve/sieve-lex.l
@@ -253,6 +253,11 @@ ws              [ \t]+
     /*   :index               defined in 'index' */
     /*   :last                defined in 'index' */
 
+    /* vnd.cyrus.addannotation */
+<INITIAL>addannotation        return ADDANNOTATION;
+<INITIAL>:priv                return PRIV;
+<INITIAL>:shared              return SHARED;
+
     /* [e]reject - RFC 5429 */
 <INITIAL>reject               return yylval->nval = REJCT;
 <INITIAL>ereject              return yylval->nval = EREJECT;

--- a/sieve/sieve.y
+++ b/sieve/sieve.y
@@ -77,6 +77,8 @@ static commandlist_t *build_addheader(sieve_script_t*, commandlist_t *c,
                                       char *name, char *value);
 static commandlist_t *build_deleteheader(sieve_script_t*, commandlist_t *c,
                                          char *name, strarray_t *values);
+static commandlist_t *build_addannotation(sieve_script_t*, commandlist_t *c,
+                                          char *entry, char *value);
 static commandlist_t *build_log(sieve_script_t*, char *text);
 static commandlist_t *build_snooze(sieve_script_t *sscript,
                                    commandlist_t *c, arrayu64_t *times);
@@ -129,7 +131,7 @@ extern void sieverestart(FILE *f);
 
 %name-prefix "sieve"
 %defines
-%destructor  { free_tree($$);     } commands command action control thenelse elsif block ktags ftags rtags stags vtags flagtags ahtags dhtags ntags itags sntags caltags ikttags
+%destructor  { free_tree($$);     } commands command action control thenelse elsif block ktags ftags rtags stags vtags flagtags ahtags dhtags aantags ntags itags sntags caltags ikttags
 %destructor  { free_testlist($$); } testlist tests
 %destructor  { free_test($$);     } test
 %destructor  { strarray_free($$); } optstringlist stringlist strings string1 recipients
@@ -231,6 +233,10 @@ extern void sieverestart(FILE *f);
 /* editheader - RFC 5293 */
 %token ADDHEADER DELETEHEADER
 %type <cl> ahtags dhtags
+
+/* vnd.cyrus.addannotation */
+%token ADDANNOTATION PRIV SHARED
+%type <cl> aantags
 
 /* [e]reject - RFC 5429 */
 %token <nval> REJCT EREJECT
@@ -483,6 +489,9 @@ action:   KEEP ktags             { $$ = build_keep(sscript, $2); }
         | DELETEHEADER dhtags string optstringlist
                                  { $$ = build_deleteheader(sscript,
                                                            $2, $3, $4); }
+        | ADDANNOTATION aantags string string
+                                 { $$ = build_addannotation(sscript,
+                                                            $2, $3, $4); }
 
         | reject string          { $$ = build_rej_err(sscript, $1, $2); }
         | NOTIFY ntags string    { $$ = build_notify(sscript, $2, $3); }
@@ -1029,6 +1038,13 @@ ahtags: /* empty */              { $$ = new_command(B_ADDHEADER, sscript); }
 
                                      $$->u.ah.index = -1;
                                  }
+        ;
+
+
+/* ADDANNOTATION tagged arguments */
+aantags: /* empty */             { $$ = new_command(B_ADDANNOTATION, sscript); }
+        | aantags PRIV           { $$ = $1; $$->u.aan.scope = 1; }
+        | aantags SHARED         { $$ = $1; $$->u.aan.scope = 0; }
         ;
 
 
@@ -2743,6 +2759,25 @@ static commandlist_t *build_deleteheader(sieve_script_t *sscript,
                              &c->u.dh.comp,
                              c->u.dh.name,
                              c->u.dh.values);
+
+    return c;
+}
+
+static commandlist_t *build_addannotation(sieve_script_t *sscript,
+                                          commandlist_t *c,
+                                          char *entry, char *value)
+{
+    assert(c && c->type == B_ADDANNOTATION);
+
+    verify_utf8(sscript, value);
+
+    c->u.aan.entry = entry;
+    c->u.aan.value = value;
+
+    c->nargs = bc_precompile(c->args, "iss",
+                             c->u.aan.scope,
+                             c->u.aan.entry,
+                             c->u.aan.value);
 
     return c;
 }

--- a/sieve/sieve_interface.h
+++ b/sieve/sieve_interface.h
@@ -43,6 +43,8 @@ typedef int sieve_add_header(void *message_context,
                              const char *header, const char *contents, int index);
 typedef int sieve_delete_header(void *message_context,
                                 const char *header, int index);
+typedef int sieve_add_annotation(void *message_context, const char *entry,
+                                 const char *attrib, const char *value);
 typedef int sieve_get_fname(void *message_context, const char **fname);
 typedef int sieve_get_envelope(void *message_context,
                                const char *field,
@@ -213,6 +215,7 @@ void sieve_register_header(sieve_interp_t *interp, sieve_get_header *f);
 void sieve_register_headersection(sieve_interp_t *interp,
                                   sieve_get_headersection *f);
 int sieve_register_addheader(sieve_interp_t *interp, sieve_add_header *f);
+int sieve_register_addannotation(sieve_interp_t *interp, sieve_add_annotation *f);
 int sieve_register_deleteheader(sieve_interp_t *interp, sieve_delete_header *f);
 void sieve_register_fname(sieve_interp_t *interp, sieve_get_fname *f);
 void sieve_register_envelope(sieve_interp_t *interp, sieve_get_envelope *f);

--- a/sieve/sieve_interface.h
+++ b/sieve/sieve_interface.h
@@ -44,6 +44,8 @@ typedef int sieve_add_header(void *message_context,
                              const char *header, const char *contents, int index);
 typedef int sieve_delete_header(void *message_context,
                                 const char *header, int index);
+typedef int sieve_add_annotation(void *message_context, const char *entry,
+                                 const char *attrib, const char *value);
 typedef int sieve_get_fname(void *message_context, const char **fname);
 typedef int sieve_get_envelope(void *message_context,
                                const char *field,
@@ -214,6 +216,7 @@ void sieve_register_header(sieve_interp_t *interp, sieve_get_header *f);
 void sieve_register_headersection(sieve_interp_t *interp,
                                   sieve_get_headersection *f);
 int sieve_register_addheader(sieve_interp_t *interp, sieve_add_header *f);
+int sieve_register_addannotation(sieve_interp_t *interp, sieve_add_annotation *f);
 int sieve_register_deleteheader(sieve_interp_t *interp, sieve_delete_header *f);
 void sieve_register_fname(sieve_interp_t *interp, sieve_get_fname *f);
 void sieve_register_envelope(sieve_interp_t *interp, sieve_get_envelope *f);

--- a/sieve/sieved.c
+++ b/sieve/sieved.c
@@ -770,6 +770,13 @@ static void dump2(bytecode_input_t *d, int bc_len)
             break;
 
 
+        case B_ADDANNOTATION:
+            printf("ADDANNOTATION SCOPE(%d)", cmd.u.aan.scope);
+            print_string(" ENTRY", cmd.u.aan.entry);
+            print_string(" VALUE", cmd.u.aan.value);
+            break;
+
+
         case B_DELETEHEADER:
             printf("DELETEHEADER INDEX(%d)", cmd.u.dh.comp.index);
             print_comparator(&cmd.u.dh.comp);
@@ -1605,6 +1612,14 @@ static int generate_block(bytecode_input_t *bc, int pos, int end,
             generate_switch(":last", (cmd.u.ah.index < 0), buf);
             generate_string(NULL, cmd.u.ah.name, buf);
             generate_string(NULL, cmd.u.ah.value, buf);
+            break;
+
+        case B_ADDANNOTATION:
+            *requires |= SIEVE_CAPA_ADDANNOTATION;
+            generate_token("addannotation", indent, buf);
+            generate_switch(":priv", cmd.u.aan.scope, buf);
+            generate_string(NULL, cmd.u.aan.entry, buf);
+            generate_string(NULL, cmd.u.aan.value, buf);
             break;
 
         case B_DELETEHEADER:

--- a/sieve/tree.c
+++ b/sieve/tree.c
@@ -271,6 +271,11 @@ commandlist_t *new_command(int type, sieve_script_t *parse_script)
         supported = parse_script->support & SIEVE_CAPA_EDITHEADER;
         break;
 
+    case B_ADDANNOTATION:
+        capability = "vnd.cyrus.addannotation";
+        supported = parse_script->support & SIEVE_CAPA_ADDANNOTATION;
+        break;
+
     case B_LOG:
         capability = "vnd.cyrus.log";
         supported = parse_script->support & SIEVE_CAPA_LOG;
@@ -500,6 +505,11 @@ void free_tree(commandlist_t *cl)
         case B_ADDHEADER:
             free(cl->u.ah.name);
             free(cl->u.ah.value);
+            break;
+
+        case B_ADDANNOTATION:
+            free(cl->u.aan.entry);
+            free(cl->u.aan.value);
             break;
 
         case B_DELETEHEADER:

--- a/sieve/tree.h
+++ b/sieve/tree.h
@@ -207,6 +207,11 @@ struct Commandlist {
             char *name;
             strarray_t *values;
         } dh;
+        struct { /* it's an addannotation action */
+            int scope;       /* 0 = value.shared (default), 1 = value.priv */
+            char *entry;
+            char *value;
+        } aan;
         struct { /* it's a log action */
             char *text;
         } l;


### PR DESCRIPTION
This adds an "addannotation" command like "addheader" to sieve.  Maybe we should write it up as a spec.

I'm thinking this might be a useful tool for adding delivery data to messages without having to adulterate them with headers during the sieve phase.