### PR TITLE
jmap_contact.c: encode content guid in vCard blobIds

### DIFF
--- a/cassandane/tiny-tests/JMAPContacts/card_blobid_reject_legacy_blob_id
+++ b/cassandane/tiny-tests/JMAPContacts/card_blobid_reject_legacy_blob_id
@@ -1,0 +1,54 @@
+#!perl
+use Cassandane::Tiny;
+
+use MIME::Base64 qw(encode_base64url decode_base64url);
+
+# Legacy blobIds for vCard do not encode the vCard content guid in the blobId.
+# This test asserts that such blob_ids are rejected now, a vCard blobId must
+# include the content guid.
+sub test_card_blobid_reject_legacy_blob_id($self)
+{
+    my $jmap = $self->{jmap};
+
+    xlog $self, "Create contact";
+    my $res = $jmap->CallMethods([['ContactCard/set', {
+        create => {
+            "1" => {
+                '@type' => 'Card',
+                version => '1.0',
+                name => { full => "foo last1" }
+            },
+    }}, "R1"]]);
+    my $contactId = $res->[0][1]{created}{1}{id};
+    $self->assert_not_null($contactId);
+
+    xlog $self, "Get blob_id";
+    $res = $jmap->CallMethods([
+        ['ContactCard/get', {
+            ids => [$contactId],
+            properties => ['cyrusimap.org:blobId'],
+        }, 'R2']
+    ]);
+    my $blob_id = $res->[0][1]{list}[0]{'cyrusimap.org:blobId'};
+    $self->assert_not_null($blob_id);
+
+    xlog $self, "Assert that blob_id downloads the vCard";
+    $res = $jmap->Download('cassandane', $blob_id);
+    $self->assert_num_equals(200, $res->{status});
+    $self->assert_str_equals("BEGIN:VCARD", substr($res->{content}, 0, 11));
+
+    xlog $self, "Transform blob_id to legacy blob_id";
+    $self->assert_str_equals('V', substr($blob_id, 0, 1));
+    my $decoded = decode_base64url(substr($blob_id, 1));
+    # The new-style blob_id encodes "M<mboxid>:<uid>SG[<guid>]"; keep only the
+    # mailbox and UID to reconstruct the legacy identifier
+    $self->assert_matches(qr/^M.*:\d+SG\[/, $decoded);
+    my ($legacy) = $decoded =~ /^(M.*:\d+)/;
+    $self->assert_not_null($legacy);
+    my $legacy_blob_id = 'V' . encode_base64url($legacy, '');
+    $self->assert_str_not_equals($blob_id, $legacy_blob_id);
+
+    xlog $self, "The legacy blob_id must not download a vCard";
+    $res = $jmap->Download('cassandane', $legacy_blob_id);
+    $self->assert_num_not_equals(200, $res->{status});
+}

--- a/imap/jmap_contact.c
+++ b/imap/jmap_contact.c
@@ -2991,7 +2991,7 @@ static int getcards_cb(void *rock, struct carddav_data *cdata)
         struct buf blobid = BUF_INITIALIZER;
 
         jmap_encode_rawdata_blobid('V', mbentry->uniqueid, record.uid,
-                                   NULL, NULL, NULL, NULL, &blobid);
+                                   NULL, NULL, "G", &record.guid, &blobid);
         json_object_set_new(obj, "cyrusimap.org:blobId",
                             json_string(buf_cstring(&blobid)));
         buf_free(&blobid);
@@ -4200,7 +4200,7 @@ static int _card_set_create(jmap_req_t *req,
 
     if (jmap_is_using(req, JMAP_CONTACTS_EXTENSION)) {
         jmap_encode_rawdata_blobid('V', mailbox_uniqueid(*mailbox), record.uid,
-                                   NULL, NULL, NULL, NULL, &buf);
+                                   NULL, NULL, "G", &record.guid, &buf);
         json_object_set_new(item, "cyrusimap.org:blobId",
                             json_string(buf_cstring(&buf)));
 
@@ -4586,7 +4586,8 @@ static int _card_set_update(jmap_req_t *req, bool apply_empty_updates,
                                       this_mailbox->i.last_uid, &record);
 
             jmap_encode_rawdata_blobid('V', mailbox_uniqueid(this_mailbox),
-                                       record.uid, NULL, NULL, NULL, NULL, &buf);
+                                       record.uid, NULL, NULL, "G",
+                                       &record.guid, &buf);
             json_object_set_new(*item, "cyrusimap.org:blobId",
                                 json_string(buf_cstring(&buf)));
 
@@ -4858,6 +4859,10 @@ static int jmap_contact_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx)
         res = HTTP_BAD_REQUEST;
         goto done;
     }
+    if (!strcmpsafe(propname, "G")) {
+        // G subpart encodes the guid of the whole vCard blob
+        xzfree(propname);
+    }
 
     if (!propname && ctx->accept_mime) {
         /* Make sure client can handle blob type. */
@@ -4943,6 +4948,12 @@ static int jmap_contact_getblob(jmap_req_t *req, jmap_getblob_context_t *ctx)
     else {
         /* Load message containing the resource */
         struct buf buf = BUF_INITIALIZER;
+
+        /* The blobId encodes the guid of the whole vCard resource */
+        if (!message_guid_equal(&guid, &record.guid)) {
+            res = HTTP_NOT_FOUND;
+            goto done;
+        }
 
         if (mailbox_map_record(mailbox, &record, &buf)) {
             ctx->errstr = "failed to load vCard";


### PR DESCRIPTION
This changes JMAP Contacts to encode the guid of the vCard in its blobId, where before it encoded only the mailbox identifier and record uid.

This is a breaking change: old-style vCard blobIds are now rejected.