### PR TITLE
httpd: escape calendar display-name in CalDAV GET

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_caldav_get_escape_displayname
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_caldav_get_escape_displayname
@@ -1,0 +1,100 @@
+#!perl
+use Cassandane::Tiny;
+use XML::Spice;
+
+# This test asserts that special characters in a CalDAV calendar
+# collection display name get escaped.
+# The display name is set both with JMAP Calendar/set and PROPPATCH.
+
+sub set_displayname_and_get_headers ($self, $method, $name)
+{
+    my $caldav = $self->{caldav};
+
+    # cassandane's own default calendar
+    my $calhref = '/dav/calendars/user/cassandane/Default';
+
+    if ($method eq 'jmap') {
+        my $jmap = $self->default_user->jmap;
+        my $cal_id = $self->default_user->calendars->default->id;
+
+        xlog $self, "set the display name via JMAP";
+        my $set = $jmap->request([[
+            'Calendar/set', {
+                update => { $cal_id => { name => $name } },
+            }, 'R1',
+        ]])->single_sentence('Calendar/set')->arguments;
+        $self->assert(exists $set->{updated}{$cal_id});
+    }
+    elsif ($method eq 'caldav') {
+        xlog $self, "set the display name via CalDAV PROPPATCH";
+        my $res = $caldav->Request(
+            'PROPPATCH', $calhref,
+            x('D:propertyupdate', $caldav->NS(),
+                x('D:set',
+                    x('D:prop',
+                        x('D:displayname', $name),
+                    ),
+                ),
+            ),
+            'Content-Type' => 'text/xml',
+        );
+        $self->assert_matches(qr{HTTP/[0-9.]+ 207\b}, $res->{headers}{status})
+            if ref $res eq 'HASH' && exists $res->{headers}{status};
+    }
+    else {
+        die "unknown method '$method'";
+    }
+
+    xlog $self, "GET the calendar as cassandane: $calhref";
+    my $service = $self->{instance}->get_service('http');
+    my $sock = $service->get_socket()
+        or die "cannot connect to http service: $!";
+    my $authority = $service->host() . ':' . $service->port();
+
+    $sock->print(
+        "GET $calhref HTTP/1.1\r\n"
+      . "Host: $authority\r\n"
+      . "Authorization: " . $caldav->auth_header() . "\r\n"
+      . "Connection: close\r\n"
+      . "\r\n"
+    );
+
+    my $raw = do { local $/; <$sock> };
+    close($sock);
+
+    xlog $self, "raw HTTP response:\n$raw";
+
+    $self->assert_matches(qr{^HTTP/[0-9.]+ 200\b}, $raw);
+
+    # Everything up to the first blank line is the response header block.
+    my ($rawheaders) = split /\r\n\r\n/, $raw, 2;
+    return $rawheaders;
+}
+
+sub assert_escape_displayname ($self, %params)
+{
+    my $method = $params{method}
+        // die "'method' parameter must be 'jmap' or 'caldav'";
+
+    # Handle CRLF in name.
+    my $rawheaders = $self->set_displayname_and_get_headers(
+        $method, "hello\r\nx-foo: world\r\n\r\n");
+    $self->assert_does_not_match(qr/^x-foo:/im, $rawheaders);
+
+    # Handle double quote or backslash in name.
+    $rawheaders = $self->set_displayname_and_get_headers($method, 'a"b\\c');
+    $self->assert_matches(qr/\Qfilename="a\"b\\c.ics"\E/, $rawheaders);
+}
+
+sub test_calendar_caldav_get_escape_displayname_jmap
+    :needs_component_jmap
+    ($self)
+{
+    $self->assert_escape_displayname(method => 'jmap');
+}
+
+sub test_calendar_caldav_get_escape_displayname_proppatch
+    ($self)
+{
+    $self->assert_escape_displayname(method => 'caldav');
+}

--- a/doc/logfmt-keys
+++ b/doc/logfmt-keys
@@ -93,6 +93,8 @@ send.time               when the message was actually sent
 
 cal.organizer           a calendar component's ORGANIZER
 cal.uid                 a calendar component's iCalendar UID
+http.header.name        the name of an HTTP header
+http.header.value       the value of an HTTP header
 imip.error              why an iMIP operation failed
 jmap.accountid          the JMAP account the request was for
 pop.subfolder           the subfolder a POP session was restricted to

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -3339,7 +3339,7 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
             /* Construct Content-Disposition header */
             char *encfname = NULL;
             for (const unsigned char *p = (unsigned char *)resp_body->dispo.fname; p && *p; p++) {
-                if (*p >= 0x80) {
+                if (*p < 0x20 || *p >= 0x7f) {
                     encfname = charset_encode_mimexvalue(resp_body->dispo.fname, NULL);
                     break;
                 }
@@ -3351,9 +3351,17 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
                 free(encfname);
             }
             else {
+                /* filename is printable ASCII: emit as a quoted-string,
+                 * backslash-escaping DQUOTE and backslash (RFC 9110, 5.6.4) */
+                struct buf fname = BUF_INITIALIZER;
+                for (const char *p = resp_body->dispo.fname; *p; p++) {
+                    if (*p == '"' || *p == '\\') buf_putc(&fname, '\\');
+                    buf_putc(&fname, *p);
+                }
                 simple_hdr(txn, "Content-Disposition", "%s; filename=\"%s\"",
                         resp_body->dispo.attach ? "attachment" : "inline",
-                        resp_body->dispo.fname);
+                        buf_cstring(&fname));
+                buf_free(&fname);
             }
         }
         if (txn->resp_body.enc.type) {

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2611,6 +2611,17 @@ EXPORTED const char *http_statusline(unsigned ver, long code)
 }
 
 
+/* Return true if s[0..len) contains a control character other than HTAB,
+ * see RFC 9110 5.6.4. */
+static bool has_illegal_hdr_char(const char *s, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        unsigned char c = s[i];
+        if ((c < ' ' && c != '\t') || c == 127) return true;
+    }
+    return false;
+}
+
 /* Output an HTTP response header.
  * 'code' specifies the HTTP Status-Code and Reason-Phrase.
  * 'txn' contains the transaction context
@@ -2627,6 +2638,16 @@ EXPORTED void simple_hdr(struct transaction_t *txn,
     va_end(args);
 
     syslog(LOG_DEBUG, "simple_hdr(%s: %s)", name, buf_cstring(&buf));
+
+    /* Drop headers with illegal characters. */
+    if (has_illegal_hdr_char(name, strlen(name)) ||
+        has_illegal_hdr_char(buf_base(&buf), buf_len(&buf))) {
+        xsyslog_ev(LOG_NOTICE, "http.header.dropped",
+                   lf_s("http.header.name", name),
+                   lf_s("http.header.value", buf_cstring(&buf)));
+        buf_free(&buf);
+        return;
+    }
 
     txn->conn->add_resp_header(txn, name, &buf);
 }
@@ -3339,7 +3360,7 @@ EXPORTED void response_header(long code, struct transaction_t *txn)
             /* Construct Content-Disposition header */
             char *encfname = NULL;
             for (const unsigned char *p = (unsigned char *)resp_body->dispo.fname; p && *p; p++) {
-                if (*p < 0x20 || *p >= 0x7f) {
+                if (*p < ' ' || *p >= 127) {
                     encfname = charset_encode_mimexvalue(resp_body->dispo.fname, NULL);
                     break;
                 }


### PR DESCRIPTION
This makes CalDAV GET properly escape display names in HTTP headers. It also changes httpd to not emit any header containing control characters in its name or value.