### PR TITLE
add an option for "always use compact ids"

### DIFF
--- a/cassandane/Cassandane/Cyrus/MailboxVersion.pm
+++ b/cassandane/Cassandane/Cyrus/MailboxVersion.pm
@@ -218,6 +218,70 @@ sub disable_compact_ids
     $self->assert_str_equals("", $res->stderr);
 }
 
+# Returns true if the $COMPACT_EMAILIDS key is present in the user's
+# conversations database on the given instance, which is not the same question
+# as whether the user gets compact ids: with "compact_ids: always" configured,
+# a user with no key still gets them.
+sub compact_ids_key_is_set
+{
+    my ($self, $user, $instance) = @_;
+
+    $user //= "cassandane";
+    $instance //= $self->{instance};
+
+    my $outfile = $instance->{basedir} . "/conv-dump-$user.txt";
+
+    $instance->run_command({ cyrus => 1,
+                             redirects => { stdout => $outfile } },
+                           'ctl_conversationsdb', '-d', $user);
+
+    return slurp_file($outfile) =~ m/^\$COMPACT_EMAILIDS\t/m ? 1 : 0;
+}
+
+# Remove the key behind Cyrus's back, the way a stray replication event or a
+# database rebuild might.
+sub delete_compact_ids_key
+{
+    my ($self, $user, $instance) = @_;
+
+    $user //= "cassandane";
+    $instance //= $self->{instance};
+
+    xlog $self, "Delete the \$COMPACT_EMAILIDS key for $user";
+
+    my $dbfile = $instance->get_conf_user_file($user, 'conversations');
+    my $engine = $instance->{config}->get('conversations_db');
+
+    $instance->run_dbcommand($dbfile, $engine,
+                             [ 'DELETE', '$COMPACT_EMAILIDS' ]);
+}
+
+# Assert that the ids the server hands out for the first message in the
+# mailbox have the given shape.  Ids are computed at read time, so the same
+# message answers to a different id once the setting changes.
+sub assert_email_id_shape
+{
+    my ($self, $want) = @_;
+
+    my %prefix = (compact => [ 'S', 'A' ], legacy => [ 'M', 'T' ]);
+    my $prefix = $prefix{$want} or die "unknown id shape '$want'";
+
+    my $res = $self->{jmap}->CallMethods([
+        [ 'Email/query', {}, 'R1' ],
+        [ 'Email/get', {
+            '#ids' => {
+                resultOf => 'R1', name => 'Email/query', path => '/ids',
+            },
+            properties => [ 'threadId' ],
+        }, 'R2' ],
+    ]);
+
+    my $email = $res->[1][1]{list}[0];
+    $self->assert_not_null($email);
+    $self->assert_matches(qr/^$prefix->[0]/, $email->{id});
+    $self->assert_matches(qr/^$prefix->[1]/, $email->{threadId});
+}
+
 sub lookup_email_id
 {
     my ($self, $oldid) = @_;

--- a/cassandane/Cassandane/Cyrus/MailboxVersion.pm
+++ b/cassandane/Cassandane/Cyrus/MailboxVersion.pm
@@ -219,6 +219,70 @@ sub disable_compact_ids
     $self->assert_str_equals("", $res->stderr);
 }
 
