### PR TITLE
twom: check mmap() result against MAP_FAILED, not NULL

### DIFF
--- a/lib/twom.c
+++ b/lib/twom.c
@@ -522,7 +522,8 @@ static inline int tm_ensure(struct twom_db *db, size_t offset)
     // map the larger file into new memory
     file->size = newoffset;
     file->base = (char *)mmap((caddr_t)0, file->size, PROT_READ|PROT_WRITE, MAP_SHARED, db->openfile->fd, 0L);
-    if (!file->base) {
+    if (file->base == MAP_FAILED) {
+        file->base = NULL;
         db->error("twom failed to mmap during tm_ensure",
                    "filename=<%s> newsize=<%08llX>",
                    db->fname, (LLU)file->size);
@@ -1665,7 +1666,8 @@ static int write_lock(struct twom_db *db, struct twom_txn **txnp,
         if (file->size) munmap(file->base, file->size);
         file->size = sbuf.st_size;
         file->base = (char *)mmap((caddr_t)0, file->size, PROT_READ|PROT_WRITE, MAP_SHARED, file->fd, 0L);
-        if (!file->base) {
+        if (file->base == MAP_FAILED) {
+            file->base = NULL;
             db->error("write_lock mmap failed",
                       "filename=<%s> size=<%08llX>", db->fname, (LLU)file->size);
             r = TWOM_IOERROR;
@@ -1818,7 +1820,8 @@ static int read_lock(struct twom_db *db, struct twom_txn **txnp,
         int flags = db->readonly ? PROT_READ : PROT_READ|PROT_WRITE;
         file->size = sbuf.st_size;
         file->base = (char *)mmap((caddr_t)0, file->size, flags, MAP_SHARED, file->fd, 0L);
-        if (!file->base) {
+        if (file->base == MAP_FAILED) {
+            file->base = NULL;
             db->error("read_lock mmap failed",
                       "filename=<%s> size=<%08llX>", db->fname, (LLU)file->size);
             r = TWOM_IOERROR;


### PR DESCRIPTION
mmap(2) signals failure by returning MAP_FAILED, not NULL.

Three sites in lib/twom.c did `if (!file->base)` after the mmap, so the failure path was never taken on real mmap failure; the next read_header() call then dereferenced (void *)-1 and crashed.

Check MAP_FAILED at each site and reset file->base to NULL on failure so the cleanup paths (which do test for NULL before munmap) behave correctly afterwards.