### PR TITLE
http_caldav.c: remove support for the PATCH method

### DIFF
--- a/changes/next/cyr-2749-remove-caldav-patch
+++ b/changes/next/cyr-2749-remove-caldav-patch
@@ -1,0 +1,26 @@
+
+Description:
+
+Support for the HTTP PATCH method on the CalDAV endpoint has been removed.
+
+No known CalDAV client uses PATCH, and the VPATCH format was never standardized.
+
+
+Documentation:
+
+None.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -132,7 +132,6 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
 
 static int caldav_mkcol(struct mailbox *mailbox);
 static int caldav_post(struct transaction_t *txn);
-static int caldav_patch(struct transaction_t *txn, void *obj);
 static int caldav_put(struct transaction_t *txn, void *obj,
                       struct mailbox *mailbox, const char *resource,
                       void *destdb, unsigned flags);
@@ -276,14 +275,6 @@ static struct mime_type_t caldav_mime_types[] = {
       NULL, &begin_jcal, &end_jcal
     },
     { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
-};
-// clang-format on
-
-// clang-format off
-static struct patch_doc_t caldav_patch_docs[] = {
-    { ICALENDAR_CONTENT_TYPE "; component=VPATCH; optinfo=\"PATCH-VERSION:1\"",
-      &caldav_patch },
-    { NULL, &caldav_patch }
 };
 // clang-format on
 
