### PR TITLE
jmap_contact.c: don't try to use a non-string value as a string

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_query_inaddressbook
+++ b/cassandane/tiny-tests/JMAPContacts/card_query_inaddressbook
@@ -46,4 +46,22 @@ sub test_card_query_inaddressbook
         'R2'
         ], $res->[0]
     );
+
+    xlog $self, "query by bogus addressBookId";
+    $res = $jmap->CallMethods([
+        ['ContactCard/query', {
+            filter => {
+                inAddressBook => ['R8k']
+            }
+        }, 'R2'],
+    ]);
+    $self->assert_deep_equals([
+        'error',
+        {
+            type => 'invalidArguments',
+            arguments => [ 'filter/inAddressBook' ]
+        },
+        'R2'
+        ], $res->[0]
+    );
 }

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -5309,7 +5309,7 @@ static void card_filter_validate(jmap_req_t *req __attribute__((unused)),
                 jmap_parser_invalid(parser, field);
             }
 
-            if (!strcmp(field, "kind")) {
+           else if (!strcmp(field, "kind")) {
                 int *kind = (int *) rock;
 
                 if (!strcmp("group", json_string_value(arg))) {


### PR DESCRIPTION
We were correctly detecting that the inAddressBook value wasn't a string (e.g. an array(, but then we continued processing and tried to use the string value (NULL), thereby segfaulting when trying to dereference a NULL pointer