### PR TITLE
imap_proxy.c: ENABLE all client-enabled capabilities on new backend

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -613,6 +613,9 @@ sub _create_instances
                 lmtp_admins => 'mailproxy',
                 proxy_authname => 'mailproxy',
                 proxy_password => 'mailproxy',
+                # Make sure the backend will advertise support for UTF8=ACCEPT
+                reject8bit => 'off',
+                munge8bit => 'off',
             );
         }
 
@@ -709,6 +712,9 @@ sub _create_instances
                     "localhost:$backend1_service_port localhost:$backend2_service_port",
                 proxy_authname => 'mailproxy',
                 proxy_password => 'mailproxy',
+                # Make sure the frontend will advertise support for UTF8=ACCEPT
+                reject8bit => 'off',
+                munge8bit => 'off',
             );
 
             my $cyrus_other_prefix = $cassini->val('cyrus other', 'prefix');
@@ -784,6 +790,9 @@ sub _create_instances
                 sasl_mech_list => 'PLAIN',
                 proxy_authname => 'mailproxy',
                 proxy_password => 'mailproxy',
+                # Make sure the backend will advertise support for UTF8=ACCEPT
+                reject8bit => 'off',
+                munge8bit => 'off',
             );
 
             $backend2_params{description} = "murder backend2 for test $class.$name";

--- a/cassandane/tiny-tests/MurderIMAP/append_utf8
+++ b/cassandane/tiny-tests/MurderIMAP/append_utf8
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_append_utf8 ($self)
+{
+    my $result;
+
+    my $frontend = $self->{frontend_store}->get_client();
+    my $MsgTxt = <<EOF;
+From: blah\@xyz.com
+To: whoever\@whereever.com
+Subject: you are a ☀
+
+Hello
+EOF
+    $MsgTxt =~ s/\n/\015\012/g;
+
+    xlog $self, "ENABLE UTF8=ACCEPT";
+    my $res = $frontend->_imap_cmd('ENABLE', 0, "enabled", "UTF8=ACCEPT");
+    $self->assert_num_equals(1, $res->{'utf8=accept'});
+
+    xlog $self, "Append message with UTF-8 header to mailbox";
+    $res = $frontend->_imap_cmd('APPEND', 0, "", "INBOX",
+                                'UTF8', [ { Literal => $MsgTxt } ]);
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+}

--- a/cassandane/tiny-tests/MurderIMAP/uidonly
+++ b/cassandane/tiny-tests/MurderIMAP/uidonly
@@ -1,0 +1,21 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_uidonly
+    ($self)
+{
+    my $frontend = $self->{frontend_store}->get_client();
+
+    my $res = $frontend->select('INBOX');
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+
+    xlog $self, "ENABLE UIDONLY";
+    $res = $frontend->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
+    $self->assert_num_equals(1, $res->{uidonly});
+
+    xlog $self, "Attempt FETCH";
+    $res = $frontend->fetch('1:*', '(UID FLAGS)');
+    $self->assert_str_equals('bad', $frontend->get_last_completion_response());
+    # get_response_code() doesn't (yet) handle [UIDREQUIRED]
+    $self->assert_matches(qr/\[UIDREQUIRED\]/, $frontend->get_last_error());
+}

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -98,7 +98,8 @@ static const struct tls_alpn_t http_alpn_map[] = {
 
 static struct protocol_t http =
 { "http", "HTTP", http_alpn_map, TYPE_SPEC,
-  { .spec = { &login, &ping, &logout } }
+  { .spec = { &login, &ping, &logout } },
+  NULL
 };
 
 static int extractor_connect(struct extractor_ctx *ext)

--- a/imap/deliver.c
+++ b/imap/deliver.c
@@ -58,7 +58,8 @@ static struct protocol_t lmtp_protocol =
       { "AUTH", 512, 0, "235", "5", "334 ", "*", NULL, 0 },
       { NULL, NULL, NULL },
       { "NOOP", NULL, "250" },
-      { "QUIT", NULL, "221" } } }
+      { "QUIT", NULL, "221" } } },
+  NULL
 };
 
 /* unused for deliver.c, but needed to make lmtpengine.c happy */