+# Returns true if the $COMPACT_EMAILIDS key is present in the user's
+# conversations database on the given instance, which is not the same question
+# as whether the user gets compact ids: with "compact_ids: always" configured,
+# a user with no key still gets them.
+sub compact_ids_key_is_set
+{
+    my ($self, $user, $instance) = @_;
+
+    $user //= "cassandane";
+    $instance //= $self->{instance};
+
+    my $outfile = $instance->{basedir} . "/conv-dump-$user.txt";
+
+    $instance->run_command({ cyrus => 1,
+                             redirects => { stdout => $outfile } },
+                           'ctl_conversationsdb', '-d', $user);
+
+    return slurp_file($outfile) =~ m/^\$COMPACT_EMAILIDS\t/m ? 1 : 0;
+}
+
+# Remove the key behind Cyrus's back, the way a stray replication event or a
+# database rebuild might.
+sub delete_compact_ids_key
+{
+    my ($self, $user, $instance) = @_;
+
+    $user //= "cassandane";
+    $instance //= $self->{instance};
+
+    xlog $self, "Delete the \$COMPACT_EMAILIDS key for $user";
+
+    my $dbfile = $instance->get_conf_user_file($user, 'conversations');
+    my $engine = $instance->{config}->get('conversations_db');
+
+    $instance->run_dbcommand($dbfile, $engine,
+                             [ 'DELETE', '$COMPACT_EMAILIDS' ]);
+}
+
+# Assert that the ids the server hands out for the first message in the
+# mailbox have the given shape.  Ids are computed at read time, so the same
+# message answers to a different id once the setting changes.
+sub assert_email_id_shape
+{
+    my ($self, $want) = @_;
+
+    my %prefix = (compact => [ 'S', 'A' ], legacy => [ 'M', 'T' ]);
+    my $prefix = $prefix{$want} or die "unknown id shape '$want'";
+
+    my $res = $self->{jmap}->CallMethods([
+        [ 'Email/query', {}, 'R1' ],
+        [ 'Email/get', {
+            '#ids' => {
+                resultOf => 'R1', name => 'Email/query', path => '/ids',
+            },
+            properties => [ 'threadId' ],
+        }, 'R2' ],
+    ]);
+
+    my $email = $res->[1][1]{list}[0];
+    $self->assert_not_null($email);
+    $self->assert_matches(qr/^$prefix->[0]/, $email->{id});
+    $self->assert_matches(qr/^$prefix->[1]/, $email->{threadId});
+}
+
 sub lookup_email_id
 {
     my ($self, $oldid) = @_;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -289,6 +289,9 @@ magic(MailboxLegacyDirs => sub {
 magic(CrossDomains => sub {
     shift->config_set(crossdomains => 'yes');
 });
+magic(CompactIdsAlways => sub {
+    shift->config_set(compact_ids => 'always');
+});
 magic(Conversations => sub {
     shift->config_set(conversations => 'yes');
 });

--- a/cassandane/tiny-tests/MailboxVersion/compactids_always_new_user
+++ b/cassandane/tiny-tests/MailboxVersion/compactids_always_new_user
@@ -1,0 +1,16 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_compactids_always_new_user
+    :min_version_3_13 :CompactIdsAlways
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+
+    xlog $self, "Create a user without asking for compactids";
+    $admintalk->create('user.other');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    xlog $self, "The setting is recorded in the new conversations db anyway";
+    $self->assert_num_equals(1, $self->compact_ids_key_is_set('other'));
+}

--- a/cassandane/tiny-tests/MailboxVersion/compactids_always_overrides_db
+++ b/cassandane/tiny-tests/MailboxVersion/compactids_always_overrides_db
@@ -1,0 +1,20 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_compactids_always_overrides_db
+    :min_version_3_13 :CompactIdsAlways
+    ($self)
+{
+    xlog $self, "Deliver a message to have something with an id";
+    $self->make_message("test compactids");
+
+    $self->assert_num_equals(1, $self->compact_ids_key_is_set());
+    $self->assert_email_id_shape('compact');
+
+    xlog $self, "Lose the per-user setting, as a stray sync might";
+    $self->delete_compact_ids_key();
+    $self->assert_num_equals(0, $self->compact_ids_key_is_set());
+
+    xlog $self, "The config still says compact, so the ids stay compact";
+    $self->assert_email_id_shape('compact');
+}

--- a/cassandane/tiny-tests/MailboxVersion/compactids_always_refuses_disable
+++ b/cassandane/tiny-tests/MailboxVersion/compactids_always_refuses_disable
@@ -1,0 +1,28 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_compactids_always_refuses_disable
+    :min_version_3_13 :CompactIdsAlways
+    ($self)
+{
+    $self->make_message("test compactids");
+    $self->assert_email_id_shape('compact');
+
+    xlog $self, "ctl_conversationsdb -I off is refused, and says why";
+    my $res = $self->{instance}->run_command_capture(
+        {
+            cyrus => 1,
+            handlers => {
+                exited_abnormally => sub ($child, $code) { return $code },
+            },
+        },
+        qw(ctl_conversationsdb -v -I off cassandane),
+    );
+
+    $self->assert_num_not_equals(0, $res->status);
+    $self->assert_matches(qr/compact_ids is set to "always"/, $res->stderr);
+
+    xlog $self, "And nothing changed";
+    $self->assert_num_equals(1, $self->compact_ids_key_is_set());
+    $self->assert_email_id_shape('compact');
+}

--- a/cassandane/tiny-tests/MailboxVersion/compactids_always_survives_replication
+++ b/cassandane/tiny-tests/MailboxVersion/compactids_always_survives_replication
@@ -1,0 +1,35 @@
+#!perl
+use Cassandane::Tiny;
+
+# A mailbox arriving from a peer that didn't send COMPACT_EMAILIDS deletes the
+# key for the whole user, since absence on the wire is indistinguishable from
+# an explicit "off".  With compact_ids set to "always", replication must not be
+# able to leave either end handing out legacy ids.
+sub test_compactids_always_survives_replication
+    :min_version_3_13 :CompactIdsAlways :Replication
+    ($self)
+{
+    $self->make_message("test compactids");
+    $self->assert_email_id_shape('compact');
+
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    $self->assert_num_equals(1, $self->compact_ids_key_is_set());
+    $self->assert_num_equals(1,
+        $self->compact_ids_key_is_set('cassandane', $self->{replica}));
+
+    xlog $self, "Lose the key on the replica, then sync again";
+    $self->delete_compact_ids_key('cassandane', $self->{replica});
+    $self->assert_num_equals(0,
+        $self->compact_ids_key_is_set('cassandane', $self->{replica}));
+
+    $self->make_message("test compactids again");
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    xlog $self, "The master restored it, and never handed out legacy ids";
+    $self->assert_num_equals(1,
+        $self->compact_ids_key_is_set('cassandane', $self->{replica}));
+    $self->assert_email_id_shape('compact');
+}

--- a/cassandane/tiny-tests/MailboxVersion/compactids_per_user_honors_db
+++ b/cassandane/tiny-tests/MailboxVersion/compactids_per_user_honors_db
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+# The default setting is unchanged, and this is what it costs: lose the key and
+# the user silently starts seeing legacy ids.
+sub test_compactids_per_user_honors_db
+    :min_version_3_13
+    ($self)
+{
+    $self->make_message("test compactids");
+
+    $self->assert_num_equals(1, $self->compact_ids_key_is_set());
+    $self->assert_email_id_shape('compact');
+
+    $self->delete_compact_ids_key();
+
+    $self->assert_num_equals(0, $self->compact_ids_key_is_set());
+    $self->assert_email_id_shape('legacy');
+}

--- a/cassandane/tiny-tests/MailboxVersion/cyrus_indexfile_20
+++ b/cassandane/tiny-tests/MailboxVersion/cyrus_indexfile_20
@@ -110,10 +110,10 @@ sub test_cyrus_indexfile_20 ($self)
     ]);
 
     my $email_id = $res->[0][1]{ids}[0];
