### PR TITLE
http_dav.c: fix for DAV ACL ACE without principal crasher

### DIFF
--- a/cassandane/tiny-tests/Carddav/acl_missing_principal
+++ b/cassandane/tiny-tests/Carddav/acl_missing_principal
@@ -1,0 +1,31 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_acl_missing_principal ($self)
+{
+    my $carddav = $self->{carddav};
+    my $book = $carddav->NewAddressBook('acl-crash-controlled');
+    $self->assert_not_null($book);
+
+    my $xml = <<'EOF';
+<?xml version="1.0" encoding="utf-8"?>
+<D:acl xmlns:D="DAV:">
+  <D:ace>
+    <D:grant>
+      <D:privilege><D:read/></D:privilege>
+    </D:grant>
+  </D:ace>
+</D:acl>
+EOF
+
+    my %headers = (
+        'Content-Type'  => 'application/xml; charset=utf-8',
+        'Authorization' => $carddav->auth_header(),
+    );
+
+    my $res = $carddav->{ua}->request(
+        'ACL', $carddav->request_url($book),
+        { content => $xml, headers => \%headers });
+
+    $self->assert_num_equals(400, $res->{status});
+}

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -3998,6 +3998,12 @@ int meth_acl(struct transaction_t *txn, void *params)
                 }
             }
 
+            if (!prin) {
+                txn->error.desc = "Missing principal in ACE";
+                ret = HTTP_BAD_REQUEST;
+                goto done;
+            }
+
             if (!xmlStrcmp(prin->name, BAD_CAST "self")) {
                 userid = httpd_userid;
             }


### PR DESCRIPTION
Prior to this fix, httpd would segfault due to trying to dereference a NULL pointer