### PR TITLE
jmap_calendar.c, caldav_util.c: never omit DTSTAMP/updated

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_no_dtstart
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_no_dtstart
@@ -22,5 +22,7 @@ EOF
     my $event = $self->putandget_vevent($uid, $ical);
     $self->assert_not_null($event);
     $self->assert_str_equals('0000-00-00T00:00:00', $event->{start});
-    $self->assert_null($event->{updated});
+    # Cyrus adds a DTSTAMP on any component missing one,
+    # so "updated" is never absent.
+    $self->assert_not_null($event->{updated});
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_peruser_only
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_peruser_only
@@ -1,0 +1,85 @@
+#!perl
+use Cassandane::Tiny;
+
+use Text::VCardFast qw(vcard2hash);
+
+sub test_calendarevent_set_updated_peruser_only
+    ($self)
+{
+    my $ownerJmap = $self->{jmap};
+    my $ownerCaldav = $self->{caldav};
+    my $default_cal = $self->default_user->calendars->default;
+    my $default_cal_id = $default_cal->id;
+
+    xlog $self, "create sharee and share calendar";
+    my $sharee_user = $self->{instance}->create_user('sharee');
+    my $shareeJmap = $sharee_user->jmap;
+    $default_cal->share_with($sharee_user => [qw(mayReadItems mayWriteAll)]);
+
+    xlog $self, "owner creates event";
+    my $res = $ownerJmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                event => {
+                    version => '2.0',
+                    calendarIds => {
+                        $default_cal_id => JSON::true,
+                    },
+                    start => '2026-01-02T03:04:05',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                    title => 'event',
+                },
+            },
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            ids => [ '#event' ],
+            properties => ['updated', 'x-href'],
+        }, 'R2'],
+    ]);
+    my $eventId = $res->[0][1]{created}{event}{id};
+    $self->assert_not_null($eventId);
+    my $updated = $res->[1][1]{list}[0]{updated};
+    my $href = $res->[1][1]{list}[0]{'x-href'};
+    $self->assert_not_null($updated);
+
+    $res = $ownerCaldav->Request('GET', "" . $href);
+    my $dtstamp = vcard2hash($res->{content})->{objects}[0]{objects}[0]
+        {properties}{dtstamp}[0]{value};
+    $self->assert_not_null($dtstamp);
+
+    sleep(1);
+
+    xlog $self, "sharee updates only a per-user property";
+    $res = $shareeJmap->CallMethods([
+        ['CalendarEvent/set', {
+            accountId => 'cassandane',
+            update => {
+                $eventId => {
+                    color => 'blue',
+                },
+            },
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            accountId => 'cassandane',
+            ids => [ $eventId ],
+            properties => ['updated'],
+        }, 'R2'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+    $self->assert_str_equals($updated, $res->[1][1]{list}[0]{updated});
+
+    xlog $self, "owner still sees the unchanged updated and DTSTAMP";
+    $res = $ownerJmap->CallMethods([
+        ['CalendarEvent/get', {
+            ids => [ $eventId ],
+            properties => ['updated'],
+        }, 'R1'],
+    ]);
+    $self->assert_str_equals($updated, $res->[0][1]{list}[0]{updated});
+
+    $res = $ownerCaldav->Request('GET', "" . $href);
+    my $newDtstamp = vcard2hash($res->{content})->{objects}[0]{objects}[0]
+        {properties}{dtstamp}[0]{value};
+    $self->assert_str_equals($dtstamp, $newDtstamp);
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_scheduled_not_source
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_scheduled_not_source
@@ -11,7 +11,6 @@ sub test_calendarevent_set_updated_scheduled_not_source
     my $t = DateTime->now();
     $t->set_time_zone('Etc/UTC');
     my $start = $t->strftime('%Y-%m-%dT%H:%M:%S');
-    my $now= $t->strftime('%Y-%m-%dT%H:%M:%SZ');
     $t->add(DateTime::Duration->new(days => -2));
     my $past = $t->strftime('%Y-%m-%dT%H:%M:%SZ');
 
@@ -46,8 +45,11 @@ sub test_calendarevent_set_updated_scheduled_not_source
             properties => ['updated'],
         }, 'R2'],
     ]);
-    $self->assert_str_equals($past, $res->[1][1]{list}[0]{updated});
+    my $updated = $res->[1][1]{list}[0]{updated};
+    $self->assert($past lt $updated);
     my $eventId = $res->[1][1]{list}[0]{id};
