### PR TITLE
jmap: fix pool leak in process_resultrefs() on unresolved wildcard refs

### DIFF
--- a/cassandane/tiny-tests/JMAPCore/resultref_wildcard_fail_mem_cleanup
+++ b/cassandane/tiny-tests/JMAPCore/resultref_wildcard_fail_mem_cleanup
@@ -1,0 +1,55 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_resultref_wildcard_fail_mem_cleanup
+    ($self)
+{
+    # Use compact JSON to keep us under the 4k jmap_max_request_size limit
+    my $jmap = $self->default_user->new_jmaptester({ json_pretty => 0 });
+    my $using = ['urn:ietf:params:jmap:core'];
+
+    # Create a multi-depth array
+    my $width = 2;
+    my $depth = 8;
+    my $nleaves = $width ** $depth;
+    my $seen = 0;
+
+    my $build_tree;
+    $build_tree = sub {
+        my ($d) = @_;
+        if ($d == 0) {
+            $seen++;
+            my $key = ($seen == $nleaves) ? 'NOTBAD' : 'BAD';
+            return { $key => JSON::true };
+        }
+        return [ map { $build_tree->($d - 1) } 1 .. $width ];
+    };
+    my $tree = $build_tree->($depth);
+
+    # Create a bogus wildcard result reference
+    my $path = '/x' . ('/*' x $depth) . '/BAD';
+
+    # Wildcard reference should fail with error
+    # and valgrind should report no leaks
+    my $res = $jmap->request({
+        methodCalls =>  [
+            ['Core/echo', { x => $tree }, 'R1'],
+            ['Core/echo', {
+                '#x' => {
+                    resultOf => 'R1',
+                    name => 'Core/echo',
+                    path => $path,
+                },
+             }, 'R2'],
+        ],
+        using => $using,
+    })->assert_successful;
+
+    $self->assert_cmp_deeply(
+        [
+            [ 'Core/echo', { x => $tree }, 'R1' ],
+            [ 'error', superhashof({ type => 'invalidResultReference' }), 'R2' ],
+        ],
+        $res->as_stripped_triples,
+    );
+}

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -139,6 +139,9 @@ static int process_resultrefs(json_t *args, json_t *resp, json_t **err)
     const char *arg;
     int ret = -1;
 
+    /* Pool of newly created JSON objects */
+    ptrarray_t pool = PTRARRAY_INITIALIZER;
+
     void *tmp;
     json_object_foreach_safe(args, tmp, arg, ref) {
         if (*arg != '#' || *(arg+1) == '\0') {
@@ -186,11 +189,6 @@ static int process_resultrefs(json_t *args, json_t *resp, json_t **err)
         if (!res) goto fail;
 
         /* Extract the reference argument value. */
-        /* We maintain our own pool of newly created JSON objects, since
-         * tracking reference counts across newly created JSON arrays is
-         * a pain. Rule: If you incref an existing JSON value or create
-         * an entirely new one, put it into the pool for cleanup. */
-        ptrarray_t pool = PTRARRAY_INITIALIZER;
         json_t *val = extract_value(json_array_get(res, 1), path, &pool);
         if (!val) goto fail;
 
@@ -199,16 +197,19 @@ static int process_resultrefs(json_t *args, json_t *resp, json_t **err)
         json_object_del(args, arg);
 
         /* Clean up reference counts of pooled JSON objects */
-        json_t *ref;
         while ((ref = ptrarray_pop(&pool))) {
             json_decref(ref);
         }
-        ptrarray_fini(&pool);
     }
 
+    ptrarray_fini(&pool);
     return 0;
 
   fail:
+    while ((ref = ptrarray_pop(&pool))) {
+        json_decref(ref);
+    }
+    ptrarray_fini(&pool);
     return ret;
 }
 


### PR DESCRIPTION
The array pool built while resolving a wildcard result reference was only drained on the per-reference success path, so a reference that failed to resolve (e.g. a later sibling branch missing) leaked every array built for branches that did resolve. Hoist the pool to function scope and drain it on the fail path too. Add a Cassandane test that reproduces the leak via repeated requests and checks worker RSS growth.