### PR TITLE
sync: UNMAILBOX names the mailbox it means

### DIFF
--- a/cassandane/tiny-tests/Replication/unmailbox_different_uniqueid
+++ b/cassandane/tiny-tests/Replication/unmailbox_different_uniqueid
@@ -1,0 +1,54 @@
+#!perl
+use Cassandane::Tiny;
+
+# A deleted mailbox's name can be taken over by a different mailbox on the
+# replica.  UNMAILBOX names the uniqueid it means, so only that mailbox is
+# ever removed, never the one which replaced it.
+sub test_unmailbox_different_uniqueid
+    :min_version_3_13 :NoReplicaonly :ImmediateDelete :NoAltNameSpace
+    ($self)
+{
+    my $master_store = $self->{master_store};
+    my $replica_store = $self->{replica_store};
+
+    my $mtalk = $master_store->get_client();
+    $mtalk->create('INBOX.tgt') || die "create: $@";
+
+    $self->run_replication();
+    $self->check_replication('cassandane');
+
+    xlog $self, "Replace the replica's copy with a different mailbox of that name";
+    my $rtalk = $replica_store->get_client();
+    $rtalk->delete('INBOX.tgt') || die "delete: $@";
+    $rtalk->create('INBOX.tgt') || die "create: $@";
+    $replica_store->set_folder('INBOX.tgt');
+    my %msgs;
+    $msgs{1} = $self->make_message("do not delete me", store => $replica_store);
+
+    xlog $self, "Delete the master's copy, leaving a tombstone to replicate";
+    $mtalk = $master_store->get_client();
+    $mtalk->delete('INBOX.tgt') || die "delete: $@";
+
+    my $file = $self->{instance}->{basedir} . "/sync.log";
+    open(my $fh, '>', $file) || die "$file: $!";
+    print $fh "UNMAILBOX user.cassandane.tgt\n";
+    close($fh);
+
+    $self->{replica}->getsyslog();
+    my $exit_code = 0;
+    $self->run_replication(
+        inputfile => $file,
+        rolling => 1,
+        handlers => {
+            exited_abnormally => sub { $exit_code = $_[1]; },
+        },
+    );
+    $self->assert_not_equals(0, $exit_code);
+    $self->assert_syslog_matches($self->{replica},
+                                 qr/refusing to UNMAILBOX a different mailbox/);
+
+    xlog $self, "The replica's mailbox and its message are untouched";
+    $replica_store->disconnect();
+    $replica_store->set_folder('INBOX.tgt');
+    $self->check_messages(\%msgs, store => $replica_store);
+}

--- a/changes/next/unmailbox-identity
+++ b/changes/next/unmailbox-identity
@@ -1,0 +1,40 @@
+Description:
+
+Replication no longer deletes the wrong mailbox when a name has been reused.
+
+"APPLY UNMAILBOX" named only the mailbox to delete, so the replica deleted
+whatever held that name at the time it arrived - which, after a delete and a
+recreate, or a rename onto the freed name, could be a completely different
+mailbox with its own messages.  The command now also carries the UNIQUEID and
+UIDVALIDITY of the mailbox the master meant, and the replica refuses the delete
+and logs "SYNCERROR: refusing to UNMAILBOX a different mailbox" if the one it
+finds is not that mailbox.  Where the folder came from the replica's own listing
+(the sweep for folders which no longer exist on the master, and XFER) this also
+closes the window between the listing and the delete.
+
+The identified form is gated on a new UNMAILBOX-ID capability, so a new master
+keeps talking to an old replica.  A replica still accepts the old form and
+deletes whatever holds the name, so an old master is unaffected - upgrade the
+master to get the protection.
+
+
+Documentation:
+
+The replication protocol reference documents the new command form and the
+UNMAILBOX-ID capability.
+
+
+Config changes:
+
+(none)
+
+
+Upgrade instructions:
+
+Both ends must run this version before the check takes effect; there is no
+ordering requirement between them.
+
+
+GitHub issue:
+
+(none)

--- a/docsrc/developer/replication-protocol.md
+++ b/docsrc/developer/replication-protocol.md
@@ -927,6 +927,7 @@ its capabilities, followed by an OK greeting:
 * STARTTLS
 * COMPRESS DEFLATE
 * SIEVE-MAILBOX
+* UNMAILBOX-ID
 * REPLICATION-ARCHIVE
 * OK servername Cyrus sync server v3.12.0-...
 ```
@@ -939,6 +940,7 @@ Each `* CAPABILITY` line is optional and depends on server configuration:
 | STARTTLS | Advertised when TLS is configured and not yet active |
 | COMPRESS DEFLATE | Advertised when zlib support is compiled in and compression is not yet active |
 | SIEVE-MAILBOX | Always advertised; indicates sieve scripts can be synced as a `#sieve` mailbox |
