### PR TITLE
promstatsd timing fixes

### DIFF
--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -92,8 +92,14 @@ sub parse_report
     return $report;
 }
 
-sub slowtest_50000_users
-    :min_version_3_1
+# This is not a test, in that it doesn't really verify any particular result,
+# and it never runs automatically.  Not even with --slow!  But it does spin up
+# a representative number of user accounts, which can be useful for seeing how
+# the prometheus subsystems perform in "reality".
+#
+# To use it, delete "stress" from the sub name and run Prometheus.50000_users.
+# And then wait a while!  Watch logs for whatever detail you're interested in.
+sub stresstest_50000_users
 {
     my ($self) = @_;
 
@@ -131,10 +137,10 @@ sub slowtest_50000_users
     sleep 3;
 
     my $response = $self->http_report();
-    $self->assert($response->{success});
+    $self->assert_not_null($response->{success});
 
     my $report = parse_report($response->{content});
-    $self->assert(scalar keys %{$report});
+    $self->assert_num_gt(0, scalar keys %{$report});
 
     # n.b. user/mailbox counts are +1 cause of user.cassandane!
     $self->assert_num_equals(1 + $nusers,

--- a/cassandane/Cassandane/Cyrus/Prometheus.pm
+++ b/cassandane/Cassandane/Cyrus/Prometheus.pm
@@ -47,10 +47,10 @@ sub _create_instances
     my ($self) = @_;
 
     $self->SUPER::_create_instances();
-    # XXX This should really run from the DAEMON section,
-    # XXX but Cassandane doesn't know about that.
-    $self->{instance}->add_start(name => 'promstatsd',
-                                 argv => [ 'promstatsd' ]);
+    $self->{instance}->add_start(name => 'statscleanup',
+                                 argv => [ 'promstatsd', '-c' ]);
+    $self->{instance}->add_daemon(name => 'promstatsd',
+                                  argv => [ 'promstatsd' ]);
 }
 
 sub tear_down

--- a/cassandane/tiny-tests/Prometheus/disabled
+++ b/cassandane/tiny-tests/Prometheus/disabled
@@ -6,7 +6,7 @@ sub test_disabled
     ($self)
 {
     my $instance = $self->{instance};
-    $instance->{starts} = [ grep { $_->{name} ne 'promstatsd' } @{$instance->{starts}} ];
+    delete $instance->{daemons}->{promstatsd};
     $instance->{config}->set(prometheus_enabled => 'no');
 
     $self->_start_instances();

--- a/cassandane/tiny-tests/Prometheus/stable_clock
+++ b/cassandane/tiny-tests/Prometheus/stable_clock
@@ -1,0 +1,61 @@
+#!perl
+use Cassandane::Tiny;
+
+use Date::Parse;
+use List::Util qw(uniq);
+use Time::HiRes qw(usleep);
+
+sub test_stable_clock
+    :min_version_3_1
+    ($self)
+{
+    my @procinfo = grep { m/^\d+ promstatsd\s*$/ }
+                        $self->{instance}->run_cyr_info('proc');
+    $self->assert_num_equals(1, scalar @procinfo);
+    my ($promstatsd_pid, undef) = split /\s/, $procinfo[0], 2;
+    xlog $self, "found promstatsd pid: $promstatsd_pid";
+
+    # do something that'll get counted; wait a moment for the initial report
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->select("INBOX");
+    sleep 3;
+
+    my @timestamps;
+
+    # collect timestamps from consecutive reports, while sending signals to
+    # promstatsd to disrupt its sleep period
+    for (1..5) {
+        sleep 2;
+        kill 'USR1', $promstatsd_pid; # this signal just toggles debug logging
+
+        my $response = $self->http_report();
+
+        $self->assert_not_null($response->{success});
+        $self->assert_num_gt(0, length $response->{content});
+
+        my $report = parse_report($response->{content});
+
+        $self->assert_num_gt(0, scalar keys %{$report});
+        $self->assert_not_null($report->{cyrus_imap_connections_total});
+
+        my $stat = $report->{cyrus_imap_connections_total}->{'service="imap"'};
+
+        # timestamp is the report time, so it will have a new value each time
+        # the report is generated, regardless of if the counted value changed
+        push @timestamps, $stat->{timestamp};
+    }
+
+    # filter out any duplicates, they're not interesting here, they just mean
+    # our sleep won the race and we got in before a new report was generated
+    @timestamps = uniq @timestamps;
+    xlog $self, "report timestamps: " . Dumper \@timestamps;
+
+    # we're configured to produce a report every 2 seconds.
+    # generously allow for 200ms slop, although even under valgrind I only
+    # see a few milliseconds difference in practice
+    for (my $t = 0; $t < @timestamps - 1; $t++) {
+        my $delta = $timestamps[$t + 1] - $timestamps[$t];
+        $self->assert_num_gt(1800, $delta);
+        $self->assert_num_lt(2200, $delta);
+    }
+}

--- a/changes/next/promstatsd-timing
+++ b/changes/next/promstatsd-timing
@@ -1,0 +1,23 @@
+Description:
+
+:cyrusman:`promstatsd(8)` is less susceptible to timing drift and other quirks.
+
+
+Documentation:
+
+:cyrusman:`promstatsd(8)`
+
+
+Config changes:
+
+prometheus_usage_update_freq (docs only)
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None

--- a/docsrc/reference/manpages/systemcommands/promstatsd.rst
+++ b/docsrc/reference/manpages/systemcommands/promstatsd.rst
@@ -24,23 +24,22 @@ Description
 
 **promstatsd** is the Cyrus Prometheus statistics collating daemon.
 
-When the **prometheus_enabled** :cyrusman:`imapd.conf(5)` setting is true,
-various Cyrus service processes will count statistics as they run.
-**promstatsd** collates these statistics into a text-based report that
-Prometheus can ingest.
+When the :imapdconf:`prometheus_enabled` setting is true, various Cyrus
+service processes will count statistics as they run.  **promstatsd** collates
+these statistics into a text-based report that Prometheus can ingest.
 
 The report produced by **promstatsd** is served by :cyrusman:`httpd(8)` at
-the "/metrics" URL, if "prometheus" has been set in **httpmodules** in
-:cyrusman:`imapd.conf(5)`.
+the "/metrics" URL, if "prometheus" has been enabled in
+:imapdconf:`httpmodules`.
 
 **promstatsd** |default-conf-text|
 
 In the first synopsis, **promstatsd** will run as a daemon, updating the
 service and (optionally) usage reports at the frequencies set by the
-**prometheus_service_update_freq** and **prometheus_usage_update_freq**
-:cyrusman:`imapd.conf(5)` options, which default to 10s and disabled,
-respectively.  The optional **-f** *service-frequency* argument can be used to
-override **prometheus_service_update_freq**.  This invocation should be run
+:imapdconf:`prometheus_service_update_freq` and
+:imapdconf:`prometheus_usage_update_freq` options.  The optional **-f**
+*service-frequency* argument can be used to override
+**prometheus_service_update_freq**.  This invocation should be run
 from the DAEMON section of :cyrusman:`cyrus.conf(5)` (see
 :ref:`promstatsd-examples` below).
 
@@ -66,8 +65,8 @@ Options
 
 .. option:: -D
 
-    Run the external debugger specified in the **debug_command**
-    :cyrusman:`imapd.conf(5)` option.
+    Run the external debugger specified in the :imapdconf:`debug_command`
+    option.
 
 .. option:: -1
 
@@ -85,8 +84,7 @@ Options
 .. option:: -f service-frequency
 
     Update the service report every *service-frequency* seconds.  If not
-    specified, the **prometheus_service_update_freq** from
-    :cyrusman:`imapd.conf(5)` will be used, which defaults to 10 seconds.
+    specified, :imapdconf:`prometheus_service_update_freq` will be used.
 
 .. option:: -v
 

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -42,15 +42,16 @@ static struct report {
     enum imapopt freq_opt;
     struct mappedfile *mf;
     struct buf buf;
-    int64_t frequency;
+    int64_t frequency; /* actually period, not frequency. d'oh */
     int64_t next_report_time;
+    int slow_collate_count;
 } reports[] = {
     { FNAME_PROM_SERVICE_REPORT, "service", &do_collate_service_report,
       IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ,
-      NULL, BUF_INITIALIZER, 0, 0 },
+      NULL, BUF_INITIALIZER, 0, 0, 0 },
     { FNAME_PROM_USAGE_REPORT,   "usage",   &do_collate_usage_report,
       IMAPOPT_PROMETHEUS_USAGE_UPDATE_FREQ,
-      NULL, BUF_INITIALIZER, 0, 0 },
+      NULL, BUF_INITIALIZER, 0, 0, 0 },
 };
 const size_t n_reports = sizeof(reports) / sizeof(reports[0]);
 
