### PR TITLE
Cassandane: use UID, not sequence numbers, by default

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1340,6 +1340,41 @@ sub check_messages
 }
 
 #
+# Run $code with $talk temporarily out of UID mode, and put the mode back
+# afterwards even if $code dies.
+#
+# Clients speak UID by default here, so a test that means to exercise message
+# sequence numbers -- rather than merely tolerate them -- has to say so, and
+# this is how it says it.  If you find yourself reaching for this, the test is
+# making a claim about sequence numbers, and the claim is worth a comment.
+#
+sub with_seq_mode
+{
+    my ($self, $talk, $code) = @_;
+
+    # Mail::IMAPTalk picks FETCH or UID FETCH from a connection-wide flag,
+    # and its uid() accessor can't be read, so save and restore by hand.
+    my $old_uid_mode = $talk->{Uid};
+    $talk->uid(0);
+
+    # Pass our caller's context through to $code: Mail::IMAPTalk::_imap_cmd
+    # flattens an array response into a list when called in list context,
+    # so a wrapper that guesses wrong turns an array ref into its first
+    # element.
+    my $wantarray = wantarray;
+    my (@list, $scalar);
+    eval {
+        if ($wantarray) { @list = $code->() } else { $scalar = $code->() }
+        1;
+    };
+    my $err = $@;
+    $talk->uid($old_uid_mode);
+    die $err if $err;
+
+    return $wantarray ? @list : $scalar;
+}
+
+#
 # Assert that the messages in the selected folder, taken in sequence number
 # order, have exactly the given UIDs -- so assert_seq_uids($talk, [1, 3])
 # means "two messages, at sequence numbers 1 and 2, with UIDs 1 and 3".
@@ -1353,14 +1388,7 @@ sub assert_seq_uids
 {
     my ($self, $talk, $expected) = @_;
 
-    # Mail::IMAPTalk picks FETCH or UID FETCH from a connection-wide flag,
-    # and its uid() accessor can't be read, so save and restore by hand.
-    my $old_uid_mode = $talk->{Uid};
-    $talk->uid(0);
-    my $res = eval { $talk->fetch('1:*', '(uid)') };
-    my $err = $@;
-    $talk->uid($old_uid_mode);
-    die $err if $err;
+    my $res = $self->with_seq_mode($talk, sub { $talk->fetch('1:*', '(uid)') });
 
     $self->assert_str_equals('ok', $talk->get_last_completion_response());
 

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -1339,6 +1339,38 @@ sub check_messages
     return $actual;
 }
 
+#
+# Assert that the messages in the selected folder, taken in sequence number
+# order, have exactly the given UIDs -- so assert_seq_uids($talk, [1, 3])
+# means "two messages, at sequence numbers 1 and 2, with UIDs 1 and 3".
+#
+# Renumbering the survivors after an expunge is the server's job, so we ask
+# the server: this issues a plain FETCH, in sequence number mode, however the
+# client is set up.  Reading the sequence numbers back out of a message store
+# would only tell us what the store had counted for itself.
+#
+sub assert_seq_uids
+{
+    my ($self, $talk, $expected) = @_;
+
+    # Mail::IMAPTalk picks FETCH or UID FETCH from a connection-wide flag,
+    # and its uid() accessor can't be read, so save and restore by hand.
+    my $old_uid_mode = $talk->{Uid};
+    $talk->uid(0);
+    my $res = eval { $talk->fetch('1:*', '(uid)') };
+    my $err = $@;
+    $talk->uid($old_uid_mode);
+    die $err if $err;
+
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    my @seqs = sort { $a <=> $b } keys %$res;
+    $self->assert_deep_equals([ 1 .. scalar @$expected ],
+                              [ map { 0 + $_ } @seqs ]);
+    $self->assert_deep_equals($expected,
+                              [ map { 0 + $res->{$_}->{uid} } @seqs ]);
+}
+
 sub _disconnect_all
 {
     my ($self) = @_;

--- a/cassandane/Cassandane/IMAPMessageStore.pm
+++ b/cassandane/Cassandane/IMAPMessageStore.pm
@@ -83,7 +83,7 @@ sub connect
                       UseBlocking => 1,  # must be blocking for SSL
                       Pedantic => 1,
                       PreserveINBOX => 1,
-                      Uid => 0,
+                      Uid => 1,
                       NoLiteralPlus => delete $params{NoLiteralPlus} || 0,
                       UseCompress => delete $params{UseCompress} || 0,
                   )
@@ -99,7 +99,7 @@ sub connect
                       Socket => $sock,
                       Pedantic => 1,
                       PreserveINBOX => 1,
-                      Uid => 0,
+                      Uid => 1,
                       NoLiteralPlus => delete $params{NoLiteralPlus} || 0,
                       UseCompress => delete $params{UseCompress} || 0,
                   )

--- a/cassandane/Cassandane/IMAPMessageStore.pm
+++ b/cassandane/Cassandane/IMAPMessageStore.pm
@@ -32,8 +32,9 @@ sub new
         # state for streaming read
         next_uid => undef,
         last_uid => undef,
-        last_batch_uid => undef,
+        next_id => undef,
         batch => undef,
+        batch_uids => undef,
         fetch_attrs => { uid => 1, 'body.peek[]' => 1 },
         # state for XCONVFETCH
         fetched => undef,
@@ -224,6 +225,29 @@ sub set_fetch_attributes
     }
 }
 
+# Perform a UID FETCH, whatever UID mode the client is currently in, and
+# return the results keyed on UID.
+#
+# Mail::IMAPTalk has no uidfetch() method: it chooses between FETCH and UID
+# FETCH from a connection-wide flag.  Worse, its uid() accessor is write-only
+# -- it always returns 1, and called with no argument it *clears* the flag --
+# so we save and restore the flag by hand.  To be fixed in future IMAP test
+# library work...
+sub _uidfetch
+{
+    my ($self, @args) = @_;
+    my $client = $self->{client};
+
+    my $old_uid_mode = $client->{Uid};
+    $client->uid(1);
+    my $res = eval { $client->fetch(@args) };
+    my $err = $@;
+    $client->uid($old_uid_mode);
+
+    die $err if $err;
+    return $res;
+}
+
 sub read_begin
 {
     my ($self) = @_;
@@ -235,56 +259,58 @@ sub read_begin
 
     $self->{next_uid} = 1;
     $self->{last_uid} = -1 + $self->{client}->get_response_code('uidnext');
-    $self->{last_batch_uid} = undef;
+    $self->{next_id} = 1;
     $self->{batch} = undef;
+    $self->{batch_uids} = [];
 }
 
-sub read_message
-{
+# Return the next message in the folder, or undef at the end of the folder.
+#
+# Messages are fetched by UID, a batch of $BATCHSIZE UIDs at a time, and
+# returned in ascending UID order (same as ascending seqnum order).  Note that
+# a batch may well come back with fewer messages than UIDs asked for, or with
+# none at all, because UIDs of expunged messages are never reused and so leave
+# gaps.
+#
+# The message's "id" attribute is its IMAP sequence number, which we have to
+# count off ourselves because there is no FETCH item that reports it.
+sub read_message {
     my ($self, $msg) = @_;
 
     for (;;)
     {
-        while (defined $self->{batch})
+        while (@{$self->{batch_uids}})
         {
-            my $uid = $self->{next_uid};
-            last if $uid > $self->{last_batch_uid};
-            $self->{next_uid}++;
-            my $rr = $self->{batch}->{$uid};
-            next unless defined $rr;
-            delete $self->{batch}->{$uid};
+            my $uid = shift @{$self->{batch_uids}};
+            my $rr = delete $self->{batch}->{$uid};
 
             # xlog "found uid=$uid in batch";
             # xlog "rr=" . Dumper($rr);
-            my $raw = $rr->{'body'};
-            delete $rr->{'body'};
-            return Cassandane::Message->new(raw => $raw,
-                                            attrs => { id => $uid, %$rr });
+            my $raw = delete $rr->{'body'};
+            return Cassandane::Message->new(
+                        raw => $raw,
+                        attrs => { %$rr,
+                                   id => $self->{next_id}++,
+                                   uid => $uid });
         }
-        $self->{batch} = undef;
 
         # xlog "batch empty or no batch available";
 
-        for (;;)
-        {
-            my $first_uid = $self->{next_uid};
-            return undef
-                if $first_uid > $self->{last_uid};  # EOF
-            my $last_uid = $first_uid + $BATCHSIZE - 1;
-            $last_uid = $self->{last_uid}
-                if $last_uid > $self->{last_uid};
-            # xlog "fetching batch range $first_uid:$last_uid";
-            my $attrs = join(' ', keys %{$self->{fetch_attrs}});
-            $self->{batch} = $self->{client}->fetch("$first_uid:$last_uid",
-                                                    "($attrs)");
-            $self->{last_batch_uid} = $last_uid;
-            last if (defined $self->{batch} && scalar $self->{batch} > 0);
-            $self->{next_uid} = $last_uid + 1;
-        }
+        my $first_uid = $self->{next_uid};
+        return undef
+            if $first_uid > $self->{last_uid};  # EOF
+        my $last_uid = $first_uid + $BATCHSIZE - 1;
+        $last_uid = $self->{last_uid}
+            if $last_uid > $self->{last_uid};
+        $self->{next_uid} = $last_uid + 1;
+
+        # xlog "fetching batch range $first_uid:$last_uid";
+        my $attrs = join(' ', keys %{$self->{fetch_attrs}});
+        $self->{batch} = $self->_uidfetch("$first_uid:$last_uid", "($attrs)")
+                         || {};
+        $self->{batch_uids} = [ sort { $a <=> $b } keys %{$self->{batch}} ];
         # xlog "have a batch, next_uid=$self->{next_uid}";
     }
-
-    return undef;
 }
 
 sub read_end
@@ -293,8 +319,9 @@ sub read_end
 
     $self->{next_uid} = undef;
     $self->{last_uid} = undef;
-    $self->{last_batch_uid} = undef;
+    $self->{next_id} = undef;
     $self->{batch} = undef;
+    $self->{batch_uids} = [];
 }
 
 sub remove

