### PR TITLE
jmap: add CalendarEvent/queryChanges

### DIFF
--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_querychanges
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_querychanges
@@ -1,0 +1,36 @@
+#!perl
+use Cassandane::Tiny;
+
+# RFC 8620 Section 5.6 makes /queryChanges part of every type's method set.
+# Cyrus cannot calculate CalendarEvent query changes, so the method must exist
+# and say so with cannotCalculateChanges -- not vanish as unknownMethod.
+
+sub test_calendarevent_querychanges
+    ($self)
+{
+    my $jmap = $self->{jmap};
+
+    xlog $self, "get current query state";
+    my $res = $jmap->CallMethods([['CalendarEvent/query', {}, 'R1']]);
+    my $state = $res->[0][1]{queryState};
+    $self->assert_not_null($state);
+
+    xlog $self, "queryChanges is refused, not unknown";
+    $res = $jmap->CallMethods([['CalendarEvent/queryChanges', {
+        sinceQueryState => $state,
+    }, 'R2']]);
+    $self->assert_cmp_deeply(
+        [['error', superhashof({ type => 'cannotCalculateChanges' }), 'R2']],
+        $res,
+    );
+
+    xlog $self, "arguments are still validated";
+    $res = $jmap->CallMethods([['CalendarEvent/queryChanges', {
+        sinceQueryState => $state,
+        filter          => { nosuchproperty => 1 },
+    }, 'R3']]);
+    $self->assert_cmp_deeply(
+        [['error', superhashof({ type => 'invalidArguments' }), 'R3']],
+        $res,
+    );
+}

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -66,6 +66,7 @@ static int jmap_calendar_set(struct jmap_req *req);
 static int jmap_calendarevent_get(struct jmap_req *req);
 static int jmap_calendarevent_changes(struct jmap_req *req);
 static int jmap_calendarevent_query(struct jmap_req *req);
+static int jmap_calendarevent_querychanges(struct jmap_req *req);
 static int jmap_calendarevent_set(struct jmap_req *req);
 static int jmap_calendarevent_copy(struct jmap_req *req);
 static int jmap_calendarevent_parse(jmap_req_t *req);
@@ -167,6 +168,12 @@ static jmap_method_t jmap_calendar_methods_standard[] = {
         "CalendarEvent/query",
         JMAP_URN_CALENDARS,
         &jmap_calendarevent_query,
+        JMAP_NEED_CSTATE
+    },
+    {
+        "CalendarEvent/queryChanges",
+        JMAP_URN_CALENDARS,
+        &jmap_calendarevent_querychanges,
         JMAP_NEED_CSTATE
     },
     {
@@ -9725,6 +9732,31 @@ static int jmap_principal_changes(struct jmap_req *req)
 
   done:
     jmap_changes_fini(&changes);
+    jmap_parser_fini(&parser);
+    return 0;
+}
+
+/* RFC 8620 Section 5.6 makes /queryChanges part of every type's method set.
+ * We cannot calculate CalendarEvent query changes, so validate the arguments
+ * and say so, rather than answer unknownMethod. */
+static int jmap_calendarevent_querychanges(struct jmap_req *req)
+{
+    struct jmap_parser parser = JMAP_PARSER_INITIALIZER;
+    struct jmap_querychanges query = JMAP_QUERYCHANGES_INITIALIZER;
+
+    json_t *err = NULL;
+    jmap_querychanges_parse(req, &parser, NULL, NULL,
+                            calendarevent_validatefilter, NULL,
+                            calendarevent_validatecomparator, NULL,
+                            &query, &err);
+    if (err) {
+        jmap_error(req, err);
+        goto done;
+    }
+    jmap_error(req, json_pack("{s:s}", "type", "cannotCalculateChanges"));
+
+done:
+    jmap_querychanges_fini(&query);
     jmap_parser_fini(&parser);
     return 0;
 }


### PR DESCRIPTION
Cyrus cannot calculate CalendarEvent query changes, but we can at least say "cannotCalculateChanges" rather than having an un-implemented function.