### PR TITLE
caldav: return ETag when uploading scheduling objects on PUT

### DIFF
--- a/cassandane/tiny-tests/Caldav/put_scheduling_object_returns_etag
+++ b/cassandane/tiny-tests/Caldav/put_scheduling_object_returns_etag
@@ -1,0 +1,88 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_put_scheduling_object_returns_etag
+    :min_version_3_13
+    ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+    my $href = "$CalendarId/$uuid.ics";
+
+    # cassandane is the ORGANIZER of this scheduling object
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:$uuid
+DTEND;TZID=Australia/Melbourne:20160831T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=Australia/Melbourne:20160831T153000
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+ATTENDEE;PARTSTAT=ACCEPTED:MAILTO:cassandane\@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:test1\@example.com
+ORGANIZER;CN=Test User:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    # annoyingly there's no "Request" that tells you the headers, so:
+    my %Headers = (
+        'Content-Type' => 'text/calendar',
+        'Authorization' => $CalDAV->auth_header(),
+    );
+
+    xlog $self, "PUT a new scheduling object as the ORGANIZER";
+    my $Response = $CalDAV->{ua}->request('PUT', $CalDAV->request_url($href), {
+        content => $card,
+        headers => \%Headers,
+    });
+
+    $self->assert_num_equals(201, $Response->{status});
+
+    xlog $self, "Server returns Schedule-Tag and ETag on create";
+    $self->assert_not_null($Response->{headers}{'schedule-tag'});
+    my $etag = $Response->{headers}{etag};
+    $self->assert_not_null($etag);
+
+    xlog $self, "Returned ETag matches the ETag of a subsequent GET";
+    $Response = $CalDAV->{ua}->request('GET', $CalDAV->request_url($href), {
+        headers => \%Headers,
+    });
+    $self->assert_num_equals(200, $Response->{status});
+    $self->assert_str_equals($etag, $Response->{headers}{etag});
+
+    xlog $self, "PUT an update to the existing scheduling object";
+    $card =~ s/An Event/An Updated Event/s;
+    $Response = $CalDAV->{ua}->request('PUT', $CalDAV->request_url($href), {
+        content => $card,
+        headers => \%Headers,
+    });
+
+    # no content, we're replacing a thing
+    $self->assert_num_equals(204, $Response->{status});
+
+    xlog $self, "Server returns Schedule-Tag and ETag on update";
+    $self->assert_not_null($Response->{headers}{'schedule-tag'});
+    my $etag2 = $Response->{headers}{etag};
+    $self->assert_not_null($etag2);
+
+    # the content has changed, so the etag MUST have changed
+    $self->assert_str_not_equals($etag, $etag2);
+
+    xlog $self, "Returned ETag matches the ETag of a subsequent GET";
+    $Response = $CalDAV->{ua}->request('GET', $CalDAV->request_url($href), {
+        headers => \%Headers,
+    });
+    $self->assert_num_equals(200, $Response->{status});
+    $self->assert_str_equals($etag2, $Response->{headers}{etag});
+}

--- a/changes/next/return-etag-on-scheduling-put
+++ b/changes/next/return-etag-on-scheduling-put
@@ -1,0 +1,26 @@
+Description:
+
+CalDAV PUT of a scheduling object (one with an ORGANIZER) now returns an
+ETag response header alongside the Schedule-Tag header.  Previously only the
+Schedule-Tag was returned, which broke plain WebDAV-sync clients that are
+unaware of RFC 6638 and rely on the ETag to synchronise.
+
+
+Documentation:
+
+(none)
+
+
+Config changes:
+
+(none)
+
+
+Upgrade instructions:
+
+(none)
+
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/issues/2456

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -1301,33 +1301,27 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
                 buf_reset(&txn->buf);
             }
 
-            if (!cdata->organizer || (flags & PREFER_REP)) {
-                /* Read index record for new message (always the last one) */
-                struct index_record newrecord;
+            /* Read index record for new message (always the last one).
+               Recompute the validators from the stored resource - even for
+               scheduling objects - so that the ETag we return matches the one
+               a subsequent GET will report (mixing in any per-user data). */
+            struct index_record newrecord;
 
-                cdata->dav.alive = 1;
-                cdata->dav.imap_uid = newuid;
+            cdata->dav.alive = 1;
+            cdata->dav.imap_uid = newuid;
 
-                caldav_get_validators(mailbox, cdata, userid, &newrecord,
-                                      &txn->resp_body.etag,
-                                      &txn->resp_body.lastmod);
+            caldav_get_validators(mailbox, cdata, userid, &newrecord,
+                                  &txn->resp_body.etag,
+                                  &txn->resp_body.lastmod);
 
-                if (flags & PREFER_REP) {
-                    /* Re-insert per-user data */
-                    icalcomponent_apply_vpatch(ical, userdata, NULL, NULL);
-                }
+            if (flags & PREFER_REP) {
+                /* Re-insert per-user data */
+                icalcomponent_apply_vpatch(ical, userdata, NULL, NULL);
             }
         }
 
-        if (cdata->organizer) {
-            if (flags & NEW_STAG) txn->resp_body.stag = sched_tag;
-
-            if (!(flags & PREFER_REP)) {
-                /* iCal data has been rewritten - don't return validators */
-                txn->resp_body.lastmod = 0;
-                txn->resp_body.etag = NULL;
-            }
-        }
+        if (cdata->organizer && (flags & NEW_STAG))
+            txn->resp_body.stag = sched_tag;
         break;
     }
 


### PR DESCRIPTION
## Summary

Fixes #2456.

When a CalDAV client `PUT`s a scheduling object (an event/todo with an `ORGANIZER`), Cyrus returned the `Schedule-Tag` header but **no `ETag`**. `caldav_store_resource()` explicitly cleared the ETag/Last-Modified validators for scheduling objects, on the grounds that the iCalendar data had been rewritten during scheduling processing.

However, `dav_store_resource()` (and `caldav_get_validators()` for shared calendars) computes the validators from the **stored** resource, so they already reflect the rewritten data and are correct to return. Omitting the ETag breaks plain WebDAV-sync clients (e.g. Evolution) that are unaware of RFC 6638 and rely on the ETag for synchronisation. RFC 6638 treats `Schedule-Tag` and `ETag` as complementary (§3.2.10) and never forbids returning an ETag on PUT.

## Change

In `caldav_store_resource()`:
- Recompute the validators from the stored resource for scheduling objects too (removes the `!cdata->organizer` guard), so the returned ETag matches what a subsequent GET reports, including per-user data on shared calendars.
- Stop clearing `etag`/`lastmod` for scheduling objects.

The `Schedule-Tag` (`NEW_STAG`) assignment is unchanged, so both headers are now returned together. The separate ETag-clearing paths in `http_caldav.c` (stripped overrides, default alerts) are unaffected — they run after this function returns.

## Testing

- New Cassandane test `Caldav.put_scheduling_object_returns_etag`: PUT (create) and PUT (update) of a scheduling object both return `Schedule-Tag` **and** `ETag`; the ETag matches a subsequent GET and changes when the content changes.
- Full `Caldav` (109 tests) and `CaldavAlarm` (33 tests) suites pass; targeted regression checks pass, including `put_usedefaultalerts_no_etag` (still correctly returns no ETag), `put_changes_etag`, `shared_etag`, and all `rfc6638_*` scheduling tests.