### PR TITLE
Add tests for backupcyrusd

### DIFF
--- a/cassandane/Cassandane/Cyrus/Backup.pm
+++ b/cassandane/Cassandane/Cyrus/Backup.pm
@@ -64,6 +64,17 @@ sub _open_backup_db ($self, $meta)
     );
 }
 
+# Helper: does the state's indexed table still have the version 5 column?
+sub _has_indexed_deleted ($self, $meta)
+{
+    my $dbh = $self->_open_backup_db($meta);
+    my $cols = $dbh->selectall_arrayref("PRAGMA table_info(indexed)",
+                                        { Slice => {} });
+    $dbh->disconnect;
+
+    return scalar grep { $_->{name} eq 'deleted' } @$cols;
+}
+
 use Cassandane::Tiny::Loader;
 
 1;

--- a/cassandane/Cassandane/Cyrus/FastMail.pm
+++ b/cassandane/Cassandane/Cyrus/FastMail.pm
@@ -11,6 +11,9 @@ use Net::CardDAVTalk 0.11;
 use Text::JSContact 0.01 qw(vcard_to_jscontact);
 use Data::Dumper;
 use Storable 'dclone';
+use Cyrus::Backup;
+use Cyrus::Backup::Restore;
+use Cyrus::Backup::State;
 
 use base qw(Cassandane::Cyrus::TestCase Cassandane::Mixin::QuotaHelper);
 use Cassandane::Util::Log;
@@ -194,6 +197,224 @@ sub _fmjmap_err
     my $res = $self->_fmjmap_req($cmd, %args);
     $self->assert_str_equals("error", $res->[0]);
     return $res->[1];
