### PR TITLE
caldav: use the canonical userid when scheduling to a local recipient

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -271,6 +271,12 @@ magic(DelayedExpunge => sub {
 magic(VirtDomains => sub {
     shift->config_set(virtdomains => 'userid');
 });
+magic(DefaultDomain => sub {
+    # Pairs with :VirtDomains.  Without a default domain the recipient of a
+    # local invitation is a foreign address, and is scheduled over iMIP rather
+    # than delivered - so the local delivery path is never entered at all.
+    shift->config_set(defaultdomain => q{example.com});
+});
 magic(NoVirtDomains => sub {
     shift->config_set(virtdomains => 'off');
 });

--- a/cassandane/tiny-tests/Caldav/sched_deliver_virtdomains
+++ b/cassandane/tiny-tests/Caldav/sched_deliver_virtdomains
@@ -1,0 +1,76 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_sched_deliver_virtdomains
+    :min_version_3_4 :VirtDomains :DefaultDomain
+    ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $admintalk->create("user.friend");
+    $admintalk->setacl("user.friend", admin => "lrswipkxtecdan");
+    $admintalk->setacl("user.friend", friend => "lrswipkxtecdn");
+
+    # The recipient needs a calendar home before anything can be delivered
+    # into it: caladdress_lookup() falls back to iMIP when the cal-home-set
+    # cannot be found, and the local delivery path this tests is then never
+    # entered at all.  Connecting over DAV provisions it.
+    my $service = $self->{instance}->get_service("http");
+    my $friendtalk = Net::CalDAVTalk->new(
+        user => "friend",
+        password => "pass",
+        host => $service->host(),
+        port => $service->port(),
+        scheme => "http",
+        url => "/",
+        expandurl => 1,
+    );
+
+    my $CalendarId = $CalDAV->NewCalendar({name => "invitations"});
+    $self->assert_not_null($CalendarId);
+
+    my $uid = "B0C4A0F2-3F4E-4A2E-9C1B-7E5C6B2A9D31";
+    my $ics = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Cassandane//NONSGML//EN
+BEGIN:VEVENT
+UID:$uid
+DTSTAMP:20210802T131858Z
+DTSTART:20210902T210000Z
+DTEND:20210902T220000Z
+SUMMARY:An invitation
+ORGANIZER;CN=Cassandane:MAILTO:cassandane\@example.com
+ATTENDEE;PARTSTAT=ACCEPTED;ROLE=CHAIR:MAILTO:cassandane\@example.com
+ATTENDEE;RSVP=TRUE;PARTSTAT=NEEDS-ACTION:MAILTO:friend\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "organiser stores an event inviting a local user";
+    $CalDAV->Request("PUT", "$CalendarId/$uid.ics", $ics,
+                     "Content-Type" => "text/calendar");
+
+    # The organiser copy records what became of each attendee.  With the
+    # recipient userid left as "friend@example.com" while the mailbox and its
+    # ACL are keyed "friend", the rights check in caldav_store_preprocess()
+    # matches nothing, the store is refused with DAV:need-privileges, and that
+    # shows up here as 5.1 instead of 1.2.
+    xlog $self, "the attendee SCHEDULE-STATUS says the invitation was delivered";
+    my $res = $CalDAV->Request("GET", "$CalendarId/$uid.ics");
+    $self->assert_matches(qr/SCHEDULE-STATUS=1\.2/, $res->{content});
+
+    # Read it back over DAV rather than IMAP: a calendar collection is not a
+    # mail mailbox, and SELECT on one is refused with "Invalid mailbox type".
+    xlog $self, "and the invitation is really in the attendee scheduling Inbox";
+    my $inbox = $friendtalk->Request("PROPFIND", "/dav/calendars/user/friend/Inbox/",
+                                     <<XML, Depth => 1, "Content-Type" => "application/xml");
+<?xml version="1.0" encoding="utf-8"?>
+<D:propfind xmlns:D="DAV:"><D:prop><D:getetag/></D:prop></D:propfind>
+XML
+    my $responses = $inbox->{'{DAV:}response'} || [];
+    my @hrefs = map { $_->{'{DAV:}href'}{content} } @$responses;
+    $self->assert_num_gte(1, scalar grep { /\.ics$/ } @hrefs);
+}

--- a/changes/next/caldav-sched-canonical-userid
+++ b/changes/next/caldav-sched-canonical-userid
@@ -1,0 +1,21 @@
+Description:
+
+Fix local CalDAV scheduling delivery on servers running with virtdomains
+enabled and a defaultdomain configured: invitations to users in the default
+domain were refused with SCHEDULE-STATUS=5.1.
+
+Documentation:
+
+No documentation change: the fix restores the documented behaviour.
+
+Config changes:
+
+None.
+
+Upgrade instructions:
+
+None.
+
+GitHub issue:
+
+None filed; the failure and its reproduction are described in the pull request.

--- a/imap/http_caldav_sched.c
+++ b/imap/http_caldav_sched.c
@@ -98,6 +98,21 @@ int caladdress_lookup(const char *addr, struct caldav_sched_param *param,
         mbentry_t *mbentry = NULL;
         /* Lookup user's cal-home-set to see if it is on this server */
         mbname_t *mbname = mbname_from_recipient(param->userid, &httpd_namespace);
+
+        /* Take the canonical userid rather than the address it was written as.
+           With virtdomains enabled and a defaultdomain configured, the domain
+           above is only trimmed when virtdomains is off, so param->userid keeps
+           "@defaultdomain" - while the mailbox and its ACL are keyed by the bare
+           userid.  Everything downstream compares against that ACL, notably the
+           auth_state that caldav_store_preprocess() builds from this userid, so
+           an uncanonicalised one matches no entry and every local delivery ends
+           in DAV:need-privileges. */
+        const char *canon_userid = mbname_userid(mbname);
+        if (canon_userid && strcmp(canon_userid, param->userid)) {
+            free(param->userid);
+            param->userid = xstrdup(canon_userid);
+        }
+
         mbname_push_boxes(mbname, config_getstring(IMAPOPT_CALENDARPREFIX));
         int r = proxy_mlookup(mbname_intname(mbname), &mbentry, NULL, NULL);
         mbname_free(&mbname);


### PR DESCRIPTION
### Symptom

On a server with `virtdomains: userid` and `defaultdomain` set, **no local user ever receives an invitation**. The organiser's copy comes back with

```
ATTENDEE;...;SCHEDULE-STATUS=5.1:mailto:someone@example.com
```

and the recipient's scheduling Inbox stays empty. The server logs

```
sched_deliver(someone@example.com)
caladdress_lookup(userid: 'someone@example.com', ...)
CalDAV scheduling delivery to someone@example.com
sched_deliver_local(organiser@example.com, someone@example.com, 0)
caldav_store_resource(user.someone.#calendars.Default) failed: 403 Forbidden ()
```

Free/busy queries for the same recipients work; only delivery fails.

### Cause

`caladdress_lookup()` trims the domain off a local calendar user address only when virtdomains is off:

```c
if (!config_virtdomains) {
    *at = '\0';  // trim off the domain
}
```

So with virtdomains on, a user in the **default** domain keeps `@defaultdomain` in `sched_param->userid`, while their mailbox and its ACL are keyed by the bare userid — which is what Cyrus itself writes when it creates their calendars (`user.someone.#calendars.Default` with an ACL entry `someone`).

`sched_deliver_local()` passes that userid to `caldav_store_resource()`, and `caldav_store_preprocess()` uses it to decide what may be written:

```c
struct auth_state *authstate = auth_newstate(userid);
rights = cyrus_acl_myrights(authstate, mailbox_acl(mailbox));
if (rights & DACL_WRITECONT) allow_propupdates = propupdate_all;
...
if (!allow_propupdates) {
    txn->error.precond = DAV_NEED_PRIVS;
```

`auth_newstate("someone@example.com")` matches no entry in an ACL keyed `someone`, so the recipient is left with whatever `anyone` grants — never `DACL_WRITECONT`. Hence 403, hence 5.1.

I confirmed the precondition under gdb (`precond = 8`, `DAV_NEED_PRIVS`), and confirmed the cause by adding a redundant ACL entry under the qualified name:

```
setacl user/someone/#calendars/Default someone@example.com lrswipkxtecdan9
```

after which the very next invitation is delivered (`SCHEDULE-STATUS=1.2`, message in the recipient's calendar). That is a workaround, not a fix — it duplicates every ACL entry.

### The change

Take `mbname_userid()` — the same canonicalisation that produced the mailbox name being written to — so the userid and the ACL agree. Sites without virtdomains, and users outside the default domain, are unaffected: for them the canonical form is the one already in use.

### Test

`cassandane/tiny-tests/Caldav/sched_deliver_virtdomains` runs a plain organiser→attendee delivery with `:VirtDomains`. The existing scheduling tests are all tagged `:NoVirtDomains`, which is presumably why this has gone unnoticed.

I could not run the Cassandane suite myself — this is a production host with the distribution package (3.8.3), not a build tree — so the test is written to the idiom of its neighbours rather than verified green. Tell me what it reports and I will fix it.