### PR TITLE
SearchFuzzy: slow down search_sort_thread_maxtime

### DIFF
--- a/cassandane/tiny-tests/SearchFuzzy/search_sort_thread_maxtime
+++ b/cassandane/tiny-tests/SearchFuzzy/search_sort_thread_maxtime
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 sub test_search_sort_thread_maxtime
-    :min_version_3_13 :needs_search_xapian :SearchMaxtime1Sec :SearchNormalizationMax20000
+    :needs_search_xapian :SearchMaxtime1Sec :SearchNormalizationMax20000
     ($self)
 {
     my $talk = $self->{store}->get_client();
@@ -13,7 +13,7 @@ sub test_search_sort_thread_maxtime
     # criteria whose DNF normalisation reliably exceeds search_maxtime,
     # independent of mailbox size
     my $crit = 'SUBJECT a';
-    $crit = "OR NOT $crit NOT $crit" for (1..14);
+    $crit = "OR NOT $crit NOT $crit" for (1..15);
 
     xlog "SEARCH must report the timeout";
     my $uids = $talk->search(\$crit);


### PR DESCRIPTION
On my laptop the SORT was running fast enough to succeed rather than time out, and then the test would fail.

Adding one more step to the exponential criteria construction slows it down enough to pass, without making the whole test unbearably slow.  My laptop runtime for this test is now ~11 seconds, and it seems to pass reliably.

I tried adding another extra step, but that stretched it to over a minute, so I backed it out.  If it turns out we do need another step for full reliability, we might add the `_slow` suffix too.