### PR TITLE
Email/query: add `category` sort comparator

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_filters
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_filters
@@ -347,8 +347,8 @@ my @TESTCASES = (
         want_guidsearch => 1,
     },
 
-    # A G record has no per-message internaldate range criteria, even though it
-    # does carry the internaldate that guidsearch sorts on.
+    # The internaldate of a G record. It must be combined with a Xapian-backed
+    # filter condition to enable guidsearch.
     {
         name            => 'before',
         filter          => { before => '2020-01-01T00:00:00Z' },
@@ -358,7 +358,7 @@ my @TESTCASES = (
         name            => 'before_and_body',
         filter          =>
             with_body_search({ before => '2020-01-01T00:00:00Z' }),
-        want_guidsearch => 0,
+        want_guidsearch => 1,
     },
     {
         name            => 'after',
@@ -368,6 +368,40 @@ my @TESTCASES = (
     {
         name            => 'after_and_body',
         filter          => with_body_search({ after => '2020-01-01T00:00:00Z' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'before_after_and_body',
+        filter          => with_body_search({
+            after  => '2020-01-01T00:00:00Z',
+            before => '2021-01-01T00:00:00Z',
+        }),
+        want_guidsearch => 1,
+    },
+
+    # The non-Xapian criteria must be the same across all clauses of the
+    # disjunctive normal form, because guidsearch post-processes the Xapian
+    # results of all clauses at once.
+    {
+        name            => 'or_before_body_same_dates',
+        filter          => {
+            operator   => 'OR',
+            conditions => [
+                { body => 'hello', before => '2020-01-01T00:00:00Z' },
+                { body => 'world', before => '2020-01-01T00:00:00Z' },
+            ],
+        },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'or_before_body_differing_dates',
+        filter          => {
+            operator   => 'OR',
+            conditions => [
+                { body => 'hello', before => '2020-01-01T00:00:00Z' },
+                { body => 'world', before => '2021-01-01T00:00:00Z' },
+            ],
+        },
         want_guidsearch => 0,
     },
 

--- a/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_filters
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_filters
@@ -405,8 +405,9 @@ my @TESTCASES = (
         want_guidsearch => 0,
     },
 
-    # $seen is not a system flag of the message, it depends on the seen state of
-    # the mailboxes the message is in.
+    # $seen is not a system flag of the message, it depends on the seen state
+    # of the mailboxes the message is in, but it is answered from the G
+    # records of the guid just like a system flag is.
     {
         name            => 'has_keyword_seen',
         filter          => { hasKeyword => '$seen' },
@@ -415,7 +416,7 @@ my @TESTCASES = (
     {
         name            => 'has_keyword_seen_and_body',
         filter          => with_body_search({ hasKeyword => '$seen' }),
-        want_guidsearch => 0,
+        want_guidsearch => 1,
     },
     {
         name            => 'not_keyword_seen',
@@ -425,7 +426,7 @@ my @TESTCASES = (
     {
         name            => 'not_keyword_seen_and_body',
         filter          => with_body_search({ notKeyword => '$seen' }),
-        want_guidsearch => 0,
+        want_guidsearch => 1,
     },
 
     # Any other keyword is neither a system flag nor Xapian-backed.

--- a/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_filters
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_filters
@@ -1,0 +1,550 @@
+#!perl
+use Cassandane::Tiny;
+
+use Sub::Install ();
+
+# ANDs a filter condition with a body search, so that the filter carries a
+# condition which guidsearch answers from the Xapian index.
+my sub with_body_search ($cond)
+{
+    return {
+        operator   => 'AND',
+        conditions => [ $cond, { body => 'hello' } ],
+    };
+}
+
+# Creates the content that filter conditions refer to: a contact card with an
+# email address, and a contact group whose only member is that card. Returns the
+# id of the Inbox and the uids of the card and of the group.
+my sub create_fixtures ($self)
+{
+    my $user = $self->default_user;
+
+    my $abook = $user->addressbooks->create;
+    my $card = $abook->create_card({
+        name   => 'Contact',
+        emails => { e1 => { address => 'contact@example.com' } },
+    });
+    my $card_uid = q{} . $card->uid;
+    my $group = $abook->create_card_group({
+        name    => 'Group',
+        members => { $card_uid => JSON::true },
+    });
+
+    return {
+        inbox => q{} . $user->mailboxes->inbox->id,
+        card  => $card_uid,
+        group => q{} . $group->uid,
+    };
+}
+
+# The filter of a case may be a code reference that is called with the fixture
+# ids and returns the filter.
+my @TESTCASES = (
+    # Filter conditions indexed in Xapian.
+    {
+        name            => 'text',
+        filter          => { text => 'hello' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'from',
+        filter          => { from => 'foo@example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'to',
+        filter          => { to => 'foo@example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'cc',
+        filter          => { cc => 'foo@example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'bcc',
+        filter          => { bcc => 'foo@example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'subject',
+        filter          => { subject => 'hello' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'body',
+        filter          => { body => 'hello' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'attachment_name',
+        filter          => { attachmentName => 'attach.txt' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'attachment_body',
+        filter          => { attachmentBody => 'hello' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'delivered_to',
+        filter          => { deliveredTo => 'foo@example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'list_id',
+        filter          => { listId => 'list.example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'language',
+        filter          => { language => 'en' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'attachment_type_pdf',
+        filter          => { attachmentType => 'pdf' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'is_high_priority',
+        filter          => { isHighPriority => JSON::true },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'is_not_high_priority',
+        filter          => { isHighPriority => JSON::false },
+        want_guidsearch => 1,
+    },
+
+    # Fuzzy search for the email addresses of contact cards.
+    {
+        name            => 'from_any_contact',
+        filter          => { fromAnyContact => JSON::true },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'to_any_contact',
+        filter          => { toAnyContact => JSON::true },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'cc_any_contact',
+        filter          => { ccAnyContact => JSON::true },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'bcc_any_contact',
+        filter          => { bccAnyContact => JSON::true },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'from_contact_card_uid',
+        filter          => sub ($ids) { { fromContactCardUid => $ids->{card} } },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'to_contact_card_uid',
+        filter          => sub ($ids) { { toContactCardUid => $ids->{card} } },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'cc_contact_card_uid',
+        filter          => sub ($ids) { { ccContactCardUid => $ids->{card} } },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'bcc_contact_card_uid',
+        filter          => sub ($ids) { { bccContactCardUid => $ids->{card} } },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'from_contact_group_id',
+        filter          => sub ($ids) { { fromContactGroupId => $ids->{group} } },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'to_contact_group_id',
+        filter          => sub ($ids) { { toContactGroupId => $ids->{group} } },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'cc_contact_group_id',
+        filter          => sub ($ids) { { ccContactGroupId => $ids->{group} } },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'bcc_contact_group_id',
+        filter          => sub ($ids) { { bccContactGroupId => $ids->{group} } },
+        want_guidsearch => 1,
+    },
+
+    # Message id headers. The search attribute of these conditions is
+    # cache-backed, but guidsearch replaces it with a Xapian-backed one.
+    {
+        name            => 'message_id',
+        filter          => { messageId => 'msg1@example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'references',
+        filter          => { references => 'msg1@example.com' },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'in_reply_to',
+        filter          => { inReplyTo => 'msg1@example.com' },
+        want_guidsearch => 1,
+    },
+
+    # The folder bitvector of a G record.
+    {
+        name            => 'in_mailbox',
+        filter          => sub ($ids) { { inMailbox => $ids->{inbox} } },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'in_mailbox_and_body',
+        filter          => sub ($ids) {
+            with_body_search({ inMailbox => $ids->{inbox} })
+        },
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'in_mailbox_other_than',
+        filter          =>
+            sub ($ids) { { inMailboxOtherThan => [ $ids->{inbox} ] } },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'in_mailbox_other_than_and_body',
+        filter          => sub ($ids) {
+            with_body_search({ inMailboxOtherThan => [ $ids->{inbox} ] })
+        },
+        want_guidsearch => 1,
+    },
+
+    # The system flags of a G record.
+    {
+        name            => 'has_keyword_draft',
+        filter          => { hasKeyword => '$draft' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_keyword_draft_and_body',
+        filter          => with_body_search({ hasKeyword => '$draft' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'has_keyword_flagged',
+        filter          => { hasKeyword => '$flagged' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_keyword_flagged_and_body',
+        filter          => with_body_search({ hasKeyword => '$flagged' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'has_keyword_answered',
+        filter          => { hasKeyword => '$answered' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_keyword_answered_and_body',
+        filter          => with_body_search({ hasKeyword => '$answered' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'not_keyword_draft',
+        filter          => { notKeyword => '$draft' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'not_keyword_draft_and_body',
+        filter          => with_body_search({ notKeyword => '$draft' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'not_keyword_flagged',
+        filter          => { notKeyword => '$flagged' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'not_keyword_flagged_and_body',
+        filter          => with_body_search({ notKeyword => '$flagged' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'not_keyword_answered',
+        filter          => { notKeyword => '$answered' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'not_keyword_answered_and_body',
+        filter          => with_body_search({ notKeyword => '$answered' }),
+        want_guidsearch => 1,
+    },
+
+    # The unseen and flag counts of a conversation. Any keyword works here as
+    # long as it is counted in conversations_counted_flags, which for this test
+    # suite includes $flagged and $IsMailingList. Email/query rejects a keyword
+    # that is not counted as an unsupported filter.
+    {
+        name            => 'all_in_thread_have_keyword_seen',
+        filter          => { allInThreadHaveKeyword => '$seen' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'all_in_thread_have_keyword_seen_and_body',
+        filter          =>
+            with_body_search({ allInThreadHaveKeyword => '$seen' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'some_in_thread_have_keyword_seen',
+        filter          => { someInThreadHaveKeyword => '$seen' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'some_in_thread_have_keyword_seen_and_body',
+        filter          =>
+            with_body_search({ someInThreadHaveKeyword => '$seen' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'none_in_thread_have_keyword_seen',
+        filter          => { noneInThreadHaveKeyword => '$seen' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'none_in_thread_have_keyword_seen_and_body',
+        filter          =>
+            with_body_search({ noneInThreadHaveKeyword => '$seen' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'all_in_thread_have_keyword_flagged',
+        filter          => { allInThreadHaveKeyword => '$flagged' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'all_in_thread_have_keyword_flagged_and_body',
+        filter          =>
+            with_body_search({ allInThreadHaveKeyword => '$flagged' }),
+        want_guidsearch => 1,
+    },
+    {
+        name            => 'some_in_thread_have_keyword_mailinglist',
+        filter          => { someInThreadHaveKeyword => '$IsMailingList' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'some_in_thread_have_keyword_mailinglist_and_body',
+        filter          =>
+            with_body_search({ someInThreadHaveKeyword => '$IsMailingList' }),
+        want_guidsearch => 1,
+    },
+
+    # A G record has no per-message internaldate range criteria, even though it
+    # does carry the internaldate that guidsearch sorts on.
+    {
+        name            => 'before',
+        filter          => { before => '2020-01-01T00:00:00Z' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'before_and_body',
+        filter          =>
+            with_body_search({ before => '2020-01-01T00:00:00Z' }),
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'after',
+        filter          => { after => '2020-01-01T00:00:00Z' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'after_and_body',
+        filter          => with_body_search({ after => '2020-01-01T00:00:00Z' }),
+        want_guidsearch => 0,
+    },
+
+    # $seen is not a system flag of the message, it depends on the seen state of
+    # the mailboxes the message is in.
+    {
+        name            => 'has_keyword_seen',
+        filter          => { hasKeyword => '$seen' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_keyword_seen_and_body',
+        filter          => with_body_search({ hasKeyword => '$seen' }),
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'not_keyword_seen',
+        filter          => { notKeyword => '$seen' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'not_keyword_seen_and_body',
+        filter          => with_body_search({ notKeyword => '$seen' }),
+        want_guidsearch => 0,
+    },
+
+    # Any other keyword is neither a system flag nor Xapian-backed.
+    {
+        name            => 'has_keyword_user',
+        filter          => { hasKeyword => 'pinned' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_keyword_user_and_body',
+        filter          => with_body_search({ hasKeyword => 'pinned' }),
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'not_keyword_user',
+        filter          => { notKeyword => 'pinned' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'not_keyword_user_and_body',
+        filter          => with_body_search({ notKeyword => 'pinned' }),
+        want_guidsearch => 0,
+    },
+
+    # $HasAttachment only exists as a per-conversation count.
+    {
+        name            => 'has_attachment',
+        filter          => { hasAttachment => JSON::true },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_attachment_and_body',
+        filter          => with_body_search({ hasAttachment => JSON::true }),
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_no_attachment',
+        filter          => { hasAttachment => JSON::false },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'has_no_attachment_and_body',
+        filter          => with_body_search({ hasAttachment => JSON::false }),
+        want_guidsearch => 0,
+    },
+
+    # A G record has no message size.
+    {
+        name            => 'min_size',
+        filter          => { minSize => 1 },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'min_size_and_body',
+        filter          => with_body_search({ minSize => 1 }),
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'max_size',
+        filter          => { maxSize => 1000000 },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'max_size_and_body',
+        filter          => with_body_search({ maxSize => 1000000 }),
+        want_guidsearch => 0,
+    },
+
+    # Header matches need the message headers.
+    {
+        name            => 'header_exists',
+        filter          => { header => [ 'X-Foo' ] },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'header_exists_and_body',
+        filter          => with_body_search({ header => [ 'X-Foo' ] }),
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'header_contains',
+        filter          => { header => [ 'X-Foo', 'bar' ] },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'header_contains_and_body',
+        filter          => with_body_search({ header => [ 'X-Foo', 'bar' ] }),
+        want_guidsearch => 0,
+    },
+
+    # Embedded emails do not get indexed as an attachment type.
+    {
+        name            => 'attachment_type_email',
+        filter          => { attachmentType => 'email' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'attachment_type_email_and_body',
+        filter          => with_body_search({ attachmentType => 'email' }),
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'attachment_type_message_rfc822',
+        filter          => { attachmentType => 'message/rfc822' },
+        want_guidsearch => 0,
+    },
+    {
+        name            => 'attachment_type_message_rfc822_and_body',
+        filter          =>
+            with_body_search({ attachmentType => 'message/rfc822' }),
+        want_guidsearch => 0,
+    },
+);
+
+sub assert_email_query_guidsearch_filters ($self, $filter, $want_guidsearch)
+{
+    my $jmap = $self->{jmap};
+    $jmap->AddUsing(
+        'urn:ietf:params:jmap:contacts',
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/contacts',
+        'https://cyrusimap.org/ns/jmap/performance',
+    );
+
+    my $ids = create_fixtures($self);
+
+    $self->make_message('msg1', body => 'hello') or die;
+
+    xlog $self, "run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    $filter = $filter->($ids) if ref $filter eq 'CODE';
+
+    my $res = $jmap->request([
+        [ 'Email/query', { filter => $filter }, 'R1' ],
+    ]);
+    $res->assert_successful;
+
+    $self->assert_cmp_deeply(
+        $want_guidsearch ? jtrue() : jfalse(),
+        $res->single_sentence('Email/query')
+            ->arguments->{performance}{details}{isGuidSearch},
+        'isGuidSearch for ' . JSON::XS->new->canonical->encode($filter),
+    );
+}
+
+for my $case (@TESTCASES) {
+    Sub::Install::install_sub({
+        code => sub :JMAPExtensions ($self, @)
+        {
+            $self->assert_email_query_guidsearch_filters(
+                $case->{filter}, $case->{want_guidsearch});
+        },
+        as => "test_email_query_guidsearch_filters_$case->{name}",
+    });
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_receivedat
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_guidsearch_receivedat
@@ -1,0 +1,145 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_guidsearch_receivedat
+    :JMAPExtensions
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing(
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/performance',
+    );
+
+    # The instant that the filters of the test cases are relative to.
+    my $received_at = '2020-06-01T00:00:00Z';
+
+    # One email per receivedAt of interest, plus one email at the boundary that
+    # the body search does not match, so that a case can not pass by returning
+    # every email in the date range.
+    my %fixture = (
+        before_received_at => {
+            receivedAt => '2020-01-01T00:00:00Z',
+            body       => 'hello',
+        },
+        at_received_at => {
+            receivedAt => $received_at,
+            body       => 'hello',
+        },
+        after_received_at => {
+            receivedAt => '2021-01-01T00:00:00Z',
+            body       => 'hello',
+        },
+        no_match => {
+            receivedAt => $received_at,
+            body       => 'goodbye',
+        },
+    );
+
+    my $inbox = $user->mailboxes->inbox;
+
+    my %id_by_subject;
+    for my $subject (sort keys %fixture) {
+        my $email = $user->emails->create({
+            mailboxIds    => { $inbox->id => JSON::true },
+            subject       => $subject,
+            receivedAt    => $fixture{$subject}{receivedAt},
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => $fixture{$subject}{body} } },
+        });
+        $id_by_subject{$subject} = q{} . $email->id;
+    }
+
+    xlog $self, "run squatter";
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    # The filter of a case is ANDed with a body search. A case names the emails
+    # it expects, in the order that sorting on receivedAt ascending puts them
+    # in. The emails that the body search matches have distinct receivedAt
+    # values, so that order is a total order.
+    my @testcases = (
+        # before is inclusive, so the email at the boundary matches.
+        {
+            desc     => 'before',
+            cond     => { before => $received_at },
+            subjects => [ qw(before_received_at at_received_at) ],
+        },
+        # after is inclusive, too.
+        {
+            desc     => 'after',
+            cond     => { after => $received_at },
+            subjects => [ qw(at_received_at after_received_at) ],
+        },
+        # Both bounds at the same instant only leave the email at the boundary.
+        {
+            desc     => 'before_and_after_received_at',
+            cond     => { after => $received_at, before => $received_at },
+            subjects => [ qw(at_received_at) ],
+        },
+        {
+            desc     => 'between',
+            cond     => {
+                after  => '2020-03-01T00:00:00Z',
+                before => '2020-09-01T00:00:00Z',
+            },
+            subjects => [ qw(at_received_at) ],
+        },
+        # No email is in this range, but the body search still has candidates.
+        {
+            desc     => 'after_all_emails',
+            cond     => { after => '2022-01-01T00:00:00Z' },
+            subjects => [],
+        },
+        # Negation. Guidsearch keeps the range criteria in a NOT node.
+        {
+            desc     => 'not_before',
+            cond     => {
+                operator   => 'NOT',
+                conditions => [ { before => $received_at } ],
+            },
+            subjects => [ qw(after_received_at) ],
+        },
+    );
+
+    # Query each case twice, once answered by guidsearch and once by uidsearch.
+    my @methods;
+    for my $case (@testcases) {
+        for my $impl (qw(guidsearch uidsearch)) {
+            push @methods, [ 'Email/query', {
+                filter => {
+                    operator   => 'AND',
+                    conditions => [ { body => 'hello' }, $case->{cond} ],
+                },
+                sort => [{
+                    property    => 'receivedAt',
+                    isAscending => JSON::true,
+                }],
+                disableGuidSearch => $impl eq 'uidsearch'
+                                      ? JSON::true : JSON::false,
+            }, "$case->{desc}_$impl" ];
+        }
+    }
+
+    my $res = $jmap->request(\@methods);
+    $res->assert_successful;
+
+    for my $case (@testcases) {
+        my @want_ids = map { $id_by_subject{$_} } $case->{subjects}->@*;
+
+        for my $impl (qw(guidsearch uidsearch)) {
+            my $client_id = "$case->{desc}_$impl";
+            my $args = $res->paragraph_by_client_id($client_id)
+                           ->single('Email/query')->arguments;
+
+            $self->assert_cmp_deeply(
+                $impl eq 'guidsearch' ? jtrue() : jfalse(),
+                $args->{performance}{details}{isGuidSearch},
+                "isGuidSearch for $client_id",
+            );
+
+            $self->assert_cmp_deeply(\@want_ids, $args->{ids},
+                "ids for $client_id");
+        }
+    }
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_query_keyword_multimbox
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_keyword_multimbox
@@ -1,0 +1,135 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_keyword_multimbox
+    :JMAPExtensions
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing(
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/performance',
+    );
+
+    my $mboxa = $user->mailboxes->create({ name => 'A' });
+    my $mboxb = $user->mailboxes->create({ name => 'B' });
+
+    # Two emails, each with a copy in both mailboxes. The one created first
+    # gets sequence number 1 in each mailbox.
+    my %id_by_subject;
+    my %receivedat = (
+        flagged   => '2020-01-01T00:00:00Z',
+        unflagged => '2021-01-01T00:00:00Z',
+    );
+    for my $subject (qw(flagged unflagged)) {
+        my $email = $user->emails->create({
+            mailboxIds    => {
+                $mboxa->id => JSON::true,
+                $mboxb->id => JSON::true,
+            },
+            subject       => $subject,
+            receivedAt    => $receivedat{$subject},
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => 'hello' } },
+        });
+        $id_by_subject{$subject} = q{} . $email->id;
+    }
+
+    xlog $self, 'set \\Flagged on the copy in mailbox A only';
+    my $imap = $self->{store}->get_client();
+    $imap->select('A');
+    $imap->store('1', '+flags', '(\\Flagged)');
+
+    xlog $self, 'run squatter';
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    # A keyword is a property of the Email, so flagging one copy flags the
+    # email. This is what Email/query must agree with.
+    my $res = $jmap->request([
+        [ 'Email/get', {
+            ids        => [ map { $id_by_subject{$_} } qw(flagged unflagged) ],
+            properties => [ 'keywords' ],
+        }, 'R1' ],
+    ]);
+    $res->assert_successful;
+    my $list = $res->single_sentence('Email/get')->arguments->{list};
+    $self->assert_cmp_deeply(jtrue(), $list->[0]{keywords}{'$flagged'},
+        'email with a flagged copy has $flagged');
+    $self->assert_cmp_deeply(undef, $list->[1]{keywords}{'$flagged'},
+        'email with no flagged copy has no $flagged');
+
+    # A case names the emails it expects, in the order that sorting on
+    # receivedAt ascending puts them in.
+    my @testcases = (
+        {
+            desc     => 'has_keyword',
+            cond     => { hasKeyword => '$flagged' },
+            subjects => [ qw(flagged) ],
+        },
+        {
+            desc     => 'not_keyword',
+            cond     => { notKeyword => '$flagged' },
+            subjects => [ qw(unflagged) ],
+        },
+        # The flagged copy is in mailbox A, but the email is flagged, so it
+        # matches a filter that restricts to mailbox B.
+        {
+            desc     => 'in_mailbox_has_keyword',
+            cond     => {
+                inMailbox  => q{} . $mboxb->id,
+                hasKeyword => '$flagged',
+            },
+            subjects => [ qw(flagged) ],
+        },
+        {
+            desc     => 'in_mailbox_not_keyword',
+            cond     => {
+                inMailbox  => q{} . $mboxb->id,
+                notKeyword => '$flagged',
+            },
+            subjects => [ qw(unflagged) ],
+        },
+    );
+
+    # Query each case twice, once answered by guidsearch and once by uidsearch.
+    my @methods;
+    for my $case (@testcases) {
+        for my $impl (qw(guidsearch uidsearch)) {
+            push @methods, [ 'Email/query', {
+                filter => {
+                    operator   => 'AND',
+                    conditions => [ { body => 'hello' }, $case->{cond} ],
+                },
+                sort => [{
+                    property    => 'receivedAt',
+                    isAscending => JSON::true,
+                }],
+                disableGuidSearch => $impl eq 'uidsearch'
+                                       ? JSON::true : JSON::false,
+            }, "$case->{desc}_$impl" ];
+        }
+    }
+
+    $res = $jmap->request(\@methods);
+    $res->assert_successful;
+
+    for my $case (@testcases) {
+        my @want_ids = map { $id_by_subject{$_} } $case->{subjects}->@*;
+
+        for my $impl (qw(guidsearch uidsearch)) {
+            my $client_id = "$case->{desc}_$impl";
+            my $args = $res->paragraph_by_client_id($client_id)
+                           ->single('Email/query')->arguments;
+
+            $self->assert_cmp_deeply(
+                $impl eq 'guidsearch' ? jtrue() : jfalse(),
+                $args->{performance}{details}{isGuidSearch},
+                "isGuidSearch for $client_id",
+            );
+
+            $self->assert_cmp_deeply(\@want_ids, $args->{ids},
+                "ids for $client_id");
+        }
+    }
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_query_keyword_seen
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_keyword_seen
@@ -1,0 +1,139 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_keyword_seen
+    :JMAPExtensions
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing(
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/performance',
+    );
+
+    my $mboxa  = $user->mailboxes->create({ name => 'A' });
+    my $mboxb  = $user->mailboxes->create({ name => 'B' });
+    my $trash  = $user->mailboxes->create({ name => 'Trash', role => 'trash' });
+
+    # Each email has two copies. The emails are created in the order below,
+    # so within each mailbox they get sequence numbers in that same order.
+    #
+    # A copy in Trash counts like any other copy, in both directions: the
+    # email whose only seen copy is in Trash is unseen, and so is the email
+    # whose only unseen copy is in Trash.
+    my @emails = (
+        { subject    => 'allseen',
+          receivedAt => '2020-01-01T00:00:00Z',
+          mailboxes  => [ $mboxa, $mboxb ] },
+        { subject    => 'partseen',
+          receivedAt => '2021-01-01T00:00:00Z',
+          mailboxes  => [ $mboxa, $mboxb ] },
+        { subject    => 'noneseen',
+          receivedAt => '2022-01-01T00:00:00Z',
+          mailboxes  => [ $mboxa, $mboxb ] },
+        { subject    => 'trashseen',
+          receivedAt => '2023-01-01T00:00:00Z',
+          mailboxes  => [ $mboxa, $trash ] },
+        { subject    => 'trashunseen',
+          receivedAt => '2024-01-01T00:00:00Z',
+          mailboxes  => [ $mboxa, $trash ] },
+    );
+
+    my %id_by_subject;
+    for my $spec (@emails) {
+        my $email = $user->emails->create({
+            mailboxIds    => { map { $_->id => JSON::true }
+                                   $spec->{mailboxes}->@* },
+            subject       => $spec->{subject},
+            receivedAt    => $spec->{receivedAt},
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => 'hello' } },
+        });
+        $id_by_subject{$spec->{subject}} = q{} . $email->id;
+    }
+
+    xlog $self, 'set \\Seen on some copies only';
+    my $imap = $self->{store}->get_client();
+    $imap->select('A');
+    $imap->store('1,2,5', '+flags', '(\\Seen)'); # allseen, partseen,
+                                                 # trashunseen
+    $imap->select('B');
+    $imap->store('1', '+flags', '(\\Seen)');     # allseen
+    $imap->select('Trash');
+    $imap->store('1', '+flags', '(\\Seen)');     # trashseen
+
+    xlog $self, 'run squatter';
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    # $seen is a property of the Email, so an Email is seen only if every one
+    # of its copies is seen. This is what Email/query must agree with, for
+    # the copy in Trash just like for any other copy.
+    my $res = $jmap->request([
+        [ 'Email/get', {
+            ids        => [ map { $id_by_subject{$_->{subject}} } @emails ],
+            properties => [ 'keywords' ],
+        }, 'R1' ],
+    ]);
+    $res->assert_successful;
+    my $list = $res->single_sentence('Email/get')->arguments->{list};
+    $self->assert_cmp_deeply(
+        [ jtrue(), undef, undef, undef, undef ],
+        [ map { $_->{keywords}{'$seen'} } $list->@* ],
+        'only the email with all copies seen has $seen',
+    );
+
+    my @testcases = (
+        {
+            desc     => 'has_keyword',
+            cond     => { hasKeyword => '$seen' },
+            subjects => [ qw(allseen) ],
+        },
+        {
+            desc     => 'not_keyword',
+            cond     => { notKeyword => '$seen' },
+            subjects => [ qw(partseen noneseen trashseen trashunseen) ],
+        },
+    );
+
+    # Query each case twice, once answered by guidsearch and once by uidsearch.
+    my @methods;
+    for my $case (@testcases) {
+        for my $impl (qw(guidsearch uidsearch)) {
+            push @methods, [ 'Email/query', {
+                filter => {
+                    operator   => 'AND',
+                    conditions => [ { body => 'hello' }, $case->{cond} ],
+                },
+                sort => [{
+                    property    => 'receivedAt',
+                    isAscending => JSON::true,
+                }],
+                disableGuidSearch => $impl eq 'uidsearch'
+                                        ? JSON::true : JSON::false,
+            }, "$case->{desc}_$impl" ];
+        }
+    }
+
+    $res = $jmap->request(\@methods);
+    $res->assert_successful;
+
+    for my $case (@testcases) {
+        my @want_ids = map { $id_by_subject{$_} } $case->{subjects}->@*;
+
+        for my $impl (qw(guidsearch uidsearch)) {
+            my $client_id = "$case->{desc}_$impl";
+            my $args = $res->paragraph_by_client_id($client_id)
+                           ->single('Email/query')->arguments;
+
+            $self->assert_cmp_deeply(
+                $impl eq 'guidsearch' ? jtrue() : jfalse(),
+                $args->{performance}{details}{isGuidSearch},
+                "isGuidSearch for $client_id",
+            );
+
+            $self->assert_cmp_deeply(\@want_ids, $args->{ids},
+                "ids for $client_id");
+        }
+    }
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sort_category
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sort_category
@@ -1,0 +1,139 @@
+#!perl
+use Cassandane::Tiny;
+
+# The emails of this test, in the order that sorting by receivedAt ascending
+# puts them in. Each names the keywords it is created with.
+my @EMAILS = (
+    { subject    => 'flagged1',
+      receivedAt => '2020-01-01T00:00:00Z',
+      keywords   => { '$flagged' => JSON::true } },
+    { subject    => 'plain',
+      receivedAt => '2021-01-01T00:00:00Z',
+      keywords   => {} },
+    { subject    => 'flagged2',
+      receivedAt => '2022-01-01T00:00:00Z',
+      keywords   => { '$flagged' => JSON::true } },
+    { subject    => 'draft',
+      receivedAt => '2023-01-01T00:00:00Z',
+      keywords   => { '$draft' => JSON::true } },
+);
+
+# Query the emails above with a category sort that groups the flagged emails
+# first and the drafts second, and assert the order of the result and its
+# groupByCounts for both Email/query implementations.
+sub assert_email_query_sort_category ($self, %params)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing(
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/performance',
+    );
+
+    my $mbox = $user->mailboxes->create({ name => 'A' });
+
+    my %id_by_subject;
+    for my $spec (@EMAILS) {
+        my $email = $user->emails->create({
+            mailboxIds    => { $mbox->id => JSON::true },
+            keywords      => $spec->{keywords},
+            subject       => $spec->{subject},
+            receivedAt    => $spec->{receivedAt},
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => 'hello' } },
+        });
+        $id_by_subject{$spec->{subject}} = q{} . $email->id;
+    }
+
+    xlog $self, 'run squatter';
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $sort = [
+        {
+            property    => 'category',
+            isAscending => $params{is_ascending},
+            groupBy     => [
+                { hasKeyword => '$flagged' },
+                { hasKeyword => '$draft' },
+            ],
+        },
+        {
+            property    => 'receivedAt',
+            isAscending => JSON::true,
+        },
+    ];
+
+    # Query once per implementation. The filter matches every email, and its
+    # body condition makes the query eligible for guidsearch.
+    my @methods;
+    for my $impl (qw(guidsearch uidsearch)) {
+        push @methods, [ 'Email/query', {
+            filter            => { body => 'hello' },
+            sort              => $sort,
+            disableGuidSearch => $impl eq 'uidsearch'
+                                    ? JSON::true : JSON::false,
+            ($params{position} ? (position => $params{position}) : ()),
+            ($params{limit}    ? (limit    => $params{limit})    : ()),
+        }, $impl ];
+    }
+
+    my $res = $jmap->request(\@methods);
+    $res->assert_successful;
+
+    my @want_ids = map { $id_by_subject{$_} } $params{subjects}->@*;
+
+    for my $impl (qw(guidsearch uidsearch)) {
+        my $args = $res->paragraph_by_client_id($impl)
+                       ->single('Email/query')->arguments;
+
+        $self->assert_cmp_deeply(
+            $impl eq 'guidsearch' ? jtrue() : jfalse(),
+            $args->{performance}{details}{isGuidSearch},
+            "isGuidSearch for $impl",
+        );
+
+        $self->assert_cmp_deeply(\@want_ids, $args->{ids}, "ids for $impl");
+
+        # The email matching no groupBy filter is in no group
+        $self->assert_cmp_deeply([2, 1], $args->{groupByCounts},
+            "groupByCounts for $impl");
+    }
+}
+
+sub test_email_query_sort_category__ascending
+    :JMAPExtensions
+    ($self)
+{
+    # Sort the flagged emails first, then the draft, then what matched no
+    # groupBy filter
+    $self->assert_email_query_sort_category(
+        is_ascending => JSON::true,
+        subjects     => [ qw(flagged1 flagged2 draft plain) ],
+    );
+}
+
+sub test_email_query_sort_category__descending
+    :JMAPExtensions
+    ($self)
+{
+    # Sort the categories in reverse order, but keep the emails within each
+    # of them in the order of receivedAt
+    $self->assert_email_query_sort_category(
+        is_ascending => JSON::false,
+        subjects     => [ qw(plain draft flagged1 flagged2) ],
+    );
+}
+
+sub test_email_query_sort_category__window
+    :JMAPExtensions
+    ($self)
+{
+    # Return a window over the result. Sorting it and counting its categories
+    # still needs the whole result, which the groupByCounts assert covers.
+    $self->assert_email_query_sort_category(
+        is_ascending => JSON::true,
+        position     => 1,
+        limit        => 2,
+        subjects     => [ qw(flagged2 draft) ],
+    );
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sort_category_inmailbox
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sort_category_inmailbox
@@ -1,0 +1,94 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_sort_category_inmailbox
+    :JMAPExtensions
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing(
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/performance',
+    );
+
+    my $mboxa = $user->mailboxes->create({ name => 'A' });
+    my $mboxb = $user->mailboxes->create({ name => 'B' });
+
+    # The emails are created in the order below, which is also the order that
+    # sorting by receivedAt ascending puts them in.
+    my @emails = (
+        { subject    => 'in_a',
+          receivedAt => '2020-01-01T00:00:00Z',
+          mailboxes  => [ $mboxa ] },
+        { subject    => 'in_b',
+          receivedAt => '2021-01-01T00:00:00Z',
+          mailboxes  => [ $mboxb ] },
+        { subject    => 'in_both',
+          receivedAt => '2022-01-01T00:00:00Z',
+          mailboxes  => [ $mboxa, $mboxb ] },
+    );
+
+    my %id_by_subject;
+    for my $spec (@emails) {
+        my $email = $user->emails->create({
+            mailboxIds    => { map { $_->id => JSON::true }
+                                   $spec->{mailboxes}->@* },
+            subject       => $spec->{subject},
+            receivedAt    => $spec->{receivedAt},
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => 'hello' } },
+        });
+        $id_by_subject{$spec->{subject}} = q{} . $email->id;
+    }
+
+    xlog $self, 'run squatter';
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $sort = [
+        {
+            property    => 'category',
+            isAscending => JSON::true,
+            groupBy     => [ { inMailbox => q{} . $mboxb->id } ],
+        },
+        {
+            property    => 'receivedAt',
+            isAscending => JSON::true,
+        },
+    ];
+
+    # Query once per implementation. The filter matches every email, and its
+    # body condition makes the query eligible for guidsearch. It does not
+    # read mailboxes, so only the category sort does.
+    my @methods;
+    for my $impl (qw(guidsearch uidsearch)) {
+        push @methods, [ 'Email/query', {
+            filter            => { body => 'hello' },
+            sort              => $sort,
+            disableGuidSearch => $impl eq 'uidsearch'
+                                    ? JSON::true : JSON::false,
+        }, $impl ];
+    }
+
+    my $res = $jmap->request(\@methods);
+    $res->assert_successful;
+
+    # An Email is in a mailbox if any of its copies is, so the email having
+    # a copy in each mailbox is in the category of mailbox B
+    my @want_ids = map { $id_by_subject{$_} } qw(in_b in_both in_a);
+
+    for my $impl (qw(guidsearch uidsearch)) {
+        my $args = $res->paragraph_by_client_id($impl)
+                       ->single('Email/query')->arguments;
+
+        $self->assert_cmp_deeply(
+            $impl eq 'guidsearch' ? jtrue() : jfalse(),
+            $args->{performance}{details}{isGuidSearch},
+            "isGuidSearch for $impl",
+        );
+
+        $self->assert_cmp_deeply(\@want_ids, $args->{ids}, "ids for $impl");
+        $self->assert_cmp_deeply([2], $args->{groupByCounts},
+            "groupByCounts for $impl");
+    }
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sort_category_threads
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sort_category_threads
@@ -1,0 +1,141 @@
+#!perl
+use Cassandane::Tiny;
+
+# Three threads of two emails each. A thread counts as unread unless every
+# one of its emails is seen, so the first and the last thread are unread.
+# The emails are created in the order below, which is also the order that
+# sorting by receivedAt ascending puts them in.
+my @EMAILS = (
+    { messageId  => 'unread_a1',
+      references => 'unread_a',
+      receivedAt => '2020-01-01T00:00:00Z',
+      keywords   => {} },
+    { messageId  => 'unread_a2',
+      references => 'unread_a',
+      receivedAt => '2021-01-01T00:00:00Z',
+      keywords   => {} },
+    { messageId  => 'read_b1',
+      references => 'read_b',
+      receivedAt => '2022-01-01T00:00:00Z',
+      keywords   => { '$seen' => JSON::true } },
+    { messageId  => 'read_b2',
+      references => 'read_b',
+      receivedAt => '2023-01-01T00:00:00Z',
+      keywords   => { '$seen' => JSON::true } },
+    { messageId  => 'unread_c1',
+      references => 'unread_c',
+      receivedAt => '2024-01-01T00:00:00Z',
+      keywords   => {} },
+    { messageId  => 'unread_c2',
+      references => 'unread_c',
+      receivedAt => '2025-01-01T00:00:00Z',
+      keywords   => { '$seen' => JSON::true } },
+);
+
+# Sort the emails above by a category that puts the unread threads first,
+# and within each category by receivedAt descending. Assert the result and
+# its groupByCounts for both Email/query implementations.
+sub assert_email_query_sort_category_threads ($self, %params)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing(
+        'https://cyrusimap.org/ns/jmap/mail',
+        'https://cyrusimap.org/ns/jmap/performance',
+    );
+
+    my $mbox = $user->mailboxes->create({ name => 'A' });
+
+    my %id_by_messageid;
+    for my $spec (@EMAILS) {
+        my $email = $user->emails->create({
+            mailboxIds    => { $mbox->id => JSON::true },
+            keywords      => $spec->{keywords},
+            messageId     => [ "$spec->{messageId}\@local" ],
+            references    => [ "$spec->{references}\@local" ],
+            subject       => "Re: $spec->{references}",
+            receivedAt    => $spec->{receivedAt},
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => 'hello' } },
+        });
+        $id_by_messageid{$spec->{messageId}} = q{} . $email->id;
+    }
+
+    xlog $self, 'run squatter';
+    $self->{instance}->run_command({cyrus => 1}, 'squatter');
+
+    my $sort = [
+        {
+            property    => 'category',
+            isAscending => JSON::true,
+            groupBy     => [{
+                operator   => 'NOT',
+                conditions => [ { allInThreadHaveKeyword => '$seen' } ],
+            }],
+        },
+        {
+            property    => 'receivedAt',
+            isAscending => JSON::false,
+        },
+    ];
+
+    # Query once per implementation. The filter matches every email, and its
+    # body condition makes the query eligible for guidsearch.
+    my @methods;
+    for my $impl (qw(guidsearch uidsearch)) {
+        push @methods, [ 'Email/query', {
+            filter            => { body => 'hello' },
+            sort              => $sort,
+            collapseThreads   => $params{collapse_threads},
+            disableGuidSearch => $impl eq 'uidsearch'
+                                    ? JSON::true : JSON::false,
+        }, $impl ];
+    }
+
+    my $res = $jmap->request(\@methods);
+    $res->assert_successful;
+
+    my @want_ids = map { $id_by_messageid{$_} } $params{messageIds}->@*;
+
+    for my $impl (qw(guidsearch uidsearch)) {
+        my $args = $res->paragraph_by_client_id($impl)
+                       ->single('Email/query')->arguments;
+
+        $self->assert_cmp_deeply(
+            $impl eq 'guidsearch' ? jtrue() : jfalse(),
+            $args->{performance}{details}{isGuidSearch},
+            "isGuidSearch for $impl",
+        );
+
+        $self->assert_cmp_deeply(\@want_ids, $args->{ids}, "ids for $impl");
+
+        $self->assert_cmp_deeply($params{counts}, $args->{groupByCounts},
+            "groupByCounts for $impl");
+    }
+}
+
+sub test_email_query_sort_category_threads__uncollapsed
+    :JMAPExtensions
+    ($self)
+{
+    $self->assert_email_query_sort_category_threads(
+        collapse_threads => JSON::false,
+        messageIds => [ qw(unread_c2 unread_c1 unread_a2 unread_a1
+                           read_b2 read_b1) ],
+        counts => [ 4 ],
+    );
+}
+
+sub test_email_query_sort_category_threads__collapsed
+    :JMAPExtensions
+    ($self)
+{
+    # The representative of a thread is its first email in sort order, so
+    # the categories must be assigned before the threads are collapsed, and
+    # the counts are over the collapsed result.
+    $self->assert_email_query_sort_category_threads(
+        collapse_threads => JSON::true,
+        messageIds => [ qw(unread_c2 unread_a2 read_b2) ],
+        counts => [ 2 ],
+    );
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_query_sort_category_unsupported
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_sort_category_unsupported
@@ -1,0 +1,125 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_query_sort_category_unsupported
+    :JMAPExtensions
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+
+    my $unread = {
+        operator   => 'NOT',
+        conditions => [ { allInThreadHaveKeyword => '$seen' } ],
+    };
+
+    my @testcases = (
+        {
+            desc => 'no_group_by',
+            sort => [ { property => 'category' } ],
+        },
+        {
+            desc => 'empty_group_by',
+            sort => [ { property => 'category', groupBy => [] } ],
+        },
+        {
+            desc => 'group_by_not_an_array',
+            sort => [ { property => 'category', groupBy => $unread } ],
+        },
+        {
+            # A category sort takes at most EMAILQUERY_MAX_CATEGORIES filters
+            desc => 'too_many_group_by',
+            sort => [ {
+                property => 'category',
+                groupBy  => [ map { $unread } 0 .. 32 ],
+            } ],
+        },
+        {
+            desc => 'invalid_condition',
+            sort => [ {
+                property => 'category',
+                groupBy  => [ { noSuchCondition => JSON::true } ],
+            } ],
+        },
+        # Only conditions that are answered from conversations.db can be
+        # evaluated for each Email of a result
+        {
+            desc => 'condition_needs_search_index',
+            sort => [ {
+                property => 'category',
+                groupBy  => [ { subject => 'hello' } ],
+            } ],
+        },
+        {
+            desc => 'condition_needs_index_record',
+            sort => [ {
+                property => 'category',
+                groupBy  => [ { minSize => 42 } ],
+            } ],
+        },
+        {
+            # A user keyword is not in the G records of a guid
+            desc => 'condition_needs_user_keyword',
+            sort => [ {
+                property => 'category',
+                groupBy  => [ { hasKeyword => 'pinned' } ],
+            } ],
+        },
+        {
+            # One unsupported condition rejects the whole filter, wherever
+            # it sits in the boolean tree
+            desc => 'condition_nested_in_operator',
+            sort => [ {
+                property => 'category',
+                groupBy  => [ {
+                    operator   => 'OR',
+                    conditions => [ { hasKeyword => '$flagged' },
+                                    { subject => 'hello' } ],
+                } ],
+            } ],
+        },
+        {
+            # The second filter is what is unsupported here
+            desc => 'second_filter_unsupported',
+            sort => [ {
+                property => 'category',
+                groupBy  => [ $unread, { subject => 'hello' } ],
+            } ],
+        },
+        {
+            desc => 'not_the_primary_sort',
+            pos  => 1,
+            sort => [
+                { property => 'receivedAt' },
+                { property => 'category', groupBy => [ $unread ] },
+            ],
+        },
+        {
+            desc => 'two_category_comparators',
+            pos  => 1,
+            sort => [
+                { property => 'category', groupBy => [ $unread ] },
+                { property => 'category', groupBy => [ $unread ] },
+            ],
+        },
+    );
+
+    my @methods = map {
+        [ 'Email/query', { sort => $_->{sort} }, $_->{desc} ]
+    } @testcases;
+
+    my $res = $jmap->request(\@methods);
+
+    for my $case (@testcases) {
+        my $args = $res->paragraph_by_client_id($case->{desc})
+                       ->single('error')->arguments;
+
+        $self->assert_str_equals('unsupportedSort', $args->{type},
+            "error type for $case->{desc}");
+
+        # The error names the comparator that is not supported
+        $self->assert_cmp_deeply([ sprintf('sort[%d]', $case->{pos} // 0) ],
+            $args->{sort}, "unsupported sort for $case->{desc}");
+    }
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_sort_category
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_sort_category
@@ -1,0 +1,43 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_querychanges_sort_category
+    :JMAPExtensions
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+
+    my $sort = [
+        {
+            property => 'category',
+            groupBy  => [ {
+                operator   => 'NOT',
+                conditions => [ { allInThreadHaveKeyword => '$seen' } ],
+            } ],
+        },
+    ];
+
+    my $res = $jmap->request([
+        [ 'Email/query', { sort => $sort }, 'R1' ],
+    ]);
+    $res->assert_successful;
+
+    my $args = $res->single_sentence('Email/query')->arguments;
+
+    # A category groups by keyword state, which makes the sort order change
+    # without any Email being added to or removed from the result
+    $self->assert_cmp_deeply(jfalse(), $args->{canCalculateChanges},
+        'canCalculateChanges');
+
+    $res = $jmap->request([
+        [ 'Email/queryChanges', {
+            sinceQueryState => $args->{queryState},
+            sort            => $sort,
+        }, 'R1' ],
+    ]);
+
+    $self->assert_str_equals('cannotCalculateChanges',
+        $res->single_sentence('error')->arguments->{type});
+}

--- a/changes/next/cyr-2790-jmap-email-query-categories
+++ b/changes/next/cyr-2790-jmap-email-query-categories
@@ -1,0 +1,37 @@
+Description:
+
+Email/query now supports the non-standard "category" comparator to sort
+query results by filter conditions. Only a subset of Email filter
+conditions is supported, a query that groups by any other condition is
+rejected with an "unsupportedSort" error.
+
+The semantics of keywords now align between Email/get and Email/query.
+Before, Email/query could evaluate the $draft, $flagged, $answered and
+$seen keywords for the index record in only one mailbox, rather than for
+the Email as a whole.
+
+
+Documentation:
+
+None
+
+
+Config changes:
+
+None. The "category" comparator requires jmap_nonstandard_extensions to
+be enabled in imapd.conf.
+
+
+Upgrade instructions:
+
+The semantics for Email keyword queries now align with Email/get:
+"notKeyword" now matches an Email if no copy of it has the flag, where it
+used to match as soon as any copy did not have it. A filter that combines
+"inMailbox" with "hasKeyword" now matches an Email whose flagged copy is in
+another mailbox. An Email whose only seen copy is in Trash no longer matches
+hasKeyword $seen.
+
+
+GitHub issue:
+
+None

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -2478,7 +2478,7 @@ HIDDEN void jmap_comparator_parse(jmap_req_t *req, struct jmap_parser *parser,
         return;
     }
 
-    struct jmap_comparator comp = { NULL, 0, NULL };
+    struct jmap_comparator comp = { .jcomp = jsort };
 
     /* property */
     json_t *val = json_object_get(jsort, "property");

--- a/imap/jmap_api.h
+++ b/imap/jmap_api.h
@@ -592,6 +592,7 @@ struct jmap_comparator {
     const char *property;
     short is_ascending;
     const char *collation;
+    json_t *jcomp;   /* the Comparator object, for non-standard properties */
 };
 
 typedef int jmap_comparator_parse_cb(jmap_req_t *req, struct jmap_comparator *comp,

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -3387,6 +3387,7 @@ enum guidsearch_expr_op {
     GSEOP_FLAGS,
     GSEOP_CONVFLAGS,
     GSEOP_ALLCONVFLAGS,
+    GSEOP_INTERNALDATE,
     GSEOP_AND,
     GSEOP_OR,
     GSEOP_NOT
@@ -3399,6 +3400,10 @@ union guidsearch_expr_value {
         uint32_t num;
         uint8_t include_trash;
     } convflag;
+    struct {
+        int64_t t;   // seconds since epoch
+        uint8_t op;  // one of SEOP_LT, SEOP_LE, SEOP_GT, SEOP_GE
+    } internaldate;
 };
 
 struct guidsearch_expr {
@@ -3529,6 +3534,23 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                 }
             }
             break;
+        case SEOP_LT:
+        case SEOP_LE:
+        case SEOP_GT:
+        case SEOP_GE:
+            {
+                if (e->attr == search_attr_find("internaldate")) {
+                    // before, after
+                    ge = xzmalloc(sizeof(struct guidsearch_expr));
+                    ge->op = GSEOP_INTERNALDATE;
+                    ge->v.internaldate.t = (int64_t) e->value.t;
+                    ge->v.internaldate.op = e->op;
+                }
+                else {
+                    assert(0); // guidsearch_rank_clause must reject this
+                }
+            }
+            break;
         case SEOP_MATCH:
             {
                 if (e->attr == search_attr_find("folder")) {
@@ -3639,6 +3661,9 @@ static void guidsearch_expr_serialise(struct buf *buf, struct guidsearch_expr *e
             break;
         case GSEOP_ALLCONVFLAGS:
             buf_appendcstr(buf, "ALLCONVFLAGS");
+            break;
+        case GSEOP_INTERNALDATE:
+            buf_appendcstr(buf, "INTERNALDATE");
             break;
         case GSEOP_AND:
             buf_appendcstr(buf, "AND");
@@ -3761,6 +3786,25 @@ static int guidsearch_expr_eval(struct conversations_state *cstate,
                 conversation_fini(&conv);
                 return ret;
             }
+        case GSEOP_INTERNALDATE:
+            {
+                /* Compare at second granularity. */
+                struct timespec internaldate;
+                TIMESPEC_FROM_NANOSEC(&internaldate, match->nano_internaldate);
+                int64_t d = (int64_t) internaldate.tv_sec - e->v.internaldate.t;
+                switch (e->v.internaldate.op) {
+                    case SEOP_LT:
+                        return d < 0;
+                    case SEOP_LE:
+                        return d <= 0;
+                    case SEOP_GT:
+                        return d > 0;
+                    case SEOP_GE:
+                        return d >= 0;
+                    default:
+                        return 1;
+                }
+            }
         default:
             return 1;
     }
@@ -3826,8 +3870,16 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
         case SEOP_LE:
         case SEOP_GT:
         case SEOP_GE:
-            // TODO support receivedAt?
-            return -1;
+            if (e->attr == search_attr_find("internaldate")) {
+                /* before
+                 * after */
+                if (nonxapian_hash) {
+                    guidsearch_hash_expr(e, nonxapian_hash);
+                }
+                return 1;
+            }
+            // minSize, maxSize and sinceEmailState are unsupported
+            else return -1;
         case SEOP_MATCH:
             // check for supported MATCH expressions
             if (e->attr == search_attr_find("folder") ||
@@ -3993,12 +4045,10 @@ static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
     }
 
     if (prev && !memcmp(rec->guidrep, prev->guidrep, MESSAGE_GUID_SIZE*2)) {
-        /* Update match for same guid */
+        /* Update match for same guid. All copies of a guid carry the same
+         * internaldate, so only folders and flags need merging. */
         if (gsq->numfolders) bv_set(&prev->folders, rec->foldernum);
         prev->system_flags |= rec->system_flags;
-        if (rec->nano_internaldate < prev->nano_internaldate) {
-            prev->nano_internaldate = rec->nano_internaldate;
-        }
         return 0;
     }
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1511,14 +1511,44 @@ static const char *jmapseen_source_as_string(enum jmapseen_source seen_source)
     }
 }
 
+static struct jmapseen_attrdata *jmapseen_attrdata_new(jmap_req_t *req)
+{
+    struct jmapseen_attrdata *ad = xzmalloc(sizeof(struct jmapseen_attrdata));
+
+    ad->userid = xstrdup(req->userid);
+    /* Assumes that conversations folders do not change during the lifetime
+     * of the query. This holds since the JMAP request keeps a read lock on
+     * conversations. */
+    ad->numfolders = conversations_num_folders(req->cstate);
+    if (ad->numfolders) {
+        ad->folders = xzmalloc(ad->numfolders * sizeof(struct jmapseen_folder));
+    }
+
+    return ad;
+}
+
+static void jmapseen_attrdata_free(struct jmapseen_attrdata **adp)
+{
+    if (!adp || !*adp) return;
+
+    struct jmapseen_attrdata *ad = *adp;
+    if (ad->seendb) seen_close(&ad->seendb);
+    for (int i = 0; i < ad->numfolders; i++) {
+        if (ad->folders[i].seendb_uids)
+            seqset_free(&ad->folders[i].seendb_uids);
+    }
+    xzfree(ad->folders);
+    xzfree(ad->userid);
+    xzfree(*adp);
+}
+
 static void emailsearch_jmapseen_internalise(struct index_state *state,
                                              const union search_value *v,
                                              void *data1,
                                              void **internalisedp)
 {
     if (*internalisedp) {
-        struct emailsearch_jmapseen_mboxdata *md = *internalisedp;
-        free(md);
+        free(*internalisedp);
         *internalisedp = NULL;
     }
 
@@ -1530,73 +1560,100 @@ static void emailsearch_jmapseen_internalise(struct index_state *state,
             return;
         }
 
-        // Initialize attribute context
         struct jmapseen_attrdata *ad = data1;
-        if (!ad->userid) {
-            // Only support queries for a single user, e.g.
-            // can't mix multiple 'jmapseen' filters for
-            // different userids in the same search tree.
-            ad->userid = xstrdup(v->s);
-        }
-
-        if (!ad->folders && state) {
-            ad->numfolders = conversations_num_folders(cstate);
-            if (ad->numfolders) {
-                // assumes that conversations folders do not change
-                // during the lifetime of the query. this should
-                // hold since the JMAP request holds a read lock
-                // on conversations.
-                ad->folders = xzmalloc(ad->numfolders * sizeof(struct jmapseen_folder));
-            }
-            if (!ad->folders) {
-                xsyslog(LOG_ERR, "could not initialize jmapseen attribute", NULL);
-                xzfree(ad->userid);
-                return;
-            }
-        }
+        if (!ad->folders) return;
 
         // Initialize mailbox context
         struct jmapseen_mboxdata *md = xzmalloc(sizeof(struct jmapseen_mboxdata));
-        md->cstate = mailbox_get_cstate(state->mailbox);
-        md->foldernum = conversation_folder_number(md->cstate,
-                CONV_FOLDER_KEY_MBOX(md->cstate, state->mailbox), 0);
+        md->cstate = cstate;
+        md->foldernum = conversation_folder_number(cstate,
+                CONV_FOLDER_KEY_MBOX(cstate, state->mailbox), 0);
         *internalisedp = md;
 
-        // Determine where to read seen flags from for this mailbox
-        enum jmapseen_source seen_source;
-        if (mboxname_isnondeliverymailbox(mailbox_name(state->mailbox),
-                                          mailbox_mbtype(state->mailbox))) {
-            seen_source = jmapseen_ignore;
+        /* We have this mailbox open already, so determine where to read its
+         * seen flags from now. Any other mailbox holding a copy of a matching
+         * email is resolved in jmapseen_folder_source(). */
+        if (md->foldernum >= 0 && md->foldernum < ad->numfolders &&
+            ad->folders[md->foldernum].seen_source == jmapseen_unknown) {
+            enum jmapseen_source seen_source;
+            if (mboxname_isnondeliverymailbox(mailbox_name(state->mailbox),
+                                              mailbox_mbtype(state->mailbox))) {
+                seen_source = jmapseen_ignore;
+            }
+            else if (mailbox_internal_seen(state->mailbox, ad->userid)) {
+                seen_source = jmapseen_flags;
+            }
+            else {
+                seen_source = jmapseen_db;
+            }
+            ad->folders[md->foldernum].seen_source = seen_source;
+
+            xsyslog(LOG_DEBUG, "determined $seen source for mailbox",
+                    "seen_source=<%s> mboxname=<%s>",
+                    jmapseen_source_as_string(seen_source),
+                    mailbox_name(state->mailbox));
         }
-        else if (mailbox_internal_seen(state->mailbox, ad->userid)) {
-            seen_source = jmapseen_flags;
+    }
+}
+
+static enum jmapseen_source jmapseen_folder_source(struct jmapseen_attrdata *ad,
+                                                   struct conversations_state *cstate,
+                                                   uint32_t foldernum)
+{
+    /* Determine where to read the seen flags of this folder from */
+    if (ad->folders[foldernum].seen_source != jmapseen_unknown)
+        return ad->folders[foldernum].seen_source;
+
+    const char *mboxname = conversations_folder_mboxname(cstate, foldernum);
+    enum jmapseen_source seen_source;
+
+    if (!mboxname || mboxname_isnondeliverymailbox(mboxname, 0)) {
+        // not a regular mailbox - ignore
+        seen_source = jmapseen_ignore;
+    }
+    else if (mboxname_userownsmailbox(ad->userid, mboxname)) {
+        // owners always store seen in flags
+        seen_source = jmapseen_flags;
+    }
+    else {
+        // need to open mailbox to read OPT_SHAREDSEEN
+        struct mailbox *mbox = NULL;
+        int r = mailbox_open_irlnb(mboxname, &mbox); // non-blocking
+        if (!r) {
+            seen_source = mailbox_internal_seen(mbox, ad->userid) ?
+                jmapseen_flags : jmapseen_db;
+            mailbox_close(&mbox);
         }
         else {
-            seen_source = jmapseen_db;
+            // could try later for locked mailboxes, but
+            // let's not amplify mailbox open attempts
+            xsyslog(LOG_ERR, "can not open mailbox, fall back to system flags",
+                    "mboxname=<%s> err=<%s>", mboxname, error_message(r));
+            seen_source = jmapseen_flags;
         }
-        ad->folders[md->foldernum].seen_source = seen_source;
-
-        xsyslog(LOG_DEBUG, "determined $seen source for mailbox",
-                "seen_source=<%s> mboxname=<%s>",
-                jmapseen_source_as_string(seen_source), mailbox_name(state->mailbox));
     }
+
+    ad->folders[foldernum].seen_source = seen_source;
+
+    xsyslog(LOG_DEBUG, "determined $seen source for mailbox",
+            "seen_source=<%s> mboxname=<%s>",
+            jmapseen_source_as_string(seen_source), mboxname);
+
+    return seen_source;
 }
 
 static int jmapseen_has_seenflag(struct jmapseen_attrdata *ad,
                                  struct conversations_state *cstate,
-                                 int foldernum,
+                                 uint32_t foldernum,
                                  uint32_t uid,
                                  uint32_t system_flags)
 {
-    if (ad->folders[foldernum].seen_source == jmapseen_ignore)
-        return 0;
+    enum jmapseen_source seen_source =
+        jmapseen_folder_source(ad, cstate, foldernum);
 
-    if (ad->folders[foldernum].seen_source == jmapseen_flags) {
-        // read seen flag from system flags
-        return !!(system_flags & FLAG_SEEN);
-    }
+    if (seen_source == jmapseen_ignore) return 0;
 
-    if (ad->folders[foldernum].seen_source == jmapseen_db) {
+    if (seen_source == jmapseen_db) {
         // read seen flag from seendb
         if (!ad->seendb) {
             int r = seen_open(ad->userid, SEEN_SILENT, &ad->seendb);
@@ -1634,19 +1691,13 @@ static int jmapseen_has_seenflag(struct jmapseen_attrdata *ad,
         }
     }
 
-    if (ad->folders[foldernum].seen_source == jmapseen_unknown) {
-        xsyslog(LOG_ERR, "unknown seen flag source. falling back to system flags",
-                "userid=<%s> mboxid=<%s>",
-                ad->userid, conversations_folder_uniqueid(cstate, foldernum));
-    }
-
     // fall back
     return !!(system_flags & FLAG_SEEN);
 }
 
 struct jmapseen_guid_counts {
     struct jmapseen_attrdata *ad;
-    struct jmapseen_mboxdata *md;
+    struct conversations_state *cstate;
     unsigned exists;
     unsigned seen;
 };
@@ -1655,43 +1706,8 @@ static int jmapseen_guid_cb(const conv_guidrec_t *rec, void *rock)
 {
     struct jmapseen_guid_counts *counts = rock;
 
-    if (counts->ad->folders[rec->foldernum].seen_source == jmapseen_unknown) {
-        // determine where to read seen flags for this mailbox from
-        const char *mboxname = conversations_folder_mboxname(counts->md->cstate, rec->foldernum);
-        enum jmapseen_source seen_source;
-        if (mboxname_isnondeliverymailbox(mboxname, 0)) {
-            // not a regular mailbox - ignore
-            seen_source = jmapseen_ignore;
-        }
-        else if (mboxname_userownsmailbox(counts->ad->userid, mboxname)) {
-            // owners always store seen in flags
-            seen_source = jmapseen_flags;
-        }
-        else {
-            // need to open mailbox to read OPT_SHAREDSEEN
-            struct mailbox *mbox = NULL;
-            int r = mailbox_open_irlnb(mboxname, &mbox); // non-blocking
-            if (!r) {
-                seen_source = mailbox_internal_seen(mbox, counts->ad->userid) ?
-                    jmapseen_flags : jmapseen_db;
-                mailbox_close(&mbox);
-            }
-            else {
-                // could try later for locked mailboxes, but
-                // let's not amplify mailbox open attempts
-                xsyslog(LOG_ERR, "can not open mailbox, fall back to system flags",
-                        "mboxname=<%s> err=<%s>", mboxname, error_message(r));
-                seen_source = jmapseen_flags;
-            }
-        }
-        counts->ad->folders[rec->foldernum].seen_source = seen_source;
-
-        xsyslog(LOG_DEBUG, "determined $seen source for mailbox",
-                "seen_source=<%s> mboxname=<%s>",
-                jmapseen_source_as_string(seen_source), mboxname);
-    }
-
-    if (counts->ad->folders[rec->foldernum].seen_source == jmapseen_ignore)
+    if (jmapseen_folder_source(counts->ad, counts->cstate, rec->foldernum) ==
+            jmapseen_ignore)
         return 0;
 
     if (!(rec->system_flags & FLAG_DELETED) &&
@@ -1699,7 +1715,7 @@ static int jmapseen_guid_cb(const conv_guidrec_t *rec, void *rock)
 
         counts->exists++;
 
-        if (jmapseen_has_seenflag(counts->ad, counts->md->cstate, rec->foldernum,
+        if (jmapseen_has_seenflag(counts->ad, counts->cstate, rec->foldernum,
                     rec->uid, rec->system_flags))
             counts->seen++;
     }
@@ -1750,7 +1766,7 @@ static int emailsearch_jmapseen_match(message_t *m,
     }
 
     // The email is seen if all G records for the guid are seen
-    struct jmapseen_guid_counts counts = { .ad = ad, .md = md };
+    struct jmapseen_guid_counts counts = { .ad = ad, .cstate = md->cstate };
     const struct message_guid *guid;
     if (!message_get_guid(m, &guid)) {
         conversations_guid_foreach(md->cstate,
@@ -1787,22 +1803,10 @@ static void emailsearch_jmapseen_decref(struct search_attr **attrp)
     if (!attr) return;
 
     struct jmapseen_attrdata *ad = attr->data1;
-    if (ad) {
-        if (ad->refcount) {
-            --ad->refcount;
-            if (!ad->refcount) {
-                if (ad->seendb)
-                    seen_close(&ad->seendb);
-                for (int i = 0; i < ad->numfolders; i++) {
-                    if (ad->folders[i].seendb_uids)
-                        seqset_free(&ad->folders[i].seendb_uids);
-                }
-                xzfree(ad->folders);
-                xzfree(ad->userid);
-                xzfree(attr->data1);
-                xzfree(*attrp);
-            }
-        }
+    if (ad && ad->refcount && !--ad->refcount) {
+        jmapseen_attrdata_free(&ad);
+        attr->data1 = NULL;
+        xzfree(*attrp);
     }
 }
 
@@ -1822,7 +1826,7 @@ static void emailsearch_jmapseen_free(union search_value *v, struct search_attr 
 }
 
 
-static search_attr_t *emailsearch_jmapseen_new(void)
+static search_attr_t *emailsearch_jmapseen_new(jmap_req_t *req)
 {
     static const search_attr_t template = {
         "jmapseen",
@@ -1845,7 +1849,7 @@ static search_attr_t *emailsearch_jmapseen_new(void)
     search_attr_t *attr = xmalloc(sizeof(search_attr_t));
     memcpy(attr, &template, sizeof(search_attr_t));
 
-    struct jmapseen_attrdata *ad = xzmalloc(sizeof(struct jmapseen_attrdata));
+    struct jmapseen_attrdata *ad = jmapseen_attrdata_new(req);
     ad->refcount++;
     attr->data1 = ad;
 
@@ -2066,19 +2070,8 @@ static void _email_search_keyword(search_expr_t *parent,
     const char *userid = req->userid;
     search_expr_t *e;
     if (!strcasecmp(keyword, "$Seen")) {
-        search_attr_t *attr = NULL;
-        int i;
-        for (i = 0; i < ptrarray_size(search_attrs); i++) {
-            search_attr_t *sattr = ptrarray_nth(search_attrs, i);
-            if (!strcmpsafe(sattr->name, "jmapseen")) {
-                attr = sattr;
-                break;
-            }
-        }
-        if (!attr) {
-            attr = emailsearch_jmapseen_new();
-            ptrarray_append(search_attrs, attr);
-        }
+        search_attr_t *attr = _email_search_attr(search_attrs,
+                "jmapseen", emailsearch_jmapseen_new, req);
         e = search_expr_new(parent, SEOP_MATCH);
         e->attr = emailsearch_jmapseen_incref(attr);
         e->value.s = xstrdup(userid);
@@ -3626,11 +3619,20 @@ static void guidsearch_expr_free(struct guidsearch_expr *e)
     free(e);
 }
 
-static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state *cstate,
-                                                     search_expr_t *parent,
-                                                     search_expr_t *e,
-                                                     hash_table *foldernum_by_mboxname,
-                                                     int *need_folders)
+/* Context for compiling a search expression into a guidsearch expression.
+ * The need_* flags tell the caller which per-email properties the compiled
+ * expression reads, so that guidsearch collects them while scanning G
+ * records. */
+struct guidsearch_build_context {
+    struct conversations_state *cstate;
+    hash_table *foldernum_by_mboxname;
+    bool need_folders;
+};
+
+static struct guidsearch_expr *
+guidsearch_expr_build(struct guidsearch_build_context *build_ctx,
+                      search_expr_t *parent,
+                      search_expr_t *e)
 {
     if (!e) return NULL;
 
@@ -3644,7 +3646,7 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                 search_expr_t *c;
                 for (c = e->children ; c; c = c->next) {
                     struct guidsearch_expr *gc =
-                        guidsearch_expr_build(cstate, e, c, foldernum_by_mboxname, need_folders);
+                        guidsearch_expr_build(build_ctx, e, c);
                     if (!gc || gc->op == GSEOP_TRUE) {
                         guidsearch_expr_free(gc);
                         continue;
@@ -3675,7 +3677,7 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                 search_expr_t *c;
                 for (c = e->children ; c; c = c->next) {
                     struct guidsearch_expr *gc =
-                        guidsearch_expr_build(cstate, e, c, foldernum_by_mboxname, need_folders);
+                        guidsearch_expr_build(build_ctx, e, c);
                     if (!gc || gc->op == GSEOP_FALSE) {
                         guidsearch_expr_free(gc);
                         continue;
@@ -3706,7 +3708,7 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                 search_expr_t *c;
                 for (c = e->children ; c; c = c->next) {
                     struct guidsearch_expr *gc =
-                        guidsearch_expr_build(cstate, e, c, foldernum_by_mboxname, need_folders);
+                        guidsearch_expr_build(build_ctx, e, c);
                     if (!gc || gc->op == GSEOP_FALSE) {
                         guidsearch_expr_free(gc);
                         continue;
@@ -3758,10 +3760,11 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                     // inMailbox filter, IMAP-style
                     ge = xzmalloc(sizeof(struct guidsearch_expr));
                     ge->op = GSEOP_INMAILBOX;
-                    void *vv = hash_lookup(e->value.s, foldernum_by_mboxname);
+                    void *vv = hash_lookup(e->value.s,
+                                           build_ctx->foldernum_by_mboxname);
                     if (vv) {
                         ge->v.num = (uint32_t)((uintptr_t)vv - 1);
-                        *need_folders = 1;
+                        build_ctx->need_folders = true;
                     }
                     else {
                         ge->op = GSEOP_FALSE;
@@ -3773,7 +3776,7 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                     ge = xzmalloc(sizeof(struct guidsearch_expr));
                     ge->op = val->is_otherthan ? GSEOP_INMAILBOX_OTHERTHAN : GSEOP_INMAILBOX;
                     ge->v.v = val;
-                    *need_folders = 1;
+                    build_ctx->need_folders = true;
                 }
                 else if (!strcmpsafe(e->attr->name, "jmap_systemflags")) {
                     // hasKeyword or notKeyword. guidsearch_rank_clause
@@ -3810,9 +3813,10 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                         assert(ncounts < UINT32_MAX-1); // must fit ge->v.num
 
                         int idx = 0;
-                        if (cstate->counted_flags) {
-                            idx = strarray_find_case(cstate->counted_flags, e->value.s, 0);
-
+                        if (build_ctx->cstate->counted_flags) {
+                            idx = strarray_find_case(
+                                    build_ctx->cstate->counted_flags,
+                                    e->value.s, 0);
                         }
                         if (idx >= 0 && idx + 1 <= (int) ncounts) {
                             ge->v.convflag.num = (uint32_t) idx + 1;
@@ -4231,6 +4235,16 @@ struct guidsearch_query {
     uint64_t index_generation;
 };
 
+/* Merge the G record of one copy of an email into the match of that email.
+ * The caller must have asserted that this request may read the copy. */
+static void guidsearch_match_add_guidrec(struct guidsearch_match *match,
+                                         const conv_guidrec_t *rec,
+                                         uint32_t numfolders)
+{
+    if (numfolders) bv_set(&match->folders, rec->foldernum);
+    match->system_flags |= rec->system_flags;
+}
+
 static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
                                   struct guidsearch_match *prev,
                                   struct guidsearch_match *next,
@@ -4250,8 +4264,7 @@ static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
     if (prev && !memcmp(rec->guidrep, prev->guidrep, MESSAGE_GUID_SIZE*2)) {
         /* Update match for same guid. All copies of a guid carry the same
          * internaldate, so only folders and flags need merging. */
-        if (gsq->numfolders) bv_set(&prev->folders, rec->foldernum);
-        prev->system_flags |= rec->system_flags;
+        guidsearch_match_add_guidrec(prev, rec, gsq->numfolders);
         return 0;
     }
 
@@ -4259,10 +4272,9 @@ static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
     guidsearch_match_init(next, gsq->numfolders);
     memcpy(next->guidrep, rec->guidrep, MESSAGE_GUID_SIZE*2);
     next->guidrep[MESSAGE_GUID_SIZE*2] = '\0';
-    if (gsq->numfolders) bv_set(&next->folders, rec->foldernum);
-    next->system_flags = rec->system_flags;
     next->nano_internaldate = rec->nano_internaldate;
     next->cid = rec->cid;
+    guidsearch_match_add_guidrec(next, rec, gsq->numfolders);
     return 1;
 }
 
@@ -4376,12 +4388,13 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
             hash_insert(mboxname, (void*)((uintptr_t)num+1), &foldernum_by_mboxname);
         }
 
-        int need_folders = 0;
+        struct guidsearch_build_context build_ctx = {
+            .cstate = req->cstate,
+            .foldernum_by_mboxname = &foldernum_by_mboxname
+        };
         search_expr_t *expr = use_dnf ? search->expr_dnf : search->expr_orig;
-        gsq->matchexpr = guidsearch_expr_build(req->cstate, NULL, expr,
-                                               &foldernum_by_mboxname,
-                                               &need_folders);
-        gsq->numfolders = need_folders ? numfolders : 0;
+        gsq->matchexpr = guidsearch_expr_build(&build_ctx, NULL, expr);
+        gsq->numfolders = build_ctx.need_folders ? numfolders : 0;
         free_hash_table(&foldernum_by_mboxname, NULL);
     }
 
@@ -4566,16 +4579,9 @@ static int emailquery_guidsearch(jmap_req_t *req,
                                  json_t **err __attribute__((unused)))
 {
     struct guidsearch_query gsq = {
-        req,
-        BV_INITIALIZER,
-        0,
-        search->want_expunged,
-        NULL,
-        0,
-        0,
-        0,
-        0,
-        0
+        .req = req,
+        .readable_folders = BV_INITIALIZER,
+        .want_expunged = search->want_expunged
     };
 
     int r = guidsearch_run(req, search, &gsq);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1474,6 +1474,13 @@ static void _email_search_type(search_expr_t *parent, const char *s)
 
 /* ====================================================================== */
 
+static void emailsearch_readable_folders(jmap_req_t *req, bitvector_t *folders);
+
+/* JMAP defines the $seen keyword as a property of the Email, so an Email is
+ * seen if every copy of it that this request may read is seen. That is how
+ * Email/get reports it in _email_keywords_to_jmap(), and it is what the
+ * guidsearch implementation of Email/query evaluates from G records. */
+
 struct jmapseen_attrdata {
     struct jmapseen_folder {
         seqset_t *seendb_uids;
@@ -1484,6 +1491,7 @@ struct jmapseen_attrdata {
             jmapseen_ignore
         } seen_source;
     } *folders;
+    bitvector_t readable_folders;
     int numfolders;
     char *userid;
     struct seen *seendb;
@@ -1523,6 +1531,8 @@ static struct jmapseen_attrdata *jmapseen_attrdata_new(jmap_req_t *req)
     if (ad->numfolders) {
         ad->folders = xzmalloc(ad->numfolders * sizeof(struct jmapseen_folder));
     }
+    bv_init(&ad->readable_folders);
+    emailsearch_readable_folders(req, &ad->readable_folders);
 
     return ad;
 }
@@ -1537,6 +1547,7 @@ static void jmapseen_attrdata_free(struct jmapseen_attrdata **adp)
         if (ad->folders[i].seendb_uids)
             seqset_free(&ad->folders[i].seendb_uids);
     }
+    bv_fini(&ad->readable_folders);
     xzfree(ad->folders);
     xzfree(ad->userid);
     xzfree(*adp);
@@ -1642,16 +1653,21 @@ static enum jmapseen_source jmapseen_folder_source(struct jmapseen_attrdata *ad,
     return seen_source;
 }
 
-static int jmapseen_has_seenflag(struct jmapseen_attrdata *ad,
-                                 struct conversations_state *cstate,
-                                 uint32_t foldernum,
-                                 uint32_t uid,
-                                 uint32_t system_flags)
+static int jmapseen_copy_seen(struct jmapseen_attrdata *ad,
+                              struct conversations_state *cstate,
+                              uint32_t foldernum,
+                              uint32_t uid,
+                              uint32_t system_flags)
 {
+    /* Returns 1 if this copy of an email is seen, 0 if it is not, and -1 if
+     * it does not count towards the $seen keyword of the email at all */
+    if (foldernum >= (uint32_t) ad->numfolders) return -1;
+    if (!bv_isset(&ad->readable_folders, foldernum)) return -1;
+
     enum jmapseen_source seen_source =
         jmapseen_folder_source(ad, cstate, foldernum);
 
-    if (seen_source == jmapseen_ignore) return 0;
+    if (seen_source == jmapseen_ignore) return -1;
 
     if (seen_source == jmapseen_db) {
         // read seen flag from seendb
@@ -1706,19 +1722,19 @@ static int jmapseen_guid_cb(const conv_guidrec_t *rec, void *rock)
 {
     struct jmapseen_guid_counts *counts = rock;
 
-    if (jmapseen_folder_source(counts->ad, counts->cstate, rec->foldernum) ==
-            jmapseen_ignore)
+    if (rec->part) return 0;
+
+    if ((rec->system_flags & FLAG_DELETED) ||
+        (rec->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
         return 0;
-
-    if (!(rec->system_flags & FLAG_DELETED) &&
-        !(rec->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
-
-        counts->exists++;
-
-        if (jmapseen_has_seenflag(counts->ad, counts->cstate, rec->foldernum,
-                    rec->uid, rec->system_flags))
-            counts->seen++;
     }
+
+    int is_seen = jmapseen_copy_seen(counts->ad, counts->cstate,
+            rec->foldernum, rec->uid, rec->system_flags);
+    if (is_seen < 0) return 0;
+
+    counts->exists++;
+    if (is_seen) counts->seen++;
 
     return 0;
 }
@@ -1738,41 +1754,15 @@ static int emailsearch_jmapseen_match(message_t *m,
         return 0;
     }
 
-    uint32_t uid, flags;
-    message_get_uid(m, &uid);
-    message_get_systemflags(m, &flags);
-    int has_seenflag = jmapseen_has_seenflag(ad, md->cstate, md->foldernum, uid, flags);
+    // The email is seen if all its readable copies are seen
+    const struct message_guid *guid = NULL;
+    if (message_get_guid(m, &guid)) return 0;
 
-    // Trash only counts its own seen messages
-    if (md->foldernum == md->cstate->trashfolder)
-        return has_seenflag;
-
-    // The mail is unseen if it unseen in this mailbox
-    if (!has_seenflag)
-        return 0;
-
-    if (ad->folders[md->foldernum].seen_source == jmapseen_flags) {
-        // The email is seen if we do not need to look at seendb and
-        // the whole conversation is seen
-        conversation_id_t cid = NULLCONVERSATION;
-        if (!message_get_cid(m, &cid)) {
-            conversation_t conv = CONVERSATION_INIT;
-            if (!conversation_load_advanced(md->cstate, cid, &conv, 0)) {
-                int is_seen = conv.exists && conv.unseen == 0;
-                conversation_fini(&conv);
-                if (is_seen) return 1;
-            }
-        }
-    }
-
-    // The email is seen if all G records for the guid are seen
     struct jmapseen_guid_counts counts = { .ad = ad, .cstate = md->cstate };
-    const struct message_guid *guid;
-    if (!message_get_guid(m, &guid)) {
-        conversations_guid_foreach(md->cstate,
-                message_guid_encode(guid), jmapseen_guid_cb, &counts);
-    }
-    return counts.exists == counts.seen;
+    conversations_guid_foreach(md->cstate,
+            message_guid_encode(guid), jmapseen_guid_cb, &counts);
+
+    return counts.exists && counts.exists == counts.seen;
 }
 
 static void emailsearch_jmapseen_serialise(struct buf *b, const union search_value *v)
@@ -3508,6 +3498,7 @@ static int emailsearch_is_mutable(struct emailsearch *search)
 struct guidsearch_match {
     char guidrep[MESSAGE_GUID_SIZE*2+1];
     uint32_t system_flags;
+    uint32_t num_unseen;    // only counted if the query needs $seen
     uint64_t nano_internaldate;  // nanoseconds since epoch
     conversation_id_t cid;
     bitvector_t folders;    // only set if numfolders > 0
@@ -3579,6 +3570,7 @@ enum guidsearch_expr_op {
     GSEOP_INMAILBOX,
     GSEOP_INMAILBOX_OTHERTHAN,
     GSEOP_FLAGS,
+    GSEOP_SEEN,
     GSEOP_CONVFLAGS,
     GSEOP_ALLCONVFLAGS,
     GSEOP_INTERNALDATE,
@@ -3627,6 +3619,7 @@ struct guidsearch_build_context {
     struct conversations_state *cstate;
     hash_table *foldernum_by_mboxname;
     bool need_folders;
+    bool need_seen;
 };
 
 static struct guidsearch_expr *
@@ -3778,6 +3771,12 @@ guidsearch_expr_build(struct guidsearch_build_context *build_ctx,
                     ge->v.v = val;
                     build_ctx->need_folders = true;
                 }
+                else if (!strcmpsafe(e->attr->name, "jmapseen")) {
+                    // hasKeyword or notKeyword for $seen
+                    ge = xzmalloc(sizeof(struct guidsearch_expr));
+                    ge->op = GSEOP_SEEN;
+                    build_ctx->need_seen = true;
+                }
                 else if (!strcmpsafe(e->attr->name, "jmap_systemflags")) {
                     // hasKeyword or notKeyword. guidsearch_rank_clause
                     // accepts this attribute for these flags only.
@@ -3861,6 +3860,9 @@ static void guidsearch_expr_serialise(struct buf *buf, struct guidsearch_expr *e
             break;
         case GSEOP_FLAGS:
             buf_appendcstr(buf, "FLAGS");
+            break;
+        case GSEOP_SEEN:
+            buf_appendcstr(buf, "SEEN");
             break;
         case GSEOP_CONVFLAGS:
             buf_appendcstr(buf, "CONVFLAGS");
@@ -3957,6 +3959,9 @@ static int guidsearch_expr_eval(struct conversations_state *cstate,
             }
         case GSEOP_FLAGS:
             return (match->system_flags & e->v.num) != 0;
+        case GSEOP_SEEN:
+            /* The email is seen if all its readable copies are seen */
+            return match->num_unseen == 0;
         case GSEOP_CONVFLAGS:
         case GSEOP_ALLCONVFLAGS:
             {
@@ -4106,6 +4111,14 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
                 }
                 return 1;
             }
+            else if (!strcmpsafe(e->attr->name, "jmapseen")) {
+                /* hasKeyword $seen
+                 * notKeyword $seen */
+                if (nonxapian_hash) {
+                    guidsearch_hash_expr(e, nonxapian_hash);
+                }
+                return 1;
+            }
             else if (e->attr == search_attr_find("convflags") ||
                      e->attr == search_attr_find("allconvflags")) {
                 /* allInThreadHaveKeyword
@@ -4149,7 +4162,6 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
                 *need_xapian_index_version = 17;
                 return 2;
             }
-            // TODO support hasKeyword:$seen
             // any other MATCH is unsupported
             else return -1;
         case SEOP_TRUE:
@@ -4227,6 +4239,8 @@ struct guidsearch_query {
     bitvector_t readable_folders;
     uint32_t numfolders;
     int want_expunged;
+    bool need_seen;
+    struct jmapseen_attrdata *seendata;  // set if need_seen, not owned
     struct guidsearch_expr *matchexpr;
     struct guidsearch_match *matches;
     size_t total;
@@ -4235,14 +4249,23 @@ struct guidsearch_query {
     uint64_t index_generation;
 };
 
-/* Merge the G record of one copy of an email into the match of that email.
- * The caller must have asserted that this request may read the copy. */
 static void guidsearch_match_add_guidrec(struct guidsearch_match *match,
                                          const conv_guidrec_t *rec,
-                                         uint32_t numfolders)
+                                         uint32_t numfolders,
+                                         struct conversations_state *cstate,
+                                         struct jmapseen_attrdata *seendata)
 {
+    /* Merges the G record of one copy into the match of its email. The
+     * caller must have asserted that this request may read the copy. */
     if (numfolders) bv_set(&match->folders, rec->foldernum);
     match->system_flags |= rec->system_flags;
+    if (seendata) {
+        int is_seen = jmapseen_copy_seen(seendata, cstate,
+                rec->foldernum, rec->uid, rec->system_flags);
+        /* A copy that does not count towards $seen is neither seen nor
+         * unseen, see jmapseen_copy_seen() */
+        if (is_seen == 0) match->num_unseen++;
+    }
 }
 
 static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
@@ -4264,7 +4287,8 @@ static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
     if (prev && !memcmp(rec->guidrep, prev->guidrep, MESSAGE_GUID_SIZE*2)) {
         /* Update match for same guid. All copies of a guid carry the same
          * internaldate, so only folders and flags need merging. */
-        guidsearch_match_add_guidrec(prev, rec, gsq->numfolders);
+        guidsearch_match_add_guidrec(prev, rec, gsq->numfolders,
+                gsq->req->cstate, gsq->need_seen ? gsq->seendata : NULL);
         return 0;
     }
 
@@ -4274,7 +4298,8 @@ static int guidsearch_add_guidrec(const conv_guidrec_t *rec,
     next->guidrep[MESSAGE_GUID_SIZE*2] = '\0';
     next->nano_internaldate = rec->nano_internaldate;
     next->cid = rec->cid;
-    guidsearch_match_add_guidrec(next, rec, gsq->numfolders);
+    guidsearch_match_add_guidrec(next, rec, gsq->numfolders,
+            gsq->req->cstate, gsq->need_seen ? gsq->seendata : NULL);
     return 1;
 }
 
@@ -4349,6 +4374,17 @@ static void free_search_value_string(union search_value *v,
     v->s = NULL;
 }
 
+static struct jmapseen_attrdata *jmapseen_attrdata_find(ptrarray_t *attrs)
+{
+    /* Returns the $seen state shared by all jmapseen filters built into this
+     * list of search attributes, or NULL if none of them reads $seen */
+    for (int i = 0; i < ptrarray_size(attrs); i++) {
+        search_attr_t *attr = ptrarray_nth(attrs, i);
+        if (!strcmpsafe(attr->name, "jmapseen")) return attr->data1;
+    }
+    return NULL;
+}
+
 static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
                           struct guidsearch_query *gsq)
 {
@@ -4395,6 +4431,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         search_expr_t *expr = use_dnf ? search->expr_dnf : search->expr_orig;
         gsq->matchexpr = guidsearch_expr_build(&build_ctx, NULL, expr);
         gsq->numfolders = build_ctx.need_folders ? numfolders : 0;
+        gsq->need_seen = build_ctx.need_seen;
         free_hash_table(&foldernum_by_mboxname, NULL);
     }
 
@@ -4581,7 +4618,8 @@ static int emailquery_guidsearch(jmap_req_t *req,
     struct guidsearch_query gsq = {
         .req = req,
         .readable_folders = BV_INITIALIZER,
-        .want_expunged = search->want_expunged
+        .want_expunged = search->want_expunged,
+        .seendata = jmapseen_attrdata_find(&search->attrs)
     };
 
     int r = guidsearch_run(req, search, &gsq);

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -1854,11 +1854,216 @@ static search_attr_t *emailsearch_jmapseen_new(void)
 
 /* ====================================================================== */
 
+static void emailsearch_readable_folders(jmap_req_t *req, bitvector_t *folders)
+{
+    /* Sets a bit for every conversations.db folder holding mail that this
+     * request may read. A JMAP property of an Email aggregates exactly these
+     * copies of its guid, so anything evaluating one from G records must
+     * agree on this set. */
+    uint32_t numfolders = conversations_num_folders(req->cstate);
+    bv_setsize(folders, numfolders);
+
+    for (uint32_t num = 0; num < numfolders; num++) {
+        const char *mboxname = conversations_folder_mboxname(req->cstate, num);
+        if (!mboxname || mboxname_isnondeliverymailbox(mboxname, 0)) continue;
+
+        mbentry_t *mbentry = NULL;
+        if (!mboxlist_lookup_allow_all(mboxname, &mbentry, NULL) &&
+            mbtype_isa(mbentry->mbtype) == MBTYPE_EMAIL &&
+            jmap_hasrights_mbentry(req, mbentry, JACL_READITEMS)) {
+            bv_set(folders, num);
+        }
+        mboxlist_entry_free(&mbentry);
+    }
+}
+
+/* ====================================================================== */
+
+/* The "jmap_systemflags" attribute replaces the IMAP "systemflags" attribute
+ * for Email/query. It evaluates system flags with JMAP semantics, where a
+ * keyword of an Email is the aggregate of the flags of its index records.
+ *
+ * Like "jmapseen", this attribute is created per request rather than being
+ * one of the singletons of search_expr.c, because the copies it aggregates
+ * over are the ones that this request may read. */
+
+struct emailsearch_systemflags_attrdata {
+    bitvector_t readable_folders;
+    size_t refcount;
+};
+
+struct emailsearch_systemflags_internal {
+    struct conversations_state *cstate;
+};
+
+static void emailsearch_systemflags_internalise(struct index_state *state,
+                                                const union search_value *v,
+                                                void *data1 __attribute__((unused)),
+                                                void **internalisedp)
+{
+    if (*internalisedp) {
+        free(*internalisedp);
+        *internalisedp = NULL;
+    }
+
+    if (state && v) {
+        struct emailsearch_systemflags_internal *internal =
+            xzmalloc(sizeof(struct emailsearch_systemflags_internal));
+        internal->cstate = mailbox_get_cstate(state->mailbox);
+        *internalisedp = internal;
+    }
+}
+
+struct emailsearch_systemflags_rock {
+    struct emailsearch_systemflags_attrdata *ad;
+    uint32_t system_flags;
+};
+
+static int emailsearch_systemflags_match_cb(const conv_guidrec_t *rec, void *rock)
+{
+    struct emailsearch_systemflags_rock *srock = rock;
+
+    if (rec->part) return 0;
+
+    if ((rec->system_flags & FLAG_DELETED) ||
+        (rec->internal_flags & FLAG_INTERNAL_EXPUNGED) ||
+        !bv_isset(&srock->ad->readable_folders, rec->foldernum)) {
+        return 0;
+    }
+
+    return (rec->system_flags & srock->system_flags) ? IMAP_OK_COMPLETED : 0;
+}
+
+static int emailsearch_systemflags_match(message_t *m,
+                                         const union search_value *v,
+                                         void *internalised,
+                                         void *data1)
+{
+    struct emailsearch_systemflags_internal *internal = internalised;
+    struct emailsearch_systemflags_attrdata *ad = data1;
+    if (!internal || !internal->cstate || !ad) return 0;
+
+    const struct message_guid *guid = NULL;
+    if (message_get_guid(m, &guid)) return 0;
+
+    struct emailsearch_systemflags_rock rock = {
+        .ad = ad, .system_flags = (uint32_t) v->u
+    };
+    int r = conversations_guid_foreach(internal->cstate,
+            message_guid_encode(guid), emailsearch_systemflags_match_cb, &rock);
+
+    return r == IMAP_OK_COMPLETED;
+}
+
+static void emailsearch_systemflags_serialise(struct buf *b,
+                                              const union search_value *v)
+{
+    if ((v->u & FLAG_ANSWERED)) buf_appendcstr(b, "\\Answered");
+    if ((v->u & FLAG_FLAGGED)) buf_appendcstr(b, "\\Flagged");
+    if ((v->u & FLAG_DRAFT)) buf_appendcstr(b, "\\Draft");
+}
+
+static int emailsearch_systemflags_unserialise(struct protstream *prot,
+                                               union search_value *v)
+{
+    char tmp[64];
+    int c = search_getseword(prot, tmp, sizeof(tmp));
+
+    if (!strcasecmp(tmp, "\\Answered")) v->u = FLAG_ANSWERED;
+    else if (!strcasecmp(tmp, "\\Flagged")) v->u = FLAG_FLAGGED;
+    else if (!strcasecmp(tmp, "\\Draft")) v->u = FLAG_DRAFT;
+    else v->u = 0;
+
+    return c;
+}
+
+static void emailsearch_systemflags_decref(struct search_attr **attrp)
+{
+    if (!attrp || !*attrp) return;
+
+    search_attr_t *attr = *attrp;
+    struct emailsearch_systemflags_attrdata *ad = attr->data1;
+    if (!ad || !ad->refcount) return;
+
+    if (--ad->refcount) return;
+
+    bv_fini(&ad->readable_folders);
+    xzfree(attr->data1);
+    xzfree(*attrp);
+}
+
+static search_attr_t *emailsearch_systemflags_incref(search_attr_t *attr)
+{
+    if (!attr || !attr->data1) return attr;
+
+    struct emailsearch_systemflags_attrdata *ad = attr->data1;
+    ad->refcount++;
+    return attr;
+}
+
+static void emailsearch_systemflags_free(union search_value *v
+                                             __attribute__((unused)),
+                                         struct search_attr **attrp)
+{
+    emailsearch_systemflags_decref(attrp);
+}
+
+static search_attr_t *emailsearch_systemflags_new(jmap_req_t *req)
+{
+    static const search_attr_t template = {
+        "jmap_systemflags",
+        SEA_MUTABLE,
+        SEARCH_PART_NONE,
+        SEARCH_COST_CONV,
+        emailsearch_systemflags_internalise,
+        /*cmp*/NULL,
+        emailsearch_systemflags_match,
+        emailsearch_systemflags_serialise,
+        emailsearch_systemflags_unserialise,
+        /*get_countability*/NULL,
+        /*duplicate*/NULL,
+        emailsearch_systemflags_free,
+        emailsearch_systemflags_decref,
+        emailsearch_systemflags_incref,
+        (void *)0
+    };
+
+    search_attr_t *attr = xmalloc(sizeof(search_attr_t));
+    memcpy(attr, &template, sizeof(search_attr_t));
+
+    struct emailsearch_systemflags_attrdata *ad =
+        xzmalloc(sizeof(struct emailsearch_systemflags_attrdata));
+    bv_init(&ad->readable_folders);
+    emailsearch_readable_folders(req, &ad->readable_folders);
+    ad->refcount++;
+    attr->data1 = ad;
+
+    return attr;
+}
+
+/* ====================================================================== */
+
+static search_attr_t *_email_search_attr(ptrarray_t *search_attrs,
+                                        const char *name,
+                                        search_attr_t *(*newattr)(jmap_req_t *),
+                                        jmap_req_t *req)
+{
+    for (int i = 0; i < ptrarray_size(search_attrs); i++) {
+        search_attr_t *attr = ptrarray_nth(search_attrs, i);
+        if (!strcmpsafe(attr->name, name)) return attr;
+    }
+
+    search_attr_t *attr = newattr(req);
+    ptrarray_append(search_attrs, attr);
+    return attr;
+}
+
 static void _email_search_keyword(search_expr_t *parent,
                                   const char *keyword,
-                                  const char *userid,
+                                  jmap_req_t *req,
                                   ptrarray_t *search_attrs)
 {
+    const char *userid = req->userid;
     search_expr_t *e;
     if (!strcasecmp(keyword, "$Seen")) {
         search_attr_t *attr = NULL;
@@ -1878,20 +2083,16 @@ static void _email_search_keyword(search_expr_t *parent,
         e->attr = emailsearch_jmapseen_incref(attr);
         e->value.s = xstrdup(userid);
     }
-    else if (!strcasecmp(keyword, "$Draft")) {
+    else if (!strcasecmp(keyword, "$Draft") ||
+             !strcasecmp(keyword, "$Flagged") ||
+             !strcasecmp(keyword, "$Answered")) {
+        search_attr_t *attr = _email_search_attr(search_attrs,
+                "jmap_systemflags", emailsearch_systemflags_new, req);
         e = search_expr_new(parent, SEOP_MATCH);
-        e->attr = search_attr_find("systemflags");
-        e->value.u = FLAG_DRAFT;
-    }
-    else if (!strcasecmp(keyword, "$Flagged")) {
-        e = search_expr_new(parent, SEOP_MATCH);
-        e->attr = search_attr_find("systemflags");
-        e->value.u = FLAG_FLAGGED;
-    }
-    else if (!strcasecmp(keyword, "$Answered")) {
-        e = search_expr_new(parent, SEOP_MATCH);
-        e->attr = search_attr_find("systemflags");
-        e->value.u = FLAG_ANSWERED;
+        e->attr = emailsearch_systemflags_incref(attr);
+        e->value.u = !strcasecmp(keyword, "$Draft")   ? FLAG_DRAFT :
+                     !strcasecmp(keyword, "$Flagged") ? FLAG_FLAGGED :
+                                                        FLAG_ANSWERED;
     }
     else {
         e = search_expr_new(parent, SEOP_MATCH);
@@ -2591,11 +2792,11 @@ static search_expr_t *_email_buildsearchexpr(jmap_req_t *req, json_t *filter,
         }
 
         if (JNOTNULL((val = json_object_get(filter, "hasKeyword")))) {
-            _email_search_keyword(this, json_string_value(val), req->userid, search_attrs);
+            _email_search_keyword(this, json_string_value(val), req, search_attrs);
         }
         if (JNOTNULL((val = json_object_get(filter, "notKeyword")))) {
             e = search_expr_new(this, SEOP_NOT);
-            _email_search_keyword(e, json_string_value(val), req->userid, search_attrs);
+            _email_search_keyword(e, json_string_value(val), req, search_attrs);
         }
 
         if (JNOTNULL((val = json_object_get(filter, "maxSize")))) {
@@ -3574,9 +3775,10 @@ static struct guidsearch_expr *guidsearch_expr_build(struct conversations_state 
                     ge->v.v = val;
                     *need_folders = 1;
                 }
-                else if (e->attr == search_attr_find("systemflags")) {
+                else if (!strcmpsafe(e->attr->name, "jmap_systemflags")) {
+                    // hasKeyword or notKeyword. guidsearch_rank_clause
+                    // accepts this attribute for these flags only.
                     if (e->value.u & (FLAG_DRAFT|FLAG_FLAGGED|FLAG_ANSWERED)) {
-                        // hasKeyword or notKeyword
                         ge = xzmalloc(sizeof(struct guidsearch_expr));
                         ge->op = GSEOP_FLAGS;
                         ge->v.num = e->value.u;
@@ -3891,7 +4093,7 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
                 }
                 return 1;
             }
-            else if (e->attr == search_attr_find("systemflags") &&
+            else if (!strcmpsafe(e->attr->name, "jmap_systemflags") &&
                     (e->value.u & (FLAG_DRAFT|FLAG_FLAGGED|FLAG_ANSWERED))) {
                 /* hasKeyword
                  * notKeyword */
@@ -3943,6 +4145,7 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
                 *need_xapian_index_version = 17;
                 return 2;
             }
+            // TODO support hasKeyword:$seen
             // any other MATCH is unsupported
             else return -1;
         case SEOP_TRUE:
@@ -4160,35 +4363,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
 
     /* Determine readable folders for userid */
     uint32_t numfolders = conversations_num_folders(req->cstate);
-    bv_setsize(&gsq->readable_folders, numfolders);
-    if (strcmp(req->userid, req->accountid)) {
-        // filter all folders that can't be read by userid
-        uint32_t num;
-        for (num = 0; num < numfolders; num++) {
-            const char *mboxname = conversations_folder_mboxname(req->cstate, num);
-            if (!mboxname) continue;
-            if (jmap_hasrights(req, mboxname, ACL_READ|ACL_LOOKUP)) {
-                bv_set(&gsq->readable_folders, num);
-            }
-        }
-    }
-    else {
-        // all user-owned mailboxes are readable
-        bv_setall(&gsq->readable_folders);
-    }
-
-    // filter all folders that aren't regular mailboxes
-    uint32_t num;
-    for (num = 0; num < numfolders; num++) {
-        const char *mboxname = conversations_folder_mboxname(req->cstate, num);
-        mbentry_t *mbentry = NULL;
-        if (!mboxname || mboxname_isnondeliverymailbox(mboxname, 0) ||
-            mboxlist_lookup_allow_all(mboxname, &mbentry, NULL) ||
-            mbtype_isa(mbentry->mbtype) != MBTYPE_EMAIL) {
-            bv_clear(&gsq->readable_folders, num);
-        }
-        mboxlist_entry_free(&mbentry);
-    }
+    emailsearch_readable_folders(req, &gsq->readable_folders);
 
     /* Prepare filter for post-processing */
     if (exprrank & 0x1) {

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -242,6 +242,10 @@ static struct email_sortfield email_sortfields[] = {
         JMAP_MAIL_EXTENSION
     },
     {
+        "category",
+        JMAP_MAIL_EXTENSION
+    },
+    {
         NULL,
         NULL
     }
@@ -257,6 +261,10 @@ static struct email_sortfield email_sortfields[] = {
 
 #define JMAP_MAIL_MAX_MAILBOXES_PER_EMAIL 20
 #define JMAP_MAIL_MAX_KEYWORDS_PER_EMAIL 100 /* defined in mailbox_user_flag */
+
+/* Maximum number of groupBy filters in a category sort. Also bounds the
+ * category index, which is stored as a byte on each match. */
+#define EMAILQUERY_MAX_CATEGORIES 32
 
 static void emailquery_handler(enum jmap_handler_event event, jmap_req_t *req, void *rock);
 
@@ -3120,6 +3128,11 @@ static struct sortcrit *_email_buildsort(jmap_req_t *req,
     json_array_foreach(sort, i, jcomp) {
         const char *prop = json_string_value(json_object_get(jcomp, "property"));
 
+        /* The category comparator is not a message attribute. It sorts the
+         * matches by which groupBy filter they match, which the Email/query
+         * implementation applies to the sorted result. */
+        if (!strcmp(prop, "category")) continue;
+
         if (json_object_get(jcomp, "isAscending") == json_false()) {
             sortcrit[j].flags |= SORT_REVERSE;
         }
@@ -3333,11 +3346,70 @@ done:
     return r;
 }
 
+static json_t *emailquery_category_comparator(json_t *jsort)
+{
+    /* Returns the category comparator of this Email/query, or NULL if it
+     * does not sort by category. There is at most one, and it is the primary
+     * sort, see _email_parse_comparator(). */
+    json_t *jcomp = json_array_get(jsort, 0);
+    const char *prop = json_string_value(json_object_get(jcomp, "property"));
+
+    return !strcmpsafe(prop, "category") ? jcomp : NULL;
+}
+
+static bool
+emailquery_groupby_validate(jmap_req_t *req,
+                            json_t *jcomp,
+                            struct email_contactfilter *contactfilter)
+{
+    /* The groupBy property of a category comparator must be a non-empty
+     * array of Email FilterConditions and FilterOperators. Which of them the
+     * Email/query implementation can evaluate is decided in
+     * emailquery_category_init(). */
+    json_t *jgroupby = json_object_get(jcomp, "groupBy");
+    size_t ngroupby = json_array_size(jgroupby);
+
+    if (!ngroupby || ngroupby > EMAILQUERY_MAX_CATEGORIES) return false;
+
+    struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
+    json_t *unsupported = json_array();
+    json_t *err = NULL;
+
+    size_t i;
+    json_t *jfilter;
+    json_array_foreach(jgroupby, i, jfilter) {
+        if (!json_is_object(jfilter)) {
+            jmap_parser_invalid(&parser, "groupBy");
+            break;
+        }
+        jmap_filter_parse(req, &parser, jfilter, unsupported,
+                          _email_parse_filter_cb, contactfilter, &err);
+        if (err) break;
+    }
+
+    bool is_valid = !err && !json_array_size(parser.invalid) &&
+                            !json_array_size(unsupported);
+
+    json_decref(err);
+    json_decref(unsupported);
+    jmap_parser_fini(&parser);
+
+    return is_valid;
+}
+
+struct emailquery_comparator_rock {
+    struct email_contactfilter *contactfilter;
+    size_t ncomparators;  // number of comparators parsed so far
+};
+
 static int _email_parse_comparator(jmap_req_t *req,
                                    struct jmap_comparator *comp,
-                                   void *rock __attribute__((unused)),
+                                   void *rock,
                                    json_t **err __attribute__((unused)))
 {
+    struct emailquery_comparator_rock *crock = rock;
+    size_t pos = crock->ncomparators++;
+
     /* Reject any collation */
     if (comp->collation) {
         return 0;
@@ -3346,9 +3418,18 @@ static int _email_parse_comparator(jmap_req_t *req,
     /* Search in list of supported sortFields */
     struct email_sortfield *sp = email_sortfields;
     for (sp = email_sortfields; sp->name; sp++) {
-        if (!strcmp(sp->name, comp->property)) {
-            return !sp->capability || jmap_is_using(req, sp->capability);
+        if (strcmp(sp->name, comp->property)) continue;
+
+        if (sp->capability && !jmap_is_using(req, sp->capability)) {
+            return 0;
         }
+        if (!strcmp(sp->name, "category")) {
+            /* Support at most one category comparator, as the primary sort */
+            return pos == 0 &&
+                   emailquery_groupby_validate(req, comp->jcomp,
+                                               crock->contactfilter);
+        }
+        return 1;
     }
 
     return 0;
@@ -3359,10 +3440,13 @@ struct emailquery_match {
     conversation_id_t cid;
     uint64_t nano_internaldate;  // nanoseconds since epoch
     smallarrayu64_t partnums;
+    uint8_t category;  // only set if the query sorts by category
 };
 
 
 #define JMAP_EMAILQUERY_RESULT_INITIALIZER { 0 }
+
+struct emailquery_category;
 
 struct emailquery {
     // query fields
@@ -3372,9 +3456,11 @@ struct emailquery {
     int disable_guidsearch;
     int findallinthread;
     struct conversations_state *cstate;  // to generate proper EMAILIDs
+    struct emailquery_category *category;
     // response fields
     json_t *partids;
     json_t *thread_emailids;
+    json_t *groupby_counts;
 };
 
 struct emailquery_cache;
@@ -3413,13 +3499,17 @@ static void jmap_emailquery_init(struct emailquery *q)
     q->partids = json_object();
 }
 
+static void emailquery_category_free(struct emailquery_category **catp);
+
 static void jmap_emailquery_fini(struct emailquery *q)
 {
     jmap_query_fini(&q->super);
     q->collapse_threads = 0;
     q->want_partids = 0;
+    emailquery_category_free(&q->category);
     json_decref(q->partids);
     json_decref(q->thread_emailids);
+    json_decref(q->groupby_counts);
 }
 
 static char *_email_make_querystate(jmap_req_t *req,
@@ -4036,14 +4126,13 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
                                   int *use_dnf,
                                   unsigned *need_xapian_index_version)
 {
-    assert(e->op != SEOP_OR);
-
     if (nonxapian_hash) {
         buf_reset(nonxapian_hash);
     }
 
     switch (e->op) {
         case SEOP_AND:
+        case SEOP_OR:
         case SEOP_NOT:
             {
                 int rank = 0;
@@ -4066,7 +4155,8 @@ static int guidsearch_rank_clause(struct conversations_state *cstate,
                 /* Create hash as list sorted list of children hashes */
                 if (strarray_size(&child_hashes)) {
                     strarray_sort(&child_hashes, cmpstringp_raw);
-                    buf_setcstr(nonxapian_hash, e->op == SEOP_AND ? "AND" : "NOT");
+                    buf_setcstr(nonxapian_hash, e->op == SEOP_AND ? "AND" :
+                                                e->op == SEOP_OR  ? "OR" : "NOT");
                     buf_putc(nonxapian_hash, '(');
                     int i;
                     for (i = 0; i < strarray_size(&child_hashes); i++) {
@@ -4239,6 +4329,7 @@ struct guidsearch_query {
     bitvector_t readable_folders;
     uint32_t numfolders;
     int want_expunged;
+    bool need_folders;
     bool need_seen;
     struct jmapseen_attrdata *seendata;  // set if need_seen, not owned
     struct guidsearch_expr *matchexpr;
@@ -4374,6 +4465,22 @@ static void free_search_value_string(union search_value *v,
     v->s = NULL;
 }
 
+static void guidsearch_foldernum_by_mboxname(struct conversations_state *cstate,
+                                             hash_table *foldernum_by_mboxname)
+{
+    /* Maps the mailbox name of each conversations folder to its folder
+     * number plus one, so that a zero hash value means "no such folder" */
+    uint32_t numfolders = conversations_num_folders(cstate);
+
+    construct_hash_table(foldernum_by_mboxname, numfolders+2, 0);
+
+    for (uint32_t num = 0; num < numfolders; num++) {
+        const char *mboxname = conversations_folder_mboxname(cstate, num);
+        if (!mboxname) continue;
+        hash_insert(mboxname, (void*)((uintptr_t)num+1), foldernum_by_mboxname);
+    }
+}
+
 static struct jmapseen_attrdata *jmapseen_attrdata_find(ptrarray_t *attrs)
 {
     /* Returns the $seen state shared by all jmapseen filters built into this
@@ -4383,6 +4490,170 @@ static struct jmapseen_attrdata *jmapseen_attrdata_find(ptrarray_t *attrs)
         if (!strcmpsafe(attr->name, "jmapseen")) return attr->data1;
     }
     return NULL;
+}
+
+/* A category sort assigns each Email the index of the first groupBy filter
+ * it matches, or the number of filters if it matches none. That index is
+ * the sort key, so applying the sort amounts to a stable partition of the
+ * result by category. */
+struct emailquery_category {
+    bool is_ascending;
+    size_t ngroups;
+    struct guidsearch_expr *exprs[EMAILQUERY_MAX_CATEGORIES];
+    search_expr_t *searchexprs[EMAILQUERY_MAX_CATEGORIES];
+    ptrarray_t attrs;   // list of heap-allocated search_attr_t
+    struct conversations_state *cstate;
+    bitvector_t readable_folders;
+    uint32_t numfolders;  // zero unless a groupBy filter reads mailboxes
+    struct jmapseen_attrdata *seendata;  // not owned, set if $seen is read
+};
+
+static void emailquery_category_free(struct emailquery_category **catp)
+{
+    if (!catp || !*catp) return;
+
+    struct emailquery_category *cat = *catp;
+
+    for (size_t i = 0; i < cat->ngroups; i++) {
+        guidsearch_expr_free(cat->exprs[i]);
+        search_expr_free(cat->searchexprs[i]);
+    }
+
+    search_attr_t *attr;
+    while ((attr = ptrarray_pop(&cat->attrs))) {
+        if (attr->freeattr) attr->freeattr(&attr);
+    }
+    ptrarray_fini(&cat->attrs);
+
+    bv_fini(&cat->readable_folders);
+
+    xzfree(*catp);
+}
+
+static int emailquery_category_init(jmap_req_t *req,
+                                    json_t *jcomp,
+                                    hash_table *contactgroups,
+                                    struct emailquery_category **catp)
+{
+    json_t *jgroupby = json_object_get(jcomp, "groupBy");
+    struct emailquery_category *cat =
+        xzmalloc(sizeof(struct emailquery_category));
+
+    cat->cstate = req->cstate;
+    cat->is_ascending = json_object_get(jcomp, "isAscending") != json_false();
+    cat->ngroups = json_array_size(jgroupby);
+
+    hash_table foldernum_by_mboxname = HASH_TABLE_INITIALIZER;
+    guidsearch_foldernum_by_mboxname(req->cstate, &foldernum_by_mboxname);
+
+    struct guidsearch_build_context build_ctx = {
+        .cstate = req->cstate,
+        .foldernum_by_mboxname = &foldernum_by_mboxname
+    };
+
+    int r = 0;
+    size_t i;
+    json_t *jfilter;
+    json_array_foreach(jgroupby, i, jfilter) {
+        search_expr_t *e = _email_buildsearchexpr(req, jfilter, NULL,
+                contactgroups, /*want_expunged*/0, &cat->attrs);
+        search_expr_detrivialise(&e);
+        /* Apply the same \Seen rewrite that emailsearch_normalise() applies
+         * to the filter of the query */
+        convert_seentrash_clause(e, req->cstate->trashfolder);
+        cat->searchexprs[i] = e;
+
+        int use_dnf = 0;
+        unsigned need_xapian_index_version = 0;
+        int rank = guidsearch_rank_clause(req->cstate, e, NULL, &use_dnf,
+                &need_xapian_index_version);
+        if (rank < 0 || (rank & 0x2)) {
+            /* Only conditions that guidsearch answers from conversations.db
+             * can be evaluated for each Email of a result */
+            r = IMAP_SEARCH_NOT_SUPPORTED;
+            break;
+        }
+
+        cat->exprs[i] = guidsearch_expr_build(&build_ctx, NULL, e);
+    }
+
+    free_hash_table(&foldernum_by_mboxname, NULL);
+
+    if (r) {
+        emailquery_category_free(&cat);
+        return r;
+    }
+
+    emailsearch_readable_folders(req, &cat->readable_folders);
+    if (build_ctx.need_folders) {
+        cat->numfolders = conversations_num_folders(req->cstate);
+    }
+    if (build_ctx.need_seen) {
+        cat->seendata = jmapseen_attrdata_find(&cat->attrs);
+    }
+
+    *catp = cat;
+    return 0;
+}
+
+static uint8_t emailquery_category_eval(struct emailquery_category *cat,
+                                        struct guidsearch_match *match)
+{
+    /* Returns the index of the first groupBy filter that this match matches,
+     * or the number of groupBy filters if it matches none of them */
+    for (size_t i = 0; i < cat->ngroups; i++) {
+        if (guidsearch_expr_eval(cat->cstate, cat->exprs[i], match)) {
+            return (uint8_t) i;
+        }
+    }
+    return (uint8_t) cat->ngroups;
+}
+
+struct emailquery_category_guidrock {
+    struct emailquery_category *cat;
+    struct guidsearch_match *match;
+};
+
+static int emailquery_category_guid_cb(const conv_guidrec_t *rec, void *rock)
+{
+    struct emailquery_category_guidrock *grock = rock;
+    struct emailquery_category *cat = grock->cat;
+
+    if (rec->part) return 0;
+
+    if ((rec->system_flags & FLAG_DELETED) ||
+        (rec->internal_flags & FLAG_INTERNAL_EXPUNGED) ||
+        !bv_isset(&cat->readable_folders, rec->foldernum)) {
+        return 0;
+    }
+
+    guidsearch_match_add_guidrec(grock->match, rec, cat->numfolders,
+                                 cat->cstate, cat->seendata);
+    return 0;
+}
+
+static uint8_t emailquery_category_of_guid(struct emailquery_category *cat,
+                                           const struct message_guid *guid,
+                                           conversation_id_t cid,
+                                           uint64_t nano_internaldate)
+{
+    /* A uidsearch match is one copy of an Email, so read the per-Email
+     * properties that the groupBy filters evaluate from the G records of the
+     * guid, exactly like guidsearch does while collecting its matches. */
+    struct guidsearch_match match;
+    guidsearch_match_init(&match, cat->numfolders);
+    match.cid = cid;
+    match.nano_internaldate = nano_internaldate;
+
+    struct emailquery_category_guidrock rock = { cat, &match };
+    conversations_guid_foreach(cat->cstate, message_guid_encode(guid),
+                               emailquery_category_guid_cb, &rock);
+
+    uint8_t category = emailquery_category_eval(cat, &match);
+
+    guidsearch_match_fini(&match);
+
+    return category;
 }
 
 static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
@@ -4416,13 +4687,7 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
     /* Prepare filter for post-processing */
     if (exprrank & 0x1) {
         hash_table foldernum_by_mboxname = HASH_TABLE_INITIALIZER;
-        construct_hash_table(&foldernum_by_mboxname, numfolders+2, 0);
-        uint32_t num;
-        for (num = 0; num < numfolders; num++) {
-            const char *mboxname = conversations_folder_mboxname(req->cstate, num);
-            if (!mboxname) continue;
-            hash_insert(mboxname, (void*)((uintptr_t)num+1), &foldernum_by_mboxname);
-        }
+        guidsearch_foldernum_by_mboxname(req->cstate, &foldernum_by_mboxname);
 
         struct guidsearch_build_context build_ctx = {
             .cstate = req->cstate,
@@ -4430,10 +4695,13 @@ static int guidsearch_run(jmap_req_t *req, struct emailsearch *search,
         };
         search_expr_t *expr = use_dnf ? search->expr_dnf : search->expr_orig;
         gsq->matchexpr = guidsearch_expr_build(&build_ctx, NULL, expr);
-        gsq->numfolders = build_ctx.need_folders ? numfolders : 0;
-        gsq->need_seen = build_ctx.need_seen;
+        gsq->need_folders |= build_ctx.need_folders;
+        gsq->need_seen |= build_ctx.need_seen;
         free_hash_table(&foldernum_by_mboxname, NULL);
     }
+    /* A category sort may need per-email properties that the filter does
+     * not, so decide what to collect only after compiling both. */
+    gsq->numfolders = gsq->need_folders ? numfolders : 0;
 
     // Xapian-backed message-id attributes, swapped into the expression
     // tree below once we are committed to running guidsearch
@@ -4590,6 +4858,9 @@ static void emailquery_guidsearch_result_ensure(struct emailquery *q, struct ema
         match->cid = gsqmatch->cid;
         match->nano_internaldate = gsqmatch->nano_internaldate;
         smallarrayu64_init(&match->partnums);
+        if (q->category) {
+            match->category = emailquery_category_eval(q->category, gsqmatch);
+        }
         if (hashset_add(qc->seen_threads, &match->cid))
             qc->collapsed_matches[qc->collapsed_len++] = *match;
     }
@@ -4621,6 +4892,15 @@ static int emailquery_guidsearch(jmap_req_t *req,
         .want_expunged = search->want_expunged,
         .seendata = jmapseen_attrdata_find(&search->attrs)
     };
+
+    /* A category sort reads per-email properties of every match, so
+     * collect them while scanning G records even if the filter does not
+     * need them */
+    if (q->category) {
+        gsq.need_folders = q->category->numfolders != 0;
+        gsq.need_seen = q->category->seendata != NULL;
+        if (!gsq.seendata) gsq.seendata = q->category->seendata;
+    }
 
     int r = guidsearch_run(req, search, &gsq);
     if (r) return r;
@@ -4703,6 +4983,10 @@ static void emailquery_uidsearch_result_ensure(struct emailquery *q, struct emai
         match->cid = md->cid;
         match->nano_internaldate = TIMESPEC_TO_NANOSEC(&md->internaldate);
         smallarrayu64_init(&match->partnums);
+        if (q->category) {
+            match->category = emailquery_category_of_guid(q->category,
+                    &match->guid, match->cid, match->nano_internaldate);
+        }
 
         /* Set partIds */
         if (rrock->want_partids && md->folder && md->folder->partnums.count) {
@@ -4850,6 +5134,20 @@ static int emailquery_search(jmap_req_t *req,
             contactgroups, 0, q->want_partids, 0, errp);
     if (*errp) goto done;
 
+    /* Compile the groupBy filters of a category sort */
+    json_t *jcategory = emailquery_category_comparator(q->super.sort);
+    if (jcategory) {
+        r = emailquery_category_init(req, jcategory, contactgroups, &q->category);
+        if (r == IMAP_SEARCH_NOT_SUPPORTED) {
+            /* Same path as jmap_query_parse() reports for a comparator that
+             * _email_parse_comparator() rejects */
+            *errp = json_pack("{s:s s:[s]}", "type", "unsupportedSort",
+                    "sort", "sort[0]");
+            goto done;
+        }
+        else if (r) goto done;
+    }
+
     /* Try to fetch matching guids directly from Xapian */
     int is_guidsearch = 0;
     if (!q->disable_guidsearch && !q->want_partids) {
@@ -4866,7 +5164,9 @@ static int emailquery_search(jmap_req_t *req,
     }
     if (r) goto done;
 
-    qr->is_mutable = emailsearch_is_mutable(&search);
+    /* A category sort orders by mutable keyword state that queryChanges
+     * can not track */
+    qr->is_mutable = emailsearch_is_mutable(&search) && !q->category;
     qr->is_imapfoldersearch = search.is_imapfolder;
     qr->is_guidsearch = is_guidsearch;
     qr->never_matches = search.never_matches;
@@ -4922,6 +5222,53 @@ static void emailquery_cache_reset(struct emailquery_cache *qc)
     memset(qc, 0, sizeof(struct emailquery_cache));
 }
 
+static void emailquery_sort_by_category(struct emailquery *q,
+                                        struct emailquery_cache *qc)
+{
+    /* Both search implementations sorted their matches by the other
+     * comparators, and the category comparator is the primary sort, so this
+     * amounts to a stable partition of the result by category. The collapsed
+     * result is rebuilt from it, because the representative of a thread is
+     * its first match in sort order, which the partition may have changed. */
+    size_t nbuckets = q->category->ngroups + 1;
+    size_t *offsets = xzmalloc(nbuckets * sizeof(size_t));
+
+    for (size_t i = 0; i < qc->uncollapsed_len; i++) {
+        offsets[qc->uncollapsed_matches[i].category]++;
+    }
+
+    /* Turn the counts into the start offset of each category. Emails that
+     * match no groupBy filter sort after all categories when ascending,
+     * and before them when descending. */
+    size_t pos = 0;
+    for (size_t i = 0; i < nbuckets; i++) {
+        size_t bucket = q->category->is_ascending ? i : nbuckets - 1 - i;
+        size_t count = offsets[bucket];
+        offsets[bucket] = pos;
+        pos += count;
+    }
+
+    struct emailquery_match *sorted =
+        xmalloc(sizeof(struct emailquery_match) * qc->uncollapsed_len);
+    for (size_t i = 0; i < qc->uncollapsed_len; i++) {
+        struct emailquery_match *match = &qc->uncollapsed_matches[i];
+        sorted[offsets[match->category]++] = *match;
+    }
+    free(qc->uncollapsed_matches);
+    qc->uncollapsed_matches = sorted;
+    free(offsets);
+
+    /* Rebuild the collapsed result */
+    hashset_free(&qc->seen_threads);
+    qc->seen_threads = hashset_new(sizeof(conversation_id_t));
+    qc->collapsed_len = 0;
+    for (size_t i = 0; i < qc->uncollapsed_len; i++) {
+        struct emailquery_match *match = &qc->uncollapsed_matches[i];
+        if (hashset_add(qc->seen_threads, &match->cid))
+            qc->collapsed_matches[qc->collapsed_len++] = *match;
+    }
+}
+
 static void emailquery_cache_ensure(struct emailquery *q,
                                     struct emailquery_cache *qc,
                                     size_t n)
@@ -4947,6 +5294,8 @@ static void emailquery_cache_ensure(struct emailquery *q,
 
     /* Postprocess total matches */
     if (qc->have_total && qc->uncollapsed_len) {
+
+        if (q->category) emailquery_sort_by_category(q, qc);
 
         /* Realloc buffers to exact size */
         if (qc->qr.total_ceiling > qc->uncollapsed_len) {
@@ -4983,10 +5332,13 @@ static void emailquery_cache_slice(struct emailquery *q,
          * 3) the offset is from the start, not from the end
          * 4) we have a limit, so we're not fetching everything
          * 5) we don't need all in thread
+         * 6) we don't sort by category, which needs the whole result both
+         *    to sort it and to count the categories
          * if all these conditions are met, then we can fill just to the
          * end of the requested window */
         if (!q->super.calculate_total && !q->super.anchor &&
-            q->super.position >= 0 && q->super.limit && !q->findallinthread) {
+            q->super.position >= 0 && q->super.limit && !q->findallinthread &&
+            !q->category) {
             size_t have_len = q->collapse_threads ?
                               qc->collapsed_len :
                               qc->uncollapsed_len;
@@ -5072,10 +5424,42 @@ static void emailquery_cache_slice(struct emailquery *q,
     *np = n;
 }
 
+static json_t *emailquery_groupby_counts(struct emailquery *q,
+                                         struct emailquery_cache *qc,
+                                         size_t ngroups)
+{
+    /* Counts how many Emails of the result matched each groupBy filter, over
+     * the whole result, and over the collapsed result if the query collapses
+     * threads. */
+    size_t *counts = xzmalloc(ngroups * sizeof(size_t));
+
+    struct emailquery_match *matches = q->collapse_threads ?
+        qc->collapsed_matches : qc->uncollapsed_matches;
+    size_t len = q->collapse_threads ?
+        qc->collapsed_len : qc->uncollapsed_len;
+
+    for (size_t i = 0; i < len; i++) {
+        /* Emails matching no groupBy filter are not counted in any group */
+        if (matches[i].category < ngroups) counts[matches[i].category]++;
+    }
+
+    json_t *jcounts = json_array();
+    for (size_t i = 0; i < ngroups; i++) {
+        json_array_append_new(jcounts, json_integer(counts[i]));
+    }
+    free(counts);
+
+    return jcounts;
+}
+
 static void emailquery_buildresult(struct emailquery *q,
                                    struct emailquery_cache *qc,
                                    json_t **errp)
 {
+    json_t *jcategory = emailquery_category_comparator(q->super.sort);
+    size_t ngroups = jcategory ?
+        json_array_size(json_object_get(jcategory, "groupBy")) : 0;
+
     if (!qc->qr.total_ceiling) {
         if (q->findallinthread) {
             q->thread_emailids = json_object();
@@ -5083,6 +5467,9 @@ static void emailquery_buildresult(struct emailquery *q,
         if (q->want_partids) {
             json_decref(q->partids);
             q->partids = json_null();
+        }
+        if (jcategory) {
+            q->groupby_counts = emailquery_groupby_counts(q, qc, ngroups);
         }
         return;
     }
@@ -5105,6 +5492,9 @@ static void emailquery_buildresult(struct emailquery *q,
     }
     if (q->findallinthread) {
         q->thread_emailids = json_object();
+    }
+    if (jcategory) {
+        q->groupby_counts = emailquery_groupby_counts(q, qc, ngroups);
     }
 
     size_t top = pos + n;
@@ -5320,6 +5710,9 @@ static json_t *emailquery_run(jmap_req_t *req, struct emailquery *q,
     if (q->thread_emailids) {
         json_object_set(res, "threadIdToEmailIds", q->thread_emailids);
     }
+    if (q->groupby_counts) {
+        json_object_set(res, "groupByCounts", q->groupby_counts);
+    }
     json_object_set(res, "collapseThreads", json_boolean(q->collapse_threads));
 
     if (jmap_is_using(req, JMAP_DEBUG_EXTENSION)) {
@@ -5403,10 +5796,11 @@ static int jmap_email_query(jmap_req_t *req)
 
     /* Parse request */
     json_t *err = NULL;
+    struct emailquery_comparator_rock crock = { .contactfilter = &contactfilter };
     jmap_query_parse(req, &parser,
                      emailquery_args_parse, &query,
                      _email_parse_filter_cb, &contactfilter,
-                     _email_parse_comparator, NULL,
+                     _email_parse_comparator, &crock,
                      &query.super, &err);
     if (err) {
         jmap_error(req, err);
@@ -5926,10 +6320,11 @@ static int jmap_email_querychanges(jmap_req_t *req)
 
     /* Parse arguments */
     json_t *err = NULL;
+    struct emailquery_comparator_rock crock = { .contactfilter = &contactfilter };
     jmap_querychanges_parse(req, &parser,
                             emailquery_args_parse, &emailquery,
                             _email_parse_filter_cb, &contactfilter,
-                            _email_parse_comparator, NULL,
+                            _email_parse_comparator, &crock,
                             &query, &err);
     if (err) {
         jmap_error(req, err);
@@ -5940,6 +6335,14 @@ static int jmap_email_querychanges(jmap_req_t *req)
         err = json_pack("{s:s}", "type", "invalidArguments");
         json_object_set(err, "arguments", parser.invalid);
         jmap_error(req, err);
+        goto done;
+    }
+
+    /* A category sort makes the sort order depend on mutable state that
+     * queryChanges does not track */
+    if (emailquery_category_comparator(query.sort)) {
+        jmap_error(req, json_pack("{s:s s:s}", "type", "cannotCalculateChanges",
+                    "description", "sort by category"));
         goto done;
     }
 


### PR DESCRIPTION
This adds a new non-standard sort comparator to Email/query. It requires the "https://cyrusimap.org/ns/jmap/mail" capability. The comparator property name is "category" and it allows to sort the query results by one or more categories, where each category is expressed as a query filter. Each Email sorts by the first filter it matches, and the response reports groupByCounts with one count per filter.

The filter is independent of the Email/query 'filter' argument. A query must have at most one 'category' sort comparator and that comparator must be the first comparator. The canCalculateChanges response always is false for queries with categories.

This is an example for an Email/query that uses the comparator:

```
{
    "filter": { "inMailbox": "P7k" },
    "sort": [
        {
            "property": "category",
            "isAscending": true,
            "groupBy": [
                { "hasKeyword": "$flagged" },
                { "notKeyword": "$seen" }
            ]
        },
        {
            "property": "receivedAt",
            "isAscending": false
        }
    ]
}
```

Internally, Cyrus implements this using guidsearch: for every email that either uidsearch or guidsearch Email/query found, it evaluates the category filter by examining the G records for that email.

Not all filter conditions are supported. The `emailQueryGroupByConditions` capability lists the supported filter conditions. The `maxCategoriesPerEmailQuery` capability defines the maximum supported size of the "groupBy" property of the 'category' comparator.

This PR also aligns the semantics of keyword search between uidsearch and guidsearch Email/query and with Email/get.
