### PR TITLE
imapd.c: handle ID command with NIL "os" value

### DIFF
--- a/cassandane/tiny-tests/ID/cmd_id_nil_os
+++ b/cassandane/tiny-tests/ID/cmd_id_nil_os
@@ -1,0 +1,31 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_cmd_id_nil_os ($self)
+{
+    # Purge any syslog lines before this test runs.
+    $self->{instance}->getsyslog();
+
+    my $imaptalk = $self->{store}->get_client();
+
+    # Send ID command with NIL as "os" value
+    $imaptalk->_imap_cmd('ID', 0, {}, qq{("os" NIL)});
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    # Send ID command with two "os" values, the second being ""
+    $imaptalk->_imap_cmd('ID', 0, {}, qq{("os" "foo" "os" "")});
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    if ($self->{instance}->{have_syslog_replacement}) {
+        # make sure that the connection is ended so that imapd reset happens
+        $imaptalk->logout();
+        undef $imaptalk;
+
+        my @behavior_lines = $self->{instance}->getsyslog(qr/client id/);
+
+        $self->assert_num_gte(2, scalar @behavior_lines);
+
+        $self->assert_matches(qr/"os" NIL/, $behavior_lines[0]);
+        $self->assert_matches(qr/"os" ""/,  $behavior_lines[1]);
+    }
+}

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3490,12 +3490,12 @@ static void cmd_id(char *tag)
                 return;
             }
 
-            if (!strcmp(field.s, "os") && !strcmp(arg.s, "iOS")) {
+            if (!strcmp(field.s, "os") && !strcmpnull(arg.s, "iOS")) {
                 imapd_id.quirks |= QUIRK_SEARCHFUZZY;
             }
 
             /* ok, we're happy enough */
-            hash_insert(field.s, xstrdup(buf_cstring(&arg)), &imapd_id.params);
+            hash_upsert(field.s, buf_releasenull(&arg), &imapd_id.params, &free);
         }
 
         if (c != ')') {

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -157,6 +157,19 @@ EXPORTED void *hash_insert(const char *key, void *data, hash_table *table)
 }
 
 /*
+** Insert or update 'key' with 'data' into hash table.
+** Any existing data associated with 'key' must be freed by 'func'.
+*/
+EXPORTED void hash_upsert(const char *key,void *data,hash_table *table,
+                          void (*func)(void *))
+{
+    void *old_data = hash_insert(key, data, table);
+
+    if (func && old_data && old_data != data)
+        func(old_data);
+}
+
+/*
 ** Look up a key and return the associated data.  Returns NULL if
 ** the key is not in the table.
 */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -53,6 +53,13 @@ hash_table *construct_hash_table(hash_table *table, size_t size,
 void *hash_insert(const char *key,void *data,hash_table *table);
 
 /*
+** Insert or update 'key' with 'data' into hash table.
+** Any existing data associated with 'key' must be freed by 'func'.
+*/
+void hash_upsert(const char *key,void *data, hash_table *table,
+                 void (*func)(void *));
+
+/*
 ** Returns a pointer to the data associated with a key.  If the key has
 ** not been inserted in the table, returns NULL.
 */


### PR DESCRIPTION
Previously, this would segfault in strcmp() with a NULL string