### PR TITLE
search_xapian: don't skip unstattable tiers

### DIFF
--- a/cassandane/tiny-tests/SearchFuzzy/tier_stat_failure
+++ b/cassandane/tiny-tests/SearchFuzzy/tier_stat_failure
@@ -1,0 +1,45 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_tier_stat_failure
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog "index a message and compact it to the t2 tier";
+    $self->make_message("xyzzy") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+    $self->{instance}->run_command({cyrus => 1},
+        'squatter', '-z', 't2', '-t', 't1');
+
+    xlog "index another message into t1";
+    $self->make_message("plugh") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog "make the t2 tier directory unstattable: deny traversal of its";
+    xlog "parent, as a wrong permission or SELinux label does";
+    my $xapdirs = ($self->{instance}->run_mbpath(-u => 'cassandane'))->{xapian};
+    my $t2 = $xapdirs->{t2};
+    use File::Basename;
+    my $t2parent = dirname($t2);
+    chmod 0000, $t2parent or die "chmod $t2parent: $!";
+
+    xlog "search with the t2 tier unreadable";
+    $talk->select('INBOX');
+    # guard the call: the failed tier open may terminate the search
+    my $uids = eval { $talk->search('fuzzy', 'subject', 'xyzzy') };
+    chmod 0755, $t2parent or die "chmod $t2parent: $!";
+
+    xlog "the unstattable tier must be kept and fail to open: a dropped";
+    xlog "tier logs only a stat warning and silently proceeds without it";
+    my @errors;
+    foreach (1..10) {
+        push @errors, $self->{instance}->getsyslog(qr/DatabaseOpeningError/);
+        last if scalar @errors >= 1;
+        sleep 1;
+    }
+    $self->assert(scalar @errors >= 1);
+
+    # consume the remaining expected IOERROR lines
+    $self->{instance}->getsyslog(qr/IOERROR/);
+}

--- a/cassandane/tiny-tests/SearchFuzzy/tier_stat_failure
+++ b/cassandane/tiny-tests/SearchFuzzy/tier_stat_failure
@@ -1,0 +1,40 @@
+#!perl
+use Cassandane::Tiny;
+use File::Basename;
+
+sub test_tier_stat_failure
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "index a message and compact it to the t2 tier";
+    $self->make_message("xyzzy") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+    $self->{instance}->run_command({cyrus => 1},
+        'squatter', '-z', 't2', '-t', 't1');
+
+    xlog $self, "index another message into t1";
+    $self->make_message("plugh") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    xlog $self, "deny traversal of the t2 tier directory's parent, as a wrong permission or SELinux label does";
+    my $xapdirs = ($self->{instance}->run_mbpath(-u => 'cassandane'))->{xapian};
+    my $t2parent = dirname($xapdirs->{t2});
+    chmod 0000, $t2parent or die "chmod $t2parent: $!";
+
+    xlog $self, "search with the t2 tier unstattable";
+    $talk->select('INBOX');
+    # guard the call: the failed tier open may terminate the search
+    my $uids = eval { $talk->search('fuzzy', 'subject', 'xyzzy') };
+    chmod 0755, $t2parent or die "chmod $t2parent: $!";
+
+    xlog $self, "the tier must be kept and fail to open: a dropped tier logs only a stat warning and silently proceeds without it";
+    my @errors;
+    timed_wait(sub {
+        push @errors, $self->{instance}->getsyslog(qr/DatabaseOpeningError/);
+        return scalar @errors >= 1;
+    }, description => "the tier open failure to be logged");
+
+    # consume the remaining expected IOERROR lines
+    $self->{instance}->getsyslog(qr/IOERROR/);
+}

--- a/changes/next/search-no-silent-tier-skip
+++ b/changes/next/search-no-silent-tier-skip
@@ -1,0 +1,25 @@
+Description:
+
+A search tier whose directory cannot be stat'ed for any reason other
+than ENOENT is no longer silently dropped: queries and compaction now
+report the tier's open failure instead of proceeding without its data.
+
+
+Documentation:
+
+None
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -367,10 +367,16 @@ static char *activefile_path(const char *mboxname, const char *part, const char 
 
     if (dostat) {
         if (xapstat(dest)) {
-            if (errno != ENOENT)
+            if (errno != ENOENT) {
+                /* Keep the path: let the database open report an error
+                 * rather than silently searching (or compacting) without
+                 * this tier as if it did not exist. */
                 syslog(LOG_ERR, "IOERROR: can't read %s for search, check permissions: %m", dest);
-            free(dest);
-            dest = NULL;
+            }
+            else {
+                free(dest);
+                dest = NULL;
+            }
         }
     }
 

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -370,10 +370,16 @@ static char *activefile_path(const char *mboxname, const char *part, const char 
 
     if (dostat) {
         if (xapstat(dest)) {
-            if (errno != ENOENT)
+            if (errno != ENOENT) {
+                /* Keep the path: let the database open report an error
+                 * rather than silently searching (or compacting) without
+                 * this tier as if it did not exist. */
                 syslog(LOG_ERR, "IOERROR: can't read %s for search, check permissions: %m", dest);
-            free(dest);
-            dest = NULL;
+            }
+            else {
+                free(dest);
+                dest = NULL;
+            }
         }
     }
 


### PR DESCRIPTION
activefile_path() with dostat drops any tier whose directory fails to stat. Dropping is only correct for ENOENT (tier not created yet): for any other failure — wrong permissions, wrong SELinux label, I/O error — the stat failure is logged but the tier is still dropped. Queries succeed over the remaining (possibly zero) databases and return results indistinguishable from a genuine absence of matches, and compact runs proceed as if the tier did not exist, risking discarding real index data.

Observed in production: a mislabelled search partition made every query return `0 msgs in 0.004 secs` against a complete 21GB index, with no client-visible failure.

Keep the path when stat fails for any reason other than ENOENT, so the subsequent database open reports a real error through the existing error paths: compact/reindex abort instead of proceeding without the tier, and every affected query logs an IOERROR.

All activefile_resolve() callers were audited for this change: the database-open paths (query, compact, XAPINDEXED writer) fail with an error as intended, while upgrade() and the file-enumeration paths already tolerate per-directory failures and behave as before. ENOENT tiers (fresh users, retired generations) are still skipped silently.

The added test compacts to a second tier, denies traversal of its parent directory as a wrong permission or SELinux label does, and asserts a search reports the tier's open failure rather than silently proceeding without it. It fails against unpatched cyrus and passes with the change (validated on a 3.12.2 backport; the master port of the test is syntax-converted from the validated version).
