### PR TITLE
jmap: charge storage quota in cases previously missed

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmailSubmission.pm
@@ -14,7 +14,7 @@ use MIME::Base64 qw(encode_base64);
 use Cwd qw(abs_path getcwd);
 use URI;
 
-use base qw(Cassandane::Cyrus::TestCase);
+use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
 
 use charnames ':full';

--- a/cassandane/tiny-tests/JMAPEmail/email_copy_quota_storage
+++ b/cassandane/tiny-tests/JMAPEmail/email_copy_quota_storage
@@ -1,0 +1,57 @@
+#!perl
+use Cassandane::Tiny;
+
+# When copying from account A to B, we should treat the write to B like an
+# append: it must not cause B to exceed its quota usage.
+sub test_email_copy_quota_storage ($self)
+{
+    my $jmap = $self->{jmap};
+    my $admintalk = $self->{adminstore}->get_client();
+
+    xlog $self, "Tighten cassandane's storage quota to 1 KiB";
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 1);  # 1 * 1024 bytes
+
+    xlog $self, "Create otheruser and grant cassandane lookup/read on it";
+
+    my $other_user = $self->{instance}->create_user('other');
+    my $other_inbox = $other_user->mailboxes->inbox;
+    $other_inbox->share_with(cassandane => [ qw(mayRead) ]);
+
+    xlog $self, "Land a >1 KiB message in other's INBOX via IMAP";
+
+    my $email = $other_inbox->new_email({
+      body_str => 'X' x 4096, # 4 KiB is more than the 1 KiB quota!
+    });
+
+    xlog $self, "Find cassandane's INBOX id";
+    my $cass_inbox_id = $self->default_user->mailboxes->inbox->id;
+
+    xlog $self, "Email/copy from other -> cassandane (over quota)";
+    my $res = $jmap->request([
+        ['Email/copy', {
+            fromAccountId => 'other',
+            accountId => 'cassandane',
+            create => {
+                copy => {
+                    id => $email->id,
+                    mailboxIds => {
+                        $cass_inbox_id => JSON::true,
+                    },
+                },
+            },
+        } ],
+    ]);
+
+    my $res_arg = $res->single_sentence('Email/copy')->arguments;
+    $self->assert_cmp_deeply(
+      superhashof({
+        created => any(undef, {}),
+        notCreated => {
+          copy => superhashof({ type => 'overQuota' }),
+        },
+      }),
+      $res_arg,
+      "can't copy email, get overQuota",
+    );
+}

