### PR TITLE
jmap_calendar.c: only support participantReply for organizer

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_reply_rsvp_attendee
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_reply_rsvp_attendee
@@ -1,0 +1,151 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_participantreply_reply_rsvp_attendee
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $default_cal_id = $self->default_user->calendars->default->id;
+
+    xlog $self, "create an event with some remote organizer";
+    my $res = $jmap->request([[
+        'CalendarEvent/set', {
+            sendSchedulingMessages => JSON::false,
+            create => {
+                1 => {
+                    version => "2.0",
+                    calendarIds => { $default_cal_id => JSON::true },
+                    sequence => 1,
+                    title => "An Event",
+                    freeBusyStatus => "busy",
+                    showWithoutTime => JSON::false,
+                    start => "2022-11-23T16:45:00",
+                    timeZone => "Australia/Melbourne",
+                    duration => "PT1H",
+                    organizerCalendarAddress =>
+                        "mailto:organizer\@example.com",
+                    participants => {
+                        organizer => {
+                            roles => { owner => JSON::true },
+                            calendarAddress =>
+                                'mailto:organizer@example.com',
+                        },
+                        cassandane => {
+                            roles => { attendee => JSON::true },
+                            participationStatus => "needs-action",
+                            calendarAddress => 'mailto:cassandane@example.com',
+                        },
+                        other => {
+                            roles => { attendee => JSON::true },
+                            participationStatus => "needs-action",
+                            calendarAddress => 'mailto:other@example.com',
+                        },
+                    },
+                },
+            },
+        },
+    ]])->single_sentence('CalendarEvent/set')->arguments;
+    my $id = $res->{created}{1}{id};
+    $self->assert_not_null($id);
+
+    # clean notification cache
+    $self->{instance}->getnotify();
+
+    xlog $self, "Attempt to RSVP on behalf of other attendee";
+    my $sentence = $jmap->request([[
+        'CalendarEvent/participantReply' => {
+            eventId => $id,
+            participantEmail => "other\@example.com",
+            updates => {
+                participationStatus => "accepted"
+            }
+        },
+    ]])->sentence(0);
+
+    xlog $self, "The RSVP attempt must be rejected";
+    $self->assert_str_equals('error', $sentence->name);
+    $self->assert_str_equals('forbidden', $sentence->arguments->{type});
+
+    xlog $self, "Check that no iMIP reply was sent";
+    my $data = $self->{instance}->getnotify();
+    my @imips = grep { $_->{METHOD} eq 'imip' } @$data;
+    foreach my $imip (@imips) {
+        my $payload = decode_json($imip->{MESSAGE});
+        $self->assert_str_not_equals("other\@example.com",
+                                     $payload->{sender});
+    }
+
+    xlog $self, "Check that participation status is unchanged";
+    $res = $jmap->request([[
+        'CalendarEvent/get' => {
+            ids => [$id],
+            properties => ['participants'],
+        },
+    ]])->single_sentence('CalendarEvent/get')->arguments;
+    $self->assert_str_equals("needs-action",
+        $res->{list}[0]{participants}{other}{participationStatus});
+
+    xlog $self, "create an event whose organizer is the account";
+    $res = $jmap->request([[
+        'CalendarEvent/set', {
+            sendSchedulingMessages => JSON::false,
+            create => {
+                2 => {
+                    version => "2.0",
+                    calendarIds => { $default_cal_id => JSON::true },
+                    sequence => 1,
+                    title => "Another Event",
+                    freeBusyStatus => "busy",
+                    showWithoutTime => JSON::false,
+                    start => "2022-11-23T16:45:00",
+                    timeZone => "Australia/Melbourne",
+                    duration => "PT1H",
+                    organizerCalendarAddress =>
+                        "mailto:cassandane\@example.com",
+                    participants => {
+                        cassandane => {
+                            roles => { owner => JSON::true },
+                            calendarAddress => 'mailto:cassandane@example.com',
+                        },
+                        other => {
+                            roles => { attendee => JSON::true },
+                            participationStatus => "needs-action",
+                            calendarAddress => 'mailto:other@example.com',
+                        },
+                    },
+                },
+            },
+        },
+    ]])->single_sentence('CalendarEvent/set')->arguments;
+    my $id2 = $res->{created}{2}{id};
+    $self->assert_not_null($id2);
+
+    # clean notification cache
+    $self->{instance}->getnotify();
+
+    xlog $self, "RSVP on behalf of other attendee is allowed when the "
+              . "organizer is one of the account's scheduling addresses";
+    $res = $jmap->request([[
+        'CalendarEvent/participantReply' => {
+            eventId => $id2,
+            participantEmail => "other\@example.com",
+            updates => {
+                participationStatus => "accepted"
+            }
+        },
+    ]])->single_sentence('CalendarEvent/participantReply')->arguments;
+    $self->assert_not_null($res->{scheduleStatus});
+
+    xlog $self, "Check that participation status changed";
+    $res = $jmap->request([[
+        'CalendarEvent/get' => {
+            ids => [$id2],
+            properties => ['participants'],
+        },
+    ]])->single_sentence('CalendarEvent/get')->arguments;
+    $self->assert_str_equals("accepted",
+        $res->{list}[0]{participants}{other}{participationStatus});
+
+    # clean notification cache
+    $self->{instance}->getnotify();
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_reply_rsvp_sharee
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_reply_rsvp_sharee
@@ -1,0 +1,140 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_participantreply_reply_rsvp_sharee
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+
+    xlog $self, "share cassandane's default calendar (read-only)";
+    my $default_cal_id = $self->default_user->calendars->default->id;
+    my ($shareeJmap) = $self->{instance}->create_user('sharee')->jmap;
+    $jmap->request([[
+        'Calendar/set', {
+            update => {
+                $default_cal_id => {
+                    shareWith => {
+                        sharee => {
+                            mayReadItems => JSON::true,
+                        },
+                    },
+                },
+            },
+        },
+    ]])->single_sentence('Calendar/set')->arguments;
+
+    xlog $self, "cassandane invites some other attendee";
+    my $res = $jmap->request([[
+        'CalendarEvent/set', {
+            create => {
+                1 => {
+                    version => "2.0",
+                    calendarIds => { $default_cal_id => JSON::true },
+                    sequence => 1,
+                    title => "public event",
+                    privacy => "public",
+                    freeBusyStatus => "busy",
+                    showWithoutTime => JSON::false,
+                    start => "2022-11-23T16:45:00",
+                    timeZone => "Australia/Melbourne",
+                    duration => "PT1H",
+                    organizerCalendarAddress =>
+                        "mailto:cassandane\@example.com",
+                    participants => {
+                        org => {
+                            roles => { owner => JSON::true },
+                            calendarAddress => 'mailto:cassandane@example.com',
+                        },
+                        other => {
+                            roles => { attendee => JSON::true },
+                            participationStatus => "needs-action",
+                            calendarAddress => 'mailto:other@example.com',
+                        },
+                    },
+                },
+            },
+        },
+    ]])->single_sentence('CalendarEvent/set')->arguments;
+    my $id = $res->{created}{1}{id};
+    $self->assert_not_null($id);
+
+    # Clean notifications
+    $self->{instance}->getnotify();
+
+    xlog $self, "Attempt as sharee to RSVP on behalf of other attendee";
+    my $sentence = $shareeJmap->request([[
+        'CalendarEvent/participantReply' => {
+            accountId => 'cassandane',
+            eventId => $id,
+            participantEmail => "other\@example.com",
+            updates => {
+                participationStatus => "accepted"
+            }
+        },
+    ]])->sentence(0);
+
+    xlog $self, "Check that RSVP attempt is rejected";
+    $self->assert_str_equals('error', $sentence->name);
+    $self->assert_str_equals('forbidden', $sentence->arguments->{type});
+
+    xlog $self, "Check that no iMIP reply was sent";
+    my $data = $self->{instance}->getnotify();
+    my @imips = grep { $_->{METHOD} eq 'imip' } @$data;
+    foreach my $imip (@imips) {
+        my $payload = decode_json($imip->{MESSAGE});
+        $self->assert_str_not_equals("other\@example.com", $payload->{sender});
+    }
+
+    xlog $self, "Check that participation status is unchanged";
+    $res = $jmap->request([[
+        'CalendarEvent/get' => {
+            ids => [$id],
+            properties => ['participants'],
+        },
+    ]])->single_sentence('CalendarEvent/get')->arguments;
+    $self->assert_str_equals("needs-action",
+        $res->{list}[0]{participants}{other}{participationStatus});
+
+    xlog $self, "grant the sharee the mayWriteAll right on the calendar";
+    $jmap->request([[
+        'Calendar/set', {
+            update => {
+                $default_cal_id => {
+                    shareWith => {
+                        sharee => {
+                            mayReadItems => JSON::true,
+                            mayWriteAll => JSON::true,
+                        },
+                    },
+                },
+            },
+        },
+    ]])->single_sentence('Calendar/set')->arguments;
+
+    # Clean notifications
+    $self->{instance}->getnotify();
+
+    xlog $self, "RSVP as sharee on behalf of other attendee is allowed when "
+              . "the sharee has the mayWriteAll right";
+    my $reply = $shareeJmap->request([[
+        'CalendarEvent/participantReply' => {
+            accountId => 'cassandane',
+            eventId => $id,
+            participantEmail => "other\@example.com",
+            updates => {
+                participationStatus => "accepted"
+            }
+        },
+    ]])->single_sentence('CalendarEvent/participantReply')->arguments;
+    $self->assert_not_null($reply->{scheduleStatus});
+
+    xlog $self, "Check that participation status changed";
+    $res = $jmap->request([[
+        'CalendarEvent/get' => {
+            ids => [$id],
+            properties => ['participants'],
+        },
+    ]])->single_sentence('CalendarEvent/get')->arguments;
+    $self->assert_str_equals("accepted",
+        $res->{list}[0]{participants}{other}{participationStatus});
+}