--- a/imap/http_proxy.c
+++ b/imap/http_proxy.c
@@ -51,7 +51,8 @@ static const struct tls_alpn_t http_alpn_map[] = {
 
 HIDDEN struct protocol_t http_protocol =
 { "http", "HTTP", http_alpn_map, TYPE_SPEC,
-  { .spec = { &login, &ping, &logout } }
+  { .spec = { &login, &ping, &logout } },
+  NULL
 };
 
 

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -48,6 +48,14 @@ static void imap_postcapability(struct backend *s)
     }
 }
 
+static void imap_postauth(struct backend *s)
+{
+    if (client_capa) {
+        /* Enable all capabilities enabled by the client on the new backend */
+        proxy_enable(s, client_capa);
+    }
+}
+
 static const struct tls_alpn_t imap_alpn_map[] = {
     { "imap", NULL, NULL },
     { "",     NULL, NULL },
@@ -80,7 +88,7 @@ struct protocol_t imap_protocol =
       { "Z01 COMPRESS DEFLATE", "* ", "Z01 OK" },
       { "N01 NOOP", "* ", "N01 OK" },
       { "Q01 LOGOUT", "* ", "Q01 " } } },
-  NULL
+  imap_postauth
 };
 
 void proxy_gentag(char *tag, size_t len)
@@ -1630,4 +1638,35 @@ static void proxy_part_filldata(partlist_t *part_list, int idx)
         item->available = server_available;
         item->total = server_total;
     }
+}
+
+void prot_print_client_capa(struct protstream *pout, unsigned capa)
+{
+    if (capa & CAPA_IMAP4REV2) {
+        prot_puts(pout, " IMAP4rev2");
+    }
+    if (capa & CAPA_CONDSTORE) {
+        prot_puts(pout, " CONDSTORE");
+    }
+    if (capa & CAPA_QRESYNC) {
+        prot_puts(pout, " QRESYNC");
+    }
+    if (capa & CAPA_UIDONLY) {
+        prot_puts(pout, " UIDONLY");
+    }
+    if (capa & CAPA_UTF8_ACCEPT) {
+        prot_puts(pout, " UTF8=ACCEPT");
+    }
+}
+
+void proxy_enable(struct backend *s, unsigned capa)
+{
+    char mytag[128];
+
+    /* Enable the specified capabilities on the backend */
+    proxy_gentag(mytag, sizeof(mytag));
+    prot_printf(s->out, "%s ENABLE", mytag);
+    prot_print_client_capa(s->out, capa);
+    prot_puts(s->out, "\r\n");
+    discard_until_tag(s, mytag, 0);
 }

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -79,7 +79,8 @@ struct protocol_t imap_protocol =
         NULL, AUTO_CAPA_AUTH_OK },
       { "Z01 COMPRESS DEFLATE", "* ", "Z01 OK" },
       { "N01 NOOP", "* ", "N01 OK" },
-      { "Q01 LOGOUT", "* ", "Q01 " } } }
+      { "Q01 LOGOUT", "* ", "Q01 " } } },
+  NULL
 };
 
 void proxy_gentag(char *tag, size_t len)

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -110,6 +110,9 @@ struct backend *proxy_findinboxserver(const char *userid)
     return s;
 }
 
