### PR TITLE
guesstz: deduplicate timezone truncation and fix guesstz

### DIFF
--- a/cunit/guesstz.testc
+++ b/cunit/guesstz.testc
@@ -3,6 +3,7 @@
 #endif
 #include "cunit/unit.h"
 
+#include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -61,6 +62,44 @@
     "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\n" \
     "END:STANDARD\r\n"
 
+/* Two zones that match except for their last transition of the guessed
+ * window: both leave +0300 for +0400 on the last Sunday of March, and return
+ * on the last Sunday of October and the first Sunday of November
+ * respectively.  Neither is a preferred zone, so their observances are the
+ * only difference between them.  Test/DstEndsNov is walked first, so a guess
+ * that stops comparing too early yields Test/DstEndsOct for both of them. */
+#define DST_ENDS_OCT_BODY \
+    "BEGIN:DAYLIGHT\r\n" \
+    "TZNAME:TESTDT\r\n" \
+    "TZOFFSETFROM:+0300\r\n" \
+    "TZOFFSETTO:+0400\r\n" \
+    "DTSTART:19810329T030000\r\n" \
+    "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\n" \
+    "END:DAYLIGHT\r\n" \
+    "BEGIN:STANDARD\r\n" \
+    "TZNAME:TESTST\r\n" \
+    "TZOFFSETFROM:+0400\r\n" \
+    "TZOFFSETTO:+0300\r\n" \
+    "DTSTART:19811025T040000\r\n" \
+    "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU\r\n" \
+    "END:STANDARD\r\n"
+
+#define DST_ENDS_NOV_BODY \
+    "BEGIN:DAYLIGHT\r\n" \
+    "TZNAME:TESTDT\r\n" \
+    "TZOFFSETFROM:+0300\r\n" \
+    "TZOFFSETTO:+0400\r\n" \
+    "DTSTART:19810329T030000\r\n" \
+    "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU\r\n" \
+    "END:DAYLIGHT\r\n" \
+    "BEGIN:STANDARD\r\n" \
+    "TZNAME:TESTST\r\n" \
+    "TZOFFSETFROM:+0400\r\n" \
+    "TZOFFSETTO:+0300\r\n" \
+    "DTSTART:19811101T040000\r\n" \
+    "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\n" \
+    "END:STANDARD\r\n"
+
 static char zonedir[1024];
 static char *dbpath;
 
@@ -73,8 +112,8 @@ static void write_vtimezone(const char *tzid, const char *body)
     /* Create the intermediate "Europe" / "America" directory. */
     char *slash = strrchr(path, '/');
     *slash = '\0';
-    if (strcmp(path, zonedir))
-        CU_ASSERT_EQUAL_FATAL(mkdir(path, 0755), 0);
+    if (strcmp(path, zonedir) && mkdir(path, 0755))
+        CU_ASSERT_EQUAL_FATAL(errno, EEXIST);
     *slash = '/';
 
     FILE *fp = fopen(path, "w");
@@ -92,6 +131,8 @@ static int set_up(void)
 
     write_vtimezone("Europe/Berlin", BERLIN_BODY);
     write_vtimezone("America/New_York", NEWYORK_BODY);
+    write_vtimezone("Test/DstEndsOct", DST_ENDS_OCT_BODY);
+    write_vtimezone("Test/DstEndsNov", DST_ENDS_NOV_BODY);
 
     FILE *fp = fopen(dbpath, "w");
     if (!fp) return -1;
@@ -166,6 +207,19 @@ static void test_etc_gmt(void)
                        "DTSTART:16010101T000000\r\n"
                        "END:STANDARD\r\n");
     CU_ASSERT_STRING_EQUAL(tzid, "Etc/GMT+8");
+    free(tzid);
+}
+
+/* Two zones whose observances match except for the last one of the guessed
+ * window are distinguished, rather than matched on their common prefix. */
+static void test_near_miss(void)
+{
+    char *tzid = guess(DST_ENDS_OCT_BODY);
+    CU_ASSERT_STRING_EQUAL(tzid, "Test/DstEndsOct");
+    free(tzid);
+
+    tzid = guess(DST_ENDS_NOV_BODY);
+    CU_ASSERT_STRING_EQUAL(tzid, "Test/DstEndsNov");
     free(tzid);
 }
 

--- a/cunit/guesstz.testc
+++ b/cunit/guesstz.testc
@@ -100,6 +100,17 @@
     "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\n" \
     "END:STANDARD\r\n"
 
+/* A zone that never transitions, at an offset that is not a whole hour so
+ * that the Etc/GMT+X shortcut does not apply to it.  Its only record in the
+ * database is the one at the start of the database range. */
+#define FIXED_OFFSET_BODY \
+    "BEGIN:STANDARD\r\n" \
+    "TZNAME:+0530\r\n" \
+    "TZOFFSETFROM:+0530\r\n" \
+    "TZOFFSETTO:+0530\r\n" \
+    "DTSTART:16010101T000000\r\n" \
+    "END:STANDARD\r\n"
+
 static char zonedir[1024];
 static char *dbpath;
 
@@ -133,6 +144,7 @@ static int set_up(void)
     write_vtimezone("America/New_York", NEWYORK_BODY);
     write_vtimezone("Test/DstEndsOct", DST_ENDS_OCT_BODY);
     write_vtimezone("Test/DstEndsNov", DST_ENDS_NOV_BODY);
