### PR TITLE
Acl based subscription

### DIFF
--- a/cassandane/tiny-tests/CaldavAlarm/simple_multiuser
+++ b/cassandane/tiny-tests/CaldavAlarm/simple_multiuser
@@ -1,9 +1,10 @@
 #!perl
 use Cassandane::Tiny;
 
-sub test_simple_multiuser
-    :min_version_3_1 :NoAltNameSpace
-    ($self)
+# A sharee's own alarms on a shared calendar fire because the sharee is
+# subscribed to it.  The subscription is either a real one, or implied by
+# the '1' (ACL_AUTOSUB) right.
+sub assert_simple_multiuser ($self, %opt)
 {
     my $CalDAV = $self->{caldav};
 
@@ -11,24 +12,14 @@ sub test_simple_multiuser
     $self->assert_not_null($CalendarId);
 
     my $AdminTalk = $self->{adminstore}->get_client();
-    $AdminTalk->create("user.foo");
-    $AdminTalk->setacl("user.cassandane.#calendars.$CalendarId", "foo", "lrswipkxtecdn789");
+    my $foo = $self->{instance}->create_user('foo');
+    $AdminTalk->setacl("user.cassandane.#calendars.$CalendarId",
+                       foo => $opt{acl});
 
-    my $foostore = $self->{instance}->get_service('imap')->create_store(
-                        username => "foo");
-    my $footalk = $foostore->get_client();
-    $footalk->subscribe("user.cassandane.#calendars.$CalendarId");
+    $foo->imap->subscribe("user.cassandane.#calendars.$CalendarId")
+        if $opt{subscribe};
 
-    my $service = $self->{instance}->get_service("http");
-    my $FooDAV = Net::CalDAVTalk->new(
-        user => 'foo',
-        password => 'pass',
-        host => $service->host(),
-        port => $service->port(),
-        scheme => 'http',
-        url => '/',
-        expandurl => 1,
-    );
+    my $FooDAV = $foo->caldav;
 
     my $cal = $FooDAV->GetCalendar("cassandane.$CalendarId");
     $self->assert_not_null($cal);
@@ -153,4 +144,18 @@ EOF
     $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 900 );
 
     $self->assert_alarms();
+}
+
+sub test_simple_multiuser
+    :NoAltNameSpace
+    ($self)
+{
+    $self->assert_simple_multiuser(acl => 'lrswipkxtecdn789', subscribe => 1);
+}
+
+sub test_simple_multiuser_autosub
+    :NoAltNameSpace :ReverseACLs
+    ($self)
+{
+    $self->assert_simple_multiuser(acl => 'lrswipkxtecdn7891', subscribe => 0);
 }

