### PR TITLE
message.c: cap RFC 2231 parameter count

### DIFF
--- a/changes/next/cyr-3126-rfc2231-param-cap
+++ b/changes/next/cyr-3126-rfc2231-param-cap
@@ -1,0 +1,30 @@
+Description:
+
+The number of parameters accepted from a single MIME header is now capped at
+128.  Parsing folded RFC 2231 continuation parameters costs time quadratic in
+the number of parameters, which was previously bounded only by the size of the
+header, so one message could consume a great deal of CPU on delivery and on
+IMAP APPEND.  The cap is well above any legitimate use, and a single long
+RFC 2231 value still folds correctly.
+
+Tracked as GitHub security advisory GHSA-jmmc-8859-q3fx.
+
+
+Documentation:
+
+None.
+
+
+Config changes:
+
+None.
+
+
+Upgrade instructions:
+
+None.
+
+
+GitHub issue:
+
+None.

--- a/cunit/message.testc
+++ b/cunit/message.testc
@@ -697,6 +697,83 @@ static void test_rfc2231_extended_continuations(void)
     message_free_body(&body);
 }
 
+/*
+ * CYR-3126: message_parse_params() must cap the number of parameters it
+ * accepts so that the O(P^2) RFC 2231 folding in message_fold_params()
+ * cannot be driven by an attacker-controlled parameter count.  These two
+ * cases exercise message_parse_type() directly, which runs the parse +
+ * fold pipeline on a struct param list without building a whole message.
+ */
+
+/*
+ * A legitimate RFC 2231 continuation must still fold correctly: the cap and
+ * the DoS guard must not break normal multi-section folding.
+ */
+static void test_rfc2231_fold_under_cap(void)
+{
+    static const char hdr[] =
+        "application/x-stuff;\r\n"
+        "\tname*0=\"the first part \";\r\n"
+        "\tname*1=\"and the second part\"";
+    char *type = NULL;
+    char *subtype = NULL;
+    struct param *params = NULL;
+
+    message_parse_type(hdr, &type, &subtype, &params);
+
+    CU_ASSERT_STRING_EQUAL(type, "APPLICATION");
+    CU_ASSERT_STRING_EQUAL(subtype, "X-STUFF");
+    CU_ASSERT_PTR_NOT_NULL_FATAL(params);
+    CU_ASSERT_STRING_EQUAL(params->attribute, "NAME");
+    CU_ASSERT_STRING_EQUAL(params->value, "the first part and the second part");
+    CU_ASSERT_PTR_NULL(params->next);
+
+    free(type);
+    free(subtype);
+    param_free(&params);
+}
+
+/*
+ * A header with far more than RFC2231_MAX_PARAMS parameters must parse
+ * without error and yield a bounded list.  We can't assert wall-clock time,
+ * so we assert the parameter count is capped.  Each parameter is an "aN*0"
+ * initial section, which is the worst case for message_fold_params().
+ */
+static void test_rfc2231_param_cap(void)
+{
+    /* Comfortably above RFC2231_MAX_PARAMS (128). -- claude, 2026-06-16 */
+    const int nattempted = 1000;
+    const int cap = 128;
+    struct buf hdr = BUF_INITIALIZER;
+    char *type = NULL;
+    char *subtype = NULL;
+    struct param *params = NULL;
+    struct param *p;
+    int count = 0;
+    int i;
+
+    buf_setcstr(&hdr, "application/x-stuff");
+    for (i = 0; i < nattempted; i++)
+        buf_printf(&hdr, "; a%d*0=x", i);
+
+    message_parse_type(buf_cstring(&hdr), &type, &subtype, &params);
+
+    CU_ASSERT_STRING_EQUAL(type, "APPLICATION");
+    CU_ASSERT_STRING_EQUAL(subtype, "X-STUFF");
+
+    for (p = params; p; p = p->next)
+        count++;
+
+    /* The cap drops everything past the limit, so the list is bounded
+     * well below the number of parameters we tried to smuggle in. */
+    CU_ASSERT(count <= cap);
+
+    free(type);
+    free(subtype);
+    param_free(&params);
+    buf_free(&hdr);
+}
+
 static void test_references(void)
 {
     static const char msg[] =

--- a/imap/message.c
+++ b/imap/message.c
@@ -1406,6 +1406,10 @@ static void message_parse_bodydisposition(const char *hdr, struct body *body)
  * next ';' or end of line, which should mark the next
  * parameter.
  */
+
+/* Without a cap, an attacker controls param count we handle, and our handling
+ * is O(N^2) -- rjbs, 2026-06-17 */
+#define RFC2231_MAX_PARAMS 128
 static void message_parse_params(const char *hdr, struct param **paramp)
 {
     struct param *param;
@@ -1414,6 +1418,7 @@ static void message_parse_params(const char *hdr, struct param **paramp)
     const char *value;
     int valuelen;
     char *p;
+    int nparams = 0;
 
     for (;;) {
         /* Skip over leading whitespace */
@@ -1498,6 +1503,10 @@ skip:
             if (*hdr == ';') hdr++;
             continue;
         }
+
+        /* Stop accepting parameters once we hit the cap (DoS guard) */
+        if (nparams++ >= RFC2231_MAX_PARAMS)
+            return;
 
         /* Save attribute/value pair */
         *paramp = param = (struct param *)xzmalloc(sizeof(struct param));


### PR DESCRIPTION
message_fold_params() rescans the whole parameter list once per RFC 2231 initial section, so its cost is O(P^2) for parameter count P. message_parse_params() allocated one struct param per parameter with no limit, so P was bounded only by header size. That meant a nasty Content-Type/Content-Disposition with many continuation parameters wass therefore a CPU-exhaustion DoS, parsed on delivery and on IMAP APPEND. This is the same as Dovecot CVE-2026-27859.

Cap accepted parameters at RFC2231_MAX_PARAMS (128), well above legitimate use and above the existing section==100 fold guard, so a single long RFC 2231 value still folds correctly.

As for tests:

The first asserts a legitimate two-section RFC 2231 continuation still folds into one parameter, guarding against the upcoming cap breaking normal folding.

The second feeds a header with 1000 distinct "aN*0" initial sections -- the worst case for message_fold_params()'s O(P^2) rescan -- and asserts the parsed list is bounded. Without the cap this list is unbounded and folding is quadratic; with it the count stays at or below the limit.

This is CYR-3126.

Reported by Michael Bommarito <michael.bommarito@gmail.com>.