+#define PIPE_FLAG_FORCE_NOTFATAL (1<<0)
+#define PIPE_FLAG_DISCARD        (1<<1)
+
 /* pipe_response() reads from 's->in' until either the tagged response
    starting with 'tag' appears, or if 'tag' is NULL, to the end of the
    current line.  If 'include_last' is set, the last/tagged line is included
@@ -123,13 +126,15 @@ struct backend *proxy_findinboxserver(const char *userid)
    even though it is in 95% of the cases, a good idea...
 */
 static int pipe_response(struct backend *s, const char *tag, int include_last,
-                         int force_notfatal)
+                         unsigned flags)
 {
     char buf[2048];
     char eol[128];
     unsigned sl;
     int cont = 0, last = !tag, r = PROXY_OK;
     size_t taglen = 0;
+    unsigned force_notfatal = flags & PIPE_FLAG_FORCE_NOTFATAL;
+    unsigned discard        = flags & PIPE_FLAG_DISCARD;
 
     s->timeout->mark = time(NULL) + IDLE_TIMEOUT;
 
@@ -201,14 +206,16 @@ static int pipe_response(struct backend *s, const char *tag, int include_last,
 
             /* write out this part, but we have to keep reading until we
                hit the end of the line */
-            if (!last || include_last) prot_write(imapd_out, buf, sl);
+            if (!discard && (!last || include_last))
+                prot_write(imapd_out, buf, sl);
             cont = 1;
             continue;
         } else {                /* we got the end of the line */
             int i;
             int litlen = 0, islit = 0;
 
-            if (!last || include_last) prot_write(imapd_out, buf, sl);
+            if (!discard && (!last || include_last))
+                prot_write(imapd_out, buf, sl);
 
             /* now we have to see if this line ends with a literal */
             if (sl < 64) {
@@ -244,7 +251,8 @@ static int pipe_response(struct backend *s, const char *tag, int include_last,
                         /* EOF or other error */
                         return -1;
                     }
-                    if (!last || include_last) prot_write(imapd_out, buf, j);
+                    if (!discard && (!last || include_last))
+                        prot_write(imapd_out, buf, j);
                     litlen -= j;
                 }
 
@@ -263,6 +271,11 @@ static int pipe_response(struct backend *s, const char *tag, int include_last,
     } while (!last || cont);
 
     return r;
+}
+
+int discard_until_tag(struct backend *s, const char *tag, int force_notfatal)
+{
+    return pipe_response(s, tag, 0, PIPE_FLAG_DISCARD | force_notfatal);
 }
 
 int pipe_until_tag(struct backend *s, const char *tag, int force_notfatal)

--- a/imap/imap_proxy.h
+++ b/imap/imap_proxy.h
@@ -65,4 +65,8 @@ int annotate_fetch_proxy(const char *server, const char *mbox_pat,
 int annotate_store_proxy(const char *server, const char *mbox_pat,
                          struct entryattlist *entryatts);
 char *find_free_server(void);
+
+void prot_print_client_capa(struct protstream *pout, unsigned capa);
+
+void proxy_enable(struct backend *s, unsigned capa);
 #endif /* _IMAP_PROXY_H */

--- a/imap/imap_proxy.h
+++ b/imap/imap_proxy.h
@@ -38,6 +38,7 @@ void proxy_gentag(char *tag, size_t len);
 
 struct backend *proxy_findinboxserver(const char *userid);
 
+int discard_until_tag(struct backend *s, const char *tag, int force_notfatal);
 int pipe_until_tag(struct backend *s, const char *tag, int force_notfatal);
 int pipe_including_tag(struct backend *s, const char *tag, int force_notfatal);
 int pipe_command(struct backend *s, int optimistic_literal);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4707,25 +4707,6 @@ out:
     quota_free(&q);
 }
 
-static void prot_print_client_capa(struct protstream *pout, unsigned capa)
-{
-    if (capa & CAPA_IMAP4REV2) {
-        prot_puts(pout, " IMAP4rev2");
-    }
-    if (capa & CAPA_CONDSTORE) {
-        prot_puts(pout, " CONDSTORE");
-    }
-    if (capa & CAPA_QRESYNC) {
-        prot_puts(pout, " QRESYNC");
-    }
-    if (capa & CAPA_UIDONLY) {
-        prot_puts(pout, " UIDONLY");
-    }
-    if (capa & CAPA_UTF8_ACCEPT) {
-        prot_puts(pout, " UTF8=ACCEPT");
-    }
-}
-
 static int parse_select_params(char *tag, char *cmd, int allowdeleted,
                                struct index_init *init)
 {
@@ -4930,15 +4911,6 @@ static void cmd_select(char *tag, char *cmd, char *name)
         if (r) {
             prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
             goto done;
-        }
-
-        if (client_capa) {
-            /* Enable client capabilities on new backend */
-            proxy_gentag(mytag, sizeof(mytag));
-            prot_printf(backend_current->out, "%s Enable", mytag);
-            prot_print_client_capa(backend_current->out, client_capa);
-            prot_puts(backend_current->out, "\r\n");
-            pipe_until_tag(backend_current, mytag, 0);
         }
 
         /* Send SELECT command to backend */
@@ -14793,7 +14765,7 @@ static void cmd_enable(char *tag)
     }
 
     /* filter out already enabled extensions */
-    new_capa ^= client_capa;
+    new_capa &= ~client_capa;
 
     if (new_capa & (CAPA_UTF8_ACCEPT | CAPA_IMAP4REV2)) {
         imapd_namespace.isutf8 = 1;
@@ -14806,24 +14778,18 @@ static void cmd_enable(char *tag)
         }
     }
 
