### PR TITLE
testrunner.pl: option to make plan check failures non-fatal

### DIFF
--- a/cassandane/Cassandane/Unit/TestPlan.pm
+++ b/cassandane/Cassandane/Unit/TestPlan.pm
@@ -787,7 +787,9 @@ sub _check_selections ($self)
 
 sub check_sanity
 {
-    my ($self) = @_;
+    my ($self, %params) = @_;
+
+    my $nonfatal = delete $params{nonfatal};
 
     # collect tiny-tests directories that are used by test modules
     my %used_tt_dirs;
@@ -872,7 +874,13 @@ sub check_sanity
 
     if (@tt_errors) {
         print STDERR "$_\n" for @tt_errors;
-        die 'bad tiny-tests detected';
+
+        if ($nonfatal) {
+            warn 'bad tiny-tests detected';
+        }
+        else {
+            die 'bad tiny-tests detected';
+        }
     }
 }
 

--- a/cassandane/testrunner.pl
+++ b/cassandane/testrunner.pl
@@ -339,6 +339,7 @@ my ($opt, $usage) = describe_options(
     [],
     [ 'verbose|v+',    "make Cassandane and Cyrus much noisier; repeat (-vvv)"
                      . " for more (default: 0)", { default => 0 } ],
+    [ 'no-fatal-plan', "test plan sanity check failures are not fatal" ],
     [ 'no-ok',         "report only failures and errors, omitting passing tests" ],
     [ 'log-directory|L=s', "collect per-test logs under this directory" ],
     [ 'config=s',      "use this Cassandane config file instead of the default" ],
@@ -490,7 +491,7 @@ else
 {
     # Build the schedule per commandline
     $plan->schedule(@names);
-    $plan->check_sanity();
+    $plan->check_sanity(nonfatal => $opt->no_fatal_plan);
 
     # Run the schedule
     $want_formats{prettier} = 1 if not scalar keys %want_formats;


### PR DESCRIPTION
Ordinarily, you can't run any tests unless `$plan->check_sanity()` succeeds.  But if there's a problem, sometimes you want to know what else is broken, without being forced to fix the first problem first.  This PR adds an option to let tests run even if the sanity check complained.