### PR TITLE
docsrc: more restructuring, this time Cassandane docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ doc/text/
 docsrc/.doctrees/
 docsrc/_doxygen/
 docsrc/build/
+docsrc/developer/cassandane-api/
 docsrc/reference/manpages/configs/imapd.conf.rst
 docsrc/reference/manpages/usercommands/cyradm.rst
 docsrc/reference/manpages/usercommands/sieveshell.rst

--- a/Makefile.am
+++ b/Makefile.am
@@ -1991,27 +1991,30 @@ docsrc/reference/manpages/usercommands/sieveshell.rst: $(top_srcdir)/perl/sieve/
 # carries Pod, plus a cross-reference file (so L<...> between them renders as an
 # internal :doc: link rather than a metacpan link) and a listing that
 # developer/cassandane.rst includes.  It's all a build artifact, gitignored
-# like the other perl2rst output.  The module list is shared with docsrc/Makefile:
+# like the other perl2rst output.  The module list is discovered at make time
+# (see docsrc/cassandane-pod.mk), shared with docsrc/Makefile.
+cassandane_srcdir = $(top_srcdir)/cassandane
 include docsrc/cassandane-pod.mk
 
 cassandane_apidir  = docsrc/developer/cassandane-api
 cassandane_pod_rst = $(CASSANDANE_POD:%=$(cassandane_apidir)/%.rst)
+cassandane_pod_pm  = $(CASSANDANE_POD:%=$(cassandane_srcdir)/%.pm)
 
 # module -> doc-page map, read by perl2rst to resolve internal L<...> links
-$(cassandane_apidir)/.xref: $(top_srcdir)/tools/pod-index Makefile
+$(cassandane_apidir)/.xref: $(top_srcdir)/tools/pod-index $(cassandane_pod_pm)
 	@$(MKDIR_P) $(@D)
 	$(AM_V_GEN)$(PERL) $(top_srcdir)/tools/pod-index --xref $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
 
 # one page per module, from its .pm and the shared xref
-$(cassandane_apidir)/%.rst: $(top_srcdir)/cassandane/%.pm $(cassandane_apidir)/.xref $(top_srcdir)/tools/perl2rst
+$(cassandane_apidir)/%.rst: $(cassandane_srcdir)/%.pm $(cassandane_apidir)/.xref $(top_srcdir)/tools/perl2rst
 	@$(MKDIR_P) $(@D)
 	$(AM_V_GEN)PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$(cassandane_apidir)/.xref \
 	    $(PERL) $(top_srcdir)/tools/perl2rst $(subst /,::,$*) <$< >$@.NEW && mv $@.NEW $@
 
 # the reST bullet list + hidden toctree that developer/cassandane.rst includes
-$(cassandane_apidir)/listing.inc: $(top_srcdir)/tools/pod-index Makefile $(CASSANDANE_POD:%=$(top_srcdir)/cassandane/%.pm)
+$(cassandane_apidir)/listing.inc: $(top_srcdir)/tools/pod-index $(cassandane_pod_pm)
 	@$(MKDIR_P) $(@D)
-	$(AM_V_GEN)$(PERL) $(top_srcdir)/tools/pod-index --listing --srcdir $(top_srcdir)/cassandane $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
+	$(AM_V_GEN)$(PERL) $(top_srcdir)/tools/pod-index --listing --srcdir $(cassandane_srcdir) $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
 
 $(cassandane_apidir)/.stamp: $(cassandane_pod_rst) $(cassandane_apidir)/listing.inc
 	@touch $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -1986,6 +1986,31 @@ docsrc/reference/manpages/usercommands/sieveshell.rst: $(top_srcdir)/perl/sieve/
 	@$(MKDIR_P) $(@D)
 	$(AM_V_GEN)$(PERL) $(top_srcdir)/tools/perl2rst sieveshell < $< > $@.NEW && mv $@.NEW $@
 
+# Render the Pod of every Cassandane module that carries any into reST, one
+# page per module, so it joins the doc site.  The pages are build artifacts,
+# gitignored like the other perl2rst output.  We build the ridiculous xref file
+# so that when we render the Pod into reST, we can know which L<...> sequences
+# should link internally, and which should go to metacpan.
+docsrc/developer/cassandane-api/.stamp: $(top_srcdir)/tools/perl2rst
+	@$(RM) -r $(@D)
+	@$(MKDIR_P) $(@D)
+	$(AM_V_GEN)pms=`cd $(top_srcdir) && grep -rl '^=head' cassandane/Cassandane --include='*.pm' | sort`; \
+	: > $(@D)/.xref; \
+	for pm in $$pms; do \
+	    mod=`echo "$$pm" | sed -e 's|^cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
+	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
+	    printf '%s\t/developer/cassandane-api/%s\n' "$$mod" "$$out" >> $(@D)/.xref; \
+	done; \
+	for pm in $$pms; do \
+	    mod=`echo "$$pm" | sed -e 's|^cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
+	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
+	    PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$(@D)/.xref \
+	        $(PERL) $(top_srcdir)/tools/perl2rst "$$mod" \
+	        < $(top_srcdir)/$$pm > $(@D)/$$out.rst.NEW \
+	        && mv $(@D)/$$out.rst.NEW $(@D)/$$out.rst; \
+	done
+	@touch $@
+
 %.1: man/.sphinx-build.stamp
 	@$(MKDIR_P) $(@D)
 	$(AM_V_GEN)touch $@
@@ -2019,7 +2044,7 @@ SPHINX_OPTS = -d $(SPHINX_CACHE) -n -q $(SPHINX_FAIL_ON_WARNINGS) -j auto
 ## detect when source directory is not build directory (i.e. VPATH
 ## build), and clone the docsrc tree into the build directory, so
 ## that we have a single "source directory" for sphinx-build to use.
-docsrc/.sphinx-build.stamp: docsrc/reference/manpages/configs/imapd.conf.rst docsrc/reference/manpages/usercommands/cyradm.rst docsrc/reference/manpages/usercommands/sieveshell.rst
+docsrc/.sphinx-build.stamp: docsrc/reference/manpages/configs/imapd.conf.rst docsrc/reference/manpages/usercommands/cyradm.rst docsrc/reference/manpages/usercommands/sieveshell.rst docsrc/developer/cassandane-api/.stamp
 	$(AM_V_GEN)test x"$(top_srcdir)" = x"$(top_builddir)" || \
         (cd $(top_srcdir) && tar cf - --mode=gu+w docsrc doc/examples) | tar xf -
 	@touch $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -539,6 +539,7 @@ dist_noinst_SCRIPTS = \
     tools/masssievec \
     tools/mknewsgroups \
     tools/perl2rst \
+    tools/pod-index \
     tools/translatesieve \
     tools/update-tzdata.sh
 noinst_MAN = \
@@ -1986,31 +1987,33 @@ docsrc/reference/manpages/usercommands/sieveshell.rst: $(top_srcdir)/perl/sieve/
 	@$(MKDIR_P) $(@D)
 	$(AM_V_GEN)$(PERL) $(top_srcdir)/tools/perl2rst sieveshell < $< > $@.NEW && mv $@.NEW $@
 
-# Render the Pod of every Cassandane module that carries any into reST, one
-# page per module, so it joins the doc site.  The pages are build artifacts,
-# gitignored like the other perl2rst output.  We build the ridiculous xref file
-# so that when we render the Pod into reST, we can know which L<...> sequences
-# should link internally, and which should go to metacpan.
-docsrc/developer/cassandane-api/.stamp: $(top_srcdir)/tools/perl2rst
-	@$(RM) -r $(@D)
+# The generated Cassandane API docs: one reST page per Cassandane module that
+# carries Pod, plus a cross-reference file (so L<...> between them renders as an
+# internal :doc: link rather than a metacpan link) and a listing that
+# developer/cassandane.rst includes.  It's all a build artifact, gitignored
+# like the other perl2rst output.  The module list is shared with docsrc/Makefile:
+include docsrc/cassandane-pod.mk
+
+cassandane_apidir  = docsrc/developer/cassandane-api
+cassandane_pod_rst = $(CASSANDANE_POD:%=$(cassandane_apidir)/%.rst)
+
+# module -> doc-page map, read by perl2rst to resolve internal L<...> links
+$(cassandane_apidir)/.xref: $(top_srcdir)/tools/pod-index Makefile
 	@$(MKDIR_P) $(@D)
-	$(AM_V_GEN)pms=`cd $(top_srcdir) && grep -rl '^=head' cassandane/Cassandane --include='*.pm' | sort`; \
-	: > $(@D)/.xref; \
-	: > $(@D)/summary.inc; \
-	for pm in $$pms; do \
-	    mod=`echo "$$pm" | sed -e 's|^cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
-	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
-	    printf '%s\t/developer/cassandane-api/%s\n' "$$mod" "$$out" >> $(@D)/.xref; \
-	done; \
-	for pm in $$pms; do \
-	    mod=`echo "$$pm" | sed -e 's|^cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
-	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
-	    PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$(@D)/.xref \
-	        PERL2RST_SUMMARY_FILE=$(@D)/summary.inc \
-	        $(PERL) $(top_srcdir)/tools/perl2rst "$$mod" \
-	        < $(top_srcdir)/$$pm > $(@D)/$$out.rst.NEW \
-	        && mv $(@D)/$$out.rst.NEW $(@D)/$$out.rst; \
-	done
+	$(AM_V_GEN)$(PERL) $(top_srcdir)/tools/pod-index --xref $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
+
+# one page per module, from its .pm and the shared xref
+$(cassandane_apidir)/%.rst: $(top_srcdir)/cassandane/%.pm $(cassandane_apidir)/.xref $(top_srcdir)/tools/perl2rst
+	@$(MKDIR_P) $(@D)
+	$(AM_V_GEN)PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$(cassandane_apidir)/.xref \
+	    $(PERL) $(top_srcdir)/tools/perl2rst $(subst /,::,$*) <$< >$@.NEW && mv $@.NEW $@
+
+# the reST bullet list + hidden toctree that developer/cassandane.rst includes
+$(cassandane_apidir)/listing.inc: $(top_srcdir)/tools/pod-index Makefile $(CASSANDANE_POD:%=$(top_srcdir)/cassandane/%.pm)
+	@$(MKDIR_P) $(@D)
+	$(AM_V_GEN)$(PERL) $(top_srcdir)/tools/pod-index --listing --srcdir $(top_srcdir)/cassandane $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
+
+$(cassandane_apidir)/.stamp: $(cassandane_pod_rst) $(cassandane_apidir)/listing.inc
 	@touch $@
 
 %.1: man/.sphinx-build.stamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -1996,6 +1996,7 @@ docsrc/developer/cassandane-api/.stamp: $(top_srcdir)/tools/perl2rst
 	@$(MKDIR_P) $(@D)
 	$(AM_V_GEN)pms=`cd $(top_srcdir) && grep -rl '^=head' cassandane/Cassandane --include='*.pm' | sort`; \
 	: > $(@D)/.xref; \
