### PR TITLE
sync_apply_unuser: don't clobber a renamed user's subscriptions

### DIFF
--- a/cassandane/tiny-tests/Replication/rename_user_subscriptions
+++ b/cassandane/tiny-tests/Replication/rename_user_subscriptions
@@ -1,0 +1,51 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# After a user rename, rolling replication must not lose the renamed user's
+# subscriptions.  The subscriptions file is stored keyed by the INBOX uniqueid,
+# which is unchanged across a rename, so the old and new userids share one
+# physical subs file.  A user rename logs USER <new> followed by UNUSER <old>,
+# and rolling replication runs USER before UNUSER; the UNUSER cleanup for the
+# old user must not nuke the subscriptions now owned by the new user.
+#
+sub test_rename_user_subscriptions
+    :NoAltNameSpace :AllowMoves :Replication :SyncLog :DelayedDelete
+    ($self)
+{
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+
+    my $master_store = $self->{master_store};
+    my $mastertalk = $master_store->get_client();
+
+    $mastertalk->create("INBOX.Test") || die;
+    $mastertalk->create("INBOX.Test.Sub") || die;
+    $mastertalk->subscribe("INBOX") || die;
+    $mastertalk->subscribe("INBOX.Test") || die;
+    $mastertalk->subscribe("INBOX.Test.Sub") || die;
+
+    # drop the conf dir lock, so the subs get written out
+    $mastertalk->logout();
+
+    xlog $self, "run initial replication";
+    $self->run_replication();
+    unlink($synclogfname);
+    $self->check_replication('cassandane');
+
+    xlog $self, "rename user";
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->rename("user.cassandane", "user.dest") || die;
+
+    xlog $self, "run rolling replication of the rename (USER dest + UNUSER cassandane)";
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+
+    xlog $self, "verify the replica still has dest's subscriptions";
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replicastore = $replicasvc->create_store(username => 'dest');
+    my $replicatalk = $replicastore->get_client();
+
+    my $subdata = $replicatalk->lsub("", "*");
+    my @names = sort map { $_->[2] } @$subdata;
+    $self->assert_deep_equals(['INBOX', 'INBOX.Test', 'INBOX.Test.Sub'], \@names);
+}

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -4654,18 +4654,30 @@ static int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
 
     user_nslock_t *user_nslock = user_nslock_lock_w(userid);
 
-    /* Nuke subscriptions */
-    /* ignore failures here - the subs file gets deleted soon anyway */
-    strarray_t *list = mboxlist_sublist(userid);
-    for (i = 0; i < list->count; i++) {
-        const char *name = strarray_nth(list, i);
-        mboxlist_changesub(name, userid, sstate->authstate, 0, 0, 0, /*silent*/1);
-    }
-
     mbentry_t *mbentry = NULL;
     char *inbox = mboxname_user_mbox(userid, 0);
     mboxlist_lookup_allow_all(inbox, &mbentry, NULL);
     free(inbox);
+
+    /* Only destroy this user's per-user data (subscriptions, seen, ...) when
+     * this is a genuine deletion.  If the INBOX has been renamed away (a
+     * modern-dirs tombstone), the per-user files are keyed by the INBOX
+     * uniqueid - which is unchanged across a rename - and so are now shared
+     * with the live user this INBOX was renamed to.  Nuking them here would
+     * clobber that live user's data.  This is the same condition that gates
+     * user_deletedata() below. */
+    int deletedata = mbentry && ((mbentry->mbtype & MBTYPE_LEGACY_DIRS) ||
+                                 !(mbentry->mbtype & MBTYPE_DELETED));
+
+    /* Nuke subscriptions */
+    /* ignore failures here - the subs file gets deleted soon anyway */
+    strarray_t *list = mboxlist_sublist(userid);
+    if (deletedata) {
+        for (i = 0; i < list->count; i++) {
+            const char *name = strarray_nth(list, i);
+            mboxlist_changesub(name, userid, sstate->authstate, 0, 0, 0, /*silent*/1);
+        }
+    }
 
     strarray_truncate(list, 0);
     mboxlist_usermboxtree(userid, NULL, addmbox_cb, list, 0);
@@ -4682,8 +4694,7 @@ static int sync_apply_unuser(struct dlist *kin, struct sync_state *sstate)
         if (r) goto done;
     }
 
-    if (mbentry && ((mbentry->mbtype & MBTYPE_LEGACY_DIRS) ||
-                    !(mbentry->mbtype & MBTYPE_DELETED))) {
+    if (deletedata) {
          r = user_deletedata(mbentry, 1);
     }
     else {


### PR DESCRIPTION
Subscriptions (and all other per-user files) are keyed by the INBOX uniqueid, which is unchanged across a user rename, so the old and new userids share one physical subs file.  A user rename logs USER <new> followed by UNUSER <old>, and rolling replication runs USER before UNUSER, so on the replica sync_apply_unuser(<old>) runs after the new user's subscriptions have already been synced in.

Its "nuke subscriptions" loop ran unconditionally, and because the defunct old userid resolves (via the name_history fallback in mboxname_conf_getpath) onto the shared uniqueid-keyed subs file, it deleted the new user's freshly-synced subscriptions.  The subs then only reappeared on the next full "sync_client -A", which never issues UNUSER for the vanished old user.

user_deletedata(), which wipes every other per-user file by uniqueid, was already gated on the tombstone predicate and so was correctly skipped for a renamed-away modern-dirs inbox; only the separate subs nuke sat outside that guard.  Hoist the inbox mbentry lookup above the nuke and gate the nuke on the same condition.