### PR TITLE
attachextract: don't extract text from zero-byte attachments

### DIFF
--- a/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_empty_part
+++ b/cassandane/tiny-tests/SearchFuzzy/squatter_attachextract_empty_part
@@ -1,0 +1,46 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_squatter_attachextract_empty_part
+    :SearchAttachmentExtractor
+    ($self)
+{
+    my $instance = $self->{instance};
+    my $imap = $self->{store}->get_client();
+
+    my $tracedir = tempdir(DIR => $instance->{basedir} . "/tmp");
+    $self->start_echo_extractor(tracedir => $tracedir);
+
+    xlog "Append email with a zero-byte attachment";
+    $self->make_message("msg1",
+        mime_type => "multipart/related",
+        mime_boundary => "123456789abcdef",
+        body => ""
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: text/plain\r\n"
+        ."\r\n"
+        ."bodyterm"
+        ."\r\n--123456789abcdef\r\n"
+        ."Content-Type: application/pdf\r\n"
+        ."\r\n"
+        ."\r\n--123456789abcdef--\r\n"
+    ) || die;
+
+    my $cachedir = tempdir(DIR => $instance->{basedir} . "/tmp");
+
+    xlog "Run squatter with cachedir $cachedir";
+    $self->{instance}->run_command({cyrus => 1},
+        'squatter', "--attachextract-cache-dir=$cachedir");
+
+    xlog "Assert text body is indexed";
+    my $uids = $imap->search('fuzzy', 'body', 'bodyterm');
+    $self->assert_deep_equals([1], $uids);
+
+    xlog "Assert extractor never got called";
+    my @tracefiles = glob($tracedir."/*");
+    $self->assert_num_equals(0, scalar @tracefiles);
+
+    xlog "Assert cache is empty";
+    my @files = glob($cachedir."/*");
+    $self->assert_num_equals(0, scalar @files);
+}

--- a/changes/next/cyr-2534-tike-empty-file
+++ b/changes/next/cyr-2534-tike-empty-file
@@ -1,0 +1,24 @@
+Description:
+
+Zero-byte attachments are no longer sent to the attachment text extractor,
+which used to reject them and log an IOERROR for every such body part.
+
+
+Documentation:
+
+:cyrusman:`squatter(8)`
+
+
+Config changes:
+
+None
+
+
+Upgrade instructions:
+
+None
+
+
+GitHub issue:
+
+None

--- a/imap/attachextract.c
+++ b/imap/attachextract.c
@@ -306,6 +306,16 @@ done:
 }
 
 
+static int is_empty_content(const struct message_guid *guid)
+{
+    static struct message_guid empty_guid = MESSAGE_GUID_INITIALIZER;
+
+    if (empty_guid.status == GUID_UNKNOWN)
+        message_guid_generate(&empty_guid, "", 0);
+
+    return message_guid_equal(guid, &empty_guid);
+}
+
 static void generate_record_id(struct buf *id, const struct attachextract_record *rec)
 {
     // encode content guid
@@ -367,6 +377,17 @@ EXPORTED int attachextract_extract(const struct attachextract_record *axrec,
     if (message_guid_isnull(&axrec->guid)) {
         xsyslog(LOG_DEBUG, "ignoring null guid", "mime_type=<%s/%s>",
                axrec->type, axrec->subtype);
+        return 0;
+    }
+
+    if (is_empty_content(&axrec->guid)) {
+        /* there's no text to extract from a zero-byte attachment, and
+         * the extractor will just reject it anyway */
+        xsyslog_ev(LOG_DEBUG, "search.attachextract.empty",
+                   lf_s("msg.guid", guidstr),
+                   lf_s("part.type", axrec->type),
+                   lf_s("part.subtype", axrec->subtype));
+        buf_reset(text);
         return 0;
     }
 


### PR DESCRIPTION
An attachment whose decoded content is empty has nothing to extract, but we sent it to the extractor anyway, which rejected it and left an IOERROR in the log for every such body part:

  IOERROR index: can't extract attachment
    da39a3ee5e6b4b0d3255bfef95601890afd80709 (APPLICATION/PDF):
    Item does not exist

Bail out early when the part's content guid is the SHA1 of zero bytes, before any cache lookup or HTTP request.  Matching on the guid rather than the raw data length also catches encoded parts, since the content guid hashes the decoded content.