### PR TITLE
jmap_contact.c: do not rewrite vCard contents for immutable properties

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_set_immutable_props_no_rewrite_vcard
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_immutable_props_no_rewrite_vcard
@@ -1,0 +1,61 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_set_immutable_props_no_rewrite_vcard
+    ($self)
+{
+    my $user = $self->default_user;
+
+    xlog $self, "PUT a version 3.0 vCard";
+    my $card = <<~"EOF";
+    BEGIN:VCARD
+    VERSION:3.0
+    UID:574E6CCF-BAE4-4005-B478-222DD257224A
+    N:Gump;Forrest;;Mr.;
+    FN:Forrest Gump
+    LABEL;TYPE=WORK:1501 Broadway\\nNew York NY 10036\\nUSA
+    END:VCARD
+    EOF
+    $card =~ s/\r?\n/\r\n/gs;
+    $user->carddav->Request('PUT', "Default/forrest.vcf",
+        $card, 'Content-Type' => 'text/vcard');
+
+    xlog $self, "Get Card id and its immutable properties";
+    my @immutable = qw(
+        cyrusimap.org:href cyrusimap.org:blobId cyrusimap.org:size
+    );
+    my $got = $user->jmap->request([[
+        'ContactCard/get',
+        { properties => [ @immutable ] },
+        'R1',
+    ]])->single_sentence('ContactCard/get')->arguments->{list}[0];
+    my $card_id = $got->{id};
+    $self->assert_not_null($card_id);
+    $self->assert_not_null($got->{$_}) for @immutable;
+
+    xlog $self, "Update Card echoing back all of its immutable properties";
+    my $set = $user->jmap->request([[
+        'ContactCard/set',
+        {
+            update => {
+                $card_id => {
+                    id => $card_id,
+                    map { $_ => $got->{$_} } @immutable,
+                },
+            },
+        },
+        'R2',
+    ]])->single_sentence('ContactCard/set')->arguments;
+
+    xlog $self, "Assert update is accepted as a no-op";
+    $self->assert_null($set->{notUpdated}{$card_id});
+
+    xlog $self, "Assert vCard wasn't rewritten";
+    my $after = $user->jmap->request([[
+        'ContactCard/get',
+        { ids => [ $card_id ], properties => [ 'cyrusimap.org:blobId' ] },
+        'R3',
+    ]])->single_sentence('ContactCard/get')->arguments->{list}[0];
+    $self->assert_str_equals($got->{'cyrusimap.org:blobId'},
+        $after->{'cyrusimap.org:blobId'});
+}

