### PR TITLE
Cass TestEntity: Add a '->destroy' method

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPMailbox.pm
@@ -31,6 +31,7 @@ sub new
                  conversations_counted_flags => "\\Draft \\Flagged \$IsMailingList \$IsNotification \$HasAttachment",
                  httpmodules => 'carddav caldav jmap',
                  specialuse_extra => '\\XSpecialUse \\XChats \\XTemplates \\XNotes',
+                 jmap_nonstandard_extensions => 'yes',
                  notesmailbox => 'Notes',
                  httpallowcompress => 'no');
 

--- a/cassandane/Cassandane/TestEntity/Role/Factory.pm
+++ b/cassandane/Cassandane/TestEntity/Role/Factory.pm
@@ -91,5 +91,25 @@ sub _update {
     return;
 }
 
+sub _destroy {
+    my ($self, $instance, @rest) = @_;
+    @rest && Carp::confess("too many arguments to destroy");
+
+    my $dt = $self->datatype;
+    my $id = $instance->id;
+
+    my $jmap = $self->user->entity_jmap;
+
+    my $res = $jmap->request([[
+        "$dt/set",
+        { destroy => [ $id ] },
+        'FactorySetDestroy',
+    ]]);
+
+    $res->single_sentence("$dt/set")->as_set->assert_no_errors;
+
+    return;
+}
+
 no Moo::Role;
 1;

--- a/cassandane/Cassandane/TestEntity/Role/Instance.pm
+++ b/cassandane/Cassandane/TestEntity/Role/Instance.pm
@@ -47,5 +47,11 @@ has properties => (
     },
 );
 
+sub destroy {
+    my $self = shift;
+
+    $self->factory->_destroy($self, @_);
+}
+
 no Moo::Role;
 1;

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_create_delete
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_create_delete
@@ -5,40 +5,29 @@ sub test_mailbox_changes_create_delete
     :min_version_3_5 :NoAltNameSpace
     ($self)
 {
-    my $jmap = $self->{jmap};
-    my $imap = $self->{store}->get_client();
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
 
-
-    $imap->create('INBOX.foo');
+    $user->mailboxes->create;
 
     my $res = $jmap->CallMethods([
         ['Mailbox/get', { }, 'R1'],
     ]);
-    my $fooId;
-    if ($res->[0][1]{list}[0]{name} eq 'foo') {
-        $fooId = $res->[0][1]{list}[0]{id};
-    }
-    else {
-        $fooId = $res->[0][1]{list}[1]{id};
-    }
-    $self->assert_not_null($fooId);
     my $state = $res->[0][1]{state};
     $self->assert_not_null($state);
 
-    $imap->create('INBOX.bar');
+    $user->mailboxes->create;
 
     $res = $jmap->CallMethods([
         ['Mailbox/changes', {
             sinceState => $state,
         }, 'R1'],
     ]);
-    my $barId = $res->[0][1]{created}[0];
-    $self->assert_not_null($barId);
     $state = $res->[0][1]{newState};
     $self->assert_not_null($state);
 
-    $imap->create("INBOX.fuzz");
-    $imap->delete("INBOX.fuzz");
+    my $doomed = $user->mailboxes->create;
+    $doomed->destroy;
 
     $res = $jmap->CallMethods([
         ['Mailbox/changes', {


### PR DESCRIPTION
This makes it easy to destroy objects without having to construct the JMAP calls by hand.

Because the entity objects use non standard jmap extensions we must enable non standard exceptions in the suite(s) using them. For now I've fixed up Cassandane::Cyrus::JMAPMailbox only so I could convert a test to ensure this new method works.