### PR TITLE
jmap_*_props.gperf: move all files into imap/jmap_props

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1266,48 +1266,48 @@ BUILT_SOURCES += \
     imap/jmap_err.h
 
 JMAP_PROPS_BUILT_SOURCES = \
-    imap/jmap_blob_props.c \
-    imap/jmap_blob_props.h \
-    imap/jmap_blob_upload_props.c \
-    imap/jmap_blob_upload_props.h \
-    imap/jmap_calendar_event_notification_props.c \
-    imap/jmap_calendar_event_notification_props.h \
-    imap/jmap_calendar_event_props.c \
-    imap/jmap_calendar_event_props.h \
-    imap/jmap_calendar_participant_identity_props.c \
-    imap/jmap_calendar_participant_identity_props.h \
-    imap/jmap_calendar_principal_props.c \
-    imap/jmap_calendar_principal_props.h \
-    imap/jmap_calendar_props.c \
-    imap/jmap_calendar_props.h \
-    imap/jmap_calendar_share_notification_props.c \
-    imap/jmap_calendar_share_notification_props.h \
-    imap/jmap_contact_addressbook_props.c \
-    imap/jmap_contact_addressbook_props.h \
-    imap/jmap_contact_card_props.c \
-    imap/jmap_contact_card_props.h \
-    imap/jmap_core_usercounters_props.c \
-    imap/jmap_core_usercounters_props.h \
-    imap/jmap_mailbox_props.c \
-    imap/jmap_mailbox_props.h \
-    imap/jmap_mail_props.c \
-    imap/jmap_mail_props.h \
-    imap/jmap_mail_submission_identity_props.c \
-    imap/jmap_mail_submission_identity_props.h \
-    imap/jmap_mail_submission_props.c \
-    imap/jmap_mail_submission_props.h \
-    imap/jmap_mail_thread_props.c \
-    imap/jmap_mail_thread_props.h \
-    imap/jmap_notes_props.c \
-    imap/jmap_notes_props.h \
-    imap/jmap_quota_legacy_props.c \
-    imap/jmap_quota_legacy_props.h \
-    imap/jmap_quota_props.c \
-    imap/jmap_quota_props.h \
-    imap/jmap_sieve_props.c \
-    imap/jmap_sieve_props.h \
-    imap/jmap_vacation_props.c \
-    imap/jmap_vacation_props.h
+    imap/jmap_props/addressbook.c \
+    imap/jmap_props/addressbook.h \
+    imap/jmap_props/blob.c \
+    imap/jmap_props/blob.h \
+    imap/jmap_props/blob_upload.c \
+    imap/jmap_props/blob_upload.h \
+    imap/jmap_props/calendar.c \
+    imap/jmap_props/calendar.h \
+    imap/jmap_props/calendar_event.c \
+    imap/jmap_props/calendar_event.h \
+    imap/jmap_props/calendar_event_notification.c \
+    imap/jmap_props/calendar_event_notification.h \
+    imap/jmap_props/contact_card.c \
+    imap/jmap_props/contact_card.h \
+    imap/jmap_props/email.c \
+    imap/jmap_props/email.h \
+    imap/jmap_props/email_submission.c \
+    imap/jmap_props/email_submission.h \
+    imap/jmap_props/identity.c \
+    imap/jmap_props/identity.h \
+    imap/jmap_props/mailbox.c \
+    imap/jmap_props/mailbox.h \
+    imap/jmap_props/notes.c \
+    imap/jmap_props/notes.h \
+    imap/jmap_props/participant_identity.c \
+    imap/jmap_props/participant_identity.h \
+    imap/jmap_props/principal.c \
+    imap/jmap_props/principal.h \
+    imap/jmap_props/quota.c \
+    imap/jmap_props/quota.h \
+    imap/jmap_props/quota_legacy.c \
+    imap/jmap_props/quota_legacy.h \
+    imap/jmap_props/share_notification.c \
+    imap/jmap_props/share_notification.h \
+    imap/jmap_props/sieve.c \
+    imap/jmap_props/sieve.h \
+    imap/jmap_props/thread.c \
+    imap/jmap_props/thread.h \
+    imap/jmap_props/usercounters.c \
+    imap/jmap_props/usercounters.h \
+    imap/jmap_props/vacation.c \
+    imap/jmap_props/vacation.h
 
 BUILT_SOURCES += $(JMAP_PROPS_BUILT_SOURCES)
 CLEANFILES += $(JMAP_PROPS_BUILT_SOURCES)