--- a/cassandane/tiny-tests/JMAPContacts/card_set_readonly_sharee_no_rewrite_vcard
+++ b/cassandane/tiny-tests/JMAPContacts/card_set_readonly_sharee_no_rewrite_vcard
@@ -1,0 +1,103 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_card_set_readonly_sharee_no_rewrite_vcard
+    ($self)
+{
+    my $sharee = $self->default_user;
+
+    xlog $self, "Create sharer user with addressbooks";
+    my $sharer = $self->{instance}->create_user('sharer');
+    my $abook_a = $sharer->addressbooks->create;
+    my $abook_b = $sharer->addressbooks->create;
+
+    xlog $self, "Share addressbooks with sharee";
+    $abook_a->share_with($sharee => [ 'mayRead' ]);
+    my $abook_a_href = $abook_a->properties->{'cyrusimap.org:href'};
+
+    $abook_b->share_with($sharee => [ 'mayRead' ]);
+    my $abook_b_href = $abook_b->properties->{'cyrusimap.org:href'};
+
+    xlog $self, "Create version 3.0 vCard 3.0 as sharer";
+    my $card = <<~"EOF";
+    BEGIN:VCARD
+    VERSION:3.0
+    UID:574E6CCF-BAE4-4005-B478-222DD257224A
+    N:Gump;Forrest;;Mr.;
+    FN:Forrest Gump
+    LABEL;TYPE=WORK:1501 Broadway\\nNew York NY 10036\\nUSA
+    END:VCARD
+    EOF
+    $card =~ s/\r?\n/\r\n/gs;
+    $sharer->carddav->Request('PUT', $abook_a_href . "/forrest.vcf",
+        $card, 'Content-Type' => 'text/vcard');
+
+    xlog $self, "Get Card as sharee";
+    my $res = $self->{jmap}->CallMethods([
+        ['ContactCard/get', {
+            accountId => 'sharer',
+            properties => [ 'cyrusimap.org:blobId' ],
+        }, 'R1'],
+    ]);
+    my $card_id = $res->[0][1]{list}[0]{id};
+    my $blob    = $res->[0][1]{list}[0]{'cyrusimap.org:blobId'};
+    $self->assert_not_null($card_id);
+    $self->assert_not_null($blob);
+
+    xlog $self, "Update Card with unchanged addressbookIds";
+    $res = $self->{jmap}->CallMethods([
+        ['ContactCard/set', {
+            accountId => 'sharer',
+            update => {
+                $card_id => {
+                    addressBookIds => { $abook_a->id => JSON::true },
+                },
+            },
+        }, 'R2'],
+    ]);
+
+    xlog $self, "Assert addressBookIds update is accepted as a no-op";
+    # A no-op update reports the id as updated with a null value (no
+    # server-set properties changed), so check the id is present rather
+    # than non-null.
+    $self->assert_null($res->[0][1]{notUpdated}{$card_id});
+    $self->assert(exists $res->[0][1]{updated}{$card_id});
+
+    xlog $self, "Assert that the card was not rewritten";
+    $res = $self->{jmap}->CallMethods([
+        ['ContactCard/get', {
+            accountId => 'sharer',
+            ids => [ $card_id ],
+            properties => [ 'cyrusimap.org:blobId' ],
+        }, 'R3'],
+    ]);
+    $self->assert_str_equals($blob,
+        $res->[0][1]{list}[0]{'cyrusimap.org:blobId'});
+
+    xlog $self, "Update Card with changed addressbookIds";
+    $res = $self->{jmap}->CallMethods([
+        ['ContactCard/set', {
+            accountId => 'sharer',
+            update => {
+                $card_id => {
+                    addressBookIds => { $abook_b->id => JSON::true },
+                },
+            },
+        }, 'R2'],
+    ]);
+
+    xlog $self, "Assert addressBookIds update is denied";
+    $self->assert_null($res->[0][1]{updated}{$card_id});
+    $self->assert_not_null($res->[0][1]{notUpdated}{$card_id});
+
+    xlog $self, "Assert that the card was not rewritten";
+    $res = $self->{jmap}->CallMethods([
+        ['ContactCard/get', {
+            accountId => 'sharer',
+            ids => [ $card_id ],
+            properties => [ 'cyrusimap.org:blobId' ],
+        }, 'R3'],
+    ]);
+    $self->assert_str_equals($blob,
+        $res->[0][1]{list}[0]{'cyrusimap.org:blobId'});
+}

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -58,7 +58,14 @@ typedef struct {
     json_t *blobNotFound;
 } jmap_contact_errors_t;
 
-static int required_set_rights(json_t *props);
+/** Defines an addresbook membership change for a Card */
+enum addrbook_change {
+    ADDRBOOK_CHANGE_NONE = 0,  /* does not change addressbook membership */
+    ADDRBOOK_CHANGE_CREATE,    /* creates a Card in the addressbook */
+    ADDRBOOK_CHANGE_MOVE,      /* moves a Card out of its addressbook */
+};
+
+static int required_set_rights(json_t *props, enum addrbook_change change);
 
 static int jmap_contact_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx);
 
@@ -1373,7 +1380,21 @@ done:
     return 0;
 }
 