--- a/cassandane/tiny-tests/Carddav/autosub_listing
+++ b/cassandane/tiny-tests/Carddav/autosub_listing
@@ -1,0 +1,41 @@
+#!perl
+use Cassandane::Tiny;
+
+# An addressbook shared with the '1' (ACL_AUTOSUB) right shows up in the
+# sharee's home-set listing without the sharee ever subscribing to it.
+sub test_autosub_listing
+    :ReverseACLs
+    ($self)
+{
+    my $admin = $self->{adminstore}->get_client();
+
+    my $owner  = $self->{instance}->create_user('owner');
+    my $sharee = $self->{instance}->create_user('sharee');
+
+    xlog $self, "provision the owner's default addressbook";
+    $self->assert_num_equals(1, scalar $owner->carddav->GetAddressBooks->@*);
+
+    xlog $self, "grant the sharee the '1' right on it";
+    $admin->setacl('user.owner.#addressbooks.Default', sharee => 'lrs1')
+        or die "setacl: $@";
+
+    # Not GetAddressBooks(): it also asks for D:acl, and dies on any ace
+    # carrying a single D:privilege, which XML::Fast hands back as a hashref
+    # rather than a one-element array -- a shared collection has several.
+    my $dav = $sharee->carddav;
+    my $NS_D = $dav->ns('D');
+    my $res = $dav->Request(
+        'PROPFIND', '',
+        x('D:propfind', $dav->NS(), x('D:prop', x('D:resourcetype'))),
+        Depth => 1,
+    );
+
+    my @hrefs = map {; $_->{"{$NS_D}href"}{content} }
+                ($res->{"{$NS_D}response"} // [])->@*;
+
+    $self->assert_cmp_deeply(
+        supersetof('/dav/addressbooks/user/sharee/owner.Default/'),
+        \@hrefs,
+        "home-set listing includes the flag-granted addressbook",
+    );
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_get_autosub
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_get_autosub
@@ -1,0 +1,38 @@
+#!perl
+use Cassandane::Tiny;
+
+# The '1' (ACL_AUTOSUB) right on a shared calendar makes Calendar/get report
+# isSubscribed even though the sharee never subscribed. The group-granted
+# case is ACL-level and covered by JMAPContacts.addressbook_get_autosub_group.
+sub test_calendar_get_autosub ($self)
+{
+    my $jmap  = $self->default_user->jmap;
+    my $admin = $self->{adminstore}->get_client();
+
+    my $other = $self->{instance}->create_user('other');
+    my $cal = $other->calendars->default;
+
+    for my $case ([ lrs => jfalse() ], [ lrs1 => jtrue() ]) {
+        my ($acl, $want) = @$case;
+
+        xlog $self, "grant '$acl' to cassandane";
+        $admin->setacl('user.other.#calendars.Default', cassandane => $acl)
+            or die "setacl: $@";
+
+        my $res = $jmap->request([
+            [ 'Calendar/get', {
+                accountId  => 'other',
+                ids        => [ $cal->id ],
+                properties => [ 'isSubscribed' ],
+            } ],
+        ]);
+
+        my $calendars = $res->single_sentence('Calendar/get')->arguments->{list};
+
+        $self->assert_cmp_deeply(
+            [ superhashof({ id => $cal->id, isSubscribed => $want }) ],
+            $calendars,
+            "isSubscribed for ACL '$acl'",
+        );
+    }
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_autosub
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_autosub
@@ -1,0 +1,81 @@
+#!perl
+use Cassandane::Tiny;
+
+# Subscribing and unsubscribing an autosub calendar both succeed, but the
+# '1' right keeps isSubscribed true until the right itself goes away.
+sub test_calendar_set_autosub ($self)
+{
+    my $jmap  = $self->default_user->jmap;
+    my $admin = $self->{adminstore}->get_client();
+
+    my $other = $self->{instance}->create_user('other');
+    my $cal = $other->calendars->default;
+
+    $admin->setacl('user.other.#calendars.Default', cassandane => 'lrs1')
+        or die "setacl: $@";
+
+    xlog $self, "subscribe for real, then unsubscribe: both must succeed";
+    my $res = $jmap->request([
+        [ 'Calendar/set', {
+            accountId => 'other',
+            update => { $cal->id => { isSubscribed => JSON::true } },
+        }, 'subscribe' ],
+        [ 'Calendar/set', {
+            accountId => 'other',
+            update => { $cal->id => { isSubscribed => JSON::false } },
+        }, 'unsubscribe' ],
+        [ 'Calendar/get', {
+            accountId  => 'other',
+            ids        => [ $cal->id ],
+            properties => [ 'isSubscribed' ],
+        }, 'get' ],
+    ]);
+
+    my $subscribe = $res->paragraph_by_client_id('subscribe')
+                        ->single('Calendar/set')->arguments;
+    my $unsubscribe = $res->paragraph_by_client_id('unsubscribe')
+                          ->single('Calendar/set')->arguments;
+    my $calendars = $res->paragraph_by_client_id('get')
+                        ->single('Calendar/get')->arguments->{list};
+
+    $self->assert_cmp_deeply(
+        superhashof({ updated => { $cal->id => ignore() } }),
+        $subscribe,
+        "subscribing an autosub calendar succeeds",
+    );
+
+    xlog $self, "server reports the still-true effective state";
+    $self->assert_cmp_deeply(
+        superhashof({
+            updated => { $cal->id => superhashof({ isSubscribed => jtrue() }) },
+        }),
+        $unsubscribe,
+        "unsubscribing succeeds but the '1' right keeps it subscribed",
+    );
+
+    $self->assert_cmp_deeply(
+        [ superhashof({ id => $cal->id, isSubscribed => jtrue() }) ],
+        $calendars,
+        "and Calendar/get agrees",
+    );
+
+    xlog $self, "removing the flag reveals the real (removed) entry";
+    $admin->setacl('user.other.#calendars.Default', cassandane => 'lrs')
+        or die "setacl: $@";
+
+    $res = $jmap->request([
+        [ 'Calendar/get', {
+            accountId  => 'other',
+            ids        => [ $cal->id ],
+            properties => [ 'isSubscribed' ],
+        } ],
+    ]);
+
+    $calendars = $res->single_sentence('Calendar/get')->arguments->{list};
+
+    $self->assert_cmp_deeply(
+        [ superhashof({ id => $cal->id, isSubscribed => jfalse() }) ],
+        $calendars,
+        "without the '1' right the earlier unsubscribe takes effect",
+    );
+}

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_get_autosub
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_get_autosub
@@ -1,0 +1,52 @@
+#!perl
+use Cassandane::Tiny;
+
+# The '1' (ACL_AUTOSUB) right on a shared addressbook makes AddressBook/get
+# report isSubscribed even though the sharee never subscribed.
+sub assert_addressbook_get_autosub ($self, $grantee)
+{
+    my $jmap  = $self->default_user->jmap;
+    my $admin = $self->{adminstore}->get_client();
+
+    my $other = $self->{instance}->create_user('other');
+    my $abook = $other->addressbooks->default;
+
+    for my $case ([ lrs => jfalse() ], [ lrs1 => jtrue() ]) {
+        my ($acl, $want) = @$case;
+
+        xlog $self, "grant '$acl' to $grantee";
+        $admin->setacl('user.other.#addressbooks.Default', $grantee => $acl)
+            or die "setacl: $@";
+
+        my $res = $jmap->request([
+            [ 'AddressBook/get', {
+                accountId  => 'other',
+                ids        => [ $abook->id ],
+                properties => [ 'isSubscribed' ],
+            } ],
+        ]);
+
+        my $books = $res->single_sentence('AddressBook/get')->arguments->{list};
+
+        $self->assert_cmp_deeply(
+            [ superhashof({ id => $abook->id, isSubscribed => $want }) ],
+            $books,
+            "isSubscribed for ACL '$acl'",
+        );
+    }
+}
+
+sub test_addressbook_get_autosub_user ($self)
+{
+    $self->assert_addressbook_get_autosub('cassandane');
+}
+
+sub test_addressbook_get_autosub_group
+    :Mboxgroups
+    ($self)
+{
+    $self->{adminstore}->get_client
+         ->_imap_cmd('SETUSERGROUP', 0, '', 'cassandane', 'group:c1-all');
+
+    $self->assert_addressbook_get_autosub('group:c1-all');
+}

--- a/cassandane/tiny-tests/JMAPContacts/addressbook_set_autosub
+++ b/cassandane/tiny-tests/JMAPContacts/addressbook_set_autosub
@@ -1,0 +1,81 @@
+#!perl
+use Cassandane::Tiny;
+
+# Subscribing and unsubscribing an autosub addressbook both succeed, but the
+# '1' right keeps isSubscribed true until the right itself goes away.
+sub test_addressbook_set_autosub ($self)
+{
+    my $jmap  = $self->default_user->jmap;
+    my $admin = $self->{adminstore}->get_client();
+
+    my $other = $self->{instance}->create_user('other');
+    my $abook = $other->addressbooks->default;
+
+    $admin->setacl('user.other.#addressbooks.Default', cassandane => 'lrs1')
+        or die "setacl: $@";
+
+    xlog $self, "subscribe for real, then unsubscribe: both must succeed";
+    my $res = $jmap->request([
+        [ 'AddressBook/set', {
+            accountId => 'other',
+            update => { $abook->id => { isSubscribed => JSON::true } },
+        }, 'subscribe' ],
+        [ 'AddressBook/set', {
+            accountId => 'other',
+            update => { $abook->id => { isSubscribed => JSON::false } },
+        }, 'unsubscribe' ],
+        [ 'AddressBook/get', {
+            accountId  => 'other',
+            ids        => [ $abook->id ],
+            properties => [ 'isSubscribed' ],
+        }, 'get' ],
+    ]);
+
+    my $subscribe = $res->paragraph_by_client_id('subscribe')
+                        ->single('AddressBook/set')->arguments;
+    my $unsubscribe = $res->paragraph_by_client_id('unsubscribe')
+                          ->single('AddressBook/set')->arguments;
+    my $books = $res->paragraph_by_client_id('get')
+                    ->single('AddressBook/get')->arguments->{list};
+
+    $self->assert_cmp_deeply(
+        superhashof({ updated => { $abook->id => ignore() } }),
+        $subscribe,
+        "subscribing an autosub addressbook succeeds",
+    );
+
+    xlog $self, "server reports the still-true effective state";
+    $self->assert_cmp_deeply(
+        superhashof({
+            updated => { $abook->id => superhashof({ isSubscribed => jtrue() }) },
+        }),
+        $unsubscribe,
+        "unsubscribing succeeds but the '1' right keeps it subscribed",
+    );
+
+    $self->assert_cmp_deeply(
+        [ superhashof({ id => $abook->id, isSubscribed => jtrue() }) ],
+        $books,
+        "and AddressBook/get agrees",
+    );
+
+    xlog $self, "removing the flag reveals the real (removed) entry";
+    $admin->setacl('user.other.#addressbooks.Default', cassandane => 'lrs')
+        or die "setacl: $@";
+
+    $res = $jmap->request([
+        [ 'AddressBook/get', {
+            accountId  => 'other',
+            ids        => [ $abook->id ],
+            properties => [ 'isSubscribed' ],
+        } ],
+    ]);
+
+    $books = $res->single_sentence('AddressBook/get')->arguments->{list};
+
+    $self->assert_cmp_deeply(
+        [ superhashof({ id => $abook->id, isSubscribed => jfalse() }) ],
+        $books,
+        "without the '1' right the earlier unsubscribe takes effect",
+    );
+}

--- a/cassandane/tiny-tests/JMAPContacts/carddav_autosub_acl_roundtrip
+++ b/cassandane/tiny-tests/JMAPContacts/carddav_autosub_acl_roundtrip
@@ -1,0 +1,39 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_carddav_autosub_acl_roundtrip
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+    my $service = $self->{instance}->get_service("http");
+
+    $admintalk->create("user.other");
+    $admintalk->setacl("user.other", admin => 'lrswipkxtecdan');
+
+    # trigger Default addressbook autocreate
+    my $othertalk = Net::CardDAVTalk->new(
+        user => "other", password => 'pass',
+        host => $service->host(), port => $service->port(),
+        scheme => 'http', url => '/', expandurl => 1,
+    );
+
+    $admintalk->setacl('user.other.#addressbooks.Default',
+                       'cassandane' => 'lrs1');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    # PROPFIND the D:acl property as the owner and check the privilege
+    my $xml = <<'EOF';
+<?xml version="1.0" encoding="utf-8" ?>
+<D:propfind xmlns:D="DAV:">
+  <D:prop><D:acl/></D:prop>
+</D:propfind>
+EOF
+    my $res = $othertalk->Request('PROPFIND', 'Default', $xml,
+                                  'Content-Type' => 'text/xml',
+                                  'Depth' => '0');
+    # Request returns a parsed XML hash; match the element name in the
+    # flattened structure rather than hard-coding the nesting shape
+    require Data::Dumper;
+    my $flat = Data::Dumper::Dumper($res);
+    $self->assert_matches(qr{auto-subscribe}, $flat);
+}

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_autosub
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_autosub
@@ -1,0 +1,65 @@
+#!perl
+use Cassandane::Tiny;
+
+# The '1' (ACL_AUTOSUB) right makes a shared mailbox look subscribed to
+# Mailbox/get and Mailbox/query, and survives an explicit unsubscribe.
+sub test_mailbox_autosub ($self)
+{
+    my $jmap  = $self->default_user->jmap;
+    my $admin = $self->{adminstore}->get_client();
+
+    xlog $self, "create another user with a shared folder";
+    $self->{instance}->create_user("other");
+    $admin->create("user.other.shared") or die "create: $@";
+    $admin->setacl("user.other.shared", cassandane => 'lrs1') or die "setacl: $@";
+
+    my $res = $jmap->request([
+        [ 'Mailbox/get', {
+            accountId  => 'other',
+            properties => [ 'name', 'isSubscribed' ],
+        } ],
+    ]);
+
+    my $mailboxes = $res->single_sentence('Mailbox/get')->arguments->{list};
+    my ($mbox) = grep {; $_->{name} eq 'shared' } $mailboxes->@*;
+
+    $self->assert_cmp_deeply(
+        superhashof({ name => 'shared', isSubscribed => jtrue() }),
+        $mbox,
+        "the '1' right alone makes the mailbox subscribed",
+    );
+
+    xlog $self, "query with isSubscribed filter must agree with get";
+    $res = $jmap->request([
+        [ 'Mailbox/query', {
+            accountId => 'other',
+            filter    => { isSubscribed => JSON::true },
+        } ],
+    ]);
+
+    my $ids = $res->single_sentence('Mailbox/query')->arguments->{ids};
+
+    $self->assert_cmp_deeply(
+        [ $mbox->{id} ],
+        $ids,
+        "Mailbox/query finds exactly the autosub mailbox",
+    );
+
+    xlog $self, "unsubscribe is accepted and reports effective true";
+    $res = $jmap->request([
+        [ 'Mailbox/set', {
+            accountId => 'other',
+            update    => { $mbox->{id} => { isSubscribed => JSON::false } },
+        } ],
+    ]);
+
+    my $set = $res->single_sentence('Mailbox/set')->arguments;
+
+    $self->assert_cmp_deeply(
+        superhashof({
+            updated => { $mbox->{id} => superhashof({ isSubscribed => jtrue() }) },
+        }),
+        $set,
+        "unsubscribing succeeds but the '1' right keeps it subscribed",
+    );
+}

--- a/cassandane/tiny-tests/Mboxgroups/esearch_autosub
+++ b/cassandane/tiny-tests/Mboxgroups/esearch_autosub
@@ -1,0 +1,52 @@
+#!perl
+use Cassandane::Tiny;
+
+# The subscribed source of an ESEARCH multisearch resolves subscriptions
+# separately from LIST, so the '1' right has to be honoured there too.
+sub test_esearch_autosub
+    :NoAltNamespace :ReverseACLs :min_version_3_7
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+    my $imaptalk  = $self->{store}->get_client();
+
+    $admintalk->create("user.otheruser.autoshared") or die "create: $@";
+    $admintalk->setacl("user.otheruser.autoshared", "group:group co", "lrsip1")
+        or die "setacl: $@";
+
+    my $raw = <<"EOF";
+From: <from\@local>\r
+To: to\@local\r
+Subject: findme\r
+Message-Id: <messageid1\@foo>\r
+Date: Wed, 7 Dec 2019 22:11:11 +1100\r
+MIME-Version: 1.0\r
+Content-Type: text/plain\r
+\r
+body\r
+EOF
+
+    $imaptalk->append('user.otheruser.autoshared', "()", $raw) || die $@;
+
+    my @results;
+    my %handlers = (
+        esearch => sub { push @results, $_[1] },
+    );
+
+    xlog $self, "the flag-granted folder is searched without a subs entry";
+    $imaptalk->_imap_cmd('ESEARCH', 0, \%handlers,
+                         'IN', '(SUBSCRIBED)', 'subject', 'findme');
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_num_equals(1, scalar @results);
+    $self->assert_str_equals('user.otheruser.autoshared', $results[0][0][3]);
+
+    xlog $self, "subscribing for real does not double up the result";
+    $imaptalk->subscribe("user.otheruser.autoshared") or die "subscribe: $@";
+
+    @results = ();
+    $imaptalk->_imap_cmd('ESEARCH', 0, \%handlers,
+                         'IN', '(SUBSCRIBED)', 'subject', 'findme');
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_num_equals(1, scalar @results);
+    $self->assert_str_equals('user.otheruser.autoshared', $results[0][0][3]);
+}

--- a/cassandane/tiny-tests/Mboxgroups/list_autosub
+++ b/cassandane/tiny-tests/Mboxgroups/list_autosub
@@ -1,0 +1,195 @@
+#!perl
+use Cassandane::Tiny;
+
+# Share a folder with the '1' (ACL_AUTOSUB) right, and give cassandane a
+# folder of its own subscribed the ordinary way, for the merge/dedup case.
+sub setup_list_autosub ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+    my $imaptalk  = $self->{store}->get_client();
+
+    $admintalk->create("user.otheruser.autoshared") or die "create: $@";
+    $admintalk->setacl("user.otheruser.autoshared", "group:group co", "lrs1")
+        or die "setacl: $@";
+
+    $imaptalk->create("INBOX.mine") or die "create: $@";
+    $imaptalk->subscribe("INBOX.mine") or die "subscribe: $@";
+
+    return $imaptalk;
+}
+
+# assert_mailbox_structure() indexes responses by name, so a duplicated
+# response would collapse and go unnoticed -- count them first, since not
+# duplicating the merged-in mailboxes is the point of these tests.
+sub assert_list_autosub ($self, $data, $expected, $msg)
+{
+    my %count;
+    $count{ $_->[2] }++ for $data->@*;
+    my @dupes = grep {; $count{$_} > 1 } sort keys %count;
+    $self->assert_num_equals(0, scalar @dupes, "duplicated in LIST: @dupes");
+
+    $self->assert_mailbox_structure($data, '.', $expected, 0, $msg);
+}
+
+sub test_list_autosub_subscribed
+    :NoAltNamespace :ReverseACLs
+    ($self)
+{
+    my $imaptalk = $self->setup_list_autosub;
+
+    xlog $self, "subscribe the shared folder for real as well";
+    $imaptalk->subscribe("user.otheruser.autoshared") or die "subscribe: $@";
+
+    my $subscribed = $imaptalk->list([qw(SUBSCRIBED)], "", "*");
+    my $recursive = $imaptalk->list([qw(SUBSCRIBED RECURSIVEMATCH)], "", "*");
+
+    $self->assert_list_autosub(
+        $subscribed,
+        {
+            'INBOX.mine' => [ '\\Subscribed' ],
+            'user.otheruser.autoshared' => [ '\\Subscribed' ],
+        },
+        "LIST (SUBSCRIBED) shows the real and the flag-granted subscription",
+    );
+
+    $self->assert_list_autosub(
+        $recursive,
+        {
+            'INBOX.mine' => [ '\\Subscribed' ],
+            'user.otheruser.autoshared' => [ '\\Subscribed' ],
+        },
+        "... and RECURSIVEMATCH does not report it twice either",
+    );
+}
+
+sub test_list_autosub_after_unsubscribe
+    :NoAltNamespace :ReverseACLs
+    ($self)
+{
+    my $imaptalk = $self->setup_list_autosub;
+
+    xlog $self, "unsubscribing the flag-granted folder succeeds";
+    $imaptalk->subscribe("user.otheruser.autoshared") or die "subscribe: $@";
+    $imaptalk->unsubscribe("user.otheruser.autoshared")
+        or die "unsubscribe: $@";
+
+    my $subscribed = $imaptalk->list([qw(SUBSCRIBED)], "", "*");
+    my $lsub = $imaptalk->lsub("", "*");
+    my $returned = $imaptalk->list([qw()], "", "*", 'RETURN', [qw(SUBSCRIBED)]);
+    my $recursive = $imaptalk->list([qw(SUBSCRIBED RECURSIVEMATCH)], "", "*");
+
+    $self->assert_list_autosub(
+        $subscribed,
+        {
+            'INBOX.mine' => [ '\\Subscribed' ],
+            'user.otheruser.autoshared' => [ '\\Subscribed' ],
+        },
+        "... but the folder stays listed via the flag",
+    );
+
+    $self->assert_list_autosub(
+        $lsub,
+        {
+            'INBOX.mine' => [],
+            'user.otheruser.autoshared' => [],
+        },
+        "LSUB shows it too",
+    );
+
+    $self->assert_list_autosub(
+        $returned,
+        {
+            'INBOX' => [],
+            'INBOX.mine' => [ '\\Subscribed' ],
+            'user.otheruser.autoshared' => [ '\\Subscribed' ],
+        },
+        "RETURN (SUBSCRIBED) annotates the flag-granted folder",
+    );
+
+    # RECURSIVEMATCH takes its own path through the LIST code, so it needs
+    # asserting separately from the LSUB and LIST (SUBSCRIBED) cases above
+    $self->assert_list_autosub(
+        $recursive,
+        {
+            'INBOX.mine' => [ '\\Subscribed' ],
+            'user.otheruser.autoshared' => [ '\\Subscribed' ],
+        },
+        "RECURSIVEMATCH shows the flag-granted folder with no real subscription",
+    );
+}
+
+# A hierarchical pattern only partially matches a name deeper in the tree,
+# which is how the LIST code learns a parent has subscribed children.  An
+# ACL-granted subscription has to reach that same machinery, or the parent
+# goes unmentioned where a real subscription would have named it.
+sub test_list_autosub_parent
+    :NoAltNamespace :ReverseACLs
+    ($self)
+{
+    my $imaptalk  = $self->setup_list_autosub;
+    my $admintalk = $self->{adminstore}->get_client();
+
+    xlog $self, "grant '1' on a child, nothing on the folder above it";
+    $admintalk->create("user.otheruser.tree") or die "create: $@";
+    $admintalk->create("user.otheruser.tree.deep") or die "create: $@";
+    $admintalk->setacl("user.otheruser.tree.deep", "group:group co", "lrs1")
+        or die "setacl: $@";
+
+    my $lsub = $imaptalk->lsub("", "user.otheruser.%");
+    my $recursive = $imaptalk->list([qw(SUBSCRIBED RECURSIVEMATCH)],
+                                    "", "user.otheruser.%");
+
+    $self->assert_list_autosub(
+        $lsub,
+        {
+            'user.otheruser.autoshared' => [],
+            'user.otheruser.tree' => [ '\\Noselect', '\\HasChildren' ],
+        },
+        "LSUB names the unsubscribed parent of the flag-granted child",
+    );
+
+    $self->assert_list_autosub(
+        $recursive,
+        {
+            'user.otheruser.autoshared' => [ '\\Subscribed' ],
+            'user.otheruser.tree' => [ '\\NonExistent', '\\HasChildren' ],
+        },
+        "RECURSIVEMATCH reports the parent of the flag-granted child",
+    );
+}
+
+sub test_list_autosub_dav_excluded
+    :NoAltNamespace :ReverseACLs
+    ($self)
+{
+    my $imaptalk  = $self->setup_list_autosub;
+    my $admintalk = $self->{adminstore}->get_client();
+
+    xlog $self, "grant '1' on a DAV mailbox as well";
+    $admintalk->create("user.otheruser.#addressbooks.Shared",
+                       [ 'TYPE', 'ADDRESSBOOK' ]) or die "create: $@";
+    $admintalk->setacl("user.otheruser.#addressbooks.Shared",
+                       "group:group co", "lrs1") or die "setacl: $@";
+
+    # the DAV mailbox is absent from both expected listings: all three
+    # listing paths must agree that '1' does not surface it
+    my $expected = {
+        'INBOX.mine' => [ '\\Subscribed' ],
+        'user.otheruser.autoshared' => [ '\\Subscribed' ],
+    };
+
+    my $subscribed = $imaptalk->list([qw(SUBSCRIBED)], "", "*");
+    my $recursive = $imaptalk->list([qw(SUBSCRIBED RECURSIVEMATCH)], "", "*");
+
+    $self->assert_list_autosub(
+        $subscribed,
+        $expected,
+        "LIST (SUBSCRIBED) does not surface the DAV mailbox",
+    );
+
+    $self->assert_list_autosub(
+        $recursive,
+        $expected,
+        "LIST (SUBSCRIBED RECURSIVEMATCH) does not surface it either",
+    );
+}

