### PR TITLE
jmap_calendar.c: don't crash CalendarEvent/get on a startless event

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_no_dtstart
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_no_dtstart
@@ -1,0 +1,28 @@
+#!perl
+use Cassandane::Tiny;
+
+# A VEVENT with no DTSTART (as produced by some clients) must not crash
+# CalendarEvent/get.
+sub test_calendarevent_get_no_dtstart ($self)
+{
+
+    my $uid = guid_string();
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//WeirdCal//WeirdCal 2026.7//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:$uid
+SEQUENCE:0
+DTSTAMP:20240408T162456Z
+TRANSP:TRANSPARENT
+LAST-MODIFIED:20240408T162440Z
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    my $event = $self->putandget_vevent($uid, $ical);
+    $self->assert_not_null($event);
+    $self->assert_null($event->{start});
+}

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -2917,6 +2917,11 @@ static void getcalendarevents_get_utctimes_internal(json_t *jsevent,
 {
     icaltimezone *utc = icaltimezone_get_utc_timezone();
 
+    /* An event without a start (e.g. a VEVENT with no DTSTART) has no
+     * start to convert, so there is nothing to derive utcStart/utcEnd
+     * from. */
+    if (!startstr) return;
+
     /* Read start */
     struct jmapical_datetime startdt = JMAPICAL_DATETIME_INITIALIZER;
     if (jmapical_localdatetime_from_string(startstr, &startdt) == -1) return;


### PR DESCRIPTION
getcalendarevents_get_utctimes reads the "start" property to derive utcStart/utcEnd, but a VEVENT with no DTSTART yields no "start", so it passed NULL to jmapical_localdatetime_from_string, which dereferenced it in strptime and crashed httpd.