### PR TITLE
mailbox: make relocking safe, and notice when the mailbox moved

### DIFF
--- a/cunit/mailbox.testc
+++ b/cunit/mailbox.testc
@@ -5,10 +5,27 @@
 #include <stdalign.h>
 #endif
 
+#include <errno.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 
 #include "cunit/unit.h"
+#include "lib/libconfig.h"
+#include "lib/util.h"
+#include "lib/xmalloc.h"
+#include "imap/global.h"
+#include "imap/imap_err.h"
 #include "imap/mailbox.h"
+#include "imap/mboxlist.h"
+#include "imap/mboxname.h"
+#include "imap/quota.h"
+#include "imap/user.h"
+
+#define DBDIR       "test-mailbox-dbdir"
+#define PARTITION   "default"
+#define ACL         "anyone\tlrswipkxtecdan\t"
+#define MBOXNAME    "user.smurf"
+#define SIBLING     "user.smurf.sub"
 
 /* XXX record cache_offset is 64b in memory but 32b on disk, and cache_version
  * XXX is 16b in memory but 32b on disk.
@@ -278,6 +295,268 @@ static void test_unique_record_offsets(void)
                         offsets[i + 1]. name, offsets[i + 1].pos);
         }
     }
+}
+
+
+/* Every holder of a struct mailbox shares its locks, so relocking on behalf
+ * of one of them would drop locks the others still rely on.  The relock is
+ * refused, and the struct is left exactly as the other holder sees it. */
+static void test_relock_refused_while_shared(void)
+{
+    struct mailbox *m1 = NULL;
+    struct mailbox *m2 = NULL;
+    int r;
+
+    r = mailbox_open_irl(MBOXNAME, &m1);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    r = mailbox_open_irl(MBOXNAME, &m2);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    CU_ASSERT_PTR_EQUAL(m1, m2);
+    CU_ASSERT_EQUAL(m1->refcount, 2);
+
+    r = mailbox_lock_index(m1, LOCK_EXCLUSIVE);
+    CU_ASSERT_EQUAL(r, IMAP_MAILBOX_LOCKED);
+
+    CU_ASSERT_EQUAL(m2->refcount, 2);
+    CU_ASSERT_EQUAL(m2->index_locktype, LOCK_SHARED);
+    CU_ASSERT_PTR_NOT_NULL(m2->index_base);
+    CU_ASSERT_PTR_NOT_NULL(m2->namelock);
+    CU_ASSERT(user_nslock_islockedmb(MBOXNAME) & LOCK_SHARED);
+
+    mailbox_close(&m1);
+    mailbox_close(&m2);
+}
+
+/* As above, but with the user namespace lock held by a sibling mailbox the
+ * relock can't even be attempted, and a refused relock must not have torn
+ * down the struct on its way out. */
+static void test_relock_refused_while_shared_and_locked_out(void)
+{
+    struct mailbox *sibling = NULL;
+    struct mailbox *m1 = NULL;
+    struct mailbox *m2 = NULL;
+    int r;
+
+    r = mailbox_open_irl(SIBLING, &sibling);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    r = mailbox_open_irl(MBOXNAME, &m1);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    r = mailbox_open_irl(MBOXNAME, &m2);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    CU_ASSERT_PTR_EQUAL(m1, m2);
+
+    r = mailbox_lock_index(m1, LOCK_EXCLUSIVE);
+    CU_ASSERT_EQUAL(r, IMAP_MAILBOX_LOCKED);
+
+    CU_ASSERT_EQUAL(m2->index_locktype, LOCK_SHARED);
+    CU_ASSERT_PTR_NOT_NULL(m2->index_base);
+    CU_ASSERT_PTR_NOT_NULL(m2->namelock);
+
+    mailbox_close(&m1);
+    mailbox_close(&m2);
+    mailbox_close(&sibling);
+}
+
+/* A sole holder can be locked out by a shared user namespace lock held for a
+ * sibling mailbox.  Refusing is the right answer, and (under valgrind) it
+ * must not leak on the way out. */
+static void test_relock_locked_out(void)
+{
+    struct mailbox *sibling = NULL;
+    struct mailbox *m = NULL;
+    int r;
+
+    r = mailbox_open_irl(SIBLING, &sibling);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    r = mailbox_open_irl(MBOXNAME, &m);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    CU_ASSERT_EQUAL(m->refcount, 1);
+
+    r = mailbox_lock_index(m, LOCK_EXCLUSIVE);
+    CU_ASSERT_EQUAL(r, IMAP_MAILBOX_LOCKED);
+
+    /* the sibling's locks are untouched */
+    CU_ASSERT_EQUAL(sibling->index_locktype, LOCK_SHARED);
+    CU_ASSERT_PTR_NOT_NULL(sibling->namelock);
+    CU_ASSERT(user_nslock_islockedmb(MBOXNAME) & LOCK_SHARED);
+
+    mailbox_close(&m);
+    mailbox_close(&sibling);
+}
+
+/* With nothing locked, the sole holder can upgrade */
+static void test_relock_upgrade(void)
+{
+    struct mailbox *m = NULL;
+    int r;
+
+    r = mailbox_open_irl(MBOXNAME, &m);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    CU_ASSERT_EQUAL(m->index_locktype, LOCK_SHARED);
+
+    r = mailbox_lock_index(m, LOCK_EXCLUSIVE);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(m->index_locktype, LOCK_EXCLUSIVE);
+    CU_ASSERT_PTR_NOT_NULL(m->namelock);
+    CU_ASSERT(user_nslock_islockedmb(MBOXNAME) & LOCK_EXCLUSIVE);
+
+    mailbox_close(&m);
+}
+
+/* Unlocking the index drops every lock, so mboxlist can change under an open
+ * struct.  Relocking notices, and says so. */
+static void test_relock_notices_deleted(void)
+{
+    struct mailbox *m = NULL;
+    mbentry_t *mbentry = NULL;
+    int r;
+
+    r = mailbox_open_irl(MBOXNAME, &m);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    mailbox_unlock_index(m, NULL);
+    CU_ASSERT_PTR_NULL(m->namelock);
+
+    r = mboxlist_lookup_allow_all(MBOXNAME, &mbentry, NULL);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    mbentry->mbtype |= MBTYPE_DELETED;
+    r = mboxlist_updatelock(mbentry, /*localonly*/1);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    mboxlist_entry_free(&mbentry);
+
+    unsigned int match = CU_SYSLOG_MATCH_SUBSTR(
+        "mailbox no longer usable after relock");
+    r = mailbox_lock_index(m, LOCK_SHARED);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_SYSLOG(match, 1);
+
+    mailbox_close(&m);
+}
+
+static void test_relock_notices_replaced(void)
+{
+    struct mailbox *m = NULL;
+    mbentry_t *mbentry = NULL;
+    int r;
+
+    r = mailbox_open_irl(MBOXNAME, &m);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    mailbox_unlock_index(m, NULL);
+
+    r = mboxlist_lookup_allow_all(MBOXNAME, &mbentry, NULL);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    free(mbentry->uniqueid);
+    mbentry->uniqueid = xstrdup(makeuuid());
+    r = mboxlist_updatelock(mbentry, /*localonly*/1);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    mboxlist_entry_free(&mbentry);
+
+    unsigned int match = CU_SYSLOG_MATCH_SUBSTR(
+        "mailbox replaced while unlocked for relock");
+    r = mailbox_lock_index(m, LOCK_SHARED);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_SYSLOG(match, 1);
+
+    mailbox_close(&m);
+}
+
+static void test_relock_notices_vanished(void)
+{
+    struct mailbox *m = NULL;
+    mbentry_t *mbentry = NULL;
+    int r;
+
+    r = mailbox_open_irl(MBOXNAME, &m);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    mailbox_unlock_index(m, NULL);
+
+    r = mboxlist_lookup_allow_all(MBOXNAME, &mbentry, NULL);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    r = mboxlist_deletelock(mbentry);
+    CU_ASSERT_EQUAL_FATAL(r, 0);
+    mboxlist_entry_free(&mbentry);
+
+    unsigned int match = CU_SYSLOG_MATCH_SUBSTR(
+        "mailbox vanished while unlocked for relock");
+    r = mailbox_lock_index(m, LOCK_SHARED);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_SYSLOG(match, 1);
+
+    mailbox_close(&m);
+}
+
+static int create_mailbox(const char *name)
+{
+    user_nslock_t *user_nslock = user_nslock_lockmb_w(name);
+    struct mailbox *mailbox = NULL;
+    int r = mailbox_create(name, /*mbtype*/0, /*version*/0, PARTITION, ACL,
+                           makeuuid(), /*jmapid*/0,
+                           /*options*/0, /*uidvalidity*/0,
+                           /*createdmodseq*/0,
+                           /*highestmodseq*/0, &mailbox);
+    if (!r) {
+        mbentry_t mbentry = MBENTRY_INITIALIZER;
+        mbentry.name = (char *) name;
+        mbentry.uniqueid = (char *) mailbox_uniqueid(mailbox);
+        mbentry.partition = (char *) PARTITION;
+        mbentry.acl = (char *) ACL;
+        r = mboxlist_updatelock(&mbentry, /*localonly*/1);
+        mailbox_close(&mailbox);
+    }
+    user_nslock_release(&user_nslock);
+    return r;
+}
+
+static int set_up(void)
+{
+    static const char * const dirs[] = {
+        DBDIR, DBDIR"/db", DBDIR"/conf", DBDIR"/data", NULL
+    };
+
+    int r = system("rm -rf " DBDIR);
+    if (r) return r;
+
+    for (const char * const *d = dirs ; *d ; d++) {
+        if (mkdir(*d, 0777) < 0) {
+            int e = errno;
+            perror(*d);
+            return e;
+        }
+    }
+
+    config_read_string(DBDIR"/conf",
+        "defaultpartition: "PARTITION"\n"
+        "partition-"PARTITION": "DBDIR"/data\n"
+    );
+
+    cyrusdb_init();
+    config_mboxlist_db = "skiplist";
+    config_annotation_db = "skiplist";
+    config_quota_db = "skiplist";
+
+    quotadb_init();
+    quotadb_open(NULL);
+    mboxlist_init();
+    mboxlist_open(NULL);
+
+    r = create_mailbox(MBOXNAME);
+    if (!r) r = create_mailbox(SIBLING);
+    return r;
+}
+
+static int tear_down(void)
+{
+    mboxlist_close();
+    mboxlist_done();
+    quotadb_close();
+    quotadb_done();
+    cyrusdb_done();
+    config_reset();
+    config_mboxlist_db = NULL;
+    config_annotation_db = NULL;
+    config_quota_db = NULL;
+
+    int r = system("rm -rf " DBDIR);
+    return r ? -1 : 0;
 }
 
 /* vim: set ft=c: */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -946,9 +946,23 @@ static int mailbox_open_index(struct mailbox *mailbox, int index_locktype)
 }
 
 