--- a/cassandane/tiny-tests/JMAPEmailSubmission/emailsubmission_futurerelease_quota_storage
+++ b/cassandane/tiny-tests/JMAPEmailSubmission/emailsubmission_futurerelease_quota_storage
@@ -1,0 +1,62 @@
+#!perl
+use Cassandane::Tiny;
+
+# A futurerelease EmailSubmission stages a full copy of the message into the
+# submission collection.  That append must be charged against the user's
+# storage quota; otherwise an over-quota user can bypass the limit by
+# scheduling sends.
+sub test_emailsubmission_futurerelease_quota_storage
+    :min_version_3_1 :needs_component_calalarmd
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+    xlog $self, "Land a >1 KiB message in cassandane's INBOX (quota unset)";
+    $self->make_message("foo", body => 'X' x 4096) or die;
+
+    xlog $self, "Discover the identity and email ids";
+    my $res = $jmap->CallMethods([
+        ['Identity/get', {}, 'R0'],
+        ['Email/query',  {}, 'R1'],
+    ]);
+    my $identityid = $res->[0][1]->{list}[0]->{id};
+    my $emailid    = $res->[1][1]->{ids}[0];
+    $self->assert_not_null($identityid);
+    $self->assert_not_null($emailid);
+
+    xlog $self, "Tighten cassandane's storage quota to 1 KiB";
+    $self->set_quotaroot('user.cassandane');
+    $self->set_quotalimits(storage => 1);  # 1 * 1024 bytes
+
+    xlog $self, "Schedule a futurerelease submission (over quota)";
+    $res = $jmap->CallMethods([
+        ['EmailSubmission/set', {
+            create => {
+                'sub1' => {
+                    identityId => $identityid,
+                    emailId    => $emailid,
+                    envelope   => {
+                        mailFrom => {
+                            email => 'cassandane@local',
+                            parameters => {
+                                holdfor => "30",
+                            },
+                        },
+                        rcptTo => [ { email => 'rcpt@local' } ],
+                    },
+                },
+            },
+        }, 'R1'],
+    ]);
+
+    $self->assert_cmp_deeply(
+      superhashof({
+        created    => any(undef, {}),
+        notCreated => {
+          sub1 => superhashof({ type => 'overQuota' }),
+        },
+      }),
+      $res->[0][1],
+      "futurerelease submission was rejected with overQuota",
+    );
+}

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -8803,8 +8803,26 @@ static int _copy_msgrecords(struct auth_state *authstate,
     int r;
     int nolink = !config_getswitch(IMAPOPT_SINGLEINSTANCESTORE);
 
+    /* When the source and destination live under different quota roots
+     * -- e.g. a cross-account JMAP Email/copy -- we have to charge the
+     * destination for the bytes we're about to land. */
+    quota_t qdiffs[QUOTA_NUMRESOURCES] = QUOTA_DIFFS_DONTCARE_INITIALIZER;
+    quota_t *qptr = NULL;
+    if (strcmpsafe(mailbox_quotaroot(src), mailbox_quotaroot(dst)) != 0) {
+        qdiffs[QUOTA_STORAGE] = 0;
+        qdiffs[QUOTA_MESSAGE] = ptrarray_size(msgrecs);
+        int i;
+        for (i = 0; i < ptrarray_size(msgrecs); i++) {
+            msgrecord_t *mr = ptrarray_nth(msgrecs, i);
+            uint32_t size = 0;
+            msgrecord_get_size(mr, &size);
+            qdiffs[QUOTA_STORAGE] += size;
+        }
+        qptr = qdiffs;
+    }
+
     r = append_setup_mbox(&as, dst, user_id, authstate,
-                 aclcheck, NULL, namespace, 0, EVENT_MESSAGE_COPY);
+                 aclcheck, qptr, namespace, 0, EVENT_MESSAGE_COPY);
     if (r) goto done;
 
     r = append_copy(src, &as, msgrecs, nolink,

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -339,6 +339,8 @@ static int store_submission(jmap_req_t *req, struct mailbox *mailbox,
     int r;
     struct timespec internaldate = { holduntil, 0 };
     struct timespec now;
+    quota_t qdiffs[QUOTA_NUMRESOURCES] = QUOTA_DIFFS_DONTCARE_INITIALIZER;
+    quota_t *qptr = NULL;
 
     cyrus_gettime(CLOCK_REALTIME, &now);
 
@@ -411,11 +413,22 @@ static int store_submission(jmap_req_t *req, struct mailbox *mailbox,
         goto done;
     }
 
+    /* A futurerelease submission stages a real copy of the message into
+     * the submission collection; charge the user's quota for it.  The
+     * non-futurerelease cases either insta-expunge the record or stage
+     * only the small JMAP_SUBMISSION_HDR header, so we keep the
+     * historical behavior of skipping the quota check there. */
+    if (holduntil) {
+        qdiffs[QUOTA_STORAGE] = ftell(f);
+        qdiffs[QUOTA_MESSAGE] = 1;
+        qptr = qdiffs;
+    }
+
     fclose(f);
 
     /* Prepare to append the message to the mailbox */
     r = append_setup_mbox(&as, mailbox, httpd_userid, httpd_authstate,
-                          0, /*quota*/NULL, 0, 0, /*event*/0);
+                          0, qptr, 0, 0, /*event*/0);
     if (r) {
         syslog(LOG_ERR, "append_setup(%s) failed: %s",
                mailbox_name(mailbox), error_message(r));


### PR DESCRIPTION
_copy_msgrecords() and store_submission() both called append_setup_mbox() with NULL for the quota array, so neither a cross-quotaroot Email/copy nor a futurerelease submission's staged copy was quota-checked.  Pass real qdiffs in both, mirroring what IMAP COPY already does.