### PR TITLE
make http, caldav, carddav, etc. mandatory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -192,7 +192,7 @@ libexec_PROGRAMS += \
     imap/lmtpd \
     imap/pop3d \
     imap/backupcyrusd \
-		imap/calalarmd \
+    imap/calalarmd \
     imap/promstatsd \
     imap/smmapd \
     ptclient/ptloader

--- a/Makefile.am
+++ b/Makefile.am
@@ -1008,6 +1008,14 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/auditlog.h \
     imap/backend.c \
     imap/backend.h \
+    imap/caldav_alarm.c \
+    imap/caldav_alarm.h \
+    imap/caldav_db.c \
+    imap/caldav_db.h \
+    imap/calsched_support.c \
+    imap/calsched_support.h \
+    imap/carddav_db.c \
+    imap/carddav_db.h \
     imap/conversations.c \
     imap/conversations.h \
     imap/convert_code.c \
@@ -1016,6 +1024,10 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/css3_color.h \
     imap/dav_db.c \
     imap/dav_db.h \
+    imap/dav_util.c \
+    imap/dav_util.h \
+    imap/defaultalarms.c \
+    imap/defaultalarms.h \
     imap/dlist.c \
     imap/dlist.h \
     imap/duplicate.c \
@@ -1026,16 +1038,20 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/haproxy.h \
     imap/http_client.c \
     imap/http_client.h \
+    imap/ical_support.c \
+    imap/ical_support.h \
+    imap/icu_wrap.cpp \
+    imap/icu_wrap.h \
     imap/idle.c \
     imap/idle.h \
     imap/idlemsg.c \
     imap/idlemsg.h \
     imap/imapparse.c \
     imap/imapparse.h \
-    imap/index.c \
-    imap/index.h \
     imap/index_file.c \
     imap/index_file.h \
+    imap/index.c \
+    imap/index.h \
     imap/jmap_util.c \
     imap/jmap_util.h \
     imap/json_support.c \
@@ -1046,18 +1062,18 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/mailbox.h \
     imap/mbdump.c \
     imap/mbdump.h \
+    imap/mboxevent.c \
+    imap/mboxevent.h \
     imap/mboxkey.c \
     imap/mboxkey.h \
     imap/mboxlist.c \
     imap/mboxlist.h \
-    imap/mboxevent.c \
-    imap/mboxevent.h \
     imap/mboxname.c \
     imap/mboxname.h \
     imap/message_guid.c \
+    imap/message_priv.h \
     imap/message.c \
     imap/message.h \
-    imap/message_priv.h \
     imap/msgrecord.c \
     imap/msgrecord.h \
     imap/mupdate-client.c \
@@ -1079,20 +1095,20 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/search_engines.h \
     imap/search_expr.c \
     imap/search_expr.h \
+    imap/search_part.h \
     imap/search_query.c \
     imap/search_query.h \
-    imap/search_part.h \
     imap/search_sort.h \
-    imap/seen.h \
     imap/seen_db.c \
+    imap/seen.h \
     imap/sievedir.c \
     imap/sievedir.h \
     imap/smtpclient.c \
     imap/smtpclient.h \
     imap/spool.c \
     imap/spool.h \
-    imap/statuscache.h \
     imap/statuscache_db.c \
+    imap/statuscache.h \
     imap/sync_log.c \
     imap/sync_log.h \
     imap/telemetry.c \
@@ -1103,15 +1119,18 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/user.h \
     imap/userdeny_db.c \
     imap/userdeny.h \
+    imap/vcard_support.c \
+    imap/vcard_support.h \
     imap/version.c \
-    imap/version.h
+    imap/version.h \
+    imap/webdav_db.c \
+    imap/webdav_db.h
 
 if SIEVE
 imap_libcyrus_imap_la_SOURCES += \
     imap/sieve_db.c \
     imap/sieve_db.h
 endif # SIEVE
-
 
 if USE_SQUAT
 imap_libcyrus_imap_la_SOURCES += \
@@ -1122,28 +1141,6 @@ imap_libcyrus_imap_la_SOURCES += \
     imap/squat_internal.c \
     imap/squat_internal.h
 endif
-
-imap_libcyrus_imap_la_SOURCES += \
-    imap/caldav_alarm.c \
-    imap/caldav_alarm.h \
-    imap/caldav_db.c \
-    imap/caldav_db.h \
-    imap/carddav_db.c \
-    imap/carddav_db.h \
-    imap/dav_util.c \
-    imap/dav_util.h \
-    imap/defaultalarms.c \
-    imap/defaultalarms.h \
-    imap/ical_support.c \
-    imap/ical_support.h \
-    imap/icu_wrap.h \
-    imap/icu_wrap.cpp \
-    imap/calsched_support.c \
-    imap/calsched_support.h \
-    imap/vcard_support.c \
-    imap/vcard_support.h \
-    imap/webdav_db.c \
-    imap/webdav_db.h
 
 if CUNIT
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -192,6 +192,7 @@ libexec_PROGRAMS += \
     imap/lmtpd \
     imap/pop3d \
     imap/backupcyrusd \
+		imap/calalarmd \
     imap/promstatsd \
     imap/smmapd \
     ptclient/ptloader
@@ -261,12 +262,6 @@ if MURDER
 libexec_PROGRAMS += imap/mupdate
 endif # MURDER
 
-if CALALARMD
-libexec_PROGRAMS += imap/calalarmd
-endif
-
-if HTTPD
-
 AM_CPPFLAGS += $(HTTP_CPPFLAGS)
 
 AM_LDFLAGS += $(HTTP_LIBS)
@@ -281,8 +276,6 @@ noinst_PROGRAMS += imap/ical_apply_patch
 sbin_PROGRAMS += \
     imap/ctl_zoneinfo \
     imap/dav_reconstruct
-
-endif # HTTPD
 
 if REPLICATION
 libexec_PROGRAMS += imap/sync_server
@@ -689,11 +682,8 @@ cunit_TESTS += \
     cunit/tok.testc \
     cunit/dynarray.testc \
     cunit/util.testc \
+    cunit/ical_support.testc \
     cunit/xsha1.testc
-
-if HTTPD
-cunit_TESTS += cunit/ical_support.testc
-endif
 
 cunit_unit_SOURCES = $(cunit_FRAMEWORK) $(cunit_TESTS) \
     imap/css3_color.c imap/mutex_fake.c imap/spool.c imap/search_expr.c \
@@ -1133,7 +1123,6 @@ imap_libcyrus_imap_la_SOURCES += \
     imap/squat_internal.h
 endif
 
-if HTTPD
 imap_libcyrus_imap_la_SOURCES += \
     imap/caldav_alarm.c \
     imap/caldav_alarm.h \
@@ -1162,9 +1151,6 @@ cunit_TESTS += cunit/http_jwt.testc
 cunit_unit_SOURCES += imap/http_jwt.c
 
 endif # CUNIT
-
-
-endif # HTTPD
 
 if USE_XAPIAN
 imap_libcyrus_imap_la_SOURCES += \
@@ -1206,7 +1192,6 @@ endif # AUTOCREATE
 if SIEVE
 imap_lmtpd_SOURCES += imap/lmtp_sieve.c imap/lmtp_sieve.h imap/smtpclient.c \
                       imap/zoneinfo_db.c
-if HTTPD
 imap_lmtpd_SOURCES += imap/jmap_util.c imap/caldav_util.c imap/defaultalarms.c imap/itip_support.c
 
 if JMAP
@@ -1214,8 +1199,6 @@ imap_lmtpd_SOURCES += \
     imap/jmap_mail_query.c imap/jmap_mail_query_parse.c \
     imap/dav_util.c imap/jmap_notif.c imap/jmap_ical.c imap/jcal.c imap/xcal.c
 endif # JMAP
-
-endif # HTTPD
 
 endif # SIEVE
 

--- a/changes/next/cyr-1715-mandatory-dav
+++ b/changes/next/cyr-1715-mandatory-dav
@@ -1,0 +1,39 @@
+Description:
+
+HTTP support, *DAV (CalDAV, CardDAV, WebDAV) and the calendar alarm daemon
+are now mandatory parts of every Cyrus IMAP build.  The ``--enable-http``
+and ``--enable-calalarmd`` configure options have been removed; the httpd
+binary and calalarmd are always built.  libical, libxml2 and SQLite3 are
+now required build dependencies.
+
+The runtime ``httpmodules`` option is unchanged: administrators continue
+to select which modules a given httpd serves, and may still run multiple
+httpd instances each serving a different subset.
+
+
+Documentation:
+
+docsrc/download/installation/manage-dav.rst
+docsrc/developer/compiling.rst
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+If you build Cyrus IMAP from source, make sure libical (>= 4.0.0),
+libxml2, SQLite3 and the xxd utility are installed, along with their
+development headers and pkg-config files.
+
+Any build scripts that pass ``--enable-http`` or ``--enable-calalarmd``
+to configure should drop those options.  ``--disable-http`` and
+``--disable-calalarmd`` are no longer accepted; the corresponding
+functionality cannot be turned off at build time.
+
+
+GitHub issue:
+
+None

--- a/configure.ac
+++ b/configure.ac
@@ -2375,13 +2375,11 @@ Cyrus Server configured components
    gssapi:             $gssapi
    autocreate:         $enable_autocreate
    idled:              $enable_idled
-   httpd:              yes
    murder:             $enable_murder
    nntpd:              $enable_nntp
    replication:        $enable_replication
    sieve:              $enable_sieve
    srs:                $enable_srs
