### PR TITLE
dav_db.c: hold the namespace lock while a user's DAV DB is open

### DIFF
--- a/cassandane/tiny-tests/Delete/admin_inbox_imm
+++ b/cassandane/tiny-tests/Delete/admin_inbox_imm
@@ -74,6 +74,11 @@ EOF
     xlog $self, "Run squatter";
     $self->{instance}->run_command({cyrus => 1}, 'squatter');
 
+    # nothing else here uses DAV, and dav.db isn't created until something does
+    xlog $self, "Give the user a dav.db";
+    $self->{instance}->run_command({cyrus => 1},
+                                   'dav_reconstruct', 'cassandane');
+
     xlog $self, "Verify user data files/directories exist";
     my $data = $self->{instance}->run_mbpath('-u', 'cassandane');
     $self->assert_file_test($data->{user}{'sub'}, '-f');

--- a/imap/dav_db.c
+++ b/imap/dav_db.c
@@ -329,15 +329,23 @@ EXPORTED void dav_getpath_byuserid(struct buf *fname, const char *userid)
     free(path);
 }
 
+/* tagged with the namespace whose lock protects the files, so deleting
+   a user can report a handle still open on them */
+static sqldb_t *_dav_open(const struct buf *fname, int scope, const char *owner)
+{
+    return sqldb_open_full(buf_cstring(fname), CMD_CREATE, DB_VERSION,
+                           davdb_upgrade,
+                           config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000,
+                           scope, owner);
+}
+
 EXPORTED sqldb_t *dav_open_userid(const char *userid)
 {
     if (reconstruct_db) return reconstruct_db;
 
-    sqldb_t *db = NULL;
     struct buf fname = BUF_INITIALIZER;
     dav_getpath_byuserid(&fname, userid);
-    db = sqldb_open(buf_cstring(&fname), CMD_CREATE, DB_VERSION, davdb_upgrade,
-                    config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000);
+    sqldb_t *db = _dav_open(&fname, SQLDB_SCOPE_USER, userid);
     buf_free(&fname);
     return db;
 }
@@ -346,12 +354,16 @@ EXPORTED sqldb_t *dav_open_mailbox(struct mailbox *mailbox)
 {
     if (reconstruct_db) return reconstruct_db;
 
-    sqldb_t *db = NULL;
+    /* a shared mailbox keeps its DAV DB in its own metadata */
+    char *userid = mboxname_to_userid(mailbox_name(mailbox));
+
     struct buf fname = BUF_INITIALIZER;
     dav_getpath(&fname, mailbox);
-    db = sqldb_open(buf_cstring(&fname), CMD_CREATE, DB_VERSION, davdb_upgrade,
-                    config_getduration(IMAPOPT_DAV_LOCK_TIMEOUT) * 1000);
+    sqldb_t *db = userid
+                ? _dav_open(&fname, SQLDB_SCOPE_USER, userid)
+                : _dav_open(&fname, SQLDB_SCOPE_MAILBOX, mailbox_name(mailbox));
     buf_free(&fname);
+    free(userid);
     return db;
 }
 

--- a/imap/http_dav_sharing.c
+++ b/imap/http_dav_sharing.c
@@ -25,11 +25,8 @@
 #define DAVNOTIFICATION_CONTENT_TYPE \
     "application/davnotification+xml; charset=utf-8"
 
-static struct webdav_db *auth_webdavdb = NULL;
-
 static void my_dav_init(struct buf *serverinfo);
 static int my_dav_auth(const char *userid);
-static void my_dav_reset(void);
 static void my_dav_shutdown(void);
 
 static unsigned long notify_allow_cb(struct request_target_t *tgt);
@@ -245,7 +242,7 @@ struct namespace_t namespace_notify = {
     MBTYPE_COLLECTION,
     (ALLOW_READ | ALLOW_POST | ALLOW_DELETE |
      ALLOW_DAV | ALLOW_PROPPATCH | ALLOW_ACL),
-    &my_dav_init, &my_dav_auth, &my_dav_reset, &my_dav_shutdown,
+    &my_dav_init, &my_dav_auth, NULL, &my_dav_shutdown,
     &dav_premethod,
     {
         { &meth_acl,            &notify_params },      /* ACL          */
@@ -400,15 +397,6 @@ static int my_dav_auth(const char *userid)
         /* proxy-only server - won't have DAV databases */
         return 0;
     }
-    else {
-        /* Open WebDAV DB for 'userid' */
-        my_dav_reset();
-        auth_webdavdb = webdav_open_userid(userid);
-        if (!auth_webdavdb) {
-            syslog(LOG_ERR, "Unable to open WebDAV DB for userid: %s", userid);
-            return HTTP_UNAVAILABLE;
-        }
-    }
 
     /* Auto-provision a notifications collection for 'userid' */
     create_notify_collection(userid, NULL);
@@ -417,16 +405,8 @@ static int my_dav_auth(const char *userid)
 }
 
 
