### PR TITLE
conversations: make cyr_expire's prune much cheaper

### DIFF
--- a/cassandane/Cassandane/Cyrus/Conversations.pm
+++ b/cassandane/Cassandane/Cyrus/Conversations.pm
@@ -59,6 +59,10 @@ sub set_up
 {
     my ($self) = @_;
     $self->SUPER::set_up();
+
+    # there's no store yet if the test asked for :NoStartInstances
+    return if not $self->{store};
+
     my ($maj, $min) = Cassandane::Instance->get_version();
 
     # basecid was added after 3.0

--- a/cassandane/tiny-tests/Conversations/cyr_expire_prune
+++ b/cassandane/tiny-tests/Conversations/cyr_expire_prune
@@ -16,12 +16,10 @@ sub _convdb_msgids
     return [ grep { m/^</ } split /\n/, slurp_file($outfile) ];
 }
 
-# cyr_expire prunes the msgid records out of the conversations database,
-# a -b batchsize at a time
-sub test_cyr_expire_prune
-    :NoStartInstances :Conversations
-    ($self)
+sub _check_cyr_expire_prune
 {
+    my ($self) = @_;
+
     # prune everything we find, on age, so we don't have to arrange for
     # the conversations themselves to go away as well
     $self->{instance}->{config}->set('conversations_keep_existing' => 'no');
@@ -47,4 +45,23 @@ sub test_cyr_expire_prune
     my $talk = $self->{store}->get_client();
     $talk->select('INBOX');
     $self->assert_num_equals(5, $talk->get_response_code('exists'));
+}
+
+# cyr_expire prunes the msgid records a -b batchsize at a time, on a
+# backend with no fetchnext, so each batch restarts the scan
+sub test_cyr_expire_prune
+    :NoStartInstances :Conversations
+    ($self)
+{
+    $self->{instance}->{config}->set('conversations_db' => 'skiplist');
+    $self->_check_cyr_expire_prune();
+}
+
+# ... and on a backend which can resume an iteration with fetchnext
+sub test_cyr_expire_prune_chunked
+    :NoStartInstances :Conversations
+    ($self)
+{
+    $self->{instance}->{config}->set('conversations_db' => 'twom');
+    $self->_check_cyr_expire_prune();
 }

--- a/cassandane/tiny-tests/Conversations/cyr_expire_prune
+++ b/cassandane/tiny-tests/Conversations/cyr_expire_prune
@@ -1,0 +1,50 @@
+#!perl
+use Cassandane::Tiny;
+
+sub _convdb_msgids
+{
+    my ($self) = @_;
+
+    my $outfile = $self->{instance}->{basedir} . "/convdb-dump.txt";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'ctl_conversationsdb', '-d', 'cassandane',
+    );
+
+    # dump format is "key\tvalue", and msgid records are the ones keyed
+    # by the literal Message-ID, angle brackets and all
+    return [ grep { m/^</ } split /\n/, slurp_file($outfile) ];
+}
+
+# cyr_expire prunes the msgid records out of the conversations database,
+# a -b batchsize at a time
+sub test_cyr_expire_prune
+    :NoStartInstances :Conversations
+    ($self)
+{
+    # prune everything we find, on age, so we don't have to arrange for
+    # the conversations themselves to go away as well
+    $self->{instance}->{config}->set('conversations_keep_existing' => 'no');
+    $self->{instance}->{config}->set('conversations_expire_after' => '0d');
+    $self->_start_instances();
+
+    $self->{store}->get_client();
+
+    xlog $self, "generating some messages";
+    $self->make_message("Message $_") for (1..5);
+
+    my $msgids = $self->_convdb_msgids();
+    $self->assert_num_equals(5, scalar @{$msgids});
+
+    xlog $self, "pruning with a batchsize smaller than the work to do";
+    $self->{instance}->run_command({ cyrus => 1 },
+                                   'cyr_expire', '-E', '1', '-b', '2');
+
+    $msgids = $self->_convdb_msgids();
+    $self->assert_num_equals(0, scalar @{$msgids});
+
+    xlog $self, "the messages themselves are still there";
+    my $talk = $self->{store}->get_client();
+    $talk->select('INBOX');
+    $self->assert_num_equals(5, $talk->get_response_code('exists'));
+}

