### PR TITLE
Strip libical-internal X-LIC-ERROR from iCalendar data

### DIFF
--- a/cassandane/Cassandane/Cyrus/Sieve.pm
+++ b/cassandane/Cassandane/Cyrus/Sieve.pm
@@ -4,6 +4,7 @@
 package Cassandane::Cyrus::Sieve;
 use Net::CalDAVTalk 0.14;
 use Text::JSContact 0.01 qw(vcard_to_jscontact);
+use Text::VCardFast;
 use strict;
 use warnings;
 use IO::File;

--- a/cassandane/tiny-tests/Caldav/multiget_strip_x_lic_error
+++ b/cassandane/tiny-tests/Caldav/multiget_strip_x_lic_error
@@ -1,0 +1,65 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_multiget_strip_x_lic_error
+    :MagicPlus
+    ($self)
+{
+    my $caldav = $self->{caldav};
+    my $plusstore = $self->{instance}->get_service('imap'
+        )->create_store(username => 'cassandane+dav');
+    my $imap = $plusstore->get_client();
+
+    xlog $self, "Append event having an X-LIC-ERROR property";
+    my $mimeMsg = <<EOF;
+From: <cassandane\@local>
+Subject: test
+Date: Mon, 28 Sep 2015 15:24:34 +0200
+Message-ID: <c6da9d16e00f7c3431b75f346a28594ca22a1f7d\@local>
+Content-Type: text/calendar; charset=utf-8; component=VEVENT
+Content-Transfer-Encoding: 8bit
+Content-Disposition: attachment;
+        filename*0="test.ics"
+MIME-Version: 1.0
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTART:20230909T160000Z
+DURATION:PT1H
+UID:4c9aff9c-91df-4859-8026-772a82f52094
+DTSTAMP:20230909T132434Z
+SUMMARY:test
+COLOR:#f0a0b0
+X-LIC-ERROR;X-LIC-ERRORTYPE=PARAMETER-VALUE-PARSE-ERROR:Invalid VALUE type for property COLOR: VALUE=TEXT
+END:VEVENT
+END:VCALENDAR
+EOF
+    $mimeMsg =~ s/\r?\n/\r\n/gs;
+    $imap->append('#calendars.Default', $mimeMsg) || die $@;
+
+    xlog $self, "Run calendar-multiget report";
+    my $xml = <<EOF;
+<?xml version="1.0" encoding="utf-8" ?>
+<C:calendar-multiget xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:prop>
+    <C:calendar-data/>
+  </D:prop>
+  <D:href>/dav/calendars/user/cassandane/Default/test.ics</D:href>
+</C:calendar-multiget>
+EOF
+    my $res = $caldav->Request('REPORT', 'Default', $xml,
+        'Content-Type' => 'application/xml');
+
+    xlog $self, "Assert X-LIC-ERROR is not in the reported calendar data";
+    my $icaldata = $res->{'{DAV:}response'}[0]{'{DAV:}propstat'}[0]
+        {'{DAV:}prop'}{'{urn:ietf:params:xml:ns:caldav}calendar-data'}{content};
+    my $vcal = Text::VCardFast::vcard2hash($icaldata);
+    my $vevent = $vcal->{objects}[0]{objects}[0];
+    $self->assert_str_equals('vevent', $vevent->{type});
+    $self->assert_null($vevent->{properties}{'x-lic-error'});
+    $self->assert_str_equals('#f0a0b0',
+        $vevent->{properties}{color}[0]{value});
+}

--- a/cassandane/tiny-tests/Caldav/put_strip_x_lic_error
+++ b/cassandane/tiny-tests/Caldav/put_strip_x_lic_error
@@ -1,0 +1,42 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_put_strip_x_lic_error
+    ($self)
+{
+    my $caldav = $self->{caldav};
+
+    xlog $self, "PUT event having a COLOR and an X-LIC-ERROR property";
+    my $eventUid = '4c9aff9c-91df-4859-8026-772a82f52094';
+    my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTART:20230909T160000Z
+DURATION:PT1H
+UID:$eventUid
+SUMMARY:test
+COLOR:#f0a0b0
+X-LIC-ERROR;X-LIC-ERRORTYPE=PARAMETER-VALUE-PARSE-ERROR:Invalid VALUE type for property COLOR: VALUE=TEXT
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    $caldav->Request('PUT',
+        "/dav/calendars/user/cassandane/Default/test.ics",
+        $ical,
+        'Content-Type' => 'text/calendar');
+
+    xlog $self, "Assert X-LIC-ERROR got stripped but COLOR is kept";
+    my $res = $caldav->Request('GET',
+        "/dav/calendars/user/cassandane/Default/test.ics");
+
+    my $vcal = Text::VCardFast::vcard2hash($res->{content});
+    my $vevent = $vcal->{objects}[0]{objects}[0];
+    $self->assert_str_equals('vevent', $vevent->{type});
+    $self->assert_null($vevent->{properties}{'x-lic-error'});
+    $self->assert_str_equals('#f0a0b0',
+        $vevent->{properties}{color}[0]{value});
+}

