### PR TITLE
util.h: use heap-allocated buffer in MODSEQ_FROM_JMAPID

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -146,15 +146,15 @@ extern const unsigned char convert_to_uppercase[256];
 }
 
 #define MODSEQ_FROM_JMAPID(jmapid, modseqp) {                                   \
-        /* use a fixed modseq-sized decode buffer */                            \
-        size_t size = sizeof(modseq_t);                                         \
-        char decstr[size];                                                      \
-        struct buf decbuf = { decstr, 0, size, 0 };                             \
+        struct buf decbuf = BUF_INITIALIZER;                                    \
         charset_decode(&decbuf, jmapid, strlen(jmapid), ENCODING_BASE64JMAPID); \
-        /* right-align the network-order decoded data */                        \
+        /* right-align the network-order decoded data; ignore an id that        \
+         * decodes to more bytes than a modseq_t (it can not be valid) */       \
         modseq_t u64 = 0;                                                       \
-        int len = buf_len(&decbuf);                                             \
-        memcpy((void *) &u64 + (size - len), buf_base(&decbuf), len);           \
+        size_t len = buf_len(&decbuf);                                          \
+        if (len && len <= sizeof(u64))                                          \
+            memcpy((char *) &u64 + (sizeof(u64) - len), buf_base(&decbuf), len);\
+        buf_free(&decbuf);                                                      \
         *modseqp = ntohll(u64);                                                 \
 }
 


### PR DESCRIPTION
This changes the MODSEQ_FROM_JMAPID macro from using a fixed-size stack-allocated buffer to a heap-allocated buffer. The original code was correct for valid input but caused an allocator error when the charset pipeline attempted to realloc the stack-allocated memory.

Using a fixed-size buffer was a neat optimization, but its actual benefit is marginal. The charset pipeline allocates on the heap in interim buffers regardless, so the cost of that one buffer doesn't make it worthwhile to poke into the struct buf definitions or to assume internals about the charset pipeline memory handling.

A cleaner solution would be to refactor the charset pipeline such that it reduces unnecessary heap allocations, but this is out of scope of this change.