### PR TITLE
enable building C++ code with clang++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -515,7 +515,14 @@ if test "x$enable_xapian" != xno ; then
         fi
 
         dnl Xapian requires CXX17
+        dnl this probe breaks under -Werror for clang++, so work around that
+        saved_CFLAGS="$CFLAGS"
+        saved_CPPFLAGS="$CPPFLAGS"
+        CFLAGS="$CFLAGS -Wno-error"
+        CPPFLAGS="$CPPFLAGS -Wno-error"
         AX_CXX_COMPILE_STDCXX(17)
+        CFLAGS="$saved_CFLAGS"
+        CPPFLAGS="$saved_CPPFLAGS"
 
         dnl If AC_PROG_LIBTOOL (or the deprecated older version AM_PROG_LIBTOOL)
         dnl has already been expanded, enable libtool support now, otherwise add


### PR DESCRIPTION
Currently we always build the C++ code with `g++`, even if we're building the C code with `clang`

Fix the two issues that stand in the way of using `clang++`

1. The C++ compiler probe fails for `clang++` under `-Werror` - add `-Wno-error` for that probe
2. util.h contains some `__attribute__` directives to facilitate Cunit testing of `clock_gettime`. `g++` is fine with parsing these, but `clang++` chokes if it sees them