### PR TITLE
Sqldb user data ownership

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -667,6 +667,7 @@ cunit_TESTS = \
     cunit/sessionid.testc \
     cunit/slowio.testc \
     cunit/smallarrayu64.testc \
+    cunit/sqldb.testc \
     cunit/xsyslog_ev.testc
 
 if SIEVE

--- a/cassandane/tiny-tests/Rename/rename_user_then_sync_reset
+++ b/cassandane/tiny-tests/Rename/rename_user_then_sync_reset
@@ -1,0 +1,50 @@
+#!perl
+use Cassandane::Tiny;
+
+# The per-user files are keyed by the INBOX uniqueid, which a rename keeps -
+# and a rename leaves a DELETED tombstone behind at the old name with that
+# same uniqueid.  Resetting the old name must not take out the live user's
+# files.
+sub test_rename_user_then_sync_reset
+    :AllowMoves :NoAltNameSpace
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+
+    my $talk = $self->{store}->get_client();
+    $talk->create("INBOX.sub") || die;
+    $self->{store}->set_folder("INBOX.sub");
+    $self->{store}->write_begin();
+    $self->{store}->write_message($self->{gen}->generate(subject => "subject 1"));
+    $self->{store}->write_end();
+    $talk->logout();
+
+    my $srcpath = $self->{instance}->run_mbpath('-u', 'cassandane');
+
+    $admintalk->rename('user.cassandane', 'user.newuser');
+    $self->assert_str_equals('ok',
+                             $admintalk->get_last_completion_response());
+
+    my $dstpath = $self->{instance}->run_mbpath('-u', 'newuser');
+
+    # with uuid paths the renamed user keeps the very same files
+    $self->assert_str_equals($srcpath->{user}{sub}, $dstpath->{user}{sub});
+
+    my @files = grep { -f $dstpath->{user}{$_} }
+                     qw(conversations counters dav seen sub);
+    $self->assert_num_not_equals(0, scalar @files);
+
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'sync_reset', '-f', 'cassandane');
+
+    foreach my $file (@files) {
+        $self->assert(-f $dstpath->{user}{$file},
+                      "$file survived reset of the old name");
+    }
+
+    # and the live user is still intact
+    my $res = $admintalk->select('user.newuser.sub');
+    $self->assert_str_equals('ok',
+                             $admintalk->get_last_completion_response());
+    $self->assert_num_equals(1, $admintalk->get_response_code('exists'));
+}

--- a/changes/next/user-data-uniqueid-ownership
+++ b/changes/next/user-data-uniqueid-ownership
@@ -1,0 +1,46 @@
+Description:
+
+Deleting a user no longer removes another user's files, and a replaced sqlite
+DB is now reported as such instead of as a generic failure.
+
+The per-user files - dav.db, conversations.db, counters.db, seen.db, sub.db and
+the search indexes - are keyed by the INBOX uniqueid, which survives both a
+rename and a delayed delete.  So a tombstone can name the very same files as a
+live user, and user_deletedata() would happily remove them: "sync_reset" of a
+user which had since been renamed away wiped the renamed user's data, as did a
+DELETE of the old name.  Only the mailbox which still owns the uniqueid now
+removes them, and the refusal is logged.  cyr_expire already made this check
+for itself and is unaffected.
+
+Any process still holding one of those files open then failed every write with
+sqlite's SQLITE_READONLY_DBMOVED, reported only as "DBERROR: step failed".
+sqldb_exec() now returns SQLDB_ERR_DBMOVED and logs that the file was removed
+or replaced.  The open-DB cache is keyed on filename, so it also checked that
+the file it opened is still there before handing a cached handle back out -
+otherwise every later open in that process inherited the dead handle.  This
+also covers dav_reconstruct_user() renaming a rebuilt dav.db into place.
+
+
+Documentation:
+
+(none)
+
+
+Config changes:
+
+(none)
+
+
+Upgrade instructions:
+
+Sites which have renamed users may have lost the renamed user's dav.db,
+conversations.db, counters.db, seen.db or search index to a later "sync_reset"
+or DELETE of the old name.  A "dav_reconstruct -u <user>" rebuilds dav.db,
+"ctl_conversationsdb -b -u <user>" the conversations DB, and "squatter -u
+<user>" the search index; seen state and subscriptions can only come back from
+a replica or a backup.
+
+
+GitHub issue:
+
+(none)