@@ -803,7 +804,38 @@ int main(int argc, char **argv)
                                   collate_took / 1000.0);
                 do_write_report(reports[i].mf, &reports[i].buf);
 
-                // XXX if collate_took is greater than frequency, uh oh!
+                /* if some report is consistently taking too long to collate
+                 * relative to how often we collate it, do so less often
+                 */
+                if (collate_took >= reports[i].frequency / 2) {
+                    reports[i].slow_collate_count ++;
+
+                    xsyslog(LOG_NOTICE, "report took too long to collate",
+                                        "report=<%s> frequency=<%" PRIi64 "s>"
+                                        " collate_took=<%gs> count=<%d>",
+                                        reports[i].desc,
+                                        reports[i].frequency / 1000,
+                                        collate_took / 1000.0,
+                                        reports[i].slow_collate_count);
+
+                    if (reports[i].slow_collate_count > 2) {
+                        int64_t new_frequency = reports[i].frequency * 2;
+
+                        xsyslog(LOG_NOTICE, "increasing time between reports",
+                                            "report=<%s> frequency=<%" PRIi64 "s>"
+                                            " new_frequency=<%" PRIi64 "s>",
+                                            reports[i].desc,
+                                            reports[i].frequency / 1000,
+                                            new_frequency / 1000);
+
+                        reports[i].frequency = new_frequency;
+                        reports[i].slow_collate_count = 0;
+                    }
+                }
+                else {
+                    reports[i].slow_collate_count = 0;
+                }
+
                 reports[i].next_report_time = tick + reports[i].frequency;
             }
         }

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -40,17 +40,16 @@ static struct report {
     const char *desc;
     void (*collate_fn)(struct buf *);
     enum imapopt freq_opt;
-    int default_frequency;
     struct mappedfile *mf;
     struct buf buf;
     int frequency;
     int64_t prev_report_time;
 } reports[] = {
     { FNAME_PROM_SERVICE_REPORT, "service", &do_collate_service_report,
-      IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ, 10,
+      IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ,
       NULL, BUF_INITIALIZER, 0, 0 },
     { FNAME_PROM_USAGE_REPORT,   "usage",   &do_collate_usage_report,
-      IMAPOPT_PROMETHEUS_USAGE_UPDATE_FREQ, 0,
+      IMAPOPT_PROMETHEUS_USAGE_UPDATE_FREQ,
       NULL, BUF_INITIALIZER, 0, 0 },
 };
 const size_t n_reports = sizeof(reports) / sizeof(reports[0]);
