### PR TITLE
imapd: report slow/cancelled SORT and THREAD like SEARCH does

### DIFF
--- a/cassandane/tiny-tests/SearchFuzzy/search_sort_thread_maxtime
+++ b/cassandane/tiny-tests/SearchFuzzy/search_sort_thread_maxtime
@@ -1,0 +1,32 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_search_sort_thread_maxtime
+    :min_version_3_13 :needs_search_xapian :SearchMaxtime1Sec :SearchNormalizationMax20000
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    $self->make_message("needle") || die;
+    $talk->select('INBOX');
+
+    # criteria whose DNF normalisation reliably exceeds search_maxtime,
+    # independent of mailbox size
+    my $crit = 'SUBJECT a';
+    $crit = "OR NOT $crit NOT $crit" for (1..14);
+
+    xlog "SEARCH must report the timeout";
+    my $uids = $talk->search(\$crit);
+    $self->assert_null($uids);
+    $self->assert_matches(qr/taking too long/i, $talk->get_last_error());
+
+    xlog "SORT must report the timeout";
+    $uids = $talk->sort('(ARRIVAL)', 'UTF-8', \$crit);
+    $self->assert_null($uids);
+    $self->assert_matches(qr/taking too long/i, $talk->get_last_error());
+
+    xlog "THREAD must report the timeout";
+    $uids = $talk->thread('ORDEREDSUBJECT', 'UTF-8', \$crit);
+    $self->assert_null($uids);
+    $self->assert_matches(qr/taking too long/i, $talk->get_last_error());
+}

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6207,12 +6207,29 @@ static int multisearch_cb(const mbentry_t *mbentry, void *rock)
     return 0;
 }
 
+/* Print the tagged completion for a search-family command (SEARCH, SORT,
+ * THREAD): OK with timing on success, NO if the search timer expired or
+ * the client cancelled (see cmd_cancelled). */
+static void search_reply_completed(const char *tag, int nmsg, clock_t start)
+{
+    int r = cmd_cancelled(/*insearch*/1);
+    if (!r) {
+        char mytime[100];
+        snprintf(mytime, sizeof(mytime), "%2.3f",
+                 (clock() - start) / (double) CLOCKS_PER_SEC);
+        prot_printf(imapd_out, "%s OK %s (%d msgs in %s secs)\r\n", tag,
+                    error_message(IMAP_OK_COMPLETED), nmsg, mytime);
+    }
+    else {
+        prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
+    }
+}
+
 static void cmd_search(const char *tag, const char *cmd)
 {
     int c;
     struct searchargs *searchargs;
     clock_t start = clock();
-    char mytime[100];
     int usinguid = 0, n = 0;
     int state = GETSEARCH_RETURN;
 
@@ -6444,16 +6461,7 @@ static void cmd_search(const char *tag, const char *cmd)
     if (searchargs->state & GETSEARCH_MODSEQ)
         condstore_enabled("SEARCH MODSEQ");
 
-    int r = cmd_cancelled(/*insearch*/1);
-    if (!r) {
-        snprintf(mytime, sizeof(mytime), "%2.3f",
-                 (clock() - start) / (double) CLOCKS_PER_SEC);
-        prot_printf(imapd_out, "%s OK %s (%d msgs in %s secs)\r\n", tag,
-                    error_message(IMAP_OK_COMPLETED), n, mytime);
-    }
-    else {
-        prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
-    }
+    search_reply_completed(tag, n, start);
 
   done:
     freesearchargs(searchargs);
@@ -6529,16 +6537,15 @@ static void cmd_sort(char *tag, int usinguid)
     if (searchargs->state & GETSEARCH_MODSEQ)
         condstore_enabled("SORT MODSEQ");
 
-    snprintf(mytime, sizeof(mytime), "%2.3f",
-             (clock() - start) / (double) CLOCKS_PER_SEC);
     if (CONFIG_TIMING_VERBOSE) {
+        snprintf(mytime, sizeof(mytime), "%2.3f",
+                 (clock() - start) / (double) CLOCKS_PER_SEC);
         char *s = sortcrit_as_string(sortcrit);
         syslog(LOG_DEBUG, "SORT (%s) processing time: %d msg in %s sec",
                s, n, mytime);
         free(s);
     }
-    prot_printf(imapd_out, "%s OK %s (%d msgs in %s secs)\r\n", tag,
-                error_message(IMAP_OK_COMPLETED), n, mytime);
+    search_reply_completed(tag, n, start);
 
     buf_free(&arg);
     freesortcrit(sortcrit);
@@ -6562,7 +6569,6 @@ static void cmd_thread(char *tag, int usinguid)
     int alg;
     struct searchargs *searchargs;
     clock_t start = clock();
-    char mytime[100];
     int n;
 
     if (backend_current) {
@@ -6634,10 +6640,7 @@ static void cmd_thread(char *tag, int usinguid)
     if (searchargs->state & GETSEARCH_MODSEQ)
         condstore_enabled("THREAD MODSEQ");
 
-    snprintf(mytime, sizeof(mytime), "%2.3f",
-             (clock() - start) / (double) CLOCKS_PER_SEC);
-    prot_printf(imapd_out, "%s OK %s (%d msgs in %s secs)\r\n", tag,
-                error_message(IMAP_OK_COMPLETED), n, mytime);
+    search_reply_completed(tag, n, start);
 
   done:
     freesearchargs(searchargs);


### PR DESCRIPTION
Commit 78a791361 made SEARCH return `NO` with an error message when the search timer expires or the client cancels, but SORT and THREAD kept printing unconditional `OK` with whatever results had accumulated before the cutoff. index_sort()/index_thread() return only a count, so a search_maxtime expiry mid-scan silently truncates the result set — observed in production as `SORT (DATE) ...` returning `OK Completed (0 msgs)` after examining ~55k of 588k messages, indistinguishable from a genuine empty result.

This moves 78a791361's completion reporting into a shared search_reply_completed() helper used by cmd_search(), cmd_sort() and cmd_thread(), so all three report timer expiry and cancellation the same way — the same consolidation approach as b5fa6d319 took for the fuzzy check. Untagged data may already have been emitted before the NO; cmd_search has had the same property with ESEARCH since 2020 and the tagged status governs.

The added test uses criteria whose DNF normalisation reliably exceeds search_maxtime, independent of mailbox size, and asserts SEARCH, SORT and THREAD all report the timeout. It fails against unpatched cyrus and passes with the change (validated on a 3.12.2 backport; the master port of the test is syntax-converted from the validated version).