+    write_vtimezone("Test/FixedOffset", FIXED_OFFSET_BODY);
 
     FILE *fp = fopen(dbpath, "w");
     if (!fp) return -1;
@@ -225,6 +237,16 @@ static void test_near_miss(void)
 
     tzid = guess(DST_ENDS_NOV_BODY);
     CU_ASSERT_STRING_EQUAL(tzid, "Test/DstEndsNov");
+    free(tzid);
+}
+
+/* A zone whose last transition precedes the guessed window -- here one that
+ * never transitions at all -- is guessed from the observance still in force
+ * at the window open, which is the only record such a zone has. */
+static void test_fixed_offset(void)
+{
+    char *tzid = guess(FIXED_OFFSET_BODY);
+    CU_ASSERT_STRING_EQUAL(tzid, "Test/FixedOffset");
     free(tzid);
 }
 

--- a/cunit/guesstz.testc
+++ b/cunit/guesstz.testc
@@ -19,8 +19,8 @@
 #define TREND   "20320101T000000Z"
 
 /* The time range we guess over, well inside the database range. */
-#define QSTART  "20201227T140000Z"
-#define QEND    "20211227T150000Z"
+#define GUESS_START "20201227T140000Z"
+#define GUESS_END   "20211227T150000Z"
 
 #define VCAL_BEGIN \
     "BEGIN:VCALENDAR\r\n" \
@@ -153,7 +153,7 @@ static int tear_down(void)
 }
 
 /* Guess the IANA name of a VTIMEZONE whose own TZID says nothing. */
-static char *guess(const char *body)
+static char *guess_range(const char *body, const char *start, const char *end)
 {
     char *ical = strconcat(VCAL_BEGIN,
                            "BEGIN:VTIMEZONE\r\nTZID:Custom\r\n",
@@ -172,14 +172,19 @@ static char *guess(const char *body)
     CU_ASSERT_PTR_NULL_FATAL((void *)guesstz_error(gtz));
 
     char *tzid = guesstz_guess(gtz, vtz,
-                               icaltime_from_string(QSTART),
-                               icaltime_from_string(QEND));
+                               icaltime_from_string(start),
+                               icaltime_from_string(end));
     CU_ASSERT_PTR_NULL((void *)guesstz_error(gtz));
 
     guesstz_close(&gtz);
     icalcomponent_free(comp);
 
     return tzid;
+}
+
+static char *guess(const char *body)
+{
+    return guess_range(body, GUESS_START, GUESS_END);
 }
 
 static void test_berlin(void)
@@ -220,6 +225,78 @@ static void test_near_miss(void)
 
     tzid = guess(DST_ENDS_NOV_BODY);
     CU_ASSERT_STRING_EQUAL(tzid, "Test/DstEndsNov");
+    free(tzid);
+}
+
+/* A VTIMEZONE whose data starts after the database range opens still gets an
+ * observance at the range open, carrying the offset that was in force before
+ * its first transition, so that it can be guessed over a window that lies
+ * entirely before that transition. */
+static void test_proleptic_offset(void)
+{
+    guesstz_t *gtz = guesstz_open(dbpath);
+    CU_ASSERT_PTR_NULL_FATAL((void *)guesstz_error(gtz));
+    char *json = guesstz_encode(gtz);
+    guesstz_close(&gtz);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(json);
+
+    json_t *jdb = json_loads(json, 0, NULL);
+    free(json);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(jdb);
+
+    /* America/New_York's own data starts in 2007, well after TRSTART */
+    json_t *jobs = json_object_get(json_object_get(jdb, "timezones"),
+                                   "America/New_York");
+    json_t *jfirst = json_array_get(jobs, 0);
+    CU_ASSERT_EQUAL_FATAL(json_array_size(jfirst), 2);
+    CU_ASSERT_STRING_EQUAL(json_string_value(json_array_get(jfirst, 0)),
+                           TRSTART);
+    CU_ASSERT_STRING_EQUAL(json_string_value(json_array_get(jfirst, 1)),
+                           "-0500");
+
+    json_decref(jdb);
+
+    /* A VTIMEZONE that has an offset before 2007, guessed over a window that
+     * opens before then, only matches a database timezone with that same
+     * offset, not one with a zero offset that never was in force. */
+    char *tzid = guess_range("BEGIN:STANDARD\r\n"
+                             "TZNAME:EST\r\n"
+                             "TZOFFSETFROM:-0500\r\n"
+                             "TZOFFSETTO:-0500\r\n"
+                             "DTSTART:19700101T000000\r\n"
+                             "END:STANDARD\r\n"
+                             NEWYORK_BODY,
+                             "20060101T000000Z", "20080101T000000Z");
+    CU_ASSERT_STRING_EQUAL(tzid, "America/New_York");
+    free(tzid);
+}
+
+/* An RRULE with no value cannot be expanded, and the observance produced by
+ * its component's DTSTART is kept regardless. */
+static void test_empty_rrule(void)
+{
+    char *tzid = guess("BEGIN:STANDARD\r\n"
+                       "TZNAME:-08\r\n"
+                       "TZOFFSETFROM:-0800\r\n"
+                       "TZOFFSETTO:-0800\r\n"
+                       "DTSTART:16010101T000000\r\n"
+                       "RRULE:\r\n"
+                       "END:STANDARD\r\n");
+    CU_ASSERT_STRING_EQUAL(tzid, "Etc/GMT+8");
+    free(tzid);
+
+    /* The DTSTART observance is still there: with it dropped the zone would
+     * have no observance in the window at all, and no guess to make. */
+    tzid = guess_range(BERLIN_BODY
+                       "BEGIN:STANDARD\r\n"
+                       "TZNAME:CET\r\n"
+                       "TZOFFSETFROM:+0100\r\n"
+                       "TZOFFSETTO:+0100\r\n"
+                       "DTSTART:20210601T000000\r\n"
+                       "RRULE:\r\n"
+                       "END:STANDARD\r\n",
+                       GUESS_START, GUESS_END);
+    CU_ASSERT_PTR_NULL(tzid);
     free(tzid);
 }
 

