### PR TITLE
lmtpengine.c and more: add SMTPUTF8 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -663,6 +663,7 @@ cunit_TESTS = \
     cunit/seqset.testc \
     cunit/sessionid.testc \
     cunit/slowio.testc \
+    cunit/smtpclient.testc \
     cunit/smallarrayu64.testc \
     cunit/xsyslog_ev.testc
 

--- a/cassandane/Cassandane/Net/SMTPServer.pm
+++ b/cassandane/Cassandane/Net/SMTPServer.pm
@@ -72,7 +72,8 @@ sub helo {
     $Self->mylog("SMTP: HELO $Host");
     return if $Self->override('helo');
     $Self->send_client_resp(250, "localhost",
-                            "AUTH", "DSN", "SIZE 10000", "ENHANCEDSTATUSCODES");
+                            "AUTH", "DSN", "SIZE 10000", "ENHANCEDSTATUSCODES",
+                            "SMTPUTF8");
 }
 
 sub mail_from {

--- a/cassandane/tiny-tests/Search/from_alabel
+++ b/cassandane/tiny-tests/Search/from_alabel
@@ -1,0 +1,62 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_from_alabel
+    :want_deliver :min_version_3_13
+    ($self)
+{
+    xlog $self, "test that the cache holds u-labels, not punycode";
+
+    # Punycode is for the DNS, so a message from xn--gr-zia.org is
+    # cached, reported and searched as grå.org. Note that both
+    # messages are pure ASCII on the wire: the a-label is what the
+    # sender wrote, and the u-label is what we make of it.
+
+    my %msgs;
+    $msgs{1} = $self->{gen}->generate(
+        subject => "IDN sender",
+        from => Cassandane::Address->new(
+            name => "Arnt",
+            localpart => "arnt",
+            domain => "xn--gr-zia.org"));
+    $msgs{2} = $self->{gen}->generate(
+        subject => "Sender with a broken a-label",
+        from => Cassandane::Address->new(
+            name => "Info",
+            localpart => "info",
+            domain => "xn--zz.example.com"));
+
+    xlog $self, "deliver the messages over LMTP";
+    $self->{instance}->deliver($msgs{1});
+    $self->{instance}->deliver($msgs{2});
+
+    my $talk = $self->{store}->get_client();
+    $talk->select('INBOX');
+
+    xlog $self, "FETCH ENVELOPE reports the u-label";
+    my $res = $talk->fetch('1:2', 'envelope')
+        or die "Cannot fetch: $@";
+    $self->assert_str_equals('grå.org',
+                             $res->{1}->{envelope}->{'From-Raw'}->[0]->[3]);
+
+    xlog $self, "an a-label that isn't valid punycode is kept as it came";
+    $self->assert_str_equals('xn--zz.example.com',
+                             $res->{2}->{envelope}->{'From-Raw'}->[0]->[3]);
+
+    xlog $self, "SEARCH FROM finds the u-label";
+    my $uids = $talk->search('charset', 'utf-8', 'from', { Quote => 'grå.org' })
+        or die "Cannot search: $@";
+    $self->assert_deep_equals([1], $uids);
+
+    xlog $self, "and the a-label, which is not what we store, finds nothing";
+    $uids = $talk->search('charset', 'utf-8', 'from',
+                          { Quote => 'xn--gr-zia.org' })
+        or die "Cannot search: $@";
+    $self->assert_deep_equals([], $uids);
+
+    xlog $self, "the undecodable a-label is searchable as it came";
+    $uids = $talk->search('charset', 'utf-8', 'from',
+                          { Quote => 'xn--zz.example.com' })
+        or die "Cannot search: $@";
+    $self->assert_deep_equals([2], $uids);
+}

--- a/cassandane/tiny-tests/Sieve/redirect_utf8_address
+++ b/cassandane/tiny-tests/Sieve/redirect_utf8_address
@@ -1,0 +1,82 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Read the SMTP telemetry log of the redirect we just did, and return
+# the lines of the conversation.
+#
+sub _smtpclient_telemetry
+{
+    my ($self) = @_;
+
+    my $telemetry_dir =
+        $self->{instance}->get_basedir() . '/conf/log/smtpclient.host';
+    opendir(my $dh, $telemetry_dir) or die "opendir $telemetry_dir: $!";
+
+    my @lines = ();
+
+    while (readdir $dh) {
+        next if not m/^lmtp-/;
+
+        my $telemetry_file = "$telemetry_dir/$_";
+        open(my $fh, '<', $telemetry_file) or die "open $telemetry_file: $!";
+        @lines = <$fh>;
+        close $fh;
+        last;
+    }
+    closedir $dh;
+
+    return @lines;
+}
+
+sub test_redirect_utf8_address
+    :want_smtpdaemon :min_version_3_13
+    ($self)
+{
+    xlog $self, "Install a Sieve script redirecting to a UTF-8 address";
+    $self->{instance}->install_sieve_script(<<EOF
+redirect "info\@grå.org";
+EOF
+    );
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    my @lines = _smtpclient_telemetry($self);
+
+    xlog $self, "MAIL FROM must announce SMTPUTF8, per RFC 6531";
+    my @from = grep { m/MAIL FROM:/ } @lines;
+    $self->assert_num_equals(1, scalar @from);
+    $self->assert_matches(qr/SMTPUTF8/, $from[0]);
+
+    xlog $self, "and the recipient goes out as UTF-8, not punycode";
+    my @rcpt = grep { m/RCPT TO:/ } @lines;
+    $self->assert_num_equals(1, scalar @rcpt);
+    $self->assert_matches(qr/info\@grå\.org/, $rcpt[0]);
+
+    xlog $self, "The message was redirected, so it is not in INBOX";
+    my $talk = $self->{store}->get_client();
+    $talk->select("INBOX");
+    $self->assert_num_equals(0, $talk->get_response_code('exists'));
+}
+
+sub test_redirect_ascii_address_no_smtputf8
+    :want_smtpdaemon :min_version_3_13
+    ($self)
+{
+    xlog $self, "Install a Sieve script redirecting to an ASCII address";
+    $self->{instance}->install_sieve_script(<<EOF
+redirect "example\@example.com";
+EOF
+    );
+
+    xlog $self, "Deliver a message";
+    my $msg = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg);
+
+    xlog $self, "An ASCII envelope stays plain SMTP";
+    my @from = grep { m/MAIL FROM:/ } _smtpclient_telemetry($self);
+    $self->assert_num_equals(1, scalar @from);
+    $self->assert_does_not_match(qr/SMTPUTF8/, $from[0]);
+}

