### PR TITLE
imapd: honor FUZZY for HEADER searches of indexed fields

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -355,6 +355,9 @@ magic(JMAPNoHasAttachment => sub {
 magic(JMAPExtensions => sub {
     shift->config_set('jmap_nonstandard_extensions' => 'yes');
 });
+magic(SearchIndexHeaders => sub {
+    shift->config_set(search_index_headers => 'yes');
+});
 magic(SearchAttachmentExtractor => sub {
     my $port = Cassandane::PortManager::alloc("localhost");
     my $self = shift;

--- a/cassandane/tiny-tests/SearchFuzzy/header_fuzzy
+++ b/cassandane/tiny-tests/SearchFuzzy/header_fuzzy
@@ -1,0 +1,84 @@
+#!perl
+use Cassandane::Tiny;
+
+# This test asserts that a FUZZY HEADER search for a header which has a
+# designated search part in Xapian (like 'Subject') is evaluated equally
+# as if FUZZY search would have been requested for that particular field.
+# That is: searches for 'FUZZY HEADER Subject' and 'FUZZY SUBJECT' are
+# evaluated equally.
+#
+# A FUZZY HEADER search for a header without a designated search part is
+# evaluated equally to a non-FUZZY search, regardless how the config sets
+# `search_index_headers`: such a header either is not indexed at all,
+# or is indexed in one lumped part that does not record which field a term
+# came from, so it never is fuzzable.
+sub assert_header_fuzzy($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "Create and index test messages";
+    $self->make_message("running fast",
+        extra_headers => [ [ 'X-Nice-Day-For', 'running fast' ] ]) || die;
+    $self->make_message("walking slowly") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "FUZZY SUBJECT matches a stemmed variant";
+    my $seqnos = $talk->search('fuzzy', 'subject', 'runs');
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "FUZZY HEADER Subject matches a stemmed variant";
+    $seqnos = $talk->search('fuzzy', 'header', 'subject', 'runs');
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "FUZZY SUBJECT does not match a mid-word substring";
+    $seqnos = $talk->search('fuzzy', 'subject', 'unning');
+    $self->assert_cmp_deeply([], $seqnos);
+
+    xlog $self, "FUZZY HEADER Subject does not match a mid-word substring";
+    $seqnos = $talk->search('fuzzy', 'header', 'subject', 'unning');
+    $self->assert_cmp_deeply([], $seqnos);
+
+    xlog $self, "HEADER Subject without FUZZY matches a mid-word substring";
+    $seqnos = $talk->search('header', 'subject', 'unning');
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "FUZZY SUBJECT does not match an empty string";
+    $seqnos = $talk->search('fuzzy', 'subject', '');
+    $self->assert_cmp_deeply([], $seqnos);
+
+    xlog $self, "FUZZY HEADER Subject does not match an empty string";
+    $seqnos = $talk->search('fuzzy', 'header', 'subject', '');
+    $self->assert_cmp_deeply([], $seqnos);
+
+    xlog $self, "HEADER Subject without FUZZY matches an empty string";
+    $seqnos = $talk->search('header', 'subject', '');
+    $self->assert_cmp_deeply([1,2], $seqnos);
+
+    xlog $self, "FUZZY HEADER of an unindexed field matches a mid-word substring";
+    $seqnos = $talk->search('fuzzy', 'header', 'x-nice-day-for', 'unning');
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "HEADER of an unindexed field without FUZZY matches the same";
+    $seqnos = $talk->search('header', 'x-nice-day-for', 'unning');
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "FUZZY HEADER does not match a term from another header field";
+    $seqnos = $talk->search('fuzzy', 'header', 'x-nice-day-for', 'walking');
+    $self->assert_cmp_deeply([], $seqnos);
+
+    xlog $self, "FUZZY HEADER of an unindexed field does not match a stemmed variant";
+    $seqnos = $talk->search('fuzzy', 'header', 'x-nice-day-for', 'runs');
+    $self->assert_cmp_deeply([], $seqnos);
+}
+
+sub test_header_fuzzy__unindexed_headers($self)
+{
+    $self->assert_header_fuzzy();
+}
+
+sub test_header_fuzzy__indexed_headers
+    :SearchIndexHeaders
+    ($self)
+{
+    $self->assert_header_fuzzy();
+}

--- a/cassandane/tiny-tests/SearchFuzzy/header_fuzzy
+++ b/cassandane/tiny-tests/SearchFuzzy/header_fuzzy
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_header_fuzzy
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    $self->make_message("running fast") || die;
+    $self->make_message("walking slowly") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog "the dedicated SUBJECT key matches a stemmed variant";
+    my $uids = $talk->search('fuzzy', 'subject', 'runs');
+    $self->assert_deep_equals([1], $uids);
+
+    xlog "HEADER Subject must match the same content the same way,";
+    xlog "not fall back to a substring scan";
+    $uids = $talk->search('fuzzy', 'header', 'subject', 'runs');
+    $self->assert_deep_equals([1], $uids);
+
+    xlog "a header field that is not a search attribute keeps substring";
+    xlog "semantics";
+    $uids = $talk->search('fuzzy', 'header', 'x-nonexistent', 'runs');
+    $self->assert_deep_equals([], $uids);
+}

--- a/changes/next/header-search-honor-fuzzy
+++ b/changes/next/header-search-honor-fuzzy
@@ -1,0 +1,27 @@
+Description:
+
+Under FUZZY search, a HEADER search of a field with a designated search
+part (Subject, From, To, Cc, Bcc) is now evaluated like the dedicated
+search key: it is served from the search engine and gains stemming, and
+no longer matches substrings or the empty string. HEADER searches of
+other fields are unchanged.
+
+
+Documentation:
+
+None
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+#6157

--- a/imap/imapparse.c
+++ b/imap/imapparse.c
@@ -1142,9 +1142,20 @@ static int get_search_criterion(struct protstream *pin,
             c = getastring(pin, pout, &arg2);
             if (c <= EOF) goto missingarg;
 
-            e = search_expr_new(parent, SEOP_MATCH);
-            e->attr = search_attr_find_field(arg.s);
-            e->value.s = charset_convert(arg2.s, base->charset, charset_flags|CHARSET_KEEPCASE);
+            const search_attr_t *attr = search_attr_find_field(arg.s);
+            if (base->fuzzy_depth > 0 && search_attr_is_fuzzable(attr)) {
+                /* RFC 6203: a fuzzable header field (Subject, From, To, ...)
+                 * uses the same index-backed match as its dedicated search
+                 * key rather than a full-text scan. */
+                e = search_expr_new(parent, SEOP_FUZZYMATCH);
+                e->attr = attr;
+                e->value.s = xstrdup(arg2.s);
+            }
+            else {
+                e = search_expr_new(parent, SEOP_MATCH);
+                e->attr = attr;
+                e->value.s = charset_convert(arg2.s, base->charset, charset_flags|CHARSET_KEEPCASE);
+            }
             if (!e->value.s) {
                 e->op = SEOP_FALSE;
                 e->attr = NULL;

--- a/imap/imapparse.c
+++ b/imap/imapparse.c
@@ -796,18 +796,18 @@ bad:
 }
 
 
-static void string_match(search_expr_t *parent, const char *val,
-                         const char *aname, struct searchargs *base)
+static void attr_match(search_expr_t *parent, const char *val,
+                       const search_attr_t *attr, struct searchargs *base)
 {
     search_expr_t *e;
-    const search_attr_t *attr = search_attr_find(aname);
     enum search_op op = SEOP_MATCH;
     char *searchval;
 
     if (base->fuzzy_depth > 0 &&
         search_attr_is_fuzzable(attr)) {
         op = SEOP_FUZZYMATCH;
-        searchval = xstrdup(val); // keep search value as-is
+        // transcode to UTF-8, but leave normalization to the search engine
+        searchval = charset_convert(val, base->charset, CHARSET_KEEPCASE);
     }
     else searchval = charset_convert(val, base->charset, charset_flags|CHARSET_KEEPCASE);
 
@@ -818,6 +818,12 @@ static void string_match(search_expr_t *parent, const char *val,
         e->op = SEOP_FALSE;
         e->attr = NULL;
     }
+}
+
+static void string_match(search_expr_t *parent, const char *val,
+                         const char *aname, struct searchargs *base)
+{
+    attr_match(parent, val, search_attr_find(aname), base);
 }
 
 static void bytestring_match(search_expr_t *parent, const char *val,
@@ -1151,13 +1157,7 @@ static int get_search_criterion(struct protstream *pin,
             c = getastring(pin, pout, &arg2);
             if (c <= EOF) goto missingarg;
 
-            e = search_expr_new(parent, SEOP_MATCH);
-            e->attr = search_attr_find_field(arg.s);
-            e->value.s = charset_convert(arg2.s, base->charset, charset_flags|CHARSET_KEEPCASE);
-            if (!e->value.s) {
-                e->op = SEOP_FALSE;
-                e->attr = NULL;
-            }
+            attr_match(parent, arg2.s, search_attr_find_field(arg.s), base);
         }
         else goto badcri;
         break;

--- a/imap/search_expr.c
+++ b/imap/search_expr.c
@@ -3353,7 +3353,7 @@ EXPORTED const search_attr_t *search_attr_find_field(const char *field)
     char *key = NULL;
     static const search_attr_t proto = {
         "name",
-        SEA_FUZZABLE,
+        /*flags*/0,
         SEARCH_PART_NONE,
         SEARCH_COST_NONE,
         search_string_internalise,


### PR DESCRIPTION
Fixes #6157.

The generic `HEADER <field-name>` search key always built a SEOP_MATCH (substring) node, even under FUZZY and even when `<field-name>` reduces to an indexed, fuzzable attribute. The dedicated keys (SUBJECT, FROM, TO, CC, BCC) build a SEOP_FUZZYMATCH node via string_match() and are served from the search engine, so `HEADER SUBJECT x` fell back to a full-mailbox scan while `SUBJECT x` — the same header content per RFC 3501 §6.4.4 — used the index. Clients such as Roundcube phrase Subject/From/To searches as HEADER searches, so they could not use the index: on a 588k-message mailbox, an `OR HEADER SUBJECT / HEADER FROM / HEADER TO / BODY` search scanned for ~14 seconds where the keyed equivalent was index-served in ~0.3.

Factor the match-node construction out of string_match() into attr_match() and build the HEADER node with it too, so a field that reduces to a dedicated attribute matches exactly like its dedicated key. Arbitrary header fields keep substring semantics in every configuration: their generated attributes no longer claim SEA_FUZZABLE, a previously unconsumed flag that should not have been set; search_attr_find_field reduces indexed fields to their dedicated, fuzzable attributes.

Two tests: header_fuzzy asserts FUZZY HEADER Subject matches a stemmed variant the same way the dedicated SUBJECT key does — a stem match cannot be served by the substring fallback — and that a header field with no search attribute keeps substring semantics both ways (a mid-word substring matches, a stemmed variant does not). header_fuzzy_xh repeats the assertions under search_index_headers, additionally pinning that a HEADER search is never served from the field-less indexed header text. Both fail on current master and pass with the change; the full Cyrus::SearchFuzzy suite passes on current master with this branch.