### PR TITLE
jmap_calendar: gate Calendar/set schedulingEnabled on ACL_ADMIN

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharee_scheduling_enabled
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharee_scheduling_enabled
@@ -1,0 +1,81 @@
+#!perl
+use Cassandane::Tiny;
+
+# Don't allow a read-only user of a shared calendar to write schedulingEnabled.
+sub test_calendar_set_sharee_scheduling_enabled ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $admintalk = $self->{adminstore}->get_client();
+    my $service = $self->{instance}->get_service('http');
+
+    xlog $self, 'create owner account "victim"';
+
+    my $victim = $self->{instance}->create_user('victim');
+
+    xlog $self, 'manifold creates a calendar';
+    my $victim_cal = $victim->calendars->create({ name => 'Victim Calendar' });
+    $victim_cal->share_with('cassandane' => [ qw( mayReadItems ) ]);
+
+    xlog $self, 'sharee Calendar/get confirms scheduling is on (default)';
+    my $res = $jmap->request([
+        ['Calendar/get', {
+            accountId  => 'victim',
+            ids        => [ $victim_cal->id ],
+            properties => [ 'id', 'schedulingEnabled', 'myRights' ],
+        } ],
+    ]);
+
+    $self->assert_cmp_deeply(
+        superhashof({
+            accountId => 'victim',
+            list => [ superhashof({
+                schedulingEnabled => jtrue(),
+                myRights          => superhashof({
+                    mayReadItems => jtrue(),
+                    mayWriteAll  => jfalse(),
+                }),
+            }) ],
+        }),
+        $res->sentence_named('Calendar/get')->arguments,
+        "re-gotten calendar looks as expected",
+    );
+
+    xlog $self, 'sharee Calendar/set tries to disable scheduling';
+    $res = $jmap->request([
+        ['Calendar/set', {
+            accountId => 'victim',
+            update => {
+                $victim_cal->id => {
+                    schedulingEnabled => JSON::false,
+                },
+            },
+        } ],
+    ]);
+
+    # The write must be rejected -- if the calendar appears in {updated},
+    # the sharee has flipped a shared annotation across the auth boundary.
+    $self->assert(
+        ! exists $res->sentence_named('Calendar/set')->arguments->{updated}{$victim_cal->id},
+        "read-only sharee must not be allowed to update schedulingEnabled on the owner's calendar",
+    );
+
+    $self->assert(
+        exists $res->sentence_named('Calendar/set')->arguments->{notUpdated}{$victim_cal->id},
+        'expected the calendar in notUpdated',
+    );
+
+    xlog $self, 'shared annotation is unchanged: Calendar/get still true';
+    $res = $jmap->request([
+        ['Calendar/get', {
+            accountId  => 'victim',
+            ids        => [$victim_cal->id],
+            properties => [ 'schedulingEnabled' ],
+        }],
+    ]);
+
+    $self->assert_equals(
+        JSON::true,
+        $res->sentence_named('Calendar/get')->arguments->{list}[0]{schedulingEnabled},
+        "sharee's attempted Calendar/set must not have changed the calendar-wide scheduling-enabled annotation",
+    );
+}

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -2195,6 +2195,20 @@ static void setcalendars_update(jmap_req_t *req,
             jmap_parser_invalid(&parser, "shareWith");
         }
     }
+
+    /* schedulingEnabled writes a shared annotation, unlike the rest of
+     * setcalendar_writeprops() which writes per-user annotations.  Don't let a
+     * sharee with only JACL_READITEMS disable scheduling on the sharer's
+     * calendar!
+     */
+    if (props.schedulingEnabled >= 0) {
+        if (!jmap_hasrights(req, mboxname, ACL_ADMIN)) {
+            /* Probably should be "forbidden", but that isn't how this function
+             * works (yet?) */
+            jmap_parser_invalid(&parser, "schedulingEnabled");
+        }
+    }
+
     if (json_array_size(parser.invalid)) {
         *err = json_pack("{s:s, s:O}",
                 "type", "invalidProperties",


### PR DESCRIPTION
setcalendar_writeprops() writes schedulingEnabled to the shared scheduling-enabled annotation, unlike other places where the /set is setting per-user annotations for personal properties.  Allowing a share target to write schedulingEnabled is an access control violation.

Didn't touch setcalendars_create, because it requires JACL_CREATECHILD on the parent and the creator becomes the calendar's owner, so the authz story is good.