### PR TITLE
gitignore: update for the new location of cyradm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ docsrc/.doctrees/
 docsrc/_doxygen/
 docsrc/build/
 docsrc/reference/manpages/configs/imapd.conf.rst
-docsrc/reference/manpages/usercommands/cyradm.rst
+docsrc/reference/manpages/systemcommands/cyradm.rst
 docsrc/reference/manpages/usercommands/sieveshell.rst
 imap/arbitron
 imap/backupcyrusd


### PR DESCRIPTION
bb37546d1de moved cyradm from user to system commands, but the gitignore wasn't updated for it.