--- a/changes/next/cyr-3208-participantreply-organizer-only
+++ b/changes/next/cyr-3208-participantreply-organizer-only
@@ -1,0 +1,25 @@
+Description:
+
+The JMAP CalendarEvent/participantReply method now enforces that the event's
+organizer is one of the calendar owner's scheduling addresses. Calendar sharees
+acting on behalf of the owner must have the mayWriteAll JMAP calendar right set.
+
+
+Documentation:
+
+None.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -8536,8 +8536,8 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
     struct caldav_data *cdata = NULL;
     mbentry_t *mbentry = NULL;
     struct mailbox *mbox = NULL;
-    strarray_t schedule_addr = STRARRAY_INITIALIZER;
-    struct updateevent update = { .schedule_addresses = &schedule_addr };
+    strarray_t reply_addr = STRARRAY_INITIALIZER; // participant email address
+    struct updateevent update = { .schedule_addresses = &reply_addr };
     icalparameter_partstat ical_part_stat = ICAL_PARTSTAT_NONE;
     json_t *res = json_object();
     char *part_id = NULL;
@@ -8559,7 +8559,7 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
         update.eid = jmap_caleventid_lookup(json_string_value(jprop),
                                             db, &cdata);
     }
-    if (!update.eid->ical_uid) {
+    if (!update.eid || !update.eid->ical_uid) {
         jmap_parser_invalid(&parser, "eventId");
     }
     jprop = json_object_get(req->args, "participantEmail");
@@ -8568,7 +8568,7 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
         if (!strncasecmp(uri, "mailto:", 7)) uri += 7;
 
         char *addr = xmlURIUnescapeString(uri, strlen(uri), NULL);
-        strarray_appendm(&schedule_addr, addr);
+        strarray_appendm(&reply_addr, addr);
         part_email = addr;
     }
     else {
@@ -8682,6 +8682,45 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
     }
     mailbox_close(&mbox);
 
