### PR TITLE
jmap: check fromAccountId before a /copy runs

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_copy_from_inaccessible_account
+++ b/cassandane/tiny-tests/JMAPEmail/email_copy_from_inaccessible_account
@@ -1,0 +1,56 @@
+#!perl
+use Cassandane::Tiny;
+
+# RFC 8620 Section 3.6.2: an accountId that does not correspond to a valid
+# account is accountNotFound. A /copy has two account ids, and fromAccountId
+# was only checked once there was something to copy -- so an empty copy from
+# an account the caller cannot see, or from no account at all, succeeded and
+# leaked that the account exists. Both ids must be checked before the method
+# runs, whatever the payload.
+
+sub test_email_copy_from_inaccessible_account
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+    xlog $self, "create user foo but do not share anything";
+    $self->{instance}->create_user("foo");
+
+    for my $from (qw(foo nosuchuser)) {
+        xlog $self, "Email/copy with nothing to copy from $from";
+        my $res = $jmap->CallMethods([['Email/copy', {
+            fromAccountId => $from,
+            accountId     => 'cassandane',
+            create        => {},
+        }, 'R1']]);
+        $self->assert_cmp_deeply(
+            [['error', superhashof({ type => 'accountNotFound' }), 'R1']],
+            $res,
+        );
+
+        xlog $self, "Blob/copy with nothing to copy from $from";
+        $res = $jmap->CallMethods([['Blob/copy', {
+            fromAccountId => $from,
+            accountId     => 'cassandane',
+            blobIds       => [],
+        }, 'R2']]);
+        $self->assert_cmp_deeply(
+            [['error', superhashof({ type => 'accountNotFound' }), 'R2']],
+            $res,
+        );
+    }
+
+    xlog $self, "a non-string fromAccountId is invalidArguments";
+    my $res = $jmap->CallMethods([['Email/copy', {
+        fromAccountId => ['foo'],
+        accountId     => 'cassandane',
+        create        => {},
+    }, 'R3']]);
+    $self->assert_cmp_deeply(
+        [['error', superhashof({
+            type      => 'invalidArguments',
+            arguments => ['fromAccountId'],
+        }), 'R3']],
+        $res,
+    );
+}

--- a/imap/jmap_api.c
+++ b/imap/jmap_api.c
@@ -716,6 +716,41 @@ HIDDEN int jmap_api(struct transaction_t *txn,
             continue;
         }
 
+        /* Validate fromAccountId the same way, if the call has one. A /copy
+         * used to check it only once there was something to copy, so an
+         * empty copy from an account this user cannot see (or from no account
+         * at all) succeeded, and told the caller the account exists.
+         * RFC 8620 Section 3.6.2. */
+        arg = json_object_get(args, "fromAccountId");
+        if (arg && arg != json_null()) {
+            const char *from_accountid = json_string_value(arg);
+            if (!from_accountid) {
+                err = json_pack("{s:s, s:[s]}", "type", "invalidArguments",
+                                "arguments", "fromAccountId");
+            }
+            else {
+                json_t *from_capas =
+                    hash_lookup(from_accountid, &capabilities_by_accountid);
+                if (!from_capas) {
+                    from_capas = lookup_capabilities(from_accountid, httpd_userid,
+                                                     httpd_authstate, &mbstates);
+                    hash_insert(from_accountid, from_capas,
+                                &capabilities_by_accountid);
+                }
+                if (json_is_null(from_capas)) {
+                    err = json_pack("{s:s}", "type", "accountNotFound");
+                }
+                else if (!json_object_get(from_capas, mp->capability)) {
+                    err = json_pack("{s:s}", "type", "accountNotSupportedByMethod");
+                }
+            }
+            if (err) {
+                json_array_append_new(resp, json_pack("[s,o,s]", "error", err, tag));
+                json_decref(args);
+                continue;
+            }
+        }
+
         /* Pre-process result references */
         if (process_resultrefs(args, resp, &err)) {
             if (!err) err = json_pack("{s:s}", "type", "invalidResultReference");


### PR DESCRIPTION
The request loop validated accountId up front but never looked at fromAccountId. Each /copy checked the source account only when it went to read something from it, so a copy with an empty "create" (or empty "blobIds" for Blob/copy) from an account the caller has no access to, or from an account that does not exist, returned a successful empty response.

RFC 8620 Section 3.6.2: accountNotFound is for an accountId that "does not correspond to a valid account", and an account the caller cannot see must be indistinguishable from one that does not exist. Answering success for one and accountNotFound for the other told the caller which accounts exist.
