### PR TITLE
Sync stale cache selfheal

### DIFF
--- a/cassandane/tiny-tests/MurderIMAP/xfer_leaves_synccache_alone
+++ b/cassandane/tiny-tests/MurderIMAP/xfer_leaves_synccache_alone
@@ -1,0 +1,32 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Invariant: an XFER doesn't touch the replication cache.  It syncs to a server
+# that isn't the channel's replica, so anything it cached would never be looked
+# up again.
+#
+sub test_xfer_leaves_synccache_alone
+    :AllowMoves :NoAltNamespace :SyncCache
+    :min_version_3_2
+    ($self)
+{
+    my $cachefname = "$self->{instance}->{basedir}/sync_cache.db";
+
+    $self->populate_user($self->{instance},
+                         $self->{backend1_store},
+                         [qw(INBOX INBOX.Drafts)]);
+
+    my $admintalk = $self->{backend1_adminstore}->get_client();
+    my $backend2_servername = $self->{backend2}->get_servername();
+
+    xlog $self, "xfer the user to the other backend";
+    my $ret = $admintalk->_imap_cmd('xfer', 0, {},
+                                    'user.cassandane', $backend2_servername);
+    $self->assert_str_equals('ok', $ret);
+    $self->assert_str_equals('ok',
+        $admintalk->get_last_completion_response());
+
+    xlog $self, "the xfer must not have written a replication cache";
+    $self->assert(!-e $cachefname, "$cachefname exists");
+}

--- a/cassandane/tiny-tests/Replication/mailbox_parent_missing_refused
+++ b/cassandane/tiny-tests/Replication/mailbox_parent_missing_refused
@@ -1,0 +1,52 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Invariant: the replica never ends up with a parentless folder.  A folder whose
+# parent is missing there is refused, leaving nothing behind; syncing the user
+# is what repairs it.
+#
+sub test_mailbox_parent_missing_refused
+    :NoAltNameSpace :ImmediateDelete :NoReplicaonly :min_version_3_9
+    ($self)
+{
+    my $mastertalk = $self->{master_store}->get_client();
+
+    $mastertalk->create("INBOX.sub");
+    $self->assert_str_equals('ok', $mastertalk->get_last_completion_response());
+
+    xlog $self, "replicate the whole user";
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    xlog $self, "delete the user on the replica, leaving tombstones behind";
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replicaadmin = $replicasvc->create_store(username => 'admin');
+    my $replicaadmintalk = $replicaadmin->get_client();
+    foreach my $folder ("user.cassandane.sub", "user.cassandane") {
+        $replicaadmintalk->delete($folder);
+        $self->assert_str_equals('ok',
+            $replicaadmintalk->get_last_completion_response());
+    }
+
+    $self->{instance}->getsyslog();
+    $self->{replica}->getsyslog();
+
+    xlog $self, "ask for only the child folder, whose parent is gone";
+    eval { $self->run_replication(mailbox => 'user.cassandane.sub') };
+
+    xlog $self, "the replica must have gained nothing";
+    $replicaadmintalk = $replicaadmin->get_client();
+    my $data = $replicaadmintalk->list("", "user.cassandane*");
+    $self->assert_deep_equals([], $data);
+
+    $self->assert_syslog_matches($self->{replica},
+        qr/Failed to open mailbox user\.cassandane\.sub to update: Permission denied/);
+    $self->assert_syslog_matches($self->{instance},
+        qr/MAILBOX received NO response: IMAP_PERMISSION_DENIED/);
+
+    xlog $self, "syncing the user is what repairs it";
+    $replicaadmin->disconnect();
+    $self->run_replication(user => 'cassandane');
+    $self->check_replication('cassandane');
+}

--- a/cassandane/tiny-tests/Replication/rename_old_synccache
+++ b/cassandane/tiny-tests/Replication/rename_old_synccache
@@ -34,11 +34,13 @@ sub test_rename_old_synccache
     $self->check_messages(\%exp, $master_store);
 
     xlog $self, "run initial replication";
-    $self->run_replication();
-    #$self->run_replication(rolling => 1, inputfile => $synclogfname);
+    # must be rolling: only rolling replication uses the sync cache, and this
+    # test needs cached records for the pre-rename names
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
     unlink($synclogfname);
     $self->check_replication('cassandane');
 
+    $self->assert_file_test($cachefname, '-f');
     rename($cachefname, "$cachefname.junk");
 
     xlog $self, "rename user";

