### PR TITLE
search: resume a batched update where its last batch stopped

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -381,6 +381,9 @@ magic(SearchEngineSquat => sub {
 magic(SearchNormalizationMax20000 => sub {
     shift->config_set(search_normalisation_max => 20000);
 });
+magic(SearchBatchsize20 => sub {
+    shift->config_set(search_batchsize => 20);
+});
 magic(SearchMaxtime1Sec => sub {
     shift->config_set(search_maxtime => 1);
 });

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -390,6 +390,9 @@ magic(SearchEngineSquat => sub {
 magic(SearchNormalizationMax20000 => sub {
     shift->config_set(search_normalisation_max => 20000);
 });
+magic(SearchBatchsize20 => sub {
+    shift->config_set(search_batchsize => 20);
+});
 magic(SearchMaxtime1Sec => sub {
     shift->config_set(search_maxtime => 1);
 });

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_index_default
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_index_default
@@ -1,0 +1,63 @@
+#!perl
+use Cassandane::Tiny;
+use POSIX qw(WNOHANG);
+
+sub test_squatter_index_default
+    :SearchBatchsize20
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    my $basedir = $self->{instance}->{basedir};
+    my $outfile = "$basedir/audit.tmp";
+
+    xlog $self, "append enough messages for three full batches and a partial one";
+    my $nmsgs = 65;
+    foreach my $i (1..$nmsgs) {
+        $self->make_message("filler $i") || die;
+    }
+
+    xlog $self, "a bare squatter run must complete: when broken it re-selects the same batch forever";
+    my $pid = $self->{instance}->run_command(
+        {cyrus => 1, background => 1}, 'squatter');
+    my $done = 0;
+    my $batchlines = 0;
+    eval {
+        timed_wait(sub {
+            if (waitpid($pid, WNOHANG) == $pid) {
+                $done = 1;
+                return 1;
+            }
+            # a correct run logs one batching line per full batch, so a
+            # fourth one means it is looping
+            $batchlines += scalar $self->{instance}->getsyslog(qr/batching/);
+            return $batchlines > 3;
+        }, description => "squatter to finish", maxwait => 60);
+    };
+    # kill a looping squatter rather than letting it outlive the test
+    eval { $self->{instance}->stop_command($pid) } if not $done;
+    $self->assert($done);
+
+    xlog $self, "every message must be searchable";
+    $talk->select('INBOX');
+    my $uids = $talk->search('fuzzy', 'subject', 'filler');
+    $self->assert_num_equals($nmsgs, scalar @$uids);
+
+    xlog $self, "one run indexes each message once: no batch may re-add an earlier one";
+    my $xapdirs = ($self->{instance}->run_mbpath(-u => 'cassandane'))->{xapian};
+    my ($gdocs, $parts) = $self->delve_docs($xapdirs->{t1} . "/xapian");
+    $self->assert_num_equals($nmsgs, scalar @$gdocs);
+
+    xlog $self, "audit reports no unindexed messages";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'squatter', '-A');
+    open my $fh, '<', $outfile or die "open $outfile: $!";
+    my @audits = readline($fh);
+    close $fh;
+    $self->assert_num_equals(0, scalar @audits);
+
+    xlog $self, "an incremental run must find nothing left to index";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+    ($gdocs, $parts) = $self->delve_docs($xapdirs->{t1} . "/xapian");
+    $self->assert_num_equals($nmsgs, scalar @$gdocs);
+}

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_index_default
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_index_default
@@ -1,0 +1,57 @@
+#!perl
+use Cassandane::Tiny;
+use POSIX qw(WNOHANG);
+
+sub test_squatter_index_default
+    :SearchBatchsize20
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    my $basedir = $self->{instance}->{basedir};
+    my $outfile = "$basedir/audit.tmp";
+
+    xlog "append more messages than search_batchsize (default 20)";
+    foreach my $i (1..25) {
+        $self->make_message("filler $i") || die;
+    }
+
+    xlog "a bare squatter run must complete: when broken it re-selects";
+    xlog "the same batch forever, logging the batching line each pass";
+    my $pid = $self->{instance}->run_command(
+        {cyrus => 1, background => 1}, 'squatter');
+    my $done = 0;
+    my $batchlines = 0;
+    foreach (1..60) {
+        if (waitpid($pid, WNOHANG) == $pid) {
+            $done = 1;
+            last;
+        }
+        # a correct run logs "batching" once; twice means the loop
+        $batchlines += scalar $self->{instance}->getsyslog(qr/batching/);
+        last if $batchlines >= 2;
+        sleep 1;
+    }
+    # kill a looping squatter rather than letting it outlive the test
+    eval { $self->{instance}->stop_command($pid) } if not $done;
+    $self->assert($done);
+
+    $talk->select('INBOX');
+    my $uids = $talk->search('fuzzy', 'subject', 'filler');
+    $self->assert_num_equals(25, scalar @$uids);
+
+    xlog "a second bare run must not add duplicate documents";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $xapdirs = ($self->{instance}->run_mbpath(-u => 'cassandane'))->{xapian};
+    my ($gdocs, $parts) = $self->delve_docs($xapdirs->{t1} . "/xapian");
+    $self->assert_num_equals(25, scalar @$gdocs);
+
+    xlog "audit reports no unindexed messages";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'squatter', '-A');
+    open my $fh, '<', $outfile or die "open $outfile: $!";
+    my @audits = readline($fh);
+    close $fh;
+    $self->assert_num_equals(0, scalar @audits);
+}

