### PR TITLE
jmap: make mayReadFreeBusy enough on its own

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith_acl
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_sharewith_acl
@@ -30,9 +30,10 @@ sub test_calendar_set_sharewith_acl
 
     my @testCases = ({
         rights => {
+            # free/busy implies lookup
             mayReadFreeBusy => JSON::true,
         },
-        acl => '9',
+        acl => 'l9',
     }, {
         rights => {
             mayReadItems => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_sharee
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_sharee
@@ -1,0 +1,79 @@
+#!perl
+use Cassandane::Tiny;
+
+# Availability for somebody else's principal, the only getAvailability case
+# which reads a DAV DB other than the account's own.  mayReadFreeBusy on its
+# own has to be enough.
+sub test_calendarprincipal_getavailability_sharee
+    :min_version_3_3
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+
+    my $admin = $self->{adminstore}->get_client();
+
+    $admin->create("user.manifold");
+    my $manifold_user = $self->{instance}->create_user_without_setup('manifold');
+    my $manjmap = $manifold_user->jmap;
+    $manjmap->DefaultUsing([
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:calendars',
+        'urn:ietf:params:jmap:principals',
+        'https://cyrusimap.org/ns/jmap/calendars',
+        'https://cyrusimap.org/ns/jmap/jscalendarbis',
+    ]);
+
+    my $res = $manjmap->CallMethods([
+        ['Calendar/get', { properties => ['id'] }, 'R1'],
+    ]);
+    my $man_cal_id = $res->[0][1]{list}[0]{id};
+    $self->assert_not_null($man_cal_id);
+
+    xlog "manifold shares free/busy with cassandane";
+    $res = $manjmap->CallMethods([
+        ['Calendar/set', {
+            update => {
+                $man_cal_id => {
+                    shareWith => {
+                        cassandane => {
+                            mayReadFreeBusy => JSON::true,
+                        },
+                    },
+                },
+            },
+        }, 'R1'],
+        ['CalendarEvent/set', {
+            create => {
+                event1 => {
+                    version => '2.0',
+                    title => 'event1',
+                    calendarIds => {
+                        $man_cal_id => JSON::true,
+                    },
+                    uid => 'manifoldevent1uid',
+                    start => '2020-08-07T11:00:00',
+                    timeZone => 'Europe/Vienna',
+                    duration => 'PT3H',
+                },
+            },
+        }, 'R2'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$man_cal_id});
+    $self->assert_not_null($res->[1][1]{created}{event1});
+
+    xlog "cassandane asks for manifold's availability";
+    $res = $jmap->CallMethods([
+        ['Principal/getAvailability', {
+            id => 'manifold',
+            utcStart => '2020-08-01T00:00:00Z',
+            utcEnd => '2020-09-01T00:00:00Z',
+        }, 'R1'],
+    ]);
+
+    $self->assert_deep_equals([{
+        utcStart => "2020-08-07T09:00:00Z",
+        utcEnd => "2020-08-07T12:00:00Z",
+        busyStatus => 'unavailable',
+        event => undef,
+    }], $res->[0][1]{list});
+}

--- a/changes/next/jmap-freebusy-implies-lookup
+++ b/changes/next/jmap-freebusy-implies-lookup
@@ -1,0 +1,37 @@
+Description:
+
+Granting somebody free/busy access to a calendar now works on its own.
+
+mayReadFreeBusy (JMAP), and the '9' ACL it maps to, only ever granted the
+free/busy right itself.  But every check which decides whether a sharee can see
+a calendar at all goes through the lookup right first, so granting free/busy
+and nothing else hid the principal from Principal/get and Principal/query, made
+the account look like it had no calendars, and turned Principal/getAvailability
+into a notFound.  It now grants lookup as well.
+
+The rule that anything beyond free/busy also implies the write right has to
+skip lookup now, or a free/busy share would quietly become writable.
+
+
+Documentation:
+
+None.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+Existing free/busy-only shares keep the ACL they were granted, which is still
+missing 'l', so they carry on not working until repaired.  Either re-share them,
+or add the lookup right anywhere '9' was granted without it:
+
+    cyradm> setaclmailbox user.example.#calendars.Default sharee +l
+
+
+GitHub issue:
+
+None.

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -610,7 +610,9 @@ calendar_sharewith_to_rights_iter:
     json_object_foreach(jsharewith, name, jval) {
         int mask;
         if (!strcmp("mayReadFreeBusy", name))
-            mask = JACL_READFB;
+            /* grant lookup too: every check goes through JACL_LOOKUP
+               first, so free/busy alone is never visible */
+            mask = JACL_READFB|JACL_LOOKUP;
         else if (!strcmp("mayReadItems", name))
             mask = JACL_READITEMS;
         else if (!strcmp("mayWriteAll", name))
@@ -637,7 +639,7 @@ calendar_sharewith_to_rights_iter:
 
     /* Can always set calendar properties for read-only calendars,
        but we need to flag the account as isReadOnly=false, so include ACL_WRITE. */
-    if (newrights & ~JACL_READFB) {
+    if (newrights & ~(JACL_READFB|JACL_LOOKUP)) {
         newrights |= ACL_WRITE;
     }
 


### PR DESCRIPTION
This is PR 3 of four - while reviewing locking and writing tests for it, Claude ran into "FreeBusy by itself doesn't work".

So we fixed that by making Lookup part of mayReadFreeBusy.