### PR TITLE
special use options: tweak defaults

### DIFF
--- a/cassandane/tiny-tests/Specialuse/default_snoozed
+++ b/cassandane/tiny-tests/Specialuse/default_snoozed
@@ -1,0 +1,29 @@
+#!perl
+use Cassandane::Tiny;
+
+# The default specialuse_protect and specialuse_nochildren lists must name
+# the \Snoozed special-use (with the trailing "d"), as that is the only
+# spelling the server ever applies.  This runs with the stock defaults, so it
+# would fail if the option defaults ever drifted back to "\Snooze".
+sub test_default_snoozed ($self)
+{
+    my $imaptalk = $self->{store}->get_client();
+
+    $imaptalk->create("Snoozed", "(USE (\\Snoozed))");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    # specialuse_nochildren: must not be allowed to create a child
+    $imaptalk->create("Snoozed.child");
+    $self->assert_equals('no', $imaptalk->get_last_completion_response());
+
+    # specialuse_protect: must not be allowed to delete it
+    $imaptalk->delete("Snoozed");
+    $self->assert_equals('no', $imaptalk->get_last_completion_response());
+
+    # specialuse_protect: must not be allowed to reparent it
+    $imaptalk->create("Other");
+    $self->assert_equals('ok', $imaptalk->get_last_completion_response());
+
+    $imaptalk->rename("Snoozed", "Other.Snoozed");
+    $self->assert_equals('no', $imaptalk->get_last_completion_response());
+}

--- a/lib/imapoptions/lmtp_exclude_specialuse
+++ b/lib/imapoptions/lmtp_exclude_specialuse
@@ -1,7 +1,7 @@
 Name: lmtp_exclude_specialuse
 Type: STRING
-Default-Value: \\Snoozed
-Last-Modified: 3.1.8
+Default-Value: \\Drafts \\Scheduled \\Snoozed
+Last-Modified: UNRELEASED
 
 Don't allow delivery to folders with given special-use attributes.
 

--- a/lib/imapoptions/specialuse_nochildren
+++ b/lib/imapoptions/specialuse_nochildren
@@ -1,7 +1,7 @@
 Name: specialuse_nochildren
 Type: STRING
-Default-Value: \\Scheduled \\Snooze
-Last-Modified: 3.6.0
+Default-Value: \\Scheduled \\Snoozed
+Last-Modified: UNRELEASED
 
 Whitespace separated list of special-use attributes that may not contain
 child folders.  If set, mailboxes with any of these attributes may not have

--- a/lib/imapoptions/specialuse_protect
+++ b/lib/imapoptions/specialuse_protect
@@ -1,8 +1,8 @@
 Name: specialuse_protect
 Type: STRING
 Default-Value: \\Archive \\Drafts \\Important \\Junk \\Sent \\Scheduled
- \\Snooze \\Trash
-Last-Modified: 3.1.7
+ \\Snoozed \\Trash
+Last-Modified: UNRELEASED
 
 Whitespace separated list of special-use attributes to protect the
 mailboxes for.  If set, don't allow mailboxes with these special use


### PR DESCRIPTION
* \Scheduled should be in lmtp_exclude_specialuse default
* \Snoozed, not \Snooze, should be in specialuse_protect default