### PR TITLE
ical_support: a VTODO with DUE and no DTSTART has one occurrence, at DUE

### DIFF
--- a/cassandane/tiny-tests/CaldavAlarm/vtodo_due_no_dtstart
+++ b/cassandane/tiny-tests/CaldavAlarm/vtodo_due_no_dtstart
@@ -1,0 +1,63 @@
+#!perl
+use Cassandane::Tiny;
+use Data::UUID;
+
+sub test_vtodo_due_no_dtstart
+  : needs_component_calalarmd
+    ($self)
+{
+    my $caldav = $self->{caldav};
+
+    my $calendarId = $caldav->NewCalendar({ name => 'foo' });
+    $self->assert_not_null($calendarId);
+
+    my $now = DateTime->now();
+    $now->set_time_zone('Etc/UTC');
+
+    # A task due in an hour, wanting ten minutes' notice. Per RFC 5545,
+    # Section 3.6.2, a VTODO may carry DUE and no DTSTART - a deadline with
+    # no moment at which it begins - and Section 3.8.6.3 says RELATED=END
+    # then refers to DUE.
+    my $due = $now->clone();
+    $due->add(DateTime::Duration->new(seconds => 3600));
+
+    my $dtstamp = $now->strftime('%Y%m%dT%H%M%SZ');
+    my $dueStr  = $due->strftime('%Y%m%dT%H%M%SZ');
+    my $uid     = (Data::UUID->new)->create_str;
+
+    $caldav->Request(
+        'PUT', "$calendarId/$uid.ics", <<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:VTODO
+UID:$uid
+SUMMARY:renew the certificate
+DTSTAMP:$dtstamp
+DUE:$dueStr
+STATUS:NEEDS-ACTION
+SEQUENCE:0
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:alarm
+TRIGGER;RELATED=END:-PT10M
+END:VALARM
+END:VTODO
+END:VCALENDAR
+EOF
+        , 'Content-Type' => 'text/calendar'
+    );
+
+    # Nothing yet: the alarm is fifty minutes off.
+    $self->{instance}->getnotify();
+    $self->{instance}->run_command({ cyrus => 1 },
+        'calalarmd', '-t' => $now->epoch() + 60);
+    $self->assert_alarms();
+
+    # Ten minutes before it is due, it fires.
+    $self->{instance}->getnotify();
+    $self->{instance}->run_command({ cyrus => 1 },
+        'calalarmd', '-t' => $due->epoch() - 600 + 60);
+    $self->assert_alarms({ summary => 'renew the certificate' });
+}

--- a/cunit/ical_support.testc
+++ b/cunit/ical_support.testc
@@ -204,4 +204,67 @@ static void test_icalcomponent_myforeach_duplicate_rrule(void)
     buf_free(&buf);
 }
 
+struct vtodo_occurrence {
+    int count;
+    icaltimetype start;
+    icaltimetype end;
+};
+
+static int icalcomponent_myforeach_vtodo_cb(icalcomponent *comp __attribute__((unused)),
+                                            icaltimetype start,
+                                            icaltimetype end,
+                                            icaltimetype recurid __attribute__((unused)),
+                                            int is_standalone __attribute__((unused)),
+                                            void *data)
+{
+    struct vtodo_occurrence *seen = data;
+    seen->count++;
+    seen->start = start;
+    seen->end = end;
+    return 1;
+}
+
+static void test_icalcomponent_myforeach_vtodo_due_only(void)
+{
+    init_caldav();
+
+    /* Per RFC 5545, Section 3.6.2, a VTODO may carry DUE and no DTSTART.
+       It has one occurrence, at DUE - which is where a VALARM written with
+       TRIGGER;RELATED=END is anchored. */
+    struct buf buf = BUF_INITIALIZER;
+    buf_setcstr(&buf,
+            "BEGIN:VCALENDAR\r\n"
+            "VERSION:2.0\r\n"
+            "PRODID:-//Foo//Bar//EN\r\n"
+            "CALSCALE:GREGORIAN\r\n"
+            "BEGIN:VTODO\r\n"
+            "UID:8E9C0A2E-2A8F-4E1B-9E2A-7C3F1B0D5A64\r\n"
+            "SUMMARY:renew the certificate\r\n"
+            "DTSTAMP:20240101T000000Z\r\n"
+            "DUE:20240102T090000Z\r\n"
+            "STATUS:NEEDS-ACTION\r\n"
+            "BEGIN:VALARM\r\n"
+            "ACTION:DISPLAY\r\n"
+            "DESCRIPTION:renew the certificate\r\n"
+            "TRIGGER;RELATED=END:-PT180M\r\n"
+            "END:VALARM\r\n"
+            "END:VTODO\r\n"
+            "END:VCALENDAR");
+
+    icalcomponent *ical = ical_string_as_icalcomponent(&buf);
+    CU_ASSERT_PTR_NOT_NULL(ical);
+
+    struct vtodo_occurrence seen = { 0, icaltime_null_time(), icaltime_null_time() };
+    struct icalperiodtype range = ICALPERIODTYPE_INITIALIZER;
+    int r = icalcomponent_myforeach(ical, range, NULL,
+        icalcomponent_myforeach_vtodo_cb, &seen);
+    CU_ASSERT_EQUAL(r, 0);
+    CU_ASSERT_EQUAL(seen.count, 1);
+    CU_ASSERT_STRING_EQUAL(icaltime_as_ical_string(seen.start), "20240102T090000Z");
+    CU_ASSERT_STRING_EQUAL(icaltime_as_ical_string(seen.end), "20240102T090000Z");
+
+    icalcomponent_free(ical);
+    buf_free(&buf);
+}
+
 /* vim: set ft=c: */

