### PR TITLE
Port Fastmail's "auditslot" to chk_cyrus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -987,6 +987,8 @@ imap_libcyrus_imap_la_SOURCES = \
     imap/append.h \
     imap/attachextract.c \
     imap/attachextract.h \
+    imap/audit.c \
+    imap/audit.h \
     imap/auditlog.c \
     imap/auditlog.h \
     imap/backend.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -612,6 +612,7 @@ cunit_TESTS = \
     cunit/aaa-db.testc \
     cunit/annotate.testc \
     cunit/arrayu64.testc \
+    cunit/audit.testc \
     cunit/auditlog.testc \
     cunit/backend.testc \
     cunit/binhex.testc \

--- a/cassandane/Cassandane/Cyrus/ChkCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/ChkCyrus.pm
@@ -5,6 +5,7 @@ package Cassandane::Cyrus::ChkCyrus;
 use strict;
 use warnings;
 
+use File::Path qw(make_path remove_tree);
 use JSON::XS;
 
 use base qw(Cassandane::Cyrus::TestCase);

--- a/cassandane/Cassandane/Cyrus/ChkCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/ChkCyrus.pm
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+package Cassandane::Cyrus::ChkCyrus;
+use strict;
+use warnings;
+
+use JSON::XS;
+
+use base qw(Cassandane::Cyrus::TestCase);
+use Cassandane::Util::Log;
+use Cassandane::Util::Slurp;
+use Cassandane::Instance;
+
+sub new
+{
+    my $class = shift;
+    return $class->SUPER::new({ adminstore => 1 }, @_);
+}
+
+sub set_up
+{
+    my ($self) = @_;
+    $self->SUPER::set_up();
+}
+
+sub tear_down
+{
+    my ($self) = @_;
+    $self->SUPER::tear_down();
+}
+
+# Run chk_cyrus in audit mode and return its findings as an arrayref of
+# hashrefs, one per JSON line.
+sub audit_json
+{
+    my ($self, @args) = @_;
+
+    my $outfile = $self->{instance}->get_basedir() . "/chk_cyrus.out";
+
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'chk_cyrus', '--json', @args);
+
+    my @findings;
+    foreach my $line (split /\n/, slurp_file($outfile)) {
+        next unless length $line;
+        push @findings, decode_json($line);
+    }
+
+    return \@findings;
+}
+
+# The set of finding codes present, for the common "did X get reported"
+# assertion.
+sub codes
+{
+    my ($findings) = @_;
+    return map { $_->{code} } @{$findings};
+}
+
+sub assert_has_code
+{
+    my ($self, $findings, $code) = @_;
+    my @codes = codes($findings);
+    $self->assert(scalar(grep { $_ eq $code } @codes),
+                  "expected finding '$code', got: " . join(q{,}, @codes));
+}
+
+sub assert_lacks_code
+{
+    my ($self, $findings, $code) = @_;
+    my @codes = codes($findings);
+    $self->assert(!scalar(grep { $_ eq $code } @codes),
+                  "unexpected finding '$code'");
+}
+
+# The mailboxes.db path and backend, for tests that damage the database.
+sub mailboxes_db
+{
+    my ($self) = @_;
+    return $self->{instance}->get_basedir() . "/conf/mailboxes.db";
+}
+
+sub mailboxes_db_format
+{
+    my ($self) = @_;
+    return $self->{instance}->{config}->get('mboxlist_db');
+}
+
+use Cassandane::Tiny::Loader;
+
+1;

--- a/cassandane/Cassandane/Cyrus/ChkCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/ChkCyrus.pm
@@ -89,6 +89,51 @@ sub mailboxes_db_format
     return $self->{instance}->{config}->get('mboxlist_db');
 }
 
+
+# Count tombstone (deleted-marker) N records in mailboxes.db.
+sub count_tombstones
+{
+    my ($self) = @_;
+    my %db = $self->{instance}->run_dbcommand(
+        $self->mailboxes_db(), $self->mailboxes_db_format(), ['SHOW']);
+    my $n = 0;
+    foreach my $k (keys %db) {
+        next unless $k =~ m/^N/;
+        $n++ if $db{$k} =~ m/\bT\s+\S*d/;
+    }
+    return $n;
+}
+
+# Does an I record exist for this uniqueid?
+sub has_i_record
+{
+    my ($self, $uniqueid) = @_;
+    my %db = $self->{instance}->run_dbcommand(
+        $self->mailboxes_db(), $self->mailboxes_db_format(), ['SHOW']);
+    return exists $db{"I$uniqueid"} ? 1 : 0;
+}
+
+# Backdate every tombstone's mtime so that pruning will consider it.
+# Cassandane creates everything fresh, so nothing is otherwise old enough.
+sub backdate_tombstones
+{
+    my ($self, $days) = @_;
+    $days //= 30;
+
+    my $db = $self->mailboxes_db();
+    my $fmt = $self->mailboxes_db_format();
+    my %all = $self->{instance}->run_dbcommand($db, $fmt, ['SHOW']);
+    my $when = time() - ($days * 86400);
+
+    foreach my $k (keys %all) {
+        next unless $k =~ m/^N/;
+        next unless $all{$k} =~ m/\bT\s+\S*d/;
+        my $v = $all{$k};
+        $v =~ s/(\sM\s+)\d+/$1$when/;
+        $self->{instance}->run_dbcommand($db, $fmt, ['SET', $k, $v]);
+    }
+}
+
 use Cassandane::Tiny::Loader;
 
 1;

--- a/cassandane/Cassandane/Cyrus/ChkCyrus.pm
+++ b/cassandane/Cassandane/Cyrus/ChkCyrus.pm
@@ -134,6 +134,16 @@ sub backdate_tombstones
     }
 }
 
+
+# Move a path's mtime back beyond the audit's young-guard, so that
+# --delete will consider it.  Cassandane creates everything fresh.
+sub backdate_path
+{
+    my ($path) = @_;
+    my $when = time() - 3600;
+    utime($when, $when, $path) or die "utime $path: $!";
+}
+
 use Cassandane::Tiny::Loader;
 
 1;

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -72,6 +72,7 @@ sub new
         install_certificates => 0,
         squatter => 0,
         smtpdaemon => 0,
+        sanity_check => 1,
     };
     map {
         $want->{$_} = delete $params->{$_}
@@ -314,6 +315,13 @@ magic(NoStartInstances => sub {
     # If any test function in your suite uses this magic, then
     # your suite's set_up function cannot assume Cyrus is running!
     shift->want('start_instances' => 0);
+});
+magic(NoSanityCheck => sub {
+    # Skip the quota -f / reconstruct -q -G consistency check that runs
+    # when an instance stops.  For tests that deliberately damage the
+    # store -- typically to check that a repair tool notices -- and which
+    # take responsibility for what they leave behind.
+    shift->want('sanity_check' => 0);
 });
 magic(MagicPlus => sub {
     shift->config_set('imapmagicplus' => 'yes');
@@ -595,6 +603,8 @@ sub _create_instances
     my %instance_params = %{$self->{_instance_params}};
 
     $instance_params{lsan_suppressions} = $self->{lsan_suppressions} // "";
+
+    $instance_params{skip_sanity_check} = 1 if !$want->{sanity_check};
 
     my $cassini = Cassandane::Cassini->instance();
 

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -88,6 +88,7 @@ sub new
         _pid => $$,
         smtpdaemon => 0,
         lsan_suppressions => "",
+        skip_sanity_check => 0,
     }, $class);
 
     $self->{name} = $params{name}
@@ -124,6 +125,8 @@ sub new
         if defined $params{smtpdaemon};
     $self->{lsan_suppressions} = $params{lsan_suppressions}
         if defined $params{lsan_suppressions};
+    $self->{skip_sanity_check} = $params{skip_sanity_check}
+        if defined $params{skip_sanity_check};
     $self->{old_jmap_ids} = $params{old_jmap_ids}
         if defined $params{old_jmap_ids};
     $self->{test_case} = $params{test_case}
@@ -1812,6 +1815,14 @@ sub _check_mupdate
 sub _check_sanity
 {
     my ($self) = @_;
+
+    # Some tests deliberately damage the store -- typically to check that
+    # a repair tool notices -- and would always trip this.  Those declare
+    # :NoSanityCheck and take responsibility for what they leave behind.
+    if ($self->{skip_sanity_check}) {
+        xlog "skipping spool sanity check at test's request";
+        return;
+    }
 
     # We added this check during 3.5 development... older versions
     # probably fail these checks.  If we backport fixes we can decrement

--- a/cassandane/tiny-tests/ChkCyrus/audit_level0_clean
+++ b/cassandane/tiny-tests/ChkCyrus/audit_level0_clean
@@ -1,0 +1,16 @@
+#!perl
+use Cassandane::Tiny;
+
+# A freshly created, undamaged store has nothing to report.  If this ever
+# starts failing, the audit has grown a false positive.
+sub test_audit_level0_clean
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $findings = $self->audit_json('--level', '0');
+    my @codes = sort { $a cmp $b } codes($findings);
+    $self->assert_str_equals('', join(q{,}, @codes));
+}

--- a/cassandane/tiny-tests/ChkCyrus/audit_level0_clean_conversations
+++ b/cassandane/tiny-tests/ChkCyrus/audit_level0_clean_conversations
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+# The J keyspace is only audited with conversations enabled, so this is
+# the configuration where those checks actually run.  A healthy store must
+# still report nothing.
+sub test_audit_level0_clean_conversations
+    :Conversations
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+    $imaptalk->create("INBOX.Sent") or die "create: $@";
+
+    my $findings = $self->audit_json('--level', '0');
+    my @codes = sort { $a cmp $b } codes($findings);
+    $self->assert_str_equals('', join(q{,}, @codes));
+}

--- a/cassandane/tiny-tests/ChkCyrus/audit_level1_clean
+++ b/cassandane/tiny-tests/ChkCyrus/audit_level1_clean
@@ -1,0 +1,18 @@
+#!perl
+use Cassandane::Tiny;
+
+# A healthy store must be clean at level 1 too.  If this starts failing,
+# the filesystem sweep has grown a false positive -- which matters more
+# than at level 0, because --delete acts on these findings.
+sub test_audit_level1_clean
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+    $self->make_message("msg") or die;
+
+    my $findings = $self->audit_json('--level', '1');
+    my @codes = sort { $a cmp $b } codes($findings);
+    $self->assert_str_equals('', join(q{,}, @codes));
+}

--- a/cassandane/tiny-tests/ChkCyrus/ctl_mboxlist_k_unchanged
+++ b/cassandane/tiny-tests/ChkCyrus/ctl_mboxlist_k_unchanged
@@ -1,0 +1,27 @@
+#!perl
+use Cassandane::Tiny;
+
+# The refactor must not change ctl_mboxlist -k's behaviour: it is the
+# existing owner of this repair and has its own users.
+sub test_ctl_mboxlist_k_unchanged
+    :Conversations :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $db = $self->mailboxes_db();
+    my $fmt = $self->mailboxes_db_format();
+
+    my %all = $self->{instance}->run_dbcommand($db, $fmt, ['SHOW']);
+    my ($jkey) = grep { m/^J/ } keys %all;
+    $self->assert_not_null($jkey);
+    $self->{instance}->run_dbcommand($db, $fmt, ['DELETE', $jkey]);
+
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_mboxlist', '-k');
+
+    my $findings = $self->audit_json('--level', '0');
+    $self->assert_lacks_code($findings, 'db-missing-j-key');
+    $self->assert_lacks_code($findings, 'db-missing-j-property');
+}

--- a/cassandane/tiny-tests/ChkCyrus/db_entry_no_meta_dir
+++ b/cassandane/tiny-tests/ChkCyrus/db_entry_no_meta_dir
@@ -1,0 +1,33 @@
+#!perl
+use Cassandane::Tiny;
+
+# The converse of an orphan directory: a database entry whose directory
+# has gone.
+#
+# The instance is stopped before the damage is done and never restarted,
+# so that tear_down's consistency check does not run over a store we broke
+# deliberately.  chk_cyrus reads the database and the disk directly and
+# does not need a running server.
+sub test_db_entry_no_meta_dir
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+    $imaptalk->logout();
+    undef $imaptalk;
+
+    my $mbpath = $self->{instance}->run_mbpath('user.cassandane.INBOX.Archive');
+
+    $self->{instance}->stop();
+    $self->{instance}->{re_use_dir} = 1;
+
+    remove_tree($mbpath->{meta}) or die "remove_tree failed";
+
+    my $findings = $self->audit_json('--level', '1');
+    $self->assert_has_code($findings, 'db-entry-no-meta-dir');
+
+    # and only for the mailbox we actually removed
+    my ($f) = grep { $_->{code} eq 'db-entry-no-meta-dir' } @{$findings};
+    $self->assert_str_equals('user.cassandane.INBOX.Archive', $f->{mboxname});
+}

--- a/cassandane/tiny-tests/ChkCyrus/db_entry_no_meta_dir
+++ b/cassandane/tiny-tests/ChkCyrus/db_entry_no_meta_dir
@@ -3,25 +3,15 @@ use Cassandane::Tiny;
 
 # The converse of an orphan directory: a database entry whose directory
 # has gone.
-#
-# The instance is stopped before the damage is done and never restarted,
-# so that tear_down's consistency check does not run over a store we broke
-# deliberately.  chk_cyrus reads the database and the disk directly and
-# does not need a running server.
 sub test_db_entry_no_meta_dir
+    :NoSanityCheck
 {
     my ($self) = @_;
 
     my $imaptalk = $self->{store}->get_client();
     $imaptalk->create("INBOX.Archive") or die "create: $@";
-    $imaptalk->logout();
-    undef $imaptalk;
 
     my $mbpath = $self->{instance}->run_mbpath('user.cassandane.INBOX.Archive');
-
-    $self->{instance}->stop();
-    $self->{instance}->{re_use_dir} = 1;
-
     remove_tree($mbpath->{meta}) or die "remove_tree failed";
 
     my $findings = $self->audit_json('--level', '1');
@@ -30,4 +20,8 @@ sub test_db_entry_no_meta_dir
     # and only for the mailbox we actually removed
     my ($f) = grep { $_->{code} eq 'db-entry-no-meta-dir' } @{$findings};
     $self->assert_str_equals('user.cassandane.INBOX.Archive', $f->{mboxname});
+
+    # the rest of the store is undisturbed
+    $self->assert_lacks_code($findings, 'meta-dir-no-db-entry');
+    $self->assert_lacks_code($findings, 'user-missing-inbox');
 }

--- a/cassandane/tiny-tests/ChkCyrus/delete_old_orphan
+++ b/cassandane/tiny-tests/ChkCyrus/delete_old_orphan
@@ -1,0 +1,27 @@
+#!perl
+use Cassandane::Tiny;
+
+# An orphan past the guard is removed with --delete --really.
+sub test_delete_old_orphan
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    my $meta = $mbpath->{meta};
+    $meta =~ s{/uuid/.*$}{};
+    my $id = '0123456789abcdef';
+    my $dir = "$meta/uuid/0/1/$id";
+    make_path($dir) or die "make_path failed";
+    backdate_path($dir);
+
+    $self->audit_json('--level', '1', '--delete', '--really');
+
+    $self->assert(!-d $dir, "an old orphan should have been removed");
+
+    # and the real mailboxes are untouched
+    my $findings = $self->audit_json('--level', '1');
+    $self->assert_str_equals('', join(q{,}, codes($findings)));
+}

--- a/cassandane/tiny-tests/ChkCyrus/delete_orphaned_i_key
+++ b/cassandane/tiny-tests/ChkCyrus/delete_orphaned_i_key
@@ -1,0 +1,30 @@
+#!perl
+use Cassandane::Tiny;
+
+# An I record whose mailbox has no N record cannot be reached by name.
+sub test_delete_orphaned_i_key
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $db = $self->mailboxes_db();
+    my $fmt = $self->mailboxes_db_format();
+
+    # drop the N record, leaving its I record stranded
+    my $N = "Nuser\x1fcassandane\x1fINBOX\x1fArchive";
+    $self->{instance}->run_dbcommand($db, $fmt, ['DELETE', $N]);
+
+    my $findings = $self->audit_json('--level', '0');
+    $self->assert_has_code($findings, 'db-missing-n-key');
+
+    $self->audit_json('--level', '0', '--delete', '--really');
+
+    $findings = $self->audit_json('--level', '0');
+    $self->assert_lacks_code($findings, 'db-missing-n-key');
+
+    # the INBOX is untouched
+    $self->assert_lacks_code($findings, 'user-missing-inbox');
+}

--- a/cassandane/tiny-tests/ChkCyrus/delete_unknown_key
+++ b/cassandane/tiny-tests/ChkCyrus/delete_unknown_key
@@ -1,0 +1,35 @@
+#!perl
+use Cassandane::Tiny;
+
+# A key with an unrecognised prefix does not belong in mailboxes.db.
+# Seeing it at all is why the scan reads the keyspace raw rather than
+# through the lookup API, which would hide or choke on it.
+sub test_delete_unknown_key
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $db = $self->mailboxes_db();
+    my $fmt = $self->mailboxes_db_format();
+
+    $self->{instance}->run_dbcommand($db, $fmt, ['SET', 'Zbogus', 'value']);
+
+    my $findings = $self->audit_json('--level', '0');
+    $self->assert_has_code($findings, 'db-unknown-key');
+
+    # a dry run must leave it alone
+    $self->audit_json('--level', '0', '--delete');
+    $findings = $self->audit_json('--level', '0');
+    $self->assert_has_code($findings, 'db-unknown-key');
+
+    # --really removes it
+    $self->audit_json('--level', '0', '--delete', '--really');
+    $findings = $self->audit_json('--level', '0');
+    $self->assert_lacks_code($findings, 'db-unknown-key');
+
+    # and nothing else was disturbed
+    $self->assert_str_equals('', join(q{,}, codes($findings)));
+}

--- a/cassandane/tiny-tests/ChkCyrus/dry_run_changes_nothing
+++ b/cassandane/tiny-tests/ChkCyrus/dry_run_changes_nothing
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+# Without --really nothing on disk may change.  This is the contract every
+# operator relies on before running for real.
+sub test_dry_run_changes_nothing
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    my $meta = $mbpath->{meta};
+    $meta =~ s{/uuid/.*$}{};
+    my $id = '0123456789abcdef';
+    my $dir = "$meta/uuid/0/1/$id";
+    make_path($dir) or die "make_path failed";
+    backdate_path($dir);
+
+    my $findings = $self->audit_json('--level', '1', '--delete');
+    $self->assert_has_code($findings, 'meta-dir-no-db-entry');
+    $self->assert_has_code($findings, 'would-remove');
+
+    $self->assert(-d $dir, "a dry run must not remove anything");
+}

--- a/cassandane/tiny-tests/ChkCyrus/fix_missing_j_key
+++ b/cassandane/tiny-tests/ChkCyrus/fix_missing_j_key
@@ -1,0 +1,35 @@
+#!perl
+use Cassandane::Tiny;
+
+# A mailbox whose J record has gone is unreachable by jmapid.  The repair
+# is shared with ctl_mboxlist -k rather than reimplemented.
+sub test_fix_missing_j_key
+    :Conversations :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $db = $self->mailboxes_db();
+    my $fmt = $self->mailboxes_db_format();
+
+    # find and drop a J record
+    my %all = $self->{instance}->run_dbcommand($db, $fmt, ['SHOW']);
+    my ($jkey) = grep { m/^J/ } keys %all;
+    $self->assert_not_null($jkey);
+    $self->{instance}->run_dbcommand($db, $fmt, ['DELETE', $jkey]);
+
+    my $findings = $self->audit_json('--level', '0');
+    $self->assert_has_code($findings, 'db-missing-j-key');
+
+    # a dry run must leave it missing
+    $self->audit_json('--level', '0', '--fix');
+    $findings = $self->audit_json('--level', '0');
+    $self->assert_has_code($findings, 'db-missing-j-key');
+
+    $self->audit_json('--level', '0', '--fix', '--really');
+
+    $findings = $self->audit_json('--level', '0');
+    $self->assert_lacks_code($findings, 'db-missing-j-key');
+}

--- a/cassandane/tiny-tests/ChkCyrus/guid_mismatch
+++ b/cassandane/tiny-tests/ChkCyrus/guid_mismatch
@@ -1,0 +1,29 @@
+#!perl
+use Cassandane::Tiny;
+
+# Level 4 parses each message and compares its guid to the index record.
+sub test_guid_mismatch
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    $self->make_message("test message") or die;
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    my $file = "$mbpath->{data}/1.";
+    open my $fh, '>', $file or die "open $file: $!";
+    print $fh "From: someone\@example.com\r\n"
+            . "Subject: different\r\n\r\ndifferent content\r\n";
+    close $fh;
+
+    # level 2 only checks existence, so it sees nothing wrong
+    my $findings = $self->audit_json('--level', '2');
+    $self->assert_lacks_code($findings, 'message-guid-mismatch');
+
+    $findings = $self->audit_json('--level', '4');
+    $self->assert_has_code($findings, 'message-guid-mismatch');
+
+    my ($f) = grep { $_->{code} eq 'message-guid-mismatch' } @{$findings};
+    $self->assert_num_equals(1, $f->{uid});
+    $self->assert_not_null($f->{guid});
+}

--- a/cassandane/tiny-tests/ChkCyrus/json_output_pure
+++ b/cassandane/tiny-tests/ChkCyrus/json_output_pure
@@ -1,0 +1,24 @@
+#!perl
+use Cassandane::Tiny;
+
+# With --json, every line of output must be a JSON object: reconstruct's
+# prose about oddities it meets along the way belongs to syslog, not to
+# the machine-readable stream.  An odd file in the spool is such an
+# oddity -- worth a remark, but not a finding.
+sub test_json_output_pure
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    $self->make_message("test message") or die;
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    open my $fh, '>', "$mbpath->{data}/oddball" or die "open: $!";
+    print $fh "not a message\n";
+    close $fh;
+
+    # audit_json() decodes every line, so any prose fails the decode
+    my $findings = $self->audit_json('--level', '4');
+    my @codes = sort { $a cmp $b } codes($findings);
+    $self->assert_str_equals('', join(q{,}, @codes));
+}

--- a/cassandane/tiny-tests/ChkCyrus/legacy_flags_unchanged
+++ b/cassandane/tiny-tests/ChkCyrus/legacy_flags_unchanged
@@ -1,0 +1,21 @@
+#!perl
+use Cassandane::Tiny;
+
+# Existing cron invocations must not change behaviour or gain output.
+# chk_cyrus with no new flag still performs a read-only reconstruct sweep
+# and emits no findings.
+sub test_legacy_flags_unchanged
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $outfile = $self->{instance}->get_basedir() . "/legacy.out";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'chk_cyrus');
+
+    my $out = slurp_file($outfile);
+    $self->assert_does_not_match(qr/\{"code"/, $out);
+}

--- a/cassandane/tiny-tests/ChkCyrus/level2_never_modifies
+++ b/cassandane/tiny-tests/ChkCyrus/level2_never_modifies
@@ -1,0 +1,31 @@
+#!perl
+use Cassandane::Tiny;
+
+# Levels 2-4 are report-only.  If reconstruct were allowed to make
+# changes it would expunge the record for a missing file, destroying the
+# guid a driver needs to fetch it back.
+sub test_level2_never_modifies
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    $self->make_message("test message") or die;
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    unlink("$mbpath->{data}/1.") or die "unlink: $!";
+
+    my $index = "$mbpath->{meta}/cyrus.index";
+    my @before = stat($index);
+
+    $self->audit_json('--level', '4');
+
+    my @after = stat($index);
+    $self->assert_num_equals($before[7], $after[7], "cyrus.index size changed");
+    $self->assert_num_equals($before[9], $after[9], "cyrus.index mtime changed");
+
+    # the record, and therefore the guid, survives for a second run
+    my $findings = $self->audit_json('--level', '2');
+    my ($f) = grep { $_->{code} eq 'message-file-missing' } @{$findings};
+    $self->assert_not_null($f);
+    $self->assert_not_null($f->{guid});
+}

--- a/cassandane/tiny-tests/ChkCyrus/mailbox_unreadable
+++ b/cassandane/tiny-tests/ChkCyrus/mailbox_unreadable
@@ -1,0 +1,28 @@
+#!perl
+use Cassandane::Tiny;
+
+# A mailbox that cannot be opened at all is the worst damage levels 2-4
+# can meet, and reconstruct cannot report it through the observer: with
+# no changes allowed it stops at the failed open.  The audit must report
+# it rather than move silently to the next mailbox.
+sub test_mailbox_unreadable
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    $self->make_message("test message") or die;
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    unlink("$mbpath->{meta}/cyrus.index") or die "unlink: $!";
+
+    my $findings = $self->audit_json('--level', '2');
+    my ($f) = grep { $_->{code} eq 'mailbox-unreadable' } @{$findings};
+
+    $self->assert_not_null($f);
+    $self->assert_str_equals('user.cassandane', $f->{mboxname});
+    $self->assert_str_equals('cassandane', $f->{user});
+    $self->assert_not_null($f->{detail});
+
+    # the failed open logs an IOERROR, which is the point of the test
+    $self->{instance}->getsyslog();
+}

--- a/cassandane/tiny-tests/ChkCyrus/message_file_missing
+++ b/cassandane/tiny-tests/ChkCyrus/message_file_missing
@@ -1,0 +1,25 @@
+#!perl
+use Cassandane::Tiny;
+
+# A missing message file must be reported with everything a driver needs
+# to fetch a replacement: user, mailbox, uid, guid and destination path.
+sub test_message_file_missing
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    $self->make_message("test message") or die;
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    unlink("$mbpath->{data}/1.") or die "unlink: $!";
+
+    my $findings = $self->audit_json('--level', '2');
+    my ($f) = grep { $_->{code} eq 'message-file-missing' } @{$findings};
+
+    $self->assert_not_null($f);
+    $self->assert_num_equals(1, $f->{uid});
+    $self->assert_not_null($f->{guid});
+    $self->assert_not_null($f->{path});
+    $self->assert_str_equals('cassandane', $f->{user});
+    $self->assert_str_equals('user.cassandane', $f->{mboxname});
+}

--- a/cassandane/tiny-tests/ChkCyrus/orphan_meta_dir
+++ b/cassandane/tiny-tests/ChkCyrus/orphan_meta_dir
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+# A mailbox directory with no database entry.  Nothing else in Cyrus looks
+# inward from the filesystem, so this direction is the audit's alone.
+sub test_orphan_meta_dir
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    # a mailbox directory that no database entry points at
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    my $meta = $mbpath->{meta};
+    $meta =~ s{/uuid/.*$}{};
+    my $id = '0123456789abcdef';
+    my $dir = "$meta/uuid/0/1/$id";
+    make_path($dir) or die "make_path $dir failed";
+
+    my $findings = $self->audit_json('--level', '1');
+    $self->assert_has_code($findings, 'meta-dir-no-db-entry');
+
+    my ($f) = grep { $_->{code} eq 'meta-dir-no-db-entry' } @{$findings};
+    $self->assert_str_equals($id, $f->{uniqueid});
+}

--- a/cassandane/tiny-tests/ChkCyrus/partition_scopes_level2
+++ b/cassandane/tiny-tests/ChkCyrus/partition_scopes_level2
@@ -1,0 +1,24 @@
+#!perl
+use Cassandane::Tiny;
+
+# --partition scopes every level the same way.  Damage on another
+# partition is out of scope for the levels 2-4 sweep, exactly as its
+# database entries are out of scope for the keyspace scan.
+sub test_partition_scopes_level2
+    :Partition2 :NoSanityCheck
+{
+    my ($self) = @_;
+
+    $self->make_message("test message") or die;
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    unlink("$mbpath->{data}/1.") or die "unlink: $!";
+
+    # the damage is on the default partition, so a p2-scoped run must
+    # not see it
+    my $findings = $self->audit_json('--level', '2', '-P', 'p2');
+    $self->assert_lacks_code($findings, 'message-file-missing');
+
+    $findings = $self->audit_json('--level', '2');
+    $self->assert_has_code($findings, 'message-file-missing');
+}

--- a/cassandane/tiny-tests/ChkCyrus/prune_delayed_delete_keeps_mailbox
+++ b/cassandane/tiny-tests/ChkCyrus/prune_delayed_delete_keeps_mailbox
@@ -1,0 +1,35 @@
+#!perl
+use Cassandane::Tiny;
+
+# A delayed delete is a rename into the DELETED namespace, so the mailbox
+# still exists and its I record must survive the prune -- only the
+# tombstone at the old name and its history item go.
+sub test_prune_delayed_delete_keeps_mailbox
+    :DelayedDelete :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Doomed") or die "create: $@";
+
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+    my $res = $imaptalk->getmetadata("INBOX.Doomed", $entry);
+    my $uniqueid = $res->{'INBOX.Doomed'}{$entry};
+    $self->assert_not_null($uniqueid);
+
+    $imaptalk->delete("INBOX.Doomed") or die "delete: $@";
+
+    $self->backdate_tombstones();
+
+    $self->audit_json('--level', '0', '--delete', '--really',
+                      '--prune-tombstones', '1');
+
+    $self->assert_num_equals(0, $self->count_tombstones());
+
+    # the mailbox lives on in the DELETED namespace
+    $self->assert_num_equals(1, $self->has_i_record($uniqueid));
+
+    my $findings = $self->audit_json('--level', '0');
+    $self->assert_lacks_code($findings, 'db-history-no-tombstone');
+    $self->assert_lacks_code($findings, 'db-missing-n-key');
+}

--- a/cassandane/tiny-tests/ChkCyrus/prune_deleted_tombstone
+++ b/cassandane/tiny-tests/ChkCyrus/prune_deleted_tombstone
@@ -1,0 +1,32 @@
+#!perl
+use Cassandane::Tiny;
+
+# An immediate delete tombstones the mailbox's own name, so pruning it
+# must take the I record with it: nothing refers to the mailbox any more.
+sub test_prune_deleted_tombstone
+    :ImmediateDelete :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Doomed") or die "create: $@";
+
+    # find the uniqueid before it goes
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+    my $res = $imaptalk->getmetadata("INBOX.Doomed", $entry);
+    my $uniqueid = $res->{'INBOX.Doomed'}{$entry};
+    $self->assert_not_null($uniqueid);
+
+    $imaptalk->delete("INBOX.Doomed") or die "delete: $@";
+
+    $self->assert($self->count_tombstones() > 0);
+    $self->assert_num_equals(1, $self->has_i_record($uniqueid));
+
+    $self->backdate_tombstones();
+
+    $self->audit_json('--level', '0', '--delete', '--really',
+                      '--prune-tombstones', '1');
+
+    $self->assert_num_equals(0, $self->count_tombstones());
+    $self->assert_num_equals(0, $self->has_i_record($uniqueid));
+}

