### PR TITLE
cassandane: filter CalendarEvent/query with inCalendar

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
@@ -162,39 +162,15 @@ sub test_calendarevent_query
         wantFastPath => JSON::true,
     }, {
         filter => {
-            inCalendars => [$calendarIdA, $calendarIdB],
-        },
-        wantIds => [$eventA1{id}, $eventA2{id}, $eventB1{id}],
-        wantFastPath => JSON::true,
-    }, {
-        filter => {
-            operator => 'NOT',
-            conditions => [{
-                inCalendars => [$calendarIdA],
-            }],
-        },
-        wantIds => [$eventB1{id}],
-        wantFastPath => JSON::true,
-    }, {
-        filter => {
             operator => 'OR',
             conditions => [{
-                inCalendars => [$calendarIdA, $calendarIdB],
+                inCalendar => $calendarIdA,
+            }, {
+                inCalendar => $calendarIdB,
             }],
         },
         wantIds => [$eventA1{id}, $eventA2{id}, $eventB1{id}],
         wantFastPath => JSON::true,
-    }, {
-        filter => {
-            operator => 'AND',
-            conditions => [{
-                inCalendars => [$calendarIdA],
-            }, {
-                text => 'test',
-            }],
-        },
-        wantIds => [$eventA1{id}, $eventA2{id}],
-        wantFastPath => JSON::false,
     }, {
         filter => {
             inCalendar => $calendarIdA,
@@ -234,6 +210,14 @@ sub test_calendarevent_query
         wantErr => {
             type => 'invalidArguments',
             arguments => [ 'filter/inCalendar' ],
+        },
+    }, {
+        filter => {
+            inCalendars => [$calendarIdA], # invalid - no such filter condition
+        },
+        wantErr => {
+            type => 'invalidArguments',
+            arguments => [ 'filter/inCalendars' ],
         },
     }, {
         filter => undef,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_shared
@@ -135,7 +135,7 @@ sub test_calendarevent_query_shared
         $res = $jmap->CallMethods([ ['CalendarEvent/query', {
                         accountId => $account,
                         "filter" => {
-                            "inCalendars" => [ $calidA ],
+                            "inCalendar" => $calidA,
                         }
                     }, "R1"] ]);
         $self->assert_num_equals(1, scalar @{$res->[0][1]{ids}});
@@ -145,7 +145,11 @@ sub test_calendarevent_query_shared
         $res = $jmap->CallMethods([ ['CalendarEvent/query', {
                         accountId => $account,
                         "filter" => {
-                            "inCalendars" => [ $calidA, $calidB ],
+                            "operator" => "OR",
+                            "conditions" => [
+                                { "inCalendar" => $calidA },
+                                { "inCalendar" => $calidB },
+                            ],
                         }
                     }, "R1"] ]);
         $self->assert_num_equals(2, scalar @{$res->[0][1]{ids}});
@@ -155,9 +159,10 @@ sub test_calendarevent_query_shared
                         accountId => $account,
                         "filter" => {
                             "operator" => "NOT",
-                            "conditions" => [{
-                                    "inCalendars" => [ $calidA, $calidB ],
-                                }],
+                            "conditions" => [
+                                { "inCalendar" => $calidA },
+                                { "inCalendar" => $calidB },
+                            ],
                         }}, "R1"]]);
         $self->assert_num_equals(0, scalar @{$res->[0][1]{ids}});
 