--- a/cassandane/tiny-tests/Annotator/add_annot_splitconv_rerun
+++ b/cassandane/tiny-tests/Annotator/add_annot_splitconv_rerun
@@ -43,7 +43,7 @@ sub test_add_annot_splitconv_rerun
 
     my $imaptalk = $self->{store}->get_client();
     $imaptalk->store('7', '-flags', '$X-FUN');
-    $imaptalk->_imap_cmd("uid xrunannotator", 0, {}, '7');
+    $imaptalk->_imap_cmd("xrunannotator", 1, {}, '7');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $exp{C}->set_annotation($entry, $attrib, $value1);
 

--- a/cassandane/tiny-tests/Annotator/annotator_callout_disabled
+++ b/cassandane/tiny-tests/Annotator/annotator_callout_disabled
@@ -37,7 +37,7 @@ sub test_annotator_callout_disabled
             $self->assert_str_equals($_[1]{flags}[1], "\$X-ME-Annot-2");
         };
     }
-    $imaptalk->_imap_cmd("uid fetch", 1, \%handlers1, '1', '(flags modseq)');
+    $imaptalk->_imap_cmd("fetch", 1, \%handlers1, '1', '(flags modseq)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
     xlog $self, "Clear the $flag from the message A.";
@@ -50,7 +50,7 @@ sub test_annotator_callout_disabled
         };
     }
     $imaptalk->store('1', '-flags', "($flag)");
-    $imaptalk->_imap_cmd("uid fetch", 1, \%handlers2, '1', '(flags modseq)');
+    $imaptalk->_imap_cmd("fetch", 1, \%handlers2, '1', '(flags modseq)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
     xlog $self, "Run xrunannotator";
@@ -62,10 +62,10 @@ sub test_annotator_callout_disabled
             $self->assert_str_equals($_[1]{flags}[0], "\\Recent");
         };
     }
-    $imaptalk->_imap_cmd("uid xrunannotator", 0, {}, '1');
+    $imaptalk->_imap_cmd("xrunannotator", 1, {}, '1');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
     xlog $self, "Nothing should have changed from the previous run of uid fetch.";
-    $imaptalk->_imap_cmd("uid fetch", 1, \%handlers3, '1', '(flags modseq)');
+    $imaptalk->_imap_cmd("fetch", 1, \%handlers3, '1', '(flags modseq)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 }

--- a/cassandane/tiny-tests/Annotator/fetch_after_annotate
+++ b/cassandane/tiny-tests/Annotator/fetch_after_annotate
@@ -35,7 +35,7 @@ sub test_fetch_after_annotate ($self)
             $self->assert_str_equals($_[1]{flags}[1], "\$X-ME-Annot-2");
         };
     }
-    $imaptalk->_imap_cmd("uid fetch", 1, \%handlers1, '1', '(flags modseq)');
+    $imaptalk->_imap_cmd("fetch", 1, \%handlers1, '1', '(flags modseq)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
     xlog $self, "Clear the $flag from the message A.";
@@ -48,7 +48,7 @@ sub test_fetch_after_annotate ($self)
         };
     }
     $imaptalk->store('1', '-flags', "($flag)");
-    $imaptalk->_imap_cmd("uid fetch", 1, \%handlers2, '1', '(flags modseq)');
+    $imaptalk->_imap_cmd("fetch", 1, \%handlers2, '1', '(flags modseq)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
     xlog $self, "Run xrunannotator";
@@ -61,9 +61,9 @@ sub test_fetch_after_annotate ($self)
             $self->assert_str_equals($_[1]{flags}[1], "\$X-ME-Annot-2");
         };
     }
-    $imaptalk->_imap_cmd("uid xrunannotator", 0, {}, '1');
+    $imaptalk->_imap_cmd("xrunannotator", 1, {}, '1');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
-    $imaptalk->_imap_cmd("uid fetch", 1, \%handlers3, '1', '(flags modseq)');
+    $imaptalk->_imap_cmd("fetch", 1, \%handlers3, '1', '(flags modseq)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 }

--- a/cassandane/tiny-tests/Archive/archive_messages
+++ b/cassandane/tiny-tests/Archive/archive_messages
@@ -15,7 +15,7 @@ sub test_archive_messages
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Append 3 messages";

--- a/cassandane/tiny-tests/Archive/archive_messages_archive_annotation
+++ b/cassandane/tiny-tests/Archive/archive_messages_archive_annotation
@@ -9,7 +9,7 @@ sub test_archive_messages_archive_annotation
     my $admintalk = $self->{adminstore}->get_client();
 
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Append 3 messages";

--- a/cassandane/tiny-tests/Archive/archivenow_messages
+++ b/cassandane/tiny-tests/Archive/archivenow_messages
@@ -7,7 +7,7 @@ sub test_archivenow_messages
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Append 3 messages";

--- a/cassandane/tiny-tests/Archive/archivenow_reconstruct
+++ b/cassandane/tiny-tests/Archive/archivenow_reconstruct
@@ -7,7 +7,7 @@ sub test_archivenow_reconstruct
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Append 3 messages";

--- a/cassandane/tiny-tests/ClamAV/remove_infected_slow
+++ b/cassandane/tiny-tests/ClamAV/remove_infected_slow
@@ -15,9 +15,9 @@ sub test_remove_infected_slow
 
     my $talk = $self->{store}->get_client();
     $talk->select("INBOX");
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $talk->select("shared.folder");
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
 
     # put some test messages in INBOX (and verify)
     $self->{store}->set_folder("INBOX");

--- a/cassandane/tiny-tests/Expunge/uid_gaps_after_expunge
+++ b/cassandane/tiny-tests/Expunge/uid_gaps_after_expunge
@@ -1,0 +1,34 @@
+#!perl
+use Cassandane::Tiny;
+
+# Expunging a message leaves a hole in the UID sequence, because UIDs are
+# never reused, while the sequence numbers of the surviving messages close up
+# behind it.  Check that the message store's read path -- the engine behind
+# check_messages() -- reports both numbers correctly once they have diverged.
+sub test_uid_gaps_after_expunge ($self)
+{
+    my $store = $self->{store};
+    my $talk = $store->get_client();
+
+    $store->set_fetch_attributes(qw(uid));
+    $store->_select();
+
+    xlog $self, "Append five messages";
+    my %msg;
+    $msg{$_} = $self->make_message("Message $_") for 1..5;
+
+    xlog $self, "Expunge the first and the third of them";
+    # At this point sequence numbers and UIDs still agree, so this works
+    # whichever of the two the client is speaking in.
+    $talk->store('1,3', '+flags', '(\\Deleted)');
+    $talk->expunge();
+    delete $msg{1};
+    delete $msg{3};
+
+    xlog $self, "The survivors keep their UIDs but move down in sequence";
+    $msg{2}->set_attributes(id => 1, uid => 2);
+    $msg{4}->set_attributes(id => 2, uid => 4);
+    $msg{5}->set_attributes(id => 3, uid => 5);
+
+    $self->check_messages(\%msg);
+}

--- a/cassandane/tiny-tests/Expunge/uid_gaps_after_expunge
+++ b/cassandane/tiny-tests/Expunge/uid_gaps_after_expunge
@@ -4,7 +4,8 @@ use Cassandane::Tiny;
 # Expunging a message leaves a hole in the UID sequence, because UIDs are
 # never reused, while the sequence numbers of the surviving messages close up
 # behind it.  Check that the message store's read path -- the engine behind
-# check_messages() -- reports both numbers correctly once they have diverged.
+# check_messages() -- still finds every message once the two have diverged,
+# and that the server renumbers the survivors as it should.
 sub test_uid_gaps_after_expunge ($self)
 {
     my $store = $self->{store};
@@ -26,9 +27,10 @@ sub test_uid_gaps_after_expunge ($self)
     delete $msg{3};
 
     xlog $self, "The survivors keep their UIDs but move down in sequence";
-    $msg{2}->set_attributes(id => 1, uid => 2);
-    $msg{4}->set_attributes(id => 2, uid => 4);
-    $msg{5}->set_attributes(id => 3, uid => 5);
+    $msg{2}->set_attributes(uid => 2);
+    $msg{4}->set_attributes(uid => 4);
+    $msg{5}->set_attributes(uid => 5);
 
     $self->check_messages(\%msg);
+    $self->assert_seq_uids($talk, [ 2, 4, 5 ]);
 }

--- a/cassandane/tiny-tests/Fetch/mailboxids
+++ b/cassandane/tiny-tests/Fetch/mailboxids
@@ -55,9 +55,12 @@ sub test_mailboxids
     # expunge INBOX
     $imaptalk->expunge();
 
-    # expect to find it in INBOX.target only
+    # expect to find it in INBOX.target only.  A UID FETCH naming a message
+    # that isn't there is not an error -- it just returns nothing -- where
+    # the sequence number form would be a NO for an out of range number.
     $res = $imaptalk->fetch('1', '(MAILBOXES MAILBOXIDS)');
-    $self->assert_str_equals('no', $imaptalk->get_last_completion_response());
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_null($res);
     $imaptalk->select('INBOX.target');
     $res = $imaptalk->fetch('1', '(MAILBOXES MAILBOXIDS)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());

--- a/cassandane/tiny-tests/Fetch/partial
+++ b/cassandane/tiny-tests/Fetch/partial
@@ -16,6 +16,11 @@ sub test_partial ($self)
     xlog $self, "check the messages got there";
     $self->check_messages(\%exp);
 
+    # PARTIAL against message sequence numbers first; UID mode is enabled
+    # further down to exercise the other form.  Clients speak UID by
+    # default, so the sequence number half has to say so.
+    $imaptalk->uid(0);
+
     # expunge the 1st and 6th
     $imaptalk->store('1,6', '+FLAGS', '(\\Deleted)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());

--- a/cassandane/tiny-tests/Flags/deleted
+++ b/cassandane/tiny-tests/Flags/deleted
@@ -20,18 +20,16 @@ sub test_deleted ($self)
     xlog $self, "Append 3 messages";
     my %msg;
     $msg{A} = $self->make_message('Message A');
-    $msg{A}->set_attributes(id => 1,
-                            uid => 1,
+    $msg{A}->set_attributes(uid => 1,
                             flags => []);
     $msg{B} = $self->make_message('Message B');
-    $msg{B}->set_attributes(id => 2,
-                            uid => 2,
+    $msg{B}->set_attributes(uid => 2,
                             flags => []);
     $msg{C} = $self->make_message('Message C');
-    $msg{C}->set_attributes(id => 3,
-                            uid => 3,
+    $msg{C}->set_attributes(uid => 3,
                             flags => []);
     $self->check_messages(\%msg);
+    $self->assert_seq_uids($talk, [ 1, 2, 3 ]);
 
     xlog $self, "Mark the middle message \\Deleted";
     my $res = $talk->store('2', '+flags', '(\\Deleted)');
@@ -42,9 +40,10 @@ sub test_deleted ($self)
     xlog $self, "Expunge the middle message";
     $talk->expunge();
     delete $msg{B};
-    $msg{A}->set_attribute(id => 1);
-    $msg{C}->set_attribute(id => 2);
     $self->check_messages(\%msg);
+
+    xlog $self, "C keeps its UID but closes up in sequence";
+    $self->assert_seq_uids($talk, [ 1, 3 ]);
 #
 #     $talk->store($seq', '+flags', '(\\flagged)') or die $@;
 }

--- a/cassandane/tiny-tests/Flags/deleted
+++ b/cassandane/tiny-tests/Flags/deleted
@@ -14,7 +14,7 @@ sub test_deleted ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Append 3 messages";
@@ -35,7 +35,7 @@ sub test_deleted ($self)
 
     xlog $self, "Mark the middle message \\Deleted";
     my $res = $talk->store('2', '+flags', '(\\Deleted)');
-    $self->assert_deep_equals({ '2' => { 'flags' => [ '\\Deleted' ] }}, $res);
+    $self->assert_deep_equals({ '2' => { 'uid' => '2', 'flags' => [ '\\Deleted' ] }}, $res);
     $msg{B}->set_attribute(flags => ['\\Deleted']);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/Flags/explicit_store_acl
+++ b/cassandane/tiny-tests/Flags/explicit_store_acl
@@ -9,7 +9,7 @@ sub test_explicit_store_acl
 
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     # add a message
@@ -22,7 +22,7 @@ sub test_explicit_store_acl
 
     # set some flags on it
     my $res = $talk->store('1', '+flags', '(\\Deleted \\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ qw(\\Deleted \\Seen)] }},
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ qw(\\Deleted \\Seen)] }},
                               $res);
     $msg{A}->set_attribute(flags => [ '\\Deleted', '\\Seen' ]);
     $self->check_messages(\%msg);
@@ -41,7 +41,7 @@ sub test_explicit_store_acl
     $talk->unselect();
     $talk->select('INBOX');
     $res = $talk->store('1', 'flags', '(\\Flagged)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [
                                 qw(\\Flagged \\Deleted)
                               ]}}, $res);
     $msg{A}->set_attribute(flags => [ '\\Flagged', '\\Deleted' ]);

