### PR TITLE
cassandane: allow globbing of test case names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 .libs
 .sphinx-build.stamp
 /.tags
-README
 VERSION
 Makefile.in
 Makefile

--- a/cassandane/Cassandane/Fixture/TestPlan/Alpha/GlobOne.pm
+++ b/cassandane/Cassandane/Fixture/TestPlan/Alpha/GlobOne.pm
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+# A fixture suite for Cassandane::Test::TestPlan.  Not a test!  See the
+# README in the parent directory.
+package Cassandane::Fixture::TestPlan::Alpha::GlobOne;
+use strict;
+use warnings;
+
+use base qw(Cassandane::Unit::TestCase);
+
+sub test_alpha { }
+sub test_beta { }
+sub test_gamma_slow { }
+
+1;

--- a/cassandane/Cassandane/Fixture/TestPlan/Alpha/GlobTwo.pm
+++ b/cassandane/Cassandane/Fixture/TestPlan/Alpha/GlobTwo.pm
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+# A fixture suite for Cassandane::Test::TestPlan.  Not a test!  See the
+# README in the parent directory.
+package Cassandane::Fixture::TestPlan::Alpha::GlobTwo;
+use strict;
+use warnings;
+
+use base qw(Cassandane::Unit::TestCase);
+
+sub test_alpha { }
+sub test_delta { }
+
+1;

--- a/cassandane/Cassandane/Fixture/TestPlan/Alpha/Other.pm
+++ b/cassandane/Cassandane/Fixture/TestPlan/Alpha/Other.pm
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+# A fixture suite for Cassandane::Test::TestPlan.  Not a test!  See the
+# README in the parent directory.
+package Cassandane::Fixture::TestPlan::Alpha::Other;
+use strict;
+use warnings;
+
+use base qw(Cassandane::Unit::TestCase);
+
+sub test_alpha { }
+
+1;

--- a/cassandane/Cassandane/Fixture/TestPlan/Alpha/Shared.pm
+++ b/cassandane/Cassandane/Fixture/TestPlan/Alpha/Shared.pm
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+# A fixture suite for Cassandane::Test::TestPlan.  Not a test!  See the
+# README in the parent directory.
+package Cassandane::Fixture::TestPlan::Alpha::Shared;
+use strict;
+use warnings;
+
+use base qw(Cassandane::Unit::TestCase);
+
+sub test_from_alpha { }
+
+1;

--- a/cassandane/Cassandane/Fixture/TestPlan/Beta/GlobThree.pm
+++ b/cassandane/Cassandane/Fixture/TestPlan/Beta/GlobThree.pm
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+# A fixture suite for Cassandane::Test::TestPlan.  Not a test!  See the
+# README in the parent directory.
+package Cassandane::Fixture::TestPlan::Beta::GlobThree;
+use strict;
+use warnings;
+
+use base qw(Cassandane::Unit::TestCase);
+
+sub test_alpha { }
+
+1;

--- a/cassandane/Cassandane/Fixture/TestPlan/Beta/Shared.pm
+++ b/cassandane/Cassandane/Fixture/TestPlan/Beta/Shared.pm
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+# A fixture suite for Cassandane::Test::TestPlan.  Not a test!  See the
+# README in the parent directory.
+package Cassandane::Fixture::TestPlan::Beta::Shared;
+use strict;
+use warnings;
+
+use base qw(Cassandane::Unit::TestCase);
+
+sub test_from_beta { }
+
+1;

--- a/cassandane/Cassandane/Fixture/TestPlan/README
+++ b/cassandane/Cassandane/Fixture/TestPlan/README
@@ -1,0 +1,21 @@
+These are not tests.  Nothing here is run by a normal Cassandane run, and
+nothing here tests Cyrus.
+
+The suites under Alpha/ and Beta/ are fixture data for Cassandane::Test::
+TestPlan, which is a test of the test planner itself.  Rather than making
+assertions about the real tests, which are changing all the time, the test
+planner tester builds a plan over these two roots instead, and asserts exactly
+which tests a given specification selects.  The tests here are all empty subs,
+because the planner only ever looks at their names.
+
+Moving these under, say, cassandane/data/ would be nice but would not work.  In
+Cassandane::Unit::TestPlan a test root is two things at once: a directory path
+*resolved against the current working directory*, and -- after s{/}{::}g -- the
+package prefix the suites are loaded by.  Those two readings coincide only
+because testrunner.pl does "use lib '.'" and runs from cassandane/, so the one
+@INC entry and the cwd are the same directory.  You can't fix that by fiddling
+@INC in the tests.
+
+Future changes to the test running code might address this, but the goal now is
+to land *these* improvements, not *every* improvement, so they live here, and
+you get this README file.

--- a/cassandane/Cassandane/Test/TestPlan.pm
+++ b/cassandane/Cassandane/Test/TestPlan.pm
@@ -228,9 +228,12 @@ sub test_negation ($self)
     $self->assert_plan(['GlobOne', '!GlobOne.*a'],
                        [qw(Alpha::GlobOne.gamma_slow)]);
 
-    # denial beats permission, whichever order they're given in
-    $self->assert_plan(['GlobOne.beta', '!GlobOne.beta'], []);
-    $self->assert_plan(['!GlobOne.beta', 'GlobOne.beta'], []);
+    # denial beats permission, whichever order they're given in -- which here
+    # leaves nothing to run at all, so see test_empty_plan_dies
+    $self->assert_plan_dies(['GlobOne.beta', '!GlobOne.beta'],
+                            qr{test plan is empty});
+    $self->assert_plan_dies(['!GlobOne.beta', 'GlobOne.beta'],
+                            qr{test plan is empty});
 
     # Denying a test that doesn't exist is not an error, unlike selecting one:
     # the "suppress" setting names tests to deny, and has to keep working
@@ -302,8 +305,38 @@ sub test_unmatched_test_dies ($self)
     $self->assert_plan_dies(['GlobOne.nonesuch', 'GlobTwo.nonesuch'],
                             qr{No tests matched: GlobOne\.nonesuch, GlobTwo\.nonesuch});
 
