### PR TITLE
managesieve: link against libcap when enabled

### DIFF
--- a/perl/sieve/managesieve/Makefile.PL.in
+++ b/perl/sieve/managesieve/Makefile.PL.in
@@ -69,7 +69,7 @@ WriteMakefile(
     'ABSTRACT'  => 'Cyrus Sieve management interface',
     'VERSION_FROM' => "@top_srcdir@/perl/sieve/managesieve/managesieve.pm", # finds $VERSION
     'MYEXTLIB'  => '../lib/.libs/libisieve.a @top_builddir@/perl/.libs/libcyrus.a @top_builddir@/perl/.libs/libcyrus_min.a',
-    'LIBS'	=> ["$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @LIB_REGEX@ @ZLIB@ @SQLITE_LIBADD@ @MYSQL_LIBADD@ @PGSQL_LIBADD@ @ICU_LIBS@"],
+    'LIBS'	=> ["$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @LIB_REGEX@ @ZLIB@ @SQLITE_LIBADD@ @MYSQL_LIBADD@ @PGSQL_LIBADD@ @ICU_LIBS@ @LIBCAP_LIBS@	"],
     'CCFLAGS'	=> '@GCOV_CFLAGS@',
     'DEFINE'	=> '-DPERL_POLLUTE',     # e.g., '-DHAVE_SOMETHING' 
     'INC'	=> "-I@top_srcdir@/lib -I@top_srcdir@/perl/sieve -I@top_srcdir@/perl/sieve/lib @SASLFLAGS@ @SSL_CPPFLAGS@",


### PR DESCRIPTION
`perl/sieve/managesieve/Makefile.PL.in`'s `LIBS` list does not have `@LIBCAP_LIBS@` (unlike `perl/imap/Makefile.PL.in`).

This breaks `sieveshell` on builds that are built with `--with-libcap` e.g. Debian).

Since `libcyrus_min.a` (linked in as `MYEXTLIB`, so its own link requirements don't propagate) calls `cap_free()` when built `--with-libcap`, `managesieve.so` ends up with an undefined symbol at dlopen time, breaking `sieveshell`.

Fix by adding `@LIBCAP_LIBS@` to `LIBS`, matching perl/imap.