--- a/cassandane/tiny-tests/ChkCyrus/prune_disabled_by_default
+++ b/cassandane/tiny-tests/ChkCyrus/prune_disabled_by_default
@@ -1,0 +1,24 @@
+#!perl
+use Cassandane::Tiny;
+
+# A tombstone pruned before a replica has synced past it means that
+# replica never learns the name is gone, and the safe threshold is a
+# property of the deployment.  So there is no default and nothing prunes
+# without an explicit --prune-tombstones.
+sub test_prune_disabled_by_default
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Old") or die "create: $@";
+    $imaptalk->rename("INBOX.Old", "INBOX.New") or die "rename: $@";
+
+    my $before = $self->count_tombstones();
+    $self->assert($before > 0, "expected a tombstone after a rename");
+
+    $self->backdate_tombstones();
+    $self->audit_json('--level', '0', '--delete', '--really');
+
+    $self->assert_num_equals($before, $self->count_tombstones());
+}

--- a/cassandane/tiny-tests/ChkCyrus/prune_renamed_tombstone
+++ b/cassandane/tiny-tests/ChkCyrus/prune_renamed_tombstone
@@ -1,0 +1,32 @@
+#!perl
+use Cassandane::Tiny;
+
+# Rename leaves a tombstone at the old name and the I record under the
+# new one.  Pruning must drop the tombstone and its history item and leave
+# the I record: the mailbox still exists.
+sub test_prune_renamed_tombstone
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Old") or die "create: $@";
+    $imaptalk->rename("INBOX.Old", "INBOX.New") or die "rename: $@";
+
+    $self->assert($self->count_tombstones() > 0);
+    $self->backdate_tombstones();
+
+    $self->audit_json('--level', '0', '--delete', '--really',
+                      '--prune-tombstones', '1');
+
+    $self->assert_num_equals(0, $self->count_tombstones());
+
+    # the mailbox itself survives, and nothing is left dangling
+    my $findings = $self->audit_json('--level', '0');
+    $self->assert_lacks_code($findings, 'db-history-no-tombstone');
+    $self->assert_lacks_code($findings, 'db-missing-i-key');
+    $self->assert_lacks_code($findings, 'db-missing-n-key');
+
+    my $res = $imaptalk->select("INBOX.New");
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+}

--- a/cassandane/tiny-tests/ChkCyrus/skip_user_level2
+++ b/cassandane/tiny-tests/ChkCyrus/skip_user_level2
@@ -1,0 +1,26 @@
+#!perl
+use Cassandane::Tiny;
+
+# --skip-user excludes the user everywhere, not just from the per-user
+# structural checks: their mailboxes must not be opened by the levels
+# 2-4 sweep either.
+sub test_skip_user_level2
+    :NoSanityCheck
+{
+    my ($self) = @_;
+
+    $self->{instance}->create_user("otheruser");
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'otheruser');
+    unlink("$mbpath->{meta}/cyrus.index") or die "unlink: $!";
+
+    my $findings = $self->audit_json('--level', '2',
+                                     '--skip-user', 'otheruser');
+    $self->assert_lacks_code($findings, 'mailbox-unreadable');
+
+    $findings = $self->audit_json('--level', '2');
+    $self->assert_has_code($findings, 'mailbox-unreadable');
+
+    # the failed open logs an IOERROR, which is the point of the test
+    $self->{instance}->getsyslog();
+}

--- a/cassandane/tiny-tests/ChkCyrus/young_orphan_survives
+++ b/cassandane/tiny-tests/ChkCyrus/young_orphan_survives
@@ -1,0 +1,27 @@
+#!perl
+use Cassandane::Tiny;
+
+# An orphan newer than the guard is reported but never removed: it may
+# belong to an operation still in flight.  This is the guard's whole
+# contract, and the thing a future refactor is most likely to break.
+sub test_young_orphan_survives
+{
+    my ($self) = @_;
+
+    my $imaptalk = $self->{store}->get_client();
+    $imaptalk->create("INBOX.Archive") or die "create: $@";
+
+    my $mbpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+    my $meta = $mbpath->{meta};
+    $meta =~ s{/uuid/.*$}{};
+    my $id = '0123456789abcdef';
+    my $dir = "$meta/uuid/0/1/$id";
+    make_path($dir) or die "make_path failed";
+    # deliberately NOT backdated
+
+    my $findings = $self->audit_json('--level', '1', '--delete', '--really');
+    $self->assert_has_code($findings, 'meta-dir-no-db-entry');
+    $self->assert_has_code($findings, 'skipped-too-young');
+
+    $self->assert(-d $dir, "a young orphan must survive --delete --really");
+}

--- a/changes/next/chk-cyrus-audit-mode
+++ b/changes/next/chk-cyrus-audit-mode
@@ -1,0 +1,37 @@
+Description:
+
+:cyrusman:`chk_cyrus(8)` gains an audit mode which checks ``mailboxes.db``
+against itself and against the mailbox directories on disk, reporting -- and
+optionally repairing -- inconsistencies that no other tool detects.
+
+
+Documentation:
+
+:cyrusman:`chk_cyrus(8)`
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None.  Without the new **-l**/**--level** option, :cyrusman:`chk_cyrus(8)`
+behaves exactly as before, so existing invocations are unaffected.
+
+Two things are worth knowing before running the new mode with **--delete**
+or **--fix**:
+
+- Nothing is modified without **--really**, and nothing newer than ten
+  minutes is ever removed.
+
+- ``--prune-tombstones`` has no default and does nothing unless given an
+  age.  Removing a tombstone before a replica has synchronised past it
+  means that replica never learns the name is gone, so the safe threshold
+  depends on your replication topology.
+
+
+GitHub issue:
+
+None

--- a/cunit/audit.testc
+++ b/cunit/audit.testc
@@ -10,27 +10,48 @@
 
 #include "cunit/unit.h"
 
+#include "imap/audit.h"
 #include "imap/mboxlist.h"
+#include "lib/libconfig.h"
 #include "lib/util.h"
 
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
-/* The mailboxes.db key separator.  Spell it as its own string literal and
- * rely on concatenation: written inline, "\x1ebob" is a single hex escape
- * of 0x1eb -- out of range -- because 'b' is a hex digit.
+#define DBDIR "test-audit-dbdir"
+
+/* The per-user checks parse mailbox names, and mbname consults the
+ * configuration (virtdomains among others), which asserts if unloaded. */
+static int set_up(void)
+{
+    config_read_string(DBDIR"/conf", "");
+    return 0;
+}
+
+static int tear_down(void)
+{
+    config_reset();
+    return 0;
+}
+
+/* mailboxes.db separators.  RS divides the fields of a key; HS divides
+ * the levels of a mailbox name within one field.  Spell them as their own
+ * string literals and rely on concatenation: written inline, "\x1ebob" is
+ * a single hex escape of 0x1eb -- out of range -- because 'b' is a hex
+ * digit.
  */
-#define SEP "\x1e"
+#define RS "\x1e"       /* record separator, between key fields */
+#define HS "\x1f"       /* unit separator, within a mailbox name */
 
 static void test_rawkey_name(void)
 {
     struct mboxlist_rawkey key;
-    const char *raw = "Nuser" SEP "bob";
+    const char *raw = "Nuser" HS "bob";
     int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
 
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_NAME);
-    CU_ASSERT_STRING_EQUAL(key.dbname, "user" SEP "bob");
+    CU_ASSERT_STRING_EQUAL(key.dbname, "user" HS "bob");
     mboxlist_rawkey_fini(&key);
 }
 
@@ -49,7 +70,7 @@ static void test_rawkey_id(void)
 static void test_rawkey_jmapid(void)
 {
     struct mboxlist_rawkey key;
-    const char *raw = "Jbob" SEP "P123";
+    const char *raw = "Jbob" RS "P123";
     int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
 
     CU_ASSERT_EQUAL(r, 0);
@@ -62,21 +83,23 @@ static void test_rawkey_jmapid(void)
 static void test_rawkey_racl_user(void)
 {
     struct mboxlist_rawkey key;
-    const char *raw = "AU" SEP "alice" SEP "user" SEP "bob";
+    /* the mailbox part contains a hierarchy separator, which must not be
+     * mistaken for a field boundary */
+    const char *raw = "AU" RS "alice" RS "user" HS "bob" HS "Archive";
     int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
 
     CU_ASSERT_EQUAL(r, 0);
     CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_RACL);
     CU_ASSERT_EQUAL(key.isuser, 1);
     CU_ASSERT_STRING_EQUAL(key.userid, "alice");
-    CU_ASSERT_STRING_EQUAL(key.aclmbox, "user" SEP "bob");
+    CU_ASSERT_STRING_EQUAL(key.aclmbox, "user" HS "bob" HS "Archive");
     mboxlist_rawkey_fini(&key);
 }
 
 static void test_rawkey_racl_shared(void)
 {
     struct mboxlist_rawkey key;
-    const char *raw = "AS" SEP "alice" SEP "shared";
+    const char *raw = "AS" RS "alice" RS "shared";
     int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
 
     CU_ASSERT_EQUAL(r, 0);
@@ -111,6 +134,648 @@ static void test_rawkey_truncated(void)
 
     /* a J key needs both a userid and a jmapid */
     CU_ASSERT_EQUAL(mboxlist_parse_rawkey("Jbob", 4, &key), IMAP_MAILBOX_BADNAME);
+}
+
+/* ------------------------------------------------------------------ */
+/* findings and emitters                                              */
+
+static int has_text(const struct buf *out, const char *needle)
+{
+    return strstr(buf_cstring((struct buf *)out), needle) != NULL;
+}
+
+/* Returns a state that appends to the given buffer.  Leaked deliberately:
+ * cunit processes are short-lived and this keeps the tests readable. */
+static struct audit_state *test_state(struct buf *out)
+{
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    config.out = out;
+    return audit_begin(&config);
+}
+
+static int find_code(const struct buf *out, const char *code)
+{
+    return has_text(out, code);
+}
+
+/* The JSON emitter must omit absent fields rather than emitting nulls,
+ * so a consumer can test for presence. */
+static void test_emit_json_omits_absent(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    struct audit_state *state;
+
+    config.json = 1;
+    config.out = &out;
+    state = audit_begin(&config);
+
+    finding.code = "meta-dir-no-db-entry";
+    finding.uniqueid = "8d3fc1";
+    finding.path = "/meta/uuid/8/d/8d3fc1";
+    audit_report(state, &finding);
+    audit_done(&state);
+
+    CU_ASSERT(has_text(&out, "\"code\":\"meta-dir-no-db-entry\""));
+    CU_ASSERT(has_text(&out, "\"uniqueid\":\"8d3fc1\""));
+    CU_ASSERT(!has_text(&out, "mboxname"));
+    CU_ASSERT(!has_text(&out, "null"));
+    buf_free(&out);
+}
+
+/* Recovery-critical findings must carry the full tuple needed to fetch a
+ * replacement: without uid, guid and path a driver cannot act on them. */
+static void test_emit_json_recovery_tuple(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    struct audit_state *state;
+
+    config.json = 1;
+    config.out = &out;
+    state = audit_begin(&config);
+
+    finding.code = "message-file-missing";
+    finding.userid = "bob";
+    finding.mboxname = "user.bob.Archive";
+    finding.uniqueid = "8d3fc1";
+    finding.path = "/spool/uuid/8/d/8d3fc1/42.";
+    finding.tier = "spool";
+    finding.guid = "0f8c1a";
+    finding.uid = 42;
+    finding.has_uid = 1;
+    audit_report(state, &finding);
+    audit_done(&state);
+
+    CU_ASSERT(has_text(&out, "\"uid\":42"));
+    CU_ASSERT(has_text(&out, "\"guid\":\"0f8c1a\""));
+    CU_ASSERT(has_text(&out, "\"tier\":\"spool\""));
+    CU_ASSERT(has_text(&out, "\"user\":\"bob\""));
+    CU_ASSERT(has_text(&out, "\"mboxname\":\"user.bob.Archive\""));
+    buf_free(&out);
+}
+
+/* One finding per line, so the output is streamable. */
+static void test_emit_json_one_per_line(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    struct audit_state *state;
+    int i, newlines = 0;
+    const char *p;
+
+    config.json = 1;
+    config.out = &out;
+    state = audit_begin(&config);
+
+    finding.code = "db-unknown-key";
+    for (i = 0; i < 3; i++) audit_report(state, &finding);
+    audit_done(&state);
+
+    for (p = buf_cstring(&out); *p; p++) if (*p == '\n') newlines++;
+    CU_ASSERT_EQUAL(newlines, 3);
+    buf_free(&out);
+}
+
+static void test_emit_text(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    struct audit_state *state;
+
+    config.out = &out;
+    state = audit_begin(&config);
+
+    finding.code = "meta-dir-no-db-entry";
+    finding.uniqueid = "8d3fc1";
+    finding.path = "/meta/uuid/8/d/8d3fc1";
+    audit_report(state, &finding);
+    audit_done(&state);
+
+    CU_ASSERT(has_text(&out, "meta-dir-no-db-entry"));
+    CU_ASSERT(has_text(&out, "8d3fc1"));
+    /* the human renderer must not emit JSON punctuation */
+    CU_ASSERT(!has_text(&out, "\"code\""));
+    buf_free(&out);
+}
+
+/* The count is what a caller uses to decide an exit status. */
+static void test_finding_count(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    struct audit_state *state;
+
+    config.out = &out;
+    state = audit_begin(&config);
+    CU_ASSERT_EQUAL(audit_finding_count(state), 0);
+
+    finding.code = "db-unknown-key";
+    audit_report(state, &finding);
+    audit_report(state, &finding);
+    CU_ASSERT_EQUAL(audit_finding_count(state), 2);
+
+    audit_done(&state);
+    buf_free(&out);
+}
+
+/* A finding with no code is a programming error upstream; drop it rather
+ * than emitting an object a consumer cannot dispatch on. */
+static void test_finding_without_code_is_ignored(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    struct audit_state *state;
+
+    config.out = &out;
+    state = audit_begin(&config);
+
+    audit_report(state, &finding);
+
+    CU_ASSERT_EQUAL(audit_finding_count(state), 0);
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+    audit_done(&state);
+    buf_free(&out);
+}
+
+/* ------------------------------------------------------------------ */
+/* level 0: mailboxes.db keyspace cross-checks                        */
+
+/* Each of these builds a synthetic keyspace and asserts exactly which
+ * findings the cross-check produces.  The invariant under test is that a
+ * key is reported if and only if its counterpart is absent.
+ */
+
+static void test_keyspace_i_without_n(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+    /* deliberately no N key */
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-missing-n-key"));
+    CU_ASSERT(!find_code(&out, "db-missing-i-key"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+static void test_keyspace_n_without_i(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P1");
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-missing-i-key"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+static void test_keyspace_matched_pair_is_clean(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+static void test_keyspace_bogus_jmapid(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "nosuchid");
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-bogus-jmapid"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* A J key whose (user, id) disagrees with the entry it points at is worse
+ * than a missing one: a lookup by jmapid would return the wrong mailbox. */
+static void test_keyspace_bad_jmapid(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P99", "abc123");
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-bad-jmapid"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+static void test_keyspace_missing_j_property(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, NULL);
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, NULL);
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-missing-j-property"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+static void test_keyspace_missing_j_key(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P1");
+    /* entry claims jmapid P1 but no J key exists */
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-missing-j-key"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* A legacy-layout entry must never be treated as an orphan: its data
+ * lives in a name-hashed directory that no UUID sweep will ever see, so
+ * reporting it as missing would invite deleting a healthy mailbox. */
+static void test_keyspace_legacy_reported_not_orphaned(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob",
+                          MBTYPE_LEGACY_DIRS, "P1");
+    audit_keyspace_add_name(&ks, "user.bob", "abc123",
+                            MBTYPE_LEGACY_DIRS, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-entry-legacy-layout"));
+    CU_ASSERT(!find_code(&out, "db-missing-n-key"));
+    CU_ASSERT(!find_code(&out, "db-missing-i-key"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* ------------------------------------------------------------------ */
+/* tombstones and name_history                                        */
+
+/* The invariant: every name_history item has a matching tombstone N
+ * record, and every tombstone N record matches either the I record's
+ * current name or one of its history items.
+ */
+
+/* Rename tombstones the old name and moves the I record to the new one,
+ * so the tombstone is explained by a history item. */
+static void test_tombstone_explained_by_history(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.New", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob.New", "abc123", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+    audit_keyspace_add_history(&ks, "abc123", "user.bob.Old", 1000);
+    audit_keyspace_add_tombstone(&ks, "user.bob.Old", "abc123", 1000);
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(!find_code(&out, "db-tombstone-no-history"));
+    CU_ASSERT(!find_code(&out, "db-history-no-tombstone"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* Delete tombstones the current name, so the tombstone is explained by
+ * the I record itself rather than by history. */
+static void test_tombstone_explained_by_current_name(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.Gone", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+    audit_keyspace_add_tombstone(&ks, "user.bob.Gone", "abc123", 1000);
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(!find_code(&out, "db-tombstone-no-history"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+static void test_tombstone_without_referent(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.New", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob.New", "abc123", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+    /* a tombstone for a name the I record has never held */
+    audit_keyspace_add_tombstone(&ks, "user.bob.Stray", "abc123", 1000);
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-tombstone-no-history"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* Without its tombstone, a replica never learns the old name is gone. */
+static void test_history_without_tombstone(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.New", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob.New", "abc123", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+    audit_keyspace_add_history(&ks, "abc123", "user.bob.Old", 1000);
+    /* no tombstone for the former name */
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-history-no-tombstone"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* A tombstone whose uniqueid has no I record at all is an orphan: it is
+ * prunable, but it is not an inconsistency to report. */
+static void test_orphan_tombstone_is_not_reported(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_tombstone(&ks, "user.bob.Gone", "gone1", 1000);
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(!find_code(&out, "db-tombstone-no-history"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* A tombstone must not satisfy the live-mailbox checks: it is a record of
+ * a name that is gone, not a mailbox that exists. */
+static void test_tombstone_does_not_satisfy_missing_n_key(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "abc123");
+    /* the only N record for this name is a tombstone */
+    audit_keyspace_add_tombstone(&ks, "user.bob", "abc123", 1000);
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-missing-n-key"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* ------------------------------------------------------------------ */
+/* per-user structure                                                 */
+
+static struct audit_state *user_state(struct buf *out, strarray_t *userlist,
+                                      strarray_t *skipusers)
+{
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    config.out = out;
+    config.userlist = userlist;
+    config.skipusers = skipusers;
+    return audit_begin(&config);
+}
+
+/* A user expected on this server whose INBOX is gone needs a human: the
+ * INBOX uniqueid cannot be recreated. */
+static void test_user_expected_missing_inbox(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+    strarray_t userlist = STRARRAY_INITIALIZER;
+
+    strarray_append(&userlist, "bob");
+
+    audit_keyspace_init(&ks);
+    /* a folder but no INBOX */
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.Archive", 0, "P1");
+
+    audit_check_users(&ks, user_state(&out, &userlist, NULL));
+
+    CU_ASSERT(find_code(&out, "user-missing-inbox"));
+    CU_ASSERT(!find_code(&out, "user-stale-folders"));
+
+    audit_keyspace_fini(&ks);
+    strarray_fini(&userlist);
+    buf_free(&out);
+}
+
+/* The same shape for a user who is not expected here is routine cleanup,
+ * not an alert. */
+static void test_user_unexpected_stale_folders(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+    strarray_t userlist = STRARRAY_INITIALIZER;   /* empty: bob not expected */
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.Archive", 0, "P1");
+
+    audit_check_users(&ks, user_state(&out, &userlist, NULL));
+
+    CU_ASSERT(find_code(&out, "user-stale-folders"));
+    CU_ASSERT(!find_code(&out, "user-missing-inbox"));
+
+    audit_keyspace_fini(&ks);
+    strarray_fini(&userlist);
+    buf_free(&out);
+}
+
+/* A user with an INBOX is healthy, whatever else they have. */
+static void test_user_with_inbox_is_clean(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+    strarray_t userlist = STRARRAY_INITIALIZER;
+
+    strarray_append(&userlist, "bob");
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "inbox1", "user.bob", 0, "P1");
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.Archive", 0, "P2");
+
+    audit_check_users(&ks, user_state(&out, &userlist, NULL));
+
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    audit_keyspace_fini(&ks);
+    strarray_fini(&userlist);
+    buf_free(&out);
+}
+
+/* Folders lying entirely within the DELETED namespace are a deleted
+ * user's remains, not damage. */
+static void test_user_only_deleted_folders_is_clean(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+    strarray_t userlist = STRARRAY_INITIALIZER;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123",
+                          "DELETED.user.bob.Archive.ABCD1234", 0, "P1");
+
+    audit_check_users(&ks, user_state(&out, &userlist, NULL));
+
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    audit_keyspace_fini(&ks);
+    strarray_fini(&userlist);
+    buf_free(&out);
+}
+
+/* With no userlist every user in the database is treated as expected, so
+ * the tool reports damage but never proposes removing a user. */
+static void test_user_no_userlist_never_proposes_removal(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.Archive", 0, "P1");
+
+    audit_check_users(&ks, user_state(&out, NULL, NULL));
+
+    CU_ASSERT(!find_code(&out, "user-stale-folders"));
+    CU_ASSERT(!find_code(&out, "user-not-expected"));
+    CU_ASSERT(find_code(&out, "user-missing-inbox"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* A user in the database but absent from an explicit userlist does not
+ * belong here.  Reported only -- removing a whole user rests entirely on
+ * external truth, so that decision is the driver's. */
+static void test_user_not_expected(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+    strarray_t userlist = STRARRAY_INITIALIZER;
+
+    strarray_append(&userlist, "alice");
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "inbox1", "user.bob", 0, "P1");
+
+    audit_check_users(&ks, user_state(&out, &userlist, NULL));
+
+    CU_ASSERT(find_code(&out, "user-not-expected"));
+
+    audit_keyspace_fini(&ks);
+    strarray_fini(&userlist);
+    buf_free(&out);
+}
+
+static void test_user_skip_list_excludes(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+    strarray_t userlist = STRARRAY_INITIALIZER;
+    strarray_t skipusers = STRARRAY_INITIALIZER;
+
+    strarray_append(&skipusers, "bob");
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob.Archive", 0, "P1");
+
+    audit_check_users(&ks, user_state(&out, &userlist, &skipusers));
+
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    audit_keyspace_fini(&ks);
+    strarray_fini(&userlist);
+    strarray_fini(&skipusers);
+    buf_free(&out);
+}
+
+/* Tombstoned entries are records of names that are gone; they must not
+ * make a user look like they still have folders here. */
+static void test_user_tombstones_are_not_folders(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+    strarray_t userlist = STRARRAY_INITIALIZER;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_tombstone(&ks, "user.bob.Archive", "abc123", 1000);
+
+    audit_check_users(&ks, user_state(&out, &userlist, NULL));
+
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    audit_keyspace_fini(&ks);
+    strarray_fini(&userlist);
+    buf_free(&out);
 }
 
 /* vim: set ft=c: */

--- a/cunit/audit.testc
+++ b/cunit/audit.testc
@@ -34,6 +34,14 @@ static int tear_down(void)
     return 0;
 }
 
+/* Replace the loaded config wholesale.  set_up has already loaded a bare
+ * one, and config_read_string does not merge, so reset first. */
+static void load_config(const char *conf)
+{
+    config_reset();
+    config_read_string(DBDIR"/conf", conf);
+}
+
 /* mailboxes.db separators.  RS divides the fields of a key; HS divides
  * the levels of a mailbox name within one field.  Spell them as their own
  * string literals and rely on concatenation: written inline, "\x1ebob" is
@@ -870,6 +878,373 @@ static void test_user_tombstones_are_not_folders(void)
 
     audit_keyspace_fini(&ks);
     strarray_fini(&userlist);
+    buf_free(&out);
+}
+
+/* ------------------------------------------------------------------ */
+/* level 1: partition roots                                           */
+
+/* Several partition options commonly point at the same directory, and
+ * the meta and archive fallbacks add more.  Scanning one twice would
+ * report every mailbox on it as its own duplicate. */
+static void test_roots_deduplicated(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n"
+                "metapartition-default: /tmp/audit-data\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_ANY, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-data");
+
+    strarray_fini(&roots);
+}
+
+static void test_roots_distinct_paths_all_collected(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("archive_enabled: yes\n"
+                "partition-default: /tmp/audit-data\n"
+                "metapartition-default: /tmp/audit-meta\n"
+                "archivepartition-default: /tmp/audit-archive\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_ANY, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 3);
+    CU_ASSERT(strarray_contains(&roots, "/tmp/audit-data"));
+    CU_ASSERT(strarray_contains(&roots, "/tmp/audit-meta"));
+    CU_ASSERT(strarray_contains(&roots, "/tmp/audit-archive"));
+
+    strarray_fini(&roots);
+}
+
+/* With archiving disabled there is no separate archive location at all --
+ * config_archivepartitiondir() returns NULL regardless of what is
+ * configured, and mboxname_metapath() puts archive files on the data
+ * partition.  Sweeping the configured-but-unused directory would report
+ * anything left there as an orphan of a mailbox that never used it. */
+static void test_roots_archive_ignored_when_disabled(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n"
+                "archivepartition-default: /tmp/audit-archive\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_ARCHIVE, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-data");
+
+    strarray_fini(&roots);
+}
+
+/* Search tiers hold per-user xapian trees in the same UUID layout, so
+ * they belong in the sweep too. */
+static void test_roots_include_search_tiers(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n"
+                "defaultsearchtier: t1\n"
+                "searchpartition-t1: /tmp/audit-search\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_ANY, &roots);
+
+    CU_ASSERT(strarray_contains(&roots, "/tmp/audit-search"));
+
+    strarray_fini(&roots);
+}
+
+/* Restricting to a partition must restrict the sweep, or a
+ * partition-scoped run would report every mailbox living elsewhere as an
+ * orphan and, with --delete, remove it. */
+static void test_roots_partition_restricted(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n"
+                "metapartition-default: /tmp/audit-meta\n"
+                "partition-other: /tmp/audit-other\n");
+
+    audit_collect_roots("default", AUDIT_ROOT_ANY, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 2);
+    CU_ASSERT(strarray_contains(&roots, "/tmp/audit-data"));
+    CU_ASSERT(strarray_contains(&roots, "/tmp/audit-meta"));
+    CU_ASSERT(!strarray_contains(&roots, "/tmp/audit-other"));
+
+    strarray_fini(&roots);
+}
+
+/* A partition name that is a prefix of another must not drag it in. */
+static void test_roots_partition_name_is_exact(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-def: /tmp/audit-def\n"
+                "partition-default: /tmp/audit-default\n");
+
+    audit_collect_roots("def", AUDIT_ROOT_ANY, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-def");
+
+    strarray_fini(&roots);
+}
+
+/* Each finding differs by the kind of root it came from, so the caller
+ * must be able to sweep one kind at a time. */
+static void test_roots_type_filtered(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n"
+                "metapartition-default: /tmp/audit-meta\n"
+                "archivepartition-default: /tmp/audit-archive\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_META, &roots);
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-meta");
+    strarray_truncate(&roots, 0);
+
+    /* "partition-" is a suffix of "metapartition-" and the rest, so this
+     * is the case that over-matches if the prefix is matched loosely */
+    audit_collect_roots(NULL, AUDIT_ROOT_DATA, &roots);
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-data");
+
+    strarray_fini(&roots);
+}
+
+/* With no metapartition configured, meta files live on the data
+ * partition -- mboxname_metapath() falls back to it.  Sweeping the
+ * unconfigured location instead would find nothing and report every
+ * mailbox in the store as missing its directory. */
+static void test_roots_meta_falls_back_to_data(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_META, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-data");
+
+    strarray_fini(&roots);
+}
+
+/* Likewise for archive. */
+static void test_roots_archive_falls_back_to_data(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_ARCHIVE, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-data");
+
+    strarray_fini(&roots);
+}
+
+/* Options merely containing the word "partition" are not partition
+ * definitions and must not be swept. */
+static void test_roots_ignores_unrelated_options(void)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+
+    load_config("partition-default: /tmp/audit-data\n"
+                "defaultpartition: default\n");
+
+    audit_collect_roots(NULL, AUDIT_ROOT_ANY, &roots);
+
+    CU_ASSERT_EQUAL(strarray_size(&roots), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&roots, 0), "/tmp/audit-data");
+
+    strarray_fini(&roots);
+}
+
+/* ------------------------------------------------------------------ */
+/* level 1: the UUID-layout scanner                                   */
+
+/* All four uniqueid formats in the wild must be accepted, or a valid
+ * mailbox directory would be reported as junk and, with --delete,
+ * removed. */
+static void test_valid_uniqueid_formats(void)
+{
+    /* really old: namehash + uidvalidity */
+    CU_ASSERT(audit_valid_uniqueid("0123456789abcdef"));
+    /* non-libuuid random */
+    CU_ASSERT(audit_valid_uniqueid("abcdefghij0123456789wxyz"));
+    /* uuid, builtin (lowercase) */
+    CU_ASSERT(audit_valid_uniqueid("01234567-89ab-cdef-0123-456789abcdef"));
+    /* uuid, imported (uppercase) */
+    CU_ASSERT(audit_valid_uniqueid("01234567-89AB-CDEF-0123-456789ABCDEF"));
+}
+
+static void test_invalid_uniqueid_formats(void)
+{
+    CU_ASSERT(!audit_valid_uniqueid(NULL));
+    CU_ASSERT(!audit_valid_uniqueid(""));
+    CU_ASSERT(!audit_valid_uniqueid("nope"));
+    CU_ASSERT(!audit_valid_uniqueid("0123456789abcdefg"));     /* 17 */
+    CU_ASSERT(!audit_valid_uniqueid("0123456789abcde"));       /* 15 */
+    CU_ASSERT(!audit_valid_uniqueid("0123456789abcdeZ"));      /* 16, not hex */
+    /* a uuid must have its dashes in the right count */
+    CU_ASSERT(!audit_valid_uniqueid("0123456789abcdef0123456789abcdef1234"));
+    /* and must not mix cases */
+    CU_ASSERT(!audit_valid_uniqueid("01234567-89ab-CDEF-0123-456789abcdef"));
+}
+
+/* A mailbox once genuinely had uniqueid "0".  The hashed path for it is a
+ * PARENT directory holding many other mailboxes, so accepting it would
+ * mean removing a whole slice of the store. */
+static void test_short_uniqueid_rejected(void)
+{
+    CU_ASSERT(!audit_valid_uniqueid("0"));
+    CU_ASSERT(!audit_valid_uniqueid("ab"));
+}
+
+/* mkdir -p for a printf-formatted path */
+static void test_mkpath(const char *fmt, ...)
+{
+    struct buf path = BUF_INITIALIZER;
+    va_list ap;
+    char *p;
+
+    va_start(ap, fmt);
+    buf_vprintf(&path, fmt, ap);
+    va_end(ap);
+
+    for (p = (char *)buf_cstring(&path) + 1; *p; p++) {
+        if (*p != '/') continue;
+        *p = '\0';
+        (void) mkdir(buf_cstring(&path), 0755);
+        *p = '/';
+    }
+    (void) mkdir(buf_cstring(&path), 0755);
+
+    buf_free(&path);
+}
+
+static void test_scan_finds_leaves(void)
+{
+    char root[] = "/tmp/audit-scan-XXXXXX";
+    strarray_t found = STRARRAY_INITIALIZER;
+    struct buf out = BUF_INITIALIZER;
+    const char *id = "0123456789abcdef";
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(root));
+    test_mkpath("%s/uuid/0/1/%s", root, id);
+
+    audit_scan_uuid_root(root, &found, test_state(&out));
+
+    CU_ASSERT_EQUAL(strarray_size(&found), 1);
+    CU_ASSERT_STRING_EQUAL(strarray_nth(&found, 0), id);
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    strarray_fini(&found);
+    buf_free(&out);
+}
+
+/* A missing root is not a finding: a site may simply not have an archive
+ * partition populated yet. */
+static void test_scan_missing_root_is_quiet(void)
+{
+    strarray_t found = STRARRAY_INITIALIZER;
+    struct buf out = BUF_INITIALIZER;
+
+    audit_scan_uuid_root("/tmp/audit-does-not-exist", &found,
+                         test_state(&out));
+
+    CU_ASSERT_EQUAL(strarray_size(&found), 0);
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    strarray_fini(&found);
+    buf_free(&out);
+}
+
+/* A directory whose name is not a single hash character does not belong
+ * in the layout at all. */
+static void test_scan_flags_bad_hash_dir(void)
+{
+    char root[] = "/tmp/audit-scan-XXXXXX";
+    strarray_t found = STRARRAY_INITIALIZER;
+    struct buf out = BUF_INITIALIZER;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(root));
+    test_mkpath("%s/uuid/zzz/1/0123456789abcdef", root);
+
+    audit_scan_uuid_root(root, &found, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "fs-bad-hash-dir"));
+    CU_ASSERT_EQUAL(strarray_size(&found), 0);
+
+    strarray_fini(&found);
+    buf_free(&out);
+}
+
+static void test_scan_flags_invalid_uniqueid(void)
+{
+    char root[] = "/tmp/audit-scan-XXXXXX";
+    strarray_t found = STRARRAY_INITIALIZER;
+    struct buf out = BUF_INITIALIZER;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(root));
+    test_mkpath("%s/uuid/n/o/nope", root);
+
+    audit_scan_uuid_root(root, &found, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "fs-invalid-uniqueid"));
+    CU_ASSERT_EQUAL(strarray_size(&found), 0);
+
+    strarray_fini(&found);
+    buf_free(&out);
+}
+
+/* An INBOX subdirectory inside a mailbox directory is a known bogus
+ * artifact; the mailbox itself is still valid and must still be found. */
+static void test_scan_flags_bogus_inbox(void)
+{
+    char root[] = "/tmp/audit-scan-XXXXXX";
+    strarray_t found = STRARRAY_INITIALIZER;
+    struct buf out = BUF_INITIALIZER;
+    const char *id = "0123456789abcdef";
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(root));
+    test_mkpath("%s/uuid/0/1/%s/INBOX", root, id);
+
+    audit_scan_uuid_root(root, &found, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "fs-bogus-inbox-dir"));
+    CU_ASSERT_EQUAL(strarray_size(&found), 1);
+
+    strarray_fini(&found);
+    buf_free(&out);
+}
+
+/* The hash directories must match the start of the uniqueid, or the
+ * mailbox is not where mboxname_id_hash() would look for it. */
+static void test_scan_flags_misfiled_uniqueid(void)
+{
+    char root[] = "/tmp/audit-scan-XXXXXX";
+    strarray_t found = STRARRAY_INITIALIZER;
+    struct buf out = BUF_INITIALIZER;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(root));
+    /* 0123456789abcdef belongs under 0/1, not 9/9 */
+    test_mkpath("%s/uuid/9/9/0123456789abcdef", root);
+
+    audit_scan_uuid_root(root, &found, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "fs-misfiled-uniqueid"));
+
+    strarray_fini(&found);
     buf_free(&out);
 }
 

--- a/cunit/audit.testc
+++ b/cunit/audit.testc
@@ -145,11 +145,23 @@ static int has_text(const struct buf *out, const char *needle)
 }
 
 /* Returns a state that appends to the given buffer.  Leaked deliberately:
- * cunit processes are short-lived and this keeps the tests readable. */
+ * cunit processes are short-lived and this keeps the tests readable.
+ *
+ * check_jmapids is on, matching an install with conversations enabled;
+ * that is the only configuration in which the J keyspace is meaningful. */
 static struct audit_state *test_state(struct buf *out)
 {
     struct audit_config config = AUDIT_CONFIG_INITIALIZER;
     config.out = out;
+    config.check_jmapids = 1;
+    return audit_begin(&config);
+}
+
+static struct audit_state *test_state_nojmap(struct buf *out)
+{
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    config.out = out;
+    config.check_jmapids = 0;
     return audit_begin(&config);
 }
 
@@ -427,6 +439,89 @@ static void test_keyspace_missing_j_key(void)
     audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
     audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P1");
     /* entry claims jmapid P1 but no J key exists */
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-missing-j-key"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* With conversations disabled every mailbox is created with modseq 1 and
+ * so shares a jmapid, leaving the J keyspace degenerate.  There is nothing
+ * to audit there, and checking anyway would report every mailbox of every
+ * user on such an install. */
+static void test_keyspace_jmapid_checks_skipped_without_conversations(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P-F");
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P-F");
+    audit_keyspace_add_id(&ks, "def456", "user.bob.Archive", 0, "P-F");
+    audit_keyspace_add_name(&ks, "user.bob.Archive", "def456", 0, "P-F");
+    /* only one J key can exist for the shared pair */
+    audit_keyspace_add_jmapid(&ks, "bob", "P-F", "def456");
+
+    audit_keyspace_check(&ks, test_state_nojmap(&out));
+
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* An entry with no jmapid at all is likewise not worth reporting when the
+ * J keyspace is not in use. */
+static void test_keyspace_missing_j_property_skipped_without_conversations(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, NULL);
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, NULL);
+
+    audit_keyspace_check(&ks, test_state_nojmap(&out));
+
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* With conversations enabled jmapids are unique per user, so a J record
+ * naming a different mailbox leaves this one unreachable by jmapid. */
+static void test_keyspace_j_key_names_other_mailbox(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "bob", "P1", "someoneelse");
+
+    audit_keyspace_check(&ks, test_state(&out));
+
+    CU_ASSERT(find_code(&out, "db-missing-j-key"));
+
+    audit_keyspace_fini(&ks);
+    buf_free(&out);
+}
+
+/* A J key for a different user does not satisfy this user's entry. */
+static void test_keyspace_j_key_wrong_user(void)
+{
+    struct buf out = BUF_INITIALIZER;
+    struct audit_keyspace ks;
+
+    audit_keyspace_init(&ks);
+    audit_keyspace_add_id(&ks, "abc123", "user.bob", 0, "P1");
+    audit_keyspace_add_name(&ks, "user.bob", "abc123", 0, "P1");
+    audit_keyspace_add_jmapid(&ks, "alice", "P1", "abc123");
 
     audit_keyspace_check(&ks, test_state(&out));
 

--- a/cunit/audit.testc
+++ b/cunit/audit.testc
@@ -7,6 +7,7 @@
 #endif
 
 #include <string.h>
+#include <utime.h>
 
 #include "cunit/unit.h"
 
@@ -1245,6 +1246,160 @@ static void test_scan_flags_misfiled_uniqueid(void)
     CU_ASSERT(find_code(&out, "fs-misfiled-uniqueid"));
 
     strarray_fini(&found);
+    buf_free(&out);
+}
+
+/* ------------------------------------------------------------------ */
+/* the young-guard and safe removal                                   */
+
+static struct audit_state *delete_state(struct buf *out, int really)
+{
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    config.out = out;
+    config.do_delete = 1;
+    config.really = really;
+    return audit_begin(&config);
+}
+
+static void backdate(const char *path)
+{
+    struct utimbuf times;
+
+    times.actime = times.modtime = time(NULL) - (AUDIT_MIN_AGE + 60);
+    CU_ASSERT_EQUAL(utime(path, &times), 0);
+}
+
+/* Anything younger than the guard may belong to an operation still in
+ * flight.  This is the guard's entire contract. */
+static void test_young_path_is_protected(void)
+{
+    char path[] = "/tmp/audit-young-XXXXXX";
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(path));
+    CU_ASSERT(audit_path_is_young(path));
+
+    rmdir(path);
+}
+
+static void test_backdated_path_is_not_young(void)
+{
+    char path[] = "/tmp/audit-old-XXXXXX";
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(path));
+    backdate(path);
+
+    CU_ASSERT(!audit_path_is_young(path));
+
+    rmdir(path);
+}
+
+/* A path that has already gone is not something to protect. */
+static void test_missing_path_is_not_young(void)
+{
+    CU_ASSERT(!audit_path_is_young("/tmp/audit-definitely-not-here"));
+}
+
+/* Without --really nothing may be touched, whatever else is set. */
+static void test_remove_respects_dry_run(void)
+{
+    char path[] = "/tmp/audit-dry-XXXXXX";
+    struct buf out = BUF_INITIALIZER;
+    struct stat sbuf;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(path));
+    backdate(path);
+
+    audit_remove_path(delete_state(&out, 0), path);
+
+    CU_ASSERT_EQUAL(stat(path, &sbuf), 0);
+
+    rmdir(path);
+    buf_free(&out);
+}
+
+static void test_remove_deletes_when_really(void)
+{
+    char path[] = "/tmp/audit-real-XXXXXX";
+    struct buf out = BUF_INITIALIZER;
+    struct stat sbuf;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(path));
+    backdate(path);
+
+    audit_remove_path(delete_state(&out, 1), path);
+
+    CU_ASSERT_EQUAL(stat(path, &sbuf), -1);
+
+    buf_free(&out);
+}
+
+/* A young path is reported but survives even with --really. */
+static void test_remove_spares_young_even_when_really(void)
+{
+    char path[] = "/tmp/audit-spare-XXXXXX";
+    struct buf out = BUF_INITIALIZER;
+    struct stat sbuf;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(path));
+    /* deliberately not backdated */
+
+    audit_remove_path(delete_state(&out, 1), path);
+
+    CU_ASSERT_EQUAL(stat(path, &sbuf), 0);
+    CU_ASSERT(find_code(&out, "skipped-too-young"));
+
+    rmdir(path);
+    buf_free(&out);
+}
+
+/* Without --delete, removal is not even considered: a plain audit must
+ * never touch anything. */
+static void test_remove_does_nothing_without_delete(void)
+{
+    char path[] = "/tmp/audit-nodel-XXXXXX";
+    struct buf out = BUF_INITIALIZER;
+    struct audit_config config = AUDIT_CONFIG_INITIALIZER;
+    struct stat sbuf;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(path));
+    backdate(path);
+
+    config.out = &out;
+    config.really = 1;      /* but do_delete is off */
+    audit_remove_path(audit_begin(&config), path);
+
+    CU_ASSERT_EQUAL(stat(path, &sbuf), 0);
+    CU_ASSERT_EQUAL(buf_len(&out), 0);
+
+    rmdir(path);
+    buf_free(&out);
+}
+
+/* A non-empty directory must go entirely: a mailbox directory always has
+ * files in it. */
+static void test_remove_deletes_recursively(void)
+{
+    char path[] = "/tmp/audit-tree-XXXXXX";
+    struct buf out = BUF_INITIALIZER;
+    struct buf file = BUF_INITIALIZER;
+    struct stat sbuf;
+    FILE *f;
+
+    CU_ASSERT_PTR_NOT_NULL(mkdtemp(path));
+    test_mkpath("%s/sub", path);
+
+    buf_printf(&file, "%s/sub/cyrus.index", path);
+    f = fopen(buf_cstring(&file), "w");
+    CU_ASSERT_PTR_NOT_NULL(f);
+    if (f) fclose(f);
+
+    backdate(path);
+
+    audit_remove_path(delete_state(&out, 1), path);
+
+    CU_ASSERT_EQUAL(stat(path, &sbuf), -1);
+
+    buf_free(&file);
     buf_free(&out);
 }
 