-    $self->assert_not_null($email_id);
+    $self->assert_matches(qr/^S/, $email_id);
 
-    my $cid = $res->[1][1]{list}[0]{threadId} =~ s/^T//r;
-    $self->assert_not_null($cid);
+    my $cid = $res->[1][1]{list}[0]{threadId};
+    $self->assert_matches(qr/^A/, $cid);
 
     $cid =~ s/^A//;
     $cid = unpack('H*', decode_base64jmap($cid));

--- a/changes/next/cyr-2794-always-compact
+++ b/changes/next/cyr-2794-always-compact
@@ -1,0 +1,33 @@
+Description:
+
+New :imapdconf:`compact_ids` option, which can enable compact JMAP object ids
+for every user regardless of their per-user conversations database setting.
+
+
+Documentation:
+
+:imapdconf:`compact_ids`, :cyrusman:`ctl_conversationsdb(8)` (which also gains
+documentation for its previously undocumented **-I** and **-U** options)
+
+
+Config changes:
+
+compact_ids (new)
+
+
+Upgrade instructions:
+
+None to upgrade; the default, "per-user", is the existing behaviour.
+
+To enable the new "always" setting, first migrate every user: reconstruct all
+mailboxes to index version 20 or later, upgrade every conversations database
+with "ctl_conversationsdb -U", and enable compact ids per user with
+"ctl_conversationsdb -I on".  Only then set compact_ids to "always", which will
+prevent the setting from being turned off again for any user.  Set it
+identically on all servers that replicate to one another or that participate in
+the same murder.
+
+
+GitHub issue:
+
+None

