### PR TITLE
Enforce valid names for mailbox components

### DIFF
--- a/cassandane/tiny-tests/Caldav/mkcalendar_bad_name_chars
+++ b/cassandane/tiny-tests/Caldav/mkcalendar_bad_name_chars
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_mkcalendar_bad_name_chars ($self)
+{
+    my $caldav = $self->{caldav};
+
+    # '.' is not in this list: it already means a shared collection
+    foreach my $name ('a^b', '^') {
+        eval { $caldav->Request('MKCALENDAR',
+                                "/dav/calendars/user/cassandane/$name/") };
+        my $err = $@;
+        $self->assert_matches(qr/Invalid characters in collection name/, $err);
+    }
+
+    my $res = $caldav->Request('MKCALENDAR',
+                               "/dav/calendars/user/cassandane/goodname/");
+    $self->assert_not_null($res);
+}

--- a/cassandane/tiny-tests/Create/bad_name_chars
+++ b/cassandane/tiny-tests/Create/bad_name_chars
@@ -2,7 +2,7 @@
 use Cassandane::Tiny;
 
 # With '.' as the hierarchy separator, '^' is how a '.' in a name is spelled
-# externally, and '/' has no special meaning at all.
+# externally, and '/' is not permitted.
 sub test_bad_name_chars ($self)
 {
     my $talk = $self->{store}->get_client();

--- a/cassandane/tiny-tests/Create/bad_name_chars
+++ b/cassandane/tiny-tests/Create/bad_name_chars
@@ -1,0 +1,58 @@
+#!perl
+use Cassandane::Tiny;
+
+# With '.' as the hierarchy separator, '^' is how a '.' in a name is spelled
+# externally, and '/' has no special meaning at all.
+sub test_bad_name_chars ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    my @bad = ('yes/no', '10% Happier');
+
+    $talk->create('owner');
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    foreach my $m (@bad) {
+        $talk->create($m);
+        $self->assert_str_equals('no', $talk->get_last_completion_response());
+
+        $talk->rename('owner', $m);
+        $self->assert_str_equals('no', $talk->get_last_completion_response());
+    }
+
+    $talk->create('a^b');
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    my $list = $talk->list('', '%');
+    $self->assert_deep_equals(['INBOX', 'a^b', 'owner'],
+                              [sort map { $_->[2] } @$list]);
+}
+
+# With unixhierarchysep the two swap over: '/' is the separator, and '^' is
+# the character that can't appear at all.
+sub test_bad_name_chars_unixhs
+    :UnixHierarchySep
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    my @bad = ('a^b', '10% Happier');
+
+    $talk->create('owner');
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    foreach my $m (@bad) {
+        $talk->create($m);
+        $self->assert_str_equals('no', $talk->get_last_completion_response());
+
+        $talk->rename('owner', $m);
+        $self->assert_str_equals('no', $talk->get_last_completion_response());
+    }
+
+    $talk->create('a.b');
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    my $list = $talk->list('', '%');
+    $self->assert_deep_equals(['INBOX', 'a.b', 'owner'],
+                              [sort map { $_->[2] } @$list]);
+}

--- a/cassandane/tiny-tests/Create/bad_userids
+++ b/cassandane/tiny-tests/Create/bad_userids
@@ -11,6 +11,16 @@ sub test_bad_userids ($self)
         'user.anonymous',
         'user.%SHARED',
         #'user..foo', # silently fixed by namespace conversion
+
+        # a reserved userid stays reserved further down the tree
+        'user.anyone.Drafts',
+
+        # a userid has to be one auth_canonifyid() would accept, which
+        # rules out these and hence any name outside US-ASCII
+        'user.a*b',
+        'user.a?b',
+        'user.group:x',
+        'user.&AOQA9gD8-',
     );
 
     foreach my $u (@bad_userids) {

--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_set_name_badchars
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_set_name_badchars
@@ -9,6 +9,8 @@ sub test_mailbox_set_name_badchars ($self)
     # untouched, but Cyrus forbids them in a mailbox name.
     my @badnames = ('10% Happier', 'yes/no', 'a;b', 'c|d', 'e<f', '"g"', 'h\\i');
 
+    push @badnames, 'a^b', '^';
+
     xlog $self, "create a mailbox to rename";
     my $res = $jmap->CallMethods([
         ['Mailbox/set', { create => {
@@ -46,4 +48,31 @@ sub test_mailbox_set_name_badchars ($self)
         }}, 'R2'],
     ]);
     $self->assert_not_null($res->[0][1]{created}{good}{id});
+
+    xlog $self, "names outside US-ASCII survive the IMAP UTF-7 round trip";
+
+    my @goodnames = (
+        'a.b',
+        "\x{e4}\x{f6}\x{fc}",                     # Latin-1 supplement
+        "\x{5317}\x{4eac}",                       # CJK
+        "\x{1f4e7} mail",                         # astral: surrogate pair in UTF-7
+        "tri\x{e8}s & \x{e0}",                    # '&' shifts in UTF-7
+    );
+
+    my %created = map {; "good$_" => {
+        name => $goodnames[$_], parentId => undef,
+    } } 0 .. $#goodnames;
+
+    $res = $jmap->CallMethods([
+        ['Mailbox/set', { create => \%created }, 'R3'],
+        ['Mailbox/get', { properties => ['name'] }, 'R4'],
+    ]);
+
+    my %name_of = map {; $_->{id} => $_->{name} } @{ $res->[1][1]{list} };
+
+    for my $i (0 .. $#goodnames) {
+        my $id = $res->[0][1]{created}{"good$i"}{id};
+        $self->assert_not_null($id);
+        $self->assert_str_equals($goodnames[$i], $name_of{$id});
+    }
 }

