### PR TITLE
cassandane: fix four rename assertions that could never fire

### DIFF
--- a/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_both
+++ b/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_both
@@ -47,5 +47,5 @@ sub test_mailbox_rename_to_clash_both
 
     # there were no renames
     $self->assert_syslog_does_not_match($self->{instance},
-                                        qr/auditlog: rename/);
+                                        qr/\bevent=auditlog\.rename\b/);
 }

--- a/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_name_only
+++ b/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_name_only
@@ -42,5 +42,5 @@ sub test_mailbox_rename_to_clash_name_only
 
     # there were no renames
     $self->assert_syslog_does_not_match($self->{instance},
-                                        qr/auditlog: rename/);
+                                        qr/\bevent=auditlog\.rename\b/);
 }

--- a/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_name_only_deep
+++ b/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_name_only_deep
@@ -41,5 +41,5 @@ sub test_mailbox_rename_to_clash_name_only_deep
 
     # there were no renames
     $self->assert_syslog_does_not_match($self->{instance},
-                                        qr/auditlog: rename/);
+                                        qr/\bevent=auditlog\.rename\b/);
 }

--- a/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_parent_only
+++ b/cassandane/tiny-tests/FastMail/mailbox_rename_to_clash_parent_only
@@ -40,5 +40,5 @@ sub test_mailbox_rename_to_clash_parent_only
 
     # there were no renames
     $self->assert_syslog_does_not_match($self->{instance},
-                                        qr/auditlog: rename/);
+                                        qr/\bevent=auditlog\.rename\b/);
 }


### PR DESCRIPTION
The four FastMail mailbox_rename_to_clash_* tests each end with

    # there were no renames
    $self->assert_syslog_does_not_match($self->{instance},
                                        qr/auditlog: rename/);

They should match event=auditlog.rename now.