### PR TITLE
cassandane: add the CalendarEvent test entity datatype

### DIFF
--- a/cassandane/Cassandane/TestEntity/DataType/Calendar.pm
+++ b/cassandane/Cassandane/TestEntity/DataType/Calendar.pm
@@ -47,9 +47,9 @@ true C<isDefault> property.
         @extra && Carp::confess("user has more than one default Calendar");
 
         $self->instance_class->new({
-            id  => "$objs[0]{id}",
+            id  => "$default->{id}",
             factory    => $self,
-            properties => $objs[0],
+            properties => $default,
         })
     }
 
@@ -65,11 +65,32 @@ true C<isDefault> property.
 package Cassandane::TestEntity::Instance::Calendar {
     use Moo;
 
+    use JSON ();
+
     use Cassandane::TestEntity::AutoSetup properties => [ qw(
         name
     ) ];
 
     with 'Cassandane::TestEntity::Role::ShareableInstance';
+
+=head2 create_event
+
+    my $event = $cal->create_event({ ... });
+
+This method creates a CalendarEvent instance that's in C<< $cal >> and no other
+calendars.
+
+=cut
+
+    sub create_event {
+        my ($self, $prop) = @_;
+        $prop //= {};
+
+        $self->user->calendarevents->create({
+            %$prop,
+            calendarIds => { $self->id => JSON::true() },
+        });
+    }
 
     no Moo;
 }

--- a/cassandane/Cassandane/TestEntity/DataType/CalendarEvent.pm
+++ b/cassandane/Cassandane/TestEntity/DataType/CalendarEvent.pm
@@ -1,0 +1,126 @@
+use v5.28.0;
+package Cassandane::TestEntity::DataType::CalendarEvent;
+
+=head1 NAME
+
+Cassandane::TestEntity::DataType::CalendarEvent - the CalendarEvent entity datatype
+
+=head1 FACTORY METHODS
+
+=cut
+
+package Cassandane::TestEntity::Factory::CalendarEvent {
+    use Moo;
+
+    use Data::GUID ();
+    use DateTime ();
+    use JSON ();
+
+=head2 create
+
+The create method provide sensible defaults, as usual.
+
+=cut
+
+    sub fill_in_creation_defaults {
+        my ($self, $prop) = @_;
+
+        state $i = 1;
+        $prop->{title} //= 'Event #' . $i++;
+
+        my $show_without_time = $prop->{showWithoutTime};
+
+        unless ($show_without_time || exists $prop->{timeZone}) {
+            $prop->{timeZone} = 'Etc/UTC';
+        }
+
+        unless (exists $prop->{start}) {
+            my $now = DateTime->now(
+                time_zone => $prop->{timeZone} // 'Etc/UTC',
+            );
+            $now->truncate(to => 'day') if $show_without_time;
+            $prop->{start} = $now->strftime('%Y-%m-%dT%H:%M:%S');
+        }
+
+        unless (exists $prop->{duration}) {
+            $prop->{duration} = $show_without_time ? 'P1D' : 'PT1H';
+        }
+
+        $prop->{uid}     //= Data::GUID->new->as_string;
+        $prop->{version} //= '2.0';
+
+        $prop->{calendarIds} //= {
+            $self->user->calendars->default->id => JSON::true(),
+        };
+
+        return;
+    }
+
+    use Cassandane::TestEntity::AutoSetup;
+
+    no Moo;
+}
+
+=head1 INSTANCE METHODS
+
+=cut
+
+package Cassandane::TestEntity::Instance::CalendarEvent {
+    use Moo;
+
+    use Cassandane::TestEntity::AutoSetup properties => [ qw(
+        alerts
+        baseEventId
+        blobId
+        calendarIds
+        categories
+        color
+        created
+        description
+        descriptionContentType
+        duration
+        endTimeZone
+        freeBusyStatus
+        hideAttendees
+        isDraft
+        isOrigin
+        keywords
+        links
+        locale
+        locations
+        mainLocationId
+        mayInviteOthers
+        mayInviteSelf
+        method
+        organizerCalendarAddress
+        participants
+        priority
+        privacy
+        prodId
+        recurrenceId
+        recurrenceIdTimeZone
+        recurrenceOverrides
+        recurrenceRule
+        relatedTo
+        scheduleSequence
+        scheduleUpdated
+        sentBy
+        sequence
+        showWithoutTime
+        start
+        status
+        timeZone
+        title
+        uid
+        updated
+        useDefaultAlerts
+        utcEnd
+        utcStart
+        version
+        virtualLocations
+    ) ];
+
+    no Moo;
+}
+
+1;

--- a/cassandane/Cassandane/TestUser.pm
+++ b/cassandane/Cassandane/TestUser.pm
@@ -170,6 +170,10 @@ The following methods return factories for the relevant datatypes:
 
 returns a L<Cassandane::TestEntity::DataType::AddressBook> factory
 
+=item calendarevents
+
+returns a L<Cassandane::TestEntity::DataType::CalendarEvent> factory
+
 =item calendars
 
 returns a L<Cassandane::TestEntity::DataType::Calendar> factory
@@ -200,11 +204,12 @@ datatype.  Mailboxes are just used as an example.
 =cut
 
 for my $pair (
-    [ addressbooks => 'AddressBook' ],
-    [ calendars    => 'Calendar' ],
-    [ contacts     => 'ContactCard' ],
-    [ emails       => 'Email' ],
-    [ mailboxes    => 'Mailbox' ],
+    [ addressbooks   => 'AddressBook' ],
+    [ calendarevents => 'CalendarEvent' ],
+    [ calendars      => 'Calendar' ],
+    [ contacts       => 'ContactCard' ],
+    [ emails         => 'Email' ],
+    [ mailboxes      => 'Mailbox' ],
 ) {
     my ($attr, $moniker) = @$pair;
     my $module = "Cassandane::TestEntity::DataType::$moniker";


### PR DESCRIPTION
This adds a test entity for calendar events. This originally was part of https://github.com/cyrusimap/cyrus-imapd/pull/6250, now with minor changes (e.g. uses the `default` function to determine the default calendar id, rather than using the first calendar in the list).