--- a/imap/guesstz.c
+++ b/imap/guesstz.c
@@ -22,6 +22,7 @@
 #include <libical/ical.h>
 
 #include "guesstz.h"
+#include "ical_support.h"
 
 /*
  *  A guesstz database file is formatted as follows:
@@ -152,7 +153,9 @@ static const char *db_magic = "guesstz";
 static uint16_t db_bom = 0xfeff;
 
 
-struct observance {
+/* One observance record of the database, decoded.  Not to be confused with
+ * ical_support's struct observance, which is what the expansion reports. */
+struct guesstzdb_observance {
     int64_t onset;
     int32_t offset;
 };
@@ -184,500 +187,19 @@ static const char *preferred_tzids[] = {
     NULL
 };
 
-struct icalobservance {
-    icaltimetype onset;
-    int offset_from;
-    int offset_to;
-    int is_daylight;
-    int is_std;
-    int is_gmt;
-};
-
-struct rdate {
-    icalproperty *prop;
-    struct icaldatetimeperiodtype date;
-};
-
-static void icaltime_set_utc(struct icaltimetype *t, int set)
+/* Expand the observances of this VTIMEZONE within the time range. */
+static icalarray *expand_observances(icalcomponent *vtz,
+                                     icaltimetype trstart, icaltimetype trend)
 {
-    icaltime_set_timezone(t, set ? icaltimezone_get_utc_timezone() : NULL);
-}
+    icalarray *obsarray = icalarray_new(sizeof(struct observance), 20);
+    icalcomponent *myvtz = icalcomponent_clone(vtz);
 