--- a/cunit/parseaddr.testc
+++ b/cunit/parseaddr.testc
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 #include "cunit/unit.h"
 #include "parseaddr.h"
 
@@ -378,6 +379,116 @@ static void test_utf8_domain(void)
     CU_ASSERT_STRING_EQUAL(a->mailbox, "jb");
     CU_ASSERT_STRING_EQUAL(a->domain, "julián.example.com");
     CU_ASSERT_PTR_NULL(a->next);
+
+    parseaddr_free(a);
+}
+
+static void test_alabel_domain(void)
+{
+    struct address *a;
+
+    /* Punycode is for the DNS. What we store, and what anyone above
+     * us sees, is the u-label, so that a search for grå.org finds
+     * this. */
+
+    a = NULL;
+    parseaddr_list("Arnt <arnt@xn--gr-zia.org>", &a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->name, "Arnt");
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "arnt");
+    CU_ASSERT_STRING_EQUAL(a->domain, "grå.org");
+    CU_ASSERT_PTR_NULL(a->next);
+
+    parseaddr_free(a);
+
+    /* every label, not just the first */
+
+    a = NULL;
+    parseaddr_list("info@xn--fsqu00a.xn--fiqs8s", &a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "info");
+    CU_ASSERT_STRING_EQUAL(a->domain, "例子.中国");
+    CU_ASSERT_PTR_NULL(a->next);
+
+    parseaddr_free(a);
+
+    /* a comment makes the output lag behind the input */
+
+    a = NULL;
+    parseaddr_list("\"Gøril\" (at home) <gøril@xn--gr-zia.org>", &a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->name, "Gøril");
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "gøril");
+    CU_ASSERT_STRING_EQUAL(a->domain, "grå.org");
+    CU_ASSERT_PTR_NULL(a->next);
+
+    parseaddr_free(a);
+}
+
+static void test_alabel_domain_grows(void)
+{
+    struct address *a;
+    const char *alabels = "xn--p1b6ci4b4b3a.xn--h2brj9c";
+    const char *ulabels = "उदाहरण.भारत";
+
+    /* The u-label is usually shorter than the a-label, but not
+     * always, and the parse happens in place. Devanagari is one of
+     * the cases that grows, so the address after it must survive the
+     * domain being rewritten. */
+
+    CU_ASSERT(strlen(ulabels) > strlen(alabels));
+
+    a = NULL;
+    parseaddr_list("उदाहरण@xn--p1b6ci4b4b3a.xn--h2brj9c, "
+                   "Gøril <goril@example.com>", &a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_PTR_NULL(a->name);
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "उदाहरण");
+    CU_ASSERT_STRING_EQUAL(a->domain, "उदाहरण.भारत");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a->next);
+
+    CU_ASSERT_STRING_EQUAL(a->next->name, "Gøril");
+    CU_ASSERT_STRING_EQUAL(a->next->mailbox, "goril");
+    CU_ASSERT_STRING_EQUAL(a->next->domain, "example.com");
+    CU_ASSERT_PTR_NULL(a->next->next);
+
+    parseaddr_free(a);
+}
+
+static void test_bad_alabel_domain(void)
+{
+    struct address *a;
+
+    /* An xn-- label that isn't valid punycode is best passed on as it
+     * arrived. */
+
+    a = NULL;
+    parseaddr_list("arnt@xn--.org", &a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "arnt");
+    CU_ASSERT_STRING_EQUAL(a->domain, "xn--.org");
+    CU_ASSERT_PTR_NULL(a->next);
+
+    parseaddr_free(a);
+
+    a = NULL;
+    parseaddr_list("arnt@xn--a.org", &a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->mailbox, "arnt");
+    CU_ASSERT_STRING_EQUAL(a->domain, "xn--a.org");
+    CU_ASSERT_PTR_NULL(a->next);
+
+    parseaddr_free(a);
+
+    /* ... and one bad label doesn't break the good ones */
+
+    a = NULL;
+    parseaddr_list("arnt@xn--gr-zia.org, info@xn--zz.example.com", &a);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a);
+    CU_ASSERT_STRING_EQUAL(a->domain, "grå.org");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(a->next);
+    CU_ASSERT_STRING_EQUAL(a->next->domain, "xn--zz.example.com");
+    CU_ASSERT_PTR_NULL(a->next->next);
 
     parseaddr_free(a);
 }