-static int mailbox_relock(struct mailbox *mailbox, int locktype, int index_locktype)
+/* pass recheck when the mailbox should still be in mboxlist; mailbox_create()
+   and the delete cleanup in mailbox_close() both work on one which
+   deliberately isn't */
+static int mailbox_relock(struct mailbox *mailbox, int locktype,
+                          int index_locktype, int recheck)
 {
     int r = 0;
+
+    /* mailbox_unlock_index() does nothing while another holder has this
+       open, so we would drop their locks and then re-lock an index we never
+       released */
+    if (mailbox->refcount > 1) {
+        xsyslog(LOG_ERR, "refusing to relock a mailbox opened more than once",
+                         "mailbox=<%s> refcount=<%d>",
+                         mailbox_name(mailbox), mailbox->refcount);
+        return IMAP_MAILBOX_LOCKED;
+    }
 
     mailbox_unlock_index(mailbox, NULL);
     mailbox_release_resources(mailbox);
@@ -958,14 +972,42 @@ static int mailbox_relock(struct mailbox *mailbox, int locktype, int index_lockt
     int haslock = user_nslock_islocked(userid);
     if (haslock) {
         if ((haslock & LOCK_SHARED) && (index_locktype & LOCK_EXCLUSIVE))
-            return IMAP_MAILBOX_LOCKED;
+            r = IMAP_MAILBOX_LOCKED;
     }
     else {
         mailbox->user_nslock = user_nslock_lock(userid, index_locktype);
     }
     free(userid);
+    if (r) return r;
     r = mboxname_lock(mailbox->lockname, &mailbox->namelock, locktype);
     if (r) return r;
+
+    /* mailbox_open_advanced() refuses a mailbox which has been deleted or
+       replaced, but our callers already hold the struct and have nowhere to
+       put the error, so only complain */
+    if (recheck) {
+        mbentry_t *mbentry = NULL;
+        if (mboxlist_lookup_allow_all(mailbox_name(mailbox), &mbentry, NULL)) {
+            xsyslog(LOG_ERR, "mailbox vanished while unlocked for relock",
+                             "mailbox=<%s> uniqueid=<%s>",
+                             mailbox_name(mailbox), mailbox_uniqueid(mailbox));
+        }
+        else if (mbentry->mbtype &
+                 (MBTYPE_DELETED|MBTYPE_MOVING|MBTYPE_INTERMEDIATE)) {
+            xsyslog(LOG_ERR, "mailbox no longer usable after relock",
+                             "mailbox=<%s> uniqueid=<%s> mbtype=<%s>",
+                             mailbox_name(mailbox), mailbox_uniqueid(mailbox),
+                             mboxlist_mbtype_to_string(mbentry->mbtype));
+        }
+        else if (strcmpsafe(mbentry->uniqueid, mailbox_uniqueid(mailbox))) {
+            xsyslog(LOG_ERR, "mailbox replaced while unlocked for relock",
+                             "mailbox=<%s> uniqueid=<%s> newuniqueid=<%s>",
+                             mailbox_name(mailbox), mailbox_uniqueid(mailbox),
+                             mbentry->uniqueid);
+        }
+        mboxlist_entry_free(&mbentry);
+    }
+
     r = mailbox_open_index(mailbox, index_locktype);
     if (r) return r;
     r = mailbox_lock_index_internal(mailbox, index_locktype);
@@ -1318,7 +1360,8 @@ EXPORTED void mailbox_close(struct mailbox **mailboxptr)
     }
 
     if (mailbox->i.options & OPT_MAILBOX_DELETED) {
-        int r = mailbox_relock(mailbox, LOCK_EXCLUSIVE, LOCK_EXCLUSIVE);
+        int r = mailbox_relock(mailbox, LOCK_EXCLUSIVE, LOCK_EXCLUSIVE,
+                               0/*recheck*/);
         /* double check just in case a new mailbox with the same name got created
          * in a race condition and isn't deleted! */
         if (!r && (mailbox->i.options & OPT_MAILBOX_DELETED)) {
@@ -2488,7 +2531,8 @@ EXPORTED int mailbox_lock_index(struct mailbox *mailbox, int index_locktype)
     }
 
     if (need_relock)
-        return mailbox_relock(mailbox, LOCK_SHARED, index_locktype);
+        return mailbox_relock(mailbox, LOCK_SHARED, index_locktype,
+                              1/*recheck*/);
 
     r = mailbox_lock_index_internal(mailbox, index_locktype);
     if (r) return r;
@@ -6647,8 +6691,10 @@ HIDDEN int mailbox_rename_copy(struct mailbox *oldmailbox,
                            NULL : mailbox_uniqueid(newmailbox));
     if (r) goto fail;
 
-    /* we have new files in place, so redo all the locks */
-    r = mailbox_relock(newmailbox, LOCK_EXCLUSIVE, LOCK_EXCLUSIVE);
+    /* we have new files in place, so redo all the locks.  mailbox_create()
+       only built the mbentry in memory, so there's nothing to recheck yet */
+    r = mailbox_relock(newmailbox, LOCK_EXCLUSIVE, LOCK_EXCLUSIVE,
+                       0/*recheck*/);
     if (r) goto fail;
 
     /* update mailbox annotations if necessary */

--- a/imap/user.h
+++ b/imap/user.h
@@ -69,7 +69,7 @@ user_nslock_t *user_nslock_bymboxname(const char *mboxname1, const char *mboxnam
 #define user_nslock_lockmb_w(m) user_nslock_bymboxname(m, NULL, LOCK_EXCLUSIVE)
 void user_nslock_release(user_nslock_t **ptr);
 int user_nslock_islocked(const char *userid);
-int user_nslock_islockedmboxname(const char *mboxname);
+int user_nslock_islockedmb(const char *mboxname);
 
 /* default to exclusive lock! */
 /* NULL is a legit value for lock_full, so use a flag value instead */


### PR DESCRIPTION
This is PR 2 of four, Claude wanted to use relock and I said "I don't trust it" so it went and looked and found that it was indeed untrustworthy!  This fixes that.