### PR TITLE
Add LIBCAP_LIBS to include path in Makefile.PL.in

### DIFF
--- a/perl/sieve/managesieve/Makefile.PL.in
+++ b/perl/sieve/managesieve/Makefile.PL.in
@@ -72,7 +72,7 @@ WriteMakefile(
     'LIBS'	=> ["$LIB_SASL @SSL_LIBS@ @LIB_UUID@ @LIB_REGEX@ @ZLIB@ @SQLITE_LIBADD@ @MYSQL_LIBADD@ @PGSQL_LIBADD@"],
     'CCFLAGS'	=> '@GCOV_CFLAGS@',
     'DEFINE'	=> '-DPERL_POLLUTE',     # e.g., '-DHAVE_SOMETHING' 
-    'INC'	=> "-I@top_srcdir@/lib -I@top_srcdir@/perl/sieve -I@top_srcdir@/perl/sieve/lib @SASLFLAGS@ @SSL_CPPFLAGS@",
+    'INC'	=> "-I@top_srcdir@/lib -I@top_srcdir@/perl/sieve -I@top_srcdir@/perl/sieve/lib @SASLFLAGS@ @SSL_CPPFLAGS@ @LIBCAP_LIBS@",
     'OBJECT'    => 'managesieve.o',
     'LD'	=> $Config{ld} . ' @GCOV_LDFLAGS@',
     # This is a disgusting hack to effectively disable the stupid


### PR DESCRIPTION
Backport of https://github.com/cyrusimap/cyrus-imapd/pull/6185 to the `3.10 branch`, which is what several distributions (e.g. Debian's `cyrus-imapd` package) still ship.

--

When Cyrus is configured with `--with-libcap`, the `Cyrus::SIEVE::managesieve` Perl module (used by `sieveshell`) fails to load at runtime:

```
Can't load '.../auto/Cyrus/SIEVE/managesieve/managesieve.so' for module Cyrus::SIEVE::managesieve: .../managesieve.so: undefined symbol: cap_free  at .../sieveshell line 71.
Compilation failed in require at .../sieveshell line 71.
BEGIN failed--compilation aborted at .../sieveshell line 71.
```

### Cause

`perl/sieve/managesieve/Makefile.PL.in`'s `LIBS` list does not have `@LIBCAP_LIBS@` (unlike `perl/imap/Makefile.PL.in`).

This breaks `sieveshell` on builds that are built with `--with-libcap` (e.g. Debian).

Since `libcyrus_min.a` (linked in as `MYEXTLIB`, so its own link requirements don't propagate) calls `cap_free()` when built `--with-libcap`, `managesieve.so` ends up with an undefined symbol at dlopen time, breaking `sieveshell`.

Fix by adding `@LIBCAP_LIBS@` to `LIBS`, matching perl/imap.