### PR TITLE
ipurge: purge in batches rather than under one lock

### DIFF
--- a/cassandane/Cassandane/Cyrus/Expunge.pm
+++ b/cassandane/Cassandane/Cyrus/Expunge.pm
@@ -8,6 +8,7 @@ use JSON::XS;
 
 use base qw(Cassandane::Cyrus::TestCase);
 use Cassandane::Util::Log;
+use Cassandane::Util::Slurp;
 
 sub new
 {

--- a/cassandane/tiny-tests/Expunge/ipurge_batchsize
+++ b/cassandane/tiny-tests/Expunge/ipurge_batchsize
@@ -1,0 +1,56 @@
+#!perl
+use Cassandane::Tiny;
+
+#
+# ipurge unlocks the mailbox between batches, so it has to pick up where it
+# left off - and the messages it decided to keep get looked at again each
+# time round, which the stats have to account for.
+#
+sub test_ipurge_batchsize
+    :min_version_3_13 :NoAltNameSpace
+    ($self)
+{
+    my $shared_folder = 'shared.folder';
+
+    # set up a shared folder that's easy to write to
+    my $admintalk = $self->{adminstore}->get_client();
+    $admintalk->create($shared_folder);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $admintalk->setacl($shared_folder, 'cassandane' => 'lrswipkxtecd');
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+
+    my $talk = $self->{store}->get_client();
+    $self->{store}->set_folder($shared_folder);
+    $self->{store}->_select();
+    for (1..6) {
+        $self->make_message("message in $shared_folder $_");
+    }
+    $talk->unselect();
+    $talk->select($shared_folder);
+
+    # flag two of them so -s will keep them: they're the ones which get
+    # walked over again on every batch
+    $talk->store('3:4', '+flags', '(\\Flagged)');
+    $self->assert_str_equals('ok', $talk->get_last_completion_response());
+
+    my $stat = $talk->status($shared_folder, '(messages)');
+    $self->assert_num_equals(6, $stat->{messages});
+
+    # one message per batch, so we go round five times for four deletes
+    my $outfile = $self->{instance}->{basedir} . "/ipurge-out.txt";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        qw( ipurge --batchsize 1 -s -i -d 2 ), $shared_folder
+    );
+    my $out = slurp_file($outfile);
+
+    $talk->unselect();
+    $stat = $talk->status($shared_folder, '(messages)');
+    $self->assert_num_equals(2, $stat->{messages});
+
+    # the counts must describe the mailbox we started with, not the sum of
+    # every batch's traversal
+    $self->assert_matches(qr/Total messages\s+6$/m, $out);
+    $self->assert_matches(qr/Deleted messages\s+4$/m, $out);
+    $self->assert_matches(qr/Remaining messages\s+2$/m, $out);
+}

--- a/docsrc/reference/manpages/systemcommands/ipurge.rst
+++ b/docsrc/reference/manpages/systemcommands/ipurge.rst
@@ -96,6 +96,15 @@ Options
 
     Enable verbose output/logging.
 
+.. option:: --batchsize=num
+
+    Purge at most "num" messages per batch, unlocking the mailbox between
+    batches so that a mailbox with a lot to purge isn't held locked for the
+    whole run.  Default is 4096; 0 means purge everything in one batch.
+
+    Note that this option is long-form only, because **-b** already means
+    *bytes* for this command.
+
 Examples
 ========
 

