### PR TITLE
Make Email/query `snoozedUntil` and `addedDates` sorts mutable

### DIFF
--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_sortsavedate
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_sortsavedate
@@ -1,0 +1,115 @@
+#!perl
+use Cassandane::Tiny;
+
+sub assert_email_querychanges_sortsavedate ($self, $sort_property,
+                                            $collapse_threads)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+
+    my $snoozed = $user->mailboxes->create({
+        name => 'snoozed',
+        role => 'snoozed',
+    });
+
+    # The snoozed#until of each email, in ascending order.  For a snoozed
+    # email that is also its savedate, so both sorts see this order.
+    my @snoozed_until = map {; sprintf '2042-01-%02dT00:00:00Z', $_ } 1..4;
+
+    xlog $self, "Create four snoozed emails, each in its own thread";
+    my (@emails, @ids);
+    for my $i (0 .. $#snoozed_until) {
+        my $email = $user->emails->create({
+            mailboxIds    => { $snoozed->id => JSON::true },
+            subject       => "snoozed email $i",
+            snoozed       => { 'until' => $snoozed_until[$i] },
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => "email $i" } },
+        });
+        push @emails, $email;
+        push @ids, q{} . $email->id;
+    }
+
+    my %query = (
+        collapseThreads => $collapse_threads ? JSON::true : JSON::false,
+        filter => { inMailbox => $snoozed->id },
+        sort   => [ {
+            isAscending => JSON::true,
+            mailboxId   => $snoozed->id,
+            property    => $sort_property,
+        } ],
+        calculateTotal => JSON::true,
+    );
+
+    xlog $self, "Query them by ascending $sort_property";
+    my $res = $jmap->request([[ 'Email/query' => { %query } ]]);
+    my $qres = $res->sentence_named('Email/query')->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            canCalculateChanges => JSON::true,
+            ids                 => \@ids,
+            position            => 0,
+            queryState          => jstr,
+            total               => 4,
+        }),
+        $qres,
+    );
+
+    my $qstate = $qres->{queryState};
+
+    xlog $self, "Re-snooze the first email to after the last one";
+    $emails[0]->update({ 'snoozed/until' => '2042-01-05T00:00:00Z' });
+
+    xlog $self, "The re-snoozed email is now last in the query";
+    $res = $jmap->request([[ 'Email/query' => { %query } ]]);
+    $self->assert_cmp_deeply(
+        [ @ids[1,2,3], $ids[0] ],
+        $res->sentence_named('Email/query')->arguments->{ids},
+    );
+
+    xlog $self, "Ask for changes, having cached up to the third position";
+    $res = $jmap->request([[ 'Email/queryChanges' => {
+        %query,
+        sinceQueryState => $qstate,
+        upToId          => $ids[2],
+    } ]]);
+
+    xlog $self, "The move past upToId must still be reported";
+    $self->assert_cmp_deeply(
+        superhashof({
+            added   => [ { id => $ids[0], index => 3 } ],
+            removed => [ $ids[0] ],
+            total   => 4,
+        }),
+        $res->sentence_named('Email/queryChanges')->arguments,
+    );
+}
+
+sub test_email_querychanges_sortsavedate__snoozeduntil
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_email_querychanges_sortsavedate('snoozedUntil', 0);
+}
+
+sub test_email_querychanges_sortsavedate__snoozeduntil_collapsed
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_email_querychanges_sortsavedate('snoozedUntil', 1);
+}
+
+sub test_email_querychanges_sortsavedate__addeddates
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_email_querychanges_sortsavedate('addedDates', 0);
+}
+
+sub test_email_querychanges_sortsavedate__addeddates_collapsed
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_email_querychanges_sortsavedate('addedDates', 1);
+}

