### PR TITLE
sieve: use imparse_isnumber for match variable references

### DIFF
--- a/cunit/sieve.testc
+++ b/cunit/sieve.testc
@@ -1583,6 +1583,51 @@ static void test_imap4flags_setflag(void)
     /* Test #2 */
 }
 
+static void test_variable_ref_number_out_of_bounds(void)
+{
+    /* Test that variable references out of bounds get handled. */
+    static const struct {
+        const char *body;
+        const char *expect;
+    } cases[] = {
+        /* negative index: this always is illegal, kept verbatim */
+        { "reject \"a:${-5}:b\";\n", "a:${-5}:b" },
+        /* MAX_MATCH_VARS is 9, so "${9}" compiles, but with no prior match
+         * the array is empty and the index is out of bounds -> expands to
+         * empty */
+        { "reject \"a:${9}:b\";\n", "a::b" },
+    };
+
+    static const char MSG[] =
+    "Date: Mon, 13 Jul 2026 08:51:06 -0500\r\n"
+    "From: foo@example.com\r\n"
+    "To: bar@example.com\r\n"
+    "Subject: test\r\n"
+    "\r\n"
+    "test\n"
+    ;
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        struct buf script = BUF_INITIALIZER;
+        sieve_test_context_t ctx;
+
+        buf_setcstr(&script, "require [\"variables\", \"reject\"];\n");
+        buf_appendcstr(&script, cases[i].body);
+
+        context_setup(&ctx, buf_cstring(&script));
+        CU_ASSERT_EQUAL(ctx.stats.errors, 0);
+
+        run_message(&ctx, MSG);
+        CU_ASSERT_EQUAL(ctx.stats.errors, 0);
+        CU_ASSERT_EQUAL(ctx.stats.rejects, 1);
+        CU_ASSERT_PTR_NOT_NULL(ctx.reject_message);
+        CU_ASSERT_STRING_EQUAL(ctx.reject_message, cases[i].expect);
+
+        context_cleanup(&ctx);
+        buf_free(&script);
+    }
+}
+
 static void test_prevars_bad(void)
 {
     sieve_test_context_t ctx;

--- a/sieve/grammar.c
+++ b/sieve/grammar.c
@@ -10,6 +10,7 @@
 #endif
 
 #include "grammar.h"
+#include "imparse.h"
 #include "xmalloc.h"
 
 
@@ -28,16 +29,6 @@ EXPORTED int sieve_is_identifier(char *s)
         }
     }
     return 1;
-}
-
-static int is_number(char *s)
-{
-    char *tail;
-
-    if (s && *s && (strtol(s, &tail, 10) || !*tail) && !*tail) {
-        return 1;
-    }
-    return 0;
 }
 
 /* TODO: implement parse_string() with a proper yacc/bison lexer/parser */
@@ -87,8 +78,8 @@ HIDDEN char *parse_string(const char *s, variable_list_t *vars)
         }
         /* create a null-terminated string for comparison */
         *variable_ref_end = '\0';
-        /* check if the string is a number */
-        is_match_var = is_number(test_str);
+        /* check if the string is a number (RFC 5229 num-variable = 1*DIGIT) */
+        is_match_var = imparse_isnumber(test_str);
         /* if we've found a valid variable, add its value to stringparts */
         if (sieve_is_identifier(test_str) || is_match_var) {
             /* capture the match_var variable number */
@@ -98,7 +89,7 @@ HIDDEN char *parse_string(const char *s, variable_list_t *vars)
             /* attempt to find the variable */
             if (is_match_var) {
                 variable = varlist_select(vars, VL_MATCH_VARS);
-                if (match_var >= variable->var->count) {
+                if (match_var < 0 || match_var >= variable->var->count) {
                     variable = NULL;
                 }
             } else {


### PR DESCRIPTION
RFC 5229 defines a numeric variable reference as one or more digits, but the local is_number() accepted anything strtol() would parse, including a leading minus sign.  Use imparse_isnumber() instead, and check the parsed index against the number of captured match variables.