### PR TITLE
quota: keep -J output valid JSON when repairs happen

### DIFF
--- a/cassandane/Cassandane/Cyrus/Quota.pm
+++ b/cassandane/Cassandane/Cyrus/Quota.pm
@@ -7,6 +7,7 @@ use warnings;
 use Cwd qw(abs_path);
 use DateTime;
 use Data::Dumper;
+use JSON::XS;
 
 use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;

--- a/cassandane/tiny-tests/Quota/quota_json_repairs
+++ b/cassandane/tiny-tests/Quota/quota_json_repairs
@@ -1,0 +1,57 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_quota_json_repairs ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+
+    xlog $self, "set ourselves a basic usage quota";
+    $self->set_quotalimits(
+        quotaroot => 'user.cassandane',
+        storage => 100000,
+        message => 50000,
+        $self->res_annot_storage => 10000,
+    );
+
+    xlog $self, "create some messages to use various quota resources";
+    my $expected_storage = 0;
+    my $expected_message = 0;
+    for (1..3) {
+        my $msg = $self->make_message("Cassandane $_", extra_lines => 5000);
+        $expected_storage += length($msg->as_string());
+        $expected_message++;
+    }
+
+    xlog $self, "corrupt the stored usage so quota -f will repair it";
+    $self->zap_quota(quotaroot => 'user.cassandane');
+
+    xlog $self, "run quota -f -J, capturing stdout and stderr separately";
+    my $basedir = $self->{instance}->{basedir};
+    my $outfile = "$basedir/quota.json";
+    my $errfile = "$basedir/quota.err";
+    $self->{instance}->run_command({
+        cyrus => 1,
+        redirects => { stdout => $outfile, stderr => $errfile },
+    }, 'quota', '-f', '-J');
+
+    xlog $self, "stdout must be valid JSON even though repairs happened";
+    my $out = slurp_file($outfile);
+    my $json = decode_json($out);
+
+    xlog $self, "repairs are reported in a top-level _repairs array";
+    $self->assert(exists $json->{_repairs});
+    $self->assert_str_equals('ARRAY', ref $json->{_repairs});
+    $self->assert_num_not_equals(0, scalar @{$json->{_repairs}});
+
+    xlog $self, "quota roots are still reported alongside the repairs";
+    # JSON reports raw usage (bytes for STORAGE, count for MESSAGE), not KiB
+    $self->assert(exists $json->{'user.cassandane'});
+    $self->assert_num_equals($expected_storage,
+                             $json->{'user.cassandane'}{STORAGE}{used});
+    $self->assert_num_equals($expected_message,
+                             $json->{'user.cassandane'}{MESSAGE}{used});
+
+    xlog $self, "repair text went into the JSON, not onto stderr";
+    my $err = slurp_file($errfile);
+    $self->assert_does_not_match(qr/usage was/, $err);
+}

--- a/imap/quota.c
+++ b/imap/quota.c
@@ -227,6 +227,35 @@ errmsg(int err, const char *fmt, ...)
     fprintf(stderr, "%s\n", buf);
 }
 
+/*
+ * Report a repair action.  In JSON mode these are collected into a top-level
+ * "_repairs" array so that the output remains valid JSON even when stdout and
+ * stderr are captured together; otherwise they're printed to stderr as before.
+ */
+static void
+__attribute__((format(printf, 1, 2)))
+report_repair(const char *fmt, ...)
+{
+    char buf[1024];
+    va_list ap;
+
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+
+    if (jsonout) {
+        json_t *repairs = json_object_get(jsonout, "_repairs");
+        if (!repairs) {
+            repairs = json_array();
+            json_object_set_new(jsonout, "_repairs", repairs);
+        }
+        json_array_append_new(repairs, json_string(buf));
+    }
+    else {
+        fprintf(stderr, "%s\n", buf);
+    }
+}
+
 static void test_sync_wait(const char *mboxname)
 {
     char *filename;
@@ -516,7 +545,7 @@ int fixquota_fixroot(struct mailbox *mailbox,
                      const char *root)
 {
     const char *oldroot = mailbox_quotaroot(mailbox);
-    fprintf(stderr, "%s: quota root %s --> %s\n", mailbox_name(mailbox),
+    report_repair("%s: quota root %s --> %s", mailbox_name(mailbox),
            oldroot ? oldroot : "(none)",
            root ? root : "(none)");
 
@@ -538,7 +567,7 @@ int fixquota_finish(int thisquota)
 
     if (!quotaroots[thisquota].refcount) {
         quotaroots[thisquota].deleted = 1;
-        fprintf(stderr, "%s: removed\n", root);
+        report_repair("%s: removed", root);
         if (!flag_reportonly)
             r = quota_deleteroot(root, 0);
         if (r) {
@@ -558,7 +587,7 @@ int fixquota_finish(int thisquota)
     /* is it different? */
     for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
         if (localq.scanuseds[res] != localq.useds[res]) {
-            fprintf(stderr, "%s: %s usage was " QUOTA_T_FMT ", now " QUOTA_T_FMT "\n",
+            report_repair("%s: %s usage was " QUOTA_T_FMT ", now " QUOTA_T_FMT,
                 root,
                 quota_names[res],
                 localq.useds[res],


### PR DESCRIPTION
Repair diagnostics from `quota -f` were printed as plain text to stderr, so capturing combined output (e.g. `quota -f -J 2>&1 | jq`) interleaved those lines with the JSON report on stdout and it no longer parsed.

In JSON mode, collect repair messages into a top-level "_repairs" array (leading underscore so consumers can skip metadata keys) instead of printing them; the non-JSON path still writes to stderr as before.