### PR TITLE
Issue createdmodseqs uniquely per host

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -633,6 +633,7 @@ cunit_TESTS = \
     cunit/guid.testc \
     cunit/hash.testc \
     cunit/hashset.testc \
+    cunit/idclass.testc \
     cunit/imapurl.testc \
     cunit/imparse.testc \
     cunit/index_file.testc \
@@ -792,6 +793,7 @@ include_HEADERS = \
     lib/hash.h \
     lib/hashset.h \
     lib/hashu64.h \
+    lib/idclass.h \
     lib/imapurl.h \
     lib/imclient.h \
     lib/imparse.h \
@@ -1603,6 +1605,7 @@ lib_libcyrus_min_la_SOURCES = \
     lib/hash.c \
     lib/hashset.c \
     lib/hashu64.c \
+    lib/idclass.c \
     lib/libconfig.c \
     lib/logfmt.c \
     lib/mpool.c \

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -488,6 +488,25 @@ magic(NoReplicaonly => sub {
     my $self = shift;
     $self->{no_replicaonly} = 1;
 });
+magic(IdClass => sub {
+    my $self = shift;
+    # the counters file, and therefore the whole scheme, is conversations-only
+    $self->config_set(conversations => 'yes');
+    $self->config_set(modseq_modulus => 16);
+    $self->config_set(modseq_base => 1);
+    # the replica must mint in a different class, or a promotion after a
+    # split brain would reissue identifiers the master already handed out
+    $self->{replica_modseq_base} = 2;
+});
+magic(IdClassClash => sub {
+    my $self = shift;
+    $self->config_set(conversations => 'yes');
+    $self->config_set(modseq_modulus => 16);
+    $self->config_set(modseq_base => 1);
+    # deliberately the same base at both ends: the misconfiguration the
+    # replication handshake check exists to catch
+    $self->{replica_modseq_base} = 1;
+});
 magic(ConversationsMaxThread10 => sub {
     my $self = shift;
     $self->config_set('conversations_max_thread' => 10);
@@ -693,6 +712,10 @@ sub _create_instances
             $replica_params{config}->set(sync_rightnow_channel => undef);
             unless ($self->{no_replicaonly}) {
                 $replica_params{config}->set(replicaonly => 'yes');
+            }
+            if (defined $self->{replica_modseq_base}) {
+                $replica_params{config}->set(
+                    modseq_base => $self->{replica_modseq_base});
             }
             my $cyrus_other_prefix = $cassini->val('cyrus other', 'prefix');
             if (defined $cyrus_other_prefix and -d $cyrus_other_prefix) {

--- a/cassandane/Cassandane/Cyrus/TestCase.pm
+++ b/cassandane/Cassandane/Cyrus/TestCase.pm
@@ -488,7 +488,7 @@ magic(NoReplicaonly => sub {
     my $self = shift;
     $self->{no_replicaonly} = 1;
 });
-magic(IdClass => sub {
+magic(ResidueClass => sub {
     my $self = shift;
     # the counters file, and therefore the whole scheme, is conversations-only
     $self->config_set(conversations => 'yes');
@@ -498,7 +498,7 @@ magic(IdClass => sub {
     # split brain would reissue identifiers the master already handed out
     $self->{replica_modseq_base} = 2;
 });
-magic(IdClassClash => sub {
+magic(ResidueClassClash => sub {
     my $self = shift;
     $self->config_set(conversations => 'yes');
     $self->config_set(modseq_modulus => 16);

--- a/cassandane/tiny-tests/Replication/idclass_createdmodseq
+++ b/cassandane/tiny-tests/Replication/idclass_createdmodseq
@@ -1,0 +1,24 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# createdmodseq is JMAP identity: the mailbox id is a base64 encoding of it.
+# Replication must never renumber it, or clients holding the id lose the
+# mailbox.
+#
+sub test_idclass_createdmodseq_preserved
+    :min_version_3_13 :IdClass
+    ($self)
+{
+    $self->make_message("replicated", store => $self->{master_store});
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    # run_replication() disconnects the stores, so ask for the clients after
+    my $master = $self->{master_store}->get_client();
+    my $master_id = $master->status("INBOX", '(mailboxid)')->{mailboxid}[0];
+    my $replica = $self->{replica_store}->get_client();
+    my $replica_id = $replica->status("INBOX", '(mailboxid)')->{mailboxid}[0];
+
+    $self->assert_str_equals($master_id, $replica_id);
+}

--- a/cassandane/tiny-tests/Replication/idclass_createdmodseq
+++ b/cassandane/tiny-tests/Replication/idclass_createdmodseq
@@ -7,7 +7,7 @@ use Cassandane::Tiny;
 # mailbox.
 #
 sub test_idclass_createdmodseq_preserved
-    :min_version_3_13 :IdClass
+    :min_version_3_13 :ResidueClass
     ($self)
 {
     $self->make_message("replicated", store => $self->{master_store});

--- a/cassandane/tiny-tests/Replication/idclass_mismatch
+++ b/cassandane/tiny-tests/Replication/idclass_mismatch
@@ -1,0 +1,21 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Two hosts sharing a base defeats the whole scheme, and the usual way to
+# get there is cloning a config onto a new host.  Replication must say so.
+#
+sub test_idclass_mismatch_is_loud
+    :min_version_3_13 :ResidueClassClash
+    ($self)
+{
+    $self->make_message("anything", store => $self->{master_store});
+    $self->run_replication();
+
+    # both ends complain, and both must be consumed here or tear_down
+    # reports the expected error as a test failure
+    $self->assert_syslog_matches($self->{instance},
+                                 qr/SYNCERROR: identifier class clash/);
+    $self->assert_syslog_matches($self->{replica},
+                                 qr/SYNCERROR: identifier class clash/);
+}

--- a/cassandane/tiny-tests/Replication/idclass_modseq
+++ b/cassandane/tiny-tests/Replication/idclass_modseq
@@ -1,0 +1,31 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Every modseq this host mints is congruent to its configured base.
+#
+sub test_idclass_modseq
+    :min_version_3_13 :IdClass
+    ($self)
+{
+    my $base = 1;
+    my $modulus = 16;
+
+    my $talk = $self->{store}->get_client();
+
+    $self->make_message("first");
+    $self->make_message("second");
+    $self->make_message("third");
+
+    $talk->select("INBOX");
+    my $res = $talk->fetch('1:*', '(modseq)');
+    $self->assert_num_equals(3, scalar keys %$res);
+
+    foreach my $uid (keys %$res) {
+        my $modseq = $res->{$uid}{modseq}[0];
+        $self->assert_num_equals($base, $modseq % $modulus);
+    }
+
+    my $status = $talk->status("INBOX", '(highestmodseq)');
+    $self->assert_num_equals($base, $status->{highestmodseq} % $modulus);
+}

--- a/cassandane/tiny-tests/Replication/idclass_modseq
+++ b/cassandane/tiny-tests/Replication/idclass_modseq
@@ -5,7 +5,7 @@ use Cassandane::Tiny;
 # Every modseq this host mints is congruent to its configured base.
 #
 sub test_idclass_modseq
-    :min_version_3_13 :IdClass
+    :min_version_3_13 :ResidueClass
     ($self)
 {
     my $base = 1;

--- a/cassandane/tiny-tests/Replication/idclass_nsec
+++ b/cassandane/tiny-tests/Replication/idclass_nsec
@@ -1,0 +1,42 @@
+#!perl
+use Cassandane::Tiny;
+use Cassandane::Util::Base64JMAP;
+
+#
+# internaldate.tv_nsec is the JMAP emailId, so it must land in this host's
+# residue class too, and stay inside UTIME_SAFE_NSEC.
+#
+sub test_idclass_nsec
+    :min_version_3_13 :IdClass
+    ($self)
+{
+    my $base = 1;
+    my $modulus = 16;
+
+    foreach my $n (1..5) {
+        $self->make_message("message $n");
+    }
+
+    my $talk = $self->{store}->get_client();
+    $talk->select("INBOX");
+    my $res = $talk->fetch('1:*', '(emailid)');
+    $self->assert_num_equals(5, scalar keys %$res);
+
+    foreach my $uid (keys %$res) {
+        my $emailid = $res->{$uid}{emailid}[0];
+        $self->assert_str_equals('S', substr($emailid, 0, 1));
+
+        # emailid encodes UINT64_MAX - (nanoseconds since epoch), big-endian
+        my $packed = decode_base64jmap(substr($emailid, 1));
+        my $nanosec = ~0 - unpack('Q>', $packed);
+        my $nsec = $nanosec % 1000000000;
+
+        # the seconds we decoded must be now, which proves the decode itself
+        # is right and the residue assertion below is not vacuous
+        $self->assert_num_lte(60, abs(time() - int($nanosec / 1000000000)));
+
+        $self->assert_num_equals($base, $nsec % $modulus);
+        $self->assert_num_gte(1, $nsec);
+        $self->assert_num_lte(999999999, $nsec);
+    }
+}

--- a/cassandane/tiny-tests/Replication/idclass_nsec
+++ b/cassandane/tiny-tests/Replication/idclass_nsec
@@ -7,7 +7,7 @@ use Cassandane::Util::Base64JMAP;
 # residue class too, and stay inside UTIME_SAFE_NSEC.
 #
 sub test_idclass_nsec
-    :min_version_3_13 :IdClass
+    :min_version_3_13 :ResidueClass
     ($self)
 {
     my $base = 1;

--- a/cassandane/tiny-tests/Replication/idclass_split_brain
+++ b/cassandane/tiny-tests/Replication/idclass_split_brain
@@ -1,0 +1,40 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# The point of the whole scheme: two hosts writing independently produce no
+# colliding identifiers, so a later merge has nothing to resolve.
+#
+sub test_idclass_split_brain_no_clash
+    :min_version_3_13 :ResidueClass :NoReplicaonly
+    ($self)
+{
+    my $modulus = 16;
+
+    # :ResidueClass gives the master base 1 and the replica base 2.
+    # :NoReplicaonly lets the replica accept writes, i.e. split brain.
+    foreach my $n (1..10) {
+        $self->make_message("master $n", store => $self->{master_store});
+        $self->make_message("replica $n", store => $self->{replica_store});
+    }
+
+    my %seen;
+    my %bases;
+    foreach my $store ($self->{master_store}, $self->{replica_store}) {
+        my $talk = $store->get_client();
+        $talk->select("INBOX");
+        my $res = $talk->fetch('1:*', '(modseq)');
+        foreach my $uid (keys %$res) {
+            my $modseq = $res->{$uid}{modseq}[0];
+            $self->assert(!exists $seen{$modseq},
+                          "modseq $modseq minted on both hosts");
+            $seen{$modseq} = 1;
+            $bases{$modseq % $modulus} = 1;
+        }
+    }
+
+    $self->assert_num_equals(20, scalar keys %seen);
+
+    # and they really did come from two different classes
+    $self->assert_num_equals(2, scalar keys %bases);
+}

--- a/cassandane/tiny-tests/Replication/idclass_uidvalidity
+++ b/cassandane/tiny-tests/Replication/idclass_uidvalidity
@@ -5,7 +5,7 @@ use Cassandane::Tiny;
 # Every uidvalidity this host mints is congruent to its configured base.
 #
 sub test_idclass_uidvalidity
-    :min_version_3_13 :IdClass
+    :min_version_3_13 :ResidueClass
     ($self)
 {
     my $base = 1;

--- a/cassandane/tiny-tests/Replication/idclass_uidvalidity
+++ b/cassandane/tiny-tests/Replication/idclass_uidvalidity
@@ -1,0 +1,21 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# Every uidvalidity this host mints is congruent to its configured base.
+#
+sub test_idclass_uidvalidity
+    :min_version_3_13 :IdClass
+    ($self)
+{
+    my $base = 1;
+    my $modulus = 16;
+
+    my $talk = $self->{store}->get_client();
+
+    foreach my $name (qw(one two three)) {
+        $talk->create("INBOX.$name") || die "create failed: $@";
+        my $status = $talk->status("INBOX.$name", '(uidvalidity)');
+        $self->assert_num_equals($base, $status->{uidvalidity} % $modulus);
+    }
+}

--- a/changes/next/idclass
+++ b/changes/next/idclass
@@ -1,0 +1,33 @@
+Description:
+
+Hosts can be given a modseq_base and modseq_modulus so that modseqs,
+uidvalidities and nanosecond timestamps minted on different hosts can never
+collide, making split-brain recovery clash-free.
+
+
+Documentation:
+
+lib/imapoptions/modseq_base and lib/imapoptions/modseq_modulus
+
+
+Config changes:
+
+modseq_base (new, INT, default 0)
+modseq_modulus (new, INT, default 1)
+
+The defaults reproduce the previous behaviour exactly.
+
+
+Upgrade instructions:
+
+Nothing is required.  To enable the guard, give every host that may ever
+allocate for a user - a master and each of its replicas, since any may be
+promoted - a distinct modseq_base, and give every host in the replication
+group the same modseq_modulus.  Values already on disk keep their existing
+residues; only newly minted identifiers are protected.  Replication logs
+"SYNCERROR: identifier class clash" at both ends if two hosts share a base.
+
+
+GitHub issue:
+
+n/a

--- a/cunit/idclass.testc
+++ b/cunit/idclass.testc
@@ -1,0 +1,74 @@
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include "cunit/unit.h"
+#include "lib/idclass.h"
+
+static void test_modseq_next_identity(void)
+{
+    /* modulus 1 is the historical behaviour: plain increment */
+    CU_ASSERT_EQUAL(idclass_modseq_next(0, 0, 1), 1);
+    CU_ASSERT_EQUAL(idclass_modseq_next(41, 0, 1), 42);
+}
+
+static void test_modseq_next_inclass(void)
+{
+    /* always strictly greater, always congruent */
+    CU_ASSERT_EQUAL(idclass_modseq_next(100, 3, 16), 115);
+    CU_ASSERT_EQUAL(idclass_modseq_next(115, 3, 16), 131);
+    CU_ASSERT_EQUAL(idclass_modseq_next(0, 3, 16), 3);
+
+    /* base 0 must still advance off zero */
+    CU_ASSERT_EQUAL(idclass_modseq_next(0, 0, 16), 16);
+    CU_ASSERT_EQUAL(idclass_modseq_next(16, 0, 16), 32);
+
+    /* adopting a foreign host's value lands us back in our own class */
+    modseq_t foreign = 1234567;  /* 1234567 % 16 == 7, not ours */
+    modseq_t mine = idclass_modseq_next(foreign, 3, 16);
+    CU_ASSERT(mine > foreign);
+    CU_ASSERT_EQUAL(mine % 16, 3);
+}
+
+static void test_uidvalidity_next(void)
+{
+    CU_ASSERT_EQUAL(idclass_uidvalidity_next(0, 0, 1), 1);
+    CU_ASSERT_EQUAL(idclass_uidvalidity_next(100, 3, 16), 115);
+
+    /* must never wrap backwards */
+    uint32_t near_max = UINT32_MAX - 2;
+    CU_ASSERT(idclass_uidvalidity_next(near_max, 3, 16) > near_max);
+}
+
+static void test_nsec_align(void)
+{
+    /* modulus 1 leaves the value alone */
+    CU_ASSERT_EQUAL(idclass_nsec_align(123456789, 0, 1), 123456789);
+
+    /* aligned onto the class, and idempotent once there */
+    CU_ASSERT_EQUAL(idclass_nsec_align(100, 3, 16), 99);
+    CU_ASSERT_EQUAL(idclass_nsec_align(99, 3, 16), 99);
+
+    /* zero is UTIME_OMIT and must never be produced */
+    CU_ASSERT_EQUAL(idclass_nsec_align(8, 0, 16), 16);
+    CU_ASSERT(idclass_nsec_align(0, 0, 16) >= 1);
+
+    /* the top of the range must stay legal */
+    CU_ASSERT(idclass_nsec_align(999999999, 15, 16) <= 999999999);
+    CU_ASSERT_EQUAL(idclass_nsec_align(999999999, 15, 16) % 16, 15);
+
+    /* a modulus that doesn't divide the range evenly */
+    CU_ASSERT(idclass_nsec_align(999999999, 6, 7) <= 999999999);
+    CU_ASSERT_EQUAL(idclass_nsec_align(999999999, 6, 7) % 7, 6);
+}
+
+static void test_nsec_next(void)
+{
+    CU_ASSERT_EQUAL(idclass_nsec_next(99, 3, 16), 115);
+
+    /* wraps to the bottom of the class rather than escaping the range */
+    long top = idclass_nsec_align(999999999, 3, 16);
+    long wrapped = idclass_nsec_next(top, 3, 16);
+    CU_ASSERT(wrapped >= 1);
+    CU_ASSERT(wrapped <= 999999999);
+    CU_ASSERT_EQUAL(wrapped % 16, 3);
+}

--- a/imap/append.c
+++ b/imap/append.c
@@ -27,6 +27,7 @@
 #include "msgrecord.h"
 #include "append.h"
 #include "global.h"
+#include "idclass.h"
 #include "prot.h"
 #include "sync_log.h"
 #include "xmalloc.h"
@@ -1212,6 +1213,9 @@ EXPORTED int append_fromstream(struct appendstate *as, struct body **body,
     struct timespec now;
     if (!internaldate) {
         cyrus_gettime(CLOCK_REALTIME, &now);
+        /* no GUID yet, so no JMAPID clash check here - but the residue
+         * class still keeps us disjoint from every other host */
+        now.tv_nsec = nsec_align(now.tv_nsec);
         internaldate = &now;
     }
     r = msgrecord_set_internaldate(msgrec, internaldate);

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -25,6 +25,7 @@
 #include "dlist.h"
 #include "hash.h"
 #include "global.h"
+#include "idclass.h"
 #include "imapd.h"
 #include "lsort.h"
 #include "mailbox.h"
@@ -3541,6 +3542,11 @@ EXPORTED void conversations_adjust_internaldate(struct conversations_state *csta
             if (!UTIME_SAFE_NSEC(internaldate->tv_nsec)) internaldate->tv_nsec = 1;
         }
 
+        // put it in this host's residue class, so a split-brained peer can't
+        // mint the same nanosecond for a different message.  idempotent, so
+        // re-aligning after a probe step is harmless
+        internaldate->tv_nsec = nsec_align(internaldate->tv_nsec);
+
         buf_reset(&jidrep);
         NANOSEC_TO_JMAPID(&jidrep, TIMESPEC_TO_NANOSEC(internaldate));
         int r = conversations_jmapid_guidrep_lookup(cstate,
@@ -3575,8 +3581,9 @@ EXPORTED void conversations_adjust_internaldate(struct conversations_state *csta
 
         mboxlist_entry_free(&lrock.mbentry);
 
-        // try the next nanosecond */
-        internaldate->tv_nsec++;
+        // try the next nanosecond in our class, wrapping rather than
+        // walking out of the UTIME_SAFE_NSEC range
+        internaldate->tv_nsec = nsec_next(internaldate->tv_nsec);
 
         // in the unlikely event that we reach the limit below, we're screwed
     } while (++count < 1000);

--- a/imap/global.c
+++ b/imap/global.c
@@ -27,6 +27,7 @@
 #include "cyr_lock.h"
 #include "gmtoff.h"
 #include "haproxy.h"
+#include "idclass.h"
 #include "iptostring.h"
 #include "global.h"
 #include "ical_support.h"
@@ -255,6 +256,13 @@ EXPORTED int cyrus_init(const char *alt_config, const char *ident, unsigned flag
           fatal("defaultpartition option contains non-alphanumeric character",
                 EX_CONFIG);
         if (Uisupper(*p)) *p = tolower((unsigned char) *p);
+    }
+
+    /* a bad residue class silently disables the split-brain guard, so
+     * refuse to start rather than pretend it is configured */
+    {
+        const char *idclass_err = idclass_config_error();
+        if (idclass_err) fatal(idclass_err, EX_CONFIG);
     }
 
     /* Look up umask */

--- a/imap/imap_proxy.h
+++ b/imap/imap_proxy.h
@@ -31,6 +31,7 @@ enum {
     CAPA_REPLICATION_ARCHIVE = (1 << 12),
     CAPA_QUOTASET            = (1 << 13),
     CAPA_UNMAILBOX_ID        = (1 << 14),
+    CAPA_IDCLASS             = (1 << 15),
 };
 
 extern struct protocol_t imap_protocol;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -461,6 +461,7 @@ static struct capa_struct base_capabilities[] = {
     { "SORT=UID",              CAPA_POSTAUTH,           { 0 } }, /* NS */
     { "THREAD=REFS",           CAPA_POSTAUTH,           { 0 } }, /* draft-ietf-morg-inthread */
     { "X-CREATEDMODSEQ",       CAPA_POSTAUTH,           { 0 } }, /* CY */
+    { "X-IDCLASS",             CAPA_POSTAUTH,           { 0 } }, /* CY */
     { "X-REPLICATION",         CAPA_POSTAUTH,           { 0 } }, /* CY */
     { "X-REPLICATION-ARCHIVE", CAPA_POSTAUTH,           { 0 } }, /* CY */
     { "X-SIEVE-MAILBOX",       CAPA_POSTAUTH,           { 0 } }, /* CY */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -4527,8 +4527,16 @@ EXPORTED int mailbox_append_index_record(struct mailbox *mailbox,
     else {
         mailbox_modseq_dirty(mailbox);
         record->modseq = mailbox->i.highestmodseq;
-        if (!record->createdmodseq || record->createdmodseq > record->modseq)
+        if (!record->createdmodseq) {
             record->createdmodseq = record->modseq;
+        }
+        else if (record->createdmodseq > record->modseq) {
+            /* a peer minted this createdmodseq in its own residue class and
+             * clients already hold it as a JMAP id - move our modseq above
+             * it rather than rewriting the identity */
+            mailbox->i.highestmodseq = modseq_next(record->createdmodseq);
+            record->modseq = mailbox->i.highestmodseq;
+        }
         record->last_updated.tv_sec = mailbox->last_updated;
         if (!record->savedate.tv_sec) {
             // store the time of actual append if requested
@@ -5832,8 +5840,16 @@ EXPORTED int mailbox_create(const char *name,
                            MBOXMODSEQ_ISFOLDER);
 
     /* and created modseq */
-    if (!createdmodseq || createdmodseq > highestmodseq)
+    if (!createdmodseq) {
         createdmodseq = highestmodseq;
+    }
+    else if (createdmodseq > highestmodseq) {
+        /* see mailbox_append_index_record: the jmapid below is derived from
+         * createdmodseq, so raise highestmodseq instead of lowering it */
+        highestmodseq = modseq_next(createdmodseq);
+        mboxname_setmodseq(mailbox_name(mailbox), highestmodseq, mbtype,
+                           MBOXMODSEQ_ISFOLDER);
+    }
 
     /* and jmapid */
     struct buf buf = BUF_INITIALIZER;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -48,6 +48,7 @@
 #include "carddav_db.h"
 #include "webdav_db.h"
 #include "ical_support.h"
+#include "idclass.h"
 #include "jmap_util.h"
 #include "vcard_support.h"
 #ifdef USE_SIEVE
@@ -1259,7 +1260,7 @@ EXPORTED modseq_t mailbox_modseq_dirty(struct mailbox *mailbox)
         mailbox_index_dirty(mailbox);
     }
 
-    mailbox->i.highestmodseq++;
+    mailbox->i.highestmodseq = modseq_next(mailbox->i.highestmodseq);
 
     return mailbox->i.highestmodseq;
 }

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -3323,7 +3323,7 @@ EXPORTED uint32_t mboxname_readuidvalidity(const char *mboxname)
 EXPORTED uint32_t mboxname_nextuidvalidity(const char *mboxname, uint32_t last)
 {
     if (!config_getswitch(IMAPOPT_CONVERSATIONS))
-        return last + 1;
+        return uidvalidity_next(last);
 
     struct mboxname_counters counters;
     int fd = -1;
@@ -3333,14 +3333,14 @@ EXPORTED uint32_t mboxname_nextuidvalidity(const char *mboxname, uint32_t last)
 
     /* XXX error handling */
     if (mboxname_load_fcounters(fname, &counters, &fd)) {
-        counters.uidvalidity = last + 1;
+        counters.uidvalidity = uidvalidity_next(last);
         goto done;
     }
 
     if (counters.uidvalidity < last)
         counters.uidvalidity = last;
 
-    counters.uidvalidity++;
+    counters.uidvalidity = uidvalidity_next(counters.uidvalidity);
 
     /* always set, because we always increased */
     mboxname_set_fcounters(fname, &counters, fd);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -18,6 +18,7 @@
 #include "crc32.h"
 #include "glob.h"
 #include "global.h"
+#include "idclass.h"
 #include "mailbox.h"
 #include "map.h"
 #include "retry.h"
@@ -3062,11 +3063,11 @@ static modseq_t mboxname_domodseq(const char *fname,
     int isdelete = flags & MBOXMODSEQ_ISDELETE;
 
     if (!config_getswitch(IMAPOPT_CONVERSATIONS))
-        return last + add;
+        return add ? modseq_next(last) : last;
 
     /* XXX error handling */
     if (mboxname_load_fcounters(fname, &counters, &fd))
-        return last + add;
+        return add ? modseq_next(last) : last;
 
     oldcounters = counters;
 
@@ -3153,9 +3154,11 @@ static modseq_t mboxname_domodseq(const char *fname,
     if (dofolder && *foldersmodseqp < last)
         *foldersmodseqp = last;
 
-    /* if adding, bring all counters up to the overall highest modseq */
+    /* if adding, bring all counters up to the overall highest modseq.
+     * The clamps above may have adopted a peer's value from a different
+     * residue class - rounding up here is what puts us back in ours. */
     if (add) {
-        counters.highestmodseq += add;
+        counters.highestmodseq = modseq_next(counters.highestmodseq);
         *typemodseqp = counters.highestmodseq;
         if (dofolder) *foldersmodseqp = counters.highestmodseq;
     }

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -257,6 +257,7 @@ static void dobanner(void)
 
         prot_printf(sync_out, "* SIEVE-MAILBOX\r\n");
         prot_printf(sync_out, "* UNMAILBOX-ID\r\n");
+        prot_printf(sync_out, "* IDCLASS\r\n");
 
         if (config_getswitch(IMAPOPT_ARCHIVE_ENABLED)) {
             prot_printf(sync_out, "* REPLICATION-ARCHIVE\r\n");

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -6792,15 +6792,18 @@ static int mailbox_full_update(struct sync_client_state *sync_cs,
     }
 
     if (mailbox->i.highestmodseq < highestmodseq) {
-        /* highestmodseq on replica is dirty - we must copy and then dirty
-         * so we go one higher! */
-        xsyslog(LOG_NOTICE, "SYNCNOTICE: highestmodseq higher on replica, updating",
-                            "mailbox=<%s> oldhighestmodseq=<" MODSEQ_FMT ">"
-                                " newhighestmodseq=<" MODSEQ_FMT ">",
-                            mailbox_name(mailbox), mailbox->i.highestmodseq, highestmodseq+1);
+        /* highestmodseq on replica is dirty - we must copy and then dirty so
+         * we go higher.  With a residue class configured that lands us back
+         * in our own class, which is how a promoted replica self-heals. */
+        modseq_t oldhighestmodseq = mailbox->i.highestmodseq;
         mailbox->modseq_dirty = 0;
         mailbox->i.highestmodseq = highestmodseq;
         mailbox_modseq_dirty(mailbox);
+        xsyslog(LOG_NOTICE, "SYNCNOTICE: highestmodseq higher on replica, updating",
+                            "mailbox=<%s> oldhighestmodseq=<" MODSEQ_FMT ">"
+                                " newhighestmodseq=<" MODSEQ_FMT ">",
+                            mailbox_name(mailbox), oldhighestmodseq,
+                            mailbox->i.highestmodseq);
         remote_modseq_was_higher = 1;
     }
 

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -24,6 +24,7 @@
 #include "assert.h"
 #include "bsearch.h"
 #include "global.h"
+#include "idclass.h"
 #include "imap_proxy.h"
 #include "mboxlist.h"
 #include "mailbox.h"
@@ -98,6 +99,7 @@ static struct protocol_t imap_csync_protocol =
           { "X-SIEVE-MAILBOX", CAPA_SIEVE_MAILBOX },
           { "X-REPLICATION-ARCHIVE", CAPA_REPLICATION_ARCHIVE },
           { "X-UNMAILBOX-ID", CAPA_UNMAILBOX_ID },
+          { "X-IDCLASS", CAPA_IDCLASS },
           { NULL, 0 } } },
       { "S01 STARTTLS", "S01 OK", "S01 NO", 0 },
       { "A01 AUTHENTICATE", 0, 0, "A01 OK", "A01 NO", "+ ", "*",
@@ -119,6 +121,7 @@ static struct protocol_t csync_protocol =
           { "SIEVE-MAILBOX", CAPA_SIEVE_MAILBOX },
           { "REPLICATION-ARCHIVE", CAPA_REPLICATION_ARCHIVE },
           { "UNMAILBOX-ID", CAPA_UNMAILBOX_ID },
+          { "IDCLASS", CAPA_IDCLASS },
           { NULL, 0 } } },
       { "STARTTLS", "OK", "NO", 1 },
       { "AUTHENTICATE", USHRT_MAX, 0, "OK", "NO", "+ ", "*", NULL, 0 },
@@ -4994,8 +4997,49 @@ static int sync_apply_capabilities(struct dlist *kin, struct sync_state *sstate)
         if (!strcasecmp(capa, "UNMAILBOX-ID")) {
             dlist_setatom(kout, NULL, capa);
         }
+        if (!strcasecmp(capa, "IDCLASS")) {
+            sstate->flags |= SYNC_FLAG_IDCLASS;
+            dlist_setatom(kout, NULL, capa);
+        }
     }
 
+    sync_send_response(kout, sstate->pout);
+    dlist_free(&kout);
+
+    return 0;
+}
+
+/* Two hosts minting in the same class silently defeats the split-brain
+ * guard, and cloning a config onto a new host is the usual way to get there */
+static void idclass_check_peer(uint32_t base, uint32_t modulus,
+                               uint32_t peer_base, uint32_t peer_modulus)
+{
+    if (modulus <= 1 || peer_modulus <= 1) return;
+
+    if (modulus != peer_modulus || base == peer_base) {
+        xsyslog(LOG_ERR, "SYNCERROR: identifier class clash",
+                         "base=<%u> modulus=<%u>"
+                         " peer.base=<%u> peer.modulus=<%u>",
+                         base, modulus, peer_base, peer_modulus);
+    }
+}
+
+static int sync_apply_idclass(struct dlist *kin, struct sync_state *sstate)
+{
+    uint32_t peer_base = 0, peer_modulus = 1;
+    uint32_t base, modulus;
+    struct dlist *kout;
+
+    if (!dlist_getnum32(kin, "BASE", &peer_base) ||
+        !dlist_getnum32(kin, "MODULUS", &peer_modulus))
+        return IMAP_PROTOCOL_BAD_PARAMETERS;
+
+    idclass_config(&base, &modulus);
+    idclass_check_peer(base, modulus, peer_base, peer_modulus);
+
+    kout = dlist_newkvlist(NULL, "IDCLASS");
+    dlist_setnum32(kout, "BASE", base);
+    dlist_setnum32(kout, "MODULUS", modulus);
     sync_send_response(kout, sstate->pout);
     dlist_free(&kout);
 
@@ -8374,6 +8418,9 @@ EXPORTED const char *sync_apply(struct dlist *kin, struct sync_reserve_list *res
     else if (!strcmp(kin->name, "CAPABILITIES"))
         r = sync_apply_capabilities(kin, state);
 
+    else if (!strcmp(kin->name, "IDCLASS"))
+        r = sync_apply_idclass(kin, state);
+
     else {
         xsyslog(LOG_ERR, "SYNCERROR: unknown command",
                          "command=<%s>",
@@ -9089,6 +9136,10 @@ connected:
         }
     }
 
+    if (CAPA(backend, CAPA_IDCLASS)) {
+        capabilities |= CAPA_IDCLASS;
+    }
+
     if (capabilities) {
         sync_do_enable(sync_cs, capabilities);
 
@@ -9098,6 +9149,10 @@ connected:
             syslog(LOG_NOTICE, "Replication to archive requested but destination didn't enable it");
             return IMAP_REMOTE_DENIED;
         }
+
+        /* both ends minting in the same class defeats the whole scheme -
+         * log it rather than refuse, so a config typo isn't an outage */
+        sync_do_idclass(sync_cs);
     }
 
     /* Set inactivity timer */
@@ -9217,6 +9272,9 @@ int sync_do_enable(struct sync_client_state *sync_cs, unsigned capabilities)
     if (capabilities & CAPA_UNMAILBOX_ID) {
         dlist_setatom(kl, NULL, "UNMAILBOX-ID");
     }
+    if (capabilities & CAPA_IDCLASS) {
+        dlist_setatom(kl, NULL, "IDCLASS");
+    }
 
     sync_send_apply(kl, sync_cs->backend->out);
     dlist_free(&kl);
@@ -9242,7 +9300,50 @@ int sync_do_enable(struct sync_client_state *sync_cs, unsigned capabilities)
                     sync_cs->flags |= SYNC_FLAG_ARCHIVE;
                 if (!strcasecmp(capa, "UNMAILBOX-ID"))
                     sync_cs->flags |= SYNC_FLAG_UNMAILBOX_ID;
+                if (!strcasecmp(capa, "IDCLASS"))
+                    sync_cs->flags |= SYNC_FLAG_IDCLASS;
             }
+        }
+    }
+
+    dlist_free(&kin);
+
+    return r;
+}
+
+EXPORTED int sync_do_idclass(struct sync_client_state *sync_cs)
+{
+    struct dlist *kl, *kin = NULL;
+    uint32_t base, modulus;
+    uint32_t peer_base = 0, peer_modulus = 1;
+    int r;
+
+    if (!(sync_cs->flags & SYNC_FLAG_IDCLASS)) return 0;
+
+    idclass_config(&base, &modulus);
+
+    kl = dlist_newkvlist(NULL, "IDCLASS");
+    dlist_setnum32(kl, "BASE", base);
+    dlist_setnum32(kl, "MODULUS", modulus);
+    sync_send_apply(kl, sync_cs->backend->out);
+    dlist_free(&kl);
+
+    r = sync_parse_response("IDCLASS", sync_cs->backend->in, &kin);
+    if (r) return r;
+
+    if (kin) {
+        /* sync_parse_response hands back a container: the named list is
+         * its head, same shape as the ENABLED response above */
+        struct dlist *ki = kin->head;
+        if (!ki || strcmp(ki->name, "IDCLASS")) {
+            xsyslog(LOG_ERR, "SYNCERROR: Illegal response to IDCLASS",
+                    "name=<%s>", ki ? ki->name : "(none)");
+            r = IMAP_PROTOCOL_BAD_PARAMETERS;
+        }
+        else {
+            dlist_getnum32(ki, "BASE", &peer_base);
+            dlist_getnum32(ki, "MODULUS", &peer_modulus);
+            idclass_check_peer(base, modulus, peer_base, peer_modulus);
         }
     }
 

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -300,6 +300,7 @@ const char *sync_restore(struct dlist *kin,
 #define SYNC_FLAG_USECACHE (1<<9)
 #define SYNC_FLAG_NOCACHE (1<<10)
 #define SYNC_FLAG_UNMAILBOX_ID (1<<11)
+#define SYNC_FLAG_IDCLASS (1<<12)
 
 int sync_do_annotation(struct sync_client_state *sync_cs, const char *mboxname);
 int sync_do_mailboxes(struct sync_client_state *sync_cs,
@@ -346,6 +347,7 @@ int sync_do_restart(struct sync_client_state *sync_cs);
 int sync_do_reader(struct sync_client_state *sync_cs, sync_log_reader_t *slr);
 
 int sync_do_enable(struct sync_client_state *sync_cs, unsigned capa);
+int sync_do_idclass(struct sync_client_state *sync_cs);
 
 int sync_connect(struct sync_client_state *sync_cs);
 void sync_disconnect(struct sync_client_state *sync_cs);

--- a/lib/idclass.c
+++ b/lib/idclass.c
@@ -1,0 +1,164 @@
+/* idclass.c -- per-host residue classes for minted identifiers
+ *
+ * Copyright (c) 1994-2026 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <config.h>
+
+#include <stdint.h>
+
+#include "idclass.h"
+#include "libconfig.h"
+#include "imapopts.h"
+
+#define NSEC_MAX 999999999
+
+/* zero is UTIME_OMIT, so class 0's lowest legal member is `modulus` */
+static long nsec_class_floor(uint32_t base, uint32_t modulus)
+{
+    return base >= 1 ? (long) base : (long) modulus;
+}
+
+EXPORTED modseq_t idclass_modseq_next(modseq_t val,
+                                      uint32_t base, uint32_t modulus)
+{
+    if (modulus <= 1) return val + 1;
+
+    modseq_t next = val - (val % modulus) + base;
+    if (next <= val) next += modulus;
+
+    return next;
+}
+
+EXPORTED uint32_t idclass_uidvalidity_next(uint32_t val,
+                                           uint32_t base, uint32_t modulus)
+{
+    if (modulus <= 1) return val + 1;
+
+    uint32_t next = val - (val % modulus) + base;
+    if (next <= val) {
+        /* refuse to wrap: going backwards is worse than leaving the class */
+        if (next > UINT32_MAX - modulus) return val + 1;
+        next += modulus;
+    }
+
+    return next;
+}
+
+EXPORTED long idclass_nsec_align(long nsec, uint32_t base, uint32_t modulus)
+{
+    if (modulus <= 1) return nsec;
+    if (nsec < 0 || nsec > NSEC_MAX) nsec = 0;
+
+    long next = nsec - (nsec % (long) modulus) + (long) base;
+    if (next > NSEC_MAX) next -= modulus;
+    if (next < 1) next = nsec_class_floor(base, modulus);
+
+    return next;
+}
+
+EXPORTED long idclass_nsec_next(long nsec, uint32_t base, uint32_t modulus)
+{
+    if (modulus <= 1) return nsec >= NSEC_MAX ? 1 : nsec + 1;
+
+    long next = nsec + (long) modulus;
+    if (next > NSEC_MAX) next = nsec_class_floor(base, modulus);
+
+    return next;
+}
+
+EXPORTED void idclass_config(uint32_t *basep, uint32_t *modulusp)
+{
+    int modulus = config_getint(IMAPOPT_MODSEQ_MODULUS);
+    int base = config_getint(IMAPOPT_MODSEQ_BASE);
+
+    /* cyrus_init() rejects an invalid pair, but be defensive: a bad pair
+     * must degrade to the historical behaviour, never to a wrong value */
+    if (modulus < 1 || base < 0 || base >= modulus) {
+        modulus = 1;
+        base = 0;
+    }
+
+    *basep = base;
+    *modulusp = modulus;
+}
+
+EXPORTED const char *idclass_config_error(void)
+{
+    int modulus = config_getint(IMAPOPT_MODSEQ_MODULUS);
+    int base = config_getint(IMAPOPT_MODSEQ_BASE);
+
+    if (modulus < 1)
+        return "modseq_modulus must be at least 1";
+    if (base < 0)
+        return "modseq_base must not be negative";
+    if (base >= modulus)
+        return "modseq_base must be less than modseq_modulus";
+
+    return NULL;
+}
+
+EXPORTED modseq_t modseq_next(modseq_t val)
+{
+    uint32_t base, modulus;
+    idclass_config(&base, &modulus);
+    return idclass_modseq_next(val, base, modulus);
+}
+
+EXPORTED uint32_t uidvalidity_next(uint32_t val)
+{
+    uint32_t base, modulus;
+    idclass_config(&base, &modulus);
+    return idclass_uidvalidity_next(val, base, modulus);
+}
+
+EXPORTED long nsec_align(long nsec)
+{
+    uint32_t base, modulus;
+    idclass_config(&base, &modulus);
+    return idclass_nsec_align(nsec, base, modulus);
+}
+
+EXPORTED long nsec_next(long nsec)
+{
+    uint32_t base, modulus;
+    idclass_config(&base, &modulus);
+    return idclass_nsec_next(nsec, base, modulus);
+}

--- a/lib/idclass.h
+++ b/lib/idclass.h
@@ -1,0 +1,137 @@
+/* idclass.h -- per-host residue classes for minted identifiers
+ *
+ * Copyright (c) 1994-2026 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any legal
+ *    details, please contact
+ *      Carnegie Mellon University
+ *      Center for Technology Transfer and Enterprise Creation
+ *      4615 Forbes Avenue
+ *      Suite 302
+ *      Pittsburgh, PA  15213
+ *      (412) 268-7393, fax: (412) 268-7395
+ *      innovation@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef INCLUDED_IDCLASS_H
+#define INCLUDED_IDCLASS_H
+
+#include <stdint.h>
+
+#include "util.h"
+
+/**
+ * @file idclass.h
+ *
+ * Per-host residue classes for minted identifiers.
+ *
+ * Every identifier this host mints is congruent to @a base modulo
+ * @a modulus.  Two hosts with different bases cannot mint the same value
+ * even while split-brained, so a later merge has no clashes to resolve.
+ *
+ * A base of 0 with a modulus of 1 is the historical behaviour: plain
+ * increment.
+ */
+
+/**
+ * The next modseq in the class.
+ *
+ * @param val the modseq to advance past
+ * @param base residue this host mints in
+ * @param modulus size of the class
+ * @return a modseq strictly greater than @a val
+ */
+extern modseq_t idclass_modseq_next(modseq_t val,
+                                    uint32_t base, uint32_t modulus);
+
+/**
+ * The next uidvalidity in the class.
+ *
+ * @param val the uidvalidity to advance past
+ * @param base residue this host mints in
+ * @param modulus size of the class
+ * @return a uidvalidity strictly greater than @a val, leaving the class
+ *         rather than wrapping if the range is nearly exhausted
+ */
+extern uint32_t idclass_uidvalidity_next(uint32_t val,
+                                         uint32_t base, uint32_t modulus);
+
+/**
+ * Move a nanosecond count onto the class without advancing it.  Idempotent,
+ * so re-aligning an already aligned value is harmless.
+ *
+ * @param nsec the count to align, or anything outside UTIME_SAFE_NSEC
+ * @param base residue this host mints in
+ * @param modulus size of the class
+ * @return a count within UTIME_SAFE_NSEC (1..999999999); zero means
+ *         UTIME_OMIT when the spool file is stamped, so it is never produced
+ */
+extern long idclass_nsec_align(long nsec, uint32_t base, uint32_t modulus);
+
+/**
+ * The next nanosecond count in the class.
+ *
+ * @param nsec the count to advance past
+ * @param base residue this host mints in
+ * @param modulus size of the class
+ * @return the next count within UTIME_SAFE_NSEC, wrapping to the bottom of
+ *         the class rather than running out of the range
+ */
+extern long idclass_nsec_next(long nsec, uint32_t base, uint32_t modulus);
+
+/** @see idclass_modseq_next, using the configured class */
+extern modseq_t modseq_next(modseq_t val);
+
+/** @see idclass_uidvalidity_next, using the configured class */
+extern uint32_t uidvalidity_next(uint32_t val);
+
+/** @see idclass_nsec_align, using the configured class */
+extern long nsec_align(long nsec);
+
+/** @see idclass_nsec_next, using the configured class */
+extern long nsec_next(long nsec);
+
+/**
+ * The class configured by modseq_base and modseq_modulus, for the
+ * replication handshake.  An invalid pair reads back as 0/1.
+ *
+ * @param[out] basep residue this host mints in
+ * @param[out] modulusp size of the class
+ */
+extern void idclass_config(uint32_t *basep, uint32_t *modulusp);
+
+/**
+ * Validate modseq_base and modseq_modulus.
+ *
+ * @return an error string, or NULL if the configured pair is valid
+ */
+extern const char *idclass_config_error(void);
+
+#endif /* INCLUDED_IDCLASS_H */

--- a/lib/imapoptions/modseq_base
+++ b/lib/imapoptions/modseq_base
@@ -1,7 +1,7 @@
 Name: modseq_base
 Type: INT
 Default-Value: 0
-Last-Modified: 3.15.0
+Last-Modified: UNRELEASED
 
 The residue class this host mints identifiers in.  Together with
 :imapdconf:`modseq_modulus` this partitions the modseq, uidvalidity and

--- a/lib/imapoptions/modseq_base
+++ b/lib/imapoptions/modseq_base
@@ -1,0 +1,18 @@
+Name: modseq_base
+Type: INT
+Default-Value: 0
+Last-Modified: 3.15.0
+
+The residue class this host mints identifiers in.  Together with
+:imapdconf:`modseq_modulus` this partitions the modseq, uidvalidity and
+nanosecond-timestamp spaces so that no two hosts can ever allocate the same
+value, even while split-brained.  Must be at least zero and less than
+:imapdconf:`modseq_modulus`.
+
+Every host that is ever allowed to allocate for the same user - a master and
+each of its replicas, since any of them may be promoted - MUST be given a
+different value.  Two hosts sharing a base defeats the entire mechanism, so
+:cyrusman:`sync_client(8)` reports a mismatch at connection time.
+
+The default of 0, with the default modulus of 1, reproduces the historical
+behaviour exactly: identifiers are simply incremented.

--- a/lib/imapoptions/modseq_modulus
+++ b/lib/imapoptions/modseq_modulus
@@ -1,0 +1,20 @@
+Name: modseq_modulus
+Type: INT
+Default-Value: 1
+Last-Modified: 3.15.0
+
+How many residue classes the identifier space is divided into - that is, the
+maximum number of hosts that can ever mint identifiers for a given user.  See
+:imapdconf:`modseq_base`.
+
+This value MUST be identical on every host in a replication group, and should
+be chosen with retired hosts in mind: a base should never be reused, so allow
+headroom beyond the current fleet size.
+
+Identifiers advance in steps of this value, so it consumes log2(modulus) bits
+of the 64-bit modseq space.  JMAP mailbox and calendar-event ids are a base64
+encoding of createdmodseq, so a large modulus makes those ids longer sooner.
+For nanosecond timestamps the modulus divides the 999999999 available values,
+which bounds how many messages can share one second in one mailbox.
+
+The default of 1 means a single class, i.e. the historical behaviour.

--- a/lib/imapoptions/modseq_modulus
+++ b/lib/imapoptions/modseq_modulus
@@ -1,7 +1,7 @@
 Name: modseq_modulus
 Type: INT
 Default-Value: 1
-Last-Modified: 3.15.0
+Last-Modified: UNRELEASED
 
 How many residue classes the identifier space is divided into - that is, the
 maximum number of hosts that can ever mint identifiers for a given user.  See


### PR DESCRIPTION
This requires setting a modulus and offset for ID creation, such that each machine creates IDs in its own offset, e.g. if it was modulus 8, one machine creates 1, 9, 17, etc and another creates 2, 10, 18, ...