### PR TITLE
sieve/bc_parse.c: fix static-buffer overflow in v0x07 bytecode path

### DIFF
--- a/sieve/bc_parse.c
+++ b/sieve/bc_parse.c
@@ -6,6 +6,8 @@
 #include <config.h>
 #endif
 
+#include <stdio.h>
+
 #include "bc_parse.h"
 #include "strarray.h"
 #include "arrayu64.h"
@@ -667,6 +669,7 @@ EXPORTED int bc_test_parse(bytecode_input_t *bc, int pos, int version,
 {
     int opcode = ntohl(bc[pos++].op);
     int has_index = 0;
+    char prefixed_fmt[MAX_ARGS+2];
 
     memset(test, 0, sizeof(test_t));
     test->type = opcode;
@@ -786,10 +789,8 @@ EXPORTED int bc_test_parse(bytecode_input_t *bc, int pos, int version,
 
             if (has_index) {
                 if (opcode == BC_CURRENTDATE) {
-                    /* parse, but ignore, index as first argument */
-                    static char buf[MAX_ARGS+1] = "_";
-
-                    fmt = strcat(buf, fmt);
+                    snprintf(prefixed_fmt, sizeof(prefixed_fmt), "_%s", fmt);
+                    fmt = prefixed_fmt;
                 }
             }
             else if (opcode == BC_DATE) {


### PR DESCRIPTION
The legacy v0x07 BC_CURRENTDATE-with-:index branch in bc_test_parse() prefixed the fmt string with "_" via a function-static buffer:

    static char buf[MAX_ARGS+1] = "_";
    fmt = strcat(buf, fmt);

The "_" initialiser runs once, at program start, so each subsequent call strcat()ed another copy of fmt onto whatever the buffer already held. We replace the static buffer with a stack-local sized for the longest possible prefixed fmt and use snprintf() so each call gets fresh storage.

This code path is only reachable when reading bytecode written by an old sievec at on-disk bytecode version 0x07, which limits exposure.

No automated test: fabricating a v0x07 bytecode_input_t buffer to drive bc_test_parse() directly from cunit is doable but feels like overkill. At some point, we can probably just drop this opcode..?