### PR TITLE
JMAPCalendars: rewrite Link object conversion

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -164,9 +164,6 @@ sub normalize_event
         delete($event->{links});
     } else {
         foreach my $link (values %{$event->{links}}) {
-            if (not defined $link->{cid}) {
-                delete($link->{cid});
-            }
             if (not defined $link->{contentType}) {
                 delete($link->{contentType});
             }
@@ -177,6 +174,7 @@ sub normalize_event
                 delete($link->{title});
             }
             $link->{q{@type}} //= 'Link';
+            $link->{rel} //= 'enclosure';
         }
     }
     # locale
@@ -190,7 +188,17 @@ sub normalize_event
         foreach my $loc (values %{$event->{locations}}) {
             $loc->{q{@type}} //= 'Location';
             foreach my $link (values %{$loc->{links}}) {
+                if (not defined $link->{contentType}) {
+                    delete($link->{contentType});
+                }
+                if (not defined $link->{size}) {
+                    delete($link->{size});
+                }
+                if (not defined $link->{title}) {
+                    delete($link->{title});
+                }
                 $link->{q{@type}} //= 'Link';
+                $link->{rel} //= 'enclosure';
             }
         }
     }
@@ -219,7 +227,17 @@ sub normalize_event
             $p->{scheduleSequence} //= 0;
             $p->{q{@type}} //= 'Participant';
             foreach my $link (values %{$p->{links}}) {
+                if (not defined $link->{contentType}) {
+                    delete($link->{contentType});
+                }
+                if (not defined $link->{size}) {
+                    delete($link->{size});
+                }
+                if (not defined $link->{title}) {
+                    delete($link->{title});
+                }
                 $link->{q{@type}} //= 'Link';
+                $link->{rel} //= 'enclosure';
             }
         }
     }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_guesstz
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_guesstz
@@ -17,7 +17,6 @@ my sub assert_guesstz
 
     my $res = $jmap->CallMethods([['CalendarEvent/get', {
         properties => [
-            'cyrusimap.org:unguessableTimezones',
             'start',
             'timeZone',
             'duration',
@@ -28,6 +27,7 @@ my sub assert_guesstz
             'title',
             'prodId',
             'x-href',
+            'iCalendar',
         ],
     }, 'R1']]);
     my $event = $res->[0][1]{list}[0];
@@ -296,6 +296,13 @@ sub test_calendarevent_get_guesstz_custom_tzid_unguessable
         ,
         superhashof({
             start => '2026-01-02T10:00:00',
+            iCalendar => superhashof({
+                'cyrusimap.org:unguessableTimezones' => [
+                    ['vtimezone',
+                        supersetof(['tzid', {}, 'text', 'Foo']),
+                        ignore()],
+                ],
+            }),
         })
     );
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_icalendar
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_icalendar
@@ -1,0 +1,136 @@
+#!perl
+use Cassandane::Tiny;
+
+# This test validates fetching the "iCalendar" property is supported
+# in CalendarEvent/get, but only if it is requested explicitly and
+# only if the https://cyrusimap.org/ns/jmap/calendars JMAP capability
+# is set in the request.
+
+sub test_calendarevent_get_icalendar ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $caldav = $self->{caldav};
+
+    my $uuid = '0f9b3a5c-2b6d-4a17-9d8e-1c2f3a4b5c6d';
+    my $alarmUid = 'c3a1f0e2-5d4b-4c7a-8e19-2b0d6f7a8c91';
+
+    xlog $self, "Create a VEVENT with non-standard elements";
+    my $ical = <<~"EOF";
+    BEGIN:VCALENDAR
+    VERSION:2.0
+    PRODID:-//Example Corp.//CalDAV Client//EN
+    CALSCALE:GREGORIAN
+    BEGIN:VEVENT
+    UID:$uuid
+    DTSTAMP:20260701T120000Z
+    DTSTART;TZID=Europe/Berlin:20260805T100000
+    DURATION:PT1H
+    SUMMARY;X-SUMMARY-PARAM=xyz:event
+    X-EVENT-PROP;X-FOO=1:eventprop
+    BEGIN:VALARM
+    UID:$alarmUid
+    ACTION:DISPLAY
+    TRIGGER:-PT5M
+    X-ALARM-PROP;X-BAR=2:alarmprop
+    END:VALARM
+    BEGIN:X-UNKNOWN-COMP
+    X-UNKNOWN-COMP-PROP:compprop
+    END:X-UNKNOWN-COMP
+    END:VEVENT
+    END:VCALENDAR
+    EOF
+
+    $caldav->Request('PUT', "Default/$uuid.ics",
+        $ical, 'Content-Type' => 'text/calendar');
+
+    my $wantEvent = superhashof({
+        iCalendar => {
+            '@type' => 'ICalComponent',
+            name => 'vevent',
+            properties => [
+                ['x-event-prop', { 'x-foo' => '1' }, 'unknown', 'eventprop'],
+            ],
+            components => [
+                ['x-unknown-comp', [
+                    ['x-unknown-comp-prop', {}, 'unknown', 'compprop'],
+                ], []],
+            ],
+            convertedProperties => {
+                title => {
+                    '@type' => 'ICalProperty',
+                    name => 'summary',
+                    parameters => { 'x-summary-param' => 'xyz' },
+                },
+            },
+        },
+        alerts => {
+            $alarmUid => superhashof({
+                iCalendar => {
+                    '@type' => 'ICalComponent',
+                    name => 'valarm',
+                    properties => [
+                        ['uid', {}, 'text', $alarmUid],
+                        ['x-alarm-prop', { 'x-bar' => '2' },
+                            'unknown', 'alarmprop'],
+                    ],
+                },
+            }),
+        },
+    });
+
+    xlog $self, "Get the 'iCalendar' property with an empty cache";
+    my $res = $jmap->request({
+        methodCalls => [
+            ['CalendarEvent/get', {
+                properties => ['iCalendar', 'alerts'],
+            }, 'R1'],
+        ],
+    });
+    $self->assert_cmp_deeply([$wantEvent],
+        $res->sentence_named('CalendarEvent/get')->arguments->{list});
+
+    xlog $self, "Assert the 'iCalendar' property isn't returned by default";
+    $res = $jmap->request({
+        methodCalls => [
+            ['CalendarEvent/get', {}, 'R1'],
+        ],
+    });
+    my $event = $res->sentence_named('CalendarEvent/get')->arguments->{list}[0];
+    $self->assert_cmp_deeply({
+        '@type' => 'Alert',
+        trigger => {
+            '@type' => 'OffsetTrigger',
+            offset => '-PT5M',
+        },
+    }, $event->{alerts}{$alarmUid}, 'no iCalendar data in the alert');
+    $self->assert_cmp_deeply([], [grep { /^iCalendar/ } keys %{$event}]);
+
+    xlog $self, "Get the 'iCalendar' property from a warmed up cache";
+    $res = $jmap->request({
+        methodCalls => [
+            ['CalendarEvent/get', {
+                properties => ['iCalendar', 'alerts'],
+            }, 'R1'],
+        ],
+    });
+    $self->assert_cmp_deeply([$wantEvent],
+        $res->sentence_named('CalendarEvent/get')->arguments->{list});
+
+    xlog $self, "Assert iCalendar requires the calendars extension";
+    $res = $jmap->request({
+        methodCalls => [
+            ['CalendarEvent/get', {
+                properties => ['iCalendar'],
+            }, 'R1'],
+        ],
+        using => [
+            'urn:ietf:params:jmap:core',
+            'urn:ietf:params:jmap:calendars',
+            'https://cyrusimap.org/ns/jmap/jscalendarbis',
+        ],
+    });
+    $self->assert_cmp_deeply(['error', {
+        type => 'invalidArguments',
+        arguments => ['properties[0:iCalendar]'],
+    }, 'R1'], $res->sentence(0)->as_stripped_triple);
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_links
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_links
@@ -2,7 +2,6 @@
 use Cassandane::Tiny;
 
 sub test_calendarevent_get_links