--- a/changes/next/search-batch-resume
+++ b/changes/next/search-batch-resume
@@ -1,0 +1,25 @@
+Description:
+
+A batched squatter update now resumes where its previous batch stopped.
+A non-incremental Xapian run completes mailboxes larger than
+search_batchsize instead of re-selecting the same first batch forever.
+
+
+Documentation:
+
+:cyrusman:`squatter(8)`
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+#6156

--- a/docsrc/reference/manpages/systemcommands/squatter.rst
+++ b/docsrc/reference/manpages/systemcommands/squatter.rst
@@ -48,9 +48,9 @@ reduce IMAP SEARCH times on a mailbox.
 
 **mode** is one of indexer, search, rolling, synclog, compact or audit.
 
-By default, **squatter** creates an index of ALL messages in the
-mailbox, not just those since the last time that it was run.  The
-**-i** option is used to select incremental updates.  Any messages
+By default, **squatter** brings the search index up to date: when it
+completes, ALL messages in the mailbox are indexed.  How existing
+index data is treated depends on the search engine (see **-i**).  Any messages
 appended to the mailbox after **squatter** is run, will NOT be included
 in the index.  To include new messages in the index, **squatter** must
 be run again, or on a regular basis via crontab, an entry in the EVENTS
@@ -173,7 +173,10 @@ Options
 
 .. option:: -i, --incremental
 
-    Incremental updates where indexes already exist.
+    Incremental updates where indexes already exist.  For the *Xapian*
+    engine this is implied unless **-Z** is given.  For the *SQUAT*
+    engine the default is to rebuild each mailbox's index completely,
+    and **-i** selects incremental updates.
 
 .. option:: -N name, --name=name
 
@@ -294,6 +297,9 @@ Options
     Reindex all the messages before compacting.  This mode reads all
     the lists of messages indexed by the listed tiers, and re-indexes
     them into a temporary database before compacting that into place.
+    Reindexing covers only messages already recorded in the index; it
+    does not add messages that were never indexed.  Run **squatter** in
+    index mode to add those.
     Xapian only.
     |v3-new-feature|
 
@@ -309,7 +315,10 @@ Options
     When indexing messages, use the Xapian internal cyrusid rather than
     referencing the ranges of already indexed messages to know if a
     particular message is indexed.  Useful if the ranges get out of