--- a/cassandane/tiny-tests/Replication/stale_synccache_replica_user_gone
+++ b/cassandane/tiny-tests/Replication/stale_synccache_replica_user_gone
@@ -1,0 +1,52 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Invariant: rolling replication recovers when the replica has lost a user.  The
+# mailbox that fails is promoted to a whole-user sync, which asks the replica
+# rather than believing the cached records for the other folders.
+#
+sub test_stale_synccache_replica_user_gone
+    :NoAltNameSpace :ImmediateDelete :NoReplicaonly :SyncCache :SyncLog
+    :min_version_3_9
+    ($self)
+{
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+
+    xlog $self, "rolling replication, so the cache gets populated";
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+    $self->check_replication('cassandane');
+
+    xlog $self, "delete the user on the replica, leaving a tombstone behind";
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replicaadmin = $replicasvc->create_store(username => 'admin');
+    my $replicaadmintalk = $replicaadmin->get_client();
+    $replicaadmintalk->delete("user.cassandane");
+    $self->assert_str_equals('ok',
+        $replicaadmintalk->get_last_completion_response());
+    $replicaadmin->disconnect();
+
+    xlog $self, "create a folder that the cache has never seen";
+    my $mastertalk = $self->{master_store}->get_client();
+    $mastertalk->create("INBOX.sub");
+    $self->assert_str_equals('ok', $mastertalk->get_last_completion_response());
+
+    $self->{instance}->getsyslog();
+    $self->{replica}->getsyslog();
+
+    xlog $self, "sync just that folder, whose parent is gone on the replica";
+    open(my $fh, ">", $synclogfname) or die "open $synclogfname: $!";
+    print $fh "MAILBOX user.cassandane.sub\n";
+    close($fh);
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+
+    xlog $self, "the replica must have the whole user back";
+    $self->check_replication('cassandane');
+
+    xlog $self, "the folder apply fails first, and says why";
+    $self->assert_syslog_matches($self->{replica},
+        qr/Failed to open mailbox user\.cassandane\.sub to update: Permission denied/);
+    $self->assert_syslog_matches($self->{instance},
+        qr/MAILBOX received NO response: IMAP_PERMISSION_DENIED/);
+}

--- a/cassandane/tiny-tests/Replication/synccache_rolling_only
+++ b/cassandane/tiny-tests/Replication/synccache_rolling_only
@@ -1,0 +1,35 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Invariant: only rolling replication reads the cache.  A sync of a named user
+# compares against the replica itself, so it repairs a lost user whatever the
+# cache claims.
+#
+sub test_synccache_rolling_only
+    :NoAltNameSpace :ImmediateDelete :NoReplicaonly :SyncCache :SyncLog
+    :min_version_3_9
+    ($self)
+{
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+    my $cachefname = "$self->{instance}->{basedir}/sync_cache.db";
+
+    xlog $self, "rolling replication, so the cache gets populated";
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+    $self->check_replication('cassandane');
+    $self->assert_file_test($cachefname, '-f');
+
+    xlog $self, "delete the user on the replica, leaving a tombstone behind";
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replicaadmin = $replicasvc->create_store(username => 'admin');
+    my $replicaadmintalk = $replicaadmin->get_client();
+    $replicaadmintalk->delete("user.cassandane");
+    $self->assert_str_equals('ok',
+        $replicaadmintalk->get_last_completion_response());
+    $replicaadmin->disconnect();
+
+    xlog $self, "a sync of the user by name must repair it";
+    $self->run_replication(user => 'cassandane');
+    $self->check_replication('cassandane');
+}

--- a/cassandane/tiny-tests/Replication/synccache_skipped_for_user
+++ b/cassandane/tiny-tests/Replication/synccache_skipped_for_user
@@ -1,0 +1,49 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Invariant: a whole-user sync asks the replica rather than believing the cache,
+# so it repairs a replica that lost the user even though nothing ever failed and
+# every folder is cached as already in sync.
+#
+sub test_synccache_skipped_for_user
+    :NoAltNameSpace :ImmediateDelete :NoReplicaonly :SyncCache :SyncLog
+    :min_version_3_9
+    ($self)
+{
+    my $synclogfname = "$self->{instance}->{basedir}/conf/sync/log";
+    my $cachefname = "$self->{instance}->{basedir}/sync_cache.db";
+
+    my $mastertalk = $self->{master_store}->get_client();
+    $mastertalk->create("INBOX.sub");
+    $self->assert_str_equals('ok', $mastertalk->get_last_completion_response());
+
+    xlog $self, "rolling replication, so the cache gets populated";
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+    unlink($synclogfname);
+    $self->check_replication('cassandane');
+    $self->assert_file_test($cachefname, '-f');
+
+    xlog $self, "delete the user on the replica, leaving tombstones behind";
+    my $replicasvc = $self->{replica}->get_service('imap');
+    my $replicaadmin = $replicasvc->create_store(username => 'admin');
+    my $replicaadmintalk = $replicaadmin->get_client();
+    foreach my $folder ("user.cassandane.sub", "user.cassandane") {
+        $replicaadmintalk->delete($folder);
+        $self->assert_str_equals('ok',
+            $replicaadmintalk->get_last_completion_response());
+    }
+    $replicaadmin->disconnect();
+
+    $self->{instance}->getsyslog();
+    $self->{replica}->getsyslog();
+
+    xlog $self, "a USER item in the log, with every folder cached as in sync";
+    open(my $fh, ">", $synclogfname) or die "open $synclogfname: $!";
+    print $fh "USER cassandane\n";
+    close($fh);
+    $self->run_replication(rolling => 1, inputfile => $synclogfname);
+
+    xlog $self, "the replica must have the whole user back";
+    $self->check_replication('cassandane');
+}