@@ -573,7 +564,7 @@ static struct meth_params caldav_params = {
     &caldav_delete_cal,
     &caldav_get,
     { CALDAV_LOCATION_OK, MBTYPE_CALENDAR, &caldav_mkcol },
-    caldav_patch_docs,
+    NULL,                                       /* No PATCH handling */
     { POST_ADDMEMBER | POST_SHARE, &caldav_post,
       { NS_CALDAV, "calendar-data", &caldav_import } },
     { CALDAV_SUPP_DATA, &caldav_put },
@@ -590,7 +581,7 @@ struct namespace_t namespace_calendar = {
     http_allow_noauth_get, /*authschemes*/0,
     MBTYPE_CALENDAR,
     (ALLOW_READ | ALLOW_POST | ALLOW_WRITE | ALLOW_DELETE |
-     ALLOW_PATCH | ALLOW_USERDATA |
+     ALLOW_USERDATA |
      ALLOW_CAL_AVAIL |
      ALLOW_DAV | ALLOW_PROPPATCH | ALLOW_MKCOL | ALLOW_ACL | ALLOW_CAL ),
     &my_caldav_init, &my_caldav_auth, my_caldav_reset, &my_caldav_shutdown,
@@ -608,7 +599,7 @@ struct namespace_t namespace_calendar = {
         { &meth_mkcol,          &caldav_params },       /* MKCOL        */
         { &meth_copy_move,      &caldav_params },       /* MOVE         */
         { &meth_options_cal,    &caldav_params },       /* OPTIONS      */
-        { &meth_patch,          &caldav_params },       /* PATCH        */
+        { NULL,                 NULL           },       /* PATCH        */
         { &meth_post,           &caldav_params },       /* POST         */
         { &meth_propfind,       &caldav_params },       /* PROPFIND     */
         { &meth_proppatch,      &caldav_params },       /* PROPPATCH    */
@@ -887,7 +878,7 @@ static int caldav_parse_path(const char *path, struct request_target_t *tgt,
     }
     else if (tgt->resource) {
         /* Resource in regular calendar collection (POST for managed attach) */
-        tgt->allow |= (namespace_calendar.allow & ALLOW_PATCH) | ALLOW_POST;
+        tgt->allow |= ALLOW_POST;
     }
 
     return 0;
@@ -3709,68 +3700,6 @@ static int caldav_post(struct transaction_t *txn)
     }
 
     return ret;
-}
-
-
-/* Perform a PATCH request
- *
- * preconditions:
- */
-static int caldav_patch(struct transaction_t *txn, void *obj)
-{
-    icalcomponent *ical = (icalcomponent *) obj;
-    icalcomponent *pdoc, *vpatch;
-    icalproperty *prop;
-    int num_changes = 0;
-    int ret = 0;
-
-    /* Validate the iCal patch */
-    pdoc = ical_string_as_icalcomponent(&txn->req_body.payload);
-    if (!pdoc || (icalcomponent_isa(pdoc) != ICAL_VCALENDAR_COMPONENT)) {
-        txn->error.desc = "Missing VCALENDAR";
-        txn->error.precond = CALDAV_VALID_DATA;
-        ret = HTTP_BAD_REQUEST;
-    }
-    else if (!icalrestriction_check(pdoc) || icalcomponent_count_errors(pdoc)) {
-        if ((txn->error.desc = get_icalcomponent_errstr(pdoc, ICAL_SUPPORT_STRICT)) ||
-            (txn->error.desc =
-             get_icalcomponent_errstr(icalcomponent_get_first_real_component(pdoc),
-                 ICAL_SUPPORT_STRICT))) {
-            buf_setcstr(&txn->buf, txn->error.desc);
-            txn->error.desc = buf_cstring(&txn->buf);
-        }
-        else txn->error.desc = "Error in VPATCH";
-        txn->error.precond = CALDAV_VALID_DATA;
-        ret = HTTP_BAD_REQUEST;
-    }
-    else if (!(vpatch = icalcomponent_get_first_real_component(pdoc)) ||
-             icalcomponent_isa(vpatch) != ICAL_VPATCH_COMPONENT) {
-        txn->error.desc = "Missing VPATCH";
-        txn->error.precond = CALDAV_VALID_DATA;
-        ret = HTTP_BAD_REQUEST;
-    }
-    else if ((prop =
-              icalcomponent_get_first_property(vpatch,
-                                               ICAL_PATCHVERSION_PROPERTY)) &&
-             strcmp(icalproperty_get_patchversion(prop), "1")) {
-        txn->error.desc = "Unsupported PATCH-VERSION";
-        txn->error.precond = CALDAV_SUPP_DATA;
-        ret = HTTP_BAD_REQUEST;
-    }
-    else {
-        ret = icalcomponent_apply_vpatch(ical, vpatch,
-                                         &num_changes, &txn->error.desc);
-    }
-
-    icalcomponent_free(pdoc);
-
-    if (ret) return ret;
-    else if (!num_changes) {
-        /* If no changes are made,
-           return HTTP_NO_CONTENT to suppress storing of resource */
-        return HTTP_NO_CONTENT;
-    }
-    else return 0;
 }
 
 
@@ -8338,10 +8267,6 @@ static int meth_options_cal(struct transaction_t *txn, void *params)
     r = dav_parse_req_target(txn, oparams);
     if (r) return r;
 
-    if (txn->req_tgt.allow & ALLOW_PATCH) {
-        /* Add Accept-Patch formats to response */
-        txn->resp_body.patch = caldav_patch_docs;
-    }
     if (txn->req_tgt.collection && !txn->req_tgt.resource) {
         /* Add subscription upgrade links */
         struct buf link = BUF_INITIALIZER;

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -610,10 +610,10 @@ HIDDEN unsigned long calcarddav_allow_cb(struct request_target_t *tgt)
         allow &= ALLOW_READ_MASK;
     }
     else if (!tgt->collection) {
-        allow &= ~(ALLOW_DELETE | ALLOW_PATCH | ALLOW_POST | ALLOW_WRITE);
+        allow &= ~(ALLOW_DELETE | ALLOW_POST | ALLOW_WRITE);
     }
     else if (!tgt->resource) {
-        allow &= ~(ALLOW_MKCOL | ALLOW_PATCH);
+        allow &= ~ALLOW_MKCOL;
     }
     else {
         allow &= ~(ALLOW_MKCOL | ALLOW_POST);
@@ -1094,7 +1094,6 @@ EXPORTED int dav_check_precond(struct transaction_t *txn,
         case METH_DELETE:
         case METH_LOCK:
         case METH_MOVE:
-        case METH_PATCH:
         case METH_POST:
         case METH_PUT:
             /* State-changing method: Only the lock owner can execute
@@ -1169,7 +1168,6 @@ EXPORTED unsigned get_preferences(struct transaction_t *txn)
     switch (txn->meth) {
     case METH_COPY:
     case METH_MOVE:
-    case METH_PATCH:
     case METH_POST:
     case METH_PUT:
         mask = PREFER_REP;
@@ -2219,10 +2217,6 @@ int propfind_methodset(const xmlChar *name, xmlNsPtr ns,
     if (allow & ALLOW_READ) {
         node = xmlNewChild(top, NULL, BAD_CAST "supported-method", NULL);
         xmlSetProp(node, BAD_CAST "name", BAD_CAST "OPTIONS");
-    }
-    if (allow & ALLOW_PATCH) {
-        node = xmlNewChild(top, NULL, BAD_CAST "supported-method", NULL);
-        xmlSetProp(node, BAD_CAST "name", BAD_CAST "PATCH");
     }
     if (allow & ALLOW_POST) {
         node = xmlNewChild(top, NULL, BAD_CAST "supported-method", NULL);
@@ -6949,232 +6943,6 @@ int meth_post(struct transaction_t *txn, void *params)
 }
 
 
-/* Perform a PATCH request
- *
- * preconditions:
- */
-int meth_patch(struct transaction_t *txn, void *params)
-{
-    struct meth_params *pparams = (struct meth_params *) params;
-    int ret, r, precond, rights;
-    const char **hdr, *etag;
-    struct patch_doc_t *patch_doc = NULL;
-    struct mailbox *mailbox = NULL;
-    struct dav_data *ddata;
-    struct index_record oldrecord;
-    time_t lastmod;
-    unsigned flags = 0;
-    void *davdb = NULL, *obj = NULL;
-    struct buf msg_buf = BUF_INITIALIZER;
-
-    /* Response should not be cached */
-    txn->flags.cc |= CC_NOCACHE;
-
-    /* Parse the path */
-    r = dav_parse_req_target(txn, pparams);
-    if (r) return r;
-
-    /* Make sure method is allowed (only allowed on resources) */
-    if (!(txn->req_tgt.allow & ALLOW_PATCH)) return HTTP_NOT_ALLOWED;
-
-    /* Check Content-Type */
-    if ((hdr = spool_getheader(txn->req_hdrs, "Content-Type"))) {
-        for (patch_doc = pparams->patch_docs; patch_doc->format; patch_doc++) {
-            if (is_mediatype(patch_doc->format, hdr[0])) break;
-        }
-    }
-    if (!patch_doc || !patch_doc->format) {
-        txn->resp_body.patch = pparams->patch_docs;
-        return HTTP_BAD_MEDIATYPE;
-    }
-
-    /* Check ACL for current user */
-    rights = httpd_myrights(httpd_authstate, txn->req_tgt.mbentry);
-    if (!(rights & DACL_WRITECONT)) {
-        /* DAV:need-privileges */
-        txn->error.precond = DAV_NEED_PRIVS;
-        txn->error.resource = txn->req_tgt.path;
-        txn->error.rights = DACL_WRITECONT;
-        return HTTP_NO_PRIVS;
-    }
-
-    if (txn->req_tgt.mbentry->server) {
-        /* Remote mailbox */
-        struct backend *be;
-
-        be = proxy_findserver(txn->req_tgt.mbentry->server,
-                              &http_protocol, httpd_userid,
-                              &backend_cached, NULL, NULL, httpd_in);
-        if (!be) return HTTP_UNAVAILABLE;
-
-        return http_pipe_req_resp(be, txn);
-    }
-
-    /* Local Mailbox */
-
-    /* Read body */
-    txn->req_body.flags |= BODY_DECODE;
-    ret = http_read_req_body(txn);
-    if (ret) {
-        txn->flags.conn = CONN_CLOSE;
-        return ret;
-    }
-
-    /* Check if we can append a new message to mailbox */
-    /* XXX  Can we guess-timate the size difference? */
-    if ((r = append_check(txn->req_tgt.mbentry->name, httpd_authstate,
-                          ACL_INSERT, NULL))) {
-        syslog(LOG_ERR, "append_check(%s) failed: %s",
-               txn->req_tgt.mbentry->name, error_message(r));
-        txn->error.desc = error_message(r);
-        return HTTP_SERVER_ERROR;
-    }
-
-    /* Open mailbox for writing */
-    r = mailbox_open_iwl(txn->req_tgt.mbentry->name, &mailbox);
-    if (r) {
-        syslog(LOG_ERR, "http_mailbox_open(%s) failed: %s",
-               txn->req_tgt.mbentry->name, error_message(r));
-        txn->error.desc = error_message(r);
-        return HTTP_SERVER_ERROR;
-    }
-
-    /* Open the DAV DB corresponding to the mailbox */
-    davdb = pparams->davdb.open_db(mailbox);
-
-    /* Find message UID for the resource */
-    pparams->davdb.lookup_resource(davdb, txn->req_tgt.mbentry,
-                                   txn->req_tgt.resource, (void *) &ddata, 0);
-    if (!ddata->imap_uid) {
-        ret = HTTP_NOT_FOUND;
-        goto done;
-    }
-
-    /* Fetch resource validators */
-    r = pparams->get_validators(mailbox, (void *) ddata, httpd_userid,
-                                &oldrecord, &etag, &lastmod);
-    if (r) {
-        txn->error.desc = error_message(r);
-        ret = HTTP_SERVER_ERROR;
-        goto done;
-    }
-
-    /* Check any preferences */
-    flags = get_preferences(txn);
-
-    /* Check any preconditions */
-    ret = precond = pparams->check_precond(txn, params, mailbox,
-                                           (void *) ddata, etag, lastmod,
-                                           NULL, NULL);
-
-    switch (precond) {
-    case HTTP_PRECOND_FAILED:
-        if (!(flags & PREFER_REP)) goto done;
-
-        /* Fill in ETag and Last-Modified */
-        txn->resp_body.etag = etag;
-        txn->resp_body.lastmod = lastmod;
-
-        /* Fall through and load message */
-        GCC_FALLTHROUGH
-
-    case HTTP_OK: {
-        unsigned offset;
-        struct buf buf = BUF_INITIALIZER;
-
-        /* Load message containing the resource */
-        mailbox_map_record(mailbox, &oldrecord, &msg_buf);
-
-        /* Resource length doesn't include RFC 5322 header */
-        offset = oldrecord.header_size;
-
-        /* Parse existing resource */
-        buf_init_ro(&buf, buf_base(&msg_buf) + offset,
-                    buf_len(&msg_buf) - offset);
-        obj = pparams->mime_types[0].to_object(&buf);
-        buf_free(&buf);
-
-        if (precond == HTTP_OK) {
-            /* Parse, validate, and apply the patch document to the resource */
-            ret = patch_doc->proc(txn, obj);
-            if (!ret) {
-                ret = pparams->put.proc(txn, obj, mailbox,
-                                        txn->req_tgt.resource, davdb, flags);
-                if (ret == HTTP_FORBIDDEN) ret = HTTP_UNPROCESSABLE;
-            }
-        }
-
-        break;
-    }
-
-    case HTTP_LOCKED:
-        txn->error.precond = DAV_NEED_LOCK_TOKEN;
-        txn->error.resource = txn->req_tgt.path;
-
-    default:
-        /* We failed a precondition */
-        goto done;
-    }
-
-    if (flags & PREFER_REP) {
-        struct resp_body_t *resp_body = &txn->resp_body;
-        struct mime_type_t *mime = pparams->mime_types;
-        struct buf *data;
-
-        if ((hdr = spool_getheader(txn->req_hdrs, "Accept"))) {
-            mime = get_accept_type(hdr, pparams->mime_types);
-            if (!mime) goto done;
-        }
-
-        switch (ret) {
-        case HTTP_NO_CONTENT:
-            ret = HTTP_OK;
-
-            GCC_FALLTHROUGH
-
-        case HTTP_CREATED:
-        case HTTP_PRECOND_FAILED:
-            /* Convert into requested MIME type */
-            data = mime->from_object(obj);
-
-            /* Fill in Content-Type, Content-Length */
-            resp_body->type = mime->content_type;
-            resp_body->len = buf_len(data);
-
-            /* Fill in Content-Location */
-            resp_body->loc = txn->req_tgt.path;
-
-            /* Fill in Expires and Cache-Control */
-            resp_body->maxage = 3600;   /* 1 hr */
-            txn->flags.cc = CC_MAXAGE
-                | CC_REVALIDATE         /* don't use stale data */
-                | CC_NOTRANSFORM;       /* don't alter iCal data */
-
-            /* Output current representation */
-            write_body(ret, txn, buf_base(data), buf_len(data));
-
-            buf_destroy(data);
-            ret = 0;
-            break;
-
-        default:
-            /* failure - do nothing */
-            break;
-        }
-    }
-
-  done:
-    if (obj) {
-        if (pparams->mime_types[0].free) pparams->mime_types[0].free(obj);
-        buf_free(&msg_buf);
-    }
-    if (davdb) pparams->davdb.close_db(davdb);
-    mailbox_close(&mailbox);
-
-    return ret;
-}
-
-
 /* Perform a PUT request
  *
  * preconditions:
@@ -7421,11 +7189,6 @@ int meth_put(struct transaction_t *txn, void *params)
     default:
         /* We failed a precondition */
         goto done;
-    }
-
-    if (txn->req_tgt.allow & ALLOW_PATCH) {
-        /* Add Accept-Patch formats to response */
-        txn->resp_body.patch = pparams->patch_docs;
     }
 
     if (flags & PREFER_REP) {

--- a/imap/http_dav.h
+++ b/imap/http_dav.h
@@ -605,7 +605,6 @@ int meth_lock(struct transaction_t *txn, void *params);
 int meth_mkcol(struct transaction_t *txn, void *params);
 int meth_propfind(struct transaction_t *txn, void *params);
 int meth_proppatch(struct transaction_t *txn, void *params);
-int meth_patch(struct transaction_t *txn, void *params);
 int meth_post(struct transaction_t *txn, void *params);
 int meth_put(struct transaction_t *txn, void *params);
 int meth_report(struct transaction_t *txn, void *params);


### PR DESCRIPTION
No known CalDAV client uses PATCH, and the VPATCH format was never standardized.