### PR TITLE
squatter.c: restart batch indexing at uid 1 after mailbox recreation

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -396,6 +396,9 @@ magic(SearchNormalizationMax20000 => sub {
 magic(SearchBatchsize20 => sub {
     shift->config_set(search_batchsize => 20);
 });
+magic(SquatterBatchDelay => sub {
+    shift->config_set(squatter_batch_delay => '10s');
+});
 magic(SearchMaxtime => sub ($self, $seconds) {
     $self->config_set(search_maxtime => $seconds);
 });

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_batch_mbox_recreated
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_batch_mbox_recreated
@@ -1,0 +1,80 @@
+#!perl
+use Cassandane::Tiny;
+
+# Squatter indexes a mailbox in batches, and holds no lock on that mailbox
+# between two batches. A mailbox that got deleted and created again by that
+# name in this window has nothing in common with the one squatter started
+# on, so squatter must restart at its first message rather than resume at
+# the uid it had reached before.
+
+sub test_squatter_batch_mbox_recreated
+    :SearchBatchsize20 :SquatterBatchDelay
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    my $instance = $self->{instance};
+
+    xlog $self, "Create mailbox A with more messages than fit in one batch";
+    $talk->create("A") || die;
+    $self->{store}->set_folder("A");
+    foreach my $i (1..21) {
+        $self->make_message("oldmsg$i") || die;
+    }
+
+    xlog $self, "Clear syslog";
+    $instance->getsyslog();
+
+    xlog $self, "Index mailbox A in the background";
+    my $pid = $instance->run_command({ cyrus => 1, background => 1 },
+        'squatter', 'user.cassandane.A');
+
+    xlog $self, "Wait for squatter to have indexed the first batch";
+    # The mailbox must get recreated while squatter sleeps between batches,
+    # so poll at a fixed rate rather than with the backoff of timed_wait,
+    # which could grow past that sleep.
+    my $deadline = time() + 60;
+    while (1) {
+        $talk->select("A") || die;
+        last if scalar @{$talk->search('fuzzy', 'subject', 'oldmsg2')};
+        die "Timed out waiting for squatter to index the first batch"
+            if time() >= $deadline;
+        sleep 1;
+    }
+
+    xlog $self, "Delete A and create a new mailbox A while squatter waits";
+    $talk->delete("A") || die;
+    $talk->create("A") || die;
+    # Uid 1 and 2 are below the uid that squatter resumes at, so a batch
+    # that keeps resuming there never indexes these messages.
+    $self->{store}->set_folder("A");
+    $self->make_message("newmsg1") || die;
+    $self->make_message("newmsg2") || die;
+
+    xlog $self, "Assert squatter terminated normally";
+    eval {
+        # a looping squatter would block waitpid forever, and there is no
+        # per-test timeout, so make sure it does not hang the whole run
+        local $SIG{ALRM} = sub { die "Timed out waiting for squatter to exit\n" };
+        alarm 60;
+        $instance->reap_command($pid);
+        alarm 0;
+    };
+    if (my $err = $@) {
+        alarm 0;
+        eval { $instance->stop_command($pid) };
+        die $err;
+    }
+
+    xlog $self, "Assert the messages of the new mailbox A got indexed";
+    $talk->select("A") || die;
+    foreach my $subject ("newmsg1", "newmsg2") {
+        my $uids = $talk->search('fuzzy', 'subject', $subject);
+        $self->assert_num_equals(1, scalar @{$uids});
+    }
+
+    if ($instance->{have_syslog_replacement}) {
+        xlog $self, "Assert squatter reported the recreated mailbox";
+        my @log = $instance->getsyslog(qr/event=search\.index\.restarted/);
+        $self->assert_num_equals(1, scalar @log);
+    }
+}

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_index_default
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_index_default
@@ -1,13 +1,13 @@
 #!perl
 use Cassandane::Tiny;
-use POSIX qw(WNOHANG);
 
 sub test_squatter_index_default
     :SearchBatchsize20
     ($self)
 {
     my $talk = $self->{store}->get_client();
-    my $basedir = $self->{instance}->{basedir};
+    my $instance = $self->{instance};
+    my $basedir = $instance->{basedir};
     my $outfile = "$basedir/audit.tmp";
 
     xlog $self, "append enough messages for three full batches and a partial one";
@@ -16,26 +16,45 @@ sub test_squatter_index_default
         $self->make_message("filler $i") || die;
     }
 
+    xlog $self, "Clear syslog";
+    $instance->getsyslog();
+
     xlog $self, "a bare squatter run must complete: when broken it re-selects the same batch forever";
-    my $pid = $self->{instance}->run_command(
-        {cyrus => 1, background => 1}, 'squatter');
-    my $done = 0;
-    my $batchlines = 0;
+    my $pid = $instance->run_command({cyrus => 1, background => 1}, 'squatter');
+
+    xlog $self, "wait for squatter to index every message";
     eval {
         timed_wait(sub {
-            if (waitpid($pid, WNOHANG) == $pid) {
-                $done = 1;
-                return 1;
-            }
-            # a correct run logs one batching line per full batch, so a
-            # fourth one means it is looping
-            $batchlines += scalar $self->{instance}->getsyslog(qr/batching/);
-            return $batchlines > 3;
-        }, description => "squatter to finish", maxwait => 60);
+            $talk->select('INBOX') || die;
+            return scalar @{$talk->search('fuzzy', 'subject', 'filler')} == $nmsgs;
+        }, description => "squatter to index all messages", maxwait => 60);
     };