--- a/cassandane/tiny-tests/JMAPEmail/email_querychanges_sortsavedate_otherfolder
+++ b/cassandane/tiny-tests/JMAPEmail/email_querychanges_sortsavedate_otherfolder
@@ -1,0 +1,108 @@
+#!perl
+use Cassandane::Tiny;
+
+sub assert_querychanges_sortsavedate_otherfolder ($self, $sort_property,
+                                                  $collapse_threads)
+{
+    my $user = $self->default_user;
+    my $jmap = $user->jmap;
+    $jmap->AddUsing('https://cyrusimap.org/ns/jmap/mail');
+
+    my $inbox = $user->mailboxes->inbox;
+    my $snoozed = $user->mailboxes->create({
+        name => 'snoozed',
+        role => 'snoozed',
+    });
+
+    # The snoozed#until of each email, in ascending order.  For a snoozed
+    # email that is also its savedate, so both sorts see this order.
+    my @snoozed_until = map {; sprintf '2042-01-%02dT00:00:00Z', $_ } 1..3;
+
+    xlog $self, "Create three snoozed emails, the second one also in Inbox";
+    my (@emails, @ids);
+    for my $i (0 .. $#snoozed_until) {
+        my %mailbox_ids = ($snoozed->id => JSON::true);
+        $mailbox_ids{$inbox->id} = JSON::true if $i == 1;
+
+        my $email = $user->emails->create({
+            mailboxIds    => \%mailbox_ids,
+            subject       => "snoozed email $i",
+            snoozed       => { 'until' => $snoozed_until[$i] },
+            bodyStructure => { type => 'text/plain', partId => 'part1' },
+            bodyValues    => { part1 => { value => "email $i" } },
+        });
+        push @emails, $email;
+        push @ids, q{} . $email->id;
+    }
+
+    my %query = (
+        collapseThreads => $collapse_threads ? JSON::true : JSON::false,
+        sort   => [ {
+            isAscending => JSON::true,
+            mailboxId   => $snoozed->id,
+            property    => $sort_property,
+        } ],
+        calculateTotal => JSON::true,
+    );
+
+    xlog $self, "The Inbox copy does not sort by its own receivedAt";
+    my $res = $jmap->request([[ 'Email/query' => { %query } ]]);
+    my $qres = $res->sentence_named('Email/query')->arguments;
+    $self->assert_cmp_deeply(
+        superhashof({
+            ids        => \@ids,
+            queryState => jstr,
+            total      => 3,
+        }),
+        $qres,
+    );
+
+    my $qstate = $qres->{queryState};
+
+    xlog $self, "Flag the email that has a copy in Inbox";
+    $emails[1]->update({ 'keywords/$flagged' => JSON::true });
+
+    xlog $self, "Ask for changes";
+    $res = $jmap->request([[ 'Email/queryChanges' => {
+        %query,
+        sinceQueryState => $qstate,
+    } ]]);
+
+    xlog $self, "It is re-added at its position in the query result";
+    $self->assert_cmp_deeply(
+        superhashof({
+            added   => [ { id => $ids[1], index => 1 } ],
+            removed => [ $ids[1] ],
+            total   => 3,
+        }),
+        $res->sentence_named('Email/queryChanges')->arguments,
+    );
+}
+
+sub test_email_querychanges_sortsavedate_otherfolder__snoozeduntil
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_querychanges_sortsavedate_otherfolder('snoozedUntil', 0);
+}
+
+sub test_email_querychanges_sortsavedate_otherfolder__snoozeduntil_collapsed
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_querychanges_sortsavedate_otherfolder('snoozedUntil', 1);
+}
+
+sub test_email_querychanges_sortsavedate_otherfolder__addeddates
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_querychanges_sortsavedate_otherfolder('addedDates', 0);
+}
+
+sub test_email_querychanges_sortsavedate_otherfolder__addeddates_collapsed
+    :needs_component_sieve :JMAPExtensions
+    ($self)
+{
+    $self->assert_querychanges_sortsavedate_otherfolder('addedDates', 1);
+}

