### PR TITLE
imapd: replace inappropriate use of named constant

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -10899,11 +10899,11 @@ static int _metadata_to_annotate(const strarray_t *entries,
         }
         strarray_append(newe, entry);
         if (depth == 1) {
-            strncat(entry, "/%", MAX_MAILBOX_NAME);
+            strncat(entry, "/%", sizeof(entry) - strlen(entry) - 1);
             strarray_append(newe, entry);
         }
         else if (depth == -1) {
-            strncat(entry, "/*", MAX_MAILBOX_NAME);
+            strncat(entry, "/*", sizeof(entry) - strlen(entry) - 1);
             strarray_append(newe, entry);
         }
     }


### PR DESCRIPTION
strncat's size parameter is the space available in the destination, not the destination's total length.  Pass the space that remains.