### PR TITLE
Hold off shutting down during write locks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -629,7 +629,6 @@ cunit_TESTS = \
     cunit/command.testc \
     cunit/conversations.testc \
     cunit/cron.testc \
-    cunit/signals.testc \
     cunit/css3_color.testc \
     cunit/cyr_qsort_r.testc \
     cunit/crc32.testc \
@@ -666,6 +665,7 @@ cunit_TESTS = \
     cunit/search_expr.testc \
     cunit/seqset.testc \
     cunit/sessionid.testc \
+    cunit/signals.testc \
     cunit/slowio.testc \
     cunit/smallarrayu64.testc \
     cunit/sqldb.testc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -629,6 +629,7 @@ cunit_TESTS = \
     cunit/command.testc \
     cunit/conversations.testc \
     cunit/cron.testc \
+    cunit/signals.testc \
     cunit/css3_color.testc \
     cunit/cyr_qsort_r.testc \
     cunit/crc32.testc \

--- a/cassandane/tiny-tests/Fetch/cache_generation_mismatch
+++ b/cassandane/tiny-tests/Fetch/cache_generation_mismatch
@@ -1,0 +1,47 @@
+#!perl
+use Cassandane::Tiny;
+
+# The first four bytes of a cache file are the generation of the index it was
+# written for.  A repack under an unlocked mailbox leaves us holding offsets
+# into a file that no longer matches, which must be reported as staleness and
+# recovered from the spool file - not parsed as if it were ours and blamed on
+# the checksum.
+sub test_cache_generation_mismatch
+    :NoAltNameSpace
+    ($self)
+{
+    my $imaptalk = $self->{store}->get_client();
+
+    $self->make_message("cache test", body => "hello world\r\n");
+
+    my $mbpath = $self->{instance}->run_mbpath('user.cassandane');
+    my $cache = "$mbpath->{data}/cyrus.cache";
+
+    $imaptalk->select("INBOX");
+
+    open(my $fh, '+<', $cache) || die "open $cache: $!";
+    binmode($fh);
+    sysread($fh, my $generation, 4) == 4 || die "read $cache: $!";
+    sysseek($fh, 0, 0);
+    syswrite($fh, pack('N', 0xdeadbeef)) == 4 || die "write $cache: $!";
+    close($fh);
+
+    $self->{instance}->getsyslog();
+
+    my $res = $imaptalk->fetch('1', '(BODY.PEEK[TEXT])');
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr/hello world/, $res->{'1'}->{body});
+
+    my @log = $self->{instance}->getsyslog();
+
+    # put the spool back before anything else looks at it
+    open($fh, '+<', $cache) || die "open $cache: $!";
+    binmode($fh);
+    syswrite($fh, $generation) == 4 || die "write $cache: $!";
+    close($fh);
+
+    $self->assert(scalar(grep { m/cache generation mismatch/ } @log),
+                  "the mismatch was not reported");
+    $self->assert(!scalar(grep { m/invalid cache record/ } @log),
+                  "the mismatch was reported as corruption");
+}

--- a/cassandane/tiny-tests/Fetch/cache_not_created_by_read
+++ b/cassandane/tiny-tests/Fetch/cache_not_created_by_read
@@ -1,0 +1,47 @@
+#!perl
+use Cassandane::Tiny;
+
+# A FETCH takes the index write lock, drops it, and only then streams the
+# bodies - so the cache file is opened with no lock held at all.  It must be
+# opened read-only: without the write lock we have no right to create one, and
+# a repack unlinks any cache file it did not rewrite.
+sub test_cache_not_created_by_read
+    :NoAltNameSpace
+    ($self)
+{
+    my $imaptalk = $self->{store}->get_client();
+
+    $self->make_message("cache test", body => "hello world\r\n");
+
+    my $mbpath = $self->{instance}->run_mbpath('user.cassandane');
+    my $cache = "$mbpath->{data}/cyrus.cache";
+    $self->assert(-f $cache, "$cache should exist to start with");
+
+    $imaptalk->select("INBOX");
+
+    # Not BODY.PEEK: asking to set \Seen is what makes a FETCH take the write
+    # lock, and the lock is what decides how the cache gets opened.  Do it
+    # once first so the message is already seen - then the second one takes
+    # the write lock but never touches the cache while it holds it, and the
+    # only cache access left is the unlocked one we care about.
+    $imaptalk->fetch('1', '(BODY[TEXT])');
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+
+    rename($cache, "$cache.saved") || die "rename $cache: $!";
+
+    my $res = $imaptalk->fetch('1', '(BODY[TEXT])');
+    $self->assert_str_equals('ok', $imaptalk->get_last_completion_response());
+    $self->assert_matches(qr/hello world/, $res->{'1'}->{body});
+
+    my $created = -e $cache;
+
+    # put the spool back before anything else looks at it
+    unlink($cache) if $created;
+    rename("$cache.saved", $cache) || die "rename $cache.saved: $!";
+
+    # the missing file is logged, and that is fair enough - drain it so the
+    # instance teardown doesn't call it a failure
+    $self->{instance}->getsyslog();
+
+    $self->assert(!$created, "a read recreated $cache");
+}

