### PR TITLE
Correctly handle duplicate modseqs in Email/changes and Mailbox/changes

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_changes_maxchanges_duplicate_modseqs
+++ b/cassandane/tiny-tests/JMAPEmail/email_changes_maxchanges_duplicate_modseqs
@@ -1,0 +1,77 @@
+#!perl
+use Cassandane::Tiny;
+
+# This test asserts that Email/changes either reports all Emails having the
+# same modseq in a response, or none of them.  It must not exceed maxChanges
+# to do so -- RFC 8620 §5.2 says "MUST NOT".
+sub test_email_changes_maxchanges_duplicate_modseqs
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "Set up three mailboxes with one email each";
+    my $mbox_a = $user->mailboxes->create({ name => 'A' });
+    my $mbox_b = $user->mailboxes->create({ name => 'B' });
+    my $mbox_c = $user->mailboxes->create({ name => 'C' });
+
+    my $email_a = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true },
+        subject    => 'msgA',
+    });
+    my $email_b = $user->emails->create({
+        mailboxIds => { $mbox_b->id => JSON::true },
+        subject    => 'msgB',
+    });
+    my $email_c = $user->emails->create({
+        mailboxIds => { $mbox_c->id => JSON::true },
+        subject    => 'msgC',
+    });
+
+    my $res = $jmap->request([[ 'Email/get', { ids => [] } ]]);
+    my $state = $res->single_sentence('Email/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Set flag on email in mailbox C";
+    $email_c->update({ 'keywords/$flagged' => JSON::true });
+
+    xlog $self, "Set flag on emails in mailboxes A and B simultaneously";
+    $res = $jmap->request([
+        [ 'Email/set', {
+            update => {
+                $email_a->id => { 'keywords/$flagged' => JSON::true },
+                $email_b->id => { 'keywords/$flagged' => JSON::true },
+            },
+        } ],
+    ]);
+    $res->assert_single_successful_set('Email/set');
+
+    xlog $self, "Email in mailbox C is reported independently from the ones in A and B";
+    $res = $jmap->request([
+        [ 'Email/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+    my $changes = $res->single_sentence('Email/changes')->arguments;
+
+    $self->assert_cmp_deeply([], $changes->{created});
+    $self->assert_cmp_deeply([ $email_c->id ], $changes->{updated});
+    $self->assert_cmp_deeply([], $changes->{destroyed});
+    $self->assert($changes->{hasMoreChanges}, "more changes");
+    $self->assert_str_not_equals($state, $changes->{newState});
+
+    xlog $self, "The emails in A and B share a modseq, so they get reported together";
+    $res = $jmap->request([
+        [ 'Email/changes', {
+            sinceState => $changes->{newState},
+            maxChanges => 2,
+        } ],
+    ]);
+    $changes = $res->single_sentence('Email/changes')->arguments;
+
+    $self->assert_cmp_deeply([], $changes->{created});
+    $self->assert_cmp_deeply(
+        bag($email_a->id, $email_b->id),
+        $changes->{updated},
+    );
+    $self->assert_cmp_deeply([], $changes->{destroyed});
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_changes_maxchanges_too_small_duplicate_modseqs
+++ b/cassandane/tiny-tests/JMAPEmail/email_changes_maxchanges_too_small_duplicate_modseqs
@@ -1,0 +1,59 @@
+#!perl
+use Cassandane::Tiny;
+
+# When a single modseq's worth of changes is larger than maxChanges, there is
+# no intermediate state to hand back.  The client would sync only a partial
+# changeset and then advance its local state.
+sub test_email_changes_maxchanges_too_small_duplicate_modseqs
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "Set up two mailboxes with one email each";
+    my $mbox_a = $user->mailboxes->create({ name => 'A' });
+    my $mbox_b = $user->mailboxes->create({ name => 'B' });
+
+    my $email_a = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true },
+        subject    => 'msgA',
+    });
+    my $email_b = $user->emails->create({
+        mailboxIds => { $mbox_b->id => JSON::true },
+        subject    => 'msgB',
+    });
+
+    my $res = $jmap->request([[ 'Email/get', { ids => [] } ]]);
+    my $state = $res->single_sentence('Email/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Set flag on emails in mailboxes A and B simultaneously";
+    $res = $jmap->request([
+        [ 'Email/set', {
+            update => {
+                $email_a->id => { 'keywords/$flagged' => JSON::true },
+                $email_b->id => { 'keywords/$flagged' => JSON::true },
+            },
+        } ],
+    ]);
+    $res->assert_single_successful_set('Email/set');
+
+    xlog $self, "Both emails get the same modseq, so maxChanges 1 is rejected";
+    $res = $jmap->request([
+        [ 'Email/changes', { sinceState => $state, maxChanges => 1 } ],
+    ]);
+
+    $self->assert_str_equals('cannotCalculateChanges',
+                             $res->single_sentence('error')->arguments->{type});
+
+    xlog $self, "... but asking for both at once works";
+    $res = $jmap->request([
+        [ 'Email/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+
+    my $changes = $res->single_sentence('Email/changes')->arguments;
+
+    $self->assert_cmp_deeply(bag($email_a->id, $email_b->id),
+                             $changes->{updated});
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/cassandane/tiny-tests/JMAPEmail/thread_changes_maxchanges_duplicate_modseqs
+++ b/cassandane/tiny-tests/JMAPEmail/thread_changes_maxchanges_duplicate_modseqs
@@ -1,0 +1,77 @@
+#!perl
+use Cassandane::Tiny;
+
+# This test asserts that Thread/changes either reports all Threads having the
+# same modseq in a response, or none of them.  It must not exceed maxChanges
+# to do so -- RFC 8620 §5.2 says "MUST NOT".
+sub test_thread_changes_maxchanges_duplicate_modseqs
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "Set up three mailboxes with one email each";
+    my $mbox_a = $user->mailboxes->create({ name => 'A' });
+    my $mbox_b = $user->mailboxes->create({ name => 'B' });
+    my $mbox_c = $user->mailboxes->create({ name => 'C' });
+
+    my $email_a = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true },
+        subject    => 'msgA',
+    });
+    my $email_b = $user->emails->create({
+        mailboxIds => { $mbox_b->id => JSON::true },
+        subject    => 'msgB',
+    });
+    my $email_c = $user->emails->create({
+        mailboxIds => { $mbox_c->id => JSON::true },
+        subject    => 'msgC',
+    });
+
+    my $res = $jmap->request([[ 'Thread/get', { ids => [] } ]]);
+    my $state = $res->single_sentence('Thread/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Set flag on email in mailbox C";
+    $email_c->update({ 'keywords/$flagged' => JSON::true });
+
+    xlog $self, "Set flag on emails in mailboxes A and B simultaneously";
+    $res = $jmap->request([
+        [ 'Email/set', {
+            update => {
+                $email_a->id => { 'keywords/$flagged' => JSON::true },
+                $email_b->id => { 'keywords/$flagged' => JSON::true },
+            },
+        } ],
+    ]);
+    $res->assert_single_successful_set('Email/set');
+
+    xlog $self, "Thread of email C is reported independently from the ones in A and B";
+    $res = $jmap->request([
+        [ 'Thread/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+    my $changes = $res->single_sentence('Thread/changes')->arguments;
+
+    $self->assert_cmp_deeply([], $changes->{created});
+    $self->assert_cmp_deeply([ $email_c->threadId ], $changes->{updated});
+    $self->assert_cmp_deeply([], $changes->{destroyed});
+    $self->assert($changes->{hasMoreChanges}, "more changes");
+    $self->assert_str_not_equals($state, $changes->{newState});
+
+    xlog $self, "The threads of A and B share a modseq, so they get reported together";
+    $res = $jmap->request([
+        [ 'Thread/changes', {
+            sinceState => $changes->{newState},
+            maxChanges => 2,
+        } ],
+    ]);
+    $changes = $res->single_sentence('Thread/changes')->arguments;
+
+    $self->assert_cmp_deeply([], $changes->{created});
+    $self->assert_cmp_deeply(
+        bag($email_a->threadId, $email_b->threadId),
+        $changes->{updated},
+    );
+    $self->assert_cmp_deeply([], $changes->{destroyed});
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/cassandane/tiny-tests/JMAPEmail/thread_changes_maxchanges_too_small_duplicate_modseqs
+++ b/cassandane/tiny-tests/JMAPEmail/thread_changes_maxchanges_too_small_duplicate_modseqs
@@ -1,0 +1,59 @@
+#!perl
+use Cassandane::Tiny;
+
+# When a single modseq's worth of changes is larger than maxChanges, there is
+# no intermediate state to hand back.  The client would sync only a partial
+# changeset and then advance its local state.
+sub test_thread_changes_maxchanges_too_small_duplicate_modseqs
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "Set up two mailboxes with one email each";
+    my $mbox_a = $user->mailboxes->create({ name => 'A' });
+    my $mbox_b = $user->mailboxes->create({ name => 'B' });
+
+    my $email_a = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true },
+        subject    => 'msgA',
+    });
+    my $email_b = $user->emails->create({
+        mailboxIds => { $mbox_b->id => JSON::true },
+        subject    => 'msgB',
+    });
+
+    my $res = $jmap->request([[ 'Thread/get', { ids => [] } ]]);
+    my $state = $res->single_sentence('Thread/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Set flag on emails in mailboxes A and B simultaneously";
+    $res = $jmap->request([
+        [ 'Email/set', {
+            update => {
+                $email_a->id => { 'keywords/$flagged' => JSON::true },
+                $email_b->id => { 'keywords/$flagged' => JSON::true },
+            },
+        } ],
+    ]);
+    $res->assert_single_successful_set('Email/set');
+
+    xlog $self, "Both threads get the same modseq, so maxChanges 1 is rejected";
+    $res = $jmap->request([
+        [ 'Thread/changes', { sinceState => $state, maxChanges => 1 } ],
+    ]);
+
+    $self->assert_str_equals('cannotCalculateChanges',
+                             $res->single_sentence('error')->arguments->{type});
+
+    xlog $self, "... but asking for both at once works";
+    $res = $jmap->request([
+        [ 'Thread/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+
+    my $changes = $res->single_sentence('Thread/changes')->arguments;
+
+    $self->assert_cmp_deeply(bag($email_a->threadId, $email_b->threadId),
+                             $changes->{updated});
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_duplicate_modseqs
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_duplicate_modseqs
@@ -1,0 +1,77 @@
+#!perl
+use Cassandane::Tiny;
+
+# This test asserts that Mailbox/changes either reports all Mailboxes having
+# the same modseq in a response, or none of them.  It must not exceed
+# maxChanges to do so -- RFC 8620 §5.2 says "MUST NOT".
+sub test_mailbox_changes_maxchanges_duplicate_modseqs
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "Set up three mailboxes with one email each";
+    my $mbox_a = $user->mailboxes->create({ name => 'A' });
+    my $mbox_b = $user->mailboxes->create({ name => 'B' });
+    my $mbox_c = $user->mailboxes->create({ name => 'C' });
+
+    my $email_a = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true },
+        subject    => 'msgA',
+    });
+    my $email_b = $user->emails->create({
+        mailboxIds => { $mbox_b->id => JSON::true },
+        subject    => 'msgB',
+    });
+    my $email_c = $user->emails->create({
+        mailboxIds => { $mbox_c->id => JSON::true },
+        subject    => 'msgC',
+    });
+
+    my $res = $jmap->request([[ 'Mailbox/get', {} ]]);
+    my $state = $res->single_sentence('Mailbox/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Set flag on email in mailbox C";
+    $email_c->update({ 'keywords/$seen' => JSON::true });
+
+    xlog $self, "Set flag on emails in mailboxes A and B simultaneously";
+    $res = $jmap->request([
+        [ 'Email/set', {
+            update => {
+                $email_a->id => { 'keywords/$seen' => JSON::true },
+                $email_b->id => { 'keywords/$seen' => JSON::true },
+            },
+        } ],
+    ]);
+    $res->assert_single_successful_set('Email/set');
+
+    xlog $self, "Mailbox C is reported independently from the ones in A and B";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+    my $changes = $res->single_sentence('Mailbox/changes')->arguments;
+
+    $self->assert_cmp_deeply([], $changes->{created});
+    $self->assert_cmp_deeply([ $mbox_c->id ], $changes->{updated});
+    $self->assert_cmp_deeply([], $changes->{destroyed});
+    $self->assert($changes->{hasMoreChanges}, "more changes");
+    $self->assert_str_not_equals($state, $changes->{newState});
+
+    xlog $self, "Mailboxes A and B share a modseq, so they get reported together";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', {
+            sinceState => $changes->{newState},
+            maxChanges => 2,
+        } ],
+    ]);
+    $changes = $res->single_sentence('Mailbox/changes')->arguments;
+
+    $self->assert_cmp_deeply([], $changes->{created});
+    $self->assert_cmp_deeply(
+        bag($mbox_a->id, $mbox_b->id),
+        $changes->{updated},
+    );
+    $self->assert_cmp_deeply([], $changes->{destroyed});
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_duplicate_thread_modseqs
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_duplicate_thread_modseqs
@@ -1,0 +1,67 @@
+#!perl
+use Cassandane::Tiny;
+
+# Two Mailboxes can share a modseq without both of them being written to.  A
+# Mailbox modseq is the greater of its highestmodseq and its conversations
+# threadmodseq, and one change to any message in a conversation raises
+# threadmodseq in every folder that conversation touches.
+#
+# This test asserts that Mailbox/changes either reports all Mailboxes having
+# the same modseq in a response, or none of them.
+sub test_mailbox_changes_maxchanges_duplicate_thread_modseqs
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "Set up two mailboxes sharing one thread";
+    my $mbox_a = $user->mailboxes->create({ name => 'A' });
+    my $mbox_b = $user->mailboxes->create({ name => 'B' });
+
+    # The same email in both mailboxes, so the conversation touches both.
+    my $email1 = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true,
+                        $mbox_b->id => JSON::true },
+        keywords   => { '$seen' => JSON::true },
+        messageId  => [ 'msg1@local' ],
+        subject    => 'msg',
+    });
+
+    # Its reply lives in mailbox A only, and is the sole unseen message of the
+    # thread, so marking it seen changes the thread counts of both mailboxes.
+    my $email2 = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true },
+        messageId  => [ 'msg2@local' ],
+        inReplyTo  => [ 'msg1@local' ],
+        references => [ 'msg1@local' ],
+        subject    => 'msg',
+    });
+
+    $self->assert_str_equals($email1->threadId, $email2->threadId);
+
+    my $res = $jmap->request([[ 'Mailbox/get', {} ]]);
+    my $state = $res->single_sentence('Mailbox/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Set flag on the reply, which is in mailbox A only";
+    $email2->update({ 'keywords/$seen' => JSON::true });
+
+    xlog $self, "Mailbox B shares the thread, so it gets the modseq of A";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', { sinceState => $state, maxChanges => 1 } ],
+    ]);
+
+    $self->assert_str_equals('cannotCalculateChanges',
+                             $res->single_sentence('error')->arguments->{type});
+
+    xlog $self, "... but asking for both at once works";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+
+    my $changes = $res->single_sentence('Mailbox/changes')->arguments;
+
+    $self->assert_cmp_deeply(bag($mbox_a->id, $mbox_b->id),
+                             $changes->{updated});
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_too_small_duplicate_modseqs
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_changes_maxchanges_too_small_duplicate_modseqs
@@ -1,0 +1,59 @@
+#!perl
+use Cassandane::Tiny;
+
+# When a single modseq's worth of changes is larger than maxChanges, there is
+# no intermediate state to hand back.  The client would sync only a partial
+# changeset and then advance its local state.
+sub test_mailbox_changes_maxchanges_too_small_duplicate_modseqs
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    xlog $self, "Set up two mailboxes with one email each";
+    my $mbox_a = $user->mailboxes->create({ name => 'A' });
+    my $mbox_b = $user->mailboxes->create({ name => 'B' });
+
+    my $email_a = $user->emails->create({
+        mailboxIds => { $mbox_a->id => JSON::true },
+        subject    => 'msgA',
+    });
+    my $email_b = $user->emails->create({
+        mailboxIds => { $mbox_b->id => JSON::true },
+        subject    => 'msgB',
+    });
+
+    my $res = $jmap->request([[ 'Mailbox/get', {} ]]);
+    my $state = $res->single_sentence('Mailbox/get')->arguments->{state};
+    $self->assert_not_null($state);
+
+    xlog $self, "Set flag on emails in mailboxes A and B simultaneously";
+    $res = $jmap->request([
+        [ 'Email/set', {
+            update => {
+                $email_a->id => { 'keywords/$seen' => JSON::true },
+                $email_b->id => { 'keywords/$seen' => JSON::true },
+            },
+        } ],
+    ]);
+    $res->assert_single_successful_set('Email/set');
+
+    xlog $self, "Both mailboxes get the same modseq, so maxChanges 1 is rejected";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', { sinceState => $state, maxChanges => 1 } ],
+    ]);
+
+    $self->assert_str_equals('cannotCalculateChanges',
+                             $res->single_sentence('error')->arguments->{type});
+
+    xlog $self, "... but asking for both at once works";
+    $res = $jmap->request([
+        [ 'Mailbox/changes', { sinceState => $state, maxChanges => 2 } ],
+    ]);
+
+    my $changes = $res->single_sentence('Mailbox/changes')->arguments;
+
+    $self->assert_cmp_deeply(bag($mbox_a->id, $mbox_b->id),
+                             $changes->{updated});
+    $self->assert(! $changes->{hasMoreChanges}, "no more changes");
+}

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2138,6 +2138,33 @@ HIDDEN void jmap_changes_fini(struct jmap_changes *changes)
     json_decref(changes->destroyed);
 }
 