--- a/cunit/sqldb.testc
+++ b/cunit/sqldb.testc
@@ -1,0 +1,233 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "config.h"
+#include "cunit/unit.h"
+#include "sqldb.h"
+
+#define DBDIR                   "test-sqldb-dbdir"
+#define DBFILE                  DBDIR "/test.db"
+#define OTHERFILE               DBDIR "/other.db"
+
+#define CMD_CREATE \
+    "CREATE TABLE IF NOT EXISTS t (" \
+    " k TEXT PRIMARY KEY," \
+    " v TEXT NOT NULL );"
+
+#define CMD_INSERT \
+    "INSERT OR REPLACE INTO t ( k, v ) VALUES ( :k, :v );"
+
+#define CMD_COUNT \
+    "SELECT COUNT(*) FROM t;"
+
+static sqldb_t *open_db(const char *fname)
+{
+    return sqldb_open(fname, CMD_CREATE, 1, NULL, SQLDB_DEFAULT_TIMEOUT);
+}
+
+static int write_row(sqldb_t *db, const char *key)
+{
+    struct sqldb_bindval bval[] = {
+        { ":k", SQLITE_TEXT, { .s = key      } },
+        { ":v", SQLITE_TEXT, { .s = "value"  } },
+        { NULL, SQLITE_NULL, { .s = NULL     } }
+    };
+
+    return sqldb_exec(db, CMD_INSERT, bval, NULL, NULL);
+}
+
+static int count_cb(sqlite3_stmt *stmt, void *rock)
+{
+    *((int *) rock) = sqlite3_column_int(stmt, 0);
+    return 0;
+}
+
+static int count_rows(sqldb_t *db)
+{
+    int count = -1;
+    int r = sqldb_exec(db, CMD_COUNT, NULL, &count_cb, &count);
+    return r ? -1 : count;
+}
+
+/* two opens of the same file share one handle, usable until the last close */
+static void test_refcount(void)
+{
+    sqldb_t *db1 = open_db(DBFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db1);
+
+    sqldb_t *db2 = open_db(DBFILE);
+    CU_ASSERT_PTR_EQUAL_FATAL(db2, db1);
+
+    /* n.b. close only clears the caller's pointer on the last reference */
+    CU_ASSERT_EQUAL(sqldb_close(&db2), SQLDB_OK);
+
+    CU_ASSERT_EQUAL(write_row(db1, "one"), SQLDB_OK);
+    CU_ASSERT_EQUAL(count_rows(db1), 1);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db1), SQLDB_OK);
+}
+
+/* a write through a handle whose file was unlinked reports SQLDB_ERR_DBMOVED */
+static void test_write_after_unlink(void)
+{
+    sqldb_t *db = open_db(DBFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+    CU_ASSERT_EQUAL(write_row(db, "one"), SQLDB_OK);
+
+    CU_ASSERT_EQUAL_FATAL(unlink(DBFILE), 0);
+
+    CU_ASSERT_EQUAL(write_row(db, "two"), SQLDB_ERR_DBMOVED);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db), SQLDB_OK);
+}
+
+/* the cache must not hand back a handle onto an unlinked inode */
+static void test_reopen_after_unlink(void)
+{
+    sqldb_t *db = open_db(DBFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+    CU_ASSERT_EQUAL(write_row(db, "one"), SQLDB_OK);
+
+    CU_ASSERT_EQUAL_FATAL(unlink(DBFILE), 0);
+
+    sqldb_t *db2 = open_db(DBFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db2);
+    CU_ASSERT_PTR_NOT_EQUAL_FATAL(db2, db);
+
+    /* the fresh handle is on a brand new file, and writable */
+    CU_ASSERT_EQUAL(count_rows(db2), 0);
+    CU_ASSERT_EQUAL(write_row(db2, "two"), SQLDB_OK);
+    CU_ASSERT_EQUAL(count_rows(db2), 1);
+
+    /* and a third open shares the fresh handle, not the stale one */
+    sqldb_t *db3 = open_db(DBFILE);
+    CU_ASSERT_PTR_EQUAL(db3, db2);
+    CU_ASSERT_EQUAL(sqldb_close(&db3), SQLDB_OK);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db2), SQLDB_OK);
+    CU_ASSERT_EQUAL(sqldb_close(&db), SQLDB_OK);
+}
+
+/* likewise when the file was replaced rather than removed */
+static void test_reopen_after_replace(void)
+{
+    sqldb_t *db = open_db(DBFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+    CU_ASSERT_EQUAL(write_row(db, "one"), SQLDB_OK);
+
+    sqldb_t *other = open_db(OTHERFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(other);
+    CU_ASSERT_EQUAL(write_row(other, "one"), SQLDB_OK);
+    CU_ASSERT_EQUAL(write_row(other, "two"), SQLDB_OK);
+    CU_ASSERT_EQUAL(sqldb_close(&other), SQLDB_OK);
+
+    CU_ASSERT_EQUAL_FATAL(rename(OTHERFILE, DBFILE), 0);
+
+    sqldb_t *db2 = open_db(DBFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db2);
+    CU_ASSERT_PTR_NOT_EQUAL_FATAL(db2, db);
+    CU_ASSERT_EQUAL(count_rows(db2), 2);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db2), SQLDB_OK);
+    CU_ASSERT_EQUAL(sqldb_close(&db), SQLDB_OK);
+}
+
+/* a tagged handle is findable by scope and owner */
+static void test_scope(void)
+{
+    sqldb_t *db = sqldb_open_full(DBFILE, CMD_CREATE, 1, NULL,
+                                  SQLDB_DEFAULT_TIMEOUT,
+                                  SQLDB_SCOPE_USER, "bob");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_USER, "bob"), 1);
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_USER, "alice"), 0);
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_MAILBOX, "bob"), 0);
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_GLOBAL, NULL), 0);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db), SQLDB_OK);
+
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_USER, "bob"), 0);
+}
+
+/* an untagged open has no scope to be found by */
+static void test_scope_untagged(void)
+{
+    sqldb_t *db = open_db(DBFILE);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_USER, "bob"), 0);
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_NONE, NULL), 0);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db), SQLDB_OK);
+}
+
+/* a stale handle is already stranded, so it doesn't count */
+static void test_scope_ignores_stale(void)
+{
+    sqldb_t *db = sqldb_open_full(DBFILE, CMD_CREATE, 1, NULL,
+                                  SQLDB_DEFAULT_TIMEOUT,
+                                  SQLDB_SCOPE_USER, "bob");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+    CU_ASSERT_EQUAL_FATAL(unlink(DBFILE), 0);
+
+    sqldb_t *db2 = sqldb_open_full(DBFILE, CMD_CREATE, 1, NULL,
+                                   SQLDB_DEFAULT_TIMEOUT,
+                                   SQLDB_SCOPE_USER, "bob");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db2);
+    CU_ASSERT_PTR_NOT_EQUAL_FATAL(db2, db);
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_USER, "bob"), 1);
+
+    /* db is still held, but it's stale, so nobody is left to strand */
+    CU_ASSERT_EQUAL(sqldb_close(&db2), SQLDB_OK);
+    CU_ASSERT_EQUAL(sqldb_isopen_forscope(SQLDB_SCOPE_USER, "bob"), 0);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db), SQLDB_OK);
+}
+
+/* in-memory databases have no file to check */
+static void test_memory(void)
+{
+    sqldb_t *db = open_db(":memory:");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(db);
+
+    sqldb_t *db2 = open_db(":memory:");
+    CU_ASSERT_PTR_EQUAL_FATAL(db2, db);
+
+    CU_ASSERT_EQUAL(write_row(db, "one"), SQLDB_OK);
+    CU_ASSERT_EQUAL(count_rows(db2), 1);
+
+    CU_ASSERT_EQUAL(sqldb_close(&db2), SQLDB_OK);
+    CU_ASSERT_EQUAL(sqldb_close(&db), SQLDB_OK);
+}
+
+static int set_up(void)
+{
+    int r = system("rm -rf " DBDIR);
+    if (r) return r;
+
+    r = mkdir(DBDIR, 0777);
+    if (r < 0) {
+        int e = errno;
+        perror(DBDIR);
+        return e;
+    }
+
+    sqldb_init();
+
+    return 0;
+}
+
+static int tear_down(void)
+{
+    int r;
+
+    sqldb_done();
+
+    r = system("rm -rf " DBDIR);
+    if (r) r = -1;
+
+    return r;
+}
+/* vim: set ft=c: */

