### PR TITLE
message.c: thread a memo by the blobId in X-ME-Memo-For

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_for_only
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_for_only
@@ -1,0 +1,59 @@
+#!perl
+use Cassandane::Tiny;
+
+# X-ME-Memo-For alone is enough to put a memo in its parent's thread:
+# neither In-Reply-To nor a matching Subject is needed.
+sub test_email_set_create_memo_for_only ($self)
+{
+  my $jmap = $self->{jmap};
+
+  $self->make_message('Email A', messageid => "msg1\@example.com");
+
+  my $res = $jmap->CallMethods([
+    [ 'Email/query', {}, 'R1' ],
+    [
+      'Email/get',
+      {
+        '#ids' => {
+          resultOf => 'R1',
+          name     => 'Email/query',
+          path     => '/ids'
+        },
+        properties => [ 'threadId', 'blobId' ],
+      },
+      'R2'
+    ],
+  ]);
+  my $parent = $res->[1][1]{list}[0];
+  $self->assert_not_null($parent->{threadId});
+
+  xlog $self, "Create memo with only X-ME-Memo-For linking it to the parent";
+  $res = $jmap->CallMethods([
+    [
+      'Email/set',
+      {
+        create => {
+          memo1 => {
+            mailboxIds             => { '$inbox' => JSON::true },
+            from                   => [ { email => 'from@local' } ],
+            subject                => 'unrelated subject',
+            messageId              => ["memo1\@example.com"],
+            'header:X-ME-Memo-For' => $parent->{blobId},
+            bodyStructure          => {
+              type   => 'text/plain',
+              partId => 'part1',
+            },
+            bodyValues => { part1 => { value => "memo" } },
+            keywords   => { '$memo' => JSON::true },
+          },
+        },
+      },
+      'R1'
+    ],
+  ]);
+
+  $self->assert_str_equals(
+    $parent->{threadId},
+    $res->[0][1]{created}{memo1}{threadId}
+  );
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_for_splitconv
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_for_splitconv
@@ -1,0 +1,100 @@
+#!perl
+use Cassandane::Tiny;
+
+# A memo carries the blobId of the message it annotates in X-ME-Memo-For.
+# The message-id index only records a conversation's base cid, so this
+# header is the only way a memo can find the right side of a split.
+sub test_email_set_create_memo_for_splitconv
+  : ConversationsMaxThread10
+    ($self)
+{
+  my $jmap = $self->{jmap};
+
+  xlog $self, "Create conversation with maximum thread count";
+  my $convsMaxThread
+    = $self->{instance}->{config}->get('conversations_max_thread');
+  $self->make_message('Email A', messageid => "msg1\@example.com");
+  my $lastUid = 1;
+  foreach my $i (2 .. $convsMaxThread) {
+    my $nextUid = $lastUid + 1;
+    $self->make_message(
+      "Re: Email A",
+      messageid     => "msg$nextUid\@example.com",
+      extra_headers => [ [ "in-reply-to", "<msg$lastUid\@example.com>" ], ],
+    );
+    $lastUid = $nextUid;
+  }
+
+  xlog $self, "Append one more reply, splitting the conversation";
+  my $splitUid = $lastUid + 1;
+  $self->make_message(
+    "Re: Email A",
+    messageid     => "msg$splitUid\@example.com",
+    extra_headers => [ [ "in-reply-to", "<msg$lastUid\@example.com>" ], ],
+  );
+
+  my $res = $jmap->CallMethods([
+    [ 'Email/query', {}, 'R1' ],
+    [
+      'Email/get',
+      {
+        '#ids' => {
+          resultOf => 'R1',
+          name     => 'Email/query',
+          path     => '/ids'
+        },
+        properties => [ 'threadId', 'messageId', 'blobId' ],
+      },
+      'R2'
+    ],
+  ]);
+
+  my %byMsgId = map { $_->{messageId}[0] => $_ } @{ $res->[1][1]{list} };
+
+  my $base  = $byMsgId{"msg1\@example.com"};
+  my $split = $byMsgId{"msg$splitUid\@example.com"};
+  $self->assert_not_null($base->{threadId});
+  $self->assert_not_null($split->{threadId});
+  $self->assert_str_not_equals($base->{threadId}, $split->{threadId});
+
+  my $make_memo = sub ($name, $parent) {
+    return {
+      mailboxIds           => { '$inbox' => JSON::true },
+      from                 => [ { email => 'from@local' } ],
+      subject              => "Re: Email A",
+      messageId            => ["$name\@example.com"],
+      inReplyTo            => $parent->{messageId},
+      'header:X-ME-Memo-For' => $parent->{blobId},
+      bodyStructure        => {
+        type   => 'text/plain',
+        partId => 'part1',
+      },
+      bodyValues => { part1 => { value => "memo $name" } },
+      keywords   => { '$memo' => JSON::true },
+    };
+  };
+
+  xlog $self, "Create memos on a message in each half of the split";
+  $res = $jmap->CallMethods([
+    [
+      'Email/set',
+      {
+        create => {
+          memoBase  => $make_memo->('memoBase',  $base),
+          memoSplit => $make_memo->('memoSplit', $split),
+        },
+      },
+      'R1'
+    ],
+  ]);
+
+  xlog $self, "Each memo joins the thread of the message it annotates";
+  $self->assert_str_equals(
+    $base->{threadId},
+    $res->[0][1]{created}{memoBase}{threadId}
+  );
+  $self->assert_str_equals(
+    $split->{threadId},
+    $res->[0][1]{created}{memoSplit}{threadId}
+  );
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_for_unknown
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_for_unknown
@@ -1,0 +1,60 @@
+#!perl
+use Cassandane::Tiny;
+
+# An X-ME-Memo-For that names no known message is ignored, and the memo
+# threads by In-Reply-To as it did before the header existed.
+sub test_email_set_create_memo_for_unknown ($self)
+{
+  my $jmap = $self->{jmap};
+
+  $self->make_message('Email A', messageid => "msg1\@example.com");
+
+  my $res = $jmap->CallMethods([
+    [ 'Email/query', {}, 'R1' ],
+    [
+      'Email/get',
+      {
+        '#ids' => {
+          resultOf => 'R1',
+          name     => 'Email/query',
+          path     => '/ids'
+        },
+        properties => [ 'threadId', 'messageId' ],
+      },
+      'R2'
+    ],
+  ]);
+  my $parent = $res->[1][1]{list}[0];
+  $self->assert_not_null($parent->{threadId});
+
+  xlog $self, "Create memo whose X-ME-Memo-For names no message";
+  $res = $jmap->CallMethods([
+    [
+      'Email/set',
+      {
+        create => {
+          memo1 => {
+            mailboxIds             => { '$inbox' => JSON::true },
+            from                   => [ { email => 'from@local' } ],
+            subject                => 'unrelated subject',
+            messageId              => ["memo1\@example.com"],
+            inReplyTo              => $parent->{messageId},
+            'header:X-ME-Memo-For' => 'G' . ('0' x 40),
+            bodyStructure          => {
+              type   => 'text/plain',
+              partId => 'part1',
+            },
+            bodyValues => { part1 => { value => "memo" } },
+            keywords   => { '$memo' => JSON::true },
+          },
+        },
+      },
+      'R1'
+    ],
+  ]);
+
+  $self->assert_str_equals(
+    $parent->{threadId},
+    $res->[0][1]{created}{memo1}{threadId}
+  );
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_inreplyto_splitconv
+++ b/cassandane/tiny-tests/JMAPEmail/email_set_create_memo_inreplyto_splitconv
@@ -1,0 +1,85 @@
+#!perl
+use Cassandane::Tiny;
+
+# Without X-ME-Memo-For, a memo follows In-Reply-To through the split
+# redirect to the current conversation, like any other reply.
+sub test_email_set_create_memo_inreplyto_splitconv
+  : ConversationsMaxThread10
+    ($self)
+{
+  my $jmap = $self->{jmap};
+
+  xlog $self, "Create conversation with maximum thread count";
+  my $convsMaxThread
+    = $self->{instance}->{config}->get('conversations_max_thread');
+  $self->make_message('Email A', messageid => "msg1\@example.com");
+  my $lastUid = 1;
+  foreach my $i (2 .. $convsMaxThread) {
+    my $nextUid = $lastUid + 1;
+    $self->make_message(
+      "Re: Email A",
+      messageid     => "msg$nextUid\@example.com",
+      extra_headers => [ [ "in-reply-to", "<msg$lastUid\@example.com>" ], ],
+    );
+    $lastUid = $nextUid;
+  }
+
+  xlog $self, "Append one more reply, splitting the conversation";
+  my $splitUid = $lastUid + 1;
+  $self->make_message(
+    "Re: Email A",
+    messageid     => "msg$splitUid\@example.com",
+    extra_headers => [ [ "in-reply-to", "<msg$lastUid\@example.com>" ], ],
+  );
+
+  my $res = $jmap->CallMethods([
+    [ 'Email/query', {}, 'R1' ],
+    [
+      'Email/get',
+      {
+        '#ids' => {
+          resultOf => 'R1',
+          name     => 'Email/query',
+          path     => '/ids'
+        },
+        properties => [ 'threadId', 'messageId' ],
+      },
+      'R2'
+    ],
+  ]);
+
+  my %byMsgId = map { $_->{messageId}[0] => $_ } @{ $res->[1][1]{list} };
+  my $base    = $byMsgId{"msg1\@example.com"};
+  my $split   = $byMsgId{"msg$splitUid\@example.com"};
+  $self->assert_str_not_equals($base->{threadId}, $split->{threadId});
+
+  xlog $self, "Create memo replying to the message in the split half";
+  $res = $jmap->CallMethods([
+    [
+      'Email/set',
+      {
+        create => {
+          memo1 => {
+            mailboxIds    => { '$inbox' => JSON::true },
+            from          => [ { email => 'from@local' } ],
+            subject       => "Re: Email A",
+            messageId     => ["memo1\@example.com"],
+            inReplyTo     => $split->{messageId},
+            bodyStructure => {
+              type   => 'text/plain',
+              partId => 'part1',
+            },
+            bodyValues => { part1 => { value => "memo" } },
+            keywords   => { '$memo' => JSON::true },
+          },
+        },
+      },
+      'R1'
+    ],
+  ]);
+
+  $self->assert_str_equals(
+    $split->{threadId},
+    $res->[0][1]{created}{memo1}{threadId}
+  );
+}

--- a/changes/next/cyr-2796-memo-fixes
+++ b/changes/next/cyr-2796-memo-fixes
@@ -1,0 +1,28 @@
+Description:
+
+A memo (a message with the `$memo` keyword) can name the message it
+annotates by JMAP blobId in a new X-ME-Memo-For header.  Cyrus then puts
+the memo in that message's conversation directly, which is the only way a
+memo can land on the right side of a split conversation.
+
+
+Documentation:
+
+docsrc/reference/extensions/memo-threading.md
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.  Memos without the header thread as before.  Clients should start
+sending X-ME-Memo-For when creating memos.
+
+
+GitHub issue:
+
+None; see https://github.com/cyrusimap/cyrus-imapd/pull/6345 for the
+approach this replaces.

--- a/doc/logfmt-keys
+++ b/doc/logfmt-keys
@@ -56,6 +56,7 @@ msg.from                the message's envelope sender
 msg.guid                the message's guid
 msg.id                  the message's RFC 5322 Message-ID
 msg.imapuid             the message's IMAP uid within its mailbox
+msg.memofor             the blobId a memo names in its X-ME-Memo-For header
 msg.modseq              the message's modseq
 msg.size                the message's size in bytes
 msg.subject             the message's subject, as UTF-8

--- a/docsrc/reference/extensions/memo-threading.md
+++ b/docsrc/reference/extensions/memo-threading.md
@@ -1,0 +1,33 @@
+# Memo threading
+
+A memo is a message with the `$memo` keyword, stored by a client as a note on
+another message in the same account.  Conversation assignment treats a memo
+differently from ordinary mail: a memo always belongs to the conversation of
+the message it annotates, it never matches on Subject, and it never causes a
+conversation to split when the `conversations_max_thread` limit is reached.
+
+## X-ME-Memo-For
+
+A client creating a memo should set this header to the JMAP `blobId` of the
+message the memo is for, exactly as JMAP reports it, with its leading `G`:
+
+```
+X-ME-Memo-For: G3b9b2e1a0f4d5c6e7a8b9c0d1e2f3a4b5c6d7e8f
+```
+
+Cyrus resolves the blobId through the conversations database to the annotated
+message's current conversation, including the base conversation id when that
+message is in a split conversation.  This is the only reliable way to place a
+memo on a message in a split conversation: the message-id index records only
+base conversation ids, so `In-Reply-To` alone always resolves to the original
+conversation, not the split one.
+
+The header is honoured only on messages carrying `$memo`.  If the blobId is
+malformed or names no message in the account, Cyrus logs
+`conversations.memo.noparent` at debug level and falls back to `In-Reply-To`.
+
+## Fallbacks
+
+Without `X-ME-Memo-For`, a memo joins the first conversation of the message
+named in its `In-Reply-To` header.  Failing that, it threads like ordinary
+mail via `References` and `X-ME-Message-ID`, still without the Subject check.

--- a/docsrc/reference/extensions/memo-threading.md
+++ b/docsrc/reference/extensions/memo-threading.md
@@ -19,8 +19,8 @@ Cyrus resolves the blobId through the conversations database to the annotated
 message's current conversation, including the base conversation id when that
 message is in a split conversation.  This is the only reliable way to place a
 memo on a message in a split conversation: the message-id index records only
-base conversation ids, so `In-Reply-To` alone always resolves to the original
-conversation, not the split one.
+base conversation ids, so `In-Reply-To` alone cannot tell which side of a
+split the annotated message is on.
 
 The header is honoured only on messages carrying `$memo`.  If the blobId is
 malformed or names no message in the account, Cyrus logs
@@ -28,6 +28,7 @@ malformed or names no message in the account, Cyrus logs
 
 ## Fallbacks
 
-Without `X-ME-Memo-For`, a memo joins the first conversation of the message
-named in its `In-Reply-To` header.  Failing that, it threads like ordinary
-mail via `References` and `X-ME-Message-ID`, still without the Subject check.
+Without `X-ME-Memo-For`, a memo joins the conversation of the message named
+in its `In-Reply-To` header, following any split to the current conversation
+as an ordinary reply would.  Failing that, it threads like ordinary mail via
+`References` and `X-ME-Message-ID`, still without the Subject check.

--- a/imap/message.c
+++ b/imap/message.c
@@ -3981,6 +3981,49 @@ out:
 }
 
 /*
+ * A memo names the message it annotates by blobId in X-ME-Memo-For.  That
+ * message's G record carries the cid and basecid a split has moved it to,
+ * which the message-id index cannot tell us.  Returns true and fills in
+ * record->cid and record->basecid when the parent is known.
+ */
+static bool memo_parent_cid_lookup(struct conversations_state *state,
+                                   message_t *msg,
+                                   struct mailbox *mailbox,
+                                   struct index_record *record)
+{
+    struct buf buf = BUF_INITIALIZER;
+    struct message_guid guid;
+    bool found = false;
+
+    int r = message_get_field(msg,
+                              "X-ME-Memo-For",
+                              MESSAGE_RAW | MESSAGE_TRIM,
+                              &buf);
+    if (r || !buf_len(&buf)) {
+        goto done;
+    }
+
+    const char *blobid = buf_cstring(&buf);
+    if (blobid[0] != 'G' || !message_guid_decode(&guid, blobid + 1)) {
+        goto done;
+    }
+
+    found = conversations_guid_cid_lookup(state,
+                                          message_guid_encode(&guid),
+                                          record);
+    if (!found) {
+        xsyslog_ev(LOG_DEBUG, "conversations.memo.noparent",
+                   lf_mailbox(mailbox),
+                   lf_msgrecord(record),
+                   lf_s("msg.memofor", blobid));
+    }
+
+done:
+    buf_free(&buf);
+    return found;
+}
+
+/*
  * Update the conversations database for the given
  * mailbox, to account for the given message.
  * @body may be NULL, in which case we get everything
@@ -4014,6 +4057,12 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
         if (conversations_guid_cid_lookup(state, message_guid_encode(&record->guid), record)) {
             mustkeep = 1;
         }
+        bool is_memo = mailbox_record_hasflag(mailbox, record, "$memo");
+        if (!record->cid && is_memo
+            && memo_parent_cid_lookup(state, msg, mailbox, record))
+        {
+            mustkeep = 1;
+        }
         if (!record->cid) record->cid = arrayu64_max(&matchlist);
         if (!record->cid) {
             record->cid = generate_conversation_id(record);
@@ -4021,7 +4070,7 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
         }
         if (!mustkeep) {
             /* Do not split conversations for messages with '$memo' flag */
-            mustkeep = mailbox_record_hasflag(mailbox, record, "$memo");
+            mustkeep = is_memo;
         }
         if (!mustkeep && !record->basecid) {
             /* try finding a CID in the match list, or if we came in with it */

--- a/imap/message.c
+++ b/imap/message.c
@@ -4043,6 +4043,7 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
     int r = 0;
     struct mailbox *local_mailbox = NULL;
     message_t *msg = message_new_from_record(mailbox, record);
+    bool is_memo = mailbox_record_hasflag(mailbox, record, "$memo");
 
     /* extract existing conversations for this message */
     r = extract_convdata(state, msg, &msgidlist, &matchlist, &msubj);
@@ -4057,7 +4058,6 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
         if (conversations_guid_cid_lookup(state, message_guid_encode(&record->guid), record)) {
             mustkeep = 1;
         }
-        bool is_memo = mailbox_record_hasflag(mailbox, record, "$memo");
         if (!record->cid && is_memo
             && memo_parent_cid_lookup(state, msg, mailbox, record))
         {
@@ -4067,10 +4067,6 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
         if (!record->cid) {
             record->cid = generate_conversation_id(record);
             if (record->cid) mustkeep = 1;
-        }
-        if (!mustkeep) {
-            /* Do not split conversations for messages with '$memo' flag */
-            mustkeep = is_memo;
         }
         if (!mustkeep && !record->basecid) {
             /* try finding a CID in the match list, or if we came in with it */
@@ -4103,8 +4099,11 @@ EXPORTED int message_update_conversations(struct conversations_state *state,
 
     if (!conv) conv = conversation_new();
 
+    /* A memo belongs with the message it annotates, so it never splits */
     uint32_t max_thread = config_getint(IMAPOPT_CONVERSATIONS_MAX_THREAD);
-    if (conv->exists >= max_thread && !mustkeep && !record->silentupdate) {
+    if (conv->exists >= max_thread && !mustkeep && !is_memo
+        && !record->silentupdate)
+    {
         /* time to reset the conversation */
         conversation_id_t was = record->cid;
         record->cid = generate_conversation_id(record);


### PR DESCRIPTION
This adds a new header, which - if present - forces the message into the thread with the message with the matching blobId (if present).

This is safe to deploy before or after the associated change - they both start working once both are present.