### PR TITLE
jmap_util: no threadid for messages without a conversation

### DIFF
--- a/imap/jmap_util.c
+++ b/imap/jmap_util.c
@@ -1352,6 +1352,13 @@ EXPORTED void jmap_set_threadid(struct conversations_state *cstate,
     char prefix = USER_COMPACT_EMAILIDS(cstate) ?
         JMAP_THREADID_PREFIX : JMAP_LEGACY_THREADID_PREFIX;
 
+    /* conversation_id_encode() renders no conversation as the atom "NIL",
+     * which prefixed would be the nonsense id "TNIL" */
+    if (cid == NULLCONVERSATION) {
+        thrid[0] = '\0';
+        return;
+    }
+
     snprintf(thrid, JMAP_THREADID_SIZE, "%c%s",
              prefix, conversation_id_encode(cstate, cid));
 }


### PR DESCRIPTION
conversation_id_encode() renders NULLCONVERSATION as the atom "NIL", so jmap_set_threadid() was prefixing it into the nonsense id "TNIL", which showed up in audit logs.  Emit the empty string instead.