-    # kill a looping squatter rather than letting it outlive the test
-    eval { $self->{instance}->stop_command($pid) } if not $done;
-    $self->assert($done);
+    if (my $err = $@) {
+        # kill a looping squatter rather than letting it outlive the test
+        eval { $instance->stop_command($pid) };
+        die $err;
+    }
+
+    xlog $self, "squatter must terminate normally";
+    eval {
+        # a looping squatter would block waitpid forever, and there is no
+        # per-test timeout, so make sure it does not hang the whole run
+        local $SIG{ALRM} = sub { die "Timed out waiting for squatter to exit\n" };
+        alarm 60;
+        $instance->reap_command($pid);
+        alarm 0;
+    };
+    if (my $err = $@) {
+        alarm 0;
+        eval { $instance->stop_command($pid) };
+        die $err;
+    }
+
+    if ($instance->{have_syslog_replacement}) {
+        xlog $self, "a correct run batches once per full batch, and no more";
+        my @log = $instance->getsyslog(qr/search_update_mailbox batching/);
+        $self->assert_num_equals(3, scalar @log);
+    }
 
     xlog $self, "every message must be searchable";
     $talk->select('INBOX');
@@ -43,12 +62,12 @@ sub test_squatter_index_default
     $self->assert_num_equals($nmsgs, scalar @$uids);
 
     xlog $self, "one run indexes each message once: no batch may re-add an earlier one";
-    my $xapdirs = ($self->{instance}->run_mbpath(-u => 'cassandane'))->{xapian};
+    my $xapdirs = ($instance->run_mbpath(-u => 'cassandane'))->{xapian};
     my ($gdocs, $parts) = $self->delve_docs($xapdirs->{t1} . "/xapian");
     $self->assert_num_equals($nmsgs, scalar @$gdocs);
 
     xlog $self, "audit reports no unindexed messages";
-    $self->{instance}->run_command(
+    $instance->run_command(
         { cyrus => 1, redirects => { stdout => $outfile } },
         'squatter', '-A');
     open my $fh, '<', $outfile or die "open $outfile: $!";
@@ -57,7 +76,7 @@ sub test_squatter_index_default
     $self->assert_num_equals(0, scalar @audits);
 
     xlog $self, "an incremental run must find nothing left to index";
-    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+    $instance->run_command({cyrus => 1}, 'squatter', '-i');
     ($gdocs, $parts) = $self->delve_docs($xapdirs->{t1} . "/xapian");
     $self->assert_num_equals($nmsgs, scalar @$gdocs);
 }

--- a/changes/next/cyr-3384-squatter-index-one-mbox-recreate
+++ b/changes/next/cyr-3384-squatter-index-one-mbox-recreate
@@ -1,0 +1,25 @@
+Description:
+
+A batched squatter update now restarts at the first message of a mailbox
+that got deleted and created again by that name between two of its
+batches, rather than resuming at the uid it had reached before.
+
+
+Documentation:
+
+:cyrusman:`squatter(8)`, :cyrusman:`imapd.conf(5)`
+
+
+Config changes:
+
+squatter_batch_delay (new)
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None

--- a/doc/logfmt-keys
+++ b/doc/logfmt-keys
@@ -108,6 +108,7 @@ search.duration         how long a search index operation took, in seconds
 search.expr             a search expression, serialised
 search.generation       the search index generation
 search.op               a search operator, e.g. OR
+search.restarts         how many times indexing restarted from the first message
 search.uncommitted      how many documents were pending when a commit failed
 search.updates          how many update passes indexed nothing
 sieve.target            the target of a Sieve action: a folder, address or url

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -275,12 +275,21 @@ done:
  * indexing goes away, so give up rather than block this run on it. */
 #define MAX_UNPRODUCTIVE_UPDATES 3
 