--- a/changes/next/cyr-3225-valid-names
+++ b/changes/next/cyr-3225-valid-names
@@ -1,0 +1,27 @@
+Description:
+
+JMAP and DAV now reject mailbox and collection names they cannot represent,
+rather than silently creating a mailbox by another name: JMAP returns
+invalidProperties for "name", and MKCOL/MKCALENDAR (and COPY/MOVE to such a
+destination) return 403.  Any mailboxes created this way previously still
+are reachable by the name they read back as.
+
+
+Documentation:
+
+None.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/changes/next/cyr-3225-valid-names
+++ b/changes/next/cyr-3225-valid-names
@@ -6,6 +6,17 @@ invalidProperties for "name", and MKCOL/MKCALENDAR (and COPY/MOVE to such a
 destination) return 403.  Any mailboxes created this way previously still
 are reachable by the name they read back as.
 
+Mailbox names are now also checked a component at a time rather than as one
+string, which tightens three things.  A name may contain only one '!', and
+it must separate a non-empty domain from a non-empty mailbox name -- names
+like "a!b!c" and "!user.foo" were accepted before.  That domain must look
+like a hostname.  And the userid in a "user." name must be one the
+authentication layer could canonify, which means plain ASCII with no '&',
+'*', ':' or '?'.
+
+The domain and userid rules are not applied on the replication path, so a
+replica still accepts whatever names its master already has.
+
 
 Documentation:
 

--- a/cunit/mboxname.testc
+++ b/cunit/mboxname.testc
@@ -8,6 +8,7 @@
 #include "imap/mboxname.h"
 #include "imap/mailbox.h"
 #include "imap/global.h"
+#include "imap/imap_err.h"
 
 #define DBDIR           "test-mboxname-dbdir"
 
@@ -1056,6 +1057,51 @@ static void test_isnondeliverymailbox(void)
     CU_ASSERT_EQUAL(1, mboxname_isdeletedmailbox("DELETED.user.foo.A", NULL));
 }
 