--- a/changes/next/cyr-3090-remove-inCalendars-filter
+++ b/changes/next/cyr-3090-remove-inCalendars-filter
@@ -1,0 +1,24 @@
+Description:
+
+Removes the non-standard "inCalendars" filter condition from
+CalendarEvent/query; use the standard "inCalendar" condition instead.
+
+
+Documentation:
+
+None.
+
+Config changes:
+
+None.
+
+Upgrade instructions:
+
+None.
+JMAP clients that filter CalendarEvent/query by "inCalendars" must switch to
+"inCalendar", combining several conditions with an "OR" filter operator if they
+need to match more than one calendar.
+
+GitHub issue:
+
+None.

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -7345,7 +7345,7 @@ static search_expr_t *eventquery_textsearch_build(jmap_req_t *req,
     search_expr_t *this, *e;
     const char *s;
     size_t i;
-    json_t *val, *arg;
+    json_t *val;
 
     if (!JNOTNULL(filter)) {
         return search_expr_new(parent, SEOP_TRUE);
@@ -7370,22 +7370,6 @@ static search_expr_t *eventquery_textsearch_build(jmap_req_t *req,
         }
     } else {
         this = search_expr_new(parent, SEOP_AND);
-
-        if ((arg = json_object_get(filter, "inCalendars"))) {
-            e = search_expr_new(this, SEOP_OR);
-            json_array_foreach(arg, i, val) {
-                const char *id = json_string_value(val);
-                mbentry_t *mbentry = NULL;
-
-                calid_to_mbentry(req, id, &mbentry);
-                if (mbentry) {
-                    search_expr_t *m = search_expr_new(e, SEOP_MATCH);
-                    m->attr = search_attr_find("folder");
-                    m->value.s = xstrdup(mbentry->name);
-                    mboxlist_entry_free(&mbentry);
-                }
-            }
-        }
 
         if ((s = json_string_value(json_object_get(filter, "inCalendar")))) {
             mbentry_t *mbentry = NULL;
@@ -7749,37 +7733,20 @@ static struct caldav_jscal_filter *build_jscal_filter(jmap_req_t *req,
     struct caldav_jscal_filter *filter = caldav_jscal_filter_new();
     const char *s;
 
-    if (json_array_size(json_object_get(jfilter, "inCalendars")) ||
-        json_string_value(json_object_get(jfilter, "inCalendar"))) {
-        size_t i;
-        json_t *jval;
-        json_t *jcalendars = json_object_get(jfilter, "inCalendars");
-        json_t *jcalendar = json_object_get(jfilter, "inCalendar");
+    s = json_string_value(json_object_get(jfilter, "inCalendar"));
+    if (s) {
+        mbentry_t *mbentry = NULL;
 
-        json_t *ids = json_array();
-        json_array_foreach(jcalendars, i, jval) {
-            json_array_append(ids, jval);
+        calid_to_mbentry(req, s, &mbentry);
+
+        if (mbentry &&
+            jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
+            caldav_jscal_filter_by_mbentrym(filter, mbentry);
         }
-        if (json_string_value(jcalendar)) {
-            json_array_append(ids, jcalendar);
+        else if (!mbentry) {
+            xsyslog(LOG_WARNING, "could not lookup calendar",
+                    "calendarId=<%s>", s);
         }
-
-        json_array_foreach(ids, i, jval) {
-            const char *id = json_string_value(jval);
-            mbentry_t *mbentry = NULL;
-
-            calid_to_mbentry(req, id, &mbentry);
-
-            if (mbentry &&
-                jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
-                caldav_jscal_filter_by_mbentrym(filter, mbentry);
-            }
-            else if (!mbentry) {
-                xsyslog(LOG_WARNING, "could not lookup calendar",
-                        "calendarId=<%s>", id);
-            }
-        }
-        json_decref(ids);
 
         if (!ptrarray_size(&filter->mbentries))
             filter->op = CALDAV_JSCAL_FALSE;
@@ -8083,23 +8050,6 @@ static void calendarevent_validatefilter(jmap_req_t *req __attribute__((unused))
             const char *id = json_string_value(arg);
             if (!id || id[0] == '#') {
                 jmap_parser_invalid(parser, field);
-            }
-        }
-        else if (!strcmp(field, "inCalendars")) {
-            if (!(json_is_array(arg) && json_array_size(arg))) {
-                jmap_parser_invalid(parser, field);
-            }
-            else {
-                size_t i;
-                json_t *uid;
-                json_array_foreach(arg, i, uid) {
-                    const char *id = json_string_value(uid);
-                    if (!id || id[0] == '#') {
-                        jmap_parser_push_index(parser, field, i, id);
-                        jmap_parser_invalid(parser, NULL);
-                        jmap_parser_pop(parser);
-                    }
-                }
             }
         }
         else if (!strcmp(field, "before") ||


### PR DESCRIPTION
The plural "inCalendars" is not part of JMAP for Calendars, so it can go away.  Client code has been converted to inCalendar (and, if necessary, logical operators).