### PR TITLE
Email/parse: return null for keywords on parsed messages

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_parse
+++ b/cassandane/tiny-tests/JMAPEmail/email_parse
@@ -7,9 +7,6 @@ sub test_email_parse
 {
     my $jmap = $self->{jmap};
 
-    my $store = $self->{store};
-    my $talk = $store->get_client();
-
     $self->make_message("foo",
         mime_type => "multipart/mixed",
         mime_boundary => "sub",
@@ -52,7 +49,7 @@ sub test_email_parse
     $self->assert_null($email->{id});
     $self->assert_null($email->{threadId});
     $self->assert_null($email->{mailboxIds});
-    $self->assert_deep_equals({}, $email->{keywords});
+    $self->assert_null($email->{keywords});
     $self->assert_deep_equals(['fake.1475639947.6507@local'], $email->{messageId});
     $self->assert_deep_equals([{name=>'Ava T. Nguyen', email=>'Ava.Nguyen@local'}], $email->{from});
     $self->assert_deep_equals([{name=>'Test User', email=>'test@local'}], $email->{to});

--- a/cassandane/tiny-tests/JMAPEmail/email_parse_blob822
+++ b/cassandane/tiny-tests/JMAPEmail/email_parse_blob822
@@ -29,9 +29,11 @@ EOF
     push @props, "bodyStructure";
     push @props, "bodyValues";
 
+    my @metadata_props = qw( id mailboxIds receivedAt keywords );
+
     my $res = $jmap->CallMethods([['Email/parse', {
         blobIds => [ $blobId ],
-        properties => \@props,
+        properties => [ @props, @metadata_props ],
         fetchAllBodyValues => JSON::true,
     }, 'R1']]);
     my $email = $res->[0][1]{parsed}{$blobId};
@@ -41,4 +43,8 @@ EOF
 
     my $bodyValue = $email->{bodyValues}{$email->{bodyStructure}{partId}};
     $self->assert_str_equals("This is a test email.\n", $bodyValue->{value});
+
+    for my $prop (@metadata_props) {
+        $self->assert_null($email->{$prop}, "expect null $prop in Email/parse");
+    }
 }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -7303,7 +7303,7 @@ static int _email_get_meta(jmap_req_t *req,
         if (jmap_wantprop(props, "mailboxIds"))
             json_object_set_new(email, "mailboxIds", json_null());
         if (jmap_wantprop(props, "keywords"))
-            json_object_set_new(email, "keywords", json_object());
+            json_object_set_new(email, "keywords", json_null());
         if (jmap_wantprop(props, "size")) {
             size_t size = msg->rfc822part->header_size + msg->rfc822part->content_size;
             json_object_set_new(email, "size", json_integer(size));


### PR DESCRIPTION
RFC 8621 §4.9 says the metadata properties id, mailboxIds, keywords, and receivedAt "will be null if requested" on Email objects returned from Email/parse, because they only make sense for stored messages. Cyrus already returned null for id, mailboxIds, and receivedAt, but returned an empty object {} for keywords.