### PR TITLE
jscalendar.c: set "start" to zero date-time for missing DTSTART

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_no_dtstart
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_no_dtstart
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_get_no_dtstart ($self)
+{
+
+    my $uid = guid_string();
+    # This VEVENT does not contain mandatory DTSTART and DTSTAMP.
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//WeirdCal//WeirdCal 2026.7//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:$uid
+SEQUENCE:0
+TRANSP:TRANSPARENT
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    my $event = $self->putandget_vevent($uid, $ical);
+    $self->assert_not_null($event);
+    $self->assert_str_equals('0000-00-00T00:00:00', $event->{start});
+    $self->assert_null($event->{updated});
+}

--- a/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendarevent_get_no_dtstart
+++ b/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendarevent_get_no_dtstart
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_get_no_dtstart ($self)
+{
+
+    my $uid = guid_string();
+    # This VEVENT does not contain mandatory DTSTART and DTSTAMP.
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//WeirdCal//WeirdCal 2026.7//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:$uid
+SEQUENCE:0
+TRANSP:TRANSPARENT
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    my $event = $self->putandget_vevent($uid, $ical);
+    $self->assert_not_null($event);
+    $self->assert_str_equals('0000-00-00T00:00:00', $event->{start});
+    $self->assert_null($event->{updated});
+}

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -6529,6 +6529,15 @@ static void entry_from_ical(jscal_ctx_t *ctx,
                 "cyrusimap.org:unguessableTimezones", jtimezones);
     }
 
+    // XXX quirk: a VEVENT without DTSTART is bogus. But in case such
+    // data exists on disk, emulate what the former implementation did.
+    if (!json_object_get(jobj, "start")
+        && icalcomponent_isa(comp) == ICAL_VEVENT_COMPONENT
+        && !ctx->cfg.no_quirk)
+    {
+        json_object_set_new(jobj, "start", json_string("0000-00-00T00:00:00"));
+    }
+
     buf_free(&buf);
 }
 


### PR DESCRIPTION
A VEVENT missing its mandatory DTSTART property does not make any sense, but libical does allow it to be compatible with obsolete RFC 2245. This also applies to DTSTAMP. This patch makes the new jscalendarbis code do what the former implementation did: set "start" to non-valid all-zeroes date-time and do not set the mandatory "updated" property.