### PR TITLE
cassandane: fix method name in FastMail test case

### DIFF
--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -130,7 +130,7 @@ sub new
     return $self;
 }
 
-sub default_jmap_using
+sub jmap_default_using
 {
     return [
         'urn:ietf:params:jmap:core',


### PR DESCRIPTION
This does not affect results, but it means the method is actually called and used.