-    sync with the actual messages (e.g. if files on a tier are lost)
+    sync with the actual messages (e.g. if files on a tier are lost).
+    Without **-i**, every message in the mailbox is checked against the
+    index; with **-i**, only messages beyond the last recorded index
+    point are checked.
     Xapian only.
     |master-new-feature|
 

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -214,8 +214,7 @@ static int search_batch_size(void)
 static int flush_batch(search_text_receiver_t *rx,
                        struct mailbox *mailbox,
                        int flags,
-                       seqset_t *uids,
-                       size_t *nindexedptr)
+                       seqset_t *uids)
 {
     int i;
     int r = 0;
@@ -284,8 +283,6 @@ static int flush_batch(search_text_receiver_t *rx,
         r = rx->flush(rx);
         if (r) goto done;
     }
-
-    if (nindexedptr) *nindexedptr = msgs.count;
 
 done:
     for (i = 0 ; i < msgs.count ; i++) {
@@ -461,9 +458,11 @@ static void select_messages_to_index(search_text_receiver_t *rx,
                                      struct mailbox *mailbox,
                                      int min_indexlevel,
                                      int flags,
+                                     uint32_t resumeuid,
                                      seqset_t *uids,
                                      dynarray_t *attachparts,
-                                     int *is_incomplete)
+                                     int *is_incomplete,
+                                     uint32_t *nextuid)
 {
     int reindex_partials = flags & SEARCH_UPDATE_REINDEX_PARTIALS;
     int batch_size = search_batch_size();
@@ -474,15 +473,21 @@ static void select_messages_to_index(search_text_receiver_t *rx,
      * ranges matching the GUID in conversations DB later, we might think we've
      * indexed it when we actually haven't */
     struct mailbox_iter *iter = mailbox_iter_init(mailbox, 0, ITER_SKIP_UNLINKED);
-    if ((flags & SEARCH_UPDATE_INCREMENTAL) && !reindex_partials)
-        mailbox_iter_startuid(iter, rx->first_unindexed_uid(rx));
+    uint32_t startuid = resumeuid;
+    if ((flags & SEARCH_UPDATE_INCREMENTAL) && !reindex_partials) {
+        uint32_t first_unindexed = rx->first_unindexed_uid(rx);
+        if (first_unindexed > startuid) startuid = first_unindexed;
+    }
+    if (startuid) mailbox_iter_startuid(iter, startuid);
 
     while ((msg = mailbox_iter_step(iter))) {
         const struct index_record *record = msg_record(msg);
         if ((flags & SEARCH_UPDATE_BATCH) && nmsgs >= batch_size) {
             syslog(LOG_INFO, "search_update_mailbox batching %d messages to %s",
                     nmsgs, mailbox_name(mailbox));
+            /* the next update resumes from this message */
             *is_incomplete = 1;
+            *nextuid = record->uid;
             break;
         }
 
@@ -511,12 +516,12 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
                                    struct mailbox **mailboxptr,
                                    int min_indexlevel,
                                    int flags,
-                                   size_t *nindexedptr)
+                                   uint32_t *resumeuidptr)
 {
     int r = 0;                  /* Using IMAP_* not SQUAT_* return codes here */
     int is_incomplete = 0;
+    uint32_t nextuid = 0;
     bool in_mailbox = false;
-    size_t nindexed = 0;
     seqset_t *uids = seqset_init(0, SEQ_SPARSE);
     dynarray_t attachparts = DYNARRAY_INITIALIZER(sizeof(struct attachpart));
     char *mycachedir = NULL;
@@ -531,15 +536,15 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
 
     // Determine the messages to index, and the parts to extract text from
 
-    select_messages_to_index(rx, mailbox, min_indexlevel, flags, uids,
-                             &attachparts, &is_incomplete);
+    select_messages_to_index(rx, mailbox, min_indexlevel, flags, *resumeuidptr,
+                             uids, &attachparts, &is_incomplete, &nextuid);
 
     if (!seqset_first(uids))
         goto done;
 
     if (!dynarray_size(&attachparts)) {
         // No attachment text to extract, index these messages right away.
-        r = flush_batch(rx, mailbox, flags, uids, &nindexed);
+        r = flush_batch(rx, mailbox, flags, uids);
         goto done;
     }
 
@@ -587,8 +592,9 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
                 lf_u("uidvalidity", uidvalidity),
                 lf_u("new_uidvalidity", mailbox->i.uidvalidity));
         // None of the selected messages got indexed. Have the caller retry
-        // this mailbox, rather than reporting it as indexed.
+        // this mailbox from the start, rather than reporting it as indexed.
         is_incomplete = 1;
+        nextuid = 0;
         goto done;
     }
 
@@ -610,14 +616,13 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
         attachextract_set_cacheonly(1);
     }
 
-    r = flush_batch(rx, mailbox, flags, uids, &nindexed);
+    r = flush_batch(rx, mailbox, flags, uids);
 
     if (!txcacheonly) {
         attachextract_set_cacheonly(0);
     }
 
  done:
-    if (nindexedptr) *nindexedptr = nindexed;
     if (mycachedir) {
         attachextract_set_cachedir(NULL);
         removedir(mycachedir);
@@ -633,7 +638,11 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
         if (!r) r = r2;
     }
     if (r) return r;
-    return is_incomplete ? IMAP_AGAIN : 0;
+    if (is_incomplete) {
+        *resumeuidptr = nextuid;
+        return IMAP_AGAIN;
+    }
+    return 0;
 }
 
 EXPORTED int search_end_update(search_text_receiver_t *rx)

--- a/imap/search_engines.h
+++ b/imap/search_engines.h
@@ -226,14 +226,16 @@ search_text_receiver_t *search_begin_update(int verbose);
  * min_indexlevel yet. Returns IMAP_AGAIN if the mailbox needs another
  * update to complete, an IMAP error code on error, or 0.
  *
