### PR TITLE
contrib: add twom-trace, an eBPF census and benchmark for cyrusdb

### DIFF
--- a/contrib/twom-trace/.gitignore
+++ b/contrib/twom-trace/.gitignore
@@ -1,0 +1,3 @@
+build/
+twom-bench
+dbbench

--- a/contrib/twom-trace/README.md
+++ b/contrib/twom-trace/README.md
@@ -1,0 +1,157 @@
+# twom-trace
+
+Census of twom access patterns inside Cyrus, via eBPF uprobes on
+`libcyrus.so.0`, plus a benchmark that replays the measured shape against any
+cyrusdb backend.
+
+The tracer answers "what shapes of database calls does this server actually
+make", per database type: operation mix, flags, key/value sizes, scan prefix
+lengths, hit/tombstone/miss split, and shared-vs-exclusive transaction rates.
+It needs no cyrus changes and no restart - it attaches to the running library.
+
+Requires root, `bpftrace`, and an unstripped `libcyrus`.
+
+## Running it
+
+    ./twom-rate 15                             # how busy is this box?
+    ./twom-capture [seconds] [outfile]         # default 60s
+
+That is the whole thing. It resolves the running cyrus package itself, so
+there is nothing to edit between releases. Needs root, `bpftrace`, and a
+`libcyrus.so.0` with symbols (our packages ship unstripped).
+
+    ./twom-capture 60                          # 60s, report to stdout
+    MAP_KEYS_MAX=65536 ./twom-capture 30       # small box (testbed, VM)
+    ./twom-report /var/tmp/twom-shape.*.txt    # re-render an old capture
+
+Run `twom-rate` first on a server you have not traced before. It attaches two
+counter-only probes, reports the twom call rate, and estimates what the full
+capture would cost in cores — cheap insurance before putting fifteen probes on
+a busy machine.
+
+## Lookups: hit / tombstone / never-existed
+
+    ./twom-hitmiss 30
+
+Splits every lookup three ways, per database type. twom_db_fetch delegates to
+twom_txn_fetch (two call sites, not inlined), so probing txn_fetch alone sees
+all of them.
+
+| at return | meaning |
+|---|---|
+| `TWOM_OK` | live record |
+| `NOTFOUND` && `loc->offset != 0` | tombstone: record present, visible version is a DELETE |
+| `NOTFOUND` && `loc->offset == 0` | never existed |
+
+Validated against ground truth (100 keys, 30 deleted, 50 absent -> 70/30/50
+exactly). Needs a uretprobe, so roughly double the census cost per call; keep
+windows short. TWOM_FETCHNEXT is bucketed separately because it advances `loc`
+past the key that was asked for.
+
+## Benchmarks
+
+Two frontends over one workload. `bench-workload.h` holds the op mix, key and
+value size distributions and scan fan-out, derived from a twom-capture census
+of a live IMAP server and rounded to plain ratios - so the shape came from
+production rather than from guesswork. Both frontends include it, so they
+cannot drift apart. Retune it against your own census if your mix differs;
+that is why the tracer ships alongside the benchmark.
+
+**twom-bench** drives the twom API directly:
+
+    ./twom-bench-build /root/cyrus-imapd
+    ./twom-bench --records 200000 --procs 8 --secs 60 --profile aggregate
+    LIB=./build/libtwom.so ./twom-capture 30    # verify the shape it generates
+
+**dbbench** goes through cyrusdb, so it runs on any backend, and reports CPU
+and disk as well as throughput:
+
+    ./dbbench-build                             # uses the running cyrus package
+    ./dbbench --engine twom --records 200000 --procs 8 --secs 60
+    RECORDS=200000 PROCS=8 SECS=30 ./dbbench-compare twom twoskip skiplist
+
+`dbbench-build` defaults to the cyrus prefix the running master has mapped, so
+headers and library come from the same build production is running.
+
+Profiles: `aggregate`, `mailboxes` (fetch-heavy, 11-record scans),
+`conversations`, `annotations`.
+
+Notes on reading the results:
+
+- Both default to NOSYNC, so the comparison measures the engines rather than
+  the box's fsync latency. `--sync` for a durability-faithful run; it changes
+  throughput by more than 2x.
+- Disk is reported as apparent size *and* allocated blocks, before and after a
+  repack. The engines differ far more in slack than in apparent size.
+- skiplist has no usable standalone repack: its checkpoint assert()s unless the
+  db is already WRITELOCKED, and an assert aborts the process. dbbench runs the
+  repack in a child so this degrades to `n/a` instead of killing the run.
+- `cursor_next` fires once more than there are records - the last call returns
+  DONE. So a census ratio of 1.6 means ~0.6 records per scan. twom-bench cannot
+  model sub-1 fan-out (integer, floored at 1), so its conversations profile is
+  optimistic.
+
+## How it works
+
+Entry-only uprobes on the fifteen twom entry points, aggregated in kernel
+maps. Nothing is emitted per event; the report is printed once at the end.
+Attaching to the library rather than a pid covers every cyrus process on the
+box, all slots, including ones that start mid-capture.
+
+Database names come from walking the structs, all verified against DWARF:
+
+    twom_db.fname    @ 0x0     fname = *(char **)db
+    twom_txn.db      @ 0x0     db    = *(void **)txn
+    twom_cursor.txn  @ 0x130   txn   = *(void **)(cur + 0x130)
+
+`twom-offsets` re-checks these before every capture and also confirms that
+resolved names really are absolute paths, because a wrong offset does not
+error — it silently yields garbage. The twom flag table is read from the
+library's own DWARF at capture time for the same reason: flags get added
+between releases (`TWOM_ONELOCK` arrived in fm-20260730).
+
+Per-user paths are collapsed to the db type (`conversations.db`, `dav.db`, …)
+in `twom-report`, not in the kernel; the `FILES` column is how many distinct
+files of that type were touched.
+
+## Cost
+
+**CPU is the constraint, not memory.** On a 48/96-core server with a terabyte
+of RAM the maps are a rounding error, so the defaults spend memory freely to
+avoid ever truncating the data.
+
+- **`MAP_KEYS_MAX`** (default 1048576). BPF hash maps are *preallocated* and
+  `count()`/`hist()` are per-CPU, allocated for `num_possible_cpus`:
+
+  | max_keys | 4 cores | 96 cores | % of 1TB |
+  |---------:|--------:|---------:|---------:|
+  |    65536 | 0.05 GB |  0.32 GB |   0.03 % |
+  |  1048576 | 0.77 GB |  5.08 GB |   0.50 % |
+  |  4194304 | 3.06 GB | 20.31 GB |   1.98 % |
+
+  5GB to guarantee a busy database is not silently dropped from the report is
+  a good trade. Turn it *down* on a testbed or VM, not up on a real server.
+  The report says so if a capture truncates anyway.
+
+- **`STRLEN`** (auto-sized from the real paths on the box, min 104, must stay
+  a multiple of 8). The db name is the *last* path component, so too small a
+  value silently truncates exactly the field the report groups by. The report
+  flags any key that comes back at the limit.
+
+Per-call cost is one uprobe trap plus one string copy — order 1µs, entry-only.
+At 96 cores you have ~96 core-seconds per second to spend, so even 1M twom
+calls/sec is ~1% of the box; `twom-rate` does that arithmetic against the real
+measured rate. There are no uretprobes: they roughly double per-call cost and
+nothing here needs a return value. Adding latency measurement means adding
+them — measure before leaving that on in production.
+
+## Gotchas found the hard way
+
+- bpftrace 0.16 has no `arg6`/`arg7` on x86_64. `fetch` flags are read at
+  `*(uint32 *)(reg("sp") + 16)` and `foreach` flags at `+ 8`.
+- A `[string, string]` map key hits a stack-alignment bug and the program is
+  rejected by the verifier. `[string, int]` is fine.
+- One map per operation multiplies the preallocation by fifteen. Everything is
+  folded into six maps keyed by an opid on purpose.
+- `master` only maps `libcyrus_min`, so the library is resolved from the lib
+  *directory* of whatever cyrus lib it has mapped.

