### PR TITLE
sphinx: silence all current warnings

### DIFF
--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -56,6 +56,10 @@ breathe_projects = {
 }
 breathe_default_project = "cyrus"
 
+# Cyrus is C, but breathe assumes .h is C++.  Tell it better.  (Otherwise, it
+# complains about name conflicts that aren't real in C.)
+breathe_domain_by_extension = {"h": "c", "c": "c"}
+
 # Default options for Breathe directives
 breathe_default_members = ('members', 'undoc-members')
 

--- a/docsrc/download/release-notes/3.12/x/3.12.0-beta1.rst
+++ b/docsrc/download/release-notes/3.12/x/3.12.0-beta1.rst
@@ -44,7 +44,7 @@ Major changes since the 3.10 series
   :cyrusman:`imapd.conf(5)` options are disabled
 * User-defined flags are now replicated even when not in use on any messages.
 * Adds support for the `HAProxy`_ protocol.  The :cyrusman:`imapd(8)`,
-  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, :cyrusman:`nntpd(8)`,
+  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, ``nntpd(8)``,
   :cyrusman:`httpd(8)`, and :cyrusman:`timsieved(8)` service daemons now accept
   a ``-H`` argument to enable this.
 * Adds support for ``comparator-i;unicode-casemap`` (:rfc:`5051`) to Sieve

--- a/docsrc/download/release-notes/3.12/x/3.12.0-beta2.rst
+++ b/docsrc/download/release-notes/3.12/x/3.12.0-beta2.rst
@@ -44,7 +44,7 @@ Major changes since the 3.10 series
   :cyrusman:`imapd.conf(5)` options are disabled
 * User-defined flags are now replicated even when not in use on any messages.
 * Adds support for the `HAProxy`_ protocol.  The :cyrusman:`imapd(8)`,
-  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, :cyrusman:`nntpd(8)`,
+  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, ``nntpd(8)``,
   :cyrusman:`httpd(8)`, and :cyrusman:`timsieved(8)` service daemons now accept
   a ``-H`` argument to enable this.
 * Adds support for ``comparator-i;unicode-casemap`` (:rfc:`5051`) to Sieve

--- a/docsrc/download/release-notes/3.12/x/3.12.0-rc1.rst
+++ b/docsrc/download/release-notes/3.12/x/3.12.0-rc1.rst
@@ -44,7 +44,7 @@ Major changes since the 3.10 series
   :cyrusman:`imapd.conf(5)` options are disabled
 * User-defined flags are now replicated even when not in use on any messages.
 * Adds support for the `HAProxy`_ protocol.  The :cyrusman:`imapd(8)`,
-  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, :cyrusman:`nntpd(8)`,
+  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, ``nntpd(8)``,
   :cyrusman:`httpd(8)`, and :cyrusman:`timsieved(8)` service daemons now accept
   a ``-H`` argument to enable this.
 * Adds support for ``comparator-i;unicode-casemap`` (:rfc:`5051`) to Sieve

--- a/docsrc/download/release-notes/3.12/x/3.12.0.rst
+++ b/docsrc/download/release-notes/3.12/x/3.12.0.rst
@@ -44,7 +44,7 @@ Major changes since the 3.10 series
   :cyrusman:`imapd.conf(5)` options are disabled
 * User-defined flags are now replicated even when not in use on any messages.
 * Adds support for the `HAProxy`_ protocol.  The :cyrusman:`imapd(8)`,
-  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, :cyrusman:`nntpd(8)`,
+  :cyrusman:`pop3d(8)`, :cyrusman:`lmtpd(8)`, ``nntpd(8)``,
   :cyrusman:`httpd(8)`, and :cyrusman:`timsieved(8)` service daemons now accept
   a ``-H`` argument to enable this.
 * Adds support for ``comparator-i;unicode-casemap`` (:rfc:`5051`) to Sieve

--- a/docsrc/download/release-notes/3.13/x/3.13.7.rst
+++ b/docsrc/download/release-notes/3.13/x/3.13.7.rst
@@ -96,7 +96,7 @@ Updates to default configuration
 ================================
 
 * OpenSSL version 3.0 or greater is now required for all builds.
-* HTTP support, *DAV (CalDAV, CardDAV, WebDAV) and the calendar alarm daemon
+* HTTP support, \*DAV (CalDAV, CardDAV, WebDAV) and the calendar alarm daemon
   are now mandatory parts of every Cyrus IMAP build.  The ``--enable-http`` and
   ``--enable-calalarmd`` configure options have been removed; the httpd binary
   and calalarmd are always built.  libical, libxml2 and SQLite3 are now