+HIDDEN size_t jmap_changes_count(const struct jmap_changes *changes)
+{
+    return json_array_size(changes->created) + json_array_size(changes->updated)
+           + json_array_size(changes->destroyed);
+}
+
+HIDDEN void jmap_changes_set_mark(const struct jmap_changes *changes,
+                                  size_t mark[3])
+{
+    mark[0] = json_array_size(changes->created);
+    mark[1] = json_array_size(changes->updated);
+    mark[2] = json_array_size(changes->destroyed);
+}
+
+HIDDEN void jmap_changes_truncate(struct jmap_changes *changes,
+                                  const size_t mark[3])
+{
+    json_t *arrays[3]
+        = { changes->created, changes->updated, changes->destroyed };
+
+    for (size_t i = 0; i < 3; i++) {
+        while (json_array_size(arrays[i]) > mark[i]) {
+            json_array_remove(arrays[i], json_array_size(arrays[i]) - 1);
+        }
+    }
+}
+
 HIDDEN json_t *jmap_changes_reply(struct jmap_changes *changes)
 {
     json_t *res = json_object();

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -488,6 +488,18 @@ extern void jmap_changes_parse(jmap_req_t *req, struct jmap_parser *parser,
                                jmap_args_parse_cb args_parse, void *args_rock,
                                struct jmap_changes *changes, json_t **err);
 extern void jmap_changes_fini(struct jmap_changes *changes);
+
+/** @brief Returns the number of created, updated and destroyed ids. */
+extern size_t jmap_changes_count(const struct jmap_changes *changes);
+
+/** @brief Marks the current end of the created, updated and destroyed ids. */
+extern void jmap_changes_set_mark(const struct jmap_changes *changes,
+                                  size_t mark[3]);
+
+/** @brief Truncates the created, updated and destroyed ids back to the mark. */
+extern void jmap_changes_truncate(struct jmap_changes *changes,
+                                  const size_t mark[3]);
+
 extern json_t *jmap_changes_reply(struct jmap_changes *changes);
 
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5531,8 +5531,9 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes,
     /* Process results */
     const ptrarray_t *msgdata = search.never_matches ? &empty_ptrarray : &search.query->merged_msgdata;
     char email_id[JMAP_MAX_EMAILID_SIZE];
-    size_t changes_count = 0;
     modseq_t highest_modseq = 0;
+    modseq_t prev_modseq = 0;
+    size_t prev_modseq_mark[3] = {0};
     int i;
     hash_table seen_ids = HASH_TABLE_INITIALIZER;
     memset(&seen_ids, 0, sizeof(hash_table));
@@ -5549,38 +5550,37 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes,
         if (hash_lookup(email_id, &seen_ids)) continue;
         hash_insert(email_id, (void*)1, &seen_ids);
 
-        /* Apply maxChanges, if any. We do overshoot maxChanges in case
-         * the modseqs are not strictly increasing, which must not ever
-         * happen in a sane account. Should the account have any duplicate
-         * modseqs then we report that as an error but gracefully finish
-         * the /changes method. */
-        if (changes->max_changes && changes_count >= changes->max_changes &&
-            md->modseq > highest_modseq) {
+        /* Apply maxChanges, if any. Emails that share a modseq have to be
+         * reported together, because the state we hand back is a modseq and
+         * there is no way to resume in the middle of them. So if the modseq we
+         * are in the middle of turns out not to fit, take it back out again
+         * and stop before it. */
+        if (changes->max_changes &&
+            jmap_changes_count(changes) >= changes->max_changes) {
+            if (md->modseq == highest_modseq) {
+                jmap_changes_truncate(changes, prev_modseq_mark);
+                highest_modseq = prev_modseq;
+            }
             changes->has_more_changes = 1;
             break;
         }
-        changes_count++;
 
-        if (md->modseq == highest_modseq && highest_modseq) {
-            xsyslog_ev(LOG_ERR, "duplicate modseq in Email/changes",
-                    lf_s("mboxname", md->folder ? md->folder->mboxname : NULL),
-                    lf_u("uid", md->uid),
-                    lf_llu("modseq", md->modseq));
-        }
-
-        /* Keep track of the highest modseq */
-        if (highest_modseq < md->modseq)
+        /* Keep track of the highest modseq, and of where it starts */
+        if (highest_modseq < md->modseq) {
+            prev_modseq = highest_modseq;
             highest_modseq = md->modseq;
+            jmap_changes_set_mark(changes, prev_modseq_mark);
+        }
 
         struct email_expunge_check rock = { req, changes->since_modseq, 0, 0 };
         if (USER_COMPACT_EMAILIDS(req->cstate)) {
             rock.nano_internaldate = TIMESPEC_TO_NANOSEC(&md->internaldate);
         }
-        int r = conversations_guid_foreach(req->cstate, guidrep,
-                                           _email_is_expunged_cb, &rock);
+        r = conversations_guid_foreach(req->cstate, guidrep,
+                                       _email_is_expunged_cb, &rock);
         if (r) {
             *err = jmap_server_error(r);
-            goto done;
+            break;
         }
 
         /* Check the message status - status is a bitfield with:
@@ -5612,6 +5612,18 @@ static void _email_changes(jmap_req_t *req, struct jmap_changes *changes,
         }
     }
     free_hash_table(&seen_ids, NULL);
+
+    if (*err) goto done;
+
+    if (changes->has_more_changes && !jmap_changes_count(changes)) {
+        /* Not even one modseq can be reported. Handing back an empty
+         * changeset with hasMoreChanges set would only defer this error
+         * by one round-trip. */
+        *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                         "description",
+                         "maxChanges too small to report a whole modseq");
+        goto done;
+    }
 
     /* Set new state */
     changes->new_modseq = changes->has_more_changes ?
