### PR TITLE
docsrc/Makefile: cyradm man page is in section 1, not 8

### DIFF
--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -63,8 +63,8 @@ doxygen:
 	@echo "Doxygen XML generated in _doxygen/xml/"
 
 init: doxygen ../lib/imapoptions ../perl/imap/IMAP/Shell.pm
-	@echo "Creating reference/manpages/systemcommands/cyradm.rst"
-	$(PERL2RST) cyradm < ../perl/imap/IMAP/Shell.pm > $(SOURCEDIR)/reference/manpages/systemcommands/cyradm.rst
+	@echo "Creating reference/manpages/usercommands/cyradm.rst"
+	$(PERL2RST) cyradm < ../perl/imap/IMAP/Shell.pm > $(SOURCEDIR)/reference/manpages/usercommands/cyradm.rst
 	@echo "Creating reference/manpages/usercommands/sieveshell.rst"
 	$(PERL2RST) sieveshell < ../perl/sieve/scripts/sieveshell.pl > $(SOURCEDIR)/reference/manpages/usercommands/sieveshell.rst
 	@echo "Creating reference/manpages/configs/imapd.conf.rst"


### PR DESCRIPTION
This was overlooked by bb37546d1debf3be18a94eced4869e26a9b45d8e

Supersedes #6096 