### PR TITLE
imapd/pop3d: account for the trailing NUL in the canon_user bounds check

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -661,7 +661,7 @@ static int imapd_canon_user(sasl_conn_t *conn, void *context,
         /* If we're only doing the authzid, put back the magic plus
            in case its used in the challenge/response calculation */
         n = strlen(imapd_magicplus);
-        if (*out_ulen + n > out_max) {
+        if (*out_ulen + n >= out_max) {
             sasl_seterror(conn, 0, "buffer overflow while canonicalizing");
             r = SASL_BUFOVER;
         }

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -222,7 +222,7 @@ static int popd_canon_user(sasl_conn_t *conn, void *context,
         /* If we're only doing the authzid, put back the subfolder
            in case its used in the challenge/response calculation */
         n = strlen(popd_subfolder);
-        if (*out_ulen + n > out_max) {
+        if (*out_ulen + n >= out_max) {
             sasl_seterror(conn, 0, "buffer overflow while canonicalizing");
             r = SASL_BUFOVER;
         }


### PR DESCRIPTION
When reinserting the magic-plus suffix into the canonicalized user, imapd_canon_user() and popd_canon_user() picked the wrong operator.