### PR TITLE
backup: keep a deleted folder through compaction until it ages out

### DIFF
--- a/cassandane/tiny-tests/Backup/compress_deleted_folder
+++ b/cassandane/tiny-tests/Backup/compress_deleted_folder
@@ -3,12 +3,18 @@ use Cassandane::Tiny;
 
 use Cyrus::Backup;
 
-# Regression test: deleted folders must stay deleted after compression.
+# Regression test: a deleted folder must survive compression as *deleted* --
+# neither coming back to life nor vanishing early.
 #
-# Before the fix, the imap row's offset was not updated when a folder was
-# deleted, so CompressBackup's StreamCopy matched the creation entry (keeping
-# it with deleted=0) and dropped the deletion entry.  After compression the
-# folder silently reappeared.
+# The deletion marker links to nowhere, so a state rebuilt from the compacted
+# file can't tell which folder it was (folderid('') is 0). Originally that
+# dropped the deletion entry and kept the creation entry, so the folder
+# reappeared live. Making the deletion win then swung the other way: the marker
+# was kept but its folderid was lost, so the folder was purged immediately and
+# its data reclaimed well before MAX_AGE. The fix replays the folder's real
+# link just before the marker during compaction, so the deletion record (and
+# the folder's data) is retained, with its timestamp, until it genuinely ages
+# out.
 sub test_compress_deleted_folder
     :min_version_3_13 :want_service_backupcyrusd
     ($self)
@@ -74,12 +80,22 @@ sub test_compress_deleted_folder
     $self->assert_num_lt($size_before, $size_after,
         'compressed tar is smaller');
 