--- a/cunit/audit.testc
+++ b/cunit/audit.testc
@@ -1,0 +1,116 @@
+/* audit.testc - unit tests for mailstore consistency auditing */
+/* SPDX-License-Identifier: BSD-3-Clause-CMU */
+/* See COPYING file at the root of the distribution for more details. */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <string.h>
+
+#include "cunit/unit.h"
+
+#include "imap/mboxlist.h"
+#include "lib/util.h"
+
+/* generated headers are not necessarily in current directory */
+#include "imap/imap_err.h"
+
+/* The mailboxes.db key separator.  Spell it as its own string literal and
+ * rely on concatenation: written inline, "\x1ebob" is a single hex escape
+ * of 0x1eb -- out of range -- because 'b' is a hex digit.
+ */
+#define SEP "\x1e"
+
+static void test_rawkey_name(void)
+{
+    struct mboxlist_rawkey key;
+    const char *raw = "Nuser" SEP "bob";
+    int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
+
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_NAME);
+    CU_ASSERT_STRING_EQUAL(key.dbname, "user" SEP "bob");
+    mboxlist_rawkey_fini(&key);
+}
+
+static void test_rawkey_id(void)
+{
+    struct mboxlist_rawkey key;
+    const char *raw = "I1234abcd";
+    int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
+
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_ID);
+    CU_ASSERT_STRING_EQUAL(key.uniqueid, "1234abcd");
+    mboxlist_rawkey_fini(&key);
+}
+
+static void test_rawkey_jmapid(void)
+{
+    struct mboxlist_rawkey key;
+    const char *raw = "Jbob" SEP "P123";
+    int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
+
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_JMAPID);
+    CU_ASSERT_STRING_EQUAL(key.userid, "bob");
+    CU_ASSERT_STRING_EQUAL(key.jmapid, "P123");
+    mboxlist_rawkey_fini(&key);
+}
+
+static void test_rawkey_racl_user(void)
+{
+    struct mboxlist_rawkey key;
+    const char *raw = "AU" SEP "alice" SEP "user" SEP "bob";
+    int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
+
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_RACL);
+    CU_ASSERT_EQUAL(key.isuser, 1);
+    CU_ASSERT_STRING_EQUAL(key.userid, "alice");
+    CU_ASSERT_STRING_EQUAL(key.aclmbox, "user" SEP "bob");
+    mboxlist_rawkey_fini(&key);
+}
+
+static void test_rawkey_racl_shared(void)
+{
+    struct mboxlist_rawkey key;
+    const char *raw = "AS" SEP "alice" SEP "shared";
+    int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
+
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_RACL);
+    CU_ASSERT_EQUAL(key.isuser, 0);
+    mboxlist_rawkey_fini(&key);
+}
+
+/* An unrecognised prefix must be reported, not guessed at: the audit's
+ * whole job is to notice keys that should not be in the database. */
+static void test_rawkey_unknown(void)
+{
+    struct mboxlist_rawkey key;
+    const char *raw = "Zwhatever";
+    int r = mboxlist_parse_rawkey(raw, strlen(raw), &key);
+
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(key.type, MBOXLIST_KEY_UNKNOWN);
+    mboxlist_rawkey_fini(&key);
+}
+
+/* A key with a valid prefix but no payload is malformed, not a valid key
+ * with an empty field. */
+static void test_rawkey_truncated(void)
+{
+    struct mboxlist_rawkey key;
+
+    CU_ASSERT_EQUAL(mboxlist_parse_rawkey("I", 1, &key), IMAP_MAILBOX_BADNAME);
+    CU_ASSERT_EQUAL(mboxlist_parse_rawkey("N", 1, &key), IMAP_MAILBOX_BADNAME);
+    CU_ASSERT_EQUAL(mboxlist_parse_rawkey("J", 1, &key), IMAP_MAILBOX_BADNAME);
+    CU_ASSERT_EQUAL(mboxlist_parse_rawkey("", 0, &key), IMAP_MAILBOX_BADNAME);
+
+    /* a J key needs both a userid and a jmapid */
+    CU_ASSERT_EQUAL(mboxlist_parse_rawkey("Jbob", 4, &key), IMAP_MAILBOX_BADNAME);
+}
+
+/* vim: set ft=c: */

--- a/docsrc/reference/manpages/systemcommands/chk_cyrus.rst
+++ b/docsrc/reference/manpages/systemcommands/chk_cyrus.rst
@@ -18,6 +18,8 @@ Synopsis
 
     **chk_cyrus** [ **-C** *config-file* ] [ **-P** *partition* | **-M** *mailbox* ]
 
+    **chk_cyrus** [ **-C** *config-file* ] **-l** *level* [ *audit-options* ]
+
 Description
 ===========
 
@@ -27,7 +29,51 @@ exist, but do not.  Status messages are output to stderr, the list of
 files/directories is output to stdout.  This list can be passed to a
 backup program to aid a partial restoration, for instance.
 
+Given **-l**, **chk_cyrus** instead runs in *audit mode*, described
+below.  Without **-l** its behaviour is exactly as it has always been, so
+existing invocations are unaffected.
+
 **chk_cyrus** |default-conf-text|
+
+Audit mode
+==========
+
+Audit mode checks the consistency of ``mailboxes.db`` against itself,
+against the mailbox directories on disk, and against the messages within
+them.  It answers the question the rest of Cyrus does not: which
+directories on disk have no database entry?
+
+The **-l** level selects how much is checked, and how much it costs:
+
+==== =========================================================
+0    ``mailboxes.db`` keyspace only; no filesystem access
+1    also database entries against the UUID directories on disk
+2    also index record exists against data file exists
+3    also file size matches the index record
+4    also file GUID matches the index record
+==== =========================================================
+
+Level 0 touches no disk at all, which makes it cheap enough to run often.
+Note that a repair (**--fix**) may still touch disk: assigning a missing
+jmapid opens the mailbox, because the id is derived from its modseq.
+
+Levels 0 and 1 are decidable from local state, and are where **--delete**
+and **--fix** act.  Levels 2 to 4 concern message and meta files, where a
+damaged file cannot be repaired from anything on this server, and where a
+local resolution does exist :cyrusman:`reconstruct(8)` already owns it.
+Those levels are therefore **report-only**, and combining them with
+**--delete** or **--fix** is an error.
+
+Nothing is modified without **--really**.  Directories and files newer
+than ten minutes are never removed, since they may belong to an operation
+still in flight.
+
+Findings are printed one per line.  With **--json** each is a JSON object
+with a stable ``code`` field, suitable for a driver to act on; absent
+fields are omitted rather than emitted as null.  Findings reporting
+damaged message files carry the mailbox, uid, and the GUID the index says
+the file should have, which is what an external tool needs in order to
+fetch a replacement from a replica or from backup.
 
 Options
 =======
@@ -51,6 +97,64 @@ Options
         The mailbox must be specified in the internal format, so rather
         than specifying ``user/john/Trash@example.org``, you will want
         to specify ``example.org!user.john.Trash``.
+
+.. option:: -l level, --level=level
+
+    Run in audit mode at the given level, 0 to 4.  See `Audit mode`_.
+
+.. option:: -j, --json
+
+    Emit findings as JSON, one object per line, instead of text.
+
+.. option:: -u userid, --user=userid
+
+    Restrict the audit to a single user.
+
+.. option:: --userlist=file
+
+    Read the usernames expected on this server from *file*, one per line.
+
+    This distinguishes a user whose INBOX has gone -- which needs a human,
+    since an INBOX cannot be recreated in UUID space -- from folders left
+    behind by a user who has moved away, which is routine cleanup.
+
+    Without it, every user found in the database is assumed to belong
+    here, so structural damage is still reported but removing a user is
+    never proposed.  Removing a whole user is never done by **chk_cyrus**
+    in any case: it rests entirely on external truth, so it is reported
+    and left to :cyrusman:`sync_reset(8)`.
+
+.. option:: --skip-user=userid
+
+    Exclude a user from the audit.  May be given more than once.  Useful
+    for users known to be mid-rename or mid-migration.
+
+.. option:: -d, --delete
+
+    Remove orphans that are decidable from local state: directories with
+    no database entry, database keys with no directory, unrecognised keys,
+    and J records that name no mailbox.  Only meaningful at level 0 or 1.
+
+.. option:: -f, --fix
+
+    Repair damage that is decidable from local state: a missing I record,
+    and a missing or unassigned jmapid.  Only meaningful at level 0 or 1.
+    May not be combined with **--delete**.
+
+.. option:: -y, --really
+
+    Actually make the changes.  Without it **--delete** and **--fix**
+    report what they would do and change nothing.
+
+.. option:: --prune-tombstones=days
+
+    Remove tombstone records, and the matching name history, older than
+    *days*.
+
+    There is no default and no pruning happens without this option.  A
+    tombstone removed before a replica has synchronised past it means that
+    replica never learns the name is gone, so the safe threshold depends
+    on your replication topology.
 
 Examples
 ========
@@ -80,6 +184,34 @@ Examples
 
         Perform consistency checks on mailbox *user.marysmith*.
 
+.. parsed-literal::
+
+    **chk_cyrus -l** *0*
+
+..
+
+        Check the ``mailboxes.db`` keyspace for internal inconsistencies,
+        without touching the filesystem.
+
+.. parsed-literal::
+
+    **chk_cyrus -l** *1* **--json**
+
+..
+
+        Also compare database entries against the mailbox directories on
+        disk, reporting findings as JSON for another tool to act on.
+
+.. parsed-literal::
+
+    **chk_cyrus -l** *1* **--delete**
+
+..
+
+        Report what removing the orphans would do, without doing it.  Add
+        **--really** to actually remove them.
+
 See Also
 ========