@@ -1348,41 +1348,41 @@ imap_httpd_SOURCES += \
     imap/jscalendar.c \
     imap/jscalendar.h
 
-imap_httpd_LDADD += imap/libcyrus_jmap_props.la
-noinst_LTLIBRARIES += imap/libcyrus_jmap_props.la
+imap_httpd_LDADD += imap/jmap_props/libcyrus_jmap_props.la
+noinst_LTLIBRARIES += imap/jmap_props/libcyrus_jmap_props.la
 
-imap_libcyrus_jmap_props_la_LIBADD =
-imap_libcyrus_jmap_props_la_CFLAGS = $(AM_CFLAGS) $(CFLAG_VISIBILITY) $(NOWARN_UNUSED_PARAMETER) $(NOERROR_UNUSED_PARAMETER)
+imap_jmap_props_libcyrus_jmap_props_la_LIBADD =
+imap_jmap_props_libcyrus_jmap_props_la_CFLAGS = $(AM_CFLAGS) $(CFLAG_VISIBILITY) $(NOWARN_UNUSED_PARAMETER) $(NOERROR_UNUSED_PARAMETER)
 
-imap_libcyrus_jmap_props_la_SOURCES = \
-    imap/jmap_blob_props.gperf \
-    imap/jmap_blob_upload_props.gperf \
-    imap/jmap_calendar_event_notification_props.gperf \
-    imap/jmap_calendar_event_props.gperf \
-    imap/jmap_calendar_participant_identity_props.gperf \
-    imap/jmap_calendar_principal_props.gperf \
-    imap/jmap_calendar_props.gperf \
-    imap/jmap_calendar_share_notification_props.gperf \
-    imap/jmap_contact_addressbook_props.gperf \
-    imap/jmap_contact_card_props.gperf \
-    imap/jmap_core_usercounters_props.gperf \
-    imap/jmap_mail_props.gperf \
-    imap/jmap_mail_submission_identity_props.gperf \
-    imap/jmap_mail_submission_props.gperf \
-    imap/jmap_mail_thread_props.gperf \
-    imap/jmap_mailbox_props.gperf \
-    imap/jmap_notes_props.gperf \
-    imap/jmap_quota_legacy_props.gperf \
-    imap/jmap_quota_props.gperf
+imap_jmap_props_libcyrus_jmap_props_la_SOURCES = \
+    imap/jmap_props/addressbook.gperf \
+    imap/jmap_props/blob.gperf \
+    imap/jmap_props/blob_upload.gperf \
+    imap/jmap_props/calendar.gperf \
+    imap/jmap_props/calendar_event.gperf \
+    imap/jmap_props/calendar_event_notification.gperf \
+    imap/jmap_props/contact_card.gperf \
+    imap/jmap_props/email.gperf \
+    imap/jmap_props/email_submission.gperf \
+    imap/jmap_props/identity.gperf \
+    imap/jmap_props/mailbox.gperf \
+    imap/jmap_props/notes.gperf \
+    imap/jmap_props/participant_identity.gperf \
+    imap/jmap_props/principal.gperf \
+    imap/jmap_props/quota.gperf \
+    imap/jmap_props/quota_legacy.gperf \
+    imap/jmap_props/share_notification.gperf \
+    imap/jmap_props/thread.gperf \
+    imap/jmap_props/usercounters.gperf
 
 if SIEVE
 imap_httpd_SOURCES += \
     imap/jmap_sieve.c \
     imap/jmap_vacation.c
 
-imap_libcyrus_jmap_props_la_SOURCES += \
-    imap/jmap_sieve_props.gperf \
-    imap/jmap_vacation_props.gperf
+imap_jmap_props_libcyrus_jmap_props_la_SOURCES += \
+    imap/jmap_props/sieve.gperf \
+    imap/jmap_props/vacation.gperf
 endif
 
 nodist_imap_httpd_SOURCES += \
@@ -1488,7 +1488,7 @@ gperf_tables = imap/css3_color_array.h imap/jmap_data_types.h \
 $(gperf_tables): %.h: %.gperf
 	$(AM_V_GEN)gperf $< > $@.NEW && mv $@.NEW $@
 