--- a/cassandane/tiny-tests/Notify/subscribed_autosub
+++ b/cassandane/tiny-tests/Notify/subscribed_autosub
@@ -1,0 +1,54 @@
+#!perl
+use Cassandane::Tiny;
+
+# The subscribed filter keys off the userid alone, so both halves of it have
+# to resolve subscriptions the same way the listings do: imapd expands the
+# set for the initial STATUS burst, and idled decides per event which idling
+# sessions to wake.  Neither may miss a mailbox granted the '1' right.
+sub test_subscribed_autosub
+    :needs_component_idled :ReverseACLs :NoAltNamespace :min_version_3_9
+    ($self)
+{
+    $self->{instance}->{config}->set(imapidlepoll => '2');
+    $self->{instance}->add_start(name => 'idled',
+                                 argv => [ 'idled' ]);
+    $self->{instance}->start();
+
+    # the suite starts its own instance, so the usual stores aren't wired up
+    my $svc = $self->{instance}->get_service('imap');
+    my $adminstore = $svc->create_store(username => 'admin',
+                                        folder => 'user.cassandane');
+    my $admintalk = $adminstore->get_client();
+
+    xlog $self, "another user's folder, granted '1' but never subscribed";
+    $admintalk->create("user.otheruser") or die "create: $@";
+    $admintalk->create("user.otheruser.autoshared") or die "create: $@";
+    $admintalk->setacl("user.otheruser.autoshared", "cassandane", "lrsip1")
+        or die "setacl: $@";
+
+    my $store = $svc->create_store();
+    my $talk = $store->get_client();
+
+    $self->assert($talk->capability()->{notify});
+
+    xlog $self, "the initial STATUS burst covers the flag-granted folder";
+    $talk->_imap_cmd('NOTIFY', 0, 'STATUS', 'SET', 'STATUS',
+                     "(subscribed (MessageNew MessageExpunge))");
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    my $status = $talk->get_response_code('status');
+    $self->assert_num_equals(0, $status->{'user.otheruser.autoshared'}{messages});
+
+    xlog $self, "and a new message there wakes the idling session";
+    my $otherstore = $svc->create_store();
+    my $othertalk = $otherstore->get_client();
+    $othertalk->append('user.otheruser.autoshared', "()",
+                       $self->{gen}->generate(subject => "findme")->as_string())
+        || die "append: $@";
+
+    my $res = $store->idle_response('STATUS', 5);
+    $self->assert($res, "received an unsolicited response");
+
+    $status = $talk->get_response_code('status');
+    $self->assert_num_equals(1, $status->{'user.otheruser.autoshared'}{messages});
+}

