### PR TITLE
imap: fix UID MOVE cross-backend in murder proxy

### DIFF
--- a/cassandane/Cassandane/Cyrus/MurderIMAP.pm
+++ b/cassandane/Cassandane/Cyrus/MurderIMAP.pm
@@ -47,6 +47,7 @@ use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
 use Cassandane::Util::Words;
 use Cassandane::Instance;
+use Cassandane::Tiny::Loader 'tiny-tests/MurderIMAP';
 
 $Data::Dumper::Sortkeys = 1;
 

--- a/cassandane/tiny-tests/MurderIMAP/move_shared_across_backends
+++ b/cassandane/tiny-tests/MurderIMAP/move_shared_across_backends
@@ -1,0 +1,44 @@
+#!perl
+use Cassandane::Tiny;
+sub test_move_shared_across_backends
+    :NoAltNamespace :IMAPMurder :needs_component_murder
+{
+    my ($self) = @_;
+    my $shared = 'shared';
+
+    # create a shared folder on backend2
+    my $admintalk = $self->{backend2_adminstore}->get_client();
+    $admintalk->create($shared);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    # grant full rights including expunge
+    $admintalk->setacl($shared, 'anyone', 'lrswipkxtecd');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # inject a message into the shared folder
+    my $frontend = $self->{frontend_store}->get_client();
+    $self->{frontend_store}->set_folder($shared);
+    $self->{frontend_store}->_select();
+    $self->{gen}->set_next_uid(1);
+    $self->make_message("Message A", store => $self->{frontend_store});
+
+    # verify the message is there
+    $frontend->select($shared);
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+
+    # MOVE to INBOX (cross-backend)
+    $frontend->move('1', 'INBOX');
+    xlog $self, "move response: " . $frontend->get_last_completion_response();
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+
+    # Verify directly on backend2: Mail::IMAPTalk does not update its
+    # internal EXISTS counter in response to an unsolicited EXPUNGE
+    # received during a MOVE.
+    my $backend2 = $self->{backend2_store}->get_client();
+    $backend2->select($shared);
+    $self->assert_num_equals(0, $backend2->get_response_code('exists'));
+
+    # verify the message is now in INBOX
+    $frontend->select('INBOX');
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+}

--- a/cassandane/tiny-tests/MurderIMAP/move_shared_across_backends_no_expunge_acl
+++ b/cassandane/tiny-tests/MurderIMAP/move_shared_across_backends_no_expunge_acl
@@ -1,0 +1,36 @@
+#!perl
+use Cassandane::Tiny;
+sub test_move_shared_across_backends_no_expunge_acl
+    :NoAltNamespace :IMAPMurder :needs_component_murder
+{
+    my ($self) = @_;
+    my $shared = 'shared';
+
+    # create a shared folder on backend2
+    my $admintalk = $self->{backend2_adminstore}->get_client();
+    $admintalk->create($shared);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    # grant rights without expunge ('e' is missing)
+    $admintalk->setacl($shared, 'anyone', 'lrswipkxtcd');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # inject a message into the shared folder
+    my $frontend = $self->{frontend_store}->get_client();
+    $self->{frontend_store}->set_folder($shared);
+    $self->{frontend_store}->_select();
+    $self->{gen}->set_next_uid(1);
+    $self->make_message("Message A", store => $self->{frontend_store});
+
+    # verify the message is there
+    $frontend->select($shared);
+    $self->assert_str_equals('ok', $frontend->get_last_completion_response());
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+
+    # MOVE to INBOX (cross-backend) should fail without expunge right
+    $frontend->move('1', 'INBOX');
+    $self->assert_matches(qr{Permission denied}, $frontend->get_last_error());
+
+    # verify the message is still in the source
+    $frontend->select($shared);
+    $self->assert_num_equals(1, $frontend->get_response_code('exists'));
+}

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -159,6 +159,7 @@ struct backend *proxy_findinboxserver(const char *userid)
    force_notfatal says to not fatal() if we lose connection to backend_current
    even though it is in 95% of the cases, a good idea...
 */
+
 static int pipe_response(struct backend *s, const char *tag, int include_last,
                          int force_notfatal)
 {
@@ -986,13 +987,14 @@ static void copy_cb(uint32_t seqno, unsigned item, void *datap, void *rock)
     }
 }
 
