### PR TITLE
configure.ac: Remove SIZE_T_FMT - C99 provides %zu for values of type size_t

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,12 +274,6 @@ AC_DEFINE_UNQUOTED([TIME_T_FMT], ["$cyr_cv_format_time_t"],
 AC_DEFINE_UNQUOTED([strtotimet(a,b,c)], [$cyr_cv_parse_time_t(a,b,c)],
                    [strtol-like parse function for time_t])
 
-CYR_INTTYPE([size_t], [#include <stdlib.h>])
-AC_DEFINE_UNQUOTED([SIZE_T_FMT], ["$cyr_cv_format_size_t"],
-                   [printf formatter for size_t])
-AC_DEFINE_UNQUOTED([strtosizet(a,b,c)], [$cyr_cv_parse_size_t(a,b,c)],
-                   [strtol-like parse function for size_t])
-
 CYR_INTTYPE([off_t], [#include <sys/types.h>])
 AC_DEFINE_UNQUOTED([OFF_T_FMT], ["$cyr_cv_format_off_t"],
                    [printf formatter for off_t])

--- a/cunit/logfmt.testc
+++ b/cunit/logfmt.testc
@@ -448,7 +448,7 @@ static void test_logfmt_push_msgrecord(void)
     message_guid_generate(&test_record.guid, msg, sizeof(msg));
     snprintf(expect_guid, sizeof(expect_guid), "msg.guid=%s",
              message_guid_encode(&test_record.guid));
-    snprintf(expect_size, sizeof(expect_size), "msg.size=" SIZE_T_FMT,
+    snprintf(expect_size, sizeof(expect_size), "msg.size=%zu",
              strlen(msg));
 
     logfmt_init(&lf, "test_logfmt_push_msgrecord");

--- a/cunit/mailbox.testc
+++ b/cunit/mailbox.testc
@@ -213,14 +213,14 @@ static void test_unique_header_offsets(void)
 
         /* better not overlap the next one */
         if (offsets[i].pos + offsets[i].val > offsets[i + 1].pos) {
-            CU_FAIL_FMT("%s at %u length " SIZE_T_FMT " overlaps %s at %u",
+            CU_FAIL_FMT("%s at %u length %zu overlaps %s at %u",
                         offsets[i].name, offsets[i].pos, offsets[i].val,
                         offsets[i + 1]. name, offsets[i + 1].pos);
         }
 
         /* not ideal to leave unnamed gaps either */
         if (offsets[i].pos + offsets[i].val < offsets[i + 1].pos) {
-            CU_FAIL_FMT("%s at %u length " SIZE_T_FMT " leaves gap before %s at %u",
+            CU_FAIL_FMT("%s at %u length %zu leaves gap before %s at %u",
                         offsets[i].name, offsets[i].pos, offsets[i].val,
                         offsets[i + 1]. name, offsets[i + 1].pos);
         }
@@ -266,14 +266,14 @@ static void test_unique_record_offsets(void)
 
         /* better not overlap the next one */
         if (offsets[i].pos + offsets[i].val > offsets[i + 1].pos) {
-            CU_FAIL_FMT("%s at %u length " SIZE_T_FMT " overlaps %s at %u",
+            CU_FAIL_FMT("%s at %u length %zu overlaps %s at %u",
                         offsets[i].name, offsets[i].pos, offsets[i].val,
                         offsets[i + 1]. name, offsets[i + 1].pos);
         }
 
         /* not ideal to leave unnamed gaps either */
         if (offsets[i].pos + offsets[i].val < offsets[i + 1].pos) {
-            CU_FAIL_FMT("%s at %u length " SIZE_T_FMT " leaves gap before %s at %u",
+            CU_FAIL_FMT("%s at %u length %zu leaves gap before %s at %u",
                         offsets[i].name, offsets[i].pos, offsets[i].val,
                         offsets[i + 1]. name, offsets[i + 1].pos);
         }

--- a/imap/annotate.c
+++ b/imap/annotate.c
@@ -1536,7 +1536,7 @@ static void output_entryatt(annotate_state_t *state, const char *entry,
 
         if ((state->attribs & ATTRIB_SIZE_SHARED)) {
             buf_reset(&buf);
-            buf_printf(&buf, SIZE_T_FMT, value->len);
+            buf_printf(&buf, "%zu", value->len);
             appendattvalue(&state->attvalues, "size.shared", &buf);
             state->found |= ATTRIB_SIZE_SHARED;
         }
@@ -1549,7 +1549,7 @@ static void output_entryatt(annotate_state_t *state, const char *entry,
 
         if ((state->attribs & ATTRIB_SIZE_PRIV)) {
             buf_reset(&buf);
-            buf_printf(&buf, SIZE_T_FMT, value->len);
+            buf_printf(&buf, "%zu", value->len);
             appendattvalue(&state->attvalues, "size.priv", &buf);
             state->found |= ATTRIB_SIZE_PRIV;
         }

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -178,7 +178,7 @@ static int extractor_httpreq(struct extractor_ctx *ext,
             "Connection: Keep-Alive\r\n"
             "Keep-Alive: timeout=%u\r\n"
             "Accept: text/plain\r\n"
-            "X-Truncate-Length: " SIZE_T_FMT "\r\n",
+            "X-Truncate-Length: %zu\r\n",
             method, url, HTTP_VERSION,
             (int) hostlen, ext->hostname, CYRUS_VERSION,
             attachextract_idle_timeout, config_search_maxsize);
@@ -189,7 +189,7 @@ static int extractor_httpreq(struct extractor_ctx *ext,
                 req_ctype ? req_ctype : "application/octet-stream");
 
         buf_printf(&req_buf,
-                "Content-Length: " SIZE_T_FMT "\r\n",
+                "Content-Length: %zu\r\n",
                 buf_len(req_body));
     }
 

--- a/imap/http_ischedule.c
+++ b/imap/http_ischedule.c
@@ -186,7 +186,7 @@ static int meth_get_isched(struct transaction_t *txn,
     /* Generate ETag based on compile date/time of this source file,
        the number of available RSCALEs and the config file size/mtime */
     assert(!buf_len(&txn->buf));
-    buf_printf(&txn->buf, TIME_T_FMT "-" SIZE_T_FMT "-" TIME_T_FMT "-" OFF_T_FMT, compile_time,
+    buf_printf(&txn->buf, TIME_T_FMT "-%zu-" TIME_T_FMT "-" OFF_T_FMT, compile_time,
                rscale_calendars ? (size_t)rscale_calendars->num_elements : 0,
                sbuf.st_mtime, sbuf.st_size);
 

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -71,7 +71,7 @@ EXPORTED void ical_support_init(void)
 
     icalparser_set_ctrl(ICALPARSER_CTRL_OMIT);
 
-    syslog(LOG_DEBUG, "%s: found " SIZE_T_FMT " timezones",
+    syslog(LOG_DEBUG, "%s: found %zu timezones",
                        __func__, timezones->num_elements);
 
 #ifdef HAVE_LIBICALVCARD_XPROP_VALUE

--- a/imap/imap_proxy.c
+++ b/imap/imap_proxy.c
@@ -995,7 +995,7 @@ int proxy_copy(const char *tag, char *sequence, char *name, int myrights,
     }
 
     /* start the append */
-    prot_printf(s->out, "%s Append {" SIZE_T_FMT "+}\r\n%s",
+    prot_printf(s->out, "%s Append {%zu+}\r\n%s",
                 tag, strlen(name), name);
 
     if (crock.uidset) sequence = freeme = seqset_cstring(crock.uidset);
@@ -1272,7 +1272,7 @@ int proxy_catenate_url(struct backend *s, struct imapurl *url, FILE *f,
 
     /* select the mailbox (read-only) */
     proxy_gentag(mytag, sizeof(mytag));
-    prot_printf(s->out, "%s Examine {" SIZE_T_FMT "+}\r\n%s\r\n",
+    prot_printf(s->out, "%s Examine {%zu+}\r\n%s\r\n",
                 mytag, strlen(url->mailbox), url->mailbox);
     for (/* each examine response */;;) {
         /* read a line */

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -4221,12 +4221,12 @@ static int cmd_append(char *tag, char *name, const char *cur_name,
             s->context = (void*) &is_active;
             if (imapd_index) {
                 const char *mboxname = index_mboxname(imapd_index);
-                prot_printf(s->out, "%s Localappend {" SIZE_T_FMT "+}\r\n%s"
-                            " {" SIZE_T_FMT "+}\r\n%s ",
+                prot_printf(s->out, "%s Localappend {%zu+}\r\n%s"
+                            " {%zu+}\r\n%s ",
                             tag, strlen(origname), origname,
                             strlen(mboxname), mboxname);
             } else {
-                prot_printf(s->out, "%s Localappend {" SIZE_T_FMT "+}\r\n%s"
+                prot_printf(s->out, "%s Localappend {%zu+}\r\n%s"
                             " \"\" ", tag, strlen(origname), origname);
             }
             if (!(r = pipe_command(s, 16384))) {
@@ -4884,7 +4884,7 @@ static void cmd_select(char *tag, char *cmd, char *name)
         }
 
         /* Send SELECT command to backend */
-        prot_printf(backend_current->out, "%s %s {" SIZE_T_FMT "+}\r\n%s",
+        prot_printf(backend_current->out, "%s %s {%zu+}\r\n%s",
                     tag, cmd, strlen(origname), origname);
         if (v->uidvalidity) {
             prot_printf(backend_current->out, " (QRESYNC (%u " MODSEQ_FMT,
@@ -6689,7 +6689,7 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
         /* simply send the COPY to the backend */
         prot_printf(
                 backend_current->out,
-                "%s %s %s {" SIZE_T_FMT "+}\r\n%s\r\n",
+                "%s %s %s {%zu+}\r\n%s\r\n",
                 tag,
                 usinguid ? (ismove ? "UID Move" : "UID Copy") : (ismove ? "Move" : "Copy"),
                 sequence,
@@ -6726,7 +6726,7 @@ static void cmd_copy(char *tag, char *sequence, char *name, int usinguid, int is
         assert(!ismove); /* XXX - support proxying moves */
 
         /* start the append */
-        prot_printf(s->out, "%s Append {" SIZE_T_FMT "+}\r\n%s",
+        prot_printf(s->out, "%s Append {%zu+}\r\n%s",
                     tag, strlen(name), name);
 
         /* append the messages */
@@ -7450,7 +7450,7 @@ static void cmd_delete(char *tag, char *name, int localonly, int force)
         if (!s) r = IMAP_SERVER_UNAVAILABLE;
 
         if (!r) {
-            prot_printf(s->out, "%s DELETE {" SIZE_T_FMT "+}\r\n%s\r\n",
+            prot_printf(s->out, "%s DELETE {%zu+}\r\n%s\r\n",
                         tag, strlen(origname), origname);
             res = pipe_until_tag(s, tag, 0);
 
@@ -8667,8 +8667,8 @@ static void cmd_changeusergroup(char *tag, char *userid, char *group, int add)
 
         if (!r) {
             prot_printf(backend_inbox->out,
-                        "%s %s {" SIZE_T_FMT "+}\r\n%s"
-                        " {" SIZE_T_FMT "+}\r\n%s\r\n",
+                        "%s %s {%zu+}\r\n%s"
+                        " {%zu+}\r\n%s\r\n",
                         tag, cmd,
                         strlen(userid), userid,
                         strlen(group), group);
@@ -8725,13 +8725,13 @@ static void cmd_changesub(char *tag, char *namespace, char *name, int add)
         if (!r) {
             if (namespace) {
                 prot_printf(backend_inbox->out,
-                            "%s %s {" SIZE_T_FMT "+}\r\n%s"
-                            " {" SIZE_T_FMT "+}\r\n%s\r\n",
+                            "%s %s {%zu+}\r\n%s"
+                            " {%zu+}\r\n%s\r\n",
                             tag, cmd,
                             strlen(namespace), namespace,
                             strlen(name), name);
             } else {
-                prot_printf(backend_inbox->out, "%s %s {" SIZE_T_FMT "+}\r\n%s\r\n",
+                prot_printf(backend_inbox->out, "%s %s {%zu+}\r\n%s\r\n",
                             tag, cmd,
                             strlen(name), name);
             }
@@ -9074,15 +9074,15 @@ static void cmd_setacl(char *tag, const char *name,
         if (!r) {
             if (rights) {
                 prot_printf(s->out,
-                            "%s Setacl {" SIZE_T_FMT "+}\r\n%s"
-                            " {" SIZE_T_FMT "+}\r\n%s {" SIZE_T_FMT "+}\r\n%s\r\n",
+                            "%s Setacl {%zu+}\r\n%s"
+                            " {%zu+}\r\n%s {%zu+}\r\n%s\r\n",
                             tag, strlen(name), name,
                             strlen(identifier), identifier,
                             strlen(rights), rights);
             } else {
                 prot_printf(s->out,
-                            "%s Deleteacl {" SIZE_T_FMT "+}\r\n%s"
-                            " {" SIZE_T_FMT "+}\r\n%s\r\n",
+                            "%s Deleteacl {%zu+}\r\n%s"
+                            " {%zu+}\r\n%s\r\n",
                             tag, strlen(name), name,
                             strlen(identifier), identifier);
             }
@@ -9243,7 +9243,7 @@ static void cmd_getquota(const char *tag, const char *name)
 
         imapd_check(s, 0);
 
-        prot_printf(s->out, "%s Getquota {" SIZE_T_FMT "+}\r\n%s\r\n",
+        prot_printf(s->out, "%s Getquota {%zu+}\r\n%s\r\n",
                     tag, strlen(name), name);
         pipe_including_tag(s, tag, 0);
 
@@ -9300,7 +9300,7 @@ static void cmd_getquotaroot(const char *tag, const char *name)
         imapd_check(s, 0);
 
         if (!r) {
-            prot_printf(s->out, "%s Getquotaroot {" SIZE_T_FMT "+}\r\n%s\r\n",
+            prot_printf(s->out, "%s Getquotaroot {%zu+}\r\n%s\r\n",
                         tag, strlen(name), name);
             pipe_including_tag(s, tag, 0);
         } else {
@@ -9813,7 +9813,7 @@ static void cmd_status(char *tag, char *name)
             imapd_check(s, TELL_EXPUNGED);
 
             if (!r) {
-                prot_printf(s->out, "%s Status {" SIZE_T_FMT "+}\r\n%s ", tag,
+                prot_printf(s->out, "%s Status {%zu+}\r\n%s ", tag,
                             strlen(name), name);
                 if (!pipe_command(s, 65536)) {
                     pipe_including_tag(s, tag, 0);
@@ -11500,7 +11500,7 @@ static int trashacl(struct protstream *pin, struct protstream *pout,
     memset(&tmp, 0, sizeof(struct buf));
     memset(&user, 0, sizeof(struct buf));
 
-    prot_printf(pout, "ACL0 GETACL {" SIZE_T_FMT "+}\r\n%s\r\n",
+    prot_printf(pout, "ACL0 GETACL {%zu+}\r\n%s\r\n",
                 strlen(mailbox), mailbox);
 
     while(1) {
@@ -11544,8 +11544,8 @@ static int trashacl(struct protstream *pin, struct protstream *pout,
 
                 snprintf(tagbuf, sizeof(tagbuf), "ACL%d", ++i);
 
-                prot_printf(pout, "%s DELETEACL {" SIZE_T_FMT "+}\r\n%s"
-                            " {" SIZE_T_FMT "+}\r\n%s\r\n",
+                prot_printf(pout, "%s DELETEACL {%zu+}\r\n%s"
+                            " {%zu+}\r\n%s\r\n",
                             tagbuf, strlen(mailbox), mailbox,
                             strlen(user.s), user.s);
                 if(c == '\r') {
@@ -11605,8 +11605,8 @@ static int dumpacl(struct protstream *pin, struct protstream *pout,
 
         snprintf(tag, sizeof(tag), "SACL%d", tagnum++);
 
-        prot_printf(pout, "%s SETACL {" SIZE_T_FMT "+}\r\n%s"
-                    " {" SIZE_T_FMT "+}\r\n%s {" SIZE_T_FMT "+}\r\n%s\r\n",
+        prot_printf(pout, "%s SETACL {%zu+}\r\n%s"
+                    " {%zu+}\r\n%s {%zu+}\r\n%s\r\n",
                     tag,
                     strlen(mboxname), mboxname,
                     strlen(acl), acl,
@@ -11808,10 +11808,10 @@ static int xfer_localcreate(struct xfer_header *xfer)
         struct backend *be = xfer->sync_cs.backend;
         if (xfer->topart) {
             /* need to send partition as an atom */
-            prot_printf(be->out, "LC1 LOCALCREATE {" SIZE_T_FMT "+}\r\n%s %s\r\n",
+            prot_printf(be->out, "LC1 LOCALCREATE {%zu+}\r\n%s %s\r\n",
                         strlen(item->extname), item->extname, xfer->topart);
         } else {
-            prot_printf(be->out, "LC1 LOCALCREATE {" SIZE_T_FMT "+}\r\n%s\r\n",
+            prot_printf(be->out, "LC1 LOCALCREATE {%zu+}\r\n%s\r\n",
                         strlen(item->extname), item->extname);
         }
         r = getresult(be->in, "LC1");
@@ -11939,7 +11939,7 @@ static int xfer_undump(struct xfer_header *xfer)
         /* Step 4: Dump local -> remote */
         if (!r) {
             struct backend *be = xfer->sync_cs.backend;
-            prot_printf(be->out, "D01 UNDUMP {" SIZE_T_FMT "+}\r\n%s ",
+            prot_printf(be->out, "D01 UNDUMP {%zu+}\r\n%s ",
                         strlen(item->extname), item->extname);
 
             r = dump_mailbox(NULL, mailbox, 0, xfer->remoteversion,
@@ -12346,7 +12346,7 @@ static int xfer_reactivate(struct xfer_header *xfer)
         }
 
         struct backend *be = xfer->sync_cs.backend;
-        prot_printf(be->out, "MP1 MUPDATEPUSH {" SIZE_T_FMT "+}\r\n%s\r\n",
+        prot_printf(be->out, "MP1 MUPDATEPUSH {%zu+}\r\n%s\r\n",
                     strlen(item->extname), item->extname);
         r = getresult(be->in, "MP1");
         if (r) {
@@ -12413,7 +12413,7 @@ static void xfer_recover(struct xfer_header *xfer)
             if (!xfer->use_replication) {
                 /* Delete remote mailbox */
                 prot_printf(xfer->sync_cs.backend->out,
-                            "LD1 LOCALDELETE {" SIZE_T_FMT "+}\r\n%s\r\n",
+                            "LD1 LOCALDELETE {%zu+}\r\n%s\r\n",
                             strlen(item->extname), item->extname);
                 r = getresult(xfer->sync_cs.backend->in, "LD1");
                 if (r) {
@@ -12491,7 +12491,7 @@ static int xfer_setquotaroot(struct xfer_header *xfer, const char *mboxname)
     /* note use of + to force the setting of a nonexistent
      * quotaroot */
     char *extname = mboxname_to_external(mboxname, &imapd_namespace, imapd_userid);
-    prot_printf(xfer->sync_cs.backend->out, "Q01 SETQUOTA {" SIZE_T_FMT "+}\r\n+%s ",
+    prot_printf(xfer->sync_cs.backend->out, "Q01 SETQUOTA {%zu+}\r\n+%s ",
                 strlen(extname)+1, extname);
     free(extname);
     print_quota_limits(xfer->sync_cs.backend->out, &q);
@@ -14721,7 +14721,7 @@ static void cmd_replace(char *tag, char *seqno, char *name, int usinguid)
 
             if (s == backend_current) {
                 /* Simply send the REPLACE to the backend */
-                prot_printf(s->out, "%s Replace %s {" SIZE_T_FMT "+}\r\n%s ",
+                prot_printf(s->out, "%s Replace %s {%zu+}\r\n%s ",
                             tag, seqno, strlen(name), name);
                 if (!(r = pipe_command(s, 16384))) {
                     pipe_including_tag(s, tag, 0);
@@ -14734,8 +14734,8 @@ static void cmd_replace(char *tag, char *seqno, char *name, int usinguid)
                     ((mbentry_t *) backend_current->context)->name :
                     index_mboxname(imapd_index);
 
-                prot_printf(s->out, "%s Localappend {" SIZE_T_FMT "+}\r\n%s"
-                            " {" SIZE_T_FMT "+}\r\n%s ",
+                prot_printf(s->out, "%s Localappend {%zu+}\r\n%s"
+                            " {%zu+}\r\n%s ",
                             tag, strlen(name), name,
                             strlen(cur_name), cur_name);
 

--- a/imap/jmap_mail_submission.c
+++ b/imap/jmap_mail_submission.c
@@ -382,7 +382,7 @@ static int store_submission(jmap_req_t *req, struct mailbox *mailbox,
             "From: %s\r\n"
             "Subject: JMAP EmailSubmission for %s\r\n"
             "Content-Type: message/rfc822\r\n"
-            "Content-Length: " SIZE_T_FMT "\r\n"
+            "Content-Length: %zu\r\n"
             "%s: ", datestr, from,
             json_string_value(json_object_get(emailsubmission, "emailId")),
             msglen, JMAP_SUBMISSION_HDR);

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -479,8 +479,8 @@ static int cache_parserecord(struct mappedfile *cachefile, uint64_t cache_offset
         /* bounds checking */
         if (offset >= buf_size) {
             xsyslog(LOG_ERR, "IOERROR: offset greater than cache size",
-                             "offset=<" SIZE_T_FMT "> "
-                             "buf_size=<" SIZE_T_FMT "> "
+                             "offset=<%zu> "
+                             "buf_size=<%zu> "
                              "cache_ent=<%d>",
                              offset, buf_size, cache_ent);
             return IMAP_IOERROR;
@@ -488,9 +488,9 @@ static int cache_parserecord(struct mappedfile *cachefile, uint64_t cache_offset
 
         if (offset + CACHE_ITEM_SIZE_SKIP + CACHE_ITEM_LEN(cacheitem) > buf_size) {
             xsyslog(LOG_ERR, "IOERROR: cache entry truncated",
-                             "offset=<" SIZE_T_FMT "> "
+                             "offset=<%zu> "
                              "length=<%u> "
-                             "buf_size=<" SIZE_T_FMT "> "
+                             "buf_size=<%zu> "
                              "cache_ent=<%d>",
                              offset, CACHE_ITEM_LEN(cacheitem),
                              buf_size, cache_ent);
@@ -566,7 +566,7 @@ static int cache_append_record(struct mappedfile *mf, struct index_record *recor
 
     n = mappedfile_pwritebuf(mf, buf, offset);
     if (n < 0) {
-        syslog(LOG_ERR, "failed to append " SIZE_T_FMT " bytes to cache", buf->len);
+        syslog(LOG_ERR, "failed to append %zu bytes to cache", buf->len);
         return IMAP_IOERROR;
     }
 

--- a/imap/mbdump.c
+++ b/imap/mbdump.c
@@ -383,7 +383,7 @@ static int dump_file(int first, int sync,
 
     /* send: name, size, and contents */
     if (first) {
-        prot_printf(pout, " {" SIZE_T_FMT "}\r\n", strlen(ftag));
+        prot_printf(pout, " {%zu}\r\n", strlen(ftag));
 
         if (sync) {
             /* synchronize */
@@ -399,7 +399,7 @@ static int dump_file(int first, int sync,
         prot_printf(pout, "%s {%lu%s}\r\n",
                     ftag, (long unsigned)len, (sync ? "+" : ""));
     } else {
-        prot_printf(pout, " {" SIZE_T_FMT "%s}\r\n%s {%lu%s}\r\n",
+        prot_printf(pout, " {%zu%s}\r\n%s {%lu%s}\r\n",
                     strlen(ftag), (sync ? "+" : ""),
                     ftag, (long unsigned)len, (sync ? "+" : ""));
     }

--- a/imap/mbexamine.c
+++ b/imap/mbexamine.c
@@ -164,7 +164,7 @@ static void usage(void)
 
 static void print_rec(const char *name, const struct buf *citem)
 {
-    printf(" %s>{" SIZE_T_FMT "}%.*s\n", name, citem->len, (int)citem->len, citem->s);
+    printf(" %s>{%zu}%.*s\n", name, citem->len, (int)citem->len, citem->s);
 }
 
 /*

--- a/imap/mupdate-client.c
+++ b/imap/mupdate-client.c
@@ -180,9 +180,9 @@ EXPORTED int mupdate_activate(mupdate_handle *handle,
 
     prot_printf(handle->conn->out,
                 "X%u ACTIVATE "
-                "{" SIZE_T_FMT "+}\r\n%s "
-                "{" SIZE_T_FMT "+}\r\n%s "
-                "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                "{%zu+}\r\n%s "
+                "{%zu+}\r\n%s "
+                "{%zu+}\r\n%s\r\n",
                 handle->tagn++,
                 strlen(mailbox), mailbox,
                 strlen(location), location,
@@ -242,8 +242,8 @@ HIDDEN int mupdate_reserve(mupdate_handle *handle,
 
     prot_printf(handle->conn->out,
                 "X%u RESERVE "
-                "{" SIZE_T_FMT "+}\r\n%s "
-                "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                "{%zu+}\r\n%s "
+                "{%zu+}\r\n%s\r\n",
                 handle->tagn++,
                 strlen(mailbox), mailbox,
                 strlen(location), location
@@ -302,8 +302,8 @@ EXPORTED int mupdate_deactivate(mupdate_handle *handle,
 
     prot_printf(handle->conn->out,
             "X%u DEACTIVATE "
-            "{" SIZE_T_FMT "+}\r\n%s "
-            "{" SIZE_T_FMT "+}\r\n%s\r\n",
+            "{%zu+}\r\n%s "
+            "{%zu+}\r\n%s\r\n",
             handle->tagn++,
             strlen(mailbox), mailbox,
             strlen(location), location
@@ -338,7 +338,7 @@ EXPORTED int mupdate_delete(mupdate_handle *handle,
     if (!handle->saslcompleted) return MUPDATE_NOAUTH;
 
     prot_printf(handle->conn->out,
-                "X%u DELETE {" SIZE_T_FMT "+}\r\n%s\r\n", handle->tagn++,
+                "X%u DELETE {%zu+}\r\n%s\r\n", handle->tagn++,
                 strlen(mailbox), mailbox);
 
     ret = mupdate_scarf(handle, mupdate_scarf_one, NULL, 1, &response);
@@ -407,7 +407,7 @@ EXPORTED int mupdate_find(mupdate_handle *handle, const char *mailbox,
     }
 
     prot_printf(handle->conn->out,
-                "X%u FIND {" SIZE_T_FMT "+}\r\n%s\r\n", handle->tagn++,
+                "X%u FIND {%zu+}\r\n%s\r\n", handle->tagn++,
                 strlen(mailbox), mailbox);
 
     memset(&(handle->mailboxdata_buf), 0, sizeof(handle->mailboxdata_buf));
@@ -448,7 +448,7 @@ EXPORTED int mupdate_list(mupdate_handle *handle, mupdate_callback callback,
 
     if (prefix) {
         prot_printf(handle->conn->out,
-                    "X%u LIST {" SIZE_T_FMT "+}\r\n%s\r\n", handle->tagn++,
+                    "X%u LIST {%zu+}\r\n%s\r\n", handle->tagn++,
                     strlen(prefix), prefix);
     } else {
         prot_printf(handle->conn->out,
@@ -752,7 +752,7 @@ EXPORTED void kick_mupdate(void)
     buf_appendcstr(&addrbuf, FNAME_MUPDATE_TARGET_SOCK);
     if (buf_len(&addrbuf) >= sizeof(srvaddr.sun_path)) {
         syslog(LOG_ERR, "kick_mupdate: configured socket path '%s' is too long"
-                        " (maximum length is " SIZE_T_FMT ")",
+                        " (maximum length is %zu)",
                         buf_cstring(&addrbuf), sizeof(srvaddr.sun_path) - 1);
         fatal("socket path too long", EX_CONFIG);
     }

--- a/imap/mupdate.c
+++ b/imap/mupdate.c
@@ -1702,9 +1702,9 @@ static void cmd_find(struct conn *C, const char *tag, const char *mailbox,
     if (m && m->t == SET_ACTIVE) {
         prot_printf(C->pout,
                 "%s MAILBOX "
-                "{" SIZE_T_FMT "+}\r\n%s "
-                "{" SIZE_T_FMT "+}\r\n%s "
-                "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                "{%zu+}\r\n%s "
+                "{%zu+}\r\n%s "
+                "{%zu+}\r\n%s\r\n",
                 tag,
                 strlen(m->mailbox), m->mailbox,
                 strlen(m->location), m->location,
@@ -1714,8 +1714,8 @@ static void cmd_find(struct conn *C, const char *tag, const char *mailbox,
     } else if (m && m->t == SET_RESERVE) {
         prot_printf(C->pout,
                 "%s RESERVE "
-                "{" SIZE_T_FMT "+}\r\n%s "
-                "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                "{%zu+}\r\n%s "
+                "{%zu+}\r\n%s\r\n",
                 tag,
                 strlen(m->mailbox), m->mailbox,
                 strlen(m->location), m->location
@@ -1724,7 +1724,7 @@ static void cmd_find(struct conn *C, const char *tag, const char *mailbox,
         /* not found, if needed, send a delete */
         prot_printf(C->pout,
                 "%s DELETE "
-                "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                "{%zu+}\r\n%s\r\n",
                 tag,
                 strlen(mailbox), mailbox
             );
@@ -1759,9 +1759,9 @@ static int sendupdate(const mbentry_t *mbentry, void *rock)
             case SET_ACTIVE:
                 prot_printf(C->pout,
                         "%s MAILBOX "
-                        "{" SIZE_T_FMT "+}\r\n%s "
-                        "{" SIZE_T_FMT "+}\r\n%s "
-                        "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                        "{%zu+}\r\n%s "
+                        "{%zu+}\r\n%s "
+                        "{%zu+}\r\n%s\r\n",
                         C->streaming,
                         strlen(m->mailbox), m->mailbox,
                         strlen(m->location), m->location,
@@ -1772,8 +1772,8 @@ static int sendupdate(const mbentry_t *mbentry, void *rock)
             case SET_RESERVE:
                 prot_printf(C->pout,
                         "%s RESERVE "
-                        "{" SIZE_T_FMT "+}\r\n%s "
-                        "{" SIZE_T_FMT "+}\r\n%s\r\n",
+                        "{%zu+}\r\n%s "
+                        "{%zu+}\r\n%s\r\n",
                         C->streaming,
                         strlen(m->mailbox), m->mailbox,
                         strlen(m->location), m->location

--- a/imap/prometheus.c
+++ b/imap/prometheus.c
@@ -73,7 +73,7 @@ static void prometheus_init(void)
 
     r = snprintf(stats.ident, sizeof(stats.ident), "%s", config_ident);
     if (r < 0 || (size_t) r >= sizeof(stats.ident))
-        syslog(LOG_WARNING, "service name '%s' is longer than " SIZE_T_FMT
+        syslog(LOG_WARNING, "service name '%s' is longer than %zu"
                             " characters - prometheus label will be truncated",
                             config_ident,
                             sizeof(stats.ident) - 1);
@@ -95,7 +95,7 @@ static void prometheus_init(void)
 
     r = mappedfile_pwrite(handle->mf, &stats, sizeof(stats), 0);
     if (r != sizeof(stats)) {
-        syslog(LOG_ERR, "IOERROR: mappedfile_pwrite: expected to write " SIZE_T_FMT "bytes, "
+        syslog(LOG_ERR, "IOERROR: mappedfile_pwrite: expected to write %zubytes, "
                         "actually wrote %d",
                         sizeof(stats), r);
         goto error;
@@ -198,7 +198,7 @@ static void prometheus_done(void *rock __attribute__((unused)))
     /* and write it out */
     r = mappedfile_pwrite(doneprocs, &accum, sizeof(accum), 0);
     if (r != sizeof(accum)) {
-        syslog(LOG_ERR, "IOERROR: mappedfile_pwrite: expected to write " SIZE_T_FMT "bytes, "
+        syslog(LOG_ERR, "IOERROR: mappedfile_pwrite: expected to write %zubytes, "
                         "actually wrote %d",
                         sizeof(accum), r);
         goto done;
@@ -266,7 +266,7 @@ EXPORTED void prometheus_apply_delta(enum prom_metric_id metric_id,
     r = mappedfile_pwrite(promhandle->mf, &metric, sizeof(metric), offset);
     if (r != sizeof(metric)) {
         syslog(LOG_ERR, "IOERROR: mappedfile_pwrite: expected to write "
-                        SIZE_T_FMT " bytes, actually wrote %d",
+                        "%zu bytes, actually wrote %d",
                         sizeof(metric), r);
     }
     else {

--- a/imap/promstatsd.c
+++ b/imap/promstatsd.c
@@ -182,8 +182,8 @@ static int promdir_foreach(promdir_foreach_cb *proc,
             if (mappedfile_size(mf) != 0) {
                 /* if it's not empty, that's a surprise! */
                 xsyslog(LOG_DEBUG, "unexpected file size",
-                                   "filename=<%s> expected=<" SIZE_T_FMT ">"
-                                   " actual=<" SIZE_T_FMT ">",
+                                   "filename=<%s> expected=<%zu>"
+                                   " actual=<%zu>",
                                    fname, sizeof(stats), mappedfile_size(mf));
             }
 

--- a/imap/saslclient.c
+++ b/imap/saslclient.c
@@ -207,7 +207,7 @@ HIDDEN int saslclient(sasl_conn_t *conn, struct sasl_cmd_t *sasl_cmd,
 
         /* send to server */
         if (sendliteral) {
-            prot_printf(pout, "{" SIZE_T_FMT "+}\r\n", strlen(base64));
+            prot_printf(pout, "{%zu+}\r\n", strlen(base64));
             prot_flush(pout);
         }
         prot_printf(pout, "%s", base64);

--- a/imap/sieve_db.c
+++ b/imap/sieve_db.c
@@ -574,7 +574,7 @@ static int store_script(struct mailbox *mailbox, struct sieve_data *sdata,
     fprintf(f, "Message-ID: <%s@%s>\r\n", sdata->contentid, config_servername);
 
     fprintf(f, "Content-Type: application/sieve; charset=utf-8\r\n");
-    fprintf(f, "Content-Length: " SIZE_T_FMT "\r\n", datalen);
+    fprintf(f, "Content-Length: %zu\r\n", datalen);
     fprintf(f, "Content-Disposition: attachment;\r\n\tfilename=\"%s%s\"\r\n",
             sdata->id ? sdata->id : makeuuid(), SIEVE_EXTENSION);
     fputs("MIME-Version: 1.0\r\n", f);

--- a/imap/smmapd.c
+++ b/imap/smmapd.c
@@ -231,7 +231,7 @@ static int verify_user(const char *key, struct auth_state *authstate)
 
     char msg[MAX_MAILBOX_PATH+1];
     if (userdeny(mbname_userid(mbname), config_ident, msg, sizeof(msg))) {
-        prot_printf(map_out, SIZE_T_FMT ":NOTFOUND %s,", 9 + strlen(msg), msg);
+        prot_printf(map_out, "%zu:NOTFOUND %s,", 9 + strlen(msg), msg);
         mbname_free(&mbname);
         return -1;
     }
@@ -306,7 +306,7 @@ static int verify_user(const char *key, struct auth_state *authstate)
             goto done;
         }
 
-        snprintf(buf,sizeof(buf),SIZE_T_FMT ":cyrus %s,%c",strlen(key)+6,key,4);
+        snprintf(buf,sizeof(buf),"%zu:cyrus %s,%c",strlen(key)+6,key,4);
         sendto(soc,buf,strlen(buf),0,(struct sockaddr *)&sin,sizeof(sin));
 
         x = sizeof(sfrom);
@@ -398,19 +398,19 @@ static int begin_handling(void)
 
         case 0:
             auditlog_client("ok", key, smmapd_clienthost);
-            prot_printf(map_out, SIZE_T_FMT ":OK %s,", 3+strlen(key), key);
+            prot_printf(map_out, "%zu:OK %s,", 3+strlen(key), key);
             break;
 
         case IMAP_MAILBOX_NONEXISTENT:
             auditlog_client("nonexistent", key, smmapd_clienthost);
-            prot_printf(map_out, SIZE_T_FMT ":NOTFOUND %s,",
+            prot_printf(map_out, "%zu:NOTFOUND %s,",
                         9+strlen(error_message(r)), error_message(r));
             break;
 
         case IMAP_QUOTA_EXCEEDED:
             auditlog_client("overquota", key, smmapd_clienthost);
             if (!config_getswitch(IMAPOPT_LMTP_OVER_QUOTA_PERM_FAILURE)) {
-                prot_printf(map_out, SIZE_T_FMT ":TEMP %s,", strlen(error_message(r))+5,
+                prot_printf(map_out, "%zu:TEMP %s,", strlen(error_message(r))+5,
                             error_message(r));
                 break;
             }
@@ -419,11 +419,11 @@ static int begin_handling(void)
         default:
             auditlog_client("failed", key, smmapd_clienthost);
             if (errstring)
-                prot_printf(map_out, SIZE_T_FMT ":PERM %s (%s),",
+                prot_printf(map_out, "%zu:PERM %s (%s),",
                             5+strlen(error_message(r))+3+strlen(errstring),
                             error_message(r), errstring);
             else
-                prot_printf(map_out, SIZE_T_FMT ":PERM %s,",
+                prot_printf(map_out, "%zu:PERM %s,",
                             5+strlen(error_message(r)), error_message(r));
             /* Malformed netstring: do not re-parse leftover bytes as new requests. */
             if (r == IMAP_PROTOCOL_ERROR)

--- a/imtest/imtest.c
+++ b/imtest/imtest.c
@@ -1865,7 +1865,7 @@ static int append_msg(const char *mbox, int size)
 {
     int lup;
 
-    prot_printf(pout,"A003 APPEND %s (\\Seen) {" SIZE_T_FMT "}\r\n",
+    prot_printf(pout,"A003 APPEND %s (\\Seen) {%zu}\r\n",
                 mbox,size+strlen(HEADERS));
     /* do normal header foo */
     prot_printf(pout,HEADERS);

--- a/lib/auth_pts.c
+++ b/lib/auth_pts.c
@@ -392,7 +392,7 @@ static int ptload(const char *identifier, struct auth_state **state)
     }
 
     if (strlen(fname) >= sizeof(srvaddr.sun_path)) {
-        syslog(LOG_ERR, "ptload(): socket filename %s too long for " SIZE_T_FMT "-byte buffer",
+        syslog(LOG_ERR, "ptload(): socket filename %s too long for %zu-byte buffer",
                         fname, sizeof(srvaddr.sun_path));
         rc = -1;
         goto done;

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -91,8 +91,8 @@ EXPORTED hash_table *construct_hash_table(hash_table *table, size_t size, int us
         if (t->hash_load_warned_at == 0                                 \
             || (int) load_factor > t->hash_load_warned_at) {            \
             xsyslog(LOG_DEBUG, "hash table load factor exceeds 3.0",    \
-                               "table=<%p> entries=<" SIZE_T_FMT ">"    \
-                               " buckets=<" SIZE_T_FMT "> load=<%.2g>", \
+                               "table=<%p> entries=<%zu>"    \
+                               " buckets=<%zu> load=<%.2g>", \
                                t, t->count, t->size, load_factor);      \
             t->hash_load_warned_at = (int) load_factor;                 \
         }                                                               \

--- a/lib/mappedfile.c
+++ b/lib/mappedfile.c
@@ -328,7 +328,7 @@ EXPORTED ssize_t mappedfile_pwrite(struct mappedfile *mf,
     written = retry_write(mf->fd, base, len);
     if (written < 0) {
         xsyslog(LOG_ERR, "IOERROR: retry_write failed",
-                         "filename=<%s> len=<" SIZE_T_FMT ">"
+                         "filename=<%s> len=<%zu>"
                             " offset=<" OFF_T_FMT ">",
                          mf->fname, len, offset);
         return -1;
@@ -381,7 +381,7 @@ EXPORTED ssize_t mappedfile_pwritev(struct mappedfile *mf,
             len += iov[i].iov_len;
         }
         xsyslog(LOG_ERR, "IOERROR: retry_writev failed",
-                         "filename=<%s> len=<" SIZE_T_FMT ">"
+                         "filename=<%s> len=<%zu>"
                             " offset=<" OFF_T_FMT ">",
                          mf->fname, len, offset);
         return -1;

--- a/lib/prot.c
+++ b/lib/prot.c
@@ -1264,9 +1264,9 @@ EXPORTED int prot_printliteral(struct protstream *out, const char *s, size_t siz
 {
     int r;
     if (out->isclient)
-        r = prot_printf(out, "{" SIZE_T_FMT "+}\r\n", size);
+        r = prot_printf(out, "{%zu+}\r\n", size);
     else
-        r = prot_printf(out, "{" SIZE_T_FMT "}\r\n", size);
+        r = prot_printf(out, "{%zu}\r\n", size);
     if (r) return r;
     return prot_write(out, s, size);
 }

--- a/lib/sqldb.c
+++ b/lib/sqldb.c
@@ -343,7 +343,7 @@ static void buf_replace_bindvals(struct buf *cmd, struct sqldb_bindval bval[])
             break;
 
         case SQLITE_BLOB:
-            buf_printf(&buf, "<" SIZE_T_FMT " bytes>", buf_len(&bval->val.b));
+            buf_printf(&buf, "<%zu bytes>", buf_len(&bval->val.b));
             break;
         }
 


### PR DESCRIPTION
No need to probe for a format string for *printf for values type size_t, as C99 provides the size modifier 'z'.

The analogous probes for time_t, off_t and rlim_t are still needed, as C has not standardised these.

Remove the macro strtosizet() which was never used, as its definition is part of the stanza that calculated SIZE_T_FMT.