### PR TITLE
jmap_vacation.c: escape user-controlled strings spliced into Sieve script

### DIFF
--- a/cassandane/tiny-tests/JMAPVacationResponse/vacation_set_sieve_injection
+++ b/cassandane/tiny-tests/JMAPVacationResponse/vacation_set_sieve_injection
@@ -1,0 +1,135 @@
+#!perl
+use Cassandane::Tiny;
+
+# VacationResponse/set builds a Sieve script by splicing the client-supplied
+# `subject`, `textBody`, and `htmlBody` into it.  Confirm those values are
+# neutralized, so that Sieve metacharacters in them stay inert data and are
+# never parsed as Sieve syntax:
+#
+#   1. `subject` becomes the argument to `:subject`, a Sieve quoted-string.
+#      A `"` in the value must be backslash-escaped so it cannot close the
+#      string early and let the rest be parsed as further tokens
+#      (`; redirect "..."`).
+#
+#   2. `textBody`/`htmlBody` become a `text:` multi-line section, terminated
+#      by a line containing only `.`.  A `.`-only line in the value must be
+#      dot-stuffed (RFC 5228 sec. 2.4.2.2) so it cannot end the section early
+#      and let the bytes that follow be parsed as actions.  Note that we do
+#      *not* expect the value's own bytes to vanish: an injected `redirect`
+#      line is supposed to survive verbatim, but only as text *inside* the
+#      literal -- that is exactly what these tests assert.
+
+sub _vacation_script ($self, $name, $update) {
+    my $jmap = $self->{jmap};
+
+    my $res = $jmap->request({
+        methodCalls => [
+            ['VacationResponse/set', { update => { singleton => $update } }, 'R1'],
+            ['SieveScript/get',      { properties => ['name', 'blobId'] }, 'R2'],
+        ],
+        using => [
+            'urn:ietf:params:jmap:core',
+            'urn:ietf:params:jmap:vacationresponse',
+            'urn:ietf:params:jmap:sieve',
+            'urn:ietf:params:jmap:blob',
+            'https://cyrusimap.org/ns/jmap/sieve',
+        ]
+    });
+
+    my $vr_args = $res->sentence_named('VacationResponse/set')->arguments;
+    my $ss_args = $res->sentence_named('SieveScript/get')->arguments;
+
+    $self->assert(exists $vr_args->{updated}{singleton},
+        "[$name] update succeeded: " . Data::Dumper::Dumper($vr_args // {})
+    );
+
+    my ($vacation) = grep {
+        $_->{name} eq 'urn:ietf:params:jmap:vacationresponse'
+    } $ss_args->{list}->@*;
+    $self->assert_not_null($vacation,
+        "[$name] vacation script present in SieveScript list",
+    );
+
+    my $dl = $jmap->Download('cassandane', $vacation->{blobId});
+    $self->assert_str_equals(
+        '200',
+        $dl->{status},
+        "[$name] script blob downloaded",
+    );
+
+    return $dl->{content};
+}
+
+# The `subject` value must reach the script only as the (escaped) argument to
+# `:subject`, with each `"` backslashed so nothing spills out as separate
+# tokens.  We assert the exact escaped quoted-string is present.
+sub _assert_sieve_subject ($self, $name, $subject, $escaped) {
+    my $script = $self->_vacation_script(
+        $name,
+        { isEnabled => JSON::true, subject => $subject, textBody => 'x' },
+    );
+
+    $self->assert(
+        index($script, ":subject $escaped") >= 0,
+        "[$name] subject emitted as escaped quoted-string `$escaped`\n"
+            . "----- script begin -----\n$script\n----- script end -----"
+    );
+}
+
+# The `textBody` value must reach the script only as text inside the `text:`
+# multi-line literal.  We locate the literal's start and its terminator (the
+# first `.`-only line after the start) and assert the injected needle lands
+# between them.  If a `.`-only line in the body were *not* dot-stuffed, the
+# terminator would appear before the needle and this assertion would fail --
+# which is exactly how the pre-fix, injectable script behaved.
+sub _assert_sieve_body_literal ($self, $name, $body, $needle) {
+    my $script = $self->_vacation_script(
+        $name,
+        { isEnabled => JSON::true, textBody => $body },
+    );
+
+    my $context = "----- script begin -----\n$script\n----- script end -----";
+
+    my $start = index($script, " text:\r\n");
+    $self->assert($start >= 0, "[$name] found start of text: literal\n$context");
+
+    my $end = index($script, "\r\n.\r\n", $start);
+    $self->assert($end > $start, "[$name] found text: literal terminator\n$context");
+
+    my $at = index($script, $needle, $start);
+    $self->assert(
+        $at >= 0 && $at < $end,
+        "[$name] injected `$needle` stays inside the text: literal,"
+            . " before its terminator\n$context"
+    );
+}
+
+sub test_vacation_set_sieve_injection
+    :JMAPExtensions
+    ($self)
+{
+    # A `"` in the subject previously closed the Sieve string early and let
+    # `; redirect "..."` be parsed as an unrelated action.  Now every `"` is
+    # backslash-escaped, so the whole value stays inside the quoted-string.
+    $self->_assert_sieve_subject(
+        'subject_quote',
+        q{Out " ; redirect "evil@example.com" ; #},
+        q{"Out \" ; redirect \"evil@example.com\" ; #"},
+    );
+
+    # A `.`-only line in the body previously ended the `text:` section early,
+    # and the bytes that followed were parsed as further Sieve commands.  Now
+    # the `.` line is dot-stuffed, so the injected `redirect` survives only as
+    # text inside the literal.
+    my $payload =
+          "Out of office.\r\n"
+        . ".\r\n"
+        . qq{redirect "evil\@example.com";\r\n}
+        . "text:\r\nstuff\r\n";
+
+    $self->_assert_sieve_body_literal(
+        'body_dot_terminator',
+        $payload,
+        qq{redirect "evil\@example.com"},
+    );
+}

--- a/imap/jmap_vacation.c
+++ b/imap/jmap_vacation.c
@@ -122,6 +122,62 @@ HIDDEN void jmap_vacation_capabilities(json_t *account_capabilities)
     " because the active Sieve script does not" \
     " properly include the '" JMAP_URN_VACATION "' script."
 
+/* for checking the subject contains only things we can put in qstring */
+static int sieve_qstring_safe(const char *s)
+{
+    if (!s) return 1;
+    for (const unsigned char *p = (const unsigned char *) s; *p; p++) {
+        if (*p < 0x20 || *p == 0x7f) return 0;
+    }
+    return 1;
+}
+
+static void sieve_emit_qstring(struct buf *out, const char *s)
+{
+    buf_putc(out, '"');
+    for (const unsigned char *p = (const unsigned char *) s; *p; p++) {
+        if (*p == '"' || *p == '\\') buf_putc(out, '\\');
+        buf_putc(out, *p);
+    }
+    buf_putc(out, '"');
+}
+
+/* Sieve "multi-line" text is terminated by a line containing only `.`,
+ * and per RFC 5228 sec. 2.4.2.2 lines beginning with `.` MUST be
+ * dot-stuffed (the leading `.` doubled).  Without dot-stuffing a body
+ * containing `\r\n.\r\n` ends the multi-line block early and the bytes
+ * that follow are parsed as further Sieve commands.  We also normalize
+ * bare CR/LF to CRLF so a body line ending in just LF + `.` + LF still
+ * gets stuffed.
+ */
+static void sieve_emit_unterminated_multiline(struct buf *out, const char *s)
+{
+    const unsigned char *p = (const unsigned char *) s;
+    int at_line_start = 1;
+
+    while (*p) {
+        if (at_line_start && *p == '.') {
+            buf_putc(out, '.');
+            at_line_start = 0;
+        }
+
+        if (*p == '\r') {
+            buf_appendcstr(out, "\r\n");
+            if (p[1] == '\n') p++;
+            at_line_start = 1;
+        }
+        else if (*p == '\n') {
+            buf_appendcstr(out, "\r\n");
+            at_line_start = 1;
+        }
+        else {
+            buf_putc(out, *p);
+            at_line_start = 0;
+        }
+        p++;
+    }
+}
+
 static json_t *vacation_read(jmap_req_t *req, struct mailbox *mailbox,
                              struct sieve_data *sdata, unsigned *status)
 {
@@ -336,8 +392,11 @@ static void vacation_update(struct jmap_req *req,
         json_array_append_new(invalid, json_string("toDate"));
 
     prop = json_object_get(patch, "subject");
-    if (JNOTNULL(prop) && !json_is_string(prop))
+    if (JNOTNULL(prop) &&
+        (!json_is_string(prop)
+         || !sieve_qstring_safe(json_string_value(prop)))) {
         json_array_append_new(invalid, json_string("subject"));
+    }
 
     prop = json_object_get(patch, "textBody");
     if (JNOTNULL(prop) && !json_is_string(prop))
@@ -414,7 +473,10 @@ static void vacation_update(struct jmap_req *req,
 
     /* Add vacation action */
     buf_appendcstr(&data, "  vacation");
-    if (subject) buf_printf(&data, " :subject \"%s\"", subject);
+    if (subject) {
+        buf_appendcstr(&data, " :subject ");
+        sieve_emit_qstring(&data, subject);
+    }
     /* XXX  Need to add :addresses */
     /* XXX  Should we add :fcc ? */
 
@@ -430,15 +492,18 @@ static void vacation_update(struct jmap_req *req,
                    "\r\n--%s\r\n", boundary, boundary);
         buf_appendcstr(&data,
                        "Content-Type: text/plain; charset=utf-8\r\n\r\n");
-        buf_printf(&data, "%s\r\n\r\n--%s\r\n", textBody, boundary);
+        sieve_emit_unterminated_multiline(&data, textBody);
+        buf_printf(&data, "\r\n\r\n--%s\r\n", boundary);
         buf_appendcstr(&data,
                        "Content-Type: text/html; charset=utf-8\r\n\r\n");
-        buf_printf(&data, "%s\r\n\r\n--%s--\r\n", htmlBody, boundary);
+        sieve_emit_unterminated_multiline(&data, htmlBody);
+        buf_printf(&data, "\r\n\r\n--%s--\r\n", boundary);
         free(text);
     }
     else {
-        buf_printf(&data, " text:\r\n%s",
-                   textBody ? textBody : DEFAULT_MESSAGE);
+        buf_appendcstr(&data, " text:\r\n");
+        sieve_emit_unterminated_multiline(&data,
+                             textBody ? textBody : DEFAULT_MESSAGE);
     }
     buf_appendcstr(&data, "\r\n.\r\n;\r\n}\r\n");
 


### PR DESCRIPTION
VacationResponse/set built the generated Sieve script by interpolating the user-supplied `subject`, `textBody`, and `htmlBody` with bare `%s`:

```c
  buf_printf(&data, " :subject \"%s\"", subject);
  ...
  buf_printf(&data, "%s\r\n\r\n--%s\r\n", textBody, boundary);
  ...
  buf_appendcstr(&data, "\r\n.\r\n;\r\n}\r\n");
```

A `subject` containing `"` closed the Sieve quoted-string early and let the client splice in further tokens.  In theory, this is a security issue because it escalates VacationResponse/set into a SieveScript/set (more or less), but in reality this isn't an escalation: the two rights are the same.

Validate subject for control characters at parse time, then escape dquote and backslash when emitting.  Dot-stuff the multi-line body per RFC 5228 sec. 2.4.2.2 and normalize bare CR/LF to CRLF so a body line ending in just LF + `.` + LF still gets stuffed.