+/* How many times to restart indexing the same mailbox because it got
+ * recreated between two batches. A client that keeps recreating a mailbox
+ * would otherwise block this run on that mailbox forever. */
+#define MAX_MAILBOX_RESTARTS 3
+
 /* This is called once for each mailbox we're told to index. */
 static int index_one(const char *name, int blocking)
 {
     struct mailbox *mailbox = NULL;
     int nunproductive = 0;
+    int nrestarts = 0;
     uint32_t resumeuid = 0;
+    uint32_t uidvalidity = 0;
+    char *prev_uniqueid = NULL;
+    int32_t batch_delay = config_getduration(IMAPOPT_SQUATTER_BATCH_DELAY);
     int r;
     int flags = SEARCH_UPDATE_BATCH;
 
@@ -350,17 +359,27 @@ again:
 
     if (r == IMAP_MAILBOX_LOCKED) {
         if (verbose) syslog(LOG_INFO, "mailbox %s locked, retrying", extname);
-        free(extname);
-        return r;
+        goto done;
     }
     if (r) {
         if (verbose) {
             printf("error opening %s: %s\n", extname, error_message(r));
         }
         syslog(LOG_INFO, "error opening %s: %s", extname, error_message(r));
-        free(extname);
 
-        return r;
+        goto done;
+    }
+
+    /* We are going to compare unique id later. A mailbox without one needs
+     * a reconstruct before anything can index it, so skip it. */
+    if (!mailbox_uniqueid(mailbox)) {
+        xsyslog_ev(LOG_ERR, "mailbox.uniqueid.missing",
+                lf_mailbox(mailbox));
+        if (verbose > 0) {
+            printf("Skipping mailbox %s\n", extname);
+        }
+        mailbox_close(&mailbox);
+        goto done;
     }
 
     syslog(LOG_INFO, "indexing mailbox %s... ", extname);
@@ -378,11 +397,39 @@ again:
                 printf("Skipping mailbox %s\n", extname);
             }
             mailbox_close(&mailbox);
-            free(extname);
-            return 0;
+            goto done;
         }
     }
 
+    /* a mailbox that got recreated between batches restarts at uid 1 */
+    if (uidvalidity != mailbox->i.uidvalidity
+        || (prev_uniqueid && strcmp(prev_uniqueid, mailbox_uniqueid(mailbox))))
+    {
+        if (prev_uniqueid) {
+            xsyslog_ev(LOG_NOTICE, "search.index.restarted",
+                    lf_s("mbox.name", name),
+                    lf_s("old.mbox.uniqueid", prev_uniqueid),
+                    lf_s("mbox.uniqueid", mailbox_uniqueid(mailbox)),
+                    lf_u("old.mbox.uidvalidity", uidvalidity),
+                    lf_u("mbox.uidvalidity", mailbox->i.uidvalidity));
+
+            /* Restarting resets the guard against unproductive updates, so
+             * a mailbox that keeps changing could loop here forever. */
+            if (++nrestarts > MAX_MAILBOX_RESTARTS) {
+                xsyslog_ev(LOG_ERR, "search.index.abandoned",
+                        lf_s("mbox.name", name),
+                        lf_d("search.restarts", nrestarts));
+                mailbox_close(&mailbox);
+                r = IMAP_AGAIN;
+                goto done;
+            }
+        }
+        uidvalidity = mailbox->i.uidvalidity;
+        resumeuid = 0;
+    }
+
+    free(prev_uniqueid);
+    prev_uniqueid = xstrdup(mailbox_uniqueid(mailbox));
     uint32_t prevuid = resumeuid;
     r = search_update_mailbox(rx, &mailbox, reindex_minlevel, flags, &resumeuid);
 
@@ -397,16 +444,22 @@ again:
          * while we extracted its attachment text, may never complete. */
         if (resumeuid > prevuid) {
             nunproductive = 0;
-            goto again;
         }
-        if (++nunproductive <= MAX_UNPRODUCTIVE_UPDATES) goto again;
+        else if (++nunproductive > MAX_UNPRODUCTIVE_UPDATES) {
+            xsyslog_ev(LOG_ERR, "search.index.abandoned",
+                    lf_s("mbox.name", name),
+                    lf_d("search.updates", nunproductive));
+            goto done;
+        }
 
-        xsyslog_ev(LOG_ERR, "search.index.abandoned",
-                lf_s("mbox.name", name),
-                lf_d("search.updates", nunproductive));
+        /* squatter holds no lock on the mailbox while it sleeps */
+        if (batch_delay > 0) sleep(batch_delay);
+        goto again;
     }
-    free(extname);
 
+done:
+    free(extname);
+    free(prev_uniqueid);
     return r;
 }
 

--- a/lib/imapoptions/squatter_batch_delay
+++ b/lib/imapoptions/squatter_batch_delay
@@ -1,0 +1,8 @@
+Name: squatter_batch_delay
+Type: DURATION
+Default-Value: 0s
+Last-Modified: 3.13.7
+
+Time for squatter to pause between two indexing batches of the same mailbox.
+Squatter holds no lock on that mailbox while it pauses, so other processes
+get a chance to lock it.


### PR DESCRIPTION
This makes batch indexing more robust against mailbox deletions and recreation between batches.

As a follow-up to dbbea16e9bf1afab93d4d2c8e3b42edef35528a7 which had introduced `resumeuid`, let's also detect the case where the mailbox got recreated between two batches. In this case we want to restart indexing from the first message in the mailbox. To prevent getting stuck we give up after a couple of batch restarts.

We introduce a new `squatter_batch_delay` option to configure how long squatter should wait between two indexing batches of the same mailbox. This option is used for testing, but it might also be useful to prevent mailbox lock starvation between squatter and other processes.

While we are at it, we also refine the test logic in the recently added squatter_index_default test that asserts the changes in dbbea16e9bf1afab93d4d2c8e3b42edef35528a7.