### PR TITLE
Log delays in calalarmd

### DIFF
--- a/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
@@ -27,6 +27,7 @@ sub new
     $config->set(caldav_historical_age => -1);
     $config->set(calendar_minimum_alarm_interval => '61s');
     $config->set(jmap_nonstandard_extensions => 'yes');
+    $config->set(auditlog => 'yes');
 
     my $self = $class->SUPER::new({
         config => $config,

--- a/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
@@ -31,7 +31,8 @@ sub new
                  jmapsubmission_deleteonsend => 'no',
                  jmap_nonstandard_extensions => 'yes',
                  httpmodules => 'carddav caldav jmap',
-                 httpallowcompress => 'no');
+                 httpallowcompress => 'no',
+                 auditlog => 'yes');
 
     my $self = $class->SUPER::new({
         config => $config,

--- a/cassandane/tiny-tests/CaldavAlarm/alarm_send_delay_auditlog
+++ b/cassandane/tiny-tests/CaldavAlarm/alarm_send_delay_auditlog
@@ -1,0 +1,71 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_alarm_send_delay_auditlog
+    :min_version_3_13 :needs_component_calalarmd
+    ($self)
+{
+    return if !$self->{instance}->{have_syslog_replacement};
+
+    my $CalDAV = $self->{caldav};
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $now = DateTime->now();
+    $now->set_time_zone('UTC');
+    # bump everything forward so a slow run (say: valgrind)
+    # doesn't cause things to magically fire...
+    $now->add(DateTime::Duration->new(seconds => 300));
+
+    # define the event to start in a few seconds, with a DISPLAY alarm
+    # at start, so the alarm trigger time is in the past once calalarmd
+    # is run well after it.
+    my $startdt = $now->clone();
+    $startdt->add(DateTime::Duration->new(seconds => 2));
+    my $startstr = $startdt->strftime('%Y%m%dT%H%M%S');
+
+    my $uuid = "12345678-1234-1234-1234-123456789abc";
+    my $href = "$CalendarId/$uuid.ics";
+    my $ics = <<"EOF";
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Cassandane//NONSGML//EN
+BEGIN:VEVENT
+UID:$uuid
+DTSTAMP:${startstr}Z
+DTSTART:${startstr}Z
+DURATION:PT1H
+SUMMARY:delay test event
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:alarm
+TRIGGER:PT0S
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $CalDAV->Request('PUT', $href, $ics,
+                     'Content-Type' => 'text/calendar');
+
+    # drain syslog so we only see lines from the calalarmd run below
+    $self->{instance}->getsyslog();
+
+    xlog $self, "run calalarmd after the alarm trigger time";
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd',
+                                   '-t' => $now->epoch() + 60);
+
+    my @lines = $self->{instance}->getsyslog(
+        qr/auditlog\.calalarmd\.send\.imip/);
+    $self->assert_num_equals(1, scalar @lines);
+
+    # n.b. CaldavAlarm.pm "use POSIX" shadows the assert() method, so
+    # assert_matches (which calls $self->assert) can't be used here;
+    # express the pattern checks via assert_num_equals on a boolean instead.
+    $self->assert_num_equals(1,
+        ($lines[0] =~ /send\.delay=<?\d+>?/) ? 1 : 0,
+        "audit line should have a parseable send.delay: $lines[0]");
+    $self->assert_num_equals(1,
+        ($lines[0] =~ /cal\.uid=/) ? 1 : 0,
+        "audit line should have a cal.uid: $lines[0]");
+}

--- a/cassandane/tiny-tests/JMAPEmailSubmission/emailsubmission_send_delay_auditlog
+++ b/cassandane/tiny-tests/JMAPEmailSubmission/emailsubmission_send_delay_auditlog
@@ -1,0 +1,64 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_emailsubmission_send_delay_auditlog
+    :min_version_3_13 :needs_component_calalarmd
+    ($self)
+{
+    return if !$self->{instance}->{have_syslog_replacement};
+
+    my $jmap = $self->{jmap};
+
+    my $res = $jmap->CallMethods([['Identity/get', {}, "R0"]]);
+    my $identityid = $res->[0][1]->{list}[0]->{id};
+    $self->assert_not_null($identityid);
+
+    xlog $self, "Generate an email via IMAP";
+    $self->make_message("foo", body => "a body\r\n") or die;
+
+    $res = $jmap->CallMethods([['Email/query', {}, "R1"]]);
+    my $emailid = $res->[0][1]->{ids}[0];
+
+    xlog $self, "create a scheduled (held) email submission";
+    $res = $jmap->CallMethods([['EmailSubmission/set', {
+        create => {
+            '1' => {
+                identityId => $identityid,
+                emailId  => $emailid,
+                envelope => {
+                    mailFrom => {
+                        email => 'from@localhost',
+                        parameters => { "holdfor" => "30" },
+                    },
+                    rcptTo => [
+                        { email => 'rcpt1@localhost' },
+                        { email => 'rcpt2@localhost' },
+                    ],
+                },
+            },
+        },
+    }, "R2"]]);
+    my $subid = $res->[0][1]->{created}{1}{id};
+    $self->assert_not_null($subid);
+
+    # drain syslog so we only see lines from the calalarmd run below
+    $self->{instance}->getsyslog();
+
+    xlog $self, "trigger delivery well after the scheduled time";
+    my $now = DateTime->now();
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd',
+                                   '-t' => $now->epoch() + 120);
+
+    $res = $jmap->CallMethods([['EmailSubmission/get',
+                                { ids => [$subid] }, "R3"]]);
+    $self->assert_str_equals('final',
+                             $res->[0][1]->{list}[0]->{undoStatus});
+
+    xlog $self, "audit log records the send with a parseable delay";
+    my @lines = $self->{instance}->getsyslog(
+        qr/auditlog\.calalarmd\.send\.futurerelease/);
+    $self->assert_num_equals(1, scalar @lines);
+    $self->assert_matches(qr/send\.outcome=<?sent>?/, $lines[0]);
+    $self->assert_matches(qr/send\.delay=<?\d+>?/, $lines[0]);
+    $self->assert_matches(qr/send\.numrcpts=<?2>?/, $lines[0]);
+}