--- a/cassandane/tiny-tests/Flags/expunge_removeflag
+++ b/cassandane/tiny-tests/Flags/expunge_removeflag
@@ -12,7 +12,7 @@ sub test_expunge_removeflag ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     my $perm = $talk->get_response_code('permanentflags');
@@ -33,13 +33,13 @@ sub test_expunge_removeflag ($self)
 
     xlog $self, "Set \$Foobar on message A";
     my $res = $talk->store('1', '+flags', '($Foobar)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '$Foobar' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '$Foobar' ] }}, $res);
     $msg{A}->set_attribute(flags => ['$Foobar']);
     $self->check_messages(\%msg);
 
     xlog $self, "Clear \$Foobar on message A";
     $res = $talk->store('1', '-flags', '($Foobar)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/Flags/flagged
+++ b/cassandane/tiny-tests/Flags/flagged
@@ -12,7 +12,7 @@ sub test_flagged ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -29,19 +29,19 @@ sub test_flagged ($self)
 
     xlog $self, "Set \\Flagged on message A";
     my $res = $talk->store('1', '+flags', '(\\Flagged)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Flagged' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Flagged' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Flagged']);
     $self->check_messages(\%msg);
 
     xlog $self, "Clear \\Flagged on message A";
     $res = $talk->store('1', '-flags', '(\\Flagged)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg);
 
     xlog $self, "Set \\Flagged on message A again";
     $res = $talk->store('1', '+flags', '(\\Flagged)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Flagged' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Flagged' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Flagged']);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/Flags/max_userflags
+++ b/cassandane/tiny-tests/Flags/max_userflags
@@ -5,7 +5,7 @@ sub test_max_userflags ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -37,14 +37,14 @@ sub test_max_userflags ($self)
 
         xlog $self, "Set $flag on message A";
         my $res = $talk->store('1', '+flags', "($flag)");
-        $self->assert_deep_equals({ '1' => { 'flags' => [ "$flag" ] }},
+        $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ "$flag" ] }},
                                   $res);
         $msg{A}->set_attribute(flags => [$flag]);
         $self->check_messages(\%msg);
 
         xlog $self, "Clear $flag on message A";
         $res = $talk->store('1', '-flags', "($flag)");
-        $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+        $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
         $msg{A}->set_attribute(flags => []);
         $self->check_messages(\%msg);
     }
@@ -65,7 +65,7 @@ sub test_max_userflags ($self)
     my @flags = sort { $allflags{$a} <=> $allflags{$b} } (keys %allflags);
     xlog $self, "Set all the user flags on message A";
     $res = $talk->store('1', '+flags', '(' . join(' ',@flags) . ')');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ @flags ] }},
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ @flags ] }},
                               $res);
     $msg{A}->set_attribute(flags => [@flags]);
     $self->check_messages(\%msg);

--- a/cassandane/tiny-tests/Flags/modseq
+++ b/cassandane/tiny-tests/Flags/modseq
@@ -20,7 +20,7 @@ sub test_modseq ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags modseq));
 
     xlog $self, "Add two messages";

--- a/cassandane/tiny-tests/Flags/multi_flags
+++ b/cassandane/tiny-tests/Flags/multi_flags
@@ -12,7 +12,7 @@ sub test_multi_flags ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -30,7 +30,7 @@ sub test_multi_flags ($self)
     xlog $self, "Set many flags on message A";
     my $res = $talk->store('1', '+flags',
                            '(\\Answered \\Flagged \\Draft \\Deleted \\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [
                                 qw(\\Answered \\Flagged \\Draft
                                    \\Deleted \\Seen)
                               ]}}, $res);
@@ -39,7 +39,7 @@ sub test_multi_flags ($self)
 
     xlog $self, "Clear \\Flagged on message A";
     $res = $talk->store('1', '-flags', '(\\Flagged)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [
                                 qw(\\Answered \\Draft \\Deleted \\Seen)
                               ]}}, $res);
     $msg{A}->set_attribute(flags => [qw(\\Answered \\Draft \\Deleted \\Seen)]);
@@ -47,7 +47,7 @@ sub test_multi_flags ($self)
 
     xlog $self, "Clear \\Draft and \\Deleted on message A";
     $res = $talk->store('1', '-flags', '(\\Draft \\Deleted)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [
                                 qw(\\Answered \\Seen)
                               ]}}, $res);
     $msg{A}->set_attribute(flags => [qw(\\Answered \\Seen)]);
@@ -55,7 +55,7 @@ sub test_multi_flags ($self)
 
     xlog $self, "Set \\Draft and \\Flagged on message A";
     $res = $talk->store('1', '+flags', '(\\Draft \\Flagged)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [
                                 qw(\\Answered \\Flagged \\Draft \\Seen)
                               ]}}, $res);
     $msg{A}->set_attribute(flags => [qw(\\Answered \\Flagged \\Draft \\Seen)]);
@@ -63,7 +63,7 @@ sub test_multi_flags ($self)
 
     xlog $self, "Set to just \\Answered and \\Seen on message A";
     $res = $talk->store('1', 'flags', '(\\Answered \\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [
                                 qw(\\Answered \\Seen)
                               ]}}, $res);
     $msg{A}->set_attribute(flags => [qw(\\Answered \\Seen)]);
@@ -86,7 +86,7 @@ sub test_multi_flags ($self)
         }
         xlog $self, "Setting " . join(',',@flags) . " on message A";
         my $res = $talk->store('1', 'flags', '(' . join(' ',@flags) . ')');
-        $self->assert_deep_equals({ '1' => { 'flags' => \@flags }}, $res);
+        $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => \@flags }}, $res);
         $msg{A}->set_attribute(flags => \@flags);
         $self->check_messages(\%msg);
     }

--- a/cassandane/tiny-tests/Flags/multi_flags_acl
+++ b/cassandane/tiny-tests/Flags/multi_flags_acl
@@ -14,7 +14,7 @@ sub test_multi_flags_acl
 
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -49,7 +49,7 @@ sub test_multi_flags_acl
             $firsttime = 0;
         }
         else {
-            $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+            $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
         }
         $msg{A}->set_attribute(flags => []);
         $self->check_messages(\%msg);