-static void get_isstd_isgmt(icalproperty *prop,
-                                         struct icalobservance *obs)
-{
-    const char *time_type =
-        icalproperty_get_parameter_as_string(prop, "X-OBSERVED-AT");
+    icaltimezone_truncate_vtimezone_advanced(myvtz, &trstart, &trend, obsarray,
+                                             NULL, NULL, NULL, NULL, 0);
 
-    if (!time_type) time_type = "W";
+    icalcomponent_free(myvtz);
 
-    switch (time_type[0]) {
-    case 'G': case 'g':
-    case 'U': case 'u':
-    case 'Z': case 'z':
-        obs->is_gmt = obs->is_std = 1;
-        break;
-    case 'S': case 's':
-        obs->is_gmt = 0;
-        obs->is_std = 1;
-        break;
-    case 'W': case 'w':
-    default:
-        obs->is_gmt = obs->is_std = 0;
-        break;
-    }
-}
-
-static void check_tombstone(struct icalobservance *tombstone,
-                            struct icalobservance *obs)
-{
-    if (icaltime_compare(obs->onset, tombstone->onset) > 0) {
-        /* onset is closer to cutoff than existing tombstone */
-        tombstone->offset_from = tombstone->offset_to = obs->offset_to;
-        tombstone->is_daylight = obs->is_daylight;
-        tombstone->onset = obs->onset;
-    }
-}
-
-static int rdate_compare(const void *rdate1, const void *rdate2)
-{
-    return icaltime_compare(((struct rdate *) rdate1)->date.time,
-                            ((struct rdate *) rdate2)->date.time);
-}
-
-static int observance_compare(const void *obs1, const void *obs2)
-{
-    return icaltime_compare(((struct icalobservance *) obs1)->onset,
-                            ((struct icalobservance *) obs2)->onset);
-}
-
-static void expand_icalobservances(icalcomponent *vtz,
-                                   icaltimetype start, icaltimetype end,
-                                   icalarray *obsarray,
-                                   struct icalobservance **proleptic)
-{
-    icalcomponent *comp, *nextc, *tomb_std = NULL, *tomb_day = NULL;
-    icalproperty *prop, *proleptic_prop = NULL;
-    struct icalobservance tombstone;
-    unsigned need_tomb = !icaltime_is_null_time(start);
-
-    // Create local copy so we can rewrite its contents
-    vtz = icalcomponent_clone(vtz);
-
-    /* See if we have a proleptic tzname in VTIMEZONE */
-    for (prop = icalcomponent_get_first_property(vtz, ICAL_X_PROPERTY);
-         prop;
-         prop = icalcomponent_get_next_property(vtz, ICAL_X_PROPERTY)) {
-        if (!strcmp("X-PROLEPTIC-TZNAME", icalproperty_get_x_name(prop))) {
-            proleptic_prop = prop;
-            break;
-        }
-    }
-
-    memset(&tombstone, 0, sizeof(struct icalobservance));
-    if (!proleptic_prop ||
-        !icalproperty_get_parameter_as_string(prop, "X-NO-BIG-BANG"))
-      tombstone.onset.year = -1;
-
-    /* Process each VTMEZONE STANDARD/DAYLIGHT subcomponent */
-    for (comp = icalcomponent_get_first_component(vtz, ICAL_ANY_COMPONENT);
-         comp; comp = nextc) {
-        icalproperty *dtstart_prop = NULL, *rrule_prop = NULL;
-        icalarray *rdate_array = icalarray_new(sizeof(struct rdate), 10);
-        icaltimetype dtstart;
-        struct icalobservance obs;
-        unsigned n, trunc_dtstart = 0;
-        int r;
-
-        nextc = icalcomponent_get_next_component(vtz, ICAL_ANY_COMPONENT);
-
-        memset(&obs, 0, sizeof(struct icalobservance));
-        obs.offset_from = obs.offset_to = INT_MAX;
-        obs.is_daylight = (icalcomponent_isa(comp) == ICAL_XDAYLIGHT_COMPONENT);
-
-        /* Grab the properties that we require to expand recurrences */
-        for (prop = icalcomponent_get_first_property(comp, ICAL_ANY_PROPERTY);
-             prop;
-             prop = icalcomponent_get_next_property(comp, ICAL_ANY_PROPERTY)) {
-
-            switch (icalproperty_isa(prop)) {
-            case ICAL_DTSTART_PROPERTY:
-                dtstart_prop = prop;
-                obs.onset = dtstart = icalproperty_get_dtstart(prop);
-                get_isstd_isgmt(prop, &obs);
-                break;
-
-            case ICAL_TZOFFSETFROM_PROPERTY:
-                obs.offset_from = icalproperty_get_tzoffsetfrom(prop);
-                break;
-
-            case ICAL_TZOFFSETTO_PROPERTY:
-                obs.offset_to = icalproperty_get_tzoffsetto(prop);
-                break;
-
-            case ICAL_RRULE_PROPERTY:
-                rrule_prop = prop;
-                break;
-
-            case ICAL_RDATE_PROPERTY: {
-                struct rdate rdate = { prop, icalproperty_get_rdate(prop) };
-
-                icalarray_append(rdate_array, &rdate);
-                break;
-            }
-
-            default:
-                /* ignore all other properties */
-                break;
-            }
-        }
-
-        /* We MUST have DTSTART, TZNAME, TZOFFSETFROM, and TZOFFSETTO */
-        if (!dtstart_prop ||
-            obs.offset_from == INT_MAX || obs.offset_to == INT_MAX) {
-            icalarray_free(rdate_array);
-            continue;
-        }
-
-        /* Adjust DTSTART observance to UTC */
-        icaltime_adjust(&obs.onset, 0, 0, 0, -obs.offset_from);
-        icaltime_set_utc(&obs.onset, 1);
-
-        /* Check DTSTART vs window close */
-        if (!icaltime_is_null_time(end) &&
-            icaltime_compare(obs.onset, end) >= 0) {
-            /* All observances occur on/after window close - remove component */
-            icalcomponent_remove_component(vtz, comp);
-            icalcomponent_free(comp);
-
-            /* Nothing else to do */
-            icalarray_free(rdate_array);
-            continue;
-        }
-
-        /* Check DTSTART vs window open */
-        r = icaltime_compare(obs.onset, start);
-        if (r < 0) {
-            /* DTSTART is prior to our window open - check it vs tombstone */
-            if (need_tomb) check_tombstone(&tombstone, &obs);
-
-            /* Adjust it */
-            trunc_dtstart = 1;
-
-        }
-        else {
-            /* DTSTART is on/after our window open */
-            if (r == 0) need_tomb = 0;
-
-            if (obsarray && !rrule_prop) {
-                /* Add the DTSTART observance to our array */
-                icalarray_append(obsarray, &obs);
-            }
-        }
-
-        if (rrule_prop) {
-            struct icalrecurrencetype *rrule =
-                icalproperty_get_rrule(rrule_prop);
-            icalrecur_iterator *ritr = NULL;
-            unsigned eternal = icaltime_is_null_time(rrule->until);
-            unsigned trunc_until = 0;
-
-            /* Check RRULE duration */
-            if (!eternal && icaltime_compare(rrule->until, start) < 0) {
-                /* RRULE ends prior to our window open -
-                   check UNTIL vs tombstone */
-                obs.onset = rrule->until;
-                if (need_tomb) check_tombstone(&tombstone, &obs);
-
-                /* Remove RRULE */
-                icalcomponent_remove_property(comp, rrule_prop);
-                icalproperty_free(rrule_prop);
-            }
-            else {
-                /* RRULE ends on/after our window open */
-                if (!icaltime_is_null_time(end) &&
-                    (eternal || icaltime_compare(rrule->until, end) >= 0)) {
-                    /* RRULE ends after our window close - need to adjust it */
-                    trunc_until = 1;
-                }
-
-                if (!eternal) {
-                    /* Adjust UNTIL to local time (for iterator) */
-                    icaltime_adjust(&rrule->until, 0, 0, 0, obs.offset_from);
-                    icaltime_set_utc(&rrule->until, 0);
-                }
-
-                if (trunc_dtstart) {
-                    /* Bump RRULE start to 1 year prior to our window open */
-                    dtstart.year = start.year - 1;
-                    dtstart.month = start.month;
-                    dtstart.day = start.day;
-                    icaltime_normalize(dtstart);
-                }
-
-                ritr = icalrecur_iterator_new(rrule, dtstart);
-            }
-
-            /* Process any RRULE observances within our window */
-            if (ritr) {
-                icaltimetype recur, prev_onset;
-
-                /* Mark original DTSTART (UTC) */
-                dtstart = obs.onset;
-
-                while (!icaltime_is_null_time(obs.onset = recur =
-                                              icalrecur_iterator_next(ritr))) {
-                    unsigned ydiff;
-
-                    /* Adjust observance to UTC */
-                    icaltime_adjust(&obs.onset, 0, 0, 0, -obs.offset_from);
-                    icaltime_set_utc(&obs.onset, 1);
-
-                    if (trunc_until && icaltime_compare(obs.onset, end) >= 0) {
-                        /* Observance is on/after window close */
-
-                        /* Check if DSTART is within 1yr of prev onset */
-                        ydiff = prev_onset.year - dtstart.year;
-                        if (ydiff <= 1) {
-                            /* Remove RRULE */
-                            icalcomponent_remove_property(comp, rrule_prop);
-                            icalproperty_free(rrule_prop);
-
-                            if (ydiff) {
-                                /* Add previous onset as RDATE */
-                                struct icaldatetimeperiodtype rdate = {
-                                    prev_onset,
-                                    icalperiodtype_null_period()
-                                };
-                                prop = icalproperty_new_rdate(rdate);
-                                icalcomponent_add_property(comp, prop);
-                            }
-                        }
-                        else if (!eternal) {
-                            /* Set UNTIL to previous onset */
-                            rrule->until = prev_onset;
-                            icalproperty_set_rrule(rrule_prop, rrule);
-                        }
-
-                        /* We're done */
-                        break;
-                    }
-
-                    /* Check observance vs our window open */
-                    r = icaltime_compare(obs.onset, start);
-                    if (r < 0) {
-                        /* Observance is prior to our window open -
-                           check it vs tombstone */
-                        if (need_tomb) check_tombstone(&tombstone, &obs);
-                    }
-                    else {
-                        /* Observance is on/after our window open */
-                        if (r == 0) need_tomb = 0;
-
-                        if (trunc_dtstart) {
-                            /* Make this observance the new DTSTART */
-                            icalproperty_set_dtstart(dtstart_prop, recur);
-                            dtstart = obs.onset;
-                            trunc_dtstart = 0;
-
-                            /* Check if new DSTART is within 1yr of UNTIL */
-                            ydiff = rrule->until.year - recur.year;
-                            if (!trunc_until && ydiff <= 1) {
-                                /* Remove RRULE */
-                                icalcomponent_remove_property(comp, rrule_prop);
-                                icalproperty_free(rrule_prop);
-
-                                if (ydiff) {
-                                    /* Add UNTIL as RDATE */
-                                    struct icaldatetimeperiodtype rdate = {
-                                        rrule->until,
-                                        icalperiodtype_null_period()
-                                    };
-                                    prop = icalproperty_new_rdate(rdate);
-                                    icalcomponent_add_property(comp, prop);
-                                }
-                            }
-                        }
-
-                        if (obsarray) {
-                            /* Add the observance to our array */
-                            icalarray_append(obsarray, &obs);
-                        }
-                        else if (!trunc_until) {
-                            /* We're done */
-                            break;
-                        }
-                    }
-                    prev_onset = obs.onset;
-                }
-                icalrecur_iterator_free(ritr);
-            }
-        }
-
-        /* Sort the RDATEs by onset */
-        icalarray_sort(rdate_array, &rdate_compare);
-
-        /* Check RDATEs */
-        for (n = 0; n < rdate_array->num_elements; n++) {
-            struct rdate *rdate = icalarray_element_at(rdate_array, n);
-
-            if (n == 0 && icaltime_compare(rdate->date.time, dtstart) == 0) {
-                /* RDATE is same as DTSTART - remove it */
-                icalcomponent_remove_property(comp, rdate->prop);
-                icalproperty_free(rdate->prop);
-                continue;
-            }
-
-            obs.onset = rdate->date.time;
-            get_isstd_isgmt(rdate->prop, &obs);
-
-            /* Adjust observance to UTC */
-            icaltime_adjust(&obs.onset, 0, 0, 0, -obs.offset_from);
-            icaltime_set_utc(&obs.onset, 1);
-
-            if (!icaltime_is_null_time(end) &&
-                icaltime_compare(obs.onset, end) >= 0) {
-                /* RDATE is after our window close - remove it */
-                icalcomponent_remove_property(comp, rdate->prop);
-                icalproperty_free(rdate->prop);
-
-                continue;
-            }
-
-            r = icaltime_compare(obs.onset, start);
-            if (r < 0) {
-                /* RDATE is prior to window open - check it vs tombstone */
-                if (need_tomb) check_tombstone(&tombstone, &obs);
-
-                /* Remove it */
-                icalcomponent_remove_property(comp, rdate->prop);
-                icalproperty_free(rdate->prop);
-            }
-            else {
-                /* RDATE is on/after our window open */
-                if (r == 0) need_tomb = 0;
-
-                if (trunc_dtstart) {
-                    /* Make this RDATE the new DTSTART */
-                    icalproperty_set_dtstart(dtstart_prop,
-                                             rdate->date.time);
-                    trunc_dtstart = 0;
-
-                    icalcomponent_remove_property(comp, rdate->prop);
-                    icalproperty_free(rdate->prop);
-                }
-
-                if (obsarray) {
-                    /* Add the observance to our array */
-                    icalarray_append(obsarray, &obs);
-                }
-            }
-        }
-        icalarray_free(rdate_array);
-
-        /* Final check */
-        if (trunc_dtstart) {
-            /* All observances in comp occur prior to window open, remove it
-               unless we haven't saved a tombstone comp of this type yet */
-            if (icalcomponent_isa(comp) == ICAL_XDAYLIGHT_COMPONENT) {
-                if (!tomb_day) {
-                    tomb_day = comp;
-                    comp = NULL;
-                }
-            }
-            else if (!tomb_std) {
-                tomb_std = comp;
-                comp = NULL;
-            }
-
-            if (comp) {
-                icalcomponent_remove_component(vtz, comp);
-                icalcomponent_free(comp);
-            }
-        }
-    }
-
-    if (need_tomb && !icaltime_is_null_time(tombstone.onset)) {
-        /* Need to add tombstone component/observance starting at window open
-           as long as its not prior to start of TZ data */
-        icalcomponent *tomb;
-        icalproperty *prop, *nextp;
-
-        if (obsarray) {
-            /* Add the tombstone to our array */
-            tombstone.onset = start;
-            tombstone.is_gmt = tombstone.is_std = 1;
-            icalarray_append(obsarray, &tombstone);
-        }
-
-        /* Determine which tombstone component we need */
-        if (tombstone.is_daylight) {
-            tomb = tomb_day;
-            tomb_day = NULL;
-        }
-        else {
-            tomb = tomb_std;
-            tomb_std = NULL;
-        }
-
-        /* Set property values on our tombstone */
-        for (prop = icalcomponent_get_first_property(tomb, ICAL_ANY_PROPERTY);
-             prop; prop = nextp) {
-
-            nextp = icalcomponent_get_next_property(tomb, ICAL_ANY_PROPERTY);
-
-            switch (icalproperty_isa(prop)) {
-            case ICAL_TZOFFSETFROM_PROPERTY:
-                icalproperty_set_tzoffsetfrom(prop, tombstone.offset_from);
-                break;
-            case ICAL_TZOFFSETTO_PROPERTY:
-                icalproperty_set_tzoffsetto(prop, tombstone.offset_to);
-                break;
-            case ICAL_DTSTART_PROPERTY:
-                /* Adjust window open to local time */
-                icaltime_adjust(&start, 0, 0, 0, tombstone.offset_from);
-                icaltime_set_utc(&start, 0);
-
-                icalproperty_set_dtstart(prop, start);
-                break;
-            default:
-                icalcomponent_remove_property(tomb, prop);
-                icalproperty_free(prop);
-                break;
-            }
-        }
-
-        /* Remove X-PROLEPTIC-TZNAME as it no longer applies */
-        if (proleptic_prop) {
-            icalcomponent_remove_property(vtz, proleptic_prop);
-            icalproperty_free(proleptic_prop);
-        }
-    }
-
-    /* Remove any unused tombstone components */
-    if (tomb_std) {
-        icalcomponent_remove_component(vtz, tomb_std);
-        icalcomponent_free(tomb_std);
-    }
-    if (tomb_day) {
-        icalcomponent_remove_component(vtz, tomb_day);
-        icalcomponent_free(tomb_day);
-    }
-
-    if (obsarray && obsarray->num_elements) {
-        struct icalobservance *obs;
-
-        /* Sort the observances by onset */
-        icalarray_sort(obsarray, &observance_compare);
-
-        /* Set offset_to for tombstone, if necessary */
-        obs = icalarray_element_at(obsarray, 0);
-        if (!tombstone.offset_to) tombstone.offset_to = obs->offset_from;
-    }
-
-    if (proleptic) *proleptic = &tombstone;
-
-    icalcomponent_free(vtz);
+    return obsarray;
 }
 
 static int is_preferred_tzid(const char *tzid)