--- a/imap/ical_support.c
+++ b/imap/ical_support.c
@@ -584,6 +584,28 @@ EXPORTED int icalcomponent_myforeach(icalcomponent *ical,
         event_length = icalcomponent_get_duration(mastercomp);
 
         /*
+         * Per RFC 5545, Section 3.6.2, a "VTODO" may carry a "DUE"
+         * property and no "DTSTART": a task with a deadline but no moment
+         * at which it begins.  Such a component cannot recur - "RRULE"
+         * expands from "DTSTART" - but it does have one occurrence, at
+         * "DUE".  Anchor it there, which is already what
+         * icalcomponent_get_utc_timespan() does for the same shape.
+         *
+         * Without this, dtstart stays a null time, the loop below has
+         * nothing to walk, and that occurrence is never visited.  A
+         * "VALARM" on such a task therefore never fires - including one
+         * written with TRIGGER;RELATED=END, the natural spelling of
+         * "remind me before this is due", which caldav_alarm.c resolves
+         * against the occurrence's end correctly once it is given one.
+         */
+        if (icaltime_is_null_time(dtstart) &&
+            icalcomponent_isa(mastercomp) == ICAL_VTODO_COMPONENT) {
+            dtstart = icalcomponent_get_due(mastercomp);
+            if (!icaltime_is_null_time(dtstart))
+                event_length = icaldurationtype_null_duration();
+        }
+
+        /*
          * Per RFC 5545, Section 3.6.1:
          *
          * For cases where a "VEVENT" calendar component


### PR DESCRIPTION
### What happens

A `VTODO` that carries `DUE` and no `DTSTART` never fires its alarm. The row is written to `caldav_alarm.sqlite3` at PUT time and deleted by `calalarmd` on its first pass, having never fired:

```
https[133540]: checking for alarms in mailbox user.x.#calendars.Default uid 13
https[133540]: update_alarmdb(user.x.#calendars.Default:13, 1788027529, 1, 0, 0, 0, NULL)
calalarmd[2978]: processing alarms for mailbox user.x.#calendars.Default uid 13 type 1 retries 0
calalarmd[2978]: update_alarmdb(user.x.#calendars.Default:13, 0, 1, 0, 0, 0, NULL)
calalarmd[2978]: DELETE FROM events WHERE mboxname = 'user.x.#calendars.Default' AND imap_uid = 13;
```

A `VEVENT` carrying the same trigger, written to the same mailbox in the same minute, was delivered normally — so this is not a configuration or notifier problem. Measured on 3.8.3; the code path is unchanged on master.

### Why it is a bug rather than a limitation

* [RFC 5545 §3.6.2](https://datatracker.ietf.org/doc/html/rfc5545#section-3.6.2) allows a `VTODO` with `DUE` and no `DTSTART` — a deadline with no moment it begins. It is the ordinary shape of "renew the certificate by Thursday morning".
* [§3.8.6.3](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.6.3) says `RELATED=END` refers to `DUE` in a `VTODO`, which is the natural way to spell "remind me before this is due".
* `VTODO` alarms are deliberately supported: `is_supported_component()` has an explicit `ICAL_VTODO_COMPONENT` case, and `caldav_alarm_support_components` defaults to `VEVENT VTODO`. `cassandane/tiny-tests/CaldavAlarm/supported_components` asserts a `VTODO` alarm fires — its `VTODO` has a `DTSTART`.
* `process_alarm_cb()` already resolves `RELATED=END` against the occurrence's end correctly. Verified separately: a `VTODO` with **both** `DTSTART` and `DUE` schedules its `RELATED=END` alarm at `DUE − trigger`, to the second.
* `icalcomponent_get_utc_timespan()` already handles this exact shape, in the same file, with an explicit `/* No DTSTART */ /* Has DUE */` branch setting both ends to `DUE`.

So the anchoring rule exists and is right; the expansion simply never yields the occurrence to anchor.

### The cause

`icalcomponent_myforeach()` takes `dtstart` from `icalcomponent_get_mydtstart()` alone. With no `DTSTART` that is a null time, `ritem` starts null, `while (data || !icaltime_is_null_time(ritem))` never runs, and the component has no occurrences — for every caller, not only alarms.

### The change

Anchor such a `VTODO` at `DUE`, matching what `icalcomponent_get_utc_timespan()` already does for the same shape (start and end both `DUE`). A `VTODO` with no `DTSTART` cannot recur — `RRULE` expands from `DTSTART` — so this yields precisely one occurrence, and components that already had a `DTSTART` are untouched.

### Tests

* `cunit/ical_support.testc` — `icalcomponent_myforeach_vtodo_due_only`. Run here: fails on master with `seen.count = 0` and a null start, passes with the change. `ical_support`, `times` and `parse_time` all green (18 tests, 196 asserts).
* `cassandane/tiny-tests/CaldavAlarm/vtodo_due_no_dtstart` — a task due in an hour with `TRIGGER;RELATED=END:-PT10M`: silent at +1 min, fires at `DUE − 10 min`. **Not run locally** — my Cassandane environment fails to bring an instance up even for the existing `CaldavAlarm.supported_components`, so this one is written from the neighbouring tests and left to CI.

I am happy to reshape this — the fallback could equally live in `caldav_alarm.c` if you would rather not touch the shared expansion path.