-    :min_version_3_1
     ($self)
 {
     my ($id, $ical) = $self->icalfile('links');
@@ -15,7 +14,6 @@ sub test_calendarevent_get_links
             contentType => "text/html",
             size => 4480,
             title => "the spec",
-            rel => "enclosure",
         },
         ignore() => {
             '@type' => 'Link',
@@ -24,6 +22,11 @@ sub test_calendarevent_get_links
         'describedby-attach' => {
             '@type' => 'Link',
             href => "http://describedby/attach",
+            rel => "describedby",
+        },
+        'describedby-url' => {
+            '@type' => 'Link',
+            href => "http://describedby/url",
             rel => "describedby",
         },
     );

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_links_convprops
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_links_convprops
@@ -1,0 +1,63 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_get_links_convprops
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $caldav = $self->{caldav};
+
+    xlog $self, "Create event having a LINK and a URL property";
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+PRODID:-//FOO//bar//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:20260102T030405Z
+UID:2a2a1e0b-c1d5-4b0f-8f2c-3d0f9a1b2c3d
+DTSTART:20260102T030405Z
+SUMMARY:test
+LINK;LINKREL=enclosure;VALUE=URI;JSID=link:https://example.com/link
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $caldav->Request('PUT', 'Default/test.ics', $ical,
+        'Content-Type' => 'text/calendar');
+
+    xlog $self, "Get Link objects including conversion property";
+    my $res = $jmap->request([
+        ['CalendarEvent/query', { }, 'R1'],
+        ['CalendarEvent/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'CalendarEvent/query',
+                path => '/ids',
+            },
+            properties => [ 'links', 'iCalendar' ],
+        }, 'R2'],
+    ]);
+    my $event =
+       $res->sentence_named('CalendarEvent/get')->arguments->{list}[0];
+    $self->assert_not_null($event);
+
+    xlog $self, "Assert that convertedProperties names LINK property";
+    $self->assert_cmp_deeply(superhashof({
+        "iCalendar" => {
+            '@type' => "ICalComponent",
+            "name" => "vevent",
+            "convertedProperties" => {
+                "links/link/href" => {
+                    '@type' => "ICalProperty",
+                    "name" => "link"
+                }
+            }
+        },
+        "links" => {
+            "link" => {
+                '@type' => "Link",
+                "href" => "https://example.com/link",
+            }
+        },
+    }), $event);
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_links_dupvalue
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_links_dupvalue
@@ -1,0 +1,97 @@
+#!perl
+use Cassandane::Tiny;
+
+# Two properties may convert to a Link object having the same href, but
+# their ids must not clash. Only the first of them gets its id derived
+# from the property value alone, the id of the other one also takes the
+# property name into account. Both ids must be stable, so converting the
+# same iCalendar data twice must result in the same Link object ids.
+
+sub test_calendarevent_get_links_dupvalue
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $caldav = $self->{caldav};
+
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+PRODID:-//FOO//bar//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:20260102T030405Z
+UID:2a2a1e0b-c1d5-4b0f-8f2c-3d0f9a1b2c3d
+DTSTART:20260102T030405Z
+SUMMARY:test
+ATTACH:https://example.com/link
+URL:https://example.com/link
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    my sub get_links
+    {
+        my $res = $jmap->CallMethods([
+            ['CalendarEvent/query', { }, 'R1'],
+            ['CalendarEvent/get', {
+                '#ids' => {
+                    resultOf => 'R1',
+                    name => 'CalendarEvent/query',
+                    path => '/ids',
+                },
+                properties => [ 'links' ],
+            }, 'R2'],
+        ]);
+        my $event = $res->[1][1]{list}[0];
+        $self->assert_not_null($event);
+        return ($event->{id}, $event->{links});
+    }
+
+    xlog $self, "Create event having an ATTACH and URL property of same value";
+    $caldav->Request('PUT', 'Default/test.ics', $ical,
+        'Content-Type' => 'text/calendar');
+
+    my ($eventId, $links) = get_links();
+
+    xlog $self, "Assert both properties converted to a distinct Link object";
+    my @linkIds = sort keys %$links;
+    $self->assert_num_equals(2, scalar @linkIds);
+
+    $self->assert_cmp_deeply([
+        {
+            '@type' => 'Link',
+            href => 'https://example.com/link',
+        },
+        {
+            '@type' => 'Link',
+            href => 'https://example.com/link',
+            rel => 'describedby',
+        },
+    ], [ sort { ($a->{rel} // '') cmp ($b->{rel} // '') } values %$links ]);
+
+    xlog $self, "Recreate the very same event";
+    $caldav->Request('PUT', 'Default/test.ics', $ical,
+        'Content-Type' => 'text/calendar');
+
+    xlog $self, "Assert the Link object ids did not change";
+    my ($newEventId, $newLinks) = get_links();
+    $self->assert_cmp_deeply($links, $newLinks);
+
+    xlog $self, "Assert a Link object id from the former read still patches it";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $newEventId => { "links/$linkIds[1]/title" => 'A title' },
+            },
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            ids => [ $newEventId ],
+            properties => [ 'links' ],
+        }, 'R2'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$newEventId});
+
+    my $got_links = $res->[1][1]{list}[0]{links};
+    $self->assert_num_equals(2, scalar keys %$got_links);
+    $self->assert_str_equals('A title', $got_links->{$linkIds[1]}{title});
+    $self->assert_null($got_links->{$linkIds[0]}{title});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_create_ical
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_create_ical
@@ -1,0 +1,195 @@
+#!perl
+use Cassandane::Tiny;
+
+use Text::VCardFast qw(vcard2hash);
+
+# This test validates the conversion of Link objects to iCalendar
+# in CalendarEvent/set{create}.
+
+# An arbitrary HREF that we set on all properties.
+my $LINK_HREF = 'https://example.com/link';
+
+my sub assert_calendarevent_set_links_create_ical ($self, %arg)
+{
+    my $jmap = $self->default_user->jmap;
+    my $caldav = $self->{caldav};
+
+    my $event = {
+        calendarIds => {
+            $self->default_user->calendars->default->id => JSON::true,
+        },
+        start => '2026-01-02T03:04:05',
+        version => '2.0',
+        links => {
+            link1 => $arg{link},
+        },
+    };
+
+    xlog $self, "Create event with links property";
+    my $res = $jmap->request([
+        [ 'CalendarEvent/set' => {
+            create => { 1 => $event },
+        }, 'a' ],
+        [ 'CalendarEvent/get' => {
+            ids => [ '#1' ],
+            properties => [ keys %$event, 'x-href' ],
+        }, 'b' ],
+    ]);
+
+    my $got_event =
+        $res->sentence_named('CalendarEvent/get')->arguments->{list}[0];
+    $self->assert_normalized_event_equals($event, $got_event);
+
+    xlog $self, "Assert iCalendar properties";
+    $res = $caldav->Request('GET', "" . $got_event->{'x-href'});
+    my $vevent = vcard2hash($res->{content})->{objects}[0]{objects}[0];
+
+    my %got_props;
+    foreach my $name (qw{attach image link url}) {
+        foreach my $prop (@{ $vevent->{properties}{$name} // [] }) {
+            push @{ $got_props{$name} }, {
+                value => $prop->{value},
+                params => $prop->{params} // {},
+            };
+        }
+    }
+
+    # The IMAGE and LINK properties have no default value type, so they
+    # also carry a VALUE parameter. The ATTACH and URL properties do not.
+    my %value_uri_param = (
+        image => { value => [ 'URI' ] },
+        link  => { value => [ 'URI' ] },
+    );
+
+    my %want_props = map {;
+        $_ => [ {
+            value => $arg{link}{href},
+            params => {
+                jsid => ignore(),
+                %{ $value_uri_param{$_} // {} },
+                %{ $arg{want_ical}{$_} },
+            },
+        } ]
+    } keys %{ $arg{want_ical} };
+
+    $self->assert_cmp_deeply(\%want_props, \%got_props);
+}
+
+sub test_calendarevent_set_links_create_ical_no_rel
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+        },
+        want_ical => { attach => { } });
+}
+
+sub test_calendarevent_set_links_create_ical_rel_enclosure
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'enclosure',
+        },
+        want_ical => { attach => { } });
+}
+
+sub test_calendarevent_set_links_create_ical_rel_icon
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'icon',
+        },
+        want_ical => { image => { } });
+}
+
+sub test_calendarevent_set_links_create_ical_rel_describedby
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'describedby',
+        },
+        want_ical => { url => { } });
+}
+
+sub test_calendarevent_set_links_create_ical_rel_me
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'me',
+        },
+        want_ical => { link => { linkrel => [ 'me' ] } });
+}
+
+# The "title" property converts to the FILENAME parameter for the ATTACH
+# and IMAGE properties, and to the LABEL parameter for the LINK and URL
+# properties. See also the rel_describedby_non_url_params test for URL.
+
+sub test_calendarevent_set_links_create_ical_rel_enclosure_title
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'enclosure',
+            title => 'somename',
+        },
+        want_ical => { attach => { filename => [ 'somename' ] } });
+}
+
+sub test_calendarevent_set_links_create_ical_rel_icon_title
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'icon',
+            title => 'somename',
+        },
+        want_ical => { image => { filename => [ 'somename' ] } });
+}
+
+sub test_calendarevent_set_links_create_ical_rel_me_title
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'me',
+            title => 'somename',
+        },
+        want_ical => {
+            link => {
+                linkrel => [ 'me' ],
+                label => [ 'somename' ],
+            },
+        });
+}
+
+sub test_calendarevent_set_links_create_ical_rel_describedby_non_url_params
+    ($self)
+{
+    assert_calendarevent_set_links_create_ical($self,
+        link => {
+            href => $LINK_HREF,
+            rel => 'describedby',
+            contentType => 'text/html',
+            title => 'somename',
+            size => 42,
+        },
+        want_ical => {
+            url => {
+                fmttype => [ 'text/html' ],
+                label => [ 'somename' ],
+                size => [ '42' ],
+            },
+        });
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_display
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_display
@@ -1,0 +1,42 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_set_links_display
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+
+    my %create;
+    foreach my $rel (qw{icon enclosure}) {
+        $create{$rel} = {
+            calendarIds => {
+                $self->default_user->calendars->default->id => JSON::true,
+            },
+            start => '2026-01-02T03:04:05',
+            version => '2.0',
+            links => {
+                link1 => {
+                    href => 'https://example.com/link',
+                    display => { badge => JSON::true },
+                    rel => $rel,
+                },
+            },
+        };
+    }
+
+    xlog $self, "Create events having a display link";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => \%create,
+        }, 'R1'],
+    ]);
+
+    xlog $self, "Assert the display property requires 'rel=icon'";
+    $self->assert_not_null($res->[0][1]{created}{icon}{id});
+
+    xlog $self, "Assert the display property with 'rel=enclosure' is rejected";
+    $self->assert_cmp_deeply({
+        type => 'invalidProperties',
+        properties => [ 'links/link1/rel' ],
+    }, $res->[0][1]{notCreated}{enclosure});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_update_ical
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_update_ical
@@ -1,0 +1,400 @@
+#!perl
+use Cassandane::Tiny;
+
+use Text::VCardFast qw(vcard2hash);
+
+# This test validates the conversion of Link objects to iCalendar
+# in CalendarEvent/set{update}.
+
+# An arbitrary HREF that we set on all properties.
+my $LINK_HREF = 'https://example.com/link';
+
+my sub assert_calendarevent_set_links_update_ical ($self, %arg)
+{
+    my $jmap = $self->default_user->jmap;
+    my $caldav = $self->{caldav};
+
+    # Binary-valued properties set their own value, everything else uses
+    # the arbitrary HREF.
+    my $orig_value = $arg{orig_value} // $LINK_HREF;
+    my $want_value = $arg{want_value} // $LINK_HREF;
+
+    xlog $self, "Create event having a $arg{orig_ical} property";
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+PRODID:-//FOO//bar//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:20260102T030405Z
+UID:2a2a1e0b-c1d5-4b0f-8f2c-3d0f9a1b2c3d
+DTSTART:20260102T030405Z
+SUMMARY:test
+$arg{orig_ical};JSID=link1:$orig_value
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $caldav->Request('PUT', 'Default/test.ics', $ical,
+        'Content-Type' => 'text/calendar');
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/query', { }, 'R1'],
+    ]);
+    my $eventId = $res->[0][1]{ids}[0];
+    $self->assert_not_null($eventId);
+
+    xlog $self, "Update event over JMAP";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $eventId => $arg{patch},
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+
+    xlog $self, "Assert updated iCalendar properties";
+    $res = $caldav->Request('GET', 'Default/test.ics');
+    my $vevent = vcard2hash($res->{content})->{objects}[0]{objects}[0];
+
+    my %got_props;
+    foreach my $name (qw{attach image link url}) {
+        foreach my $prop (@{ $vevent->{properties}{$name} // [] }) {
+            push @{ $got_props{$name} }, {
+                value => $prop->{value},
+                params => $prop->{params} // {},
+            };
+        }
+    }
+
+    # The IMAGE and LINK properties have no default value type, so they
+    # set a VALUE parameter. Ignore them when comparing the result.
+    my %value_uri_param = (
+        image => { value => [ 'URI' ] },
+        link  => { value => [ 'URI' ] },
+    );
+
+    my %want_props = map {;
+        $_ => [ {
+            value => $want_value,
+            params => {
+                jsid => ignore(),
+                %{ $value_uri_param{$_} // {} },
+                %{ $arg{want_ical}{$_} },
+            },
+        } ]
+    } keys %{ $arg{want_ical} };
+
+    $self->assert_cmp_deeply(\%want_props, \%got_props);
+}
+
+sub test_calendarevent_set_links_update_ical_attach
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { attach => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_attach_enclosure
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;LINKREL=enclosure',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { attach => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_attach_icon
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;LINKREL=icon',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_attach_me
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;LINKREL=me',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { link => { linkrel => [ 'me' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_attach_binary
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;VALUE=BINARY;ENCODING=BASE64;FMTTYPE=text/plain',
+        orig_value => 'aGVsbG8=',
+        patch => { title => 'updated' },
+        want_value => 'aGVsbG8=',
+        want_ical => {
+            attach => {
+                encoding => [ 'BASE64' ],
+                fmttype => [ 'text/plain' ],
+                value => [ 'BINARY' ],
+            },
+        });
+}
+
+sub test_calendarevent_set_links_update_ical_attach_binary_describedby
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;VALUE=BINARY;ENCODING=BASE64'
+                   . ';FMTTYPE=text/plain;LINKREL=describedby',
+        orig_value => 'aGVsbG8=',
+        patch => { title => 'updated' },
+        want_value => 'aGVsbG8=',
+        want_ical => {
+            attach => {
+                encoding => [ 'BASE64' ],
+                fmttype => [ 'text/plain' ],
+                linkrel => [ 'describedby' ],
+                value => [ 'BINARY' ],
+            },
+        });
+}
+
+sub test_calendarevent_set_links_update_ical_attach_binary_me
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;VALUE=BINARY;ENCODING=BASE64'
+                   . ';FMTTYPE=text/plain;LINKREL=me',
+        orig_value => 'aGVsbG8=',
+        patch => { title => 'updated' },
+        want_value => 'aGVsbG8=',
+        want_ical => {
+            attach => {
+                encoding => [ 'BASE64' ],
+                fmttype => [ 'text/plain' ],
+                linkrel => [ 'me' ],
+                value => [ 'BINARY' ],
+            },
+        });
+}
+
+sub test_calendarevent_set_links_update_ical_image_binary_me
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;VALUE=BINARY;ENCODING=BASE64'
+                   . ';FMTTYPE=image/png;LINKREL=me',
+        orig_value => 'aGVsbG8=',
+        patch => { title => 'updated' },
+        want_value => 'aGVsbG8=',
+        want_ical => {
+            image => {
+                encoding => [ 'BASE64' ],
+                fmttype => [ 'image/png' ],
+                linkrel => [ 'me' ],
+                value => [ 'BINARY' ],
+            },
+        });
+}
+
+sub test_calendarevent_set_links_update_ical_link_data_uri_me
+    ($self)
+{
+    # A "data:" URI that got stored as a URI value stays a URI value.
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'LINK;VALUE=URI;LINKREL=me',
+        orig_value => 'data:text/plain;base64,aGVsbG8=',
+        patch => { title => 'updated' },
+        want_value => 'data:text/plain;base64,aGVsbG8=',
+        want_ical => { link => { linkrel => [ 'me' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_image
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_image_icon
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;LINKREL=icon;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_image_enclosure
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;LINKREL=enclosure;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { attach => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_image_me
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;LINKREL=me;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { link => { linkrel => [ 'me' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_image_display
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;DISPLAY=BADGE;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { display => [ 'BADGE' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_image_display_icon
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;LINKREL=icon;DISPLAY=BADGE;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { display => [ 'BADGE' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_image_display_enclosure
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;LINKREL=enclosure;DISPLAY=BADGE;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { display => [ 'BADGE' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_image_display_me
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'IMAGE;LINKREL=me;DISPLAY=BADGE;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { display => [ 'BADGE' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_link
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'LINK;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { attach => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_link_enclosure
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'LINK;LINKREL=enclosure;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { attach => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_link_icon
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'LINK;LINKREL=icon;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { image => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_link_describedby
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'LINK;LINKREL=describedby;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { url => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_link_me
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'LINK;LINKREL=me;VALUE=URI',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { link => { linkrel => [ 'me' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_url
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'URL',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { url => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_url_describedby
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'URL;LINKREL=describedby',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { url => { } });
+}
+
+sub test_calendarevent_set_links_update_ical_url_me
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'URL;LINKREL=me',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => { link => { linkrel => [ 'me' ] } });
+}
+
+sub test_calendarevent_set_links_update_ical_url_fmttype_label_size
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'URL;FMTTYPE=text/html;LABEL=A title;SIZE=42',
+        patch => { 'links/link1/href' => $LINK_HREF },
+        want_ical => {
+            url => {
+                fmttype => [ 'text/html' ],
+                label => [ 'A title' ],
+                size => [ '42' ],
+            },
+        });
+}
+
+sub test_calendarevent_set_links_update_ical_keep_xparam
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;X-FOO=bar',
+        patch => {
+            'links/link1/href' => $LINK_HREF,
+            'links/link1/rel' => 'icon',
+            'links/link1/display' => { badge => JSON::true },
+        },
+        want_ical => {
+            image => {
+                display => [ 'BADGE' ],
+                'x-foo' => [ 'bar' ],
+            },
+        });
+}
+
+sub test_calendarevent_set_links_update_ical_keep_filename
+    ($self)
+{
+    assert_calendarevent_set_links_update_ical($self,
+        orig_ical => 'ATTACH;FILENAME=photo.jpg',
+        patch => {
+            'links/link1/href' => $LINK_HREF,
+            'links/link1/rel' => 'icon',
+        },
+        want_ical => { image => { filename => [ 'photo.jpg' ] } });
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_url_once
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_url_once
@@ -1,0 +1,53 @@
+#!perl
+use Cassandane::Tiny;
+
+use Text::VCardFast qw(vcard2hash);
+
+sub test_calendarevent_set_links_url_once
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $caldav = $self->{caldav};
+
+    my $event = {
+        calendarIds => {
+            $self->default_user->calendars->default->id => JSON::true,
+        },
+        start => '2026-01-02T03:04:05',
+        version => '2.0',
+        links => {
+            link1 => {
+                '@type' => 'Link',
+                href => 'https://example.com/link1',
+                rel => 'describedby',
+            },
+            link2 => {
+                '@type' => 'Link',
+                href => 'https://example.com/link2',
+                rel => 'describedby',
+            },
+        },
+    };
+
+    xlog $self, "Create event having two describedby links";
+    my $res = $jmap->request([
+        [ 'CalendarEvent/set' => {
+            create => { 1 => $event },
+        }, 'a' ],
+        [ 'CalendarEvent/get' => {
+            ids => [ '#1' ],
+            properties => [ keys %$event, 'x-href' ],
+        }, 'b' ],
+    ]);
+
+    my $got_event =
+        $res->sentence_named('CalendarEvent/get')->arguments->{list}[0];
+    $self->assert_normalized_event_equals($event, $got_event);
+
+    xlog $self, "Assert exactly one URL and one LINK property was set";
+    $res = $caldav->Request('GET', "" . $got_event->{'x-href'});
+    my $vevent = vcard2hash($res->{content})->{objects}[0]{objects}[0];
+
+    $self->assert_num_equals(1, scalar @{ $vevent->{properties}{url} });
+    $self->assert_num_equals(1, scalar @{ $vevent->{properties}{link} });
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_url_pinned
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_url_pinned
@@ -1,0 +1,107 @@
+#!perl
+use Cassandane::Tiny;
+
+use Text::VCardFast qw(vcard2hash);
+
+sub test_calendarevent_set_links_url_pinned
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $caldav = $self->{caldav};
+
+    xlog $self, "Create event having a LINK and a URL property";
+    my $ical = <<'EOF';
+BEGIN:VCALENDAR
+PRODID:-//FOO//bar//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:20260102T030405Z
+UID:2a2a1e0b-c1d5-4b0f-8f2c-3d0f9a1b2c3d
+DTSTART:20260102T030405Z
+SUMMARY:test
+LINK;LINKREL=describedby;VALUE=URI;JSID=link:https://example.com/link
+URL;JSID=url:https://example.com/url
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $caldav->Request('PUT', 'Default/test.ics', $ical,
+        'Content-Type' => 'text/calendar');
+
+    xlog $self, "Assert both Link objects have a describedby relation";
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/query', { }, 'R1'],
+        ['CalendarEvent/get', {
+            '#ids' => {
+                resultOf => 'R1',
+                name => 'CalendarEvent/query',
+                path => '/ids',
+            },
+            properties => [ 'links' ],
+        }, 'R2'],
+    ]);
+
+    my $event = $res->[1][1]{list}[0];
+    $self->assert_not_null($event);
+
+    $self->assert_cmp_deeply({
+        link => {
+            '@type' => 'Link',
+            href => 'https://example.com/link',
+            rel => 'describedby',
+        },
+        url => {
+            '@type' => 'Link',
+            href => 'https://example.com/url',
+            rel => 'describedby',
+        },
+    }, $event->{links});
+
+    xlog $self, "Set size, title and contentType on the Link object";
+    $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            update => {
+                $event->{id} => {
+                    'links/url/contentType' => 'text/html',
+                    'links/url/size' => 42,
+                    'links/url/title' => 'A title',
+                },
+            },
+        }, 'R1'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$event->{id}});
+
+    xlog $self, "Assert url kept the URL property";
+    $res = $caldav->Request('GET', 'Default/test.ics');
+    my $vevent = vcard2hash($res->{content})->{objects}[0]{objects}[0];
+
+    my %got_props;
+    foreach my $name (qw{link url}) {
+        foreach my $prop (@{ $vevent->{properties}{$name} // [] }) {
+            push @{ $got_props{$name} }, {
+                value => $prop->{value},
+                params => $prop->{params} // {},
+            };
+        }
+    }
+
+    $self->assert_cmp_deeply({
+        link => [ {
+            value => 'https://example.com/link',
+            params => {
+                jsid => ignore(),
+                value => [ 'URI' ],
+                linkrel => [ 'describedby' ],
+            },
+        } ],
+        url => [ {
+            value => 'https://example.com/url',
+            params => {
+                jsid => ignore(),
+                fmttype => [ 'text/html' ],
+                size => [ '42' ],
+                label => [ 'A title' ],
+            },
+        } ],
+    }, \%got_props);
+}

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -94,7 +94,7 @@ static int jmap_sharenotification_querychanges(struct jmap_req *req);
 
 static int jmap_calendarevent_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx);
 
-#define JMAPCACHE_CALVERSION 27
+#define JMAPCACHE_CALVERSION 28
 
 // clang-format off
 static jmap_method_t jmap_calendar_methods_standard[] = {
@@ -3714,8 +3714,10 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
             ptrarray_append(&rock->malloced_fallbacktzs, floatingtz);
     }
 
-    /* Try to read from cache */
-    if (jscal->cacheversion == JMAPCACHE_CALVERSION) {
+    /* Try to read from cache, but force conversion from iCalendar
+     * if the conversion properties are requested. */
+    if (jscal->cacheversion == JMAPCACHE_CALVERSION &&
+            !jmapctx->from_ical.want_icalprops) {
         jsevent = json_loads(jscal->cachedata, 0, NULL);
         if (jsevent) {
             // XXX ignore cached entrys while we serve both RFC8984
@@ -3876,14 +3878,18 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
                 cdata->dav.imap_uid, req->userid, &rock->guid);
     }
 
-    /* Add to cache */
-    json_t *cached = hashu64_lookup(cdata->dav.rowid, &rock->cache_jsevents);
-    if (!cached) {
-        cached = json_object();
-        hashu64_insert(cdata->dav.rowid, cached, &rock->cache_jsevents);
+    /* Add to cache, but only if the event does not include conversion
+     * properties. */
+    if (!jmapctx->from_ical.want_icalprops) {
+        json_t *cached =
+            hashu64_lookup(cdata->dav.rowid, &rock->cache_jsevents);
+        if (!cached) {
+            cached = json_object();
+            hashu64_insert(cdata->dav.rowid, cached, &rock->cache_jsevents);
+        }
+        json_object_set(cached, jscal->ical_recurid, jsevent);
+        jsevent = json_deep_copy(jsevent);
     }
-    json_object_set(cached, jscal->ical_recurid, jsevent);
-    jsevent = json_deep_copy(jsevent);
 
 gotevent:
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -3630,6 +3630,20 @@ static bool jsevent_is_origin(json_t *jsevent, const strarray_t *schedule_addres
     return true;
 }
 
+static void getcalendarevents_reset_ical(struct getcalendarevents_rock *rock)
+{
+    if (rock->ical) {
+        icalcomponent_free(rock->ical);
+        rock->ical = NULL;
+    }
+    rock->imap_uid = 0;
+    rock->is_draft = 0;
+    message_guid_set_null(&rock->guid);
+    if (rock->ical_instances_by_recurid.size)
+        free_hash_table(&rock->ical_instances_by_recurid,
+                        _icalcomponent_free_cb);
+}
+
 static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
 {
     struct getcalendarevents_rock *rock = vrock;
@@ -3686,11 +3700,7 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
                 &rock->schedule_addresses);
 
         // reset ical iterator state
-        if (rock->ical) {
-            icalcomponent_free(rock->ical);
-            rock->ical = NULL;
-        }
-        rock->imap_uid = 0;
+        getcalendarevents_reset_ical(rock);
     }
 
     /* Check mailbox ACL rights */
@@ -3744,21 +3754,17 @@ static int getcalendarevents_cb(void *vrock, struct caldav_jscal *jscal)
                 json_decref(jsevent);
                 jsevent = NULL;
             }
-            else goto gotevent;
+            else {
+                getcalendarevents_reset_ical(rock);
+                goto gotevent;
+            }
         }
     }
 
     if ((rock->imap_uid != cdata->dav.imap_uid) || !rock->ical) {
         /* Reset iterator state */
-        if (rock->ical) {
-            icalcomponent_free(rock->ical);
-            rock->ical = NULL;
-        }
+        getcalendarevents_reset_ical(rock);
         rock->imap_uid = cdata->dav.imap_uid;
-        rock->is_draft = 0;
-        message_guid_set_null(&rock->guid);
-        if (rock->ical_instances_by_recurid.size)
-            free_hash_table(&rock->ical_instances_by_recurid, _icalcomponent_free_cb);
 
         /* Open calendar mailbox. */
         if (!rock->mailbox || strcmp(mailbox_uniqueid(rock->mailbox), rock->mbentry->uniqueid)) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -473,9 +473,6 @@ static json_t *alert_from_ical(jmap_req_t *req,
     icalcomponent_add_component(vcal, vevent);
 
     jscal_cfg_t cfg = { 0 };
-    if (jmap_is_using(req, JMAP_DEBUG_EXTENSION)) {
-        cfg.debug = true;
-    }
 
     json_t *jalert = NULL;
     json_t *jgroup = jscal_from_ical(&cfg, vcal);
@@ -1257,9 +1254,6 @@ static icalcomponent *alert_to_ical(jmap_req_t *req,
 
     jscal_cfg_t cfg = { 0 };
     cfg.emailalert_default_uri = email_recipient;
-    if (jmap_is_using(req, JMAP_DEBUG_EXTENSION)) {
-        cfg.debug = true;
-    }
 
     struct jmap_parser myparser = JMAP_PARSER_INITIALIZER;
     icalcomponent *vcal = jscal_to_ical(&cfg, jevent, &myparser);
@@ -3576,9 +3570,6 @@ static json_t *ical_to_jsevent(jmap_req_t *req, icalcomponent *ical,
 {
     if (jmap_is_using(req, JMAP_JSCALENDARBIS_EXTENSION)) {
         jscal_cfg_t cfg = jmapical_ctx_to_jscalendar_cfg(jmapctx);
-        if (jmap_is_using(req, JMAP_DEBUG_EXTENSION)) {
-            cfg.debug = true;
-        }
 
         json_t *jgroup = jscal_from_ical(&cfg, ical);
         if (!jgroup) return NULL;
@@ -3599,9 +3590,6 @@ static json_t *ical_to_jsevents(jmap_req_t *req, icalcomponent *ical,
 {
     if (jmap_is_using(req, JMAP_JSCALENDARBIS_EXTENSION)) {
         jscal_cfg_t cfg = jmapical_ctx_to_jscalendar_cfg(jmapctx);
-        if (jmap_is_using(req, JMAP_DEBUG_EXTENSION)) {
-            cfg.debug = true;
-        }
 
         json_t *jgroup = jscal_from_ical(&cfg, ical);
         if (!jgroup) return NULL;

--- a/imap/jmap_props/calendar_event.gperf
+++ b/imap/jmap_props/calendar_event.gperf
@@ -86,7 +86,6 @@ jmap_property_t;
 "blobId",                  JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 "cyrusimap.org:iCalProps", JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_SKIP_GET
 "debugBlobId",             JMAP_DEBUG_EXTENSION,     JMAP_PROP_SERVER_SET
-"cyrusimap.org:unguessableTimezones", JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_SKIP_GET
 #
 # jscalendarbis spec
 "endTimeZone",             NULL, 0

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -613,8 +613,27 @@ static bool is_known_param(icalproperty *prop, icalparameter *param)
     case ICAL_IMAGE_PROPERTY:
     case ICAL_LINK_PROPERTY:
         switch (param_kind) {
-        case ICAL_DISPLAY_PARAMETER:
         case ICAL_ENCODING_PARAMETER:
+        case ICAL_FMTTYPE_PARAMETER:
+        case ICAL_LABEL_PARAMETER:
+        case ICAL_LINKREL_PARAMETER:
+        case ICAL_SIZE_PARAMETER:
+            return true;
+        case ICAL_DISPLAY_PARAMETER:
+            // The DISPLAY parameter only is defined for the IMAGE property.
+            return prop_kind == ICAL_IMAGE_PROPERTY;
+        case ICAL_FILENAME_PARAMETER:
+            // The "title" property converts to the FILENAME parameter for
+            // the ATTACH and IMAGE properties.
+            return prop_kind != ICAL_LINK_PROPERTY;
+        default:
+            return false;
+        }
+
+    case ICAL_URL_PROPERTY:
+        // No parameter is defined for the URL property, but these still
+        // convert to the properties of a Link object.
+        switch (param_kind) {
         case ICAL_FMTTYPE_PARAMETER:
         case ICAL_LABEL_PARAMETER:
         case ICAL_LINKREL_PARAMETER:
@@ -740,6 +759,7 @@ static bool is_known_prop(icalcomponent *comp, icalproperty *prop)
         case ICAL_SOURCE_PROPERTY:
         case ICAL_STYLEDDESCRIPTION_PROPERTY:
         case ICAL_UID_PROPERTY:
+        case ICAL_URL_PROPERTY:
         case ICAL_VERSION_PROPERTY:
             return true;
         default:
@@ -830,6 +850,7 @@ static bool is_known_prop(icalcomponent *comp, icalproperty *prop)
         case ICAL_NAME_PROPERTY:
         case ICAL_LOCATIONTYPE_PROPERTY:
         case ICAL_STYLEDDESCRIPTION_PROPERTY:
+        case ICAL_URL_PROPERTY:
             return true;
         default:
             if (myicalproperty_has_name(prop, "COORDINATES")) {
@@ -848,6 +869,7 @@ static bool is_known_prop(icalcomponent *comp, icalproperty *prop)
         case ICAL_NAME_PROPERTY:
         case ICAL_PERCENTCOMPLETE_PROPERTY:
         case ICAL_STYLEDDESCRIPTION_PROPERTY:
+        case ICAL_URL_PROPERTY:
             return true;
         default:
             return false;
@@ -1561,6 +1583,30 @@ static icalproperty *jobj_get_icalprop(jscal_ctx_t *ctx,
     return prop;
 }
 
+// TODO this is the third reader that read the convertedProperties property,
+// see also jobj_get_icalprop and jobj_get_icalprop_valuetype. This could
+// get refactored into a shared lookup helper.
+static icalproperty_kind jobj_get_icalprop_kind(jscal_ctx_t *ctx,
+                                                json_t *jobj,
+                                                const char *proppath)
+{
+    if (!ctx->cfg.use_icalendar_convprops) return ICAL_NO_PROPERTY;
+
+    json_t *jcomp = json_object_get(jobj, "iCalendar");
+    if (!jcomp) return ICAL_NO_PROPERTY;
+
+    json_t *jconvprops = json_object_get(jcomp, "convertedProperties");
+    if (!jconvprops) return ICAL_NO_PROPERTY;
+
+    json_t *jconvprop = json_object_get(jconvprops, proppath);
+    if (!jconvprop) return ICAL_NO_PROPERTY;
+
+    const char *name = json_string_value(json_object_get(jconvprop, "name"));
+    if (!name) return ICAL_NO_PROPERTY;
+
+    return icalproperty_string_to_kind(name);
+}
+
 static enum icalvalue_kind jobj_get_icalprop_valuetype(jscal_ctx_t *ctx,
                                                        json_t *jobj,
                                                        const char *proppath,
@@ -1613,13 +1659,25 @@ static bool jobj_has_icalquirk(json_t *jobj, const char *quirk)
 static const char *const JSCAL_UUID5NAMESPACE =
     "7f1e1965-ae73-4454-b088-232c90730ce2";
 
-static void myicalproperty_make_uuid5(icalproperty *prop, struct buf *buf)
+static void myicalproperty_make_uuid5(icalproperty *prop,
+                                      bool encode_name,
+                                      struct buf *buf)
 {
-    const char *s = icalproperty_get_value_as_string(prop);
-    buf_setcstr(
-        buf,
-        makeuuid5(JSCAL_UUID5NAMESPACE, (const unsigned char *) s, strlen(s)));
+    struct buf key = BUF_INITIALIZER;
+
+    if (encode_name) {
+        buf_setcstr(&key, icalproperty_get_property_name(prop));
+        buf_putc(&key, ':');
+    }
+    buf_appendcstr(&key, icalproperty_get_value_as_string(prop));
+
+    buf_setcstr(buf,
+                makeuuid5(JSCAL_UUID5NAMESPACE,
+                          (const unsigned char *) buf_cstring(&key),
+                          buf_len(&key)));
     buf_cstring(buf);
+
+    buf_free(&key);
 }
 
 static void jsid_to_prop(icalproperty *prop, const char *key, bool force)
@@ -1630,7 +1688,7 @@ static void jsid_to_prop(icalproperty *prop, const char *key, bool force)
     }
 
     struct buf buf = BUF_INITIALIZER;
-    myicalproperty_make_uuid5(prop, &buf);
+    myicalproperty_make_uuid5(prop, false, &buf);
     bool is_derived = !strcmp(key, buf_cstring(&buf));
     buf_free(&buf);
     if (!is_derived) {
@@ -1662,12 +1720,18 @@ static const char *jsid_from_prop(icalproperty *prop,
     }
 
     // Generate UUIDv5 from property value.
-    myicalproperty_make_uuid5(prop, buf);
+    myicalproperty_make_uuid5(prop, false, buf);
     if (!json_object_get(jobj, buf_cstring(buf))) {
         return buf_cstring(buf);
     }
 
-    // Generating random UUIDv4.
+    // Another property uses that id, also encode the property name.
+    myicalproperty_make_uuid5(prop, true, buf);
+    if (!json_object_get(jobj, buf_cstring(buf))) {
+        return buf_cstring(buf);
+    }
+
+    // Generate random UUIDv4.
     buf_setcstr(buf, makeuuid());
     return buf_cstring(buf);
 }
@@ -1681,7 +1745,7 @@ static void jsid_to_comp(icalcomponent *comp, const char *jsid)
         icalproperty *prop =
             myicalcomponent_get_property(comp, ICAL_CALENDARADDRESS_PROPERTY);
         if (prop) {
-            myicalproperty_make_uuid5(prop, &buf);
+            myicalproperty_make_uuid5(prop, false, &buf);
             if (!strcmp(jsid, buf_cstring(&buf))) goto done;
             buf_reset(&buf);
         }
@@ -1740,7 +1804,7 @@ static const char *jsid_from_comp(icalcomponent *comp,
         prop =
             myicalcomponent_get_property(comp, ICAL_CALENDARADDRESS_PROPERTY);
         if (prop) {
-            myicalproperty_make_uuid5(prop, buf);
+            myicalproperty_make_uuid5(prop, false, buf);
             if (!json_object_get(jobj, buf_cstring(buf))) {
                 return buf_cstring(buf);
             }
@@ -2064,31 +2128,130 @@ static void links_to_ical(jscal_ctx_t *ctx,
 
     const char *key;
     json_t *jlink;
+
+    // At most one Link object converts to the URL property, because that
+    // property MUST NOT occur more than once in a component. Determine
+    // which one that is, if any.
+    //
+    // The FMTTYPE, LABEL and SIZE parameters are not specified for the URL
+    // property, but testing suggests that Apple clients ignore them. Stick
+    // to any existing URL property even if these Link properties are added.
+    const char *url_key = NULL;
+    json_object_foreach(jlinks, key, jlink)
+    {
+        // Only the "describedby" link relation converts to URL.
+        const char *rel = json_string_value(json_object_get(jlink, "rel"));
+        if (strcasecmpsafe(rel, "describedby")) continue;
+
+        jmap_parser_push(&parser, key);
+        bool had_binary_value =
+            jobj_get_icalprop_valuetype(
+                ctx, jobj, jmap_parser_path_at(&parser, "href"),
+                ICAL_ANY_PROPERTY) == ICAL_BINARY_VALUE;
+        bool converted_from_url =
+            jobj_get_icalprop_kind(
+                ctx, jobj, jmap_parser_path_at(&parser, "href")) ==
+            ICAL_URL_PROPERTY;
+        jmap_parser_pop(&parser);
+
+        // A Link object that had a BINARY value type can not convert to URL.
+        if (had_binary_value) continue;
+
+        // Prefer the Link object that converted from the URL property.
+        if (!url_key) url_key = key;
+
+        if (converted_from_url) {
+            url_key = key;
+            break;
+        }
+    }
+
     json_object_foreach(jlinks, key, jlink)
     {
         jmap_parser_push(&parser, key);
 
         const char *href = json_string_value(json_object_get(jlink, "href"));
 
-        // Determine which property kind to use, keep using former one.
+        // The default value of the "rel" property is "enclosure".
+        const char *rel = json_string_value(json_object_get(jlink, "rel"));
+        if (!rel) rel = "enclosure";
+
+        // Determine which property name to use by inspecting the "rel"
+        // property.
+        icalproperty_kind want_kind;
+        if (!strcasecmp(rel, "icon")) {
+            want_kind = ICAL_IMAGE_PROPERTY;
+        }
+        else if (!strcasecmp(rel, "enclosure")) {
+            want_kind = ICAL_ATTACH_PROPERTY;
+        }
+        else if (url_key && !strcmp(url_key, key)) {
+            want_kind = ICAL_URL_PROPERTY;
+        }
+        else {
+            want_kind = ICAL_LINK_PROPERTY;
+        }
+
+        // Keep using the former property, if it is compatible with
+        // the current "rel" property value.
         icalproperty *prop =
             jobj_get_icalprop(ctx,
                               jobj,
                               jmap_parser_path_at(&parser, "href"),
                               ICAL_ANY_PROPERTY,
                               0);
-        if (!prop) {
-            if (JNOTNULL(json_object_get(jlink, "display")))
-                prop = icalproperty_new(ICAL_IMAGE_PROPERTY);
-            else if (JNOTNULL(json_object_get(jlink, "rel")))
-                prop = icalproperty_new(ICAL_LINK_PROPERTY);
-            else
-                prop = icalproperty_new(ICAL_ATTACH_PROPERTY);
+
+        // A Link object that converted from a BINARY value still keeps that
+        // value type, unless its "href" got changed to some other scheme.
+        bool use_binary_value =
+            jobj_get_icalprop_valuetype(
+                ctx, jobj, jmap_parser_path_at(&parser, "href"),
+                ICAL_ANY_PROPERTY) == ICAL_BINARY_VALUE
+            && !strncasecmp("data:", href, 5);
+
+        // Only the ATTACH and IMAGE properties allow a BINARY value. If we
+        // have to, we even preserve the LINKREL on ATTACH or IMAGE.
+        bool keep_linkrel = false;
+        if (use_binary_value && want_kind != ICAL_ATTACH_PROPERTY
+            && want_kind != ICAL_IMAGE_PROPERTY)
+        {
+            want_kind = prop && icalproperty_isa(prop) == ICAL_IMAGE_PROPERTY
+                            ? ICAL_IMAGE_PROPERTY
+                            : ICAL_ATTACH_PROPERTY;
+
+            // The link relation does not match the property kind, so it
+            // must get preserved in the LINKREL parameter.
+            keep_linkrel = true;
         }
 
-        // Convert data: URI value to BINARY value
+        if (prop && icalproperty_isa(prop) != want_kind) {
+            // Change property kind but preserve unknown parameters.
+            icalproperty *former_prop = prop;
+            prop = icalproperty_new(want_kind);
+            icalparameter *param;
+            icalparamiter param_iter;
+            myicalproperty_foreach_parameter(
+                former_prop, ICAL_ANY_PARAMETER, param, param_iter)
+            {
+                if (!is_known_param(prop, param)) {
+                    icalproperty_add_parameter(prop,
+                                               icalparameter_clone(param));
+                }
+            }
+            icalproperty_free(former_prop);
+        }
+        else if (!prop) {
+            prop = icalproperty_new(want_kind);
+        }
+
+        icalproperty_kind prop_kind = icalproperty_isa(prop);
+
+        // Convert data: URI value to BINARY value. Only the ATTACH and
+        // IMAGE properties allow that value type.
+        bool have_value = false;
         if (!strncasecmp("data:", href, 5)
-            && icalproperty_isa(prop) != ICAL_LINK_PROPERTY)
+            && (prop_kind == ICAL_ATTACH_PROPERTY
+                || prop_kind == ICAL_IMAGE_PROPERTY))
         {
             struct buf fmttype = BUF_INITIALIZER;
             const char *s = href + 5;
@@ -2110,6 +2273,8 @@ static void links_to_ical(jscal_ctx_t *ctx,
                     icalproperty_add_parameter(
                         prop, icalparameter_new_fmttype(buf_cstring(&fmttype)));
                 }
+
+                have_value = true;
             }
 
             buf_free(&fmttype);
@@ -2117,9 +2282,9 @@ static void links_to_ical(jscal_ctx_t *ctx,
 
         // Otherwise set URI value but make sure it's using the same
         // libical-internal value type as if read from iCalendar.
-        if (!icalproperty_get_value(prop)) {
-            if (icalproperty_isa(prop) == ICAL_ATTACH_PROPERTY ||
-                icalproperty_isa(prop) == ICAL_IMAGE_PROPERTY) {
+        if (!have_value) {
+            if (prop_kind == ICAL_ATTACH_PROPERTY ||
+                prop_kind == ICAL_IMAGE_PROPERTY) {
                 icalattach *attach = icalattach_new_from_url(href);
                 icalproperty_set_value(prop, icalvalue_new_attach(attach));
                 icalattach_unref(attach);
@@ -2137,7 +2302,9 @@ static void links_to_ical(jscal_ctx_t *ctx,
             icalproperty_add_parameter(prop, icalparameter_new_fmttype(s));
         }
 
-        if (JNOTNULL(jval = json_object_get(jlink, "display"))) {
+        // The DISPLAY parameter only is defined for the IMAGE property.
+        if (prop_kind == ICAL_IMAGE_PROPERTY &&
+                JNOTNULL(jval = json_object_get(jlink, "display"))) {
             icalenumarray *displays = icalenumarray_new(json_object_size(jval));
             icalenumarray_element elem = { 0 };
             for (void *it = json_object_iter(jval); it;
@@ -2162,10 +2329,12 @@ static void links_to_ical(jscal_ctx_t *ctx,
             }
         }
 
-        if (JNOTNULL(jval = json_object_get(jlink, "rel"))) {
-            const char *rel = json_string_value(jval);
-            icalproperty_add_parameter(prop,
-                    icalparameter_new_linkrel(rel));
+        // Only set the LINKREL parameter on the LINK property. It is not
+        // defined for the ATTACH, IMAGE and URL properties. Only exception
+        // is a BINARY value, which forced the property kind above and
+        // otherwise would lose the link relation.
+        if (prop_kind == ICAL_LINK_PROPERTY || keep_linkrel) {
+            icalproperty_add_parameter(prop, icalparameter_new_linkrel(rel));
         }
 
         if (JNOTNULL(jval = json_object_get(jlink, "size"))) {
@@ -2176,9 +2345,21 @@ static void links_to_ical(jscal_ctx_t *ctx,
                 prop, icalparameter_new_size(buf_cstring(&buf)));
         }
 
+        // The "title" property converts to the FILENAME parameter for the
+        // ATTACH and IMAGE properties, and to the LABEL parameter for the
+        // LINK and URL properties.
         if (JNOTNULL(jval = json_object_get(jlink, "title"))) {
             const char *title = json_string_value(jval);
-            icalproperty_add_parameter(prop, icalparameter_new_label(title));
+            if (prop_kind == ICAL_ATTACH_PROPERTY
+                || prop_kind == ICAL_IMAGE_PROPERTY)
+            {
+                icalproperty_add_parameter(prop,
+                                           icalparameter_new_filename(title));
+            }
+            else {
+                icalproperty_add_parameter(prop,
+                                           icalparameter_new_label(title));
+            }
         }
 
         // Add property.
@@ -3760,6 +3941,14 @@ static void validate_links(jscal_ctx_t *ctx __attribute__((unused)),
             jmap_parser_invalid(parser, "href");
         }
 
+        // If the "display" property is set, then the "rel"
+        // property value MUST be "icon".
+        if (JNOTNULL(json_object_get(jlink, "display")) &&
+                strcasecmpsafe("icon",
+                    json_string_value(json_object_get(jlink, "rel")))) {
+            jmap_parser_invalid(parser, "rel");
+        }
+
         jmap_parser_pop(parser);
     }
 }
@@ -5329,6 +5518,7 @@ static void links_from_ical(jscal_ctx_t *ctx __attribute__((unused)),
         case ICAL_ATTACH_PROPERTY:
         case ICAL_IMAGE_PROPERTY:
         case ICAL_LINK_PROPERTY:
+        case ICAL_URL_PROPERTY:
             break;
         default:
             continue;
@@ -5360,7 +5550,7 @@ static void links_from_ical(jscal_ctx_t *ctx __attribute__((unused)),
         default:
             continue;
         }
-        if (!strval) continue;
+        if (!strval || *strval == '\0') continue;
 
         // Build href from value.
         if (value_kind == ICAL_BINARY_VALUE) {
@@ -5377,18 +5567,24 @@ static void links_from_ical(jscal_ctx_t *ctx __attribute__((unused)),
             buf_setcstr(&href, strval);
         }
 
+        icalproperty_kind prop_kind = icalproperty_isa(prop);
+
         json_t *jlink = json_pack("{s:s}", "@type", "Link");
         json_object_set_new(jlink, "href", json_string(buf_cstring(&href)));
 
         // Set Link properties.
+        // The FILENAME parameter of the ATTACH and IMAGE properties takes
+        // precedence over the LABEL parameter when setting "title".
+        bool have_filename = false;
         icalparameter *param;
         icalparamiter param_iter;
         myicalproperty_foreach_parameter(
             prop, ICAL_ANY_PARAMETER, param, param_iter)
         {
             icalparameter_kind param_kind = icalparameter_isa(param);
+
             if (param_kind == ICAL_DISPLAY_PARAMETER
-                && icalproperty_isa(prop) == ICAL_IMAGE_PROPERTY)
+                && prop_kind == ICAL_IMAGE_PROPERTY)
             {
                 json_t *jdisplay = json_object();
                 for (size_t i = 0; i < icalparameter_get_display_size(param);
@@ -5413,11 +5609,23 @@ static void links_from_ical(jscal_ctx_t *ctx __attribute__((unused)),
                     "contentType",
                     json_string(icalparameter_get_fmttype(param)));
             }
-            else if (param_kind == ICAL_LABEL_PARAMETER) {
+            else if (param_kind == ICAL_FILENAME_PARAMETER
+                     && (prop_kind == ICAL_ATTACH_PROPERTY
+                         || prop_kind == ICAL_IMAGE_PROPERTY))
+            {
                 json_object_set_new(
                     jlink,
                     "title",
-                    json_string(icalparameter_get_label(param)));
+                    json_string(icalparameter_get_filename(param)));
+                have_filename = true;
+            }
+            else if (param_kind == ICAL_LABEL_PARAMETER) {
+                if (!have_filename) {
+                    json_object_set_new(
+                        jlink,
+                        "title",
+                        json_string(icalparameter_get_label(param)));
+                }
             }
             else if (param_kind == ICAL_LINKREL_PARAMETER) {
                 const char *rel = icalparameter_get_linkrel(param);
@@ -5449,27 +5657,63 @@ static void links_from_ical(jscal_ctx_t *ctx __attribute__((unused)),
         const char *key = jsid_from_prop(prop, jlinks, &buf);
         json_object_set_new(jlinks, key, jlink);
 
+        // Determine the link relation by property kind.
+        const char *rel = json_string_value(json_object_get(jlink, "rel"));
+        if (!rel) {
+            if (prop_kind == ICAL_IMAGE_PROPERTY) {
+                rel = "icon";
+                json_object_set_new(jlink, "rel", json_string(rel));
+            }
+            else if (prop_kind == ICAL_URL_PROPERTY) {
+                rel = "describedby";
+                json_object_set_new(jlink, "rel", json_string(rel));
+            }
+            else {
+                rel = "enclosure";
+                // Do not set default relation on Link object.
+            }
+        }
+
+        // Sanitize "rel" property.
+        if (json_object_get(jlink, "display") && strcasecmp(rel, "icon")) {
+            // The "display" property requires "rel=icon".
+            rel = "icon";
+            json_object_set_new(jlink, "rel", json_string(rel));
+        }
+        else if (!strcasecmp(rel, "enclosure")) {
+            // Remove default "enclosure" relation, if any.
+            rel = "enclosure";
+            json_object_del(jlink, "rel");
+        }
+
         // Preserve conversion-specific info, if necessary.
         jmap_parser_push(&parser, key);
         jmap_parser_push(&parser, "href");
 
         if (value_kind == ICAL_BINARY_VALUE) {
             jobj_set_icalprop_valuetype(
-                ctx, jobj, jmap_parser_path(&parser), prop);
-        }
-        else if (icalproperty_isa(prop) == ICAL_IMAGE_PROPERTY) {
-            if (myicalproperty_get_parameter(prop, ICAL_LINKREL_PARAMETER))
-                jobj_set_icalprop_name(
                     ctx, jobj, jmap_parser_path(&parser), prop);
         }
-        else if (icalproperty_isa(prop) == ICAL_LINK_PROPERTY) {
-            if (!myicalproperty_get_parameter(prop, ICAL_LINKREL_PARAMETER))
-                jobj_set_icalprop_name(
-                    ctx, jobj, jmap_parser_path(&parser), prop);
+
+        // Preserve the property name for the URL property, so that we
+        // know which Link object to convert back to URL in an update.
+        if (prop_kind == ICAL_URL_PROPERTY) {
+            jobj_set_icalprop_name(
+                 ctx, jobj, jmap_parser_path(&parser), prop);
         }
-        else if (icalproperty_isa(prop) != ICAL_ATTACH_PROPERTY) {
-            jobj_set_icalprop_name(ctx, jobj, jmap_parser_path(&parser), prop);
+
+        // Preserve the property name for unexpected link relations.
+        if ((!strcasecmp(rel, "enclosure") &&
+                    prop_kind != ICAL_ATTACH_PROPERTY) ||
+            (!strcasecmp(rel, "icon") &&
+                    prop_kind != ICAL_IMAGE_PROPERTY) ||
+            (!strcasecmp(rel, "describedby") &&
+                    prop_kind != ICAL_URL_PROPERTY)) {
+            jobj_set_icalprop_name(
+                 ctx, jobj, jmap_parser_path(&parser), prop);
         }
+
+        // Preserve unknown iCalendar parameters.
         jobj_set_icalprop_params(ctx, jobj, jmap_parser_path(&parser), prop);
 
         jmap_parser_pop(&parser);

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -3531,7 +3531,8 @@ static void validate_jicalcomponent(jscal_ctx_t *ctx,
             if (!is_stringset(jval, NULL))
                 jmap_parser_invalid(parser, key);
         }
-        else {
+        // Ignore extension properties, reject anything else.
+        else if (!is_vendorext_key(key)) {
             jmap_parser_invalid(parser, key);
         }
     }
@@ -6519,15 +6520,17 @@ static void entry_from_ical(jscal_ctx_t *ctx,
     jobj_set_icalcomp(ctx, jobj, comp);
     vendorexts_from_ical(comp, jobj);
 
-    // XXX for debugging only
-    if (ctx->cfg.debug && ptrarray_size(&ctx->unguessable_vtimezones)) {
+    if (ctx->cfg.use_icalendar_convprops
+        && ptrarray_size(&ctx->unguessable_vtimezones))
+    {
+        json_t *jcomp = jobj_set_icalcomp_name(ctx, jobj, comp);
         json_t *jtimezones = json_array();
         for (int i = 0; i < ptrarray_size(&ctx->unguessable_vtimezones); i++) {
             icalcomponent *vtz = ptrarray_nth(&ctx->unguessable_vtimezones, i);
             json_array_append_new(jtimezones, icalcomponent_as_jcal_array(vtz));
         }
-        json_object_set_new(jobj,
-                "cyrusimap.org:unguessableTimezones", jtimezones);
+        json_object_set_new(jcomp, "cyrusimap.org:unguessableTimezones",
+                            jtimezones);
     }
 
     // XXX quirk: a VEVENT without DTSTART is bogus. But in case such

--- a/imap/jscalendar.h
+++ b/imap/jscalendar.h
@@ -52,11 +52,6 @@ typedef struct {
      */
     bool no_quirk;
 
-    /**
-     * Toggles if to enable debugging output.
-     */
-    bool debug;
-
 } jscal_cfg_t;
 
 /** @brief Convert a JSCalendar object to an iCalendar object.


### PR DESCRIPTION
This changes how Cyrus convert JSCalendar Link objects from and to iCalendar. The former implementation converted a Link object having any "rel" property value to a LINK property. This was incorrect, both JSCalendar 1.0 (RFC 8984) and 2.0 (jscalendarbis) define the special-purpose link relations "enclosure", "icon" and "describedby".

The new conversion rules for converting Link object to iCalendar are:

1. Choose ATTACH if the "rel" property value is "enclosure".
2. Choose IMAGE if the "rel" property value is "icon".
3. Choose URL if the "rel" property value is "describedby" and no URL property is set in the iCalendar component.
4. Choose LINK otherwise.

The jscalendarbis specification now defines the default value for Link.rel is "enclosure", which means there can not be a Link object without a link relation (but the default value need not be transmitted). The jscalendar-icalendar specification also now is updated accordingly.

This PR also contains a few other changes that are required to fix existing LINK properties on disk that should become ATTACH properties: it fixes a bug in the calendar event cache for CalendarEvent/get where the "iCalendar" property could have been omitted in the response. It also fixes a bug in CalendarEvent/get where the event iterator could have had an invalid state.