+}
+
+# Route Cyrus::Backup's chatter into the cassandane log when running verbose
+package Cassandane::Cyrus::FastMail::BackupLogger {
+    sub log
+    {
+        my (undef, $msg) = @_;
+        if (ref $msg eq 'ARRAY') {
+            my ($fmt, @args) = @$msg;
+            $msg = sprintf($fmt, @args);
+        }
+        Cassandane::Util::Log::xlog($msg);
+    }
+    *log_debug = \&log;
+    sub log_event {}
+    sub log_debug_event {}
+}
+
+# Create the meta and data directories a backup needs, and return them
+# along with everything needed to talk to this instance's backupcyrusd.
+sub _backup_dirs
+{
+    my ($self) = @_;
+
+    my $service = $self->{instance}->get_service('backupcyrusd');
+
+    my $meta = "$self->{instance}->{basedir}/backupmeta";
+    my $data = "$self->{instance}->{basedir}/backupdata";
+    mkdir($meta);
+    mkdir($data);
+
+    $Cyrus::Backup::LOGGER_CB = sub { 'Cassandane::Cyrus::FastMail::BackupLogger' }
+        if $self->{store}->{verbose};
+
+    return ($service->host, $service->port,
+            $self->{instance}->get_servername, $meta, $data);
+}
+
+# The uniqueid cyrus knows a folder by, which is also how the backup
+# names the folder's directory in the tar file.
+sub _mailbox_uniqueid
+{
+    my ($self, $folder) = @_;
+
+    my $entry = '/shared/vendor/cmu/cyrus-imapd/uniqueid';
+    my $talk = $self->{store}->get_client();
+    my $res = $talk->getmetadata($folder, $entry);
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+    $self->assert_not_null($res->{$folder}{$entry});
+
+    return $res->{$folder}{$entry};
+}
+
+# Every mailbox cyrus has for a user, as { extname => uniqueid }, which is
+# what a complete backup's folder list should look like.  Only valid with
+# altnamespace off, which is how this suite configures cyrus.
+sub _mailboxes_by_extname
+{
+    my ($self, $userid) = @_;
+    $userid ||= 'cassandane';
+
+    my $mboxes = $self->{instance}->read_mailboxes_db();
+
+    my %res;
+    foreach my $intname (keys %$mboxes) {
+        my $extname = $intname;
+        next unless $extname =~ s{^user\.\Q$userid\E(\.|$)}{INBOX$1};
+        # tombstones ('d') and intermediates ('i') aren't real folders, and
+        # mboxlist_usermboxtree doesn't hand them to backupcyrusd
+        next if $mboxes->{$intname}{mbtype} =~ m/[di]/;
+        $res{$extname} = $mboxes->{$intname}{uniqueid};
+    }
+
+    return \%res;
+}
+
+# Summarise what a backup contains, by joining up the tables of its state
+# database into something a test can make readable assertions about:
+#
+#  {
+#    names   => { $foldername => $uniqueid },      # live folders only
+#    folders => { $uniqueid => { folderid => $id,
+#                                uniqueid => $uniqueid,
+#                                names => { $foldername => $deleted },
+#                                meta => { index => {...}, header => {...} },
+#                                uids => { $uid => $guid } } },
+#    meta    => { seen => {...}, sub => {...} },   # per-user files
+#    files   => { $guid => { size => $n, refcount => $n } },
+#  }
+sub _backup_content
+{
+    my ($self, $meta, $statefile) = @_;
+    $statefile ||= 'backupstate.sqlite3';
+
+    my $state = Cyrus::Backup::State->new($meta, $statefile);
+    my $dbh = $state->dbh();
+
+    my %res = (names => {}, folders => {}, meta => {}, files => {});
+
+    my %byid;
+    foreach my $row (@{$dbh->selectall_arrayref(
+        "SELECT folderid, uniqueid FROM folders", { Slice => {} })})
+    {
+        my $folder = {
+            folderid => $row->{folderid},
+            uniqueid => $row->{uniqueid},
+            names => {},
+            meta => {},
+            uids => {},
+        };
+        $byid{$row->{folderid}} = $folder;
+        $res{folders}{$row->{uniqueid}} = $folder;
+    }
+
+    # a name may appear more than once as folders are deleted and recreated,
+    # so walk them in the order they were backed up and let later win
+    foreach my $row (@{$dbh->selectall_arrayref(
+        "SELECT name, folderid, deleted FROM imap ORDER BY offset",
+        { Slice => {} })})
+    {
+        my $folder = $byid{$row->{folderid}};
+        next unless $folder;
+        $folder->{names}{$row->{name}} = $row->{deleted};
+        if ($row->{deleted}) {
+            delete $res{names}{$row->{name}};
+        }
+        else {
+            $res{names}{$row->{name}} = $folder->{uniqueid};
+        }
+    }
+
+    foreach my $row (@{$dbh->selectall_arrayref(
+        "SELECT folderid, name, sha1, size, mtime, inode, stale FROM fmeta",
+        { Slice => {} })})
+    {
+        my $folder = $byid{$row->{folderid}};
+        next unless $folder;
+        $folder->{meta}{$row->{name}} = $row;
+    }
+
+    foreach my $row (@{$dbh->selectall_arrayref(
+        "SELECT indexed.folderid, indexed.uid, files.guid
+           FROM indexed JOIN files USING (fileid)", { Slice => {} })})
+    {
+        my $folder = $byid{$row->{folderid}};
+        next unless $folder;
+        $folder->{uids}{$row->{uid}} = $row->{guid};
+    }
+
+    foreach my $row (@{$dbh->selectall_arrayref(
+        "SELECT guid, size, refcount FROM files", { Slice => {} })})
+    {
+        $res{files}{$row->{guid}} = $row;
+    }
+
+    # the meta table is keyed on (type, name), but 'annot' and 'sieve' are
+    # legacy types that nothing writes any more, so name alone will do
+    foreach my $row (@{$dbh->selectall_arrayref(
+        "SELECT type, name, sha1, size, mtime, inode, stale FROM meta",
+        { Slice => {} })})
+    {
+        $res{meta}{$row->{name}} = $row;
+    }
+
+    $state->cancel();
+
+    return \%res;
+}
+
+# Just the structure of a _backup_content, without the bookkeeping that
+# legitimately differs between two states describing the same content
+# (folderids, offsets, staleness counters, timestamps).
+sub _backup_summary
+{
+    my ($self, $content) = @_;
+
+    my %res = (
+        names => $content->{names},
+        meta => [sort keys %{$content->{meta}}],
+        folders => {},
+        files => {},
+    );
+
+    foreach my $uniqueid (keys %{$content->{folders}}) {
+        my $folder = $content->{folders}{$uniqueid};
+        $res{folders}{$uniqueid} = {
+            names => $folder->{names},
+            uids => $folder->{uids},
+            meta => [sort keys %{$folder->{meta}}],
+        };
+    }
+
+    foreach my $guid (keys %{$content->{files}}) {
+        $res{files}{$guid} = $content->{files}{$guid}{refcount};
+    }
+
+    return \%res;
+}
+
+# Extract a message from the backup's tar file and return its bytes.
+sub _backup_file
+{
+    my ($self, $meta, $guid) = @_;
+
+    my $restore = Cyrus::Backup::Restore->new($meta);
+    $restore->GetFile($guid);
+
+    # GetFile returns bare guids rather than paths when the file has
+    # already been extracted, so work out the path ourselves
+    my $path = "$meta/files/$guid";
+    return undef unless -f $path;
+
+    open(my $fh, '<', $path) or die "can't read $path: $!";
+    local $/ = undef;
+    my $content = <$fh>;
+    close($fh);
+
+    return $content;
 }
 
 use Cassandane::Tiny::Loader;

--- a/cassandane/tiny-tests/Backup/basic
+++ b/cassandane/tiny-tests/Backup/basic
@@ -5,7 +5,7 @@ use Cyrus::Backup;
 use Cyrus::Backup::Restore;
 
 sub test_basic
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     $self->make_message("Email 1") or die;

--- a/cassandane/tiny-tests/Backup/compress_deleted_folder
+++ b/cassandane/tiny-tests/Backup/compress_deleted_folder
@@ -16,7 +16,7 @@ use Cyrus::Backup;
 # the folder's data) is retained, with its timestamp, until it genuinely ages
 # out.
 sub test_compress_deleted_folder
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my $talk = $self->{store}->get_client();

--- a/cassandane/tiny-tests/Backup/compress_deleted_folder_ages_out
+++ b/cassandane/tiny-tests/Backup/compress_deleted_folder_ages_out
@@ -8,7 +8,7 @@ use DBI;
 # still restorable), then be reclaimed once its deletion timestamp ages past
 # MAX_AGE.
 sub test_compress_deleted_folder_ages_out
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my $talk = $self->{store}->get_client();

--- a/cassandane/tiny-tests/Backup/folder_delete
+++ b/cassandane/tiny-tests/Backup/folder_delete
@@ -4,7 +4,7 @@ use Cassandane::Tiny;
 use Cyrus::Backup;
 
 sub test_folder_delete
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my $talk = $self->{store}->get_client();

--- a/cassandane/tiny-tests/Backup/restore_getfile
+++ b/cassandane/tiny-tests/Backup/restore_getfile
@@ -7,7 +7,7 @@ use Cyrus::Backup::Restore;
 # Test that Cyrus::Backup::Restore can extract message files from a backup
 # by their SHA1 guid, both before and after compression.
 sub test_restore_getfile
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my $talk = $self->{store}->get_client();

--- a/cassandane/tiny-tests/Backup/restore_tar_contents
+++ b/cassandane/tiny-tests/Backup/restore_tar_contents
@@ -7,7 +7,7 @@ use Cyrus::Backup::Restore;
 # Test that Cyrus::Backup::Restore::GetTar can stream through a backup
 # and that the tar contains the expected entry types.
 sub test_restore_tar_contents
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my $talk = $self->{store}->get_client();

--- a/cassandane/tiny-tests/Backup/upgrade_v5_state
+++ b/cassandane/tiny-tests/Backup/upgrade_v5_state
@@ -1,0 +1,81 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+use Cyrus::Backup::Restore;
+
+# Version 6 dropped the indexed.deleted column.  A state database that hasn't
+# been compacted since the upgrade still has it, and it's NOT NULL with no
+# default, so backups have to keep filling it in until a compact rewrites the
+# state with the current schema.
+sub test_upgrade_v5_state
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+    $self->make_message("Email 1") or die;
+
+    my ($meta, $data, $service, $servername) = $self->_backup_setup();
+    $self->_do_backup($meta, $data, $service, $servername);
+
+    # rewrite the state the way a version 5 one looks on disk: indexed with a
+    # deleted column, and the version to match.  Dropping the table takes its
+    # triggers with it, so replay them from their own recorded DDL.
+    my $dbh = $self->_open_backup_db($meta);
+    my $triggers = $dbh->selectcol_arrayref(
+        "SELECT sql FROM sqlite_master
+          WHERE type = 'trigger' AND tbl_name = 'indexed'");
+    $self->assert_num_gt(0, scalar @$triggers);
+
+    $dbh->do("CREATE TABLE indexed_v5 (
+                folderid INTEGER NOT NULL,
+                uid INTEGER NOT NULL,
+                fileid INTEGER NOT NULL,
+                deleted INTEGER NOT NULL,
+                PRIMARY KEY (folderid, uid))");
+    $dbh->do("INSERT INTO indexed_v5 SELECT folderid, uid, fileid, 0 FROM indexed");
+    $dbh->do("DROP TABLE indexed");
+    $dbh->do("ALTER TABLE indexed_v5 RENAME TO indexed");
+    $dbh->do($_) foreach @$triggers;
+    $dbh->do("UPDATE status SET version = 5");
+    $dbh->disconnect;
+
+    $self->assert($self->_has_indexed_deleted($meta),
+                  'test set the state back to the version 5 schema');
+
+    # a backup against that state still has to work, and still has to index
+    # the new message
+    my $msg = $self->make_message("Email 2") or die;
+    my ($version) = $self->_do_backup($meta, $data, $service, $servername);
+    $self->assert_num_equals(5, $version);
+
+    $dbh = $self->_open_backup_db($meta);
+    my ($count) = $dbh->selectrow_array(
+        "SELECT COUNT(*) FROM indexed JOIN files USING (fileid) WHERE guid = ?",
+        {}, $msg->guid);
+    $dbh->disconnect;
+    $self->assert_num_equals(1, $count, 'new message indexed in a v5 state');
+
+    # compacting rewrites the state from scratch, which is where the upgrade
+    # actually happens
+    my $restore = Cyrus::Backup::Restore->new($meta);
+    my $oldfile = $restore->TarFileName();
+    undef $restore;
+    sleep 1 while Cyrus::Backup::NewDataFilename(0) eq $oldfile;
+
+    my ($cversion) = Cyrus::Backup::CompressBackup($meta, $data, 'cassandane',
+                                                   undef, 101);
+    $self->assert_num_equals(Cyrus::Backup::CurrentBackupVersion(), $cversion);
+
+    $dbh = $self->_open_backup_db($meta);
+    my ($dbversion) = $dbh->selectrow_array("SELECT version FROM status");
+    ($count) = $dbh->selectrow_array(
+        "SELECT COUNT(*) FROM indexed JOIN files USING (fileid) WHERE guid = ?",
+        {}, $msg->guid);
+    $dbh->disconnect;
+
+    $self->assert_num_equals(6, $dbversion);
+    $self->assert_num_equals(1, $count, 'message survived the upgrade');
+    $self->assert(!$self->_has_indexed_deleted($meta),
+                  'compact dropped the indexed.deleted column');
+}

--- a/cassandane/tiny-tests/Backup/upgrade_v5_state
+++ b/cassandane/tiny-tests/Backup/upgrade_v5_state
@@ -9,7 +9,7 @@ use Cyrus::Backup::Restore;
 # default, so backups have to keep filling it in until a compact rewrites the
 # state with the current schema.
 sub test_upgrade_v5_state
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my $talk = $self->{store}->get_client();

--- a/cassandane/tiny-tests/FastMail/backupcyrusd
+++ b/cassandane/tiny-tests/FastMail/backupcyrusd
@@ -6,7 +6,7 @@ use Cyrus::Backup;
 use Cyrus::Backup::Restore;
 
 sub test_backupcyrusd
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my $msg1 = $self->make_message("Email 1") or die;

--- a/cassandane/tiny-tests/FastMail/backupcyrusd
+++ b/cassandane/tiny-tests/FastMail/backupcyrusd
@@ -9,41 +9,89 @@ sub test_backupcyrusd
     :min_version_3_13 :want_service_backupcyrusd
     ($self)
 {
-    $self->make_message("Email 1") or die;
-    $self->make_message("Email 2") or die;
+    my $msg1 = $self->make_message("Email 1") or die;
+    my $msg2 = $self->make_message("Email 2") or die;
 
-    my $servername = $self->{instance}->get_servername;
-    my $service = $self->{instance}->get_service('backupcyrusd');
+    my ($host, $port, $servername, $meta, $data) = $self->_backup_dirs();
 
-    my $data = "$self->{instance}->{basedir}/backupdata";
-    my $meta = "$self->{instance}->{basedir}/backupmeta";
-    mkdir($data);
-    mkdir($meta);
-
-    $ENV{DEBUGIO} = 1 if $self->{store}->{verbose};
-
-    my @users = Cyrus::Backup::GetUsers($service->host, $service->port, $servername);
+    my @users = Cyrus::Backup::GetUsers($host, $port, $servername);
     $self->assert_str_equals('cassandane', join(',', @users));
 
-    my ($version, $size) = Cyrus::Backup::BackupUser($service->host, $service->port, $meta, $data, $servername, 'cassandane');
+    my ($version, $size) = Cyrus::Backup::BackupUser($host, $port,
+                                                     $meta, $data,
+                                                     $servername, 'cassandane');
     $self->assert_num_gt(0, $size);
+
+    # the backup contains every folder cyrus knows about for this user,
+    # under the same uniqueids
+    my $backup = $self->_backup_content($meta);
+    $self->assert_deep_equals($self->_mailboxes_by_extname(),
+                              $backup->{names});
+
+    my $uniqueid = $self->_mailbox_uniqueid("INBOX");
+    my $inbox = $backup->{folders}{$uniqueid};
+    $self->assert_not_null($inbox);
+
+    # we backed up the folder's metadata files
+    $self->assert_not_null($inbox->{meta}{header});
+    $self->assert_not_null($inbox->{meta}{index});
+    $self->assert_num_gt(0, $inbox->{meta}{index}{size});
+
+    # and both messages, indexed by the uid cyrus gave them
+    $self->assert_deep_equals({ 1 => $msg1->guid, 2 => $msg2->guid },
+                              $inbox->{uids});
+
+    # the messages are the only files: the other folders are all empty
+    $self->assert_deep_equals([sort ($msg1->guid, $msg2->guid)],
+                              [sort keys %{$backup->{files}}]);
+    $self->assert_num_equals(1, $backup->{files}{$msg1->guid}{refcount});
+    $self->assert_num_equals(1, $backup->{files}{$msg2->guid}{refcount});
+
+    # nothing has subscribed yet, so there's no subscriptions file to back up
+    $self->assert_deep_equals({}, $backup->{meta});
 
     # we'll get a new email and a subscription
     my $talk = $self->{store}->get_client();
     $talk->subscribe("INBOX");
-    $self->make_message("Email 3") or die;
+    my $msg3 = $self->make_message("Email 3") or die;
 
-    my ($newversion, $newsize) = Cyrus::Backup::BackupUser($service->host, $service->port, $meta, $data, $servername, 'cassandane');
+    my ($newversion, $newsize) = Cyrus::Backup::BackupUser($host, $port,
+                                                           $meta, $data,
+                                                           $servername,
+                                                           'cassandane');
 
     $self->assert_num_equals($version, $newversion);
     $self->assert_num_gt($size, $newsize);
 
-    # XXX - add more tests to check the content of the backups
+    $backup = $self->_backup_content($meta);
+
+    # the subscription showed up as a per-user meta file
+    $self->assert_not_null($backup->{meta}{sub});
+    $self->assert_num_gt(0, $backup->{meta}{sub}{size});
+
+    # same folders, and the INBOX now has the third message too
+    $self->assert_deep_equals($self->_mailboxes_by_extname(),
+                              $backup->{names});
+    $inbox = $backup->{folders}{$uniqueid};
+    $self->assert_deep_equals(
+        { 1 => $msg1->guid, 2 => $msg2->guid, 3 => $msg3->guid },
+        $inbox->{uids});
+    $self->assert_deep_equals(
+        [sort ($msg1->guid, $msg2->guid, $msg3->guid)],
+        [sort keys %{$backup->{files}}]);
 
     $self->assert(-f "$meta/backupstate.sqlite3");
 
     my $restore = Cyrus::Backup::Restore->new($meta);
     my $file = $restore->TarFileName();
+    undef $restore;
 
     $self->assert(-f "$data/$file");
+
+    # and the bytes we can get back out of the tar file are the bytes we
+    # delivered in the first place
+    foreach my $msg ($msg1, $msg2, $msg3) {
+        my $content = $self->_backup_file($meta, $msg->guid);
+        $self->assert_str_equals($msg->as_string(), $content);
+    }
 }

--- a/cassandane/tiny-tests/FastMail/backupcyrusd_compress
+++ b/cassandane/tiny-tests/FastMail/backupcyrusd_compress
@@ -5,7 +5,7 @@ use Cyrus::Backup;
 use Cyrus::Backup::Restore;
 
 sub test_backupcyrusd_compress
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my ($host, $port, $servername, $meta, $data) = $self->_backup_dirs();

--- a/cassandane/tiny-tests/FastMail/backupcyrusd_compress
+++ b/cassandane/tiny-tests/FastMail/backupcyrusd_compress
@@ -1,0 +1,104 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+use Cyrus::Backup::Restore;
+
+sub test_backupcyrusd_compress
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my ($host, $port, $servername, $meta, $data) = $self->_backup_dirs();
+
+    my $talk = $self->{store}->get_client();
+    $talk->create("INBOX.keep") or die "can't create INBOX.keep";
+    $talk->create("INBOX.old") or die "can't create INBOX.old";
+    $talk->create("INBOX.gone") or die "can't create INBOX.gone";
+
+    my %msgs;
+    foreach my $folder (qw(keep old gone)) {
+        $self->{store}->set_folder("INBOX.$folder");
+        $msgs{$folder} = [$self->make_message("Email in $folder") or die];
+    }
+
+    my $keepid = $self->_mailbox_uniqueid("INBOX.keep");
+    my $oldid = $self->_mailbox_uniqueid("INBOX.old");
+    my $goneid = $self->_mailbox_uniqueid("INBOX.gone");
+
+    Cyrus::Backup::BackupUser($host, $port, $meta, $data,
+                              $servername, 'cassandane');
+
+    # churn: a second message rewrites cyrus.index, leaving the copy we
+    # already backed up as dead weight in the tar file
+    $self->{store}->set_folder("INBOX.keep");
+    push @{$msgs{keep}}, ($self->make_message("Another email in keep") or die);
+
+    # a rename leaves a deletion marker behind for the old name
+    $talk->rename("INBOX.old", "INBOX.renamed")
+        or die "can't rename INBOX.old: " . $talk->get_last_error();
+
+    # and a delete leaves one behind for a folder that's gone for good
+    $talk->delete("INBOX.gone")
+        or die "can't delete INBOX.gone: " . $talk->get_last_error();
+
+    Cyrus::Backup::BackupUser($host, $port, $meta, $data,
+                              $servername, 'cassandane');
+
+    my $before = $self->_backup_content($meta);
+    $self->assert_str_equals($keepid, $before->{names}{'INBOX.keep'});
+    $self->assert_str_equals($oldid, $before->{names}{'INBOX.renamed'});
+    $self->assert_num_gt(0, $before->{folders}{$oldid}{names}{'INBOX.old'});
+    $self->assert_num_gt(0, $before->{folders}{$goneid}{names}{'INBOX.gone'});
+
+    my $restore = Cyrus::Backup::Restore->new($meta);
+    my $oldfile = $restore->TarFileName();
+    undef $restore;
+    $self->assert(-f "$data/$oldfile");
+
+    # the new tar file is named for the time it was written, so don't try to
+    # compress until a new name is available
+    sleep 1 while Cyrus::Backup::NewDataFilename(0) eq $oldfile;
+
+    # 100% demands a tar file with nothing dead in it at all, which ours
+    # isn't, so this always rewrites
+    my ($version, $offset, $percentage)
+        = Cyrus::Backup::CompressBackup($meta, $data, 'cassandane',
+                                        undef, 100);
+
+    $self->assert_num_equals(Cyrus::Backup::CurrentBackupVersion(), $version);
+    $self->assert_num_gt(0, $offset);
+    $self->assert_num_lt(100, $percentage);
+
+    # we're on a new tar file now, and the old one has been cleaned up
+    $restore = Cyrus::Backup::Restore->new($meta);
+    my $newfile = $restore->TarFileName();
+    undef $restore;
+    $self->assert_str_not_equals($oldfile, $newfile);
+    $self->assert(-f "$data/$newfile");
+    $self->assert(!-e "$data/$oldfile");
+    $self->assert(-e "$meta/$newfile");
+
+    # compaction throws away dead data, not live content: everything we had
+    # before is still described by the state database
+    my $after = $self->_backup_content($meta);
+    $self->assert_deep_equals($self->_backup_summary($before),
+                              $self->_backup_summary($after));
+
+    # and the messages still come back out of the new tar file intact
+    foreach my $folder (qw(keep old gone)) {
+        foreach my $msg (@{$msgs{$folder}}) {
+            $self->assert_str_equals($msg->as_string(),
+                                     $self->_backup_file($meta, $msg->guid));
+        }
+    }
+
+    # the state database is only a cache of what the tar file says, so
+    # rebuilding it from scratch has to produce the same answer.  In
+    # particular the deletion markers have to keep naming the folder they
+    # deleted, or a rebuilt state loses the folder before it ages out.
+    Cyrus::Backup::RebuildState($meta, $data, $newfile, 'rebuilt.sqlite3');
+
+    my $rebuilt = $self->_backup_content($meta, 'rebuilt.sqlite3');
+    $self->assert_deep_equals($self->_backup_summary($after),
+                              $self->_backup_summary($rebuilt));
+}

--- a/cassandane/tiny-tests/FastMail/backupcyrusd_folders
+++ b/cassandane/tiny-tests/FastMail/backupcyrusd_folders
@@ -1,0 +1,85 @@
+#!perl
+use Cassandane::Tiny;
+
+use Cyrus::Backup;
+
+sub test_backupcyrusd_folders
+    :min_version_3_13 :want_service_backupcyrusd
+    ($self)
+{
+    my ($host, $port, $servername, $meta, $data) = $self->_backup_dirs();
+
+    my $talk = $self->{store}->get_client();
+    $talk->create("INBOX.foo") or die "can't create INBOX.foo";
+    $self->{store}->set_folder("INBOX.foo");
+    my $msg = $self->make_message("Email in foo") or die;
+
+    my $uniqueid = $self->_mailbox_uniqueid("INBOX.foo");
+
+    Cyrus::Backup::BackupUser($host, $port, $meta, $data,
+                              $servername, 'cassandane');
+
+    my $backup = $self->_backup_content($meta);
+    $self->assert_deep_equals($self->_mailboxes_by_extname(),
+                              $backup->{names});
+    $self->assert_str_equals($uniqueid, $backup->{names}{'INBOX.foo'});
+
+    my $folder = $backup->{folders}{$uniqueid};
+    $self->assert_deep_equals({ 'INBOX.foo' => 0 }, $folder->{names});
+    $self->assert_deep_equals({ 1 => $msg->guid }, $folder->{uids});
+
+    # a rename keeps the same uniqueid, so the backup should keep pointing
+    # at the same folder rather than fetching everything again
+    $talk->rename("INBOX.foo", "INBOX.bar")
+        or die "can't rename INBOX.foo: " . $talk->get_last_error();
+    $self->assert_str_equals($uniqueid, $self->_mailbox_uniqueid("INBOX.bar"));
+
+    Cyrus::Backup::BackupUser($host, $port, $meta, $data,
+                              $servername, 'cassandane');
+
+    $backup = $self->_backup_content($meta);
+    $self->assert_deep_equals($self->_mailboxes_by_extname(),
+                              $backup->{names});
+    $self->assert_null($backup->{names}{'INBOX.foo'});
+    $self->assert_str_equals($uniqueid, $backup->{names}{'INBOX.bar'});
+
+    # the old name is retained, but marked as deleted at the time we noticed
+    $folder = $backup->{folders}{$uniqueid};
+    $self->assert_num_equals(0, $folder->{names}{'INBOX.bar'});
+    $self->assert_num_gt(0, $folder->{names}{'INBOX.foo'});
+
+    # and the message is still there, under the same folder
+    $self->assert_deep_equals({ 1 => $msg->guid }, $folder->{uids});
+    $self->assert_num_equals(1, $backup->{files}{$msg->guid}{refcount});
+
+    # now delete it entirely
+    $talk->delete("INBOX.bar")
+        or die "can't delete INBOX.bar: " . $talk->get_last_error();
+
+    Cyrus::Backup::BackupUser($host, $port, $meta, $data,
+                              $servername, 'cassandane');
+
+    $backup = $self->_backup_content($meta);
+
+    # delete_mode is delayed, so cyrus has moved the folder into the DELETED
+    # namespace rather than removing it: the backup follows it there, under
+    # the same uniqueid
+    my ($deleted) = grep { m/^DELETED\./ } keys %{$backup->{names}};
+    $self->assert_matches(qr/^DELETED\.user\.cassandane\.bar\./, $deleted);
+    $self->assert_str_equals($uniqueid, $backup->{names}{$deleted});
+
+    # apart from that, the backup still matches what cyrus has
+    delete $backup->{names}{$deleted};
+    $self->assert_deep_equals($self->_mailboxes_by_extname(),
+                              $backup->{names});
+
+    # both of the folder's old names are now marked deleted, but the folder
+    # and its message are still in the backup: they only go once they age out
+    $folder = $backup->{folders}{$uniqueid};
+    $self->assert_num_gt(0, $folder->{names}{'INBOX.foo'});
+    $self->assert_num_gt(0, $folder->{names}{'INBOX.bar'});
+    $self->assert_num_equals(0, $folder->{names}{$deleted});
+    $self->assert_deep_equals({ 1 => $msg->guid }, $folder->{uids});
+    $self->assert_str_equals($msg->as_string(),
+                             $self->_backup_file($meta, $msg->guid));
+}

--- a/cassandane/tiny-tests/FastMail/backupcyrusd_folders
+++ b/cassandane/tiny-tests/FastMail/backupcyrusd_folders
@@ -4,7 +4,7 @@ use Cassandane::Tiny;
 use Cyrus::Backup;
 
 sub test_backupcyrusd_folders
-    :min_version_3_13 :want_service_backupcyrusd
+    :want_service_backupcyrusd
     ($self)
 {
     my ($host, $port, $servername, $meta, $data) = $self->_backup_dirs();

--- a/perl/imap/IMAP.pm
+++ b/perl/imap/IMAP.pm
@@ -4,6 +4,7 @@
 package Cyrus::IMAP;
 
 use strict;
+use warnings;
 use vars qw($VERSION @ISA);
 
 require DynaLoader;

--- a/perl/imap/IMAP/Admin.pm
+++ b/perl/imap/IMAP/Admin.pm
@@ -3,6 +3,7 @@
 
 package Cyrus::IMAP::Admin;
 use strict;
+use warnings;
 use Cyrus::IMAP;
 use vars qw($VERSION
             *create *delete *deleteacl *listacl *list *rename *setacl

--- a/perl/imap/IMAP/Shell.pm
+++ b/perl/imap/IMAP/Shell.pm
@@ -17,6 +17,7 @@
 
 package Cyrus::IMAP::Shell;
 use strict;
+use warnings;
 
 use IO::File;
 use Cyrus::IMAP::Admin;

--- a/perl/imap/lib/Cyrus/Backup.pm
+++ b/perl/imap/lib/Cyrus/Backup.pm
@@ -255,7 +255,7 @@ sub BackupUser {
   # remove stale data files :)
   if (opendir(DH, $DataDir)) {
     while (my $item = readdir(DH)) {
-      next if ($item eq 'backupstate.sqlite3' and $DataDir eq $Metadir);
+      next if ($item eq 'backupstate.sqlite3' and $DataDir eq $MetaDir);
       next if $item eq $NewName;
       next if $item eq '..';
       next if $item eq '.';

--- a/perl/imap/lib/Cyrus/Backup.pm
+++ b/perl/imap/lib/Cyrus/Backup.pm
@@ -9,6 +9,8 @@
 #
 # XXX - tune the when-to-rebuild figures
 package Cyrus::Backup;
+use strict;
+use warnings;
 
 use Cyrus::Backup::State;
 use Cyrus::Backup::Tar;

--- a/perl/imap/lib/Cyrus/Backup.pm
+++ b/perl/imap/lib/Cyrus/Backup.pm
@@ -624,24 +624,20 @@ sub ParseIndex {
   my $index = eval { Cyrus::IndexFile->new($fh, strict_crc => 1) };
 
   my $o_uid = $index->record_offset_for('Uid');
-  my $o_last = $index->record_offset_for('LastUpdated');
   my $o_sysflags = $index->record_offset_for('SystemFlags');
   my $o_guid = $index->record_offset_for('MessageGuid');
 
   unless ($index) {
-    die "Failed to read index for $FolderName ($uniqueid, $is_expunge)\n";
+    die "Failed to read index for $FolderName ($uniqueid)\n";
   }
 
   # speed things up again!
   if ($index->{version} < 10 or $index->{version} > $MAX_INDEXVERSION) {
-    die "Don't know how to handle indexes with version $index->{version} for $FolderName ($uniqueid, $is_expunge)\n";
+    die "Don't know how to handle indexes with version $index->{version} for $FolderName ($uniqueid)\n";
   }
 
   my $sth = $dbh->prepare("SELECT uid,fileid,deleted FROM indexed WHERE folderid = ? ORDER BY uid ASC");
   $sth->execute($folderid);
-
-  my $Now = time();
-  my $ExpireTime = $Now - $MAX_AGE;
 
   # scan through the database and the index file in step
 
@@ -654,7 +650,6 @@ sub ParseIndex {
 
   my $uid = $record ? unpack('N', substr($record, $o_uid, 4)) : undef;
   my $guid;
-  my $last;
 
   # cases:
   # 1) they both exist and are the same,
@@ -676,16 +671,16 @@ sub ParseIndex {
     # RARE - this would be something like an undelete?
     elsif ($record and (not $dbitem or $uid < $dbitem->[0])) {
 
-      # ignore it if it's old, otherwise create and fetch
+      # create and fetch, unless the message file is already gone
       my $sysflags = unpack('N', substr($record, $o_sysflags, 4));
       unless ($sysflags & (1<<30)) { # unlinked
         $guid = unpack('H40', substr($record, $o_guid, 20));
-        push @toadd, [$uid, $guid, $is_expunge ? $last : 0];
+        push @toadd, [$uid, $guid];
       }
 
       # move forward
       $record = $index->next_record_raw();
-      $uid = $record ? unpack('N', substr($record, 0, 4)) : undef;
+      $uid = $record ? unpack('N', substr($record, $o_uid, 4)) : undef;
     }
 
     # 3) $uid is less or $record is blank and $uid exists
@@ -717,10 +712,10 @@ sub ParseIndex {
   }
 
   if (@toadd) {
-    my $sth = $dbh->prepare("INSERT INTO indexed (folderid, uid, fileid, deleted) VALUES (?, ?, ?, ?)");
+    my $sth = $dbh->prepare("INSERT INTO indexed (folderid, uid, fileid, deleted) VALUES (?, ?, ?, 0)");
     my %need;
     foreach my $need_create (@toadd) {
-      my ($uid, $guid, $last) = @$need_create;
+      my ($uid, $guid) = @$need_create;
       my $fileid = $state->fileid($guid);
       unless ($fileid) {
         $need{$uid} = $guid;
@@ -728,12 +723,12 @@ sub ParseIndex {
     }
     $missingsub->(\%need) if (keys %need and $missingsub);
     foreach my $need_create (@toadd) {
-      my ($uid, $guid, $last) = @$need_create;
+      my ($uid, $guid) = @$need_create;
       my $fileid = $state->fileid($guid);
       unless ($fileid) {
         die "no file for $uniqueid $uid ($guid) and no way to get it\n";
       }
-      unless ($sth->execute($folderid, $uid, $fileid, $last)) {
+      unless ($sth->execute($folderid, $uid, $fileid)) {
         die "failed to add to DB: " . $dbh->errstr;
       }
     }

--- a/perl/imap/lib/Cyrus/Backup.pm
+++ b/perl/imap/lib/Cyrus/Backup.pm
@@ -36,7 +36,7 @@ our $LOGGER_CB = sub { 'Cyrus::NullLogger' };
 
 sub logger { $LOGGER_CB->() }
 
-our $BackupVersion = 5;
+our $BackupVersion = 6;
 # UPDATE THIS WHENEVER A NEW CYRUS INDEX MINOR_VERSION IS CREATED
 our $MAX_INDEXVERSION = 20;
 
@@ -638,7 +638,7 @@ sub ParseIndex {
     die "Don't know how to handle indexes with version $index->{version} for $FolderName ($uniqueid)\n";
   }
 
-  my $sth = $dbh->prepare("SELECT uid,fileid,deleted FROM indexed WHERE folderid = ? ORDER BY uid ASC");
+  my $sth = $dbh->prepare("SELECT uid,fileid FROM indexed WHERE folderid = ? ORDER BY uid ASC");
   $sth->execute($folderid);
 
   # scan through the database and the index file in step
@@ -688,9 +688,7 @@ sub ParseIndex {
     # 3) $uid is less or $record is blank and $uid exists
     elsif ($dbitem and (not $record or $dbitem->[0] < $uid)) {
       # remove the stale record
-      unless ($dbitem->[2]) {
-        push @todel, $dbitem->[0];
-      }
+      push @todel, $dbitem->[0];
 
       # move forward
       $dbitem = $sth->fetchrow_arrayref();
@@ -714,7 +712,12 @@ sub ParseIndex {
   }
 
   if (@toadd) {
-    my $sth = $dbh->prepare("INSERT INTO indexed (folderid, uid, fileid, deleted) VALUES (?, ?, ?, 0)");
+    # a version < 6 state still has the indexed.deleted column, and it's NOT
+    # NULL with no default, so keep naming it until the next compact rewrites
+    # the state with the current schema
+    my $sth = $state->{version} < 6
+      ? $dbh->prepare("INSERT INTO indexed (folderid, uid, fileid, deleted) VALUES (?, ?, ?, 0)")
+      : $dbh->prepare("INSERT INTO indexed (folderid, uid, fileid) VALUES (?, ?, ?)");
     my %need;
     foreach my $need_create (@toadd) {
       my ($uid, $guid) = @$need_create;

--- a/perl/imap/lib/Cyrus/Backup/Restore.pm
+++ b/perl/imap/lib/Cyrus/Backup/Restore.pm
@@ -2,6 +2,8 @@
 # See COPYING file at the root of the distribution for more details.
 
 package Cyrus::Backup::Restore;
+use strict;
+use warnings;
 
 use Archive::Tar::Stream;
 use Cyrus::Backup;

--- a/perl/imap/lib/Cyrus/Backup/State.pm
+++ b/perl/imap/lib/Cyrus/Backup/State.pm
@@ -2,6 +2,8 @@
 # See COPYING file at the root of the distribution for more details.
 
 package Cyrus::Backup::State;
+use strict;
+use warnings;
 
 use Cyrus::Backup;
 use DBI;

--- a/perl/imap/lib/Cyrus/Backup/State.pm
+++ b/perl/imap/lib/Cyrus/Backup/State.pm
@@ -78,7 +78,6 @@ CREATE TABLE indexed (
   folderid INTEGER NOT NULL,
   uid INTEGER NOT NULL,
   fileid INTEGER NOT NULL,
-  deleted INTEGER NOT NULL,
   PRIMARY KEY (folderid, uid)
 );
   },

--- a/perl/imap/lib/Cyrus/Backup/Tar.pm
+++ b/perl/imap/lib/Cyrus/Backup/Tar.pm
@@ -2,6 +2,8 @@
 # See COPYING file at the root of the distribution for more details.
 
 package Cyrus::Backup::Tar;
+use strict;
+use warnings;
 
 sub new {
   my $class = shift;
@@ -48,7 +50,7 @@ sub _openfile {
     }
   }
   elsif (-f $tarfile) {
-    $Logger->log(["%s: bogus file, removing", $tarfile]);
+    Cyrus::Backup::logger->log(["%s: bogus file, removing", $tarfile]);
     unlink($tarfile);
   }
 

--- a/perl/imap/lib/Cyrus/CacheFile.pm
+++ b/perl/imap/lib/Cyrus/CacheFile.pm
@@ -11,7 +11,7 @@ use IO::File;
 use IO::File::fcntl;
 use IO::Handle;
 use File::Temp;
-use YAML;
+use Data::Dumper;
 
 =pod
 
@@ -157,7 +157,7 @@ sub dump_record {
   my $Self = shift;
   my $rec = shift || $Self->{record};
   return unless $rec;
-  print Dump($rec->{records});
+  print Dumper($rec->{records});
 }
 
 sub print_record {

--- a/perl/imap/lib/Cyrus/Mbentry.pm
+++ b/perl/imap/lib/Cyrus/Mbentry.pm
@@ -2,6 +2,8 @@
 # See COPYING file at the root of the distribution for more details.
 
 package Cyrus::Mbentry;
+use strict;
+use warnings;
 use Moo;
 
 use Cyrus::DList;

--- a/perl/sieve/managesieve/managesieve.pm
+++ b/perl/sieve/managesieve/managesieve.pm
@@ -4,6 +4,7 @@
 package Cyrus::SIEVE::managesieve;
 
 use strict;
+use warnings;
 use Carp;
 use vars qw($VERSION @ISA @EXPORT @EXPORT_OK $AUTOLOAD);
 

--- a/perl/sieve/scripts/sieveshell.pl
+++ b/perl/sieve/scripts/sieveshell.pl
@@ -164,6 +164,7 @@ my $obj = sieve_get_handle($acapserver,
 if (!defined $obj) {
     my $errstr = sieve_get_global_error() // "unknown error";
     die "unable to connect to '$acapserver': $errstr";
+}
 
 my $term = Term::ReadLine->new("sieveshell");
 


### PR DESCRIPTION
This not only adds the tests, but also fixes all the perl module compilation and testability, there was a YAML which isn't in the dar container but wasn't being used, and a missing brace in sieveshell as well.

This also removes some dead code from the backup protocol, bumping the version to 6.