### PR TITLE
jmap: advance the Mailbox queryState when queryChanges reports a removal

### DIFF
--- a/cassandane/tiny-tests/JMAPMailbox/mailbox_querychanges_removed_state
+++ b/cassandane/tiny-tests/JMAPMailbox/mailbox_querychanges_removed_state
@@ -1,0 +1,114 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_mailbox_querychanges_removed_state
+    ($self)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+
+    my $sort = [{ property => 'name' }];
+
+    xlog $self, "Create a mailbox without a role, and one with a role";
+    my $mbox_plain = $user->mailboxes->create({ name => 'A' });
+    my $mbox_role = $user->mailboxes->create({
+        name => 'B',
+        role => 'xspecialuse',
+    });
+
+    xlog $self, "Query mailboxes without a filter";
+    my $res = $jmap->request([[ 'Mailbox/query', { sort => $sort } ]]);
+    my $query = $res->single_sentence('Mailbox/query')->arguments;
+    $self->assert($query->{canCalculateChanges}, "can calculate changes");
+    my $state = $query->{queryState};
+    $self->assert_not_null($state);
+
+    xlog $self, "Destroy the mailbox without a role";
+    $mbox_plain->destroy;
+
+    xlog $self, "Assert the removal advances the query state";
+    $res = $jmap->request([[ 'Mailbox/queryChanges', {
+        sinceQueryState => $state,
+        sort            => $sort,
+    } ]]);
+    my $changes = $res->single_sentence('Mailbox/queryChanges')->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            oldQueryState => $state,
+            added         => [],
+            removed       => [ $mbox_plain->id ],
+        }),
+        $changes,
+    );
+    $self->assert_str_not_equals($state, $changes->{newQueryState});
+
+    xlog $self, "Assert there are no changes at the new query state";
+    $state = $changes->{newQueryState};
+    $res = $jmap->request([[ 'Mailbox/queryChanges', {
+        sinceQueryState => $state,
+        sort            => $sort,
+    } ]]);
+    $changes = $res->single_sentence('Mailbox/queryChanges')->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            oldQueryState => $state,
+            newQueryState => $state,
+            added         => [],
+            removed       => [],
+        }),
+        $changes,
+    );
+
+    my $filter = { role => 'xspecialuse' };
+
+    xlog $self, "Query mailboxes filtered by role";
+    $res = $jmap->request([[ 'Mailbox/query', {
+        filter => $filter,
+        sort   => $sort,
+    } ]]);
+    $query = $res->single_sentence('Mailbox/query')->arguments;
+    $self->assert_cmp_deeply([ $mbox_role->id ], $query->{ids});
+    $state = $query->{queryState};
+    $self->assert_not_null($state);
+
+    xlog $self, "Destroy the mailbox with the role";
+    $mbox_role->destroy;
+
+    # A filter on role makes queryChanges overreport in removed, because
+    # annotation history isn't tracked. The reported state still must
+    # account for the removals it reports.
+    xlog $self, "Assert the removal advances the role query state";
+    $res = $jmap->request([[ 'Mailbox/queryChanges', {
+        sinceQueryState => $state,
+        filter          => $filter,
+        sort            => $sort,
+    } ]]);
+    $changes = $res->single_sentence('Mailbox/queryChanges')->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            oldQueryState => $state,
+            added         => [],
+            removed       => supersetof($mbox_role->id),
+        }),
+        $changes,
+    );
+    $self->assert_str_not_equals($state, $changes->{newQueryState});
+
+    xlog $self, "Assert there are no changes at the new role query state";
+    $state = $changes->{newQueryState};
+    $res = $jmap->request([[ 'Mailbox/queryChanges', {
+        sinceQueryState => $state,
+        filter          => $filter,
+        sort            => $sort,
+    } ]]);
+    $changes = $res->single_sentence('Mailbox/queryChanges')->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            oldQueryState => $state,
+            newQueryState => $state,
+            added         => [],
+            removed       => [],
+        }),
+        $changes,
+    );
+}

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -1577,11 +1577,17 @@ static int jmap_mailbox_querychanges(jmap_req_t *req)
         if (mbrec->mbtype & MBTYPE_DELETED) {
             if (mbrec->foldermodseq > sincemodseq) {
                 hash_insert(mbrec->id, (void*)1, &removed);
+                if (highestmodseq < mbrec->foldermodseq) {
+                    highestmodseq = mbrec->foldermodseq;
+                }
             }
         }
         else if (!jmap_hasrights(req, mbrec->mboxname, JACL_LOOKUP)) {
             if (mbrec->createdmodseq <= sincemodseq) {
                 hash_insert(mbrec->id, (void*)1, &removed);
+                if (highestmodseq < mbrec->foldermodseq) {
+                    highestmodseq = mbrec->foldermodseq;
+                }
             }
         }
         else if (mbrec->foldermodseq > sincemodseq && mbrec->shared_mbtype != _SHAREDMBOX_HIDDEN) {

--- a/imap/jmap_mailbox.c
+++ b/imap/jmap_mailbox.c
@@ -1491,6 +1491,7 @@ done:
 struct mboxquerychanges_rock {
     hash_table *removed;
     modseq_t sincemodseq;
+    modseq_t highestmodseq;
 
     struct conversations_state *cstate;  // to generate proper MAILBOXIDs
 };
@@ -1502,6 +1503,9 @@ static int _mboxquerychanges_cb(const mbentry_t *mbentry, void *vrock)
         char mboxid[JMAP_MAX_MAILBOXID_SIZE];
         jmap_set_mailboxid(rock->cstate, mbentry, mboxid);
         hash_insert(mboxid, (void*)1, rock->removed);
+        if (rock->highestmodseq < mbentry->foldermodseq) {
+            rock->highestmodseq = mbentry->foldermodseq;
+        }
     }
     return 0;
 }
@@ -1550,6 +1554,7 @@ static int jmap_mailbox_querychanges(jmap_req_t *req)
     r = _mboxquery_run(mbquery, &args);
     if (r) goto done;
 
+    modseq_t highestmodseq = sincemodseq;
     hash_table removed = HASH_TABLE_INITIALIZER;
     construct_hash_table(&removed, mbquery->result.count + 1, 0);
     if (mbquery->need_role) {
@@ -1560,17 +1565,17 @@ static int jmap_mailbox_querychanges(jmap_req_t *req)
          * until we have a sane way of tracking annotation changes */
 
         struct mboxquerychanges_rock rock = {
-            &removed, sincemodseq, req->cstate
+            &removed, sincemodseq, sincemodseq, req->cstate
         };
-        int r = mboxlist_usermboxtree(req->accountid, req->authstate,
-                                      _mboxquerychanges_cb, &rock,
-                                      MBOXTREE_TOMBSTONES|
-                                      MBOXTREE_DELETED|
-                                      MBOXTREE_INTERMEDIATES);
+        r = mboxlist_usermboxtree(req->accountid, req->authstate,
+                                  _mboxquerychanges_cb, &rock,
+                                  MBOXTREE_TOMBSTONES|
+                                  MBOXTREE_DELETED|
+                                  MBOXTREE_INTERMEDIATES);
         if (r) goto done;
+        highestmodseq = rock.highestmodseq;
     }
 
-    modseq_t highestmodseq = sincemodseq;
     ssize_t i;
     for (i = 0; i < mbquery->result.count; i++) {
         mboxquery_record_t *mbrec = ptrarray_nth(&mbquery->result, i);


### PR DESCRIPTION
Mailbox/queryChanges returned a newQueryState identical to the one it was given whenever the only change was a mailbox being destroyed, while still listing that mailbox in "removed".  We need to bump the state.