+| UNMAILBOX-ID | Always advertised; indicates APPLY UNMAILBOX accepts the kvlist form which identifies the mailbox to delete |
 | REPLICATION-ARCHIVE | Advertised when `archive_enabled` is set in imapd.conf |
 
 ### AUTHENTICATE
@@ -1492,9 +1494,27 @@ multi-tier replication setups.
 Deletes a mailbox on the replica.
 
 ```
-C: S3 APPLY UNMAILBOX %(MBOXNAME user.cassandane.OldFolder)
+C: S3 APPLY UNMAILBOX %(MBOXNAME user.cassandane.OldFolder
+       UNIQUEID d4f5a6b7-... UIDVALIDITY 1711200000)
 S: S3 OK Success
 ```
+
+The replica deletes the mailbox only if the one holding that name is
+the one named by UNIQUEID and UIDVALIDITY; otherwise it returns
+`IMAP_MAILBOX_MOVED` and leaves it alone.  A name can be reused, so
+without the identity check a delete of the master's mailbox could take
+out a completely different mailbox which had since taken over the name.
+A UIDVALIDITY of 0 means "unknown" and is not compared.
+
+This form is only sent to a replica which advertised and enabled the
+UNMAILBOX-ID capability.  Otherwise the older form is sent:
+
+```
+C: S3 APPLY UNMAILBOX user.cassandane.OldFolder
+S: S3 OK Success
+```
+
+which deletes whatever holds the name.  A replica accepts both forms.
 
 #### APPLY LOCAL\_UNMAILBOX
 
@@ -1690,8 +1710,8 @@ client has inspected the banner and wants to opt in to features
 like SIEVE-MAILBOX or REPLICATION-ARCHIVE.
 
 ```
-C: S19 APPLY CAPABILITIES (SIEVE-MAILBOX REPLICATION-ARCHIVE)
-S: * %(ENABLED (SIEVE-MAILBOX REPLICATION-ARCHIVE))
+C: S19 APPLY CAPABILITIES (SIEVE-MAILBOX UNMAILBOX-ID REPLICATION-ARCHIVE)
+S: * %(ENABLED (SIEVE-MAILBOX UNMAILBOX-ID REPLICATION-ARCHIVE))
 S: S19 OK Success
 ```
 

