### PR TITLE
imapd: decode SEARCH strings as UTF-8 for UTF8=ACCEPT and IMAP4rev2

### DIFF
--- a/cassandane/tiny-tests/SearchFuzzy/search_utf8_value
+++ b/cassandane/tiny-tests/SearchFuzzy/search_utf8_value
@@ -1,0 +1,74 @@
+#!perl
+use Cassandane::Tiny;
+
+sub assert_search_utf8_value($self, %params)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "Create and index test message";
+    $self->make_message("=?utf-8?Q?Gr=C3=BC=C3=9Fe?=") || die;
+    $self->{instance}->run_command({cyrus => 1}, 'squatter', '-i');
+
+    my $term = encode('UTF-8', "Gr\x{fc}\x{df}e");
+
+    my @charset = ('charset', 'utf-8');
+    my $isrev2 = 0;
+    if (my $capa = $params{enable}) {
+        xlog $self, "ENABLE $capa";
+        my $res = $talk->_imap_cmd('ENABLE', 0, 'enabled', $capa);
+        $self->assert_num_equals(1, $res->{lc $capa});
+        @charset = ();
+        $isrev2 = $capa eq 'IMAP4REV2';
+
+        if ($capa eq 'UTF8=ACCEPT') {
+            xlog $self, "SEARCH with a CHARSET is rejected";
+            $talk->search('charset', 'utf-8', 'subject', { Quote => $term });
+            $self->assert_str_equals('bad',
+                $talk->get_last_completion_response());
+        }
+    }
+
+    my $search = sub (@args) {
+        return $talk->search(@charset, @args) if !$isrev2;
+
+        # RFC 9051, Appendix E.4: SEARCH returns an ESEARCH response
+        my @esearch;
+        my %handlers = (esearch => sub { push @esearch, $_[1] });
+        $talk->_imap_cmd('SEARCH', 0, \%handlers, @args);
+        $self->assert_num_equals(1, scalar @esearch);
+        return [split /,/, $esearch[0][2]];
+    };
+
+    xlog $self, "SUBJECT matches a non-ASCII term";
+    my $seqnos = $search->('subject', { Quote => $term });
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "HEADER Subject matches a non-ASCII term";
+    $seqnos = $search->('header', 'subject', { Quote => $term });
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "FUZZY SUBJECT matches a non-ASCII term";
+    $seqnos = $search->('fuzzy', ['subject', { Quote => $term }]);
+    $self->assert_cmp_deeply([1], $seqnos);
+
+    xlog $self, "FUZZY HEADER Subject matches a non-ASCII term";
+    $seqnos = $search->('fuzzy', ['header', 'subject', { Quote => $term }]);
+    $self->assert_cmp_deeply([1], $seqnos);
+}
+
+sub test_search_utf8_value__charset($self)
+{
+    $self->assert_search_utf8_value();
+}
+
+sub test_search_utf8_value__utf8accept
+    :NoMunge8Bit
+    ($self)
+{
+    $self->assert_search_utf8_value(enable => 'UTF8=ACCEPT');
+}
+
+sub test_search_utf8_value__imap4rev2($self)
+{
+    $self->assert_search_utf8_value(enable => 'IMAP4REV2');
+}

--- a/changes/next/search-utf8accept-charset
+++ b/changes/next/search-utf8accept-charset
@@ -1,0 +1,27 @@
+Description:
+
+Fixes IMAP SEARCH (and FUZZY SEARCH) for non-ASCII search terms if the
+client enabled UTF8=ACCEPT or IMAP4rev2 rather than passing the CHARSET
+argument. Before, non-ASCII bytes were ignored in the search terms of all
+string-valued search keys, such as SUBJECT, FROM, HEADER, BODY and TEXT.
+Now, they are correctly processed by the search backend.
+
+
+Documentation:
+
+None
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6223,7 +6223,7 @@ static void cmd_search(const char *tag, const char *cmd)
         break;
     }
 
-    /* RFC 9855, Section 3: MUST reject SEARCH with a charset specification */ 
+    /* RFC 9755, Section 3: MUST reject SEARCH with a charset specification */
     if (!(client_capa & CAPA_UTF8_ACCEPT)) {
         state |= GETSEARCH_CHARSET_KEYWORD;
     }
@@ -6232,6 +6232,13 @@ static void cmd_search(const char *tag, const char *cmd)
     searchargs = new_searchargs(tag, state,
                                 &imapd_namespace, imapd_userid, imapd_authstate,
                                 imapd_userisadmin || imapd_userisproxyadmin);
+
+    /* RFC 9755, Section 3 and RFC 9051, Section 6.4.4: the default charset
+       is UTF-8, rather than US-ASCII */
+    if (client_capa & (CAPA_UTF8_ACCEPT | CAPA_IMAP4REV2)) {
+        charset_free(&searchargs->charset);
+        searchargs->charset = charset_lookupname("utf-8");
+    }
 
     searchargs->maxargssize_mark = maxargssize_mark;
 


### PR DESCRIPTION
This is a follow-up to https://github.com/cyrusimap/cyrus-imapd/pull/6159:

Non-ASCII bytes were ignored in the search terms of all string-valued search keys, such as SUBJECT, FROM, HEADER, BODY and TEXT, if the client enabled UTF8=ACCEPT or IMAP4rev2 rather than passing the CHARSET argument. Now, these clients default to UTF-8 rather than US-ASCII.

The code comment now references the correct RFC 9755, rather than RFC 6855.