### PR TITLE
http_rss: escape unsafe characters in feeds

### DIFF
--- a/cassandane/Cassandane/Cyrus/RSS.pm
+++ b/cassandane/Cassandane/Cyrus/RSS.pm
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+package Cassandane::Cyrus::RSS;
+use strict;
+use warnings;
+use HTTP::Tiny;
+use MIME::Base64 qw(encode_base64);
+
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+use Cassandane::Message;
+
+sub new
+{
+    my $class = shift;
+
+    my $config = Cassandane::Config->default()->clone();
+    $config->set(httpmodules => 'rss');
+    $config->set(httpallowcompress => 'no');
+
+    my $self = $class->SUPER::new({
+        config => $config,
+        deliver => 1,
+        adminstore => 1,
+        services => [ 'imap', 'http' ],
+    }, @_);
+
+    $self->needs('component', 'httpd');
+    return $self;
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+    $self->SUPER::tear_down();
+}
+
+# Issue a GET against the RSS namespace, authenticated as cassandane.
+sub _rss_get
+{
+    my ($self, $path) = @_;
+
+    my $service = $self->{instance}->get_service("http");
+    my $url = sprintf("http://%s:%s%s",
+                      $service->host(), $service->port(), $path);
+
+    my $auth = 'Basic ' . encode_base64('cassandane:pass', '');
+    return HTTP::Tiny->new()->get($url, {
+        headers => { Authorization => $auth },
+    });
+}
+
+# Deliver a raw RFC822 message to cassandane@INBOX.
+sub _deliver_raw
+{
+    my ($self, $raw) = @_;
+    $self->{instance}->deliver(Cassandane::Message->new(raw => $raw));
+}
+
+# Assert that a hostile string survives a round trip through delivery + RSS
+# rendering only in escaped form: the unescaped sentinel must not appear in
+# the response body.
+sub _assert_rss_does_not_contain
+{
+    my ($self, %args) = @_;
+
+    my $raw      = $args{raw}      || die "missing raw";
+    my $sentinel = $args{sentinel} || die "missing sentinel";
+    my $path     = $args{path}     || '/rss/INBOX/';
+    my $label    = $args{label}    || 'rss response';
+
+    $self->_deliver_raw($raw);
+
+    my $res = $self->_rss_get($path);
+    $self->assert($res->{success}, "$label: HTTP request succeeded "
+                                 . "(status=$res->{status})");
+
+    my $body = $res->{content} // q{};
+    $self->assert(index($body, $sentinel) == -1,
+        "$label: response body must not contain unescaped '$sentinel'");
+}
+
+use Cassandane::Tiny::Loader;
+
+1;

--- a/cassandane/tiny-tests/RSS/escape_attachment_filename
+++ b/cassandane/tiny-tests/RSS/escape_attachment_filename
@@ -1,0 +1,29 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_escape_attachment_filename ($self)
+{
+    # MIME parameter values can carry quoted-string content with
+    # arbitrary bytes; display_part() in http_rss.c renders the filename
+    # parameter both as anchor text and as alt="..." on an <img>.
+    my $raw = <<'EOF';
+From: sender@example.org
+To: cassandane@example.com
+Subject: Filename XSS
+Message-ID: <rss-xss-filename@example.org>
+Date: Mon, 01 Jan 2024 00:00:00 +0000
+MIME-Version: 1.0
+Content-Type: image/png; name="<script>alert(3)</script>.png"
+Content-Disposition: attachment; filename="<script>alert(3)</script>.png"
+Content-Transfer-Encoding: base64
+
+aGVsbG8K
+EOF
+
+    $self->_assert_rss_does_not_contain(
+        raw      => $raw,
+        sentinel => '<script>alert(3)</script>',
+        path     => '/rss/INBOX/1.',
+        label    => 'attachment filename in per-message HTML',
+    );
+}

