### PR TITLE
http_caldav_sched.c: defensively NULL-check iSchedule response status

### DIFF
--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -1154,6 +1154,16 @@ static void sched_deliver_remote(const char *cal_ownerid, const char *sched_user
                         status = xmlNodeGetContent(node);
                 }
 
+                /* A bogus response may omit <request-status>, or provide it as
+                 * an empty element (in which case xmlNodeGetContent can return
+                 * NULL).  Treat it as tempfail rather than NULL deref. */
+                if (!status) {
+                    SCHED_STATUS(sched_data,
+                                 REQSTAT_TEMPFAIL, SCHEDSTAT_TEMPFAIL);
+                    xmlFree(recip);
+                    continue;
+                }
+
                 if (!strncmp((const char *) status, "2.0", 3)) {
                     SCHED_STATUS(sched_data,
                                  REQSTAT_DELIVERED, SCHEDSTAT_DELIVERED);


### PR DESCRIPTION
In sched_deliver_remote, when processing the <schedule-response> from a remote iSchedule peer, the per-response loop initialises `status` to NULL and only assigns it if a <request-status> child element is found. xmlNodeGetContent may also return NULL for an empty element.

Abort before dereferencing null.