--- a/changes/next/cyr-2097-log-calalarmd-delay
+++ b/changes/next/cyr-2097-log-calalarmd-delay
@@ -1,0 +1,29 @@
+Description:
+
+calalarmd now logs the scheduled-vs-actual send delay for every send it
+performs, via a new "auditlog.calalarmd.send.*" audit event (actions
+futurerelease, snooze, and imip) that includes a machine-parseable
+"send.delay" field in seconds plus the username and message detail. It
+also exports three bucketed prometheus counters -
+cyrus_calalarmd_futurerelease_delay_total,
+cyrus_calalarmd_snooze_delay_total and cyrus_calalarmd_imip_delay_total -
+each labelled by delay band (ontime/late/slow/verylate), so send backlog
+can be graphed and alerted on.
+
+Documentation:
+
+None (audit events and prometheus metrics are self-documented in the source:
+imap/auditlog.c and imap/promdata.p).
+
+Config changes:
+
+None. The audit lines require the existing "auditlog" option; the prometheus
+counters require the existing "prometheus_enabled" option.
+
+Upgrade instructions:
+
+None.
+
+GitHub issue:
+
+None

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -330,6 +330,40 @@ EXPORTED void auditlog_sieve(const char *action,
     auditlog_finish(&lf);
 }
 