-   calalarmd:          yes
    jmap:               $enable_jmap
    com_err:            $with_com_err
 
@@ -2397,8 +2395,6 @@ External dependencies:
    wslay:              $with_wslay
    brotli:             $with_brotli
    zstd:               $with_zstd
-   xml2:               $with_xml2
-   ical:               $with_ical
    shapelib:           $with_shapelib
    icu4c:              $with_icu4c
    chardet:            $with_chardet
@@ -2408,7 +2404,6 @@ External dependencies:
 Database support:
    mysql:              $with_mysql
    postgresql:         $use_pgsql
-   sqlite:             $use_sqlite
 
 Search engine:
    squat:              $enable_squat

--- a/configure.ac
+++ b/configure.ac
@@ -1434,166 +1434,150 @@ AC_PATH_PROG([XXD],[xxd])
 AM_CONDITIONAL([HAVE_XXD], [test -n "$XXD"])
 
 dnl
-dnl see if we're compiling with HTTP support
+dnl HTTP support (and CalDAV, CardDAV, WebDAV) is mandatory as of Cyrus 3.13.5
+dnl libical, libxml2, sqlite3 and xxd are required build dependencies.
 dnl
-AC_ARG_ENABLE(http,
-        [AS_HELP_STRING([--enable-http], [enable HTTP support])],, [enable_http="no";])
-AM_CONDITIONAL([HTTPD], [test "$enable_http" != "no"])
+AM_CONDITIONAL([HTTPD], [true])
+AC_DEFINE(USE_HTTPD,[],[Build with HTTP functionality])
 
 HTTP_CPPFLAGS=
 HTTP_LIBS=
-if test "$enable_http" != no; then
-dnl
-dnl make sure all the modules we need are present
-dnl
-        if test "x$HAVE_SQLITE" != x1; then
-            AC_MSG_ERROR([Need sqlite3 for http])
-        else
-            use_sqlite="yes"
-            AC_DEFINE(WITH_DAV,[],[Build *DAV support into httpd?])
-        fi
 
-        AS_IF([test -z "$XXD"], [AC_MSG_ERROR([Need xxd for http])])
+if test "x$HAVE_SQLITE" != x1; then
+    AC_MSG_ERROR([Need sqlite3 for http])
+else
+    use_sqlite="yes"
+    AC_DEFINE(WITH_DAV,[],[Build *DAV support into httpd?])
+fi
 
-        PKG_CHECK_MODULES([XML2], [libxml-2.0], [
-                AC_DEFINE(HAVE_XML2, [], [Build with libxml support])
-                LIBS="$LIBS ${XML2_LIBS}"
-                with_xml2=yes
-                ],
-                AC_MSG_ERROR([Need libxml-2.0 for http]))
+AS_IF([test -z "$XXD"], [AC_MSG_ERROR([Need xxd for http])])
 
-        AC_CHECK_LIB(xml2, xmlFirstElementChild, [
-                AC_DEFINE(HAVE_XML_FIRSTCHILD,[],
-                        [Do we have support for xmlFirstElementChild()?])
+PKG_CHECK_MODULES([XML2], [libxml-2.0], [
+        AC_DEFINE(HAVE_XML2, [], [Build with libxml support])
+        LIBS="$LIBS ${XML2_LIBS}"
+        with_xml2=yes
+        ],
+        AC_MSG_ERROR([Need libxml-2.0 for http]))
 
-                AC_CHECK_LIB(xml2, xmlBufferDetach,
-                        AC_DEFINE(HAVE_XML_BUFFERDETACH,[],
-                                [Do we have support for xmlBufferDetach()?]))
-                ])
+AC_CHECK_LIB(xml2, xmlFirstElementChild, [
+        AC_DEFINE(HAVE_XML_FIRSTCHILD,[],
+                [Do we have support for xmlFirstElementChild()?])
 
-        PKG_CHECK_MODULES([ICAL], [libical >= 3.99.99], [
-                AC_DEFINE(HAVE_ICAL,[],[Build CalDAV support into httpd?])
-                LIBS="$LIBS ${ICAL_LIBS} -licalvcard"
-                with_ical=yes
-                ],
-                AC_MSG_ERROR([Need libical for http]))
+        AC_CHECK_LIB(xml2, xmlBufferDetach,
+                AC_DEFINE(HAVE_XML_BUFFERDETACH,[],
+                        [Do we have support for xmlBufferDetach()?]))
+        ])
 
