### PR TITLE
zeroskip.c, twom.c: pin xxhash to -O2 on gcc instead of probing at configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2136,52 +2136,6 @@ AS_IF(
     )]
 )
 
-dnl lib/zeroskip.c compiles xxhash inline (XXH_INLINE_ALL) because not doing so
-dnl costs about 3x on ALL hashing -- one-shot as well as streaming, so every span
-dnl checksum, conversion, repack and consistency check pays it.  Some compilers
-dnl cannot honour those hints at low optimisation and fail the build outright
-dnl rather than fall back, e.g. gcc 14 at -Og never devirtualises the function
-dnl pointers xxhash's long-input loop reaches its accumulate and scramble helpers
-dnl through, so their always_inline becomes an error.  XXH_NO_INLINE_HINTS
-dnl demotes every internal xxhash function to a plain static and pays that 3x, so
-dnl probe with the real CFLAGS and set it only where the build needs it to
-dnl compile at all.  Mirror zeroskip.c's usage: unreferenced statics never reach
-dnl the inliner, so a probe that only includes the header always passes.
-AC_CACHE_CHECK(
-    [whether xxhash's inline hints compile at this optimisation level],
-    [cyrus_cv_xxhash_inline_hints],
-    [
-        AC_LANG_PUSH([C])
-        saved_CPPFLAGS="$CPPFLAGS"
-        CPPFLAGS="$CPPFLAGS -I$srcdir/lib"
-        AC_COMPILE_IFELSE(
-            [AC_LANG_PROGRAM(
-                [
-                    #define XXH_INLINE_ALL
-                    #define XXH3_STREAM_USE_STACK 1
-                    #include "xxhash.h"
-                ],
-                [
-                    char buf[[8192]];
-                    XXH3_state_t st;
-
-                    XXH3_64bits_reset(&st);
-                    XXH3_64bits_update(&st, buf, sizeof(buf));
-                    if (XXH3_64bits_digest(&st) != XXH3_64bits(buf, sizeof(buf)))
-                        return 1;
-                ])
-            ],
-            [cyrus_cv_xxhash_inline_hints=yes],
-            [cyrus_cv_xxhash_inline_hints=no]
-        )
-        CPPFLAGS="$saved_CPPFLAGS"
-        AC_LANG_POP([C])
-    ])
-AS_IF(
-    [test "x$cyrus_cv_xxhash_inline_hints" != "xyes"],
-    [CPPFLAGS="$CPPFLAGS -DXXH_NO_INLINE_HINTS=1"]
-)
-
 dnl documentation generation (sphinx, sphinx_rtd_theme, perl2rst, gitpython)
 AC_DEFUN([WARN_DOCDEPS], [
     AM_COND_IF([ENABLE_RELEASE_CHECKS],

--- a/lib/twom.c
+++ b/lib/twom.c
@@ -24,9 +24,15 @@
 
 #define XXH_STATIC_LINKING_ONLY /* access advanced declarations */
 #define XXH_INLINE_ALL          /* maximum optimise */
-#define XXH_NO_INLINE_HINTS   1 /* allow compiling with -Og on modern compilers */
 #define XXH_IMPLEMENTATION      /* access definitions */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize("O2")
+#endif
 #include "xxhash.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Self-contained UUID (RFC 4122 version 4) support.  We generate and format
  * UUIDs ourselves rather than depending on util-linux's libuuid, which is not

--- a/lib/zeroskip.c
+++ b/lib/zeroskip.c
@@ -49,25 +49,14 @@
  * gcc, which already defines it. */
 #define XXH3_STREAM_USE_STACK 1
 
-/* XXH_NO_INLINE_HINTS is deliberately NOT set here, and must not be: it turns
- * every internal xxhash function into a plain `static`, and on modern compilers
- * that costs about 3x on ALL hashing -- one-shot as well as streaming, so every
- * span checksum, conversion, repack and consistency check pays it.  Measured at
- * 21MB, aarch64: gcc 14 goes 59.0 -> 19.4 GB/s and clang 19 goes 62.5 -> 24.3.
- * End to end that is 8% of a bulk load (zsbench 400k at 1000-per-txn, best of
- * nine: gcc 1107k -> 1202k/s, clang 1122k -> 1205k/s).
- *
- * It IS still required below -O2 on gcc, which refuses always_inline for the
- * NEON helpers at -Og ("function not considered for inlining") and hits an
- * internal compiler error at -O1 on aarch64.  So the low-optimisation targets
- * in the Makefile pass -DXXH_NO_INLINE_HINTS=1 themselves; see XXH_LOWOPT_DEF
- * there.  A hand-rolled -Og build without it fails loudly at compile time,
- * which is the right way round -- the alternative was every optimised build
- * silently paying 3x.  (Downstream twom sets this flag too and does NOT need
- * it: it only ever calls one-shot XXH3_64bits, so the streaming helpers that
- * fail to inline are never instantiated.) */
-
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize("O2")
+#endif
 #include "xxhash.h"
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 /* Syscall interposition for crash and sync-failure injection (T-8, T-8a).
  *


### PR DESCRIPTION
The configure probe only sees configure-time CFLAGS. A build that passes -Og at make time passed the probe at -O0 and then failed in lib/zeroskip.c with gcc 14's "inlining failed in call to always_inline".

Reproduced with gcc 14 (trixie): the failure is specific to -Og. -O0, -O1, -O2, -O3 and -Os all build, and no single -f flag from -O1/-O2 rescues -Og, so there is no narrower switch. Since no preprocessor macro distinguishes -Og from -O2, compile the header itself at -O2 with a gcc pragma around the include and drop the probe. clang is excluded because it errors on the unknown pragma under -Werror and does not have the problem.

twom.c had `XXH_NO_INLINE_HINTS 1` unconditionally, paying about 3x on every hash; it gets the same treatment.

Verified: gcc 14 and clang 19 compile both files at every optimisation level with -Wall -Wextra -Werror; at -O2 the zeroskip.o disassembly is identical apart from `__LINE__` constants; full build plus the zeroskip and aaa-db cunit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)