--- a/changes/next/cyr-2574-lmtpd-shutdown
+++ b/changes/next/cyr-2574-lmtpd-shutdown
@@ -1,0 +1,28 @@
+Description:
+
+A graceful shutdown now waits for any write transaction in progress to finish,
+so a service signalled mid-delivery can no longer leave a mailbox committed
+without its conversations DB, or an LMTP message delivered but unacknowledged.
+Several places that held a lock while waiting on the network have been fixed so
+that wait is bounded by local work.
+
+
+Documentation:
+
+None; behaviour of existing shutdown handling.
+
+
+Config changes:
+
+None.  Note that the new behaviour relies on the global lock, so it does not
+apply when global_lock is turned off.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/cunit/signals.testc
+++ b/cunit/signals.testc
@@ -31,7 +31,6 @@ static void test_deferral_lifecycle(void)
     CU_ASSERT_EQUAL(shutdowns, 0);
 
     /* two nested transactions, then the signal arrives */
-    signals_add_handlers(0);
     signals_defer_shutdown();
     signals_defer_shutdown();
     raise(SIGTERM);
@@ -53,4 +52,8 @@ static void test_deferral_lifecycle(void)
     /* the outermost one lets it through */
     signals_resume_shutdown();
     CU_ASSERT_EQUAL(shutdowns, 1);
+
+    /* nothing clears a delivered signal for us, and every other test in this
+     * binary shares the array */
+    signals_clear(SIGTERM);
 }

--- a/cunit/signals.testc
+++ b/cunit/signals.testc
@@ -1,0 +1,56 @@
+/* Unit test for lib/signals.c shutdown deferral */
+#include <config.h>
+#include <signal.h>
+
+#include "cunit/unit.h"
+
+#include "lib/signals.h"
+
+static int shutdowns;
+
+/* The real shutdown callbacks exit.  Ours returns so the test can keep
+ * looking, which has one consequence worth knowing: signals_poll_mask() sets
+ * its in-shutdown flag before calling us and nothing ever clears it, so only
+ * the FIRST shutdown in this process can fire.  Hence a single test that walks
+ * the whole lifecycle, rather than one test per property. */
+static void count_shutdown(int code __attribute__((unused)))
+{
+    shutdowns++;
+}
+
+static void test_deferral_lifecycle(void)
+{
+    shutdowns = 0;
+    signals_add_handlers(0);
+    signals_clear(SIGTERM);
+    signals_set_shutdown(count_shutdown);
+
+    /* nothing pending: releasing a transaction shuts nothing down */
+    signals_defer_shutdown();
+    signals_resume_shutdown();
+    CU_ASSERT_EQUAL(shutdowns, 0);
+
+    /* two nested transactions, then the signal arrives */
+    signals_add_handlers(0);
+    signals_defer_shutdown();
+    signals_defer_shutdown();
+    raise(SIGTERM);
+
+    /* Held.  And reported as nothing: callers read a nonzero return as "stop
+     * what you are doing", and prot.c uses it to abandon a read, which would
+     * tear apart the transaction we are deferring for. */
+    CU_ASSERT_EQUAL(signals_poll(), 0);
+    CU_ASSERT_EQUAL(shutdowns, 0);
+
+    /* still held, and still quiet, on a second look */
+    CU_ASSERT_EQUAL(signals_poll(), 0);
+    CU_ASSERT_EQUAL(shutdowns, 0);
+
+    /* the inner transaction closing is not enough */
+    signals_resume_shutdown();
+    CU_ASSERT_EQUAL(shutdowns, 0);
+
+    /* the outermost one lets it through */
+    signals_resume_shutdown();
+    CU_ASSERT_EQUAL(shutdowns, 1);
+}

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -2878,6 +2878,25 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
     }
     else return HTTP_BAD_REQUEST;
 
