### PR TITLE
jmap_contact.c: ignore bogus JSCOMPS parameters in ContactCard/get

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_get_adr_bogus_jscomp
+++ b/cassandane/tiny-tests/JMAPContacts/card_get_adr_bogus_jscomp
@@ -1,0 +1,42 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_get_adr_bogus_jscomp
+    :needs_component_jmap
+    ($self)
+{
+    my $jmap = $self->{jmap};
+    my $carddav = $self->{carddav};
+
+    xlog $self, "PUT vCard with bogus JSCOMPS parameters";
+    # adr1: JSCOMPS references an empty component
+    # adr2: JSCOMPS references a component that is not part of the address
+    my $card = <<~"EOF";
+    BEGIN:VCARD
+    VERSION:4.0
+    UID:bed2b3d9-479c-4800-84f5-04116c35fa0a
+    PRODID:-//FOO//bar//EN
+    FN:Test
+    ADR;PROP-ID=adr1;JSCOMPS=";3;0":;;;foo;;;
+    ADR;PROP-ID=adr2;JSCOMPS=";18;3":;;;foo;;;;;;;;;;;;;;;bar
+    CREATED:20260625T000859Z
+    END:VCARD
+    EOF
+    $card =~ s/\r?\n/\r\n/gs;
+
+    $carddav->Request('PUT', 'Default/test.vcf',
+        $card, 'Content-Type' => 'text/vcard');
+
+
+    # Assert that the bogus JSCOMPS parameters are ignored.
+    my $res = $jmap->request([
+        ['ContactCard/get', { }, 'R1'],
+    ]);
+
+    my $jscard = $res->single_sentence('ContactCard/get')->arguments->{list}[0];
+
+    $self->assert_cmp_deeply({
+        adr1 => { components => [ { kind => 'locality', value => 'foo' } ] },
+        adr2 => { components => [ { kind => 'locality', value => 'foo' } ] },
+    }, $jscard->{addresses});
+}

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -3360,6 +3360,47 @@ static void jscomps_from_vcard(json_t *obj, vcardproperty *prop,
 
     param = vcardproperty_get_first_parameter(prop, VCARD_JSCOMPS_PARAMETER);
     if (param) {
+        /* Validate the JSCOMPS references. If any is false, ignore JSCOMPS. */
+        vcardstructuredtype *jscomps = vcardparameter_get_jscomps(param);
+        size_t num_jscomps = vcardstructured_num_fields(jscomps);
+        size_t num_comp_kinds = 0;
+
+        while (comp_kinds[num_comp_kinds].name) num_comp_kinds++;
+
+        for (i = 1; i < num_jscomps; i++) {
+            sa = vcardstructured_field_at(jscomps, i);
+            val = vcardstrarray_element_at(sa, 0);
+            if (!val) break;
+
+            if (*val == 's') {
+                /* separator: must carry a value */
+                if (!vcardstrarray_element_at(sa, 1)) break;
+            }
+            else {
+                int field_idx = atoi(val);
+                int val_idx = 0;
+
+                if (field_idx < 0 ||
+                    field_idx >= (int) vcardstructured_num_fields(st) ||
+                    field_idx >= (int) num_comp_kinds) break;
+
+                if (vcardstrarray_size(sa) > 1)
+                    val_idx = atoi(vcardstrarray_element_at(sa, 1));
+
+                val = vcardstrarray_element_at(
+                        vcardstructured_field_at(st, field_idx), val_idx);
+                if (!val || !*val) break;
+            }
+        }
+
+        if (i < num_jscomps) {
+            /* Bogus reference: drop the JSCOMPS parameter */
+            vcardproperty_remove_parameter_by_ref(prop, param);
+            param = NULL;
+        }
+    }
+
+    if (param) {
         /* Order components per JSCOMPS */
         vcardstructuredtype *jscomps = vcardparameter_get_jscomps(param);
 


### PR DESCRIPTION
A JSCOMPS parameter that references an empty or out-of-range component is invalid and must be ignored. This patch updates vCard to JSContact conversion to validate the JSCOMPS references. If any is invalid, it drops the parameter and handles the name/address components as if the isOrdered property is false.