### PR TITLE
replication: converge quota modseq, usergroups and raclmodseq

### DIFF
--- a/cassandane/Cassandane/Cyrus/Replication.pm
+++ b/cassandane/Cassandane/Cyrus/Replication.pm
@@ -7,6 +7,8 @@ use warnings;
 use Data::Dumper;
 use DateTime;
 
+use Cyrus::DList;
+
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::CRLF;
 use Cassandane::Util::Log;
@@ -65,6 +67,28 @@ sub assert_user_sub_not_exists
     xlog $self, "Looking for subscriptions file $subs";
 
     $self->assert_not_file_test($subs, '-f');
+}
+
+sub imap_getusergroup
+{
+    my ($self, $talk, $item) = @_;
+
+    my $usergroups = {};
+    my $handlers = {
+        'usergroup' => sub {
+            my (undef, $response) = @_;
+
+            my %ug = @{$response};
+            while (my ($user, $groups) = each %ug) {
+                $usergroups->{$user} = { map { $_ => 1 } @{$groups} };
+            }
+        },
+    };
+
+    $talk->_imap_cmd('GETUSERGROUP', 0, $handlers, $item);
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    return $usergroups;
 }
 
 use Cassandane::Tiny::Loader;

--- a/cassandane/tiny-tests/Replication/quota_modseq
+++ b/cassandane/tiny-tests/Replication/quota_modseq
@@ -1,0 +1,71 @@
+#!perl
+use Cassandane::Tiny;
+
+sub quota_record
+{
+    my ($self, $instance, $root) = @_;
+
+    my (undef, $rec) = $instance->run_dbcommand(
+        $instance->get_basedir() . '/conf/quotas.db', 'twoskip',
+        ['SHOW', $root]);
+    $self->assert_not_null($rec);
+
+    return Cyrus::DList->parse_string($rec)->as_perl();
+}
+
+sub set_quota_modseq
+{
+    my ($self, $instance, $root, $modseq) = @_;
+
+    my $hash = $self->quota_record($instance, $root);
+    $hash->{MODSEQ} = $modseq;
+    $instance->run_dbcommand(
+        $instance->get_basedir() . '/conf/quotas.db', 'twoskip',
+        ['SET', $root, Cyrus::DList->new_perl('', $hash)->as_string()]);
+}
+
+sub test_quota_modseq
+    :Conversations :NoStartInstances
+    ($self)
+{
+    # quotalegacy keeps one file per root, which run_dbcommand can't read
+    $_->{config}->set(quota_db => 'twoskip')
+        for ($self->{instance}, $self->{replica});
+    $self->_start_instances();
+
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->setquota("user.cassandane", "(storage 100000)");
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $self->run_replication();
+
+    my $modseq = $self->quota_record($self->{instance},
+                                     'user.cassandane')->{MODSEQ};
+    $self->assert_num_not_equals(0, $modseq);
+    $self->assert_num_equals($modseq,
+        $self->quota_record($self->{replica}, 'user.cassandane')->{MODSEQ});
+
+    # the modseq drifts on its own: the master allocates a fresh one from its
+    # own counters on every usage change, while the replica applies silently
+    # and keeps whatever it had.  a difference in the modseq alone has to be
+    # enough to bring the two back together
+    $self->set_quota_modseq($self->{replica}, 'user.cassandane', $modseq - 1);
+    $self->assert_num_equals($modseq - 1,
+        $self->quota_record($self->{replica}, 'user.cassandane')->{MODSEQ});
+
+    $self->run_replication();
+    $self->assert_num_equals($modseq,
+        $self->quota_record($self->{replica}, 'user.cassandane')->{MODSEQ});
+
+    # and a usage change, which moves the modseq while leaving the limits
+    # exactly where they were
+    $self->make_message("quota bump");
+
+    my $bumped = $self->quota_record($self->{instance},
+                                     'user.cassandane')->{MODSEQ};
+    $self->assert_num_not_equals($modseq, $bumped);
+
+    $self->run_replication();
+    $self->assert_num_equals($bumped,
+        $self->quota_record($self->{replica}, 'user.cassandane')->{MODSEQ});
+}