@@ -751,10 +750,7 @@ int main(int argc, char **argv)
                                 reports[i].fname,
                                 NULL);
 
-        if (reports[i].frequency <= 0)
-            reports[i].frequency = config_getduration(reports[i].freq_opt);
-        if (reports[i].frequency <= 0)
-            reports[i].frequency = reports[i].default_frequency;
+        reports[i].frequency = config_getduration(reports[i].freq_opt);
 
         if (reports[i].frequency) {
             syslog(LOG_DEBUG, "updating %s every %d seconds",

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -42,8 +42,8 @@ static struct report {
     enum imapopt freq_opt;
     struct mappedfile *mf;
     struct buf buf;
-    int frequency;
-    int64_t prev_report_time;
+    int64_t frequency;
+    int64_t next_report_time;
 } reports[] = {
     { FNAME_PROM_SERVICE_REPORT, "service", &do_collate_service_report,
       IMAPOPT_PROMETHEUS_SERVICE_UPDATE_FREQ,
@@ -637,7 +637,7 @@ static void do_write_report(struct mappedfile *mf, const struct buf *report)
 
 static inline int report_due(const struct report *report, int64_t tick)
 {
-    return (report->prev_report_time + 1000 * report->frequency <= tick);
+    return report->next_report_time <= tick;
 }
 
 int main(int argc, char **argv)
@@ -651,10 +651,10 @@ int main(int argc, char **argv)
     int debugmode = 0;
     int verbose = 0;
     int oneshot = 0;
-    int min_frequency = INT_MAX;
     int opt;
     int r;
     unsigned i;
+    int64_t tick;
 
     p = getenv("CYRUS_VERBOSE");
     if (p) verbose = atoi(p) + 1;
@@ -682,8 +682,8 @@ int main(int argc, char **argv)
             break;
 
         case 'f': /* set service report frequency */
-            reports[0].frequency = atoi(optarg);
-            if (reports[0].frequency <= 0) usage();
+            reports[0].frequency = 1000 * atoi(optarg);
+            if (reports[0].frequency < 1000) usage();
             break;
 
         case 'v': /* verbose */
@@ -745,18 +745,18 @@ int main(int argc, char **argv)
         }
     }
 
+    tick = now_ms();
     for (i = 0; i < n_reports; i++) {
         char *fname = strconcat(prometheus_stats_dir(),
                                 reports[i].fname,
                                 NULL);
 
-        reports[i].frequency = config_getduration(reports[i].freq_opt);
+        reports[i].frequency = 1000 * config_getduration(reports[i].freq_opt);
 
         if (reports[i].frequency) {
-            syslog(LOG_DEBUG, "updating %s every %d seconds",
-                              fname, reports[i].frequency);
-            if (reports[i].frequency < min_frequency)
-                min_frequency = reports[i].frequency;
+            syslog(LOG_DEBUG, "updating %s every %" PRIi64 " seconds",
+                              fname, reports[i].frequency / 1000);
+            reports[i].next_report_time = tick + reports[i].frequency;
         }
         else {
             syslog(LOG_DEBUG, "not updating %s due to frequency 0", fname);
@@ -768,11 +768,11 @@ int main(int argc, char **argv)
         free(fname);
         if (r) fatal("couldn't open report file", EX_IOERR);
     }
-    assert(min_frequency > 0 && min_frequency < INT_MAX);
 
     for (;;) {
         int sig;
-        int64_t tick, elapsed;
+        int64_t next_report_time;
+        struct timespec wake;
 
         sig = signals_poll();
         if (sig == SIGHUP && getenv("CYRUS_ISDAEMON")) {
@@ -793,12 +793,18 @@ int main(int argc, char **argv)
                 && (oneshot || report_due(&reports[i], tick)))
             {
                 int64_t profile_starttime = now_ms();
+                int64_t collate_took;
+
                 reports[i].collate_fn(&reports[i].buf);
+                collate_took = now_ms() - profile_starttime;
+
                 syslog(LOG_DEBUG, "collated %s report in %f seconds",
                                   reports[i].desc,
-                                  (now_ms() - profile_starttime) / 1000.0);
+                                  collate_took / 1000.0);
                 do_write_report(reports[i].mf, &reports[i].buf);
-                reports[i].prev_report_time = tick;
+
+                // XXX if collate_took is greater than frequency, uh oh!
+                reports[i].next_report_time = tick + reports[i].frequency;
             }
         }
 
@@ -806,15 +812,23 @@ int main(int argc, char **argv)
             shut_down(0);
         }
 
-        /* then wait around a bit */
-        /* XXX This isn't exactly right: if service is 10s and usage is 15s
-         * XXX we'll end up waking at 10s, 20s, 30s, 40s, and the usage report
-         * XXX will be on a lurching clock since 10 doesn't evenly divide 15.
-         * XXX Probably want to use greatest common divisor, but that would
-         * XXX become annoying to compute if we add a third report to the mix.
-         */
-        elapsed = now_ms() - tick;
-        sleep(min_frequency - elapsed / 1000);
+        /* then wait around until the next report is due */
+        next_report_time = INT64_MAX;
+        for (i = 0; i < n_reports; i++) {
+            if (reports[i].frequency) {
+                next_report_time = MIN(next_report_time,
+                                       reports[i].next_report_time);
+            }
+        }
+        assert(next_report_time > tick);
+        assert(next_report_time < INT64_MAX);
+
+        wake.tv_sec = next_report_time / 1000;
+        wake.tv_nsec = (next_report_time % 1000) * 1000000; /* ms -> ns */
+        do {
+            r = clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &wake, NULL);
+            assert(r == 0 || r == EINTR);
+        } while (r == EINTR);
     }
 
     /* NOTREACHED */

--- a/lib/imapoptions/prometheus_usage_update_freq
+++ b/lib/imapoptions/prometheus_usage_update_freq
@@ -1,11 +1,8 @@
 Name: prometheus_usage_update_freq
 Type: DURATION
 Default-Value: NULL
-Last-Modified: 3.12.0
+Last-Modified: UNRELEASED
 
 Frequency in at which promstatsd should re-collate its usage statistics
 report.  Note that this report is relatively expensive to produce.  If not
 set, usage statistics are not reported.
-
-Best to make this a multiple of
-:imapdconf:`prometheus_service_update_freq`.


### PR DESCRIPTION
This PR improves the regularity at which promstatsd produces prometheus reports.  Specifically, it fixes several sources of timing drift, and limits the impact an expensive report can have on other reports.

**Reviewers:** I suggest reading this commit by commit.