### PR TITLE
caldav_alarm.c: don't skip other alarms if one has an absolute trigger (3.8 backport)

### DIFF
--- a/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
+++ b/cassandane/Cassandane/Cyrus/CaldavAlarm.pm
@@ -625,9 +625,12 @@ sub test_recurring_absolute_trigger
     my $end = $enddt->strftime('%Y%m%dT%H%M%SZ');
 
     # set the trigger to notify us at the start of the event
-    my $triggerdt = $startdt->clone();
-    $triggerdt->add(DateTime::Duration->new(seconds => 0 - $now->offset()));
-    my $trigger = $triggerdt->strftime('%Y%m%dT%H%M%SZ');
+    my $trigger = $startdt->strftime('%Y%m%dT%H%M%SZ');
+
+    # calculate start time for second instance
+    my $recuriddt = $startdt->clone();
+    $recuriddt->add(DateTime::Duration->new(days => 1));
+    my $recurid = $recuriddt->strftime('%Y%m%dT%H%M%SZ');
 
     my $uuid = "574E2CD0-2D2A-4554-8B63-C7504481D3A9";
     my $href = "$CalendarId/$uuid.ics";
@@ -645,10 +648,16 @@ SUMMARY:Simple
 DTSTART:$start
 DTSTAMP:20150806T234327Z
 SEQUENCE:0
-RRULE:FREQ=DAILY
+RRULE:FREQ=DAILY;COUNT=3
 BEGIN:VALARM
 TRIGGER;VALUE=DATE-TIME:$trigger
 ACTION:DISPLAY
+SUMMARY: My alarm
+DESCRIPTION:My alarm has triggered
+END:VALARM
+BEGIN:VALARM
+TRIGGER:PT0S
+ACTION:EMAIL
 SUMMARY: My alarm
 DESCRIPTION:My alarm has triggered
 END:VALARM
@@ -661,13 +670,23 @@ EOF
     # clean notification cache
     $self->{instance}->getnotify();
 
+    # adjust now to UTC
+    $now->add(DateTime::Duration->new(seconds => $now->offset()));
+
     $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() - 60 );
 
     $self->assert_alarms();
 
+    # fire alarms for first instance
     $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 60 );
 
-    $self->assert_alarms({summary => 'Simple', start => $start});
+    $self->assert_alarms({summary => 'Simple', start => $start, action => 'display'},
+                         {summary => 'Simple', start => $start, action => 'email'});
+
+    # fire alarm for second instance
+    $self->{instance}->run_command({ cyrus => 1 }, 'calalarmd', '-t' => $now->epoch() + 86400 + 60 );
+
+    $self->assert_alarms({summary => 'Simple', start => $recurid, action => 'email'});
 }
 
 sub test_simple_reconstruct

--- a/imap/caldav_alarm.c
+++ b/imap/caldav_alarm.c
@@ -589,6 +589,12 @@ static int process_alarm_cb(icalcomponent *comp,
         if (check <= data->last) {
             continue;
         }
+        else if (!is_duration &&
+                 icaltime_compare(recurid, icalcomponent_get_dtstart(comp)) > 0) {
+            /* alarms with absolute triggers can only fire once */
+            syslog(LOG_DEBUG, "XXX  absolute trigger - skipping recurrence");
+            continue;
+        }
 
         if (check <= data->now && !data->dryrun) {
             prop = icalcomponent_get_first_property(comp, ICAL_SUMMARY_PROPERTY);
@@ -625,12 +631,6 @@ static int process_alarm_cb(icalcomponent *comp,
             time_t next = data->now + 86400*30;
             if (!data->nextcheck || next < data->nextcheck)
                 data->nextcheck = next;
-            return 0;
-        }
-        else if (!is_duration) {
-            /* alarms with absolute triggers can only fire once,
-               so stop recurrence expansion */
-            syslog(LOG_DEBUG, "XXX  absolute trigger - stop recurrence expansion");
             return 0;
         }
     }


### PR DESCRIPTION
Backport of #4562 (commit 9a5a0611) to the 3.8 branch, test included.

`master` fixed this in August 2023, but 3.8 still carries the original shape:
in `process_alarm_cb()`, the "an absolute trigger can only fire once" branch
sits at the **bottom of the loop over VALARMs** and does `return 0`:

```c
        else if (!is_duration) {
            /* alarms with absolute triggers can only fire once,
               so stop recurrence expansion */
            syslog(LOG_DEBUG, "XXX  absolute trigger - stop recurrence expansion");
            return 0;
        }
```

The comment only intends to stop expanding *occurrences*, but the `return 0`
also abandons **every remaining VALARM of the same component**. Anything
listed after the first absolute trigger is never examined, so `nextcheck`
stays 0 and `update_alarmdb(..., 0, ...)` drops the row: that object never
gets another alarm.

### How it shows up in the field

RFC 9074 snoozing writes exactly this shape — an extra VALARM with an absolute
`TRIGGER`, alongside the relative ones the object already carries. On 3.8.3, a
VTODO with `DTSTART`, `DUE` and five `TRIGGER;RELATED=END` alarms, snoozed once
by a client that wrote the snooze alarm first in the component:

```
calalarmd: sending alarm at 20260830T111906Z for user.alice.#calendars.Default 25 - 20260608T094100Z(1) ...
calalarmd: XXX  absolute trigger - stop recurrence expansion
calalarmd: data: 1788088746 0
calalarmd: update_alarmdb(user.alice.#calendars.Default:25, 0, 1, 0, 0, 0, NULL)
calalarmd: DELETE FROM events WHERE mboxname = 'user.alice.#calendars.Default' AND imap_uid = 25;
```

The snooze fires, then the five remaining reminders — the nearest of them five
days away — stop existing for the server. The previous revision of the same
object, which happened to carry the snooze VALARM *last*, was scheduled
correctly, which is what makes this so easy to miss: whether an object keeps
its reminders depends on the order a client happened to write its VALARMs in.

Ordering the VALARMs is a usable client-side workaround, and we are shipping
one, but it only protects objects our own client writes.

### The change

Straight cherry-pick of 9a5a0611: the guard moves up next to the
"already sent" check and becomes a `continue`, and the bottom branch goes
away. `cassandane/Cassandane/Cyrus/CaldavAlarm.pm` gets the upstream
`test_recurring_absolute_trigger` rework from the same commit — it adds a
second, relative VALARM to the recurring event and asserts that both fire on
the first instance and that the relative one still fires on the second.

Both hunks applied to `cyrus-imapd-3.8` without conflict.
