### PR TITLE
append: fix some includes

### DIFF
--- a/imap/append.c
+++ b/imap/append.c
@@ -19,6 +19,7 @@
 #include <inttypes.h>
 
 #include "acl.h"
+#include "append.h"
 #include "assert.h"
 #include "mailbox.h"
 #include "notify.h"

--- a/imap/append.h
+++ b/imap/append.h
@@ -7,6 +7,7 @@
 
 #include <stdbool.h>
 
+#include "acl.h"
 #include "index.h"
 #include "mailbox.h"
 #include "mboxevent.h"


### PR DESCRIPTION
* The append API requires callers to use constants defined in acl.h, so append.h should include acl.h.
* append.c wasn't including its own header.  Do so!  Don't rely on something else dragging it in.

This is a surgical fix for [an issue reported on the mailing list](https://cyrus.topicbox.com/groups/info/Ta23e8d2dc952dbc6-M33cd54ccc23bd0d43c8359d3).  There's a lot to improve in this space, but not in this PR.

**Context:** Something about the way Cyrus builds on our usual platforms lets us get away with some pretty sloppy use of `#include`, though I don't know what.  In any case, we occasionally get reports of dumb mistakes like this from users on stricter platforms.  Such is life.