### PR TITLE
jmap_mailbox: check mailbox naming policy before creating or renaming

### DIFF
--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_set_name_badchars
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_set_name_badchars
@@ -1,0 +1,49 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_mailbox_set_name_badchars ($self)
+{
+    my $jmap = $self->{jmap};
+
+    # These are all legal UTF-8, and all survive IMAP UTF-7 encoding
+    # untouched, but Cyrus forbids them in a mailbox name.
+    my @badnames = ('10% Happier', 'yes/no', 'a;b', 'c|d', 'e<f', '"g"', 'h\\i');
+
+    xlog $self, "create a mailbox to rename";
+    my $res = $jmap->CallMethods([
+        ['Mailbox/set', { create => {
+            victim => { name => 'victim', parentId => undef, role => undef },
+        }}, 'R0'],
+    ]);
+    my $victim = $res->[0][1]{created}{victim}{id};
+    $self->assert_not_null($victim);
+
+    my sub assert_bad_name($name) {
+        my $res = $jmap->CallMethods([
+            ['Mailbox/set', {
+                create => { bad => { name => $name, parentId => undef } },
+                update => { $victim => { name => $name } },
+            }, 'R1'],
+        ]);
+
+        $self->assert_str_equals('invalidProperties',
+                                 $res->[0][1]{notCreated}{bad}{type});
+        $self->assert_deep_equals(['name'],
+                                  $res->[0][1]{notCreated}{bad}{properties});
+
+        $self->assert_str_equals('invalidProperties',
+                                 $res->[0][1]{notUpdated}{$victim}{type});
+        $self->assert_deep_equals(['name'],
+                                  $res->[0][1]{notUpdated}{$victim}{properties});
+    }
+
+    assert_bad_name($_) for @badnames;
+
+    xlog $self, "a name made only of legal characters still works";
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', { create => {
+            good => { name => "10 percent happier (#1) + a bit", parentId => undef },
+        }}, 'R2'],
+    ]);
+    $self->assert_not_null($res->[0][1]{created}{good}{id});
+}

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -2111,6 +2111,11 @@ static void _mbox_create(jmap_req_t *req, struct mboxset_args *args,
         goto done;
     }
 
+    if (mboxname_policycheck(mboxname)) {
+        jmap_parser_invalid(&parser, "name");
+        goto done;
+    }
+
     /* Skip role updates in first iteration */
     if (args->specialuse && *args->specialuse) {
         if (mode == _MBOXSET_SKIP) {
@@ -2511,6 +2516,15 @@ static void _mbox_update(jmap_req_t *req, struct mboxset_args *args,
                 goto done;
             }
             ptrarray_append(&strpool, newmboxname);
+
+            /* If the JMAP name didn't change then it can't be at fault -- the
+             * old mailbox exists, so its name already passed policy -- and we
+             * must be moving it somewhere we can't. */
+            if (mboxname_policycheck(newmboxname)) {
+                jmap_parser_invalid(&parser,
+                                    name == oldname ? "parentId" : "name");
+                goto done;
+            }
 
             r = jmap_mboxlist_lookup(newmboxname, NULL, NULL);
             if (r == 0) {


### PR DESCRIPTION
IMAP UTF-7 only encodes non-ASCII (and '&'), so printable US-ASCII in a JMAP mailbox name reaches the internal mailbox name untouched -- including characters that mboxname_policycheck() forbids, such as '%'.  Those names were rejected further down in mboxlist_createmailbox() or mboxlist_renametree(), which meant the client got a serverFail and the admin got an IOERROR in the log, for what is really just a bad argument.

Run the policy check ourselves and report invalidProperties instead.