### PR TITLE
guesstz: fix the symlinked_alias flake, make database builds deterministic

### DIFF
--- a/cunit/guesstz.testc
+++ b/cunit/guesstz.testc
@@ -269,6 +269,34 @@ static void test_symlinked_alias(void)
     free(alias);
 }
 
+/* The zoneinfo directory is walked in name order, so a zone's place in the
+ * database doesn't depend on the order the filesystem hands its entries
+ * back.  The fixture writes Europe/Berlin before America/New_York, so
+ * creation order and name order disagree, and preftzs is stored in database
+ * order -- if the walk followed readdir this would be the writing order on
+ * some filesystems and not others. */
+static void test_walk_is_name_ordered(void)
+{
+    guesstz_t *gtz = guesstz_open(dbpath);
+    CU_ASSERT_PTR_NULL_FATAL((void *)guesstz_error(gtz));
+    char *json = guesstz_encode(gtz);
+    guesstz_close(&gtz);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(json);
+
+    json_t *jdb = json_loads(json, 0, NULL);
+    free(json);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(jdb);
+
+    json_t *jpreftzs = json_object_get(jdb, "preftzs");
+    CU_ASSERT_EQUAL_FATAL(json_array_size(jpreftzs), 2);
+    CU_ASSERT_STRING_EQUAL(json_string_value(json_array_get(jpreftzs, 0)),
+                           "America/New_York");
+    CU_ASSERT_STRING_EQUAL(json_string_value(json_array_get(jpreftzs, 1)),
+                           "Europe/Berlin");
+
+    json_decref(jdb);
+}
+
 /* The JSON dump round-trips the database header. */
 static void test_encode(void)
 {

--- a/cunit/guesstz.testc
+++ b/cunit/guesstz.testc
@@ -297,6 +297,44 @@ static void test_walk_is_name_ordered(void)
     json_decref(jdb);
 }
 
+/* An alias with a file of its own names the zone it aliases in
+ * TZID-ALIAS-OF, and stays out of the database so that a guess answers with
+ * the canonical zone rather than the alias. */
+static void test_aliasof_excluded(void)
+{
+    char *path = strconcat(zonedir, "/Europe/Berlin-alias.ics", (char *)NULL);
+    FILE *fp = fopen(path, "w");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(fp);
+    fprintf(fp, "%sBEGIN:VTIMEZONE\r\nTZID:Europe/Berlin-alias\r\n"
+                "TZID-ALIAS-OF:Europe/Berlin\r\n%sEND:VTIMEZONE\r\n%s",
+            VCAL_BEGIN, BERLIN_BODY, VCAL_END);
+    fclose(fp);
+
+    char *dbwith = strconcat(zonedir, "/aliasof.db", (char *)NULL);
+    fp = fopen(dbwith, "w");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(fp);
+    int r = guesstz_create(zonedir,
+                           icaltime_from_string(TRSTART),
+                           icaltime_from_string(TREND), fp);
+    fclose(fp);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+
+    guesstz_t *gtz = guesstz_open(dbwith);
+    CU_ASSERT_PTR_NULL_FATAL((void *)guesstz_error(gtz));
+    char *json = guesstz_encode(gtz);
+    guesstz_close(&gtz);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(json);
+    CU_ASSERT_PTR_NULL(strstr(json, "Europe/Berlin-alias"));
+    CU_ASSERT_PTR_NOT_NULL(strstr(json, "Europe/Berlin"));
+    free(json);
+
+    /* Leave the fixture as we found it for the tests after this one. */
+    CU_ASSERT_EQUAL(unlink(path), 0);
+    CU_ASSERT_EQUAL(unlink(dbwith), 0);
+    free(dbwith);
+    free(path);
+}
+
 /* The JSON dump round-trips the database header. */
 static void test_encode(void)
 {

--- a/cunit/guesstz.testc
+++ b/cunit/guesstz.testc
@@ -6,6 +6,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <jansson.h>
+
 #include "util.h"
 
 #include "imap/guesstz.h"
@@ -212,6 +214,31 @@ static void test_open_missing(void)
     guesstz_close(&gtz);
 }
 
+/* Encode a database for comparison against another one.  The header carries
+ * the time it was built at one-second resolution, so two databases built
+ * moments apart disagree on it whenever they straddle a second -- which says
+ * nothing about the zones they hold, so drop it. */
+static char *encode_for_compare(const char *path)
+{
+    guesstz_t *gtz = guesstz_open(path);
+    CU_ASSERT_PTR_NULL_FATAL((void *)guesstz_error(gtz));
+    char *raw = guesstz_encode(gtz);
+    guesstz_close(&gtz);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(raw);
+
+    json_t *jdb = json_loads(raw, 0, NULL);
+    free(raw);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(jdb);
+
+    json_object_del(json_object_get(jdb, "config"), "createdAt");
+
+    char *encoded = json_dumps(jdb, JSON_SORT_KEYS|JSON_INDENT(2));
+    json_decref(jdb);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(encoded);
+
+    return encoded;
+}
+
 /* A zoneinfo directory may name an alias with a symlink to the zone it
  * aliases, and indexing one must not file that zone a second time. */
 static void test_symlinked_alias(void)
