### PR TITLE
universal logfmt: phase 0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -530,6 +530,7 @@ dist_noinst_SCRIPTS = \
     lib/mkchartable.pl \
     perl/sieve/scripts/sieveshell.pl \
     tools/arbitronsort.pl \
+    tools/lint-logfmt-keys \
     tools/fixsearchpath.pl \
     tools/fixup-zoneinfo.pl \
     tools/git-version.sh \
@@ -737,7 +738,7 @@ check_PROGRAMS += cunit/unit
 # To run unit tests under Valgrind, do:
 #     make VG=1 check
 # This applies to all check rules except check-fast.
-check-local: cunit/run
+check-local: cunit/run lint-logfmt-keys
 	@echo "Running unit tests"
 	$(PERL) cunit/run --verbose --tmpdir=$(CYRUS_CUNIT_TMPDIR)
 
@@ -769,6 +770,19 @@ check-discrete-%: cunit/run cunit/unit
 	$(PERL) cunit/run --discrete --tmpdir=$(CYRUS_CUNIT_TMPDIR) $*
 
 endif # CUNIT
+
+# Check that every logfmt key used in the source is registered in
+# doc/logfmt-keys.  See doc/README.logfmt.md.
+#
+# n.b. neither the target nor the script is named check-something.  The
+# check-% pattern rule above matches after the directory part is stripped,
+# so a "tools/check-logfmt-keys" prerequisite sends make off trying to run
+# a cunit suite called "tools/logfmt-keys".
+lint-logfmt-keys:
+	@echo "Checking logfmt keys"
+	$(AM_V_at)$(PERL) $(top_srcdir)/tools/lint-logfmt-keys $(top_srcdir)
+
+.PHONY: lint-logfmt-keys
 
 includedir=@includedir@/cyrus
 

--- a/cassandane/Cassandane/Cyrus/Rename.pm
+++ b/cassandane/Cassandane/Cyrus/Rename.pm
@@ -50,8 +50,8 @@ sub _match_intermediates
 {
     my ($self, %expect) = @_;
     my @lines = $self->{instance}->getsyslog();
-    #'Aug 23 12:34:20 bat 0234200101/ctl_cyrusdb[14527]: mboxlist: creating intermediate with children: user.cassandane.a (ec10f137-1bee-443e-8cb2-c6c893463b0a)',
-    #'Aug 23 12:34:20 bat 0234200101/ctl_cyrusdb[14527]: mboxlist: deleting intermediate with no children: user.cassandane.hanging (b13ba9d4-9d40-4474-911f-77346a73d747)',
+    #'<notice> Aug 23 12:34:20 bat 0234200101/ctl_cyrusdb[14527]: mboxlist: creating intermediate with children: user.cassandane.a (ec10f137-1bee-443e-8cb2-c6c893463b0a)',
+    #'<notice> Aug 23 12:34:20 bat 0234200101/ctl_cyrusdb[14527]: mboxlist: deleting intermediate with no children: user.cassandane.hanging (b13ba9d4-9d40-4474-911f-77346a73d747)',
     for (@lines) {
         if (m/mboxlist: creating intermediate with children: (.*?)($| \()/) {
             my $mbox = $1;

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1837,6 +1837,34 @@ sub _check_sanity
     return;
 }
 
+# Lines captured by our syslog replacement (utils/syslog.c) are prefixed
+# with the severity they were logged at.  These are the severities that
+# mean the server hit a problem the test didn't ask for.
+my $error_severity = qr{^<(?:emerg|alert|crit|err)>};
+
+# Decide whether a captured syslog line represents an unexpected error.
+#
+# logfmt events (which always begin "event=") carry their severity, so we
+# can recognise a problem without knowing anything about the message text.
+# That's the whole point of recording the severity: as logfmt conversion
+# proceeds, messages can be reworded freely without silently switching off
+# this check.
+#
+# Everything else is still matched by text.  We can't simply promote the
+# old messages to severity matching, because plenty of them are logged at
+# LOG_ERR without being the kind of error a test should fail on.  This
+# clause shrinks as logfmt conversion proceeds, and goes away with the last
+# unconverted call site.
+sub _syslog_line_is_error
+{
+    my ($line) = @_;
+
+    return scalar $line =~ $error_severity
+        if $line =~ m/\]: event=/;
+
+    return scalar $line =~ m/ERROR|TRACELOG|Unknown code ____/;
+}
+
 sub _check_syslog
 {
     my ($self, $pattern) = @_;
@@ -1849,7 +1877,7 @@ sub _check_syslog
 
     my @lines = $self->getsyslog();
     my @errors = grep {
-        m/ERROR|TRACELOG|Unknown code ____/ || ($pattern && m/$pattern/)
+        _syslog_line_is_error($_) || ($pattern && m/$pattern/)
     } @lines;
 
     @errors = grep { not m/DBERROR.*skipstamp/ } @errors;
@@ -2812,6 +2840,15 @@ sub setup_syslog_replacement
 # In most cases you probably want assert_syslog_matches from TestCase
 # (or assert_syslog_does_not_match).  If you need something trickier,
 # check those anyway to see how to do so safely.
+#
+# Returned lines look like:
+#
+#   <notice> Aug 23 12:34:20.123456 bat 0234200101/imap[14527]: message
+#
+# The leading "<severity>" is added by our syslog replacement, because real
+# syslog doesn't preserve the priority into the log file.  Match on it if
+# you care how loudly something was logged; don't rely on it to identify
+# a message, since the same event can be logged at different severities.
 sub getsyslog
 {
     my ($self, $pattern) = @_;

--- a/cassandane/tiny-tests/Caldav/schedule_organizer_mismatch
+++ b/cassandane/tiny-tests/Caldav/schedule_organizer_mismatch
@@ -42,5 +42,5 @@ EOF
 
     xlog $self, "We should have generated a syslog message about the mismatch";
     $self->assert_syslog_matches($self->{instance},
-        qr/Not scheduling calendar component/);
+        qr/event=caldav\.schedule\.skipped/);
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move_fast_path
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move_fast_path
@@ -63,7 +63,7 @@ sub test_calendarevent_set_move_fast_path
     xlog $self, "Assert that the fast path was taken";
     if ($self->{instance}->{have_syslog_replacement}) {
         my @lines = $self->{instance}->getsyslog(
-            qr/moved calendar event via fast path/);
+            qr/event=jmap\.calendarevent\.moved/);
         $self->assert_num_equals(1, scalar @lines);
     }
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_organizer_mismatch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_organizer_mismatch
@@ -49,5 +49,5 @@ sub test_calendarevent_set_schedule_organizer_mismatch
 
     xlog $self, "We should have generated a syslog message about the mismatch";
     $self->assert_syslog_matches($self->{instance},
-        qr/Not scheduling calendar component/);
+        qr/event=caldav\.schedule\.skipped/);
 }

--- a/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_interrupted
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_interrupted
@@ -154,6 +154,6 @@ sub test_squatter_attachextract_interrupted_mbox_recreated
         $self->create_message_in_mailbox("A", { subject => "recreatedmsg1" });
         $self->create_message_in_mailbox("A", { subject => "recreatedmsg2" });
         $self->create_message_in_mailbox("A", { subject => "recreatedmsg3" });
-    }, expect_syslog => qr/mailbox changed while extracting attachments/,
+    }, expect_syslog => qr/event=search\.index\.mailbox_changed/,
        expect_reindexed => ["recreatedmsg1", "recreatedmsg2", "recreatedmsg3"]);
 }

--- a/cassandane/utils/syslog.c
+++ b/cassandane/utils/syslog.c
@@ -6,6 +6,12 @@
  *
  * Set CASSANDANE_SYSLOG_FNAME in the environment to specify the file
  * to which logged lines should be appended.
+ *
+ * Each captured line is prefixed with the severity it was logged at, as
+ * "<err> ", so that log consumers can recognise problems without having
+ * to match on message text.  Real syslog discards the priority by the
+ * time it reaches the log file, which is why we record it ourselves.
+ * Cassandane::Instance::_check_syslog depends on this prefix.
  */
 
 /* need _GNU_SOURCE for RTLD_NEXT */
@@ -88,6 +94,22 @@ EXPORTED void closelog(void)
     is_opened = 0;
 }
 
