### PR TITLE
sync: don't take $GLOBAL for the per-user sync lock

### DIFF
--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -227,10 +227,21 @@ done:
     return r;
 }
 
+static int lock_needs_globallock(const char *mboxname)
+{
+    /* locks in the noglobal namespace don't protect user data, so they
+     * don't need to hold the global lock off for the duration */
+    if (!strncmp(mboxname, NOGLOBAL_LOCK_PREFIX, strlen(NOGLOBAL_LOCK_PREFIX)))
+        return 0;
+
+    return 1;
+}
+
 EXPORTED int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
                            int locktype_and_flags)
 {
-    if (config_take_globallock && locktype_and_flags & LOCK_EXCLUSIVE) {
+    if (config_take_globallock && locktype_and_flags & LOCK_EXCLUSIVE
+                               && lock_needs_globallock(mboxname)) {
         // if we have an exclusive lock, we MUST already be holding
         // the shared global lock, or we have to open it.
         if (!mboxname_islocked(GLOBAL_LOCKNAME)) {

--- a/imap/mboxname.h
+++ b/imap/mboxname.h
@@ -94,6 +94,10 @@ char *mboxname_from_external(const char *extname, const struct namespace *ns, co
 char *mboxname_to_external(const char *intname, const struct namespace *ns, const char *userid);
 
 
+/* namelocks in this namespace don't protect user data, so taking one
+ * exclusively doesn't imply taking the shared $GLOBAL lock as well */
+#define NOGLOBAL_LOCK_PREFIX "*N*"
+
 int open_mboxlocks_exist(void);
 int mboxname_lock(const char *mboxname, struct mboxlock **mboxlockptr,
                   int locktype);

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -214,7 +214,10 @@ static const char *_synclock_name(const char *hostname, const char *userid)
     static struct buf buf = BUF_INITIALIZER;
     if (!userid) userid = ""; // no userid == global lock
 
-    buf_setcstr(&buf, "*S*");
+    /* replication is read-only unless it finds something to fix, in which
+     * case it takes a real write lock (and hence $GLOBAL) then - so the
+     * sync lock itself lives in the namespace which doesn't take $GLOBAL */
+    buf_setcstr(&buf, NOGLOBAL_LOCK_PREFIX "S*");
 
     for (p = hostname; *p; p++) {
         switch(*p) {


### PR DESCRIPTION
$GLOBAL is held shared by every exclusive namelock which protects user data, so that a snapshot can take it exclusively and know nobody is partway through a change.  The sync lock is held for the whole of a user's replication run, which is read-only unless something needs fixing - and when it does, that takes a real write lock and hence $GLOBAL then.  Holding it off for the entire run just stopped snapshots from running while replication was reading.

Give namelocks which don't protect user data their own namespace, and put the sync lock in it.