-    if (ptrarray_size(&backend_cached)) {
+    if (new_capa) {
         /* ENABLE on all remote mailboxes */
         for (int i = 0; i < ptrarray_size(&backend_cached); i++) {
-            struct backend *be = ptrarray_nth(&backend_cached, i);
-
-            prot_printf(be->out, "%s ENABLE", tag);
-            prot_print_client_capa(be->out, new_capa);
-            prot_puts(be->out, "\r\n");
-            pipe_until_tag(be, tag, 0);
+            proxy_enable(ptrarray_nth(&backend_cached, i), new_capa);
         }
     }
-    else {
-        /* RFC 9051, 6.3.1:
-         * The ENABLED response is sent even if no extensions were enabled. */
-        prot_puts(imapd_out, "* ENABLED");
-        prot_print_client_capa(imapd_out, new_capa);
-        prot_puts(imapd_out, "\r\n");
-    }
+
+    /* RFC 9051, 6.3.1:
+     * The ENABLED response is sent even if no extensions were enabled. */
+    prot_puts(imapd_out, "* ENABLED");
+    prot_print_client_capa(imapd_out, new_capa);
+    prot_puts(imapd_out, "\r\n");
 
     /* track the new capabilities */
     client_capa |= new_capa;

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -143,7 +143,8 @@ static struct protocol_t lmtp_protocol =
       { "AUTH", 512, 0, "235", "5", "334 ", "*", NULL, 0 },
       { NULL, NULL, NULL },
       { "NOOP", NULL, "250" },
-      { "QUIT", NULL, "221" } } }
+      { "QUIT", NULL, "221" } } },
+  NULL
 };
 
 static struct sasl_callback mysasl_cb[] = {

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -47,7 +47,8 @@ static struct protocol_t mupdate_protocol =
       { "A01 AUTHENTICATE", USHRT_MAX, 1, "A01 OK", "A01 NO", "", "*", NULL, 0 },
       { "Z01 COMPRESS \"DEFLATE\"", NULL, "Z01 OK" },
       { "N01 NOOP", NULL, "N01 OK" },
-      { "Q01 LOGOUT", NULL, "Q01 " } } }
+      { "Q01 LOGOUT", NULL, "Q01 " } } },
+  NULL
 };
 
 EXPORTED int mupdate_connect(const char *server,

--- a/imap/nntpd.c
+++ b/imap/nntpd.c
@@ -239,7 +239,8 @@ static struct protocol_t nntp_protocol =
       { "AUTHINFO SASL", 512, 0, "28", "48", "383 ", "*", &nntp_parsesuccess, 0 },
       { NULL, NULL, NULL },
       { "DATE", NULL, "111" },
-      { "QUIT", NULL, "205" } } }
+      { "QUIT", NULL, "205" } } },
+  NULL
 };
 
 static int read_response(struct backend *s, int force_notfatal, char **result)

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -142,7 +142,8 @@ static struct protocol_t pop3_protocol =
       { "AUTH", 255, 0, "+OK", "-ERR", "+ ", "*", NULL, 0 },
       { NULL, NULL, NULL },
       { "NOOP", NULL, "+OK" },
