### PR TITLE
allow cyrus to use `static_assert`

### DIFF
--- a/cunit/meta-timeofday.testc
+++ b/cunit/meta-timeofday.testc
@@ -9,6 +9,7 @@
 #include "cunit/unit.h"
 #include "cunit/unit-timeofday.h"
 
+#include "lib/assert.h"
 #include "lib/util.h"
 
 #if HAVE_VALGRIND_VALGRIND_H
@@ -22,7 +23,7 @@
 #endif
 
 #define MAX_SLEEPS (3)
-_Static_assert(MAX_SLEEPS >= 2, "need to sleep at least twice");
+static_assert(MAX_SLEEPS >= 2, "need to sleep at least twice");
 
 static int tear_down(void)
 {

--- a/cunit/sessionid.testc
+++ b/cunit/sessionid.testc
@@ -1,6 +1,7 @@
 #include "cunit/unit.h"
 #include "lib/sessionid.h"
 
+#include "lib/assert.h"
 #include "lib/libconfig.h"
 #include "lib/xmalloc.h"
 
@@ -11,8 +12,8 @@
 #define X64     X16 X16 X16 X16
 #define X255    X64 X64 X64 X16 X16 X16 X15
 #define X256    X64 X64 X64 X64
-_Static_assert(sizeof(X255) == 255 + 1, "X255 is wrong length");
-_Static_assert(sizeof(X256) == 256 + 1, "X266 is wrong length");
+static_assert(sizeof(X255) == 255 + 1, "X255 is wrong length");
+static_assert(sizeof(X256) == 256 + 1, "X256 is wrong length");
 
 static int set_up(void)
 {

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -29,6 +29,7 @@
 #include "annotate.h"
 #include "acl.h"
 #include "append.h"
+#include "assert.h"
 #include "dlist.h"
 #include "global.h"
 #include "http_dav.h"
@@ -82,8 +83,8 @@ static const struct dav_namespace_t {
  * known_namespaces[] slots, so the two must match.  See comment on the
  * NS_* enum in http_dav.h.
  */
-_Static_assert(NUM_NAMESPACE == NUM_KNOWN_NAMESPACES,
-               "NUM_NAMESPACE must match known_namespaces[]");
+static_assert(NUM_NAMESPACE == NUM_KNOWN_NAMESPACES,
+              "NUM_NAMESPACE must match known_namespaces[]");
 
 static const struct match_type_t {
     const char *name;

--- a/imap/http_dav.h
+++ b/imap/http_dav.h
@@ -41,7 +41,7 @@
  * http_dav.c -- callers stack-allocate xmlNsPtr ns[NUM_NAMESPACE] and the
  * dead-property PROPPATCH path then indexes that array by the matching
  * known_namespaces[] slot, so a short array means an out-of-bounds read
- * and a worker crash.  A _Static_assert in http_dav.c enforces this.
+ * and a worker crash.  A static_assert in http_dav.c enforces this.
  */
 enum {
     NS_REQ_ROOT = -1,   /* special case: ns of request root (not an index) */

--- a/imap/mailbox.c
+++ b/imap/mailbox.c
@@ -138,14 +138,14 @@ static struct MsgFlagMap msgflagmap[] = {
     {"EX", (int)FLAG_INTERNAL_EXPUNGED}
     /* ZZ -> invalid file found on disk */
 };
-_Static_assert(N_MSGFLAGMAP == sizeof(msgflagmap) / sizeof(msgflagmap[0]),
-               "N_MSGFLAGMAP has the wrong value");
+static_assert(N_MSGFLAGMAP == sizeof(msgflagmap) / sizeof(msgflagmap[0]),
+              "N_MSGFLAGMAP has the wrong value");
 /* The length of the msgflagmap list * 2 +
  * Total number of separators possible
  * = 33 bytes
  */
-_Static_assert(FLAGMAPSTR_MAXLEN == 1 + 3 * N_MSGFLAGMAP,
-               "FLAGMAPSTR_MAXLEN has the wrong value");
+static_assert(FLAGMAPSTR_MAXLEN == 1 + 3 * N_MSGFLAGMAP,
+              "FLAGMAPSTR_MAXLEN has the wrong value");
 
 static int mailbox_index_unlink(struct mailbox *mailbox);
 static int _mailbox_index_repack(struct mailbox *mailbox,

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -13,4 +13,15 @@ void assertionfailed(const char *file, int line, const char *expr);
      ? (void)(0)                                                    \
      : assertionfailed(__FILE__, __LINE__, #expr))
 
+/* In C11, static_assert is a macro provided by the system assert header.
+ * We can't use that header with this one, so provide an equivalent macro.
+ *
+ * In C23 and C++, static_assert is a language keyword, so do nothing.
+ */
+#if ((!defined __STDC_VERSION__ || __STDC_VERSION__ <= 201710L) \
+     && !defined __cplusplus)
+# undef static_assert
+# define static_assert _Static_assert
+#endif
+
 #endif /* INCLUDED_ASSERT_H */

--- a/lib/hash_priv.h
+++ b/lib/hash_priv.h
@@ -5,6 +5,8 @@
 
 #include <sysexits.h>
 
+#include "assert.h"
+
 /* Resize the hash when we hit this: */
 #define HASH_LOAD_FACTOR 1
 /* 8 entries: */
@@ -85,8 +87,8 @@ static uint64_t round_up_log_base2(uint64_t v) {
 
 /* realistically you don't want to go below 0.5, but coded like this so that
  * the logic just below is good enough to catch all overflow possiblities. */
-_Static_assert(1 < sizeof(void *) * HASH_LOAD_FACTOR,
-               "HASH_LOAD_FACTOR is too small");
+static_assert(1 < sizeof(void *) * HASH_LOAD_FACTOR,
+              "HASH_LOAD_FACTOR is too small");
 
 static uint8_t hash_base2_size_for_entries(uint64_t entries) {
   if (entries <= (1 << HASH_MIN_SIZE_BASE_2) / (1.0 / HASH_LOAD_FACTOR))

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -1328,8 +1328,8 @@ static const unsigned char cmpstringp_path_lookup[] = {
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff,
 };
-_Static_assert(256 == sizeof(cmpstringp_path_lookup),
-               "cmpstringp_path_lookup has wrong number of elems");
+static_assert(256 == sizeof(cmpstringp_path_lookup),
+              "cmpstringp_path_lookup has wrong number of elems");
 
 /* Treats '/' (0x2f) as lower than other printables so that
  * file paths sort pre-order, depth-first.


### PR DESCRIPTION
C11 added the `_Static_assert` keyword, and added a `static_assert` macro to `assert.h`.

We can't use the system `assert.h` in Cyrus because of conflicts with our own, so we haven't been able to use the `static_assert` macro; instead, we've been using the `_Static_assert` keyword directly.

C++ provides `static_assert` as a keyword, and does not recognise `_Static_assert` at all.  This hasn't been a problem yet, but we're using `_Static_assert` more and more, so it might bite us sooner or later.  C23 deprecates `_Static_assert`, and promotes `static_assert` to a keyword.  It's clear that `static_assert` is the future and `_Static_assert` is a dead end.

This PR adds a `static_assert` macro definition to _our_ `assert.h`, so that we can use the common spelling without relying on the system header.  The macro definition is conditionalised to avoid conflict with the C++/C23 keyword of the same name.  It also switches all existing usage of `_Static_assert` to `static_assert`, bringing in our assert.h if it wasn't already present.