-        dnl Check if libical supports PARTICIPANT-TYPE=VOTER
-        AC_CHECK_DECL([ICAL_PARTICIPANTTYPE_VOTER],
-                AC_DEFINE(HAVE_PARTTYPE_VOTER,[],
-                        [Do we have support for PARTICIPANT-TYPE=VOTER?]),
-                [], [[#include <libical/ical.h>]])
+PKG_CHECK_MODULES([ICAL], [libical >= 3.99.99], [
+        AC_DEFINE(HAVE_ICAL,[],[Build CalDAV support into httpd?])
+        LIBS="$LIBS ${ICAL_LIBS} -licalvcard"
+        with_ical=yes
+        ],
+        AC_MSG_ERROR([Need libical for http]))
 
-        dnl vcardparser_set_xprop_value_kind will be new in libical 4.0
-        AC_CHECK_LIB(icalvcard, vcardparser_set_xprop_value_kind,
-                AC_DEFINE(HAVE_LIBICALVCARD_XPROP_VALUE,[],
-                        [Do we have support for custom x-property value types?]))
+dnl Check if libical supports PARTICIPANT-TYPE=VOTER
+AC_CHECK_DECL([ICAL_PARTICIPANTTYPE_VOTER],
+        AC_DEFINE(HAVE_PARTTYPE_VOTER,[],
+                [Do we have support for PARTICIPANT-TYPE=VOTER?]),
+        [], [[#include <libical/ical.h>]])
+
+dnl vcardparser_set_xprop_value_kind will be new in libical 4.0
+AC_CHECK_LIB(icalvcard, vcardparser_set_xprop_value_kind,
+        AC_DEFINE(HAVE_LIBICALVCARD_XPROP_VALUE,[],
+                [Do we have support for custom x-property value types?]))
 
 dnl  Don't bother checking for DKIM until iSchedule gains traction
-dnl        PKG_CHECK_MODULES([DKIM], [opendkim >= 2.7.0],
-dnl                AC_EGREP_HEADER(DKIM_CANON_ISCHEDULE, dkim.h,
-dnl                        AC_DEFINE(WITH_DKIM,[],
-dnl                                [Build DKIM support into iSchedule?]),
-dnl                        AC_MSG_WARN([Your version of OpenDKIM can not support iSchedule.  Consider patching OpenDKIM with contrib/dkim_canon_ischedule.patch])),
-dnl                AC_MSG_WARN([Your version of OpenDKIM can not support iSchedule.  Consider upgrading to OpenDKIM >= 2.7.0]))
+dnl PKG_CHECK_MODULES([DKIM], [opendkim >= 2.7.0],
+dnl         AC_EGREP_HEADER(DKIM_CANON_ISCHEDULE, dkim.h,
+dnl                 AC_DEFINE(WITH_DKIM,[],
+dnl                         [Build DKIM support into iSchedule?]),
+dnl                 AC_MSG_WARN([Your version of OpenDKIM can not support iSchedule.  Consider patching OpenDKIM with contrib/dkim_canon_ischedule.patch])),
+dnl         AC_MSG_WARN([Your version of OpenDKIM can not support iSchedule.  Consider upgrading to OpenDKIM >= 2.7.0]))
 
-        AC_ARG_WITH(nghttp2, [AS_HELP_STRING([--without-nghttp2], [disable HTTP/2 support (check)])],,[with_nghttp2="check"])
-        if test "x$with_nghttp2" = "xyes" -o "x$with_nghttp2" = "xcheck"; then
-                PKG_CHECK_MODULES([NGHTTP2], [libnghttp2 >= 1.34.0], [
-                        AC_DEFINE(HAVE_NGHTTP2,[],
-                                [Build HTTP/2 support into httpd?])
-                        AC_CHECK_DECL([nghttp2_submit_data2],
-                                AC_DEFINE(HAVE_NGHTTP2_SSIZE,[],
-                                [Do we have support for nghttp2_ssize?]),
-                                [], [[#include <nghttp2/nghttp2.h>]])
-                        with_nghttp2=yes
-                ], [
-                        if test "x$with_nghttp2" = "xyes"; then
-                                AC_MSG_ERROR([HTTP/2 explicitly requested, but libnghttp2 was not found])
-                        fi
-                        AC_MSG_NOTICE([httpd will not have support for HTTP/2.  Consider installing libnghttp2 >= 1.5])
-                        with_nghttp2=no
-                ])
-        fi
-
-
-        AC_ARG_WITH(wslay, [AS_HELP_STRING([--without-wslay], [disable WebSockets support (check)])],,[with_wslay="check"])
-        if test "x$with_wslay" = "xyes" -o "x$with_wslay" = "xcheck"; then
-                PKG_CHECK_MODULES([WSLAY], [libwslay >= 1.1.1], [
-                        with_wslay=yes
-                ], [
-                        AC_SEARCH_LIBS([wslay_event_context_free], [wslay], [
-                            AC_SUBST([WSLAY_LIBS], [-lwslay])
-                            with_wslay=yes
-                        ], [
-                                if test "x$with_wslay" = "xyes"; then
-                                        AC_MSG_ERROR([WebSockets explicitly requested, but libwslay was not found])
-                                fi
-                                with_wslay=no
-                        ])
-                ])
-
-                if test "x$with_wslay" = "xyes"; then
-                        AC_DEFINE(HAVE_WSLAY,[],
-                                [Build WebSockets support into httpd?])
-                else
-                        AC_MSG_NOTICE([httpd will not have support for WebSockets.  Consider installing libwslay])
+AC_ARG_WITH(nghttp2, [AS_HELP_STRING([--without-nghttp2], [disable HTTP/2 support (check)])],,[with_nghttp2="check"])
+if test "x$with_nghttp2" = "xyes" -o "x$with_nghttp2" = "xcheck"; then
+        PKG_CHECK_MODULES([NGHTTP2], [libnghttp2 >= 1.34.0], [
+                AC_DEFINE(HAVE_NGHTTP2,[],
+                        [Build HTTP/2 support into httpd?])
+                AC_CHECK_DECL([nghttp2_submit_data2],
+                        AC_DEFINE(HAVE_NGHTTP2_SSIZE,[],
+                        [Do we have support for nghttp2_ssize?]),
+                        [], [[#include <nghttp2/nghttp2.h>]])
+                with_nghttp2=yes
+        ], [
+                if test "x$with_nghttp2" = "xyes"; then
+                        AC_MSG_ERROR([HTTP/2 explicitly requested, but libnghttp2 was not found])
                 fi
-        fi
-
-        AC_ARG_WITH(brotli, [AS_HELP_STRING([--without-brotli], [disable brotli compression (check)])])
-        if test "x$with_brotli" = xyes -o "${with_brotli+x}" != x; then
-                PKG_CHECK_MODULES([BROTLI], [libbrotlienc], [
-                        AC_DEFINE(HAVE_BROTLI,[],
-                                [Build Brotli compression support into httpd?])
-                        with_brotli=yes
-                ], [
-                        if test "x$with_brotli" = xyes; then
-                                AC_MSG_ERROR([brotli compression explicitly requested, but libbrotlienc was not found])
-                        fi
-                        with_brotli="no (libbrotlienc not found)"
-                ])
-        fi
-
-        AC_ARG_WITH(zstd, [AS_HELP_STRING([--without-zstd], [disable Zstandard compression (check)])])
-        if test "x$with_zstd" = xyes -o "${with_zstd+x}" != x; then
-                PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.4.0], [
-                        AC_DEFINE(HAVE_ZSTD,[],
-                                [Build Zstandard compression support into httpd?])
-                        with_zstd=yes
-                ], [
-                        if test "x$with_zstd" = xyes; then
-                                AC_MSG_ERROR([Zstandard compression explicitly requested, but libzstd was not found])
-                        fi
-                        with_zstd="no (libzstd >= 1.4.0 not found)"
-               ])
-        fi
-
-        PKG_CHECK_MODULES([SHAPELIB], [shapelib >= 1.3.0],[
-                AC_DEFINE(HAVE_SHAPELIB,[],
-                        [Build geographic support into tzdist?])
-                AC_DEFINE(SHAPELIB_VERSION, ["1.3.0"], [ShapeLib Version])
-                with_shapelib=yes
-                ],
-                AC_MSG_NOTICE([tzdist will not have geolocation support.  Consider installing shapelib]))
-
-        HTTP_CPPFLAGS="${XML2_CFLAGS} ${SQLITE3_CFLAGS} ${ICAL_CFLAGS} ${GLIB_CFLAGS} ${JANSSON_CFLAGS} ${NGHTTP2_CFLAGS} ${WSLAY_CFLAGS} ${BROTLI_CFLAGS} ${ZSTD_CFLAGS} ${SHAPELIB_CFLAGS}"
-        HTTP_LIBS="${XML2_LIBS} ${SQLITE3_LIBS} ${ICAL_LIBS} ${GLIB_LIBS} ${JANSSON_LIBS} ${NGHTTP2_LIBS} ${WSLAY_LIBS} ${BROTLI_LIBS} ${ZSTD_LIBS} ${SHAPELIB_LIBS} ${LIBM}"
-else
-        with_nghttp2="no (httpd is not built)"
-        with_wslay="no (httpd is not built)"
-        with_brotli="no (httpd is not built)"
-        with_zstd="no (httpd is not built)"
-        with_xml2="no (httpd is not built)"
-        with_ical="no (httpd is not built)"
-        with_icalvcard="no (httpd is not built)"
-        with_shapelib="no (httpd is not built)"
+                AC_MSG_NOTICE([httpd will not have support for HTTP/2.  Consider installing libnghttp2 >= 1.5])
+                with_nghttp2=no
+        ])
 fi
+
+
+AC_ARG_WITH(wslay, [AS_HELP_STRING([--without-wslay], [disable WebSockets support (check)])],,[with_wslay="check"])
+if test "x$with_wslay" = "xyes" -o "x$with_wslay" = "xcheck"; then
+        PKG_CHECK_MODULES([WSLAY], [libwslay >= 1.1.1], [
+                with_wslay=yes
+        ], [
+                AC_SEARCH_LIBS([wslay_event_context_free], [wslay], [
+                    AC_SUBST([WSLAY_LIBS], [-lwslay])
+                    with_wslay=yes
+                ], [
+                        if test "x$with_wslay" = "xyes"; then
+                                AC_MSG_ERROR([WebSockets explicitly requested, but libwslay was not found])
+                        fi
+                        with_wslay=no
+                ])
+        ])
+
+        if test "x$with_wslay" = "xyes"; then
+                AC_DEFINE(HAVE_WSLAY,[],
+                        [Build WebSockets support into httpd?])
+        else
+                AC_MSG_NOTICE([httpd will not have support for WebSockets.  Consider installing libwslay])
+        fi
+fi
+
+AC_ARG_WITH(brotli, [AS_HELP_STRING([--without-brotli], [disable brotli compression (check)])])
+if test "x$with_brotli" = xyes -o "${with_brotli+x}" != x; then
+        PKG_CHECK_MODULES([BROTLI], [libbrotlienc], [
+                AC_DEFINE(HAVE_BROTLI,[],
+                        [Build Brotli compression support into httpd?])
+                with_brotli=yes
+        ], [
+                if test "x$with_brotli" = xyes; then
+                        AC_MSG_ERROR([brotli compression explicitly requested, but libbrotlienc was not found])
+                fi
+                with_brotli="no (libbrotlienc not found)"
+        ])
+fi
+
+AC_ARG_WITH(zstd, [AS_HELP_STRING([--without-zstd], [disable Zstandard compression (check)])])
+if test "x$with_zstd" = xyes -o "${with_zstd+x}" != x; then
+        PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.4.0], [
+                AC_DEFINE(HAVE_ZSTD,[],
+                        [Build Zstandard compression support into httpd?])
+                with_zstd=yes
+        ], [
+                if test "x$with_zstd" = xyes; then
+                        AC_MSG_ERROR([Zstandard compression explicitly requested, but libzstd was not found])
+                fi
+                with_zstd="no (libzstd >= 1.4.0 not found)"
+       ])
+fi
+
+PKG_CHECK_MODULES([SHAPELIB], [shapelib >= 1.3.0],[
+        AC_DEFINE(HAVE_SHAPELIB,[],
+                [Build geographic support into tzdist?])
+        AC_DEFINE(SHAPELIB_VERSION, ["1.3.0"], [ShapeLib Version])
+        with_shapelib=yes
+        ],
+        AC_MSG_NOTICE([tzdist will not have geolocation support.  Consider installing shapelib]))
+
+HTTP_CPPFLAGS="${XML2_CFLAGS} ${SQLITE3_CFLAGS} ${ICAL_CFLAGS} ${GLIB_CFLAGS} ${JANSSON_CFLAGS} ${NGHTTP2_CFLAGS} ${WSLAY_CFLAGS} ${BROTLI_CFLAGS} ${ZSTD_CFLAGS} ${SHAPELIB_CFLAGS}"
+HTTP_LIBS="${XML2_LIBS} ${SQLITE3_LIBS} ${ICAL_LIBS} ${GLIB_LIBS} ${JANSSON_LIBS} ${NGHTTP2_LIBS} ${WSLAY_LIBS} ${BROTLI_LIBS} ${ZSTD_LIBS} ${SHAPELIB_LIBS} ${LIBM}"
 AC_SUBST(HTTP_CPPFLAGS)
 AC_SUBST(HTTP_LIBS)
-if test "x$enable_http" = "xyes"; then
-        AC_DEFINE(USE_HTTPD,[],[Build with HTTP functionality])
-fi
 
 dnl
 dnl allow setting a compile-time default for zoneinfo_dir
@@ -1611,18 +1595,10 @@ AS_IF([test "x$with_zoneinfo_dir" != "x"],
                          [Default zoneinfo_dir]))
 
 dnl
-dnl see if we're compiling with calendar alarm support
+dnl Calendar alarm support is mandatory as of Cyrus 3.13.5
 dnl
-AC_ARG_ENABLE(calalarmd,
-        [AS_HELP_STRING([--enable-calalarmd], [enable CalDAV alarm support])],,[enable_calalarmd="no";])
-if test "x$enable_calalarmd" = "xyes"; then
-    if test "x$enable_http" = "xyes"; then
-    AC_DEFINE(USE_CALALARMD,[],[Build with calendar alarm functionality])
-    else
-    AC_MSG_ERROR([--enable-calalarmd requires --enable-http])
-    fi
-fi
-AM_CONDITIONAL([CALALARMD], [test "$enable_calalarmd" != "no"])
+AC_DEFINE(USE_CALALARMD,[],[Build with calendar alarm functionality])
+AM_CONDITIONAL([CALALARMD], [true])
 
 dnl
 dnl see if we're compiling with JMAP support
@@ -1632,9 +1608,6 @@ AC_ARG_ENABLE(jmap,
 if test "x$enable_jmap" = "xyes" ; then
     if test "x$enable_xapian" = "xno" ; then
         AC_MSG_ERROR([--enable-jmap requires --enable-xapian])
-    fi
-    if test "x$enable_http" = "xno" ; then
-        AC_MSG_ERROR([--enable-jmap requires --enable-http])
     fi
     AC_DEFINE(WITH_JMAP,[],[Build with JMAP support])
 fi
@@ -2413,13 +2386,13 @@ Cyrus Server configured components
    gssapi:             $gssapi
    autocreate:         $enable_autocreate
    idled:              $enable_idled
-   httpd:              $enable_http
+   httpd:              yes
    murder:             $enable_murder
    nntpd:              $enable_nntp
    replication:        $enable_replication
    sieve:              $enable_sieve
    srs:                $enable_srs
-   calalarmd:          $enable_calalarmd
+   calalarmd:          yes
    jmap:               $enable_jmap
    com_err:            $with_com_err
 

--- a/configure.ac
+++ b/configure.ac
@@ -1437,8 +1437,6 @@ dnl
 dnl HTTP support (and CalDAV, CardDAV, WebDAV) is mandatory as of Cyrus 3.13.5
 dnl libical, libxml2, sqlite3 and xxd are required build dependencies.
 dnl
-AM_CONDITIONAL([HTTPD], [true])
-AC_DEFINE(USE_HTTPD,[],[Build with HTTP functionality])
 
 HTTP_CPPFLAGS=
 HTTP_LIBS=
@@ -1447,13 +1445,11 @@ if test "x$HAVE_SQLITE" != x1; then
     AC_MSG_ERROR([Need sqlite3 for http])
 else
     use_sqlite="yes"
-    AC_DEFINE(WITH_DAV,[],[Build *DAV support into httpd?])
 fi
 
 AS_IF([test -z "$XXD"], [AC_MSG_ERROR([Need xxd for http])])
 
 PKG_CHECK_MODULES([XML2], [libxml-2.0], [
-        AC_DEFINE(HAVE_XML2, [], [Build with libxml support])
         LIBS="$LIBS ${XML2_LIBS}"
         with_xml2=yes
         ],
@@ -1469,7 +1465,6 @@ AC_CHECK_LIB(xml2, xmlFirstElementChild, [
         ])
 
 PKG_CHECK_MODULES([ICAL], [libical >= 3.99.99], [
-        AC_DEFINE(HAVE_ICAL,[],[Build CalDAV support into httpd?])
         LIBS="$LIBS ${ICAL_LIBS} -licalvcard"
         with_ical=yes
         ],
@@ -1597,8 +1592,6 @@ AS_IF([test "x$with_zoneinfo_dir" != "x"],
 dnl
 dnl Calendar alarm support is mandatory as of Cyrus 3.13.5
 dnl
-AC_DEFINE(USE_CALALARMD,[],[Build with calendar alarm functionality])
-AM_CONDITIONAL([CALALARMD], [true])
 
 dnl
 dnl see if we're compiling with JMAP support

--- a/configure.ac
+++ b/configure.ac
@@ -1590,10 +1590,6 @@ AS_IF([test "x$with_zoneinfo_dir" != "x"],
                          [Default zoneinfo_dir]))
 
 dnl
-dnl Calendar alarm support is mandatory as of Cyrus 3.13.5
-dnl
-
-dnl
 dnl see if we're compiling with JMAP support
 dnl
 AC_ARG_ENABLE(jmap,

--- a/doc/examples/cyrus_conf/normal.conf
+++ b/doc/examples/cyrus_conf/normal.conf
@@ -18,7 +18,7 @@ SERVICES {
 #  nntp          cmd="nntpd" listen="nntp" prefork=0
 #  nntps         cmd="nntpd -s" listen="nntps" prefork=0
 
-  # http serves CalDAV, CardDAV, JMAP, RSS, etc.; see the httpmodules
+  # httpd serves CalDAV, CardDAV, JMAP, RSS, etc.; see the httpmodules
   # option in imapd.conf(5) to choose which modules each httpd advertises
   http          cmd="httpd" listen="http" prefork=0
   https         cmd="httpd -s" listen="https" prefork=0

--- a/doc/examples/cyrus_conf/normal.conf
+++ b/doc/examples/cyrus_conf/normal.conf
@@ -18,7 +18,8 @@ SERVICES {
 #  nntp          cmd="nntpd" listen="nntp" prefork=0
 #  nntps         cmd="nntpd -s" listen="nntps" prefork=0
 
-  # these are only necessary if using HTTP for CalDAV, CardDAV, or RSS
+  # http serves CalDAV, CardDAV, JMAP, RSS, etc.; see the httpmodules
+  # option in imapd.conf(5) to choose which modules each httpd advertises
   http          cmd="httpd" listen="http" prefork=0
   https         cmd="httpd -s" listen="https" prefork=0
 
@@ -60,4 +61,7 @@ EVENTS {
 DAEMON {
   # this is only necessary if using idled for IMAP IDLE
 #  idled         cmd="idled"
+
+  # required for CalDAV / JMAP-Calendars alarms to fire
+  calalarmd     cmd="calalarmd"
 }

--- a/docsrc/compiling.rst
+++ b/docsrc/compiling.rst
@@ -248,10 +248,18 @@ via configure.
 
 Sieve is enabled by default.
 
-CalDAV, CardDAV, WebDAV, JMAP
-#############################
+JMAP
+####
 
-    ``./configure --enable-http --enable-calalarmd --enable-jmap``
+    ``./configure --enable-jmap``
+
+.. note::
+
+    HTTP, CalDAV, CardDAV, WebDAV and the calendar alarm daemon are
+    always built and no longer require configure options.  libical,
+    libxml2 and SQLite3 are required build dependencies for every Cyrus
+    build (see the table above).  JMAP remains optional because it also
+    requires Xapian.
 
 Murder
 ######

--- a/docsrc/compiling.rst
+++ b/docsrc/compiling.rst
@@ -142,7 +142,7 @@ CalDAV, CardDAV, or JMAP (httpd subsystem)
     character set. Required for JMAP, but otherwise is not needed."
     `libical`_, libical-dev, "yes", "It provides
     calendaring functionality for CalDAV, which can't be used without this lib.
-    Version 3.0.10 or higher is required."
+    Version 4.0.0 or higher is required."
     `libxml`_, libxml2-dev, "yes", "A fundamental lib for
     all \*DAV functionality."
     `nghttp2`_, libnghttp2-dev, "no", "HTTP/2 support

--- a/docsrc/download/installation/http/caldav.rst
+++ b/docsrc/download/installation/http/caldav.rst
@@ -7,10 +7,11 @@ CalDAV
 Configuration
 =============
 
-When enabled, the CalDAV module allows Cyrus to function as a calendar and
-scheduling server. This module uses a subset of the mailbox hierarchy as
-calendar collections, the toplevel of which is specified by the
-:imapdconf:`calendarprefix` option. The public calendar hierarchy will reside
+When ``caldav`` is included in the :imapdconf:`httpmodules` option, the
+CalDAV module allows Cyrus to function as a calendar and scheduling server.
+This module uses a subset of the mailbox hierarchy as calendar collections,
+the toplevel of which is specified by the :imapdconf:`calendarprefix`
+option. The public calendar hierarchy will reside
 at the toplevel of the shared mailbox namespace. A user's personal calendar
 hierarchy will be a child of their Inbox.
 

--- a/docsrc/download/installation/http/carddav.rst
+++ b/docsrc/download/installation/http/carddav.rst
@@ -7,9 +7,10 @@ CardDAV
 Configuration
 =============
 
-When enabled, the CardDAV module allows Cyrus to function as a contacts server.
-This module uses a subset of the mailbox hierarchy as addressbook collections,
-the toplevel of which is specified by the :imapdconf:`addressbookprefix`
+When ``carddav`` is included in the :imapdconf:`httpmodules` option, the
+CardDAV module allows Cyrus to function as a contacts server.  This module
+uses a subset of the mailbox hierarchy as addressbook collections, the
+toplevel of which is specified by the :imapdconf:`addressbookprefix`
 option. The public addressbook hierarchy will reside at the toplevel of the
 shared mailbox namespace. A user's personal addressbook hierarchy will be a
 child of their Inbox.

--- a/docsrc/download/installation/http/webdav.rst
+++ b/docsrc/download/installation/http/webdav.rst
@@ -7,9 +7,10 @@ WebDAV
 Configuration
 =============
 
-When enabled, the WebDAV module allows Cyrus to function as a storage server.
-This module uses a subset of the mailbox hierarchy as collections, the toplevel
-of which is specified by the :imapdconf:`davdriveprefix` option. The public
+When ``webdav`` is included in the :imapdconf:`httpmodules` option, the
+WebDAV module allows Cyrus to function as a storage server.  This module
+uses a subset of the mailbox hierarchy as collections, the toplevel of
+which is specified by the :imapdconf:`davdriveprefix` option. The public
 storage hierarchy lives at the toplevel of the shared mailbox namespace. A
 user's personal storage hierarchy will be a child of their Inbox.
 

--- a/docsrc/download/installation/manage-dav.rst
+++ b/docsrc/download/installation/manage-dav.rst
@@ -11,6 +11,16 @@ This assumes you already have the relevant modules enabled in your Cyrus
 :ref:`installation <setup>`, either via packages, or through a
 manual installation.
 
+.. note::
+
+    As of Cyrus IMAP 3.13.7, HTTP support, CalDAV, CardDAV, WebDAV, and the
+    calendar alarm daemon (``calalarmd``) are mandatory parts of every
+    build; libical, libxml2, and SQLite3 are required build dependencies.
+    The former ``--enable-http`` and ``--enable-calalarmd`` configure
+    options have been removed. Selecting which HTTP modules a given
+    ``httpd`` instance serves continues to be controlled at runtime by the
+    :imapdconf:`httpmodules` option.
+
 CalDAV, CardDAV and WebDAV all provide their functionality through an http
 server. Cyrus HTTP is NOT a general purpose HTTP server (such as Apache httpd).
 Its feature set is limited to:

--- a/docsrc/installing.rst
+++ b/docsrc/installing.rst
@@ -21,8 +21,8 @@ To check: the final output of the configure step will display where a ``make ins
     make install-binsymlinks    # Only needed if you're testing older Cyrus versions
 
 
-Optional Components
-===================
+Additional Configuration
+========================
 
 .. toctree::
     :maxdepth: 2

--- a/docsrc/reference/admin/monitoring.rst
+++ b/docsrc/reference/admin/monitoring.rst
@@ -6,9 +6,6 @@ Monitoring
 
 Cyrus IMAP supports monitoring using Prometheus_.
 
-To use this functionality, Cyrus IMAP must have been built with the
-``--enable-http`` configure option enabled.
-
 .. _imap-admin-monitoring-setup:
 
 Setup

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -43,12 +43,10 @@
 #include "quota.h"
 #include "xunlink.h"
 
-#ifdef WITH_DAV
 #include "caldav_alarm.h"
 #include "dav_util.h"
 
 #define CAL_TZ_ANNOT  DAV_ANNOT_NS "<" XML_NS_CALDAV ">calendar-timezone"
-#endif
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
@@ -3180,7 +3178,6 @@ static int write_entry(struct mailbox *mailbox,
 
     if (!mailbox)
         sync_log_annotation("");
-#ifdef WITH_DAV
     else if (mbtype_isa(mailbox->h.mbtype) == MBTYPE_CALENDAR &&
              !strncmp(entry, CAL_TZ_ANNOT, strlen(CAL_TZ_ANNOT))) {
         char *freeme = NULL;
@@ -3190,7 +3187,6 @@ static int write_entry(struct mailbox *mailbox,
         r = caldav_alarm_update_floating(mailbox, userid);
         free(freeme);
     }
-#endif
 
 out:
     annotate_putdb(&d);

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -87,11 +87,7 @@ static json_t *buildinfo()
 #else
     json_object_set_new(component, "idled", json_false());
 #endif
-#ifdef USE_HTTPD
     json_object_set_new(component, "httpd", json_true());
-#else
-    json_object_set_new(component, "httpd", json_false());
-#endif
 #ifdef USE_MURDER
     json_object_set_new(component, "murder", json_true());
 #else
@@ -172,11 +168,7 @@ static json_t *buildinfo()
 #else
     json_object_set_new(dependency, "brotli", json_false());
 #endif
-#ifdef USE_HTTPD
     json_object_set_new(dependency, "xml2", json_true());
-#else
-    json_object_set_new(dependency, "xml2", json_false());
-#endif
 #ifdef HAVE_ICAL
     json_object_set_new(dependency, "ical", json_true());
 #else

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -112,11 +112,7 @@ static json_t *buildinfo()
 #else
     json_object_set_new(component, "sieve", json_false());
 #endif
-#ifdef USE_CALALARMD
     json_object_set_new(component, "calalarmd", json_true());
-#else
-    json_object_set_new(component, "calalarmd", json_false());
-#endif
 #ifdef WITH_JMAP
     json_object_set_new(component, "jmap", json_true());
 #else

--- a/imap/cyr_buildinfo.c
+++ b/imap/cyr_buildinfo.c
@@ -169,11 +169,7 @@ static json_t *buildinfo()
     json_object_set_new(dependency, "brotli", json_false());
 #endif
     json_object_set_new(dependency, "xml2", json_true());
-#ifdef HAVE_ICAL
     json_object_set_new(dependency, "ical", json_true());
-#else
-    json_object_set_new(dependency, "ical", json_false());
-#endif
 #ifdef HAVE_ICU
     json_object_set_new(dependency, "icu4c", json_true());
 #else

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -409,7 +409,6 @@ static int _dav_reconstruct_mb(const mbentry_t *mbentry,
     signals_poll();
 
     switch (mbtype_isa(mbentry->mbtype)) {
-#ifdef WITH_DAV
     case MBTYPE_CALENDAR:
     case MBTYPE_COLLECTION:
     case MBTYPE_ADDRESSBOOK:
@@ -421,7 +420,6 @@ static int _dav_reconstruct_mb(const mbentry_t *mbentry,
         addproc = &mailbox_add_dav;
         writelock = 1; // write lock so we can delete stale index records
         break;
-#endif
 #ifdef USE_SIEVE
     case MBTYPE_SIEVE:
         addproc = &mailbox_add_sieve;
@@ -508,10 +506,8 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
                                 config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000);
     if (reconstruct_db) {
         r = sqldb_begin(reconstruct_db, "reconstruct");
-#ifdef WITH_DAV
         // make all the alarm updates to go this database too
         if (!r) r = caldav_alarm_set_reconstruct(reconstruct_db);
-#endif
         // reconstruct everything
         if (!r) {
             struct recon_rock rrock =
@@ -522,13 +518,11 @@ EXPORTED int dav_reconstruct_user(const char *userid, const char *audit_tool)
 
             free_hashu64_table(&rrock.cmodseqs, NULL);
         }
-#ifdef WITH_DAV
         // make sure all the alarms are resolved
         if (!r) r = caldav_alarm_process(0, NULL, /*dryrun*/1);
         // commit events over to ther alarm database if we're keeping them
         if (!r && !audit_tool) r = caldav_alarm_commit_reconstruct(userid);
         else caldav_alarm_rollback_reconstruct();
-#endif
         // and commit to this DB
         if (r) sqldb_rollback(reconstruct_db, "reconstruct");
         else sqldb_commit(reconstruct_db, "reconstruct");

--- a/imap/global.c
+++ b/imap/global.c
@@ -392,10 +392,8 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
         config_take_globallock = 0;
     }
 
-#ifdef HAVE_ICAL
     /* Initialize libical */
     ical_support_init();
-#endif
 
     register_mboxgroups_cb(mboxlist_lookup_usergroups);
 

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -71,9 +71,7 @@
 
 #include "master/service.h"
 
-#ifdef WITH_DAV
 #include "http_dav.h"
-#endif
 
 #include <libxml/tree.h>
 #include <libxml/HTMLtree.h>
@@ -551,7 +549,6 @@ struct namespace_t *http_namespaces[] = {
     &namespace_convert,
 #endif
     &namespace_tzdist,          /* MUST be before namespace_calendar!! */
-#ifdef WITH_DAV
     &namespace_calendar,
     &namespace_freebusy,
     &namespace_addressbook,
@@ -561,7 +558,6 @@ struct namespace_t *http_namespaces[] = {
     &namespace_applepush,       /* MUST be after namespace_cal & addr */
     &namespace_ischedule,
     &namespace_domainkey,
-#endif /* WITH_DAV */
     &namespace_rss,
     &namespace_dblookup,
     &namespace_admin,
@@ -3035,13 +3031,11 @@ HIDDEN void log_request(long code, struct transaction_t *txn)
         buf_printf(logbuf, "%sallow-origin", sep);
         sep = "; ";
     }
-#ifdef WITH_DAV
     else if (txn->error.precond) {
         buf_printf(logbuf, "%sprecond=", sep);
         dav_precond_as_string(logbuf, &txn->error);
         sep = "; ";
     }
-#endif
     else if (txn->error.desc) {
         buf_printf(logbuf, "%serror=%s", sep, txn->error.desc);
         sep = "; ";
@@ -3873,7 +3867,6 @@ EXPORTED void error_response(long code, struct transaction_t *txn)
     txn->flags.vary &= ~(VARY_BRIEF | VARY_PREFER);
     txn->resp_body.prefs = 0;
 
-#ifdef WITH_DAV
     if (code != HTTP_UNAUTHORIZED && txn->error.precond) {
         xmlNodePtr root = xml_add_error(NULL, &txn->error, NULL);
 
@@ -3883,7 +3876,6 @@ EXPORTED void error_response(long code, struct transaction_t *txn)
             return;
         }
     }
-#endif /* WITH_DAV */
 
     if (!txn->error.desc) {
         switch (code) {
@@ -5096,7 +5088,6 @@ static int meth_propfind_root(struct transaction_t *txn,
 {
     assert(txn);
 
-#ifdef WITH_DAV
     /* Apple iCal and Evolution both check "/" */
     if (!strcmp(txn->req_uri->path, "/") ||
         !strcmp(txn->req_uri->path, "/dav/")) {
@@ -5126,7 +5117,6 @@ static int meth_propfind_root(struct transaction_t *txn,
         txn->req_tgt.allow |= ALLOW_DAV;
         return meth_propfind(txn, &root_params);
     }
-#endif /* WITH_DAV */
 
     return HTTP_NOT_ALLOWED;
 }

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -28,8 +28,6 @@
 
 #include "imap/imap_err.h"
 
-#ifdef HAVE_ICAL
-
 static int initialized = 0;
 
 #ifdef HAVE_LIBICALVCARD_XPROP_VALUE
@@ -3267,5 +3265,3 @@ EXPORTED bool ical_is_valid_color(const char *val, bool allow_alpha)
 
     return is_css3_color(val);
 }
-
-#endif /* HAVE_ICAL */

--- a/imap/ical_support.h
+++ b/imap/ical_support.h
@@ -7,8 +7,6 @@
 
 #include <config.h>
 
-#ifdef HAVE_ICAL
-
 #include <libical/ical.h>
 #include <libical/vcard.h>
 
@@ -264,7 +262,5 @@ extern bool ical_is_valid_color(const char *val, bool allow_alpha);
  */
 extern vcardparameter *vcardproperty_get_parameter_by_name(vcardproperty *prop,
                                                            const char *name);
-
-#endif /* HAVE_ICAL */
 
 #endif /* ICAL_SUPPORT_H */

--- a/imap/index.c
+++ b/imap/index.c
@@ -16,11 +16,9 @@
 #include <ctype.h>
 #include <stdlib.h>
 
-#ifdef USE_HTTPD
 /* For iCalendar indexing */
 #include <libical/ical.h>
 #include "vcard_support.h"
-#endif
 
 #include "acl.h"
 #include "annotate.h"
@@ -4527,7 +4525,6 @@ static int extract_cb(const struct buf *text, void *rock)
     return str->receiver->append_text(str->receiver, text);
 }
 
-#ifdef USE_HTTPD
 static int extract_icalbuf(struct buf *raw, charset_t charset, int encoding,
                            struct getsearchtext_rock *str)
 {
@@ -4756,8 +4753,6 @@ done:
     return r;
 }
 
-#endif /* USE_HTTPD */
-
 EXPORTED int index_want_attachextract(const char *type, const char *subtype)
 {
     return ((!strcasecmpsafe(type, "APPLICATION") &&
@@ -4872,14 +4867,10 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
         if (str->snippet_iteration >= 2) goto done;
 
         if (!strcmpsafe(subtype, "CALENDAR")) {
-#ifdef USE_HTTPD
             extract_icalbuf(data, charset, encoding, str);
-#endif /* USE_HTTPD */
         }
         else if (!strcmpsafe(subtype, "VCARD")) {
-#ifdef USE_HTTPD
             extract_vcardbuf(data, charset, encoding, str);
-#endif /* USE_HTTPD */
         }
         else {
             /* body-like */
@@ -4901,12 +4892,10 @@ static int getsearchtext_cb(int isbody, charset_t charset, int encoding,
             str->receiver->end_part(str->receiver);
         }
     }
-#ifdef USE_HTTPD
     else if (isbody && (!strcmpsafe(type, "APPLICATION") && !strcmpsafe(subtype, "ICS"))) {
         // application/ics is an alias for text/icalendar
         extract_icalbuf(data, charset, encoding, str);
     }
-#endif /* USE_HTTPD */
     else if (isbody && index_want_attachextract(type, subtype)) {
 
         /* Ignore attachments in first snippet generation pass */

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -64,7 +64,6 @@ static int _email_threadkeyword_is_valid(const char *keyword)
 }
 
 
-#ifdef WITH_DAV
 
 #include "annotate.h"
 #include "carddav_db.h"
@@ -1827,7 +1826,6 @@ done:
     return matches ? 1 : 0;
 }
 
-#endif /* WITH_DAV */
 
 static void headermatch_normalize(struct jmap_headermatch *hm, struct buf *val)
 {

--- a/imap/jmap_mail_query.h
+++ b/imap/jmap_mail_query.h
@@ -12,7 +12,6 @@
 #include "jmap_mail_query_parse.h"
 #include "jmap_util.h"
 
-#ifdef WITH_DAV
 
 #include <time.h>
 
@@ -146,6 +145,5 @@ extern void jmap_get_card_emails(strarray_t *card_uids, unsigned card_kind,
                                  ptrarray_t *abook_sets,
                                  strarray_t *emails, strarray_t **member_uids);
 
-#endif /* WITH_DAV */
 
 #endif /* JMAP_MAIL_QUERY_H */

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1415,7 +1415,6 @@ EXPORTED char *jmap_role_to_specialuse(const char *role)
     return specialuse;
 }
 
-#ifdef HAVE_ICAL
 EXPORTED struct jmap_caleventid *jmap_caleventid_lookup(const char *id,
                                                         struct caldav_db *db,
                                                         struct caldav_data **cdatap)
@@ -1606,8 +1605,6 @@ EXPORTED void jmap_alertid_encode(icalcomponent *valarm, struct buf *idbuf)
 
     buf_setcstr(idbuf, id);
 }
-
-#endif /* HAVE_ICAL */
 
 EXPORTED int jmap_is_valid_id(const char *id)
 {

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -216,7 +216,6 @@ extern void jmap_set_contactid(struct conversations_state *cstate,
 extern void jmap_set_calendarid(struct conversations_state *cstate,
                                 const mbentry_t *mbentry, char *calid);
 
-#ifdef HAVE_ICAL
 struct jmap_caleventid {
     const char *raw; /* as requested by client */
     const char *ical_uid;
@@ -242,6 +241,5 @@ extern const char *jmap_caleventid_encode(const struct jmap_caleventid *eid, str
 extern void jmap_caleventid_free(struct jmap_caleventid **eidptr);
 
 extern void jmap_alertid_encode(icalcomponent *valarm, struct buf *buf);
-#endif /* HAVE_ICAL */
 
 #endif /* JMAP_UTIL_H */

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -1176,7 +1176,6 @@ done:
     return ret;
 }
 
-#ifdef HAVE_ICAL
 #include <jansson.h>
 #include "ical_support.h"
 
@@ -1757,7 +1756,6 @@ static int sieve_processcal(void *ac, void *ic, void *sc, void *mc,
     return ret;
 }
 #endif /* WITH_DAV */
-#endif /* HAVE_ICAL */
 
 static int sieve_keep(void *ac,
                       void *ic __attribute__((unused)),
@@ -2375,7 +2373,6 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
 #ifdef WITH_JMAP
     sieve_register_jmapquery(interp, &jmapquery);
 #endif
-#ifdef HAVE_ICAL
     /* need timezones for sieve snooze and stripping in processcal */
     zoneinfo_open(NULL);
     ical_support_init();
@@ -2383,7 +2380,6 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
 #ifdef WITH_DAV
     sieve_register_processcal(interp, &sieve_processcal);
 #endif
-#endif /* HAVE_ICAL */
     sieve_register_parse_error(interp, &sieve_parse_error_handler);
     sieve_register_execute_error(interp, &sieve_execute_error_handler);
 

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -616,7 +616,6 @@ static char *sieve_srs_forward(char *return_path __attribute__((unused)))
 
 #endif /* USE_SRS */
 
-#ifdef WITH_DAV
 #include <libxml/uri.h>
 
 static mbentry_t *get_addrbook_mbentry(const char *list, const char *userid)
@@ -714,7 +713,6 @@ static int list_addresses(void *rock, struct carddav_data *cdata)
 
     return 0;
 }
-#endif /* WITH_DAV */
 
 static int send_forward(sieve_redirect_context_t *rc,
                         struct sieve_interp_ctx *ctx,
@@ -741,7 +739,6 @@ static int send_forward(sieve_redirect_context_t *rc,
     }
 
     if (rc->is_ext_list) {
-#ifdef WITH_DAV
         strarray_t *sa = strarray_split(rc->addr, ",", STRARRAY_TRIM);
 
         for (int i = 0; i < strarray_size(sa); i++) {
@@ -761,7 +758,6 @@ static int send_forward(sieve_redirect_context_t *rc,
             mboxlist_entry_free(&mbentry);
         }
         strarray_free(sa);
-#endif
     }
     else {
         struct address_itr ai;
@@ -1411,7 +1407,6 @@ done:
     return ret;
 }
 
-#ifdef WITH_DAV
 #include "caldav_util.h"
 #include "http_caldav_sched.h"
 
@@ -1755,7 +1750,6 @@ static int sieve_processcal(void *ac, void *ic, void *sc, void *mc,
 
     return ret;
 }
-#endif /* WITH_DAV */
 
 static int sieve_keep(void *ac,
                       void *ic __attribute__((unused)),
@@ -2367,9 +2361,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
         fatal("sieve_register_duplicate()", EX_SOFTWARE);
     }
 
-#ifdef WITH_DAV
     sieve_register_extlists(interp, &listvalidator, &listcompare);
-#endif
 #ifdef WITH_JMAP
     sieve_register_jmapquery(interp, &jmapquery);
 #endif
@@ -2377,9 +2369,7 @@ sieve_interp_t *setup_sieve(struct sieve_interp_ctx *ctx)
     zoneinfo_open(NULL);
     ical_support_init();
     sieve_register_snooze(interp, &sieve_snooze);
-#ifdef WITH_DAV
     sieve_register_processcal(interp, &sieve_processcal);
-#endif
     sieve_register_parse_error(interp, &sieve_parse_error_handler);
     sieve_register_execute_error(interp, &sieve_execute_error_handler);
 

--- a/imap/lmtp_sieve.h
+++ b/imap/lmtp_sieve.h
@@ -9,11 +9,7 @@
 #include "conversations.h"
 #include "sieve/sieve_interface.h"
 
-#ifdef WITH_DAV
 #include "carddav_db.h"
-#else
-struct carddav_db { };
-#endif
 
 struct sieve_interp_ctx {
     const char *userid;

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -35,9 +35,7 @@
 #include "autocreate.h"
 #endif
 #include "backend.h"
-#ifdef WITH_DAV
 #include "carddav_db.h"
-#endif
 #include "duplicate.h"
 #include "global.h"
 #include "idle.h"
@@ -910,10 +908,8 @@ int deliver(message_data_t *msgdata, char *authuser,
                 r = run_sieve(mbname, interp, &mydata);
             // set a flag if sieve failed
             if (r < 0) strarray_append(&flags, "$SieveFailed");
-#ifdef WITH_DAV
             if (ctx.carddavdb) carddav_close(ctx.carddavdb);
             ctx.carddavdb = NULL;
-#endif
             sieve_srs_free();
             sieve_interp_free(&interp);
             /* if there was no sieve script, or an error during execution,

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -1061,7 +1061,7 @@ static void shut_down(int code)
 
     libcyrus_run_delayed();
 
-#if defined USE_SIEVE && defined HAVE_ICAL
+#ifdef USE_SIEVE
     zoneinfo_close(NULL);
 #endif
     /* close backend connections */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -43,7 +43,6 @@
 #include "assert.h"
 #include "auditlog.h"
 #include "bsearch.h"
-#ifdef WITH_DAV
 #include "caldav_db.h"
 #include "caldav_alarm.h"
 #include "carddav_db.h"
@@ -51,7 +50,6 @@
 #include "ical_support.h"
 #include "jmap_util.h"
 #include "vcard_support.h"
-#endif /* WITH_DAV */
 #ifdef USE_SIEVE
 #include "sieve_db.h"
 #include "sievedir.h"
@@ -161,11 +159,9 @@ static void cleanup_stale_expunged(struct mailbox *mailbox);
 static bit32 mailbox_index_record_to_buf(struct index_record *record, int version,
                                          unsigned char *buf);
 
-#ifdef WITH_DAV
 EXPORTED struct webdav_db *mailbox_open_webdav(struct mailbox *);
 static int mailbox_commit_dav(struct mailbox *mailbox);
 static int mailbox_abort_dav(struct mailbox *mailbox);
-#endif
 
 #ifdef USE_SIEVE
 static int mailbox_commit_sieve(struct mailbox *mailbox);
@@ -2233,7 +2229,6 @@ EXPORTED int mailbox_has_conversations_full(struct mailbox *mailbox, int allow_d
     return 1;
 }
 
-#ifdef WITH_DAV
 HIDDEN struct caldav_db *mailbox_open_caldav(struct mailbox *mailbox)
 {
     if (!mailbox->local_caldav) {
@@ -2275,7 +2270,6 @@ EXPORTED struct webdav_db *mailbox_open_webdav(struct mailbox *mailbox)
     }
     return mailbox->local_webdav;
 }
-#endif
 
 static uint32_t mailbox_getuid(struct mailbox *mailbox, uint32_t recno)
 {
@@ -2768,10 +2762,8 @@ EXPORTED int mailbox_abort(struct mailbox *mailbox)
 {
     int r;
 
-#ifdef WITH_DAV
     r = mailbox_abort_dav(mailbox);
     if (r) return r;
-#endif
 
 #ifdef USE_SIEVE
     r = mailbox_abort_sieve(mailbox);
@@ -2827,10 +2819,8 @@ EXPORTED int mailbox_commit(struct mailbox *mailbox)
     int n, r;
 
     /* try to commit sub parts first */
-#ifdef WITH_DAV
     r = mailbox_commit_dav(mailbox);
     if (r) return r;
-#endif
 
 #ifdef USE_SIEVE
     r = mailbox_commit_sieve(mailbox);
@@ -3361,7 +3351,6 @@ out:
     return r;
 }
 
-#ifdef WITH_DAV
 static int mailbox_update_carddav(struct mailbox *mailbox,
                                   const struct index_record *new)
 {
@@ -3772,7 +3761,6 @@ static int mailbox_abort_dav(struct mailbox *mailbox)
     return 0;
 }
 
-#endif // WITH_DAV
 
 #ifdef WITH_JMAP
 #include "jmap_util.h"
@@ -4216,10 +4204,8 @@ static int mailbox_update_indexes(struct mailbox *mailbox,
     r = mailbox_update_conversations(mailbox, old, new);
     if (r) return r;
 
-#ifdef WITH_DAV
     r = mailbox_update_dav(mailbox, old, new);
     if (r && r != IMAP_NO_MSGGONE) return r;
-#endif
 
 #ifdef WITH_JMAP
     r = mailbox_update_email_alarms(mailbox, old, new);
@@ -5929,7 +5915,6 @@ static int chkchildren(const mbentry_t *mbentry,
     return 0;
 }
 
-#ifdef WITH_DAV
 EXPORTED int mailbox_add_dav(struct mailbox *mailbox, hashu64_table *cmodseqs)
 {
     const message_t *msg;
@@ -6016,7 +6001,6 @@ EXPORTED int mailbox_add_dav(struct mailbox *mailbox, hashu64_table *cmodseqs)
     return r;
 }
 
-#endif /* WITH_DAV */
 
 EXPORTED int mailbox_add_conversations(struct mailbox *mailbox, int silent)
 {
@@ -6115,11 +6099,9 @@ static int mailbox_delete_internal(struct mailbox **mailboxptr)
     mailbox_index_dirty(mailbox);
     mailbox->i.options |= OPT_MAILBOX_DELETED;
 
-#ifdef WITH_DAV
     /* remove any DAV records */
     r = mailbox_delete_dav(mailbox);
     if (r) return r;
-#endif
 
 #ifdef USE_SIEVE
     /* remove any Sieve records */
@@ -6165,7 +6147,6 @@ static int mailbox_delete_alarms(struct mailbox *mailbox)
 }
 #endif /* WITH_JMAP */
 
-#ifdef WITH_DAV
 static int mailbox_delete_caldav(struct mailbox *mailbox)
 {
     struct caldav_db *caldavdb = NULL;
@@ -6230,7 +6211,6 @@ EXPORTED int mailbox_delete_dav(struct mailbox *mailbox)
 
     return 0;
 }
-#endif /* WITH_DAV */
 
 /*
  * Delete and close the mailbox 'mailbox'.  Closes 'mailbox' whether
@@ -6249,10 +6229,8 @@ EXPORTED int mailbox_delete(struct mailbox **mailboxptr)
     if (r) return r;
 #endif /* WITH_JMAP */
 
-#ifdef WITH_DAV
     r = mailbox_delete_dav(mailbox);
     if (r) return r;
-#endif /* WITH_DAV */
 
 #ifdef USE_SIEVE
     r = mailbox_delete_sieve(mailbox);

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -262,11 +262,9 @@ struct mailbox {
     /* namespace lock */
     struct usernamespacelocks *user_nslock;
 
-#ifdef WITH_DAV
     struct caldav_db *local_caldav;
     struct carddav_db *local_carddav;
     struct webdav_db *local_webdav;
-#endif
 #ifdef USE_SIEVE
     struct sieve_db *local_sieve;
     char *sievedir;

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -22,9 +22,7 @@
 #include <utime.h>
 
 #include "annotate.h"
-#ifdef WITH_DAV
 #include "dav_db.h"
-#endif
 #include "global.h"
 #include "map.h"
 #include "mappedfile.h"
@@ -425,9 +423,7 @@ static struct data_file data_files[] = {
     { META_INDEX,   "cyrus.index"   },
     { META_CACHE,   "cyrus.cache"   },
     { META_EXPUNGE, "cyrus.expunge" },
-#ifdef WITH_DAV
     { META_DAV,     "cyrus.dav"     },
-#endif
     { 0, NULL }
 };
 
@@ -601,15 +597,11 @@ EXPORTED int dump_mailbox(const char *tag, struct mailbox *mailbox, uint32_t uid
                 ftag = "MBOXKEY";
                 break;
             case DAV_DB: {
-#ifdef WITH_DAV
                 struct buf dav_file = BUF_INITIALIZER;
 
                 dav_getpath_byuserid(&dav_file, userid);
                 fname = (char *) buf_cstring(&dav_file);
                 ftag = "DAV";
-#else
-                continue;
-#endif
                 break;
             }
             default:
@@ -1055,14 +1047,12 @@ EXPORTED int undump_mailbox(const char *mbname,
             char *s = user_hash_subs(userid);
             strlcpy(fnamebuf, s, sizeof(fnamebuf));
             free(s);
-#ifdef WITH_DAV
         } else if (userid && !strcmp(file.s, "DAV")) {
             /* overwriting this outright is absolutely what we want to do */
             struct buf dav_file = BUF_INITIALIZER;
             dav_getpath_byuserid(&dav_file, userid);
             strlcpy(fnamebuf, buf_cstring(&dav_file), sizeof(fnamebuf));
             buf_free(&dav_file);
-#endif
         } else if (userid && !strcmp(file.s, "SEEN")) {
             seen_file = seen_getpath(userid);
 

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -15,10 +15,8 @@
 
 #include "annotate.h"
 #include "assert.h"
-#ifdef WITH_DAV
 #include "caldav_db.h"
 #include "carddav_db.h"
-#endif /* WITH_DAV */
 #include "global.h"
 #include "imapurl.h"
 #include "libconfig.h"
@@ -1108,7 +1106,6 @@ EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *
                                    cacheitem_size(record, CACHE_BODYSTRUCTURE)));
     }
 
-#ifdef WITH_DAV
     /* add caldav items */
     if (mbtypes_dav(mailbox_mbtype(mailbox)) &&
         (mboxevent_expected_param(event->type, EVENT_DAV_FILENAME) ||
@@ -1163,7 +1160,6 @@ EXPORTED void mboxevent_extract_record(struct mboxevent *event, struct mailbox *
 
         free(xval);
     }
-#endif // WITH_DAV
 
     if (body) message_free_body(body);
     free(body);
@@ -1340,7 +1336,6 @@ EXPORTED void mboxevent_extract_msgrecord(struct mboxevent *event, msgrecord_t *
         FILL_STRING_PARAM(event, EVENT_BODYSTRUCTURE, bs);
     }
 
-#ifdef WITH_DAV
     /* add caldav items */
     if (mbtypes_dav(mailbox_mbtype(mailbox)) &&
         (mboxevent_expected_param(event->type, EVENT_DAV_FILENAME) ||
@@ -1397,7 +1392,6 @@ EXPORTED void mboxevent_extract_msgrecord(struct mboxevent *event, msgrecord_t *
 
         free(xval);
     }
-#endif // WITH_DAV
 
     if (body) message_free_body(body);
     free(body);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -3193,10 +3193,8 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
 #ifdef USE_SIEVE
                 mailbox_add_sieve(newmailbox, NULL);
 #endif
-#ifdef WITH_DAV
             } else {
                 mailbox_add_dav(newmailbox, NULL);
-#endif
             }
 
             mailbox_close(&newmailbox);
@@ -3242,12 +3240,10 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
                 mboxevent_set_access(mboxevent, NULL, NULL, userid, newname, 1);
             }
 
-#ifdef WITH_DAV
             /* Remove DAV DB records for a delayed delete mailbox */
             if (mboxname_isdeletedmailbox(newname, NULL)) {
                 mailbox_delete_dav(oldmailbox);
             }
-#endif
 
             /* log the rename before we close either mailbox, so that
              * we never nuke the mailbox from the replica before realising

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -34,9 +34,7 @@
 #include "annotate.h"
 #include "append.h"
 #include "auth.h"
-#ifdef WITH_DAV
 #include "dav_db.h"
-#endif /* WITH_DAV */
 #include "dlist.h"
 #include "global.h"
 #include "hash.h"

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -44,9 +44,7 @@
 #include "sievedir.h"
 #include "xunlink.h"
 
-#ifdef USE_CALALARMD
 #include "caldav_alarm.h"
-#endif
 
 #ifdef USE_SIEVE
 #include "sieve_db.h"
@@ -1702,7 +1700,6 @@ static int apply_annotations(struct mailbox *mailbox,
 out:
 
     if (record) {
-#ifdef USE_CALALARMD
         if (mbtype_isa(mailbox_mbtype(mailbox)) == MBTYPE_CALENDAR) {
             // NOTE: this is because we don't pass the annotations through
             // with the record as we create it, so we can't update the alarm
@@ -1711,7 +1708,6 @@ out:
             // the alarm AFTER writing the record.
             caldav_alarm_sync_nextcheck(mailbox, record);
         }
-#endif
     }
     else {
         /* need to manage our own txn for the global db */

--- a/imap/user.c
+++ b/imap/user.c
@@ -54,9 +54,7 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
-#ifdef WITH_DAV
 #include "caldav_alarm.h"
-#endif
 
 #if 0
 static int user_deleteacl(char *name, int matchlen, int category, void* rock)
@@ -288,10 +286,8 @@ EXPORTED int user_deletedata(const mbentry_t *mbentry, int wipe_user)
     /* delete all the search engine data (if any) */
     search_deluser(mbentry);
 
-#ifdef WITH_DAV
     /* delete all the calendar alarms for the user */
     caldav_alarm_delete_user(userid);
-#endif /* WITH_DAV */
 
     /* delete paths in our list */
     /* XXX  MUST do this last in case one of the functions above

--- a/imap/webdav_db.c
+++ b/imap/webdav_db.c
@@ -4,7 +4,6 @@
 
 #include <config.h>
 
-#ifdef WITH_DAV
 
 #include <syslog.h>
 #include <string.h>
@@ -504,17 +503,3 @@ EXPORTED int webdav_get_updates(struct webdav_db *webdavdb,
     return r;
 }
 
-#else
-
-EXPORTED int webdav_init(void)
-{
-    return 0;
-}
-
-
-EXPORTED int webdav_done(void)
-{
-    return 0;
-}
-
-#endif /* WITH_DAV */

--- a/imap/webdav_db.h
+++ b/imap/webdav_db.h
@@ -13,7 +13,6 @@ int webdav_init(void);
 /* done with all webdav operations for this process */
 int webdav_done(void);
 
-#ifdef WITH_DAV
 
 #include "dav_db.h"
 #include "mboxlist.h"
@@ -94,6 +93,5 @@ int webdav_get_updates(struct webdav_db *webdavdb,
                        modseq_t oldmodseq, const mbentry_t *mbentry, int kind,
                        int max_records, webdav_cb_t *cb, void *rock);
 
-#endif /* WITH_DAV */
 
 #endif /* WEBDAV_DB_H */

--- a/lib/imapoptions/httpmodules
+++ b/lib/imapoptions/httpmodules
@@ -6,8 +6,8 @@ Default-Value:
 Last-Modified: 3.1.7
 
 Space-separated list of HTTP modules that will be enabled in
-:cyrusman:`httpd(8)`.  This option has no effect on modules that are
-disabled at compile time due to missing dependencies (e.g. libical).
+:cyrusman:`httpd(8)`.  Running multiple httpd instances, each with a
+different :imapdconf:`httpmodules` value, is supported.
 
 Note that "domainkey" depends on "ischedule" being enabled, and that both
 "freebusy" and "ischedule" depend on "caldav" being enabled.

--- a/sieve/bc_eval.c
+++ b/sieve/bc_eval.c
@@ -30,9 +30,7 @@
 #include <string.h>
 #include <syslog.h>
 
-#ifdef HAVE_ICAL
 #include <libical/ical.h>
-#endif
 
 /**************************************************************************/
 /**************************************************************************/
@@ -1185,7 +1183,6 @@ envelope_err:
                 }
 
                 if (!parse_tzoffset(str, &tzoffset)) {
-#ifdef HAVE_ICAL
                     /* Is this an IANA TZID? rather than an offset? */
                     icaltimezone *tz = icaltimezone_get_builtin_timezone(str);
 
@@ -1193,9 +1190,7 @@ envelope_err:
                         icaltimetype tt = icaltime_from_timet_with_zone(t, 0, tz);
 
                         tzoffset = icaltimezone_get_utc_offset(tz, &tt, NULL);
-                    } else
-#endif
-                    {
+                    } else {
                         res = 0;
                         goto date_err;
                     }

--- a/sieve/script.c
+++ b/sieve/script.c
@@ -124,7 +124,6 @@ static int stub_parse_error(int lineno, const char *msg,
     return SIEVE_OK;
 }
 
-#ifdef WITH_DAV
 #include <libxml/uri.h>
 
 static int listvalidator(void *ic __attribute__((unused)),
@@ -146,7 +145,6 @@ static int listvalidator(void *ic __attribute__((unused)),
 
     return ret;
 }
-#endif /* WITH_DAV */
 
 EXPORTED sieve_interp_t *sieve_build_nonexec_interp()
 {
@@ -195,11 +193,9 @@ EXPORTED sieve_interp_t *sieve_build_nonexec_interp()
         goto done;
     }
 
-#ifdef WITH_DAV
     sieve_register_extlists(interpreter, &listvalidator,
                             (sieve_list_comparator *) &stub_generic);
     sieve_register_processcal(interpreter, (sieve_callback *) &stub_generic);
-#endif
 #ifdef WITH_JMAP
     sieve_register_jmapquery(interpreter, (sieve_jmapquery *) &stub_generic);
 #endif

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -579,7 +579,6 @@ static int jmapquery(void *ic __attribute__((unused)), void *sc, void *mc, const
 }
 #endif
 
-#ifdef WITH_DAV
 static int processcal(void *ac, void *ic __attribute__((unused)), void *sc,
                       void *mc, const char **errmsg __attribute__((unused)))
 {
@@ -828,7 +827,6 @@ static int processcal(void *ac, void *ic __attribute__((unused)), void *sc,
 
     return SIEVE_OK;
 }
-#endif
 
 static sieve_vacation_t vacation = {
     0,                          /* min response */
@@ -1027,9 +1025,7 @@ int main(int argc, char *argv[])
 #ifdef WITH_JMAP
     sieve_register_jmapquery(i, &jmapquery);
 #endif
-#ifdef WITH_DAV
     sieve_register_processcal(i, &processcal);
-#endif
 
     res = sieve_script_load(script, &exe);
     if (res != SIEVE_OK) {


### PR DESCRIPTION
As long discussed, this is another step along the "fewer build configurations" path.