### PR TITLE
Cassandane: Add a separate jmap httpd for TestEntity use

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -628,6 +628,14 @@ sub _create_instances
             die 'Use of config_<testname> subs is not supported anymore';
         }
 
+        # TestEntity stuff
+        my $teport = Cassandane::PortManager::alloc("localhost");
+        $conf->set(
+            tejmap_jmap_nonstandard_extensions => 'yes',
+            tejmap_httpmodules => 'jmap caldav carddav',
+            tejmap_conversations => 'yes',
+        );
+
         $instance_params{config} = $conf;
         $instance_params{install_certificates} = $want->{install_certificates};
         $instance_params{smtpdaemon} = $want->{smtpdaemon};
@@ -646,6 +654,8 @@ sub _create_instances
         $self->{instance}->add_services(@{$want->{services}});
         $self->{instance}->_setup_for_deliver()
             if ($want->{deliver});
+
+        $self->{instance}->add_service(name => 'tejmap', port => $teport, argv => ['httpd']);
 
         if ($want->{squatter}) {
             $self->{instance}->add_daemon(

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -3229,10 +3229,16 @@ sub make_folder_intermediate
     $self->start();
 }
 
-sub _common_http_service_args ($self) {
-  $self->{_common_http_service_args} //= do {
-      my $service = $self->get_service("https")
-                 || $self->get_service("http");
+sub _common_http_service_args ($self, $want_service = "") {
+  $self->{"_common_http_service_args_$want_service"} //= do {
+      my $service;
+
+      if ($want_service) {
+          $service = $self->get_service($want_service);
+      } else {
+          $service = $self->get_service("https")
+                  || $self->get_service("http");
+      }
 
       $service
           || Carp::confess("can't build _common_http_service_args without an http service configured");
@@ -3250,7 +3256,7 @@ sub _common_http_service_args ($self) {
       };
   };
 
-  return $self->{_common_http_service_args}->%*;
+  return $self->{"_common_http_service_args_$want_service"}->%*;
 }
 
 my @DEFAULT_USING = qw(
@@ -3279,11 +3285,15 @@ sub new_jmaptester_ws_for_user ($self, $user, $new_arg = undef) {
   );
 }
 
+sub new_entity_jmaptester_for_user ($self, $user, $new_arg = undef) {
+  return $self->_new_jmaptester_for_user('Cassandane::JMAPTester', {}, $user, $new_arg, 'entity');
+}
+
 sub new_jmaptester_for_user ($self, $user, $new_arg = undef) {
   return $self->_new_jmaptester_for_user('Cassandane::JMAPTester', {}, $user, $new_arg);
 }
 
-sub _new_jmaptester_for_user($self, $tester_class, $tester_arg, $user, $new_arg = undef) {
+sub _new_jmaptester_for_user($self, $tester_class, $tester_arg, $user, $new_arg = undef, $is_entity = undef) {
     my %overrides;
     if ($new_arg) {
         %overrides  = ref $new_arg eq 'HASH'  ? %$new_arg
@@ -3291,11 +3301,13 @@ sub _new_jmaptester_for_user($self, $tester_class, $tester_arg, $user, $new_arg 
                     : Carp::confess("expected hash or array reference to ->new_jmaptester, got neither");
     }
 
-    unless ($self->{config}->get_bit('httpmodules', 'jmap')) {
-        Carp::croak("User JMAP::Tester requested, but jmap httpmodule not enabled");
+    unless ($is_entity) {
+        unless ($self->{config}->get_bit('httpmodules', 'jmap')) {
+            Carp::croak("User JMAP::Tester requested, but jmap httpmodule not enabled");
+        }
     }
 
-    my %arg = $self->_common_http_service_args;
+    my %arg = $self->_common_http_service_args($is_entity ? 'tejmap' : "");
 
     my $host = $arg{host};
     my $port = $arg{port};

--- a/cassandane/Cassandane/TestUser.pm
+++ b/cassandane/Cassandane/TestUser.pm
@@ -59,7 +59,7 @@ has entity_jmap => (
     is => 'ro',
     lazy => 1,
     default => sub ($self) {
-        $self->new_jmaptester({
+        $self->new_entity_jmaptester({
           ident => "entity_jmap/" . $self->username,
         });
     }
@@ -79,6 +79,10 @@ If the argument is an arrayref, it will be used as the default C<using> for the
 JMAPTester.
 
 =cut
+
+sub new_entity_jmaptester($self, $new_arg = undef) {
+    $self->instance->new_entity_jmaptester_for_user($self, $new_arg);
+}
 
 # Either 0-arg to get a default-config one, or provide just [using...] for
 # custom using, or {k=>v,...} to override constructor args.


### PR DESCRIPTION
This way, the specific configurations required for the TestEntity system don't need to be enabled on every test suite that uses it, so it Just Works.

This also means the daemon(s) under test can have specific configurations that may behave differently if the jmap configuration changes were enabled. The only thing this might not be true for is conversations must be enabled for httpd to support jmap, so conversations dbs may come into existence when normally they wouldn't if these tests use the jmap entities at all.