--- a/cunit/smtpclient.testc
+++ b/cunit/smtpclient.testc
@@ -1,0 +1,52 @@
+#include <stdarg.h>
+#include <stdlib.h>
+#include "cunit/unit.h"
+#include "imap/smtpclient.h"
+
+static void test_addr_needs_utf8(void)
+{
+    CU_ASSERT_EQUAL(smtp_addr_needs_utf8("arnt@example.com"), 0);
+    CU_ASSERT_EQUAL(smtp_addr_needs_utf8("arnt@xn--gr-zia.org"), 0);
+    CU_ASSERT_EQUAL(smtp_addr_needs_utf8(""), 0);
+    CU_ASSERT_EQUAL(smtp_addr_needs_utf8(NULL), 0);
+
+    CU_ASSERT(smtp_addr_needs_utf8("arnt@grå.org"));
+    CU_ASSERT(smtp_addr_needs_utf8("gøril@example.com"));
+    CU_ASSERT(smtp_addr_needs_utf8("उदाहरण@उदाहरण.भारत"));
+    CU_ASSERT(smtp_addr_needs_utf8("例子@例子.中国"));
+}
+
+/* Build an envelope from 'from' and the NULL-terminated rcpts, ask
+ * whether it needs SMTPUTF8, and clean up. */
+static int needs_utf8(const char *from, ...)
+{
+    smtp_envelope_t env = SMTP_ENVELOPE_INITIALIZER;
+    const char *rcpt;
+    va_list ap;
+    int r;
+
+    smtp_envelope_set_from(&env, from);
+
+    va_start(ap, from);
+    while ((rcpt = va_arg(ap, const char *))) {
+        smtp_envelope_add_rcpt(&env, rcpt);
+    }
+    va_end(ap);
+
+    r = smtp_envelope_needs_utf8(&env);
+    smtp_envelope_fini(&env);
+
+    return r;
+}
+
+static void test_envelope_needs_utf8(void)
+{
+    CU_ASSERT(needs_utf8("arnt@example.com", "gøril@example.com", NULL));
+    CU_ASSERT(needs_utf8("arnt@grå.org", "info@example.com", NULL));
+    CU_ASSERT(needs_utf8("arnt@example.com", "info@example.com",
+                         "info@grå.org", "arnt@example.com", NULL));
+    CU_ASSERT_EQUAL(needs_utf8("arnt@xn--gr-zia.org", "info@example.com",
+                               "info@xn--fsqu00a.xn--fiqs8s", NULL), 0);
+}
+
+/* vim: set ft=c: */

