### PR TITLE
caldav: return 404 for PROPFIND on a non-existing resource

### DIFF
--- a/cassandane/tiny-tests/Caldav/propfind_nonexistent_resource
+++ b/cassandane/tiny-tests/Caldav/propfind_nonexistent_resource
@@ -1,0 +1,46 @@
+#!perl
+use Cassandane::Tiny;
+
+# RFC 4918 Section 9.6: a PROPFIND on a Request-URI that is not mapped to a
+# resource MUST return 404 (Not Found), not a 207 Multi-Status wrapping a
+# nested 404.  (GitHub issue #5667)
+sub test_propfind_nonexistent_resource
+    :min_version_3_13
+    ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    my $CalendarId = $CalDAV->NewCalendar({name => 'foo'});
+    $self->assert_not_null($CalendarId);
+
+    my $propfind = <<'EOF';
+<?xml version="1.0" encoding="utf-8"?>
+<D:propfind xmlns:D="DAV:"><D:prop><D:getetag/></D:prop></D:propfind>
+EOF
+
+    my %headers = (
+        'Content-Type' => 'application/xml',
+        'Depth' => '0',
+        'Authorization' => $CalDAV->auth_header(),
+    );
+
+    # A PROPFIND on a non-existing resource in an existing collection must be
+    # a top-level 404, not a 207.
+    my $R = $CalDAV->{ua}->request('PROPFIND',
+        $CalDAV->request_url("$CalendarId/does-not-exist.ics"),
+        { content => $propfind, headers => \%headers });
+    $self->assert_num_equals(404, $R->{status});
+
+    # A PROPFIND on a resource inside a non-existing collection must also be
+    # a top-level 404 (not a 500).
+    $R = $CalDAV->{ua}->request('PROPFIND',
+        $CalDAV->request_url("no-such-collection/does-not-exist.ics"),
+        { content => $propfind, headers => \%headers });
+    $self->assert_num_equals(404, $R->{status});
+
+    # A PROPFIND on an existing collection must still return 207 Multi-Status.
+    $R = $CalDAV->{ua}->request('PROPFIND',
+        $CalDAV->request_url("$CalendarId/"),
+        { content => $propfind, headers => \%headers });
+    $self->assert_num_equals(207, $R->{status});
+}

--- a/changes/next/propfind-404-nonexistent-resource
+++ b/changes/next/propfind-404-nonexistent-resource
@@ -1,0 +1,27 @@
+Description:
+
+A WebDAV/CalDAV/CardDAV PROPFIND request on a Request-URI that is not mapped
+to a resource now returns 404 (Not Found), as required by RFC 4918 Section
+9.6.  Previously such a request returned a 207 Multi-Status wrapping a nested
+404, which confused plain WebDAV clients (e.g. KDE Dolphin) into believing the
+resource already existed.
+
+
+Documentation:
+
+(none)
+
+
+Config changes:
+
+(none)
+
+
+Upgrade instructions:
+
+(none)
+
+
+GitHub issue:
+
+https://github.com/cyrusimap/cyrus-imapd/issues/5667

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -6251,6 +6251,37 @@ EXPORTED int meth_propfind(struct transaction_t *txn, void *params)
         }
 
         /* Local Mailbox */
+
+        if (txn->req_tgt.resource && fparams->davdb.open_db) {
+            /* PROPFIND on a resource that is not mapped MUST return
+               404 (Not Found), not a 207 with a nested 404
+               (RFC 4918, Section 9.6) */
+            struct mailbox *mailbox = NULL;
+            struct dav_data *ddata;
+            void *davdb;
+
+            r = mailbox_open_irl(txn->req_tgt.mbentry->name, &mailbox);
+            if (r == IMAP_MAILBOX_NONEXISTENT) {
+                /* Collection is gone - the resource can't exist either */
+                return HTTP_NOT_FOUND;
+            }
+            else if (r) {
+                syslog(LOG_INFO, "mailbox_open_irl(%s) failed: %s",
+                       txn->req_tgt.mbentry->name, error_message(r));
+                txn->error.desc = error_message(r);
+                return HTTP_SERVER_ERROR;
+            }
+
+            davdb = fparams->davdb.open_db(mailbox);
+            fparams->davdb.lookup_resource(davdb, txn->req_tgt.mbentry,
+                                           txn->req_tgt.resource,
+                                           (void **) &ddata, 0);
+            int found = ddata->rowid != 0;
+            fparams->davdb.close_db(davdb);
+            mailbox_close(&mailbox);
+
+            if (!found) return HTTP_NOT_FOUND;
+        }
     }
 
     /* Principal or Local Mailbox */


### PR DESCRIPTION
## Problem

A WebDAV/CalDAV/CardDAV `PROPFIND` on a Request-URI that is **not mapped to a resource** returns a `207 Multi-Status` wrapping a nested `404`, instead of a top-level `404 Not Found`:

```
PROPFIND /dav/.../coll/does-not-exist.ics
=> HTTP/1.1 207 Multi-Status
   <d:multistatus>
     <d:response>
       <d:href>/dav/.../coll/does-not-exist.ics</d:href>
       <d:status>HTTP/1.1 404 Not Found</d:status>
     </d:response>
   </d:multistatus>
```

RFC 4918 §9.6 requires `GET/HEAD/PROPFIND` on an unmapped URL to return `404`:

> Thus, after a successful DELETE operation (and in the absence of other actions), a subsequent GET/HEAD/PROPFIND request to the target Request-URI MUST return 404 (Not Found).

Some plain WebDAV clients (e.g. KDE Dolphin) interpret the `207` as "the resource already exists" and refuse to create new files/folders.

Fixes #5667.

## Fix

`meth_propfind()` now checks, **before** emitting the multistatus response (the `207` status line is committed early, in the chunked path), that a resource-targeted request refers to a resource that exists in the DAV DB, and returns a top-level `404` if it does not. This mirrors the existing pre-checks in `meth_get_head()` and `meth_proppatch()`.

- Collection-targeted PROPFINDs are unaffected and still return `207`.
- The principal namespace (and root params) have no `davdb` ops, so the guard `fparams->davdb.open_db` short-circuits there — no behavior change and no NULL deref.
- `IMAP_MAILBOX_NONEXISTENT` from `mailbox_open_irl` is treated as `404` (not `500`), matching the adjacent home-set handling, to cover a collection deleted between lookup and open.

## Testing

Added `Caldav.propfind_nonexistent_resource` covering:
- missing resource in an existing collection → `404`
- missing resource in a missing collection → `404`
- existing collection → `207` (regression guard)

Verified at the HTTP surface (missing/existing resource, Depth 0/1, empty-body allprop, principal namespace) and ran the full `Caldav` (109) and `Carddav` (86) suites with no regressions.