+
+    sleep(1);
 
     xlog "Change partstat of cassandane";
     $res = $jmap->CallMethods([
@@ -64,14 +66,15 @@ sub test_calendarevent_set_updated_scheduled_not_source
         }, 'R2'],
     ]);
     $self->assert(exists $res->[0][1]{updated}{$eventId});
-    $self->assert_str_equals($past, $res->[1][1]{list}[0]{updated});
+    $self->assert($updated lt $res->[1][1]{list}[0]{updated});
+    $updated = $res->[1][1]{list}[0]{updated};
 
     xlog "Client updates updated property themselves";
     $res = $jmap->CallMethods([
         ['CalendarEvent/set', {
             update => {
                 $eventId => {
-                    updated => $now,
+                    updated => $past,
                 },
             },
         }, 'R1'],
@@ -81,5 +84,5 @@ sub test_calendarevent_set_updated_scheduled_not_source
         }, 'R2'],
     ]);
     $self->assert(exists $res->[0][1]{updated}{$eventId});
-    $self->assert_str_equals($now, $res->[1][1]{list}[0]{updated});
+    $self->assert_date_matches($updated, $res->[1][1]{list}[0]{updated}, 2);
 }

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_shared_sharee_creates
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_shared_sharee_creates
@@ -1,0 +1,60 @@
+#!perl
+use Cassandane::Tiny;
+
+use Text::VCardFast qw(vcard2hash);
+
+sub test_calendarevent_set_updated_shared_sharee_creates
+    ($self)
+{
+    my $ownerCaldav = $self->{caldav};
+    my $default_cal = $self->default_user->calendars->default;
+    my $default_cal_id = $default_cal->id;
+
+    xlog $self, "create sharee and share calendar";
+    my $sharee_user = $self->{instance}->create_user('sharee');
+    my $shareeJmap = $sharee_user->jmap;
+    $default_cal->share_with($sharee_user => [qw(mayReadItems mayWriteAll)]);
+
+    xlog $self, "sharee creates event where owner is an invitee, not organizer";
+    my $res = $shareeJmap->CallMethods([
+        ['CalendarEvent/set', {
+            accountId => 'cassandane',
+            create => {
+                event => {
+                    version => '2.0',
+                    calendarIds => {
+                        $default_cal_id => JSON::true,
+                    },
+                    start => '2026-01-02T03:04:05',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                    title => 'event',
+                    organizerCalendarAddress => 'mailto:someone@example.com',
+                    participants => {
+                        cassandane => {
+                            calendarAddress => 'mailto:cassandane@example.com',
+                            expectReply => JSON::true,
+                            participationStatus => 'accepted',
+                        },
+                    },
+                },
+            },
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            accountId => 'cassandane',
+            ids => [ '#event' ],
+            properties => ['isOrigin', 'updated', 'x-href'],
+        }, 'R2'],
+    ]);
+    my $event = $res->[1][1]{list}[0];
+    $self->assert_not_null($event);
+    $self->assert_cmp_deeply(superhashof({
+        isOrigin => jfalse(),
+        updated  => ignore(),
+    }), $event);
+
+    xlog $self, "assert DTSTAMP is present in the stored iCalendar";
+    $res = $ownerCaldav->Request('GET', "" . $event->{'x-href'});
+    my $vevent = vcard2hash($res->{content})->{objects}[0]{objects}[0];
+    $self->assert_not_null($vevent->{properties}{dtstamp}[0]{value});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_shared_sharee_updates
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_shared_sharee_updates
@@ -1,0 +1,95 @@
+#!perl
+use Cassandane::Tiny;
+
+use Text::VCardFast qw(vcard2hash);
+
+sub test_calendarevent_set_updated_shared_sharee_updates
+    ($self)
+{
+    my $ownerJmap = $self->{jmap};
+    my $ownerCaldav = $self->{caldav};
+    my $default_cal = $self->default_user->calendars->default;
+    my $default_cal_id = $default_cal->id;
+
+    xlog $self, "create sharee and share calendar";
+    my $sharee_user = $self->{instance}->create_user('sharee');
+    my $shareeJmap = $sharee_user->jmap;
+    $default_cal->share_with($sharee_user => [qw(mayReadItems mayWriteAll)]);
+
+    xlog $self, "owner creates event where they and sharee are invitees";
+    my $res = $ownerJmap->CallMethods([
+        ['CalendarEvent/set', {
+            create => {
+                event => {
+                    version => '2.0',
+                    calendarIds => {
+                        $default_cal_id => JSON::true,
+                    },
+                    start => '2026-01-02T03:04:05',
+                    timeZone => 'Etc/UTC',
+                    duration => 'PT1H',
+                    title => 'event',
+                    organizerCalendarAddress => 'mailto:someone@example.com',
+                    participants => {
+                        cassandane => {
+                            calendarAddress => 'mailto:cassandane@example.com',
+                            expectReply => JSON::true,
+                            participationStatus => 'accepted',
+                        },
+                        sharee => {
+                            calendarAddress => 'mailto:sharee@example.com',
+                            expectReply => JSON::true,
+                            participationStatus => 'needs-action',
+                        },
+                    },
+                },
+            },
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            ids => [ '#event' ],
+            properties => ['updated', 'x-href'],
+        }, 'R2'],
+    ]);
+    my $eventId = $res->[0][1]{created}{event}{id};
+    $self->assert_not_null($eventId);
+    my $updated = $res->[1][1]{list}[0]{updated};
+    my $href = $res->[1][1]{list}[0]{'x-href'};
+
+    $res = $ownerCaldav->Request('GET', "" . $href);
+    my $dtstamp = vcard2hash($res->{content})->{objects}[0]{objects}[0]
+        {properties}{dtstamp}[0]{value};
+    $self->assert_not_null($dtstamp);
+
+    sleep(1);
+
+    xlog $self, "sharee (an invitee, not the organizer) updates the event";
+    $res = $shareeJmap->CallMethods([
+        ['CalendarEvent/set', {
+            accountId => 'cassandane',
+            update => {
+                $eventId => {
+                    'participants/sharee/participationStatus' => 'accepted',
+                },
+            },
+        }, 'R1'],
+        ['CalendarEvent/get', {
+            accountId => 'cassandane',
+            ids => [ $eventId ],
+            properties => ['isOrigin', 'updated'],
+        }, 'R2'],
+    ]);
+    $self->assert(exists $res->[0][1]{updated}{$eventId});
+    my $event = $res->[1][1]{list}[0];
+    $self->assert_cmp_deeply(superhashof({
+        isOrigin => jfalse(),
+        updated  => ignore(),
+    }), $event);
+    $self->assert($updated lt $event->{updated});
+
+    xlog $self, "assert DTSTAMP was bumped in the stored iCalendar too";
+    $res = $ownerCaldav->Request('GET', "" . $href);
+    my $newDtstamp = vcard2hash($res->{content})->{objects}[0]{objects}[0]
+        {properties}{dtstamp}[0]{value};
+    $self->assert_not_null($newDtstamp);
+    $self->assert_str_not_equals($dtstamp, $newDtstamp);
+}

--- a/imap/caldav_util.c
+++ b/imap/caldav_util.c
@@ -217,6 +217,28 @@ EXPORTED int caldav_is_personalized(struct mailbox *mailbox,
     return 0;
 }
 
+/* RFC 5545 requires DTSTAMP on every VEVENT/VTODO/VJOURNAL/VFREEBUSY,
+ * and JSCalendar's "updated" is also mandatory.
+ * Make sure we never have a component without one. */
+static void add_missing_dtstamp(icalcomponent *ical, icalcomponent_kind kind,
+                                time_t t)
+{
+    icalcomponent *comp;
+
+    if (!utc_zone) utc_zone = icaltimezone_get_utc_timezone();
+
+    icaltimetype tt = icaltime_from_timet_with_zone(t, 0, utc_zone);
+
+    for (comp = icalcomponent_get_first_component(ical, kind);
+         comp;
+         comp = icalcomponent_get_next_component(ical, kind)) {
+
+        if (!icalcomponent_get_first_property(comp, ICAL_DTSTAMP_PROPERTY)) {
+            icalcomponent_add_property(comp, icalproperty_new_dtstamp(tt));
+        }
+    }
+}
+
 EXPORTED icalcomponent *caldav_record_to_ical(struct mailbox *mailbox,
                                               const struct caldav_data *cdata,
                                               const char *userid,
@@ -231,6 +253,11 @@ EXPORTED icalcomponent *caldav_record_to_ical(struct mailbox *mailbox,
     }
 
     ical = record_to_ical(mailbox, &record, schedule_addresses);
+    if (ical) {
+        icalcomponent *comp = icalcomponent_get_first_real_component(ical);
+        add_missing_dtstamp(ical,
+                            icalcomponent_isa(comp), record.internaldate.tv_sec);
+    }
 
     if (userid && (namespace_calendar.allow & ALLOW_USERDATA)) {
         struct buf userdata = BUF_INITIALIZER;
@@ -1024,6 +1051,8 @@ EXPORTED int caldav_store_resource(struct transaction_t *txn, icalcomponent *ica
         txn->error.precond = CALDAV_SUPP_COMP;
         return HTTP_FORBIDDEN;
     }
+
+    add_missing_dtstamp(ical, kind, time(0) /*now*/);
 
     if (!annotatemore_lookupmask_mbox(mailbox, prop_annot, txn->userid, &attrib)
         && attrib.len) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -129,8 +129,8 @@ static char *_imip_calendar_address(const strarray_t *schedule_addresses)
     return strconcat("mailto:", addr, NULL);
 }
 
-/* v29 is just v28, bumped to ensure all entries are JSCalendar 2.0 */
-#define JMAPCACHE_CALVERSION 29
+/* v30 is just v29, bumped so that we evict events missing "update" property */
+#define JMAPCACHE_CALVERSION 30
 
 // clang-format off
 static jmap_method_t jmap_calendar_methods_standard[] = {
@@ -4910,8 +4910,8 @@ static int createevent_toical(jmap_req_t *req,
     }
 
 
-    if (jsevent_is_origin(create->jsevent, &create->schedule_addresses) && !create->is_copy) {
-        // Set updated and created.
+    if (!create->is_copy) {
+        // Set updated.
         time_t t_now = time(NULL);
         char s[RFC3339_DATETIME_MAX+1] = { 0 };
         time_to_rfc3339(t_now, s, RFC3339_DATETIME_MAX+1);
@@ -4920,46 +4920,53 @@ static int createevent_toical(jmap_req_t *req,
         json_object_set(create->jsevent, "updated", jupdated);
         json_object_set(create->serverset, "updated", jupdated);
 
-        json_t *jcreated = json_object_get(create->jsevent, "created");
-        const char *created = json_string_value(jcreated);
-        time_t t_created = t_now;
-        if (created && time_from_iso8601(created, &t_created) == -1) {
-            t_created = t_now;
-        }
-        if (JNULL(jcreated) || t_created > t_now) {
-            json_object_set(create->jsevent, "created", jupdated);
-            json_object_set(create->serverset, "created", jupdated);
-        }
-        json_decref(jupdated);
+        if (jsevent_is_origin(create->jsevent, &create->schedule_addresses)) {
+            // Set created.
+            json_t *jcreated = json_object_get(create->jsevent, "created");
+            const char *created = json_string_value(jcreated);
+            time_t t_created = t_now;
+            if (created && time_from_iso8601(created, &t_created) == -1) {
+                t_created = t_now;
+            }
+            if (JNULL(jcreated) || t_created > t_now) {
+                json_object_set(create->jsevent, "created", jupdated);
+                json_object_set(create->serverset, "created", jupdated);
+            }
 
-        // Set sequence if not already set.
-        if (!json_object_get(create->jsevent, "sequence")) {
-            json_object_set_new(create->jsevent, "sequence", json_integer(0));
-        }
+            // Set sequence if not already set.
+            if (!json_object_get(create->jsevent, "sequence")) {
+                json_object_set_new(create->jsevent,
+                                    "sequence", json_integer(0));
+            }
 
-        // XXX quirk: former implementation set organizer address
-        if (JNULL(json_object_get(create->jsevent, "organizerCalendarAddress"))) {
-            json_t *jparts = json_object_get(create->jsevent, "participants");
-            json_t *jpart;
-            const char *key;
-            json_object_foreach(jparts, key, jpart) {
-                if (JNOTNULL(json_object_get(jpart, "calendarAddress"))) {
-                    // At least one scheduled Participant is set.
-                    char *orga =
-                        _imip_calendar_address(&create->schedule_addresses);
-                    if (orga) {
-                        json_t *jorga = json_string(orga);
-                        json_object_set(create->jsevent,
-                                "organizerCalendarAddress", jorga);
-                        json_object_set(create->serverset,
-                                "organizerCalendarAddress", jorga);
-                        json_decref(jorga);
-                        free(orga);
+            // XXX quirk: former implementation set organizer address
+            if (JNULL(json_object_get(create->jsevent,
+                                      "organizerCalendarAddress"))) {
+                json_t *jparts = json_object_get(create->jsevent,
+                                                 "participants");
+                json_t *jpart;
+                const char *key;
+                json_object_foreach(jparts, key, jpart) {
+                    if (JNOTNULL(json_object_get(jpart, "calendarAddress"))) {
+                        // At least one scheduled Participant is set.
+                        char *orga =
+                            _imip_calendar_address(&create->schedule_addresses);
+                        if (orga) {
+                            json_t *jorga = json_string(orga);
+                            json_object_set(create->jsevent,
+                                            "organizerCalendarAddress", jorga);
+                            json_object_set(create->serverset,
+                                            "organizerCalendarAddress", jorga);
+                            json_decref(jorga);
+                            free(orga);
+                        }
                     }
+                    break;
                 }
-                break;
             }
         }
+
+        json_decref(jupdated);
     }
 
     jscal_cfg_t cfg = { .emailalert_default_uri = emailalert_recipient,
@@ -5741,24 +5748,10 @@ done:
     *new_eventp = new_event;
 }
 
-static void updateevent_bump_sequence(json_t *old_event,
-                                      json_t *new_event,
-                                      json_t *update,
-                                      strarray_t *schedule_addresses)
+/* Return true if any shared property is getting updated */
+static bool updateevent_patch_updates_shared_prop(json_t *old_event,
+                                                   json_t *new_event)
 {
-    /* Bump sequence iff... */
-
-    /* ... server is the source of the event */
-    json_t *jorga = json_object_get(new_event, "organizerCalendarAddress");
-    if (JNOTNULL(jorga)) {
-        const char *addr = json_string_value(jorga);
-        if (addr && !strncasecmp(addr, "mailto:", 7) &&
-                !strarray_contains(schedule_addresses, addr + 7)) {
-            return;
-        }
-    }
-
-    /* ... a non per-user property got updated */
     int updates_shared_prop = 0;
     json_t *jpatch = jmap_patchobject_create(old_event, new_event, 0/*no_remove*/);
     const char *path;
@@ -5785,6 +5778,28 @@ static void updateevent_bump_sequence(json_t *old_event,
         }
     }
     json_decref(jpatch);
+    return updates_shared_prop;
+}
+
+static void updateevent_bump_sequence(json_t *old_event,
+                                      json_t *new_event,
+                                      json_t *update,
+                                      strarray_t *schedule_addresses,
+                                      bool updates_shared_prop)
+{
+    /* Bump sequence iff... */
+
+    /* ... server is the source of the event */
+    json_t *jorga = json_object_get(new_event, "organizerCalendarAddress");
+    if (JNOTNULL(jorga)) {
+        const char *addr = json_string_value(jorga);
+        if (addr && !strncasecmp(addr, "mailto:", 7) &&
+                !strarray_contains(schedule_addresses, addr + 7)) {
+            return;
+        }
+    }
+
+    /* ... a non per-user property got updated */
     if (!updates_shared_prop)
         return;
 
@@ -5915,8 +5930,12 @@ static int updateevent_apply_patch(jmap_req_t *req,
 
     updateevent_validate_ids(update->old_event, new_event, invalid);
 
+    bool updates_shared_prop =
+        updateevent_patch_updates_shared_prop(update->old_event, new_event);
+
     updateevent_bump_sequence(update->old_event, new_event,
-            update->serverset, update->schedule_addresses);
+            update->serverset, update->schedule_addresses,
+            updates_shared_prop);
 
     // Do not allow to set method - but ignore keeping it.
     const char *new_method =
@@ -5929,14 +5948,18 @@ static int updateevent_apply_patch(jmap_req_t *req,
         }
     }
 
-    // Set updated.
-    if (jsevent_is_origin(new_event, update->schedule_addresses)) {
+    if (updates_shared_prop) {
+        // Set updated.
         char s[RFC3339_DATETIME_MAX+1] = { 0 };
         time_to_rfc3339(time(NULL), s, RFC3339_DATETIME_MAX+1);
         json_t *jupdated = json_string(s);
         json_object_set(new_event, "updated", jupdated);
         json_object_set(update->serverset, "updated", jupdated);
         json_decref(jupdated);
+    }
+    else {
+        json_object_set(new_event, "updated",
+                json_object_get(update->old_event, "updated"));
     }
 
     /* Convert to iCalendar */


### PR DESCRIPTION
JSCalendar states that "updated" mandatory, but we were only setting it in CalendarEvent/set when the acting account originated the event. An attendee's copy on a shared calendar could be created or edited with jsevent_is_origin() false, silently dropping the property from both the JSON and the stored DTSTAMP.