--- a/imap/ipurge.c
+++ b/imap/ipurge.c
@@ -47,6 +47,12 @@ typedef struct mbox_stats_s {
 static int dryrun = 0;
 static int verbose = 0;
 static int forceall = 0;
+static int batchsize = 4096;
+
+/* -b is already "bytes" here, so batchsize is long-only */
+enum {
+    OPT_BATCHSIZE = 256,
+};
 
 /* current namespace */
 static struct namespace purge_namespace;
@@ -71,6 +77,7 @@ int main (int argc, char *argv[]) {
 
     static const struct option long_options[] = {
         /* n.b. no long option for -C */
+        { "batchsize", required_argument, NULL, OPT_BATCHSIZE },
         { "no-recursive", no_argument, NULL, 'M' },
         { "delivery-time", no_argument, NULL, 'X' },
         { "bytes", required_argument, NULL, 'b' },
@@ -117,6 +124,9 @@ int main (int argc, char *argv[]) {
                 usage(argv[0]);
             }
             size = atoi(optarg) * 1048576; /* 1024 * 1024 */
+            break;
+        case OPT_BATCHSIZE:
+            batchsize = atoi(optarg);
             break;
         case 'n':
             dryrun = 1;
@@ -197,6 +207,7 @@ static int usage(const char *name)
     printf("\t -o only purge messages that are deleted.\n");
     printf("\t -n only print messages that would be deleted (dry run).\n");
     printf("\t -v enable verbose output/logging.\n");
+    printf("\t --batchsize num purge num messages per locked batch (default 4096, 0 for no limit).\n");
     exit(0);
 }
 
@@ -204,6 +215,7 @@ static int usage(const char *name)
 static int purge_one(const mbname_t *mbname)
 {
     struct mailbox *mailbox = NULL;
+    uint64_t already_deleted = 0, already_deleted_bytes = 0;
     int r;
     mbox_stats_t stats;
     const char *name = mbname_intname(mbname);
@@ -220,15 +232,31 @@ static int purge_one(const mbname_t *mbname)
         printf("Working on %s...\n", name);
     }
 
-    r = mailbox_open_iwl(name, &mailbox);
-    if (r) { /* did we find it? */
-        syslog(LOG_ERR, "Couldn't find %s, check spelling", name);
-        return r;
-    }
+    /* Purge a batch at a time, dropping the lock in between, so that a
+     * mailbox with a lot to remove doesn't hold its index locked for the
+     * entire purge. */
+    do {
+        r = mailbox_open_iwl(name, &mailbox);
+        if (r) { /* did we find it? */
+            syslog(LOG_ERR, "Couldn't find %s, check spelling", name);
+            return r;
+        }
 
-    mailbox_expunge(mailbox, NULL, purge_check, &stats, NULL, EVENT_MESSAGE_EXPUNGE, /*limit*/0);
+        /* each round only sees what's left, so count from scratch and add
+         * the earlier rounds back in once we're done */
+        already_deleted = stats.deleted;
+        already_deleted_bytes = stats.deleted_bytes;
+        stats.total = 0;
+        stats.total_bytes = 0;
 
-    mailbox_close(&mailbox);
+        r = mailbox_expunge(mailbox, NULL, purge_check, &stats, NULL,
+                            EVENT_MESSAGE_EXPUNGE, batchsize);
+
+        mailbox_close(&mailbox);
+    } while (r == IMAP_AGAIN);
+
+    stats.total += already_deleted;
+    stats.total_bytes += already_deleted_bytes;
 
     print_stats(&stats);
 


### PR DESCRIPTION
purge_one() held the mailbox index locked with mailbox_open_iwl() and then called mailbox_expunge() with no limit, so a mailbox with a lot to purge was locked for the whole run.  It's the one caller with the batching machinery available which wasn't using it.

Pass a limit and loop on IMAP_AGAIN, closing and reopening the mailbox in between, the same way cyr_expire does.  mailbox_expunge() builds its iterator with ITER_SKIP_EXPUNGED, so each round picks up where the last one left off.

The stats need a hand, though: purge_check() counts every record it is shown, and the messages we decide to keep get shown to it again on every round, so the totals would climb with the number of batches.  Count them fresh each round and add back what the earlier rounds removed, since the iterator only ever shows us what's left.

-b already means "bytes" for ipurge, and -B for batchsize right next to a destructive -b seemed like a bad idea, so --batchsize is long-form only.