### PR TITLE
Implement Identity/changes as a trivial empty-changes method

### DIFF
--- a/cassandane/tiny-tests/JMAPCore/identity_changes
+++ b/cassandane/tiny-tests/JMAPCore/identity_changes
@@ -1,0 +1,37 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_identity_changes ($self)
+{
+    my $jmap = $self->default_user->jmap;
+
+    xlog "Identity/get to pick up the current state";
+    my $res = $jmap->request([['Identity/get', { ids => [] } ]]);
+    my $state = $res->single_sentence->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog "Identity/changes with sinceState == current state must return empty";
+    $res = $jmap->request([['Identity/changes', { sinceState => $state } ]]);
+
+    $self->assert_cmp_deeply(
+      superhashof({
+        oldState => $state,
+        newState => $state,
+        created  => [],
+        updated  => [],
+        destroyed => [],
+        hasMoreChanges => bool(0),
+      }),
+      $res->single_sentence('Identity/changes')->arguments,
+    );
+
+    xlog "Identity/changes with an unknown sinceState must yield";
+    xlog "cannotCalculateChanges, not unknownMethod";
+
+    $res = $jmap->request([['Identity/changes', { sinceState => '999' } ]]);
+    $self->assert_str_equals('error', $res->single_sentence->name);
+    $self->assert_str_equals(
+      'cannotCalculateChanges',
+      $res->single_sentence->arguments->{type},
+    );
+}

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -43,6 +43,7 @@ static int jmap_emailsubmission_changes(jmap_req_t *req);
 static int jmap_emailsubmission_query(jmap_req_t *req);
 static int jmap_emailsubmission_querychanges(jmap_req_t *req);
 static int jmap_identity_get(jmap_req_t *req);
+static int jmap_identity_changes(jmap_req_t *req);
 
 // clang-format off
 static jmap_method_t jmap_emailsubmission_methods_standard[] = {
@@ -80,6 +81,12 @@ static jmap_method_t jmap_emailsubmission_methods_standard[] = {
         "Identity/get",
         JMAP_URN_SUBMISSION,
         &jmap_identity_get,
+        /*flags*/0
+    },
+    {
+        "Identity/changes",
+        JMAP_URN_SUBMISSION,
+        &jmap_identity_changes,
         /*flags*/0
     },
     { NULL, NULL, NULL, 0}
@@ -2308,5 +2315,34 @@ static int jmap_identity_get(jmap_req_t *req)
 done:
     jmap_parser_fini(&parser);
     jmap_get_fini(&get);
+    return 0;
+}
+
+static int jmap_identity_changes(jmap_req_t *req)
+{
+    struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
+    struct jmap_changes changes = JMAP_CHANGES_INITIALIZER;
+    json_t *err = NULL;
+
+    jmap_changes_parse(req, &parser, /*minmodseq*/0, NULL, NULL, &changes, &err);
+    if (err) {
+        jmap_error(req, err);
+        goto done;
+    }
+
+    /* The Cyrus Identity object is basically a stub with no mutable state, so
+     * its state string is hardcoded to "0".  No /changes from another state
+     * can make any sense.  Give up. */
+    if (changes.since_modseq != 0) {
+        jmap_error(req, json_pack("{s:s}", "type", "cannotCalculateChanges"));
+        goto done;
+    }
+
+    changes.new_modseq = 0;
+    jmap_ok(req, jmap_changes_reply(&changes));
+
+done:
+    jmap_changes_fini(&changes);
+    jmap_parser_fini(&parser);
     return 0;
 }


### PR DESCRIPTION
RFC 8621 §6.2 lists Identity/changes as a required method, but Cyrus registered only Identity/get on the JMAP submission capability.

Cyrus's Identity object is implicit (one identity per user, derived from the authenticated userid) and has no mutable state.  Identity/changes can therefore follow that fiction:

    if sinceState is "0":
      return empty created/updated/destroyed, oldState == newState == "0"
    else
      return cannotCalculateChanges

Once an Identity/set implementation lands, it can grow real state-tracking and this method will start reporting actual changes.