### PR TITLE
http_h2.c: Don't try to output headers twice

### DIFF
--- a/imap/http_h2.c
+++ b/imap/http_h2.c
@@ -204,6 +204,7 @@ static int data_chunk_recv_cb(nghttp2_session *session,
          * so without this a client can stream unbounded DATA frames and
          * exhaust memory. */
         if (txn->req_body.max && len > txn->req_body.max - txn->req_body.len) {
+            txn->req_body.flags |= BODY_DISCARD;
             error_response(HTTP_CONTENT_TOO_LARGE, txn);
             return NGHTTP2_ERR_CANCEL;
         }


### PR DESCRIPTION
The first call to error_response sends all headers then frees them but leaves them in a list of headers to send.

Then... a second call later happens later that tries to send those headers again and rereads that freed data.

Avoid that by telling other parts of the stack we don't want to respond to this request anymore.

Setting BODY_DISCARD appears to be the way to do that.