--- a/changes/next/sync-uncache-whole-user
+++ b/changes/next/sync-uncache-whole-user
@@ -1,0 +1,38 @@
+Description:
+
+Replication now recovers when a replica has lost a user.
+
+The replication cache is only read by rolling replication, and never for a
+whole-user sync.  Every other case compares against the replica itself, so it
+notices that the replica isn't what the cache claims and repairs it.  This makes
+"sync_client -u <user>" able to fix such a user, which it previously was not:
+with a warm cache it decided every folder was already in sync and did nothing.
+
+An XFER no longer writes to the cache.  It syncs to a server that isn't the
+channel's replica, so the records it wrote were never going to be read back.
+
+sync_server also reports IMAP_PERMISSION_DENIED by name instead of "NO Unknown
+error", so these failures are identifiable in sync_client logs.
+
+Documentation:
+
+(none)
+
+
+Config changes:
+
+(none)
+
+Upgrade instructions:
+
+Sites using sync_cache_db_path may have replicas that are silently missing
+users whose folders are all tombstoned in the replica's mailboxes.db, with the
+master believing them to be in sync.  Such a user is repaired by any whole-user
+sync, which rolling replication does by itself as soon as one of their folders
+fails to apply, or which can be run on demand with "sync_client -u <user>" or
+-A.
+
+
+GitHub issue:
+
+(none)

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -11754,7 +11754,8 @@ static int xfer_init(const char *toserver, struct xfer_header **xferptr)
     syslog(LOG_INFO, "XFER: connecting to server '%s'", toserver);
 
     xfer->sync_cs.servername = toserver;