--- a/docsrc/reference/admin/access-control/rights-reference.rst
+++ b/docsrc/reference/admin/access-control/rights-reference.rst
@@ -374,3 +374,50 @@ Individual Rights Reference
         :ref:`imap-admin-access-control-right-e`,
         :ref:`imap-admin-access-control-right-t` and
         :ref:`imap-admin-access-control-right-x` rights.
+
+.. _imap-admin-access-control-right-1:
+
+``1``
+-----
+
+    Stands for **auto-subscribe**. This is a Cyrus-specific right: one
+    of the :rfc:`4314` digit rights reserved for local or site-defined
+    use.
+
+    Any user whose effective rights on a mailbox include the
+    :ref:`imap-admin-access-control-right-1` right -- whether granted
+    directly, or through a ``group:`` identifier (see
+    :ref:`imap-admin-access-control-identifiers`) -- is treated as
+    subscribed to that mailbox. Such a mailbox appears in the ``LSUB``
+    response and in ``LIST (SUBSCRIBED)`` / ``LIST`` ``RETURN
+    (SUBSCRIBED)`` responses, is searched by the subscribed-scope
+    ``ESEARCH`` multisearch, wakes an ``IDLE`` session that asked for
+    ``NOTIFY`` on the ``subscribed`` mailbox filter, is reported with
+    ``isSubscribed: true`` over JMAP for Mailbox, Calendar and
+    AddressBook objects, is listed among the user's shared CalDAV and
+    CardDAV collections, and has its per-user calendar alarms fire as
+    normal.
+
+    Enumerating another user's or a shared mailbox this way requires
+    :imapdconf:`reverseacls` to be enabled: the reverse index is what
+    makes it possible to find the mailboxes a user has been granted a
+    right on without walking every mailbox on the server. Without it,
+    the right still governs anything that asks about one named mailbox
+    -- ``isSubscribed``, alarm delivery -- but such mailboxes will not
+    appear in listings.
+
+    ``SUBSCRIBE`` and ``UNSUBSCRIBE`` still operate on the user's real
+    subscription entry for the mailbox and succeed as usual. However,
+    while the :ref:`imap-admin-access-control-right-1` right is held,
+    the mailbox's effective subscription state remains subscribed
+    regardless of that entry; removing the right restores whatever the
+    user's real subscription state was.
+
+    This right is intended for centrally-managed shared folders, such
+    as an organisation-wide address book shared to a group, where
+    subscription should not depend on individual users managing it
+    themselves.
+
+    Granting this right to the ``anyone`` identifier auto-subscribes
+    every user with access to the mailbox. That's coherent, but almost
+    never what's wanted; grant it to a ``group:`` identifier instead.

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -711,8 +711,22 @@ static icalcomponent *vpatch_from_peruserdata(struct dlist *dl)
     return vpatch;
 }
 
