### PR TITLE
mboxlist: let admins delete a mailbox they hold no ACL on

### DIFF
--- a/cassandane/Cassandane/Cyrus/Shared.pm
+++ b/cassandane/Cassandane/Cyrus/Shared.pm
@@ -38,6 +38,40 @@ sub tear_down
     $self->SUPER::tear_down();
 }
 
+# A mailbox created without anyone being granted 'x' must still be
+# deletable by an admin: admins are not subject to ACL checks anywhere
+# else, and a top-level shared folder only ever gets 'defaultacl'.
+sub shared_admin_delete_common
+{
+    my ($self) = @_;
+
+    my $admintalk = $self->{adminstore}->get_client();
+
+    xlog $self, "create a top-level shared folder";
+    $admintalk->create('shared');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    xlog $self, "nobody has been granted 'x' on it";
+    my %acl = @{$admintalk->getacl('shared')};
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $self->assert_does_not_match(qr/x/, $acl{admin} // '');
+
+    xlog $self, "admin can delete it anyway";
+    $admintalk->delete('shared');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    xlog $self, "same for a user mailbox with no admin entry in its acl";
+    $admintalk->create('user.orphan');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    %acl = @{$admintalk->getacl('user.orphan')};
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $self->assert_does_not_match(qr/x/, $acl{admin} // '');
+
+    $admintalk->delete('user.orphan');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+}
+
 sub shared_subscribe_common
 {
     my ($self, $user1, $user2) = @_;

--- a/cassandane/tiny-tests/Shared/admin_delete_delayed
+++ b/cassandane/tiny-tests/Shared/admin_delete_delayed
@@ -1,0 +1,9 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_admin_delete_delayed
+    :DelayedDelete
+    ($self)
+{
+    $self->shared_admin_delete_common();
+}

--- a/cassandane/tiny-tests/Shared/admin_delete_immediate
+++ b/cassandane/tiny-tests/Shared/admin_delete_immediate
@@ -1,0 +1,9 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_admin_delete_immediate
+    :ImmediateDelete
+    ($self)
+{
+    $self->shared_admin_delete_common();
+}

--- a/imap/mboxlist.c
+++ b/imap/mboxlist.c
@@ -2340,7 +2340,10 @@ mboxlist_delayed_deletemailbox(const char *name, int isadmin,
     int r = 0;
     long myrights;
 
-    int checkacl = flags & MBOXLIST_DELETE_CHECKACL;
+    /* admins aren't subject to ACL checks anywhere else, and a mailbox can
+     * easily have an ACL which grants nobody 'x' - a top-level shared folder
+     * only ever gets 'defaultacl' - so don't let one become undeletable */
+    int checkacl = !isadmin && (flags & MBOXLIST_DELETE_CHECKACL);
     int localonly = flags & MBOXLIST_DELETE_LOCALONLY;
     int force = flags & MBOXLIST_DELETE_FORCE;
     int keep_intermediaries = flags & MBOXLIST_DELETE_KEEP_INTERMEDIARIES;
@@ -2464,7 +2467,8 @@ EXPORTED int mboxlist_deletemailbox(const char *name, int isadmin,
     int isremote = 0;
     mupdate_handle *mupdate_h = NULL;
 
-    int checkacl = flags & MBOXLIST_DELETE_CHECKACL;
+    /* see the comment in mboxlist_delayed_deletemailbox() */
+    int checkacl = !isadmin && (flags & MBOXLIST_DELETE_CHECKACL);
     int localonly = flags & MBOXLIST_DELETE_LOCALONLY;
     int force = flags & MBOXLIST_DELETE_FORCE;
     int keep_intermediaries = flags & MBOXLIST_DELETE_KEEP_INTERMEDIARIES;

--- a/imap/mboxlist.h
+++ b/imap/mboxlist.h
@@ -198,6 +198,8 @@ int mboxlist_createmailboxlock(const mbentry_t *mbentry,
                                const struct auth_state *auth_state,
                                unsigned flags, struct mailbox **mboxptr);
 
+/* require ACL_DELETEMBOX on the mailbox - ignored if isadmin, just like the
+ * ACL checks in mboxlist_create_namecheck() and mboxlist_renamemailbox() */
 #define MBOXLIST_DELETE_CHECKACL            (1<<0)
 /* setting local_only disables any communication with the mupdate server
  * and deletes the mailbox from the filesystem regardless of if it is


### PR DESCRIPTION
For DELETE, MBOXLIST_DELETE_CHECKACL was honoured regardless of isadmin, unlike EVERY other codepath (SETACL, CREATE, RENAME).

The obvious fix is to just allow the DELETE.  The admin can already SETACL anything they like including granting themselves the DELETE right, but that's just silly.