--- a/contrib/twom-trace/bench-workload.h
+++ b/contrib/twom-trace/bench-workload.h
@@ -1,0 +1,117 @@
+/* bench-workload.h - a measured production workload, shared by twom-bench
+ * (direct twom API) and dbbench (cyrusdb API, any backend).
+ *
+ * The shape below was derived from a twom-capture census of a live IMAP
+ * server rather than invented, then rounded to plain ratios - only the
+ * proportions matter, since every table is sampled by relative weight.
+ * Both frontends include this so they cannot drift apart: a twom-only number
+ * and a cross-engine number describe the same workload.
+ *
+ * Retune these against your own census if your mix differs; that is the point
+ * of shipping the tracer alongside the benchmark.
+ */
+#ifndef BENCH_WORKLOAD_H
+#define BENCH_WORKLOAD_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+/* fetch key lengths: {low, high, weight-per-mille} */
+static const int KEYLEN[][3] = {
+    {   2,    4,     5 }, {   8,   16,    55 }, {  16,   32,   305 },
+    {  32,   64,   480 }, {  64,  128,   150 }, { 128,  256,     5 },
+};
+/* store value lengths: {low, high, weight-per-mille} */
+static const int VALLEN[][3] = {
+    {   1,    2,    30 }, {   4,    8,    10 }, {   8,   16,    60 },
+    {  16,   32,   225 }, {  32,   64,   500 }, {  64,  128,    50 },
+    { 128,  256,    75 }, { 256,  512,    45 }, { 512, 1024,     3 },
+    {1024, 4096,     1 }, {4096,16384,     1 },
+};
+#define NKEYLEN ((int)(sizeof(KEYLEN)/sizeof(KEYLEN[0])))
+#define NVALLEN ((int)(sizeof(VALLEN)/sizeof(VALLEN[0])))
+
+/* `scan` is cursor_next/foreach straight from the census. cursor_next fires
+ * once more than there are records - the last call returns DONE - so records
+ * per scan is scan-1. conversations.db at 1.6 means most of its scans return
+ * nothing at all, which integer fanout cannot model; it floors at 1. */
+struct profile { const char *name; int fetch, foreach, store; double scan; };
+static const struct profile PROFILES[] = {
+    /* fetch/foreach/store as relative weights per 10000 operations.
+     * Reads dominate everywhere; writes are well under 1% on most databases. */
+    { "aggregate",     8500, 1400, 100,  3.7 },
+    { "mailboxes",     9250,  750,   1, 11.0 },
+    { "conversations", 6550, 3250, 200,  1.6 },
+    { "annotations",   9935,   65,   1,  1.7 },
+    { NULL, 0, 0, 0, 0 }
+};
+
+static uint64_t rnd_state;
+static inline uint64_t rnd(void)
+{
+    rnd_state ^= rnd_state << 13; rnd_state ^= rnd_state >> 7;
+    rnd_state ^= rnd_state << 17; return rnd_state;
+}
+
+static inline double bench_now(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec / 1e9;
+}
+
+/* seed==0 draws from the global rng; a non-zero seed makes the draw a pure
+ * function of the record id, which is what lets a fetch rebuild the exact key
+ * that populate wrote. Getting this wrong just silently tanks the hit rate. */
+static int pick_seeded(const int t[][3], int n, uint64_t seed)
+{
+    int total = 0, i;
+    for (i = 0; i < n; i++) total += t[i][2];
+    uint64_t h = seed;
+    if (h) { h ^= h >> 33; h *= 0xff51afd7ed558ccdULL; h ^= h >> 33; }
+    else   { h = rnd(); }
+    int r = h % total;
+    for (i = 0; i < n; i++) { r -= t[i][2]; if (r < 0) break; }
+    if (i == n) i = n - 1;
+    int span = t[i][1] - t[i][0];
+    return t[i][0] + (int)((h >> 32) % (span ? span : 1));
+}
+#define pick(t, n) pick_seeded((t), (n), 0)
+
+/* Cyrus keys are structured, not random: mailbox names, uuids, uid suffixes.
+ * Shared prefixes are what a skiplist actually walks, so the structure - not
+ * just the length - is part of the workload.
+ *
+ * Records are laid out in groups of `fanout`, and PREFIX is a strict prefix of
+ * every key in a group, so a prefix scan returns exactly `fanout` records.
+ * Padding is appended after the prefix, so a varying key length never breaks
+ * prefix matching. */
+#define PREFIX_FMT "user.u%08u.INBOX.Folder%04u.item"
+
+static int mkprefix(char *buf, uint64_t group)
+{
+    return sprintf(buf, PREFIX_FMT,
+                   (unsigned)(group / 1000), (unsigned)(group % 1000));
+}
+
+static int mkkey(char *buf, uint64_t group, uint64_t item)
+{
+    int n = mkprefix(buf, group);
+    n += sprintf(buf + n, "%04u", (unsigned)item);
+    int len = pick_seeded(KEYLEN, NKEYLEN, group * 1000003ULL + item + 1);
+    if (len < n) len = n;
+    while (n < len) { buf[n] = 'a' + (char)((group + item + n) % 26); n++; }
+    buf[n] = 0;
+    return n;
+}
+
+static const struct profile *find_profile(const char *name)
+{
+    const struct profile *pf = PROFILES;
+    while (pf->name && strcmp(pf->name, name)) pf++;
+    return pf->name ? pf : NULL;
+}
+
+#endif /* BENCH_WORKLOAD_H */

--- a/contrib/twom-trace/dbbench-build
+++ b/contrib/twom-trace/dbbench-build
@@ -1,0 +1,33 @@
+#!/bin/bash
+# dbbench-build [cyrus-prefix]
+# Builds dbbench against the cyrusdb API. Defaults to the cyrus package the
+# running master has mapped, so the benchmark measures the same library
+# production is running - headers and lib from the same build, no ABI drift.
+set -eu
+HERE=$(dirname "$(readlink -f "$0")")
+
+PREFIX=${1:-}
+if [ -z "$PREFIX" ]; then
+  . "$HERE/libcyrus.sh"
+  lib=$(find_libcyrus) || exit 1
+  # .../<prefix>/lib/libcyrus.so.0 -> <prefix>
+  PREFIX=$(cd "$(dirname "$lib")/.." && pwd)
+fi
+[ -n "$PREFIX" ] || { echo "cannot find a cyrus prefix; pass one" >&2; exit 1; }
+
+INC=$PREFIX/include/cyrus
+LIB=$PREFIX/lib
+[ -f "$INC/cyrusdb.h" ] || { echo "no cyrusdb.h under $INC" >&2; exit 1; }
+[ -f "$LIB/libcyrus.so.0" ] || { echo "no libcyrus.so.0 under $LIB" >&2; exit 1; }
+
+echo "cyrus prefix: $PREFIX"
+
+# EXPORTED/HIDDEN are cyrus's visibility macros, normally from its config.h;
+# we are not building inside the tree, so define them away.
+gcc -O2 -g -o "$HERE/dbbench" "$HERE/dbbench.c" \
+    -DEXPORTED= -DHIDDEN= \
+    -I"$INC" -I"$HERE" \
+    -L"$LIB" -lcyrus -lcyrus_min -Wl,-rpath,"$LIB"
+
+echo "built $HERE/dbbench"
+"$HERE/dbbench" --list-engines 2>/dev/null | sed 's/^/  engine: /' || true

--- a/contrib/twom-trace/dbbench-compare
+++ b/contrib/twom-trace/dbbench-compare
@@ -1,0 +1,51 @@
+#!/bin/bash
+# dbbench-compare [engine ...]
+# Run the same measured workload against several cyrusdb backends and tabulate
+# throughput, CPU, wall time and disk.
+#   RECORDS=200000 PROCS=8 SECS=30 PROFILE=aggregate DB=/var/tmp/dbbench.db
+# Extra dbbench flags can be passed through in OPTS, e.g. OPTS=--sync
+set -u
+HERE=$(dirname "$(readlink -f "$0")")
+BENCH=$HERE/dbbench
+[ -x "$BENCH" ] || { echo "build it first: $HERE/dbbench-build" >&2; exit 1; }
+
+RECORDS=${RECORDS:-200000}
+PROCS=${PROCS:-8}
+SECS=${SECS:-30}
+PROFILE=${PROFILE:-aggregate}
+DB=${DB:-/var/tmp/dbbench.db}
+OPTS=${OPTS:-}
+
+# quotalegacy is a directory-per-quota-root store, not a general kv backend
+ENGINES=${*:-twom twoskip skiplist}
+RAW=${RAW:-/var/tmp/dbbench-compare.$(date +%Y%m%dT%H%M%S).txt}
+
+printf 'workload: profile=%s records=%s procs=%s secs=%s%s\n' \
+  "$PROFILE" "$RECORDS" "$PROCS" "$SECS" "${OPTS:+ opts=$OPTS}"
+printf 'raw: %s\n\n' "$RAW"
+
+for e in $ENGINES; do
+  rm -f "$DB"* 2>/dev/null
+  printf '### %s\n' "$e" >> "$RAW"
+  # shellcheck disable=SC2086
+  "$BENCH" --engine "$e" --db "$DB" --records "$RECORDS" --procs "$PROCS" \
+           --secs "$SECS" --profile "$PROFILE" $OPTS >> "$RAW" 2>&1
+  grep -h '^RESULT ' "$RAW" | tail -1 | grep -q "engine=$e" \
+    || printf 'RESULT engine=%s FAILED\n' "$e" >> "$RAW"
+done
+
+awk '
+  /^RESULT /{
+    delete f
+    for (i = 2; i <= NF; i++) { split($i, kv, "="); f[kv[1]] = kv[2] }
+    if (!hdr++)
+      printf "%-10s %9s %7s %7s %6s %7s %7s %10s %10s %8s %7s\n",
+        "ENGINE","OPS/S","CORES","US/OP","HIT%","P50us","P99us",
+        "ON-DISK","AFTER PACK","B/REC","PACK s"
+    if (f["FAILED"] != "" || f["ops"] == "") { printf "%-10s  failed\n", f["engine"]; next }
+    printf "%-10s %9d %7.2f %7.2f %6.1f %7d %7d %9.1fM %9.1fM %8.1f %7s\n",
+      f["engine"], f["opsps"], f["cores"], f["usop"], f["hit"],
+      f["p50"], f["p99"], f["alloc_run"]/1048576, f["alloc_pack"]/1048576,
+      f["brec"], (f["repack"]=="yes" ? sprintf("%.2f", f["packsec"]) : "n/a")
+  }
+' "$RAW"

