### PR TITLE
fix append_fromstage() argument mixups

### DIFF
--- a/imap/jmap_blob.c
+++ b/imap/jmap_blob.c
@@ -153,7 +153,8 @@ static int jmap_copyblob(jmap_req_t *req,
     strarray_t flags = STRARRAY_INITIALIZER;
     strarray_append(&flags, "\\Deleted");
     strarray_append(&flags, "\\Expunged");  // custom flag to insta-expunge!
-        r = append_fromstage(&as, &to_body, stage, 0, internaldate, &flags, 0, NULL);
+        r = append_fromstage(&as, &to_body, stage, /*internaldate*/NULL,
+                             /*createdmodseq*/0, &flags, 0, NULL);
     strarray_fini(&flags);
         if (r) {
         syslog(LOG_ERR, "jmap_copyblob(%s): append_fromstage: %s",

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -315,7 +315,6 @@ static int create_managedattach(struct jmapical_ctx *jmapctx,
     struct mailbox *srcmbox = NULL;
     struct body *body = NULL;
     struct stagemsg *stage = NULL;
-    time_t internaldate = time(NULL);
     struct appendstate as;
     jmap_getblob_context_t getblobctx;
     jmap_getblob_ctx_init(&getblobctx, req->accountid, blobid, NULL, 1);
@@ -372,8 +371,8 @@ static int create_managedattach(struct jmapical_ctx *jmapctx,
     if (r) goto done;
 
     strarray_t flags = STRARRAY_INITIALIZER;
-    r = append_fromstage(&as, &body, stage, 0,
-                         internaldate, &flags, 0, NULL);
+    r = append_fromstage(&as, &body, stage, /*internaldate*/NULL,
+                         /*createdmodseq*/0, &flags, 0, NULL);
         if (r) {
         append_abort(&as);
         goto done;


### PR DESCRIPTION
jmap_copyblob() and create_managedattach() each passed a time_t into the createdmodseq (modseq_t) argument of append_fromstage(), instead of into the internaldate slot.  Both are 64-bit, so there was no compiler warning.

This likely didn't have any actual impact, because mailbox_append_index_record() sets createdmodseq to the record's modseq whenever if the given createdmodseq is 0 or exceeds the modseq.  A Unix timestamp exceeds any likely modseq, so passing the time will act like passing 0 -- unless the user's counters.db has some really unlikely value.

Pass 0 for createdmodseq explicitly and drop the misplaced time_t, so the calls no longer depend on the clamp to be correct.