### PR TITLE
jmap: log requests using calendars without jscalendarbis

### DIFF
--- a/cunit/jmap_util.testc
+++ b/cunit/jmap_util.testc
@@ -3,7 +3,33 @@
 #include "xmalloc.h"
 #include "util.h"
 #include "hash.h"
+#include "imap/jmap_api.h"
 #include "imap/jmap_util.h"
+
+#include "lib/libconfig.h"
+#include "lib/sessionid.h"
+#include "lib/strarray.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#define DBDIR "test-jmap-util-dbdir"
+
+static int set_up(void)
+{
+    config_read_string(DBDIR"/conf", NULL);
+    session_clear_id();
+    trace_set_id(NULL, 0);
+    return 0;
+}
+
+static int tear_down(void)
+{
+    session_clear_id();
+    trace_set_id(NULL, 0);
+    config_reset();
+    return 0;
+}
 
 static void test_patchobject(void)
 {
@@ -496,6 +522,59 @@ static void test_caleventid(void)
     TESTCASE("EMzzzzzzzzzzw", NULL, NULL, 18446744073709551615ULL);
 
     TESTCASE("ER20211207-EM-yV", NULL, "20211207", 1000);
+}
+
+#define WITHOUT_JSCAL_EVENT "event=jmap.calendars.without_jscalendarbis"
+
+/* Assert whether a "using" set with the given capabilities emits the
+ * "calendars without jscalendarbis" log line exactly once (or not at all). */
+static void assert_jscalendarbis_logged(bool with_calendars,
+                                        bool with_jscalendarbis,
+                                        bool expect_log)
+{
+    strarray_t using = STRARRAY_INITIALIZER;
+
+    strarray_add(&using, JMAP_URN_CORE);
+    if (with_calendars)
+        strarray_add(&using, JMAP_URN_CALENDARS);
+    if (with_jscalendarbis)
+        strarray_add(&using, JMAP_JSCALENDARBIS_EXTENSION);
+
+    CU_SYSLOG_MATCH_SUBSTR(WITHOUT_JSCAL_EVENT);
+    jmap_log_calendars_without_jscalendarbis(&using);
+    CU_ASSERT_SYSLOG(/* match */ 0, expect_log ? 1 : 0);
+
+    strarray_fini(&using);
+}
+
+static void test_jscalendarbis_warning(void)
+{
+    /*                           calendars  jscalendarbis  should log */
+    assert_jscalendarbis_logged( true,      false,         true  );
+    assert_jscalendarbis_logged( true,      true,          false );
+    assert_jscalendarbis_logged( false,     false,         false );
+    assert_jscalendarbis_logged( false,     true,          false );
+}
+
+static void test_jscalendarbis_warning_session(void)
+{
+    strarray_t using = STRARRAY_INITIALIZER;
+    char match[256];
+
+    strarray_add(&using, JMAP_URN_CALENDARS);
+
+    session_new_id();
+    trace_set_id("sometraceid", 0);
+
+    snprintf(match, sizeof(match),
+             WITHOUT_JSCAL_EVENT " r.sessionid=%s r.tid=sometraceid",
+             session_id());
+
+    CU_SYSLOG_MATCH_SUBSTR(match);
+    jmap_log_calendars_without_jscalendarbis(&using);
+    CU_ASSERT_SYSLOG(/* match */ 0, 1);
+
+    strarray_fini(&using);
 }
 
 /* vim: set ft=c: */

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -644,6 +644,8 @@ HIDDEN int jmap_api(struct transaction_t *txn,
         strarray_add(&using_capabilities, json_string_value(json_array_get(jusing, i)));
     }
 
+    jmap_log_calendars_without_jscalendarbis(&using_capabilities);
+
     /* Push client method calls on call stack */
     json_t *jmethod_calls = json_object_get(jreq, "methodCalls");
     for (i = json_array_size(jmethod_calls); i > 0; i--) {

--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -19,9 +19,11 @@
 #include "global.h"
 #include "hash.h"
 #include "index.h"
+#include "jmap_api.h"
 #include "jmap_ical.h"
 #include "jmap_util.h"
 #include "json_support.h"
+#include "logfmt.h"
 #include "search_query.h"
 #include "times.h"
 #include "user.h"
@@ -1413,6 +1415,22 @@ EXPORTED char *jmap_role_to_specialuse(const char *role)
     char *specialuse = strconcat("\\", role, (char *)NULL);
     specialuse[1] = toupper(specialuse[1]);
     return specialuse;
+}
+
+/* Just for a brief window, log anything using JMAP for Calendars without
+ * jscalendarbis.  We want to remove support for this configuration, so first:
+ * log if we saw it! */
+EXPORTED void jmap_log_calendars_without_jscalendarbis(
+    const strarray_t *using_capabilities)
+{
+    if (!strarray_contains(using_capabilities, JMAP_URN_CALENDARS)) return;
+    if (strarray_contains(using_capabilities, JMAP_JSCALENDARBIS_EXTENSION)) return;
+
+    struct logfmt lf = LOGFMT_INITIALIZER;
+    logfmt_init(&lf, "jmap.calendars.without_jscalendarbis");
+    logfmt_push_session(&lf);
+    syslog(LOG_NOTICE, "%s", logfmt_cstring(&lf));
+    logfmt_fini(&lf);
 }
 
 EXPORTED struct jmap_caleventid *jmap_caleventid_lookup(const char *id,

--- a/imap/jmap_util.h
+++ b/imap/jmap_util.h
@@ -68,6 +68,9 @@ extern const char *jmap_keyword_to_imap(const char *keyword);
 
 extern char *jmap_role_to_specialuse(const char *role);
 
+extern void jmap_log_calendars_without_jscalendarbis(
+    const strarray_t *using_capabilities);
+
 /* JMAP request parser */
 struct jmap_parser {
     struct buf buf;


### PR DESCRIPTION
Enabling JMAP calendars (JMAP_URN_CALENDARS) without also enabling the jscalendarbis extension (JMAP_JSCALENDARBIS_EXTENSION) was useful for the transition to JSCalendar 2.0, but we want to drop that configuration and assert that any use of calendars gets JSCalendar 2.0.

Emit a logfmt line when that combination appears.  Then we'll track down and eliminate any use cases like that.  Then we'll eliminate the old code path.