-static void my_dav_reset(void)
-{
-    if (auth_webdavdb) webdav_close(auth_webdavdb);
-    auth_webdavdb = NULL;
-}
-
-
 static void my_dav_shutdown(void)
 {
-    my_dav_reset();
     webdav_done();
 }
 
@@ -969,6 +949,7 @@ HIDDEN int notify_post(struct transaction_t *txn)
     int rights, ret, r, legacy = 0, add = 0;
     struct mailbox *shared = NULL;
     struct webdav_db *webdavdb = NULL;
+    user_nslock_t *user_nslock = NULL;
     struct webdav_data *wdata;
     struct dlist *dl = NULL, *data;
     const char *type_str, *mboxname, *url_prefix;
@@ -1067,6 +1048,11 @@ HIDDEN int notify_post(struct transaction_t *txn)
         }
     }
 
+    /* everything down to the [un]subscribe is the sharee's own data.  Hold
+       only their lock, and drop it before touching the sharer's mailbox;
+       holding both deadlocks against a share accepted the other way */
+    user_nslock = user_nslock_lock_w(txn->req_tgt.userid);
+
     /* Open the WebDAV DB corresponding to the mailbox */
     webdavdb = webdav_open_userid(txn->req_tgt.userid);
 
@@ -1099,6 +1085,10 @@ HIDDEN int notify_post(struct transaction_t *txn)
         ret = HTTP_SERVER_ERROR;
         goto done;
     }
+
+    webdav_close(webdavdb);
+    webdavdb = NULL;
+    user_nslock_release(&user_nslock);
 
     /* Set invite status */
     r = mailbox_open_iwl(mboxname, &shared);
@@ -1211,6 +1201,7 @@ HIDDEN int notify_post(struct transaction_t *txn)
     if (root) xmlFreeDoc(root->doc);
     if (notify) xmlFreeDoc(notify->doc);
     webdav_close(webdavdb);
+    user_nslock_release(&user_nslock);
     mbname_free(&mbname);
     dlist_free(&dl);
 

--- a/imap/http_dblookup.c
+++ b/imap/http_dblookup.c
@@ -9,6 +9,7 @@
 #include "json_support.h"
 #include "spool.h"
 #include "mboxlist.h"
+#include "user.h"
 #include "util.h"
 #include "xstrlcpy.h"
 
@@ -484,23 +485,30 @@ static int meth_get_db(struct transaction_t *txn,
                       txn->req_hdrs);
 
 
+    /* each of these opens the user's DAV DB, which needs the namespace lock
+       or the files can go away underneath us.  All read-only, so share */
+    user_nslock_t *user_nslock = user_nslock_lock(userhdrs[0], LOCK_SHARED);
+    int ret = HTTP_NOT_FOUND;
+
     if (!strcmp(txn->req_uri->path, "/dblookup/email"))
-        return get_email(txn, userhdrs[0], keyhdrs[0]);
+        ret = get_email(txn, userhdrs[0], keyhdrs[0]);
 
-    if (!strcmp(txn->req_uri->path, "/dblookup/email2uids"))
-        return get_email2uids(txn, userhdrs[0], keyhdrs[0]);
+    else if (!strcmp(txn->req_uri->path, "/dblookup/email2uids"))
+        ret = get_email2uids(txn, userhdrs[0], keyhdrs[0]);
 
-    if (!strcmp(txn->req_uri->path, "/dblookup/email2details"))
-        return get_email2details(txn, userhdrs[0], keyhdrs[0]);
+    else if (!strcmp(txn->req_uri->path, "/dblookup/email2details"))
+        ret = get_email2details(txn, userhdrs[0], keyhdrs[0]);
 