--- a/imap/user.c
+++ b/imap/user.c
@@ -42,6 +42,7 @@
 #include "search_engines.h"
 #include "seen.h"
 #include "sievedir.h"
+#include "sqldb.h"
 #include "sync_log.h"
 #include "user.h"
 #include "util.h"
@@ -232,7 +233,30 @@ EXPORTED int user_deletedata(const mbentry_t *mbentry, int wipe_user)
 
     assert(user_nslock_islocked(userid));
 
-    if (!(mbentry->mbtype & MBTYPE_LEGACY_DIRS) && mbentry->uniqueid) {
+    int byid = !(mbentry->mbtype & MBTYPE_LEGACY_DIRS) && mbentry->uniqueid;
+    int shared = 0;
+
+    /* the uniqueid survives a rename and a delayed delete, so a tombstone
+       can name the very same files as a live user.  Only remove them if we
+       still own the uniqueid, e.g. sync_reset of a renamed-away user */
+    if (byid) {
+        mbentry_t *owner = NULL;
+        if (!mboxlist_lookup_by_uniqueid(mbentry->uniqueid, &owner, NULL)
+            && strcmpsafe(owner->name, mbentry->name)
+            && !mboxname_isdeletedmailbox(owner->name, NULL)) {
+            xsyslog(LOG_ERR, "keeping user files still owned by another mailbox",
+                             "userid=<%s> mboxname=<%s> uniqueid=<%s> ownername=<%s>",
+                             userid, mbentry->name, mbentry->uniqueid,
+                             owner->name);
+            shared = 1;
+        }
+        mboxlist_entry_free(&owner);
+    }
+
+    if (shared) {
+        /* nothing keyed by uniqueid is ours to remove */
+    }
+    else if (byid) {
         for (suffixes = user_file_suffixes; *suffixes; suffixes++) {
             strarray_appendm(&paths,
                              mboxid_conf_getpath(mbentry->uniqueid, *suffixes));
@@ -281,11 +305,18 @@ EXPORTED int user_deletedata(const mbentry_t *mbentry, int wipe_user)
     /* delete quotas */
     user_deletequotaroots(userid);
 
-    /* delete all the search engine data (if any) */
-    search_deluser(mbentry);
+    /* delete all the search engine data (if any) - also keyed by uniqueid */
+    if (!shared) search_deluser(mbentry);
 
     /* delete all the calendar alarms for the user */
     caldav_alarm_delete_user(userid);
+
+    /* a handle held over this write keeps writing to an inode which is no
+       longer there, and only finds out at SQLDB_ERR_DBMOVED time */
+    if (strarray_size(&paths) && sqldb_isopen_forscope(SQLDB_SCOPE_USER, userid)) {
+        xsyslog(LOG_ERR, "removing user files with a sqldb still open on them",
+                         "userid=<%s>", userid);
+    }
 
     /* delete paths in our list */
     /* XXX  MUST do this last in case one of the functions above

--- a/lib/sqldb.c
+++ b/lib/sqldb.c
@@ -54,9 +54,46 @@ static int _free_open(sqldb_t *open)
 {
     int rc = sqlite3_close(open->db);
     free(open->fname);
+    free(open->owner);
     free(open);
     int r = (rc == SQLITE_OK ? SQLDB_OK : SQLDB_ERR_UNKNOWN);
     return r;
+}
+
+/* record which file we opened, for _isunmoved() to compare against.  A zero
+   ino means we couldn't tell, and we skip the check for that handle */
+static void _stampfile(sqldb_t *open)
+{
+    struct stat sbuf;
+
+    if (!*open->fname || !strcmp(open->fname, ":memory:")) return;
+
+    if (stat(open->fname, &sbuf)) {
+        xsyslog(LOG_NOTICE, "couldn't stat sqldb we just opened",
+                            "fname=<%s>", open->fname);
+        return;
+    }
+
+    open->dev = sbuf.st_dev;
+    open->ino = sbuf.st_ino;
+}
+
+/* check that a cached handle still refers to the file it opened.  The cache
+   is keyed on filename, so the file may have been unlinked or replaced, and
+   sqlite fails every write through such a handle with
+   SQLITE_READONLY_DBMOVED */
+static int _isunmoved(sqldb_t *open)
+{
+    struct stat sbuf;
+
+    if (!*open->fname || !strcmp(open->fname, ":memory:")) return 1;
+
+    /* we never got a stat, so we can't tell */
+    if (!open->ino) return 1;
+
+    if (stat(open->fname, &sbuf)) return 0;
+
+    return (sbuf.st_dev == open->dev && sbuf.st_ino == open->ino);
 }
 
 static int _version_cb(void *rock, int ncol, char **vals, char **names __attribute__((unused)))
@@ -74,21 +111,48 @@ EXPORTED sqldb_t *sqldb_open(const char *fname, const char *initsql,
                              int version, const struct sqldb_upgrade *upgrade,
                              int timeout_ms)
 {
+    return sqldb_open_full(fname, initsql, version, upgrade, timeout_ms,
+                           SQLDB_SCOPE_NONE, NULL);
+}
+
+EXPORTED sqldb_t *sqldb_open_full(const char *fname, const char *initsql,
+                                  int version, const struct sqldb_upgrade *upgrade,
+                                  int timeout_ms, int scope, const char *owner)
+{
     int rc = SQLITE_OK;
     struct stat sbuf;
     sqldb_t *open;
     int i;
 
     for (open = open_sqldbs; open; open = open->next) {
-        if (!strcmp(open->fname, fname)) {
-            /* already open! */
-            open->refcount++;
-            return open;
+        if (open->stale) continue;
+        if (strcmp(open->fname, fname)) continue;
+
+        if (!_isunmoved(open)) {
+            xsyslog(LOG_NOTICE, "sqldb file replaced while open, reopening",
+                                "fname=<%s>", open->fname);
+            open->stale = 1;
+            continue;
         }
+
+        /* disagreement here means somebody is taking the wrong lock */
+        if (open->scope != scope || strcmpsafe(open->owner, owner)) {
+            xsyslog(LOG_ERR, "DBERROR: sqldb already open with a different scope",
+                             "fname=<%s> scope=<%d> owner=<%s>"
+                             " openscope=<%d> openowner=<%s>",
+                             fname, scope, owner ? owner : "",
+                             open->scope, open->owner ? open->owner : "");
+        }
+
+        /* already open! */
+        open->refcount++;
+        return open;
     }
 
     open = xzmalloc(sizeof(sqldb_t));
     open->fname = xstrdup(fname);
+    open->scope = scope;
+    open->owner = xstrdupnull(owner);
 
     if (*fname && strcmp(fname, ":memory:")) {
         rc = stat(open->fname, &sbuf);
@@ -267,6 +331,8 @@ transout:
     }
 
 out:
+    _stampfile(open);
+
     /* stitch on up */
     open->refcount = 1;
     open->next = open_sqldbs;
@@ -406,7 +472,23 @@ EXPORTED int sqldb_exec(sqldb_t *open, const char *cmd, struct sqldb_bindval bva
                          "fname=<%s> cmd=<%s> error=<%s>",
                 open->fname, buf_cstring(&newcmd), sqlite3_errmsg(open->db));
         buf_free(&newcmd);
-        r = SQLDB_ERR_UNKNOWN;
+
+        /* the file was unlinked or replaced, so this handle will never write
+           again.  Report that distinctly from a generic failure */
+        if (0
+#ifdef SQLITE_READONLY_DBMOVED
+            || rc == SQLITE_READONLY_DBMOVED
+#endif
+#ifdef SQLITE_READONLY_DIRECTORY
+            || rc == SQLITE_READONLY_DIRECTORY
+#endif
+           ) {
+            open->stale = 1;
+            xsyslog(LOG_ERR, "DBERROR: sqldb removed or replaced while open",
+                             "fname=<%s>", open->fname);
+            r = SQLDB_ERR_DBMOVED;
+        }
+        else r = SQLDB_ERR_UNKNOWN;
     }
 
     return r;
@@ -522,6 +604,23 @@ EXPORTED int sqldb_close(sqldb_t **dbp)
     *dbp = NULL;
 
     return _free_open(open);
+}
+
+EXPORTED int sqldb_isopen_forscope(int scope, const char *owner)
+{
+    sqldb_t *open;
+
+    /* an untagged database is protected by nothing */
+    if (scope == SQLDB_SCOPE_NONE) return 0;
+
+    for (open = open_sqldbs; open; open = open->next) {
+        if (open->stale) continue;
+        if (open->scope != scope) continue;
+        if (strcmpsafe(open->owner, owner)) continue;
+        return 1;
+    }
+
+    return 0;
 }
 
 EXPORTED int sqldb_attach(sqldb_t *open, const char *fname)

--- a/lib/sqldb.h
+++ b/lib/sqldb.h
@@ -5,6 +5,8 @@
 #ifndef SQLDB_H
 #define SQLDB_H
 
+#include <sys/types.h>
+
 #include <sqlite3.h>
 #include "ptrarray.h"
 #include "strarray.h"
@@ -22,6 +24,16 @@ struct sqldb_bindval {
 
 #define SQL_MAXVAL 256
 
+/* track the scope of data that each database contains, allowing us to
+   ensure the correct locks are taken, and ensure we don't try to use
+   a database that has been deleted */
+enum sqldb_scope {
+    SQLDB_SCOPE_NONE = 0,   /* process-local, no owner */
+    SQLDB_SCOPE_USER,       /* user namespace lock, owner is the userid */
+    SQLDB_SCOPE_MAILBOX,    /* mailbox name lock, owner is the mboxname */
+    SQLDB_SCOPE_GLOBAL,     /* its own lock, no owner */
+};
+
 struct sqldb {
     sqlite3 *db;
     char *fname;
@@ -29,6 +41,11 @@ struct sqldb {
     int refcount;
     int writelock;
     int attached;
+    dev_t dev;      /* identify the file we opened, to detect it being */
+    ino_t ino;      /* unlinked or replaced */
+    int stale;      /* it has been */
+    int scope;      /* enum sqldb_scope */
+    char *owner;    /* userid or mboxname, per the scope */
     strarray_t trans;
     ptrarray_t stmts;
     struct sqldb *next;
@@ -54,10 +71,19 @@ int sqldb_done(void);
 #define SQLDB_OK           0
 #define SQLDB_ERR_UNKNOWN -1
 #define SQLDB_ERR_LIMIT   -2
+#define SQLDB_ERR_DBMOVED -3
 
 sqldb_t *sqldb_open(const char *fname, const char *initsql,
                    int version, const struct sqldb_upgrade *upgradesql,
                    int timeout_ms);
+
+/* as sqldb_open, tagged with the scope of data it contains */
+sqldb_t *sqldb_open_full(const char *fname, const char *initsql,
+                   int version, const struct sqldb_upgrade *upgradesql,
+                   int timeout_ms, int scope, const char *owner);
+
+/* report whether any live handle remains for this scope */
+int sqldb_isopen_forscope(int scope, const char *owner);
 
 int sqldb_attach(sqldb_t *open, const char *fname);
 int sqldb_detach(sqldb_t *open);


### PR DESCRIPTION
This is PR one of four -- this should stop all the DBERROR syslogs for sqlite issues, which seem to happen mostly around renames and deletes, but also has some sync_reset safety that's quite essential, and might mean we don't need to reconstruct users after a rename.