### PR TITLE
clarify detail about slow tests under CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       run: cyd test --no-ok --slow --format prettier "${{ matrix.skip }}"
     - name: rerun cassandane failures noisily
       if: ${{ steps.cass1.outcome == 'failure' }}
-      run: cyd test --no-slow --format pretty --rerun
+      run: cyd test --format pretty --rerun
     - name: collect logs
       if: ${{ ! matrix.skip-cass }}
       run: cat /dev/shm/cass/*/conf/log/syslog


### PR DESCRIPTION
This PR has two commits, but only one of them is real.  CI failing means everything is okay.

The first commit introduces a slow test, `ACL.bogus_slow`, which intentionally fails.  The fact that it fails in CI means that CI can detect and report failures in slow tests.  Whew!  **I will discard this commit, and wait for a clean CI run, before merging.**

The second commit is the real commit.  It's a trivial, zero-impact change to the workflow file, removing a token that was misleading.  Details are in the commit message.