### PR TITLE
conversations: keep J keys for expunged records on rebuild

### DIFF
--- a/cassandane/tiny-tests/Conversations/audit_expunged_jmapid
+++ b/cassandane/tiny-tests/Conversations/audit_expunged_jmapid
@@ -1,0 +1,31 @@
+#!perl
+use Cassandane::Tiny;
+
+# An expunged record keeps its J key until it is unlinked, so a rebuild
+# over the same records must produce the same J keys as the live db.
+sub test_audit_expunged_jmapid
+    :Conversations
+    ($self)
+{
+    my $talk = $self->{store}->get_client();
+
+    xlog $self, "generating messages";
+    $self->make_message("Message $_") for (1..3);
+
+    xlog $self, "expunging one of them without unlinking";
+    $talk->select('INBOX');
+    $talk->store('2', '+flags', '(\\Deleted)');
+    $talk->expunge();
+
+    xlog $self, "auditing the conversations db";
+    my $outfile = $self->{instance}->{basedir} . "/conv-audit.txt";
+    $self->{instance}->run_command(
+        { cyrus => 1, redirects => { stdout => $outfile } },
+        'ctl_conversationsdb', '-A', '-v', 'cassandane',
+    );
+    my $data = slurp_file($outfile);
+
+    $self->assert_does_not_match(qr/^REALONLY: "J/m, $data);
+    $self->assert_does_not_match(qr/^TEMPONLY: "J/m, $data);
+    $self->assert_matches(qr/^cassandane is OK$/m, $data);
+}

--- a/imap/conversations.c
+++ b/imap/conversations.c
@@ -2425,8 +2425,9 @@ static int conversations_set_guid(struct conversations_state *state,
             r = cyrusdb_delete(state->db, buf_base(&key), buf_len(&key),
                                &state->txn, /*force*/1);
         }
-        else if (!(record->internal_flags & FLAG_INTERNAL_EXPUNGED)) {
-            /* Add J record */
+        else {
+            /* Add J record, kept for as long as any G record exists so
+             * the JMAPID stays unique among indexed but expunged messages */
             r = cyrusdb_store(state->db, buf_base(&key), buf_len(&key),
                               guidrep, strlen(guidrep), &state->txn);
         }


### PR DESCRIPTION
ctl_conversationsdb -A reported every expunged message as a REALONLY difference because of the J keys.  This made debugging real issues hard, so add them back.