### PR TITLE
lmtpengine.c: don't underflow the buffer in clean_retpath

### DIFF
--- a/imap/lmtpengine.c
+++ b/imap/lmtpengine.c
@@ -485,7 +485,7 @@ static void clean_retpath(char *rpath)
         /* use strlen(rpath) so we move the NUL too */
         memmove(rpath, rpath+1, sl);
         sl--; /* string is one shorter now */
-        if (rpath[sl-1] == '>') {
+        if (sl && rpath[sl-1] == '>') {
             rpath[sl-1] = '\0';
         }
     }


### PR DESCRIPTION
If skipping the opening "<" makes our string length zero, don't underflow.  This can't happen today, because parseaddr() won't accept a bare "<", but it's a time bomb.