### PR TITLE
[3.12 backport] imapparse.c: move search-fuzzy-always check into get_search_program()

### DIFF
--- a/cunit/search_expr.testc
+++ b/cunit/search_expr.testc
@@ -48,7 +48,7 @@ static void test_get_search_program(void)
         searchargs = new_searchargs(".", 0, &ns, userid, authstate, isadmin); \
         pin = prot_readmap(_in, sizeof(_in)-1); \
         pout = prot_writebuf(&actual_errs); \
-        c = get_search_program(pin, pout, searchargs); \
+        c = get_search_program(pin, pout, 0/*quirks*/, searchargs); \
         CU_ASSERT_EQUAL(c, '\r'); \
         buf_cstring(&actual_errs); \
         CU_ASSERT_STRING_EQUAL(actual_errs.s, expected_errs); \

--- a/imap/cyr_virusscan.c
+++ b/imap/cyr_virusscan.c
@@ -351,7 +351,7 @@ int main (int argc, char *argv[])
 
         srock.searchargs = new_searchargs("*", GETSEARCH_CHARSET_KEYWORD,
                                           &scan_namespace, NULL, NULL, 1);
-        c = get_search_program(scan_in, scan_out, srock.searchargs);
+        c = get_search_program(scan_in, scan_out, 0/*quirks*/, srock.searchargs);
         prot_free(scan_in);
         prot_flush(scan_out);
         prot_free(scan_out);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -237,11 +237,10 @@ static struct event_groups {
 
 } *notify_event_groups = NULL;
 
-#define QUIRK_SEARCHFUZZY (1<<0)
 static struct id_data {
     hash_table params;
+    unsigned quirks;
     int did_id;
-    int quirks;
 } imapd_id = { HASH_TABLE_INITIALIZER, 0, 0 };
 
 #ifdef HAVE_SSL
@@ -6218,29 +6217,7 @@ static void cmd_search(const char *tag, const char *cmd)
 
     searchargs->maxargssize_mark = maxargssize_mark;
 
