### PR TITLE
cass gdb hints: Escape '!' in path names so bash is happy

### DIFF
--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -1747,6 +1747,7 @@ sub find_cores
         if (defined $prog) {
            xlog "   from program $prog";
            my ($bin) = $prog =~ m/^(\S+)/; # binary only
+           $core =~ s/!/\\!/g;
            xlog "   debug: sudo gdb $bin $core";
         }
     }


### PR DESCRIPTION
When cass detects a core file, it provides a hint for how to run gdb against it. The core files usually look like this:

    .../cores/core.!usr!cyrus!libexec!httpd.12345.6.789

bash interprets '!' specially, trying to use cassandane's gdb hint usually produces an error like:

    bash: !usr!cyrus!libexec!httpd.12345.6.789: event not found

If we escape it then you can copy/paste it as is and everyone's happy.