@@ -64,7 +64,7 @@ sub test_multi_flags_acl
         $res = $talk->store('1', '+flags', "(@flags)");
 
         # it should work, but only the allowed flag should have been set
-        $self->assert_deep_equals({ '1' => { 'flags' => [ $flag ] }}, $res);
+        $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ $flag ] }}, $res);
         $self->assert_equals('ok', $talk->get_last_completion_response());
         $msg{A}->set_attribute(flags => [$flag]);
         $self->check_messages(\%msg);

--- a/cassandane/tiny-tests/Flags/search_allflags
+++ b/cassandane/tiny-tests/Flags/search_allflags
@@ -10,7 +10,7 @@ sub test_search_allflags ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add messages and flags";
@@ -22,7 +22,7 @@ sub test_search_allflags ($self)
         $msg{$i} = $self->make_message("Message $i");
         xlog $self, "Set $flag on message $i";
         my $res = $talk->store($i, '+flags', "($flag)");
-        $self->assert_deep_equals({ "$i" => { 'flags' => [
+        $self->assert_deep_equals({ "$i" => { 'uid' => "$i", 'flags' => [
                                         '\\Recent', $flag
                                   ]}}, $res);
     }

--- a/cassandane/tiny-tests/Flags/seen
+++ b/cassandane/tiny-tests/Flags/seen
@@ -18,7 +18,7 @@ sub test_seen ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -35,19 +35,19 @@ sub test_seen ($self)
 
     xlog $self, "Set \\Seen on message A";
     my $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 
     xlog $self, "Clear \\Seen on message A";
     $res = $talk->store('1', '-flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg);
 
     xlog $self, "Set \\Seen on message A again";
     $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/Flags/seen_otheruser
+++ b/cassandane/tiny-tests/Flags/seen_otheruser
@@ -26,11 +26,12 @@ sub test_seen_otheruser
 
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     my $otherstore = $self->{instance}->get_service('imap')->create_store(username => 'otheruser');
     my $othertalk = $otherstore->get_client(username => 'otheruser');
+    $othertalk->uid(1);
     $otherstore->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -53,27 +54,27 @@ sub test_seen_otheruser
 
     xlog $self, "Set \\Seen on message A";
     my $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $self->check_messages(\%msg, store => $otherstore);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg, store => $self->{store});
 
     xlog $self, "Set \\Seen on message A as otheruser";
     $res = $othertalk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $self->check_messages(\%msg, store => $otherstore);
     $self->check_messages(\%msg, store => $self->{store});
 
     xlog $self, "Clear \\Seen on message A";
     $res = $talk->store('1', '-flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $self->check_messages(\%msg, store => $otherstore);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg, store => $self->{store});
 
     xlog $self, "Clear \\Seen on message A as otheruser";
     $res = $othertalk->store('1', '-flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $self->check_messages(\%msg, store => $otherstore);
     $self->check_messages(\%msg, store => $self->{store});
 }

--- a/cassandane/tiny-tests/Flags/seen_sharedmb_nosharedseen
+++ b/cassandane/tiny-tests/Flags/seen_sharedmb_nosharedseen
@@ -24,7 +24,7 @@ sub test_seen_sharedmb_nosharedseen
     my $talk = $self->{store}->get_client();
     $self->{store}->set_folder("Shared Folders/$folder");
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -43,19 +43,19 @@ sub test_seen_sharedmb_nosharedseen
     # and the expected untagged fetch response
     xlog $self, "Set \\Seen on message A";
     my $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 
     xlog $self, "Clear \\Seen on message A";
     $res = $talk->store('1', '-flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg);
 
     xlog $self, "Set \\Seen on message A again";
     $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/Flags/seen_sharedmb_sharedseen
+++ b/cassandane/tiny-tests/Flags/seen_sharedmb_sharedseen
@@ -24,7 +24,7 @@ sub test_seen_sharedmb_sharedseen
     my $talk = $self->{store}->get_client();
     $self->{store}->set_folder("Shared Folders/$folder");
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -43,19 +43,19 @@ sub test_seen_sharedmb_sharedseen
     # and the expected untagged fetch response
     xlog $self, "Set \\Seen on message A";
     my $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 
     xlog $self, "Clear \\Seen on message A";
     $res = $talk->store('1', '-flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg);
 
     xlog $self, "Set \\Seen on message A again";
     $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/Flags/setseen
+++ b/cassandane/tiny-tests/Flags/setseen
@@ -6,7 +6,7 @@ sub test_setseen ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add three messages";

--- a/cassandane/tiny-tests/Flags/setseen_after_store
+++ b/cassandane/tiny-tests/Flags/setseen_after_store
@@ -10,7 +10,7 @@ sub test_setseen_after_store ($self)
 
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -39,7 +39,7 @@ sub test_setseen_after_store ($self)
        # XXX flags.silent should cause there to not be an untagged response
        # XXX unless the affected data was also modified by another user, but
        # XXX for some reason Cyrus still returns it here?
-       $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+       $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     }
     $talk->fetch('1', '(body[])');
     $self->check_messages(\%msg);

--- a/cassandane/tiny-tests/Flags/setseen_notify
+++ b/cassandane/tiny-tests/Flags/setseen_notify
@@ -7,7 +7,7 @@ sub test_setseen_notify
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Throw away existing notify";
@@ -25,7 +25,7 @@ sub test_setseen_notify
 
     $msg{A}->set_attribute(flags => ['\\Seen']);
     my $res = $talk->store('1', '+flags', '\\Seen');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
 
     my $notify2 = $self->{instance}->getnotify();
 

--- a/cassandane/tiny-tests/Flags/unchangedsince
+++ b/cassandane/tiny-tests/Flags/unchangedsince
@@ -24,7 +24,7 @@ sub test_unchangedsince ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags modseq));
 
     xlog $self, "Add two messages";

--- a/cassandane/tiny-tests/Flags/unchangedsince_multi
+++ b/cassandane/tiny-tests/Flags/unchangedsince_multi
@@ -36,8 +36,7 @@ sub test_unchangedsince_multi ($self)
     {
         my $letter = chr(64 + $i);  # A ... Z
         $msg{$letter} = $self->make_message('Message ' . $letter);
-        $msg{$letter}->set_attributes(id => $i,
-                                      uid => $i,
+        $msg{$letter}->set_attributes(uid => $i,
                                       flags => []);
     }
 
@@ -135,14 +134,10 @@ sub test_unchangedsince_multi ($self)
     $msg{X}->set_attribute(flags => ['\\Flagged']);
     $msg{Y}->set_attribute(flags => ['\\Flagged']);
     $msg{Z}->set_attribute(flags => ['\\Flagged']);
-    # We start a new session in check_messages, so we
-    # have to renumber here to account for deletion
-    for (my $i = 7 ; $i <= 26 ; $i++)
-    {
-        my $letter = chr(64 + $i);  # G ... Z
-        $msg{$letter}->set_attribute(id => $i-3);
-    }
     my $act1 = $self->check_messages(\%msg);
+
+    xlog $self, "the survivors closed up in sequence when D,E,F went";
+    $self->assert_seq_uids($talk, [ 1..3, 7..26 ]);
 
 # TODO: this fails with current Cyrus code
 #     xlog $self, "returns a NO response?";

--- a/cassandane/tiny-tests/Flags/unchangedsince_multi
+++ b/cassandane/tiny-tests/Flags/unchangedsince_multi
@@ -27,7 +27,7 @@ sub test_unchangedsince_multi ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags modseq));
 
     xlog $self, "Add some messages";
@@ -44,9 +44,9 @@ sub test_unchangedsince_multi ($self)
     xlog $self, "Bump the modseq on M,N,O";
     my $res = $talk->store('13,14,15', '+flags', '(\\Draft)');
     $self->assert_deep_equals({
-        '13' => { 'flags' => [ '\\Draft' ] },
-        '14' => { 'flags' => [ '\\Draft' ] },
-        '15' => { 'flags' => [ '\\Draft' ] },
+        '13' => { 'uid' => '13', 'flags' => [ '\\Draft' ] },
+        '14' => { 'uid' => '14', 'flags' => [ '\\Draft' ] },
+        '15' => { 'uid' => '15', 'flags' => [ '\\Draft' ] },
     }, $res);
     $msg{M}->set_attribute(flags => ['\\Draft']);
     $msg{N}->set_attribute(flags => ['\\Draft']);
@@ -59,13 +59,14 @@ sub test_unchangedsince_multi ($self)
         $store2->connect();
         $store2->_select();
         my $talk2 = $store2->get_client();
+        $talk2->uid(1);
         xlog $self, "Delete and expunge D,E,F from another session";
         for (my $i = 4 ; $i <= 6 ; $i++)
         {
             my $letter = chr(64 + $i);  # D, E, F
             my $res = $talk2->store($i, '+flags', '(\\Deleted)');
             $self->assert_deep_equals({
-                "$i" => { 'flags' => [ '\\Deleted' ] }
+                "$i" => { 'uid' => "$i", 'flags' => [ '\\Deleted' ] }
             }, $res);
             delete $msg{$letter};
         }
@@ -179,15 +180,21 @@ sub test_unchangedsince_multi ($self)
     $self->assert_deep_equals($modified, ['13:15']);
 
     xlog $self, "sent untagged FETCH responses with the new modseq?";
-    # also tells about the 3 messages which were deleted since
-    # the last command
-    $self->assert_num_equals(23, scalar keys %fetched);
-    foreach my $i (1..3, 7..12, 16..26)
+    # A server may not send EXPUNGE during a command that speaks in sequence
+    # numbers.  During a UID command it may, and Cyrus does.  So the three
+    # messages the other session expunged are reported as untagged EXPUNGEs
+    # ahead of the FETCHes -- not, as they would be for a plain STORE, as
+    # three extra FETCH responses -- and the FETCHes that follow are numbered
+    # in the closed-up sequence.  M, N and O failed the conditional store and
+    # so are not reported at all.
+    $self->assert_num_equals(20, 0+%fetched);
+    foreach my $seq (1..9, 13..23)
     {
-        my $letter = chr(64 + $i);
-        $self->assert_not_null($fetched{$i});
+        my $uid = ($seq <= 3 ? $seq : $seq + 3);   # D, E and F are gone
+        my $letter = chr(64 + $uid);
+        $self->assert_not_null($fetched{$seq});
         $self->assert_num_equals(get_modseq($act1, $letter),
-                                 get_modseq_from_fetch(\%fetched, $i));
+                                 get_modseq_from_fetch(\%fetched, $seq));
     }
 
 }