--- a/cassandane/tiny-tests/Replication/splitconv_basecid
+++ b/cassandane/tiny-tests/Replication/splitconv_basecid
@@ -1,0 +1,44 @@
+#!perl
+use Cassandane::Tiny;
+
+sub basecids
+{
+    my ($self, $store) = @_;
+
+    my $talk = $store->get_client();
+    $talk->select('INBOX');
+    my $res = $talk->fetch('1:*', '(uid basecid)');
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    return { map { $_ => $res->{$_}->{basecid} // '' } keys %$res };
+}
+
+sub test_splitconv_basecid
+    :Conversations :NoStartInstances
+    ($self)
+{
+    $_->{config}->set(conversations_max_thread => 5)
+        for ($self->{instance}, $self->{replica});
+    $self->_start_instances();
+
+    my $msg = $self->make_message("Message A");
+    $self->make_message("Re: Message A", references => [ $msg ]) for (1..6);
+
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    my $master = $self->basecids($self->{store});
+    $self->assert(scalar grep { $_ } values %$master);
+    $self->assert_deep_equals($master, $self->basecids($self->{replica_store}));
+
+    # zeroing the cids drops basecid on the master.  the replica has to follow:
+    # it can only ever have got its own value from here
+    $self->{instance}->run_command({ cyrus => 1 }, 'ctl_conversationsdb',
+                                   '-z', 'cassandane');
+
+    $master = $self->basecids($self->{store});
+    $self->assert_num_equals(0, scalar grep { $_ } values %$master);
+
+    $self->run_replication();
+    $self->assert_deep_equals($master, $self->basecids($self->{replica_store}));
+}

--- a/cassandane/tiny-tests/Replication/usergroups_alone
+++ b/cassandane/tiny-tests/Replication/usergroups_alone
@@ -1,0 +1,39 @@
+#!perl
+use Cassandane::Tiny;
+
+sub replica_usergroups
+{
+    my ($self, $userid) = @_;
+
+    # a fresh store each time: run_replication() disconnects everything
+    my $store = $self->{replica}->get_service('imap')
+                     ->create_store(username => 'admin');
+    return $self->imap_getusergroup($store->get_client(), $userid)->{$userid};
+}
+
+sub test_usergroups_alone
+    :Mboxgroups :ReverseACLs
+    ($self)
+{
+    # settle everything first, so that a group change is the only thing
+    # left for the next replication run to notice
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->_imap_cmd('SETUSERGROUP', 0, '', 'cassandane', 'group:shared');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $self->run_replication();
+    $self->assert_not_null(
+        $self->replica_usergroups('cassandane')->{'group:shared'});
+
+    $admintalk = $self->{adminstore}->get_client();
+    $admintalk->_imap_cmd('UNSETUSERGROUP', 0, '', 'cassandane',
+                          'group:shared');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    $self->run_replication();
+    $self->assert_null(
+        $self->replica_usergroups('cassandane')->{'group:shared'});
+}

--- a/changes/next/replication-basecid-splitconversation
+++ b/changes/next/replication-basecid-splitconversation
@@ -1,0 +1,41 @@
+Description:
+
+A replica can now lose a basethrid (basecid) that the master no longer has.
+Previously it could only ever gain one, and a mailbox in that state failed
+replication with "Replication inconsistency detected" on every run.
+
+FLAG_INTERNAL_SPLITCONVERSATION guards basecid - below mailbox version 20 it
+is what makes the value readable back out of its annotation, and
+mailbox_rewrite_index_record() restores basecid from the old record whenever
+the flag is set but the value is zero.  The flag is not part of the sync
+protocol, and sync_mailbox_compare_update() keeps the replica's own internal
+flags for everything except EXPUNGED, so a record which took basecid == 0 from
+the master went into the rewrite with the flag still set and had the replica's
+own basecid put straight back.  For version 20 mailboxes basecid is part of the
+sync CRC, so the two ends never agreed again.  The flag now follows the basecid
+wherever one is taken from the peer.
+
+compare_one_record() also took the replica's cid without its basecid when the
+replica's copy was the more recent one, leaving the master with a base thread
+id belonging to a conversation it no longer referenced - and then pushing that
+back over the replica's.  It takes both now.
+
+
+Documentation:
+
+(none)
+
+
+Config changes:
+
+(none)
+
+
+Upgrade instructions:
+
+(none)
+
+
+GitHub issue:
+
+(none)

--- a/changes/next/replication-quota-modseq-usergroups
+++ b/changes/next/replication-quota-modseq-usergroups
@@ -1,0 +1,46 @@
+Description:
+
+Replication now converges the quota modseq, usergroup memberships and the
+reverse-ACL modseq, none of which could previously come back into agreement
+once the two sides had drifted apart.
+
+The quota modseq moves on every usage change, so on a busy master it is almost
+always the only part of a quota root that differs.  Nothing carried it: the
+replica dropped the MODSEQ out of the QUOTA response it was already sending,
+update_quota_work() compared only the limits and so never sent a QUOTA for a
+modseq-only difference, mboxlist_setquotas() applied the replicated modseq only
+when a limit had also moved, and quota_write() then overwrote it with the
+replica's own highestmodseq.  All four are fixed, so the replica now stores the
+master's value verbatim.  This is what JMAP Quota/changes state is built from,
+so a replica which had drifted backwards would, once promoted, hand out states
+below ones its clients already held.
+
+is_unchanged(), which decides whether sync_client sends a mailbox at all, never
+compared USERGROUPS and ignored RACLMODSEQ whenever either side was zero.  A
+usergroup added on the master therefore sat there until something else about
+the mailbox changed, and a replica with no racl modseq never acquired one.
+Both are now compared.  USERGROUPS is also sent when the list is empty, so that
+removing a user's last group replicates, and the replica records RACLMODSEQ
+even with reverseacls off locally, so that it can converge either way.
+
+
+Documentation:
+
+(none)
+
+
+Config changes:
+
+(none)
+
+
+Upgrade instructions:
+
+The RACLMODSEQ comparison no longer tolerates a peer which doesn't report one.
+Replicas older than 3.1.7, which predates RACLMODSEQ in the sync protocol, will
+have their user INBOXes re-sent on every run.
+
+
+GitHub issue:
+
+(none)

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -4902,20 +4902,29 @@ EXPORTED int mboxlist_setquotas(const char *root,
                     mboxevent_extract_quota(quotawithin_event, &q, res);
             }
         }
+        int limitschanged = q.dirty;
+
+        /* the modseq is replicated in its own right - it moves on every usage
+         * change, so it's usually the only thing that differs */
+        if (quotamodseq && q.modseq != quotamodseq) {
+            q.modseq = quotamodseq;
+            q.dirty = 1;
+        }
+
         if (q.dirty) {
-            if (quotamodseq)
-                q.modseq = quotamodseq;
             r = quota_write(&q, silent, &tid);
 
-            if (quotachange_event == NULL) {
-                quotachange_event = mboxevent_enqueue(EVENT_QUOTA_CHANGE, &mboxevents);
-            }
+            if (limitschanged) {
+                if (quotachange_event == NULL) {
+                    quotachange_event = mboxevent_enqueue(EVENT_QUOTA_CHANGE, &mboxevents);
+                }
 
-            for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
-                mboxevent_extract_quota(quotachange_event, &q, res);
-            }
+                for (res = 0; res < QUOTA_NUMRESOURCES; res++) {
+                    mboxevent_extract_quota(quotachange_event, &q, res);
+                }
 
-            auditlog_quota("setquota", root, oldquotas, newquotas);
+                auditlog_quota("setquota", root, oldquotas, newquotas);
+            }
         }
 
         if (!r)

