### PR TITLE
search_sort_thread_maxtime: avoid CPU busywork with a better config

### DIFF
--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -396,8 +396,8 @@ magic(SearchNormalizationMax20000 => sub {
 magic(SearchBatchsize20 => sub {
     shift->config_set(search_batchsize => 20);
 });
-magic(SearchMaxtime1Sec => sub {
-    shift->config_set(search_maxtime => 1);
+magic(SearchMaxtime => sub($self, $seconds) {
+    shift->config_set(search_maxtime => $seconds);
 });
 magic(SearchMaxSize4k => sub {
     shift->config_set(search_maxsize => 4);

--- a/cassandane/tiny-tests/JMAPEmail/email_query_dnfcomplexity
+++ b/cassandane/tiny-tests/JMAPEmail/email_query_dnfcomplexity
@@ -3,7 +3,7 @@ use Cassandane::Tiny;
 
 sub test_email_query_dnfcomplexity
     :min_version_3_4 :needs_component_sieve
-    :JMAPExtensions :SearchNormalizationMax20000 :SearchMaxTime1Sec
+    :JMAPExtensions :SearchNormalizationMax20000 :SearchMaxTime(1)
     ($self)
 {
     my $jmap = $self->{jmap};

--- a/cassandane/tiny-tests/SearchFuzzy/search_sort_thread_maxtime
+++ b/cassandane/tiny-tests/SearchFuzzy/search_sort_thread_maxtime
@@ -1,8 +1,12 @@
 #!perl
 use Cassandane::Tiny;
 
+# search_maxtime of 0 is treated as no timeout (see cmdtime_checksearch)
+# so we need something small.
+# (Don't use a negative timeout, as that seems like a bug we should fix)
+
 sub test_search_sort_thread_maxtime
-    :needs_search_xapian :SearchMaxtime1Sec :SearchNormalizationMax20000
+    :needs_search_xapian :SearchMaxtime(1.e-18)
     ($self)
 {
     my $talk = $self->{store}->get_client();
@@ -10,10 +14,8 @@ sub test_search_sort_thread_maxtime
     $self->make_message("needle") || die;
     $talk->select('INBOX');
 
-    # criteria whose DNF normalisation reliably exceeds search_maxtime,
-    # independent of mailbox size
+    # With search_maxtime set to nothing, any search times out immediately
     my $crit = 'SUBJECT a';
-    $crit = "OR NOT $crit NOT $crit" for (1..15);
 
     xlog "SEARCH must report the timeout";
     my $uids = $talk->search(\$crit);


### PR DESCRIPTION
Set search_maxtime to (almost) 0 to cause even the most trivial searches to time out. Hence we can remove the extra terms previously used to hit pathological cases in the DNF normalisation code intended to burn CPU and cross a 1 second timeout.