### PR TITLE
index.c: remove unused uidvalidity_is_max from struct vanished_params

### DIFF
--- a/imap/index.c
+++ b/imap/index.c
@@ -920,15 +920,7 @@ seqset_t *index_vanished(struct index_state *state,
     seqset_t *seq;
 
     /* check uidvalidity match */
-    /* XXX Seems like uidvalidity_is_max never gets set to anything but zero.
-     * XXX What was its purpose?  Can we get rid of it?
-     */
-    if (params->uidvalidity_is_max) {
-        if (params->uidvalidity < mailbox->i.uidvalidity) return NULL;
-    }
-    else {
-        if (params->uidvalidity != mailbox->i.uidvalidity) return NULL;
-    }
+    if (params->uidvalidity != mailbox->i.uidvalidity) return NULL;
 
     /* No recently expunged messages */
     if (params->modseq >= state->highestmodseq) return NULL;

--- a/imap/index.h
+++ b/imap/index.h
@@ -39,7 +39,6 @@ struct vanished_params {
     const char *match_seq;
     const char *match_uid;
     const char *sequence;
-    int uidvalidity_is_max;
 };
 
 struct index_init {


### PR DESCRIPTION
Fixes #4045

Best guess is that this was used in the past by the since removed XCONV code