- * If nindexedptr is not NULL, it is set to the number of messages this
- * update indexed. A caller that repeats an update returning IMAP_AGAIN
- * must use it to tell an update that made progress from one that did not,
- * so that it does not repeat forever. */
+ * *resumeuidptr must not be NULL. On entry it is the lowest uid this
+ * update considers, 0 for all messages; on IMAP_AGAIN it is set to the uid
+ * the next update must resume from. A caller that repeats an update
+ * returning IMAP_AGAIN must pass the same variable every time and use it to
+ * tell an update that made progress from one that did not, so that it does
+ * not repeat forever. */
 int search_update_mailbox(search_text_receiver_t *rx,
                           struct mailbox **mailboxptr,
                           int min_indexlevel, int flags,
-                          size_t *nindexedptr);
+                          uint32_t *resumeuidptr);
 int search_end_update(search_text_receiver_t *rx);
 
 /* Create a search text receiver for snippets. For each non-empty

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -1224,6 +1224,19 @@ int main(int argc, char **argv)
             fatal(error_message(r), EX_CONFIG);
     }
 
+    /* For the Xapian engine, non-incremental indexing cannot complete
+     * mailboxes larger than search_batchsize (the same batch is built
+     * on every pass) and re-adds duplicate documents for mailboxes
+     * that fit in one batch.  Imply -i unless -Z supplies its own
+     * per-message index check.  The squat engine keeps its documented
+     * rebuild-by-default behavior. */
+    if ((mode == INDEXER || mode == SYNCLOG) &&
+        !incremental_mode && !xapindexed_mode &&
+        config_getenum(IMAPOPT_SEARCH_ENGINE) == IMAP_ENUM_SEARCH_ENGINE_XAPIAN) {
+        syslog(LOG_NOTICE, "xapian: forcing incremental mode (-i implied)");
+        incremental_mode = 1;
+    }
+
     if (mode == ROLLING || mode == SYNCLOG) {
         signals_set_shutdown(&shut_down);
         signals_add_handlers(0);

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -280,6 +280,7 @@ static int index_one(const char *name, int blocking)
 {
     struct mailbox *mailbox = NULL;
     int nunproductive = 0;
+    uint32_t resumeuid = 0;
     int r;
     int flags = SEARCH_UPDATE_BATCH;
 
@@ -382,8 +383,8 @@ again:
         }
     }
 
-    size_t nindexed = 0;
-    r = search_update_mailbox(rx, &mailbox, reindex_minlevel, flags, &nindexed);
+    uint32_t prevuid = resumeuid;
+    r = search_update_mailbox(rx, &mailbox, reindex_minlevel, flags, &resumeuid);
 
     mailbox_close(&mailbox);
 
@@ -394,7 +395,7 @@ again:
         /* Batching an update indexes messages, so keep going. An update
          * that indexed nothing, e.g. because the mailbox got recreated
          * while we extracted its attachment text, may never complete. */
-        if (nindexed) {
+        if (resumeuid > prevuid) {
             nunproductive = 0;
             goto again;
         }


### PR DESCRIPTION
Fixes #6156.

`search_update_mailbox()` indexes at most `search_batchsize` messages per call and returns `IMAP_AGAIN`; squatter repeats the call until the mailbox is complete. Every repeat selected messages from the start of the mailbox again. An incremental update was unaffected, because it starts at the first UID its indexed ranges do not cover and those ranges advance with every batch. A non-incremental update ignores the ranges by design: with Xapian it re-selected the same first batch on every repeat, so bare `squatter` never completed a mailbox larger than `search_batchsize`, and re-added that batch's documents on every pass until it was killed.

This carries a resume UID across the repeats — the UID of the message that tripped the batch limit — so each repeat continues where the last one stopped. It replaces the `nindexedptr` parameter added in #6045: squatter now tells an update that made progress from one that did not by whether the resume UID advanced.

Reworked after #6045 landed. The earlier version of this PR made bare `squatter` imply `-i` for Xapian. #6045 added `squatter_createdmodseq_reindex`, which runs bare `squatter` on an already-indexed mailbox specifically so that its documents get re-added and the index generation bumps — implying `-i` breaks that test. So this version leaves the meaning of a bare run alone and only fixes the batching, which resolves #6156.

The test appends more messages than three batches hold and asserts a bare run completes, that every message is searchable, that one run indexes each message once, that `squatter -A` reports nothing, and that a following `-i` run adds nothing. It fails on current master (the run loops) and passes with the fix. The full `Cyrus::SearchFuzzy` suite passes on current master with this branch.