### PR TITLE
jmap: use the registered calendarHasEvent error code, not calendarHasEvents

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroy_events
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroy_events
@@ -57,7 +57,7 @@ sub test_calendar_set_destroy_events
             properties => ['id'],
         }, 'R4'],
     ]);
-    $self->assert_str_equals('calendarHasEvents',
+    $self->assert_str_equals('calendarHasEvent',
         $res->[0][1]{notDestroyed}{$calendarId}{type});
     $self->assert_str_equals($eventId, $res->[1][1]{list}[0]{id});
     $self->assert_deep_equals([$calendarId], $res->[2][1]{destroyed});

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1936,7 +1936,7 @@ static void setcalendars_destroy(jmap_req_t *req, const char *calid,
     if (!destroy_events) {
         r = caldav_foreach(db, mbentry, _calendar_hasevents_cb, NULL);
         if (r == CYRUSDB_DONE) {
-            *err = json_pack("{s:s}", "type", "calendarHasEvents");
+            *err = json_pack("{s:s}", "type", "calendarHasEvent");
             goto done;
         }
         else if (r) {


### PR DESCRIPTION
Calendar/set destroy rejected a calendar that still held events with a "calendarHasEvents" SetError. The registered code is singular.  Fix that.