### PR TITLE
master-cronevent.testc: Avoid a fatalized format warning with gcc's ubsan

### DIFF
--- a/cunit/master-cronevent.testc
+++ b/cunit/master-cronevent.testc
@@ -199,17 +199,16 @@ static void test_cronevent_add_broken_command(void)
     };
     const size_t n_tests = sizeof(tests) / sizeof(tests[0]);
     dynarray_t *schedule, *details;
-    int i;
 
     cronevent_get_schedule(&schedule, &details);
 
-    for (i = 0; i < (int) n_tests; i++) {
+    for (size_t i = 0; i < n_tests; i++) {
         char name[16];
         const char *spec = "* * * * *";
         struct cronevent_details *event_details;
         unsigned j;
 
-        snprintf(name, sizeof(name), "event %d", i);
+        snprintf(name, sizeof(name), "event %zu", i);
 
         cronevent_add(name, spec, tests[i].cmd, false);
         assert_schedule_invariants();


### PR DESCRIPTION
With the optimizer enabled, gcc -fsanitize=undefined issues a format warning. This is fatal with -Werror, stopping the build dead:

    error: '%d' directive output may be truncated writing between 1 and 11 bytes into a region of size 10 [-Werror=format-truncation=]
    note: directive argument in the range [-2147483647, 2]

This inference is actually incorrect - the range is [0, 2] hence "%d" can't overflow. The "obvious" fix is to increase the buffer length. A better fix is to change the variable to unsigned int and the format to "%u", as it's used as an array index. Using (default) signed variables for array indexes is an anti-pattern that can cause CVE-level bugs.