+EXPORTED void auditlog_send(const struct auditlog_send *s)
+{
+    struct logfmt lf = LOGFMT_INITIALIZER;
+
+    if (!config_auditlog) return;
+
+    auditlog_begin(&lf, s->action);
+
+    if (s->userid)
+        logfmt_push(&lf, "u.username", s->userid);
+
+    logfmt_push(&lf, "send.outcome", s->outcome);
+    logfmt_pushf(&lf, "send.scheduled", TIME_T_FMT, s->scheduled);
+    logfmt_pushf(&lf, "send.time", TIME_T_FMT, s->sent);
+    logfmt_pushf(&lf, "send.delay", "%lld",
+                 (long long)(s->sent - s->scheduled));
+    logfmt_pushf(&lf, "send.retries", "%u", s->num_retries);
+
+    if (s->num_rcpts)
+        logfmt_pushf(&lf, "send.numrcpts", "%u", s->num_rcpts);
+    if (s->msgid)
+        logfmt_push(&lf, "msg.id", s->msgid);
+    if (s->from)
+        logfmt_push(&lf, "msg.from", s->from);
+    if (s->to)
+        logfmt_push(&lf, "msg.to", s->to);
+    if (s->subject)
+        logfmt_push_utf8(&lf, "msg.subject", s->subject);
+    if (s->caluid)
+        logfmt_push(&lf, "cal.uid", s->caluid);
+
+    auditlog_finish(&lf);
+}
+
 EXPORTED void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out)
 {
     struct logfmt lf = LOGFMT_INITIALIZER;

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -90,6 +90,25 @@ extern void auditlog_sieve(const char *action,
                            const char *vac_from_addr,
                            const char *vac_to_addr);
 
+/** @brief A calalarmd send event, for auditlog_send() */
+struct auditlog_send {
+    const char *action;    /* e.g. "calalarmd.send.futurerelease" */
+    const char *outcome;   /* "sent" | "cancelled" | "unsnoozed" */
+    const char *userid;
+    time_t scheduled;      /* when it should have been sent */
+    time_t sent;           /* when calalarmd actually sent it */
+    const char *msgid;     /* optional */
+    const char *from;      /* optional */
+    const char *to;        /* optional; first rcpt, num_rcpts carries the count */
+    const char *subject;   /* optional; pushed via logfmt_push_utf8 */
+    const char *caluid;    /* optional (imip) */
+    unsigned num_rcpts;    /* 0 = omit */
+    unsigned num_retries;
+};
+
+/** @brief Log a calalarmd send with scheduled-vs-actual delay */
+extern void auditlog_send(const struct auditlog_send *s);
+
 /** @brief Log session traffic statistics */
 extern void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out);
 

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -614,6 +614,9 @@ static int process_alarm_cb(icalcomponent *comp,
                 int sr = send_alarm(data, comp, alarm, start, end,
                                     recurid, is_standalone, alarmtime);
                 if (!sr) {
+                    /* outcome "sent" reflects successful dispatch to the
+                     * notification subsystem; send_alarm() can't report
+                     * downstream delivery failure */
                     struct auditlog_send as = {
                         .action = "calalarmd.send.imip",
                         .outcome = "sent",

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -2084,6 +2084,20 @@ static int process_snoozed(struct caldav_alarm_data *data,
         caldav_alarm_bump_nextcheck(data, runtime + 300, runtime, error_message(r));
     }
 
+    if (!r) {
+        char *userid = mboxname_to_userid(mailbox_name(mailbox));
+        struct auditlog_send as = {
+            .action = "calalarmd.send.snooze",
+            .outcome = "unsnoozed",
+            .userid = userid,
+            .scheduled = wakeup,
+            .sent = runtime,
+        };
+        auditlog_send(&as);
+        bump_send_delay_metric(ALARM_SNOOZE, runtime - wakeup);
+        free(userid);
+    }
+
  done:
     if (snoozed) json_decref(snoozed);
 

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -25,6 +25,8 @@
 #include "json_support.h"
 #include "libconfig.h"
 #include "mboxevent.h"
+#include "auditlog.h"
+#include "prometheus.h"
 #include "mboxlist.h"
 #include "mboxname.h"
 #include "msgrecord.h"
@@ -1687,6 +1689,57 @@ static int update_unscheduled(const char *mboxname, time_t nextcheck)
     return -1;
 }
 
+#endif /* WITH_JMAP */
+
+/* map a send delay (in seconds) to a bucket band: 0=ontime 1=late 2=slow 3=verylate */
+static int send_delay_band(time_t delay)
+{
+    if (delay <= 10)   return 0;
+    if (delay <= 60)   return 1;
+    if (delay <= 1800) return 2;
+    return 3;
+}
+
+/* bump the prometheus delay counter for the given alarm type */
+static void bump_send_delay_metric(uint32_t type, time_t delay)
+{
+    int band = send_delay_band(delay < 0 ? 0 : delay);
+
+    switch (type) {
+    case ALARM_SEND: {
+        static const enum prom_metric_id b[] = {
+            CYRUS_CALALARMD_FUTURERELEASE_DELAY_TOTAL_BUCKET_ONTIME,
+            CYRUS_CALALARMD_FUTURERELEASE_DELAY_TOTAL_BUCKET_LATE,
+            CYRUS_CALALARMD_FUTURERELEASE_DELAY_TOTAL_BUCKET_SLOW,
+            CYRUS_CALALARMD_FUTURERELEASE_DELAY_TOTAL_BUCKET_VERYLATE,
+        };
+        prometheus_apply_delta(b[band], 1);
+        break;
+    }
+    case ALARM_SNOOZE: {
+        static const enum prom_metric_id b[] = {
+            CYRUS_CALALARMD_SNOOZE_DELAY_TOTAL_BUCKET_ONTIME,
+            CYRUS_CALALARMD_SNOOZE_DELAY_TOTAL_BUCKET_LATE,
+            CYRUS_CALALARMD_SNOOZE_DELAY_TOTAL_BUCKET_SLOW,
+            CYRUS_CALALARMD_SNOOZE_DELAY_TOTAL_BUCKET_VERYLATE,
+        };
+        prometheus_apply_delta(b[band], 1);
+        break;
+    }
+    case ALARM_CALENDAR: {
+        static const enum prom_metric_id b[] = {
+            CYRUS_CALALARMD_IMIP_DELAY_TOTAL_BUCKET_ONTIME,
+            CYRUS_CALALARMD_IMIP_DELAY_TOTAL_BUCKET_LATE,
+            CYRUS_CALALARMD_IMIP_DELAY_TOTAL_BUCKET_SLOW,
+            CYRUS_CALALARMD_IMIP_DELAY_TOTAL_BUCKET_VERYLATE,
+        };
+        prometheus_apply_delta(b[band], 1);
+        break;
+    }
+    }
+}
+
+#ifdef WITH_JMAP
 static int process_futurerelease(struct caldav_alarm_data *data,
                                  struct mailbox *mailbox,
                                  struct index_record *record,
@@ -1699,6 +1752,9 @@ static int process_futurerelease(struct caldav_alarm_data *data,
     smtpclient_t *sm = NULL;
     int do_move = 0;
     int r = 0;
+    char *userid = NULL;
+    struct buf subjbuf = BUF_INITIALIZER;
+    struct buf msgidbuf = BUF_INITIALIZER;
 
     syslog(LOG_DEBUG, "processing future release for mailbox %s uid %u",
            mailbox_name(mailbox), record->uid);
@@ -1735,6 +1791,22 @@ static int process_futurerelease(struct caldav_alarm_data *data,
     if (JNULL(onSend)) {
         /* Treat onSend:null as non-existent */
         onSend = NULL;
+    }
+
+    /* Gather audit detail (valid whether or not the send succeeds) */
+    userid = mboxname_to_userid(mailbox_name(mailbox));
+    message_get_subject(m, &subjbuf);
+    message_get_messageid(m, &msgidbuf);
+
+    const char *env_from = NULL;
+    const char *env_to = NULL;
+    if (JNOTNULL(envelope)) {
+        env_from = json_string_value(
+            json_object_get(json_object_get(envelope, "mailFrom"), "email"));
+        json_t *rcpts = json_object_get(envelope, "rcptTo");
+        if (json_array_size(rcpts))
+            env_to = json_string_value(
+                json_object_get(json_array_get(rcpts, 0), "email"));
     }
 
     /* Load message */
@@ -1805,7 +1877,6 @@ static int process_futurerelease(struct caldav_alarm_data *data,
 
     const char *destmboxid = NULL;
     json_t *setkeywords = NULL;
-    char *userid = NULL;
 
     if (r) {
         /* Determine if we should retry (again) or cancel the submission.
@@ -1819,6 +1890,24 @@ static int process_futurerelease(struct caldav_alarm_data *data,
         default: cancel = 1; break;
         }
 
+        if (cancel) {
+            struct auditlog_send as = {
+                .action = "calalarmd.send.futurerelease",
+                .outcome = "cancelled",
+                .userid = userid,
+                .scheduled = record->internaldate.tv_sec,
+                .sent = runtime,
+                .msgid = buf_len(&msgidbuf) ? buf_cstring(&msgidbuf) : NULL,
+                .from = env_from,
+                .to = env_to,
+                .subject = buf_len(&subjbuf) ? buf_cstring(&subjbuf) : NULL,
+                .num_rcpts = data->num_rcpts,
+                .num_retries = data->num_retries,
+            };
+            auditlog_send(&as);
+            bump_send_delay_metric(ALARM_SEND, runtime - record->internaldate.tv_sec);
+        }
+
         if (!cancel) {
             /* Retry */
             caldav_alarm_bump_nextcheck(data, runtime + duration, runtime, err);
@@ -1829,7 +1918,6 @@ static int process_futurerelease(struct caldav_alarm_data *data,
             /* Move the scheduled message back into Drafts mailbox.
                Use INBOX as a fallback. */
             do_move = 1;
-            userid = mboxname_to_userid(data->mboxname);
 
             char *destname = mboxlist_find_specialuse("\\Drafts", userid);
             mbentry_t *mbentry = NULL;
@@ -1853,6 +1941,22 @@ static int process_futurerelease(struct caldav_alarm_data *data,
     else {
         /* Mark the email as sent */
         record->system_flags |= FLAG_ANSWERED;
+
+        struct auditlog_send as = {
+            .action = "calalarmd.send.futurerelease",
+            .outcome = "sent",
+            .userid = userid,
+            .scheduled = record->internaldate.tv_sec,
+            .sent = runtime,
+            .msgid = buf_len(&msgidbuf) ? buf_cstring(&msgidbuf) : NULL,
+            .from = env_from,
+            .to = env_to,
+            .subject = buf_len(&subjbuf) ? buf_cstring(&subjbuf) : NULL,
+            .num_rcpts = data->num_rcpts,
+            .num_retries = data->num_retries,
+        };
+        auditlog_send(&as);
+        bump_send_delay_metric(ALARM_SEND, runtime - record->internaldate.tv_sec);
 
         /* Get any onSend instructions */
         if (onSend) {
@@ -1883,8 +1987,6 @@ static int process_futurerelease(struct caldav_alarm_data *data,
 
     if (do_move) {
         /* Move the scheduled message into the specified mailbox */
-        if (!userid) userid = mboxname_to_userid(data->mboxname);
-
         const char *emailid =
             json_string_value(json_object_get(submission, "emailId"));
         struct find_sched_rock frock = { userid, NULL, 0 };
@@ -1926,12 +2028,14 @@ static int process_futurerelease(struct caldav_alarm_data *data,
         mailbox_close(&sched_mbox);
         free(frock.mboxname);
     }
-    free(userid);
 
   done:
+    free(userid);
     if (submission) json_decref(submission);
     if (m) message_unref(&m);
     buf_free(&buf);
+    buf_free(&subjbuf);
+    buf_free(&msgidbuf);
 
     return r;
 }

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -469,6 +469,10 @@ static int send_alarm(struct get_alarm_rock *rock,
     return 0;
 }
 
+/* bump the prometheus delay counter for the given alarm type
+ * (defined later in this file; forward-declared for use in process_alarm_cb) */
+static void bump_send_delay_metric(uint32_t type, time_t delay);
+
 static int process_alarm_cb(icalcomponent *comp,
                             icaltimetype start, icaltimetype end,
                             icaltimetype recurid,
@@ -607,7 +611,21 @@ static int process_alarm_cb(icalcomponent *comp,
                        data->mboxname, data->imap_uid,
                        icaltime_as_ical_string(start), alarmno,
                        summary);
-                send_alarm(data, comp, alarm, start, end, recurid, is_standalone, alarmtime);
+                int sr = send_alarm(data, comp, alarm, start, end,
+                                    recurid, is_standalone, alarmtime);
+                if (!sr) {
+                    struct auditlog_send as = {
+                        .action = "calalarmd.send.imip",
+                        .outcome = "sent",
+                        .userid = data->userid,
+                        .scheduled = check,
+                        .sent = data->now,
+                        .subject = summary,
+                        .caluid = icalcomponent_get_uid(comp),
+                    };
+                    auditlog_send(&as);
+                    bump_send_delay_metric(ALARM_CALENDAR, data->now - check);
+                }
             }
         }
 

--- a/imap/promdata.p
+++ b/imap/promdata.p
@@ -151,3 +151,9 @@ metric counter cyrus_http_unbind_total            The total number of HTTP UNBIN
     label cyrus_http_unbind_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive cgi convert
 metric counter cyrus_http_unlock_total            The total number of HTTP UNLOCKs
     label cyrus_http_unlock_total namespace default admin applepush calendar freebusy addressbook principal notify dblookup ischedule domainkeys jmap prometheus rss tzdist drive cgi convert
+metric counter cyrus_calalarmd_futurerelease_delay_total   Delayed-email sends bucketed by scheduled-vs-actual delay
+    label cyrus_calalarmd_futurerelease_delay_total bucket ontime late slow verylate
+metric counter cyrus_calalarmd_snooze_delay_total          Snoozed-email wakeups bucketed by scheduled-vs-actual delay
+    label cyrus_calalarmd_snooze_delay_total bucket ontime late slow verylate
+metric counter cyrus_calalarmd_imip_delay_total            iMIP calendar-alarm sends bucketed by scheduled-vs-actual delay
+    label cyrus_calalarmd_imip_delay_total bucket ontime late slow verylate


### PR DESCRIPTION
I've had this task sitting around for ages - it's useful to have stats on delayed sends and more syslog to help support figure out what happened.

I'll cut the Claude plans out when actually submitting