+	: > $(@D)/summary.inc; \
 	for pm in $$pms; do \
 	    mod=`echo "$$pm" | sed -e 's|^cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
 	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
@@ -2005,6 +2006,7 @@ docsrc/developer/cassandane-api/.stamp: $(top_srcdir)/tools/perl2rst
 	    mod=`echo "$$pm" | sed -e 's|^cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
 	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
 	    PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$(@D)/.xref \
+	        PERL2RST_SUMMARY_FILE=$(@D)/summary.inc \
 	        $(PERL) $(top_srcdir)/tools/perl2rst "$$mod" \
 	        < $(top_srcdir)/$$pm > $(@D)/$$out.rst.NEW \
 	        && mv $(@D)/$$out.rst.NEW $(@D)/$$out.rst; \

--- a/cassandane/Cassandane/TestUser.pm
+++ b/cassandane/Cassandane/TestUser.pm
@@ -20,7 +20,7 @@ either with or without setup actions:
     my $user = $test_case->instance->create_user_without_setup("someuser");
 
 Once you have them, you can get pre-authenticated clients for various protocols
-with the L</jmap>, L</caldav>, L</carddav>, or L</imap> methods.
+with the C<jmap>, C<caldav>, C<carddav>, or C<imap> methods.
 
 You can also easily create test data using the entity system, for which see the
 L</Test Entities> section below or L<Cassandane::TestEntity>.

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -6,6 +6,7 @@ use strict;
 use warnings;
 use Cwd qw(abs_path);
 use File::Slurp;
+use Getopt::Long::Descriptive;
 use List::Util qw(uniq);
 
 use lib '.';
@@ -28,15 +29,8 @@ $Data::Dumper::Trailingcomma = 1;
 $ENV{DATAPRINTERRC} = abs_path('.dataprinter')
     unless exists $ENV{DATAPRINTERRC};
 
-my %want_formats = ();
 my %format_params = ();
 my $output_dir = 'reports';
-my $do_list = 0;
-# The default really should be --no-keep-going like make
-my $keep_going = 1;
-my $skip_slow = 1;
-my $slow_only = 0;
-my $log_directory;
 my @names;
 
 # Make sure our binary components have been built already
@@ -162,10 +156,43 @@ if ($@) {
     };
 }
 
