### PR TITLE
caldav: do not dereference an unparsed calendar-availability

### DIFF
--- a/cassandane/tiny-tests/Caldav/sched_busytime_query_bad_availability
+++ b/cassandane/tiny-tests/Caldav/sched_busytime_query_bad_availability
@@ -1,0 +1,50 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_sched_busytime_query_bad_availability
+    :NoVirtDomains :MagicPlus
+    ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    # Create a second calendar user
+    my $user = $self->{instance}->create_user("friend");
+    $user->caldav;
+
+    # Create a +DAV IMAP connection for the second user
+    my $plusstore = $self->{instance}->get_service('imap')->create_store(username => 'friend+dav');
+    my $imaptalk = $plusstore->get_client();
+
+    # CALDAV:calendar-availability is stored verbatim and only parsed when a
+    # free/busy query needs it, so a value that does not parse leaves
+    # icalparser_parse_string() returning NULL.  add_vavailability() used to
+    # walk that pointer, taking httpd down with it - the client sees the
+    # connection close mid-response rather than an answer.
+    $imaptalk->setmetadata("#calendars.Inbox",
+        "/shared/vendor/cmu/cyrus-httpd/<urn:ietf:params:xml:ns:caldav>calendar-availability",
+        "this is not an iCalendar object");
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    my $query = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+METHOD:REQUEST
+BEGIN:VFREEBUSY
+UID:5D3E1B26-8CF2-4C9C-9F4E-3D0F5C0A7A11
+DTSTAMP:20210802T131858Z
+DTEND:20210903T000000Z
+DTSTART:20210902T210000Z
+ATTENDEE:MAILTO:cassandane\@example.com
+ATTENDEE:MAILTO:friend\@example.com
+ORGANIZER:MAILTO:cassandane\@example.com
+END:VFREEBUSY
+END:VCALENDAR
+EOF
+
+    xlog $self, "freebusy query covering a user whose availability does not parse";
+    my $res = $CalDAV->Request('POST', 'Outbox',
+                               $query, 'Content-Type' => 'text/calendar');
+    my $text = Dumper($res);
+    $self->assert_matches(qr/schedule-response/, $text);
+}

--- a/changes/next/caldav-availability-null-guard
+++ b/changes/next/caldav-availability-null-guard
@@ -1,0 +1,20 @@
+Description:
+
+Fix a crash in the CalDAV free/busy handler when a scheduling query covers
+several recipients and one of them publishes a CALDAV:calendar-availability.
+
+Documentation:
+
+No documentation change: the fix restores the documented behaviour.
+
+Config changes:
+
+None.
+
+Upgrade instructions:
+
+None.
+
+GitHub issue:
+
+None filed; the crash and its reproduction are described in the pull request.

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -7470,6 +7470,19 @@ add_vavailability(struct vavailability_array *vavail, icalcomponent *ical)
     icalcomponent *vav;
     icalproperty *prop;
 
+    /* Callers hand us whatever came out of a parse: the CALDAV:calendar-availability
+       annotation is stored verbatim and only parsed here, so icalparser_parse_string()
+       may well have returned NULL, and a component that did parse may still hold
+       nothing we can take a period from.  Either way this array owns what it is
+       given, so anything refused has to be freed rather than leaked. */
+    if (!ical) return;
+
+    vav = icalcomponent_get_first_real_component(ical);
+    if (!vav) {
+        icalcomponent_free(ical);
+        return;
+    }
+
     /* Grow the array, if necessary */
     if (vavail->len == vavail->alloc) {
         vavail->alloc += 10;  /* XXX  arbitrary */
@@ -7480,8 +7493,6 @@ add_vavailability(struct vavailability_array *vavail, icalcomponent *ical)
     /* Add new vavailability */
     newav = &vavail->vav[vavail->len++];
     newav->ical = ical;
-
-    vav = icalcomponent_get_first_real_component(ical);
 
     /* Set period */
     newav->per.start = icalcomponent_get_dtstart(vav);

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -8019,6 +8019,7 @@ icalcomponent *busytime_query_local(struct transaction_t *txn,
                                   icalparser_parse_string(buf_cstring(&attrib)));
             }
         }
+        buf_free(&attrib);
         free(mboxname);
         free(userid);
     }


### PR DESCRIPTION
### The crash

`httpd` dies on a CalDAV free/busy request (`POST` to a scheduling Outbox) as soon as the query names **more than one recipient and any one of them publishes office hours** (a `CALDAV:calendar-availability` on their scheduling Inbox):

```
#0  icalcomponent_get_first_component (libical.so.3 + 0x33f16)
#1  busytime_query_local
#2  sched_busytime_query
#3  caldav_post
#4  meth_post
    signal 11 (Segmentation fault, core dumped)
```

The client sees the connection close mid-response; behind a reverse proxy it surfaces as a 502.

### Why

`add_vavailability()` stores the component and walks it in the same breath:

```c
newav->ical = ical;
vav = icalcomponent_get_first_real_component(ical);
newav->per.start = icalcomponent_get_dtstart(vav);
```

Neither pointer is checked, and both can be NULL:

* `busytime_query_local()` passes `icalparser_parse_string(buf_cstring(&attrib))` straight in. The annotation is stored verbatim and parsed only here, so a value that does not parse yields NULL.
* Even for a component that parses, `icalcomponent_get_first_real_component()` returns NULL when there is nothing it recognises inside, leaving `vav` NULL for the `icalcomponent_get_dtstart()` on the next line.

`add_vavailability()` is static and gets inlined, which is why the frame attributed to it in the backtrace is `busytime_query_local`.

### The change

Return early when there is nothing usable, before touching the array. The array owns what it is handed — entries are released through `vav->ical` at the end of the query — so a refused component is freed here rather than leaked. A client whose availability cannot be applied now simply gets a free/busy answer without it, instead of losing the connection.

### Reproducing

Observed on 3.8.3, and the same code is on master.

1. Give a user office hours:
   `PROPPATCH` `CALDAV:calendar-availability` on their scheduling Inbox with any VAVAILABILITY.
2. `POST` a `METHOD:REQUEST` VFREEBUSY to a scheduling Outbox with **two** `ATTENDEE` lines, one of them that user.
3. The child process dies with the backtrace above.

Asking about the same people **one at a time** answers correctly every time, which is what made the failure look data-dependent at first. Removing the availability also makes it go away.

I could not tell from a production core dump which of the two pointers was NULL — the guard covers both, and each is reachable from the call site.