### PR TITLE
imap: fix UID MOVE cross-backend in murder proxy

### DIFF
--- a/cassandane/Cassandane/Cyrus/MurderIMAP.pm
+++ b/cassandane/Cassandane/Cyrus/MurderIMAP.pm
@@ -1234,4 +1234,83 @@ sub test_proxy_search
     $self->assert_str_equals($results[0][3], "2:5,7:9");
 }
 
+sub test_move_shared_across_backends
+    :NoAltNamespace :IMAPMurder :needs_component_murder
+{
+    my ($self) = @_;
+
+    my $shared = 'shared';
+
+    # create a shared folder on backend2
+    my $admintalk = $self->{backend2_adminstore}->get_client();
+    $admintalk->create($shared);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    # grant full rights including expunge
+    $admintalk->setacl($shared, 'anyone', 'lrswipkxtecd');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # inject a message into the shared folder
+    my $frontend = $self->{frontend_store}->get_client();
+    $self->{frontend_store}->set_folder($shared);
+    $self->{frontend_store}->_select();
+    $self->{gen}->set_next_uid(1);
+    $self->make_message("Message A", store => $self->{frontend_store});
+
+    # verify the message is there
+    $frontend->select($shared);
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+
+    # MOVE to INBOX (cross-backend)
+    $frontend->move('1', 'INBOX');
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+
+    # Verify directly on backend2: Mail::IMAPTalk does not update its
+    # internal EXISTS counter in response to an unsolicited EXPUNGE
+    # received during a MOVE.
+    my $backend2 = $self->{backend2_store}->get_client();
+    $backend2->select($shared);
+    $self->assert_num_equals(0, $backend2->get_response_code('exists'));
+
+    # verify the message is now in INBOX
+    $frontend->select('INBOX');
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+}
+
+sub test_move_shared_across_backends_no_expunge_acl
+    :NoAltNamespace :IMAPMurder :needs_component_murder
+{
+    my ($self) = @_;
+
+    my $shared = 'shared';
+
+    # create a shared folder on backend2
+    my $admintalk = $self->{backend2_adminstore}->get_client();
+    $admintalk->create($shared);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    # grant rights without expunge ('e' is missing)
+    $admintalk->setacl($shared, 'anyone', 'lrswipkxtcd');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # inject a message into the shared folder
+    my $frontend = $self->{frontend_store}->get_client();
+    $self->{frontend_store}->set_folder($shared);
+    $self->{frontend_store}->_select();
+    $self->{gen}->set_next_uid(1);
+    $self->make_message("Message A", store => $self->{frontend_store});
+
+    # verify the message is there
+    $frontend->select($shared);
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+
+    # MOVE to INBOX (cross-backend) should fail without expunge right
+    $frontend->move('1', 'INBOX');
+    $self->assert_matches(qr{Permission denied}, $frontend->get_last_error());
+
+    # verify the message is still in the source
+    $frontend->select($shared);
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+}
+
 1;

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -152,6 +152,7 @@ struct backend *proxy_findinboxserver(const char *userid)
    force_notfatal says to not fatal() if we lose connection to backend_current
    even though it is in 95% of the cases, a good idea...
 */
+
 static int pipe_response(struct backend *s, const char *tag, int include_last,
                          int force_notfatal)
 {
@@ -864,8 +865,8 @@ static char *editflags(char *flags)
     return flags;
 }
 
-void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
-                int usinguid, struct backend *s)
+int proxy_copy(const char *tag, char *sequence, char *name, int myrights,
+                int usinguid, struct backend *s, int ismove)
 {
     char mytag[128];
     struct d {
@@ -875,6 +876,7 @@ void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
         struct d *next;
     } *head, *p, *q;
     int c;
+    int ret = PROXY_NO;
 
     /* find out what the flags & internaldate for this message are */
     proxy_gentag(mytag, sizeof(mytag));
@@ -1169,6 +1171,35 @@ void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
         res = pipe_until_tag(s, tag, 0);
 
         if (res == PROXY_OK) {
+            if (ismove) {
+                char movetag[128];
+                const char *expseq = sequence;
+
+                /* mark \Deleted on source backend */
+                proxy_gentag(movetag, sizeof(movetag));
+                prot_printf(backend_current->out,
+                            "%s UID Store %s +FLAGS.SILENT (\\Deleted)\r\n",
+                            movetag, expseq);
+                if (pipe_until_tag(backend_current, movetag, 0) != PROXY_OK) {
+                    syslog(LOG_ERR, "MOVE proxy: UID STORE \\Deleted failed on source "
+                                    "after successful APPEND, expunge will be skipped "
+                                    "(user: %s)",
+                                    imapd_userid);
+                }
+
+                /* UID EXPUNGE (RFC 4315, always available on Cyrus backends) */
+                proxy_gentag(movetag, sizeof(movetag));
+                prot_printf(backend_current->out,
+                            "%s UID Expunge %s\r\n",
+                            movetag, expseq);
+                if (pipe_until_tag(backend_current, movetag, 0) != PROXY_OK) {
+                     syslog(LOG_ERR, "MOVE proxy: UID EXPUNGE failed on source after "
+                                     "successful APPEND, message may be duplicated "
+                                     "(user: %s)",
+                                     imapd_userid);
+                }
+            }
+
             if (myrights & ACL_READ) {
                 appenduid = strchr(s->last_result.s, '[');
                 /* skip over APPENDUID */
@@ -1186,6 +1217,7 @@ void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
                 prot_printf(imapd_out, "%s OK %s\r\n", tag,
                             error_message(IMAP_OK_COMPLETED));
             }
+            ret = PROXY_OK;
         } else {
             prot_printf(imapd_out, "%s %s", tag, s->last_result.s);
         }
@@ -1207,6 +1239,7 @@ void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
         if (p->flags) free(p->flags);
         free(p);
     }