--- a/cassandane/tiny-tests/RSS/escape_from_display_name
+++ b/cassandane/tiny-tests/RSS/escape_from_display_name
@@ -1,0 +1,27 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_escape_from_display_name ($self)
+{
+    # A double-quoted display-name preserves arbitrary content verbatim
+    # through parseaddr_phrase, so this lands in the From header on disk
+    # as a literal "<script>...</script>" string.  display_address() in
+    # http_rss.c emits addr->name unescaped into the per-message HTML.
+    my $raw = <<'EOF';
+From: "<script>alert(1)</script>" <attacker@example.org>
+To: cassandane@example.com
+Subject: From display name XSS
+Message-ID: <rss-xss-from-name@example.org>
+Date: Mon, 01 Jan 2024 00:00:00 +0000
+Content-Type: text/plain
+
+body
+EOF
+
+    $self->_assert_rss_does_not_contain(
+        raw      => $raw,
+        sentinel => '<script>alert(1)</script>',
+        path     => '/rss/INBOX/1.',
+        label    => 'From display-name in per-message HTML',
+    );
+}

--- a/cassandane/tiny-tests/RSS/escape_from_local_part
+++ b/cassandane/tiny-tests/RSS/escape_from_local_part
@@ -1,0 +1,29 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_escape_from_local_part ($self)
+{
+    # A double-quoted local-part survives parseaddr verbatim too, so the
+    # mailbox part of the address can contain HTML metachars.  This hits
+    # both Atom paths (<name> with no display-name, and <email>) plus
+    # display_address() in the per-message HTML.
+    my $raw = <<'EOF';
+From: "<script>alert(2)</script>"@example.org
+To: cassandane@example.com
+Subject: From mailbox XSS
+Message-ID: <rss-xss-from-local@example.org>
+Date: Mon, 01 Jan 2024 00:00:00 +0000
+Content-Type: text/plain
+
+body
+EOF
+
+    for my $path ('/rss/INBOX/', '/rss/INBOX/1.') {
+        $self->_assert_rss_does_not_contain(
+            raw      => $raw,
+            sentinel => '<script>alert(2)</script>',
+            path     => $path,
+            label    => "From mailbox local-part via $path",
+        );
+    }
+}

--- a/imap/http_rss.c
+++ b/imap/http_rss.c
@@ -757,6 +757,37 @@ static void buf_escapestr(struct buf *buf, const char *str, unsigned max,
 }
 
 
+/* HTML-escape a string for inline use inside a buf_printf_markup() line:
+ * no leading indent, no trailing newline, and no <blockquote> warning
+ * injection from buf_escapestr()'s `replace` mode (which would tear an
+ * enclosing tag or attribute in half).  Non-printable bytes are passed
+ * through as 'X', matching buf_escapestr()'s non-replace behaviour.
+ * -- claude, 2026-05-21
+ */
+static void buf_escape_inline(struct buf *buf, const char *str)
+{
+    const char *c;
+
+    for (c = str; c && *c; c++) {
+        if (*c == '"') buf_appendcstr(buf, "&quot;");
+        else if (*c == '&') buf_appendcstr(buf, "&amp;");
+        else if (*c == '<') buf_appendcstr(buf, "&lt;");
+        else if (*c == '>') buf_appendcstr(buf, "&gt;");
+        else if ((*c & 0xc0) == 0xc0) {
+            /* leading byte of a multi-byte UTF-8 sequence: copy the
+             * leader and all of its continuation bytes verbatim
+             */
+            unsigned char lead = *c;
+
+            do buf_putc(buf, *c);
+            while (((lead <<= 1) & 0x80) && c++);
+        }
+        else if (!(isspace(*c) || isprint(*c))) buf_putc(buf, 'X');
+        else buf_putc(buf, *c);
+    }
+}
+
+
 /* List messages as an RSS feed */
 static int list_messages(struct transaction_t *txn, struct mailbox *mailbox)
 {
@@ -988,13 +1019,25 @@ static int list_messages(struct transaction_t *txn, struct mailbox *mailbox)
                 free(name);
             }
             else {
-                buf_printf_markup(buf, level, "<name>%s@%s</name>",
-                                  addr->mailbox, addr->domain);
+                if (config_httpprettytelemetry)
+                    buf_printf(buf, "%*s", level * MARKUP_INDENT, "");
+                buf_appendcstr(buf, "<name>");
+                buf_escape_inline(buf, addr->mailbox);
+                buf_appendcstr(buf, "@");
+                buf_escape_inline(buf, addr->domain);
+                buf_appendcstr(buf, "</name>");
+                if (config_httpprettytelemetry) buf_appendcstr(buf, "\n");
             }
 
             /* <email> - optional */
