### PR TITLE
sync_support.c: always raise the replica's deletedmodseq to master's

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_changes_replica_behind_cannot_calculate_changes
+++ b/cassandane/tiny-tests/JMAPEmail/email_changes_replica_behind_cannot_calculate_changes
@@ -1,0 +1,67 @@
+#!perl
+use Cassandane::Tiny;
+
+# A replica which was behind when master expunged and repacked a message
+# never sees the expunged record, so it must inherit master's
+# deletedmodseq rather than answering Email/changes from its own.
+
+sub test_email_changes_replica_behind_cannot_calculate_changes
+    :needs_component_jmap :needs_component_replication :Replication
+    :NoReplicaonly
+    ($self)
+{
+    my $master_jmap = $self->default_user->jmap;
+
+    xlog $self, "deliver message to master";
+    $self->make_message("Message X") or die;
+
+    my $email_id = $master_jmap->request(
+        [['Email/query', {} ]])->single_sentence->arguments->{ids}[0];
+    $self->assert_not_null($email_id);
+
+    xlog $self, "replicate master -> replica";
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    xlog $self, "get Email state from replica";
+    my $replica_jmap = $self->{replica}->new_jmaptester_for_user($self->default_user);
+    my $res = $replica_jmap->request(
+        [['Email/get', { ids => [$email_id], properties => ['id'] } ]]);
+    $self->assert_str_equals($email_id, $res->single_sentence->arguments->{list}[0]{id});
+
+    my $email_state = $replica_jmap->request(
+        [['Email/get', { ids => [] } ]])->single_sentence->arguments->{state};
+    $self->assert_not_null($email_state);
+
+    xlog $self, "destroy Email on master";
+    $res = $master_jmap->request([[ 'Email/set', { destroy => [$email_id] } ]]);
+    $self->assert_deep_equals([$email_id],
+                              $res->single_sentence->arguments->{destroyed});
+
+    xlog $self, "expunge the record on master, without replicating first";
+    $self->run_delayed_expunge();
+
+    xlog $self, "assert that master returns cannotCalculateChanges";
+    $res = $master_jmap->request([[ 'Email/changes', {
+        sinceState  => $email_state,
+        includeCADs => jtrue,
+    } ]]);
+    $self->assert_str_equals("cannotCalculateChanges",
+                             $res->single_sentence->arguments->{type} // '');
+
+    xlog $self, "replicate onto the stale replica";
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    xlog $self, "call Email/changes on the replica";
+    $replica_jmap = $self->{replica}->new_jmaptester_for_user($self->default_user);
+    $res = $replica_jmap->request([[ 'Email/changes', {
+        sinceState  => $email_state,
+        includeCADs => jtrue,
+    } ]]);
+
+    xlog $self, "assert that replica returns cannotCalculateChanges";
+    $self->assert_str_equals('error', $res->single_sentence->name);
+    $self->assert_str_equals('cannotCalculateChanges',
+                             $res->single_sentence->arguments->{type});
+}

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -3237,7 +3237,6 @@ static int sync_apply_mailbox(struct dlist *kin,
     struct synccrcs since_crcs = { 0, 0 };
 
     struct mailbox *mailbox = NULL;
-    bool created = false;
     struct dlist *kr;
     struct dlist *ka = NULL;
     struct dlist *userflags = NULL;
@@ -3371,10 +3370,7 @@ static int sync_apply_mailbox(struct dlist *kin,
         }
         /* set a highestmodseq of 0 so ALL changes are future
          * changes and get applied */
-        if (!r) {
-            mailbox->i.highestmodseq = 0;
-            created = true;
-        }
+        if (!r) mailbox->i.highestmodseq = 0;
 
 #ifdef USE_SIEVE
         if (mbtype_isa(mbtype) == MBTYPE_SIEVE) {
@@ -3437,10 +3433,7 @@ static int sync_apply_mailbox(struct dlist *kin,
                                                flags, &mailbox);
             /* set a highestmodseq of 0 so ALL changes are future
              * changes and get applied */
-            if (!r) {
-                mailbox->i.highestmodseq = 0;
-                created = true;
-            }
+            if (!r) mailbox->i.highestmodseq = 0;
         }
         else {
             xsyslog(LOG_ERR, "SYNCERROR: mailbox uniqueid changed - retry",
@@ -3686,10 +3679,12 @@ static int sync_apply_mailbox(struct dlist *kin,
     mailbox->i.pop3_last_login.tv_sec = pop3_last_login;
     mailbox->i.pop3_show_after.tv_sec = pop3_show_after;
     mailbox->i.createdmodseq = createdmodseq;
-    /* Replicate the deletedmodseq, but only when we just (re)created the
-     * mailbox, as otherwise it would get reset to 1. In all other cases
-     * the replica keeps track on its own of deletedmodseq. */
-    if (created && deletedmodseq > mailbox->i.deletedmodseq)
+    /* Raise the deletedmodseq to master's if it's higher.  The replica also
+     * tracks its own as it repacks, so this can only ever go up: a replica
+     * which was behind when master expunged and repacked never sees those
+     * expunged records, and must not claim it can calculate changes from
+     * before they vanished. */
+    if (deletedmodseq > mailbox->i.deletedmodseq)
         mailbox->i.deletedmodseq = deletedmodseq;
     /* only alter the syncable options */
     mailbox->i.options = (options & MAILBOX_OPTIONS_MASK) |
@@ -3698,8 +3693,8 @@ static int sync_apply_mailbox(struct dlist *kin,
     /* always set the highestmodseq */
     mboxname_setmodseq(mailbox_name(mailbox), highestmodseq, mailbox_mbtype(mailbox), /*flags*/0);
 
-    /* Also set the per-user maildeletedmodseq counter in case of a full reset */
-    if (created && deletedmodseq)
+    /* and the per-user deleted counter, which is also raise-only */
+    if (deletedmodseq)
         mboxname_setmodseq(mailbox_name(mailbox), deletedmodseq,
                            mailbox_mbtype(mailbox), MBOXMODSEQ_ISDELETE);
 


### PR DESCRIPTION
A replica which was behind when master expunged a message and then repacked never receives that expunged record: the record is already gone from master's index by the time replication resumes. 

This is the "inefficient replication" case, and we need to handle it!  In the general case it does mean the replica will sometimes say "cannotCalculateChanges" for queries where it does have all the data, but they are still queries from over a week ago in the default config, and that's OLD queries!