### PR TITLE
Sieve deferred actions

### DIFF
--- a/cassandane/tiny-tests/Sieve/deliver_fileinto_otheruser
+++ b/cassandane/tiny-tests/Sieve/deliver_fileinto_otheruser
@@ -1,0 +1,36 @@
+#!perl
+use Cassandane::Tiny;
+
+# Filing into a mailbox another user owns is held over until the recipient's
+# lock is dropped, then delivered.  Every other otheruser/globalshared fileinto
+# test checks the INBOX fallback; this is the case where it works.
+sub test_deliver_fileinto_otheruser
+    :NoAltNameSpace
+    ($self)
+{
+    my $admintalk = $self->{adminstore}->get_client();
+
+    $self->{instance}->create_user('alice');
+    $admintalk->create("user.alice.shared") || die;
+    $admintalk->setacl("user.alice.shared", 'cassandane' => 'lrsip') || die;
+
+    my $target = "user.alice.shared";
+
+    $self->{instance}->install_sieve_script(<<EOF
+require ["fileinto"];
+fileinto "$target";
+EOF
+    , username => 'cassandane');
+
+    my $msg1 = $self->{gen}->generate(subject => "Message 1");
+    $self->{instance}->deliver($msg1, users => [ 'cassandane' ]);
+
+    xlog $self, "the message went to the other user's mailbox";
+    $admintalk->select($target);
+    $self->assert_str_equals('ok', $admintalk->get_last_completion_response());
+    $self->assert_num_equals(1, $admintalk->get_response_code('exists'));
+
+    xlog $self, "and not to our INBOX, because fileinto cancels keep";
+    $self->{store}->set_folder('INBOX');
+    $self->check_messages({}, check_guid => 0);
+}

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -995,17 +995,23 @@ static int sieve_reject(void *ac, void *ic,
     }
 }
 
+/* more than one deferred fileinto can be waiting at once, so these can't be
+   static.  dd is first, so cleanup can recover the allocation from the
+   pointer we handed out */
+struct special_delivery {
+    deliver_data_t dd;
+    message_data_t md;
+    struct message_content mc;
+};
+
 static deliver_data_t *setup_special_delivery(deliver_data_t *mydata,
                                               struct buf *headers)
 {
-    static deliver_data_t dd;
-    static message_data_t md;
-    static struct message_content mc;
+    struct special_delivery *special = xzmalloc(sizeof(struct special_delivery));
 
-    memcpy(&dd, mydata, sizeof(deliver_data_t));
-    dd.m = memcpy(&md, mydata->m, sizeof(message_data_t));
-    dd.content = &mc;
-    memset(&mc, 0, sizeof(struct message_content));
+    memcpy(&special->dd, mydata, sizeof(deliver_data_t));
+    special->dd.m = memcpy(&special->md, mydata->m, sizeof(message_data_t));
+    special->dd.content = &special->mc;
 
     /* build the mailboxname from the recipient address */
     const mbname_t *origmbname = msg_getrcpt(mydata->m, mydata->cur_rcpt);
@@ -1017,35 +1023,40 @@ static deliver_data_t *setup_special_delivery(deliver_data_t *mydata,
     }
 
     const char *intname = mbname_intname(mbname);
-    md.f = append_newstage(intname, time(0),
-                           strhash(intname) /* unique msgnum for modified msg */,
-                           &dd.stage);
+    special->md.f = append_newstage(intname, time(0),
+                                    strhash(intname) /* unique msgnum */,
+                                    &special->dd.stage);
     mbname_free(&mbname);
-    if (!md.f) return NULL;
+    if (!special->md.f) {
+        free(special);
+        return NULL;
+    }
 
     char buf[4096];
 
     /* write updated message headers */
-    fwrite(buf_base(headers), buf_len(headers), 1, md.f);
+    fwrite(buf_base(headers), buf_len(headers), 1, special->md.f);
 
     /* get offset of message body */
-    md.body_offset = ftell(md.f);
+    special->md.body_offset = ftell(special->md.f);
 
     /* write message body */
     fseek(mydata->m->f, mydata->m->body_offset, SEEK_SET);
-    while (fgets(buf, sizeof(buf), mydata->m->f)) fputs(buf, md.f);
+    while (fgets(buf, sizeof(buf), mydata->m->f)) fputs(buf, special->md.f);
 
-    if (fflush(md.f) || ferror(md.f) || fdatasync(fileno(md.f))) {
+    if (fflush(special->md.f) || ferror(special->md.f) ||
+        fdatasync(fileno(special->md.f))) {
         xsyslog_ev(LOG_ERR, "sieve.delivery.stage.failed",
                    lf_mbname("mbox.name", origmbname));
-        fclose(md.f);
+        fclose(special->md.f);
+        free(special);
         return NULL;
     }
 
     /* XXX  do we look for updated Date and Message-ID? */
-    md.size = ftell(md.f);
-    md.data = prot_new(fileno(md.f), 0);
-    return &dd;
+    special->md.size = ftell(special->md.f);
+    special->md.data = prot_new(fileno(special->md.f), 0);
+    return &special->dd;
 }
 
 static void cleanup_special_delivery(deliver_data_t *mydata)
@@ -1061,6 +1072,162 @@ static void cleanup_special_delivery(deliver_data_t *mydata)
         message_free_body(mydata->content->body);
         free(mydata->content->body);
     }
