### PR TITLE
imapoptions: require absolute configdirectory

### DIFF
--- a/changes/next/cyr-3160-absolute-configdirectory
+++ b/changes/next/cyr-3160-absolute-configdirectory
@@ -1,0 +1,23 @@
+Description:
+
+The :imapdconf:`configdirectory` must now be an absolute path.
+
+
+Documentation:
+
+:imapdconf:`configdirectory`
+
+
+Config changes:
+
+configdirectory
+
+
+Upgrade instructions:
+
+If configdirectory was set to a relative path, it must be changed.
+
+
+GitHub issue:
+
+None

--- a/cunit/libconfig.testc
+++ b/cunit/libconfig.testc
@@ -819,6 +819,40 @@ static void test_configdirectory_missing(void)
     );
 }
 
+static void test_configdirectory_relative(void)
+{
+    CU_EXPECT_CYRFATAL_BEGIN
+    config_read_string(NULL,
+        "configdirectory: "DBDIR"/conf\n"
+    );
+    CU_EXPECT_CYRFATAL_END(
+        EX_CONFIG,
+        "configdirectory must be fully qualified"
+    );
+}
+
+static void test_configdirectory_root(void)
+{
+    CU_EXPECT_CYRFATAL_BEGIN
+    config_read_string("/", NULL);
+    CU_EXPECT_CYRFATAL_END(
+        EX_CONFIG,
+        "configdirectory must not be '/'"
+    );
+}
+
+static void test_configdirectory_empty(void)
+{
+    CU_EXPECT_CYRFATAL_BEGIN
+    config_read_string(NULL,
+        "configdirectory: \n"
+    );
+    CU_EXPECT_CYRFATAL_END(
+        EX_CONFIG,
+        "empty option value on line 1 of configuration file"
+    );
+}
+
 static void test_deprecated_int(void)
 {
     /* { "autocreatequotamsg", -1, INT, "2.5.0", "2.5.0", "autocreate_quota_messages" } */

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -45,9 +45,6 @@ EXPORTED const char *prometheus_stats_dir(void)
 
     tmp = config_getstring(IMAPOPT_PROMETHEUS_STATS_DIR);
 
-    /* XXX this is a little weird, we don't validate these requirements
-     * XXX for config_dir...
-     */
     if (tmp[0] != '/')
         fatal("prometheus_stats_dir must be fully qualified", EX_CONFIG);
 

--- a/lib/imapoptions/configdirectory
+++ b/lib/imapoptions/configdirectory
@@ -1,6 +1,7 @@
 Name: configdirectory
 Type: STRING
 Default-Value: NULL
-Last-Modified: 2.3.17
+Last-Modified: UNRELEASED
 
-The pathname of the IMAP configuration directory.  This field is required.
+The absolute pathname of the IMAP configuration directory.  This field is
+required.

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -654,6 +654,12 @@ EXPORTED void config_read(const char *alt_config, const int config_need_data)
         fatal("configdirectory option not specified in configuration file",
               EX_CONFIG);
     }
+    else if (config_dir[0] != '/') {
+        fatal("configdirectory must be fully qualified", EX_CONFIG);
+    }
+    else if (!config_dir[1]) {
+        fatal("configdirectory must not be '/'", EX_CONFIG);
+    }
 
     for (opt = IMAPOPT_ZERO; opt < IMAPOPT_LAST; opt++) {
         /* Scan options to see if we need to replace {configdirectory} */

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -56,9 +56,6 @@ static char *proc_getpath(pid_t pid, int isnew)
     /* belt and suspenders: libconfig defaults it if it wasn't set */
     assert(procpath != NULL);
 
-    /* XXX this is kinda weird -- we do not have this level of verification
-     * XXX for config_dir, but perhaps we should
-     */
     if (procpath[0] != '/')
         fatal("proc_path must be fully qualified", EX_CONFIG);
 


### PR DESCRIPTION
Setting `configdirectory` to a relative path doesn't make much sense.  A few niche code paths already assume it's an absolute path, but let's enforce (and test!) that properly and consistently.