### PR TITLE
Cross user lock ordering

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_crossuser_concurrent
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_crossuser_concurrent
@@ -1,0 +1,122 @@
+#!perl
+use Cassandane::Tiny;
+use POSIX qw(_exit);
+use Fcntl qw(:flock);
+use File::Temp qw(tempfile);
+
+# Two local users each organize an event the other attends, then RSVP on
+# the other's behalf at the same time.  Each call holds its own account's
+# lock while sched_deliver_local() writes into the other user's calendar,
+# so this is the shape in which a lock taken in the wrong order deadlocks.
+sub test_calendarevent_participantreply_crossuser_concurrent
+    :NoAltNameSpace
+    ($self)
+{
+    my $cassandane = $self->default_user;
+    my $alice = $self->{instance}->create_user('alice');
+
+    my %eventid;
+    for my $pair ([$cassandane, $alice], [$alice, $cassandane]) {
+        my ($organizer, $attendee) = @$pair;
+        my $caldav = $organizer->caldav;
+        my $calid = $caldav->NewCalendar({name => 'invites'});
+        $self->assert_not_null($calid);
+
+        my $uid = "crossuser-" . $organizer->username;
+        my $orgaddr = $organizer->username . '@example.com';
+        my $attaddr = $attendee->username . '@example.com';
+        my $card = <<EOF2;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Cassandane//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:$uid
+SUMMARY:An Event
+DTSTART:20260831T153000Z
+DURATION:PT1H
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+ORGANIZER:MAILTO:$orgaddr
+ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:MAILTO:$attaddr
+END:VEVENT
+END:VCALENDAR
+EOF2
+        $caldav->Request('PUT', "$calid/$uid.ics", $card,
+                         'Content-Type' => 'text/calendar');
+
+        my $res = $organizer->jmap->request([['CalendarEvent/get', {
+            ids => undef, properties => ['uid'],
+        }, "R0"]]);
+        my ($event) = grep { $_->{uid} eq $uid }
+                           @{$res->single_sentence->arguments->{list}};
+        $self->assert_not_null($event);
+        $eventid{$organizer->username} = $event->{id};
+    }
+
+    my $rounds = 10;
+    my $rsvp_loop = sub ($barrier, $organizer, $attendee) {
+        open(my $fh, '>', $barrier) or die "open $barrier: $!";
+        flock($fh, LOCK_SH);
+        my $jmap = $organizer->new_jmaptester;
+        for my $round (1..$rounds) {
+            my $res = $jmap->request([['CalendarEvent/participantReply', {
+                eventId => $eventid{$organizer->username},
+                participantEmail => $attendee->username . '@example.com',
+                updates => {
+                    participationStatus => $round % 2 ? 'accepted' : 'declined',
+                },
+            }, "R1"]]);
+            _exit(1) if $res->sentence(0)->name ne 'CalendarEvent/participantReply';
+        }
+        _exit(0);
+    };
+
+    my (undef, $barrier) = tempfile();
+    open(my $fh, '>', $barrier) or die "open $barrier: $!";
+    flock($fh, LOCK_EX) or die "flock: $!";
+
+    my @pids;
+    for my $pair ([$cassandane, $alice], [$alice, $cassandane]) {
+        my $pid = fork();
+        die "fork: $!" unless defined $pid;
+        if (!$pid) {
+            close($fh);
+            $rsvp_loop->($barrier, @$pair);
+        }
+        push @pids, $pid;
+    }
+
+    # release both at once
+    undef $fh;
+
+    my $deadline = time() + 120;
+    for my $pid (@pids) {
+        while (waitpid($pid, POSIX::WNOHANG()) == 0) {
+            if (time() > $deadline) {
+                kill 'KILL', @pids;
+                $self->fail("participantReply never finished");
+            }
+            select(undef, undef, undef, 0.05);
+        }
+        $self->assert_num_equals(0, $? >> 8, "child $pid replied cleanly");
+    }
+    unlink $barrier;
+
+    xlog $self, "both organizers' copies carry the final RSVP";
+    for my $pair ([$cassandane, $alice], [$alice, $cassandane]) {
+        my ($organizer, $attendee) = @$pair;
+        my $res = $organizer->jmap->request([['CalendarEvent/get', {
+            ids => [$eventid{$organizer->username}],
+            properties => ['participants'],
+        }, "R0"]]);
+        my $event = $res->single_sentence->arguments->{list}[0];
+        my $attaddr = 'mailto:' . $attendee->username . '@example.com';
+        my ($part) = grep { lc($_->{calendarAddress} // '') eq $attaddr }
+                          values %{$event->{participants}};
+        $self->assert_not_null($part);
+        $self->assert_str_equals($rounds % 2 ? 'accepted' : 'declined',
+                                 $part->{participationStatus});
+    }
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_localorg
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_localorg
@@ -1,0 +1,97 @@
+#!perl
+use Cassandane::Tiny;
+
+# Every other participantReply test makes the participant external.  A
+# local participant is the only case which reaches sched_deliver_local()
+# for a second user, so cover it.
+sub test_calendarevent_participantreply_localorg
+    :NoAltNameSpace
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->create("user.alice");
+
+    my $service = $self->{instance}->get_service("http");
+    my $alicetalk = Net::CalDAVTalk->new(
+        user => "alice",
+        password => 'pass',
+        host => $service->host(),
+        port => $service->port(),
+        scheme => 'http',
+        url => '/',
+        expandurl => 1,
+    );
+
+    xlog $self, "give the attendee an address we can invite";
+    my $xml = <<EOF;
+<?xml version="1.0" encoding="UTF-8"?>
+<D:propertyupdate xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:set>
+    <D:prop>
+      <C:calendar-user-address-set>
+        <D:href>mailto:alice\@example.com</D:href>
+      </C:calendar-user-address-set>
+    </D:prop>
+  </D:set>
+</D:propertyupdate>
+EOF
+    $alicetalk->Request('PROPPATCH', "/dav/principals/user/alice", $xml,
+                        'Content-Type' => 'text/xml');
+
+    my $caldav = $self->{caldav};
+    my $calid = $caldav->NewCalendar({name => 'invites'});
+    $self->assert_not_null($calid);
+
+    my $uid = "6de280c9-edff-4019-8ebd-cfebc73f8201";
+    my $card = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.10.4//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20150806T234327Z
+UID:$uid
+SUMMARY:An Event
+DTSTART:20260831T153000Z
+DURATION:PT1H
+DTSTAMP:20150806T234327Z
+SEQUENCE:0
+ORGANIZER;CN="Cassandane":MAILTO:cassandane\@example.com
+ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN="Alice":MAILTO:alice\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+
+    xlog $self, "invite the local attendee, which files the event in her calendar";
+    $caldav->Request('PUT', "$calid/$uid.ics", $card,
+                     'Content-Type' => 'text/calendar');
+
+    my $jmap = $self->{jmap};
+    my $res = $jmap->CallMethods([['CalendarEvent/get', {
+        ids => undef, properties => ['uid'],
+    }, "R0"]]);
+    my ($event) = grep { $_->{uid} eq $uid } @{$res->[0][1]{list}};
+    $self->assert_not_null($event);
+
+    xlog $self, "RSVP on the local attendee's behalf";
+    $res = $jmap->CallMethods([['CalendarEvent/participantReply', {
+        eventId => $event->{id},
+        participantEmail => "alice\@example.com",
+        updates => {
+            participationStatus => "accepted"
+        }
+    }, "R1"]]);
+
+    # 1.2 is "delivered", which only sched_deliver_local() sets
+    $self->assert_str_equals("1.2", $res->[0][1]{scheduleStatus});
+
+    xlog $self, "the attendee's copy has the acceptance";
+    my $response = $alicetalk->Request('GET',
+                                       "/dav/calendars/user/alice/Default/$uid.ics");
+    my $ical = $response->{content};
+    $ical =~ s/\r?\n[ \t]//g;
+    my ($attendee) = grep { m/^ATTENDEE.*alice\@example\.com/ }
+                          split /\r?\n/, $ical;
+    $self->assert_not_null($attendee);
+    $self->assert_matches(qr/PARTSTAT=ACCEPTED/, $attendee);
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_error_keeps_lock
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_error_keeps_lock
@@ -1,0 +1,55 @@
+#!perl
+use Cassandane::Tiny;
+
+# A failed getAvailability must release the principal's lock: httpd is
+# long-lived, and a leaked shared lock makes the next exclusive lock on the
+# same user in this process abort.
+sub test_calendarprincipal_getavailability_error_keeps_lock
+    :NoCheckSyslog
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    my $calendar_id = $user->calendars->default->id;
+
+    xlog $self, "create an event inside the availability time range";
+    my $res = $jmap->request([[
+        'CalendarEvent/set' => {
+            create => {
+                event1 => {
+                    version => '2.0',
+                    calendarIds => {
+                        $calendar_id => JSON::true,
+                    },
+                    title => 'event1',
+                    start => '2020-08-15T09:00:00',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                },
+            },
+        },
+    ]])->single_sentence('CalendarEvent/set')->arguments;
+    $self->assert_not_null($res->{created}{event1});
+
+    xlog $self, "break the calendar so opening it fails";
+    my $header = $self->{instance}->folder_to_directory(
+        'INBOX.#calendars.Default') . '/cyrus.header';
+    $self->assert(-f $header, "couldn't find cyrus.header file");
+    rename $header, "$header.hidden" or die "rename $header: $!";
+
+    xlog $self, "getAvailability fails, then a write in the same process";
+    $res = $jmap->request([
+        [ 'Principal/getAvailability' => {
+            id => 'cassandane',
+            utcStart => '2020-08-01T00:00:00Z',
+            utcEnd => '2020-09-01T00:00:00Z',
+        } ],
+        [ 'Calendar/set' => {} ],
+    ]);
+    $self->assert_str_equals('error', $res->sentence(0)->name);
+    $self->assert_str_equals('serverFail',
+                             $res->sentence(0)->arguments->{type});
+    $self->assert_str_equals('Calendar/set', $res->sentence(1)->name);
+
+    rename "$header.hidden", $header or die "rename $header: $!";
+}

--- a/cassandane/tiny-tests/Rename/rename_user_fails_after_tombstone
+++ b/cassandane/tiny-tests/Rename/rename_user_fails_after_tombstone
@@ -1,0 +1,40 @@
+#!perl
+use Cassandane::Tiny;
+
+# An admin user rename writes a DELETED tombstone at the new name before it
+# checks the submailboxes, so a failure there has to clean that up again.
+sub test_rename_user_fails_after_tombstone
+    :AllowMoves :NoAltNameSpace
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+    my $talk = $self->{store}->get_client();
+
+    # fits under the old user name, not under a longer one
+    my $sub = 'a' x 470;
+    $talk->create("INBOX.$sub") || die "create: $@";
+
+    my $newuser = 'x' x 40;
+    xlog $self, "rename fails because a submailbox name would be too long";
+    $admintalk->rename('user.cassandane', "user.$newuser");
+    $self->assert_str_equals('no',
+                             $admintalk->get_last_completion_response());
+
+    xlog $self, "imapd survived";
+    $admintalk->noop();
+    $self->assert_str_equals('ok',
+                             $admintalk->get_last_completion_response());
+
+    xlog $self, "the tombstone at the new name is gone";
+    my $mailboxesdb = $self->{instance}->read_mailboxes_db();
+    my @newnames = grep { m/^user\.$newuser/ } keys %$mailboxesdb;
+    $self->assert_cmp_deeply([], \@newnames);
+
+    xlog $self, "and the old user is intact enough to rename properly";
+    $admintalk->rename('user.cassandane', 'user.newuser');
+    $self->assert_str_equals('ok',
+                             $admintalk->get_last_completion_response());
+    $admintalk->select("user.newuser.$sub");
+    $self->assert_str_equals('ok',
+                             $admintalk->get_last_completion_response());
+}

--- a/cassandane/tiny-tests/Rename/rename_user_opposite_directions_concurrent
+++ b/cassandane/tiny-tests/Rename/rename_user_opposite_directions_concurrent
@@ -1,0 +1,79 @@
+#!perl
+use Cassandane::Tiny;
+use POSIX qw(_exit);
+use Fcntl qw(:flock);
+use File::Temp qw(tempfile);
+
+# Renaming user.alpha to user.beta and user.beta to user.alpha at the same
+# time takes the same two user locks from both sides.  lockdouble() orders
+# them by userid, so this must never deadlock, whichever rename wins.
+sub test_rename_user_opposite_directions_concurrent
+    :AllowMoves :NoAltNameSpace
+    ($self)
+{
+    my $svc = $self->{instance}->get_service('imap');
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $self->{instance}->create_user('alpha', subdirs => ['sub']);
+
+    my $rename_as_admin = sub ($barrier, $old, $new) {
+        open(my $fh, '>', $barrier) or die "open $barrier: $!";
+        flock($fh, LOCK_SH);
+        my $client = $svc->create_store(username => 'admin')->get_client();
+        $client->rename($old, $new);
+        _exit($client->get_last_completion_response() eq 'ok' ? 0 : 1);
+    };
+
+    for my $round (1..10) {
+        my (undef, $barrier) = tempfile();
+        open(my $fh, '>', $barrier) or die "open $barrier: $!";
+        flock($fh, LOCK_EX) or die "flock: $!";
+
+        my @pids;
+        for my $dir (['user.alpha', 'user.beta'], ['user.beta', 'user.alpha']) {
+            my $pid = fork();
+            die "fork: $!" unless defined $pid;
+            if (!$pid) {
+                close($fh);
+                $rename_as_admin->($barrier, @$dir);
+            }
+            push @pids, $pid;
+        }
+
+        # release both at once
+        undef $fh;
+
+        my $deadline = time() + 60;
+        for my $pid (@pids) {
+            while (waitpid($pid, POSIX::WNOHANG()) == 0) {
+                if (time() > $deadline) {
+                    kill 'KILL', @pids;
+                    $self->fail("round $round: rename never finished");
+                }
+                select(undef, undef, undef, 0.05);
+            }
+        }
+        unlink $barrier;
+
+        xlog $self, "round $round: exactly one of the two users exists";
+        my $list = $admintalk->list('', 'user.*');
+        my %seen = map { $_->[2] => 1 } @$list;
+        my $alpha = exists $seen{'user.alpha'} ? 1 : 0;
+        my $beta = exists $seen{'user.beta'} ? 1 : 0;
+        $self->assert_num_equals(1, $alpha + $beta);
+
+        if ($beta) {
+            $admintalk->rename('user.beta', 'user.alpha');
+            $self->assert_str_equals('ok',
+                    $admintalk->get_last_completion_response(),
+                    "rename back: " . ($admintalk->get_last_error() // ""));
+        }
+    }
+
+    my $final = $admintalk->list('', 'user.*');
+    $admintalk->select('user.alpha.sub');
+    $self->assert_str_equals('ok',
+                             $admintalk->get_last_completion_response(),
+                             "select: " . ($admintalk->get_last_error() // "") .
+                             " final: " . join(" ", map { $_->[2] } @$final));
+}

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -8291,10 +8291,7 @@ submboxes:
 
 respond:
 
-    imapd_check(NULL, 0);
-
     if (r) {
-        prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
         xsyslog(LOG_NOTICE, "rename failed",
                 "oldmboxname=<%s> newmboxname=<%s> error=<%s>",
                 oldmailboxname, newmailboxname, error_message(r));
@@ -8310,6 +8307,16 @@ respond:
                 xsyslog(LOG_ERR, "IOERROR: removing temporary uniqueid tombstone after rename error",
                         "mboxname=<%s> error=<%s>", newdestmbentry->name, error_message(r2));
         }
+    }
+
+    /* imapd_check() relocks the selected mailbox, which takes its owner's
+       lock, so the rename's own locks have to be gone first */
+    user_nslock_release(&user_nslock);
+
+    imapd_check(NULL, 0);
+
+    if (r) {
+        prot_printf(imapd_out, "%s NO %s\r\n", tag, error_message(r));
     } else {
         if (config_mupdate_server)
             kick_mupdate();

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -198,7 +198,10 @@ static jmap_method_t jmap_calendar_methods_standard[] = {
         "CalendarEvent/participantReply",
         JMAP_CALENDARS_EXTENSION,
         &jmap_calendarevent_participantreply,
-        JMAP_NEED_CSTATE | JMAP_READ_WRITE
+        /* only reads the account; everything written belongs to the
+           organizer and the participant.  Takes its own lock and drops it
+           before scheduling */
+        JMAP_READ_WRITE | JMAP_NO_USERLOCK
     },
     {
         "CalendarEventNotification/get",
@@ -8572,7 +8575,12 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
     json_t *res = json_object();
     char *part_id = NULL;
     json_t *err = NULL;
+    modseq_t createdmodseq = 0;
     int r = 0;
+
+    /* we only read this account, so share the lock, and drop it before
+       scheduling takes the organizer's and the participant's in turn */
+    user_nslock_t *nslock = user_nslock_lock(req->accountid, LOCK_SHARED);
 
     db = caldav_open_userid(req->accountid);
     if (!db) {
@@ -8834,10 +8842,18 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
         goto done;
     }
 
+    /* everything we need is in memory now, so drop this account before
+       reaching for anybody else's */
+    createdmodseq = cdata->dav.createdmodseq;
+    caldav_close(db);
+    db = NULL;
+    cdata = NULL;
+    user_nslock_release(&nslock);
+
     /* Create and send the reply */
     sched_reply(req->accountid, req->accountid, &reply_addr,
                 update.oldical, update.newical,
-                cdata->dav.createdmodseq, SCHED_MECH_JMAP_PARTREPLY);
+                createdmodseq, SCHED_MECH_JMAP_PARTREPLY);
 
     /* Get SCHEDULE-STATUS */
     const char *organizer = NULL;
@@ -8877,7 +8893,7 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
     schedule_one_attendee(req->accountid, req->accountid, NULL, organizer,
                           part_email, caldav_get_historical_cutoff(),
                           update.oldical, update.newical,
-                          cdata->dav.createdmodseq,
+                          createdmodseq,
                           SCHED_MECH_JMAP_PARTREPLY);
 
 no_op:
@@ -8915,6 +8931,7 @@ done:
     jmap_caleventid_free(&update.eid);
     if (db) caldav_close(db);
     mailbox_close(&mbox);
+    user_nslock_release(&nslock);
     if (update.oldical) icalcomponent_free(update.oldical);
     if (update.newical) icalcomponent_free(update.newical);
     json_decref(res);

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -282,7 +282,9 @@ static jmap_method_t jmap_calendar_methods_standard[] = {
         "Principal/getAvailability",
         JMAP_URN_PRINCIPALS,
         &jmap_principal_getavailability,
-        JMAP_NEED_CSTATE
+        /* reads the principal's calendars, not the account's, so it takes
+           the principal's lock rather than holding two at once */
+        JMAP_NO_USERLOCK
     },
     {
         "ShareNotification/get",
@@ -10191,10 +10193,14 @@ static void principal_getavailability(jmap_req_t *req,
                                       int show_details,
                                       hash_table *props)
 {
+    /* everything we read belongs to the principal, so lock only them */
+    user_nslock_t *user_nslock = user_nslock_lock(principalid, LOCK_SHARED);
+
     struct caldav_db *db = caldav_open_userid(principalid);
     if (!db) {
         jmap_error(req, json_pack("{s:s s:s}", "type", "serverFail",
                     "description", "cannot open caldav db"));
+        user_nslock_release(&user_nslock);
         return;
     }
 
@@ -10242,7 +10248,7 @@ static void principal_getavailability(jmap_req_t *req,
         icaltimezone_free(rock.floatingtz, 1);
         rock.floatingtz = NULL;
     }
-    if (r) return;
+    if (r) goto done;
 
     /* Check cumulated calendar ACLs */
     if (checkacl) {
@@ -10330,6 +10336,7 @@ static void principal_getavailability(jmap_req_t *req,
 done:
     buf_free(&buf);
     caldav_close(db);
+    user_nslock_release(&user_nslock);
     for (i = 0; i < dynarray_size(busyperiods); i++) {
         struct busyperiod *bp = dynarray_nth(busyperiods, i);
         json_decref(bp->jevent);


### PR DESCRIPTION
This is PR has now been split into 4!  This remaining part is the core lock ordering fixes - each place where we might lock a second or further user while still holding a user lock we do one of two changes:
1) ensure we lock all users up-front so we lock them in the right order
2) unlock the first user before locking another one