-    # a specification that matches, but is then denied, is not an error
-    $self->assert_plan(['GlobOne.beta', '!GlobOne.beta'], []);
+    # A specification that matches and is then denied is not this error: it did
+    # match, so it's never named here.  It dies for being empty instead.
+    $self->assert_plan_dies(['GlobOne.beta', '!GlobOne.beta'],
+                            qr{test plan is empty});
+}
+
+sub test_empty_plan_dies ($self)
+{
+    # Every specification here is individually fine, so nothing above catches
+    # these.  A plan that runs nothing still has to be fatal, because "OK (0
+    # tests)" is exactly what a run where everything passed looks like.
+
+    # a suite, denied
+    $self->assert_plan_dies(['GlobOne', '!GlobOne'], qr{test plan is empty});
+
+    # a suite, denied a test at a time
+    $self->assert_plan_dies(['GlobTwo', '!GlobTwo.alpha', '!GlobTwo.delta'],
+                            qr{test plan is empty});
+
+    # a whole root, denied
+    $self->assert_plan_dies([$BETA, "!$BETA"], qr{test plan is empty});
+
+    # a glob, denied by the same glob
+    $self->assert_plan_dies(['Glob*.alpha', '!Glob*.alpha'],
+                            qr{test plan is empty});
+
+    # ... and one survivor anywhere in the plan is enough to save it
+    $self->assert_plan(['GlobOne', '!GlobOne.alpha', '!GlobOne.beta'],
+                       [qw(Alpha::GlobOne.gamma_slow)]);
+
+    $self->assert_plan(['GlobOne', 'Other', '!GlobOne'],
+                       [qw(Alpha::Other.alpha)]);
 }
 
 sub test_slow_flags ($self)

--- a/cassandane/Cassandane/Test/TestPlan.pm
+++ b/cassandane/Cassandane/Test/TestPlan.pm
@@ -200,24 +200,27 @@ sub test_unmatched_test_dies ($self)
 
 sub test_slow_flags ($self)
 {
-    # naming a slow test explicitly turns the skip_slow filter off
+    # asking for a whole suite isn't asking for its slow tests
     $self->assert_slow_flag(['GlobOne'], 'skip_slow', 1);
     $self->assert_slow_flag(['GlobOne.beta'], 'skip_slow', 1);
-    $self->assert_slow_flag(['GlobOne.gamma_slow'], 'skip_slow', 0);
 
-    # ... but a negated one doesn't
+    # but selecting only slow tests is, however you spell it
+    $self->assert_slow_flag(['GlobOne.gamma_slow'], 'skip_slow', 0);
+    $self->assert_slow_flag(['GlobOne.*_slow'], 'skip_slow', 0);
+    $self->assert_slow_flag(['GlobOne.gamma*'], 'skip_slow', 0);
+
+    # ... whereas selecting a mixture of slow and regular tests isn't
+    $self->assert_slow_flag(['GlobOne.*'], 'skip_slow', 1);
+
+    # ... and neither is denying a slow test
     $self->assert_slow_flag(['GlobOne', '!GlobOne.gamma_slow'], 'skip_slow', 1);
 
-    # A glob doesn't count as naming it explicitly, so this selects the slow
-    # test and then filters it back out again.  That is arguably wrong; if it
-    # gets fixed, this expectation should change.
-    $self->assert_slow_flag(['GlobOne.*_slow'], 'skip_slow', 1);
-
-    # symmetrically, naming a non-slow test turns slow_only off
+    # slow_only works the same way, in reverse
+    $self->assert_slow_flag(['GlobOne.beta'], 'slow_only', 0, slow_only => 1);
+    $self->assert_slow_flag(['GlobOne.*a'], 'slow_only', 0, slow_only => 1);
     $self->assert_slow_flag(['GlobOne.gamma_slow'], 'slow_only', 1,
                             slow_only => 1);
-    $self->assert_slow_flag(['GlobOne.beta'], 'slow_only', 0,
-                            slow_only => 1);
+    $self->assert_slow_flag(['GlobOne.*'], 'slow_only', 1, slow_only => 1);
 }
 
 1;

--- a/cassandane/Cassandane/Test/TestPlan.pm
+++ b/cassandane/Cassandane/Test/TestPlan.pm
@@ -233,6 +233,26 @@ sub test_root_shadowing ($self)
     $self->assert_plan(['Alpha::Glob*'], \@GLOB_STAR);
 }
 
