### PR TITLE
http_dav: guard against NULL strchr results in eval_if

### DIFF
--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -937,6 +937,9 @@ static bool eval_if(const char *hdr, struct meth_params *params,
 
             tag = ++list;
             list = strchr(tag, '>');
+            /* A tagged-list with no closing '>' is malformed; bail rather
+             * than dereferencing NULL. */
+            if (!list) break;
             *list++ = '\0';
 
             mailbox = NULL;
@@ -1054,9 +1057,10 @@ static bool eval_if(const char *hdr, struct meth_params *params,
             islocked = tgt_islocked;
         }
 
+        /* With no '(' there is no condition list, don't eval_list it. */
         list = strchr(list, '(');
 
-        ret |= eval_list(list, mailbox, etag, lock_token, islocked);
+        if (list) ret |= eval_list(list, mailbox, etag, lock_token, islocked);
 
         if (davdb) params->davdb.close_db(davdb);
         mailbox_close(&my_mailbox);


### PR DESCRIPTION
If-header parsing uses strchr() to find the end of a tagged-list token and the start of a condition list, then uses both results without checking them.  Bail out of the tagged-list parse when there is no closing '>', and skip eval_list() when there is no condition list.