-# Build jmap_*_props.[ch] from jmap_*_props.gperf
+# Build imap/jmap_props/*.[ch] from imap/jmap_props/*.gperf
 .gperf.c:
 	$(AM_V_GEN)gperf $< > $@.NEW && mv $@.NEW $@
 

--- a/imap/jmap_blob.c
+++ b/imap/jmap_blob.c
@@ -18,8 +18,8 @@
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
 #include "imap/jmap_err.h"
-#include "imap/jmap_blob_props.h"
-#include "imap/jmap_blob_upload_props.h"
+#include "imap/jmap_props/blob.h"
+#include "imap/jmap_props/blob_upload.h"
 
 
 static int jmap_blob_copy(jmap_req_t *req);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -55,12 +55,12 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
-#include "imap/jmap_calendar_event_notification_props.h"
-#include "imap/jmap_calendar_event_props.h"
-#include "imap/jmap_calendar_participant_identity_props.h"
-#include "imap/jmap_calendar_principal_props.h"
-#include "imap/jmap_calendar_props.h"
-#include "imap/jmap_calendar_share_notification_props.h"
+#include "imap/jmap_props/calendar.h"
+#include "imap/jmap_props/calendar_event.h"
+#include "imap/jmap_props/calendar_event_notification.h"
+#include "imap/jmap_props/participant_identity.h"
+#include "imap/jmap_props/principal.h"
+#include "imap/jmap_props/share_notification.h"
 
 static int jmap_calendar_get(struct jmap_req *req);
 static int jmap_calendar_changes(struct jmap_req *req);
@@ -9000,7 +9000,7 @@ static int jmap_principal_get(struct jmap_req *req)
     struct jmap_get get = JMAP_GET_INITIALIZER;
     json_t *err = NULL;
 