+    /* Read the body before taking any lock.  This waits on the client for as
+     * long as it cares to take, and the calendar lock below is exclusive on
+     * the whole user namespace.  Only `op` decides whether there is a body to
+     * read, and we know that already. */
+    if (op != ATTACH_REMOVE) {
+        txn->req_body.flags |= BODY_DECODE;
+        r = http_read_req_body(txn);
+        if (r) {
+            txn->flags.conn = CONN_CLOSE;
+            return r;
+        }
+
+        /* Make sure we have a body */
+        if (!buf_len(&txn->req_body.payload)) {
+            txn->error.desc = "Missing request body";
+            return HTTP_BAD_REQUEST;
+        }
+    }
+
     /* Open calendar for writing */
     r = mailbox_open_iwl(txn->req_tgt.mbentry->name, &calendar);
     if (r) {
@@ -2985,20 +3004,7 @@ static int caldav_post_attach(struct transaction_t *txn, int rights)
         static char uid[2*MESSAGE_GUID_SIZE+1];
         struct message_guid guid;
 
-        /* Read body */
-        txn->req_body.flags |= BODY_DECODE;
-        r = http_read_req_body(txn);
-        if (r) {
-            txn->flags.conn = CONN_CLOSE;
-            return r;
-        }
-
-        /* Make sure we have a body */
-        if (!buf_len(&txn->req_body.payload)) {
-            txn->error.desc = "Missing request body";
-            ret = HTTP_BAD_REQUEST;
-            goto done;
-        }
+        /* body was read before we took the lock, above */
 
         /* Generate UID of body content */
         message_guid_generate(&guid, buf_base(&txn->req_body.payload),

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -6614,13 +6614,6 @@ int meth_proppatch(struct transaction_t *txn, void *params)
 
     /* Local Mailbox */
 
-    r = mailbox_open_iwl(txn->req_tgt.mbentry->name, &mailbox);
-    if (r) {
-        syslog(LOG_ERR, "IOERROR: failed to open mailbox %s for proppatch",
-               txn->req_tgt.mbentry->name);
-        return HTTP_SERVER_ERROR;
-    }
-
     /* Parse the PROPPATCH body */
     ret = parse_xml_body(txn, &root, NULL);
     if (!ret && !root) {
@@ -6640,6 +6633,19 @@ int meth_proppatch(struct transaction_t *txn, void *params)
         goto done;
     }
     instr = root->children;
+
+    /* Only now take the write lock: parse_xml_body() above reads the request
+     * body from the client, which blocks for as long as the client takes to
+     * send it, and this lock is exclusive on the whole user namespace.  A
+     * malformed request no longer takes the lock at all. */
+    /* don't set r: the done: path aborts the mailbox when it is set, and we
+     * have no mailbox to abort if this failed */
+    if (mailbox_open_iwl(txn->req_tgt.mbentry->name, &mailbox)) {
+        syslog(LOG_ERR, "IOERROR: failed to open mailbox %s for proppatch",
+               txn->req_tgt.mbentry->name);
+        ret = HTTP_SERVER_ERROR;
+        goto done;
+    }
 
     /* Start construction of our multistatus response */
     if (!(root = init_xml_response("multistatus", NS_DAV, root, ns))) {

--- a/imap/httpd.c
+++ b/imap/httpd.c
@@ -2182,6 +2182,10 @@ static void cmdloop(struct http_connection *conn)
 
         sync_log_reset();
 
+        /* Locks from the last request are gone now, and the client has not
+         * been answered yet: send the notifications it queued. */
+        mboxevent_flush_notifications();
+
         /* Check for input from client */
         do {
             /* Flush any buffered output */

--- a/imap/imap_err.et
+++ b/imap/imap_err.et
@@ -68,6 +68,9 @@ ec IMAP_SYNC_BADSIEVE,
 ec IMAP_MAILBOX_CHECKSUM,
    "Mailbox format corruption detected"
 
+ec IMAP_MAILBOX_REPACKED,
+   "Mailbox was repacked while we were reading it"
+
 ec IMAP_MAILBOX_NOTSUPPORTED,
    "Operation is not supported on mailbox"
 

--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -1493,6 +1493,10 @@ static void cmdloop(void)
 
         sync_log_reset();
 
+        /* Locks from the last command are gone now, and the client has not
+         * been answered yet: send the notifications it queued. */
+        mboxevent_flush_notifications();
+
         /* Flush any buffered output */
         prot_flush(imapd_out);
         if (backend_current) prot_flush(backend_current->out);

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -38,6 +38,7 @@
 #include "global.h"
 #include "mboxevent.h"
 #include "prometheus.h"
+#include "signals.h"
 #include "xmalloc.h"
 #include "xstrlcpy.h"
 #include "version.h"
@@ -1138,6 +1139,15 @@ void lmtpmode(struct lmtp_func *func,
                 prometheus_apply_delta(CYRUS_LMTP_RECEIVED_BYTES_TOTAL, msg->size);
                 prometheus_apply_delta(CYRUS_LMTP_RECEIVED_RECIPIENTS_TOTAL, msg->rcpt_num);
 
+                /* The unit of work the MTA cares about is "delivered AND
+                 * acknowledged", not "committed".  Shutting down between
+                 * those two makes the MTA redeliver a message we already
+                 * have, so hold a shutdown off across the whole thing - the
+                 * per-transaction deferral in mboxname.c nests inside this
+                 * one, which also keeps us from exiting between two
+                 * recipients of the same DATA. */
+                signals_defer_shutdown();
+
                 /* do delivery, report status */
                 func->deliver(msg, msg->authuser, msg->authstate, msg->ns);
 
@@ -1150,6 +1160,11 @@ void lmtpmode(struct lmtp_func *func,
                     send_lmtp_error(pout, msg->rcpt[j]->status,
                                     msg->rcpt[j]->resp);
                 }
+
+                /* on the wire, not just in the buffer, before we let go */
+                prot_flush(pout);
+
+                signals_resume_shutdown();
 
                 prometheus_increment(CYRUS_LMTP_TRANSMITTED_MESSAGES_TOTAL);
                 prometheus_apply_delta(CYRUS_LMTP_TRANSMITTED_BYTES_TOTAL, delivered * msg->size);

--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -36,6 +36,7 @@
 #include "prot.h"
 #include "times.h"
 #include "global.h"
+#include "mboxevent.h"
 #include "prometheus.h"
 #include "xmalloc.h"
 #include "xstrlcpy.h"
@@ -1139,6 +1140,10 @@ void lmtpmode(struct lmtp_func *func,
 
                 /* do delivery, report status */
                 func->deliver(msg, msg->authuser, msg->authstate, msg->ns);
+
+                /* Delivery is over and its locks are gone, so send the
+                 * notifications it queued before we answer the client. */
+                mboxevent_flush_notifications();
 
                 for (j = 0; j < msg->rcpt_num; j++) {
                     if (!msg->rcpt[j]->status) delivered++;

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2551,12 +2551,22 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
     /* And the namelock.  Callers stream responses to a client after unlocking,
      * which blocks for as long as the client takes to read them; a namelock
      * held across that stalls repack, rename and delete on this mailbox.  The
-     * struct and its mappings stay usable, and mailbox_lock_index() re-takes
-     * both locks via mailbox_relock() if we come back for more.
+     * struct and its mappings stay usable, and mailbox_lock_index() gets us
+     * back in - via mailbox_relock(), which re-takes the namelock too, unless
+     * an outer user namespacelock means we never dropped our exclusion in the
+     * first place, in which case the namelock stays gone.  Note that
+     * open_mailboxes_namelocked() answers 0 for a mailbox in that state.
      *
-     * The cost is that a repack can now unlink message files we are still
-     * streaming from.  mailbox_map_record() then fails with ENOENT and the
-     * caller reports the message as gone - see IMAP_NO_MSGGONE in index.c. */
+     * The cost is that a repack can now move things under a mailbox we are
+     * still reading from.  Message files: mailbox_map_record() fails with
+     * ENOENT and the caller reports the message as gone (IMAP_NO_MSGGONE in
+     * index.c).  Cache files: we closed our mappings above, so the next read
+     * reopens by name and can get the repacked file, where our offsets mean
+     * nothing.  cache_getfile() doesn't check generation_no on the read path,
+     * so that is caught one layer down by the CRC in
+     * mailbox_cacherecord_internal() - no garbage reaches the client, but it
+     * surfaces as IMAP_MAILBOX_CHECKSUM and an "invalid cache record" IOERROR,
+     * which reads like corruption and isn't. */
     mboxname_release(&mailbox->namelock);
 }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -611,6 +611,19 @@ static struct mappedfile *cache_getfile(ptrarray_t *list, const char *fname,
     return cachefile;
 }
 
+/* The generation of the index this cache file was written for, stamped into
+ * the first four bytes by cache_getfile() above.  Records start after it, so
+ * offset 0 is never a real cache offset. */
+static uint32_t cache_generation(struct mappedfile *cachefile)
+{
+    const struct buf *buf = mappedfile_buf(cachefile);
+
+    if (mappedfile_size(cachefile) < 4)
+        return 0;
+
+    return ntohl(*(bit32 *)buf->s);
+}
+
 static struct mappedfile *mailbox_cachefile(struct mailbox *mailbox,
                                             const struct index_record *record)
 {
@@ -719,6 +732,18 @@ static int mailbox_cacherecord_internal(struct mailbox *mailbox,
     if (!record->cache_offset)
         goto err;
 
+    /* A repack rewrites every offset and bumps the generation, and unlinks
+     * any cache file it didn't rewrite - so a file stamped differently from
+     * our index is simply not the one our offsets came from.  Reachable two
+     * ways: we read without the index lock (see mailbox_unlock_index), or a
+     * repack died between renaming the index and renaming the caches, which
+     * mailbox_repack_commit() explicitly leaves for us to notice.  Either
+     * way there is nothing here to parse. */
+    if (cache_generation(cachefile) != mailbox->i.generation_no) {
+        r = IMAP_MAILBOX_REPACKED;
+        goto err;
+    }
+
     /* try to parse the cache record */
     r = cache_parserecord(cachefile, record->cache_offset, &backdoor->crec);
     if (r) goto err;
@@ -743,6 +768,13 @@ err:
         xsyslog(LOG_ERR, "IOERROR: missing cache offset",
                          "mailbox=<%s> uid=<%u>",
                          mailbox_name(mailbox), record->uid);
+    else if (r == IMAP_MAILBOX_REPACKED)
+        /* not an IOERROR: nothing is broken, we just lost the race */
+        xsyslog(LOG_NOTICE, "cache generation mismatch, reparsing",
+                            "mailbox=<%s> uid=<%u> ours=<%u> theirs=<%u>",
+                            mailbox_name(mailbox), record->uid,
+                            mailbox->i.generation_no,
+                            cache_generation(cachefile));
     else if (r)
         xsyslog(LOG_ERR, "IOERROR invalid cache record",
                          "mailbox=<%s> uid=<%u> error=<%s> crc=<%d> cache_offset=<%llu>",
@@ -2569,11 +2601,8 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
      * ENOENT and the caller reports the message as gone (IMAP_NO_MSGGONE in
      * index.c).  Cache files: we closed our mappings above, so the next read
      * reopens by name and can get the repacked file, where our offsets mean
-     * nothing.  cache_getfile() doesn't check generation_no on the read path,
-     * so that is caught one layer down by the CRC in
-     * mailbox_cacherecord_internal() - no garbage reaches the client, but it
-     * surfaces as IMAP_MAILBOX_CHECKSUM and an "invalid cache record" IOERROR,
-     * which reads like corruption and isn't. */
+     * nothing - mailbox_cacherecord_internal() sees the generation change and
+     * reparses from the spool file. */
     mboxname_release(&mailbox->namelock);
 }
 

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -621,7 +621,14 @@ static struct mappedfile *mailbox_cachefile(struct mailbox *mailbox,
     else
         fname = mailbox_meta_fname(mailbox, META_CACHE);
 
-    int is_readonly = mailbox->is_readonly || mailbox->index_locktype == LOCK_SHARED;
+    /* Writing the cache needs the index write lock - mailbox_append_cache()
+     * asserts it.  Ask by the lock rather than by mailbox->is_readonly, which
+     * is set once at open time and says nothing about now: callers stream
+     * responses after mailbox_unlock_index(), and opening read-write there
+     * would create a fresh cyrus.cache stamped with our stale generation if a
+     * repack had unlinked the real one. */
+    int is_readonly = mailbox->is_readonly
+                   || !mailbox_index_islocked(mailbox, /*write*/1);
     return cache_getfile(&mailbox->caches, fname, is_readonly, mailbox->i.generation_no);
 }
 
@@ -4146,8 +4153,12 @@ EXPORTED struct conversations_state *mailbox_get_cstate_full(struct mailbox *mai
         return cstate;
     }
 
-    /* open the conversations DB - abort if this fails */
-    int is_readonly = mailbox->is_readonly || mailbox->index_locktype == LOCK_SHARED;
+    /* open the conversations DB - abort if this fails.  Same rule as the
+     * cache: without the index write lock we have no business opening it
+     * read-write, and mailbox_unlock_index() drops our cstate, so a caller
+     * after the unlock lands right back in here with no lock at all. */
+    int is_readonly = mailbox->is_readonly
+                   || !mailbox_index_islocked(mailbox, /*write*/1);
     int r = conversations_open_mbox(mailbox_name(mailbox), is_readonly, &mailbox->cstate_value);
     if (r) {
         xsyslog(LOG_ERR, "DBERROR: failed to open conversations",

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -2547,6 +2547,17 @@ EXPORTED void mailbox_unlock_index(struct mailbox *mailbox, struct statusdata *s
 
     // release the namespacelock here
     user_nslock_release(&mailbox->user_nslock);
+
+    /* And the namelock.  Callers stream responses to a client after unlocking,
+     * which blocks for as long as the client takes to read them; a namelock
+     * held across that stalls repack, rename and delete on this mailbox.  The
+     * struct and its mappings stay usable, and mailbox_lock_index() re-takes
+     * both locks via mailbox_relock() if we come back for more.
+     *
+     * The cost is that a repack can now unlink message files we are still
+     * streaming from.  mailbox_map_record() then fails with ENOENT and the
+     * caller reports the message as gone - see IMAP_NO_MSGGONE in index.c. */
+    mboxname_release(&mailbox->namelock);
 }
 
 static char *mailbox_header_data_cstring(struct mailbox *mailbox)

--- a/imap/mboxevent.c
+++ b/imap/mboxevent.c
@@ -20,6 +20,7 @@
 #include "global.h"
 #include "imapurl.h"
 #include "libconfig.h"
+#include "libcyr_cfg.h"
 #include "map.h"
 #include "times.h"
 #include "user.h"
@@ -652,6 +653,74 @@ static int mboxevent_expected_param(enum event_type type, enum event_param param
     return type & (MESSAGE_EVENTS|FLAGS_EVENTS);
 }
 
+/* Sending a notification means a synchronous round-trip to notifyd, and we are
+ * called from inside append_commit() - before mailbox_commit(), holding the
+ * mailbox and an exclusive user namespace lock.  Blocking there stalls every
+ * other writer for as long as notifyd takes to answer.
+ *
+ * So queue the formatted messages and hand them to notifyd once the locks are
+ * gone.  Formatting stays here, where the event data is; only the socket work
+ * is deferred.  The queue is FIFO because event order is meaningful - see the
+ * FlagsSet/FlagsClear swap below, and mailbox_commit()'s Modseq event.
+ *
+ * Services drive this by calling mboxevent_flush_notifications() once their
+ * locks are gone but before the client has been answered, which is where the
+ * notification used to be sent from - a client that acts and then asks what
+ * was notified must still see it.  That is a different moment from
+ * libcyrus_run_delayed(), which services deliberately run *after* answering
+ * ("while a user isn't waiting on a reply") because it does things like
+ * cyrusdb checkpoints; putting notifications there would make them arrive
+ * after the response.  A delayed action is still registered as a backstop for
+ * code paths that never reach an explicit flush, and libcyrus_done() runs it,
+ * so nothing is silently dropped. */
+struct pending_notify {
+    struct pending_notify *next;
+    char *notifier;
+    char *message;
+};
+
+static struct pending_notify *pending_notifies = NULL;
+static struct pending_notify **pending_notifies_tail = &pending_notifies;
+
+EXPORTED void mboxevent_flush_notifications(void)
+{
+    while (pending_notifies) {
+        struct pending_notify *p = pending_notifies;
+        pending_notifies = p->next;
+        if (!pending_notifies) pending_notifies_tail = &pending_notifies;
+
+        notify(p->notifier, "EVENT", NULL, NULL, NULL, 0, NULL, p->message, NULL);
+
+        free(p->notifier);
+        free(p->message);
+        free(p);
+    }
+}
+
+static void mboxevent_delayed_flush(void *rock __attribute__((unused)))
+{
+    mboxevent_flush_notifications();
+}
+
+/* takes ownership of message */
+static void mboxevent_queue_notify(const char *notifier, char *message)
+{
+    struct pending_notify *p = xzmalloc(sizeof(struct pending_notify));
+
+    p->notifier = xstrdup(notifier);
+    p->message = message;
+
+    *pending_notifies_tail = p;
+    pending_notifies_tail = &p->next;
+
+    /* Backstop only.  Services call mboxevent_flush_notifications() directly at
+     * the point where their locks are gone but the client has not yet been
+     * answered; this catches anything that never reaches such a point.  Keyed,
+     * so however many events we queue there is only ever one action. */
+    libcyrus_delayed_action("mboxevent_notify", mboxevent_delayed_flush,
+                            NULL, NULL);
+}
+
 #define TIMESTAMP_MAX 32
 EXPORTED void mboxevent_notify(struct mboxevent **mboxevents)
 {
@@ -659,7 +728,6 @@ EXPORTED void mboxevent_notify(struct mboxevent **mboxevents)
     struct mboxevent *event;
     char stimestamp[TIMESTAMP_MAX+1];
     char *formatted_message;
-    const char *fname = NULL;
 
     /* nothing to notify */
     if (!*mboxevents)
@@ -775,9 +843,9 @@ EXPORTED void mboxevent_notify(struct mboxevent **mboxevents)
 
                 formatted_message = json_dumps(jevent,
                                                JSON_PRESERVE_ORDER|JSON_COMPACT);
-                notify(notifier, "EVENT", NULL, NULL, NULL, 0, NULL,
-                       formatted_message, fname);
-                free(formatted_message);
+                /* this path never passes a file to notifyd, so there is no
+                 * file lifetime to keep open until it has been read */
+                mboxevent_queue_notify(notifier, formatted_message);
             }
 
             if (idle_notifier &&

--- a/imap/mboxevent.h
+++ b/imap/mboxevent.h
@@ -241,6 +241,13 @@ struct mboxevent *mboxevent_enqueue(enum event_type type,
 void mboxevent_notify(struct mboxevent **mboxevents);
 
 /*
+ * Send the notifications queued by mboxevent_notify().  Call once no locks are
+ * held, but before answering the client - a client that acts and then asks what
+ * was notified must still see it.
+ */
+void mboxevent_flush_notifications(void);
+
+/*
  * Release any allocated resources of this given event
  */
 void mboxevent_free(struct mboxevent **event);

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -21,6 +21,7 @@
 #include "mailbox.h"
 #include "map.h"
 #include "retry.h"
+#include "signals.h"
 #include "user.h"
 #include "util.h"
 #include "xmalloc.h"
@@ -117,6 +118,17 @@ static struct mboxlocklist *create_lockitem(const char *name)
     item->l.lock_fd = -1;
     item->l.locktype = 0;
 
+    /* Every write takes the global lock for the duration of the transaction
+     * (see mboxname_lock() below), so this is exactly "a write starts here".
+     * Hold off any graceful shutdown until it is released, or we risk exiting
+     * with a mailbox committed but its conversations DB not, or an LMTP message
+     * delivered but never acknowledged.
+     *
+     * This is only safe to leave unbounded because no transaction waits on the
+     * wire, so the delay is our own local work rather than a peer's. */
+    if (!strcmp(name, GLOBAL_LOCKNAME))
+        signals_defer_shutdown();
+
     return item;
 }
 
@@ -143,6 +155,8 @@ static void remove_lockitem(struct mboxlocklist *remitem)
                 previtem->next = item->next;
             else
                 open_mboxlocks = item->next;
+            int wasglobal = !strcmp(item->l.name, GLOBAL_LOCKNAME);
+
             if (item->l.lock_fd != -1) {
                 if (item->l.locktype)
                     lock_unlock(item->l.lock_fd, item->l.name);
@@ -150,6 +164,13 @@ static void remove_lockitem(struct mboxlocklist *remitem)
             }
             free(item->l.name);
             free(item);
+
+            /* The write transaction is over and everything it touched is
+             * committed and unlocked, so this is the moment a shutdown we held
+             * off can safely happen - and it does, inside here, without
+             * returning. */
+            if (wasglobal) signals_resume_shutdown();
+
             return;
         }
         previtem = item;

--- a/imap/mboxname.c
+++ b/imap/mboxname.c
@@ -124,8 +124,14 @@ static struct mboxlocklist *create_lockitem(const char *name)
      * with a mailbox committed but its conversations DB not, or an LMTP message
      * delivered but never acknowledged.
      *
-     * This is only safe to leave unbounded because no transaction waits on the
-     * wire, so the delay is our own local work rather than a peer's. */
+     * The deferral is unbounded, which is fine while a transaction is only
+     * waiting on local work.  It is not always: in a murder, mboxlist_setacl()
+     * and friends hold a namespacelock across a mupdate round trip, and
+     * cyr_withlock_run() holds the global lock across an arbitrary command.  A
+     * process wedged on one of those now ignores SIGTERM until the peer
+     * answers or the prot layer times out.  The escape hatch is SA_RESETHAND:
+     * a second signal kills us outright, mid-transaction, which is what we
+     * were trying to avoid - so that is a last resort, not a plan. */
     if (!strcmp(name, GLOBAL_LOCKNAME))
         signals_defer_shutdown();
 

--- a/imap/pop3d.c
+++ b/imap/pop3d.c
@@ -716,6 +716,10 @@ static void cmdloop(void)
                       popd_mailbox ? mailbox_name(popd_mailbox) : NULL,
                       NULL);
 
+        /* Locks from the last command are gone now, and the client has not
+         * been answered yet: send the notifications it queued. */
+        mboxevent_flush_notifications();
+
         libcyrus_run_delayed();
 
         if (backend) {

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -98,10 +98,27 @@ EXPORTED void signals_reset_sighup_handler(int restartable)
 
 static shutdownfn *shutdown_cb = NULL;
 static int signals_in_shutdown = 0;
+static int signals_deferred = 0;
+static int signals_deferral_logged = 0;
 
 EXPORTED void signals_set_shutdown(shutdownfn *s)
 {
     shutdown_cb = s;
+}
+
+EXPORTED void signals_defer_shutdown(void)
+{
+    signals_deferred++;
+}
+
+EXPORTED void signals_resume_shutdown(void)
+{
+    assert(signals_deferred > 0);
+
+    if (--signals_deferred) return;
+
+    /* runs any shutdown we held off, and so may not return */
+    signals_poll();
 }
 
 /* Build a human-readable description of another process from just the
@@ -148,7 +165,21 @@ static int signals_poll_mask(sigset_t *oldmaskp)
 {
     int sig;
 
-    if (!signals_in_shutdown &&
+    if (!signals_in_shutdown && signals_deferred &&
+        (gotsignal[SIGINT] || gotsignal[SIGQUIT] || gotsignal[SIGTERM])) {
+
+        /* A write transaction is open.  Leave the signal set and act on it in
+         * signals_resume_shutdown(), so we exit between transactions rather
+         * than halfway through one.  Say so once: a process that then wedges
+         * mid-transaction is otherwise a mystery to whoever is waiting for it
+         * to die. */
+        if (!signals_deferral_logged) {
+            signals_deferral_logged = 1;
+            syslog(LOG_NOTICE,
+                   "graceful shutdown deferred: write transaction in progress");
+        }
+    }
+    else if (!signals_in_shutdown &&
         (gotsignal[SIGINT] || gotsignal[SIGQUIT] || gotsignal[SIGTERM])) {
 
         if (killer_pid && killer_pid != getppid()) {
@@ -178,6 +209,15 @@ static int signals_poll_mask(sigset_t *oldmaskp)
                 gotsignal[sig] = 0;
                 config_toggle_debug();
             }
+            break;
+        case SIGINT:
+        case SIGQUIT:
+        case SIGTERM:
+            /* Only reachable while deferred - otherwise we shut down above and
+             * never got here.  Must NOT be reported: callers read a nonzero
+             * return as "stop what you are doing", and prot.c uses it to
+             * abandon a read (lib/prot.c:700), which would tear apart the very
+             * transaction we are deferring for. */
             break;
         default:
             if (gotsignal[sig]) return sig;

--- a/lib/signals.h
+++ b/lib/signals.h
@@ -13,6 +13,18 @@ typedef void shutdownfn(int);
 void signals_add_handlers(int alarm);
 void signals_reset_sighup_handler(int restartable);
 void signals_set_shutdown(shutdownfn *s);
+
+/*
+ * Hold off a graceful shutdown while a write transaction is in progress, so we
+ * never exit with a mailbox committed but its conversations DB not, or with an
+ * LMTP message delivered but never acknowledged.
+ *
+ * These nest.  signals_resume_shutdown() runs the deferred shutdown when the
+ * last one is released, and so MAY NOT RETURN.
+ */
+void signals_defer_shutdown(void);
+void signals_resume_shutdown(void);
+
 int signals_poll(void);
 int signals_select(int nfds, fd_set *rfds, fd_set *wfds,
                    fd_set *efds, struct timeval *tout);

--- a/notifyd/notifyd.c
+++ b/notifyd/notifyd.c
@@ -213,6 +213,10 @@ EXPORTED int service_init(int argc, char **argv, char **envp __attribute__((unus
 
     if (!default_method) fatal("unknown notification method %s", EX_USAGE);
 
+    /* A client that hangs up before reading our reply must not take us with
+     * it: every other service does this, and we are shared by all of them. */
+    signal(SIGPIPE, SIG_IGN);
+
     signals_set_shutdown(&shut_down);
 
     return 0;


### PR DESCRIPTION
This avoids getting killed in the middle of deliveries where possible, so we get clean states.

When I wrote this it would have had problems with the sync lock, but now that the fix for that has been merged, this is safe!