--- a/docsrc/reference/manpages/systemcommands/sync_client.rst
+++ b/docsrc/reference/manpages/systemcommands/sync_client.rst
@@ -121,8 +121,8 @@ Options
 .. option:: -r, --rolling
 
     Rolling (repeat) replication mode. Pick up a list of actions
-    recorded by the :cyrusman:`lmtpd(8)`, :cyrusman:`imapd(8)`,
-    :cyrusman:`pop3d(8)` and :cyrusman:`nntpd(8)` daemons from the file
+    recorded by the :cyrusman:`lmtpd(8)`, :cyrusman:`imapd(8)` and
+    :cyrusman:`pop3d(8)` daemons from the file
     specified in ``sync_log_file``. Repeat until ``sync_shutdown_file``
     appears.  Alternative log and shutdown files can be specified with
     **-f** and **-F**.

--- a/imap/auditlog.c
+++ b/imap/auditlog.c
@@ -330,7 +330,7 @@ EXPORTED void auditlog_sieve(const char *action,
     auditlog_finish(&lf);
 }
 
-EXPORTED void auditlog_send(const struct auditlog_send *s)
+EXPORTED void auditlog_send(const struct auditlog_send_event *s)
 {
     struct logfmt lf = LOGFMT_INITIALIZER;
 

--- a/imap/auditlog.h
+++ b/imap/auditlog.h
@@ -91,7 +91,7 @@ extern void auditlog_sieve(const char *action,
                            const char *vac_to_addr);
 
 /** @brief A calalarmd send event, for auditlog_send() */
-struct auditlog_send {
+struct auditlog_send_event {
     const char *action;    /* e.g. "calalarmd.send.futurerelease" */
     const char *outcome;   /* "sent" | "cancelled" | "unsnoozed" */
     const char *userid;
@@ -107,7 +107,7 @@ struct auditlog_send {
 };
 
 /** @brief Log a calalarmd send with scheduled-vs-actual delay */
-extern void auditlog_send(const struct auditlog_send *s);
+extern void auditlog_send(const struct auditlog_send_event *s);
 
 /** @brief Log session traffic statistics */
 extern void auditlog_traffic(uint64_t bytes_in, uint64_t bytes_out);

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -617,7 +617,7 @@ static int process_alarm_cb(icalcomponent *comp,
                     /* outcome "sent" reflects successful dispatch to the
                      * notification subsystem; send_alarm() can't report
                      * downstream delivery failure */
-                    struct auditlog_send as = {
+                    struct auditlog_send_event as = {
                         .action = "calalarmd.send.imip",
                         .outcome = "sent",
                         .userid = data->userid,
@@ -1892,7 +1892,7 @@ static int process_futurerelease(struct caldav_alarm_data *data,
         }
 
         if (cancel) {
-            struct auditlog_send as = {
+            struct auditlog_send_event as = {
                 .action = "calalarmd.send.futurerelease",
                 .outcome = "cancelled",
                 .userid = userid,
@@ -1943,7 +1943,7 @@ static int process_futurerelease(struct caldav_alarm_data *data,
         /* Mark the email as sent */
         record->system_flags |= FLAG_ANSWERED;
 
-        struct auditlog_send as = {
+        struct auditlog_send_event as = {
             .action = "calalarmd.send.futurerelease",
             .outcome = "sent",
             .userid = userid,
@@ -2087,7 +2087,7 @@ static int process_snoozed(struct caldav_alarm_data *data,
 
     if (!r) {
         char *userid = mboxname_to_userid(mailbox_name(mailbox));
-        struct auditlog_send as = {
+        struct auditlog_send_event as = {
             .action = "calalarmd.send.snooze",
             .outcome = "unsnoozed",
             .userid = userid,

--- a/tools/lib/Cyrus/IMAPOptions/App/Command/manrst.pm
+++ b/tools/lib/Cyrus/IMAPOptions/App/Command/manrst.pm
@@ -130,7 +130,6 @@ sub footer ($self)
 
     :cyrusman:`imapd(8)`,
     :cyrusman:`pop3d(8)`,
-    :cyrusman:`nntpd(8)`,
     :cyrusman:`lmtpd(8)`,
     :cyrusman:`httpd(8)`,
     :cyrusman:`timsieved(8)`,


### PR DESCRIPTION
We thought we had "warnings are fatal" on in our CI, but it wasn't effective.  First, we silence the errors.  Then we fix the fatalization.