+/* The severity names used by syslog.conf(5), so that they'll look familiar. */
+static const char *severity_name(int priority)
+{
+    switch (LOG_PRI(priority)) {
+    case LOG_EMERG:   return "emerg";
+    case LOG_ALERT:   return "alert";
+    case LOG_CRIT:    return "crit";
+    case LOG_ERR:     return "err";
+    case LOG_WARNING: return "warning";
+    case LOG_NOTICE:  return "notice";
+    case LOG_INFO:    return "info";
+    case LOG_DEBUG:   return "debug";
+    default:          return "unknown";
+    }
+}
+
 static void fake_vsyslog(int priority, const char *format, va_list ap)
 {
     struct timeval now = {0};
@@ -103,8 +125,11 @@ static void fake_vsyslog(int priority, const char *format, va_list ap)
 
     gettimeofday(&now, NULL);
 
+    /* The severity goes first, so that it can be matched with an anchored
+     * pattern that can never be confused by the message body. */
     strftime(timestamp, sizeof(timestamp), "%b %d %T", localtime(&now.tv_sec));
-    fprintf(out, "%s.%06" PRIdMAX " %s %s[%" PRIdMAX "]: ",
+    fprintf(out, "<%s> %s.%06" PRIdMAX " %s %s[%" PRIdMAX "]: ",
+                 severity_name(priority),
                  timestamp, (intmax_t) now.tv_usec,
                  hostname, myident, (intmax_t) pid);
     errno = saved_errno;

--- a/changes/next/logfmt-foundations
+++ b/changes/next/logfmt-foundations
@@ -1,0 +1,48 @@
+Description:
+
+Groundwork for converting Cyrus's syslogging to logfmt.  The logfmt event
+and key vocabulary is now written down and enforced, xsyslog_ev() has
+helpers for booleans, times, durations, errors, optional fields and whole
+structs, and it no longer builds events that the log mask will discard.
+
+The handful of logfmt call sites that predated the vocabulary have been
+renamed to conform to it.  These events changed name and field names:
+
+  "unexpected OR, expected DNF subclause" -> search.query.unexpected_op
+  "Not scheduling calendar component..."  -> caldav.schedule.skipped
+  "append_setup_mbox failed"              -> jmap.calendarevent.move.failed
+  "append_copy failed"                    -> jmap.calendarevent.move.failed
+  "append_commit failed"                  -> jmap.calendarevent.move.failed
+  "mailbox_rewrite_index_record failed"   -> jmap.calendarevent.move.failed
+  "moved calendar event via fast path"    -> jmap.calendarevent.moved
+  "attachment text is not cached"         -> search.attachextract.uncached
+  "could not extract all attachment text" -> search.attachextract.incomplete
+  "giving up on mailbox that indexes..."  -> search.index.abandoned
+  "mailbox changed while extracting..."   -> search.index.mailbox_changed
+  "not updating indexed.db after..."      -> search.index.state.skipped
+  "bumping index generation"              -> search.index.generation.bumped
+  "committed Xapian transaction"          -> search.xapian.transaction.committed
+  "failed to commit transaction"          -> search.xapian.transaction.failed
+  "cannot calculate changes: search..."   -> jmap.querychanges.index_changed
+
+
+Documentation:
+
+doc/README.logfmt.md
+doc/logfmt-keys
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+Deployments parsing the events listed above will need to update their
+tooling.  No other log output has changed yet.
+
+
+GitHub issue:
+
+None

--- a/cunit/logfmt.testc
+++ b/cunit/logfmt.testc
@@ -431,7 +431,7 @@ static void test_logfmt_push_mbname(void)
     logfmt_fini(&lf);
 }
 
-static void test_logfmt_push_record(void)
+static void test_logfmt_push_msgrecord(void)
 {
     static const char msg[] = "banana";
     struct index_record test_record = {
@@ -451,9 +451,9 @@ static void test_logfmt_push_record(void)
     snprintf(expect_size, sizeof(expect_size), "msg.size=" SIZE_T_FMT,
              strlen(msg));
 
-    logfmt_init(&lf, "test_logfmt_push_record");
+    logfmt_init(&lf, "test_logfmt_push_msgrecord");
 
-    logfmt_push_record(&lf, &test_record);
+    logfmt_push_msgrecord(&lf, &test_record);
 
     CU_ASSERT_PTR_NOT_NULL(strstr(logfmt_cstring(&lf), "msg.imapuid=123"));
     CU_ASSERT_PTR_NOT_NULL(strstr(logfmt_cstring(&lf), "msg.modseq=234"));

--- a/cunit/xsyslog_ev.testc
+++ b/cunit/xsyslog_ev.testc
@@ -1,6 +1,8 @@
 #include "cunit/unit.h"
 #include "lib/util.h"
 
+#include "imap/imap_err.h"
+
 #include "lib/libconfig.h"
 #include "lib/logfmt.h"
 #include "lib/sessionid.h"
@@ -8,6 +10,7 @@
 #include <syslog.h>
 #include <limits.h>
 #include <errno.h>
+#include <time.h>
 
 #define DBDIR "test-xsyslogev-dbdir"
 
@@ -353,6 +356,164 @@ static void test_trace_id(void)
     xsyslog_ev(LOG_ERR, "trace id test",
                         lf_d("first", 1));
     CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_b(void)
+{
+    int falsey = 0;
+
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_b"
+                           " yes=1 no=0 truthy=1 falsey=0");
+    xsyslog_ev(LOG_ERR, "test.lf_b",
+        lf_b("yes", 1), lf_b("no", 0), lf_b("truthy", 42),
+        lf_b("falsey", falsey));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_time(void)
+{
+    time_t when = 1723150181;
+
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_time"
+                           " when=1723150181 epoch=0");
+    xsyslog_ev(LOG_ERR, "test.lf_time",
+        lf_time("when", when), lf_time("epoch", (time_t) 0));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_duration(void)
+{
+    /* always seconds, always three decimal places, so that durations
+     * logged in different places are directly comparable
+     */
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_duration"
+                           " half=0.500 long=12.000 tiny=0.000 whole=3.142");
+    xsyslog_ev(LOG_ERR, "test.lf_duration",
+        lf_duration("half", 0.5),
+        lf_duration("long", 12.0),
+        lf_duration("tiny", 0.0004),
+        lf_duration("whole", 3.14159));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static void test_lf_buf(void)
+{
+    struct buf buf = BUF_INITIALIZER;
+
+    buf_setcstr(&buf, "two words");
+
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_buf value=\"two words\"");
+    xsyslog_ev(LOG_ERR, "test.lf_buf", lf_buf("value", &buf));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&buf);
+}
+
+static void test_lf_err(void)
+{
+    struct buf escaped = BUF_INITIALIZER;
+    struct buf want = BUF_INITIALIZER;
+
+    logfmt_escape_bytestring(&escaped, error_message(IMAP_MAILBOX_NONEXISTENT));
+    buf_printf(&want, "event=test.lf_err error=%s", buf_cstring(&escaped));
+
+    CU_SYSLOG_MATCH_SUBSTR(buf_cstring(&want));
+    xsyslog_ev(LOG_ERR, "test.lf_err",
+        lf_err("error", IMAP_MAILBOX_NONEXISTENT));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    buf_free(&want);
+    buf_free(&escaped);
+}
+
+static void test_lf_s_opt(void)
+{
+    unsigned pat_line = 0, pat_gone = 0;
+
+    /* a NULL lf_s_opt() contributes nothing at all, where a NULL lf_s()
+     * would have logged ~null~
+     */
+    pat_line = CU_SYSLOG_MATCH_SUBSTR("event=test.lf_s_opt"
+                                      " here=yes null=~null~");
+    pat_gone = CU_SYSLOG_MATCH_SUBSTR("gone=");
+
+    xsyslog_ev(LOG_ERR, "test.lf_s_opt",
+        lf_s_opt("here", "yes"),
+        lf_s_opt("gone", NULL),
+        lf_s("null", NULL));
+
+    CU_ASSERT_SYSLOG(pat_line, 1);
+    CU_ASSERT_SYSLOG(pat_gone, 0);
+}
+
+static void test_lf_s_opt_evaluates_once(void)
+{
+    const char *values[] = { "first", "second" };
+    int i = 0;
+
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_s_opt_once value=first");
+    xsyslog_ev(LOG_ERR, "test.lf_s_opt_once",
+        lf_s_opt("value", values[i++]));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    CU_ASSERT_EQUAL(1, i);
+}
+
+static void test_lf_flag(void)
+{
+    unsigned pat_line = 0, pat_off = 0;
+
+    pat_line = CU_SYSLOG_MATCH_SUBSTR("event=test.lf_flag on=1 after=1");
+    pat_off = CU_SYSLOG_MATCH_SUBSTR("off=");
+
+    xsyslog_ev(LOG_ERR, "test.lf_flag",
+        lf_flag("on", 1),
+        lf_flag("off", 0),
+        lf_d("after", 1));
+
+    CU_ASSERT_SYSLOG(pat_line, 1);
+    CU_ASSERT_SYSLOG(pat_off, 0);
+}
+
+static void test_no_args(void)
+{
+    CU_SYSLOG_MATCH_SUBSTR("event=test.no_args");
+    xsyslog_ev(LOG_ERR, "test.no_args");
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+}
+
+static int side_effects = 0;
+
+static int have_a_side_effect(void)
+{
+    side_effects++;
+
+    return 1;
+}
+
+static void test_masked_priority(void)
+{
+    int oldmask = setlogmask(LOG_UPTO(LOG_INFO));
+
+    /* a masked-out event isn't logged, and -- the point of the exercise --
+     * its arguments aren't even evaluated
+     */
+    side_effects = 0;
+    CU_SYSLOG_MATCH_SUBSTR("event=test.masked");
+    xsyslog_ev(LOG_DEBUG, "test.masked", lf_d("n", have_a_side_effect()));
+    CU_ASSERT_SYSLOG(/*all*/0, 0);
+    CU_ASSERT_EQUAL(0, side_effects);
+
+    /* ... and once it's not masked out, both happen again */
+    setlogmask(LOG_UPTO(LOG_DEBUG));
+
+    side_effects = 0;
+    CU_SYSLOG_MATCH_SUBSTR("event=test.unmasked n=1");
+    xsyslog_ev(LOG_DEBUG, "test.unmasked", lf_d("n", have_a_side_effect()));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+    CU_ASSERT_EQUAL(1, side_effects);
+
+    setlogmask(oldmask);
 }
 
 static int mess_with_errno(void)

--- a/cunit/xsyslog_ev.testc
+++ b/cunit/xsyslog_ev.testc
@@ -6,6 +6,7 @@
 #include "lib/libconfig.h"
 #include "lib/logfmt.h"
 #include "lib/sessionid.h"
+#include "lib/strarray.h"
 
 #include <syslog.h>
 #include <limits.h>
@@ -473,6 +474,74 @@ static void test_lf_flag(void)
 
     CU_ASSERT_SYSLOG(pat_line, 1);
     CU_ASSERT_SYSLOG(pat_off, 0);
+}
+
+static void test_lf_strarray(void)
+{
+    strarray_t sa = STRARRAY_INITIALIZER;
+    strarray_t empty = STRARRAY_INITIALIZER;
+    unsigned pat_line = 0, pat_bare = 0;
+
+    strarray_append(&sa, "one@example.com");
+    strarray_append(&sa, "two words");
+
+    /* one indexed key per element, and the bare key doesn't appear at all */
+    pat_line = CU_SYSLOG_MATCH_SUBSTR("event=test.lf_strarray"
+                                      " addrs.0=one@example.com"
+                                      " addrs.1=\"two words\" after=1");
+    pat_bare = CU_SYSLOG_MATCH_SUBSTR(" addrs=");
+
+    xsyslog_ev(LOG_ERR, "test.lf_strarray",
+        lf_strarray("addrs", &sa),
+        lf_d("after", 1));
+
+    CU_ASSERT_SYSLOG(pat_line, 1);
+    CU_ASSERT_SYSLOG(pat_bare, 0);
+
+    /* empty and NULL stay distinguishable, as they are for a string value */
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_strarray empty=\"\" null=~null~");
+    xsyslog_ev(LOG_ERR, "test.lf_strarray",
+        lf_strarray("empty", &empty),
+        lf_strarray("null", NULL));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    strarray_fini(&sa);
+}
+
+struct pair {
+    const char *one;
+    const char *two;
+};
+
+/* stands in for the real push functions, which live over in imap/ */
+static void push_pair(struct logfmt *lf, const char *key, const void *value)
+{
+    const struct pair *pair = value;
+    struct buf subkey = BUF_INITIALIZER;
+
+    buf_printf(&subkey, "%s.one", key);
+    logfmt_push(lf, buf_cstring(&subkey), pair->one);
+
+    buf_setcstr(&subkey, key);
+    buf_appendcstr(&subkey, ".two");
+    logfmt_push(lf, buf_cstring(&subkey), pair->two);
+
+    buf_free(&subkey);
+}
+
+static void test_lf_fn(void)
+{
+    struct pair pair = { "hello", "there" };
+
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_fn"
+                           " thing.one=hello thing.two=there");
+    xsyslog_ev(LOG_ERR, "test.lf_fn", lf_fn("thing", push_pair, &pair));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
+
+    /* the same struct under a different key */
+    CU_SYSLOG_MATCH_SUBSTR("event=test.lf_fn old.one=hello old.two=there");
+    xsyslog_ev(LOG_ERR, "test.lf_fn", lf_fn("old", push_pair, &pair));
+    CU_ASSERT_SYSLOG(/*all*/0, 1);
 }
 
 static void test_no_args(void)

--- a/doc/README.logfmt.md
+++ b/doc/README.logfmt.md
@@ -7,7 +7,7 @@ logs can be parsed reliably instead of scraped with regular expressions.
 This document is the rulebook for that conversion.  It covers how to emit an
 event, how to name it, and how to name and format its fields.  The vocabulary
 itself — the list of every key you're allowed to use — lives in
