### PR TITLE
AccountSync: use external altnamespace names in dump/undump

### DIFF
--- a/cassandane/tiny-tests/SyncProto/syncproto_dump_restore
+++ b/cassandane/tiny-tests/SyncProto/syncproto_dump_restore
@@ -25,6 +25,11 @@ sub test_syncproto_dump_restore ($self)
     my $sp = Cyrus::SyncProto->new($admintalk);
     my $as = Cyrus::AccountSync->new($sp);
     my $data = $as->dump_user(username => 'cassandane');
+
+    xlog $self, "Dumped names use external altnamespace + unixhs format";
+    my @names = sort map { $_->{name} } @{$data->{mailboxes}};
+    $self->assert_deep_equals(['INBOX', 'Sent', 'subfolder'], \@names);
+
     $self->assert_null($as->dump_user(username => 'newuser'));
     $as->undump_user(username => 'newuser', data => $data);
     my $newdata = $as->dump_user(username => 'newuser');

--- a/cassandane/tiny-tests/SyncProto/syncproto_dump_restore
+++ b/cassandane/tiny-tests/SyncProto/syncproto_dump_restore
@@ -28,7 +28,8 @@ sub test_syncproto_dump_restore ($self)
 
     xlog $self, "Dumped names use external altnamespace + unixhs format";
     my @names = sort map { $_->{name} } @{$data->{mailboxes}};
-    $self->assert_deep_equals(['INBOX', 'Sent', 'subfolder'], \@names);
+    $self->assert_deep_equals(['INBOX', 'INBOX/subfolder', 'Sent', 'subfolder'],
+                              \@names);
 
     $self->assert_null($as->dump_user(username => 'newuser'));
     $as->undump_user(username => 'newuser', data => $data);

--- a/perl/imap/lib/Cyrus/AccountSync.pm
+++ b/perl/imap/lib/Cyrus/AccountSync.pm
@@ -154,7 +154,7 @@ sub undump_user {
       push @records, \%record;
     }
     $self->{sync}->dlwrite("APPLY", "MESSAGE", \@upload) if @upload;
-    my $mbname = Cyrus::Mbname->new_userfolder($opts{username}, $mailbox->{name});
+    my $mbname = Cyrus::Mbname->new_extuserfolder($opts{username}, $mailbox->{name});
     my $intname = $mbname->intname;
     my $highestmodseq = $mailbox->{highestModificationSequenceValue} || 1;
     my $uidvalidity = $mailbox->{uidValidity} || $time;
@@ -204,7 +204,7 @@ sub _mkname {
   my $mboxname = shift;
 
   my $mbname = Cyrus::Mbname->new_intname($mboxname);
-  return $mbname->userfolder;
+  return $mbname->extuserfolder;
 
 }
 

--- a/perl/imap/lib/Cyrus/Mbname.pm
+++ b/perl/imap/lib/Cyrus/Mbname.pm
@@ -120,6 +120,32 @@ sub new_userfolder {
     return bless \%self, ref($class) || $class;
 }
 
+sub new_extuserfolder {
+    my $class = shift;
+    my $username = shift;
+    my $folder = shift;
+
+    my %self;
+    if ($username =~ s/\@(.*)//) {
+        $self{domain} = $1;
+    }
+    $self{localpart} = $username;
+
+    # external altnamespace + unixhierarchysep: "/" separator, with the inbox
+    # named exactly "INBOX" and its siblings as bare top-level names.  This is
+    # the inverse of extuserfolder(): only the bare string "INBOX" is the
+    # inbox; "INBOX/child" is a folder literally named INBOX below the inbox,
+    # not the inbox itself, so the leading component must be preserved.
+    if (defined $folder and $folder ne 'INBOX') {
+        $self{boxes} = [split m{/}, $folder];
+    }
+    else {
+        $self{boxes} = [];    # INBOX
+    }
+
+    return bless \%self, ref($class) || $class;
+}
+
 sub new_adminfolder {
     # this is basically new_intname, but with the domain on the end...
     my $class = shift;


### PR DESCRIPTION
dump_user/undump_user previously used Cyrus::Mbname's userfolder / new_userfolder pair, which represent mailboxes in internal form with a leading "INBOX" component and "." hierarchy separator (e.g. "INBOX.Archive"). This does not match the external altnamespace + unixhierarchysep naming that Apple (and other JMAP implementations) use for account dumps, so dumps could not interoperate and hand-authored external-format data failed to restore ("Unknown top-level Archive").

Switch to the extuserfolder / new_extuserfolder pair so mailbox names in the dumped data use the external representation: "INBOX" for the inbox, bare names for children ("Archive", "Sent"), and "/" for nested hierarchy ("Parent/Child"). The pair round-trips symmetrically, so dump -> undump -> dump is unchanged.

Extend the SyncProto dump/restore test to assert the external name format in addition to the existing round-trip check.