### PR TITLE
caldav: validate VTODO DUE against DTSTART on PUT

### DIFF
--- a/cassandane/tiny-tests/Caldav/put_vtodo_due_dtstart_mismatch
+++ b/cassandane/tiny-tests/Caldav/put_vtodo_due_dtstart_mismatch
@@ -1,0 +1,82 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_put_vtodo_due_dtstart_mismatch
+    :min_version_3_13
+    ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    # RFC 5545 3.8.2.3: in a VTODO, DUE MUST have the same value type as
+    # DTSTART.  Here DTSTART is a DATE-TIME but DUE is a DATE, which is invalid.
+    my $uuid = "5de280c9-edff-4019-8ebd-cfebc73f8202";
+    my $todo = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VTODO
+CREATED:20150806T234327Z
+UID:$uuid
+DTSTAMP:20150806T234327Z
+DTSTART:20160831T153000Z
+DUE;VALUE=DATE:20160901
+SUMMARY:A Task
+END:VTODO
+END:VCALENDAR
+EOF
+
+    eval { $CalDAV->Request('PUT', "$CalendarId/$uuid.ics", $todo,
+                            'Content-Type' => 'text/calendar') };
+    $self->assert_matches(qr/valid-calendar-data/, $@);
+
+    # A VTODO with DUE but no DTSTART is valid - DTSTART is optional in a
+    # VTODO, so the value-type check must not reject it.
+    $uuid = "5de280c9-edff-4019-8ebd-cfebc73f8203";
+    my $todo2 = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VTODO
+CREATED:20150806T234327Z
+UID:$uuid
+DTSTAMP:20150806T234327Z
+DUE;VALUE=DATE:20160901
+SUMMARY:A Task
+END:VTODO
+END:VCALENDAR
+EOF
+
+    my $Response = $CalDAV->{ua}->request('PUT',
+        $CalDAV->request_url("$CalendarId/$uuid.ics"),
+        { content => $todo2,
+          headers => { 'Content-Type' => 'text/calendar',
+                       'Authorization' => $CalDAV->auth_header() } });
+    $self->assert_num_equals(201, $Response->{status});
+
+    # DTSTART is *required* in a VEVENT (unlike VTODO), so a VEVENT with only
+    # DTEND must still be rejected - the VTODO relaxation must not leak here.
+    $uuid = "5de280c9-edff-4019-8ebd-cfebc73f8204";
+    my $event = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:$uuid
+DTSTAMP:20150806T234327Z
+DTEND;VALUE=DATE:20160901
+SUMMARY:An Event
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    eval { $CalDAV->Request('PUT', "$CalendarId/$uuid.ics", $event,
+                            'Content-Type' => 'text/calendar') };
+    $self->assert_matches(qr/valid-calendar-data/, $@);
+}

--- a/changes/next/validate-vtodo-due-dtstart
+++ b/changes/next/validate-vtodo-due-dtstart
@@ -1,0 +1,27 @@
+Description:
+
+CalDAV PUT of a VTODO now validates that, when both DTSTART and DUE are
+present, DUE has the same value type as DTSTART and occurs no earlier than
+DTSTART, as required by RFC 5545 Section 3.8.2.3.  Previously only VEVENT
+DTEND/DTSTART were validated this way; an invalid VTODO (e.g. a DATE-TIME
+DTSTART with a DATE DUE) was accepted.
+
+
+Documentation:
+
+(none)
+
+
+Config changes:
+
+(none)
+
+
+Upgrade instructions:
+
+(none)
+
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/issues/4591

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -3777,26 +3777,13 @@ static int validate_dtend_duration(icalcomponent *comp, struct error_t *error)
     icalproperty *prop;
 
     prop = icalcomponent_get_first_property(comp, ICAL_DTEND_PROPERTY);