+/* mboxlist_issubscribed already avoids building an auth state for a mailbox
+ * that grants '1' to nobody, but it still has to read the mbentry to find
+ * that out.  These callbacks run once per per-user annotation record, and
+ * has_alarms() runs on every record store, so hoist the answer to once per
+ * mailbox and keep the unsubscribed sharee down to a single subs-db fetch */
+static int is_sharee_subscribed(const char *mailbox, const char *userid,
+                                int mbox_autosub)
+{
+    if (!mbox_autosub) return mboxlist_checksub(mailbox, userid) == 0;
+
+    return mboxlist_issubscribed(mailbox, userid, NULL);
+}
+
 struct has_alarms_rock {
     uint32_t mbox_options;
+    int mbox_autosub;   /* mailbox ACL grants '1' to somebody */
     int *has_alarms;
 };
 
@@ -729,7 +743,7 @@ static int has_peruser_alarms_cb(const char *mailbox,
 
     if (!mboxname_userownsmailbox(userid, mailbox) &&
         ((hrock->mbox_options & OPT_IMAP_SHAREDSEEN) ||
-         mboxlist_checksub(mailbox, userid) != 0)) {
+         !is_sharee_subscribed(mailbox, userid, hrock->mbox_autosub))) {
         /* No per-user-data, or sharee has unsubscribed from this calendar */
         return 0;
     }
@@ -960,7 +974,11 @@ static int has_alarms(void *data, struct mailbox *mailbox,
     }
 
     /* Check all per-user-cal-data for VALARMs */
-    struct has_alarms_rock hrock = { mailbox->i.options, &has_alarms };
+    struct has_alarms_rock hrock = {
+        mailbox->i.options,
+        cyrus_acl_anygrants(mailbox_acl(mailbox), ACL_AUTOSUB),
+        &has_alarms
+    };
 
     syslog(LOG_DEBUG, "checking per-user-data");
     mailbox_get_annotate_state(mailbox, uid, NULL);
@@ -1244,6 +1262,7 @@ static int alarm_read_cb(sqlite3_stmt *stmt, void *rock)
 
 struct process_alarms_rock {
     uint32_t mbox_options;
+    int mbox_autosub;   /* mailbox ACL grants '1' to somebody */
     modseq_t createdmodseq; // for CalendarEvent ID
     icalcomponent *ical;
     struct lastalarm_data *alarm;
@@ -1266,7 +1285,7 @@ static int process_peruser_alarms_cb(const char *mailbox, uint32_t uid,
 
     if (!mboxname_userownsmailbox(userid, mailbox) &&
         ((prock->mbox_options & OPT_IMAP_SHAREDSEEN) ||
-         mboxlist_checksub(mailbox, userid) != 0)) {
+         !is_sharee_subscribed(mailbox, userid, prock->mbox_autosub))) {
         /* No per-user-data, or sharee has unsubscribed from this calendar */
         return 0;
     }
@@ -1362,7 +1381,9 @@ static int process_valarms(struct mailbox *mailbox,
 
     /* Process VALARMs in per-user-cal-data */
     struct process_alarms_rock prock = {
-        mailbox->i.options, record->createdmodseq,
+        mailbox->i.options,
+        cyrus_acl_anygrants(mailbox_acl(mailbox), ACL_AUTOSUB),
+        record->createdmodseq,
         ical, &data, runtime, dryrun
     };
 

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -7230,9 +7230,10 @@ static int report_cal_query(struct transaction_t *txn,
                               MBOXTREE_SKIP_ROOT);
 
             /* Add responses for all shared calendar collections */
-            mboxlist_usersubs(txn->req_tgt.userid,
-                              calquery_by_collection, fctx,
-                              MBOXTREE_SKIP_PERSONAL);
+            mboxlist_usersubs_effective(txn->req_tgt.userid,
+                                        httpd_authstate,
+                                        calquery_by_collection, fctx,
+                                        MBOXTREE_SKIP_PERSONAL);
         }
     }
 

--- a/imap/http_carddav.c
+++ b/imap/http_carddav.c
@@ -2401,9 +2401,10 @@ static int report_card_query(struct transaction_t *txn,
                               MBOXTREE_SKIP_ROOT);
 
             /* Add responses for all shared addressbook collections */