--- a/docsrc/reference/manpages/systemcommands/ctl_conversationsdb.rst
+++ b/docsrc/reference/manpages/systemcommands/ctl_conversationsdb.rst
@@ -19,6 +19,7 @@ Synopsis
     **ctl_conversationsdb** [ -C *config-file* ] **-u** *userid* < text
     **ctl_conversationsdb** [ -C *config-file* ] [ **-v** ] [ **-z** | **-b** | **-R** ] *userid*
     **ctl_conversationsdb** [ -C *config-file* ] [ **-v** ] [ **-z** | **-b** | **-R** ] **-r**
+    **ctl_conversationsdb** [ -C *config-file* ] [ **-v** ] **-I** *switch* *userid*
 
 Description
 ===========
@@ -124,6 +125,25 @@ Options
     If given with **-b**, allows splitting of conversations during the
     rewrite.   Only do this if changing the maximum conversation size
     and you need to split those existing conversations.
+
+.. option:: -U, --upgrade
+
+    Upgrade the conversations database for user *userid* to the current
+    version, recalculating counts as needed.
+
+.. option:: -I switch, --enable-compact-emailids switch
+
+    Enable or disable compact ids for user *userid*, where *switch* is one
+    of ``1``, ``on`` or ``yes`` to enable, or ``0``, ``off`` or ``no`` to
+    disable.
+
+    Compact ids may only be enabled once the user's conversations database
+    is at version 2 or later and every one of the user's mailboxes is at
+    index version 20 or later; both are checked, and enabling fails if
+    either is not yet true.  Use **-U** and :cyrusman:`reconstruct(8)` to
+    get there.
+
+    Disabling fails if :imapdconf:`compact_ids` is set to ``always``.
 
 Examples
 ========

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -133,6 +133,11 @@ EXPORTED char *conversations_getmboxpath(const char *mboxname)
     return fname;
 }
 
