### PR TITLE
doc: calendar_user_address_set generates identities, not just scope

### DIFF
--- a/lib/imapoptions/calendar_user_address_set
+++ b/lib/imapoptions/calendar_user_address_set
@@ -6,3 +6,26 @@ Last-Modified: 2.5.0
 Space-separated list of domains corresponding to calendar user addresses
 for which the server is responsible.  If not set (the default), the value
 of the :imapdconf:`defaultdomain` option will be used.
+
+This option does more than declare which domains are ours, and both of its
+effects matter when more than one domain is listed:
+
+* every user is given **one calendar user address per listed domain**.  A
+  user ``jsmith`` with three domains listed owns ``jsmith@example.com``,
+  ``jsmith@example.net`` and ``jsmith@example.org`` as far as scheduling is
+  concerned, whether or not those mailboxes exist.
+
+* conversely, an ATTENDEE or ORGANIZER in any listed domain is treated as
+  local.  When :imapdconf:`virtdomains` is disabled the domain is then
+  **stripped**, so ``jsmith@example.com`` and ``jsmith@example.net`` resolve
+  to the same account.
+
+.. WARNING::
+
+   List several domains only where the local part identifies the same person
+   in all of them, or enable :imapdconf:`virtdomains`.  In a multi-tenant
+   deployment where each tenant has its own domain and local parts are not
+   unique across tenants, listing every tenant domain here makes unrelated
+   accounts share an identity: an invitation addressed to one tenant's
+   ``info@`` is delivered to another tenant's ``info``, and either user can
+   reply to the other's invitations.


### PR DESCRIPTION
The documentation for `calendar_user_address_set` currently reads:

> Space-separated list of domains corresponding to calendar user addresses
> for which the server is responsible.

That reads as a **scoping** list — the domains this server answers for — which
is how at least one multi-tenant deployment configured it: every tenant domain
was listed, on the assumption it was declaring which domains are ours, much
like sendmail's local-host-names.

The option does two further things, and neither is documented:

**It generates addresses.** In `imap/calsched_support.c`,
`caldav_get_schedule_addresses()` builds `<userid>@<domain>` for *every* listed
domain when the userid has no `@`. A user is therefore declared to own their
local part in all of them, whether or not those mailboxes exist.

**It resolves them back, and strips the domain.** In
`imap/http_caldav_sched.c`, an attendee whose domain is in the list is treated
as local, and then:

```c
if (!config_virtdomains) {
    *at = '\0';  // trim off the domain
}
```

so `jsmith@example.com` and `jsmith@example.net` resolve to the *same* account.

### Why this matters

In a hosting deployment where each tenant has its own domain and local parts
are not unique across tenants — an `info@` per tenant — listing every tenant
domain here makes unrelated accounts share a scheduling identity. An invitation
addressed to one tenant's `info@` is delivered to another tenant's `info`, and
either user can reply to the other's invitations.

This is correct and expected behaviour for a single-domain install. The
surprise is only that the documentation gives no hint that the option behaves
as an alias generator, nor that `virtdomains` changes the outcome.

### This PR

Documentation only — no behaviour change. It adds the two effects and a warning
about the multi-domain case.

Verified: all five `tools/imapoptions.pl` generators (`manrst`, `docs`,
`sample`, `cheader`, `csource`) run clean, and the generated RST places this
text at top level, so the bullet list and the `.. WARNING::` directive are
valid there.

The branch is based on the fork point rather than current master; this file has
not changed upstream since, so the result is identical. Happy to rebase.
