### PR TITLE
release policy: we update the latest stable major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ Welcome
 This is the Cyrus IMAP Server, developer version 3.13.  This version is under
 active development, and is not considered "stable".
 
-The current stable series is 3.12.
-
-Versions 3.8 to 3.10 still receive security updates, and some non-security bug
-fixes.
+The current stable series is 3.12.  That release still receives security
+updates and some non-security bug fixes.
 
 What is Cyrus
 =============

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,9 +7,7 @@ Security updates are still provided for
 | Version | Supported          |
 | ------- | ------------------ |
 | 3.12.x  | :white_check_mark: |
-| 3.10.x  | :white_check_mark: |
-| 3.8.x   | :white_check_mark: |
-| < 3.8   | :x:                |
+| < 3.12  | :x:                |
 
 Note that this does not include versions with odd middle numbers: 3.13.x, for example.  These are developer snapshots, and security issues found only in the developer branches will be fixed directly on master with no embargo.  Don't run developer snapshots in production.
 

--- a/docsrc/developer/process.rst
+++ b/docsrc/developer/process.rst
@@ -73,9 +73,11 @@ particular meaning.  We make these at our discretion.  You should think of them
 as major versions that might includer larger new features or a more complex
 upgrade than usual.
 
-We stop releasing minor versions for major versions after two years.  While we
-*might* push bugfixes for significant problems to the git branch for an old
-major release, we won't undertake a new release.  If you're running an old
+We generally don't release minor versions for major versions other than the
+current stable one.  That is, once 3.14.0 is released, there may not be further
+3.12.x releases.  In practice, we *sometimes* push bugfixes for significant
+problems to the git branch for an old major release, and *might* make a minor
+version to ship security updates.  Really, though, if you're running an old
 version of Cyrus, it's up to you (or your package manager) to track and package
 new patches.
 
@@ -84,5 +86,5 @@ of Cyrus, we practice responsible disclosure.  We produce a fix, then inform
 downstream package mangers of that fix.  The fix comes with an embargo date so
 it can be released publicly at the same time that updated packages become
 available.  In general, we do not pursue security fixes for major versions of
-Cyrus over three years old. There may be exceptions to this, but generally you
+Cyrus over one year old.  There may be exceptions to this, but generally you
 should try to run a recent release.


### PR DESCRIPTION
As we've been talking about internally:  We'll release updates for the current stable branch.  We *might* supply patches for earlier versions, but it's not the stated plan.