--- a/cassandane/tiny-tests/Sieve/imip_strip_x_lic_error
+++ b/cassandane/tiny-tests/Sieve/imip_strip_x_lic_error
@@ -1,0 +1,80 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_imip_strip_x_lic_error
+    :needs_component_httpd :want_service_http
+    ($self)
+{
+    my $IMAP = $self->{store}->get_client();
+    $self->{store}->_select();
+    $self->assert_num_equals(1, $IMAP->uid());
+    $self->{store}->set_fetch_attributes(qw(uid flags));
+
+    my $CalDAV = $self->{caldav};
+    my $CalendarHref =
+        $self->default_user->calendars->default->properties->{'x-href'};
+    my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+
+    xlog $self, "Install a sieve script to process iMIP";
+    $self->{instance}->install_sieve_script(<<EOF
+require ["body", "variables", "imap4flags", "processcalendar"];
+if body :content "text/calendar" :contains "\nMETHOD:" {
+    processcalendar :outcome "outcome";
+    if string "\${outcome}" "added" {
+        setflag "\\\\Flagged";
+    }
+}
+EOF
+    );
+
+    my $imip = <<EOF;
+Date: Thu, 23 Sep 2021 09:06:18 -0400
+From: Foo <foo\@example.net>
+To: Cassandane <cassandane\@example.com>
+Message-ID: <$uuid\@example.net>
+Content-Type: text/calendar; method=REQUEST; component=VEVENT
+X-Cassandane-Unique: $uuid
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+CREATED:20210923T034327Z
+UID:$uuid
+DTEND;TZID=America/New_York:20210923T183000
+TRANSP:OPAQUE
+SUMMARY:An Event
+DTSTART;TZID=America/New_York:20210923T153000
+DTSTAMP:20210923T034327Z
+SEQUENCE:0
+COLOR:#f0a0b0
+X-LIC-ERROR;X-LIC-ERRORTYPE=PARAMETER-VALUE-PARSE-ERROR:Invalid VALUE type for property COLOR: VALUE=TEXT
+ORGANIZER;CN=Test User:MAILTO:foo\@example.net
+ATTENDEE;CN=Test User;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:foo\@example.net
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "Deliver iMIP invite having an X-LIC-ERROR property";
+    my $msg = Cassandane::Message->new(raw => $imip);
+    $msg->set_attribute(uid => 1,
+                        flags => [ '\\Recent', '\\Flagged' ]);
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "Check that the message made it to INBOX";
+    $self->check_messages({ 1 => $msg }, check_guid => 0);
+
+    xlog $self, "Check that the event made it to calendar";
+    my $events = $CalDAV->GetEvents($CalendarHref);
+    $self->assert_equals(1, scalar @$events);
+    $self->assert_str_equals($uuid, $events->[0]{uid});
+
+    xlog $self, "Assert X-LIC-ERROR is not in the stored event";
+    my $res = $CalDAV->Request('GET', $events->[0]{href});
+    my $vcal = Text::VCardFast::vcard2hash($res->{content});
+    my $vevent = $vcal->{objects}[0]{objects}[0];
+    $self->assert_str_equals('vevent', $vevent->{type});
+    $self->assert_null($vevent->{properties}{'x-lic-error'});
+}

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -5772,6 +5772,9 @@ static int propfind_caldata(const xmlChar *name, xmlNsPtr ns,
         }
 
         if (ical) {
+            /* Remove all X-LIC-ERROR properties */
+            icalcomponent_strip_errors(ical);
+
             /* Create iCalendar data from new ical component */
             data = icalcomponent_as_ical_string(ical);
             datalen = strlen(data);

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -794,9 +794,51 @@ EXPORTED icalcomponent *icalcomponent_new_stream(struct mailbox *mailbox,
     return ical;
 }
 
+/* Remove all X-LIC-ERROR content lines, including their folded lines, from
+ * the iCalendar data in rawical. Returns a newly allocated string.
+ *
+ * The libical parser reports parse errors as X-LIC-ERROR properties, so a
+ * client-sent X-LIC-ERROR property is indistinguishable from a parse error
+ * once the data got parsed. Strip them from the raw data instead. */
+static char *strip_xlicerror_lines(const char *rawical)
+{
+    static const char propname[] = "X-LIC-ERROR";
+    struct buf buf = BUF_INITIALIZER;
+
+    for (const char *p = rawical; *p;) {
+        const char *eol = strchr(p, '\n');
+        size_t linelen = eol ? (size_t) (eol - p) + 1 : strlen(p);
+
+        if (!strncasecmp(p, propname, sizeof(propname) - 1)
+            && (p[sizeof(propname) - 1] == ';'
+                || p[sizeof(propname) - 1] == ':'))
+        {
+            /* Skip this property and any of its folded lines */
+            p += linelen;
+            while (*p == ' ' || *p == '\t') {
+                eol = strchr(p, '\n');
+                p += eol ? (size_t) (eol - p) + 1 : strlen(p);
+            }
+        }
+        else {
+            buf_appendmap(&buf, p, linelen);
+            p += linelen;
+        }
+    }
+
+    return buf_release(&buf);
+}
+
 EXPORTED icalcomponent *ical_string_as_icalcomponent(const struct buf *buf)
 {
     const char *rawical = buf_cstring(buf);
+    char *stripped = NULL;
+
+    if (stristr(rawical, "X-LIC-ERROR")) {
+        stripped = strip_xlicerror_lines(rawical);
+        rawical = stripped;
+    }
+
     icalcomponent *ical = icalparser_parse_string(rawical);
 
     if (!ical && !stristr(rawical, "END:VCALENDAR")) {
@@ -805,6 +847,7 @@ EXPORTED icalcomponent *ical_string_as_icalcomponent(const struct buf *buf)
         free(fixed);
     }
 
+    free(stripped);
     return ical;
 }
 


### PR DESCRIPTION
We already stripped X-LIC-ERROR in CalDAV GET, but multiget REPORT still contained the bogus properties. Also if the original iCalendar data contained X-LIC-ERROR properties we reject that data as invalid in PUT and incoming iTIP, even if it was Cyrus that had left these errors in the data in the first place.