-void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
-                int usinguid, struct backend *s)
+int proxy_copy(const char *tag, char *sequence, char *name, int myrights,
+                int usinguid, struct backend *s, int ismove)
 {
     struct copy_rock crock = { HASHU64_TABLE_INITIALIZER, { 0 }, s, NULL };
     unsigned items = FETCH_FLAGS | FETCH_INTERNALDATE;
     char *freeme = NULL;
     int res;
+    int ret = PROXY_NO;
 
     construct_hashu64_table(&crock.msg_byuid, 1024, 0);
 
@@ -1030,6 +1032,38 @@ void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
         res = pipe_until_tag(s, tag, 0);
 
         if (res == PROXY_OK) {
+            /* expseq is freeme when set (UID set fetched from the source via FETCH
+             * callbacks), otherwise the original sequence argument.  Either way it
+             * refers to messages on backend_current, the source backend. */
+            if (ismove) {
+                char movetag[128];
+                const char *expseq = freeme ? freeme : sequence;
+
+                /* mark \Deleted on source backend */
+                proxy_gentag(movetag, sizeof(movetag));
+                prot_printf(backend_current->out,
+                            "%s UID Store %s +FLAGS.SILENT (\\Deleted)\r\n",
+                            movetag, expseq);
+                if (pipe_until_tag(backend_current, movetag, 0) != PROXY_OK) {
+                    syslog(LOG_ERR, "MOVE proxy: UID STORE \\Deleted failed on source "
+                                    "after successful APPEND, expunge will be skipped "
+                                    "(user: %s)",
+                                    imapd_userid);
+                }
+
+                /* UID EXPUNGE (RFC 4315, always available on Cyrus backends) */
+                proxy_gentag(movetag, sizeof(movetag));
+                prot_printf(backend_current->out,
+                            "%s UID Expunge %s\r\n",
+                            movetag, expseq);
+                if (pipe_until_tag(backend_current, movetag, 0) != PROXY_OK) {
+                     syslog(LOG_ERR, "MOVE proxy: UID EXPUNGE failed on source after "
+                                     "successful APPEND, message may be duplicated "
+                                     "(user: %s)",
+                                     imapd_userid);
+                }
+            }
+
             if (myrights & ACL_READ) {
                 appenduid = strchr(s->last_result.s, '[');
                 /* skip over APPENDUID */
@@ -1047,6 +1081,7 @@ void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
                 prot_printf(imapd_out, "%s OK %s\r\n", tag,
                             error_message(IMAP_OK_COMPLETED));
             }
+            ret = PROXY_OK;
         } else {
             prot_printf(imapd_out, "%s %s", tag, s->last_result.s);
         }
@@ -1063,6 +1098,7 @@ void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
     free_hashu64_table(&crock.msg_byuid, NULL);
     seqset_free(&crock.uidset);
     free(freeme);
+    return ret;
 }
 
 int proxy_fetch(char *sequence, int usinguid, unsigned items,

--- a/imap/imap_proxy.h
+++ b/imap/imap_proxy.h
@@ -90,8 +90,8 @@ int proxy_fetch(char *sequence, int usinguid, unsigned items,
                                 void *datap, void *rock),
                 void *rock);
 
-void proxy_copy(const char *tag, char *sequence, char *name, int myrights,
-                int usinguid, struct backend *s);
+int proxy_copy(const char *tag, char *sequence, char *name, int myrights,
+                int usinguid, struct backend *s, int ismove);
 
 int proxy_catenate_url(struct backend *s, struct imapurl *url, FILE *f,
                        size_t maxsize, unsigned long *size, const char **parseerr);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6668,7 +6668,16 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
             /* this is the hard case; we have to fetch the messages and append
                them to the other mailbox */
 
-            proxy_copy(tag, sequence, name, myrights, usinguid, s);
+            /* need permission to delete from source if it's a move */
+            if (ismove && backend_current->context && !(cyrus_acl_myrights(imapd_authstate, ((mbentry_t *)backend_current->context)->acl) & ACL_EXPUNGE)) {
+                r = IMAP_PERMISSION_DENIED;
+                goto done;
+            }
+
+            /* Return value ignored: the tagged response has already been sent to
+             * the client.  The int return is reserved for a future compensation
+             * path if expunge fails after a successful append. */
+            proxy_copy(tag, sequence, name, myrights, usinguid, s, ismove);
             goto cleanup;
         }
         /* xxx  end of separate proxy-only code */


### PR DESCRIPTION
---

### Problem

In a Cyrus murder cluster, a `UID MOVE` where source and destination live on different backends was silently degraded into a `COPY`: the message was appended to the destination but never expunged from the source.

Root cause: `cmd_copy()` calls `proxy_copy()` without the `ismove` flag, so no post-APPEND expunge was ever issued.

---

### Design

Backport of master commit d8a578d73 (PR #6081).

Implements the approach outlined by @elliefm in #51:

> 1. Check `ACL_EXPUNGE` on the source before proceeding.
> 2. `proxy_copy()` should return a status, not void.
> 3. On success, expunge the source messages.

See inline code comments for implementation details.

---

### Tests (Cassandane)

Two new tiny-tests under `cassandane/tiny-tests/MurderIMAP/`:

- `move_shared_across_backends`: cross-backend MOVE succeeds, source is verified empty.
- `move_shared_across_backends_no_expunge_acl`: MOVE is rejected with `NO` when the user lacks the `e` ACL right; source is untouched.

---

### Known limitations / future work

- **No atomicity**: if `APPEND` succeeds but `UID EXPUNGE` fails, the message exists on both backends. The `int` return type of `proxy_copy()` is plumbing for a future compensation path.

---

### Compatibility

Backport of master commit d8a578d73 to cyrus-imapd-3.12.

The C code applies cleanly. Cassandane adaptations were needed:
- Added `use Cassandane::Tiny::Loader 'tiny-tests/MurderIMAP'` to MurderIMAP.pm
- Replaced Perl subroutine signature syntax (`($self)`) with `my ($self) = @_;` for compatibility with this branch

No configuration change required.