+static int _compactids_always(void)
+{
+    return config_getenum(IMAPOPT_COMPACT_IDS) == IMAP_ENUM_COMPACT_IDS_ALWAYS;
+}
+
 static int _init_counted(struct conversations_state *state,
                          const char *val, int vallen)
 {
@@ -375,12 +380,16 @@ EXPORTED int conversations_open_path_version(const char *fname,
        otherwise we assume v0 unless/until we read VERSIONKEY
     */
     struct stat sbuf;
+    int is_new = 0;
     if (!stat(fname, &sbuf))
         open->s.version = 0;
-    else if (version)
-        open->s.version = version;
-    else
-        open->s.version = CONVERSATIONS_VERSION;
+    else {
+        is_new = 1;
+        if (version)
+            open->s.version = version;
+        else
+            open->s.version = CONVERSATIONS_VERSION;
+    }
 
     /* open db */
     int flags = CYRUSDB_CREATE | (shared ? (CYRUSDB_SHARED|CYRUSDB_NOCRC) : CYRUSDB_CONVERT);
@@ -407,6 +416,31 @@ EXPORTED int conversations_open_path_version(const char *fname,
     /* are compactids enabled? */
     cyrusdb_fetch(open->s.db, IDKEY, strlen(IDKEY), &val, &vallen, &open->s.txn);
     if (vallen) open->s.compact_emailids = 1;
+    else if (_compactids_always()) {
+        /* The config says to ignore the per-user setting entirely.  We still
+         * honor the db version, since compact ids can't be generated from a v1
+         * database - but complain about it, don't silently hand out legacy
+         * ids! -- rjbs, 2026-08-06
+         */
+        if (open->s.version >= 2) {
+            open->s.compact_emailids = 1;
+
+            /* a brand new database gets the setting recorded, so that the
+             * on-disk state doesn't depend on the config staying set */
+            if (is_new && !shared)
+                conversations_enable_compactids(&open->s, 1);
+        }
+        else {
+            /* once per process is plenty: this shouldn't happen ever, but if
+             * it does, this would get called *a lot* */
+            static int warned_v1 = 0;
+            if (!warned_v1++) {
+                syslog(LOG_ERR, "compact_ids is \"always\" but %s is version %d:"
+                                " falling back to legacy ids",
+                       fname, open->s.version);
+            }
+        }
+    }
 
     /* load or initialize counted flags */
     cyrusdb_fetch(open->s.db, CFKEY, strlen(CFKEY), &val, &vallen, &open->s.txn);

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -3624,6 +3624,17 @@ EXPORTED int conversations_enable_compactids(struct conversations_state *state,
 {
     int r;
 
+    /* refusing here is the whole point of the "always" setting: it's not
+     * enough to ignore the flag when reading, because replication will
+     * happily delete it out from under us. -- rjbs, 2026-08-06
+     */
+    if (!enable && _compactids_always()) {
+        syslog(LOG_NOTICE, "compact_ids is \"always\":"
+                           " refusing to disable compactids for %s",
+               state->userid ? state->userid : "<unknown>");
+        return 0;
+    }
+
     if (enable) {
         char vbuf[16];
         snprintf(vbuf, sizeof(vbuf), "%d", enable);

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -444,6 +444,15 @@ static int do_compactids(const char *userid, int enable)
     struct conversations_state *state = NULL;
     int r;
 
+    if (!enable &&
+        config_getenum(IMAPOPT_COMPACT_IDS) == IMAP_ENUM_COMPACT_IDS_ALWAYS) {
+        fprintf(stderr,
+                "cannot disable compactids for user '%s':"
+                " compact_ids is set to \"always\"\n",
+                userid);
+        return IMAP_MAILBOX_BADFORMAT;
+    }
+
     r = conversations_open_user(userid, 0/*shared*/, &state);
     if (r) return r;
 

--- a/imap/ctl_conversationsdb.c
+++ b/imap/ctl_conversationsdb.c
@@ -1186,6 +1186,15 @@ int main(int argc, char **argv)
                 !strcasecmp(optarg, "on") || !strcasecmp(optarg, "yes")) {
                 enable_compactids = 1;
             }
+            else if (!strcmp(optarg, "0") ||
+                     !strcasecmp(optarg, "off") || !strcasecmp(optarg, "no")) {
+                enable_compactids = 0;
+            }
+            else {
+                /* don't let a typo silently mean "disable" */
+                fprintf(stderr, "unrecognised value for -I: %s\n", optarg);
+                usage(argv[0]);
+            }
             mode = ENABLE_COMPACTIDS;
             rock = (void *) &enable_compactids;
             break;
@@ -1257,7 +1266,7 @@ static int usage(const char *name)
     fprintf(stderr, "    -U             upgrade to latest version of conversations.db\n");
     fprintf(stderr, "    -A             audit conversations DB counts\n");
     fprintf(stderr, "    -F             check folder names\n");
-    fprintf(stderr, "    -I switch      enable/disable compact emailids.  1/on/yes to enable\n");
+    fprintf(stderr, "    -I switch      enable/disable compact emailids.  1/on/yes or 0/off/no\n");
     fprintf(stderr, "    -T dir         store temporary data for audit in dir\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "    -r             recursive mode: username is a prefix\n");

--- a/lib/imapoptions/compact_ids
+++ b/lib/imapoptions/compact_ids
@@ -1,0 +1,29 @@
+Name: compact_ids
+Type: ENUM
+Allowed-Values: per-user always
+Default-Value: per-user
+Last-Modified: UNRELEASED
+
+Whether compact JMAP object ids are enabled for a user.
+
+Compact ids affect quite a few JMAP types as well as IMAP OBJECTID data items.
+
+*per-user*
+    Compact ids are enabled for a user only if the ``$COMPACT_EMAILIDS``
+    key is present in that user's conversations database, as set by
+    :cyrusman:`ctl_conversationsdb(8)` ``-I on`` or by the ``COMPACTIDS``
+    argument to the IMAP ``CREATE`` command.
+
+*always*
+    Compact ids are enabled for every user, whether or not their conversations
+    database says so, and the setting cannot be turned off for an individual
+    user.  Newly created users have the setting written to their conversations
+    database as well.
+
+    Do not set this until every user has been migrated!  Compact email ids
+    are derived from the nanosecond internaldate, which only exists in
+    mailbox index version 20 and later, and compact ids in general require
+    conversations database version 2 or later.
+
+    "always" will be the only effective setting in the next major release, and
+    this option will be removed.


### PR DESCRIPTION
The real future is "only compact ids exist", but we need a release that supports both for the sake of upgrading.  This lets a fully upgraded install (and I know of a pretty big one) set this option and avoid any sort of fluke with conversation db downgrading a user.

In the next next release, we'll strip this option along with fat ids entirely.