--- a/cassandane/tiny-tests/Flags/userflag
+++ b/cassandane/tiny-tests/Flags/userflag
@@ -15,7 +15,7 @@ sub test_userflag ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -32,19 +32,19 @@ sub test_userflag ($self)
 
     xlog $self, "Set \$Foobar on message A";
     my $res = $talk->store('1', '+flags', '($Foobar)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '$Foobar' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '$Foobar' ] }}, $res);
     $msg{A}->set_attribute(flags => ['$Foobar']);
     $self->check_messages(\%msg);
 
     xlog $self, "Clear \$Foobar on message A";
     $res = $talk->store('1', '-flags', '($Foobar)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg);
 
     xlog $self, "Set \$Foobar on message A again";
     $res = $talk->store('1', '+flags', '($Foobar)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '$Foobar' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '$Foobar' ] }}, $res);
     $msg{A}->set_attribute(flags => ['$Foobar']);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_no_sched_inbox
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_no_sched_inbox
@@ -11,7 +11,7 @@ sub test_calendarevent_query_no_sched_inbox
     my $caldav = $self->{caldav};
 
     $self->{store}->_select();
-    $self->assert_num_equals(1, $imap->uid());
+    $imap->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     my $uuid = "6de280c9-edff-4019-8ebd-cfebc73f8201";

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_deletedcopy
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_deletedcopy
@@ -36,7 +36,9 @@ sub test_email_querychanges_deletedcopy
     $talk->select("INBOX.foo");
     $talk->move("1", "INBOX");
     $talk->select("INBOX");
-    $talk->store("2", "+flags", "(\\Flagged)");
+    # B left and came back with a new UID, so INBOX is now UIDs 1,3,4,5
+    # (A, C, D, B).  The message being flagged here is C.
+    $talk->store("3", "+flags", "(\\Flagged)");
 
     # order is now A (B) C D B, and (B), C and B are "changed"
 

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_skipdeleted
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_skipdeleted
@@ -39,7 +39,9 @@ sub test_email_querychanges_skipdeleted
     my $old = $res->[0][1];
 
     $talk->select("INBOX");
-    $talk->store("1", "+flags", "(\\Flagged)");
+    # A and B left and came back with new UIDs, so INBOX is now UIDs 3,4,5,6
+    # (C, D, A, B).  The message being flagged here is C.
+    $talk->store("3", "+flags", "(\\Flagged)");
 
     $res = $jmap->CallMethods([['Email/queryChanges', {
         sort => [

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_thread
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_thread
@@ -65,7 +65,8 @@ sub test_email_querychanges_thread
     $self->assert(ref($res->[0][1]{removed}) eq 'ARRAY');
     $self->assert_num_equals(0, scalar @{$res->[0][1]{removed}});
 
-    $talk->store('3', "+flags", '\\Deleted');
+    # UID 3 went in the expunge above, so the next one along is UID 4.
+    $talk->store('4', "+flags", '\\Deleted');
     $talk->expunge();
 
     $res = $jmap->CallMethods([['Email/queryChanges', { sinceQueryState => $state, collapseThreads => JSON::true }, "R1"]]);

--- a/cassandane/tiny-tests/JMAPEmail/email_set_guidsearch_updated_internaldate
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_guidsearch_updated_internaldate
@@ -116,8 +116,11 @@ sub test_email_set_guidsearch_updated_internaldate
     xlog "Append blob of message A via IMAP";
     $imap->append('INBOX', $emailBlobA) || die $@;
 
-    $res = $imap->fetch('3', "(emailid)");
-    my $emailIdC = $res->{3}{emailid}[0];
+    # A was destroyed further up, so the UIDs here have a hole in them; take
+    # the new message's UID from the APPENDUID rather than counting.
+    my $uidC = $imap->get_response_code('appenduid')->[1];
+    $res = $imap->fetch($uidC, "(emailid)");
+    my $emailIdC = $res->{$uidC}{emailid}[0];
 
     xlog $self, "run incremental squatter";
     $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');

--- a/cassandane/tiny-tests/JMAPNote/note_set
+++ b/cassandane/tiny-tests/JMAPNote/note_set
@@ -128,7 +128,9 @@ sub test_note_set
     xlog "set \flagged";
     my $imap = $self->{store}->get_client();
     $imap->select('INBOX.Notes') || die $@;
-    $imap->store('1', '+flags', '(\\flagged)') || die $@;
+    # Updating a note rewrites its message, burning a UID each time, so
+    # address the note as "whatever is in there" rather than by number.
+    $imap->store('1:*', '+flags', '(\\flagged)') || die $@;
 
     xlog "verify isFlagged";
     $res = $jmap->CallMethods([['Note/get', { }, "R1"]]);

--- a/cassandane/tiny-tests/Metadata/modseq
+++ b/cassandane/tiny-tests/Metadata/modseq
@@ -12,7 +12,7 @@ sub test_modseq ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid modseq));
 
     xlog $self, "Append 3 messages";
@@ -34,14 +34,17 @@ sub test_modseq ($self)
     $self->assert_deep_equals(
             {
                 1 => {
+                        uid => 1,
                         modseq => [$hms0-2],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 2 => {
+                        uid => 2,
                         modseq => [$hms0-1],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 3 => {
+                        uid => 3,
                         modseq => [$hms0],
                         annotation => { $entry => { $attrib => undef } }
                      },
@@ -63,14 +66,17 @@ sub test_modseq ($self)
     $self->assert_deep_equals(
             {
                 1 => {
+                        uid => 1,
                         modseq => [$hms1],
                         annotation => { $entry => { $attrib => $value1 } }
                      },
                 2 => {
+                        uid => 2,
                         modseq => [$hms0-1],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 3 => {
+                        uid => 3,
                         modseq => [$hms0],
                         annotation => { $entry => { $attrib => undef } }
                      },
@@ -92,14 +98,17 @@ sub test_modseq ($self)
     $self->assert_deep_equals(
             {
                 1 => {
+                        uid => 1,
                         modseq => [$hms2],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 2 => {
+                        uid => 2,
                         modseq => [$hms0-1],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 3 => {
+                        uid => 3,
                         modseq => [$hms0],
                         annotation => { $entry => { $attrib => undef } }
                      },

--- a/cassandane/tiny-tests/Metadata/permessage_getset
+++ b/cassandane/tiny-tests/Metadata/permessage_getset
@@ -26,9 +26,9 @@ sub test_permessage_getset ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => undef } } },
-                2 => { annotation => { $entry => { $attrib => undef } } },
-                3 => { annotation => { $entry => { $attrib => undef } } },
+                1 => { uid => 1, annotation => { $entry => { $attrib => undef } } },
+                2 => { uid => 2, annotation => { $entry => { $attrib => undef } } },
+                3 => { uid => 3, annotation => { $entry => { $attrib => undef } } },
             },
             $res);
 
@@ -44,9 +44,9 @@ sub test_permessage_getset ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => $value1 } } },
-                2 => { annotation => { $entry => { $attrib => undef } } },
-                3 => { annotation => { $entry => { $attrib => undef } } },
+                1 => { uid => 1, annotation => { $entry => { $attrib => $value1 } } },
+                2 => { uid => 2, annotation => { $entry => { $attrib => undef } } },
+                3 => { uid => 3, annotation => { $entry => { $attrib => undef } } },
             },
             $res);
 
@@ -62,9 +62,9 @@ sub test_permessage_getset ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => $value1 } } },
-                2 => { annotation => { $entry => { $attrib => undef } } },
-                3 => { annotation => { $entry => { $attrib => $value2 } } },
+                1 => { uid => 1, annotation => { $entry => { $attrib => $value1 } } },
+                2 => { uid => 2, annotation => { $entry => { $attrib => undef } } },
+                3 => { uid => 3, annotation => { $entry => { $attrib => $value2 } } },
             },
             $res);
 
@@ -82,9 +82,9 @@ sub test_permessage_getset ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => $value3 } } },
-                2 => { annotation => { $entry => { $attrib => $value3 } } },
-                3 => { annotation => { $entry => { $attrib => $value3 } } },
+                1 => { uid => 1, annotation => { $entry => { $attrib => $value3 } } },
+                2 => { uid => 2, annotation => { $entry => { $attrib => $value3 } } },
+                3 => { uid => 3, annotation => { $entry => { $attrib => $value3 } } },
             },
             $res);
 
@@ -102,9 +102,9 @@ sub test_permessage_getset ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => $value3 } } },
-                2 => { annotation => { $entry => { $attrib => undef } } },
-                3 => { annotation => { $entry => { $attrib => $value3 } } },
+                1 => { uid => 1, annotation => { $entry => { $attrib => $value3 } } },
+                2 => { uid => 2, annotation => { $entry => { $attrib => undef } } },
+                3 => { uid => 3, annotation => { $entry => { $attrib => $value3 } } },
             },
             $res);
 
@@ -122,9 +122,9 @@ sub test_permessage_getset ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => undef } } },
-                2 => { annotation => { $entry => { $attrib => undef } } },
-                3 => { annotation => { $entry => { $attrib => undef } } },
+                1 => { uid => 1, annotation => { $entry => { $attrib => undef } } },
+                2 => { uid => 2, annotation => { $entry => { $attrib => undef } } },
+                3 => { uid => 3, annotation => { $entry => { $attrib => undef } } },
             },
             $res);
 }