-static int required_set_rights(json_t *props)
+static bool _card_prop_is_immutable(const char *name)
+{
+    if (!strcmp(name, "id")) {
+        return true;
+    }
+    if (!strncmp(name, "cyrusimap.org:", 14)) {
+        const char *sub = name + 14;
+        return !strcmp(sub, "href") ||
+               !strcmp(sub, "blobId") ||
+               !strcmp(sub, "size");
+    }
+    return false;
+}
+
+static int required_set_rights(json_t *props, enum addrbook_change change)
 {
     int needrights = 0;
     const char *name;
@@ -1382,31 +1403,40 @@ static int required_set_rights(json_t *props)
     json_object_foreach(props, name, val) {
         const char *myname = name;
 
-        if (!strcmp(myname, "id") ||
-            !strcmp(myname, "x-href") ||
-            !strcmp(myname, "x-hasPhoto") ||
-            !strcmp(myname, "addressbookId")) {
+        if (_card_prop_is_immutable(myname)) {
             /* immutable */
         }
-        else if (!strcmp(myname, "addressBookIds") ||
-                 (!strncmp(myname, "cyrusimap.org:", 14) && (myname += 14) &&
-                  (!strcmp(myname, "href") ||
-                   !strcmp(myname, "blobId") ||
-                   !strcmp(myname, "size")))) {
-            /* immutable */
-        }
-        else if (!strcmp(myname, "importance")) {
-            /* writing shared meta-data (per RFC 5257) */
-            needrights |= JACL_SETPROPERTIES;
-        }
-        else if (!strcmp(myname, "isFlagged")) {
-            /* writing private meta-data */
-            needrights |= JACL_SETKEYWORDS;
+        else if (!strcmp(myname, "addressBookIds")) {
+            /* membership change; rights are determined by `change` below */
         }
         else {
-            /* writing vCard data */
-            needrights |= JACL_UPDATEITEMS;
+            /* a "cyrusimap.org:" prefix denotes Cyrus-specific meta-data */
+            if (!strncmp(myname, "cyrusimap.org:", 14)) myname += 14;
+
+            if (!strcmp(myname, "importance")) {
+                /* writing shared meta-data (per RFC 5257) */
+                needrights |= JACL_SETPROPERTIES;
+            }
+            else if (!strcmp(myname, "isFlagged")) {
+                /* writing private meta-data */
+                needrights |= JACL_SETKEYWORDS;
+            }
+            else {
+                /* writing vCard data */
+                needrights |= JACL_UPDATEITEMS;
+            }
         }
+    }
+
+    switch (change) {
+    case ADDRBOOK_CHANGE_CREATE:
+        needrights |= JACL_ADDITEMS;
+        break;
+    case ADDRBOOK_CHANGE_MOVE:
+        needrights |= JACL_REMOVEITEMS;
+        break;
+    case ADDRBOOK_CHANGE_NONE:
+        break;
     }
 
     return needrights;
@@ -9106,7 +9136,7 @@ static int _card_set_create(jmap_req_t *req,
         json_object_del(jcard, "addressBookIds");
     }
 
-    int needrights = required_set_rights(jcard);
+    int needrights = required_set_rights(jcard, ADDRBOOK_CHANGE_CREATE);
 
     /* Check permissions. */
     if (!mbentry || !jmap_hasrights_mbentry(req, mbentry, needrights)) {
@@ -9332,7 +9362,35 @@ static int _card_set_update(jmap_req_t *req, bool apply_empty_updates,
 
     mbentry = jmap_mbentry_from_dav(req, &cdata->dav);
 
-    int needrights = required_set_rights(jcard);
+    /* Determine whether this set relocates the card to a different address
+     * book. An addressBookIds naming the card's current book is a no-op (no
+     * move, no rewrite); a different book is a move that requires rights. */
+    bool is_move = false;
+    json_t *jabookids = json_object_get(jcard, "addressBookIds");
+    if (jabookids && json_object_size(jabookids) == 1) {
+        void *iter = json_object_iter(jabookids);
+        const char *abookid = json_object_iter_value(iter) == json_true() ?
+            json_object_iter_key(iter) : NULL;
+        if (abookid && *abookid == '#')
+            abookid = jmap_lookup_id(req, abookid + 1);
+
+        mbentry_t *tgtmbentry = NULL;
+        if (abookid) abookid_to_mbentry(req, abookid, &tgtmbentry);
+        if (tgtmbentry && mbentry) {
+            if (!strcmpsafe(tgtmbentry->name, mbentry->name)) {
+                /* sets the current address book: a no-op, not a move */
+                num_props--;
+            }
+            else {
+                /* sets a different address book: a move */
+                is_move = true;
+            }
+        }
+        mboxlist_entry_free(&tgtmbentry);
+    }
+
+    int needrights = required_set_rights(jcard,
+        is_move ? ADDRBOOK_CHANGE_MOVE : ADDRBOOK_CHANGE_NONE);
 
     int rights = mbentry ? jmap_myrights_mbentry(req, mbentry) : 0;
     if (!mbentry || (rights & needrights) != needrights) {
@@ -9358,6 +9416,22 @@ static int _card_set_update(jmap_req_t *req, bool apply_empty_updates,
     olduid = cdata->dav.imap_uid;
 
     annots = mailbox_extract_annots(*mailbox, &record);
+
+    /* Check for changes on immutable id property */
+    json_t *jid = json_object_get(jcard, "id");
+    if (jid && strcmpsafe(json_string_value(jid), id)) {
+        json_array_append_new(invalid, json_string("id"));
+        goto done;
+    }
+
+    /* Check other immutable properties, ignore value changes. */
+    {
+        const char *pname;
+        json_t *jval;
+        json_object_foreach(jcard, pname, jval) {
+            if (_card_prop_is_immutable(pname)) num_props--;
+        }
+    }
 
     const char *key = "cyrusimap.org:importance";
     json_t *jval;


### PR DESCRIPTION
This changes ContactCard/set{update} to not rewrite the vCard for if the update results in a no-op. This happens if the update only sets immutable properties or if the addressbookIds property is written by keeping the same addressbook. This prevents lossy conversions when the original vCard was version "3.0" and the updated vCard would become a version "4.0" vCard.