-            buf_printf_markup(buf, level, "<email>%s@%s</email>",
-                              addr->mailbox, addr->domain);
+            if (config_httpprettytelemetry)
+                buf_printf(buf, "%*s", level * MARKUP_INDENT, "");
+            buf_appendcstr(buf, "<email>");
+            buf_escape_inline(buf, addr->mailbox);
+            buf_appendcstr(buf, "@");
+            buf_escape_inline(buf, addr->domain);
+            buf_appendcstr(buf, "</email>");
+            if (config_httpprettytelemetry) buf_appendcstr(buf, "\n");
 
             buf_printf_markup(buf, --level, "</author>");
         }
@@ -1047,9 +1090,20 @@ static void display_address(struct buf *buf, struct address *addr,
         buf_printf(buf, "%*s", level * MARKUP_INDENT, "");
 
     buf_printf(buf, "%s", sep);
-    if (addr->name) buf_printf(buf, "\"%s\" ", addr->name);
-    buf_printf(buf, "<a href=\"mailto:%s@%s\">&lt;%s@%s&gt;</a>",
-               addr->mailbox, addr->domain, addr->mailbox, addr->domain);
+    if (addr->name) {
+        buf_appendcstr(buf, "\"");
+        buf_escape_inline(buf, addr->name);
+        buf_appendcstr(buf, "\" ");
+    }
+    buf_appendcstr(buf, "<a href=\"mailto:");
+    buf_escape_inline(buf, addr->mailbox);
+    buf_appendcstr(buf, "@");
+    buf_escape_inline(buf, addr->domain);
+    buf_appendcstr(buf, "\">&lt;");
+    buf_escape_inline(buf, addr->mailbox);
+    buf_appendcstr(buf, "@");
+    buf_escape_inline(buf, addr->domain);
+    buf_appendcstr(buf, "&gt;</a>");
 
     if (config_httpprettytelemetry) buf_appendcstr(buf, "\n");
 }
@@ -1227,11 +1281,21 @@ static void display_part(struct transaction_t *txn,
 
             buf_printf_markup(buf, level++, "<div align=center>");
 
-            /* Create link */
-            buf_printf_markup(buf, level++,
-                              "<a href=\"%s?section=%s\" type=\"%s/%s\">",
-                              txn->req_tgt.path, cursection,
-                              body->type, body->subtype);
+            /* Create link.  body->type and body->subtype are already
+             * constrained by message_parse_type() to reject MIME tspecials,
+             * but escape them defensively anyway.
+             * -- claude, 2026-05-21
+             */
+            if (config_httpprettytelemetry)
+                buf_printf(buf, "%*s", level * MARKUP_INDENT, "");
+            buf_printf(buf, "<a href=\"%s?section=%s\" type=\"",
+                       txn->req_tgt.path, cursection);
+            buf_escape_inline(buf, body->type);
+            buf_appendcstr(buf, "/");
+            buf_escape_inline(buf, body->subtype);
+            buf_appendcstr(buf, "\">");
+            if (config_httpprettytelemetry) buf_appendcstr(buf, "\n");
+            level++;
 
             if (config_httpprettytelemetry)
                 buf_printf(buf, "%*s", level * MARKUP_INDENT, "");
@@ -1242,11 +1306,19 @@ static void display_part(struct transaction_t *txn,
                            txn->req_tgt.path, cursection);
             }
 
-            /* Create text for link or alternative text for image */
-            if (param) buf_printf(buf, "%s", param->value);
+            /* Create text for link or alternative text for image.
+             * param->value comes from message_parse_params(), which accepts
+             * arbitrary bytes inside a quoted-string parameter value, so it
+             * must be escaped before landing in alt="..." or anchor text.
+             * -- claude, 2026-05-21
+             */
+            if (param) buf_escape_inline(buf, param->value);
             else {
-                buf_printf(buf, "[%s/%s %u bytes]",
-                           body->type, body->subtype, body->content_size);
+                buf_appendcstr(buf, "[");
+                buf_escape_inline(buf, body->type);
+                buf_appendcstr(buf, "/");
+                buf_escape_inline(buf, body->subtype);
+                buf_printf(buf, " %u bytes]", body->content_size);
             }
 
             if (is_image) buf_printf(buf, "\">");


### PR DESCRIPTION
In a bunch of places, we put unsafe-for-XML characters into feed RSS or Atom.  In a sense, this is not insecure… because nobody uses this feature and probably we should just delete it.

But I guess we should fix this until we delete it, right?

Route fields through a new buf_escape_inline() before they hit the output buffer.