+static void test_policycheck_component(void)
+{
+    CU_ASSERT_EQUAL(0, mboxname_policycheck_component("Drafts"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck_component("a.b"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck_component("."));
+
+    /* a component arrives already encoded, and no sequence spans the '.'
+     * that separates two of them */
+    CU_ASSERT_EQUAL(0, mboxname_policycheck_component("&AOQA9gD8-"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck_component("&-"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("&"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("&AOQA9gD8"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("&AAA-"));
+
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("a^b"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("^"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("a/b"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("/"));
+
+    /* the rest of what mboxname_policycheck() bans is banned here too */
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("10% Happier"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("a;b"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("c|d"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("e<f"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("\"g\""));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("h\\i"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck_component("caf\xc3\xa9"));
+
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck_component(""));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck_component(NULL));
+}
 
 
 static enum enum_value old_config_virtdomains;

--- a/cunit/mboxname.testc
+++ b/cunit/mboxname.testc
@@ -1144,6 +1144,68 @@ static void test_policycheck(void)
     CU_ASSERT_EQUAL(0, mboxname_policycheck("DELETED.user.foo.a/b.A1B2C3D4"));
 }
 
+static void test_policycheck_domain(void)
+{
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("example.com!user.foo"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("a.b.c.example.com!user.foo"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("xn--80ak6aa92e.com!user.foo"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("host-name.com!user.foo"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("localhost!user.foo"));
+
+    /* a domain is a hostname: labels of letters, digits and hyphens */
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("Example.COM!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("under_score.com!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("-lead.com!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("trail-.com!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("a..b!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck(".example.com!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("example.com.!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("spa ce.com!user.foo"));
+}
+
+static void test_policycheck_userid(void)
+{
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo^bar"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo+detail"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo-bar_baz"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.FooBar"));
+
+    /* a userid must be plain ASCII: auth_unix bans '&' outright, so a
+     * modified UTF-7 sequence could never canonify back to itself */
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("user.&AOQA9gD8-"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("user.&AOQA9gD8-.Drafts"));
+
+    /* and none of the other characters auth_unix refuses to canonify */
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("user.a*b"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("user.a?b"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("user.group:x"));
+
+    /* the reserved userids, which are ACL identifiers rather than owners */
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("user.anyone"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("user.anonymous"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("user.anyone.Drafts"));
+
+    /* the rules apply to the userid, not to the folders underneath it */
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo.&AOQA9gD8-"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo.a*b"));
+
+    /* nor to a shared mailbox that merely starts with something similar */
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("users.a*b"));
+}
+
 
 static enum enum_value old_config_virtdomains;
 static union config_value old_config_unixhierarchysep;

--- a/cunit/mboxname.testc
+++ b/cunit/mboxname.testc
@@ -1103,6 +1103,47 @@ static void test_policycheck_component(void)
     CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck_component(NULL));
 }
 
+/* config_virtdomains is ON for this suite, see set_up() */
+static void test_policycheck(void)
+{
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo.Drafts"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("shared.folder"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("example.com!user.foo"));
+
+    /* a '^' is a '.' in a component, and belongs in an internal name */
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo.a^b"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo.&AOQA9gD8-"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("user.foo.&AOQA9gD8"));
+
+    /* mailboxes.db reserves keys starting with '$', but only at the top */
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("$RACL"));
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("user.foo.$bar"));
+
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("user"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("user.anyone"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("user.anonymous"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("user.%foo"));
+
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck(".leading"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("trailing."));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("a..b"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("~tilde"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("a\tb"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("a/b"));
+
+    /* every '!' belongs to the domain, so there is only ever the one */
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("a!b!c"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME, mboxname_policycheck("!user.foo"));
+    CU_ASSERT_EQUAL(IMAP_MAILBOX_BADNAME,
+                    mboxname_policycheck("example.com!user.foo!bar"));
+
+    /* the delayed delete namespace is exempt: it was checked on the way in */
+    CU_ASSERT_EQUAL(0, mboxname_policycheck("DELETED.user.foo.a/b.A1B2C3D4"));
+}
+
 
 static enum enum_value old_config_virtdomains;
 static union config_value old_config_unixhierarchysep;

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -4253,7 +4253,8 @@ static int move_collection(const mbentry_t *mbentry, void *rock)
         r = mboxlist_renamemailbox(mbentry, buf_cstring(&mrock->newname),
                                    NULL /* partition */, 0 /* uidvalidity */,
                                    1 /* admin */, httpd_userid, httpd_authstate,
-                                   NULL, 0, 0, 1 /* ignorequota */, 0, 0, 0);
+                                   NULL, 0, 0, 1 /* ignorequota */, 0, 0,
+                                   /*flags*/0);
     }
 
     if (r) {
@@ -4468,7 +4469,8 @@ static int dav_move_collection(struct transaction_t *txn,
     r = mboxlist_renamemailbox(txn->req_tgt.mbentry, newmailboxname,
                                NULL /* partition */, 0 /* uidvalidity */,
                                httpd_userisadmin, httpd_userid, httpd_authstate,
-                               mboxevent, 0, 0, 1 /* ignorequota */, 0, 0, 0);
+                               mboxevent, 0, 0, 1 /* ignorequota */, 0, 0,
+                               /*flags*/0);
 
     if (!r) mboxevent_notify(&mboxevent);
     mboxevent_free(&mboxevent);

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -736,6 +736,14 @@ HIDDEN int calcarddav_parse_path(const char *path,
     if (tgt->collen) {
         collection = freeme = xstrndup(tgt->collection, tgt->collen);
 
+        /* only a creation has to be representable: an existing collection
+         * may have been made before we checked */
+        if (tgt->mbentry && mboxname_policycheck_component(collection)) {
+            *resultstr = "Invalid characters in collection name";
+            ret = HTTP_FORBIDDEN;
+            goto done;
+        }
+
         p = strrchr(collection, SHARED_COLLECTION_DELIM);
         if (p) {
             if (tgt->mbentry) { /* MKCOL or COPY/MOVE destination */

--- a/imap/http_webdav.c
+++ b/imap/http_webdav.c
@@ -465,6 +465,16 @@ static int webdav_parse_path(const char *path, struct request_target_t *tgt,
     while (len) {
         /* Get collection(s) */
         char *val = xstrndup(p, len);
+
+        /* only a creation has to be representable: an existing collection
+         * may have been made before we checked */
+        if (tgt->mbentry && mboxname_policycheck_component(val)) {
+            free(val);
+            mbname_free(&mbname);
+            *resultstr = "Invalid characters in collection name";
+            return HTTP_FORBIDDEN;
+        }
+
         mbname_push_boxes(mbname, val);
         free(val);
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -7713,7 +7713,8 @@ static int renmbox(const mbentry_t *mbentry, void *rock)
                                text->partition, uidvalidity,
                                1, imapd_userid, imapd_authstate, NULL, 0, 0,
                                text->rename_user, /*keep_intermediaries*/1,
-                               0, /*silent*/text->rename_user);
+                               0, text->rename_user
+                                  ? MBOXLIST_RENAME_SILENT : 0);
 
     if (!r && config_getswitch(IMAPOPT_DELETE_UNSUBSCRIBE)) {
         mboxlist_changesub(mbentry->name, imapd_userid, imapd_authstate,
@@ -8164,7 +8165,8 @@ static void cmd_rename(char *tag, char *oldname, char *newname, char *location, 
                                    0 /* uidvalidity */, imapd_userisadmin,
                                    imapd_userid, imapd_authstate, mboxevent,
                                    0, 0, rename_user, /*keep_intermediaries*/1,
-                                   0, /*silent*/rename_user);
+                                   0, rename_user
+                                      ? MBOXLIST_RENAME_SILENT : 0);
 
         if (!r) {
             /* Add sharees of this renamed mailbox to our hash */

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -1648,6 +1648,35 @@ done:
     return mboxname;
 }
 
+static int _mbox_name_roundtrips(const char *name)
+{
+    charset_t utf8 = charset_lookupname("utf-8");
+    charset_t utf7 = charset_lookupname("imap-utf-7");
+    char *encoded = NULL, *decoded = NULL;
+    int ok = 0;
+
+    if (utf8 == CHARSET_UNKNOWN_CHARSET || utf7 == CHARSET_UNKNOWN_CHARSET)
+        goto done;
+
+    encoded = charset_to_imaputf7(name, strlen(name), utf8, ENCODING_NONE);
+    if (!encoded) goto done;
+
+    /* the encoded form is what gets pushed into the mbname */
+    if (mboxname_policycheck_component(encoded)) goto done;
+
+    decoded = charset_to_utf8cstr(encoded, strlen(encoded), utf7, ENCODING_NONE);
+    if (!decoded) goto done;
+
+    ok = !strcmp(decoded, name);
+
+done:
+    free(encoded);
+    free(decoded);
+    charset_free(&utf8);
+    charset_free(&utf7);
+    return ok;
+}
+
 static char *_mbox_tmpname(const char *name, const char *parentname, int is_toplevel)
 {
     int retries = 0;
@@ -1749,6 +1778,13 @@ static void _mboxset_args_parse(json_t *jargs,
                 is_valid = 1;
             }
         }
+
+        /* mboxname_policycheck() only ever sees the assembled internal name,
+         * by which point an escaped '.' and a literal '^' look the same and
+         * the UTF-7 encoding has already happened. */
+        if (is_valid > 0 && !_mbox_name_roundtrips(name))
+            is_valid = 0;
+
         if (is_valid > 0) {
             args->name = name;
         }

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -1670,13 +1670,14 @@ err:
 static int mboxlist_create_namecheck(const char *mboxname,
                                      const char *userid,
                                      const struct auth_state *auth_state,
-                                     int isadmin, int force_subdirs)
+                                     int isadmin, int force_subdirs,
+                                     int policyflags)
 {
     mbentry_t *mbentry = NULL;
     int r = 0;
 
     /* policy first */
-    r = mboxname_policycheck(mboxname);
+    r = mboxname_policycheck_flags(mboxname, policyflags);
     if (r) goto done;
 
     /* is this the user's INBOX namespace? */
@@ -1850,7 +1851,7 @@ EXPORTED int mboxlist_createmailboxcheck(const char *name, int mbtype __attribut
     init_internal();
 
     r = mboxlist_create_namecheck(name, userid, auth_state,
-                                  isadmin, forceuser);
+                                  isadmin, forceuser, 0);
     if (r) goto done;
 
     if (newacl) {
@@ -2040,7 +2041,11 @@ EXPORTED int mboxlist_createmailbox_version(const mbentry_t *mbentry, int minor_
     init_internal();
 
     r = mboxlist_create_namecheck(mboxname, userid, auth_state,
-                                  isadmin, (flags & MBOXLIST_CREATE_FORCEUSER));
+                                  isadmin, (flags & MBOXLIST_CREATE_FORCEUSER),
+                                  /* a replica has to accept whatever name the
+                                     master already has */
+                                  (flags & MBOXLIST_CREATE_SYNC)
+                                    ? MBOXNAME_POLICY_SKIP_IDENTITY : 0);
     if (r) goto done;
 
     assert_namespacelocked(mboxname);
@@ -2421,7 +2426,7 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
                                localonly /* local_only */,
                                force, 1,
                                keep_intermediaries,
-                               0 /* move_subscription */, 0 /* silent */);
+                               0 /* move_subscription */, /*flags*/0);
 
     if (r) goto done;
 
@@ -2763,7 +2768,7 @@ static int dorename(const mbentry_t *mbentry, void *rock)
                                /*mboxevent*/NULL,
                                text->local_only, /*forceuser*/1, text->ignorequota,
                                text->keep_intermediaries,
-                               text->move_subscription, /*silent*/0);
+                               text->move_subscription, /*flags*/0);
 
     return r;
 }
@@ -2810,7 +2815,8 @@ EXPORTED int mboxlist_renametree(const char *oldname, const char *newname,
                                auth_state,
                                mboxevent,
                                local_only, forceuser, ignorequota,
-                               keep_intermediaries, move_subscription, /*silent*/0);
+                               keep_intermediaries, move_subscription,
+                               /*flags*/0);
     mboxlist_entry_free(&mbentry);
 
     // special-case only children exist
@@ -2835,8 +2841,12 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
                                     struct mboxevent *mboxevent,
                                     int local_only, int forceuser,
                                     int ignorequota, int keep_intermediaries,
-                                    int move_subscription, int silent)
+                                    int move_subscription, int flags)
 {
+    int silent = !!(flags & MBOXLIST_RENAME_SILENT);
+    /* a replica has to accept whatever name the master already has */
+    int policyflags = (flags & MBOXLIST_RENAME_SYNC)
+                    ? MBOXNAME_POLICY_SKIP_IDENTITY : 0;
     int r;
     const char *oldname = mbentry->name;
     int mupdatecommiterror = 0;
@@ -2873,7 +2883,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
     /* special-case: intermediate mailbox */
     if (mbentry->mbtype & MBTYPE_INTERMEDIATE) {
         r = mboxlist_create_namecheck(newname, userid, auth_state,
-                                      isadmin, forceuser);
+                                      isadmin, forceuser, policyflags);
         if (r) goto done;
         newmbentry = mboxlist_entry_copy(mbentry);
         free(newmbentry->name);
@@ -2980,7 +2990,7 @@ EXPORTED int mboxlist_renamemailbox(const mbentry_t *mbentry,
     }
 
     r = mboxlist_create_namecheck(newname, userid, auth_state,
-                                  isadmin, forceuser);
+                                  isadmin, forceuser, policyflags);
     if (r) goto done;
 
     if ((mailbox_mbtype(oldmailbox) & MBTYPE_LEGACY_DIRS)) {

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -240,6 +240,11 @@ int mboxlist_renametree(const char *oldname, const char *newname,
                         struct mboxevent *mboxevent,
                         int local_only, int forceuser, int ignorequota,
                         int keep_intermediaries, int move_subscription);
+/* don't bump modseqs or send notifications for the change */
+#define MBOXLIST_RENAME_SILENT              (1<<0)
+/* rename mailbox from sync */
+#define MBOXLIST_RENAME_SYNC                (1<<1)
+
 /* Rename/move a mailbox (hierarchical) */
 /* prepare MailboxRename notification if mboxevent is not NULL */
 int mboxlist_renamemailbox(const mbentry_t *mbentry, const char *newname,
@@ -249,7 +254,7 @@ int mboxlist_renamemailbox(const mbentry_t *mbentry, const char *newname,
                            struct mboxevent *mboxevent,
                            int local_only, int forceuser, int ignorequota,
                            int keep_intermediaries, int move_subscription,
-                           int silent);
+                           int flags);
 
 /* change ACL */
 int mboxlist_setacl(const struct namespace *namespace, const char *name,

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1802,83 +1802,20 @@ EXPORTED int mboxname_same_userid(const char *name1, const char *name2)
 }
 
 /*
- * Apply site policy restrictions on mailbox names.
- * Restrictions are hardwired for now.
  * NOTE: '^' is '.' externally in unixhs, and invalid in unixhs
  *
  * The set of printable chars that are not in GOODCHARS are:
  *    !"%&/;<>\`{|}
  */
 #define GOODCHARS " #$'()*+,-.0123456789:=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz~"
-EXPORTED int mboxname_policycheck(const char *name)
+
+/* the character-by-character half of mboxname_policycheck(): the checks that
+ * don't care where in the namespace the name sits */
+static int _policycheck_chars(const char *name, int hasdom)
 {
-    const char *p;
     int sawutf7 = 0;
     unsigned c1, c2, c3, c4, c5, c6, c7, c8;
     int ucs4;
-    int namelen = strlen(name);
-    int hasdom = 0;
-
-    /* We reserve mailboxes.db keys beginning with $ for internal use
-     * (e.g. $RACL), so don't allow a real mailbox to sneak in there.
-     *
-     * N.B This is only forbidden at the absolute top of the internal
-     * namespace: stuff like "user.foo.$bar", "domain!user.foo.$bar",
-     * "domain!$bar", and even "user.$bar" are all still valid here,
-     * because none of those names start with $, and won't conflict.
-     */
-    if (name[0] == '$')
-        return IMAP_MAILBOX_BADNAME;
-
-    /* Skip policy check on mailbox created in delayed delete namespace
-     * assuming the mailbox existed before and was OK then.
-     * This should allow mailboxes that are extremely long to be
-     * deleted when delayed_delete is enabled.
-     * A thorough fix might remove the prefix and timestamp
-     * then continue with the check
-     */
-    if (mboxname_isdeletedmailbox(name, NULL))
-        return 0;
-
-    if (namelen > MAX_MAILBOX_CREATENAME)
-        return IMAP_MAILBOX_BADNAME;
-
-    /* find the virtual domain, if any.  We don't sanity check domain
-       names yet - maybe we should */
-    p = strchr(name, '!');
-    if (p) {
-        if (config_virtdomains) {
-            name = p + 1;
-            namelen = strlen(name);
-            hasdom = 1;
-        }
-        else
-            return IMAP_MAILBOX_BADNAME;
-    }
-
-    /* bad mbox patterns */
-    // empty name
-    if (!name[0]) return IMAP_MAILBOX_BADNAME;
-    // leading dot
-    if (name[0] == '.') return IMAP_MAILBOX_BADNAME;
-    // leading ~
-    if (name[0] == '~') return IMAP_MAILBOX_BADNAME;
-    // trailing dot
-    if (name[namelen-1] == '.') return IMAP_MAILBOX_BADNAME;
-    // double dot (zero length path item)
-    if (strstr(name, "..")) return IMAP_MAILBOX_BADNAME;
-    // non-" " whitespace
-    if (strchr(name, '\r')) return IMAP_MAILBOX_BADNAME;
-    if (strchr(name, '\n')) return IMAP_MAILBOX_BADNAME;
-    if (strchr(name, '\t')) return IMAP_MAILBOX_BADNAME;
-    // top level user
-    if (!strcmp(name, "user")) return IMAP_MAILBOX_BADNAME;
-    // special users
-    if (!strcmp(name, "user.anyone")) return IMAP_MAILBOX_BADNAME;
-    if (!strcmp(name, "user.anonymous")) return IMAP_MAILBOX_BADNAME;
-    // redundant but explicit ban on userids starting with '%'
-    // (would conflict with backups of shared mailboxes)
-    if (!strncmp(name, "user.%", 6)) return IMAP_MAILBOX_BADNAME;
 
     while (*name) {
         if (*name == '&') {
@@ -1953,6 +1890,95 @@ EXPORTED int mboxname_policycheck(const char *name)
         }
     }
     return 0;
+}
+
+EXPORTED int mboxname_policycheck_component(const char *name)
+{
+    if (!name || !*name)
+        return IMAP_MAILBOX_BADNAME;
+
+    /* '^' is in GOODCHARS only because it is how _append_intbuf() writes a
+     * '.': a component containing one would name a different mailbox */
+    if (strchr(name, '^'))
+        return IMAP_MAILBOX_BADNAME;
+
+    /* no '!' without a domain, and no UTF-7 sequence spans the '.' that
+     * separates two components, so the whole name adds nothing here */
+    return _policycheck_chars(name, 0);
+}
+
+/*
+ * Apply site policy restrictions on mailbox names.
+ * Restrictions are hardwired for now.
+ */
+EXPORTED int mboxname_policycheck(const char *name)
+{
+    const char *p;
+    int namelen = strlen(name);
+    int hasdom = 0;
+
+    /* We reserve mailboxes.db keys beginning with $ for internal use
+     * (e.g. $RACL), so don't allow a real mailbox to sneak in there.
+     *
+     * N.B This is only forbidden at the absolute top of the internal
+     * namespace: stuff like "user.foo.$bar", "domain!user.foo.$bar",
+     * "domain!$bar", and even "user.$bar" are all still valid here,
+     * because none of those names start with $, and won't conflict.
+     */
+    if (name[0] == '$')
+        return IMAP_MAILBOX_BADNAME;
+
+    /* Skip policy check on mailbox created in delayed delete namespace
+     * assuming the mailbox existed before and was OK then.
+     * This should allow mailboxes that are extremely long to be
+     * deleted when delayed_delete is enabled.
+     * A thorough fix might remove the prefix and timestamp
+     * then continue with the check
+     */
+    if (mboxname_isdeletedmailbox(name, NULL))
+        return 0;
+
+    if (namelen > MAX_MAILBOX_CREATENAME)
+        return IMAP_MAILBOX_BADNAME;
+
+    /* find the virtual domain, if any.  We don't sanity check domain
+       names yet - maybe we should */
+    p = strchr(name, '!');
+    if (p) {
+        if (config_virtdomains) {
+            name = p + 1;
+            namelen = strlen(name);
+            hasdom = 1;
+        }
+        else
+            return IMAP_MAILBOX_BADNAME;
+    }
+
+    /* bad mbox patterns */
+    // empty name
+    if (!name[0]) return IMAP_MAILBOX_BADNAME;
+    // leading dot
+    if (name[0] == '.') return IMAP_MAILBOX_BADNAME;
+    // leading ~
+    if (name[0] == '~') return IMAP_MAILBOX_BADNAME;
+    // trailing dot
+    if (name[namelen-1] == '.') return IMAP_MAILBOX_BADNAME;
+    // double dot (zero length path item)
+    if (strstr(name, "..")) return IMAP_MAILBOX_BADNAME;
+    // non-" " whitespace
+    if (strchr(name, '\r')) return IMAP_MAILBOX_BADNAME;
+    if (strchr(name, '\n')) return IMAP_MAILBOX_BADNAME;
+    if (strchr(name, '\t')) return IMAP_MAILBOX_BADNAME;
+    // top level user
+    if (!strcmp(name, "user")) return IMAP_MAILBOX_BADNAME;
+    // special users
+    if (!strcmp(name, "user.anyone")) return IMAP_MAILBOX_BADNAME;
+    if (!strcmp(name, "user.anonymous")) return IMAP_MAILBOX_BADNAME;
+    // redundant but explicit ban on userids starting with '%'
+    // (would conflict with backups of shared mailboxes)
+    if (!strncmp(name, "user.%", 6)) return IMAP_MAILBOX_BADNAME;
+
+    return _policycheck_chars(name, hasdom);
 }
 
 EXPORTED int mboxname_is_prefix(const char *longstr, const char *shortstr)

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1809,13 +1809,19 @@ EXPORTED int mboxname_same_userid(const char *name1, const char *name2)
  */
 #define GOODCHARS " #$'()*+,-.0123456789:=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz~"
 
-/* the character-by-character half of mboxname_policycheck(): the checks that
- * don't care where in the namespace the name sits */
-static int _policycheck_chars(const char *name, int hasdom)
+EXPORTED int mboxname_policycheck_component(const char *name)
 {
     int sawutf7 = 0;
     unsigned c1, c2, c3, c4, c5, c6, c7, c8;
     int ucs4;
+
+    if (!name || !*name)
+        return IMAP_MAILBOX_BADNAME;
+
+    /* '^' is in GOODCHARS only because it is how _append_intbuf() writes a
+     * '.': a component containing one would name a different mailbox */
+    if (strchr(name, '^'))
+        return IMAP_MAILBOX_BADNAME;
 
     while (*name) {
         if (*name == '&') {
@@ -1883,7 +1889,7 @@ static int _policycheck_chars(const char *name, int hasdom)
             name++;             /* Skip over terminating '-' */
         }
         else {
-            if (!(strchr(GOODCHARS, *name) || (hasdom && *name == '!')))
+            if (!strchr(GOODCHARS, *name))
                 return IMAP_MAILBOX_BADNAME;
             name++;
             sawutf7 = 0;
@@ -1892,30 +1898,17 @@ static int _policycheck_chars(const char *name, int hasdom)
     return 0;
 }
 
-EXPORTED int mboxname_policycheck_component(const char *name)
-{
-    if (!name || !*name)
-        return IMAP_MAILBOX_BADNAME;
-
-    /* '^' is in GOODCHARS only because it is how _append_intbuf() writes a
-     * '.': a component containing one would name a different mailbox */
-    if (strchr(name, '^'))
-        return IMAP_MAILBOX_BADNAME;
-
-    /* no '!' without a domain, and no UTF-7 sequence spans the '.' that
-     * separates two components, so the whole name adds nothing here */
-    return _policycheck_chars(name, 0);
-}
-
 /*
  * Apply site policy restrictions on mailbox names.
  * Restrictions are hardwired for now.
  */
 EXPORTED int mboxname_policycheck(const char *name)
 {
+    strarray_t *boxes;
     const char *p;
     int namelen = strlen(name);
-    int hasdom = 0;
+    int i;
+    int r = 0;
 
     /* We reserve mailboxes.db keys beginning with $ for internal use
      * (e.g. $RACL), so don't allow a real mailbox to sneak in there.
@@ -1941,17 +1934,15 @@ EXPORTED int mboxname_policycheck(const char *name)
     if (namelen > MAX_MAILBOX_CREATENAME)
         return IMAP_MAILBOX_BADNAME;
 
-    /* find the virtual domain, if any.  We don't sanity check domain
-       names yet - maybe we should */
+    /* split off the virtual domain: it is not part of the hierarchy, and
+       every '!' belongs to it, so there is only ever the one */
     p = strchr(name, '!');
     if (p) {
-        if (config_virtdomains) {
-            name = p + 1;
-            namelen = strlen(name);
-            hasdom = 1;
-        }
-        else
-            return IMAP_MAILBOX_BADNAME;
+        if (!config_virtdomains) return IMAP_MAILBOX_BADNAME;
+        if (p == name) return IMAP_MAILBOX_BADNAME;
+        name = p + 1;
+        namelen = strlen(name);
+        if (strchr(name, '!')) return IMAP_MAILBOX_BADNAME;
     }
 
     /* bad mbox patterns */
@@ -1978,7 +1969,14 @@ EXPORTED int mboxname_policycheck(const char *name)
     // (would conflict with backups of shared mailboxes)
     if (!strncmp(name, "user.%", 6)) return IMAP_MAILBOX_BADNAME;
 
-    return _policycheck_chars(name, hasdom);
+    /* now that no component can be empty, check each one on its own.  The
+     * escaping is undone first, so a '^' is seen as the '.' it stands for */
+    boxes = _array_from_intname(strarray_split(name, ".", 0));
+    for (i = 0; !r && i < strarray_size(boxes); i++)
+        r = mboxname_policycheck_component(strarray_nth(boxes, i));
+    strarray_free(boxes);
+
+    return r;
 }
 
 EXPORTED int mboxname_is_prefix(const char *longstr, const char *shortstr)

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -1899,10 +1899,58 @@ EXPORTED int mboxname_policycheck_component(const char *name)
 }
 
 /*
+ * A domain is a hostname: dot separated labels of lowercase letters, digits
+ * and hyphens, with no empty label and no label starting or ending in '-'.
+ */
+static int _policycheck_domain(const char *domain, size_t len)
+{
+    size_t i;
+    size_t labellen = 0;
+
+    if (!len) return IMAP_MAILBOX_BADNAME;
+
+    for (i = 0; i < len; i++) {
+        char c = domain[i];
+
+        if (c == '.') {
+            if (!labellen || domain[i-1] == '-')
+                return IMAP_MAILBOX_BADNAME;
+            labellen = 0;
+            continue;
+        }
+
+        if (c == '-') {
+            if (!labellen) return IMAP_MAILBOX_BADNAME;
+        }
+        else if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))) {
+            return IMAP_MAILBOX_BADNAME;
+        }
+
+        labellen++;
+    }
+
+    if (!labellen || domain[len-1] == '-')
+        return IMAP_MAILBOX_BADNAME;
+
+    return 0;
+}
+
+/* the printable characters auth_canonifyid() will not accept which are
+ * otherwise legal in a mailbox component.  A userid that contains one could
+ * never be canonified, so no such user could own the mailbox: '&' rules out
+ * modified UTF-7 too, which is why a userid is always plain ASCII. */
+#define BADUSERCHARS "&*:?"
+
+/*
  * Apply site policy restrictions on mailbox names.
  * Restrictions are hardwired for now.
  */
 EXPORTED int mboxname_policycheck(const char *name)
+{
+    return mboxname_policycheck_flags(name, 0);
+}
+
+EXPORTED int mboxname_policycheck_flags(const char *name, int flags)
 {
     strarray_t *boxes;
     const char *p;
@@ -1940,6 +1988,9 @@ EXPORTED int mboxname_policycheck(const char *name)
     if (p) {
         if (!config_virtdomains) return IMAP_MAILBOX_BADNAME;
         if (p == name) return IMAP_MAILBOX_BADNAME;
+        if (!(flags & MBOXNAME_POLICY_SKIP_IDENTITY)
+            && _policycheck_domain(name, p - name))
+            return IMAP_MAILBOX_BADNAME;
         name = p + 1;
         namelen = strlen(name);
         if (strchr(name, '!')) return IMAP_MAILBOX_BADNAME;
@@ -1962,18 +2013,25 @@ EXPORTED int mboxname_policycheck(const char *name)
     if (strchr(name, '\t')) return IMAP_MAILBOX_BADNAME;
     // top level user
     if (!strcmp(name, "user")) return IMAP_MAILBOX_BADNAME;
-    // special users
-    if (!strcmp(name, "user.anyone")) return IMAP_MAILBOX_BADNAME;
-    if (!strcmp(name, "user.anonymous")) return IMAP_MAILBOX_BADNAME;
-    // redundant but explicit ban on userids starting with '%'
-    // (would conflict with backups of shared mailboxes)
-    if (!strncmp(name, "user.%", 6)) return IMAP_MAILBOX_BADNAME;
 
     /* now that no component can be empty, check each one on its own.  The
      * escaping is undone first, so a '^' is seen as the '.' it stands for */
     boxes = _array_from_intname(strarray_split(name, ".", 0));
+
+    if (strarray_size(boxes) > 1 && !strcmp(strarray_nth(boxes, 0), "user")) {
+        const char *userid = strarray_nth(boxes, 1);
+
+        /* ACL identifiers, so never the owner of a mailbox */
+        if (!strcmp(userid, "anyone") || !strcmp(userid, "anonymous"))
+            r = IMAP_MAILBOX_BADNAME;
+        else if (!(flags & MBOXNAME_POLICY_SKIP_IDENTITY)
+                 && userid[strcspn(userid, BADUSERCHARS)])
+            r = IMAP_MAILBOX_BADNAME;
+    }
+
     for (i = 0; !r && i < strarray_size(boxes); i++)
         r = mboxname_policycheck_component(strarray_nth(boxes, i));
+
     strarray_free(boxes);
 
     return r;

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -292,6 +292,13 @@ char *mboxname_lockpath_suffix(const char *mboxname, const char *suffix);
  */
 int mboxname_policycheck(const char *name);
 
+/* Skip the rules about who the name identifies -- the domain and the userid.
+ * For a name created elsewhere and only replayed here, where refusing it now
+ * would strand a mailbox that already exists. */
+#define MBOXNAME_POLICY_SKIP_IDENTITY (1<<0)
+
+int mboxname_policycheck_flags(const char *name, int flags);
+
 /*
  * Return 0 if 'name' consists of legal characters for a single component of
  * a mailbox name.  Applies the same character rules as mboxname_policycheck(),

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -292,6 +292,14 @@ char *mboxname_lockpath_suffix(const char *mboxname, const char *suffix);
  */
 int mboxname_policycheck(const char *name);
 
+/*
+ * Return 0 if 'name' consists of legal characters for a single component of
+ * a mailbox name.  Applies the same character rules as mboxname_policycheck(),
+ * which only ever sees an assembled internal name, plus a ban on '^' -- the
+ * internal spelling of a '.'.
+ */
+int mboxname_policycheck_component(const char *name);
+
 void mboxname_todeleted(const char *name, char *result, int withtime);
 
 /*

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -4461,7 +4461,7 @@ static int sync_apply_rename(struct dlist *kin, struct sync_state *sstate)
                                1/*ignorequota*/,
                                1/*keep_intermediaries*/,
                                0/*move_subscription*/,
-                               1/*silent*/);
+                               MBOXLIST_RENAME_SILENT|MBOXLIST_RENAME_SYNC);
 
 
 done:


### PR DESCRIPTION
We don't have strict enough mailbox name creation logic for JMAP (or DAV) to stop the users creating names which don't round trip to the same name.  This fixes it!