-    jmap_get_parse(req, &parser, &calendarprincipal_props, 0, NULL, NULL, &get, &err);
+    jmap_get_parse(req, &parser, &principal_props, 0, NULL, NULL, &get, &err);
     if (err) {
         jmap_error(req, err);
         goto done;
@@ -9565,8 +9565,7 @@ static int jmap_principal_set(struct jmap_req *req)
     struct jmap_set set = JMAP_SET_INITIALIZER;
     json_t *err = NULL;
 
-    jmap_set_parse(req, &argparser, &calendarprincipal_props,
-                   NULL, NULL, &set, &err);
+    jmap_set_parse(req, &argparser, &principal_props, NULL, NULL, &set, &err);
     if (err) {
         jmap_error(req, err);
         goto done;

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -39,8 +39,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
-#include "imap/jmap_contact_addressbook_props.h"
-#include "imap/jmap_contact_card_props.h"
+#include "imap/jmap_props/addressbook.h"
+#include "imap/jmap_props/contact_card.h"
 
 static int jmap_addressbook_get(struct jmap_req *req);
 static int jmap_addressbook_changes(struct jmap_req *req);

--- a/imap/jmap_core.c
+++ b/imap/jmap_core.c
@@ -15,7 +15,7 @@
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
 #include "imap/jmap_err.h"
-#include "imap/jmap_core_usercounters_props.h"
+#include "imap/jmap_props/usercounters.h"
 
 
 /* JMAP Core API Methods */

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -60,8 +60,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
-#include "imap/jmap_mail_props.h"
-#include "imap/jmap_mail_thread_props.h"
+#include "imap/jmap_props/email.h"
+#include "imap/jmap_props/thread.h"
 
 static int jmap_email_query(jmap_req_t *req);
 static int jmap_email_querychanges(jmap_req_t *req);

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -32,8 +32,8 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
-#include "imap/jmap_mail_submission_props.h"
-#include "imap/jmap_mail_submission_identity_props.h"
+#include "imap/jmap_props/email_submission.h"
+#include "imap/jmap_props/identity.h"
 
 #define JMAP_SUBID_SIZE 12
 

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -37,7 +37,7 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
-#include "imap/jmap_mailbox_props.h"
+#include "imap/jmap_props/mailbox.h"
 
 
 static int jmap_mailbox_get(jmap_req_t *req);

--- a/imap/jmap_notes.c
+++ b/imap/jmap_notes.c
@@ -29,7 +29,7 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
-#include "imap/jmap_notes_props.h"
+#include "imap/jmap_props/notes.h"
 
 #define APPLE_NOTES_ID  "com.apple.mail-note"
 

--- a/imap/jmap_props/addressbook.gperf
+++ b/imap/jmap_props/addressbook.gperf
@@ -1,6 +1,5 @@
 %{
-/* jmap_contact_addressbook_props.c --
-   Lookup function for JMAP AddressBook properties */
+/* addressbook.c -- Lookup function for JMAP AddressBook properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/blob.gperf
+++ b/imap/jmap_props/blob.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_blob_props.c -- Lookup function for JMAP Blob properties */
+/* blob.c -- Lookup function for JMAP Blob properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/blob_upload.gperf
+++ b/imap/jmap_props/blob_upload.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_blob_upload_props.c -- Lookup function for JMAP Blob properties */
+/* blob_upload.c -- Lookup function for JMAP Blob/Upload properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/calendar.gperf
+++ b/imap/jmap_props/calendar.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_calendar_props.c -- Lookup function for JMAP Calendar properties */
+/* calendar.c -- Lookup function for JMAP Calendar properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/calendar_event.gperf
+++ b/imap/jmap_props/calendar_event.gperf
@@ -1,6 +1,5 @@
 %{
-/* jmap_calendar_event_props.c --
-   Lookup function for JMAP CalendarEvent properties */
+/* calendar_event.c -- Lookup function for JMAP CalendarEvent properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/calendar_event_notification.gperf
+++ b/imap/jmap_props/calendar_event_notification.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_calendar_event_notification_props.c --
+/* calendar_event_notification.c --
    Lookup function for JMAP CalendarEventNotification properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */

--- a/imap/jmap_props/contact_card.gperf
+++ b/imap/jmap_props/contact_card.gperf
@@ -1,6 +1,5 @@
 %{
-/* jmap_contact_card_props.c --
-   Lookup function for JMAP ContactCard properties */
+/* contact_card.c -- Lookup function for JMAP ContactCard properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/email.gperf
+++ b/imap/jmap_props/email.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_mail_props.c -- Lookup function for JMAP Email properties */
+/* email_props.c -- Lookup function for JMAP Email properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/email_submission.gperf
+++ b/imap/jmap_props/email_submission.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_mail_submission_props.c --
+/* email_submission.c --
    Lookup function for JMAP Email Submission properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */

--- a/imap/jmap_props/identity.gperf
+++ b/imap/jmap_props/identity.gperf
@@ -1,6 +1,5 @@
 %{
-/* jmap_mail_submission_identity_props.c --
-   Lookup function for JMAP Email Submission Identity properties */
+/* identity.c -- Lookup function for JMAP Email Submission Identity properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/mailbox.gperf
+++ b/imap/jmap_props/mailbox.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_mailbox_props.c -- Lookup function for JMAP Mailbox properties */
+/* mailbox.c -- Lookup function for JMAP Mailbox properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/notes.gperf
+++ b/imap/jmap_props/notes.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_notes_props.c -- Lookup function for JMAP Notes properties */
+/* notes.c -- Lookup function for JMAP Notes properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/participant_identity.gperf
+++ b/imap/jmap_props/participant_identity.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_calendar_participant_identity_props.c --
+/* participant_identity.c --
    Lookup function for JMAP ParticipantIdentity properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */

--- a/imap/jmap_props/principal.gperf
+++ b/imap/jmap_props/principal.gperf
@@ -1,6 +1,5 @@
 %{
-/* jmap_calendar_principal_props.c --
-   Lookup function for JMAP CalendarPrincipal properties */
+/* principal.c -- Lookup function for JMAP Principal properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 
@@ -18,11 +17,11 @@
 
 %define slot-name             name
 %define initializer-suffix    ,NULL,0
-%define constants-prefix      CALENDARPRINCIPAL_PROP_
-%define word-array-name       calendarprincipal_prop_array
-%define length-table-name     calendarprincipal_prop_lengths
-%define hash-function-name    calendarprincipal_prop_hash
-%define lookup-function-name  calendarprincipal_prop_lookup
+%define constants-prefix      PRINCIPAL_PROP_
+%define word-array-name       principal_prop_array
+%define length-table-name     principal_prop_lengths
+%define hash-function-name    principal_prop_hash
+%define lookup-function-name  principal_prop_lookup
 
 jmap_property_t;
 
@@ -40,10 +39,10 @@ jmap_property_t;
 "calendarAddress",    NULL, JMAP_PROP_SERVER_SET
 %%
 
-const jmap_prop_hash_table_t jmap_calendarprincipal_props_map = {
-    calendarprincipal_prop_array,
-    CALENDARPRINCIPAL_PROP_TOTAL_KEYWORDS,
-    CALENDARPRINCIPAL_PROP_MIN_HASH_VALUE,
-    CALENDARPRINCIPAL_PROP_MAX_HASH_VALUE,
-    &calendarprincipal_prop_lookup
+const jmap_prop_hash_table_t jmap_principal_props_map = {
+    principal_prop_array,
+    PRINCIPAL_PROP_TOTAL_KEYWORDS,
+    PRINCIPAL_PROP_MIN_HASH_VALUE,
+    PRINCIPAL_PROP_MAX_HASH_VALUE,
+    &principal_prop_lookup
 };

--- a/imap/jmap_props/quota.gperf
+++ b/imap/jmap_props/quota.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_quota_props.c -- Lookup function for JMAP Quota properties */
+/* quota.c -- Lookup function for JMAP Quota properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/quota_legacy.gperf
+++ b/imap/jmap_props/quota_legacy.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_quota_legacy_props.c -- Lookup function Legacy JMAP Quota properties */
+/* quota_legacy.c -- Lookup function Legacy JMAP Quota properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/share_notification.gperf
+++ b/imap/jmap_props/share_notification.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_calendar_share_notification_props.c --
+/* share_notification.c --
    Lookup function for JMAP ShareNotification properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */

--- a/imap/jmap_props/sieve.gperf
+++ b/imap/jmap_props/sieve.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_sieve_props.c -- Lookup function for JMAP Sieve properties */
+/* sieve.c -- Lookup function for JMAP Sieve properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/thread.gperf
+++ b/imap/jmap_props/thread.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_mail_thread_props.c -- Lookup function for JMAP Thread properties */
+/* thread.c -- Lookup function for JMAP Thread properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/usercounters.gperf
+++ b/imap/jmap_props/usercounters.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_core_usercounters_props.c -- Lookup function for JMAP Core properties */
+/* usercounters.c -- Lookup function for JMAP UserCounters properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_props/vacation.gperf
+++ b/imap/jmap_props/vacation.gperf
@@ -1,5 +1,5 @@
 %{
-/* jmap_vacation_props.c -- Lookup function for JMAP Vacation properties */
+/* vacation.c -- Lookup function for JMAP Vacation properties */
 /* SPDX-License-Identifier: BSD-3-Clause-CMU */
 /* See COPYING file at the root of the distribution for more details. */
 

--- a/imap/jmap_quota.c
+++ b/imap/jmap_quota.c
@@ -15,8 +15,8 @@
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
 #include "imap/jmap_err.h"
-#include "imap/jmap_quota_props.h"
-#include "imap/jmap_quota_legacy_props.h"
+#include "imap/jmap_props/quota.h"
+#include "imap/jmap_props/quota_legacy.h"
 
 
 static int jmap_legacy_quota_get(jmap_req_t *req);

--- a/imap/jmap_sieve.c
+++ b/imap/jmap_sieve.c
@@ -39,7 +39,7 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/http_err.h"
 #include "imap/imap_err.h"
-#include "imap/jmap_sieve_props.h"
+#include "imap/jmap_props/sieve.h"
 
 static int jmap_sieve_get(jmap_req_t *req);
 static int jmap_sieve_set(jmap_req_t *req);

--- a/imap/jmap_vacation.c
+++ b/imap/jmap_vacation.c
@@ -30,7 +30,7 @@
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
-#include "imap/jmap_vacation_props.h"
+#include "imap/jmap_props/vacation.h"
 
 static int jmap_vacation_get(jmap_req_t *req);
 static int jmap_vacation_set(jmap_req_t *req);


### PR DESCRIPTION
Remove generated t from imap/

I've removde the "jmap_" prefix and "_props" suffix from the gperf files.  And I renamed some to remove superfluous labeling