--- a/changes/next/cyr-3475-emailquerychanges-destroyed-unchanged-query-response
+++ b/changes/next/cyr-3475-emailquerychanges-destroyed-unchanged-query-response
@@ -1,0 +1,21 @@
+Description:
+
+Fixes a bug in JMAP Email/queryChanges where the snoozedUntil and addedDates
+sort properties were erroneously handled as immutable. Now they are mutable
+sorts, and resnoozed emails get their new result location reported correctly.
+
+Documentation:
+
+None
+
+Config changes:
+
+None
+
+Upgrade instructions:
+
+None
+
+GitHub issue:
+
+None

--- a/changes/next/cyr-3475-emailquerychanges-destroyed-unchanged-query-response
+++ b/changes/next/cyr-3475-emailquerychanges-destroyed-unchanged-query-response
@@ -3,6 +3,8 @@ Description:
 Fixes a bug in JMAP Email/queryChanges where the snoozedUntil and addedDates
 sort properties were erroneously handled as immutable. Now they are mutable
 sorts, and resnoozed emails get their new result location reported correctly.
+Also fixes the index reported for an email in these sorted results, if that
+email has a copy in a different mailbox.
 
 Documentation:
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -4918,6 +4918,28 @@ struct emailquery_uidsearch_result_rock {
     uint64_t partnum_seq;
 };
 
+/* Return the guids of the messages in this search result that have a
+ * non-zero savedate.  A copy of such a message with a zero savedate is
+ * not part of a savedate-sorted query result: the copy with the non-zero
+ * savedate represents the message. */
+static struct hashset *emailquery_savedates(const ptrarray_t *msgdata)
+{
+    struct hashset *savedates = hashset_new(MESSAGE_GUID_SIZE);
+
+    for (int i = 0; i < msgdata->count; i++) {
+        MsgData *md = ptrarray_nth(msgdata, i);
+
+        /* Skip expunged or hidden messages */
+        if (md->system_flags & FLAG_DELETED ||
+            md->internal_flags & FLAG_INTERNAL_EXPUNGED)
+            continue;
+
+        if (md->savedate) hashset_add(savedates, &md->guid.value);
+    }
+
+    return savedates;
+}
+
 static void emailquery_uidsearch_result_ensure(struct emailquery *q, struct emailquery_cache *qc, size_t n)
 {
     struct emailquery_uidsearch_result_rock *rrock = qc->qr.rock;
@@ -5069,22 +5091,8 @@ static int emailquery_uidsearch(jmap_req_t *req,
 
     ptrarray_t *msgdata = &rrock->query->merged_msgdata;
 
-    if (search->sort_savedate) {
-        /* Build hashset of messages with savedates */
-        rrock->savedates = hashset_new(MESSAGE_GUID_SIZE);
-
-        int j;
-        for (j = 0; j < msgdata->count; j++) {
-            MsgData *md = ptrarray_nth(msgdata, j);
-
-            /* Skip expunged or hidden messages */
-            if (md->system_flags & FLAG_DELETED ||
-                md->internal_flags & FLAG_INTERNAL_EXPUNGED)
-                continue;
-
-            if (md->savedate) hashset_add(rrock->savedates, &md->guid.value);
-        }
-    }
+    if (search->sort_savedate)
+        rrock->savedates = emailquery_savedates(msgdata);
 
     qr->rock = rrock;
     qr->total_ceiling = msgdata->count;
@@ -5817,6 +5825,7 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     modseq_t addrbook_modseq = 0;
     modseq_t since_highest_createdmodseq = 0;
     uint64_t since_index_generation = 0;
+    struct hashset *savedates = NULL;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
@@ -5881,6 +5890,8 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
     char email_id[JMAP_MAX_EMAILID_SIZE];
     int found_up_to = 0;
     size_t mdcount = msgdata->count;
+
+    if (search.sort_savedate) savedates = emailquery_savedates(msgdata);
 
     hash_table touched_ids = HASH_TABLE_INITIALIZER;
     memset(&touched_ids, 0, sizeof(hash_table));
@@ -5949,6 +5960,11 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
 
         int is_expunged = (md->system_flags & FLAG_DELETED) ||
                 (md->internal_flags & FLAG_INTERNAL_EXPUNGED);
+
+        /* Skip the copies that the query result does not contain */
+        if (savedates && !is_expunged && !md->savedate &&
+            hashset_exists(savedates, &md->guid.value))
+            continue;
 
         size_t touched_id = (size_t)hash_lookup(email_id, &touched_ids);
         size_t new_touched_id = touched_id;
@@ -6062,6 +6078,7 @@ done:
         }
         else *err = jmap_server_error(r);
     }