-    # THE KEY ASSERTION: Disposable must not reappear after compression
-    my ($disp_after) = $dbh->selectrow_array(
-        "SELECT COUNT(*) FROM imap WHERE name = 'INBOX.Disposable'",
+    # Disposable must not come back to life...
+    my ($disp_live) = $dbh->selectrow_array(
+        "SELECT COUNT(*) FROM imap WHERE name = 'INBOX.Disposable' AND deleted = 0",
     );
-    $self->assert_num_equals(0, $disp_after,
-        'Disposable folder removed from imap after compress');
+    $self->assert_num_equals(0, $disp_live,
+        'Disposable folder not live after compress');
+
+    # ...but it must stay recorded as deleted, with its original timestamp, so
+    # it's still restorable until the deletion ages past MAX_AGE.
+    my ($disp_deleted_after) = $dbh->selectrow_array(
+        "SELECT deleted FROM imap WHERE name = 'INBOX.Disposable' AND deleted != 0",
+    );
+    $self->assert($disp_deleted_after,
+        'Disposable retained as deleted after compress (within grace)');
+    $self->assert_num_equals($disp_deleted, $disp_deleted_after,
+        'deletion timestamp preserved across compress');
 
     # Keep folder should still be present with all its messages
     my ($keep_count) = $dbh->selectrow_array(

--- a/cassandane/tiny-tests/Backup/compress_deleted_folder_ages_out
+++ b/cassandane/tiny-tests/Backup/compress_deleted_folder_ages_out
@@ -1,0 +1,72 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+use DBI;
+
+# A folder deleted within MAX_AGE must survive compaction as deleted (so it is
+# still restorable), then be reclaimed once its deletion timestamp ages past
+# MAX_AGE.
+sub test_compress_deleted_folder_ages_out
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    $talk->create("INBOX.Keep");
+    $talk->create("INBOX.Disposable");
+    $self->{store}->set_folder("INBOX.Keep");
+    $self->make_message("Keep msg 1") or die;
+    $self->{store}->set_folder("INBOX.Disposable");
+    $self->make_message("Disposable msg 1") or die;
+
+    my ($meta, $data, $service, $servername) = $self->_backup_setup();
+    $self->_do_backup($meta, $data, $service, $servername);
+
+    # Delete Disposable and back up again so it's recorded as deleted.
+    $talk->delete("INBOX.Disposable");
+    $self->{instance}->run_command({ cyrus => 1 },
+        'cyr_expire', '-X' => '0', '-D' => '0');
+    $self->_do_backup($meta, $data, $service, $servername);
+
+    my $disposable_meta_bytes = sub {
+        my $dbh = $self->_open_backup_db($meta);
+        my ($mb) = $dbh->selectrow_array(
+            "SELECT COALESCE(SUM(size + stale), 0) FROM fmeta WHERE folderid IN "
+            . "(SELECT folderid FROM imap WHERE name = 'INBOX.Disposable')");
+        $dbh->disconnect;
+        return $mb;
+    };
+
+    # Compress within the grace window: the folder stays recorded as deleted
+    # and keeps its metadata.
+    sleep 1;
+    Cyrus::Backup::CompressBackup($meta, $data, 'cassandane', undef, 101);
+
+    my $dbh = $self->_open_backup_db($meta);
+    my ($deleted_ts) = $dbh->selectrow_array(
+        "SELECT deleted FROM imap WHERE name = 'INBOX.Disposable' AND deleted != 0");
+    $dbh->disconnect;
+    $self->assert($deleted_ts, 'deleted folder retained within grace');
+    $self->assert_num_gt(0, $disposable_meta_bytes->(),
+        'deleted folder metadata retained within grace');
+
+    # Age the deletion past MAX_AGE, then compress again: now it is reclaimed.
+    my $old = time() - $Cyrus::Backup::MAX_AGE - 86400;
+    my $rw = DBI->connect("dbi:SQLite:dbname=$meta/backupstate.sqlite3",
+        undef, undef, { RaiseError => 1 });
+    $rw->do("UPDATE imap SET deleted = ? WHERE name = 'INBOX.Disposable'", {}, $old);
+    $rw->disconnect;
+
+    sleep 1;
+    Cyrus::Backup::CompressBackup($meta, $data, 'cassandane', undef, 101);
+
+    $dbh = $self->_open_backup_db($meta);
+    my ($still) = $dbh->selectrow_array(
+        "SELECT COUNT(*) FROM imap WHERE name = 'INBOX.Disposable'");
+    $dbh->disconnect;
+    $self->assert_num_equals(0, $still,
+        'aged-out deleted folder reclaimed after MAX_AGE');
+    $self->assert_num_equals(0, $disposable_meta_bytes->(),
+        'aged-out deleted folder metadata reclaimed');
+}

--- a/perl/imap/lib/Cyrus/Backup.pm
+++ b/perl/imap/lib/Cyrus/Backup.pm
@@ -462,6 +462,22 @@ sub CompressBackup {
       }
       if ($key =~ m{^imap/}) {
         $header->{linkname} =~ s{^folders/}{};
+        # A deletion marker links to nowhere, so a state rebuilt from the new
+        # file alone can't tell which folder it was: folderid('') is 0, no imap
+        # row is recreated, and the folder's metadata is reclaimed before
+        # MAX_AGE. Replay the folder's real link immediately before the marker
+        # so the rebuilt state keeps the name->folderid mapping. The marker's
+        # own mtime still drives ageing -- once it passes ExpireTime the loop
+        # above stops keeping it and the folder finally drops.
+        if ($header->{linkname} eq '' and $cur->{folderid}) {
+          my ($unq) = $state->dbh->selectrow_array(
+            "SELECT uniqueid FROM folders WHERE folderid = ?", {}, $cur->{folderid});
+          if ($unq) {
+            my $lh = $ts->AddLink($key, $unq, mtime => $cur->{deleted});
+            $outstate->addheader($lh, $lh->{_pos});
+            $outpos = $ts->OutPos();
+          }
+        }
       }
       if ($key =~ m{^files/}) {
         # then make sure we only get one copy of it


### PR DESCRIPTION
This came up when testing backup compaction for Fastmail, we found that a file would compact and immediately have more changes to compact!  Only the second pass would lock in entirely.

This showed that we were losing deleted folders immediately after the second repack; even though they're supposed to persist for some time for data safety.

This change persists the deletion marker, so the compaction continues to hold the remaining data until it times out.