@@ -727,7 +249,7 @@ static void observances_from_ical(struct observances *obs, icalarray *icalobs)
     uint8_t *p = obs->alloc;
     size_t i;
     for (i = 0; i < obs->count; i++) {
-        struct icalobservance *icalob = icalarray_element_at(icalobs, i);
+        struct observance *icalob = icalarray_element_at(icalobs, i);
 
         int64_t onset = icaltime_as_timet_with_zone(icalob->onset, utc);
         memcpy(p, &onset, sizeof(int64_t));
@@ -739,9 +261,9 @@ static void observances_from_ical(struct observances *obs, icalarray *icalobs)
     }
 }
 
-static struct observance observances_nth(struct observances *obs, uint32_t i)
+static struct guesstzdb_observance observances_nth(struct observances *obs, uint32_t i)
 {
-    struct observance ob;
+    struct guesstzdb_observance ob;
 
     const uint8_t *d = obs->data + i * OBSERVANCE_SIZE;
     ob.onset = load_int64_t(d);
@@ -795,7 +317,7 @@ static struct guesstz_tz timezones_idx(const uint8_t *timezones, uint64_t idx)
 static void truncate_obs(struct observances *obs, int64_t onset)
 {
     ssize_t i;
-    struct observance ob;
+    struct guesstzdb_observance ob;
     for (i = 0; i < obs->count; i++) {
         ob = observances_nth(obs, i);
         if (ob.onset >= onset) {
@@ -843,14 +365,13 @@ static char *guess_timezone(struct db *db,
     }
 
     /* Generate observances */
-    icalarray *icalobs = icalarray_new(sizeof(struct icalobservance), 20);
-    expand_icalobservances(vtz, trstart, trend, icalobs, NULL);
+    icalarray *icalobs = expand_observances(vtz, trstart, trend);
     observances_from_ical(&obs, icalobs);
     icalarray_free(icalobs);
     if (!obs.count) goto done;
 
     /* Attempt to convert to Etc/GMT+X timezone */
-    struct observance firstob = observances_nth(&obs, 0);
+    struct guesstzdb_observance firstob = observances_nth(&obs, 0);
     if (obs.count == 1 && ((firstob.offset % (60*60)) == 0)) {
         if (icalcomponent_get_first_component(vtz, ICAL_XSTANDARD_COMPONENT) &&
             !icalcomponent_get_next_component(vtz, ICAL_XSTANDARD_COMPONENT) &&
@@ -887,7 +408,7 @@ static char *guess_timezone(struct db *db,
         }
 
         /* Start offsets must match */
-        struct observance dbob = observances_nth(dbobs, 0);
+        struct guesstzdb_observance dbob = observances_nth(dbobs, 0);
         if (dbob.offset != firstob.offset) {
             continue;
         }
@@ -912,9 +433,7 @@ static char *guess_timezone(struct db *db,
     }
 
 done:
-    if (obs.count) {
-        free(obs.alloc);
-    }
+    free(obs.alloc);
     return tzid;
 }
 
@@ -1088,8 +607,7 @@ static void add_vtimezone(icalarray *timezones, icalcomponent *vtz,
     const char *tzid = icalproperty_get_tzid(prop);
     if (!tzid) return;
 
-    icalarray *icalobs = icalarray_new(sizeof(struct icalobservance), 20);
-    expand_icalobservances(vtz, trstart, trend, icalobs, NULL);
+    icalarray *icalobs = expand_observances(vtz, trstart, trend);
 
     if (icalobs->num_elements) {
         /* Initialize timezone */
@@ -1110,7 +628,7 @@ static void add_vtimezone(icalarray *timezones, icalcomponent *vtz,
         icalarray *uniqoffsets = icalarray_new(sizeof(int32_t), 20);
         size_t i;
         for (i = 0; i < icalobs->num_elements; i++) {
-            struct icalobservance *icalob = icalarray_element_at(icalobs, i);
+            struct observance *icalob = icalarray_element_at(icalobs, i);
             int32_t offset = icalob->offset_to;
 
             int is_uniq = 1;

--- a/imap/guesstz.c
+++ b/imap/guesstz.c
@@ -318,6 +318,8 @@ static void truncate_obs(struct observances *obs, int64_t onset)
 {
     ssize_t i;
     struct guesstzdb_observance ob;
+    if (!obs->count) return;
+
     for (i = 0; i < obs->count; i++) {
         ob = observances_nth(obs, i);
         if (ob.onset >= onset) {
@@ -325,10 +327,10 @@ static void truncate_obs(struct observances *obs, int64_t onset)
         }
     }
     if (i == obs->count) {
-        obs->count = 0;
-        return;
+        /* All observances precede onset, so the last one is still in force */
+        i = obs->count - 1;
     }
-    if (ob.onset > onset) {
+    else if (ob.onset > onset) {
         if (i == 0) {
             obs->count = 0;
             return;

--- a/imap/guesstz.c
+++ b/imap/guesstz.c
@@ -815,7 +815,7 @@ static void truncate_obs(struct observances *obs, int64_t onset)
     }
 
     obs->data += i * OBSERVANCE_SIZE;
-    obs->count = obs->count - i + 1;
+    obs->count -= i;
 }
 
 static int is_preferred_tzidx(struct db *db, uint64_t idx)
@@ -893,9 +893,8 @@ static char *guess_timezone(struct db *db,
         }
 
         /* Compare remaining obervances */
-        if (dbobs->count > 1 && obs.count > 1) {
-            size_t cmplen = obs.count < dbobs->count ?
-                obs.count - 1 : dbobs->count - 1;
+        if (obs.count > 1) {
+            size_t cmplen = (obs.count - 1) * OBSERVANCE_SIZE;
             if (memcmp(obs.data + OBSERVANCE_SIZE,
                        dbobs->data + OBSERVANCE_SIZE, cmplen)) {
                 continue;

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -2590,6 +2590,7 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
     tombstone.name = icalmemory_tmp_copy(proleptic_prop ?
                                          icalproperty_get_x(proleptic_prop) :
                                          "LMT");
+    tombstone.offset_from = tombstone.offset_to = INT_MAX;
     if (!proleptic_prop ||
         !icalproperty_get_parameter_as_string(prop, "X-NO-BIG-BANG"))
       tombstone.onset.year = -1;
@@ -2607,6 +2608,7 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
         nextc = icalcomponent_get_next_component(vtz, ICAL_ANY_COMPONENT);
 
         memset(&obs, 0, sizeof(struct observance));
+        obs.name = "";
         obs.offset_from = obs.offset_to = INT_MAX;
         obs.is_daylight = (icalcomponent_isa(comp) == ICAL_XDAYLIGHT_COMPONENT);
 
@@ -2618,6 +2620,7 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
             switch (icalproperty_isa(prop)) {
             case ICAL_TZNAME_PROPERTY:
                 obs.name = icalproperty_get_tzname(prop);
+                if (!obs.name) obs.name = "";
                 break;
 
             case ICAL_DTSTART_PROPERTY:
@@ -2653,8 +2656,8 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
             }
         }
 
-        /* We MUST have DTSTART, TZNAME, TZOFFSETFROM, and TZOFFSETTO */
-        if (!dtstart_prop || !obs.name ||
+        /* We MUST have DTSTART, TZOFFSETFROM, and TZOFFSETTO */
+        if (!dtstart_prop ||
             obs.offset_from == INT_MAX || obs.offset_to == INT_MAX) {
             icalarray_free(rdate_array);
             continue;
@@ -2679,6 +2682,12 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
             continue;
         }
 
+        /* Ignore RRULE with invalid or no value */
+        struct icalrecurrencetype *rrule = NULL;
+        if (rrule_prop && !(rrule = icalproperty_get_recurrence(rrule_prop))) {
+            rrule_prop = NULL;
+        }
+
         /* Check DTSTART vs window open */
         r = icaltime_compare(obs.onset, start);
         if (r < 0) {
@@ -2701,8 +2710,7 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
             }
         }
 
-        struct icalrecurrencetype *rrule = NULL;
-        if (rrule_prop && (rrule = icalproperty_get_recurrence(rrule_prop))) {
+        if (rrule_prop) {
             icalrecur_iterator *ritr = NULL;
             unsigned eternal = icaltime_is_null_time(rrule->until);
             unsigned trunc_until = 0;
@@ -2963,8 +2971,9 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
         icalcomponent *tomb;
         icalproperty *prop, *nextp;
 
-        if (obsarray) {
-            /* Add the tombstone to our array */
+        /* Add the tombstone, but only if we could determine its offset */
+        if (obsarray && (tombstone.offset_to != INT_MAX ||
+                         obsarray->num_elements)) {
             tombstone.onset = start;
             tombstone.is_gmt = tombstone.is_std = 1;
             icalarray_append(obsarray, &tombstone);
@@ -2981,7 +2990,9 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
         }
 
         /* Set property values on our tombstone */
-        for (prop = icalcomponent_get_first_property(tomb, ICAL_ANY_PROPERTY);
+        for (prop = tomb ?
+                 icalcomponent_get_first_property(tomb, ICAL_ANY_PROPERTY) :
+                 NULL;
              prop; prop = nextp) {
 
             nextp = icalcomponent_get_next_property(tomb, ICAL_ANY_PROPERTY);
@@ -3027,15 +3038,25 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
         icalcomponent_free(tomb_day);
     }
 
-    if (obsarray) {
+    if (obsarray && obsarray->num_elements) {
         struct observance *obs;
 
         /* Sort the observances by onset */
         icalarray_sort(obsarray, &observance_compare);
 
-        /* Set offset_to for tombstone, if necessary */
         obs = icalarray_element_at(obsarray, 0);
-        if (!tombstone.offset_to) tombstone.offset_to = obs->offset_from;
+
+        /* A tombstone with no offset of its own sorts first, and its offset
+           equals the offset_from of the next observance */
+        if (obs->offset_to == INT_MAX && obsarray->num_elements > 1) {
+            struct observance *next = icalarray_element_at(obsarray, 1);
+            obs->offset_from = obs->offset_to = next->offset_from;
+        }
+
+        /* Set offset_to for tombstone, if necessary */
+        if (tombstone.offset_to == INT_MAX) {
+            tombstone.offset_from = tombstone.offset_to = obs->offset_from;
+        }
 
         /* Adjust actual range if necessary */
         if (adjust_start) {
@@ -3049,6 +3070,11 @@ EXPORTED void icaltimezone_truncate_vtimezone_advanced(icalcomponent *vtz,
     }
 
     if (proleptic) {
+        if (tombstone.offset_to == INT_MAX) {
+            /* We could not determine the offset before the VTIMEZONE onsets
+               start */
+            tombstone.offset_from = tombstone.offset_to = 0;
+        }
         memcpy(proleptic, &tombstone, sizeof(struct observance));
     }
 }


### PR DESCRIPTION
Now that guesstz is part of the cyrus-imapd codebase we deduplicate its timezone truncation code. This PR changes guesstz to use the ical_support API for timezone truncation. While doing so, we port the fixes that went into guesstz for timezone truncation.

This also fixes a couple of other bugs that were latent in guesstz since years and now show up with improved test coverage and tooling.