### PR TITLE
gitignore: ignore clang compilation database file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ cmulocal/ltsugar.m4
 cmulocal/ltversion.m4
 cmulocal/lt~obsolete.m4
 compile
+compile_commands.json
 confdefs.h
 config.guess
 config.h


### PR DESCRIPTION
clang tooling requires the `compile_commands.json` file, aka known as the compilation database. But this is specific to a build, it does not belong to version control.