-    xfer->sync_cs.flags = SYNC_FLAG_LOGGING | SYNC_FLAG_LOCALONLY;
+    xfer->sync_cs.flags = SYNC_FLAG_LOGGING | SYNC_FLAG_LOCALONLY
+                        | SYNC_FLAG_NOCACHE;
 
     /* Get a connection to the remote backend */
     xfer->sync_cs.backend = proxy_findserver(toserver, &imap_protocol, "", &backend_cached,

--- a/imap/sync_client.c
+++ b/imap/sync_client.c
@@ -640,6 +640,10 @@ int main(int argc, char **argv)
     sync_cs.channel = channel;
     sync_cs.flags = flags;
 
+    /* every other mode compares against the replica itself, which is what lets
+     * it repair a replica that's been changed behind our back */
+    if (mode == MODE_REPEAT) sync_cs.flags |= SYNC_FLAG_USECACHE;
+
     switch (mode) {
     case MODE_USER:
         /* Open up connection to server */

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -7637,10 +7637,17 @@ redo:
     struct dlist *kl = NULL;
     struct dlist *cachel = NULL;
 
+    /* only use the cache in normal rolling replication, that's where the bulk
+     * of the benefit comes from, and if we escalate to a full USER sync or
+     * run a sync manually, correctness outweighs efficiency, e.g. if the
+     * INBOX is cached locally but missing remotely then syncing another
+     * folder would hit an infinite loop asserting that parent is needed */
+    int usecache = (sync_cs->flags & SYNC_FLAG_USECACHE) && !sync_cs->userid;
+
     for (mbox = mboxname_list->head; mbox; mbox = mbox->next) {
         struct dlist *cl = NULL;
         // check if it's in the cache, then we don't need to look it up
-        if (!sync_readcache(sync_cs, mbox->name, &cl) && cl) {
+        if (usecache && !sync_readcache(sync_cs, mbox->name, &cl) && cl) {
             if (!cachel) cachel = dlist_newlist(NULL, "MAILBOXES");
             dlist_stitch(cachel, cl);
             if ((flags & SYNC_FLAG_VERBOSE) || (flags & SYNC_FLAG_LOGGING))

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -7637,10 +7637,15 @@ redo:
     struct dlist *kl = NULL;
     struct dlist *cachel = NULL;
 
+    /* the cache records what the replica looked like last time this channel's
+     * rolling process talked to it, so only it can trust a cached copy.  Every
+     * mode still writes to the cache, it just may not read from it. */
+    int usecache = !!(sync_cs->flags & SYNC_FLAG_USECACHE);
+
     for (mbox = mboxname_list->head; mbox; mbox = mbox->next) {
         struct dlist *cl = NULL;
         // check if it's in the cache, then we don't need to look it up
-        if (!sync_readcache(sync_cs, mbox->name, &cl) && cl) {
+        if (usecache && !sync_readcache(sync_cs, mbox->name, &cl) && cl) {
             if (!cachel) cachel = dlist_newlist(NULL, "MAILBOXES");
             dlist_stitch(cachel, cl);
             if ((flags & SYNC_FLAG_VERBOSE) || (flags & SYNC_FLAG_LOGGING))

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -5516,6 +5516,10 @@ static int reserve_messages(struct sync_client_state *sync_cs,
 
 static struct db *sync_getcachedb(struct sync_client_state *sync_cs)
 {
+    /* nothing to gain: we're syncing somewhere that isn't this channel's
+     * replica, so whatever we cached would never be looked up again */
+    if (sync_cs->flags & SYNC_FLAG_NOCACHE) return NULL;
+
     if (sync_cs->cachedb) return sync_cs->cachedb;
 
     const char *dbtype = config_getstring(IMAPOPT_SYNC_CACHE_DB);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -7638,9 +7638,11 @@ redo:
     struct dlist *cachel = NULL;
 
     /* the cache records what the replica looked like last time this channel's
-     * rolling process talked to it, so only it can trust a cached copy.  Every
-     * mode still writes to the cache, it just may not read from it. */
-    int usecache = !!(sync_cs->flags & SYNC_FLAG_USECACHE);
+     * rolling process talked to it, so only it can trust a cached copy.  A
+     * whole-user sync asks as well: it's our chance to notice that the replica
+     * isn't what we think it is.  Every mode still writes to the cache, it just
+     * may not read from it. */
+    int usecache = (sync_cs->flags & SYNC_FLAG_USECACHE) && !sync_cs->userid;
 
     for (mbox = mboxname_list->head; mbox; mbox = mbox->next) {
         struct dlist *cl = NULL;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2265,6 +2265,9 @@ int sync_parse_response(const char *cmd, struct protstream *in,
         else if (!strncmp(errmsg.s, "IMAP_MAILBOX_NOTSUPPORTED ",
                           strlen("IMAP_MAILBOX_NOTSUPPORTED ")))
             return IMAP_MAILBOX_NOTSUPPORTED;
+        else if (!strncmp(errmsg.s, "IMAP_PERMISSION_DENIED ",
+                          strlen("IMAP_PERMISSION_DENIED ")))
+            return IMAP_PERMISSION_DENIED;
         else if (!strncmp(errmsg.s, "IMAP_SYNC_CHECKSUM ",
                           strlen("IMAP_SYNC_CHECKSUM ")))
             return IMAP_SYNC_CHECKSUM;
@@ -5188,6 +5191,9 @@ static const char *sync_response(int r)
         break;
     case IMAP_MAILBOX_NOTSUPPORTED:
         resp = "NO IMAP_MAILBOX_NOTSUPPORTED Operation is not supported on mailbox";
+        break;
+    case IMAP_PERMISSION_DENIED:
+        resp = "NO IMAP_PERMISSION_DENIED Permission denied";
         break;
     case IMAP_SYNC_CHECKSUM:
         resp = "NO IMAP_SYNC_CHECKSUM Checksum Failure";

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -296,6 +296,7 @@ const char *sync_restore(struct dlist *kin,
 #define SYNC_FLAG_SIEVE_MAILBOX (1<<6)
 #define SYNC_FLAG_NONBLOCK (1<<7)
 #define SYNC_FLAG_ARCHIVE (1<<8)
+#define SYNC_FLAG_USECACHE (1<<9)
 
 int sync_do_annotation(struct sync_client_state *sync_cs, const char *mboxname);
 int sync_do_mailboxes(struct sync_client_state *sync_cs,

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -297,6 +297,7 @@ const char *sync_restore(struct dlist *kin,
 #define SYNC_FLAG_NONBLOCK (1<<7)
 #define SYNC_FLAG_ARCHIVE (1<<8)
 #define SYNC_FLAG_USECACHE (1<<9)
+#define SYNC_FLAG_NOCACHE (1<<10)
 
 int sync_do_annotation(struct sync_client_state *sync_cs, const char *mboxname);
 int sync_do_mailboxes(struct sync_client_state *sync_cs,


### PR DESCRIPTION
We had an issue where users would be wiped on a replica by a propogated sync_reset on the master, then synced in again and the cache on the master would make it think that the replica existed when in fact it didn't!

I looked a few different paths and settled on "every sync USER bypasses the cache entirely".  This was most robust, and full user syncs are rare in production.