### PR TITLE
squatter: audit messages outside the recorded ranges

### DIFF
--- a/cassandane/tiny-tests/SearchFuzzy/audit_unrecorded
+++ b/cassandane/tiny-tests/SearchFuzzy/audit_unrecorded
@@ -1,0 +1,39 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_audit_unrecorded
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    my $basedir = $self->{instance}->{basedir};
+    my $outfile = "$basedir/audit.tmp";
+
+    xlog "create and index two messages";
+    $self->make_message("needle one") || die;
+    $self->make_message("needle two") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog "audit reports nothing";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'squatter', '-A');
+    open my $fh, '<', $outfile or die "open $outfile: $!";
+    my @audits = readline($fh);
+    close $fh;
+    $self->assert_num_equals(0, scalar @audits);
+
+    xlog "append a third message without indexing it";
+    $self->make_message("needle three") || die;
+
+    xlog "audit reports the unindexed message even though no recorded";
+    xlog "range claims it";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'squatter', '-A');
+    open $fh, '<', $outfile or die "open $outfile: $!";
+    @audits = readline($fh);
+    close $fh;
+    $self->assert_num_equals(1, scalar @audits);
+    $self->assert_str_equals("Unindexed message(s) in user.cassandane: 3 \n",
+                             $audits[0]);
+}

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2317,19 +2317,17 @@ static int audit_mailbox(search_text_receiver_t *rx, bitvector_t *unindexed)
         goto done;
     }
 
-    iter = mailbox_iter_init(tr->super.mailbox, 0, ITER_SKIP_UNLINKED);
+    /* check every live message: an unindexed message outside the recorded
+     * ranges is just as lost as one inside them.  Expunged messages are
+     * skipped: their documents may legitimately have been expired or
+     * compacted away. */
+    iter = mailbox_iter_init(tr->super.mailbox, 0,
+                             ITER_SKIP_UNLINKED|ITER_SKIP_EXPUNGED);
 
     while ((msg = mailbox_iter_step(iter))) {
         uint32_t uid;
         r = message_get_uid((message_t*) msg, &uid);
         if (r) goto done;
-
-        if (!seqset_ismember(tr->oldindexed, uid)) {
-            if (tr->super.verbose)
-                syslog(LOG_INFO, "search_xapian: ignoring %s:%d during audit",
-                        mailbox_name(tr->super.mailbox), uid);
-            continue;
-        }
 
         const struct message_guid *guid;
         r = message_get_guid((message_t*) msg, &guid);

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2531,19 +2531,17 @@ static int audit_mailbox(search_text_receiver_t *rx, bitvector_t *unindexed)
         goto done;
     }
 
-    iter = mailbox_iter_init(tr->super.mailbox, 0, ITER_SKIP_UNLINKED);
+    /* check every live message: an unindexed message outside the recorded
+     * ranges is just as lost as one inside them.  Expunged messages are
+     * skipped: their documents may legitimately have been expired or
+     * compacted away. */
+    iter = mailbox_iter_init(tr->super.mailbox, 0,
+                             ITER_SKIP_UNLINKED|ITER_SKIP_EXPUNGED);
 
     while ((msg = mailbox_iter_step(iter))) {
         uint32_t uid;
         r = message_get_uid((message_t*) msg, &uid);
         if (r) goto done;
-
-        if (!seqset_ismember(tr->oldindexed, uid)) {
-            if (tr->super.verbose)
-                syslog(LOG_INFO, "search_xapian: ignoring %s:%d during audit",
-                        mailbox_name(tr->super.mailbox), uid);
-            continue;
-        }
 
         const struct message_guid *guid;
         r = message_get_guid((message_t*) msg, &guid);


### PR DESCRIPTION
Audit mode only verified messages claimed by the recorded indexed ranges and ignored the rest, presuming an unclaimed message is backlog that the next incremental run will index. That presumption trusts the machinery being audited: a message repeatedly skipped by the CONVINDEXED dedup (see #6158) is unclaimed and never indexed, so the audit missed exactly the messages most in need of reporting. squatter.8 also already promises that `-A` "reports any unindexed messages".

Check every live message against Xapian. Expunged messages are now skipped: their documents may legitimately have been expired or compacted away, and reporting them would be noise.

On a production 594k-message mailbox whose index predated the CONVINDEXED dedup fix, the extended audit found 70 unindexed live messages in under ten seconds -- spaced one per search_batchsize (8192) interval, the batch boundary loss pattern of #6158 -- in an index the unextended audit had repeatedly reported clean. A single squatter -Z pass then repaired them and the audit reported clean.

The audit_unrecorded test asserts a delivered-but-never-indexed message is reported. It fails against unpatched cyrus and passes with the change (validated on a 3.12.2 backport; the master port of the test is syntax-converted from the validated version). The full SearchFuzzy suite, including the existing audit_unindexed and index_tier_audit_bug tests, passes with the change applied.
