### PR TITLE
mboxlist.c: prevent subs.db version upgrade race failures

### DIFF
--- a/cassandane/tiny-tests/Subscriptions/create_subs_db_in_two_procs_slow
+++ b/cassandane/tiny-tests/Subscriptions/create_subs_db_in_two_procs_slow
@@ -1,0 +1,57 @@
+#!perl
+use Cassandane::Tiny;
+use POSIX qw(_exit);
+use Fcntl qw(:flock);
+use File::Temp qw(tempfile);
+
+sub test_create_subs_db_in_two_procs_slow
+    :NoAltNameSpace
+    ($self)
+{
+    my $user = $self->default_user;
+
+    my $creator = $user->imap;
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', "cassandane");
+    my $subdb = $mbpath->{user}->{sub};
+
+    for my $suffix (1..500) {
+        $creator->create("INBOX.Test$suffix") || die "Failed to create a folder?!";
+
+        my $conn1 = $user->imap;
+        my $conn2 = $user->imap;
+
+        my (undef, $tmp) = tempfile;
+
+        # Lock a file exclusively in the parent, then have two children wait
+        # on it with shared locks. Then unlock them both in the parent so they
+        # execute at almost the same time. Gives us a good chance of failure.
+        open(my $fh, '>', $tmp) or die "Failed to open lockfile $tmp: $!\n";
+        $self->assert_equals(1, flock($fh, LOCK_EX));
+
+        $self->assert_equals(1, unlink($subdb));
+
+        if (!fork) {
+          close($fh);
+          open(my $fh, '>', $tmp) or die "Failed to open lockfile $tmp: $!\n";
+          flock($fh, LOCK_SH);
+
+          $conn1->subscribe("INBOX.Test$suffix");
+          _exit(0);
+        }
+
+        if (!fork) {
+          close($fh);
+          open(my $fh, '>', $tmp) or die "Failed to open lockfile $tmp: $!\n";
+          flock($fh, LOCK_SH);
+
+          $conn2->subscribe("INBOX.Test$suffix");
+          _exit(0);
+        }
+
+        undef $fh;
+
+        wait();
+        wait();
+    }
+}

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -5994,7 +5994,7 @@ static int mboxlist_upgrade_subs_work(const char *userid,
 
     /* create new db file name */
     buf_setcstr(&buf, subsfname);
-    buf_appendcstr(&buf, ".NEW");
+    buf_appendcstr(&buf, ".UPGRADE");
     newsubsfname = buf_release(&buf);
 
     /* open new db file */
@@ -6075,16 +6075,11 @@ static int mboxlist_upgrade_subs(const char *userid,
     int curr_version;
     int r = 0;
 
-    if (!subsdb_needs_upgrade(userid, subsfname, *subs, NULL))
-        return 0;
-
     // lock the subs namespace - we'll hold this lock while we upgrade.
     char *lockname = strconcat("$SUBS_UPGRADE$", userid, (char *)NULL);
     r = mboxname_lock(lockname, &upgradelock, LOCK_EXCLUSIVE);
     if (r) goto done;
 
-    /* if it no longer needs upgrading, we lost the race and someone else
-     * already upgraded the DB.  Bonus. */
     if (subsdb_needs_upgrade(userid, subsfname, *subs, &curr_version)) {
         xsyslog(LOG_NOTICE, "upgrading user subscriptions",
                             "userid=<%s> subsfname=<%s>"


### PR DESCRIPTION
- Lock the subs namespace while both reading and upgrading the subs.db
- Use an ".UPGRADE" file suffix for the upgraded db, so we don't conflict with
  ".NEW" used by cyrusdb_flat.c

Without these fixes, one of the files in play (subs.db, subs.db.NEW) would
randomly get deleted out from under us by a competing process.