-[`doc/logfmt-keys`](logfmt-keys) and is enforced by `tools/check-logfmt-keys`.
+[`doc/logfmt-keys`](logfmt-keys) and is enforced by `tools/lint-logfmt-keys`.
 
 ## Why a rulebook
 
@@ -170,7 +170,7 @@ Two structural prefixes stack on top of the above:
 Rules:
 
 - **Every key must be registered** in `doc/logfmt-keys` before use.
-  `tools/check-logfmt-keys` fails the build otherwise.  Adding a key is meant
+  `tools/lint-logfmt-keys` fails the build otherwise.  Adding a key is meant
   to be easy — a one-line patch — but deliberate.
 - **Same fact, same key, everywhere.** If you're about to invent a key for
   something that already has one, use the existing one even if you'd have
@@ -291,7 +291,7 @@ correctly by rejecting it.
 2. If there isn't one, add it there, in the same patch as the code that uses
    it, with a description that says what the value *is* — not what your one
    call site uses it for.
-3. Run `tools/check-logfmt-keys` (or just build; it runs as part of `make
+3. Run `tools/lint-logfmt-keys` (or just build; it runs as part of `make
    check`).
 
 ## Changing an existing event
@@ -345,7 +345,7 @@ properly.
 | `imap/auditlog.c`              | the `auditlog.*` event family                            |
 | `imap/loginlog.c`              | the `login.*` event family                               |
 | `doc/logfmt-keys`              | the registered key vocabulary                            |
-| `tools/check-logfmt-keys`      | the lint that enforces it                                |
+| `tools/lint-logfmt-keys`       | the lint that enforces it                                |
 | `cunit/logfmt.testc`           | tests for escaping and the push functions                |
 | `cunit/xsyslog_ev.testc`       | tests for `xsyslog_ev()` and the `lf_*` macros           |
 

--- a/doc/README.logfmt.md
+++ b/doc/README.logfmt.md
@@ -1,0 +1,357 @@
+# Structured logging with logfmt
+
+Cyrus is converting its syslogging from prose to
+[logfmt](https://metacpan.org/pod/Log::Fmt#The-logfmt-text-format), so that
+logs can be parsed reliably instead of scraped with regular expressions.
+
+This document is the rulebook for that conversion.  It covers how to emit an
+event, how to name it, and how to name and format its fields.  The vocabulary
+itself — the list of every key you're allowed to use — lives in
+[`doc/logfmt-keys`](logfmt-keys) and is enforced by `tools/check-logfmt-keys`.
+
+## Why a rulebook
+
+The value of structured logging is entirely in its consistency.  A log where
+the same fact is called `mboxid` in one place, `mbox.uniqueid` in another and
+`uniqueid` in a third is barely better than prose, because every consumer still
+needs a table of special cases.
+
+Cyrus has around 2700 logging call sites.  Converting them without an agreed
+vocabulary would produce exactly that mess, so the vocabulary comes first and
+the lint makes it stick.
+
+## The shape of an event
+
+A logfmt event is a single syslog line of `key=value` pairs:
+
+```
+event=login.good r.sessionid=fastmail-1723150181-3493991-1 r.clienthost=10.0.0.7 u.username=jbloggs login.mech=PLAIN login.tls=1
+```
+
+`event` always comes first, and every line has exactly one.  It is the name of
+the thing that happened, and it is what a log consumer keys off.
+
+Values are escaped by `lib/logfmt.c`, which quotes anything containing a space
+or other awkward byte.  You never have to escape or quote a value yourself, and
+you should never try — passing a pre-quoted string just gets it double-quoted.
+
+The grammar the escaper implements is documented in a comment at the top of
+`logfmt_escape_bytestring()` in `lib/logfmt.c`.
+
+## Emitting an event
+
+There are three ways to log, in increasing order of ceremony.  Pick the least
+ceremonious one that fits.
+
+### 1. `xsyslog_ev()` — for a one-off event
+
+Most call sites are like this: something went wrong in one particular place,
+and you want to say so with some context.
+
+```c
+xsyslog_ev(LOG_ERR, "mailbox.append.failed",
+           lf_mailbox(mailbox),
+           lf_msgrecord(record),
+           lf_err("error", r));
+```
+
+This is the direct replacement for `syslog()` and `xsyslog()`, and it's what
+the bulk of the conversion produces.
+
+`xsyslog_ev()` adds some fields for you:
+
+- `r.sessionid` and `r.tid`, when the process has them;
+- `sys.error` (from `errno`) and `caller.file` / `caller.line` / `caller.func`,
+  but *only* when the priority is not `LOG_NOTICE` or `LOG_INFO`.
+
+That last rule exists so that routine operational events don't carry debugging
+noise.  It does mean that if you log at `LOG_NOTICE` you will not get
+`caller.*`, which is occasionally surprising.
+
+### 2. A typed event module — for an event logged from several places
+
+When the same event is logged from more than one file, don't repeat the field
+list at each site.  Write a function that takes the event's data as arguments
+and emits it, and put it next to its peers.  `imap/loginlog.c` and
+`imap/auditlog.c` are the existing examples:
+
+```c
+loginlog_good(clienthost, userid, "PLAIN", /*tls*/ 1);
+```
+
+This is how we guarantee that `login.good` means the same thing and carries the
+same fields whether it came from `imapd`, `pop3d` or `httpd`.  It is also the
+unit that log-parsing code is written against, so a shared event that isn't in
+a module will drift.
+
+Rule of thumb: **two call sites is a coincidence, three is a module.**
+
+### 3. `struct logfmt` directly — for events built up conditionally
+
+The typed modules use this internally.  Reach for it when the field list
+depends on control flow in a way that a single call can't express.
+
+```c
+struct logfmt lf = LOGFMT_INITIALIZER;
+
+logfmt_init(&lf, "sync.mailbox.replicated");
+logfmt_push_session(&lf);
+logfmt_push_mailbox(&lf, mailbox);
+
+if (renamed) logfmt_push(&lf, "old.mbox.name", oldname);
+
+logfmt_emit(&lf, LOG_NOTICE);
+```
+
+Note that this form does *not* add `r.sessionid`, `sys.error` or `caller.*` for
+you; call `logfmt_push_session()` and `logfmt_push_caller()` yourself if you
+want them.
+
+## Naming events
+
+```
+event = segment *( "." segment )
+segment = 1*( lowercase / DIGIT / "_" )
+```
+
+Read the name as **`<subsystem>.<object>.<outcome>`**, from general to
+specific, so that a prefix match selects a useful family:
+
+| Good                     | Bad                      | Why                        |
+| ------------------------ | ------------------------ | -------------------------- |
+| `lmtp.deliver.rejected`  | `"message rejected"`     | a name, not a sentence     |
+| `jmap.email.set.failed`  | `jmap.failed.email.set`  | general to specific        |
+| `mailbox.append.failed`  | `mailbox.append_failed`  | outcome is its own segment |
+| `dav.caldav.put.invalid` | `DAV.CalDAV.Put.Invalid` | lowercase only             |
+
+Rules:
+
+- **Never put data in the event name.** `event=jmap.email.get` with
+  `jmap.accountid=...`, never `event=jmap.email.get.u123`.  The name must have
+  low cardinality or it can't be counted or grouped.
+- **Don't put the severity in the name.** `mailbox.append.failed` logged at
+  `LOG_ERR` is right; `mailbox.append.error` is redundant.
+- **Name the outcome, not the function.** `mailbox.append.failed` beats
+  `append_setup_mbox_failed`.  Function names are refactoring debris and they
+  tell a log consumer nothing about what actually broke.  The function name is
+  already in `caller.func`.
+- An event name is an interface.  Once something outside the tree parses it,
+  renaming it is a breaking change; see "Changing an existing event" below.
+
+## Naming keys
+
+Keys are dotted too, and the first segment says what the value is *about*, not
+which subsystem happened to log it.  A mailbox is `mbox.name` whether IMAP,
+JMAP or the replication code logged it.
+
+The registered namespaces:
+
+| Prefix                             | For                                                               |
+| ---------------------------------- | ----------------------------------------------------------------- |
+| `r.`                               | the request or connection: `r.sessionid`, `r.tid`, `r.clienthost` |
+| `u.`                               | the user: `u.username`                                            |
+| `mbox.`                            | a mailbox: `mbox.name`, `mbox.uniqueid`, `mbox.mailboxid`         |
+| `msg.`                             | a message: `msg.guid`, `msg.imapuid`, `msg.id`, `msg.size`        |
+| `sys.`                             | the operating system: `sys.error`                                 |
+| `caller.`                          | the C source location that logged it                              |
+| `login.`                           | authentication                                                    |
+| `send.`                            | outbound delivery                                                 |
+| `quota.`, `sieve.`, `cal.`, `pop.` | those subsystems                                                  |
+| `http.`, `jmap.`, `dav.`           | those protocols                                                   |
+| `error`                            | why the operation failed (bare, no prefix — it's universal)       |
+
+Two structural prefixes stack on top of the above:
+
+- **`old.`** — the value before a change: `old.mbox.name`, `old.msg.sysflags`.
+  Always paired with the unprefixed key carrying the new value.
+- **`out.`** — a value on the way out, where the event also mentions one coming
+  in: `msg.id` and `out.msg.id` in Sieve redirect logging.
+
+Rules:
+
+- **Every key must be registered** in `doc/logfmt-keys` before use.
+  `tools/check-logfmt-keys` fails the build otherwise.  Adding a key is meant
+  to be easy — a one-line patch — but deliberate.
+- **Same fact, same key, everywhere.** If you're about to invent a key for
+  something that already has one, use the existing one even if you'd have
+  spelled it differently.
+- **Don't abbreviate inconsistently.** It's `mbox`, never `mailbox` or `mb`.
+- A key is an interface, exactly like an event name.
+
+## Values
+
+Use the typed `lf_*` macros rather than formatting values yourself; they keep
+the representation of a given type consistent across the whole log.
+
+| Macro                              | Emits                                            |
+| ---------------------------------- | ------------------------------------------------ |
+| `lf_s(k, v)`                       | a byte string, escaped                           |
+| `lf_utf8(k, v)`                    | a UTF-8 string, escaped per codepoint            |
+| `lf_d`, `lf_ld`, `lf_lld`, `lf_zd` | integers                                         |
+| `lf_u`, `lf_lu`, `lf_llu`, `lf_zu` | integers                                         |
+| `lf_llx(k, v)`                     | hex, no `0x` prefix                              |
+| `lf_f(k, v)`                       | a double, `%f`                                   |
+| `lf_b(k, cond)`                    | `1` or `0`                                       |
+| `lf_time(k, t)`                    | a `time_t` as epoch seconds                      |
+| `lf_duration(k, secs)`             | a double as seconds, 3 decimal places            |
+| `lf_err(k, r)`                     | a Cyrus error code as its `error_message()` text |
+| `lf_buf(k, buf)`                   | a `struct buf`, escaped                          |
+| `lf_s_opt(k, v)`                   | `lf_s`, or nothing at all if `v` is NULL         |
+| `lf_flag(k, cond)`                 | `k=1` if true, nothing at all if false           |
+| `lf_raw(k, fmt, ...)`              | anything else, `printf`-formatted                |
+
+And these log a whole struct, contributing several fields at once:
+
+| Macro                | Emits                                                               | Declared in       |
+| -------------------- | ------------------------------------------------------------------- | ----------------- |
+| `lf_mailbox(mb)`     | `mbox.name`, `mbox.uniqueid`, `mbox.mailboxid`                      | `imap/mailbox.h`  |
+| `lf_msgrecord(rec)`  | `msg.imapuid`, `msg.modseq`, `msg.sysflags`, `msg.guid`, `msg.size` | `imap/mailbox.h`  |
+| `lf_mbentry(mbe)`    | as `lf_mailbox`, plus `mbox.type`                                   | `imap/mboxlist.h` |
+| `lf_mbname(k, mb)`   | a mailbox name, under the key you give                              | `imap/mboxname.h` |
+| `lf_strarray(k, sa)` | each element as `k.0`, `k.1`, ...                                   | `lib/strarray.h`  |
+| `lf_fn(k, fn, p)`    | whatever `fn` pushes — the generic form                             | `lib/util.h`      |
+
+Prefer these to spelling the fields out.  They're the reason the same
+mailbox is described the same way in every event, and adding a field to one
+of them improves every call site at once.  To log a struct that doesn't have
+one yet, write the push function next to the struct and give it an `lf_` macro
+there.  For anything in `imap/` that's forced — `lib/logfmt.c` can't see those
+types — but do it for `lib/` types too, so there's one place to look.
+
+Conventions these encode, so you don't have to decide each time:
+
+- **Booleans are `1` and `0`**, not `true`/`false` and not `yes`/`no`.  This
+  matches what shipped in 3.13 for `login.tls` and friends.
+- **Times are epoch seconds**, matching the existing `send.scheduled` and
+  `send.time`.  Log the machine-readable form; let the reader localise it.
+- **Durations are seconds**, as a decimal, so that `0.004` and `12.500` are
+  directly comparable.  Never log milliseconds under a key that doesn't say so.
+- **Text that came from a user is `lf_utf8`**, not `lf_s`: mailbox names,
+  subjects, display names.  Protocol tokens, hostnames, GUIDs and error strings
+  are `lf_s`.
+
+### Absent values
+
+`lf_s(k, NULL)` logs `k=~null~`, which says "we looked and there was nothing".
+`lf_s_opt(k, NULL)` omits the key entirely, which says "not applicable here".
+
+Both are legitimate; they mean different things.  Prefer `lf_s_opt` for fields
+that only apply to some variants of an event, and plain `lf_s` where a missing
+value is itself interesting.
+
+### Lists
+
+A list of values is logged as one indexed key per element, not as a joined
+string:
+
+    sched.addresses.0=cassandane@example.com sched.addresses.1=cass@example.net
+
+`lf_strarray()` does this for you.  A reader gets the elements without having
+to know which separator we picked, and without us having to promise that no
+element ever contains that separator.
+
+Register the base key — `sched.addresses` — not the indexed forms.  The lint
+only ever sees the base key, because that's what the source says.
+
+An empty list logs `k=""` and a NULL one `k=~null~`, so those two cases still
+say something.  A non-empty list logs only the indexed keys, never the bare
+one.
+
+### Things not to log
+
+- **Passwords and credentials.**  The one exception in the tree is
+  `login.password` for a rejected anonymous login, where the "password" is an
+  email address by convention.  Don't add more.
+- **Message bodies**, or anything unbounded.  Log a GUID and a size.
+- **Values you formatted into a sentence.**  `lf_s("error", "failed to open
+  mailbox foo")` throws away the structure we're here to create.  It's
+  `lf_mailbox(...)` plus `lf_err("error", r)`.
+
+## Choosing a severity
+
+The severity is not decoration: Cassandane fails any test whose log contains a
+logfmt event at `err` or worse (see `_check_syslog` in
+`cassandane/Cassandane/Instance.pm`).  Logging routine, expected conditions at
+`LOG_ERR` will turn tests red.
+
+| Priority      | Means                                                         |
+| ------------- | ------------------------------------------------------------- |
+| `LOG_ERR`     | the server malfunctioned, or lost data, or a bug was hit      |
+| `LOG_WARNING` | something is wrong but the server coped                       |
+| `LOG_NOTICE`  | a routine operational event worth keeping: logins, deliveries |
+| `LOG_INFO`    | detail a busy operator might want                             |
+| `LOG_DEBUG`   | detail only a developer wants                                 |
+
+A client sending a malformed request is **not** `LOG_ERR` — the server worked
+correctly by rejecting it.
+
+## Adding to the vocabulary
+
+1. Check `doc/logfmt-keys` for an existing key that means what you mean.
+2. If there isn't one, add it there, in the same patch as the code that uses
+   it, with a description that says what the value *is* — not what your one
+   call site uses it for.
+3. Run `tools/check-logfmt-keys` (or just build; it runs as part of `make
+   check`).
+
+## Changing an existing event
+
+Event names and keys are consumed by log-parsing code outside this repository.
+Treat them as you would any other interface:
+
+- Adding a new key to an existing event is safe.
+- Renaming or removing a key, renaming an event, or changing a value's format
+  or units is a **breaking change**.  It needs a `changes/next/` entry saying
+  exactly what changed, so that operators find it in the release notes.
+
+## Converting an existing call site
+
+The mechanical part is turning the prose into a name and the interpolations
+into fields:
+
+```c
+/* before */
+syslog(LOG_ERR, "IOERROR: failed to append to %s uid %u: %s",
+       mailbox_name(mailbox), record->uid, error_message(r));
+
+/* after */
+xsyslog_ev(LOG_ERR, "mailbox.append.failed",
+           lf_mailbox(mailbox),
+           lf_msgrecord(record),
+           lf_err("error", r));
+```
+
+The judgement part is everything else:
+
+- Does this event already exist somewhere else under another name?  Reuse it.
+- Is the message actually two different events sharing a code path?  Split it.
+- Is anything in the message text a *value*?  It becomes a field, not part of
+  the name.
+- Is there context available that the prose didn't bother with — a mailbox, a
+  uid, a userid?  Add it.  The old message was constrained by what fit in a
+  readable sentence; the new one isn't.
+
+Note the `IOERROR:` prefix disappearing.  That prefix existed so operators
+could grep for trouble; `event=` plus the syslog severity now does that job
+properly.
+
+## Where the code lives
+
+| File                           | Contains                                                 |
+| ------------------------------ | -------------------------------------------------------- |
+| `lib/logfmt.c`, `lib/logfmt.h` | escaping, and the `struct logfmt` API                    |
+| `lib/util.h`                   | `xsyslog_ev()` and the `lf_*` macros                     |
+| `lib/util.c`                   | `_xsyslog_ev()`, which turns an arg list into a log line |
+| `imap/auditlog.c`              | the `auditlog.*` event family                            |
+| `imap/loginlog.c`              | the `login.*` event family                               |
+| `doc/logfmt-keys`              | the registered key vocabulary                            |
+| `tools/check-logfmt-keys`      | the lint that enforces it                                |
+| `cunit/logfmt.testc`           | tests for escaping and the push functions                |
+| `cunit/xsyslog_ev.testc`       | tests for `xsyslog_ev()` and the `lf_*` macros           |
+
+Data-type-specific push functions live next to the struct they log, not in
+`logfmt.c`, since that module can't see them.  Find them with:
+
+```
+$ git grep 'void logfmt_push_'
+```

--- a/doc/logfmt-keys
+++ b/doc/logfmt-keys
@@ -1,7 +1,7 @@
 # doc/logfmt-keys - the registered logfmt key vocabulary
 #
 # Every logfmt key used anywhere in the source must appear in this file.
-# tools/check-logfmt-keys enforces that.  See doc/README.logfmt.md for the
+# tools/lint-logfmt-keys enforces that.  See doc/README.logfmt.md for the
 # naming rules and for why we bother.
 #
 # Format: one key per line, then whitespace, then a description of what the

--- a/doc/logfmt-keys
+++ b/doc/logfmt-keys
@@ -48,6 +48,7 @@ mbox.uniqueid           the mailbox's uniqueid
 
 ### msg. - a message
 
+msg                     placeholder for "no message"; value is always ~null~
 msg.cid                 the message's conversation id
 msg.date                the message's date, as sent
 msg.emailid             the message's JMAP id
@@ -82,11 +83,16 @@ send.time               when the message was actually sent
 
 ### per-subsystem
 
+cal.organizer           a calendar component's ORGANIZER
 cal.uid                 a calendar component's iCalendar UID
 imip.error              why an iMIP operation failed
 pop.subfolder           the subfolder a POP session was restricted to
 quota.root              the quota root a quota applies to
+sched.addresses         the scheduling addresses considered, one per indexed subkey
+sched.userid            the userid whose scheduling addresses were used
 scope                   the scope a duplicate-delivery check applied to
+search.expr             a search expression, serialised
+search.op               a search operator, e.g. OR
 sieve.target            the target of a Sieve action: a folder, address or url
 vacation.from           the From address of a vacation response
 vacation.to             the To address of a vacation response
@@ -100,6 +106,8 @@ out.msg.id              Message-ID we sent, where msg.id is the one we got
 old.mbox.acl            the mailbox ACL before the change
 old.mbox.name           the mailbox name before the rename
 old.mbox.part           the partition before the move
+old.mbox.uniqueid       the uniqueid of the mailbox a message moved out of
+old.msg.imapuid         the message's IMAP uid before a move
 old.msg.sysflags        the message's system flags before the change
 
 ### usage counters

--- a/doc/logfmt-keys
+++ b/doc/logfmt-keys
@@ -1,0 +1,119 @@
+# doc/logfmt-keys - the registered logfmt key vocabulary
+#
+# Every logfmt key used anywhere in the source must appear in this file.
+# tools/check-logfmt-keys enforces that.  See doc/README.logfmt.md for the
+# naming rules and for why we bother.
+#
+# Format: one key per line, then whitespace, then a description of what the
+# value is.  Describe the value, not the call site: a key is shared, and the
+# next person to want one like it will read this line to decide whether yours
+# already fits.
+#
+# Blank lines and #-comments are ignored.  Keep each section sorted.
+#
+# Adding a key belongs in the same commit as the code that uses it.
+# Removing or renaming one is a breaking change for log consumers, and needs
+# a changes/next/ entry.
+
+### the event itself
+
+event                   name of the event; always the first pair on the line
+
+### r. - the request or connection
+
+r.clienthost            the client end of the connection, as host [ip]
+r.sessionid             this process's session id
+r.tid                   trace id, when the client supplied one
+remote.sessionid        the session id of a backend we proxied to
+
+### u. - the user
+
+u.username              the authenticated userid the event happened for
+
+### mbox. - a mailbox
+
+mbox                    placeholder for "no mailbox"; value is always ~null~
+mbox.acl                the mailbox ACL, in its stored form
+mbox.crcs.annot         annotation sync CRC
+mbox.crcs.basic         basic sync CRC
+mbox.deletedmodseq      highest modseq of a deletion in this mailbox
+mbox.foldermodseq       the mailbox's folder modseq
+mbox.highestmodseq      the mailbox's highest modseq
+mbox.mailboxid          the mailbox's JMAP id
+mbox.name               the mailbox name, in the admin namespace
+mbox.part               the partition the mailbox is on
+mbox.type               the mailbox type, as a string
+mbox.uidvalidity        the mailbox's uidvalidity
+mbox.uniqueid           the mailbox's uniqueid
+
+### msg. - a message
+
+msg.cid                 the message's conversation id
+msg.date                the message's date, as sent
+msg.emailid             the message's JMAP id
+msg.from                the message's envelope sender
+msg.guid                the message's guid
+msg.id                  the message's RFC 5322 Message-ID
+msg.imapuid             the message's IMAP uid within its mailbox
+msg.modseq              the message's modseq
+msg.size                the message's size in bytes
+msg.subject             the message's subject, as UTF-8
+msg.sysflags            the message's system flags, as a string
+msg.to                  the message's envelope recipient
+
+### login. - authentication
+
+login.anonymous         1 if the login was anonymous
+login.magic             the magic-plus suffix supplied with the username
+login.mech              the SASL mechanism used
+login.nopassword        1 if the login was accepted without a password
+login.password          the password given for a refused anonymous login
+login.scheme            the HTTP auth scheme used
+login.tls               1 if the connection was under TLS
+
+### send. - outbound delivery
+
+send.delay              seconds between when a message was due and when it went
+send.numrcpts           how many recipients the message went to
+send.outcome            what happened: sent, cancelled, unsnoozed
+send.retries            how many times sending had been retried
+send.scheduled          when the message was due to be sent
+send.time               when the message was actually sent
+
+### per-subsystem
+
+cal.uid                 a calendar component's iCalendar UID
+imip.error              why an iMIP operation failed
+pop.subfolder           the subfolder a POP session was restricted to
+quota.root              the quota root a quota applies to
+scope                   the scope a duplicate-delivery check applied to
+sieve.target            the target of a Sieve action: a folder, address or url
+vacation.from           the From address of a vacation response
+vacation.to             the To address of a vacation response
+
+### out. - the outbound half of an event that has two halves
+
+out.msg.id              Message-ID we sent, where msg.id is the one we got
+
+### old. - the value before a change, paired with the unprefixed key
+
+old.mbox.acl            the mailbox ACL before the change
+old.mbox.name           the mailbox name before the rename
+old.mbox.part           the partition before the move
+old.msg.sysflags        the message's system flags before the change
+
+### usage counters
+
+used.bytes.in           bytes read from the client this session
+used.bytes.out          bytes written to the client this session
+
+### failure detail
+
+error                   why the operation failed, as human-readable text
+sys.error               strerror() of errno at the point of logging
+
+### caller. - where in the C source the event was logged
+
+caller.file             source file
+caller.func             function name
+caller.line             line number

--- a/doc/logfmt-keys
+++ b/doc/logfmt-keys
@@ -62,6 +62,14 @@ msg.subject             the message's subject, as UTF-8
 msg.sysflags            the message's system flags, as a string
 msg.to                  the message's envelope recipient
 
+### part. - a body part of a message
+
+part.cachefile          path to the extracted-text cache file for this part
+part.count              how many parts an operation covered
+part.failed             how many of them it could not handle
+part.subtype            the part's MIME subtype
+part.type               the part's MIME type
+
 ### login. - authentication
 
 login.anonymous         1 if the login was anonymous
@@ -86,13 +94,22 @@ send.time               when the message was actually sent
 cal.organizer           a calendar component's ORGANIZER
 cal.uid                 a calendar component's iCalendar UID
 imip.error              why an iMIP operation failed
+jmap.accountid          the JMAP account the request was for
 pop.subfolder           the subfolder a POP session was restricted to
 quota.root              the quota root a quota applies to
 sched.addresses         the scheduling addresses considered, one per indexed subkey
 sched.userid            the userid whose scheduling addresses were used
 scope                   the scope a duplicate-delivery check applied to
+search.batch_highest_createdmodseq  highest createdmodseq indexed in this batch
+search.batch_lowest_createdmodseq   lowest createdmodseq indexed in this batch
+search.committed        how many documents a Xapian commit wrote
+search.createdmodseq    highest createdmodseq the search index covers
+search.duration         how long a search index operation took, in seconds
 search.expr             a search expression, serialised
+search.generation       the search index generation
 search.op               a search operator, e.g. OR
+search.uncommitted      how many documents were pending when a commit failed
+search.updates          how many update passes indexed nothing
 sieve.target            the target of a Sieve action: a folder, address or url
 vacation.from           the From address of a vacation response
 vacation.to             the To address of a vacation response
@@ -106,9 +123,12 @@ out.msg.id              Message-ID we sent, where msg.id is the one we got
 old.mbox.acl            the mailbox ACL before the change
 old.mbox.name           the mailbox name before the rename
 old.mbox.part           the partition before the move
+old.mbox.uidvalidity    the mailbox's uidvalidity before it changed
 old.mbox.uniqueid       the uniqueid of the mailbox a message moved out of
 old.msg.imapuid         the message's IMAP uid before a move
 old.msg.sysflags        the message's system flags before the change
+old.search.createdmodseq  the createdmodseq the client last saw
+old.search.generation   the search index generation the client last saw
 
 ### usage counters
 

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -408,11 +408,11 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
     }
 
     if (attachextract_cacheonly) {
-        xsyslog_ev(LOG_DEBUG, "attachment text is not cached",
-                lf_s("guid", guidstr),
-                lf_s("type", axrec->type),
-                lf_s("subtype", axrec->subtype),
-                lf_s("cachefname", cachefname));
+        xsyslog_ev(LOG_DEBUG, "search.attachextract.uncached",
+                lf_s("msg.guid", guidstr),
+                lf_s("part.type", axrec->type),
+                lf_s("part.subtype", axrec->subtype),
+                lf_s("part.cachefile", cachefname));
         r = IMAP_NOTFOUND;
         goto done;
     }

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -197,7 +197,7 @@ EXPORTED void auditlog_message(const char *action,
     auditlog_begin(&lf, action);
 
     logfmt_push_mailbox(&lf, mailbox);
-    logfmt_push_record(&lf, record);
+    logfmt_push_msgrecord(&lf, record);
     logfmt_push(&lf, "msg.emailid", emailid);
     logfmt_push(&lf, "msg.cid", threadid);
 

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -3049,14 +3049,14 @@ void sched_reply(const char *cal_ownerid, const char *sched_userid,
             icalcomponent_get_first_real_component(newical ? newical : oldical);
         if (comp && icalcomponent_get_first_invitee(comp)) {
             const char *organizer = get_organizer(comp);
-            char *addrs = strarray_join(schedule_addresses, ", ");
-            xsyslog_ev(LOG_WARNING, "Not scheduling calendar component, "
-                    "ORGANIZER or ATTENDEE not found in scheduling addresses",
-                    lf_s("ical_uid", icalcomponent_get_uid(comp)),
-                    lf_s("sched_userid", sched_userid),
-                    lf_s("organizer", organizer),
-                    lf_s("sched_addrs", addrs));
-            free(addrs);
+            /* neither the ORGANIZER nor any ATTENDEE matched one of the
+             * user's scheduling addresses, so there's nothing to schedule
+             */
+            xsyslog_ev(LOG_WARNING, "caldav.schedule.skipped",
+                    lf_s("cal.uid", icalcomponent_get_uid(comp)),
+                    lf_s("cal.organizer", organizer),
+                    lf_s("sched.userid", sched_userid),
+                    lf_strarray("sched.addresses", schedule_addresses));
         }
     }
 

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -6182,9 +6182,9 @@ static void setcalendarevents_update(jmap_req_t *req,
                               JACL_ADDITEMS, NULL, &jmap_namespace, 0,
                               EVENT_MESSAGE_MOVE);
         if (r) {
-            xsyslog_ev(LOG_ERR, "append_setup_mbox failed",
-                    lf_s("dst_mboxid", mailbox_uniqueid(dstmbox)),
-                    lf_s("error", error_message(r)));
+            xsyslog_ev(LOG_ERR, "jmap.calendarevent.move.failed",
+                    lf_s("mbox.uniqueid", mailbox_uniqueid(dstmbox)),
+                    lf_err("error", r));
             goto done;
         }
 
@@ -6198,19 +6198,19 @@ static void setcalendarevents_update(jmap_req_t *req,
         ptrarray_fini(&msgrecs);
         if (r) {
             append_abort(&as);
-            xsyslog_ev(LOG_ERR, "append_copy failed",
-                    lf_s("src_mboxid", mailbox_uniqueid(mbox)),
-                    lf_s("dst_mboxid", mailbox_uniqueid(dstmbox)),
-                    lf_s("error", error_message(r)));
+            xsyslog_ev(LOG_ERR, "jmap.calendarevent.move.failed",
+                    lf_s("old.mbox.uniqueid", mailbox_uniqueid(mbox)),
+                    lf_s("mbox.uniqueid", mailbox_uniqueid(dstmbox)),
+                    lf_err("error", r));
             goto done;
         }
 
         /* Finish append */
         r = append_commit(&as);
         if (r) {
-            xsyslog_ev(LOG_ERR, "append_commit failed",
-                    lf_s("dst_mboxid", mailbox_uniqueid(dstmbox)),
-                    lf_s("error", error_message(r)));
+            xsyslog_ev(LOG_ERR, "jmap.calendarevent.move.failed",
+                    lf_s("mbox.uniqueid", mailbox_uniqueid(dstmbox)),
+                    lf_err("error", r));
             goto done;
         }
 
@@ -6219,10 +6219,10 @@ static void setcalendarevents_update(jmap_req_t *req,
         mboxevent = mboxevent_new(EVENT_MESSAGE_EXPUNGE);
         r = mailbox_rewrite_index_record(mbox, &record);
         if (r) {
-            xsyslog_ev(LOG_ERR, "mailbox_rewrite_index_record failed: %s",
-                    lf_s("src_mboxid", mailbox_uniqueid(mbox)),
-                    lf_u("imap_uid", record.uid),
-                    lf_s("error", error_message(r)));
+            xsyslog_ev(LOG_ERR, "jmap.calendarevent.move.failed",
+                    lf_s("old.mbox.uniqueid", mailbox_uniqueid(mbox)),
+                    lf_u("old.msg.imapuid", record.uid),
+                    lf_err("error", r));
             mailbox_close(&mbox);
             goto done;
         }
@@ -6235,11 +6235,11 @@ static void setcalendarevents_update(jmap_req_t *req,
         mboxevent_free(&mboxevent);
 
         /* Successfully moved, all done! */
-        xsyslog_ev(LOG_DEBUG, "moved calendar event via fast path",
-                lf_s("ical_uid", eid->ical_uid),
-                lf_u("src_imap_uid", record.uid),
-                lf_s("src_mboxid", mailbox_uniqueid(mbox)),
-                lf_s("dst_mboxid", mailbox_uniqueid(dstmbox)));
+        xsyslog_ev(LOG_DEBUG, "jmap.calendarevent.moved",
+                lf_s("cal.uid", eid->ical_uid),
+                lf_u("old.msg.imapuid", record.uid),
+                lf_s("old.mbox.uniqueid", mailbox_uniqueid(mbox)),
+                lf_s("mbox.uniqueid", mailbox_uniqueid(dstmbox)));
         r = 0;
         goto done;
     }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5226,13 +5226,13 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
         if (!since_highest_createdmodseq || !highest_createdmodseq ||
                 since_index_generation != index_generation ||
                 highest_createdmodseq < since_highest_createdmodseq) {
-            xsyslog_ev(LOG_INFO, "cannot calculate changes: search index changed",
-                    lf_s("accountid", req->accountid),
-                    lf_llu("since_highest_createdmodseq",
+            xsyslog_ev(LOG_INFO, "jmap.querychanges.index_changed",
+                    lf_s("jmap.accountid", req->accountid),
+                    lf_llu("old.search.createdmodseq",
                         since_highest_createdmodseq),
-                    lf_llu("since_index_generation", since_index_generation),
-                    lf_llu("highest_createdmodseq", highest_createdmodseq),
-                    lf_llu("index_generation", index_generation));
+                    lf_llu("old.search.generation", since_index_generation),
+                    lf_llu("search.createdmodseq", highest_createdmodseq),
+                    lf_llu("search.generation", index_generation));
             *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                           "description", "search index changed");
             goto done;
@@ -5486,13 +5486,13 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
         if (!since_highest_createdmodseq || !highest_createdmodseq ||
                 since_index_generation != index_generation ||
                 highest_createdmodseq < since_highest_createdmodseq) {
-            xsyslog_ev(LOG_INFO, "cannot calculate changes: search index changed",
-                    lf_s("accountid", req->accountid),
-                    lf_llu("since_highest_createdmodseq",
+            xsyslog_ev(LOG_INFO, "jmap.querychanges.index_changed",
+                    lf_s("jmap.accountid", req->accountid),
+                    lf_llu("old.search.createdmodseq",
                         since_highest_createdmodseq),
-                    lf_llu("since_index_generation", since_index_generation),
-                    lf_llu("highest_createdmodseq", highest_createdmodseq),
-                    lf_llu("index_generation", index_generation));
+                    lf_llu("old.search.generation", since_index_generation),
+                    lf_llu("search.createdmodseq", highest_createdmodseq),
+                    lf_llu("search.generation", index_generation));
             *err = json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
                                           "description", "search index changed");
             goto done;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -8431,6 +8431,12 @@ EXPORTED void logfmt_push_msgrecord(struct logfmt *lf,
 {
     char sysflags[FLAGMAPSTR_MAXLEN] = {0};
 
+    if (!record) {
+        /* as for logfmt_push_mailbox(): logging shouldn't crash us */
+        logfmt_push(lf, "msg", NULL);
+        return;
+    }
+
     flags_to_str(record, sysflags);
 
     logfmt_pushf(lf, "msg.imapuid", "%" PRIu32, record->uid);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -8426,8 +8426,8 @@ EXPORTED void logfmt_push_mailbox(struct logfmt *lf,
     }
 }
 
-EXPORTED void logfmt_push_record(struct logfmt *lf,
-                                 const struct index_record *record)
+EXPORTED void logfmt_push_msgrecord(struct logfmt *lf,
+                                    const struct index_record *record)
 {
     char sysflags[FLAGMAPSTR_MAXLEN] = {0};
 
@@ -8438,4 +8438,18 @@ EXPORTED void logfmt_push_record(struct logfmt *lf,
     logfmt_push(lf, "msg.sysflags", sysflags);
     logfmt_push(lf, "msg.guid", message_guid_encode(&record->guid));
     logfmt_pushf(lf, "msg.size", UINT64_FMT, record->size);
+}
+
+EXPORTED void logfmt_arg_mailbox(struct logfmt *lf,
+                                 const char *key __attribute__((unused)),
+                                 const void *value)
+{
+    logfmt_push_mailbox(lf, (const struct mailbox *) value);
+}
+
+EXPORTED void logfmt_arg_msgrecord(struct logfmt *lf,
+                                   const char *key __attribute__((unused)),
+                                   const void *value)
+{
+    logfmt_push_msgrecord(lf, (const struct index_record *) value);
 }

--- a/imap/mailbox.h
+++ b/imap/mailbox.h
@@ -769,7 +769,22 @@ extern int mailbox_set_datafile_timestamps(struct mailbox *mailbox,
 /* data-type aware logging */
 extern void logfmt_push_mailbox(struct logfmt *lf,
                                 const struct mailbox *mailbox);
-extern void logfmt_push_record(struct logfmt *lf,
-                               const struct index_record *record);
+extern void logfmt_push_msgrecord(struct logfmt *lf,
+                                  const struct index_record *record);
+
+extern void logfmt_arg_mailbox(struct logfmt *lf,
+                               const char *key, const void *value);
+extern void logfmt_arg_msgrecord(struct logfmt *lf,
+                                 const char *key, const void *value);
+
+/* Log a mailbox's identity -- mbox.name, mbox.uniqueid, mbox.mailboxid --
+ * or mbox=~null~ if it's NULL.  For xsyslog_ev().
+ */
+#define lf_mailbox(mailboxp) lf_fn("mbox", logfmt_arg_mailbox, (mailboxp))
+
+/* Log a message record -- msg.imapuid, msg.modseq, msg.sysflags, msg.guid,
+ * msg.size.  For xsyslog_ev().
+ */
+#define lf_msgrecord(recordp) lf_fn("msg", logfmt_arg_msgrecord, (recordp))
 
 #endif /* INCLUDED_MAILBOX_H */

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -6189,3 +6189,27 @@ EXPORTED json_t *mbentry_paths_json(const struct mboxlist_entry *mbentry)
 
     return jres;
 }
+
+EXPORTED void logfmt_push_mbentry(struct logfmt *lf, const mbentry_t *mbentry)
+{
+    if (mbentry) {
+        mbname_t *mbname = mbname_from_intname(mbentry->name);
+
+        logfmt_push_mbname(lf, "mbox.name", mbname);
+        logfmt_push(lf, "mbox.uniqueid", mbentry->uniqueid);
+        logfmt_push(lf, "mbox.mailboxid", mbentry->jmapid);
+        logfmt_push(lf, "mbox.type", mboxlist_mbtype_to_string(mbentry->mbtype));
+
+        mbname_free(&mbname);
+    }
+    else {
+        logfmt_push(lf, "mbox", NULL);
+    }
+}
+
+EXPORTED void logfmt_arg_mbentry(struct logfmt *lf,
+                                 const char *key __attribute__((unused)),
+                                 const void *value)
+{
+    logfmt_push_mbentry(lf, (const mbentry_t *) value);
+}

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -404,4 +404,16 @@ int mboxlist_promote_intermediary(const char *mboxname);
 
 int mboxlist_upgrade(int *upgraded);
 
+/* data-type aware logging */
+extern void logfmt_push_mbentry(struct logfmt *lf, const mbentry_t *mbentry);
+
+extern void logfmt_arg_mbentry(struct logfmt *lf,
+                               const char *key, const void *value);
+
+/* Log a mailbox entry's identity -- mbox.name, mbox.uniqueid,
+ * mbox.mailboxid, mbox.type -- or mbox=~null~ if it's NULL.  For
+ * xsyslog_ev().  Where you have an open mailbox, prefer lf_mailbox().
+ */
+#define lf_mbentry(mbentryp) lf_fn("mbox", logfmt_arg_mbentry, (mbentryp))
+
 #endif

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -3405,6 +3405,12 @@ EXPORTED void logfmt_push_mbname(struct logfmt *lf,
 
     if (!key) key = "mbox.name";
 
+    if (!mbname) {
+        /* logging shouldn't be the thing that crashes us */
+        logfmt_push(lf, key, NULL);
+        return;
+    }
+
     logfmt_push(lf, key, mbname_extname(mbname, admin_namespace, NULL));
 }
 

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -3407,3 +3407,10 @@ EXPORTED void logfmt_push_mbname(struct logfmt *lf,
 
     logfmt_push(lf, key, mbname_extname(mbname, admin_namespace, NULL));
 }
+
+EXPORTED void logfmt_arg_mbname(struct logfmt *lf,
+                                const char *key,
+                                const void *value)
+{
+    logfmt_push_mbname(lf, key, (const mbname_t *) value);
+}

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -368,4 +368,11 @@ void mboxname_zero_counters(const char *mboxname);
 void logfmt_push_mbname(struct logfmt *lf,
                         const char *key, const mbname_t *mbname);
 
+void logfmt_arg_mbname(struct logfmt *lf, const char *key, const void *value);
+
+/* Log an mbname_t under `key`, for xsyslog_ev().  Normally "mbox.name", but
+ * you could supply (say) "old.mbox.name" instead.
+ */
+#define lf_mbname(key, mbnamep) lf_fn(key, logfmt_arg_mbname, (mbnamep))
+
 #endif

--- a/imap/search_engines.c
+++ b/imap/search_engines.c
@@ -571,10 +571,10 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
     size_t nfailed = warmup_attachextract_cache(&attachparts);
     if (nfailed) {
         // The messages of those parts can not get indexed fully.
-        xsyslog_ev(LOG_WARNING, "could not extract all attachment text",
-                lf_s("mboxname", mboxname),
-                lf_d("parts", dynarray_size(&attachparts)),
-                lf_zu("failed_parts", nfailed));
+        xsyslog_ev(LOG_WARNING, "search.attachextract.incomplete",
+                lf_s("mbox.name", mboxname),
+                lf_d("part.count", dynarray_size(&attachparts)),
+                lf_zu("part.failed", nfailed));
     }
 
     // Retake mailbox lock
@@ -585,12 +585,12 @@ EXPORTED int search_update_mailbox(search_text_receiver_t *rx,
     // got renumbered, has nothing in common with the messages we selected.
     if (strcmpsafe(uniqueid, mailbox_uniqueid(mailbox)) ||
             uidvalidity != mailbox->i.uidvalidity) {
-        xsyslog_ev(LOG_NOTICE, "mailbox changed while extracting attachments",
-                lf_s("mboxname", mboxname),
-                lf_s("uniqueid", uniqueid),
-                lf_s("new_uniqueid", mailbox_uniqueid(mailbox)),
-                lf_u("uidvalidity", uidvalidity),
-                lf_u("new_uidvalidity", mailbox->i.uidvalidity));
+        xsyslog_ev(LOG_NOTICE, "search.index.mailbox_changed",
+                lf_s("mbox.name", mboxname),
+                lf_s("old.mbox.uniqueid", uniqueid),
+                lf_s("mbox.uniqueid", mailbox_uniqueid(mailbox)),
+                lf_u("old.mbox.uidvalidity", uidvalidity),
+                lf_u("mbox.uidvalidity", mailbox->i.uidvalidity));
         // None of the selected messages got indexed. Have the caller retry
         // this mailbox from the start, rather than reporting it as indexed.
         is_incomplete = 1;

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -902,9 +902,9 @@ static void subquery_run_indexed(const char *serialised_sub __attribute__((unuse
             // only. But in lack of debug_assert let's rather log and
             // continue evaluating the query instead of aborting.
             char *s = search_expr_serialise(sub->indexed);
-            xsyslog_ev(LOG_ERR,
-                       "unexpected OR, expected DNF subclause",
-                       lf_s("indexed", s));
+            xsyslog_ev(LOG_ERR, "search.query.unexpected_op",
+                       lf_s("search.op", "OR"),
+                       lf_s("search.expr", s));
             free(s);
         }
         /* fall through */

--- a/imap/search_xapian.c
+++ b/imap/search_xapian.c
@@ -2443,17 +2443,17 @@ static int commit_transaction(xapian_update_receiver_t *tr)
     gettimeofday(&end, NULL);
     if (r) {
         tr->commit_failed = true; // keep track of failed commit
-        xsyslog_ev(LOG_ERR, "failed to commit transaction",
-                lf_s("mailbox", mailbox_name(tr->super.mailbox)),
-                lf_u("uncommitted", uncommitted),
-                lf_f("seconds", timesub(&start, &end)),
-                lf_s("error", error_message(r)));
+        xsyslog_ev(LOG_ERR, "search.xapian.transaction.failed",
+                lf_mailbox(tr->super.mailbox),
+                lf_u("search.uncommitted", uncommitted),
+                lf_duration("search.duration", timesub(&start, &end)),
+                lf_err("error", r));
         return r;
     }
 
-    xsyslog_ev(LOG_INFO, "committed Xapian transaction",
-                lf_u("committed", uncommitted),
-                lf_f("seconds", timesub(&start, &end)));
+    xsyslog_ev(LOG_INFO, "search.xapian.transaction.committed",
+                lf_u("search.committed", uncommitted),
+                lf_duration("search.duration", timesub(&start, &end)));
 
     tr->commits++;
     return 0;
@@ -2467,8 +2467,8 @@ static int commit_transaction(xapian_update_receiver_t *tr)
 static int update_indexeddb(xapian_update_receiver_t *tr)
 {
     if (tr->commit_failed) {
-        xsyslog_ev(LOG_ERR, "not updating indexed.db after failed commit",
-                lf_s("mailbox", mailbox_name(tr->super.mailbox)));
+        xsyslog_ev(LOG_ERR, "search.index.state.skipped",
+                lf_mailbox(tr->super.mailbox));
         return IMAP_IOERROR;
     }
 
@@ -2485,14 +2485,14 @@ static int update_indexeddb(xapian_update_receiver_t *tr)
              * createdmodseq suggested we had. We need to invalidate the
              * index generation. */
             tr->index_generation++;
-            xsyslog_ev(LOG_INFO, "bumping index generation",
-                    lf_s("mailbox", mailbox_name(tr->super.mailbox)),
-                    lf_llu("batch_lowest_createdmodseq",
+            xsyslog_ev(LOG_INFO, "search.index.generation.bumped",
+                    lf_mailbox(tr->super.mailbox),
+                    lf_llu("search.batch_lowest_createdmodseq",
                         tr->batch_lowest_createdmodseq),
-                    lf_llu("batch_highest_createdmodseq",
+                    lf_llu("search.batch_highest_createdmodseq",
                         tr->batch_highest_createdmodseq),
-                    lf_llu("highest_createdmodseq", tr->highest_createdmodseq),
-                    lf_llu("index_generation", tr->index_generation));
+                    lf_llu("search.createdmodseq", tr->highest_createdmodseq),
+                    lf_llu("search.generation", tr->index_generation));
         }
 
         /* Update the highest createdmodseq */

--- a/imap/squatter.c
+++ b/imap/squatter.c
@@ -401,9 +401,9 @@ again:
         }
         if (++nunproductive <= MAX_UNPRODUCTIVE_UPDATES) goto again;
 
-        xsyslog_ev(LOG_ERR, "giving up on mailbox that indexes no message",
-                lf_s("mboxname", name),
-                lf_d("updates", nunproductive));
+        xsyslog_ev(LOG_ERR, "search.index.abandoned",
+                lf_s("mbox.name", name),
+                lf_d("search.updates", nunproductive));
     }
     free(extname);
 

--- a/lib/logfmt.c
+++ b/lib/logfmt.c
@@ -13,6 +13,7 @@
 #include "unicode/utf8.h"
 #include "unicode/utypes.h"
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -248,6 +249,16 @@ EXPORTED void logfmt_fini(struct logfmt *lf)
 EXPORTED const char *logfmt_cstring(const struct logfmt *lf)
 {
     return buf_cstring(&lf->msg);
+}
+
+EXPORTED void logfmt_emit(struct logfmt *lf, int priority)
+{
+    int saved_errno = errno;
+
+    syslog(priority, "%s", logfmt_cstring(lf));
+    logfmt_fini(lf);
+
+    errno = saved_errno;
 }
 
 EXPORTED void logfmt_push(struct logfmt *lf,

--- a/lib/logfmt.h
+++ b/lib/logfmt.h
@@ -24,6 +24,11 @@ extern void logfmt_init(struct logfmt *lf, const char *event);
 extern void logfmt_fini(struct logfmt *lf);
 const char *logfmt_cstring(const struct logfmt *lf);
 
+/* Write the event to syslog and release it.  The logfmt is safe to
+ * logfmt_init() again afterwards, but must not otherwise be used.
+ */
+extern void logfmt_emit(struct logfmt *lf, int priority);
+
 extern void logfmt_push(struct logfmt *lf, const char *key, const char *value);
 
 extern void logfmt_push_utf8(struct logfmt *lf,

--- a/lib/strarray.c
+++ b/lib/strarray.c
@@ -4,6 +4,7 @@
 
 #include "strarray.h"
 #include <memory.h>
+#include "logfmt.h"
 #include "util.h"
 #include "xmalloc.h"
 
@@ -479,4 +480,36 @@ EXPORTED void strarray_addfirst_case(strarray_t *sa, const char *s)
 {
     strarray_remove_all_case(sa, s);
     strarray_unshift(sa, s);
+}
+
+EXPORTED void logfmt_push_strarray(struct logfmt *lf, const char *key,
+                                   const strarray_t *sa)
+{
+    struct buf subkey = BUF_INITIALIZER;
+    int i;
+
+    if (!sa) {
+        /* as for the other push functions: logging mustn't be what crashes us */
+        logfmt_push(lf, key, NULL);
+        return;
+    }
+
+    if (!strarray_size(sa)) {
+        logfmt_push(lf, key, "");
+        return;
+    }
+
+    for (i = 0; i < strarray_size(sa); i++) {
+        buf_reset(&subkey);
+        buf_printf(&subkey, "%s.%d", key, i);
+        logfmt_push(lf, buf_cstring(&subkey), strarray_nth(sa, i));
+    }
+
+    buf_free(&subkey);
+}
+
+EXPORTED void logfmt_arg_strarray(struct logfmt *lf, const char *key,
+                                  const void *value)
+{
+    logfmt_push_strarray(lf, key, (const strarray_t *) value);
 }

--- a/lib/strarray.h
+++ b/lib/strarray.h
@@ -92,4 +92,22 @@ int strarray_cmp(const strarray_t *a, const strarray_t *b);
          idx < strarray_size(sa) && (str = strarray_nth(sa, idx));    \
          idx++)
 
+/* Push the array onto a logfmt event as key.0, key.1, ... -- one pair per
+ * element, so that a list stays machine-readable instead of becoming a
+ * joined string the reader has to split again.
+ *
+ * A NULL array logs key=~null~ and an empty one logs key="", the same way a
+ * NULL or empty string value would.  Otherwise only the indexed keys are
+ * logged, never the bare one.
+ *
+ * This is for short lists: scheduling addresses, flag names, that sort of
+ * thing.  syslog truncates long lines, so don't hand it something unbounded.
+ */
+struct logfmt;
+void logfmt_push_strarray(struct logfmt *lf, const char *key,
+                          const strarray_t *sa);
+void logfmt_arg_strarray(struct logfmt *lf, const char *key,
+                         const void *value);
+#define lf_strarray(key, sap) lf_fn(key, logfmt_arg_strarray, (sap))
+
 #endif /* __CYRUS_STRARRAY_H__ */

--- a/lib/util.c
+++ b/lib/util.c
@@ -1530,6 +1530,20 @@ EXPORTED void _xsyslog_ev(int saved_errno, int priority, const char *event,
         case LF_LLX: logfmt_pushf(&lf, name, "%llx", arg->data[i].llu); break;
         case LF_F:   logfmt_pushf(&lf, name, "%f", arg->data[i].f);     break;
 
+        case LF_B:
+            logfmt_push(&lf, name, arg->data[i].d ? "1" : "0");
+            break;
+        case LF_TIME:
+            logfmt_pushf(&lf, name, "%lld", arg->data[i].lld);
+            break;
+        case LF_DURATION:
+            logfmt_pushf(&lf, name, "%.3f", arg->data[i].f);
+            break;
+
+        case LF_SKIP:
+            /* lf_s_opt()/lf_flag() decided this field doesn't apply */
+            break;
+
         case LF_S:
             logfmt_push(&lf, name, arg->data[i].s);
             break;
@@ -1554,8 +1568,7 @@ EXPORTED void _xsyslog_ev(int saved_errno, int priority, const char *event,
         logfmt_push_caller(&lf, file, line, func);
     }
 
-    syslog(priority, "%s", logfmt_cstring(&lf));
-    logfmt_fini(&lf);
+    logfmt_emit(&lf, priority);
 
     errno = saved_errno;
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -1544,6 +1544,10 @@ EXPORTED void _xsyslog_ev(int saved_errno, int priority, const char *event,
             /* lf_s_opt()/lf_flag() decided this field doesn't apply */
             break;
 
+        case LF_FN:
+            arg->data[i].fn.push(&lf, name, arg->data[i].fn.value);
+            break;
+
         case LF_S:
             logfmt_push(&lf, name, arg->data[i].s);
             break;

--- a/lib/util.h
+++ b/lib/util.h
@@ -382,6 +382,15 @@ void xsyslog_fn(int priority, const char *description,
                      + __GNUC_MINOR__ * 100     \
                      + __GNUC_PATCHLEVEL__)
 
+struct logfmt;
+
+/* Pushes some struct's fields onto an event.  `key` is the key to log the
+ * value under, for types that log a single field; types that log a whole
+ * set of fields under fixed keys ignore it.
+ */
+typedef void (*lf_push_fn)(struct logfmt *lf, const char *key,
+                           const void *value);
+
 typedef struct xsyslog_ev_arg {
     const char *name;
     int type;
@@ -397,6 +406,10 @@ typedef struct xsyslog_ev_arg {
         size_t zu;
         double f;
         const char *s;
+        struct {
+            lf_push_fn push;
+            const void *value;
+        } fn;
     };
 } xsyslog_ev_arg;
 
@@ -465,7 +478,8 @@ enum xsyslog_ev_arg_type {
     LF_B,
     LF_TIME,
     LF_DURATION,
-    LF_SKIP
+    LF_SKIP,
+    LF_FN
 };
 
 #define lf_c(key, value)    (xsyslog_ev_arg){ key, LF_C,    { .c   = value } }
@@ -529,6 +543,17 @@ enum xsyslog_ev_arg_type {
 
 /* key=1 if the condition holds, and nothing at all if it doesn't. */
 #define lf_flag(key, cond)  ((cond) ? lf_b(key, 1) : lf_skip())
+
+/* Log a whole struct, using a push function that knows its fields.
+ *
+ * lib/ can't see the structs that most events are about, so the actual
+ * helpers are declared alongside the struct they log -- lf_mailbox() in
+ * imap/mailbox.h, and so on.  Find them with:
+ *
+ *     $ git grep 'define lf_'
+ */
+#define lf_fn(key, pushfn, valuep)                                          \
+    (xsyslog_ev_arg){ key, LF_FN, { .fn = { (pushfn), (valuep) } } }
 
 /* Set up cyrus_gettime as a weak alias for a wrapper around clock_gettime.
  * We then use cyrus_gettime everywhere instead of clock_gettime, and unit

--- a/lib/util.h
+++ b/lib/util.h
@@ -14,6 +14,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <syslog.h>
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -414,12 +415,36 @@ void _xsyslog_ev(int saved_errno, int priority, const char *event,
                  const char *file, int line, const char *func,
                  xsyslog_ev_arg_list *arg);
 
+/* Would syslog actually keep a message logged at this priority?
+ *
+ * setlogmask(0) asks libc for the current mask without changing it, which is
+ * just a read of a global.  We check before building the argument list so
+ * that masked-out events -- LOG_DEBUG, most of the time -- don't pay for
+ * formatting nobody will read.
+ */
+static inline int logfmt_want(int priority)
+{
+    return setlogmask(0) & LOG_MASK(LOG_PRI(priority));
+}
+
+/* Log a structured event.  See doc/README.logfmt.md.
+ *
+ * Arguments are built with the lf_*() macros below, e.g.
+ *
+ *     xsyslog_ev(LOG_ERR, "mailbox.append.failed",
+ *                lf_s("mbox.uniqueid", mailbox_uniqueid(mailbox)),
+ *                lf_u("msg.imapuid", record->uid),
+ *                lf_err("error", r));
+ *
+ * n.b. the arguments are only evaluated if the event will be logged.
+ */
 #define xsyslog_ev(priority, event, ...)                                    \
     do {                                                                    \
         int se = errno;                                                     \
-        _xsyslog_ev(se, priority, event,                                    \
-                    __FILE__, __LINE__, __func__,                           \
-                    XSYSLOG_EV_ARG_LIST(__VA_ARGS__));                      \
+        if (logfmt_want(priority))                                          \
+            _xsyslog_ev(se, priority, event,                                \
+                        __FILE__, __LINE__, __func__,                       \
+                        XSYSLOG_EV_ARG_LIST(__VA_ARGS__));                  \
     } while (0)
 
 enum xsyslog_ev_arg_type {
@@ -436,7 +461,11 @@ enum xsyslog_ev_arg_type {
     LF_F,
     LF_S,
     LF_UTF8,
-    LF_RAW
+    LF_RAW,
+    LF_B,
+    LF_TIME,
+    LF_DURATION,
+    LF_SKIP
 };
 
 #define lf_c(key, value)    (xsyslog_ev_arg){ key, LF_C,    { .c   = value } }
@@ -458,6 +487,48 @@ enum xsyslog_ev_arg_type {
     buf_printf(&value, fmt, __VA_ARGS__);                                   \
     (xsyslog_ev_arg){ key, LF_RAW, { .s = buf_release(&value) } };          \
 })
+
+/* An argument that isn't there.  _xsyslog_ev() drops these, which is how the
+ * conditional helpers below manage to contribute nothing to the event.
+ */
+#define lf_skip()           (xsyslog_ev_arg){ "-", LF_SKIP, { .s = NULL } }
+
+/* A boolean, as 1 or 0.  Use this rather than lf_c(), which takes a char and
+ * would log lf_c("k", 1) as the control character 0x01.
+ */
+#define lf_b(key, value)    (xsyslog_ev_arg){ key, LF_B,                    \
+                                              { .d = (value) ? 1 : 0 } }
+
+/* A time_t, as epoch seconds. */
+#define lf_time(key, value) (xsyslog_ev_arg){ key, LF_TIME,                 \
+                                              { .lld = (long long)(value) } }
+
+/* An elapsed time, in seconds, to millisecond precision.  Always seconds:
+ * don't log milliseconds under a key that doesn't say so.
+ */
+#define lf_duration(key, secs)                                              \
+    (xsyslog_ev_arg){ key, LF_DURATION, { .f = (secs) } }
+
+/* A struct buf.  Takes a pointer, calls buf_cstring on it. */
+#define lf_buf(key, bufp)   lf_s(key, buf_cstring(bufp))
+
+/* A Cyrus error code, as its error_message() text.  The caller needs an
+ * *_err.h included for that, which anything with an `int r` will have.
+ */
+#define lf_err(key, r)      lf_s(key, error_message(r))
+
+/* A string, or nothing at all if it's NULL.
+ *
+ * This is for fields that only apply to some variants of an event.  Where a
+ * missing value is itself worth recording, use lf_s(), which logs ~null~.
+ */
+#define lf_s_opt(key, value) ({                                             \
+    const char *_lf_value = (value);                                        \
+    _lf_value ? lf_s(key, _lf_value) : lf_skip();                           \
+})
+
+/* key=1 if the condition holds, and nothing at all if it doesn't. */
+#define lf_flag(key, cond)  ((cond) ? lf_b(key, 1) : lf_skip())
 
 /* Set up cyrus_gettime as a weak alias for a wrapper around clock_gettime.
  * We then use cyrus_gettime everywhere instead of clock_gettime, and unit

--- a/tools/lint-logfmt-keys
+++ b/tools/lint-logfmt-keys
@@ -1,0 +1,156 @@
+#!/usr/bin/perl
+#
+# lint-logfmt-keys - check logfmt keys in the source against doc/logfmt-keys
+#
+# Every logfmt key used in the source must be registered in doc/logfmt-keys.
+# See doc/README.logfmt.md for why.
+#
+# Usage: tools/lint-logfmt-keys [--list-unused] [srcdir]
+#
+# Exits non-zero, with a report on stderr, if anything is wrong.
+
+use strict;
+use warnings;
+
+use File::Find;
+use Getopt::Long;
+
+my $list_unused = 0;
+GetOptions('list-unused' => \$list_unused) or exit 2;
+
+my $srcdir = shift // '.';
+
+my $registry = "$srcdir/doc/logfmt-keys";
+
+# A key is lowercase dotted segments.  This is the syntax doc/README.logfmt.md
+# describes; keeping it mechanical stops "mbox.mailboxID" ever happening.
+my $key_re = qr/[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)*/;
+
+# Directories to scan.  master/ and the like will join this list as they're
+# converted; there's no point scanning what has no logfmt in it yet.
+my @scan = qw(imap lib sieve timsieved ptclient notifyd master);
+
+my @problems;
+
+#
+# Read the registry
+#
+
+open my $fh, '<', $registry or die "can't read $registry: $!\n";
+
+my %registered;
+my %section_of;
+my $section = '(top)';
+my @in_section;
+
+while (my $line = <$fh>) {
+    chomp $line;
+
+    if ($line =~ /^###\s*(.*)/) {
+        check_sorted($section, \@in_section);
+        $section = $1;
+        @in_section = ();
+        next;
+    }
+
+    next if $line =~ /^\s*#/ || $line !~ /\S/;
+
+    my ($key, $description) = $line =~ /^(\S+)\s+(.*\S)/;
+
+    if (! defined $key) {
+        push @problems, "$registry:$.: can't parse: $line";
+        next;
+    }
+
+    if ($key !~ /^$key_re$/) {
+        push @problems, "$registry:$.: not a well-formed key: $key";
+    }
+
+    if (exists $registered{$key}) {
+        push @problems, "$registry:$.: duplicate key: $key";
+    }
+
+    $registered{$key} = 0;
+    $section_of{$key} = $section;
+    push @in_section, $key;
+}
+
+check_sorted($section, \@in_section);
+close $fh;
+
+sub check_sorted
+{
+    my ($name, $keys) = @_;
+
+    for my $i (1 .. $#$keys) {
+        next if $keys->[$i - 1] le $keys->[$i];
+        push @problems,
+             "$registry: section '$name' is out of order:"
+             . " $keys->[$i] should come before $keys->[$i - 1]";
+        return; # one complaint per section is plenty
+    }
+}
+
+#
+# Scan the source
+#
+
+my @sources;
+find(sub {
+    return unless -f && /\.[ch]$/;
+    push @sources, $File::Find::name;
+}, grep { -d } map { "$srcdir/$_" } @scan);
+
+for my $source (sort @sources) {
+    open my $src, '<', $source or die "can't read $source: $!\n";
+    my $code = do { local $/; <$src> };
+    close $src;
+
+    # Comments talk about keys without using them -- lib/util.h explains
+    # lf_c("k", 1) -- so they mustn't be scanned.  Replace rather than
+    # delete, so that line numbers survive.
+    $code =~ s{/\*(.*?)\*/}{my $c = $1; $c =~ s/[^\n]//g; "/*$c*/"}ges;
+    $code =~ s{//[^\n]*}{//}g;
+
+    my $lineno = 0;
+
+    for my $line (split /\n/, $code, -1) {
+        $lineno++;
+
+        # lf_s("key", ...), lf_mbname("key", ...), lf_fn("key", ...) &c.
+        # and logfmt_push(lf, "key", ...) and its variants.  Keys built at
+        # runtime can't be checked, and are simply not matched here.
+        my @keys = $line =~ /\blf_[a-z0-9_]+\(\s*"([^"]*)"/g;
+        push @keys, $line =~ /\blogfmt_push[a-z0-9_]*\([^,()]+,\s*"([^"]*)"/g;
+
+        for my $key (@keys) {
+            if (! exists $registered{$key}) {
+                my $rel = $source;
+                $rel =~ s{^\Q$srcdir\E/}{};
+                push @problems, "$rel:$lineno: unregistered logfmt key: $key";
+            }
+            else {
+                $registered{$key}++;
+            }
+        }
+    }
+}
+
+#
+# Report
+#
+
+if (@problems) {
+    print STDERR "$_\n" for @problems;
+    print STDERR "\n";
+    print STDERR "Every logfmt key must be registered in doc/logfmt-keys.\n";
+    print STDERR "See doc/README.logfmt.md for the naming rules.\n";
+    exit 1;
+}
+
+if ($list_unused) {
+    my @unused = sort grep { ! $registered{$_} } keys %registered;
+    print "unused: $_ ($section_of{$_})\n" for @unused;
+}
+
+exit 0;


### PR DESCRIPTION
This is the first of what I expect to be a multi-phase process of converting everything, or roughly everything, from xsyslog to logfmt, either through xsyslog_ev or other methods.

This PR focuses on:

1. updating Cassandane to keep catching problems when they stop being DBERROR or IOERROR
2. add lf_X helpers for various popular Xes (note especially LF_FN)
3. setting up build-time checks that we're following "the rules"

Oh and it adds "the rules", some documentation in ./doc that I think needs to be significantly edited and merged into docsrc, but which felt good enough to start with at phase 0.  (We're not starting on phase 1 because this isn't Tcl.)