### PR TITLE
jmap_mail.c: re-order to avoid pointer arithmetic on a void pointer

### DIFF
--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -6827,8 +6827,8 @@ static void _email_keywords_fini(struct email_keywords *keywords)
 static void _email_keywords_add_keyword(struct email_keywords *keywords,
                                         const char *keyword)
 {
-    uintptr_t count = (uintptr_t) hash_lookup(keyword, &keywords->counts);
-    hash_insert(keyword, (void*) count+1, &keywords->counts);
+    uintptr_t count = 1 + (uintptr_t) hash_lookup(keyword, &keywords->counts);
+    hash_insert(keyword, (void*) count, &keywords->counts);
 }
 
 static int _email_keywords_add_msgrecord(struct email_keywords *keywords,


### PR DESCRIPTION
The value in question is actually an integer cast to a pointer so that it can be stored in a hashu64. Perform the addition as part of the integer expression prior to casting, instead of on the cast value. The latter is undefined behaviour, and clang's ubsan will fault it with optimisation enabled.