### PR TITLE
jmap_contact.c: don't set empty-valued parameters and groups

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_set_create_ignore_empty_string
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_create_ignore_empty_string
@@ -1,0 +1,68 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_set_create_ignore_empty_string
+    ($self)
+{
+    my $abook = $self->default_user->addressbooks->default;
+
+    xlog $self, "create a card with empty-string values";
+    my $card = $abook->create_card({
+        '@type' => 'Card',
+        name => 'John Doe',
+        addresses => {
+            k23 => {
+                '@type' => 'Address',
+                contexts => { private => JSON::true },
+                pref => 1,
+                components => [
+                    { kind => 'name', value => 'FOO BAR' },
+                ],
+                countryCode => '',
+            },
+        },
+        personalInfo => {
+            'PERSINFO-1' => {
+                '@type' => 'PersonalInfo',
+                kind => 'interest',
+                value => 'music',
+                level => '',
+            },
+            'PERSINFO-2' => {
+                '@type' => 'PersonalInfo',
+                kind => 'hobby',
+                value => 'reading',
+                label => '',
+            },
+        },
+    });
+
+    $self->assert_not_null($card->id);
+
+    my $vcard = $card->as_vcard4_struct;
+    my $props = $vcard->{properties};
+
+    xlog $self, "an empty countryCode must not emit an empty-valued CC parameter";
+    my $adr = $props->{adr};
+    $self->assert_not_null($adr);
+    $self->assert_num_equals(1, scalar @$adr);
+    $self->assert(
+        !exists $adr->[0]{params}{cc},
+        "ADR property must not have a CC parameter for an empty countryCode"
+    );
+
+    xlog $self, "an empty level must not emit an empty-valued LEVEL parameter";
+    my $interest = $props->{interest};
+    $self->assert_not_null($interest);
+    $self->assert_num_equals(1, scalar @$interest);
+    $self->assert(
+        !exists $interest->[0]{params}{level},
+        "INTEREST property must not have a LEVEL parameter for an empty level"
+    );
+
+    xlog $self, "an empty label must not emit an empty X-ABLabel property";
+    $self->assert(
+        !exists $props->{'x-ablabel'},
+        "an empty label must not emit an X-ABLabel property"
+    );
+}

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -6094,38 +6094,58 @@ static void _jsparam_to_vcard(struct jmap_parser *parser,
                 }
             }
 
-            param = new = vcardparameter_new(VCARD_LEVEL_PARAMETER);
-            vcardparameter_set_value_from_string(param, val);
+            if (*val) {
+                param = new = vcardparameter_new(VCARD_LEVEL_PARAMETER);
+                vcardparameter_set_value_from_string(param, val);
+            }
+            else {
+                /* Treat an empty string the same as an absent value rather
+                   than emitting an empty-valued parameter (e.g. LEVEL=) */
+                jprop = NULL;
+            }
         }
         break;
 
     case VCARD_X_PARAMETER:
         /* label translates to a grouped X-ABLabel property */
         if (json_is_string(jprop)) {
-            vcardproperty *label = vcardproperty_new(VCARD_X_PROPERTY);
-            vcardproperty_set_value(label,
-                    vcardvalue_new_text(json_string_value(jprop)));
-            const char *group;
+            const char *val = json_string_value(jprop);
 
-            vcardproperty_set_x_name(label, VCARD_APPLE_LABEL_PROPERTY);
-            vcardcomponent_add_property(vcardproperty_get_parent(prop), label);
+            if (*val) {
+                vcardproperty *label = vcardproperty_new(VCARD_X_PROPERTY);
+                vcardproperty_set_value(label, vcardvalue_new_text(val));
+                const char *group;
 
-            buf_setcstr(&buf, vcardproperty_get_property_name(prop));
-            buf_truncate(&buf, MIN(5, buf_len(&buf)));
-            buf_printf(&buf, "%u", (*groupnum)++);
-            group = buf_lcase(&buf);
+                vcardproperty_set_x_name(label, VCARD_APPLE_LABEL_PROPERTY);
+                vcardcomponent_add_property(vcardproperty_get_parent(prop), label);
 
-            vcardproperty_set_group(label, group);
-            vcardproperty_set_group(prop, group);
+                buf_setcstr(&buf, vcardproperty_get_property_name(prop));
+                buf_truncate(&buf, MIN(5, buf_len(&buf)));
+                buf_printf(&buf, "%u", (*groupnum)++);
+                group = buf_lcase(&buf);
+
+                vcardproperty_set_group(label, group);
+                vcardproperty_set_group(prop, group);
+            }
+            /* Treat an empty string the same as an absent value rather than
+               emitting an empty X-ABLabel property */
             jprop = NULL;
         }
         break;
 
     default:
         if (json_is_string(jprop)) {
-            param = new = vcardparameter_new(pkind);
-            vcardparameter_set_value_from_string(param,
-                                                 json_string_value(jprop));
+            const char *val = json_string_value(jprop);
+
+            if (*val) {
+                param = new = vcardparameter_new(pkind);
+                vcardparameter_set_value_from_string(param, val);
+            }
+            else {
+                /* Treat an empty string the same as an absent value rather
+                   than emitting an empty-valued parameter (e.g. CC="") */
+                jprop = NULL;
+            }
         }
         break;
     }


### PR DESCRIPTION
When converting a JSContact Card to vCard, an empty string property value could result in a parameter without value. Similarly, an empty label resulted in an empty group. This patch updates Cyrus to treat an empty string like an absent value.