@@ -229,21 +256,12 @@ static void test_symlinked_alias(void)
     CU_ASSERT_EQUAL_FATAL(r, 0);
 
     /* The database of the fixture without the symlink is our reference. */
-    guesstz_t *gtz = guesstz_open(dbpath);
-    CU_ASSERT_PTR_NULL_FATAL((void *)guesstz_error(gtz));
-    char *want = guesstz_encode(gtz);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(want);
-    guesstz_close(&gtz);
-
-    gtz = guesstz_open(path);
-    CU_ASSERT_PTR_NULL_FATAL((void *)guesstz_error(gtz));
-    char *have = guesstz_encode(gtz);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(have);
+    char *want = encode_for_compare(dbpath);
+    char *have = encode_for_compare(path);
     CU_ASSERT_STRING_EQUAL(have, want);
 
     free(have);
     free(want);
-    guesstz_close(&gtz);
 
     /* Leave the fixture as we found it for the tests after this one. */
     CU_ASSERT_EQUAL(unlink(alias), 0);

--- a/imap/guesstz.c
+++ b/imap/guesstz.c
@@ -1144,12 +1144,23 @@ static void add_vtimezone(icalarray *timezones, icalcomponent *vtz,
     icalarray_free(icalobs);
 }
 
+/* Walk the zoneinfo directory in name order.  fts_open with no comparator
+ * hands back each directory in readdir order, which differs between
+ * filesystems - and a zone's position in the database is what breaks ties
+ * between zones whose observances are identical, of which IANA has many.  So
+ * without this the database, and the guesses it answers with, depend on how
+ * the zoneinfo directory happens to be laid out on disk. */
+static int compare_ftsent(const FTSENT **a, const FTSENT **b)
+{
+    return strcmp((*a)->fts_name, (*b)->fts_name);
+}
+
 EXPORTED int guesstz_create(const char *zoneinfo_dir,
                    icaltimetype trstart, icaltimetype trend,
                    FILE *fp)
 {
     char *paths[2] = { (char *) zoneinfo_dir, NULL };
-    FTS *fts = fts_open(paths, FTS_PHYSICAL, NULL);
+    FTS *fts = fts_open(paths, FTS_PHYSICAL, compare_ftsent);
     if (!fts) {
         fprintf(stderr, "fts_open(%s): %s\n", zoneinfo_dir, strerror(errno));
         return EX_IOERR;

--- a/imap/guesstz.c
+++ b/imap/guesstz.c
@@ -1174,12 +1174,7 @@ EXPORTED int guesstz_create(const char *zoneinfo_dir,
     while ((fe = fts_read(fts))) {
         /* Skip symlinks.  A zoneinfo directory may name a time zone alias
          * with a link to the zone it aliases, and we index that zone by its
-         * own file already.
-         *
-         * TODO An alias that has a file of its own still enters the database
-         * under its own TZID, so a guess may name an alias rather than the
-         * canonical zone.  Skip the VTIMEZONEs that carry TZID-ALIAS-OF as
-         * well. */
+         * own file already. */
         if (fe->fts_info != FTS_F) {
             continue;
         }
@@ -1206,6 +1201,15 @@ EXPORTED int guesstz_create(const char *zoneinfo_dir,
             for (vtz = icalcomponent_get_first_component(ical, ICAL_VTIMEZONE_COMPONENT);
                  vtz;
                  vtz = icalcomponent_get_next_component(ical, ICAL_VTIMEZONE_COMPONENT)) {
+
+                /* An alias that has a file of its own carries TZID-ALIAS-OF
+                 * naming the zone it aliases.  That zone is indexed by its
+                 * own file, so filing the alias too would only give a guess
+                 * the chance to answer with the alias instead. */
+                if (icalcomponent_get_first_property(vtz,
+                            ICAL_TZIDALIASOF_PROPERTY)) {
+                    continue;
+                }
 
                 add_vtimezone(timezones, vtz, trstart, trend, tzoffsets);
             }


### PR DESCRIPTION
  `guesstz:symlinked_alias` intermittently fails `valgrind-make-check` on master
  (run 32261786152). Fixed root cause and two related determinism issues over 3 commits.

  ### Behaviour change

  Commits 2 and 3 change database contents. `cyr_guesstz` output differs, and some
  guesses return a different rules-equivalent TZID: canonical names instead of
  aliases, and the same answer regardless of filesystem.