--- a/imap/deliver.c
+++ b/imap/deliver.c
@@ -53,6 +53,7 @@ static struct protocol_t lmtp_protocol =
           { "PIPELINING", CAPA_PIPELINING },
           { "IGNOREQUOTA", CAPA_IGNOREQUOTA },
           { "TRACE", CAPA_TRACE },
+          { "SMTPUTF8", CAPA_SMTPUTF8 },
           { NULL, 0 } } },
       { "STARTTLS", "220", "454", 0 },
       { "AUTH", 512, 0, "235", "5", "334 ", "*", NULL, 0 },

--- a/imap/imap_err.et
+++ b/imap/imap_err.et
@@ -119,6 +119,9 @@ ec IMAP_MESSAGE_CONTAINSNL,
 ec IMAP_MESSAGE_CONTAINS8BIT,
    "Message contains non-ASCII characters in headers"
 
+ec IMAP_REMOTE_NO_SMTPUTF8,
+   "Remote server does not support SMTPUTF8"
+
 ec IMAP_MESSAGE_BADHEADER,
    "Message contains invalid header"
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6220,7 +6220,7 @@ static void cmd_search(const char *tag, const char *cmd)
         break;
     }
 
-    /* RFC 9855, Section 3: MUST reject SEARCH with a charset specification */ 
+    /* RFC 9755, Section 3: MUST reject SEARCH with a charset specification */
     if (!(client_capa & CAPA_UTF8_ACCEPT)) {
         state |= GETSEARCH_CHARSET_KEYWORD;
     }
@@ -8101,7 +8101,7 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location, 
         rock.newuser = newuser;
         rock.partition = location;
         rock.rename_user = rename_user;
-            rock.noisy = noisy;
+        rock.noisy = noisy;
 
         /* Check mboxnames to ensure we can write them all BEFORE we start */
         r = mboxlist_allmbox(ombn, checkmboxname, &rock, 0);

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -136,6 +136,7 @@ static struct protocol_t lmtp_protocol =
           { "PIPELINING", CAPA_PIPELINING },
           { "IGNOREQUOTA", CAPA_IGNOREQUOTA },
           { "TRACE", CAPA_TRACE },
+          { "SMTPUTF8", CAPA_SMTPUTF8 },
           { NULL, 0 } } },
       { "STARTTLS", "220", "454", 0 },
       { "AUTH", 512, 0, "235", "5", "334 ", "*", NULL, 0 },

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -401,7 +401,6 @@ static char *parseautheq(char **strp)
 static char *parseaddr(char *s)
 {
     char *p;
-    int lmtp_strict_rfc2821 = config_getswitch(IMAPOPT_LMTP_STRICT_RFC2821);
 
     p = s;
 
@@ -439,15 +438,9 @@ static char *parseaddr(char *s)
             if (*p == '\\') {
                 if (!*++p) return 0;
             }
-            else {
-                if (*p & 128 && !lmtp_strict_rfc2821) {
-                    /* this prevents us from becoming a backscatter
-                       source if our MTA allows 8bit in local-part
-                       of addresses. */
-                    *p = 'X';
-                }
-                if (*p <= ' ' || (*p & 128) ||
-                    strchr("<>()[]\\,;:\"", *p)) return 0;
+            else if ((*(unsigned char *)p <= ' ' && *p) ||
+                     strchr("<>()[]\\,;:\"", *p)) {
+                return 0;
             }
             p++;
         }
@@ -462,7 +455,8 @@ static char *parseaddr(char *s)
             if (*p++ != ']') return 0;
         }
         else {
-            while (Uisalnum(*p) || *p == '.' || *p == '-') p++;
+            while (Uisalnum(*p) || *p == '.' || *p == '-' ||
+                   *(unsigned char *)p >= 128) p++;
         }
     }
 
