### PR TITLE
sync_support.c: replicate mailbox deletedmodseq after sync_reset

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_changes_sync_reset_cannot_calculate_changes
+++ b/cassandane/tiny-tests/JMAPEmail/email_changes_sync_reset_cannot_calculate_changes
@@ -1,0 +1,92 @@
+#!perl
+use Cassandane::Tiny;
+
+# This asserts that Email/changes on a replica after sync_reset is safe
+# with regards to destroyed messages on master where the expunged flag
+# didn't make it to the replica.
+
+my sub assert_email_changes_sync_reset_cannot_calculate_changes
+    ($self, $recreate_on_replica)
+{
+    my $master_jmap = $self->default_user->jmap;
+
+    xlog $self, "deliver message to master";
+    $self->make_message("Message X") or die;
+
+    my $email_id = $master_jmap->request(
+        [['Email/query', {} ]])->single_sentence->arguments->{ids}[0];
+    $self->assert_not_null($email_id);
+
+    xlog $self, "replicate master -> replica";
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    xlog $self, "get Email state from replica";
+    my $replica_jmap = $self->{replica}->new_jmaptester_for_user($self->default_user);
+    my $res = $replica_jmap->request(
+        [['Email/get', { ids => [$email_id], properties => ['id'] } ]]);
+    $self->assert_str_equals($email_id, $res->single_sentence->arguments->{list}[0]{id});
+
+    my $email_state = $replica_jmap->request(
+        [['Email/get', { ids => [] } ]])->single_sentence->arguments->{state};
+    $self->assert_not_null($email_state);
+
+    xlog $self, "destroy Email on master";
+    $res = $master_jmap->request([[ 'Email/set', { destroy => [$email_id] } ]]);
+    $self->assert_deep_equals([$email_id],
+                              $res->single_sentence->arguments->{destroyed});
+
+    xlog $self, "expunge the record on master";
+    $self->run_delayed_expunge();
+
+    xlog $self, "assert that master returns cannotCalculateChanges";
+    $res = $master_jmap->request([[ 'Email/changes', {
+        sinceState  => $email_state,
+        includeCADs => jtrue,
+    } ]]);
+    $self->assert_str_equals("cannotCalculateChanges",
+                             $res->single_sentence->arguments->{type} // '');
+
+    xlog $self, "reset the replica mailbox";
+    $self->{replica}->run_command({ cyrus => 1 },
+                                  'sync_reset', '-f', 'cassandane');
+
+    if ($recreate_on_replica) {
+        xlog $self, "recreate the replica mailbox with a new uniqueid";
+        my $radmin = $self->{replica}->get_service('imap')
+                          ->create_store(username => 'admin')->get_client();
+        $radmin->create('user.cassandane');
+        $self->assert_str_equals('ok', $radmin->get_last_completion_response());
+    }
+
+    xlog $self, "replicate onto the reset replica";
+    $self->run_replication();
+
+    xlog $self, "call Email/changes on the recreated replica";
+    $replica_jmap = $self->{replica}->new_jmaptester_for_user($self->default_user);
+    $res = $replica_jmap->request([[ 'Email/changes', {
+        sinceState  => $email_state,
+        includeCADs => jtrue,
+    } ]]);
+
+    xlog $self, "assert that replica returns cannotCalculateChanges";
+    $self->assert_str_equals('error', $res->single_sentence->name);
+    $self->assert_str_equals('cannotCalculateChanges',
+                             $res->single_sentence->arguments->{type});
+}
+
+sub test_email_changes_sync_reset_recreate_cannot_calculate_changes
+    :needs_component_jmap :needs_component_replication :Replication
+    :NoReplicaonly :Admin
+    ($self)
+{
+    assert_email_changes_sync_reset_cannot_calculate_changes($self, 1);
+}
+
+sub test_email_changes_sync_reset_create_cannot_calculate_changes
+    :needs_component_jmap :needs_component_replication :Replication
+    :NoReplicaonly
+    ($self)
+{
+    assert_email_changes_sync_reset_cannot_calculate_changes($self, 0);
+}

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2095,6 +2095,9 @@ static int sync_prepare_dlists(struct mailbox *mailbox,
     if (mailbox_foldermodseq(mailbox))
         dlist_setnum64(kl, "FOLDERMODSEQ", mailbox_foldermodseq(mailbox));
 
+    if (mailbox->i.deletedmodseq)
+        dlist_setnum64(kl, "DELETEDMODSEQ", mailbox->i.deletedmodseq);
+
     /* always send mailbox annotations */
     r = read_annotations(mailbox, NULL, &annots, 0, 0);
     if (r) goto done;
@@ -3220,6 +3223,7 @@ static int sync_apply_mailbox(struct dlist *kin,
     modseq_t xconvmodseq = 0;
     modseq_t raclmodseq = 0;
     modseq_t createdmodseq = 0;
+    modseq_t deletedmodseq = 0;
     const char *groups = NULL;
     const char *jmapid = NULL;
 
@@ -3228,6 +3232,7 @@ static int sync_apply_mailbox(struct dlist *kin,
     struct synccrcs since_crcs = { 0, 0 };
 
     struct mailbox *mailbox = NULL;
+    bool created = false;
     struct dlist *kr;
     struct dlist *ka = NULL;
     struct dlist *userflags = NULL;
@@ -3305,6 +3310,7 @@ static int sync_apply_mailbox(struct dlist *kin,
     dlist_getnum32(kin, "COMPACT_EMAILIDS", &compact_emailids);
     dlist_getnum64(kin, "RACLMODSEQ", &raclmodseq);
     dlist_getnum64(kin, "FOLDERMODSEQ", &foldermodseq);
+    dlist_getnum64(kin, "DELETEDMODSEQ", &deletedmodseq);
     dlist_getlist(kin, "USERFLAGS", &userflags);
     dlist_getatom(kin, "USERGROUPS", &groups);
     dlist_getatom(kin, "JMAPID", &jmapid);
@@ -3360,7 +3366,10 @@ static int sync_apply_mailbox(struct dlist *kin,
         }
         /* set a highestmodseq of 0 so ALL changes are future
          * changes and get applied */
-        if (!r) mailbox->i.highestmodseq = 0;
+        if (!r) {
+            mailbox->i.highestmodseq = 0;
+            created = true;
+        }
 
 #ifdef USE_SIEVE
         if (mbtype_isa(mbtype) == MBTYPE_SIEVE) {
@@ -3423,7 +3432,10 @@ static int sync_apply_mailbox(struct dlist *kin,
                                                flags, &mailbox);
             /* set a highestmodseq of 0 so ALL changes are future
              * changes and get applied */
-            if (!r) mailbox->i.highestmodseq = 0;
+            if (!r) {
+                mailbox->i.highestmodseq = 0;
+                created = true;
+            }
         }
         else {
             xsyslog(LOG_ERR, "SYNCERROR: mailbox uniqueid changed - retry",
@@ -3669,12 +3681,22 @@ static int sync_apply_mailbox(struct dlist *kin,
     mailbox->i.pop3_last_login.tv_sec = pop3_last_login;
     mailbox->i.pop3_show_after.tv_sec = pop3_show_after;
     mailbox->i.createdmodseq = createdmodseq;
+    /* Replicate the deletedmodseq, but only when we just (re)created the
+     * mailbox, as otherwise it would get reset to 1. In all other cases
+     * the replica keeps track on its own of deletedmodseq. */
+    if (created && deletedmodseq > mailbox->i.deletedmodseq)
+        mailbox->i.deletedmodseq = deletedmodseq;
     /* only alter the syncable options */
     mailbox->i.options = (options & MAILBOX_OPTIONS_MASK) |
                          (mailbox->i.options & ~MAILBOX_OPTIONS_MASK);
 
     /* always set the highestmodseq */
     mboxname_setmodseq(mailbox_name(mailbox), highestmodseq, mailbox_mbtype(mailbox), /*flags*/0);
+
+    /* Also set the per-user maildeletedmodseq counter in case of a full reset */
+    if (created && deletedmodseq)
+        mboxname_setmodseq(mailbox_name(mailbox), deletedmodseq,
+                           mailbox_mbtype(mailbox), MBOXMODSEQ_ISDELETE);
 
     /* this happens rarely, so let us know */
     if (mailbox->i.uidvalidity != uidvalidity) {


### PR DESCRIPTION
This fixes a bug where a JMAP client switching their Email/changes requests from master to the replica could silently get out of sync. This only occurs if the message got expunged from master before the replica could get notified about its deletion, and only if the replica recreated the mailbox from scratch. This happens both when the replica fully recreated the mailbox tree after a sync_reset, and when it replaced a mailbox whose uniqueid had changed. In these cases, the replica must receive the deletedmodseq from master, rather than keeping track of its own deletedmodseq as is done during regular replication.