--- a/imap/quota_db.c
+++ b/imap/quota_db.c
@@ -428,8 +428,12 @@ EXPORTED int quota_write(struct quota *quota, int silent, struct txn **tid)
     if (!qrlen) return IMAP_QUOTAROOT_NONEXISTENT;
 
     if (quota->dirty && mboxname_isusermailbox(quota->root, /*isinbox*/0)) {
-        if (silent)
-            quota->modseq = mboxname_setquotamodseq(quota->root, quota->modseq);
+        if (silent) {
+            /* raise the counters, but store the caller's modseq verbatim.
+             * setquotamodseq returns the local highestmodseq, which would
+             * replace a replicated value with one the master never issued */
+            mboxname_setquotamodseq(quota->root, quota->modseq);
+        }
         else
             quota->modseq = mboxname_nextquotamodseq(quota->root, quota->modseq);
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -1807,6 +1807,18 @@ static int sync_getflags(struct dlist *kl,
     return 0;
 }
 
+/* basecid is only meaningful while SPLITCONVERSATION is set: below version 20
+ * it's read back from an annotation, and mailbox_rewrite_index_record()
+ * restores it from the old record while the flag is set.  The flag isn't on
+ * the wire, so anywhere we take a basecid from the peer we set it ourselves. */
+static void sync_set_splitconversation(struct index_record *record)
+{
+    if (record->basecid)
+        record->internal_flags |= FLAG_INTERNAL_SPLITCONVERSATION;
+    else
+        record->internal_flags &= ~FLAG_INTERNAL_SPLITCONVERSATION;
+}
+
 static int parse_upload(struct dlist *kr, struct mailbox *mailbox,
                         struct index_record *record,
                         struct sync_annot_list **salp)
@@ -1842,6 +1854,9 @@ static int parse_upload(struct dlist *kr, struct mailbox *mailbox,
     /* the ANNOTATIONS list is optional too */
     if (salp && dlist_getlist(kr, "ANNOTATIONS", &fl))
         r = decode_annotations(fl, salp, mailbox, record);
+
+    /* basecid arrives with the annotations */
+    sync_set_splitconversation(record);
 
     return r;
 }
@@ -3113,6 +3128,11 @@ static int sync_mailbox_compare_update(struct mailbox *mailbox,
              * non-EXPUNGED, but master's internal_flags for EXPUNGED */
             copy.internal_flags = rrecord->internal_flags & ~FLAG_INTERNAL_EXPUNGED;
             copy.internal_flags |= mrecord.internal_flags & FLAG_INTERNAL_EXPUNGED;
+            /* SPLITCONVERSATION guards basecid, which we just took from the
+             * master, so it has to come from there too - it isn't on the wire,
+             * and mailbox_rewrite_index_record() puts the replica's own
+             * basecid back while the flag is still set */
+            sync_set_splitconversation(&copy);
 
             for (i = 0; i < MAX_USER_FLAGS/32; i++)
                 copy.user_flags[i] = mrecord.user_flags[i];
@@ -6523,6 +6543,9 @@ static int compare_one_record(struct sync_client_state *sync_cs,
             mp->internal_flags |= rp->internal_flags & FLAG_INTERNAL_EXPUNGED;
 
             mp->cid = rp->cid;
+            /* basecid is only meaningful against the cid we just took */
+            mp->basecid = rp->basecid;
+            sync_set_splitconversation(mp);
             for (i = 0; i < MAX_USER_FLAGS/32; i++)
                 mp->user_flags[i] = rp->user_flags[i];
         }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -674,6 +674,7 @@ void sync_folder_list_free(struct sync_folder_list **lp)
         free(current->name);
         free(current->partition);
         free(current->acl);
+        free(current->groups);
         sync_annot_list_free(&current->annots);
         free(current);
         current = next;

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -2078,14 +2078,17 @@ static int sync_prepare_dlists(struct mailbox *mailbox,
         if (raclmodseq)
             dlist_setnum64(kl, "RACLMODSEQ", raclmodseq);
         char *userid = mboxname_to_userid(mailbox_name(mailbox));
-        strarray_t groups = STRARRAY_INITIALIZER;
-        int r = mboxlist_lookup_usergroups(userid, &groups);
-        if (!r && strarray_size(&groups)) {
-            char *groupstxt = strarray_join(&groups, "\t");
-            dlist_setatom(kl, "USERGROUPS", groupstxt);
-            free(groupstxt);
+        if (userid) {
+            strarray_t groups = STRARRAY_INITIALIZER;
+            if (!mboxlist_lookup_usergroups(userid, &groups)) {
+                /* always sent, even empty: otherwise removing a user's last
+                 * group never reaches the replica */
+                char *groupstxt = strarray_join(&groups, "\t");
+                dlist_setatom(kl, "USERGROUPS", groupstxt ? groupstxt : "");
+                free(groupstxt);
+            }
+            strarray_fini(&groups);
         }
-        strarray_fini(&groups);
         free(userid);
     }
     dlist_setnum32(kl, "VERSION", mailbox->i.minor_version);
@@ -3715,7 +3718,9 @@ static int sync_apply_mailbox(struct dlist *kin,
         r = mailbox_update_xconvmodseq(mailbox, xconvmodseq, opt_force);
     }
 
-    if (config_getswitch(IMAPOPT_REVERSEACLS) && raclmodseq) {
+    /* record it even with reverseacls off here: it's just a counter, and the
+     * replica has to carry it or it can never converge with the master */
+    if (raclmodseq) {
         mboxname_setraclmodseq(mailbox_name(mailbox), raclmodseq);
     }
 
@@ -5677,6 +5682,7 @@ static int sync_kl_parse(struct dlist *kin,
             if (!dlist_getatom(kl, "ROOT", &root)) return IMAP_PROTOCOL_BAD_PARAMETERS;
             sq = sync_quota_list_add(quota_list, root);
             sync_decode_quota_limits(kl, sq->limits);
+            dlist_getnum64(kl, "MODSEQ", &sq->modseq);
         }
 
         else if (!strcmp(kl->name, "LSUB")) {
@@ -6089,6 +6095,10 @@ static int update_quota_work(struct sync_client_state *sync_cs,
             if (client->limits[res] != server->limits[res])
                 changed++;
         }
+        /* the modseq is the JMAP Quota state, so it has to converge in its own
+         * right - the master allocates a new one on every usage change */
+        if (client->modseq != server->modseq)
+            changed++;
         if (!changed)
             return 0;
     }
@@ -6901,8 +6911,24 @@ static int is_unchanged(struct mailbox *mailbox, struct sync_folder *remote)
 
     if (config_getswitch(IMAPOPT_REVERSEACLS)) {
         modseq_t raclmodseq = mboxname_readraclmodseq(mailbox_name(mailbox));
-        // don't bail if either are zero, that could be version skew
-        if (raclmodseq && remote->raclmodseq && remote->raclmodseq != raclmodseq) return 0;
+        if (remote->raclmodseq != raclmodseq) return 0;
+    }
+
+    /* usergroups are per-user, but they ride along with every mailbox.  the
+     * empty string is a real value here - it means "this user is in no
+     * groups" - so only NULL means the peer didn't tell us */
+    if (remote->groups) {
+        char *userid = mboxname_to_userid(mailbox_name(mailbox));
+        strarray_t groups = STRARRAY_INITIALIZER;
+        int same = 1;
+        if (!mboxlist_lookup_usergroups(userid, &groups)) {
+            char *groupstxt = strarray_join(&groups, "\t");
+            same = !strcmp(groupstxt ? groupstxt : "", remote->groups);
+            free(groupstxt);
+        }
+        strarray_fini(&groups);
+        free(userid);
+        if (!same) return 0;
     }
 
     if (mailbox_has_conversations(mailbox)) {
@@ -7042,8 +7068,10 @@ static int update_mailbox_once(struct sync_client_state *sync_cs,
         if (r) goto done;
     }
 
-    /* bump the raclmodseq if it's higher on the replica */
-    if (remote && is_repeat && remote->raclmodseq) {
+    /* bump the raclmodseq if it's higher on the replica.  setraclmodseq only
+     * raises, so without this the higher side would never come back down and
+     * is_unchanged would send this mailbox on every run forever */
+    if (remote && remote->raclmodseq) {
         mboxname_setraclmodseq(mailbox_name(mailbox), remote->raclmodseq);
     }
 

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -137,6 +137,7 @@ struct sync_quota {
     struct sync_quota *next;
     char *root;
     quota_t limits[QUOTA_NUMRESOURCES];
+    modseq_t modseq;
     int done;
 };
 


### PR DESCRIPTION
These values were getting out of sync between replicas, and are actually all needed in order for JMAP queries to return the right things, so they have to be replicated.