-            mboxlist_usersubs(txn->req_tgt.userid,
-                              propfind_by_collection, fctx,
-                              MBOXTREE_SKIP_PERSONAL);
+            mboxlist_usersubs_effective(txn->req_tgt.userid,
+                                        httpd_authstate,
+                                        propfind_by_collection, fctx,
+                                        MBOXTREE_SKIP_PERSONAL);
         }
     }
 

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -2482,6 +2482,14 @@ static void add_privs(int rights, unsigned flags,
     xmlNodePtr priv;
     int do_contained;
 
+    /* CYRUS:auto-subscribe (not implied by DAV:all, so emitted first,
+       ahead of the DAV:all early return) */
+    if (rights & ACL_AUTOSUB) {
+        ensure_ns(ns, NS_CYRUS, root, XML_NS_CYRUS, "CY");
+        priv = xmlNewChild(parent, NULL, BAD_CAST "privilege", NULL);
+        xmlNewChild(priv, ns[NS_CYRUS], BAD_CAST "auto-subscribe", NULL);
+    }
+
     /* DAV:all */
     if ((rights & DACL_ALL) == DACL_ALL &&
         /* DAV:all on CALDAV:schedule-in/outbox MUST include CALDAV:schedule */
@@ -2741,10 +2749,11 @@ int propfind_acl(const xmlChar *name, xmlNsPtr ns,
 
     if (!propstat) {
         /* Prescreen "property" request */
+        /* Add namespaces for possible privileges */
+        ensure_ns(fctx->ns, NS_CYRUS, fctx->root, XML_NS_CYRUS, "CY");
         if (fctx->req_tgt->namespace->id == URL_NS_CALENDAR &&
             (fctx->req_tgt->collection ||
              (fctx->req_tgt->userid && fctx->depth >= 1) || fctx->depth >= 2)) {
-            /* Add namespaces for possible privileges */
             ensure_ns(fctx->ns, NS_CALDAV, fctx->root, XML_NS_CALDAV, "C");
         }
 
@@ -6517,9 +6526,10 @@ EXPORTED int meth_propfind(struct transaction_t *txn, void *params)
 
                 case URL_NS_ADDRESSBOOK:
                     /* Add responses for shared collections */
-                    mboxlist_usersubs(txn->req_tgt.userid,
-                                      propfind_by_collection, &fctx,
-                                      MBOXTREE_SKIP_PERSONAL);
+                    mboxlist_usersubs_effective(txn->req_tgt.userid,
+                                                httpd_authstate,
+                                                propfind_by_collection, &fctx,
+                                                MBOXTREE_SKIP_PERSONAL);
                     break;
                 }
             }
@@ -7693,9 +7703,10 @@ int expand_property(xmlNodePtr inroot, struct propfind_ctx *fctx,
             case URL_NS_CALENDAR:
             case URL_NS_ADDRESSBOOK:
                 /* Add responses for shared collections */
-                mboxlist_usersubs(fctx->req_tgt->userid,
-                                  propfind_by_collection, fctx,
-                                  MBOXTREE_SKIP_PERSONAL);
+                mboxlist_usersubs_effective(fctx->req_tgt->userid,
+                                            httpd_authstate,
+                                            propfind_by_collection, fctx,
+                                            MBOXTREE_SKIP_PERSONAL);
                 break;
             }
         }

--- a/imap/idled.c
+++ b/imap/idled.c
@@ -94,7 +94,35 @@ struct notify_rock {
     json_t *msg;
     pid_t last_pid;
     arrayu64_t *failed_pids;
+    /* one message fans out to every registered client, and several of them
+     * can be the same user, so keep the auth state the '1' right needs for
+     * the length of the fan-out rather than per client.  the userid is our
+     * own copy: the caller's comes out of the row's json, which goes away
+     * when that row's callback returns */
+    char *authstate_userid;
+    struct auth_state *authstate;
 };
+
+/* is userid subscribed to mbentry, counting the ACL_AUTOSUB grant?
+ * mboxlist_issubscribed answers this, but it has to read the mbentry to
+ * decide whether the right is in play and it can't hold an auth state
+ * across calls -- we have the mbentry already and the rock outlives the
+ * fan-out, so do the same steps here and keep both */
+static int is_subscribed(struct notify_rock *nrock,
+                         const mbentry_t *mbentry, const char *userid)
+{
+    if (mboxlist_checksub(mbentry->name, userid) == 0) return 1;
+    if (!cyrus_acl_anygrants(mbentry->acl, ACL_AUTOSUB)) return 0;
+
+    if (strcmpsafe(nrock->authstate_userid, userid)) {
+        auth_freestate(nrock->authstate);
+        free(nrock->authstate_userid);
+        nrock->authstate = auth_newstate(userid);
+        nrock->authstate_userid = xstrdup(userid);
+    }
+
+    return cyrus_acl_myrights(nrock->authstate, mbentry->acl) & ACL_AUTOSUB;
+}
 
 static int notify_cb(sqlite3_stmt *stmt, void *rock)
 {
@@ -156,14 +184,11 @@ static int notify_cb(sqlite3_stmt *stmt, void *rock)
                 notify = 1;
             break;
 
-        case FILTER_SUBSCRIBED: {
+        case FILTER_SUBSCRIBED:
             /* keyval is userid */
-            strarray_t *sublist = mboxlist_sublist(keyval);
-            if (strarray_contains(sublist, mbentry->name))
+            if (is_subscribed(nrock, mbentry, keyval))
                 notify = 1;
-            strarray_free(sublist);
             break;
-        }
 
         case FILTER_SUBTREE:
             json_array_foreach(keys, i, key) {
@@ -285,7 +310,7 @@ static void process_message(struct sockaddr_un *remote, json_t *msg)
         const char *jevent = json_string_value(json_object_get(msg, "event"));
         enum event_type event = name_to_mboxevent(jevent);
         arrayu64_t failed_pids = ARRAYU64_INITIALIZER;
-        struct notify_rock nrock = { msg, 0, &failed_pids };
+        struct notify_rock nrock = { msg, 0, &failed_pids, NULL, NULL };
 
         if (verbose || debugmode) {
             syslog(LOG_DEBUG, "idle notify '%s'", jevent);
@@ -318,6 +343,8 @@ static void process_message(struct sockaddr_un *remote, json_t *msg)
         }
 
         arrayu64_fini(&failed_pids);
+        auth_freestate(nrock.authstate);
+        free(nrock.authstate_userid);
     }
     else {
         syslog(LOG_ERR, "unrecognized message: %s", type);

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6364,7 +6364,9 @@ static void cmd_search(const char *tag, const char *cmd)
                 break;
 
             case SEARCH_SOURCE_SUBSCRIBED:
-                mboxlist_usersubs(searchargs->userid, multisearch_cb, &mrock, 0);
+                mboxlist_usersubs_effective(searchargs->userid,
+                                            searchargs->authstate,
+                                            multisearch_cb, &mrock, 0);
                 break;
 
             default: {
@@ -13392,8 +13394,17 @@ static void list_response(const char *extname, const mbentry_t *mbentry,
 
 static void _addsubs(struct list_rock *rock)
 {
+    /* rock->subs is only populated for RETURN (SUBSCRIBED) on a normal
+     * LIST; that's also the only case where this ACL check should apply
+     * -- otherwise \Subscribed would leak into plain LIST responses that
+     * never asked for subscription state */
     if (!rock->subs) return;
     if (!rock->last_mbentry) return;
+
+    if (cyrus_acl_myrights(imapd_authstate, rock->last_mbentry->acl)
+        & ACL_AUTOSUB)
+        rock->last_attributes |= MBOX_ATTRIBUTE_SUBSCRIBED;
+
     int i;
     const char *last_name = rock->last_mbentry->name;
     int namelen = strlen(last_name);
@@ -15203,7 +15214,8 @@ static void cmd_notify(char *tag, int set)
             if (do_status && (new_egroups->subscribed_events & IMAP_NOTIFY_MESSAGE)) {
                 srock.filter = FILTER_SUBSCRIBED;
                 srock.events = new_egroups->subscribed_events;
-                mboxlist_usersubs(imapd_userid, &notify_set_status, &srock, 0);
+                mboxlist_usersubs_effective(imapd_userid, imapd_authstate,
+                                            &notify_set_status, &srock, 0);
             }
         }
         if (new_egroups->subtree.events) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -828,6 +828,10 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
             /* Users always subscribe their own calendars */
             is_subscribed = 1;
         }
+        else if (rights & ACL_AUTOSUB) {
+            /* ACL keeps this user subscribed */
+            is_subscribed = 1;
+        }
         else {
             /* Lookup mailbox subscriptions */
             is_subscribed = mboxlist_checksub(mbentry->name, req->userid) == 0;
@@ -2248,8 +2252,16 @@ static void setcalendars_update(jmap_req_t *req,
         goto done;
     }
 
-    /* Report calendar as updated. */
-    *record = json_null();
+    /* Report calendar as updated. If the client asked to
+     * unsubscribe but an auto-subscribe ACL keeps them subscribed,
+     * report the effective value back as server-set. */
+    if (props.isSubscribed == 0 &&
+            (jmap_myrights(req, mboxname) & ACL_AUTOSUB)) {
+        *record = json_pack("{s:b}", "isSubscribed", 1);
+    }
+    else {
+        *record = json_null();
+    }
 
 done:
     setcalendar_props_fini(&props);

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -1936,6 +1936,10 @@ static int getaddressbooks_cb(const mbentry_t *mbentry, void *vrock)
             /* Users always subscribe their own addressbooks */
             is_subscribed = 1;
         }
+        else if (rights & ACL_AUTOSUB) {
+            /* ACL keeps this user subscribed */
+            is_subscribed = 1;
+        }
         else {
             /* Lookup mailbox subscriptions */
             is_subscribed = mboxlist_checksub(mbentry->name, req->userid) == 0;
@@ -2679,8 +2683,16 @@ static void setaddressbooks_update(jmap_req_t *req,
         goto done;
     }
 
-    /* Report addressbook as updated. */
-    *record = json_null();
+    /* Report addressbook as updated. If the client asked to
+     * unsubscribe but an auto-subscribe ACL keeps them subscribed,
+     * report the effective value back as server-set. */
+    if (props.isSubscribed == 0 &&
+            (jmap_myrights(req, mbentry->name) & ACL_AUTOSUB)) {
+        *record = json_pack("{s:b}", "isSubscribed", 1);
+    }
+    else {
+        *record = json_null();
+    }
 
 done:
     mboxlist_entry_free(&mbentry);

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -648,7 +648,8 @@ static json_t *_mbox_get(jmap_req_t *req,
     }
 
     if (jmap_wantprop(props, "isSubscribed")) {
-        int is_subscribed = strarray_contains(sublist, mbentry->name);
+        int is_subscribed = strarray_contains(sublist, mbentry->name) ||
+            (jmap_myrights_mbentry(req, mbentry) & ACL_AUTOSUB);
         json_object_set_new(obj, "isSubscribed", json_boolean(is_subscribed));
     }
 
@@ -993,7 +994,8 @@ static int _mboxquery_eval_filter(mboxquery_t *query,
         }
         if (JNOTNULL(filter->is_subscribed)) {
             int want_subscribed = json_boolean_value(filter->is_subscribed);
-            int is_subscribed = strarray_contains(query->sublist, rec->mboxname);
+            int is_subscribed = strarray_contains(query->sublist, rec->mboxname) ||
+                (jmap_myrights(query->req, rec->mboxname) & ACL_AUTOSUB);
             if (want_subscribed && !is_subscribed) return 0;
             if (!want_subscribed && is_subscribed) return 0;
         }
@@ -3185,7 +3187,14 @@ static void _mboxset_run(jmap_req_t *req, struct mboxset *set,
                 ptrarray_append(&skipped_put, args);
             }
             else {
-                json_object_set(set->super.updated, args->mbox_id, json_null());
+                if (args->is_subscribed == 0 &&
+                    (jmap_myrights_mboxid(req, args->mbox_id) & ACL_AUTOSUB)) {
+                    json_object_set_new(set->super.updated, args->mbox_id,
+                                        json_pack("{s:b}", "isSubscribed", 1));
+                }
+                else {
+                    json_object_set(set->super.updated, args->mbox_id, json_null());
+                }
                 if (result.tmp_imapname) {
                     struct tmp_rename *tmp = xzmalloc(sizeof(struct tmp_rename));
                     tmp->old_imapname = xstrdupnull(result.old_imapname);

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -29,6 +29,7 @@
 #include "assert.h"
 #include "global.h"
 #include "cyrusdb.h"
+#include "hash.h"
 #include "util.h"
 #include "mailbox.h"
 #include "mboxevent.h"
@@ -3692,23 +3693,18 @@ struct find_rock {
     void *procrock;
 };
 
-/* return non-zero if we like this one */
-static int find_p(void *rockp,
-                  const char *key, size_t keylen,
-                  const char *data, size_t datalen)
+/* return non-zero if we like this one.  dbname is the record's name;
+ * data/datalen are its db value, unused for subscriptions which have empty
+ * values, so an ACL-only subscription can be fed through here with no
+ * record at all */
+static int find_dbname_p(struct find_rock *rock,
+                         const char *dbname, size_t dbnamelen,
+                         const char *data, size_t datalen)
 {
-    struct find_rock *rock = (struct find_rock *) rockp;
-    struct buf dbname = BUF_INITIALIZER;
     int i;
 
-    /* skip any non-name keys */
-    if (key[0] != KEY_TYPE_NAME) return 0;
-
-    mboxlist_dbname_from_key(key, keylen,
-                             rock->issubs ? rock->userid : NULL, &dbname);
-
     assert(!rock->mbname);
-    rock->mbname = mbname_from_dbname(buf_cstring(&dbname));
+    rock->mbname = mbname_from_dbname(dbname);
 
     if (!rock->isadmin && !config_getswitch(IMAPOPT_CROSSDOMAINS)) {
         /* don't list mailboxes outside of the default domain */
@@ -3743,8 +3739,7 @@ static int find_p(void *rockp,
         goto good;
 
     /* ignore entirely deleted records */
-    if (mboxlist_parse_entry(&rock->mbentry,
-                             buf_cstring(&dbname), buf_len(&dbname),
+    if (mboxlist_parse_entry(&rock->mbentry, dbname, dbnamelen,
                              data, datalen))
         goto nomatch;
 
@@ -3765,8 +3760,6 @@ static int find_p(void *rockp,
     }
 
 good:
-    buf_free(&dbname);
-
     if (rock->p) {
         struct findall_data fdata = { extname, 0, rock->mbentry, rock->mbname, 0 };
         /* mbname confirms that it's an exact match */
@@ -3782,8 +3775,27 @@ good:
 nomatch:
     mboxlist_entry_free(&rock->mbentry);
     mbname_free(&rock->mbname);
-    buf_free(&dbname);
     return 0;
+}
+
+static int find_p(void *rockp,
+                  const char *key, size_t keylen,
+                  const char *data, size_t datalen)
+{
+    struct find_rock *rock = (struct find_rock *) rockp;
+    struct buf dbname = BUF_INITIALIZER;
+
+    /* skip any non-name keys */
+    if (key[0] != KEY_TYPE_NAME) return 0;
+
+    mboxlist_dbname_from_key(key, keylen,
+                             rock->issubs ? rock->userid : NULL, &dbname);
+
+    int r = find_dbname_p(rock, buf_cstring(&dbname), buf_len(&dbname),
+                          data, datalen);
+
+    buf_free(&dbname);
+    return r;
 }
 
 static int find_cb(void *rockp,
@@ -3849,6 +3861,17 @@ static int find_cb(void *rockp,
     mboxlist_entry_free(&rock->mbentry);
     mbname_free(&rock->mbname);
     return r;
+}
+
+/* run one name through find_p/find_cb without a db record behind it.  Only
+ * valid for subscriptions, where find_dbname_p never looks at the value */
+static int find_emit_dbname(struct find_rock *rock, const char *dbname)
+{
+    assert(rock->issubs);
+
+    if (!find_dbname_p(rock, dbname, strlen(dbname), NULL, 0)) return 0;
+
+    return find_cb(rock, NULL, 0, NULL, 0);
 }
 
 struct allmb_rock {
@@ -4258,6 +4281,108 @@ EXPORTED int mboxlist_usermboxtree(const char *userid,
     return r;
 }
 
+struct subsname_rock {
+    const char *userid;
+    strarray_t *names;
+};
+
+static int subsname_cb(void *rockp, const char *key, size_t keylen,
+                       const char *data __attribute__((unused)),
+                       size_t datalen __attribute__((unused)))
+{
+    struct subsname_rock *srock = (struct subsname_rock *) rockp;
+    struct buf dbname = BUF_INITIALIZER;
+
+    if (key[0] == KEY_TYPE_NAME) {
+        mboxlist_dbname_from_key(key, keylen, srock->userid, &dbname);
+        strarray_append(srock->names, buf_cstring(&dbname));
+        buf_free(&dbname);
+    }
+
+    return 0;
+}
+
+/* collect mailboxes in this category where the user's effective rights
+ * include ACL_AUTOSUB - subscribed by grant rather than by a subs record.
+ * Needs reverseacls: the reverse index is the only way to find the grants
+ * without walking every mailbox on the server */
+static void mboxlist_autosub_matches(struct find_rock *rock,
+                                     const char *prefix, size_t len,
+                                     strarray_t *names)
+{
+    strarray_t matches = STRARRAY_INITIALIZER;
+    int i;
+
+    /* rock->db is the subs db here, the grants live in mailboxes.db */
+    mboxlist_racl_matches(mbdb,
+                          (rock->mb_category == MBNAME_OTHERUSER),
+                          rock->userid,
+                          rock->auth_state,
+                          prefix, len,
+                          &matches);
+
+    for (i = 0; i < strarray_size(&matches); i++) {
+        const char *dbname = strarray_nth(&matches, i);
+        mbentry_t *mbentry = NULL;
+
+        /* skips reserved, deleted and intermediate records for us */
+        if (mboxlist_mylookup(dbname, &mbentry, NULL, 0, 0)) continue;
+
+        if (cyrus_acl_myrights(rock->auth_state, mbentry->acl) & ACL_AUTOSUB)
+            strarray_append(names, dbname);
+
+        mboxlist_entry_free(&mbentry);
+    }
+
+    strarray_fini(&matches);
+}
+
+/* Subscriptions outside the user's own tree have two sources: the subs db,
+ * and mailboxes carrying the '1' right.  Merge them into one sorted stream
+ * rather than running a second pass - the LIST callbacks compare each name
+ * against the previous one to derive \HasChildren and the LSUB parent
+ * mention, so names arriving out of order come out wrong. */
+static int mboxlist_find_subs_category(struct find_rock *rock,
+                                       const char *prefix, size_t len)
+{
+    strarray_t autosubs = STRARRAY_INITIALIZER;
+    strarray_t names = STRARRAY_INITIALIZER;
+    struct subsname_rock srock = { rock->userid, &names };
+    struct buf key = BUF_INITIALIZER;
+    int r = 0;
+    int i;
+
+    mboxlist_autosub_matches(rock, prefix, len, &autosubs);
+
+    mboxlist_dbname_to_key(prefix, len, rock->userid, &key);
+
+    if (!strarray_size(&autosubs)) {
+        /* nothing granted anywhere in reach, which is the usual case - walk
+         * the subs db directly rather than paying for a merge of one list */
+        r = cyrusdb_foreach(rock->db, buf_base(&key), buf_len(&key),
+                            &find_p, &find_cb, rock, NULL);
+        goto done;
+    }
+
+    r = cyrusdb_foreach(rock->db, buf_base(&key), buf_len(&key),
+                        NULL, subsname_cb, &srock, NULL);
+    if (r) goto done;
+
+    /* a mailbox can be both really subscribed and granted the right */
+    strarray_cat(&names, &autosubs);
+    strarray_sort(&names, cmpstringp_raw);
+    strarray_uniq(&names);
+
+    for (i = 0; !r && i < strarray_size(&names); i++)
+        r = find_emit_dbname(rock, strarray_nth(&names, i));
+
+ done:
+    strarray_fini(&names);
+    strarray_fini(&autosubs);
+    buf_free(&key);
+    return r;
+}
+
 static int mboxlist_find_category(struct find_rock *rock, const char *prefix, size_t len)
 {
     struct buf key = BUF_INITIALIZER;
@@ -4265,7 +4390,14 @@ static int mboxlist_find_category(struct find_rock *rock, const char *prefix, si
 
     init_internal();
 
-    if (!rock->issubs && !rock->isadmin && have_racl) {
+    if (rock->issubs && !rock->isadmin && have_racl &&
+        (rock->mb_category == MBNAME_OTHERUSER ||
+         rock->mb_category == MBNAME_SHARED)) {
+        /* only these two categories can hold someone else's mailbox, and
+         * mboxlist_update_racl never writes a key for a mailbox's own owner */
+        r = mboxlist_find_subs_category(rock, prefix, len);
+    }
+    else if (!rock->issubs && !rock->isadmin && have_racl) {
         /* we're using reverse ACLs */
         strarray_t matches = STRARRAY_INITIALIZER;
         int i;
@@ -5363,6 +5495,59 @@ EXPORTED int mboxlist_usersubs(const char *userid, mboxlist_cb *proc,
     return r;
 }
 
+struct effsubs_rock {
+    const char *userid;
+    const struct auth_state *auth_state;
+    hash_table seen;
+    mboxlist_cb *proc;
+    void *rock;
+    int flags;
+};
+
+static int effsubs_subs_cb(const mbentry_t *mbentry, void *vrock)
+{
+    struct effsubs_rock *erock = vrock;
+    hash_insert(mbentry->name, (void *)1, &erock->seen);
+    return erock->proc(mbentry, erock->rock);
+}
+
+static int effsubs_acl_cb(const mbentry_t *mbentry, void *vrock)
+{
+    struct effsubs_rock *erock = vrock;
+
+    if (hash_lookup(mbentry->name, &erock->seen)) return 0;
+    if ((erock->flags & MBOXTREE_SKIP_PERSONAL) &&
+        mboxname_userownsmailbox(erock->userid, mbentry->name))
+        return 0;
+    if (!(cyrus_acl_myrights(erock->auth_state, mbentry->acl) & ACL_AUTOSUB))
+        return 0;
+
+    return erock->proc(mbentry, erock->rock);
+}
+
+/* like mboxlist_usersubs, but also visits mailboxes whose effective
+ * rights for userid include ACL_AUTOSUB, each mailbox at most once.
+ * shared-mailbox coverage relies on reverseacls being enabled, same
+ * as any other MBOXTREE_PLUS_RACL caller.
+ * rights are computed from auth_state, while RACL enumeration keys
+ * off userid, so callers must pass a (userid, auth_state) pair that
+ * name the same principal */
+EXPORTED int mboxlist_usersubs_effective(const char *userid,
+                                         const struct auth_state *auth_state,
+                                         mboxlist_cb *proc, void *rock,
+                                         int flags)
+{
+    struct effsubs_rock erock = { userid, auth_state, HASH_TABLE_INITIALIZER,
+                                  proc, rock, flags };
+    construct_hash_table(&erock.seen, 1024, 0);
+
+    int r = mboxlist_usersubs(userid, effsubs_subs_cb, &erock, flags);
+    if (!r) r = mboxlist_usermboxtree(userid, auth_state, effsubs_acl_cb,
+                                      &erock, MBOXTREE_PLUS_RACL);
+
+    free_hash_table(&erock.seen, NULL);
+    return r;
+}
 
 
 
@@ -5392,6 +5577,37 @@ EXPORTED int mboxlist_checksub(const char *name, const char *userid)
 
     mboxlist_closesubs(subs);
     return r;
+}
+
+/* effective subscription: a real subs entry, or ACL_AUTOSUB in the
+ * user's effective rights. auth_state may be NULL, in which case one
+ * is constructed for userid. Returns nonzero if subscribed. */
+EXPORTED int mboxlist_issubscribed(const char *name, const char *userid,
+                                   const struct auth_state *auth_state)
+{
+    if (mboxlist_checksub(name, userid) == 0) return 1;
+
+    mbentry_t *mbentry = NULL;
+    if (mboxlist_lookup(name, &mbentry, NULL)) return 0;
+
+    int rights = 0;
+
+    /* the miss is the common case, and building an auth state for it would
+     * invert mboxlist_checksub's cost -- so ask the ACL whether anybody at
+     * all is granted the right before working out whether this user is */
+    if (cyrus_acl_anygrants(mbentry->acl, ACL_AUTOSUB)) {
+        struct auth_state *mystate = NULL;
+        if (!auth_state)
+            auth_state = mystate = auth_newstate(userid);
+
+        rights = cyrus_acl_myrights(auth_state, mbentry->acl);
+
+        if (mystate) auth_freestate(mystate);
+    }
+
+    mboxlist_entry_free(&mbentry);
+
+    return (rights & ACL_AUTOSUB) ? 1 : 0;
 }
 
 /*

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -335,6 +335,12 @@ int mboxlist_usermboxtree(const char *userid, const struct auth_state *auth_stat
                           mboxlist_cb *proc, void *rock, int flags);
 int mboxlist_usersubs(const char *userid, mboxlist_cb *proc, void *rock, int flags);
 
+/* like mboxlist_usersubs, but also visits mailboxes whose effective
+ * rights for userid include ACL_AUTOSUB, each mailbox at most once */
+int mboxlist_usersubs_effective(const char *userid,
+                                const struct auth_state *auth_state,
+                                mboxlist_cb *proc, void *rock, int flags);
+
 strarray_t *mboxlist_sublist(const char *userid);
 
 /* Find subscribed mailboxes that match 'pattern'. */
@@ -366,6 +372,14 @@ int mboxlist_findstage(const char *name, char *stagedir, size_t sd_len);
 
 /* Check 'user's subscription status for mailbox 'name' */
 int mboxlist_checksub(const char *name, const char *userid);
+
+/* effective subscription: a real subs entry, or ACL_AUTOSUB in the
+ * user's effective rights. auth_state may be NULL, in which case one
+ * is constructed for userid -- but only for a mailbox whose ACL grants
+ * the right to somebody, so passing NULL is cheap on the mailboxes
+ * nobody has been granted it on. Returns nonzero if subscribed. */
+int mboxlist_issubscribed(const char *name, const char *userid,
+                          const struct auth_state *auth_state);
 
 /* Change 'user's subscription status for mailbox 'name'. */
 int mboxlist_changesub(const char *name, const char *userid,

--- a/lib/acl.h
+++ b/lib/acl.h
@@ -34,6 +34,11 @@
 #define ACL_USER9       0x100000L
 #define ACL_USER0       0x200000L
 
+/* alias: a user (or group member) whose effective rights include
+ * ACL_USER1 is treated as subscribed to the mailbox, with no
+ * subscription-db entry needed (and none removable) */
+#define ACL_AUTOSUB     ACL_USER1
+
 /* ALL: all non-user ACLs */
 #define ACL_ALL         (ACL_LOOKUP|ACL_READ|ACL_SETSEEN|ACL_WRITE\
                         |ACL_INSERT|ACL_POST|ACL_CREATE|ACL_DELETEMBOX\
@@ -73,6 +78,13 @@ extern char *cyrus_acl_masktostr(int acl, char *str);
  * Calculate the set of rights the user in 'auth_state' has in the ACL 'acl'.
  */
 extern int cyrus_acl_myrights(const struct auth_state *auth_state, const char *acl);
+
+/*  cyrus_acl_anygrants(acl, mask)
+ * Non-zero if any positive ACE in 'acl' grants any right in 'mask'.  Lets a
+ * caller skip a per-identifier rights calculation when nobody can hold the
+ * right anyway.
+ */
+extern int cyrus_acl_anygrants(const char *acl, int mask);
 
 /*  cyrus_acl_set(acl, identifier, mode, access, canonproc, canonrock) Modify the
  * ACL pointed to by 'acl' to modify the rights granted to

--- a/lib/acl_afs.c
+++ b/lib/acl_afs.c
@@ -22,6 +22,40 @@
 #include "lib/libcyr_cfg.h"
 
 /*
+ * Return non-zero if any positive ACE in 'acl' grants any right in 'mask'.
+ * A cheap way to skip a per-identifier rights calculation entirely: no
+ * positive grant means nobody can hold the right, whatever the auth state,
+ * since negative ACEs only ever take rights away.
+ */
+EXPORTED int cyrus_acl_anygrants(const char *acl, int mask)
+{
+    const char *thisid, *rights, *nextid;
+
+    for (thisid = acl; thisid && *thisid; thisid = nextid) {
+        rights = strchr(thisid, '\t');
+        if (!rights) break;
+        rights++;
+
+        nextid = strchr(rights, '\t');
+        if (!nextid) break;
+
+        if (*thisid != '-') {
+            char *rightstr = xstrndup(rights, nextid - rights);
+            int thismask = 0;
+
+            cyrus_acl_strtomask(rightstr, &thismask);
+            free(rightstr);
+
+            if (thismask & mask) return 1;
+        }
+
+        nextid++;
+    }
+
+    return 0;
+}
+
+/*
  * Calculate the set of rights the user in 'auth_state' has in the ACL 'acl'.
  */
 EXPORTED int cyrus_acl_myrights(const struct auth_state *auth_state, const char *origacl)


### PR DESCRIPTION
This is the missing part to allow us to switch from individual ACLs on the Shared address book to a single customer-wide ACL without having to still do the per-user accounting for subscriptions.