+    /* dd is the first member, so this is the whole allocation */
+    free(mydata);
+}
+
+/* the append, and the create-and-retry if the target isn't there yet.  The
+   immediate and deferred paths both do exactly this, at different times */
+static int do_fileinto(deliver_data_t *mdata, const char *userid,
+                       const struct auth_state *authstate,
+                       const strarray_t *flags, unsigned mode,
+                       const char *intname, const char *specialuse,
+                       int do_create, int quotaoverride)
+{
+    message_data_t *md = mdata->m;
+    struct imap4flags imap4flags = { flags, authstate };
+    int ret;
+
+    ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
+                          &imap4flags, NULL, userid, authstate, md->id,
+                          userid, mdata->notifyheader, mode,
+                          intname, md->date, 0 /*savedate*/, quotaoverride, 0);
+
+    if (ret == IMAP_MAILBOX_NONEXISTENT) {
+        /* if "plus" folder under INBOX, then try to create it */
+        ret = autosieve_createfolder(userid, authstate, intname, do_create);
+
+        /* Try to deliver the mail again. */
+        if (!ret) {
+            if (specialuse) {
+                /* Attempt to add special-use flag to newly created mailbox */
+                struct buf buf = BUF_INITIALIZER;
+                int r = specialuse_validate(NULL, userid, specialuse, &buf, 0);
+
+                if (!r) {
+                    annotatemore_write(intname, "/specialuse", userid, &buf);
+                }
+                buf_free(&buf);
+            }
+
+            ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
+                                  &imap4flags, NULL, userid, authstate, md->id,
+                                  userid, mdata->notifyheader, mode,
+                                  intname, md->date, 0 /*savedate*/,
+                                  quotaoverride, 0);
+        }
+    }
+
+    return ret;
+}
+
+/* a fileinto whose target belongs to somebody else waits here until lmtpd has
+   committed the recipient's conversations state and dropped their lock.  They
+   drain grouped by owner, keeping each owner's appends atomic, and never
+   holding one owner's lock while taking another's */
+struct deferred_fileinto {
+    char *owner;                /* who owns the target, NULL if it's shared */
+    char *userid;               /* the recipient, whose script this was */
+    char *intname;
+    char *specialuse;
+    strarray_t flags;
+    unsigned mode;
+    int do_create;
+    int quotaoverride;
+    deliver_data_t *mdata;
+    int mdata_is_special;       /* ours to clean up */
+};
+
+static ptrarray_t deferred_fileintos = PTRARRAY_INITIALIZER;
+
+static void defer_fileinto(const char *owner, const char *userid,
+                           const char *intname, deliver_data_t *mdata,
+                           int mdata_is_special, const strarray_t *flags,
+                           unsigned mode, const char *specialuse,
+                           int do_create, int quotaoverride)
+{
+    struct deferred_fileinto *item = xzmalloc(sizeof(struct deferred_fileinto));
+
+    item->owner = xstrdupnull(owner);
+    item->userid = xstrdupnull(userid);
+    item->intname = xstrdup(intname);
+    item->specialuse = xstrdupnull(specialuse);
+    if (flags) strarray_cat(&item->flags, flags);
+    item->mode = mode;
+    item->do_create = do_create;
+    item->quotaoverride = quotaoverride;
+    item->mdata = mdata;
+    item->mdata_is_special = mdata_is_special;
+
+    ptrarray_append(&deferred_fileintos, item);
+}
+
+static void free_deferred_fileinto(struct deferred_fileinto *item)
+{
+    if (item->mdata_is_special) cleanup_special_delivery(item->mdata);
+    free(item->owner);
+    free(item->userid);
+    free(item->intname);
+    free(item->specialuse);
+    strarray_fini(&item->flags);
+    free(item);
+}
+
+/* deliver everything we put aside.  Returns true if anything failed, so lmtpd
+   can put one copy in the recipient's INBOX, where a failed fileinto has
+   always ended up; the script has finished and can't be told */
+EXPORTED int sieve_run_deferred_fileinto(void)
+{
+    int fallback = 0;
+
+    while (ptrarray_size(&deferred_fileintos)) {
+        struct deferred_fileinto *first = ptrarray_nth(&deferred_fileintos, 0);
+        char *owner = xstrdupnull(first->owner);
+        struct conversations_state *state = NULL;
+        int i;
+
+        /* one conversations state for the whole group.  Carry on without it
+           if we can't get it: each mailbox opens its own, so we lose the
+           grouping but not the mail */
+        if (owner) {
+            int r = conversations_open_user(owner, 0/*shared*/, &state);
+            if (r) {
+                xsyslog_ev(LOG_WARNING,
+                           "sieve.fileinto.deferred.conversations.failed",
+                           lf_s("u.username", owner),
+                           lf_err("error", r));
+            }
+        }
+
+        for (i = 0; i < ptrarray_size(&deferred_fileintos); i++) {
+            struct deferred_fileinto *item =
+                ptrarray_nth(&deferred_fileintos, i);
+            if (strcmpsafe(item->owner, owner)) continue;
+
+            struct auth_state *authstate = auth_newstate(item->userid);
+            int ret = do_fileinto(item->mdata, item->userid, authstate,
+                                  &item->flags, item->mode, item->intname,
+                                  item->specialuse, item->do_create,
+                                  item->quotaoverride);
+            if (ret) {
+                xsyslog_ev(LOG_WARNING, "sieve.fileinto.deferred.failed",
+                           lf_s("u.username", item->userid),
+                           lf_intname("mbox.name", item->intname),
+                           lf_err("error", ret));
+                fallback = 1;
+            }
+            auth_freestate(authstate);
+
+            free_deferred_fileinto(item);
+            ptrarray_remove(&deferred_fileintos, i);
+            i--;
+        }
+
+        conversations_commit(&state);
+        free(owner);
+    }
+
+    return fallback;
 }
 
 static int sieve_fileinto(void *ac,
@@ -1115,7 +1282,6 @@ static int sieve_fileinto(void *ac,
 
     message_data_t *md = mdata->m;
     int quotaoverride = msg_getrcpt_ignorequota(md, mdata->cur_rcpt);
-    struct imap4flags imap4flags = { fc->imapflags, sd->authstate };
     unsigned mode = ACTION_FILEINTO;
 
     if (fc->ikeep_target) mode = ACTION_IMPLICIT | TARGET_SET;
@@ -1129,36 +1295,22 @@ static int sieve_fileinto(void *ac,
         else md = mdata->m;
     }
 
-    ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
-                          &imap4flags, NULL, userid, sd->authstate, md->id,
-                          userid, mdata->notifyheader, mode,
-                          intname, md->date, 0 /*savedate*/, quotaoverride, 0);
-
-    if (ret == IMAP_MAILBOX_NONEXISTENT) {
-        /* if "plus" folder under INBOX, then try to create it */
-        ret = autosieve_createfolder(userid, sd->authstate,
-                                     intname, fc->do_create);
-
-        /* Try to deliver the mail again. */
-        if (!ret) {
-            if (fc->specialuse) {
-                /* Attempt to add special-use flag to newly created mailbox */
-                struct buf specialuse = BUF_INITIALIZER;
-                int r = specialuse_validate(NULL, userid, fc->specialuse, &specialuse, 0);
-
-                if (!r) {
-                    annotatemore_write(intname, "/specialuse",
-                                       userid, &specialuse);
-                }
-                buf_free(&specialuse);
-            }
-
-            ret = deliver_mailbox(md->f, mdata->content, mdata->stage, md->size,
-                                  &imap4flags, NULL, userid, sd->authstate, md->id,
-                                  userid, mdata->notifyheader, mode,
-                                  intname, md->date, 0 /*savedate*/, quotaoverride, 0);
-        }
+    /* filing into a mailbox somebody else owns takes their namespace lock,
+       and we hold the recipient's.  Put it aside until lmtpd lets go.  We must
+       report success before we know, and a failure falls back to INBOX */
+    char *owner = mboxname_to_userid(intname);
+    if (strcmpsafe(owner, userid)) {
+        defer_fileinto(owner, userid, intname, mdata, fc->headers != NULL,
+                       fc->imapflags, mode, fc->specialuse, fc->do_create,
+                       quotaoverride);
+        free(owner);
+        ret = 0;
+        goto done;
     }
+    free(owner);
+
+    ret = do_fileinto(mdata, userid, sd->authstate, fc->imapflags, mode,
+                      intname, fc->specialuse, fc->do_create, quotaoverride);
 
     if (fc->headers) cleanup_special_delivery(mdata);
 
@@ -2522,8 +2674,11 @@ static int autosieve_createfolder(const char *userid, const struct auth_state *a
     // unless configured to create it, drop out now
     if (!createsievefolder) return IMAP_MAILBOX_NONEXISTENT;
 
-    // lock the namespace and check again before trying to create
-    user_nslock_t *user_nslock = user_nslock_lock_w(userid);
+    // lock the namespace we're creating in - which is only the recipient's
+    // when they're filing into their own account - and check again
+    char *owner = mboxname_to_userid(internalname);
+    user_nslock_t *user_nslock = user_nslock_lock_w(owner);
+    free(owner);
 
     // did we lose the race?
     r = mboxlist_lookup(internalname, 0, 0);

--- a/imap/lmtp_sieve.c
+++ b/imap/lmtp_sieve.c
@@ -846,8 +846,12 @@ done:
 }
 
 
-static int sieve_redirect(void *ac, void *ic,
-                          void *sc, void *mc, const char **errmsg)
+static void defer_redirect(sieve_redirect_context_t *rc, const char *userid,
+                           const char *return_path, deliver_data_t *mdata,
+                           int mdata_is_special, const duplicate_key_t *dkey);
+
+static int sieve_redirect(void *ac, void *ic, void *sc, void *mc,
+                          const char **errmsg __attribute__((unused)))
 {
     sieve_redirect_context_t *rc = (sieve_redirect_context_t *) ac;
     struct sieve_interp_ctx *ctx = (struct sieve_interp_ctx *) ic;
@@ -856,7 +860,6 @@ static int sieve_redirect(void *ac, void *ic,
     message_data_t *m = mdata->m;
     char buf[8192], *sievedb = NULL;
     duplicate_key_t dkey = DUPLICATE_INITIALIZER;
-    int res;
 
     /* if we have a msgid, we can track our redirects */
     if (m->id) {
@@ -879,26 +882,15 @@ static int sieve_redirect(void *ac, void *ic,
         else m = mdata->m;
     }
 
-    res = send_forward(rc, ctx, m->return_path, m->data);
+    /* Put it aside until lmtpd has committed this user's conversations state
+       and let go of their lock: sending is a whole SMTP transaction with
+       another server, and we must not hold a lock across that.  We have to
+       claim success now, before we know - a later failure puts one copy in the
+       recipient's INBOX, where a failed redirect has always ended up. */
+    defer_redirect(rc, ctx->userid, m->return_path, mdata,
+                   rc->headers ? 1 : 0, sievedb ? &dkey : NULL);
 
-    if (rc->headers) cleanup_special_delivery(mdata);
-
-    if (res == 0) {
-        /* mark this message as redirected */
-        if (sievedb) duplicate_mark(&dkey, time(NULL), 0);
-
-        prometheus_increment(CYRUS_LMTP_SIEVE_REDIRECT_TOTAL);
-        auditlog_sieve("sieve.redirect",
-                       ctx->userid, m->id, NULL, rc->addr, NULL, NULL);
-        return SIEVE_OK;
-    } else {
-        if (res == -1) {
-            *errmsg = "Could not spawn sendmail process";
-        } else {
-            *errmsg = error_message(res);
-        }
-        return SIEVE_FAIL;
-    }
+    return SIEVE_OK;
 }
 
 static int sieve_discard(void *ac __attribute__((unused)),
@@ -1173,10 +1165,121 @@ static void free_deferred_fileinto(struct deferred_fileinto *item)
     free(item);
 }
 
+/* a redirect waits here for the same reason a foreign fileinto does: sending
+   is a whole SMTP transaction with another server, and the recipient's
+   conversations state - and so their namespace lock - is held across the
+   script run */
+struct deferred_redirect {
+    sieve_redirect_context_t rc;        /* strings below are ours */
+    char *addr;
+    char *deliverby;
+    char *dsn_notify;
+    char *dsn_ret;
+    char *userid;                       /* the recipient, for auth */
+    char *return_path;
+    deliver_data_t *mdata;
+    int mdata_is_special;               /* ours to clean up */
+    char *dkey_id;                      /* marked once the send worked */
+    char *dkey_to;
+    char *dkey_date;
+};
+
+static ptrarray_t deferred_redirects = PTRARRAY_INITIALIZER;
+
+static void defer_redirect(sieve_redirect_context_t *rc, const char *userid,
+                           const char *return_path, deliver_data_t *mdata,
+                           int mdata_is_special, const duplicate_key_t *dkey)
+{
+    struct deferred_redirect *item = xzmalloc(sizeof(struct deferred_redirect));
+
+    /* copy the context, then re-point every string at our own copy: the
+       interpreter frees the original when the script finishes */
+    item->rc = *rc;
+    item->addr = xstrdupnull(rc->addr);
+    item->deliverby = xstrdupnull(rc->deliverby);
+    item->dsn_notify = xstrdupnull(rc->dsn_notify);
+    item->dsn_ret = xstrdupnull(rc->dsn_ret);
+    item->rc.addr = item->addr;
+    item->rc.deliverby = item->deliverby;
+    item->rc.dsn_notify = item->dsn_notify;
+    item->rc.dsn_ret = item->dsn_ret;
+    item->rc.headers = NULL;    /* already applied to mdata below */
+
+    item->userid = xstrdupnull(userid);
+    item->return_path = xstrdupnull(return_path);
+    item->mdata = mdata;
+    item->mdata_is_special = mdata_is_special;
+
+    if (dkey && dkey->id) {
+        item->dkey_id = xstrdup(dkey->id);
+        item->dkey_to = xstrdupnull(dkey->to);
+        item->dkey_date = xstrdupnull(dkey->date);
+    }
+
+    ptrarray_append(&deferred_redirects, item);
+}
+
+static void free_deferred_redirect(struct deferred_redirect *item)
+{
+    if (item->mdata_is_special) cleanup_special_delivery(item->mdata);
+    free(item->addr);
+    free(item->deliverby);
+    free(item->dsn_notify);
+    free(item->dsn_ret);
+    free(item->userid);
+    free(item->return_path);
+    free(item->dkey_id);
+    free(item->dkey_to);
+    free(item->dkey_date);
+    free(item);
+}
+
+static int run_deferred_redirects(void)
+{
+    int fallback = 0;
+
+    while (ptrarray_size(&deferred_redirects)) {
+        struct deferred_redirect *item = ptrarray_shift(&deferred_redirects);
+        /* a fresh context: the script's is long gone, and the CardDAV DB it
+           may open is only wanted for an ext_list redirect */
+        struct sieve_interp_ctx ctx = { item->userid, NULL, NULL };
+
+        int r = send_forward(&item->rc, &ctx, item->return_path,
+                             item->mdata->m->data);
+
+        if (ctx.carddavdb) carddav_close(ctx.carddavdb);
+
+        if (r) {
+            xsyslog_ev(LOG_WARNING, "sieve.redirect.deferred.failed",
+                       lf_s("u.username", item->userid),
+                       lf_s("sieve.target", item->addr),
+                       lf_err("error", r));
+            fallback = 1;
+        }
+        else {
+            if (item->dkey_id) {
+                duplicate_key_t dkey = DUPLICATE_INITIALIZER;
+                dkey.id = item->dkey_id;
+                dkey.to = item->dkey_to;
+                dkey.date = item->dkey_date;
+                duplicate_mark(&dkey, time(NULL), 0);
+            }
+
+            prometheus_increment(CYRUS_LMTP_SIEVE_REDIRECT_TOTAL);
+            auditlog_sieve("sieve.redirect", item->userid, item->mdata->m->id,
+                           NULL, item->addr, NULL, NULL);
+        }
+
+        free_deferred_redirect(item);
+    }
+
+    return fallback;
+}
+
 /* deliver everything we put aside.  Returns true if anything failed, so lmtpd
    can put one copy in the recipient's INBOX, where a failed fileinto has
    always ended up; the script has finished and can't be told */
-EXPORTED int sieve_run_deferred_fileinto(void)
+EXPORTED int sieve_run_deferred(void)
 {
     int fallback = 0;
 
@@ -1226,6 +1329,9 @@ EXPORTED int sieve_run_deferred_fileinto(void)
         conversations_commit(&state);
         free(owner);
     }
+
+    /* local work first, then the wire */
+    if (run_deferred_redirects()) fallback = 1;
 
     return fallback;
 }

--- a/imap/lmtp_sieve.h
+++ b/imap/lmtp_sieve.h
@@ -26,6 +26,6 @@ void sieve_srs_free(void);
 /* run the fileintos which targeted other users, once the recipient's lock has
    been dropped.  Returns true if any failed, so the caller can fall back to
    INBOX once, however many failed */
-int sieve_run_deferred_fileinto(void);
+int sieve_run_deferred(void);
 
 #endif /* LMTP_SIEVE_H */

--- a/imap/lmtp_sieve.h
+++ b/imap/lmtp_sieve.h
@@ -23,4 +23,9 @@ int run_sieve(const mbname_t *mbname,
 void sieve_srs_init(void);
 void sieve_srs_free(void);
 
+/* run the fileintos which targeted other users, once the recipient's lock has
+   been dropped.  Returns true if any failed, so the caller can fall back to
+   INBOX once, however many failed */
+int sieve_run_deferred_fileinto(void);
+
 #endif /* LMTP_SIEVE_H */

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -929,7 +929,7 @@ int deliver(message_data_t *msgdata, char *authuser,
                other users can go, an owner at a time.  On any failure put one
                copy in this user's INBOX, where a failed fileinto has always
                ended up */
-            if (sieve_run_deferred_fileinto()) {
+            if (sieve_run_deferred()) {
                 strarray_t fbflags = STRARRAY_INITIALIZER;
                 struct imap4flags fbimap4flags = { &fbflags, authstate };
 

--- a/imap/lmtpd.c
+++ b/imap/lmtpd.c
@@ -924,6 +924,22 @@ int deliver(message_data_t *msgdata, char *authuser,
             strarray_fini(&flags);
             conversations_commit(&state);
 
+#ifdef USE_SIEVE
+            /* this user is unlocked now, so the fileintos which targeted
+               other users can go, an owner at a time.  On any failure put one
+               copy in this user's INBOX, where a failed fileinto has always
+               ended up */
+            if (sieve_run_deferred_fileinto()) {
+                strarray_t fbflags = STRARRAY_INITIALIZER;
+                struct imap4flags fbimap4flags = { &fbflags, authstate };
+
+                if (userid) conversations_open_user(userid, 0/*shared*/, &state);
+                r = deliver_local(&mydata, &fbimap4flags, mbname);
+                strarray_fini(&fbflags);
+                conversations_commit(&state);
+            }
+#endif
+
            unregister:
             proc_register(&proc_handle, 0, config_ident, lmtpd_clienthost, NULL, NULL, NULL);
         }


### PR DESCRIPTION
The last of the #6292 separations.  This defers sending until after the user lock, in the same way we defer different user actions until after the user lock, so the user lock isn't held across the SMTP session.