+    return ret;
 }
 /* xxx  end of separate proxy-only code */
 

--- a/imap/imap_proxy.h
+++ b/imap/imap_proxy.h
@@ -84,8 +84,8 @@ int pipe_lsub(struct backend *s, const char *userid, const char *tag,
 void print_listresponse(unsigned cmd, const char *extname, char hier_sep,
                         uint32_t attributes, struct buf *extraflags);
 
-void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
-                int usinguid, struct backend *s);
+int proxy_copy(const char *tag, char *sequence, char *name, int myrights,
+                int usinguid, struct backend *s, int ismove);
 
 int proxy_catenate_url(struct backend *s, struct imapurl *url, FILE *f,
                        size_t maxsize, unsigned long *size, const char **parseerr);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3902,6 +3902,7 @@ static void cmd_append(char *tag, char *name, const char *cur_name)
 
         if (!r) {
             int is_active = 1;
+            void *save_context = s->context;
             s->context = (void*) &is_active;
             if (imapd_index) {
                 const char *mboxname = index_mboxname(imapd_index);
@@ -3916,7 +3917,7 @@ static void cmd_append(char *tag, char *name, const char *cur_name)
             if (!(r = pipe_command(s, 16384))) {
                 pipe_including_tag(s, tag, 0);
             }
-            s->context = NULL;
+            s->context = save_context;
         } else {
             eatline(imapd_in, prot_getc(imapd_in));
         }
@@ -4481,6 +4482,8 @@ static void cmd_select(char *tag, char *cmd, char *name)
 
         switch (pipe_including_tag(backend_current, tag, 0)) {
         case PROXY_OK:
+            mboxlist_entry_free((mbentry_t **) &backend_current->context);
+            backend_current->context = mboxlist_entry_copy(mbentry);
             syslog(LOG_DEBUG, "open: user %s opened %s on %s",
                    imapd_userid, name, mbentry->server);
 
@@ -6190,6 +6193,9 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
            (remove when we move to a unified environment) */
         struct backend *s = NULL;
 
+	/* save source context before proxy_findserver may change backend_current */
+        mbentry_t *source_mbentry = backend_current->context? mboxlist_entry_copy((mbentry_t *)backend_current->context) : NULL;
+
         s = proxy_findserver(mbentry->server, &imap_protocol,
                              proxy_userid, &backend_cached,
                              &backend_current, &backend_inbox, imapd_in);
@@ -6203,7 +6209,17 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
             /* this is the hard case; we have to fetch the messages and append
                them to the other mailbox */
 
-            proxy_copy(tag, sequence, name, myrights, usinguid, s);
+            /* need permission to delete from source if it's a move */
+            if (ismove && source_mbentry && !(cyrus_acl_myrights(imapd_authstate, source_mbentry->acl) & ACL_EXPUNGE)) {
+		mboxlist_entry_free(&source_mbentry);
+                r = IMAP_PERMISSION_DENIED;
+                goto done;
+            }
+            /* Return value ignored: the tagged response has already been sent to
+             * the client.  The int return is reserved for a future compensation
+             * path if expunge fails after a successful append. */
+            proxy_copy(tag, sequence, name, myrights, usinguid, s, ismove);
+	    mboxlist_entry_free(&source_mbentry);
             goto cleanup;
         }
         /* xxx  end of separate proxy-only code */


### PR DESCRIPTION
---

### Problem

In a Cyrus murder cluster, a `UID MOVE` where source and destination live on different backends was silently degraded into a `COPY`: the message was appended to the destination but never expunged from the source.

Root cause: `cmd_copy()` calls `proxy_copy()` without the `ismove` flag, so no post-APPEND expunge was ever issued.

---

### Design

Backport of master commit d8a578d73 (PR #6081).
Implements the approach outlined by @elliefm in #51:

> 1. Check `ACL_EXPUNGE` on the source before proceeding.
> 2. `proxy_copy()` should return a status, not void.
> 3. On success, expunge the source messages.

See inline code comments for implementation details.

---

### Tests (Cassandane)

Two new tests in `cassandane/Cassandane/Cyrus/MurderIMAP.pm`:

- `test_move_shared_across_backends`: cross-backend MOVE succeeds, source is verified empty.
- `test_move_shared_across_backends_no_expunge_acl`: MOVE is rejected with `NO` when the user lacks the `e` ACL right; source is untouched.

---

### Known limitations / future work

- **No atomicity**: if `APPEND` succeeds but `UID EXPUNGE` fails, the message exists on both backends. The `int` return type of `proxy_copy()` is plumbing for a future compensation path.

---

### Tests (Cassandane)

Two new tests in `cassandane/Cassandane/Cyrus/MurderIMAP.pm`:

- `test_move_shared_across_backends`: cross-backend MOVE succeeds, source is verified empty.
- `test_move_shared_across_backends_no_expunge_acl`: MOVE is rejected with `NO` when the user lacks the `e` ACL right; source is untouched.

---

### Known limitations / future work

- **No atomicity**: if `APPEND` succeeds but `UID EXPUNGE` fails, the message exists on both backends. The `int` return type of `proxy_copy()` is plumbing for a future compensation path.

---

### Compatibility

Backport of master commit d8a578d73 to cyrus-imapd-3.8. Requires two additional fixes not needed on master:

- `cmd_select`: store `mbentry` in `backend_current->context` on successful proxy SELECT (already done on master).
- `cmd_append`: save and restore `backend_current->context` instead of setting it to NULL (already done on master).

No configuration change required.