### PR TITLE
jmap_blob.c: /lookup with zero ids should return an empty response

### DIFF
--- a/cassandane/tiny-tests/JMAPBlob/blob_lookup
+++ b/cassandane/tiny-tests/JMAPBlob/blob_lookup
@@ -64,4 +64,11 @@ sub test_blob_lookup
     $self->assert_str_equals($emailId, $res->[0][1]{list}[0]{matchedIds}{Email}[0]);
     $self->assert_num_equals(1, scalar @{$res->[0][1]{notFound}});
     $self->assert_str_equals('unknown', $res->[0][1]{notFound}[0]);
+
+    xlog "Blob/lookup with zero ids doesn't crash/assert";
+    $res = $jmap->CallMethods(
+        [['Blob/lookup', { ids => [], typeNames => ['Mailbox', 'Thread', 'Email'] }, 'R1']],
+    );
+    $self->assert_num_equals(0, scalar @{$res->[0][1]{list}});
+    $self->assert_num_equals(0, scalar @{$res->[0][1]{notFound}});
 }

--- a/imap/jmap_blob.c
+++ b/imap/jmap_blob.c
@@ -652,6 +652,8 @@ static int jmap_blob_lookup(jmap_req_t *req)
         goto done;
     }
 
+    if (!json_array_size(get.ids)) goto reply;
+
     // we'll just make this 'matchedIds' later
     const char *resname = json_object_get(req->args, "typeNames") ? "matchedIds" : "types";
 
@@ -805,6 +807,7 @@ static int jmap_blob_lookup(jmap_req_t *req)
     // now clean all the found things!
     free_hash_table(&found, _free_found);
 
+reply:
     /* Reply */
     jmap_ok(req, jmap_get_reply(&get));
 


### PR DESCRIPTION
Previously, this would cause an assert() due to trying to create a hash table with size == 0