### PR TITLE
Fix crash if a mailbox is deleted while append is happening

### DIFF
--- a/cassandane/Cassandane/Cyrus/Append.pm
+++ b/cassandane/Cassandane/Cyrus/Append.pm
@@ -11,6 +11,7 @@ use Data::Dumper;
 use Storable 'dclone';
 use File::Basename;
 use IO::File;
+use IO::Select;
 
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -248,6 +248,9 @@ magic(DelayedDelete => sub {
 magic(UnixHierarchySep => sub {
     shift->config_set(unixhierarchysep => 'yes');
 });
+magic(QuotaUseConversations => sub {
+    shift->config_set(quota_use_conversations => 'yes');
+});
 magic(ImmediateExpunge => sub {
     shift->config_set(expunge_mode => 'immediate');
 });

--- a/cassandane/tiny-tests/Append/append_trycreate_deleted_race
+++ b/cassandane/tiny-tests/Append/append_trycreate_deleted_race
@@ -1,0 +1,102 @@
+#!perl
+use Cassandane::Tiny;
+
+# A NONEXISTENT failure deep in the APPEND path triggers a TRYCREATE check,
+# which runs the quota check.  With quota_use_conversations enabled that opens
+# the conversations DB and takes the user namespace lock.  By that point
+# imapd_check() has re-opened the selected mailbox, leaving it parked with its
+# namelock held (but its nslock released), so taking the nslock must not trip
+# the lock-ordering assertion in user_nslock_lock().
+#
+# We provoke the late NONEXISTENT by deleting the target between APPEND's
+# initial existence check and the point where it opens the mailbox to write:
+# the synchronising literal gives a second connection a window to delete it
+# (which is exactly what happens when a client deletes a folder while another
+# session is appending to it).
+#
+# Invariant: APPEND to a mailbox that is deleted out from under us, while
+# another mailbox is selected, returns TRYCREATE without crashing the server.
+sub test_append_trycreate_deleted_race
+    :QuotaUseConversations
+    ($self)
+{
+    my $imaptalk = $self->{store}->get_client();
+    my $admintalk = $self->{adminstore}->get_client();
+
+    xlog $self, "Give the user a quota root so the TRYCREATE check runs quota";
+    $admintalk->setquota('user.cassandane', [storage => 100000]) || die $@;
+
+    my $mimeMessage = <<'EOF';
+From: <from@local>
+To: to@local
+Subject: test
+Date: Mon, 13 Apr 2020 15:34:03 +0200
+MIME-Version: 1.0
+Content-Type: text/plain
+
+test
+EOF
+    $mimeMessage =~ s/\r?\n/\r\n/gs;
+
+    xlog $self, "Create the target mailbox so the initial APPEND check passes";
+    $imaptalk->create('INBOX.Sample') || die $@;
+
+    xlog $self, "Select INBOX so it gets re-opened (and parked) during APPEND";
+    $imaptalk->select('INBOX');
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    # drive the APPEND by hand so we can pause at the synchronising literal
+    my $sock = $imaptalk->{Socket};
+    my $len = length($mimeMessage);
+    $sock->print("zz1 APPEND INBOX.Sample {$len}\r\n");
+    $sock->flush();
+
+    # Read from $sock until $pattern matches, but never block forever: if the
+    # server deadlocks (the bug this test guards against) we want a fast, clear
+    # failure rather than a hang that CI can only kill by timing out the run.
+    my $read_until = sub {
+        my ($pattern, $what) = @_;
+        my $sel = IO::Select->new($sock);
+        my $data = '';
+        while ($data !~ $pattern) {
+            die "timed out waiting for $what (server hung?): $data"
+                unless $sel->can_read(30);
+            my $buf;
+            die "no $what (connection closed): $data"
+                unless sysread($sock, $buf, 4096);
+            $data .= $buf;
+        }
+        return $data;
+    };
+
+    xlog $self, "Wait for the continuation request";
+    my $cont = $read_until->(qr/\r\n/, "continuation");
+    $self->assert_matches(qr/^\+/, $cont);
+
+    xlog $self, "Delete the target out from under the in-flight APPEND";
+    # The admin-visible name keeps the INBOX. component of the personal
+    # namespace: INBOX.Sample lives at user.cassandane.INBOX.Sample.
+    my $deleted = $admintalk->delete('user.cassandane.INBOX.Sample');
+
+    xlog $self, "Now send the message body, completing the APPEND";
+    # Always finish the command, even if the delete above failed: leaving the
+    # synchronising literal half-sent parks the server reading the body, and
+    # tear_down's LOGOUT then gets swallowed as literal data, hanging the run.
+    $sock->print($mimeMessage . "\r\n");
+    $sock->flush();
+
+    my $resp = $read_until->(qr/^zz1 /m, "tagged response");
+    xlog $self, "APPEND response: $resp";
+
+    $self->assert($deleted, "failed to delete target mid-append: " .
+        $admintalk->get_last_error());
+    $self->assert_matches(qr/^zz1 NO /m, $resp);
+    $self->assert_matches(qr/TRYCREATE/, $resp);
+
+    xlog $self, "Server is still alive (did not assert/crash)";
+    my $checktalk = $self->{store}->get_client();
+    $checktalk->status('INBOX', ['messages']);
+    $self->assert_str_equals('ok', $checktalk->get_last_completion_response());
+}
+
+1;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4568,6 +4568,9 @@ static int cmd_append(char *tag, char *name, const char *cur_name,
                     tag, url, parseerr);
     } else if (r) {
         const char *respcode = "";
+        /* release the selected mailbox before the TRYCREATE check below, which
+         * may need to take the user namespace lock */
+        index_release(imapd_index);
         if (r == IMAP_MAILBOX_NOTSUPPORTED) {
             respcode = "[CANNOT] ";
         }


### PR DESCRIPTION
We get this crash very rarely, but it can happen!  Found one user who had 3 of them; wild - they deleted an entire tree while appending to it from a client.