### PR TITLE
http_caldav_sched.c: improve logging for ignored scheduling objects

### DIFF
--- a/cassandane/tiny-tests/Caldav/schedule_organizer_mismatch
+++ b/cassandane/tiny-tests/Caldav/schedule_organizer_mismatch
@@ -1,0 +1,46 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_schedule_organizer_mismatch
+    ($self)
+{
+    my $caldav = $self->default_user->caldav;
+
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+    my $href = "Default/$uuid.ics";
+
+    # cassandane is neither the ORGANIZER nor an ATTENDEE of this event
+    my $event = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:$uuid
+DTEND;TZID=Australia/Melbourne:20160831T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=Australia/Melbourne:20160831T153000
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:unknown-attendee\@example.com
+ORGANIZER:MAILTO:unknown-organizer\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    # clean notification and syslog cache
+    $self->{instance}->getnotify();
+    $self->{instance}->getsyslog();
+
+    xlog $self, "PUT an event with an unknown ORGANIZER";
+    $caldav->Request('PUT', $href, $event,
+                     'Content-Type' => 'text/calendar');
+
+    xlog $self, "Verify that no iMIP message is sent";
+    $self->assert_caldav_notified();
+
+    xlog $self, "We should have generated a syslog message about the mismatch";
+    $self->assert_syslog_matches($self->{instance},
+        qr/Not scheduling calendar component/);
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_organizer_mismatch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_organizer_mismatch
@@ -1,0 +1,53 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_set_schedule_organizer_mismatch
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $default_cal_id = $self->default_user->calendars->default->id;
+
+    # clean notification and syslog cache
+    $self->{instance}->getnotify();
+    $self->{instance}->getsyslog();
+
+    xlog $self, "create event with an unknown ORGANIZER";
+    my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
+        1 => {
+            version => "2.0",
+            calendarIds => {
+                $default_cal_id => JSON::true,
+            },
+            title => "foo",
+            showWithoutTime => JSON::false,
+            start => "2015-10-06T16:45:00",
+            timeZone => "Australia/Melbourne",
+            duration => "PT1H",
+            organizerCalendarAddress => "mailto:unknown-organizer\@example.com",
+            participants => {
+                org => {
+                    name => "Unknown Organizer",
+                    calendarAddress => 'mailto:unknown-organizer@example.com',
+                    roles => {
+                        owner => JSON::true,
+                    },
+                },
+                att => {
+                    name => "Unknown Attendee",
+                    calendarAddress => 'mailto:unknown-attendee@example.com',
+                },
+            },
+        }
+    }}, "R1"]]);
+    my $id = $res->[0][1]{created}{1}{id};
+    $self->assert_not_null($id);
+
+    xlog $self, "Verify that no iMIP message is sent";
+    my $data = $self->{instance}->getnotify();
+    my ($imip) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_null($imip);
+
+    xlog $self, "We should have generated a syslog message about the mismatch";
+    $self->assert_syslog_matches($self->{instance},
+        qr/Not scheduling calendar component/);
+}

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -1192,7 +1192,7 @@ static int _scheduling_enabled(struct transaction_t *txn,
         !strcasecmp(buf_cstring(&buf), "F")) {
         is_enabled = 0;
 
-        syslog(LOG_DEBUG, "Scheduling disabled for user %s on mailbox %s"
+        syslog(LOG_WARNING, "Scheduling disabled for user %s on mailbox %s"
                " by CY:scheduling-enabled annotation",
                httpd_userid, mailbox_name(mailbox));
     }

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -2507,7 +2507,7 @@ void sched_request(const char *cal_ownerid, const char *sched_userid,
 
     if (!(rights & DACL_INVITE)) {
         /* DAV:need-privileges */
-        syslog(LOG_DEBUG,
+        syslog(LOG_WARNING,
                "No schedule-send-invite privilege for user %s on Outbox %s",
                httpd_userid, organizer);
 
@@ -2600,6 +2600,7 @@ struct reply_data {
     int master_send;
     int do_send;
     icalparameter_scheduleforcesend force_send;
+    bool found_attendee;  /* one of our schedule addresses is an attendee */
 };
 
 
@@ -2720,6 +2721,8 @@ static void schedule_sub_declines(const char *attendee,
         if (!find_attendee(comp, attendee))
             continue;
 
+        reply->found_attendee = true;
+
         /* no organizer, can't do anything */
         const char *organizer = get_organizer(comp);
         if (!organizer) continue;
@@ -2795,6 +2798,8 @@ static void schedule_sub_replies(const char *attendee,
         if (!find_attendee(comp, attendee))
             continue;
 
+        reply->found_attendee = true;
+
         /* no organizer, can't do anything */
         const char *organizer = get_organizer(comp);
         if (!organizer) continue;
@@ -2848,6 +2853,8 @@ static void schedule_full_decline(const char *attendee,
     icalcomponent *mastercomp = find_attended_component(oldical, "", attendee);
     if (!mastercomp) return;
 
+    reply->found_attendee = true;
+
     reply->organizer = get_organizer(mastercomp);
     if (!reply->organizer) return;
 
@@ -2892,6 +2899,8 @@ static void schedule_full_reply(const char *attendee,
         schedule_full_decline(attendee, h_cutoff, oldical, newical, reply);
         return;
     }
+
+    reply->found_attendee = true;
 
     reply->organizer = get_organizer(mastercomp);
     if (!reply->organizer) return;
@@ -2984,7 +2993,7 @@ void sched_reply(const char *cal_ownerid, const char *sched_userid,
 
     if (!(rights & DACL_REPLY)) {
         /* DAV:need-privileges */
-        syslog(LOG_DEBUG,
+        syslog(LOG_WARNING,
                "No schedule-send-reply privilege for user %s on Outbox %s",
                httpd_userid, sched_userid);
         update_organizer_status(newical, NULL, SCHEDSTAT_NOPRIVS);
@@ -3001,15 +3010,18 @@ void sched_reply(const char *cal_ownerid, const char *sched_userid,
      * send the accepts if any */
     icaltimetype h_cutoff = caldav_get_historical_cutoff();
 
+    bool found_attendee = false;
     int i;
     for (i = 0; i < strarray_size(schedule_addresses); i++) {
         const char *attendee = strarray_nth(schedule_addresses, i);
-        struct reply_data reply = { NULL, NULL, NULL, 0, 0, ICAL_SCHEDULEFORCESEND_NONE };
+        struct reply_data reply = { NULL, NULL, NULL, 0, 0, ICAL_SCHEDULEFORCESEND_NONE, false };
         if (!strncasecmp(attendee, "mailto:", 7)) attendee += 7;
 
         schedule_full_reply(attendee, h_cutoff, oldical, newical, &reply);
         schedule_sub_replies(attendee, h_cutoff, oldical, newical, &reply);
         schedule_sub_declines(attendee, h_cutoff, oldical, newical, &reply);
+
+        if (reply.found_attendee) found_attendee = true;
 
         if (reply.do_send) {
             unsigned flags = SCHEDFLAG_IS_REPLY;
@@ -3026,6 +3038,24 @@ void sched_reply(const char *cal_ownerid, const char *sched_userid,
 
         if (reply.didparts) strarray_free(reply.didparts);
         if (reply.itip) icalcomponent_free(reply.itip);
+    }
+
+    if (!found_attendee) {
+        /* If the event has attendees and/or an organizer, but none of them
+         * match any scheduling addresses then nothing gets scheduled. */
+        icalcomponent *comp =
+            icalcomponent_get_first_real_component(newical ? newical : oldical);
+        if (comp && icalcomponent_get_first_invitee(comp)) {
+            const char *organizer = get_organizer(comp);
+            char *addrs = strarray_join(schedule_addresses, ", ");
+            xsyslog_ev(LOG_WARNING, "Not scheduling calendar component, "
+                    "ORGANIZER or ATTENDEE not found in scheduling addresses",
+                    lf_s("ical_uid", icalcomponent_get_uid(comp)),
+                    lf_s("sched_userid", sched_userid),
+                    lf_s("organizer", organizer),
+                    lf_s("sched_addrs", addrs));
+            free(addrs);
+        }
     }
 
     if (myoldical) icalcomponent_free(myoldical);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4287,7 +4287,7 @@ static int setcalendarevents_schedule(const struct mailbox *mailbox,
     if (!strcasecmp(buf_cstring(&buf), "F") ||
         // http_caldav.c: has been accepting "no" so we do here as well
         !strcasecmp(buf_cstring(&buf), "no")) {
-        syslog(LOG_DEBUG, "Scheduling disabled for user %s on mailbox %s"
+        syslog(LOG_WARNING, "Scheduling disabled for user %s on mailbox %s"
                " by CY:scheduling-enabled annotation",
                httpd_userid, mailbox_name(mailbox));
         buf_free(&buf);


### PR DESCRIPTION
This improves logging for the case where Cyrus decides to not send an iTIP message although the calendar object is scheduled. This does not change existing functionality but is meant to support debugging.

The following cases now log with LOG_WARNING level:

- The CY:scheduling-enabled annotation is false for the user.
- The calendar user is neither the ORGANIZER nor an ATTENDEE.
- The Scheduling Outbox lacks DACL_INVITE or DACL_REPLY, for invites and replies respectively.

Tested by:
- Caldav.schedule_organizer_mismatch
- Caldav.scheduling_enabled
- Caldav.scheduling_privileges
- JMAPCalendars.calendar_scheduling_enabled
- JMAPCalendars.calendarevent_set_schedule_organizer_mismatch