--- a/imap/imap_proxy.h
+++ b/imap/imap_proxy.h
@@ -30,6 +30,7 @@ enum {
     CAPA_SIEVE_MAILBOX       = (1 << 11),
     CAPA_REPLICATION_ARCHIVE = (1 << 12),
     CAPA_QUOTASET            = (1 << 13),
+    CAPA_UNMAILBOX_ID        = (1 << 14),
 };
 
 extern struct protocol_t imap_protocol;

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -464,6 +464,7 @@ static struct capa_struct base_capabilities[] = {
     { "X-REPLICATION",         CAPA_POSTAUTH,           { 0 } }, /* CY */
     { "X-REPLICATION-ARCHIVE", CAPA_POSTAUTH,           { 0 } }, /* CY */
     { "X-SIEVE-MAILBOX",       CAPA_POSTAUTH,           { 0 } }, /* CY */
+    { "X-UNMAILBOX-ID",        CAPA_POSTAUTH,           { 0 } }, /* CY */
     { "XAPPLEPUSHSERVICE",     CAPA_OMNIAUTH|CAPA_STATE,         /* NS */
       { .statep = &apns_enabled }                             },
     { "XLIST",                 CAPA_POSTAUTH,           { 0 } }, /* NS */
@@ -12295,7 +12296,8 @@ static int xfer_finalsync(struct xfer_header *xfer)
     for (rfolder = replica_folders->head; rfolder; rfolder = rfolder->next) {
         if (rfolder->mark) continue;
 
-        r = sync_do_folder_delete(&xfer->sync_cs, rfolder->name);
+        r = sync_do_folder_delete(&xfer->sync_cs, rfolder->name,
+                                  rfolder->uniqueid, rfolder->uidvalidity);
         if (r) {
             syslog(LOG_ERR, "sync_folder_delete(): failed: %s '%s'",
                    rfolder->name, error_message(r));

--- a/imap/sync_server.c
+++ b/imap/sync_server.c
@@ -256,6 +256,7 @@ static void dobanner(void)
 #endif
 
         prot_printf(sync_out, "* SIEVE-MAILBOX\r\n");
+        prot_printf(sync_out, "* UNMAILBOX-ID\r\n");
 
         if (config_getswitch(IMAPOPT_ARCHIVE_ENABLED)) {
             prot_printf(sync_out, "* REPLICATION-ARCHIVE\r\n");

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -97,6 +97,7 @@ static struct protocol_t imap_csync_protocol =
           { "X-REPLICATION", CAPA_REPLICATION },
           { "X-SIEVE-MAILBOX", CAPA_SIEVE_MAILBOX },
           { "X-REPLICATION-ARCHIVE", CAPA_REPLICATION_ARCHIVE },
+          { "X-UNMAILBOX-ID", CAPA_UNMAILBOX_ID },
           { NULL, 0 } } },
       { "S01 STARTTLS", "S01 OK", "S01 NO", 0 },
       { "A01 AUTHENTICATE", 0, 0, "A01 OK", "A01 NO", "+ ", "*",
@@ -117,6 +118,7 @@ static struct protocol_t csync_protocol =
           { "COMPRESS=DEFLATE", CAPA_COMPRESS },
           { "SIEVE-MAILBOX", CAPA_SIEVE_MAILBOX },
           { "REPLICATION-ARCHIVE", CAPA_REPLICATION_ARCHIVE },
+          { "UNMAILBOX-ID", CAPA_UNMAILBOX_ID },
           { NULL, 0 } } },
       { "STARTTLS", "OK", "NO", 1 },
       { "AUTHENTICATE", USHRT_MAX, 0, "OK", "NO", "+ ", "*", NULL, 0 },
@@ -4310,18 +4312,57 @@ bail:
 
 static int sync_apply_unmailbox(struct dlist *kin, struct sync_state *sstate)
 {
-    const char *mboxname = kin->sval;
+    const char *mboxname;
+    const char *uniqueid = NULL;
+    uint32_t uidvalidity = 0;
+
+    if (dlist_getatom(kin, "MBOXNAME", &mboxname)) {
+        /* the master identifies the mailbox it means */
+        if (!dlist_getatom(kin, "UNIQUEID", &uniqueid))
+            return IMAP_PROTOCOL_BAD_PARAMETERS;
+        dlist_getnum32(kin, "UIDVALIDITY", &uidvalidity);
+    }
+    else {
+        /* a master too old to identify it: delete whatever is here */
+        mboxname = kin->sval;
+        if (!mboxname) return IMAP_PROTOCOL_BAD_PARAMETERS;
+    }
 
     user_nslock_t *user_nslock = user_nslock_lockmb_w(mboxname);
+    mbentry_t *mbentry = NULL;
+    int r = 0;
+
+    if (uniqueid) {
+        r = mboxlist_lookup_allow_all(mboxname, &mbentry, NULL);
+        if (r) goto done;
+
+        /* a name can be reused, so the mailbox here may be a different one
+           entirely - the master only asked us to delete the one it named.
+           A zero uidvalidity is "unknown" (intermediates have none), so only
+           a disagreement between two real values counts */
+        if (strcmpsafe(mbentry->uniqueid, uniqueid) ||
+            (uidvalidity && mbentry->uidvalidity &&
+             mbentry->uidvalidity != uidvalidity)) {
+            xsyslog(LOG_ERR, "SYNCERROR: refusing to UNMAILBOX a different mailbox",
+                             "mailbox=<%s> uniqueid=<%s> uidvalidity=<%u>"
+                             " wanted_uniqueid=<%s> wanted_uidvalidity=<%u>",
+                             mboxname, mbentry->uniqueid, mbentry->uidvalidity,
+                             uniqueid, uidvalidity);
+            r = IMAP_MAILBOX_MOVED;
+            goto done;
+        }
+    }
 
     /* Delete with admin privileges */
     int delflags = MBOXLIST_DELETE_FORCE | MBOXLIST_DELETE_SILENT;
     if (sstate->flags & SYNC_FLAG_LOCALONLY)
         delflags |= MBOXLIST_DELETE_LOCALONLY;
-    int r = mboxlist_deletemailbox(mboxname, sstate->userisadmin,
-                                   sstate->userid, sstate->authstate,
-                                   NULL, delflags);
+    r = mboxlist_deletemailbox(mboxname, sstate->userisadmin,
+                               sstate->userid, sstate->authstate,
+                               NULL, delflags);
 
+ done:
+    mboxlist_entry_free(&mbentry);
     user_nslock_release(&user_nslock);
 
     return r;
@@ -4917,6 +4958,12 @@ static int sync_apply_capabilities(struct dlist *kin, struct sync_state *sstate)
                 sstate->flags |= SYNC_FLAG_ARCHIVE;
                 dlist_setatom(kout, NULL, capa);
             }
+        }
+
+        /* we always understand both UNMAILBOX forms, so there's no state to
+           keep - the client just needs to know it can send the longer one */
+        if (!strcasecmp(capa, "UNMAILBOX-ID")) {
+            dlist_setatom(kout, NULL, capa);
         }
     }
 
