### PR TITLE
Add clangd cache files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.tar.gz
 *.tar.bz2
 *~
+.cache/
 .clang-format
 .deps
 .dirstamp


### PR DESCRIPTION
The clangd LSP server keeps a cache of indexed source files in the .cache directory. Ignore it just like the compile_commands.json file.