### PR TITLE
cassandane: make verbosity 2 actually useful

### DIFF
--- a/cassandane/Cassandane/IMAPMessageStore.pm
+++ b/cassandane/Cassandane/IMAPMessageStore.pm
@@ -106,7 +106,7 @@ sub connect
     }
 
     $client->set_tracing(1)
-        if $self->{verbose};
+        if $self->{verbose} >= 3;
 
     my $banner = $client->get_response_code('remainder');
     if (not $params{NoLogin}) {

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -3317,7 +3317,7 @@ sub _new_jmaptester_for_user($self, $tester_class, $tester_arg, $user, $new_arg 
 
     # This causes all requests and responses to be printed to STDERR.
     local $ENV{JMAP_TESTER_LOGGER} = 'HTTP:-2'
-        unless exists $ENV{JMAP_TESTER_LOGGER};
+        if get_verbose() >= 3 && not exists $ENV{JMAP_TESTER_LOGGER};
 
     my $jtest = $tester_class->new({
         fallback_account_id => $user->username,


### PR DESCRIPTION
... by moving the IMAP protocol chatter from verbosity 1 to 3, and the JMAP protocol chatter from verbosity 0 to 3.

Some tests produce huge amounts of protocol chatter output, which makes the other output hard to see.  With the protocol chatter moved to verbosity 3, verbosity 2 becomes useful for seeing the other verbose output without it.