-    if (!strcmp(txn->req_uri->path, "/dblookup/uid2groups"))
-        return get_uid2groups(txn, userhdrs[0], keyhdrs[0]);
+    else if (!strcmp(txn->req_uri->path, "/dblookup/uid2groups"))
+        ret = get_uid2groups(txn, userhdrs[0], keyhdrs[0]);
 
-    if (!strcmp(txn->req_uri->path, "/dblookup/expandcard"))
-        return get_expandcard(txn, userhdrs[0], keyhdrs[0]);
+    else if (!strcmp(txn->req_uri->path, "/dblookup/expandcard"))
+        ret = get_expandcard(txn, userhdrs[0], keyhdrs[0]);
 
-    if (!strcmp(txn->req_uri->path, "/dblookup/mbpath"))
-        return get_mbpath(txn, userhdrs[0], keyhdrs[0]);
+    else if (!strcmp(txn->req_uri->path, "/dblookup/mbpath"))
+        ret = get_mbpath(txn, userhdrs[0], keyhdrs[0]);
 
-    return HTTP_NOT_FOUND;
+    user_nslock_release(&user_nslock);
+
+    return ret;
 }

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -2112,36 +2112,10 @@ static void _email_search_contactgroup(search_expr_t *parent,
 {
     if (!contactgroups) return;
 
-    /* At this point contactgroups must have entries - we can only get here if
-     * jmap_email_contactfilter_from_filtercondition() has been called,
-     * it called construct_hash_table(), and made one or more calls to
-     * hash_insert()
-     * The previous code assumed that it was possible for contactgroups to be
-     * non-NULL but point to an uninitialised hash table, and returned early
-     * in that case. That choice seemed conceptually buggy, because it's not
-     * consistent with the "hard false" SEOP_FALSE return just below - if the
-     * user is asking to filter on a groupid, and there are *no* group IDs, then
-     * the filter should return zero results, not return all results.
-     *
-     * It's actually already handled this way (failure) -
-     * _email_parse_filter_cb() correctly checks and propagates the error
-     * returned from jmap_email_contactfilter_from_filtercondition() and the
-     * search fails. In that function, for carddav_open_userid() to return NULL
-     * dav_open_userid() must fail - the user's SQLite DB on disk must be
-     * present AND corrupt. However, before we even reach that code path Cyrus
-     * has called my_dav_auth() in http_dav_sharing.c
-     * That calls webdav_open_userid(userid), which also calls
-     * dav_open_userid(userid). The failure path there is:
-     * if (!auth_webdavdb) {
-     *     syslog(LOG_ERR, "Unable to open WebDAV DB for userid: %s", userid);
-     *     return HTTP_UNAVAILABLE;
-     * }
-     * Hence that failure isn't even possible via the functions this source file
-     * - the only path that might cause contactgroups not be initialised is
-     * unreachable, because Cyrus will have already returned a 503 status
-     * response if the dav.db exists but can't be read.
-     * (Hence I can't write a test for it)
-     */
+    /* an empty table means the user has no groups, so a groupid filter
+       matches nothing, same as the SEOP_FALSE below.  Don't return early and
+       match everything.  A DAV DB which wouldn't open is an error, already
+       propagated by _email_parse_filter_cb(), so we never get here */
 
     strarray_t *members = hash_lookup(groupid, contactgroups);
     if (!members || !strarray_size(members)) {

--- a/imap/jmap_mail_query.c
+++ b/imap/jmap_mail_query.c
@@ -105,6 +105,8 @@ static int _get_sharedaddressbooks_cb(struct findall_data *data, void *rock)
     if (strcmp(userid, set->userid)) {
         set = xzmalloc(sizeof(struct abook_set));
         set->userid = userid;
+        /* the sharee set isn't known until the sweep is done, so this
+           reads without their lock and the files may go away under it */
         set->carddavdb = carddav_open_userid(userid);
         ptrarray_append(abook_sets, set);
     }

--- a/imap/sync_support.c
+++ b/imap/sync_support.c
@@ -942,6 +942,9 @@ static int sync_sieve_deactivate(const char *userid)
 #ifdef USE_SIEVE
 static int sync_sieve_activate(const char *userid, const char *bcname)
 {
+    /* the Sieve DB is the user's DAV DB and needs the namespace lock, and we
+       open it before the mailbox which would otherwise take it for us */
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
     struct sieve_db *db = sievedb_open_userid(userid);
     struct mailbox *mailbox = NULL;
     struct sieve_data *sdata = NULL;
@@ -949,6 +952,7 @@ static int sync_sieve_activate(const char *userid, const char *bcname)
 
     if (!db) {
         syslog(LOG_ERR, "Failed to open Sieve DB for %s", userid);
+        user_nslock_release(&user_nslock);
         return IMAP_INTERNAL;
     }
 
@@ -974,12 +978,14 @@ static int sync_sieve_activate(const char *userid, const char *bcname)
   done:
     mailbox_close(&mailbox);
     sievedb_close(db);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
 
 static int sync_sieve_delete(const char *userid, const char *fname)
 {
+    user_nslock_t *user_nslock;
     struct sieve_db *db;
     struct mailbox *mailbox = NULL;
     struct sieve_data *sdata = NULL;
@@ -993,9 +999,11 @@ static int sync_sieve_delete(const char *userid, const char *fname)
         return 0;
     }
 
+    user_nslock = user_nslock_lock_w(userid);
     db = sievedb_open_userid(userid);
     if (!db) {
         syslog(LOG_ERR, "Failed to open Sieve DB for %s", userid);
+        user_nslock_release(&user_nslock);
         return IMAP_INTERNAL;
     }
 
@@ -1023,6 +1031,7 @@ static int sync_sieve_delete(const char *userid, const char *fname)
   done:
     mailbox_close(&mailbox);
     sievedb_close(db);
+    user_nslock_release(&user_nslock);
 
     return r;
 }
@@ -4053,12 +4062,16 @@ static int list_gen_cb(void *rock, struct sieve_data *sdata)
 static struct sync_sieve_list *sync_sieve_list_generate(const char *userid)
 {
     struct sync_sieve_list *list = sync_sieve_list_create();
+    /* read-only, so share the lock, but we still need it */
+    user_nslock_t *user_nslock = user_nslock_lock(userid, LOCK_SHARED);
     struct sieve_db *db = sievedb_open_userid(userid);
 
     if (db) {
         sievedb_foreach(db, &list_gen_cb, list);
         sievedb_close(db);
     }
+
+    user_nslock_release(&user_nslock);
 
     return list;
 }
@@ -4110,6 +4123,7 @@ static int sync_sieve_upload(const char *userid, const char *fname,
                       size_t len)
 {
     const char *sieve_path = user_sieve_path(userid);
+    user_nslock_t *user_nslock;
     char name[2048];
     char *ext;
     int r = 0;
@@ -4133,6 +4147,7 @@ static int sync_sieve_upload(const char *userid, const char *fname,
         }
     }
 
+    user_nslock = user_nslock_lock_w(userid);
     db = sievedb_open_userid(userid);
     if (!db) {
         syslog(LOG_ERR, "Failed to open Sieve DB for %s", userid);
@@ -4165,6 +4180,7 @@ static int sync_sieve_upload(const char *userid, const char *fname,
 
     mailbox_close(&mailbox);
     sievedb_close(db);
+    user_nslock_release(&user_nslock);
     buf_free(&buf);
 
     return r;
@@ -4317,7 +4333,9 @@ static int sync_get_user(struct dlist *kin, struct sync_state *sstate)
     if (r) goto bail;
 
 #ifdef USE_SIEVE
-    /* Remove any cruft from sievedir */
+    /* only read the DB, but unlink from sievedir off the back of it, so
+       take the lock exclusively */
+    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
     const char *sieve_path = user_sieve_path(userid);
     struct sieve_db *db = sievedb_open_userid(userid);
     strarray_t list = STRARRAY_INITIALIZER;
@@ -4330,6 +4348,7 @@ static int sync_get_user(struct dlist *kin, struct sync_state *sstate)
 
     sievedir_foreach(sieve_path, 0/*flags*/, &remove_cb, &list);
     strarray_fini(&list);
+    user_nslock_release(&user_nslock);
 #endif
 
 bail:

--- a/timsieved/actions.c
+++ b/timsieved/actions.c
@@ -40,6 +40,7 @@ static char *sieve_dir_config = NULL;
 static char *sieved_userid = NULL;
 
 static struct mailbox *sieve_mailbox = NULL;
+static user_nslock_t *sieved_nslock = NULL;
 static struct sieve_db *sievedb = NULL;
 
 int actions_init(void)
@@ -100,26 +101,51 @@ int actions_setuser(const char *userid)
 
     if (result) return TIMSIEVE_FAIL;
 
-    sievedb = sievedb_open_userid(sieved_userid);
-    if (!sievedb) return TIMSIEVE_FAIL;
+    return TIMSIEVE_OK;
+}
 
-    result = sieve_ensure_folder(sieved_userid, &sieve_mailbox, /*silent*/0);
-    if (result) return TIMSIEVE_FAIL;
+/* the Sieve DB is the user's DAV DB and needs their namespace lock.  Open it
+   per command rather than for the connection, so we aren't holding a handle
+   onto files which get removed when the user is deleted */
+int actions_open_user(void)
+{
+    if (!sieved_userid) return TIMSIEVE_FAIL;
+
+    assert(!sieved_nslock);
+    sieved_nslock = user_nslock_lock_w(sieved_userid);
+
+    sievedb = sievedb_open_userid(sieved_userid);
+    if (!sievedb) goto fail;
+
+    if (sieve_ensure_folder(sieved_userid, &sieve_mailbox, /*silent*/0))
+        goto fail;
 
     mailbox_unlock_index(sieve_mailbox, NULL);
 
     return TIMSIEVE_OK;
+
+ fail:
+    actions_close_user();
+    return TIMSIEVE_FAIL;
+}
+
+void actions_close_user(void)
+{
+    mailbox_close(&sieve_mailbox);
+    sieve_mailbox = NULL;
+
+    sievedb_close(sievedb);
+    sievedb = NULL;
+
+    user_nslock_release(&sieved_nslock);
 }
 
 void actions_unsetuser(void)
 {
     xzfree(sieved_userid);
 
-    mailbox_close(&sieve_mailbox);
-    sieve_mailbox = NULL;
-
-    sievedb_close(sievedb);
-    sievedb = NULL;
+    /* each command closes its own; belt and braces */
+    actions_close_user();
 }
 
 int capabilities(struct protstream *conn, sasl_conn_t *saslconn,

--- a/timsieved/actions.h
+++ b/timsieved/actions.h
@@ -85,6 +85,11 @@ int actions_init(void);
 
 int actions_setuser(const char *userid);
 
+/* open and close the user's Sieve DB and mailbox around a single command,
+   under their namespace lock */
+int actions_open_user(void);
+void actions_close_user(void);
+
 /*
  * Unset user after unauthentication/logout
  *

--- a/timsieved/parser.c
+++ b/timsieved/parser.c
@@ -118,6 +118,7 @@ int parser(struct protstream *sieved_out, struct protstream *sieved_in,
   struct buf sieve_data = BUF_INITIALIZER;
   unsigned long num;
   int ret = FALSE;
+  int needdb = 0;
 
   /* get one token from the lexer */
   while(token == EOL)
@@ -143,6 +144,26 @@ int parser(struct protstream *sieved_out, struct protstream *sieved_in,
       lex_setrecovering();
 
     goto error;
+  }
+
+  /* the Sieve DB isn't held across commands, so open it for the ones which
+     need it and close again below */
+  switch (token) {
+  case GETSCRIPT:
+  case PUTSCRIPT:
+  case SETACTIVE:
+  case LISTSCRIPTS:
+  case DELETESCRIPT:
+  case HAVESPACE:
+  case CHECKSCRIPT:
+  case RENAMESCRIPT:
+      needdb = authenticated && !verify_only;
+      break;
+  }
+
+  if (needdb && actions_open_user() != TIMSIEVE_OK) {
+      error_msg = "Failed to open Sieve database";
+      goto error;
   }
 
   switch (token)
@@ -544,6 +565,8 @@ int parser(struct protstream *sieved_out, struct protstream *sieved_in,
   }
 
  done:
+  if (needdb) actions_close_user();
+
   /* free memory */
   buf_free(&mechanism_name);
   buf_free(&initial_challenge);
@@ -558,6 +581,7 @@ int parser(struct protstream *sieved_out, struct protstream *sieved_in,
   return ret;
 
  error:
+  if (needdb) actions_close_user();
 
   /* free memory */
   buf_free(&mechanism_name);


### PR DESCRIPTION
This is separated out from #6292 - this brings DAV DB under the namespace lock consistently.