### PR TITLE
jmap_mailbox: don't return more changes than maxChanges

### DIFF
--- a/cassandane/Cassandane/Util/CRLF.pm
+++ b/cassandane/Cassandane/Util/CRLF.pm
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+package Cassandane::Util::CRLF;
+use strict;
+use warnings;
+use experimental 'signatures';
+use base qw(Exporter);
+
+our @EXPORT = qw(&to_crlf);
+
+# Convert a string's newlines to CRLF, for use where the wire format demands
+# them -- appending a message over IMAP, say.
+#
+# Lines that already end in CRLF are left alone, so this is safe to apply to
+# a string that's already part-converted.
+sub to_crlf ($string)
+{
+    return undef if !defined $string;
+    return $string =~ s/\r?\n/\r\n/gr;
+}
+
+1;

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_not_exceeded
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_not_exceeded
@@ -1,0 +1,119 @@
+#!perl
+use Cassandane::Tiny;
+use Cassandane::Util::CRLF;
+
+# Several mailboxes can legitimately get the same changed modseq at once.
+# A mailbox modseq is the greater of its highestmodseq and its conversations
+# threadmodseq, and one change to any message in a conversation raises
+# threadmodseq in every folder that conversation touches.
+#
+# Mailbox/changes has to report such a group all at once, because the state
+# it hands back is a modseq.  What it must not do is report more than
+# maxChanges to get there -- RFC 8620 §5.2 says "MUST NOT".
+sub test_mailbox_changes_maxchanges_not_exceeded
+    :NoAltNameSpace
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    my $imap = $user->imap;
+    $imap->uid(1);
+
+    xlog $self, "Set up mailboxes";
+    my %mbox = map {; $_ => $user->mailboxes->create({ name => $_ }) }
+               qw( a b c );
+
+    # one thread spanning a and b, so that a change to it touches both
+    my $threaded = to_crlf(<<~'EOF');
+        From: <from@local>
+        To: to@local
+        Subject: test
+        Message-Id: <threaded1@foo>
+        Date: Wed, 7 Dec 2019 22:11:11 +1100
+        MIME-Version: 1.0
+        Content-Type: text/plain
+
+        threaded
+        EOF
+
+    my $reply = to_crlf(<<~'EOF');
+        From: <from@local>
+        To: to@local
+        Subject: test
+        Message-Id: <threaded2@foo>
+        In-Reply-To: <threaded1@foo>
+        Date: Wed, 7 Dec 2019 22:11:12 +1100
+        MIME-Version: 1.0
+        Content-Type: text/plain
+
+        threaded reply
+        EOF
+
+    my $lonely = to_crlf(<<~'EOF');
+        From: <from@local>
+        To: to@local
+        Subject: unrelated
+        Message-Id: <lonely1@foo>
+        Date: Wed, 7 Dec 2019 22:11:13 +1100
+        MIME-Version: 1.0
+        Content-Type: text/plain
+
+        lonely
+        EOF
+
+    xlog $self, "Set up messages";
+    $imap->append('INBOX.a', "(\\Seen)", $threaded) || die $@;
+    $imap->append('INBOX.a', "()", $reply) || die $@;
+    $imap->append('INBOX.b', "(\\Seen)", $threaded) || die $@;
+
+    my $res = $jmap->request([[ 'Mailbox/get', {} ]]);
+    my $state = $res->single_sentence('Mailbox/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Change c on its own, giving one mailbox at one modseq";
+    $imap->append('INBOX.c', "()", $lonely) || die $@;
+
+    xlog $self, "Mark the thread seen, giving a and b at a later modseq";
+    $imap->select("INBOX.a");
+    $imap->store(2, "+flags", "\\Seen");
+
+    xlog $self, "Page through the changes, never exceeding maxChanges";
+    # n.b. never interpolate $maxchanges into a string.  That sets the
+    # scalar's string flag, and JSON::PP then sends it as "2" rather than 2,
+    # which Mailbox/changes quite rightly rejects as invalidArguments.
+    my $maxchanges = 2;
+    my %seen;
+    my $rounds = 0;
+
+    while (1) {
+        $self->assert($rounds++ < 10, "Mailbox/changes did not terminate");
+
+        $res = $jmap->request([
+            [ 'Mailbox/changes', {
+                sinceState => $state,
+                maxChanges => $maxchanges,
+            } ],
+        ]);
+
+        my $changes = $res->single_sentence('Mailbox/changes')->arguments;
+
+        my @got = ($changes->{created}->@*,
+                   $changes->{updated}->@*,
+                   $changes->{destroyed}->@*);
+
+        $self->assert(scalar @got <= $maxchanges,
+                      "returned " . scalar(@got) . " ids, over maxChanges");
+
+        $seen{$_} = 1 for @got;
+
+        $self->assert_str_not_equals($state, $changes->{newState});
+        $state = $changes->{newState};
+
+        last if not $changes->{hasMoreChanges};
+    }
+
+    xlog $self, "All three mailboxes should have been reported";
+    $self->assert_not_null($seen{$mbox{a}->id});
+    $self->assert_not_null($seen{$mbox{b}->id});
+    $self->assert_not_null($seen{$mbox{c}->id});
+}

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_too_small
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_too_small
@@ -1,0 +1,80 @@
+#!perl
+use Cassandane::Tiny;
+use Cassandane::Util::CRLF;
+
+# When a single modseq's worth of changes is larger than maxChanges, there is
+# no intermediate state to hand back.  The client would sync only a partial
+# changeset and then advance its local state.  Oops RFC 8620 §5.2 says to
+# return cannotCalculateChanges.
+sub test_mailbox_changes_maxchanges_too_small
+    :NoAltNameSpace
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    my $imap = $user->imap;
+    $imap->uid(1);
+
+    xlog $self, "Set up mailboxes";
+    my %mbox = map {; $_ => $user->mailboxes->create({ name => $_ }) }
+               qw( a b );
+
+    my $threaded = to_crlf(<<~'EOF');
+        From: <from@local>
+        To: to@local
+        Subject: test
+        Message-Id: <threaded1@foo>
+        Date: Wed, 7 Dec 2019 22:11:11 +1100
+        MIME-Version: 1.0
+        Content-Type: text/plain
+
+        threaded
+        EOF
+
+    my $reply = to_crlf(<<~'EOF');
+        From: <from@local>
+        To: to@local
+        Subject: test
+        Message-Id: <threaded2@foo>
+        In-Reply-To: <threaded1@foo>
+        Date: Wed, 7 Dec 2019 22:11:12 +1100
+        MIME-Version: 1.0
+        Content-Type: text/plain
+
+        threaded reply
+        EOF
+
+    xlog $self, "Set up a thread spanning both mailboxes";
+    $imap->append('INBOX.a', "(\\Seen)", $threaded) || die $@;
+    $imap->append('INBOX.a', "()", $reply) || die $@;
+    $imap->append('INBOX.b', "(\\Seen)", $threaded) || die $@;
+
+    my $res = $jmap->request([[ 'Mailbox/get', {} ]]);
+    my $state = $res->single_sentence('Mailbox/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Mark the thread seen, changing both mailboxes at once";
+    $imap->select("INBOX.a");
+    $imap->store(2, "+flags", "\\Seen");
+
+    xlog $self, "Both mailboxes change together, so maxChanges 1 can't work";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', { sinceState => $state, maxChanges => 1 } ],
+    ]);
+
+    $self->assert_str_equals('cannotCalculateChanges',
+                             $res->single_sentence('error')->arguments->{type});
+
+    xlog $self, "... but asking for both at once does";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+
+    my $changes = $res->single_sentence('Mailbox/changes')->arguments;
+
+    $self->assert_cmp_deeply(
+        bag($mbox{a}->id . "", $mbox{b}->id . ""),
+        $changes->{updated},
+    );
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4153,7 +4153,8 @@ static int _mbox_changes_cmp(const void **pa, const void **pb)
 
 static int _mbox_changes(jmap_req_t *req,
                          struct jmap_changes *changes,
-                         int *only_counts_changed)
+                         int *only_counts_changed,
+                         json_t **err)
 {
     *only_counts_changed = 1;
 
@@ -4191,41 +4192,61 @@ static int _mbox_changes(jmap_req_t *req,
     }
     ptrarray_sort(&updates, _mbox_changes_cmp);
 
-    /* Build result */
+    /* Build result
+     *
+     * Gather up all the changes up to maxChanges, but absolutely not more.  If
+     * we can't fit all the changes in that size, we have to report
+     * cannotCalculateChanges, not overrun.
+     */
     changes->has_more_changes = 0;
     windowmodseq = 0;
-    for (i = 0; i < updates.count; i++) {
+    i = 0;
+    while (i < updates.count) {
         json_t *update = ptrarray_nth(&updates, i);
-        const char *id = json_string_value(json_object_get(update, "id"));
-        modseq_t modseq = json_integer_value(json_object_get(update, "modseq"));
+        modseq_t groupmodseq =
+            (modseq_t) json_integer_value(json_object_get(update, "modseq"));
+        int groupend;
 
-        /* Apply maxChanges, if any. We do overshoot maxChanges in case
-         * the modseqs are not strictly increasing, which must not ever
-         * happen in a sane account. Should the account have any duplicate
-         * modseqs then we report that as an error but gracefully finish
-         * the /changes method. */
-        if (changes->max_changes && ((size_t) i) >= changes->max_changes &&
-            modseq > windowmodseq) {
+        for (groupend = i; groupend < updates.count; groupend++) {
+            update = ptrarray_nth(&updates, groupend);
+            if ((modseq_t) json_integer_value(json_object_get(update, "modseq"))
+                != groupmodseq) {
+                break;
+            }
+        }
+
+        /* groupend is also the number of changes we'd have reported once this
+         * group is done, since we only ever report a prefix */
+        if (changes->max_changes
+            && (size_t) groupend > changes->max_changes) {
             changes->has_more_changes = 1;
             break;
         }
 
-        if (modseq == windowmodseq && windowmodseq) {
-            xsyslog_ev(LOG_ERR, "duplicate modseq in Mailbox/changes",
-                    lf_s("mboxid", id),
-                    lf_llu("modseq", modseq));
+        for ( ; i < groupend; i++) {
+            const char *id;
+
+            update = ptrarray_nth(&updates, i);
+            id = json_string_value(json_object_get(update, "id"));
+
+            if (json_object_get(data.created, id)) {
+                json_array_append_new(changes->created, json_string(id));
+            } else if (json_object_get(data.updated, id)) {
+                json_array_append_new(changes->updated, json_string(id));
+            } else {
+                json_array_append_new(changes->destroyed, json_string(id));
+            }
         }
 
-        if (windowmodseq < modseq)
-            windowmodseq = modseq;
+        windowmodseq = groupmodseq;
+    }
 
-        if (json_object_get(data.created, id)) {
-            json_array_append_new(changes->created, json_string(id));
-        } else if (json_object_get(data.updated, id)) {
-            json_array_append_new(changes->updated, json_string(id));
-        } else {
-            json_array_append_new(changes->destroyed, json_string(id));
-        }
+    if (changes->has_more_changes && !windowmodseq) {
+        /* The first group alone exceeds maxChanges, we must report an error */
+        *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                         "description",
+                         "maxChanges too small to report a whole modseq");
+        goto done;
     }
 
     if ((json_array_size(changes->created) == 0 &&
@@ -4264,10 +4285,14 @@ static int jmap_mailbox_changes(jmap_req_t *req)
 
     /* Search for updates */
     int only_counts_changed = 0;
-    int r = _mbox_changes(req, &changes, &only_counts_changed);
+    int r = _mbox_changes(req, &changes, &only_counts_changed, &err);
     if (r) {
         syslog(LOG_ERR, "jmap: Mailbox/changes: %s", error_message(r));
         jmap_error(req, jmap_server_error(r));
+        goto done;
+    }
+    if (err) {
+        jmap_error(req, err);
         goto done;
     }
 


### PR DESCRIPTION
RFC 8620 section 5.2 says the server MUST ensure the number of ids returned across created, updated and destroyed does not exceed maxChanges, and that where it can't calculate an intermediate state it MUST return cannotCalculateChanges instead.  Mailbox/changes was deliberately overshooting.

The old code seemed to think this couldn't come up, anyway: "duplicate modseqs must not ever happen in a sane account", but that's not right. Two Mailboxes can end up with the same modseq based on the conversations in them.  In fact, I found this happening in our tests, in JMAPMailbox/mailbox_changes_on_thread_counts.