--- a/docsrc/reference/manpages/systemcommands/cyr_expire.rst
+++ b/docsrc/reference/manpages/systemcommands/cyr_expire.rst
@@ -162,8 +162,9 @@ Options
 
 .. option:: -b num, --batchsize=num
 
-    Process "num" messages per batch when expunging or expiring.  Default
-    is 4096.
+    Process "num" messages per batch when expunging or expiring, and "num"
+    records per batch when pruning conversations databases.  Default is
+    4096.  The conversations database is unlocked between batches.
 
 .. option:: -v, --verbose
 

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -3157,13 +3157,14 @@ EXPORTED int conversations_prune(struct conversations_state *state,
 }
 
 EXPORTED int conversations_prune_user(const char *userid, time_t thresh,
-                                      unsigned int *nseenp,
+                                      int batchsize, unsigned int *nseenp,
                                       unsigned int *ndeletedp)
 {
     struct conversations_state *state = NULL;
     strarray_t todelete = STRARRAY_INITIALIZER;
     unsigned int nseen = 0, ndeleted = 0;
     int keep_existing;
+    int nkeys;
     int i;
     int r;
 
@@ -3177,24 +3178,38 @@ EXPORTED int conversations_prune_user(const char *userid, time_t thresh,
     if (r) goto done;
 
     /* nothing to remove: never take the write lock at all */
-    if (!strarray_size(&todelete)) goto done;
+    nkeys = strarray_size(&todelete);
+    if (!nkeys) goto done;
 
     keep_existing = config_getswitch(IMAPOPT_CONVERSATIONS_KEEP_EXISTING);
 
-    r = conversations_open_user(userid, 0/*shared*/, &state);
-    if (r) goto done;
+    if (batchsize <= 0) batchsize = nkeys;
 
-    for (i = 0; i < strarray_size(&todelete); i++) {
-        const char *key = strarray_nth(&todelete, i);
-        if (!prune_still_stale(state, key, thresh, keep_existing))
-            continue;
-        r = cyrusdb_delete(state->db, key, strlen(key),
-                           &state->txn, /*force*/1);
+    /* second pass takes the write lock, but only a batch at a time */
+    for (i = 0; i < nkeys; ) {
+        int end = i + batchsize;
+        unsigned int n = 0;
+
+        if (end > nkeys) end = nkeys;
+
+        r = conversations_open_user(userid, 0/*shared*/, &state);
         if (r) goto done;
-        ndeleted++;
-    }
 
-    r = conversations_commit(&state);
+        for (; i < end; i++) {
+            const char *key = strarray_nth(&todelete, i);
+            if (!prune_still_stale(state, key, thresh, keep_existing))
+                continue;
+            r = cyrusdb_delete(state->db, key, strlen(key),
+                               &state->txn, /*force*/1);
+            if (r) goto done;
+            n++;
+        }
+
+        r = conversations_commit(&state);
+        if (r) goto done;
+
+        ndeleted += n;
+    }
 
 done:
     conversations_abort(&state);

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -3056,23 +3056,161 @@ static int addknowncid(void *rock,
     return 0;
 }
 
+/* private stop signal, distinct from every CYRUSDB_ error */
+#define PRUNE_BATCH_FULL (-1000)
+
+struct walk_rock {
+    foreach_cb *cb;
+    void *rock;
+    struct buf *resume;   /* last key handled; empty before the first batch */
+    int remaining;
+    bool resumed;
+};
+
+static int keycmp(const char *a, size_t alen, const char *b, size_t blen)
+{
+    size_t n = alen < blen ? alen : blen;
+    int r = n ? memcmp(a, b, n) : 0;
+    if (r) return r;
+    if (alen == blen) return 0;
+    return alen < blen ? -1 : 1;
+}
+
+static int walkcb(void *rock, const char *key, size_t keylen,
+                  const char *data, size_t datalen)
+{
+    struct walk_rock *wrock = (struct walk_rock *)rock;
+    int r;
+
+    if (!wrock->resumed) {
+        if (keycmp(key, keylen,
+                   buf_base(wrock->resume), buf_len(wrock->resume)) <= 0)
+            return 0;
+        wrock->resumed = true;
+    }
+
+    /* our own copy: key points into the mapped file, which goes away
+     * when we drop the lock */
+    buf_setmap(wrock->resume, key, keylen);
+
+    r = wrock->cb(wrock->rock, key, keylen, data, datalen);
+    if (r) return r;
+
+    return --wrock->remaining ? 0 : PRUNE_BATCH_FULL;
+}
+
+/* One batch, resuming after *resume and updating it.  Sets *done once the
+ * range runs out. */
+static int prune_batch(struct conversations_state *state, int batchsize,
+                       const char *prefix, size_t prefixlen,
+                       struct buf *resume, bool *done,
+                       foreach_cb *cb, void *rock)
+{
+    int r;
+
+    if (cyrusdb_canfetchnext(DB)) {
+        /* every key we want sorts at or after the bare prefix */
+        if (!buf_len(resume)) buf_setcstr(resume, prefix);
+
+        for (int n = 0; n < batchsize; n++) {
+            const char *found = NULL, *data = NULL;
+            size_t foundlen = 0, datalen = 0;
+
+            r = cyrusdb_fetchnext(state->db, buf_base(resume), buf_len(resume),
+                                  &found, &foundlen, &data, &datalen,
+                                  &state->txn);
+            if (r == CYRUSDB_NOTFOUND) break;
+            if (r) return r;
+
+            /* off the end of the range we care about */
+            if (foundlen < prefixlen || memcmp(found, prefix, prefixlen)) break;
+
+            buf_setmap(resume, found, foundlen);
+
+            r = cb(rock, found, foundlen, data, datalen);
+            if (r) return r;
+
+            if (n + 1 == batchsize) return 0;
+        }
+
+        *done = true;
+        return 0;
+    }
+
+    /* no fetchnext: start the walk over each time and skip what earlier
+     * batches already handled */
+    struct walk_rock wrock = { cb, rock, resume, batchsize, false };
+
+    r = cyrusdb_foreach(state->db, prefix, prefixlen, NULL,
+                        walkcb, &wrock, &state->txn);
+    if (r == PRUNE_BATCH_FULL) return 0;
+    if (r) return r;
+
+    *done = true;
+    return 0;
+}
+
+/* Walk every record under prefix, calling cb for each one.
+ *
+ * With a state, the caller holds the database and we just iterate it.
+ * Without one, we reopen it every batchsize records, so a scan of a big
+ * database doesn't hold the user namespace lock for its whole length.  That
+ * gives a torn view, which is fine for pruning: every candidate is
+ * re-checked under the write lock.
+ *
+ * Resuming costs one seek per batch on a backend with fetchnext, and a
+ * rescan of everything already walked on one without.
+ */
+static int prune_walk(struct conversations_state *state, const char *userid,
+                      int batchsize, const char *prefix,
+                      foreach_cb *cb, void *rock)
+{
+    size_t prefixlen = strlen(prefix);
+    struct buf resume = BUF_INITIALIZER;
+    bool done = false;
+    int r = 0;
+
+    if (state)
+        return cyrusdb_foreach(state->db, prefix, prefixlen, NULL,
+                               cb, rock, &state->txn);
+
+    while (!done) {
+        struct conversations_state *mystate = NULL;
+
+        r = conversations_open_user(userid, 1/*shared*/, &mystate);
+        if (r) break;
+
+        r = prune_batch(mystate, batchsize, prefix, prefixlen,
+                        &resume, &done, cb, rock);
+
+        conversations_abort(&mystate);
+        if (r) break;
+    }
+
+    buf_free(&resume);
+
+    return r;
+}
+
 /* read-only pass: collect the prunable msgid records, so the expensive
  * scan never needs the write lock */
-static int prune_scan(struct conversations_state *state, time_t thresh,
+static int prune_scan(struct conversations_state *state, const char *userid,
+                      int batchsize, time_t thresh,
                       strarray_t *todelete, unsigned int *nseenp)
 {
     struct prune_rock rock = { NULL, ARRAYU64_INITIALIZER, todelete, thresh, 0 };
     int r = 0;
 
     if (config_getswitch(IMAPOPT_CONVERSATIONS_KEEP_EXISTING)) {
-        // these will be added in CID order, so we don't need to sort them
+        // walked in key order, which is CID order, so the filter comes
+        // out sorted ready for bsearch
         rock.cidfilter = arrayu64_new();
-        r = cyrusdb_foreach(state->db, "B", 1, NULL, addknowncid,
-                            rock.cidfilter, &state->txn);
+        r = prune_walk(state, userid, batchsize, "B", addknowncid,
+                       rock.cidfilter);
         if (r) goto done;
     }
 
-    r = cyrusdb_foreach(state->db, "<", 1, NULL, prunecb, &rock, &state->txn);
+    r = prune_walk(state, userid, batchsize, "<", prunecb, &rock);
 
 done:
     arrayu64_fini(&rock.cids);
@@ -3137,7 +3275,7 @@ EXPORTED int conversations_prune(struct conversations_state *state,
     unsigned int nseen = 0, ndeleted = 0;
     int i;
 
-    int r = prune_scan(state, thresh, &todelete, &nseen);
+    int r = prune_scan(state, NULL, 0, thresh, &todelete, &nseen);
 
     for (i = 0; !r && i < strarray_size(&todelete); i++) {
         const char *key = strarray_nth(&todelete, i);
@@ -3168,13 +3306,18 @@ EXPORTED int conversations_prune_user(const char *userid, time_t thresh,
     int i;
     int r;
 
-    /* first pass is read-only, so the user isn't locked out for however
-     * long it takes to read their entire conversations database */
-    r = conversations_open_user(userid, 1/*shared*/, &state);
-    if (r) goto done;
+    /* first pass is read-only, and takes the lock a batch at a time so
+     * writers get a look in */
+    if (batchsize > 0) {
+        r = prune_scan(NULL, userid, batchsize, thresh, &todelete, &nseen);
+    }
+    else {
+        r = conversations_open_user(userid, 1/*shared*/, &state);
+        if (r) goto done;
 
-    r = prune_scan(state, thresh, &todelete, &nseen);
-    conversations_abort(&state);
+        r = prune_scan(state, NULL, 0, thresh, &todelete, &nseen);
+        conversations_abort(&state);
+    }
     if (r) goto done;
 
     /* nothing to remove: never take the write lock at all */

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2999,12 +2999,11 @@ EXPORTED void conversation_free(conversation_t *conv)
 }
 
 struct prune_rock {
-    struct conversations_state *state;
     arrayu64_t *cidfilter;
     arrayu64_t cids;
+    strarray_t *todelete;
     time_t thresh;
     unsigned int nseen;
-    unsigned int ndeleted;
 };
 
 static int prunecb(void *rock,
@@ -3013,39 +3012,32 @@ static int prunecb(void *rock,
 {
     struct prune_rock *prock = (struct prune_rock *)rock;
     time_t stamp;
-    int r;
 
     prock->nseen++;
-    r = check_msgid(key, keylen, NULL);
-    if (r) goto done;
+
+    /* not a msgid record: skip it, but keep scanning */
+    if (check_msgid(key, keylen, NULL)) return 0;
 
     arrayu64_truncate(&prock->cids, 0);
 
-    r = _conversations_parse(data, datalen, &prock->cids, &stamp);
-    if (r) goto done;
+    if (_conversations_parse(data, datalen, &prock->cids, &stamp)) return 0;
 
     if (prock->cidfilter) {
         size_t i;
         for (i = 0; i < arrayu64_size(&prock->cids); i++) {
             if (arrayu64_bsearch(prock->cidfilter, arrayu64_nth(&prock->cids, i)))
-                goto done; // found a match
+                return 0; // found a match
         }
     }
     else {
         /* keep records newer than the threshold */
         if (stamp >= prock->thresh)
-            goto done;
+            return 0;
     }
 
-    prock->ndeleted++;
+    strarray_appendm(prock->todelete, xstrndup(key, keylen));
 
-    r = cyrusdb_delete(prock->state->db,
-                       key, keylen,
-                       &prock->state->txn,
-                       /*force*/1);
-
-done:
-    return r;
+    return 0;
 }
 
 static int addknowncid(void *rock,
@@ -3064,20 +3056,25 @@ static int addknowncid(void *rock,
     return 0;
 }
 
-EXPORTED int conversations_prune(struct conversations_state *state,
-                                 time_t thresh, unsigned int *nseenp,
-                                 unsigned int *ndeletedp)
+/* read-only pass: collect the prunable msgid records, so the expensive
+ * scan never needs the write lock */
+static int prune_scan(struct conversations_state *state, time_t thresh,
+                      strarray_t *todelete, unsigned int *nseenp)
 {
-    struct prune_rock rock = { state, NULL, ARRAYU64_INITIALIZER, thresh, 0, 0 };
+    struct prune_rock rock = { NULL, ARRAYU64_INITIALIZER, todelete, thresh, 0 };
+    int r = 0;
 
     if (config_getswitch(IMAPOPT_CONVERSATIONS_KEEP_EXISTING)) {
         // these will be added in CID order, so we don't need to sort them
         rock.cidfilter = arrayu64_new();
-        cyrusdb_foreach(state->db, "B", 1, NULL, addknowncid, rock.cidfilter, &state->txn);
+        r = cyrusdb_foreach(state->db, "B", 1, NULL, addknowncid,
+                            rock.cidfilter, &state->txn);
+        if (r) goto done;
     }
 
-    cyrusdb_foreach(state->db, "<", 1, NULL, prunecb, &rock, &state->txn);
+    r = cyrusdb_foreach(state->db, "<", 1, NULL, prunecb, &rock, &state->txn);
 
+done:
     arrayu64_fini(&rock.cids);
     if (rock.cidfilter) {
         arrayu64_fini(rock.cidfilter);
@@ -3086,10 +3083,129 @@ EXPORTED int conversations_prune(struct conversations_state *state,
 
     if (nseenp)
         *nseenp = rock.nseen;
-    if (ndeletedp)
-        *ndeletedp = rock.ndeleted;
 
-    return 0;
+    return r;
+}
+
+/* the scan may have run without the write lock, so anything it turned up has
+ * to be re-checked against the database as it stands now */
+static int prune_still_stale(struct conversations_state *state,
+                             const char *key, time_t thresh,
+                             int keep_existing)
+{
+    const char *data = NULL;
+    size_t datalen = 0;
+    arrayu64_t cids = ARRAYU64_INITIALIZER;
+    time_t stamp;
+    int stale = 0;
+    size_t i;
+
+    if (cyrusdb_fetch(state->db, key, strlen(key),
+                      &data, &datalen, &state->txn))
+        goto done;  /* gone already */
+
+    if (_conversations_parse(data, datalen, &cids, &stamp))
+        goto done;
+
+    if (!keep_existing) {
+        stale = (stamp < thresh);
+        goto done;
+    }
+
+    for (i = 0; i < arrayu64_size(&cids); i++) {
+        char bkey[CONVERSATION_ID_STRMAX+2];
+        snprintf(bkey, sizeof(bkey), "B" CONV_FMT, arrayu64_nth(&cids, i));
+        data = NULL;
+        datalen = 0;
+        if (!cyrusdb_fetch(state->db, bkey, strlen(bkey),
+                           &data, &datalen, &state->txn))
+            goto done;  /* the conversation is still around */
+    }
+
+    stale = 1;
+
+done:
+    arrayu64_fini(&cids);
+    return stale;
+}
+
+EXPORTED int conversations_prune(struct conversations_state *state,
+                                 time_t thresh, unsigned int *nseenp,
+                                 unsigned int *ndeletedp)
+{
+    strarray_t todelete = STRARRAY_INITIALIZER;
+    unsigned int nseen = 0, ndeleted = 0;
+    int i;
+
+    int r = prune_scan(state, thresh, &todelete, &nseen);
+
+    for (i = 0; !r && i < strarray_size(&todelete); i++) {
+        const char *key = strarray_nth(&todelete, i);
+        r = cyrusdb_delete(state->db, key, strlen(key),
+                           &state->txn, /*force*/1);
+        if (!r) ndeleted++;
+    }
+
+    strarray_fini(&todelete);
+
+    if (nseenp)
+        *nseenp = nseen;
+    if (ndeletedp)
+        *ndeletedp = ndeleted;
+
+    return r;
+}
+
+EXPORTED int conversations_prune_user(const char *userid, time_t thresh,
+                                      unsigned int *nseenp,
+                                      unsigned int *ndeletedp)
+{
+    struct conversations_state *state = NULL;
+    strarray_t todelete = STRARRAY_INITIALIZER;
+    unsigned int nseen = 0, ndeleted = 0;
+    int keep_existing;
+    int i;
+    int r;
+
+    /* first pass is read-only, so the user isn't locked out for however
+     * long it takes to read their entire conversations database */
+    r = conversations_open_user(userid, 1/*shared*/, &state);
+    if (r) goto done;
+
+    r = prune_scan(state, thresh, &todelete, &nseen);
+    conversations_abort(&state);
+    if (r) goto done;
+
+    /* nothing to remove: never take the write lock at all */
+    if (!strarray_size(&todelete)) goto done;
+
+    keep_existing = config_getswitch(IMAPOPT_CONVERSATIONS_KEEP_EXISTING);
+
+    r = conversations_open_user(userid, 0/*shared*/, &state);
+    if (r) goto done;
+
+    for (i = 0; i < strarray_size(&todelete); i++) {
+        const char *key = strarray_nth(&todelete, i);
+        if (!prune_still_stale(state, key, thresh, keep_existing))
+            continue;
+        r = cyrusdb_delete(state->db, key, strlen(key),
+                           &state->txn, /*force*/1);
+        if (r) goto done;
+        ndeleted++;
+    }
+
+    r = conversations_commit(&state);
+
+done:
+    conversations_abort(&state);
+    strarray_fini(&todelete);
+
+    if (nseenp)
+        *nseenp = nseen;
+    if (ndeletedp)
+        *ndeletedp = ndeleted;
+
+    return r;
 }
 
 /* NOTE: this makes an "ATOM" return */

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -356,10 +356,11 @@ extern int conversations_prune(struct conversations_state *state,
                                time_t thresh, unsigned int *,
                                unsigned int *);
 /* as above, but does its own opening: the (expensive) scan runs with a
- * shared lock, and the write lock is only taken if there's work to do */
+ * shared lock, and the write lock is only taken if there's work to do,
+ * a batchsize of records at a time (<= 0 means all in one transaction) */
 extern int conversations_prune_user(const char *userid,
-                                    time_t thresh, unsigned int *,
-                                    unsigned int *);
+                                    time_t thresh, int batchsize,
+                                    unsigned int *, unsigned int *);
 extern void conversations_dump(struct conversations_state *, FILE *);
 extern int conversations_undump(struct conversations_state *, FILE *);
 

--- a/imap/conversations.h
+++ b/imap/conversations.h
@@ -355,6 +355,11 @@ extern void conversation_update_thread(conversation_t *conv,
 extern int conversations_prune(struct conversations_state *state,
                                time_t thresh, unsigned int *,
                                unsigned int *);
+/* as above, but does its own opening: the (expensive) scan runs with a
+ * shared lock, and the write lock is only taken if there's work to do */
+extern int conversations_prune_user(const char *userid,
+                                    time_t thresh, unsigned int *,
+                                    unsigned int *);
 extern void conversations_dump(struct conversations_state *, FILE *);
 extern int conversations_undump(struct conversations_state *, FILE *);
 

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -103,6 +103,7 @@ struct expire_rock {
 struct conversations_rock {
     struct hash_table seen;
     time_t expire_mark;
+    int batchsize;
     unsigned long databases_seen;
     unsigned long msgids_seen;
     unsigned long msgids_expired;
@@ -612,7 +613,8 @@ static int expire_conversations_user(const char *userid, void *rock)
 
     verbosep("Pruning conversations from db %s", filename);
 
-    conversations_prune_user(userid, crock->expire_mark, &nseen, &ndeleted);
+    conversations_prune_user(userid, crock->expire_mark, crock->batchsize,
+                             &nseen, &ndeleted);
     libcyrus_run_delayed();
 
     crock->databases_seen++;
@@ -781,6 +783,7 @@ static int do_cid_expire(struct cyr_expire_ctx *ctx)
 
         cid_expire_seconds = config_getduration(IMAPOPT_CONVERSATIONS_EXPIRE_AFTER);
         ctx->crock.expire_mark = time(0) - cid_expire_seconds + 1;
+        ctx->crock.batchsize = ctx->args.batchsize;
 
         verbosep("Removing conversation entries older than %0.2f days",
                        (double)(cid_expire_seconds/SECS_IN_A_DAY));

--- a/imap/cyr_expire.c
+++ b/imap/cyr_expire.c
@@ -593,12 +593,43 @@ done:
     return 0;
 }
 
+static int expire_conversations_user(const char *userid, void *rock)
+{
+    struct conversations_rock *crock = (struct conversations_rock *)rock;
+    unsigned int nseen = 0, ndeleted = 0;
+    struct stat sbuf;
+    char *filename = NULL;
+
+    signals_poll();
+
+    filename = conversations_getuserpath(userid);
+    if (!filename)
+        goto done;
+
+    /* nothing to prune, and no reason to create one either */
+    if (stat(filename, &sbuf))
+        goto done;
+
+    verbosep("Pruning conversations from db %s", filename);
+
+    conversations_prune_user(userid, crock->expire_mark, &nseen, &ndeleted);
+    libcyrus_run_delayed();
+
+    crock->databases_seen++;
+    crock->msgids_seen += nseen;
+    crock->msgids_expired += ndeleted;
+
+done:
+    free(filename);
+    return 0;
+}
+
+/* only used when we've been given a mailbox prefix to filter on - otherwise
+ * we iterate the users directly rather than every mailbox they own */
 static int expire_conversations(const mbentry_t *mbentry, void *rock)
 {
     struct conversations_rock *crock = (struct conversations_rock *)rock;
-    struct conversations_state *state = NULL;
-    unsigned int nseen = 0, ndeleted = 0;
-    char *filename = NULL;
+    char *userid = NULL;
 
     signals_poll();
 
@@ -611,29 +642,19 @@ static int expire_conversations(const mbentry_t *mbentry, void *rock)
     if (mboxname_isdeletedmailbox(mbentry->name, NULL))
         goto done;
 
-    filename = conversations_getmboxpath(mbentry->name);
-    if (!filename)
+    userid = mboxname_to_userid(mbentry->name);
+    if (!userid)
         goto done;
 
-    if (hash_lookup(filename, &crock->seen))
+    if (hash_lookup(userid, &crock->seen))
         goto done;
 
-    verbosep("Pruning conversations from db %s", filename);
+    hash_insert(userid, (void *)1, &crock->seen);
 
-    if (!conversations_open_mbox(mbentry->name, 0/*shared*/, &state)) {
-        conversations_prune(state, crock->expire_mark, &nseen, &ndeleted);
-        conversations_commit(&state);
-        libcyrus_run_delayed();
-    }
-
-    hash_insert(filename, (void *)1, &crock->seen);
-
-    crock->databases_seen++;
-    crock->msgids_seen += nseen;
-    crock->msgids_expired += ndeleted;
+    expire_conversations_user(userid, crock);
 
 done:
-    free(filename);
+    free(userid);
     return 0;
 }
 
@@ -765,11 +786,12 @@ static int do_cid_expire(struct cyr_expire_ctx *ctx)
                        (double)(cid_expire_seconds/SECS_IN_A_DAY));
 
         if (ctx->args.userid)
-            mboxlist_usermboxtree(ctx->args.userid, NULL, expire_conversations,
-                                  &ctx->crock, MBOXTREE_DELETED);
-        else
+            expire_conversations_user(ctx->args.userid, &ctx->crock);
+        else if (ctx->args.mbox_prefix && *ctx->args.mbox_prefix)
             mboxlist_allmbox(ctx->args.mbox_prefix, expire_conversations,
                              &ctx->crock, 0);
+        else
+            mboxlist_alluser(expire_conversations_user, &ctx->crock);
 
         syslog(LOG_NOTICE, "Expired %lu entries of %lu entries seen "
                             "in %lu conversation databases",


### PR DESCRIPTION
The prune pass walked every mailbox in mailboxes.db, building a conversations path and hashing it just to find that it was the same user's database it had already done.  Iterate the users instead, and skip a user entirely if they have no conversations database rather than creating an empty one for them.

Then split the prune itself in two.  The expensive half is reading the whole database to work out which msgid records are prunable, and that doesn't need the write lock - so do it with a shared lock, drop it, and only take the write lock if there was anything to remove.  For a user with nothing to expire we never take it at all, and when we do we hold it for the deletes rather than for a full scan.  Candidates are re-checked once we hold the lock, since the database can have moved on in between.

Also fix prunecb returning the error from check_msgid() and _conversations_parse() as its foreach return value: a single malformed record aborted the scan and left the rest of the database unpruned.