### PR TITLE
index.c: FETCH 1:* (VANISHED) has to look at ALL messages

### DIFF
--- a/cassandane/tiny-tests/QResync/qresync_simple
+++ b/cassandane/tiny-tests/QResync/qresync_simple
@@ -14,6 +14,7 @@ sub test_qresync_simple ($self)
     }
 
     my $talk = $self->{store}->get_client();
+    $talk->uid(1);
     $talk->select("INBOX");
     my $uidvalidity = $talk->get_response_code('uidvalidity');
 
@@ -32,4 +33,18 @@ sub test_qresync_simple ($self)
     @vanished = $talk->get_response_code('vanished');
     $self->assert_num_equals(23, $talk->get_response_code('exists'));
     $self->assert_equals("5:10,25:45", $vanished[0][1]);
+
+    xlog $self, "Mark last messages \\Deleted";
+    my $res = $talk->store('*', '+flags', '(\\Deleted)');
+    my $modseq = $res->{50}{modseq}[0];
+
+    xlog $self, "Expunge message";
+    $talk->expunge();
+    @vanished = $talk->get_response_code('vanished');
+    $self->assert_equals("50", $vanished[0][0]);
+
+    xlog $self, "Fetch vanished changedsince";
+    $talk->fetch('1:*', '(uid)', "(changedsince $modseq vanished)");   
+    @vanished = $talk->get_response_code('vanished');
+    $self->assert_equals("50", $vanished[0][1]);
 }

--- a/imap/index.c
+++ b/imap/index.c
@@ -147,8 +147,11 @@ static void index_thread_refs(struct index_state *state,
                               unsigned *msgno_list, unsigned int nmsg,
                               int usinguid);
 
+#define SEQ_PARSE_USINGUID 1
+#define SEQ_PARSE_VANISHED 2
+
 static seqset_t *_parse_sequence(struct index_state *state,
-                                 const char *sequence, int usinguid);
+                                 const char *sequence, unsigned mode);
 static void massage_header(char *hdr);
 
 /* NOTE: Make sure these are listed in CAPABILITY_STRING */
@@ -936,7 +939,7 @@ seqset_t *index_vanished(struct index_state *state,
     if (params->modseq >= state->highestmodseq) return NULL;
 
     outlist = seqset_init(0, SEQ_SPARSE);
-    seq = _parse_sequence(state, params->sequence, 1);
+    seq = _parse_sequence(state, params->sequence, SEQ_PARSE_VANISHED);
 
     /* XXX - use match_seq and match_uid */
 
@@ -7339,7 +7342,7 @@ EXPORTED int index_hasrights(const struct index_state *state, int rights)
  * Parse a sequence into an array of sorted & merged ranges.
  */
 static seqset_t *_parse_sequence(struct index_state *state,
-                                 const char *sequence, int usinguid)
+                                 const char *sequence, unsigned mode)
 {
     unsigned maxval;
 
@@ -7354,11 +7357,16 @@ static seqset_t *_parse_sequence(struct index_state *state,
        "*" represents the largest number in use.
        In the case of message sequence numbers,
        it is the number of messages in a non-empty mailbox.
-       In the case of unique identifiers,
+       In the case of vanished unique identifiers (RFC 7162, Section 3.2.6),
+       it is the mailbox's current UIDNEXT value.
+       Otherwise, in the case of unique identifiers,
        it is the unique identifier of the last message in the mailbox
        or, if the mailbox is empty, the mailbox's current UIDNEXT value.
     */
-    if (usinguid) {
+    if (mode == SEQ_PARSE_VANISHED) {
+        maxval = state->last_uid + 1;
+    }
+    else if (mode == SEQ_PARSE_USINGUID) {
         if (state->exists) maxval = index_getuid(state, state->exists);
         else maxval = state->last_uid + 1;
     }


### PR DESCRIPTION
Expunged messages may have UIDs greater than the last visible message. Without this fix, if the last UID were expunged, it would not be reported as VANISHED.