+    /* Validate the authenticated user may reply for the participant */
+    {
+        /* Determine the organizer of the event. */
+        icalcomponent *mastercomp =
+            icalcomponent_get_first_real_component(update.oldical);
+        icalproperty *orgprop = mastercomp ?
+            icalcomponent_get_first_property(mastercomp,
+                    ICAL_ORGANIZER_PROPERTY) : NULL;
+        const char *org = orgprop ?
+            icalproperty_get_decoded_calendaraddress(orgprop) : NULL;
+
+        /* Check that the organizer is one of the account's scheduling
+         * addresses. */
+        strarray_t sched_addrs = STRARRAY_INITIALIZER;
+        get_schedule_addresses(mbentry->name, req->accountid, &sched_addrs);
+        bool may_reply = org && strarray_contains_case(&sched_addrs, org);
+
+        /* Check that the authenticated user has the "mayWriteAll" right on
+         * this calendar. The owner of the calendar always may write all. */
+        if (may_reply && strcmp(req->userid, req->accountid)) {
+            may_reply = jmap_hasrights_mbentry(req, mbentry,
+                    JACL_WRITEALL|JACL_RSVP);
+        }
+
+        if (!may_reply) {
+            xsyslog_ev(LOG_NOTICE,
+                    "jmap.calendarevent.participantreply.forbidden",
+                    lf_s("u.username", req->userid),
+                    lf_s("jmap.accountid", req->accountid),
+                    lf_s("cal.organizer", org),
+                    lf_strarray("sched.addresses", &sched_addrs));
+            strarray_fini(&sched_addrs);
+            err = json_pack("{s:s}", "type", "forbidden");
+            goto done;
+        }
+
+        strarray_fini(&sched_addrs);
+    }
+
     /* Find participantId */
     icalcomponent *comp = icalcomponent_get_first_real_component(update.oldical);
     icalcomponent_kind kind = icalcomponent_isa(comp);
@@ -8766,7 +8805,7 @@ static int jmap_calendarevent_participantreply(struct jmap_req *req)
     }
 
     /* Create and send the reply */
-    sched_reply(req->accountid, req->accountid, &schedule_addr,
+    sched_reply(req->accountid, req->accountid, &reply_addr,
                 update.oldical, update.newical,
                 cdata->dav.createdmodseq, SCHED_MECH_JMAP_PARTREPLY);
 
@@ -8815,6 +8854,7 @@ no_op:
     /* Build response */
     req->accountid = NULL;
     jmap_ok(req, res);
+    res = NULL;  // ownership passed to the response
 
 done:
     if (!err) {
@@ -8847,9 +8887,10 @@ done:
     mailbox_close(&mbox);
     if (update.oldical) icalcomponent_free(update.oldical);
     if (update.newical) icalcomponent_free(update.newical);
+    json_decref(res);
     json_decref(update.event_patch);
     json_decref(update.old_event);
-    strarray_fini(&schedule_addr);
+    strarray_fini(&reply_addr);
     mboxlist_entry_free(&mbentry);
     free(part_id);
     return 0;


### PR DESCRIPTION
This makes the participantReply method reject the participant reply unless all of the following conditions are met:

1. the ORGANIZER of the event must match one of the scheduling addresses of the account to which the calendar of the event belongs
2. the authenticated user of the JMAP request either must be the owner of the calendar or must have the JMAP CalendarRight "mayWriteAll".

Attendees or non-attending sharees can not change the participation status.