+sub test_plus_stands_in_for_star ($self)
+{
+    # '+' means '*' wherever a '*' could have gone, because '*' can't be typed
+    # unquoted at a shell prompt
+    $self->assert_plan(['Glob+'], \@GLOB_STAR);
+    $self->assert_plan(['+'], \@EVERYTHING);
+    $self->assert_plan(['GlobOne.b+'], [qw(Alpha::GlobOne.beta)]);
+    $self->assert_plan(['Glob+.alpha'],
+                       [qw(Alpha::GlobOne.alpha
+                           Alpha::GlobTwo.alpha
+                           Beta::GlobThree.alpha)]);
+    $self->assert_plan(['Glob+', '!Glob+.alpha'],
+                       [qw(Alpha::GlobOne.beta
+                           Alpha::GlobOne.gamma_slow
+                           Alpha::GlobTwo.delta)]);
+
+    # the two spellings are interchangeable within one specification
+    $self->assert_plan(['Glob+.b*'], [qw(Alpha::GlobOne.beta)]);
+}
+
 sub test_unrecognised_spec_dies ($self)
 {
     $self->assert_plan_dies(['Nonesuch'],

--- a/cassandane/Cassandane/Test/TestPlan.pm
+++ b/cassandane/Cassandane/Test/TestPlan.pm
@@ -26,6 +26,16 @@ my @GLOB_ONE = qw(Alpha::GlobOne.alpha
                   Alpha::GlobOne.beta
                   Alpha::GlobOne.gamma_slow);
 
+# Everything matching "Glob*", which spans both roots.
+my @GLOB_STAR = (@GLOB_ONE, qw(Alpha::GlobTwo.alpha
+                               Alpha::GlobTwo.delta
+                               Beta::GlobThree.alpha));
+
+# Every test in the fixture.
+my @EVERYTHING = (@GLOB_STAR, qw(Alpha::Other.alpha
+                                 Alpha::Shared.from_alpha
+                                 Beta::Shared.from_beta));
+
 # Build a plan over the fixture roots and schedule @$specs on it.
 sub _fixture_plan ($specs, %opts)
 {
@@ -111,15 +121,68 @@ sub test_whole_root ($self)
     $self->assert_plan([$BETA],
                        [qw(Beta::GlobThree.alpha Beta::Shared.from_beta)]);
 
-    $self->assert_plan([$ALPHA, $BETA],
-                       [@GLOB_ONE,
-                        qw(Alpha::GlobTwo.alpha
-                           Alpha::GlobTwo.delta
-                           Alpha::Other.alpha
-                           Alpha::Shared.from_alpha
-                           Beta::GlobThree.alpha
-                           Beta::Shared.from_beta)]);
+    $self->assert_plan([$ALPHA, $BETA], \@EVERYTHING);
 }
+
+sub test_suite_globs ($self)
+{
+    # a globbed suite name is collected from every root, unlike an exact one
+    $self->assert_plan(['Glob*'], \@GLOB_STAR);
+    $self->assert_plan(['Shared*'],
+                       [qw(Alpha::Shared.from_alpha Beta::Shared.from_beta)]);
+
+    $self->assert_plan(['GlobT*'],
+                       [qw(Alpha::GlobTwo.alpha
+                           Alpha::GlobTwo.delta
+                           Beta::GlobThree.alpha)]);
+
+    $self->assert_plan(['*One'], \@GLOB_ONE);
+
+    # ... and on its own it means every suite there is
+    $self->assert_plan(['*'], \@EVERYTHING);
+
+    # a fully qualified glob is confined to the root it names
+    $self->assert_plan(['Cassandane::Fixture::TestPlan::Beta::Glob*'],
+                       [qw(Beta::GlobThree.alpha)]);
+
+    # a glob matching no suite is as fatal as a name that doesn't exist
+    $self->assert_plan_dies(['Nonesuch*'],
+                            qr{Unrecognised test specification: Nonesuch\*});
+
+    # a globbed suite can be negated, or have parts of it negated
+    $self->assert_plan(['Glob*', '!GlobTwo'],
+                       [@GLOB_ONE, 'Beta::GlobThree.alpha']);
+
+    $self->assert_plan(['Glob*', '!Glob*.alpha'],
+                       [qw(Alpha::GlobOne.beta
+                           Alpha::GlobOne.gamma_slow
+                           Alpha::GlobTwo.delta)]);
+}
+
+sub test_suite_globs_with_tests ($self)
+{
+    $self->assert_plan(['Glob*.alpha'],
+                       [qw(Alpha::GlobOne.alpha
+                           Alpha::GlobTwo.alpha
+                           Beta::GlobThree.alpha)]);
+
+    $self->assert_plan(['Glob*.*a'],
+                       [qw(Alpha::GlobOne.alpha
+                           Alpha::GlobOne.beta
+                           Alpha::GlobTwo.alpha
+                           Alpha::GlobTwo.delta
+                           Beta::GlobThree.alpha)]);
+
+    # The test only has to exist in one of the suites the glob matched.  If it
+    # had to exist in all of them, a suite glob would be almost unusable with a
+    # test name after it.
+    $self->assert_plan(['Glob*.delta'], [qw(Alpha::GlobTwo.delta)]);
+
+    # ... but if it turns up in none of them, that's still a mistake
+    $self->assert_plan_dies(['Glob*.nonesuch'],
+                            qr{No tests matched: Glob\*\.nonesuch});
+}
+
 
 sub test_test_globs ($self)
 {
@@ -164,6 +227,10 @@ sub test_root_shadowing ($self)
     # ... so the only way to name the other one is in full
     $self->assert_plan(['Cassandane::Fixture::TestPlan::Beta::Shared'],
                        [qw(Beta::Shared.from_beta)]);
+
+    # A leading component that doesn't resolve is dropped rather than being
+    # treated as a constraint, so naming a root doesn't confine a glob to it.
+    $self->assert_plan(['Alpha::Glob*'], \@GLOB_STAR);
 }
 
 sub test_unrecognised_spec_dies ($self)

--- a/cassandane/Cassandane/Test/TestPlan.pm
+++ b/cassandane/Cassandane/Test/TestPlan.pm
@@ -20,6 +20,12 @@ my $BETA  = 'Cassandane/Fixture/TestPlan/Beta';
 # read "Alpha::GlobOne.beta" instead of the full package name.
 my $PREFIX = 'Cassandane::Fixture::TestPlan::';
 
+# The whole of Alpha::GlobOne, which most of these cases select one way or
+# another.  Note that it has both slow and regular tests in it.
+my @GLOB_ONE = qw(Alpha::GlobOne.alpha
+                  Alpha::GlobOne.beta
+                  Alpha::GlobOne.gamma_slow);
+
 # Build a plan over the fixture roots and schedule @$specs on it.
 sub _fixture_plan ($specs, %opts)
 {
@@ -69,18 +75,12 @@ sub assert_slow_flag ($self, $specs, $flag, $expect, %opts)
 
 sub test_whole_suite ($self)
 {
-    $self->assert_plan(['GlobOne'],
-                       [qw(Alpha::GlobOne.alpha
-                           Alpha::GlobOne.beta
-                           Alpha::GlobOne.gamma_slow)]);
+    $self->assert_plan(['GlobOne'], \@GLOB_ONE);
 
     $self->assert_plan(['Other'], [qw(Alpha::Other.alpha)]);
 
     $self->assert_plan(['GlobOne', 'Other'],
-                       [qw(Alpha::GlobOne.alpha
-                           Alpha::GlobOne.beta
-                           Alpha::GlobOne.gamma_slow
-                           Alpha::Other.alpha)]);
+                       [@GLOB_ONE, 'Alpha::Other.alpha']);
 }
 
 sub test_single_test ($self)
@@ -89,10 +89,6 @@ sub test_single_test ($self)
 
     $self->assert_plan(['GlobOne.beta', 'GlobTwo.delta'],
                        [qw(Alpha::GlobOne.beta Alpha::GlobTwo.delta)]);
-
-    # a test that doesn't exist is not an error -- it just quietly selects
-    # nothing.  If that ever becomes an error, this expectation should change.
-    $self->assert_plan(['GlobOne.nonesuch'], []);
 }
 
 sub test_suite_naming ($self)
@@ -106,10 +102,7 @@ sub test_suite_naming ($self)
                   'Cassandane::Fixture::TestPlan::Alpha::GlobOne',
                   'Cassandane/Fixture/TestPlan/Alpha/GlobOne.pm')
     {
-        $self->assert_plan([$spec],
-                           [qw(Alpha::GlobOne.alpha
-                               Alpha::GlobOne.beta
-                               Alpha::GlobOne.gamma_slow)]);
+        $self->assert_plan([$spec], \@GLOB_ONE);
     }
 }
 
