### PR TITLE
gitignore: ignore gperf-generated code in the new jmap_props directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,8 @@ imap/imap_err.c
 imap/imap_err.h
 imap/imapd
 imap/ipurge
-imap/jmap_*_props.c
-imap/jmap_*_props.h
+imap/jmap_props/*.c
+imap/jmap_props/*.h
 imap/jmap_data_types.h
 imap/jmap_err.c
 imap/jmap_err.h


### PR DESCRIPTION
https://github.com/cyrusimap/cyrus-imapd/pull/6168 refactored the gperf files for JMAP into a separate directory, but the gitignore file needs to get updated to ignore them, too.