-      { "QUIT", NULL, "+OK" } } }
+      { "QUIT", NULL, "+OK" } } },
+  NULL
 };
 
 static void bitpipe(void);

--- a/imap/protocol.h
+++ b/imap/protocol.h
@@ -100,6 +100,7 @@ struct protocol_t {
            int (*logout)(struct backend *s);
        } spec;
     } u;
+    void (*post_auth)(struct backend *s);
 };
 
 #endif /* _INCLUDED_PROTOCOL_H */

--- a/imap/proxy.c
+++ b/imap/proxy.c
@@ -154,6 +154,11 @@ EXPORTED struct backend * proxy_findserver(const char *server,          /* hostn
                                              time(NULL) + IDLE_TIMEOUT,
                                              backend_timeout, ret);
         }
+
+        if (prot->post_auth) {
+            /* do post-auth processing */
+            prot->post_auth(ret);
+        }
     }
 
     ret->current = current;

--- a/imap/smtpclient.c
+++ b/imap/smtpclient.c
@@ -87,7 +87,8 @@ static struct protocol_t smtp_protocol =
       { "AUTH", 512, 0, "235", "5", "334 ", "*", NULL, 0 },
       { NULL, NULL, NULL },
       { "NOOP", NULL, "250" },
-      { "QUIT", NULL, "221" } } }
+      { "QUIT", NULL, "221" } } },
+  NULL
 };
 
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -100,7 +100,8 @@ static struct protocol_t imap_csync_protocol =
         &imap_sasl_parsesuccess, AUTO_CAPA_AUTH_OK },
       { "Z01 COMPRESS DEFLATE", "* ", "Z01 OK" },
       { "N01 NOOP", "* ", "N01 OK" },
-      { "Q01 LOGOUT", "* ", "Q01 " } } }
+      { "Q01 LOGOUT", "* ", "Q01 " } } },
+  NULL
 };
 
 static struct protocol_t csync_protocol =
@@ -118,7 +119,8 @@ static struct protocol_t csync_protocol =
       { "AUTHENTICATE", USHRT_MAX, 0, "OK", "NO", "+ ", "*", NULL, 0 },
       { "COMPRESS DEFLATE", NULL, "OK" },
       { "NOOP", NULL, "OK" },
-      { "EXIT", NULL, "OK" } } }
+      { "EXIT", NULL, "OK" } } },
+  NULL
 };
 
 struct sync_action {

--- a/ptclient/http.c
+++ b/ptclient/http.c
@@ -92,7 +92,8 @@ static const struct tls_alpn_t http_alpn_map[] = {
 
 static struct protocol_t protocol =
 { "http", "HTTP", http_alpn_map, TYPE_SPEC,
-  { .spec = { &login, &ping, &logout } }
+  { .spec = { &login, &ping, &logout } },
+  NULL
 };
 
 

--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -101,7 +101,8 @@ static struct protocol_t sieve_protocol =
         &sieve_parsesuccess, AUTO_CAPA_AUTH_SSF },
       { NULL, NULL, NULL },
       { NULL, NULL, NULL },
-      { "LOGOUT", NULL, "OK" } } }
+      { "LOGOUT", NULL, "OK" } } },
+  NULL
 };
 
 /* Returns TRUE if we are done */


### PR DESCRIPTION
Also:
 - fix calculation of newly enabled capabilities
 - consolidate proxying of ENABLE into proxy_enable()

Previously, we were only sending ENABLE to backends on SELECT.
However this failed to account for commands that operate in
unselected state, E.g. APPEND, COPY, etc.
Now, we send ENABLE to a backend immediately after connecting
which covers any command that we will subsequently send to it.

This PR is best reviewed commit by commit