### PR TITLE
Mailbox/set: report duplicate name as alreadyExists

### DIFF
--- a/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_both
+++ b/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_both
@@ -36,7 +36,10 @@ sub test_mailbox_rename_to_clash_both
     });
 
     # rejected due to name existing
-    $self->assert_str_equals("name", $res->{notUpdated}{$mboxids{A}}{properties}[0]);
+    $self->assert_cmp_deeply(
+      superhashof({ type => 'alreadyExists' }),
+      $res->{notUpdated}{$mboxids{A}},
+    );
 
     $res = $jmap->Call('Mailbox/get', {});
     my %mboxids2 = map { $_->{name} => $_->{id} } @{$res->{list}};

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_set_already_exists
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_set_already_exists
@@ -1,0 +1,64 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_mailbox_set_already_exists
+    :min_version_3_1
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+    xlog "create the first mailbox; it should succeed";
+    my $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            create => {
+                mbox1 => {
+                    name => 'Duplicate Name Test',
+                    parentId => undef,
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert_not_null($res->[0][1]{created}{mbox1}{id});
+
+    xlog "creating a second mailbox with the same name under the same parent";
+    xlog "must yield SetError 'alreadyExists' (RFC 8621 S2.5)";
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            create => {
+                mbox2 => {
+                    name => 'Duplicate Name Test',
+                    parentId => undef,
+                },
+            },
+        }, 'R2'],
+    ]);
+    $self->assert_null($res->[0][1]{created});
+    $self->assert_str_equals('alreadyExists',
+        $res->[0][1]{notCreated}{mbox2}{type});
+
+    xlog "renaming a different mailbox onto an existing name must also fail";
+    xlog "with 'alreadyExists' rather than 'invalidProperties'";
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            create => {
+                mbox3 => {
+                    name => 'Will Be Renamed',
+                    parentId => undef,
+                },
+            },
+        }, 'R3'],
+    ]);
+    my $renameId = $res->[0][1]{created}{mbox3}{id};
+    $self->assert_not_null($renameId);
+
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', {
+            update => {
+                $renameId => { name => 'Duplicate Name Test' },
+            },
+        }, 'R4'],
+    ]);
+    $self->assert_null($res->[0][1]{updated});
+    $self->assert_str_equals('alreadyExists',
+        $res->[0][1]{notUpdated}{$renameId}{type});
+}

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -2141,7 +2141,7 @@ static void _mbox_create(jmap_req_t *req, struct mboxset_args *args,
         }
         else {
             syslog(LOG_ERR, "jmap: mailbox already exists: %s", mboxname);
-            jmap_parser_invalid(&parser, "name");
+            result->err = json_pack("{s:s}", "type", "alreadyExists");
             goto done;
         }
     }
@@ -2234,7 +2234,10 @@ static void _mbox_create(jmap_req_t *req, struct mboxset_args *args,
     }
 
 done:
-    if (json_array_size(parser.invalid)) {
+    if (result->err) {
+        /* already set above (e.g. alreadyExists) */
+    }
+    else if (json_array_size(parser.invalid)) {
         result->err = json_pack("{s:s}", "type", "invalidProperties");
         json_object_set(result->err, "properties", parser.invalid);
     }
@@ -2530,7 +2533,7 @@ static void _mbox_update(jmap_req_t *req, struct mboxset_args *args,
                 }
                 else {
                     syslog(LOG_ERR, "jmap: mailbox already exists: %s", newmboxname);
-                    jmap_parser_invalid(&parser, "name");
+                    result->err = json_pack("{s:s}", "type", "alreadyExists");
                     goto done;
                 }
             }
@@ -2653,11 +2656,14 @@ static void _mbox_update(jmap_req_t *req, struct mboxset_args *args,
     if (r) goto done;
 
 done:
-    if (json_array_size(parser.invalid)) {
+    if (result->err) {
+        /* already set above (e.g. alreadyExists, notFound, forbidden) */
+    }
+    else if (json_array_size(parser.invalid)) {
         result->err = json_pack("{s:s}", "type", "invalidProperties");
         json_object_set(result->err, "properties", parser.invalid);
     }
-    else if (r && result->err == NULL) {
+    else if (r) {
         result->err = jmap_server_error(r);
     }
     jmap_parser_fini(&parser);


### PR DESCRIPTION
RFC 8621 §2.5 requires an "alreadyExists" error on name conflict, but we issued "invalidProperties".

This also teaches the relevant done blocks to leave an already-set result->err in place.  (I suspect we should make this easier to do more generically.)