--- a/cassandane/tiny-tests/Metadata/permessage_unknown
+++ b/cassandane/tiny-tests/Metadata/permessage_unknown
@@ -22,7 +22,7 @@ sub test_permessage_unknown ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => undef } } }
+                1 => { uid => 1, annotation => { $entry => { $attrib => undef } } }
             },
             $res);
 
@@ -38,7 +38,7 @@ sub test_permessage_unknown ($self)
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => undef } } }
+                1 => { uid => 1, annotation => { $entry => { $attrib => undef } } }
             },
             $res);
 }

--- a/cassandane/tiny-tests/Metadata/permessage_unknown_allowed
+++ b/cassandane/tiny-tests/Metadata/permessage_unknown_allowed
@@ -24,7 +24,7 @@ sub test_permessage_unknown_allowed
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => undef } } }
+                1 => { uid => 1, annotation => { $entry => { $attrib => undef } } }
             },
             $res);
 
@@ -40,7 +40,7 @@ sub test_permessage_unknown_allowed
     $self->assert_not_null($res);
     $self->assert_deep_equals(
             {
-                1 => { annotation => { $entry => { $attrib => $value1 } } }
+                1 => { uid => 1, annotation => { $entry => { $attrib => $value1 } } }
             },
             $res);
 }

--- a/cassandane/tiny-tests/Metadata/unchangedsince
+++ b/cassandane/tiny-tests/Metadata/unchangedsince
@@ -24,7 +24,7 @@ sub test_unchangedsince ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid modseq));
 
     xlog $self, "Append 3 messages";
