### PR TITLE
jmap_calendar: fix busy period handling in Principal/getAvailability

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_mergedprivate
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_mergedprivate
@@ -1,0 +1,76 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarprincipal_getavailability_mergedprivate
+    ($self)
+{
+    my $jmap = $self->{jmap};
+    my $default_cal_id = $self->default_user->calendars->default->id;
+
+    # Two private events merge into a single busy period without event
+    # details, followed by a public event that keeps its details. This
+    # exercises compacting the busy period array while an event is set.
+
+    my $res = $jmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                'private-0900-1000' => {
+                    version => '2.0',
+                    calendarIds => {
+                        $default_cal_id => JSON::true,
+                    },
+                    title => "private-0900-1000",
+                    start => "2020-08-01T09:00:00",
+                    timeZone => "Etc/UTC",
+                    duration => "PT1H",
+                    privacy => 'private',
+                },
+                'private-0930-1100' => {
+                    version => '2.0',
+                    calendarIds => {
+                        $default_cal_id => JSON::true,
+                    },
+                    title => "private-0930-1100",
+                    start => "2020-08-01T09:30:00",
+                    timeZone => "Etc/UTC",
+                    duration => "PT1H30M",
+                    privacy => 'private',
+                },
+                'public-1200-1300' => {
+                    version => '2.0',
+                    calendarIds => {
+                        $default_cal_id => JSON::true,
+                    },
+                    title => "public-1200-1300",
+                    start => "2020-08-01T12:00:00",
+                    timeZone => "Etc/UTC",
+                    duration => "PT1H",
+                    privacy => 'public',
+                },
+            },
+        }, 'R1'],
+        ['Principal/getAvailability', {
+            id => 'cassandane',
+            utcStart => '2020-08-01T00:00:00Z',
+            utcEnd => '2020-09-01T00:00:00Z',
+            showDetails => JSON::true,
+            eventProperties => ['start', 'title'],
+        }, 'R2'],
+    ]);
+    $self->assert_num_equals(3, scalar keys %{$res->[0][1]{created}});
+
+    $self->assert_cmp_deeply([{
+        utcStart => "2020-08-01T09:00:00Z",
+        utcEnd => "2020-08-01T11:00:00Z",
+        busyStatus => 'unavailable',
+        event => undef,
+    }, {
+        utcStart => "2020-08-01T12:00:00Z",
+        utcEnd => "2020-08-01T13:00:00Z",
+        busyStatus => 'unavailable',
+        event => {
+            start => "2020-08-01T12:00:00",
+            title => 'public-1200-1300',
+        },
+    }], $res->[1][1]{list});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_nobusyperiods
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_nobusyperiods
@@ -1,0 +1,40 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarprincipal_getavailability_nobusyperiods($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    my $calendar_id = $user->calendars->default->id;
+
+    xlog $self, "create event outside of the availability time range";
+    my $res = $jmap->request([[
+        'CalendarEvent/set' => {
+            create => {
+                event1 => {
+                    version => '2.0',
+                    calendarIds => {
+                        $calendar_id => JSON::true,
+                    },
+                    title => 'event1',
+                    start => '2020-09-15T09:00:00',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                },
+            },
+        },
+    ]])->single_sentence('CalendarEvent/set')->arguments;
+
+    $self->assert_not_null($res->{created}{event1});
+
+    xlog $self, "assert that no busy periods are returned";
+    $res = $jmap->request([[
+        'Principal/getAvailability' => {
+            id => 'cassandane',
+            utcStart => '2020-08-01T00:00:00Z',
+            utcEnd => '2020-09-01T00:00:00Z',
+        },
+    ]])->single_sentence('Principal/getAvailability')->arguments;
+
+    $self->assert_cmp_deeply([], $res->{list});
+}

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -7955,7 +7955,10 @@ static int eventquery_run(jmap_req_t *req,
         matches = mymatches;
 
         struct eventquery_cmp_rock rock = { sort, nsort };
-        cyr_qsort_r(matches.data, matches.count, sizeof(void*), eventquery_cmp, &rock);
+        if (matches.count) {
+            cyr_qsort_r(matches.data, matches.count, sizeof(void*),
+                        eventquery_cmp, &rock);
+        }
     }
 
     query->total = ptrarray_size(&matches);
@@ -9608,8 +9611,10 @@ static int principal_query(jmap_req_t *req, struct jmap_query *query, json_t **e
             is_ascending = 0;
         }
     }
-    cyr_qsort_r(matches.data, matches.count, sizeof(char*),
-                principalid_cmp, (void*)(intptr_t) is_ascending);
+    if (matches.count) {
+        cyr_qsort_r(matches.data, matches.count, sizeof(char*),
+                    principalid_cmp, (void*)(intptr_t) is_ascending);
+    }
 
     /* Apply windowing */
     size_t startpos = 0;
@@ -10208,8 +10213,12 @@ static void principal_getavailability(jmap_req_t *req,
      * property. If there are overlapping BusyPeriod time ranges with
      * different “busyStatus” properties the server MUST choose the value in
      * the following order: confirmed > unavailable > tentative. */
-    cyr_qsort_r(busyperiods->data, busyperiods->count, sizeof(struct busyperiod),
-            (int(*)(const void*, const void*, void*))busyperiod_cmp, NULL);
+    if (busyperiods->count) {
+        cyr_qsort_r(busyperiods->data, busyperiods->count,
+                    sizeof(struct busyperiod),
+                    (int (*)(const void *, const void *, void *))busyperiod_cmp,
+                    NULL);
+    }
     int count = dynarray_size(busyperiods) ? 1 : 0;
     int i;
     for (i = 1; i < dynarray_size(busyperiods); i++) {
@@ -10220,6 +10229,8 @@ static void principal_getavailability(jmap_req_t *req,
             if (count != i) {
                 /* Insert new busy period */
                 dynarray_set(busyperiods, count, bp);
+                /* Ownership of jevent moved to the new slot */
+                bp->jevent = NULL;
             }
             count++;
         }


### PR DESCRIPTION
Add a Cassandane test for a Principal/getAvailability result without any busy periods, and one for a result where two merged busy periods are followed by a busy period that carries event details. Fixes calls to qsort for empty busy period arrays.

The fix originally was part of https://github.com/cyrusimap/cyrus-imapd/pull/6250.