### PR TITLE
http_h2.c: don't ever advertise "h2c" in Alt-Svc

### DIFF
--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -513,11 +513,6 @@ HIDDEN void http2_altsvc(struct buf *altsvc)
 
         if (config_altsvc) {
             buf_printf(altsvc, "%sh2=\"%s\"", sep, config_altsvc);
-            sep = ", ";
-        }
-        if (httpd_localip) {
-            const char *port = strchr(httpd_localip, ';');
-            buf_printf(altsvc, "%sh2c=\":%s\"", sep, port ? port+1 : "80");
         }
     }
 }
@@ -869,29 +864,16 @@ HIDDEN int http2_start_session(struct transaction_t *txn,
     }
 
     if (httpd_altsvc) {
-        /* Remove h2c from Alt-Svc value */
-        char *p = strstr(httpd_altsvc, "h2c=");
-        if (p == httpd_altsvc) {
-            free(httpd_altsvc);
-            httpd_altsvc = NULL;
-        }
-        else if (p) {
-            while (*--p == ' ');
-            *p  = '\0';
-        }
+        char *origin = strconcat("https://", config_servername, NULL);
 
-        if (httpd_altsvc) {
-            char *origin = strconcat("https://", config_servername, NULL);
+        r = nghttp2_submit_altsvc(ctx->session, NGHTTP2_FLAG_NONE, 0,
+                                  (uint8_t *) origin, strlen(origin),
+                                  (uint8_t *) httpd_altsvc, strlen(httpd_altsvc));
+        free(origin);
 
-            r = nghttp2_submit_altsvc(ctx->session, NGHTTP2_FLAG_NONE, 0,
-                                      (uint8_t *) origin, strlen(origin),
-                                      (uint8_t *) httpd_altsvc, strlen(httpd_altsvc));
-            free(origin);
-
-            if (r) {
-                syslog(LOG_ERR, "nghttp2_submit_altsvc: %s", nghttp2_strerror(r));
-                return HTTP_SERVER_ERROR;
-            }
+        if (r) {
+            syslog(LOG_ERR, "nghttp2_submit_altsvc: %s", nghttp2_strerror(r));
+            return HTTP_SERVER_ERROR;
         }
     }
 


### PR DESCRIPTION
"h2c" (cleartext HTTP/2) has been deprecated and Alt-Svc is supposed to advertise "better" protocol options than what is currently being used by the client, NOT "lesser" options.