@@ -5703,8 +5715,9 @@ static void _thread_changes(jmap_req_t *req, struct jmap_changes *changes, json_
 
     /* Process results */
     const ptrarray_t *msgdata = search.never_matches ? &empty_ptrarray : &search.query->merged_msgdata;
-    size_t changes_count = 0;
     modseq_t highest_modseq = 0;
+    modseq_t prev_modseq = 0;
+    size_t prev_modseq_mark[3] = {0};
     int i;
 
     struct hashset *seen_threads = hashset_new(8);
@@ -5717,28 +5730,27 @@ static void _thread_changes(jmap_req_t *req, struct jmap_changes *changes, json_
         /* Skip already seen threads */
         if (!hashset_add(seen_threads, &md->cid)) continue;
 
-        /* Apply maxChanges, if any. We do overshoot maxChanges in case
-         * the modseqs are not strictly increasing, which must not ever
-         * happen in a sane account. Should the account have any duplicate
-         * modseqs then we report that as an error but gracefully finish
-         * the /changes method. */
-        if (changes->max_changes && changes_count >= changes->max_changes &&
-            md->modseq > highest_modseq) {
+        /* Apply maxChanges, if any. Threads that share a modseq have to be
+         * reported together, because the state we hand back is a modseq and
+         * there is no way to resume in the middle of them. So if the modseq we
+         * are in the middle of turns out not to fit, take it back out again
+         * and stop before it. */
+        if (changes->max_changes &&
+            jmap_changes_count(changes) >= changes->max_changes) {
+            if (md->modseq == highest_modseq) {
+                jmap_changes_truncate(changes, prev_modseq_mark);
+                highest_modseq = prev_modseq;
+            }
             changes->has_more_changes = 1;
             break;
         }
-        changes_count++;
 
-        if (md->modseq == highest_modseq && highest_modseq) {
-            xsyslog_ev(LOG_ERR, "duplicate modseq in Thread/changes",
-                    lf_s("mboxname", md->folder ? md->folder->mboxname : NULL),
-                    lf_u("uid", md->uid),
-                    lf_llu("modseq", md->modseq));
-        }
-
-        /* Keep track of the highest modseq */
-        if (highest_modseq < md->modseq)
+        /* Keep track of the highest modseq, and of where it starts */
+        if (highest_modseq < md->modseq) {
+            prev_modseq = highest_modseq;
             highest_modseq = md->modseq;
+            jmap_changes_set_mark(changes, prev_modseq_mark);
+        }
 
         /* Determine if the thread got changed or destroyed */
         if (conversation_load_advanced(req->cstate, md->cid, &conv, /*flags*/0))
@@ -5761,6 +5773,16 @@ static void _thread_changes(jmap_req_t *req, struct jmap_changes *changes, json_
         memset(&conv, 0, sizeof(conversation_t));
     }
     hashset_free(&seen_threads);
+
+    if (changes->has_more_changes && !jmap_changes_count(changes)) {
+        /* Not even one modseq can be reported. Handing back an empty
+         * changeset with hasMoreChanges set would only defer this error
+         * by one round-trip. */
+        *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                         "description",
+                         "maxChanges too small to report a whole modseq");
+        goto done;
+    }
 
     /* Set new state */
     changes->new_modseq = changes->has_more_changes ?

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -4153,7 +4153,8 @@ static int _mbox_changes_cmp(const void **pa, const void **pb)
 
 static int _mbox_changes(jmap_req_t *req,
                          struct jmap_changes *changes,
-                         int *only_counts_changed)
+                         int *only_counts_changed,
+                         json_t **err)
 {
     *only_counts_changed = 1;
 
@@ -4167,6 +4168,8 @@ static int _mbox_changes(jmap_req_t *req,
         req
     };
     modseq_t windowmodseq;
+    modseq_t prev_modseq = 0;
+    size_t prev_modseq_mark[3] = {0};
     const char *id;
     json_t *val;
     int r, i;
@@ -4199,25 +4202,27 @@ static int _mbox_changes(jmap_req_t *req,
         const char *id = json_string_value(json_object_get(update, "id"));
         modseq_t modseq = json_integer_value(json_object_get(update, "modseq"));
 
-        /* Apply maxChanges, if any. We do overshoot maxChanges in case
-         * the modseqs are not strictly increasing, which must not ever
-         * happen in a sane account. Should the account have any duplicate
-         * modseqs then we report that as an error but gracefully finish
-         * the /changes method. */
-        if (changes->max_changes && ((size_t) i) >= changes->max_changes &&
-            modseq > windowmodseq) {
+        /* Apply maxChanges, if any. Mailboxes that share a modseq have to be
+         * reported together, because the state we hand back is a modseq and
+         * there is no way to resume in the middle of them. So if the modseq we
+         * are in the middle of turns out not to fit, take it back out again
+         * and stop before it. */
+        if (changes->max_changes &&
+            jmap_changes_count(changes) >= changes->max_changes) {
+            if (modseq == windowmodseq) {
+                jmap_changes_truncate(changes, prev_modseq_mark);
+                windowmodseq = prev_modseq;
+            }
             changes->has_more_changes = 1;
             break;
         }
 
-        if (modseq == windowmodseq && windowmodseq) {
-            xsyslog_ev(LOG_ERR, "duplicate modseq in Mailbox/changes",
-                    lf_s("mboxid", id),
-                    lf_llu("modseq", modseq));
-        }
-
-        if (windowmodseq < modseq)
+        /* Keep track of the highest modseq, and of where it starts */
+        if (windowmodseq < modseq) {
+            prev_modseq = windowmodseq;
             windowmodseq = modseq;
+            jmap_changes_set_mark(changes, prev_modseq_mark);
+        }
 
         if (json_object_get(data.created, id)) {
             json_array_append_new(changes->created, json_string(id));
@@ -4226,6 +4231,14 @@ static int _mbox_changes(jmap_req_t *req,
         } else {
             json_array_append_new(changes->destroyed, json_string(id));
         }
+    }
+
+    if (changes->has_more_changes && !jmap_changes_count(changes)) {
+        /* Not even one modseq can be reported */
+        *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                         "description",
+                         "maxChanges too small to report a whole modseq");
+        goto done;
     }
 
     if ((json_array_size(changes->created) == 0 &&
@@ -4264,10 +4277,14 @@ static int jmap_mailbox_changes(jmap_req_t *req)
 
     /* Search for updates */
     int only_counts_changed = 0;
-    int r = _mbox_changes(req, &changes, &only_counts_changed);
+    int r = _mbox_changes(req, &changes, &only_counts_changed, &err);
     if (r) {
         syslog(LOG_ERR, "jmap: Mailbox/changes: %s", error_message(r));
         jmap_error(req, jmap_server_error(r));
+        goto done;
+    }
+    if (err) {
+        jmap_error(req, err);
         goto done;
     }
 


### PR DESCRIPTION
In https://github.com/cyrusimap/cyrus-imapd/pull/6167 we made Cyrus gracefully handle duplicate modseqs on the assumption that these only occur for corrupted mailbox state. We also made it log errors in case it encounters duplicate modseqs. As it turns out, duplicate modseqs are a regular thing in Cyrus, both because foldermodseqs bump when a message in a thread gets a new modseq, and because the Email/set bulk update code can result in two messages in separate mailboxes getting the same modseq.

Whether we do want these duplicate modseqs to occur is a secondary question. As of now, they are a given and we need to better handle them than overshooting the `maxChanges` window in a `/changes` method based on the assumption that this only will happen in exceptional cases.

This PR now makes Cyrus correctly handle `maxChanges`: it caps the changes response and returns `cannotCalculateChanges` if it can't report a single change due to the limited `maxChanges` window.

This PR is based on the findings of https://github.com/cyrusimap/cyrus-imapd/pull/6216 for which this PR is a replacement.