@@ -5793,7 +5840,8 @@ static int folder_rename(struct sync_client_state *sync_cs,
     return r;
 }
 
-int sync_do_folder_delete(struct sync_client_state *sync_cs, const char *mboxname)
+int sync_do_folder_delete(struct sync_client_state *sync_cs, const char *mboxname,
+                          const char *uniqueid, uint32_t uidvalidity)
 {
     const char *cmd =
         (sync_cs->flags & SYNC_FLAG_LOCALONLY) ? "LOCAL_UNMAILBOX" :"UNMAILBOX";
@@ -5806,7 +5854,17 @@ int sync_do_folder_delete(struct sync_client_state *sync_cs, const char *mboxnam
     if (sync_cs->flags & SYNC_FLAG_LOGGING)
         syslog(LOG_INFO, "%s %s", cmd, mboxname);
 
-    kl = dlist_setatom(NULL, cmd, mboxname);
+    /* the kvlist form names which mailbox we mean, so the replica can refuse
+       to delete a different one which has since taken over the name */
+    if (uniqueid && (sync_cs->flags & SYNC_FLAG_UNMAILBOX_ID)) {
+        kl = dlist_newkvlist(NULL, cmd);
+        dlist_setatom(kl, "MBOXNAME", mboxname);
+        dlist_setatom(kl, "UNIQUEID", uniqueid);
+        dlist_setnum32(kl, "UIDVALIDITY", uidvalidity);
+    }
+    else {
+        kl = dlist_setatom(NULL, cmd, mboxname);
+    }
     sync_send_apply(kl, sync_cs->backend->out);
     dlist_free(&kl);
 
@@ -7407,7 +7465,8 @@ static int do_folders(struct sync_client_state *sync_cs,
                         continue;
                     }
                 }
-                r = sync_do_folder_delete(sync_cs, rfolder->name);
+                r = sync_do_folder_delete(sync_cs, rfolder->name,
+                                          rfolder->uniqueid, rfolder->uidvalidity);
                 if (r) {
                     syslog(LOG_ERR, "SYNCERROR: sync_do_folder_delete(): failed: %s (%s)",
                                     rfolder->name, error_message(r));
@@ -7444,7 +7503,8 @@ static int do_folders(struct sync_client_state *sync_cs,
             /* we're forcing a delete */
             syslog(LOG_NOTICE, "SYNCNOTICE: forcing delete of remote folder despite no tombstone %s",
                    rfolder->name);
-            r = sync_do_folder_delete(sync_cs, rfolder->name);
+            r = sync_do_folder_delete(sync_cs, rfolder->name,
+                                      rfolder->uniqueid, rfolder->uidvalidity);
             if (r) {
                 syslog(LOG_ERR, "SYNCERROR: sync_do_folder_delete(): failed: %s (%s)",
                                 rfolder->name, error_message(r));
@@ -8402,7 +8462,8 @@ static int do_unmailbox(struct sync_client_state *sync_cs, const char *mboxname)
                             mboxname);
         }
         else {
-            r = sync_do_folder_delete(sync_cs, mboxname);
+            r = sync_do_folder_delete(sync_cs, mboxname, tombstone->uniqueid,
+                                      tombstone->uidvalidity);
             if (r) {
                 syslog(LOG_ERR, "%s: sync_do_folder_delete(): failed: %s '%s'",
                                 __func__, mboxname, error_message(r));
@@ -8954,6 +9015,11 @@ connected:
         capabilities |= CAPA_SIEVE_MAILBOX;
     }
 
+    if (CAPA(backend, CAPA_UNMAILBOX_ID)) {
+        syslog(LOG_INFO, "Destination supports identified UNMAILBOX");
+        capabilities |= CAPA_UNMAILBOX_ID;
+    }
+
     if (sync_cs->flags & SYNC_FLAG_ARCHIVE) {
         if (CAPA(backend, CAPA_REPLICATION_ARCHIVE)) {
             syslog(LOG_INFO, "Destination supports replication to archive");
@@ -9090,6 +9156,9 @@ int sync_do_enable(struct sync_client_state *sync_cs, unsigned capabilities)
     if (capabilities & CAPA_REPLICATION_ARCHIVE) {
         dlist_setatom(kl, NULL, "REPLICATION-ARCHIVE");
     }
+    if (capabilities & CAPA_UNMAILBOX_ID) {
+        dlist_setatom(kl, NULL, "UNMAILBOX-ID");
+    }
 
     sync_send_apply(kl, sync_cs->backend->out);
     dlist_free(&kl);
@@ -9113,6 +9182,8 @@ int sync_do_enable(struct sync_client_state *sync_cs, unsigned capabilities)
                     sync_cs->flags |= SYNC_FLAG_SIEVE_MAILBOX;
                 if (!strcasecmp(capa, "REPLICATION-ARCHIVE"))
                     sync_cs->flags |= SYNC_FLAG_ARCHIVE;
+                if (!strcasecmp(capa, "UNMAILBOX-ID"))
+                    sync_cs->flags |= SYNC_FLAG_UNMAILBOX_ID;
             }
         }
     }

--- a/imap/sync_support.h
+++ b/imap/sync_support.h
@@ -298,6 +298,7 @@ const char *sync_restore(struct dlist *kin,
 #define SYNC_FLAG_ARCHIVE (1<<8)
 #define SYNC_FLAG_USECACHE (1<<9)
 #define SYNC_FLAG_NOCACHE (1<<10)
+#define SYNC_FLAG_UNMAILBOX_ID (1<<11)
 
 int sync_do_annotation(struct sync_client_state *sync_cs, const char *mboxname);
 int sync_do_mailboxes(struct sync_client_state *sync_cs,
@@ -327,7 +328,8 @@ int sync_do_update_mailbox(struct sync_client_state *sync_cs,
                            struct sync_reserve_list *reserve_guids);
 
 int sync_do_folder_delete(struct sync_client_state *sync_cs,
-                          const char *mboxname);
+                          const char *mboxname, const char *uniqueid,
+                          uint32_t uidvalidity);
 int sync_do_user_quota(struct sync_client_state *sync_cs,
                        struct sync_name_list *master_quotaroots,
                        struct sync_quota_list *replica_quota);

--- a/perl/imap/lib/Cyrus/ImapClone.pm
+++ b/perl/imap/lib/Cyrus/ImapClone.pm
@@ -367,7 +367,9 @@ sub syncmailboxes {
     if (delete $mbox{$mailbox->{MBOXNAME}}) {
       $Self->syncmailbox($mailbox->{MBOXNAME}, $mailbox);
     } else {
-      $Self->{syncer}->apply_unmailbox($mailbox->{MBOXNAME});
+      $Self->{syncer}->apply_unmailbox($mailbox->{MBOXNAME},
+                                       $mailbox->{UNIQUEID},
+                                       $mailbox->{UIDVALIDITY});
     }
   }
   foreach my $new (sort keys %mbox) {

--- a/perl/imap/lib/Cyrus/SyncProto.pm
+++ b/perl/imap/lib/Cyrus/SyncProto.pm
@@ -146,8 +146,16 @@ sub apply_unuser {
 sub apply_unmailbox {
   my $Self = shift;
   my $mailbox = shift;
+  my $uniqueid = shift;
+  my $uidvalidity = shift;
 
-  return $Self->dlwrite('APPLY', 'UNMAILBOX', $mailbox);
+  # without a uniqueid the replica deletes whatever holds the name now,
+  # which may no longer be the mailbox we meant
+  return $Self->dlwrite('APPLY', 'UNMAILBOX', $mailbox) unless $uniqueid;
+
+  return $Self->dlwrite('APPLY', 'UNMAILBOX', { MBOXNAME => $mailbox,
+                                                UNIQUEID => $uniqueid,
+                                                UIDVALIDITY => $uidvalidity || 0 });
 }
 
 sub get_user {


### PR DESCRIPTION
A mailbox name can be reused, so by the time UNMAILBOX arrived the replica could be holding a different mailbox at that name - a recreate, or a rename onto the freed name - and it deleted that one instead, messages and all.

Carry the UNIQUEID and UIDVALIDITY of the mailbox the master meant, and refuse the delete when the replica finds anything else.  Where the name came from the replica's own folder listing (the sweep for folders which no longer exist on the master, and XFER) this also closes the window between the listing and the delete.

Gated on a new UNMAILBOX-ID capability so a new master still talks to an old replica; a replica accepts both forms, so an old master is unaffected.