### PR TITLE
jmap_mail.c: gracefully handle duplicate modseqs with maxChanges

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5549,10 +5549,23 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes,
         if (hash_lookup(email_id, &seen_ids)) continue;
         hash_insert(email_id, (void*)1, &seen_ids);
 
-        /* Apply limit, if any */
-        if (changes->max_changes && ++changes_count > changes->max_changes) {
+        /* Apply maxChanges, if any. We do overshoot maxChanges in case
+         * the modseqs are not strictly increasing, which must not ever
+         * happen in a sane account. Should the account have any duplicate
+         * modseqs then we report that as an error but gracefully finish
+         * the /changes method. */
+        if (changes->max_changes && changes_count >= changes->max_changes &&
+            md->modseq > highest_modseq) {
             changes->has_more_changes = 1;
             break;
+        }
+        changes_count++;
+
+        if (md->modseq == highest_modseq && highest_modseq) {
+            xsyslog_ev(LOG_ERR, "duplicate modseq in Email/changes",
+                    lf_s("mboxname", md->folder ? md->folder->mboxname : NULL),
+                    lf_u("uid", md->uid),
+                    lf_llu("modseq", md->modseq));
         }
 
         /* Keep track of the highest modseq */
@@ -5704,10 +5717,23 @@ static void _thread_changes(jmap_req_t *req, struct jmap_changes *changes, json_
         /* Skip already seen threads */
         if (!hashset_add(seen_threads, &md->cid)) continue;
 
-        /* Apply limit, if any */
-        if (changes->max_changes && ++changes_count > changes->max_changes) {
+        /* Apply maxChanges, if any. We do overshoot maxChanges in case
+         * the modseqs are not strictly increasing, which must not ever
+         * happen in a sane account. Should the account have any duplicate
+         * modseqs then we report that as an error but gracefully finish
+         * the /changes method. */
+        if (changes->max_changes && changes_count >= changes->max_changes &&
+            md->modseq > highest_modseq) {
             changes->has_more_changes = 1;
             break;
+        }
+        changes_count++;
+
+        if (md->modseq == highest_modseq && highest_modseq) {
+            xsyslog_ev(LOG_ERR, "duplicate modseq in Thread/changes",
+                    lf_s("mboxname", md->folder ? md->folder->mboxname : NULL),
+                    lf_u("uid", md->uid),
+                    lf_llu("modseq", md->modseq));
         }
 
         /* Keep track of the highest modseq */

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4199,9 +4199,21 @@ static int _mbox_changes(jmap_req_t *req,
         const char *id = json_string_value(json_object_get(update, "id"));
         modseq_t modseq = json_integer_value(json_object_get(update, "modseq"));
 
-        if (changes->max_changes && ((size_t) i) >= changes->max_changes) {
+        /* Apply maxChanges, if any. We do overshoot maxChanges in case
+         * the modseqs are not strictly increasing, which must not ever
+         * happen in a sane account. Should the account have any duplicate
+         * modseqs then we report that as an error but gracefully finish
+         * the /changes method. */
+        if (changes->max_changes && ((size_t) i) >= changes->max_changes &&
+            modseq > windowmodseq) {
             changes->has_more_changes = 1;
             break;
+        }
+
+        if (modseq == windowmodseq && windowmodseq) {
+            xsyslog_ev(LOG_ERR, "duplicate modseq in Mailbox/changes",
+                    lf_s("mboxid", id),
+                    lf_llu("modseq", modseq));
         }
 
         if (windowmodseq < modseq)


### PR DESCRIPTION
This makes the Email/changes and Mailbox/changes commands handle duplicate modseqs in combination with the maxChanges argument. In a sane account, the modseqs never are duplicate. But to protect against the client state go corrupt in the erroneous case, we now overshoot the allowed maxChanges number of reported changes so that entries with duplicate modseqs do get reported as changed, rather than not silently omitted. Also, this patch logs the duplicate modseqs as an error.