@@ -119,10 +112,8 @@ sub test_whole_root ($self)
                        [qw(Beta::GlobThree.alpha Beta::Shared.from_beta)]);
 
     $self->assert_plan([$ALPHA, $BETA],
-                       [qw(Alpha::GlobOne.alpha
-                           Alpha::GlobOne.beta
-                           Alpha::GlobOne.gamma_slow
-                           Alpha::GlobTwo.alpha
+                       [@GLOB_ONE,
+                        qw(Alpha::GlobTwo.alpha
                            Alpha::GlobTwo.delta
                            Alpha::Other.alpha
                            Alpha::Shared.from_alpha
@@ -132,10 +123,7 @@ sub test_whole_root ($self)
 
 sub test_test_globs ($self)
 {
-    $self->assert_plan(['GlobOne.*'],
-                       [qw(Alpha::GlobOne.alpha
-                           Alpha::GlobOne.beta
-                           Alpha::GlobOne.gamma_slow)]);
+    $self->assert_plan(['GlobOne.*'], \@GLOB_ONE);
 
     $self->assert_plan(['GlobOne.*a'],
                        [qw(Alpha::GlobOne.alpha Alpha::GlobOne.beta)]);
@@ -143,9 +131,6 @@ sub test_test_globs ($self)
     $self->assert_plan(['GlobOne.b*'], [qw(Alpha::GlobOne.beta)]);
 
     $self->assert_plan(['GlobOne.*mm*'], [qw(Alpha::GlobOne.gamma_slow)]);
-
-    # a glob is anchored at both ends, so this does not match gamma_slow
-    $self->assert_plan(['GlobOne.mm*'], []);
 }
 
 sub test_negation ($self)
@@ -162,6 +147,12 @@ sub test_negation ($self)
     # denial beats permission, whichever order they're given in
     $self->assert_plan(['GlobOne.beta', '!GlobOne.beta'], []);
     $self->assert_plan(['!GlobOne.beta', 'GlobOne.beta'], []);
+
+    # Denying a test that doesn't exist is not an error, unlike selecting one:
+    # the "suppress" setting names tests to deny, and has to keep working
+    # against a version of Cyrus where the test is gone.
+    $self->assert_plan(['GlobOne', '!GlobOne.nonesuch'], \@GLOB_ONE);
+    $self->assert_plan(['GlobOne', '!GlobOne.zz*'], \@GLOB_ONE);
 }
 
 sub test_root_shadowing ($self)
@@ -186,6 +177,25 @@ sub test_unrecognised_spec_dies ($self)
     # a bad spec is fatal even alongside good ones
     $self->assert_plan_dies(['GlobOne', 'Nonesuch'],
                             qr{Unrecognised test specification: Nonesuch});
+}
+
+sub test_unmatched_test_dies ($self)
+{
+    # Selecting nothing is nearly always a typo, and a run that plans no tests
+    # looks just like a run where everything passed.
+    $self->assert_plan_dies(['GlobOne.nonesuch'],
+                            qr{No tests matched: GlobOne\.nonesuch});
+
+    # a glob that matches nothing is exactly as suspicious
+    $self->assert_plan_dies(['GlobOne.mm*'],
+                            qr{No tests matched: GlobOne\.mm\*});
+
+    # every bad specification is named, not just the first one found
+    $self->assert_plan_dies(['GlobOne.nonesuch', 'GlobTwo.nonesuch'],
+                            qr{No tests matched: GlobOne\.nonesuch, GlobTwo\.nonesuch});
+
+    # a specification that matches, but is then denied, is not an error
+    $self->assert_plan(['GlobOne.beta', '!GlobOne.beta'], []);
 }
 
 sub test_slow_flags ($self)

--- a/cassandane/Cassandane/Test/TestPlan.pm
+++ b/cassandane/Cassandane/Test/TestPlan.pm
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+package Cassandane::Test::TestPlan;
+use strict;
+use warnings;
+use experimental 'signatures';
+
+use base qw(Cassandane::Unit::TestCase);
+use Cassandane::Unit::TestPlan;
+
+# We plan against a fixture tree rather than the real test roots so that these
+# expectations don't have to be rewritten every time a suite is added or
+# renamed.  See Cassandane/Fixture/TestPlan/README.  Like the real roots, these
+# are relative to the cassandane directory, which is where a test run's cwd is.
+my $ALPHA = 'Cassandane/Fixture/TestPlan/Alpha';
+my $BETA  = 'Cassandane/Fixture/TestPlan/Beta';
+
+# Trimmed off both sides of every comparison, so that expectations below can
+# read "Alpha::GlobOne.beta" instead of the full package name.
+my $PREFIX = 'Cassandane::Fixture::TestPlan::';
+
+# Build a plan over the fixture roots and schedule @$specs on it.
+sub _fixture_plan ($specs, %opts)
+{
+    my $plan = Cassandane::Unit::TestPlan->new(
+        test_roots => [ $ALPHA, $BETA ],
+        %opts,
+    );
+    $plan->schedule(@$specs);
+
+    return $plan;
+}
+
+# Assert that scheduling $specs would run exactly the tests in @$expect, each
+# named as "Alpha::GlobOne.beta".  The specs are folded into both sides of the
+# comparison so that a failure says which case failed.
+sub assert_plan ($self, $specs, $expect, $desc = undef)
+{
+    my $label = $desc // join q{ }, @$specs;
+    my @got = map {; s/^\Q$PREFIX\E//r } _fixture_plan($specs)->list();
+
+    $self->assert_str_equals(
+        join(q{ }, "$label:", sort @$expect),
+        join(q{ }, "$label:", sort @got),
+    );
+}
+
+# Assert that scheduling $specs dies, with a message matching $qr.
+sub assert_plan_dies ($self, $specs, $qr)
+{
+    eval { _fixture_plan($specs) };
+    my $e = $@;
+
+    $self->assert_matches($qr, $e);
+}
+
+# Assert that scheduling $specs leaves the $flag ('skip_slow' or 'slow_only')
+# set to $expect.  %opts seeds the plan's initial flags.
+sub assert_slow_flag ($self, $specs, $flag, $expect, %opts)
+{
+    my $plan = _fixture_plan($specs, %opts);
+
+    $self->assert_str_equals(
+        join(q{ }, @$specs, $flag, $expect),
+        join(q{ }, @$specs, $flag, $plan->{$flag}),
+    );
+}
+
+sub test_whole_suite ($self)
+{
+    $self->assert_plan(['GlobOne'],
+                       [qw(Alpha::GlobOne.alpha
+                           Alpha::GlobOne.beta
+                           Alpha::GlobOne.gamma_slow)]);
+
+    $self->assert_plan(['Other'], [qw(Alpha::Other.alpha)]);
+
+    $self->assert_plan(['GlobOne', 'Other'],
+                       [qw(Alpha::GlobOne.alpha
+                           Alpha::GlobOne.beta
+                           Alpha::GlobOne.gamma_slow
+                           Alpha::Other.alpha)]);
+}
+
+sub test_single_test ($self)
+{
+    $self->assert_plan(['GlobOne.beta'], [qw(Alpha::GlobOne.beta)]);
+
+    $self->assert_plan(['GlobOne.beta', 'GlobTwo.delta'],
+                       [qw(Alpha::GlobOne.beta Alpha::GlobTwo.delta)]);
+
+    # a test that doesn't exist is not an error -- it just quietly selects
+    # nothing.  If that ever becomes an error, this expectation should change.
+    $self->assert_plan(['GlobOne.nonesuch'], []);
+}
+
+sub test_suite_naming ($self)
+{
+    # a suite can be named by its bare moniker, by any suffix of its package
+    # name, or by the whole thing -- with either separator
+    for my $spec ('GlobOne',
+                  'Alpha::GlobOne',
+                  'Alpha.GlobOne',
+                  'Alpha/GlobOne',
+                  'Cassandane::Fixture::TestPlan::Alpha::GlobOne',
+                  'Cassandane/Fixture/TestPlan/Alpha/GlobOne.pm')
+    {
+        $self->assert_plan([$spec],
+                           [qw(Alpha::GlobOne.alpha
+                               Alpha::GlobOne.beta
+                               Alpha::GlobOne.gamma_slow)]);
+    }
+}
+
+sub test_whole_root ($self)
+{
+    $self->assert_plan([$BETA],
+                       [qw(Beta::GlobThree.alpha Beta::Shared.from_beta)]);
+
+    $self->assert_plan([$ALPHA, $BETA],
+                       [qw(Alpha::GlobOne.alpha
+                           Alpha::GlobOne.beta
+                           Alpha::GlobOne.gamma_slow
+                           Alpha::GlobTwo.alpha
+                           Alpha::GlobTwo.delta
+                           Alpha::Other.alpha
+                           Alpha::Shared.from_alpha
+                           Beta::GlobThree.alpha
+                           Beta::Shared.from_beta)]);
+}
+
+sub test_test_globs ($self)
+{
+    $self->assert_plan(['GlobOne.*'],
+                       [qw(Alpha::GlobOne.alpha
+                           Alpha::GlobOne.beta
+                           Alpha::GlobOne.gamma_slow)]);
+
+    $self->assert_plan(['GlobOne.*a'],
+                       [qw(Alpha::GlobOne.alpha Alpha::GlobOne.beta)]);
+
+    $self->assert_plan(['GlobOne.b*'], [qw(Alpha::GlobOne.beta)]);
+
+    $self->assert_plan(['GlobOne.*mm*'], [qw(Alpha::GlobOne.gamma_slow)]);
+
+    # a glob is anchored at both ends, so this does not match gamma_slow
+    $self->assert_plan(['GlobOne.mm*'], []);
+}
+
+sub test_negation ($self)
+{
+    $self->assert_plan([$BETA, '!GlobThree'], [qw(Beta::Shared.from_beta)]);
+    $self->assert_plan([$BETA, '~GlobThree'], [qw(Beta::Shared.from_beta)]);
+
+    $self->assert_plan(['GlobOne', '!GlobOne.beta'],
+                       [qw(Alpha::GlobOne.alpha Alpha::GlobOne.gamma_slow)]);
+
+    $self->assert_plan(['GlobOne', '!GlobOne.*a'],
+                       [qw(Alpha::GlobOne.gamma_slow)]);
+
+    # denial beats permission, whichever order they're given in
+    $self->assert_plan(['GlobOne.beta', '!GlobOne.beta'], []);
+    $self->assert_plan(['!GlobOne.beta', 'GlobOne.beta'], []);
+}
+
+sub test_root_shadowing ($self)
+{
+    # Shared exists in both roots, and the earlier root wins ...
+    $self->assert_plan(['Shared'], [qw(Alpha::Shared.from_alpha)]);
+    $self->assert_plan(['Beta::Shared'], [qw(Alpha::Shared.from_alpha)]);
+
+    # ... so the only way to name the other one is in full
+    $self->assert_plan(['Cassandane::Fixture::TestPlan::Beta::Shared'],
+                       [qw(Beta::Shared.from_beta)]);
+}
+
+sub test_unrecognised_spec_dies ($self)
+{
+    $self->assert_plan_dies(['Nonesuch'],
+                            qr{Unrecognised test specification: Nonesuch});
+
+    $self->assert_plan_dies(['Nonesuch.beta'],
+                            qr{Unrecognised test specification: Nonesuch\.beta});
+
+    # a bad spec is fatal even alongside good ones
+    $self->assert_plan_dies(['GlobOne', 'Nonesuch'],
+                            qr{Unrecognised test specification: Nonesuch});
+}
+
+sub test_slow_flags ($self)
+{
+    # naming a slow test explicitly turns the skip_slow filter off
+    $self->assert_slow_flag(['GlobOne'], 'skip_slow', 1);
+    $self->assert_slow_flag(['GlobOne.beta'], 'skip_slow', 1);
+    $self->assert_slow_flag(['GlobOne.gamma_slow'], 'skip_slow', 0);
+
+    # ... but a negated one doesn't
+    $self->assert_slow_flag(['GlobOne', '!GlobOne.gamma_slow'], 'skip_slow', 1);
+
+    # A glob doesn't count as naming it explicitly, so this selects the slow
+    # test and then filters it back out again.  That is arguably wrong; if it
+    # gets fixed, this expectation should change.
+    $self->assert_slow_flag(['GlobOne.*_slow'], 'skip_slow', 1);
+
+    # symmetrically, naming a non-slow test turns slow_only off
+    $self->assert_slow_flag(['GlobOne.gamma_slow'], 'slow_only', 1,
+                            slow_only => 1);
+    $self->assert_slow_flag(['GlobOne.beta'], 'slow_only', 0,
+                            slow_only => 1);
+}
+
+1;

--- a/cassandane/Cassandane/Test/TestPlan.pm
+++ b/cassandane/Cassandane/Test/TestPlan.pm
@@ -116,6 +116,27 @@ sub test_suite_naming ($self)
     }
 }
 
+sub test_separators_are_interchangeable ($self)
+{
+    # The separator between a suite and a test is no different from the one
+    # between the parts of a suite name: '.', '/' and '::' are all flattened to
+    # the same thing before anything looks at the specification, which is why
+    # nothing can tell which one you typed.
+    for my $spec ('GlobOne.beta', 'GlobOne/beta', 'GlobOne::beta')
+    {
+        $self->assert_plan([$spec], [qw(Alpha::GlobOne.beta)]);
+    }
+
+    # ... and that stays true once both halves are globbed.  Only GlobOne has a
+    # test starting with 'b', so the other suites the glob matched contribute
+    # nothing rather than making this an error.
+    for my $spec ('Glob*.b*', 'Glob*/b*', 'Glob*::b*',
+                  'Glob+.b+', 'Glob+/b+', 'Glob+::b+')
+    {
+        $self->assert_plan([$spec], [qw(Alpha::GlobOne.beta)]);
+    }
+}
+
 sub test_whole_root ($self)
 {
     $self->assert_plan([$BETA],

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -544,7 +544,8 @@ sub _schedule
     }
 }
 
-# Returns ($neg, $ostype, $ospath, $testname)
+# Returns a list of [ $neg, $ostype, $ospath, $testname ] tuples.  It's a list
+# because one specification can name more than one suite.
 sub _parse_test_spec
 {
     my ($self, $name) = @_;
@@ -572,16 +573,16 @@ sub _parse_test_spec
     foreach my $candidate (@paths) {
         foreach my $root ($self->{test_roots}->@*)
         {
-            return ($neg, 'd', $candidate, undef)
+            return [ $neg, q{d}, $candidate, undef ]
                 if ($root eq $candidate);
 
             my $fpath = $candidate;
             $fpath = "$root/$candidate"
                 if ("$root/" ne substr($candidate, 0, length($root)+1));
 
-            return ($neg, 'd', $fpath, undef)
+            return [ $neg, q{d}, $fpath, undef ]
                 if ( -d $fpath );
-            return ($neg, 'f', "$fpath.pm", undef)
+            return [ $neg, q{f}, "$fpath.pm", undef ]
                 if ( -f "$fpath.pm" );
 
             my $test;
@@ -592,9 +593,9 @@ sub _parse_test_spec
                 if ($test =~ /\*/) {
                     my @hunks = split /\*+/, $test, -1;
                     my $regex = join q{.*}, map {; quotemeta } @hunks;
-                    return ($neg, 'f', "$fpath.pm", qr{\A$regex\z});
+                    return [ $neg, q{f}, "$fpath.pm", qr{\A$regex\z} ];
                 } else {
-                    return ($neg, 'f', "$fpath.pm", $test)
+                    return [ $neg, q{f}, "$fpath.pm", $test ]
                 }
             }
         }
@@ -645,22 +646,25 @@ sub schedule
 
     foreach my $name (@names)
     {
-        my ($neg, $type, $path, $test) = $self->_parse_test_spec($name);
+        foreach my $spec ($self->_parse_test_spec($name))
+        {
+            my ($neg, $type, $path, $test) = @$spec;
 
-        if ($type eq 'd')
-        {
-            opendir DIR, $path
-                or die "Cannot open directory $path for reading: $!";
-            while ($_ = readdir DIR)
+            if ($type eq 'd')
             {
-                next unless m/\.pm$/;
-                $self->_schedule($neg, "$path/$_", undef, $name);
+                opendir DIR, $path
+                    or die "Cannot open directory $path for reading: $!";
+                while ($_ = readdir DIR)
+                {
+                    next unless m/\.pm$/;
+                    $self->_schedule($neg, "$path/$_", undef, $name);
+                }
+                closedir DIR;
             }
-            closedir DIR;
-        }
-        else
-        {
-            $self->_schedule($neg, $path, $test, $name);
+            else
+            {
+                $self->_schedule($neg, $path, $test, $name);
+            }
         }
     }
 

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -647,28 +647,6 @@ sub schedule
     {
         my ($neg, $type, $path, $test) = $self->_parse_test_spec($name);
 
-        # slow test explicitly requested by name, so turn off the filter
-        if (defined $test
-            and ! ref $test
-            and $test =~ m/_slow$/
-            and ! $neg
-            and $self->{skip_slow})
-        {
-            xlog "$name was explicitly requested. Enabling slow tests!";
-            $self->{skip_slow} = 0;
-        }
-
-        # non-slow test explicitly requested by name, so turn off slow-only
-        if (defined $test
-            and ! ref $test
-            and $test !~ m/_slow$/
-            and ! $neg
-            and $self->{slow_only})
-        {
-            xlog "$name was explicitly requested. Enabling regular tests!";
-            $self->{slow_only} = 0;
-        }
-
         if ($type eq 'd')
         {
             opendir DIR, $path
@@ -695,6 +673,10 @@ sub schedule
 #
 # A specification that matches no tests at all is fatal.  It's nearly always a
 # typo, and you think everything passed, but actually nothing ran.
+#
+# A specification that matches only slow tests turns the skip_slow filter off,
+# on the grounds that you can't have meant to ask for tests that were then
+# going to be filtered out from under you.
 sub _check_selections ($self)
 {
     my @matches = map {; $_->_spec_matches() }
@@ -702,6 +684,23 @@ sub _check_selections ($self)
 
     my @unmatched = map {; $_->{spec} } grep {; ! $_->{tests}->@* } @matches;
     die "No tests matched: " . join(q{, }, @unmatched) . "\n" if @unmatched;
+
+    foreach my $match (@matches)
+    {
+        my @tests = $match->{tests}->@*;
+
+        if ($self->{skip_slow} and not grep {; $_ !~ m/_slow$/ } @tests)
+        {
+            xlog "$match->{spec} was explicitly requested. Enabling slow tests!";
+            $self->{skip_slow} = 0;
+        }
+
+        if ($self->{slow_only} and not grep {; $_ =~ m/_slow$/ } @tests)
+        {
+            xlog "$match->{spec} was explicitly requested. Enabling regular tests!";
+            $self->{slow_only} = 0;
+        }
+    }
 }
 
 sub check_sanity

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -756,7 +756,7 @@ sub _check_selections ($self)
     {
         my @tests = $matched{$spec}->@*;
 
-        if ($self->{skip_slow} and not grep {; $_ !~ m/_slow$/ } @tests)
+        if ($self->{skip_slow} and @tests == grep {; /_slow$/ } @tests)
         {
             xlog "$spec was explicitly requested. Enabling slow tests!";
             $self->{skip_slow} = 0;

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -450,7 +450,7 @@ use File::Path qw(mkpath);
 use Data::Dumper;
 use Cassandane::Util::Log;
 
-my @test_roots = (
+my @default_test_roots = (
     'Cassandane/Test',
     'Cassandane/Cyrus',
 );
@@ -465,6 +465,7 @@ sub new
         maxworkers => delete $opts{maxworkers} || 1,
         skip_slow => delete $opts{skip_slow} // 1,
         slow_only => delete $opts{slow_only} // 0,
+        test_roots => delete $opts{test_roots} // [ @default_test_roots ],
     };
     die "Unknown options: " . join(' ', keys %opts)
         if scalar %opts;
@@ -514,7 +515,7 @@ sub _schedule
 # Returns ($neg, $ostype, $ospath, $testname)
 sub _parse_test_spec
 {
-    my ($name) = @_;
+    my ($self, $name) = @_;
 
     my ($neg, $path) = ($name =~ m/^([~!]?)(.*)$/);
     $path =~ s/\.pm$//g;
@@ -537,7 +538,7 @@ sub _parse_test_spec
     }
 
     foreach my $candidate (@paths) {
-        foreach my $root (@test_roots)
+        foreach my $root ($self->{test_roots}->@*)
         {
             return ($neg, 'd', $candidate, undef)
                 if ($root eq $candidate);
@@ -579,7 +580,7 @@ sub _default_test_list
 
     my %default;
     my %suppressed;
-    @default{@test_roots} = ();
+    @default{$self->{test_roots}->@*} = ();
 
     # skip suppressions
     foreach my $s (@tosuppress) {
@@ -612,7 +613,7 @@ sub schedule
 
     foreach my $name (@names)
     {
-        my ($neg, $type, $path, $test) = _parse_test_spec($name);
+        my ($neg, $type, $path, $test) = $self->_parse_test_spec($name);
 
         # slow test explicitly requested by name, so turn off the filter
         if (defined $test
@@ -679,7 +680,7 @@ sub check_sanity
             }
             close $fh;
         },
-    }, @test_roots);
+    }, $self->{test_roots}->@*);
 
     # collect tiny-tests directories that exist on disk
     my %real_tt_dirs;

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -544,8 +544,47 @@ sub _schedule
     }
 }
 
+# Turns a glob into an anchored regex.  '*' matches any run of characters,
+# including none, and nothing else is special.
+sub _glob_to_regex ($glob)
+{
+    my @hunks = split /\*+/, $glob, -1;
+    my $regex = join q{.*}, map {; quotemeta } @hunks;
+
+    return qr{\A$regex\z};
+}
+
+# Given a path whose last component may be a glob -- ".../Cyrus/JMAP*" --
+# return the suite files it matches, in sorted order.  Returns nothing if
+# there's no glob to expand, or if the directory that would hold the matches
+# doesn't exist, so the caller can use this to ask "is this a globbed suite
+# name?" without checking first.
+sub _glob_suites ($path)
+{
+    my ($dir, $leaf) = ($path =~ m/^(.*)\/([^\/]+)$/);
+    return if not defined $leaf;
+    return if $leaf !~ m/\*/;
+    return if not -d $dir;
+
+    my $regex = _glob_to_regex($leaf);
+
+    opendir my $dh, $dir
+        or die "Cannot open directory $dir for reading: $!";
+    my @moniker = grep {; my $m = $_; $m =~ s/\.pm$// and $m =~ $regex }
+                  readdir $dh;
+    closedir $dh;
+
+    return map {; "$dir/$_" } sort @moniker;
+}
+
 # Returns a list of [ $neg, $ostype, $ospath, $testname ] tuples.  It's a list
 # because one specification can name more than one suite.
+#
+# An exact name is resolved against the roots in order and the first hit wins,
+# so that a suite in an earlier root shadows one of the same name later on.  A
+# globbed suite name is instead collected from every root, because "JMAP*"
+# plainly means all of them and not just the ones in whichever root happened to
+# match first.
 sub _parse_test_spec
 {
     my ($self, $name) = @_;
@@ -571,6 +610,8 @@ sub _parse_test_spec
     }
 
     foreach my $candidate (@paths) {
+        my @globbed;
+
         foreach my $root ($self->{test_roots}->@*)
         {
             return [ $neg, q{d}, $candidate, undef ]
@@ -585,20 +626,25 @@ sub _parse_test_spec
             return [ $neg, q{f}, "$fpath.pm", undef ]
                 if ( -f "$fpath.pm" );
 
+            # the whole thing may be a globbed suite name, with no test named
+            push @globbed, map {; [ $neg, q{f}, $_, undef ] }
+                           _glob_suites($fpath);
+
             my $test;
             ($fpath, $test) = ($fpath =~ m/^(.*)\/([^\/]+)$/);
             next unless defined $test;
 
-            if ( -f "$fpath.pm" ) {
-                if ($test =~ /\*/) {
-                    my @hunks = split /\*+/, $test, -1;
-                    my $regex = join q{.*}, map {; quotemeta } @hunks;
-                    return [ $neg, q{f}, "$fpath.pm", qr{\A$regex\z} ];
-                } else {
-                    return [ $neg, q{f}, "$fpath.pm", $test ]
-                }
-            }
+            $test = _glob_to_regex($test) if $test =~ m/\*/;
+
+            return [ $neg, q{f}, "$fpath.pm", $test ]
+                if ( -f "$fpath.pm" );
+
+            # ... or the suite part alone may be globbed, with a test after it
+            push @globbed, map {; [ $neg, q{f}, $_, $test ] }
+                           _glob_suites($fpath);
         }
+
+        return @globbed if @globbed;
     }
 
     die "Unrecognised test specification: $name";
@@ -683,25 +729,40 @@ sub schedule
 # going to be filtered out from under you.
 sub _check_selections ($self)
 {
-    my @matches = map {; $_->_spec_matches() }
-                  $self->{schedule}->@{ sort keys $self->{schedule}->%* };
+    # One specification can be applied to several suites, so gather up
+    # everything it matched before judging it.  "JMAP*.blob_get" has done its
+    # job if any one of the JMAP suites has that test; it's only a mistake if
+    # none of them do.
+    my (@specs, %matched);
 
-    my @unmatched = map {; $_->{spec} } grep {; ! $_->{tests}->@* } @matches;
+    foreach my $item ($self->{schedule}->@{ sort keys $self->{schedule}->%* })
+    {
+        foreach my $match ($item->_spec_matches())
+        {
+            my $spec = $match->{spec};
+
+            push @specs, $spec if not $matched{$spec};
+            $matched{$spec} //= [];
+            push $matched{$spec}->@*, $match->{tests}->@*;
+        }
+    }
+
+    my @unmatched = grep {; ! $matched{$_}->@* } @specs;
     die "No tests matched: " . join(q{, }, @unmatched) . "\n" if @unmatched;
 
-    foreach my $match (@matches)
+    foreach my $spec (@specs)
     {
-        my @tests = $match->{tests}->@*;
+        my @tests = $matched{$spec}->@*;
 
         if ($self->{skip_slow} and not grep {; $_ !~ m/_slow$/ } @tests)
         {
-            xlog "$match->{spec} was explicitly requested. Enabling slow tests!";
+            xlog "$spec was explicitly requested. Enabling slow tests!";
             $self->{skip_slow} = 0;
         }
 
         if ($self->{slow_only} and not grep {; $_ =~ m/_slow$/ } @tests)
         {
-            xlog "$match->{spec} was explicitly requested. Enabling regular tests!";
+            xlog "$spec was explicitly requested. Enabling regular tests!";
             $self->{slow_only} = 0;
         }
     }

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -4,6 +4,7 @@
 package Cassandane::Unit::TestPlanItem;
 use strict;
 use warnings;
+use experimental 'signatures';
 use IO::Handle;
 use POSIX;
 use Time::HiRes qw(time);
@@ -66,13 +67,44 @@ sub _deny
 
 sub _allow
 {
-    my ($self, $test) = @_;
+    my ($self, $test, $spec) = @_;
+
+    # $spec is the specification this came from, kept only so that
+    # _spec_matches can complain about it by the name the user typed
+    push $self->{allowed_specs}->@*, { spec => $spec, test => $test };
+
     if (ref $test) {
         push @{ $self->{allowed_patterns} }, $test;
     } else {
         $self->{allowed}->{$test} = 1;
     }
     return;
+}
+
+# Returns, for each specification that selected individual tests from this
+# suite, a hash of the specification and the test names it actually matched.
+# Loading the suite is the only way to know those names, so this can't be
+# answered until scheduling is finished.
+#
+# Missing suppressions aren't a problem.  We want to keep working against
+# versions of Cyrus where the named test doesn't exist.
+sub _spec_matches ($self)
+{
+    return if not $self->{allowed_specs};
+
+    my @names = map {; s/^test_//r } $self->_get_loaded_suite()->names()->@*;
+
+    my @matches;
+    foreach my $allowed ($self->{allowed_specs}->@*)
+    {
+        my $test = $allowed->{test};
+        my @matched = ref $test ? grep {; $_ =~ $test } @names
+                                : grep {; $_ eq $test } @names;
+
+        push @matches, { spec => $allowed->{spec}, tests => \@matched };
+    }
+
+    return @matches;
 }
 
 package Cassandane::Unit::Worker;
@@ -481,7 +513,7 @@ sub _get_item
 
 sub _schedule
 {
-    my ($self, $neg, $path, $testname) = @_;
+    my ($self, $neg, $path, $testname, $spec) = @_;
     return if ($path =~ m/\/TestCase\.pm$/);
 
     my $suite = $path;
@@ -507,7 +539,7 @@ sub _schedule
         my $item = $self->_get_item($suite);
         if (defined $testname)
         {
-            $item->_allow($testname) if $testname;
+            $item->_allow($testname, $spec) if $testname;
         }
     }
 }
@@ -644,15 +676,32 @@ sub schedule
             while ($_ = readdir DIR)
             {
                 next unless m/\.pm$/;
-                $self->_schedule($neg, "$path/$_", undef);
+                $self->_schedule($neg, "$path/$_", undef, $name);
             }
             closedir DIR;
         }
         else
         {
-            $self->_schedule($neg, $path, $test);
+            $self->_schedule($neg, $path, $test, $name);
         }
     }
+
+    $self->_check_selections();
+}
+
+# Check what the specifications that named individual tests actually selected.
+# This can't happen while they're being parsed, because it needs the suites to
+# be loaded, which can't happen until we know which suites to load.
+#
+# A specification that matches no tests at all is fatal.  It's nearly always a
+# typo, and you think everything passed, but actually nothing ran.
+sub _check_selections ($self)
+{
+    my @matches = map {; $_->_spec_matches() }
+                  $self->{schedule}->@{ sort keys $self->{schedule}->%* };
+
+    my @unmatched = map {; $_->{spec} } grep {; ! $_->{tests}->@* } @matches;
+    die "No tests matched: " . join(q{, }, @unmatched) . "\n" if @unmatched;
 }
 
 sub check_sanity

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -70,7 +70,7 @@ sub _allow
     my ($self, $test, $spec) = @_;
 
     # $spec is the specification this came from, kept only so that
-    # _spec_matches can complain about it by the name the user typed
+    # _get_candidates can complain about it by the name the user typed
     push $self->{allowed_specs}->@*, { spec => $spec, test => $test };
 
     if (ref $test) {
@@ -85,10 +85,7 @@ sub _allow
 # suite, a hash of the specification and the test names it actually matched.
 # Loading the suite is the only way to know those names, so this can't be
 # answered until scheduling is finished.
-#
-# Missing suppressions aren't a problem.  We want to keep working against
-# versions of Cyrus where the named test doesn't exist.
-sub _spec_matches ($self)
+sub _get_candidates ($self)
 {
     return if not $self->{allowed_specs};
 
@@ -742,7 +739,7 @@ sub _check_selections ($self)
 
     foreach my $item ($self->{schedule}->@{ sort keys $self->{schedule}->%* })
     {
-        foreach my $match ($item->_spec_matches())
+        foreach my $match ($item->_get_candidates())
         {
             my $spec = $match->{spec};
 

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -578,11 +578,11 @@ sub _glob_suites ($path)
 }
 
 # Returns a list of [ $neg, $ostype, $ospath, $testname ] tuples.  It's a list
-# because one specification can name more than one suite.
+# because one specification can name more than one test case.
 #
 # An exact name is resolved against the roots in order and the first hit wins,
-# so that a suite in an earlier root shadows one of the same name later on.  A
-# globbed suite name is instead collected from every root, because "JMAP*"
+# so that a test case in an earlier root shadows one of the same name later on.  A
+# globbed test case name is instead collected from every root, because "JMAP*"
 # plainly means all of them and not just the ones in whichever root happened to
 # match first.
 sub _parse_test_spec
@@ -598,6 +598,11 @@ sub _parse_test_spec
     $path =~ s/\/*$//;
 
     $neg = '!' if $neg eq '~';
+
+    # '*' has to be quoted in every shell worth using, so let '+' mean the same
+    # thing.  Neither suite names nor test names can contain a '+', so there's
+    # no loss in functionality.
+    $path =~ s/\+/*/g;
 
     # Allow Cyrus::TesterJMAP and TesterJMAP to work
     my @paths;

--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -717,6 +717,21 @@ sub schedule
     }
 
     $self->_check_selections();
+    $self->_check_not_empty();
+}
+
+# Every specification can be fine, but we still have nothing to run, because a
+# negation can cancel out a selection: "ACL !ACL" is nothing.
+sub _check_not_empty ($self)
+{
+    foreach my $item (values $self->{schedule}->%*)
+    {
+        my @names = map {; s/^test_//r } $item->_get_loaded_suite()->names()->@*;
+
+        return if grep {; $item->_is_allowed($_) } @names;
+    }
+
+    die "No tests to run: the test plan is empty\n";
 }
 
 # Check what the specifications that named individual tests actually selected.

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -165,6 +165,22 @@ if ($@) {
 sub usage
 {
     printf STDERR "Usage: testrunner.pl [options] -f <xml|tap|pretty|prettier> [testname...]\n";
+    print STDERR <<'END';
+
+A testname is a suite, optionally followed by a dot and a test within it.
+Prefixing one with '!' (or '~') excludes it instead:
+
+    JMAPCore                every test in the suite
+    JMAPCore.blob_download  just that test
+    !JMAPCore.blob_download  everything else in the suite
+
+Either part may be a glob, where '*' matches any run of characters:
+
+    JMAP*                   every JMAP suite
+    JMAPCore.blob_*         every blob test in JMAPCore
+    JMAP*.blob_*            both at once
+
+END
     exit(1);
 }
 

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -180,6 +180,9 @@ Either part may be a glob, where '*' matches any run of characters:
     JMAPCore.blob_*         every blob test in JMAPCore
     JMAP*.blob_*            both at once
 
+A '+' is accepted anywhere a '*' would be, so that a glob can be typed
+without having to be quoted against the shell.
+
 END
     exit(1);
 }


### PR DESCRIPTION
My real goal was to make `dar test JMAP*` work.  It took more than the five lines I was hoping for.

First, make the thing testable.  It was critical and untested.

Then, fix the things that testing exposed that seemed goofy: zero-test runs, how slow test selection affected things.

Then, refactoring to allow test case globbing to work at all.

Then the thing itself!

One thing I noticed while in here:  We say "suite" a lot for a test case, but the Test::Unit jargon is "test case".  I'd like us to reduce duplicative jargon.  But that can happen later, this already ate a lot more time than I meant it to!