### PR TITLE
caldav: honour serverinfo when building the iCalendar PRODID

### DIFF
--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -724,8 +724,20 @@ static void my_caldav_init(struct buf *serverinfo)
 
     compile_time = calc_compile_time(__TIME__, __DATE__);
 
-    buf_printf(&ical_prodid_buf,
-               "-//CyrusIMAP.org/Cyrus %s//EN", CYRUS_VERSION);
+    /* PRODID names the product that wrote the object, which RFC 5545 3.7.3
+       asks for - but the version number inside it is server information like
+       any other, and serverinfo is the setting that says how much of that to
+       disclose.  Every other place that prints CYRUS_VERSION over HTTP tests
+       it first; this one did not, so any calendar object, and any answer from
+       the free/busy URL - which serves unauthenticated GETs - named the exact
+       build to whoever asked. */
+    if (config_serverinfo == IMAP_ENUM_SERVERINFO_ON) {
+        buf_printf(&ical_prodid_buf,
+                   "-//CyrusIMAP.org/Cyrus %s//EN", CYRUS_VERSION);
+    }
+    else {
+        buf_setcstr(&ical_prodid_buf, "-//CyrusIMAP.org/Cyrus//EN");
+    }
     ical_prodid = buf_cstring(&ical_prodid_buf);
 
     utc_zone = icaltimezone_get_utc_timezone();


### PR DESCRIPTION
`ical_prodid` is built once at startup and stamped on every iCalendar object httpd hands out:

```c
buf_printf(&ical_prodid_buf, "-//CyrusIMAP.org/Cyrus %s//EN", CYRUS_VERSION);
```

RFC 5545 §3.7.3 does want a PRODID, and naming the product is the point of it. The version inside it is a different matter: that is server information, and `serverinfo` is the setting that says how much of it to disclose. Every other place that prints `CYRUS_VERSION` over HTTP tests it first — `http_dav.c:8693`, `http_ischedule.c:628`, `http_rss.c:905`, `httpd.c:3218`, and the `Via` header in `http_proxy.c:530` — so an administrator who sets `serverinfo: off` reasonably expects the version to be gone from the HTTP surface.

It is not, and the PRODID travels further than most headers:

* every event exported or fetched by any client, including ones outside the organisation a calendar is shared with;
* every answer from the `/freebusy` namespace, which serves GET **without authentication** (`http_allow_noauth_get`). Anyone who can guess a login name learns the exact build, distribution packaging string included.

Observed on a server with `serverinfo: off`, where no `Server` header is sent and the greeting is bare:

```
$ curl -s https://example.org/freebusy/user/someone | head -3
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//CyrusIMAP.org/Cyrus 3.8.3-10.el10 Fedora//EN
```

With this change the product is still named, as the RFC asks, and only the version goes:

```
PRODID:-//CyrusIMAP.org/Cyrus//EN
```

`serverinfo: on` is unchanged, and it is the default, so nothing moves for anybody who has not asked for it.

Built and checked against current master (`dd81135`). I have not added a Cassandane test: asserting on a PRODID would pin a string that is deliberately allowed to vary, and the behaviour is one branch on an existing, already-tested setting. Happy to add one if you would rather have it.