@@ -82,14 +82,17 @@ sub test_unchangedsince ($self)
     $self->assert_deep_equals(
             {
                 1 => {
+                        uid => 1,
                         modseq => [$hms1],
                         annotation => { $entry => { $attrib => $value1 } }
                      },
                 2 => {
+                        uid => 2,
                         modseq => [$hms0-1],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 3 => {
+                        uid => 3,
                         modseq => [$hms0],
                         annotation => { $entry => { $attrib => undef } }
                      },
@@ -114,14 +117,17 @@ sub test_unchangedsince ($self)
     $self->assert_deep_equals(
             {
                 1 => {
+                        uid => 1,
                         modseq => [$hms2],
                         annotation => { $entry => { $attrib => $value2 } }
                      },
                 2 => {
+                        uid => 2,
                         modseq => [$hms0-1],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 3 => {
+                        uid => 3,
                         modseq => [$hms0],
                         annotation => { $entry => { $attrib => undef } }
                      },
@@ -148,14 +154,17 @@ sub test_unchangedsince ($self)
             {
                 1 => {
                         # unchanged
+                        uid => 1,
                         modseq => [$hms2],
                         annotation => { $entry => { $attrib => $value2 } }
                      },
                 2 => {
+                        uid => 2,
                         modseq => [$hms0-1],
                         annotation => { $entry => { $attrib => undef } }
                      },
                 3 => {
+                        uid => 3,
                         modseq => [$hms0],
                         annotation => { $entry => { $attrib => undef } }
                      },

--- a/cassandane/tiny-tests/MurderIMAP/proxy_search
+++ b/cassandane/tiny-tests/MurderIMAP/proxy_search
@@ -27,8 +27,10 @@ sub test_proxy_search ($self)
     my $frontend = $self->{frontend_store}->get_client();
     $frontend->examine('INBOX');
 
+    # This test deliberately asks the same SEARCH both ways over a mailbox
+    # with holes in it, so the sequence number form has to be spelled out.
     xlog $self, "SEARCH ALL";
-    my $res = $frontend->search('all');
+    my $res = $self->with_seq_mode($frontend, sub { $frontend->search('all') });
     $self->assert_str_equals('ok', $frontend->get_last_completion_response());
     $self->assert_str_equals($res->[0], "1");
     $self->assert_str_equals($res->[1], "2");
@@ -39,7 +41,6 @@ sub test_proxy_search ($self)
     $self->assert_str_equals($res->[6], "7");
 
     xlog $self, "UID SEARCH ALL";
-    $frontend->uid(1);
     $res = $frontend->search('all');
     $self->assert_str_equals('ok', $frontend->get_last_completion_response());
     $self->assert_str_equals($res->[0], "2");

--- a/cassandane/tiny-tests/MurderIMAP/uidonly
+++ b/cassandane/tiny-tests/MurderIMAP/uidonly
@@ -13,8 +13,10 @@ sub test_uidonly
     $res = $frontend->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
     $self->assert_num_equals(1, $res->{uidonly});
 
+    # Rejecting message sequence numbers is the whole point of UIDONLY, so
+    # this has to be asked in sequence numbers to mean anything.
     xlog $self, "Attempt FETCH";
-    $res = $frontend->fetch('1:*', '(UID FLAGS)');
+    $self->with_seq_mode($frontend, sub { $frontend->fetch('1:*', '(UID FLAGS)') });
     $self->assert_str_equals('bad', $frontend->get_last_completion_response());
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $frontend->get_last_error());

--- a/cassandane/tiny-tests/Notify/idle
+++ b/cassandane/tiny-tests/Notify/idle
@@ -62,7 +62,7 @@ sub test_idle
     $self->assert_num_equals(1, $talk->get_response_code('recent'));
 
     my $fetch = $talk->get_response_code('fetch');
-    $self->assert_num_equals(1, $fetch->{1}{uid});
+    $self->assert_not_null($fetch->{1});
     $self->assert_str_equals('Message 1', $fetch->{1}{headers}{subject}[0]);
 
     xlog $self, "Create mailbox in other session";
@@ -124,8 +124,8 @@ sub test_idle
     $self->assert_num_equals(1, $talk->get_response_code('recent'));
 
     $fetch = $talk->get_response_code('fetch');
-    $self->assert_num_equals(2, $fetch->{1}{uid});
-    $self->assert_str_equals('Message 2', $fetch->{1}{headers}{subject}[0]);
+    $self->assert_not_null($fetch->{2});
+    $self->assert_str_equals('Message 2', $fetch->{2}{headers}{subject}[0]);
 
     xlog $self, "Unselect INBOX";
     $talk->unselect();

--- a/cassandane/tiny-tests/Notify/message
+++ b/cassandane/tiny-tests/Notify/message
@@ -98,14 +98,16 @@ sub test_message
     $self->assert_num_equals(1, $talk->get_response_code('recent'));
 
     my $fetch = $talk->get_response_code('fetch');
-    $self->assert_num_equals(3, $fetch->{2}{uid});
-    $self->assert_str_equals('Message 3', $fetch->{2}{headers}{subject}[0]);
-    $self->assert_not_null($fetch->{2}{headers}{from});
-    $self->assert_not_null($fetch->{2}{emailid}[0]);
-    $self->assert_not_null($fetch->{2}{mailboxids}[0]);
+    $self->assert_not_null($fetch->{3});
+    $self->assert_str_equals('Message 3', $fetch->{3}{headers}{subject}[0]);
+    $self->assert_not_null($fetch->{3}{headers}{from});
+    $self->assert_not_null($fetch->{3}{emailid}[0]);
+    $self->assert_not_null($fetch->{3}{mailboxids}[0]);
 
     xlog $self, "DELETE message from INBOX in other session";
-    $res = $othertalk->store('1', '+flags', '(\\Deleted)');
+    # UID 1 was expunged further up, so the message sitting at the front of
+    # this mailbox is UID 2.
+    $res = $othertalk->store('2', '+flags', '(\\Deleted)');
 
     # Should get FETCH response for INBOX
     $res = $store->idle_response('FETCH', 3);
@@ -114,8 +116,8 @@ sub test_message
     $self->assert(!$res, "no more unsolicited responses");
 
     $fetch = $talk->get_response_code('fetch');
-    $self->assert_num_equals(2, $fetch->{1}{uid});
-    $self->assert_str_equals('\\Deleted', $fetch->{1}{flags}[0]);
+    $self->assert_not_null($fetch->{2});
+    $self->assert_str_equals('\\Deleted', $fetch->{2}{flags}[0]);
 
     xlog $self, "EXPUNGE message from INBOX in other session";
     $res = $othertalk->expunge();

--- a/cassandane/tiny-tests/Reconstruct/downgrade_upgrade
+++ b/cassandane/tiny-tests/Reconstruct/downgrade_upgrade
@@ -5,7 +5,7 @@ sub test_downgrade_upgrade ($self)
 {
     my $talk = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $talk->uid());
+    $talk->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Add two messages";
@@ -22,19 +22,19 @@ sub test_downgrade_upgrade ($self)
 
     xlog $self, "Set \\Seen on message A";
     my $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 
     xlog $self, "Clear \\Seen on message A";
         $res = $talk->store('1', '-flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [] }}, $res);
     $msg{A}->set_attribute(flags => []);
     $self->check_messages(\%msg);
 
     xlog $self, "Set \\Seen on message A again";
     $res = $talk->store('1', '+flags', '(\\Seen)');
-    $self->assert_deep_equals({ '1' => { 'flags' => [ '\\Seen' ] }}, $res);
+    $self->assert_deep_equals({ '1' => { 'uid' => '1', 'flags' => [ '\\Seen' ] }}, $res);
     $msg{A}->set_attribute(flags => ['\\Seen']);
     $self->check_messages(\%msg);
 

--- a/cassandane/tiny-tests/Replication/toarchive
+++ b/cassandane/tiny-tests/Replication/toarchive
@@ -11,7 +11,7 @@ sub test_toarchive
 
     my $mtalk = $self->{master_store}->get_client();
     $self->{master_store}->_select();
-    $self->assert_num_equals(1, $mtalk->uid());
+    $mtalk->uid(1);
     $self->{master_store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Append 3 old messages";

--- a/cassandane/tiny-tests/Replication/toarchive_noarchive
+++ b/cassandane/tiny-tests/Replication/toarchive_noarchive
@@ -11,7 +11,7 @@ sub test_toarchive_noarchive
 
     my $mtalk = $self->{master_store}->get_client();
     $self->{master_store}->_select();
-    $self->assert_num_equals(1, $mtalk->uid());
+    $mtalk->uid(1);
     $self->{master_store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Append 3 old messages";

--- a/cassandane/tiny-tests/Search/searchres
+++ b/cassandane/tiny-tests/Search/searchres
@@ -224,15 +224,13 @@ EOF
     xlog $self, "Fetch using the search results";
     $res = $imaptalk->fetch('$', 'UID');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
-    $self->assert_num_equals(5, scalar keys %{$res});
-    $self->assert_str_equals('3', $res->{'2'}->{uid});
-    $self->assert_str_equals('4', $res->{'3'}->{uid});
-    $self->assert_str_equals('5', $res->{'4'}->{uid});
-    $self->assert_str_equals('6', $res->{'5'}->{uid});
-    $self->assert_str_equals('7', $res->{'6'}->{uid});
+    # The saved result still names the same five messages after the expunge.
+    $self->assert_deep_equals([ 3, 4, 5, 6, 7 ],
+                              [ sort { $a <=> $b } keys %{$res} ]);
 
     xlog $self, "Expunge the middle message in the search results range";
-    $res = $imaptalk->store('4', '+flags', '(\\Deleted)');
+    # The saved result is UIDs 3,4,5,6,7, so the middle of it is UID 5.
+    $res = $imaptalk->store('5', '+flags', '(\\Deleted)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $res = $imaptalk->expunge();
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
@@ -240,14 +238,12 @@ EOF
     xlog $self, "Fetch using the search results";
     $res = $imaptalk->fetch('$', 'UID');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
-    $self->assert_num_equals(4, scalar keys %{$res});
-    $self->assert_str_equals('3', $res->{'2'}->{uid});
-    $self->assert_str_equals('4', $res->{'3'}->{uid});
-    $self->assert_str_equals('6', $res->{'4'}->{uid});
-    $self->assert_str_equals('7', $res->{'5'}->{uid});
+    $self->assert_deep_equals([ 3, 4, 6, 7 ],
+                              [ sort { $a <=> $b } keys %{$res} ]);
 
     xlog $self, "Expunge the 1st message in the 1st range and the last in the 2nd";
-    $res = $imaptalk->store('2,5', '+flags', '(\\Deleted)');
+    # The saved result is now UIDs 3,5,6,7 -- ranges "3" and "5:7".
+    $res = $imaptalk->store('3,7', '+flags', '(\\Deleted)');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $res = $imaptalk->expunge();
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
@@ -255,9 +251,8 @@ EOF
     xlog $self, "Fetch using the search results";
     $res = $imaptalk->fetch('$', 'UID');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
-    $self->assert_num_equals(2, scalar keys %{$res});
-    $self->assert_str_equals('4', $res->{'2'}->{uid});
-    $self->assert_str_equals('6', $res->{'3'}->{uid});
+    $self->assert_deep_equals([ 4, 6 ],
+                              [ sort { $a <=> $b } keys %{$res} ]);
 
     xlog $self, "Search the mailbox for a from address in the saved results";
     @results = ();
@@ -269,6 +264,6 @@ EOF
     xlog $self, "Fetch using the search results";
     $res = $imaptalk->fetch('$', 'UID');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
-    $self->assert_num_equals(1, scalar keys %{$res});
-    $self->assert_str_equals('6', $res->{'3'}->{uid});
+    $self->assert_deep_equals([ 6 ],
+                              [ sort { $a <=> $b } keys %{$res} ]);
 }

--- a/cassandane/tiny-tests/Sieve/deliver_multiple_users
+++ b/cassandane/tiny-tests/Sieve/deliver_multiple_users
@@ -28,27 +28,34 @@ EOF
     $self->{instance}->deliver($msg1,
                                users => [ 'cassandane', 'other1', 'other2' ]);
 
-    # message should NOT appear in cassandane INBOX
+    # message should NOT appear in cassandane INBOX.  A UID FETCH naming a
+    # message that isn't there returns nothing rather than failing, so check
+    # that nothing came back rather than that the command was refused.
     my $admintalk = $self->{adminstore}->get_client();
     $admintalk->examine('user.cassandane');
-    $admintalk->fetch('1', '(flags)');
-    $self->assert_str_equals('no', $admintalk->get_last_completion_response());
+    my $res = $admintalk->fetch('1', '(flags)');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $self->assert_null($res);
 
     # message should appear in other1 INBOX
     $admintalk->examine('user.other1');
-    my $res = $admintalk->fetch('1', '(flags)');
+    $res = $admintalk->fetch('1', '(flags)');
     $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
-    $self->assert_deep_equals($res, { '1' => { 'flags' => [ '\\Recent'] }});
+    $self->assert_deep_equals($res,
+                              { '1' => { 'uid' => '1',
+                                         'flags' => [ '\\Recent'] }});
 
     # message should NOT appear in other2 INBOX
     $admintalk->examine('user.other2');
-    $admintalk->fetch('1', '(flags)');
-    $self->assert_str_equals('no', $admintalk->get_last_completion_response());
+    $res = $admintalk->fetch('1', '(flags)');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $self->assert_null($res);
 
     # message should appear in other2 INBOX.sub
     $admintalk->examine('user.other2.sub');
     $res = $admintalk->fetch('1', '(flags)');
     $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
     $self->assert_deep_equals($res,
-                              { '1' => { 'flags' => [ '\\Recent', '\\Flagged'] }});
+                              { '1' => { 'uid' => '1',
+                                         'flags' => [ '\\Recent', '\\Flagged'] }});
 }

--- a/cassandane/tiny-tests/Sieve/imip_add
+++ b/cassandane/tiny-tests/Sieve/imip_add
@@ -7,7 +7,7 @@ sub test_imip_add
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_allow_public
+++ b/cassandane/tiny-tests/Sieve/imip_allow_public
@@ -7,7 +7,7 @@ sub test_imip_allow_public
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_cancel
+++ b/cassandane/tiny-tests/Sieve/imip_cancel
@@ -7,7 +7,7 @@ sub test_imip_cancel
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_cancel_delete
+++ b/cassandane/tiny-tests/Sieve/imip_cancel_delete
@@ -7,7 +7,7 @@ sub test_imip_cancel_delete
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_cancel_instance
+++ b/cassandane/tiny-tests/Sieve/imip_cancel_instance
@@ -7,7 +7,7 @@ sub test_imip_cancel_instance
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_cancel_to_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_cancel_to_organizer
@@ -7,7 +7,7 @@ sub test_imip_cancel_to_organizer
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_disallow_multiple_vcalendar
+++ b/cassandane/tiny-tests/Sieve/imip_disallow_multiple_vcalendar
@@ -7,7 +7,7 @@ sub test_imip_disallow_multiple_vcalendar
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_disallow_public
+++ b/cassandane/tiny-tests/Sieve/imip_disallow_public
@@ -7,7 +7,7 @@ sub test_imip_disallow_public
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite
+++ b/cassandane/tiny-tests/Sieve/imip_invite
@@ -7,7 +7,7 @@ sub test_imip_invite
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_base64
+++ b/cassandane/tiny-tests/Sieve/imip_invite_base64
@@ -7,7 +7,7 @@ sub test_imip_invite_base64
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_calendarid
+++ b/cassandane/tiny-tests/Sieve/imip_invite_calendarid
@@ -7,7 +7,7 @@ sub test_imip_invite_calendarid
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user and second calendar";

--- a/cassandane/tiny-tests/Sieve/imip_invite_funky_uid
+++ b/cassandane/tiny-tests/Sieve/imip_invite_funky_uid
@@ -7,7 +7,7 @@ sub test_imip_invite_funky_uid
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_known_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_invite_known_organizer
@@ -7,7 +7,7 @@ sub test_imip_invite_known_organizer
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_multipart
+++ b/cassandane/tiny-tests/Sieve/imip_invite_multipart
@@ -7,7 +7,7 @@ sub test_imip_invite_multipart
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_single_then_master
+++ b/cassandane/tiny-tests/Sieve/imip_invite_single_then_master
@@ -7,7 +7,7 @@ sub test_imip_invite_single_then_master
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_unknown_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_invite_unknown_organizer
@@ -7,7 +7,7 @@ sub test_imip_invite_unknown_organizer
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_updatesonly
+++ b/cassandane/tiny-tests/Sieve/imip_invite_updatesonly
@@ -7,7 +7,7 @@ sub test_imip_invite_updatesonly
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_invite_wrong_addr
+++ b/cassandane/tiny-tests/Sieve/imip_invite_wrong_addr
@@ -7,7 +7,7 @@ sub test_imip_invite_wrong_addr
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_override
+++ b/cassandane/tiny-tests/Sieve/imip_override
@@ -7,7 +7,7 @@ sub test_imip_override
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_preserve_alerts
+++ b/cassandane/tiny-tests/Sieve/imip_preserve_alerts
@@ -7,7 +7,7 @@ sub test_imip_preserve_alerts
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_publish
+++ b/cassandane/tiny-tests/Sieve/imip_publish
@@ -7,7 +7,7 @@ sub test_imip_publish
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_publish_legacy
+++ b/cassandane/tiny-tests/Sieve/imip_publish_legacy
@@ -7,7 +7,7 @@ sub test_imip_publish_legacy
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_publish_no_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_publish_no_organizer
@@ -7,7 +7,7 @@ sub test_imip_publish_no_organizer
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_publish_no_organizer_legacy
+++ b/cassandane/tiny-tests/Sieve/imip_publish_no_organizer_legacy
@@ -7,7 +7,7 @@ sub test_imip_publish_no_organizer_legacy
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply
+++ b/cassandane/tiny-tests/Sieve/imip_reply
@@ -7,7 +7,7 @@ sub test_imip_reply
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_no_organizer
+++ b/cassandane/tiny-tests/Sieve/imip_reply_no_organizer
@@ -7,7 +7,7 @@ sub test_imip_reply_no_organizer
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_one_recurrence
+++ b/cassandane/tiny-tests/Sieve/imip_reply_one_recurrence
@@ -7,7 +7,7 @@ sub test_imip_reply_one_recurrence
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_override
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override
@@ -7,7 +7,7 @@ sub test_imip_reply_override
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_override_google
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override_google
@@ -7,7 +7,7 @@ sub test_imip_reply_override_google
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_override_invalid
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override_invalid
@@ -7,7 +7,7 @@ sub test_imip_reply_override_invalid
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_override_rdate
+++ b/cassandane/tiny-tests/Sieve/imip_reply_override_rdate
@@ -7,7 +7,7 @@ sub test_imip_reply_override_rdate
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_partycrasher
+++ b/cassandane/tiny-tests/Sieve/imip_reply_partycrasher
@@ -8,7 +8,7 @@ sub test_imip_reply_partycrasher
 
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_two_recurrences
+++ b/cassandane/tiny-tests/Sieve/imip_reply_two_recurrences
@@ -7,7 +7,7 @@ sub test_imip_reply_two_recurrences
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_reply_with_alarm
+++ b/cassandane/tiny-tests/Sieve/imip_reply_with_alarm
@@ -7,7 +7,7 @@ sub test_imip_reply_with_alarm
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_strip_personal_data
+++ b/cassandane/tiny-tests/Sieve/imip_strip_personal_data
@@ -7,7 +7,7 @@ sub test_imip_strip_personal_data
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_strip_x_lic_error
+++ b/cassandane/tiny-tests/Sieve/imip_strip_x_lic_error
@@ -7,7 +7,7 @@ sub test_imip_strip_x_lic_error
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     my $CalDAV = $self->{caldav};

--- a/cassandane/tiny-tests/Sieve/imip_update
+++ b/cassandane/tiny-tests/Sieve/imip_update
@@ -7,7 +7,7 @@ sub test_imip_update
 {
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/Sieve/imip_update_master_and_add_override
+++ b/cassandane/tiny-tests/Sieve/imip_update_master_and_add_override
@@ -10,7 +10,7 @@ sub test_imip_update_master_and_add_override
 
     my $IMAP = $self->{store}->get_client();
     $self->{store}->_select();
-    $self->assert_num_equals(1, $IMAP->uid());
+    $IMAP->uid(1);
     $self->{store}->set_fetch_attributes(qw(uid flags));
 
     xlog $self, "Create calendar user";

--- a/cassandane/tiny-tests/UIDonly/copy_move
+++ b/cassandane/tiny-tests/UIDonly/copy_move
@@ -27,20 +27,25 @@ sub test_copy_move
     $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
     $self->assert_num_equals(1, $res->{uidonly});
 
+    # Rejecting message sequence numbers is the whole point of UIDONLY, so
+    # these two have to be asked in sequence numbers to mean anything.
     xlog $self, "attempt COPY";
-    $res = $imaptalk->copy(1, $folder);
+    $self->with_seq_mode($imaptalk, sub { $imaptalk->copy(1, $folder) });
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $imaptalk->get_last_error());
 
     xlog $self, "attempt MOVE";
-    $res = $imaptalk->move(1, $folder);
+    $self->with_seq_mode($imaptalk, sub { $imaptalk->move(1, $folder) });
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $imaptalk->get_last_error());
 
+    # Spelled out with 0 rather than letting _imap_cmd add the "uid ": what
+    # is under test is which form the server accepts, so the command must not
+    # depend on the connection's mode.
     xlog $self, "UID MOVE";
-    $res = $imaptalk->_imap_cmd('UID MOVE', 1, 'vanished', '1', $folder);
+    $res = $imaptalk->_imap_cmd('UID MOVE', 0, 'vanished', '1', $folder);
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $self->assert_str_equals('1', $res->[0]);
 }

--- a/cassandane/tiny-tests/UIDonly/fetch
+++ b/cassandane/tiny-tests/UIDonly/fetch
@@ -24,24 +24,17 @@ sub test_fetch
     $imaptalk->expunge();
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
 
-    xlog $self, "FETCH all UID + FLAGS";
-    my $res = $imaptalk->fetch('1:*', '(UID FLAGS)');
-    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
-    $self->assert_str_equals($res->{'1'}->{uid}, "2");
-    $self->assert_str_equals($res->{'2'}->{uid}, "3");
-    $self->assert_str_equals($res->{'3'}->{uid}, "4");
-    $self->assert_str_equals($res->{'4'}->{uid}, "5");
-    $self->assert_str_equals($res->{'5'}->{uid}, "7");
-    $self->assert_str_equals($res->{'6'}->{uid}, "8");
-    $self->assert_str_equals($res->{'7'}->{uid}, "9");
-    $self->assert_str_equals($res->{'8'}->{uid}, "10");
+    xlog $self, "the survivors closed up in sequence, keeping their UIDs";
+    $self->assert_seq_uids($imaptalk, [ 2, 3, 4, 5, 7, 8, 9, 10 ]);
 
     xlog $self, "ENABLE UIDONLY";
-    $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
+    my $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
     $self->assert_num_equals(1, $res->{uidonly});
 
+    # Rejecting message sequence numbers is the whole point of UIDONLY, so
+    # this has to be asked in sequence numbers to mean anything.
     xlog $self, "attempt FETCH again";
-    $res = $imaptalk->fetch('1:*', '(UID FLAGS)');
+    $self->with_seq_mode($imaptalk, sub { $imaptalk->fetch('1:*', '(UID FLAGS)') });
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $imaptalk->get_last_error());

--- a/cassandane/tiny-tests/UIDonly/search
+++ b/cassandane/tiny-tests/UIDonly/search
@@ -39,18 +39,24 @@ sub test_search
     $res = $imaptalk->_imap_cmd('ENABLE', 0, 'enabled', 'UIDONLY');
     $self->assert_num_equals(1, $res->{uidonly});
 
+    # Rejecting message sequence numbers is the whole point of UIDONLY, so
+    # this has to be asked in sequence numbers to mean anything.
     xlog $self, "attempt SEARCH";
-    $res = $imaptalk->search('not', 'deleted');
+    $self->with_seq_mode($imaptalk, sub { $imaptalk->search('not', 'deleted') });
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $imaptalk->get_last_error());
 
+    # These spell the command out and pass 0 rather than letting _imap_cmd
+    # add the "uid " for them: this test turns UID mode off a few lines up,
+    # and what it is checking is the literal syntax the server accepts, so
+    # the command should not depend on the connection's state.
     xlog $self, "attempt UID SEARCH with msgnos";
-    $res = $imaptalk->_imap_cmd('UID SEARCH', 1, 'search', '1:10');
+    $res = $imaptalk->_imap_cmd('UID SEARCH', 0, 'search', '1:10');
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
 
     xlog $self, "UID SEARCH";
-    $res = $imaptalk->_imap_cmd('UID SEARCH', 1, 'search', 'not', 'deleted');
+    $res = $imaptalk->_imap_cmd('UID SEARCH', 0, 'search', 'not', 'deleted');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $self->assert_num_equals(8, scalar @{$res});
     $self->assert_num_equals(2, $res->[0]);
@@ -63,7 +69,7 @@ sub test_search
     $self->assert_num_equals(10, $res->[7]);
 
     xlog $self, "UID SEARCH with UIDs";
-    $res = $imaptalk->_imap_cmd('UID SEARCH', 1, 'search', 'uid', '1:10');
+    $res = $imaptalk->_imap_cmd('UID SEARCH', 0, 'search', 'uid', '1:10');
     $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
     $self->assert_num_equals(10, scalar @{$res});
 }

--- a/cassandane/tiny-tests/UIDonly/store
+++ b/cassandane/tiny-tests/UIDonly/store
@@ -23,8 +23,11 @@ sub test_store
     $self->assert_num_equals(1, $res->{uidonly});
     $self->assert_num_equals(1, $res->{condstore});
 
+    # Rejecting message sequence numbers is the whole point of UIDONLY, so
+    # this has to be asked in sequence numbers to mean anything.
     xlog $self, "attempt STORE";
-    $imaptalk->store('1,6', '+FLAGS', '(\\Deleted)');
+    $self->with_seq_mode($imaptalk,
+                         sub { $imaptalk->store('1,6', '+FLAGS', '(\\Deleted)') });
     $self->assert_str_equals('bad', $imaptalk->get_last_completion_response());
     # get_response_code() doesn't (yet) handle [UIDREQUIRED]
     $self->assert_matches(qr/\[UIDREQUIRED\]/, $imaptalk->get_last_error());

--- a/cassandane/tiny-tests/UIDonly/unsolicited
+++ b/cassandane/tiny-tests/UIDonly/unsolicited
@@ -27,7 +27,8 @@ sub test_unsolicited
     $res = $admintalk->select('user.cassandane');
 
     xlog $self, "set flag in another session";
-    $admintalk->store('1', '+flags', '\\flagged');
+    # UID 1 was expunged above, so the surviving message is UID 2.
+    $admintalk->store('2', '+flags', '\\flagged');
 
     xlog $self, "poll for changes";
     my %fetched = $self->uidonly_cmd($imaptalk, 'NOOP');


### PR DESCRIPTION
UIDs are the right thing.  We should focus on testing via UIDs, and sequence numbers are tested on demand.