-    if (prop) {
-        /* Make sure DTEND > DTSTART, and both values have value same type */
-        icaltimetype dtstart = icalcomponent_get_dtstart(comp);
-        icaltimetype dtend =
-            icalproperty_get_datetime_with_component(prop, comp);
-
-        if (icaltime_is_date(dtend) != icaltime_is_date(dtstart)) {
-            error->desc = "DTSTART and DTEND must have same value type";
-            error->precond = CALDAV_VALID_DATA;
-            return HTTP_FORBIDDEN;
-        }
-        if (icaltime_compare(dtend, dtstart) < 0) {
-            /* NOTE: Per RFC 5545, DTEND != DTSTART, but this occurs
-               frequently enough in the wild for us to allow it */
-            error->desc = "DTEND must occur after DTSTART";
-            error->precond = CALDAV_VALID_DATA;
-            return HTTP_FORBIDDEN;
-        }
+    if (!prop) {
+        /* A VTODO may use DUE in place of DTEND - same constraints apply
+           (RFC 5545, Section 3.8.2.3) */
+        prop = icalcomponent_get_first_property(comp, ICAL_DUE_PROPERTY);
     }
-    else {
+
+    if (!prop) {
         /* Make sure DURATION > 0 */
         prop = icalcomponent_get_first_property(comp, ICAL_DURATION_PROPERTY);
         if (prop) {
@@ -3811,6 +3798,30 @@ static int validate_dtend_duration(icalcomponent *comp, struct error_t *error)
                 return HTTP_FORBIDDEN;
             }
         }
+        return 0;
+    }
+
+    /* Make sure DTEND/DUE > DTSTART, and both values have same value type.
+       DTSTART is optional in a VTODO, so skip the check when it is absent;
+       it is required in a VEVENT, so a missing one there still fails below. */
+    icaltimetype dtstart = icalcomponent_get_dtstart(comp);
+    if (icalcomponent_isa(comp) == ICAL_VTODO_COMPONENT &&
+        icaltime_is_null_time(dtstart)) {
+        return 0;
+    }
+
+    icaltimetype dtend = icalproperty_get_datetime_with_component(prop, comp);
+    if (icaltime_is_date(dtend) != icaltime_is_date(dtstart)) {
+        error->desc = "DTSTART and DTEND/DUE must have same value type";
+        error->precond = CALDAV_VALID_DATA;
+        return HTTP_FORBIDDEN;
+    }
+    if (icaltime_compare(dtend, dtstart) < 0) {
+        /* NOTE: Per RFC 5545, DTEND != DTSTART, but this occurs
+           frequently enough in the wild for us to allow it */
+        error->desc = "DTEND/DUE must occur after DTSTART";
+        error->precond = CALDAV_VALID_DATA;
+        return HTTP_FORBIDDEN;
     }
 
     return 0;


### PR DESCRIPTION
## Summary

Fixes #4591.

RFC 5545 Section 3.8.2.3 requires that, when a VTODO specifies both `DTSTART` and `DUE`, the `DUE` property MUST have the same value type as `DTSTART` and MUST be later in time than `DTSTART`.

`validate_dtend_duration()` only enforced this for VEVENT `DTEND`/`DTSTART`, so an invalid VTODO — e.g. a `DATE-TIME` `DTSTART` with a `DATE` `DUE` — was accepted on PUT.

## Change

In `validate_dtend_duration()`:
- Fall back to `DUE` when `DTEND` is absent (the VTODO case) and apply the same value-type and ordering checks that already exist for `DTEND`.
- `DTSTART` is optional in a VTODO but required in a VEVENT, so the "DTSTART absent → skip comparison" short-circuit is scoped to `VTODO`: a VTODO with `DUE` and no `DTSTART` is accepted, while a VEVENT missing `DTSTART` continues to fail validation exactly as before.
- The function was also flattened with early returns to avoid the extra nesting and a duplicate `DTSTART` lookup.

## Testing

New Cassandane test `Caldav.put_vtodo_due_dtstart_mismatch` covers:
- VTODO with `DATE-TIME` `DTSTART` + `DATE` `DUE` → rejected (`valid-calendar-data`).
- VTODO with `DUE` and no `DTSTART` → accepted (DTSTART optional in VTODO).
- VEVENT with `DTEND` and no `DTSTART` → still rejected (relaxation must not leak to VEVENT).

Full `Caldav` (109 tests) and `JMAPCalendars` (306 tests) suites pass.