### PR TITLE
cunit: better names for temp files/dirs

### DIFF
--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -44,7 +44,7 @@ static char *make_basedir(const char *const *reldirs)
     char basedir[PATH_MAX] = {0};
     const char *const *d;
 
-    if (!cunit_tmpdir(basedir, sizeof(basedir), "cunit-db-test.XXXXXX"))
+    if (!cunit_tmpdir(basedir, sizeof(basedir), "aaa-db.testc-XXXXXX"))
         return NULL;
 
     for (d = reldirs; *d; d++) {

--- a/cunit/aaa-db.testc
+++ b/cunit/aaa-db.testc
@@ -44,7 +44,7 @@ static char *make_basedir(const char *const *reldirs)
     char basedir[PATH_MAX] = {0};
     const char *const *d;
 
-    if (!cunit_tmpdir(basedir, sizeof(basedir), "cunit-db-test.XXXXXX"))
+    if (!cunit_tmpdir(basedir, sizeof(basedir), "aaa-db-XXXXXX"))
         return NULL;
 
     for (d = reldirs; *d; d++) {

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -1192,7 +1192,7 @@ static void test_dump(void)
 #define N_CID_TO_FOLDER 333
     struct stat sb;
 
-    fd = cunit_tmpfile(filename, sizeof(filename), "cyrus-conv.datXXXXXX");
+    fd = cunit_tmpfile(filename, sizeof(filename), "conversations.testc-dump-XXXXXX");
     CU_ASSERT_FATAL(fd >= 0);
     fp = fdopen(fd, "r+");
     CU_ASSERT_PTR_NOT_NULL_FATAL(fp);

--- a/cunit/conversations.testc
+++ b/cunit/conversations.testc
@@ -1192,7 +1192,7 @@ static void test_dump(void)
 #define N_CID_TO_FOLDER 333
     struct stat sb;
 
-    fd = cunit_tmpfile(filename, sizeof(filename), "cyrus-conv.datXXXXXX");
+    fd = cunit_tmpfile(filename, sizeof(filename), "conversations-XXXXXX");
     CU_ASSERT_FATAL(fd >= 0);
     fp = fdopen(fd, "r+");
     CU_ASSERT_PTR_NOT_NULL_FATAL(fp);

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -69,7 +69,7 @@ static void test_init_multi(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt.testc-XXXXXX"));
 
     char *fnames[2] = {
         strconcat(dname, "/hmac.pem", NULL),
@@ -104,7 +104,7 @@ static void test_init_nokeys(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt.testc-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -166,7 +166,7 @@ static void test_validate(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt.testc-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -350,7 +350,7 @@ static void test_validate_claims_no_max_age(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt.testc-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -408,7 +408,7 @@ static void test_validate_claims_with_max_age(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt.testc-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -467,7 +467,7 @@ static void test_auth(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt.testc-XXXXXX"));
 
     char *fnames[2] = {
         strconcat(dname, "/hmac.pem", NULL),

--- a/cunit/http_jwt.testc
+++ b/cunit/http_jwt.testc
@@ -69,7 +69,7 @@ static void test_init_multi(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt-XXXXXX"));
 
     char *fnames[2] = {
         strconcat(dname, "/hmac.pem", NULL),
@@ -104,7 +104,7 @@ static void test_init_nokeys(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -166,7 +166,7 @@ static void test_validate(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -350,7 +350,7 @@ static void test_validate_claims_no_max_age(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -408,7 +408,7 @@ static void test_validate_claims_with_max_age(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt-XXXXXX"));
 
     char *fname = strconcat(dname, "/key.pem", NULL);
     FILE *fp = fopen(fname, "w");
@@ -467,7 +467,7 @@ static void test_auth(void)
 
     CU_ASSERT_PTR_NOT_NULL_FATAL(cunit_tmpdir(dname,
                                               sizeof(dname),
-                                              "cyrus-cunit-XXXXXX"));
+                                              "http_jwt-XXXXXX"));
 
     char *fnames[2] = {
         strconcat(dname, "/hmac.pem", NULL),

--- a/cunit/pcunit
+++ b/cunit/pcunit
@@ -64,7 +64,8 @@ while (@suites) {
     }
 
     my $next = shift @suites;
-    my (undef, $outfile) = tempfile(DIR => $tmpdir, UNLINK => 0);
+    my (undef, $outfile) = tempfile("cyrus-cunit-$next.out-XXXXXX",
+                                    DIR => $tmpdir, UNLINK => 0);
 
     my $pid = fork;
     unless ($pid) {

--- a/cunit/proc.testc
+++ b/cunit/proc.testc
@@ -27,7 +27,7 @@ static int set_up(void)
 {
     char dir[PATH_MAX] = {0};
 
-    if (!cunit_tmpdir(dir, sizeof(dir), "cyrus-cunit-proctestc-XXXXXX"))
+    if (!cunit_tmpdir(dir, sizeof(dir), "proc.testc-XXXXXX"))
         return -1;
 
     myconfigdir = xstrdup(dir);

--- a/cunit/proc.testc
+++ b/cunit/proc.testc
@@ -27,7 +27,7 @@ static int set_up(void)
 {
     char dir[PATH_MAX] = {0};
 
-    if (!cunit_tmpdir(dir, sizeof(dir), "cyrus-cunit-proctestc-XXXXXX"))
+    if (!cunit_tmpdir(dir, sizeof(dir), "proc-XXXXXX"))
         return -1;
 
     myconfigdir = xstrdup(dir);

--- a/cunit/prot.testc
+++ b/cunit/prot.testc
@@ -8,7 +8,7 @@
 
 #define PROLOG \
     char _fname[PATH_MAX] = {0}; \
-    int _fd = cunit_tmpfile(_fname, sizeof(_fname), "cyrus-protXXXXXX");
+    int _fd = cunit_tmpfile(_fname, sizeof(_fname), "prot.testc-XXXXXX");
 
 #define BEGIN \
     { \

--- a/cunit/prot.testc
+++ b/cunit/prot.testc
@@ -8,7 +8,7 @@
 
 #define PROLOG \
     char _fname[PATH_MAX] = {0}; \
-    int _fd = cunit_tmpfile(_fname, sizeof(_fname), "cyrus-protXXXXXX");
+    int _fd = cunit_tmpfile(_fname, sizeof(_fname), "prot-XXXXXX");
 
 #define BEGIN \
     { \

--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -620,7 +620,7 @@ static void context_setup(sieve_test_context_t *ctx,
 
     r = sieve_generate_bytecode(&bytecode, scr);
     CU_ASSERT(r > 0);
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sievetest-BC-XXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sieve.testc-bytecode-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = sieve_emit_bytecode(fd, bytecode);
     CU_ASSERT(r > 0);
@@ -723,7 +723,7 @@ static sieve_test_message_t *sieve_test_message_new(const char *text, int len)
     msg->length = len;
     msg->headers = spool_new_hdrcache();
 
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sievetest-MS-XXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sieve.testc-msg-XXXXXX");
     CU_ASSERT(fd >= 0);
     msg->filename = xstrdup(tempfile);
     r = retry_write(fd, text, len);

--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -620,7 +620,7 @@ static void context_setup(sieve_test_context_t *ctx,
 
     r = sieve_generate_bytecode(&bytecode, scr);
     CU_ASSERT(r > 0);
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sievetest-BC-XXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sieve-bytecode-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = sieve_emit_bytecode(fd, bytecode);
     CU_ASSERT(r > 0);
@@ -723,7 +723,7 @@ static sieve_test_message_t *sieve_test_message_new(const char *text, int len)
     msg->length = len;
     msg->headers = spool_new_hdrcache();
 
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sievetest-MS-XXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "sieve-msg-XXXXXX");
     CU_ASSERT(fd >= 0);
     msg->filename = xstrdup(tempfile);
     r = retry_write(fd, text, len);

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -149,7 +149,7 @@ static void test_fill(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool.testc-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
@@ -229,7 +229,7 @@ static void test_folded_headers(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool.testc-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
@@ -301,7 +301,7 @@ static void test_empty_headers(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool.testc-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
@@ -415,7 +415,7 @@ static void test_fill_null(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool.testc-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);

--- a/cunit/spool.testc
+++ b/cunit/spool.testc
@@ -149,7 +149,7 @@ static void test_fill(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
@@ -229,7 +229,7 @@ static void test_folded_headers(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
@@ -301,7 +301,7 @@ static void test_empty_headers(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);
@@ -415,7 +415,7 @@ static void test_fill_null(void)
 
     /* Setup @pin to point to the start of a file open for (at least)
      * reading containing the message. */
-    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spooltestAXXXXXX");
+    fd = cunit_tmpfile(tempfile, sizeof(tempfile), "spool-XXXXXX");
     CU_ASSERT(fd >= 0);
     r = retry_write(fd, MSG, sizeof(MSG)-1);
     CU_ASSERT_EQUAL(r, sizeof(MSG)-1);

--- a/cunit/unit.c
+++ b/cunit/unit.c
@@ -308,7 +308,7 @@ EXPORTED void config_read_string(const char *confdir, const char *s)
     }
 
     /* write config to the tmp file and then read it normally */
-    fd = cunit_tmpfile(fname, sizeof(fname), "cyrus-cunit-configXXXXXX");
+    fd = cunit_tmpfile(fname, sizeof(fname), "imapd.conf-XXXXXX");
     if (!fd) fatal("cunit_tmpfile", errno);
     retry_write(fd, buf_cstring(&opt_confdir), buf_len(&opt_confdir));
     buf_free(&opt_confdir);


### PR DESCRIPTION
Previously, we arranged for cunit processes to run in their own workdir; arranged for temporary files used by tests to be created under that workdir; and made the path where those workdirs are created configurable.

With the renovations finished, we can now paint the walls.  This PR gives all the temporary files sensible names, instead of the mess we used to have.

For test files that previously had meaningless names, they're now named for the test suite they come from.  For ones that had (somewhat) meaningful names, they've been improved.  The imapd.conf file is now named accordingly.  Since we're using cunit-specific workdirs now (and not just blatting into `/tmp`), we don't need "cyrus-cunit-" prefixes on anything.