-:cyrusman:`imapd.conf(5)`, :cyrusman:`master(8)`
+:cyrusman:`imapd.conf(5)`, :cyrusman:`master(8)`,
+:cyrusman:`reconstruct(8)`, :cyrusman:`ctl_mboxlist(8)`

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -1028,27 +1028,28 @@ EXPORTED void audit_collect_roots(const char *partition, int types,
  * removing a whole slice of the store. */
 #define AUDIT_MIN_UNIQUEID_LEN 3
 
-static int all_lowerhex(const char *s, size_t len)
+static bool all_lowerhex(const char *s, size_t len)
 {
     size_t i;
 
     for (i = 0; i < len; i++) {
-        if (!isxdigit((unsigned char)s[i])) return 0;
-        if (isupper((unsigned char)s[i])) return 0;
+        if (!isxdigit((unsigned char)s[i])) return false;
+        if (isupper((unsigned char)s[i])) return false;
     }
 
-    return 1;
+    return true;
 }
 
-EXPORTED int audit_valid_uniqueid(const char *id)
+EXPORTED bool audit_valid_uniqueid(const char *id)
 {
     size_t len, i;
-    int dashes = 0, lower = 0, upper = 0;
+    int dashes = 0;
+    bool lower = false, upper = false;
 
-    if (!id) return 0;
+    if (!id) return false;
 
     len = strlen(id);
-    if (len < AUDIT_MIN_UNIQUEID_LEN) return 0;
+    if (len < AUDIT_MIN_UNIQUEID_LEN) return false;
 
     /* really old format: namehash + uidvalidity */
     if (len == 16) return all_lowerhex(id, len);
@@ -1058,9 +1059,9 @@ EXPORTED int audit_valid_uniqueid(const char *id)
         for (i = 0; i < len; i++) {
             if (islower((unsigned char)id[i])) continue;
             if (isdigit((unsigned char)id[i])) continue;
-            return 0;
+            return false;
         }
-        return 1;
+        return true;
     }
 
     /* uuid format, either builtin (lowercase) or imported (uppercase),
@@ -1068,18 +1069,18 @@ EXPORTED int audit_valid_uniqueid(const char *id)
     if (len == 36) {
         for (i = 0; i < len; i++) {
             if (id[i] == '-') { dashes++; continue; }
-            if (!isxdigit((unsigned char)id[i])) return 0;
-            if (islower((unsigned char)id[i])) lower = 1;
-            if (isupper((unsigned char)id[i])) upper = 1;
+            if (!isxdigit((unsigned char)id[i])) return false;
+            if (islower((unsigned char)id[i])) lower = true;
+            if (isupper((unsigned char)id[i])) upper = true;
         }
-        if (lower && upper) return 0;
+        if (lower && upper) return false;
         return dashes == 4;
     }
 
-    return 0;
+    return false;
 }
 
-static int valid_hashchar(const char *name)
+static bool valid_hashchar(const char *name)
 {
     return name[0] && !name[1] && isalnum((unsigned char)name[0]);
 }
@@ -1224,12 +1225,12 @@ EXPORTED void audit_scan_uuid_root(const char *root, strarray_t *found,
 /* ------------------------------------------------------------------ */
 /* removal, and the guards on it                                      */
 
-EXPORTED int audit_path_is_young(const char *path)
+EXPORTED bool audit_path_is_young(const char *path)
 {
     struct stat sbuf;
 
     /* already gone: nothing to protect */
-    if (stat(path, &sbuf) < 0) return 0;
+    if (stat(path, &sbuf) < 0) return false;
 
     return time(NULL) < sbuf.st_mtime + AUDIT_MIN_AGE;
 }
@@ -1559,7 +1560,7 @@ static int scan_cb(void *rock, const char *rawkey, size_t rawkeylen,
         break;
 
     case MBOXLIST_KEY_RACL:
-        /* collected but not yet cross-checked; see the racl work */
+        /* derived state: ctl_cyrusdb -r rebuilds it from the ACLs */
         break;
 
     case MBOXLIST_KEY_JMAPID:

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -1603,6 +1603,108 @@ static int scan_cb(void *rock, const char *rawkey, size_t rawkeylen,
     return 0;
 }
 
+/* ------------------------------------------------------------------ */
+/* levels 2-4: message and meta damage                                */
+
+/* Forward reconstruct's structured findings to the audit's emitter. */
+static void reconstruct_finding_cb(void *rock,
+                                   const struct reconstruct_finding *rf)
+{
+    struct audit_state *state = (struct audit_state *)rock;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    mbname_t *mbname = NULL;
+
+    finding.code = rf->code;
+    finding.mboxname = rf->mboxname;
+    finding.uniqueid = rf->uniqueid;
+    finding.path = rf->path;
+    finding.tier = rf->tier;
+    finding.metaname = rf->metaname;
+    finding.guid = rf->guid;
+    finding.uid = rf->uid;
+    finding.size = rf->size;
+    finding.has_uid = rf->has_uid;
+    finding.has_size = rf->has_size;
+
+    /* a driver fetching a replacement needs the owner */
+    if (rf->mboxname) {
+        mbname = mbname_from_intname(rf->mboxname);
+        finding.userid = mbname_userid(mbname);
+    }
+
+    audit_report(state, &finding);
+
+    mbname_free(&mbname);
+}
+
+struct mbcheckrock {
+    struct audit_state *state;
+    int flags;
+};
+
+static int check_mailbox_cb(const mbentry_t *mbentry, void *rock)
+{
+    struct mbcheckrock *mrock = (struct mbcheckrock *)rock;
+    struct reconstruct_report report = { reconstruct_finding_cb,
+                                         mrock->state };
+    mbname_t *mbname = NULL;
+    const char *userid;
+    int r;
+
+    if (mbentry->mbtype & (MBTYPE_DELETED | MBTYPE_REMOTE |
+                           MBTYPE_INTERMEDIATE))
+        return 0;
+
+    if (!entry_in_scope(mrock->state, mbentry)) return 0;
+
+    mbname = mbname_from_intname(mbentry->name);
+    userid = mbname_userid(mbname);
+
+    if (userid && mrock->state->config.skipusers &&
+        strarray_contains(mrock->state->config.skipusers, userid))
+        goto done;
+
+    /* Never RECONSTRUCT_MAKE_CHANGES.  Allowed to make changes it would
+     * expunge the index record for a missing file, destroying the very
+     * guid a driver needs to fetch the message back. */
+    r = mailbox_reconstruct_report(mbentry->name, mrock->flags, NULL, &report);
+
+    /* A mailbox that cannot even be opened is exactly what these levels
+     * exist to surface, and reconstruct cannot report it through the
+     * observer: with no changes allowed it stops at the failed open.
+     * Deleted mid-run is the exception -- that is not damage. */
+    if (r && r != IMAP_MAILBOX_NONEXISTENT) {
+        struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+        finding.code = "mailbox-unreadable";
+        finding.mboxname = mbentry->name;
+        finding.uniqueid = mbentry->uniqueid;
+        finding.userid = userid;
+        finding.detail = error_message(r);
+        audit_report(mrock->state, &finding);
+    }
+
+  done:
+    mbname_free(&mbname);
+
+    return 0;
+}
+
+static void audit_check_mailboxes(struct audit_state *state)
+{
+    struct mbcheckrock mrock = { state, 0 };
+
+    if (state->config.level >= 3) mrock.flags |= RECONSTRUCT_DO_STAT;
+    if (state->config.level >= 4) mrock.flags |= RECONSTRUCT_ALWAYS_PARSE;
+
+    if (state->config.userid) {
+        mboxlist_usermboxtree(state->config.userid, NULL, check_mailbox_cb,
+                              &mrock, 0);
+    }
+    else {
+        mboxlist_allmbox("", check_mailbox_cb, &mrock, 0);
+    }
+}
+
 EXPORTED int audit_run(struct audit_state *state)
 {
     struct audit_keyspace ks;
@@ -1639,6 +1741,10 @@ EXPORTED int audit_run(struct audit_state *state)
         r = audit_apply_repairs(state);
         if (!r) r = audit_apply_prunes(state);
         if (!r) r = audit_apply_jmapid_fixes(state);
+
+        /* Levels 2-4 are report-only, so they run after the repairs and
+         * take no part in them. */
+        if (!r && state->config.level >= 2) audit_check_mailboxes(state);
     }
 
     if (dofs) fsview_fini(&fs);

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -1291,17 +1291,40 @@ static void fsview_init(struct audit_fsview *fs)
 
 static void fsview_fini(struct audit_fsview *fs)
 {
-    free_hash_table(&fs->meta, NULL);
-    free_hash_table(&fs->data, NULL);
-    free_hash_table(&fs->archive, NULL);
-    free_hash_table(&fs->search, NULL);
-    free_hash_table(&fs->user, NULL);
-    free_hash_table(&fs->sieve, NULL);
+    /* values are the directory paths, owned by the table */
+    free_hash_table(&fs->meta, free);
+    free_hash_table(&fs->data, free);
+    free_hash_table(&fs->archive, free);
+    free_hash_table(&fs->search, free);
+    free_hash_table(&fs->user, free);
+    free_hash_table(&fs->sieve, free);
 }
 
 /* Sweep every root of one kind into a set.  Hashed rather than kept as a
  * list: a large store has millions of mailboxes and every cross-check
  * below is a membership test. */
+/* Record each uniqueid found under base, with the directory it was found
+ * in as the value.  The layout is deterministic -- it is what
+ * mboxname_id_hash() builds -- so the path is rebuilt rather than carried
+ * back out of the scanner. */
+static void collect_found(hash_table *set, const char *base,
+                          const strarray_t *found)
+{
+    int i;
+
+    for (i = 0; i < strarray_size(found); i++) {
+        const char *id = strarray_nth(found, i);
+        struct buf path = BUF_INITIALIZER;
+
+        if (hash_lookup(id, set)) continue;
+
+        buf_printf(&path, "%s/uuid/%c/%c/%s", base, id[0], id[1], id);
+        hash_insert(id, buf_release(&path), set);
+
+        buf_free(&path);
+    }
+}
+
 static void sweep_into(hash_table *set, const char *partition, int type,
                        const char *suffix, struct audit_state *state)
 {
@@ -1313,17 +1336,12 @@ static void sweep_into(hash_table *set, const char *partition, int type,
     for (i = 0; i < strarray_size(&roots); i++) {
         strarray_t found = STRARRAY_INITIALIZER;
         struct buf base = BUF_INITIALIZER;
-        int j;
 
         buf_setcstr(&base, strarray_nth(&roots, i));
         if (suffix) buf_printf(&base, "/%s", suffix);
 
         audit_scan_uuid_root(buf_cstring(&base), &found, state);
-
-        for (j = 0; j < strarray_size(&found); j++) {
-            const char *id = strarray_nth(&found, j);
-            if (!hash_lookup(id, set)) hash_insert(id, (void *)1, set);
-        }
+        collect_found(set, buf_cstring(&base), &found);
 
         buf_free(&base);
         strarray_fini(&found);
@@ -1338,14 +1356,9 @@ static void sweep_dir_into(hash_table *set, const char *dir,
                            struct audit_state *state)
 {
     strarray_t found = STRARRAY_INITIALIZER;
-    int i;
 
     audit_scan_uuid_root(dir, &found, state);
-
-    for (i = 0; i < strarray_size(&found); i++) {
-        const char *id = strarray_nth(&found, i);
-        if (!hash_lookup(id, set)) hash_insert(id, (void *)1, set);
-    }
+    collect_found(set, dir, &found);
 
     strarray_fini(&found);
 }
@@ -1385,26 +1398,43 @@ struct orphanrock {
     hash_table *against;
     const char *code;
     struct audit_state *state;
+    int removable;      /* is the path this refers to ours to remove? */
 };
 
-static void orphan_cb(const char *uniqueid,
-                      void *data __attribute__((unused)), void *rock)
+static void orphan_cb(const char *uniqueid, void *data, void *rock)
 {
     struct orphanrock *orock = (struct orphanrock *)rock;
+    const char *path = (const char *)data;
     struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
 
     if (hash_lookup(uniqueid, orock->against)) return;
 
     finding.code = orock->code;
     finding.uniqueid = uniqueid;
+    finding.path = path;
     audit_report(orock->state, &finding);
+
+    if (!orock->removable || !path) return;
+
+    /* Re-verify before acting: the sweep produced a candidate list, not a
+     * decision, and a mailbox may have been created since. */
+    if (!mboxlist_lookup_by_uniqueid(uniqueid, NULL, NULL)) {
+        struct audit_finding race = AUDIT_FINDING_INITIALIZER;
+        race.code = "race-detected";
+        race.uniqueid = uniqueid;
+        audit_report(orock->state, &race);
+        return;
+    }
+
+    audit_remove_path(orock->state, path);
 }
 
 /* Report each uniqueid in `set` that is absent from `against`. */
 static void report_orphans(hash_table *set, hash_table *against,
-                           const char *code, struct audit_state *state)
+                           const char *code, int removable,
+                           struct audit_state *state)
 {
-    struct orphanrock rock = { against, code, state };
+    struct orphanrock rock = { against, code, state, removable };
 
     hash_enumerate(set, orphan_cb, &rock);
 }
@@ -1445,22 +1475,23 @@ static void audit_check_filesystem(struct audit_fsview *fs,
     /* A mailbox directory with no database entry.  Nothing else in Cyrus
      * looks inward from the filesystem, so this is the direction only the
      * audit covers. */
-    report_orphans(&fs->meta, &ks->byid, "meta-dir-no-db-entry", state);
+    report_orphans(&fs->meta, &ks->byid, "meta-dir-no-db-entry", 1, state);
 
     /* Spool and archive without meta.  When those partitions share a disk
      * path with meta -- which is common -- the sets are identical and
      * these can never fire. */
-    report_orphans(&fs->data, &fs->meta, "spool-dir-no-meta-dir", state);
-    report_orphans(&fs->archive, &fs->meta, "archive-dir-no-meta-dir", state);
+    report_orphans(&fs->data, &fs->meta, "spool-dir-no-meta-dir", 1, state);
+    report_orphans(&fs->archive, &fs->meta, "archive-dir-no-meta-dir", 1,
+                   state);
 
     /* Only whole-uniqueid orphans are reported for search: adjudicating
      * individual xapian directories of a live mailbox needs to know
      * whether a repack is in flight, and getting that wrong destroys a
      * live index. */
-    report_orphans(&fs->search, &ks->byid, "search-dir-no-db-entry", state);
+    report_orphans(&fs->search, &ks->byid, "search-dir-no-db-entry", 1, state);
 
-    report_orphans(&fs->user, &ks->byid, "user-files-no-db-entry", state);
-    report_orphans(&fs->sieve, &ks->byid, "sieve-files-no-db-entry", state);
+    report_orphans(&fs->user, &ks->byid, "user-files-no-db-entry", 1, state);
+    report_orphans(&fs->sieve, &ks->byid, "sieve-files-no-db-entry", 1, state);
 
     hash_enumerate(&ks->byid, check_ondisk_cb, &drock);
 }

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -17,6 +17,7 @@
 
 #include "audit.h"
 #include "libconfig.h"
+#include "imap/imap_err.h"
 #include "mboxlist.h"
 #include "mboxname.h"
 #include "user.h"
@@ -33,7 +34,18 @@ struct audit_state {
      * read transaction, so nothing can be written while it runs. */
     strarray_t deletes;     /* raw keys to remove */
     strarray_t fix_jmapids; /* uniqueids needing a J record */
+    ptrarray_t prunes;      /* struct audit_prune */
 };
+
+/* A tombstone judged old enough to remove, and the I record it refers
+ * to.  What happens to that I record depends on whether it still carries
+ * the tombstoned name -- see audit_apply_prunes(). */
+struct audit_prune {
+    char *mboxname;
+    char *uniqueid;
+};
+
+static void free_prune(void *data);
 
 EXPORTED struct audit_state *audit_begin(const struct audit_config *config)
 {
@@ -147,6 +159,10 @@ EXPORTED void audit_done(struct audit_state **statep)
     strarray_fini(&(*statep)->deletes);
     strarray_fini(&(*statep)->fix_jmapids);
 
+    while (ptrarray_size(&(*statep)->prunes))
+        free_prune(ptrarray_pop(&(*statep)->prunes));
+    ptrarray_fini(&(*statep)->prunes);
+
     free(*statep);
     *statep = NULL;
 }
@@ -194,6 +210,124 @@ static void queue_fix_jmapid(struct audit_state *state, const char *uniqueid)
     if (!state->config.do_fix) return;
 
     strarray_append(&state->fix_jmapids, uniqueid);
+}
+
+static void queue_prune(struct audit_state *state, const char *mboxname,
+                        const char *uniqueid)
+{
+    struct audit_prune *p;
+
+    if (!state->config.prune_days) return;
+
+    p = xzmalloc(sizeof(struct audit_prune));
+    p->mboxname = xstrdupnull(mboxname);
+    p->uniqueid = xstrdupnull(uniqueid);
+
+    ptrarray_append(&state->prunes, p);
+}
+
+static void free_prune(void *data)
+{
+    struct audit_prune *p = (struct audit_prune *)data;
+
+    if (!p) return;
+    free(p->mboxname);
+    free(p->uniqueid);
+    free(p);
+}
+
+/* Remove a tombstone, and whatever refers to it.
+ *
+ * Rename tombstones the old name and moves the I record to the new one;
+ * delete tombstones the current name.  So for a tombstone at name X with
+ * uniqueid U:
+ *
+ *   I(U) exists and names X   the mailbox is entirely gone -- drop both
+ *   I(U) exists, names other  the mailbox lives elsewhere -- drop the
+ *                             tombstone and the matching history item
+ *   I(U) absent               an orphan -- drop the tombstone alone
+ *
+ * All within one transaction, so the database is never left describing a
+ * name that no longer exists.
+ */
+static int prune_one(const struct audit_prune *p, struct txn **tid)
+{
+    mbentry_t *byid = NULL;
+    struct buf key = BUF_INITIALIZER;
+    int i, r;
+
+    /* the tombstone itself, in every case */
+    mboxlist_key_for_name(p->mboxname, &key);
+    r = mboxlist_rawkey_delete(buf_base(&key), buf_len(&key), tid);
+    if (r) goto done;
+
+    r = mboxlist_lookup_by_uniqueid(p->uniqueid, &byid, tid);
+    if (r == IMAP_MAILBOX_NONEXISTENT) { r = 0; goto done; }
+    if (r) goto done;
+
+    if (!strcmpsafe(byid->name, p->mboxname)) {
+        /* nothing refers to this mailbox any more */
+        buf_reset(&key);
+        mboxlist_key_for_id(p->uniqueid, &key);
+        r = mboxlist_rawkey_delete(buf_base(&key), buf_len(&key), tid);
+        goto done;
+    }
+
+    /* the mailbox survives under another name: drop just the history
+     * item, rather than the record that still describes a live mailbox */
+    for (i = 0; i < ptrarray_size(&byid->name_history); i++) {
+        former_name_t *h = ptrarray_nth(&byid->name_history, i);
+
+        if (strcmpsafe(h->name, p->mboxname)) continue;
+
+        ptrarray_remove(&byid->name_history, i);
+        free(h->name);
+        free(h->partition);
+        free(h);
+
+        r = mboxlist_rewrite_id_record(byid, tid);
+        break;
+    }
+
+  done:
+    mboxlist_entry_free(&byid);
+    buf_free(&key);
+
+    return r;
+}
+
+static int audit_apply_prunes(struct audit_state *state)
+{
+    struct txn *tid = NULL;
+    int i, r = 0;
+
+    if (!ptrarray_size(&state->prunes)) return 0;
+
+    if (!state->config.really) {
+        for (i = 0; i < ptrarray_size(&state->prunes); i++) {
+            const struct audit_prune *p = ptrarray_nth(&state->prunes, i);
+            struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+            finding.code = "would-prune-tombstone";
+            finding.mboxname = p->mboxname;
+            finding.uniqueid = p->uniqueid;
+            audit_report(state, &finding);
+        }
+        return 0;
+    }
+
+    for (i = 0; i < ptrarray_size(&state->prunes); i++) {
+        r = prune_one(ptrarray_nth(&state->prunes, i), &tid);
+        if (r) break;
+    }
+
+    if (r) {
+        if (tid) mboxlist_abort(tid);
+        return r;
+    }
+
+    if (tid) r = mboxlist_commit(tid);
+
+    return r;
 }
 
 /* Apply everything queued, in one transaction.  Returns 0 on success. */
@@ -616,6 +750,22 @@ EXPORTED void audit_keyspace_check(struct audit_keyspace *ks,
         struct audit_dbentry *entry = hash_lookup(t->uniqueid, &ks->byid);
         struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
 
+        finding.uniqueid = t->uniqueid;
+        finding.mboxname = t->dbname;
+
+        /* Pruning is off unless an age was given: a tombstone removed
+         * before a replica has synced past it means that replica never
+         * learns the name is gone, and the safe threshold is a property
+         * of the deployment rather than something Cyrus can know. */
+        if (state->config.prune_days &&
+            t->mtime &&
+            t->mtime < time(NULL) - (state->config.prune_days * 86400)) {
+            finding.code = "db-stale-tombstone";
+            audit_report(state, &finding);
+            queue_prune(state, t->dbname, t->uniqueid);
+            continue;
+        }
+
         /* no I record at all: an orphan tombstone.  Prunable, but not an
          * inconsistency -- there is nothing left for it to disagree with */
         if (!entry) continue;
@@ -624,8 +774,6 @@ EXPORTED void audit_keyspace_check(struct audit_keyspace *ks,
         if (find_history_item(ks, t->uniqueid, t->dbname)) continue; /* renamed */
 
         finding.code = "db-tombstone-no-history";
-        finding.uniqueid = t->uniqueid;
-        finding.mboxname = t->dbname;
         audit_report(state, &finding);
     }
 
@@ -1458,6 +1606,7 @@ EXPORTED int audit_run(struct audit_state *state)
         /* Only now, with the read transaction closed and every check
          * done, do we write anything. */
         r = audit_apply_repairs(state);
+        if (!r) r = audit_apply_prunes(state);
         if (!r) r = audit_apply_jmapid_fixes(state);
     }
 

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -314,20 +314,41 @@ static int find_tombstone(const struct audit_keyspace *ks, const char *dbname)
     return 0;
 }
 
-/* Does a J key exist pointing at this entry with the entry's own jmapid? */
+/* Does a J key exist for this entry, naming this mailbox?
+ *
+ * The match is on all three of (userid, jmapid, uniqueid): a J record
+ * that names a different mailbox does not make this one reachable by
+ * jmapid.  That is only a safe thing to require because the caller has
+ * told us conversations are enabled -- see check_jmapids.
+ */
 static int find_jmapid_key(const struct audit_keyspace *ks,
-                           const struct audit_dbentry *entry)
+                           const struct audit_dbentry *entry,
+                           struct buf *founduser)
 {
-    int i;
+    mbname_t *mbname;
+    const char *userid;
+    int i, found = 0;
+
+    if (!entry->dbname) return 0;
+
+    mbname = mbname_from_intname(entry->dbname);
+    userid = mbname_userid(mbname);
+    if (!userid) userid = "";
+
+    if (founduser) buf_setcstr(founduser, userid);
 
     for (i = 0; i < ptrarray_size(&ks->jmapids); i++) {
         const struct audit_jmapid *j = ptrarray_nth(&ks->jmapids, i);
-        if (strcmpsafe(j->uniqueid, entry->uniqueid)) continue;
         if (strcmpsafe(j->jmapid, entry->jmapid)) continue;
-        return 1;
+        if (strcmpsafe(j->userid, userid)) continue;
+        if (strcmpsafe(j->uniqueid, entry->uniqueid)) continue;
+        found = 1;
+        break;
     }
 
-    return 0;
+    mbname_free(&mbname);
+
+    return found;
 }
 
 struct checkrock {
@@ -359,15 +380,25 @@ static void check_id_cb(const char *uniqueid, void *data, void *rock)
         audit_report(crock->state, &finding);
     }
 
+    /* The J keyspace is only meaningful with conversations enabled. */
+    if (!crock->state->config.check_jmapids) return;
+
     if (!entry->jmapid) {
         finding.code = "db-missing-j-property";
         finding.detail = "run ctl_mboxlist -k";
         audit_report(crock->state, &finding);
     }
-    else if (!find_jmapid_key(crock->ks, entry)) {
-        finding.code = "db-missing-j-key";
-        finding.detail = "run ctl_mboxlist -k";
-        audit_report(crock->state, &finding);
+    else {
+        struct buf owner = BUF_INITIALIZER;
+
+        if (!find_jmapid_key(crock->ks, entry, &owner)) {
+            finding.code = "db-missing-j-key";
+            finding.userid = buf_cstring(&owner);
+            finding.detail = "run ctl_mboxlist -k";
+            audit_report(crock->state, &finding);
+        }
+
+        buf_free(&owner);
     }
 }
 
@@ -398,7 +429,8 @@ EXPORTED void audit_keyspace_check(struct audit_keyspace *ks,
     hash_enumerate(&ks->byid, check_id_cb, &crock);
     hash_enumerate(&ks->byname, check_name_cb, &crock);
 
-    for (i = 0; i < ptrarray_size(&ks->jmapids); i++) {
+    for (i = 0; state->config.check_jmapids &&
+                i < ptrarray_size(&ks->jmapids); i++) {
         struct audit_jmapid *j = ptrarray_nth(&ks->jmapids, i);
         struct audit_dbentry *entry = hash_lookup(j->uniqueid, &ks->byid);
         struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
@@ -578,4 +610,134 @@ EXPORTED void audit_check_users(struct audit_keyspace *ks,
     hash_enumerate(&users, check_user_cb, &urock);
 
     free_hash_table(&users, free_userinfo);
+}
+
+/* ------------------------------------------------------------------ */
+/* driving the scan                                                   */
+
+struct scanrock {
+    struct audit_keyspace *ks;
+    struct audit_state *state;
+};
+
+/* Is this entry one we should consider at all, given --partition and
+ * --user?  A partition-scoped run must ignore entries elsewhere, or it
+ * would report every mailbox on another partition as an orphan. */
+static int entry_in_scope(struct audit_state *state, const mbentry_t *mbentry)
+{
+    if (state->config.partition) {
+        if (strcmpsafe(mbentry->partition, state->config.partition))
+            return 0;
+    }
+
+    if (state->config.userid) {
+        mbname_t *mbname = mbname_from_intname(mbentry->name);
+        int match = !strcmpsafe(mbname_userid(mbname), state->config.userid);
+        mbname_free(&mbname);
+        if (!match) return 0;
+    }
+
+    return 1;
+}
+
+static int scan_cb(void *rock, const struct mboxlist_rawkey *key,
+                   const mbentry_t *mbentry,
+                   const char *data __attribute__((unused)),
+                   size_t datalen __attribute__((unused)))
+{
+    struct scanrock *srock = (struct scanrock *)rock;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    int i;
+
+    switch (key->type) {
+    case MBOXLIST_KEY_UNKNOWN:
+        finding.code = "db-unknown-key";
+        audit_report(srock->state, &finding);
+        return 0;
+
+    case MBOXLIST_KEY_RACL:
+        /* collected but not yet cross-checked; see the racl work */
+        return 0;
+
+    case MBOXLIST_KEY_JMAPID:
+        if (!mbentry) {
+            finding.code = "db-unparseable-entry";
+            finding.userid = key->userid;
+            audit_report(srock->state, &finding);
+            return 0;
+        }
+        audit_keyspace_add_jmapid(srock->ks, key->userid, key->jmapid,
+                                  mbentry->uniqueid);
+        return 0;
+
+    case MBOXLIST_KEY_ID:
+        if (!mbentry) {
+            finding.code = "db-unparseable-entry";
+            finding.uniqueid = key->uniqueid;
+            audit_report(srock->state, &finding);
+            return 0;
+        }
+        if (!entry_in_scope(srock->state, mbentry)) return 0;
+
+        audit_keyspace_add_id(srock->ks, key->uniqueid, mbentry->name,
+                              mbentry->mbtype, mbentry->jmapid);
+
+        /* the former names this record remembers */
+        for (i = 0; i < ptrarray_size(&mbentry->name_history); i++) {
+            const former_name_t *h = ptrarray_nth(&mbentry->name_history, i);
+            audit_keyspace_add_history(srock->ks, key->uniqueid,
+                                       h->name, h->mtime);
+        }
+        return 0;
+
+    case MBOXLIST_KEY_NAME:
+        if (!mbentry) {
+            finding.code = "db-unparseable-entry";
+            finding.mboxname = key->dbname;
+            audit_report(srock->state, &finding);
+            return 0;
+        }
+        if (!entry_in_scope(srock->state, mbentry)) return 0;
+
+        /* A tombstone records a name that is gone.  It is not a live
+         * mailbox, so it must not satisfy the I-without-N check. */
+        if (mbentry->mbtype & MBTYPE_DELETED) {
+            audit_keyspace_add_tombstone(srock->ks, mbentry->name,
+                                         mbentry->uniqueid, mbentry->mtime);
+            return 0;
+        }
+
+        audit_keyspace_add_name(srock->ks, mbentry->name, mbentry->uniqueid,
+                                mbentry->mbtype, mbentry->jmapid);
+        return 0;
+    }
+
+    return 0;
+}
+
+EXPORTED int audit_run(struct audit_state *state)
+{
+    struct audit_keyspace ks;
+    struct scanrock srock = { &ks, state };
+    struct txn *tid = NULL;
+    int r;
+
+    audit_keyspace_init(&ks);
+
+    /* One transaction for the whole scan: the cross-checks compare keys of
+     * different types against each other, so they need a snapshot that is
+     * consistent across all of them. */
+    r = mboxlist_foreach_raw(scan_cb, &srock, &tid);
+
+    /* read-only: nothing to commit */
+    if (tid) mboxlist_abort(tid);
+
+    if (!r) {
+        audit_keyspace_check(&ks, state);
+        audit_check_users(&ks, state);
+    }
+
+    audit_keyspace_fini(&ks);
+
+    return r;
 }

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -19,6 +19,7 @@
 #include "libconfig.h"
 #include "mboxlist.h"
 #include "mboxname.h"
+#include "user.h"
 #include "xmalloc.h"
 
 struct audit_state {
@@ -31,6 +32,7 @@ struct audit_state {
      * database as it was rather than half-fixed.  The scan itself holds a
      * read transaction, so nothing can be written while it runs. */
     strarray_t deletes;     /* raw keys to remove */
+    strarray_t fix_jmapids; /* uniqueids needing a J record */
 };
 
 EXPORTED struct audit_state *audit_begin(const struct audit_config *config)
@@ -143,6 +145,7 @@ EXPORTED void audit_done(struct audit_state **statep)
     if (!statep || !*statep) return;
 
     strarray_fini(&(*statep)->deletes);
+    strarray_fini(&(*statep)->fix_jmapids);
 
     free(*statep);
     *statep = NULL;
@@ -183,6 +186,16 @@ static void queue_delete_jmapid(struct audit_state *state,
     buf_free(&key);
 }
 
+/* Queue a mailbox for jmapid repair.  Unlike the deletions this is not a
+ * raw key write -- mboxlist_fix_jmapid() may have to open the mailbox and
+ * bump its modseq -- so it is applied outside the delete transaction. */
+static void queue_fix_jmapid(struct audit_state *state, const char *uniqueid)
+{
+    if (!state->config.do_fix) return;
+
+    strarray_append(&state->fix_jmapids, uniqueid);
+}
+
 /* Apply everything queued, in one transaction.  Returns 0 on success. */
 static int audit_apply_repairs(struct audit_state *state)
 {
@@ -221,6 +234,54 @@ static int audit_apply_repairs(struct audit_state *state)
     }
 
     if (tid) r = mboxlist_commit(tid);
+
+    return r;
+}
+
+/* Assign jmapids to the mailboxes that need one.  Separate from the
+ * delete transaction because mboxlist_fix_jmapid() opens the mailbox and
+ * bumps its modseq, and holds its own locks while doing so. */
+static int audit_apply_jmapid_fixes(struct audit_state *state)
+{
+    int i, r = 0;
+
+    for (i = 0; i < strarray_size(&state->fix_jmapids); i++) {
+        const char *uniqueid = strarray_nth(&state->fix_jmapids, i);
+        mbentry_t *mbentry = NULL;
+        user_nslock_t *nslock = NULL;
+        int r2;
+
+        /* Re-verify: the sweep produced a candidate list, not a decision,
+         * and the mailbox may have changed since. */
+        r2 = mboxlist_lookup_by_uniqueid(uniqueid, &mbentry, NULL);
+        if (r2 || !mbentry) {
+            mboxlist_entry_free(&mbentry);
+            continue;
+        }
+
+        if (!state->config.really) {
+            struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+            finding.code = "would-fix-jmapid";
+            finding.uniqueid = uniqueid;
+            finding.mboxname = mbentry->name;
+            audit_report(state, &finding);
+            mboxlist_entry_free(&mbentry);
+            continue;
+        }
+
+        nslock = user_nslock_lockmb_w(mbentry->name);
+        r2 = mboxlist_fix_jmapid(mbentry);
+        user_nslock_release(&nslock);
+
+        if (r2) {
+            xsyslog(LOG_ERR, "audit: failed to fix jmapid",
+                    "mboxname=<%s> error=<%s>",
+                    mbentry->name, error_message(r2));
+            if (!r) r = r2;
+        }
+
+        mboxlist_entry_free(&mbentry);
+    }
 
     return r;
 }
@@ -477,8 +538,8 @@ static void check_id_cb(const char *uniqueid, void *data, void *rock)
 
     if (!entry->jmapid) {
         finding.code = "db-missing-j-property";
-        finding.detail = "run ctl_mboxlist -k";
         audit_report(crock->state, &finding);
+        queue_fix_jmapid(crock->state, uniqueid);
     }
     else {
         struct buf owner = BUF_INITIALIZER;
@@ -486,8 +547,8 @@ static void check_id_cb(const char *uniqueid, void *data, void *rock)
         if (!find_jmapid_key(crock->ks, entry, &owner)) {
             finding.code = "db-missing-j-key";
             finding.userid = buf_cstring(&owner);
-            finding.detail = "run ctl_mboxlist -k";
             audit_report(crock->state, &finding);
+            queue_fix_jmapid(crock->state, uniqueid);
         }
 
         buf_free(&owner);
@@ -1397,6 +1458,7 @@ EXPORTED int audit_run(struct audit_state *state)
         /* Only now, with the read transaction closed and every check
          * done, do we write anything. */
         r = audit_apply_repairs(state);
+        if (!r) r = audit_apply_jmapid_fixes(state);
     }
 
     if (dofs) fsview_fini(&fs);

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -25,6 +25,12 @@ struct audit_state {
     struct audit_config config;
     struct buf *out;        /* borrowed from config, or NULL for stdout */
     unsigned count;
+
+    /* Repairs are accumulated during the checks and applied afterwards in
+     * one transaction, so that a failure part-way through leaves the
+     * database as it was rather than half-fixed.  The scan itself holds a
+     * read transaction, so nothing can be written while it runs. */
+    strarray_t deletes;     /* raw keys to remove */
 };
 
 EXPORTED struct audit_state *audit_begin(const struct audit_config *config)
@@ -136,8 +142,87 @@ EXPORTED void audit_done(struct audit_state **statep)
 {
     if (!statep || !*statep) return;
 
+    strarray_fini(&(*statep)->deletes);
+
     free(*statep);
     *statep = NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* repairs                                                            */
+
+/* Queue a key for removal.  Nothing is written during the scan: the
+ * checks run inside a read transaction, and a repair may touch several
+ * keys that must land together or not at all. */
+static void queue_delete(struct audit_state *state, const struct buf *key)
+{
+    if (!state->config.do_delete) return;
+
+    strarray_appendm(&state->deletes,
+                     xstrndup(buf_base(key), buf_len(key)));
+}
+
+static void queue_delete_id(struct audit_state *state, const char *uniqueid)
+{
+    struct buf key = BUF_INITIALIZER;
+
+    mboxlist_key_for_id(uniqueid, &key);
+    queue_delete(state, &key);
+
+    buf_free(&key);
+}
+
+static void queue_delete_jmapid(struct audit_state *state,
+                                const char *userid, const char *jmapid)
+{
+    struct buf key = BUF_INITIALIZER;
+
+    mboxlist_key_for_jmapid(userid, jmapid, &key);
+    queue_delete(state, &key);
+
+    buf_free(&key);
+}
+
+/* Apply everything queued, in one transaction.  Returns 0 on success. */
+static int audit_apply_repairs(struct audit_state *state)
+{
+    struct txn *tid = NULL;
+    int i, r = 0;
+
+    if (!strarray_size(&state->deletes)) return 0;
+
+    /* Without --really the intent has already been reported and there is
+     * nothing to write. */
+    if (!state->config.really) {
+        for (i = 0; i < strarray_size(&state->deletes); i++) {
+            struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+            finding.code = "would-delete-key";
+            finding.detail = strarray_nth(&state->deletes, i);
+            audit_report(state, &finding);
+        }
+        return 0;
+    }
+
+    for (i = 0; i < strarray_size(&state->deletes); i++) {
+        const char *key = strarray_nth(&state->deletes, i);
+
+        r = mboxlist_rawkey_delete(key, strlen(key), &tid);
+        if (r) {
+            xsyslog(LOG_ERR, "audit: failed to delete key",
+                    "error=<%s>", cyrusdb_strerror(r));
+            break;
+        }
+    }
+
+    if (r) {
+        /* leave the database as it was rather than half-repaired */
+        if (tid) mboxlist_abort(tid);
+        return r;
+    }
+
+    if (tid) r = mboxlist_commit(tid);
+
+    return r;
 }
 
 /* ------------------------------------------------------------------ */
@@ -383,6 +468,8 @@ static void check_id_cb(const char *uniqueid, void *data, void *rock)
     if (!entry->dbname || !hash_lookup(entry->dbname, &crock->ks->byname)) {
         finding.code = "db-missing-n-key";
         audit_report(crock->state, &finding);
+        /* an I record nothing can reach by name */
+        queue_delete_id(crock->state, uniqueid);
     }
 
     /* The J keyspace is only meaningful with conversations enabled. */
@@ -446,6 +533,7 @@ EXPORTED void audit_keyspace_check(struct audit_keyspace *ks,
         if (!entry) {
             finding.code = "db-bogus-jmapid";
             audit_report(state, &finding);
+            queue_delete_jmapid(state, j->userid, j->jmapid);
             continue;
         }
 
@@ -455,6 +543,7 @@ EXPORTED void audit_keyspace_check(struct audit_keyspace *ks,
             finding.code = "db-bad-jmapid";
             finding.mboxname = entry->dbname;
             audit_report(state, &finding);
+            queue_delete_jmapid(state, j->userid, j->jmapid);
         }
     }
 
@@ -924,6 +1013,50 @@ EXPORTED void audit_scan_uuid_root(const char *root, strarray_t *found,
 }
 
 /* ------------------------------------------------------------------ */
+/* removal, and the guards on it                                      */
+
+EXPORTED int audit_path_is_young(const char *path)
+{
+    struct stat sbuf;
+
+    /* already gone: nothing to protect */
+    if (stat(path, &sbuf) < 0) return 0;
+
+    return time(NULL) < sbuf.st_mtime + AUDIT_MIN_AGE;
+}
+
+EXPORTED void audit_remove_path(struct audit_state *state, const char *path)
+{
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+    /* a plain audit never touches anything */
+    if (!state->config.do_delete) return;
+
+    /* Anything this new may belong to an operation still in flight.  No
+     * flag overrides this; tests backdate mtimes instead. */
+    if (audit_path_is_young(path)) {
+        finding.code = "skipped-too-young";
+        finding.path = path;
+        audit_report(state, &finding);
+        return;
+    }
+
+    if (!state->config.really) {
+        finding.code = "would-remove";
+        finding.path = path;
+        audit_report(state, &finding);
+        return;
+    }
+
+    if (removedir(path)) {
+        xsyslog(LOG_ERR, "audit: failed to remove", "path=<%s>", path);
+        finding.code = "remove-failed";
+        finding.path = path;
+        audit_report(state, &finding);
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /* level 1: db entries vs directories on disk                         */
 
 /* The on-disk view, one set of uniqueids per kind of location. */
@@ -1151,44 +1284,51 @@ static int entry_in_scope(struct audit_state *state, const mbentry_t *mbentry)
     return 1;
 }
 
-static int scan_cb(void *rock, const struct mboxlist_rawkey *key,
+static int scan_cb(void *rock, const char *rawkey, size_t rawkeylen,
+                   const struct mboxlist_rawkey *key,
                    const mbentry_t *mbentry,
                    const char *data __attribute__((unused)),
                    size_t datalen __attribute__((unused)))
 {
     struct scanrock *srock = (struct scanrock *)rock;
     struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+    struct buf keybuf = BUF_INITIALIZER;
     int i;
+
+    buf_init_ro(&keybuf, rawkey, rawkeylen);
+
+    /* A value that will not parse cannot be interpreted or repaired, only
+     * removed.  Reporting it is the whole reason this scan reads the
+     * keyspace raw rather than through the lookup API. */
+    if (key->type != MBOXLIST_KEY_UNKNOWN &&
+        key->type != MBOXLIST_KEY_RACL && !mbentry) {
+        finding.code = "db-unparseable-entry";
+        finding.uniqueid = key->uniqueid;
+        finding.mboxname = key->dbname;
+        finding.userid = key->userid;
+        audit_report(srock->state, &finding);
+        queue_delete(srock->state, &keybuf);
+        goto done;
+    }
 
     switch (key->type) {
     case MBOXLIST_KEY_UNKNOWN:
         finding.code = "db-unknown-key";
         audit_report(srock->state, &finding);
-        return 0;
+        queue_delete(srock->state, &keybuf);
+        break;
 
     case MBOXLIST_KEY_RACL:
         /* collected but not yet cross-checked; see the racl work */
-        return 0;
+        break;
 
     case MBOXLIST_KEY_JMAPID:
-        if (!mbentry) {
-            finding.code = "db-unparseable-entry";
-            finding.userid = key->userid;
-            audit_report(srock->state, &finding);
-            return 0;
-        }
         audit_keyspace_add_jmapid(srock->ks, key->userid, key->jmapid,
                                   mbentry->uniqueid);
-        return 0;
+        break;
 
     case MBOXLIST_KEY_ID:
-        if (!mbentry) {
-            finding.code = "db-unparseable-entry";
-            finding.uniqueid = key->uniqueid;
-            audit_report(srock->state, &finding);
-            return 0;
-        }
-        if (!entry_in_scope(srock->state, mbentry)) return 0;
+        if (!entry_in_scope(srock->state, mbentry)) break;
 
         audit_keyspace_add_id(srock->ks, key->uniqueid, mbentry->name,
                               mbentry->mbtype, mbentry->jmapid);
@@ -1199,29 +1339,26 @@ static int scan_cb(void *rock, const struct mboxlist_rawkey *key,
             audit_keyspace_add_history(srock->ks, key->uniqueid,
                                        h->name, h->mtime);
         }
-        return 0;
+        break;
 
     case MBOXLIST_KEY_NAME:
-        if (!mbentry) {
-            finding.code = "db-unparseable-entry";
-            finding.mboxname = key->dbname;
-            audit_report(srock->state, &finding);
-            return 0;
-        }
-        if (!entry_in_scope(srock->state, mbentry)) return 0;
+        if (!entry_in_scope(srock->state, mbentry)) break;
 
         /* A tombstone records a name that is gone.  It is not a live
          * mailbox, so it must not satisfy the I-without-N check. */
         if (mbentry->mbtype & MBTYPE_DELETED) {
             audit_keyspace_add_tombstone(srock->ks, mbentry->name,
                                          mbentry->uniqueid, mbentry->mtime);
-            return 0;
+            break;
         }
 
         audit_keyspace_add_name(srock->ks, mbentry->name, mbentry->uniqueid,
                                 mbentry->mbtype, mbentry->jmapid);
-        return 0;
+        break;
     }
+
+  done:
+    buf_free(&keybuf);
 
     return 0;
 }
@@ -1256,6 +1393,10 @@ EXPORTED int audit_run(struct audit_state *state)
         audit_keyspace_check(&ks, state);
         audit_check_users(&ks, state);
         if (dofs) audit_check_filesystem(&fs, &ks, state);
+
+        /* Only now, with the read transaction closed and every check
+         * done, do we write anything. */
+        r = audit_apply_repairs(state);
     }
 
     if (dofs) fsview_fini(&fs);

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -1,0 +1,581 @@
+/* audit.c - mailstore consistency auditing */
+/* SPDX-License-Identifier: BSD-3-Clause-CMU */
+/* See COPYING file at the root of the distribution for more details. */
+
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#include <jansson.h>
+
+#include "audit.h"
+#include "mboxlist.h"
+#include "mboxname.h"
+#include "xmalloc.h"
+
+struct audit_state {
+    struct audit_config config;
+    struct buf *out;        /* borrowed from config, or NULL for stdout */
+    unsigned count;
+};
+
+EXPORTED struct audit_state *audit_begin(const struct audit_config *config)
+{
+    struct audit_state *state = xzmalloc(sizeof(struct audit_state));
+
+    state->config = *config;
+    state->out = config->out;
+
+    return state;
+}
+
+EXPORTED unsigned audit_finding_count(const struct audit_state *state)
+{
+    return state ? state->count : 0;
+}
+
+static void audit_emit(struct audit_state *state, struct buf *line)
+{
+    if (state->out) {
+        buf_append(state->out, line);
+        buf_putc(state->out, '\n');
+    }
+    else {
+        printf("%s\n", buf_cstring(line));
+    }
+}
+
+static void audit_emit_json(struct audit_state *state,
+                            const struct audit_finding *finding)
+{
+    json_t *obj = json_object();
+    struct buf line = BUF_INITIALIZER;
+    char *dumped;
+
+    /* Absent fields are omitted rather than emitted as null, so that a
+     * consumer can simply test for presence. */
+    json_object_set_new(obj, "code", json_string(finding->code));
+    if (finding->uniqueid)
+        json_object_set_new(obj, "uniqueid", json_string(finding->uniqueid));
+    if (finding->mboxname)
+        json_object_set_new(obj, "mboxname", json_string(finding->mboxname));
+    if (finding->userid)
+        json_object_set_new(obj, "user", json_string(finding->userid));
+    if (finding->path)
+        json_object_set_new(obj, "path", json_string(finding->path));
+    if (finding->tier)
+        json_object_set_new(obj, "tier", json_string(finding->tier));
+    if (finding->metaname)
+        json_object_set_new(obj, "metaname", json_string(finding->metaname));
+    if (finding->guid)
+        json_object_set_new(obj, "guid", json_string(finding->guid));
+    if (finding->detail)
+        json_object_set_new(obj, "detail", json_string(finding->detail));
+    if (finding->has_uid)
+        json_object_set_new(obj, "uid", json_integer(finding->uid));
+    if (finding->has_size)
+        json_object_set_new(obj, "size", json_integer(finding->size));
+
+    dumped = json_dumps(obj, JSON_COMPACT | JSON_PRESERVE_ORDER);
+    if (dumped) {
+        buf_setcstr(&line, dumped);
+        audit_emit(state, &line);
+        free(dumped);
+    }
+
+    buf_free(&line);
+    json_decref(obj);
+}
+
+static void audit_emit_text(struct audit_state *state,
+                            const struct audit_finding *finding)
+{
+    struct buf line = BUF_INITIALIZER;
+
+    buf_setcstr(&line, finding->code);
+    if (finding->mboxname) buf_printf(&line, " %s", finding->mboxname);
+    if (finding->uniqueid) buf_printf(&line, " (%s)", finding->uniqueid);
+    if (finding->has_uid) buf_printf(&line, " uid %u", finding->uid);
+    if (finding->path) buf_printf(&line, " %s", finding->path);
+    if (finding->detail) buf_printf(&line, " - %s", finding->detail);
+
+    audit_emit(state, &line);
+    buf_free(&line);
+}
+
+EXPORTED void audit_report(struct audit_state *state,
+                           const struct audit_finding *finding)
+{
+    if (!state || !finding) return;
+
+    /* A finding with no code is a programming error upstream.  Drop it
+     * rather than emitting something a consumer cannot dispatch on. */
+    if (!finding->code) return;
+
+    state->count++;
+
+    if (state->config.json) audit_emit_json(state, finding);
+    else audit_emit_text(state, finding);
+
+    syslog(LOG_NOTICE, "audit: %s mailbox=<%s> uniqueid=<%s> path=<%s>",
+           finding->code,
+           finding->mboxname ? finding->mboxname : "",
+           finding->uniqueid ? finding->uniqueid : "",
+           finding->path ? finding->path : "");
+}
+
+EXPORTED void audit_done(struct audit_state **statep)
+{
+    if (!statep || !*statep) return;
+
+    free(*statep);
+    *statep = NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* level 0: the mailboxes.db keyspace                                 */
+
+static void free_dbentry(void *data)
+{
+    struct audit_dbentry *entry = (struct audit_dbentry *)data;
+
+    if (!entry) return;
+    free(entry->uniqueid);
+    free(entry->dbname);
+    free(entry->jmapid);
+    free(entry);
+}
+
+static void free_jmapid(void *data)
+{
+    struct audit_jmapid *j = (struct audit_jmapid *)data;
+
+    if (!j) return;
+    free(j->userid);
+    free(j->jmapid);
+    free(j->uniqueid);
+    free(j);
+}
+
+static void free_tombstone(void *data)
+{
+    struct audit_tombstone *t = (struct audit_tombstone *)data;
+
+    if (!t) return;
+    free(t->dbname);
+    free(t->uniqueid);
+    free(t);
+}
+
+static void free_history(void *data)
+{
+    struct audit_history *h = (struct audit_history *)data;
+
+    if (!h) return;
+    free(h->uniqueid);
+    free(h->dbname);
+    free(h);
+}
+
+EXPORTED void audit_keyspace_init(struct audit_keyspace *ks)
+{
+    memset(ks, 0, sizeof(*ks));
+
+    /* not mpool-backed: entries are freed individually in fini */
+    construct_hash_table(&ks->byid, 4096, 0);
+    construct_hash_table(&ks->byname, 4096, 0);
+    ptrarray_init(&ks->jmapids);
+    ptrarray_init(&ks->tombstones);
+    ptrarray_init(&ks->history);
+}
+
+EXPORTED void audit_keyspace_fini(struct audit_keyspace *ks)
+{
+    void *item;
+
+    free_hash_table(&ks->byid, free_dbentry);
+    free_hash_table(&ks->byname, free_dbentry);
+
+    while ((item = ptrarray_pop(&ks->jmapids)))
+        free_jmapid(item);
+    ptrarray_fini(&ks->jmapids);
+
+    while ((item = ptrarray_pop(&ks->tombstones)))
+        free_tombstone(item);
+    ptrarray_fini(&ks->tombstones);
+
+    while ((item = ptrarray_pop(&ks->history)))
+        free_history(item);
+    ptrarray_fini(&ks->history);
+}
+
+static struct audit_dbentry *new_dbentry(const char *uniqueid,
+                                         const char *dbname,
+                                         uint32_t mbtype,
+                                         const char *jmapid)
+{
+    struct audit_dbentry *entry = xzmalloc(sizeof(struct audit_dbentry));
+
+    entry->uniqueid = xstrdupnull(uniqueid);
+    entry->dbname = xstrdupnull(dbname);
+    entry->jmapid = xstrdupnull(jmapid);
+    entry->mbtype = mbtype;
+
+    return entry;
+}
+
+EXPORTED void audit_keyspace_add_id(struct audit_keyspace *ks,
+                                    const char *uniqueid, const char *dbname,
+                                    uint32_t mbtype, const char *jmapid)
+{
+    if (!uniqueid) return;
+    hash_insert(uniqueid, new_dbentry(uniqueid, dbname, mbtype, jmapid),
+                &ks->byid);
+}
+
+EXPORTED void audit_keyspace_add_name(struct audit_keyspace *ks,
+                                      const char *dbname, const char *uniqueid,
+                                      uint32_t mbtype, const char *jmapid)
+{
+    if (!dbname) return;
+    hash_insert(dbname, new_dbentry(uniqueid, dbname, mbtype, jmapid),
+                &ks->byname);
+}
+
+EXPORTED void audit_keyspace_add_jmapid(struct audit_keyspace *ks,
+                                        const char *userid, const char *jmapid,
+                                        const char *uniqueid)
+{
+    struct audit_jmapid *j = xzmalloc(sizeof(struct audit_jmapid));
+
+    j->userid = xstrdupnull(userid);
+    j->jmapid = xstrdupnull(jmapid);
+    j->uniqueid = xstrdupnull(uniqueid);
+
+    ptrarray_append(&ks->jmapids, j);
+}
+
+EXPORTED void audit_keyspace_add_tombstone(struct audit_keyspace *ks,
+                                           const char *dbname,
+                                           const char *uniqueid,
+                                           time_t mtime)
+{
+    struct audit_tombstone *t = xzmalloc(sizeof(struct audit_tombstone));
+
+    t->dbname = xstrdupnull(dbname);
+    t->uniqueid = xstrdupnull(uniqueid);
+    t->mtime = mtime;
+
+    ptrarray_append(&ks->tombstones, t);
+}
+
+EXPORTED void audit_keyspace_add_history(struct audit_keyspace *ks,
+                                         const char *uniqueid,
+                                         const char *dbname,
+                                         time_t mtime)
+{
+    struct audit_history *h = xzmalloc(sizeof(struct audit_history));
+
+    h->uniqueid = xstrdupnull(uniqueid);
+    h->dbname = xstrdupnull(dbname);
+    h->mtime = mtime;
+
+    ptrarray_append(&ks->history, h);
+}
+
+/* Does this I record carry the given name as a former name? */
+static int find_history_item(const struct audit_keyspace *ks,
+                             const char *uniqueid, const char *dbname)
+{
+    int i;
+
+    for (i = 0; i < ptrarray_size(&ks->history); i++) {
+        const struct audit_history *h = ptrarray_nth(&ks->history, i);
+        if (strcmpsafe(h->uniqueid, uniqueid)) continue;
+        if (strcmpsafe(h->dbname, dbname)) continue;
+        return 1;
+    }
+
+    return 0;
+}
+
+static int find_tombstone(const struct audit_keyspace *ks, const char *dbname)
+{
+    int i;
+
+    for (i = 0; i < ptrarray_size(&ks->tombstones); i++) {
+        const struct audit_tombstone *t = ptrarray_nth(&ks->tombstones, i);
+        if (!strcmpsafe(t->dbname, dbname)) return 1;
+    }
+
+    return 0;
+}
+
+/* Does a J key exist pointing at this entry with the entry's own jmapid? */
+static int find_jmapid_key(const struct audit_keyspace *ks,
+                           const struct audit_dbentry *entry)
+{
+    int i;
+
+    for (i = 0; i < ptrarray_size(&ks->jmapids); i++) {
+        const struct audit_jmapid *j = ptrarray_nth(&ks->jmapids, i);
+        if (strcmpsafe(j->uniqueid, entry->uniqueid)) continue;
+        if (strcmpsafe(j->jmapid, entry->jmapid)) continue;
+        return 1;
+    }
+
+    return 0;
+}
+
+struct checkrock {
+    struct audit_keyspace *ks;
+    struct audit_state *state;
+};
+
+static void check_id_cb(const char *uniqueid, void *data, void *rock)
+{
+    struct checkrock *crock = (struct checkrock *)rock;
+    struct audit_dbentry *entry = (struct audit_dbentry *)data;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+    finding.uniqueid = uniqueid;
+    finding.mboxname = entry->dbname;
+
+    /* A legacy-layout mailbox lives in a name-hashed directory that no
+     * UUID sweep will ever visit.  Report it so an operator knows it is
+     * there, but never let it reach the orphan checks -- treating it as
+     * missing would invite deleting a healthy mailbox's record. */
+    if (entry->mbtype & MBTYPE_LEGACY_DIRS) {
+        finding.code = "db-entry-legacy-layout";
+        audit_report(crock->state, &finding);
+        return;
+    }
+
+    if (!entry->dbname || !hash_lookup(entry->dbname, &crock->ks->byname)) {
+        finding.code = "db-missing-n-key";
+        audit_report(crock->state, &finding);
+    }
+
+    if (!entry->jmapid) {
+        finding.code = "db-missing-j-property";
+        finding.detail = "run ctl_mboxlist -k";
+        audit_report(crock->state, &finding);
+    }
+    else if (!find_jmapid_key(crock->ks, entry)) {
+        finding.code = "db-missing-j-key";
+        finding.detail = "run ctl_mboxlist -k";
+        audit_report(crock->state, &finding);
+    }
+}
+
+static void check_name_cb(const char *dbname, void *data, void *rock)
+{
+    struct checkrock *crock = (struct checkrock *)rock;
+    struct audit_dbentry *entry = (struct audit_dbentry *)data;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+    /* already reported by check_id_cb */
+    if (entry->mbtype & MBTYPE_LEGACY_DIRS) return;
+
+    if (!entry->uniqueid || !hash_lookup(entry->uniqueid, &crock->ks->byid)) {
+        finding.code = "db-missing-i-key";
+        finding.mboxname = dbname;
+        finding.uniqueid = entry->uniqueid;
+        finding.detail = "run reconstruct";
+        audit_report(crock->state, &finding);
+    }
+}
+
+EXPORTED void audit_keyspace_check(struct audit_keyspace *ks,
+                                   struct audit_state *state)
+{
+    struct checkrock crock = { ks, state };
+    int i;
+
+    hash_enumerate(&ks->byid, check_id_cb, &crock);
+    hash_enumerate(&ks->byname, check_name_cb, &crock);
+
+    for (i = 0; i < ptrarray_size(&ks->jmapids); i++) {
+        struct audit_jmapid *j = ptrarray_nth(&ks->jmapids, i);
+        struct audit_dbentry *entry = hash_lookup(j->uniqueid, &ks->byid);
+        struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+        finding.uniqueid = j->uniqueid;
+        finding.userid = j->userid;
+
+        if (!entry) {
+            finding.code = "db-bogus-jmapid";
+            audit_report(state, &finding);
+            continue;
+        }
+
+        /* a J key that disagrees with the entry it names is worse than a
+         * missing one: a lookup by jmapid returns the wrong mailbox */
+        if (strcmpsafe(entry->jmapid, j->jmapid)) {
+            finding.code = "db-bad-jmapid";
+            finding.mboxname = entry->dbname;
+            audit_report(state, &finding);
+        }
+    }
+
+    /* Every tombstone must be explained: either the I record still carries
+     * the tombstoned name (the mailbox was deleted), or one of its history
+     * items does (the mailbox was renamed away from it). */
+    for (i = 0; i < ptrarray_size(&ks->tombstones); i++) {
+        struct audit_tombstone *t = ptrarray_nth(&ks->tombstones, i);
+        struct audit_dbentry *entry = hash_lookup(t->uniqueid, &ks->byid);
+        struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+        /* no I record at all: an orphan tombstone.  Prunable, but not an
+         * inconsistency -- there is nothing left for it to disagree with */
+        if (!entry) continue;
+
+        if (!strcmpsafe(entry->dbname, t->dbname)) continue;    /* deleted */
+        if (find_history_item(ks, t->uniqueid, t->dbname)) continue; /* renamed */
+
+        finding.code = "db-tombstone-no-history";
+        finding.uniqueid = t->uniqueid;
+        finding.mboxname = t->dbname;
+        audit_report(state, &finding);
+    }
+
+    /* And every history item must have its tombstone, or a replica will
+     * never learn that the old name is gone. */
+    for (i = 0; i < ptrarray_size(&ks->history); i++) {
+        struct audit_history *h = ptrarray_nth(&ks->history, i);
+        struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+        if (find_tombstone(ks, h->dbname)) continue;
+
+        finding.code = "db-history-no-tombstone";
+        finding.uniqueid = h->uniqueid;
+        finding.mboxname = h->dbname;
+        audit_report(state, &finding);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* per-user structure                                                 */
+
+struct userinfo {
+    char *userid;
+    char *inboxid;      /* uniqueid of the INBOX, if we found one */
+    int live_folders;   /* folders outside the DELETED namespace */
+};
+
+static void free_userinfo(void *data)
+{
+    struct userinfo *u = (struct userinfo *)data;
+
+    if (!u) return;
+    free(u->userid);
+    free(u->inboxid);
+    free(u);
+}
+
+struct userrock {
+    hash_table *users;
+    struct audit_state *state;
+};
+
+static void collect_user_cb(const char *uniqueid, void *data, void *rock)
+{
+    struct userrock *urock = (struct userrock *)rock;
+    struct audit_dbentry *entry = (struct audit_dbentry *)data;
+    mbname_t *mbname;
+    const char *userid;
+    struct userinfo *u;
+
+    if (!entry->dbname) return;
+
+    mbname = mbname_from_intname(entry->dbname);
+    userid = mbname_userid(mbname);
+
+    /* shared mailboxes have no owning user, so there is no per-user
+     * structure to check */
+    if (!userid) goto done;
+
+    u = hash_lookup(userid, urock->users);
+    if (!u) {
+        u = xzmalloc(sizeof(struct userinfo));
+        u->userid = xstrdup(userid);
+        hash_insert(userid, u, urock->users);
+    }
+
+    if (mbname_isdeleted(mbname)) goto done;
+
+    u->live_folders++;
+
+    /* the INBOX is the user's mailbox with no sub-boxes below it */
+    if (!strarray_size(mbname_boxes(mbname)))
+        if (!u->inboxid) u->inboxid = xstrdup(uniqueid);
+
+  done:
+    mbname_free(&mbname);
+}
+
+/* With no userlist we cannot know, so we assume the user belongs here.
+ * That is the safe reading: it means we report structural damage but
+ * never propose removing a user we have no evidence about. */
+static int user_is_expected(struct audit_state *state, const char *userid)
+{
+    if (!state->config.userlist) return 1;
+    return strarray_contains(state->config.userlist, userid);
+}
+
+static void check_user_cb(const char *userid, void *data, void *rock)
+{
+    struct userrock *urock = (struct userrock *)rock;
+    struct userinfo *u = (struct userinfo *)data;
+    struct audit_state *state = urock->state;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+    if (state->config.skipusers &&
+        strarray_contains(state->config.skipusers, userid))
+        return;
+
+    finding.userid = userid;
+
+    if (!u->inboxid) {
+        /* folders entirely within the DELETED namespace are just a
+         * deleted user's remains, not damage */
+        if (u->live_folders) {
+            if (user_is_expected(state, userid)) {
+                /* unrecoverable in UUID space: needs a human */
+                finding.code = "user-missing-inbox";
+            }
+            else {
+                finding.code = "user-stale-folders";
+            }
+            audit_report(state, &finding);
+        }
+        return;
+    }
+
+    /* The user has an INBOX but the driver says they do not belong here.
+     * Report only: removing a whole user rests entirely on external
+     * truth, so that decision stays with the caller. */
+    if (state->config.userlist &&
+        !strarray_contains(state->config.userlist, userid)) {
+        finding.code = "user-not-expected";
+        finding.uniqueid = u->inboxid;
+        audit_report(state, &finding);
+    }
+}
+
+EXPORTED void audit_check_users(struct audit_keyspace *ks,
+                                struct audit_state *state)
+{
+    hash_table users = HASH_TABLE_INITIALIZER;
+    struct userrock urock = { &users, state };
+
+    construct_hash_table(&users, 1024, 0);
+
+    hash_enumerate(&ks->byid, collect_user_cb, &urock);
+    hash_enumerate(&users, check_user_cb, &urock);
+
+    free_hash_table(&users, free_userinfo);
+}

--- a/imap/audit.c
+++ b/imap/audit.c
@@ -4,14 +4,19 @@
 
 #include <config.h>
 
+#include <ctype.h>
+#include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <syslog.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #include <jansson.h>
 
 #include "audit.h"
+#include "libconfig.h"
 #include "mboxlist.h"
 #include "mboxname.h"
 #include "xmalloc.h"
@@ -613,6 +618,512 @@ EXPORTED void audit_check_users(struct audit_keyspace *ks,
 }
 
 /* ------------------------------------------------------------------ */
+/* level 1: on-disk roots                                             */
+
+struct namerock {
+    const char *prefix;
+    const char *want;       /* NULL for all */
+    strarray_t *names;
+};
+
+/* Collect the names defined by options of one prefix.  Matched on an
+ * exact prefix rather than a substring search, so that options merely
+ * containing the word -- such as defaultpartition -- are not mistaken for
+ * definitions, and "partition-" does not also match "metapartition-". */
+static void collect_name_cb(const char *key, const char *value, void *rock)
+{
+    struct namerock *nrock = (struct namerock *)rock;
+    size_t len = strlen(nrock->prefix);
+
+    if (strncmp(key, nrock->prefix, len)) return;
+    if (!key[len]) return;
+    if (!value || !*value) return;
+
+    /* "partition-x" must not be reached via the tail of
+     * "metapartition-x"; config_foreachoverflowstring hands us whole
+     * option names, so an exact prefix match is enough */
+    if (nrock->want && strcmp(key + len, nrock->want)) return;
+
+    if (strarray_contains(nrock->names, key + len)) return;
+
+    strarray_append(nrock->names, key + len);
+}
+
+static void collect_names(const char *prefix, const char *want,
+                          strarray_t *names)
+{
+    struct namerock nrock = { prefix, want, names };
+
+    config_foreachoverflowstring(collect_name_cb, &nrock);
+}
+
+static void add_root(strarray_t *roots, const char *dir)
+{
+    if (!dir || !*dir) return;
+
+    /* Deduplicate by disk path.  A site that has not configured a
+     * metapartition gets the data partition back from
+     * config_metapartitiondir()'s fallback, so the same path legitimately
+     * arrives more than once; sweeping it twice would report every
+     * mailbox on it as its own duplicate. */
+    if (strarray_contains(roots, dir)) return;
+
+    strarray_append(roots, dir);
+}
+
+EXPORTED void audit_collect_roots(const char *partition, int types,
+                                  strarray_t *roots)
+{
+    strarray_t names = STRARRAY_INITIALIZER;
+    int i;
+
+    if (types & AUDIT_ROOT_SEARCH) {
+        /* search tiers are named independently of mail partitions */
+        strarray_t tiers = STRARRAY_INITIALIZER;
+
+        collect_names("searchpartition-", NULL, &tiers);
+        for (i = 0; i < strarray_size(&tiers); i++) {
+            struct buf key = BUF_INITIALIZER;
+            buf_printf(&key, "searchpartition-%s", strarray_nth(&tiers, i));
+            add_root(roots, config_getoverflowstring(buf_cstring(&key), NULL));
+            buf_free(&key);
+        }
+
+        strarray_fini(&tiers);
+    }
+
+    if (!(types & (AUDIT_ROOT_DATA | AUDIT_ROOT_META | AUDIT_ROOT_ARCHIVE)))
+        return;
+
+    collect_names("partition-", partition, &names);
+
+    for (i = 0; i < strarray_size(&names); i++) {
+        const char *name = strarray_nth(&names, i);
+
+        /* Resolve through Cyrus's own accessors so that the fallbacks
+         * match mboxname_metapath(): with no metapartition configured the
+         * meta files live on the data partition, and auditing the
+         * unconfigured location would report every mailbox as missing. */
+        if (types & AUDIT_ROOT_DATA)
+            add_root(roots, config_partitiondir(name));
+
+        if (types & AUDIT_ROOT_META) {
+            const char *dir = config_metapartitiondir(name);
+            add_root(roots, dir ? dir : config_partitiondir(name));
+        }
+
+        if (types & AUDIT_ROOT_ARCHIVE) {
+            const char *dir = config_archivepartitiondir(name);
+            add_root(roots, dir ? dir : config_partitiondir(name));
+        }
+    }
+
+    strarray_fini(&names);
+}
+
+/* ------------------------------------------------------------------ */
+/* level 1: the UUID-layout scanner                                   */
+
+/* A uniqueid shorter than this would hash to a path that is the PARENT of
+ * many mailbox directories rather than a mailbox directory.  A mailbox
+ * with uniqueid "0" existed in the wild; treating it as valid would mean
+ * removing a whole slice of the store. */
+#define AUDIT_MIN_UNIQUEID_LEN 3
+
+static int all_lowerhex(const char *s, size_t len)
+{
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        if (!isxdigit((unsigned char)s[i])) return 0;
+        if (isupper((unsigned char)s[i])) return 0;
+    }
+
+    return 1;
+}
+
+EXPORTED int audit_valid_uniqueid(const char *id)
+{
+    size_t len, i;
+    int dashes = 0, lower = 0, upper = 0;
+
+    if (!id) return 0;
+
+    len = strlen(id);
+    if (len < AUDIT_MIN_UNIQUEID_LEN) return 0;
+
+    /* really old format: namehash + uidvalidity */
+    if (len == 16) return all_lowerhex(id, len);
+
+    /* non-libuuid random format */
+    if (len == 24) {
+        for (i = 0; i < len; i++) {
+            if (islower((unsigned char)id[i])) continue;
+            if (isdigit((unsigned char)id[i])) continue;
+            return 0;
+        }
+        return 1;
+    }
+
+    /* uuid format, either builtin (lowercase) or imported (uppercase),
+     * but never a mix of the two */
+    if (len == 36) {
+        for (i = 0; i < len; i++) {
+            if (id[i] == '-') { dashes++; continue; }
+            if (!isxdigit((unsigned char)id[i])) return 0;
+            if (islower((unsigned char)id[i])) lower = 1;
+            if (isupper((unsigned char)id[i])) upper = 1;
+        }
+        if (lower && upper) return 0;
+        return dashes == 4;
+    }
+
+    return 0;
+}
+
+static int valid_hashchar(const char *name)
+{
+    return name[0] && !name[1] && isalnum((unsigned char)name[0]);
+}
+
+/* A mailbox directory holding an INBOX subdirectory is a known bogus
+ * artifact.  The mailbox itself is still valid. */
+static void check_bogus_inbox(const char *leaf, struct audit_state *state)
+{
+    struct buf path = BUF_INITIALIZER;
+    struct stat sbuf;
+
+    buf_printf(&path, "%s/INBOX", leaf);
+
+    if (!stat(buf_cstring(&path), &sbuf) && S_ISDIR(sbuf.st_mode)) {
+        struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+        finding.code = "fs-bogus-inbox-dir";
+        finding.path = buf_cstring(&path);
+        audit_report(state, &finding);
+    }
+
+    buf_free(&path);
+}
+
+struct scandir {
+    const char *root;
+    strarray_t *found;
+    struct audit_state *state;
+};
+
+static void scan_leaf_dir(struct scandir *sd, const char *dirpath,
+                          char c0, char c1)
+{
+    DIR *dh = opendir(dirpath);
+    struct dirent *de;
+
+    if (!dh) return;
+
+    while ((de = readdir(dh))) {
+        struct buf leaf = BUF_INITIALIZER;
+        struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+        if (de->d_name[0] == '.') continue;
+
+        buf_printf(&leaf, "%s/%s", dirpath, de->d_name);
+        finding.path = buf_cstring(&leaf);
+
+        if (!audit_valid_uniqueid(de->d_name)) {
+            finding.code = "fs-invalid-uniqueid";
+            audit_report(sd->state, &finding);
+            buf_free(&leaf);
+            continue;
+        }
+
+        /* mboxname_id_hash() places a mailbox under the first two
+         * characters of its uniqueid; anywhere else and nothing will
+         * ever look for it here */
+        if (de->d_name[0] != c0 || de->d_name[1] != c1) {
+            finding.code = "fs-misfiled-uniqueid";
+            finding.uniqueid = de->d_name;
+            audit_report(sd->state, &finding);
+            buf_free(&leaf);
+            continue;
+        }
+
+        strarray_append(sd->found, de->d_name);
+        check_bogus_inbox(buf_cstring(&leaf), sd->state);
+
+        buf_free(&leaf);
+    }
+
+    closedir(dh);
+}
+
+EXPORTED void audit_scan_uuid_root(const char *root, strarray_t *found,
+                                   struct audit_state *state)
+{
+    struct scandir sd = { root, found, state };
+    struct buf base = BUF_INITIALIZER;
+    DIR *d0;
+    struct dirent *e0;
+
+    buf_printf(&base, "%s/uuid", root);
+
+    /* A missing root is not a finding: a site may simply not have this
+     * partition populated. */
+    d0 = opendir(buf_cstring(&base));
+    if (!d0) goto done;
+
+    while ((e0 = readdir(d0))) {
+        struct buf lvl1 = BUF_INITIALIZER;
+        DIR *d1;
+        struct dirent *e1;
+
+        if (e0->d_name[0] == '.') continue;
+
+        buf_printf(&lvl1, "%s/%s", buf_cstring(&base), e0->d_name);
+
+        if (!valid_hashchar(e0->d_name)) {
+            struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+            finding.code = "fs-bad-hash-dir";
+            finding.path = buf_cstring(&lvl1);
+            audit_report(state, &finding);
+            buf_free(&lvl1);
+            continue;
+        }
+
+        d1 = opendir(buf_cstring(&lvl1));
+        if (!d1) { buf_free(&lvl1); continue; }
+
+        while ((e1 = readdir(d1))) {
+            struct buf lvl2 = BUF_INITIALIZER;
+
+            if (e1->d_name[0] == '.') continue;
+
+            buf_printf(&lvl2, "%s/%s", buf_cstring(&lvl1), e1->d_name);
+
+            if (!valid_hashchar(e1->d_name)) {
+                struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+                finding.code = "fs-bad-hash-dir";
+                finding.path = buf_cstring(&lvl2);
+                audit_report(state, &finding);
+                buf_free(&lvl2);
+                continue;
+            }
+
+            scan_leaf_dir(&sd, buf_cstring(&lvl2),
+                          e0->d_name[0], e1->d_name[0]);
+
+            buf_free(&lvl2);
+        }
+
+        closedir(d1);
+        buf_free(&lvl1);
+    }
+
+    closedir(d0);
+
+  done:
+    buf_free(&base);
+}
+
+/* ------------------------------------------------------------------ */
+/* level 1: db entries vs directories on disk                         */
+
+/* The on-disk view, one set of uniqueids per kind of location. */
+struct audit_fsview {
+    hash_table meta;
+    hash_table data;
+    hash_table archive;
+    hash_table search;
+    hash_table user;
+    hash_table sieve;
+};
+
+static void fsview_init(struct audit_fsview *fs)
+{
+    memset(fs, 0, sizeof(*fs));
+    construct_hash_table(&fs->meta, 4096, 0);
+    construct_hash_table(&fs->data, 4096, 0);
+    construct_hash_table(&fs->archive, 4096, 0);
+    construct_hash_table(&fs->search, 4096, 0);
+    construct_hash_table(&fs->user, 4096, 0);
+    construct_hash_table(&fs->sieve, 4096, 0);
+}
+
+static void fsview_fini(struct audit_fsview *fs)
+{
+    free_hash_table(&fs->meta, NULL);
+    free_hash_table(&fs->data, NULL);
+    free_hash_table(&fs->archive, NULL);
+    free_hash_table(&fs->search, NULL);
+    free_hash_table(&fs->user, NULL);
+    free_hash_table(&fs->sieve, NULL);
+}
+
+/* Sweep every root of one kind into a set.  Hashed rather than kept as a
+ * list: a large store has millions of mailboxes and every cross-check
+ * below is a membership test. */
+static void sweep_into(hash_table *set, const char *partition, int type,
+                       const char *suffix, struct audit_state *state)
+{
+    strarray_t roots = STRARRAY_INITIALIZER;
+    int i;
+
+    audit_collect_roots(partition, type, &roots);
+
+    for (i = 0; i < strarray_size(&roots); i++) {
+        strarray_t found = STRARRAY_INITIALIZER;
+        struct buf base = BUF_INITIALIZER;
+        int j;
+
+        buf_setcstr(&base, strarray_nth(&roots, i));
+        if (suffix) buf_printf(&base, "/%s", suffix);
+
+        audit_scan_uuid_root(buf_cstring(&base), &found, state);
+
+        for (j = 0; j < strarray_size(&found); j++) {
+            const char *id = strarray_nth(&found, j);
+            if (!hash_lookup(id, set)) hash_insert(id, (void *)1, set);
+        }
+
+        buf_free(&base);
+        strarray_fini(&found);
+    }
+
+    strarray_fini(&roots);
+}
+
+/* Sweep a single directory that is not a partition, such as the
+ * per-user and sieve trees under configdirectory. */
+static void sweep_dir_into(hash_table *set, const char *dir,
+                           struct audit_state *state)
+{
+    strarray_t found = STRARRAY_INITIALIZER;
+    int i;
+
+    audit_scan_uuid_root(dir, &found, state);
+
+    for (i = 0; i < strarray_size(&found); i++) {
+        const char *id = strarray_nth(&found, i);
+        if (!hash_lookup(id, set)) hash_insert(id, (void *)1, set);
+    }
+
+    strarray_fini(&found);
+}
+
+static void audit_sweep_filesystem(struct audit_fsview *fs,
+                                   struct audit_state *state)
+{
+    const char *partition = state->config.partition;
+    const char *confdir = config_getstring(IMAPOPT_CONFIGDIRECTORY);
+    struct buf dir = BUF_INITIALIZER;
+
+    /* Scan order is load-bearing.  Every cross-check below asks "does X
+     * exist without Y", so sweeping spool and archive before meta -- and
+     * all of them before the database -- means a mailbox created or
+     * deleted mid-run can only produce a false orphan, which we then
+     * re-verify, never a false "safe to delete".  Do not reorder. */
+    sweep_into(&fs->data, partition, AUDIT_ROOT_DATA, NULL, state);
+    sweep_into(&fs->archive, partition, AUDIT_ROOT_ARCHIVE, NULL, state);
+    sweep_into(&fs->meta, partition, AUDIT_ROOT_META, NULL, state);
+
+    /* search tiers keep their per-user trees below a "user" directory */
+    sweep_into(&fs->search, partition, AUDIT_ROOT_SEARCH, "user", state);
+
+    if (confdir) {
+        buf_printf(&dir, "%s/user", confdir);
+        sweep_dir_into(&fs->user, buf_cstring(&dir), state);
+
+        buf_reset(&dir);
+        buf_printf(&dir, "%s/sieve", confdir);
+        sweep_dir_into(&fs->sieve, buf_cstring(&dir), state);
+    }
+
+    buf_free(&dir);
+}
+
+struct orphanrock {
+    hash_table *against;
+    const char *code;
+    struct audit_state *state;
+};
+
+static void orphan_cb(const char *uniqueid,
+                      void *data __attribute__((unused)), void *rock)
+{
+    struct orphanrock *orock = (struct orphanrock *)rock;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+    if (hash_lookup(uniqueid, orock->against)) return;
+
+    finding.code = orock->code;
+    finding.uniqueid = uniqueid;
+    audit_report(orock->state, &finding);
+}
+
+/* Report each uniqueid in `set` that is absent from `against`. */
+static void report_orphans(hash_table *set, hash_table *against,
+                           const char *code, struct audit_state *state)
+{
+    struct orphanrock rock = { against, code, state };
+
+    hash_enumerate(set, orphan_cb, &rock);
+}
+
+struct dbcheckrock {
+    struct audit_fsview *fs;
+    struct audit_state *state;
+};
+
+static void check_ondisk_cb(const char *uniqueid, void *data, void *rock)
+{
+    struct dbcheckrock *drock = (struct dbcheckrock *)rock;
+    struct audit_dbentry *entry = (struct audit_dbentry *)data;
+    struct audit_finding finding = AUDIT_FINDING_INITIALIZER;
+
+    /* A legacy-layout mailbox lives in a name-hashed directory that the
+     * UUID sweep never visits, so its absence here means nothing.  It is
+     * already reported as db-entry-legacy-layout. */
+    if (entry->mbtype & MBTYPE_LEGACY_DIRS) return;
+
+    /* Remote and intermediate mailboxes have no data of their own. */
+    if (entry->mbtype & (MBTYPE_REMOTE | MBTYPE_INTERMEDIATE)) return;
+
+    if (hash_lookup(uniqueid, &drock->fs->meta)) return;
+
+    finding.code = "db-entry-no-meta-dir";
+    finding.uniqueid = uniqueid;
+    finding.mboxname = entry->dbname;
+    audit_report(drock->state, &finding);
+}
+
+static void audit_check_filesystem(struct audit_fsview *fs,
+                                   struct audit_keyspace *ks,
+                                   struct audit_state *state)
+{
+    struct dbcheckrock drock = { fs, state };
+
+    /* A mailbox directory with no database entry.  Nothing else in Cyrus
+     * looks inward from the filesystem, so this is the direction only the
+     * audit covers. */
+    report_orphans(&fs->meta, &ks->byid, "meta-dir-no-db-entry", state);
+
+    /* Spool and archive without meta.  When those partitions share a disk
+     * path with meta -- which is common -- the sets are identical and
+     * these can never fire. */
+    report_orphans(&fs->data, &fs->meta, "spool-dir-no-meta-dir", state);
+    report_orphans(&fs->archive, &fs->meta, "archive-dir-no-meta-dir", state);
+
+    /* Only whole-uniqueid orphans are reported for search: adjudicating
+     * individual xapian directories of a live mailbox needs to know
+     * whether a repack is in flight, and getting that wrong destroys a
+     * live index. */
+    report_orphans(&fs->search, &ks->byid, "search-dir-no-db-entry", state);
+
+    report_orphans(&fs->user, &ks->byid, "user-files-no-db-entry", state);
+    report_orphans(&fs->sieve, &ks->byid, "sieve-files-no-db-entry", state);
+
+    hash_enumerate(&ks->byid, check_ondisk_cb, &drock);
+}
+
+/* ------------------------------------------------------------------ */
 /* driving the scan                                                   */
 
 struct scanrock {
@@ -718,11 +1229,20 @@ static int scan_cb(void *rock, const struct mboxlist_rawkey *key,
 EXPORTED int audit_run(struct audit_state *state)
 {
     struct audit_keyspace ks;
+    struct audit_fsview fs;
     struct scanrock srock = { &ks, state };
     struct txn *tid = NULL;
+    int dofs = state->config.level >= 1;
     int r;
 
     audit_keyspace_init(&ks);
+    if (dofs) fsview_init(&fs);
+
+    /* Sweep the filesystem before reading the database.  See the comment
+     * in audit_sweep_filesystem(): the order is what makes a mid-run
+     * create or delete produce a false orphan rather than a false "safe
+     * to delete". */
+    if (dofs) audit_sweep_filesystem(&fs, state);
 
     /* One transaction for the whole scan: the cross-checks compare keys of
      * different types against each other, so they need a snapshot that is
@@ -735,8 +1255,10 @@ EXPORTED int audit_run(struct audit_state *state)
     if (!r) {
         audit_keyspace_check(&ks, state);
         audit_check_users(&ks, state);
+        if (dofs) audit_check_filesystem(&fs, &ks, state);
     }
 
+    if (dofs) fsview_fini(&fs);
     audit_keyspace_fini(&ks);
 
     return r;

--- a/imap/audit.h
+++ b/imap/audit.h
@@ -153,6 +153,13 @@ int audit_valid_uniqueid(const char *id);
 void audit_scan_uuid_root(const char *root, strarray_t *found,
                           struct audit_state *state);
 
+/* Is this path too new to touch?  See AUDIT_MIN_AGE. */
+int audit_path_is_young(const char *path);
+
+/* Remove a path, subject to --delete, --really and the young-guard.
+ * Does nothing at all unless --delete was given. */
+void audit_remove_path(struct audit_state *state, const char *path);
+
 /* Run the audit at the configured level.  Returns 0 on success; findings
  * are reported through the emitter and counted by audit_finding_count(). */
 int audit_run(struct audit_state *state);

--- a/imap/audit.h
+++ b/imap/audit.h
@@ -5,6 +5,7 @@
 #ifndef INCLUDED_AUDIT_H
 #define INCLUDED_AUDIT_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "hash.h"
@@ -12,71 +13,82 @@
 #include "strarray.h"
 #include "util.h"
 
-/* Directories and files younger than this are never removed: they may
+/**
+ * @file audit.h
+ *
+ * Mailstore consistency auditing: the checks chk_cyrus runs, and the
+ * repairs it can be asked to apply.
+ */
+
+/**
+ * Directories and files younger than this are never removed: they may
  * belong to an operation still in flight.  There is deliberately no flag
  * to override this; tests backdate mtimes instead.
  */
 #define AUDIT_MIN_AGE 600
 
+/** One thing found wrong, as handed to the emitter */
 struct audit_finding {
-    const char *code;       /* stable slug, eg "message-file-missing" */
+    const char *code;       /**< stable slug, eg "message-file-missing" */
     const char *uniqueid;
-    const char *mboxname;   /* internal name */
+    const char *mboxname;   /**< internal name */
     const char *userid;
     const char *path;
-    const char *tier;       /* "spool" | "archive" */
-    const char *metaname;   /* "index" | "header" | ... */
-    const char *guid;       /* expected guid from the index record */
-    const char *detail;     /* free text for the human renderer */
+    const char *tier;       /**< "spool" | "archive" */
+    const char *metaname;   /**< "index" | "header" | ... */
+    const char *guid;       /**< expected guid from the index record */
+    const char *detail;     /**< free text for the human renderer */
     uint32_t uid;
     uint64_t size;
-    int has_uid;
-    int has_size;
+    bool has_uid;
+    bool has_size;
 };
 
 #define AUDIT_FINDING_INITIALIZER \
-    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0 }
+    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, false, false }
 
+/** What to check, and what to do about it */
 struct audit_config {
-    int level;              /* 0-4 */
-    int json;
-    int do_delete;
-    int do_fix;
-    int really;
-    int prune_days;         /* 0 disables tombstone pruning */
+    int level;              /**< 0-4 */
+    bool json;
+    bool do_delete;
+    bool do_fix;
+    bool really;
+    int prune_days;         /**< 0 disables tombstone pruning */
 
-    /* Whether the J keyspace is worth auditing at all.  jmapids are
-     * derived from createdmodseq, and mboxname_domodseq() never consults
-     * the per-user counter when conversations are disabled, so every
-     * mailbox on such an install is created with modseq 1 and the same
-     * jmapid.  The keyspace is degenerate there and JMAP is unusable
-     * anyway, so there is nothing to check.  Set from the conversations
-     * switch by the caller. */
-    int check_jmapids;
-    const char *partition;  /* NULL for all */
-    const char *userid;     /* NULL for all */
-    strarray_t *userlist;   /* NULL: every db user is treated as expected */
+    /**
+     * Whether the J keyspace is worth auditing at all.  With conversations
+     * disabled every mailbox is created with modseq 1, so every jmapid is
+     * the same and the keyspace is degenerate.  Set from the conversations
+     * switch by the caller.
+     */
+    bool check_jmapids;
+    const char *partition;  /**< NULL for all */
+    const char *userid;     /**< NULL for all */
+    strarray_t *userlist;   /**< NULL: every db user is treated as expected */
     strarray_t *skipusers;
-    struct buf *out;        /* NULL means stdout */
+    struct buf *out;        /**< NULL means stdout */
 };
 
 #define AUDIT_CONFIG_INITIALIZER \
-    { 0, 0, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL }
+    { 0, false, false, false, false, 0, false, NULL, NULL, NULL, NULL, NULL }
 
 struct audit_state;
 
-/* The accumulated mailboxes.db keyspace, built during a single scan and
+/**
+ * The accumulated mailboxes.db keyspace, built during a single scan and
  * cross-checked afterwards.  Cross-checking cannot happen during the scan
  * because a key seen early may only be explicable by one seen late.
  */
 struct audit_keyspace {
-    hash_table byid;        /* uniqueid -> struct audit_dbentry */
-    hash_table byname;      /* dbname   -> struct audit_dbentry */
-    ptrarray_t jmapids;     /* struct audit_jmapid */
-    ptrarray_t tombstones;  /* struct audit_tombstone */
-    ptrarray_t history;     /* struct audit_history */
+    hash_table byid;        /**< uniqueid -> struct audit_dbentry */
+    hash_table byname;      /**< dbname   -> struct audit_dbentry */
+    ptrarray_t jmapids;     /**< struct audit_jmapid */
+    ptrarray_t tombstones;  /**< struct audit_tombstone */
+    ptrarray_t history;     /**< struct audit_history */
 };
 
+/** An I or N record's mailbox */
 struct audit_dbentry {
     char *uniqueid;
     char *dbname;
@@ -84,23 +96,24 @@ struct audit_dbentry {
     uint32_t mbtype;
 };
 
+/** A J record: a mailbox reachable by jmapid */
 struct audit_jmapid {
     char *userid;
     char *jmapid;
     char *uniqueid;
 };
 
-/* A tombstone N record: a name the mailbox used to be known by. */
+/** A tombstone N record: a name the mailbox used to be known by */
 struct audit_tombstone {
     char *dbname;
     char *uniqueid;
     time_t mtime;
 };
 
-/* A name_history item hanging off an I record. */
+/** A name_history item hanging off an I record */
 struct audit_history {
-    char *uniqueid;     /* the I record this item belongs to */
-    char *dbname;       /* the former name */
+    char *uniqueid;     /**< the I record this item belongs to */
+    char *dbname;       /**< the former name */
     time_t mtime;
 };
 
@@ -122,52 +135,120 @@ void audit_keyspace_add_history(struct audit_keyspace *ks,
                                 const char *uniqueid, const char *dbname,
                                 time_t mtime);
 
+/**
+ * Cross-check an accumulated keyspace, reporting through @a state.
+ *
+ * @param ks the keyspace, complete
+ * @param state the running audit
+ */
 void audit_keyspace_check(struct audit_keyspace *ks,
                           struct audit_state *state);
+
+/**
+ * Check each user the keyspace mentions against the configured user list.
+ *
+ * @param ks the keyspace, complete
+ * @param state the running audit
+ */
 void audit_check_users(struct audit_keyspace *ks, struct audit_state *state);
 
-/* Which kind of partition option a root came from.  A single disk path
- * can serve several: it is common for meta and spool to share one. */
+/**
+ * Which kind of partition option a root came from.  A single disk path
+ * can serve several: it is common for meta and spool to share one.
+ */
 enum {
-    AUDIT_ROOT_DATA    = (1<<0),    /* partition-* */
-    AUDIT_ROOT_META    = (1<<1),    /* metapartition-* */
-    AUDIT_ROOT_ARCHIVE = (1<<2),    /* archivepartition-* */
-    AUDIT_ROOT_SEARCH  = (1<<3),    /* searchpartition-* */
+    AUDIT_ROOT_DATA    = (1<<0),    /**< partition-* */
+    AUDIT_ROOT_META    = (1<<1),    /**< metapartition-* */
+    AUDIT_ROOT_ARCHIVE = (1<<2),    /**< archivepartition-* */
+    AUDIT_ROOT_SEARCH  = (1<<3),    /**< searchpartition-* */
     AUDIT_ROOT_ANY     = 0xf,
 };
 
-/* Collect the distinct on-disk roots to sweep, deduplicated by disk path.
- * Only roots whose kind is in the types mask are collected.  If partition
- * is non-NULL only that partition's roots are collected. */
+/**
+ * Collect the distinct on-disk roots to sweep, deduplicated by disk path.
+ *
+ * @param partition only this partition's roots, or NULL for all
+ * @param types mask of AUDIT_ROOT_* kinds to collect
+ * @param[out] roots the paths found
+ */
 void audit_collect_roots(const char *partition, int types, strarray_t *roots);
 
-/* Is this a plausible mailbox uniqueid?  Rejects anything shorter than
+/**
+ * Is this a plausible mailbox uniqueid?  Rejects anything shorter than
  * three characters: a mailbox with uniqueid "0" existed in the wild, and
  * mboxname_id_hash() would place it at a path that is the PARENT of many
- * other mailbox directories. */
-int audit_valid_uniqueid(const char *id);
+ * other mailbox directories.
+ *
+ * @param id the candidate
+ * @return true if it could be a uniqueid
+ */
+bool audit_valid_uniqueid(const char *id);
 
-/* Walk <root>/uuid/<c0>/<c1>/<uniqueid>, the inverse of
- * mboxname_id_hash(), appending each uniqueid found to *found and
- * reporting anything that does not belong. */
+/**
+ * Walk <root>/uuid/<c0>/<c1>/<uniqueid>, the inverse of
+ * mboxname_id_hash(), reporting anything that does not belong.
+ *
+ * @param root the on-disk root to walk
+ * @param[out] found each uniqueid seen, appended
+ * @param state the running audit
+ */
 void audit_scan_uuid_root(const char *root, strarray_t *found,
                           struct audit_state *state);
 
-/* Is this path too new to touch?  See AUDIT_MIN_AGE. */
-int audit_path_is_young(const char *path);
+/**
+ * Is this path too new to touch?  See AUDIT_MIN_AGE.
+ *
+ * @param path the path to stat
+ * @return true if it must be left alone
+ */
+bool audit_path_is_young(const char *path);
 
-/* Remove a path, subject to --delete, --really and the young-guard.
- * Does nothing at all unless --delete was given. */
+/**
+ * Remove a path, subject to --delete, --really and the young-guard.  Does
+ * nothing at all unless --delete was given.
+ *
+ * @param state the running audit
+ * @param path the path to remove
+ */
 void audit_remove_path(struct audit_state *state, const char *path);
 
-/* Run the audit at the configured level.  Returns 0 on success; findings
- * are reported through the emitter and counted by audit_finding_count(). */
+/**
+ * Run the audit at the configured level.  Findings are reported through
+ * the emitter and counted by audit_finding_count().
+ *
+ * @param state the running audit
+ * @return 0 on success
+ */
 int audit_run(struct audit_state *state);
 
+/**
+ * Begin an audit.
+ *
+ * @param config what to check and what to repair; copied
+ * @return the running audit, to be freed with audit_done()
+ */
 struct audit_state *audit_begin(const struct audit_config *config);
+
+/**
+ * Emit one finding.
+ *
+ * @param state the running audit
+ * @param finding what was found; nothing is retained
+ */
 void audit_report(struct audit_state *state,
                   const struct audit_finding *finding);
+
+/**
+ * @param state the running audit
+ * @return how many findings have been emitted
+ */
 unsigned audit_finding_count(const struct audit_state *state);
+
+/**
+ * Finish an audit, applying any queued repairs.
+ *
+ * @param[in,out] statep the running audit, set to NULL
+ */
 void audit_done(struct audit_state **statep);
 
 #endif /* INCLUDED_AUDIT_H */

--- a/imap/audit.h
+++ b/imap/audit.h
@@ -126,6 +126,33 @@ void audit_keyspace_check(struct audit_keyspace *ks,
                           struct audit_state *state);
 void audit_check_users(struct audit_keyspace *ks, struct audit_state *state);
 
+/* Which kind of partition option a root came from.  A single disk path
+ * can serve several: it is common for meta and spool to share one. */
+enum {
+    AUDIT_ROOT_DATA    = (1<<0),    /* partition-* */
+    AUDIT_ROOT_META    = (1<<1),    /* metapartition-* */
+    AUDIT_ROOT_ARCHIVE = (1<<2),    /* archivepartition-* */
+    AUDIT_ROOT_SEARCH  = (1<<3),    /* searchpartition-* */
+    AUDIT_ROOT_ANY     = 0xf,
+};
+
+/* Collect the distinct on-disk roots to sweep, deduplicated by disk path.
+ * Only roots whose kind is in the types mask are collected.  If partition
+ * is non-NULL only that partition's roots are collected. */
+void audit_collect_roots(const char *partition, int types, strarray_t *roots);
+
+/* Is this a plausible mailbox uniqueid?  Rejects anything shorter than
+ * three characters: a mailbox with uniqueid "0" existed in the wild, and
+ * mboxname_id_hash() would place it at a path that is the PARENT of many
+ * other mailbox directories. */
+int audit_valid_uniqueid(const char *id);
+
+/* Walk <root>/uuid/<c0>/<c1>/<uniqueid>, the inverse of
+ * mboxname_id_hash(), appending each uniqueid found to *found and
+ * reporting anything that does not belong. */
+void audit_scan_uuid_root(const char *root, strarray_t *found,
+                          struct audit_state *state);
+
 /* Run the audit at the configured level.  Returns 0 on success; findings
  * are reported through the emitter and counted by audit_finding_count(). */
 int audit_run(struct audit_state *state);

--- a/imap/audit.h
+++ b/imap/audit.h
@@ -1,0 +1,126 @@
+/* audit.h - mailstore consistency auditing */
+/* SPDX-License-Identifier: BSD-3-Clause-CMU */
+/* See COPYING file at the root of the distribution for more details. */
+
+#ifndef INCLUDED_AUDIT_H
+#define INCLUDED_AUDIT_H
+
+#include <stdint.h>
+
+#include "hash.h"
+#include "ptrarray.h"
+#include "strarray.h"
+#include "util.h"
+
+/* Directories and files younger than this are never removed: they may
+ * belong to an operation still in flight.  There is deliberately no flag
+ * to override this; tests backdate mtimes instead.
+ */
+#define AUDIT_MIN_AGE 600
+
+struct audit_finding {
+    const char *code;       /* stable slug, eg "message-file-missing" */
+    const char *uniqueid;
+    const char *mboxname;   /* internal name */
+    const char *userid;
+    const char *path;
+    const char *tier;       /* "spool" | "archive" */
+    const char *metaname;   /* "index" | "header" | ... */
+    const char *guid;       /* expected guid from the index record */
+    const char *detail;     /* free text for the human renderer */
+    uint32_t uid;
+    uint64_t size;
+    int has_uid;
+    int has_size;
+};
+
+#define AUDIT_FINDING_INITIALIZER \
+    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0 }
+
+struct audit_config {
+    int level;              /* 0-4 */
+    int json;
+    int do_delete;
+    int do_fix;
+    int really;
+    int prune_days;         /* 0 disables tombstone pruning */
+    const char *partition;  /* NULL for all */
+    const char *userid;     /* NULL for all */
+    strarray_t *userlist;   /* NULL: every db user is treated as expected */
+    strarray_t *skipusers;
+    struct buf *out;        /* NULL means stdout */
+};
+
+#define AUDIT_CONFIG_INITIALIZER \
+    { 0, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL }
+
+struct audit_state;
+
+/* The accumulated mailboxes.db keyspace, built during a single scan and
+ * cross-checked afterwards.  Cross-checking cannot happen during the scan
+ * because a key seen early may only be explicable by one seen late.
+ */
+struct audit_keyspace {
+    hash_table byid;        /* uniqueid -> struct audit_dbentry */
+    hash_table byname;      /* dbname   -> struct audit_dbentry */
+    ptrarray_t jmapids;     /* struct audit_jmapid */
+    ptrarray_t tombstones;  /* struct audit_tombstone */
+    ptrarray_t history;     /* struct audit_history */
+};
+
+struct audit_dbentry {
+    char *uniqueid;
+    char *dbname;
+    char *jmapid;
+    uint32_t mbtype;
+};
+
+struct audit_jmapid {
+    char *userid;
+    char *jmapid;
+    char *uniqueid;
+};
+
+/* A tombstone N record: a name the mailbox used to be known by. */
+struct audit_tombstone {
+    char *dbname;
+    char *uniqueid;
+    time_t mtime;
+};
+
+/* A name_history item hanging off an I record. */
+struct audit_history {
+    char *uniqueid;     /* the I record this item belongs to */
+    char *dbname;       /* the former name */
+    time_t mtime;
+};
+
+void audit_keyspace_init(struct audit_keyspace *ks);
+void audit_keyspace_fini(struct audit_keyspace *ks);
+
+void audit_keyspace_add_id(struct audit_keyspace *ks, const char *uniqueid,
+                           const char *dbname, uint32_t mbtype,
+                           const char *jmapid);
+void audit_keyspace_add_name(struct audit_keyspace *ks, const char *dbname,
+                             const char *uniqueid, uint32_t mbtype,
+                             const char *jmapid);
+void audit_keyspace_add_jmapid(struct audit_keyspace *ks, const char *userid,
+                               const char *jmapid, const char *uniqueid);
+void audit_keyspace_add_tombstone(struct audit_keyspace *ks,
+                                  const char *dbname, const char *uniqueid,
+                                  time_t mtime);
+void audit_keyspace_add_history(struct audit_keyspace *ks,
+                                const char *uniqueid, const char *dbname,
+                                time_t mtime);
+
+void audit_keyspace_check(struct audit_keyspace *ks,
+                          struct audit_state *state);
+void audit_check_users(struct audit_keyspace *ks, struct audit_state *state);
+
+struct audit_state *audit_begin(const struct audit_config *config);
+void audit_report(struct audit_state *state,
+                  const struct audit_finding *finding);
+unsigned audit_finding_count(const struct audit_state *state);
+void audit_done(struct audit_state **statep);
+
+#endif /* INCLUDED_AUDIT_H */

--- a/imap/audit.h
+++ b/imap/audit.h
@@ -44,6 +44,15 @@ struct audit_config {
     int do_fix;
     int really;
     int prune_days;         /* 0 disables tombstone pruning */
+
+    /* Whether the J keyspace is worth auditing at all.  jmapids are
+     * derived from createdmodseq, and mboxname_domodseq() never consults
+     * the per-user counter when conversations are disabled, so every
+     * mailbox on such an install is created with modseq 1 and the same
+     * jmapid.  The keyspace is degenerate there and JMAP is unusable
+     * anyway, so there is nothing to check.  Set from the conversations
+     * switch by the caller. */
+    int check_jmapids;
     const char *partition;  /* NULL for all */
     const char *userid;     /* NULL for all */
     strarray_t *userlist;   /* NULL: every db user is treated as expected */
@@ -52,7 +61,7 @@ struct audit_config {
 };
 
 #define AUDIT_CONFIG_INITIALIZER \
-    { 0, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL }
+    { 0, 0, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL }
 
 struct audit_state;
 
@@ -116,6 +125,10 @@ void audit_keyspace_add_history(struct audit_keyspace *ks,
 void audit_keyspace_check(struct audit_keyspace *ks,
                           struct audit_state *state);
 void audit_check_users(struct audit_keyspace *ks, struct audit_state *state);
+
+/* Run the audit at the configured level.  Returns 0 on success; findings
+ * are reported through the emitter and counted by audit_finding_count(). */
+int audit_run(struct audit_state *state);
 
 struct audit_state *audit_begin(const struct audit_config *config);
 void audit_report(struct audit_state *state,

--- a/imap/chk_cyrus.c
+++ b/imap/chk_cyrus.c
@@ -4,6 +4,7 @@
 
 #include <config.h>
 
+#include <errno.h>
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -19,6 +20,7 @@
 #include <unistd.h>
 #endif
 
+#include "audit.h"
 #include "index.h"
 #include "global.h"
 #include "mboxlist.h"
@@ -29,10 +31,70 @@
 /* generated headers are not necessarily in current directory */
 #include "imap/imap_err.h"
 
+/* long-only options; values above any short option character */
+enum {
+    OPT_USERLIST = 256,
+    OPT_SKIPUSER,
+    OPT_PRUNE,
+};
+
 static void usage(void)
 {
     fprintf(stderr, "chk_cyrus [-C <altconfig>] partition\n");
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Audit mode (nothing below changes behaviour unless"
+                    " --level is given):\n");
+    fprintf(stderr, "  -l, --level N       0-4; enables audit mode\n");
+    fprintf(stderr, "                        0: mailboxes.db keyspace only,"
+                    " no disk access\n");
+    fprintf(stderr, "                        1: also db entries vs UUID dirs"
+                    " on disk\n");
+    fprintf(stderr, "                        2: also index record vs data"
+                    " file exists\n");
+    fprintf(stderr, "                        3: also size match\n");
+    fprintf(stderr, "                        4: also GUID match\n");
+    fprintf(stderr, "  -j, --json          JSON-lines output instead of"
+                    " text\n");
+    fprintf(stderr, "  -u, --user USERID   restrict the run to one user\n");
+    fprintf(stderr, "      --userlist FILE usernames expected on this"
+                    " server\n");
+    fprintf(stderr, "      --skip-user U   exclude a user; repeatable\n");
+    fprintf(stderr, "  -d, --delete        remove locally-decidable"
+                    " orphans\n");
+    fprintf(stderr, "  -f, --fix           repair locally-decidable"
+                    " damage\n");
+    fprintf(stderr, "  -y, --really        actually act; without it -d/-f"
+                    " only report\n");
+    fprintf(stderr, "      --prune-tombstones DAYS\n");
+    fprintf(stderr, "                      prune tombstones and history older"
+                    " than DAYS\n");
+    fprintf(stderr, "                        (no default; pruning is off"
+                    " unless given)\n");
     exit(-1);
+}
+
+/* Read a newline-separated list of usernames, skipping blank lines. */
+static strarray_t *read_userlist(const char *fname)
+{
+    strarray_t *list = strarray_new();
+    char line[MAX_MAILBOX_NAME + 2];
+    FILE *f = fopen(fname, "r");
+
+    if (!f) {
+        fprintf(stderr, "can't open userlist %s: %s\n",
+                fname, strerror(errno));
+        exit(EX_NOINPUT);
+    }
+
+    while (fgets(line, sizeof(line), f)) {
+        char *p = line + strlen(line);
+        while (p > line && (p[-1] == '\n' || p[-1] == '\r')) *--p = '\0';
+        if (*line) strarray_append(list, line);
+    }
+
+    fclose(f);
+
+    return list;
 }
 
 static const char *check_part = NULL; /* partition we are checking */
@@ -77,15 +139,26 @@ int main(int argc, char **argv)
     char *alt_config = NULL;
     char pattern[2] = { '*', '\0' };
     const char *mailbox = NULL;
+    struct audit_config audit_config = AUDIT_CONFIG_INITIALIZER;
+    int do_audit = 0;
     int opt;
 
     /* keep this in alphabetical order */
-    static const char short_options[] = "C:M:P:";
+    static const char short_options[] = "C:M:P:dfjl:u:y";
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */
         { "mailbox", required_argument, NULL, 'M' },
         { "partition", required_argument, NULL, 'P' },
+        { "delete", no_argument, NULL, 'd' },
+        { "fix", no_argument, NULL, 'f' },
+        { "json", no_argument, NULL, 'j' },
+        { "level", required_argument, NULL, 'l' },
+        { "user", required_argument, NULL, 'u' },
+        { "really", no_argument, NULL, 'y' },
+        { "userlist", required_argument, NULL, OPT_USERLIST },
+        { "skip-user", required_argument, NULL, OPT_SKIPUSER },
+        { "prune-tombstones", required_argument, NULL, OPT_PRUNE },
 
         { 0, 0, 0, 0 },
     };
@@ -114,13 +187,112 @@ int main(int argc, char **argv)
             mailbox = optarg;
             break;
 
+        case 'l':
+            audit_config.level = atoi(optarg);
+            do_audit = 1;
+            break;
+
+        case 'j':
+            audit_config.json = 1;
+            break;
+
+        case 'd':
+            audit_config.do_delete = 1;
+            break;
+
+        case 'f':
+            audit_config.do_fix = 1;
+            break;
+
+        case 'y':
+            audit_config.really = 1;
+            break;
+
+        case 'u':
+            audit_config.userid = optarg;
+            break;
+
+        case OPT_USERLIST:
+            audit_config.userlist = read_userlist(optarg);
+            break;
+
+        case OPT_SKIPUSER:
+            if (!audit_config.skipusers)
+                audit_config.skipusers = strarray_new();
+            strarray_append(audit_config.skipusers, optarg);
+            break;
+
+        case OPT_PRUNE:
+            audit_config.prune_days = atoi(optarg);
+            break;
+
         default:
             usage();
             /* NOTREACHED */
         }
     }
 
+    if (do_audit) {
+        if (audit_config.level < 0 || audit_config.level > 4) {
+            fprintf(stderr, "--level must be between 0 and 4\n");
+            usage();
+        }
+        if (audit_config.do_delete && audit_config.do_fix) {
+            fprintf(stderr, "--delete and --fix are mutually exclusive\n");
+            usage();
+        }
+        if (audit_config.really &&
+            !audit_config.do_delete && !audit_config.do_fix) {
+            fprintf(stderr, "--really requires --delete or --fix\n");
+            usage();
+        }
+        /* Levels 2-4 are message and meta damage.  There is no local
+         * source to repair from, and where a local resolution does exist
+         * reconstruct already owns it, so acting there is never right. */
+        if (audit_config.level >= 2 &&
+            (audit_config.do_delete || audit_config.do_fix)) {
+            fprintf(stderr, "--delete and --fix are only meaningful at"
+                            " --level 0 or 1\n");
+            usage();
+        }
+        if (audit_config.prune_days < 0) {
+            fprintf(stderr, "--prune-tombstones must not be negative\n");
+            usage();
+        }
+    }
+    else if (audit_config.json || audit_config.do_delete ||
+             audit_config.do_fix || audit_config.really ||
+             audit_config.userlist || audit_config.skipusers ||
+             audit_config.userid || audit_config.prune_days) {
+        fprintf(stderr, "audit options require --level\n");
+        usage();
+    }
+
     cyrus_init(alt_config, "chk_cyrus", 0, CONFIG_NEED_PARTITION_DATA);
+
+    if (do_audit) {
+        struct audit_state *state;
+        int r;
+
+        audit_config.partition = check_part;
+
+        /* jmapids come from createdmodseq, and without conversations the
+         * per-user counter is never consulted, so every mailbox is created
+         * with modseq 1 and the same jmapid.  The J keyspace is degenerate
+         * there and JMAP unusable, so there is nothing worth checking. */
+        audit_config.check_jmapids = config_getswitch(IMAPOPT_CONVERSATIONS);
+
+        state = audit_begin(&audit_config);
+        r = audit_run(state);
+        audit_done(&state);
+
+        if (audit_config.userlist) strarray_free(audit_config.userlist);
+        if (audit_config.skipusers) strarray_free(audit_config.skipusers);
+
+        cyrus_done();
+
+        return r ? EX_SOFTWARE : 0;
+    }
 
     if(mailbox) {
         fprintf(stderr, "Examining mailbox: %s\n", mailbox);

--- a/imap/ctl_mboxlist.c
+++ b/imap/ctl_mboxlist.c
@@ -1222,74 +1222,7 @@ static void do_verify(void)
 
 static int fix_cb(const mbentry_t *mbentry, void *rockp __attribute__((unused)))
 {
-    mbentry_t *byunqid = NULL;
-
-    int r = mboxlist_lookup_by_uniqueid(mbentry->uniqueid, &byunqid, NULL);
-    if (r) {
-        xsyslog(LOG_NOTICE, "missing uniqueid record, skipping",
-               "mboxname=<%s> uniqueid=<%s>",
-               mbentry->name, mbentry->uniqueid);
-        return 0;
-    }
-
-    // we are not the current record?  We don't need to process this.
-    if (strcmp(mbentry->name, byunqid->name))
-        goto done;
-
-    if (mbentry->jmapid) {
-        mbname_t *mbname = mbname_from_intname(mbentry->name);
-        const char *userid = mbname_userid(mbname);
-
-        if (!userid) userid = "";
-
-        // already got a record, we're good!
-        int res = mboxlist_lookup_by_jmapid(userid, mbentry->jmapid, NULL, NULL);
-        mbname_free(&mbname);
-        if (!res) return 0;
-
-        xsyslog(LOG_NOTICE, "adding missing J record to mboxlist",
-                "mboxname=<%s> jmapid=<%s>",
-                mbentry->name, mbentry->jmapid);
-    }
-    else {
-        struct mailbox *mailbox = NULL;
-        r = mailbox_open_from_mbe(byunqid, &mailbox);
-        if (r) goto done;
-        struct buf jmapid = BUF_INITIALIZER;
-
-        byunqid->foldermodseq = mailbox_modseq_dirty(mailbox);
-
-        buf_putc(&jmapid, JMAP_MAILBOXID_PREFIX);
-        MODSEQ_TO_JMAPID(&jmapid, byunqid->foldermodseq);
-        mailbox_set_jmapid(mailbox, buf_cstring(&jmapid));
-
-        free(byunqid->jmapid);
-        byunqid->jmapid = buf_release(&jmapid);
-        buf_free(&jmapid);
-
-        xsyslog(LOG_NOTICE, "adding new J record to mboxlist",
-                "mboxname=<%s> jmapid=<%s>",
-                byunqid->name, byunqid->jmapid);
-
-        r = mailbox_commit(mailbox);
-        if (r) {
-            xsyslog(LOG_ERR, "DBERROR: error committing transaction",
-                    "error=<%s>", cyrusdb_strerror(r));
-            goto done;
-        }
-    }
-
-    r = mboxlist_updatelock(byunqid, /*localonly*/1);
-    if (r) {
-        xsyslog(LOG_ERR, "failed to update mboxlist",
-                "mboxname=<%s> error=<%s>",
-                mbentry->name, error_message(r));
-    }
-
-done:
-    mboxlist_entry_free(&byunqid);
-
-    return r;
+    return mboxlist_fix_jmapid(mbentry);
 }
 
 static void do_fix_keys(int intermediary)

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -6827,7 +6827,7 @@ EXPORTED int mailbox_parse_datafilename(const char *name, uint32_t *uidp)
 }
 
 static int find_files(struct mailbox *mailbox, struct found_uids *files,
-                      int flags)
+                      int flags, struct reconstruct_report *report)
 {
     strarray_t paths = STRARRAY_INITIALIZER;
     DIR *dirp;
@@ -6864,12 +6864,12 @@ static int find_files(struct mailbox *mailbox, struct found_uids *files,
                 if (stat(buf, &sbuf) == -1) continue; /* ignore ephemeral */
                 if (!S_ISDIR(sbuf.st_mode)) {
                     if (!(flags & RECONSTRUCT_IGNORE_ODDFILES)) {
-                        printf("%s odd file %s\n", mailbox_name(mailbox), buf);
+                        if (!report) printf("%s odd file %s\n", mailbox_name(mailbox), buf);
                         syslog(LOG_ERR, "%s odd file %s", mailbox_name(mailbox), buf);
                         if (flags & RECONSTRUCT_REMOVE_ODDFILES)
                             xunlink(buf);
                         else {
-                            printf("run reconstruct with -O to remove odd files\n");
+                            if (!report) printf("run reconstruct with -O to remove odd files\n");
                             syslog(LOG_ERR, "run reconstruct with -O to "
                                             "remove odd files");
                         }
@@ -6962,7 +6962,20 @@ done:
 
 /* this is kind of like mailbox_create, but we try to rescue
  * what we can from the filesystem! */
-static int mailbox_reconstruct_create(const char *name, struct mailbox **mbptr)
+/* Report recoverable data damage to an optional observer.  Damage that
+ * reconstruct repairs on its own is not reported here: only the cases
+ * where the data is gone or wrong and a replacement has to come from
+ * somewhere else. */
+static void reconstruct_report(struct reconstruct_report *report,
+                               const struct reconstruct_finding *f)
+{
+    if (!report || !report->proc) return;
+
+    report->proc(report->rock, f);
+}
+
+static int mailbox_reconstruct_create(const char *name, struct mailbox **mbptr,
+                                      struct reconstruct_report *report)
 {
     struct mailbox *mailbox = NULL;
     int options = config_getint(IMAPOPT_MAILBOX_DEFAULT_OPTIONS)
@@ -7014,7 +7027,15 @@ static int mailbox_reconstruct_create(const char *name, struct mailbox **mbptr)
     if (!r) r = mailbox_lock_index_internal(mailbox, LOCK_EXCLUSIVE);
     if (!r) r = mailbox_read_index_header(mailbox);
     if (r) {
-        printf("%s: failed to read index header\n", mailbox_name(mailbox));
+        if (!report) printf("%s: failed to read index header\n", mailbox_name(mailbox));
+        {
+            struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+            f.code = "meta-file-unreadable";
+            f.mboxname = mailbox_name(mailbox);
+            f.metaname = "index";
+            f.path = mailbox_meta_fname(mailbox, META_INDEX);
+            reconstruct_report(report, &f);
+        }
         syslog(LOG_ERR, "failed to read index header for %s", mailbox_name(mailbox));
         /* no cyrus.index file at all - well, we're in a pickle!
          * no point trying to rescue anything else... */
@@ -7032,7 +7053,15 @@ static int mailbox_reconstruct_create(const char *name, struct mailbox **mbptr)
     r = mailbox_read_header(mailbox, NULL);
     if (r) {
         /* Header failed to read - recreate it */
-        printf("%s: failed to read header file\n", mailbox_name(mailbox));
+        if (!report) printf("%s: failed to read header file\n", mailbox_name(mailbox));
+        {
+            struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+            f.code = "meta-file-unreadable";
+            f.mboxname = mailbox_name(mailbox);
+            f.metaname = "header";
+            f.path = mailbox_meta_fname(mailbox, META_HEADER);
+            reconstruct_report(report, &f);
+        }
         syslog(LOG_ERR, "failed to read header file for %s", mailbox_name(mailbox));
 
         mailbox_make_uniqueid(mailbox);
@@ -7056,7 +7085,8 @@ done:
     return r;
 }
 
-static int mailbox_reconstruct_acl(struct mailbox *mailbox, int flags)
+static int mailbox_reconstruct_acl(struct mailbox *mailbox, int flags,
+                                   struct reconstruct_report *report)
 {
     int make_changes = flags & RECONSTRUCT_MAKE_CHANGES;
     int r;
@@ -7065,10 +7095,12 @@ static int mailbox_reconstruct_acl(struct mailbox *mailbox, int flags)
     if (r) return r;
 
     if (strcmp(mailbox_acl(mailbox), mailbox->h.acl)) {
-        printf("%s: update acl from header %s => %s\n", mailbox_name(mailbox),
-               mailbox_acl(mailbox), mailbox->h.acl);
-        if (make_changes)
-            printf("XXX - this is a noop right now - needs to update mailboxes.db\n");
+        if (!report) {
+            printf("%s: update acl from header %s => %s\n", mailbox_name(mailbox),
+                   mailbox_acl(mailbox), mailbox->h.acl);
+            if (make_changes)
+                printf("XXX - this is a noop right now - needs to update mailboxes.db\n");
+        }
     }
 
     return r;
@@ -7076,7 +7108,8 @@ static int mailbox_reconstruct_acl(struct mailbox *mailbox, int flags)
 
 static int records_match(const char *mboxname,
                          struct index_record *old,
-                         struct index_record *new)
+                         struct index_record *new,
+                         struct reconstruct_report *report)
 {
     int i;
     int match = 1;
@@ -7084,47 +7117,58 @@ static int records_match(const char *mboxname,
 
     if (old->internaldate.tv_sec != new->internaldate.tv_sec ||
         old->internaldate.tv_nsec != new->internaldate.tv_nsec) {
-        printf("%s uid %u mismatch: internaldate\n",
+        if (!report) printf("%s uid %u mismatch: internaldate\n",
                mboxname, new->uid);
         match = 0;
     }
     if (old->sentdate.tv_sec != new->sentdate.tv_sec) {
-        printf("%s uid %u mismatch: sentdate\n",
+        if (!report) printf("%s uid %u mismatch: sentdate\n",
                mboxname, new->uid);
         match = 0;
     }
     if (old->size != new->size) {
-        printf("%s uid %u mismatch: size\n",
+        if (!report) printf("%s uid %u mismatch: size\n",
                mboxname, new->uid);
+        {
+            struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+            f.code = "message-size-mismatch";
+            f.mboxname = mboxname;
+            f.uid = new->uid;
+            f.has_uid = 1;
+            f.size = old->size;
+            f.has_size = 1;
+            f.guid = message_guid_encode(&old->guid);
+            reconstruct_report(report, &f);
+        }
         match = 0;
     }
     if (old->header_size != new->header_size) {
-        printf("%s uid %u mismatch: header_size\n",
+        if (!report) printf("%s uid %u mismatch: header_size\n",
                mboxname, new->uid);
         match = 0;
     }
     if (old->gmtime.tv_sec != new->gmtime.tv_sec) {
-        printf("%s uid %u mismatch: gmtime\n",
+        if (!report) printf("%s uid %u mismatch: gmtime\n",
                mboxname, new->uid);
         match = 0;
     }
     if (old->savedate.tv_sec != new->savedate.tv_sec) {
-        printf("%s uid %u mismatch: savedate\n",
+        if (!report) printf("%s uid %u mismatch: savedate\n",
                mboxname, new->uid);
         match = 0;
     }
     if (old->createdmodseq != new->createdmodseq) {
-        printf("%s uid %u mismatch: createdmodseq\n",
+        if (!report) printf("%s uid %u mismatch: createdmodseq\n",
                mboxname, new->uid);
         match = 0;
     }
     if (old->system_flags != new->system_flags) {
-        printf("%s uid %u mismatch: systemflags\n",
+        if (!report) printf("%s uid %u mismatch: systemflags\n",
                mboxname, new->uid);
         match = 0;
     }
     if (old->internal_flags != new->internal_flags) {
-        printf("%s uid %u mismatch: internalflags\n",
+        if (!report) printf("%s uid %u mismatch: internalflags\n",
                mboxname, new->uid);
         match = 0;
     }
@@ -7133,13 +7177,22 @@ static int records_match(const char *mboxname,
             userflags_dirty = 1;
     }
     if (userflags_dirty) {
-        printf("%s uid %u mismatch: userflags\n",
+        if (!report) printf("%s uid %u mismatch: userflags\n",
                mboxname, new->uid);
         match = 0;
     }
     if (!message_guid_equal(&old->guid, &new->guid)) {
-        printf("%s uid %u mismatch: guid\n",
+        if (!report) printf("%s uid %u mismatch: guid\n",
                mboxname, new->uid);
+        {
+            struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+            f.code = "message-guid-mismatch";
+            f.mboxname = mboxname;
+            f.uid = new->uid;
+            f.has_uid = 1;
+            f.guid = message_guid_encode(&old->guid);
+            reconstruct_report(report, &f);
+        }
         match = 0;
     }
 
@@ -7172,7 +7225,8 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
                                               bit32 *valid_user_flags,
                                               int flags, int have_file,
                                               int has_snoozedannot,
-                                              struct found_uids *discovered)
+                                              struct found_uids *discovered,
+                                              struct reconstruct_report *report)
 {
     const char *fname = mailbox_record_fname(mailbox, record);
     int r = 0;
@@ -7205,7 +7259,24 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
             goto out;
         }
 
-        printf("%s uid %u not found\n", mailbox_name(mailbox), record->uid);
+        if (!report) printf("%s uid %u not found\n", mailbox_name(mailbox), record->uid);
+        {
+            struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+            f.code = "message-file-missing";
+            f.mboxname = mailbox_name(mailbox);
+            f.uniqueid = mailbox_uniqueid(mailbox);
+            f.uid = record->uid;
+            f.has_uid = 1;
+            f.size = record->size;
+            f.has_size = 1;
+            f.guid = message_guid_encode(&record->guid);
+            f.tier = (record->internal_flags & FLAG_INTERNAL_ARCHIVED)
+                     ? "archive" : "spool";
+            f.path = (record->internal_flags & FLAG_INTERNAL_ARCHIVED)
+                     ? mailbox_archive_fname(mailbox, record->uid)
+                     : mailbox_spool_fname(mailbox, record->uid);
+            reconstruct_report(report, &f);
+        }
         syslog(LOG_ERR, "%s uid %u not found", mailbox_name(mailbox), record->uid);
 
         if (!make_changes) {
@@ -7251,8 +7322,18 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
         if (!message_guid_equal(&record->guid, &copy.guid)) {
             int do_unlink = 0;
 
-            printf("%s uid %u guid mismatch\n",
+            if (!report) printf("%s uid %u guid mismatch\n",
                    mailbox_name(mailbox), record->uid);
+            {
+                struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+                f.code = "message-guid-mismatch";
+                f.mboxname = mailbox_name(mailbox);
+                f.uniqueid = mailbox_uniqueid(mailbox);
+                f.uid = record->uid;
+                f.has_uid = 1;
+                f.guid = message_guid_encode(&record->guid);
+                reconstruct_report(report, &f);
+            }
             syslog(LOG_ERR, "%s uid %u guid mismatch",
                    mailbox_name(mailbox), record->uid);
 
@@ -7308,7 +7389,17 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
     if (!record->size) {
         /* dang, guess it failed to parse */
 
-        printf("%s uid %u failed to parse\n", mailbox_name(mailbox), record->uid);
+        if (!report) printf("%s uid %u failed to parse\n", mailbox_name(mailbox), record->uid);
+        {
+            struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+            f.code = "message-unparseable";
+            f.mboxname = mailbox_name(mailbox);
+            f.uniqueid = mailbox_uniqueid(mailbox);
+            f.uid = record->uid;
+            f.has_uid = 1;
+            f.guid = message_guid_encode(&record->guid);
+            reconstruct_report(report, &f);
+        }
         syslog(LOG_ERR, "%s uid %u failed to parse", mailbox_name(mailbox), record->uid);
 
         if (!make_changes) {
@@ -7359,7 +7450,7 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
 
     /* XXX - conditions under which modseq or uid or internaldate could be bogus? */
     if (record->modseq > mailbox->i.highestmodseq) {
-        printf("%s uid %u future modseq " MODSEQ_FMT " found\n",
+        if (!report) printf("%s uid %u future modseq " MODSEQ_FMT " found\n",
                    mailbox_name(mailbox), record->uid, record->modseq);
         syslog(LOG_ERR, "%s uid %u future modseq " MODSEQ_FMT " found",
                    mailbox_name(mailbox), record->uid, record->modseq);
@@ -7370,7 +7461,7 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
     }
 
     if (record->uid > mailbox->i.last_uid) {
-        printf("%s future uid %u found\n",
+        if (!report) printf("%s future uid %u found\n",
                mailbox_name(mailbox), record->uid);
         syslog(LOG_ERR, "%s future uid %u found",
                mailbox_name(mailbox), record->uid);
@@ -7386,7 +7477,7 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
     /* check if the snoozed status matches (unless expunged, which shouldn't be snoozed) */
     if (!(record->internal_flags & FLAG_INTERNAL_EXPUNGED)
       && !!(record->internal_flags & FLAG_INTERNAL_SNOOZED) != !!has_snoozedannot) {
-        printf("%s uid %u snoozed mismatch\n", mailbox_name(mailbox), record->uid);
+        if (!report) printf("%s uid %u snoozed mismatch\n", mailbox_name(mailbox), record->uid);
         syslog(LOG_ERR, "%s uid %u snoozed mismatch", mailbox_name(mailbox), record->uid);
         if (has_snoozedannot) record->internal_flags |= FLAG_INTERNAL_SNOOZED;
         else record->internal_flags &= ~FLAG_INTERNAL_SNOOZED;
@@ -7395,7 +7486,7 @@ static int mailbox_reconstruct_compare_update(struct mailbox *mailbox,
 
     /* after all this - if it still matches in every respect, we don't need
      * to rewrite the record - just return */
-    if (records_match(mailbox_name(mailbox), &copy, record)) {
+    if (records_match(mailbox_name(mailbox), &copy, record, report)) {
         r = 0 ;
         goto out;
     }
@@ -7435,7 +7526,8 @@ out:
 
 
 static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int isarchive,
-                                      int has_snoozedannot, int flags)
+                                      int has_snoozedannot, int flags,
+                                      struct reconstruct_report *report)
 {
     /* XXX - support archived */
     const char *fname;
@@ -7471,7 +7563,17 @@ static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int
     /* no file, nothing to do! */
     if (r) {
         syslog(LOG_ERR, "%s uid %u not found", mailbox_name(mailbox), uid);
-        printf("%s uid %u not found", mailbox_name(mailbox), uid);
+        if (!report) printf("%s uid %u not found", mailbox_name(mailbox), uid);
+        {
+            struct reconstruct_finding f = RECONSTRUCT_FINDING_INITIALIZER;
+            f.code = "message-file-missing";
+            f.mboxname = mailbox_name(mailbox);
+            f.uniqueid = mailbox_uniqueid(mailbox);
+            f.uid = uid;
+            f.has_uid = 1;
+            f.tier = isarchive ? "archive" : "spool";
+            reconstruct_report(report, &f);
+        }
         r = 0;
 
         if (make_changes)
@@ -7502,7 +7604,7 @@ static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int
     }
 
     if (uid > mailbox->i.last_uid) {
-        printf("%s uid %u found - adding\n", mailbox_name(mailbox), uid);
+        if (!report) printf("%s uid %u found - adding\n", mailbox_name(mailbox), uid);
         syslog(LOG_ERR, "%s uid %u found - adding", mailbox_name(mailbox), uid);
         record.uid = uid;
     }
@@ -7510,7 +7612,7 @@ static int mailbox_reconstruct_append(struct mailbox *mailbox, uint32_t uid, int
         char *oldfname;
         char *newfname;
 
-        printf("%s uid %u rediscovered - appending\n", mailbox_name(mailbox), uid);
+        if (!report) printf("%s uid %u rediscovered - appending\n", mailbox_name(mailbox), uid);
         syslog(LOG_ERR, "%s uid %u rediscovered - appending", mailbox_name(mailbox), uid);
         /* XXX - check firstexpunged? */
         record.uid = mailbox->i.last_uid + 1;
@@ -7553,10 +7655,11 @@ out:
 
 static void reconstruct_compare_headers(struct mailbox *mailbox,
                                         struct index_header *old,
-                                        struct index_header *new)
+                                        struct index_header *new,
+                                        struct reconstruct_report *report)
 {
     if (old->quota_mailbox_used != new->quota_mailbox_used) {
-        printf("%s updating quota_mailbox_used: "
+        if (!report) printf("%s updating quota_mailbox_used: "
                QUOTA_T_FMT " => " QUOTA_T_FMT "\n", mailbox_name(mailbox),
                old->quota_mailbox_used, new->quota_mailbox_used);
         syslog(LOG_ERR, "%s updating quota_mailbox_used: "
@@ -7565,7 +7668,7 @@ static void reconstruct_compare_headers(struct mailbox *mailbox,
     }
 
     if (old->quota_annot_used != new->quota_annot_used) {
-        printf("%s updating quota_annot_used: "
+        if (!report) printf("%s updating quota_annot_used: "
                QUOTA_T_FMT " => " QUOTA_T_FMT "\n", mailbox_name(mailbox),
                old->quota_annot_used, new->quota_annot_used);
         syslog(LOG_ERR, "%s updating quota_annot_used: "
@@ -7574,7 +7677,7 @@ static void reconstruct_compare_headers(struct mailbox *mailbox,
     }
 
     if (old->quota_deleted_used != new->quota_deleted_used) {
-        printf("%s updating quota_deleted_used: "
+        if (!report) printf("%s updating quota_deleted_used: "
                QUOTA_T_FMT " => " QUOTA_T_FMT "\n", mailbox_name(mailbox),
                old->quota_deleted_used, new->quota_deleted_used);
         syslog(LOG_ERR, "%s updating quota_deleted_used: "
@@ -7583,7 +7686,7 @@ static void reconstruct_compare_headers(struct mailbox *mailbox,
     }
 
     if (old->quota_expunged_used != new->quota_expunged_used) {
-        printf("%s updating quota_expunged_used: "
+        if (!report) printf("%s updating quota_expunged_used: "
                QUOTA_T_FMT " => " QUOTA_T_FMT "\n", mailbox_name(mailbox),
                old->quota_expunged_used, new->quota_expunged_used);
         syslog(LOG_ERR, "%s updating quota_expunged_used: "
@@ -7594,42 +7697,42 @@ static void reconstruct_compare_headers(struct mailbox *mailbox,
     if (old->answered != new->answered) {
         syslog(LOG_ERR, "%s: updating answered %u => %u",
                mailbox_name(mailbox), old->answered, new->answered);
-        printf("%s: updating answered %u => %u\n",
+        if (!report) printf("%s: updating answered %u => %u\n",
                mailbox_name(mailbox), old->answered, new->answered);
     }
 
     if (old->flagged != new->flagged) {
         syslog(LOG_ERR, "%s: updating flagged %u => %u",
                mailbox_name(mailbox), old->flagged, new->flagged);
-        printf("%s: updating flagged %u => %u\n",
+        if (!report) printf("%s: updating flagged %u => %u\n",
                mailbox_name(mailbox), old->flagged, new->flagged);
     }
 
     if (old->deleted != new->deleted) {
         syslog(LOG_ERR, "%s: updating deleted %u => %u",
                mailbox_name(mailbox), old->deleted, new->deleted);
-        printf("%s: updating deleted %u => %u\n",
+        if (!report) printf("%s: updating deleted %u => %u\n",
                mailbox_name(mailbox), old->deleted, new->deleted);
     }
 
     if (old->exists != new->exists) {
         syslog(LOG_ERR, "%s: updating exists %u => %u",
                mailbox_name(mailbox), old->exists, new->exists);
-        printf("%s: updating exists %u => %u\n",
+        if (!report) printf("%s: updating exists %u => %u\n",
                mailbox_name(mailbox), old->exists, new->exists);
     }
 
     if (old->synccrcs.basic != new->synccrcs.basic) {
         syslog(LOG_ERR, "%s: updating sync_crc %u => %u",
                mailbox_name(mailbox), old->synccrcs.basic, new->synccrcs.basic);
-        printf("%s: updating sync_crc %u => %u\n",
+        if (!report) printf("%s: updating sync_crc %u => %u\n",
                mailbox_name(mailbox), old->synccrcs.basic, new->synccrcs.basic);
     }
 
     if (old->synccrcs.annot != new->synccrcs.annot) {
         syslog(LOG_ERR, "%s: updating sync_crc_annot %u => %u",
                mailbox_name(mailbox), old->synccrcs.annot, new->synccrcs.annot);
-        printf("%s: updating sync_crc_annot %u => %u\n",
+        if (!report) printf("%s: updating sync_crc_annot %u => %u\n",
                mailbox_name(mailbox), old->synccrcs.annot, new->synccrcs.annot);
     }
 
@@ -7720,7 +7823,8 @@ static int find_annots(struct mailbox *mailbox, struct found_uids *annots)
 
 static int reconstruct_delannots(struct mailbox *mailbox,
                                  struct found_uids *delannots,
-                                 int flags)
+                                 int flags,
+                                 struct reconstruct_report *report)
 {
     int make_changes = (flags & RECONSTRUCT_MAKE_CHANGES);
     int r = 0;
@@ -7735,7 +7839,7 @@ static int reconstruct_delannots(struct mailbox *mailbox,
     while (delannots->pos < delannots->nused) {
         uint32_t uid = delannots->found[delannots->pos].uid;
         syslog(LOG_NOTICE, "removing stale annotations for %u", uid);
-        printf("removing stale annotations for %u\n", uid);
+        if (!report) printf("removing stale annotations for %u\n", uid);
         if (make_changes) {
             r = annotate_msg_cleanup(mailbox, uid);
             if (r) goto out;
@@ -7751,7 +7855,15 @@ out:
 /*
  * Reconstruct the single mailbox named 'name'
  */
-EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **mboxptr)
+EXPORTED int mailbox_reconstruct(const char *name, int flags,
+                                 struct mailbox **mboxptr)
+{
+    return mailbox_reconstruct_report(name, flags, mboxptr, NULL);
+}
+
+EXPORTED int mailbox_reconstruct_report(const char *name, int flags,
+                                        struct mailbox **mboxptr,
+                                        struct reconstruct_report *report)
 {
     /* settings */
     int make_changes = (flags & RECONSTRUCT_MAKE_CHANGES);
@@ -7777,12 +7889,12 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
     if (r) {
         if (!make_changes) return r;
         /* returns a locktype == LOCK_EXCLUSIVE mailbox */
-        r = mailbox_reconstruct_create(name, &mailbox);
+        r = mailbox_reconstruct_create(name, &mailbox, report);
     }
     if (r) return r;
 
     /* NOTE: we have to do this first, because it reads the header */
-    r = mailbox_reconstruct_acl(mailbox, flags);
+    r = mailbox_reconstruct_acl(mailbox, flags, report);
     if (r) goto close;
 
     /* open and lock the annotation state */
@@ -7800,7 +7912,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
     for (flag = 0; flag < MAX_USER_FLAGS; flag++) {
         if (!mailbox->h.flagname[flag]) continue;
         if (!imparse_isatom(mailbox->h.flagname[flag])) {
-            printf("%s: bogus flag name %d:%s",
+            if (!report) printf("%s: bogus flag name %d:%s",
                    mailbox_name(mailbox), flag, mailbox->h.flagname[flag]);
             syslog(LOG_ERR, "%s: bogus flag name %d:%s",
                    mailbox_name(mailbox), flag, mailbox->h.flagname[flag]);
@@ -7814,7 +7926,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
     /* find cyrus.expunge file if present */
     cleanup_stale_expunged(mailbox);
 
-    r = find_files(mailbox, &files, flags);
+    r = find_files(mailbox, &files, flags, report);
     if (r) goto close;
 
     r = find_annots(mailbox, &annots);
@@ -7862,7 +7974,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
             if (have_file) {
                 /* we can just unlink this one, already processed one copy */
                 const char *fname = mailbox_archive_fname(mailbox, record.uid);
-                printf("Removing duplicate archive file %s\n", fname);
+                if (!report) printf("Removing duplicate archive file %s\n", fname);
                 xunlink(fname);
             }
             else {
@@ -7870,7 +7982,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
                     if (!(record.internal_flags & FLAG_INTERNAL_ARCHIVED)) {
                         /* oops, it's really archived - let's fix that right now */
                         record.internal_flags |= FLAG_INTERNAL_ARCHIVED;
-                        printf("Marking file as archived %s %u\n", mailbox_name(mailbox), record.uid);
+                        if (!report) printf("Marking file as archived %s %u\n", mailbox_name(mailbox), record.uid);
                         mailbox_rewrite_index_record(mailbox, &record);
                     }
                 }
@@ -7878,7 +7990,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
                     if (record.internal_flags & FLAG_INTERNAL_ARCHIVED) {
                         /* oops, non-archived copy exists, let's use that */
                         record.internal_flags &= ~FLAG_INTERNAL_ARCHIVED;
-                        printf("Marking file as not archived %s %u\n", mailbox_name(mailbox), record.uid);
+                        if (!report) printf("Marking file as not archived %s %u\n", mailbox_name(mailbox), record.uid);
                         mailbox_rewrite_index_record(mailbox, &record);
                     }
                 }
@@ -7891,7 +8003,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
                                                valid_user_flags,
                                                flags, have_file,
                                                has_snoozedannot,
-                                               &discovered);
+                                               &discovered, report);
         if (r) goto close;
 
         if (mailbox->i.minor_version >= 13) {
@@ -7900,7 +8012,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
             if (!buf.len) mailbox_annotation_lookup(mailbox, record.uid, IMAP_ANNOT_NS "thrid", NULL, &buf);
             if (buf.len) {
                 syslog(LOG_NOTICE, "removing stale thrid for %u", record.uid);
-                printf("removing stale thrid for %u\n", record.uid);
+                if (!report) printf("removing stale thrid for %u\n", record.uid);
                 buf_reset(&buf);
                 r = mailbox_annotation_write(mailbox, record.uid, IMAP_ANNOT_NS "thrid", "", &buf);
                 if (r) goto close;
@@ -7913,7 +8025,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
             if (!buf.len) mailbox_annotation_lookup(mailbox, record.uid, IMAP_ANNOT_NS "savedate", NULL, &buf);
             if (buf.len) {
                 syslog(LOG_NOTICE, "removing stale savedate for %u", record.uid);
-                printf("removing stale savedate for %u\n", record.uid);
+                if (!report) printf("removing stale savedate for %u\n", record.uid);
                 buf_reset(&buf);
                 r = mailbox_annotation_write(mailbox, record.uid, IMAP_ANNOT_NS "savedate", "", &buf);
                 if (r) goto close;
@@ -7926,7 +8038,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
             if (!buf.len) mailbox_annotation_lookup(mailbox, record.uid, IMAP_ANNOT_NS "createdmodseq", NULL, &buf);
             if (buf.len) {
                 syslog(LOG_NOTICE, "removing stale createdmodseq for %u", record.uid);
-                printf("removing stale createdmodseq for %u\n", record.uid);
+                if (!report) printf("removing stale createdmodseq for %u\n", record.uid);
                 buf_reset(&buf);
                 r = mailbox_annotation_write(mailbox, record.uid, IMAP_ANNOT_NS "createdmodseq", "", &buf);
                 if (r) goto close;
@@ -7939,7 +8051,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
             if (!buf.len) mailbox_annotation_lookup(mailbox, record.uid, IMAP_ANNOT_NS "basethrid", NULL, &buf);
             if (buf.len) {
                 syslog(LOG_NOTICE, "removing stale basethrid for %u", record.uid);
-                printf("removing stale basethrid for %u\n", record.uid);
+                if (!report) printf("removing stale basethrid for %u\n", record.uid);
                 buf_reset(&buf);
                 r = mailbox_annotation_write(mailbox, record.uid, IMAP_ANNOT_NS "basethrid", "", &buf);
                 if (r) goto close;
@@ -7983,7 +8095,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
 
         r = mailbox_reconstruct_append(mailbox, files.found[files.pos].uid,
                                        files.found[files.pos].isarchive,
-                                       has_snoozedannot, flags);
+                                       has_snoozedannot, flags, report);
         if (r) goto close;
         files.pos++;
 
@@ -7999,13 +8111,13 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
     while (discovered.pos < discovered.nused) {
         r = mailbox_reconstruct_append(mailbox, discovered.found[discovered.pos].uid,
                                        discovered.found[discovered.pos].isarchive,
-                                       /*has_snoozedannot*/0, flags);
+                                       /*has_snoozedannot*/0, flags, report);
         if (r) goto close;
         discovered.pos++;
     }
 
     if (delannots.nused) {
-        r = reconstruct_delannots(mailbox, &delannots, flags);
+        r = reconstruct_delannots(mailbox, &delannots, flags, report);
         if (r) goto close;
     }
 
@@ -8019,7 +8131,7 @@ EXPORTED int mailbox_reconstruct(const char *name, int flags, struct mailbox **m
     if (r) goto close;
 
     /* inform users of any changed header fields */
-    reconstruct_compare_headers(mailbox, &old_header, &mailbox->i);
+    reconstruct_compare_headers(mailbox, &old_header, &mailbox->i, report);
 
     // make the mailbox dirty regardless
     if (flags & RECONSTRUCT_ALWAYS_DIRTY)

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -664,7 +664,47 @@ extern int mailbox_rename_cleanup(struct mailbox **mailboxptr);
 
 extern int mailbox_copyfile_fdptr(const char *from, const char *to, int nolink, int *dirfdp);
 
+/* Optional structured reporting from reconstruct, for the consistency
+ * audit.  Only the sites representing recoverable data damage report
+ * through this; everything else reconstruct repairs itself and needs no
+ * external help.
+ *
+ * A finding carries whatever a caller needs to fetch a replacement from a
+ * replica or from backup: the mailbox, the uid, and the guid the index
+ * says the file should have.
+ */
+struct reconstruct_finding {
+    const char *code;       /* stable slug */
+    const char *mboxname;
+    const char *userid;
+    const char *uniqueid;
+    const char *path;
+    const char *tier;       /* "spool" | "archive" */
+    const char *metaname;   /* "index" | "header" */
+    const char *guid;
+    uint32_t uid;
+    uint64_t size;
+    int has_uid;
+    int has_size;
+};
+
+#define RECONSTRUCT_FINDING_INITIALIZER \
+    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0 }
+
+typedef void reconstruct_reportproc_t(void *rock,
+                                      const struct reconstruct_finding *f);
+
+struct reconstruct_report {
+    reconstruct_reportproc_t *proc;
+    void *rock;
+};
+
 extern int mailbox_reconstruct(const char *name, int flags, struct mailbox **mailboxp);
+/* as mailbox_reconstruct(), but also reporting recoverable damage
+ * structurally.  report may be NULL. */
+extern int mailbox_reconstruct_report(const char *name, int flags,
+                                      struct mailbox **mailboxp,
+                                      struct reconstruct_report *report);
 
 /*
  * Create the unique identifier for a mailbox named 'name' with
@@ -675,6 +715,7 @@ extern int mailbox_reconstruct(const char *name, int flags, struct mailbox **mai
 
 extern void mailbox_set_uniqueid(struct mailbox *mailbox, const char *uniqueid);
 extern void mailbox_set_jmapid(struct mailbox *mailbox, const char *jmapid);
+
 extern void mailbox_set_mbtype(struct mailbox *mailbox, uint32_t mbtype);
 
 extern int mailbox_setversion(struct mailbox *mailbox,

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -31,6 +31,7 @@
 #include "cyrusdb.h"
 #include "hash.h"
 #include "util.h"
+#include "jmap_util.h"
 #include "mailbox.h"
 #include "mboxevent.h"
 #include "xmalloc.h"
@@ -1246,6 +1247,91 @@ EXPORTED int mboxlist_foreach_raw(mboxlist_rawproc_t *proc, void *rock,
     /* One foreach inside a single transaction gives a consistent snapshot
      * across all key types, which every cross-check depends on. */
     return cyrusdb_foreach(mbdb, "", 0, NULL, rawforeach_cb, &frock, tid);
+}
+
+/*
+ * Ensure this mailbox is reachable by jmapid: assign one if it has none,
+ * and write the J record.
+ *
+ * This is not a database-only repair.  The jmapid is derived from the
+ * folder's modseq, so with no jmapid present it opens the mailbox,
+ * dirties the modseq, writes the header and commits before updating the
+ * mbentry.  Callers must be prepared for that cost.
+ *
+ * Shared by ctl_mboxlist -k and the consistency audit: a second
+ * implementation of jmapid assignment would drift from this one.
+ */
+EXPORTED int mboxlist_fix_jmapid(const mbentry_t *mbentry)
+{
+    mbentry_t *byunqid = NULL;
+
+    int r = mboxlist_lookup_by_uniqueid(mbentry->uniqueid, &byunqid, NULL);
+    if (r) {
+        xsyslog(LOG_NOTICE, "missing uniqueid record, skipping",
+               "mboxname=<%s> uniqueid=<%s>",
+               mbentry->name, mbentry->uniqueid);
+        return 0;
+    }
+
+    // we are not the current record?  We don't need to process this.
+    if (strcmp(mbentry->name, byunqid->name))
+        goto done;
+
+    if (mbentry->jmapid) {
+        mbname_t *mbname = mbname_from_intname(mbentry->name);
+        const char *userid = mbname_userid(mbname);
+
+        if (!userid) userid = "";
+
+        // already got a record, we're good!
+        int res = mboxlist_lookup_by_jmapid(userid, mbentry->jmapid, NULL, NULL);
+        mbname_free(&mbname);
+        if (!res) goto done;
+
+        xsyslog(LOG_NOTICE, "adding missing J record to mboxlist",
+                "mboxname=<%s> jmapid=<%s>",
+                mbentry->name, mbentry->jmapid);
+    }
+    else {
+        struct mailbox *mailbox = NULL;
+        r = mailbox_open_from_mbe(byunqid, &mailbox);
+        if (r) goto done;
+        struct buf jmapid = BUF_INITIALIZER;
+
+        byunqid->foldermodseq = mailbox_modseq_dirty(mailbox);
+
+        buf_putc(&jmapid, JMAP_MAILBOXID_PREFIX);
+        MODSEQ_TO_JMAPID(&jmapid, byunqid->foldermodseq);
+        mailbox_set_jmapid(mailbox, buf_cstring(&jmapid));
+
+        free(byunqid->jmapid);
+        byunqid->jmapid = buf_release(&jmapid);
+        buf_free(&jmapid);
+
+        xsyslog(LOG_NOTICE, "adding new J record to mboxlist",
+                "mboxname=<%s> jmapid=<%s>",
+                byunqid->name, byunqid->jmapid);
+
+        r = mailbox_commit(mailbox);
+        mailbox_close(&mailbox);
+        if (r) {
+            xsyslog(LOG_ERR, "DBERROR: error committing transaction",
+                    "error=<%s>", cyrusdb_strerror(r));
+            goto done;
+        }
+    }
+
+    r = mboxlist_updatelock(byunqid, /*localonly*/1);
+    if (r) {
+        xsyslog(LOG_ERR, "failed to update mboxlist",
+                "mboxname=<%s> error=<%s>",
+                mbentry->name, error_message(r));
+    }
+
+done:
+    mboxlist_entry_free(&byunqid);
+
+    return r;
 }
 
 EXPORTED void mboxlist_key_for_name(const char *mboxname, struct buf *key)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1119,6 +1119,134 @@ static void mboxlist_racl_key(int isuser, const char *keyuser,
     }
 }
 
+/*
+ * Raw keyspace access, for consistency auditing.
+ *
+ * The audit has to see keys the regular lookup API would hide or choke
+ * on -- an unparseable entry or an unrecognised prefix is exactly the
+ * kind of thing it exists to find -- so these live here, next to the key
+ * format they depend on, rather than in the auditing code.
+ */
+EXPORTED int mboxlist_parse_rawkey(const char *key, size_t keylen,
+                                   struct mboxlist_rawkey *rawkey)
+{
+    const char *sep;
+
+    memset(rawkey, 0, sizeof(*rawkey));
+
+    if (!keylen) return IMAP_MAILBOX_BADNAME;
+
+    switch (key[0]) {
+    case KEY_TYPE_NAME:
+        if (keylen < 2) return IMAP_MAILBOX_BADNAME;
+        rawkey->type = MBOXLIST_KEY_NAME;
+        rawkey->dbname = xstrndup(key + 1, keylen - 1);
+        return 0;
+
+    case KEY_TYPE_ID:
+        if (keylen < 2) return IMAP_MAILBOX_BADNAME;
+        rawkey->type = MBOXLIST_KEY_ID;
+        rawkey->uniqueid = xstrndup(key + 1, keylen - 1);
+        return 0;
+
+    case KEY_TYPE_JID:
+        if (keylen < 2) return IMAP_MAILBOX_BADNAME;
+        sep = memchr(key + 1, DB_RECORDSEP_CHAR, keylen - 1);
+        /* an empty userid is legal (shared mailboxes), but the separator
+         * and a jmapid are not optional */
+        if (!sep || sep + 1 >= key + keylen) return IMAP_MAILBOX_BADNAME;
+        rawkey->type = MBOXLIST_KEY_JMAPID;
+        rawkey->userid = xstrndup(key + 1, sep - (key + 1));
+        rawkey->jmapid = xstrndup(sep + 1, (key + keylen) - (sep + 1));
+        return 0;
+
+    case KEY_TYPE_ACL:
+        if (keylen < 3 || key[2] != DB_RECORDSEP_CHAR)
+            return IMAP_MAILBOX_BADNAME;
+        if (key[1] != 'U' && key[1] != 'S')
+            return IMAP_MAILBOX_BADNAME;
+        rawkey->type = MBOXLIST_KEY_RACL;
+        rawkey->isuser = (key[1] == 'U');
+        sep = memchr(key + 3, DB_RECORDSEP_CHAR, keylen - 3);
+        if (sep) {
+            rawkey->userid = xstrndup(key + 3, sep - (key + 3));
+            rawkey->aclmbox = xstrndup(sep + 1, (key + keylen) - (sep + 1));
+        }
+        else {
+            /* mboxlist_racl_key() omits both trailing parts when they are
+             * NULL, so a key with neither is well-formed */
+            rawkey->userid = xstrndup(key + 3, keylen - 3);
+        }
+        return 0;
+
+    default:
+        rawkey->type = MBOXLIST_KEY_UNKNOWN;
+        return 0;
+    }
+}
+
+EXPORTED void mboxlist_rawkey_fini(struct mboxlist_rawkey *rawkey)
+{
+    if (!rawkey) return;
+    xzfree(rawkey->dbname);
+    xzfree(rawkey->uniqueid);
+    xzfree(rawkey->userid);
+    xzfree(rawkey->jmapid);
+    xzfree(rawkey->aclmbox);
+    rawkey->type = MBOXLIST_KEY_UNKNOWN;
+    rawkey->isuser = 0;
+}
+
+struct rawforeach_rock {
+    mboxlist_rawproc_t *proc;
+    void *rock;
+};
+
+static int rawforeach_cb(void *rock, const char *key, size_t keylen,
+                         const char *data, size_t datalen)
+{
+    struct rawforeach_rock *frock = (struct rawforeach_rock *)rock;
+    struct mboxlist_rawkey rawkey = MBOXLIST_RAWKEY_INITIALIZER;
+    mbentry_t *mbentry = NULL;
+    int r;
+
+    r = mboxlist_parse_rawkey(key, keylen, &rawkey);
+    if (r) {
+        /* report it rather than dropping it: a malformed key is a finding,
+         * not a reason to stop */
+        rawkey.type = MBOXLIST_KEY_UNKNOWN;
+    }
+
+    /* a NULL mbentry tells the callback the value did not parse */
+    if (rawkey.type == MBOXLIST_KEY_NAME) {
+        mboxlist_parse_entry(&mbentry, rawkey.dbname, strlen(rawkey.dbname),
+                             data, datalen);
+    }
+    else if (rawkey.type == MBOXLIST_KEY_ID ||
+             rawkey.type == MBOXLIST_KEY_JMAPID) {
+        mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
+    }
+
+    r = frock->proc(frock->rock, &rawkey, mbentry, data, datalen);
+
+    mboxlist_entry_free(&mbentry);
+    mboxlist_rawkey_fini(&rawkey);
+
+    return r;
+}
+
+EXPORTED int mboxlist_foreach_raw(mboxlist_rawproc_t *proc, void *rock,
+                                  struct txn **tid)
+{
+    struct rawforeach_rock frock = { proc, rock };
+
+    init_internal();
+
+    /* One foreach inside a single transaction gives a consistent snapshot
+     * across all key types, which every cross-check depends on. */
+    return cyrusdb_foreach(mbdb, "", 0, NULL, rawforeach_cb, &frock, tid);
+}
+
 static int user_can_read(const strarray_t *aclbits, const char *user)
 {
     int i;

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1227,7 +1227,8 @@ static int rawforeach_cb(void *rock, const char *key, size_t keylen,
         mboxlist_parse_entry(&mbentry, NULL, 0, data, datalen);
     }
 
-    r = frock->proc(frock->rock, &rawkey, mbentry, data, datalen);
+    r = frock->proc(frock->rock, key, keylen, &rawkey, mbentry,
+                    data, datalen);
 
     mboxlist_entry_free(&mbentry);
     mboxlist_rawkey_fini(&rawkey);
@@ -1245,6 +1246,43 @@ EXPORTED int mboxlist_foreach_raw(mboxlist_rawproc_t *proc, void *rock,
     /* One foreach inside a single transaction gives a consistent snapshot
      * across all key types, which every cross-check depends on. */
     return cyrusdb_foreach(mbdb, "", 0, NULL, rawforeach_cb, &frock, tid);
+}
+
+EXPORTED void mboxlist_key_for_name(const char *mboxname, struct buf *key)
+{
+    char *dbname = mboxname_to_dbname(mboxname);
+
+    mboxlist_dbname_to_key(dbname, strlen(dbname), NULL, key);
+
+    free(dbname);
+}
+
+EXPORTED void mboxlist_key_for_id(const char *uniqueid, struct buf *key)
+{
+    mboxlist_id_to_key(uniqueid, key);
+}
+
+EXPORTED void mboxlist_key_for_jmapid(const char *userid, const char *jmapid,
+                                      struct buf *key)
+{
+    mboxlist_jmapid_to_key(userid, jmapid, key);
+}
+
+EXPORTED int mboxlist_rawkey_delete(const char *key, size_t keylen,
+                                    struct txn **tid)
+{
+    init_internal();
+
+    return cyrusdb_delete(mbdb, key, keylen, tid, /*force*/1);
+}
+
+EXPORTED int mboxlist_rawkey_store(const char *key, size_t keylen,
+                                   const char *data, size_t datalen,
+                                   struct txn **tid)
+{
+    init_internal();
+
+    return cyrusdb_store(mbdb, key, keylen, data, datalen, tid);
 }
 
 static int user_can_read(const strarray_t *aclbits, const char *user)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1354,6 +1354,31 @@ EXPORTED void mboxlist_key_for_jmapid(const char *userid, const char *jmapid,
     mboxlist_jmapid_to_key(userid, jmapid, key);
 }
 
+EXPORTED int mboxlist_rewrite_id_record(const mbentry_t *mbentry,
+                                        struct txn **tid)
+{
+    char *dbname = mboxname_to_dbname(mbentry->name);
+    struct dlist *dl = mboxlist_entry_dlist(dbname, mbentry, KEY_TYPE_ID);
+    struct buf mboxent = BUF_INITIALIZER;
+    struct buf key = BUF_INITIALIZER;
+    int r;
+
+    init_internal();
+
+    dlist_printbuf(dl, 0, &mboxent);
+    mboxlist_id_to_key(mbentry->uniqueid, &key);
+
+    r = cyrusdb_store(mbdb, buf_base(&key), buf_len(&key),
+                      buf_base(&mboxent), buf_len(&mboxent), tid);
+
+    dlist_free(&dl);
+    buf_free(&mboxent);
+    buf_free(&key);
+    free(dbname);
+
+    return r;
+}
+
 EXPORTED int mboxlist_rawkey_delete(const char *key, size_t keylen,
                                     struct txn **tid)
 {

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -182,6 +182,14 @@ void mboxlist_rawkey_fini(struct mboxlist_rawkey *rawkey);
 int mboxlist_foreach_raw(mboxlist_rawproc_t *proc, void *rock,
                          struct txn **tid);
 
+/* Ensure a mailbox is reachable by jmapid: assign one if it has none, and
+ * write the J record.  Not database-only -- with no jmapid present this
+ * opens the mailbox, dirties the modseq and writes the header, because
+ * the jmapid is derived from the folder's modseq.
+ *
+ * Shared by ctl_mboxlist -k and the consistency audit. */
+int mboxlist_fix_jmapid(const mbentry_t *mbentry);
+
 /* Build the key for a record.  The inverse of mboxlist_parse_rawkey(),
  * kept here so that key format knowledge stays in one file. */
 void mboxlist_key_for_name(const char *mboxname, struct buf *key);

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -167,9 +167,12 @@ struct mboxlist_rawkey {
 #define MBOXLIST_RAWKEY_INITIALIZER \
     { MBOXLIST_KEY_UNKNOWN, NULL, NULL, NULL, NULL, NULL, 0 }
 
-/* mbentry is NULL if the value could not be parsed */
+/* key/keylen are the stored bytes, so that a caller can remove exactly
+ * what it saw.  parsed is the interpretation of those bytes; mbentry is
+ * NULL if the value could not be parsed. */
 typedef int mboxlist_rawproc_t(void *rock,
-                               const struct mboxlist_rawkey *key,
+                               const char *key, size_t keylen,
+                               const struct mboxlist_rawkey *parsed,
                                const mbentry_t *mbentry,
                                const char *data, size_t datalen);
 
@@ -178,6 +181,21 @@ int mboxlist_parse_rawkey(const char *key, size_t keylen,
 void mboxlist_rawkey_fini(struct mboxlist_rawkey *rawkey);
 int mboxlist_foreach_raw(mboxlist_rawproc_t *proc, void *rock,
                          struct txn **tid);
+
+/* Build the key for a record.  The inverse of mboxlist_parse_rawkey(),
+ * kept here so that key format knowledge stays in one file. */
+void mboxlist_key_for_name(const char *mboxname, struct buf *key);
+void mboxlist_key_for_id(const char *uniqueid, struct buf *key);
+void mboxlist_key_for_jmapid(const char *userid, const char *jmapid,
+                             struct buf *key);
+
+/* Raw key writes, for repairing a damaged keyspace.  The caller owns the
+ * transaction, so that a repair touching several keys either lands whole
+ * or not at all. */
+int mboxlist_rawkey_delete(const char *key, size_t keylen, struct txn **tid);
+int mboxlist_rawkey_store(const char *key, size_t keylen,
+                          const char *data, size_t datalen,
+                          struct txn **tid);
 
 char *mboxlist_find_specialuse(const char *use, const char *userid);
 char *mboxlist_find_uniqueid(const char *uniqueid, const char *userid,

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -197,6 +197,12 @@ void mboxlist_key_for_id(const char *uniqueid, struct buf *key);
 void mboxlist_key_for_jmapid(const char *userid, const char *jmapid,
                              struct buf *key);
 
+/* Rewrite the I record for an mbentry, serialised exactly as
+ * mboxlist_update_entry_full() would.  For repairs that alter an existing
+ * record -- pruning a name_history item, say -- without the surrounding
+ * bookkeeping of a real update. */
+int mboxlist_rewrite_id_record(const mbentry_t *mbentry, struct txn **tid);
+
 /* Raw key writes, for repairing a damaged keyspace.  The caller owns the
  * transaction, so that a repair touching several keys either lands whole
  * or not at all. */

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -140,6 +140,45 @@ int mboxlist_lookup_by_uniqueid(const char *uniqueid,
 int mboxlist_lookup_by_jmapid(const char *userid, const char *jmapid,
                               mbentry_t **entryptr, struct txn **tid);
 
+/* Raw access to the mailboxes.db keyspace, for consistency auditing.
+ *
+ * Unlike the mboxlist_lookup* API, this reports every key in the database
+ * including ones that fail to parse, so that a damaged database can be
+ * examined and repaired rather than merely erroring out.
+ */
+enum mboxlist_keytype {
+    MBOXLIST_KEY_UNKNOWN = 0,
+    MBOXLIST_KEY_NAME,          /* N<dbname> */
+    MBOXLIST_KEY_ID,            /* I<uniqueid> */
+    MBOXLIST_KEY_JMAPID,        /* J<userid>\x1e<jmapid> */
+    MBOXLIST_KEY_RACL,          /* AU\x1e<userid>\x1e<dbname>, or AS\x1e... */
+};
+
+struct mboxlist_rawkey {
+    enum mboxlist_keytype type;
+    char *dbname;       /* NAME */
+    char *uniqueid;     /* ID */
+    char *userid;       /* JMAPID: the owner.  RACL: user granted access */
+    char *jmapid;       /* JMAPID */
+    char *aclmbox;      /* RACL: dbname of the mailbox granted */
+    int isuser;         /* RACL: 1 for AU, 0 for AS */
+};
+
+#define MBOXLIST_RAWKEY_INITIALIZER \
+    { MBOXLIST_KEY_UNKNOWN, NULL, NULL, NULL, NULL, NULL, 0 }
+
+/* mbentry is NULL if the value could not be parsed */
+typedef int mboxlist_rawproc_t(void *rock,
+                               const struct mboxlist_rawkey *key,
+                               const mbentry_t *mbentry,
+                               const char *data, size_t datalen);
+
+int mboxlist_parse_rawkey(const char *key, size_t keylen,
+                          struct mboxlist_rawkey *rawkey);
+void mboxlist_rawkey_fini(struct mboxlist_rawkey *rawkey);
+int mboxlist_foreach_raw(mboxlist_rawproc_t *proc, void *rock,
+                         struct txn **tid);
+
 char *mboxlist_find_specialuse(const char *use, const char *userid);
 char *mboxlist_find_uniqueid(const char *uniqueid, const char *userid,
                              const struct auth_state *auth_state);


### PR DESCRIPTION
This is the process written in Perl in 'auditslot' which Fastmail has used for checking whether anything in the spool is wrong.