--- a/contrib/twom-trace/dbbench.c
+++ b/contrib/twom-trace/dbbench.c
@@ -1,0 +1,326 @@
+/* dbbench - replay the measured production workload against ANY cyrusdb
+ * backend, and report throughput, CPU, wall time and disk footprint.
+ *
+ * Goes through the cyrusdb abstraction rather than twom directly, so
+ * --engine picks the backend by name (twom, twoskip, skiplist, flat, ...).
+ * The workload itself is shared with twom-bench via bench-workload.h, so the
+ * single-engine and cross-engine numbers describe the same access pattern.
+ *
+ * Disk is reported as both apparent size and allocated blocks, before and
+ * after a repack: the engines differ far more in slack than in apparent size,
+ * and the repack is where twom's compaction shows up.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <dirent.h>
+#include <getopt.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <sys/resource.h>
+
+#include "cyrusdb.h"
+#include "bench-workload.h"
+
+/* cyrus expects the embedding program to supply these */
+EXPORTED void fatal(const char *msg, int code)
+{
+    fprintf(stderr, "fatal: %s\n", msg);
+    exit(code);
+}
+
+struct stats { uint64_t ops, fetch, hit, miss, fe, recs, st, ns, lat[40]; };
+
+struct disk { uint64_t apparent, allocated; int files; };
+
+/* every file whose name starts with the db's basename: the db plus whatever
+ * index/journal/.NEW companions a backend leaves beside it */
+static struct disk disk_usage(const char *path)
+{
+    struct disk d = {0, 0, 0};
+    char tmp[4096], tmp2[4096];
+    snprintf(tmp, sizeof(tmp), "%s", path);
+    snprintf(tmp2, sizeof(tmp2), "%s", path);
+    const char *dir = dirname(tmp);
+    const char *base = basename(tmp2);
+    DIR *dp = opendir(dir);
+    if (!dp) return d;
+    struct dirent *e;
+    size_t bl = strlen(base);
+    while ((e = readdir(dp))) {
+        if (strncmp(e->d_name, base, bl)) continue;
+        char full[8192];
+        snprintf(full, sizeof(full), "%s/%s", dir, e->d_name);
+        struct stat sb;
+        if (stat(full, &sb)) continue;
+        if (!S_ISREG(sb.st_mode)) continue;
+        d.apparent += sb.st_size;
+        d.allocated += (uint64_t)sb.st_blocks * 512;
+        d.files++;
+    }
+    closedir(dp);
+    return d;
+}
+
+static int cb_count(void *rock, const char *k, size_t kl, const char *v, size_t vl)
+{ (*(uint64_t *)rock)++; return 0; }
+
+static double cpu_of(const struct rusage *r)
+{ return r->ru_utime.tv_sec + r->ru_utime.tv_usec/1e6
+       + r->ru_stime.tv_sec + r->ru_stime.tv_usec/1e6; }
+
+int main(int argc, char **argv)
+{
+    const char *dbpath = "/var/tmp/dbbench.db";
+    const char *engine = "twom";
+    const char *pname  = "aggregate";
+    int nrec = 200000, nproc = 8, secs = 30, missmix = 20;
+    int populate = 1, do_repack = 1, shared = 1, sync = 0;
+    static struct option lo[] = {
+        {"db",required_argument,0,'d'},      {"engine",required_argument,0,'e'},
+        {"records",required_argument,0,'n'}, {"procs",required_argument,0,'p'},
+        {"secs",required_argument,0,'s'},    {"profile",required_argument,0,'P'},
+        {"miss",required_argument,0,'m'},    {"no-populate",no_argument,0,'X'},
+        {"no-repack",no_argument,0,'R'},     {"no-shared",no_argument,0,'S'},
+        {"list-engines",no_argument,0,'L'},  {"sync",no_argument,0,'Y'},
+        {"help",no_argument,0,'h'}, {0,0,0,0}
+    };
+    int c;
+    while ((c = getopt_long(argc, argv, "d:e:n:p:s:P:m:XRSLYh", lo, NULL)) != -1) {
+        switch (c) {
+        case 'd': dbpath = optarg; break;
+        case 'e': engine = optarg; break;
+        case 'n': nrec = atoi(optarg); break;
+        case 'p': nproc = atoi(optarg); break;
+        case 's': secs = atoi(optarg); break;
+        case 'P': pname = optarg; break;
+        case 'm': missmix = atoi(optarg); break;
+        case 'X': populate = 0; break;
+        case 'R': do_repack = 0; break;
+        case 'S': shared = 0; break;
+        case 'Y': sync = 1; break;
+        case 'L': {
+            cyrusdb_init();
+            strarray_t *b = cyrusdb_backends();
+            for (int i = 0; i < b->count; i++) printf("%s\n", b->data[i]);
+            cyrusdb_done();
+            return 0;
+        }
+        default:
+            fprintf(stderr,
+              "usage: %s [--engine NAME] [--db PATH] [--records N] [--procs N]\n"
+              "          [--secs N] [--profile aggregate|mailboxes|conversations|annotations]\n"
+              "          [--miss PCT] [--no-populate] [--no-repack] [--no-shared]\n"
+              "          [--sync] [--list-engines]\n", argv[0]);
+            return 1;
+        }
+    }
+    const struct profile *pf = find_profile(pname);
+    if (!pf) { fprintf(stderr, "unknown profile %s\n", pname); return 1; }
+
+    /* -1 because cursor_next counts the terminating DONE call too */
+    int fanout = (int)(pf->scan - 1 + 0.5); if (fanout < 1) fanout = 1;
+    int ngroups = nrec / fanout; if (ngroups < 1) ngroups = 1;
+    nrec = ngroups * fanout;
+
+    /* default to NOSYNC so the comparison measures the engines rather than
+     * this box's fsync latency; --sync for a durability-faithful run */
+    int openflags = sync ? 0 : CYRUSDB_NOSYNC;
+
+    cyrusdb_init();
+
+    struct db *db = NULL;
+    struct txn *tid = NULL;
+    int r;
+    char key[512];
+    static char val[16384];
+    memset(val, 'v', sizeof(val));
+
+    if (populate) {
+        fprintf(stderr, "populating %s (%s) with %d records...\n",
+                dbpath, engine, nrec);
+        unlink(dbpath);
+        r = cyrusdb_open(engine, dbpath, CYRUSDB_CREATE | openflags, &db);
+        if (r) { fprintf(stderr, "open: %s\n", cyrusdb_strerror(r)); return 1; }
+        for (int i = 0; i < nrec; i++) {
+            int kl = mkkey(key, i / fanout, i % fanout);
+            int vl = pick_seeded(VALLEN, NVALLEN, i + 1);
+            r = cyrusdb_store(db, key, kl, val, vl, &tid);
+            if (r) { fprintf(stderr, "store: %s\n", cyrusdb_strerror(r)); return 1; }
+            if ((i % 20000) == 19999) { cyrusdb_commit(db, tid); tid = NULL; }
+        }
+        if (tid) { cyrusdb_commit(db, tid); tid = NULL; }
+        cyrusdb_close(db);
+    }
+
+    struct disk d_pop = disk_usage(dbpath);
+
+    struct stats *sh = mmap(NULL, sizeof(*sh) * nproc, PROT_READ|PROT_WRITE,
+                            MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+    memset(sh, 0, sizeof(*sh) * nproc);
+
+    fprintf(stderr, "engine=%s profile=%s procs=%d secs=%d miss=%d%% "
+                    "fanout=%d groups=%d sync=%s\n",
+            engine, pf->name, nproc, secs, missmix, fanout, ngroups,
+            sync ? "yes" : "no");
+
+    double t0 = bench_now();
+    for (int w = 0; w < nproc; w++) {
+        if (fork()) continue;
+        /* ---- worker ---- */
+        struct stats *st = &sh[w];
+        rnd_state = (uint64_t)(w + 1) * 88172645463325252ULL;
+        struct db *wdb = NULL;
+        if (cyrusdb_open(engine, dbpath, openflags, &wdb)) _exit(1);
+        int total = pf->fetch + pf->foreach + pf->store;
+        char wkey[512];
+        double deadline = bench_now() + secs;
+
+        while (bench_now() < deadline) {
+            int roll = rnd() % total;
+            double s = bench_now();
+            struct txn *t = NULL;
+            if (roll < pf->fetch) {
+                /* prod is 99.5% shared transactions: one read txn per op */
+                if (shared) cyrusdb_lock(wdb, &t, CYRUSDB_SHARED);
+                uint64_t id = rnd() % nrec;
+                int miss = (int)(rnd() % 100) < missmix;
+                uint64_t g = miss ? (uint64_t)ngroups + id : id / fanout;
+                int kl = mkkey(wkey, g, id % fanout);
+                const char *vp; size_t vl;
+                r = cyrusdb_fetch(wdb, wkey, kl, &vp, &vl, &t);
+                if (r == 0) st->hit++; else st->miss++;
+                if (t) cyrusdb_abort(wdb, t);
+                st->fetch++;
+            } else if (roll < pf->fetch + pf->foreach) {
+                if (shared) cyrusdb_lock(wdb, &t, CYRUSDB_SHARED);
+                uint64_t recs = 0;
+                int pl = mkprefix(wkey, rnd() % ngroups);
+                cyrusdb_foreach(wdb, wkey, pl, NULL, cb_count, &recs, &t);
+                if (t) cyrusdb_abort(wdb, t);
+                st->fe++; st->recs += recs;
+            } else {
+                uint64_t id = rnd() % nrec;
+                int kl = mkkey(wkey, id / fanout, id % fanout);
+                int vl = pick(VALLEN, NVALLEN);
+                if (cyrusdb_store(wdb, wkey, kl, val, vl, &t) == 0 && t)
+                    cyrusdb_commit(wdb, t);
+                else if (t) cyrusdb_abort(wdb, t);
+                st->st++;
+            }
+            uint64_t ns = (uint64_t)((bench_now() - s) * 1e9);
+            st->ns += ns; st->ops++;
+            int b = 0; while ((ns >>= 1) && b < 39) b++;
+            st->lat[b]++;
+        }
+        cyrusdb_close(wdb);
+        _exit(0);
+    }
+    for (int w = 0; w < nproc; w++) wait(NULL);
+    double el = bench_now() - t0;
+
+    struct rusage ru;
+    getrusage(RUSAGE_CHILDREN, &ru);
+    double cpu = cpu_of(&ru);
+
+    struct disk d_run = disk_usage(dbpath);
+    struct disk d_pack = d_run;
+    double packsec = 0;
+    int packed = 0;
+    if (do_repack) {
+        /* skiplist's checkpoint assert()s unless the db is already WRITELOCKED,
+         * and an assert aborts the process - so do it in a child and treat a
+         * dead child as "this backend has no standalone repack". */
+        double p0 = bench_now();
+        pid_t pid = fork();
+        if (pid == 0) {
+            struct db *pdb = NULL;
+            if (cyrusdb_open(engine, dbpath, openflags, &pdb)) _exit(2);
+            int rr = cyrusdb_repack(pdb);
+            cyrusdb_close(pdb);
+            _exit(rr == CYRUSDB_OK ? 0 : 3);
+        }
+        int wst = 0;
+        waitpid(pid, &wst, 0);
+        packed = WIFEXITED(wst) && WEXITSTATUS(wst) == 0;
+        packsec = bench_now() - p0;
+        if (packed) d_pack = disk_usage(dbpath);
+        else fprintf(stderr, "note: no usable standalone repack for %s\n", engine);
+    }
+    cyrusdb_done();
+
+    struct stats t = {0};
+    for (int w = 0; w < nproc; w++) {
+        t.ops += sh[w].ops; t.fetch += sh[w].fetch; t.hit += sh[w].hit;
+        t.miss += sh[w].miss; t.fe += sh[w].fe; t.recs += sh[w].recs;
+        t.st += sh[w].st; t.ns += sh[w].ns;
+        for (int b = 0; b < 40; b++) t.lat[b] += sh[w].lat[b];
+    }
+#define MB(x) ((double)(x) / (1024.0*1024.0))
+    printf("\nengine       %s   profile=%s   records=%d   procs=%d\n",
+           engine, pf->name, nrec, nproc);
+    printf("walltime     %.1fs\n", el);
+    printf("cpu          %.1fs  (%.2f cores, %.2f us/op)\n",
+           cpu, el > 0 ? cpu/el : 0, t.ops ? cpu*1e6/t.ops : 0);
+    printf("operations   %llu  (%.0f/s)\n", (unsigned long long)t.ops, t.ops/el);
+    printf("  fetch      %llu  (%.0f/s)  hit %.1f%%\n",
+           (unsigned long long)t.fetch, t.fetch/el,
+           t.fetch ? 100.0*t.hit/t.fetch : 0);
+    printf("  foreach    %llu  (%.0f/s)  %.1f records/scan\n",
+           (unsigned long long)t.fe, t.fe/el, t.fe ? (double)t.recs/t.fe : 0);
+    printf("  store      %llu  (%.0f/s)\n", (unsigned long long)t.st, t.st/el);
+    printf("mean latency %.1fus\n", t.ops ? t.ns/1e3/t.ops : 0);
+    uint64_t cum = 0;
+    for (int b = 0; b < 40; b++) {
+        cum += t.lat[b];
+        if (t.ops && cum >= t.ops/2) { printf("latency      p50=%lluus ", 1ULL<<b>>10); break; }
+    }
+    cum = 0;
+    for (int b = 0; b < 40; b++) {
+        cum += t.lat[b];
+        if (t.ops && cum >= t.ops*99/100) { printf("p99=%lluus\n", 1ULL<<b>>10); break; }
+    }
+    printf("disk         %-10s %10s %10s %6s\n", "", "apparent", "on-disk", "files");
+    printf("  populated  %-10s %9.1fM %9.1fM %6d\n", "",
+           MB(d_pop.apparent), MB(d_pop.allocated), d_pop.files);
+    printf("  after run  %-10s %9.1fM %9.1fM %6d\n", "",
+           MB(d_run.apparent), MB(d_run.allocated), d_run.files);
+    if (do_repack && packed)
+        printf("  repacked   %-10s %9.1fM %9.1fM %6d  (%.1fs)\n", "",
+               MB(d_pack.apparent), MB(d_pack.allocated), d_pack.files, packsec);
+    else if (do_repack)
+        printf("  repacked   %-10s %9s\n", "", "n/a");
+    printf("bytes/record %.1f apparent, %.1f on-disk%s\n",
+           nrec ? (double)d_pack.apparent/nrec : 0,
+           nrec ? (double)d_pack.allocated/nrec : 0,
+           packed ? " (after repack)" : "");
+
+    /* machine-readable: dbbench-compare parses this rather than the prose */
+    uint64_t p50 = 0, p99 = 0, cum2 = 0;
+    for (int b = 0; b < 40; b++) {
+        cum2 += t.lat[b];
+        if (!p50 && t.ops && cum2 >= t.ops/2) p50 = 1ULL<<b>>10;
+        if (!p99 && t.ops && cum2 >= t.ops*99/100) { p99 = 1ULL<<b>>10; break; }
+    }
+    printf("RESULT engine=%s profile=%s records=%d procs=%d wall=%.2f cpu=%.2f"
+           " ops=%llu opsps=%.0f cores=%.2f usop=%.2f hit=%.1f"
+           " p50=%llu p99=%llu recscan=%.2f"
+           " app_pop=%llu alloc_pop=%llu app_run=%llu alloc_run=%llu"
+           " app_pack=%llu alloc_pack=%llu brec=%.1f packsec=%.2f repack=%s\n",
+           engine, pf->name, nrec, nproc, el, cpu,
+           (unsigned long long)t.ops, t.ops/el, el > 0 ? cpu/el : 0,
+           t.ops ? cpu*1e6/t.ops : 0, t.fetch ? 100.0*t.hit/t.fetch : 0,
+           (unsigned long long)p50, (unsigned long long)p99,
+           t.fe ? (double)t.recs/t.fe : 0,
+           (unsigned long long)d_pop.apparent, (unsigned long long)d_pop.allocated,
+           (unsigned long long)d_run.apparent, (unsigned long long)d_run.allocated,
+           (unsigned long long)d_pack.apparent, (unsigned long long)d_pack.allocated,
+           nrec ? (double)d_pack.allocated/nrec : 0, packsec,
+           packed ? "yes" : "no");
+    return 0;
+}

--- a/contrib/twom-trace/libcyrus.sh
+++ b/contrib/twom-trace/libcyrus.sh
@@ -1,0 +1,42 @@
+# libcyrus.sh - locate the libcyrus the running cyrus is actually using.
+# Sourced by twom-capture, twom-rate, twom-hitmiss and dbbench-build.
+#
+# Deliberately does not assume any particular install layout: it asks the
+# running processes rather than guessing at paths. LIB= overrides everything,
+# which is also how the benchmark's private libtwom.so gets traced.
+
+find_libcyrus() {
+    if [ -n "${LIB:-}" ]; then
+        [ -e "$LIB" ] || { echo "LIB=$LIB does not exist" >&2; return 1; }
+        printf '%s\n' "$LIB"; return 0
+    fi
+
+    # Prefer a process that maps libcyrus itself.
+    local p hit
+    for p in /proc/[0-9]*; do
+        hit=$(awk '$NF ~ /\/libcyrus\.so/ { print $NF; exit }' "$p/maps" 2>/dev/null)
+        [ -n "$hit" ] && { printf '%s\n' "$hit"; return 0; }
+    done
+
+    # cyrus master only maps libcyrus_min, so fall back to its directory.
+    local dir
+    for p in /proc/[0-9]*; do
+        hit=$(awk '$NF ~ /\/libcyrus[_.a-z]*\.so/ { print $NF; exit }' "$p/maps" 2>/dev/null)
+        [ -n "$hit" ] || continue
+        dir=${hit%/*}
+        for cand in "$dir"/libcyrus.so.0 "$dir"/libcyrus.so; do
+            [ -e "$cand" ] && { printf '%s\n' "$cand"; return 0; }
+        done
+    done
+
+    echo "cannot find libcyrus in any running process; is cyrus running?" >&2
+    echo "pass LIB=/path/to/libcyrus.so.0 to override." >&2
+    return 1
+}
+
+check_twom_symbols() {
+    local lib=$1
+    nm "$lib" 2>/dev/null | grep -q ' twom_db_fetch$' && return 0
+    echo "no twom symbols in $lib - stripped build, or too old for twom." >&2
+    return 1
+}

--- a/contrib/twom-trace/twom-bench-build
+++ b/contrib/twom-trace/twom-bench-build
@@ -1,0 +1,29 @@
+#!/bin/bash
+# twom-bench-build [path-to-cyrus-source]
+# Builds twom-bench against twom.c from the cyrus tree, as a shared library so
+# the twom-capture / twom-hitmiss uprobes can attach to it the same way they
+# attach to libcyrus.
+set -eu
+# contrib/twom-trace/ -> the cyrus tree two levels up
+SRC=${1:-$(cd "$(dirname "$(readlink -f "$0")")/../.." && pwd)}
+HERE=$(dirname "$(readlink -f "$0")")
+LIBDIR=$HERE/build
+[ -f "$SRC/lib/twom.c" ] || { echo "no twom.c under $SRC/lib" >&2; exit 1; }
+
+mkdir -p "$LIBDIR"
+# cyrus's own assert.h calls assertionfailed(); twom.c is otherwise standalone
+cat > "$LIBDIR/stub.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+void assertionfailed(const char *file, int line, const char *expr)
+{ fprintf(stderr, "assert %s:%d: %s\n", file, line, expr); abort(); }
+EOF
+
+gcc -O2 -g -fPIC -shared -I"$SRC/lib" \
+    -o "$LIBDIR/libtwom.so" "$SRC/lib/twom.c" "$LIBDIR/stub.c" -luuid
+gcc -O2 -g -I"$SRC/lib" -o "$HERE/twom-bench" "$HERE/twom-bench.c" \
+    -L"$LIBDIR" -ltwom -Wl,-rpath,"$LIBDIR"
+
+echo "built $HERE/twom-bench"
+echo "  twom source: $(cd "$SRC" && git describe --always --dirty 2>/dev/null || echo "$SRC")"
+echo "  trace it with: LIB=$LIBDIR/libtwom.so $HERE/twom-capture 30"

--- a/contrib/twom-trace/twom-bench.c
+++ b/contrib/twom-trace/twom-bench.c
@@ -1,0 +1,195 @@
+/* twom-bench - replay production twom access patterns against a twom database.
+ *
+ * The op mix and the key/value size distributions live in bench-workload.h and
+ * were derived from a twom-capture census of a live server, not invented.
+ * Defaults reproduce the aggregate shape; --profile picks a single database's
+ * personality, and they differ a lot: mailboxes.db is fetch-dominated with
+ * ~11-record scans, while conversations.db does huge numbers of tiny ones.
+ *
+ * Build: see twom-bench-build. Links twom.c from the cyrus tree directly, as
+ * a shared library, so the twom-capture/twom-hitmiss uprobes can attach to it
+ * exactly as they do to libcyrus.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <getopt.h>
+#include "twom.h"
+
+#include "bench-workload.h"
+
+struct stats { uint64_t ops, fetch, hit, miss, fe, recs, st, ns, lat[40]; };
+
+static int cb_count(void *rock, const char *k, size_t kl, const char *d, size_t dl)
+{ (*(uint64_t *)rock)++; return 0; }
+
+int main(int argc, char **argv)
+{
+    const char *dbpath = "/var/tmp/twom-bench.db";
+    const char *pname  = "aggregate";
+    int nrec = 200000, nproc = 8, secs = 30, missmix = 20, populate = 1;
+    static struct option lo[] = {
+        {"db",required_argument,0,'d'}, {"records",required_argument,0,'n'},
+        {"procs",required_argument,0,'p'}, {"secs",required_argument,0,'s'},
+        {"profile",required_argument,0,'P'}, {"miss",required_argument,0,'m'},
+        {"no-populate",no_argument,0,'X'}, {"help",no_argument,0,'h'}, {0,0,0,0}
+    };
+    int c;
+    while ((c = getopt_long(argc, argv, "d:n:p:s:P:m:Xh", lo, NULL)) != -1) {
+        switch (c) {
+        case 'd': dbpath = optarg; break;
+        case 'n': nrec = atoi(optarg); break;
+        case 'p': nproc = atoi(optarg); break;
+        case 's': secs = atoi(optarg); break;
+        case 'P': pname = optarg; break;
+        case 'm': missmix = atoi(optarg); break;
+        case 'X': populate = 0; break;
+        default:
+            fprintf(stderr,
+              "usage: %s [--db PATH] [--records N] [--procs N] [--secs N]\n"
+              "          [--profile aggregate|mailboxes|conversations|annotations]\n"
+              "          [--miss PCT] [--no-populate]\n", argv[0]);
+            return 1;
+        }
+    }
+    const struct profile *pf = find_profile(pname);
+    if (!pf) { fprintf(stderr, "unknown profile %s\n", pname); return 1; }
+
+    /* -1 because cursor_next counts the terminating TWOM_DONE call too */
+    int fanout = (int)(pf->scan - 1 + 0.5); if (fanout < 1) fanout = 1;
+    int ngroups = nrec / fanout; if (ngroups < 1) ngroups = 1;
+    nrec = ngroups * fanout;
+
+    struct twom_open_data setup = TWOM_OPEN_DATA_INITIALIZER;
+    struct twom_db *db = NULL;
+    int r;
+
+    if (populate) {
+        fprintf(stderr, "populating %s with %d records...\n", dbpath, nrec);
+        setup.flags = TWOM_CREATE | TWOM_NOSYNC;
+        r = twom_db_open(dbpath, &setup, &db, NULL);
+        if (r) { fprintf(stderr, "open: %s\n", twom_strerror(r)); return 1; }
+        char key[512], val[16384];
+        memset(val, 'v', sizeof(val));
+        struct twom_txn *txn = NULL;
+        twom_db_begin_txn(db, 0, &txn);
+        for (int i = 0; i < nrec; i++) {
+            int kl = mkkey(key, i / fanout, i % fanout);
+            int vl = pick_seeded(VALLEN, NVALLEN, i + 1);
+            twom_txn_store(txn, key, kl, val, vl, 0);
+            if ((i % 20000) == 19999) {   /* commit periodically, like cyrus */
+                twom_txn_commit(&txn); txn = NULL;
+                twom_db_begin_txn(db, 0, &txn);
+            }
+        }
+        if (txn) twom_txn_commit(&txn);
+        twom_db_close(&db);
+    }
+
+    struct stats *sh = mmap(NULL, sizeof(*sh) * nproc, PROT_READ|PROT_WRITE,
+                            MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+    memset(sh, 0, sizeof(*sh) * nproc);
+
+    fprintf(stderr, "profile=%s procs=%d secs=%d miss=%d%% fanout=%d groups=%d -> %s\n",
+            pf->name, nproc, secs, missmix, fanout, ngroups, dbpath);
+
+    double t0 = bench_now();
+    for (int w = 0; w < nproc; w++) {
+        if (fork()) continue;
+        /* ---- worker ---- */
+        struct stats *st = &sh[w];
+        rnd_state = (uint64_t)(w + 1) * 88172645463325252ULL;
+        struct twom_db *wdb = NULL;
+        struct twom_open_data ws = TWOM_OPEN_DATA_INITIALIZER;
+        ws.flags = TWOM_NOSYNC;
+        if (twom_db_open(dbpath, &ws, &wdb, NULL)) _exit(1);
+
+        int total = pf->fetch + pf->foreach + pf->store;
+        char key[512], val[16384];
+        memset(val, 'v', sizeof(val));
+        double deadline = bench_now() + secs;
+
+        while (bench_now() < deadline) {
+            int roll = rnd() % total;
+            double s = bench_now();
+            /* prod is 99.5% shared transactions: one read txn per operation */
+            if (roll < pf->fetch) {
+                struct twom_txn *txn = NULL;
+                if (twom_db_begin_txn(wdb, TWOM_SHARED, &txn)) continue;
+                uint64_t id = rnd() % nrec;
+                int miss = (int)(rnd() % 100) < missmix;
+                /* a miss reaches past the populated group range, so it is a
+                 * genuine "never existed" rather than a malformed key */
+                uint64_t g = miss ? (uint64_t)ngroups + id : id / fanout;
+                int kl = mkkey(key, g, id % fanout);
+                const char *vp; size_t vl;
+                r = twom_txn_fetch(txn, key, kl, NULL, NULL, &vp, &vl, 0);
+                if (r == 0) st->hit++; else st->miss++;
+                twom_txn_abort(&txn);
+                st->fetch++;
+            } else if (roll < pf->fetch + pf->foreach) {
+                struct twom_txn *txn = NULL;
+                if (twom_db_begin_txn(wdb, TWOM_SHARED, &txn)) continue;
+                uint64_t recs = 0;
+                int pl = mkprefix(key, rnd() % ngroups);
+                twom_txn_foreach(txn, key, pl, NULL, cb_count, &recs,
+                                 TWOM_ALWAYSYIELD);
+                twom_txn_abort(&txn);
+                st->fe++; st->recs += recs;
+            } else {
+                struct twom_txn *txn = NULL;
+                if (twom_db_begin_txn(wdb, 0, &txn)) continue;
+                uint64_t id = rnd() % nrec;
+                int kl = mkkey(key, id / fanout, id % fanout);
+                int vl = pick(VALLEN, NVALLEN);
+                twom_txn_store(txn, key, kl, val, vl, 0);
+                twom_txn_commit(&txn);
+                st->st++;
+            }
+            uint64_t ns = (uint64_t)((bench_now() - s) * 1e9);
+            st->ns += ns; st->ops++;
+            int b = 0; while ((ns >>= 1) && b < 39) b++;
+            st->lat[b]++;
+        }
+        twom_db_close(&wdb);
+        _exit(0);
+    }
+    for (int w = 0; w < nproc; w++) wait(NULL);
+    double el = bench_now() - t0;
+
+    struct stats t = {0};
+    for (int w = 0; w < nproc; w++) {
+        t.ops += sh[w].ops; t.fetch += sh[w].fetch; t.hit += sh[w].hit;
+        t.miss += sh[w].miss; t.fe += sh[w].fe; t.recs += sh[w].recs;
+        t.st += sh[w].st; t.ns += sh[w].ns;
+        for (int b = 0; b < 40; b++) t.lat[b] += sh[w].lat[b];
+    }
+    printf("\nelapsed      %.1fs across %d processes\n", el, nproc);
+    printf("operations   %llu  (%.0f/s)\n", (unsigned long long)t.ops, t.ops/el);
+    printf("  fetch      %llu  (%.0f/s)  hit %.1f%%\n",
+           (unsigned long long)t.fetch, t.fetch/el,
+           t.fetch ? 100.0*t.hit/t.fetch : 0);
+    printf("  foreach    %llu  (%.0f/s)  %.1f records/scan\n",
+           (unsigned long long)t.fe, t.fe/el, t.fe ? (double)t.recs/t.fe : 0);
+    printf("  store      %llu  (%.0f/s)\n", (unsigned long long)t.st, t.st/el);
+    printf("mean latency %.1fus\n", t.ops ? t.ns/1e3/t.ops : 0);
+    uint64_t cum = 0;
+    printf("latency      ");
+    for (int b = 0; b < 40; b++) {
+        cum += t.lat[b];
+        if (t.ops && cum >= t.ops/2)   { printf("p50=%lluus ", 1ULL<<b>>10); break; }
+    }
+    cum = 0;
+    for (int b = 0; b < 40; b++) {
+        cum += t.lat[b];
+        if (t.ops && cum >= t.ops*99/100) { printf("p99=%lluus", 1ULL<<b>>10); break; }
+    }
+    printf("\n");
+    return 0;
+}

--- a/contrib/twom-trace/twom-capture
+++ b/contrib/twom-trace/twom-capture
@@ -1,0 +1,77 @@
+#!/bin/bash
+# twom-capture [seconds] [outfile]
+# Capture twom access-pattern census from every running cyrus process.
+set -u
+SECS=${1:-60}
+OUT=${2:-/var/tmp/twom-shape.$(hostname -s).$(date +%Y%m%dT%H%M%S).txt}
+HERE=$(dirname "$(readlink -f "$0")")
+
+# Ask the running processes where libcyrus is rather than assuming an install
+# layout. LIB= overrides, which is also how the benchmark's private libtwom.so
+# gets traced with the same tooling.
+. "$HERE/libcyrus.sh"
+LIB=$(find_libcyrus) || exit 1
+check_twom_symbols "$LIB" || exit 1
+
+echo "lib:  $LIB"
+echo "secs: $SECS"
+echo "out:  $OUT"
+
+"$HERE/twom-offsets" "$LIB" || exit 1
+
+sed -e "s|@LIB@|$LIB|g" -e "s|@SECS@|$SECS|g" \
+    "$HERE/twom-shape.bt.in" > /tmp/twom-shape.bt
+
+# Emit the flag table straight from this build's DWARF so the decoder cannot
+# drift when twom gains a flag (20260730 added TWOM_ONELOCK, for instance).
+# gdb omits implicitly-numbered enumerators, so pass the raw line through and
+# let twom-report resolve them.
+: > "$OUT"
+if command -v gdb >/dev/null 2>&1; then
+  gdb -q -batch -ex 'ptype enum twom_flagspec' "$LIB" 2>/dev/null \
+    | sed -n 's/^type = enum twom_flagspec /#enum /p' >> "$OUT"
+fi
+echo "#lib $LIB" >> "$OUT"
+
+# The db name is the LAST component of the path, so a short STRLEN silently
+# truncates away the exact field the report groups by. Size it from the real
+# paths on this box plus headroom; twom-report also flags any key that comes
+# back at the truncation length. Keep it a multiple of 8 - the [string, int]
+# map key has to stay 8-byte aligned or the verifier rejects the program.
+# 160 comfortably covers the deep per-user paths cyrus builds; the report
+# flags any key that still came back at the limit, so a wrong guess is loud
+# rather than silent. Lower it if you want smaller map keys.
+STRLEN=${STRLEN:-160}
+echo "strlen: $STRLEN"
+
+# MAP_KEYS_MAX applies to every map and BPF hash maps are PREALLOCATED, with
+# per-CPU values for count()/hist(), allocated for num_possible_cpus:
+#   ~6 x max_keys x (key + 8 x ncpus + 64)
+# On a 96-core server that is ~5GB at 1M keys - 0.5% of a terabyte, and cheap
+# next to silently truncating a busy database out of the report. Spend the
+# memory. On a small box (a testbed, a VM) drop it to 65536, ~0.05GB.
+export BPFTRACE_STRLEN=$STRLEN
+export BPFTRACE_MAP_KEYS_MAX=${MAP_KEYS_MAX:-1048576}
+echo "#strlen $STRLEN" >> "$OUT"
+# The preflight detaches its own uprobes from this same inode moments ago.
+# Attaching again while that teardown is still in flight intermittently yields
+# probes that register but never fire in already-running processes, i.e. a
+# silently empty capture. Let it settle, and retry once if it happens anyway.
+sleep 3
+
+HDR=$(cat "$OUT")
+for attempt in 1 2 3 4; do
+  printf '%s\n' "$HDR" > "$OUT"
+  bpftrace /tmp/twom-shape.bt >> "$OUT" 2>"$OUT.err"
+  rc=$?
+  grep -q '^@ops\[' "$OUT" && break
+  echo "attempt $attempt came back empty (uprobe attach race) - retrying" >&2
+  sleep $((attempt * 5))
+done
+if [ $rc -ne 0 ] || ! grep -q '^@ops\[' "$OUT"; then
+  echo "capture failed (rc=$rc):" >&2; head -20 "$OUT.err" >&2; exit 1
+fi
+
+echo "raw: $OUT"
+echo
+"$HERE/twom-report" "$OUT"

--- a/contrib/twom-trace/twom-hitmiss
+++ b/contrib/twom-trace/twom-hitmiss
@@ -1,0 +1,58 @@
+#!/bin/bash
+# twom-hitmiss [seconds] [outfile]
+# Split twom lookups into hit / tombstone / never-existed, per database type.
+# Uses a uretprobe, so it costs roughly double the census per call - keep the
+# window short on a busy server.
+set -u
+SECS=${1:-30}
+OUT=${2:-/var/tmp/twom-hitmiss.$(hostname -s).$(date +%Y%m%dT%H%M%S).txt}
+HERE=$(dirname "$(readlink -f "$0")")
+
+ . "$HERE/libcyrus.sh"
+LIB=$(find_libcyrus) || exit 1
+
+"$HERE/twom-offsets" "$LIB" || exit 1
+
+STRLEN=${STRLEN:-160}
+echo "lib:  $LIB"; echo "secs: $SECS"; echo "out:  $OUT"
+
+sed -e "s|@LIB@|$LIB|g" -e "s|@SECS@|$SECS|g" \
+    "$HERE/twom-hitmiss.bt.in" > /tmp/twom-hitmiss.bt
+
+BPFTRACE_STRLEN=$STRLEN \
+BPFTRACE_MAP_KEYS_MAX=${MAP_KEYS_MAX:-1048576} \
+  bpftrace /tmp/twom-hitmiss.bt > "$OUT" 2>"$OUT.err"
+rc=$?
+if [ $rc -ne 0 ] || ! grep -q '^@result' "$OUT"; then
+  echo "capture failed (rc=$rc):" >&2; head -20 "$OUT.err" >&2; exit 1
+fi
+echo "raw: $OUT"; echo
+
+awk '
+  /^@result\[/ {
+    line = $0
+    sub(/^@result\[/, "", line)
+    n = index(line, "]:")
+    inner = substr(line, 1, n-1)
+    cnt   = substr(line, n+2) + 0
+    c = inner; sub(/^.*, /, "", c)           # trailing class id
+    p = inner; sub(/, [0-9]+$/, "", p)       # leading path
+    b = p; sub(/^.*\//, "", b)               # basename = db type
+    tot[b] += cnt; cls[b, c] += cnt; grand += cnt
+  }
+  END {
+    printf "%-20s %10s %9s %9s %9s %9s %8s\n", \
+      "DB TYPE","LOOKUPS","hit","tombstone","never","other","fetchnext"
+    for (b in tot) {
+      printf "%-20s %10d %9d %9d %9d %9d %8d\n", b, tot[b], \
+        cls[b,1], cls[b,2], cls[b,3], cls[b,4], cls[b,5]
+      h += cls[b,1]; t += cls[b,2]; nv += cls[b,3]
+    }
+    printf "%-20s %10d %9d %9d %9d\n", "ALL", grand, h, t, nv
+    if (h+t+nv > 0) {
+      printf "\n  hit rate        %.1f%%\n", 100*h/(h+t+nv)
+      printf "  of the misses:  %.1f%% tombstone, %.1f%% never existed\n", \
+        (t+nv)?100*t/(t+nv):0, (t+nv)?100*nv/(t+nv):0
+    }
+  }
+' "$OUT"

--- a/contrib/twom-trace/twom-hitmiss.bt.in
+++ b/contrib/twom-trace/twom-hitmiss.bt.in
@@ -1,0 +1,58 @@
+#!/usr/bin/env bpftrace
+/*
+ * twom-hitmiss.bt - split twom lookups into hit / tombstone / never-existed.
+ *
+ * twom_db_fetch delegates to twom_txn_fetch (verified in the disassembly: two
+ * call sites, not inlined), so probing txn_fetch alone catches every lookup.
+ *
+ * The classification is only valid AFTER find_loc has run, so this needs a
+ * uretprobe - roughly double the per-call cost of the census. Fetch is the
+ * hottest twom entry point, so run this in shorter windows.
+ *
+ *   ret == TWOM_OK (0)                  -> key existed, live
+ *   ret == TWOM_NOTFOUND && offset != 0 -> tombstone: a record is present but
+ *                                          the version visible to this txn is
+ *                                          a DELETE
+ *   ret == TWOM_NOTFOUND && offset == 0 -> never existed
+ *                                          ("if there's no match, this key
+ *                                           never existed" - twom.c)
+ *
+ * Offsets (DWARF-verified against fm-20260730):
+ *   twom_txn.db      @ 0x0
+ *   twom_db.loc      @ 0x8
+ *   tm_loc.offset    @ 0x10   -> db + 0x18
+ *
+ * TWOM_FETCHNEXT is bucketed separately: it advances loc past the requested
+ * key, so offset no longer describes the key that was asked for.
+ */
+
+BEGIN { printf("twom-hitmiss: capturing for @SECS@s...\n"); }
+
+uprobe:@LIB@:twom_txn_fetch
+{
+  @txn[tid] = arg0;
+  @fnext[tid] = *(uint32 *)(reg("sp") + 16) & 8192;   /* TWOM_FETCHNEXT */
+}
+
+uretprobe:@LIB@:twom_txn_fetch
+/@txn[tid]/
+{
+  $db  = *(uint64 *)@txn[tid];
+  $off = *(uint64 *)($db + 0x18);
+  $ret = (int32)retval;
+
+  /* 1 hit, 2 tombstone, 3 never existed, 4 other error, 5 fetchnext */
+  $class = @fnext[tid] ? 5
+         : $ret == 0    ? 1
+         : $ret == -5   ? ($off ? 2 : 3)
+         : 4;
+
+  @result[str(*(uint64 *)$db), $class] = count();
+
+  delete(@txn[tid]);
+  delete(@fnext[tid]);
+}
+
+interval:s:@SECS@ { exit(); }
+
+END { clear(@txn); clear(@fnext); printf("twom-hitmiss: done\n"); }

--- a/contrib/twom-trace/twom-offsets
+++ b/contrib/twom-trace/twom-offsets
@@ -1,0 +1,38 @@
+#!/bin/bash
+# twom-offsets <libcyrus.so.0>
+# Preflight for twom-shape.bt: a wrong struct offset does not error, it just
+# yields garbage filenames, so verify before spending a capture window.
+set -u
+LIB=${1:?usage: twom-offsets <libcyrus.so.0>}
+fail=0
+
+# 1. symbols must be present (a stripped package build would lose them)
+for s in twom_db_fetch twom_txn_fetch twom_cursor_next twom_db_open; do
+  nm "$LIB" 2>/dev/null | grep -q " $s\$" || { echo "MISSING SYMBOL: $s" >&2; fail=1; }
+done
+[ $fail -ne 0 ] && { echo "cannot instrument $LIB" >&2; exit 1; }
+
+# 2. offsets from DWARF, if the package ships debug info
+if command -v gdb >/dev/null 2>&1; then
+  read -r c_txn t_db d_fname <<<"$(gdb -q -batch \
+      -ex 'printf "%d ", &((struct twom_cursor *)0)->txn' \
+      -ex 'printf "%d ", &((struct twom_txn *)0)->db' \
+      -ex 'printf "%d\n", &((struct twom_db *)0)->fname' \
+      "$LIB" 2>/dev/null | tail -1)"
+  if [ -n "${d_fname:-}" ]; then
+    echo "offsets: cursor.txn=$c_txn txn.db=$t_db db.fname=$d_fname"
+    [ "$c_txn" = "304" ] || { echo "MISMATCH: cursor.txn is $c_txn, script assumes 304 (0x130)" >&2; fail=1; }
+    [ "$t_db"  = "0"   ] || { echo "MISMATCH: txn.db is $t_db, script assumes 0" >&2; fail=1; }
+    [ "$d_fname" = "0" ] || { echo "MISMATCH: db.fname is $d_fname, script assumes 0" >&2; fail=1; }
+    [ $fail -ne 0 ] && { echo "edit twom-shape.bt.in before capturing" >&2; exit 1; }
+  else
+    echo "note: no DWARF in $LIB, falling back to a live sanity check"
+  fi
+fi
+
+# 3. NO live bpftrace check here. Attaching and detaching probes on the same
+#    inode immediately before the real capture intermittently leaves the
+#    capture's probes registered but never firing - a silently empty run.
+#    Verified: 5/5 clean without this, intermittent failures with it.
+#    twom-report validates the resolved paths from the capture itself instead.
+exit 0

--- a/contrib/twom-trace/twom-rate
+++ b/contrib/twom-trace/twom-rate
@@ -1,0 +1,56 @@
+#!/bin/bash
+# twom-rate [seconds]
+# Cheap pre-flight: how many twom calls/sec does this box actually make, and
+# what would instrumenting them cost? Two probes only, counters only, so it is
+# far lighter than a full capture. Run this first on a busy server.
+set -u
+SECS=${1:-10}
+HERE=$(dirname "$(readlink -f "$0")")
+
+ . "$HERE/libcyrus.sh"
+LIB=$(find_libcyrus) || exit 1
+
+NCPU=$(nproc)
+echo "lib:   $LIB"
+echo "cores: $NCPU online, $(cat /sys/devices/system/cpu/possible) possible"
+echo "sampling ${SECS}s..."
+
+# Split cursor_next out: it is the hot one, and it is the probe most likely to
+# make a full capture expensive on a busy box.
+OUT=$(timeout $((SECS + 20)) bpftrace -e "
+uprobe:$LIB:twom_cursor_next { @cursor_next = count(); }
+uprobe:$LIB:twom_db_fetch,
+uprobe:$LIB:twom_txn_fetch,
+uprobe:$LIB:twom_db_foreach,
+uprobe:$LIB:twom_txn_foreach,
+uprobe:$LIB:twom_db_store,
+uprobe:$LIB:twom_txn_store,
+uprobe:$LIB:twom_db_begin_cursor,
+uprobe:$LIB:twom_txn_begin_cursor,
+uprobe:$LIB:twom_db_begin_txn,
+uprobe:$LIB:twom_txn_commit,
+uprobe:$LIB:twom_txn_abort,
+uprobe:$LIB:twom_db_open,
+uprobe:$LIB:twom_db_yield,
+uprobe:$LIB:twom_db_repack { @other = count(); }
+interval:s:$SECS { exit(); }" 2>/dev/null)
+
+cn=$(echo "$OUT" | sed -n 's/^@cursor_next: *//p'); cn=${cn:-0}
+ot=$(echo "$OUT" | sed -n 's/^@other: *//p');       ot=${ot:-0}
+
+awk -v cn="$cn" -v ot="$ot" -v s="$SECS" -v ncpu="$NCPU" 'BEGIN {
+  tot = cn + ot; rate = tot / s;
+  printf "\n  cursor_next   %12d  (%.0f/s)\n", cn, cn/s;
+  printf "  all others    %12d  (%.0f/s)\n", ot, ot/s;
+  printf "  TOTAL         %12d  (%.0f/s)\n\n", tot, rate;
+  # ~1us per uprobe hit measured on this hardware class (entry-only, one trap
+  # plus one string copy). Treat as an order-of-magnitude estimate.
+  for (i = 1; i <= 2; i++) {
+    us = i;  cores = rate * us / 1e6;
+    printf "  at %dus/call: %.2f cores (%.2f%% of %d)\n", us, cores, 100*cores/ncpu, ncpu;
+  }
+  print "";
+  if (rate > 2000000) print "  VERY HOT - sample a subset of slots, or shorten the window.";
+  else if (rate > 500000) print "  hot, but a 30-60s window should be fine.";
+  else print "  comfortable for a full 60s capture.";
+}'

--- a/contrib/twom-trace/twom-report
+++ b/contrib/twom-trace/twom-report
@@ -1,0 +1,178 @@
+#!/usr/bin/perl
+# twom-report <raw-bpftrace-output>
+# Collapses per-user db paths to db type and decodes twom flag bitmasks.
+use strict;
+use warnings;
+
+# Fallback only. The capture normally embeds this build's own enum as a
+# "#enum" line, which is what actually gets used - twom gains flags between
+# releases (TWOM_ONELOCK arrived in fm-20260730) and a stale table would
+# silently mis-decode them.
+my @FLAGS = (
+  [ 1<<0,  'CREATE'         ], [ 1<<1,  'SHARED'      ],
+  [ 1<<2,  'NOCSUM'         ], [ 1<<3,  'NOSYNC'      ],
+  [ 1<<4,  'NONBLOCKING'    ], [ 1<<5,  'ONELOCK'     ],
+  [ 1<<9,  'ALWAYSYIELD'    ], [ 1<<10, 'NOYIELD'     ],
+  [ 1<<11, 'IFNOTEXIST'     ], [ 1<<12, 'IFEXIST'     ],
+  [ 1<<13, 'FETCHNEXT'      ], [ 1<<14, 'SKIPROOT'    ],
+  [ 1<<15, 'MVCC'           ], [ 1<<16, 'CURSOR_PREFIX' ],
+  [ 1<<27, 'CSUM_NULL'      ], [ 1<<28, 'CSUM_XXH64'  ],
+  [ 1<<29, 'CSUM_EXTERNAL'  ], [ 1<<30, 'COMPAR_EXTERNAL' ],
+);
+
+# "#enum {TWOM_CREATE = 1, TWOM_SHARED, TWOM_NOCSUM = 4, ...}" - gdb prints a
+# value only when it breaks the sequence, so carry the running value forward.
+sub parse_enum {
+  my ($txt) = @_;
+  my @f;
+  my $next = 0;
+  $txt =~ s/^.*?\{//s; $txt =~ s/\}.*$//s;
+  for my $e (split /\s*,\s*/, $txt) {
+    next unless $e =~ /^\s*TWOM_([A-Z0-9_]+)\s*(?:=\s*(-?\d+))?\s*$/;
+    my ($name, $val) = ($1, $2);
+    $val = $next unless defined $val;
+    $next = $val + 1;
+    push @f, [ $val, $name ] if $val > 0;
+  }
+  return @f;
+}
+
+sub decode_flags {
+  my ($v) = @_;
+  return '-' unless $v;
+  my $known = 0;
+  my @on;
+  for my $f (@FLAGS) {
+    next unless $v & $f->[0];
+    push @on, $f->[1];
+    $known |= $f->[0];
+  }
+  push @on, sprintf('0x%x', $v & ~$known) if $v & ~$known;
+  return join('|', @on);
+}
+
+# .../conf/user/uuid/f/f/<uuid>/conversations.db -> conversations.db (per-user)
+# .../meta/uuid/2/6/<uuid>/cyrus.annotations     -> cyrus.annotations (per-mailbox)
+# .../conf/mailboxes.db                          -> mailboxes.db (global)
+sub db_type {
+  my ($p) = @_;
+  my $per_user = ($p =~ m{/uuid/}) ? 1 : 0;
+  my ($base) = $p =~ m{([^/]+)$};
+  $base = $p unless defined $base;
+  $base =~ s{^sync_cache_.*\.db$}{sync_cache.db};
+  return ($base, $per_user);
+}
+
+my $file = shift or die "usage: twom-report <raw>\n";
+open my $fh, '<', $file or die "$file: $!\n";
+
+my @OPNAME = (undef, qw(db_fetch txn_fetch db_foreach txn_foreach cursor_next
+                        db_store txn_store db_begin_cursor txn_begin_cursor
+                        begin_txn txn_commit txn_abort db_open db_yield db_repack));
+
+my (%ops, %flags, %distinct, %txnmode, %hist, $cur_hist, $nkeys, $lib, $strlen, $trunc, $junk);
+while (my $l = <$fh>) {
+  chomp $l;
+  if ($l =~ /^#enum\s+(.*)$/) {
+    my @f = parse_enum($1);
+    @FLAGS = @f if @f;
+    next;
+  }
+  elsif ($l =~ /^#lib\s+(.*)$/)    { $lib = $1; next; }
+  elsif ($l =~ /^#strlen\s+(\d+)$/) { $strlen = $1; next; }
+  if ($l =~ /^\@ops\[(.+), (\d+)\]:\s+(\d+)$/) {
+    my ($path, $opid, $n) = ($1, $2, $3);
+    my $op = $OPNAME[$opid] || "op$opid";
+    my ($t, $pu) = db_type($path);
+    $ops{$t}{$op} += $n;
+    $distinct{$t}{$path} = 1 if $pu;
+    $nkeys++;
+    # bpftrace str() cuts at STRLEN-1; such a key lost its trailing db name
+    $trunc++ if $strlen && length($path) >= $strlen - 1;
+    # a wrong struct offset does not error, it yields junk instead of a path
+    $junk++ unless $path =~ m{^/};
+    $cur_hist = undef;
+  }
+  elsif ($l =~ /^\@flags\[(\d+), (\d+)\]:\s+(\d+)$/) {
+    my $op = $OPNAME[$1] || "op$1";
+    $flags{$op}{$2} += $3;
+    $cur_hist = undef;
+  }
+  elsif ($l =~ /^\@txnmode\[(\d+)\]:\s+(\d+)$/) {
+    $txnmode{$1 ? 'shared' : 'exclusive'} += $2;
+    $cur_hist = undef;
+  }
+  elsif ($l =~ /^\@(keylen|vallen|preflen)\[(\d+)\]:\s*$/) {
+    $cur_hist = ($OPNAME[$2] || "op$2") . " $1";
+  }
+  elsif (defined $cur_hist && $l =~ /^\[/)   { push @{$hist{$cur_hist}}, $l; }
+  elsif ($l eq '')                            { $cur_hist = undef; }
+}
+close $fh;
+
+my @allops = qw(db_fetch txn_fetch db_foreach txn_foreach cursor_next
+                db_store txn_store db_begin_cursor txn_begin_cursor
+                begin_txn txn_commit txn_abort db_open db_yield db_repack);
+my %seen;
+for my $t (keys %ops) { $seen{$_} = 1 for keys %{$ops{$t}} }
+my @cols = grep { $seen{$_} } @allops;
+
+my %tot;
+for my $t (keys %ops) { $tot{$t} += $ops{$t}{$_} for keys %{$ops{$t}} }
+my $grand = 0; $grand += $tot{$_} for keys %tot;
+
+print "lib: $lib\n\n" if $lib;
+print "== operations per database type ==\n";
+printf "%-20s %10s %5s", 'DB TYPE', 'TOTAL', '%';
+printf " %10s", $_ for @cols;
+printf " %8s\n", 'FILES';
+for my $t (sort { $tot{$b} <=> $tot{$a} } keys %ops) {
+  printf "%-20s %10d %4.1f%%", $t, $tot{$t}, $grand ? 100 * $tot{$t} / $grand : 0;
+  printf " %10s", ($ops{$t}{$_} // 0) for @cols;
+  printf " %8s\n", scalar(keys %{$distinct{$t} || {}}) || '-';
+}
+printf "%-20s %10d\n", 'ALL', $grand;
+
+print "\n== flags by operation ==\n";
+for my $op (sort keys %flags) {
+  my $h = $flags{$op};
+  for my $v (sort { $h->{$b} <=> $h->{$a} } keys %$h) {
+    printf "  %-18s %10d  %s\n", $op, $h->{$v}, decode_flags($v);
+  }
+}
+
+if (%txnmode) {
+  print "\n== begin_txn lock mode ==\n";
+  printf "  shared=%d exclusive=%d\n",
+    $txnmode{shared} // 0, $txnmode{exclusive} // 0;
+}
+
+if (%hist) {
+  print "\n== size distributions (bytes) ==\n";
+  for my $h (sort keys %hist) {
+    print "$h:\n";
+    print "$_\n" for @{$hist{$h}};
+    print "\n";
+  }
+}
+
+# The @ops map is preallocated and silently drops keys once full, which would
+# understate a busy db rather than erroring, so say so loudly.
+if ($junk) {
+  printf "\n*** WARNING: %d resolved name(s) are not absolute paths - the struct\n", $junk;
+  print  "*** offsets are probably wrong for this build. Do not trust this run.\n";
+}
+
+if ($trunc) {
+  printf "\n*** WARNING: %d path(s) hit the %d-byte string limit and lost their\n",
+    $trunc, $strlen;
+  print  "*** trailing db name, so those rows are grouped wrongly.\n";
+  print  "*** Re-run with a larger STRLEN (must stay a multiple of 8).\n";
+}
+
+my $max = $ENV{BPFTRACE_MAP_KEYS_MAX} || 1048576;
+if (defined $nkeys && $nkeys >= 0.95 * $max) {
+  printf "\n*** WARNING: %d of %d map keys used - counts are probably TRUNCATED.\n",
+    $nkeys, $max;
+  print  "*** Re-run with a shorter window or a larger BPFTRACE_MAP_KEYS_MAX.\n";
+}

--- a/contrib/twom-trace/twom-shape.bt.in
+++ b/contrib/twom-trace/twom-shape.bt.in
@@ -1,0 +1,127 @@
+#!/usr/bin/env bpftrace
+/*
+ * twom-shape.bt - census of twom access patterns inside Cyrus.
+ *
+ * Entry-only uprobes, aggregated in-kernel; nothing is emitted per-event, so
+ * cost is one trap plus one string copy per twom call. Attaches to
+ * libcyrus.so.0 itself, so it covers every cyrus process on the box (all
+ * slots, all daemons) including ones that start mid-capture.
+ *
+ * Struct offsets used (verified against DWARF in libcyrus.so.0):
+ *   twom_db.fname     @ 0x0    -> fname = *(char **)db
+ *   twom_txn.db       @ 0x0    -> db    = *(void **)txn
+ *   twom_cursor.txn   @ 0x130  -> txn   = *(void **)(cur + 0x130)
+ *
+ * MEMORY: bpftrace sizes EVERY map at BPFTRACE_MAP_KEYS_MAX and count()/hist()
+ * are per-CPU, so cost is (maps x max_keys x ncpus). That is why everything is
+ * folded into six maps keyed by an opid rather than one map per operation -
+ * the earlier per-operation layout cost ~200MB on 4 cores and would scale with
+ * core count on a real mail server. Keep the map count low.
+ *
+ * A composite [string, int] key is fine, but [string, string] hits a stack
+ * alignment bug in bpftrace 0.16 and the program is rejected. Don't go back.
+ *
+ * opid: 1 db_fetch      2 txn_fetch     3 db_foreach   4 txn_foreach
+ *       5 cursor_next   6 db_store      7 txn_store    8 db_begin_cursor
+ *       9 txn_begin_cursor            10 begin_txn    11 txn_commit
+ *      12 txn_abort    13 db_open      14 db_yield    15 db_repack
+ */
+
+BEGIN { printf("twom-shape: capturing for @SECS@s...\n"); }
+
+/* ---- non-transactional reads ---- */
+uprobe:@LIB@:twom_db_fetch
+{
+  @ops[str(*(uint64 *)arg0), 1] = count();
+  @flags[1, *(uint32 *)(reg("sp") + 16)] = count();
+  @keylen[1] = hist(arg2);
+}
+
+/* ---- transactional reads ---- */
+uprobe:@LIB@:twom_txn_fetch
+{
+  @ops[str(*(uint64 *)(*(uint64 *)arg0)), 2] = count();
+  @flags[2, *(uint32 *)(reg("sp") + 16)] = count();
+  @keylen[2] = hist(arg2);
+}
+
+/* ---- range scans: prefix length is the interesting shape ---- */
+uprobe:@LIB@:twom_db_foreach
+{
+  @ops[str(*(uint64 *)arg0), 3] = count();
+  @flags[3, *(uint32 *)(reg("sp") + 8)] = count();
+  @preflen[3] = hist(arg2);
+}
+
+uprobe:@LIB@:twom_txn_foreach
+{
+  @ops[str(*(uint64 *)(*(uint64 *)arg0)), 4] = count();
+  @flags[4, *(uint32 *)(reg("sp") + 8)] = count();
+  @preflen[4] = hist(arg2);
+}
+
+/* cursor_next is the hottest probe: count only, no extra work */
+uprobe:@LIB@:twom_cursor_next
+{
+  @ops[str(*(uint64 *)(*(uint64 *)(*(uint64 *)(arg0 + 0x130)))), 5] = count();
+}
+
+/* ---- writes: flags carry IFEXIST/IFNOTEXIST, vallen 0 means delete ---- */
+uprobe:@LIB@:twom_db_store
+{
+  @ops[str(*(uint64 *)arg0), 6] = count();
+  @flags[6, arg5] = count();
+  @keylen[6] = hist(arg2);
+  @vallen[6] = hist(arg4);
+}
+
+uprobe:@LIB@:twom_txn_store
+{
+  @ops[str(*(uint64 *)(*(uint64 *)arg0)), 7] = count();
+  @flags[7, arg5] = count();
+  @keylen[7] = hist(arg2);
+  @vallen[7] = hist(arg4);
+}
+
+/* ---- cursors ---- */
+uprobe:@LIB@:twom_db_begin_cursor
+{
+  @ops[str(*(uint64 *)arg0), 8] = count();
+  @flags[8, arg4] = count();
+}
+
+uprobe:@LIB@:twom_txn_begin_cursor
+{
+  @ops[str(*(uint64 *)(*(uint64 *)arg0)), 9] = count();
+  @flags[9, arg4] = count();
+}
+
+/* ---- transaction lifecycle: shared vs exclusive is the contention story ---- */
+uprobe:@LIB@:twom_db_begin_txn
+{
+  @ops[str(*(uint64 *)arg0), 10] = count();
+  @txnmode[arg1] = count();
+}
+
+uprobe:@LIB@:twom_txn_commit
+{ @ops[str(*(uint64 *)(*(uint64 *)(*(uint64 *)arg0))), 11] = count(); }
+
+uprobe:@LIB@:twom_txn_abort
+{ @ops[str(*(uint64 *)(*(uint64 *)(*(uint64 *)arg0))), 12] = count(); }
+
+/* ---- open / yield / repack: rare but expensive, worth per-db counts ---- */
+uprobe:@LIB@:twom_db_open
+{
+  @ops[str(arg0), 13] = count();
+  @flags[13, *(uint32 *)arg1] = count();
+}
+
+uprobe:@LIB@:twom_db_yield
+{ @ops[str(*(uint64 *)arg0), 14] = count(); }
+
+uprobe:@LIB@:twom_db_repack
+{ @ops[str(*(uint64 *)arg0), 15] = count(); }
+
+interval:s:@SECS@ { exit(); }
+
+END { printf("twom-shape: done\n"); }


### PR DESCRIPTION
There was no way to see what shapes of database calls cyrus actually makes on a live server short of patching in counters and restarting, which rules out looking at production. These uprobes attach to the running libcyrus instead: no cyrus change, no restart, and they cover every process on the box including ones that start mid-capture.

twom-capture reports the operation mix, flags, key and value sizes and scan prefix lengths per database; twom-hitmiss splits lookups into hit, tombstone and never-existed, which the return code alone cannot tell you. Everything aggregates in kernel maps, so cost is one trap plus one string copy per call and nothing is emitted per event.

dbbench then replays the measured shape against any cyrusdb backend and reports CPU and disk alongside throughput, so "twom is faster" can be a number rather than a belief. It shares its workload with twom-bench so the single-engine and cross-engine runs cannot describe different things.

The struct offsets the tracer walks are checked against DWARF before each run and the flag names are read from the library being traced, because a wrong offset does not fail - it quietly reports nonsense.