-    /* Set FUZZY search according to config and quirks */
-    static const char *annot = IMAP_ANNOT_NS "search-fuzzy-always";
-    char *inbox = mboxname_user_mbox(imapd_userid, NULL);
-    struct buf val = BUF_INITIALIZER;
-    if (imapd_id.quirks & QUIRK_SEARCHFUZZY) {
-        /* Quirks overrule anything */
-        searchargs->fuzzy_depth++;
-    }
-    else if (!annotatemore_lookupmask(inbox, annot, imapd_userid, &val) && val.len) {
-        /* User may override global config */
-        int b = config_parse_switch(buf_cstring(&val));
-        if (b > 0 || (b < 0 && config_getswitch(IMAPOPT_SEARCH_FUZZY_ALWAYS))) {
-            searchargs->fuzzy_depth++;
-        }
-    }
-    else if (config_getswitch(IMAPOPT_SEARCH_FUZZY_ALWAYS)) {
-        /* Use global config */
-        searchargs->fuzzy_depth++;
-    }
-    buf_free(&val);
-    free(inbox);
-
-    c = get_search_program(imapd_in, imapd_out, searchargs);
+    c = get_search_program(imapd_in, imapd_out, imapd_id.quirks, searchargs);
     if (c == EOF) {
         eatline(imapd_in, ' ');
         goto done;
@@ -6466,9 +6443,6 @@ static void cmd_sort(char *tag, int usinguid)
 
     searchargs->maxargssize_mark = maxargssize_mark;
 
-    if (imapd_id.quirks & QUIRK_SEARCHFUZZY)
-        searchargs->fuzzy_depth++;
-
     /* See if its ESORT */
     c = getword(imapd_in, &arg);
     if (c == EOF) goto error;
@@ -6481,7 +6455,7 @@ static void cmd_sort(char *tag, int usinguid)
     c = getsortcriteria(tag, &sortcrit);
     if (c == EOF) goto error;
 
-    c = get_search_program(imapd_in, imapd_out, searchargs);
+    c = get_search_program(imapd_in, imapd_out, imapd_id.quirks, searchargs);
     if (c == EOF) goto error;
 
     if (!IS_EOL(c, imapd_in)) {
@@ -6591,7 +6565,7 @@ static void cmd_thread(char *tag, int usinguid)
 
     searchargs->maxargssize_mark = maxargssize_mark;
 
-    c = get_search_program(imapd_in, imapd_out, searchargs);
+    c = get_search_program(imapd_in, imapd_out, imapd_id.quirks, searchargs);
     if (c == EOF) {
         eatline(imapd_in, ' ');
         goto done;

--- a/imap/imapd.h
+++ b/imap/imapd.h
@@ -61,6 +61,9 @@ extern char *imapd_userid;
 /* Authorization state for logged in userid */
 extern struct auth_state *imapd_authstate;
 
+/* Client quirks */
+#define QUIRK_SEARCHFUZZY (1<<0)
+
 struct octetinfo
 {
     int start_octet;

--- a/imap/imapparse.c
+++ b/imap/imapparse.c
@@ -1596,9 +1596,41 @@ static int get_search_criterion(struct protstream *pin,
  */
 EXPORTED int get_search_program(struct protstream *pin,
                                 struct protstream *pout,
+                                unsigned client_quirks,
                                 struct searchargs *searchargs)
 {
     int c;
+
+    /* Set FUZZY search according to config and quirks */
+    if (client_quirks & QUIRK_SEARCHFUZZY) {
+        /* Quirks overrule anything */
+        searchargs->fuzzy_depth++;
+    }
+    else {
+        int config_fuzzy = -1;
+
+        if (searchargs->userid) {
+            static const char *annot = IMAP_ANNOT_NS "search-fuzzy-always";
+            char *inbox = mboxname_user_mbox(searchargs->userid, NULL);
+            struct buf val = BUF_INITIALIZER;
+
+            if (!annotatemore_lookupmask(inbox, annot, searchargs->userid, &val)
+                && buf_len(&val)) {
+                /* User may override global config */
+                config_fuzzy = config_parse_switch(buf_cstring(&val));
+                if (config_fuzzy > 0)
+                    searchargs->fuzzy_depth++;
+            }
+
+            buf_free(&val);
+            free(inbox);
+        }
+
+        if (config_fuzzy < 0 && config_getswitch(IMAPOPT_SEARCH_FUZZY_ALWAYS)) {
+            /* Use global config */
+            searchargs->fuzzy_depth++;
+        }
+    }
 
     searchargs->root = search_expr_new(NULL, SEOP_AND);
 

--- a/imap/imapparse.h
+++ b/imap/imapparse.h
@@ -97,7 +97,7 @@ int getmodseq(struct protstream *pin, modseq_t *num);
 void eatline(struct protstream *pin, int c);
 
 int get_search_program(struct protstream *pin, struct protstream *pout,
-                       struct searchargs *searchargs);
+                       unsigned client_quirks, struct searchargs *searchargs);
 int get_search_return_opts(struct protstream *pin, struct protstream *pout,
                            struct searchargs *searchargs);
 

--- a/imap/search_test.c
+++ b/imap/search_test.c
@@ -142,7 +142,7 @@ static int do_search(const char *mboxname,
 
     gettimeofday(&start_time, NULL);
 
-    r = get_search_program(pin, pout, searchargs);
+    r = get_search_program(pin, pout, 0/*quirks*/, searchargs);
     if (r != '\r') {
         fprintf(stderr, "Couldn't parse IMAP search program\n");
         goto out;
@@ -211,7 +211,7 @@ static int do_serialise(char **words, int nwords)
 
     searchargs = new_searchargs(".", GETSEARCH_CHARSET_KEYWORD, &ns, userid, auth_newstate(userid), /*isadmin*/0);
 
-    r = get_search_program(pin, pout, searchargs);
+    r = get_search_program(pin, pout, 0/*quirks*/, searchargs);
     if (r != '\r') {
         fprintf(stderr, "Couldn't parse IMAP search program\n");
         goto out;


### PR DESCRIPTION
Cherry-pick of b5fa6d319 from master onto cyrus-imapd-3.12.

Requesting backport because the pre-fix behavior impacts production on 3.12: with `search_fuzzy_always: 1`, only cmd_search() consulted the option — cmd_sort() applied fuzzy only for QUIRK_SEARCHFUZZY (iOS) clients and cmd_thread() never — so SORT/THREAD criteria could not be served by the Xapian engine and degraded to sequential mailbox scans. Identical criteria returned contradictory results depending on the wrapping command. Observed on a 588k-message mailbox (3.12.2, full Xapian index, protocol telemetry):

```
A0003 UID SORT (DATE) US-ASCII ALL BODY FOOBAR
* OK [INPROGRESS ("A0003" 27644 588706)] Still processing...   <- scan
A0003 OK Completed (0 msgs in 28.399 secs)                     <- truncated at search_maxtime
A0004 UID SEARCH RETURN (ALL) BODY FOOBAR
A0004 OK Completed (363 msgs in 0.065 secs)                    <- Xapian
```

Since Roundcube (and other clients) lead their search flow with SORT-with-criteria, this makes search effectively unusable on large mailboxes despite a complete index. Verified locally that with this change the same flow is engine-served end-to-end (sub-second).
