### PR TITLE
message: let a memo follow a split conversation

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_after_splitconv
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_after_splitconv
@@ -1,0 +1,106 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_email_set_create_memo_after_splitconv
+  : ConversationsMaxThread10
+    ($self)
+{
+  my $jmap = $self->{jmap};
+
+  xlog $self, "Create conversation with maximum thread count";
+  my $convsMaxThread
+    = $self->{instance}->{config}->get('conversations_max_thread');
+  $self->make_message('Email A', messageid => "msg1\@example.com");
+  my $lastUid = 1;
+  foreach my $i (2 .. $convsMaxThread) {
+    my $nextUid = $lastUid + 1;
+    $self->make_message(
+      "Re: Email A",
+      messageid     => "msg$nextUid\@example.com",
+      extra_headers => [
+        [ "in-reply-to", "<msg$lastUid\@example.com>" ],
+      ],
+    );
+    $lastUid = $nextUid;
+  }
+
+  xlog $self, "Append one more reply, splitting the conversation";
+  my $splitUid = $lastUid + 1;
+  $self->make_message(
+    "Re: Email A",
+    messageid     => "msg$splitUid\@example.com",
+    extra_headers => [
+      [ "in-reply-to", "<msg$lastUid\@example.com>" ],
+    ],
+  );
+
+  my $res = $jmap->CallMethods([
+    [
+      'Email/query',
+      {
+        sort => [ { property => 'receivedAt', isAscending => JSON::true } ],
+      },
+      'R1'
+    ],
+    [
+      'Email/get',
+      {
+        '#ids' => {
+          resultOf => 'R1',
+          name     => 'Email/query',
+          path     => '/ids'
+        },
+        properties => [ 'threadId', 'messageId' ],
+      },
+      'R2'
+    ],
+  ]);
+
+  my %threadIdByMsgId
+    = map { $_->{messageId}[0] => $_->{threadId} } @{ $res->[1][1]{list} };
+
+  my $baseThreadId  = $threadIdByMsgId{"msg1\@example.com"};
+  my $splitThreadId = $threadIdByMsgId{"msg$splitUid\@example.com"};
+  $self->assert_not_null($baseThreadId);
+  $self->assert_not_null($splitThreadId);
+  $self->assert_str_not_equals($baseThreadId, $splitThreadId);
+
+  xlog $self, "Create memo replying to the message in the split conversation";
+  my $memoUid = $splitUid + 1;
+  $res = $jmap->CallMethods([
+    [
+      'Email/set',
+      {
+        create => {
+          "$memoUid" => {
+            mailboxIds    => { '$inbox' => JSON::true },
+            from          => [ { email => 'from@local' } ],
+            to            => [ { email => 'to@local' } ],
+            subject       => "Re: Email A",
+            messageId     => ["msg$memoUid\@example.com"],
+            inReplyTo     => ["msg$splitUid\@example.com"],
+            bodyStructure => {
+              type   => 'text/plain',
+              partId => 'part1',
+            },
+            bodyValues => {
+              part1 => {
+                value => "body$memoUid XXX",
+              },
+            },
+            keywords => {
+              '$memo' => JSON::true,
+            },
+          },
+        },
+      },
+      'R1'
+    ],
+  ]);
+
+  xlog $self, "Memo joins the conversation of the message it replies to";
+  $self->assert_str_equals(
+    $splitThreadId,
+    $res->[0][1]{created}{$memoUid}{threadId}
+  );
+}

--- a/imap/message.c
+++ b/imap/message.c
@@ -4019,10 +4019,6 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
             record->cid = generate_conversation_id(record);
             if (record->cid) mustkeep = 1;
         }
-        if (!mustkeep) {
-            /* Do not split conversations for messages with '$memo' flag */
-            mustkeep = mailbox_record_hasflag(mailbox, record, "$memo");
-        }
         if (!mustkeep && !record->basecid) {
             /* try finding a CID in the match list, or if we came in with it */
             struct buf annotkey = BUF_INITIALIZER;
@@ -4054,8 +4050,14 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
 
     if (!conv) conv = conversation_new();
 
+    /* A memo belongs with the message it annotates, so it never splits the
+     * conversation.  This is separate from mustkeep: a memo must still follow
+     * an already split conversation to its current cid. */
+    bool is_memo = mailbox_record_hasflag(mailbox, record, "$memo");
+
     uint32_t max_thread = config_getint(IMAPOPT_CONVERSATIONS_MAX_THREAD);
-    if (conv->exists >= max_thread && !mustkeep && !record->silentupdate) {
+    if (conv->exists >= max_thread && !mustkeep && !is_memo
+        && !record->silentupdate) {
         /* time to reset the conversation */
         conversation_id_t was = record->cid;
         record->cid = generate_conversation_id(record);


### PR DESCRIPTION
The '$memo' check set mustkeep, which also gates the newcid annotation lookup immediately below it.  The msgid index only ever records a message's basecid, so once a conversation has split, every message-id in the thread still resolves to the base cid: ordinary messages follow the newcid annotation on to the current cid, but a memo skipped that and landed in the base conversation, away from the message it annotates.

Give the no-split rule its own flag so it no longer disables the redirect.

A memo whose parent is itself in the base conversation still ends up in the current one.  The msgid index cannot say which side of a split holds the parent record.