-sub usage
-{
-    printf STDERR "Usage: testrunner.pl [options] -f <xml|tap|pretty|prettier> [testname...]\n";
-    print STDERR <<'END';
+my ($opt, $usage) = describe_options(
+    "%c %o [testname...]",
+
+    [ 'format|f=s@',   "test report format, repeatable: xml, tap, pretty, or"
+                     . " prettier (default: prettier)" ],
+    [ 'list|l+',       "list matching tests instead of running them; repeat"
+                     . " (-ll) to list individual tests, not just suites" ],
+    [],
+    [ 'jobs|j=i',      "run this many test workers in parallel" ],
+    # The default really should be --no-keep-going like make
+    [ 'keep-going|k!', "keep going after a test fails (default: yes)",
+                       { default => 1 } ],
+    [ 'stop|S',        "stop at the first failing test; same as --no-keep-going" ],
+    [],
+    [ 'slow',          "also run the tests marked slow" ],
+    [ 'slow-only',     "run *only* the tests marked slow" ],
+    [ 'rerun',         "rerun only the tests that failed on the previous run" ],
+    [ 'rerun-suite',   "like --rerun, but rerun the whole suite of each failure" ],
+    [],
+    [ 'valgrind!',     "run every Cyrus executable under Valgrind (slow, thorough)" ],
+    [ 'cleanup|c:s',   "clean up leftovers before the run and after each passing"
+                     . " test: yes|no|pre|post (bare --cleanup means yes)" ],
+    [ 'no-cleanup',    "never clean up leftovers (overrides --cleanup)" ],
+    [],
+    [ 'verbose|v+',    "make Cassandane and Cyrus much noisier; repeat (-vvv)"
+                     . " for more (default: 0)", { default => 0 } ],
+    [ 'no-ok',         "report only failures and errors, omitting passing tests" ],
+    [ 'log-directory|L=s', "collect per-test logs under this directory" ],
+    [ 'config=s',      "use this Cassandane config file instead of the default" ],
+    [ 'define|D=s%',   "override one Cassandane config value: -Dsection.param=value" ],
+    [],
+    [ 'help|h',        "print this help message and exit" ],
+);
+
+# The option list can't convey how to name tests, so append this to both the
+# --help output and any usage error.
+my $testname_help = <<'END';
 
 A testname is a suite, optionally followed by a dot and a test within it.
 Prefixing one with '!' (or '~') excludes it instead:
@@ -184,126 +211,64 @@ A '+' is accepted anywhere a '*' would be, so that a glob can be typed
 without having to be quoted against the shell.
 
 END
-    exit(1);
+
+sub usage {
+    print STDERR $usage->text, $testname_help;
+    exit 1;
 }
 
-my $cassini_filename;
+if ($opt->help) {
+    print $usage->text, $testname_help;
+    exit 0;
+}
+
+my $cassini_filename = $opt->config;
 my @cassini_overrides;
-my $want_rerun;
 
-while (defined(my $a = shift))
-{
-    if ($a eq '--config')
-    {
-        $cassini_filename = shift;
-    }
-    elsif ($a eq '-c' || $a =~ m/^--cleanup(?:=(\w*))?$/)
-    {
-        my $v = $1 // 'yes';
-        usage if not grep { $v eq $_ } qw(yes no pre post);
-        push(@cassini_overrides, ['cassandane', 'cleanup', $v]);
-    }
-    elsif ($a eq '--no-cleanup')
-    {
-        push(@cassini_overrides, ['cassandane', 'cleanup', 'no']);
-    }
-    elsif ($a eq '-f')
-    {
-        my $format = shift;
-        usage unless defined $formatters{$format};
-        $want_formats{$format} = 1;
-    }
-    elsif ($a =~ m/^-f(\w+)$/)
-    {
-        my $format = $1;
-        usage unless defined $formatters{$format};
-        $want_formats{$format} = 1;
-    }
-    elsif ($a eq '-v' || $a eq '--verbose')
-    {
-        set_verbose(get_verbose()+1);
-    }
-    elsif ($a =~ m/^-v+$/)
-    {
-        # ganged verbosity
-        set_verbose(get_verbose() + length($a) - 1);
-    }
-    elsif ($a eq '--valgrind')
-    {
-        push(@cassini_overrides, ['valgrind', 'enabled', 'yes']);
-    }
-    elsif ($a eq '--no-valgrind')
-    {
-        push(@cassini_overrides, ['valgrind', 'enabled', 'no']);
-    }
-    elsif ($a eq '-j' || $a eq '--jobs')
-    {
-        my $jobs = 0 + shift;
-        usage unless $jobs > 0;
-        push(@cassini_overrides, ['cassandane', 'maxworkers', $jobs]);
-    }
-    elsif ($a =~ m/^-j(\d+)$/)
-    {
-        my $jobs = 0 + $1;
-        usage unless $jobs > 0;
-        push(@cassini_overrides, ['cassandane', 'maxworkers', $jobs]);
-    }
-    elsif ($a eq '-L' || $a eq '--log-directory')
-    {
-        $log_directory = shift;
-        usage unless defined $log_directory;
-    }
-    elsif ($a eq '-l' || $a eq '--list')
-    {
-        $do_list++;
-    }
-    elsif ($a eq '-k' || $a eq '--keep-going')
-    {
-        # These option names stolen from GNU make
-        $keep_going = 1;
-    }
-    elsif ($a eq '-S' || $a eq '--stop' || $a eq '--no-keep-going')
-    {
-        # These option names stolen from GNU make
-        $keep_going = 0;
-    }
-    elsif ($a =~ m/^-D.*=/)
-    {
-        my ($sec, $param, $val) = ($a =~ m/^-D([^.=]+)\.([^.=]+)=(.*)$/);
-        push(@cassini_overrides, [$sec, $param, $val]);
-    }
-    elsif ($a eq '--slow')
-    {
-        $skip_slow = 0;
-    }
-    elsif ($a eq '--slow-only')
-    {
-        $skip_slow = 0;
-        $slow_only = 1;
-    }
-    elsif ($a eq '--rerun')
-    {
-        $want_rerun = 1;
-    }
-    elsif ($a eq '--rerun-suite')
-    {
-        $want_rerun = 2;
-    }
-    elsif ($a eq '--no-ok')
-    {
-        # suppress success reports in formatters that support that
-        # (i.e. only report errors and failures)
-        $format_params{no_ok} = 1;
-    }
-    elsif ($a =~ m/^-/)
-    {
-        usage;
-    }
-    else
-    {
-        push(@names, split(/\s+/, $a));
+my %want_formats;
+for my $format (@{ $opt->format // [] }) {
+    usage() unless defined $formatters{$format};
+    $want_formats{$format} = 1;
+}
+
+set_verbose(get_verbose() + $opt->verbose);
+
+$format_params{no_ok} = 1 if $opt->no_ok;
+
+my $do_list       = $opt->list // 0;
+my $keep_going    = $opt->stop ? 0 : $opt->keep_going;
+my $skip_slow     = ($opt->slow || $opt->slow_only) ? 0 : 1;
+my $slow_only     = $opt->slow_only ? 1 : 0;
+my $log_directory = $opt->log_directory;
+my $want_rerun    = $opt->rerun_suite ? 2 : $opt->rerun ? 1 : 0;
+
+if (defined $opt->jobs) {
+    usage() unless $opt->jobs > 0;
+    push @cassini_overrides, ['cassandane', 'maxworkers', $opt->jobs];
+}
+
+if (defined $opt->valgrind) {
+    push @cassini_overrides,
+        ['valgrind', 'enabled', $opt->valgrind ? 'yes' : 'no'];
+}
+
+push @cassini_overrides, ['cassandane', 'cleanup', 'no'] if $opt->no_cleanup;
+
+if (defined $opt->cleanup) {
+    my $v = $opt->cleanup eq '' ? 'yes' : $opt->cleanup;
+    usage() unless grep { $v eq $_ } qw(yes no pre post);
+    push @cassini_overrides, ['cassandane', 'cleanup', $v];
+}
+
+if (my $overrides = $opt->define) {
+    for my $key (sort keys %$overrides) {
+        my ($sec, $param) = split /\./, $key, 2;
+        usage() unless length($sec // '') && length($param // '');
+        push @cassini_overrides, [$sec, $param, $overrides->{$key}];
     }
 }
+
+push @names, map { split /\s+/, $_ } @ARGV;
 
 my $cassini = Cassandane::Cassini->new(filename => $cassini_filename);
 map { $cassini->override(@$_); } @cassini_overrides;

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -2,6 +2,163 @@
 # SPDX-License-Identifier: BSD-3-Clause-CMU
 # See COPYING file at the root of the distribution for more details.
 
+=head1 NAME
+
+testrunner.pl - run the Cassandane integration test suite
+
+=head1 SYNOPSIS
+
+    ./testrunner.pl [options] [testname...]
+
+    ./testrunner.pl                     # run everything, 'prettier' output
+    ./testrunner.pl Quota               # run the whole Quota suite
+    ./testrunner.pl Quota.quotarename   # run one test
+    ./testrunner.pl Admin Quota         # run several suites
+    ./testrunner.pl ~Quota              # run everything *except* Quota
+    ./testrunner.pl -l                  # list matching suites, don't run them
+
+=head1 DESCRIPTION
+
+This is the low-level runner for the Cassandane test suite.  If you just want
+to run the tests, you almost certainly want C<cyd test> (inside the container)
+or C<dar test> (from the host), which builds Cyrus, provisions a
+F<cassandane.ini>, and drops to the C<cyrus> user before handing off to this
+script.  Reach for C<testrunner.pl> directly only when you need something
+C<cyd test> doesn't expose, or when you're debugging the runner itself.  In
+other words: by the time you're typing C<./testrunner.pl>, you've opted into
+hard mode.
+
+A few things worth knowing before you do:
+
+=over 4
+
+=item *
+
+Cassandane runs out of its own directory; nothing gets installed.  Run this
+script with the F<cassandane/> directory as your working directory.
+
+=item *
+
+The Cyrus code under test must run as the superuser or as the C<cyrus> user.
+You invoke C<testrunner.pl> as yourself; if you're root it steps down to
+C<cyrus>, and otherwise it re-invokes itself under C<sudo>.
+
+=item *
+
+All runtime state lives under the C<rootdir> from F<cassandane.ini> (by
+default F</var/tmp/cass>).  A list of the tests that failed is left in
+F<$rootdir/failed> (this is what C<--rerun> reads), and C<-f prettier> writes
+full error reports for failed tests under F<$rootdir/reports>.
+
+=item *
+
+Before running anything, the script checks that Cassandane's own helper
+binaries (listed in F<utils/Makefile>) have been built, and bails out telling
+you to run C<make> if they haven't.
+
+=back
+
+=head1 SELECTING TESTS
+
+With no test names, every test is run.  Otherwise, name what you want:
+
+=over 4
+
+=item *
+
+a whole suite by its name without the leading C<Cassandane::Cyrus::>, e.g.
+C<Quota>;
+
+=item *
+
+a single test as C<Suite.test>, e.g. C<Quota.quotarename>.
+
+=back
+
+Names accumulate left to right, and any name may be negated by prefixing it
+with C<!> or C<~>.  (Your shell probably wants C<!> escaped, so C<~> is usually
+easier.)  So C<Quota ~Quota.quotarename> runs the whole Quota suite except
+C<quotarename>, and C<~Quota> runs everything but the Quota suite.
+
+For convenience, a single argument may contain several whitespace-separated
+names.
+
+=head1 OPTIONS
+
+Run C<./testrunner.pl --help> for the authoritative, self-documenting list.
+The options most worth knowing about:
+
+=over 4
+
+=item B<-f>, B<--format> I<FORMAT>
+
+Choose a test report format; repeatable.  The formats are:
+
+=over 4
+
+=item C<prettier> (the default)
+
+One line per test with its status, quiet about the details of failures.  Best
+for running many tests: see F<$rootdir/failed> and F<$rootdir/reports>
+afterward for the gory details.
+
+=item C<pretty>
+
+Like C<prettier>, but dumps each failure's error report inline.  Noisy in bulk;
+handy when debugging a single test, especially with C<-vvv>.
+
+=item C<tap>
+
+Test Anything Protocol.  Rudimentary, but should be valid TAP.
+
+=item C<xml>
+
+jUnit-style XML, written to a F<reports/> subdirectory of the current
+directory.  (Not the same F<reports> as C<prettier> uses.)  Useful for some CI
+systems; our GitHub CI doesn't use it.
+
+=back
+
+=item B<-v>, B<--verbose>
+
+Make Cassandane and several of the Cyrus programs it runs much noisier on
+stderr.  Repeatable, and the short form stacks: C<-vvv>.
+
+=item B<--valgrind>
+
+Run every Cyrus executable under Valgrind.  Much slower, but it catches a lot
+of subtle bugs.  Per-test logs land in F<$rootdir/$instance/vglogs/>, and any
+error Valgrind reports (leaks included) fails the test.
+
+=item B<-c>, B<--cleanup>[=I<yes|no|pre|post>]
+
+Clean up C<$rootdir> leftovers before the run and after each passing test.
+Useful when disk (e.g. a tmpfs) is tight.  Bare C<--cleanup> means C<yes>.  If
+you want this most of the time, set C<cassandane.cleanup> in F<cassandane.ini>
+and use C<--no-cleanup> to override it.
+
+=item B<-j>, B<--jobs> I<N>
+
+Run I<N> test workers in parallel.
+
+=item B<--slow>, B<--slow-only>
+
+Also run (or run only) the tests marked slow, which are skipped by default.
+
+=item B<--rerun>, B<--rerun-suite>
+
+Rerun just the tests that failed last time (read from F<$rootdir/failed>).
+C<--rerun-suite> reruns the whole suite of each such test.
+
+=item B<-l>, B<--list>
+
+List the matching tests instead of running them.  Repeat (C<-ll>) to list
+individual tests rather than just suites.
+
+=back
+
+=cut
+
 use strict;
 use warnings;
 use Cwd qw(abs_path);

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -139,7 +139,8 @@ and use C<--no-cleanup> to override it.
 
 =item B<-j>, B<--jobs> I<N>
 
-Run I<N> test workers in parallel.
+Run I<N> test workers in parallel.  Defaults to the C<cassandane.maxworkers>
+setting from F<cassandane.ini>.
 
 =item B<--slow>, B<--slow-only>
 

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -322,7 +322,6 @@ my ($opt, $usage) = describe_options(
                      . " (-ll) to list individual tests, not just suites" ],
     [],
     [ 'jobs|j=i',      "run this many test workers in parallel" ],
-    # The default really should be --no-keep-going like make
     [ 'keep-going|k!', "keep going after a test fails (default: yes)",
                        { default => 1 } ],
     [ 'stop|S',        "stop at the first failing test; same as --no-keep-going" ],

--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -75,6 +75,7 @@ cassandane-api:
 	@dir=$(SOURCEDIR)/developer/cassandane-api; \
 	pms=`grep -rl '^=head' ../cassandane/Cassandane --include='*.pm' | sort`; \
 	: > $$dir/.xref; \
+	: > $$dir/summary.inc; \
 	for pm in $$pms; do \
 	    mod=`echo "$$pm" | sed -e 's|.*/cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
 	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
@@ -85,6 +86,7 @@ cassandane-api:
 	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
 	    echo "  $$mod"; \
 	    PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$$dir/.xref \
+	        PERL2RST_SUMMARY_FILE=$$dir/summary.inc \
 	        $(PERL2RST) "$$mod" < "$$pm" > $$dir/$$out.rst; \
 	done
 

--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -26,7 +26,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(S
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext doxygen
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext doxygen cassandane-api
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -56,13 +56,39 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf _doxygen
+	rm -rf $(SOURCEDIR)/developer/cassandane-api
 
 doxygen:
 	@echo "Running Doxygen to generate XML for Breathe..."
 	cd .. && doxygen Doxyfile
 	@echo "Doxygen XML generated in _doxygen/xml/"
 
-init: doxygen ../lib/imapoptions ../perl/imap/IMAP/Shell.pm
+# Render the Pod of every Cassandane module any into reST, one page per module,
+# so it joins the doc site.  The pages are build artifacts, gitignored like the
+# other perl2rst output.  We build the ridiculous xref file so that when we
+# render the Pod into reST, we can know which L<...> sequences should link
+# internally, and which should go to metacpan.
+cassandane-api:
+	@echo "Rendering Cassandane module Pod into developer/cassandane-api/"
+	@rm -rf $(SOURCEDIR)/developer/cassandane-api
+	@mkdir -p $(SOURCEDIR)/developer/cassandane-api
+	@dir=$(SOURCEDIR)/developer/cassandane-api; \
+	pms=`grep -rl '^=head' ../cassandane/Cassandane --include='*.pm' | sort`; \
+	: > $$dir/.xref; \
+	for pm in $$pms; do \
+	    mod=`echo "$$pm" | sed -e 's|.*/cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
+	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
+	    printf '%s\t/developer/cassandane-api/%s\n' "$$mod" "$$out" >> $$dir/.xref; \
+	done; \
+	for pm in $$pms; do \
+	    mod=`echo "$$pm" | sed -e 's|.*/cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
+	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
+	    echo "  $$mod"; \
+	    PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$$dir/.xref \
+	        $(PERL2RST) "$$mod" < "$$pm" > $$dir/$$out.rst; \
+	done
+
+init: doxygen cassandane-api ../lib/imapoptions ../perl/imap/IMAP/Shell.pm
 	@echo "Creating reference/manpages/usercommands/cyradm.rst"
 	$(PERL2RST) cyradm < ../perl/imap/IMAP/Shell.pm > $(SOURCEDIR)/reference/manpages/usercommands/cyradm.rst
 	@echo "Creating reference/manpages/usercommands/sieveshell.rst"

--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -64,32 +64,30 @@ doxygen:
 	cd .. && doxygen Doxyfile
 	@echo "Doxygen XML generated in _doxygen/xml/"
 
-# Render the Pod of every Cassandane module any into reST, one page per module,
-# so it joins the doc site.  The pages are build artifacts, gitignored like the
-# other perl2rst output.  We build the ridiculous xref file so that when we
-# render the Pod into reST, we can know which L<...> sequences should link
-# internally, and which should go to metacpan.
-# Generated Cassandane API docs.  The module list lives in cassandane-pod.mk,
-# shared with the top-level Makefile.am; the rules mirror it too.
+# Generated Cassandane API docs.  The module list is discovered at make time
+# by cassandane-pod.mk, shared with the top-level Makefile.am; the rules mirror
+# it too.
+cassandane_srcdir = ../cassandane
 include cassandane-pod.mk
 
 cassandane_apidir  = $(SOURCEDIR)/developer/cassandane-api
 cassandane_pod_rst = $(CASSANDANE_POD:%=$(cassandane_apidir)/%.rst)
+cassandane_pod_pm  = $(CASSANDANE_POD:%=$(cassandane_srcdir)/%.pm)
 
 cassandane-api: $(cassandane_pod_rst) $(cassandane_apidir)/listing.inc
 
-$(cassandane_apidir)/.xref: $(POD_INDEX) cassandane-pod.mk
+$(cassandane_apidir)/.xref: $(POD_INDEX) $(cassandane_pod_pm)
 	@mkdir -p $(@D)
 	$(POD_INDEX) --xref $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
 
-$(cassandane_apidir)/%.rst: ../cassandane/%.pm $(cassandane_apidir)/.xref $(PERL2RST)
+$(cassandane_apidir)/%.rst: $(cassandane_srcdir)/%.pm $(cassandane_apidir)/.xref $(PERL2RST)
 	@mkdir -p $(@D)
 	PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$(cassandane_apidir)/.xref \
 	    $(PERL2RST) $(subst /,::,$*) <$< >$@.NEW && mv $@.NEW $@
 
-$(cassandane_apidir)/listing.inc: $(POD_INDEX) cassandane-pod.mk $(CASSANDANE_POD:%=../cassandane/%.pm)
+$(cassandane_apidir)/listing.inc: $(POD_INDEX) $(cassandane_pod_pm)
 	@mkdir -p $(@D)
-	$(POD_INDEX) --listing --srcdir ../cassandane $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
+	$(POD_INDEX) --listing --srcdir $(cassandane_srcdir) $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
 
 init: doxygen cassandane-api ../lib/imapoptions ../perl/imap/IMAP/Shell.pm
 	@echo "Creating reference/manpages/usercommands/cyradm.rst"

--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -8,6 +8,7 @@ PAPER         =
 SOURCEDIR     = .
 BUILDDIR      = build
 PERL2RST      = ../tools/perl2rst
+POD_INDEX     = ../tools/pod-index
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -68,27 +69,27 @@ doxygen:
 # other perl2rst output.  We build the ridiculous xref file so that when we
 # render the Pod into reST, we can know which L<...> sequences should link
 # internally, and which should go to metacpan.
-cassandane-api:
-	@echo "Rendering Cassandane module Pod into developer/cassandane-api/"
-	@rm -rf $(SOURCEDIR)/developer/cassandane-api
-	@mkdir -p $(SOURCEDIR)/developer/cassandane-api
-	@dir=$(SOURCEDIR)/developer/cassandane-api; \
-	pms=`grep -rl '^=head' ../cassandane/Cassandane --include='*.pm' | sort`; \
-	: > $$dir/.xref; \
-	: > $$dir/summary.inc; \
-	for pm in $$pms; do \
-	    mod=`echo "$$pm" | sed -e 's|.*/cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
-	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
-	    printf '%s\t/developer/cassandane-api/%s\n' "$$mod" "$$out" >> $$dir/.xref; \
-	done; \
-	for pm in $$pms; do \
-	    mod=`echo "$$pm" | sed -e 's|.*/cassandane/||' -e 's|\.pm$$||' -e 's|/|::|g'`; \
-	    out=`echo "$$mod" | sed -e 's|::|-|g'`; \
-	    echo "  $$mod"; \
-	    PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$$dir/.xref \
-	        PERL2RST_SUMMARY_FILE=$$dir/summary.inc \
-	        $(PERL2RST) "$$mod" < "$$pm" > $$dir/$$out.rst; \
-	done
+# Generated Cassandane API docs.  The module list lives in cassandane-pod.mk,
+# shared with the top-level Makefile.am; the rules mirror it too.
+include cassandane-pod.mk
+
+cassandane_apidir  = $(SOURCEDIR)/developer/cassandane-api
+cassandane_pod_rst = $(CASSANDANE_POD:%=$(cassandane_apidir)/%.rst)
+
+cassandane-api: $(cassandane_pod_rst) $(cassandane_apidir)/listing.inc
+
+$(cassandane_apidir)/.xref: $(POD_INDEX) cassandane-pod.mk
+	@mkdir -p $(@D)
+	$(POD_INDEX) --xref $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
+
+$(cassandane_apidir)/%.rst: ../cassandane/%.pm $(cassandane_apidir)/.xref $(PERL2RST)
+	@mkdir -p $(@D)
+	PERL2RST_NAMESPACE=Cassandane PERL2RST_XREF_FILE=$(cassandane_apidir)/.xref \
+	    $(PERL2RST) $(subst /,::,$*) <$< >$@.NEW && mv $@.NEW $@
+
+$(cassandane_apidir)/listing.inc: $(POD_INDEX) cassandane-pod.mk $(CASSANDANE_POD:%=../cassandane/%.pm)
+	@mkdir -p $(@D)
+	$(POD_INDEX) --listing --srcdir ../cassandane $(CASSANDANE_POD) >$@.NEW && mv $@.NEW $@
 
 init: doxygen cassandane-api ../lib/imapoptions ../perl/imap/IMAP/Shell.pm
 	@echo "Creating reference/manpages/usercommands/cyradm.rst"

--- a/docsrc/cassandane-pod.mk
+++ b/docsrc/cassandane-pod.mk
@@ -1,0 +1,14 @@
+# Cassandane modules whose Pod is published to the doc site, as stems: paths
+# under cassandane/, without the .pm extension.  Shared by the top-level
+# Makefile.am and docsrc/Makefile so the list lives in exactly one place.
+#
+# When a module grows Pod worth publishing, add it here.  (This could later be
+# generated at configure time instead of maintained by hand.)
+CASSANDANE_POD = \
+    Cassandane/TestEntity \
+    Cassandane/TestEntity/DataType/AddressBook \
+    Cassandane/TestEntity/DataType/Calendar \
+    Cassandane/TestEntity/DataType/ContactCard \
+    Cassandane/TestEntity/DataType/Email \
+    Cassandane/TestEntity/DataType/Mailbox \
+    Cassandane/TestUser

--- a/docsrc/cassandane-pod.mk
+++ b/docsrc/cassandane-pod.mk
@@ -1,14 +1,9 @@
 # Cassandane modules whose Pod is published to the doc site, as stems: paths
-# under cassandane/, without the .pm extension.  Shared by the top-level
-# Makefile.am and docsrc/Makefile so the list lives in exactly one place.
+# under cassandane/, without the .pm extension (e.g. "Cassandane/TestUser").
 #
-# When a module grows Pod worth publishing, add it here.  (This could later be
-# generated at configure time instead of maintained by hand.)
-CASSANDANE_POD = \
-    Cassandane/TestEntity \
-    Cassandane/TestEntity/DataType/AddressBook \
-    Cassandane/TestEntity/DataType/Calendar \
-    Cassandane/TestEntity/DataType/ContactCard \
-    Cassandane/TestEntity/DataType/Email \
-    Cassandane/TestEntity/DataType/Mailbox \
-    Cassandane/TestUser
+# The list is discovered at make time -- every module with an "=head" line --
+# so it can't drift out of sync with the source and nobody has to remember to
+# maintain it.  cassandane_srcdir comes from outside, and it differs between
+# the autoconf build and docsrc/Makefile!
+CASSANDANE_POD := $(shell cd $(cassandane_srcdir) && \
+    grep -rl '^=head' Cassandane --include='*.pm' | sed 's|\.pm$$||' | sort)

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -333,3 +333,16 @@ plus non-RFC822 attributes, as returned by a message store or the generator)
 and ``Cassandane::Generator`` (which produces plausible random messages).  Both
 are best read about at the source: ``perldoc Cassandane/Message.pm`` and
 ``perldoc Cassandane/Generator.pm``.
+
+Module reference
+----------------
+
+Some Cassandane modules are documented in their source using Perl's Pod system.
+The pages below are rendered from that Pod when the docs are built.  (You can
+read the same text offline with ``perldoc``.)
+
+.. toctree::
+    :glob:
+    :maxdepth: 1
+
+    cassandane-api/*

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -16,136 +16,35 @@ Cassandane test suite.
 2. Running The Tests
 --------------------
 
-In day-to-day development you don't set up Cassandane or run it by hand:
-``dar test`` (or ``cyd test`` inside the container) provisions everything and
-runs the suite as the ``cyrus`` user for you.  See the :ref:`developer
-quickstart <developer-quickstart>` for that workflow.
+Almost all the time you run Cassandane through ``dar test`` (from the host) or
+``cyd test`` (inside the container), which builds Cyrus, writes a
+``cassandane.ini``, and runs the suite as the ``cyrus`` user for you.  See the
+:ref:`developer quickstart <developer-quickstart>` for that workflow.
 
-The rest of this section explains how to select and run tests; it applies
-whether you go through ``dar test`` or call ``testrunner.pl`` directly inside
-the container.
-
-2.1. Running tests
-^^^^^^^^^^^^^^^^^^
-
-Cassandane tests are run out of the Cassandane directory itself, without
-installing Cassandane anywhere.  This is not the result of deliberate policy so
-much as implementation laziness.
-
-All runtime state is created under the cassandane rootdir configured in
-cassandane.ini (by default: ``/var/tmp/cass``).
-
-Internally, Cassandane (or more precisely, the Cyrus code it exercises) needs
-to run either as the superuser or as the "cyrus" user.  You invoke it as
-yourself: inside the container, ``cyd test`` steps down to the "cyrus" user for
-you, and a direct ``testrunner.pl`` run will re-invoke itself with sudo.
-
-The script 'testrunner.pl' is your interface for running Cassandane tests.
-There are several other Perl scripts in the directory, but they are utilities
-which were helpful during manual testing rather than part of the test suite
-itself.
-
-With no arguments, testrunner.pl runs all the tests that come with Cassandane
-and reports the results to the terminal in the 'prettier' test report format.
-The testrunner.pl exit code will be 0 if all tests passed, non-zero otherwise.
+Whether you go through ``dar test`` or the runner directly, you choose what to
+run by naming suites and individual tests:
 
 .. code::
 
-    $ ./testrunner.pl
-    [  OK  ] Cyrus::ACL.reconstruct
-    [  OK  ] Cyrus::ACL.move
-    [  OK  ] Cyrus::ACL.delete
-    ...
+    dar test Quota               # the whole Quota suite
+    dar test Quota.quotarename   # a single test
+    dar test Admin Quota         # several suites
+    dar test ~Quota              # everything except the Quota suite
 
-There are several test report formats to choose from, by invoking testrunner.pl
-with the -f 'format' option.
+Names accumulate from left to right, and any name can be negated with ``!`` or
+``~`` (``~`` is usually easier to slip past the shell).  ``dar test`` also
+exposes the options most people reach for — ``--slow``, ``--rerun``,
+``--valgrind``, ``-j``, and so on; run ``dar test --help`` to see them.
 
-``-f pretty``
-    Human readable output to the terminal, showing the ok/failed/error status
-    and name for each test, as well as the error reports from any not-ok tests.
-    This gets noisy in the case of failures!  It's mostly useful when debugging
-    single tests, especially in conjunction with -vvv.
-
-``-f prettier`` (the default)
-    As for pretty, but without the noise when problems occur.  This is most
-    useful when running many (or all) tests at once.  A list of failed tests
-    is written to $rootdir/failed, and the full error reports for any failed
-    tests are written to $rootdir/reports, so you can still access these details
-    if you find yourself needing them after the fact.
-
-``-f xml``
-    This writes reports in jUnit format.  The reports will be xml files in a
-    subdirectory "reports" of the current directory at the time testrunner.pl
-    was invoked.  Note that this is NOT the same "reports" file as used by
-    -f prettier.  This format is apparently useful for integration with various
-    CI systems, though it's not used by our Github CI.
-
-``-f tap``
-    TAP is a common format which originated with Perl and is now widely used,
-    see http://en.wikipedia.org/wiki/Test_Anything_Protocol for more
-    information.  Cassandane's implementation is very rudimentary, but should
-    generally produce valid TAP.
-
-You can run just a subset of tests by giving arguments to testrunner.pl.
-Tests to run are most commonly specified as:
-
-* a test suite without the leading Cassandane::Cyrus
-
-    .. code::
-
-        $ ./testrunner.pl Quota
-
-* a single test in a single test suite
-
-    .. code::
-
-        $ ./testrunner.pl Quota.quotarename
-
-Multiple test suites or tests can be specified as well:
-
-    .. code::
-
-        $ ./testrunner.pl Admin Quota.quotarename
-
-Arguments can be negated by using a leading exclamation mark (!) or tilde (~)
-character.  Note that you may need to escape the ! from the shell, so ~ is
-generally preferable:
+Underneath, the actual runner is ``cassandane/testrunner.pl``, run as the
+``cyrus`` user from inside the ``cassandane`` directory.  You need it directly
+only when you want something ``dar test`` doesn't expose, or when debugging the
+runner itself.  It documents itself:
 
 .. code::
 
-    $ ./testrunner.pl ~Quota
-
-will run all the tests from all the suites except the Quota suite.
-Arguments accumulate from left to right, so e.g.
-
-.. code::
-
-    $ ./testrunner.pl Quota ~Quota.quotarename
-
-will run all the tests in the Quota suite except the quotarename test.
-
-The -v (or --verbose) option to testrunner.pl causes both Cassandane and
-several Cyrus programs run by Cassandane to emit a lot of information to
-stderr.  You can specify this option multiple times for increased verbosity,
-and the single-character version can be stacked, like -vvv.
-
-The --valgrind option to testrunner.pl runs all the Cyrus executables using
-Valgrind.  This is of course much slower but is recommended because it finds
-many subtle bugs.  The Valgrind logs are saved in the files
-$rootdir/$instance/vglogs/$name.$pid.  Cassandane will examine these logs after
-each test finishes, and will fail the test if there are any errors (including
-memory leaks) reported.
-
-The --cleanup option causes Cassandane to do two things.  Firstly, it
-immediately cleans up any files left over in $rootdir.  Secondly, it cleans up
-any such files after each test, unless the test fails.  This should be helpful
-when the filesystem in use does not have much room, such as when running on a
-tmpfs filesystem.  You'll probably find this useful, so enable
-cassandane.cleanup in your cassandane.ini rather than typing it all the time.
-Then use --no-cleanup to override it when you don't want that.
-
-testrunner.pl also accepts a bunch of other options that are not documented
-here.  Consult the script itself for the full and most up-to-date set.
+    ./testrunner.pl --help       # the full, authoritative option list
+    perldoc ./testrunner.pl      # what it is, and notes on driving it
 
 3. Adding Your Own Tests
 ------------------------

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -341,8 +341,13 @@ Some Cassandane modules are documented in their source using Perl's Pod system.
 The pages below are rendered from that Pod when the docs are built.  (You can
 read the same text offline with ``perldoc``.)
 
+.. include:: cassandane-api/summary.inc
+
+.. The pages themselves are listed above; this hidden toctree is what actually
+   puts them in the navigation tree.
+
 .. toctree::
     :glob:
-    :maxdepth: 1
+    :hidden:
 
     cassandane-api/*

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -5,16 +5,30 @@ The Cassandane test suite
 
 .. contents::
 
-1. Introduction
----------------
+.. sectnum::
+
+Introduction
+------------
 
 Cyrus IMAP includes two test suites.  One is written in C, using CUnit, and is
 primarily *unit testing*.  The other, known as Cassandane, is written in Perl,
 using Test::Unit, and is primarily *integration testing*.  This page covers the
 Cassandane test suite.
 
-2. Running The Tests
---------------------
+Tests are grouped into *suites*, and each suite is a Perl module: those under
+``Cassandane/Cyrus/`` exercise Cyrus, and those under ``Cassandane/Test/``
+exercise Cassandane itself.  Most Cyrus tests are written as *tiny-tests* — one
+subroutine per file under ``cassandane/tiny-tests/{Suite}/``, sharing the
+suite module's setup.
+
+If you just want to get productive fast, the :ref:`developer quickstart
+<developer-quickstart>` takes you from a fresh checkout to a first passing test
+and the conventions to write it with the grain.  This page is the fuller
+story: how a test is put together and what the framework gives you to work
+with.
+
+Running the tests
+-----------------
 
 Almost all the time you run Cassandane through ``dar test`` (from the host) or
 ``cyd test`` (inside the container), which builds Cyrus, writes a
@@ -46,377 +60,23 @@ runner itself.  It documents itself:
     ./testrunner.pl --help       # the full, authoritative option list
     perldoc ./testrunner.pl      # what it is, and notes on driving it
 
-3. Adding Your Own Tests
-------------------------
-
-The source code for tests are Perl modules located in two directories under the
-Cassandane main directory.
-
-``Cassandane/Test/``
-    contains tests which exercise the Cassandane core classes,
-    i.e. self-tests.
-
-``Cassandane/Cyrus/``
-    contains tests which exercise Cyrus.
-
-Cassandane uses the Perl Test::Unit framework.  For more detailed information
-consult the Test::Unit documentation.  Each Cassandane test module derives from
-the Cassandane::Unit::TestCase class, and is logically a group of related
-tests.  The module can define the following methods.
-
-``new``
-    Constructor, creates and returns a new TestCase.  For Cassandane
-    tests, this will typically create Cassandane::Config and
-    Cassandane::Instance objects (see later).
-
-``set_up``
-    Optional method which is called by the framework before every
-    test is run.  It has no return value and should 'die' if anything
-    goes wrong.  For Cassandane tests, this will typically start an
-    Instance (see later).
-
-``tear_down``
-    Optional method which is called by the framework after every
-    test is run.  It has no return value and should 'die' if anything
-    goes wrong.  For Cassandane tests, this will typically stop an
-    Instance (see later).
-
-``test_foo``
-    Defines a test named "foo".  It has no return value and should
-    either call $self->assert(boolean) or 'die' if anything goes wrong.
-    Multiple test_whatever methods can be defined in a module.
-
-3.1 Helper Classes
-^^^^^^^^^^^^^^^^^^
-
-Cassandane contains a number of helper classes designed to make easier
-the job of writing tests that access Cyrus.  This section provides a
-brief overview.
-
-Cassandane::Instance
-    Encapsulates an instance of Cyrus, with its own directory
-    structure, configuration files, master process, and one or more
-    services such as imapd.
-
-    To create a default Instance:
-
-    .. code:: perl
-
-        my $instance = Cassandane::Instance->new();
-
-    To create an Instance with a non-default parameter in the
-    configuration file:
-
-    .. code:: perl
-
-        my $config = Cassandane::Config->default()->clone();
-        $config->set(conversations => 'on');
-        my $instance = Cassandane::Instance->new(config => $config);
-
-    By default the Instance has no services, but just runs the master
-    daemon.  This is rarely a useful setup.  To add a service, in this case
-    the imapd daemon:
-
-    .. code:: perl
-
-        $instance->add_service(name => 'imap');
-
-    Starting the Instance creates the directory structure and
-    configuration files, then starts the master process and waits for
-    all the defined services to be running (as reported by netstat).
-
-    .. code:: perl
-
-        $instance->start();
-
-    Stopping the instance kills all master process and all services
-    as gracefully as possible, and waits for them to die.
-
-    .. code:: perl
-
-        $instance->stop();
-
-    Interactions with services are handled via one of the classed
-    derived from the abstract Cassandane::MessageStore class.  To create
-    a store for a particular service in an Instance:
-
-    .. code:: perl
-
-        $store = $instance->get_service('imap')->create_store();
-
-    For the imapd service in particular, Cassandane::IMAPMessageStore
-    wraps a Mail::IMAPTalk object which can be retrieved thus:
-
-    .. code:: perl
-
-        my $imaptalk = $store->get_client();
-
-    The Cassandane::Instance can also produce TestUser objects for handling the
-    data of individual users.  There are two methods:
-
-    .. code:: perl
-
-       # This will perform initialization for the user, ensuring some basic
-       # normal bookkeeping was done, and then return a TestUser object:
-       my $testuser = $instance->create_user('username');
-
-       # This will just create the TestUser object, without touching any data
-       # on disk.  (Its protocol clients will work, and Cyrus will create
-       # whatever records are needed as they're accessed.)
-       my $testuser = $instance->create_user_without_setup('username');
-
-    Also, the method ``default_user`` will return a default user for the
-    running test, generally named ``cassandane``.
-
-Cassandane::TestUser
-    This class represents a Cyrus user, and provides methods for getting
-    protocol clients and creating test data.
-
-    You can get a TestUser by calling ``create_user`` or
-    ``create_user_without_setup`` on the Cassandane::Instance object.
-
-    The following methods are provided:
-
-    ``jmap`` and ``jmap_ws``
-        These methods provide cached JMAP clients (Cassandane::JMAPTester and
-        Cassandane::JMAPTesterWS, respectively).  They have all of Cyrus's
-        capabilities enabled by default.
-
-    ``new_jmap`` and ``new_jmap_ws``
-        These methods construct new JMAP clients (Cassandane::JMAPTester and
-        Cassandane::JMAPTesterWS, respectively).  They have all of Cyrus's
-        capabilities enabled by default, but you can pass an array of using
-        strings to pick different capabilities.  Alternatively, you can pass a
-        hashref of options, which will be passed along to the JMAP::Tester
-        constructor.
-
-    ``carddav`` and ``caldav``
-        These methods return cached Net::CardDAVTalk and Net::CalDAVTalk
-        objects, respectively, for interacting with the user's data over those
-        protocols.
-
-    ``imap``
-        This method returns a new Mail::IMAPTalk object, for interacting with
-        the user's data over IMAP.
-
-    test data entity methods
-        These methods return test data factories.  For more information run
-        ``perldoc cassandane/Cassandane/TestEntity/DataType/{TYPE}.pm`` for the
-        type you're interested in.  In general, they will have the methods
-        ``get`` and ``create``, to retrieve or create new instances of that
-        datatype.
-
-        * addressbooks
-        * contacts
-        * emails
-        * mailboxes
-
-Cassandane::Config
-    Encapsulates the configuration information present in an imapd.conf
-    format configuration file.  Config objects are useful for passing
-    to the Cassandane::Instance constructor to set up Cyrus instances
-    with particular configuration options.
-
-    The Config module keeps a global Config object.  This object should
-    not be modified directly but should be cloned (see below).  To get
-    the default object:
-
-    .. code:: perl
-
-        my $config = Cassandane::Config->default();
-
-    Configs use a lightweight copy-on-write cloning mechanism.  The
-    clone() method can be used to create a new Config object based on a
-    parent Config object.  The child remembers it's parent.
-
-    .. code:: perl
-
-        my $child_config = $parent_config->clone();
-
-    The set() and get() methods can be used to set and get key-value
-    pairs from a Config object.  The set() method always works on the
-    object itself, but get() will walk back up the ancestry chain until
-    it finds a matching key.
-
-    .. code:: perl
-
-        $config->set(conversations => 'on');
-        $config->set(foo => '1', bar => '2');
-
-        my $foo = $config->get('foo');
-
-    The typical use for a Config object is:
-
-    .. code:: perl
-
-        my $config = Cassandane::Config->default()->clone();
-        $config->set(conversations => 'on');
-        my $instance = Cassandane::Instance->new(config => $config);
-
-Cassandane::Message
-    Encapsulates an RFC822 message, plus a set of non-RFC822 attributes
-    expressed as key-value pairs.   Message objects are returned from
-    MessageStore->read_message() and Generator->generate().
-
-    To create a new default Message object
-
-    .. code:: perl
-
-        my $msg = Cassandane::Message->new();
-
-    To create a Message object read from a file handle
-
-    .. code:: perl
-
-        my $fh = ...
-        my $msg = Cassandane::Message->new(fh => $fh);
-
-    To get all the RFC822 headers of a given name, as a reference
-    to an array of strings:
-
-    .. code:: perl
-
-        my $values = $msg->get_headers('Received');
-
-    To get an RFC822 header and enforce that there is only a single
-    header of that name, use
-
-    .. code:: perl
-
-        my $value = $msg->get_header('From');
-
-    To set an RFC822 header, replacing any previous headers of
-    the same name:
-
-    .. code:: perl
-
-        $msg->set_headers('From', 'Foo Bar <foo@bar.org>');
-
-    To set multiple RFC822 headers with the same name, replacing
-    any previous headers of that name:
-
-    .. code:: perl
-
-        my @values = ('baz', 'quux');
-        $msg->set_headers('Received', @values);
-
-    To add an RFC822 header:
-
-    .. code:: perl
-
-        $msg->add_header('Subject', 'Hello World');
-
-    To set the RFC822 body (as one big string)
-
-    .. code:: perl
-
-        $msg->set_body('....one enormous string...');
-
-    To get a non-RFC822 attribute (this may have be placed on the message
-    as a side effect of it's creation e.g. during an IMAP FETCH command):
-
-    .. code:: perl
-
-        my $cid = $msg->get_attribute('cid');
-
-Cassandane::Generator
-    Creates new Message objects with a number of useful default values
-    based on random words.  Has a constructor and a single function
-
-    .. code:: perl
-
-        my $gen = Cassandane::Generator->new();
-        my $msg = $gen->generate();
-
-    By default, messages will have values for the RFC822 body and the
-    following headers:
-
-    * Return-Path
-    * Received
-    * MIME-Version - 1.0
-    * Content-Type - text/plain; charset="us-ascii"
-    * Content-Transfer-Encoding - 7bit
-    * Subject
-    * From
-    * Message-ID
-    * Date
-    * To
-    * X-Cassandane-Unique - a string of hex digits, unique per generator call
-
-    Some of these can be overridden by providing options to generate()
-
-    .. code::
-
-      my $msg = $gen->generate(subject => "Hello world");
-
-    The following options can be used:
-
-    date
-        a DateTime object
-    from
-        a Cassandane::Address object
-    subject
-        a string
-    to
-        a Cassandane::Address object
-    messageid
-        a string
-
-3.2 Targeting specific versions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you're writing a new Cyrus feature, you can (and should) mark tests for that
-feature as requiring the new version of Cyrus.  Because a newer version of
-Cassandane is sometimes run against older versions of Cyrus, this lets the test
-running skip tests that absolutely require a newer Cyrus.
-
-There are two new magical subroutine attribute patterns:
-
-* ``:min_version_x_y_z``
-* ``:max_version_x_y_z``
-
-…where in both cases y and z are optional.
-
-These only apply to test suites inheriting from Cassandane::Cyrus::TestCase.
-Test suites inheriting from Cassandane::Unit::TestCase will ignore these
-attributes entirely -- but you probably shouldn't inherit from this anyway
-(unless you're testing Cassandane itself).
-
-So for example, you might test a feature that's new in master with
-something like:
-
-.. code:: perl
-
-    sub test_my_new_feature
-        :min_version_3_0
-    {
-         # [...]
-    }
-
-And you might continue to test some hypothetical feature that's been
-discontinued on master but still exists in the stable branch with
-something like:
-
-.. code:: perl
-
-    sub test_my_obsolete_feature
-        :max_version_2_5
-    {
-        # [...]
-    }
-
-Cassandane::Instance offers ``get_version()``.  It's able to detect versions as
-far back as 2.5.0.  So if you need to do some version-based conditionalisation
-within a test function (or within infrastructure), you can use something like:
-
-.. code:: perl
-
-    my ($major, $minor, $revision, $extra) = Cassandane::Instance->get_version()
-
-Cassandane::Test::Skip implements the skip handling.
-
-4. An example test
-------------------
+When a single test misbehaves, ``./testrunner.pl -f pretty -vvv Suite.test``
+prints each failure's error report inline and turns up the Cassandane and Cyrus
+logging; ``perldoc ./testrunner.pl`` explains where the logs land.
+
+Writing a test
+--------------
+
+A test is a subroutine whose name begins with ``test_``.  Most live as
+*tiny-tests*: one such subroutine to a file under
+``cassandane/tiny-tests/{Suite}/``, the file beginning with ``#!perl`` and
+``use Cassandane::Tiny;``.  Drop the file into the suite's directory and the
+suite module in ``Cassandane/Cyrus/`` picks it up automatically; run it with
+``dar test Suite.name``.
+
+The example that follows shows only the subroutine — the ``use
+Cassandane::Tiny;`` wrapper is understood.  The best way to see how the pieces
+fit together is to read a real one, lightly polished:
 
 .. code-block:: perl
    :linenos:
@@ -462,12 +122,19 @@ Cassandane::Test::Skip implements the skip handling.
     }
 
 This example shows off many of the most common things you'll be using when
-writing Cassandane tests.  First, we see the ``needs_dependency_icalvcard``
-attribute, telling the test planner to skip this test when ``icalvcard`` is not
-compiled into Cyrus.
+writing Cassandane tests.
 
-It then sets ``$user`` to the default user.  Most tests only need one user, and
-so can use the default user instead of creating one.  The test calls
+First, we see the ``needs_dependency_icalvcard`` attribute, telling the test
+planner to skip this test when ``icalvcard`` is not compiled into Cyrus.  These
+attributes go between the subroutine name and its signature; see `Test
+attributes`_ below.
+
+The ``xlog`` calls scattered through the test log a line to Cassandane's output
+describing what's about to happen.  They're not required, but they make a
+failing test far easier to follow, so use them liberally.
+
+The test then sets ``$user`` to the default user.  Most tests only need one
+user, and so can use the default user instead of creating one.  It calls
 ``$user->jmap`` to get a JMAP client for the user.  Although the client is a
 Cassandane::JMAPTester, you'll find most of the relevant documentation in
 `JMAP::Tester <https://metacpan.org/pod/JMAP::Tester>`__, its parent class.
@@ -500,13 +167,11 @@ sentence_named
 single_sentence
     This method asserts that the response has exactly one sentence in it.  If a
     sentence name is passed as an argument to this method, it also asserts that
-    the sentence has that name.  If both assertions are true, the sentence in
+    the sentence has that name.  If both assertions are true, the sentence is
     returned.
 
 Every sentence has methods for accessing the first, second, and third items in
 the array it represents:  name, arguments, and client_id.
-
-We'll see much of this used in this test, soon!
 
 From lines 8 through 15, the test is creating test data.  To make it easy to
 make test data (for example, to hide the creation of boring mandatory
@@ -534,3 +199,137 @@ ContactCard/query response.
 
 The rest of the test is more of the same.
 
+Assertions
+^^^^^^^^^^
+
+A test passes unless it dies or an assertion fails, so assertions are how you
+state what "correct" means.  The ones you'll reach for most often come from
+Test::Unit:
+
+``assert($bool)``, ``assert_str_equals($expect, $got)``,
+``assert_num_equals($expect, $got)``, ``assert_null`` / ``assert_not_null``,
+and ``assert_matches($regex, $string)`` for scalars; and
+``assert_deep_equals($expect, $got)`` for nested data structures.
+
+Cassandane adds more in ``Cassandane::Unit::TestCase``.  The most generally
+useful is ``assert_cmp_deeply``, which compares against `Test::Deep
+<https://metacpan.org/pod/Test::Deep>`__ matchers — ``bag`` (order-insensitive
+lists, as in the example above), ``superhashof`` (partial hashes), and so on —
+when an exact ``assert_deep_equals`` would be too strict.  There are also
+domain-specific assertions such as ``assert_mailbox_structure`` and
+``assert_syslog_matches``.
+
+Run ``perldoc Cassandane/Unit/TestCase.pm`` for the Cassandane assertions, and
+see the Test::Unit and Test::Deep documentation for the rest.
+
+Test attributes
+---------------
+
+A test subroutine can carry *attributes*, written between its name and its
+signature, that tell the test planner how and whether to run it.  These apply
+to suites inheriting from ``Cassandane::Cyrus::TestCase`` (which is almost all
+of them); suites inheriting directly from ``Cassandane::Unit::TestCase`` ignore
+them, but you shouldn't be inheriting from that unless you're testing
+Cassandane itself.
+
+The ones you'll meet first are the ``:needs_*`` family, which skip a test
+unless Cyrus was built with some capability:
+
+* ``:needs_component_NAME`` — a Cyrus component (e.g. ``httpd``) is enabled.
+* ``:needs_dependency_NAME`` — a compiled-in library (e.g. ``icalvcard``) is
+  present.
+
+Next are the version guards, which skip a test outside a range of Cyrus
+versions:
+
+* ``:min_version_x_y_z``
+* ``:max_version_x_y_z``
+
+…where ``y`` and ``z`` are optional.  These used to be required on any test for
+a new feature, and you'll still see them on a great many older tests, but they
+now matter only when a newer Cassandane runs against an *older or external*
+Cyrus — a replication test against a stable-branch server, say.  A test runs
+against the Cyrus in its own branch by default, so a new feature usually needs
+no guard at all.  When you do want one, a feature new in 3.0 is guarded with:
+
+.. code:: perl
+
+    sub test_my_new_feature
+        :min_version_3_0
+    {
+         # [...]
+    }
+
+and a feature that survives only on a stable branch with:
+
+.. code:: perl
+
+    sub test_my_obsolete_feature
+        :max_version_2_5
+    {
+        # [...]
+    }
+
+There is also a family of ``:want_*`` "magic" attributes that switch on
+services or features (replication, and so on) before the test runs.  For the
+full, current set of magic and ``:needs_*`` categories, read
+``Cassandane/Cyrus/TestCase.pm`` — this is exactly the kind of list that rots
+in prose, so the source is the reference.
+
+If you need to branch on the Cyrus version *inside* a test (or inside
+infrastructure) rather than skip the whole thing, ``Cassandane::Instance``
+offers ``get_version()``, which can detect versions as far back as 2.5.0:
+
+.. code:: perl
+
+    my ($major, $minor, $revision, $extra) = Cassandane::Instance->get_version()
+
+The skip handling itself lives in ``Cassandane::Test::Skip``.
+
+The object model
+----------------
+
+You can write a great many tests knowing only ``default_user`` and its
+factories, as above.  When you need more — a non-default configuration, several
+users, or a protocol other than JMAP — these are the objects underneath.  This
+is a conceptual map; for method-level detail, ``perldoc`` the modules named
+here.
+
+Cassandane::Instance
+    A running Cyrus: its own directory tree, config, ``master`` process, and
+    services such as ``imapd``.  A test's ``set_up`` normally builds one, starts
+    it, and tears it down afterward, so most tests never touch it directly.
+    An Instance also mints users — ``create_user('name')`` sets a user up on
+    disk, ``create_user_without_setup('name')`` just makes the object — and
+    ``default_user`` returns the standard user (usually ``cassandane``).  A
+    service on the Instance can hand you a message store, and from that a
+    protocol client (for imapd, a `Mail::IMAPTalk
+    <https://metacpan.org/pod/Mail::IMAPTalk>`__).
+
+Cassandane::TestUser
+    A single Cyrus user, and your usual entry point.  It vends protocol
+    clients — ``jmap`` and ``jmap_ws`` (cached) or ``new_jmap`` / ``new_jmap_ws``
+    (fresh, and able to select capabilities), ``caldav`` and ``carddav``, and
+    ``imap`` — and the test-data factories (``emails``, ``mailboxes``,
+    ``contacts``, ``addressbooks``, …) used in the example above.
+
+Cassandane::Config
+    An ``imapd.conf`` in object form, used to start an Instance with particular
+    options.  There's a shared default you should never mutate; instead clone it
+    and ``set`` what you need:
+
+    .. code:: perl
+
+        my $config = Cassandane::Config->default()->clone();
+        $config->set(conversations => 'on');
+        my $instance = Cassandane::Instance->new(config => $config);
+
+    Cloning is copy-on-write and ``get`` walks back up the ancestry, so a clone
+    sees its parent's values until it overrides them.
+
+Two more classes come up once you're generating or inspecting mail directly
+rather than through the factories: ``Cassandane::Message`` (an RFC822 message
+plus non-RFC822 attributes, as returned by a message store or the generator)
+and ``Cassandane::Generator`` (which produces plausible random messages).  Both
+are best read about at the source: ``perldoc Cassandane/Message.pm`` and
+``perldoc Cassandane/Generator.pm``.

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -204,14 +204,14 @@ Assertions
 
 A test passes unless it dies or an assertion fails, so assertions are how you
 state what "correct" means.  The ones you'll reach for most often come from
-Test::Unit:
+`Test::Unit::Assert <https://metacpan.org/pod/Test::Unit::Assert>`__:
 
 * ``assert_str_equals($expect, $got)``
 * ``assert_num_equals($expect, $got)``
 * ``assert_null($value)``
 * ``assert_not_null($value)``
 * ``assert_matches($regex, $string)``
-* ``assert_not_matches($regex, $string)``
+* ``assert_does_not_match($regex, $string)``
 * ``assert_deep_equals($expect, $got)`` for data structures
 
 Cassandane adds more in ``Cassandane::Unit::TestCase``.  The most generally

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -295,8 +295,6 @@ offers ``get_version()``, which can detect versions as far back as 2.5.0:
 
     my ($major, $minor, $revision, $extra) = Cassandane::Instance->get_version()
 
-The skip handling itself lives in ``Cassandane::Test::Skip``.
-
 The object model
 ----------------
 

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -206,10 +206,13 @@ A test passes unless it dies or an assertion fails, so assertions are how you
 state what "correct" means.  The ones you'll reach for most often come from
 Test::Unit:
 
-``assert($bool)``, ``assert_str_equals($expect, $got)``,
-``assert_num_equals($expect, $got)``, ``assert_null`` / ``assert_not_null``,
-and ``assert_matches($regex, $string)`` for scalars; and
-``assert_deep_equals($expect, $got)`` for nested data structures.
+* ``assert_str_equals($expect, $got)``
+* ``assert_num_equals($expect, $got)``
+* ``assert_null($value)``
+* ``assert_not_null($value)``
+* ``assert_matches($regex, $string)``
+* ``assert_not_matches($regex, $string)``
+* ``assert_deep_equals($expect, $got)`` for data structures
 
 Cassandane adds more in ``Cassandane::Unit::TestCase``.  The most generally
 useful is ``assert_cmp_deeply``, which compares against `Test::Deep

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -238,9 +238,17 @@ Cassandane itself.
 The ones you'll meet first are the ``:needs_*`` family, which skip a test
 unless Cyrus was built with some capability:
 
-* ``:needs_component_NAME`` — a Cyrus component (e.g. ``httpd``) is enabled.
-* ``:needs_dependency_NAME`` — a compiled-in library (e.g. ``icalvcard``) is
-  present.
+* ``:needs_CATEGORY_NAME`` - the thing named NAME in category CATEGORY is
+  present
+* ``:needs_CATEGORY_NAME(VALUE)`` - same thing, but it also must have the given
+  value
+
+You can see all the categories, names, and values by running the
+``cyr_buildinfo`` tool.  The most common categories are "component" for
+features that Cyrus can be built with or without and "dependency" for libraries
+that Cyrus may or may not have available.  Those two categories only tell you
+whether a dependency is present or not present, there's no useful value to
+test.
 
 Next are the version guards, which skip a test outside a range of Cyrus
 versions:

--- a/docsrc/developer/cassandane.rst
+++ b/docsrc/developer/cassandane.rst
@@ -341,13 +341,7 @@ Some Cassandane modules are documented in their source using Perl's Pod system.
 The pages below are rendered from that Pod when the docs are built.  (You can
 read the same text offline with ``perldoc``.)
 
-.. include:: cassandane-api/summary.inc
+.. The listing below is generated: a bullet per module plus the hidden toctree
+   that puts the pages in the navigation tree.
 
-.. The pages themselves are listed above; this hidden toctree is what actually
-   puts them in the navigation tree.
-
-.. toctree::
-    :glob:
-    :hidden:
-
-    cassandane-api/*
+.. include:: cassandane-api/listing.inc

--- a/tools/perl2rst
+++ b/tools/perl2rst
@@ -1,9 +1,39 @@
-#!/usr/bin/perl -w
-
+#!/usr/bin/perl
 use strict;
 use warnings;
 
 use Pod::POM::View::Restructured;
+
+# Optional "intelligent link" mode, enabled when the environment supplies a
+# namespace and/or a cross-reference map.  Without it, every L<> becomes a
+# (long-dead) search.cpan.org link; with it, links dispatch by target:
+#
+#   * a target that has a page of its own -> an internal :doc: cross-reference
+#   * another module in our namespace     -> literal text (no page to link to)
+#   * any other Module::Name              -> a metacpan.org link
+#   * L</section>                         -> an in-page link
+#
+# A L</section> whose section doesn't exist is left as a dangling in-page link
+# on purpose, so the doc build (under -W) fails and the broken Pod gets fixed
+# rather than silently masked.
+#
+# PERL2RST_NAMESPACE   a module-name prefix that counts as "ours"
+# PERL2RST_XREF_FILE   a file of "Module::Name<TAB>docname" lines, one per
+#                      module that has its own generated page
+my $namespace = $ENV{PERL2RST_NAMESPACE};
+
+my %xref;
+if (my $xref_file = $ENV{PERL2RST_XREF_FILE}) {
+    open my $fh, '<', $xref_file or die "can't read $xref_file: $!";
+    while (defined(my $line = <$fh>)) {
+        chomp $line;
+        my ($module, $docname) = split /\t/, $line, 2;
+        $xref{$module} = $docname if defined $docname && length $docname;
+    }
+    close $fh;
+}
+
+my $intelligent = defined($namespace) || %xref;
 
 {
     no warnings 'redefine';
@@ -11,8 +41,6 @@ use Pod::POM::View::Restructured;
         my ($self, $node) = @_;
 
         my $fmt = $node->format();
-
-        #print STDERR "got for: fmt='$fmt', text='" . $node->text() . "'\n";
 
         if ($fmt eq 'pod2rst') {
             my $text = $node->text();
@@ -27,11 +55,42 @@ use Pod::POM::View::Restructured;
 
         return $self->SUPER::view_for($node);
     };
+
+    # Render L<> ourselves in intelligent mode.  We capture the shipped method
+    # rather than calling SUPER:: -- SUPER:: from a glob-installed sub resolves
+    # against this script's package, not the view's.
+    my $orig_link = \&Pod::POM::View::Restructured::view_seq_link;
+    *Pod::POM::View::Restructured::view_seq_link = sub {
+        my ($self, $text) = @_;
+        return $orig_link->($self, $text) unless $intelligent;
+
+        my ($label, $target) = $text =~ /\A(.+?)\|(.+)\z/s
+                             ? ($1, $2)
+                             : ($text, $text);
+
+        # L</section> or L<"section">
+        if ($target =~ m{\A/(.+)\z}s) {
+            (my $section = $1) =~ s/\A"(.+)"\z/$1/;
+            return qq{`$section`_};
+        }
+
+        (my $module = $target) =~ s/\s+/ /g;
+
+        return qq{:doc:`$label <$xref{$module}>`} if $xref{$module};
+
+        if (defined($namespace) && $module =~ /\A\Q$namespace\E(?:::|\z)/) {
+            return qq{``$module``};
+        }
+
+        if ($module =~ /::/) {
+            return qq{`$label <https://metacpan.org/pod/$module>`_};
+        }
+
+        return $orig_link->($self, $text);
+    };
 }
 
 my $title = shift || die "Usage: $0 title < in > out";
 
 my $conv = Pod::POM::View::Restructured->new;
 my $output = $conv->convert_file(\*STDIN, "**$title**", \*STDOUT);
-
-

--- a/tools/perl2rst
+++ b/tools/perl2rst
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use File::Temp qw(tempfile);
 use Pod::POM::View::Restructured;
 
 # Optional "intelligent link" mode, enabled when the environment supplies a
@@ -17,9 +18,12 @@ use Pod::POM::View::Restructured;
 # on purpose, so the doc build (under -W) fails and the broken Pod gets fixed
 # rather than silently masked.
 #
-# PERL2RST_NAMESPACE   a module-name prefix that counts as "ours"
-# PERL2RST_XREF_FILE   a file of "Module::Name<TAB>docname" lines, one per
-#                      module that has its own generated page
+# PERL2RST_NAMESPACE     a module-name prefix that counts as "ours"
+# PERL2RST_XREF_FILE     a file of "Module::Name<TAB>docname" lines, one per
+#                        module that has its own generated page
+# PERL2RST_SUMMARY_FILE  a file to append a reST definition-list entry to for
+#                        this module: its :doc: link and the abstract from its
+#                        =head1 NAME line ("Module - the abstract goes here")
 my $namespace = $ENV{PERL2RST_NAMESPACE};
 
 my %xref;
@@ -93,4 +97,28 @@ my $intelligent = defined($namespace) || %xref;
 my $title = shift || die "Usage: $0 title < in > out";
 
 my $conv = Pod::POM::View::Restructured->new;
-my $output = $conv->convert_file(\*STDIN, "**$title**", \*STDOUT);
+
+# In summary mode we read the input twice -- once to lift the abstract out of
+# the NAME section for the module listing, once to convert -- so slurp it and
+# stage a temp file (convert_file wants something -r can stat, which an
+# in-memory filehandle is not).
+if (my $summary_file = $ENV{PERL2RST_SUMMARY_FILE}) {
+    my $content = do { local $/; <STDIN> };
+
+    if (defined(my $docname = $xref{$title})) {
+        my ($abstract) = $content
+            =~ /^=head1[ \t]+NAME\b.*\n(?:[ \t]*\n)+[ \t]*\S.*?\s+-\s+(.+?)[ \t]*$/m;
+        open my $sfh, '>>', $summary_file
+            or die "can't append to $summary_file: $!";
+        print $sfh "* :doc:`$title <$docname>` - ", ($abstract // '(no summary)'), "\n\n";
+        close $sfh;
+    }
+
+    my ($tmp_fh, $tmp_name) = tempfile(UNLINK => 1);
+    print $tmp_fh $content;
+    close $tmp_fh;
+    $conv->convert_file($tmp_name, "**$title**", \*STDOUT);
+}
+else {
+    $conv->convert_file(\*STDIN, "**$title**", \*STDOUT);
+}

--- a/tools/perl2rst
+++ b/tools/perl2rst
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 
-use File::Temp qw(tempfile);
 use Pod::POM::View::Restructured;
 
 # Optional "intelligent link" mode, enabled when the environment supplies a
@@ -18,12 +17,9 @@ use Pod::POM::View::Restructured;
 # on purpose, so the doc build (under -W) fails and the broken Pod gets fixed
 # rather than silently masked.
 #
-# PERL2RST_NAMESPACE     a module-name prefix that counts as "ours"
-# PERL2RST_XREF_FILE     a file of "Module::Name<TAB>docname" lines, one per
-#                        module that has its own generated page
-# PERL2RST_SUMMARY_FILE  a file to append a reST definition-list entry to for
-#                        this module: its :doc: link and the abstract from its
-#                        =head1 NAME line ("Module - the abstract goes here")
+# PERL2RST_NAMESPACE   a module-name prefix that counts as "ours"
+# PERL2RST_XREF_FILE   a file of "Module::Name<TAB>docname" lines, one per
+#                      module that has its own generated page
 my $namespace = $ENV{PERL2RST_NAMESPACE};
 
 my %xref;
@@ -97,28 +93,4 @@ my $intelligent = defined($namespace) || %xref;
 my $title = shift || die "Usage: $0 title < in > out";
 
 my $conv = Pod::POM::View::Restructured->new;
-
-# In summary mode we read the input twice -- once to lift the abstract out of
-# the NAME section for the module listing, once to convert -- so slurp it and
-# stage a temp file (convert_file wants something -r can stat, which an
-# in-memory filehandle is not).
-if (my $summary_file = $ENV{PERL2RST_SUMMARY_FILE}) {
-    my $content = do { local $/; <STDIN> };
-
-    if (defined(my $docname = $xref{$title})) {
-        my ($abstract) = $content
-            =~ /^=head1[ \t]+NAME\b.*\n(?:[ \t]*\n)+[ \t]*\S.*?\s+-\s+(.+?)[ \t]*$/m;
-        open my $sfh, '>>', $summary_file
-            or die "can't append to $summary_file: $!";
-        print $sfh "* :doc:`$title <$docname>` - ", ($abstract // '(no summary)'), "\n\n";
-        close $sfh;
-    }
-
-    my ($tmp_fh, $tmp_name) = tempfile(UNLINK => 1);
-    print $tmp_fh $content;
-    close $tmp_fh;
-    $conv->convert_file($tmp_name, "**$title**", \*STDOUT);
-}
-else {
-    $conv->convert_file(\*STDIN, "**$title**", \*STDOUT);
-}
+$conv->convert_file(\*STDIN, "**$title**", \*STDOUT);

--- a/tools/pod-index
+++ b/tools/pod-index
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+use v5.28.0;
+use warnings;
+
+use experimental 'signatures';
+
+use Getopt::Long::Descriptive;
+
+# Build the aggregate files for the generated Cassandane API docs from a list
+# of module stems -- paths under cassandane/, without the .pm, e.g.
+# "Cassandane/TestUser".  Each module's own page is rendered separately (by
+# perl2rst); this fills in the two files that describe the set as a whole:
+#
+#   --xref     the "Module::Name<TAB>docname" cross-reference that perl2rst
+#              reads to turn L<Some::Module> into an internal :doc: link
+#
+#   --listing  the reStructuredText that developer/cassandane.rst includes:
+#              one bullet per module (its :doc: link and the abstract from its
+#              =head1 NAME line), followed by a hidden toctree of the pages
+#
+# A docname is the absolute Sphinx name of a module's page, "<base>/<stem>".
+
+my ($opt, $usage) = describe_options(
+    '%c %o <module-stem>...',
+    [ 'xref',     'print the module-to-docname cross-reference' ],
+    [ 'listing',  'print the reST module listing and hidden toctree' ],
+    [],
+    [ 'base=s',   'doc-root-relative base for the generated pages',
+                  { default => '/developer/cassandane-api' } ],
+    [ 'srcdir=s', 'directory the stems are relative to; needed by --listing' ],
+    [ 'help',     'print this message and exit' ],
+);
+
+if ($opt->help or !($opt->xref xor $opt->listing)) {
+    print $usage->text;
+    exit($opt->help ? 0 : 1);
+}
+
+my @stems = @ARGV
+    or die "$0: no module stems given\n";
+
+sub module_of  ($stem) { $stem =~ s{/}{::}gr }
+sub docname_of ($stem) { $opt->base . "/" . $stem }
+
+if ($opt->xref) {
+    print module_of($_), "\t", docname_of($_), "\n" for @stems;
+    exit 0;
+}
+
+# --listing
+defined $opt->srcdir or die "$0: --listing needs --srcdir\n";
+
+for my $stem (@stems) {
+    printf "* :doc:`%s <%s>` - %s\n",
+        module_of($stem), docname_of($stem), abstract_of($stem);
+}
+
+print "\n.. toctree::\n   :hidden:\n\n";
+print "   ", docname_of($_), "\n" for @stems;
+
+# The abstract is the text after the " - " on the module's "=head1 NAME" line:
+#
+#     =head1 NAME
+#
+#     Cassandane::TestUser - a handle on a Cyrus user with test-related methods
+sub abstract_of ($stem) {
+    my $file = $opt->srcdir . "/" . $stem . ".pm";
+    open my $fh, '<', $file or die "$0: can't read $file: $!";
+    my $pod = do { local $/; <$fh> };
+    close $fh;
+
+    my ($abstract) = $pod
+        =~ /^=head1[ \t]+NAME\b.*\n(?:[ \t]*\n)+[ \t]*\S.*?\s+-\s+(.+?)[ \t]*$/m;
+
+    return $abstract // '(no summary)';
+}


### PR DESCRIPTION
This is more "rework the docs to be more navigable".  Also, to create better incentive structures for writing docs in the right place.  This PR comprises:

* converting testrunner.pl to GLD so it gets a usage message; adding Pod to it
* remove that content from the docsrc; you don't need it to just run/write quick tests
* update the cassandane.rst with more focus on "writing and running tests, the common day-to-day"
* ❗️publishing any present Cassandane Pod documentation to the cassandane page (later, probably want to expand this)

The changes I made to the Makefile.am feel a bit monstrous, but I wasn't sure whether (a) I could make them much better or (b) it was worth doing anyway.

There's a lot left to do, but I think this is a good increment to merge.  Likely future work:

* document more of Cassandane's perl
* (especially if we follow through on merging in Test::Unit)

Maybe significantly later:
* render non-Cassandane perl library docs, like Cyrus::IndexFile