### PR TITLE
http_h2: one DATA provider per stream, not one per chunk

### DIFF
--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -44,6 +44,20 @@ struct http2_stream {
     int32_t id;                         /* Stream ID */
     size_t num_resp_hdrs;               /* Number of response headers */
     nghttp2_nv resp_hdrs[HTTP2_MAX_HEADERS]; /* Array of response headers */
+
+    /* Response body awaiting transmission.
+     *
+     * nghttp2 accepts only ONE outstanding DATA submission per stream, so we
+     * submit a single data provider and append every chunk here.  While the
+     * flow control window is open the provider is drained by the http2_output()
+     * below, and this stays near empty; once the window closes it grows until
+     * the peer sends WINDOW_UPDATE.
+     */
+    struct buf body;                    /* Pending response body */
+    size_t body_off;                    /* How much has been read out */
+    unsigned body_submitted : 1;        /* Data provider already submitted? */
+    unsigned body_complete  : 1;        /* No further chunks are coming */
+    unsigned body_deferred  : 1;        /* Provider parked, needs resuming */
 };
 
 static nghttp2_session_callbacks *http2_callbacks = NULL;
@@ -55,6 +69,8 @@ static void stream_free(struct transaction_t *txn)
 
         if (strm) {
             int i;
+
+            buf_free(&strm->body);
 
             for (i = 0; i < HTTP2_MAX_HEADERS; i++) {
                 free(strm->resp_hdrs[i].value);
@@ -669,16 +685,9 @@ static int end_resp_headers(struct transaction_t *txn, long code)
  * nghttp2_session_mem_send2() calls when the stream's HTTP/2 flow-
  * control window is exhausted.
  */
-struct h2_body_chunk {
-    struct buf data;
-    size_t pos;
-};
-
-static void free_body_chunk(struct h2_body_chunk *chunk)
-{
-    buf_free(&chunk->data);
-    free(chunk);
-}
+/* Drop the consumed prefix of a response body once it reaches this size,
+   rather than waiting for the whole buffer to drain. */
+#define HTTP2_BODY_COMPACT_AT (64 * 1024)
 
 static nghttp2_ssize data_source_read_cb(nghttp2_session *sess __attribute__((unused)),
                                          int32_t stream_id,
@@ -687,20 +696,44 @@ static nghttp2_ssize data_source_read_cb(nghttp2_session *sess __attribute__((un
                                          nghttp2_data_source *source,
                                          void *user_data __attribute__((unused)))
 {
-    struct h2_body_chunk *chunk = source->ptr;
-    size_t remain = buf_len(&chunk->data) - chunk->pos;
+    struct http2_stream *strm = source->ptr;
+    size_t remain = buf_len(&strm->body) - strm->body_off;
     size_t n = length < remain ? length : remain;
 
-    if (n) memcpy(buf, buf_base(&chunk->data) + chunk->pos, n);
-    chunk->pos += n;
-
     syslog(LOG_DEBUG,
-           "http2_data_source_read_cb(id=%d, len=%zu): n=%zu, eof=%d",
-           stream_id, length, n, chunk->pos == buf_len(&chunk->data));
+           "http2_data_source_read_cb(id=%d, len=%zu): remain=%zu, n=%zu, complete=%d",
+           stream_id, length, remain, n, strm->body_complete);
 
-    if (chunk->pos == buf_len(&chunk->data)) {
+    if (!n) {
+        if (!strm->body_complete) {
+            /* The response is still being generated.  Park the provider;
+               resp_body_chunk() resumes it when the next chunk arrives.
+               Signalling EOF here instead would truncate the response. */
+            strm->body_deferred = 1;
+            return NGHTTP2_ERR_DEFERRED;
+        }
+
         *data_flags |= NGHTTP2_DATA_FLAG_EOF;
-        free_body_chunk(chunk);  /* Done with our copy */
+        return 0;
+    }
+
+    memcpy(buf, buf_base(&strm->body) + strm->body_off, n);
+    strm->body_off += n;
+
+    if (strm->body_complete && strm->body_off == buf_len(&strm->body)) {
+        *data_flags |= NGHTTP2_DATA_FLAG_EOF;
+    }
+
+    /* Reclaim what has already been handed to nghttp2, so that a large
+       response to a slow reader does not also retain everything already
+       sent. */
+    if (strm->body_off == buf_len(&strm->body)) {
+        buf_reset(&strm->body);
+        strm->body_off = 0;
+    }
+    else if (strm->body_off >= HTTP2_BODY_COMPACT_AT) {
+        buf_remove(&strm->body, 0, strm->body_off);
+        strm->body_off = 0;
     }
 
     return n;
@@ -736,40 +769,61 @@ static int resp_body_chunk(struct transaction_t *txn,
         retry_writev(txn->conn->logfd, iov, niov);
     }
 
-    /* Own copy of this chunk -- see struct h2_body_chunk's comment for
-     * why we can't just alias 'data' instead of copying it. */
-    struct h2_body_chunk *chunk = xzmalloc(sizeof(struct h2_body_chunk));
-    if (datalen) buf_setmap(&chunk->data, data, datalen);
-
-    nghttp2_data_provider2 prd = {
-        .source.ptr    = chunk,
-        .read_callback = data_source_read_cb
-    };
-
-    uint8_t flags = NGHTTP2_FLAG_END_STREAM;
-    if (txn->flags.te) {
+    if (txn->flags.te && (txn->flags.trailer & TRAILER_CMD5)) {
         if (!last_chunk) {
-            flags = NGHTTP2_FLAG_NONE;
-            if (datalen && (txn->flags.trailer & TRAILER_CMD5)) {
-                MD5Update(md5ctx, data, datalen);
-            }
+            if (datalen) MD5Update(md5ctx, data, datalen);
         }
-        else if (txn->flags.trailer) {
-            flags = NGHTTP2_FLAG_NONE;
-            if (txn->flags.trailer & TRAILER_CMD5) MD5Final(md5, md5ctx);
+        else {
+            MD5Final(md5, md5ctx);
         }
     }
 
-    syslog(LOG_DEBUG, "nghttp2_submit_data2(id=%d, datalen=%d, flags=%#x)",
-           strm->id, datalen, flags);
+    /* Our own copy -- see struct http2_stream's body comment for why we
+     * can't just alias 'data' instead of copying it. */
+    if (datalen) buf_appendmap(&strm->body, data, datalen);
+    if (last_chunk) strm->body_complete = 1;
 
-    int r = nghttp2_submit_data2(ctx->session, flags, strm->id, &prd);
-    if (r) {
-        syslog(LOG_ERR, "nghttp2_submit_data2: %s", nghttp2_strerror(r));
-        free_body_chunk(chunk);
-        return HTTP_SERVER_ERROR;
+    int r = 0;
+    if (!strm->body_submitted) {
+        /* nghttp2 accepts only one DATA submission per stream, so this runs
+           exactly once; every later chunk is appended above.
+
+           END_STREAM is decided here, on the first chunk, from flags that are
+           already final at this point: whether the response is chunked, and
+           whether trailers will follow (in which case the trailing HEADERS
+           closes the stream instead). */
+        uint8_t flags = NGHTTP2_FLAG_END_STREAM;
+        if (txn->flags.te && (txn->flags.trailer & ~TRAILER_PROXY)) {
+            flags = NGHTTP2_FLAG_NONE;
+        }
+
+        nghttp2_data_provider2 prd = {
+            .source.ptr    = strm,
+            .read_callback = data_source_read_cb
+        };
+
+        syslog(LOG_DEBUG, "nghttp2_submit_data2(id=%d, flags=%#x)",
+               strm->id, flags);
+
+        r = nghttp2_submit_data2(ctx->session, flags, strm->id, &prd);
+        if (r) {
+            syslog(LOG_ERR, "nghttp2_submit_data2: %s", nghttp2_strerror(r));
+            return HTTP_SERVER_ERROR;
+        }
+        strm->body_submitted = 1;
     }
-    else {
+    else if (strm->body_deferred) {
+        /* The provider ran dry while the response was still being generated.
+           Wake it now that there is more to send. */
+        strm->body_deferred = 0;
+        r = nghttp2_session_resume_data(ctx->session, strm->id);
+        if (r) {
+            syslog(LOG_ERR, "nghttp2_session_resume_data: %s",
+                   nghttp2_strerror(r));
+        }
+    }
+
+    {
         /* Write frame(s) */
         http2_output(txn->conn);
 


### PR DESCRIPTION
A response larger than the HTTP/2 flow control window is **truncated and the
stream is never closed**, so the client waits until its own timeout.

Reproduced against **`master` (72f1c5f)**, not only against the 3.8.3 we run in
production — and after #6200's nghttp2 v2 migration and after fdfbf7d, which
fixed a neighbouring problem in the same function three days ago.

## What happens

`resp_body_chunk()` submits a data provider for **every chunk** of the
response, but nghttp2 accepts only **one outstanding DATA submission per
stream**.

While the flow control window is open, each provider is drained immediately by
the `http2_output()` that follows, so the next submit succeeds and **the bug is
invisible**. Once the window closes — as soon as the response passes 65535
bytes — the current provider stops being drained and every later submit fails:

```
nghttp2_submit_data2: DATA or HEADERS frame has already been submitted for the stream
```

The rest of the body is lost, and the final chunk carrying `END_STREAM` is
refused along with the others, so the stream never closes. On a 594 KB REPORT:
**384 submissions for 134 reads**.

The error is logged, then `resp_body_chunk()` returns `HTTP_SERVER_ERROR` to a
caller that does not look at it — so nothing upstream learns the response was
truncated.

## The server's own trace

```
http2_data_source_read_cb(id=1, len=16384): n=3716, eof=1
http2_output(): sent 3725 bytes
http2_input(): read 26 bytes
http2_begin_frame_cb(id=0, type=8, flags=0)      <- WINDOW_UPDATE, connection
http2_begin_frame_cb(id=1, type=8, flags=0)      <- WINDOW_UPDATE, stream
nghttp2_session_mem_recv2: 26
http_proxy_check_input()
                                                 <- 25 s of silence
client closed connection
```

The `WINDOW_UPDATE` **is received and consumed**. There is simply nothing left
for nghttp2 to send: the later chunks were never accepted.

## Why it has not been seen

It needs a client that lets the window actually close:

| client | server | result |
|---|---|---|
| nghttp2 1.52.0 | 3.8.3 | 139 637 bytes, 19 ms |
| **nghttp2 1.68.0** | 3.8.3 | **stalls at 66 758 bytes** |
| nghttp2 1.52.0 | master | 594 362 bytes, 35 ms |
| **nghttp2 1.68.0** | master | **stalls at 69 251 bytes** |

HTTP/1.1 serves the whole response in every case, and the stall disappears if
the client opens a large window (`nghttp -w 24 -W 24`) — which confirms the
mechanism.

Reverse proxies that speak HTTP/1.1 to Cyrus hide it entirely; a client
reaching httpd directly over h2 does not.

## The fix

One provider per stream, fed from a buffer on `struct http2_stream`:

* `resp_body_chunk()` appends the chunk and submits **once**; later chunks
  resume the provider with `nghttp2_session_resume_data()`;
* the read callback returns `NGHTTP2_ERR_DEFERRED` when the buffer is empty but
  the response is not finished — signalling `EOF` there is what truncated it —
  and sets `NGHTTP2_DATA_FLAG_EOF` only on the last byte of the last chunk;
* `END_STREAM` is decided on the first chunk, from flags that are already final
  at that point: whether the response is chunked, and whether trailers follow;
* **the copy introduced by fdfbf7d is kept.** The caller's buffer is reused for
  the next chunk, so aliasing it was only safe while draining was synchronous.
  The consumed prefix is reclaimed once it passes 64 KB, so a large response to
  a slow reader does not also retain everything already sent.

`struct h2_body_chunk` becomes unused and is removed; its role moves to the
stream.

## Measured after the fix, against master

| case | result |
|---|---|
| 594 KB REPORT over h2, default window | **594 362 bytes, 30 ms** (was: stalled at 69 251) |
| the same over TLS | 594 362 bytes, 60 ms |
| h2 body compared with the h1.1 body | **byte for byte identical** |
| small response (852 bytes) | unchanged |
| `HEAD` / 204 with no body | unchanged |
| `sync-collection` (trailer path) | 46 827 bytes, ok |
| four concurrent 524 KB streams | all four complete and identical |

## Known limitation, stated rather than hidden

The buffer holds what the peer cannot yet receive, which is inherent — you
cannot discard bytes you have not sent. Cyrus generates its response
synchronously, so against a very slow client the lead can become the whole
response. Real backpressure would be the next step; this is still strictly
better than losing the bytes.

Cassandane was **not** run: `Test2::IPC` fails to create its temporary
directory in my container regardless of `TMPDIR`, which predates this change
and is unrelated to it. The verification above is direct, against a running
server, and covers the paths this patch rewrites.