+    if (savedates) hashset_free(&savedates);
     emailsearch_fini(&search);
 }
 
@@ -6076,6 +6093,7 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     modseq_t addrbook_modseq = 0;
     modseq_t since_highest_createdmodseq = 0;
     uint64_t since_index_generation = 0;
+    struct hashset *savedates = NULL;
     int r = 0;
 
     if (!_email_read_querystate(req, query->since_querystate,
@@ -6140,6 +6158,8 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
     int found_up_to = 0;
     size_t mdcount = msgdata->count;
 
+    if (search.sort_savedate) savedates = emailquery_savedates(msgdata);
+
     hash_table touched_ids = HASH_TABLE_INITIALIZER;
     memset(&touched_ids, 0, sizeof(hash_table));
     construct_hash_table(&touched_ids, mdcount + 1, 0);
@@ -6194,6 +6214,11 @@ static void _email_querychanges_uncollapsed(jmap_req_t *req,
 
         int is_expunged = (md->system_flags & FLAG_DELETED) ||
                 (md->internal_flags & FLAG_INTERNAL_EXPUNGED);
+
+        /* Skip the copies that the query result does not contain */
+        if (savedates && !is_expunged && !md->savedate &&
+            hashset_exists(savedates, &md->guid.value))
+            continue;
 
         size_t touched_id = (size_t)hash_lookup(email_id, &touched_ids);
         size_t new_touched_id = touched_id;
@@ -6276,6 +6301,7 @@ done:
         }
         else *err = jmap_server_error(r);
     }
+    if (savedates) hashset_free(&savedates);
     emailsearch_fini(&search);
 }
 

--- a/imap/jmap_mail.c
+++ b/imap/jmap_mail.c
@@ -5921,12 +5921,10 @@ static void _email_querychanges_collapsed(jmap_req_t *req,
 
         // for this phase, we only care that it has a change
         if (md->modseq <= since_modseq && !is_newly_indexed) {
-            if (search.is_mutable) {
-                modseq_t modseq = md->convmodseq;
-                if (!modseq) conversation_get_modseq(req->cstate, md->cid, &modseq);
-                if (modseq > since_modseq)
-                    hashu64_insert(md->cid, (void*)1, &touched_cids);
-            }
+            /* Only a conversation-scoped sort key can change the order
+             * without the message's own modseq advancing. */
+            if (search.is_mutable && md->convmodseq > since_modseq)
+                hashu64_insert(md->cid, (void*)1, &touched_cids);
             continue;
         }
 

--- a/imap/search_query.c
+++ b/imap/search_query.c
@@ -1211,6 +1211,9 @@ static int is_mutable_sort(struct sortcrit *sortcrit)
             case SORT_CONVEXISTS:
             case SORT_CONVSIZE:
             case SORT_HASCONVFLAG:
+            /* savedate is rewritten in place when an email is (re-)snoozed */
+            case SORT_SAVEDATE:
+            case SORT_SNOOZEDUNTIL:
                 return 1;
             default:
                 break;


### PR DESCRIPTION
This fixes a bug in JMAP Email/queryChanges where the snoozedUntil and addedDates sort properties were erroneously handled as immutable. Now they are mutable sorts, and resnoozed emails get reported correctly in their new result location in the /queryChanges response.

With addedDates sorts now being mutable, an Email/queryChanges for collapsed threads would have read conversations.db for every unchanged email in the result. That read is not necessary: only immutable search filters reach this codepath, and for those, only a conversation-scoped sort key can reorder results without the message's own modseq advancing. And for these, convmodseq is pre-loaded.