### PR TITLE
jmap_api.c: clear mayDelete on the new default

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_isdefault
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_isdefault
@@ -109,7 +109,10 @@ sub test_calendar_set_isdefault
         superhashof({
             created => {
                 2 => superhashof({
-                    isDefault => JSON::true
+                    isDefault => JSON::true,
+                    myRights => superhashof({
+                        mayDelete => JSON::false
+                    })
                 })
             },
             updated => {                   

--- a/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendar_set_isdefault
+++ b/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendar_set_isdefault
@@ -109,7 +109,10 @@ sub test_calendar_set_isdefault
         superhashof({
             created => {
                 2 => superhashof({
-                    isDefault => JSON::true
+                    isDefault => JSON::true,
+                    myRights => superhashof({
+                        mayDelete => JSON::false
+                    })
                 })
             },
             updated => {                   

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_isdefault
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_isdefault
@@ -109,7 +109,10 @@ sub test_addressbook_set_isdefault
         superhashof({
             created => {
                 2 => superhashof({
-                    isDefault => JSON::true
+                    isDefault => JSON::true,
+                    myRights => superhashof({
+                        mayDelete => JSON::false
+                    })
                 })
             },
             updated => {                   

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -3623,6 +3623,14 @@ EXPORTED void jmap_report_isdefault(struct jmap_set *set, const char *name,
 
     if (json_is_object(obj)) {
         json_object_set_new(obj, "isDefault", json_boolean(isdef));
+
+        /* A create record is built before onSuccessSetIsDefault runs, so its
+         * myRights still shows mayDelete:true, which we won't respect.
+         * Replace it with false.  -- rjbs, 2026-07-29 */
+        json_t *jrights = json_object_get(obj, "myRights");
+        if (isdef && json_is_object(jrights)) {
+            json_object_set_new(jrights, "mayDelete", json_false());
+        }
     }
     else {
         /* Did we make any other updates to the mailbox? */


### PR DESCRIPTION
A Calendar/set or AddressBook/set that creates a collection and makes it the default in the same call builds the "created" record before onSuccessSetIsDefault runs.  Then it shows myRights/mayDelete as true, even though we want to show false when you can't actually delete.  Just clobber the false with true in this case.

The theory here is that myRights is *effective* rights, not *durable* rights, so you might see mayDelete:true in a shareWith entry where that principal would see mayDelete:false in their myRights.  The spec doesn't exactly say that this is right, but doing it the other way risks weird problems when you *think* you're setting a shareWith entry to its existing value, but change the mayDelete in the ACLs to match the one masked by isDefault.

Permissions are weird.