### PR TITLE
imapd: track real CATENATE TEXT/UTF8 size in totalsize

### DIFF
--- a/cassandane/tiny-tests/IMAPLimits/maxmessagesize_catenate_text
+++ b/cassandane/tiny-tests/IMAPLimits/maxmessagesize_catenate_text
@@ -1,0 +1,23 @@
+#!perl
+use Cassandane::Tiny;
+
+# If you can't APPEND a message because it's too long, you shouldn't be able to
+# APPEND it via CATENATE either!
+
+sub test_maxmessagesize_catenate_text ($self)
+{
+    my $talk  = $self->{store}->get_client();
+    my $tag   = $talk->{CmdId}++;
+
+    my $payload = ('X' x 58) . "\x0d\x0a";
+
+    my $cmd = "$tag APPEND INBOX CATENATE ("
+            . "TEXT {60+}\r\n$payload "
+            . "TEXT {60+}\r\n$payload"
+            . ")\r\n";
+
+    $talk->_imap_socket_out($cmd);
+
+    $self->assert_no_toobig($talk);
+    $self->assert_bye_toobig;
+}

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -3886,6 +3886,7 @@ static int catenate_text(const char *tag, FILE *f, size_t maxsize,
     int c;
     static struct buf arg;
     unsigned size = 0;
+    unsigned literal_size;
     char buf[4096+1];
     unsigned n;
     int r;
@@ -3896,6 +3897,8 @@ static int catenate_text(const char *tag, FILE *f, size_t maxsize,
     r = getliteralsize(tag, arg.s, c, maxsize - *totalsize,
                        &size, binary, parseerr);
     if (r) return r;
+
+    literal_size = size;
 
     /* Catenate message part to stage */
     while (size) {
@@ -3918,7 +3921,7 @@ static int catenate_text(const char *tag, FILE *f, size_t maxsize,
         if (f) fwrite(buf, n, 1, f);
     }
 
-    *totalsize += size;
+    *totalsize += literal_size;
 
     return r;
 }


### PR DESCRIPTION
totalsize was incremented by "size", but size is a decrementor that the loop above drains to zero.  Accumulate the number of bytes actually read instead.