### PR TITLE
jmap_ical.c: Don't crash with badly formed participants.sendTo

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_bad_sendto
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_bad_sendto
@@ -1,0 +1,46 @@
+#!perl
+use Cassandane::Tiny;
+
+# Make sure we don't crash with badly formed sendTo arguments
+
+sub test_calendarevent_set_bad_sendto
+    :min_version_3_4
+{
+    my ($self) = @_;
+    my $jmap = $self->{jmap};
+
+    for my $bad (
+        { sendTo => { imip  => JSON::true } },
+        { sendTo => { other => JSON::true } },
+        { sendTo => { fake  => JSON::true } },
+        { sendTo => JSON::true },
+        { sendTo => [ JSON::true ] },
+    ) {
+        my $res = $jmap->CallMethods([
+            [ "CalendarEvent/set", {
+                create => {
+                    new => {
+                        calendarIds => { Default => JSON::true, },
+                        participants => {
+                            foo => $bad,
+                        },
+                        start => "2020-08-01T01:30:00",
+                    },
+                },
+            }, "a", ],
+        ]);
+
+        $self->assert_str_equals('CalendarEvent/set', $res->[0][0]);
+        $self->assert_deep_equals(
+            {
+                new => {
+                    properties => [
+                       'participants/foo/sendTo',
+                    ],
+                    type => 'invalidProperties',
+                },
+            },
+            $res->[0][1]{notCreated}
+        );
+    }
+}

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -5915,14 +5915,14 @@ static void participants_to_ical(icalcomponent *comp,
         char *caladdress = NULL;
         json_t *sendTo = json_object_get(jval, "sendTo");
         if (json_object_get(sendTo, "imip")) {
-            caladdress = xstrdup(json_string_value(json_object_get(sendTo, "imip")));
+            caladdress = xstrdupnull(json_string_value(json_object_get(sendTo, "imip")));
         }
         else if (json_object_get(sendTo, "other")) {
-            caladdress = xstrdup(json_string_value(json_object_get(sendTo, "other")));
+            caladdress = xstrdupnull(json_string_value(json_object_get(sendTo, "other")));
         }
         else if (json_object_size(sendTo)) {
             const char *anymethod = json_object_iter_key(json_object_iter(sendTo));
-            caladdress = xstrdup(json_string_value(json_object_get(sendTo, anymethod)));
+            caladdress = xstrdupnull(json_string_value(json_object_get(sendTo, anymethod)));
         }
         if (!caladdress) continue; /* reported later as error */
         hash_insert(partid, caladdress, &caladdress_by_participant_id);


### PR DESCRIPTION
If the sendTo value of the key we pick is not a valid json string, don't crash trying to strdup a null pointer.

Thanks to Bin Luo of UESTC for reporting this.