### PR TITLE
lmtpengine: use OR when accumulating xtext nibbles in parseautheq

### DIFF
--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -2047,6 +2047,11 @@ sub deliver
         push(@cmd, '--trace-id', $params{trace_id});
     }
 
+    if (defined $params{auth_id})
+    {
+        push(@cmd, '-a', $params{auth_id});
+    }
+
     my @users;
     if (defined $params{users})
     {

--- a/cassandane/tiny-tests/Delivery/autheq_xtext_decode
+++ b/cassandane/tiny-tests/Delivery/autheq_xtext_decode
@@ -1,0 +1,41 @@
+#!perl
+use Cassandane::Tiny;
+
+# When LMTP delivery carries "MAIL FROM ... AUTH=<identity>", the identity is
+# xtext-encoded per RFC 3461/4954: a "+XX" sequence is a hex escape for one
+# byte.  lmtpd decodes it and records the result in the Received: header as
+# "(authenticated user=...)".  A decoding bug once turned every "+XX" escape
+# into a NUL byte, truncating the identity at the first escape -- so this case
+# pins down that the escapes round-trip to the bytes they encode.
+
+sub test_autheq_xtext_decode ($self)
+{
+    # "fred+2Bbar" is xtext for "fred+bar"; "+2B" is the escape for '+'.
+    my $wire     = 'fred+2Bbar'; # the AUTH= value as sent on the wire
+    my $expected = 'fred+bar';   # what it should decode to
+
+    $self->{store}->set_fetch_attributes(qw(uid));
+    $self->{store}->set_folder('INBOX');
+
+    my $msg = $self->{gen}->generate(subject => "autheq $wire", uid => 1);
+    my $ret = $self->{instance}->deliver(
+        $msg,
+        user    => "cassandane",
+        auth_id => $wire,
+    );
+    $self->assert_num_equals(0, $ret);
+
+    my @received;
+    $self->{store}->read_begin();
+    while (my $got = $self->{store}->read_message()) {
+        push @received, @{ $got->get_headers('received') // [] };
+    }
+    $self->{store}->read_end();
+
+    $self->assert_num_not_equals(0, scalar @received);
+    $self->assert_num_equals(
+        1,
+        scalar(grep { /\(authenticated user=\Q$expected\E / } @received),
+        "no Received header records authenticated user=$expected",
+    );
+}

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -356,9 +356,9 @@ static char *parseautheq(char **strp)
             for (lup=0;lup<2;lup++)
             {
                 if ((*s>='0') && (*s<='9'))
-                    (*str) = (*str) & (*s - '0');
+                    (*str) = (*str) | (*s - '0');
                 else if ((*s>='A') && (*s<='F'))
-                    (*str) = (*str) & (*s - 'A' + 10);
+                    (*str) = (*str) | (*s - 'A' + 10);
                 else {
                     free(ret);
                     *strp = s;


### PR DESCRIPTION
parseautheq() builds each decoded byte from two hex nibbles but combined them with bitwise AND rather than OR, so every "+XX" escape in an LMTP AUTH= parameter decoded to a NUL byte.