@@ -1161,6 +1155,7 @@ void lmtpmode(struct lmtp_func *func,
 
               prot_printf(pout, "250-%s\r\n"
                                 "250-8BITMIME\r\n"
+                                "250-SMTPUTF8\r\n"
                                 "250-ENHANCEDSTATUSCODES\r\n"
                                 "250-PIPELINING\r\n"
                                 "250-SIZE %" PRIu64 "\r\n",
@@ -1251,6 +1246,11 @@ void lmtpmode(struct lmtp_func *func,
                         break;
 
                     case 's': case 'S':
+                        if (strncasecmp(tmp, "smtputf8", 8) == 0) {
+                            tmp += 8;
+                            break;
+                        }
+
                         if (strncasecmp(tmp, "size=", 5) != 0) {
                             goto badparam;
                         }

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -873,6 +873,18 @@ static int reset_saslconn(sasl_conn_t **conn)
     return SASL_OK;
 }
 
+/*
+ * Do we accept UTF-8? This is the same question imapd answers by
+ * advertising UTF8=ACCEPT, and it has to have the same answer: what
+ * arrives here is what IMAP serves later, so a server that will munge
+ * or reject 8-bit data has no business asking an MTA to send it.
+ */
+static int lmtp_utf8_allowed(void)
+{
+    return !(config_getswitch(IMAPOPT_REJECT8BIT) ||
+             config_getswitch(IMAPOPT_MUNGE8BIT));
+}
+
 void lmtpmode(struct lmtp_func *func,
               struct protstream *pin,
               struct protstream *pout,
@@ -1157,11 +1169,14 @@ void lmtpmode(struct lmtp_func *func,
 
               prot_printf(pout, "250-%s\r\n"
                                 "250-8BITMIME\r\n"
-                                "250-SMTPUTF8\r\n"
                                 "250-ENHANCEDSTATUSCODES\r\n"
                                 "250-PIPELINING\r\n"
                                 "250-SIZE %" PRIu64 "\r\n",
                           config_servername, max_msgsize);
+
+              if (lmtp_utf8_allowed()) {
+                  prot_printf(pout, "250-SMTPUTF8\r\n");
+              }
 
               if (tls_starttls_enabled() && !cd.starttls_done &&
                   cd.authenticated == NOAUTH) {
@@ -1249,6 +1264,8 @@ void lmtpmode(struct lmtp_func *func,
 
                     case 's': case 'S':
                         if (strncasecmp(tmp, "smtputf8", 8) == 0) {
+                            /* we only take what we advertised */
+                            if (!lmtp_utf8_allowed()) goto badparam;
                             tmp += 8;
                             break;
                         }

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -47,6 +47,7 @@
 #include "imap/mupdate_err.h"
 
 #include "lmtpengine.h"
+#include "smtpclient.h"
 #include "tls.h"
 #include "telemetry.h"
 
@@ -169,6 +170,7 @@ static void send_lmtp_error(struct protstream *pout, int r, strarray_t *resp)
     case IMAP_MESSAGE_CONTAINS8BIT:
     case IMAP_MESSAGE_BADHEADER:
     case IMAP_MESSAGE_NOBLANKLINE:
+    case IMAP_REMOTE_NO_SMTPUTF8:
         code = LMTP_MESSAGE_INVALID;
         break;
 
@@ -1688,6 +1690,7 @@ int lmtp_runtxn(struct backend *conn, struct lmtp_txn *txn)
     int j, code, r = 0;
     char buf[8192];
     int onegood;
+    int needs_utf8;
     const char *traceid = trace_id();
 
     assert(conn && txn);
@@ -1712,6 +1715,20 @@ int lmtp_runtxn(struct backend *conn, struct lmtp_txn *txn)
         }
     }
 
+    /* does this envelope need SMTPUTF8? */
+    needs_utf8 = smtp_addr_needs_utf8(txn->from);
+    for (j = 0; !needs_utf8 && j < txn->rcpt_num; j++) {
+        needs_utf8 = smtp_addr_needs_utf8(txn->rcpt[j].addr);
+    }
+    if (needs_utf8 && !CAPA(conn, CAPA_SMTPUTF8)) {
+        /* Very odd: we advertised SMTPUTF8 but the backend doesn't? */
+        syslog(LOG_ERR, "lmtp_runtxn: UTF-8 envelope but no SMTPUTF8 from %s",
+               conn->hostname);
+        code = 550;
+        r = 0;
+        goto failall;
+    }
+
     /* mail from */
     if (!txn->from) {
         prot_printf(conn->out, "MAIL FROM:<>");
@@ -1723,6 +1740,9 @@ int lmtp_runtxn(struct backend *conn, struct lmtp_txn *txn)
     if (CAPA(conn, CAPA_AUTH)) {
         prot_printf(conn->out, " AUTH=%s",
                     txn->auth && txn->auth[0] ? txn->auth : "<>");
+    }
+    if (needs_utf8) {
+        prot_printf(conn->out, " SMTPUTF8");
     }
     prot_printf(conn->out, "\r\n");
     r = getlastresp(buf, sizeof(buf)-1, &code, conn->in, NULL);

--- a/imap/lmtpengine.h
+++ b/imap/lmtpengine.h
@@ -107,6 +107,7 @@ enum {
     CAPA_PIPELINING     = (1 << 3),
     CAPA_IGNOREQUOTA    = (1 << 4),
     CAPA_TRACE          = (1 << 5),
+    CAPA_SMTPUTF8       = (1 << 6),
 };
 
 struct lmtp_txn {

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1908,7 +1908,9 @@ EXPORTED int mboxname_policycheck(const char *name)
             name++;             /* Skip over terminating '-' */
         }
         else {
-            if (!(strchr(GOODCHARS, *name) || (hasdom && *name == '!')))
+            if (!(strchr(GOODCHARS, *name) ||
+                  *(unsigned char *)name >= 128 ||
+                  (hasdom && *name == '!')))
                 return IMAP_MAILBOX_BADNAME;
             name++;
             sawutf7 = 0;

--- a/imap/smtpclient.c
+++ b/imap/smtpclient.c
@@ -50,6 +50,7 @@ struct smtpclient {
     char *by;
     char *jmapid;
     unsigned long msgsize;
+    int smtputf8;
     smtp_resp_t resp;
 };
 
@@ -62,6 +63,7 @@ enum {
     SMTPCLIENT_CAPA_PRIORITY  = (1 << 8),
     SMTPCLIENT_CAPA_SENDCHECK = (1 << 9),
     SMTPCLIENT_CAPA_JMAPID    = (1 << 10),
+    SMTPCLIENT_CAPA_SMTPUTF8  = (1 << 11),
 };
 
 static const char *smtpclient_ehlo_hostname = NULL;
@@ -82,6 +84,7 @@ static struct protocol_t smtp_protocol =
           { "MT-PRIORITY", SMTPCLIENT_CAPA_PRIORITY },
           { "SENDCHECK", SMTPCLIENT_CAPA_SENDCHECK },
           { "JMAPIDENTITY", SMTPCLIENT_CAPA_JMAPID },
+          { "SMTPUTF8", SMTPCLIENT_CAPA_SMTPUTF8 },
           { NULL, 0 } } },
       { "STARTTLS", "220", "454", 0 },
       { "AUTH", 512, 0, "235", "5", "334 ", "*", NULL, 0 },
@@ -509,7 +512,8 @@ static void smtp_params_set_extra(ptrarray_t *params, ptrarray_t *extra,
     if (i == params->count) {
         smtp_param_t *param = xzmalloc(sizeof(smtp_param_t));
         param->key = xstrdup(key);
-        param->val = xstrdup(val);
+        /* SMTPUTF8 has no value */
+        param->val = xstrdupnull(val);
         ptrarray_add(extra, param);
     }
 }
@@ -526,10 +530,46 @@ static void smtp_params_fini(ptrarray_t *params)
     ptrarray_fini(params);
 }
 
+/* Does this envelope address need SMTPUTF8? */
+EXPORTED int smtp_addr_needs_utf8(const char *addr)
+{
+    const unsigned char *p = (const unsigned char *) addr;
+
+    if (!p) return 0;
+
+    for ( ; *p; p++) {
+        if (*p >= 128) return 1;
+    }
+    return 0;
+}
+
+/*
+ * Does this envelope need SMTPUTF8?
+ *
+ * Strictly speaking, a header field with UTF8 should also trigger it,
+ * but that's tricky to implement and readers are used to just-send-8
+ * anyway. So we just look at the envelope.
+ */
+EXPORTED int smtp_envelope_needs_utf8(smtp_envelope_t *env)
+{
+    int i;
+
+    if (smtp_addr_needs_utf8(env->from.addr)) return 1;
+
+    for (i = 0; i < ptrarray_size(&env->rcpts); i++) {
+        smtp_addr_t *addr = ptrarray_nth(&env->rcpts, i);
+        if (smtp_addr_needs_utf8(addr->addr)) return 1;
+    }
+    return 0;
+}
+
 /* Write a MAIL FROM command for address addr. */
 static int smtpclient_from(smtpclient_t *sm, smtp_addr_t *addr)
 {
     ptrarray_t extra_params = PTRARRAY_INITIALIZER;
+    if (sm->smtputf8) {
+        smtp_params_set_extra(&addr->params, &extra_params, "SMTPUTF8", NULL);
+    }
     if (sm->authid && CAPA(sm->backend, CAPA_AUTH)) {
         smtp_params_set_extra(&addr->params, &extra_params, "AUTH", sm->authid);
     }
@@ -717,6 +757,15 @@ static int smtpclient_sendenv(smtpclient_t *sm, smtp_envelope_t *env)
 
     r = validate_envelope(env);
     if (r) goto done;
+
+    sm->smtputf8 = smtp_envelope_needs_utf8(env);
+    if (sm->smtputf8 && !CAPA(sm->backend, SMTPCLIENT_CAPA_SMTPUTF8)) {
+        syslog(LOG_ERR, "smtpclient: sessionid=<%s> "
+               "UTF-8 envelope but no SMTPUTF8 from %s",
+               session_id(), sm->backend->hostname);
+        r = IMAP_REMOTE_NO_SMTPUTF8;
+        goto done;
+    }
 
     r = smtpclient_from(sm, &env->from);
     if (r) goto done;

--- a/imap/smtpclient.h
+++ b/imap/smtpclient.h
@@ -36,6 +36,11 @@ typedef struct {
 /* The empty SMTP envelope */
 #define SMTP_ENVELOPE_INITIALIZER { { NULL, PTRARRAY_INITIALIZER, 0 }, PTRARRAY_INITIALIZER }
 
+/* Return non-zero if addr, or any address in env, needs SMTPUTF8
+ * as defined in RFC 6531. */
+extern int smtp_addr_needs_utf8(const char *addr);
+extern int smtp_envelope_needs_utf8(smtp_envelope_t *env);
+
 /* Return non-zero if val is a valid esmtp-keyword
  * as defined in RFC 5321, section 4.1.2. */
 extern int smtp_is_valid_esmtp_keyword(const char *val);

--- a/lib/auth_mboxgroups.c
+++ b/lib/auth_mboxgroups.c
@@ -61,8 +61,11 @@ static int mymemberof(const struct auth_state *auth_state, const char *identifie
  * ?    it just scares me
  * ctrl chars, DEL
  *      can't send them as IMAP characters in plain folder names, I think
- * 80-FF forbidden because you can't send them in IMAP anyway
- *       (and they're forbidden as folder names). (This could be fixed.)
+ *
+ * 80-FF are permitted because of UTF8=ACCEPT and IMAP4rev2, and
+ * classified as alphas here because most of them may be parts of
+ * alphas. Most of them may also be nonalpha; this really warrants
+ * consideration on a per-code-point basis.
  *
  * + and - are *allowed* although '+' is probably used for userid+detail
  * subaddressing and qmail users use '-' for subaddressing.
@@ -83,15 +86,15 @@ static const char allowedchars[256] = {
     1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 60-6F */
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 0, /* 70-7F */
 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 80-8F */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 90-9F */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* A0-AF */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* B0-BF */
 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* C0-CF */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* D0-DF */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* E0-EF */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0  /* F0-FF */
 };
 // clang-format: on
 

--- a/lib/parseaddr.c
+++ b/lib/parseaddr.c
@@ -8,6 +8,8 @@
 #include <string.h>
 
 #include "parseaddr.h"
+#include "charset.h"
+#include "stristr.h"
 #include "xmalloc.h"
 #include "util.h"
 
@@ -23,7 +25,8 @@ static int parseaddr_phrase(char **inp,
 static int parseaddr_domain(char **inp,
                             const char **domainp,
                             const char **commmentp,
-                            int *invalid);
+                            int *invalid,
+                            const char *bufend);
 static int parseaddr_route(char **inp, const char **routep);
 
 /*
@@ -35,7 +38,9 @@ EXPORTED void parseaddr_list(const char *str, struct address **addrp)
     char *s;
     int ingroup = 0;
     char *freeme;
+    const char *bufend;
     int tok = ' ', invalid = 0;
+    size_t len, size;
     const char *phrase, *route, *mailbox, *domain, *comment;
 
     /* Skip down to the tail */
@@ -43,7 +48,15 @@ EXPORTED void parseaddr_list(const char *str, struct address **addrp)
         addrp = &(*addrp)->next;
     }
 
-    s = freeme = xstrdup(str);
+    /* The parse happens in place, so an a-label that turns into a
+       longer u-label needs room to grow even if it very seldom grows.
+       See the comment in parseaddr_to_ulabels. */
+    len = strlen(str);
+    size = stristr(str, "xn--") ? 4 * len + 1 : len + 1;
+    freeme = xmalloc(size);
+    memcpy(freeme, str, len + 1);
+    s = freeme;
+    bufend = freeme + size;
 
     while (tok) {
         tok = parseaddr_phrase(&s, &phrase, ingroup ? ",@<;" : ",@<:");
@@ -66,7 +79,7 @@ EXPORTED void parseaddr_list(const char *str, struct address **addrp)
             continue;
 
         case '@':
-            tok = parseaddr_domain(&s, &domain, &comment, &invalid);
+            tok = parseaddr_domain(&s, &domain, &comment, &invalid, bufend);
             parseaddr_append(&addrp, comment, 0, phrase, domain, &freeme, invalid);
             if (tok == ';') {
                 parseaddr_append(&addrp, 0, 0, 0, 0, &freeme, invalid);
@@ -93,7 +106,7 @@ EXPORTED void parseaddr_list(const char *str, struct address **addrp)
                         continue;
                     }
                 }
-                tok = parseaddr_domain(&s, &domain, 0, &invalid);
+                tok = parseaddr_domain(&s, &domain, 0, &invalid, bufend);
                 parseaddr_append(&addrp, phrase, route, mailbox, domain,
                                  &freeme, invalid);
                 while (tok && tok != '>') tok = *s++;
@@ -264,6 +277,58 @@ fail:
     return 0;
 }
 
+/* Does any label of 'domain' look like an a-label? */
+static int parseaddr_has_alabel(const char *domain)
+{
+    while (domain) {
+        if (!strncasecmp(domain, "xn--", 4)) return 1;
+        domain = strchr(domain, '.');
+        if (domain) domain++;
+    }
+    return 0;
+}
+
+/*
+ * Convert the a-labels of the parsed, NUL-terminated 'domain' to
+ * u-labels, in place. Punycode belongs in the DNS; everything above
+ * this stores and shows the u-label, so that a search for grå.org
+ * finds mail from xn--gr-zia.org.
+ *
+ * A domain that ICU won't decode is left exactly as it arrived, and so
+ * is stored that way. This isn't ideal, but I don't see any better way to
+ * handle errors like example@xn--zz.example.com.
+ */
+static void parseaddr_to_ulabels(char *domain, char **tailp,
+                                 const char *bufend)
+{
+    char *tail = *tailp;
+    char *utf8;
+    size_t need, taillen;
+
+    if (!parseaddr_has_alabel(domain)) return;
+
+    utf8 = charset_idna_to_utf8(domain);
+    if (!utf8) return;
+
+    /* The u-label form may be longer than the a-label form, in which
+       case the not yet parsed remainder has to move out of the way. */
+    need = strlen(utf8);
+    if (domain + need >= tail) {
+        size_t extra = domain + need + 1 - tail;
+        taillen = strlen(tail);
+        if (tail + taillen + 1 + extra > bufend) {
+            /* parseaddr_list() sizes the buffer so this cannot happen */
+            free(utf8);
+            return;
+        }
+        memmove(tail + extra, tail, taillen + 1);
+        *tailp = tail + extra;
+    }
+
+    memcpy(domain, utf8, need + 1);
+    free(utf8);
+}
+
 /*
  * Parse a domain.  If 'commentp' is non-nil, parses any trailing comment.
  * If the domain is invalid, set invalid to non-zero.
@@ -271,7 +336,8 @@ fail:
 static int parseaddr_domain(char **inp,
                             const char **domainp,
                             const char **commentp,
-                            int *invalid)
+                            int *invalid,
+                            const char *bufend)
 {
     u_char c;
     char *src = *inp;
@@ -321,8 +387,17 @@ static int parseaddr_domain(char **inp,
             if (commentp) *commentp = 0;
         }
         else if (!Uisspace(c)) {
+            char *tail;
+
             if (dst > *domainp && dst[-1] == '.') dst--;
             *dst = '\0';
+
+            /* src has stepped past the terminating character, which at
+               the end of the string is the NUL, with nothing after. */
+            tail = c ? src : src - 1;
+            parseaddr_to_ulabels((char *) *domainp, &tail, bufend);
+            src = tail;
+
             *inp = src;
             return c;
         }

--- a/sieve/test.c
+++ b/sieve/test.c
@@ -42,6 +42,7 @@
 #ifdef WITH_JMAP
 #include "imap/jmap_mail_query.h"
 #endif
+#include "imap/ical_support.h"
 
 static char vacation_answer;
 


### PR DESCRIPTION
This also adds tests and makes them pass. Most notably, a test that a message can arrive via LMTP and then matches a UTF8 UID SEARCH, which required making conversations.db store UTF8 always.