### PR TITLE
cassandane: report JMAP::Tester aborts as failures, not errors

### DIFF
--- a/cassandane/.dataprinter
+++ b/cassandane/.dataprinter
@@ -1,0 +1,34 @@
+# Data::Printer configuration for cassandane.  testrunner.pl points
+# DATAPRINTERRC at this file, so it beats any ~/.dataprinter you have.
+
+indent = 2
+
+class.expand       = all
+class.parents      = 0
+class.stringify    = 0
+class.show_methods = none
+class.show_overloads = 0
+
+theme = Monokai
+colors.caller_info = '#ffff00'
+colors.brackets    = '#888888'
+colors.escaped     = '#888800'
+colors.undef       = '#d00000'
+colors.true        = '#82AAFF'
+colors.false       = '#82AAFF'
+
+end_separator = 1
+hash_separator = " => "
+print_escapes = 1
+show_dualvar = off
+show_readonly = 0
+
+hash_max  = 10000
+array_max = 10000
+
+# loading Web before JType so JType can replace Typist formatting
+filters = DateTime, Web, JType, JMAP, StructDumb
+
+filter_datetime.show_class_name = 1
+filter_datetime.show_timezone   = 1
+

--- a/cassandane/Cassandane/JMAPAbort.pm
+++ b/cassandane/Cassandane/JMAPAbort.pm
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: BSD-3-Clause-CMU
+# See COPYING file at the root of the distribution for more details.
+
+package Cassandane::JMAPAbort;
+use strict;
+use warnings;
+use experimental 'signatures';
+
+use parent qw(Test::Unit::Failure);
+
+use Error ();
+
+=head1 NAME
+
+Cassandane::JMAPAbort - a JMAP::Tester abort that Test::Unit calls a failure
+
+=head1 DESCRIPTION
+
+When JMAP::Tester gives up, it throws a L<JMAP::Tester::Abort>, which is a
+Throwable::Error.  Test::Unit only understands Error.pm exceptions, and of
+those only a Test::Unit::Failure is reported as a failing test; anything else
+is an error, meaning the test suite itself is broken.  An abort is a I<failing>
+test, so it should look like one.
+
+This stupid class saves us from multiple inheritance, and
+L<Cassandane::Role::JMAPTester> makes our JMAP::Tester classes use it.
+
+=cut
+
+# The packages between the abort and the test that provoked it.  We don't want
+# to report any of their frames as the location of the failure.
+my $PLUMBING = qr{
+    \A (?: JMAP::Tester
+         | Cassandane::JMAPAbort
+         | Cassandane::Role::JMAPTester )
+    \b
+}x;
+
+=head1 METHODS
+
+=head2 new
+
+    Cassandane::JMAPAbort->new($message);
+    Cassandane::JMAPAbort->new({ message => $message, diagnostics => \@diags });
+
+Those are the two ways JMAP::Tester builds an abort.  The diagnostics have
+already been formatted by the tester's diagnostic dumper, and get folded into
+the message, because the message is all that Test::Unit will ever show.
+
+Called any other way, we assume we've been given the usual Error.pm arguments.
+That happens when Test::Unit::Assert rethrows an exception to blame the caller
+of an assertion, which it does by passing our own guts back to C<new>.
+
+=cut
+
+sub new ($class, @args) {
+    unless (@args == 1) {
+        local $Error::Depth = $Error::Depth + 1;
+        return $class->SUPER::new(@args);
+    }
+
+    my $arg = ref $args[0] ? $args[0] : { message => $args[0] };
+
+    my $text = $arg->{message};
+    for my $diagnostic (@{ $arg->{diagnostics} // [] }) {
+        $text .= "\n" unless $text =~ /\n\z/;
+        $text .= $diagnostic;
+    }
+    $text =~ s/\n\z//;
+
+    # Error->new blames the caller $Error::Depth frames up and prunes the stack
+    # trace it captures to match.  Everything between us and the test is
+    # plumbing, so skip it.
+    my $depth = 0;
+    while (my $package = (caller $depth)[0]) {
+        last unless $package =~ $PLUMBING;
+        $depth++;
+    }
+
+    local $Error::Depth = $depth + 1;
+    return $class->SUPER::new(-text => $text);
+}
+
+1;

--- a/cassandane/Cassandane/Role/JMAPTester.pm
+++ b/cassandane/Cassandane/Role/JMAPTester.pm
@@ -13,7 +13,7 @@ use JMAP::Tester::Abort ();
 # We want to throw an Error instead -- or, well, we don't want to, but we sort
 # of have to.  This solution is absolutely gross: just replace the
 # JMAP::Tester::Abort constructor.
-unless (JMAP::Tester->can('abort_class')) {
+{
     no warnings 'redefine';
     *JMAP::Tester::Abort::new = sub ($, @rest) {
         return Cassandane::JMAPAbort->new(@rest);

--- a/cassandane/Cassandane/Role/JMAPTester.pm
+++ b/cassandane/Cassandane/Role/JMAPTester.pm
@@ -3,12 +3,37 @@ use Moo::Role;
 
 use experimental 'signatures';
 
+use Cassandane::JMAPAbort ();
 use Encode ();
+use JMAP::Tester ();
+use JMAP::Tester::Abort ();
+
+# A JMAP::Tester::Abort is a Throwable::Error, which Test::Unit reports as an
+# error -- as though the suite were broken -- instead of as a failing test.
+# We want to throw an Error instead -- or, well, we don't want to, but we sort
+# of have to.  This solution is absolutely gross: just replace the
+# JMAP::Tester::Abort constructor.
+unless (JMAP::Tester->can('abort_class')) {
+    no warnings 'redefine';
+    *JMAP::Tester::Abort::new = sub ($, @rest) {
+        return Cassandane::JMAPAbort->new(@rest);
+    };
+}
 
 has fallback_account_id => (
     is       => 'ro',
     required => 1,
 );
+
+# JMAP::Tester dumps the values in an abort's diagnostics as JSON.
+# Data::Printer is easier to read, and I can bring in my cool .dataprinter to
+# make it even better.
+sub default_diagnostic_dumper {
+    require Data::Printer;
+    return sub ($value) {
+        return Data::Printer::np($value, colored => 1);
+    };
+}
 
 # This emulates JMAPTalk's DefaultUsing
 sub DefaultUsing {

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -4,6 +4,7 @@
 
 use strict;
 use warnings;
+use Cwd qw(abs_path);
 use File::Slurp;
 use List::Util qw(uniq);
 
@@ -23,6 +24,9 @@ $Data::Dumper::Deepcopy = 1;
 $Data::Dumper::Indent = 1;
 $Data::Dumper::Sortkeys = 1;
 $Data::Dumper::Trailingcomma = 1;
+
+$ENV{DATAPRINTERRC} = abs_path('.dataprinter')
+    unless exists $ENV{DATAPRINTERRC};
 
 my %want_formats = ();
 my %format_params = ();


### PR DESCRIPTION
A JMAP::Tester::Abort is a Throwable::Error.  Test::Unit only knows about Error.pm exceptions, and of those only a Test::Unit::Failure counts as a failing test, so a JMAP::Tester abort looked like ERROR when it should've looked like FAIL.  Do we care?  Well, maybe not all *that* much, but accuracy matters.

More importantly, JMAP::Tester aborts carry really nice diagnostics!  I want those.

The method here is gross as heck: we just replace the JMAP::Tester::Abort constructor, because otherwise there's sort of an air gap between some (but not all) of the JMAP::Tester classes and any central hub to change this code.

Also: I looked at making a multiply inheriting class (boo, hiss), but the big problem was going to be that the error has to be Storable, too. Just nevermind.

As for the .dataprinter file: it's mine!  We use it elsewhere, though, so it should be familiar to some.